### PR TITLE
chore(doc): correct value to disable `max_recv_msg_size` for otelcol components

### DIFF
--- a/docs/sources/reference/components/otelcol.extension.jaeger_remote_sampling.md
+++ b/docs/sources/reference/components/otelcol.extension.jaeger_remote_sampling.md
@@ -115,7 +115,7 @@ Name                     | Type      | Description                              
 -------------------------|-----------|----------------------------------------------------------------------------|-------------------|---------
 `endpoint`               | `string`  | `host:port` to listen for traffic on.                                      | `"0.0.0.0:14250"` | no
 `transport`              | `string`  | Transport to use for the gRPC server.                                      | `"tcp"`           | no
-`max_recv_msg_size`      | `string`  | Maximum size of messages the server will accept. 0 disables a limit.       |                   | no
+`max_recv_msg_size`      | `string`  | Maximum size of messages the server will accept. `"0KiB"` disables the limit.       |                   | no
 `max_concurrent_streams` | `number`  | Limit the number of concurrent streaming RPC calls.                        |                   | no
 `read_buffer_size`       | `string`  | Size of the read buffer the gRPC server will use for reading from clients. | `"512KiB"`        | no
 `write_buffer_size`      | `string`  | Size of the write buffer the gRPC server will use for writing to clients.  |                   | no

--- a/docs/sources/reference/components/otelcol.receiver.jaeger.md
+++ b/docs/sources/reference/components/otelcol.receiver.jaeger.md
@@ -99,7 +99,7 @@ Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `endpoint` | `string` | `host:port` to listen for traffic on. | `"0.0.0.0:14250"` | no
 `transport` | `string` | Transport to use for the gRPC server. | `"tcp"` | no
-`max_recv_msg_size` | `string` | Maximum size of messages the server will accept. 0 disables a limit. | | no
+`max_recv_msg_size` | `string` | Maximum size of messages the server will accept. `"0KiB"` disables the limit. | | no
 `max_concurrent_streams` | `number` | Limit the number of concurrent streaming RPC calls. | | no
 `read_buffer_size` | `string` | Size of the read buffer the gRPC server will use for reading from clients. | `"512KiB"` | no
 `write_buffer_size` | `string` | Size of the write buffer the gRPC server will use for writing to clients. | | no

--- a/docs/sources/reference/components/otelcol.receiver.opencensus.md
+++ b/docs/sources/reference/components/otelcol.receiver.opencensus.md
@@ -40,7 +40,7 @@ Name | Type | Description | Default | Required
 `cors_allowed_origins` | `list(string)` | A list of allowed Cross-Origin Resource Sharing (CORS) origins. |  | no
 `endpoint` | `string` | `host:port` to listen for traffic on. | `"0.0.0.0:55678"` | no
 `transport` | `string` | Transport to use for the gRPC server. | `"tcp"` | no
-`max_recv_msg_size` | `string` | Maximum size of messages the server will accept. 0 disables a limit. | | no
+`max_recv_msg_size` | `string` | Maximum size of messages the server will accept. `"0KiB"` disables the limit. | | no
 `max_concurrent_streams` | `number` | Limit the number of concurrent streaming RPC calls. | | no
 `read_buffer_size` | `string` | Size of the read buffer the gRPC server will use for reading from clients. | `"512KiB"` | no
 `write_buffer_size` | `string` | Size of the write buffer the gRPC server will use for writing to clients. | | no

--- a/docs/sources/reference/components/otelcol.receiver.otlp.md
+++ b/docs/sources/reference/components/otelcol.receiver.otlp.md
@@ -78,7 +78,7 @@ Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `endpoint` | `string` | `host:port` to listen for traffic on. | `"0.0.0.0:4317"` | no
 `transport` | `string` | Transport to use for the gRPC server. | `"tcp"` | no
-`max_recv_msg_size` | `string` | Maximum size of messages the server will accept. 0 disables a limit. | | no
+`max_recv_msg_size` | `string` | Maximum size of messages the server will accept. `"0KiB"` disables the limit. | | no
 `max_concurrent_streams` | `number` | Limit the number of concurrent streaming RPC calls. | | no
 `read_buffer_size` | `string` | Size of the read buffer the gRPC server will use for reading from clients. | `"512KiB"` | no
 `write_buffer_size` | `string` | Size of the write buffer the gRPC server will use for writing to clients. | | no


### PR DESCRIPTION


<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #622 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

