### PR TITLE
Display remote configuration components in Alloy's local UI

### DIFF
--- a/internal/web/api/api.go
+++ b/internal/web/api/api.go
@@ -24,12 +24,13 @@ import (
 // AlloyAPI is a wrapper around the component API.
 type AlloyAPI struct {
 	alloy           service.Host
+	remotecfg       service.Host
 	CallbackManager livedebugging.CallbackManager
 }
 
 // NewAlloyAPI instantiates a new Alloy API.
-func NewAlloyAPI(alloy service.Host, CallbackManager livedebugging.CallbackManager) *AlloyAPI {
-	return &AlloyAPI{alloy: alloy, CallbackManager: CallbackManager}
+func NewAlloyAPI(alloy, remotecfg service.Host, CallbackManager livedebugging.CallbackManager) *AlloyAPI {
+	return &AlloyAPI{alloy: alloy, remotecfg: remotecfg, CallbackManager: CallbackManager}
 }
 
 // RegisterRoutes registers all the API's routes.
@@ -39,8 +40,14 @@ func (a *AlloyAPI) RegisterRoutes(urlPrefix string, r *mux.Router) {
 	// component IDs.
 
 	r.Handle(path.Join(urlPrefix, "/modules/{moduleID:.+}/components"), httputil.CompressionHandler{Handler: a.listComponentsHandler()})
+	r.Handle(path.Join(urlPrefix, "/remotecfg/modules/{moduleID:.+}/components"), httputil.CompressionHandler{Handler: a.listRemotecfgComponentsHandler()})
+
 	r.Handle(path.Join(urlPrefix, "/components"), httputil.CompressionHandler{Handler: a.listComponentsHandler()})
+	r.Handle(path.Join(urlPrefix, "/remotecfg/components"), httputil.CompressionHandler{Handler: a.listRemotecfgComponentsHandler()})
+
 	r.Handle(path.Join(urlPrefix, "/components/{id:.+}"), httputil.CompressionHandler{Handler: a.getComponentHandler()})
+	r.Handle(path.Join(urlPrefix, "/remotecfg/components/{id:.+}"), httputil.CompressionHandler{Handler: a.getRemotecfgComponentHandler()})
+
 	r.Handle(path.Join(urlPrefix, "/peers"), httputil.CompressionHandler{Handler: a.getClusteringPeersHandler()})
 	r.Handle(path.Join(urlPrefix, "/debug/{id:.+}"), a.liveDebugging())
 }
@@ -71,12 +78,63 @@ func (a *AlloyAPI) listComponentsHandler() http.HandlerFunc {
 	}
 }
 
+func (a *AlloyAPI) listRemotecfgComponentsHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// moduleID is set from the /modules/{moduleID:.+}/components route above
+		// but not from the /components route.
+		var moduleID string
+		if vars := mux.Vars(r); vars != nil {
+			moduleID = vars["moduleID"]
+		}
+
+		components, err := a.remotecfg.ListComponents(moduleID, component.InfoOptions{
+			GetHealth: true,
+		})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		bb, err := json.Marshal(components)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write(bb)
+	}
+}
+
 func (a *AlloyAPI) getComponentHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
 		requestedComponent := component.ParseID(vars["id"])
 
 		component, err := a.alloy.GetComponent(requestedComponent, component.InfoOptions{
+			GetHealth:    true,
+			GetArguments: true,
+			GetExports:   true,
+			GetDebugInfo: true,
+		})
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+
+		bb, err := json.Marshal(component)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write(bb)
+	}
+}
+
+func (a *AlloyAPI) getRemotecfgComponentHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		requestedComponent := component.ParseID(vars["id"])
+
+		component, err := a.remotecfg.GetComponent(requestedComponent, component.InfoOptions{
 			GetHealth:    true,
 			GetArguments: true,
 			GetExports:   true,

--- a/internal/web/ui/src/Router.tsx
+++ b/internal/web/ui/src/Router.tsx
@@ -18,7 +18,11 @@ const Router = ({ basePath }: Props) => {
       <main>
         <Routes>
           <Route path="/" element={<PageComponentList />} />
+          <Route path="/remotecfg" element={<PageComponentList />} />
+
           <Route path="/component/*" element={<ComponentDetailPage />} />
+          <Route path="/remotecfg/component/*" element={<ComponentDetailPage />} />
+
           <Route path="/graph" element={<Graph />} />
           <Route path="/clustering" element={<PageClusteringPeers />} />
           <Route path="/debug/*" element={<PageLiveDebugging />} />

--- a/internal/web/ui/src/Router.tsx
+++ b/internal/web/ui/src/Router.tsx
@@ -6,6 +6,8 @@ import ComponentDetailPage from './pages/ComponentDetailPage';
 import Graph from './pages/Graph';
 import PageLiveDebugging from './pages/LiveDebugging';
 import PageComponentList from './pages/PageComponentList';
+import PageRemoteComponentList from './pages/PageRemoteComponentList';
+import RemoteComponentDetailPage from './pages/RemoteComponentDetailPage';
 
 interface Props {
   basePath: string;
@@ -18,10 +20,10 @@ const Router = ({ basePath }: Props) => {
       <main>
         <Routes>
           <Route path="/" element={<PageComponentList />} />
-          <Route path="/remotecfg" element={<PageComponentList />} />
+          <Route path="/remotecfg" element={<PageRemoteComponentList />} />
 
           <Route path="/component/*" element={<ComponentDetailPage />} />
-          <Route path="/remotecfg/component/*" element={<ComponentDetailPage />} />
+          <Route path="/remotecfg/component/*" element={<RemoteComponentDetailPage />} />
 
           <Route path="/graph" element={<Graph />} />
           <Route path="/clustering" element={<PageClusteringPeers />} />

--- a/internal/web/ui/src/features/component/ComponentList.tsx
+++ b/internal/web/ui/src/features/component/ComponentList.tsx
@@ -10,7 +10,7 @@ import styles from './ComponentList.module.css';
 interface ComponentListProps {
   components: ComponentInfo[];
   moduleID?: string;
-  useRemotecfg?: boolean;
+  useRemotecfg: boolean;
   handleSorting?: (sortField: string, sortOrder: SortOrder) => void;
 }
 

--- a/internal/web/ui/src/features/component/ComponentList.tsx
+++ b/internal/web/ui/src/features/component/ComponentList.tsx
@@ -10,13 +10,15 @@ import styles from './ComponentList.module.css';
 interface ComponentListProps {
   components: ComponentInfo[];
   moduleID?: string;
+  useRemotecfg?: boolean;
   handleSorting?: (sortField: string, sortOrder: SortOrder) => void;
 }
 
 const TABLEHEADERS = ['Health', 'ID'];
 
-const ComponentList = ({ components, moduleID, handleSorting }: ComponentListProps) => {
+const ComponentList = ({ components, moduleID, useRemotecfg, handleSorting }: ComponentListProps) => {
   const tableStyles = { width: '130px' };
+  const urlPrefix = useRemotecfg ? '/remotecfg' : '';
   const pathPrefix = moduleID ? moduleID + '/' : '';
 
   /**
@@ -30,7 +32,7 @@ const ComponentList = ({ components, moduleID, handleSorting }: ComponentListPro
         </td>
         <td className={styles.idColumn}>
           <span className={styles.idName}>{id}</span>
-          <NavLink to={'/component/' + pathPrefix + id} className={styles.viewButton}>
+          <NavLink to={urlPrefix + '/component/' + pathPrefix + id} className={styles.viewButton}>
             View
           </NavLink>
         </td>

--- a/internal/web/ui/src/features/component/ComponentView.tsx
+++ b/internal/web/ui/src/features/component/ComponentView.tsx
@@ -103,11 +103,15 @@ export const ComponentView: FC<ComponentViewProps> = (props) => {
           </a>
         </div>
 
-        <div className={styles.debugLink}>
-          <a href={`debug/${pathJoin([props.component.moduleID, props.component.localID])}`}>
-            <FontAwesomeIcon icon={faBug} /> Live debugging
-          </a>
-        </div>
+        {useRemotecfg ? (
+          'Live debugging is not yet available for remote components'
+        ) : (
+          <div className={styles.debugLink}>
+            <a href={`debug/${pathJoin([props.component.moduleID, props.component.localID])}`}>
+              <FontAwesomeIcon icon={faBug} /> Live debugging
+            </a>
+          </div>
+        )}
 
         {props.component.health.message && (
           <blockquote>

--- a/internal/web/ui/src/features/component/ComponentView.tsx
+++ b/internal/web/ui/src/features/component/ComponentView.tsx
@@ -1,5 +1,6 @@
 import { FC, Fragment, ReactElement } from 'react';
 import { Link } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { faBug, faCubes, faLink } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
@@ -26,6 +27,8 @@ export const ComponentView: FC<ComponentViewProps> = (props) => {
   const argsPartition = partitionBody(props.component.arguments, 'Arguments');
   const exportsPartition = props.component.exports && partitionBody(props.component.exports, 'Exports');
   const debugPartition = props.component.debugInfo && partitionBody(props.component.debugInfo, 'Debug info');
+  const location = useLocation();
+  const useRemotecfg = location.pathname.startsWith('/remotecfg');
 
   function partitionTOC(partition: PartitionedBody): ReactElement {
     return (
@@ -126,7 +129,7 @@ export const ComponentView: FC<ComponentViewProps> = (props) => {
           <section id="dependencies">
             <h2>Dependencies</h2>
             <div className={styles.sectionContent}>
-              <ComponentList components={referencesTo} moduleID={props.component.moduleID} />
+              <ComponentList components={referencesTo} useRemotecfg={useRemotecfg} moduleID={props.component.moduleID} />
             </div>
           </section>
         )}
@@ -135,7 +138,7 @@ export const ComponentView: FC<ComponentViewProps> = (props) => {
           <section id="dependants">
             <h2>Dependants</h2>
             <div className={styles.sectionContent}>
-              <ComponentList components={referencedBy} moduleID={props.component.moduleID} />
+              <ComponentList components={referencedBy} useRemotecfg={useRemotecfg} moduleID={props.component.moduleID} />
             </div>
           </section>
         )}
@@ -146,6 +149,7 @@ export const ComponentView: FC<ComponentViewProps> = (props) => {
             <div className={styles.sectionContent}>
               <ComponentList
                 components={props.component.moduleInfo}
+                useRemotecfg={useRemotecfg}
                 moduleID={pathJoin([props.component.moduleID, props.component.localID])}
               />
             </div>

--- a/internal/web/ui/src/features/layout/Navbar.tsx
+++ b/internal/web/ui/src/features/layout/Navbar.tsx
@@ -24,6 +24,11 @@ function Navbar() {
           </NavLink>
         </li>
         <li>
+          <NavLink to="/remotecfg" className="nav-link">
+            Remote Configuration
+          </NavLink>
+        </li>
+        <li>
           <a href="https://grafana.com/docs/alloy/latest">Help</a>
         </li>
       </ul>

--- a/internal/web/ui/src/hooks/componentInfo.tsx
+++ b/internal/web/ui/src/hooks/componentInfo.tsx
@@ -35,7 +35,7 @@ export const useComponentInfo = (
 
       worker().catch(console.error);
     },
-    [moduleID]
+    [moduleID, isRemotecfg]
   );
 
   return [components, setComponents];

--- a/internal/web/ui/src/hooks/componentInfo.tsx
+++ b/internal/web/ui/src/hooks/componentInfo.tsx
@@ -9,14 +9,21 @@ import { ComponentInfo } from '../features/component/types';
  * determining the proper list of components from the context of a module.
  */
 export const useComponentInfo = (
-  moduleID: string
+  moduleID: string,
+  isRemotecfg?: boolean
 ): [ComponentInfo[], React.Dispatch<React.SetStateAction<ComponentInfo[]>>] => {
   const [components, setComponents] = useState<ComponentInfo[]>([]);
 
   useEffect(
     function () {
       const worker = async () => {
-        const infoPath = moduleID === '' ? './api/v0/web/components' : `./api/v0/web/modules/${moduleID}/components`;
+        const infoPath = isRemotecfg
+          ? moduleID === ''
+            ? './api/v0/web/remotecfg/components'
+            : `./api/v0/web/remotecfg/modules/${moduleID}/components`
+          : moduleID === ''
+          ? './api/v0/web/components'
+          : `./api/v0/web/modules/${moduleID}/components`;
 
         // Request is relative to the <base> tag inside of <head>.
         const resp = await fetch(infoPath, {

--- a/internal/web/ui/src/hooks/componentInfo.tsx
+++ b/internal/web/ui/src/hooks/componentInfo.tsx
@@ -10,7 +10,7 @@ import { ComponentInfo } from '../features/component/types';
  */
 export const useComponentInfo = (
   moduleID: string,
-  isRemotecfg?: boolean
+  isRemotecfg: boolean
 ): [ComponentInfo[], React.Dispatch<React.SetStateAction<ComponentInfo[]>>] => {
   const [components, setComponents] = useState<ComponentInfo[]>([]);
 

--- a/internal/web/ui/src/pages/ComponentDetailPage.tsx
+++ b/internal/web/ui/src/pages/ComponentDetailPage.tsx
@@ -1,4 +1,5 @@
 import { FC, useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { useParams } from 'react-router-dom';
 
 import { ComponentView } from '../features/component/ComponentView';
@@ -8,9 +9,11 @@ import { parseID } from '../utils/id';
 
 const ComponentDetailPage: FC = () => {
   const { '*': id } = useParams();
+  const location = useLocation();
+  const useRemotecfg = location.pathname.startsWith('/remotecfg');
 
   const { moduleID } = parseID(id || '');
-  const [components] = useComponentInfo(moduleID);
+  const [components] = useComponentInfo(moduleID, useRemotecfg);
   const infoByID = componentInfoByID(components);
 
   const [component, setComponent] = useState<ComponentDetail | undefined>(undefined);
@@ -21,16 +24,21 @@ const ComponentDetailPage: FC = () => {
         return;
       }
 
+      const fetchURL = useRemotecfg ? `./api/v0/web/remotecfg/components/${id}` : `./api/v0/web/components/${id}`;
       const worker = async () => {
         // Request is relative to the <base> tag inside of <head>.
-        const resp = await fetch(`./api/v0/web/components/${id}`, {
+        const resp = await fetch(fetchURL, {
           cache: 'no-cache',
           credentials: 'same-origin',
         });
         const data: ComponentDetail = await resp.json();
 
         for (const moduleID of data.createdModuleIDs || []) {
-          const moduleComponentsResp = await fetch(`./api/v0/web/modules/${moduleID}/components`, {
+          const modulesURL = useRemotecfg
+            ? `./api/v0/web/remotecfg/modules/${moduleID}/components`
+            : `./api/v0/web/modules/${moduleID}/components`;
+
+          const moduleComponentsResp = await fetch(modulesURL, {
             cache: 'no-cache',
             credentials: 'same-origin',
           });

--- a/internal/web/ui/src/pages/ComponentDetailPage.tsx
+++ b/internal/web/ui/src/pages/ComponentDetailPage.tsx
@@ -52,7 +52,7 @@ const ComponentDetailPage: FC = () => {
 
       worker().catch(console.error);
     },
-    [id]
+    [id, useRemotecfg]
   );
 
   return component ? <ComponentView component={component} info={infoByID} /> : <div></div>;

--- a/internal/web/ui/src/pages/Graph.tsx
+++ b/internal/web/ui/src/pages/Graph.tsx
@@ -5,7 +5,7 @@ import Page from '../features/layout/Page';
 import { useComponentInfo } from '../hooks/componentInfo';
 
 function Graph() {
-  const [components] = useComponentInfo('');
+  const [components] = useComponentInfo('', false);
 
   return (
     <Page name="Graph" desc="Relationships between defined components" icon={faDiagramProject}>

--- a/internal/web/ui/src/pages/PageComponentList.tsx
+++ b/internal/web/ui/src/pages/PageComponentList.tsx
@@ -20,6 +20,8 @@ function getSortValue(component: ComponentInfo, field: string): string | undefin
 function PageComponentList() {
   const location = useLocation();
   const useRemotecfg = location.pathname.startsWith('/remotecfg');
+  const pageName = useRemotecfg ? 'Remote Configuration' : 'Components';
+  const pageDesc = useRemotecfg ? 'List of remote configuration pipelines' : 'List of defined components';
 
   const [components, setComponents] = useComponentInfo('', useRemotecfg);
 
@@ -41,7 +43,7 @@ function PageComponentList() {
   };
 
   return (
-    <Page name="Components" desc="List of defined components" icon={faCubes}>
+    <Page name={pageName} desc={pageDesc} icon={faCubes}>
       <ComponentList components={components} useRemotecfg={useRemotecfg} handleSorting={handleSorting} />
     </Page>
   );

--- a/internal/web/ui/src/pages/PageComponentList.tsx
+++ b/internal/web/ui/src/pages/PageComponentList.tsx
@@ -1,3 +1,4 @@
+import { useLocation } from 'react-router-dom';
 import { faCubes } from '@fortawesome/free-solid-svg-icons';
 
 import ComponentList from '../features/component/ComponentList';
@@ -17,7 +18,10 @@ function getSortValue(component: ComponentInfo, field: string): string | undefin
 }
 
 function PageComponentList() {
-  const [components, setComponents] = useComponentInfo('');
+  const location = useLocation();
+  const useRemotecfg = location.pathname.startsWith('/remotecfg');
+
+  const [components, setComponents] = useComponentInfo('', useRemotecfg);
 
   // TODO: make this sorting logic reusable
   const handleSorting = (sortField: string, sortOrder: SortOrder): void => {
@@ -38,7 +42,7 @@ function PageComponentList() {
 
   return (
     <Page name="Components" desc="List of defined components" icon={faCubes}>
-      <ComponentList components={components} handleSorting={handleSorting} />
+      <ComponentList components={components} useRemotecfg={useRemotecfg} handleSorting={handleSorting} />
     </Page>
   );
 }

--- a/internal/web/ui/src/pages/PageRemoteComponentList.tsx
+++ b/internal/web/ui/src/pages/PageRemoteComponentList.tsx
@@ -16,8 +16,8 @@ function getSortValue(component: ComponentInfo, field: string): string | undefin
   return valueGetter ? valueGetter(component) : undefined;
 }
 
-function PageComponentList() {
-  const [components, setComponents] = useComponentInfo('', false);
+function PageRemoteComponentList() {
+  const [components, setComponents] = useComponentInfo('', true);
 
   // TODO: make this sorting logic reusable
   const handleSorting = (sortField: string, sortOrder: SortOrder): void => {
@@ -37,10 +37,10 @@ function PageComponentList() {
   };
 
   return (
-    <Page name="Components" desc="List of defined components" icon={faCubes}>
-      <ComponentList components={components} useRemotecfg={false} handleSorting={handleSorting} />
+    <Page name="Remote Configuration" desc="List of remote configuration pipelines" icon={faCubes}>
+      <ComponentList components={components} useRemotecfg={true} handleSorting={handleSorting} />
     </Page>
   );
 }
 
-export default PageComponentList;
+export default PageRemoteComponentList;

--- a/internal/web/ui/src/pages/RemoteComponentDetailPage.tsx
+++ b/internal/web/ui/src/pages/RemoteComponentDetailPage.tsx
@@ -6,10 +6,11 @@ import { ComponentDetail, ComponentInfo, componentInfoByID } from '../features/c
 import { useComponentInfo } from '../hooks/componentInfo';
 import { parseID } from '../utils/id';
 
-const ComponentDetailPage: FC = () => {
+const RemoteComponentDetailPage: FC = () => {
   const { '*': id } = useParams();
+
   const { moduleID } = parseID(id || '');
-  const [components] = useComponentInfo(moduleID, false);
+  const [components] = useComponentInfo(moduleID, true);
   const infoByID = componentInfoByID(components);
 
   const [component, setComponent] = useState<ComponentDetail | undefined>(undefined);
@@ -20,7 +21,7 @@ const ComponentDetailPage: FC = () => {
         return;
       }
 
-      const fetchURL = `./api/v0/web/components/${id}`;
+      const fetchURL = `./api/v0/web/remotecfg/components/${id}`;
       const worker = async () => {
         // Request is relative to the <base> tag inside of <head>.
         const resp = await fetch(fetchURL, {
@@ -30,7 +31,7 @@ const ComponentDetailPage: FC = () => {
         const data: ComponentDetail = await resp.json();
 
         for (const moduleID of data.createdModuleIDs || []) {
-          const modulesURL = `./api/v0/web/modules/${moduleID}/components`;
+          const modulesURL = `./api/v0/web/remotecfg/modules/${moduleID}/components`;
 
           const moduleComponentsResp = await fetch(modulesURL, {
             cache: 'no-cache',
@@ -52,4 +53,4 @@ const ComponentDetailPage: FC = () => {
   return component ? <ComponentView component={component} info={infoByID} /> : <div></div>;
 };
 
-export default ComponentDetailPage;
+export default RemoteComponentDetailPage;


### PR DESCRIPTION
#### PR Description

This PR wires in the Data() call of the remotecfg service that exposes its isolated Host to be able to display remotely loaded components via the UI.

To do this, we introduce new API endpoinst prefixed with /remotecfg, and make use of the existing layout pages to call to either host dynamically. To do that, I'm having  `useLocation()`'s output as a parameter, depending on the current URL the user has navigated to.

This shouldn't impact any of the existing UI capabilities, just adding new ones. I've tested with nested modules under remotecfg's controller and they seem to be working properly.

#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated

![image](https://github.com/user-attachments/assets/d3960f87-0cda-4567-a3f2-2bced5e7be19)
![image](https://github.com/user-attachments/assets/dfe8f8e6-80a6-4049-92aa-cf6fd618a796)
![image](https://github.com/user-attachments/assets/c5c515c3-7f4c-4587-adf6-92aff3d9d2aa)
