### PR TITLE
Alloy-Mixin: add severity and description to alerts, plus other improvements

### DIFF
--- a/operations/alloy-mixin/alerts/clustering.libsonnet
+++ b/operations/alloy-mixin/alerts/clustering.libsonnet
@@ -12,7 +12,8 @@ local alert = import './utils/alert.jsonnet';
             'stddev by (cluster, namespace, job) (sum without (state) (cluster_node_peers)) != 0' 
           else 
             'stddev by (job) (sum without (state) (cluster_node_peers)) != 0',
-          'Cluster is not converging: nodes report different number of peers in the cluster.',
+          'Cluster is not converging.',
+          'Cluster is not converging: nodes report different number of peers in the cluster. Job is {{ $labels.job }}',
           '10m',
         ),
 
@@ -32,7 +33,8 @@ local alert = import './utils/alert.jsonnet';
             count by (job) (cluster_node_info)
           |||
           ,
-          'Nodes report different number of peers vs. the count of observed Alloy metrics. Some Alloy metrics may be missing or the cluster is in a split brain state.',
+          'Nodes report different number of peers vs. the count of observed Alloy metrics.',
+          'Nodes report different number of peers vs. the count of observed Alloy metrics. Some Alloy metrics may be missing or the cluster is in a split brain state. Job is {{ $labels.job }}',          
           '15m',
         ),
 
@@ -42,7 +44,8 @@ local alert = import './utils/alert.jsonnet';
           |||
             cluster_node_gossip_health_score > 0
           |||,
-          'Cluster node is reporting a gossip protocol health score > 0.',
+          'Cluster unhealthy.',
+          'Cluster node is reporting a gossip protocol health score > 0. Job is {{ $labels.job }}',
           '10m',
         ),
 
@@ -54,7 +57,8 @@ local alert = import './utils/alert.jsonnet';
           else
             'sum by (job) (rate(cluster_node_gossip_received_events_total{event="node_conflict"}[2m])) > 0'
           ,
-          'A node tried to join the cluster with a name conflicting with an existing peer.',
+          'Cluster Node Name Conflict.',
+          'A node tried to join the cluster with a name conflicting with an existing peer. Job is {{ $labels.job }}',          
           '10m',
         ),
 
@@ -67,6 +71,7 @@ local alert = import './utils/alert.jsonnet';
             'sum by (job, instance) (cluster_node_peers{state="terminating"}) > 0'
           ,
           'Cluster node stuck in Terminating state.',
+          'There is a node within the cluster that is stuck in Terminating state. Job is {{ $labels.job }}',
           '10m',
         ),
 
@@ -83,7 +88,8 @@ local alert = import './utils/alert.jsonnet';
             ) > 1
           |||
           ,
-          'Cluster nodes are not using the same configuration file.',
+          'Cluster configuration drifting.',
+          'Cluster nodes are not using the same configuration file. Job is {{ $labels.job }}',
           '5m',
         ),
       ]

--- a/operations/alloy-mixin/alerts/controller.libsonnet
+++ b/operations/alloy-mixin/alerts/controller.libsonnet
@@ -9,11 +9,12 @@ local alert = import './utils/alert.jsonnet';
         alert.newRule(
           'SlowComponentEvaluations',
           if enableK8sCluster then
-            'sum by (cluster, namespace, job, component_path, component_id) (rate(alloy_component_evaluation_slow_seconds[10m])) > 0'
+            'sum without (cluster, namespace, job, instance, component_path, component_id) (rate(alloy_component_evaluation_slow_seconds[10m])) > 0'
           else
-            'sum by (job, component_path, component_id) (rate(alloy_component_evaluation_slow_seconds[10m])) > 0'
+            'sum without (job, instance, component_path, component_id) (rate(alloy_component_evaluation_slow_seconds[10m])) > 0'
           ,
           'Component evaluations are taking too long.',
+          'Component evaluations are taking too long for instance {{ $labels.instance }}, component_path {{ $labels.component_path }}, component_id {{ $labels.component_id }}.',
           '15m',
         ),
 
@@ -21,11 +22,12 @@ local alert = import './utils/alert.jsonnet';
         alert.newRule(
           'UnhealthyComponents',
           if enableK8sCluster then
-            'sum by (cluster, namespace, job) (alloy_component_controller_running_components{health_type!="healthy"}) > 0'
+            'sum without (cluster, namespace, job, instance) (alloy_component_controller_running_components{health_type!="healthy"}) > 0'
           else
-            'sum by (job) (alloy_component_controller_running_components{health_type!="healthy"}) > 0'
+            'sum without (job, instance) (alloy_component_controller_running_components{health_type!="healthy"}) > 0'
           ,
           'Unhealthy components detected.',
+          'Unhealthy components detected within instance {{ $labels.instance }}',
           '15m',
         ),
       ]

--- a/operations/alloy-mixin/alerts/controller.libsonnet
+++ b/operations/alloy-mixin/alerts/controller.libsonnet
@@ -9,9 +9,9 @@ local alert = import './utils/alert.jsonnet';
         alert.newRule(
           'SlowComponentEvaluations',
           if enableK8sCluster then
-            'sum without (cluster, namespace, job, instance, component_path, component_id) (rate(alloy_component_evaluation_slow_seconds[10m])) > 0'
+            'sum by (cluster, namespace, job, instance, component_path, component_id) (rate(alloy_component_evaluation_slow_seconds[10m])) > 0'
           else
-            'sum without (job, instance, component_path, component_id) (rate(alloy_component_evaluation_slow_seconds[10m])) > 0'
+            'sum by (job, instance, component_path, component_id) (rate(alloy_component_evaluation_slow_seconds[10m])) > 0'
           ,
           'Component evaluations are taking too long.',
           'Component evaluations are taking too long for instance {{ $labels.instance }}, component_path {{ $labels.component_path }}, component_id {{ $labels.component_id }}.',
@@ -22,9 +22,9 @@ local alert = import './utils/alert.jsonnet';
         alert.newRule(
           'UnhealthyComponents',
           if enableK8sCluster then
-            'sum without (cluster, namespace, job, instance) (alloy_component_controller_running_components{health_type!="healthy"}) > 0'
+            'sum by (cluster, namespace, job, instance) (alloy_component_controller_running_components{health_type!="healthy"}) > 0'
           else
-            'sum without (job, instance) (alloy_component_controller_running_components{health_type!="healthy"}) > 0'
+            'sum by (job, instance) (alloy_component_controller_running_components{health_type!="healthy"}) > 0'
           ,
           'Unhealthy components detected.',
           'Unhealthy components detected within instance {{ $labels.instance }}',

--- a/operations/alloy-mixin/alerts/controller.libsonnet
+++ b/operations/alloy-mixin/alerts/controller.libsonnet
@@ -9,12 +9,12 @@ local alert = import './utils/alert.jsonnet';
         alert.newRule(
           'SlowComponentEvaluations',
           if enableK8sCluster then
-            'sum by (cluster, namespace, job, instance, component_path, component_id) (rate(alloy_component_evaluation_slow_seconds[10m])) > 0'
+            'sum by (cluster, namespace, job, component_path, component_id) (rate(alloy_component_evaluation_slow_seconds[10m])) > 0'
           else
-            'sum by (job, instance, component_path, component_id) (rate(alloy_component_evaluation_slow_seconds[10m])) > 0'
+            'sum by (job, component_path, component_id) (rate(alloy_component_evaluation_slow_seconds[10m])) > 0'
           ,
           'Component evaluations are taking too long.',
-          'Component evaluations are taking too long for instance {{ $labels.instance }}, component_path {{ $labels.component_path }}, component_id {{ $labels.component_id }}.',
+          'Component evaluations are taking too long under job {{ $labels.job }}, component_path {{ $labels.component_path }}, component_id {{ $labels.component_id }}.',
           '15m',
         ),
 
@@ -22,12 +22,12 @@ local alert = import './utils/alert.jsonnet';
         alert.newRule(
           'UnhealthyComponents',
           if enableK8sCluster then
-            'sum by (cluster, namespace, job, instance) (alloy_component_controller_running_components{health_type!="healthy"}) > 0'
+            'sum by (cluster, namespace, job) (alloy_component_controller_running_components{health_type!="healthy"}) > 0'
           else
-            'sum by (job, instance) (alloy_component_controller_running_components{health_type!="healthy"}) > 0'
+            'sum by (job) (alloy_component_controller_running_components{health_type!="healthy"}) > 0'
           ,
           'Unhealthy components detected.',
-          'Unhealthy components detected within instance {{ $labels.instance }}',
+          'Unhealthy components detected under job {{ $labels.job }}',
           '15m',
         ),
       ]

--- a/operations/alloy-mixin/alerts/opentelemetry.libsonnet
+++ b/operations/alloy-mixin/alerts/opentelemetry.libsonnet
@@ -11,9 +11,9 @@ local alert = import './utils/alert.jsonnet';
         alert.newRule(
           'OtelcolReceiverRefusedSpans',
           if enableK8sCluster then
-            'sum without (cluster, namespace, job, instance) (rate(receiver_refused_spans_ratio_total{}[1m])) > 0'
+            'sum by (cluster, namespace, job, instance) (rate(receiver_refused_spans_ratio_total{}[1m])) > 0'
           else
-            'sum without (job, instance) (rate(receiver_refused_spans_ratio_total{}[1m])) > 0'
+            'sum by (job, instance) (rate(receiver_refused_spans_ratio_total{}[1m])) > 0'
           ,
           'The receiver could not push some spans to the pipeline.',
           'The receiver could not push some spans to the pipeline, instance {{ $labels.instance }}. This could be due to reaching a limit such as the ones imposed by otelcol.processor.memory_limiter.',
@@ -25,9 +25,9 @@ local alert = import './utils/alert.jsonnet';
         alert.newRule(
           'OtelcolExporterFailedSpans',
           if enableK8sCluster then
-            'sum without (cluster, namespace, job, instance) (rate(exporter_send_failed_spans_ratio_total{}[1m])) > 0'
+            'sum by (cluster, namespace, job, instance) (rate(exporter_send_failed_spans_ratio_total{}[1m])) > 0'
           else
-            'sum without (job, instance) (rate(exporter_send_failed_spans_ratio_total{}[1m])) > 0'
+            'sum by (job, instance) (rate(exporter_send_failed_spans_ratio_total{}[1m])) > 0'
           ,
           'The exporter failed to send spans to their destination.',
           'The exporter failed to send spans to their destination, instance {{ $labels.instance }}. There could be an issue with the payload or with the destination endpoint.',

--- a/operations/alloy-mixin/alerts/opentelemetry.libsonnet
+++ b/operations/alloy-mixin/alerts/opentelemetry.libsonnet
@@ -11,12 +11,12 @@ local alert = import './utils/alert.jsonnet';
         alert.newRule(
           'OtelcolReceiverRefusedSpans',
           if enableK8sCluster then
-            'sum by (cluster, namespace, job, instance) (rate(receiver_refused_spans_ratio_total{}[1m])) > 0'
+            'sum by (cluster, namespace, job) (rate(receiver_refused_spans_ratio_total{}[1m])) > 0'
           else
-            'sum by (job, instance) (rate(receiver_refused_spans_ratio_total{}[1m])) > 0'
+            'sum by (job) (rate(receiver_refused_spans_ratio_total{}[1m])) > 0'
           ,
           'The receiver could not push some spans to the pipeline.',
-          'The receiver could not push some spans to the pipeline, instance {{ $labels.instance }}. This could be due to reaching a limit such as the ones imposed by otelcol.processor.memory_limiter.',
+          'The receiver could not push some spans to the pipeline under job {{ $labels.job }}. This could be due to reaching a limit such as the ones imposed by otelcol.processor.memory_limiter.',
           '5m',
         ),
 
@@ -25,12 +25,12 @@ local alert = import './utils/alert.jsonnet';
         alert.newRule(
           'OtelcolExporterFailedSpans',
           if enableK8sCluster then
-            'sum by (cluster, namespace, job, instance) (rate(exporter_send_failed_spans_ratio_total{}[1m])) > 0'
+            'sum by (cluster, namespace, job) (rate(exporter_send_failed_spans_ratio_total{}[1m])) > 0'
           else
-            'sum by (job, instance) (rate(exporter_send_failed_spans_ratio_total{}[1m])) > 0'
+            'sum by (job) (rate(exporter_send_failed_spans_ratio_total{}[1m])) > 0'
           ,
           'The exporter failed to send spans to their destination.',
-          'The exporter failed to send spans to their destination, instance {{ $labels.instance }}. There could be an issue with the payload or with the destination endpoint.',
+          'The exporter failed to send spans to their destination under job {{ $labels.job }}. There could be an issue with the payload or with the destination endpoint.',
           '5m',
         ),
       ]

--- a/operations/alloy-mixin/alerts/opentelemetry.libsonnet
+++ b/operations/alloy-mixin/alerts/opentelemetry.libsonnet
@@ -11,11 +11,12 @@ local alert = import './utils/alert.jsonnet';
         alert.newRule(
           'OtelcolReceiverRefusedSpans',
           if enableK8sCluster then
-            'sum by (cluster, namespace, job) (rate(receiver_refused_spans_ratio_total{}[1m])) > 0'
+            'sum without (cluster, namespace, job, instance) (rate(receiver_refused_spans_ratio_total{}[1m])) > 0'
           else
-            'sum by (job) (rate(receiver_refused_spans_ratio_total{}[1m])) > 0'
+            'sum without (job, instance) (rate(receiver_refused_spans_ratio_total{}[1m])) > 0'
           ,
           'The receiver could not push some spans to the pipeline.',
+          'The receiver could not push some spans to the pipeline, instance {{ $labels.instance }}. This could be due to reaching a limit such as the ones imposed by otelcol.processor.memory_limiter.',
           '5m',
         ),
 
@@ -24,11 +25,12 @@ local alert = import './utils/alert.jsonnet';
         alert.newRule(
           'OtelcolExporterFailedSpans',
           if enableK8sCluster then
-            'sum by (cluster, namespace, job) (rate(exporter_send_failed_spans_ratio_total{}[1m])) > 0'
+            'sum without (cluster, namespace, job, instance) (rate(exporter_send_failed_spans_ratio_total{}[1m])) > 0'
           else
-            'sum by (job) (rate(exporter_send_failed_spans_ratio_total{}[1m])) > 0'
+            'sum without (job, instance) (rate(exporter_send_failed_spans_ratio_total{}[1m])) > 0'
           ,
           'The exporter failed to send spans to their destination.',
+          'The exporter failed to send spans to their destination, instance {{ $labels.instance }}. There could be an issue with the payload or with the destination endpoint.',
           '5m',
         ),
       ]

--- a/operations/alloy-mixin/alerts/utils/alert.jsonnet
+++ b/operations/alloy-mixin/alerts/utils/alert.jsonnet
@@ -6,7 +6,7 @@
     rules: rules,
   },
 
-  newRule(name='', expr='', message='', description='', severity='warning', forT=''):: std.prune({
+  newRule(name='', expr='', message='', description='', forT='', severity='warning'):: std.prune({
     alert: name,
     expr: expr,
     annotations: {

--- a/operations/alloy-mixin/alerts/utils/alert.jsonnet
+++ b/operations/alloy-mixin/alerts/utils/alert.jsonnet
@@ -6,12 +6,16 @@
     rules: rules,
   },
 
-  newRule(name='', expr='', message='', forT=''):: std.prune({
+  newRule(name='', expr='', message='', description='', severity='warning', forT=''):: std.prune({
     alert: name,
     expr: expr,
     annotations: {
-      message: message,
+      summary: message,
+      description: description,
     },
     'for': forT,
+    labels: {
+      severity: severity,
+    },
   }),
 }

--- a/operations/alloy-mixin/config.libsonnet
+++ b/operations/alloy-mixin/config.libsonnet
@@ -2,7 +2,7 @@
     _config+:: {
         enableK8sCluster: true,
         enableAlloyCluster: true,
-        enableLokiLogs: true,
+        enableLokiLogs: false,
         filterSelector: '', #use it to filter specific metric label values, ie: job=~"integrations/alloy"
         k8sClusterSelector: 'cluster=~"$cluster", namespace=~"$namespace"',
         groupSelector: if self.enableK8sCluster then self.k8sClusterSelector + ', job=~"$job"' else 'job=~"$job"',        

--- a/operations/alloy-mixin/config.libsonnet
+++ b/operations/alloy-mixin/config.libsonnet
@@ -2,7 +2,7 @@
     _config+:: {
         enableK8sCluster: true,
         enableAlloyCluster: true,
-        enableLokiLogs: false,
+        enableLokiLogs: true,
         filterSelector: '', #use it to filter specific metric label values, ie: job=~"integrations/alloy"
         k8sClusterSelector: 'cluster=~"$cluster", namespace=~"$namespace"',
         groupSelector: if self.enableK8sCluster then self.k8sClusterSelector + ', job=~"$job"' else 'job=~"$job"',        

--- a/operations/alloy-mixin/config.libsonnet
+++ b/operations/alloy-mixin/config.libsonnet
@@ -5,9 +5,7 @@
         enableLokiLogs: true,
         filterSelector: '', #use it to filter specific metric label values, ie: job=~"integrations/alloy"
         k8sClusterSelector: 'cluster=~"$cluster", namespace=~"$namespace"',
-        groupSelector: 
-            (if !std.isEmpty(self.filterSelector) then self.filterSelector + ', ') + 
-            (if self.enableK8sCluster then self.k8sClusterSelector + ', job=~"$job"' else 'job=~"$job"'),
+        groupSelector: if self.enableK8sCluster then self.k8sClusterSelector + ', job=~"$job"' else 'job=~"$job"',
         instanceSelector: self.groupSelector + ', instance=~"$instance"',        
         logsFilterSelector: '', #use to filter logs originated from alloy, and avoid picking up other platform logs, ie: service_name="alloy"
         dashboardTag: 'alloy-mixin',

--- a/operations/alloy-mixin/config.libsonnet
+++ b/operations/alloy-mixin/config.libsonnet
@@ -5,7 +5,9 @@
         enableLokiLogs: true,
         filterSelector: '', #use it to filter specific metric label values, ie: job=~"integrations/alloy"
         k8sClusterSelector: 'cluster=~"$cluster", namespace=~"$namespace"',
-        groupSelector: if self.enableK8sCluster then self.k8sClusterSelector + ', job=~"$job"' else 'job=~"$job"',        
+        groupSelector: 
+            (if !std.isEmpty(self.filterSelector) then self.filterSelector + ', ') + 
+            (if self.enableK8sCluster then self.k8sClusterSelector + ', job=~"$job"' else 'job=~"$job"'),
         instanceSelector: self.groupSelector + ', instance=~"$instance"',        
         logsFilterSelector: '', #use to filter logs originated from alloy, and avoid picking up other platform logs, ie: service_name="alloy"
         dashboardTag: 'alloy-mixin',

--- a/operations/alloy-mixin/dashboards/controller.libsonnet
+++ b/operations/alloy-mixin/dashboards/controller.libsonnet
@@ -36,7 +36,7 @@ local filename = 'alloy-controller.json';
         panel.withQueries([
           panel.newQuery(
             expr= |||
-              count(alloy_component_controller_evaluating{%(groupSelector)s})
+              count(alloy_component_controller_running_components{%(groupSelector)s})
             ||| % $._config,
           ),
         ])

--- a/operations/alloy-mixin/dashboards/controller.libsonnet
+++ b/operations/alloy-mixin/dashboards/controller.libsonnet
@@ -36,7 +36,7 @@ local filename = 'alloy-controller.json';
         panel.withQueries([
           panel.newQuery(
             expr= |||
-              count(alloy_component_controller_running_components{%(groupSelector)s})
+              count(group(alloy_component_controller_running_components{%(groupSelector)s}) by (instance))
             ||| % $._config,
           ),
         ])

--- a/operations/alloy-mixin/dashboards/utils/templates.libsonnet
+++ b/operations/alloy-mixin/dashboards/utils/templates.libsonnet
@@ -73,7 +73,7 @@ local dashboard = import './dashboard.jsonnet';
                 name='namespace', 
                 query=namespaceTemplateQuery,
                 setenceCaseLabels=setenceCaseLabels),
-                dashboard.newMultiTemplateVariable(
+                dashboard.newTemplateVariable(
                 name='job', 
                 query=k8sJobTemplateQuery,
                 setenceCaseLabels=setenceCaseLabels),
@@ -88,7 +88,7 @@ local dashboard = import './dashboard.jsonnet';
             else []
         else
             [
-                dashboard.newMultiTemplateVariable(
+                dashboard.newTemplateVariable(
                 name='job', 
                 query=jobTemplateQuery,
                 setenceCaseLabels=setenceCaseLabels),                


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This is adapting Alloy Mixin alerts to comply with https://monitoring.mixins.dev/ best practices.

- Adding summary and description annotations, removing message
- Adding severity (warning for all alerts - lmk if you want another severity for any of these)
- Adding labels to descriptions to help troubleshooting alert
- Adding instance label into queries for controller and otel alerts - this is instance granular is it not?

Additionally:
- Making job template non-multi variable, to avoid picking up unwanted metrics
- Changing Running Instances count panel within controller dashboard to group by `instance`, since this is duplicating the values

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

During integration testing, we noticed `alloy_component_controller_evaluating` emits 2 active series for each instance, thus duplicating the running instances panel value.

![image](https://github.com/grafana/alloy/assets/9431850/5a4c7e05-7499-4838-b993-51b9332c4836)
![image](https://github.com/grafana/alloy/assets/9431850/bd88d30b-2348-4437-b0fb-1ac98715ed75)


#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
