### PR TITLE
misc: migrate to community.grafana.com

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -7,7 +7,7 @@ body:
       value: |
         Thank you for opening a bug report for Grafana Alloy.
 
-        Please do not use GitHub issues for support questions. If you need help or support, ask a question in [GitHub Discussions](https://github.com/grafana/alloy/discussions) or join the `#alloy` channel on the [Grafana Slack](https://slack.grafana.com/).
+        Please do not use GitHub issues for support questions. If you need help or support, ask a question on [Grafana Community](https://community.grafana.com/c/grafana-alloy) or join the `#alloy` channel on the [Grafana Slack](https://slack.grafana.com/).
   - type: textarea
     attributes:
       label: What's wrong?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,10 +1,10 @@
-# NOTE(rfratto): this file *must* have the .yml extension otherwise GitHub doesn't 
+# NOTE(rfratto): this file *must* have the .yml extension otherwise GitHub doesn't
 # recognize it.
 blank_issues_enabled: true
 contact_links:
   - name: Grafana Alloy community support
-    url: https://github.com/grafana/alloy/discussions
-    about: If you need help or support, ask questions in GitHub Discussions.
+    url: https://community.grafana.com/c/grafana-alloy
+    about: If you need help or support, ask questions on Grafana Community.
   - name: Grafana Alloy Slack
     url: https://slack.grafana.com/
     about: "Join the #alloy slack channel to chat about Grafana Alloy in real-time."

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -7,7 +7,7 @@ body:
       value: |
         Thank you for opening a feature request for Grafana Alloy.
 
-        Please do not use GitHub issues for support questions. If you need help or support, ask a question in [GitHub Discussions](https://github.com/grafana/alloy/discussions) or join the `#alloy` channel on the [Grafana Slack](https://slack.grafana.com/).
+        Please do not use GitHub issues for support questions. If you need help or support, ask a question on [Grafana Community](https://community.grafana.com/c/grafana-alloy) or join the `#alloy` channel on the [Grafana Slack](https://slack.grafana.com/).
   - type: textarea
     attributes:
       label: Request

--- a/.github/ISSUE_TEMPLATE/proposal.yaml
+++ b/.github/ISSUE_TEMPLATE/proposal.yaml
@@ -7,7 +7,7 @@ body:
       value: |
         Thank you for opening a proposal for Grafana Alloy.
 
-        Please do not use GitHub issues for support questions. If you need help or support, ask a question in [GitHub Discussions](https://github.com/grafana/alloy/discussions) or join the `#alloy` channel on the [Grafana Slack](https://slack.grafana.com/).
+        Please do not use GitHub issues for support questions. If you need help or support, ask a question on [Grafana Community](https://community.grafana.com/c/grafana-alloy) or join the `#alloy` channel on the [Grafana Slack](https://slack.grafana.com/).
   - type: textarea
     attributes:
       label: Background

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -20,7 +20,7 @@ The Grafana Alloy developers and community are expected to follow the values def
 
 ## Projects
 
-Each project must have a [`MAINTAINERS.md`][maintainers] file with at least one maintainer. Where a project has a release process, access and documentation should be such that more than one person can perform a release. Where a project has a release process, access and documentation should be such that more than one person can perform a release. Releases should be announced on the [GitHub Discussions][discussions] page. Any new projects should be first proposed on the [team mailing list][team] following the voting procedures listed below.
+Each project must have a [`MAINTAINERS.md`][maintainers] file with at least one maintainer. Where a project has a release process, access and documentation should be such that more than one person can perform a release. Where a project has a release process, access and documentation should be such that more than one person can perform a release. Releases should be announced on the [Community][community] site. Any new projects should be first proposed on the [team mailing list][team] following the voting procedures listed below.
 
 ## Decision making
 
@@ -58,7 +58,7 @@ The current team members are:
 
 Maintainers lead one or more project(s) or parts thereof and serve as a point of conflict resolution amongst the contributors to this project. Ideally, maintainers are also team members, but exceptions are possible for suitable maintainers that, for whatever reason, are not yet team members.
 
-Changes in maintainership have to be announced on the [GitHub Discussions][discussions] page. They are decided by [rough consensus](#consensus) and formalized by changing the [`MAINTAINERS.md`][maintainers] file of the respective repository.
+Changes in maintainership have to be announced on the [Community][community] site. They are decided by [rough consensus](#consensus) and formalized by changing the [`MAINTAINERS.md`][maintainers] file of the respective repository.
 
 Maintainers are granted commit rights to all projects covered by this governance.
 
@@ -68,7 +68,7 @@ A project may have multiple maintainers, as long as the responsibilities are cle
 
 ### Technical decisions
 
-Technical decisions that only affect a single project are made informally by the maintainer of this project, and [rough consensus](#consensus) is assumed. Technical decisions that span multiple parts of the project should be discussed and made on the [GitHub discussions page][discussions].
+Technical decisions that only affect a single project are made informally by the maintainer of this project, and [rough consensus](#consensus) is assumed. Technical decisions that span multiple parts of the project should be discussed and made on the issue.
 
 Decisions are usually made by [rough consensus](#consensus). If no consensus can be reached, the matter may be resolved by [majority vote](#majority-vote).
 
@@ -78,7 +78,7 @@ Changes to this document are made by Grafana Labs.
 
 ### Other matters
 
-Any matter that needs a decision may be called to a vote by any member if they deem it necessary. For private or personnel matters, discussion and voting takes place on the [team mailing list][team], otherwise on the [GitHub discussions page][discussions].
+Any matter that needs a decision may be called to a vote by any member if they deem it necessary. For private or personnel matters, discussion and voting takes place on the [team mailing list][team], otherwise on the related issue.
 
 ## Voting
 
@@ -90,7 +90,7 @@ For all votes, voting must be open for at least one week. The end date should be
 
 In all cases, all and only [team members](#team-members) are eligible to vote, with the sole exception of the forced removal of a team member, in which said member is not eligible to vote.
 
-Discussion and votes on personnel matters (including but not limited to team membership and maintainership) are held in private on the [team mailing list][team]. All other discussion and votes are held in public on the [GitHub discussions page][discussions].
+Discussion and votes on personnel matters (including but not limited to team membership and maintainership) are held in private on the [team mailing list][team]. All other discussion and votes are held in public on the related issue.
 
 For public discussions, anyone interested is encouraged to participate. Formal power to object or vote is limited to [team members](#team-members).
 
@@ -98,7 +98,7 @@ For public discussions, anyone interested is encouraged to participate. Formal p
 
 The default decision making mechanism for the Grafana Alloy project is [rough][rough] consensus. This means that any decision on technical issues is considered supported by the [team][team] as long as nobody objects or the objection has been considered but not necessarily accommodated.
 
-Silence on any consensus decision is implicit agreement and equivalent to explicit agreement. Explicit agreement may be stated at will. Decisions may, but do not need to be called out and put up for decision on the [GitHub discussions page][discussions] at any time and by anyone.
+Silence on any consensus decision is implicit agreement and equivalent to explicit agreement. Explicit agreement may be stated at will. Decisions may, but do not need to be called out and put up for decision at any time and by anyone.
 
 Consensus decisions can never override or go against the spirit of an earlier explicit vote.
 
@@ -133,7 +133,7 @@ If there are multiple alternatives, members may vote for one or more alternative
 The new member is
 
 - added to the list of [team members](#team-members). Ideally by sending a PR of their own, at least approving said PR.
-- announced on the [GitHub discussions page][discussions] by an existing team member. Ideally, the new member replies in this thread, acknowledging team membership.
+- announced on the [Community site][community] by an existing team member. Ideally, the new member replies in this thread, acknowledging team membership.
 - added to the projects with commit rights.
 - added to the [team mailing list][team].
 
@@ -154,4 +154,4 @@ If needed, we reserve the right to publicly announce removal.
 [maintainers]: https://github.com/grafana/alloy/blob/main/MAINTAINERS.md
 [rough]: https://tools.ietf.org/html/rfc7282
 [team]: https://groups.google.com/forum/#!forum/grafana-alloy-team
-[discussions]: https://github.com/grafana/alloy/discussions
+[community]: https://community.grafana.com/c/grafana-alloy

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 </p>
 
 Grafana Alloy is an open source OpenTelemetry Collector distribution with
-built-in Prometheus pipelines and support for metrics, logs, traces, and 
-profiles. 
+built-in Prometheus pipelines and support for metrics, logs, traces, and
+profiles.
 
 <p>
 <img src="docs/sources/assets/alloy_screenshot.png">
@@ -128,13 +128,13 @@ To engage with the Alloy community:
   Grafana Slack, visit <https://slack.grafana.com/> and join the `#alloy`
   channel.
 
-* Ask questions on the [Discussions page][discussions].
+* Ask questions on the [Grafana community site][community].
 
 * [File an issue][issue] for bugs, issues, and feature suggestions.
 
 * Attend the monthly [community call][community-call].
 
-[discussions]: https://github.com/grafana/alloy/discussions
+[community]: https://community.grafana.com/c/grafana-alloy
 [issue]: https://github.com/grafana/alloy/issues/new
 [community-call]: https://docs.google.com/document/d/1TqaZD1JPfNadZ4V81OCBPCG_TksDYGlNlGdMnTWUSpo
 


### PR DESCRIPTION
community.grafana.com has had a Grafana Alloy category for a while now, leading to a gap where maintainers were unaware of where some questions were being asked.

community.grafana.com is the typical place for questions for a few projects, so it makes sense to shut down the discussions page on GitHub in favor of the community site instead.