### PR TITLE
Bump node version to 18 in build image

### DIFF
--- a/internal/web/ui/README.md
+++ b/internal/web/ui/README.md
@@ -3,4 +3,4 @@
 ## Prerequisites
 
 * Yarn >= v1.22
-* Node.js >= v16
+* Node.js >= v18

--- a/tools/build-image/Dockerfile
+++ b/tools/build-image/Dockerfile
@@ -68,7 +68,7 @@ FROM rfratto/viceroy:v0.4.0
 
 RUN  apt-get update && apt-get install -qy ca-certificates curl gnupg && mkdir -p /etc/apt/keyrings  \
  &&  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
- &&  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+ &&  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
  &&  apt-get update && apt-get install -qy nodejs \
  &&  rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The live debugging front-end uses [Grafana React Components](https://developers.grafana.com/ui/latest/index.html?path=/docs/docs-overview-intro--docs) which requires Node > 18.