### PR TITLE
Allow to override the cluster headless service port name for Istio support

### DIFF
--- a/operations/helm/charts/alloy/templates/cluster_service.yaml
+++ b/operations/helm/charts/alloy/templates/cluster_service.yaml
@@ -18,7 +18,7 @@ spec:
     #
     # This service should only be used for clustering, and not metric
     # collection.
-    - name: http
+    - name: {{ coalesce $values.clustering.portName "http" }}
       port: {{ $values.listenPort }}
       targetPort: {{ $values.listenPort }}
       protocol: "TCP"


### PR DESCRIPTION
This will be needed for an Istio mesh based installation due to this issue with headless services + Istio - https://istio.io/latest/docs/ops/common-problems/network-issues/#503-error-while-accessing-headless-services

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #800

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
