### PR TITLE
prometheus.remote_write: notify remote_write of data upon WAL commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,12 @@ Main (unreleased)
 
 - In `mimir.rules.kubernetes`, fix an issue where unrecoverable errors from the Mimir API were retried. (@56quarters)
 
-- Flow: Fix an issue where `faro.receiver`'s `extra_log_labels` with empty value don't
-  map existing value in log line. (@hainenber)
+- Fix an issue where `faro.receiver`'s `extra_log_labels` with empty value
+  don't map existing value in log line. (@hainenber)
+
+- Fix an issue where `prometheus.remote_write` only queued data for sending
+  every 15 seconds instead of as soon as data was written to the WAL.
+  (@rfratto)
 
 ### Other changes
 

--- a/internal/component/prometheus/remotewrite/remote_write.go
+++ b/internal/component/prometheus/remotewrite/remote_write.go
@@ -84,6 +84,8 @@ func New(o component.Options, c Arguments) (*Component, error) {
 	remoteLogger := log.With(o.Logger, "subcomponent", "rw")
 	remoteStore := remote.NewStorage(remoteLogger, o.Registerer, startTime, o.DataPath, remoteFlushDeadline, nil)
 
+	walStorage.SetNotifier(remoteStore)
+
 	service, err := o.GetServiceData(labelstore.ServiceName)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This commit fixes an issue where the remote_write queue only checked for new WAL data every 15 seconds. remote_write can be notified of new data immediately by calling `Notify` on the remote storage, but we weren't doing this, which caused us to fall back to the 15 second interval.