### PR TITLE
Add GPG install instructions for Debian installs

### DIFF
--- a/docs/sources/get-started/install/linux.md
+++ b/docs/sources/get-started/install/linux.md
@@ -10,6 +10,15 @@ weight: 300
 
 You can install {{< param "PRODUCT_NAME" >}} as a systemd service on Linux.
 
+## Before you begin
+
+Some Debian-based cloud Virtual Machines don't have GPG installed by default.
+To install GPG in your Linux Virtual Machine, run the following command in a terminal window.
+
+```shell
+sudo apt install gpg
+```
+
 ## Install
 
 To install {{< param "PRODUCT_NAME" >}} on Linux, run the following commands in a terminal window.


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Some Debian-based cloud Virtual Machines don't have GPG installed by default.  Add instructions to install GPG before installing Alloy.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
