### PR TITLE
Update prometheus.exporter.unix  - OS specific defaults for filesystem block

### DIFF
--- a/docs/sources/reference/components/prometheus.exporter.unix.md
+++ b/docs/sources/reference/components/prometheus.exporter.unix.md
@@ -125,20 +125,41 @@ The following blocks are supported inside the definition of `prometheus.exporter
 
 ### filesystem block
 
-The default values can vary by the operating system {{< param "PRODUCT_NAME" >}} runs on.
-Refer to the [integration source](https://github.com/grafana/alloy/blob/main/internal/static/integrations/node_exporter/config.go) for up-to-date values on each operating system.
+The default values vary by the operating system {{< param "PRODUCT_NAME" >}} runs on.
 
-| Name                   | Type       | Description                                                         | Default                                         | Required |
-| ---------------------- | ---------- | ------------------------------------------------------------------- | ----------------------------------------------- | -------- |
-| `fs_types_exclude`     | `string`   | Regexp of filesystem types to ignore for filesystem collector.      | (_see below_ )                                  | no       |
-| `mount_points_exclude` | `string`   | Regexp of mount points to ignore for filesystem collector.          | `"^/(dev\|proc\|sys\|var/lib/docker/.+)($\|/)"` | no       |
-| `mount_timeout`        | `duration` | How long to wait for a mount to respond before marking it as stale. | `"5s"`                                          | no       |
+| Name                   | Type       | Description                                                         | Default        | Required |
+|------------------------|------------|---------------------------------------------------------------------|----------------|----------|
+| `fs_types_exclude`     | `string`   | Regexp of filesystem types to ignore for filesystem collector.      | (_see below_ ) | no       |
+| `mount_points_exclude` | `string`   | Regexp of mount points to ignore for filesystem collector.          | (_see below_ ) | no       |
+| `mount_timeout`        | `duration` | How long to wait for a mount to respond before marking it as stale. | `"5s"`         | no       |
 
 `fs_types_exclude` defaults to the following regular expression string:
 
-```
+{{< code >}}
+```linux
 ^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$
 ```
+```osx
+^(autofs|devfs)$
+```
+```bsd
+^devfs$
+```
+{{< /code >}}
+
+`mount_points_exclude` defaults to the following regular expression string:
+
+{{< code >}}
+```linux
+^/(dev|proc|run/credentials/.+|sys|var/lib/docker/.+)($|/)
+```
+```osx
+^/(dev)($|/)
+```
+```bsd
+^/(dev)($|/)
+```
+{{< /code >}}
 
 ### ipvs block
 
@@ -153,7 +174,7 @@ Refer to the [integration source](https://github.com/grafana/alloy/blob/main/int
 | `server`                 | `string`   | NTP server to use for the collector.                         | `"127.0.0.1"` | no       |
 | `server_is_local`        | `boolean`  | Certifies that the server address isn't a public NTP server. | false         | no       |
 | `ip_ttl`                 | `int`      | TTL to use while sending NTP query.                          | 1             | no       |
-| `local_offset_tolerance` | `duration` | Offset between local clock and local ntpd time to tolerate.  | `"1ms"`       | no       |
+| `local_offset_tolerance` | `duration` | Offset between local clock and local NTPD time to tolerate.  | `"1ms"`       | no       |
 | `max_distance`           | `duration` | Max accumulated distance to the root.                        | `"3466080us"` | no       |
 | `protocol_version`       | `int`      | NTP protocol version.                                        | 4             | no       |
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Update prometheus.exporter.unix  - OS specific defaults for filesystem block

* Added code block shortcode to document variances in the defaults for Linux, OSX and BSD 

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes https://github.com/grafana/alloy/issues/214

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
