### PR TITLE
misc: replace as many user-facing references to River as possible

### DIFF
--- a/internal/flow/internal/controller/node_builtin_component.go
+++ b/internal/flow/internal/controller/node_builtin_component.go
@@ -224,7 +224,7 @@ func (cn *BuiltinComponentNode) NodeID() string { return cn.nodeID }
 // BuiltinComponentNode.
 func (cn *BuiltinComponentNode) UpdateBlock(b *ast.BlockStmt) {
 	if !BlockComponentID(b).Equals(cn.id) {
-		panic("UpdateBlock called with an River block with a different component ID")
+		panic("UpdateBlock called with an block with a different component ID")
 	}
 
 	cn.mut.Lock()
@@ -258,7 +258,7 @@ func (cn *BuiltinComponentNode) evaluate(scope *vm.Scope) error {
 
 	argsPointer := cn.reg.CloneArguments()
 	if err := cn.eval.Evaluate(scope, argsPointer); err != nil {
-		return fmt.Errorf("decoding River: %w", err)
+		return fmt.Errorf("decoding configuration: %w", err)
 	}
 
 	// args is always a pointer to the args type, so we want to deference it since

--- a/internal/flow/internal/controller/node_config_argument.go
+++ b/internal/flow/internal/controller/node_config_argument.go
@@ -53,7 +53,7 @@ func (cn *ArgumentConfigNode) Evaluate(scope *vm.Scope) error {
 
 	var argument argumentBlock
 	if err := cn.eval.Evaluate(scope, &argument); err != nil {
-		return fmt.Errorf("decoding River: %w", err)
+		return fmt.Errorf("decoding configuration: %w", err)
 	}
 
 	cn.defaultValue = argument.Default

--- a/internal/flow/internal/controller/node_config_export.go
+++ b/internal/flow/internal/controller/node_config_export.go
@@ -50,7 +50,7 @@ func (cn *ExportConfigNode) Evaluate(scope *vm.Scope) error {
 
 	var export exportBlock
 	if err := cn.eval.Evaluate(scope, &export); err != nil {
-		return fmt.Errorf("decoding River: %w", err)
+		return fmt.Errorf("decoding configuration: %w", err)
 	}
 	cn.value = export.Value
 	return nil

--- a/internal/flow/internal/controller/node_config_logging.go
+++ b/internal/flow/internal/controller/node_config_logging.go
@@ -60,7 +60,7 @@ func (cn *LoggingConfigNode) Evaluate(scope *vm.Scope) error {
 	args := logging.DefaultOptions
 	if cn.eval != nil {
 		if err := cn.eval.Evaluate(scope, &args); err != nil {
-			return fmt.Errorf("decoding River: %w", err)
+			return fmt.Errorf("decoding configuration: %w", err)
 		}
 	}
 

--- a/internal/flow/internal/controller/node_config_tracing.go
+++ b/internal/flow/internal/controller/node_config_tracing.go
@@ -60,7 +60,7 @@ func (cn *TracingConfigNode) Evaluate(scope *vm.Scope) error {
 	args := tracing.DefaultOptions
 	if cn.eval != nil {
 		if err := cn.eval.Evaluate(scope, &args); err != nil {
-			return fmt.Errorf("decoding River: %w", err)
+			return fmt.Errorf("decoding configuration: %w", err)
 		}
 	}
 

--- a/internal/flow/internal/controller/node_custom_component.go
+++ b/internal/flow/internal/controller/node_custom_component.go
@@ -181,7 +181,7 @@ func (cn *CustomComponentNode) evaluate(evalScope *vm.Scope) error {
 
 	var args map[string]any
 	if err := cn.eval.Evaluate(evalScope, &args); err != nil {
-		return fmt.Errorf("decoding River: %w", err)
+		return fmt.Errorf("decoding configuration: %w", err)
 	}
 
 	cn.args = args

--- a/internal/flow/internal/controller/node_service.go
+++ b/internal/flow/internal/controller/node_service.go
@@ -64,7 +64,7 @@ func (sn *ServiceNode) Block() *ast.BlockStmt {
 // ServiceNode.
 func (sn *ServiceNode) UpdateBlock(b *ast.BlockStmt) {
 	if b != nil && !BlockComponentID(b).Equals([]string{sn.NodeID()}) {
-		panic("UpdateBlock called with a River block with a different block ID")
+		panic("UpdateBlock called with a block with a different block ID")
 	}
 
 	sn.mut.Lock()
@@ -97,7 +97,7 @@ func (sn *ServiceNode) Evaluate(scope *vm.Scope) error {
 	argsPointer := reflect.New(reflect.TypeOf(sn.def.ConfigType)).Interface()
 
 	if err := sn.eval.Evaluate(scope, argsPointer); err != nil {
-		return fmt.Errorf("decoding River: %w", err)
+		return fmt.Errorf("decoding configuration: %w", err)
 	}
 
 	// args is always a pointer to the args type, so we want to deference it

--- a/internal/flow/internal/importsource/import_file.go
+++ b/internal/flow/internal/importsource/import_file.go
@@ -59,7 +59,7 @@ func (a *importFileConfigBlock) SetToDefault() {
 func (im *ImportFile) Evaluate(scope *vm.Scope) error {
 	var arguments importFileConfigBlock
 	if err := im.eval.Evaluate(scope, &arguments); err != nil {
-		return fmt.Errorf("decoding River: %w", err)
+		return fmt.Errorf("decoding configuration: %w", err)
 	}
 	if im.fileComponent == nil {
 		var err error

--- a/internal/flow/internal/importsource/import_git.go
+++ b/internal/flow/internal/importsource/import_git.go
@@ -74,7 +74,7 @@ func NewImportGit(managedOpts component.Options, eval *vm.Evaluator, onContentCh
 func (im *ImportGit) Evaluate(scope *vm.Scope) error {
 	var arguments GitArguments
 	if err := im.eval.Evaluate(scope, &arguments); err != nil {
-		return fmt.Errorf("decoding River: %w", err)
+		return fmt.Errorf("decoding configuration: %w", err)
 	}
 
 	if reflect.DeepEqual(im.args, arguments) {

--- a/internal/flow/internal/importsource/import_http.go
+++ b/internal/flow/internal/importsource/import_http.go
@@ -63,7 +63,7 @@ func (args *HTTPArguments) SetToDefault() {
 func (im *ImportHTTP) Evaluate(scope *vm.Scope) error {
 	var arguments HTTPArguments
 	if err := im.eval.Evaluate(scope, &arguments); err != nil {
-		return fmt.Errorf("decoding River: %w", err)
+		return fmt.Errorf("decoding configuration: %w", err)
 	}
 	if im.managedRemoteHTTP == nil {
 		var err error

--- a/internal/flow/internal/importsource/import_string.go
+++ b/internal/flow/internal/importsource/import_string.go
@@ -33,7 +33,7 @@ type importStringConfigBlock struct {
 func (im *ImportString) Evaluate(scope *vm.Scope) error {
 	var arguments importStringConfigBlock
 	if err := im.eval.Evaluate(scope, &arguments); err != nil {
-		return fmt.Errorf("decoding River: %w", err)
+		return fmt.Errorf("decoding configuration: %w", err)
 	}
 
 	if reflect.DeepEqual(im.arguments, arguments) {

--- a/internal/flow/module.go
+++ b/internal/flow/module.go
@@ -40,7 +40,7 @@ func newModuleController(o *moduleControllerOptions) controller.ModuleController
 // NewModule creates a new, unstarted Module.
 func (m *moduleController) NewModule(id string, export component.ExportFunc) (component.Module, error) {
 	if id != "" && !scanner.IsValidIdentifier(id) {
-		return nil, fmt.Errorf("module ID %q is not a valid River identifier", id)
+		return nil, fmt.Errorf("module ID %q is not a valid identifier", id)
 	}
 
 	m.mut.Lock()
@@ -63,7 +63,7 @@ func (m *moduleController) NewModule(id string, export component.ExportFunc) (co
 // NewCustomComponent creates a new, unstarted CustomComponent.
 func (m *moduleController) NewCustomComponent(id string, export component.ExportFunc) (controller.CustomComponent, error) {
 	if id != "" && !scanner.IsValidIdentifier(id) {
-		return nil, fmt.Errorf("customComponent ID %q is not a valid River identifier", id)
+		return nil, fmt.Errorf("customComponent ID %q is not a valid identifier", id)
 	}
 
 	m.mut.Lock()

--- a/internal/flowmode/cmd_convert.go
+++ b/internal/flowmode/cmd_convert.go
@@ -26,9 +26,9 @@ func convertCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "convert [flags] [file]",
-		Short: "Convert a supported config file to River",
+		Short: "Convert a supported config file to Alloy",
 		Long: `The convert subcommand translates a supported config file to
-a River configuration file.
+an Alloy configuration file.
 
 If the file argument is not supplied or if the file argument is "-", then
 convert will read from stdin.

--- a/internal/flowmode/cmd_fmt.go
+++ b/internal/flowmode/cmd_fmt.go
@@ -21,9 +21,9 @@ func fmtCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "fmt [flags] file",
-		Short: "Format a River file",
-		Long: `The fmt subcommand applies standard formatting rules to the specified
-River configuration file.
+		Short: "Format a configuration file",
+		Long: `The fmt subcommand applies standard formatting rules to the
+specified configuration file.
 
 If the file argument is not supplied or if the file argument is "-", then fmt will read from stdin.
 

--- a/internal/flowmode/cmd_run.go
+++ b/internal/flowmode/cmd_run.go
@@ -68,8 +68,9 @@ func runCommand() *cobra.Command {
 		Long: `The run subcommand runs Grafana Agent Flow in the foreground until an interrupt
 is received.
 
-run must be provided an argument pointing at the River dir/file-path to use. If the
-River dir/file-path wasn't specified, can't be loaded, or contains errors, run will exit
+run must be provided an argument pointing at the Alloy configuration
+dirirectory or file path to use. If the configuration directory or file path
+wasn't specified, can't be loaded, or contains errors, run will exit
 immediately.
 
 If path is a directory, all *.river files in that directory will be combined

--- a/internal/service/remotecfg/remotecfg_test.go
+++ b/internal/service/remotecfg/remotecfg_test.go
@@ -42,7 +42,7 @@ func TestOnDiskCache(t *testing.T) {
 	env.svc.asClient = client
 
 	// Mock client to return an unparseable response.
-	client.getConfigFunc = buildGetConfigHandler("unparseable river config")
+	client.getConfigFunc = buildGetConfigHandler("unparseable config")
 
 	// Write the cache contents, and run the service.
 	err := os.WriteFile(env.svc.dataPath, []byte(cacheContents), 0644)

--- a/syntax/ast/walk.go
+++ b/syntax/ast/walk.go
@@ -66,7 +66,7 @@ func Walk(v Visitor, node Node) {
 	case *ParenExpr:
 		Walk(v, n.Inner)
 	default:
-		panic(fmt.Sprintf("river/ast: unexpected node type %T", n))
+		panic(fmt.Sprintf("syntax/ast: unexpected node type %T", n))
 	}
 
 	v.Visit(nil)

--- a/syntax/encoding/riverjson/riverjson.go
+++ b/syntax/encoding/riverjson/riverjson.go
@@ -61,7 +61,7 @@ func encodeStructAsBody(rv reflect.Value) jsonBody {
 
 	case reflect.Map:
 		if rv.Type().Key().Kind() != reflect.String {
-			panic("river/encoding/riverjson: unsupported map type; expected map[string]T, got " + rv.Type().String())
+			panic("syntax/encoding/riverjson: unsupported map type; expected map[string]T, got " + rv.Type().String())
 		}
 
 		iter := rv.MapRange()
@@ -76,7 +76,7 @@ func encodeStructAsBody(rv reflect.Value) jsonBody {
 		}
 
 	default:
-		panic(fmt.Sprintf("river/encoding/riverjson: can only encode struct or map[string]T values to bodies, got %s", rv.Kind()))
+		panic(fmt.Sprintf("syntax/encoding/riverjson: can only encode struct or map[string]T values to bodies, got %s", rv.Kind()))
 	}
 
 	return body
@@ -111,7 +111,7 @@ func encodeFieldAsStatements(prefix []string, field rivertags.Field, fieldValue 
 			// Iterate over the map and add each element as an attribute into it.
 
 			if fieldValue.Type().Key().Kind() != reflect.String {
-				panic("river/encoding/riverjson: unsupported map type for block; expected map[string]T, got " + fieldValue.Type().String())
+				panic("syntax/encoding/riverjson: unsupported map type for block; expected map[string]T, got " + fieldValue.Type().String())
 			}
 
 			statements := []jsonStatement{}
@@ -182,7 +182,7 @@ func encodeFieldAsStatements(prefix []string, field rivertags.Field, fieldValue 
 			return statements
 
 		default:
-			panic(fmt.Sprintf("river/encoding/riverjson: unrecognized enum kind %s", fieldValue.Kind()))
+			panic(fmt.Sprintf("syntax/encoding/riverjson: unrecognized enum kind %s", fieldValue.Kind()))
 		}
 	}
 
@@ -308,6 +308,6 @@ func buildJSONValue(v value.Value) jsonValue {
 		return jsonValue{Type: "capsule", Value: v.Describe()}
 
 	default:
-		panic(fmt.Sprintf("river/encoding/riverjson: unrecognized value type %q", v.Type()))
+		panic(fmt.Sprintf("syntax/encoding/riverjson: unrecognized value type %q", v.Type()))
 	}
 }

--- a/syntax/internal/rivertags/rivertags.go
+++ b/syntax/internal/rivertags/rivertags.go
@@ -148,7 +148,7 @@ func (f Field) IsLabel() bool { return f.Flags&FlagLabel != 0 }
 // `river:",label"` tags, which must be strings.
 func Get(ty reflect.Type) []Field {
 	if k := ty.Kind(); k != reflect.Struct {
-		panic(fmt.Sprintf("rivertags: Get requires struct kind, got %s", k))
+		panic(fmt.Sprintf("syntaxtags: Get requires struct kind, got %s", k))
 	}
 
 	var (
@@ -161,7 +161,7 @@ func Get(ty reflect.Type) []Field {
 	for _, field := range reflect.VisibleFields(ty) {
 		// River does not support embedding of fields
 		if field.Anonymous {
-			panic(fmt.Sprintf("river: anonymous fields not supported %s", printPathToField(ty, field.Index)))
+			panic(fmt.Sprintf("syntax: anonymous fields not supported %s", printPathToField(ty, field.Index)))
 		}
 
 		tag, tagged := field.Tag.Lookup("river")
@@ -170,15 +170,15 @@ func Get(ty reflect.Type) []Field {
 		}
 
 		if !field.IsExported() {
-			panic(fmt.Sprintf("river: river tag found on unexported field at %s", printPathToField(ty, field.Index)))
+			panic(fmt.Sprintf("syntax: river tag found on unexported field at %s", printPathToField(ty, field.Index)))
 		}
 
 		options := strings.SplitN(tag, ",", 2)
 		if len(options) == 0 {
-			panic(fmt.Sprintf("river: unsupported empty tag at %s", printPathToField(ty, field.Index)))
+			panic(fmt.Sprintf("syntax: unsupported empty tag at %s", printPathToField(ty, field.Index)))
 		}
 		if len(options) != 2 {
-			panic(fmt.Sprintf("river: field %s tag is missing options", printPathToField(ty, field.Index)))
+			panic(fmt.Sprintf("syntax: field %s tag is missing options", printPathToField(ty, field.Index)))
 		}
 
 		fullName := options[0]
@@ -189,18 +189,18 @@ func Get(ty reflect.Type) []Field {
 		}
 
 		if first, used := usedNames[fullName]; used && fullName != "" {
-			panic(fmt.Sprintf("river: field name %s already used by %s", fullName, printPathToField(ty, first)))
+			panic(fmt.Sprintf("syntax: field name %s already used by %s", fullName, printPathToField(ty, first)))
 		}
 		usedNames[fullName] = tf.Index
 
 		flags, ok := parseFlags(options[1])
 		if !ok {
-			panic(fmt.Sprintf("river: unrecognized river tag format %q at %s", tag, printPathToField(ty, tf.Index)))
+			panic(fmt.Sprintf("syntax: unrecognized river tag format %q at %s", tag, printPathToField(ty, tf.Index)))
 		}
 		tf.Flags = flags
 
 		if len(tf.Name) > 1 && tf.Flags&(FlagBlock|FlagEnum) == 0 {
-			panic(fmt.Sprintf("river: field names with `.` may only be used by blocks or enums (found at %s)", printPathToField(ty, tf.Index)))
+			panic(fmt.Sprintf("syntax: field names with `.` may only be used by blocks or enums (found at %s)", printPathToField(ty, tf.Index)))
 		}
 
 		if tf.Flags&FlagEnum != 0 {
@@ -211,21 +211,21 @@ func Get(ty reflect.Type) []Field {
 
 		if tf.Flags&FlagLabel != 0 {
 			if fullName != "" {
-				panic(fmt.Sprintf("river: label field at %s must not have a name", printPathToField(ty, tf.Index)))
+				panic(fmt.Sprintf("syntax: label field at %s must not have a name", printPathToField(ty, tf.Index)))
 			}
 			if field.Type.Kind() != reflect.String {
-				panic(fmt.Sprintf("river: label field at %s must be a string", printPathToField(ty, tf.Index)))
+				panic(fmt.Sprintf("syntax: label field at %s must be a string", printPathToField(ty, tf.Index)))
 			}
 
 			if usedLabelField != nil {
-				panic(fmt.Sprintf("river: label field already used by %s", printPathToField(ty, tf.Index)))
+				panic(fmt.Sprintf("syntax: label field already used by %s", printPathToField(ty, tf.Index)))
 			}
 			usedLabelField = tf.Index
 		}
 
 		if tf.Flags&FlagSquash != 0 {
 			if fullName != "" {
-				panic(fmt.Sprintf("river: squash field at %s must not have a name", printPathToField(ty, tf.Index)))
+				panic(fmt.Sprintf("syntax: squash field at %s must not have a name", printPathToField(ty, tf.Index)))
 			}
 
 			innerType := deferenceType(field.Type)
@@ -245,14 +245,14 @@ func Get(ty reflect.Type) []Field {
 				}
 
 			default:
-				panic(fmt.Sprintf("rivertags: squash field requires struct, got %s", innerType))
+				panic(fmt.Sprintf("syntaxtags: squash field requires struct, got %s", innerType))
 			}
 
 			continue
 		}
 
 		if fullName == "" && tf.Flags&(FlagLabel|FlagSquash) == 0 /* (e.g., *not* a label or squash) */ {
-			panic(fmt.Sprintf("river: non-empty field name required at %s", printPathToField(ty, tf.Index)))
+			panic(fmt.Sprintf("syntaxtags: non-empty field name required at %s", printPathToField(ty, tf.Index)))
 		}
 
 		fields = append(fields, tf)

--- a/syntax/token/builder/builder.go
+++ b/syntax/token/builder/builder.go
@@ -174,7 +174,7 @@ func (b *Body) encodeFields(rv reflect.Value) {
 		rv = rv.Elem()
 	}
 	if rv.Kind() != reflect.Struct {
-		panic(fmt.Sprintf("river/token/builder: can only encode struct values to bodies, got %s", rv.Type()))
+		panic(fmt.Sprintf("syntax/token/builder: can only encode struct values to bodies, got %s", rv.Type()))
 	}
 
 	fields := rivertags.Get(rv.Type())
@@ -223,7 +223,7 @@ func (b *Body) encodeField(prefix []string, field rivertags.Field, fieldValue re
 		case fieldValue.Kind() == reflect.Map:
 			// Iterate over the map and add each element as an attribute into it.
 			if fieldValue.Type().Key().Kind() != reflect.String {
-				panic("river/token/builder: unsupported map type for block; expected map[string]T, got " + fieldValue.Type().String())
+				panic("syntax/token/builder: unsupported map type for block; expected map[string]T, got " + fieldValue.Type().String())
 			}
 
 			inner := NewBlock(fullName, "")
@@ -267,7 +267,7 @@ func (b *Body) encodeField(prefix []string, field rivertags.Field, fieldValue re
 			}
 
 		default:
-			panic(fmt.Sprintf("river/token/builder: unrecognized enum kind %s", fieldValue.Kind()))
+			panic(fmt.Sprintf("syntax/token/builder: unrecognized enum kind %s", fieldValue.Kind()))
 		}
 	}
 }

--- a/syntax/vm/op_binary.go
+++ b/syntax/vm/op_binary.go
@@ -204,7 +204,7 @@ func evalBinop(lhs value.Value, op token.Token, rhs value.Value) (value.Value, e
 		}
 	}
 
-	panic("river/vm: unreachable")
+	panic("syntax/vm: unreachable")
 }
 
 // tryUnwrapOptionalSecret accepts a value and, if it is a
@@ -294,7 +294,7 @@ func valuesEqual(lhs value.Value, rhs value.Value) bool {
 		return reflect.DeepEqual(lhs.Interface(), rhs.Interface())
 	}
 
-	panic("river/vm: unreachable")
+	panic("syntax/vm: unreachable")
 }
 
 // binopAllowedTypes maps what type of values are permitted for a specific
@@ -322,7 +322,7 @@ var binopAllowedTypes = map[token.Token][]value.Type{
 func acceptableBinopType(val value.Value, op token.Token) bool {
 	allowed, ok := binopAllowedTypes[op]
 	if !ok {
-		panic("river/vm: unexpected binop type")
+		panic("syntax/vm: unexpected binop type")
 	}
 
 	actualType := val.Type()

--- a/syntax/vm/op_unary.go
+++ b/syntax/vm/op_unary.go
@@ -29,5 +29,5 @@ func evalUnaryOp(op token.Token, val value.Value) (value.Value, error) {
 		}
 	}
 
-	panic("river/vm: unreachable")
+	panic("syntax/vm: unreachable")
 }

--- a/syntax/vm/struct_decoder.go
+++ b/syntax/vm/struct_decoder.go
@@ -25,7 +25,7 @@ func (st *structDecoder) Decode(stmts ast.Body, rv reflect.Value) error {
 	// TODO(rfratto): potentially loosen this restriction and allow decoding into
 	// an interface{} or map[string]interface{}.
 	if rv.Kind() != reflect.Struct {
-		panic(fmt.Sprintf("river/vm: structDecoder expects struct, got %s", rv.Kind()))
+		panic(fmt.Sprintf("syntax/vm: structDecoder expects struct, got %s", rv.Kind()))
 	}
 
 	state := decodeOptions{
@@ -79,7 +79,7 @@ func (st *structDecoder) Decode(stmts ast.Body, rv reflect.Value) error {
 			}
 
 		default:
-			panic(fmt.Sprintf("river/vm: unrecognized node type %T", stmt))
+			panic(fmt.Sprintf("syntax/vm: unrecognized node type %T", stmt))
 		}
 	}
 
@@ -228,7 +228,7 @@ func (st *structDecoder) decodeNormalBlock(fullName string, block *ast.BlockStmt
 
 		blockIndex, ok := state.BlockIndex[block]
 		if !ok {
-			panic("river/vm: block not found in index lookup table")
+			panic("syntax/vm: block not found in index lookup table")
 		}
 		decodeElement := prepareDecodeValue(decodeField.Index(blockIndex))
 		err := st.VM.evaluateBlockOrBody(st.Scope, st.Assoc, block, decodeElement)
@@ -254,7 +254,7 @@ func (st *structDecoder) decodeNormalBlock(fullName string, block *ast.BlockStmt
 
 		blockIndex, ok := state.BlockIndex[block]
 		if !ok {
-			panic("river/vm: block not found in index lookup table")
+			panic("syntax/vm: block not found in index lookup table")
 		}
 		decodeElement := prepareDecodeValue(decodeField.Index(blockIndex))
 		err := st.VM.evaluateBlockOrBody(st.Scope, st.Assoc, block, decodeElement)
@@ -297,7 +297,7 @@ func (st *structDecoder) decodeEnumBlock(fullName string, block *ast.BlockStmt, 
 	decodeField := prepareDecodeValue(enumField)
 
 	if decodeField.Kind() != reflect.Slice {
-		panic("river/vm: enum field must be a slice kind, got " + decodeField.Kind().String())
+		panic("syntax/vm: enum field must be a slice kind, got " + decodeField.Kind().String())
 	}
 
 	// If this is the first time we've seen the enum, reset its length to zero.
@@ -310,7 +310,7 @@ func (st *structDecoder) decodeEnumBlock(fullName string, block *ast.BlockStmt, 
 	// Prepare the enum element to decode into.
 	enumIndex, ok := state.EnumIndex[block]
 	if !ok {
-		panic("river/vm: enum block not found in index lookup table")
+		panic("syntax/vm: enum block not found in index lookup table")
 	}
 	enumElement := prepareDecodeValue(decodeField.Index(enumIndex))
 

--- a/syntax/vm/vm.go
+++ b/syntax/vm/vm.go
@@ -53,19 +53,19 @@ func (vm *Evaluator) Evaluate(scope *Scope, v interface{}) (err error) {
 	case *ast.BlockStmt, ast.Body:
 		rv := reflect.ValueOf(v)
 		if rv.Kind() != reflect.Pointer {
-			panic(fmt.Sprintf("river/vm: expected pointer, got %s", rv.Kind()))
+			panic(fmt.Sprintf("syntax/vm: expected pointer, got %s", rv.Kind()))
 		}
 		return vm.evaluateBlockOrBody(scope, assoc, node, rv)
 	case *ast.File:
 		rv := reflect.ValueOf(v)
 		if rv.Kind() != reflect.Pointer {
-			panic(fmt.Sprintf("river/vm: expected pointer, got %s", rv.Kind()))
+			panic(fmt.Sprintf("syntax/vm: expected pointer, got %s", rv.Kind()))
 		}
 		return vm.evaluateBlockOrBody(scope, assoc, node.Body, rv)
 	default:
 		expr, ok := node.(ast.Expr)
 		if !ok {
-			panic(fmt.Sprintf("river/vm: unexpected value type %T", node))
+			panic(fmt.Sprintf("syntax/vm: unexpected value type %T", node))
 		}
 		val, err := vm.evaluateExpr(scope, assoc, expr)
 		if err != nil {
@@ -108,7 +108,7 @@ func (vm *Evaluator) evaluateUnmarshalRiver(scope *Scope, assoc map[value.Value]
 		return ru.UnmarshalRiver(func(v interface{}) error {
 			rv := reflect.ValueOf(v)
 			if rv.Kind() != reflect.Pointer {
-				panic(fmt.Sprintf("river/vm: expected pointer, got %s", rv.Kind()))
+				panic(fmt.Sprintf("syntax/vm: expected pointer, got %s", rv.Kind()))
 			}
 			return vm.evaluateBlockOrBody(scope, assoc, node, rv.Elem())
 		}), true
@@ -141,7 +141,7 @@ func (vm *Evaluator) evaluateDecode(scope *Scope, assoc map[value.Value]ast.Node
 	} else if rv.Kind() == reflect.Map {
 		return vm.evaluateMap(scope, assoc, node, rv)
 	} else if rv.Kind() != reflect.Struct {
-		panic(fmt.Sprintf("river/vm: can only evaluate blocks into structs, got %s", rv.Kind()))
+		panic(fmt.Sprintf("syntax/vm: can only evaluate blocks into structs, got %s", rv.Kind()))
 	}
 
 	ti := getCachedTagInfo(rv.Type())
@@ -157,7 +157,7 @@ func (vm *Evaluator) evaluateDecode(scope *Scope, assoc map[value.Value]ast.Node
 	case ast.Body:
 		stmts = node
 	default:
-		panic(fmt.Sprintf("river/vm: unrecognized node type %T", node))
+		panic(fmt.Sprintf("syntax/vm: unrecognized node type %T", node))
 	}
 
 	sd := structDecoder{
@@ -187,7 +187,7 @@ func (vm *Evaluator) evaluateMap(scope *Scope, assoc map[value.Value]ast.Node, n
 	case ast.Body:
 		stmts = node
 	default:
-		panic(fmt.Sprintf("river/vm: unrecognized node type %T", node))
+		panic(fmt.Sprintf("syntax/vm: unrecognized node type %T", node))
 	}
 
 	if rv.IsNil() {
@@ -221,7 +221,7 @@ func (vm *Evaluator) evaluateMap(scope *Scope, assoc map[value.Value]ast.Node, n
 			}
 
 		default:
-			panic(fmt.Sprintf("river/vm: unrecognized node type %T", stmt))
+			panic(fmt.Sprintf("syntax/vm: unrecognized node type %T", stmt))
 		}
 	}
 
@@ -274,7 +274,7 @@ func (vm *Evaluator) evaluateBlockLabel(node *ast.BlockStmt, tfs []rivertags.Fie
 	)
 	if !reflect.TypeOf(node.Label).AssignableTo(fieldType) {
 		// The Label struct field needs to be a string.
-		panic(fmt.Sprintf("river/vm: cannot assign block label to non-string type %s", fieldType))
+		panic(fmt.Sprintf("syntax/vm: cannot assign block label to non-string type %s", fieldType))
 	}
 	field.Set(reflect.ValueOf(node.Label))
 	return nil
@@ -449,7 +449,7 @@ func (vm *Evaluator) evaluateExpr(scope *Scope, assoc map[value.Value]ast.Node, 
 		return funcVal.Call(args...)
 
 	default:
-		panic(fmt.Sprintf("river/vm: unexpected ast.Expr type %T", expr))
+		panic(fmt.Sprintf("syntax/vm: unexpected ast.Expr type %T", expr))
 	}
 }
 


### PR DESCRIPTION
Replace as many user-facing references to River with "syntax", "configuration", "Alloy configuration syntax", or "Alloy configuration" as much as possible.

This is a first pass, and more passes will be needed closer to the 1.0 launch. In particular, this commit avoids changing any reference which may be conflict prone until closer to launch, especially Go struct tags. 