### PR TITLE
feat(common/loki): switch Snappy compression from `golang/snappy` to `klauspost/compress/snappy` for better compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,9 @@ Main (unreleased)
 
 - Updated Prometheus dependency to [v2.51.2](https://github.com/prometheus/prometheus/releases/tag/v2.51.2) (@thampiotr)
 
+- Switch from `github.com/golang/snappy` to `github.com/klauspost/compress/snappy` for 
+  better compression in Loki clients. (@hainenber)
+
 v1.1.0
 ------
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/Lusitaniae/apache_exporter v0.11.1-0.20220518131644-f9522724dab4
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/PuerkitoBio/rehttp v1.4.0
-	github.com/Shopify/sarama v1.38.1
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/alecthomas/units v0.0.0-20231202071711-9a357b53e9c9
 	github.com/aws/aws-sdk-go-v2 v1.26.1
@@ -44,7 +43,6 @@ require (
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.5.4
-	github.com/golang/snappy v0.0.4
 	github.com/google/cadvisor v0.47.0
 	github.com/google/dnsmasq_exporter v0.2.1-0.20230620100026-44b14480804a
 	github.com/google/go-cmp v0.6.0
@@ -293,6 +291,7 @@ require (
 	github.com/Microsoft/hcsshim v0.12.3 // indirect
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20230828082145-3c4c8a2d2371 // indirect
+	github.com/Shopify/sarama v1.38.1 // indirect
 	github.com/Showmax/go-fqdn v1.0.0 // indirect
 	github.com/Workiva/go-datastructures v1.1.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.1 // indirect
@@ -426,6 +425,7 @@ require (
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/snappy v0.0.4 // indirect
 	github.com/gomodule/redigo v1.8.9 // indirect
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/flatbuffers v23.5.26+incompatible // indirect

--- a/internal/cmd/integration-tests/configs/kafka/main.go
+++ b/internal/cmd/integration-tests/configs/kafka/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/Shopify/sarama"
+	"github.com/IBM/sarama"
 )
 
 const (

--- a/internal/component/common/loki/client/batch.go
+++ b/internal/component/common/loki/client/batch.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/golang/snappy"
+	"github.com/klauspost/compress/snappy"
 	"github.com/prometheus/common/model"
 	"golang.org/x/exp/slices"
 

--- a/internal/component/common/loki/client/batch.go
+++ b/internal/component/common/loki/client/batch.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -9,7 +10,6 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/klauspost/compress/snappy"
 	"github.com/prometheus/common/model"
-	"golang.org/x/exp/slices"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 

--- a/internal/component/loki/source/cloudflare/internal/cloudflaretarget/fields.go
+++ b/internal/component/loki/source/cloudflare/internal/cloudflaretarget/fields.go
@@ -7,8 +7,7 @@ package cloudflaretarget
 
 import (
 	"fmt"
-
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 // FieldsType defines the set of fields to fetch alongside logs.

--- a/internal/component/prometheus/receive_http/receive_http_test.go
+++ b/internal/component/prometheus/receive_http/receive_http_test.go
@@ -8,12 +8,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/snappy"
 	"github.com/grafana/alloy/internal/component"
 	fnet "github.com/grafana/alloy/internal/component/common/net"
 	alloyprom "github.com/grafana/alloy/internal/component/prometheus"
 	"github.com/grafana/alloy/internal/service/labelstore"
 	"github.com/grafana/alloy/internal/util"
+	"github.com/klauspost/compress/snappy"
 	"github.com/phayes/freeport"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/config"

--- a/internal/component/registry.go
+++ b/internal/component/registry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 
 	"github.com/go-kit/log"
@@ -12,7 +13,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 )
 
 // The parsedName of a component is the parts of its name ("remote.http") split

--- a/internal/converter/internal/otelcolconvert/pipeline_group.go
+++ b/internal/converter/internal/otelcolconvert/pipeline_group.go
@@ -3,11 +3,11 @@ package otelcolconvert
 import (
 	"cmp"
 	"fmt"
+	"slices"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/service/pipelines"
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 )
 
 // pipelineGroup groups a set of pipelines together by their telemetry type.

--- a/internal/converter/internal/prometheusconvert/component/scrape.go
+++ b/internal/converter/internal/prometheusconvert/component/scrape.go
@@ -2,10 +2,9 @@ package component
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 	"time"
-
-	"golang.org/x/exp/maps"
 
 	prom_config "github.com/prometheus/prometheus/config"
 	prom_discovery "github.com/prometheus/prometheus/discovery"

--- a/internal/util/testappender/collectingappender.go
+++ b/internal/util/testappender/collectingappender.go
@@ -2,6 +2,7 @@ package testappender
 
 import (
 	"context"
+	"maps"
 	"sync"
 
 	"github.com/prometheus/prometheus/model/exemplar"
@@ -9,7 +10,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/metadata"
 	"github.com/prometheus/prometheus/storage"
-	"golang.org/x/exp/maps"
 )
 
 type MetricSample struct {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
I discovered that Snappy compression could be done from `github.com/klauspost/compress/snappy`. It's advertised as having "better compression" so I think the switch could be a performance win.

In addition, there's still usage of old `Shopify/sarama`, which is `IBM/sarama` now. 

Hijack this PR are also replacements of `golang.org/x/exp/maps` and `golang.org/x/exp/slices` to stdlib's equivalences.

#### Which issue(s) this PR fixes
N/A

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
