### PR TITLE
docs/developer: change release branch naming convention

### DIFF
--- a/docs/developer/release/1-create-release-branch.md
+++ b/docs/developer/release/1-create-release-branch.md
@@ -14,10 +14,10 @@ Patch Releases for that major pr minor version of the agent.
 
 2. Create and push the release branch from the selected base commit:
 
-    The name of the release branch should be `release-VERSION_PREFIX`
-    defined above, such as `release-v0.31`.
+    The name of the release branch should be `release/VERSION_PREFIX`
+    defined above, such as `release/v0.31`.
 
-        > **NOTE**: Branches are only made for VERSION_PREFIX; do not create branches for the full VERSION such as `release-v0.31-rc.0` or `release-v0.31.0`.
+        > **NOTE**: Branches are only made for VERSION_PREFIX; do not create branches for the full VERSION such as `release/v0.31-rc.0` or `release/v0.31.0`.
 
     - If the consensus commit is the latest commit from main you can branch from main.
     - If the consensus commit is not the latest commit from main, branch from that instead.

--- a/docs/developer/release/3-update-version-in-code.md
+++ b/docs/developer/release/3-update-version-in-code.md
@@ -40,7 +40,7 @@ The project must be updated to reference the upcoming release tag whenever a new
     - Stable Release example PR [here](https://github.com/grafana/agent/pull/3119)
     - Patch Release example PR [here](https://github.com/grafana/agent/pull/3191)
 
-4. Create a branch from `release-VERSION_PREFIX` for [grafana/agent](https://github.com/grafana/agent).
+4. Create a branch from `release/VERSION_PREFIX` for [grafana/agent](https://github.com/grafana/agent).
 
 5. Cherry pick the commit on main from the merged PR in Step 3 from main into the new branch from Step 4:
 
@@ -50,7 +50,7 @@ The project must be updated to reference the upcoming release tag whenever a new
 
     Delete the `Main (unreleased)` header and anything underneath it as part of the cherry-pick. Alternatively, do it after the cherry-pick is completed.
 
-6. Create a PR to merge to `release-VERSION_PREFIX` (must be merged before continuing).
+6. Create a PR to merge to `release/VERSION_PREFIX` (must be merged before continuing).
 
     - Release Candidate example PR [here](https://github.com/grafana/agent/pull/3066)
     - Stable Release example PR [here](https://github.com/grafana/agent/pull/3123)


### PR DESCRIPTION
Change the release branch naming convention to `release/vMAJOR.MINOR`. This naming convention makes it easier to write branch protection rules for release branches without colliding with branches pushed by contributors.
