### PR TITLE
remove setcap from docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,6 @@ RUN groupadd --gid $UID $USERNAME
 RUN useradd -m -u $UID -g $UID $USERNAME
 RUN chown -R $USERNAME:$USERNAME /etc/alloy
 RUN chown -R $USERNAME:$USERNAME /bin/alloy
-RUN setcap 'cap_net_bind_service=+ep' /bin/alloy
 
 RUN mkdir -p /var/lib/alloy/data
 RUN chown -R $USERNAME:$USERNAME /var/lib/alloy


### PR DESCRIPTION
This was needed when the helm chart was using port 80 by default, if you were running as a non-root user.

Now that 12345 is a more universal default, I don't think this is needed. But it is harmful because you can't drop all capabilities anymore since the binary requires net_bind_service.

If you are running as root, this should not affect you. The only people that might notice this are people running as non-root, binding to port 80. I do not have a solution for that.