### PR TITLE
Update loki.source.api.md

### DIFF
--- a/docs/sources/reference/components/loki.source.api.md
+++ b/docs/sources/reference/components/loki.source.api.md
@@ -30,7 +30,7 @@ The component will start HTTP server on the configured port and address with the
 
 - `/loki/api/v1/push` - accepting `POST` requests compatible with [Loki push API][loki-push-api], for example, from another {{< param "PRODUCT_NAME" >}}'s [`loki.write`][loki.write] component.
 - `/loki/api/v1/raw` - accepting `POST` requests with newline-delimited log lines in body. This can be used to send NDJSON or plaintext logs. This is compatible with promtail's push API endpoint - see [promtail's documentation][promtail-push-api] for more information. NOTE: when this endpoint is used, the incoming timestamps cannot be used and the `use_incoming_timestamp = true` setting will be ignored.
-- `/loki/ready` - accepting `GET` requests - can be used to confirm the server is reachable and healthy.
+- `/ready` - accepting `GET` requests - can be used to confirm the server is reachable and healthy.
 - `/api/v1/push` - internally reroutes to `/loki/api/v1/push`
 - `/api/v1/raw` - internally reroutes to `/loki/api/v1/raw`
 


### PR DESCRIPTION
The `/loki/ready` endpoint does not seem to be a valid one. Instead should be `/ready` as stated here: https://github.com/grafana/alloy/blob/main/internal/component/loki/source/api/internal/lokipush/push_api_server.go#L78 and here https://grafana.com/docs/loki/latest/reference/api/#status-endpoints

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
