### PR TITLE
prometheus.exporter.snmp dynamic targets support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,9 @@ Main (unreleased)
 
 - Added support for NS records to `discovery.dns`. (@djcode)
 
-- Improved clustering use cases for tracking GCP delta metrics in the `prometheus.exporter.gcp` (@kgeckhart) 
+- Improved clustering use cases for tracking GCP delta metrics in the `prometheus.exporter.gcp` (@kgeckhart)
+
+- Add the `targets` argument to the `prometheus.exporter.snmp` component to support passing SNMP targets at runtime. (@wildum)
 
 ### Bugfixes
 

--- a/docs/sources/reference/components/prometheus.exporter.snmp.md
+++ b/docs/sources/reference/components/prometheus.exporter.snmp.md
@@ -58,7 +58,7 @@ The `config` argument must be a YAML document as string defining which SNMP modu
 The `targets` argument is an alternative to the [target][] block. This is useful when SNMP targets are supplied by another component.
 The following labels can be set to a target:
 * `name`: The name of the target (required).
-* `address`: The address of SNMP device (required).
+* `address` or `__address__`: The address of SNMP device (required).
 * `module`: The SNMP module to use for polling.
 * `auth`: The SNMP authentication profile to use.
 * `walk_params`: The config to use for this target.
@@ -289,25 +289,15 @@ The YAML file in this example looks like this:
   auth: public_v2
 ```
 
-This example uses the [`discovery.file` component][disc] and the [`discovery.relabel` component][relabel] to send targets to the `prometheus.exporter.snmp` component:
+This example uses the [`discovery.file` component][disc] to send targets to the `prometheus.exporter.snmp` component:
 ```alloy
 discovery.file "example" {
   files = ["targets.yml"]
 }
 
-discovery.relabel "example" {
-  targets = discovery.file.example.targets
-
-  rule {
-    source_labels = ["__address__"]
-    target_label  = "address"
-    action        = "replace"
-  }
-}
-
 prometheus.exporter.snmp "example" {
   config_file = "snmp_modules.yml"
-  targets = discovery.relabel.example.output
+  targets = discovery.file.example.targets
 }
 
 // Configure a prometheus.scrape component to collect SNMP metrics.
@@ -336,7 +326,6 @@ The YAML file in this example looks like this:
 [scrape]: ../prometheus.scrape/
 [file]: ../local.file/
 [disc]: ../discovery.file/
-[relabel]: ../discovery.relabel/
 
 <!-- START GENERATED COMPATIBLE COMPONENTS -->
 

--- a/docs/sources/reference/components/prometheus.exporter.snmp.md
+++ b/docs/sources/reference/components/prometheus.exporter.snmp.md
@@ -197,15 +197,20 @@ prometheus.scrape "demo" {
 
 prometheus.remote_write "demo" {
     endpoint {
-        url = PROMETHEUS_REMOTE_WRITE_URL
+        url = <PROMETHEUS_REMOTE_WRITE_URL>
 
         basic_auth {
-            username = USERNAME
-            password = PASSWORD
+            username = <USERNAME>
+            password = <PASSWORD>
         }
     }
 }
 ```
+
+Replace the following:
+- _`<PROMETHEUS_REMOTE_WRITE_URL>`_: The URL of the Prometheus remote_write-compatible server to send metrics to.
+- _`<USERNAME>`_: The username to use for authentication to the remote_write API.
+- _`<PASSWORD>`_: The password to use for authentication to the remote_write API.
 
 This example uses the alternative way to pass targets:
 
@@ -327,12 +332,6 @@ The YAML file in this example looks like this:
     module: default
     auth: public_v2
 ```
-
-Replace the following:
-
-- `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
-- `USERNAME`: The username to use for authentication to the remote_write API.
-- `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: ../prometheus.scrape/
 [file]: ../local.file/

--- a/docs/sources/reference/components/prometheus.exporter.snmp.md
+++ b/docs/sources/reference/components/prometheus.exporter.snmp.md
@@ -235,7 +235,7 @@ prometheus.scrape "demo" {
 }
 ```
 
-This example uses the [`local.file` component][file] to read targets from a YAML file and feed them to the prometheus.exporter.snmp component:
+This example uses the [`local.file` component][file] to read targets from a YAML file and send them to the prometheus.exporter.snmp component:
 
 ```alloy
 local.file "targets" {

--- a/docs/sources/reference/components/prometheus.exporter.snmp.md
+++ b/docs/sources/reference/components/prometheus.exporter.snmp.md
@@ -46,13 +46,13 @@ The `config` argument must be a YAML document as string defining which SNMP modu
 - `remote.http.LABEL.content`
 - `remote.s3.LABEL.content`
 
-The `targets` argument serves as an alternative to the [target][] block. This is useful when SNMP targets are supplied by another component.
+The `targets` argument is an alternative to the [target][] block. This is useful when SNMP targets are supplied by another component.
 The following labels can be set to a target:
-* `name` is the name of the target (required).
-* `address` is the address of SNMP device (required).
-* `module` is the SNMP module to use for polling.
-* `auth` is the SNMP authentication profile to use.
-* `walk_params` is the config to use for this target.
+* `name`: The name of the target (required).
+* `address`: The address of SNMP device (required).
+* `module`: The SNMP module to use for polling.
+* `auth`: The SNMP authentication profile to use.
+* `walk_params`: The config to use for this target.
 
 ## Blocks
 

--- a/docs/sources/reference/components/prometheus.exporter.snmp.md
+++ b/docs/sources/reference/components/prometheus.exporter.snmp.md
@@ -25,6 +25,15 @@ prometheus.exporter.snmp "LABEL" {
 }
 ```
 
+or 
+
+```alloy
+prometheus.exporter.snmp "LABEL" {
+  config_file = SNMP_CONFIG_FILE_PATH
+  targets     = TARGET_LIST
+}
+```
+
 ## Arguments
 
 The following arguments can be used to configure the exporter's behavior.
@@ -264,7 +273,7 @@ prometheus.scrape "demo" {
 ```
 
 The YAML file in this example looks like this:
-```
+```yaml
 - name: t1
   address: localhost:161
   module: default
@@ -276,7 +285,7 @@ The YAML file in this example looks like this:
 ```
 
 This example uses the [`discovery.file` component][disc] and the [`discovery.relabel` component][relabel] to send targets to the `prometheus.exporter.snmp` component:
-```
+```alloy
 discovery.file "example" {
   files = ["targets.yml"]
 }
@@ -304,7 +313,7 @@ prometheus.scrape "demo" {
 ```
 
 The YAML file in this example looks like this:
-```
+```yaml
 - targets:
   - localhost:161
   labels:

--- a/internal/cmd/integration-tests/common/common.go
+++ b/internal/cmd/integration-tests/common/common.go
@@ -12,7 +12,7 @@ type Unmarshaler interface {
 }
 
 const DefaultRetryInterval = 100 * time.Millisecond
-const DefaultTimeout = time.Minute
+const DefaultTimeout = 90 * time.Second
 
 func FetchDataFromURL(url string, target Unmarshaler) error {
 	resp, err := http.Get(url)

--- a/internal/cmd/integration-tests/docker-compose.yaml
+++ b/internal/cmd/integration-tests/docker-compose.yaml
@@ -57,7 +57,14 @@ services:
       context: ../../..
     ports:
       - "9001:9001"
+
   redis:
     image: redis:6.0.9-alpine
     ports:
       - "6379:6379"
+
+  snmp-simulator:
+    image: tandrup/snmpsim:v0.4
+    container_name: snmpsim
+    ports:
+      - "161:161/udp"

--- a/internal/cmd/integration-tests/tests/redis/redis_metrics_test.go
+++ b/internal/cmd/integration-tests/tests/redis/redis_metrics_test.go
@@ -27,6 +27,5 @@ func TestRedisMetrics(t *testing.T) {
 		"redis_memory_used_rss_bytes",
 		"redis_up",
 	}
-	// TODO(marctc): Report list of failed metrics instead of one by one.
 	common.MimirMetricsTest(t, redisMetrics, []string{}, "redis_metrics")
 }

--- a/internal/cmd/integration-tests/tests/snmp/config.alloy
+++ b/internal/cmd/integration-tests/tests/snmp/config.alloy
@@ -1,0 +1,101 @@
+prometheus.exporter.snmp "snmp_metrics" {
+  config = `
+auths:
+  public_v2:
+    community: public
+    security_level: noAuthNoPriv
+    auth_protocol: MD5
+    priv_protocol: DES
+    version: 2
+modules:
+  default:
+    walk:
+      - 1.3.6.1.2.1.1  # OID for system
+      - 1.3.6.1.2.1.2  # OID for interfaces
+    metrics:
+      - name: sysDescr
+        oid: 1.3.6.1.2.1.1.1.0
+        type: DisplayString
+        help: "A textual description of the entity."
+`
+  targets = [
+    {
+      "name" = "t1",
+      "address" = "localhost:161",
+      "module" = "default",
+      "auth" = "public_v2",
+    },
+  ]
+}
+
+prometheus.scrape "snmp_metrics" {
+  targets    = prometheus.exporter.snmp.snmp_metrics.targets
+  forward_to = [prometheus.remote_write.snmp_metrics.receiver]
+  scrape_interval = "1s"
+  scrape_timeout = "500ms"
+}
+
+prometheus.remote_write "snmp_metrics" {
+  endpoint {
+    url = "http://localhost:9009/api/v1/push"
+    metadata_config {
+        send_interval = "1s"
+    }
+    queue_config {
+        max_samples_per_send = 100
+    }    
+  }
+  external_labels = {
+    test_name = "snmp_metrics",
+  }  
+}
+
+prometheus.exporter.snmp "snmp_metrics2" {
+  config = `
+auths:
+  public_v2:
+    community: public
+    security_level: noAuthNoPriv
+    auth_protocol: MD5
+    priv_protocol: DES
+    version: 2
+modules:
+  default:
+    walk:
+      - 1.3.6.1.2.1.1  # OID for system
+      - 1.3.6.1.2.1.2  # OID for interfaces
+    metrics:
+      - name: sysDescr
+        oid: 1.3.6.1.2.1.1.1.0
+        type: DisplayString
+        help: "A textual description of the entity."
+`
+  target "t1" {
+      address     = "localhost:161"
+      module      = "default"
+      auth        = "public_v2"
+  }
+}
+
+prometheus.scrape "snmp_metrics2" {
+  targets    = prometheus.exporter.snmp.snmp_metrics2.targets
+  forward_to = [prometheus.remote_write.snmp_metrics2.receiver]
+  scrape_interval = "1s"
+  scrape_timeout = "500ms"
+}
+
+prometheus.remote_write "snmp_metrics2" {
+  endpoint {
+    url = "http://localhost:9009/api/v1/push"
+    metadata_config {
+        send_interval = "1s"
+    }
+    queue_config {
+        max_samples_per_send = 100
+    }    
+  }
+  external_labels = {
+    test_name = "snmp_metrics2",
+  }  
+}
+

--- a/internal/cmd/integration-tests/tests/snmp/snmp_metrics_test.go
+++ b/internal/cmd/integration-tests/tests/snmp/snmp_metrics_test.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+package main
+
+import (
+	"testing"
+
+	"github.com/grafana/alloy/internal/cmd/integration-tests/common"
+)
+
+func TestSNMPMetrics(t *testing.T) {
+	var SNMPMetrics = []string{
+		"scrape_duration_seconds",
+		"scrape_samples_post_metric_relabeling",
+		"scrape_samples_scraped",
+		"scrape_series_added",
+		"snmp_packet_duration_seconds_bucket",
+		"snmp_packet_duration_seconds_count",
+		"snmp_packet_duration_seconds_sum",
+		"snmp_packet_retries_total",
+		"snmp_packets_total",
+		"snmp_request_in_flight",
+		"snmp_scrape_duration_seconds",
+		"snmp_scrape_packets_retried",
+		"snmp_scrape_packets_sent",
+		"snmp_scrape_pdus_returned",
+		"snmp_scrape_walk_duration_seconds",
+		"snmp_unexpected_pdu_type_total",
+		"sysDescr",
+		"up",
+	}
+	common.MimirMetricsTest(t, SNMPMetrics, []string{}, "snmp_metrics")
+	common.MimirMetricsTest(t, SNMPMetrics, []string{}, "snmp_metrics2")
+}

--- a/internal/cmd/integration-tests/utils.go
+++ b/internal/cmd/integration-tests/utils.go
@@ -40,8 +40,8 @@ func buildAlloy() {
 
 func setupEnvironment() {
 	executeCommand("docker-compose", []string{"up", "-d"}, "Setting up environment with Docker Compose")
-	fmt.Println("Sleep for 30 seconds to ensure that the env has time to initialize...")
-	time.Sleep(30 * time.Second)
+	fmt.Println("Sleep for 45 seconds to ensure that the env has time to initialize...")
+	time.Sleep(45 * time.Second)
 }
 
 func runSingleTest(testDir string, port int) {

--- a/internal/component/prometheus/exporter/exporter.go
+++ b/internal/component/prometheus/exporter/exporter.go
@@ -75,7 +75,7 @@ func (c *Component) Run(ctx context.Context) error {
 			c.metricsHandler = c.getHttpHandler(exporter)
 			c.mut.Unlock()
 			go func() {
-				if err := exporter.Run(newCtx); err != nil {
+				if err := exporter.Run(newCtx); err != nil && err != context.Canceled {
 					level.Error(c.opts.Logger).Log("msg", "error running exporter", "err", err)
 				}
 			}()

--- a/internal/component/prometheus/exporter/snmp/snmp.go
+++ b/internal/component/prometheus/exporter/snmp/snmp.go
@@ -168,22 +168,10 @@ func (a *Arguments) UnmarshalAlloy(f func(interface{}) error) error {
 		return errors.New("config and config_file are mutually exclusive")
 	}
 
-	err := yaml.UnmarshalStrict([]byte(a.Config.Value), &a.ConfigStruct)
-	if err != nil {
-		return fmt.Errorf("invalid snmp_exporter config: %s", err)
-	}
-
-	return nil
-}
-
-// Validate implements syntax.Validator.
-func (a *Arguments) Validate() error {
 	if len(a.Targets) != 0 && len(a.TargetsList) != 0 {
 		return fmt.Errorf("the block `target` and the attribute `targets` are mutually exclusive")
 	}
-	if len(a.Targets) == 0 && len(a.TargetsList) == 0 {
-		return fmt.Errorf("either a `target block` or a `targets` attribute should be set")
-	}
+
 	for _, target := range a.TargetsList {
 		if _, hasName := target["name"]; !hasName {
 			return fmt.Errorf("all targets must have a `name`")
@@ -192,6 +180,12 @@ func (a *Arguments) Validate() error {
 			return fmt.Errorf("all targets must have an `address`")
 		}
 	}
+
+	err := yaml.UnmarshalStrict([]byte(a.Config.Value), &a.ConfigStruct)
+	if err != nil {
+		return fmt.Errorf("invalid snmp_exporter config: %s", err)
+	}
+
 	return nil
 }
 

--- a/internal/component/prometheus/exporter/snmp/snmp.go
+++ b/internal/component/prometheus/exporter/snmp/snmp.go
@@ -127,7 +127,7 @@ type Arguments struct {
 	TargetsList TargetsList `alloy:"targets,attr,optional"`
 }
 
-type TargetsList []discovery.Target
+type TargetsList []map[string]string
 
 func (t TargetsList) Convert() []snmp_exporter.SNMPTarget {
 	targets := make([]snmp_exporter.SNMPTarget, 0, len(t))

--- a/internal/component/prometheus/exporter/snmp/snmp_test.go
+++ b/internal/component/prometheus/exporter/snmp/snmp_test.go
@@ -173,6 +173,47 @@ func TestConvertTargetsList(t *testing.T) {
 	require.Equal(t, "1.3.6.1.2.1.2", res[0].WalkParams)
 }
 
+func TestConvertTargetsListAlternativeAddress(t *testing.T) {
+	targets := TargetsList{
+		{
+			"name":        "network_switch_1",
+			"address":     "192.168.1.2",
+			"__address__": "192.168.1.3",
+			"module":      "if_mib",
+			"auth":        "public_v2",
+			"walk_params": "1.3.6.1.2.1.2",
+		},
+	}
+
+	res := targets.Convert()
+	require.Equal(t, 1, len(res))
+	require.Equal(t, "network_switch_1", res[0].Name)
+	require.Equal(t, "192.168.1.2", res[0].Target)
+	require.Equal(t, "if_mib", res[0].Module)
+	require.Equal(t, "public_v2", res[0].Auth)
+	require.Equal(t, "1.3.6.1.2.1.2", res[0].WalkParams)
+}
+
+func TestConvertTargetsListAddressOverride(t *testing.T) {
+	targets := TargetsList{
+		{
+			"name":        "network_switch_1",
+			"__address__": "192.168.1.2",
+			"module":      "if_mib",
+			"auth":        "public_v2",
+			"walk_params": "1.3.6.1.2.1.2",
+		},
+	}
+
+	res := targets.Convert()
+	require.Equal(t, 1, len(res))
+	require.Equal(t, "network_switch_1", res[0].Name)
+	require.Equal(t, "192.168.1.2", res[0].Target)
+	require.Equal(t, "if_mib", res[0].Module)
+	require.Equal(t, "public_v2", res[0].Auth)
+	require.Equal(t, "1.3.6.1.2.1.2", res[0].WalkParams)
+}
+
 func TestValidateTargetMissingName(t *testing.T) {
 	alloyCfg := `
 		config_file = "modules.yml"

--- a/internal/component/prometheus/exporter/snmp/snmp_test.go
+++ b/internal/component/prometheus/exporter/snmp/snmp_test.go
@@ -157,7 +157,7 @@ func TestConvertTargetsList(t *testing.T) {
 	targets := TargetsList{
 		{
 			"name":        "network_switch_1",
-			"target":      "192.168.1.2",
+			"address":     "192.168.1.2",
 			"module":      "if_mib",
 			"auth":        "public_v2",
 			"walk_params": "1.3.6.1.2.1.2",

--- a/internal/component/prometheus/exporter/snmp/snmp_test.go
+++ b/internal/component/prometheus/exporter/snmp/snmp_test.go
@@ -174,60 +174,60 @@ func TestConvertTargetsList(t *testing.T) {
 }
 
 func TestValidateTargetMissingName(t *testing.T) {
-	targets := TargetsList{
-		{
-			"target":      "192.168.1.2",
-			"module":      "if_mib",
-			"auth":        "public_v2",
-			"walk_params": "1.3.6.1.2.1.2",
-		},
-	}
-	args := Arguments{
-		TargetsList: targets,
-	}
-	require.ErrorContains(t, args.Validate(), "all targets must have a `name`")
+	alloyCfg := `
+		config_file = "modules.yml"
+		targets = [
+			{
+				"address" = "192.168.1.2", 
+				"module" = "if_mib",
+				"walk_params" = "public",
+				"auth" = "public_v2",
+			},
+		  ]		
+`
+	var args Arguments
+	err := syntax.Unmarshal([]byte(alloyCfg), &args)
+	require.ErrorContains(t, err, "all targets must have a `name`")
 }
 
 func TestValidateTargetMissingAddress(t *testing.T) {
-	targets := TargetsList{
-		{
-			"name":        "target1",
-			"module":      "if_mib",
-			"auth":        "public_v2",
-			"walk_params": "1.3.6.1.2.1.2",
-		},
-	}
-	args := Arguments{
-		TargetsList: targets,
-	}
-	require.ErrorContains(t, args.Validate(), "all targets must have an `address`")
-}
-
-func TestValidateMissingTargets(t *testing.T) {
-	args := Arguments{}
-	require.ErrorContains(t, args.Validate(), "either a `target block` or a `targets` attribute should be set")
+	alloyCfg := `
+		config_file = "modules.yml"
+		targets = [
+			{
+				"name" = "t1",
+				"module" = "if_mib",
+				"walk_params" = "public",
+				"auth" = "public_v2",
+			},
+		  ]		
+`
+	var args Arguments
+	err := syntax.Unmarshal([]byte(alloyCfg), &args)
+	require.ErrorContains(t, err, "all targets must have an `address`")
 }
 
 func TestValidateTargetsMutualExclusivity(t *testing.T) {
-	targets := TargetsList{
-		{
-			"target":      "192.168.1.2",
-			"module":      "if_mib",
-			"auth":        "public_v2",
-			"walk_params": "1.3.6.1.2.1.2",
-		},
-	}
-	targetBlock := TargetBlock{{
-		Name:   "network_switch_1",
-		Target: "192.168.1.2",
-		Module: "if_mib",
-		Auth:   "public_v2",
-	}}
-	args := Arguments{
-		TargetsList: targets,
-		Targets:     targetBlock,
-	}
-	require.ErrorContains(t, args.Validate(), "the block `target` and the attribute `targets` are mutually exclusive")
+	alloyCfg := `
+		config_file = "modules.yml"
+		targets = [
+			{
+				"name" = "t1",
+				"address" = "192.168.1.2", 
+				"module" = "if_mib",
+				"walk_params" = "public",
+				"auth" = "public_v2",
+			},
+		  ]		
+		target "t2" {
+			address = "192.168.1.3"
+			module = "mikrotik"
+			walk_params = "private"
+		}
+`
+	var args Arguments
+	err := syntax.Unmarshal([]byte(alloyCfg), &args)
+	require.ErrorContains(t, err, "the block `target` and the attribute `targets` are mutually exclusive")
 }
 
 func TestConvertWalkParams(t *testing.T) {

--- a/internal/converter/internal/staticconvert/internal/build/snmp_exporter.go
+++ b/internal/converter/internal/staticconvert/internal/build/snmp_exporter.go
@@ -16,15 +16,15 @@ func (b *ConfigBuilder) appendSnmpExporter(config *snmp_exporter.Config) discove
 }
 
 func toSnmpExporter(config *snmp_exporter.Config) *snmp.Arguments {
-	targets := make([]snmp.SNMPTarget, len(config.SnmpTargets))
-	for i, t := range config.SnmpTargets {
-		targets[i] = snmp.SNMPTarget{
-			Name:       common.SanitizeIdentifierPanics(t.Name),
-			Target:     t.Target,
-			Module:     t.Module,
-			Auth:       t.Auth,
-			WalkParams: t.WalkParams,
-		}
+	var targets snmp.TargetsList
+	for _, t := range config.SnmpTargets {
+		target := make(map[string]string)
+		target["name"] = common.SanitizeIdentifierPanics(t.Name)
+		target["address"] = t.Target
+		target["module"] = t.Module
+		target["auth"] = t.Auth
+		target["walk_params"] = t.WalkParams
+		targets = append(targets, target)
 	}
 
 	walkParams := make([]snmp.WalkParam, len(config.WalkParams))
@@ -46,10 +46,10 @@ func toSnmpExporter(config *snmp_exporter.Config) *snmp.Arguments {
 	}
 
 	return &snmp.Arguments{
-		ConfigFile: config.SnmpConfigFile,
-		Config:     alloytypes.OptionalSecret{},
-		Targets:    targets,
-		WalkParams: walkParams,
+		ConfigFile:  config.SnmpConfigFile,
+		Config:      alloytypes.OptionalSecret{},
+		TargetsList: targets,
+		WalkParams:  walkParams,
 		ConfigStruct: snmp_config.Config{
 			Auths:   config.SnmpConfig.Auths,
 			Modules: config.SnmpConfig.Modules,
@@ -64,15 +64,15 @@ func (b *ConfigBuilder) appendSnmpExporterV2(config *snmp_exporter_v2.Config) di
 }
 
 func toSnmpExporterV2(config *snmp_exporter_v2.Config) *snmp.Arguments {
-	targets := make([]snmp.SNMPTarget, len(config.SnmpTargets))
-	for i, t := range config.SnmpTargets {
-		targets[i] = snmp.SNMPTarget{
-			Name:       common.SanitizeIdentifierPanics(t.Name),
-			Target:     t.Target,
-			Module:     t.Module,
-			Auth:       t.Auth,
-			WalkParams: t.WalkParams,
-		}
+	var targets snmp.TargetsList
+	for _, t := range config.SnmpTargets {
+		target := make(map[string]string)
+		target["name"] = common.SanitizeIdentifierPanics(t.Name)
+		target["address"] = t.Target
+		target["module"] = t.Module
+		target["auth"] = t.Auth
+		target["walk_params"] = t.WalkParams
+		targets = append(targets, target)
 	}
 
 	walkParams := make([]snmp.WalkParam, len(config.WalkParams))
@@ -94,10 +94,10 @@ func toSnmpExporterV2(config *snmp_exporter_v2.Config) *snmp.Arguments {
 	}
 
 	return &snmp.Arguments{
-		ConfigFile: config.SnmpConfigFile,
-		Config:     alloytypes.OptionalSecret{},
-		Targets:    targets,
-		WalkParams: walkParams,
+		ConfigFile:  config.SnmpConfigFile,
+		Config:      alloytypes.OptionalSecret{},
+		TargetsList: targets,
+		WalkParams:  walkParams,
 		ConfigStruct: snmp_config.Config{
 			Auths:   config.SnmpConfig.Auths,
 			Modules: config.SnmpConfig.Modules,

--- a/internal/converter/internal/staticconvert/internal/build/snmp_exporter.go
+++ b/internal/converter/internal/staticconvert/internal/build/snmp_exporter.go
@@ -19,7 +19,7 @@ func toSnmpExporter(config *snmp_exporter.Config) *snmp.Arguments {
 	var targets snmp.TargetsList
 	for _, t := range config.SnmpTargets {
 		target := make(map[string]string)
-		target["name"] = common.SanitizeIdentifierPanics(t.Name)
+		target["name"] = t.Name
 		target["address"] = t.Target
 		target["module"] = t.Module
 		target["auth"] = t.Auth
@@ -67,7 +67,7 @@ func toSnmpExporterV2(config *snmp_exporter_v2.Config) *snmp.Arguments {
 	var targets snmp.TargetsList
 	for _, t := range config.SnmpTargets {
 		target := make(map[string]string)
-		target["name"] = common.SanitizeIdentifierPanics(t.Name)
+		target["name"] = t.Name
 		target["address"] = t.Target
 		target["module"] = t.Module
 		target["auth"] = t.Auth

--- a/internal/converter/internal/staticconvert/testdata-v2/integrations_v2.alloy
+++ b/internal/converter/internal/staticconvert/testdata-v2/integrations_v2.alloy
@@ -714,7 +714,7 @@ prometheus.exporter.snmp "integrations_snmp" {
 		address     = "192.168.1.2",
 		auth        = "public",
 		module      = "if_mib",
-		name        = "network_switch_1",
+		name        = "network_switch.1",
 		walk_params = "public",
 	}, {
 		address     = "192.168.1.3",

--- a/internal/converter/internal/staticconvert/testdata-v2/integrations_v2.alloy
+++ b/internal/converter/internal/staticconvert/testdata-v2/integrations_v2.alloy
@@ -710,19 +710,19 @@ prometheus.scrape "integrations_blackbox" {
 }
 
 prometheus.exporter.snmp "integrations_snmp" {
-	target "network_switch_1" {
-		address     = "192.168.1.2"
-		module      = "if_mib"
-		auth        = "public"
-		walk_params = "public"
-	}
-
-	target "network_router_2" {
-		address     = "192.168.1.3"
-		module      = "mikrotik"
-		auth        = "private"
-		walk_params = "private"
-	}
+	targets = [{
+		address     = "192.168.1.2",
+		auth        = "public",
+		module      = "if_mib",
+		name        = "network_switch_1",
+		walk_params = "public",
+	}, {
+		address     = "192.168.1.3",
+		auth        = "private",
+		module      = "mikrotik",
+		name        = "network_router_2",
+		walk_params = "private",
+	}]
 }
 
 discovery.relabel "integrations_snmp" {

--- a/internal/converter/internal/staticconvert/testdata-v2/integrations_v2.yaml
+++ b/internal/converter/internal/staticconvert/testdata-v2/integrations_v2.yaml
@@ -204,7 +204,7 @@ integrations:
           replacement: redis-2
   snmp:
     snmp_targets:
-      - name: network_switch_1
+      - name: network_switch.1
         address: 192.168.1.2
         module: if_mib
         walk_params: public

--- a/internal/converter/internal/staticconvert/testdata/integrations.alloy
+++ b/internal/converter/internal/staticconvert/testdata/integrations.alloy
@@ -89,19 +89,19 @@ prometheus.scrape "integrations_blackbox" {
 }
 
 prometheus.exporter.snmp "integrations_snmp" {
-	target "network_switch_1" {
-		address     = "192.168.1.2"
-		module      = "if_mib"
-		auth        = "public"
-		walk_params = "public"
-	}
-
-	target "network_router_2" {
-		address     = "192.168.1.3"
-		module      = "mikrotik"
-		auth        = "private"
-		walk_params = "private"
-	}
+	targets = [{
+		address     = "192.168.1.2",
+		auth        = "public",
+		module      = "if_mib",
+		name        = "network_switch_1",
+		walk_params = "public",
+	}, {
+		address     = "192.168.1.3",
+		auth        = "private",
+		module      = "mikrotik",
+		name        = "network_router_2",
+		walk_params = "private",
+	}]
 }
 
 discovery.relabel "integrations_snmp" {

--- a/internal/converter/internal/staticconvert/testdata/integrations.alloy
+++ b/internal/converter/internal/staticconvert/testdata/integrations.alloy
@@ -93,7 +93,7 @@ prometheus.exporter.snmp "integrations_snmp" {
 		address     = "192.168.1.2",
 		auth        = "public",
 		module      = "if_mib",
-		name        = "network_switch_1",
+		name        = "network_switch.1",
 		walk_params = "public",
 	}, {
 		address     = "192.168.1.3",

--- a/internal/converter/internal/staticconvert/testdata/integrations.yaml
+++ b/internal/converter/internal/staticconvert/testdata/integrations.yaml
@@ -171,7 +171,7 @@ integrations:
   snmp:
     enabled: true
     snmp_targets:
-      - name: network_switch_1
+      - name: network_switch.1
         address: 192.168.1.2
         module: if_mib
         walk_params: public


### PR DESCRIPTION
#### PR Description

Add an argument `targets` to support passing targets at runtime to the exporter.

Also add integration tests to cover both ways of passing targets.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

Related to https://github.com/grafana/alloy/issues/273
Related to https://github.com/grafana/alloy/issues/289
Fixes https://github.com/grafana/alloy/issues/954

#### Notes to the Reviewer

I added an additional argument because replacing the target block would be a breaking change.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [x] Create an issue to eventually delete the target block when switching to a major version
