### PR TITLE
Build Alloy for linux/riscv64

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -290,6 +290,23 @@ trigger:
 type: docker
 ---
 kind: pipeline
+name: Build alloy (Linux riscv64)
+platform:
+  arch: amd64
+  os: linux
+steps:
+- commands:
+  - make generate-ui
+  - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=riscv64 GOARM=
+    make alloy
+  image: grafana/alloy-build-image:v0.1.3
+  name: Build
+trigger:
+  event:
+  - pull_request
+type: docker
+---
+kind: pipeline
 name: Build alloy (macOS Intel)
 platform:
   arch: amd64
@@ -833,8 +850,3 @@ get:
   path: infra/data/ci/github/updater-app
 kind: secret
 name: updater_private_key
----
-kind: signature
-hmac: ee269482e125ef982b0dffcf21ded182eb20960f97adf0513610fac49a1ab775
-
-...

--- a/.drone/pipelines/crosscompile.jsonnet
+++ b/.drone/pipelines/crosscompile.jsonnet
@@ -14,6 +14,7 @@ local os_arch_tuples = [
   { name: 'Linux arm64', os: 'linux', arch: 'arm64' },
   { name: 'Linux ppc64le', os: 'linux', arch: 'ppc64le' },
   { name: 'Linux s390x', os: 'linux', arch: 's390x' },
+  { name: 'Linux riscv64', os: 'linux', arch: 'riscv64' },
 
   // Darwin
   { name: 'macOS Intel', os: 'darwin', arch: 'amd64' },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Features
+
+- Build binaries and OCI images for linux/riscv64. (@macabu)
+
 ### Enhancements
 
 - Clustering peer resolution through `--cluster.join-addresses` flag has been

--- a/tools/ci/docker-containers
+++ b/tools/ci/docker-containers
@@ -57,7 +57,7 @@ fi
 
 # Build all of our images.
 
-export BUILD_PLATFORMS=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
+export BUILD_PLATFORMS=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/riscv64
 export BUILD_PLATFORMS_BORINGCRYPTO=linux/amd64,linux/arm64
 
 case "$TARGET_CONTAINER" in

--- a/tools/make/packaging.mk
+++ b/tools/make/packaging.mk
@@ -56,6 +56,12 @@ dist/alloy-linux-s390x: GOARCH  := s390x
 dist/alloy-linux-s390x: generate-ui
 	$(PACKAGING_VARS) ALLOY_BINARY=$@ "$(MAKE)" -f $(PARENT_MAKEFILE) alloy
 
+dist/alloy-linux-riscv64: GO_TAGS += netgo builtinassets promtail_journal_enabled
+dist/alloy-linux-riscv64: GOOS    := linux
+dist/alloy-linux-riscv64: GOARCH  := riscv64 
+dist/alloy-linux-riscv64: generate-ui
+	$(PACKAGING_VARS) ALLOY_BINARY=$@ "$(MAKE)" -f $(PARENT_MAKEFILE) alloy
+
 dist/alloy-darwin-amd64: GO_TAGS += netgo builtinassets
 dist/alloy-darwin-amd64: GOOS    := darwin
 dist/alloy-darwin-amd64: GOARCH  := amd64
@@ -167,7 +173,8 @@ ALLOY_PACKAGE_PREFIX  := dist/alloy-$(ALLOY_PACKAGE_VERSION)-$(ALLOY_PACKAGE_REL
 dist-alloy-packages: dist-alloy-packages-amd64   \
                      dist-alloy-packages-arm64   \
                      dist-alloy-packages-ppc64le \
-                     dist-alloy-packages-s390x
+                     dist-alloy-packages-s390x   \
+                     dist-alloy-packages-riscv64
 
 .PHONY: dist-alloy-packages-amd64
 dist-alloy-packages-amd64: dist/alloy-linux-amd64
@@ -203,6 +210,15 @@ ifeq ($(USE_CONTAINER),1)
 else
 	$(call generate_alloy_fpm,deb,s390x,s390x,$(ALLOY_PACKAGE_PREFIX).s390x.deb)
 	$(call generate_alloy_fpm,rpm,s390x,s390x,$(ALLOY_PACKAGE_PREFIX).s390x.rpm)
+endif
+
+.PHONY: dist-alloy-packages-riscv64
+dist-alloy-packages-riscv64: dist/alloy-linux-riscv64
+ifeq ($(USE_CONTAINER),1)
+	$(RERUN_IN_CONTAINER)
+else
+	$(call generate_alloy_fpm,deb,riscv64,riscv64,$(ALLOY_PACKAGE_PREFIX).riscv64.deb)
+	$(call generate_alloy_fpm,rpm,riscv64,riscv64,$(ALLOY_PACKAGE_PREFIX).riscv64.rpm)
 endif
 
 #


### PR DESCRIPTION
#### PR Description
Builds binaries and OCI images for `linux/riscv64`. I was able to validate that the binary worked and was sending metrics to Loki (sample config).

```sh
user@bananapif3:~/Projects/alloy/dist$ file alloy-linux-riscv64
alloy-linux-riscv64: ELF 64-bit LSB executable, UCB RISC-V, RVC, double-float ABI, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-riscv64-lp64d.so.1, BuildID[sha1]=252737e53b37668ec9a2b5baad07bbe4ea82ef1f, for GNU/Linux 4.15.0, stripped

user@bananapif3:~/Projects/alloy/dist$ ldd alloy-linux-riscv64
	linux-vdso.so.1 (0x0000003f946d8000)
	libc.so.6 => /lib/riscv64-linux-gnu/libc.so.6 (0x0000003f94564000)
	/lib/ld-linux-riscv64-lp64d.so.1 (0x0000003f946da000)
```

#### Which issue(s) this PR fixes

Fixes https://github.com/grafana/alloy/issues/1036

#### Notes to the Reviewer

#### PR Checklist

- [X] CHANGELOG.md updated
