### PR TITLE
Dockerfile.windows: fix issue where Alloy build was not produced

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -12,7 +12,7 @@ SHELL ["cmd", "/S", "/C"]
 # we can before moving on to the next step.
 RUN ""C:\Program Files\git\bin\bash.exe" -c "RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} make generate-ui && rm -rf web/ui/node_modules && yarn cache clean --all""
 
-RUN ""C:\Program Files\git\bin\bash.exe" -c "RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} GO_TAGS="builtinassets ${GO_TAGS}" make alloy""
+RUN ""C:\Program Files\git\bin\bash.exe" -c "RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} GO_TAGS='builtinassets ${GO_TAGS}' make alloy""
 # In this case, we're separating the clean command from make alloy to avoid an issue where access to some mod cache
 # files is denied immediately after make alloy, for example:
 # "go: remove C:\go\pkg\mod\golang.org\toolchain@v0.0.1-go1.22.1.windows-amd64\bin\go.exe: Access is denied."


### PR DESCRIPTION
PR #725 reintroduced boringcrypto support and mistakenly switched the quote syntax in the Dockerfile used to pass variables. This change was not necessary as the surrounding string already used double quotes, and making the change prevented the proper command from being passed to make.