### PR TITLE
Clear `discovery.*` cache when config is reloaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,8 +132,8 @@ Main (unreleased)
   Previously, the reload would fail for `loki.process` without an error in the logs and the metrics
   from the `metrics` stage would get stuck at the same values. (@ptodev)
 
-- Fix a bug in `discovery.kubernetes` where old `targets` would continue to be exported to downstream components,
-  even if the component is configured to not discover them. (@ptodev)
+- Fix a bug in `discovery.*` components where old `targets` would continue to be exported to downstream components.
+  This would only happen if the config for `discovery.*`  is reloaded in such a way that no new targets were discovered. (@ptodev)
 
 v1.2.1
 -----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,9 @@ Main (unreleased)
   Previously, the reload would fail for `loki.process` without an error in the logs and the metrics
   from the `metrics` stage would get stuck at the same values. (@ptodev)
 
+- Fix a bug in `discovery.kubernetes` where old `targets` would continue to be exported to downstream components,
+  even if the component is configured to not discover them. (@ptodev)
+
 v1.2.1
 -----------------
 

--- a/internal/component/discovery/discovery.go
+++ b/internal/component/discovery/discovery.go
@@ -226,6 +226,12 @@ func (c *Component) runDiscovery(ctx context.Context, d DiscovererWithMetrics) {
 				haveUpdates = false
 			}
 		case <-ctx.Done():
+			// Clear the cache
+			//TODO: Write a unit test which changes the config, reloads the component,
+			// and checks that the targets which should no longer be exported are removed.
+			// For example, remove certain namespaces from the config and make sure there is no
+			// __meta_kubernetes_namespace label whose value is set to the removed namespace.
+			cache = map[string]*targetgroup.Group{}
 			// shut down the discoverer - send latest targets and wait for discoverer goroutine to exit
 			send()
 			<-runExited


### PR DESCRIPTION
#### PR Description

This PR fixes a bug whereby if `discovery.` components such as `discovery.kubernetes` are reconfigured differently, they may still end up exporting targets that it's not meant to export. For example, if an Alloy is configured like this...

```
discovery.kubernetes "pods" {
  role = "pod"
  kubeconfig_file = env("HOME") + "/.kube/config"
  namespaces {
    names = ["default", "alloy-logs"]
  }
}
```

...and then reconfigured like this...
```
discovery.kubernetes "pods" {
  role = "pod"
  kubeconfig_file = env("HOME") + "/.kube/config"
  namespaces {
    names = ["default"]
  }
}
```

... after the config is reloaded with `localhost:12345/-/reload`, Alloy would still end up exporting targets with a `__meta_kubernetes_namespace` label set to `alloy-logs` **but only if there are no pods discovered in the `default` namespace**. If pods were discovered in the `default` namespace, this bug wouldn't trigger and no pods from `alloy-logs` will flow downstream, as expected.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
