### PR TITLE
fix(helm): alloy.extraPorts not working with service.type=NodePort

### DIFF
--- a/operations/helm/charts/alloy/templates/service.yaml
+++ b/operations/helm/charts/alloy/templates/service.yaml
@@ -31,6 +31,9 @@ spec:
       protocol: "TCP"
 {{- range $portMap := $values.extraPorts }}
     - name: {{ $portMap.name }}
+      {{- if eq $.Values.service.type "NodePort" }}
+      nodePort: {{ $portMap.nodePort }}
+      {{- end }}
       port: {{ $portMap.port }}
       targetPort: {{ $portMap.targetPort }}
       protocol: {{ coalesce $portMap.protocol "TCP" }}

--- a/operations/helm/charts/alloy/values.yaml
+++ b/operations/helm/charts/alloy/values.yaml
@@ -79,8 +79,10 @@ alloy:
   extraArgs: []
 
   # -- Extra ports to expose on the Alloy container.
+  # NodePort `nodePort`. Only takes effect when `service.type: NodePort`
   extraPorts: []
   # - name: "faro"
+  #   nodePort: 31129
   #   port: 12347
   #   targetPort: 12347
   #   protocol: "TCP"


### PR DESCRIPTION
#### PR Description

#### Which issue(s) this PR fixes

Fixes #1089

#### Notes to the Reviewer
Helm chart version not changed.

#### PR Checklist

- [ ] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
