### PR TITLE
CHANGELOG: remove date tracking from changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
-v1.1.0-rc.0 (2024-05-03)
-------------------------
+v1.1.0-rc.0
+-----------
 
 ### Features
 
@@ -76,7 +76,7 @@ v1.1.0-rc.0 (2024-05-03)
 - Imported code using `slog` logging will now not panic and replay correctly when logged before the logging
   config block is initialized. (@mattdurham)
 
-- Fix a bug where custom components would not shadow the stdlib. If you have a module whose name conflicts with an stdlib function 
+- Fix a bug where custom components would not shadow the stdlib. If you have a module whose name conflicts with an stdlib function
   and if you use this exact function in your config, then you will need to rename your module. (@wildum)
 
 ### Other changes
@@ -156,8 +156,8 @@ v1.1.0-rc.0 (2024-05-03)
   - `otelcol.processor.resourcedetection`: Update to ec2 scraper so that core attributes are not dropped if describeTags returns an error (likely due to permissions).
     https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/30672
 
-v1.0.0 (2024-04-09)
--------------------
+v1.0.0
+------
 
 ### Features
 

--- a/docs/developer/release/3-update-version-in-code.md
+++ b/docs/developer/release/3-update-version-in-code.md
@@ -16,11 +16,11 @@ The project must be updated to reference the upcoming release tag whenever a new
 
     1. `CHANGELOG.md` Header
         - First Release Candidate or a Patch Release
-            - Add a new header under `Main (unreleased)` for `VERSION (YYYY-MM-DD)`.
+            - Add a new header under `Main (unreleased)` for `VERSION`.
         - Additional RCV or SRV
-            - Update the header `PREVIOUS_RELEASE_CANDIDATE_VERSION (YYYY-MM-DD)` to `VERSION (YYYY-MM-DD)`. The date may need updating.
+            - Update the header `PREVIOUS_RELEASE_CANDIDATE_VERSION` to `VERSION`. The date may need updating.
 
-    2. Move the unreleased changes we want to add to the release branch from `Main (unreleased)` to `VERSION (YYYY-MM-DD)`.
+    2. Move the unreleased changes we want to add to the release branch from `Main (unreleased)` to `VERSION`.
 
 3. Create a PR to merge to main (must be merged before continuing).
 

--- a/docs/developer/release/README.md
+++ b/docs/developer/release/README.md
@@ -4,7 +4,7 @@ This document describes the process of creating a release for the
 `grafana/alloy` repo. A release includes release assets for everything inside
 the repository.
 
-The processes described here are for v0.24.0 and above.
+The processes described here are for v1.0 and above.
 
 # Release Cycle
 


### PR DESCRIPTION
Tracking dates in the changelog provide little value and incur cost when relases need to be delayed (such as the issues with the current 1.1 release).

This commit removes dates from changelog release sections.

As an alternative, users who wish to know the release date should use the GitHub release publish date as the source of truth.
