### PR TITLE
Remove set bind permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,9 @@ Main (unreleased)
   `/var/lib/alloy` exists before configuring its permissions and ownership.
   (@rfratto)
 
+- Remove setcap for `cap_net_bind_service` to allow alloy to run in restricted environments.
+  Modern container runtimes allow binding to unprivileged ports as non-root. (@BlackDex)
+
 v1.0.0 (2024-04-09)
 -------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ LABEL org.opencontainers.image.source="https://github.com/grafana/alloy"
 # Install dependencies needed at runtime.
 RUN <<EOF
   apt-get update
-  apt-get install -qy libsystemd-dev tzdata ca-certificates libcap2-bin
+  apt-get install -qy libsystemd-dev tzdata ca-certificates
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 EOF
 
@@ -53,7 +53,6 @@ RUN groupadd --gid $UID $USERNAME
 RUN useradd -m -u $UID -g $UID $USERNAME
 RUN chown -R $USERNAME:$USERNAME /etc/alloy
 RUN chown -R $USERNAME:$USERNAME /bin/alloy
-RUN setcap 'cap_net_bind_service=+ep' /bin/alloy
 
 RUN mkdir -p /var/lib/alloy/data
 RUN chown -R $USERNAME:$USERNAME /var/lib/alloy


### PR DESCRIPTION
#### PR Description

In this PR https://github.com/grafana/agent/pull/6817 the setcap was added for the alloy/agent binary for some reason unknown to me.

Since the docker engine allows binding to unpriviliged ports already for a long time via https://github.com/moby/moby/pull/41030, which was implemented in the Docker engine v20.10.x and also other container runtimes.

#### Which issue(s) this PR fixes
Fixes #117
Fixes #303

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] ~Documentation added~
- [ ] ~Tests updated~
- [ ] ~Config converters updated~
