### PR TITLE
docs: incorrent url attribute in otelcol.exporter.otlp example (opentelemetry-data.md)

### DIFF
--- a/docs/sources/collect/opentelemetry-data.md
+++ b/docs/sources/collect/opentelemetry-data.md
@@ -54,7 +54,7 @@ To configure an `otelcol.exporter.otlp` component for exporting OpenTelemetry da
    ```alloy
    otelcol.exporter.otlp "<EXPORTER_LABEL>" {
      client {
-       url = "<HOST>:<PORT>"
+       endpoint = "<HOST>:<PORT>"
      }
    }
    ```


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Replaced incorrect `url` attribute by `endpoint` in `otelcol.exporter.otlp` example on https://grafana.com/docs/alloy/latest/collect/opentelemetry-data/#configure-an-opentelemetry-protocol-exporter

#### Which issue(s) this PR fixes
None.

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
