### PR TITLE
remotecfg: add some basic metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Main (unreleased)
 ### Enhancements
 
 - (_Public preview_) Add native histogram support to `otelcol.receiver.prometheus`. (@wildum)
+- (_Public preview_) Add metrics to report status of `remotecfg` service. (@captncraig)
 
 ### Bugfixes
 

--- a/internal/alloycli/cmd_run.go
+++ b/internal/alloycli/cmd_run.go
@@ -267,6 +267,7 @@ func (fr *alloyRun) Run(configPath string) error {
 	remoteCfgService, err := remotecfgservice.New(remotecfgservice.Options{
 		Logger:      log.With(l, "service", "remotecfg"),
 		StoragePath: fr.storagePath,
+		Metrics:     reg,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create the remotecfg service: %w", err)

--- a/internal/service/remotecfg/remotecfg.go
+++ b/internal/service/remotecfg/remotecfg.go
@@ -119,30 +119,30 @@ func New(opts Options) (*Service, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	prom := promauto.With(opts.Metrics)
 	return &Service{
 		opts:   opts,
 		ticker: time.NewTicker(math.MaxInt64),
-		configHash: promauto.NewGaugeVec(
+		configHash: prom.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Name: "remotecfg_hash",
 				Help: "Hash of the currently active remote configuration.",
 			},
 			[]string{"hash"},
 		),
-		lastFetchSuccess: promauto.NewGauge(
+		lastFetchSuccess: prom.NewGauge(
 			prometheus.GaugeOpts{
 				Name: "remotecfg_last_load_successful",
 				Help: "Remote config loaded successfully",
 			},
 		),
-		totalFailures: promauto.NewCounter(
+		totalFailures: prom.NewCounter(
 			prometheus.CounterOpts{
 				Name: "remotecfg_load_failures_total",
 				Help: "Remote configuration load failures",
 			},
 		),
-		lastFetchSuccessTime: promauto.NewGauge(
+		lastFetchSuccessTime: prom.NewGauge(
 			prometheus.GaugeOpts{
 				Name: "remotecfg_last_load_success_timestamp_seconds",
 				Help: "Timestamp of the last successful remote configuration load",

--- a/internal/service/remotecfg/remotecfg.go
+++ b/internal/service/remotecfg/remotecfg.go
@@ -386,8 +386,10 @@ func (s *Service) getCfgHash() string {
 func (s *Service) setCfgHash(h string) {
 	s.mut.Lock()
 	defer s.mut.Unlock()
-	s.metrics.configHash.Reset()
-	s.metrics.configHash.WithLabelValues(h).Set(1)
+	if s.metrics != nil {
+		s.metrics.configHash.Reset()
+		s.metrics.configHash.WithLabelValues(h).Set(1)
+	}
 	s.currentConfigHash = h
 }
 


### PR DESCRIPTION
New metrics:

- remotecfg_hash
- remotecfg_last_load_successful
- remotecfg_load_failures_total
- remotecfg_last_load_success_timestamp_seconds
- remotecfg_load_attempts_total
- remotecfg_request_duration_seconds

Component loading info should already be exposed via controller metrics. 

This does not give any insight into the fallback local files, and is focused mainly on the remote fetch.