### PR TITLE
update stability notes

### DIFF
--- a/docs/sources/shared/stability/experimental.md
+++ b/docs/sources/shared/stability/experimental.md
@@ -6,6 +6,7 @@ headless: true
 
 > **EXPERIMENTAL**: This is an [experimental][] component. Experimental
 > components are subject to frequent breaking changes, and may be removed with
-> no equivalent replacement.
+> no equivalent replacement. The `stability.level` flag must be set to `experimental`
+> to use the component.
 
 [experimental]: https://grafana.com/docs/release-life-cycle/

--- a/docs/sources/shared/stability/public_preview.md
+++ b/docs/sources/shared/stability/public_preview.md
@@ -5,6 +5,7 @@ headless: true
 ---
 
 > **Public preview**: This is a [public preview][] component. Public preview components are subject to breaking
-> changes, and may be replaced with equivalent functionality that cover the same use case.
+> changes, and may be replaced with equivalent functionality that cover the same use case. The `stability.level` flag must 
+> be set to `public-preview` to use the component.
 
 [public preview]: https://grafana.com/docs/release-life-cycle/


### PR DESCRIPTION
The note informs about the stability level but does not specify that the stability flag should be set.
The users will find it out in an error message when Alloy fails to run.

Adding the flag info to the note improves the user experience by preventing them from failing the first run.