### PR TITLE
fix: alloy docs link to discovery.relabel

### DIFF
--- a/docs/sources/reference/components/discovery/discovery.kubernetes.md
+++ b/docs/sources/reference/components/discovery/discovery.kubernetes.md
@@ -99,6 +99,8 @@ For each declared port of a container, a single target is generated.
 If a container has no specified ports, a port-free target per container is created.
 These targets must have a port manually injected using a [`discovery.relabel` component][discovery.relabel] before metrics can be collected from them.
 
+[discovery.relabel]: ../discovery.relabel/
+
 The following labels are included for discovered pods:
 
 * `__meta_kubernetes_namespace`: The namespace of the pod object.


### PR DESCRIPTION
#### PR Description

Fixes a missing/broken link in the Alloy docs for kubernetes discovery -> relabel

#### Notes to the Reviewer

Validated locally with `make docs`.

#### PR Checklist

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
