### PR TITLE
feat(static/metrics): migrate default WAL directory to `data-alloy`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
 build/
 data/
-data-agent/
+data-alloy/
 dist/
 internal/web/ui/node_modules/
 internal/web/ui/build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,6 @@ Main (unreleased)
 
 - Fixed issue with defaults for Beyla component not being applied correctly. (marctc)  
 
-### Other changes
-
-- Migrate static mode's default WAL directory from `data-agent` to `data-alloy`. (@hainenber)
-
 v1.0.0 (2024-04-09)
 -------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ Main (unreleased)
 
 - Fixed issue with defaults for Beyla component not being applied correctly. (marctc)  
 
+### Other changes
+
+- Migrate static mode's default WAL directory from `data-agent` to `data-alloy`. (@hainenber)
+
 v1.0.0 (2024-04-09)
 -------------------
 

--- a/internal/static/metrics/agent.go
+++ b/internal/static/metrics/agent.go
@@ -19,7 +19,7 @@ import (
 var DefaultConfig = Config{
 	Global:                 instance.DefaultGlobalConfig,
 	InstanceRestartBackoff: 5 * time.Second,
-	WALDir:                 "data-agent/",
+	WALDir:                 "data-alloy/",
 	WALCleanupAge:          12 * time.Hour,
 	WALCleanupPeriod:       30 * time.Minute,
 	ServiceConfig:          cluster.DefaultConfig,

--- a/internal/static/metrics/agent.go
+++ b/internal/static/metrics/agent.go
@@ -19,12 +19,14 @@ import (
 var DefaultConfig = Config{
 	Global:                 instance.DefaultGlobalConfig,
 	InstanceRestartBackoff: 5 * time.Second,
-	WALDir:                 "data-alloy/",
-	WALCleanupAge:          12 * time.Hour,
-	WALCleanupPeriod:       30 * time.Minute,
-	ServiceConfig:          cluster.DefaultConfig,
-	ServiceClientConfig:    client.DefaultConfig,
-	InstanceMode:           instance.DefaultMode,
+	// The following legacy WALDir path is intetionally kept for config conversion from static to Alloy.
+	// Consult Alloy maintainers for changes.
+	WALDir:              "data-alloy/",
+	WALCleanupAge:       12 * time.Hour,
+	WALCleanupPeriod:    30 * time.Minute,
+	ServiceConfig:       cluster.DefaultConfig,
+	ServiceClientConfig: client.DefaultConfig,
+	InstanceMode:        instance.DefaultMode,
 }
 
 // Config defines the configuration for the entire set of Prometheus client

--- a/internal/static/metrics/agent.go
+++ b/internal/static/metrics/agent.go
@@ -19,7 +19,7 @@ import (
 var DefaultConfig = Config{
 	Global:                 instance.DefaultGlobalConfig,
 	InstanceRestartBackoff: 5 * time.Second,
-	// The following legacy WALDir path is intetionally kept for config conversion from static to Alloy.
+	// The following legacy WALDir path is intentionally kept for config conversion from static to Alloy.
 	// Consult Alloy maintainers for changes.
 	WALDir:              "data-agent/",
 	WALCleanupAge:       12 * time.Hour,

--- a/internal/static/metrics/agent.go
+++ b/internal/static/metrics/agent.go
@@ -21,7 +21,7 @@ var DefaultConfig = Config{
 	InstanceRestartBackoff: 5 * time.Second,
 	// The following legacy WALDir path is intetionally kept for config conversion from static to Alloy.
 	// Consult Alloy maintainers for changes.
-	WALDir:              "data-alloy/",
+	WALDir:              "data-agent/",
 	WALCleanupAge:       12 * time.Hour,
 	WALCleanupPeriod:    30 * time.Minute,
 	ServiceConfig:       cluster.DefaultConfig,


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

I notice that there are a few places where `data-agent` is still referenced despite the default directory for storage is now `data-alloy`. 

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

I have a hunch that these refs are being intentionally kept for other purposes. If that's the case, kindly help closing the PR as I don't have further context :D

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated