### PR TITLE
Fixed Luhn Typo

### DIFF
--- a/docs/sources/reference/components/loki.process.md
+++ b/docs/sources/reference/components/loki.process.md
@@ -523,7 +523,7 @@ The following arguments are supported:
 | ------------- | ------------- | ---------------------------------------------- | ---------------- | -------- |
 | `replacement` | `string`      | String to substitute the matched patterns with | `"**REDACTED**"` | no      |
 | `source`      | `string`      | Source of the data to parse.                   | `""`             | no       |
-| `minLength`   | `int`         | Minimum length of digits to consider           | `13`             | no       |
+| `min_length`   | `int`         | Minimum length of digits to consider           | `13`             | no       |
 
 
 The `source` field defines the source of data to search. When `source` is


### PR DESCRIPTION

#### PR Description

#### Which issue(s) this PR fixes

Fixes typo in `loki.process -> stage.luhn` where `minLength` was incorrectly referenced, it is `min_length`

#### Notes to the Reviewer

Reference: https://github.com/grafana/alloy/blob/main/internal/component/loki/process/stages/luhn.go#L16

#### PR Checklist

- [X] Documentation added
