### PR TITLE
Add appProtocol for OpenShift

### DIFF
--- a/operations/helm/charts/alloy/CHANGELOG.md
+++ b/operations/helm/charts/alloy/CHANGELOG.md
@@ -13,6 +13,7 @@ Unreleased
 ### Enhancements
 
 - Add the ability to set --cluster.name in the Helm chart with alloy.clustering.name. (@petewall)
+- Add the ability to set appProtocol in extraPorts to help OpenShift users to expose gRPC. (@clementduveau)
 
 0.6.0 (2024-08-05)
 ------------------

--- a/operations/helm/charts/alloy/README.md
+++ b/operations/helm/charts/alloy/README.md
@@ -179,6 +179,7 @@ Port numbers specified must be 0 < x < 65535.
 | hostPort | hostPort | (Optional) Number of port to expose on the host. Daemonsets taking traffic might find this useful. |
 | name | name | If specified, this must be an `IANA_SVC_NAME` and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
 | protocol | protocol | Must be UDP, TCP, or SCTP. Defaults to "TCP". |
+| appProtocol | appProtocol | Hint on application protocol. This is used to expose Alloy externally on OpenShift clusters using "h2c". Optional. No default value. |
 
 ### alloy.listenAddr
 
@@ -280,3 +281,30 @@ To expose this information to Grafana Alloy for telemetry collection:
   privileged: true
   runAsUser: 0
   ```
+
+## Expose Alloy externally on OpenShift clusters
+
+If you want to send telemetry from an Alloy instance outside of the OpenShift clusters over gRPC towards the Alloy instance on the OpenShift clusters, you need to:
+
+* Set the optional `appProtocol` on `alloy.extraPorts` to `h2c`
+* Expose the service via Ingress or Route within the OpenShift cluster. Example of a Route in OpenShift:
+```yaml
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: route-otlp-alloy-h2c
+spec:
+  to:
+    kind: Service
+    name: test-grpc-h2c
+    weight: 100
+  port:
+    targetPort: otlp-grpc
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None
+```
+
+
+Once this Ingress/Route is exposed it would then allow gRPC communication for (for example) traces. This allow an Alloy instance on a VM or another Kubernetes/OpenShift cluster to be able to communicate over gRPC via the exposed Ingress or Route.

--- a/operations/helm/charts/alloy/README.md
+++ b/operations/helm/charts/alloy/README.md
@@ -306,5 +306,4 @@ spec:
   wildcardPolicy: None
 ```
 
-
 Once this Ingress/Route is exposed it would then allow gRPC communication for (for example) traces. This allow an Alloy instance on a VM or another Kubernetes/OpenShift cluster to be able to communicate over gRPC via the exposed Ingress or Route.

--- a/operations/helm/charts/alloy/README.md.gotmpl
+++ b/operations/helm/charts/alloy/README.md.gotmpl
@@ -76,6 +76,7 @@ Port numbers specified must be 0 < x < 65535.
 | hostPort | hostPort | (Optional) Number of port to expose on the host. Daemonsets taking traffic might find this useful. |
 | name | name | If specified, this must be an `IANA_SVC_NAME` and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
 | protocol | protocol | Must be UDP, TCP, or SCTP. Defaults to "TCP". |
+| appProtocol | appProtocol | Hint on application protocol. This is used to expose Alloy externally on OpenShift clusters using "h2c". Optional. No default value. |
 
 ### alloy.listenAddr
 
@@ -177,3 +178,30 @@ To expose this information to Grafana Alloy for telemetry collection:
   privileged: true
   runAsUser: 0
   ```
+
+## Expose Alloy externally on OpenShift clusters
+
+If you want to send telemetry from an Alloy instance outside of the OpenShift clusters over gRPC towards the Alloy instance on the OpenShift clusters, you need to:
+
+* Set the optional `appProtocol` on `alloy.extraPorts` to `h2c`
+* Expose the service via Ingress or Route within the OpenShift cluster. Example of a Route in OpenShift:
+```yaml
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: route-otlp-alloy-h2c
+spec:
+  to:
+    kind: Service
+    name: test-grpc-h2c
+    weight: 100
+  port:
+    targetPort: otlp-grpc
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None
+```
+
+
+Once this Ingress/Route is exposed it would then allow gRPC communication for (for example) traces. This allow an Alloy instance on a VM or another Kubernetes/OpenShift cluster to be able to communicate over gRPC via the exposed Ingress or Route.

--- a/operations/helm/charts/alloy/templates/cluster_service.yaml
+++ b/operations/helm/charts/alloy/templates/cluster_service.yaml
@@ -29,5 +29,9 @@ spec:
       port: {{ $portMap.port }}
       targetPort: {{ $portMap.targetPort }}
       protocol: {{ coalesce $portMap.protocol "TCP" }}
+      # Useful for OpenShift clusters that want to expose Alloy ports externally
+      {{- if not (empty $portMap.appProtocol) }}
+      appProtocol: {{ $portMap.appProtocol }}
+      {{- end }}
   {{- end }}
 {{- end }}

--- a/operations/helm/charts/alloy/templates/cluster_service.yaml
+++ b/operations/helm/charts/alloy/templates/cluster_service.yaml
@@ -29,8 +29,8 @@ spec:
       port: {{ $portMap.port }}
       targetPort: {{ $portMap.targetPort }}
       protocol: {{ coalesce $portMap.protocol "TCP" }}
-      # Useful for OpenShift clusters that want to expose Alloy ports externally
       {{- if not (empty $portMap.appProtocol) }}
+      # Useful for OpenShift clusters that want to expose Alloy ports externally
       appProtocol: {{ $portMap.appProtocol }}
       {{- end }}
   {{- end }}

--- a/operations/helm/charts/alloy/templates/service.yaml
+++ b/operations/helm/charts/alloy/templates/service.yaml
@@ -34,5 +34,9 @@ spec:
       port: {{ $portMap.port }}
       targetPort: {{ $portMap.targetPort }}
       protocol: {{ coalesce $portMap.protocol "TCP" }}
+      {{- if not (empty $portMap.appProtocol) }}
+      # Useful for OpenShift clusters that want to expose Alloy ports externally
+      appProtocol: {{ $portMap.appProtocol }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/operations/helm/charts/alloy/values.yaml
+++ b/operations/helm/charts/alloy/values.yaml
@@ -87,6 +87,7 @@ alloy:
   #   port: 12347
   #   targetPort: 12347
   #   protocol: "TCP"
+  #   appProtocol: "h2c"
 
   mounts:
     # -- Mount /var/log from the host into the container for log collection.


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
On OpenShift, to expose Alloy gRPC to receive OTLP from other ressources, by default, you need to specifiy appProtocol = h2c on the service. It actually depends on your setup but the default Ingress HAProxy requires it, so probably 80% of RedHat customers needs it.

This PR just add the appProtocol as a possibility in the values.yaml. If not set, it outputs nothing. No default value because Kubernetes uses it as a "[hint](https://kubernetes.io/docs/concepts/services-networking/service/#:~:text=This%20is%20used%20as%20a%20hint%20for%20implementations%20to%20offer%20richer%20behavior)", therefore it's not mandatory.

#### Which issue(s) this PR fixes

Fixes #1405 

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated --> I don't have an environment to test it, it should have no effect on vanilla K8s. We can ask @benoitschipper for tests on OpenShift
