### PR TITLE
docs: Make supported language explicit

### DIFF
--- a/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
@@ -19,9 +19,9 @@ You can specify multiple `pyroscope.ebpf` components by giving them different la
 
 ## Supported languages
 
-This eBPF profiler only collects CPU profiles. Generally natively compiled languages like C/C++, Go, Rust are supported (also see [Troubleshooting]({{< relref "#troubleshooting" >}}) for additional requirements).
+This eBPF profiler only collects CPU profiles. Generally, natively compiled languages like C/C++, Go, and Rust are supported. Refer to [Troubleshooting unknown symbols](#troubleshooting-unknown-symbols) for additional requirements.
 
-The only high-level language supported is Python (as long as `python_enabled=true`). Other high-level languages like Java, Ruby, PHP, JavaScript, etc. will require some additional work in order to correctly show stack traces of methods in these languages. Currently their CPU usage will be displayed belonging to the runtime's methods instead.
+Python is the only supported high-level language, as long as `python_enabled=true`. Other high-level languages like Java, Ruby, PHP, and JavaScript require additional work to show stack traces of methods in these languages correctly. Currently, their CPU usage will be reported belonging to the runtime's methods instead.
 
 ## Usage
 
@@ -119,7 +119,7 @@ If it's not specified, it's attempted to be inferred from multiple sources:
 
 If `service_name` isn't specified and couldn't be inferred, it's set to `unspecified`.
 
-## Troubleshooting unknown symbols {#troubleshooting}
+## Troubleshooting unknown symbols
 
 Symbols are extracted from various sources, including:
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
@@ -8,7 +8,7 @@ title: pyroscope.ebpf
 
 # pyroscope.ebpf
 
-`pyroscope.ebpf` configures an ebpf profiling job for the current host.
+`pyroscope.ebpf` configures an eBPF profiling job for the current host.
 The collected performance profiles are forwarded to the list of receivers passed in `forward_to`.
 
 {{< admonition type="note" >}}
@@ -16,6 +16,12 @@ To use the  `pyroscope.ebpf` component you must run {{< param "PRODUCT_NAME" >}}
 {{< /admonition >}}
 
 You can specify multiple `pyroscope.ebpf` components by giving them different labels, however it's not recommended as it can lead to additional memory and CPU usage.
+
+## Supported languages
+
+This eBPF profiler only collects CPU profiles. Generally natively compiled languages like C/C++, Go, Rust are supported (also see [Troubleshooting]({{< relref "#troubleshooting" >}}) for additional requirements).
+
+The only high-level language supported is Python (as long as `python_enabled=true`). Other high-level languages like Java, Ruby, PHP, JavaScript, etc. will require some additional work in order to correctly show stack traces of methods in these languages. Currently their CPU usage will be displayed belonging to the runtime's methods instead.
 
 ## Usage
 
@@ -28,7 +34,7 @@ pyroscope.ebpf "LABEL" {
 
 ## Arguments
 
-The component configures and starts a new ebpf profiling job to collect performance profiles from the current host.
+The component configures and starts a new eBPF profiling job to collect performance profiles from the current host.
 
 You can use the following arguments to configure a `pyroscope.ebpf`.
 Only the `forward_to` and `targets` fields are required.
@@ -71,7 +77,7 @@ Name                      | Type                     | Description              
 * `pyroscope_ebpf_active_targets` (gauge): Number of active targets the component tracks.
 * `pyroscope_ebpf_profiling_sessions_total` (counter): Number of profiling sessions completed.
 * `pyroscope_ebpf_profiling_sessions_failing_total` (counter): Number of profiling sessions failed.
-* `pyroscope_ebpf_pprofs_total` (counter): Number of pprof profiles collected by the ebpf component.
+* `pyroscope_ebpf_pprofs_total` (counter): Number of pprof profiles collected by the eBPF component.
 
 ## Profile collecting behavior
 
@@ -113,7 +119,7 @@ If it's not specified, it's attempted to be inferred from multiple sources:
 
 If `service_name` isn't specified and couldn't be inferred, it's set to `unspecified`.
 
-## Troubleshooting unknown symbols
+## Troubleshooting unknown symbols {#troubleshooting}
 
 Symbols are extracted from various sources, including:
 
@@ -171,13 +177,6 @@ If your profiles show many shallow stack traces, typically 1-2 frames deep, your
 
 To compile your code with frame pointers, include the `-fno-omit-frame-pointer` flag in your compiler options.
 
-### Profiling interpreted languages
-
-Profiling interpreted languages like Python, Ruby, JavaScript, etc., isn't ideal using this implementation.
-The JIT-compiled methods in these languages are typically not in ELF file format, demanding additional steps for profiling.
-For instance, using perf-map-agent and enabling frame pointers for Java.
-
-Interpreted methods will display the interpreter function’s name rather than the actual function.
 
 ## Example
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
@@ -19,7 +19,7 @@ You can specify multiple `pyroscope.ebpf` components by giving them different la
 
 ## Supported languages
 
-This eBPF profiler only collects CPU profiles. Generally, natively compiled languages like C/C++, Go, and Rust are supported. Refer to [Troubleshooting unknown symbols](#troubleshooting-unknown-symbols) for additional requirements.
+This eBPF profiler only collects CPU profiles. Generally, natively compiled languages like C/C++, Go, and Rust are supported. Refer to [Troubleshooting unknown symbols][troubleshooting] for additional requirements.
 
 Python is the only supported high-level language, as long as `python_enabled=true`. Other high-level languages like Java, Ruby, PHP, and JavaScript require additional work to show stack traces of methods in these languages correctly. Currently, their CPU usage will be reported belonging to the runtime's methods instead.
 
@@ -127,7 +127,7 @@ Symbols are extracted from various sources, including:
 - The `.symtab` and `.dynsym` sections in the debug ELF file.
 - The `.gopclntab` section in Go language ELF files.
 
-The search for debug files follows [gdb algorithm](https://sourceware.org/gdb/onlinedocs/gdb/Separate-Debug-Files.html).
+The search for debug files follows [gdb algorithm].
 For example, if the profiler wants to find the debug file for `/lib/x86_64-linux-gnu/libc.so.6` with a `.gnu_debuglink` set to `libc.so.6.debug` and a build ID `0123456789abcdef`.
 The following paths are examined:
 
@@ -277,6 +277,10 @@ pyroscope.ebpf "default" {
   targets      = discovery.relabel.local_containers.output
 }
 ```
+
+[troubleshooting]: #troubleshooting-unknown-symbols
+[gdb algorithm]: https://sourceware.org/gdb/onlinedocs/gdb/Separate-Debug-Files.html
+
 <!-- START GENERATED COMPATIBLE COMPONENTS -->
 
 ## Compatible components

--- a/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
@@ -21,7 +21,9 @@ You can specify multiple `pyroscope.ebpf` components by giving them different la
 
 This eBPF profiler only collects CPU profiles. Generally, natively compiled languages like C/C++, Go, and Rust are supported. Refer to [Troubleshooting unknown symbols][troubleshooting] for additional requirements.
 
-Python is the only supported high-level language, as long as `python_enabled=true`. Other high-level languages like Java, Ruby, PHP, and JavaScript require additional work to show stack traces of methods in these languages correctly. Currently, their CPU usage will be reported belonging to the runtime's methods instead.
+Python is the only supported high-level language, as long as `python_enabled=true`.
+Other high-level languages like Java, Ruby, PHP, and JavaScript require additional work to show stack traces of methods in these languages correctly.
+Currently, the CPU usage for these languages is reported as belonging to the runtime's methods.
 
 ## Usage
 
@@ -127,7 +129,7 @@ Symbols are extracted from various sources, including:
 - The `.symtab` and `.dynsym` sections in the debug ELF file.
 - The `.gopclntab` section in Go language ELF files.
 
-The search for debug files follows [gdb algorithm].
+The search for debug files follows [gdb algorithm][].
 For example, if the profiler wants to find the debug file for `/lib/x86_64-linux-gnu/libc.so.6` with a `.gnu_debuglink` set to `libc.so.6.debug` and a build ID `0123456789abcdef`.
 The following paths are examined:
 


### PR DESCRIPTION
This makes it explicit what languages are supposed to work and what steps are required to debug problems.
