### PR TITLE
Add live debugging support to all otel processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Main (unreleased)
 
 - Add the `targets` argument to the `prometheus.exporter.blackbox` component to support passing blackbox targets at runtime. (@wildum)
 
+- Added live debugging support to `otelcol.processor.*` components. (@wildum)
+
 ### Bugfixes
 
 - Fixed an issue with `loki.source.kubernetes_events` not starting in large clusters due to short informer sync timeout. (@nrwiersma)

--- a/docs/sources/troubleshoot/debug.md
+++ b/docs/sources/troubleshoot/debug.md
@@ -105,6 +105,7 @@ Live debugging is not yet available in all components.
 
 Supported components:
 * prometheus.relabel
+* otelcol.processor.*
 {{< /admonition >}}
 
 

--- a/docs/sources/troubleshoot/debug.md
+++ b/docs/sources/troubleshoot/debug.md
@@ -104,8 +104,8 @@ The format and content of the debugging data vary depending on the component typ
 Live debugging is not yet available in all components.
 
 Supported components:
-* prometheus.relabel
-* otelcol.processor.*
+* `prometheus.relabel`
+* `otelcol.processor.*`
 {{< /admonition >}}
 
 

--- a/internal/component/component.go
+++ b/internal/component/component.go
@@ -114,8 +114,8 @@ type DebugComponent interface {
 	DebugInfo() interface{}
 }
 
-// LiveDebugging is an interface marker used by the components that support the live debugging feature.
+// LiveDebugging is an interface used by the components that support the live debugging feature.
 type LiveDebugging interface {
-	// LiveDebugging marks the component for live debugging support. It is never invoked.
-	LiveDebugging()
+	// LiveDebugging is invoked when the number of consumers changes.
+	LiveDebugging(consumers int)
 }

--- a/internal/component/otelcol/internal/livedebuggingconsumer/databuffer.go
+++ b/internal/component/otelcol/internal/livedebuggingconsumer/databuffer.go
@@ -1,0 +1,287 @@
+// Copy from the OTLP text in the Opentelemetry collector
+
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package livedebuggingconsumer
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"strings"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+type dataBuffer struct {
+	buf bytes.Buffer
+}
+
+func (b *dataBuffer) logEntry(format string, a ...any) {
+	b.buf.WriteString(fmt.Sprintf(format, a...))
+	b.buf.WriteString("\n")
+}
+
+func (b *dataBuffer) logAttr(attr string, value any) {
+	b.logEntry("    %-15s: %s", attr, value)
+}
+
+func (b *dataBuffer) logAttributes(header string, m pcommon.Map) {
+	if m.Len() == 0 {
+		return
+	}
+
+	b.logEntry("%s:", header)
+	attrPrefix := "     ->"
+
+	// Add offset to attributes if needed.
+	headerParts := strings.Split(header, "->")
+	if len(headerParts) > 1 {
+		attrPrefix = headerParts[0] + attrPrefix
+	}
+
+	m.Range(func(k string, v pcommon.Value) bool {
+		b.logEntry("%s %s: %s", attrPrefix, k, valueToString(v))
+		return true
+	})
+}
+
+func (b *dataBuffer) logInstrumentationScope(il pcommon.InstrumentationScope) {
+	b.logEntry(
+		"InstrumentationScope %s %s",
+		il.Name(),
+		il.Version())
+	b.logAttributes("InstrumentationScope attributes", il.Attributes())
+}
+
+func (b *dataBuffer) logMetricDescriptor(md pmetric.Metric) {
+	b.logEntry("Descriptor:")
+	b.logEntry("     -> Name: %s", md.Name())
+	b.logEntry("     -> Description: %s", md.Description())
+	b.logEntry("     -> Unit: %s", md.Unit())
+	b.logEntry("     -> DataType: %s", md.Type().String())
+}
+
+func (b *dataBuffer) logMetricDataPoints(m pmetric.Metric) {
+	switch m.Type() {
+	case pmetric.MetricTypeEmpty:
+		return
+	case pmetric.MetricTypeGauge:
+		b.logNumberDataPoints(m.Gauge().DataPoints())
+	case pmetric.MetricTypeSum:
+		data := m.Sum()
+		b.logEntry("     -> IsMonotonic: %t", data.IsMonotonic())
+		b.logEntry("     -> AggregationTemporality: %s", data.AggregationTemporality().String())
+		b.logNumberDataPoints(data.DataPoints())
+	case pmetric.MetricTypeHistogram:
+		data := m.Histogram()
+		b.logEntry("     -> AggregationTemporality: %s", data.AggregationTemporality().String())
+		b.logHistogramDataPoints(data.DataPoints())
+	case pmetric.MetricTypeExponentialHistogram:
+		data := m.ExponentialHistogram()
+		b.logEntry("     -> AggregationTemporality: %s", data.AggregationTemporality().String())
+		b.logExponentialHistogramDataPoints(data.DataPoints())
+	case pmetric.MetricTypeSummary:
+		data := m.Summary()
+		b.logDoubleSummaryDataPoints(data.DataPoints())
+	}
+}
+
+func (b *dataBuffer) logNumberDataPoints(ps pmetric.NumberDataPointSlice) {
+	for i := 0; i < ps.Len(); i++ {
+		p := ps.At(i)
+		b.logEntry("NumberDataPoints #%d", i)
+		b.logDataPointAttributes(p.Attributes())
+
+		b.logEntry("StartTimestamp: %s", p.StartTimestamp())
+		b.logEntry("Timestamp: %s", p.Timestamp())
+		switch p.ValueType() {
+		case pmetric.NumberDataPointValueTypeInt:
+			b.logEntry("Value: %d", p.IntValue())
+		case pmetric.NumberDataPointValueTypeDouble:
+			b.logEntry("Value: %f", p.DoubleValue())
+		}
+
+		b.logExemplars("Exemplars", p.Exemplars())
+	}
+}
+
+func (b *dataBuffer) logHistogramDataPoints(ps pmetric.HistogramDataPointSlice) {
+	for i := 0; i < ps.Len(); i++ {
+		p := ps.At(i)
+		b.logEntry("HistogramDataPoints #%d", i)
+		b.logDataPointAttributes(p.Attributes())
+
+		b.logEntry("StartTimestamp: %s", p.StartTimestamp())
+		b.logEntry("Timestamp: %s", p.Timestamp())
+		b.logEntry("Count: %d", p.Count())
+
+		if p.HasSum() {
+			b.logEntry("Sum: %f", p.Sum())
+		}
+
+		if p.HasMin() {
+			b.logEntry("Min: %f", p.Min())
+		}
+
+		if p.HasMax() {
+			b.logEntry("Max: %f", p.Max())
+		}
+
+		for i := 0; i < p.ExplicitBounds().Len(); i++ {
+			b.logEntry("ExplicitBounds #%d: %f", i, p.ExplicitBounds().At(i))
+		}
+
+		for j := 0; j < p.BucketCounts().Len(); j++ {
+			b.logEntry("Buckets #%d, Count: %d", j, p.BucketCounts().At(j))
+		}
+
+		b.logExemplars("Exemplars", p.Exemplars())
+	}
+}
+
+func (b *dataBuffer) logExponentialHistogramDataPoints(ps pmetric.ExponentialHistogramDataPointSlice) {
+	for i := 0; i < ps.Len(); i++ {
+		p := ps.At(i)
+		b.logEntry("ExponentialHistogramDataPoints #%d", i)
+		b.logDataPointAttributes(p.Attributes())
+
+		b.logEntry("StartTimestamp: %s", p.StartTimestamp())
+		b.logEntry("Timestamp: %s", p.Timestamp())
+		b.logEntry("Count: %d", p.Count())
+
+		if p.HasSum() {
+			b.logEntry("Sum: %f", p.Sum())
+		}
+
+		if p.HasMin() {
+			b.logEntry("Min: %f", p.Min())
+		}
+
+		if p.HasMax() {
+			b.logEntry("Max: %f", p.Max())
+		}
+
+		scale := int(p.Scale())
+		factor := math.Ldexp(math.Ln2, -scale)
+		// Note: the equation used here, which is
+		//   math.Exp(index * factor)
+		// reports +Inf as the _lower_ boundary of the bucket nearest
+		// infinity, which is incorrect and can be addressed in various
+		// ways.  The OTel-Go implementation of this histogram pending
+		// in https://github.com/open-telemetry/opentelemetry-go/pull/2393
+		// uses a lookup table for the last finite boundary, which can be
+		// easily computed using `math/big` (for scales up to 20).
+
+		negB := p.Negative().BucketCounts()
+		posB := p.Positive().BucketCounts()
+
+		for i := 0; i < negB.Len(); i++ {
+			pos := negB.Len() - i - 1
+			index := p.Negative().Offset() + int32(pos)
+			lower := math.Exp(float64(index) * factor)
+			upper := math.Exp(float64(index+1) * factor)
+			b.logEntry("Bucket [%f, %f), Count: %d", -upper, -lower, negB.At(pos))
+		}
+
+		if p.ZeroCount() != 0 {
+			b.logEntry("Bucket [0, 0], Count: %d", p.ZeroCount())
+		}
+
+		for pos := 0; pos < posB.Len(); pos++ {
+			index := p.Positive().Offset() + int32(pos)
+			lower := math.Exp(float64(index) * factor)
+			upper := math.Exp(float64(index+1) * factor)
+			b.logEntry("Bucket (%f, %f], Count: %d", lower, upper, posB.At(pos))
+		}
+
+		b.logExemplars("Exemplars", p.Exemplars())
+	}
+}
+
+func (b *dataBuffer) logDoubleSummaryDataPoints(ps pmetric.SummaryDataPointSlice) {
+	for i := 0; i < ps.Len(); i++ {
+		p := ps.At(i)
+		b.logEntry("SummaryDataPoints #%d", i)
+		b.logDataPointAttributes(p.Attributes())
+
+		b.logEntry("StartTimestamp: %s", p.StartTimestamp())
+		b.logEntry("Timestamp: %s", p.Timestamp())
+		b.logEntry("Count: %d", p.Count())
+		b.logEntry("Sum: %f", p.Sum())
+
+		quantiles := p.QuantileValues()
+		for i := 0; i < quantiles.Len(); i++ {
+			quantile := quantiles.At(i)
+			b.logEntry("QuantileValue #%d: Quantile %f, Value %f", i, quantile.Quantile(), quantile.Value())
+		}
+	}
+}
+
+func (b *dataBuffer) logDataPointAttributes(attributes pcommon.Map) {
+	b.logAttributes("Data point attributes", attributes)
+}
+
+func (b *dataBuffer) logEvents(description string, se ptrace.SpanEventSlice) {
+	if se.Len() == 0 {
+		return
+	}
+
+	b.logEntry("%s:", description)
+	for i := 0; i < se.Len(); i++ {
+		e := se.At(i)
+		b.logEntry("SpanEvent #%d", i)
+		b.logEntry("     -> Name: %s", e.Name())
+		b.logEntry("     -> Timestamp: %s", e.Timestamp())
+		b.logEntry("     -> DroppedAttributesCount: %d", e.DroppedAttributesCount())
+		b.logAttributes("     -> Attributes:", e.Attributes())
+	}
+}
+
+func (b *dataBuffer) logLinks(description string, sl ptrace.SpanLinkSlice) {
+	if sl.Len() == 0 {
+		return
+	}
+
+	b.logEntry("%s:", description)
+
+	for i := 0; i < sl.Len(); i++ {
+		l := sl.At(i)
+		b.logEntry("SpanLink #%d", i)
+		b.logEntry("     -> Trace ID: %s", l.TraceID())
+		b.logEntry("     -> ID: %s", l.SpanID())
+		b.logEntry("     -> TraceState: %s", l.TraceState().AsRaw())
+		b.logEntry("     -> DroppedAttributesCount: %d", l.DroppedAttributesCount())
+		b.logAttributes("     -> Attributes:", l.Attributes())
+	}
+}
+
+func (b *dataBuffer) logExemplars(description string, se pmetric.ExemplarSlice) {
+	if se.Len() == 0 {
+		return
+	}
+
+	b.logEntry("%s:", description)
+
+	for i := 0; i < se.Len(); i++ {
+		e := se.At(i)
+		b.logEntry("Exemplar #%d", i)
+		b.logEntry("     -> Trace ID: %s", e.TraceID())
+		b.logEntry("     -> Span ID: %s", e.SpanID())
+		b.logEntry("     -> Timestamp: %s", e.Timestamp())
+		switch e.ValueType() {
+		case pmetric.ExemplarValueTypeInt:
+			b.logEntry("     -> Value: %d", e.IntValue())
+		case pmetric.ExemplarValueTypeDouble:
+			b.logEntry("     -> Value: %f", e.DoubleValue())
+		}
+		b.logAttributes("     -> FilteredAttributes", e.FilteredAttributes())
+	}
+}
+
+func valueToString(v pcommon.Value) string {
+	return fmt.Sprintf("%s(%s)", v.Type().String(), v.AsString())
+}

--- a/internal/component/otelcol/internal/livedebuggingconsumer/livedebuggingconsumer.go
+++ b/internal/component/otelcol/internal/livedebuggingconsumer/livedebuggingconsumer.go
@@ -1,0 +1,67 @@
+// Package livedebuggingconsumer implements an OpenTelemetry Collector consumer
+// which can be used to send live debugging data to Alloy UI.
+package livedebuggingconsumer
+
+import (
+	"context"
+
+	"github.com/grafana/alloy/internal/component/otelcol"
+	"github.com/grafana/alloy/internal/service/livedebugging"
+	otelconsumer "go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+type Consumer struct {
+	debugDataPublisher livedebugging.DebugDataPublisher
+	componentID        livedebugging.ComponentID
+	logsMarshaler      plog.Marshaler
+	metricsMarshaler   pmetric.Marshaler
+	tracesMarshaler    ptrace.Marshaler
+}
+
+var _ otelcol.Consumer = (*Consumer)(nil)
+
+func New(debugDataPublisher livedebugging.DebugDataPublisher, componentID string) *Consumer {
+	return &Consumer{
+		debugDataPublisher: debugDataPublisher,
+		componentID:        livedebugging.ComponentID(componentID),
+		logsMarshaler:      NewTextLogsMarshaler(),
+		metricsMarshaler:   NewTextMetricsMarshaler(),
+		tracesMarshaler:    NewTextTracesMarshaler(),
+	}
+}
+
+// Capabilities implements otelcol.Consumer.
+func (c *Consumer) Capabilities() otelconsumer.Capabilities {
+	// streaming data should not modify the value
+	return otelconsumer.Capabilities{MutatesData: false}
+}
+
+// ConsumeTraces implements otelcol.ConsumeTraces.
+func (c *Consumer) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
+	if c.debugDataPublisher.IsActive(c.componentID) {
+		data, _ := c.tracesMarshaler.MarshalTraces(td)
+		c.debugDataPublisher.Publish(c.componentID, string(data))
+	}
+	return nil
+}
+
+// ConsumeMetrics implements otelcol.ConsumeMetrics.
+func (c *Consumer) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+	if c.debugDataPublisher.IsActive(c.componentID) {
+		data, _ := c.metricsMarshaler.MarshalMetrics(md)
+		c.debugDataPublisher.Publish(c.componentID, string(data))
+	}
+	return nil
+}
+
+// ConsumeLogs implements otelcol.ConsumeLogs.
+func (c *Consumer) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
+	if c.debugDataPublisher.IsActive(c.componentID) {
+		data, _ := c.logsMarshaler.MarshalLogs(ld)
+		c.debugDataPublisher.Publish(c.componentID, string(data))
+	}
+	return nil
+}

--- a/internal/component/otelcol/internal/livedebuggingconsumer/logs.go
+++ b/internal/component/otelcol/internal/livedebuggingconsumer/logs.go
@@ -1,0 +1,53 @@
+// Copy from the OTLP text in the Opentelemetry collector
+
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package livedebuggingconsumer
+
+import (
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+// NewTextLogsMarshaler returns a plog.Marshaler to encode to OTLP text bytes.
+func NewTextLogsMarshaler() plog.Marshaler {
+	return textLogsMarshaler{}
+}
+
+type textLogsMarshaler struct{}
+
+// MarshalLogs plog.Logs to OTLP text.
+func (textLogsMarshaler) MarshalLogs(ld plog.Logs) ([]byte, error) {
+	buf := dataBuffer{}
+	rls := ld.ResourceLogs()
+	for i := 0; i < rls.Len(); i++ {
+		buf.logEntry("ResourceLog #%d", i)
+		rl := rls.At(i)
+		buf.logEntry("Resource SchemaURL: %s", rl.SchemaUrl())
+		buf.logAttributes("Resource attributes", rl.Resource().Attributes())
+		ills := rl.ScopeLogs()
+		for j := 0; j < ills.Len(); j++ {
+			buf.logEntry("ScopeLogs #%d", j)
+			ils := ills.At(j)
+			buf.logEntry("ScopeLogs SchemaURL: %s", ils.SchemaUrl())
+			buf.logInstrumentationScope(ils.Scope())
+
+			logs := ils.LogRecords()
+			for k := 0; k < logs.Len(); k++ {
+				buf.logEntry("LogRecord #%d", k)
+				lr := logs.At(k)
+				buf.logEntry("ObservedTimestamp: %s", lr.ObservedTimestamp())
+				buf.logEntry("Timestamp: %s", lr.Timestamp())
+				buf.logEntry("SeverityText: %s", lr.SeverityText())
+				buf.logEntry("SeverityNumber: %s(%d)", lr.SeverityNumber(), lr.SeverityNumber())
+				buf.logEntry("Body: %s", valueToString(lr.Body()))
+				buf.logAttributes("Attributes", lr.Attributes())
+				buf.logEntry("Trace ID: %s", lr.TraceID())
+				buf.logEntry("Span ID: %s", lr.SpanID())
+				buf.logEntry("Flags: %d", lr.Flags())
+			}
+		}
+	}
+
+	return buf.buf.Bytes(), nil
+}

--- a/internal/component/otelcol/internal/livedebuggingconsumer/metrics.go
+++ b/internal/component/otelcol/internal/livedebuggingconsumer/metrics.go
@@ -1,0 +1,43 @@
+// Copy from the OTLP text in the Opentelemetry collector
+
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package livedebuggingconsumer
+
+import "go.opentelemetry.io/collector/pdata/pmetric"
+
+// NewTextMetricsMarshaler returns a pmetric.Marshaler to encode to OTLP text bytes.
+func NewTextMetricsMarshaler() pmetric.Marshaler {
+	return textMetricsMarshaler{}
+}
+
+type textMetricsMarshaler struct{}
+
+// MarshalMetrics pmetric.Metrics to OTLP text.
+func (textMetricsMarshaler) MarshalMetrics(md pmetric.Metrics) ([]byte, error) {
+	buf := dataBuffer{}
+	rms := md.ResourceMetrics()
+	for i := 0; i < rms.Len(); i++ {
+		buf.logEntry("ResourceMetrics #%d", i)
+		rm := rms.At(i)
+		buf.logEntry("Resource SchemaURL: %s", rm.SchemaUrl())
+		buf.logAttributes("Resource attributes", rm.Resource().Attributes())
+		ilms := rm.ScopeMetrics()
+		for j := 0; j < ilms.Len(); j++ {
+			buf.logEntry("ScopeMetrics #%d", j)
+			ilm := ilms.At(j)
+			buf.logEntry("ScopeMetrics SchemaURL: %s", ilm.SchemaUrl())
+			buf.logInstrumentationScope(ilm.Scope())
+			metrics := ilm.Metrics()
+			for k := 0; k < metrics.Len(); k++ {
+				buf.logEntry("Metric #%d", k)
+				metric := metrics.At(k)
+				buf.logMetricDescriptor(metric)
+				buf.logMetricDataPoints(metric)
+			}
+		}
+	}
+
+	return buf.buf.Bytes(), nil
+}

--- a/internal/component/otelcol/internal/livedebuggingconsumer/traces.go
+++ b/internal/component/otelcol/internal/livedebuggingconsumer/traces.go
@@ -1,0 +1,58 @@
+// Copy from the OTLP text in the Opentelemetry collector
+
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package livedebuggingconsumer
+
+import (
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+// NewTextTracesMarshaler returns a ptrace.Marshaler to encode to OTLP text bytes.
+func NewTextTracesMarshaler() ptrace.Marshaler {
+	return textTracesMarshaler{}
+}
+
+type textTracesMarshaler struct{}
+
+// MarshalTraces ptrace.Traces to OTLP text.
+func (textTracesMarshaler) MarshalTraces(td ptrace.Traces) ([]byte, error) {
+	buf := dataBuffer{}
+	rss := td.ResourceSpans()
+	for i := 0; i < rss.Len(); i++ {
+		buf.logEntry("ResourceSpans #%d", i)
+		rs := rss.At(i)
+		buf.logEntry("Resource SchemaURL: %s", rs.SchemaUrl())
+		buf.logAttributes("Resource attributes", rs.Resource().Attributes())
+		ilss := rs.ScopeSpans()
+		for j := 0; j < ilss.Len(); j++ {
+			buf.logEntry("ScopeSpans #%d", j)
+			ils := ilss.At(j)
+			buf.logEntry("ScopeSpans SchemaURL: %s", ils.SchemaUrl())
+			buf.logInstrumentationScope(ils.Scope())
+
+			spans := ils.Spans()
+			for k := 0; k < spans.Len(); k++ {
+				buf.logEntry("Span #%d", k)
+				span := spans.At(k)
+				buf.logAttr("Trace ID", span.TraceID())
+				buf.logAttr("Parent ID", span.ParentSpanID())
+				buf.logAttr("ID", span.SpanID())
+				buf.logAttr("Name", span.Name())
+				buf.logAttr("Kind", span.Kind().String())
+				buf.logAttr("Start time", span.StartTimestamp().String())
+				buf.logAttr("End time", span.EndTimestamp().String())
+
+				buf.logAttr("Status code", span.Status().Code().String())
+				buf.logAttr("Status message", span.Status().Message())
+
+				buf.logAttributes("Attributes", span.Attributes())
+				buf.logEvents("Events", span.Events())
+				buf.logLinks("Links", span.Links())
+			}
+		}
+	}
+
+	return buf.buf.Bytes(), nil
+}

--- a/internal/component/prometheus/relabel/relabel.go
+++ b/internal/component/prometheus/relabel/relabel.go
@@ -318,7 +318,7 @@ func (c *Component) addToCache(originalID uint64, lbls labels.Labels, keep bool)
 	})
 }
 
-func (c *Component) LiveDebugging() {}
+func (c *Component) LiveDebugging(_ int) {}
 
 // labelAndID stores both the globalrefid for the label and the id itself. We store the id so that it doesn't have
 // to be recalculated again.


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #1030 

#### Notes to the Reviewer

I created a new consumer that is injected into every otel processors.

When a stream is open, it will format the consumed telemetry using the OTLP text formatting and send it to the live debugging service.
Else it does nothing.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
