### PR TITLE
No error when http fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,9 @@ Main (unreleased)
   cluster instance to another could have a staleness marker inserted and result
   in a gap in metrics (@thampiotr)
 
-- If the port defined in `--server.http.listen-addr` or using the default listen address`127.0.0.1:12345` 
-  is not available then exit Alloy immediately. (@mattdurham)
+- Exit Alloy immediately if the port it runs on is not available. 
+  This port can be configured with `--server.http.listen-addr` or using
+  the default listen address`127.0.0.1:12345`. (@mattdurham) 
 
 v1.1.0-rc.0
 -----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Main (unreleased)
   cluster instance to another could have a staleness marker inserted and result
   in a gap in metrics (@thampiotr)
 
+- If the port defined in `--server.http.listen-addr` or using the default listen address`127.0.0.1:12345` 
+  is not available then exit Alloy immediately. (@mattdurham)
+
 v1.1.0-rc.0
 -----------
 

--- a/internal/service/http/http.go
+++ b/internal/service/http/http.go
@@ -153,7 +153,7 @@ func (s *Service) Run(ctx context.Context, host service.Host) error {
 	netLis, err := net.Listen("tcp", s.opts.HTTPListenAddr)
 	if err != nil {
 		// There is no recovering from failing to listen on the port.
-		level.Error(s.log).Log("failed to listen on %s: %w", s.opts.HTTPListenAddr, err)
+		level.Error(s.log).Log("msg", fmt.Sprintf("failed to listen on %s", s.opts.HTTPListenAddr), "err", err)
 		os.Exit(1)
 	}
 	if err := s.tcpLis.SetInner(netLis); err != nil {

--- a/internal/service/http/http.go
+++ b/internal/service/http/http.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	_ "net/http/pprof" // Register pprof handlers
+	"os"
 	"path"
 	"sort"
 	"strings"
@@ -151,7 +152,9 @@ func (s *Service) Run(ctx context.Context, host service.Host) error {
 
 	netLis, err := net.Listen("tcp", s.opts.HTTPListenAddr)
 	if err != nil {
-		return fmt.Errorf("failed to listen on %s: %w", s.opts.HTTPListenAddr, err)
+		// There is no recovering from failing to listen on the port.
+		level.Error(s.log).Log("failed to listen on %s: %w", s.opts.HTTPListenAddr, err)
+		os.Exit(1)
 	}
 	if err := s.tcpLis.SetInner(netLis); err != nil {
 		return fmt.Errorf("failed to use listener: %w", err)


### PR DESCRIPTION
#### PR Description

Fail early if the port is not available for any reason. Originally I was going to try and handle the error through the scheduler but that was going to touch a lot of code and introduce a larger change for something that does not allow recovery.

Additional credit to @mrashad10 for initially working on this issue.

#### Which issue(s) this PR fixes

Fixes #694


#### PR Checklist


- [X] CHANGELOG.md updated

