### PR TITLE
Helm: make controller namespace configurable

### DIFF
--- a/operations/helm/charts/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/charts/alloy/templates/controllers/daemonset.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "alloy.fullname" . }}
+  namespace: {{ include "alloy.namespace" . }}
   labels:
     {{- include "alloy.labels" . | nindent 4 }}
   {{- with .Values.controller.extraAnnotations }}

--- a/operations/helm/charts/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/charts/alloy/templates/controllers/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "alloy.fullname" . }}
+  namespace: {{ include "alloy.namespace" . }}
   labels:
     {{- include "alloy.labels" . | nindent 4 }}
   {{- with .Values.controller.extraAnnotations }}

--- a/operations/helm/charts/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/charts/alloy/templates/controllers/statefulset.yaml
@@ -6,6 +6,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "alloy.fullname" . }}
+  namespace: {{ include "alloy.namespace" . }}
   labels:
     {{- include "alloy.labels" . | nindent 4 }}
   {{- with .Values.controller.extraAnnotations }}


### PR DESCRIPTION
Right now, alloy controller in Helm always deployed into `default` namespace, despite other resources it relies on, such as service account, use release namespace. The deployment fails as a result. This PR uses the default `namespace` from helpers

