### PR TITLE
ci: fix backport job

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -22,6 +22,6 @@ jobs:
       - name: Run backport
         uses: ./actions/backport
         with:
-          token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
+          token: ${{secrets.GITHUB_TOKEN}}
           labelsToAdd: "backport"
           title: "[{{base}}] {{originalTitle}}"


### PR DESCRIPTION
Use common secret GITHUB_TOKEN for backport jobs. This means that backports will be done by the github-actions bot instead of grafanabot, but the backport job will work properly.

I verified this works by looking at grafana/tempo, which uses GITHUB_TOKEN instead of a grafanabot API token.
