### PR TITLE
misc: switch to using a GitHub app for Helm chart releases

### DIFF
--- a/.drone/pipelines/build_images.jsonnet
+++ b/.drone/pipelines/build_images.jsonnet
@@ -17,9 +17,6 @@ local locals = {
 };
 
 [
-  // TODO(rfratto): The following are temporarily diasbled as grafana/alloy
-  // gets set up.
-
   pipelines.linux('Create Linux build image') {
     trigger: locals.on_build_image_tag,
     steps: [{

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -63,6 +63,12 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.setup.outputs.changed == 'true'
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.ALLOYBOT_APP_ID }}
+          private-key: ${{ secrets.ALLOYBOT_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -81,7 +87,7 @@ jobs:
           fetch-depth: 0
           repository: grafana/helm-charts
           path: helm-charts
-          token: "${{ secrets.GH_BOT_ACCESS_TOKEN }}"
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure Git for helm-charts
         run: |
@@ -138,7 +144,7 @@ jobs:
           name: ${{ steps.parse-chart.outputs.packagename }}
           repository: grafana/helm-charts
           tag_name: ${{ steps.parse-chart.outputs.packagename }}
-          token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           body: |
             ${{ steps.parse-chart.outputs.desc }}
 
@@ -157,4 +163,4 @@ jobs:
       - name: Update helm-charts index.yaml
         run: |
           cd helm-charts
-          "${CR_TOOL_PATH}/cr" index --config "${CR_CONFIGFILE}" --token "${{ secrets.GH_BOT_ACCESS_TOKEN }}" --index-path "${CR_INDEX_PATH}" --package-path "${CR_PACKAGE_PATH}" --push
+          "${CR_TOOL_PATH}/cr" index --config "${CR_CONFIGFILE}" --token "${{ steps.app-token.outputs.token }}" --index-path "${CR_INDEX_PATH}" --package-path "${CR_PACKAGE_PATH}" --push


### PR DESCRIPTION
This switches to using [grafana-alloybot] for Helm chart releases instead of the temporary PAT used for the initial release.

The secrets used by the workflow have been added to the repository already.

[grafana-alloybot]: https://github.com/apps/grafana-alloybot