### PR TITLE
remotecfg: wire calls to RegisterCollector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,8 +62,6 @@ Main (unreleased)
 
 - `mimir.rules.kubernetes` is now able to add extra labels to the Prometheus rules. (@psychomantys)
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 - Upgrade from OpenTelemetry v0.102.1 to v0.105.0.
   - [`otelcol.receiver.*`] A new `compression_algorithms` attribute to configure which 
     compression algorithms are allowed by the HTTP server.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Main (unreleased)
 - `mimir.rules.kubernetes` is now able to add extra labels to the Prometheus rules. (@psychomantys)
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 - Upgrade from OpenTelemetry v0.102.1 to v0.105.0.
   - [`otelcol.receiver.*`] A new `compression_algorithms` attribute to configure which 
     compression algorithms are allowed by the HTTP server.
@@ -125,7 +126,7 @@ Main (unreleased)
   - Full list of changes: https://github.com/grafana/beyla/releases/tag/v1.7.0
 
 - Enable instances connected to remotecfg-compatible servers to Register
-  themselves from the remote service. (@tpaschalis)
+  themselves to the remote service. (@tpaschalis)
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Main (unreleased)
 
 - `mimir.rules.kubernetes` is now able to add extra labels to the Prometheus rules. (@psychomantys)
 
+<<<<<<< HEAD
 - Upgrade from OpenTelemetry v0.102.1 to v0.105.0.
   - [`otelcol.receiver.*`] A new `compression_algorithms` attribute to configure which 
     compression algorithms are allowed by the HTTP server.
@@ -122,6 +123,9 @@ Main (unreleased)
   - New supported protocols: SQL, Redis, Kafka
   - Several bugfixes
   - Full list of changes: https://github.com/grafana/beyla/releases/tag/v1.7.0
+
+- Enable instances connected to remotecfg-compatible servers to Register
+  themselves from the remote service. (@tpaschalis)
 
 ### Bugfixes
 

--- a/docs/sources/reference/config-blocks/remotecfg.md
+++ b/docs/sources/reference/config-blocks/remotecfg.md
@@ -46,7 +46,8 @@ Name             | Type                 | Description                           
 
 If the `url` is not set, then the service block is a no-op.
 
-If not set, the self-reported `id` that {{< param "PRODUCT_NAME" >}} uses is a randomly generated, anonymous unique ID (UUID) that is stored as an `alloy_seed.json` file in {{< param "PRODUCT_NAME" >}}'s storage path so that it can persist across restarts. In that case, the `name` field can be used to set another human-friendly identifier for the specific Alloy instance.
+If not set, the self-reported `id` that {{< param "PRODUCT_NAME" >}} uses is a randomly generated, anonymous unique ID (UUID) that is stored as an `alloy_seed.json` file in the {{< param "PRODUCT_NAME" >}} storage path so that it can persist across restarts.
+You can use the `name` field to set another human-friendly identifier for the specific {{< param "PRODUCT_NAME" >}} instance.
 
 The `id` and `attributes` fields are used in the periodic request sent to the
 remote endpoint so that the API can decide what configuration to serve.

--- a/docs/sources/reference/config-blocks/remotecfg.md
+++ b/docs/sources/reference/config-blocks/remotecfg.md
@@ -42,10 +42,11 @@ Name             | Type                 | Description                           
 `id`             | `string`             | A self-reported ID.                               | `see below` | no
 `attributes`     | `map(string)`        | A set of self-reported attributes.                | `{}`        | no
 `poll_frequency` | `duration`           | How often to poll the API for new configuration.  | `"1m"`      | no
+`name`           | `string`             | A human-readable name for the collector.          | `""`        | no
 
 If the `url` is not set, then the service block is a no-op.
 
-If not set, the self-reported `id` that {{< param "PRODUCT_NAME" >}} uses is a randomly generated, anonymous unique ID (UUID) that is stored as an `alloy_seed.json` file in {{< param "PRODUCT_NAME" >}}'s storage path so that it can persist across restarts.
+If not set, the self-reported `id` that {{< param "PRODUCT_NAME" >}} uses is a randomly generated, anonymous unique ID (UUID) that is stored as an `alloy_seed.json` file in {{< param "PRODUCT_NAME" >}}'s storage path so that it can persist across restarts. In that case, the `name` field can be used to set another human-friendly identifier for the specific Alloy instance.
 
 The `id` and `attributes` fields are used in the periodic request sent to the
 remote endpoint so that the API can decide what configuration to serve.

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/google/renameio/v2 v2.0.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
-	github.com/grafana/alloy-remote-config v0.0.6
+	github.com/grafana/alloy-remote-config v0.0.8
 	github.com/grafana/alloy/syntax v0.1.0
 	github.com/grafana/beyla v1.7.0
 	github.com/grafana/catchpoint-prometheus-exporter v0.0.0-20240606062944-e55f3668661d

--- a/go.sum
+++ b/go.sum
@@ -1008,8 +1008,8 @@ github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/gosnmp/gosnmp v1.37.0 h1:/Tf8D3b9wrnNuf/SfbvO+44mPrjVphBhRtcGg22V07Y=
 github.com/gosnmp/gosnmp v1.37.0/go.mod h1:GDH9vNqpsD7f2HvZhKs5dlqSEcAS6s6Qp099oZRCR+M=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
-github.com/grafana/alloy-remote-config v0.0.6 h1:/GzYu3/QPHRZFeqeeCZWnDMzXbXVkr7tAfrnHGZzreA=
-github.com/grafana/alloy-remote-config v0.0.6/go.mod h1:kHE1usYo2WAVCikQkIXuoG1Clz8BSdiz3kF+DZSCQ4k=
+github.com/grafana/alloy-remote-config v0.0.8 h1:bQTk7rkR1Hykss+bfMv7CucpF/fRsi2lixJHfIcOMnc=
+github.com/grafana/alloy-remote-config v0.0.8/go.mod h1:kHE1usYo2WAVCikQkIXuoG1Clz8BSdiz3kF+DZSCQ4k=
 github.com/grafana/beyla v1.7.0 h1:0BoIUTwIyXN2h1zrYm+/ffA9toezHJ5GQq4PqU3HrrU=
 github.com/grafana/beyla v1.7.0/go.mod h1:n0dWKeQDxNY8qjgiG0ochjsSva94KPcDSXUBqwIrnVo=
 github.com/grafana/cadvisor v0.0.0-20240729082359-1f04a91701e2 h1:ju6EcY2aEobeBg185ETtFCKj5WzaQ48qfkbsSRRQrF4=

--- a/internal/service/remotecfg/noop.go
+++ b/internal/service/remotecfg/noop.go
@@ -14,3 +14,13 @@ type noopClient struct{}
 func (c noopClient) GetConfig(context.Context, *connect.Request[collectorv1.GetConfigRequest]) (*connect.Response[collectorv1.GetConfigResponse], error) {
 	return nil, errors.New("noop client")
 }
+
+// RegisterCollector checks in the current collector to the API on startup.
+func (c noopClient) RegisterCollector(context.Context, *connect.Request[collectorv1.RegisterCollectorRequest]) (*connect.Response[collectorv1.RegisterCollectorResponse], error) {
+	return nil, errors.New("noop client")
+}
+
+// UnregisterCollector checks out the current collector to the API on shutdown.
+func (c noopClient) UnregisterCollector(context.Context, *connect.Request[collectorv1.UnregisterCollectorRequest]) (*connect.Response[collectorv1.UnregisterCollectorResponse], error) {
+	return nil, errors.New("noop client")
+}

--- a/internal/service/remotecfg/remotecfg_test.go
+++ b/internal/service/remotecfg/remotecfg_test.go
@@ -44,6 +44,10 @@ func TestOnDiskCache(t *testing.T) {
 	client := &collectorClient{}
 	env.svc.asClient = client
 
+	var registerCalled, unregisterCalled atomic.Bool
+	client.registerCollectorFunc = buildRegisterCollectorFunc(&registerCalled)
+	client.unregisterCollectorFunc = buildUnregisterCollectorFunc(&unregisterCalled)
+
 	// Mock client to return an unparseable response.
 	client.getConfigFunc = buildGetConfigHandler("unparseable config")
 


### PR DESCRIPTION

#### PR Description
This PR updates the API definition for remotecfg to its latest version, and wires in calls to the RegisterCollector/UnregisterCollector rpcs on startup and shutdown.

#### Which issue(s) this PR fixes
No issue filed

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
- [X] Documentation added
- [X] Tests updated
