### PR TITLE
Removed extra tab in yaml example

### DIFF
--- a/docs/sources/tasks/configure/configure-kubernetes.md
+++ b/docs/sources/tasks/configure/configure-kubernetes.md
@@ -134,7 +134,7 @@ Use this method if you prefer to write your {{< param "PRODUCT_NAME" >}} configu
 1. Modify Helm Chart's configuration in your `values.yaml` to use the existing ConfigMap:
 
    ```yaml
-     alloy:
+   alloy:
      configMap:
        create: false
        name: alloy-config


### PR DESCRIPTION
There were two extra spaces in the example for values.yaml  when using existing configmap. This was resulting in the following error:
```
Error: UPGRADE FAILED: template: alloy/templates/controllers/daemonset.yaml:20:8: executing "alloy/templates/controllers/daemonset.yaml" at <include "alloy.pod-template" .>: error calling include: template: alloy/templates/controllers/_pod.yaml:2:42: executing "alloy.pod-template" at <.Values.alloy>: wrong type for value; expected map[string]interface {}; got interface {}
```

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
