### PR TITLE
Update SNMP exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Main (unreleased)
   This port can be configured with `--server.http.listen-addr` or using
   the default listen address`127.0.0.1:12345`. (@mattdurham) 
 
+### Other changes
+
+- `prometheus.exporter.snmp`: Updating SNMP exporter from v0.24.1 to v0.26.0.
+
 v1.1.0-rc.0
 -----------
 

--- a/docs/sources/reference/components/prometheus.exporter.snmp.md
+++ b/docs/sources/reference/components/prometheus.exporter.snmp.md
@@ -10,7 +10,7 @@ The `prometheus.exporter.snmp` component embeds
 [`snmp_exporter`](https://github.com/prometheus/snmp_exporter). `snmp_exporter` lets you collect SNMP data and expose them as Prometheus metrics.
 
 {{< admonition type="note" >}}
-`prometheus.exporter.snmp` uses the latest configuration introduced in version 0.23 of the Prometheus `snmp_exporter`.
+`prometheus.exporter.snmp` uses the latest configuration introduced in version 0.26 of the Prometheus `snmp_exporter`.
 {{< /admonition >}}
 
 ## Usage

--- a/go.mod
+++ b/go.mod
@@ -156,7 +156,7 @@ require (
 	github.com/prometheus/node_exporter v1.6.0
 	github.com/prometheus/procfs v0.12.0
 	github.com/prometheus/prometheus v1.99.0
-	github.com/prometheus/snmp_exporter v0.24.1
+	github.com/prometheus/snmp_exporter v0.26.0
 	github.com/prometheus/statsd_exporter v0.22.8
 	github.com/richardartoul/molecule v1.0.1-0.20221107223329-32cfee06a052
 	github.com/rs/cors v1.10.1
@@ -432,7 +432,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.12.2 // indirect
 	github.com/gophercloud/gophercloud v1.8.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
-	github.com/gosnmp/gosnmp v1.36.0 // indirect
+	github.com/gosnmp/gosnmp v1.37.0 // indirect
 	github.com/grafana/go-offsets-tracker v0.1.7 // indirect
 	github.com/grafana/gomemcache v0.0.0-20231204155601-7de47a8c3cb0 // indirect
 	github.com/grafana/jfr-parser v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1024,6 +1024,8 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gosnmp/gosnmp v1.36.0 h1:1Si+MImHcKIqFc3/kJEs2LOULP1nlFKlzPFyrMOk5Qk=
 github.com/gosnmp/gosnmp v1.36.0/go.mod h1:iLcZxN2MxKhH0jPQDVMZaSNypw1ykqVi27O79koQj6w=
+github.com/gosnmp/gosnmp v1.37.0 h1:/Tf8D3b9wrnNuf/SfbvO+44mPrjVphBhRtcGg22V07Y=
+github.com/gosnmp/gosnmp v1.37.0/go.mod h1:GDH9vNqpsD7f2HvZhKs5dlqSEcAS6s6Qp099oZRCR+M=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
 github.com/grafana/alloy-remote-config v0.0.4 h1:XqpZ5ZmaVc1E1MZwWoQ4pTPtDQq1L2I2TEhN5JpH8nY=
 github.com/grafana/alloy-remote-config v0.0.4/go.mod h1:kHE1usYo2WAVCikQkIXuoG1Clz8BSdiz3kF+DZSCQ4k=
@@ -1982,6 +1984,10 @@ github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
 github.com/prometheus/snmp_exporter v0.24.1 h1:AihTbJHurMo8bjtjJde8U+4gMEvpvYvT21Xbd4SzJgY=
 github.com/prometheus/snmp_exporter v0.24.1/go.mod h1:j6uIGkdR0DXvKn7HJtSkeDj//UY0sWmdd6XhvdBjln0=
+github.com/prometheus/snmp_exporter v0.25.1-0.20240501011921-5f907e691aa5 h1:eDoGVogLF6DRe1s7NpQI6oz8atI3eM2Q58JmHiKOkRM=
+github.com/prometheus/snmp_exporter v0.25.1-0.20240501011921-5f907e691aa5/go.mod h1:zOJjSLA//ET2bH76vYBdftmKEg1LiqfNesyZy+nMHvc=
+github.com/prometheus/snmp_exporter v0.26.0 h1:7THSh/mAIMmHkiVhmsrAwiH1XNGiFelhPCKBe8PXg8U=
+github.com/prometheus/snmp_exporter v0.26.0/go.mod h1:GJEhIONojqxbjn3eyCykWeGVXQJg9pdYSX2scFLpEA0=
 github.com/prometheus/statsd_exporter v0.22.8 h1:Qo2D9ZzaQG+id9i5NYNGmbf1aa/KxKbB9aKfMS+Yib0=
 github.com/prometheus/statsd_exporter v0.22.8/go.mod h1:/DzwbTEaFTE0Ojz5PqcSk6+PFHOPWGxdXVr6yC8eFOM=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=

--- a/internal/static/integrations/snmp_exporter/snmp_exporter.go
+++ b/internal/static/integrations/snmp_exporter/snmp_exporter.go
@@ -100,7 +100,7 @@ func New(log log.Logger, c *Config) (integrations.Integration, error) {
 func LoadSNMPConfig(snmpConfigFile string, snmpCfg *snmp_config.Config) (*snmp_config.Config, error) {
 	var err error
 	if snmpConfigFile != "" {
-		snmpCfg, err = snmp_config.LoadFile([]string{snmpConfigFile})
+		snmpCfg, err = snmp_config.LoadFile([]string{snmpConfigFile}, false)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load snmp config from file %v: %w", snmpConfigFile, err)
 		}


### PR DESCRIPTION
This PR will pick up a particular [feature](https://github.com/prometheus/snmp_exporter/pull/1163) from the upstream SNMP exporter.

Unfortunately, this feature is not yet in a "release" version of SNMP exporter. If @RichiH is planning to release a new version soon, then I could change the go.mod to reference it? If there isn't a new version, then we'll need to reword our docs to point to the commit.