### PR TITLE
docs: Update editor support

### DIFF
--- a/docs/sources/concepts/config-language/_index.md
+++ b/docs/sources/concepts/config-language/_index.md
@@ -114,12 +114,5 @@ You can use one or all of the following tools to help you write configuration fi
   * [Vim/Neovim](https://github.com/grafana/vim-alloy)
 * Code formatting using the [`agent fmt` command][fmt]
 
-You can also start developing your own tooling using the {{< param "PRODUCT_ROOT_NAME" >}} repository as a go package or use the
-[tree-sitter grammar][] with other programming languages.
-
 [RFC]: https://github.com/grafana/agent/blob/97a55d0d908b26dbb1126cc08b6dcc18f6e30087/docs/rfcs/0005-river.md
-[vim]: https://github.com/rfratto/vim-river
-[VSCode]: https://github.com/rfratto/vscode-river
-[river-mode]: https://github.com/jdbaldry/river-mode
-[tree-sitter grammar]: https://github.com/grafana/tree-sitter-river
 [fmt]: ../../reference/cli/fmt/


### PR DESCRIPTION
* Update the links to the VSCode and Vim plugins to be the official repositories for Alloy.
* Temporarily remove links to unofficial repositories that are River-specific; these can be added back in the future once Alloy equivalents exist.