### PR TITLE
.github: add issue template for documentation feedback

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs.yaml
+++ b/.github/ISSUE_TEMPLATE/docs.yaml
@@ -1,0 +1,19 @@
+name: Documentation feedback
+description: Give feedback on the Grafana Alloy documentation.
+labels: ["type/docs"]
+body:
+  - type: input
+    id: page
+    attributes:
+      label: Page
+      description: The page you're providing feedback on.
+      placeholder: /docs/alloy/latest/getting-started/
+    validations:
+      required: true
+  - type: textarea
+    id: feedback
+    attributes:
+      label: Feedback
+      description: What feedback do you have?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/docs.yaml
+++ b/.github/ISSUE_TEMPLATE/docs.yaml
@@ -1,5 +1,6 @@
 name: Documentation feedback
 description: Give feedback on the Grafana Alloy documentation.
+title: "Docs feedback: "
 labels: ["type/docs"]
 body:
   - type: input

--- a/.github/ISSUE_TEMPLATE/docs.yaml
+++ b/.github/ISSUE_TEMPLATE/docs.yaml
@@ -3,11 +3,11 @@ description: Give feedback on the Grafana Alloy documentation.
 labels: ["type/docs"]
 body:
   - type: input
-    id: page
+    id: url
     attributes:
-      label: Page
-      description: The page you're providing feedback on.
-      placeholder: /docs/alloy/latest/getting-started/
+      label: URL
+      description: The URL of the page you're providing feedback on.
+      placeholder: https://grafana.com/docs/alloy/latest/
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
This adds an issue template for documentation feedback. The documentation URL is given an id of `url` so that it can be prefilled by links with a query parameter `?url=URL_ENCODED_DOCS_LINK` 

cc @jdbaldry @clayton-cornell 