### PR TITLE
fix(faro/receiver): set default `DebugMetrics` argument for OtelCol components in E2E test

### DIFF
--- a/internal/component/faro/receiver/receiver_otelcol_test.go
+++ b/internal/component/faro/receiver/receiver_otelcol_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/alloy/internal/component/otelcol"
 	"github.com/grafana/alloy/internal/component/otelcol/auth"
 	"github.com/grafana/alloy/internal/component/otelcol/auth/headers"
+	otelcolCfg "github.com/grafana/alloy/internal/component/otelcol/config"
 	otlphttp "github.com/grafana/alloy/internal/component/otelcol/exporter/otlphttp"
 	"github.com/grafana/alloy/internal/runtime/componenttest"
 	"github.com/grafana/alloy/internal/util"
@@ -61,6 +62,10 @@ func TestWithOtelcolConsumer(t *testing.T) {
 					Action:      headers.ActionUpsert,
 				},
 			},
+			DebugMetrics: otelcolCfg.DebugMetricsArguments{
+				DisableHighCardinalityMetrics: true,
+				Level:                         otelcolCfg.LevelDetailed,
+			},
 		})
 		require.NoError(t, err)
 	}()
@@ -81,6 +86,10 @@ func TestWithOtelcolConsumer(t *testing.T) {
 				},
 			}),
 			Encoding: otlphttp.EncodingJSON,
+			DebugMetrics: otelcolCfg.DebugMetricsArguments{
+				DisableHighCardinalityMetrics: true,
+				Level:                         otelcolCfg.LevelDetailed,
+			},
 		})
 		require.NoError(t, err)
 	}()


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Fixes the failed E2E test occurred in Drone ([sample](https://drone.grafana.net/grafana/alloy/1317/2/2)). 
This started after merging #825, which is authored by me :(

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests updated