### PR TITLE
Fix panic loki source docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,9 @@ Main (unreleased)
 
 - Exit Alloy immediately if the port it runs on is not available. 
   This port can be configured with `--server.http.listen-addr` or using
-  the default listen address`127.0.0.1:12345`. (@mattdurham) 
+  the default listen address`127.0.0.1:12345`. (@mattdurham)
+
+- Fix a panic in `loki.source.docker` when trying to stop a target that was never started. (@wildum)
 
 ### Other changes
 

--- a/internal/component/loki/source/docker/docker_test.go
+++ b/internal/component/loki/source/docker/docker_test.go
@@ -125,6 +125,22 @@ func TestRestart(t *testing.T) {
 	}, time.Second, 20*time.Millisecond, "Expected log lines were not found within the time limit after restart.")
 }
 
+func TestTargetNeverStarted(t *testing.T) {
+	runningState := false
+	client := clientMock{
+		logLine: "2024-05-02T13:11:55.879889Z caller=module_service.go:114 msg=\"module stopped\" module=distributor",
+		running: func() bool { return runningState },
+	}
+
+	tailer, _ := setupTailer(t, client)
+	ctx, cancel := context.WithCancel(context.Background())
+	go tailer.Run(ctx)
+
+	time.Sleep(20 * time.Millisecond)
+
+	require.NotPanics(t, func() { cancel() })
+}
+
 func setupTailer(t *testing.T, client clientMock) (tailer *tailer, entryHandler *fake.Client) {
 	w := log.NewSyncWriter(os.Stderr)
 	logger := log.NewLogfmtLogger(w)

--- a/internal/component/loki/source/docker/internal/dockertarget/target.go
+++ b/internal/component/loki/source/docker/internal/dockertarget/target.go
@@ -235,9 +235,11 @@ func (t *Target) StartIfNotRunning() {
 
 // Stop shuts down the target.
 func (t *Target) Stop() {
-	t.cancel()
-	t.wg.Wait()
-	level.Debug(t.logger).Log("msg", "stopped Docker target", "container", t.containerName)
+	if t.Ready() {
+		t.cancel()
+		t.wg.Wait()
+		level.Debug(t.logger).Log("msg", "stopped Docker target", "container", t.containerName)
+	}
 }
 
 // Ready reports whether the target is running.


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This [fix](https://github.com/grafana/alloy/pull/742) introduced a panic when the code attempts to stop a target that was never started.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

It was reported by https://github.com/grafana/alloy/issues/868 (not putting the fixes # above before the issue is confirmed to be solved)

#### Notes to the Reviewer

I could reproduce the bug via the test.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Tests updated
