### PR TITLE
Wire component lookups to remotecfg's isolated controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,8 @@ v1.3.0-rc.0
 - Enable instances connected to remotecfg-compatible servers to Register
   themselves to the remote service. (@tpaschalis)
 
+- Allow in-memory listener to work for remotecfg-supplied components. (@tpaschalis)
+
 ### Bugfixes
 
 - Fixed a clustering mode issue where a fatal startup failure of the clustering service

--- a/internal/converter/internal/test_common/testing.go
+++ b/internal/converter/internal/test_common/testing.go
@@ -20,6 +20,7 @@ import (
 	cluster_service "github.com/grafana/alloy/internal/service/cluster"
 	http_service "github.com/grafana/alloy/internal/service/http"
 	"github.com/grafana/alloy/internal/service/labelstore"
+	remotecfg_service "github.com/grafana/alloy/internal/service/remotecfg"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
@@ -194,6 +195,13 @@ func attemptLoadingAlloyConfig(t *testing.T, bb []byte) {
 	})
 	require.NoError(t, err)
 
+	remotecfgService, err := remotecfg_service.New(remotecfg_service.Options{
+		Logger:      logger,
+		StoragePath: t.TempDir(),
+		Metrics:     prometheus.DefaultRegisterer,
+	})
+	require.NoError(t, err)
+
 	f := alloy_runtime.New(alloy_runtime.Options{
 		Logger:       logger,
 		DataPath:     t.TempDir(),
@@ -205,6 +213,7 @@ func attemptLoadingAlloyConfig(t *testing.T, bb []byte) {
 			http_service.New(http_service.Options{}),
 			clusterService,
 			labelstore.New(nil, prometheus.DefaultRegisterer),
+			remotecfgService,
 		},
 	})
 	err = f.LoadSource(cfg, nil)

--- a/internal/runtime/alloy_services.go
+++ b/internal/runtime/alloy_services.go
@@ -69,7 +69,7 @@ func serviceConsumersForGraph(graph *dag.Graph, serviceName string, includePeerS
 // NewController returns a new, unstarted, isolated Alloy controller so that
 // services can instantiate their own components.
 func (f *Runtime) NewController(id string) service.Controller {
-	return serviceController{
+	return ServiceController{
 		f: newController(controllerOptions{
 			Options: Options{
 				ControllerID:    id,
@@ -88,16 +88,18 @@ func (f *Runtime) NewController(id string) service.Controller {
 	}
 }
 
-type serviceController struct {
+type ServiceController struct {
 	f *Runtime
 }
 
-func (sc serviceController) Run(ctx context.Context) { sc.f.Run(ctx) }
-func (sc serviceController) LoadSource(b []byte, args map[string]any) error {
+func (sc ServiceController) Run(ctx context.Context) { sc.f.Run(ctx) }
+func (sc ServiceController) LoadSource(b []byte, args map[string]any) error {
 	source, err := ParseSource("", b)
 	if err != nil {
 		return err
 	}
 	return sc.f.LoadSource(source, args)
 }
-func (sc serviceController) Ready() bool { return sc.f.Ready() }
+func (sc ServiceController) Ready() bool { return sc.f.Ready() }
+
+func (sc ServiceController) GetHost() service.Host { return sc.f }

--- a/internal/runtime/module_eval_test.go
+++ b/internal/runtime/module_eval_test.go
@@ -20,6 +20,7 @@ import (
 	http_service "github.com/grafana/alloy/internal/service/http"
 	"github.com/grafana/alloy/internal/service/labelstore"
 	otel_service "github.com/grafana/alloy/internal/service/otel"
+	remotecfg_service "github.com/grafana/alloy/internal/service/remotecfg"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
@@ -331,6 +332,13 @@ func testOptions(t *testing.T) runtime.Options {
 	otelService := otel_service.New(s)
 	require.NotNil(t, otelService)
 
+	remotecfgService, err := remotecfg_service.New(remotecfg_service.Options{
+		Logger:      s,
+		StoragePath: t.TempDir(),
+		Metrics:     prometheus.DefaultRegisterer,
+	})
+	require.NoError(t, err)
+
 	return runtime.Options{
 		Logger:               s,
 		DataPath:             t.TempDir(),
@@ -342,6 +350,7 @@ func testOptions(t *testing.T) runtime.Options {
 			clusterService,
 			otelService,
 			labelstore.New(nil, prometheus.DefaultRegisterer),
+			remotecfgService,
 		},
 	}
 }

--- a/internal/service/http/http.go
+++ b/internal/service/http/http.go
@@ -182,7 +182,7 @@ func (s *Service) Run(ctx context.Context, host service.Host) error {
 		// This will never happen as the service dependency is explicit.
 		return fmt.Errorf("failed to get the remotecfg service when setting up the http service")
 	}
-	remotecfgHost := svc.(*remotecfg.Service).Data().(remotecfg.Data).Host
+	remotecfgHost := svc.Data().(remotecfg.Data).Host
 
 	// NOTE(@tpaschalis) These need to be kept in order for the longer
 	// remotecfg prefix to be invoked correctly.

--- a/internal/service/http/http.go
+++ b/internal/service/http/http.go
@@ -132,7 +132,7 @@ func (s *Service) Definition() service.Definition {
 	return service.Definition{
 		Name:       ServiceName,
 		ConfigType: Arguments{},
-		DependsOn:  []string{remotecfg.ServiceName}, // http requires remotecfg to be up to wire lookups to its controller.
+		DependsOn:  nil, //[]string{remotecfg.ServiceName}, // http requires remotecfg to be up to wire lookups to its controller.
 		Stability:  featuregate.StabilityGenerallyAvailable,
 	}
 }

--- a/internal/service/http/http.go
+++ b/internal/service/http/http.go
@@ -21,6 +21,7 @@ import (
 	alloy_runtime "github.com/grafana/alloy/internal/runtime"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
 	"github.com/grafana/alloy/internal/service"
+	"github.com/grafana/alloy/internal/service/remotecfg"
 	"github.com/grafana/alloy/internal/static/server"
 	"github.com/grafana/ckit/memconn"
 	_ "github.com/grafana/pyroscope-go/godeltaprof/http/pprof" // Register godeltaprof handler
@@ -79,7 +80,8 @@ type Service struct {
 
 	memLis *memconn.Listener
 
-	componentHttpPathPrefix string
+	componentHttpPathPrefix          string
+	componentHttpPathPrefixRemotecfg string
 }
 
 var _ service.Service = (*Service)(nil)
@@ -120,7 +122,8 @@ func New(opts Options) *Service {
 		tcpLis:    tcpLis,
 		memLis:    memconn.NewListener(l),
 
-		componentHttpPathPrefix: "/api/v0/component/",
+		componentHttpPathPrefix:          "/api/v0/component/",
+		componentHttpPathPrefixRemotecfg: "/api/v0/component/remotecfg",
 	}
 }
 
@@ -129,7 +132,7 @@ func (s *Service) Definition() service.Definition {
 	return service.Definition{
 		Name:       ServiceName,
 		ConfigType: Arguments{},
-		DependsOn:  nil, // http has no dependencies.
+		DependsOn:  []string{remotecfg.ServiceName}, // http requires remotecfg to be up to wire lookups to its controller.
 		Stability:  featuregate.StabilityGenerallyAvailable,
 	}
 }
@@ -174,7 +177,18 @@ func (s *Service) Run(ctx context.Context, host service.Host) error {
 		r.PathPrefix("/debug/pprof").Handler(http.DefaultServeMux)
 	}
 
-	r.PathPrefix(s.componentHttpPathPrefix).Handler(s.componentHandler(host))
+	svc, ok := host.GetService(remotecfg.ServiceName)
+	if !ok {
+		// This will never happen as the service dependency is explicit.
+		level.Error(s.log).Log("msg", "failed to get the remotecfg service when setting up the http service")
+		os.Exit(1)
+	}
+	remotecfgHost := svc.(*remotecfg.Service).Data().(remotecfg.Data).Host
+
+	// NOTE(@tpaschalis) These need to be kept in order for the longer
+	// remotecfg prefix to be invoked correctly.
+	r.PathPrefix(s.componentHttpPathPrefixRemotecfg).Handler(s.componentHandler(remotecfgHost, s.componentHttpPathPrefixRemotecfg))
+	r.PathPrefix(s.componentHttpPathPrefix).Handler(s.componentHandler(host, s.componentHttpPathPrefix))
 
 	if s.opts.ReadyFunc != nil {
 		r.HandleFunc("/-/ready", func(w http.ResponseWriter, _ *http.Request) {
@@ -265,10 +279,10 @@ func (s *Service) getServiceRoutes(host service.Host) []serviceRoute {
 	return routes
 }
 
-func (s *Service) componentHandler(host service.Host) http.HandlerFunc {
+func (s *Service) componentHandler(host service.Host, pathPrefix string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Trim the path prefix to get our full path.
-		trimmedPath := strings.TrimPrefix(r.URL.Path, s.componentHttpPathPrefix)
+		trimmedPath := strings.TrimPrefix(r.URL.Path, pathPrefix)
 
 		// splitURLPath should only fail given an unexpected path.
 		componentID, componentPath, err := splitURLPath(host, trimmedPath)

--- a/internal/service/http/http.go
+++ b/internal/service/http/http.go
@@ -132,7 +132,7 @@ func (s *Service) Definition() service.Definition {
 	return service.Definition{
 		Name:       ServiceName,
 		ConfigType: Arguments{},
-		DependsOn:  nil, //[]string{remotecfg.ServiceName}, // http requires remotecfg to be up to wire lookups to its controller.
+		DependsOn:  []string{remotecfg.ServiceName}, // http requires remotecfg to be up to wire lookups to its controller.
 		Stability:  featuregate.StabilityGenerallyAvailable,
 	}
 }

--- a/internal/service/http/http.go
+++ b/internal/service/http/http.go
@@ -180,8 +180,7 @@ func (s *Service) Run(ctx context.Context, host service.Host) error {
 	svc, ok := host.GetService(remotecfg.ServiceName)
 	if !ok {
 		// This will never happen as the service dependency is explicit.
-		level.Error(s.log).Log("msg", "failed to get the remotecfg service when setting up the http service")
-		os.Exit(1)
+		return fmt.Errorf("failed to get the remotecfg service when setting up the http service")
 	}
 	remotecfgHost := svc.(*remotecfg.Service).Data().(remotecfg.Data).Host
 


### PR DESCRIPTION
#### PR Description

This PR exposes the Host of the isolated controller that is run by the remotecfg service, to allow for component lookups to be made against them.

This enables, for example, the in-memory HTTP listener to work properly for remotecfg-supplied configurations.

@rfratto pointed me to a design doc about a [controller refactor](https://docs.google.com/document/d/1jo0WBg89KMqXRixsr7uAZ6cMVgVg50AEhmoq2S-Y1ss/edit#heading=h.4d226co8feom) which potentially could've given us a different approach, but I believe this is the most straightforward way to achieve this right now.

#### Which issue(s) this PR fixes

No issue filed.

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
- [ ] Documentation added (N/A)
- [ ] Tests updated
