### PR TITLE
discovery.process: restore public preview status

### DIFF
--- a/docs/sources/reference/components/discovery.process.md
+++ b/docs/sources/reference/components/discovery.process.md
@@ -2,6 +2,8 @@
 canonical: https://grafana.com/docs/alloy/latest/reference/components/discovery.process/
 description: Learn about discovery.process
 title: discovery.process
+labels:
+  stage: beta
 ---
 
 # discovery.process

--- a/internal/component/discovery/process/process.go
+++ b/internal/component/discovery/process/process.go
@@ -15,7 +15,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "discovery.process",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityBeta,
 		Args:      Arguments{},
 		Exports:   discovery.Exports{},
 


### PR DESCRIPTION
discovery.process was mistakenly bumped to GA, but this wasn't intentional and the maintainers have asked for it to remain at beta/public preview.