### PR TITLE
fix(pyroscope/scrape): add support for scraping `alloy`'s internal domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ Main (unreleased)
 
 - Add a description to Alloy DEB and RPM packages. (@rfratto)
 
+- Fix an issue where `pyroscope.scrape` cannot scrape `alloy.internal:12345`. (@hainenber)
+
 v1.0.0 (2024-04-09)
 -------------------
 

--- a/internal/component/pyroscope/scrape/manager_test.go
+++ b/internal/component/pyroscope/scrape/manager_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/grafana/alloy/internal/component/pyroscope"
 	"github.com/grafana/alloy/internal/util"
+	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/model/labels"
@@ -16,7 +17,7 @@ import (
 func TestManager(t *testing.T) {
 	reloadInterval = time.Millisecond
 
-	m := NewManager(pyroscope.AppendableFunc(func(ctx context.Context, labels labels.Labels, samples []*pyroscope.RawSample) error {
+	m := NewManager([]config_util.HTTPClientOption{}, pyroscope.AppendableFunc(func(ctx context.Context, labels labels.Labels, samples []*pyroscope.RawSample) error {
 		return nil
 	}), util.TestLogger(t))
 

--- a/internal/component/pyroscope/scrape/manager_test.go
+++ b/internal/component/pyroscope/scrape/manager_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/grafana/alloy/internal/component/pyroscope"
 	"github.com/grafana/alloy/internal/util"
-	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/model/labels"
@@ -17,7 +16,7 @@ import (
 func TestManager(t *testing.T) {
 	reloadInterval = time.Millisecond
 
-	m := NewManager([]config_util.HTTPClientOption{}, pyroscope.AppendableFunc(func(ctx context.Context, labels labels.Labels, samples []*pyroscope.RawSample) error {
+	m := NewManager(Options{}, pyroscope.AppendableFunc(func(ctx context.Context, labels labels.Labels, samples []*pyroscope.RawSample) error {
 		return nil
 	}), util.TestLogger(t))
 

--- a/internal/component/pyroscope/scrape/scrape.go
+++ b/internal/component/pyroscope/scrape/scrape.go
@@ -11,6 +11,8 @@ import (
 	"github.com/grafana/alloy/internal/component/pyroscope"
 	"github.com/grafana/alloy/internal/featuregate"
 	"github.com/grafana/alloy/internal/service/cluster"
+	"github.com/grafana/alloy/internal/service/http"
+	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 
@@ -241,6 +243,12 @@ var _ component.Component = (*Component)(nil)
 
 // New creates a new pprof.scrape component.
 func New(o component.Options, args Arguments) (*Component, error) {
+	serviceData, err := o.GetServiceData(http.ServiceName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get information about HTTP server: %w", err)
+	}
+	httpData := serviceData.(http.Data)
+
 	data, err := o.GetServiceData(cluster.ServiceName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get info about cluster service: %w", err)
@@ -248,7 +256,10 @@ func New(o component.Options, args Arguments) (*Component, error) {
 	clusterData := data.(cluster.Cluster)
 
 	alloyAppendable := pyroscope.NewFanout(args.ForwardTo, o.ID, o.Registerer)
-	scraper := NewManager(alloyAppendable, o.Logger)
+	scrapeHttpOptions := []config_util.HTTPClientOption{
+		config_util.WithDialContextFunc(httpData.DialFunc),
+	}
+	scraper := NewManager(scrapeHttpOptions, alloyAppendable, o.Logger)
 	c := &Component{
 		opts:          o,
 		cluster:       clusterData,

--- a/internal/component/pyroscope/scrape/scrape.go
+++ b/internal/component/pyroscope/scrape/scrape.go
@@ -256,8 +256,10 @@ func New(o component.Options, args Arguments) (*Component, error) {
 	clusterData := data.(cluster.Cluster)
 
 	alloyAppendable := pyroscope.NewFanout(args.ForwardTo, o.ID, o.Registerer)
-	scrapeHttpOptions := []config_util.HTTPClientOption{
-		config_util.WithDialContextFunc(httpData.DialFunc),
+	scrapeHttpOptions := Options{
+		HTTPClientOptions: []config_util.HTTPClientOption{
+			config_util.WithDialContextFunc(httpData.DialFunc),
+		},
 	}
 	scraper := NewManager(scrapeHttpOptions, alloyAppendable, o.Logger)
 	c := &Component{

--- a/internal/component/pyroscope/scrape/scrape_loop.go
+++ b/internal/component/pyroscope/scrape/scrape_loop.go
@@ -37,8 +37,8 @@ type scrapePool struct {
 	droppedTargets []*Target
 }
 
-func newScrapePool(cfg Arguments, appendable pyroscope.Appendable, logger log.Logger) (*scrapePool, error) {
-	scrapeClient, err := commonconfig.NewClientFromConfig(*cfg.HTTPClientConfig.Convert(), cfg.JobName)
+func newScrapePool(hco []commonconfig.HTTPClientOption, cfg Arguments, appendable pyroscope.Appendable, logger log.Logger) (*scrapePool, error) {
+	scrapeClient, err := commonconfig.NewClientFromConfig(*cfg.HTTPClientConfig.Convert(), cfg.JobName, hco...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/component/pyroscope/scrape/scrape_loop_test.go
+++ b/internal/component/pyroscope/scrape/scrape_loop_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/alloy/internal/component/discovery"
 	"github.com/grafana/alloy/internal/component/pyroscope"
 	"github.com/grafana/alloy/internal/util"
+	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/model/labels"
@@ -33,7 +34,7 @@ func TestScrapePool(t *testing.T) {
 	args.ProfilingConfig.Goroutine.Enabled = false
 	args.ProfilingConfig.Memory.Enabled = false
 
-	p, err := newScrapePool(args, pyroscope.AppendableFunc(
+	p, err := newScrapePool([]config_util.HTTPClientOption{}, args, pyroscope.AppendableFunc(
 		func(ctx context.Context, labels labels.Labels, samples []*pyroscope.RawSample) error {
 			return nil
 		}),
@@ -213,7 +214,7 @@ func BenchmarkSync(b *testing.B) {
 	args := NewDefaultArguments()
 	args.Targets = []discovery.Target{}
 
-	p, err := newScrapePool(args, pyroscope.AppendableFunc(
+	p, err := newScrapePool([]config_util.HTTPClientOption{}, args, pyroscope.AppendableFunc(
 		func(ctx context.Context, labels labels.Labels, samples []*pyroscope.RawSample) error {
 			return nil
 		}),

--- a/internal/component/pyroscope/scrape/scrape_test.go
+++ b/internal/component/pyroscope/scrape/scrape_test.go
@@ -3,6 +3,7 @@ package scrape
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -14,6 +15,7 @@ import (
 	"github.com/grafana/alloy/internal/component/prometheus/scrape"
 	"github.com/grafana/alloy/internal/component/pyroscope"
 	"github.com/grafana/alloy/internal/service/cluster"
+	http_service "github.com/grafana/alloy/internal/service/http"
 	"github.com/grafana/alloy/internal/util"
 	"github.com/grafana/alloy/syntax"
 	"github.com/prometheus/client_golang/prometheus"
@@ -69,6 +71,13 @@ func getServiceData(name string) (interface{}, error) {
 	switch name {
 	case cluster.ServiceName:
 		return cluster.Mock(), nil
+	case http_service.ServiceName:
+		return http_service.Data{
+			HTTPListenAddr:   "localhost:12345",
+			MemoryListenAddr: "alloy.internal:1245",
+			BaseHTTPPath:     "/",
+			DialFunc:         (&net.Dialer{}).DialContext,
+		}, nil
 	default:
 		return nil, fmt.Errorf("unrecognized service name %q", name)
 	}


### PR DESCRIPTION


<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

The error logs are no longer there and Alloy continues to scrape profile from `alloy.internal:12345`. Ran with config
```
pyroscope.scrape "default" {
  targets = [
    {"__address__" = "alloy.internal:12345", "service_name" = "alloy"},
  ]
  forward_to = []
}
```

<img width="1183" alt="image" src="https://github.com/grafana/alloy/assets/41283691/c1a7533d-cbf3-4865-811f-4a59626da4c9">

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #603 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
