### PR TITLE
otelcol: update stability for a subset of otelcol components

### DIFF
--- a/docs/sources/reference/components/otelcol.connector.host_info.md
+++ b/docs/sources/reference/components/otelcol.connector.host_info.md
@@ -2,13 +2,11 @@
 canonical: https://grafana.com/docs/alloy/latest/reference/components/otelcol.connector.host_info/
 description: Learn about otelcol.connector.host_info
 labels:
-  stage: experimental
+  stage: stable
 title: otelcol.connector.host_info
 ---
 
 # otelcol.connector.host_info
-
-{{< docs/shared lookup="stability/experimental.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 `otel.connector.host_info` accepts span data from other `otelcol` components and generates usage metrics.
 

--- a/docs/sources/reference/components/otelcol.connector.servicegraph.md
+++ b/docs/sources/reference/components/otelcol.connector.servicegraph.md
@@ -2,13 +2,11 @@
 canonical: https://grafana.com/docs/alloy/latest/reference/components/otelcol.connector.servicegraph/
 description: Learn about otelcol.connector.servicegraph
 labels:
-  stage: experimental
+  stage: stable
 title: otelcol.connector.servicegraph
 ---
 
 # otelcol.connector.servicegraph
-
-{{< docs/shared lookup="stability/experimental.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 `otelcol.connector.servicegraph` accepts span data from other `otelcol` components and outputs metrics representing the relationship between various services in a system.
 A metric represents an edge in the service graph.

--- a/docs/sources/reference/components/otelcol.connector.spanmetrics.md
+++ b/docs/sources/reference/components/otelcol.connector.spanmetrics.md
@@ -2,13 +2,11 @@
 canonical: https://grafana.com/docs/alloy/latest/reference/components/otelcol.connector.spanmetrics/
 description: Learn about otelcol.connector.spanmetrics
 labels:
-  stage: experimental
+  stage: stable
 title: otelcol.connector.spanmetrics
 ---
 
 # otelcol.connector.spanmetrics
-
-{{< docs/shared lookup="stability/experimental.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 `otelcol.connector.spanmetrics` accepts span data from other `otelcol` components and
 aggregates Request, Error and Duration (R.E.D) OpenTelemetry metrics from the spans:

--- a/docs/sources/reference/components/otelcol.processor.filter.md
+++ b/docs/sources/reference/components/otelcol.processor.filter.md
@@ -2,13 +2,11 @@
 canonical: https://grafana.com/docs/alloy/latest/reference/components/otelcol.processor.filter/
 description: Learn about otelcol.processor.filter
 labels:
-  stage: experimental
+  stage: stable
 title: otelcol.processor.filter
 ---
 
 # otelcol.processor.filter
-
-{{< docs/shared lookup="stability/experimental.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 `otelcol.processor.filter` accepts and filters telemetry data from other `otelcol`
 components using the [OpenTelemetry Transformation Language (OTTL)][OTTL].
@@ -48,10 +46,10 @@ You can specify multiple `otelcol.processor.filter` components by giving them di
 {{< admonition type="warning" >}}
 Exercise caution when using `otelcol.processor.filter`:
 
-- Make sure you understand schema/format of the incoming data and test the configuration thoroughly. 
+- Make sure you understand schema/format of the incoming data and test the configuration thoroughly.
   In general, use a configuration that is as specific as possible ensure you retain only the data you want to keep.
-- [Orphaned Telemetry][]: The processor allows dropping spans. Dropping a span may lead to 
-  orphaned spans if the dropped span is a parent. Dropping a span may lead to orphaned logs 
+- [Orphaned Telemetry][]: The processor allows dropping spans. Dropping a span may lead to
+  orphaned spans if the dropped span is a parent. Dropping a span may lead to orphaned logs
   if the log references the dropped span.
 
 [Orphaned Telemetry]: https://github.com/open-telemetry/opentelemetry-collector/blob/v0.85.0/docs/standard-warnings.md#orphaned-telemetry

--- a/docs/sources/reference/components/otelcol.processor.transform.md
+++ b/docs/sources/reference/components/otelcol.processor.transform.md
@@ -2,13 +2,11 @@
 canonical: https://grafana.com/docs/alloy/latest/reference/components/otelcol.processor.transform/
 description: Learn about otelcol.processor.transform
 labels:
-  stage: experimental
+  stage: stable
 title: otelcol.processor.transform
 ---
 
 # otelcol.processor.transform
-
-{{< docs/shared lookup="stability/experimental.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 `otelcol.processor.transform` accepts telemetry data from other `otelcol`
 components and modifies it using the [OpenTelemetry Transformation Language (OTTL)][OTTL].
@@ -18,7 +16,7 @@ A path is a reference to a telemetry data such as:
 * Instrumentation scope name.
 * Span attributes.
 
-In addition to the [standard OTTL functions][OTTL functions], 
+In addition to the [standard OTTL functions][OTTL functions],
 there is also a set of metrics-only functions:
 * [convert_sum_to_gauge][]
 * [convert_gauge_to_sum][]
@@ -130,7 +128,7 @@ output | [output][] | Configures where to send received telemetry data. | yes
 
 ### trace_statements block
 
-The `trace_statements` block specifies statements which transform trace telemetry signals. 
+The `trace_statements` block specifies statements which transform trace telemetry signals.
 Multiple `trace_statements` blocks can be specified.
 
 Name | Type | Description | Default | Required
@@ -148,7 +146,7 @@ See [OTTL Context][] for more information about how ot use contexts.
 
 ### metric_statements block
 
-The `metric_statements` block specifies statements which transform metric telemetry signals. 
+The `metric_statements` block specifies statements which transform metric telemetry signals.
 Multiple `metric_statements` blocks can be specified.
 
 Name | Type | Description | Default | Required
@@ -166,7 +164,7 @@ Refer to [OTTL Context][] for more information about how to use contexts.
 
 ### log_statements block
 
-The `log_statements` block specifies statements which transform log telemetry signals. 
+The `log_statements` block specifies statements which transform log telemetry signals.
 Multiple `log_statements` blocks can be specified.
 
 Name | Type | Description | Default | Required
@@ -184,7 +182,7 @@ See [OTTL Context][] for more information about how ot use contexts.
 ### OTTL Context
 
 Each context allows the transformation of its type of telemetry.
-For example, statements associated with a `resource` context will be able to transform the resource's 
+For example, statements associated with a `resource` context will be able to transform the resource's
 `attributes` and `dropped_attributes_count`.
 
 Each type of `context` defines its own paths and enums specific to that context.
@@ -205,7 +203,7 @@ Contexts __NEVER__ supply access to individual items "lower" in the protobuf def
 - Similarly, statements associated to a `span` __WILL NOT__ be able to access individual SpanEvents, but can access the entire SpanEvents slice.
 
 For practical purposes, this means that a context cannot make decisions on its telemetry based on telemetry "lower" in the structure.
-For example, __the following context statement is not possible__ because it attempts to use individual datapoint 
+For example, __the following context statement is not possible__ because it attempts to use individual datapoint
 attributes in the condition of a statement associated to a `metric`:
 
 ```river
@@ -241,7 +239,7 @@ The protobuf definitions for OTLP signals are maintained on GitHub:
 
 Whenever possible, associate your statements to the context which the statement intens to transform.
 The contexts are nested, and the higher-level contexts don't have to iterate through any of the
-contexts at a lower level. For example, although you can modify resource attributes associated to a 
+contexts at a lower level. For example, although you can modify resource attributes associated to a
 span using the `span` context, it is more efficient to use the `resource` context.
 
 ### output block
@@ -286,7 +284,7 @@ otelcol.processor.transform "default" {
   trace_statements {
     context = "span"
     statements = [
-      // Accessing a map with a key that does not exist will return nil. 
+      // Accessing a map with a key that does not exist will return nil.
       `set(attributes["test"], "pass") where attributes["test"] == nil`,
     ]
   }
@@ -436,12 +434,12 @@ otelcol.processor.transform "default" {
       // Parse body as JSON and merge the resulting map with the cache map, ignoring non-json bodies.
       // cache is a field exposed by OTTL that is a temporary storage place for complex operations.
       `merge_maps(cache, ParseJSON(body), "upsert") where IsMatch(body, "^\\{")`,
-  
+
       // Set attributes using the values merged into cache.
       // If the attribute doesn't exist in cache then nothing happens.
       `set(attributes["attr1"], cache["attr1"])`,
       `set(attributes["attr2"], cache["attr2"])`,
-  
+
       // To access nested maps you can chain index ([]) operations.
       // If nested or attr3 do no exist in cache then nothing happens.
       `set(attributes["nested.attr3"], cache["nested"]["attr3"])`,
@@ -462,8 +460,8 @@ each `"` with a `\"`, and each `\` with a `\\` inside a [normal][river-strings] 
 
 ### Various transformations of attributes and status codes
 
-The example takes advantage of context efficiency by grouping transformations 
-with the context which it intends to transform. 
+The example takes advantage of context efficiency by grouping transformations
+with the context which it intends to transform.
 
 ```river
 otelcol.receiver.otlp "default" {

--- a/internal/component/otelcol/connector/host_info/host_info.go
+++ b/internal/component/otelcol/connector/host_info/host_info.go
@@ -17,7 +17,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "otelcol.connector.host_info",
-		Stability: featuregate.StabilityExperimental,
+		Stability: featuregate.StabilityStable,
 		Args:      Arguments{},
 		Exports:   otelcol.ConsumerExports{},
 

--- a/internal/component/otelcol/connector/servicegraph/servicegraph.go
+++ b/internal/component/otelcol/connector/servicegraph/servicegraph.go
@@ -18,7 +18,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "otelcol.connector.servicegraph",
-		Stability: featuregate.StabilityExperimental,
+		Stability: featuregate.StabilityStable,
 		Args:      Arguments{},
 		Exports:   otelcol.ConsumerExports{},
 

--- a/internal/component/otelcol/connector/spanmetrics/spanmetrics.go
+++ b/internal/component/otelcol/connector/spanmetrics/spanmetrics.go
@@ -18,7 +18,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "otelcol.connector.spanmetrics",
-		Stability: featuregate.StabilityExperimental,
+		Stability: featuregate.StabilityStable,
 		Args:      Arguments{},
 		Exports:   otelcol.ConsumerExports{},
 

--- a/internal/component/otelcol/processor/filter/filter.go
+++ b/internal/component/otelcol/processor/filter/filter.go
@@ -15,7 +15,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "otelcol.processor.filter",
-		Stability: featuregate.StabilityExperimental,
+		Stability: featuregate.StabilityStable,
 		Args:      Arguments{},
 		Exports:   otelcol.ConsumerExports{},
 

--- a/internal/component/otelcol/processor/transform/transform.go
+++ b/internal/component/otelcol/processor/transform/transform.go
@@ -19,7 +19,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "otelcol.processor.transform",
-		Stability: featuregate.StabilityExperimental,
+		Stability: featuregate.StabilityStable,
 		Args:      Arguments{},
 		Exports:   otelcol.ConsumerExports{},
 


### PR DESCRIPTION
The following components have been updated to stable:

* otelcol.connector.host_info
* otelcol.connector.servicegraph
* otelcol.connector.spanmetrics
* otelcol.processor.filter
* otelcol.processor.transform