### PR TITLE
Updated local.file to change `path` to `filename` as per documentation

### DIFF
--- a/docs/sources/tutorials/first-components-and-stdlib/index.md
+++ b/docs/sources/tutorials/first-components-and-stdlib/index.md
@@ -78,7 +78,7 @@ Look at the following simple pipeline:
 
 ```alloy
 local.file "example" {
-    path = env("HOME") + "file.txt"
+    filename = env("HOME") + "/file.txt"
 }
 
 prometheus.remote_write "local_prom" {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Following the tutorial this with the latest `alloy`  (v1.0.0) throws:
```
Error: config.alloy:2:5: unrecognized attribute name "path"

1 | local.file "example" {
2 |     path = env("HOME") + "file.txt"
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
3 | }
```

looking at the documentation, the correct key is `filename` not `path`.
Further, on the single change:
```
Error: config.alloy:1:1: Failed to build component: building component: failed to read file: open /home/userfile.txt: no such file or directory

1 |   local.file "example" {
  |  _^^^^^^^^^^^^^^^^^^^^^^
2 | |     filename = env("HOME") + "file.txt"
3 | | }
  | |_^
4 |
```

Meaning there is also a need for a `/`

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
