### PR TITLE
http: fix pathPrefix used to look up remotecfg's components

### DIFF
--- a/internal/service/http/http.go
+++ b/internal/service/http/http.go
@@ -178,8 +178,9 @@ func (s *Service) Run(ctx context.Context, host service.Host) error {
 	}
 
 	// NOTE(@tpaschalis) These need to be kept in order for the longer
-	// remotecfg prefix to be invoked correctly.
-	r.PathPrefix(s.componentHttpPathPrefixRemotecfg).Handler(s.componentHandler(remoteCfgHostProvider(host), s.componentHttpPathPrefixRemotecfg))
+	// remotecfg prefix to be invoked correctly. The pathPrefix is still the
+	// same so that `remotecfg/` is not stripped from component lookups.
+	r.PathPrefix(s.componentHttpPathPrefixRemotecfg).Handler(s.componentHandler(remoteCfgHostProvider(host), s.componentHttpPathPrefix))
 	r.PathPrefix(s.componentHttpPathPrefix).Handler(s.componentHandler(rootHostProvider(host), s.componentHttpPathPrefix))
 
 	if s.opts.ReadyFunc != nil {


### PR DESCRIPTION
#### PR Description

At some point during #1372 I accidentally changed the pathPrefix used for the lookup of remotecfg components, stripping out the `remotecfg/` prefix and failing the component lookups.

After this change, I've verified that both local and remotecfg component lookups work as intended in parallel, both through the default and the in-memory listener 

```
$ curl -i localhost:12349/api/v0/component/remotecfg/self.default/prometheus.exporter.self.default/metrics
HTTP/1.1 200 OK
Content-Type: text/plain; version=0.0.4; charset=utf-8; escaping=values
Date: Mon, 19 Aug 2024 15:43:54 GMT
Transfer-Encoding: chunked

# HELP alloy_build_info A metric with a constant '1' value labeled by version, revision, branch, goversion from which alloy was built, and the goos and goarch for the build.
# TYPE alloy_build_info gauge

$  curl -i localhost:12349/api/v0/component/prometheus.exporter.self.default/metrics
HTTP/1.1 200 OK
Content-Type: text/plain; version=0.0.4; charset=utf-8; escaping=values
Date: Mon, 19 Aug 2024 15:41:48 GMT
Transfer-Encoding: chunked

# HELP alloy_build_info A metric with a constant '1' value labeled by version, revision, branch, goversion from which alloy was built, and the goos and goarch for the build.
# TYPE alloy_build_info gauge
```


#### Which issue(s) this PR fixes
Fixes #1486 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated (N/A) 
- [ ] Documentation added (N/A)
- [ ] Tests updated 
- [ ] Config converters updated (N/A)
