### PR TITLE
Fix custom components not always getting updated when config in imported directory changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Main (unreleased)
 
 ### Bugfixes
 
+- Fix a bug where custom components don't always get updated when the config is modified in an imported directory. (@ante012)
+
 - Fixed an issue which caused loss of context data in Faro exception. (@codecapitano)
 
 - Fixed an issue where providing multiple hostnames or IP addresses
@@ -162,7 +164,6 @@ v1.3.0
   Previously, the reload would fail for `loki.process` without an error in the logs and the metrics
   from the `metrics` stage would get stuck at the same values. (@ptodev)
 
-- Fix a bug where custom components don't always get updated when the config is modified in an imported directory. (@ante012)
 
 v1.2.1
 -----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,8 @@ v1.3.0
   Previously, the reload would fail for `loki.process` without an error in the logs and the metrics
   from the `metrics` stage would get stuck at the same values. (@ptodev)
 
+- Fix a bug where custom components don't always get updated when the config is modified in an imported directory. (@ante012)
+
 v1.2.1
 -----------------
 

--- a/internal/runtime/alloy_components.go
+++ b/internal/runtime/alloy_components.go
@@ -22,7 +22,7 @@ func (f *Runtime) GetComponent(id component.ID, opts component.InfoOptions) (*co
 		return mod.f.GetComponent(component.ID{LocalID: id.LocalID}, opts)
 	}
 
-	graph := f.loader.OriginalGraph()
+	graph := f.loader.Graph()
 
 	node := graph.GetByID(id.LocalID)
 	if node == nil {
@@ -53,7 +53,7 @@ func (f *Runtime) ListComponents(moduleID string, opts component.InfoOptions) ([
 
 	var (
 		components = f.loader.Components()
-		graph      = f.loader.OriginalGraph()
+		graph      = f.loader.Graph()
 	)
 
 	detail := make([]*component.Info, len(components))

--- a/internal/runtime/alloy_services.go
+++ b/internal/runtime/alloy_services.go
@@ -12,13 +12,13 @@ import (
 // [component.Component] and [service.Service]s which declared a dependency on
 // the named service.
 func (f *Runtime) GetServiceConsumers(serviceName string) []service.Consumer {
-	consumers := serviceConsumersForGraph(f.loader.OriginalGraph(), serviceName, true)
+	consumers := serviceConsumersForGraph(f.loader.Graph(), serviceName, true)
 
 	// Iterate through all modules to find other components that depend on the
 	// service. Peer services aren't checked here, since the services are always
 	// a subset of the services from the root controller.
 	for _, mod := range f.modules.List() {
-		moduleGraph := mod.f.loader.OriginalGraph()
+		moduleGraph := mod.f.loader.Graph()
 		consumers = append(consumers, serviceConsumersForGraph(moduleGraph, serviceName, false)...)
 	}
 

--- a/internal/runtime/internal/dag/ops.go
+++ b/internal/runtime/internal/dag/ops.go
@@ -11,7 +11,9 @@ import (
 // as many edges as possible while maintaining the same "reachability" as the
 // original graph: any node N reachable from node S will still be reachable
 // after a reduction.
-func Reduce(g *Graph) {
+// edgesToPreserve allows the caller to specify a set of edges that
+// must not be removed during the transitive reduction.
+func Reduce(g *Graph, edgesToPreserve map[Edge]struct{}) {
 	// A direct edge between two vertices can be removed if that same target
 	// vertex is indirectly reachable through another edge.
 	//
@@ -24,7 +26,9 @@ func Reduce(g *Graph) {
 			// edges if they exist. This is a safe operation because other is still
 			// reachable by source via its (source, direct) edge.
 			for indirect := range g.outEdges[direct] {
-				g.RemoveEdge(Edge{From: source, To: indirect})
+				if _, ok := edgesToPreserve[Edge{From: source, To: indirect}]; !ok {
+					g.RemoveEdge(Edge{From: source, To: indirect})
+				}
 			}
 			return nil
 		})

--- a/internal/runtime/internal/dag/ops.go
+++ b/internal/runtime/internal/dag/ops.go
@@ -7,34 +7,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
-// Reduce performs a transitive reduction on g. A transitive reduction removes
-// as many edges as possible while maintaining the same "reachability" as the
-// original graph: any node N reachable from node S will still be reachable
-// after a reduction.
-// edgesToPreserve allows the caller to specify a set of edges that
-// must not be removed during the transitive reduction.
-func Reduce(g *Graph, edgesToPreserve map[Edge]struct{}) {
-	// A direct edge between two vertices can be removed if that same target
-	// vertex is indirectly reachable through another edge.
-	//
-	// To detect this, we iterate through all vertices in the graph, performing a
-	// depth-first search at its dependencies. If the target vertex is reachable
-	// from the source vertex, the edge is removed.
-	for source := range g.nodes {
-		_ = Walk(g, g.Dependencies(source), func(direct Node) error {
-			// Iterate over (direct, indirect) edges and remove (source, indirect)
-			// edges if they exist. This is a safe operation because other is still
-			// reachable by source via its (source, direct) edge.
-			for indirect := range g.outEdges[direct] {
-				if _, ok := edgesToPreserve[Edge{From: source, To: indirect}]; !ok {
-					g.RemoveEdge(Edge{From: source, To: indirect})
-				}
-			}
-			return nil
-		})
-	}
-}
-
 // Validate checks that the graph doesn't contain cycles
 func Validate(g *Graph) error {
 	var err error

--- a/internal/runtime/testdata/import_file_folder/import_file_folder_6.txtar
+++ b/internal/runtime/testdata/import_file_folder/import_file_folder_6.txtar
@@ -1,0 +1,55 @@
+Import folder with passthrough and connect components from import, on update modify one imported module.
+
+-- main.alloy --
+testcomponents.count "inc" {
+  frequency = "10ms"
+  max = 10
+}
+
+import.file "testImport" {
+  filename = "tmpTest"
+}
+
+testImport.a "aa" {
+  input = testcomponents.count.inc.count
+}
+
+testImport.b "bb" {
+  input = testImport.a.aa.output
+}
+
+testcomponents.summation "sum" {
+  input = testImport.b.bb.output
+}
+
+-- module1.alloy --
+declare "a" {
+  argument "input" {}
+
+  export "output" {
+    value = argument.input.value
+  }
+}
+
+-- module2.alloy --
+declare "b" {
+  argument "input" {}
+
+  testcomponents.passthrough "pt" {
+    input = argument.input.value
+    lag = "1ms"
+  }
+
+  export "output" {
+    value = testcomponents.passthrough.pt.output
+  }
+}
+
+-- update/module2.alloy --
+declare "b" {
+  argument "input" {}
+
+  export "output" {
+    value = -argument.input.value
+  }
+}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Fixes custom components not getting updated when config changes in the imported directory they were declared in. 

It happens when you connect imported components because the transitive reduction of the dependency graph only keeps the edge from one of the components to the importConfigNode.

It is fixed here by modifying the reduce operation of the dependency graph to always keep edges from custom components to importConfigNodes.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #1348

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Tests updated
