### PR TITLE
fix(helm): explicitly include namespace in manifests

### DIFF
--- a/operations/helm/charts/alloy/templates/cluster_service.yaml
+++ b/operations/helm/charts/alloy/templates/cluster_service.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "alloy.fullname" . }}-cluster
+  namespace: {{ include "alloy.namespace" . }}
   labels:
     {{- include "alloy.labels" . | nindent 4 }}
     app.kubernetes.io/component: networking

--- a/operations/helm/charts/alloy/templates/configmap.yaml
+++ b/operations/helm/charts/alloy/templates/configmap.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "alloy.fullname" . }}
+  namespace: {{ include "alloy.namespace" . }}
   labels:
     {{- include "alloy.labels" . | nindent 4 }}
     app.kubernetes.io/component: config

--- a/operations/helm/charts/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/charts/alloy/templates/controllers/daemonset.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "alloy.fullname" . }}
+  namespace: {{ include "alloy.namespace" . }}
   labels:
     {{- include "alloy.labels" . | nindent 4 }}
   {{- with .Values.controller.extraAnnotations }}

--- a/operations/helm/charts/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/charts/alloy/templates/controllers/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "alloy.fullname" . }}
+  namespace: {{ include "alloy.namespace" . }}
   labels:
     {{- include "alloy.labels" . | nindent 4 }}
   {{- with .Values.controller.extraAnnotations }}

--- a/operations/helm/charts/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/charts/alloy/templates/controllers/statefulset.yaml
@@ -6,6 +6,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "alloy.fullname" . }}
+  namespace: {{ include "alloy.namespace" . }}
   labels:
     {{- include "alloy.labels" . | nindent 4 }}
   {{- with .Values.controller.extraAnnotations }}

--- a/operations/helm/charts/alloy/templates/hpa.yaml
+++ b/operations/helm/charts/alloy/templates/hpa.yaml
@@ -16,6 +16,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "alloy.fullname" . }}
+  namespace: {{ include "alloy.namespace" . }}
   labels:
     {{- include "alloy.labels" . | nindent 4 }}
     app.kubernetes.io/component: availability

--- a/operations/helm/charts/alloy/templates/pdb.yaml
+++ b/operations/helm/charts/alloy/templates/pdb.yaml
@@ -15,7 +15,7 @@ apiVersion: {{ include "alloy.controller.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "alloy.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "alloy.namespace" . }}
   labels:
     {{- include "alloy.labels" . | nindent 4 }}
 spec:

--- a/operations/helm/charts/alloy/templates/service.yaml
+++ b/operations/helm/charts/alloy/templates/service.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "alloy.fullname" . }}
+  namespace: {{ include "alloy.namespace" . }}
   labels:
     {{- include "alloy.labels" . | nindent 4 }}
     app.kubernetes.io/component: networking

--- a/operations/helm/charts/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/charts/alloy/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "alloy.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "alloy.namespace" . }}
   labels:
     {{- include "alloy.labels" . | nindent 4 }}
     app.kubernetes.io/component: rbac

--- a/operations/helm/charts/alloy/templates/servicemonitor.yaml
+++ b/operations/helm/charts/alloy/templates/servicemonitor.yaml
@@ -4,6 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "alloy.fullname" . }}
+  namespace: {{ include "alloy.namespace" . }}
   labels:
     {{- include "alloy.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics


### PR DESCRIPTION
Currently, most of the manifests omit `.metadata.namespace`.

This works fine with `helm install` / `helm upgrade` where all the manifests without a namespace will be installed to `--namespace` anyway.

However, `helm template` will produce the manifests as-is (with no namespace), regardless of `--namespace`, forcing users to add the namespace manually or use more tooling.

This change adds the namespace to all manifests.

Fixes #1607 

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
