### PR TITLE
Logger: expose it as slog handler

### DIFF
--- a/internal/runtime/logging/logger.go
+++ b/internal/runtime/logging/logger.go
@@ -166,6 +166,13 @@ func (l *Logger) addRecord(r slog.Record, df *deferredSlogHandler) {
 	})
 }
 
+// SlogHandler exposes the Logger instance as a slog.Handler interface for
+// easier integration with external components that do not directly use Logger
+// (for example, Beyla)
+func (l *Logger) SlogHandler() slog.Handler {
+	return l.deferredSlog
+}
+
 type lokiWriter struct {
 	f []loki.LogsReceiver
 }


### PR DESCRIPTION
#### PR Description

Lets exposing a `logging.Logger` instance as an `slog.Handler` interface implementer. This will provide automatic integration of the Alloy logging subsystem with external components such as Beyla.

#### Which issue(s) this PR fixes

Addresses this comment from another Pull Request: https://github.com/grafana/alloy/pull/1356#discussion_r1695064186

#### Notes to the Reviewer

#### PR Checklist

- [] CHANGELOG.md updated
- [] Documentation added
- [X] Tests updated
- [] Config converters updated
