### PR TITLE
main: use VERSION file as fallback for version reporting

### DIFF
--- a/fallback_version.go
+++ b/fallback_version.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	_ "embed"
+	"strings"
+
+	"github.com/grafana/alloy/internal/build"
+)
+
+//go:embed VERSION
+var fallbackVersionText []byte
+
+// fallbackVersion returns a version string to use for when the version isn't
+// explicitly set at build time. The version string will always have -devel
+// appended to it.
+func fallbackVersion() string {
+	return fallbackVersionFromText(fallbackVersionText)
+}
+
+func fallbackVersionFromText(text []byte) string {
+	// Find the first line in fallbackVersionText which isn't a blank line or a
+	// line starting with #.
+	scanner := bufio.NewScanner(bytes.NewReader(text))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if len(line) == 0 || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		return line + "-devel"
+	}
+
+	// We shouldn't hit this case since we always control the contents of the
+	// VERSION file, but just in case we'll return the existing version.
+	return build.Version
+}

--- a/fallback_version_test.go
+++ b/fallback_version_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_fallbackVersionFromText(t *testing.T) {
+	in := `# This is a comment 
+# This is another comment 
+
+v1.2.3
+
+This line is ignored!`
+	expect := "v1.2.3-devel"
+
+	actual := fallbackVersionFromText([]byte(in))
+	require.Equal(t, expect, actual)
+}

--- a/main.go
+++ b/main.go
@@ -18,6 +18,12 @@ import (
 )
 
 func init() {
+	// If the build version wasn't set by the build process, we'll set it based
+	// on the version string in VERSION.
+	if build.Version == "" || build.Version == "v0.0.0" {
+		build.Version = fallbackVersion()
+	}
+
 	prometheus.MustRegister(build.NewCollector("alloy"))
 }
 


### PR DESCRIPTION
Currently, if Alloy was built without setting build information, it reports its version as `v0.0.0`. This can be problematic if using components whose behaviour depends on the User-Agent header. 

This commit adds using the VERSION file as fallback, so if the version information wasn't present (such as when ussing `go run .`), the reported version is taken from the VERSION file at the root of the repository.

The version reported is then appended with `-devel` to indicate that it is not the final release.

For example, as the VERSION file currently contains `v1.1.0`, then the fallback reported version will be `v1.1.0-devel`.

This PR will increase the binary size by 1KB as the `VERSION` file (with all of its comments) is embedded into the binary. If we wanted to reduce this overhead, we could remove or reduce the comments from the VERSION file.