### PR TITLE
[Docs] import.http: Add missing http client-related blocks

### DIFF
--- a/docs/sources/reference/config-blocks/import.http.md
+++ b/docs/sources/reference/config-blocks/import.http.md
@@ -28,6 +28,52 @@ Name             | Type          | Description                             | Def
 `poll_frequency` | `duration`    | Frequency to poll the URL.              | `"1m"`  | no
 `poll_timeout`   | `duration`    | Timeout when polling the URL.           | `"10s"` | no
 
+## Blocks
+
+The following blocks are supported inside the definition of `import.http`:
+
+Hierarchy                    | Block             | Description                                              | Required
+-----------------------------|-------------------|----------------------------------------------------------|---------
+client                       | [client][]        | HTTP client settings when connecting to the endpoint.    | no
+client > basic_auth          | [basic_auth][]    | Configure basic_auth for authenticating to the endpoint. | no
+client > authorization       | [authorization][] | Configure generic authorization to the endpoint.         | no
+client > oauth2              | [oauth2][]        | Configure OAuth2 for authenticating to the endpoint.     | no
+client > oauth2 > tls_config | [tls_config][]    | Configure TLS settings for connecting to the endpoint.   | no
+client > tls_config          | [tls_config][]    | Configure TLS settings for connecting to the endpoint.   | no
+
+The `>` symbol indicates deeper levels of nesting.
+For example, `client > basic_auth` refers to an `basic_auth` block defined inside a `client` block.
+
+### client block
+
+The `client` block configures settings used to connect to the HTTP server.
+
+{{< docs/shared lookup="reference/components/http-client-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### basic_auth block
+
+The `basic_auth` block configures basic authentication to use when polling the configured URL.
+
+{{< docs/shared lookup="reference/components/basic-auth-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### authorization block
+
+The `authorization` block configures custom authorization to use when polling the configured URL.
+
+{{< docs/shared lookup="reference/components/authorization-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### oauth2 block
+
+The `oauth2` block configures OAuth2 authorization to use when polling the configured URL.
+
+{{< docs/shared lookup="reference/components/oauth2-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### tls_config block
+
+The `tls_config` block configures TLS settings for connecting to HTTPS servers.
+
+{{< docs/shared lookup="reference/components/tls-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
 ## Example
 
 This example imports custom components from an HTTP response and instantiates a custom component for adding two numbers:
@@ -57,3 +103,9 @@ math.add "default" {
 }
 ```
 {{< /collapse >}}
+
+[client]: #client-block
+[basic_auth]: #basic_auth-block
+[authorization]: #authorization-block
+[oauth2]: #oauth2-block
+[tls_config]: #tls_config-block


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Adds missing blocks for configuring the HTTP client in `import.http` (inherited from `remote.http`) to the docs.

The Client [is present in the import.http struct](https://github.com/grafana/alloy/blob/main/internal/alloy/internal/importsource/import_http.go#L47) and set in [the call to remote_http.New(...)](https://github.com/grafana/alloy/blob/main/internal/alloy/internal/importsource/import_http.go#L70).

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] Documentation added
