### PR TITLE
example: install jb dependencies before provisioning

### DIFF
--- a/example/grafana.yaml
+++ b/example/grafana.yaml
@@ -16,13 +16,24 @@ services:
       timeout: 10s
       retries: 5
 
+  install-dashboard-dependencies:
+    build: images/jb
+    restart: on-failure
+    depends_on:
+      grafana:
+        condition: service_healthy
+    volumes:
+      - ../operations/alloy-mixin:/etc/alloy-mixin
+    working_dir: /etc/alloy-mixin
+    command: jb install
+
   # Provision alloy-mixin after Grafana is healthy and running.
   provision-dashboards:
     build: images/grizzly
     restart: on-failure
     depends_on:
-      grafana:
-        condition: service_healthy
+      install-dashboard-dependencies:
+        condition: service_completed_successfully
     environment:
       - GRAFANA_URL=http://grafana:3000
     volumes:
@@ -35,8 +46,8 @@ services:
     build: images/grizzly
     restart: on-failure
     depends_on:
-      grafana:
-        condition: service_healthy
+      install-dashboard-dependencies:
+        condition: service_completed_successfully
     environment:
       - GRAFANA_URL=http://grafana:3000
     volumes:

--- a/example/images/jb/Dockerfile
+++ b/example/images/jb/Dockerfile
@@ -1,0 +1,3 @@
+FROM golang:1.22-alpine
+
+RUN go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@c862f0670eb199b5024e31ff024f39b74d3b803a


### PR DESCRIPTION
grafana/alloy#808 introduced dependencies for the mixin, which accidentally broke the example environment; as the mixin originally didn't have dependencies, the example environment didn't install them before provisioning dashboards.

This commit runs jb to locally install dependencies before provisioning dashboards.

cc @gaantunes 