### PR TITLE
Mention `otelcol.processor.deltatocumulative` in the `otelcol.exporter.prometheus` docs

### DIFF
--- a/docs/sources/reference/components/otelcol.exporter.prometheus.md
+++ b/docs/sources/reference/components/otelcol.exporter.prometheus.md
@@ -93,7 +93,12 @@ are forwarded to the `forward_to` argument.
 
 The following are dropped during the conversion process:
 
-* Metrics that use the delta aggregation temporality
+* Metrics that use the delta aggregation temporality.
+  Prometheus does not support delta metrics natively.
+  If your {{< param "PRODUCT_NAME" >}} instance ingests delta OTLP metrics,
+  consider converting them to cumulative OTLP metrics using [otelcol.processor.deltatocumulative][] prior to using `otelcol.exporter.prometheus`.
+
+[otelcol.processor.deltatocumulative]: ../otelcol.processor.deltatocumulative
 
 ## Component health
 

--- a/docs/sources/reference/components/otelcol.exporter.prometheus.md
+++ b/docs/sources/reference/components/otelcol.exporter.prometheus.md
@@ -94,11 +94,12 @@ are forwarded to the `forward_to` argument.
 The following are dropped during the conversion process:
 
 * Metrics that use the delta aggregation temporality.
-  Prometheus does not support delta metrics natively.
-  If your {{< param "PRODUCT_NAME" >}} instance ingests delta OTLP metrics,
-  consider converting them to cumulative OTLP metrics using [otelcol.processor.deltatocumulative][] prior to using `otelcol.exporter.prometheus`.
+  {{< admonition type="note" >}}
+  Prometheus does not natively support delta metrics.
+  If your {{< param "PRODUCT_NAME" >}} instance ingests delta OTLP metrics, you can convert them to cumulative OTLP metrics with [`otelcol.processor.deltatocumulative`][otelcol.processor.deltatocumulative] before you use `otelcol.exporter.prometheus`.
 
-[otelcol.processor.deltatocumulative]: ../otelcol.processor.deltatocumulative
+  [otelcol.processor.deltatocumulative]: ../otelcol.processor.deltatocumulative
+  {{< /admonition >}}
 
 ## Component health
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Now that we have a `otelcol.processor.deltatocumulative` component, I don't think there is a need to support delta conversions within `otelcol.exporter.prometheus`.

#### Which issue(s) this PR fixes

Fixes #519

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
