### PR TITLE
packaging: don't assume /var/lib/alloy exists when running chown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,10 @@ Main (unreleased)
 - The log level of `finished node evaluation` log lines has been decreased to
   'debug'. (@tpaschalis)
 
+- Update post-installation scripts for DEB/RPM packages to ensure
+  `/var/lib/alloy` exists before configuring its permissions and ownership.
+  (@rfratto)
+
 v1.0.0 (2024-04-09)
 -------------------
 

--- a/packaging/deb/control/postinst
+++ b/packaging/deb/control/postinst
@@ -26,8 +26,11 @@ case "$1" in
             usermod -a -G systemd-journal "$ALLOY_USER"
         fi
 
-        chown $ALLOY_USER:$ALLOY_GROUP /var/lib/alloy
-        chmod 770 /var/lib/alloy
+        if [ ! -d /var/lib/alloy ]; then
+          mkdir /var/lib/alloy
+          chown $ALLOY_USER:$ALLOY_GROUP /var/lib/alloy
+          chmod 770 /var/lib/alloy
+        fi
 
         if [ ! -d /var/lib/alloy/data ]; then
           mkdir /var/lib/alloy/data

--- a/packaging/rpm/control/postinst
+++ b/packaging/rpm/control/postinst
@@ -29,8 +29,11 @@ if [ "$1" -eq 1 ] ; then
 
     add_to_logging_groups
 
-    chown $ALLOY_USER:$ALLOY_GROUP /var/lib/alloy
-    chmod 770 /var/lib/alloy
+    if [ ! -d /var/lib/alloy ]; then
+      mkdir /var/lib/alloy
+      chown $ALLOY_USER:$ALLOY_GROUP /var/lib/alloy
+      chmod 770 /var/lib/alloy
+    fi
 
     if [ ! -d /var/lib/alloy/data ]; then
       mkdir /var/lib/alloy/data


### PR DESCRIPTION
The /var/lib/alloy directory may not necessarily exist when installing or upgrading Alloy, which would cause the chown/chmod of the directory to fail.

Related to grafana/alloy#723, though I haven't been able to reproduce the specific error that user was seeing.