### PR TITLE
Allow setting the CPU profiling event for Java Async Profiler in the `pyroscope.java` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Main (unreleased)
 - (_Public preview_) Added rate limiting of cluster state changes to reduce the
   number of unnecessary, intermediate state updates. (@thampiotr)
 
+- Allow activating `wall` mode for Java Async Profiler (@slbucur)
+
 ### Bugfixes
 
 - Fixed a clustering mode issue where a fatal startup failure of the clustering service

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ Main (unreleased)
 - (_Public preview_) Added rate limiting of cluster state changes to reduce the
   number of unnecessary, intermediate state updates. (@thampiotr)
 
-- Allow setting the CPU profiling event for Java Async Profiler (@slbucur)
+- Allow setting the CPU profiling event for Java Async Profiler in `pyroscope.java` component (@slbucur)
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ Main (unreleased)
 - (_Public preview_) Added rate limiting of cluster state changes to reduce the
   number of unnecessary, intermediate state updates. (@thampiotr)
 
-- Allow activating `wall` mode for Java Async Profiler (@slbucur)
+- Allow setting the CPU profiling event for Java Async Profiler (@slbucur)
 
 ### Bugfixes
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.java.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.java.md
@@ -84,16 +84,31 @@ The `profiling_config` block describes how async-profiler is invoked.
 
 The following arguments are supported:
 
-Name          | Type       | Description                                                                                                                                                                                                                          | Default | Required
---------------|------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|---------
-`interval`    | `duration` | How frequently to collect profiles from the targets.                                                                                                                                                                                 | "60s"   | no
-`cpu`         | `bool`     | A flag to enable cpu profiling, using `itimer` async-profiler event.                                                                                                                                                                 | true    | no
-`sample_rate` | `int`      | CPU profiling sample rate. It is converted from Hz to interval and passed as `-i` arg to async-profiler.                                                                                                                             | 100     | no
-`alloc`       | `string`   | Allocation profiling sampling configuration  It is passed as `--alloc` arg to async-profiler.                                                                                                                                        | "512k"  | no
-`lock`        | `string`   | Lock profiling sampling configuration. It is passed as `--lock` arg to async-profiler.                                                                                                                                               | "10ms"  | no
-`wall`        | `bool`     | Activates the `wall` mode when `cpu` profiling is enabled. This sample all threads equally every given period of time regardless of thread status: Running, Sleeping or Blocked. It is passed as `-e wall -t` arg to async-profiler. | false   | no
+Name          | Type       | Description                                                                                                 | Default  | Required
+--------------|------------|-------------------------------------------------------------------------------------------------------------|----------|---------
+`interval`    | `duration` | How frequently to collect profiles from the targets.                                                        | "60s"    | no
+`cpu`         | `bool`     | A flag to enable cpu profiling, using `itimer` async-profiler event by default.                             | true     | no
+`sample_rate` | `int`      | CPU profiling sample rate. It is converted from Hz to interval and passed as an `-i` arg to async-profiler. | 100      | no
+`alloc`       | `string`   | Allocation profiling sampling configuration  It is passed as an `--alloc` arg to async-profiler.            | "512k"   | no
+`lock`        | `string`   | Lock profiling sampling configuration. It is passed as an `--lock` arg to async-profiler.                   | "10ms"   | no
+`event`       | `string`   | Sets the CPU profiling event. Can be one of `itimer`, `cpu` or `wall`.                                      | "itimer" | no
+`per_thread`  | `bool`     | Sets per thread mode on async profiler. It is passed as an `-t` arg to async-profiler.                      | false    | no
 
 Refer to [profiler-options](https://github.com/async-profiler/async-profiler?tab=readme-ov-file#profiler-options) for more information about async-profiler configuration.
+
+#### `event` argument
+
+Sets the CPU profiling event:
+* `itimer` - default, uses the [`setitimer(ITIMER_PROF)`](http://man7.org/linux/man-pages/man2/setitimer.2.html) 
+   syscall which generates a signal every time a process consumes CPU 
+* `cpu` - uses PMU-case sampling (like Intel PEBS or AMD IBS), can be more accurate than `itimer`, but it's not available in every platform.
+* `wall` - This sample all threads equally every given period of time regardless of thread status: Running, Sleeping or Blocked.
+   For instance, this can be helpful when profiling application start-up time or IO intensive processes.
+
+#### `per_thread` argument  
+Sets per thread mode on async profiler. Profile threads separately, each stack trace will end with a frame that denotes a single thread.
+
+The Wall-clock profiler (`event=wall`) is most useful in per-thread mode.
 
 ## Exported fields
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.java.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.java.md
@@ -84,13 +84,14 @@ The `profiling_config` block describes how async-profiler is invoked.
 
 The following arguments are supported:
 
-Name          | Type       | Description                                                                                              | Default | Required
---------------|------------|----------------------------------------------------------------------------------------------------------|---------|---------
-`interval`    | `duration` | How frequently to collect profiles from the targets.                                                     | "60s"   | no
-`cpu`         | `bool`     | A flag to enable cpu profiling, using `itimer` async-profiler event.                                     | true    | no
-`sample_rate` | `int`      | CPU profiling sample rate. It is converted from Hz to interval and passed as `-i` arg to async-profiler. | 100     | no
-`alloc`       | `string`   | Allocation profiling sampling configuration  It is passed as `--alloc` arg to async-profiler.            | "512k"  | no
-`lock`        | `string`   | Lock profiling sampling configuration. It is passed as `--lock` arg to async-profiler.                   | "10ms"  | no
+Name          | Type       | Description                                                                                                                                                                                                                          | Default | Required
+--------------|------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|---------
+`interval`    | `duration` | How frequently to collect profiles from the targets.                                                                                                                                                                                 | "60s"   | no
+`cpu`         | `bool`     | A flag to enable cpu profiling, using `itimer` async-profiler event.                                                                                                                                                                 | true    | no
+`sample_rate` | `int`      | CPU profiling sample rate. It is converted from Hz to interval and passed as `-i` arg to async-profiler.                                                                                                                             | 100     | no
+`alloc`       | `string`   | Allocation profiling sampling configuration  It is passed as `--alloc` arg to async-profiler.                                                                                                                                        | "512k"  | no
+`lock`        | `string`   | Lock profiling sampling configuration. It is passed as `--lock` arg to async-profiler.                                                                                                                                               | "10ms"  | no
+`wall`        | `bool`     | Activates the `wall` mode when `cpu` profiling is enabled. This sample all threads equally every given period of time regardless of thread status: Running, Sleeping or Blocked. It is passed as `-e wall -t` arg to async-profiler. | false   | no
 
 Refer to [profiler-options](https://github.com/async-profiler/async-profiler?tab=readme-ov-file#profiler-options) for more information about async-profiler configuration.
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.java.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.java.md
@@ -106,7 +106,7 @@ Sets the CPU profiling event:
    For example, this can be helpful when profiling application start-up time or IO-intensive processes.
 
 #### `per_thread` argument  
-Sets per thread mode on async profiler. Threads are profiled separately, each stack trace will end with a frame that denotes a single thread.
+Sets per thread mode on async profiler. Threads are profiled separately and each stack trace will end with a frame that denotes a single thread.
 
 The Wall-clock profiler (`event=wall`) is most useful in per-thread mode.
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.java.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.java.md
@@ -106,7 +106,7 @@ Sets the CPU profiling event:
    For example, this can be helpful when profiling application start-up time or IO-intensive processes.
 
 #### `per_thread` argument  
-Sets per thread mode on async profiler. Profile threads separately, each stack trace will end with a frame that denotes a single thread.
+Sets per thread mode on async profiler. Threads are profiled separately, each stack trace will end with a frame that denotes a single thread.
 
 The Wall-clock profiler (`event=wall`) is most useful in per-thread mode.
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.java.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.java.md
@@ -99,11 +99,11 @@ Refer to [profiler-options](https://github.com/async-profiler/async-profiler?tab
 #### `event` argument
 
 Sets the CPU profiling event:
-* `itimer` - default, uses the [`setitimer(ITIMER_PROF)`](http://man7.org/linux/man-pages/man2/setitimer.2.html) 
-   syscall which generates a signal every time a process consumes CPU 
-* `cpu` - uses PMU-case sampling (like Intel PEBS or AMD IBS), can be more accurate than `itimer`, but it's not available in every platform.
-* `wall` - This sample all threads equally every given period of time regardless of thread status: Running, Sleeping or Blocked.
-   For instance, this can be helpful when profiling application start-up time or IO intensive processes.
+* `itimer` - Default. Uses the [`setitimer(ITIMER_PROF)`](http://man7.org/linux/man-pages/man2/setitimer.2.html) 
+   syscall, which generates a signal every time a process consumes CPU. 
+* `cpu` - Uses PMU-case sampling (like Intel PEBS or AMD IBS), can be more accurate than `itimer`, but it's not available on every platform.
+* `wall` - This samples all threads equally every given period of time regardless of thread status: Running, Sleeping, or Blocked.
+   For example, this can be helpful when profiling application start-up time or IO-intensive processes.
 
 #### `per_thread` argument  
 Sets per thread mode on async profiler. Profile threads separately, each stack trace will end with a frame that denotes a single thread.

--- a/internal/component/pyroscope/java/args.go
+++ b/internal/component/pyroscope/java/args.go
@@ -21,6 +21,7 @@ type ProfilingConfig struct {
 	Alloc      string        `alloy:"alloc,attr,optional"`
 	Lock       string        `alloy:"lock,attr,optional"`
 	CPU        bool          `alloy:"cpu,attr,optional"`
+	Wall       bool          `alloy:"wall,attr,optional"`
 }
 
 func (rc *Arguments) UnmarshalAlloy(f func(interface{}) error) error {
@@ -38,6 +39,7 @@ func defaultArguments() Arguments {
 			Alloc:      "10ms",
 			Lock:       "512k",
 			CPU:        true,
+			Wall:       false,
 		},
 	}
 }

--- a/internal/component/pyroscope/java/args.go
+++ b/internal/component/pyroscope/java/args.go
@@ -1,6 +1,7 @@
 package java
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/grafana/alloy/internal/component/discovery"
@@ -21,13 +22,23 @@ type ProfilingConfig struct {
 	Alloc      string        `alloy:"alloc,attr,optional"`
 	Lock       string        `alloy:"lock,attr,optional"`
 	CPU        bool          `alloy:"cpu,attr,optional"`
-	Wall       bool          `alloy:"wall,attr,optional"`
+	Event      string        `alloy:"event,attr,optional"`
+	PerThread  bool          `alloy:"per_thread,attr,optional"`
 }
 
 func (rc *Arguments) UnmarshalAlloy(f func(interface{}) error) error {
 	*rc = defaultArguments()
 	type config Arguments
 	return f((*config)(rc))
+}
+
+func (arg *Arguments) Validate() error {
+	switch arg.ProfilingConfig.Event {
+	case "itimer", "cpu", "wall":
+		return nil
+	default:
+		return fmt.Errorf("invalid event: '%s'. Event but be one of 'itimer', 'cpu' or 'wall'", arg.ProfilingConfig.Event)
+	}
 }
 
 func defaultArguments() Arguments {
@@ -39,7 +50,8 @@ func defaultArguments() Arguments {
 			Alloc:      "10ms",
 			Lock:       "512k",
 			CPU:        true,
-			Wall:       false,
+			Event:      "itimer",
+			PerThread:  false,
 		},
 	}
 }

--- a/internal/component/pyroscope/java/args.go
+++ b/internal/component/pyroscope/java/args.go
@@ -37,7 +37,7 @@ func (arg *Arguments) Validate() error {
 	case "itimer", "cpu", "wall":
 		return nil
 	default:
-		return fmt.Errorf("invalid event: '%s'. Event but be one of 'itimer', 'cpu' or 'wall'", arg.ProfilingConfig.Event)
+		return fmt.Errorf("invalid event: '%s'. Event must be one of 'itimer', 'cpu' or 'wall'", arg.ProfilingConfig.Event)
 	}
 }
 

--- a/internal/component/pyroscope/java/loop.go
+++ b/internal/component/pyroscope/java/loop.go
@@ -183,7 +183,12 @@ func (p *profilingLoop) start() error {
 		"-o", "jfr",
 	)
 	if cfg.CPU {
-		argv = append(argv, "-e", "itimer")
+		if cfg.Wall {
+			argv = append(argv, "-e", "wall", "-t")
+		} else {
+			argv = append(argv, "-e", "itimer")
+		}
+
 		profilingInterval := time.Second.Nanoseconds() / int64(cfg.SampleRate)
 		argv = append(argv, "-i", strconv.FormatInt(profilingInterval, 10))
 	}

--- a/internal/component/pyroscope/java/loop.go
+++ b/internal/component/pyroscope/java/loop.go
@@ -183,12 +183,10 @@ func (p *profilingLoop) start() error {
 		"-o", "jfr",
 	)
 	if cfg.CPU {
-		if cfg.Wall {
-			argv = append(argv, "-e", "wall", "-t")
-		} else {
-			argv = append(argv, "-e", "itimer")
+		argv = append(argv, "-e", cfg.Event)
+		if cfg.PerThread {
+			argv = append(argv, "-t")
 		}
-
 		profilingInterval := time.Second.Nanoseconds() / int64(cfg.SampleRate)
 		argv = append(argv, "-i", strconv.FormatInt(profilingInterval, 10))
 	}


### PR DESCRIPTION
#### PR Description

The new `event` argument can be set to one of `itimer`, `cpu` and `wall`, like in the Pyroscope Java Agent:
https://grafana.com/docs/pyroscope/latest/configure-client/language-sdks/java/#configuration-options

Also add a parameter to allow enabling `per thread mode`, which should be used when setting the `wall` CPU event.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
