### PR TITLE
oracle exporter custom metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Main (unreleased)
 - Added community components support, enabling community members to implement and maintain components. (@wildum)
 
 ### Enhancements
+- Added custom metrics capability to oracle exporter. (@EHSchmitt4395)
 
 - Added a success rate panel on the Prometheus Components dashboard. (@thampiotr)
 
@@ -50,7 +51,7 @@ Main (unreleased)
 - Fixed a clustering mode issue where a fatal startup failure of the clustering service
   would exit the service silently, without also exiting the Alloy process. (@thampiotr)
 
-- Fix a bug which prevented config reloads to work if a Loki `metrics` stage is in the pipeline. 
+- Fix a bug which prevented config reloads to work if a Loki `metrics` stage is in the pipeline.
   Previously, the reload would fail for `loki.process` without an error in the logs and the metrics
   from the `metrics` stage would get stuck at the same values. (@ptodev)
 

--- a/internal/component/prometheus/exporter/oracledb/oracledb.go
+++ b/internal/component/prometheus/exporter/oracledb/oracledb.go
@@ -36,7 +36,6 @@ var DefaultArguments = Arguments{
 	MaxOpenConns: 10,
 	QueryTimeout: 5,
 }
-
 var (
 	errNoConnectionString = errors.New("no connection string was provided")
 	errNoHostname         = errors.New("no hostname in connection string")
@@ -48,6 +47,7 @@ type Arguments struct {
 	MaxIdleConns     int               `alloy:"max_idle_conns,attr,optional"`
 	MaxOpenConns     int               `alloy:"max_open_conns,attr,optional"`
 	QueryTimeout     int               `alloy:"query_timeout,attr,optional"`
+	CustomMetrics      alloytypes.OptionalSecret `alloy:"custom_metrics,attr,optional"`
 }
 
 // SetToDefault implements syntax.Defaulter.
@@ -82,5 +82,6 @@ func (a *Arguments) Convert() *oracledb_exporter.Config {
 		MaxIdleConns:     a.MaxIdleConns,
 		MaxOpenConns:     a.MaxOpenConns,
 		QueryTimeout:     a.QueryTimeout,
+		CustomMetrics:    a.CustomMetrics.Value,
 	}
 }

--- a/internal/component/prometheus/exporter/oracledb/oracledb_test.go
+++ b/internal/component/prometheus/exporter/oracledb/oracledb_test.go
@@ -17,7 +17,7 @@ func TestAlloyUnmarshal(t *testing.T) {
 	max_idle_conns     = 0
 	max_open_conns     = 10
 	query_timeout      = 5
-	`
+	custom_metrics     = ` + "`metrics:\n- context: \"slow_queries\"\n  metricsdesc:\n    p95_time_usecs: \"Gauge metric with percentile 95 of elapsed time.\"\n    p99_time_usecs: \"Gauge metric with percentile 99 of elapsed time.\"\n  request: \"select  percentile_disc(0.95)  within group (order by elapsed_time) as p95_time_usecs,\n    percentile_disc(0.99)  within group (order by elapsed_time) as p99_time_usecs\n    from v$sql where last_active_time >= sysdate - 5/(24*60)\"`"
 
 	var args Arguments
 	err := syntax.Unmarshal([]byte(alloyConfig), &args)
@@ -28,6 +28,16 @@ func TestAlloyUnmarshal(t *testing.T) {
 		MaxIdleConns:     0,
 		MaxOpenConns:     10,
 		QueryTimeout:     5,
+		CustomMetrics: alloytypes.OptionalSecret{
+			Value: `metrics:
+- context: "slow_queries"
+  metricsdesc:
+    p95_time_usecs: "Gauge metric with percentile 95 of elapsed time."
+    p99_time_usecs: "Gauge metric with percentile 99 of elapsed time."
+  request: "select  percentile_disc(0.95)  within group (order by elapsed_time) as p95_time_usecs,
+    percentile_disc(0.99)  within group (order by elapsed_time) as p99_time_usecs
+    from v$sql where last_active_time >= sysdate - 5/(24*60)"`,
+		},
 	}
 
 	require.Equal(t, expected, args)
@@ -73,11 +83,25 @@ func TestArgumentsValidate(t *testing.T) {
 			err:     errNoHostname,
 		},
 		{
-			name: "valid",
+			name: "valid OracleDB",
 			args: Arguments{
-				ConnectionString: alloytypes.Secret("oracle://user:password@localhost:1521/orcl.localnet"),
+				ConnectionString:   alloytypes.Secret("oracle://user:password@localhost:1521/orcl.localnet"),
+				MaxIdleConns: 1,
+				MaxOpenConns: 1,
+				QueryTimeout: 5,
+				CustomMetrics: alloytypes.OptionalSecret{
+					Value: `metrics:
+- context: "slow_queries"
+  metricsdesc:
+    p95_time_usecs: "Gauge metric with percentile 95 of elapsed time."
+    p99_time_usecs: "Gauge metric with percentile 99 of elapsed time."
+  request: "select percentile_disc(0.95) within group (order by elapsed_time) as p95_time_usecs,
+           percentile_disc(0.99) within group (order by elapsed_time) as p99_time_usecs
+           from v$sql where last_active_time >= sysdate - 5/(24*60)"`,
+				},
 			},
 			wantErr: false,
+			err:     errors.New("invalid custom_metrics"),
 		},
 	}
 
@@ -93,8 +117,37 @@ func TestArgumentsValidate(t *testing.T) {
 		})
 	}
 }
+func TestConvertCustom(t *testing.T) {
+	strCustomMetrics := `metrics:
+- context: "slow_queries"
+  metricsdesc:
+    p95_time_usecs: "Gauge metric with percentile 95 of elapsed time."
+    p99_time_usecs: "Gauge metric with percentile 99 of elapsed time."
+  request: "select  percentile_disc(0.95)  within group (order by elapsed_time) as p95_time_usecs,
+    percentile_disc(0.99)  within group (order by elapsed_time) as p99_time_usecs
+    from v$sql where last_active_time >= sysdate - 5/(24*60)"`
 
-func TestConvert(t *testing.T) {
+	alloyConfig := `
+	connection_string  = "oracle://user:password@localhost:1521/orcl.localnet"
+	custom_metrics     = ` + "`metrics:\n- context: \"slow_queries\"\n  metricsdesc:\n    p95_time_usecs: \"Gauge metric with percentile 95 of elapsed time.\"\n    p99_time_usecs: \"Gauge metric with percentile 99 of elapsed time.\"\n  request: \"select  percentile_disc(0.95)  within group (order by elapsed_time) as p95_time_usecs,\n    percentile_disc(0.99)  within group (order by elapsed_time) as p99_time_usecs\n    from v$sql where last_active_time >= sysdate - 5/(24*60)\"`"
+
+	var args Arguments
+
+	err := syntax.Unmarshal([]byte(alloyConfig), &args)
+	require.NoError(t, err)
+
+	res := args.Convert()
+
+	expected := oracledb_exporter.Config{
+		ConnectionString: config_util.Secret("oracle://user:password@localhost:1521/orcl.localnet"),
+		MaxIdleConns:     DefaultArguments.MaxIdleConns,
+		MaxOpenConns:     DefaultArguments.MaxOpenConns,
+		QueryTimeout:     DefaultArguments.QueryTimeout,
+		CustomMetrics:    strCustomMetrics,
+	}
+	require.Equal(t, expected, *res)
+}
+func TestConvertNoCustom(t *testing.T) {
 	alloyConfig := `
 	connection_string  = "oracle://user:password@localhost:1521/orcl.localnet"
 	`
@@ -109,6 +162,7 @@ func TestConvert(t *testing.T) {
 		MaxIdleConns:     DefaultArguments.MaxIdleConns,
 		MaxOpenConns:     DefaultArguments.MaxOpenConns,
 		QueryTimeout:     DefaultArguments.QueryTimeout,
+		CustomMetrics:   "",
 	}
 	require.Equal(t, expected, *res)
 }

--- a/internal/static/integrations/oracledb_exporter/oracledb_exporter.go
+++ b/internal/static/integrations/oracledb_exporter/oracledb_exporter.go
@@ -24,6 +24,7 @@ var DefaultConfig = Config{
 	MaxOpenConns:     10,
 	MaxIdleConns:     0,
 	QueryTimeout:     5,
+	// CustomMetrics:    "",
 }
 
 var (
@@ -37,8 +38,8 @@ type Config struct {
 	MaxIdleConns     int                `yaml:"max_idle_connections"`
 	MaxOpenConns     int                `yaml:"max_open_connections"`
 	QueryTimeout     int                `yaml:"query_timeout"`
+	CustomMetrics    string             `yaml:"custom_metrics,omitempty"`
 }
-
 // ValidateConnString attempts to ensure the connection string supplied is valid
 // to connect to an OracleDB instance
 func validateConnString(connStr string) error {
@@ -104,8 +105,7 @@ func New(logger log.Logger, c *Config) (integrations.Integration, error) {
 		DSN:          string(c.ConnectionString),
 		MaxIdleConns: c.MaxIdleConns,
 		MaxOpenConns: c.MaxOpenConns,
-		// no custom metrics file for this integration
-		CustomMetrics: "",
+		CustomMetrics: c.CustomMetrics,
 		QueryTimeout:  c.QueryTimeout,
 	})
 

--- a/internal/static/integrations/oracledb_exporter/oracledb_exporter_test.go
+++ b/internal/static/integrations/oracledb_exporter/oracledb_exporter_test.go
@@ -16,9 +16,10 @@ enabled: true
 connection_string: oracle://user:password@localhost:1521/orcl.localnet
 scrape_timeout: "1m"
 scrape_integration: true
-max_idle_connections: 0
-max_open_connections: 10
-query_timeout: 5`
+max_idle_conns: 0
+max_open_conns: 10
+query_timeout: 5
+custom_metrics: ""`
 
 	var c Config
 	require.NoError(t, yaml.Unmarshal([]byte(strConfig), &c))
@@ -28,6 +29,7 @@ query_timeout: 5`
 		MaxIdleConns:     0,
 		MaxOpenConns:     10,
 		QueryTimeout:     5,
+		CustomMetrics:    "",
 	}, c)
 }
 
@@ -73,7 +75,7 @@ func TestConfigValidate(t *testing.T) {
 			name: "invalid scheme - cockroachdb",
 			getConfig: func() Config {
 				c := DefaultConfig
-				c.ConnectionString = "postgres://maxroach@localhost:26257/movr?password=pwd"
+				c.ConnectionString = config_util.Secret("postgres://maxroach@localhost:26257/movr?password=pwd")
 				return c
 			},
 			expectedErr: errors.New("unexpected scheme of type 'postgres'. Was expecting 'oracle'"),
@@ -82,7 +84,7 @@ func TestConfigValidate(t *testing.T) {
 			name: "invalid connection string",
 			getConfig: func() Config {
 				c := DefaultConfig
-				c.ConnectionString = "localhost:1521"
+				c.ConnectionString = config_util.Secret("localhost:1521")
 				return c
 			},
 			expectedErr: errors.New("unexpected scheme of type 'localhost'. Was expecting 'oracle'"),
@@ -103,7 +105,7 @@ func TestConfigValidate(t *testing.T) {
 
 func TestConfig_InstanceKey(t *testing.T) {
 	c := DefaultConfig
-	c.ConnectionString = "oracle://user:password@localhost:1521/orcl.localnet"
+	c.ConnectionString = config_util.Secret("oracle://user:password@localhost:1521/orcl.localnet")
 
 	ik := "agent-key"
 	id, err := c.InstanceKey(ik)


### PR DESCRIPTION

#### PR Description
Oracle Exporter wrapped in alloy deployment has capability to include custom metrics. This PR aims to add that capability to alloy, modeling mssql exporter. 

#### Notes to the Reviewer
The code is compatible with a file path to be read in from alloy config, ie `local.file` , the tests however are modeled after yaml string. 
#### PR Checklist
- [x] CHANGELOG.md updated
- [ ] Documentation added (will add once confirmed sound, or changes needed ie path) 
- [x] Tests updated
