### PR TITLE
docs: document backwards compatibility

### DIFF
--- a/docs/sources/introduction/backward-compatability.md
+++ b/docs/sources/introduction/backward-compatability.md
@@ -1,9 +1,9 @@
 ---
-canonical: https://grafana.com/docs/alloy/latest/backwards-compatability/
+canonical: https://grafana.com/docs/alloy/latest/introduction/backward-compatability/
 description: Grafana Alloy backward compatibility
 menuTitle: Backward compatibility
 title: Grafana Alloy backward compatibility
-weight: 950
+weight: 999
 ---
 
 # {{% param "FULL_PRODUCT_NAME" %}} backward compatibility


### PR DESCRIPTION
Document backwards compatability based on the grafana/agent backwards compatability [RFC]. Some changes have been made:

* Mention of major release burnout has been removed. We will continue to try to limit major releases to once per calendar year, but I'm not sure it's worth documenting. 

* LTS support for previous major releases has been removed. The RFC was less formal, and it's not clear how we'll continue to support v1 as v2 gets released. That sounds more like a problem for when we release v2 :)

* "The scope of backwards compatibility" has been removed from the backwards compatability list, as it is needlessly verbose and we may have forgotten an obvious exception.

* The exceptions "undocumented behavior," "tagged as exempt," "other telemetry data," and "non-versioned network APIs" have been integrated elsewhere in the doc to keep the list of exceptions shorter.

* "Bugs" and "specification errors" have been added to the exception list, as incorrect behavior that is relied on may require a breaking change, and contradictory specification in the documentation may need to be resolved by breaking compatibility.  

Despite the changes above, the intent is still the same: we strive wherever possible to maintain compatability for users between minor and patch releases.

[RFC]: https://github.com/grafana/agent/blob/main/docs/rfcs/0008-backwards-compatibility.md