### PR TITLE
mimir.rules.kubernetes: Add support for clustered mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ Main (unreleased)
 - Don't restart tailers in `loki.source.kubernetes` component by above-average
   time deltas if K8s version is >= 1.29.1 (@hainenber)
 
+- In `mimir.rules.kubernetes`, add support for running in a cluster of Alloy instances
+  by electing a single instance as the leader for the `mimir.rules.kubernetes` component
+  to avoid conflicts when making calls to the Mimir API. (@56quarters)
+
 ### Bugfixes
 
 - Fixed issue with defaults for Beyla component not being applied correctly. (marctc)

--- a/docs/sources/reference/components/mimir.rules.kubernetes.md
+++ b/docs/sources/reference/components/mimir.rules.kubernetes.md
@@ -24,15 +24,6 @@ in Kubernetes in order for {{< param "PRODUCT_NAME" >}} to access it via the Kub
 [Role-based access control (RBAC)]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 {{< /admonition >}}
 
-{{< admonition type="warning" >}}
-This component does not support [clustered mode][]. Using this component as part of a cluster of 
-{{< param "PRODUCT_NAME" >}} instances will cause them to all attempt to update rules using the
-Mimir API, conflicting with each other. When using this component, it must be run in a separate
-single-instance deployment of {{< param "PRODUCT_NAME" >}}.
-
-[clustered mode]: ../../../concepts/clustering/
-{{< /admonition >}}
-
 [Kubernetes label selectors]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
 [prometheus-operator]: https://prometheus-operator.dev/
 [within a Pod]: https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/

--- a/docs/sources/reference/components/mimir.rules.kubernetes.md
+++ b/docs/sources/reference/components/mimir.rules.kubernetes.md
@@ -25,7 +25,7 @@ in Kubernetes in order for {{< param "PRODUCT_NAME" >}} to access it via the Kub
 {{< /admonition >}}
 
 {{< admonition type="note" >}}
-Since version 1.1, this component supports [clustered mode][]. When using this component as part
+{{< param "PRODUCT_NAME" >}} version 1.1 and higher supports [clustered mode][] in this component. When you use this component as part
 of a cluster of {{< param "PRODUCT_NAME" >}} instances, only a single instance from the cluster
 will update rules using the Mimir API.
 

--- a/docs/sources/reference/components/mimir.rules.kubernetes.md
+++ b/docs/sources/reference/components/mimir.rules.kubernetes.md
@@ -24,6 +24,14 @@ in Kubernetes in order for {{< param "PRODUCT_NAME" >}} to access it via the Kub
 [Role-based access control (RBAC)]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 {{< /admonition >}}
 
+{{< admonition type="note" >}}
+Since version 1.1, this component supports [clustered mode][]. When using this component as part
+of a cluster of {{< param "PRODUCT_NAME" >}} instances, only a single instance from the cluster
+will update rules using the Mimir API.
+
+[clustered mode]: ../../../concepts/clustering/
+{{< /admonition >}}
+
 [Kubernetes label selectors]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
 [prometheus-operator]: https://prometheus-operator.dev/
 [within a Pod]: https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/

--- a/internal/component/mimir/rules/kubernetes/events.go
+++ b/internal/component/mimir/rules/kubernetes/events.go
@@ -25,15 +25,6 @@ const (
 	eventTypeSyncMimir kubernetes.EventType = "sync-mimir"
 )
 
-// healthReporter allows the eventProcessor to mark the owning component as healthy
-// or unhealthy. This interface allows for easier testing of the eventProcessor.
-type healthReporter interface {
-	// reportUnhealthy marks the owning component as unhealthy
-	reportUnhealthy(err error)
-	// reportHealthy marks the owning component as healthy
-	reportHealthy()
-}
-
 type eventProcessor struct {
 	queue    workqueue.RateLimitingInterface
 	stopChan chan struct{}

--- a/internal/component/mimir/rules/kubernetes/events_test.go
+++ b/internal/component/mimir/rules/kubernetes/events_test.go
@@ -37,7 +37,7 @@ func newFakeMimirClient() *fakeMimirClient {
 	}
 }
 
-func (m *fakeMimirClient) CreateRuleGroup(ctx context.Context, namespace string, rule rulefmt.RuleGroup) error {
+func (m *fakeMimirClient) CreateRuleGroup(_ context.Context, namespace string, rule rulefmt.RuleGroup) error {
 	m.rulesMut.Lock()
 	defer m.rulesMut.Unlock()
 	m.deleteLocked(namespace, rule.Name)
@@ -45,7 +45,7 @@ func (m *fakeMimirClient) CreateRuleGroup(ctx context.Context, namespace string,
 	return nil
 }
 
-func (m *fakeMimirClient) DeleteRuleGroup(ctx context.Context, namespace, group string) error {
+func (m *fakeMimirClient) DeleteRuleGroup(_ context.Context, namespace, group string) error {
 	m.rulesMut.Lock()
 	defer m.rulesMut.Unlock()
 	m.deleteLocked(namespace, group)
@@ -71,7 +71,7 @@ func (m *fakeMimirClient) deleteLocked(namespace, group string) {
 	}
 }
 
-func (m *fakeMimirClient) ListRules(ctx context.Context, namespace string) (map[string][]rulefmt.RuleGroup, error) {
+func (m *fakeMimirClient) ListRules(_ context.Context, namespace string) (map[string][]rulefmt.RuleGroup, error) {
 	m.rulesMut.RLock()
 	defer m.rulesMut.RUnlock()
 	output := make(map[string][]rulefmt.RuleGroup)
@@ -83,12 +83,6 @@ func (m *fakeMimirClient) ListRules(ctx context.Context, namespace string) (map[
 	}
 	return output, nil
 }
-
-type fakeHealthReporter struct{}
-
-func (f fakeHealthReporter) reportUnhealthy(error) {}
-
-func (f fakeHealthReporter) reportHealthy() {}
 
 func TestEventLoop(t *testing.T) {
 	nsIndexer := cache.NewIndexer(

--- a/internal/component/mimir/rules/kubernetes/rules_test.go
+++ b/internal/component/mimir/rules/kubernetes/rules_test.go
@@ -1,9 +1,21 @@
 package rules
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/go-kit/log"
+	"github.com/grafana/alloy/internal/component"
+	"github.com/grafana/alloy/internal/service/cluster"
 	"github.com/grafana/alloy/syntax"
+	"github.com/grafana/ckit/peer"
+	"github.com/grafana/ckit/shard"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,4 +44,296 @@ func TestBadAlloyConfig(t *testing.T) {
 	var args Arguments
 	err := syntax.Unmarshal([]byte(exampleAlloyConfig), &args)
 	require.ErrorContains(t, err, "at most one of basic_auth, authorization, oauth2, bearer_token & bearer_token_file must be configured")
+}
+
+type fakeCluster struct{}
+
+func (f fakeCluster) Lookup(shard.Key, int, shard.Op) ([]peer.Peer, error) {
+	return nil, nil
+}
+
+func (f fakeCluster) Peers() []peer.Peer {
+	return nil
+}
+
+type fakeLeadership struct {
+	leader    bool
+	changed   bool
+	updateErr error
+}
+
+func (f *fakeLeadership) update() (bool, error) {
+	return f.changed, f.updateErr
+}
+
+func (f *fakeLeadership) isLeader() bool {
+	return f.leader
+}
+
+type fakeLifecycle struct {
+	updateCalled    atomic.Bool
+	startupCalled   atomic.Bool
+	restartCalled   atomic.Bool
+	shutdownCalled  atomic.Bool
+	syncStateCalled atomic.Bool
+
+	startupErr error
+	restartErr error
+}
+
+func (f *fakeLifecycle) update(Arguments) {
+	f.updateCalled.Store(true)
+}
+
+func (f *fakeLifecycle) startup(context.Context) error {
+	f.startupCalled.Store(true)
+	return f.startupErr
+}
+
+func (f *fakeLifecycle) restart(context.Context) error {
+	f.restartCalled.Store(true)
+	return f.restartErr
+}
+
+func (f *fakeLifecycle) shutdown() {
+	f.shutdownCalled.Store(true)
+}
+
+func (f *fakeLifecycle) syncState() {
+	f.syncStateCalled.Store(true)
+}
+
+type fakeHealthReporter struct {
+	mtx sync.Mutex
+	err error
+}
+
+func (f *fakeHealthReporter) reportUnhealthy(err error) {
+	f.mtx.Lock()
+	f.err = err
+	f.mtx.Unlock()
+}
+
+func (f *fakeHealthReporter) reportHealthy() {
+	f.mtx.Lock()
+	f.err = nil
+	f.mtx.Unlock()
+}
+
+func (f *fakeHealthReporter) getErr() error {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	return f.err
+}
+
+func newComponentForTesting(t *testing.T, reg prometheus.Registerer, logger log.Logger) *Component {
+	opts := component.Options{
+		ID:         "mimir.rules.kubernetes",
+		Logger:     logger,
+		Registerer: reg,
+		GetServiceData: func(name string) (interface{}, error) {
+			if name == cluster.ServiceName {
+				return &fakeCluster{}, nil
+			}
+
+			panic(fmt.Sprintf("unexpected service name %s", name))
+		},
+	}
+
+	args := Arguments{Address: "http://localhost:8080/"}
+	args.SetToDefault()
+
+	c, err := newNoInit(opts, args)
+	require.NoError(t, err)
+	return c
+}
+
+func TestIterationHandlesUpdate(t *testing.T) {
+	t.Run("error during restart", func(t *testing.T) {
+		reg := prometheus.NewPedanticRegistry()
+		logger := log.NewNopLogger()
+
+		leader := &fakeLeadership{}
+		health := &fakeHealthReporter{}
+		state := &fakeLifecycle{}
+		state.restartErr = errors.New("expected test error")
+
+		newArgs := Arguments{Address: "http://localhost:8080/"}
+		newArgs.SetToDefault()
+
+		c := newComponentForTesting(t, reg, logger)
+		go func() {
+			require.NoError(t, c.iteration(context.Background(), leader, state, health))
+		}()
+
+		require.Error(t, c.Update(newArgs))
+		require.Error(t, health.getErr())
+		require.True(t, state.restartCalled.Load())
+	})
+
+	t.Run("success", func(t *testing.T) {
+		reg := prometheus.NewPedanticRegistry()
+		logger := log.NewNopLogger()
+
+		leader := &fakeLeadership{}
+		health := &fakeHealthReporter{}
+		state := &fakeLifecycle{}
+
+		newArgs := Arguments{Address: "http://localhost:8080/"}
+		newArgs.SetToDefault()
+
+		c := newComponentForTesting(t, reg, logger)
+		go func() {
+			require.NoError(t, c.iteration(context.Background(), leader, state, health))
+		}()
+
+		require.NoError(t, c.Update(newArgs))
+		require.NoError(t, health.getErr())
+		require.True(t, state.restartCalled.Load())
+	})
+}
+
+func TestIterationHandlesClusterChange(t *testing.T) {
+	t.Run("error during leader check", func(t *testing.T) {
+		reg := prometheus.NewPedanticRegistry()
+		logger := log.NewNopLogger()
+
+		leader := &fakeLeadership{}
+		leader.updateErr = errors.New("expected test error")
+		health := &fakeHealthReporter{}
+		state := &fakeLifecycle{}
+
+		c := newComponentForTesting(t, reg, logger)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			require.NoError(t, c.iteration(context.Background(), leader, state, health))
+		}()
+
+		c.NotifyClusterChange()
+		wg.Wait()
+		
+		require.Error(t, health.getErr())
+		require.False(t, state.restartCalled.Load())
+	})
+
+	t.Run("leader not changed", func(t *testing.T) {
+		reg := prometheus.NewPedanticRegistry()
+		logger := log.NewNopLogger()
+
+		leader := &fakeLeadership{}
+		leader.changed = false
+		health := &fakeHealthReporter{}
+		state := &fakeLifecycle{}
+
+		c := newComponentForTesting(t, reg, logger)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			require.NoError(t, c.iteration(context.Background(), leader, state, health))
+		}()
+
+		c.NotifyClusterChange()
+		wg.Wait()
+
+		require.NoError(t, health.getErr())
+		require.False(t, state.restartCalled.Load())
+	})
+
+	t.Run("error during restart", func(t *testing.T) {
+		reg := prometheus.NewPedanticRegistry()
+		logger := log.NewNopLogger()
+
+		leader := &fakeLeadership{}
+		leader.changed = true
+		health := &fakeHealthReporter{}
+		state := &fakeLifecycle{}
+		state.restartErr = errors.New("expected test error")
+
+		c := newComponentForTesting(t, reg, logger)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			require.NoError(t, c.iteration(context.Background(), leader, state, health))
+		}()
+
+		c.NotifyClusterChange()
+		wg.Wait()
+
+		require.Error(t, health.getErr())
+		require.True(t, state.restartCalled.Load())
+	})
+
+	t.Run("success", func(t *testing.T) {
+		reg := prometheus.NewPedanticRegistry()
+		logger := log.NewNopLogger()
+
+		leader := &fakeLeadership{}
+		leader.changed = true
+		health := &fakeHealthReporter{}
+		state := &fakeLifecycle{}
+
+		c := newComponentForTesting(t, reg, logger)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			require.NoError(t, c.iteration(context.Background(), leader, state, health))
+		}()
+
+		c.NotifyClusterChange()
+		wg.Wait()
+
+		require.NoError(t, health.getErr())
+		require.True(t, state.restartCalled.Load())
+	})
+}
+
+func TestIterationHandlesContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	reg := prometheus.NewPedanticRegistry()
+	logger := log.NewNopLogger()
+
+	leader := &fakeLeadership{}
+	health := &fakeHealthReporter{}
+	state := &fakeLifecycle{}
+
+	c := newComponentForTesting(t, reg, logger)
+	go func() {
+		require.ErrorIs(t, c.iteration(ctx, leader, state, health), errShutdown)
+	}()
+
+	cancel()
+	require.NoError(t, health.getErr())
+}
+
+func TestIterationHandlesTick(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	logger := log.NewNopLogger()
+
+	leader := &fakeLeadership{}
+	health := &fakeHealthReporter{}
+	state := &fakeLifecycle{}
+
+	c := newComponentForTesting(t, reg, logger)
+	c.ticker.Reset(time.Millisecond)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		require.NoError(t, c.iteration(context.Background(), leader, state, health))
+	}()
+
+	wg.Wait()
+
+	require.NoError(t, health.getErr())
+	require.True(t, state.syncStateCalled.Load())
 }

--- a/internal/component/mimir/rules/kubernetes/rules_test.go
+++ b/internal/component/mimir/rules/kubernetes/rules_test.go
@@ -166,7 +166,7 @@ func TestIterationHandlesUpdate(t *testing.T) {
 			require.NoError(t, c.iteration(context.Background(), leader, state, health))
 		}()
 
-		require.Error(t, c.Update(newArgs))
+		require.NoError(t, c.Update(newArgs))
 		require.Error(t, health.getErr())
 		require.True(t, state.restartCalled.Load())
 	})
@@ -214,7 +214,7 @@ func TestIterationHandlesClusterChange(t *testing.T) {
 
 		c.NotifyClusterChange()
 		wg.Wait()
-		
+
 		require.Error(t, health.getErr())
 		require.False(t, state.restartCalled.Load())
 	})


### PR DESCRIPTION
#### PR Description

This change adds support for updating Mimir rules based on PrometheusRule objects when running in clustered mode. It does this by picking a single instance to be the leader responsible for making changes using the Mimir API. Other non-leader instances will not process events or make calls to the Mimir API.

#### Which issue(s) this PR fixes

Related: https://github.com/grafana/alloy/pull/158
Related: https://github.com/grafana/alloy/pull/616
Related: https://github.com/grafana/alloy/pull/648

#### Notes to the Reviewer

It might be helpful to review this by commit:

- a05ac6b55e63f49ac85e29b6ebc72adfc696208e Introduces leader election such that only a single Alloy instance will receive Kubernetes events and make requests to the Mimir API based on them. This was a relatively small change but lacked any unit tests.
- 2d46f69f2800502eaccacb96553e98abe3589197 Was a larger refactor that kept the same idea as the previous commit but moved things around and introduced a few internal interfaces so that the interesting logic in `Component::Run()` could be unit tested.
- 0023f5f789bfb75343e0f78caf81efa6d5155bd7 Removes the warning in the docs introduced by #648

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
