### PR TITLE
loader: decrease log level of 'finished node evaluation' lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ Main (unreleased)
   `latest-nanoserver-1809`. The old tag will no longer be updated, and will be
   removed in a future release. (@rfratto)
 
+- The log level of `finished node evaluation` log lines has been decreased to
+  'debug'. (@tpaschalis)
+
 v1.0.0 (2024-04-09)
 -------------------
 

--- a/internal/alloy/internal/controller/loader.go
+++ b/internal/alloy/internal/controller/loader.go
@@ -782,7 +782,7 @@ func (l *Loader) concurrentEvalFn(n dag.Node, spanCtx context.Context, tracer tr
 	defer func() {
 		duration := time.Since(start)
 		l.cm.onComponentEvaluationDone(n.NodeID(), duration)
-		level.Info(l.log).Log("msg", "finished node evaluation", "node_id", n.NodeID(), "duration", duration)
+		level.Debug(l.log).Log("msg", "finished node evaluation", "node_id", n.NodeID(), "duration", duration)
 	}()
 
 	var err error


### PR DESCRIPTION
#### PR Description

This PR decreases the log level of the `msg="finished node evaluation"` log lines, since they can drown out all other logs

#### Which issue(s) this PR fixes

No issue filed.

#### Notes to the Reviewer

I purposefully left the Info log level on the Apply function that is called on manual reloads of the configuration. I'm not 100% sure yet, but I think they might be marginally more useful to see new components being added in, but still they can be much more noisy than all other log sources.

I also think this doesn't warrant a CHANGELOG entry, if you think it does don't hesitate to push an extra commit for me here.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A) 
- [ ] Config converters updated (N/A)
