### PR TITLE
Expose feature gate stability level to components

### DIFF
--- a/internal/alloy/internal/controller/node_builtin_component.go
+++ b/internal/alloy/internal/controller/node_builtin_component.go
@@ -183,6 +183,8 @@ func getManagedOptions(globals ComponentGlobals, cn *BuiltinComponentNode) compo
 		GetServiceData: func(name string) (interface{}, error) {
 			return globals.GetServiceData(name)
 		},
+
+		MinStability: globals.MinStability,
 	}
 }
 

--- a/internal/component/registry.go
+++ b/internal/component/registry.go
@@ -105,6 +105,9 @@ type Options struct {
 	// The result of GetServiceData may be cached as the value will not change at
 	// runtime.
 	GetServiceData func(name string) (interface{}, error)
+
+	// Minimum allowed stability level for features
+	MinStability featuregate.Stability
 }
 
 // Registration describes a single component.

--- a/internal/component/registry.go
+++ b/internal/component/registry.go
@@ -106,7 +106,14 @@ type Options struct {
 	// runtime.
 	GetServiceData func(name string) (interface{}, error)
 
-	// Minimum allowed stability level for features
+	// MinStability tracks the minimum stability level of behavior that components should
+	// use. This allows components to optionally enable less-stable functionality.
+	//
+	// For example, if MinStability was [featuregate.StabilityGenerallyAvailable], only GA
+	// behavior should be used. If MinStability was [featuregate.StabilityPublicPreview], then
+	// Public Preview and GA behavior can be used.
+	//
+	// The value of MinStability is static for the process lifetime.
 	MinStability featuregate.Stability
 }
 


### PR DESCRIPTION
This will allow us to enable some features based on the stability level at the component level.
This is especially useful to match the feature gate system that otel uses for new functionalities.

Example: the support for prometheus native histograms in otelcol.receiver.prometheus is only available via feature flag. To match a similar behavior we would enable it only for public preview.

Context: https://github.com/grafana/alloy/pull/835
