### PR TITLE
build: add a description to generated DEB/RPM packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ Main (unreleased)
   `alloy_clustering` instead of `clustering`) to avoid collision with installs
   of `agent-flow-mixin`. (@rfratto)
 
+- Add a description to Alloy DEB and RPM packages. (@rfratto)
+
 v1.0.0 (2024-04-09)
 -------------------
 

--- a/tools/make/packaging.mk
+++ b/tools/make/packaging.mk
@@ -120,6 +120,7 @@ define generate_alloy_fpm =
 		--license "Apache 2.0" \
 		--vendor "Grafana Labs" \
 		--url "https://github.com/grafana/alloy" \
+		--description "Grafana Alloy is an OpenTelemetry Collector distribution with programmable pipelines." \
 		--rpm-digest sha256 \
 		-t $(1) \
 		--after-install packaging/$(1)/control/postinst \


### PR DESCRIPTION
Closes #636. 

I looked at the list of other [flags](https://fpm.readthedocs.io/en/latest/cli-reference.html) FPM exposes to us to see if anything else looked particularly interesting, but nothing stood out to me as useful for making it easier to identify what the `alloy` package is. 