### PR TITLE
In the otelcol docs, refer to either server or client TLS config.

### DIFF
--- a/docs/sources/reference/components/otelcol.auth.oauth2.md
+++ b/docs/sources/reference/components/otelcol.auth.oauth2.md
@@ -67,7 +67,7 @@ tls       | [tls][] | TLS settings for the token client. | no
 
 The `tls` block configures TLS settings used for connecting to the token client. If the `tls` block isn't provided, TLS won't be used for communication.
 
-{{< docs/shared lookup="reference/components/otelcol-tls-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+{{< docs/shared lookup="reference/components/otelcol-tls-client-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/reference/components/otelcol.exporter.loadbalancing.md
+++ b/docs/sources/reference/components/otelcol.exporter.loadbalancing.md
@@ -213,7 +213,7 @@ able to handle and proxy HTTP/2 traffic.
 
 The `tls` block configures TLS settings used for the connection to the gRPC server.
 
-{{< docs/shared lookup="reference/components/otelcol-tls-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+{{< docs/shared lookup="reference/components/otelcol-tls-client-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ### keepalive block
 

--- a/docs/sources/reference/components/otelcol.exporter.otlp.md
+++ b/docs/sources/reference/components/otelcol.exporter.otlp.md
@@ -109,7 +109,7 @@ able to handle and proxy HTTP/2 traffic.
 The `tls` block configures TLS settings used for the connection to the gRPC
 server.
 
-{{< docs/shared lookup="reference/components/otelcol-tls-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+{{< docs/shared lookup="reference/components/otelcol-tls-client-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 {{< admonition type="note" >}}
 `otelcol.exporter.otlp` uses gRPC, which does not allow you to send sensitive credentials (like `auth`) over insecure channels.

--- a/docs/sources/reference/components/otelcol.exporter.otlphttp.md
+++ b/docs/sources/reference/components/otelcol.exporter.otlphttp.md
@@ -104,7 +104,7 @@ If `http2_read_idle_timeout` is unset or set to `0s`, then no health check will 
 The `tls` block configures TLS settings used for the connection to the HTTP
 server.
 
-{{< docs/shared lookup="reference/components/otelcol-tls-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+{{< docs/shared lookup="reference/components/otelcol-tls-client-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ### sending_queue block
 

--- a/docs/sources/reference/components/otelcol.extension.jaeger_remote_sampling.md
+++ b/docs/sources/reference/components/otelcol.extension.jaeger_remote_sampling.md
@@ -45,7 +45,7 @@ grpc > keepalive > server_parameters  | [server_parameters][]  | Server paramete
 grpc > keepalive > enforcement_policy | [enforcement_policy][] | Enforcement policy for keepalive settings.                                       | no
 source                                | [source][]             | Configures the Jaeger remote sampling document.                                  | yes
 source > remote                       | [remote][]             | Configures the gRPC client used to retrieve the Jaeger remote sampling document. | no
-source > remote > tls                 | [tls][]                | Configures TLS for the gRPC client.                                              | no
+source > remote > tls                 | [tls_client][]                | Configures TLS for the gRPC client.                                              | no
 source > remote > keepalive           | [keepalive][]          | Configures keepalive settings for the gRPC client.                               | no
 
 The `>` symbol indicates deeper levels of nesting. For example, `grpc > tls`
@@ -80,7 +80,7 @@ Name                    | Type      | Description                               
 The `tls` block configures TLS settings used for a server. If the `tls` block
 isn't provided, TLS won't be used for connections to the server.
 
-{{< docs/shared lookup="reference/components/otelcol-tls-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+{{< docs/shared lookup="reference/components/otelcol-tls-server-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ### cors block
 
@@ -223,7 +223,7 @@ able to handle and proxy HTTP/2 traffic.
 The `tls` block configures TLS settings used for the connection to the gRPC
 server.
 
-{{< docs/shared lookup="reference/components/otelcol-tls-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+{{< docs/shared lookup="reference/components/otelcol-tls-client-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ### keepalive client block
 

--- a/docs/sources/reference/components/otelcol.processor.resourcedetection.md
+++ b/docs/sources/reference/components/otelcol.processor.resourcedetection.md
@@ -676,7 +676,7 @@ Block                                                  | Description            
 The `tls` block configures TLS settings used for the connection to the gRPC
 server.
 
-{{< docs/shared lookup="reference/components/otelcol-tls-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+{{< docs/shared lookup="reference/components/otelcol-tls-client-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 #### openshift > resource_attributes
 

--- a/docs/sources/reference/components/otelcol.receiver.jaeger.md
+++ b/docs/sources/reference/components/otelcol.receiver.jaeger.md
@@ -110,7 +110,7 @@ Name | Type | Description | Default | Required
 The `tls` block configures TLS settings used for a server. If the `tls` block
 isn't provided, TLS won't be used for connections to the server.
 
-{{< docs/shared lookup="reference/components/otelcol-tls-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+{{< docs/shared lookup="reference/components/otelcol-tls-server-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ### keepalive block
 

--- a/docs/sources/reference/components/otelcol.receiver.kafka.md
+++ b/docs/sources/reference/components/otelcol.receiver.kafka.md
@@ -165,7 +165,7 @@ The `tls` block configures TLS settings used for connecting to the Kafka
 brokers. If the `tls` block isn't provided, TLS won't be used for
 communication.
 
-{{< docs/shared lookup="reference/components/otelcol-tls-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+{{< docs/shared lookup="reference/components/otelcol-tls-client-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ### kerberos block
 

--- a/docs/sources/reference/components/otelcol.receiver.opencensus.md
+++ b/docs/sources/reference/components/otelcol.receiver.opencensus.md
@@ -86,7 +86,7 @@ refers to a `tls` block defined inside a `grpc` block.
 The `tls` block configures TLS settings used for a server. If the `tls` block
 isn't provided, TLS won't be used for connections to the server.
 
-{{< docs/shared lookup="reference/components/otelcol-tls-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+{{< docs/shared lookup="reference/components/otelcol-tls-server-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ### keepalive block
 

--- a/docs/sources/reference/components/otelcol.receiver.otlp.md
+++ b/docs/sources/reference/components/otelcol.receiver.otlp.md
@@ -89,7 +89,7 @@ Name | Type | Description | Default | Required
 The `tls` block configures TLS settings used for a server. If the `tls` block
 isn't provided, TLS won't be used for connections to the server.
 
-{{< docs/shared lookup="reference/components/otelcol-tls-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+{{< docs/shared lookup="reference/components/otelcol-tls-server-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ### keepalive block
 

--- a/docs/sources/reference/components/otelcol.receiver.vcenter.md
+++ b/docs/sources/reference/components/otelcol.receiver.vcenter.md
@@ -90,7 +90,7 @@ output | [output][] | Configures where to send received telemetry data. | yes
 The `tls` block configures TLS settings used for a server. If the `tls` block
 isn't provided, TLS won't be used for connections to the server.
 
-{{< docs/shared lookup="reference/components/otelcol-tls-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+{{< docs/shared lookup="reference/components/otelcol-tls-client-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ### metrics block
 

--- a/docs/sources/reference/components/otelcol.receiver.zipkin.md
+++ b/docs/sources/reference/components/otelcol.receiver.zipkin.md
@@ -66,7 +66,7 @@ refers to a `tls` block defined inside a `grpc` block.
 The `tls` block configures TLS settings used for a server. If the `tls` block
 isn't provided, TLS won't be used for connections to the server.
 
-{{< docs/shared lookup="reference/components/otelcol-tls-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+{{< docs/shared lookup="reference/components/otelcol-tls-server-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ### cors block
 

--- a/docs/sources/shared/reference/components/otelcol-tls-client-block.md
+++ b/docs/sources/shared/reference/components/otelcol-tls-client-block.md
@@ -1,6 +1,6 @@
 ---
-canonical: https://grafana.com/docs/alloy/latest/shared/reference/components/otelcol-tls-config-block/
-description: Shared content, otelcol tls config block
+canonical: https://grafana.com/docs/alloy/latest/shared/reference/components/otelcol-tls-client-block/
+description: Shared content, otelcol tls client block
 headless: true
 ---
 

--- a/docs/sources/shared/reference/components/otelcol-tls-server-block.md
+++ b/docs/sources/shared/reference/components/otelcol-tls-server-block.md
@@ -30,10 +30,10 @@ The following pairs of arguments are mutually exclusive and can't both be set si
 * `key_pem` and `key_file`
 
 If `cipher_suites` is left blank, a safe default list is used.
-See the [Go Cipher Suites documentation][golang-cipher-suites] for a list of supported cipher suites.
+Refer to the [Go Cipher Suites documentation][golang-cipher-suites] for a list of supported cipher suites.
 
 `client_ca_file` sets the `ClientCA` and `ClientAuth` to `RequireAndVerifyClientCert` in the `TLSConfig`. 
-See to the [Go TLS documentation][golang-tls] for more information.
+Refer to the [Go TLS documentation][golang-tls] for more information.
 
 [golang-tls]: https://godoc.org/crypto/tls#Config
 [golang-cipher-suites]: https://go.dev/src/crypto/tls/cipher_suites.go

--- a/docs/sources/shared/reference/components/otelcol-tls-server-block.md
+++ b/docs/sources/shared/reference/components/otelcol-tls-server-block.md
@@ -1,0 +1,39 @@
+---
+canonical: https://grafana.com/docs/alloy/latest/shared/reference/components/otelcol-tls-server-block/
+description: Shared content, otelcol tls server block
+headless: true
+---
+
+The following arguments are supported:
+
+Name                           | Type           | Description                                                                                  | Default     | Required
+-------------------------------|----------------|----------------------------------------------------------------------------------------------|-------------|---------
+`ca_file`                      | `string`       | Path to the CA file.                                                                         |             | no
+`ca_pem`                       | `string`       | CA PEM-encoded text to validate the server with.                                             |             | no
+`cert_file`                    | `string`       | Path to the TLS certificate.                                                                 |             | no
+`cert_pem`                     | `string`       | Certificate PEM-encoded text for client authentication.                                      |             | no
+`include_system_ca_certs_pool` | `boolean`      | Whether to load the system certificate authorities pool alongside the certificate authority. | `false`     | no
+`key_file`                     | `string`       | Path to the TLS certificate key.                                                             |             | no
+`key_pem`                      | `secret`       | Key PEM-encoded text for client authentication.                                              |             | no
+`max_version`                  | `string`       | Maximum acceptable TLS version for connections.                                              | `"TLS 1.3"` | no
+`min_version`                  | `string`       | Minimum acceptable TLS version for connections.                                              | `"TLS 1.2"` | no
+`cipher_suites`                | `list(string)` | A list of TLS cipher suites that the TLS transport can use.                                  | `[]`        | no
+`reload_interval`              | `duration`     | The duration after which the certificate is reloaded.                                        | `"0s"`      | no
+`client_ca_file`               | `string`       | Path to the TLS cert to use by the server to verify a client certificate.                    |             | no
+
+If `reload_interval` is set to `"0s"`, the certificate never reloaded.
+
+The following pairs of arguments are mutually exclusive and can't both be set simultaneously:
+
+* `ca_pem` and `ca_file`
+* `cert_pem` and `cert_file`
+* `key_pem` and `key_file`
+
+If `cipher_suites` is left blank, a safe default list is used.
+See the [Go Cipher Suites documentation][golang-cipher-suites] for a list of supported cipher suites.
+
+`client_ca_file` sets the `ClientCA` and `ClientAuth` to `RequireAndVerifyClientCert` in the `TLSConfig`. 
+See to the [Go TLS documentation][golang-tls] for more information.
+
+[golang-tls]: https://godoc.org/crypto/tls#Config
+[golang-cipher-suites]: https://go.dev/src/crypto/tls/cipher_suites.go


### PR DESCRIPTION
The TLS arguments for clients and servers differ. However, the docs are currently only showing the attributes for clients.

This PR renames the current TLS argument to "client arguments", and introduces "server" arguments. It also changes all references in docs to use the appropriate arguments.