### PR TITLE
docs: use explicit install for macOS

### DIFF
--- a/docs/sources/get-started/install/macos.md
+++ b/docs/sources/get-started/install/macos.md
@@ -34,7 +34,7 @@ To install {{< param "PRODUCT_NAME" >}} on macOS, run the following commands in 
 1. Install {{< param "PRODUCT_NAME" >}}:
 
    ```shell
-   brew install alloy
+   brew install grafana/grafana/alloy
    ```
 
 ## Upgrade
@@ -44,7 +44,7 @@ To upgrade {{< param "PRODUCT_NAME" >}} on macOS, run the following commands in 
 1. Upgrade {{< param "PRODUCT_NAME" >}}:
 
    ```shell
-   brew upgrade alloy
+   brew upgrade grafana/grafana/alloy
    ```
 
 1. Restart {{< param "PRODUCT_NAME" >}}:
@@ -58,7 +58,7 @@ To upgrade {{< param "PRODUCT_NAME" >}} on macOS, run the following commands in 
 To uninstall {{< param "PRODUCT_NAME" >}} on macOS, run the following command in a terminal window:
 
 ```shell
-brew uninstall alloy
+brew uninstall grafana/grafana/alloy
 ```
 
 ## Next steps


### PR DESCRIPTION
There is a cask in Homebrew also called Alloy. While it doesn't collide with a formula called Alloy, it can be confusing.

This commit changes the instructions to explicitly install the Formula from the Grafana tap.