### PR TITLE
Add Secret resource into Helm chart to allow passing sensitive values to config via environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Main (unreleased)
   seen by each instance in the cluster. This can help diagnose cluster split
   brain issues. (@thampiotr)
 
+- Added a new Secret resource into the helm chart to allow passing values into
+  config via environement variables.
+
 ### Bugfixes
 
 - Fixed an issue which caused loss of context data in Faro exception. (@codecapitano)

--- a/operations/helm/charts/alloy/README.md
+++ b/operations/helm/charts/alloy/README.md
@@ -44,6 +44,7 @@ useful if just using the default DaemonSet isn't sufficient.
 | alloy.envFrom | list | `[]` | Maps all the keys on a ConfigMap or Secret as environment variables. https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envfromsource-v1-core |
 | alloy.extraArgs | list | `[]` | Extra args to pass to `alloy run`: https://grafana.com/docs/alloy/latest/reference/cli/run/ |
 | alloy.extraEnv | list | `[]` | Extra environment variables to pass to the Alloy container. |
+| alloy.extraSecretEnv | string | `[]` | Extra environment variables to store in a Secret and pass to Alloy container. |
 | alloy.extraPorts | list | `[]` | Extra ports to expose on the Alloy container. |
 | alloy.listenAddr | string | `"0.0.0.0"` | Address to listen for traffic on. 0.0.0.0 exposes the UI to other containers. |
 | alloy.listenPort | int | `12345` | Port to listen for traffic on. |

--- a/operations/helm/charts/alloy/config/example.alloy
+++ b/operations/helm/charts/alloy/config/example.alloy
@@ -26,3 +26,14 @@ discovery.kubernetes "endpointslices" {
 discovery.kubernetes "ingresses" {
 	role = "ingress"
 }
+
+prometheus.remote_write "demo" {
+  endpoint {
+    url = env("PROMETHEUS_REMOTEWRITE_URL")
+
+    basic_auth {
+      username = env("PROMETHEUS_REMOTEWRITE_USERNAME")
+      password = env("PROMETHEUS_REMOTEWRITE_PASSWORD")
+    }
+  }
+}

--- a/operations/helm/charts/alloy/templates/containers/_agent.yaml
+++ b/operations/helm/charts/alloy/templates/containers/_agent.yaml
@@ -35,9 +35,15 @@
     {{- range $values.extraEnv }}
     - {{- toYaml . | nindent 6 }}
     {{- end }}
-  {{- if $values.envFrom }}
+  {{- if or $values.envFrom $values.extraSecretEnv }}
   envFrom:
-    {{- toYaml $values.envFrom | nindent 4 }}
+    {{- if $values.extraSecretEnv }}
+    - secretRef:
+        name: {{ include "alloy.fullname" . }}
+    {{- end }}
+    {{- if $values.envFrom }}
+      {{- toYaml $values.envFrom | nindent 4 }}
+    {{- end }}
   {{- end }}
   ports:
     - containerPort: {{ $values.listenPort }}

--- a/operations/helm/charts/alloy/templates/secret.yaml
+++ b/operations/helm/charts/alloy/templates/secret.yaml
@@ -1,0 +1,14 @@
+{{- $values := (mustMergeOverwrite .Values.alloy (or .Values.agent dict)) -}}
+{{- if $values.extraSecretEnv }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "alloy.fullname" . }}
+  labels:
+    {{- include "alloy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: config
+data:
+  {{- range $secretEnvMap := $values.extraSecretEnv }}
+  {{ $secretEnvMap.name }}: {{ $secretEnvMap.value | b64enc }}
+  {{- end }}
+{{- end }}

--- a/operations/helm/charts/alloy/values.yaml
+++ b/operations/helm/charts/alloy/values.yaml
@@ -75,6 +75,15 @@ alloy:
   # -- Extra environment variables to pass to the Alloy container.
   extraEnv: []
 
+  # -- Extra environment variables to store in a Secret and pass to Alloy container.
+  extraSecretEnv: []
+  # - name: PROMETHEUS_REMOTEWRITE_URL
+  #   value: https://some-prometheus:9090/api/v1/write
+  # - name: PROMETHEUS_REMOTEWRITE_USERNAME
+  #   value: foo
+  # - name: PROMETHEUS_REMOTEWRITE_PASSWORD
+  #   value: bar
+
   # -- Maps all the keys on a ConfigMap or Secret as environment variables. https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envfromsource-v1-core
   envFrom: []
 


### PR DESCRIPTION
#### PR Description

This PR introduces a new Secret resources into the Helm chart which is used to store sensitive values as environment variables and populate them into the Alloy container to be read within the Alloy config using the `env` directive.

This allow for sensitive values to be stored in a Secret rather than in the ConfigMap or the Pod definition.

#### Notes to the Reviewer

I did my best to add some meaningful examples on how those secret values are defined and used from the config, but I am open to suggestions.

I would also appreciate some guidance on how to update the Helm chart tests.

#### PR Checklist

- [x] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
