### PR TITLE
clustering: fix ipv6 advertise addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ Main (unreleased)
 
 - Fix a panic in `loki.source.docker` when trying to stop a target that was never started. (@wildum)
 
+- Fix error on boot when using IPv6 advertise addresses without explicitly
+  specifying a port. (@matthewpi)
+
 ### Other changes
 
 - `prometheus.exporter.snmp`: Updating SNMP exporter from v0.24.1 to v0.26.0.

--- a/internal/alloycli/cluster_builder_test.go
+++ b/internal/alloycli/cluster_builder_test.go
@@ -3,6 +3,7 @@ package alloycli
 import (
 	"testing"
 
+	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,4 +16,41 @@ func TestBuildClusterService(t *testing.T) {
 	cs, err := buildClusterService(opts)
 	require.Nil(t, cs)
 	require.EqualError(t, err, "at most one of join peers and discover peers may be set")
+}
+
+func TestGetAdvertiseAddress(t *testing.T) {
+	// This tests that an IPv4 advertise address is properly joined to it's port.
+	t.Run("IPv4", func(t *testing.T) {
+		opts := clusterOptions{
+			AdvertiseAddress: "1.1.1.1",
+		}
+
+		addr, err := getAdvertiseAddress(opts, 80)
+		require.Nil(t, err)
+		require.Equal(t, "1.1.1.1:80", addr)
+	})
+
+	// This tests that an IPv6 advertise address is properly joined to it's port.
+	t.Run("IPv6", func(t *testing.T) {
+		opts := clusterOptions{
+			AdvertiseAddress: "2606:4700:4700::1111",
+		}
+
+		addr, err := getAdvertiseAddress(opts, 80)
+		require.Nil(t, err)
+		require.Equal(t, "[2606:4700:4700::1111]:80", addr)
+	})
+
+	// This tests the loopback fallback.
+	t.Run("loopback Fallback", func(t *testing.T) {
+		opts := clusterOptions{
+			Log:                 log.NewNopLogger(),
+			EnableClustering:    true,
+			AdvertiseInterfaces: []string{"lo"},
+		}
+
+		addr, err := getAdvertiseAddress(opts, 80)
+		require.Nil(t, err)
+		require.Equal(t, "127.0.0.1:80", addr)
+	})
 }


### PR DESCRIPTION
#### PR Description

The previous logic for handling IPv6 addresses for clustering was flawed.  This PR updates it so IPv6 addresses are properly joined with their ports, avoiding a `too many colons in address` error upon starting Alloy in cluster-mode.

#### Which issue(s) this PR fixes

There is not an open issue for this bug.

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG.md updated
- [ ] Tests updated