### PR TITLE
Add additional buckets to fanout histogram

### DIFF
--- a/internal/component/prometheus/fanout.go
+++ b/internal/component/prometheus/fanout.go
@@ -33,8 +33,9 @@ type Fanout struct {
 // NewFanout creates a fanout appendable.
 func NewFanout(children []storage.Appendable, componentID string, register prometheus.Registerer, ls labelstore.LabelStore) *Fanout {
 	wl := prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name: "prometheus_fanout_latency",
-		Help: "Write latency for sending to direct and indirect components",
+		Name:    "prometheus_fanout_latency",
+		Help:    "Write latency for sending to direct and indirect components",
+		Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60},
 	})
 	_ = register.Register(wl)
 


### PR DESCRIPTION
#### PR Description

  - The prometheus_fanout_latency is used to measure latencies for data moving between components.
  - The default buckets are limited to 10s, which limits the ability detect very high latencies.
  - Adds to additional buckets (30s, 60s) for additional resolution.

#### Notes to the Reviewer

  - I initially planned to replace some of the existing buckets instead of adding new ones, but I believe most components will fall into the smaller buckets and reducing the resolution there would lead to distortions in the quantile calculations (and potentially create the ilusion of performance degradation). Note however that the 2 new buckets will result in increased cardinality of 2 metrics per collector instance.
