### PR TITLE
tools/ci: fix issue where Docker containers reported invalid semantic versions

### DIFF
--- a/tools/ci/docker-containers
+++ b/tools/ci/docker-containers
@@ -27,10 +27,14 @@ export DEVEL_ALLOY_IMAGE=grafana/alloy-dev
 if [ -n "$DRONE_TAG" ]; then
   VERSION=$DRONE_TAG
 else
-  VERSION=$(./tools/image-tag-docker)
+  # NOTE(rfratto): Do not use ./tools/image-tag-docker here, which doesn't
+  # produce valid semver.
+  VERSION=$(./tools/image-tag)
 fi
 
-# The TAG_VERSION is the version to use for the Docker tag.
+# The TAG_VERSION is the version to use for the Docker tag. It is sanitized to
+# force it to be a valid Docker tag name (primarily by removing the +
+# characters that may have been emitted by ./tools/image-tag).
 TAG_VERSION=${VERSION//+/-}
 
 # We also need to know which "branch tag" to update. Branch tags are used as a

--- a/tools/ci/docker-containers-windows
+++ b/tools/ci/docker-containers-windows
@@ -22,11 +22,15 @@ export DEVEL_ALLOY_IMAGE=grafana/alloy-dev
 if [ -n "$DRONE_TAG" ]; then
   VERSION=$DRONE_TAG
 else
-  VERSION=$(./tools/image-tag-docker)
+  # NOTE(rfratto): Do not use ./tools/image-tag-docker here, which doesn't
+  # produce valid semver.
+  VERSION=$(./tools/image-tag)
 fi
 
-# The VERSION_TAG is the version to use for the Docker tag.
-VERSION_TAG=${VERSION}-nanoserver-1809
+# The VERSION_TAG is the version to use for the Docker tag. It is sanitized to
+# force it to be a valid Docker tag name (primarily by removing the +
+# characters that may have been emitted by ./tools/image-tag).
+VERSION_TAG=${VERSION//+/-}-nanoserver-1809
 
 # We also need to know which "branch tag" to update. Branch tags are used as a
 # secondary tag for Docker containers. The branch tag is "latest" when being


### PR DESCRIPTION
PR #640 neglected to notice that using Docker-compatible tag names overwrote the behavior for the version baked into the binary, causing binaries to start reporting invalid semantic version strings.

This commit undoes the changes to tools/ci introduced in #640 in favour of the original approach. 