### PR TITLE
Remove fail-fast on cluster bootstrap when peers discovery fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Main (unreleased)
 - Updated Snowflake exporter with performance improvements for larger environments. 
   Also added a new panel to track deleted tables to the Snowflake mixin. (@Caleb-Hurshman)
 
+- Changed the cluster startup behaviour, reverting to the previous logic where
+  a failure to resolve cluster join peers results in the node creating its own cluster. This is
+  to facilitate the process of bootstrapping a new cluster following user feedback (@thampiotr)
+
 ### Bugfixes
 
 - Fix a bug where custom components don't always get updated when the config is modified in an imported directory. (@ante012)

--- a/internal/service/cluster/cluster.go
+++ b/internal/service/cluster/cluster.go
@@ -275,10 +275,9 @@ func (s *Service) Run(ctx context.Context, host service.Host) error {
 
 	peers, err := s.getPeers()
 	if err != nil {
-		// Fatal failure on startup if we can't discover peers to prevent a split brain and give a clear signal to the user.
-		// NOTE: currently returning error from `Run` will not be handled correctly: https://github.com/grafana/alloy/issues/843
-		level.Error(s.log).Log("msg", "fatal error: failed to get peers to join at startup - this is likely a configuration error", "err", err)
-		os.Exit(1)
+		// Warn when failed to get peers on startup as it can result in a split brain. We do not fail hard here
+		// because it would complicate the process of bootstrapping a new cluster.
+		level.Warn(s.log).Log("msg", "failed to get peers to join at startup; will create a new cluster", "err", err)
 	}
 
 	// We log on info level including all the peers (without any abbreviation), as it's happening only on startup and


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This removes the behaviour of failing fast when peers discovery fails during startup with clustering configured. 
- It was[ added originally](https://github.com/grafana/alloy/pull/1242/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR31-R34) to prevent incidents that can result in large clusters ending up in split brain.
- However, this added friction when creating bootstrapping new clusters.
- We decided to go back to previous behaviour because we have also made it easier to diagnose cluster split-brain scenarios, so we trust they will be easier to fix. 

#### Which issue(s) this PR fixes

Fixes #1441

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

Before:
```
piotrwork@bitp-ThinkPad-X1-Carbon-2nd ~/w/bin> ./alloy-linux-amd64 run ../empty-config.alloy --cluster.enabled --cluster.join-addresses wrong-address
ts=2024-08-20T15:23:18.54020246Z level=info "boringcrypto enabled"=false
ts=2024-08-20T15:23:18.540229048Z level=warn msg="could not find advertise address using network interfaces" service=cluster "[eth0 en0]"="falling back to localhost" err="no useable address found for interfaces [eth0 en0]: 2 errors occurred:\n\t* interface \"eth0\": route ip+net: no such network interface\n\t* interface \"en0\": route ip+net: no such network interface\n\n"
ts=2024-08-20T15:23:18.540249275Z level=info msg="running usage stats reporter"
ts=2024-08-20T15:23:18.540261028Z level=info msg="starting complete graph evaluation" controller_path=/ controller_id="" trace_id=522419acb593bc95219efe3ea78a5342
ts=2024-08-20T15:23:18.540272167Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=522419acb593bc95219efe3ea78a5342 node_id=tracing duration=5.432µs
ts=2024-08-20T15:23:18.540283724Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=522419acb593bc95219efe3ea78a5342 node_id=logging duration=82.308µs
ts=2024-08-20T15:23:18.54034534Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=522419acb593bc95219efe3ea78a5342 node_id=remotecfg duration=49.865µs
ts=2024-08-20T15:23:18.540377173Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=522419acb593bc95219efe3ea78a5342 node_id=livedebugging duration=7.531µs
ts=2024-08-20T15:23:18.540390804Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=522419acb593bc95219efe3ea78a5342 node_id=otel duration=1.138µs
ts=2024-08-20T15:23:18.54040593Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=522419acb593bc95219efe3ea78a5342 node_id=labelstore duration=4.47µs
ts=2024-08-20T15:23:18.54043175Z level=info msg="applying non-TLS config to HTTP server" service=http
ts=2024-08-20T15:23:18.540442776Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=522419acb593bc95219efe3ea78a5342 node_id=http duration=17.944µs
ts=2024-08-20T15:23:18.540459265Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=522419acb593bc95219efe3ea78a5342 node_id=ui duration=1.043µs
ts=2024-08-20T15:23:18.540477535Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=522419acb593bc95219efe3ea78a5342 node_id=cluster duration=1.059µs
ts=2024-08-20T15:23:18.540488853Z level=info msg="finished complete graph evaluation" controller_path=/ controller_id="" trace_id=522419acb593bc95219efe3ea78a5342 duration=354.037µs
ts=2024-08-20T15:23:18.540585946Z level=info msg="scheduling loaded components and services"
ts=2024-08-20T15:23:18.541361538Z level=info msg="now listening for http traffic" service=http addr=127.0.0.1:12345
ts=2024-08-20T15:23:18.547902867Z level=warn msg="failed to resolve SRV records" service=cluster addr=wrong-address err="lookup wrong-address on 127.0.0.53:53: no such host"
ts=2024-08-20T15:23:18.548032388Z level=error msg="fatal error: failed to get peers to join at startup - this is likely a configuration error" service=cluster err="static peer discovery: failed to find any valid join addresses: failed to extract host and port: address wrong-address: missing port in address\nfailed to resolve SRV records: lookup wrong-address on 127.0.0.53:53: no such host"
```

After:
```
piotrwork@bitp-ThinkPad-X1-Carbon-2nd ~/w/alloy (main)> ./build/alloy run ../empty-config.alloy --cluster.enabled --cluster.join-addresses wrong-address
ts=2024-08-20T15:18:49.654876797Z level=info "boringcrypto enabled"=false
ts=2024-08-20T15:18:49.654903537Z level=warn msg="could not find advertise address using network interfaces" service=cluster "[eth0 en0]"="falling back to localhost" err="no useable address found for interfaces [eth0 en0]: 2 errors occurred:\n\t* interface \"eth0\": route ip+net: no such network interface\n\t* interface \"en0\": route ip+net: no such network interface\n\n"
ts=2024-08-20T15:18:49.654924602Z level=info msg="using provided peers for discovery" service=cluster join_peers=wrong-address
ts=2024-08-20T15:18:49.654932814Z level=info msg="running usage stats reporter"
ts=2024-08-20T15:18:49.654938345Z level=info msg="starting complete graph evaluation" controller_path=/ controller_id="" trace_id=986117b1634ab467331a43e147f0f81f
ts=2024-08-20T15:18:49.654953507Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=986117b1634ab467331a43e147f0f81f node_id=logging duration=83.215µs
ts=2024-08-20T15:18:49.654979292Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=986117b1634ab467331a43e147f0f81f node_id=otel duration=2.731µs
ts=2024-08-20T15:18:49.655008395Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=986117b1634ab467331a43e147f0f81f node_id=livedebugging duration=13.815µs
ts=2024-08-20T15:18:49.655030908Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=986117b1634ab467331a43e147f0f81f node_id=labelstore duration=5.755µs
ts=2024-08-20T15:18:49.655050793Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=986117b1634ab467331a43e147f0f81f node_id=tracing duration=5.032µs
ts=2024-08-20T15:18:49.655110337Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=986117b1634ab467331a43e147f0f81f node_id=remotecfg duration=45.207µs
ts=2024-08-20T15:18:49.655134151Z level=info msg="applying non-TLS config to HTTP server" service=http
ts=2024-08-20T15:18:49.65514668Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=986117b1634ab467331a43e147f0f81f node_id=http duration=22.868µs
ts=2024-08-20T15:18:49.655156813Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=986117b1634ab467331a43e147f0f81f node_id=ui duration=766ns
ts=2024-08-20T15:18:49.655179483Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=986117b1634ab467331a43e147f0f81f node_id=cluster duration=993ns
ts=2024-08-20T15:18:49.655195661Z level=info msg="finished complete graph evaluation" controller_path=/ controller_id="" trace_id=986117b1634ab467331a43e147f0f81f duration=383.2µs
ts=2024-08-20T15:18:49.655283312Z level=info msg="scheduling loaded components and services"
ts=2024-08-20T15:18:49.655919269Z level=info msg="now listening for http traffic" service=http addr=127.0.0.1:12345
ts=2024-08-20T15:18:49.66284907Z level=warn msg="failed to resolve provided join address" service=cluster addr=wrong-address
ts=2024-08-20T15:18:49.662986065Z level=warn msg="failed to get peers to join at startup; will create a new cluster" service=cluster err="static peer discovery: failed to find any valid join addresses: could not parse as an IP or IP:port address: \"wrong-address\"\nfailed to resolve \"A/AAAA\" records: lookup wrong-address on 127.0.0.53:53: server misbehaving\nfailed to resolve \"SRV\" records: lookup wrong-address on 127.0.0.53:53: no such host"
ts=2024-08-20T15:18:49.663031868Z level=info msg="starting cluster node" service=cluster peers_count=0 peers="" advertise_addr=127.0.0.1:12345
ts=2024-08-20T15:18:49.663339681Z level=info msg="peers changed" service=cluster peers_count=1 peers=bitp-ThinkPad-X1-Carbon-2nd
ts=2024-08-20T15:19:49.671271053Z level=warn msg="failed to resolve provided join address" service=cluster addr=wrong-address
ts=2024-08-20T15:19:49.671315959Z level=warn msg="failed to refresh list of peers" service=cluster err="static peer discovery: failed to find any valid join addresses: could not parse as an IP or IP:port address: \"wrong-address\"\nfailed to resolve \"A/AAAA\" records: lookup wrong-address on 127.0.0.53:53: server misbehaving\nfailed to resolve \"SRV\" records: lookup wrong-address on 127.0.0.53:53: no such host"
^Cinterrupt received
```

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
