### PR TITLE
fix: Ensure HTTP server startup errors are logged (#694)

### DIFF
--- a/internal/cmd/integration-tests/configs/prom-gen/main.go
+++ b/internal/cmd/integration-tests/configs/prom-gen/main.go
@@ -44,7 +44,11 @@ func main() {
 	}()
 	log.Printf("HTTP server on %s", listenAddress)
 
-	go func() { log.Fatal(server.ListenAndServe()) }()
+	go func() {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("Server Listening error: %v", err)
+		}
+	}()
 
 	labels := map[string]string{
 		"address": address,


### PR DESCRIPTION
### Bugfixes

#### PR Description
This commit modifies the go routine that starts the HTTP server to explicitly log any errors encountered during startup, except for `http.ErrServerClosed`, which is expected during graceful shutdown. This change ensures that issues related to the server's startup, such as the address already being in use, are logged, making it easier to diagnose and fix.
#### Which issue(s) this PR fixes

Fixes #694

#### Notes to the Reviewer

#### PR Checklist