### PR TITLE
docs: remove 'd' from duration values spec

### DIFF
--- a/docs/sources/concepts/configuration-syntax/expressions/types_and_values.md
+++ b/docs/sources/concepts/configuration-syntax/expressions/types_and_values.md
@@ -28,10 +28,9 @@ In addition to the preceding types, the [component reference][] documentation us
   The key type of an object is always a string or an identifier converted into a string.
 * `list(T)`: an `array` with the value type`T`.
   For example, `list(string)` is an array where all the values are strings.
-* `duration`: a `string` denoting a duration of time, such as `"1d"`, `"1h30m"`, `"10s"`.
+* `duration`: a `string` denoting a duration of time, such as `"100ms"`, `"1h30m"`, `"10s"`.
   Valid units are:
 
-  * `d` for days.
   * `h` for hours.
   * `m` for minutes.
   * `s` for seconds.


### PR DESCRIPTION
Fixes #599

This PR addresses a spec inconsistency. This is not a breaking change, since `d` was never actually supported as a valid duration unit.

I still think that the Go team had a [good rationale](https://github.com/golang/go/issues/11473) for not adding support for it in time.ParseDuration; if it's so important for people to use higher values we could find a way to support richer expressions such as `5 * 24h` in the future instead.