### PR TITLE
helm/charts/alloy: update default listen port to 12345

### DIFF
--- a/operations/helm/charts/alloy/CHANGELOG.md
+++ b/operations/helm/charts/alloy/CHANGELOG.md
@@ -14,4 +14,5 @@ internal API changes are not present.
 
 - Introduce a Grafana Alloy Helm chart. The Grafana Alloy Helm chart is
   backwards compatibile with the values.yaml from the `grafana-agent` Helm
-  chart. (@rfratto)
+  chart. Review the Helm chart README for a description on how to migrate.
+  (@rfratto)

--- a/operations/helm/charts/alloy/README.md
+++ b/operations/helm/charts/alloy/README.md
@@ -44,7 +44,7 @@ useful if just using the default DaemonSet isn't sufficient.
 | alloy.extraEnv | list | `[]` | Extra environment variables to pass to the Alloy container. |
 | alloy.extraPorts | list | `[]` | Extra ports to expose on the Alloy container. |
 | alloy.listenAddr | string | `"0.0.0.0"` | Address to listen for traffic on. 0.0.0.0 exposes the UI to other containers. |
-| alloy.listenPort | int | `80` | Port to listen for traffic on. |
+| alloy.listenPort | int | `12345` | Port to listen for traffic on. |
 | alloy.listenScheme | string | `"HTTP"` | Scheme is needed for readiness probes. If enabling tls in your configs, set to "HTTPS" |
 | alloy.mounts.dockercontainers | bool | `false` | Mount /var/lib/docker/containers from the host into the container for log collection. |
 | alloy.mounts.extra | list | `[]` | Extra volume mounts to add into the Grafana Alloy container. Does not affect the watch container. |
@@ -130,6 +130,18 @@ useful if just using the default DaemonSet isn't sufficient.
 | serviceMonitor.metricRelabelings | list | `[]` | MetricRelabelConfigs to apply to samples after scraping, but before ingestion. ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig |
 | serviceMonitor.relabelings | list | `[]` | RelabelConfigs to apply to samples before scraping ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig |
 | serviceMonitor.tlsConfig | object | `{}` | Customize tls parameters for the service monitor |
+
+#### Migrate from `grafana/grafana-agent` chart to `grafana/alloy`
+
+The `values.yaml` file for the `grafana/grafana-agent` chart is compatible with
+the chart for `grafana/alloy`, with two exceptions:
+
+* The `agent` field in `values.yaml` is deprecated in favor of `alloy`. Support
+  for the `agent` field will be removed in a future release.
+
+* The default value for `alloy.listenPort` is `12345` to align with the default
+  listen port in other installations. To retain the previous default, set
+  `alloy.listenPort` to `80` when installing.
 
 ### alloy.extraArgs
 

--- a/operations/helm/charts/alloy/README.md.gotmpl
+++ b/operations/helm/charts/alloy/README.md.gotmpl
@@ -31,6 +31,18 @@ useful if just using the default DaemonSet isn't sufficient.
 
 {{ template "chart.valuesSection" . }}
 
+#### Migrate from `grafana/grafana-agent` chart to `grafana/alloy`
+
+The `values.yaml` file for the `grafana/grafana-agent` chart is compatible with
+the chart for `grafana/alloy`, with two exceptions:
+
+* The `agent` field in `values.yaml` is deprecated in favor of `alloy`. Support
+  for the `agent` field will be removed in a future release.
+
+* The default value for `alloy.listenPort` is `12345` to align with the default
+  listen port in other installations. To retain the previous default, set
+  `alloy.listenPort` to `80` when installing.
+
 ### alloy.extraArgs
 
 `alloy.extraArgs` allows for passing extra arguments to the Grafana Alloy

--- a/operations/helm/charts/alloy/values.yaml
+++ b/operations/helm/charts/alloy/values.yaml
@@ -49,7 +49,7 @@ alloy:
   listenAddr: 0.0.0.0
 
   # -- Port to listen for traffic on.
-  listenPort: 80
+  listenPort: 12345
 
   # -- Scheme is needed for readiness probes. If enabling tls in your configs, set to "HTTPS"
   listenScheme: HTTP

--- a/operations/helm/tests/additional-serviceaccount-label/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/additional-serviceaccount-label/alloy/templates/controllers/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -43,12 +43,12 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -59,7 +59,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/additional-serviceaccount-label/alloy/templates/service.yaml
+++ b/operations/helm/tests/additional-serviceaccount-label/alloy/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"

--- a/operations/helm/tests/clustering/alloy/templates/cluster_service.yaml
+++ b/operations/helm/tests/clustering/alloy/templates/cluster_service.yaml
@@ -24,6 +24,6 @@ spec:
     # This service should only be used for clustering, and not metric
     # collection.
     - name: http
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"

--- a/operations/helm/tests/clustering/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/clustering/alloy/templates/controllers/statefulset.yaml
@@ -36,7 +36,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
             - --cluster.enabled=true
             - --cluster.join-addresses=alloy-cluster
@@ -48,12 +48,12 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -64,7 +64,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/clustering/alloy/templates/service.yaml
+++ b/operations/helm/tests/clustering/alloy/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"

--- a/operations/helm/tests/controller-volumes-extra/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/controller-volumes-extra/alloy/templates/controllers/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -43,12 +43,12 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -62,7 +62,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/controller-volumes-extra/alloy/templates/service.yaml
+++ b/operations/helm/tests/controller-volumes-extra/alloy/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"

--- a/operations/helm/tests/create-daemonset-hostnetwork/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset-hostnetwork/alloy/templates/controllers/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -43,12 +43,12 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -59,7 +59,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/create-daemonset-hostnetwork/alloy/templates/service.yaml
+++ b/operations/helm/tests/create-daemonset-hostnetwork/alloy/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"

--- a/operations/helm/tests/create-daemonset/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset/alloy/templates/controllers/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -43,12 +43,12 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -59,7 +59,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/create-daemonset/alloy/templates/service.yaml
+++ b/operations/helm/tests/create-daemonset/alloy/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"

--- a/operations/helm/tests/create-deployment-autoscaling/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment-autoscaling/alloy/templates/controllers/deployment.yaml
@@ -33,7 +33,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -43,12 +43,12 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -62,7 +62,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/create-deployment-autoscaling/alloy/templates/service.yaml
+++ b/operations/helm/tests/create-deployment-autoscaling/alloy/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"

--- a/operations/helm/tests/create-deployment/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment/alloy/templates/controllers/deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -44,12 +44,12 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -60,7 +60,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/create-deployment/alloy/templates/service.yaml
+++ b/operations/helm/tests/create-deployment/alloy/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"

--- a/operations/helm/tests/create-statefulset-autoscaling/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset-autoscaling/alloy/templates/controllers/statefulset.yaml
@@ -35,7 +35,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -45,12 +45,12 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -64,7 +64,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/create-statefulset-autoscaling/alloy/templates/service.yaml
+++ b/operations/helm/tests/create-statefulset-autoscaling/alloy/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"

--- a/operations/helm/tests/create-statefulset/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset/alloy/templates/controllers/statefulset.yaml
@@ -36,7 +36,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -46,12 +46,12 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -62,7 +62,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/create-statefulset/alloy/templates/service.yaml
+++ b/operations/helm/tests/create-statefulset/alloy/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"

--- a/operations/helm/tests/custom-config/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/custom-config/alloy/templates/controllers/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -43,12 +43,12 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -59,7 +59,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/custom-config/alloy/templates/service.yaml
+++ b/operations/helm/tests/custom-config/alloy/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"

--- a/operations/helm/tests/default-values/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/default-values/alloy/templates/controllers/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -43,12 +43,12 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -59,7 +59,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/default-values/alloy/templates/service.yaml
+++ b/operations/helm/tests/default-values/alloy/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"

--- a/operations/helm/tests/enable-servicemonitor-tls/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/enable-servicemonitor-tls/alloy/templates/controllers/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -43,12 +43,12 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTPS
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -59,7 +59,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/enable-servicemonitor-tls/alloy/templates/service.yaml
+++ b/operations/helm/tests/enable-servicemonitor-tls/alloy/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"

--- a/operations/helm/tests/enable-servicemonitor/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/enable-servicemonitor/alloy/templates/controllers/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -43,12 +43,12 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -59,7 +59,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/enable-servicemonitor/alloy/templates/service.yaml
+++ b/operations/helm/tests/enable-servicemonitor/alloy/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"

--- a/operations/helm/tests/envFrom/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/envFrom/alloy/templates/controllers/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -46,12 +46,12 @@ spec:
             - configMapRef:
                 name: special-config
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -62,7 +62,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/envFrom/alloy/templates/service.yaml
+++ b/operations/helm/tests/envFrom/alloy/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"

--- a/operations/helm/tests/existing-config/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/existing-config/alloy/templates/controllers/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
             - run
             - /etc/alloy/my-config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -43,12 +43,12 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -59,7 +59,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/existing-config/alloy/templates/service.yaml
+++ b/operations/helm/tests/existing-config/alloy/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"

--- a/operations/helm/tests/extra-env/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-env/alloy/templates/controllers/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -52,12 +52,12 @@ spec:
               name: NAME
               value: Kubernetes
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -68,7 +68,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/extra-env/alloy/templates/service.yaml
+++ b/operations/helm/tests/extra-env/alloy/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"

--- a/operations/helm/tests/extra-ports/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-ports/alloy/templates/controllers/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -43,7 +43,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
             - containerPort: 14268
               name: jaeger-thrift
@@ -51,7 +51,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -62,7 +62,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/extra-ports/alloy/templates/service.yaml
+++ b/operations/helm/tests/extra-ports/alloy/templates/service.yaml
@@ -18,8 +18,8 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"
     - name: jaeger-thrift
       port: 14268

--- a/operations/helm/tests/faro-ingress/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/faro-ingress/alloy/templates/controllers/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -43,7 +43,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
             - containerPort: 12347
               name: faro
@@ -51,7 +51,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -62,7 +62,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/faro-ingress/alloy/templates/service.yaml
+++ b/operations/helm/tests/faro-ingress/alloy/templates/service.yaml
@@ -18,8 +18,8 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"
     - name: faro
       port: 12347

--- a/operations/helm/tests/global-image-pullsecrets/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/global-image-pullsecrets/alloy/templates/controllers/daemonset.yaml
@@ -38,7 +38,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -48,12 +48,12 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -64,7 +64,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/global-image-pullsecrets/alloy/templates/service.yaml
+++ b/operations/helm/tests/global-image-pullsecrets/alloy/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"

--- a/operations/helm/tests/global-image-registry/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/global-image-registry/alloy/templates/controllers/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -43,12 +43,12 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -59,7 +59,7 @@ spec:
           image: quay.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/global-image-registry/alloy/templates/service.yaml
+++ b/operations/helm/tests/global-image-registry/alloy/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"

--- a/operations/helm/tests/initcontainers/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/initcontainers/alloy/templates/controllers/daemonset.yaml
@@ -51,7 +51,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -61,12 +61,12 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -80,7 +80,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/initcontainers/alloy/templates/service.yaml
+++ b/operations/helm/tests/initcontainers/alloy/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"

--- a/operations/helm/tests/local-image-pullsecrets/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/local-image-pullsecrets/alloy/templates/controllers/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -45,12 +45,12 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -61,7 +61,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/local-image-pullsecrets/alloy/templates/service.yaml
+++ b/operations/helm/tests/local-image-pullsecrets/alloy/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"

--- a/operations/helm/tests/local-image-registry/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/local-image-registry/alloy/templates/controllers/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -43,12 +43,12 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -59,7 +59,7 @@ spec:
           image: quay.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/local-image-registry/alloy/templates/service.yaml
+++ b/operations/helm/tests/local-image-registry/alloy/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"

--- a/operations/helm/tests/nodeselectors-and-tolerations/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/nodeselectors-and-tolerations/alloy/templates/controllers/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -43,12 +43,12 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -59,7 +59,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/nodeselectors-and-tolerations/alloy/templates/service.yaml
+++ b/operations/helm/tests/nodeselectors-and-tolerations/alloy/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"

--- a/operations/helm/tests/nonroot/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/nonroot/alloy/templates/controllers/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -45,12 +45,12 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -64,7 +64,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/nonroot/alloy/templates/service.yaml
+++ b/operations/helm/tests/nonroot/alloy/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"

--- a/operations/helm/tests/pod_annotations/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/pod_annotations/alloy/templates/controllers/daemonset.yaml
@@ -34,7 +34,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -44,12 +44,12 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -60,7 +60,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/pod_annotations/alloy/templates/service.yaml
+++ b/operations/helm/tests/pod_annotations/alloy/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"

--- a/operations/helm/tests/sidecars/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/sidecars/alloy/templates/controllers/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -43,12 +43,12 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -62,7 +62,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/sidecars/alloy/templates/service.yaml
+++ b/operations/helm/tests/sidecars/alloy/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"

--- a/operations/helm/tests/topologyspreadconstraints/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/topologyspreadconstraints/alloy/templates/controllers/deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -44,12 +44,12 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -60,7 +60,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/topologyspreadconstraints/alloy/templates/service.yaml
+++ b/operations/helm/tests/topologyspreadconstraints/alloy/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"

--- a/operations/helm/tests/with-digests/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/with-digests/alloy/templates/controllers/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -43,12 +43,12 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -59,7 +59,7 @@ spec:
           image: docker.io/jimmidyson/configmap-reload@sha256:5af9d3041d12a3e63f115125f89b66d2ba981fe82e64302ac370c5496055059c
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:80/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/with-digests/alloy/templates/service.yaml
+++ b/operations/helm/tests/with-digests/alloy/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"


### PR DESCRIPTION
This changes the default listen port to 12345 so it aligns with all other Alloy installations.