### PR TITLE
Add a brief explanation how to collect different telemetry

### DIFF
--- a/docs/sources/collect/choose-component.md
+++ b/docs/sources/collect/choose-component.md
@@ -1,0 +1,72 @@
+---
+canonical: https://grafana.com/docs/alloy/latest/collect/choose-component/
+description: Find out which components are useful for which tasks
+title: Choose an Alloy component
+weight: 100
+---
+
+# Choose an Alloy component
+
+[Components][components] are the building blocks of Alloy, and there is a [large number of them][components-ref].
+The components you select and configure depend on the telemetry signals you want to collect.
+
+[components]: ../../get-started/components/
+[components-ref]: ../../reference/components/
+
+## Metrics for infrastructure
+
+Use `prometheus.*` components to collect infrastructure metrics.
+This will give you the best experience with [Grafana Infrastructure Observability][].
+
+For example, you can get metrics for a Linux host using `prometheus.exporter.unix`, 
+and metrics for a MongoDB instance using `prometheus.exporter.mongodb`. 
+
+You can also scrape any Prometheus endpoint using `prometheus.scrape`.
+Use `discovery.*` components to find targets for `prometheus.scrape`.
+
+[Grafana Infrastructure Observability]:https://grafana.com/docs/grafana-cloud/monitor-infrastructure/
+
+## Metrics for applications
+
+Use `otelcol.receiver.*` components to collect application metrics.
+This will give you the best experience with [Grafana Application Observability][], which is OpenTelemetry-native.
+
+For example, use `otelcol.receiver.otlp` to collect metrics from OpenTelemetry-instrumented applications.
+
+If your application is already instrumented with Prometheus metrics, there is no need to use `otelcol.*` components.
+Use `prometheus.*` components for the entire pipeline and send the metrics using `prometheus.remote_write`.
+
+[Grafana Application Observability]:https://grafana.com/docs/grafana-cloud/monitor-applications/application-observability/introduction/
+
+## Logs from infrastructure
+
+Use `loki.*` components to collect infrastructure logs.
+The `loki.*` components label your logs in a way that resembles Prometheus metrics.
+This makes it easy to correlate infrastructure metrics collected by `prometheus.*` components
+with logs collected by `loki.*` components.
+
+For example, the label that both `prometheus.*` and `loki.*` components would use for a Kubernetes namespace is called `namespace`.
+On the other hand, gathering logs using an `otelcol.*` component might use the [OpenTelemetry semantics][OTel-semantics] label called `k8s.namespace.name`,
+which wouldn't correspond to the `namespace` label that is common in the Prometheus ecosystem.
+
+## Logs from applications
+
+Use `otelcol.receiver.*` components to collect application logs.
+This will gather the application logs in an OpenTelemetry-native way, making it easier to 
+correlate the logs with OpenTelemetry metrics and traces coming from the application.
+All application telemetry must follow the [OpenTelemetry semantic conventions][OTel-semantics], simplifying this correlation.
+
+For example, if your application runs on Kubernetes, every trace, log, and metric can have a `k8s.namespace.name` resource attribute.
+
+
+[OTel-semantics]:https://opentelemetry.io/docs/concepts/semantic-conventions/
+
+## Traces
+
+Use `otelcol.receiver.*` components to collect traces.
+
+If your application is not yet instrumented for tracing, use `beyla.ebpf` to generate traces for it automatically.
+
+## Profiles
+
+Use `pyroscope.*` components to collect profiles.

--- a/docs/sources/collect/choose-component.md
+++ b/docs/sources/collect/choose-component.md
@@ -1,13 +1,14 @@
 ---
 canonical: https://grafana.com/docs/alloy/latest/collect/choose-component/
 description: Find out which components are useful for which tasks
-title: Choose an Alloy component
+title: Choose a Grafana Alloy component
+menuTitle: Choose a component
 weight: 100
 ---
 
-# Choose an Alloy component
+# Choose a  {{< param "FULL_PRODUCT_NAME" >}} component
 
-[Components][components] are the building blocks of Alloy, and there is a [large number of them][components-ref].
+[Components][components] are the building blocks of {{< param "FULL_PRODUCT_NAME" >}}, and there is a [large number of them][components-ref].
 The components you select and configure depend on the telemetry signals you want to collect.
 
 [components]: ../../get-started/components/
@@ -57,7 +58,6 @@ correlate the logs with OpenTelemetry metrics and traces coming from the applica
 All application telemetry must follow the [OpenTelemetry semantic conventions][OTel-semantics], simplifying this correlation.
 
 For example, if your application runs on Kubernetes, every trace, log, and metric can have a `k8s.namespace.name` resource attribute.
-
 
 [OTel-semantics]:https://opentelemetry.io/docs/concepts/semantic-conventions/
 

--- a/docs/sources/reference/components/_index.md
+++ b/docs/sources/reference/components/_index.md
@@ -12,3 +12,63 @@ This section contains reference documentation for all recognized [components][].
 {{< section >}}
 
 [components]: ../../get-started/components/
+
+## How to collect different telemetry signals
+
+### Metrics for infrastructure
+
+Use `prometheus.*` components for collecting infrastructure metrics.
+This will give you the best experience with [Grafana Infrastructure Observability][].
+
+For example, you can get metrics for a Linux host using `prometheus.exporter.unix`, 
+and metrics for a MongoDB instance using `prometheus.exporter.mongodb`. 
+
+You can also scrape any Prometheus endpoint using `prometheus.scrape`.
+Use `discovery.*` components to find targets for `prometheus.scrape`.
+
+[Grafana Infrastructure Observability]:https://grafana.com/docs/grafana-cloud/monitor-infrastructure/
+
+### Metrics for applications
+
+Use `otelcol.receiver.*` components for collecting application metrics.
+This will give you the best experience with [Grafana Application Observability][], which is OpenTelemetry-native.
+
+For example, use `otelcol.receiver.otlp` to collect metrics from OpenTelemetry-instrumented applications.
+
+If your application is already instrumented with Prometheus metrics, there is no need to use `otelcol.*` components.
+Use `prometheus.*` components for the entire pipeline and send the metrics using `prometheus.remote_write`.
+
+[Grafana Application Observability]:https://grafana.com/docs/grafana-cloud/monitor-applications/application-observability/introduction/
+
+### Logs from infrastructure
+
+Use `loki.*` components to collect infrastructure logs.
+The `loki.*` components label your logs in a way which resembles Prometheus metrics.
+This makes it easy to correlate infrastructure metrics collected by `prometheus.*` components
+with logs collected by `loki.*` components.
+
+For example, the label which both `prometheus.*` and `loki.*` components would use for a Kubernetes namespace is called `namespace`.
+On the other hand, gathering logs using an `otelcol.*` component might use the [OpenTelemetry semantics][OTel-semantics] label called `k8s.namespace.name`,
+which wouldn't correspond to the `namespace` label that is common in the Prometheus ecosystem.
+
+### Logs from applications
+
+Use `otelcol.receiver.*` components to collect application logs.
+This will gather the application logs in an OpenTelemetry-native way, which will make it easier to 
+correlate the logs with OpenTelemetry metrics and traces coming from the application.
+To make this correlation easier, all application telemetry must follow the [OpenTelemetry semantic conventions][OTel-semantics].
+
+For example, if your application is running on Kubernetes, every trace, log, and metric may have a `k8s.namespace.name` resource attribute.
+
+
+[OTel-semantics]:https://opentelemetry.io/docs/concepts/semantic-conventions/
+
+### Traces
+
+Use `otelcol.receiver.*` components for collecting traces.
+
+If your application is not yet instrumented for tracing, use `beyla.ebpf` to generate traces for it automatically.
+
+### Profiles
+
+Use `pyroscope.*` components to collect profiles.

--- a/docs/sources/reference/components/_index.md
+++ b/docs/sources/reference/components/_index.md
@@ -13,11 +13,14 @@ This section contains reference documentation for all recognized [components][].
 
 [components]: ../../get-started/components/
 
-## How to collect different telemetry signals
+## Collect different telemetry signals
+
+Components are the building blocks of Alloy. The components you select and configure depend on the telemetry signals you want to collect.
+
 
 ### Metrics for infrastructure
 
-Use `prometheus.*` components for collecting infrastructure metrics.
+Use `prometheus.*` components to collect infrastructure metrics.
 This will give you the best experience with [Grafana Infrastructure Observability][].
 
 For example, you can get metrics for a Linux host using `prometheus.exporter.unix`, 
@@ -30,7 +33,7 @@ Use `discovery.*` components to find targets for `prometheus.scrape`.
 
 ### Metrics for applications
 
-Use `otelcol.receiver.*` components for collecting application metrics.
+Use `otelcol.receiver.*` components to collect application metrics.
 This will give you the best experience with [Grafana Application Observability][], which is OpenTelemetry-native.
 
 For example, use `otelcol.receiver.otlp` to collect metrics from OpenTelemetry-instrumented applications.
@@ -43,29 +46,29 @@ Use `prometheus.*` components for the entire pipeline and send the metrics using
 ### Logs from infrastructure
 
 Use `loki.*` components to collect infrastructure logs.
-The `loki.*` components label your logs in a way which resembles Prometheus metrics.
+The `loki.*` components label your logs in a way that resembles Prometheus metrics.
 This makes it easy to correlate infrastructure metrics collected by `prometheus.*` components
 with logs collected by `loki.*` components.
 
-For example, the label which both `prometheus.*` and `loki.*` components would use for a Kubernetes namespace is called `namespace`.
+For example, the label that both `prometheus.*` and `loki.*` components would use for a Kubernetes namespace is called `namespace`.
 On the other hand, gathering logs using an `otelcol.*` component might use the [OpenTelemetry semantics][OTel-semantics] label called `k8s.namespace.name`,
 which wouldn't correspond to the `namespace` label that is common in the Prometheus ecosystem.
 
 ### Logs from applications
 
 Use `otelcol.receiver.*` components to collect application logs.
-This will gather the application logs in an OpenTelemetry-native way, which will make it easier to 
+This will gather the application logs in an OpenTelemetry-native way, making it easier to 
 correlate the logs with OpenTelemetry metrics and traces coming from the application.
-To make this correlation easier, all application telemetry must follow the [OpenTelemetry semantic conventions][OTel-semantics].
+All application telemetry must follow the [OpenTelemetry semantic conventions][OTel-semantics], simplifying this correlation.
 
-For example, if your application is running on Kubernetes, every trace, log, and metric may have a `k8s.namespace.name` resource attribute.
+For example, if your application runs on Kubernetes, every trace, log, and metric can have a `k8s.namespace.name` resource attribute.
 
 
 [OTel-semantics]:https://opentelemetry.io/docs/concepts/semantic-conventions/
 
 ### Traces
 
-Use `otelcol.receiver.*` components for collecting traces.
+Use `otelcol.receiver.*` components to collect traces.
 
 If your application is not yet instrumented for tracing, use `beyla.ebpf` to generate traces for it automatically.
 

--- a/docs/sources/reference/components/_index.md
+++ b/docs/sources/reference/components/_index.md
@@ -8,7 +8,7 @@ weight: 300
 # Components
 
 This section contains reference documentation for all recognized [components][].
-For a birds eye view on the components ecosystem, refer to the [Choose a component][choose-component] page.
+Refer to [Choose a Grafana Alloy component][choose-component] for an overview of the components ecosystem.
 
 {{< section >}}
 

--- a/docs/sources/reference/components/_index.md
+++ b/docs/sources/reference/components/_index.md
@@ -8,70 +8,9 @@ weight: 300
 # Components
 
 This section contains reference documentation for all recognized [components][].
+For a birds eye view on the components ecosystem, refer to the [Choose a component][choose-component] page.
 
 {{< section >}}
 
 [components]: ../../get-started/components/
-
-## Collect different telemetry signals
-
-Components are the building blocks of Alloy. The components you select and configure depend on the telemetry signals you want to collect.
-
-
-### Metrics for infrastructure
-
-Use `prometheus.*` components to collect infrastructure metrics.
-This will give you the best experience with [Grafana Infrastructure Observability][].
-
-For example, you can get metrics for a Linux host using `prometheus.exporter.unix`, 
-and metrics for a MongoDB instance using `prometheus.exporter.mongodb`. 
-
-You can also scrape any Prometheus endpoint using `prometheus.scrape`.
-Use `discovery.*` components to find targets for `prometheus.scrape`.
-
-[Grafana Infrastructure Observability]:https://grafana.com/docs/grafana-cloud/monitor-infrastructure/
-
-### Metrics for applications
-
-Use `otelcol.receiver.*` components to collect application metrics.
-This will give you the best experience with [Grafana Application Observability][], which is OpenTelemetry-native.
-
-For example, use `otelcol.receiver.otlp` to collect metrics from OpenTelemetry-instrumented applications.
-
-If your application is already instrumented with Prometheus metrics, there is no need to use `otelcol.*` components.
-Use `prometheus.*` components for the entire pipeline and send the metrics using `prometheus.remote_write`.
-
-[Grafana Application Observability]:https://grafana.com/docs/grafana-cloud/monitor-applications/application-observability/introduction/
-
-### Logs from infrastructure
-
-Use `loki.*` components to collect infrastructure logs.
-The `loki.*` components label your logs in a way that resembles Prometheus metrics.
-This makes it easy to correlate infrastructure metrics collected by `prometheus.*` components
-with logs collected by `loki.*` components.
-
-For example, the label that both `prometheus.*` and `loki.*` components would use for a Kubernetes namespace is called `namespace`.
-On the other hand, gathering logs using an `otelcol.*` component might use the [OpenTelemetry semantics][OTel-semantics] label called `k8s.namespace.name`,
-which wouldn't correspond to the `namespace` label that is common in the Prometheus ecosystem.
-
-### Logs from applications
-
-Use `otelcol.receiver.*` components to collect application logs.
-This will gather the application logs in an OpenTelemetry-native way, making it easier to 
-correlate the logs with OpenTelemetry metrics and traces coming from the application.
-All application telemetry must follow the [OpenTelemetry semantic conventions][OTel-semantics], simplifying this correlation.
-
-For example, if your application runs on Kubernetes, every trace, log, and metric can have a `k8s.namespace.name` resource attribute.
-
-
-[OTel-semantics]:https://opentelemetry.io/docs/concepts/semantic-conventions/
-
-### Traces
-
-Use `otelcol.receiver.*` components to collect traces.
-
-If your application is not yet instrumented for tracing, use `beyla.ebpf` to generate traces for it automatically.
-
-### Profiles
-
-Use `pyroscope.*` components to collect profiles.
+[choose-component]: ../../collect/choose-component/


### PR DESCRIPTION
Alloy support Prometheus-native, Loki-native, and OTel-native components. I hope this document clarifies when it's recommended to use which component.

I think the Components page is a natural fit for this, since it's a birds eye view on which components need to be used. If someone lands on the Components page for the first time, they might be confused about what to click on if there is no such content.