### PR TITLE
feat: make automounting of the ServiceAccountToken configureable

### DIFF
--- a/operations/helm/charts/alloy/Chart.yaml
+++ b/operations/helm/charts/alloy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: alloy
 description: 'Grafana Alloy'
 type: application
-version: 0.10.0
+version: 0.11.0
 appVersion: 'v1.5.0'
 icon: https://raw.githubusercontent.com/grafana/alloy/main/docs/sources/assets/alloy_icon_orange.svg
 

--- a/operations/helm/charts/alloy/templates/controllers/_pod.yaml
+++ b/operations/helm/charts/alloy/templates/controllers/_pod.yaml
@@ -66,6 +66,9 @@ spec:
   topologySpreadConstraints:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if .Values.controller.automountServiceAccountToken }}
+  automountServiceAccountToken: {{ .Values.controller.automountServiceAccountToken }}
+  {{- end }}
   volumes:
     - name: config
       configMap:

--- a/operations/helm/charts/alloy/values.yaml
+++ b/operations/helm/charts/alloy/values.yaml
@@ -188,6 +188,10 @@ controller:
   # 'statefulset'.
   parallelRollout: true
 
+  # -- Wether to automatically mount the ServiceAccountToken.
+  # https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting
+  automountServiceAccountToken: true
+
   # -- Configures Pods to use the host network. When set to true, the ports that will be used must be specified.
   hostNetwork: false
 


### PR DESCRIPTION
#### PR Description

This PR adds a Helm value to disable `automountServiceAccountToken` in the pod spec.

We use alloy as a simple OTLP receiver and forward all metrics to Prometheus via its remote write endpoint and in our case Alloy doesn't need any access to the Kubernetes API.

I've kept the default to `true` to not break anything.
