### PR TITLE
tools/ci: fix pushed Windows "latest" name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ Main (unreleased)
 
 - Add a description to Alloy DEB and RPM packages. (@rfratto)
 
+- The latest Windows Docker image is now pushed as `nanoserver-1809` instead of
+  `latest-nanoserver-1809`. The old tag will no longer be updated, and will be
+  removed in a future release. (@rfratto)
+
 v1.0.0 (2024-04-09)
 -------------------
 

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@
 include tools/make/*.mk
 
 ALLOY_IMAGE          ?= grafana/alloy:latest
-ALLOY_IMAGE_WINDOWS  ?= grafana/alloy:latest-nanoserver-1809
+ALLOY_IMAGE_WINDOWS  ?= grafana/alloy:nanoserver-1809
 ALLOY_BINARY         ?= build/alloy
 SERVICE_BINARY       ?= build/alloy-service
 ALLOYLINT_BINARY     ?= build/alloylint

--- a/docs/sources/get-started/install/docker.md
+++ b/docs/sources/get-started/install/docker.md
@@ -58,7 +58,7 @@ To run {{< param "PRODUCT_NAME" >}} as a Windows Docker container, run the follo
 docker run \
   -v "<CONFIG_FILE_PATH>:C:\Program Files\GrafanaLabs\Alloy\config.alloy" \
   -p 12345:12345 \
-  grafana/alloy:latest-nanoserver-1809 \
+  grafana/alloy:nanoserver-1809 \
     run --server.http.listen-addr=0.0.0.0:12345 "--storage.path=C:\ProgramData\GrafanaLabs\Alloy\data" \
     "C:\Program Files\GrafanaLabs\Alloy\config.alloy"
 ```

--- a/tools/ci/docker-containers-windows
+++ b/tools/ci/docker-containers-windows
@@ -40,8 +40,8 @@ VERSION_TAG=${VERSION//+/-}-nanoserver-1809
 # If we're not running from drone, we'll set the branch tag to match the
 # version. This effectively acts as a no-op because it will tag the same Docker
 # image twice.
-if [[ -n "$DRONE_TAG" && "$DRONE_TAG" != *"-rc."* ]] || [[ "$TARGET_CONTAINER" == *"-devel" ]]; then
-  BRANCH_TAG=latest-nanoserver-1809
+if [[ -n "$DRONE_TAG" && "$DRONE_TAG" != *"-rc."* ]] || [[ "$TARGET_CONTAINER" == *"-devel"* ]]; then
+  BRANCH_TAG=nanoserver-1809
 else
   BRANCH_TAG=$VERSION_TAG
 fi


### PR DESCRIPTION
The latest image for the Winows container was intended to be `nanoserver-1809`, but instead we were pushing `latest-nanoserver-1809`.

If we decide to merge this, I will manually create a `nanoserver-1809` tag to point to `v1.0.0-nanoserver-1809`, and leave the old tag intact until it is removed at a to-be-determined future date.

Fixes #664.