### PR TITLE
Correct typo for data stream field

### DIFF
--- a/docs/sources/reference/components/prometheus.exporter.elasticsearch.md
+++ b/docs/sources/reference/components/prometheus.exporter.elasticsearch.md
@@ -48,7 +48,7 @@ Omitted fields take their default values.
 | `client_cert`          | `string`   | Path to PEM file that contains the corresponding cert for the private key to connect to Elasticsearch. |                           | no       |
 | `ssl_skip_verify`      | `bool`     | Skip SSL verification when connecting to Elasticsearch.                                                |                           | no       |
 | `aliases`              | `bool`     | Include informational aliases metrics.                                                                 |                           | no       |
-| `data_streams`         | `bool`     | Export stats for Data Streams.                                                                         |                           | no       |
+| `data_stream`         | `bool`     | Export stats for Data Streams.                                                                         |                           | no       |
 | `slm`                  | `bool`     | Export stats for SLM (Snapshot Lifecycle Management).                                                  |                           | no       |
 
 ## Blocks


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
The correspondence field named `data_stream` as per the source code found here: https://github.com/grafana/alloy/blob/996c74a0ee45cad7b83220cbd3d0064a844f09cd/internal/static/integrations/elasticsearch_exporter/elasticsearch_exporter.go#L70

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
