### PR TITLE
Fix panic when Component ID contains `/` in `otelcomponent.MustNewType(ID)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Main (unreleased)
 
 ### Bugfixes
 
+- Fix panic when component ID contains `/` in `otelcomponent.MustNewType(ID)`.(@qclaogui)
+
 - Fixed an issue with `prometheus.scrape` in which targets that move from one
   cluster instance to another could have a staleness marker inserted and result
   in a gap in metrics (@thampiotr)

--- a/internal/component/otelcol/auth/auth.go
+++ b/internal/component/otelcol/auth/auth.go
@@ -168,7 +168,7 @@ func (a *Auth) Update(args component.Arguments) error {
 		components = append(components, ext)
 	}
 
-	cTypeStr := strings.ReplaceAll(a.opts.ID, ".", "_")
+	cTypeStr := strings.ReplaceAll(strings.ReplaceAll(a.opts.ID, ".", "_"), "/", "_")
 
 	// Inform listeners that our handler changed.
 	a.opts.OnStateChange(Exports{

--- a/internal/component/otelcol/receiver/prometheus/prometheus.go
+++ b/internal/component/otelcol/receiver/prometheus/prometheus.go
@@ -117,7 +117,7 @@ func (c *Component) Update(newConfig component.Arguments) error {
 		gcInterval = 5 * time.Minute
 	)
 
-	cTypeStr := strings.ReplaceAll(c.opts.ID, ".", "_")
+	cTypeStr := strings.ReplaceAll(strings.ReplaceAll(c.opts.ID, ".", "_"), "/", "_")
 
 	settings := otelreceiver.CreateSettings{
 


### PR DESCRIPTION

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Component ID may contains `/`. See:
https://github.com/grafana/alloy/blob/430658c7753711192b5f7cedeb70306a2844b0b3/internal/alloy/internal/controller/node_custom_component.go#L107
 
https://github.com/grafana/alloy/blob/430658c7753711192b5f7cedeb70306a2844b0b3/internal/alloy/internal/controller/loader.go#L915-L919 
which cause panic in  `otelcomponent.MustNewType(ComponentID)` https://github.com/open-telemetry/opentelemetry-collector/blob/c70b51f056fa39304989e6feb25658fd4c24e0d2/component/config.go#L153

#### Which issue(s) this PR fixes

Fix panic when component ID contains `/` in `otelcomponent.MustNewType(ID)`. Fixed: #859 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
