### PR TITLE
Added support for NS records to discovery.dns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Main (unreleased)
 
 - Allow override debug metrics level for `otelcol.*` components. (@hainenber)
 
+- Added support for NS records to `discovery.dns`. (@djcode)
+
 ### Bugfixes
 
 - Fix panic when component ID contains `/` in `otelcomponent.MustNewType(ID)`.(@qclaogui)

--- a/docs/sources/reference/components/discovery.dns.md
+++ b/docs/sources/reference/components/discovery.dns.md
@@ -20,12 +20,12 @@ discovery.dns "LABEL" {
 
 The following arguments are supported:
 
-Name               | Type           | Description                                                      | Default | Required
--------------------|----------------|------------------------------------------------------------------|---------|---------
-`names`            | `list(string)` | DNS names to look up.                                            |         | yes
-`port`             | `number`       | Port to use for collecting metrics. Not used for SRV records.    | `0`     | no
-`refresh_interval` | `duration`     | How often to query DNS for updates.                              | `"30s"` | no
-`type`             | `string`       | Type of DNS record to query. Must be one of SRV, A, AAAA, or MX. | `"SRV"` | no
+Name               | Type           | Description                                                          | Default | Required
+-------------------|----------------|----------------------------------------------------------------------|---------|---------
+`names`            | `list(string)` | DNS names to look up.                                                |         | yes
+`port`             | `number`       | Port to use for collecting metrics. Not used for SRV records.        | `0`     | no
+`refresh_interval` | `duration`     | How often to query DNS for updates.                                  | `"30s"` | no
+`type`             | `string`       | Type of DNS record to query. Must be one of SRV, A, AAAA, MX, or NS. | `"SRV"` | no
 
 ## Exported fields
 
@@ -41,7 +41,7 @@ Each target includes the following labels:
 * `__meta_dns_srv_record_target`: Target field of the SRV record.
 * `__meta_dns_srv_record_port`: Port field of the SRV record.
 * `__meta_dns_mx_record_target`: Target field of the MX record.
-
+* `__meta_dns_ns_record_target`: Target field of the NS record.
 
 ## Component health
 

--- a/internal/component/discovery/dns/dns.go
+++ b/internal/component/discovery/dns/dns.go
@@ -49,7 +49,7 @@ func (args *Arguments) SetToDefault() {
 func (args *Arguments) Validate() error {
 	switch strings.ToUpper(args.Type) {
 	case "SRV":
-	case "A", "AAAA", "MX":
+	case "A", "AAAA", "MX", "NS":
 		if args.Port == 0 {
 			return errors.New("a port is required in DNS-SD configs for all record types except SRV")
 		}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Support for this was [added to Prometheus](https://github.com/prometheus/prometheus/pull/13219) a few months ago. @djcode opened a [PR](https://github.com/grafana/agent/pull/5905) for this feature to be supported in Grafana Agent , and the Alloy PR is a copy of the Agent PR. 

I'm not sure if we will include this feature in Grafana Agent. The Agent PR might get closed, because we might not update the Prometheus dependency in the Agent anytime soon.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
