### PR TITLE
feat: add namespace to faro receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Main (unreleased)
 ### Enhancements
 
 - Added a success rate panel on the Prometheus Components dashboard. (@thampiotr)
+- Add namespace field to Faro payload (@cedricziel)
 
 v1.2.0-rc.0
 -----------------

--- a/internal/component/faro/receiver/internal/payload/payload.go
+++ b/internal/component/faro/receiver/internal/payload/payload.go
@@ -354,6 +354,7 @@ func (p Page) KeyVal() *KeyVal {
 // App holds metadata about the application event originates from
 type App struct {
 	Name        string `json:"name,omitempty"`
+	Namespace   string `json:"namespace,omitempty"`
 	Release     string `json:"release,omitempty"`
 	Version     string `json:"version,omitempty"`
 	Environment string `json:"environment,omitempty"`
@@ -386,6 +387,7 @@ func (e Event) KeyVal() *KeyVal {
 func (a App) KeyVal() *KeyVal {
 	kv := NewKeyVal()
 	KeyValAdd(kv, "name", a.Name)
+	KeyValAdd(kv, "namespace", a.Namespace)
 	KeyValAdd(kv, "release", a.Release)
 	KeyValAdd(kv, "version", a.Version)
 	KeyValAdd(kv, "environment", a.Environment)


### PR DESCRIPTION
#### PR Description

This change adds the namespace field to the app meta.

It's used to logically structure apps and will be used to facilitate a mapping to opentelemetry's service.namespace

#### Notes to the Reviewer

Required for grafana/faro-web-sdk#626

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
