### PR TITLE
Add Windows application manifest

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
 pkg/operator/crds/*.yaml linguist-generated=true
 
 *.txtar text eol=lf
+Makefile text eol=lf
+tools/make/*.mk text eol=lf
+tools/image-tag text eol=lf
+tools/release text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,6 @@ buildx-v*
 cover*.out
 .uptodate
 node_modules
+*.syso
 
 /docs/variables.mk.local

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@
 ##   generate-helm-tests       Generate Helm chart tests.
 ##   generate-ui               Generate the UI assets.
 ##   generate-versioned-files  Generate versioned files.
+##   generate-winmanifest      Generate the Windows application manifest.
 ##
 ## Other targets:
 ##
@@ -210,8 +211,8 @@ alloy-image-windows:
 # Targets for generating assets
 #
 
-.PHONY: generate generate-drone generate-helm-docs generate-helm-tests generate-ui generate-versioned-files
-generate: generate-drone generate-helm-docs generate-helm-tests generate-ui generate-versioned-files generate-docs
+.PHONY: generate generate-drone generate-helm-docs generate-helm-tests generate-ui generate-versioned-files generate-winmanifest
+generate: generate-drone generate-helm-docs generate-helm-tests generate-ui generate-versioned-files generate-docs generate-winmanifest
 
 generate-drone:
 	drone jsonnet -V BUILD_IMAGE_VERSION=$(BUILD_IMAGE_VERSION) --stream --format --source .drone/drone.jsonnet --target .drone/drone.yml
@@ -249,6 +250,13 @@ ifeq ($(USE_CONTAINER),1)
 	$(RERUN_IN_CONTAINER)
 else
 	go generate ./docs
+endif
+
+generate-winmanifest:
+ifeq ($(USE_CONTAINER),1)
+	$(RERUN_IN_CONTAINER)
+else
+	go generate ./internal/winmanifest
 endif
 #
 # Other targets

--- a/internal/cmd/alloy-service/main_windows.go
+++ b/internal/cmd/alloy-service/main_windows.go
@@ -9,6 +9,9 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"golang.org/x/sys/windows/svc"
+
+	// Embed application manifest for Windows builds
+	_ "github.com/grafana/alloy/internal/winmanifest"
 )
 
 const serviceName = "Alloy"

--- a/internal/winmanifest/doc.go
+++ b/internal/winmanifest/doc.go
@@ -1,0 +1,9 @@
+// Package winmanifest provides a basic manifest.
+//
+// You import it for its side effects only, as
+//
+//	import _ "github.com/grafana/alloy/internal/winmanifest"
+//
+// On non-Windows platforms this package does nothing.
+
+package winmanifest

--- a/internal/winmanifest/generate_windows.go
+++ b/internal/winmanifest/generate_windows.go
@@ -1,0 +1,3 @@
+package winmanifest
+
+//go:generate go run github.com/tc-hib/go-winres@v0.3.3 make --product-version=git-tag --file-version=git-tag

--- a/internal/winmanifest/winres/winres.json
+++ b/internal/winmanifest/winres/winres.json
@@ -1,0 +1,44 @@
+{
+  "RT_GROUP_ICON": {
+    "#1": {
+      "0000": "../../../packaging/windows/logo.ico"
+    }
+  },
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "description": "OpenTelemetry Collector distribution with programmable pipelines",
+        "minimum-os": "win7",
+        "execution-level": "as invoker",
+        "ui-access": false,
+        "long-path-aware": true
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "",
+            "CompanyName": "Grafana Labs",
+            "FileDescription": "OpenTelemetry Collector distribution with programmable pipelines",
+            "FileVersion": "",
+            "InternalName": "",
+            "LegalCopyright": "Grafana Labs",
+            "LegalTrademarks": "",
+            "OriginalFilename": "",
+            "PrivateBuild": "",
+            "ProductName": "Grafana Alloy",
+            "ProductVersion": "",
+            "SpecialBuild": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/main.go
+++ b/main.go
@@ -15,6 +15,9 @@ import (
 	// Embed a set of fallback X.509 trusted roots
 	// Allows the app to work correctly even when the OS does not provide a verifier or systems roots pool
 	_ "golang.org/x/crypto/x509roots/fallback"
+
+	// Embed application manifest for Windows builds
+	_ "github.com/grafana/alloy/internal/winmanifest"
 )
 
 func init() {

--- a/tools/make/packaging.mk
+++ b/tools/make/packaging.mk
@@ -73,7 +73,7 @@ dist/alloy-darwin-arm64: generate-ui
 dist/alloy-windows-amd64.exe: GO_TAGS += builtinassets
 dist/alloy-windows-amd64.exe: GOOS    := windows
 dist/alloy-windows-amd64.exe: GOARCH  := amd64
-dist/alloy-windows-amd64.exe: generate-ui
+dist/alloy-windows-amd64.exe: generate-ui generate-winmanifest
 	$(PACKAGING_VARS) ALLOY_BINARY=$@ "$(MAKE)" -f $(PARENT_MAKEFILE) alloy
 
 # NOTE(rfratto): do not use netgo when building Windows binaries, which
@@ -102,7 +102,7 @@ dist-alloy-service-binaries: dist.temp/alloy-service-windows-amd64.exe
 dist.temp/alloy-service-windows-amd64.exe: GO_TAGS += builtinassets
 dist.temp/alloy-service-windows-amd64.exe: GOOS    := windows
 dist.temp/alloy-service-windows-amd64.exe: GOARCH  := amd64
-dist.temp/alloy-service-windows-amd64.exe: generate-ui
+dist.temp/alloy-service-windows-amd64.exe: generate-ui generate-winmanifest
 	$(PACKAGING_VARS) SERVICE_BINARY=$@ "$(MAKE)" -f $(PARENT_MAKEFILE) alloy-service
 
 #


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR attaches a [Windows Application Manifest](https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests) to alloy and alloy service binary. 

It add an icon to the binaries and enabled modern OS feature, like [Windows long-path awareness](https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests#longPathAware) and attach meta information like version of alloy.

go-winres is using git tag --describe to detect the currently git tag. It dev builds may result into mis-leadling versioning, since git tag --describe may take note of the helm chart tags as well. See https://github.com/tc-hib/go-winres/issues/23

![Unbenannt](https://github.com/grafana/alloy/assets/1560587/1ddbae78-ffed-4a08-9eb4-3c5592f5f0ce)

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
