### PR TITLE
[Docs] discovery.ec2 add missing basic-auth block reference

### DIFF
--- a/docs/sources/reference/components/discovery.ec2.md
+++ b/docs/sources/reference/components/discovery.ec2.md
@@ -67,6 +67,11 @@ tls_config          | [tls_config][]    | Configure TLS settings for connecting 
 [authorization]: #authorization-block
 [oauth2]: #oauth2-block
 [tls_config]: #tls_config-block
+[basic_auth]: #basic_auth-block
+
+### basic_auth block
+
+{{< docs/shared lookup="reference/components/basic-auth-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ### authorization block
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Adds a missing `basic_auth` block reference and link. Verified in the code that [the component embeds](https://github.com/grafana/alloy/blob/main/internal/component/discovery/aws/ec2.go#L50) the `HTTPClientConfig`, which contains a `basic_auth` field.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] Documentation added
