### PR TITLE
remotecfg: introduce the rest of the httpclientconfig block attributes

### DIFF
--- a/docs/sources/reference/config-blocks/remotecfg.md
+++ b/docs/sources/reference/config-blocks/remotecfg.md
@@ -52,15 +52,6 @@ Name             | Type                 | Description                           
 `proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.         | `false` | no
 `proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests. |         | no
 
- At most, one of the following can be provided:
- - [`bearer_token` argument](#endpoint-block).
- - [`bearer_token_file` argument](#endpoint-block).
- - [`basic_auth` block][basic_auth].
- - [`authorization` block][authorization].
- - [`oauth2` block][oauth2].
- - [`sigv4` block][sigv4].
- - [`azuread` block][azuread].
-
 If the `url` is not set, then the service block is a no-op.
 
 If not set, the self-reported `id` that {{< param "PRODUCT_NAME" >}} uses is a randomly generated, anonymous unique ID (UUID) that is stored as an `alloy_seed.json` file in the {{< param "PRODUCT_NAME" >}} storage path so that it can persist across restarts.
@@ -77,6 +68,15 @@ You can't override this prefix.
 * `collector.version`: The version of {{< param "PRODUCT_NAME" >}}.
 
 The `poll_frequency` must be set to at least `"10s"`.
+
+ At most, one of the following can be provided:
+ - [`bearer_token` argument][arguments].
+ - [`bearer_token_file` argument][arguments].
+ - [`basic_auth` block][basic_auth].
+ - [`authorization` block][authorization].
+ - [`oauth2` block][oauth2].
+
+{{< docs/shared lookup="reference/components/http-client-proxy-config-description.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ## Blocks
 
@@ -110,6 +110,7 @@ For example, `oauth2 > tls_config` refers to a `tls_config` block defined inside
 {{< docs/shared lookup="reference/components/tls-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 [API definition]: https://github.com/grafana/alloy-remote-config
+[arguments]: #arguments
 [basic_auth]: #basic_auth-block
 [authorization]: #authorization-block
 [oauth2]: #oauth2-block

--- a/docs/sources/reference/config-blocks/remotecfg.md
+++ b/docs/sources/reference/config-blocks/remotecfg.md
@@ -43,6 +43,23 @@ Name             | Type                 | Description                           
 `attributes`     | `map(string)`        | A set of self-reported attributes.                | `{}`        | no
 `poll_frequency` | `duration`           | How often to poll the API for new configuration.  | `"1m"`      | no
 `name`           | `string`             | A human-readable name for the collector.          | `""`        | no
+`bearer_token_file`      | `string`            | File containing a bearer token to authenticate with.          |         | no
+`bearer_token`           | `secret`            | Bearer token to authenticate with.                            |         | no
+`enable_http2`           | `bool`              | Whether HTTP2 is supported for requests.                      | `true`  | no
+`follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.  | `true`  | no
+`proxy_url`              | `string`            | HTTP proxy to send requests through.                          |         | no
+`no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. | | no
+`proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.         | `false` | no
+`proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests. |         | no
+
+ At most, one of the following can be provided:
+ - [`bearer_token` argument](#endpoint-block).
+ - [`bearer_token_file` argument](#endpoint-block).
+ - [`basic_auth` block][basic_auth].
+ - [`authorization` block][authorization].
+ - [`oauth2` block][oauth2].
+ - [`sigv4` block][sigv4].
+ - [`azuread` block][azuread].
 
 If the `url` is not set, then the service block is a no-op.
 


### PR DESCRIPTION

#### PR Description
This PR adds documentation in the remotecfg page for the rest of the squashed fields of the HTTPClientConfig block.
#### Which issue(s) this PR fixes
No issue filed

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated (N/A)
- [X] Documentation added
- [ ] Tests updated (N/A)