### PR TITLE
Community components

### DIFF
--- a/.github/ISSUE_TEMPLATE/community_component_proposal.yaml
+++ b/.github/ISSUE_TEMPLATE/community_component_proposal.yaml
@@ -1,0 +1,22 @@
+name: Community component proposal
+description: Propose a new community component.
+labels: ["community-component"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for opening a community component proposal for Grafana Alloy.
+
+        Before opening the proposal, make sure you read the [Community Component Guidelines](https://github.com/grafana/alloy/tree/main/docs/developer/adding-community-components.md).
+  - type: textarea
+    attributes:
+      label: Community component name
+      description: What is the name of the component you want to add?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Community component description
+      description: What should this component do?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/community_component_proposal.yaml
+++ b/.github/ISSUE_TEMPLATE/community_component_proposal.yaml
@@ -7,7 +7,7 @@ body:
       value: |
         Thank you for opening a community component proposal for Grafana Alloy.
 
-        Before opening the proposal, make sure you read the [Community Component Guidelines](https://github.com/grafana/alloy/tree/main/docs/developer/adding-community-components.md).
+        Make sure you read the [Community Component Guidelines](https://github.com/grafana/alloy/tree/main/docs/developer/adding-community-components.md).
   - type: textarea
     attributes:
       label: Community component name

--- a/.github/ISSUE_TEMPLATE/community_component_proposal.yaml
+++ b/.github/ISSUE_TEMPLATE/community_component_proposal.yaml
@@ -1,6 +1,6 @@
 name: Community component proposal
 description: Propose a new community component.
-labels: ["community-component"]
+labels: ["community-component", "proposal"]
 body:
   - type: markdown
     attributes:
@@ -14,6 +14,9 @@ body:
       description: What is the name of the component you want to add?
     validations:
       required: true
+  - type: checkboxes
+    attributes:
+      label: Are you willing to be the maintainer for this component in Alloy? 
   - type: textarea
     attributes:
       label: Community component description

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Main (unreleased)
 
 - Update Public preview `remotecfg` argument from `metadata` to `attributes`. (@erikbaranowski)
 
+### Features
+
+- Added community components support, enabling community members to implement and maintain components. (@wildum)
+
 ### Enhancements
 
 - Added a success rate panel on the Prometheus Components dashboard. (@thampiotr)

--- a/docs/developer/adding-community-components.md
+++ b/docs/developer/adding-community-components.md
@@ -1,0 +1,53 @@
+# Adding community components
+
+[Community components][cc] are components that are implemented and maintained by the community.
+
+## Before opening a proposal
+
+The first step is to ensure that the proposal meets the following criteria and does not duplicate existing proposals:
+
+* Avoid overlapping functionalities.
+* Avoid components that can be implemented as [modules][module].
+* Avoid components that affect our dependencies in an undesired way, such as pulling in an incompatible version or bloating the collector.
+* Make sure that the code licenses are compatible with Alloy's [license][].
+
+While not mandatory, it is beneficial if:
+
+* The component comes from [Opentelemetry's contrib repository][otel].
+* The component supports all the [platforms that Alloy supports][platforms].
+
+## Creating a proposal
+
+To create a proposal, submit a new issue in [Alloy's repo][issue] with the template `Community component proposal`.
+
+Make sure that the issue has the label `community-component` before submitting it.
+
+## Implementing the component
+
+When the proposal has been accepted, you can claim it and start the implementation (make sure that you are familiar with our [contribution guidelines][contributing]).
+
+Doing the implementation will make you a maintainer of the component. This will take effect as soon as the pull request is merged to the main branch.
+
+Community components live amongst other components in the code. The only difference with core components is that the flag `Community` should be set to true when registering the component.
+
+The documentation should also follow the same pattern as the core components but at a different [location][cc dir].
+
+## Being a community component maintainer
+
+Community component maintainers may be pinged on GitHub issues and Pull Requests related to their components. They are expected to help keeping their component up to date with the project (e.g. if it's a component from [Opentelemetry's contrib repository][otel], the implementation should match the current otel version of the project).
+
+Failing to keep the component up to date may result in the component being disabled or removed.
+
+The list of maintainers is kept as a comment in the component's Go file:
+* Anyone can volunteer to become a maintainer by opening a pull request to add their GitHub handle to the list.
+* Any maintainer can step out of the role by opening a pull request to remove their GitHub handle from the list.
+
+
+[cc]: ../sources/concepts/community_components.md
+[cc dir]: https://grafana.com/docs/alloy/latest/reference/community_components
+[module]: ../sources/concepts/modules.md
+[license]: ../../LICENSE
+[platforms]: ../sources/introduction/supported-platforms.md
+[otel]: https://github.com/open-telemetry/opentelemetry-collector-contrib
+[issue]: https://github.com/grafana/alloy/issues/new/choose
+[contributing]: contributing.md

--- a/docs/developer/adding-community-components.md
+++ b/docs/developer/adding-community-components.md
@@ -10,6 +10,7 @@ The first step is to ensure that the proposal meets the following criteria and d
 * Avoid components that can be implemented as [modules][module].
 * Avoid components that affect our dependencies in an undesired way, such as pulling in an incompatible version or bloating the collector.
 * Make sure that the code licenses are compatible with Alloy's [license][].
+* You are willing to be a maintainer of the component.
 
 While not mandatory, it is beneficial if:
 
@@ -34,13 +35,13 @@ The documentation should also follow the same pattern as the core components but
 
 ## Being a community component maintainer
 
-Community component maintainers may be pinged on GitHub issues and Pull Requests related to their components. They are expected to help keeping their component up to date with the project (e.g. if it's a component from [Opentelemetry's contrib repository][otel], the implementation should match the current otel version of the project).
+Community component maintainers may be pinged on GitHub issues and Pull Requests related to their components. They are expected to help keeping their component and the documentation up to date with the project (e.g. if it's a component from [Opentelemetry's contrib repository][otel], the implementation should match the current otel version of the project).
 
 Failing to keep the component up to date may result in the component being disabled or removed.
 
 The list of maintainers is kept as a comment in the component's Go file:
-* Anyone can volunteer to become a maintainer by opening a pull request to add their GitHub handle to the list.
-* Any maintainer can step out of the role by opening a pull request to remove their GitHub handle from the list.
+* Anyone can volunteer to become a maintainer by opening a pull request to add themselves as code owner for the component.
+* Any maintainer can step out of the role by opening a pull request to remove their GitHub handle from code owners for the component.
 
 
 [cc]: ../sources/concepts/community_components.md

--- a/docs/developer/adding-community-components.md
+++ b/docs/developer/adding-community-components.md
@@ -55,9 +55,9 @@ The list of maintainers is kept as a comment in the component's Go file:
 * Any maintainer can step out of the role by opening a pull request to remove their GitHub handle from code owners for the component.
 
 
-[cc]: ../sources/concepts/community_components.md
+[cc]: ../sources/get-started/community_components.md
 [cc dir]: https://grafana.com/docs/alloy/latest/reference/community_components
-[module]: ../sources/concepts/modules.md
+[module]: ../sources/get-started/modules.md
 [license]: ../../LICENSE
 [platforms]: ../sources/introduction/supported-platforms.md
 [otel]: https://github.com/open-telemetry/opentelemetry-collector-contrib

--- a/docs/developer/adding-community-components.md
+++ b/docs/developer/adding-community-components.md
@@ -48,7 +48,7 @@ The documentation should also follow the same pattern as the core components but
 
 Community component maintainers may be pinged on GitHub issues and Pull Requests related to their components. They are expected to help keeping their component and the documentation up to date with the project (e.g. if it's a component from [OpenTelemetry's contrib repository][otel], the implementation should match the current OTel version of the project).
 
-Failing to keep the component up to date may result in the component being disabled or removed.
+Failing to keep the component up to date may result in the component being deprecated, disabled, or removed.
 
 The list of maintainers is kept as a comment in the component's Go file:
 * Anyone can volunteer to become a maintainer by opening a pull request to add themselves as code owner for the component.

--- a/docs/developer/adding-community-components.md
+++ b/docs/developer/adding-community-components.md
@@ -46,7 +46,7 @@ The documentation should also follow the same pattern as the core components but
 
 ## Being a community component maintainer
 
-Community component maintainers may be pinged on GitHub issues and Pull Requests related to their components. They are expected to help keeping their component and the documentation up to date with the project (e.g. if it's a component from [Opentelemetry's contrib repository][otel], the implementation should match the current otel version of the project).
+Community component maintainers may be pinged on GitHub issues and Pull Requests related to their components. They are expected to help keeping their component and the documentation up to date with the project (e.g. if it's a component from [OpenTelemetry's contrib repository][otel], the implementation should match the current OTel version of the project).
 
 Failing to keep the component up to date may result in the component being disabled or removed.
 

--- a/docs/developer/adding-community-components.md
+++ b/docs/developer/adding-community-components.md
@@ -2,6 +2,12 @@
 
 [Community components][cc] are components that are implemented and maintained by the community.
 
+## Community vs core components
+
+The community components category is mainly targeted at vendor-specific components for which Grafana does not offer commercial support (for example the Datadog exporter).
+
+Some vendor-agnostic components may also be accepted as community components if they are not accepted as core components.
+
 ## Before opening a proposal
 
 The first step is to ensure that the proposal meets the following criteria and does not duplicate existing proposals:
@@ -17,11 +23,16 @@ While not mandatory, it is beneficial if:
 * The component comes from [Opentelemetry's contrib repository][otel].
 * The component supports all the [platforms that Alloy supports][platforms].
 
+We are implementing a gradual rollout strategy for community components to allow for process refinement as needed.
+Even if a proposal meets all the established criteria, we may exercise caution in its acceptance to ensure a smooth integration process.
+
 ## Creating a proposal
 
 To create a proposal, submit a new issue in [Alloy's repo][issue] with the template `Community component proposal`.
 
 Make sure that the issue has the label `community-component` before submitting it.
+
+The proposal will go through our [review process][]. Make sure that you use the [review template][] in your issue.
 
 ## Implementing the component
 
@@ -52,3 +63,5 @@ The list of maintainers is kept as a comment in the component's Go file:
 [otel]: https://github.com/open-telemetry/opentelemetry-collector-contrib
 [issue]: https://github.com/grafana/alloy/issues/new/choose
 [contributing]: contributing.md
+[review process]: ../design/README.md
+[review template]: ../design/template.md

--- a/docs/developer/adding-community-components.md
+++ b/docs/developer/adding-community-components.md
@@ -32,7 +32,7 @@ To create a proposal, submit a new issue in [Alloy's repo][issue] with the templ
 
 Make sure that the issue has the label `community-component` before submitting it.
 
-The proposal will go through our [review process][]. Make sure that you use the [review template][] in your issue.
+The proposal will go through our [review process][].
 
 ## Implementing the component
 

--- a/docs/sources/get-started/community_components.md
+++ b/docs/sources/get-started/community_components.md
@@ -1,0 +1,20 @@
+---
+canonical: https://grafana.com/docs/alloy/latest/concepts/community_components/
+description: Learn about community components
+title: Community components
+weight: 100
+---
+
+# Community components
+
+__Community components__ are [components][Components] implemented and maintained by the community.
+
+While Grafana does not offer commercial support for these components, they undergo acceptance and review by {{< param "PRODUCT_NAME" >}}'s team before being added to the repository.
+
+To use these community components, you need to explicitly pass the `--community-component` flag to the `run` command.
+
+{{< admonition type="warning" >}}
+__Community components__ that are not kept up to date by the community may be disable or removed.
+{{< /admonition >}}
+
+[Components]: ../components/

--- a/docs/sources/get-started/community_components.md
+++ b/docs/sources/get-started/community_components.md
@@ -14,7 +14,7 @@ While Grafana does not offer commercial support for these components, they under
 To use these community components, you need to explicitly pass the `--community-component` flag to the `run` command.
 
 {{< admonition type="warning" >}}
-__Community components__ that are not kept up to date by the community may be disable or removed.
+__Community components__ without an owner may be eventually disabled or removed.
 {{< /admonition >}}
 
 [Components]: ../components/

--- a/docs/sources/get-started/community_components.md
+++ b/docs/sources/get-started/community_components.md
@@ -9,7 +9,7 @@ weight: 100
 
 __Community components__ are [components][Components] implemented and maintained by the community.
 
-While Grafana does not offer commercial support for these components, they undergo acceptance and review by the {{< param "PRODUCT_NAME" >}} development team before being added to the repository.
+While Grafana does not offer commercial support for these components, they still undergo acceptance and review by the {{< param "PRODUCT_NAME" >}} development team before being added to the repository.
 
 To use these community components, you must explicitly pass the `--feature.community-components.enabled` flag to the `run` command.
 

--- a/docs/sources/get-started/community_components.md
+++ b/docs/sources/get-started/community_components.md
@@ -16,7 +16,7 @@ To use these community components, you must explicitly pass the `--feature.commu
 __Community components__ don't have a stability level. They are not covered by our [backward compatibility strategy][backward-compatibility].
 
 {{< admonition type="warning" >}}
-__Community components__ without an owner may be eventually disabled or removed if they preventing us from being able to continue work on Alloy.
+__Community components__ without a maintainer may be disabled or removed if the components prevent or block the development of {{< param "PRODUCT_NAME" >}}.
 {{< /admonition >}}
 
 [Components]: ../components/

--- a/docs/sources/get-started/community_components.md
+++ b/docs/sources/get-started/community_components.md
@@ -13,8 +13,11 @@ While Grafana does not offer commercial support for these components, they under
 
 To use these community components, you need to explicitly pass the `--feature.community-components.enabled` flag to the `run` command.
 
+__Community components__ don't have a stability level. They are not covered by our [backward compatibility strategy][backward-compatibility].
+
 {{< admonition type="warning" >}}
 __Community components__ without an owner may be eventually disabled or removed if they preventing us from being able to continue work on Alloy.
 {{< /admonition >}}
 
 [Components]: ../components/
+[backward-compatibility]: ../../introduction/backward-compatibility/

--- a/docs/sources/get-started/community_components.md
+++ b/docs/sources/get-started/community_components.md
@@ -14,7 +14,7 @@ While Grafana does not offer commercial support for these components, they under
 To use these community components, you need to explicitly pass the `--community-component` flag to the `run` command.
 
 {{< admonition type="warning" >}}
-__Community components__ without an owner may be eventually disabled or removed.
+__Community components__ without an owner may be eventually disabled or removed if they preventing us from being able to continue work on Alloy.
 {{< /admonition >}}
 
 [Components]: ../components/

--- a/docs/sources/get-started/community_components.md
+++ b/docs/sources/get-started/community_components.md
@@ -11,7 +11,7 @@ __Community components__ are [components][Components] implemented and maintained
 
 While Grafana does not offer commercial support for these components, they undergo acceptance and review by the {{< param "PRODUCT_NAME" >}} development team before being added to the repository.
 
-To use these community components, you need to explicitly pass the `--feature.community-components.enabled` flag to the `run` command.
+To use these community components, you must explicitly pass the `--feature.community-components.enabled` flag to the `run` command.
 
 __Community components__ don't have a stability level. They are not covered by our [backward compatibility strategy][backward-compatibility].
 

--- a/docs/sources/get-started/community_components.md
+++ b/docs/sources/get-started/community_components.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/alloy/latest/concepts/community_components/
+canonical: https://grafana.com/docs/alloy/latest/get-started/community_components/
 description: Learn about community components
 title: Community components
 weight: 100

--- a/docs/sources/get-started/community_components.md
+++ b/docs/sources/get-started/community_components.md
@@ -11,7 +11,7 @@ __Community components__ are [components][Components] implemented and maintained
 
 While Grafana does not offer commercial support for these components, they undergo acceptance and review by {{< param "PRODUCT_NAME" >}}'s team before being added to the repository.
 
-To use these community components, you need to explicitly pass the `--community-component` flag to the `run` command.
+To use these community components, you need to explicitly pass the `--feature.community-components.enabled` flag to the `run` command.
 
 {{< admonition type="warning" >}}
 __Community components__ without an owner may be eventually disabled or removed if they preventing us from being able to continue work on Alloy.

--- a/docs/sources/get-started/community_components.md
+++ b/docs/sources/get-started/community_components.md
@@ -13,7 +13,7 @@ While Grafana does not offer commercial support for these components, they still
 
 To use these community components, you must explicitly pass the `--feature.community-components.enabled` flag to the `run` command.
 
-__Community components__ don't have a stability level. They are not covered by our [backward compatibility strategy][backward-compatibility].
+__Community components__ don't have a stability level. They aren't covered by our [backward compatibility strategy][backward-compatibility].
 
 {{< admonition type="warning" >}}
 __Community components__ without a maintainer may be disabled or removed if the components prevent or block the development of {{< param "PRODUCT_NAME" >}}.

--- a/docs/sources/get-started/community_components.md
+++ b/docs/sources/get-started/community_components.md
@@ -9,7 +9,7 @@ weight: 100
 
 __Community components__ are [components][Components] implemented and maintained by the community.
 
-While Grafana does not offer commercial support for these components, they undergo acceptance and review by {{< param "PRODUCT_NAME" >}}'s team before being added to the repository.
+While Grafana does not offer commercial support for these components, they undergo acceptance and review by the {{< param "PRODUCT_NAME" >}} development team before being added to the repository.
 
 To use these community components, you need to explicitly pass the `--feature.community-components.enabled` flag to the `run` command.
 

--- a/docs/sources/introduction/backward-compatibility.md
+++ b/docs/sources/introduction/backward-compatibility.md
@@ -33,6 +33,8 @@ We strive to maintain backward compatibility, but there are situations that may 
 
 * **Upstream changes**: Much of the functionality of {{< param "PRODUCT_NAME" >}} is built on top of other software, such as OpenTelemetry Collector and Prometheus. If upstream software breaks compatibility, we may need to reflect this in {{< param "PRODUCT_NAME" >}}.
 
+* **Community components**: Community components are components implemented and maintained by the community. They are not covered by our backward compatibility strategy.
+
 We try, whenever possible, to resolve these issues without breaking compatibility.
 
 [semantic versioning]: https://semver.org/

--- a/docs/sources/reference/cli/run.md
+++ b/docs/sources/reference/cli/run.md
@@ -55,6 +55,7 @@ The following flags are supported:
 * `--config.bypass-conversion-errors`: Enable bypassing errors when converting (default `false`).
 * `--config.extra-args`: Extra arguments from the original format used by the converter.
 * `--stability.level`: The minimum permitted stability level of functionality to run. Supported values: `experimental`, `public-preview`, `generally-available` (default `"generally-available"`).
+* `--community-component`: Enable community components (default `false`).
 
 ## Update the configuration file
 

--- a/docs/sources/reference/cli/run.md
+++ b/docs/sources/reference/cli/run.md
@@ -55,7 +55,7 @@ The following flags are supported:
 * `--config.bypass-conversion-errors`: Enable bypassing errors when converting (default `false`).
 * `--config.extra-args`: Extra arguments from the original format used by the converter.
 * `--stability.level`: The minimum permitted stability level of functionality to run. Supported values: `experimental`, `public-preview`, `generally-available` (default `"generally-available"`).
-* `--community-component`: Enable community components (default `false`).
+* `--feature.community-components.enabled`: Enable community components (default `false`).
 
 ## Update the configuration file
 

--- a/internal/alloycli/cmd_run.go
+++ b/internal/alloycli/cmd_run.go
@@ -142,7 +142,7 @@ depending on the nature of the reload error.
 		BoolVar(&r.disableReporting, "disable-reporting", r.disableReporting, "Disable reporting of enabled components to Grafana.")
 	cmd.Flags().StringVar(&r.storagePath, "storage.path", r.storagePath, "Base directory where components can store data")
 	cmd.Flags().Var(&r.minStability, "stability.level", fmt.Sprintf("Minimum stability level of features to enable. Supported values: %s", strings.Join(featuregate.AllowedValues(), ", ")))
-	cmd.Flags().BoolVar(&r.community, "community-component", r.community, "Enable community components.")
+	cmd.Flags().BoolVar(&r.community, "feature.community-components.enabled", r.community, "Enable community components.")
 	return cmd
 }
 

--- a/internal/alloycli/cmd_run.go
+++ b/internal/alloycli/cmd_run.go
@@ -142,7 +142,7 @@ depending on the nature of the reload error.
 		BoolVar(&r.disableReporting, "disable-reporting", r.disableReporting, "Disable reporting of enabled components to Grafana.")
 	cmd.Flags().StringVar(&r.storagePath, "storage.path", r.storagePath, "Base directory where components can store data")
 	cmd.Flags().Var(&r.minStability, "stability.level", fmt.Sprintf("Minimum stability level of features to enable. Supported values: %s", strings.Join(featuregate.AllowedValues(), ", ")))
-	cmd.Flags().BoolVar(&r.community, "feature.community-components.enabled", r.community, "Enable community components.")
+	cmd.Flags().BoolVar(&r.enableCommunityComps, "feature.community-components.enabled", r.enableCommunityComps, "Enable community components.")
 	return cmd
 }
 
@@ -166,7 +166,7 @@ type alloyRun struct {
 	configFormat                 string
 	configBypassConversionErrors bool
 	configExtraArgs              string
-	community                    bool
+	enableCommunityComps         bool
 }
 
 func (fr *alloyRun) Run(configPath string) error {
@@ -293,12 +293,12 @@ func (fr *alloyRun) Run(configPath string) error {
 	alloyseed.Init(fr.storagePath, l)
 
 	f := alloy_runtime.New(alloy_runtime.Options{
-		Logger:       l,
-		Tracer:       t,
-		DataPath:     fr.storagePath,
-		Reg:          reg,
-		MinStability: fr.minStability,
-		Community:    fr.community,
+		Logger:               l,
+		Tracer:               t,
+		DataPath:             fr.storagePath,
+		Reg:                  reg,
+		MinStability:         fr.minStability,
+		EnableCommunityComps: fr.enableCommunityComps,
 		Services: []service.Service{
 			clusterService,
 			httpService,

--- a/internal/alloycli/cmd_run.go
+++ b/internal/alloycli/cmd_run.go
@@ -142,6 +142,7 @@ depending on the nature of the reload error.
 		BoolVar(&r.disableReporting, "disable-reporting", r.disableReporting, "Disable reporting of enabled components to Grafana.")
 	cmd.Flags().StringVar(&r.storagePath, "storage.path", r.storagePath, "Base directory where components can store data")
 	cmd.Flags().Var(&r.minStability, "stability.level", fmt.Sprintf("Minimum stability level of features to enable. Supported values: %s", strings.Join(featuregate.AllowedValues(), ", ")))
+	cmd.Flags().BoolVar(&r.community, "community-component", r.community, "Enable community components.")
 	return cmd
 }
 
@@ -165,6 +166,7 @@ type alloyRun struct {
 	configFormat                 string
 	configBypassConversionErrors bool
 	configExtraArgs              string
+	community                    bool
 }
 
 func (fr *alloyRun) Run(configPath string) error {
@@ -296,6 +298,7 @@ func (fr *alloyRun) Run(configPath string) error {
 		DataPath:     fr.storagePath,
 		Reg:          reg,
 		MinStability: fr.minStability,
+		Community:    fr.community,
 		Services: []service.Service{
 			clusterService,
 			httpService,

--- a/internal/component/registry.go
+++ b/internal/component/registry.go
@@ -149,6 +149,9 @@ type Registration struct {
 	// Build should construct a new component from an initial Arguments and set
 	// of options.
 	Build func(opts Options, args Arguments) (Component, error)
+
+	// Community is true if the component is a community component.
+	Community bool
 }
 
 // CloneArguments returns a new zero value of the registered Arguments type.

--- a/internal/component/registry.go
+++ b/internal/component/registry.go
@@ -137,6 +137,9 @@ type Registration struct {
 	// This field must be set to a non-zero value.
 	Stability featuregate.Stability
 
+	// Community is true if the component is a community component.
+	Community bool
+
 	// An example Arguments value that the registered component expects to
 	// receive as input. Components should provide the zero value of their
 	// Arguments type here.
@@ -149,9 +152,6 @@ type Registration struct {
 	// Build should construct a new component from an initial Arguments and set
 	// of options.
 	Build func(opts Options, args Arguments) (Component, error)
-
-	// Community is true if the component is a community component.
-	Community bool
 }
 
 // CloneArguments returns a new zero value of the registered Arguments type.

--- a/internal/component/registry.go
+++ b/internal/component/registry.go
@@ -175,7 +175,7 @@ func Register(r Registration) {
 	case !r.Community && r.Stability == featuregate.StabilityUndefined:
 		panic(fmt.Sprintf("Component %q has an undefined stability level - please provide stability level when registering the component", r.Name))
 	case r.Community && r.Stability != featuregate.StabilityUndefined:
-		panic(fmt.Sprintf("Community component %q has a defined stability level - community components are not affected by the stability level. It should remain `undefined`", r.Name))
+		panic(fmt.Sprintf("Community component %q has a defined stability level - community components are not subject to this stability level setting. It should remain `undefined`", r.Name))
 	}
 
 	parsed, err := parseComponentName(r.Name)

--- a/internal/component/registry.go
+++ b/internal/component/registry.go
@@ -163,15 +163,19 @@ func (r Registration) CloneArguments() Arguments {
 //   - the name is in use by another component,
 //   - the name is invalid,
 //   - the component name has a suffix length mismatch with an existing component,
-//   - the component's stability level is not defined.
+//   - the component's stability level is not defined and the component is not a community component
+//   - the component's stability level is defined and the component is a community component
 //
 // NOTE: the above panics will trigger during the integration tests if the registrations are invalid.
 func Register(r Registration) {
 	if _, exist := registered[r.Name]; exist {
 		panic(fmt.Sprintf("Component name %q already registered", r.Name))
 	}
-	if r.Stability == featuregate.StabilityUndefined {
+	switch {
+	case !r.Community && r.Stability == featuregate.StabilityUndefined:
 		panic(fmt.Sprintf("Component %q has an undefined stability level - please provide stability level when registering the component", r.Name))
+	case r.Community && r.Stability != featuregate.StabilityUndefined:
+		panic(fmt.Sprintf("Community component %q has a defined stability level - community components are not affected by the stability level. It should remain `undefined`", r.Name))
 	}
 
 	parsed, err := parseComponentName(r.Name)

--- a/internal/runtime/alloy.go
+++ b/internal/runtime/alloy.go
@@ -106,6 +106,9 @@ type Options struct {
 	// Services are configured when LoadFile is invoked. Services are started
 	// when the Alloy controller runs after LoadFile is invoked at least once.
 	Services []service.Service
+
+	// Community enables the use of community components.
+	Community bool
 }
 
 // Runtime is the Alloy system.
@@ -192,6 +195,7 @@ func newController(o controllerOptions) *Runtime {
 			TraceProvider: tracer,
 			DataPath:      o.DataPath,
 			MinStability:  o.MinStability,
+			Community:     o.Community,
 			OnBlockNodeUpdate: func(cn controller.BlockNode) {
 				// Changed node should be queued for reevaluation.
 				f.updateQueue.Enqueue(&controller.QueuedNode{Node: cn, LastUpdatedTime: time.Now()})
@@ -208,6 +212,7 @@ func newController(o controllerOptions) *Runtime {
 					Reg:               o.Reg,
 					DataPath:          o.DataPath,
 					MinStability:      o.MinStability,
+					Community:         o.Community,
 					ID:                id,
 					ServiceMap:        serviceMap,
 					WorkerPool:        workerPool,

--- a/internal/runtime/alloy.go
+++ b/internal/runtime/alloy.go
@@ -107,8 +107,8 @@ type Options struct {
 	// when the Alloy controller runs after LoadFile is invoked at least once.
 	Services []service.Service
 
-	// Community enables the use of community components.
-	Community bool
+	// EnableCommunityComps enables the use of community components.
+	EnableCommunityComps bool
 }
 
 // Runtime is the Alloy system.
@@ -191,11 +191,11 @@ func newController(o controllerOptions) *Runtime {
 
 	f.loader = controller.NewLoader(controller.LoaderOptions{
 		ComponentGlobals: controller.ComponentGlobals{
-			Logger:        log,
-			TraceProvider: tracer,
-			DataPath:      o.DataPath,
-			MinStability:  o.MinStability,
-			Community:     o.Community,
+			Logger:               log,
+			TraceProvider:        tracer,
+			DataPath:             o.DataPath,
+			MinStability:         o.MinStability,
+			EnableCommunityComps: o.EnableCommunityComps,
 			OnBlockNodeUpdate: func(cn controller.BlockNode) {
 				// Changed node should be queued for reevaluation.
 				f.updateQueue.Enqueue(&controller.QueuedNode{Node: cn, LastUpdatedTime: time.Now()})
@@ -205,17 +205,17 @@ func newController(o controllerOptions) *Runtime {
 			ControllerID:    o.ControllerID,
 			NewModuleController: func(id string) controller.ModuleController {
 				return newModuleController(&moduleControllerOptions{
-					ComponentRegistry: o.ComponentRegistry,
-					ModuleRegistry:    o.ModuleRegistry,
-					Logger:            log,
-					Tracer:            tracer,
-					Reg:               o.Reg,
-					DataPath:          o.DataPath,
-					MinStability:      o.MinStability,
-					Community:         o.Community,
-					ID:                id,
-					ServiceMap:        serviceMap,
-					WorkerPool:        workerPool,
+					ComponentRegistry:    o.ComponentRegistry,
+					ModuleRegistry:       o.ModuleRegistry,
+					Logger:               log,
+					Tracer:               tracer,
+					Reg:                  o.Reg,
+					DataPath:             o.DataPath,
+					MinStability:         o.MinStability,
+					EnableCommunityComps: o.EnableCommunityComps,
+					ID:                   id,
+					ServiceMap:           serviceMap,
+					WorkerPool:           workerPool,
 				})
 			},
 			GetServiceData: func(name string) (interface{}, error) {

--- a/internal/runtime/alloy_services_test.go
+++ b/internal/runtime/alloy_services_test.go
@@ -213,6 +213,7 @@ func TestComponents_Using_Services(t *testing.T) {
 
 		registry = controller.NewRegistryMap(
 			featuregate.StabilityGenerallyAvailable,
+			true,
 			map[string]component.Registration{
 				"service_consumer": {
 					Name:      "service_consumer",
@@ -275,6 +276,7 @@ func TestComponents_Using_Services_In_Modules(t *testing.T) {
 
 		registry = controller.NewRegistryMap(
 			featuregate.StabilityGenerallyAvailable,
+			true,
 			map[string]component.Registration{
 				"module_loader": {
 					Name:      "module_loader",

--- a/internal/runtime/declare_test.go
+++ b/internal/runtime/declare_test.go
@@ -293,6 +293,40 @@ func TestDeclare(t *testing.T) {
 			`,
 			expected: 10,
 		},
+		{
+			name: "CommunityComponent",
+			config: `
+			declare "com" {
+				argument "input" {
+					optional = false
+				}
+
+				testcomponents.community "default" {}
+			
+				testcomponents.passthrough "pt" {
+					input = argument.input.value
+					lag = "1ms"
+				}
+			
+				export "output" {
+					value = testcomponents.passthrough.pt.output
+				}
+			}
+			testcomponents.count "inc" {
+				frequency = "10ms"
+				max = 10
+			}
+		
+			com "myModule" {
+				input = testcomponents.count.inc.count
+			}
+		
+			testcomponents.summation "sum" {
+				input = com.myModule.output
+			}
+			`,
+			expected: 10,
+		},
 	}
 
 	for _, tc := range tt {

--- a/internal/runtime/internal/controller/component_registry.go
+++ b/internal/runtime/internal/controller/component_registry.go
@@ -21,10 +21,10 @@ type defaultComponentRegistry struct {
 
 // NewDefaultComponentRegistry creates a new [ComponentRegistry] which gets
 // components registered to github.com/grafana/alloy/internal/component.
-func NewDefaultComponentRegistry(minStability featuregate.Stability, community bool) ComponentRegistry {
+func NewDefaultComponentRegistry(minStability featuregate.Stability, enableCommunityComps bool) ComponentRegistry {
 	return defaultComponentRegistry{
 		minStability: minStability,
-		community:    community,
+		community:    enableCommunityComps,
 	}
 }
 

--- a/internal/runtime/internal/controller/component_registry.go
+++ b/internal/runtime/internal/controller/component_registry.go
@@ -35,11 +35,17 @@ func (reg defaultComponentRegistry) Get(name string) (component.Registration, er
 	if !exists {
 		return component.Registration{}, fmt.Errorf("cannot find the definition of component name %q", name)
 	}
-	if err := featuregate.CheckAllowed(cr.Stability, reg.minStability, fmt.Sprintf("component %q", name)); err != nil {
-		return component.Registration{}, err
+
+	if cr.Community {
+		if !reg.community {
+			return component.Registration{}, fmt.Errorf("the component %q is a community component. Use the --community-component command-line flag to enable community components", name)
+		}
+		return cr, nil // community components are not affected by feature stability
 	}
-	if cr.Community && !reg.community {
-		return component.Registration{}, fmt.Errorf("the component %q is a community component. Use the --community-component command-line flag to enable community components", name)
+
+	err := featuregate.CheckAllowed(cr.Stability, reg.minStability, fmt.Sprintf("component %q", name))
+	if err != nil {
+		return component.Registration{}, err
 	}
 	return cr, nil
 }
@@ -71,11 +77,16 @@ func (m registryMap) Get(name string) (component.Registration, error) {
 	if !ok {
 		return component.Registration{}, fmt.Errorf("cannot find the definition of component name %q", name)
 	}
-	if err := featuregate.CheckAllowed(reg.Stability, m.minStability, fmt.Sprintf("component %q", name)); err != nil {
-		return component.Registration{}, err
+	if reg.Community {
+		if !m.community {
+			return component.Registration{}, fmt.Errorf("the component %q is a community component. Use the --community-component command-line flag to enable community components", name)
+		}
+		return reg, nil // community components are not affected by feature stability
 	}
-	if reg.Community && !m.community {
-		return component.Registration{}, fmt.Errorf("the component %q is a community component. Use the --community-component command-line flag to enable community components", name)
+
+	err := featuregate.CheckAllowed(reg.Stability, m.minStability, fmt.Sprintf("component %q", name))
+	if err != nil {
+		return component.Registration{}, err
 	}
 	return reg, nil
 }

--- a/internal/runtime/internal/controller/component_registry.go
+++ b/internal/runtime/internal/controller/component_registry.go
@@ -38,7 +38,7 @@ func (reg defaultComponentRegistry) Get(name string) (component.Registration, er
 
 	if cr.Community {
 		if !reg.community {
-			return component.Registration{}, fmt.Errorf("the component %q is a community component. Use the --community-component command-line flag to enable community components", name)
+			return component.Registration{}, fmt.Errorf("the component %q is a community component. Use the --feature.community-components.enabled command-line flag to enable community components", name)
 		}
 		return cr, nil // community components are not affected by feature stability
 	}
@@ -79,7 +79,7 @@ func (m registryMap) Get(name string) (component.Registration, error) {
 	}
 	if reg.Community {
 		if !m.community {
-			return component.Registration{}, fmt.Errorf("the component %q is a community component. Use the --community-component command-line flag to enable community components", name)
+			return component.Registration{}, fmt.Errorf("the component %q is a community component. Use the --feature.community-components.enabled command-line flag to enable community components", name)
 		}
 		return reg, nil // community components are not affected by feature stability
 	}

--- a/internal/runtime/internal/controller/loader.go
+++ b/internal/runtime/internal/controller/loader.go
@@ -78,7 +78,7 @@ func NewLoader(opts LoaderOptions) *Loader {
 	parent, id := splitPath(globals.ControllerID)
 
 	if reg == nil {
-		reg = NewDefaultComponentRegistry(opts.ComponentGlobals.MinStability)
+		reg = NewDefaultComponentRegistry(opts.ComponentGlobals.MinStability, opts.ComponentGlobals.Community)
 	}
 
 	l := &Loader{

--- a/internal/runtime/internal/controller/loader.go
+++ b/internal/runtime/internal/controller/loader.go
@@ -78,7 +78,7 @@ func NewLoader(opts LoaderOptions) *Loader {
 	parent, id := splitPath(globals.ControllerID)
 
 	if reg == nil {
-		reg = NewDefaultComponentRegistry(opts.ComponentGlobals.MinStability, opts.ComponentGlobals.Community)
+		reg = NewDefaultComponentRegistry(opts.ComponentGlobals.MinStability, opts.ComponentGlobals.EnableCommunityComps)
 	}
 
 	l := &Loader{

--- a/internal/runtime/internal/controller/loader_test.go
+++ b/internal/runtime/internal/controller/loader_test.go
@@ -42,6 +42,10 @@ func TestLoader(t *testing.T) {
 		}
 	`
 
+	testFileCommunity := `
+		testcomponents.community "com" {}
+	`
+
 	testConfig := `
 		logging {
 			level = "debug"
@@ -183,6 +187,20 @@ func TestLoader(t *testing.T) {
 		l := controller.NewLoader(newLoaderOptionsWithStability(featuregate.StabilityUndefined))
 		diags := applyFromContent(t, l, []byte(testFile), nil, nil)
 		require.ErrorContains(t, diags.ErrorOrNil(), "stability levels must be defined: got \"public-preview\" as stability of component \"testcomponents.tick\" and <invalid_stability_level> as the minimum stability level")
+	})
+
+	t.Run("Load community component with community enabled", func(t *testing.T) {
+		options := newLoaderOptions()
+		options.ComponentGlobals.Community = true
+		l := controller.NewLoader(options)
+		diags := applyFromContent(t, l, []byte(testFileCommunity), nil, nil)
+		require.NoError(t, diags.ErrorOrNil())
+	})
+
+	t.Run("Load community component with community disabled", func(t *testing.T) {
+		l := controller.NewLoader(newLoaderOptions())
+		diags := applyFromContent(t, l, []byte(testFileCommunity), nil, nil)
+		require.ErrorContains(t, diags.ErrorOrNil(), "the component \"testcomponents.community\" is a community component. Use the --community-component command-line flag to enable community components")
 	})
 
 	t.Run("Partial load with invalid reference", func(t *testing.T) {

--- a/internal/runtime/internal/controller/loader_test.go
+++ b/internal/runtime/internal/controller/loader_test.go
@@ -208,7 +208,7 @@ func TestLoader(t *testing.T) {
 	t.Run("Load community component with community disabled", func(t *testing.T) {
 		l := controller.NewLoader(newLoaderOptions())
 		diags := applyFromContent(t, l, []byte(testFileCommunity), nil, nil)
-		require.ErrorContains(t, diags.ErrorOrNil(), "the component \"testcomponents.community\" is a community component. Use the --community-component command-line flag to enable community components")
+		require.ErrorContains(t, diags.ErrorOrNil(), "the component \"testcomponents.community\" is a community component. Use the --feature.community-components.enabled command-line flag to enable community components")
 	})
 
 	t.Run("Partial load with invalid reference", func(t *testing.T) {

--- a/internal/runtime/internal/controller/loader_test.go
+++ b/internal/runtime/internal/controller/loader_test.go
@@ -197,6 +197,14 @@ func TestLoader(t *testing.T) {
 		require.NoError(t, diags.ErrorOrNil())
 	})
 
+	t.Run("Load community component with community enabled and undefined stability level", func(t *testing.T) {
+		options := newLoaderOptionsWithStability(featuregate.StabilityUndefined)
+		options.ComponentGlobals.Community = true
+		l := controller.NewLoader(options)
+		diags := applyFromContent(t, l, []byte(testFileCommunity), nil, nil)
+		require.NoError(t, diags.ErrorOrNil())
+	})
+
 	t.Run("Load community component with community disabled", func(t *testing.T) {
 		l := controller.NewLoader(newLoaderOptions())
 		diags := applyFromContent(t, l, []byte(testFileCommunity), nil, nil)

--- a/internal/runtime/internal/controller/loader_test.go
+++ b/internal/runtime/internal/controller/loader_test.go
@@ -191,7 +191,7 @@ func TestLoader(t *testing.T) {
 
 	t.Run("Load community component with community enabled", func(t *testing.T) {
 		options := newLoaderOptions()
-		options.ComponentGlobals.Community = true
+		options.ComponentGlobals.EnableCommunityComps = true
 		l := controller.NewLoader(options)
 		diags := applyFromContent(t, l, []byte(testFileCommunity), nil, nil)
 		require.NoError(t, diags.ErrorOrNil())
@@ -199,7 +199,7 @@ func TestLoader(t *testing.T) {
 
 	t.Run("Load community component with community enabled and undefined stability level", func(t *testing.T) {
 		options := newLoaderOptionsWithStability(featuregate.StabilityUndefined)
-		options.ComponentGlobals.Community = true
+		options.ComponentGlobals.EnableCommunityComps = true
 		l := controller.NewLoader(options)
 		diags := applyFromContent(t, l, []byte(testFileCommunity), nil, nil)
 		require.NoError(t, diags.ErrorOrNil())

--- a/internal/runtime/internal/controller/node_builtin_component.go
+++ b/internal/runtime/internal/controller/node_builtin_component.go
@@ -73,6 +73,7 @@ type ComponentGlobals struct {
 	ControllerID        string                                 // ID of controller.
 	NewModuleController func(id string) ModuleController       // Func to generate a module controller.
 	GetServiceData      func(name string) (interface{}, error) // Get data for a service.
+	Community           bool                                   // Enables the use of community components.
 }
 
 // BuiltinComponentNode is a controller node which manages a builtin component.

--- a/internal/runtime/internal/controller/node_builtin_component.go
+++ b/internal/runtime/internal/controller/node_builtin_component.go
@@ -63,17 +63,17 @@ type DialFunc func(ctx context.Context, network, address string) (net.Conn, erro
 // ComponentGlobals are used by BuiltinComponentNodes to build managed components. All
 // BuiltinComponentNodes should use the same ComponentGlobals.
 type ComponentGlobals struct {
-	Logger              *logging.Logger                        // Logger shared between all managed components.
-	TraceProvider       trace.TracerProvider                   // Tracer shared between all managed components.
-	DataPath            string                                 // Shared directory where component data may be stored
-	MinStability        featuregate.Stability                  // Minimum allowed stability level for features
-	OnBlockNodeUpdate   func(cn BlockNode)                     // Informs controller that we need to reevaluate
-	OnExportsChange     func(exports map[string]any)           // Invoked when the managed component updated its exports
-	Registerer          prometheus.Registerer                  // Registerer for serving Alloy and component metrics
-	ControllerID        string                                 // ID of controller.
-	NewModuleController func(id string) ModuleController       // Func to generate a module controller.
-	GetServiceData      func(name string) (interface{}, error) // Get data for a service.
-	Community           bool                                   // Enables the use of community components.
+	Logger               *logging.Logger                        // Logger shared between all managed components.
+	TraceProvider        trace.TracerProvider                   // Tracer shared between all managed components.
+	DataPath             string                                 // Shared directory where component data may be stored
+	MinStability         featuregate.Stability                  // Minimum allowed stability level for features
+	OnBlockNodeUpdate    func(cn BlockNode)                     // Informs controller that we need to reevaluate
+	OnExportsChange      func(exports map[string]any)           // Invoked when the managed component updated its exports
+	Registerer           prometheus.Registerer                  // Registerer for serving Alloy and component metrics
+	ControllerID         string                                 // ID of controller.
+	NewModuleController  func(id string) ModuleController       // Func to generate a module controller.
+	GetServiceData       func(name string) (interface{}, error) // Get data for a service.
+	EnableCommunityComps bool                                   // Enables the use of community components.
 }
 
 // BuiltinComponentNode is a controller node which manages a builtin component.

--- a/internal/runtime/internal/testcomponents/community.go
+++ b/internal/runtime/internal/testcomponents/community.go
@@ -1,0 +1,38 @@
+package testcomponents
+
+import (
+	"context"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/alloy/internal/component"
+	"github.com/grafana/alloy/internal/featuregate"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:      "testcomponents.community",
+		Stability: featuregate.StabilityGenerallyAvailable,
+		Args:      struct{}{},
+		Community: true,
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			return &Community{log: opts.Logger}, nil
+		},
+	})
+}
+
+// Community is a test community component.
+type Community struct {
+	log log.Logger
+}
+
+func (e *Community) Run(ctx context.Context) error {
+	e.log.Log("msg", "running community component")
+	<-ctx.Done()
+	return nil
+}
+
+func (e *Community) Update(args component.Arguments) error {
+	e.log.Log("msg", "updating community component")
+	return nil
+}

--- a/internal/runtime/internal/testcomponents/community.go
+++ b/internal/runtime/internal/testcomponents/community.go
@@ -5,13 +5,11 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/alloy/internal/component"
-	"github.com/grafana/alloy/internal/featuregate"
 )
 
 func init() {
 	component.Register(component.Registration{
 		Name:      "testcomponents.community",
-		Stability: featuregate.StabilityGenerallyAvailable,
 		Args:      struct{}{},
 		Community: true,
 

--- a/internal/runtime/module.go
+++ b/internal/runtime/module.go
@@ -226,4 +226,7 @@ type moduleControllerOptions struct {
 	// WorkerPool is a worker pool that can be used to run tasks asynchronously. A default pool will be created if this
 	// is nil.
 	WorkerPool worker.Pool
+
+	// Community enables the use of community components.
+	Community bool
 }

--- a/internal/runtime/module.go
+++ b/internal/runtime/module.go
@@ -227,6 +227,6 @@ type moduleControllerOptions struct {
 	// is nil.
 	WorkerPool worker.Pool
 
-	// Community enables the use of community components.
-	Community bool
+	// EnableCommunityComps enables the use of community components.
+	EnableCommunityComps bool
 }

--- a/internal/runtime/module.go
+++ b/internal/runtime/module.go
@@ -136,12 +136,13 @@ func newModule(o *moduleOptions) *module {
 			ComponentRegistry: o.ComponentRegistry,
 			WorkerPool:        o.WorkerPool,
 			Options: Options{
-				ControllerID: o.ID,
-				Tracer:       o.Tracer,
-				Reg:          o.Reg,
-				Logger:       o.Logger,
-				DataPath:     o.DataPath,
-				MinStability: o.MinStability,
+				ControllerID:         o.ID,
+				Tracer:               o.Tracer,
+				Reg:                  o.Reg,
+				Logger:               o.Logger,
+				DataPath:             o.DataPath,
+				MinStability:         o.MinStability,
+				EnableCommunityComps: o.EnableCommunityComps,
 				OnExportsChange: func(exports map[string]any) {
 					if o.export != nil {
 						o.export(exports)

--- a/internal/runtime/module_eval_test.go
+++ b/internal/runtime/module_eval_test.go
@@ -332,10 +332,11 @@ func testOptions(t *testing.T) runtime.Options {
 	require.NotNil(t, otelService)
 
 	return runtime.Options{
-		Logger:       s,
-		DataPath:     t.TempDir(),
-		MinStability: featuregate.StabilityPublicPreview,
-		Reg:          nil,
+		Logger:               s,
+		DataPath:             t.TempDir(),
+		MinStability:         featuregate.StabilityPublicPreview,
+		EnableCommunityComps: true,
+		Reg:                  nil,
 		Services: []service.Service{
 			http_service.New(http_service.Options{}),
 			clusterService,

--- a/internal/runtime/testdata/import_error/import_error_5.txtar
+++ b/internal/runtime/testdata/import_error/import_error_5.txtar
@@ -1,0 +1,14 @@
+Use of an imported community component without specifying the flag propagates the error
+
+-- main.alloy --
+
+import.string "testImport" {
+  content = ` declare "a" {
+    testcomponents.community "com" {}
+  }`
+}
+
+testImport.a "cc" {}
+
+-- error --
+the component "testcomponents.community" is a community component. Use the --community-component command-line flag to enable community components

--- a/internal/runtime/testdata/import_error/import_error_5.txtar
+++ b/internal/runtime/testdata/import_error/import_error_5.txtar
@@ -11,4 +11,4 @@ import.string "testImport" {
 testImport.a "cc" {}
 
 -- error --
-the component "testcomponents.community" is a community component. Use the --community-component command-line flag to enable community components
+the component "testcomponents.community" is a community component. Use the --feature.community-components.enabled command-line flag to enable community components

--- a/internal/runtime/testdata/import_error/import_error_6.txtar
+++ b/internal/runtime/testdata/import_error/import_error_6.txtar
@@ -1,0 +1,18 @@
+Use of a nested declare community component without specifying the flag propagates the error
+
+-- main.alloy --
+
+declare "a" {
+
+  declare "b" {
+    testcomponents.community "com" {}
+  }
+
+  b "cc" {}
+
+}
+
+a "cc" {}
+
+-- error --
+the component "testcomponents.community" is a community component. Use the --community-component command-line flag to enable community components

--- a/internal/runtime/testdata/import_error/import_error_6.txtar
+++ b/internal/runtime/testdata/import_error/import_error_6.txtar
@@ -15,4 +15,4 @@ declare "a" {
 a "cc" {}
 
 -- error --
-the component "testcomponents.community" is a community component. Use the --community-component command-line flag to enable community components
+the component "testcomponents.community" is a community component. Use the --feature.community-components.enabled command-line flag to enable community components


### PR DESCRIPTION
This PR introduces the concept of community components.

Community components are components owned and maintained by the community.
Grafana's commercial support offer does not cover them.

This category exists mainly to add vendor-specific components to Alloy like the Datadog exporter.

Closes #1077