### PR TITLE
fix(web/ui): fix issue where text labels displayed outside of component's node boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Main (unreleased)
 
 - Fixed issue with defaults for Beyla component not being applied correctly. (marctc)  
 
+- Fixed issue where text labels displayed outside of component node's boundary. (@hainenber)
+
 v1.0.0 (2024-04-09)
 -------------------
 

--- a/internal/web/ui/src/features/graph/ComponentGraph.tsx
+++ b/internal/web/ui/src/features/graph/ComponentGraph.tsx
@@ -330,6 +330,12 @@ export const ComponentGraph: FC<ComponentGraphProps> = (props) => {
 
     const linkedNodes = nodes.append('a').attr('href', (n) => `${baseComponentPath}/${n.data.localID}`);
 
+    // Check if above `a` element got rendered with latitude equaling to node's margin
+    // If that's the case then we're running in quirks of Firefox SVG rendering
+    // and have to perform "hack"
+    const { x: linkedX } = linkedNodes.node()?.getBoundingClientRect() || {};
+    const withY = linkedX === nodeMargin;
+
     // Plot nodes
     linkedNodes
       .append('rect')
@@ -350,6 +356,7 @@ export const ComponentGraph: FC<ComponentGraphProps> = (props) => {
     nodeContent
       .append('text')
       .text((d) => d.data.name)
+      .attr('y', withY ? 10.5 : null)
       .attr('font-size', '13')
       .attr('font-weight', 'bold')
       .attr('font-family', '"Roboto", sans-serif')
@@ -361,7 +368,12 @@ export const ComponentGraph: FC<ComponentGraphProps> = (props) => {
     nodeContent
       .append('text')
       .text((d) => d.data.label || '')
-      .attr('y', 13 /* font size */ + 2 /* margin from previous text line */)
+      .attr(
+        'y',
+        13 /* font size */ +
+          2 /* margin from previous text line */ +
+          (withY ? 10.5 : 0) /* extra padding from above for Firefox rendering*/
+      )
       .attr('font-size', '13')
       .attr('font-weight', 'normal')
       .attr('font-family', '"Roboto", sans-serif')
@@ -399,7 +411,7 @@ export const ComponentGraph: FC<ComponentGraphProps> = (props) => {
         return text.charAt(0).toUpperCase() + text.substring(1);
       })
       .attr('x', 45 / 2) // Anchor to middle of box
-      .attr('y', 14 / 2) // Middle of box
+      .attr('y', 14 / 2 + (withY ? 2.5 : 0)) // Middle of box
       .attr('font-size', '7')
       .attr('font-weight', 'bold')
       .attr('font-family', '"Roboto", sans-serif')


### PR DESCRIPTION


<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Graph rendering on Chrome-based browsers are intact (I'm using Edge for example)

<img width="879" alt="image" src="https://github.com/grafana/alloy/assets/41283691/cf07bf73-b777-404c-acd9-8800457c9219">


Fixed the issue in Firefox
<img width="879" alt="image" src="https://github.com/grafana/alloy/assets/41283691/645b0469-8b25-4595-967c-4c3325b3c009">

As a bonus, Safari is fine and dandy
<img width="879" alt="image" src="https://github.com/grafana/alloy/assets/41283691/26769c41-4a9a-4f98-8a13-46d43c5c5b51">




#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #183 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
