### PR TITLE
docs: warn in task page that live debugging must be enabled

### DIFF
--- a/docs/sources/tasks/debug.md
+++ b/docs/sources/tasks/debug.md
@@ -78,6 +78,12 @@ The clustering page shows the following information for each cluster node:
 
 Live debugging provides a real-time stream of debugging data from a component. You can access this page from the corresponding [Component detail page](#component-detail-page).
 
+{{< admonition type="caution" >}}
+Live debugging is disabled by default to avoid accidentally displaying sensitive telemetry data. To enable live debugging, configure the [livedebugging block][livedebugging].
+
+[livedebugging]: {{< relref "../reference/config-blocks/livedebugging" >}}
+{{< /admonition >}}
+
 Live debugging allows you to do the following:
 
 * Pause and clear the data stream.

--- a/docs/sources/tasks/debug.md
+++ b/docs/sources/tasks/debug.md
@@ -81,7 +81,7 @@ Live debugging provides a real-time stream of debugging data from a component. Y
 {{< admonition type="caution" >}}
 Live debugging is disabled by default to avoid accidentally displaying sensitive telemetry data. To enable live debugging, configure the [livedebugging block][livedebugging].
 
-[livedebugging]: {{< relref "../reference/config-blocks/livedebugging" >}}
+[livedebugging]: ../../reference/config-blocks/livedebugging/
 {{< /admonition >}}
 
 Live debugging allows you to do the following:


### PR DESCRIPTION
This PR fixes an issue where the task page for debugging does not guide you to the reference documentation for how to enable the functionality. 