### PR TITLE
Fix loki.source.docker to handle targets with multiple networks configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,8 @@ Main (unreleased)
 
 - Fix panic when `import.git` is given a revision that does not exist on the remote repo. (@hainenber)
 
+- Fixed an issue with `loki.source.docker` where collecting logs from targets configured with multiple networks would result in errors. (@wildum)
+
 ### Other changes
 
 - `pyroscope.ebpf`, `pyroscope.java`, `pyroscope.scrape`, `pyroscope.write` and `discovery.process` components are now GA. (@korniltsev)

--- a/internal/component/loki/source/docker/docker.go
+++ b/internal/component/loki/source/docker/docker.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"sync"
 	"time"
 
@@ -179,6 +180,11 @@ func (c *Component) Run(ctx context.Context) error {
 	}
 }
 
+type promTarget struct {
+	labels      model.LabelSet
+	fingerPrint model.Fingerprint
+}
+
 // Update implements component.Component.
 func (c *Component) Update(args component.Arguments) error {
 	newArgs := args.(Arguments)
@@ -219,29 +225,39 @@ func (c *Component) Update(args component.Arguments) error {
 	targets := make([]*dt.Target, 0, len(newArgs.Targets))
 	seenTargets := make(map[string]struct{}, len(newArgs.Targets))
 
-	for _, target := range newArgs.Targets {
-		containerID, ok := target[dockerLabelContainerID]
-		if !ok {
-			level.Debug(c.opts.Logger).Log("msg", "docker target did not include container ID label:"+dockerLabelContainerID)
-			continue
-		}
-		if _, seen := seenTargets[containerID]; seen {
-			continue
-		}
-		seenTargets[containerID] = struct{}{}
-
+	promTargets := make([]promTarget, len(newArgs.Targets))
+	for i, target := range newArgs.Targets {
 		var labels = make(model.LabelSet)
 		for k, v := range target {
 			labels[model.LabelName(k)] = model.LabelValue(v)
 		}
+		promTargets[i] = promTarget{labels: labels, fingerPrint: labels.Fingerprint()}
+	}
+
+	// Sorting the targets before filtering ensures consistent filtering of targets
+	// when multiple targets share the same containerID.
+	sort.Slice(promTargets, func(i, j int) bool {
+		return promTargets[i].fingerPrint < promTargets[j].fingerPrint
+	})
+
+	for _, markedTarget := range promTargets {
+		containerID, ok := markedTarget.labels[dockerLabelContainerID]
+		if !ok {
+			level.Debug(c.opts.Logger).Log("msg", "docker target did not include container ID label:"+dockerLabelContainerID)
+			continue
+		}
+		if _, seen := seenTargets[string(containerID)]; seen {
+			continue
+		}
+		seenTargets[string(containerID)] = struct{}{}
 
 		tgt, err := dt.NewTarget(
 			c.metrics,
 			log.With(c.opts.Logger, "target", fmt.Sprintf("docker/%s", containerID)),
 			c.manager.opts.handler,
 			c.manager.opts.positions,
-			containerID,
-			labels.Merge(c.defaultLabels),
+			string(containerID),
+			markedTarget.labels.Merge(c.defaultLabels),
 			c.rcs,
 			c.manager.opts.client,
 		)

--- a/internal/component/loki/source/docker/docker_test.go
+++ b/internal/component/loki/source/docker/docker_test.go
@@ -87,6 +87,22 @@ func TestDuplicateTargets(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, cmp.manager.tasks, 1)
+	require.Equal(t, cmp.manager.tasks[0].target.LabelsStr(), "{__meta_docker_container_id=\"foo\", __meta_docker_port_private=\"8080\"}")
+
+	var newCfg = `
+		host       = "tcp://127.0.0.1:9376"
+		targets    = [
+			{__meta_docker_container_id = "foo", __meta_docker_port_private = "8081"},
+			{__meta_docker_container_id = "foo", __meta_docker_port_private = "8080"},
+		]
+		forward_to = []
+	`
+	err = syntax.Unmarshal([]byte(newCfg), &args)
+	require.NoError(t, err)
+	cmp.Update(args)
+	require.Len(t, cmp.manager.tasks, 1)
+	// Although the order of the targets changed, the filtered target stays the same.
+	require.Equal(t, cmp.manager.tasks[0].target.LabelsStr(), "{__meta_docker_container_id=\"foo\", __meta_docker_port_private=\"8080\"}")
 }
 
 func TestRestart(t *testing.T) {


### PR DESCRIPTION

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Explanation from the investigation in the linked issue:

The discovery.docker component will create one target for every network on the same container. This means that the loki.source.docker receives multiple targets that have the same containerID in random order. This [fix](https://github.com/grafana/agent/pull/6055) introduced a filter in the loki.source.docker component to avoid collecting logs multiple times from the same container. But because the order is not guaranteed, if both targetA and targetB have the same containerID, whichever target is first in the list will be selected.
As a consequence, if we have a worker collecting logs on targetA and an update comes with targetB instead, then the worker will be canceled and a new one for targetB will start. This creates error logs with workers being canceled.
This fix sorts the targets according to their label fingerprints before filtering on the containerID. This way, if multiple targets have the same containerID, it will always be the same one that will be selected for log collection.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #225 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Tests updated
