### PR TITLE
Push build images for Alloy on tags of `build-image/v*`

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1,5 +1,107 @@
 ---
 kind: pipeline
+name: Create Linux build image
+platform:
+  arch: amd64
+  os: linux
+steps:
+- commands:
+  - export IMAGE_TAG=${DRONE_TAG##build-image/v}
+  - docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
+  - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+  - docker buildx create --name multiarch --driver docker-container --use
+  - docker buildx build --build-arg="GO_RUNTIME=golang:1.22.1-bullseye" --push --platform
+    linux/amd64,linux/arm64 -t grafana/alloy-build-image:$IMAGE_TAG ./tools/build-image
+  environment:
+    DOCKER_LOGIN:
+      from_secret: docker_login
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+  image: docker
+  name: Build
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+trigger:
+  event:
+  - tag
+  ref:
+  - refs/tags/build-image/v*
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+kind: pipeline
+name: Create Linux build image for boringcrypto
+platform:
+  arch: amd64
+  os: linux
+steps:
+- commands:
+  - export IMAGE_TAG=${DRONE_TAG##build-image/v}-boringcrypto
+  - docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
+  - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+  - docker buildx create --name multiarch --driver docker-container --use
+  - docker buildx build --build-arg="GO_RUNTIME=mcr.microsoft.com/oss/go/microsoft/golang:1.22.1-bullseye"
+    --push --platform linux/amd64,linux/arm64 -t grafana/alloy-build-image:$IMAGE_TAG
+    ./tools/build-image
+  environment:
+    DOCKER_LOGIN:
+      from_secret: docker_login
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+  image: docker
+  name: Build
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+trigger:
+  event:
+  - tag
+  ref:
+  - refs/tags/build-image/v*
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+kind: pipeline
+name: Create Windows build image
+platform:
+  arch: amd64
+  os: windows
+  version: "1809"
+steps:
+- commands:
+  - $IMAGE_TAG="${DRONE_TAG##build-image/v}-windows"
+  - docker login -u $Env:DOCKER_LOGIN -p $Env:DOCKER_PASSWORD
+  - docker build -t grafana/alloy-build-image:$IMAGE_TAG ./tools/build-image/windows
+  - docker push grafana/alloy-build-image:$IMAGE_TAG
+  environment:
+    DOCKER_LOGIN:
+      from_secret: docker_login
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+  image: docker:windowsservercore-1809
+  name: Build
+  volumes:
+  - name: docker
+    path: //./pipe/docker_engine/
+trigger:
+  event:
+  - tag
+  ref:
+  - refs/tags/build-image/v*
+type: docker
+volumes:
+- host:
+    path: //./pipe/docker_engine/
+  name: docker
+---
+kind: pipeline
 name: Lint
 platform:
   arch: amd64
@@ -565,6 +667,6 @@ kind: secret
 name: updater_private_key
 ---
 kind: signature
-hmac: 3484a2c2210641cb0e653616c7100ec52f49cb68c7f20647248de013e0da1826
+hmac: b8a4493d643d2f8f0f8fac5bfa627473eb28219f7a6e6a623366c35b7e549e08
 
 ...

--- a/.drone/pipelines/build_images.jsonnet
+++ b/.drone/pipelines/build_images.jsonnet
@@ -20,7 +20,6 @@ local locals = {
   // TODO(rfratto): The following are temporarily diasbled as grafana/alloy
   // gets set up.
 
-  /*
   pipelines.linux('Create Linux build image') {
     trigger: locals.on_build_image_tag,
     steps: [{
@@ -36,7 +35,7 @@ local locals = {
         'docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD',
         'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes',
         'docker buildx create --name multiarch --driver docker-container --use',
-        'docker buildx build --build-arg="GO_RUNTIME=golang:1.22.1-bullseye" --push --platform linux/amd64,linux/arm64 -t grafana/agent-build-image:$IMAGE_TAG ./tools/build-image',
+        'docker buildx build --build-arg="GO_RUNTIME=golang:1.22.1-bullseye" --push --platform linux/amd64,linux/arm64 -t grafana/alloy-build-image:$IMAGE_TAG ./tools/build-image',
       ],
     }],
     volumes: [{
@@ -59,14 +58,14 @@ local locals = {
         'docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD',
         'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes',
         'docker buildx create --name multiarch --driver docker-container --use',
-        'docker buildx build --build-arg="GO_RUNTIME=mcr.microsoft.com/oss/go/microsoft/golang:1.22.1-bullseye" --push --platform linux/amd64,linux/arm64 -t grafana/agent-build-image:$IMAGE_TAG ./tools/build-image',
+        'docker buildx build --build-arg="GO_RUNTIME=mcr.microsoft.com/oss/go/microsoft/golang:1.22.1-bullseye" --push --platform linux/amd64,linux/arm64 -t grafana/alloy-build-image:$IMAGE_TAG ./tools/build-image',
       ],
     }],
     volumes: [{
       name: 'docker',
       host: { path: '/var/run/docker.sock' },
     }],
-   },
+  },
 
   pipelines.windows('Create Windows build image') {
     trigger: locals.on_build_image_tag,
@@ -83,8 +82,8 @@ local locals = {
         // and not by Windows (where the syntax obviously wouldn't work).
         '$IMAGE_TAG="${DRONE_TAG##build-image/v}-windows"',
         'docker login -u $Env:DOCKER_LOGIN -p $Env:DOCKER_PASSWORD',
-        'docker build -t grafana/agent-build-image:$IMAGE_TAG ./tools/build-image/windows',
-        'docker push grafana/agent-build-image:$IMAGE_TAG',
+        'docker build -t grafana/alloy-build-image:$IMAGE_TAG ./tools/build-image/windows',
+        'docker push grafana/alloy-build-image:$IMAGE_TAG',
       ],
     }],
     volumes: [{
@@ -92,5 +91,4 @@ local locals = {
       host: { path: '//./pipe/docker_engine/' },
     }],
   },
-  */
 ]

--- a/.drone/pipelines/build_images.jsonnet
+++ b/.drone/pipelines/build_images.jsonnet
@@ -31,7 +31,7 @@ local locals = {
       }],
       environment: locals.docker_environment,
       commands: [
-        'export IMAGE_TAG=${DRONE_TAG##build-image/v}',
+        'export IMAGE_TAG=${DRONE_TAG##build-image/}',
         'docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD',
         'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes',
         'docker buildx create --name multiarch --driver docker-container --use',
@@ -54,7 +54,7 @@ local locals = {
       }],
       environment: locals.docker_environment,
       commands: [
-        'export IMAGE_TAG=${DRONE_TAG##build-image/v}-boringcrypto',
+        'export IMAGE_TAG=${DRONE_TAG##build-image/}-boringcrypto',
         'docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD',
         'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes',
         'docker buildx create --name multiarch --driver docker-container --use',
@@ -80,7 +80,7 @@ local locals = {
       commands: [
         // NOTE(rfratto): the variable syntax is parsed ahead of time by Drone,
         // and not by Windows (where the syntax obviously wouldn't work).
-        '$IMAGE_TAG="${DRONE_TAG##build-image/v}-windows"',
+        '$IMAGE_TAG="${DRONE_TAG##build-image/}-windows"',
         'docker login -u $Env:DOCKER_LOGIN -p $Env:DOCKER_PASSWORD',
         'docker build -t grafana/alloy-build-image:$IMAGE_TAG ./tools/build-image/windows',
         'docker push grafana/alloy-build-image:$IMAGE_TAG',

--- a/tools/build-image/README.md
+++ b/tools/build-image/README.md
@@ -5,23 +5,19 @@ Grafana Alloy.
 
 There are two images:
 
-* `grafana/alloy-build-image:X.Y.Z` (for building Linux containers)
-* `grafana/alloy-build-image:X.Y.Z-windows` (for building Windows containers)
+* `grafana/alloy-build-image:vX.Y.Z` (for building Linux containers)
+* `grafana/alloy-build-image:vX.Y.Z-windows` (for building Windows containers)
 
-(Where `X.Y.Z` is replaced with some semantic version, like 0.14.0).
+(Where `X.Y.Z` is replaced with some semantic version, like 0.1.0).
 
 ## Pushing new images
 
 Once a commit is merged to main which updates the build-image Dockerfiles, a
 maintainer must push a tag matching the pattern `build-image/vX.Y.Z` to the
-grafana/alloy repo. For example, to create version v0.15.0 of the build images,
-a maintainer would push the tag `build-image/v0.15.0`.
-
-> **NOTE**: The tag name is expected to be prefixed with `v`, but the pushed
-> images have the v prefix removed.
+grafana/alloy repo. For example, to create version v0.1.0 of the build images,
+a maintainer would push the tag `build-image/v0.1.0`.
 
 Automation will trigger off of this tag being pushed, building and pushing the
 new build images to Docker Hub.
 
 A follow-up commit to use the newly pushed build images must be made.
-

--- a/tools/build-image/README.md
+++ b/tools/build-image/README.md
@@ -3,9 +3,10 @@
 The Grafana Alloy build images are used for CI workflows to manage builds of
 Grafana Alloy.
 
-There are two images:
+There are the following images:
 
 * `grafana/alloy-build-image:vX.Y.Z` (for building Linux containers)
+* `grafana/alloy-build-image:vX.Y.Z-boringcrypto` (for building Linux containers with boringcrypto)
 * `grafana/alloy-build-image:vX.Y.Z-windows` (for building Windows containers)
 
 (Where `X.Y.Z` is replaced with some semantic version, like 0.1.0).


### PR DESCRIPTION
This PR restores the ability to push build images for Alloy with images called `grafana/alloy-build-image`. 

Unlike `grafana/agent-build-image`, the `v` prefix is added to tag names to align with all other images pushed within the Alloy project.