### PR TITLE
remotecfg: set lower poll_frequency limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,8 +58,8 @@ Main (unreleased)
 
 - Allow override debug metrics level for `otelcol.*` components. (@hainenber)
 
-- Add a lower limit of 1 second for the the `poll_frequency` argument in the
-  `remotecfg` block. (@tpaschalis)
+- Add an initial lower limit of 10 seconds for the the `poll_frequency`
+  argument in the `remotecfg` block. (@tpaschalis)
 
 - Added support for NS records to `discovery.dns`. (@djcode)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ Main (unreleased)
 
 - Allow override debug metrics level for `otelcol.*` components. (@hainenber)
 
+- Add a lower limit of 1 second for the the `poll_frequency` argument in the
+  `remotecfg` block. (@tpaschalis)
+
 - Added support for NS records to `discovery.dns`. (@djcode)
 
 ### Bugfixes

--- a/docs/sources/reference/config-blocks/remotecfg.md
+++ b/docs/sources/reference/config-blocks/remotecfg.md
@@ -50,7 +50,7 @@ If not set, the self-reported `id` that {{< param "PRODUCT_NAME" >}} uses is a r
 The `id` and `metadata` fields are used in the periodic request sent to the
 remote endpoint so that the API can decide what configuration to serve.
 
-The `poll_frequency` must be set to least "1s".
+The `poll_frequency` must be set to at least `"10s"`.
 
 ## Blocks
 

--- a/docs/sources/reference/config-blocks/remotecfg.md
+++ b/docs/sources/reference/config-blocks/remotecfg.md
@@ -50,6 +50,8 @@ If not set, the self-reported `id` that {{< param "PRODUCT_NAME" >}} uses is a r
 The `id` and `metadata` fields are used in the periodic request sent to the
 remote endpoint so that the API can decide what configuration to serve.
 
+The `poll_frequency` must be set to least "1s".
+
 ## Blocks
 
 The following blocks are supported inside the definition of `remotecfg`:

--- a/internal/service/remotecfg/remotecfg.go
+++ b/internal/service/remotecfg/remotecfg.go
@@ -99,8 +99,8 @@ func (a *Arguments) SetToDefault() {
 
 // Validate implements syntax.Validator.
 func (a *Arguments) Validate() error {
-	if a.PollFrequency < 1*time.Second {
-		return fmt.Errorf("poll_frequency must be at least 1s, got %q", a.PollFrequency)
+	if a.PollFrequency < 10*time.Second {
+		return fmt.Errorf("poll_frequency must be at least \"10s\", got %q", a.PollFrequency)
 	}
 
 	// We must explicitly Validate because HTTPClientConfig is squashed and it

--- a/internal/service/remotecfg/remotecfg.go
+++ b/internal/service/remotecfg/remotecfg.go
@@ -99,6 +99,10 @@ func (a *Arguments) SetToDefault() {
 
 // Validate implements syntax.Validator.
 func (a *Arguments) Validate() error {
+	if a.PollFrequency < 1*time.Second {
+		return fmt.Errorf("poll_frequency must be at least 1s, got %q", a.PollFrequency)
+	}
+
 	// We must explicitly Validate because HTTPClientConfig is squashed and it
 	// won't run otherwise
 	if a.HTTPClientConfig != nil {

--- a/internal/service/remotecfg/remotecfg_test.go
+++ b/internal/service/remotecfg/remotecfg_test.go
@@ -70,7 +70,7 @@ func TestAPIResponse(t *testing.T) {
 	env := newTestEnvironment(t)
 	require.NoError(t, env.ApplyConfig(fmt.Sprintf(`
 		url            = "%s"
-		poll_frequency = "10ms"
+		poll_frequency = "1s"
 	`, url)))
 
 	client := &collectorClient{}
@@ -100,7 +100,7 @@ func TestAPIResponse(t *testing.T) {
 	// Verify that the service has loaded the updated response.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		assert.Equal(c, getHash([]byte(cfg2)), env.svc.getCfgHash())
-	}, time.Second, 10*time.Millisecond)
+	}, 2*time.Second, 10*time.Millisecond)
 }
 
 func buildGetConfigHandler(in string) func(context.Context, *connect.Request[collectorv1.GetConfigRequest]) (*connect.Response[collectorv1.GetConfigResponse], error) {


### PR DESCRIPTION
#### PR Description

This PR adds a lower limit for the poll_frequency used in the remotecfg block so that Alloy instances don't accidentally hammer a server implementation. I think that's a good starting point but this value can be fine-tuned in the future. 

#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
- [X] Documentation added
- [x] Tests updated
- [ ] Config converters updated (N/A)
