### PR TITLE
loki.rules.kubernetes: Add support for clustered mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,10 @@ Main (unreleased)
 
 - Added support for NS records to `discovery.dns`. (@djcode)
 
+- In `loki.rules.kubernetes`, add support for running in a cluster of Alloy instances
+  by electing a single instance as the leader for the `loki.rules.kubernetes` component
+  to avoid conflicts when making calls to the Loki API. (@toontijtgat2)
+
 ### Bugfixes
 
 - Fixed an issue with `prometheus.scrape` in which targets that move from one

--- a/internal/component/loki/rules/kubernetes/rules.go
+++ b/internal/component/loki/rules/kubernetes/rules.go
@@ -2,8 +2,10 @@ package rules
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -11,6 +13,8 @@ import (
 	commonK8s "github.com/grafana/alloy/internal/component/common/kubernetes"
 	"github.com/grafana/alloy/internal/featuregate"
 	lokiClient "github.com/grafana/alloy/internal/loki/client"
+	"github.com/grafana/alloy/internal/service/cluster"
+	"github.com/grafana/ckit/shard"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
 	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/instrument"
@@ -28,6 +32,15 @@ import (
 
 	promExternalVersions "github.com/prometheus-operator/prometheus-operator/pkg/client/informers/externalversions"
 	promVersioned "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
+)
+
+const (
+	configurationUpdate = "configuration-update"
+	clusterUpdate       = "cluster-update"
+)
+
+var (
+	errShutdown = errors.New("component is shutting down")
 )
 
 func init() {
@@ -66,6 +79,9 @@ type Component struct {
 
 	currentState commonK8s.RuleGroupsByNamespace
 
+	leader         leadership
+	clusterUpdates chan struct{}
+
 	metrics   *metrics
 	healthMut sync.RWMutex
 	health    component.Health
@@ -73,6 +89,7 @@ type Component struct {
 
 type metrics struct {
 	configUpdatesTotal prometheus.Counter
+	clusterUpdatesTotal prometheus.Counter
 
 	eventsTotal   *prometheus.CounterVec
 	eventsFailed  *prometheus.CounterVec
@@ -81,23 +98,17 @@ type metrics struct {
 	lokiClientTiming *prometheus.HistogramVec
 }
 
-func (m *metrics) Register(r prometheus.Registerer) error {
-	r.MustRegister(
-		m.configUpdatesTotal,
-		m.eventsTotal,
-		m.eventsFailed,
-		m.eventsRetried,
-		m.lokiClientTiming,
-	)
-	return nil
-}
-
 func newMetrics() *metrics {
 	return &metrics{
 		configUpdatesTotal: prometheus.NewCounter(prometheus.CounterOpts{
 			Subsystem: "loki_rules",
 			Name:      "config_updates_total",
 			Help:      "Total number of times the configuration has been updated.",
+		}),
+		clusterUpdatesTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Subsystem: "mimir_rules",
+			Name:      "cluster_updates_total",
+			Help:      "Total number of times the cluster has changed.",
 		}),
 		eventsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Subsystem: "loki_rules",
@@ -123,29 +134,37 @@ func newMetrics() *metrics {
 	}
 }
 
+func (m *metrics) register(r prometheus.Registerer) error {
+	for _, c := range []prometheus.Collector{
+		m.configUpdatesTotal,
+		m.clusterUpdatesTotal,
+		m.eventsTotal,
+		m.eventsFailed,
+		m.eventsRetried,
+		m.mimirClientTiming,
+	} {
+		if err := r.Register(c); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 type ConfigUpdate struct {
 	args Arguments
-	err  chan error
 }
 
 var _ component.Component = (*Component)(nil)
 var _ component.DebugComponent = (*Component)(nil)
 var _ component.HealthComponent = (*Component)(nil)
+var _ cluster.Component = (*Component)(nil)
 
-func NewComponent(o component.Options, args Arguments) (*Component, error) {
-	metrics := newMetrics()
-	err := metrics.Register(o.Registerer)
+// New creates a new Component and initializes required clients based on the provided configuration.
+func New(o component.Options, args Arguments) (*Component, error) {
+	c, err := newNoInit(o, args)
 	if err != nil {
-		return nil, fmt.Errorf("registering metrics failed: %w", err)
-	}
-
-	c := &Component{
-		log:           o.Logger,
-		opts:          o,
-		args:          args,
-		configUpdates: make(chan ConfigUpdate),
-		ticker:        time.NewTicker(args.SyncInterval),
-		metrics:       metrics,
+		return nil, err
 	}
 
 	err = c.init()
@@ -156,7 +175,67 @@ func NewComponent(o component.Options, args Arguments) (*Component, error) {
 	return c, nil
 }
 
+func newNoInit(o component.Options, args Arguments) (*Component, error) {
+	m := newMetrics()
+	if err := m.register(o.Registerer); err != nil {
+		return nil, fmt.Errorf("registering metrics failed: %w", err)
+	}
+
+	clusterSvc, err := o.GetServiceData(cluster.ServiceName)
+	if err != nil {
+		return nil, fmt.Errorf("getting cluster service failed: %w", err)
+	}
+
+	c := &Component{
+		log:            o.Logger,
+		opts:           o,
+		args:           args,
+		leader:         newComponentLeadership(o.ID, o.Logger, clusterSvc.(cluster.Cluster)),
+		configUpdates:  make(chan ConfigUpdate),
+		clusterUpdates: make(chan struct{}, 1),
+		ticker:         time.NewTicker(args.SyncInterval),
+		metrics:        m,
+	}
+
+	return c, nil
+}
+
 func (c *Component) Run(ctx context.Context) error {
+	c.startupWithRetries(ctx, c.leader, c, c)
+
+	for {
+		// iteration only returns a sentinel error to indicate shutdown, otherwise it handles
+		// any errors encountered itself by logging and marking the component as unhealthy.
+		err := c.iteration(ctx, c.leader, c, c)
+		if errors.Is(err, errShutdown) {
+			break
+		} else if err != nil {
+			level.Error(c.log).Log("msg", "unexpected error from iteration loop; this is a bug", "err", err)
+			c.reportUnhealthy(err)
+		}
+	}
+
+	return nil
+}
+
+func (c *Component) Update(newConfig component.Arguments) error {
+	c.configUpdates <- ConfigUpdate{
+		args: newConfig.(Arguments),
+	}
+	return nil
+}
+
+func (c *Component) NotifyClusterChange() {
+	// NOTE that we use cluster updates and ownership of a particular key to implement our
+	// own leadership election. Once per-component scheduling is introduced to Alloy, this
+	// leadership election logic should be removed in favor of per-component scheduling.
+	select {
+	case c.clusterUpdates <- struct{}{}:
+	default: // update already scheduled
+	}
+}
+
+func (c *Component) startupWithRetries(ctx context.Context, leader leadership, state lifecycle, health healthReporter) {
 	startupBackoff := backoff.New(
 		ctx,
 		backoff.Config{
@@ -166,52 +245,77 @@ func (c *Component) Run(ctx context.Context) error {
 		},
 	)
 	for {
-		if err := c.startup(ctx); err != nil {
-			level.Error(c.log).Log("msg", "starting up component failed", "err", err)
-			c.reportUnhealthy(err)
+		// Repeatedly check if we are the leader and attempt to start the component
+		_, err := leader.update()
+		if err != nil {
+			level.Error(c.log).Log("msg", "checking leadership during starting failed, will retry", "err", err)
+			health.reportUnhealthy(err)
+		} else if err := state.startup(ctx); err != nil {
+			level.Error(c.log).Log("msg", "starting up component failed, will retry", "err", err)
+			health.reportUnhealthy(err)
 		} else {
 			break
 		}
 		startupBackoff.Wait()
 	}
-
-	for {
-		select {
-		case update := <-c.configUpdates:
-			c.metrics.configUpdatesTotal.Inc()
-			c.shutdown()
-
-			c.args = update.args
-			err := c.init()
-			if err != nil {
-				level.Error(c.log).Log("msg", "updating configuration failed", "err", err)
-				c.reportUnhealthy(err)
-				update.err <- err
-				continue
-			}
-
-			err = c.startup(ctx)
-			if err != nil {
-				level.Error(c.log).Log("msg", "updating configuration failed", "err", err)
-				c.reportUnhealthy(err)
-				update.err <- err
-				continue
-			}
-
-			update.err <- nil
-		case <-ctx.Done():
-			c.shutdown()
-			return nil
-		case <-c.ticker.C:
-			c.queue.Add(commonK8s.Event{
-				Typ: eventTypeSyncLoki,
-			})
-		}
-	}
 }
 
-// startup launches the informers and starts the event loop.
+func (c *Component) iteration(ctx context.Context, leader leadership, state lifecycle, health healthReporter) error {
+	select {
+	case update := <-c.configUpdates:
+		c.metrics.configUpdatesTotal.Inc()
+		state.update(update.args)
+
+		if err := state.restart(ctx); err != nil {
+			level.Error(c.log).Log("msg", "restarting component failed", "trigger", configurationUpdate, "err", err)
+			health.reportUnhealthy(err)
+		}
+	case <-c.clusterUpdates:
+		c.metrics.clusterUpdatesTotal.Inc()
+
+		changed, err := leader.update()
+		if err != nil {
+			level.Error(c.log).Log("msg", "checking leadership failed", "trigger", clusterUpdate, "err", err)
+			health.reportUnhealthy(err)
+		} else if changed {
+			if err := state.restart(ctx); err != nil {
+				level.Error(c.log).Log("msg", "restarting component failed", "trigger", clusterUpdate, "err", err)
+				health.reportUnhealthy(err)
+			}
+		}
+	case <-ctx.Done():
+		state.shutdown()
+		return errShutdown
+	}
+
+	return nil
+}
+
+// update updates the Arguments used to create new Kubernetes or Mimir clients
+// when restarting the component in response to configuration or cluster updates.
+func (c *Component) update(args Arguments) {
+	c.args = args
+}
+
+// restart stops any existing event processor and starts a new one. This method is
+// a shortcut for calling shutdown, init, and startup in sequence.
+func (c *Component) restart(ctx context.Context) error {
+	c.shutdown()
+	if err := c.init(); err != nil {
+		return err
+	}
+
+	return c.startup(ctx)
+}
+
+// startup launches the informers and starts the event loop if this instance is
+// the leader. If it is not the leader, startup does nothing.
 func (c *Component) startup(ctx context.Context) error {
+	if !c.leader.isLeader() {
+		level.Info(c.log).Log("msg", "skipping startup because we are not the leader")
+		return nil
+	}
+
 	cfg := workqueue.RateLimitingQueueConfig{Name: "loki.rules.kubernetes"}
 	c.queue = workqueue.NewRateLimitingQueueWithConfig(workqueue.DefaultControllerRateLimiter(), cfg)
 	c.informerStopChan = make(chan struct{})
@@ -229,18 +333,11 @@ func (c *Component) startup(ctx context.Context) error {
 	return nil
 }
 
+// shutdown stops processing new events and waits for currently queued ones to be
+// processed.
 func (c *Component) shutdown() {
 	close(c.informerStopChan)
 	c.queue.ShutDownWithDrain()
-}
-
-func (c *Component) Update(newConfig component.Arguments) error {
-	errChan := make(chan error)
-	c.configUpdates <- ConfigUpdate{
-		args: newConfig.(Arguments),
-		err:  errChan,
-	}
-	return <-errChan
 }
 
 func (c *Component) init() error {
@@ -331,4 +428,57 @@ func (c *Component) startRuleInformer() error {
 	factory.Start(c.informerStopChan)
 	factory.WaitForCacheSync(c.informerStopChan)
 	return nil
+}
+
+// healthReporter encapsulates the logic for marking a component as healthy or
+// not healthy to make testing portions of the Component easier.
+type healthReporter interface {
+	// reportUnhealthy marks the owning component as unhealthy
+	reportUnhealthy(err error)
+	// reportHealthy marks the owning component as healthy
+	reportHealthy()
+}
+
+// lifecycle encapsulates state transitions and mutable state to make testing
+// portions of the Component easier.
+type lifecycle interface {
+	// update updates the Arguments used for configuring the Component.
+	update(args Arguments)
+
+	// startup starts processing events from Kubernetes object changes.
+	startup(ctx context.Context) error
+
+	// restart stops the component if running and then starts it again.
+	restart(ctx context.Context) error
+
+	// shutdown stops the component, blocking until existing events are processed.
+	shutdown()
+
+	// syncState requests that Mimir ruler state be synced independent of any
+	// changes made to Kubernetes objects.
+	syncState()
+}
+
+// leadership encapsulates the logic for checking if this instance of the Component
+// is the leader among all instances to avoid conflicting updates of the Mimir API.
+type leadership interface {
+	// update checks if this component instance is still the leader, stores the result,
+	// and returns true if the leadership status has changed since the last time update
+	// was called.
+	update() (bool, error)
+
+	// isLeader returns true if this component instance is the leader, false otherwise.
+	isLeader() bool
+}
+
+// leadership encapsulates the logic for checking if this instance of the Component
+// is the leader among all instances to avoid conflicting updates of the Mimir API.
+type leadership interface {
+	// update checks if this component instance is still the leader, stores the result,
+	// and returns true if the leadership status has changed since the last time update
+	// was called.
+	update() (bool, error)
+
+	// isLeader returns true if this component instance is the leader, false otherwise.
+	isLeader() bool
 }

--- a/internal/component/loki/rules/kubernetes/rules_test.go
+++ b/internal/component/loki/rules/kubernetes/rules_test.go
@@ -1,10 +1,23 @@
 package rules
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
 	"testing"
+	"time"
 
-	"github.com/grafana/alloy/syntax"
+	"github.com/go-kit/log"
+	"github.com/grafana/ckit/peer"
+	"github.com/grafana/ckit/shard"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+
+	"github.com/grafana/alloy/internal/component"
+	"github.com/grafana/alloy/internal/service/cluster"
+	"github.com/grafana/alloy/syntax"
 )
 
 func TestAlloyConfig(t *testing.T) {
@@ -32,4 +45,296 @@ func TestBadAlloyConfig(t *testing.T) {
 	var args Arguments
 	err := syntax.Unmarshal([]byte(exampleAlloyConfig), &args)
 	require.ErrorContains(t, err, "at most one of basic_auth, authorization, oauth2, bearer_token & bearer_token_file must be configured")
+}
+
+type fakeCluster struct{}
+
+func (f fakeCluster) Lookup(shard.Key, int, shard.Op) ([]peer.Peer, error) {
+	return nil, nil
+}
+
+func (f fakeCluster) Peers() []peer.Peer {
+	return nil
+}
+
+type fakeLeadership struct {
+	leader    bool
+	changed   bool
+	updateErr error
+}
+
+func (f *fakeLeadership) update() (bool, error) {
+	return f.changed, f.updateErr
+}
+
+func (f *fakeLeadership) isLeader() bool {
+	return f.leader
+}
+
+type fakeLifecycle struct {
+	updateCalled    atomic.Bool
+	startupCalled   atomic.Bool
+	restartCalled   atomic.Bool
+	shutdownCalled  atomic.Bool
+	syncStateCalled atomic.Bool
+
+	startupErr error
+	restartErr error
+}
+
+func (f *fakeLifecycle) update(Arguments) {
+	f.updateCalled.Store(true)
+}
+
+func (f *fakeLifecycle) startup(context.Context) error {
+	f.startupCalled.Store(true)
+	return f.startupErr
+}
+
+func (f *fakeLifecycle) restart(context.Context) error {
+	f.restartCalled.Store(true)
+	return f.restartErr
+}
+
+func (f *fakeLifecycle) shutdown() {
+	f.shutdownCalled.Store(true)
+}
+
+func (f *fakeLifecycle) syncState() {
+	f.syncStateCalled.Store(true)
+}
+
+type fakeHealthReporter struct {
+	mtx sync.Mutex
+	err error
+}
+
+func (f *fakeHealthReporter) reportUnhealthy(err error) {
+	f.mtx.Lock()
+	f.err = err
+	f.mtx.Unlock()
+}
+
+func (f *fakeHealthReporter) reportHealthy() {
+	f.mtx.Lock()
+	f.err = nil
+	f.mtx.Unlock()
+}
+
+func (f *fakeHealthReporter) getErr() error {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	return f.err
+}
+
+func newComponentForTesting(t *testing.T, reg prometheus.Registerer, logger log.Logger) *Component {
+	opts := component.Options{
+		ID:         "loki.rules.kubernetes",
+		Logger:     logger,
+		Registerer: reg,
+		GetServiceData: func(name string) (interface{}, error) {
+			if name == cluster.ServiceName {
+				return &fakeCluster{}, nil
+			}
+
+			panic(fmt.Sprintf("unexpected service name %s", name))
+		},
+	}
+
+	args := Arguments{Address: "http://localhost:8080/"}
+	args.SetToDefault()
+
+	c, err := newNoInit(opts, args)
+	require.NoError(t, err)
+	return c
+}
+
+func TestIterationHandlesUpdate(t *testing.T) {
+	t.Run("error during restart", func(t *testing.T) {
+		reg := prometheus.NewPedanticRegistry()
+		logger := log.NewNopLogger()
+
+		leader := &fakeLeadership{}
+		health := &fakeHealthReporter{}
+		state := &fakeLifecycle{}
+		state.restartErr = errors.New("expected test error")
+
+		newArgs := Arguments{Address: "http://localhost:8080/"}
+		newArgs.SetToDefault()
+
+		c := newComponentForTesting(t, reg, logger)
+		go func() {
+			require.NoError(t, c.iteration(context.Background(), leader, state, health))
+		}()
+
+		require.NoError(t, c.Update(newArgs))
+		require.Error(t, health.getErr())
+		require.True(t, state.restartCalled.Load())
+	})
+
+	t.Run("success", func(t *testing.T) {
+		reg := prometheus.NewPedanticRegistry()
+		logger := log.NewNopLogger()
+
+		leader := &fakeLeadership{}
+		health := &fakeHealthReporter{}
+		state := &fakeLifecycle{}
+
+		newArgs := Arguments{Address: "http://localhost:8080/"}
+		newArgs.SetToDefault()
+
+		c := newComponentForTesting(t, reg, logger)
+		go func() {
+			require.NoError(t, c.iteration(context.Background(), leader, state, health))
+		}()
+
+		require.NoError(t, c.Update(newArgs))
+		require.NoError(t, health.getErr())
+		require.True(t, state.restartCalled.Load())
+	})
+}
+
+func TestIterationHandlesClusterChange(t *testing.T) {
+	t.Run("error during leader check", func(t *testing.T) {
+		reg := prometheus.NewPedanticRegistry()
+		logger := log.NewNopLogger()
+
+		leader := &fakeLeadership{}
+		leader.updateErr = errors.New("expected test error")
+		health := &fakeHealthReporter{}
+		state := &fakeLifecycle{}
+
+		c := newComponentForTesting(t, reg, logger)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			require.NoError(t, c.iteration(context.Background(), leader, state, health))
+		}()
+
+		c.NotifyClusterChange()
+		wg.Wait()
+
+		require.Error(t, health.getErr())
+		require.False(t, state.restartCalled.Load())
+	})
+
+	t.Run("leader not changed", func(t *testing.T) {
+		reg := prometheus.NewPedanticRegistry()
+		logger := log.NewNopLogger()
+
+		leader := &fakeLeadership{}
+		leader.changed = false
+		health := &fakeHealthReporter{}
+		state := &fakeLifecycle{}
+
+		c := newComponentForTesting(t, reg, logger)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			require.NoError(t, c.iteration(context.Background(), leader, state, health))
+		}()
+
+		c.NotifyClusterChange()
+		wg.Wait()
+
+		require.NoError(t, health.getErr())
+		require.False(t, state.restartCalled.Load())
+	})
+
+	t.Run("error during restart", func(t *testing.T) {
+		reg := prometheus.NewPedanticRegistry()
+		logger := log.NewNopLogger()
+
+		leader := &fakeLeadership{}
+		leader.changed = true
+		health := &fakeHealthReporter{}
+		state := &fakeLifecycle{}
+		state.restartErr = errors.New("expected test error")
+
+		c := newComponentForTesting(t, reg, logger)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			require.NoError(t, c.iteration(context.Background(), leader, state, health))
+		}()
+
+		c.NotifyClusterChange()
+		wg.Wait()
+
+		require.Error(t, health.getErr())
+		require.True(t, state.restartCalled.Load())
+	})
+
+	t.Run("success", func(t *testing.T) {
+		reg := prometheus.NewPedanticRegistry()
+		logger := log.NewNopLogger()
+
+		leader := &fakeLeadership{}
+		leader.changed = true
+		health := &fakeHealthReporter{}
+		state := &fakeLifecycle{}
+
+		c := newComponentForTesting(t, reg, logger)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			require.NoError(t, c.iteration(context.Background(), leader, state, health))
+		}()
+
+		c.NotifyClusterChange()
+		wg.Wait()
+
+		require.NoError(t, health.getErr())
+		require.True(t, state.restartCalled.Load())
+	})
+}
+
+func TestIterationHandlesContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	reg := prometheus.NewPedanticRegistry()
+	logger := log.NewNopLogger()
+
+	leader := &fakeLeadership{}
+	health := &fakeHealthReporter{}
+	state := &fakeLifecycle{}
+
+	c := newComponentForTesting(t, reg, logger)
+	go func() {
+		require.ErrorIs(t, c.iteration(ctx, leader, state, health), errShutdown)
+	}()
+
+	cancel()
+	require.NoError(t, health.getErr())
+}
+
+func TestIterationHandlesTick(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	logger := log.NewNopLogger()
+
+	leader := &fakeLeadership{}
+	health := &fakeHealthReporter{}
+	state := &fakeLifecycle{}
+
+	c := newComponentForTesting(t, reg, logger)
+	c.ticker.Reset(time.Millisecond)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		require.NoError(t, c.iteration(context.Background(), leader, state, health))
+	}()
+
+	wg.Wait()
+
+	require.NoError(t, health.getErr())
+	require.True(t, state.syncStateCalled.Load())
 }

--- a/internal/component/mimir/rules/kubernetes/rules.go
+++ b/internal/component/mimir/rules/kubernetes/rules.go
@@ -495,38 +495,14 @@ type leadership interface {
 	isLeader() bool
 }
 
-// componentLeadership implements leadership based on checking ownership of a specific
-// key using a cluster.Cluster service.
-type componentLeadership struct {
-	id      string
-	logger  log.Logger
-	cluster cluster.Cluster
-	leader  atomic.Bool
-}
+// leadership encapsulates the logic for checking if this instance of the Component
+// is the leader among all instances to avoid conflicting updates of the Mimir API.
+type leadership interface {
+	// update checks if this component instance is still the leader, stores the result,
+	// and returns true if the leadership status has changed since the last time update
+	// was called.
+	update() (bool, error)
 
-func newComponentLeadership(id string, logger log.Logger, cluster cluster.Cluster) *componentLeadership {
-	return &componentLeadership{
-		id:      id,
-		logger:  logger,
-		cluster: cluster,
-	}
-}
-
-func (l *componentLeadership) update() (bool, error) {
-	peers, err := l.cluster.Lookup(shard.StringKey(l.id), 1, shard.OpReadWrite)
-	if err != nil {
-		return false, fmt.Errorf("unable to determine leader for %s: %w", l.id, err)
-	}
-
-	if len(peers) != 1 {
-		return false, fmt.Errorf("unexpected peers from leadership check: %+v", peers)
-	}
-
-	isLeader := peers[0].Self
-	level.Info(l.logger).Log("msg", "checked leadership of component", "is_leader", isLeader)
-	return l.leader.Swap(isLeader) != isLeader, nil
-}
-
-func (l *componentLeadership) isLeader() bool {
-	return l.leader.Load()
+	// isLeader returns true if this component instance is the leader, false otherwise.
+	isLeader() bool
 }


### PR DESCRIPTION
#### PR Description
This change adds support for updating Loki rules based on PrometheusRule objects when running in clustered mode. It does this by picking a single instance to be the leader responsible for making changes using the Loki API. Other non-leader instances will not process events or make calls to the Loki API.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #976

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated