### PR TITLE
Update changelog for v1.2 rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ This document contains a historical list of changes between releases. Only
 changes that impact end-user behavior are listed; changes to documentation or
 internal API changes are not present.
 
+v1.2.0-rc.1
+-----------------
+
+### Security fixes
+
+- Fixes the following vulnerabilities (@ptodev):
+  - [CVE-2024-35255][https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-35255]
+  - [CVE-2024-36129][https://avd.aquasec.com/nvd/2024/cve-2024-36129/]
+
 v1.2.0-rc.0
 -----------------
 


### PR DESCRIPTION
I think this is all that's needed before creating a tag for the 2nd RC. There is no need to update the version to `v1.2 rc.2` anywhere.