### PR TITLE
mimir.rules.kubernetes: Add warning about clustering to docs

### DIFF
--- a/docs/sources/reference/components/mimir.rules.kubernetes.md
+++ b/docs/sources/reference/components/mimir.rules.kubernetes.md
@@ -24,6 +24,12 @@ in Kubernetes in order for {{< param "PRODUCT_NAME" >}} to access it via the Kub
 [Role-based access control (RBAC)]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 {{< /admonition >}}
 
+{{< admonition type="warning" >}}
+This component does not support [clustered mode][] and must be run in a separate single-instance deployment of {{< param "PRODUCT_NAME" >}}.
+
+[clustered mode]: ../../../concepts/clustering/
+{{< /admonition >}}
+
 [Kubernetes label selectors]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
 [prometheus-operator]: https://prometheus-operator.dev/
 [within a Pod]: https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/

--- a/docs/sources/reference/components/mimir.rules.kubernetes.md
+++ b/docs/sources/reference/components/mimir.rules.kubernetes.md
@@ -25,7 +25,10 @@ in Kubernetes in order for {{< param "PRODUCT_NAME" >}} to access it via the Kub
 {{< /admonition >}}
 
 {{< admonition type="warning" >}}
-This component does not support [clustered mode][] and must be run in a separate single-instance deployment of {{< param "PRODUCT_NAME" >}}.
+This component does not support [clustered mode][]. Using this component as part of a cluster of 
+{{< param "PRODUCT_NAME" >}} instances will cause them to all attempt to update rules using the
+Mimir API, conflicting with each other. When using this component, it must be run in a separate
+single-instance deployment of {{< param "PRODUCT_NAME" >}}.
 
 [clustered mode]: ../../../concepts/clustering/
 {{< /admonition >}}


### PR DESCRIPTION
#### PR Description

The component doesn't support running in clustered mode. When multiple clustered Alloy instances run the component, they will end up conflicting with each other making API requests to the Mimir ruler.

#### Which issue(s) this PR fixes

N/A

#### Notes to the Reviewer

N/A

#### PR Checklist

- [X] Documentation added
