### PR TITLE
Add dynamic targets support to prometheus.exporter.blackbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,10 @@ Main (unreleased)
 ### Enhancements
 
 - Added a success rate panel on the Prometheus Components dashboard. (@thampiotr)
+
 - Add namespace field to Faro payload (@cedricziel)
+
+- Add the `targets` argument to the `prometheus.exporter.blackbox` component to support passing blackbox targets at runtime. (@wildum)
 
 ### Bugfixes
 

--- a/docs/sources/reference/components/prometheus.exporter.blackbox.md
+++ b/docs/sources/reference/components/prometheus.exporter.blackbox.md
@@ -50,7 +50,8 @@ The `config` argument must be a YAML document as string defining which `blackbox
 - `remote.s3.LABEL.content`
 
 The `targets` argument is an alternative to the [target][] block. This is useful when blackbox targets are supplied by another component.
-The following labels can be set to a target:
+
+You can set the following labels to a target:
 * `name`: The name of the target to probe (required).
 * `address`: The address of the target to probe (required).
 * `module`: The blackbox module to use to probe.

--- a/docs/sources/reference/components/prometheus.exporter.blackbox.md
+++ b/docs/sources/reference/components/prometheus.exporter.blackbox.md
@@ -49,7 +49,8 @@ The `config` argument must be a YAML document as string defining which `blackbox
 - `remote.http.LABEL.content`
 - `remote.s3.LABEL.content`
 
-The `targets` argument is an alternative to the [target][] block. This is useful when blackbox targets are supplied by another component.
+You can't use both the `targets` argument and the [target][] block in the same configuration file.
+The `targets` argument must be used when blackbox targets cannot be passed as a target block because another component supplies them.
 
 You can set the following labels to a target:
 * `name`: The name of the target to probe (required).

--- a/docs/sources/reference/components/prometheus.exporter.blackbox.md
+++ b/docs/sources/reference/components/prometheus.exporter.blackbox.md
@@ -20,16 +20,25 @@ prometheus.exporter.blackbox "LABEL" {
 }
 ```
 
+or 
+
+```alloy
+prometheus.exporter.blackbox "LABEL" {
+  targets = TARGET_LIST
+}
+```
+
 ## Arguments
 
 The following arguments can be used to configure the exporter's behavior.
 Omitted fields take their default values.
 
-| Name                   | Type                 | Description                                                        | Default  | Required |
-| ---------------------- | -------------------- | ------------------------------------------------------------------ | -------- | -------- |
+| Name                   | Type                 | Description                                                      | Default  | Required |
+| ---------------------- | -------------------- | ---------------------------------------------------------------- | -------- | -------- |
 | `config_file`          | `string`             | `blackbox_exporter` configuration file path.                       |          | no       |
 | `config`               | `string` or `secret` | `blackbox_exporter` configuration as inline string.                |          | no       |
-| `probe_timeout_offset` | `duration`           | Offset in seconds to subtract from timeout when probing targets.   | `"0.5s"` | no       |
+| `probe_timeout_offset` | `duration`           | Offset in seconds to subtract from timeout when probing targets. | `"0.5s"` | no       |
+| `targets`              | `list(map(string))`  | Blackbox targets.                                                |          | no       |
 
 Either `config_file` or `config` must be specified.
 The `config_file` argument points to a YAML file defining which `blackbox_exporter` modules to use.
@@ -40,6 +49,15 @@ The `config` argument must be a YAML document as string defining which `blackbox
 - `remote.http.LABEL.content`
 - `remote.s3.LABEL.content`
 
+The `targets` argument is an alternative to the [target][] block. This is useful when blackbox targets are supplied by another component.
+The following labels can be set to a target:
+* `name`: The name of the target to probe (required).
+* `address`: The address of the target to probe (required).
+* `module`: The blackbox module to use to probe.
+
+Any additional labels will be passed to the exported target of the component.
+
+
 Refer to [`blackbox_exporter`](https://github.com/prometheus/blackbox_exporter/blob/master/example.yml) for more information about generating a configuration file.
 
 ## Blocks
@@ -49,7 +67,7 @@ The following blocks are supported inside the definition of
 
 | Hierarchy | Name       | Description                   | Required |
 | --------- | ---------- | ----------------------------- | -------- |
-| target    | [target][] | Configures a blackbox target. | yes      |
+| target    | [target][] | Configures a blackbox target. | no       |
 
 [target]: #target-block
 
@@ -58,12 +76,12 @@ The following blocks are supported inside the definition of
 The `target` block defines an individual blackbox target.
 The `target` block may be specified multiple times to define multiple targets. `name` attribute is required and will be used in the target's `job` label.
 
-| Name      | Type             | Description                         | Default | Required |
-| --------- | ---------------- | ----------------------------------- | ------- | -------- |
-| `name`    | `string`         | The name of the target to probe.    |         | yes      |
-| `address` | `string`         | The address of the target to probe. |         | yes      |
-| `module`  | `string`         | Blackbox module to use to probe.    | `""`    | no       |
-| `labels`  | `map(string)`    | Labels to add to the target.        |         | no       |
+| Name      | Type          | Description                         | Default | Required |
+| --------- | ------------- | ----------------------------------- | ------- | -------- |
+| `name`    | `string`      | The name of the target to probe.    |         | yes      |
+| `address` | `string`      | The address of the target to probe. |         | yes      |
+| `module`  | `string`      | Blackbox module to use to probe.    | `""`    | no       |
+| `labels`  | `map(string)` | Labels to add to the target.        |         | no       |
 
 Labels specified in the `labels` argument won't override labels set by `blackbox_exporter`.
 
@@ -91,7 +109,7 @@ debug metrics.
 
 ### Collect metrics using a blackbox exporter configuration file
 
-This example uses a [`prometheus.scrape` component][scrape] to collect metrics from `prometheus.exporter.blackbox`.
+This example uses a [`prometheus.scrape` component][scrape] to collect metrics from `prometheus.exporter.blackbox`. 
 It adds an extra label, `env="dev"`, to the metrics emitted by the `grafana` target. The `example` target doesn't have any added labels.
 
 The `config_file` argument is used to define which `blackbox_exporter` modules to use. You can use the [blackbox example config file](https://github.com/prometheus/blackbox_exporter/blob/master/example.yml).
@@ -116,7 +134,7 @@ prometheus.exporter.blackbox "example" {
   }
 }
 
-// Configure a prometheus.scrape component to collect Blackbox metrics.
+// Configure a prometheus.scrape component to collect blackbox metrics.
 prometheus.scrape "demo" {
   targets    = prometheus.exporter.blackbox.example.targets
   forward_to = [prometheus.remote_write.demo.receiver]
@@ -164,7 +182,7 @@ prometheus.exporter.blackbox "example" {
   }
 }
 
-// Configure a prometheus.scrape component to collect Blackbox metrics.
+// Configure a prometheus.scrape component to collect blackbox metrics.
 prometheus.scrape "demo" {
   targets    = prometheus.exporter.blackbox.example.targets
   forward_to = [prometheus.remote_write.demo.receiver]
@@ -182,14 +200,61 @@ prometheus.remote_write "demo" {
 }
 ```
 
+### Collect metrics from a dynamic set of targets
+
+This example is the same as above but the blackbox targets are discovered via a [`discovery.file` component][disc] and sent to the `prometheus.exporter.blackbox`:
+
+```alloy
+discovery.file "example" {
+  files = ["targets.yml"]
+}
+
+prometheus.exporter.blackbox "example" {
+  config = "{ modules: { http_2xx: { prober: http, timeout: 5s } } }"
+  targets = discovery.file.example.targets
+}
+
+prometheus.scrape "example" {
+  targets    = prometheus.exporter.blackbox.example.targets
+  forward_to = [prometheus.remote_write.example.receiver]
+}
+
+prometheus.remote_write "example" {
+  endpoint {
+    url = PROMETHEUS_REMOTE_WRITE_URL
+
+    basic_auth {
+      username = USERNAME
+      password = PASSWORD
+    }
+  }
+}
+```
+
+The YAML file in this example looks like this:
+```yaml
+- targets:
+  - localhost:9009
+  labels:
+    name: t1
+    module: http_2xx
+    other_label: example
+- targets:
+  - localhost:9009
+  labels:
+    name: t2
+    module: http_2xx
+```
+
 Replace the following:
 
 - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
 - `USERNAME`: The username to use for authentication to the `remote_write` API.
 - `PASSWORD`: The password to use for authentication to the `remote_write` API.
 
-
 [scrape]: ../prometheus.scrape/
+[disc]: ../discovery.file/
+[relabel]: ../discovery.relabel/
 
 <!-- START GENERATED COMPATIBLE COMPONENTS -->
 

--- a/docs/sources/reference/components/prometheus.exporter.blackbox.md
+++ b/docs/sources/reference/components/prometheus.exporter.blackbox.md
@@ -55,8 +55,7 @@ The following labels can be set to a target:
 * `address`: The address of the target to probe (required).
 * `module`: The blackbox module to use to probe.
 
-Any additional labels will be passed to the exported target of the component.
-
+The component passes any additional labels to the exported target.
 
 Refer to [`blackbox_exporter`](https://github.com/prometheus/blackbox_exporter/blob/master/example.yml) for more information about generating a configuration file.
 

--- a/internal/cmd/integration-tests/tests/blackbox/blackbox_metrics_test.go
+++ b/internal/cmd/integration-tests/tests/blackbox/blackbox_metrics_test.go
@@ -1,0 +1,33 @@
+//go:build !windows
+
+package main
+
+import (
+	"testing"
+
+	"github.com/grafana/alloy/internal/cmd/integration-tests/common"
+)
+
+func TestBlackBoxMetrics(t *testing.T) {
+	var blackboxMetrics = []string{
+		"probe_dns_lookup_time_seconds",
+		"probe_duration_seconds",
+		"probe_failed_due_to_regex",
+		"probe_http_content_length",
+		"probe_http_duration_seconds",
+		"probe_http_redirects",
+		"probe_http_ssl",
+		"probe_http_status_code",
+		"probe_http_uncompressed_body_length",
+		"probe_http_version",
+		"probe_ip_addr_hash",
+		"probe_ip_protocol",
+		"probe_success",
+		"scrape_duration_seconds",
+		"scrape_samples_post_metric_relabeling",
+		"scrape_samples_scraped",
+		"scrape_series_added",
+		"up",
+	}
+	common.MimirMetricsTest(t, blackboxMetrics, []string{}, "blackbox_metrics")
+}

--- a/internal/cmd/integration-tests/tests/blackbox/config.alloy
+++ b/internal/cmd/integration-tests/tests/blackbox/config.alloy
@@ -1,0 +1,63 @@
+prometheus.exporter.blackbox "blackbox_metrics" {
+  config = "{ modules: { http_2xx: { prober: http, timeout: 5s } } }"
+  targets = [
+    {
+      "name" = "t1",
+      "address" = "localhost:9009", // use mimir as a target
+      "module" = "http_2xx",
+    },
+  ]
+}
+
+prometheus.scrape "blackbox_metrics" {
+  targets    = prometheus.exporter.blackbox.blackbox_metrics.targets
+  forward_to = [prometheus.remote_write.blackbox_metrics.receiver]
+  scrape_interval = "1s"
+  scrape_timeout = "500ms"
+}
+
+prometheus.remote_write "blackbox_metrics" {
+  endpoint {
+    url = "http://localhost:9009/api/v1/push"
+    metadata_config {
+        send_interval = "1s"
+    }
+    queue_config {
+        max_samples_per_send = 100
+    }    
+  }
+  external_labels = {
+    test_name = "blackbox_metrics",
+  }  
+}
+
+prometheus.exporter.blackbox "blackbox_metrics2" {
+  config = "{ modules: { http_2xx: { prober: http, timeout: 5s } } }"
+  target {
+    name = "t1"
+    address = "localhost:9009" // use mimir as a target
+    module = "http_2xx"
+  }
+}
+
+prometheus.scrape "blackbox_metrics2" {
+  targets    = prometheus.exporter.blackbox.blackbox_metrics2.targets
+  forward_to = [prometheus.remote_write.blackbox_metrics2.receiver]
+  scrape_interval = "1s"
+  scrape_timeout = "500ms"
+}
+
+prometheus.remote_write "blackbox_metrics2" {
+  endpoint {
+    url = "http://localhost:9009/api/v1/push"
+    metadata_config {
+        send_interval = "1s"
+    }
+    queue_config {
+        max_samples_per_send = 100
+    }    
+  }
+  external_labels = {
+    test_name = "blackbox_metrics2",
+  }  
+}

--- a/internal/component/prometheus/exporter/blackbox/blackbox.go
+++ b/internal/component/prometheus/exporter/blackbox/blackbox.go
@@ -38,8 +38,13 @@ func createExporter(opts component.Options, args component.Arguments, defaultIns
 func buildBlackboxTargets(baseTarget discovery.Target, args component.Arguments) []discovery.Target {
 	var targets []discovery.Target
 
-	a := args.(Arguments)
-	for _, tgt := range a.Targets {
+	blackboxTargets := args.(Arguments).Targets
+	if len(blackboxTargets) == 0 {
+		// Converting to BlackboxTarget to avoid duplicating logic
+		blackboxTargets = args.(Arguments).TargetsList.convert()
+	}
+
+	for _, tgt := range blackboxTargets {
 		target := make(discovery.Target)
 		// Set extra labels first, meaning that any other labels will override
 		for k, v := range tgt.Labels {
@@ -93,8 +98,49 @@ func (t TargetBlock) Convert() []blackbox_exporter.BlackboxTarget {
 type Arguments struct {
 	ConfigFile         string                    `alloy:"config_file,attr,optional"`
 	Config             alloytypes.OptionalSecret `alloy:"config,attr,optional"`
-	Targets            TargetBlock               `alloy:"target,block"`
+	Targets            TargetBlock               `alloy:"target,block,optional"`
 	ProbeTimeoutOffset time.Duration             `alloy:"probe_timeout_offset,attr,optional"`
+
+	// New way of passing targets. This allows the component to receive targets from other components.
+	TargetsList TargetsList `alloy:"targets,attr,optional"`
+}
+
+type TargetsList []map[string]string
+
+func (t TargetsList) Convert() []blackbox_exporter.BlackboxTarget {
+	targets := make([]blackbox_exporter.BlackboxTarget, 0, len(t))
+	for _, target := range t {
+		address, _ := getAddress(target)
+		targets = append(targets, blackbox_exporter.BlackboxTarget{
+			Name:   target["name"],
+			Target: address,
+			Module: target["module"],
+		})
+	}
+	return targets
+}
+
+func (t TargetsList) convert() []BlackboxTarget {
+	targets := make([]BlackboxTarget, 0, len(t))
+	for _, target := range t {
+
+		// extract the extra labels
+		labels := make(map[string]string)
+		for key, value := range target {
+			if key != "name" && key != "__address__" && key != "address" && key != "module" {
+				labels[key] = value
+			}
+		}
+
+		address, _ := getAddress(target)
+		targets = append(targets, BlackboxTarget{
+			Name:   target["name"],
+			Target: address,
+			Module: target["module"],
+			Labels: labels,
+		})
+	}
+	return targets
 }
 
 // SetToDefault implements syntax.Defaulter.
@@ -118,15 +164,42 @@ func (a *Arguments) Validate() error {
 		return fmt.Errorf("invalid blackbox_exporter config: %s", err)
 	}
 
+	if len(a.Targets) != 0 && len(a.TargetsList) != 0 {
+		return fmt.Errorf("the block `target` and the attribute `targets` are mutually exclusive")
+	}
+	for _, target := range a.TargetsList {
+		if _, hasName := target["name"]; !hasName {
+			return fmt.Errorf("all targets must have a `name`")
+		}
+		if _, hasAddress := getAddress(target); !hasAddress {
+			return fmt.Errorf("all targets must have an `address` or an `__address__` label")
+		}
+	}
 	return nil
 }
 
 // Convert converts the component's Arguments to the integration's Config.
 func (a *Arguments) Convert() *blackbox_exporter.Config {
+	var targets []blackbox_exporter.BlackboxTarget
+	if len(a.Targets) != 0 {
+		targets = a.Targets.Convert()
+	} else {
+		targets = a.TargetsList.Convert()
+	}
 	return &blackbox_exporter.Config{
 		BlackboxConfigFile: a.ConfigFile,
 		BlackboxConfig:     util.RawYAML(a.Config.Value),
-		BlackboxTargets:    a.Targets.Convert(),
+		BlackboxTargets:    targets,
 		ProbeTimeoutOffset: a.ProbeTimeoutOffset.Seconds(),
 	}
+}
+
+func getAddress(data map[string]string) (string, bool) {
+	if value, ok := data["address"]; ok {
+		return value, true
+	}
+	if value, ok := data["__address__"]; ok {
+		return value, true
+	}
+	return "", false
 }

--- a/internal/component/prometheus/exporter/blackbox/blackbox.go
+++ b/internal/component/prometheus/exporter/blackbox/blackbox.go
@@ -41,7 +41,7 @@ func buildBlackboxTargets(baseTarget discovery.Target, args component.Arguments)
 	blackboxTargets := args.(Arguments).Targets
 	if len(blackboxTargets) == 0 {
 		// Converting to BlackboxTarget to avoid duplicating logic
-		blackboxTargets = args.(Arguments).TargetsList.convert()
+		blackboxTargets = args.(Arguments).TargetsList.convertInternal()
 	}
 
 	for _, tgt := range blackboxTargets {
@@ -120,7 +120,7 @@ func (t TargetsList) Convert() []blackbox_exporter.BlackboxTarget {
 	return targets
 }
 
-func (t TargetsList) convert() []BlackboxTarget {
+func (t TargetsList) convertInternal() []BlackboxTarget {
 	targets := make([]BlackboxTarget, 0, len(t))
 	for _, target := range t {
 

--- a/internal/component/prometheus/exporter/blackbox/blackbox_test.go
+++ b/internal/component/prometheus/exporter/blackbox/blackbox_test.go
@@ -42,6 +42,41 @@ func TestUnmarshalAlloy(t *testing.T) {
 	require.Contains(t, "http_2xx", args.Targets[1].Module)
 }
 
+func TestUnmarshalAlloyTargets(t *testing.T) {
+	alloyCfg := `
+		config_file = "modules.yml"
+		targets = [
+			{
+				"name" = "target_a", 
+				"address" = "http://example.com", 
+				"module" = "http_2xx",
+				"some_label1" = "a",
+				"some_label2" = "b",
+			},
+			{
+				"name" = "target_b", 
+				"address" = "http://grafana.com", 
+				"module" = "http_2xx",
+			},
+		  ]	
+`
+	var args Arguments
+	err := syntax.Unmarshal([]byte(alloyCfg), &args)
+	require.NoError(t, err)
+	require.Equal(t, "modules.yml", args.ConfigFile)
+	require.Equal(t, 2, len(args.TargetsList))
+
+	require.Contains(t, "target_a", args.TargetsList[0]["name"])
+	require.Contains(t, "http://example.com", args.TargetsList[0]["address"])
+	require.Contains(t, "http_2xx", args.TargetsList[0]["module"])
+	require.Contains(t, "a", args.TargetsList[0]["some_label1"])
+	require.Contains(t, "b", args.TargetsList[0]["some_label2"])
+
+	require.Contains(t, "target_b", args.TargetsList[1]["name"])
+	require.Contains(t, "http://grafana.com", args.TargetsList[1]["address"])
+	require.Contains(t, "http_2xx", args.TargetsList[1]["module"])
+}
+
 func TestUnmarshalAlloyWithInlineConfig(t *testing.T) {
 	alloyCfg := `
 		config = "{ modules: { http_2xx: { prober: http, timeout: 5s } } }"
@@ -282,4 +317,137 @@ func TestBuildBlackboxTargetsWithExtraLabels(t *testing.T) {
 	require.Equal(t, 1, len(targets))
 	require.Equal(t, "integrations/blackbox/target_a", targets[0]["job"])
 	require.Equal(t, "prometheus.exporter.blackbox.default", targets[0]["instance"])
+}
+
+// Test convert from TargetsList to []blackbox_exporter.BlackboxTarget
+func TestConvertTargetsList(t *testing.T) {
+	targets := TargetsList{
+		{
+			"name":        "target_a",
+			"address":     "http://example.com",
+			"module":      "http_2xx",
+			"some_label1": "a",
+			"some_label2": "b",
+		},
+	}
+
+	res := targets.Convert()
+	require.Equal(t, 1, len(res))
+	require.Equal(t, "target_a", res[0].Name)
+	require.Equal(t, "http://example.com", res[0].Target)
+	require.Equal(t, "http_2xx", res[0].Module)
+}
+
+// Test convert from TargetsList to []blackbox_exporter.BlackboxTarget
+func TestConvertTargetsListDifferentAddressLabel(t *testing.T) {
+	targets := TargetsList{
+		{
+			"name":        "target_a",
+			"__address__": "http://example.com",
+			"module":      "http_2xx",
+			"some_label1": "a",
+			"some_label2": "b",
+		},
+	}
+
+	res := targets.Convert()
+	require.Equal(t, 1, len(res))
+	require.Equal(t, "target_a", res[0].Name)
+	require.Equal(t, "http://example.com", res[0].Target)
+	require.Equal(t, "http_2xx", res[0].Module)
+}
+
+// Test convert from TargetsList to []BlackboxTarget
+func TestConvertTargetsList2(t *testing.T) {
+	targets := TargetsList{
+		{
+			"name":        "target_a",
+			"address":     "http://example.com",
+			"module":      "http_2xx",
+			"some_label1": "a",
+			"some_label2": "b",
+		},
+	}
+
+	res := targets.convert()
+	require.Equal(t, 1, len(res))
+	require.Equal(t, "target_a", res[0].Name)
+	require.Equal(t, "http://example.com", res[0].Target)
+	require.Equal(t, "http_2xx", res[0].Module)
+	require.Equal(t, "a", res[0].Labels["some_label1"])
+	require.Equal(t, "b", res[0].Labels["some_label2"])
+}
+
+// Test convert from TargetsList to []BlackboxTarget
+func TestConvertTargetsList2DifferentAddressLabel(t *testing.T) {
+	targets := TargetsList{
+		{
+			"name":        "target_a",
+			"__address__": "http://example.com",
+			"module":      "http_2xx",
+			"some_label1": "a",
+			"some_label2": "b",
+		},
+	}
+
+	res := targets.convert()
+	require.Equal(t, 1, len(res))
+	require.Equal(t, "target_a", res[0].Name)
+	require.Equal(t, "http://example.com", res[0].Target)
+	require.Equal(t, "http_2xx", res[0].Module)
+	require.Equal(t, "a", res[0].Labels["some_label1"])
+	require.Equal(t, "b", res[0].Labels["some_label2"])
+}
+
+func TestValidateTargetMissingName(t *testing.T) {
+	targets := TargetsList{
+		{
+			"address":     "http://example.com",
+			"module":      "http_2xx",
+			"some_label1": "a",
+			"some_label2": "b",
+		},
+	}
+	args := Arguments{
+		ConfigFile:  "modules.yml",
+		TargetsList: targets,
+	}
+	require.ErrorContains(t, args.Validate(), "all targets must have a `name`")
+}
+
+func TestValidateTargetMissingAddress(t *testing.T) {
+	targets := TargetsList{
+		{
+			"name":        "target_a",
+			"module":      "http_2xx",
+			"some_label1": "a",
+			"some_label2": "b",
+		},
+	}
+	args := Arguments{
+		ConfigFile:  "modules.yml",
+		TargetsList: targets,
+	}
+	require.ErrorContains(t, args.Validate(), "all targets must have an `address` or an `__address__` label")
+}
+
+func TestValidateTargetsMutualExclusivity(t *testing.T) {
+	targets := TargetsList{
+		{
+			"name":    "target_a",
+			"address": "http://example.com",
+			"module":  "http_2xx",
+		},
+	}
+	targetBlock := TargetBlock{{
+		Name:   "network_switch_1",
+		Target: "192.168.1.2",
+		Module: "if_mib",
+	}}
+	args := Arguments{
+		ConfigFile:  "modules.yml",
+		TargetsList: targets,
+		Targets:     targetBlock,
+	}
+	require.ErrorContains(t, args.Validate(), "the block `target` and the attribute `targets` are mutually exclusive")
 }

--- a/internal/component/prometheus/exporter/blackbox/blackbox_test.go
+++ b/internal/component/prometheus/exporter/blackbox/blackbox_test.go
@@ -369,7 +369,7 @@ func TestConvertTargetsList2(t *testing.T) {
 		},
 	}
 
-	res := targets.convert()
+	res := targets.convertInternal()
 	require.Equal(t, 1, len(res))
 	require.Equal(t, "target_a", res[0].Name)
 	require.Equal(t, "http://example.com", res[0].Target)
@@ -390,7 +390,7 @@ func TestConvertTargetsList2DifferentAddressLabel(t *testing.T) {
 		},
 	}
 
-	res := targets.convert()
+	res := targets.convertInternal()
 	require.Equal(t, 1, len(res))
 	require.Equal(t, "target_a", res[0].Name)
 	require.Equal(t, "http://example.com", res[0].Target)

--- a/internal/converter/internal/staticconvert/internal/build/blackbox_exporter.go
+++ b/internal/converter/internal/staticconvert/internal/build/blackbox_exporter.go
@@ -22,7 +22,7 @@ func toBlackboxExporter(config *blackbox_exporter.Config) *blackbox.Arguments {
 			IsSecret: false,
 			Value:    string(config.BlackboxConfig),
 		},
-		Targets:            toBlackboxTargets(config.BlackboxTargets),
+		TargetsList:        toBlackboxTargets(config.BlackboxTargets),
 		ProbeTimeoutOffset: time.Duration(config.ProbeTimeoutOffset),
 	}
 }
@@ -39,25 +39,19 @@ func toBlackboxExporterV2(config *blackbox_exporter_v2.Config) *blackbox.Argumen
 			IsSecret: false,
 			Value:    string(config.BlackboxConfig),
 		},
-		Targets:            toBlackboxTargets(config.BlackboxTargets),
+		TargetsList:        toBlackboxTargets(config.BlackboxTargets),
 		ProbeTimeoutOffset: time.Duration(config.ProbeTimeoutOffset),
 	}
 }
 
-func toBlackboxTargets(blackboxTargets []blackbox_exporter.BlackboxTarget) blackbox.TargetBlock {
-	var targetBlock blackbox.TargetBlock
-
+func toBlackboxTargets(blackboxTargets []blackbox_exporter.BlackboxTarget) []map[string]string {
+	var targets blackbox.TargetsList
 	for _, bt := range blackboxTargets {
-		targetBlock = append(targetBlock, toBlackboxTarget(bt))
+		target := make(map[string]string)
+		target["name"] = bt.Name
+		target["address"] = bt.Target
+		target["module"] = bt.Module
+		targets = append(targets, target)
 	}
-
-	return targetBlock
-}
-
-func toBlackboxTarget(target blackbox_exporter.BlackboxTarget) blackbox.BlackboxTarget {
-	return blackbox.BlackboxTarget{
-		Name:   target.Name,
-		Target: target.Target,
-		Module: target.Module,
-	}
+	return targets
 }

--- a/internal/converter/internal/staticconvert/testdata-v2/integrations_v2.alloy
+++ b/internal/converter/internal/staticconvert/testdata-v2/integrations_v2.alloy
@@ -684,14 +684,13 @@ prometheus.scrape "integrations_apache2" {
 }
 
 prometheus.exporter.blackbox "integrations_blackbox" {
-	config = "modules:\n  http_2xx:\n    prober: http\n    timeout: 5s\n    http:\n      method: POST\n      headers:\n        Content-Type: application/json\n      body: '{}'\n      preferred_ip_protocol: ip4\n"
-
-	target {
-		name    = "example"
-		address = "http://example.com"
-		module  = "http_2xx"
-	}
+	config               = "modules:\n  http_2xx:\n    prober: http\n    timeout: 5s\n    http:\n      method: POST\n      headers:\n        Content-Type: application/json\n      body: '{}'\n      preferred_ip_protocol: ip4\n"
 	probe_timeout_offset = "0s"
+	targets              = [{
+		address = "http://example.com",
+		module  = "http_2xx",
+		name    = "example",
+	}]
 }
 
 discovery.relabel "integrations_blackbox" {

--- a/internal/converter/internal/staticconvert/testdata/integrations.alloy
+++ b/internal/converter/internal/staticconvert/testdata/integrations.alloy
@@ -57,14 +57,13 @@ prometheus.scrape "integrations_apache_http" {
 }
 
 prometheus.exporter.blackbox "integrations_blackbox" {
-	config = "modules:\n  http_2xx:\n    prober: http\n    timeout: 5s\n    http:\n      method: POST\n      headers:\n        Content-Type: application/json\n      body: '{}'\n      preferred_ip_protocol: ip4\n"
-
-	target {
-		name    = "example"
-		address = "http://example.com"
-		module  = "http_2xx"
-	}
+	config               = "modules:\n  http_2xx:\n    prober: http\n    timeout: 5s\n    http:\n      method: POST\n      headers:\n        Content-Type: application/json\n      body: '{}'\n      preferred_ip_protocol: ip4\n"
 	probe_timeout_offset = "0s"
+	targets              = [{
+		address = "http://example.com",
+		module  = "http_2xx",
+		name    = "example",
+	}]
 }
 
 discovery.relabel "integrations_blackbox" {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Add an argument targets to support passing targets at runtime to the exporter.

Also add integration tests to cover both ways of passing targets.

(similar to https://github.com/grafana/alloy/pull/969) 

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #273 

#### Notes to the Reviewer

I added an additional argument because replacing the target block would be a breaking change.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated
- [ ] Create an issue to eventually delete the target block when switching to a major version
