### PR TITLE
use alloy-dev latest instead of non-existent main

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@7c2007bcb556501da015201bcba5aa14069b74e2
         with:
-          image-ref: 'grafana/alloy:main'
+          image-ref: 'grafana/alloy-dev:latest'
           format: 'template'
           template: '@/contrib/sarif.tpl'
           output: 'trivy-results.sarif'


### PR DESCRIPTION

#### PR Description

Switch to using alloy-dev:latest which should be the main build.

#### Which issue(s) this PR fixes

Fixes #1172 

#### Notes to the Reviewer

#### PR Checklist

Not a user facing change.
