### PR TITLE
Rate limit how often components get notified about cluster changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ Main (unreleased)
 - (_Public preview_) Added rate limiting of cluster state changes to reduce the
   number of unnecessary, intermediate state updates. (@thampiotr)
 
-
 v1.2.1
 -----------------
 
@@ -48,9 +47,6 @@ v1.2.1
 ### Other
 
 - Use Go 1.22.5 for builds. (@mattdurham)
-
-- (_Public preview_) Added rate limiting of cluster state changes to reduce the
-  number of unnecessary, intermediate state updates. (@thampiotr)
 
 v1.2.0
 -----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ Main (unreleased)
 
 - Use Go 1.22.5 for builds. (@mattdurham)
 
+- (_Public preview_) Added rate limiting of cluster state changes to reduce the
+  number of unnecessary, intermediate state updates. (@thampiotr)
+
 v1.2.0
 -----------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ v1.2.1
 
 - Use Go 1.22.5 for builds. (@mattdurham)
 
+- (_Public preview_) Added rate limiting of cluster state changes to reduce the
+  number of unnecessary, intermediate state updates. (@thampiotr)
+
 v1.2.0
 -----------------
 

--- a/internal/alloycli/cluster_builder.go
+++ b/internal/alloycli/cluster_builder.go
@@ -25,16 +25,17 @@ type clusterOptions struct {
 	Metrics prometheus.Registerer
 	Tracer  trace.TracerProvider
 
-	EnableClustering    bool
-	NodeName            string
-	AdvertiseAddress    string
-	ListenAddress       string
-	JoinPeers           []string
-	DiscoverPeers       string
-	RejoinInterval      time.Duration
-	AdvertiseInterfaces []string
-	ClusterMaxJoinPeers int
-	ClusterName         string
+	EnableClustering          bool
+	NodeName                  string
+	AdvertiseAddress          string
+	ListenAddress             string
+	JoinPeers                 []string
+	DiscoverPeers             string
+	RejoinInterval            time.Duration
+	AdvertiseInterfaces       []string
+	ClusterMaxJoinPeers       int
+	ClusterName               string
+	EnableStateUpdatesLimiter bool
 }
 
 func buildClusterService(opts clusterOptions) (*cluster.Service, error) {
@@ -45,11 +46,12 @@ func buildClusterService(opts clusterOptions) (*cluster.Service, error) {
 		Metrics: opts.Metrics,
 		Tracer:  opts.Tracer,
 
-		EnableClustering:    opts.EnableClustering,
-		NodeName:            opts.NodeName,
-		RejoinInterval:      opts.RejoinInterval,
-		ClusterMaxJoinPeers: opts.ClusterMaxJoinPeers,
-		ClusterName:         opts.ClusterName,
+		EnableClustering:          opts.EnableClustering,
+		NodeName:                  opts.NodeName,
+		RejoinInterval:            opts.RejoinInterval,
+		ClusterMaxJoinPeers:       opts.ClusterMaxJoinPeers,
+		ClusterName:               opts.ClusterName,
+		EnableStateUpdatesLimiter: opts.EnableStateUpdatesLimiter,
 	}
 
 	if config.NodeName == "" {

--- a/internal/alloycli/cmd_run.go
+++ b/internal/alloycli/cmd_run.go
@@ -248,6 +248,8 @@ func (fr *alloyRun) Run(configPath string) error {
 		AdvertiseInterfaces: fr.clusterAdvInterfaces,
 		ClusterMaxJoinPeers: fr.ClusterMaxJoinPeers,
 		ClusterName:         fr.clusterName,
+		//TODO(add #issue number): graduate to GA once we have more confidence in this feature
+		EnableStateUpdatesLimiter: fr.minStability.Permits(featuregate.StabilityPublicPreview),
 	})
 	if err != nil {
 		return err

--- a/internal/alloycli/cmd_run.go
+++ b/internal/alloycli/cmd_run.go
@@ -248,7 +248,7 @@ func (fr *alloyRun) Run(configPath string) error {
 		AdvertiseInterfaces: fr.clusterAdvInterfaces,
 		ClusterMaxJoinPeers: fr.ClusterMaxJoinPeers,
 		ClusterName:         fr.clusterName,
-		//TODO(add #issue number): graduate to GA once we have more confidence in this feature
+		//TODO(alloy/#1274): graduate to GA once we have more confidence in this feature
 		EnableStateUpdatesLimiter: fr.minStability.Permits(featuregate.StabilityPublicPreview),
 	})
 	if err != nil {

--- a/internal/service/cluster/cluster.go
+++ b/internal/service/cluster/cluster.go
@@ -233,9 +233,9 @@ func (s *Service) Run(ctx context.Context, host service.Host) error {
 				span.RecordError(err)
 			}
 			span.End()
-
-			// Grab a fresh view of the peers for logging, since we may have waited a bit for the limiter to permit.
-			peers = s.node.Peers()
+			// NOTE: after waiting for the limiter, the `peers` may be slightly outdated, but that's fine as the
+			// most up-to-date peers will be dispatched to the Observer by ckit eventually. The intermediate updates
+			// will be skipped, which is exactly what we want here.
 		}
 
 		if ctx.Err() != nil {

--- a/internal/service/cluster/cluster.go
+++ b/internal/service/cluster/cluster.go
@@ -54,9 +54,10 @@ const (
 	// maxPeersToLog is the maximum number of peers to log on info level. All peers are logged on debug level.
 	maxPeersToLog = 10
 
-	// peersUpdateMinInterval is the minimum time interval between propagating peer changes to Alloy components.
+	// stateUpdateMinInterval is the minimum time interval between propagating peer changes to Alloy components.
 	// This allows to rate limit the number of updates when the cluster is frequently changing (e.g. during rollout).
-	peersUpdateMinInterval = time.Second
+	// This is only used when Options.EnableStateUpdatesLimiter is set to true.
+	stateUpdateMinInterval = time.Second
 )
 
 // Options are used to configure the cluster service. Options are constant for
@@ -71,11 +72,12 @@ type Options struct {
 	// possible for other nodes to join the cluster.
 	EnableClustering bool
 
-	NodeName            string        // Name to use for this node in the cluster.
-	AdvertiseAddress    string        // Address to advertise to other nodes in the cluster.
-	RejoinInterval      time.Duration // How frequently to rejoin the cluster to address split brain issues.
-	ClusterMaxJoinPeers int           // Number of initial peers to join from the discovered set.
-	ClusterName         string        // Name to prevent nodes without this identifier from joining the cluster.
+	NodeName                  string        // Name to use for this node in the cluster.
+	AdvertiseAddress          string        // Address to advertise to other nodes in the cluster.
+	RejoinInterval            time.Duration // How frequently to rejoin the cluster to address split brain issues.
+	ClusterMaxJoinPeers       int           // Number of initial peers to join from the discovered set.
+	ClusterName               string        // Name to prevent nodes without this identifier from joining the cluster.
+	EnableStateUpdatesLimiter bool          // Enables rate limiting of state updates to components.
 
 	// Function to discover peers to join. If this function is nil or returns an
 	// empty slice, no peers will be joined.
@@ -215,15 +217,15 @@ func (s *Service) Run(ctx context.Context, host service.Host) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	limiter := rate.NewLimiter(rate.Every(peersUpdateMinInterval), 1)
+	limiter := rate.NewLimiter(rate.Every(stateUpdateMinInterval), 1)
 	s.node.Observe(ckit.FuncObserver(func(_ []peer.Peer) (reregister bool) {
 		tracer := s.tracer.Tracer("")
 		spanCtx, span := tracer.Start(ctx, "NotifyClusterChange", trace.WithSpanKind(trace.SpanKindInternal))
 		defer span.End()
 
-		// Limit how often we notify components about peer changes. At start up we may receive N updates in a period
-		// of less than one second. This leads to a lot of unnecessary processing.
-		{
+		if s.opts.EnableStateUpdatesLimiter {
+			// Limit how often we notify components about peer changes. At start up we may receive N updates in a period
+			// of less than one second. This leads to a lot of unnecessary processing.
 			_, span := tracer.Start(spanCtx, "RateLimitWait", trace.WithSpanKind(trace.SpanKindInternal))
 			if err := limiter.Wait(ctx); err != nil {
 				// This should never happen, but it should be safe to just ignore it and continue.


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

In a larger cluster we'd get a lot of cluster updates during startup that are propagated to all observing components. This leads to unnecessary processing at startup which can delay the startup and it can generate a lot of logs and tracing spans where it's not really helpful or required. In the extreme case, when cluster is very large, the number of log messages generated can be noticeable and some users have reported it previously as a bug.

With this PR, the call to Observe is rate-limited at 1 update per second. Intermediate updates while we're waiting for the limiter are not sent by `ckit`, but that's okay cause a call to Observe only notifies all the components, which subsequently get the most up-to-date list of peers from the service directly (or check data ownership with the service).

This change also adds a tracing span to allow observing this behaviour.

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

If I query logs on a test cluster of 22 instances during a rollout using something like `sum by(pod) (count_over_time({cluster="...", namespace="..."} |= `peers changed` [1m]))` I will currently get a volume of logs that looks something like this:

![image](https://github.com/grafana/alloy/assets/17101802/e64a3243-8bc9-4636-8510-26564b5130d9)

After this change, it'll be something more like this:
![image](https://github.com/grafana/alloy/assets/17101802/36b7dd4e-994d-4419-affa-c3b1491d6380)

Also, here's an example of traces:
![image](https://github.com/grafana/alloy/assets/17101802/fe4b3bc1-a06a-4f68-b0d0-f9c6427283e2)
