### PR TITLE
chore(doc): rectify actual Agent-to-Alloyconverted result from static config

### DIFF
--- a/docs/sources/tasks/migrate/from-static.md
+++ b/docs/sources/tasks/migrate/from-static.md
@@ -250,6 +250,7 @@ loki.source.file "logs_varlogs_varlogs" {
         min_poll_frequency = "1s"
         max_poll_frequency = "5s"
     }
+    legacy_positions_file = "/var/lib/agent/data-agent/varlogs.yml"
 }
 
 loki.write "logs_varlogs" {


### PR DESCRIPTION
I ran the convert command from `from-static.md` and the actual results is a bit different compared to what described in the doc. This PR is to rectify such defect

<img width="879" alt="image" src="https://github.com/grafana/alloy/assets/41283691/5d765a7f-1365-48c8-9e83-3451f440a70c">


<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
N/A
