### PR TITLE
Updated Typo in MSSQL Block Docs

### DIFF
--- a/docs/sources/reference/components/prometheus.exporter.windows.md
+++ b/docs/sources/reference/components/prometheus.exporter.windows.md
@@ -132,7 +132,7 @@ Specifying `enabled_classes` is useful to limit the response to the MSMQs you sp
 
 Name | Type     | Description | Default | Required
 ---- |----------| ----------- | ------- | --------
-`enabled_classes` | `list(string)` | Comma-separated list of MSSQL WMI classes to use. | `["accessmethods", "availreplica", "bufman", "databases", "dbreplica", "genstats", "locks", "memmgr", "sqlstats", "sqlerrorstransactions"]` | no
+`enabled_classes` | `list(string)` | Comma-separated list of MSSQL WMI classes to use. | `["accessmethods", "availreplica", "bufman", "databases", "dbreplica", "genstats", "locks", "memmgr", "sqlstats", "sqlerrors", "transactions"]` | no
 
 
 ### network block


### PR DESCRIPTION
Updated a typo in the mssql block heading in the [prometheus.exporter.windows](https://grafana.com/docs/alloy/latest/reference/components/prometheus.exporter.windows/) documentation. 

`.. "sqlerrorstransactions"]` --> `.. "sqlerrors", "transactions"]`. 

This is as per the supported MSSQL WMI classes discussed here:  
https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.mssql.md
