### PR TITLE
Sum in alerts by cluster and namespace

### DIFF
--- a/operations/alloy-mixin/alerts/opentelemetry.libsonnet
+++ b/operations/alloy-mixin/alerts/opentelemetry.libsonnet
@@ -8,7 +8,7 @@ alert.newGroup(
     // imposed by otelcol.processor.memory_limiter.
     alert.newRule(
       'OtelcolReceiverRefusedSpans',
-      'sum(rate(receiver_refused_spans_ratio_total{}[1m])) > 0',
+      'sum by (cluster, namespace) (rate(receiver_refused_spans_ratio_total{}[1m])) > 0',
       'The receiver could not push some spans to the pipeline.',
       '5m',
     ),
@@ -17,7 +17,7 @@ alert.newGroup(
     // There could be an issue with the payload or with the destination endpoint.
     alert.newRule(
       'OtelcolExporterFailedSpans',
-      'sum(rate(exporter_send_failed_spans_ratio_total{}[1m])) > 0',
+      'sum by (cluster, namespace) (rate(exporter_send_failed_spans_ratio_total{}[1m])) > 0',
       'The exporter failed to send spans to their destination.',
       '5m',
     ),


### PR DESCRIPTION
It is a convention in Alloy alerts to sum by at least `cluster` and `namespace`, and it also makes the alerts more useful.