### PR TITLE
Reintroduce boringcrypto images

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -354,7 +354,7 @@ trigger:
 type: docker
 ---
 kind: pipeline
-name: Publish development Linux alloy container
+name: Publish Linux alloy-devel container
 platform:
   arch: amd64
   os: linux
@@ -371,10 +371,10 @@ steps:
   - mkdir -p $HOME/.docker
   - printenv GCR_CREDS > $HOME/.docker/config.json
   - docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
-  - docker buildx create --name multiarch-alloy-alloy-${DRONE_COMMIT_SHA} --driver
+  - docker buildx create --name multiarch-alloy-alloy-devel-${DRONE_COMMIT_SHA} --driver
     docker-container --use
   - ./tools/ci/docker-containers alloy-devel
-  - docker buildx rm multiarch-alloy-alloy-${DRONE_COMMIT_SHA}
+  - docker buildx rm multiarch-alloy-alloy-devel-${DRONE_COMMIT_SHA}
   environment:
     DOCKER_LOGIN:
       from_secret: docker_login
@@ -397,7 +397,50 @@ volumes:
   name: docker
 ---
 kind: pipeline
-name: Publish development Windows alloy container
+name: Publish Linux alloy-boringcrypto-devel container
+platform:
+  arch: amd64
+  os: linux
+steps:
+- commands:
+  - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+  failure: ignore
+  image: grafana/alloy-build-image:v0.1.0
+  name: Configure QEMU
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+- commands:
+  - mkdir -p $HOME/.docker
+  - printenv GCR_CREDS > $HOME/.docker/config.json
+  - docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
+  - docker buildx create --name multiarch-alloy-alloy-boringcrypto-devel-${DRONE_COMMIT_SHA}
+    --driver docker-container --use
+  - ./tools/ci/docker-containers alloy-boringcrypto-devel
+  - docker buildx rm multiarch-alloy-alloy-boringcrypto-devel-${DRONE_COMMIT_SHA}
+  environment:
+    DOCKER_LOGIN:
+      from_secret: docker_login
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+    GCR_CREDS:
+      from_secret: gcr_admin
+  image: grafana/alloy-build-image:v0.1.0
+  name: Publish container
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+trigger:
+  ref:
+  - refs/heads/main
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+kind: pipeline
+name: Publish Windows alloy-devel container
 platform:
   arch: amd64
   os: windows
@@ -409,6 +452,40 @@ steps:
   - '& "C:/Program Files/git/bin/bash.exe" -c ''docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD'''
   - '& "C:/Program Files/git/bin/bash.exe" -c ''./tools/ci/docker-containers-windows
     alloy-devel'''
+  environment:
+    DOCKER_LOGIN:
+      from_secret: docker_login
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+    GCR_CREDS:
+      from_secret: gcr_admin
+  image: grafana/alloy-build-image:v0.1.0-windows
+  name: Build containers
+  volumes:
+  - name: docker
+    path: //./pipe/docker_engine/
+trigger:
+  ref:
+  - refs/heads/main
+type: docker
+volumes:
+- host:
+    path: //./pipe/docker_engine/
+  name: docker
+---
+kind: pipeline
+name: Publish Windows alloy-cngcrypto-devel container
+platform:
+  arch: amd64
+  os: windows
+  version: "1809"
+steps:
+- commands:
+  - '& "C:/Program Files/git/bin/bash.exe" -c ''mkdir -p $HOME/.docker'''
+  - '& "C:/Program Files/git/bin/bash.exe" -c ''printenv GCR_CREDS > $HOME/.docker/config.json'''
+  - '& "C:/Program Files/git/bin/bash.exe" -c ''docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD'''
+  - '& "C:/Program Files/git/bin/bash.exe" -c ''./tools/ci/docker-containers-windows
+    alloy-cngcrypto-devel'''
   environment:
     DOCKER_LOGIN:
       from_secret: docker_login
@@ -474,6 +551,49 @@ volumes:
   name: docker
 ---
 kind: pipeline
+name: Publish Linux alloy-boringcrypto container
+platform:
+  arch: amd64
+  os: linux
+steps:
+- commands:
+  - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+  failure: ignore
+  image: grafana/alloy-build-image:v0.1.0
+  name: Configure QEMU
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+- commands:
+  - mkdir -p $HOME/.docker
+  - printenv GCR_CREDS > $HOME/.docker/config.json
+  - docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
+  - docker buildx create --name multiarch-alloy-alloy-boringcrypto-${DRONE_COMMIT_SHA}
+    --driver docker-container --use
+  - ./tools/ci/docker-containers alloy-boringcrypto
+  - docker buildx rm multiarch-alloy-alloy-boringcrypto-${DRONE_COMMIT_SHA}
+  environment:
+    DOCKER_LOGIN:
+      from_secret: docker_login
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+    GCR_CREDS:
+      from_secret: gcr_admin
+  image: grafana/alloy-build-image:v0.1.0
+  name: Publish container
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+trigger:
+  ref:
+  - refs/tags/v*
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+kind: pipeline
 name: Publish Windows alloy container
 platform:
   arch: amd64
@@ -507,8 +627,43 @@ volumes:
     path: //./pipe/docker_engine/
   name: docker
 ---
+kind: pipeline
+name: Publish Windows alloy-cngcrypto container
+platform:
+  arch: amd64
+  os: windows
+  version: "1809"
+steps:
+- commands:
+  - '& "C:/Program Files/git/bin/bash.exe" -c ''mkdir -p $HOME/.docker'''
+  - '& "C:/Program Files/git/bin/bash.exe" -c ''printenv GCR_CREDS > $HOME/.docker/config.json'''
+  - '& "C:/Program Files/git/bin/bash.exe" -c ''docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD'''
+  - '& "C:/Program Files/git/bin/bash.exe" -c ''./tools/ci/docker-containers-windows
+    alloy-cngcrypto'''
+  environment:
+    DOCKER_LOGIN:
+      from_secret: docker_login
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+    GCR_CREDS:
+      from_secret: gcr_admin
+  image: grafana/alloy-build-image:v0.1.0-windows
+  name: Build containers
+  volumes:
+  - name: docker
+    path: //./pipe/docker_engine/
+trigger:
+  ref:
+  - refs/tags/v*
+type: docker
+volumes:
+- host:
+    path: //./pipe/docker_engine/
+  name: docker
+---
 depends_on:
-- Publish development Linux alloy container
+- Publish Linux alloy-devel container
+- Publish Linux alloy-boringcrypto-devel container
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -555,7 +710,9 @@ type: docker
 ---
 depends_on:
 - Publish Linux alloy container
+- Publish Linux alloy-boringcrypto container
 - Publish Windows alloy container
+- Publish Windows alloy-cngcrypto container
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -713,6 +870,6 @@ kind: secret
 name: updater_private_key
 ---
 kind: signature
-hmac: eef3ddde1e027f6c8c113bf748036cb79961708262d651193c231096cda5260d
+hmac: 883a9a5afd22cd78dd7b0cbe53b2523ebc4afe148272c9d0df2754d036d17319
 
 ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Main (unreleased)
 
 - (_Public preview_) Add support for setting GOMEMLIMIT based on cgroup setting. (@mattdurham)
 
+- (_Public preview_) Introduce `boringcrypto` and `cngcrypto` Docker images.
+  These Docker images are tagged with the `-boringcrypto` (for Linux) and
+  `-cngcrypto` (for Windows) suffixes. `boringcrypto` support is only available
+  on AMD64 and ARM64, while `cngcrypto` support is only available on AMD64.
+  (@rfratto, @mattdurham)
+
 ### Enhancements
 
 - Update `prometheus.exporter.kafka` with the following functionalities (@wildum):

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,6 +1,7 @@
 FROM grafana/alloy-build-image:v0.1.0-windows as builder
 ARG VERSION
 ARG RELEASE_BUILD=1
+ARG GO_TAGS
 
 COPY . /src/alloy
 WORKDIR /src/alloy
@@ -11,7 +12,7 @@ SHELL ["cmd", "/S", "/C"]
 # we can before moving on to the next step.
 RUN ""C:\Program Files\git\bin\bash.exe" -c "RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} make generate-ui && rm -rf web/ui/node_modules && yarn cache clean --all""
 
-RUN ""C:\Program Files\git\bin\bash.exe" -c "RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} GO_TAGS='builtinassets' make alloy""
+RUN ""C:\Program Files\git\bin\bash.exe" -c "RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} GO_TAGS="builtinassets ${GO_TAGS}" make alloy""
 # In this case, we're separating the clean command from make alloy to avoid an issue where access to some mod cache
 # files is denied immediately after make alloy, for example:
 # "go: remove C:\go\pkg\mod\golang.org\toolchain@v0.0.1-go1.22.1.windows-amd64\bin\go.exe: Access is denied."

--- a/docs/sources/get-started/install/docker.md
+++ b/docs/sources/get-started/install/docker.md
@@ -50,6 +50,19 @@ Make sure you pass `--server.http.listen-addr=0.0.0.0:12345` as an argument as s
 If you don't pass this argument, the [debugging UI][UI] won't be available outside of the Docker container.
 {{< /admonition >}}
 
+### Boringcrypto images
+
+> **Note**: `boringcrypto` support is in _Public preview_ and is only available
+> on AMD64 and ARM64 platforms.
+
+`boringcrypto` images are published with every release starting with version
+1.1:
+
+* The latest `boringcrypto` image is published as `grafana/alloy:boringcrypto`.
+* A specific version of the `boringcrypto` image is published as
+  `grafana/alloy:<VERSION>-boringcrypto`, such as
+  `grafana/alloy:v1.1.0-boringcrypto`.
+
 ## Run a Windows Docker container
 
 To run {{< param "PRODUCT_NAME" >}} as a Windows Docker container, run the following command in a terminal window:
@@ -74,6 +87,20 @@ Refer to the documentation for [run][] for more information about the options av
 Make sure you pass `--server.http.listen-addr=0.0.0.0:12345` as an argument as shown in the example above.
 If you don't pass this argument, the [debugging UI][UI] won't be available outside of the Docker container.
 {{< /admonition >}}
+
+### Cngcrypto images
+
+> **Note**: `cngcrypto` support is in _Public preview_ and is only available
+> on AMD64 platforms.
+
+`cngcrypto` images are published with every release starting with version
+1.1:
+
+* The latest `cngcrypto` image is published as `grafana/alloy:nanoserver-1809-cngcrypto`.
+* A specific version of the `cngcrypto` image is published as
+  `grafana/alloy:<VERSION>-nanoserver-1809-cngcrypto`, such as
+  `grafana/alloy:v1.1.0-nanoserver-1809-cngcrypto`.
+
 
 ## Verify
 

--- a/docs/sources/get-started/install/docker.md
+++ b/docs/sources/get-started/install/docker.md
@@ -50,17 +50,17 @@ Make sure you pass `--server.http.listen-addr=0.0.0.0:12345` as an argument as s
 If you don't pass this argument, the [debugging UI][UI] won't be available outside of the Docker container.
 {{< /admonition >}}
 
-### Boringcrypto images
+### BoringCrypto images
 
 {{< admonition type="note" >}}
-`boringcrypto` support is in _Public preview_ and is only available on AMD64 and ARM64 platforms.
+BoringCrypto support is in _Public preview_ and is only available on AMD64 and ARM64 platforms.
 {{< /admonition >}}
 
-`boringcrypto` images are published with every release starting with version
+BoringCrypto images are published with every release starting with version
 1.1:
 
-* The latest `boringcrypto` image is published as `grafana/alloy:boringcrypto`.
-* A specific version of the `boringcrypto` image is published as
+* The latest BoringCrypto image is published as `grafana/alloy:boringcrypto`.
+* A specific version of the BoringCrypto image is published as
   `grafana/alloy:<VERSION>-boringcrypto`, such as
   `grafana/alloy:v1.1.0-boringcrypto`.
 
@@ -89,17 +89,17 @@ Make sure you pass `--server.http.listen-addr=0.0.0.0:12345` as an argument as s
 If you don't pass this argument, the [debugging UI][UI] won't be available outside of the Docker container.
 {{< /admonition >}}
 
-### Cngcrypto images
+### CNGCrypto images
 
 {{< admonition type="note" >}}
-`cngcrypto` support is in _Public preview_ and is only available on AMD64 platforms.
+CNGCrypto support is in _Public preview_ and is only available on AMD64 platforms.
 {{< /admonition >}}
 
-`cngcrypto` images are published with every release starting with version
+CNGCrypto images are published with every release starting with version
 1.1:
 
-* The latest `cngcrypto` image is published as `grafana/alloy:nanoserver-1809-cngcrypto`.
-* A specific version of the `cngcrypto` image is published as
+* The latest CNGCrypto image is published as `grafana/alloy:nanoserver-1809-cngcrypto`.
+* A specific version of the CNGCrypto image is published as
   `grafana/alloy:<VERSION>-nanoserver-1809-cngcrypto`, such as
   `grafana/alloy:v1.1.0-nanoserver-1809-cngcrypto`.
 

--- a/docs/sources/get-started/install/docker.md
+++ b/docs/sources/get-started/install/docker.md
@@ -52,8 +52,9 @@ If you don't pass this argument, the [debugging UI][UI] won't be available outsi
 
 ### Boringcrypto images
 
-> **Note**: `boringcrypto` support is in _Public preview_ and is only available
-> on AMD64 and ARM64 platforms.
+{{< admonition type="note" >}}
+`boringcrypto` support is in _Public preview_ and is only available on AMD64 and ARM64 platforms.
+{{< /admonition >}}
 
 `boringcrypto` images are published with every release starting with version
 1.1:
@@ -90,8 +91,9 @@ If you don't pass this argument, the [debugging UI][UI] won't be available outsi
 
 ### Cngcrypto images
 
-> **Note**: `cngcrypto` support is in _Public preview_ and is only available
-> on AMD64 platforms.
+{{< admonition type="note" >}}
+`cngcrypto` support is in _Public preview_ and is only available on AMD64 platforms.
+{{< /admonition >}}
 
 `cngcrypto` images are published with every release starting with version
 1.1:
@@ -100,7 +102,6 @@ If you don't pass this argument, the [debugging UI][UI] won't be available outsi
 * A specific version of the `cngcrypto` image is published as
   `grafana/alloy:<VERSION>-nanoserver-1809-cngcrypto`, such as
   `grafana/alloy:v1.1.0-nanoserver-1809-cngcrypto`.
-
 
 ## Verify
 

--- a/docs/sources/reference/config-blocks/http.md
+++ b/docs/sources/reference/config-blocks/http.md
@@ -88,36 +88,36 @@ The `cipher_suites` argument determines what cipher suites to use.
 If you don't provide cipher suite, a default list is used.
 The set of cipher suites specified may be from the following:
 
-| Cipher                                          |
-| ----------------------------------------------- |
-| `TLS_RSA_WITH_AES_128_CBC_SHA`                  |
-| `TLS_RSA_WITH_AES_256_CBC_SHA`                  |
-| `TLS_RSA_WITH_AES_128_GCM_SHA256`               |
-| `TLS_RSA_WITH_AES_256_GCM_SHA384`               |
-| `TLS_AES_128_GCM_SHA256`                        |
-| `TLS_AES_256_GCM_SHA384`                        |
-| `TLS_CHACHA20_POLY1305_SHA256`                  |
-| `TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA`          |
-| `TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA`          |
-| `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA`            |
-| `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA`            |
-| `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`       |
-| `TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`       |
-| `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`         |
-| `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`         |
-| `TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256`   |
-| `TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256` |
+| Cipher                                          | Allowed in `boringcrypto`/`cngcrypto` builds |
+| ----------------------------------------------- | -------------------------------------------- |
+| `TLS_RSA_WITH_AES_128_CBC_SHA`                  | no                                           |
+| `TLS_RSA_WITH_AES_256_CBC_SHA`                  | no                                           |
+| `TLS_RSA_WITH_AES_128_GCM_SHA256`               | yes                                          |
+| `TLS_RSA_WITH_AES_256_GCM_SHA384`               | yes                                          |
+| `TLS_AES_128_GCM_SHA256`                        | no                                           |
+| `TLS_AES_256_GCM_SHA384`                        | no                                           |
+| `TLS_CHACHA20_POLY1305_SHA256`                  | no                                           |
+| `TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA`          | no                                           |
+| `TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA`          | no                                           |
+| `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA`            | no                                           |
+| `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA`            | no                                           |
+| `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`       | yes                                          |
+| `TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`       | yes                                          |
+| `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`         | yes                                          |
+| `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`         | yes                                          |
+| `TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256`   | no                                           |
+| `TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256` | no                                           |
 
 The `curve_preferences` argument determines the set of elliptic curves to prefer during a handshake in preference order.
 If not provided, a default list is used.
 The set of elliptic curves specified may be from the following:
 
-| Curve       |
-| ----------- |
-| `CurveP256` |
-| `CurveP384` |
-| `CurveP521` |
-| `X25519`    |
+| Curve       | Allowed in `boringcrypto`/`cngcrypto` builds |
+| ----------- | -------------------------------------------- |
+| `CurveP256` | yes                                          |
+| `CurveP384` | yes                                          |
+| `CurveP521` | yes                                          |
+| `X25519`    | no                                           |
 
 The `min_version` and `max_version` arguments determine the oldest and newest TLS version that's acceptable from clients.
 If you don't provide the min and max TLS version, a default value is used.

--- a/docs/sources/reference/config-blocks/http.md
+++ b/docs/sources/reference/config-blocks/http.md
@@ -88,36 +88,36 @@ The `cipher_suites` argument determines what cipher suites to use.
 If you don't provide cipher suite, a default list is used.
 The set of cipher suites specified may be from the following:
 
-| Cipher                                          | Allowed in `boringcrypto`/`cngcrypto` builds |
-| ----------------------------------------------- | -------------------------------------------- |
-| `TLS_RSA_WITH_AES_128_CBC_SHA`                  | no                                           |
-| `TLS_RSA_WITH_AES_256_CBC_SHA`                  | no                                           |
-| `TLS_RSA_WITH_AES_128_GCM_SHA256`               | yes                                          |
-| `TLS_RSA_WITH_AES_256_GCM_SHA384`               | yes                                          |
-| `TLS_AES_128_GCM_SHA256`                        | no                                           |
-| `TLS_AES_256_GCM_SHA384`                        | no                                           |
-| `TLS_CHACHA20_POLY1305_SHA256`                  | no                                           |
-| `TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA`          | no                                           |
-| `TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA`          | no                                           |
-| `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA`            | no                                           |
-| `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA`            | no                                           |
-| `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`       | yes                                          |
-| `TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`       | yes                                          |
-| `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`         | yes                                          |
-| `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`         | yes                                          |
-| `TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256`   | no                                           |
-| `TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256` | no                                           |
+| Cipher                                          | Allowed in BoringCrypto/CNGCrypto builds |
+| ----------------------------------------------- | ---------------------------------------- |
+| `TLS_RSA_WITH_AES_128_CBC_SHA`                  | no                                       |
+| `TLS_RSA_WITH_AES_256_CBC_SHA`                  | no                                       |
+| `TLS_RSA_WITH_AES_128_GCM_SHA256`               | yes                                      |
+| `TLS_RSA_WITH_AES_256_GCM_SHA384`               | yes                                      |
+| `TLS_AES_128_GCM_SHA256`                        | no                                       |
+| `TLS_AES_256_GCM_SHA384`                        | no                                       |
+| `TLS_CHACHA20_POLY1305_SHA256`                  | no                                       |
+| `TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA`          | no                                       |
+| `TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA`          | no                                       |
+| `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA`            | no                                       |
+| `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA`            | no                                       |
+| `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`       | yes                                      |
+| `TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`       | yes                                      |
+| `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`         | yes                                      |
+| `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`         | yes                                      |
+| `TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256`   | no                                       |
+| `TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256` | no                                       |
 
 The `curve_preferences` argument determines the set of elliptic curves to prefer during a handshake in preference order.
 If not provided, a default list is used.
 The set of elliptic curves specified may be from the following:
 
-| Curve       | Allowed in `boringcrypto`/`cngcrypto` builds |
-| ----------- | -------------------------------------------- |
-| `CurveP256` | yes                                          |
-| `CurveP384` | yes                                          |
-| `CurveP521` | yes                                          |
-| `X25519`    | no                                           |
+| Curve       | Allowed in BoringCrypto/CNGCrypto builds |
+| ----------- | ---------------------------------------- |
+| `CurveP256` | yes                                      |
+| `CurveP384` | yes                                      |
+| `CurveP521` | yes                                      |
+| `X25519`    | no                                       |
 
 The `min_version` and `max_version` arguments determine the oldest and newest TLS version that's acceptable from clients.
 If you don't provide the min and max TLS version, a default value is used.

--- a/tools/ci/docker-containers
+++ b/tools/ci/docker-containers
@@ -32,6 +32,10 @@ else
   VERSION=$(./tools/image-tag)
 fi
 
+# DEFAULT_LATEST is the default tag to use for the "latest" tag.
+DEFAULT_LATEST=latest
+BORINGCRYPTO_LATEST=boringcrypto
+
 # The TAG_VERSION is the version to use for the Docker tag. It is sanitized to
 # force it to be a valid Docker tag name (primarily by removing the +
 # characters that may have been emitted by ./tools/image-tag).
@@ -45,7 +49,7 @@ TAG_VERSION=${VERSION//+/-}
 # If we're not running from drone, we'll set the branch tag to match the
 # version. This effectively acts as a no-op because it will tag the same Docker
 # image twice.
-if [[ -n "$DRONE_TAG" && "$DRONE_TAG" != *"-rc."* ]] || [[ "$TARGET_CONTAINER" == *"-devel" ]]; then
+if [[ -n "$DRONE_TAG" && "$DRONE_TAG" != *"-rc."* ]] || [[ "$TARGET_CONTAINER" == *"-devel"* ]]; then
   BRANCH_TAG=latest
 else
   BRANCH_TAG=$TAG_VERSION
@@ -54,6 +58,7 @@ fi
 # Build all of our images.
 
 export BUILD_PLATFORMS=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
+export BUILD_PLATFORMS_BORINGCRYPTO=linux/amd64,linux/arm64
 
 case "$TARGET_CONTAINER" in
   alloy)
@@ -64,6 +69,22 @@ case "$TARGET_CONTAINER" in
       -t "$RELEASE_ALLOY_IMAGE:$TAG_VERSION" \
       -t "$RELEASE_ALLOY_IMAGE:$BRANCH_TAG"  \
       -f Dockerfile                          \
+      .
+    ;;
+
+  alloy-boringcrypto)
+    if [[ "$BRANCH_TAG" == "$DEFAULT_LATEST" ]]; then
+      BRANCH_TAG=$BORINGCRYPTO_LATEST
+    fi
+
+    docker buildx build --push                            \
+      --platform $BUILD_PLATFORMS_BORINGCRYPTO            \
+      --build-arg RELEASE_BUILD=1                         \
+      --build-arg VERSION="$VERSION"                      \
+      --build-arg GOEXPERIMENT=boringcrypto               \
+      -t "$RELEASE_ALLOY_IMAGE:$TAG_VERSION-boringcrypto" \
+      -t "$RELEASE_ALLOY_IMAGE:$BRANCH_TAG"               \
+      -f Dockerfile                                       \
       .
     ;;
 
@@ -78,8 +99,24 @@ case "$TARGET_CONTAINER" in
       .
     ;;
 
+  alloy-devel-boringcrypto)
+    if [[ "$BRANCH_TAG" == "$DEFAULT_LATEST" ]]; then
+      BRANCH_TAG=$BORINGCRYPTO_LATEST
+    fi
+
+    docker buildx build --push                          \
+      --platform $BUILD_PLATFORMS_BORINGCRYPTO          \
+      --build-arg RELEASE_BUILD=1                       \
+      --build-arg VERSION="$VERSION"                    \
+      --build-arg GOEXPERIMENT=boringcrypto             \
+      -t "$DEVEL_ALLOY_IMAGE:$TAG_VERSION-boringcrypto" \
+      -t "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"               \
+      -f Dockerfile                                     \
+      .
+    ;;
+
   *)
-    echo "Usage: $0 alloy|alloy-devel"
+    echo "Usage: $0 alloy|alloy-boringcrypto|alloy-devel|alloy-devel-boringcrypto"
     exit 1
     ;;
 esac

--- a/tools/ci/docker-containers-windows
+++ b/tools/ci/docker-containers-windows
@@ -27,6 +27,10 @@ else
   VERSION=$(./tools/image-tag)
 fi
 
+# DEFAULT_LATEST is the default tag to use for the "latest" tag.
+DEFAULT_LATEST=nanoserver-1809
+CNGCRYPTO_LATEST=nanoserver-1809-cngcrypto
+
 # The VERSION_TAG is the version to use for the Docker tag. It is sanitized to
 # force it to be a valid Docker tag name (primarily by removing the +
 # characters that may have been emitted by ./tools/image-tag).
@@ -41,7 +45,7 @@ VERSION_TAG=${VERSION//+/-}-nanoserver-1809
 # version. This effectively acts as a no-op because it will tag the same Docker
 # image twice.
 if [[ -n "$DRONE_TAG" && "$DRONE_TAG" != *"-rc."* ]] || [[ "$TARGET_CONTAINER" == *"-devel"* ]]; then
-  BRANCH_TAG=nanoserver-1809
+  BRANCH_TAG=$DEFAULT_LATEST
 else
   BRANCH_TAG=$VERSION_TAG
 fi
@@ -53,6 +57,25 @@ case "$TARGET_CONTAINER" in
       -t "$RELEASE_ALLOY_IMAGE:$BRANCH_TAG"  \
       --build-arg VERSION="$VERSION"         \
       --build-arg RELEASE_BUILD=1            \
+      -f ./Dockerfile.windows                \
+      .
+
+    docker push "$RELEASE_ALLOY_IMAGE:$VERSION_TAG"
+    docker push "$RELEASE_ALLOY_IMAGE:$BRANCH_TAG"
+    ;;
+
+  alloy-cngcrypto)
+    if [[ "$BRANCH_TAG" == "$DEFAULT_LATEST" ]]; then
+      BRANCH_TAG=$CNGCRYPTO_LATEST
+    fi
+
+    docker build                             \
+      -t "$RELEASE_ALLOY_IMAGE:$VERSION_TAG-cngcrypto" \
+      -t "$RELEASE_ALLOY_IMAGE:$BRANCH_TAG"  \
+      --build-arg VERSION="$VERSION"         \
+      --build-arg RELEASE_BUILD=1            \
+      --build-arg GOEXPERIMENT=cngcrypto     \
+      --build-arg GO_TAGS=cngcrypto          \
       -f ./Dockerfile.windows                \
       .
 
@@ -73,8 +96,27 @@ case "$TARGET_CONTAINER" in
     docker push "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"
     ;;
 
+  alloy-devel-cngcrypto)
+    if [[ "$BRANCH_TAG" == "$DEFAULT_LATEST" ]]; then
+      BRANCH_TAG=$CNGCRYPTO_LATEST
+    fi
+
+    docker build                           \
+      -t "$DEVEL_ALLOY_IMAGE:$VERSION_TAG-cngcrypto" \
+      -t "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"  \
+      --build-arg VERSION="$VERSION"       \
+      --build-arg RELEASE_BUILD=1          \
+      --build-arg GOEXPERIMENT=cngcrypto   \
+      --build-arg GO_TAGS=cngcrypto        \
+      -f ./Dockerfile.windows              \
+      .
+
+    docker push "$DEVEL_ALLOY_IMAGE:$VERSION_TAG"
+    docker push "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"
+    ;;
+
   *)
-    echo "Usage: $0 alloy|alloy-devel"
+    echo "Usage: $0 alloy|alloy-cngcrypto|alloy-devel|alloy-devel-cngcrypto"
     exit 1
     ;;
 esac


### PR DESCRIPTION
This PR introduces boringcrypto/cngcrypto Docker images to mirror boringcrypto/cngcrypto support in Grafana Agent.

Related to #64.

I'll follow up with another PR for distributing boringcrypto binaries after this is merged.