### PR TITLE
Docker: fix Windows container

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -101,7 +101,7 @@ platform:
   version: "1809"
 steps:
 - commands:
-  - '& "C:/Program Files/git/bin/bash.exe" ./tools/ci/docker-containers-windows alloy'
+  - '& "C:/Program Files/git/bin/bash.exe" -c "make alloy-image-windows"'
   image: grafana/agent-build-image:0.40.2-windows
   name: Build container
   volumes:
@@ -302,12 +302,18 @@ platform:
   version: "1809"
 steps:
 - commands:
-  - '& "C:/Program Files/git/bin/bash.exe" ./tools/ci/docker-containers-windows alloy-devel'
+  - '& "C:/Program Files/git/bin/bash.exe" -c "mkdir -p $HOME/.docker"'
+  - '& "C:/Program Files/git/bin/bash.exe" -c "printenv GCR_CREDS > $HOME/.docker/config.json"'
+  - '& "C:/Program Files/git/bin/bash.exe" -c "docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD"'
+  - '& "C:/Program Files/git/bin/bash.exe" -c "./tools/ci/docker-containers-windows
+    alloy-devel"'
   environment:
     DOCKER_LOGIN:
       from_secret: docker_login
     DOCKER_PASSWORD:
       from_secret: docker_password
+    GCR_CREDS:
+      from_secret: gcr_admin
   image: grafana/agent-build-image:0.40.2-windows
   name: Build containers
   volumes:
@@ -559,6 +565,6 @@ kind: secret
 name: updater_private_key
 ---
 kind: signature
-hmac: 21df6cb02f24c4eab41dc3425f43c865141d400b2ad00571bde9a1803577e77c
+hmac: 33ad6940aa3d0615eb3be75bbeee0a90910b5b03280c1a80cc664abeb0de2932
 
 ...

--- a/.drone/pipelines/check_containers.jsonnet
+++ b/.drone/pipelines/check_containers.jsonnet
@@ -6,7 +6,7 @@ local linux_containers = [
 ];
 
 local windows_containers = [
-  { name: 'grafana/alloy', argument: 'alloy', path: 'Dockerfile.windows' },
+  { name: 'grafana/alloy', make: 'make alloy-image-windows', path: 'Dockerfile.windows' },
 ];
 
 (
@@ -45,7 +45,7 @@ local windows_containers = [
         path: '//./pipe/docker_engine/',
       }],
       commands: [
-        '& "C:/Program Files/git/bin/bash.exe" ./tools/ci/docker-containers-windows %s' % container.argument,
+        '& "C:/Program Files/git/bin/bash.exe" -c "%s"' % container.make,
       ],
     }],
     volumes: [{

--- a/.drone/pipelines/publish.jsonnet
+++ b/.drone/pipelines/publish.jsonnet
@@ -74,9 +74,13 @@ local windows_containers_dev_jobs = std.map(function(container) (
       environment: {
         DOCKER_LOGIN: secrets.docker_login.fromSecret,
         DOCKER_PASSWORD: secrets.docker_password.fromSecret,
+        GCR_CREDS: secrets.gcr_admin.fromSecret,
       },
       commands: [
-        '& "C:/Program Files/git/bin/bash.exe" ./tools/ci/docker-containers-windows %s-devel' % container,
+        pipelines.windows_command('mkdir -p $HOME/.docker'),
+        pipelines.windows_command('printenv GCR_CREDS > $HOME/.docker/config.json'),
+        pipelines.windows_command('docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD'),
+        pipelines.windows_command('./tools/ci/docker-containers-windows %s-devel' % container),
       ],
     }],
     volumes: [{
@@ -137,9 +141,6 @@ local linux_containers_jobs = std.map(function(container) (
 ), linux_containers);
 
 
-local windows_bash_command = function(command)
-  '& "C:/Program Files/git/bin/bash.exe" -c "%s"' % command;
-
 local windows_containers_jobs = std.map(function(container) (
   pipelines.windows('Publish Windows %s container' % container) {
     trigger: {
@@ -158,10 +159,10 @@ local windows_containers_jobs = std.map(function(container) (
         GCR_CREDS: secrets.gcr_admin.fromSecret,
       },
       commands: [
-        windows_bash_command('mkdir -p $HOME/.docker'),
-        windows_bash_command('printenv GCR_CREDS > $HOME/.docker/config.json'),
-        windows_bash_command('docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD'),
-        windows_bash_command('./tools/ci/docker-containers-windows %s' % container),
+        pipelines.windows_command('mkdir -p $HOME/.docker'),
+        pipelines.windows_command('printenv GCR_CREDS > $HOME/.docker/config.json'),
+        pipelines.windows_command('docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD'),
+        pipelines.windows_command('./tools/ci/docker-containers-windows %s' % container),
       ],
     }],
     volumes: [{

--- a/.drone/util/pipelines.jsonnet
+++ b/.drone/util/pipelines.jsonnet
@@ -19,4 +19,6 @@
       version: '1809',
     },
   },
+
+  windows_command(command):: '& "C:/Program Files/git/bin/bash.exe" -c "%s"' % command,
 }

--- a/docs/sources/get-started/install/docker.md
+++ b/docs/sources/get-started/install/docker.md
@@ -58,7 +58,7 @@ To run {{< param "PRODUCT_NAME" >}} as a Windows Docker container, run the follo
 docker run \
   -v "<CONFIG_FILE_PATH>:C:\Program Files\GrafanaLabs\Alloy\config.alloy" \
   -p 12345:12345 \
-  grafana/alloy:latest-windows \
+  grafana/alloy:latest-nanoserver-1809 \
     run --server.http.listen-addr=0.0.0.0:12345 "--storage.path=C:\ProgramData\GrafanaLabs\Alloy\data" \
     "C:\Program Files\GrafanaLabs\Alloy\config.alloy"
 ```

--- a/tools/ci/docker-containers-windows
+++ b/tools/ci/docker-containers-windows
@@ -34,7 +34,7 @@ fi
 # The VERSION_TAG is the version to use for the Docker tag. It is sanitized to
 # force it to be a valid tag name; ./tools/image-tag can emit characters that
 # are valid for semver but invalid for Docker tags, such as +.
-VERSION_TAG=${VERSION//+/-}-windows
+VERSION_TAG=${VERSION//+/-}-nanoserver-1809
 
 # We also need to know which "branch tag" to update. Branch tags are used as a
 # secondary tag for Docker containers. The branch tag is "latest" when being
@@ -45,9 +45,9 @@ VERSION_TAG=${VERSION//+/-}-windows
 # version. This effectively acts as a no-op because it will tag the same Docker
 # image twice.
 if [ -n "$DRONE_TAG" ] && [[ "$DRONE_TAG" != *"-rc."* ]]; then
-  BRANCH_TAG=latest-windows
+  BRANCH_TAG=latest-nanoserver-1809
 elif [ -n "$DRONE_BRANCH" ]; then
-  BRANCH_TAG=$DRONE_BRANCH-windows
+  BRANCH_TAG=$DRONE_BRANCH-nanoserver-1809
 else
   BRANCH_TAG=$VERSION_TAG
 fi


### PR DESCRIPTION
* Fix CI job to check Windows container builds properly
* Ensures Windows containers end in `-nanoserver-1809` as is our new convention
* Add `make alloy-image-windows` target to Makefile