### PR TITLE
docs: Corrects `path` to `exe_path` in Beyla's docs

### DIFF
--- a/docs/sources/reference/components/beyla.ebpf.md
+++ b/docs/sources/reference/components/beyla.ebpf.md
@@ -127,13 +127,13 @@ Name         | Type     | Description                                           
 `name `      | `string` | The name of the service to match.                                               |         | no
 `namespace`  | `string` | The namespace of the service to match.                                          |         | no
 `open_ports` | `string` | The port of the running service for Beyla automatically instrumented with eBPF. |         | no
-`path`       | `string` | The path of the running service for Beyla automatically instrumented with eBPF. |         | no
+`exe_path`   | `string` | The path of the running service for Beyla automatically instrumented with eBPF. |         | no
 
 `name` defines a name for the matching instrumented service.
 It is used to populate the `service.name` OTEL property and/or the `service_name` Prometheus property in the exported metrics/traces.
 `open_port` accepts a comma-separated list of ports (for example, `80,443`), and port ranges (for example, `8000-8999`).
 If the executable matches only one of the ports in the list, it is considered to match the selection criteria.
-`path` accepts a regular expression to be matched against the full executable command line, including the directory where the executable resides on the file system.
+`exe_path` accepts a regular expression to be matched against the full executable command line, including the directory where the executable resides on the file system.
 
 ### output block
 


### PR DESCRIPTION
#### PR Description

Corrects `path` to `exe_path` in Beyla's docs [`services-block`](https://grafana.com/docs/alloy/latest/reference/components/beyla.ebpf/#services-block) , to match the code.

See: https://github.com/grafana/alloy/blob/main/internal/component/beyla/ebpf/args.go#L43

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->
N/A
#### Notes to the Reviewer

#### PR Checklist
N/A
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
