### PR TITLE
Show timestamps of incoming and outgoing log lines during live debugging of loki.process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ Main (unreleased)
   a failure to resolve cluster join peers results in the node creating its own cluster. This is
   to facilitate the process of bootstrapping a new cluster following user feedback (@thampiotr)
 
+- Live debugging of `loki.process` will now also print the timestamp of incoming and outgoing log lines.
+  This is helpful for debugging `stage.timestamp`. (@ptodev)
+
 ### Bugfixes
 
 - Fix a bug where custom components don't always get updated when the config is modified in an imported directory. (@ante012)

--- a/internal/component/loki/process/process.go
+++ b/internal/component/loki/process/process.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+	"time"
 
 	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/component/common/loki"
@@ -160,7 +161,7 @@ func (c *Component) handleIn(ctx context.Context, wg *sync.WaitGroup) {
 				return
 			case c.processIn <- entry.Clone():
 				if c.debugDataPublisher.IsActive(componentID) {
-					c.debugDataPublisher.Publish(componentID, fmt.Sprintf("[IN]: entry: %s, labels: %s", entry.Line, entry.Labels.String()))
+					c.debugDataPublisher.Publish(componentID, fmt.Sprintf("[IN]: timestamp: %s, entry: %s, labels: %s", entry.Timestamp.Format(time.RFC3339Nano), entry.Line, entry.Labels.String()))
 				}
 				// TODO(@tpaschalis) Instead of calling Clone() at the
 				// component's entrypoint here, we can try a copy-on-write
@@ -189,7 +190,7 @@ func (c *Component) handleOut(ctx context.Context, wg *sync.WaitGroup) {
 					return
 				case f.Chan() <- entry:
 					if c.debugDataPublisher.IsActive(componentID) {
-						c.debugDataPublisher.Publish(componentID, fmt.Sprintf("[OUT]: entry: %s, labels: %s", entry.Line, entry.Labels.String()))
+						c.debugDataPublisher.Publish(componentID, fmt.Sprintf("[OUT]: timestamp: %s, entry: %s, labels: %s", entry.Timestamp.Format(time.RFC3339Nano), entry.Line, entry.Labels.String()))
 					}
 				}
 			}

--- a/internal/component/loki/process/process_test.go
+++ b/internal/component/loki/process/process_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/grafana/alloy/internal/runtime/componenttest"
 	"github.com/grafana/alloy/internal/service/livedebugging"
 	"github.com/grafana/alloy/internal/util"
+	"github.com/grafana/alloy/internal/util/testlivedebugging"
 	"github.com/grafana/alloy/syntax"
 )
 
@@ -66,6 +67,10 @@ func TestJSONLabelsStage(t *testing.T) {
 				  user   = "",
 				  ts     = "timestamp",
 			    }
+			}
+			stage.timestamp {
+				source = "timestamp"
+				format = "RFC3339Nano"
 			}`
 
 	// Unmarshal the Alloy relabel rules into a custom struct, as we don't have
@@ -80,12 +85,14 @@ func TestJSONLabelsStage(t *testing.T) {
 
 	ch1, ch2 := loki.NewLogsReceiver(), loki.NewLogsReceiver()
 
+	liveDebuggingLog := []string{}
+
 	// Create and run the component, so that it can process and forwards logs.
 	opts := component.Options{
 		Logger:         util.TestAlloyLogger(t),
 		Registerer:     prometheus.NewRegistry(),
 		OnStateChange:  func(e component.Exports) {},
-		GetServiceData: getServiceData,
+		GetServiceData: getServiceDataWithLiveDebugging(&liveDebuggingLog),
 	}
 	args := Arguments{
 		ForwardTo: []loki.LogsReceiver{ch1, ch2},
@@ -98,23 +105,31 @@ func TestJSONLabelsStage(t *testing.T) {
 	defer cancel()
 	go c.Run(ctx)
 
+	// Choose a timestamp which is different from the one in the json log line that is being sent.
+	ingestionTs, err := time.Parse(time.RFC3339, "2020-11-15T02:08:41-07:00")
+	require.NoError(t, err)
+
 	// Send a log entry to the component's receiver.
-	ts := time.Now()
 	logEntry := loki.Entry{
 		Labels: model.LabelSet{"filename": "/var/log/pods/agent/agent/1.log", "foo": "bar"},
 		Entry: logproto.Entry{
-			Timestamp: ts,
+			Timestamp: ingestionTs,
 			Line:      logline,
 		},
 	}
 
 	c.receiver.Chan() <- logEntry
 
+	// This is the timestamp from the json body of the log line that is being sent.
+	expectedTsLabel := "2019-04-30T02:12:41.8443515Z"
+	expectedTs, err := time.Parse(time.RFC3339Nano, expectedTsLabel)
+	require.NoError(t, err)
+
 	wantLabelSet := model.LabelSet{
 		"filename": "/var/log/pods/agent/agent/1.log",
 		"foo":      "bar",
 		"stream":   "stderr",
-		"ts":       "2019-04-30T02:12:41.8443515Z",
+		"ts":       model.LabelValue(expectedTsLabel),
 		"user":     "smith",
 	}
 
@@ -123,17 +138,24 @@ func TestJSONLabelsStage(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		select {
 		case logEntry := <-ch1.Chan():
-			require.WithinDuration(t, time.Now(), logEntry.Timestamp, 1*time.Second)
+			require.Equal(t, expectedTs, logEntry.Timestamp)
 			require.Equal(t, logline, logEntry.Line)
 			require.Equal(t, wantLabelSet, logEntry.Labels)
 		case logEntry := <-ch2.Chan():
-			require.WithinDuration(t, time.Now(), logEntry.Timestamp, 1*time.Second)
+			require.Equal(t, expectedTs, logEntry.Timestamp)
 			require.Equal(t, logline, logEntry.Line)
 			require.Equal(t, wantLabelSet, logEntry.Labels)
 		case <-time.After(5 * time.Second):
 			require.FailNow(t, "failed waiting for log line")
 		}
 	}
+
+	// The timestamp in "IN" is different from the one in "OUT".
+	expectedLiveDebuggingLog := []string{
+		"[IN]: timestamp: 2020-11-15T02:08:41-07:00, entry: {\"log\":\"log message\\n\",\"stream\":\"stderr\",\"time\":\"2019-04-30T02:12:41.8443515Z\",\"extra\":\"{\\\"user\\\":\\\"smith\\\"}\"}, labels: {filename=\"/var/log/pods/agent/agent/1.log\", foo=\"bar\"}",
+		"[OUT]: timestamp: 2019-04-30T02:12:41.8443515Z, entry: {\"log\":\"log message\\n\",\"stream\":\"stderr\",\"time\":\"2019-04-30T02:12:41.8443515Z\",\"extra\":\"{\\\"user\\\":\\\"smith\\\"}\"}, labels: {filename=\"/var/log/pods/agent/agent/1.log\", foo=\"bar\", stream=\"stderr\", ts=\"2019-04-30T02:12:41.8443515Z\", user=\"smith\"}",
+	}
+	require.Equal(t, expectedLiveDebuggingLog, liveDebuggingLog)
 }
 
 func TestStaticLabelsLabelAllowLabelDrop(t *testing.T) {
@@ -600,6 +622,31 @@ func getServiceData(name string) (interface{}, error) {
 		return livedebugging.NewLiveDebugging(), nil
 	default:
 		return nil, fmt.Errorf("service not found %s", name)
+	}
+}
+
+func getServiceDataWithLiveDebugging(liveDebuggingLog *[]string) func(string) (interface{}, error) {
+	ld := livedebugging.NewLiveDebugging()
+	host := &testlivedebugging.FakeServiceHost{
+		ComponentsInfo: map[component.ID]testlivedebugging.FakeInfo{
+			component.ParseID(""): {ComponentName: "", Component: &testlivedebugging.FakeComponentLiveDebugging{}},
+		},
+	}
+	ld.SetServiceHost(host)
+	ld.SetEnabled(true)
+	ld.AddCallback(
+		"callback1",
+		"",
+		func(data string) { *liveDebuggingLog = append(*liveDebuggingLog, data) },
+	)
+
+	return func(name string) (interface{}, error) {
+		switch name {
+		case livedebugging.ServiceName:
+			return ld, nil
+		default:
+			return nil, fmt.Errorf("service not found %s", name)
+		}
 	}
 }
 

--- a/internal/component/loki/process/process_test.go
+++ b/internal/component/loki/process/process_test.go
@@ -159,6 +159,7 @@ func TestJSONLabelsStage(t *testing.T) {
 	wgRun.Wait()
 
 	// The timestamp in "IN" is different from the one in "OUT".
+	// Even though there are two downstream components, we expect only one "OUT" line to be printed.
 	expectedLiveDebuggingLog := []string{
 		"[IN]: timestamp: 2020-11-15T02:08:41-07:00, entry: {\"log\":\"log message\\n\",\"stream\":\"stderr\",\"time\":\"2019-04-30T02:12:41.8443515Z\",\"extra\":\"{\\\"user\\\":\\\"smith\\\"}\"}, labels: {filename=\"/var/log/pods/agent/agent/1.log\", foo=\"bar\"}",
 		"[OUT]: timestamp: 2019-04-30T02:12:41.8443515Z, entry: {\"log\":\"log message\\n\",\"stream\":\"stderr\",\"time\":\"2019-04-30T02:12:41.8443515Z\",\"extra\":\"{\\\"user\\\":\\\"smith\\\"}\"}, labels: {filename=\"/var/log/pods/agent/agent/1.log\", foo=\"bar\", stream=\"stderr\", ts=\"2019-04-30T02:12:41.8443515Z\", user=\"smith\"}",

--- a/internal/service/livedebugging/livedebugging_test.go
+++ b/internal/service/livedebugging/livedebugging_test.go
@@ -1,11 +1,10 @@
 package livedebugging
 
 import (
-	"context"
 	"testing"
 
 	"github.com/grafana/alloy/internal/component"
-	"github.com/grafana/alloy/internal/service"
+	"github.com/grafana/alloy/internal/util/testlivedebugging"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,7 +29,7 @@ func TestAddCallback(t *testing.T) {
 	require.NoError(t, livedebugging.AddCallback(callbackID, "fake.liveDebugging", callback))
 
 	component, _ := livedebugging.host.GetComponent(component.ParseID("fake.liveDebugging"), component.InfoOptions{})
-	require.Equal(t, 1, component.Component.(*fakeComponentLiveDebugging).ConsumersCount)
+	require.Equal(t, 1, component.Component.(*testlivedebugging.FakeComponentLiveDebugging).ConsumersCount)
 
 	err = livedebugging.AddCallback(callbackID, "fake.noLiveDebugging", callback)
 	require.ErrorContains(t, err, "the component \"fake.noLiveDebugging\" does not support live debugging")
@@ -110,9 +109,9 @@ func TestDeleteCallback(t *testing.T) {
 	component, _ := livedebugging.host.GetComponent(component.ParseID("fake.liveDebugging"), component.InfoOptions{})
 
 	require.NoError(t, livedebugging.AddCallback(callbackID1, componentID, callback1))
-	require.Equal(t, 1, component.Component.(*fakeComponentLiveDebugging).ConsumersCount)
+	require.Equal(t, 1, component.Component.(*testlivedebugging.FakeComponentLiveDebugging).ConsumersCount)
 	require.NoError(t, livedebugging.AddCallback(callbackID2, componentID, callback2))
-	require.Equal(t, 2, component.Component.(*fakeComponentLiveDebugging).ConsumersCount)
+	require.Equal(t, 2, component.Component.(*testlivedebugging.FakeComponentLiveDebugging).ConsumersCount)
 	require.Len(t, livedebugging.callbacks[componentID], 2)
 
 	// Deleting callbacks that don't exist should not panic
@@ -121,72 +120,24 @@ func TestDeleteCallback(t *testing.T) {
 
 	livedebugging.DeleteCallback(callbackID1, componentID)
 	require.Len(t, livedebugging.callbacks[componentID], 1)
-	require.Equal(t, 1, component.Component.(*fakeComponentLiveDebugging).ConsumersCount)
+	require.Equal(t, 1, component.Component.(*testlivedebugging.FakeComponentLiveDebugging).ConsumersCount)
 
 	livedebugging.DeleteCallback(callbackID2, componentID)
 	require.Empty(t, livedebugging.callbacks[componentID])
-	require.Equal(t, 0, component.Component.(*fakeComponentLiveDebugging).ConsumersCount)
+	require.Equal(t, 0, component.Component.(*testlivedebugging.FakeComponentLiveDebugging).ConsumersCount)
 
 	require.False(t, livedebugging.IsActive(ComponentID("fake.liveDebugging")))
 }
 
 func setupServiceHost(liveDebugging *liveDebugging) {
-	host := &fakeServiceHost{
-		componentsInfo: map[component.ID]fakeInfo{
-			component.ParseID("fake.liveDebugging"):                {ComponentName: "fake.liveDebugging", Component: &fakeComponentLiveDebugging{}},
-			component.ParseID("declared.cmp/fake.liveDebugging"):   {ComponentName: "fake.liveDebugging", Component: &fakeComponentLiveDebugging{}},
-			component.ParseID("fake.noLiveDebugging"):              {ComponentName: "fake.noLiveDebugging", Component: &fakeComponentNoLiveDebugging{}},
-			component.ParseID("declared.cmp/fake.noLiveDebugging"): {ComponentName: "fake.noLiveDebugging", Component: &fakeComponentNoLiveDebugging{}},
+	host := &testlivedebugging.FakeServiceHost{
+		ComponentsInfo: map[component.ID]testlivedebugging.FakeInfo{
+			component.ParseID("fake.liveDebugging"):                {ComponentName: "fake.liveDebugging", Component: &testlivedebugging.FakeComponentLiveDebugging{}},
+			component.ParseID("declared.cmp/fake.liveDebugging"):   {ComponentName: "fake.liveDebugging", Component: &testlivedebugging.FakeComponentLiveDebugging{}},
+			component.ParseID("fake.noLiveDebugging"):              {ComponentName: "fake.noLiveDebugging", Component: &testlivedebugging.FakeComponentNoLiveDebugging{}},
+			component.ParseID("declared.cmp/fake.noLiveDebugging"): {ComponentName: "fake.noLiveDebugging", Component: &testlivedebugging.FakeComponentNoLiveDebugging{}},
 		},
 	}
 	liveDebugging.SetServiceHost(host)
 	liveDebugging.SetEnabled(true)
-}
-
-type fakeInfo struct {
-	ComponentName string
-	Component     component.Component
-}
-
-type fakeServiceHost struct {
-	service.Host
-	componentsInfo map[component.ID]fakeInfo
-}
-
-func (h *fakeServiceHost) GetComponent(id component.ID, opts component.InfoOptions) (*component.Info, error) {
-	info, exist := h.componentsInfo[id]
-	if exist {
-		return &component.Info{ID: id, ComponentName: info.ComponentName, Component: info.Component}, nil
-	}
-
-	return nil, component.ErrComponentNotFound
-}
-
-type fakeComponentLiveDebugging struct {
-	ConsumersCount int
-}
-
-func (f *fakeComponentLiveDebugging) LiveDebugging(consumers int) {
-	f.ConsumersCount = consumers
-}
-
-func (f *fakeComponentLiveDebugging) Run(ctx context.Context) error {
-	<-ctx.Done()
-	return nil
-}
-
-func (f *fakeComponentLiveDebugging) Update(_ component.Arguments) error {
-	return nil
-}
-
-type fakeComponentNoLiveDebugging struct {
-}
-
-func (f *fakeComponentNoLiveDebugging) Run(ctx context.Context) error {
-	<-ctx.Done()
-	return nil
-}
-
-func (f *fakeComponentNoLiveDebugging) Update(_ component.Arguments) error {
-	return nil
 }

--- a/internal/util/testlivedebugging/testlivedebugging.go
+++ b/internal/util/testlivedebugging/testlivedebugging.go
@@ -1,0 +1,56 @@
+package testlivedebugging
+
+import (
+	"context"
+
+	"github.com/grafana/alloy/internal/component"
+	"github.com/grafana/alloy/internal/service"
+)
+
+type FakeInfo struct {
+	ComponentName string
+	Component     component.Component
+}
+
+type FakeServiceHost struct {
+	service.Host
+	ComponentsInfo map[component.ID]FakeInfo
+}
+
+func (h *FakeServiceHost) GetComponent(id component.ID, opts component.InfoOptions) (*component.Info, error) {
+	info, exist := h.ComponentsInfo[id]
+	if exist {
+		return &component.Info{ID: id, ComponentName: info.ComponentName, Component: info.Component}, nil
+	}
+
+	return nil, component.ErrComponentNotFound
+}
+
+type FakeComponentLiveDebugging struct {
+	ConsumersCount int
+}
+
+func (f *FakeComponentLiveDebugging) LiveDebugging(consumers int) {
+	f.ConsumersCount = consumers
+}
+
+func (f *FakeComponentLiveDebugging) Run(ctx context.Context) error {
+	<-ctx.Done()
+	return nil
+}
+
+func (f *FakeComponentLiveDebugging) Update(_ component.Arguments) error {
+	return nil
+}
+
+type FakeComponentNoLiveDebugging struct {
+}
+
+func (f *FakeComponentNoLiveDebugging) Run(ctx context.Context) error {
+	<-ctx.Done()
+	return nil
+}
+
+func (f *FakeComponentNoLiveDebugging) Update(_ component.Arguments) error {
+	return nil
+}

--- a/internal/util/testlivedebugging/testlivedebugging.go
+++ b/internal/util/testlivedebugging/testlivedebugging.go
@@ -2,6 +2,7 @@ package testlivedebugging
 
 import (
 	"context"
+	"sync"
 
 	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/service"
@@ -53,4 +54,27 @@ func (f *FakeComponentNoLiveDebugging) Run(ctx context.Context) error {
 
 func (f *FakeComponentNoLiveDebugging) Update(_ component.Arguments) error {
 	return nil
+}
+
+type Log struct {
+	m    sync.Mutex
+	logs []string
+}
+
+func NewLog() *Log {
+	return &Log{
+		logs: []string{},
+	}
+}
+
+func (l *Log) Append(log string) {
+	l.m.Lock()
+	defer l.m.Unlock()
+	l.logs = append(l.logs, log)
+}
+
+func (l *Log) Get() []string {
+	l.m.Lock()
+	defer l.m.Unlock()
+	return append([]string{}, l.logs...)
 }

--- a/internal/util/testlivedebugging/testlivedebugging_test.go
+++ b/internal/util/testlivedebugging/testlivedebugging_test.go
@@ -1,0 +1,19 @@
+package testlivedebugging_test
+
+import (
+	"testing"
+
+	"github.com/grafana/alloy/internal/util/testlivedebugging"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogShallowCopy(t *testing.T) {
+	log := testlivedebugging.NewLog()
+	log.Append("test")
+
+	logSlice1 := log.Get()
+	logSlice1[0] = "asdf"
+
+	logSlice2 := log.Get()
+	require.Equal(t, []string{"test"}, logSlice2)
+}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This can be useful for debugging `stage.timestamp`. A user [noticed](https://grafana.slack.com/archives/C01050C3D8F/p1723711382290759) that this was missing.

I suppose we don't need to print timestamps for `loki.relabel` since `loki.relabel` can't modify them.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
