### PR TITLE
[Controller]: check node refs before stdlib refs when nodes are wired together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,6 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
-### Bugfixes
-
-- Fix a bug where custom components would not shadow the stdlib. (@wildum)
-
-{{< admonition type="warning" >}}
-If you have a module whose name conflicts with an stdlib function and if you use this exact function in your config, then
-you will need to rename your module.
-{{< /admonition >}}
-
 v1.1.0-rc.0 (2024-05-03)
 ------------------------
 
@@ -84,6 +75,9 @@ v1.1.0-rc.0 (2024-05-03)
 
 - Imported code using `slog` logging will now not panic and replay correctly when logged before the logging
   config block is initialized. (@mattdurham)
+
+- Fix a bug where custom components would not shadow the stdlib. If you have a module whose name conflicts with an stdlib function 
+  and if you use this exact function in your config, then you will need to rename your module. (@wildum)
 
 ### Other changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Bugfixes
+
+- Fix a bug where custom components would not shadow the stdlib. (@wildum)
+
+{{< admonition type="warning" >}}
+If you have a module whose name conflicts with an stdlib function and if you use this exact function in your config, then
+you will need to rename your module.
+{{< /admonition >}}
+
 v1.1.0-rc.0 (2024-05-03)
 ------------------------
 

--- a/internal/alloy/declare_test.go
+++ b/internal/alloy/declare_test.go
@@ -261,6 +261,38 @@ func TestDeclare(t *testing.T) {
 			`,
 			expected: -10,
 		},
+		{
+			name: "ShadowStdlib",
+			config: `
+			declare "constants" {
+				argument "input" {
+					optional = false
+				}
+			
+				testcomponents.passthrough "pt" {
+					input = argument.input.value
+					lag = "1ms"
+				}
+			
+				export "output" {
+					value = testcomponents.passthrough.pt.output
+				}
+			}
+			testcomponents.count "inc" {
+				frequency = "10ms"
+				max = 10
+			}
+		
+			constants "myModule" {
+				input = testcomponents.count.inc.count
+			}
+		
+			testcomponents.summation "sum" {
+				input = constants.myModule.output
+			}
+			`,
+			expected: 10,
+		},
 	}
 
 	for _, tc := range tt {

--- a/internal/alloy/internal/controller/component_references.go
+++ b/internal/alloy/internal/controller/component_references.go
@@ -42,19 +42,17 @@ func ComponentReferences(cn dag.Node, g *dag.Graph) ([]Reference, diag.Diagnosti
 
 	refs := make([]Reference, 0, len(traversals))
 	for _, t := range traversals {
-		// We use an empty scope to determine if a reference refers to something in
-		// the stdlib, since vm.Scope.Lookup will search the scope tree + the
-		// stdlib.
-		//
-		// Any call to an stdlib function is ignored.
-		var emptyScope vm.Scope
-		if _, ok := emptyScope.Lookup(t[0].Name); ok {
-			continue
-		}
-
 		ref, resolveDiags := resolveTraversal(t, g)
-		diags = append(diags, resolveDiags...)
 		if resolveDiags.HasErrors() {
+			// We use an empty scope to determine if a reference refers to something in
+			// the stdlib, since vm.Scope.Lookup will search the scope tree + the
+			// stdlib.
+			//
+			// Any call to an stdlib function is ignored.
+			var emptyScope vm.Scope
+			if _, exist := emptyScope.Lookup(t[0].Name); !exist {
+				diags = append(diags, resolveDiags...)
+			}
 			continue
 		}
 		refs = append(refs, ref)


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

For forwards compatibility, we established that declares and imports should shadow other things. The wiring of the nodes in the loader does not follow this statement because references for the stdlib are checked before node references.

This PR changes the order so that custom components can shadow the stdlib. This will allow us to extend the stdlib without breaking our users configs.

#### PR Checklist

- [x] CHANGELOG.md updated
- [x] Tests updated
