### PR TITLE
loki.process: fix bug where drop_counter_reason gets set incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ Main (unreleased)
   for `discovery.*`  is reloaded in such a way that no new targets were
   discovered. (@ptodev, @thampiotr)
 
+- Fixed bug in `loki.process` with `sampling` stage where all components use same `drop_counter_reason`. (@captncraig)
+
 ### Other
 
 - Renamed standard library functions. Old names are still valid but are marked deprecated. (@wildum)

--- a/internal/component/loki/process/stages/sampling.go
+++ b/internal/component/loki/process/stages/sampling.go
@@ -66,6 +66,7 @@ type samplingStage struct {
 
 func (m *samplingStage) Run(in chan Entry) chan Entry {
 	out := make(chan Entry)
+	reason := *m.cfg.DropReason
 	go func() {
 		defer close(out)
 		for e := range in {
@@ -73,7 +74,7 @@ func (m *samplingStage) Run(in chan Entry) chan Entry {
 				out <- e
 				continue
 			}
-			m.dropCount.WithLabelValues(*m.cfg.DropReason).Inc()
+			m.dropCount.WithLabelValues(reason).Inc()
 		}
 	}()
 	return out

--- a/internal/component/loki/process/stages/sampling.go
+++ b/internal/component/loki/process/stages/sampling.go
@@ -27,9 +27,7 @@ type SamplingConfig struct {
 }
 
 func (s *SamplingConfig) SetToDefault() {
-	if s.DropReason == "" {
-		s.DropReason = defaultSamplingpReason
-	}
+	s.DropReason = defaultSamplingpReason
 }
 
 func (s *SamplingConfig) Validate() error {

--- a/internal/converter/internal/promtailconvert/internal/build/stages.go
+++ b/internal/converter/internal/promtailconvert/internal/build/stages.go
@@ -240,7 +240,7 @@ func convertSampling(cfg interface{}, diags *diag.Diagnostics) (stages.StageConf
 	fSampling.SetToDefault()
 	fSampling.SamplingRate = pSampling.SamplingRate
 	if pSampling.DropReason != nil {
-		fSampling.DropReason = pSampling.DropReason
+		fSampling.DropReason = *pSampling.DropReason
 	}
 	return stages.StageConfig{
 		SamplingConfig: fSampling,


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

The issue we are seeing is that if you define multiple `loki.process` stages with `sampling`, both components will use the same drop reason label. 

For some reason, both string pointers have the same address, and I am still not clear why. Changing the drop reason to a plain string avoids the issue, as well as not calling `WithLabels` inside the loop.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
