### PR TITLE
chore(pyroscope): mark pyroscope components as GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Main (unreleased)
 
 ### Other changes
 
+- `pyroscope.ebpf`, `pyroscope.java`, `pyroscope.scrape`, `pyroscope.write` and `discovery.process` components are now GA. (@korniltsev)
+
 - `prometheus.exporter.snmp`: Updating SNMP exporter from v0.24.1 to v0.26.0. (@ptodev, @erikbaranowski)
 
 - `prometheus.scrape` component's `enable_protobuf_negotiation` argument is now

--- a/docs/sources/reference/components/discovery.process.md
+++ b/docs/sources/reference/components/discovery.process.md
@@ -4,11 +4,7 @@ description: Learn about discovery.process
 title: discovery.process
 ---
 
-<span class="badge docs-labels__stage docs-labels__item">Public preview</span>
-
 # discovery.process
-
-{{< docs/shared lookup="stability/public_preview.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 `discovery.process` discovers processes running on the local Linux OS.
 

--- a/docs/sources/reference/components/pyroscope.ebpf.md
+++ b/docs/sources/reference/components/pyroscope.ebpf.md
@@ -4,11 +4,7 @@ description: Learn about pyroscope.ebpf
 title: pyroscope.ebpf
 ---
 
-<span class="badge docs-labels__stage docs-labels__item">Public preview</span>
-
 # pyroscope.ebpf
-
-{{< docs/shared lookup="stability/public_preview.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 `pyroscope.ebpf` configures an ebpf profiling job for the current host.
 The collected performance profiles are forwarded to the list of receivers passed in `forward_to`.

--- a/docs/sources/reference/components/pyroscope.java.md
+++ b/docs/sources/reference/components/pyroscope.java.md
@@ -4,11 +4,7 @@ description: Learn about pyroscope.java
 title: pyroscope.java
 ---
 
-<span class="badge docs-labels__stage docs-labels__item">Public preview</span>
-
 # pyroscope.java
-
-{{< docs/shared lookup="stability/public_preview.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 `pyroscope.java` continuously profiles Java processes running on the local Linux OS using [async-profiler](https://github.com/async-profiler/async-profiler).
 

--- a/docs/sources/reference/components/pyroscope.scrape.md
+++ b/docs/sources/reference/components/pyroscope.scrape.md
@@ -4,11 +4,7 @@ description: Learn about pyroscope.scrape
 title: pyroscope.scrape
 ---
 
-<span class="badge docs-labels__stage docs-labels__item">Public preview</span>
-
 # pyroscope.scrape
-
-{{< docs/shared lookup="stability/public_preview.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 `pyroscope.scrape` collects [pprof] performance profiles for a given set of HTTP `targets`.
 

--- a/docs/sources/reference/components/pyroscope.write.md
+++ b/docs/sources/reference/components/pyroscope.write.md
@@ -4,11 +4,7 @@ description: Learn about pyroscope.write
 title: pyroscope.write
 ---
 
-<span class="badge docs-labels__stage docs-labels__item">Public preview</span>
-
 # pyroscope.write
-
-{{< docs/shared lookup="stability/public_preview.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 `pyroscope.write` receives performance profiles from other components and forwards them to a series of user-supplied endpoints using [Pyroscope' Push API](/oss/pyroscope/).
 

--- a/internal/component/discovery/process/process.go
+++ b/internal/component/discovery/process/process.go
@@ -15,7 +15,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "discovery.process",
-		Stability: featuregate.StabilityPublicPreview,
+		Stability: featuregate.StabilityGenerallyAvailable,
 		Args:      Arguments{},
 		Exports:   discovery.Exports{},
 

--- a/internal/component/pyroscope/ebpf/ebpf_linux.go
+++ b/internal/component/pyroscope/ebpf/ebpf_linux.go
@@ -25,7 +25,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "pyroscope.ebpf",
-		Stability: featuregate.StabilityPublicPreview,
+		Stability: featuregate.StabilityGenerallyAvailable,
 		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {

--- a/internal/component/pyroscope/java/java.go
+++ b/internal/component/pyroscope/java/java.go
@@ -23,7 +23,7 @@ const (
 func init() {
 	component.Register(component.Registration{
 		Name:      "pyroscope.java",
-		Stability: featuregate.StabilityPublicPreview,
+		Stability: featuregate.StabilityGenerallyAvailable,
 		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {

--- a/internal/component/pyroscope/scrape/scrape.go
+++ b/internal/component/pyroscope/scrape/scrape.go
@@ -38,7 +38,7 @@ const (
 func init() {
 	component.Register(component.Registration{
 		Name:      "pyroscope.scrape",
-		Stability: featuregate.StabilityPublicPreview,
+		Stability: featuregate.StabilityGenerallyAvailable,
 		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {

--- a/internal/component/pyroscope/write/write.go
+++ b/internal/component/pyroscope/write/write.go
@@ -37,7 +37,7 @@ var (
 func init() {
 	component.Register(component.Registration{
 		Name:      "pyroscope.write",
-		Stability: featuregate.StabilityPublicPreview,
+		Stability: featuregate.StabilityGenerallyAvailable,
 		Args:      Arguments{},
 		Exports:   Exports{},
 		Build: func(o component.Options, c component.Arguments) (component.Component, error) {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Dealing with stability-preview is a burden for both internal grafana users and external.
Let's mark `pyroscope.ebpf`, `pyroscope.java`, `pyroscope.scrape`, `pyroscope.write`, `discovery.process` as GA.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
