### PR TITLE
prepare changelog for 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Main (unreleased)
 
 - Added `scrape_protocols` option to `prometheus.scrape`, which allows to
   control the preferred order of scrape protocols. (@thampiotr)
-  
+
 - Add support for configuring CPU profile's duration scraped by `pyroscope.scrape`. (@hainenber)
 
 - Improved filesystem error handling when working with `loki.source.file` and `local.file_match`,
@@ -62,28 +62,9 @@ Main (unreleased)
 
 ### Bugfixes
 
-- Fix panic when component ID contains `/` in `otelcomponent.MustNewType(ID)`.(@qclaogui)
-
 - Fixed an issue with `prometheus.scrape` in which targets that move from one
   cluster instance to another could have a staleness marker inserted and result
   in a gap in metrics (@thampiotr)
-
-- Exit Alloy immediately if the port it runs on is not available. 
-  This port can be configured with `--server.http.listen-addr` or using
-  the default listen address`127.0.0.1:12345`. (@mattdurham)
-
-- Fix a panic in `loki.source.docker` when trying to stop a target that was never started. (@wildum)
-
-- Fix error on boot when using IPv6 advertise addresses without explicitly
-  specifying a port. (@matthewpi)
-  
-- Fix an issue where having long component labels (>63 chars) on otelcol.auth
-  components lead to a panic. (@tpaschalis)
-
-- Update `prometheus.exporter.snowflake` with the [latest](https://github.com/grafana/snowflake-prometheus-exporter) version of the exporter as of May 28, 2024 (@StefanKurek)
-  - Fixes issue where returned `NULL` values from database could cause unexpected errors.
-
-- Bubble up SSH key conversion error to facilitate failed `import.git`. (@hainenber)
 
 ### Other changes
 
@@ -97,6 +78,30 @@ Main (unreleased)
   documentation for further details. (@thampiotr)
 
 - Updated Prometheus dependency to [v2.51.2](https://github.com/prometheus/prometheus/releases/tag/v2.51.2) (@thampiotr)
+
+v1.1.1
+------
+
+### Bugfixes
+
+- Fix panic when component ID contains `/` in `otelcomponent.MustNewType(ID)`.(@qclaogui)
+
+- Exit Alloy immediately if the port it runs on is not available.
+  This port can be configured with `--server.http.listen-addr` or using
+  the default listen address`127.0.0.1:12345`. (@mattdurham)
+
+- Fix a panic in `loki.source.docker` when trying to stop a target that was never started. (@wildum)
+
+- Fix error on boot when using IPv6 advertise addresses without explicitly
+  specifying a port. (@matthewpi)
+
+- Fix an issue where having long component labels (>63 chars) on otelcol.auth
+  components lead to a panic. (@tpaschalis)
+
+- Update `prometheus.exporter.snowflake` with the [latest](https://github.com/grafana/snowflake-prometheus-exporter) version of the exporter as of May 28, 2024 (@StefanKurek)
+  - Fixes issue where returned `NULL` values from database could cause unexpected errors.
+
+- Bubble up SSH key conversion error to facilitate failed `import.git`. (@hainenber)
 
 v1.1.0
 ------


### PR DESCRIPTION
This includes all bugfixes found in main to date except for #703, which is a more involved change that should probably wait for a minor release.