### PR TITLE
feat(prom/exp/snmp): add support to pass multiple SNMP config files to `prometheus.exporter.snmp`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ Main (unreleased)
 
 - Added support for NS records to `discovery.dns`. (@djcode)
 
+- Add support to pass multiple SNMP config files to `prometheus.exporter.snmp`. (@hainenber)
+
 ### Bugfixes
 
 - Fixed an issue with `prometheus.scrape` in which targets that move from one

--- a/docs/sources/reference/components/prometheus.exporter.snmp.md
+++ b/docs/sources/reference/components/prometheus.exporter.snmp.md
@@ -39,7 +39,7 @@ Omitted fields take their default values.
 The `config_file` argument points to a YAML file defining which snmp_exporter modules to use.
 Refer to [snmp_exporter](https://github.com/prometheus/snmp_exporter#generating-configuration) for details on how to generate a configuration file.
 
-The `config_files` argument consist of list of YAML files with content as described as above for `config_file`.
+Each file listed in in the `config_files` argument must conform to the `config_file` requirements.
 
 The `config` argument must be a YAML document as string defining which SNMP modules and auths to use.
 `config` is typically loaded by using the exports of another component. For example,

--- a/docs/sources/reference/components/prometheus.exporter.snmp.md
+++ b/docs/sources/reference/components/prometheus.exporter.snmp.md
@@ -33,7 +33,7 @@ Omitted fields take their default values.
 | Name          | Type                 | Description                                               | Default | Required |
 | ------------- | -------------------- | --------------------------------------------------------- | ------- | -------- |
 | `config_file` | `string`             | SNMP configuration file defining custom modules.          |         | no       |
-| `config_file` | `list(string)`       | List of SNMP configuration files defining custom modules. |         | no       |
+| `config_files` | `list(string)`       | List of SNMP configuration files defining custom modules. |         | no       |
 | `config`      | `string` or `secret` | SNMP configuration as inline string.                      |         | no       |
 
 The `config_file` argument points to a YAML file defining which snmp_exporter modules to use.

--- a/docs/sources/reference/components/prometheus.exporter.snmp.md
+++ b/docs/sources/reference/components/prometheus.exporter.snmp.md
@@ -17,7 +17,7 @@ The `prometheus.exporter.snmp` component embeds
 
 ```alloy
 prometheus.exporter.snmp "LABEL" {
-  config_file = SNMP_CONFIG_FILE_PATH
+  config_files = [SNMP_CONFIG_FILE_PATH_1, SNMP_CONFIG_FILE_PATH_2]
 
   target "TARGET_NAME" {
     address = TARGET_ADDRESS
@@ -30,13 +30,16 @@ prometheus.exporter.snmp "LABEL" {
 The following arguments can be used to configure the exporter's behavior.
 Omitted fields take their default values.
 
-| Name          | Type                 | Description                                      | Default | Required |
-| ------------- | -------------------- | ------------------------------------------------ | ------- | -------- |
-| `config_file` | `string`             | SNMP configuration file defining custom modules. |         | no       |
-| `config`      | `string` or `secret` | SNMP configuration as inline string.             |         | no       |
+| Name          | Type                 | Description                                               | Default | Required |
+| ------------- | -------------------- | --------------------------------------------------------- | ------- | -------- |
+| `config_file` | `string`             | SNMP configuration file defining custom modules.          |         | no       |
+| `config_file` | `list(string)`       | List of SNMP configuration files defining custom modules. |         | no       |
+| `config`      | `string` or `secret` | SNMP configuration as inline string.                      |         | no       |
 
 The `config_file` argument points to a YAML file defining which snmp_exporter modules to use.
 Refer to [snmp_exporter](https://github.com/prometheus/snmp_exporter#generating-configuration) for details on how to generate a configuration file.
+
+The `config_files` argument consist of list of YAML files with content as described as above for `config_file`.
 
 The `config` argument must be a YAML document as string defining which SNMP modules and auths to use.
 `config` is typically loaded by using the exports of another component. For example,
@@ -109,7 +112,7 @@ from `prometheus.exporter.snmp`:
 
 ```alloy
 prometheus.exporter.snmp "example" {
-    config_file = "snmp_modules.yml"
+    config_files = ["snmp_modules.yml"]
 
     target "network_switch_1" {
         address     = "192.168.1.2"

--- a/internal/component/prometheus/exporter/snmp/snmp.go
+++ b/internal/component/prometheus/exporter/snmp/snmp.go
@@ -113,6 +113,7 @@ func (w WalkParams) Convert() map[string]snmp_config.WalkParams {
 
 type Arguments struct {
 	ConfigFile   string                    `alloy:"config_file,attr,optional"`
+	ConfigFiles  []string                  `alloy:"config_files,attr,optional"`
 	Config       alloytypes.OptionalSecret `alloy:"config,attr,optional"`
 	Targets      TargetBlock               `alloy:"target,block"`
 	WalkParams   WalkParams                `alloy:"walk_param,block,optional"`
@@ -141,9 +142,10 @@ func (a *Arguments) UnmarshalAlloy(f func(interface{}) error) error {
 // Convert converts the component's Arguments to the integration's Config.
 func (a *Arguments) Convert() *snmp_exporter.Config {
 	return &snmp_exporter.Config{
-		SnmpConfigFile: a.ConfigFile,
-		SnmpTargets:    a.Targets.Convert(),
-		WalkParams:     a.WalkParams.Convert(),
-		SnmpConfig:     a.ConfigStruct,
+		SnmpConfigFile:  a.ConfigFile,
+		SnmpConfigFiles: a.ConfigFiles,
+		SnmpTargets:     a.Targets.Convert(),
+		WalkParams:      a.WalkParams.Convert(),
+		SnmpConfig:      a.ConfigStruct,
 	}
 }

--- a/internal/component/prometheus/exporter/snmp/snmp_test.go
+++ b/internal/component/prometheus/exporter/snmp/snmp_test.go
@@ -62,13 +62,15 @@ func TestUnmarshalAlloy(t *testing.T) {
 
 func TestConvertConfig(t *testing.T) {
 	args := Arguments{
-		ConfigFile: "modules.yml",
-		Targets:    TargetBlock{{Name: "network_switch_1", Target: "192.168.1.2", Module: "if_mib"}},
-		WalkParams: WalkParams{{Name: "public", Retries: 2}},
+		ConfigFile:  "modules.yml",
+		ConfigFiles: []string{"modules_1.yml", "modules_2.yml"},
+		Targets:     TargetBlock{{Name: "network_switch_1", Target: "192.168.1.2", Module: "if_mib"}},
+		WalkParams:  WalkParams{{Name: "public", Retries: 2}},
 	}
 
 	res := args.Convert()
 	require.Equal(t, "modules.yml", res.SnmpConfigFile)
+	require.Equal(t, []string{"modules_1.yml", "modules_2.yml"}, res.SnmpConfigFiles)
 	require.Equal(t, 1, len(res.SnmpTargets))
 	require.Equal(t, "network_switch_1", res.SnmpTargets[0].Name)
 }

--- a/internal/static/integrations/snmp_exporter/snmp_exporter_test.go
+++ b/internal/static/integrations/snmp_exporter/snmp_exporter_test.go
@@ -35,7 +35,7 @@ func TestLoadSNMPConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg, err := LoadSNMPConfig(tt.cfg.SnmpConfigFile, &tt.cfg.SnmpConfig)
+			cfg, err := LoadSNMPConfig([]string{tt.cfg.SnmpConfigFile}, &tt.cfg.SnmpConfig)
 			require.NoError(t, err)
 
 			require.Equal(t, tt.expectedNumModules, len(cfg.Modules))

--- a/internal/static/integrations/v2/snmp_exporter/snmp_exporter.go
+++ b/internal/static/integrations/v2/snmp_exporter/snmp_exporter.go
@@ -20,7 +20,7 @@ var DefaultConfig = Config{
 type Config struct {
 	WalkParams      map[string]snmp_config.WalkParams `yaml:"walk_params,omitempty"`
 	SnmpConfigFile  string                            `yaml:"config_file,omitempty"`
-	SnmpConfigFiles []string                          `yaml:"config_file,omitempty"`
+	SnmpConfigFiles []string                          `yaml:"config_files,omitempty"`
 	SnmpTargets     []snmp_exporter.SNMPTarget        `yaml:"snmp_targets"`
 	SnmpConfig      snmp_config.Config                `yaml:"snmp_config,omitempty"`
 	Common          common.MetricsConfig              `yaml:",inline"`

--- a/internal/static/integrations/v2/snmp_exporter/snmp_exporter.go
+++ b/internal/static/integrations/v2/snmp_exporter/snmp_exporter.go
@@ -11,17 +11,19 @@ import (
 
 // DefaultConfig holds the default settings for the snmp_exporter integration.
 var DefaultConfig = Config{
-	WalkParams:     make(map[string]snmp_config.WalkParams),
-	SnmpConfigFile: "",
+	WalkParams:      make(map[string]snmp_config.WalkParams),
+	SnmpConfigFile:  "",
+	SnmpConfigFiles: []string{},
 }
 
 // Config configures the SNMP integration.
 type Config struct {
-	WalkParams     map[string]snmp_config.WalkParams `yaml:"walk_params,omitempty"`
-	SnmpConfigFile string                            `yaml:"config_file,omitempty"`
-	SnmpTargets    []snmp_exporter.SNMPTarget        `yaml:"snmp_targets"`
-	SnmpConfig     snmp_config.Config                `yaml:"snmp_config,omitempty"`
-	Common         common.MetricsConfig              `yaml:",inline"`
+	WalkParams      map[string]snmp_config.WalkParams `yaml:"walk_params,omitempty"`
+	SnmpConfigFile  string                            `yaml:"config_file,omitempty"`
+	SnmpConfigFiles []string                          `yaml:"config_file,omitempty"`
+	SnmpTargets     []snmp_exporter.SNMPTarget        `yaml:"snmp_targets"`
+	SnmpConfig      snmp_config.Config                `yaml:"snmp_config,omitempty"`
+	Common          common.MetricsConfig              `yaml:",inline"`
 
 	globals integrations_v2.Globals
 }
@@ -42,7 +44,8 @@ func (c *Config) Identifier(globals integrations_v2.Globals) (string, error) {
 
 // NewIntegration creates a new SNMP integration.
 func (c *Config) NewIntegration(log log.Logger, globals integrations_v2.Globals) (integrations_v2.Integration, error) {
-	snmpCfg, err := snmp_exporter.LoadSNMPConfig(c.SnmpConfigFile, &c.SnmpConfig)
+	snmpConfigFiles := append(c.SnmpConfigFiles, c.SnmpConfigFile)
+	snmpCfg, err := snmp_exporter.LoadSNMPConfig(snmpConfigFiles, &c.SnmpConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Closes #916 

#### Notes to the Reviewer

I decided not to add another test case into `snmp_test.go` as it doesn't test whole component with argument but rather just a unit test for `LoadSNMP` function. Incoming integration test in #954 will address this.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated
