### PR TITLE
misc: rename rivertags packages to syntaxtags

### DIFF
--- a/internal/cmd/agentlint/main.go
+++ b/internal/cmd/agentlint/main.go
@@ -4,13 +4,13 @@ package main
 
 import (
 	"github.com/grafana/agent/internal/cmd/agentlint/internal/findcomponents"
-	"github.com/grafana/agent/internal/cmd/agentlint/internal/rivertags"
+	"github.com/grafana/agent/internal/cmd/agentlint/internal/syntaxtags"
 	"golang.org/x/tools/go/analysis/multichecker"
 )
 
 func main() {
 	multichecker.Main(
 		findcomponents.Analyzer,
-		rivertags.Analyzer,
+		syntaxtags.Analyzer,
 	)
 }

--- a/syntax/encoding/riverjson/riverjson.go
+++ b/syntax/encoding/riverjson/riverjson.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/grafana/river/internal/reflectutil"
-	"github.com/grafana/river/internal/rivertags"
+	"github.com/grafana/river/internal/syntaxtags"
 	"github.com/grafana/river/internal/value"
 	"github.com/grafana/river/token/builder"
 )
@@ -39,7 +39,7 @@ func encodeStructAsBody(rv reflect.Value) jsonBody {
 
 	switch rv.Kind() {
 	case reflect.Struct:
-		fields := rivertags.Get(rv.Type())
+		fields := syntaxtags.Get(rv.Type())
 		defaults := reflect.New(rv.Type()).Elem()
 		if defaults.CanAddr() && defaults.Addr().Type().Implements(goRiverDefaulter) {
 			defaults.Addr().Interface().(value.Defaulter).SetToDefault()
@@ -85,7 +85,7 @@ func encodeStructAsBody(rv reflect.Value) jsonBody {
 // encodeFieldAsStatements encodes an individual field from a struct as a set
 // of statements. One field may map to multiple statements in the case of a
 // slice of blocks.
-func encodeFieldAsStatements(prefix []string, field rivertags.Field, fieldValue reflect.Value) []jsonStatement {
+func encodeFieldAsStatements(prefix []string, field syntaxtags.Field, fieldValue reflect.Value) []jsonStatement {
 	fieldName := strings.Join(field.Name, ".")
 
 	for fieldValue.Kind() == reflect.Pointer {
@@ -204,9 +204,9 @@ func mergeStringSlice(a, b []string) []string {
 
 // getBlockLabel returns the label for a given block.
 func getBlockLabel(rv reflect.Value) string {
-	tags := rivertags.Get(rv.Type())
+	tags := syntaxtags.Get(rv.Type())
 	for _, tag := range tags {
-		if tag.Flags&rivertags.FlagLabel != 0 {
+		if tag.Flags&syntaxtags.FlagLabel != 0 {
 			return reflectutil.Get(rv, tag).String()
 		}
 	}
@@ -222,7 +222,7 @@ func encodeEnumElementToStatements(prefix []string, enumElement reflect.Value) [
 		enumElement = enumElement.Elem()
 	}
 
-	fields := rivertags.Get(enumElement.Type())
+	fields := syntaxtags.Get(enumElement.Type())
 
 	statements := []jsonStatement{}
 

--- a/syntax/internal/reflectutil/walk.go
+++ b/syntax/internal/reflectutil/walk.go
@@ -3,12 +3,12 @@ package reflectutil
 import (
 	"reflect"
 
-	"github.com/grafana/river/internal/rivertags"
+	"github.com/grafana/river/internal/syntaxtags"
 )
 
 // GetOrAlloc returns the nested field of value corresponding to index.
 // GetOrAlloc panics if not given a struct.
-func GetOrAlloc(value reflect.Value, field rivertags.Field) reflect.Value {
+func GetOrAlloc(value reflect.Value, field syntaxtags.Field) reflect.Value {
 	return GetOrAllocIndex(value, field.Index)
 }
 
@@ -51,7 +51,7 @@ func deferencePointer(value reflect.Value) reflect.Value {
 // It is similar to [reflect/Value.FieldByIndex] but can handle traversing
 // through nil pointers. If Get traverses through a nil pointer, a non-settable
 // zero value for the final field is returned.
-func Get(value reflect.Value, field rivertags.Field) reflect.Value {
+func Get(value reflect.Value, field syntaxtags.Field) reflect.Value {
 	if len(field.Index) == 1 {
 		return value.Field(field.Index[0])
 	}

--- a/syntax/internal/reflectutil/walk_test.go
+++ b/syntax/internal/reflectutil/walk_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/grafana/river/internal/reflectutil"
-	"github.com/grafana/river/internal/rivertags"
+	"github.com/grafana/river/internal/syntaxtags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,7 +25,7 @@ func TestDeeplyNested_Access(t *testing.T) {
 	s.Field1.Field2.Field3.Value = "Hello, world!"
 
 	rv := reflect.ValueOf(&s).Elem()
-	innerValue := reflectutil.GetOrAlloc(rv, rivertags.Field{Index: []int{0, 0, 0, 0}})
+	innerValue := reflectutil.GetOrAlloc(rv, syntaxtags.Field{Index: []int{0, 0, 0, 0}})
 	assert.True(t, innerValue.CanSet())
 	assert.Equal(t, reflect.String, innerValue.Kind())
 }
@@ -44,7 +44,7 @@ func TestDeeplyNested_Allocate(t *testing.T) {
 	var s Struct
 
 	rv := reflect.ValueOf(&s).Elem()
-	innerValue := reflectutil.GetOrAlloc(rv, rivertags.Field{Index: []int{0, 0, 0, 0}})
+	innerValue := reflectutil.GetOrAlloc(rv, syntaxtags.Field{Index: []int{0, 0, 0, 0}})
 	require.True(t, innerValue.CanSet())
 	require.Equal(t, reflect.String, innerValue.Kind())
 
@@ -66,7 +66,7 @@ func TestDeeplyNested_NoAllocate(t *testing.T) {
 	var s Struct
 
 	rv := reflect.ValueOf(&s).Elem()
-	innerValue := reflectutil.Get(rv, rivertags.Field{Index: []int{0, 0, 0, 0}})
+	innerValue := reflectutil.Get(rv, syntaxtags.Field{Index: []int{0, 0, 0, 0}})
 	assert.False(t, innerValue.CanSet())
 	assert.Equal(t, reflect.String, innerValue.Kind())
 }

--- a/syntax/internal/syntaxtags/syntaxtags.go
+++ b/syntax/internal/syntaxtags/syntaxtags.go
@@ -1,6 +1,6 @@
-// Package rivertags decodes a struct type into river object
-// and structural tags.
-package rivertags
+// Package syntaxtags decodes a struct type into syntax object and structural
+// tags.
+package syntaxtags
 
 import (
 	"fmt"
@@ -159,7 +159,7 @@ func Get(ty reflect.Type) []Field {
 	)
 
 	for _, field := range reflect.VisibleFields(ty) {
-		// River does not support embedding of fields
+		// Alloy's syntax does not support embedding of fields
 		if field.Anonymous {
 			panic(fmt.Sprintf("syntax: anonymous fields not supported %s", printPathToField(ty, field.Index)))
 		}

--- a/syntax/internal/syntaxtags/syntaxtags_test.go
+++ b/syntax/internal/syntaxtags/syntaxtags_test.go
@@ -1,10 +1,10 @@
-package rivertags_test
+package syntaxtags_test
 
 import (
 	"reflect"
 	"testing"
 
-	"github.com/grafana/river/internal/rivertags"
+	"github.com/grafana/river/internal/syntaxtags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -22,16 +22,16 @@ func Test_Get(t *testing.T) {
 		Label    string     `river:",label"`
 	}
 
-	fs := rivertags.Get(reflect.TypeOf(Struct{}))
+	fs := syntaxtags.Get(reflect.TypeOf(Struct{}))
 
-	expect := []rivertags.Field{
-		{[]string{"req_attr"}, []int{1}, rivertags.FlagAttr},
-		{[]string{"opt_attr"}, []int{2}, rivertags.FlagAttr | rivertags.FlagOptional},
-		{[]string{"req_block"}, []int{3}, rivertags.FlagBlock},
-		{[]string{"opt_block"}, []int{4}, rivertags.FlagBlock | rivertags.FlagOptional},
-		{[]string{"req_enum"}, []int{5}, rivertags.FlagEnum},
-		{[]string{"opt_enum"}, []int{6}, rivertags.FlagEnum | rivertags.FlagOptional},
-		{[]string{""}, []int{7}, rivertags.FlagLabel},
+	expect := []syntaxtags.Field{
+		{[]string{"req_attr"}, []int{1}, syntaxtags.FlagAttr},
+		{[]string{"opt_attr"}, []int{2}, syntaxtags.FlagAttr | syntaxtags.FlagOptional},
+		{[]string{"req_block"}, []int{3}, syntaxtags.FlagBlock},
+		{[]string{"opt_block"}, []int{4}, syntaxtags.FlagBlock | syntaxtags.FlagOptional},
+		{[]string{"req_enum"}, []int{5}, syntaxtags.FlagEnum},
+		{[]string{"opt_enum"}, []int{6}, syntaxtags.FlagEnum | syntaxtags.FlagOptional},
+		{[]string{""}, []int{7}, syntaxtags.FlagLabel},
 	}
 
 	require.Equal(t, expect, fs)
@@ -48,7 +48,7 @@ func TestEmbedded(t *testing.T) {
 		InnerStruct
 		Field2 string `river:"parent_field_2,attr"`
 	}
-	require.PanicsWithValue(t, "river: anonymous fields not supported rivertags_test.Struct.InnerStruct", func() { rivertags.Get(reflect.TypeOf(Struct{})) })
+	require.PanicsWithValue(t, "syntax: anonymous fields not supported syntaxtags_test.Struct.InnerStruct", func() { syntaxtags.Get(reflect.TypeOf(Struct{})) })
 }
 
 func TestSquash(t *testing.T) {
@@ -69,33 +69,33 @@ func TestSquash(t *testing.T) {
 		Field2 string       `river:"parent_field_2,attr"`
 	}
 
-	expect := []rivertags.Field{
+	expect := []syntaxtags.Field{
 		{
 			Name:  []string{"parent_field_1"},
 			Index: []int{0},
-			Flags: rivertags.FlagAttr,
+			Flags: syntaxtags.FlagAttr,
 		},
 		{
 			Name:  []string{"inner_field_1"},
 			Index: []int{1, 0},
-			Flags: rivertags.FlagAttr,
+			Flags: syntaxtags.FlagAttr,
 		},
 		{
 			Name:  []string{"inner_field_2"},
 			Index: []int{1, 1},
-			Flags: rivertags.FlagAttr,
+			Flags: syntaxtags.FlagAttr,
 		},
 		{
 			Name:  []string{"parent_field_2"},
 			Index: []int{2},
-			Flags: rivertags.FlagAttr,
+			Flags: syntaxtags.FlagAttr,
 		},
 	}
 
-	structActual := rivertags.Get(reflect.TypeOf(Struct{}))
+	structActual := syntaxtags.Get(reflect.TypeOf(Struct{}))
 	assert.Equal(t, expect, structActual)
 
-	structPointerActual := rivertags.Get(reflect.TypeOf(StructWithPointer{}))
+	structPointerActual := syntaxtags.Get(reflect.TypeOf(StructWithPointer{}))
 	assert.Equal(t, expect, structPointerActual)
 }
 
@@ -113,20 +113,20 @@ func TestDeepSquash(t *testing.T) {
 		Inner InnerStruct `river:",squash"`
 	}
 
-	expect := []rivertags.Field{
+	expect := []syntaxtags.Field{
 		{
 			Name:  []string{"inner_field_1"},
 			Index: []int{0, 0, 0},
-			Flags: rivertags.FlagAttr,
+			Flags: syntaxtags.FlagAttr,
 		},
 		{
 			Name:  []string{"inner_field_2"},
 			Index: []int{0, 0, 1},
-			Flags: rivertags.FlagAttr,
+			Flags: syntaxtags.FlagAttr,
 		},
 	}
 
-	structActual := rivertags.Get(reflect.TypeOf(Struct{}))
+	structActual := syntaxtags.Get(reflect.TypeOf(Struct{}))
 	assert.Equal(t, expect, structActual)
 }
 
@@ -134,40 +134,40 @@ func Test_Get_Panics(t *testing.T) {
 	expectPanic := func(t *testing.T, expect string, v interface{}) {
 		t.Helper()
 		require.PanicsWithValue(t, expect, func() {
-			_ = rivertags.Get(reflect.TypeOf(v))
+			_ = syntaxtags.Get(reflect.TypeOf(v))
 		})
 	}
 
 	t.Run("Tagged fields must be exported", func(t *testing.T) {
 		type Struct struct {
-			attr string `river:"field,attr"` // nolint:unused //nolint:rivertags
+			attr string `river:"field,attr"` // nolint:unused //nolint:syntaxtags
 		}
-		expect := `river: river tag found on unexported field at rivertags_test.Struct.attr`
+		expect := `syntax: river tag found on unexported field at syntaxtags_test.Struct.attr`
 		expectPanic(t, expect, Struct{})
 	})
 
 	t.Run("Options are required", func(t *testing.T) {
 		type Struct struct {
-			Attr string `river:"field"` //nolint:rivertags
+			Attr string `river:"field"` //nolint:syntaxtags
 		}
-		expect := `river: field rivertags_test.Struct.Attr tag is missing options`
+		expect := `syntax: field syntaxtags_test.Struct.Attr tag is missing options`
 		expectPanic(t, expect, Struct{})
 	})
 
 	t.Run("Field names must be unique", func(t *testing.T) {
 		type Struct struct {
 			Attr  string `river:"field1,attr"`
-			Block string `river:"field1,block,optional"` //nolint:rivertags
+			Block string `river:"field1,block,optional"` //nolint:syntaxtags
 		}
-		expect := `river: field name field1 already used by rivertags_test.Struct.Attr`
+		expect := `syntax: field name field1 already used by syntaxtags_test.Struct.Attr`
 		expectPanic(t, expect, Struct{})
 	})
 
 	t.Run("Name is required for non-label field", func(t *testing.T) {
 		type Struct struct {
-			Attr string `river:",attr"` //nolint:rivertags
+			Attr string `river:",attr"` //nolint:syntaxtags
 		}
-		expect := `river: non-empty field name required at rivertags_test.Struct.Attr`
+		expect := `syntaxtags: non-empty field name required at syntaxtags_test.Struct.Attr`
 		expectPanic(t, expect, Struct{})
 	})
 
@@ -176,7 +176,7 @@ func Test_Get_Panics(t *testing.T) {
 			Label1 string `river:",label"`
 			Label2 string `river:",label"`
 		}
-		expect := `river: label field already used by rivertags_test.Struct.Label2`
+		expect := `syntax: label field already used by syntaxtags_test.Struct.Label2`
 		expectPanic(t, expect, Struct{})
 	})
 }

--- a/syntax/internal/value/tag_cache.go
+++ b/syntax/internal/value/tag_cache.go
@@ -3,7 +3,7 @@ package value
 import (
 	"reflect"
 
-	"github.com/grafana/river/internal/rivertags"
+	"github.com/grafana/river/internal/syntaxtags"
 )
 
 // tagsCache caches the river tags for a struct type. This is never cleared,
@@ -20,17 +20,17 @@ func getCachedTags(t reflect.Type) *objectFields {
 		return entry
 	}
 
-	ff := rivertags.Get(t)
+	ff := syntaxtags.Get(t)
 
 	// Build a tree of keys.
 	tree := &objectFields{
-		fields:       make(map[string]rivertags.Field),
+		fields:       make(map[string]syntaxtags.Field),
 		nestedFields: make(map[string]*objectFields),
 		keys:         []string{},
 	}
 
 	for _, f := range ff {
-		if f.Flags&rivertags.FlagLabel != 0 {
+		if f.Flags&syntaxtags.FlagLabel != 0 {
 			// Skip over label tags.
 			tree.labelField = f
 			continue
@@ -52,7 +52,7 @@ func getCachedTags(t reflect.Type) *objectFields {
 			inner, ok := node.nestedFields[name]
 			if !ok {
 				inner = &objectFields{
-					fields:       make(map[string]rivertags.Field),
+					fields:       make(map[string]syntaxtags.Field),
 					nestedFields: make(map[string]*objectFields),
 					keys:         []string{},
 				}
@@ -66,14 +66,14 @@ func getCachedTags(t reflect.Type) *objectFields {
 	return tree
 }
 
-// objectFields is a parsed tree of fields in rivertags. It forms a tree where
+// objectFields is a parsed tree of fields in syntaxtags. It forms a tree where
 // leaves are nested fields (e.g., for block names that have multiple name
 // fragments) and nodes are the fields themselves.
 type objectFields struct {
-	fields       map[string]rivertags.Field
+	fields       map[string]syntaxtags.Field
 	nestedFields map[string]*objectFields
 	keys         []string // Combination of fields + nestedFields
-	labelField   rivertags.Field
+	labelField   syntaxtags.Field
 }
 
 type objectKeyType int
@@ -103,7 +103,7 @@ func (of *objectFields) Len() int { return len(of.keys) }
 func (of *objectFields) Keys() []string { return of.keys }
 
 // Field gets a non-nested field. Returns false if name is a nested field.
-func (of *objectFields) Field(name string) (rivertags.Field, bool) {
+func (of *objectFields) Field(name string) (syntaxtags.Field, bool) {
 	f, ok := of.fields[name]
 	return f, ok
 }
@@ -116,6 +116,6 @@ func (of *objectFields) NestedField(name string) (*objectFields, bool) {
 }
 
 // LabelField returns the field used for the label (if any).
-func (of *objectFields) LabelField() (rivertags.Field, bool) {
+func (of *objectFields) LabelField() (syntaxtags.Field, bool) {
 	return of.labelField, of.labelField.Index != nil
 }

--- a/syntax/token/builder/builder.go
+++ b/syntax/token/builder/builder.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/grafana/river/internal/reflectutil"
-	"github.com/grafana/river/internal/rivertags"
+	"github.com/grafana/river/internal/syntaxtags"
 	"github.com/grafana/river/internal/value"
 	"github.com/grafana/river/token"
 )
@@ -156,9 +156,9 @@ func (b *Body) AppendFrom(goValue interface{}) {
 
 // getBlockLabel returns the label for a given block.
 func getBlockLabel(rv reflect.Value) string {
-	tags := rivertags.Get(rv.Type())
+	tags := syntaxtags.Get(rv.Type())
 	for _, tag := range tags {
-		if tag.Flags&rivertags.FlagLabel != 0 {
+		if tag.Flags&syntaxtags.FlagLabel != 0 {
 			return reflectutil.Get(rv, tag).String()
 		}
 	}
@@ -177,7 +177,7 @@ func (b *Body) encodeFields(rv reflect.Value) {
 		panic(fmt.Sprintf("syntax/token/builder: can only encode struct values to bodies, got %s", rv.Type()))
 	}
 
-	fields := rivertags.Get(rv.Type())
+	fields := syntaxtags.Get(rv.Type())
 	defaults := reflect.New(rv.Type()).Elem()
 	if defaults.CanAddr() && defaults.Addr().Type().Implements(goRiverDefaulter) {
 		defaults.Addr().Interface().(value.Defaulter).SetToDefault()
@@ -202,7 +202,7 @@ func (b *Body) encodeFields(rv reflect.Value) {
 	}
 }
 
-func (b *Body) encodeField(prefix []string, field rivertags.Field, fieldValue reflect.Value) {
+func (b *Body) encodeField(prefix []string, field syntaxtags.Field, fieldValue reflect.Value) {
 	fieldName := strings.Join(field.Name, ".")
 
 	for fieldValue.Kind() == reflect.Pointer {
@@ -243,7 +243,7 @@ func (b *Body) encodeField(prefix []string, field rivertags.Field, fieldValue re
 				// Recursively call encodeField for each element in the slice/array for
 				// non-zero blocks. The recursive call will hit the case below and add
 				// a new block for each field encountered.
-				if field.Flags&rivertags.FlagOptional != 0 && elem.IsZero() {
+				if field.Flags&syntaxtags.FlagOptional != 0 && elem.IsZero() {
 					continue
 				}
 				b.encodeField(prefix, field, elem)
@@ -293,7 +293,7 @@ func (b *Body) encodeEnumElement(prefix []string, enumElement reflect.Value) {
 		enumElement = enumElement.Elem()
 	}
 
-	fields := rivertags.Get(enumElement.Type())
+	fields := syntaxtags.Get(enumElement.Type())
 
 	// Find the first non-zero field and encode it.
 	for _, field := range fields {

--- a/syntax/vm/struct_decoder.go
+++ b/syntax/vm/struct_decoder.go
@@ -8,7 +8,7 @@ import (
 	"github.com/grafana/river/ast"
 	"github.com/grafana/river/diag"
 	"github.com/grafana/river/internal/reflectutil"
-	"github.com/grafana/river/internal/rivertags"
+	"github.com/grafana/river/internal/syntaxtags"
 	"github.com/grafana/river/internal/value"
 )
 
@@ -110,7 +110,7 @@ func (st *structDecoder) Decode(stmts ast.Body, rv reflect.Value) error {
 }
 
 type decodeOptions struct {
-	Tags       map[string]rivertags.Field
+	Tags       map[string]syntaxtags.Field
 	EnumBlocks map[string]enumBlock
 
 	SeenAttrs, SeenBlocks, SeenEnums map[string]struct{}

--- a/syntax/vm/tag_cache.go
+++ b/syntax/vm/tag_cache.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/grafana/river/internal/rivertags"
+	"github.com/grafana/river/internal/syntaxtags"
 )
 
 // tagsCache caches the river tags for a struct type. This is never cleared,
@@ -22,10 +22,10 @@ func getCachedTagInfo(t reflect.Type) *tagInfo {
 		return entry.(*tagInfo)
 	}
 
-	tfs := rivertags.Get(t)
+	tfs := syntaxtags.Get(t)
 	ti := &tagInfo{
 		Tags:       tfs,
-		TagLookup:  make(map[string]rivertags.Field, len(tfs)),
+		TagLookup:  make(map[string]syntaxtags.Field, len(tfs)),
 		EnumLookup: make(map[string]enumBlock), // The length is not known ahead of time
 	}
 
@@ -66,8 +66,8 @@ func deferenceType(ty reflect.Type) reflect.Type {
 }
 
 type tagInfo struct {
-	Tags      []rivertags.Field
-	TagLookup map[string]rivertags.Field
+	Tags      []syntaxtags.Field
+	TagLookup map[string]syntaxtags.Field
 
 	// EnumLookup maps enum blocks to the enum field. For example, an enum block
 	// called "foo.foo" and "foo.bar" will both map to the "foo" enum field.
@@ -75,6 +75,6 @@ type tagInfo struct {
 }
 
 type enumBlock struct {
-	EnumField  rivertags.Field // Field in the parent struct of the enum slice
-	BlockField rivertags.Field // Field in the enum struct for the enum block
+	EnumField  syntaxtags.Field // Field in the parent struct of the enum slice
+	BlockField syntaxtags.Field // Field in the enum struct for the enum block
 }

--- a/syntax/vm/vm.go
+++ b/syntax/vm/vm.go
@@ -9,8 +9,8 @@ import (
 	"github.com/grafana/river/ast"
 	"github.com/grafana/river/diag"
 	"github.com/grafana/river/internal/reflectutil"
-	"github.com/grafana/river/internal/rivertags"
 	"github.com/grafana/river/internal/stdlib"
+	"github.com/grafana/river/internal/syntaxtags"
 	"github.com/grafana/river/internal/value"
 )
 
@@ -228,13 +228,13 @@ func (vm *Evaluator) evaluateMap(scope *Scope, assoc map[value.Value]ast.Node, n
 	return nil
 }
 
-func (vm *Evaluator) evaluateBlockLabel(node *ast.BlockStmt, tfs []rivertags.Field, rv reflect.Value) error {
+func (vm *Evaluator) evaluateBlockLabel(node *ast.BlockStmt, tfs []syntaxtags.Field, rv reflect.Value) error {
 	var (
-		labelField rivertags.Field
+		labelField syntaxtags.Field
 		foundField bool
 	)
 	for _, tf := range tfs {
-		if tf.Flags&rivertags.FlagLabel != 0 {
+		if tf.Flags&syntaxtags.FlagLabel != 0 {
 			labelField = tf
 			foundField = true
 			break


### PR DESCRIPTION
This commit renames rivertags packages to syntaxtags, and replaces as many references of "River" to "syntax" or "Alloy syntax" as possible.

This is a safe change for syntax/internal/rivertags as it is an internal package and cannot be imported from the top-level module.

The tag names themselves have not yet changed, so those are left untouched.
