### PR TITLE
ci: fix permissions for Helm chart release

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -68,6 +68,8 @@ jobs:
         with:
           app-id: ${{ secrets.ALLOYBOT_APP_ID }}
           private-key: ${{ secrets.ALLOYBOT_PRIVATE_KEY }}
+          owner: grafana
+          repositories: helm-charts
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
actions/create-github-app-token by default only generates a token for the current repository. We need a token for grafana/helm-charts.