### PR TITLE
pyroscope.java: Add glibc detection for arm64

### DIFF
--- a/internal/component/pyroscope/java/asprof/asprof.go
+++ b/internal/component/pyroscope/java/asprof/asprof.go
@@ -184,6 +184,9 @@ func isGlibcMapping(m *procfs.ProcMap) bool {
 	if strings.Contains(m.Pathname, "x86_64-linux-gnu/libc-") {
 		return true
 	}
+	if strings.Contains(m.Pathname, "aarch64-linux-gnu/libc-") {
+		return true
+	}
 	return false
 }
 


### PR DESCRIPTION
This PR makes sure glibc is also detected correctly on ARM64 linux.