### PR TITLE
Remove shortcode from metadata

### DIFF
--- a/docs/sources/concepts/configuration-syntax/expressions/types_and_values.md
+++ b/docs/sources/concepts/configuration-syntax/expressions/types_and_values.md
@@ -1,6 +1,6 @@
 ---
 canonical: https://grafana.com/docs/alloy/latest/concepts/configuration-syntax/expressions/types_and_values/
-description: Learn about the {{< param "PRODUCT_NAME" >}} syntax types and values
+description: Learn about the Alloy syntax types and values
 title: Types and values
 weight: 100
 ---

--- a/docs/sources/concepts/configuration-syntax/files.md
+++ b/docs/sources/concepts/configuration-syntax/files.md
@@ -1,6 +1,6 @@
 ---
 canonical: https://grafana.com/docs/alloy/latest/concepts/configuration-syntax/files/
-description: Learn about {{< param "PRODUCT_NAME" >}} configuration files
+description: Learn about Alloy configuration files
 title: Files
 weight: 100
 ---

--- a/docs/sources/concepts/configuration-syntax/syntax.md
+++ b/docs/sources/concepts/configuration-syntax/syntax.md
@@ -1,6 +1,6 @@
 ---
 canonical: https://grafana.com/docs/alloy/latest/concepts/configuration-syntax/syntax/
-description: Learn about the {{< param "PRODUCT_NAME" >}} syntax
+description: Learn about the Alloy syntax
 title: Syntax
 weight: 200
 ---

--- a/docs/sources/tutorials/first-components-and-stdlib/index.md
+++ b/docs/sources/tutorials/first-components-and-stdlib/index.md
@@ -1,6 +1,6 @@
 ---
 canonical: https://grafana.com/docs/alloy/latest/tutorials/first-components-and-stdlib/
-description: Learn about the basics of the {{< param "PRODUCT_NAME" >}} configuration syntax
+description: Learn about the basics of the Alloy configuration syntax
 title: First components and the standard library
 weight: 20
 ---


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

A shortcode was accidentally placed in the metadata during teh pro for Agent->Alloy. This PR fixes this up.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
