### PR TITLE
fix(docs): change pyroscope ports from 4100 to default pyroscope port 4040

### DIFF
--- a/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
@@ -244,7 +244,7 @@ pyroscope.ebpf "local_pods" {
 
 pyroscope.write "endpoint" {
   endpoint {
-    url = "http://pyroscope:4100"
+    url = "http://pyroscope:4040"
   }
 }
 ```
@@ -270,7 +270,7 @@ discovery.relabel "local_containers" {
 
 pyroscope.write "staging" {
   endpoint {
-    url = "http://pyroscope:4100"
+    url = "http://pyroscope:4040"
   }
 }
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.scrape.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.scrape.md
@@ -429,7 +429,7 @@ The scraped profiles are sent to `pyroscope.write` which remote writes them to a
 ```alloy
 pyroscope.scrape "local" {
   targets = [
-    {"__address__" = "localhost:4100", "service_name"="pyroscope"},
+    {"__address__" = "localhost:4040", "service_name"="pyroscope"},
     {"__address__" = "localhost:12345", "service_name"="alloy"},
   ]
 
@@ -438,7 +438,7 @@ pyroscope.scrape "local" {
 
 pyroscope.write "local" {
   endpoint {
-    url = "http://pyroscope:4100"
+    url = "http://pyroscope:4040"
   }
 }
 ```
@@ -446,11 +446,11 @@ pyroscope.write "local" {
 These endpoints will be scraped every 15 seconds:
 
 ```
-http://localhost:4100/debug/pprof/allocs
-http://localhost:4100/debug/pprof/block
-http://localhost:4100/debug/pprof/goroutine
-http://localhost:4100/debug/pprof/mutex
-http://localhost:4100/debug/pprof/profile?seconds=14
+http://localhost:4040/debug/pprof/allocs
+http://localhost:4040/debug/pprof/block
+http://localhost:4040/debug/pprof/goroutine
+http://localhost:4040/debug/pprof/mutex
+http://localhost:4040/debug/pprof/profile?seconds=14
 
 http://localhost:12345/debug/pprof/allocs
 http://localhost:12345/debug/pprof/block
@@ -483,7 +483,7 @@ pyroscope.scrape "local" {
 
 pyroscope.write "local" {
   endpoint {
-    url = "http://pyroscope:4100"
+    url = "http://pyroscope:4040"
   }
 }
 ```
@@ -509,7 +509,7 @@ pyroscope.scrape "local" {
 
 pyroscope.write "local" {
   endpoint {
-    url = "http://pyroscope:4100"
+    url = "http://pyroscope:4040"
   }
 }
 ```

--- a/docs/sources/reference/components/pyroscope/pyroscope.write.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.write.md
@@ -131,7 +131,7 @@ In those cases, exported fields are kept at their last healthy values.
 pyroscope.write "staging" {
   // Send metrics to a locally running Pyroscope instance.
   endpoint {
-    url = "http://pyroscope:4100"
+    url = "http://pyroscope:4040"
     headers = {
       "X-Scope-OrgID" = "squad-1",
     }
@@ -143,7 +143,7 @@ pyroscope.write "staging" {
 
 pyroscope.scrape "default" {
   targets = [
-    {"__address__" = "pyroscope:4100", "service_name"="pyroscope"},
+    {"__address__" = "pyroscope:4040", "service_name"="pyroscope"},
     {"__address__" = "alloy:12345", "service_name"="alloy"},
   ]
   forward_to = [pyroscope.write.staging.receiver]


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
change pyroscope ports from 4100 to default pyroscope port 4040
#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
