### PR TITLE
Update windows install to add DisplayVersion registry key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ Main (unreleased)
 
 - Updated Prometheus dependency to [v2.51.2](https://github.com/prometheus/prometheus/releases/tag/v2.51.2) (@thampiotr)
 
-- Updated Windows install script to seperate DisplayName and DisplayVersion into seperate tags
+- Updated Windows install script to add DisplayVersion into registory on install
 
 v1.1.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Main (unreleased)
 
 - Updated Prometheus dependency to [v2.51.2](https://github.com/prometheus/prometheus/releases/tag/v2.51.2) (@thampiotr)
 
+- Updated Windows install script to seperate DisplayName and DisplayVersion into seperate tags
 
 v1.1.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ Main (unreleased)
 
 - Updated Prometheus dependency to [v2.51.2](https://github.com/prometheus/prometheus/releases/tag/v2.51.2) (@thampiotr)
 
-- Updated Windows install script to add DisplayVersion into registory on install
+- Updated Windows install script to add DisplayVersion into registory on install (@enessene)
 
 v1.1.0
 ------

--- a/packaging/windows/install_script.nsis
+++ b/packaging/windows/install_script.nsis
@@ -81,7 +81,8 @@ Section "install"
   # overwriting existing registry entries since we want it to be relevant to
   # the current installed version.
   !define UNINSTALLKEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}"
-  WriteRegStr   HKLM "${UNINSTALLKEY}" "DisplayName"          '${APPNAME} ${VERSION}'
+  WriteRegStr   HKLM "${UNINSTALLKEY}" "DisplayName"          '${APPNAME}'
+  WriteRegStr   HKLM "${UNINSTALLKEY}" "DisplayVersion"       '${VERSION}'
   WriteRegStr   HKLM "${UNINSTALLKEY}" "UninstallString"      '"$INSTDIR\uninstall.exe"'
   WriteRegStr   HKLM "${UNINSTALLKEY}" "QuietUninstallString" '"$INSTDIR\uninstall.exe" /S'
   WriteRegStr   HKLM "${UNINSTALLKEY}" "InstallLocation"      '"$INSTDIR"'

--- a/packaging/windows/install_script.nsis
+++ b/packaging/windows/install_script.nsis
@@ -81,7 +81,7 @@ Section "install"
   # overwriting existing registry entries since we want it to be relevant to
   # the current installed version.
   !define UNINSTALLKEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}"
-  WriteRegStr   HKLM "${UNINSTALLKEY}" "DisplayName"          '${APPNAME}'
+  WriteRegStr   HKLM "${UNINSTALLKEY}" "DisplayName"          '${APPNAME} ${VERSION}'
   WriteRegStr   HKLM "${UNINSTALLKEY}" "DisplayVersion"       '${VERSION}'
   WriteRegStr   HKLM "${UNINSTALLKEY}" "UninstallString"      '"$INSTDIR\uninstall.exe"'
   WriteRegStr   HKLM "${UNINSTALLKEY}" "QuietUninstallString" '"$INSTDIR\uninstall.exe" /S'


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
The current name includes the version id but it is not available as a seperate registry key. This PR makes the installer add "DisplayVersion" so the version properly shows up in Windows and makes version extraction easier.

![image](https://github.com/grafana/alloy/assets/9263360/871ac74c-622c-4a24-8383-5c26bd78f93b)

(For more info here: https://learn.microsoft.com/en-us/windows/win32/msi/uninstall-registry-key)

#### Which issue(s) this PR fixes
N/A
<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer
This is mainly annoying in automatic deployments as the version has to be extracted from the name or in another way. (yes a bit of an oversimplification)

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x ] CHANGELOG.md updated