### PR TITLE
Update discovery.kubernetes selectors block description

### DIFF
--- a/docs/sources/reference/components/discovery/discovery.kubernetes.md
+++ b/docs/sources/reference/components/discovery/discovery.kubernetes.md
@@ -196,7 +196,7 @@ The following blocks are supported inside the definition of
 Hierarchy           | Block               | Description                                              | Required
 --------------------|---------------------|----------------------------------------------------------|---------
 namespaces          | [namespaces][]      | Information about which Kubernetes namespaces to search. | no
-selectors           | [selectors][]       | Information about which Kubernetes namespaces to search. | no
+selectors           | [selectors][]       | Selectors to filter discovered Kubernetes resources.     | no
 attach_metadata     | [attach_metadata][] | Optional metadata to attach to discovered targets.       | no
 basic_auth          | [basic_auth][]      | Configure basic_auth for authenticating to the endpoint. | no
 authorization       | [authorization][]   | Configure generic authorization to the endpoint.         | no


### PR DESCRIPTION
This PR suggest a new description for the `selectors` block in the `discovery.kubernetes` component.

AFAIU this block filters the resources selected in the role argument and not the namespace as stated.

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

