### PR TITLE
VERISON: bump to v1.2.0 in main

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -20,4 +20,4 @@
 #
 # Lines starting with "#" and blank lines are ignored.
 
-v1.1.0
+v1.2.0

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -4,7 +4,7 @@ title: Grafana Alloy
 description: Grafana Alloy is a a vendor-neutral distribution of the OTel Collector
 weight: 350
 cascade:
-  ALLOY_RELEASE: v1.1.0
+  ALLOY_RELEASE: v1.2.0
   OTEL_VERSION: v0.87.0
   FULL_PRODUCT_NAME: Grafana Alloy
   PRODUCT_NAME: Alloy


### PR DESCRIPTION
Now that the release/v1.1 branch has been cut, the main branch has switched to the development cycle for v1.2.0.