### PR TITLE
tools: fix incompatibilities between normal and alpine sh

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -518,9 +518,9 @@ platform:
   os: linux
 steps:
 - commands:
-  - apk update && apk add git
-  - echo "$(sh ./tools/image-tag-docker)" > .tag-only
-  - echo "grafana/alloy-dev:$(sh ./tools/image-tag-docker)" > .image-tag
+  - apk add --no-cache bash git
+  - echo "$(bash ./tools/image-tag-docker)" > .tag-only
+  - echo "grafana/alloy-dev:$(bash ./tools/image-tag-docker)" > .image-tag
   image: alpine
   name: Create .image-tag
 - image: us.gcr.io/kubernetes-dev/drone/plugins/updater
@@ -713,6 +713,6 @@ kind: secret
 name: updater_private_key
 ---
 kind: signature
-hmac: 478adbeda3c0ad620fbeb8eca6aa976709b6d9e71451644663a3c4362380df69
+hmac: eef3ddde1e027f6c8c113bf748036cb79961708262d651193c231096cda5260d
 
 ...

--- a/.drone/pipelines/publish.jsonnet
+++ b/.drone/pipelines/publish.jsonnet
@@ -184,9 +184,9 @@ linux_containers_jobs + windows_containers_jobs + [
         name: 'Create .image-tag',
         image: 'alpine',
         commands: [
-          'apk update && apk add git',
-          'echo "$(sh ./tools/image-tag-docker)" > .tag-only',
-          'echo "grafana/alloy-dev:$(sh ./tools/image-tag-docker)" > .image-tag',
+          'apk add --no-cache bash git',
+          'echo "$(bash ./tools/image-tag-docker)" > .tag-only',
+          'echo "grafana/alloy-dev:$(bash ./tools/image-tag-docker)" > .image-tag',
         ],
       },
       {

--- a/tools/image-tag
+++ b/tools/image-tag
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 #
 # image-tag determines which version to embed into a built image.
 #

--- a/tools/image-tag-docker
+++ b/tools/image-tag-docker
@@ -1,7 +1,7 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 #
 # image-tag-docker runs ./tools/image-tag but sanitizes invalid characters
 # for use in Docker image tags.
 
-TAG=$(sh ./tools/image-tag)
+TAG=$(/usr/bin/env bash ./tools/image-tag)
 echo ${TAG//+/-}


### PR DESCRIPTION
`sh` (as executed by Alpine) understands `set -o pipefail`, but other installations of sh do not.

This commit partially reverts the change from #640 so that the scripts expect bash, and that our usage of alpine installs bash before executing the tools/image-tag-docker script.