### PR TITLE
Add cluster peers per instance panel to cluster overview dash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Main (unreleased)
   used as a temporary measure, since this flag will be disabled in future
   releases. (@thampiotr)
 
+- Added a new panel to Cluster Overview dashboard to show the number of peers
+  seen by each instance in the cluster. This can help diagnose cluster split
+  brain issues. (@thampiotr)
+
 ### Bugfixes
 
 - Fixed an issue which caused loss of context data in Faro exception. (@codecapitano)

--- a/operations/alloy-mixin/dashboards/cluster-overview.libsonnet
+++ b/operations/alloy-mixin/dashboards/cluster-overview.libsonnet
@@ -225,5 +225,30 @@ local cluster_node_filename = 'alloy-cluster-node.json';
           },
         ])
       ),
+
+      // Number of peers as seen by each instance.
+      (
+        panel.new(title='Number of peers seen by each instance', type='timeseries') +
+        panel.withUnit('instances') +
+        panel.withDescription(|||
+          The number of cluster peers seen by each instance.
+
+          When cluster is converged, every peer should see all the other instances. When we have a split brain or one
+          peer not joining the cluster, we will see two or more groups of instances that report different peer numbers
+          for an extended period of time and not converging.
+
+          This graph helps to identify which instances may be in a split brain state.
+        |||) +
+        panel.withPosition({ h: 12, w: 24, x: 0, y: 18 }) +
+        panel.withQueries([
+          panel.newQuery(
+            expr= |||
+              sum by(instance) (cluster_node_peers{%(groupSelector)s})
+            ||| % $._config,
+            legendFormat='{{instance}}',
+          ),
+        ])
+      ),
+
     ]),
 }

--- a/operations/alloy-mixin/dashboards/cluster-overview.libsonnet
+++ b/operations/alloy-mixin/dashboards/cluster-overview.libsonnet
@@ -229,7 +229,7 @@ local cluster_node_filename = 'alloy-cluster-node.json';
       // Number of peers as seen by each instance.
       (
         panel.new(title='Number of peers seen by each instance', type='timeseries') +
-        panel.withUnit('instances') +
+        panel.withUnit('peers') +
         panel.withDescription(|||
           The number of cluster peers seen by each instance.
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This adds a breakdown of number of peers seen by each instance in cluster overview. It can be invaluable in quickly diagnosing cluster split brain issues and which instances are affected. 

For example this issue: https://github.com/grafana/alloy/issues/1208

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

Fixes #1208 

#### Notes to the Reviewer

Tested locally with `grr`

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
