### PR TITLE
Downgrade error log lines on Windows filesystem access issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ Main (unreleased)
   
 - Add support for configuring CPU profile's duration scraped by `pyroscope.scrape`. (@hainenber)
 
+- Improved filesystem error handling when working with `loki.source.file` and `local.file_match`,
+  which removes some false-positive error log messages on Windows (@thampiotr) 
+
 ### Bugfixes
 
 - Fix panic when component ID contains `/` in `otelcomponent.MustNewType(ID)`.(@qclaogui)

--- a/go.mod
+++ b/go.mod
@@ -159,6 +159,7 @@ require (
 	github.com/prometheus/snmp_exporter v0.26.0
 	github.com/prometheus/statsd_exporter v0.22.8
 	github.com/richardartoul/molecule v1.0.1-0.20221107223329-32cfee06a052
+	github.com/rogpeppe/go-internal v1.12.0
 	github.com/rs/cors v1.10.1
 	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.25
 	github.com/shirou/gopsutil/v3 v3.24.3

--- a/internal/component/common/loki/utils/fs_errors.go
+++ b/internal/component/common/loki/utils/fs_errors.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"errors"
+	"os"
+	"strings"
+
+	"github.com/rogpeppe/go-internal/robustio"
+)
+
+// IsEphemeralOrFileClosed checks if the error is an ephemeral error or if the file is already closed. This is useful
+// on certain file systems (e.g. on Windows) where in practice reading a file can result in ephemeral errors
+// (e.g. due to antivirus scans) or if the file appears as closed when being removed or rotated.
+func IsEphemeralOrFileClosed(err error) bool {
+	return robustio.IsEphemeralError(err) ||
+		errors.Is(os.ErrClosed, err) ||
+		// The above errors.Is(os.ErrClosedm, err) condition doesn't always capture the 'file already closed' error on
+		// Windows. Check the error message as well.
+		// Inspired by https://github.com/grafana/loki/blob/987e551f9e21b9a612dd0b6a3e60503ce6fe13a8/clients/cmd/docker-driver/driver.go#L145
+		strings.Contains(err.Error(), "file already closed")
+}

--- a/internal/component/loki/source/file/tailer.go
+++ b/internal/component/loki/source/file/tailer.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/component/common/loki/positions"
+	"github.com/grafana/alloy/internal/component/common/loki/utils"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
 )
 
@@ -309,10 +310,17 @@ func (t *tailer) Stop() {
 			level.Error(t.logger).Log("msg", "error marking file position when stopping tailer", "path", t.path, "error", err)
 		}
 
-		// Stop the underlying tailer
+		// Stop the underlying tailer to prevent resource leak.
 		err = t.tail.Stop()
 		if err != nil {
-			level.Error(t.logger).Log("msg", "error stopping tailer", "path", t.path, "error", err)
+			if utils.IsEphemeralOrFileClosed(err) {
+				// Don't log as error if the file is already closed, or we got an ephemeral error - it's a common case
+				// when files are rotating while being read and the tailer would have stopped correctly anyway.
+				level.Debug(t.logger).Log("msg", "tailer stopped with file I/O error", "path", t.path, "error", err)
+			} else {
+				// Log as error for other reasons, as a resource leak may have happened.
+				level.Error(t.logger).Log("msg", "error stopping tailer", "path", t.path, "error", err)
+			}
 		}
 		// Wait for readLines() to consume all the remaining messages and exit when the channel is closed
 		<-t.done


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

We had reports of misleading log lines being printed on Windows when log files are being deleted / moved during log file rotation. For example:

```
{"ts":"2024-05-16T06:00:49.0098797Z","level":"error","msg":"error stopping tailer","component_path":"...","component_id":"...","component":"tailer","path":"...","error":"seek ...: file already closed"}
{"ts":"2024-05-16T05:00:09.0009908Z","level":"error","msg":"error getting os stat","component_path":"...","component_id":"...","path":"...","err":"CreateFile ...: Access is denied."}
```

It seems that on Windows we can get these errors when trying to access the files shortly after they're being moved/deleted. In this PR we detect these specific errors and downgrade the log line to `debug` level.

Reproduced and later verified this fix works on a Windows VM. Also checked the goroutine dump to verify no goroutine leaks occurred. 

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
