### PR TITLE
packaging/deb/postinst: don't add Alloy user to adm group

### DIFF
--- a/packaging/deb/control/postinst
+++ b/packaging/deb/control/postinst
@@ -18,10 +18,7 @@ case "$1" in
             useradd -m -r -g "$ALLOY_GROUP" -d /var/lib/alloy -s /sbin/nologin -c "alloy user" "$ALLOY_USER"
         fi
 
-        # Add Alloy user to groups used for reading logs.
-        if getent group adm > /dev/null 2>&1 ; then
-            usermod -a -G adm "$ALLOY_USER"
-        fi
+        # Add Alloy user to systemd-journal group for reading logs.
         if getent group systemd-journal > /dev/null 2>&1 ; then
             usermod -a -G systemd-journal "$ALLOY_USER"
         fi


### PR DESCRIPTION
The systemd-journald group is sufficient to get system logs, at least all systemd-journald provided ones.

See
https://www.freedesktop.org/software/systemd/man/latest/systemd-journald.service.html#Access%20Control and https://github.com/NixOS/nixpkgs/pull/318306#discussion_r1633083262 for details, ~handing out `adm` is effectively giving `sudo` rights, which is precisely what we don't want to do~.

#### PR Description

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
