### PR TITLE
packaging: change default Nice value on Linux installs to -5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ Main (unreleased)
   every 15 seconds instead of as soon as data was written to the WAL.
   (@rfratto)
 
-- Imported code using `slog` logging will now not panic and replay correctly when logged before the logging 
+- Imported code using `slog` logging will now not panic and replay correctly when logged before the logging
   config block is initialized. (@mattdurham)
 
 ### Other changes
@@ -95,26 +95,26 @@ Main (unreleased)
 
 - Remove setcap for `cap_net_bind_service` to allow alloy to run in restricted environments.
   Modern container runtimes allow binding to unprivileged ports as non-root. (@BlackDex)
-  
+
 - Upgrading from OpenTelemetry v0.96.0 to v0.99.0.
   - `otelcol.processor.batch`: Prevent starting unnecessary goroutines.
     https://github.com/open-telemetry/opentelemetry-collector/issues/9739
   - `otelcol.exporter.otlp`: Checks for port in the config validation for the otlpexporter.
     https://github.com/open-telemetry/opentelemetry-collector/issues/9505
-  - `otelcol.receiver.otlp`: Fix bug where the otlp receiver did not properly respond 
+  - `otelcol.receiver.otlp`: Fix bug where the otlp receiver did not properly respond
     with a retryable error code when possible for http.
     https://github.com/open-telemetry/opentelemetry-collector/pull/9357
   - `otelcol.receiver.vcenter`: Fixed the resource attribute model to more accurately support multi-cluster deployments.
     https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30879
     For more information on impacts please refer to:
     https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31113
-    The main impact is that `vcenter.resource_pool.name`, `vcenter.resource_pool.inventory_path`, 
+    The main impact is that `vcenter.resource_pool.name`, `vcenter.resource_pool.inventory_path`,
     and `vcenter.cluster.name` are reported with more accuracy on VM metrics.
   - `otelcol.receiver.vcenter`: Remove the `vcenter.cluster.name` resource attribute from Host resources if the Host is standalone (no cluster).
     https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32548
   - `otelcol.receiver.vcenter`: Changes process for collecting VMs & VM perf metrics to be more efficient (one call now for all VMs).
     https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/31837
-  - `otelcol.connector.servicegraph`: Added a new `database_name_attribute` config argument to allow users to 
+  - `otelcol.connector.servicegraph`: Added a new `database_name_attribute` config argument to allow users to
     specify a custom attribute name for identifying the database name in span attributes.
     https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/30726
   - `otelcol.connector.servicegraph`: Fix 'failed to find dimensions for key' error from race condition in metrics cleanup.
@@ -147,6 +147,10 @@ Main (unreleased)
     https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32574
   - `otelcol.processor.resourcedetection`: Update to ec2 scraper so that core attributes are not dropped if describeTags returns an error (likely due to permissions).
     https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/30672
+
+- The default nice value on Linux installations when installing through DEB/RPM
+  packages has been updated from `0` to `-5` to give Alloy higher priority.
+  (@rfratto)
 
 v1.0.0 (2024-04-09)
 -------------------

--- a/packaging/deb/alloy.service
+++ b/packaging/deb/alloy.service
@@ -15,6 +15,7 @@ ExecStart=/usr/bin/alloy run $CUSTOM_ARGS --storage.path=/var/lib/alloy/data $CO
 ExecReload=/usr/bin/env kill -HUP $MAINPID
 TimeoutStopSec=20s
 SendSIGKILL=no
+Nice=-5
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/rpm/alloy.service
+++ b/packaging/rpm/alloy.service
@@ -15,6 +15,7 @@ ExecStart=/usr/bin/alloy run $CUSTOM_ARGS --storage.path=/var/lib/alloy/data $CO
 ExecReload=/usr/bin/env kill -HUP $MAINPID
 TimeoutStopSec=20s
 SendSIGKILL=no
+Nice=-5
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This changes the default Nice value on Linux installs (when our DEB or RPM installers are used) from 0 to -5. This gives Alloy a higher priority so monitoring can be prioritzed when there's CPU pressure elsewhere on a machine.

I tested this locally and it works and sets the priority properly, though I don't know if -5 is sufficient. We can keep tuning this over time as needed. (The supported range of nice values is -20 to 19). 