### PR TITLE
docs/developer: update contributing guide

### DIFF
--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -67,7 +67,7 @@ To compile Alloy, clone the repository and build using `make alloy`:
 
 ```bash
 $ git clone https://github.com/grafana/alloy.git
-& cd alloy
+$ cd alloy
 $ make alloy
 $ ./build/alloy run <CONFIG_FILE>
 ```


### PR DESCRIPTION
This PR updates the contributing guide to be correct (it has since gone stale) and ensures that all mentions of Agent are renamed to Alloy.