### PR TITLE
Remote vault patch 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ Main (unreleased)
   for `discovery.*`  is reloaded in such a way that no new targets were
   discovered. (@ptodev, @thampiotr)
 
+- Fixed an issue where specifying both path and key in the remote.vault `path` configuration could result in incorrect URLs.
+  The `path` and `key` arguments have been separated to allow for clear and accurate specification of Vault secrets. (@PatMis16)
+
 ### Other
 
 - Renamed standard library functions. Old names are still valid but are marked deprecated. (@wildum)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,8 +68,9 @@ Main (unreleased)
   for `discovery.*`  is reloaded in such a way that no new targets were
   discovered. (@ptodev, @thampiotr)
 
-- Fixed an issue where specifying both path and key in the remote.vault `path` configuration could result in incorrect URLs.
-  The `path` and `key` arguments have been separated to allow for clear and accurate specification of Vault secrets. (@PatMis16)
+- Fixed an issue (see https://github.com/grafana/alloy/issues/1599) where specifying both path and key in the remote.vault `path`
+  configuration could result in incorrect URLs. The `path` and `key` arguments have been separated to allow for clear and accurate
+  specification of Vault secrets. (@PatMis16)
 
 ### Other
 

--- a/docs/sources/reference/components/remote/remote.vault.md
+++ b/docs/sources/reference/components/remote/remote.vault.md
@@ -41,7 +41,7 @@ Name               | Type       | Description                                   
 `server`           | `string`   | The Vault server to connect to.                            |         | yes
 `namespace`        | `string`   | The Vault namespace to connect to (Vault Enterprise only). |         | no
 `path`             | `string`   | The path to retrieve a secret from.                        |         | yes
-`key`              | `string`   | The key to retrive a secret from.                          |         | yes
+`key`              | `string`   | The key to retrieve a secret from.                         |         | no
 `reread_frequency` | `duration` | Rate to re-read keys.                                      | `"0s"`  | no
 
 Tokens with a lease will be automatically renewed roughly two-thirds through their lease duration.

--- a/docs/sources/reference/components/remote/remote.vault.md
+++ b/docs/sources/reference/components/remote/remote.vault.md
@@ -23,6 +23,7 @@ labels.
 remote.vault "LABEL" {
   server = "VAULT_SERVER"
   path   = "VAULT_PATH"
+  key    = "VAULT_KEY"
 
   // Alternatively, use one of the other auth.* mechanisms.
   auth.token {
@@ -40,6 +41,7 @@ Name               | Type       | Description                                   
 `server`           | `string`   | The Vault server to connect to.                            |         | yes
 `namespace`        | `string`   | The Vault namespace to connect to (Vault Enterprise only). |         | no
 `path`             | `string`   | The path to retrieve a secret from.                        |         | yes
+`key`              | `string`   | The key to retrive a secret from.                          |         | yes
 `reread_frequency` | `duration` | Rate to re-read keys.                                      | `"0s"`  | no
 
 Tokens with a lease will be automatically renewed roughly two-thirds through their lease duration.
@@ -290,7 +292,8 @@ local.file "vault_token" {
 
 remote.vault "remote_write" {
   server = "https://prod-vault.corporate.internal"
-  path   = "secret/prometheus/remote_write"
+  path   = "secret"
+  key    = "prometheus/remote_write
 
   auth.token {
     token = local.file.vault_token.content

--- a/internal/component/remote/vault/client.go
+++ b/internal/component/remote/vault/client.go
@@ -2,6 +2,8 @@ package vault
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	vault "github.com/hashicorp/vault/api"
 )
@@ -17,10 +19,12 @@ type secretStore interface {
 type kvStore struct{ c *vault.Client }
 
 func (ks *kvStore) Read(ctx context.Context, args *Arguments) (*vault.Secret, error) {
-	
-	if args.Key != nil {
+	var kvSecret *vault.KVSecret
+	var err error
+
+	if args.Key != "" {
 		kv := ks.c.KVv2(args.Path)
-		kvSecret, err := kv.Get(ctx, args.Key)
+		kvSecret, err = kv.Get(ctx, args.Key)
 		if err != nil {
 			return nil, err
 		}
@@ -30,11 +34,9 @@ func (ks *kvStore) Read(ctx context.Context, args *Arguments) (*vault.Secret, er
 		if len(pathParts) != 2 {
 			return nil, fmt.Errorf("missing mount path in %q", args.Path)
 		}
-	
+
 		kv := ks.c.KVv2(pathParts[0])
-		kvSecret, err := kv.Get(ctx, pathParts[1])
-		kv := ks.c.KVv2(args.Path)
-		kvSecret, err := kv.Get(ctx, args.Key)
+		kvSecret, err = kv.Get(ctx, pathParts[1])
 		if err != nil {
 			return nil, err
 		}

--- a/internal/component/remote/vault/client.go
+++ b/internal/component/remote/vault/client.go
@@ -2,8 +2,6 @@ package vault
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	vault "github.com/hashicorp/vault/api"
 )

--- a/internal/component/remote/vault/client.go
+++ b/internal/component/remote/vault/client.go
@@ -20,7 +20,7 @@ type kvStore struct{ c *vault.Client }
 
 func (ks *kvStore) Read(ctx context.Context, args *Arguments) (*vault.Secret, error) {
 	kv := ks.c.KVv2(args.Path)
-	kvSecret, err := kv.Get(ctx, args.Secret)
+	kvSecret, err := kv.Get(ctx, args.Key)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/component/remote/vault/client.go
+++ b/internal/component/remote/vault/client.go
@@ -17,10 +17,27 @@ type secretStore interface {
 type kvStore struct{ c *vault.Client }
 
 func (ks *kvStore) Read(ctx context.Context, args *Arguments) (*vault.Secret, error) {
-	kv := ks.c.KVv2(args.Path)
-	kvSecret, err := kv.Get(ctx, args.Key)
-	if err != nil {
-		return nil, err
+	
+	if args.Key != nil {
+		kv := ks.c.KVv2(args.Path)
+		kvSecret, err := kv.Get(ctx, args.Key)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// Split the path so we know which kv mount we want to use.
+		pathParts := strings.SplitN(args.Path, "/", 2)
+		if len(pathParts) != 2 {
+			return nil, fmt.Errorf("missing mount path in %q", args.Path)
+		}
+	
+		kv := ks.c.KVv2(pathParts[0])
+		kvSecret, err := kv.Get(ctx, pathParts[1])
+		kv := ks.c.KVv2(args.Path)
+		kvSecret, err := kv.Get(ctx, args.Key)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// kvSecret.Data contains unwrapped data. Let's assign that to the raw secret

--- a/internal/component/remote/vault/client.go
+++ b/internal/component/remote/vault/client.go
@@ -19,14 +19,8 @@ type secretStore interface {
 type kvStore struct{ c *vault.Client }
 
 func (ks *kvStore) Read(ctx context.Context, args *Arguments) (*vault.Secret, error) {
-	// Split the path so we know which kv mount we want to use.
-	pathParts := strings.SplitN(args.Path, "/", 2)
-	if len(pathParts) != 2 {
-		return nil, fmt.Errorf("missing mount path in %q", args.Path)
-	}
-
-	kv := ks.c.KVv2(pathParts[0])
-	kvSecret, err := kv.Get(ctx, pathParts[1])
+	kv := ks.c.KVv2(args.Path)
+	kvSecret, err := kv.Get(ctx, args.Secret)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/component/remote/vault/client.go
+++ b/internal/component/remote/vault/client.go
@@ -22,6 +22,9 @@ func (ks *kvStore) Read(ctx context.Context, args *Arguments) (*vault.Secret, er
 	var kvSecret *vault.KVSecret
 	var err error
 
+	// If a key is provided, we use that to get the secret from the KV store.
+	// This allows for more flexibility in how secrets are stored in vault.
+	// eg. long/path/kv/secret/key where long/path/kv is the path and secret/key is the key.
 	if args.Key != "" {
 		kv := ks.c.KVv2(args.Path)
 		kvSecret, err = kv.Get(ctx, args.Key)
@@ -29,6 +32,7 @@ func (ks *kvStore) Read(ctx context.Context, args *Arguments) (*vault.Secret, er
 			return nil, err
 		}
 	} else {
+		// for backward compatibility, we assume the path is in the format path/secret
 		// Split the path so we know which kv mount we want to use.
 		pathParts := strings.SplitN(args.Path, "/", 2)
 		if len(pathParts) != 2 {

--- a/internal/component/remote/vault/vault.go
+++ b/internal/component/remote/vault/vault.go
@@ -35,7 +35,7 @@ type Arguments struct {
 	Namespace string `alloy:"namespace,attr,optional"`
 
 	Path string `alloy:"path,attr"`
-	Secret string `alloy:"secret,attr"`
+	Key string `alloy:"key,attr"`
 
 	RereadFrequency time.Duration `alloy:"reread_frequency,attr,optional"`
 

--- a/internal/component/remote/vault/vault.go
+++ b/internal/component/remote/vault/vault.go
@@ -35,6 +35,7 @@ type Arguments struct {
 	Namespace string `alloy:"namespace,attr,optional"`
 
 	Path string `alloy:"path,attr"`
+	Secret string `alloy:"secret,attr"`
 
 	RereadFrequency time.Duration `alloy:"reread_frequency,attr,optional"`
 

--- a/internal/component/remote/vault/vault.go
+++ b/internal/component/remote/vault/vault.go
@@ -35,7 +35,7 @@ type Arguments struct {
 	Namespace string `alloy:"namespace,attr,optional"`
 
 	Path string `alloy:"path,attr"`
-	Key string `alloy:"key,attr"`
+	Key string `alloy:"key,attr,optional"`
 
 	RereadFrequency time.Duration `alloy:"reread_frequency,attr,optional"`
 

--- a/internal/component/remote/vault/vault_test.go
+++ b/internal/component/remote/vault/vault_test.go
@@ -37,8 +37,8 @@ func Test_GetSecrets(t *testing.T) {
 
 	cfg := fmt.Sprintf(`
 		server = "%s"
-		path   = ""
-  		secret = "secret/test"
+		path   = "secret"
+  		secret = "test"
 
 		reread_frequency = "0s"
 

--- a/internal/component/remote/vault/vault_test.go
+++ b/internal/component/remote/vault/vault_test.go
@@ -37,7 +37,8 @@ func Test_GetSecrets(t *testing.T) {
 
 	cfg := fmt.Sprintf(`
 		server = "%s"
-		path   = "secret/test"
+		path   = ""
+  		secret = "secret/test"
 
 		reread_frequency = "0s"
 
@@ -86,7 +87,8 @@ func Test_PollSecrets(t *testing.T) {
 
 	cfg := fmt.Sprintf(`
 		server = "%s"
-		path   = "secret/test"
+		path   = ""
+  		key = "secret/test"
 
 		reread_frequency = "100ms"
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Fixed an issue where specifying both path and key in the remote.vault path configuration could result in incorrect URLs. The path and key arguments have been separated to allow for clear and accurate specification of Vault secrets.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #1599 

#### Notes to the Reviewer
Not sure about the config converters part. Please check.
Please also check if the documentation is clear and understandable. 

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
