### PR TITLE
[mimir.rules.kubernetes] Fix flaky test

### DIFF
--- a/internal/component/mimir/rules/kubernetes/rules_test.go
+++ b/internal/component/mimir/rules/kubernetes/rules_test.go
@@ -162,12 +162,18 @@ func TestIterationHandlesUpdate(t *testing.T) {
 		newArgs := Arguments{Address: "http://localhost:8080/"}
 		newArgs.SetToDefault()
 
+		var wg sync.WaitGroup
+		wg.Add(1)
+
 		c := newComponentForTesting(t, reg, logger)
 		go func() {
+			defer wg.Done()
 			require.NoError(t, c.iteration(context.Background(), leader, state, health))
 		}()
 
 		require.NoError(t, c.Update(newArgs))
+		wg.Wait()
+
 		require.Error(t, health.getErr())
 		require.True(t, state.restartCalled.Load())
 	})
@@ -183,12 +189,18 @@ func TestIterationHandlesUpdate(t *testing.T) {
 		newArgs := Arguments{Address: "http://localhost:8080/"}
 		newArgs.SetToDefault()
 
+		var wg sync.WaitGroup
+		wg.Add(1)
+
 		c := newComponentForTesting(t, reg, logger)
 		go func() {
+			defer wg.Done()
 			require.NoError(t, c.iteration(context.Background(), leader, state, health))
 		}()
 
 		require.NoError(t, c.Update(newArgs))
+		wg.Wait()
+
 		require.NoError(t, health.getErr())
 		require.True(t, state.restartCalled.Load())
 	})


### PR DESCRIPTION
The CI [failed](https://drone.grafana.net/grafana/alloy/1507) on one of my unrelated PRs, so I thought I'd fix it.

This was the error:
```
--- FAIL: TestIterationHandlesUpdate (0.00s)
    --- FAIL: TestIterationHandlesUpdate/error_during_restart (0.00s)
        rules_test.go:171: 
            	Error Trace:	/drone/src/internal/component/mimir/rules/kubernetes/rules_test.go:171
            	Error:      	An error is expected but got nil.
            	Test:       	TestIterationHandlesUpdate/error_during_restart
FAIL
FAIL	github.com/grafana/alloy/internal/component/mimir/rules/kubernetes	0.174s
```