### PR TITLE
feat: Snowflake exporter deleted table enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Main (unreleased)
   seen by each instance in the cluster. This can help diagnose cluster split
   brain issues. (@thampiotr)
 
+- Updated Snowflake exporter with performance improvements for larger environments. 
+  Also added a new panel to track deleted tables to the Snowflake mixin. (@Caleb-Hurshman)
+
 ### Bugfixes
 
 - Fixed an issue which caused loss of context data in Faro exception. (@codecapitano)

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.snowflake.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.snowflake.md
@@ -58,15 +58,16 @@ Omitted fields take their default values.
 One of `password` or `private_key_path` must be specified to authenticate.
 Users with an encrypted private key will also need to provide a `private_key_password`.
 
-| Name                   | Type     | Description                                                                                       | Default          | Required |
-| ---------------------- | -------- | ------------------------------------------------------------------------------------------------- | ---------------- | -------- |
-| `account_name`         | `string` | The account to collect metrics from.                                                              |                  | yes      |
-| `username`             | `string` | The username for the user used when querying metrics.                                             |                  | yes      |
-| `password`             | `secret` | The password for the user used when querying metrics (required for password authentication).      |                  | no       |
-| `private_key_path`     | `secret` | The path to the user's RSA private key file (required for RSA key-pair authentication).           |                  | no       |
-| `private_key_password` | `secret` | The password for the user's RSA private key (required for encrypted RSA key-pair authentication). |                  | no       |
-| `role`                 | `string` | The role to use when querying metrics.                                                            | `"ACCOUNTADMIN"` | no       |
-| `warehouse`            | `string` | The warehouse to use when querying metrics.                                                       |                  | yes      |
+| Name                     | Type     | Description                                                                                       | Default          | Required |
+| ------------------------ | -------- | ------------------------------------------------------------------------------------------------- | ---------------- | -------- |
+| `account_name`           | `string` | The account to collect metrics from.                                                              |                  | yes      |
+| `username`               | `string` | The username for the user used when querying metrics.                                             |                  | yes      |
+| `password`               | `secret` | The password for the user used when querying metrics (required for password authentication).      |                  | no       |
+| `private_key_path`       | `secret` | The path to the user's RSA private key file (required for RSA key-pair authentication).           |                  | no       |
+| `private_key_password`   | `secret` | The password for the user's RSA private key (required for encrypted RSA key-pair authentication). |                  | no       |
+| `role`                   | `string` | The role to use when querying metrics.                                                            | `"ACCOUNTADMIN"` | no       |
+| `warehouse`              | `string` | The warehouse to use when querying metrics.                                                       |                  | yes      |
+| `exclude_deleted_tables` |  `bool`  | Whether to exclude deleted tables when querying table storage metrics.                            | `false`          | no       |
 
 ## Blocks
 

--- a/go.mod
+++ b/go.mod
@@ -450,7 +450,7 @@ require (
 	github.com/grafana/go-offsets-tracker v0.1.7 // indirect
 	github.com/grafana/gomemcache v0.0.0-20231204155601-7de47a8c3cb0 // indirect
 	github.com/grafana/jfr-parser v0.8.0 // indirect
-	github.com/grafana/snowflake-prometheus-exporter v0.0.0-20240701202215-1d847d62ed15
+	github.com/grafana/snowflake-prometheus-exporter v0.0.0-20240813124544-9995e8354548
 	github.com/grobie/gomemcache v0.0.0-20230213081705-239240bbc445 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1069,6 +1069,8 @@ github.com/grafana/smimesign v0.2.1-0.20220408144937-2a5adf3481d3 h1:UPkAxuhlAcR
 github.com/grafana/smimesign v0.2.1-0.20220408144937-2a5adf3481d3/go.mod h1:iZiiwNT4HbtGRVqCQu7uJPEZCuEE5sfSSttcnePkDl4=
 github.com/grafana/snowflake-prometheus-exporter v0.0.0-20240701202215-1d847d62ed15 h1:J4PmreN24XmbqMIKReAS/P1t7ND6NCAZApcbjBhedrY=
 github.com/grafana/snowflake-prometheus-exporter v0.0.0-20240701202215-1d847d62ed15/go.mod h1:DANNLd5vSKqHloqNX4yeS+9ZRI89dj8ySZeEWlI5UU4=
+github.com/grafana/snowflake-prometheus-exporter v0.0.0-20240813124544-9995e8354548 h1:XwoNrPHEl07N7EIMt/WXlzGj0Q4CDEfa+6nrdnQGOG4=
+github.com/grafana/snowflake-prometheus-exporter v0.0.0-20240813124544-9995e8354548/go.mod h1:DANNLd5vSKqHloqNX4yeS+9ZRI89dj8ySZeEWlI5UU4=
 github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0 h1:bjh0PVYSVVFxzINqPFYJmAmJNrWPgnVjuSdYJGHmtFU=
 github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0/go.mod h1:7t5XR+2IA8P2qggOAHTj/GCZfoLBle3OvNSYh1VkRBU=
 github.com/grafana/vmware_exporter v0.0.5-beta h1:2JCqzIWJzns8FN78wPsueC9rT3e3kZo2OUoL5kGMjdM=

--- a/internal/component/prometheus/exporter/snowflake/snowflake.go
+++ b/internal/component/prometheus/exporter/snowflake/snowflake.go
@@ -33,13 +33,14 @@ var DefaultArguments = Arguments{
 
 // Arguments controls the snowflake exporter.
 type Arguments struct {
-	AccountName        string            `alloy:"account_name,attr"`
-	Username           string            `alloy:"username,attr"`
-	Password           alloytypes.Secret `alloy:"password,attr,optional"`
-	PrivateKeyPath     string            `alloy:"private_key_path,attr,optional"`
-	PrivateKeyPassword alloytypes.Secret `alloy:"private_key_password,attr,optional"`
-	Role               string            `alloy:"role,attr,optional"`
-	Warehouse          string            `alloy:"warehouse,attr"`
+	AccountName          string            `alloy:"account_name,attr"`
+	Username             string            `alloy:"username,attr"`
+	Password             alloytypes.Secret `alloy:"password,attr,optional"`
+	PrivateKeyPath       string            `alloy:"private_key_path,attr,optional"`
+	PrivateKeyPassword   alloytypes.Secret `alloy:"private_key_password,attr,optional"`
+	Role                 string            `alloy:"role,attr,optional"`
+	Warehouse            string            `alloy:"warehouse,attr"`
+	ExcludeDeletedTables bool              `alloy:"exclude_deleted_tables,attr,optional"`
 }
 
 // SetToDefault implements syntax.Defaulter.
@@ -49,12 +50,13 @@ func (a *Arguments) SetToDefault() {
 
 func (a *Arguments) Convert() *snowflake_exporter.Config {
 	return &snowflake_exporter.Config{
-		AccountName:        a.AccountName,
-		Username:           a.Username,
-		Password:           config_util.Secret(a.Password),
-		PrivateKeyPath:     a.PrivateKeyPath,
-		PrivateKeyPassword: config_util.Secret(a.PrivateKeyPassword),
-		Role:               a.Role,
-		Warehouse:          a.Warehouse,
+		AccountName:          a.AccountName,
+		Username:             a.Username,
+		Password:             config_util.Secret(a.Password),
+		PrivateKeyPath:       a.PrivateKeyPath,
+		PrivateKeyPassword:   config_util.Secret(a.PrivateKeyPassword),
+		Role:                 a.Role,
+		Warehouse:            a.Warehouse,
+		ExcludeDeletedTables: a.ExcludeDeletedTables,
 	}
 }

--- a/internal/component/prometheus/exporter/snowflake/snowflake_test.go
+++ b/internal/component/prometheus/exporter/snowflake/snowflake_test.go
@@ -12,13 +12,14 @@ import (
 
 func TestAlloyUnmarshal(t *testing.T) {
 	alloyConfig := `
-	account_name 				 = "some_account"
-	username     				 = "some_user"
-	password     				 = "some_password"
-	private_key_path 		 = "/some/path/rsa_key.p8"
-	private_key_password = "some_password"
-	role         				 = "some_role"
-	warehouse    				 = "some_warehouse"
+	account_name 				   = "some_account"
+	username     				   = "some_user"
+	password     				 	 = "some_password"
+	private_key_path 		 	 = "/some/path/rsa_key.p8"
+	private_key_password 	 = "some_password"
+	role         					 = "some_role"
+	warehouse    				 	 = "some_warehouse"
+	exclude_deleted_tables = true
 	`
 
 	var args Arguments
@@ -26,13 +27,14 @@ func TestAlloyUnmarshal(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := Arguments{
-		AccountName:        "some_account",
-		Username:           "some_user",
-		Password:           alloytypes.Secret("some_password"),
-		PrivateKeyPath:     "/some/path/rsa_key.p8",
-		PrivateKeyPassword: alloytypes.Secret("some_password"),
-		Role:               "some_role",
-		Warehouse:          "some_warehouse",
+		AccountName:          "some_account",
+		Username:             "some_user",
+		Password:             alloytypes.Secret("some_password"),
+		PrivateKeyPath:       "/some/path/rsa_key.p8",
+		PrivateKeyPassword:   alloytypes.Secret("some_password"),
+		Role:                 "some_role",
+		Warehouse:            "some_warehouse",
+		ExcludeDeletedTables: true,
 	}
 
 	require.Equal(t, expected, args)
@@ -40,12 +42,13 @@ func TestAlloyUnmarshal(t *testing.T) {
 
 func TestConvert(t *testing.T) {
 	alloyConfig := `
-	account_name         = "some_account"
-	username             = "some_user"
-	password             = "some_password"
-	private_key_path     = "/some/path/rsa_key.p8"
-	private_key_password = "some_password"
-	warehouse            = "some_warehouse"
+	account_name           = "some_account"
+	username               = "some_user"
+	password               = "some_password"
+	private_key_path       = "/some/path/rsa_key.p8"
+	private_key_password   = "some_password"
+	warehouse              = "some_warehouse"
+	exclude_deleted_tables = true
 	`
 	var args Arguments
 	err := syntax.Unmarshal([]byte(alloyConfig), &args)
@@ -54,13 +57,14 @@ func TestConvert(t *testing.T) {
 	res := args.Convert()
 
 	expected := snowflake_exporter.Config{
-		AccountName:        "some_account",
-		Username:           "some_user",
-		Password:           config_util.Secret("some_password"),
-		PrivateKeyPath:     "/some/path/rsa_key.p8",
-		PrivateKeyPassword: config_util.Secret("some_password"),
-		Role:               DefaultArguments.Role,
-		Warehouse:          "some_warehouse",
+		AccountName:          "some_account",
+		Username:             "some_user",
+		Password:             config_util.Secret("some_password"),
+		PrivateKeyPath:       "/some/path/rsa_key.p8",
+		PrivateKeyPassword:   config_util.Secret("some_password"),
+		Role:                 DefaultArguments.Role,
+		Warehouse:            "some_warehouse",
+		ExcludeDeletedTables: true,
 	}
 	require.Equal(t, expected, *res)
 }

--- a/internal/static/integrations/snowflake_exporter/snowflake_exporter.go
+++ b/internal/static/integrations/snowflake_exporter/snowflake_exporter.go
@@ -16,13 +16,14 @@ var DefaultConfig = Config{
 
 // Config is the configuration for the snowflake integration
 type Config struct {
-	AccountName        string             `yaml:"account_name,omitempty"`
-	Username           string             `yaml:"username,omitempty"`
-	Password           config_util.Secret `yaml:"password,omitempty"`
-	PrivateKeyPath     string             `yaml:"private_key_path,omitempty"`
-	PrivateKeyPassword config_util.Secret `yaml:"private_key_password,omitempty"`
-	Role               string             `yaml:"role,omitempty"`
-	Warehouse          string             `yaml:"warehouse,omitempty"`
+	AccountName          string             `yaml:"account_name,omitempty"`
+	Username             string             `yaml:"username,omitempty"`
+	Password             config_util.Secret `yaml:"password,omitempty"`
+	PrivateKeyPath       string             `yaml:"private_key_path,omitempty"`
+	PrivateKeyPassword   config_util.Secret `yaml:"private_key_password,omitempty"`
+	Role                 string             `yaml:"role,omitempty"`
+	Warehouse            string             `yaml:"warehouse,omitempty"`
+	ExcludeDeletedTables bool               `yaml:"exclude_deleted_tables,omitempty"`
 }
 
 func (c *Config) exporterConfig() *collector.Config {
@@ -34,6 +35,7 @@ func (c *Config) exporterConfig() *collector.Config {
 		PrivateKeyPassword: string(c.PrivateKeyPassword),
 		Role:               c.Role,
 		Warehouse:          c.Warehouse,
+		ExcludeDeleted:     c.ExcludeDeletedTables,
 	}
 }
 

--- a/internal/static/integrations/snowflake_exporter/snowflake_exporter_test.go
+++ b/internal/static/integrations/snowflake_exporter/snowflake_exporter_test.go
@@ -14,29 +14,32 @@ func TestConfig_UnmarshalYaml(t *testing.T) {
 account_name: "some_account"
 username: "some_user"
 password: "some_password"
-warehouse: "some_warehouse"`
+warehouse: "some_warehouse"
+exclude_deleted_tables: true`
 
 	var c Config
 
 	require.NoError(t, yaml.UnmarshalStrict([]byte(strConfig), &c))
 
 	require.Equal(t, Config{
-		AccountName: "some_account",
-		Username:    "some_user",
-		Password:    "some_password",
-		Warehouse:   "some_warehouse",
-		Role:        "ACCOUNTADMIN",
+		AccountName:          "some_account",
+		Username:             "some_user",
+		Password:             "some_password",
+		Warehouse:            "some_warehouse",
+		Role:                 "ACCOUNTADMIN",
+		ExcludeDeletedTables: true,
 	}, c)
 }
 
 func TestConfig_NewIntegration(t *testing.T) {
 	t.Run("integration with valid config", func(t *testing.T) {
 		c := &Config{
-			AccountName: "some_account",
-			Username:    "some_user",
-			Password:    "some_password",
-			Warehouse:   "some_warehouse",
-			Role:        "ACCOUNTADMIN",
+			AccountName:          "some_account",
+			Username:             "some_user",
+			Password:             "some_password",
+			Warehouse:            "some_warehouse",
+			Role:                 "ACCOUNTADMIN",
+			ExcludeDeletedTables: true,
 		}
 
 		i, err := c.NewIntegration(log.NewJSONLogger(os.Stdout))


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR pulls in the updated Snowflake exporter, which includes the following changes:
 - Modified table storage query, now excludes tables in failsafe mode for longer than 7 days
 - New flag, allowing the user to exclude deleted tables entirely when querying table storage
 - New metric/panel to track deleted tables

This PR adds support and relevant documentation for the exporter's new capabilities.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->
Related to [#10637](https://github.com/grafana/support-escalations/issues/10637)

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated
