### PR TITLE
Alloy-Mixin: allow config overwrite

### DIFF
--- a/example/config/alloy/config.alloy
+++ b/example/config/alloy/config.alloy
@@ -8,7 +8,21 @@ logging {
 	level = "debug"
 
 	// Forward internal logs to the local Loki instance.
-	write_to = [loki.write.loki.receiver]
+	write_to = [loki.relabel.alloy_logs.receiver]
+}
+
+loki.relabel "alloy_logs"{
+	rule {
+		target_label = "instance"
+		replacement = constants.hostname
+	}
+
+	rule {
+		target_label = "job"
+		replacement = "integrations/self"
+	}
+
+	forward_to = [loki.write.loki.receiver]
 }
 
 tracing {

--- a/operations/alloy-mixin/alerts.libsonnet
+++ b/operations/alloy-mixin/alerts.libsonnet
@@ -10,7 +10,7 @@ local openTelemetryAlerts = (import './alerts/opentelemetry.libsonnet');
     openTelemetryAlerts.newOpenTelemetryAlertsGroup($._config.enableK8sCluster)
   ],
 
-  prometheusAlerts+: {
+  prometheusAlerts+:: {
     groups+: 
       if $._config.enableAlloyCluster then
         alloyClusterAlerts + otherAlerts

--- a/operations/alloy-mixin/config.libsonnet
+++ b/operations/alloy-mixin/config.libsonnet
@@ -9,6 +9,6 @@
         instanceSelector: self.groupSelector + ', instance=~"$instance"',        
         logsFilterSelector: '', #use to filter logs originated from alloy, and avoid picking up other platform logs, ie: service_name="alloy"
         dashboardTag: 'alloy-mixin',
-        setenceCaseTemplates: false,
+        useSetenceCaseTemplateLabels: false,
     }
 }

--- a/operations/alloy-mixin/config.libsonnet
+++ b/operations/alloy-mixin/config.libsonnet
@@ -3,11 +3,12 @@
         enableK8sCluster: true,
         enableAlloyCluster: true,
         enableLokiLogs: true,
-        filterSelector: 'job=~"integrations/self"', #default job name used by alloy "self" exporter
+        filterSelector: '', #use it to filter specific metric label values, ie: job=~"integrations/alloy"
         k8sClusterSelector: 'cluster=~"$cluster", namespace=~"$namespace"',
         groupSelector: if self.enableK8sCluster then self.k8sClusterSelector + ', job="$job"' else 'job="$job"',        
         instanceSelector: self.groupSelector + ', instance=~"$instance"',        
-        logsFilterSelector: 'service_name="alloy"', #use to filter logs originated from alloy, and avoid picking up other platform logs
-        dashboardTag: 'alloy-mixin'
+        logsFilterSelector: '', #use to filter logs originated from alloy, and avoid picking up other platform logs, ie: service_name="alloy"
+        dashboardTag: 'alloy-mixin',
+        setenceCaseTemplates: false,
     }
 }

--- a/operations/alloy-mixin/config.libsonnet
+++ b/operations/alloy-mixin/config.libsonnet
@@ -3,10 +3,11 @@
         enableK8sCluster: true,
         enableAlloyCluster: true,
         enableLokiLogs: true,
-        filterSelector: 'job=~"$job"',
-        groupSelector: if self.enableK8sCluster then self.k8sClusterSelector + ', ' + self.filterSelector else self.filterSelector,
-        instanceSelector: self.groupSelector + ', instance=~"$instance"',
+        filterSelector: 'job=~"integrations/self"', #default job name used by alloy "self" exporter
         k8sClusterSelector: 'cluster=~"$cluster", namespace=~"$namespace"',
+        groupSelector: if self.enableK8sCluster then self.k8sClusterSelector + ', job="$job"' else 'job="$job"',        
+        instanceSelector: self.groupSelector + ', instance=~"$instance"',        
+        logsFilterSelector: 'service_name="alloy"', #use to filter logs originated from alloy, and avoid picking up other platform logs
         dashboardTag: 'alloy-mixin'
     }
 }

--- a/operations/alloy-mixin/dashboards.libsonnet
+++ b/operations/alloy-mixin/dashboards.libsonnet
@@ -1,24 +1,21 @@
 (import './dashboards/alloy-logs.libsonnet') +
 {
-  //declare config here to propagate it to the dashboards.
-  local config = {_config:: $._config},
-
   local alloyClusterDashboards =   
     (import './dashboards/cluster-node.libsonnet') + 
-    (import './dashboards/cluster-overview.libsonnet') +
-    config,
-
+    (import './dashboards/cluster-overview.libsonnet'),
   local otherDashboards =  
     (import './dashboards/resources.libsonnet') +
     (import './dashboards/controller.libsonnet') + 
     (import './dashboards/prometheus.libsonnet') + 
-    (import './dashboards/opentelemetry.libsonnet') +
-    config,  
+    (import './dashboards/opentelemetry.libsonnet'),
 
   grafanaDashboards+::
+  // Propagate config down to inner dashboards.
+  { _config:: $._config } + (
     if $._config.enableAlloyCluster then 
-       alloyClusterDashboards +
-       otherDashboards
-    else
+      alloyClusterDashboards + 
       otherDashboards
+    else 
+      otherDashboards 
+  )
 }

--- a/operations/alloy-mixin/dashboards.libsonnet
+++ b/operations/alloy-mixin/dashboards.libsonnet
@@ -1,5 +1,8 @@
 (import './dashboards/alloy-logs.libsonnet') +
 {
+  //declare config here to propagate it to the dashboards.
+  local config = {_config:: $._config},
+
   local alloyClusterDashboards =   
     (import './dashboards/cluster-node.libsonnet') + 
     (import './dashboards/cluster-overview.libsonnet') +
@@ -10,9 +13,7 @@
     (import './dashboards/controller.libsonnet') + 
     (import './dashboards/prometheus.libsonnet') + 
     (import './dashboards/opentelemetry.libsonnet') +
-    config,
-
-  local config = {_config:: $._config},
+    config,  
 
   grafanaDashboards+::
     if $._config.enableAlloyCluster then 

--- a/operations/alloy-mixin/dashboards.libsonnet
+++ b/operations/alloy-mixin/dashboards.libsonnet
@@ -1,18 +1,20 @@
-local alloyClusterDashboards =   
-  (import './dashboards/cluster-node.libsonnet') + 
-  (import './dashboards/cluster-overview.libsonnet') +
-  (import './config.libsonnet');
-
-local otherDashboards =  
-  (import './dashboards/resources.libsonnet') +
-  (import './dashboards/controller.libsonnet') + 
-  (import './dashboards/prometheus.libsonnet') + 
-  (import './dashboards/opentelemetry.libsonnet') +
-  (import './config.libsonnet');
-
 (import './dashboards/alloy-logs.libsonnet') +
-{   
-  grafanaDashboards+:     
+{
+  local alloyClusterDashboards =   
+    (import './dashboards/cluster-node.libsonnet') + 
+    (import './dashboards/cluster-overview.libsonnet') +
+    config,
+
+  local otherDashboards =  
+    (import './dashboards/resources.libsonnet') +
+    (import './dashboards/controller.libsonnet') + 
+    (import './dashboards/prometheus.libsonnet') + 
+    (import './dashboards/opentelemetry.libsonnet') +
+    config,
+
+  local config = {_config:: $._config},
+
+  grafanaDashboards+::
     if $._config.enableAlloyCluster then 
        alloyClusterDashboards +
        otherDashboards

--- a/operations/alloy-mixin/dashboards/alloy-logs.libsonnet
+++ b/operations/alloy-mixin/dashboards/alloy-logs.libsonnet
@@ -12,7 +12,7 @@ local logsDashboard = import 'github.com/grafana/jsonnet-libs/logs-lib/logs/main
           'Alloy / Logs Overview',
           datasourceName='loki_datasource',
           datasourceRegex='',
-          filterSelector=$._config.filterSelector,
+          filterSelector=$._config.logsFilterSelector,
           labels=labels,
           formatParser=null,
           showLogsVolume=true

--- a/operations/alloy-mixin/dashboards/alloy-logs.libsonnet
+++ b/operations/alloy-mixin/dashboards/alloy-logs.libsonnet
@@ -9,7 +9,7 @@ local logsDashboard = import 'github.com/grafana/jsonnet-libs/logs-lib/logs/main
     if $._config.enableLokiLogs then {
       local alloyLogs =
         logsDashboard.new(
-          'Alloy logs overview',
+          'Alloy / Logs Overview',
           datasourceName='loki_datasource',
           datasourceRegex='',
           filterSelector=$._config.filterSelector,
@@ -18,6 +18,7 @@ local logsDashboard = import 'github.com/grafana/jsonnet-libs/logs-lib/logs/main
           showLogsVolume=true
         )
         {
+          tags: [$._config.dashboardTag],
           panels+:
             {
               logs+:

--- a/operations/alloy-mixin/dashboards/alloy-logs.libsonnet
+++ b/operations/alloy-mixin/dashboards/alloy-logs.libsonnet
@@ -17,8 +17,7 @@ local logsDashboard = import 'github.com/grafana/jsonnet-libs/logs-lib/logs/main
           formatParser=null,
           showLogsVolume=true
         )
-        {
-          tags: [$._config.dashboardTag],
+        {          
           panels+:
             {
               logs+:
@@ -28,7 +27,8 @@ local logsDashboard = import 'github.com/grafana/jsonnet-libs/logs-lib/logs/main
           dashboards+:
             {
               logs+: g.dashboard.withLinksMixin($.grafanaDashboards['alloy-resources.json'].links)                     
-                     + g.dashboard.withRefresh('10s'),
+                     + g.dashboard.withRefresh('10s')
+                     + g.dashboard.withTagsMixin($._config.dashboardTag),
             },
         },
       'alloy-logs.json': alloyLogs.dashboards.logs,

--- a/operations/alloy-mixin/dashboards/alloy-logs.libsonnet
+++ b/operations/alloy-mixin/dashboards/alloy-logs.libsonnet
@@ -17,7 +17,7 @@ local logsDashboard = import 'github.com/grafana/jsonnet-libs/logs-lib/logs/main
           formatParser=null,
           showLogsVolume=true
         )
-        {          
+        {
           panels+:
             {
               logs+:

--- a/operations/alloy-mixin/dashboards/cluster-node.libsonnet
+++ b/operations/alloy-mixin/dashboards/cluster-node.libsonnet
@@ -9,7 +9,7 @@ local filename = 'alloy-cluster-node.json';
       filterSelector=$._config.filterSelector, 
       enableK8sCluster=$._config.enableK8sCluster, 
       includeInstance=true,
-      useSentenceCaseLabel=$._config.setenceCaseTemplates)
+      useSetenceCaseTemplateLabels=$._config.setenceCaseTemplates)
     .variables,
 
   [filename]:

--- a/operations/alloy-mixin/dashboards/cluster-node.libsonnet
+++ b/operations/alloy-mixin/dashboards/cluster-node.libsonnet
@@ -9,8 +9,7 @@ local filename = 'alloy-cluster-node.json';
       filterSelector=$._config.filterSelector, 
       enableK8sCluster=$._config.enableK8sCluster, 
       includeInstance=true,
-      useSetenceCaseTemplateLabels=$._config.setenceCaseTemplates)
-    .variables,
+      setenceCaseLabels=$._config.useSetenceCaseTemplateLabels),
 
   [filename]:
     dashboard.new(name='Alloy / Cluster Node', tag=$._config.dashboardTag) +

--- a/operations/alloy-mixin/dashboards/cluster-node.libsonnet
+++ b/operations/alloy-mixin/dashboards/cluster-node.libsonnet
@@ -6,15 +6,39 @@ local filename = 'alloy-cluster-node.json';
   local templateVariables = 
     if $._config.enableK8sCluster then
       [
-        dashboard.newTemplateVariable('cluster', 'label_values(alloy_component_controller_running_components, cluster)'),
-        dashboard.newTemplateVariable('namespace', 'label_values(alloy_component_controller_running_components{cluster=~"$cluster"}, namespace)'),
-        dashboard.newMultiTemplateVariable('job', 'label_values(alloy_component_controller_running_components{cluster=~"$cluster", namespace=~"$namespace"}, job)'),
-        dashboard.newMultiTemplateVariable('instance', 'label_values(alloy_component_controller_running_components{cluster=~"$cluster", namespace=~"$namespace", job=~"$job"}, instance)'),
+        dashboard.newTemplateVariable(
+          name='cluster', 
+          query= |||
+            label_values(alloy_component_controller_running_components{%(filterSelector)s}, cluster)
+          ||| % $._config),
+        dashboard.newTemplateVariable(
+          name='namespace', 
+          query= |||
+            label_values(alloy_component_controller_running_components{%(filterSelector)s, cluster=~"$cluster"}, namespace)
+          ||| % $._config),
+        dashboard.newMultiTemplateVariable(
+          name='job', 
+          query= |||
+            label_values(alloy_component_controller_running_components{%(filterSelector)s, cluster=~"$cluster", namespace=~"$namespace"}, job)
+          ||| % $._config),
+        dashboard.newMultiTemplateVariable(
+          name='instance', 
+          query= |||
+            label_values(alloy_component_controller_running_components{%(filterSelector)s, cluster=~"$cluster", namespace=~"$namespace", job=~"$job"}, instance)
+          ||| % $._config),
       ]
     else
       [
-        dashboard.newMultiTemplateVariable('job', 'label_values(alloy_component_controller_running_components, job)'),
-        dashboard.newMultiTemplateVariable('instance', 'label_values(alloy_component_controller_running_components{job=~"$job"}, instance)'),
+        dashboard.newMultiTemplateVariable(
+          name='job', 
+          query= |||
+            label_values(alloy_component_controller_running_components{%(filterSelector)s}, job)
+          ||| % $._config),
+        dashboard.newMultiTemplateVariable(
+          name='instance', 
+          query= |||
+            label_values(alloy_component_controller_running_components{%(filterSelector)s, job=~"$job"}, instance)
+          ||| % $._config),
       ],
 
   [filename]:

--- a/operations/alloy-mixin/dashboards/cluster-node.libsonnet
+++ b/operations/alloy-mixin/dashboards/cluster-node.libsonnet
@@ -1,45 +1,16 @@
 local dashboard = import './utils/dashboard.jsonnet';
 local panel = import './utils/panel.jsonnet';
+local templates = import './utils/templates.libsonnet';
 local filename = 'alloy-cluster-node.json';
 
 {
   local templateVariables = 
-    if $._config.enableK8sCluster then
-      [
-        dashboard.newTemplateVariable(
-          name='cluster', 
-          query= |||
-            label_values(alloy_component_controller_running_components{%(filterSelector)s}, cluster)
-          ||| % $._config),
-        dashboard.newTemplateVariable(
-          name='namespace', 
-          query= |||
-            label_values(alloy_component_controller_running_components{%(filterSelector)s, cluster=~"$cluster"}, namespace)
-          ||| % $._config),
-        dashboard.newMultiTemplateVariable(
-          name='job', 
-          query= |||
-            label_values(alloy_component_controller_running_components{%(filterSelector)s, cluster=~"$cluster", namespace=~"$namespace"}, job)
-          ||| % $._config),
-        dashboard.newMultiTemplateVariable(
-          name='instance', 
-          query= |||
-            label_values(alloy_component_controller_running_components{%(filterSelector)s, cluster=~"$cluster", namespace=~"$namespace", job=~"$job"}, instance)
-          ||| % $._config),
-      ]
-    else
-      [
-        dashboard.newMultiTemplateVariable(
-          name='job', 
-          query= |||
-            label_values(alloy_component_controller_running_components{%(filterSelector)s}, job)
-          ||| % $._config),
-        dashboard.newMultiTemplateVariable(
-          name='instance', 
-          query= |||
-            label_values(alloy_component_controller_running_components{%(filterSelector)s, job=~"$job"}, instance)
-          ||| % $._config),
-      ],
+    templates.newTemplateVariablesList(
+      filterSelector=$._config.filterSelector, 
+      enableK8sCluster=$._config.enableK8sCluster, 
+      includeInstance=true,
+      useSentenceCaseLabel=$._config.setenceCaseTemplates)
+    .variables,
 
   [filename]:
     dashboard.new(name='Alloy / Cluster Node', tag=$._config.dashboardTag) +

--- a/operations/alloy-mixin/dashboards/cluster-overview.libsonnet
+++ b/operations/alloy-mixin/dashboards/cluster-overview.libsonnet
@@ -10,8 +10,7 @@ local cluster_node_filename = 'alloy-cluster-node.json';
       filterSelector=$._config.filterSelector, 
       enableK8sCluster=$._config.enableK8sCluster, 
       includeInstance=false,
-      useSetenceCaseTemplateLabels=$._config.setenceCaseTemplates)
-    .variables,
+      setenceCaseLabels=$._config.useSetenceCaseTemplateLabels),
 
   [filename]:
     dashboard.new(name='Alloy / Cluster Overview', tag=$._config.dashboardTag) +

--- a/operations/alloy-mixin/dashboards/cluster-overview.libsonnet
+++ b/operations/alloy-mixin/dashboards/cluster-overview.libsonnet
@@ -7,13 +7,29 @@ local cluster_node_filename = 'alloy-cluster-node.json';
   local templateVariables = 
     if $._config.enableK8sCluster then
       [
-        dashboard.newTemplateVariable('cluster', 'label_values(alloy_component_controller_running_components, cluster)'),
-        dashboard.newTemplateVariable('namespace', 'label_values(alloy_component_controller_running_components{cluster=~"$cluster"}, namespace)'),
-        dashboard.newMultiTemplateVariable('job', 'label_values(alloy_component_controller_running_components{cluster=~"$cluster", namespace=~"$namespace"}, job)'),
+        dashboard.newTemplateVariable(
+          name='cluster', 
+          query= ||| 
+            label_values(alloy_component_controller_running_components{%(filterSelector)s}, cluster)
+          ||| % $._config),
+        dashboard.newTemplateVariable(
+          name='namespace', 
+          query= |||
+            label_values(alloy_component_controller_running_components{%(filterSelector)s, cluster=~"$cluster"}, namespace)
+          ||| % $._config),
+        dashboard.newMultiTemplateVariable(
+          name='job', 
+          query= ||| 
+            label_values(alloy_component_controller_running_components{%(filterSelector)s, cluster=~"$cluster", namespace=~"$namespace"}, job)
+          ||| % $._config),        
       ]
     else
       [
-        dashboard.newMultiTemplateVariable('job', 'label_values(alloy_component_controller_running_components, job)'),        
+        dashboard.newMultiTemplateVariable(
+          name='job', 
+          query= ||| 
+            label_values(alloy_component_controller_running_components{%(filterSelector)s}, job)
+          ||| % $._config),        
       ],
 
   [filename]:

--- a/operations/alloy-mixin/dashboards/cluster-overview.libsonnet
+++ b/operations/alloy-mixin/dashboards/cluster-overview.libsonnet
@@ -10,7 +10,7 @@ local cluster_node_filename = 'alloy-cluster-node.json';
       filterSelector=$._config.filterSelector, 
       enableK8sCluster=$._config.enableK8sCluster, 
       includeInstance=false,
-      useSentenceCaseLabel=$._config.setenceCaseTemplates)
+      useSetenceCaseTemplateLabels=$._config.setenceCaseTemplates)
     .variables,
 
   [filename]:

--- a/operations/alloy-mixin/dashboards/cluster-overview.libsonnet
+++ b/operations/alloy-mixin/dashboards/cluster-overview.libsonnet
@@ -36,7 +36,9 @@ local cluster_node_filename = 'alloy-cluster-node.json';
         panel.withPosition({ h: 9, w: 8, x: 0, y: 0 }) +
         panel.withQueries([
           panel.newInstantQuery(
-            expr='count(cluster_node_info{%(groupSelector)s})'
+            expr= |||
+              'count(cluster_node_info{%(groupSelector)s})'
+            ||| % $._config
           ),
         ])
       ),
@@ -49,7 +51,9 @@ local cluster_node_filename = 'alloy-cluster-node.json';
         panel.withPosition({ h: 9, w: 16, x: 8, y: 0 }) +
         panel.withQueries([
           panel.newInstantQuery(
-            expr='cluster_node_info{%(groupSelector)s}',
+            expr= |||
+              'cluster_node_info{%(groupSelector)s}'
+            ||| % $._config,
             format='table',
           ),
         ]) +

--- a/operations/alloy-mixin/dashboards/cluster-overview.libsonnet
+++ b/operations/alloy-mixin/dashboards/cluster-overview.libsonnet
@@ -1,36 +1,17 @@
 local dashboard = import './utils/dashboard.jsonnet';
 local panel = import './utils/panel.jsonnet';
 local filename = 'alloy-cluster-overview.json';
+local templates = import './utils/templates.libsonnet';
 local cluster_node_filename = 'alloy-cluster-node.json';
 
 {
   local templateVariables = 
-    if $._config.enableK8sCluster then
-      [
-        dashboard.newTemplateVariable(
-          name='cluster', 
-          query= ||| 
-            label_values(alloy_component_controller_running_components{%(filterSelector)s}, cluster)
-          ||| % $._config),
-        dashboard.newTemplateVariable(
-          name='namespace', 
-          query= |||
-            label_values(alloy_component_controller_running_components{%(filterSelector)s, cluster=~"$cluster"}, namespace)
-          ||| % $._config),
-        dashboard.newMultiTemplateVariable(
-          name='job', 
-          query= ||| 
-            label_values(alloy_component_controller_running_components{%(filterSelector)s, cluster=~"$cluster", namespace=~"$namespace"}, job)
-          ||| % $._config),        
-      ]
-    else
-      [
-        dashboard.newMultiTemplateVariable(
-          name='job', 
-          query= ||| 
-            label_values(alloy_component_controller_running_components{%(filterSelector)s}, job)
-          ||| % $._config),        
-      ],
+    templates.newTemplateVariablesList(
+      filterSelector=$._config.filterSelector, 
+      enableK8sCluster=$._config.enableK8sCluster, 
+      includeInstance=false,
+      useSentenceCaseLabel=$._config.setenceCaseTemplates)
+    .variables,
 
   [filename]:
     dashboard.new(name='Alloy / Cluster Overview', tag=$._config.dashboardTag) +

--- a/operations/alloy-mixin/dashboards/controller.libsonnet
+++ b/operations/alloy-mixin/dashboards/controller.libsonnet
@@ -9,7 +9,7 @@ local filename = 'alloy-controller.json';
       filterSelector=$._config.filterSelector, 
       enableK8sCluster=$._config.enableK8sCluster, 
       includeInstance=false,
-      useSentenceCaseLabel=$._config.setenceCaseTemplates)
+      useSetenceCaseTemplateLabels=$._config.setenceCaseTemplates)
     .variables,
 
   [filename]:

--- a/operations/alloy-mixin/dashboards/controller.libsonnet
+++ b/operations/alloy-mixin/dashboards/controller.libsonnet
@@ -1,36 +1,16 @@
 local dashboard = import './utils/dashboard.jsonnet';
 local panel = import './utils/panel.jsonnet';
+local templates = import './utils/templates.libsonnet';
 local filename = 'alloy-controller.json';
 
 {
-
   local templateVariables = 
-    if $._config.enableK8sCluster then
-      [
-        dashboard.newTemplateVariable(
-          name='cluster', 
-          query= ||| 
-            label_values(alloy_component_controller_running_components{%(filterSelector)s}, cluster)
-          ||| % $._config),
-        dashboard.newTemplateVariable(
-          name='namespace', 
-          query= |||
-            label_values(alloy_component_controller_running_components{%(filterSelector)s, cluster=~"$cluster"}, namespace)
-          ||| % $._config),
-        dashboard.newMultiTemplateVariable(
-          name='job', 
-          query= ||| 
-            label_values(alloy_component_controller_running_components{%(filterSelector)s, cluster=~"$cluster", namespace=~"$namespace"}, job)
-          ||| % $._config),        
-      ]
-    else
-      [
-        dashboard.newMultiTemplateVariable(
-          name='job', 
-          query= ||| 
-            label_values(alloy_component_controller_running_components{%(filterSelector)s}, job)
-          ||| % $._config),        
-      ],
+    templates.newTemplateVariablesList(
+      filterSelector=$._config.filterSelector, 
+      enableK8sCluster=$._config.enableK8sCluster, 
+      includeInstance=false,
+      useSentenceCaseLabel=$._config.setenceCaseTemplates)
+    .variables,
 
   [filename]:
     dashboard.new(name='Alloy / Controller', tag=$._config.dashboardTag) +

--- a/operations/alloy-mixin/dashboards/controller.libsonnet
+++ b/operations/alloy-mixin/dashboards/controller.libsonnet
@@ -309,7 +309,7 @@ local filename = 'alloy-controller.json';
             expr= |||
               sum(increase(alloy_component_evaluation_seconds{%(groupSelector)s}[$__rate_interval]))
               or ignoring (le)
-              sum by (le) (increase(alloy_component_evaluation_seconds_bucket{%(groupSelector)s}[$__rate_interval]))'
+              sum by (le) (increase(alloy_component_evaluation_seconds_bucket{%(groupSelector)s}[$__rate_interval]))
             ||| % $._config,
             format='heatmap',
             legendFormat='{{le}}',

--- a/operations/alloy-mixin/dashboards/controller.libsonnet
+++ b/operations/alloy-mixin/dashboards/controller.libsonnet
@@ -7,13 +7,29 @@ local filename = 'alloy-controller.json';
   local templateVariables = 
     if $._config.enableK8sCluster then
       [
-        dashboard.newTemplateVariable('cluster', 'label_values(alloy_component_controller_running_components, cluster)'),
-        dashboard.newTemplateVariable('namespace', 'label_values(alloy_component_controller_running_components{cluster=~"$cluster"}, namespace)'),
-        dashboard.newMultiTemplateVariable('job', 'label_values(alloy_component_controller_running_components{cluster=~"$cluster", namespace=~"$namespace"}, job)'),
+        dashboard.newTemplateVariable(
+          name='cluster', 
+          query= ||| 
+            label_values(alloy_component_controller_running_components{%(filterSelector)s}, cluster)
+          ||| % $._config),
+        dashboard.newTemplateVariable(
+          name='namespace', 
+          query= |||
+            label_values(alloy_component_controller_running_components{%(filterSelector)s, cluster=~"$cluster"}, namespace)
+          ||| % $._config),
+        dashboard.newMultiTemplateVariable(
+          name='job', 
+          query= ||| 
+            label_values(alloy_component_controller_running_components{%(filterSelector)s, cluster=~"$cluster", namespace=~"$namespace"}, job)
+          ||| % $._config),        
       ]
     else
       [
-        dashboard.newMultiTemplateVariable('job', 'label_values(alloy_component_controller_running_components, job)'),        
+        dashboard.newMultiTemplateVariable(
+          name='job', 
+          query= ||| 
+            label_values(alloy_component_controller_running_components{%(filterSelector)s}, job)
+          ||| % $._config),        
       ],
 
   [filename]:

--- a/operations/alloy-mixin/dashboards/controller.libsonnet
+++ b/operations/alloy-mixin/dashboards/controller.libsonnet
@@ -9,8 +9,7 @@ local filename = 'alloy-controller.json';
       filterSelector=$._config.filterSelector, 
       enableK8sCluster=$._config.enableK8sCluster, 
       includeInstance=false,
-      useSetenceCaseTemplateLabels=$._config.setenceCaseTemplates)
-    .variables,
+      setenceCaseLabels=$._config.useSetenceCaseTemplateLabels),
 
   [filename]:
     dashboard.new(name='Alloy / Controller', tag=$._config.dashboardTag) +

--- a/operations/alloy-mixin/dashboards/opentelemetry.libsonnet
+++ b/operations/alloy-mixin/dashboards/opentelemetry.libsonnet
@@ -21,7 +21,7 @@ local stackedPanelMixin = {
       filterSelector=$._config.filterSelector, 
       enableK8sCluster=$._config.enableK8sCluster, 
       includeInstance=true,
-      useSentenceCaseLabel=$._config.setenceCaseTemplates)
+      useSetenceCaseTemplateLabels=$._config.setenceCaseTemplates)
     .variables,
 
   [filename]:

--- a/operations/alloy-mixin/dashboards/opentelemetry.libsonnet
+++ b/operations/alloy-mixin/dashboards/opentelemetry.libsonnet
@@ -18,15 +18,39 @@ local stackedPanelMixin = {
   local templateVariables = 
     if $._config.enableK8sCluster then
       [
-        dashboard.newTemplateVariable('cluster', 'label_values(alloy_component_controller_running_components, cluster)'),
-        dashboard.newTemplateVariable('namespace', 'label_values(alloy_component_controller_running_components{cluster=~"$cluster"}, namespace)'),
-        dashboard.newMultiTemplateVariable('job', 'label_values(alloy_component_controller_running_components{cluster=~"$cluster", namespace=~"$namespace"}, job)'),
-        dashboard.newMultiTemplateVariable('instance', 'label_values(alloy_component_controller_running_components{cluster=~"$cluster", namespace=~"$namespace", job=~"$job"}, instance)'),
+        dashboard.newTemplateVariable(
+          name='cluster', 
+          query= ||| 
+            label_values(alloy_component_controller_running_components{%(filterSelector)s}, cluster)
+          ||| % $._config),
+        dashboard.newTemplateVariable(
+          name='namespace', 
+          query= |||
+            label_values(alloy_component_controller_running_components{%(filterSelector)s, cluster=~"$cluster"}, namespace)
+          ||| % $._config),
+        dashboard.newMultiTemplateVariable(
+          name='job', 
+          query= ||| 
+            label_values(alloy_component_controller_running_components{%(filterSelector)s, cluster=~"$cluster", namespace=~"$namespace"}, job)
+          ||| % $._config),
+        dashboard.newMultiTemplateVariable(
+          name='instance', 
+          query= |||
+            label_values(alloy_component_controller_running_components{%(filterSelector)s, cluster=~"$cluster", namespace=~"$namespace", job=~"$job"}, instance)
+          ||| % $._config),
       ]
     else
       [
-        dashboard.newMultiTemplateVariable('job', 'label_values(alloy_component_controller_running_components, job)'),
-        dashboard.newMultiTemplateVariable('instance', 'label_values(alloy_component_controller_running_components{job=~"$job"}, instance)'),
+        dashboard.newMultiTemplateVariable(
+          name='job', 
+          query= ||| 
+            label_values(alloy_component_controller_running_components{%(filterSelector)s}, job)
+          ||| % $._config),
+        dashboard.newMultiTemplateVariable(
+          name='instance', 
+          query= |||
+            label_values(alloy_component_controller_running_components{%(filterSelector)s, job=~"$job"}, instance)
+          ||| % $._config),
       ],
 
   [filename]:

--- a/operations/alloy-mixin/dashboards/opentelemetry.libsonnet
+++ b/operations/alloy-mixin/dashboards/opentelemetry.libsonnet
@@ -1,5 +1,6 @@
 local dashboard = import './utils/dashboard.jsonnet';
 local panel = import './utils/panel.jsonnet';
+local templates = import './utils/templates.libsonnet';
 local filename = 'alloy-opentelemetry.json';
 
 local stackedPanelMixin = {
@@ -16,42 +17,12 @@ local stackedPanelMixin = {
 
 {
   local templateVariables = 
-    if $._config.enableK8sCluster then
-      [
-        dashboard.newTemplateVariable(
-          name='cluster', 
-          query= ||| 
-            label_values(alloy_component_controller_running_components{%(filterSelector)s}, cluster)
-          ||| % $._config),
-        dashboard.newTemplateVariable(
-          name='namespace', 
-          query= |||
-            label_values(alloy_component_controller_running_components{%(filterSelector)s, cluster=~"$cluster"}, namespace)
-          ||| % $._config),
-        dashboard.newMultiTemplateVariable(
-          name='job', 
-          query= ||| 
-            label_values(alloy_component_controller_running_components{%(filterSelector)s, cluster=~"$cluster", namespace=~"$namespace"}, job)
-          ||| % $._config),
-        dashboard.newMultiTemplateVariable(
-          name='instance', 
-          query= |||
-            label_values(alloy_component_controller_running_components{%(filterSelector)s, cluster=~"$cluster", namespace=~"$namespace", job=~"$job"}, instance)
-          ||| % $._config),
-      ]
-    else
-      [
-        dashboard.newMultiTemplateVariable(
-          name='job', 
-          query= ||| 
-            label_values(alloy_component_controller_running_components{%(filterSelector)s}, job)
-          ||| % $._config),
-        dashboard.newMultiTemplateVariable(
-          name='instance', 
-          query= |||
-            label_values(alloy_component_controller_running_components{%(filterSelector)s, job=~"$job"}, instance)
-          ||| % $._config),
-      ],
+    templates.newTemplateVariablesList(
+      filterSelector=$._config.filterSelector, 
+      enableK8sCluster=$._config.enableK8sCluster, 
+      includeInstance=true,
+      useSentenceCaseLabel=$._config.setenceCaseTemplates)
+    .variables,
 
   [filename]:
     dashboard.new(name='Alloy / OpenTelemetry', tag=$._config.dashboardTag) +

--- a/operations/alloy-mixin/dashboards/opentelemetry.libsonnet
+++ b/operations/alloy-mixin/dashboards/opentelemetry.libsonnet
@@ -21,8 +21,7 @@ local stackedPanelMixin = {
       filterSelector=$._config.filterSelector, 
       enableK8sCluster=$._config.enableK8sCluster, 
       includeInstance=true,
-      useSetenceCaseTemplateLabels=$._config.setenceCaseTemplates)
-    .variables,
+      setenceCaseLabels=$._config.useSetenceCaseTemplateLabels),
 
   [filename]:
     dashboard.new(name='Alloy / OpenTelemetry', tag=$._config.dashboardTag) +

--- a/operations/alloy-mixin/dashboards/prometheus.libsonnet
+++ b/operations/alloy-mixin/dashboards/prometheus.libsonnet
@@ -397,24 +397,72 @@ local filename = 'alloy-prometheus-remote-write.json';
     else
       remoteWritePanels(y_offset=0),
 
-  local templateVariables = 
+  local templateVariables =
     if $._config.enableK8sCluster then
       [
-        dashboard.newTemplateVariable('cluster', 'label_values(alloy_component_controller_running_components, cluster)'),
-        dashboard.newTemplateVariable('namespace', 'label_values(alloy_component_controller_running_components{cluster=~"$cluster"}, namespace)'),
-        dashboard.newMultiTemplateVariable('job', 'label_values(alloy_component_controller_running_components{cluster=~"$cluster", namespace=~"$namespace"}, job)'),
-        dashboard.newMultiTemplateVariable('instance', 'label_values(alloy_component_controller_running_components{cluster=~"$cluster", namespace=~"$namespace", job=~"$job"}, instance)'),
-        dashboard.newMultiTemplateVariable('component_path', 'label_values(prometheus_remote_write_wal_samples_appended_total{cluster=~"$cluster", namespace=~"$namespace", job=~"$job", instance=~"$instance", component_id=~"prometheus.remote_write.*", component_path=~".*"}, component_path)'),
-        dashboard.newMultiTemplateVariable('component', 'label_values(prometheus_remote_write_wal_samples_appended_total{cluster=~"$cluster", namespace=~"$namespace", job=~"$job", instance=~"$instance", component_id=~"prometheus.remote_write.*"}, component_id)'),
-        dashboard.newMultiTemplateVariable('url', 'label_values(prometheus_remote_storage_sent_batch_duration_seconds_sum{cluster=~"$cluster", namespace=~"$namespace", job="$job", instance=~"$instance", component_id=~"$component"}, url)'),
+        dashboard.newTemplateVariable(
+          name='cluster', 
+          query= ||| 
+            label_values(alloy_component_controller_running_components{%(filterSelector)s}, cluster)
+          ||| % $._config),
+        dashboard.newTemplateVariable(
+          name='namespace', 
+          query= |||
+            label_values(alloy_component_controller_running_components{%(filterSelector)s, cluster=~"$cluster"}, namespace)
+          ||| % $._config),
+        dashboard.newMultiTemplateVariable(
+          name='job', 
+          query= ||| 
+            label_values(alloy_component_controller_running_components{%(filterSelector)s, cluster=~"$cluster", namespace=~"$namespace"}, job)
+          ||| % $._config),
+        dashboard.newMultiTemplateVariable(
+          name='instance', 
+          query= |||
+            label_values(alloy_component_controller_running_components{%(filterSelector)s, cluster=~"$cluster", namespace=~"$namespace", job=~"$job"}, instance)
+          ||| % $._config),
+        dashboard.newMultiTemplateVariable(
+          name='component_path', 
+          query= |||
+            label_values(prometheus_remote_write_wal_samples_appended_total{%(filterSelector)s, cluster=~"$cluster", namespace=~"$namespace", job=~"$job", instance=~"$instance", component_id=~"prometheus.remote_write.*", component_path=~".*"}, component_path)
+          ||| % $._config),
+        dashboard.newMultiTemplateVariable(
+          name='component', 
+          query= |||
+            'label_values(prometheus_remote_write_wal_samples_appended_total{%(filterSelector)s, cluster=~"$cluster", namespace=~"$namespace", job=~"$job", instance=~"$instance", component_id=~"prometheus.remote_write.*"}, component_id)
+          ||| % $._config),          
+        dashboard.newMultiTemplateVariable(
+          name='url', 
+          query= |||
+            'label_values(prometheus_remote_storage_sent_batch_duration_seconds_sum{%(filterSelector)s, cluster=~"$cluster", namespace=~"$namespace", job="$job", instance=~"$instance", component_id=~"$component"}, url)
+          ||| % $._config),
       ]
     else
       [
-        dashboard.newMultiTemplateVariable('job', 'label_values(alloy_component_controller_running_components, job)'),
-        dashboard.newMultiTemplateVariable('instance', 'label_values(alloy_component_controller_running_components{job=~"$job"}, instance)'),
-        dashboard.newMultiTemplateVariable('component_path', 'label_values(prometheus_remote_write_wal_samples_appended_total{job=~"$job", instance=~"$instance", component_id=~"prometheus.remote_write.*", component_path=~".*"}, component_path)'),
-        dashboard.newMultiTemplateVariable('component', 'label_values(prometheus_remote_write_wal_samples_appended_total{job=~"$job", instance=~"$instance", component_id=~"prometheus.remote_write.*"}, component_id)'),
-        dashboard.newMultiTemplateVariable('url', 'label_values(prometheus_remote_storage_sent_batch_duration_seconds_sum{job=~"$job", instance=~"$instance", component_id=~"$component"}, url)'),
+        dashboard.newMultiTemplateVariable(
+          name='job', 
+          query= ||| 
+            label_values(alloy_component_controller_running_components{%(filterSelector)s}, job)
+          ||| % $._config),
+        dashboard.newMultiTemplateVariable(
+          name='instance', 
+          query= |||
+            label_values(alloy_component_controller_running_components{%(filterSelector)s, job=~"$job"}, instance)
+          ||| % $._config),
+        dashboard.newMultiTemplateVariable(
+          name='component_path', 
+          query= |||
+            label_values(prometheus_remote_write_wal_samples_appended_total{%(filterSelector)s, job=~"$job", instance=~"$instance", component_id=~"prometheus.remote_write.*", component_path=~".*"}, component_path)
+          ||| % $._config),
+        dashboard.newMultiTemplateVariable(
+          name='component', 
+          query= |||
+            'label_values(prometheus_remote_write_wal_samples_appended_total{%(filterSelector)s, job=~"$job", instance=~"$instance", component_id=~"prometheus.remote_write.*"}, component_id)
+          ||| % $._config),          
+        dashboard.newMultiTemplateVariable(
+          name='url', 
+          query= |||
+            'label_values(prometheus_remote_storage_sent_batch_duration_seconds_sum{%(filterSelector)s, job="$job", instance=~"$instance", component_id=~"$component"}, url)
+          ||| % $._config),
       ],
 
   [filename]:

--- a/operations/alloy-mixin/dashboards/prometheus.libsonnet
+++ b/operations/alloy-mixin/dashboards/prometheus.libsonnet
@@ -464,30 +464,30 @@ local filename = 'alloy-prometheus-remote-write.json';
         dashboard.newMultiTemplateVariable(
           name='component_path', 
           query=k8sComponentPathQuery,
-          useSentenceCaseLabel=$._config.setenceCaseTemplates),
+          useSetenceCaseTemplateLabels=$._config.setenceCaseTemplates),
         dashboard.newMultiTemplateVariable(
           name='component', 
           query=k8sComponentQuery,
-          useSentenceCaseLabel=$._config.setenceCaseTemplates),          
+          useSetenceCaseTemplateLabels=$._config.setenceCaseTemplates),          
         dashboard.newMultiTemplateVariable(
           name='url', 
           query= k8sUrlQuery,
-          useSentenceCaseLabel=$._config.setenceCaseTemplates),
+          useSetenceCaseTemplateLabels=$._config.setenceCaseTemplates),
       ]
     else
       [       
         dashboard.newMultiTemplateVariable(
           name='component_path', 
           query=componentPathQuery,
-          useSentenceCaseLabel=$._config.setenceCaseTemplates),
+          useSetenceCaseTemplateLabels=$._config.setenceCaseTemplates),
         dashboard.newMultiTemplateVariable(
           name='component', 
           query=componentQuery,
-          useSentenceCaseLabel=$._config.setenceCaseTemplates),          
+          useSetenceCaseTemplateLabels=$._config.setenceCaseTemplates),          
         dashboard.newMultiTemplateVariable(
           name='url', 
           query=urlQuery,
-          useSentenceCaseLabel=$._config.setenceCaseTemplates),
+          useSetenceCaseTemplateLabels=$._config.setenceCaseTemplates),
       ],
     
     local templateVariables = 
@@ -495,7 +495,7 @@ local filename = 'alloy-prometheus-remote-write.json';
         filterSelector=$._config.filterSelector, 
         enableK8sCluster=$._config.enableK8sCluster, 
         includeInstance=true,
-        useSentenceCaseLabel=$._config.setenceCaseTemplates)
+        useSetenceCaseTemplateLabels=$._config.setenceCaseTemplates)
       .variables + prometheusTemplateVariables,
 
   [filename]:

--- a/operations/alloy-mixin/dashboards/prometheus.libsonnet
+++ b/operations/alloy-mixin/dashboards/prometheus.libsonnet
@@ -464,30 +464,30 @@ local filename = 'alloy-prometheus-remote-write.json';
         dashboard.newMultiTemplateVariable(
           name='component_path', 
           query=k8sComponentPathQuery,
-          useSetenceCaseTemplateLabels=$._config.setenceCaseTemplates),
+          setenceCaseLabels=$._config.useSetenceCaseTemplateLabels),
         dashboard.newMultiTemplateVariable(
           name='component', 
           query=k8sComponentQuery,
-          useSetenceCaseTemplateLabels=$._config.setenceCaseTemplates),          
+          setenceCaseLabels=$._config.useSetenceCaseTemplateLabels),          
         dashboard.newMultiTemplateVariable(
           name='url', 
           query= k8sUrlQuery,
-          useSetenceCaseTemplateLabels=$._config.setenceCaseTemplates),
+          setenceCaseLabels=$._config.useSetenceCaseTemplateLabels),
       ]
     else
       [       
         dashboard.newMultiTemplateVariable(
           name='component_path', 
           query=componentPathQuery,
-          useSetenceCaseTemplateLabels=$._config.setenceCaseTemplates),
+          setenceCaseLabels=$._config.useSetenceCaseTemplateLabels),
         dashboard.newMultiTemplateVariable(
           name='component', 
           query=componentQuery,
-          useSetenceCaseTemplateLabels=$._config.setenceCaseTemplates),          
+          setenceCaseLabels=$._config.useSetenceCaseTemplateLabels),          
         dashboard.newMultiTemplateVariable(
           name='url', 
           query=urlQuery,
-          useSetenceCaseTemplateLabels=$._config.setenceCaseTemplates),
+          setenceCaseLabels=$._config.useSetenceCaseTemplateLabels),
       ],
     
     local templateVariables = 
@@ -495,8 +495,8 @@ local filename = 'alloy-prometheus-remote-write.json';
         filterSelector=$._config.filterSelector, 
         enableK8sCluster=$._config.enableK8sCluster, 
         includeInstance=true,
-        useSetenceCaseTemplateLabels=$._config.setenceCaseTemplates)
-      .variables + prometheusTemplateVariables,
+        setenceCaseLabels=$._config.useSetenceCaseTemplateLabels)
+      + prometheusTemplateVariables,
 
   [filename]:
     dashboard.new(name='Alloy / Prometheus Components', tag=$._config.dashboardTag) +

--- a/operations/alloy-mixin/dashboards/resources.libsonnet
+++ b/operations/alloy-mixin/dashboards/resources.libsonnet
@@ -33,8 +33,7 @@ local stackedPanelMixin = {
       filterSelector=$._config.filterSelector, 
       enableK8sCluster=$._config.enableK8sCluster, 
       includeInstance=true,
-      useSetenceCaseTemplateLabels=$._config.setenceCaseTemplates)
-    .variables,
+      setenceCaseLabels=$._config.useSetenceCaseTemplateLabels),
 
   [filename]:
     dashboard.new(name='Alloy / Resources', tag=$._config.dashboardTag) +

--- a/operations/alloy-mixin/dashboards/resources.libsonnet
+++ b/operations/alloy-mixin/dashboards/resources.libsonnet
@@ -33,7 +33,7 @@ local stackedPanelMixin = {
       filterSelector=$._config.filterSelector, 
       enableK8sCluster=$._config.enableK8sCluster, 
       includeInstance=true,
-      useSentenceCaseLabel=$._config.setenceCaseTemplates)
+      useSetenceCaseTemplateLabels=$._config.setenceCaseTemplates)
     .variables,
 
   [filename]:

--- a/operations/alloy-mixin/dashboards/resources.libsonnet
+++ b/operations/alloy-mixin/dashboards/resources.libsonnet
@@ -30,15 +30,39 @@ local stackedPanelMixin = {
   local templateVariables = 
     if $._config.enableK8sCluster then
       [
-        dashboard.newTemplateVariable('cluster', 'label_values(alloy_component_controller_running_components, cluster)'),
-        dashboard.newTemplateVariable('namespace', 'label_values(alloy_component_controller_running_components{cluster=~"$cluster"}, namespace)'),
-        dashboard.newMultiTemplateVariable('job', 'label_values(alloy_component_controller_running_components{cluster=~"$cluster", namespace=~"$namespace"}, job)'),
-        dashboard.newMultiTemplateVariable('instance', 'label_values(alloy_component_controller_running_components{cluster=~"$cluster", namespace=~"$namespace", job=~"$job"}, instance)'),
+        dashboard.newTemplateVariable(
+          name='cluster', 
+          query= ||| 
+            label_values(alloy_component_controller_running_components{%(filterSelector)s}, cluster)
+          ||| % $._config),
+        dashboard.newTemplateVariable(
+          name='namespace', 
+          query= |||
+            label_values(alloy_component_controller_running_components{%(filterSelector)s, cluster=~"$cluster"}, namespace)
+          ||| % $._config),
+        dashboard.newMultiTemplateVariable(
+          name='job', 
+          query= ||| 
+            label_values(alloy_component_controller_running_components{%(filterSelector)s, cluster=~"$cluster", namespace=~"$namespace"}, job)
+          ||| % $._config),
+        dashboard.newMultiTemplateVariable(
+          name='instance', 
+          query= |||
+            label_values(alloy_component_controller_running_components{%(filterSelector)s, cluster=~"$cluster", namespace=~"$namespace", job=~"$job"}, instance)
+          ||| % $._config),
       ]
     else
       [
-        dashboard.newMultiTemplateVariable('job', 'label_values(alloy_component_controller_running_components, job)'),
-        dashboard.newMultiTemplateVariable('instance', 'label_values(alloy_component_controller_running_components{job=~"$job"}, instance)'),        
+        dashboard.newMultiTemplateVariable(
+          name='job', 
+          query= ||| 
+            label_values(alloy_component_controller_running_components{%(filterSelector)s}, job)
+          ||| % $._config),
+        dashboard.newMultiTemplateVariable(
+          name='instance', 
+          query= |||
+            label_values(alloy_component_controller_running_components{%(filterSelector)s, job=~"$job"}, instance)
+          ||| % $._config),
       ],
 
   [filename]:

--- a/operations/alloy-mixin/dashboards/utils/dashboard.jsonnet
+++ b/operations/alloy-mixin/dashboards/utils/dashboard.jsonnet
@@ -66,9 +66,9 @@
     },
   },
 
-  newTemplateVariable(name, query):: {
+  newTemplateVariable(name, query, useSentenceCaseLabel=false):: {
     name: name,
-    label: $.toSentenceCase(name),
+    label: if useSentenceCaseLabel then $.toSentenceCase(name) else name,
     type: 'query',
     query: {
       query: query,
@@ -89,7 +89,7 @@
     titleFormat: '{{cluster}}/{{namespace}}',
   },
 
-  newMultiTemplateVariable(name, query):: $.newTemplateVariable(name, query) {
+  newMultiTemplateVariable(name, query, useSentenceCaseLabel=false):: $.newTemplateVariable(name, query, useSentenceCaseLabel) {
     multi: true,
     allValue: '.*',
     includeAll: true,

--- a/operations/alloy-mixin/dashboards/utils/dashboard.jsonnet
+++ b/operations/alloy-mixin/dashboards/utils/dashboard.jsonnet
@@ -66,9 +66,9 @@
     },
   },
 
-  newTemplateVariable(name, query, useSentenceCaseLabel=false):: {
+  newTemplateVariable(name, query, useSetenceCaseTemplateLabels=false):: {
     name: name,
-    label: if useSentenceCaseLabel then $.toSentenceCase(name) else name,
+    label: if useSetenceCaseTemplateLabels then $.toSentenceCase(name) else name,
     type: 'query',
     query: {
       query: query,
@@ -89,7 +89,7 @@
     titleFormat: '{{cluster}}/{{namespace}}',
   },
 
-  newMultiTemplateVariable(name, query, useSentenceCaseLabel=false):: $.newTemplateVariable(name, query, useSentenceCaseLabel) {
+  newMultiTemplateVariable(name, query, useSetenceCaseTemplateLabels=false):: $.newTemplateVariable(name, query, useSetenceCaseTemplateLabels) {
     multi: true,
     allValue: '.*',
     includeAll: true,

--- a/operations/alloy-mixin/dashboards/utils/dashboard.jsonnet
+++ b/operations/alloy-mixin/dashboards/utils/dashboard.jsonnet
@@ -68,7 +68,7 @@
 
   newTemplateVariable(name, query):: {
     name: name,
-    label: name,
+    label: $.toSentenceCase(name),
     type: 'query',
     query: {
       query: query,
@@ -126,4 +126,7 @@
       targetBlank: false,
     }],
   },
+
+  toSentenceCase(string)::
+    std.asciiUpper(string[0]) + std.slice(string, 1, std.length(string), 1),
 }

--- a/operations/alloy-mixin/dashboards/utils/dashboard.jsonnet
+++ b/operations/alloy-mixin/dashboards/utils/dashboard.jsonnet
@@ -66,9 +66,9 @@
     },
   },
 
-  newTemplateVariable(name, query, useSetenceCaseTemplateLabels=false):: {
+  newTemplateVariable(name, query, setenceCaseLabels=false):: {
     name: name,
-    label: if useSetenceCaseTemplateLabels then $.toSentenceCase(name) else name,
+    label: if setenceCaseLabels then $.toSentenceCase(name) else name,
     type: 'query',
     query: {
       query: query,
@@ -89,7 +89,7 @@
     titleFormat: '{{cluster}}/{{namespace}}',
   },
 
-  newMultiTemplateVariable(name, query, useSetenceCaseTemplateLabels=false):: $.newTemplateVariable(name, query, useSetenceCaseTemplateLabels) {
+  newMultiTemplateVariable(name, query, setenceCaseLabels=false):: $.newTemplateVariable(name, query, setenceCaseLabels) {
     multi: true,
     allValue: '.*',
     includeAll: true,

--- a/operations/alloy-mixin/dashboards/utils/templates.libsonnet
+++ b/operations/alloy-mixin/dashboards/utils/templates.libsonnet
@@ -65,36 +65,42 @@ local dashboard = import './dashboard.jsonnet';
 
         variables:  
             if enableK8sCluster then
-            [
-                dashboard.newTemplateVariable(
-                name='cluster', 
-                query=clusterTemplateQuery,
-                useSentenceCaseLabel=useSentenceCaseLabel),
-                dashboard.newTemplateVariable(
-                name='namespace', 
-                query=namespaceTemplateQuery,
-                useSentenceCaseLabel=useSentenceCaseLabel),
-                dashboard.newMultiTemplateVariable(
-                name='job', 
-                query=k8sJobTemplateQuery,
-                useSentenceCaseLabel=useSentenceCaseLabel),
-                if includeInstance then
+                [
+                    dashboard.newTemplateVariable(
+                    name='cluster', 
+                    query=clusterTemplateQuery,
+                    useSentenceCaseLabel=useSentenceCaseLabel),
+                    dashboard.newTemplateVariable(
+                    name='namespace', 
+                    query=namespaceTemplateQuery,
+                    useSentenceCaseLabel=useSentenceCaseLabel),
                     dashboard.newMultiTemplateVariable(
-                    name='instance', 
-                    query=k8sInstanceTemplateQuery,
-                useSentenceCaseLabel=useSentenceCaseLabel),
-            ]
+                    name='job', 
+                    query=k8sJobTemplateQuery,
+                    useSentenceCaseLabel=useSentenceCaseLabel),
+                ] + 
+                if includeInstance then
+                    [   
+                        dashboard.newMultiTemplateVariable(
+                        name='instance', 
+                        query=k8sInstanceTemplateQuery,
+                        useSentenceCaseLabel=useSentenceCaseLabel) 
+                    ]
+                else []
             else
-            [
-                dashboard.newMultiTemplateVariable(
-                name='job', 
-                query=jobTemplateQuery,
-                useSentenceCaseLabel=useSentenceCaseLabel),
-                if includeInstance then
+                [
                     dashboard.newMultiTemplateVariable(
-                    name='instance', 
-                    query=instanceTemplateQuery,
-                useSentenceCaseLabel=useSentenceCaseLabel),
-            ],        
+                    name='job', 
+                    query=jobTemplateQuery,
+                    useSentenceCaseLabel=useSentenceCaseLabel),                
+                ] + 
+                if includeInstance then
+                    [
+                        dashboard.newMultiTemplateVariable(
+                        name='instance', 
+                        query=instanceTemplateQuery,
+                        useSentenceCaseLabel=useSentenceCaseLabel)
+                    ]
+                else [],
     }
 }

--- a/operations/alloy-mixin/dashboards/utils/templates.libsonnet
+++ b/operations/alloy-mixin/dashboards/utils/templates.libsonnet
@@ -1,0 +1,100 @@
+local dashboard = import './dashboard.jsonnet';
+
+{
+    newTemplateVariablesList(filterSelector='', enableK8sCluster=true, includeInstance=true, useSentenceCaseLabel=false):: {        
+
+        local clusterTemplateQuery = 
+            if std.isEmpty(filterSelector) then
+            |||
+                label_values(alloy_component_controller_running_components, cluster)
+            |||
+            else
+            |||
+                label_values(alloy_component_controller_running_components{%s}, cluster)
+            ||| % filterSelector,
+
+        local namespaceTemplateQuery =
+            if std.isEmpty(filterSelector) then
+            |||
+                label_values(alloy_component_controller_running_components{cluster=~"$cluster"}, namespace)
+            |||
+            else
+            |||
+                label_values(alloy_component_controller_running_components{%s, cluster=~"$cluster"}, namespace)
+            ||| % filterSelector,
+        
+        local k8sJobTemplateQuery = 
+            if std.isEmpty(filterSelector) then
+            |||
+                label_values(alloy_component_controller_running_components{cluster=~"$cluster", namespace=~"$namespace"}, job)
+            |||
+            else
+            |||
+                label_values(alloy_component_controller_running_components{%s, cluster=~"$cluster", namespace=~"$namespace"}, job)
+            ||| % filterSelector,
+        
+        local k8sInstanceTemplateQuery = 
+            if std.isEmpty(filterSelector) then
+            |||
+                label_values(alloy_component_controller_running_components{cluster=~"$cluster", namespace=~"$namespace", job=~"$job"}, instance)
+            ||| 
+            else
+            |||
+                label_values(alloy_component_controller_running_components{%s, cluster=~"$cluster", namespace=~"$namespace", job=~"$job"}, instance)
+            ||| % filterSelector,
+
+        local jobTemplateQuery = 
+            if std.isEmpty(filterSelector) then
+            |||
+                label_values(alloy_component_controller_running_components, job)
+            |||
+            else
+            |||
+                label_values(alloy_component_controller_running_components{%s}, job)
+            ||| % filterSelector,
+        
+        local instanceTemplateQuery = 
+            if std.isEmpty(filterSelector) then
+            |||
+                label_values(alloy_component_controller_running_components{job=~"$job"}, instance)
+            |||
+            else
+            |||
+                label_values(alloy_component_controller_running_components{%s, job=~"$job"}, instance)
+            ||| % filterSelector,
+
+        variables:  
+            if enableK8sCluster then
+            [
+                dashboard.newTemplateVariable(
+                name='cluster', 
+                query=clusterTemplateQuery,
+                useSentenceCaseLabel=useSentenceCaseLabel),
+                dashboard.newTemplateVariable(
+                name='namespace', 
+                query=namespaceTemplateQuery,
+                useSentenceCaseLabel=useSentenceCaseLabel),
+                dashboard.newMultiTemplateVariable(
+                name='job', 
+                query=k8sJobTemplateQuery,
+                useSentenceCaseLabel=useSentenceCaseLabel),
+                if includeInstance then
+                    dashboard.newMultiTemplateVariable(
+                    name='instance', 
+                    query=k8sInstanceTemplateQuery,
+                useSentenceCaseLabel=useSentenceCaseLabel),
+            ]
+            else
+            [
+                dashboard.newMultiTemplateVariable(
+                name='job', 
+                query=jobTemplateQuery,
+                useSentenceCaseLabel=useSentenceCaseLabel),
+                if includeInstance then
+                    dashboard.newMultiTemplateVariable(
+                    name='instance', 
+                    query=instanceTemplateQuery,
+                useSentenceCaseLabel=useSentenceCaseLabel),
+            ],        
+    }
+}

--- a/operations/alloy-mixin/dashboards/utils/templates.libsonnet
+++ b/operations/alloy-mixin/dashboards/utils/templates.libsonnet
@@ -1,7 +1,7 @@
 local dashboard = import './dashboard.jsonnet';
 
 {
-    newTemplateVariablesList(filterSelector='', enableK8sCluster=true, includeInstance=true, useSentenceCaseLabel=false):: {        
+    newTemplateVariablesList(filterSelector='', enableK8sCluster=true, includeInstance=true, setenceCaseLabels=false):: (     
 
         local clusterTemplateQuery = 
             if std.isEmpty(filterSelector) then
@@ -11,7 +11,7 @@ local dashboard = import './dashboard.jsonnet';
             else
             |||
                 label_values(alloy_component_controller_running_components{%s}, cluster)
-            ||| % filterSelector,
+            ||| % filterSelector;
 
         local namespaceTemplateQuery =
             if std.isEmpty(filterSelector) then
@@ -21,7 +21,7 @@ local dashboard = import './dashboard.jsonnet';
             else
             |||
                 label_values(alloy_component_controller_running_components{%s, cluster=~"$cluster"}, namespace)
-            ||| % filterSelector,
+            ||| % filterSelector;
         
         local k8sJobTemplateQuery = 
             if std.isEmpty(filterSelector) then
@@ -31,7 +31,7 @@ local dashboard = import './dashboard.jsonnet';
             else
             |||
                 label_values(alloy_component_controller_running_components{%s, cluster=~"$cluster", namespace=~"$namespace"}, job)
-            ||| % filterSelector,
+            ||| % filterSelector;
         
         local k8sInstanceTemplateQuery = 
             if std.isEmpty(filterSelector) then
@@ -41,7 +41,7 @@ local dashboard = import './dashboard.jsonnet';
             else
             |||
                 label_values(alloy_component_controller_running_components{%s, cluster=~"$cluster", namespace=~"$namespace", job=~"$job"}, instance)
-            ||| % filterSelector,
+            ||| % filterSelector;
 
         local jobTemplateQuery = 
             if std.isEmpty(filterSelector) then
@@ -51,7 +51,7 @@ local dashboard = import './dashboard.jsonnet';
             else
             |||
                 label_values(alloy_component_controller_running_components{%s}, job)
-            ||| % filterSelector,
+            ||| % filterSelector;
         
         local instanceTemplateQuery = 
             if std.isEmpty(filterSelector) then
@@ -61,46 +61,45 @@ local dashboard = import './dashboard.jsonnet';
             else
             |||
                 label_values(alloy_component_controller_running_components{%s, job=~"$job"}, instance)
-            ||| % filterSelector,
-
-        variables:  
-            if enableK8sCluster then
-                [
-                    dashboard.newTemplateVariable(
-                    name='cluster', 
-                    query=clusterTemplateQuery,
-                    useSentenceCaseLabel=useSentenceCaseLabel),
-                    dashboard.newTemplateVariable(
-                    name='namespace', 
-                    query=namespaceTemplateQuery,
-                    useSentenceCaseLabel=useSentenceCaseLabel),
+            ||| % filterSelector;
+        
+        if enableK8sCluster then
+            [
+                dashboard.newTemplateVariable(
+                name='cluster', 
+                query=clusterTemplateQuery,
+                setenceCaseLabels=setenceCaseLabels),
+                dashboard.newTemplateVariable(
+                name='namespace', 
+                query=namespaceTemplateQuery,
+                setenceCaseLabels=setenceCaseLabels),
+                dashboard.newMultiTemplateVariable(
+                name='job', 
+                query=k8sJobTemplateQuery,
+                setenceCaseLabels=setenceCaseLabels),
+            ] + 
+            if includeInstance then
+                [   
                     dashboard.newMultiTemplateVariable(
-                    name='job', 
-                    query=k8sJobTemplateQuery,
-                    useSentenceCaseLabel=useSentenceCaseLabel),
-                ] + 
-                if includeInstance then
-                    [   
-                        dashboard.newMultiTemplateVariable(
-                        name='instance', 
-                        query=k8sInstanceTemplateQuery,
-                        useSentenceCaseLabel=useSentenceCaseLabel) 
-                    ]
-                else []
-            else
+                    name='instance', 
+                    query=k8sInstanceTemplateQuery,
+                    setenceCaseLabels=setenceCaseLabels) 
+                ]
+            else []
+        else
+            [
+                dashboard.newMultiTemplateVariable(
+                name='job', 
+                query=jobTemplateQuery,
+                setenceCaseLabels=setenceCaseLabels),                
+            ] + 
+            if includeInstance then
                 [
                     dashboard.newMultiTemplateVariable(
-                    name='job', 
-                    query=jobTemplateQuery,
-                    useSentenceCaseLabel=useSentenceCaseLabel),                
-                ] + 
-                if includeInstance then
-                    [
-                        dashboard.newMultiTemplateVariable(
-                        name='instance', 
-                        query=instanceTemplateQuery,
-                        useSentenceCaseLabel=useSentenceCaseLabel)
-                    ]
-                else [],
-    }
+                    name='instance', 
+                    query=instanceTemplateQuery,
+                    setenceCaseLabels=setenceCaseLabels)
+                ]
+            else []
+    )
 }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Implementing the following changes:
- Allow overwriting the config values for dashboards, instead of always pulling it from the local config file.
- `grafanaDashboards` and `prometheusAlerts` hidden, according to the mixin schema.
- allow filter selector for metrics to avoid Grafana Agent metrics query collision, and setting default to `job="integrations/self"`
- allow filter selector for logs to avoid pulling logs from other platforms, and setting default to `service_name="alloy"`
- fixing bugs reported by @rfratto in the comment below

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
