### PR TITLE
Add GOMAXPROCS and GOMEMLIMIT env vars to alloy container in the Helm chart

### DIFF
--- a/operations/helm/charts/alloy/.helmignore
+++ b/operations/helm/charts/alloy/.helmignore
@@ -27,3 +27,7 @@ README.md.gotmpl
 
 # Don't packages the tests used for CI.
 /tests/
+/ci/
+.helmignore
+CHANGELOG.md
+/config/

--- a/operations/helm/charts/alloy/CHANGELOG.md
+++ b/operations/helm/charts/alloy/CHANGELOG.md
@@ -7,6 +7,11 @@ This document contains a historical list of changes between releases. Only
 changes that impact end-user behavior are listed; changes to documentation or
 internal API changes are not present.
 
+Unreleased
+----------
+
+- Introduce `GOMEMLIMIT` and `GOMAXPROCS` env vars to the alloy container (@aerfio)
+
 0.1.1 (2024-04-11)
 ------------------
 

--- a/operations/helm/charts/alloy/templates/containers/_alloy.yaml
+++ b/operations/helm/charts/alloy/templates/containers/_alloy.yaml
@@ -29,6 +29,18 @@
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
+    - name: GOMAXPROCS
+      valueFrom:
+        resourceFieldRef:
+          containerName: alloy
+          divisor: "1"
+          resource: limits.cpu
+    - name: GOMEMLIMIT
+      valueFrom:
+        resourceFieldRef:
+          containerName: alloy
+          divisor: "1"
+          resource: limits.memory
     {{- range $values.extraEnv }}
     - {{- toYaml . | nindent 6 }}
     {{- end }}

--- a/operations/helm/tests/additional-serviceaccount-label/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/additional-serviceaccount-label/alloy/templates/controllers/daemonset.yaml
@@ -43,6 +43,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
           ports:
             - containerPort: 12345
               name: http-metrics

--- a/operations/helm/tests/clustering/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/clustering/alloy/templates/controllers/statefulset.yaml
@@ -48,6 +48,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
           ports:
             - containerPort: 12345
               name: http-metrics

--- a/operations/helm/tests/controller-volumes-extra/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/controller-volumes-extra/alloy/templates/controllers/daemonset.yaml
@@ -43,6 +43,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
           ports:
             - containerPort: 12345
               name: http-metrics

--- a/operations/helm/tests/create-daemonset-hostnetwork/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset-hostnetwork/alloy/templates/controllers/daemonset.yaml
@@ -43,6 +43,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
           ports:
             - containerPort: 12345
               name: http-metrics

--- a/operations/helm/tests/create-daemonset/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset/alloy/templates/controllers/daemonset.yaml
@@ -43,6 +43,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
           ports:
             - containerPort: 12345
               name: http-metrics

--- a/operations/helm/tests/create-deployment-autoscaling/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment-autoscaling/alloy/templates/controllers/deployment.yaml
@@ -43,6 +43,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
           ports:
             - containerPort: 12345
               name: http-metrics

--- a/operations/helm/tests/create-deployment/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment/alloy/templates/controllers/deployment.yaml
@@ -44,6 +44,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
           ports:
             - containerPort: 12345
               name: http-metrics

--- a/operations/helm/tests/create-statefulset-autoscaling/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset-autoscaling/alloy/templates/controllers/statefulset.yaml
@@ -45,6 +45,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
           ports:
             - containerPort: 12345
               name: http-metrics

--- a/operations/helm/tests/create-statefulset/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset/alloy/templates/controllers/statefulset.yaml
@@ -46,6 +46,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
           ports:
             - containerPort: 12345
               name: http-metrics

--- a/operations/helm/tests/custom-config/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/custom-config/alloy/templates/controllers/daemonset.yaml
@@ -43,6 +43,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
           ports:
             - containerPort: 12345
               name: http-metrics

--- a/operations/helm/tests/default-values/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/default-values/alloy/templates/controllers/daemonset.yaml
@@ -43,6 +43,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
           ports:
             - containerPort: 12345
               name: http-metrics

--- a/operations/helm/tests/enable-servicemonitor-tls/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/enable-servicemonitor-tls/alloy/templates/controllers/daemonset.yaml
@@ -43,6 +43,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
           ports:
             - containerPort: 12345
               name: http-metrics

--- a/operations/helm/tests/enable-servicemonitor/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/enable-servicemonitor/alloy/templates/controllers/daemonset.yaml
@@ -43,6 +43,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
           ports:
             - containerPort: 12345
               name: http-metrics

--- a/operations/helm/tests/envFrom/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/envFrom/alloy/templates/controllers/daemonset.yaml
@@ -43,6 +43,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
           envFrom:
             - configMapRef:
                 name: special-config

--- a/operations/helm/tests/existing-config/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/existing-config/alloy/templates/controllers/daemonset.yaml
@@ -43,6 +43,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
           ports:
             - containerPort: 12345
               name: http-metrics

--- a/operations/helm/tests/extra-env/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-env/alloy/templates/controllers/daemonset.yaml
@@ -43,6 +43,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
             -
               name: GREETING
               value: Warm greetings to

--- a/operations/helm/tests/extra-ports/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-ports/alloy/templates/controllers/daemonset.yaml
@@ -43,6 +43,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
           ports:
             - containerPort: 12345
               name: http-metrics

--- a/operations/helm/tests/faro-ingress/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/faro-ingress/alloy/templates/controllers/daemonset.yaml
@@ -43,6 +43,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
           ports:
             - containerPort: 12345
               name: http-metrics

--- a/operations/helm/tests/global-image-pullsecrets/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/global-image-pullsecrets/alloy/templates/controllers/daemonset.yaml
@@ -48,6 +48,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
           ports:
             - containerPort: 12345
               name: http-metrics

--- a/operations/helm/tests/global-image-registry/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/global-image-registry/alloy/templates/controllers/daemonset.yaml
@@ -43,6 +43,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
           ports:
             - containerPort: 12345
               name: http-metrics

--- a/operations/helm/tests/initcontainers/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/initcontainers/alloy/templates/controllers/daemonset.yaml
@@ -61,6 +61,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
           ports:
             - containerPort: 12345
               name: http-metrics

--- a/operations/helm/tests/local-image-pullsecrets/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/local-image-pullsecrets/alloy/templates/controllers/daemonset.yaml
@@ -45,6 +45,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
           ports:
             - containerPort: 12345
               name: http-metrics

--- a/operations/helm/tests/local-image-registry/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/local-image-registry/alloy/templates/controllers/daemonset.yaml
@@ -43,6 +43,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
           ports:
             - containerPort: 12345
               name: http-metrics

--- a/operations/helm/tests/nodeselectors-and-tolerations/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/nodeselectors-and-tolerations/alloy/templates/controllers/daemonset.yaml
@@ -43,6 +43,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
           ports:
             - containerPort: 12345
               name: http-metrics

--- a/operations/helm/tests/nonroot/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/nonroot/alloy/templates/controllers/daemonset.yaml
@@ -45,6 +45,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
           ports:
             - containerPort: 12345
               name: http-metrics

--- a/operations/helm/tests/pod_annotations/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/pod_annotations/alloy/templates/controllers/daemonset.yaml
@@ -44,6 +44,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
           ports:
             - containerPort: 12345
               name: http-metrics

--- a/operations/helm/tests/sidecars/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/sidecars/alloy/templates/controllers/daemonset.yaml
@@ -43,6 +43,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
           ports:
             - containerPort: 12345
               name: http-metrics

--- a/operations/helm/tests/topologyspreadconstraints/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/topologyspreadconstraints/alloy/templates/controllers/deployment.yaml
@@ -44,6 +44,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
           ports:
             - containerPort: 12345
               name: http-metrics

--- a/operations/helm/tests/with-digests/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/with-digests/alloy/templates/controllers/daemonset.yaml
@@ -43,6 +43,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: alloy
+                  divisor: "1"
+                  resource: limits.memory
           ports:
             - containerPort: 12345
               name: http-metrics


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

- Introduce `GOMAXPROCS` env var to alloy container, which is responsible for limiting the number of OS threads that Go runtime will create, leading to better performance if Go app is limited by k8s limits. It's best practice for this env to match Linux container CPU quota. See the description of https://github.com/uber-go/automaxprocs for details
- Introduce `GOMEMLIMIT` env var to alloy container, which is soft runtime memory limit. More info: https://tip.golang.org/doc/gc-guide
- Remove useless dirs from packaged alloy chart

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
