### PR TITLE
remove explicit chown step that made docker image bigger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN  apt-get update \
  &&  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 
-COPY --from=build --chown=$UID --chmod=770 /src/alloy/build/alloy /bin/alloy
+COPY --from=build --chown=$UID /src/alloy/build/alloy /bin/alloy
 COPY --chown=$UID example-config.alloy /etc/alloy/config.alloy
 
 # Create alloy user in container, but do not set it as default

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,8 @@ RUN  apt-get update \
  &&  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 
-COPY --from=build /src/alloy/build/alloy /bin/alloy
-COPY example-config.alloy /etc/alloy/config.alloy
+COPY --from=build --chown=$UID --chmod=770 /src/alloy/build/alloy /bin/alloy
+COPY --chown=$UID example-config.alloy /etc/alloy/config.alloy
 
 # Create alloy user in container, but do not set it as default
 #
@@ -53,8 +53,6 @@ COPY example-config.alloy /etc/alloy/config.alloy
 # undocumented feature; use at your own risk.
 RUN groupadd --gid $UID $USERNAME
 RUN useradd -m -u $UID -g $UID $USERNAME
-RUN chown -R $USERNAME:$USERNAME /etc/alloy
-RUN chown -R $USERNAME:$USERNAME /bin/alloy
 
 RUN mkdir -p /var/lib/alloy/data
 RUN chown -R $USERNAME:$USERNAME /var/lib/alloy


### PR DESCRIPTION
Before (v1.1): 544MB (according to docker desktop)
```
# ls -la /bin/alloy
-rwxr-xr-x 1 alloy alloy 228652376 May 30 14:17 /bin/alloy
# ls -la /var/lib/alloy
total 12
drwxrwx--- 1 alloy alloy 4096 May 30 14:17 .
drwxr-xr-x 1 root  root  4096 May 30 14:17 ..
drwxrwx--- 1 alloy alloy 4096 May 30 14:17 data
# ls -la /etc/alloy
total 12
drwxr-xr-x 1 alloy alloy 4096 May 30 14:17 .
drwxr-xr-x 1 root  root  4096 Jun 21 15:27 ..
-rw-r--r-- 1 alloy alloy  748 May 30 14:13 config.alloy
```

After: 408MB
```
# ls -la /bin/alloy
-rwxr-xr-x 1 alloy alloy 321554776 Jun 21 15:32 /bin/alloy
# ls -la /var/lib/alloy
total 20
drwxrwx--- 1 alloy alloy 4096 Jun 21 15:21 .
drwxr-xr-x 1 root  root  4096 Jun 21 15:21 ..
drwxrwx--- 1 alloy alloy 4096 Jun 21 15:21 data
# ls -la /etc/alloy
total 12
drwxr-xr-x 2 alloy alloy 4096 Jun 21 15:21 .
drwxr-xr-x 1 root  root  4096 Jun 21 15:23 ..
-rw-rw-r-- 1 alloy alloy  748 Mar 29 03:34 config.alloy
```

It isn't a massive improvement, but it is something for free.