### PR TITLE
improvement: Expose hwmon collector config options in prometheus.exporter.unix component.

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.exporter.unix.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.unix.md
@@ -60,6 +60,7 @@ The following blocks are supported inside the definition of `prometheus.exporter
 | disk        | [disk][]        | Configures the diskstats collector.   | no       |
 | ethtool     | [ethtool][]     | Configures the ethtool collector.     | no       |
 | filesystem  | [filesystem][]  | Configures the filesystem collector.  | no       |
+| hwmon       | [hwmon][]       | Configures the hwmon collector.       | no       |
 | ipvs        | [ipvs][]        | Configures the ipvs collector.        | no       |
 | ntp         | [ntp][]         | Configures the ntp collector.         | no       |
 | netclass    | [netclass][]    | Configures the netclass collector.    | no       |
@@ -80,6 +81,7 @@ The following blocks are supported inside the definition of `prometheus.exporter
 [disk]: #disk-block
 [ethtool]: #ethtool-block
 [filesystem]: #filesystem-block
+[hwmon]: #hwmon-block
 [ipvs]: #ipvs-block
 [ntp]: #ntp-block
 [netclass]: #netclass-block
@@ -162,6 +164,15 @@ The default values vary by the operating system {{< param "PRODUCT_NAME" >}} run
 ^/(dev)($|/)
 ```
 {{< /code >}}
+
+### hwmon block
+
+The default values vary by the operating system {{< param "PRODUCT_NAME" >}} runs on.
+
+| Name               | Type       | Description                                                          | Default  | Required |
+|--------------------|------------|----------------------------------------------------------------------|----------|----------|
+| `chip_include`     | `string`   | Regexp of hwmon chip to include (mutually exclusive to chip-exclude. |          | no       |
+| `chip_exclude`     | `string`   | Regexp of hwmon chip to include (mutually exclusive to chip-include. |          | no       |
 
 ### ipvs block
 

--- a/internal/component/prometheus/exporter/unix/config.go
+++ b/internal/component/prometheus/exporter/unix/config.go
@@ -85,6 +85,7 @@ type Arguments struct {
 	Disk        DiskStatsConfig   `alloy:"disk,block,optional"`
 	EthTool     EthToolConfig     `alloy:"ethtool,block,optional"`
 	Filesystem  FilesystemConfig  `alloy:"filesystem,block,optional"`
+	HWmon       HWmonConfig       `alloy:"hwmon,block,optional"`
 	IPVS        IPVSConfig        `alloy:"ipvs,block,optional"`
 	NTP         NTPConfig         `alloy:"ntp,block,optional"`
 	Netclass    NetclassConfig    `alloy:"netclass,block,optional"`
@@ -234,6 +235,12 @@ type EthToolConfig struct {
 	DeviceExclude  string `alloy:"device_exclude,attr,optional"`
 	DeviceInclude  string `alloy:"device_include,attr,optional"`
 	MetricsInclude string `alloy:"metrics_include,attr,optional"`
+}
+
+// HwMonConfig contains config specific to the hwmon collector.
+type HwMonConfig struct {
+	ChipExclude string `alloy:"chip_exclude,attr,optional"`
+	ChipInclude string `alloy:"chip_include,attr,optional"`
 }
 
 // FilesystemConfig contains config specific to the filesystem collector.

--- a/internal/converter/internal/staticconvert/internal/build/node_exporter.go
+++ b/internal/converter/internal/staticconvert/internal/build/node_exporter.go
@@ -44,6 +44,10 @@ func toNodeExporter(config *node_exporter.Config) *unix.Arguments {
 			MountPointsExclude: config.FilesystemMountPointsExclude,
 			MountTimeout:       config.FilesystemMountTimeout,
 		},
+		HwMon: unix.HwMonConfig{
+			ChipExclude: config.HwMonChipExclude,
+			ChipInclude: config.HwMonChipInclude,
+		},
 		IPVS: unix.IPVSConfig{
 			BackendLabels: config.IPVSBackendLabels,
 		},

--- a/internal/static/integrations/node_exporter/config.go
+++ b/internal/static/integrations/node_exporter/config.go
@@ -112,6 +112,10 @@ type Config struct {
 	FilesystemFSTypesExclude         string              `yaml:"filesystem_fs_types_exclude,omitempty"`
 	FilesystemMountPointsExclude     string              `yaml:"filesystem_mount_points_exclude,omitempty"`
 	FilesystemMountTimeout           time.Duration       `yaml:"filesystem_mount_timeout,omitempty"`
+	HWMonChipInclude                 string              `yaml:"hwmon_chip_include,omitempty"`
+	HWMonChipExclude                 string              `yaml:"hwmon_chip_exclude,omitempty"`
+	HWMonSensorInclude               string              `yaml:"hwmon_sensor_include,omitempty"`
+	HWMonSensorExclude               string              `yaml:"hwmon_sensor_exclude,omitempty"`
 	IPVSBackendLabels                []string            `yaml:"ipvs_backend_labels,omitempty"`
 	NTPIPTTL                         int                 `yaml:"ntp_ip_ttl,omitempty"`
 	NTPLocalOffsetTolerance          time.Duration       `yaml:"ntp_local_offset_tolerance,omitempty"`
@@ -380,6 +384,11 @@ func (c *Config) mapConfigToNodeConfig() *collector.NodeCollectorConfig {
 		OldFSTypesExcluded:     &blankString,
 		OldMountPointsExcluded: &blankString,
 		StatWorkerCount:        &blankInt,
+	}
+
+	cfg.HwMon = collector.HwMonConfig{
+		ChipInclude: &c.HwMonChipInclude,
+		ChipExclude: &c.HwMonChipExclude,
 	}
 
 	var joinedLabels string


### PR DESCRIPTION
#### PR Description

Exposes hwmon collector config options in the `prometheus.exporter.unix` component. The hwmon collector currently in the last v1.8.2 release of node_exporter supports hwmon configuration for which hwmon chips to filter to. This is useful for those users that just want a subset of hwmon metrics, and don't want to list a collection of relabel_rules to drop irrelevant hwmon metrics. 

https://github.com/prometheus/node_exporter/blob/f1e0e8360aa60b6cb5e5cc1560bed348fc2c1895/collector/hwmon_linux.go#L35-L36

#### Which issue(s) this PR fixes

n/a

#### Notes to the Reviewer

A recent PR to node_exporter also added support for filtering on sensors. However these is not a release of node_exporter that has this change yet. 
https://github.com/prometheus/node_exporter/commit/e11a4f03091115deeec015120586a7af17550f65

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [x] Config converters updated
