### PR TITLE
Add live debugging support to all otelcol receivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Main (unreleased)
 
 - Added live debugging support to `otelcol.processor.*` components. (@wildum)
 
+- Added live debugging support to `otelcol.receiver.*` components. (@wildum)
+
 - Added a `namespace` label to probes scraped by the `prometheus.operator.probes` component to align with the upstream Prometheus Operator setup. (@toontijtgat2)
 
 ### Bugfixes

--- a/docs/sources/troubleshoot/debug.md
+++ b/docs/sources/troubleshoot/debug.md
@@ -106,6 +106,7 @@ Live debugging is not yet available in all components.
 Supported components:
 * `prometheus.relabel`
 * `otelcol.processor.*`
+* `otelcol.receiver.*`
 {{< /admonition >}}
 
 

--- a/internal/component/otelcol/receiver/loki/loki.go
+++ b/internal/component/otelcol/receiver/loki/loki.go
@@ -12,8 +12,10 @@ import (
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/component/otelcol"
 	"github.com/grafana/alloy/internal/component/otelcol/internal/fanoutconsumer"
+	"github.com/grafana/alloy/internal/component/otelcol/internal/livedebuggingconsumer"
 	"github.com/grafana/alloy/internal/featuregate"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
+	"github.com/grafana/alloy/internal/service/livedebugging"
 	loki_translator "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -54,17 +56,32 @@ type Component struct {
 	mut      sync.RWMutex
 	receiver loki.LogsReceiver
 	logsSink consumer.Logs
+
+	liveDebuggingConsumer *livedebuggingconsumer.Consumer
+	debugDataPublisher    livedebugging.DebugDataPublisher
+
+	args Arguments
 }
 
-var _ component.Component = (*Component)(nil)
+var (
+	_ component.Component     = (*Component)(nil)
+	_ component.LiveDebugging = (*Component)(nil)
+)
 
 // New creates a new otelcol.receiver.loki component.
 func New(o component.Options, c Arguments) (*Component, error) {
+	debugDataPublisher, err := o.GetServiceData(livedebugging.ServiceName)
+	if err != nil {
+		return nil, err
+	}
+
 	// TODO(@tpaschalis) Create a metrics struct to count
 	// total/successful/errored log entries?
 	res := &Component{
-		log:  o.Logger,
-		opts: o,
+		log:                   o.Logger,
+		opts:                  o,
+		liveDebuggingConsumer: livedebuggingconsumer.New(debugDataPublisher.(livedebugging.DebugDataPublisher), o.ID),
+		debugDataPublisher:    debugDataPublisher.(livedebugging.DebugDataPublisher),
 	}
 
 	// Create and immediately export the receiver which remains the same for
@@ -102,8 +119,12 @@ func (c *Component) Update(newConfig component.Arguments) error {
 	c.mut.Lock()
 	defer c.mut.Unlock()
 
-	cfg := newConfig.(Arguments)
-	c.logsSink = fanoutconsumer.Logs(cfg.Output.Logs)
+	c.args = newConfig.(Arguments)
+	logs := c.args.Output.Logs
+	if c.debugDataPublisher.IsActive(livedebugging.ComponentID(c.opts.ID)) {
+		logs = append(logs, c.liveDebuggingConsumer)
+	}
+	c.logsSink = fanoutconsumer.Logs(logs)
 
 	return nil
 }
@@ -148,4 +169,8 @@ func convertLokiEntryToPlog(lokiEntry loki.Entry) plog.Logs {
 	loki_translator.ConvertEntryToLogRecord(&lokiEntry.Entry, &lr, lokiEntry.Labels, true)
 
 	return logs
+}
+
+func (c *Component) LiveDebugging(_ int) {
+	c.Update(c.args)
 }

--- a/internal/component/otelcol/receiver/prometheus/prometheus.go
+++ b/internal/component/otelcol/receiver/prometheus/prometheus.go
@@ -14,8 +14,10 @@ import (
 	"github.com/grafana/alloy/internal/component/otelcol"
 	otelcolCfg "github.com/grafana/alloy/internal/component/otelcol/config"
 	"github.com/grafana/alloy/internal/component/otelcol/internal/fanoutconsumer"
+	"github.com/grafana/alloy/internal/component/otelcol/internal/livedebuggingconsumer"
 	"github.com/grafana/alloy/internal/component/otelcol/receiver/prometheus/internal"
 	"github.com/grafana/alloy/internal/featuregate"
+	"github.com/grafana/alloy/internal/service/livedebugging"
 	"github.com/grafana/alloy/internal/util/zapadapter"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
@@ -65,15 +67,28 @@ type Component struct {
 	mut        sync.RWMutex
 	cfg        Arguments
 	appendable storage.Appendable
+
+	liveDebuggingConsumer *livedebuggingconsumer.Consumer
+	debugDataPublisher    livedebugging.DebugDataPublisher
 }
 
-var _ component.Component = (*Component)(nil)
+var (
+	_ component.Component     = (*Component)(nil)
+	_ component.LiveDebugging = (*Component)(nil)
+)
 
 // New creates a new otelcol.receiver.prometheus component.
 func New(o component.Options, c Arguments) (*Component, error) {
+	debugDataPublisher, err := o.GetServiceData(livedebugging.ServiceName)
+	if err != nil {
+		return nil, err
+	}
+
 	res := &Component{
-		log:  o.Logger,
-		opts: o,
+		log:                   o.Logger,
+		opts:                  o,
+		liveDebuggingConsumer: livedebuggingconsumer.New(debugDataPublisher.(livedebugging.DebugDataPublisher), o.ID),
+		debugDataPublisher:    debugDataPublisher.(livedebugging.DebugDataPublisher),
 	}
 
 	if err := res.Update(c); err != nil {
@@ -146,7 +161,11 @@ func (c *Component) Update(newConfig component.Arguments) error {
 			Version:     build.Version,
 		},
 	}
-	metricsSink := fanoutconsumer.Metrics(cfg.Output.Metrics)
+	metrics := cfg.Output.Metrics
+	if c.debugDataPublisher.IsActive(livedebugging.ComponentID(c.opts.ID)) {
+		metrics = append(metrics, c.liveDebuggingConsumer)
+	}
+	metricsSink := fanoutconsumer.Metrics(metrics)
 
 	appendable, err := internal.NewAppendable(
 		metricsSink,
@@ -168,4 +187,8 @@ func (c *Component) Update(newConfig component.Arguments) error {
 	c.opts.OnStateChange(Exports{Receiver: c.appendable})
 
 	return nil
+}
+
+func (c *Component) LiveDebugging(_ int) {
+	c.Update(c.cfg)
 }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR adds live debugging support to all otelcol receivers.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #1040 

#### Notes to the Reviewer

The PR follows the same pattern as the [live debugging support for processors](https://github.com/grafana/alloy/pull/1042).

I tested the following components:
- otelcol.receiver.otlp
- otelcol.receiver.prometheus
- otelcol.receiver.loki

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
