### PR TITLE
[release/v1.0] tools/ci: fix pushed Windows "latest" name (#665)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ This document contains a historical list of changes between releases. Only
 changes that impact end-user behavior are listed; changes to documentation or
 internal API changes are not present.
 
+Main (unreleased)
+-----------------
+
+### Other changes
+
+- The latest Windows Docker image is now pushed as `nanoserver-1809` instead of
+  `latest-nanoserver-1809`. The old tag will no longer be updated, and will be
+  removed in a future release. (@rfratto)
+
 v1.0.0 (2024-04-09)
 -------------------
 

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@
 include tools/make/*.mk
 
 ALLOY_IMAGE          ?= grafana/alloy:latest
-ALLOY_IMAGE_WINDOWS  ?= grafana/alloy:latest-nanoserver-1809
+ALLOY_IMAGE_WINDOWS  ?= grafana/alloy:nanoserver-1809
 ALLOY_BINARY         ?= build/alloy
 SERVICE_BINARY       ?= build/alloy-service
 ALLOYLINT_BINARY     ?= build/alloylint

--- a/docs/sources/get-started/install/docker.md
+++ b/docs/sources/get-started/install/docker.md
@@ -58,7 +58,7 @@ To run {{< param "PRODUCT_NAME" >}} as a Windows Docker container, run the follo
 docker run \
   -v "<CONFIG_FILE_PATH>:C:\Program Files\GrafanaLabs\Alloy\config.alloy" \
   -p 12345:12345 \
-  grafana/alloy:latest-nanoserver-1809 \
+  grafana/alloy:nanoserver-1809 \
     run --server.http.listen-addr=0.0.0.0:12345 "--storage.path=C:\ProgramData\GrafanaLabs\Alloy\data" \
     "C:\Program Files\GrafanaLabs\Alloy\config.alloy"
 ```

--- a/tools/ci/docker-containers-windows
+++ b/tools/ci/docker-containers-windows
@@ -39,7 +39,7 @@ VERSION_TAG=${VERSION//+/-}-nanoserver-1809
 # version. This effectively acts as a no-op because it will tag the same Docker
 # image twice.
 if [ -n "$DRONE_TAG" ] && [[ "$DRONE_TAG" != *"-rc."* ]]; then
-  BRANCH_TAG=latest-nanoserver-1809
+  BRANCH_TAG=nanoserver-1809
 else
   BRANCH_TAG=$VERSION_TAG
 fi


### PR DESCRIPTION
The latest image for the Winows container was intended to be `nanoserver-1809`, but instead we were pushing `latest-nanoserver-1809`.

I've manually created the appropriate tag, and left the old tag intact. We should remove the incorrect tag at a to-be-determined future date.

Fixes #664.

(cherry picked from commit 2bbb096ee8c8dbab49c8f2ed4502a0ebc06ba29b)