### PR TITLE
fix: close procRoot dir

### DIFF
--- a/internal/component/pyroscope/java/asprof/asprof.go
+++ b/internal/component/pyroscope/java/asprof/asprof.go
@@ -115,6 +115,7 @@ func (p *Profiler) CopyLib(dist *Distribution, pid int) error {
 	if err != nil {
 		return fmt.Errorf("failed to open proc root %s: %w", procRoot, err)
 	}
+	defer procRootFile.Close()
 	dstLibPath := strings.TrimPrefix(dist.LibPath(), "/")
 	dstLauncherPath := strings.TrimPrefix(dist.LauncherPath(), "/")
 	if err = writeFile(procRootFile, dstLibPath, libData, false); err != nil {


### PR DESCRIPTION
This fix was originally suggested in https://github.com/grafana/agent/pull/6906. Sot it is a forward port.