### PR TITLE
Only use internalTrafficPolicy: if on Kubernetes vesrion 1.26 or later

### DIFF
--- a/operations/helm/charts/alloy/CHANGELOG.md
+++ b/operations/helm/charts/alloy/CHANGELOG.md
@@ -10,6 +10,10 @@ internal API changes are not present.
 Unreleased
 ----------
 
+### Enhancements
+
+- Only utilize spec.internalTrafficPolicy in the Service if deploying to Kubernetes 1.26 or later. (@petewall)
+
 0.4.0 (2024-06-26)
 ------------------
 

--- a/operations/helm/charts/alloy/templates/service.yaml
+++ b/operations/helm/charts/alloy/templates/service.yaml
@@ -18,7 +18,9 @@ spec:
   {{- end }}
   selector:
     {{- include "alloy.selectorLabels" . | nindent 4 }}
+  {{- if semverCompare ">=1.26-0" .Capabilities.KubeVersion.Version }}
   internalTrafficPolicy: {{.Values.service.internalTrafficPolicy}}
+  {{- end }}
   ports:
     - name: http-metrics
       {{- if eq .Values.service.type "NodePort" }}


### PR DESCRIPTION
Using the latest k8s version
```
petewall@GrafanaPete:~/src/grafana/alloy/operations/helm/charts/alloy % helm template test . | yq -r "select(.kind==\"Service\")"                    
# Source: alloy/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: test-alloy
  labels:
    helm.sh/chart: alloy-0.4.0
    app.kubernetes.io/name: alloy
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "v1.2.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: alloy
    app.kubernetes.io/component: networking
spec:
  type: ClusterIP
  selector:
    app.kubernetes.io/name: alloy
    app.kubernetes.io/instance: test
  internalTrafficPolicy: Cluster
  ports:
    - name: http-metrics
      port: 12345
      targetPort: 12345
      protocol: "TCP"
```

Using an older k8s version:
```
petewall@GrafanaPete:~/src/grafana/alloy/operations/helm/charts/alloy % helm template --kube-version 1.19 test . | yq -r "select(.kind==\"Service\")"            
# Source: alloy/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: test-alloy
  labels:
    helm.sh/chart: alloy-0.4.0
    app.kubernetes.io/name: alloy
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "v1.2.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: alloy
    app.kubernetes.io/component: networking
spec:
  type: ClusterIP
  selector:
    app.kubernetes.io/name: alloy
    app.kubernetes.io/instance: test
  ports:
    - name: http-metrics
      port: 12345
      targetPort: 12345
      protocol: "TCP"
```