### PR TITLE
misc: remove ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,9 +1,0 @@
-This is the list of organizations, organized alphabetically, that are using the Grafana Agent in
-production environments. Please send PRs to add or remove organizations.
-
-* [AB Tasty](https://www.abtasty.com/)
-* [Canonical](https://www.ubuntu.com/)
-* Cerner Enterprise Hosting
-* [CLOUDETEER GmbH](https://www.cloudeteer.de/)
-* [Embark Studios](https://www.embark.dev/)
-* [Grafana Labs](https://grafana.com)


### PR DESCRIPTION
ADOPTERS.md was a list of adopters using Grafana Agent, and is no longer appropriate for Grafana Alloy.

This file may be added back in the future with a new adopter list for Grafana Alloy.