### PR TITLE
Default to `0.0.0.0` instead of `localhost` in OTel receivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,6 @@ v1.3.0-rc.0
 
 ### Breaking changes
 
-- `otelcol.receiver.otlp`, `otelcol.receiver.jaeger`, `otelcol.extension.jaeger_remote_sampling`, `otelcol.receiver.zipkin` 
-  will now configure `endpoint` using `localhost` by default instead of `0.0.0.0`. 
-  This may break the receiver in containerized environments like Kubernetes. 
-  If you depend on `0.0.0.0`, configure the `endpoint` attribute to explicitly use `0.0.0.0`.
 - [`otelcol.exporter.otlp`,`otelcol.exporter.loadbalancing`]: Change the default gRPC load balancing strategy.
   The default value for the `balancer_name` attribute has changed to `round_robin`
   https://github.com/open-telemetry/opentelemetry-collector/pull/10319

--- a/docs/sources/reference/components/otelcol/otelcol.extension.jaeger_remote_sampling.md
+++ b/docs/sources/reference/components/otelcol/otelcol.extension.jaeger_remote_sampling.md
@@ -75,7 +75,7 @@ The following arguments are supported:
 
 Name                     | Type           | Description                                                     | Default          | Required
 -------------------------|----------------|-----------------------------------------------------------------|------------------|---------
-`endpoint`               | `string`       | `host:port` to listen for traffic on.                           | `"localhost:5778"` | no
+`endpoint`               | `string`       | `host:port` to listen for traffic on.                           | `"0.0.0.0:5778"` | no
 `max_request_body_size`  | `string`       | Maximum request body size the server will allow.                | `20MiB`          | no
 `include_metadata`       | `boolean`      | Propagate incoming connection metadata to downstream consumers. |                  | no
 `compression_algorithms` | `list(string)` | A list of compression algorithms the server can accept.         | `["", "gzip", "zstd", "zlib", "snappy", "deflate"]` | no
@@ -118,7 +118,7 @@ The following arguments are supported:
 
 Name                     | Type      | Description                                                                | Default           | Required
 -------------------------|-----------|----------------------------------------------------------------------------|-------------------|---------
-`endpoint`               | `string`  | `host:port` to listen for traffic on.                                      | `"localhost:14250"` | no
+`endpoint`               | `string`  | `host:port` to listen for traffic on.                                      | `"0.0.0.0:14250"` | no
 `transport`              | `string`  | Transport to use for the gRPC server.                                      | `"tcp"`           | no
 `max_recv_msg_size`      | `string`  | Maximum size of messages the server will accept.                           | `"4MiB"`          | no
 `max_concurrent_streams` | `number`  | Limit the number of concurrent streaming RPC calls.                        |                   | no

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.jaeger.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.jaeger.md
@@ -94,7 +94,7 @@ The following arguments are supported:
 
 Name                     | Type      | Description                                                                | Default           | Required
 -------------------------|-----------|----------------------------------------------------------------------------|-------------------|---------
-`endpoint`               | `string`  | `host:port` to listen for traffic on.                                      | `"localhost:14250"` | no
+`endpoint`               | `string`  | `host:port` to listen for traffic on.                                      | `"0.0.0.0:14250"` | no
 `transport`              | `string`  | Transport to use for the gRPC server.                                      | `"tcp"`           | no
 `max_recv_msg_size`      | `string`  | Maximum size of messages the server will accept.                           | `"4MiB`"          | no
 `max_concurrent_streams` | `number`  | Limit the number of concurrent streaming RPC calls.                        |                   | no
@@ -150,7 +150,7 @@ The following arguments are supported:
 
 Name                     | Type      | Description                                                     | Default           | Required
 -------------------------|-----------|-----------------------------------------------------------------|-------------------|---------
-`endpoint`               | `string`  | `host:port` to listen for traffic on.                           | `"localhost:14268"` | no
+`endpoint`               | `string`  | `host:port` to listen for traffic on.                           | `"0.0.0.0:14268"` | no
 `max_request_body_size`  | `string`  | Maximum request body size the server will allow.                | `20MiB`           | no
 `include_metadata`       | `boolean` | Propagate incoming connection metadata to downstream consumers. |                   | no
 `compression_algorithms` | `list(string)` | A list of compression algorithms the server can accept.    | `["", "gzip", "zstd", "zlib", "snappy", "deflate"]` | no
@@ -186,7 +186,7 @@ The following arguments are supported:
 
 Name                 | Type     | Description                                                    | Default          | Required
 ---------------------|----------|----------------------------------------------------------------|------------------|---------
-`endpoint`           | `string` | `host:port` to listen for traffic on.                          | `"localhost:6832"` | no
+`endpoint`           | `string` | `host:port` to listen for traffic on.                          | `"0.0.0.0:6832"` | no
 `queue_size`         | `number` | Maximum number of UDP messages that can be queued at once.     | `1000`           | no
 `max_packet_size`    | `string` | Maximum UDP message size.                                      | `"65KiB"`        | no
 `workers`            | `number` | Number of workers to concurrently read from the message queue. | `10`             | no
@@ -201,7 +201,7 @@ The following arguments are supported:
 
 Name                 | Type     | Description                                                    | Default          | Required
 ---------------------|----------|----------------------------------------------------------------|------------------|---------
-`endpoint`           | `string` | `host:port` to listen for traffic on.                          | `localhost:6831"` | no
+`endpoint`           | `string` | `host:port` to listen for traffic on.                          | `"0.0.0.0:6831"` | no
 `queue_size`         | `number` | Maximum number of UDP messages that can be queued at once.     | `1000`           | no
 `max_packet_size`    | `string` | Maximum UDP message size.                                      | `"65KiB"`        | no
 `workers`            | `number` | Number of workers to concurrently read from the message queue. | `10`             | no

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.opencensus.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.opencensus.md
@@ -40,7 +40,7 @@ otelcol.receiver.opencensus "LABEL" {
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `cors_allowed_origins` | `list(string)` | A list of allowed Cross-Origin Resource Sharing (CORS) origins. |  | no
-`endpoint` | `string` | `host:port` to listen for traffic on. | `"localhost:55678"` | no
+`endpoint` | `string` | `host:port` to listen for traffic on. | `"0.0.0.0:55678"` | no
 `transport` | `string` | Transport to use for the gRPC server. | `"tcp"` | no
 `max_recv_msg_size` | `string` | Maximum size of messages the server will accept. | `"4MiB`" | no
 `max_concurrent_streams` | `number` | Limit the number of concurrent streaming RPC calls. | | no

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.otlp.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.otlp.md
@@ -78,7 +78,7 @@ The following arguments are supported:
 
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`endpoint` | `string` | `host:port` to listen for traffic on. | `"localhost:4317"` | no
+`endpoint` | `string` | `host:port` to listen for traffic on. | `"0.0.0.0:4317"` | no
 `transport` | `string` | Transport to use for the gRPC server. | `"tcp"` | no
 `max_recv_msg_size` | `string` | Maximum size of messages the server will accept. | `"4MiB`" | no
 `max_concurrent_streams` | `number` | Limit the number of concurrent streaming RPC calls. | | no
@@ -138,7 +138,7 @@ The following arguments are supported:
 
 Name | Type | Description | Default         | Required
 ---- | ---- | ----------- |-----------------| --------
-`endpoint` | `string` | `host:port` to listen for traffic on. | `"localhost:4318"` | no
+`endpoint` | `string` | `host:port` to listen for traffic on. | `"0.0.0.0:4318"` | no
 `max_request_body_size` | `string`   | Maximum request body size the server will allow.                   | `20MiB`          | no
 `include_metadata` | `boolean` | Propagate incoming connection metadata to downstream consumers. |                 | no
 `traces_url_path` | `string` | The URL path to receive traces on. | `"/v1/traces"`  | no

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.zipkin.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.zipkin.md
@@ -35,7 +35,7 @@ otelcol.receiver.zipkin "LABEL" {
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `parse_string_tags` | `bool` | Parse string tags and binary annotations into non-string types. | `false` | no
-`endpoint` | `string` | `host:port` to listen for traffic on. | `"localhost:9411"` | no
+`endpoint` | `string` | `host:port` to listen for traffic on. | `"0.0.0.0:9411"` | no
 `max_request_body_size` | `string`   | Maximum request body size the server will allow.                   | `20MiB`          | no
 `include_metadata` | `boolean` | Propagate incoming connection metadata to downstream consumers. | | no
 `compression_algorithms` | `list(string)` | A list of compression algorithms the server can accept.    | `["", "gzip", "zstd", "zlib", "snappy", "deflate"]` | no

--- a/internal/cmd/integration-tests/tests/otlp-metrics/config.alloy
+++ b/internal/cmd/integration-tests/tests/otlp-metrics/config.alloy
@@ -1,7 +1,5 @@
 otelcol.receiver.otlp "otlp_metrics" {
-  http {
-    endpoint = "0.0.0.0:4318"
-  }
+  http {}
 
   output {
     metrics = [otelcol.processor.attributes.otlp_metrics.input, otelcol.exporter.prometheus.otlp_to_prom_metrics.input]

--- a/internal/component/otelcol/extension/jaeger_remote_sampling/internal/jaegerremotesampling/config_test.go
+++ b/internal/component/otelcol/extension/jaeger_remote_sampling/internal/jaegerremotesampling/config_test.go
@@ -27,9 +27,9 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id: component.NewID(component.MustNewType(typeStr)),
 			expected: &Config{
-				HTTPServerConfig: &confighttp.ServerConfig{Endpoint: "localhost:5778"},
+				HTTPServerConfig: &confighttp.ServerConfig{Endpoint: ":5778"},
 				GRPCServerConfig: &configgrpc.ServerConfig{NetAddr: confignet.AddrConfig{
-					Endpoint:  "localhost:14250",
+					Endpoint:  ":14250",
 					Transport: confignet.TransportTypeTCP,
 				}},
 				Source: Source{
@@ -42,9 +42,9 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id: component.NewIDWithName(component.MustNewType(typeStr), "1"),
 			expected: &Config{
-				HTTPServerConfig: &confighttp.ServerConfig{Endpoint: "localhost:5778"},
+				HTTPServerConfig: &confighttp.ServerConfig{Endpoint: ":5778"},
 				GRPCServerConfig: &configgrpc.ServerConfig{NetAddr: confignet.AddrConfig{
-					Endpoint:  "localhost:14250",
+					Endpoint:  ":14250",
 					Transport: confignet.TransportTypeTCP,
 				}},
 				Source: Source{

--- a/internal/component/otelcol/extension/jaeger_remote_sampling/internal/jaegerremotesampling/factory.go
+++ b/internal/component/otelcol/extension/jaeger_remote_sampling/internal/jaegerremotesampling/factory.go
@@ -34,11 +34,11 @@ func NewFactory() extension.Factory {
 func createDefaultConfig() component.Config {
 	return &Config{
 		HTTPServerConfig: &confighttp.ServerConfig{
-			Endpoint: "localhost:5778",
+			Endpoint: ":5778",
 		},
 		GRPCServerConfig: &configgrpc.ServerConfig{
 			NetAddr: confignet.AddrConfig{
-				Endpoint:  "localhost:14250",
+				Endpoint:  ":14250",
 				Transport: "tcp",
 			},
 		},

--- a/internal/component/otelcol/extension/jaeger_remote_sampling/internal/jaegerremotesampling/factory_test.go
+++ b/internal/component/otelcol/extension/jaeger_remote_sampling/internal/jaegerremotesampling/factory_test.go
@@ -18,9 +18,9 @@ import (
 func TestCreateDefaultConfig(t *testing.T) {
 	// prepare and test
 	expected := &Config{
-		HTTPServerConfig: &confighttp.ServerConfig{Endpoint: "localhost:5778"},
+		HTTPServerConfig: &confighttp.ServerConfig{Endpoint: ":5778"},
 		GRPCServerConfig: &configgrpc.ServerConfig{NetAddr: confignet.AddrConfig{
-			Endpoint:  "localhost:14250",
+			Endpoint:  ":14250",
 			Transport: confignet.TransportTypeTCP,
 		}},
 	}

--- a/internal/component/otelcol/receiver/jaeger/jaeger.go
+++ b/internal/component/otelcol/receiver/jaeger/jaeger.go
@@ -106,7 +106,7 @@ type GRPC struct {
 func (args *GRPC) SetToDefault() {
 	*args = GRPC{
 		GRPCServerArguments: &otelcol.GRPCServerArguments{
-			Endpoint:  "localhost:14250",
+			Endpoint:  "0.0.0.0:14250",
 			Transport: "tcp",
 		},
 	}
@@ -129,7 +129,7 @@ type ThriftHTTP struct {
 func (args *ThriftHTTP) SetToDefault() {
 	*args = ThriftHTTP{
 		HTTPServerArguments: &otelcol.HTTPServerArguments{
-			Endpoint:              "localhost:14268",
+			Endpoint:              "0.0.0.0:14268",
 			CompressionAlgorithms: append([]string(nil), otelcol.DefaultCompressionAlgorithms...),
 		},
 	}
@@ -179,7 +179,7 @@ type ThriftCompact struct {
 func (args *ThriftCompact) SetToDefault() {
 	*args = ThriftCompact{
 		ProtocolUDP: &ProtocolUDP{
-			Endpoint:      "localhost:6831",
+			Endpoint:      "0.0.0.0:6831",
 			QueueSize:     1_000,
 			MaxPacketSize: 65 * units.KiB,
 			Workers:       10,
@@ -205,7 +205,7 @@ type ThriftBinary struct {
 func (args *ThriftBinary) SetToDefault() {
 	*args = ThriftBinary{
 		ProtocolUDP: &ProtocolUDP{
-			Endpoint:      "localhost:6832",
+			Endpoint:      "0.0.0.0:6832",
 			QueueSize:     1_000,
 			MaxPacketSize: 65 * units.KiB,
 			Workers:       10,

--- a/internal/component/otelcol/receiver/opencensus/opencensus.go
+++ b/internal/component/otelcol/receiver/opencensus/opencensus.go
@@ -45,7 +45,7 @@ var _ receiver.Arguments = Arguments{}
 func (args *Arguments) SetToDefault() {
 	*args = Arguments{
 		GRPC: otelcol.GRPCServerArguments{
-			Endpoint:  "localhost:55678",
+			Endpoint:  "0.0.0.0:55678",
 			Transport: "tcp",
 
 			ReadBufferSize: 512 * units.Kibibyte,

--- a/internal/component/otelcol/receiver/opencensus/opencensus_test.go
+++ b/internal/component/otelcol/receiver/opencensus/opencensus_test.go
@@ -59,7 +59,7 @@ func TestDefaultArguments_UnmarshalAlloy(t *testing.T) {
 	defaultArgs.SetToDefault()
 
 	// Check the gRPC arguments
-	require.Equal(t, otelArgs.NetAddr.Endpoint, "localhost:55678")
+	require.Equal(t, otelArgs.NetAddr.Endpoint, "0.0.0.0:55678")
 
 	// Check the gRPC arguments
 	require.Equal(t, defaultArgs.GRPC.Endpoint, otelArgs.NetAddr.Endpoint)

--- a/internal/component/otelcol/receiver/otlp/otlp.go
+++ b/internal/component/otelcol/receiver/otlp/otlp.go
@@ -136,7 +136,7 @@ func validateURL(url string, urlName string) error {
 // SetToDefault implements syntax.Defaulter.
 func (args *GRPCServerArguments) SetToDefault() {
 	*args = GRPCServerArguments{
-		Endpoint:  "localhost:4317",
+		Endpoint:  "0.0.0.0:4317",
 		Transport: "tcp",
 
 		ReadBufferSize: 512 * units.Kibibyte,
@@ -148,7 +148,7 @@ func (args *GRPCServerArguments) SetToDefault() {
 func (args *HTTPConfigArguments) SetToDefault() {
 	*args = HTTPConfigArguments{
 		HTTPServerArguments: &otelcol.HTTPServerArguments{
-			Endpoint:              "localhost:4318",
+			Endpoint:              "0.0.0.0:4318",
 			CompressionAlgorithms: append([]string(nil), otelcol.DefaultCompressionAlgorithms...),
 		},
 		MetricsURLPath: "/v1/metrics",

--- a/internal/component/otelcol/receiver/otlp/otlp_test.go
+++ b/internal/component/otelcol/receiver/otlp/otlp_test.go
@@ -145,14 +145,14 @@ func TestUnmarshalDefault(t *testing.T) {
 		Protocols: otlpreceiver.Protocols{
 			GRPC: &configgrpc.ServerConfig{
 				NetAddr: confignet.AddrConfig{
-					Endpoint:  "localhost:4317",
+					Endpoint:  "0.0.0.0:4317",
 					Transport: "tcp",
 				},
 				ReadBufferSize: 524288,
 			},
 			HTTP: &otlpreceiver.HTTPConfig{
 				ServerConfig: &confighttp.ServerConfig{
-					Endpoint:              "localhost:4318",
+					Endpoint:              "0.0.0.0:4318",
 					CompressionAlgorithms: []string{"", "gzip", "zstd", "zlib", "snappy", "deflate"},
 				},
 				TracesURLPath:  "/v1/traces",

--- a/internal/component/otelcol/receiver/zipkin/zipkin.go
+++ b/internal/component/otelcol/receiver/zipkin/zipkin.go
@@ -44,7 +44,7 @@ var _ receiver.Arguments = Arguments{}
 func (args *Arguments) SetToDefault() {
 	*args = Arguments{
 		HTTPServer: otelcol.HTTPServerArguments{
-			Endpoint:              "localhost:9411",
+			Endpoint:              "0.0.0.0:9411",
 			CompressionAlgorithms: append([]string(nil), otelcol.DefaultCompressionAlgorithms...),
 		},
 	}

--- a/internal/component/otelcol/receiver/zipkin/zipkin_test.go
+++ b/internal/component/otelcol/receiver/zipkin/zipkin_test.go
@@ -56,7 +56,7 @@ func TestArguments_UnmarshalDefaults(t *testing.T) {
 
 	expected := zipkinreceiver.Config{
 		ServerConfig: confighttp.ServerConfig{
-			Endpoint:              "localhost:9411",
+			Endpoint:              "0.0.0.0:9411",
 			CompressionAlgorithms: []string{"", "gzip", "zstd", "zlib", "snappy", "deflate"},
 		},
 	}

--- a/internal/converter/internal/otelcolconvert/testdata/attributes.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/attributes.alloy
@@ -1,7 +1,11 @@
 otelcol.receiver.otlp "default" {
-	grpc { }
+	grpc {
+		endpoint = "localhost:4317"
+	}
 
-	http { }
+	http {
+		endpoint = "localhost:4318"
+	}
 
 	output {
 		metrics = [otelcol.processor.attributes.default_example.input]

--- a/internal/converter/internal/otelcolconvert/testdata/basicauth.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/basicauth.alloy
@@ -9,9 +9,13 @@ otelcol.auth.basic "default_client" {
 }
 
 otelcol.receiver.otlp "default" {
-	grpc { }
+	grpc {
+		endpoint = "localhost:4317"
+	}
 
-	http { }
+	http {
+		endpoint = "localhost:4318"
+	}
 
 	output {
 		metrics = [otelcol.exporter.otlp.default.input]

--- a/internal/converter/internal/otelcolconvert/testdata/batch.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/batch.alloy
@@ -1,7 +1,11 @@
 otelcol.receiver.otlp "default" {
-	grpc { }
+	grpc {
+		endpoint = "localhost:4317"
+	}
 
-	http { }
+	http {
+		endpoint = "localhost:4318"
+	}
 
 	output {
 		metrics = [otelcol.processor.batch.default.input]

--- a/internal/converter/internal/otelcolconvert/testdata/bearertoken.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/bearertoken.alloy
@@ -13,9 +13,13 @@ otelcol.auth.bearer "default_withscheme" {
 }
 
 otelcol.receiver.otlp "default" {
-	grpc { }
+	grpc {
+		endpoint = "localhost:4317"
+	}
 
-	http { }
+	http {
+		endpoint = "localhost:4318"
+	}
 
 	output {
 		metrics = [otelcol.exporter.otlp.default_withauth.input, otelcol.exporter.otlphttp.default_withauth.input]

--- a/internal/converter/internal/otelcolconvert/testdata/debug.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/debug.alloy
@@ -1,7 +1,11 @@
 otelcol.receiver.otlp "default" {
-	grpc { }
+	grpc {
+		endpoint = "localhost:4317"
+	}
 
-	http { }
+	http {
+		endpoint = "localhost:4318"
+	}
 
 	output {
 		metrics = [otelcol.exporter.debug.default.input, otelcol.exporter.debug.default_default.input]

--- a/internal/converter/internal/otelcolconvert/testdata/deltatocumulative.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/deltatocumulative.alloy
@@ -1,7 +1,11 @@
 otelcol.receiver.otlp "default" {
-	grpc { }
+	grpc {
+		endpoint = "localhost:4317"
+	}
 
-	http { }
+	http {
+		endpoint = "localhost:4318"
+	}
 
 	output {
 		metrics = [otelcol.processor.deltatocumulative.default.input]

--- a/internal/converter/internal/otelcolconvert/testdata/filter.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/filter.alloy
@@ -1,7 +1,11 @@
 otelcol.receiver.otlp "default" {
-	grpc { }
+	grpc {
+		endpoint = "localhost:4317"
+	}
 
-	http { }
+	http {
+		endpoint = "localhost:4318"
+	}
 
 	output {
 		metrics = [otelcol.processor.filter.default_ottl.input]

--- a/internal/converter/internal/otelcolconvert/testdata/headerssetter.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/headerssetter.alloy
@@ -23,9 +23,13 @@ otelcol.auth.headers "default" {
 }
 
 otelcol.receiver.otlp "default" {
-	grpc { }
+	grpc {
+		endpoint = "localhost:4317"
+	}
 
-	http { }
+	http {
+		endpoint = "localhost:4318"
+	}
 
 	output {
 		metrics = [otelcol.exporter.otlp.default.input]

--- a/internal/converter/internal/otelcolconvert/testdata/inconsistent_processor.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/inconsistent_processor.alloy
@@ -1,7 +1,11 @@
 otelcol.receiver.otlp "default" {
-	grpc { }
+	grpc {
+		endpoint = "localhost:4317"
+	}
 
-	http { }
+	http {
+		endpoint = "localhost:4318"
+	}
 
 	output {
 		metrics = [otelcol.exporter.otlp.default.input]

--- a/internal/converter/internal/otelcolconvert/testdata/jaeger.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/jaeger.alloy
@@ -1,14 +1,20 @@
 otelcol.receiver.jaeger "default" {
 	protocols {
-		grpc { }
+		grpc {
+			endpoint = "localhost:14250"
+		}
 
-		thrift_http { }
+		thrift_http {
+			endpoint = "localhost:14268"
+		}
 
 		thrift_binary {
+			endpoint        = "localhost:6832"
 			max_packet_size = "63KiB488B"
 		}
 
 		thrift_compact {
+			endpoint        = "localhost:6831"
 			max_packet_size = "63KiB488B"
 		}
 	}

--- a/internal/converter/internal/otelcolconvert/testdata/jaegerremotesampling.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/jaegerremotesampling.alloy
@@ -13,15 +13,21 @@ otelcol.extension.jaeger_remote_sampling "default" {
 
 otelcol.receiver.jaeger "default" {
 	protocols {
-		grpc { }
+		grpc {
+			endpoint = "localhost:14250"
+		}
 
-		thrift_http { }
+		thrift_http {
+			endpoint = "localhost:14268"
+		}
 
 		thrift_binary {
+			endpoint        = "localhost:6832"
 			max_packet_size = "63KiB488B"
 		}
 
 		thrift_compact {
+			endpoint        = "localhost:6831"
 			max_packet_size = "63KiB488B"
 		}
 	}

--- a/internal/converter/internal/otelcolconvert/testdata/k8sattributes.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/k8sattributes.alloy
@@ -1,7 +1,11 @@
 otelcol.receiver.otlp "default" {
-	grpc { }
+	grpc {
+		endpoint = "localhost:4317"
+	}
 
-	http { }
+	http {
+		endpoint = "localhost:4318"
+	}
 
 	output {
 		metrics = [otelcol.processor.k8sattributes.default.input]

--- a/internal/converter/internal/otelcolconvert/testdata/loadbalancing.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/loadbalancing.alloy
@@ -1,5 +1,7 @@
 otelcol.receiver.otlp "default" {
-	grpc { }
+	grpc {
+		endpoint = "localhost:4317"
+	}
 
 	output {
 		metrics = [otelcol.exporter.loadbalancing.default.input]

--- a/internal/converter/internal/otelcolconvert/testdata/logging.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/logging.alloy
@@ -1,7 +1,11 @@
 otelcol.receiver.otlp "default" {
-	grpc { }
+	grpc {
+		endpoint = "localhost:4317"
+	}
 
-	http { }
+	http {
+		endpoint = "localhost:4318"
+	}
 
 	output {
 		metrics = [otelcol.exporter.logging.default.input, otelcol.exporter.logging.default_2.input]

--- a/internal/converter/internal/otelcolconvert/testdata/memorylimiter.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/memorylimiter.alloy
@@ -1,7 +1,11 @@
 otelcol.receiver.otlp "default" {
-	grpc { }
+	grpc {
+		endpoint = "localhost:4317"
+	}
 
-	http { }
+	http {
+		endpoint = "localhost:4318"
+	}
 
 	output {
 		metrics = [otelcol.processor.memory_limiter.default.input]

--- a/internal/converter/internal/otelcolconvert/testdata/oauth2.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/oauth2.alloy
@@ -17,7 +17,9 @@ otelcol.auth.oauth2 "default" {
 }
 
 otelcol.receiver.otlp "default" {
-	grpc { }
+	grpc {
+		endpoint = "localhost:4317"
+	}
 
 	output {
 		metrics = [otelcol.exporter.otlp.default_withauth.input, otelcol.exporter.otlphttp.default_noauth.input]

--- a/internal/converter/internal/otelcolconvert/testdata/opencensus.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/opencensus.alloy
@@ -1,4 +1,6 @@
 otelcol.receiver.opencensus "default" {
+	endpoint = "localhost:55678"
+
 	output {
 		metrics = [otelcol.exporter.otlp.default.input]
 		traces  = [otelcol.exporter.otlp.default.input]

--- a/internal/converter/internal/otelcolconvert/testdata/otelcol_without_validation/sigv4auth.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/otelcol_without_validation/sigv4auth.alloy
@@ -9,9 +9,13 @@ otelcol.auth.sigv4 "default" {
 }
 
 otelcol.receiver.otlp "default" {
-	grpc { }
+	grpc {
+		endpoint = "localhost:4317"
+	}
 
-	http { }
+	http {
+		endpoint = "localhost:4318"
+	}
 
 	output {
 		metrics = [otelcol.exporter.otlp.default.input]

--- a/internal/converter/internal/otelcolconvert/testdata/otlp.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/otlp.alloy
@@ -1,7 +1,10 @@
 otelcol.receiver.otlp "default" {
-	grpc { }
+	grpc {
+		endpoint = "localhost:4317"
+	}
 
 	http {
+		endpoint               = "localhost:4318"
 		compression_algorithms = ["zlib"]
 	}
 

--- a/internal/converter/internal/otelcolconvert/testdata/otlphttp.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/otlphttp.alloy
@@ -1,7 +1,11 @@
 otelcol.receiver.otlp "default" {
-	grpc { }
+	grpc {
+		endpoint = "localhost:4317"
+	}
 
-	http { }
+	http {
+		endpoint = "localhost:4318"
+	}
 
 	output {
 		metrics = [otelcol.exporter.otlphttp.default.input]

--- a/internal/converter/internal/otelcolconvert/testdata/probabilistic_sampler.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/probabilistic_sampler.alloy
@@ -1,7 +1,11 @@
 otelcol.receiver.otlp "default" {
-	grpc { }
+	grpc {
+		endpoint = "localhost:4317"
+	}
 
-	http { }
+	http {
+		endpoint = "localhost:4318"
+	}
 
 	output {
 		metrics = [otelcol.exporter.otlp.default.input]

--- a/internal/converter/internal/otelcolconvert/testdata/servicegraph.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/servicegraph.alloy
@@ -1,7 +1,11 @@
 otelcol.receiver.otlp "default" {
-	grpc { }
+	grpc {
+		endpoint = "localhost:4317"
+	}
 
-	http { }
+	http {
+		endpoint = "localhost:4318"
+	}
 
 	output {
 		traces = [otelcol.connector.servicegraph.default.input]

--- a/internal/converter/internal/otelcolconvert/testdata/span.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/span.alloy
@@ -1,7 +1,11 @@
 otelcol.receiver.otlp "default" {
-	grpc { }
+	grpc {
+		endpoint = "localhost:4317"
+	}
 
-	http { }
+	http {
+		endpoint = "localhost:4318"
+	}
 
 	output {
 		metrics = [otelcol.exporter.otlp.default.input]

--- a/internal/converter/internal/otelcolconvert/testdata/span_full.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/span_full.alloy
@@ -1,7 +1,11 @@
 otelcol.receiver.otlp "default" {
-	grpc { }
+	grpc {
+		endpoint = "localhost:4317"
+	}
 
-	http { }
+	http {
+		endpoint = "localhost:4318"
+	}
 
 	output {
 		metrics = [otelcol.exporter.otlp.default.input]

--- a/internal/converter/internal/otelcolconvert/testdata/spanmetrics.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/spanmetrics.alloy
@@ -1,7 +1,11 @@
 otelcol.receiver.otlp "default" {
-	grpc { }
+	grpc {
+		endpoint = "localhost:4317"
+	}
 
-	http { }
+	http {
+		endpoint = "localhost:4318"
+	}
 
 	output {
 		logs   = [otelcol.exporter.otlp.default.input]

--- a/internal/converter/internal/otelcolconvert/testdata/spanmetrics_full.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/spanmetrics_full.alloy
@@ -1,7 +1,11 @@
 otelcol.receiver.otlp "default_traces" {
-	grpc { }
+	grpc {
+		endpoint = "localhost:4317"
+	}
 
-	http { }
+	http {
+		endpoint = "localhost:4318"
+	}
 
 	output {
 		traces = [otelcol.exporter.otlp.default_traces_backend.input, otelcol.connector.spanmetrics.default.input]

--- a/internal/converter/internal/otelcolconvert/testdata/tail_sampling.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/tail_sampling.alloy
@@ -1,7 +1,11 @@
 otelcol.receiver.otlp "default" {
-	grpc { }
+	grpc {
+		endpoint = "localhost:4317"
+	}
 
-	http { }
+	http {
+		endpoint = "localhost:4318"
+	}
 
 	output {
 		metrics = [otelcol.processor.tail_sampling.default.input]

--- a/internal/converter/internal/otelcolconvert/testdata/transform.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/transform.alloy
@@ -1,7 +1,11 @@
 otelcol.receiver.otlp "default" {
-	grpc { }
+	grpc {
+		endpoint = "localhost:4317"
+	}
 
-	http { }
+	http {
+		endpoint = "localhost:4318"
+	}
 
 	output {
 		metrics = [otelcol.processor.transform.default.input]

--- a/internal/converter/internal/otelcolconvert/testdata/zipkin.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/zipkin.alloy
@@ -1,4 +1,6 @@
 otelcol.receiver.zipkin "default" {
+	endpoint = "localhost:9411"
+
 	output {
 		traces = [otelcol.exporter.otlp.default.input]
 	}

--- a/internal/converter/internal/staticconvert/testdata/traces.alloy
+++ b/internal/converter/internal/staticconvert/testdata/traces.alloy
@@ -30,10 +30,12 @@ otelcol.extension.jaeger_remote_sampling "default_0" {
 
 otelcol.receiver.otlp "_0_default" {
 	grpc {
+		endpoint         = "localhost:4317"
 		include_metadata = true
 	}
 
 	http {
+		endpoint         = "localhost:4318"
 		include_metadata = true
 	}
 

--- a/internal/converter/internal/staticconvert/testdata/traces_multi.alloy
+++ b/internal/converter/internal/staticconvert/testdata/traces_multi.alloy
@@ -1,9 +1,11 @@
 otelcol.receiver.otlp "trace_config_1_default" {
 	grpc {
+		endpoint         = "localhost:4317"
 		include_metadata = true
 	}
 
 	http {
+		endpoint         = "localhost:4318"
 		include_metadata = true
 	}
 
@@ -35,10 +37,12 @@ otelcol.exporter.otlp "trace_config_1_default_0" {
 
 otelcol.receiver.otlp "trace_config_2_default" {
 	grpc {
+		endpoint         = "localhost:4317"
 		include_metadata = true
 	}
 
 	http {
+		endpoint         = "localhost:4318"
 		include_metadata = true
 	}
 

--- a/internal/converter/internal/staticconvert/testdata/unsupported.alloy
+++ b/internal/converter/internal/staticconvert/testdata/unsupported.alloy
@@ -52,10 +52,12 @@ prometheus.remote_write "integrations" {
 
 otelcol.receiver.otlp "default" {
 	grpc {
+		endpoint         = "localhost:4317"
 		include_metadata = true
 	}
 
 	http {
+		endpoint         = "localhost:4318"
 		include_metadata = true
 	}
 


### PR DESCRIPTION
#### PR Description

This rollbacks a recent OTel breaking change, which was ported to Alloy in #1362 but so far it hasn't been released in Alloy officially (it's just been on the main branch for a few days).

The initial argument for having the breaking change in Alloy was that it gives users a more up to date OTel experience, which aligns with the upstream defaults. However, this particular breaking change has such a large impact that we decided the best time to introduce it would be in Alloy 2.0, which will probably go out at some point next year. 

#### Notes to the Reviewer

The converters will now explicitly convert `endpoint` attributes to `localhost`, since `localhost` is what upstream uses by default.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated
