### PR TITLE
build: temporarily remove boringcrypto

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -252,57 +252,6 @@ trigger:
 type: docker
 ---
 kind: pipeline
-name: Build agent-boringcrypto (Linux amd64 boringcrypto)
-platform:
-  arch: amd64
-  os: linux
-steps:
-- commands:
-  - make generate-ui
-  - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=amd64 GOARM=
-    GOEXPERIMENT=boringcrypto make agent-boringcrypto
-  image: grafana/agent-build-image:0.40.2
-  name: Build
-trigger:
-  event:
-  - pull_request
-type: docker
----
-kind: pipeline
-name: Build agent-boringcrypto (Linux arm64 boringcrypto)
-platform:
-  arch: amd64
-  os: linux
-steps:
-- commands:
-  - make generate-ui
-  - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=arm64 GOARM=
-    GOEXPERIMENT=boringcrypto make agent-boringcrypto
-  image: grafana/agent-build-image:0.40.2
-  name: Build
-trigger:
-  event:
-  - pull_request
-type: docker
----
-kind: pipeline
-name: Build agent-windows-boringcrypto (Windows amd64)
-platform:
-  arch: amd64
-  os: linux
-steps:
-- commands:
-  - make generate-ui
-  - GO_TAGS="builtinassets" GOOS=windows GOARCH=amd64 GOARM= GOEXPERIMENT=cngcrypto
-    make agent-windows-boringcrypto
-  image: grafana/agent-build-image:0.40.2-boringcrypto
-  name: Build
-trigger:
-  event:
-  - pull_request
-type: docker
----
-kind: pipeline
 name: Publish development Linux agent container
 platform:
   arch: amd64
@@ -450,6 +399,6 @@ kind: secret
 name: updater_private_key
 ---
 kind: signature
-hmac: eb4c87d4abc880513c7c2977c46910fa96041461aa2edea16a7970f5c145dd01
+hmac: 2088d828b5aeec4f38008f932b1402a03745e941ba06c6c4d72a96d42dfb7f01
 
 ...

--- a/.drone/pipelines/crosscompile.jsonnet
+++ b/.drone/pipelines/crosscompile.jsonnet
@@ -32,24 +32,6 @@ local targets = [
   'agent',
 ];
 
-local targets_boringcrypto = [
-  'agent-boringcrypto',
-];
-local targets_boringcrypto_windows = [
-  'agent-windows-boringcrypto',
-];
-
-
-local os_arch_types_boringcrypto = [
-  // Linux boringcrypto
-  { name: 'Linux amd64 boringcrypto', os: 'linux', arch: 'amd64', experiment: 'boringcrypto' },
-  { name: 'Linux arm64 boringcrypto', os: 'linux', arch: 'arm64', experiment: 'boringcrypto' },
-];
-local windows_os_arch_types_boringcrypto = [
-  // Windows boringcrypto
-  { name: 'Windows amd64', os: 'windows', arch: 'amd64', experiment: 'cngcrypto' },
-];
-
 local build_environments(targets, tuples, image) = std.flatMap(function(target) (
   std.map(function(platform) (
     pipelines.linux('Build %s (%s)' % [target, platform.name]) {
@@ -81,6 +63,4 @@ local build_environments(targets, tuples, image) = std.flatMap(function(target) 
   ), tuples)
 ), targets);
 
-build_environments(targets, os_arch_tuples, build_image.linux) +
-build_environments(targets_boringcrypto, os_arch_types_boringcrypto, build_image.linux) +
-build_environments(targets_boringcrypto_windows, windows_os_arch_types_boringcrypto, build_image.boringcrypto)
+build_environments(targets, os_arch_tuples, build_image.linux)

--- a/.drone/pipelines/publish.jsonnet
+++ b/.drone/pipelines/publish.jsonnet
@@ -6,8 +6,7 @@ local ghTokenFilename = '/drone/src/gh-token.txt';
 // job_names gets the list of job names for use in depends_on.
 local job_names = function(jobs) std.map(function(job) job.name, jobs);
 
-local linux_containers = ['agent', 'agent-boringcrypto'];
-local dev_linux_containers = ['agent'];  // TODO(rfratto): add boringcrypto after figuring out what to do with it
+local linux_containers = ['agent'];
 
 local linux_containers_dev_jobs = std.map(function(container) (
   pipelines.linux('Publish development Linux %s container' % container) {
@@ -59,7 +58,7 @@ local linux_containers_dev_jobs = std.map(function(container) (
       host: { path: '/var/run/docker.sock' },
     }],
   }
-), dev_linux_containers);
+), linux_containers);
 
 
 local linux_containers_jobs = std.map(function(container) (

--- a/tools/ci/docker-containers
+++ b/tools/ci/docker-containers
@@ -8,12 +8,9 @@
 set -euxo pipefail
 
 RELEASE_AGENT_IMAGE=grafana/agent
-RELEASE_AGENTBORINGCRYPTO_IMAGE=grafana/agent-boringcrypto
 DEVELOPMENT_AGENT_IMAGE=us-docker.pkg.dev/grafanalabs-dev/docker-alloy-dev/alloy
-DEVELOPMENT_AGENTBORINGCRYPTO_IMAGE=us-docker.pkg.dev/grafanalabs-dev/docker-alloy-dev/alloy-boringcrypto
 
 DEFAULT_AGENT_IMAGE=${RELEASE_AGENT_IMAGE}
-DEFAULT_AGENTBORINGCRYPTO_IMAGE=${RELEASE_AGENTBORINGCRYPTO_IMAGE}
 
 # Environment variables used throughout this script. These must be set
 # otherwise bash will fail with an "unbound variable" error because of the `set
@@ -27,11 +24,9 @@ export DEVELOPMENT=${DEVELOPMENT:-}
 
 if [ -n "$DEVELOPMENT" ]; then
   DEFAULT_AGENT_IMAGE=${DEVELOPMENT_AGENT_IMAGE}
-  DEFAULT_AGENTBORINGCRYPTO_IMAGE=${DEVELOPMENT_AGENTBORINGCRYPTO_IMAGE}
 fi
 
 export AGENT_IMAGE=${DEFAULT_AGENT_IMAGE}
-export AGENT_BORINGCRYPTO_IMAGE=${DEFAULT_AGENTBORINGCRYPTO_IMAGE}
 
 # We need to determine what version to assign to built binaries. If containers
 # are being built from a Drone tag trigger, we force the version to come from the
@@ -65,7 +60,6 @@ fi
 # Build all of our images.
 
 export BUILD_PLATFORMS=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
-export BUILD_PLATFORMS_BORINGCRYPTO=linux/amd64,linux/arm64
 
 case "$TARGET_CONTAINER" in
   agent)
@@ -79,20 +73,8 @@ case "$TARGET_CONTAINER" in
       .
     ;;
 
-  agent-boringcrypto)
-    docker buildx build --push                    \
-      --platform $BUILD_PLATFORMS_BORINGCRYPTO    \
-      --build-arg RELEASE_BUILD=1                 \
-      --build-arg VERSION="$VERSION"              \
-      --build-arg GOEXPERIMENT=boringcrypto       \
-      -t "$AGENT_BORINGCRYPTO_IMAGE:$TAG_VERSION" \
-      -t "$AGENT_BORINGCRYPTO_IMAGE:$BRANCH_TAG"  \
-      -f cmd/grafana-agent/Dockerfile             \
-      .
-    ;;
-
   *)
-    echo "Usage: $0 agent|agent-boringcrypto"
+    echo "Usage: $0 agent"
     exit 1
     ;;
 esac

--- a/tools/make/packaging.mk
+++ b/tools/make/packaging.mk
@@ -27,9 +27,7 @@ dist-agent-binaries: dist/grafana-agent-linux-amd64                    \
                      dist/grafana-agent-darwin-amd64                   \
                      dist/grafana-agent-darwin-arm64                   \
                      dist/grafana-agent-windows-amd64.exe              \
-                     dist/grafana-agent-windows-boringcrypto-amd64.exe \
-                     dist/grafana-agent-freebsd-amd64                  \
-                     dist/grafana-agent-linux-arm64-boringcrypto
+                     dist/grafana-agent-freebsd-amd64
 
 dist/grafana-agent-linux-amd64: GO_TAGS += netgo builtinassets promtail_journal_enabled
 dist/grafana-agent-linux-amd64: GOOS    := linux
@@ -83,30 +81,10 @@ dist/grafana-agent-windows-amd64.exe: generate-ui
 #
 # TODO(rfratto): add netgo back to Windows builds if a version of Go is
 # released which natively supports resolving DNS short names on Windows.
-dist/grafana-agent-windows-boringcrypto-amd64.exe: GO_TAGS += builtinassets
-dist/grafana-agent-windows-boringcrypto-amd64.exe: GOOS    := windows
-dist/grafana-agent-windows-boringcrypto-amd64.exe: GOARCH  := amd64
-dist/grafana-agent-windows-boringcrypto-amd64.exe: generate-ui
-	$(PACKAGING_VARS) AGENT_BINARY=$@ "$(MAKE)" -f $(PARENT_MAKEFILE) agent
-
 dist/grafana-agent-freebsd-amd64: GO_TAGS += netgo builtinassets
 dist/grafana-agent-freebsd-amd64: GOOS    := freebsd
 dist/grafana-agent-freebsd-amd64: GOARCH  := amd64
 dist/grafana-agent-freebsd-amd64: generate-ui
-	$(PACKAGING_VARS) AGENT_BINARY=$@ "$(MAKE)" -f $(PARENT_MAKEFILE) agent
-
-dist/grafana-agent-linux-amd64-boringcrypto: GO_TAGS      += netgo builtinassets promtail_journal_enabled
-dist/grafana-agent-linux-amd64-boringcrypto: GOOS         := linux
-dist/grafana-agent-linux-amd64-boringcrypto: GOARCH       := amd64
-dist/grafana-agent-linux-amd64-boringcrypto: GOEXPERIMENT := boringcrypto
-dist/grafana-agent-linux-amd64-boringcrypto: generate-ui
-	$(PACKAGING_VARS) AGENT_BINARY=$@ "$(MAKE)" -f $(PARENT_MAKEFILE) agent
-
-dist/grafana-agent-linux-arm64-boringcrypto: GO_TAGS      += netgo builtinassets promtail_journal_enabled
-dist/grafana-agent-linux-arm64-boringcrypto: GOOS         := linux
-dist/grafana-agent-linux-arm64-boringcrypto: GOARCH       := arm64
-dist/grafana-agent-linux-arm64-boringcrypto: GOEXPERIMENT := boringcrypto
-dist/grafana-agent-linux-arm64-boringcrypto: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ "$(MAKE)" -f $(PARENT_MAKEFILE) agent
 
 #


### PR DESCRIPTION
Temporarily remove boringcrypto builds as we need time to figure out what boringcrypto support looks like in Alloy and how we deliver release assets for boringcrypto builds.