### PR TITLE
Docs: Add "Tuning max_shards" to Prometheus remote write doc

### DIFF
--- a/docs/sources/reference/components/prometheus.remote_write.md
+++ b/docs/sources/reference/components/prometheus.remote_write.md
@@ -171,7 +171,8 @@ Each queue then manages a number of concurrent _shards_ which is responsible
 for sending a fraction of data to their respective endpoints. The number of
 shards is automatically raised if samples are not being sent to the endpoint
 quickly enough. The range of permitted shards can be configured with the
-`min_shards` and `max_shards` arguments.
+`min_shards` and `max_shards` arguments. See "[Tuning `max_shards`](#tuning-max_shards)"
+for more information about how to configure `max_shards`.
 
 Each shard has a buffer of samples it will keep in memory, controlled with the
 `capacity` argument. New metrics aren't read from the WAL unless there is at

--- a/docs/sources/reference/components/prometheus.remote_write.md
+++ b/docs/sources/reference/components/prometheus.remote_write.md
@@ -499,7 +499,7 @@ remote write endpoint `url`:
 clamp_min(
     (
         # Measure the actual number of shards used the 90th percentile of time.
-        min by(cluster, agent_hostname, url) (ceil(quantile_over_time(0.9, prometheus_remote_storage_shards{url=~".*grafana.*"}[24h])))
+        min by(cluster, agent_hostname, url) (ceil(quantile_over_time(0.9, prometheus_remote_storage_shards[24h])))
 
         # Add room for spikes.
         * 4

--- a/docs/sources/reference/components/prometheus.remote_write.md
+++ b/docs/sources/reference/components/prometheus.remote_write.md
@@ -480,10 +480,10 @@ The [`queue_config`](#queue_config-block) block allows you to configure `max_sha
 number of concurrent shards sending samples to the Prometheus-compatible remote write endpoint.
 For each shard, a single remote write request can send up to `max_samples_per_send` samples.
 
-{{< param "PRODUCT_NAME" >}} will try to not use too many shards, but if the queue falls behind the remote write
+{{< param "PRODUCT_NAME" >}} will try not to use too many shards, but if the queue falls behind, the remote write
 component will increase the number of shards up to `max_shards` to increase throughput. A high number of shards may
-potentially overwhelm the remote endpoint, or increase {{< param "PRODUCT_NAME" >}} memory utilization. For this reason,
-it's important to tune `max_shards` to a reasonable value which is good enough to keep up with the backlog of data
+potentially overwhelm the remote endpoint or increase {{< param "PRODUCT_NAME" >}} memory utilization. For this reason,
+it's important to tune `max_shards` to a reasonable value that is good enough to keep up with the backlog of data
 to send to the remote endpoint without overwhelming it.
 
 The maximum throughput that {{< param "PRODUCT_NAME" >}} can achieve when remote writing is equal to
@@ -497,12 +497,12 @@ instance scrapes up to 1 million active series. However, if you run {{< param "P
 at a large scale and each instance scrapes more than 1 million series, we recommend
 increasing the value of `max_shards`.
 
-{{< param "PRODUCT_NAME" >}} exposes few metrics that you can use to monitor the remote write shards:
+{{< param "PRODUCT_NAME" >}} exposes a few metrics that you can use to monitor the remote write shards:
 
 * `prometheus_remote_storage_shards` (gauge): The number of shards used for concurrent delivery of metrics to an endpoint.
 * `prometheus_remote_storage_shards_min` (gauge): The minimum number of shards a queue is allowed to run.
-* `prometheus_remote_storage_shards_max` (gauge): The maximum number of a shards a queue is allowed to run.
-* `prometheus_remote_storage_shards_desired` (gauge): The number of shards a queue wants to run to be able to keep up with the amount of incoming metrics.
+* `prometheus_remote_storage_shards_max` (gauge): The maximum number of shards a queue is allowed to run.
+* `prometheus_remote_storage_shards_desired` (gauge): The number of shards a queue wants to run to keep up with the number of incoming metrics.
 
 If you're already running {{< param "PRODUCT_NAME" >}}, a rule of thumb is to set `max_shards` to
 4x shard utilization. Using the metrics explained above, you can run the following PromQL instant query
@@ -511,8 +511,8 @@ to compute the suggested `max_shards` value for each remote write endpoint `url`
 ```
 clamp_min(
     (
-        # Calculate the 90th percentile desired shards over the last 7 days period.
-        # If you're running {{< param "PRODUCT_NAME" >}} since less than 7 days, then
+        # Calculate the 90th percentile desired shards over the last seven-day period.
+        # If you're running {{< param "PRODUCT_NAME" >}} for less than seven days, then
         # reduce the [7d] period to cover only the time range since when you deployed it.
         ceil(quantile_over_time(0.9, prometheus_remote_storage_shards_desired[7d]))
 
@@ -525,7 +525,7 @@ clamp_min(
 ```
 
 If you aren't running {{< param "PRODUCT_NAME" >}} yet, we recommend running it with the default `max_shards`
-and then use the PromQL instant query mentioned above to compute the recommended `max_shards`.
+and then using the PromQL instant query mentioned above to compute the recommended `max_shards`.
 
 ### WAL corruption
 

--- a/docs/sources/reference/components/prometheus.remote_write.md
+++ b/docs/sources/reference/components/prometheus.remote_write.md
@@ -480,6 +480,12 @@ The [`queue_config`](#queue_config-block) block allows you to configure `max_sha
 number of concurrent shards sending samples to the Prometheus-compatible remote write endpoint.
 For each shard, a single remote write request can send up to `max_samples_per_send` samples.
 
+{{< param "PRODUCT_NAME" >}} will try to not use too many shards, but if the queue falls behind the remote write
+component will increase the number of shards up to `max_shards` to increase throughput. A high number of shards may
+potentially overwhelm the remote endpoint, or increase {{< param "PRODUCT_NAME" >}} memory utilization. For this reason,
+it's important to tune `max_shards` to a reasonable value which is good enough to keep up with the backlog of data
+to send to the remote endpoint without overwhelming it.
+
 The maximum throughput that {{< param "PRODUCT_NAME" >}} can achieve when remote writing is equal to
 `max_shards * max_samples_per_send * <1 / average write request latency>`. For example, running {{< param "PRODUCT_NAME" >}} with the
 default configuration of 50 `max_shards` and 2000 `max_samples_per_send`, and assuming the

--- a/docs/sources/reference/components/prometheus.remote_write.md
+++ b/docs/sources/reference/components/prometheus.remote_write.md
@@ -171,7 +171,7 @@ Each queue then manages a number of concurrent _shards_ which is responsible
 for sending a fraction of data to their respective endpoints. The number of
 shards is automatically raised if samples are not being sent to the endpoint
 quickly enough. The range of permitted shards can be configured with the
-`min_shards` and `max_shards` arguments. See "[Tuning `max_shards`](#tuning-max_shards)"
+`min_shards` and `max_shards` arguments. Refer to  [Tuning `max_shards`](#tuning-max_shards)
 for more information about how to configure `max_shards`.
 
 Each shard has a buffer of samples it will keep in memory, controlled with the
@@ -476,35 +476,35 @@ before being pushed to the remote_write endpoint.
 
 ### Tuning `max_shards`
 
-The [`queue_config`](#queue_config-block) block allows to configure `max_shards`. The `max_shards` is the maximum
+The [`queue_config`](#queue_config-block) block allows you to configure `max_shards`. The `max_shards` is the maximum
 number of concurrent shards sending samples to the Prometheus-compatible remote write endpoint.
 For each shard, a single remote write request can send up to `max_samples_per_send` samples.
 
-The maximum throughput that Grafana Alloy can achieve when remote writing is a function of
-`max_shards * max_samples_per_send * <write request latency>`. For example, running Alloy with the
+The maximum throughput that {{< param "PRODUCT_NAME" >}} can achieve when remote writing is equal to
+`max_shards * max_samples_per_send * <write request latency>`. For example, running {{< param "PRODUCT_NAME" >}} with the
 default configuration of 50 `max_shards` and 2000 `max_samples_per_send`, and assuming the
 average latency of a remote write request is 500ms, the maximum throughput achievable is
 about `50 * 2000 * (1s / 500ms) = 200K samples / s`.
 
-The default `max_shards` configuration is good for most use cases. However, if you run Alloy
-at a large scale and each Alloy instance scrapes more than 1 million series, we recommend
-increasing `max_shards`.
+The default `max_shards` configuration is good for most use cases. However, if you run {{< param "PRODUCT_NAME" >}}
+at a large scale and each {{< param "PRODUCT_NAME" >}} instance scrapes more than 1 million series, we recommend
+increasing the value of `max_shards`.
 
 Assuming a steady number of series of time, without a high churning rate, a rule of
-thumb to configure `max_shards` to a value 4 times higher than the actual shards utilization.
-You can run the following PromQL query to compute the suggested `max_shards` for each
+thumb is to set `max_shards` to 4x shard utilization.
+Run the following PromQL query to compute the suggested `max_shards` value for each
 remote write endpoint `url`:
 
 ```
 clamp_min(
     (
-        # Measure the actual number of shards used the 90th percentile of time.
+        # Calculate the 90th percentile in-use shards over the most recent 24 hour period
         min by(cluster, agent_hostname, url) (ceil(quantile_over_time(0.9, prometheus_remote_storage_shards[24h])))
 
         # Add room for spikes.
         * 4
     ),
-    # Recommended to run at least 50 max_shards, as in the default configuration.
+    # We recommend setting max_shards to a value of no less than 50, as in the default configuration.
     50
 )
 ```

--- a/docs/sources/reference/components/prometheus.remote_write.md
+++ b/docs/sources/reference/components/prometheus.remote_write.md
@@ -487,7 +487,7 @@ average latency of a remote write request is 500ms, the maximum throughput achie
 about `50 * 2000 * (1s / 500ms) = 200K samples / s`.
 
 The default `max_shards` configuration is good for most use cases, especially if each {{< param "PRODUCT_NAME" >}}
-replica scrapes up to 1 million active series. However, if you run {{< param "PRODUCT_NAME" >}}
+instance scrapes up to 1 million active series. However, if you run {{< param "PRODUCT_NAME" >}}
 at a large scale and each instance scrapes more than 1 million series, we recommend
 increasing the value of `max_shards`.
 

--- a/docs/sources/reference/components/prometheus.remote_write.md
+++ b/docs/sources/reference/components/prometheus.remote_write.md
@@ -476,7 +476,7 @@ before being pushed to the remote_write endpoint.
 
 ### Tuning `max_shards`
 
-The `queue_config` block allows to configure `max_shards`. The `max_shards` is the maximum
+The [`queue_config`](#queue_config-block) block allows to configure `max_shards`. The `max_shards` is the maximum
 number of concurrent shards sending samples to the Prometheus-compatible remote write endpoint.
 For each shard, a single remote write request can send up to `max_samples_per_send` samples.
 


### PR DESCRIPTION
#### PR Description

At Grafana Labs, in Mimir team we're preparing to migrate some customers (technically Mimir cells) to the new architecture. As part of this migration, we'll send out some communications and we're double checking doc accordingly.

I was checking the Prometheus remote write config and I noticed that we don't give any suggestion on how to tune `max_shards`. Tuning `max_shards` and give it some root for spikes is important to make sure that Alloy can keep up with the backlog in case of a outage (e.g. a networking issue between Alloy and Mimir).

In this PR I propose to add a "Tuning max_shards" section in the Prometheus remote write doc page.

_Please **don't** merge yet, even if you agree with the wording. I want to get thoughts from different people first._

#### Which issue(s) this PR fixes

N/A

#### Notes to the Reviewer

N/A

#### PR Checklist

- [x] Documentation added
