### PR TITLE
runtime: reuse worker pool for new child controllers

### DIFF
--- a/internal/runtime/alloy_services.go
+++ b/internal/runtime/alloy_services.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/grafana/alloy/internal/runtime/internal/controller"
 	"github.com/grafana/alloy/internal/runtime/internal/dag"
-	"github.com/grafana/alloy/internal/runtime/internal/worker"
 	"github.com/grafana/alloy/internal/service"
 )
 
@@ -84,7 +83,7 @@ func (f *Runtime) NewController(id string) service.Controller {
 			},
 			IsModule:       true,
 			ModuleRegistry: newModuleRegistry(),
-			WorkerPool:     worker.NewDefaultWorkerPool(),
+			WorkerPool:     f.opts.WorkerPool, // NOTE(@tpaschalis) Reuse the worker pool since the worker cleanup is triggered from the root controller.
 		}),
 	}
 }

--- a/internal/runtime/alloy_services_test.go
+++ b/internal/runtime/alloy_services_test.go
@@ -338,6 +338,41 @@ func TestComponents_Using_Services_In_Modules(t *testing.T) {
 	require.NoError(t, componentBuilt.Wait(5*time.Second), "Component should have been built")
 }
 
+func TestNewControllerNoLeak(t *testing.T) {
+	defer verifyNoGoroutineLeaks(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var (
+		startedSvc = util.NewWaitTrigger()
+
+		svc = &testservices.Fake{
+			RunFunc: func(ctx context.Context, _ service.Host) error {
+				startedSvc.Trigger()
+
+				<-ctx.Done()
+				return nil
+			},
+		}
+	)
+
+	opts := testOptions(t)
+	opts.Services = append(opts.Services, svc)
+
+	ctrl := New(opts)
+	require.NoError(t, ctrl.LoadSource(makeEmptyFile(t), nil))
+
+	// Start the controller. This should cause our service to run.
+	go ctrl.Run(ctx)
+	require.NoError(t, startedSvc.Wait(5*time.Second), "Service did not start")
+
+	// Create a new isolated controller from ctrl and run it.
+	// Returning from the test should shut down this new controller as well
+	// and avoid leaking any goroutines.
+	nctrl := ctrl.NewController("id")
+	go nctrl.Run(ctx)
+}
+
 func makeEmptyFile(t *testing.T) *Source {
 	t.Helper()
 


### PR DESCRIPTION
#### PR Description

Right now, child controllers started from the NewController start their own individual worker pool for managing component lifecycle. The fact that these controllers are non-root though [prohibits them](https://github.com/grafana/alloy/blob/09548bf1a77c5b704147ec711444f672baf2bbd4/internal/runtime/alloy.go#L244
) from being properly cleaned up, meaning they can leak goroutines.

In the rest of the cases that we spawn module controllers, [the worker pool is inherited](https://github.com/grafana/alloy/blob/09548bf1a77c5b704147ec711444f672baf2bbd4/internal/runtime/alloy.go#L207) from the root, so this PR makes it so that NewController follow along in the same pattern.

#### Which issue(s) this PR fixes

No issue filed.

#### Notes to the Reviewer

As discussed, I'd like to _not_ include this PR in the upcoming release, so as to leave some time for dogfooding with this internally.

Feel free to propose more ways we can test this or any raise any other questions you may have.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated (N/A)
- [ ] Documentation added (N/A)
- [X] Tests updated
