### PR TITLE
Fix DNS test so it's cross-platform

### DIFF
--- a/internal/alloycli/cluster_builder.go
+++ b/internal/alloycli/cluster_builder.go
@@ -170,7 +170,8 @@ func buildJoinAddresses(providedAddr []string, log log.Logger) ([]string, error)
 		// If it's a host:port, use it as is.
 		_, _, err := net.SplitHostPort(addr)
 		if err != nil {
-			deferredErr = errors.Join(deferredErr, err)
+			wrappedErr := fmt.Errorf("failed to extract host and port: %w", err)
+			deferredErr = errors.Join(deferredErr, wrappedErr)
 		} else {
 			level.Debug(log).Log("msg", "found a host:port cluster join address", "addr", addr)
 			result = append(result, addr)
@@ -189,7 +190,8 @@ func buildJoinAddresses(providedAddr []string, log log.Logger) ([]string, error)
 		_, srvs, err := net.LookupSRV("", "", addr)
 		if err != nil {
 			level.Warn(log).Log("msg", "failed to resolve SRV records", "addr", addr, "err", err)
-			deferredErr = errors.Join(deferredErr, err)
+			wrappedErr := fmt.Errorf("failed to resolve SRV records: %w", err)
+			deferredErr = errors.Join(deferredErr, wrappedErr)
 		} else {
 			level.Debug(log).Log("msg", "found cluster join addresses via SRV records", "addr", addr, "count", len(srvs))
 			for _, srv := range srvs {

--- a/internal/alloycli/cluster_builder_test.go
+++ b/internal/alloycli/cluster_builder_test.go
@@ -94,13 +94,15 @@ func TestStaticDiscovery(t *testing.T) {
 	})
 	t.Run("nothing found", func(t *testing.T) {
 		logger := log.NewLogfmtLogger(os.Stdout)
-		sd := newStaticDiscovery([]string{"this | wont | work", "and/this/won't/either"}, 12345, logger)
+		sd := newStaticDiscovery([]string{"this | wont | work"}, 12345, logger)
 		actual, err := sd()
 		require.Nil(t, actual)
 		require.ErrorContains(t, err, "failed to find any valid join addresses")
-		require.ErrorContains(t, err, "this | wont | work: missing port in address")
-		require.ErrorContains(t, err, "lookup this | wont | work: no such host")
-		require.ErrorContains(t, err, "and/this/won't/either: missing port in address")
-		require.ErrorContains(t, err, "lookup and/this/won't/either: no such host")
+		// We can only check the error messages in Alloy's code.
+		// We cannot check for error messages from other Go libraries,
+		// because they may differ based on operating system and
+		// on env var settings such as GODEBUG=netdns.
+		require.ErrorContains(t, err, "failed to extract host and port")
+		require.ErrorContains(t, err, "failed to resolve SRV records")
 	})
 }


### PR DESCRIPTION
#### PR Description

A test has been [failing](https://drone.grafana.net/grafana/alloy/2190/2/2) for Windows builds on the main branch:

```
--- FAIL: TestStaticDiscovery (0.00s)
    --- FAIL: TestStaticDiscovery/nothing_found (0.00s)
        cluster_builder_test.go:102: 
            	Error Trace:	C:/drone/src/internal/alloycli/cluster_builder_test.go:102
            	Error:      	Error "static peer discovery: failed to find any valid join addresses: address this | wont | work: missing port in address\nlookup this | wont | work: dnsquery: DNS name contains an invalid character.\naddress and/this/won't/either: missing port in address\nlookup and/this/won't/either: dnsquery: DNS name contains an invalid character." does not contain "lookup this | wont | work: no such host"
            	Test:       	TestStaticDiscovery/nothing_found
FAIL
FAIL	github.com/grafana/alloy/internal/alloycli	0.625s
```

It was added in #1242 (cc @thampiotr) .

#### Notes to the Reviewer

Just for fun, I thought I'd try to fix the "invalid character" error on Windows by changing the test like this:

```go
t.Run("nothing found", func(t *testing.T) {
	logger := log.NewLogfmtLogger(os.Stdout)
	sd := newStaticDiscovery([]string{"ThisWontWork", "AndThisWontWork"}, 12345, logger)
	actual, err := sd()
	require.Nil(t, actual)
	require.ErrorContains(t, err, "failed to find any valid join addresses")
	require.ErrorContains(t, err, "ThisWontWork: missing port in address")
	require.ErrorContains(t, err, "lookup ThisWontWork: no such host")
	require.ErrorContains(t, err, "AndThisWontWork: missing port in address")
	require.ErrorContains(t, err, "lookup AndThisWontWork: no such host")
})
```

The above test worked fine on Windows, but failed on MacOS with this error:

```
--- FAIL: TestStaticDiscovery (3.66s)
    --- FAIL: TestStaticDiscovery/nothing_found (3.66s)
        /Users/paulintodev/Documents/GitHub/alloy-3/internal/alloycli/cluster_builder_test.go:102: 
            	Error Trace:	/Users/paulintodev/Documents/GitHub/alloy-3/internal/alloycli/cluster_builder_test.go:102
            	Error:      	Error "static peer discovery: failed to find any valid join addresses: address ThisWontWork: missing port in address\nlookup ThisWontWork on [fe80::1%en0]:53: no such host\naddress AndThisWontWork: missing port in address\nlookup AndThisWontWork on [fe80::1%en0]:53: no such host" does not contain "lookup ThisWontWork: no such host"
            	Test:       	TestStaticDiscovery/nothing_found
FAIL
FAIL	github.com/grafana/alloy/internal/alloycli	5.793s
```

This reaffirms my belief that we shouldn't check the contents of the actual error, unless it comes from Alloy. TBH I'm not sure if we should even test the Alloy error, but I don't see any major downsides.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
