### PR TITLE
Fix EOF issue when building on drone in windows.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,9 @@ ARG USERNAME="alloy"
 LABEL org.opencontainers.image.source="https://github.com/grafana/alloy"
 
 # Install dependencies needed at runtime.
-RUN  apt-get update
-RUN  apt-get install -qy libsystemd-dev tzdata ca-certificates
-RUN  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN  apt-get update \
+ &&  apt-get install -qy libsystemd-dev tzdata ca-certificates \
+ &&  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 
 COPY --from=build /src/alloy/build/alloy /bin/alloy

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,11 +39,10 @@ ARG USERNAME="alloy"
 LABEL org.opencontainers.image.source="https://github.com/grafana/alloy"
 
 # Install dependencies needed at runtime.
-RUN <<EOF
-  apt-get update
-  apt-get install -qy libsystemd-dev tzdata ca-certificates
-  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-EOF
+RUN  apt-get update
+RUN  apt-get install -qy libsystemd-dev tzdata ca-certificates
+RUN  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 
 COPY --from=build /src/alloy/build/alloy /bin/alloy
 COPY example-config.alloy /etc/alloy/config.alloy

--- a/tools/build-image/Dockerfile
+++ b/tools/build-image/Dockerfile
@@ -66,11 +66,11 @@ FROM rfratto/viceroy:v0.4.0
 # platform.
 # Source: https://github.com/nodesource/distributions#installation-instructions
 
-RUN  apt-get update && apt-get install -qy ca-certificates curl gnupg && mkdir -p /etc/apt/keyrings
-RUN  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-RUN  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
-RUN  apt-get update && apt-get install -qy nodejs
-RUN  rm -rf /var/lib/apt/lists/*
+RUN  apt-get update && apt-get install -qy ca-certificates curl gnupg && mkdir -p /etc/apt/keyrings  \
+ &&  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+ &&  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+ &&  apt-get update && apt-get install -qy nodejs \
+ &&  rm -rf /var/lib/apt/lists/*
 
 # Install Yarn.
 #

--- a/tools/build-image/Dockerfile
+++ b/tools/build-image/Dockerfile
@@ -65,14 +65,12 @@ FROM rfratto/viceroy:v0.4.0
 # will fail on installing NodeJS for all platforms instead of just our host
 # platform.
 # Source: https://github.com/nodesource/distributions#installation-instructions
-RUN <<EOF
-  apt-get update && apt-get install -qy ca-certificates curl gnupg && mkdir -p /etc/apt/keyrings
-  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 
-  apt-get update && apt-get install -qy nodejs
-  rm -rf /var/lib/apt/lists/*
-EOF
+RUN  apt-get update && apt-get install -qy ca-certificates curl gnupg && mkdir -p /etc/apt/keyrings
+RUN  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN  apt-get update && apt-get install -qy nodejs
+RUN  rm -rf /var/lib/apt/lists/*
 
 # Install Yarn.
 #


### PR DESCRIPTION
#### PR Description

When using drone on windows the code must pass through a few layers til it gets to the linux build container, the EOF command is not compatible with windows and will cause issues. In my case it either only partially executed the command or ignored it. That then led to corepack not found since it never installed nodejs.

By using separate RUN lines the behavior is the same when calling drone on linux and windows even when they are both using a linux docker container under the hood.