### PR TITLE
Remove double slash from relative URL

### DIFF
--- a/docs/sources/reference/config-blocks/argument.md
+++ b/docs/sources/reference/config-blocks/argument.md
@@ -70,4 +70,4 @@ declare "self_collect" {
 ```
 
 [custom component]: ../../../concepts/custom_components/
-[declare]: ../..//config-blocks/declare/
+[declare]: ../../config-blocks/declare/


### PR DESCRIPTION
Sends crawlers in a spiral
