### PR TITLE
Add alert support for dedicated deployments for allow, alloy-logs, alloy-events, etc

### DIFF
--- a/operations/alloy-mixin/alerts/clustering.libsonnet
+++ b/operations/alloy-mixin/alerts/clustering.libsonnet
@@ -19,8 +19,8 @@ alert.newGroup(
       // metrics.
       |||
         sum without (state) (cluster_node_peers) !=
-        on (cluster, namespace) group_left
-        count by (cluster, namespace) (cluster_node_info)
+        on (cluster, namespace, job) group_left
+        count by (cluster, namespace, job) (cluster_node_info)
       |||,
       'Nodes report different number of peers vs. the count of observed Alloy metrics. Some Alloy metrics may be missing or the cluster is in a split brain state.',
       '15m',
@@ -57,7 +57,7 @@ alert.newGroup(
       'ClusterConfigurationDrift',
       |||
         count without (sha256) (
-            max by (cluster, namespace, sha256) (alloy_config_hash and on(cluster, namespace) cluster_node_info)
+            max by (cluster, namespace, sha256, job) (alloy_config_hash and on(cluster, namespace) cluster_node_info)
         ) > 1
       |||,
       'Cluster nodes are not using the same configuration file.',


### PR DESCRIPTION

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

When deploying alloy with
https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring, the alloy deployment is split by component and each component has it's own ServiceMonitor.

```
❯ kubectl get servicemonitor
monitoring-alloy          23h
monitoring-alloy-events   23h
monitoring-alloy-logs     23h
```

This leads to constant `ClusterNodeCountMismatch` and `ClusterConfigurationDrift` alerts because the current alerts does not differentiate between those seperate deployments.

This PR adds the `job` label to those alerts to group them by those deployments.
