### PR TITLE
chore(web/ui): use named imports for React

### DIFF
--- a/internal/web/ui/src/Router.tsx
+++ b/internal/web/ui/src/Router.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
 import Navbar from './features/layout/Navbar';

--- a/internal/web/ui/src/contexts/PathPrefixContext.tsx
+++ b/internal/web/ui/src/contexts/PathPrefixContext.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import { createContext, useContext } from 'react';
 
 /**
  * PathPrefixContext propagates the base URL throughout the component tree where
  * the application is hosted.
  */
-const PathPrefixContext = React.createContext('');
+const PathPrefixContext = createContext('');
 
 /**
  * usePathPrefix retrieves the current base URL where the application is
@@ -14,7 +14,7 @@ const PathPrefixContext = React.createContext('');
  * The returned path prefix will always end in a `/`.
  */
 function usePathPrefix(): string {
-  const prefix = React.useContext(PathPrefixContext);
+  const prefix = useContext(PathPrefixContext);
   if (prefix === '') {
     return '/';
   }

--- a/internal/web/ui/src/features/clustering/Table.tsx
+++ b/internal/web/ui/src/features/clustering/Table.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import { CSSProperties } from 'react';
 
 import styles from './Table.module.css';
 
 interface Props {
   tableHeaders: string[];
-  style?: React.CSSProperties;
+  style?: CSSProperties;
   renderTableData: () => JSX.Element[];
 }
 

--- a/internal/web/ui/src/features/component/ComponentBody.tsx
+++ b/internal/web/ui/src/features/component/ComponentBody.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import { Fragment } from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 
 import { alloyStringify } from '../alloy-syntax-js/stringify';

--- a/internal/web/ui/src/features/component/Table.tsx
+++ b/internal/web/ui/src/features/component/Table.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { CSSProperties } from 'react';
 
 import TableHead from './TableHead';
 import { SortOrder } from './types';
@@ -7,7 +7,7 @@ import styles from './Table.module.css';
 
 interface Props {
   tableHeaders: string[];
-  style?: React.CSSProperties;
+  style?: CSSProperties;
   handleSorting?: (sortField: string, sortOrder: SortOrder) => void;
   renderTableData: () => JSX.Element[];
 }

--- a/internal/web/ui/src/features/component/style.ts
+++ b/internal/web/ui/src/features/component/style.ts
@@ -1,8 +1,8 @@
-import React from 'react';
+import { CSSProperties } from 'react';
 
 // Object for react-syntax-highlighter's custom theme
 export const style: {
-  [key: string]: React.CSSProperties;
+  [key: string]: CSSProperties;
 } = {
   'code[class*="language-"]': {
     color: 'black',

--- a/internal/web/ui/src/index.tsx
+++ b/internal/web/ui/src/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
 
 import App from './App';
@@ -8,7 +8,7 @@ import './index.css';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
-  <React.StrictMode>
+  <StrictMode>
     <App />
-  </React.StrictMode>
+  </StrictMode>
 );


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

React 18 now automatically injects JSX runtime during compilation so React import is no longer necessary. I also switch to named imports for currency and slightly better bundling.

I ran `yarn start`, `yarn build`. Everything stays identical to builds prior to this change.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->
N/A

#### Notes to the Reviewer
N/A

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

