### PR TITLE
Add a snmp_context argument to SNMP exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,9 @@ Main (unreleased)
   - `otelcol.processor.resourcedetection`: Added a `tags` config argument to the `azure` detection mechanism.
   It exposes regex-matched Azure resource tags as OpenTelemetry resource attributes.
 
+- A new `snmp_context` configuration argument for `prometheus.exporter.snmp`
+  which overrides the `context_name` parameter in the SNMP configuration file. (@ptodev)
+
 ### Bugfixes
 
 - Fixed an issue with `prometheus.scrape` in which targets that move from one

--- a/docs/sources/reference/components/prometheus.exporter.snmp.md
+++ b/docs/sources/reference/components/prometheus.exporter.snmp.md
@@ -81,12 +81,13 @@ The following blocks are supported inside the definition of
 The `target` block defines an individual SNMP target.
 The `target` block may be specified multiple times to define multiple targets. The label of the block is required and will be used in the target's `job` label.
 
-| Name          | Type     | Description                         | Default | Required |
-| ------------- | -------- | ----------------------------------- | ------- | -------- |
-| `address`     | `string` | The address of SNMP device.         |         | yes      |
-| `module`      | `string` | SNMP module to use for polling.     | `""`    | no       |
-| `auth`        | `string` | SNMP authentication profile to use. | `""`    | no       |
-| `walk_params` | `string` | Config to use for this target.      | `""`    | no       |
+| Name           | Type     | Description                                                           | Default | Required |
+| -------------- | -------- | --------------------------------------------------------------------- | ------- | -------- |
+| `address`      | `string` | The address of SNMP device.                                           |         | yes      |
+| `module`       | `string` | SNMP module to use for polling.                                       | `""`    | no       |
+| `auth`         | `string` | SNMP authentication profile to use.                                   | `""`    | no       |
+| `walk_params`  | `string` | Config to use for this target.                                        | `""`    | no       |
+| `snmp_context` | `string` | Override the `context_name` parameter in the SNMP configuration file. | `""`    | no       |
 
 ### walk_param block
 

--- a/internal/component/prometheus/exporter/snmp/snmp.go
+++ b/internal/component/prometheus/exporter/snmp/snmp.go
@@ -56,6 +56,9 @@ func buildSNMPTargets(baseTarget discovery.Target, args component.Arguments) []d
 		if tgt.WalkParams != "" {
 			target["__param_walk_params"] = tgt.WalkParams
 		}
+		if tgt.SNMPContext != "" {
+			target["__param_snmp_context"] = tgt.SNMPContext
+		}
 		if tgt.Auth != "" {
 			target["__param_auth"] = tgt.Auth
 		}
@@ -68,11 +71,12 @@ func buildSNMPTargets(baseTarget discovery.Target, args component.Arguments) []d
 
 // SNMPTarget defines a target to be used by the exporter.
 type SNMPTarget struct {
-	Name       string `alloy:",label"`
-	Target     string `alloy:"address,attr"`
-	Module     string `alloy:"module,attr,optional"`
-	Auth       string `alloy:"auth,attr,optional"`
-	WalkParams string `alloy:"walk_params,attr,optional"`
+	Name        string `alloy:",label"`
+	Target      string `alloy:"address,attr"`
+	Module      string `alloy:"module,attr,optional"`
+	Auth        string `alloy:"auth,attr,optional"`
+	WalkParams  string `alloy:"walk_params,attr,optional"`
+	SNMPContext string `alloy:"snmp_context,attr,optional"`
 }
 
 type TargetBlock []SNMPTarget
@@ -82,11 +86,12 @@ func (t TargetBlock) Convert() []snmp_exporter.SNMPTarget {
 	targets := make([]snmp_exporter.SNMPTarget, 0, len(t))
 	for _, target := range t {
 		targets = append(targets, snmp_exporter.SNMPTarget{
-			Name:       target.Name,
-			Target:     target.Target,
-			Module:     target.Module,
-			Auth:       target.Auth,
-			WalkParams: target.WalkParams,
+			Name:        target.Name,
+			Target:      target.Target,
+			Module:      target.Module,
+			Auth:        target.Auth,
+			WalkParams:  target.WalkParams,
+			SNMPContext: target.SNMPContext,
 		})
 	}
 	return targets
@@ -134,11 +139,12 @@ func (t TargetsList) Convert() []snmp_exporter.SNMPTarget {
 	for _, target := range t {
 		address, _ := getAddress(target)
 		targets = append(targets, snmp_exporter.SNMPTarget{
-			Name:       target["name"],
-			Target:     address,
-			Module:     target["module"],
-			Auth:       target["auth"],
-			WalkParams: target["walk_params"],
+			Name:        target["name"],
+			Target:      address,
+			Module:      target["module"],
+			Auth:        target["auth"],
+			WalkParams:  target["walk_params"],
+			SNMPContext: target["snmp_context"],
 		})
 	}
 	return targets
@@ -149,11 +155,12 @@ func (t TargetsList) convert() []SNMPTarget {
 	for _, target := range t {
 		address, _ := getAddress(target)
 		targets = append(targets, SNMPTarget{
-			Name:       target["name"],
-			Target:     address,
-			Module:     target["module"],
-			Auth:       target["auth"],
-			WalkParams: target["walk_params"],
+			Name:        target["name"],
+			Target:      address,
+			Module:      target["module"],
+			Auth:        target["auth"],
+			WalkParams:  target["walk_params"],
+			SNMPContext: target["snmp_context"],
 		})
 	}
 	return targets

--- a/internal/component/prometheus/exporter/snmp/snmp_test.go
+++ b/internal/component/prometheus/exporter/snmp/snmp_test.go
@@ -21,6 +21,7 @@ func TestUnmarshalAlloy(t *testing.T) {
 			module = "if_mib"
 			walk_params = "public"
 			auth = "public_v2"
+			snmp_context = "testcontext"
 		}
 		target "network_router_2" {
 			address = "192.168.1.3"
@@ -45,6 +46,7 @@ func TestUnmarshalAlloy(t *testing.T) {
 	require.Contains(t, "if_mib", args.Targets[0].Module)
 	require.Contains(t, "public", args.Targets[0].WalkParams)
 	require.Contains(t, "public_v2", args.Targets[0].Auth)
+	require.Contains(t, "testcontext", args.Targets[0].SNMPContext)
 
 	require.Contains(t, "network_router_2", args.Targets[1].Name)
 	require.Contains(t, "192.168.1.3", args.Targets[1].Target)
@@ -139,10 +141,11 @@ func TestConvertConfigWithInlineConfig(t *testing.T) {
 
 func TestConvertTargets(t *testing.T) {
 	targets := TargetBlock{{
-		Name:   "network_switch_1",
-		Target: "192.168.1.2",
-		Module: "if_mib",
-		Auth:   "public_v2",
+		Name:        "network_switch_1",
+		Target:      "192.168.1.2",
+		Module:      "if_mib",
+		Auth:        "public_v2",
+		SNMPContext: "testcontext",
 	}}
 
 	res := targets.Convert()
@@ -151,6 +154,7 @@ func TestConvertTargets(t *testing.T) {
 	require.Equal(t, "192.168.1.2", res[0].Target)
 	require.Equal(t, "if_mib", res[0].Module)
 	require.Equal(t, "public_v2", res[0].Auth)
+	require.Equal(t, "testcontext", res[0].SNMPContext)
 }
 
 func TestConvertTargetsList(t *testing.T) {

--- a/internal/converter/internal/staticconvert/internal/build/snmp_exporter.go
+++ b/internal/converter/internal/staticconvert/internal/build/snmp_exporter.go
@@ -24,6 +24,7 @@ func toSnmpExporter(config *snmp_exporter.Config) *snmp.Arguments {
 		target["module"] = t.Module
 		target["auth"] = t.Auth
 		target["walk_params"] = t.WalkParams
+		target["snmp_context"] = t.SNMPContext
 		targets = append(targets, target)
 	}
 
@@ -72,6 +73,7 @@ func toSnmpExporterV2(config *snmp_exporter_v2.Config) *snmp.Arguments {
 		target["module"] = t.Module
 		target["auth"] = t.Auth
 		target["walk_params"] = t.WalkParams
+		target["snmp_context"] = t.SNMPContext
 		targets = append(targets, target)
 	}
 

--- a/internal/converter/internal/staticconvert/testdata-v2/integrations_v2.alloy
+++ b/internal/converter/internal/staticconvert/testdata-v2/integrations_v2.alloy
@@ -715,15 +715,15 @@ prometheus.exporter.snmp "integrations_snmp" {
 		auth         = "public",
 		module       = "if_mib",
 		name         = "network_switch.1",
+		snmp_context = "dummyContext",
 		walk_params  = "public",
-		snmp_context = "dummyContext"
-		
 	}, {
-		address     = "192.168.1.3",
-		auth        = "private",
-		module      = "mikrotik",
-		name        = "network_router_2",
-		walk_params = "private",
+		address      = "192.168.1.3",
+		auth         = "private",
+		module       = "mikrotik",
+		name         = "network_router_2",
+		snmp_context = "dummyContext",
+		walk_params  = "private",
 	}]
 }
 

--- a/internal/converter/internal/staticconvert/testdata-v2/integrations_v2.alloy
+++ b/internal/converter/internal/staticconvert/testdata-v2/integrations_v2.alloy
@@ -711,11 +711,13 @@ prometheus.scrape "integrations_blackbox" {
 
 prometheus.exporter.snmp "integrations_snmp" {
 	targets = [{
-		address     = "192.168.1.2",
-		auth        = "public",
-		module      = "if_mib",
-		name        = "network_switch.1",
-		walk_params = "public",
+		address      = "192.168.1.2",
+		auth         = "public",
+		module       = "if_mib",
+		name         = "network_switch.1",
+		walk_params  = "public",
+		snmp_context = "dummyContext"
+		
 	}, {
 		address     = "192.168.1.3",
 		auth        = "private",

--- a/internal/converter/internal/staticconvert/testdata-v2/integrations_v2.yaml
+++ b/internal/converter/internal/staticconvert/testdata-v2/integrations_v2.yaml
@@ -209,6 +209,7 @@ integrations:
         module: if_mib
         walk_params: public
         auth: public
+        snmp_context: dummyContext
       - name: network_router_2
         address: 192.168.1.3
         module: mikrotik

--- a/internal/converter/internal/staticconvert/testdata-v2/integrations_v2.yaml
+++ b/internal/converter/internal/staticconvert/testdata-v2/integrations_v2.yaml
@@ -215,6 +215,7 @@ integrations:
         module: mikrotik
         walk_params: private
         auth: private
+        snmp_context: dummyContext
   snowflake_configs:
     - account_name: XXXXXXX-YYYYYYY
       username: snowflake-user

--- a/internal/converter/internal/staticconvert/testdata/integrations.alloy
+++ b/internal/converter/internal/staticconvert/testdata/integrations.alloy
@@ -94,14 +94,15 @@ prometheus.exporter.snmp "integrations_snmp" {
 		auth         = "public",
 		module       = "if_mib",
 		name         = "network_switch.1",
+		snmp_context = "dummyContext",
 		walk_params  = "public",
-		snmp_context = "dummyContext"
 	}, {
-		address     = "192.168.1.3",
-		auth        = "private",
-		module      = "mikrotik",
-		name        = "network_router_2",
-		walk_params = "private",
+		address      = "192.168.1.3",
+		auth         = "private",
+		module       = "mikrotik",
+		name         = "network_router_2",
+		snmp_context = "dummyContext",
+		walk_params  = "private",
 	}]
 }
 

--- a/internal/converter/internal/staticconvert/testdata/integrations.alloy
+++ b/internal/converter/internal/staticconvert/testdata/integrations.alloy
@@ -90,11 +90,12 @@ prometheus.scrape "integrations_blackbox" {
 
 prometheus.exporter.snmp "integrations_snmp" {
 	targets = [{
-		address     = "192.168.1.2",
-		auth        = "public",
-		module      = "if_mib",
-		name        = "network_switch.1",
-		walk_params = "public",
+		address      = "192.168.1.2",
+		auth         = "public",
+		module       = "if_mib",
+		name         = "network_switch.1",
+		walk_params  = "public",
+		snmp_context = "dummyContext"
 	}, {
 		address     = "192.168.1.3",
 		auth        = "private",

--- a/internal/converter/internal/staticconvert/testdata/integrations.yaml
+++ b/internal/converter/internal/staticconvert/testdata/integrations.yaml
@@ -176,6 +176,7 @@ integrations:
         module: if_mib
         walk_params: public
         auth: public
+        snmp_context: dummyContext
       - name: network_router_2
         address: 192.168.1.3
         module: mikrotik

--- a/internal/converter/internal/staticconvert/testdata/integrations.yaml
+++ b/internal/converter/internal/staticconvert/testdata/integrations.yaml
@@ -182,6 +182,7 @@ integrations:
         module: mikrotik
         walk_params: private
         auth: private
+        snmp_context: dummyContext
   snowflake:
     enabled: true
     account_name: XXXXXXX-YYYYYYY

--- a/internal/static/integrations/snmp_exporter/snmp_exporter.go
+++ b/internal/static/integrations/snmp_exporter/snmp_exporter.go
@@ -27,11 +27,12 @@ var DefaultConfig = Config{
 
 // SNMPTarget defines a target device to be used by the integration.
 type SNMPTarget struct {
-	Name       string `yaml:"name"`
-	Target     string `yaml:"address"`
-	Module     string `yaml:"module"`
-	Auth       string `yaml:"auth"`
-	WalkParams string `yaml:"walk_params,omitempty"`
+	Name        string `yaml:"name"`
+	Target      string `yaml:"address"`
+	Module      string `yaml:"module"`
+	Auth        string `yaml:"auth"`
+	WalkParams  string `yaml:"walk_params,omitempty"`
+	SNMPContext string `yaml:"snmp_context,omitempty"`
 }
 
 // Config configures the SNMP integration.
@@ -198,6 +199,9 @@ func (i *Integration) ScrapeConfigs() []config.ScrapeConfig {
 		}
 		if target.WalkParams != "" {
 			queryParams.Add("walk_params", target.WalkParams)
+		}
+		if target.SNMPContext != "" {
+			queryParams.Add("snmp_context", target.SNMPContext)
 		}
 		res = append(res, config.ScrapeConfig{
 			JobName:     i.sh.cfg.Name() + "/" + target.Name,

--- a/internal/static/integrations/v2/snmp_exporter/snmp.go
+++ b/internal/static/integrations/v2/snmp_exporter/snmp.go
@@ -68,6 +68,12 @@ func (sh *snmpHandler) Targets(ep integrations.Endpoint) []*targetgroup.Group {
 			})
 		}
 
+		if t.SNMPContext != "" {
+			labelSet = labelSet.Merge(model.LabelSet{
+				"__param_snmp_context": model.LabelValue(t.SNMPContext),
+			})
+		}
+
 		if t.Auth != "" {
 			labelSet = labelSet.Merge(model.LabelSet{
 				"__param_auth": model.LabelValue(t.Auth),


### PR DESCRIPTION
#### PR Description

Adding a `snmp_context` config argument which was added in the [upstream repo](https://github.com/prometheus/snmp_exporter/pull/1163) and [in Agent](https://github.com/grafana/agent/pull/6923) a few weeks ago.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated
