### PR TITLE
(Experiment) Dockerfile.windows: remove clean cache step

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -13,10 +13,6 @@ SHELL ["cmd", "/S", "/C"]
 RUN ""C:\Program Files\git\bin\bash.exe" -c "RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} make generate-ui && rm -rf web/ui/node_modules && yarn cache clean --all""
 
 RUN ""C:\Program Files\git\bin\bash.exe" -c "RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} GO_TAGS=\"builtinassets ${GO_TAGS}\" make alloy""
-# In this case, we're separating the clean command from make alloy to avoid an issue where access to some mod cache
-# files is denied immediately after make alloy, for example:
-# "go: remove C:\go\pkg\mod\golang.org\toolchain@v0.0.1-go1.22.3.windows-amd64\bin\go.exe: Access is denied."
-RUN ""C:\Program Files\git\bin\bash.exe" -c "go clean -cache -modcache""
 
 # Use the smallest container possible for the final image
 FROM mcr.microsoft.com/windows/nanoserver:1809


### PR DESCRIPTION
PR grafana/agent#6671 split out cleaning the Go cache into its own step. This increased build times as stages are slow to produce on Windows.

As Dockerfile.windows is a multi-stage Dockerfile, and the cache doesn't carry over to the final image, cleaning the Go cache can be safely skipped to reduce the overall build time.