### PR TITLE
Fix syntax error in first code block and execute TS in command

### DIFF
--- a/docs/sources/tutorials/processing-logs/index.md
+++ b/docs/sources/tutorials/processing-logs/index.md
@@ -38,7 +38,7 @@ loki.source.api "listener" {
         listen_port    = 9999
     }
 
-    labels = { "source": "api" }
+    labels = { source = "api" }
 
     forward_to = [loki.process.process_logs.receiver]
 }
@@ -342,16 +342,10 @@ Replace the following:
 
 * _`<BINARY_FILE_PATH>`_: The path to the {{< param "PRODUCT_NAME" >}} binary.
 
-To get the current time in `RFC3339` format, you can run:
+Try executing the following which will insert the current timestamp:
 
 ```bash
-date -u +"%Y-%m-%dT%H:%M:%SZ"
-```
-
-Try executing the following, replacing the `"timestamp"` value:
-
-```bash
-curl localhost:9999/loki/api/v1/raw -XPOST -H "Content-Type: application/json" -d '{"log": {"is_secret": "false", "level": "debug", "message": "This is a debug message!"}, "timestamp": <YOUR TIMESTAMP HERE>}'
+curl localhost:9999/loki/api/v1/raw -XPOST -H "Content-Type: application/json" -d '{"log": {"is_secret": "false", "level": "debug", "message": "This is a debug message!"}, "timestamp":  "'"$(date -u +"%Y-%m-%dT%H:%M:%SZ")"'"}'
 ```
 
 Now that you have sent some logs, its time to see how they look in Grafana.


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->


#### PR Description

\- 1 -

There is a syntactical error in first block which listed `loki.source.api labels` as:
```
    labels = { "source": "api" }
```
instead of the correct format of:
```
    labels = { source = "api" }
```
as per [documentation](https://grafana.com/docs/alloy/latest/reference/components/loki.source.api/) (and second reference below which was correct)

\- 2 -

Also, placing timestamp command directly in the call makes it easier to spam logs for testing and troubleshooting.
```
... "timestamp": "'"$(date -u +"%Y-%m-%dT%H:%M:%SZ")"'"}' 
```

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
