### PR TITLE
docs: remove step to create discussion page

### DIFF
--- a/docs/developer/release/6-publish-release.md
+++ b/docs/developer/release/6-publish-release.md
@@ -15,11 +15,10 @@ This is how to publish the release in GitHub.
 3. Add a footer to the `Notable Changes` section:
 
     `For a full list of changes, please refer to the [CHANGELOG](https://github.com/grafana/agent/blob/RELEASE_VERSION/CHANGELOG.md)!`
-    
-    Do not substitute the value for `CHANGELOG`.  
+
+    Do not substitute the value for `CHANGELOG`.
 
 4. At the bottom of the release page, perform the following:
-    - Tick the check box to "add a discussion" under the category for "announcements".
     - For a Release Candidate, tick the checkbox to "pre-release".
     - For a Stable Release or Patch Release, tick the checkbox to "set as the latest release".
 


### PR DESCRIPTION
At least for now, the idea is to focus discussion towards <https://community.grafana.com>, so discussions have been disabled in the Alloy repo.