### PR TITLE
Add path_join function to the stdlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Features
+
+- Add the function `path_join` to the stdlib. (@wildum)
+
 v1.1.0-rc.0
 -----------
 

--- a/docs/sources/reference/stdlib/path_join.md
+++ b/docs/sources/reference/stdlib/path_join.md
@@ -1,0 +1,20 @@
+---
+canonical: https://grafana.com/docs/alloy/latest/reference/stdlib/path_join/
+description: Learn about path_join
+title: path_join
+---
+
+# path_join
+
+`path_join` joins any number of path elements into a single path, separating them with an OS specific separator.
+
+## Examples
+
+```alloy
+> path_join("this/is", "a/path")
+"this/is/a/path"
+> path_join("empty/path", "")
+"empty/path"
+> join("foo/", "/bar/", "foo/bar", "foo")
+"foo/bar/foo/bar/foo"
+```

--- a/syntax/internal/stdlib/stdlib.go
+++ b/syntax/internal/stdlib/stdlib.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/grafana/alloy/syntax/alloytypes"
@@ -129,4 +130,5 @@ var Identifiers = map[string]interface{}{
 	"trim_prefix": strings.TrimPrefix,
 	"trim_suffix": strings.TrimSuffix,
 	"trim_space":  strings.TrimSpace,
+	"path_join":   filepath.Join,
 }

--- a/syntax/vm/vm_stdlib_test.go
+++ b/syntax/vm/vm_stdlib_test.go
@@ -163,6 +163,7 @@ func TestStdlib_StringFunc(t *testing.T) {
 		{"trim2", `trim("   hello! world.!  ", "! ")`, "hello! world."},
 		{"trim_prefix", `trim_prefix("helloworld", "hello")`, "world"},
 		{"trim_suffix", `trim_suffix("helloworld", "world")`, "hello"},
+		{"path_join", `path_join("this/is", "a/path")`, "this/is/a/path"},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Adding this function to the stdlib is needed to move forward with the relative path solution that is implemented for the modules. This function should also be useful in other scenarios.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
