### PR TITLE
Add info about order of arguments when customising the Windows config

### DIFF
--- a/docs/sources/tasks/configure/configure-windows.md
+++ b/docs/sources/tasks/configure/configure-windows.md
@@ -46,6 +46,7 @@ To change the set of command-line arguments passed to the {{< param "PRODUCT_NAM
 1. Double-click on the value called **Arguments***.
 
 1. In the dialog box, enter the new set of arguments to pass to the {{< param "PRODUCT_NAME" >}} binary.
+   Make sure that the `storage.path` argument is last in the set of arguments.
 
 1. Restart the {{< param "PRODUCT_NAME" >}} service:
 

--- a/docs/sources/tasks/configure/configure-windows.md
+++ b/docs/sources/tasks/configure/configure-windows.md
@@ -46,7 +46,7 @@ To change the set of command-line arguments passed to the {{< param "PRODUCT_NAM
 1. Double-click on the value called **Arguments***.
 
 1. In the dialog box, enter the new set of arguments to pass to the {{< param "PRODUCT_NAME" >}} binary.
-   Make sure that the `storage.path` argument is last in the set of arguments.
+   Make sure that each argument is is on its own line.
 
 1. Restart the {{< param "PRODUCT_NAME" >}} service:
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Add info about order of arguments when customising the Windows config.

If the storage.path argument is not last in the set of custom arguments, you will get the following error:

```
Error: failed to create the remotecfg service: mkdir C:\ProgramData\GrafanaLabs\Alloy\data --server.http.listen-addr=0.0.0.0:12345: The directory name is invalid.
```

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
