### PR TITLE
Bump build image to v0.1.2 to support nodeJS 18

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -110,7 +110,7 @@ steps:
 - commands:
   - apt-get update -y && apt-get install -y libsystemd-dev
   - make lint
-  image: grafana/alloy-build-image:v0.1.1
+  image: grafana/alloy-build-image:v0.1.2
   name: Lint
 trigger:
   event:
@@ -125,7 +125,7 @@ platform:
 steps:
 - commands:
   - make GO_TAGS="nodocker" test
-  image: grafana/alloy-build-image:v0.1.1
+  image: grafana/alloy-build-image:v0.1.2
   name: Run Go tests
 trigger:
   event:
@@ -140,7 +140,7 @@ platform:
 steps:
 - commands:
   - K8S_USE_DOCKER_NETWORK=1 make test
-  image: grafana/alloy-build-image:v0.1.1
+  image: grafana/alloy-build-image:v0.1.2
   name: Run Go tests
   volumes:
   - name: docker
@@ -163,7 +163,7 @@ platform:
 steps:
 - commands:
   - go test -tags="nodocker,nonetwork" ./...
-  image: grafana/alloy-build-image:v0.1.1-windows
+  image: grafana/alloy-build-image:v0.1.2-windows
   name: Run Go tests
 trigger:
   ref:
@@ -178,7 +178,7 @@ platform:
 steps:
 - commands:
   - make alloy-image
-  image: grafana/alloy-build-image:v0.1.1
+  image: grafana/alloy-build-image:v0.1.2
   name: Build container
   volumes:
   - name: docker
@@ -204,7 +204,7 @@ platform:
 steps:
 - commands:
   - '& "C:/Program Files/git/bin/bash.exe" -c "make alloy-image-windows"'
-  image: grafana/alloy-build-image:v0.1.1-windows
+  image: grafana/alloy-build-image:v0.1.2-windows
   name: Build container
   volumes:
   - name: docker
@@ -231,7 +231,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=amd64 GOARM=
     make alloy
-  image: grafana/alloy-build-image:v0.1.1
+  image: grafana/alloy-build-image:v0.1.2
   name: Build
 trigger:
   event:
@@ -248,7 +248,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=arm64 GOARM=
     make alloy
-  image: grafana/alloy-build-image:v0.1.1
+  image: grafana/alloy-build-image:v0.1.2
   name: Build
 trigger:
   event:
@@ -265,7 +265,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=ppc64le GOARM=
     make alloy
-  image: grafana/alloy-build-image:v0.1.1
+  image: grafana/alloy-build-image:v0.1.2
   name: Build
 trigger:
   event:
@@ -282,7 +282,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=s390x GOARM=
     make alloy
-  image: grafana/alloy-build-image:v0.1.1
+  image: grafana/alloy-build-image:v0.1.2
   name: Build
 trigger:
   event:
@@ -298,7 +298,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=darwin GOARCH=amd64 GOARM= make alloy
-  image: grafana/alloy-build-image:v0.1.1
+  image: grafana/alloy-build-image:v0.1.2
   name: Build
 trigger:
   event:
@@ -314,7 +314,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=darwin GOARCH=arm64 GOARM= make alloy
-  image: grafana/alloy-build-image:v0.1.1
+  image: grafana/alloy-build-image:v0.1.2
   name: Build
 trigger:
   event:
@@ -330,7 +330,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=windows GOARCH=amd64 GOARM= make alloy
-  image: grafana/alloy-build-image:v0.1.1
+  image: grafana/alloy-build-image:v0.1.2
   name: Build
 trigger:
   event:
@@ -346,7 +346,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=freebsd GOARCH=amd64 GOARM= make alloy
-  image: grafana/alloy-build-image:v0.1.1
+  image: grafana/alloy-build-image:v0.1.2
   name: Build
 trigger:
   event:
@@ -363,7 +363,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=amd64 GOARM=
     GOEXPERIMENT=boringcrypto make alloy
-  image: grafana/alloy-build-image:v0.1.1-boringcrypto
+  image: grafana/alloy-build-image:v0.1.2-boringcrypto
   name: Build
 trigger:
   event:
@@ -380,7 +380,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=arm64 GOARM=
     GOEXPERIMENT=boringcrypto make alloy
-  image: grafana/alloy-build-image:v0.1.1-boringcrypto
+  image: grafana/alloy-build-image:v0.1.2-boringcrypto
   name: Build
 trigger:
   event:
@@ -396,7 +396,7 @@ steps:
 - commands:
   - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   failure: ignore
-  image: grafana/alloy-build-image:v0.1.1
+  image: grafana/alloy-build-image:v0.1.2
   name: Configure QEMU
   volumes:
   - name: docker
@@ -416,7 +416,7 @@ steps:
       from_secret: docker_password
     GCR_CREDS:
       from_secret: gcr_admin
-  image: grafana/alloy-build-image:v0.1.1
+  image: grafana/alloy-build-image:v0.1.2
   name: Publish container
   volumes:
   - name: docker
@@ -439,7 +439,7 @@ steps:
 - commands:
   - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   failure: ignore
-  image: grafana/alloy-build-image:v0.1.1
+  image: grafana/alloy-build-image:v0.1.2
   name: Configure QEMU
   volumes:
   - name: docker
@@ -459,7 +459,7 @@ steps:
       from_secret: docker_password
     GCR_CREDS:
       from_secret: gcr_admin
-  image: grafana/alloy-build-image:v0.1.1
+  image: grafana/alloy-build-image:v0.1.2
   name: Publish container
   volumes:
   - name: docker
@@ -493,7 +493,7 @@ steps:
       from_secret: docker_password
     GCR_CREDS:
       from_secret: gcr_admin
-  image: grafana/alloy-build-image:v0.1.1-windows
+  image: grafana/alloy-build-image:v0.1.2-windows
   name: Build containers
   volumes:
   - name: docker
@@ -516,7 +516,7 @@ steps:
 - commands:
   - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   failure: ignore
-  image: grafana/alloy-build-image:v0.1.1
+  image: grafana/alloy-build-image:v0.1.2
   name: Configure QEMU
   volumes:
   - name: docker
@@ -536,7 +536,7 @@ steps:
       from_secret: docker_password
     GCR_CREDS:
       from_secret: gcr_admin
-  image: grafana/alloy-build-image:v0.1.1
+  image: grafana/alloy-build-image:v0.1.2
   name: Publish container
   volumes:
   - name: docker
@@ -559,7 +559,7 @@ steps:
 - commands:
   - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   failure: ignore
-  image: grafana/alloy-build-image:v0.1.1
+  image: grafana/alloy-build-image:v0.1.2
   name: Configure QEMU
   volumes:
   - name: docker
@@ -579,7 +579,7 @@ steps:
       from_secret: docker_password
     GCR_CREDS:
       from_secret: gcr_admin
-  image: grafana/alloy-build-image:v0.1.1
+  image: grafana/alloy-build-image:v0.1.2
   name: Publish container
   volumes:
   - name: docker
@@ -613,7 +613,7 @@ steps:
       from_secret: docker_password
     GCR_CREDS:
       from_secret: gcr_admin
-  image: grafana/alloy-build-image:v0.1.1-windows
+  image: grafana/alloy-build-image:v0.1.2-windows
   name: Build containers
   volumes:
   - name: docker
@@ -714,7 +714,7 @@ steps:
       from_secret: gpg_private_key
     GPG_PUBLIC_KEY:
       from_secret: gpg_public_key
-  image: grafana/alloy-build-image:v0.1.1
+  image: grafana/alloy-build-image:v0.1.2
   name: Publish release
   volumes:
   - name: docker
@@ -737,7 +737,7 @@ steps:
 - commands:
   - DOCKER_OPTS="" make dist/alloy-linux-amd64
   - DOCKER_OPTS="" make test-packages
-  image: grafana/alloy-build-image:v0.1.1
+  image: grafana/alloy-build-image:v0.1.2
   name: Test Linux system packages
   volumes:
   - name: docker
@@ -835,6 +835,6 @@ kind: secret
 name: updater_private_key
 ---
 kind: signature
-hmac: edfc9eabaa8e7af503b548fca203b5e7491258cbf778e172db3fc0cdd23ac3d4
+hmac: 60dbc7f93c24089a985433ec810276f8bbf84f6b93a173e27b2d278388329511
 
 ...

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
 # in environment variables.
 
-FROM --platform=$BUILDPLATFORM grafana/alloy-build-image:v0.1.1 as build
+FROM --platform=$BUILDPLATFORM grafana/alloy-build-image:v0.1.2 as build
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,4 +1,4 @@
-FROM grafana/alloy-build-image:v0.1.1-windows as builder
+FROM grafana/alloy-build-image:v0.1.2-windows as builder
 ARG VERSION
 ARG RELEASE_BUILD=1
 ARG GO_TAGS

--- a/tools/make/build-container.mk
+++ b/tools/make/build-container.mk
@@ -34,7 +34,7 @@
 # variable names should be passed through to the container.
 
 USE_CONTAINER       ?= 0
-BUILD_IMAGE_VERSION ?= v0.1.1
+BUILD_IMAGE_VERSION ?= v0.1.2
 BUILD_IMAGE         ?= grafana/alloy-build-image:$(BUILD_IMAGE_VERSION)
 DOCKER_OPTS         ?= -it
 


### PR DESCRIPTION
The only change was to bump the nodeJS version to 18 to support grafana's react component used for the live debugging. 
See https://github.com/grafana/alloy/pull/940