### PR TITLE
alloy-mixin: add `alloy_` prefix to all alert group names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Main (unreleased)
   * show the offset/lag for all consumer group or only the connected ones
   * set the minimum number of topics to monitor
   * enable/disable auto-creation of requested topics if they don't already exist
-  * regex to exclude topics / groups 
+  * regex to exclude topics / groups
   * added metric kafka_broker_info
 
 - In `prometheus.exporter.kafka`, the interpolation table used to compute estimated lag metrics is now pruned
@@ -32,8 +32,13 @@ Main (unreleased)
 - Fix an issue on Windows where uninstalling Alloy did not remove it from the
   Add/Remove programs list. (@rfratto)
 
-
 - Fixed issue where text labels displayed outside of component node's boundary. (@hainenber)
+
+### Other changes
+
+- Update `alloy-mixin` to use more specific alert group names (for example,
+  `alloy_clustering` instead of `clustering`) to avoid collision with installs
+  of `agent-flow-mixin`. (@rfratto)
 
 v1.0.0 (2024-04-09)
 -------------------

--- a/operations/alloy-mixin/alerts/clustering.libsonnet
+++ b/operations/alloy-mixin/alerts/clustering.libsonnet
@@ -1,7 +1,7 @@
 local alert = import './utils/alert.jsonnet';
 
 alert.newGroup(
-  'clustering',
+  'alloy_clustering',
   [
     // Cluster not converging.
     alert.newRule(

--- a/operations/alloy-mixin/alerts/opentelemetry.libsonnet
+++ b/operations/alloy-mixin/alerts/opentelemetry.libsonnet
@@ -1,7 +1,7 @@
 local alert = import './utils/alert.jsonnet';
 
 alert.newGroup(
-  'otelcol',
+  'alloy_otelcol',
   [
     // An otelcol.exporter component rcould not push some spans to the pipeline.
     // This could be due to reaching a limit such as the ones


### PR DESCRIPTION
This avoids a potential collision when installing `alloy-mixin` alongside `agent-flow-mixin`.