### PR TITLE
Update azure event hub connection string data type to secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ Main (unreleased)
 - Fixed an issue where clustering peers resolution via hostname in `--cluster.join-addresses`
   resolves to duplicated IP addresses when using SRV records. (@thampiotr)
 
+- Fixed an issue where the `connection_string` for the `loki.source.azure_event_hubs` component
+  was displayed in the UI in plaintext. (@MorrisWitthein)
+
 v1.3.0
 -----------------
 

--- a/docs/sources/reference/components/loki/loki.source.azure_event_hubs.md
+++ b/docs/sources/reference/components/loki/loki.source.azure_event_hubs.md
@@ -89,7 +89,7 @@ The `authentication` block defines the authentication method when communicating 
 Name                | Type           | Description                                                               | Default | Required
 --------------------|----------------|---------------------------------------------------------------------------|---------|---------
 `mechanism`         | `string`       | Authentication mechanism.                                                 |         | yes
-`connection_string` | `string`       | Event Hubs ConnectionString for authentication on Azure Cloud.            |         | no
+`connection_string` | `secret`       | Event Hubs ConnectionString for authentication on Azure Cloud.            |         | no
 `scopes`            | `list(string)` | Access token scopes. Default is `fully_qualified_namespace` without port. |         | no
 
 `mechanism` supports the values `"connection_string"` and `"oauth"`. If `"connection_string"` is used,

--- a/internal/component/loki/source/azure_event_hubs/azure_event_hubs.go
+++ b/internal/component/loki/source/azure_event_hubs/azure_event_hubs.go
@@ -14,6 +14,7 @@ import (
 	kt "github.com/grafana/alloy/internal/component/loki/source/internal/kafkatarget"
 	"github.com/grafana/alloy/internal/featuregate"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
+	"github.com/grafana/alloy/syntax/alloytypes"
 	"github.com/grafana/dskit/flagext"
 
 	"github.com/prometheus/common/model"
@@ -50,9 +51,9 @@ type Arguments struct {
 
 // AzureEventHubsAuthentication describe the configuration for authentication with Azure Event Hub
 type AzureEventHubsAuthentication struct {
-	Mechanism        string   `alloy:"mechanism,attr"`
-	Scopes           []string `alloy:"scopes,attr,optional"`
-	ConnectionString string   `alloy:"connection_string,attr,optional"`
+	Mechanism        string            `alloy:"mechanism,attr"`
+	Scopes           []string          `alloy:"scopes,attr,optional"`
+	ConnectionString alloytypes.Secret `alloy:"connection_string,attr,optional"`
 }
 
 func getDefault() Arguments {
@@ -184,7 +185,7 @@ func (a *Arguments) Convert() (kt.Config, error) {
 			SASLConfig: kt.SASLConfig{
 				UseTLS:    true,
 				User:      "$ConnectionString",
-				Password:  flagext.SecretWithValue(a.Authentication.ConnectionString),
+				Password:  flagext.SecretWithValue(string(a.Authentication.ConnectionString)),
 				Mechanism: sarama.SASLTypePlaintext,
 			},
 		}

--- a/internal/converter/internal/promtailconvert/internal/build/azure_event_hub.go
+++ b/internal/converter/internal/promtailconvert/internal/build/azure_event_hub.go
@@ -4,6 +4,7 @@ import (
 	"github.com/grafana/alloy/internal/component/common/relabel"
 	"github.com/grafana/alloy/internal/component/loki/source/azure_event_hubs"
 	"github.com/grafana/alloy/internal/converter/internal/common"
+	"github.com/grafana/alloy/syntax/alloytypes"
 )
 
 func (s *ScrapeConfigBuilder) AppendAzureEventHubs() {
@@ -15,7 +16,7 @@ func (s *ScrapeConfigBuilder) AppendAzureEventHubs() {
 		FullyQualifiedNamespace: aCfg.FullyQualifiedNamespace,
 		EventHubs:               aCfg.EventHubs,
 		Authentication: azure_event_hubs.AzureEventHubsAuthentication{
-			ConnectionString: aCfg.ConnectionString,
+			ConnectionString: alloytypes.Secret(aCfg.ConnectionString),
 		},
 		GroupID:                aCfg.GroupID,
 		UseIncomingTimestamp:   aCfg.UseIncomingTimestamp,
@@ -25,9 +26,11 @@ func (s *ScrapeConfigBuilder) AppendAzureEventHubs() {
 		ForwardTo:              s.getOrNewProcessStageReceivers(),
 	}
 	override := func(val interface{}) interface{} {
-		switch val.(type) {
+		switch value := val.(type) {
 		case relabel.Rules:
 			return common.CustomTokenizer{Expr: s.getOrNewDiscoveryRelabelRules()}
+		case alloytypes.Secret:
+			return string(value)
 		default:
 			return val
 		}


### PR DESCRIPTION
#### PR Description

The connection_string in the authentication block of `loki.source.azure_event_hubs` is currently displayed in plaintext in the UI. This is fixed by changing the data type from string to Secret.

#### Which issue(s) this PR fixes

Fixes #1383

#### PR Checklist

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Config converters updated
