### PR TITLE
Copy datadogreceiver go mod files for integration tests

### DIFF
--- a/internal/cmd/integration-tests/configs/kafka/Dockerfile
+++ b/internal/cmd/integration-tests/configs/kafka/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:1.22.3 as build
 WORKDIR /app/
 COPY go.mod go.sum ./
 COPY syntax/go.mod syntax/go.sum ./syntax/
+COPY internal/etc/datadogreceiver/go.mod internal/etc/datadogreceiver/go.sum ./internal/etc/datadogreceiver/
 RUN go mod download
 COPY ./internal/cmd/integration-tests/configs/kafka/ ./
 RUN CGO_ENABLED=0 go build -o main main.go

--- a/internal/cmd/integration-tests/configs/otel-metrics-gen/Dockerfile
+++ b/internal/cmd/integration-tests/configs/otel-metrics-gen/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:1.22.3 as build
 WORKDIR /app/
 COPY go.mod go.sum ./
 COPY syntax/go.mod syntax/go.sum ./syntax/
+COPY internal/etc/datadogreceiver/go.mod internal/etc/datadogreceiver/go.sum ./internal/etc/datadogreceiver/
 RUN go mod download
 COPY ./internal/cmd/integration-tests/configs/otel-metrics-gen/ ./
 RUN CGO_ENABLED=0 go build -o main main.go

--- a/internal/cmd/integration-tests/configs/prom-gen/Dockerfile
+++ b/internal/cmd/integration-tests/configs/prom-gen/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:1.22.3 as build
 WORKDIR /app/
 COPY go.mod go.sum ./
 COPY syntax/go.mod syntax/go.sum ./syntax/
+COPY internal/etc/datadogreceiver/go.mod internal/etc/datadogreceiver/go.sum ./internal/etc/datadogreceiver/
 RUN go mod download
 COPY ./internal/cmd/integration-tests/configs/prom-gen/ ./
 RUN CGO_ENABLED=0 go build -o main main.go


### PR DESCRIPTION
This seems to be [breaking the integration tests](https://github.com/grafana/alloy/actions/runs/9560645618/job/26353194386) on the main branch.