### PR TITLE
Fix bad link syntax in notes

### DIFF
--- a/docs/sources/get-started/install/docker.md
+++ b/docs/sources/get-started/install/docker.md
@@ -48,6 +48,8 @@ Refer to the documentation for [run][] for more information about the options av
 {{< admonition type="note" >}}
 Make sure you pass `--server.http.listen-addr=0.0.0.0:12345` as an argument as shown in the example.
 If you don't pass this argument, the [debugging UI][UI] won't be available outside of the Docker container.
+
+[UI]: ../../../tasks/debug/#alloy-ui
 {{< /admonition >}}
 
 ### BoringCrypto images
@@ -87,6 +89,8 @@ Refer to the documentation for [run][] for more information about the options av
 {{< admonition type="note" >}}
 Make sure you pass `--server.http.listen-addr=0.0.0.0:12345` as an argument as shown in the example above.
 If you don't pass this argument, the [debugging UI][UI] won't be available outside of the Docker container.
+
+[UI]: ../../../tasks/debug/#alloy-ui
 {{< /admonition >}}
 
 ## Verify


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Link syntax is incorrect in the Notes on this page. https://grafana.com/docs/alloy/latest/get-started/install/docker/ Refs need to be included within the admonition shortcode to resolve correctly.

This error isn't present in Agent: https://grafana.com/docs/agent/latest/flow/get-started/install/docker/
#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
