### PR TITLE
Fix cluster fail fast and CRD manager panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ Main (unreleased)
 - (_Public preview_) Added rate limiting of cluster state changes to reduce the
   number of unnecessary, intermediate state updates. (@thampiotr)
 
+### Bugfixes
+
+- Fixed a clustering mode issue where a fatal startup failure of the clustering service
+  would exit the service silently, without also exiting the Alloy process. (@thampiotr)
+
 v1.2.1
 -----------------
 

--- a/internal/component/prometheus/operator/common/crdmanager.go
+++ b/internal/component/prometheus/operator/common/crdmanager.go
@@ -194,13 +194,11 @@ func filterTargets(m map[string][]*targetgroup.Group, c cluster.Cluster) map[str
 			// as each node does this consistently.
 			for _, t := range group.Targets {
 				peers, err := c.Lookup(shard.StringKey(nonMetaLabelString(t)), 1, shard.OpReadWrite)
-				if err != nil {
-					// This can only fail in case we ask for more owners than the
-					// available peers. This should never happen, but in any case we fall
+				if len(peers) == 0 || err != nil {
+					// If the cluster found no peers or returned an error, we fall
 					// back to owning the target ourselves.
 					g2.Targets = append(g2.Targets, t)
-				}
-				if peers[0].Self {
+				} else if peers[0].Self {
 					g2.Targets = append(g2.Targets, t)
 				}
 			}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

With [this change ](https://github.com/grafana/alloy/pull/1242) we have fixed the error handling behaviour in clustering:
When using dynamic discovery and discovery failing at startup, clustering service would return an error from its `Run` signalling a fatal error. However when using static discovery, clustering service would continue and create its own cluster, silently failing peer discovery. We prefer the failing fast and failing hard behaviour at startup and misconfiguration to prevent a large cluster going split-brain. Thus we made static discovery in-line with the dynamic discovery error handling and `Run` method returns an error when static discovery fails. 

There is however, another issue in that returning an error from `Run` method of a service is not fatal and also [not printed as a warning / error on any level](https://github.com/grafana/alloy/blob/4b1eb1b8b6141e0c61876791942e69b66cd4e73e/internal/runtime/internal/controller/scheduler.go#L140). Other services such [as HTTP run os.Exit on fatal errors](https://github.com/grafana/alloy/issues/843) currently as a workaround. 

In this PR:
- We add the same logic as in HTTP service to Clustering service to fail hard on fatal errors.
- We also fix a panic in CRD manager where the set of `peers` returned from cluster is not checked if its empty. Other callers do [check](https://github.com/grafana/alloy/blob/12fb27390f07973c5ec053ed27dfaa65b423bf51/internal/component/discovery/distributed_targets.go#L38) for [empty](https://github.com/grafana/alloy/blob/4b1eb1b8b6141e0c61876791942e69b66cd4e73e/internal/component/loki/source/podlogs/reconciler.go#L150) list of [peers](https://github.com/grafana/alloy/blob/be34410b9e841cc0c37c153f9550d9086a304bca/internal/component/mimir/rules/kubernetes/rules.go#L521) and it doesn't seem to be a guarantee that there will always be peers returned.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

Before the changes:
```
./alloy-darwin-arm64 run config.alloy --cluster.enabled=true --cluster.join-addresses=wrong.address.com
ts=2024-07-12T15:36:19.38364Z level=info "boringcrypto enabled"=false
ts=2024-07-12T15:36:19.383675Z level=info msg="running usage stats reporter"
ts=2024-07-12T15:36:19.383678Z level=info msg="starting complete graph evaluation" controller_path=/ controller_id="" trace_id=ae7713179c987898a37c949fed51c098
ts=2024-07-12T15:36:19.383682Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=ae7713179c987898a37c949fed51c098 node_id=otel duration=9.75µs
ts=2024-07-12T15:36:19.383688Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=ae7713179c987898a37c949fed51c098 node_id=livedebugging duration=22.667µs
ts=2024-07-12T15:36:19.383691Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=ae7713179c987898a37c949fed51c098 node_id=labelstore duration=3.083µs
ts=2024-07-12T15:36:19.383693Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=ae7713179c987898a37c949fed51c098 node_id=tracing duration=1.959µs
ts=2024-07-12T15:36:19.383724Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=ae7713179c987898a37c949fed51c098 node_id=logging duration=102.583µs
ts=2024-07-12T15:36:19.383772Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=ae7713179c987898a37c949fed51c098 node_id=remotecfg duration=38.25µs
ts=2024-07-12T15:36:19.38378Z level=info msg="applying non-TLS config to HTTP server" service=http
ts=2024-07-12T15:36:19.383782Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=ae7713179c987898a37c949fed51c098 node_id=http duration=4.875µs
ts=2024-07-12T15:36:19.383787Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=ae7713179c987898a37c949fed51c098 node_id=ui duration=208ns
ts=2024-07-12T15:36:19.383792Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=ae7713179c987898a37c949fed51c098 node_id=cluster duration=792ns
ts=2024-07-12T15:36:19.383796Z level=info msg="finished complete graph evaluation" controller_path=/ controller_id="" trace_id=ae7713179c987898a37c949fed51c098 duration=324.542µs
ts=2024-07-12T15:36:19.383813Z level=info msg="scheduling loaded components and services"
ts=2024-07-12T15:36:19.384435Z level=info msg="now listening for http traffic" service=http addr=127.0.0.1:12345
ts=2024-07-12T15:36:19.410664Z level=warn msg="failed to resolve SRV records" service=cluster addr=wrong.address.com err="lookup wrong.address.com on 192.168.0.1:53: no such host"
```
^ the clustering service has exited at this point and there's no indication of any issue. But attempts to find peers will return empty arrays (and thus the CRD manager will panic if it runs). I can see in the UI that there are no peers (not even local instance itself):
![image](https://github.com/user-attachments/assets/d4c2f37b-3414-48c4-9e7a-ae7331ffd793)

And also can see the clustering service is gone because the below goroutine is missing:
```
1 @ 0x102bc5918 0x102b8eee4 0x102b8eaa4 0x1057c035c 0x10566c14c 0x10566d2e8 0x102c003a4
#	0x1057c035b	github.com/grafana/alloy/internal/service/cluster.(*Service).Run+0x5ab			/drone/src/internal/service/cluster/cluster.go:305
```

After the changes:
```
alloy run config.alloy --cluster.enabled=true --cluster.join-addresses=wrong.address.com
ts=2024-07-12T15:27:23.329731Z level=info "boringcrypto enabled"=false
ts=2024-07-12T15:27:23.330165Z level=info msg="starting complete graph evaluation" controller_path=/ controller_id="" trace_id=4870f047d8ccc40c66ccc40dedf05b15
ts=2024-07-12T15:27:23.330178Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=4870f047d8ccc40c66ccc40dedf05b15 node_id=logging duration=578.917µs
ts=2024-07-12T15:27:23.330348Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=4870f047d8ccc40c66ccc40dedf05b15 node_id=remotecfg duration=162.292µs
ts=2024-07-12T15:27:23.330362Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=4870f047d8ccc40c66ccc40dedf05b15 node_id=labelstore duration=2.25µs
ts=2024-07-12T15:27:23.330368Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=4870f047d8ccc40c66ccc40dedf05b15 node_id=tracing duration=1.584µs
ts=2024-07-12T15:27:23.330372Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=4870f047d8ccc40c66ccc40dedf05b15 node_id=otel duration=292ns
ts=2024-07-12T15:27:23.330381Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=4870f047d8ccc40c66ccc40dedf05b15 node_id=livedebugging duration=4.542µs
ts=2024-07-12T15:27:23.330387Z level=info msg="applying non-TLS config to HTTP server" service=http
ts=2024-07-12T15:27:23.33042Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=4870f047d8ccc40c66ccc40dedf05b15 node_id=http duration=34.709µs
ts=2024-07-12T15:27:23.330426Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=4870f047d8ccc40c66ccc40dedf05b15 node_id=ui duration=334ns
ts=2024-07-12T15:27:23.330431Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=4870f047d8ccc40c66ccc40dedf05b15 node_id=cluster duration=208ns
ts=2024-07-12T15:27:23.330434Z level=info msg="finished complete graph evaluation" controller_path=/ controller_id="" trace_id=4870f047d8ccc40c66ccc40dedf05b15 duration=1.035458ms
ts=2024-07-12T15:27:23.330449Z level=info msg="scheduling loaded components and services"
ts=2024-07-12T15:27:23.330335Z level=info msg="running usage stats reporter"
ts=2024-07-12T15:27:23.332872Z level=info msg="now listening for http traffic" service=http addr=127.0.0.1:12345
ts=2024-07-12T15:27:23.362989Z level=warn msg="failed to resolve SRV records" service=cluster addr=wrong.address.com err="lookup wrong.address.com on 192.168.0.1:53: no such host"
ts=2024-07-12T15:27:23.36302Z level=error msg="fatal error: failed to get peers to join at startup - this is likely a configuration error" service=cluster err="static peer discovery: failed to find any valid join addresses: address wrong.address.com: missing port in address\nlookup wrong.address.com on 192.168.0.1:53: no such host"
```
^ process exits with status 1

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
