### PR TITLE
Fix unnecessary `loki.process` config reloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Bugfixes
+
+- Fixed a bug which caused `loki.process` to reload itself when a config reload is triggered,
+  even if its config didn't change. This would only happen when certain stages were present (e.g. `stage.labels`). (@ptodev)
+
 v1.3.0
 -----------------
 

--- a/internal/component/all/all_test.go
+++ b/internal/component/all/all_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/grafana/alloy/internal/component"
+	"github.com/grafana/alloy/internal/util"
 	"github.com/grafana/alloy/syntax"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -55,122 +56,12 @@ func testNoReusePointer(t *testing.T, reg component.Registration) {
 		return
 	}
 
-	if path, shared := sharePointer(rv1, rv2); shared {
+	if path, shared := util.SharePointer(rv1, rv2, true); shared {
 		fullPath := fmt.Sprintf("%s.%s.%s", ty.PkgPath(), ty.Name(), path)
 
 		assert.Fail(t,
 			fmt.Sprintf("Detected SetToDefault pointer reuse at %s", fullPath),
 			"Types implementing syntax.Defaulter must not reuse pointers across multiple calls. Doing so leads to default values being changed when unmarshaling configuration files. If you're seeing this error, check the path above and ensure that copies are being made of any pointers in all instances of SetToDefault calls where that field is used.",
 		)
-	}
-}
-
-func sharePointer(a, b reflect.Value) (string, bool) {
-	// We want to recursively check a and b, so if they're nil they need to be
-	// initialized to see if any of their inner values have shared pointers after
-	// being initialized with defaults.
-	initValue(a)
-	initValue(b)
-
-	// From the documentation of reflect.Value.Pointer, values of chan, func,
-	// map, pointer, slice, and unsafe pointer are all pointer values.
-	//
-	// Additionally, we want to recurse into values (even if they don't have
-	// addresses) to see if there's shared pointers inside of them.
-	switch a.Kind() {
-	case reflect.Chan, reflect.Func, reflect.UnsafePointer:
-		return "", a.Pointer() == b.Pointer()
-
-	case reflect.Map:
-		if pointersMatch(a, b) {
-			return "", true
-		}
-
-		iter := a.MapRange()
-		for iter.Next() {
-			aValue, bValue := iter.Value(), b.MapIndex(iter.Key())
-			if !bValue.IsValid() {
-				continue
-			}
-			if path, shared := sharePointer(aValue, bValue); shared {
-				return path, true
-			}
-		}
-		return "", false
-
-	case reflect.Pointer:
-		if pointersMatch(a, b) {
-			return "", true
-		} else {
-			// Recursively navigate inside of the pointer.
-			return sharePointer(a.Elem(), b.Elem())
-		}
-
-	case reflect.Interface:
-		if a.UnsafeAddr() == b.UnsafeAddr() {
-			return "", true
-		}
-		return sharePointer(a.Elem(), b.Elem())
-
-	case reflect.Slice:
-		if pointersMatch(a, b) {
-			// If the slices are preallocated immutable pointers such as []string{}, we can ignore
-			if a.Len() == 0 && a.Cap() == 0 && b.Len() == 0 && b.Cap() == 0 {
-				return "", false
-			}
-			return "", true
-		}
-
-		size := min(a.Len(), b.Len())
-		for i := 0; i < size; i++ {
-			if path, shared := sharePointer(a.Index(i), b.Index(i)); shared {
-				return path, true
-			}
-		}
-		return "", false
-	}
-
-	// Recurse into non-pointer types.
-	switch a.Kind() {
-	case reflect.Array:
-		for i := 0; i < a.Len(); i++ {
-			if path, shared := sharePointer(a.Index(i), b.Index(i)); shared {
-				return path, true
-			}
-		}
-		return "", false
-
-	case reflect.Struct:
-		// Check to make sure there are no shared pointers between args1 and args2.
-		for i := 0; i < a.NumField(); i++ {
-			if path, shared := sharePointer(a.Field(i), b.Field(i)); shared {
-				fullPath := a.Type().Field(i).Name
-				if path != "" {
-					fullPath += "." + path
-				}
-				return fullPath, true
-			}
-		}
-		return "", false
-	}
-
-	return "", false
-}
-
-func pointersMatch(a, b reflect.Value) bool {
-	if a.IsNil() || b.IsNil() {
-		return false
-	}
-	return a.Pointer() == b.Pointer()
-}
-
-// initValue initializes nil pointers. If the nil pointer implements
-// syntax.Defaulter, it is also set to default values.
-func initValue(rv reflect.Value) {
-	if rv.Kind() == reflect.Pointer && rv.IsNil() {
-		rv.Set(reflect.New(rv.Type().Elem()))
-		if defaulter, ok := rv.Interface().(syntax.Defaulter); ok {
-			defaulter.SetToDefault()
-		}
 	}
 }

--- a/internal/component/loki/process/metric/counters.go
+++ b/internal/component/loki/process/metric/counters.go
@@ -31,6 +31,24 @@ type CounterConfig struct {
 	CountEntryBytes bool   `alloy:"count_entry_bytes,attr,optional"`
 }
 
+func (c *CounterConfig) Copy() *CounterConfig {
+	if c == nil {
+		return nil
+	}
+
+	return &CounterConfig{
+		Name:            c.Name,
+		Description:     c.Description,
+		Source:          c.Source,
+		Prefix:          c.Prefix,
+		MaxIdle:         c.MaxIdle,
+		Value:           c.Value,
+		Action:          c.Action,
+		MatchAll:        c.MatchAll,
+		CountEntryBytes: c.CountEntryBytes,
+	}
+}
+
 // DefaultCounterConfig sets the default for a Counter.
 var DefaultCounterConfig = CounterConfig{
 	MaxIdle: 5 * time.Minute,

--- a/internal/component/loki/process/metric/gauges.go
+++ b/internal/component/loki/process/metric/gauges.go
@@ -40,6 +40,22 @@ type GaugeConfig struct {
 	Action string `alloy:"action,attr"`
 }
 
+func (g *GaugeConfig) Copy() *GaugeConfig {
+	if g == nil {
+		return nil
+	}
+
+	return &GaugeConfig{
+		Name:        g.Name,
+		Description: g.Description,
+		Source:      g.Source,
+		Prefix:      g.Prefix,
+		MaxIdle:     g.MaxIdle,
+		Value:       g.Value,
+		Action:      g.Action,
+	}
+}
+
 // SetToDefault implements syntax.Defaulter.
 func (g *GaugeConfig) SetToDefault() {
 	*g = DefaultGaugeConfig

--- a/internal/component/loki/process/metric/histograms.go
+++ b/internal/component/loki/process/metric/histograms.go
@@ -4,6 +4,7 @@ package metric
 
 import (
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -27,6 +28,22 @@ type HistogramConfig struct {
 
 	// Histogram-specific fields
 	Buckets []float64 `alloy:"buckets,attr"`
+}
+
+func (h *HistogramConfig) Copy() *HistogramConfig {
+	if h == nil {
+		return nil
+	}
+
+	return &HistogramConfig{
+		Name:        h.Name,
+		Description: h.Description,
+		Source:      h.Source,
+		Prefix:      h.Prefix,
+		MaxIdle:     h.MaxIdle,
+		Value:       h.Value,
+		Buckets:     slices.Clone(h.Buckets),
+	}
 }
 
 // SetToDefault implements syntax.Defaulter.

--- a/internal/component/loki/process/process_test.go
+++ b/internal/component/loki/process/process_test.go
@@ -710,9 +710,13 @@ func TestConfigCopy(t *testing.T) {
 	stg := `
 	stage.cri { }
 
-	stage.decolorize { }
+	// Exclude this stage from the test because its config struct 
+	// has no arguments and the shallow copy validator gets confused.
+	// stage.decolorize { }
 
-	stage.docker { }
+	// Exclude this stage from the test because its config struct 
+	// has no arguments and the shallow copy validator gets confused.
+	// stage.docker { }
 
 	stage.drop { }
 

--- a/internal/component/loki/process/stages/decolorize.go
+++ b/internal/component/loki/process/stages/decolorize.go
@@ -6,6 +6,14 @@ import (
 
 type DecolorizeConfig struct{}
 
+func (s *DecolorizeConfig) Copy() *DecolorizeConfig {
+	if s == nil {
+		return nil
+	}
+
+	return &DecolorizeConfig{}
+}
+
 type decolorizeStage struct{}
 
 func newDecolorizeStage(_ DecolorizeConfig) (Stage, error) {

--- a/internal/component/loki/process/stages/drop_test.go
+++ b/internal/component/loki/process/stages/drop_test.go
@@ -411,7 +411,7 @@ func Test_dropStage_Process(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateDropConfig(tt.config)
+			_, err := validateDropConfig(tt.config)
 			if err != nil {
 				t.Error(err)
 			}
@@ -465,7 +465,7 @@ func Test_validateDropConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := validateDropConfig(tt.config); ((err != nil) && (err.Error() != tt.wantErr.Error())) || (err == nil && tt.wantErr != nil) {
+			if _, err := validateDropConfig(tt.config); ((err != nil) && (err.Error() != tt.wantErr.Error())) || (err == nil && tt.wantErr != nil) {
 				t.Errorf("validateDropConfig() error = %v, wantErr = %v", err, tt.wantErr)
 			}
 		})

--- a/internal/component/loki/process/stages/eventlogmessage.go
+++ b/internal/component/loki/process/stages/eventlogmessage.go
@@ -19,6 +19,18 @@ type EventLogMessageConfig struct {
 	OverwriteExisting bool   `alloy:"overwrite_existing,attr,optional"`
 }
 
+func (s *EventLogMessageConfig) Copy() *EventLogMessageConfig {
+	if s == nil {
+		return nil
+	}
+
+	return &EventLogMessageConfig{
+		Source:            s.Source,
+		DropInvalidLabels: s.DropInvalidLabels,
+		OverwriteExisting: s.OverwriteExisting,
+	}
+}
+
 func (e *EventLogMessageConfig) Validate() error {
 	if !model.LabelName(e.Source).IsValid() {
 		return fmt.Errorf(ErrInvalidLabelName, e.Source)

--- a/internal/component/loki/process/stages/extensions.go
+++ b/internal/component/loki/process/stages/extensions.go
@@ -19,12 +19,32 @@ const (
 // pipeline for decoding entries that are using the Docker logs format.
 type DockerConfig struct{}
 
+func (s *DockerConfig) Copy() *DockerConfig {
+	if s == nil {
+		return nil
+	}
+
+	return &DockerConfig{}
+}
+
 // CRIConfig is an empty struct that is used to enable a pre-defined pipeline
 // for decoding entries that are using the CRI logging format.
 type CRIConfig struct {
 	MaxPartialLines            int    `alloy:"max_partial_lines,attr,optional"`
 	MaxPartialLineSize         uint64 `alloy:"max_partial_line_size,attr,optional"`
 	MaxPartialLineSizeTruncate bool   `alloy:"max_partial_line_size_truncate,attr,optional"`
+}
+
+func (s *CRIConfig) Copy() *CRIConfig {
+	if s == nil {
+		return nil
+	}
+
+	return &CRIConfig{
+		MaxPartialLines:            s.MaxPartialLines,
+		MaxPartialLineSize:         s.MaxPartialLineSize,
+		MaxPartialLineSizeTruncate: s.MaxPartialLineSizeTruncate,
+	}
 }
 
 var (

--- a/internal/component/loki/process/stages/geoip.go
+++ b/internal/component/loki/process/stages/geoip.go
@@ -3,6 +3,7 @@ package stages
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"net"
 	"reflect"
 
@@ -60,6 +61,19 @@ type GeoIPConfig struct {
 	Source        *string           `alloy:"source,attr"`
 	DBType        string            `alloy:"db_type,attr,optional"`
 	CustomLookups map[string]string `alloy:"custom_lookups,attr,optional"`
+}
+
+func (s *GeoIPConfig) Copy() *GeoIPConfig {
+	if s == nil {
+		return nil
+	}
+
+	return &GeoIPConfig{
+		DB:            s.DB,
+		Source:        copyStrPtr(s.Source),
+		DBType:        s.DBType,
+		CustomLookups: maps.Clone(s.CustomLookups),
+	}
 }
 
 func validateGeoIPConfig(c GeoIPConfig) (map[string]*jmespath.JMESPath, error) {

--- a/internal/component/loki/process/stages/json.go
+++ b/internal/component/loki/process/stages/json.go
@@ -3,6 +3,7 @@ package stages
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"reflect"
 
 	"github.com/go-kit/log"
@@ -25,6 +26,18 @@ type JSONConfig struct {
 	Expressions   map[string]string `alloy:"expressions,attr"`
 	Source        *string           `alloy:"source,attr,optional"`
 	DropMalformed bool              `alloy:"drop_malformed,attr,optional"`
+}
+
+func (s *JSONConfig) Copy() *JSONConfig {
+	if s == nil {
+		return nil
+	}
+
+	return &JSONConfig{
+		Expressions:   maps.Clone(s.Expressions),
+		Source:        copyStrPtr(s.Source),
+		DropMalformed: s.DropMalformed,
+	}
 }
 
 // validateJSONConfig validates a json config and returns a map of necessary jmespath expressions.

--- a/internal/component/loki/process/stages/label_drop.go
+++ b/internal/component/loki/process/stages/label_drop.go
@@ -2,6 +2,7 @@ package stages
 
 import (
 	"errors"
+	"slices"
 	"time"
 
 	"github.com/prometheus/common/model"
@@ -13,6 +14,16 @@ var ErrEmptyLabelDropStageConfig = errors.New("labeldrop stage config cannot be 
 // LabelDropConfig contains the slice of labels to be dropped.
 type LabelDropConfig struct {
 	Values []string `alloy:"values,attr"`
+}
+
+func (s *LabelDropConfig) Copy() *LabelDropConfig {
+	if s == nil {
+		return nil
+	}
+
+	return &LabelDropConfig{
+		Values: slices.Clone(s.Values),
+	}
 }
 
 func newLabelDropStage(config LabelDropConfig) (Stage, error) {

--- a/internal/component/loki/process/stages/label_keep.go
+++ b/internal/component/loki/process/stages/label_keep.go
@@ -2,6 +2,7 @@ package stages
 
 import (
 	"errors"
+	"slices"
 	"time"
 
 	"github.com/prometheus/common/model"
@@ -13,6 +14,16 @@ var ErrEmptyLabelAllowStageConfig = errors.New("labelallow stage config cannot b
 // LabelAllowConfig contains the slice of labels to allow through.
 type LabelAllowConfig struct {
 	Values []string `alloy:"values,attr"`
+}
+
+func (s *LabelAllowConfig) Copy() *LabelAllowConfig {
+	if s == nil {
+		return nil
+	}
+
+	return &LabelAllowConfig{
+		Values: slices.Clone(s.Values),
+	}
 }
 
 func newLabelAllowStage(config LabelAllowConfig) (Stage, error) {

--- a/internal/component/loki/process/stages/labels.go
+++ b/internal/component/loki/process/stages/labels.go
@@ -21,6 +21,21 @@ type LabelsConfig struct {
 	Values map[string]*string `alloy:"values,attr"`
 }
 
+func (s *LabelsConfig) Copy() *LabelsConfig {
+	if s == nil {
+		return nil
+	}
+
+	values := make(map[string]*string, len(s.Values))
+	for k, v := range s.Values {
+		values[k] = copyStrPtr(v)
+	}
+
+	return &LabelsConfig{
+		Values: values,
+	}
+}
+
 // validateLabelsConfig validates the Label stage configuration
 func validateLabelsConfig(c LabelsConfig) error {
 	if c.Values == nil {

--- a/internal/component/loki/process/stages/limit.go
+++ b/internal/component/loki/process/stages/limit.go
@@ -31,6 +31,20 @@ type LimitConfig struct {
 	MaxDistinctLabels int     `alloy:"max_distinct_labels,attr,optional"`
 }
 
+func (c *LimitConfig) Copy() *LimitConfig {
+	if c == nil {
+		return nil
+	}
+
+	return &LimitConfig{
+		Rate:              c.Rate,
+		Burst:             c.Burst,
+		Drop:              c.Drop,
+		ByLabelName:       c.ByLabelName,
+		MaxDistinctLabels: c.MaxDistinctLabels,
+	}
+}
+
 func newLimitStage(logger log.Logger, cfg LimitConfig, registerer prometheus.Registerer) (Stage, error) {
 	err := validateLimitConfig(cfg)
 	if err != nil {

--- a/internal/component/loki/process/stages/logfmt.go
+++ b/internal/component/loki/process/stages/logfmt.go
@@ -3,6 +3,7 @@ package stages
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"reflect"
 	"strings"
 	"time"
@@ -23,6 +24,17 @@ var (
 type LogfmtConfig struct {
 	Mapping map[string]string `alloy:"mapping,attr"`
 	Source  string            `alloy:"source,attr,optional"`
+}
+
+func (s *LogfmtConfig) Copy() *LogfmtConfig {
+	if s == nil {
+		return nil
+	}
+
+	return &LogfmtConfig{
+		Mapping: maps.Clone(s.Mapping),
+		Source:  s.Source,
+	}
 }
 
 // validateLogfmtConfig validates a logfmt stage config and returns an inverse mapping of configured mapping.

--- a/internal/component/loki/process/stages/luhn.go
+++ b/internal/component/loki/process/stages/luhn.go
@@ -16,6 +16,18 @@ type LuhnFilterConfig struct {
 	MinLength   int     `alloy:"min_length,attr,optional"`
 }
 
+func (s *LuhnFilterConfig) Copy() *LuhnFilterConfig {
+	if s == nil {
+		return nil
+	}
+
+	return &LuhnFilterConfig{
+		Replacement: s.Replacement,
+		Source:      copyStrPtr(s.Source),
+		MinLength:   s.MinLength,
+	}
+}
+
 // validateLuhnFilterConfig validates the LuhnFilterConfig.
 func validateLuhnFilterConfig(c LuhnFilterConfig) error {
 	if c.Replacement == "" {

--- a/internal/component/loki/process/stages/match.go
+++ b/internal/component/loki/process/stages/match.go
@@ -34,6 +34,30 @@ type MatchConfig struct {
 	DropReason   string        `alloy:"drop_counter_reason,attr,optional"`
 }
 
+func (s *MatchConfig) Copy() *MatchConfig {
+	if s == nil {
+		return nil
+	}
+
+	//TODO: When Stages is nil, does this output nil?
+	stages := []StageConfig{}
+	if s.Stages != nil {
+		stages = make([]StageConfig, 0, len(s.Stages))
+		for i := range s.Stages {
+			// stages[i] = *s.Stages[i].Copy()
+			stages = append(stages, *s.Stages[i].Copy())
+		}
+	}
+
+	return &MatchConfig{
+		Selector:     s.Selector,
+		Stages:       stages,
+		Action:       s.Action,
+		PipelineName: s.PipelineName,
+		DropReason:   s.DropReason,
+	}
+}
+
 // validateMatcherConfig validates the MatcherConfig for the matcherStage
 func validateMatcherConfig(cfg *MatchConfig) (logql.Expr, error) {
 	if cfg.Selector == "" {

--- a/internal/component/loki/process/stages/metric.go
+++ b/internal/component/loki/process/stages/metric.go
@@ -63,8 +63,8 @@ func (s *MetricsConfig) Copy() *MetricsConfig {
 	}
 
 	metrics := make([]MetricConfig, 0, len(s.Metrics))
-	for i, metric := range s.Metrics {
-		metrics[i] = *metric.Copy()
+	for _, metric := range s.Metrics {
+		metrics = append(metrics, *metric.Copy())
 	}
 
 	return &MetricsConfig{

--- a/internal/component/loki/process/stages/metric.go
+++ b/internal/component/loki/process/stages/metric.go
@@ -40,9 +40,36 @@ type MetricConfig struct {
 	Histogram *metric.HistogramConfig `alloy:"histogram,block,optional"`
 }
 
+func (c *MetricConfig) Copy() *MetricConfig {
+	if c == nil {
+		return nil
+	}
+
+	return &MetricConfig{
+		Counter:   c.Counter.Copy(),
+		Gauge:     c.Gauge.Copy(),
+		Histogram: c.Histogram.Copy(),
+	}
+}
+
 // MetricsConfig is a set of configured metrics.
 type MetricsConfig struct {
 	Metrics []MetricConfig `alloy:"metric,enum,optional"`
+}
+
+func (s *MetricsConfig) Copy() *MetricsConfig {
+	if s == nil {
+		return nil
+	}
+
+	metrics := make([]MetricConfig, 0, len(s.Metrics))
+	for i, metric := range s.Metrics {
+		metrics[i] = *metric.Copy()
+	}
+
+	return &MetricsConfig{
+		Metrics: metrics,
+	}
 }
 
 type cfgCollector struct {

--- a/internal/component/loki/process/stages/multiline_test.go
+++ b/internal/component/loki/process/stages/multiline_test.go
@@ -17,12 +17,13 @@ import (
 func TestMultilineStageProcess(t *testing.T) {
 	logger := util.TestAlloyLogger(t)
 	mcfg := MultilineConfig{Expression: "^START", MaxWaitTime: 3 * time.Second}
-	err := validateMultilineConfig(&mcfg)
+	regex, err := validateMultilineConfig(&mcfg)
 	require.NoError(t, err)
 
 	stage := &multilineStage{
 		cfg:    mcfg,
 		logger: logger,
+		regex:  regex,
 	}
 
 	out := processEntries(stage,
@@ -44,12 +45,13 @@ func TestMultilineStageProcess(t *testing.T) {
 func TestMultilineStageMultiStreams(t *testing.T) {
 	logger := util.TestAlloyLogger(t)
 	mcfg := MultilineConfig{Expression: "^START", MaxWaitTime: 3 * time.Second}
-	err := validateMultilineConfig(&mcfg)
+	regex, err := validateMultilineConfig(&mcfg)
 	require.NoError(t, err)
 
 	stage := &multilineStage{
 		cfg:    mcfg,
 		logger: logger,
+		regex:  regex,
 	}
 
 	out := processEntries(stage,
@@ -84,12 +86,13 @@ func TestMultilineStageMultiStreams(t *testing.T) {
 func TestMultilineStageMaxWaitTime(t *testing.T) {
 	logger := util.TestAlloyLogger(t)
 	mcfg := MultilineConfig{Expression: "^START", MaxWaitTime: 100 * time.Millisecond}
-	err := validateMultilineConfig(&mcfg)
+	regex, err := validateMultilineConfig(&mcfg)
 	require.NoError(t, err)
 
 	stage := &multilineStage{
 		cfg:    mcfg,
 		logger: logger,
+		regex:  regex,
 	}
 
 	in := make(chan Entry, 2)

--- a/internal/component/loki/process/stages/output.go
+++ b/internal/component/loki/process/stages/output.go
@@ -22,6 +22,16 @@ type OutputConfig struct {
 	Source string `alloy:"source,attr"`
 }
 
+func (s *OutputConfig) Copy() *OutputConfig {
+	if s == nil {
+		return nil
+	}
+
+	return &OutputConfig{
+		Source: s.Source,
+	}
+}
+
 // newOutputStage creates a new outputStage
 func newOutputStage(logger log.Logger, config OutputConfig) (Stage, error) {
 	if config.Source == "" {

--- a/internal/component/loki/process/stages/pack.go
+++ b/internal/component/loki/process/stages/pack.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"sort"
 	"time"
 
@@ -104,6 +105,17 @@ func (w Packed) MarshalJSON() ([]byte, error) {
 type PackConfig struct {
 	Labels          []string `alloy:"labels,attr"`
 	IngestTimestamp bool     `alloy:"ingest_timestamp,attr,optional"`
+}
+
+func (c *PackConfig) Copy() *PackConfig {
+	if c == nil {
+		return nil
+	}
+
+	return &PackConfig{
+		Labels:          slices.Clone(c.Labels),
+		IngestTimestamp: c.IngestTimestamp,
+	}
 }
 
 // DefaultPackConfig sets the defaults.

--- a/internal/component/loki/process/stages/pipeline.go
+++ b/internal/component/loki/process/stages/pipeline.go
@@ -44,6 +44,37 @@ type StageConfig struct {
 	TimestampConfig       *TimestampConfig       `alloy:"timestamp,block,optional"`
 }
 
+func (sc *StageConfig) Copy() *StageConfig {
+	return &StageConfig{
+		CRIConfig:             sc.CRIConfig.Copy(),
+		DecolorizeConfig:      sc.DecolorizeConfig.Copy(),
+		DockerConfig:          sc.DockerConfig.Copy(),
+		DropConfig:            sc.DropConfig.Copy(),
+		EventLogMessageConfig: sc.EventLogMessageConfig.Copy(),
+		GeoIPConfig:           sc.GeoIPConfig.Copy(),
+		JSONConfig:            sc.JSONConfig.Copy(),
+		LabelAllowConfig:      sc.LabelAllowConfig.Copy(),
+		LabelDropConfig:       sc.LabelDropConfig.Copy(),
+		LabelsConfig:          sc.LabelsConfig.Copy(),
+		LimitConfig:           sc.LimitConfig.Copy(),
+		LogfmtConfig:          sc.LogfmtConfig.Copy(),
+		LuhnFilterConfig:      sc.LuhnFilterConfig.Copy(),
+		MatchConfig:           sc.MatchConfig.Copy(),
+		MetricsConfig:         sc.MetricsConfig.Copy(),
+		MultilineConfig:       sc.MultilineConfig.Copy(),
+		OutputConfig:          sc.OutputConfig.Copy(),
+		PackConfig:            sc.PackConfig.Copy(),
+		RegexConfig:           sc.RegexConfig.Copy(),
+		ReplaceConfig:         sc.ReplaceConfig.Copy(),
+		StaticLabelsConfig:    sc.StaticLabelsConfig.Copy(),
+		StructuredMetadata:    sc.StructuredMetadata.Copy(),
+		SamplingConfig:        sc.SamplingConfig.Copy(),
+		TemplateConfig:        sc.TemplateConfig.Copy(),
+		TenantConfig:          sc.TenantConfig.Copy(),
+		TimestampConfig:       sc.TimestampConfig.Copy(),
+	}
+}
+
 var rateLimiter *rate.Limiter
 var rateLimiterDrop bool
 var rateLimiterDropReason = "global_rate_limiter_drop"

--- a/internal/component/loki/process/stages/regex.go
+++ b/internal/component/loki/process/stages/regex.go
@@ -27,6 +27,17 @@ type RegexConfig struct {
 	Source     *string `alloy:"source,attr,optional"`
 }
 
+func (c *RegexConfig) Copy() *RegexConfig {
+	if c == nil {
+		return nil
+	}
+
+	return &RegexConfig{
+		Expression: c.Expression,
+		Source:     copyStrPtr(c.Source),
+	}
+}
+
 // validateRegexConfig validates the config and return a regex
 func validateRegexConfig(c RegexConfig) (*regexp.Regexp, error) {
 	if c.Expression == "" {

--- a/internal/component/loki/process/stages/replace.go
+++ b/internal/component/loki/process/stages/replace.go
@@ -33,6 +33,18 @@ type ReplaceConfig struct {
 	Replace    string `alloy:"replace,attr,optional"`
 }
 
+func (s *ReplaceConfig) Copy() *ReplaceConfig {
+	if s == nil {
+		return nil
+	}
+
+	return &ReplaceConfig{
+		Expression: s.Expression,
+		Source:     s.Source,
+		Replace:    s.Replace,
+	}
+}
+
 func getExpressionRegex(c ReplaceConfig) (*regexp.Regexp, error) {
 	if c.Expression == "" {
 		return nil, ErrExpressionRequired

--- a/internal/component/loki/process/stages/sampling.go
+++ b/internal/component/loki/process/stages/sampling.go
@@ -26,6 +26,17 @@ type SamplingConfig struct {
 	SamplingRate float64 `alloy:"rate,attr"`
 }
 
+func (s *SamplingConfig) Copy() *SamplingConfig {
+	if s == nil {
+		return nil
+	}
+
+	return &SamplingConfig{
+		DropReason:   copyStrPtr(s.DropReason),
+		SamplingRate: s.SamplingRate,
+	}
+}
+
 func (s *SamplingConfig) SetToDefault() {
 	if s.DropReason == nil || *s.DropReason == "" {
 		s.DropReason = &defaultSamplingpReason

--- a/internal/component/loki/process/stages/static_labels.go
+++ b/internal/component/loki/process/stages/static_labels.go
@@ -19,6 +19,21 @@ type StaticLabelsConfig struct {
 	Values map[string]*string `alloy:"values,attr"`
 }
 
+func (c *StaticLabelsConfig) Copy() *StaticLabelsConfig {
+	if c == nil {
+		return nil
+	}
+
+	values := make(map[string]*string, len(c.Values))
+	for k, v := range c.Values {
+		values[k] = copyStrPtr(v)
+	}
+
+	return &StaticLabelsConfig{
+		Values: values,
+	}
+}
+
 func newStaticLabelsStage(logger log.Logger, config StaticLabelsConfig) (Stage, error) {
 	err := validateLabelStaticConfig(config)
 	if err != nil {

--- a/internal/component/loki/process/stages/template.go
+++ b/internal/component/loki/process/stages/template.go
@@ -67,6 +67,17 @@ type TemplateConfig struct {
 	Template string `alloy:"template,attr"`
 }
 
+func (c *TemplateConfig) Copy() *TemplateConfig {
+	if c == nil {
+		return nil
+	}
+
+	return &TemplateConfig{
+		Source:   c.Source,
+		Template: c.Template,
+	}
+}
+
 // validateTemplateConfig validates the templateStage config.
 func validateTemplateConfig(cfg TemplateConfig) (*template.Template, error) {
 	if cfg.Source == "" {

--- a/internal/component/loki/process/stages/tenant.go
+++ b/internal/component/loki/process/stages/tenant.go
@@ -31,6 +31,18 @@ type TenantConfig struct {
 	Value  string `alloy:"value,attr,optional"`
 }
 
+func (c *TenantConfig) Copy() *TenantConfig {
+	if c == nil {
+		return nil
+	}
+
+	return &TenantConfig{
+		Label:  c.Label,
+		Source: c.Source,
+		Value:  c.Value,
+	}
+}
+
 // validateTenantConfig validates the tenant stage configuration
 func validateTenantConfig(c TenantConfig) error {
 	if c.Source == "" && c.Value == "" && c.Label == "" {

--- a/internal/component/loki/process/stages/timestamp.go
+++ b/internal/component/loki/process/stages/timestamp.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"time"
 
 	"github.com/go-kit/log"
@@ -49,6 +50,20 @@ type TimestampConfig struct {
 	FallbackFormats []string `alloy:"fallback_formats,attr,optional"`
 	Location        *string  `alloy:"location,attr,optional"`
 	ActionOnFailure string   `alloy:"action_on_failure,attr,optional"`
+}
+
+func (c *TimestampConfig) Copy() *TimestampConfig {
+	if c == nil {
+		return nil
+	}
+
+	return &TimestampConfig{
+		Source:          c.Source,
+		Format:          c.Format,
+		FallbackFormats: slices.Clone(c.FallbackFormats),
+		Location:        copyStrPtr(c.Location),
+		ActionOnFailure: c.ActionOnFailure,
+	}
 }
 
 type parser func(string) (time.Time, error)

--- a/internal/component/loki/process/stages/util.go
+++ b/internal/component/loki/process/stages/util.go
@@ -202,3 +202,12 @@ func stringsContain(values []string, search string) bool {
 
 	return false
 }
+
+func copyStrPtr(s *string) *string {
+	if s == nil {
+		return nil
+	}
+
+	res := *s
+	return &res
+}

--- a/internal/util/test_shallow_copy.go
+++ b/internal/util/test_shallow_copy.go
@@ -1,0 +1,119 @@
+package util
+
+import (
+	"reflect"
+
+	"github.com/grafana/alloy/syntax"
+)
+
+func SharePointer(a, b reflect.Value, initValues bool) (string, bool) {
+	// We want to recursively check a and b, so if they're nil they need to be
+	// initialized to see if any of their inner values have shared pointers after
+	// being initialized with defaults.
+	if initValues {
+		initValue(a)
+		initValue(b)
+	}
+
+	// From the documentation of reflect.Value.Pointer, values of chan, func,
+	// map, pointer, slice, and unsafe pointer are all pointer values.
+	//
+	// Additionally, we want to recurse into values (even if they don't have
+	// addresses) to see if there's shared pointers inside of them.
+	switch a.Kind() {
+	case reflect.Chan, reflect.Func, reflect.UnsafePointer:
+		return "", a.Pointer() == b.Pointer()
+
+	case reflect.Map:
+		if pointersMatch(a, b) {
+			return "", true
+		}
+
+		iter := a.MapRange()
+		for iter.Next() {
+			aValue, bValue := iter.Value(), b.MapIndex(iter.Key())
+			if !bValue.IsValid() {
+				continue
+			}
+			if path, shared := SharePointer(aValue, bValue, initValues); shared {
+				return path, true
+			}
+		}
+		return "", false
+
+	case reflect.Pointer:
+		if pointersMatch(a, b) {
+			return "", true
+		} else {
+			// Recursively navigate inside of the pointer.
+			return SharePointer(a.Elem(), b.Elem(), initValues)
+		}
+
+	case reflect.Interface:
+		if a.UnsafeAddr() == b.UnsafeAddr() {
+			return "", true
+		}
+		return SharePointer(a.Elem(), b.Elem(), initValues)
+
+	case reflect.Slice:
+		if pointersMatch(a, b) {
+			// If the slices are preallocated immutable pointers such as []string{}, we can ignore
+			if a.Len() == 0 && a.Cap() == 0 && b.Len() == 0 && b.Cap() == 0 {
+				return "", false
+			}
+			return "", true
+		}
+
+		size := min(a.Len(), b.Len())
+		for i := 0; i < size; i++ {
+			if path, shared := SharePointer(a.Index(i), b.Index(i), initValues); shared {
+				return path, true
+			}
+		}
+		return "", false
+	}
+
+	// Recurse into non-pointer types.
+	switch a.Kind() {
+	case reflect.Array:
+		for i := 0; i < a.Len(); i++ {
+			if path, shared := SharePointer(a.Index(i), b.Index(i), initValues); shared {
+				return path, true
+			}
+		}
+		return "", false
+
+	case reflect.Struct:
+		// Check to make sure there are no shared pointers between args1 and args2.
+		for i := 0; i < a.NumField(); i++ {
+			if path, shared := SharePointer(a.Field(i), b.Field(i), initValues); shared {
+				fullPath := a.Type().Field(i).Name
+				if path != "" {
+					fullPath += "." + path
+				}
+				return fullPath, true
+			}
+		}
+		return "", false
+	}
+
+	return "", false
+}
+
+func pointersMatch(a, b reflect.Value) bool {
+	if a.IsNil() || b.IsNil() {
+		return false
+	}
+	return a.Pointer() == b.Pointer()
+}
+
+// initValue initializes nil pointers. If the nil pointer implements
+// syntax.Defaulter, it is also set to default values.
+func initValue(rv reflect.Value) {
+	if rv.Kind() == reflect.Pointer && rv.IsNil() {
+		rv.Set(reflect.New(rv.Type().Elem()))
+		if defaulter, ok := rv.Interface().(syntax.Defaulter); ok {
+			defaulter.SetToDefault()
+		}
+	}
+}

--- a/internal/util/test_shallow_copy_test.go
+++ b/internal/util/test_shallow_copy_test.go
@@ -1,0 +1,148 @@
+package util
+
+import (
+	"maps"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/strings/slices"
+)
+
+type copyable interface {
+	Copy() any
+}
+
+// String pointer
+type withStringPointer struct {
+	a *string
+}
+
+type withStringPointer_Shallow withStringPointer
+type withStringPointer_Deep withStringPointer
+
+func (s withStringPointer_Shallow) Copy() any {
+	return s
+}
+
+func (s withStringPointer_Deep) Copy() any {
+	strCopy := *s.a
+	return withStringPointer_Deep{
+		a: &strCopy,
+	}
+}
+
+// Map
+type withMap struct {
+	a map[string]string
+}
+
+type withMap_Shallow withMap
+type withMap_Deep withMap
+
+func (s withMap_Shallow) Copy() any {
+	return s
+}
+
+func (s withMap_Deep) Copy() any {
+	return withMap_Deep{
+		a: maps.Clone(s.a),
+	}
+}
+
+// Slice
+type withSlice struct {
+	a []string
+}
+
+type withSlice_Shallow withSlice
+type withSlice_Deep withSlice
+
+func (s withSlice_Shallow) Copy() any {
+	return s
+}
+
+func (s withSlice_Deep) Copy() any {
+	return withSlice_Deep{
+		a: slices.Clone(s.a),
+	}
+}
+
+// Primitive types
+type withPrimitiveTypes struct {
+	a int
+	b bool
+}
+
+func (s withPrimitiveTypes) Copy() any {
+	return s
+}
+
+// Utility functions
+func newStrPtr(s string) *string {
+	return &s
+}
+
+// Test for shallow and deep copying
+func Test_ShallowCopy(t *testing.T) {
+	tests := map[string]struct {
+		input             copyable
+		expectShallowCopy bool
+	}{
+		"stringPtrShallow": {
+			input: withStringPointer_Shallow{
+				a: newStrPtr("test"),
+			},
+			expectShallowCopy: true,
+		},
+		"stringPtrDeep": {
+			input: withStringPointer_Deep{
+				a: newStrPtr("test"),
+			},
+			expectShallowCopy: false,
+		},
+		"mapShallow": {
+			input: withMap_Shallow{
+				a: map[string]string{"a": "b"},
+			},
+			expectShallowCopy: true,
+		},
+		"mapDeep": {
+			input: withMap_Deep{
+				a: map[string]string{"a": "b"},
+			},
+			expectShallowCopy: false,
+		},
+		"sliceShallow": {
+			input: withSlice_Shallow{
+				a: []string{"a", "b"},
+			},
+			expectShallowCopy: true,
+		},
+		"sliceDeep": {
+			input: withSlice_Deep{
+				a: []string{"a", "b"},
+			},
+			expectShallowCopy: false,
+		},
+		"primitiveTypes": {
+			input: withPrimitiveTypes{
+				a: 1,
+				b: true,
+			},
+			expectShallowCopy: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			copiedInput := test.input.Copy()
+			_, shared := SharePointer(reflect.ValueOf(test.input), reflect.ValueOf(copiedInput), false)
+			if test.expectShallowCopy {
+				require.True(t, shared, "expected a shallow copy")
+			} else {
+				require.False(t, shared, "expected a deep copy")
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### PR Description

When Alloy's config is reloaded, components whose config didn't change should not be reloaded. This hasn't been true for `loki.process` if certain stages are present. That's because for some stages the config struct is mutated after the pipeline is started. Notably, this is the case for `stage.labels`. The solution I went with in this PR is to deep copy the config struct so that we can compare the old and new configs more reliably.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
