### PR TITLE
Dockerfile: make it clear that non-root support is experimental

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,9 @@ COPY --from=build /src/alloy/build/alloy /bin/alloy
 COPY example-config.alloy /etc/alloy/config.alloy
 
 # Create alloy user in container, but do not set it as default
+#
+# NOTE(rfratto): non-root support in Docker containers is an experimental,
+# undocumented feature; use at your own risk.
 RUN groupadd --gid $UID $USERNAME
 RUN useradd -m -u $UID -g $UID $USERNAME
 RUN chown -R $USERNAME:$USERNAME /etc/alloy


### PR DESCRIPTION
Users looking at the Dockerfile may not understand that non-root support is both undocumented and experimental. This commit makes that status explicit with a comment.
