### PR TITLE
mimir.rules.kubernetes: Add additional labels to rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ Main (unreleased)
 
 - Allow setting the CPU profiling event for Java Async Profiler in `pyroscope.java` component (@slbucur)
 
+- `mimir.rules.kubernetes` is now able to add extra labels to the Prometheus rules. (@psychomantys)
+
 ### Bugfixes
 
 - Fixed a clustering mode issue where a fatal startup failure of the clustering service

--- a/docs/sources/reference/components/mimir/mimir.rules.kubernetes.md
+++ b/docs/sources/reference/components/mimir/mimir.rules.kubernetes.md
@@ -66,6 +66,7 @@ Name                     | Type                | Description                    
 `no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. |               | no
 `proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.                                            | `false`       | no
 `proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests.                                    |               | no
+`external_labels`        | `map(string)`       | Labels to add to each rule.                                                                      | `{}` | no
 
  At most, one of the following can be provided:
  - [`bearer_token` argument](#arguments).
@@ -96,6 +97,8 @@ If `prometheus_http_prefix` is set to `/mimir`, `mimir.rules.kubernetes` contact
 This is useful if you configure Mimir to use a different [prefix][gem-path-prefix] for its Prometheus endpoints than the default one.
 
 `prometheus_http_prefix` is ignored if `use_legacy_routes` is set to `true`.
+
+`external_labels` will override label values if labels with the same names already exist inside the rule.
 
 ## Blocks
 
@@ -234,8 +237,8 @@ mimir.rules.kubernetes "local" {
 }
 ```
 
-This example creates a `mimir.rules.kubernetes` component that loads discovered
-rules to Grafana Cloud.
+This example creates a `mimir.rules.kubernetes` component that loads discovered rules to Grafana Cloud. 
+It will also add a `"label1"` label to each rule. If that label already exists, its value will be overridden with `"value1"`.
 
 ```alloy
 mimir.rules.kubernetes "default" {
@@ -246,6 +249,7 @@ mimir.rules.kubernetes "default" {
         // Alternatively, load the password from a file:
         // password_file = "GRAFANA_CLOUD_API_KEY_PATH"
     }
+    external_labels = {"label1" = "value1"}
 }
 ```
 

--- a/docs/sources/reference/components/mimir/mimir.rules.kubernetes.md
+++ b/docs/sources/reference/components/mimir/mimir.rules.kubernetes.md
@@ -238,7 +238,7 @@ mimir.rules.kubernetes "local" {
 ```
 
 This example creates a `mimir.rules.kubernetes` component that loads discovered rules to Grafana Cloud. 
-It will also add a `"label1"` label to each rule. If that label already exists, its value will be overridden with `"value1"`.
+It also adds a `"label1"` label to each rule. If that label already exists, it is overwritten with `"value1"`.
 
 ```alloy
 mimir.rules.kubernetes "default" {

--- a/internal/component/mimir/rules/kubernetes/rules.go
+++ b/internal/component/mimir/rules/kubernetes/rules.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"sync"
 	"time"
 
@@ -439,6 +440,10 @@ func (c *Component) startRuleInformer(queue workqueue.RateLimitingInterface, sto
 }
 
 func (c *Component) newEventProcessor(queue workqueue.RateLimitingInterface, stopChan chan struct{}, namespaceLister coreListers.NamespaceLister, ruleLister promListers.PrometheusRuleLister) *eventProcessor {
+	// Copy the label map to make sure that a change in arguments won't immediately propagate to the event processor.
+	externalLabels := make(map[string]string, len(c.args.ExternalLabels))
+	maps.Copy(externalLabels, c.args.ExternalLabels)
+
 	return &eventProcessor{
 		queue:             queue,
 		stopChan:          stopChan,
@@ -451,6 +456,7 @@ func (c *Component) newEventProcessor(queue workqueue.RateLimitingInterface, sto
 		namespacePrefix:   c.args.MimirNameSpacePrefix,
 		metrics:           c.metrics,
 		logger:            c.log,
+		externalLabels:    externalLabels,
 	}
 }
 

--- a/internal/component/mimir/rules/kubernetes/rules_test.go
+++ b/internal/component/mimir/rules/kubernetes/rules_test.go
@@ -27,6 +27,7 @@ func TestAlloyConfig(t *testing.T) {
 		username = "GRAFANA_CLOUD_USER"
 		password = "GRAFANA_CLOUD_API_KEY"
 	}
+	external_labels = {"label1" = "value1"}
 `
 
 	var args Arguments

--- a/internal/component/mimir/rules/kubernetes/types.go
+++ b/internal/component/mimir/rules/kubernetes/types.go
@@ -16,6 +16,7 @@ type Arguments struct {
 	HTTPClientConfig     config.HTTPClientConfig `alloy:",squash"`
 	SyncInterval         time.Duration           `alloy:"sync_interval,attr,optional"`
 	MimirNameSpacePrefix string                  `alloy:"mimir_namespace_prefix,attr,optional"`
+	ExternalLabels       map[string]string       `alloy:"external_labels,attr,optional"`
 
 	RuleSelector          kubernetes.LabelSelector `alloy:"rule_selector,block,optional"`
 	RuleNamespaceSelector kubernetes.LabelSelector `alloy:"rule_namespace_selector,block,optional"`


### PR DESCRIPTION
#### PR Description

This can be useful when users are migrating from many independent Prometheus instances to one central Mimir instance.

Credit for this PR goes to @psychomantys, who authored an [Agent PR](https://github.com/grafana/agent/pull/6769) which this PR is based on.

#### Which issue(s) this PR fixes

Fixes #291

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
