### PR TITLE
Fix issue preventing import.git from syncing due to divergent branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,8 @@ v1.4.0
   configuration could result in incorrect URLs. The `path` and `key` arguments have been separated to allow for clear and accurate
   specification of Vault secrets. (@PatMis16)
 
+- Fixed a bug in `import.git` which caused a `"non-fast-forward update"` error message. (@ptodev)
+
 ### Other
 
 - Renamed standard library functions. Old names are still valid but are marked deprecated. (@wildum)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Breaking changes
+
+- `import.git`: The default value for `revision` has changed from `HEAD` to `main`. (@ptodev)
+  It is no longer allowed to set `revision` to `"HEAD"`, `"FETCH_HEAD"`, `"ORIG_HEAD"`, `"MERGE_HEAD"`, or `"CHERRY_PICK_HEAD"`.
+
 ### Features
 
 - Add the function `path_join` to the stdlib. (@wildum)
@@ -27,6 +32,8 @@ Main (unreleased)
 
 - Update yet-another-cloudwatch-exporter from v0.60.0 vo v0.61.0: (@morremeyer)
   - Fixes a bug where cloudwatch S3 metrics are reported as `0`
+
+- Fixed a bug in `import.git` which caused a `"non-fast-forward update"` error message. (@ptodev)
 
 ### Other changes
 
@@ -134,8 +141,6 @@ v1.4.0
 - Fixed an issue (see https://github.com/grafana/alloy/issues/1599) where specifying both path and key in the remote.vault `path`
   configuration could result in incorrect URLs. The `path` and `key` arguments have been separated to allow for clear and accurate
   specification of Vault secrets. (@PatMis16)
-
-- Fixed a bug in `import.git` which caused a `"non-fast-forward update"` error message. (@ptodev)
 
 ### Other
 

--- a/internal/runtime/import_git_test.go
+++ b/internal/runtime/import_git_test.go
@@ -43,6 +43,7 @@ testImport.add "cc" {
 `
 	// Create our git repository.
 	runGit(t, testRepo, "init", testRepo)
+	runGit(t, testRepo, "checkout", "-b", "main")
 
 	// Add the file we want.
 	math := filepath.Join(testRepo, "math.alloy")
@@ -108,6 +109,7 @@ testImport.add "cc" {
 }
 `
 	runGit(t, testRepo, "init", testRepo)
+	runGit(t, testRepo, "checkout", "-b", "main")
 
 	runGit(t, testRepo, "checkout", "-b", "testor")
 
@@ -161,6 +163,8 @@ func TestPullUpdatingFromHash(t *testing.T) {
 	testRepo := t.TempDir()
 
 	runGit(t, testRepo, "init", testRepo)
+	runGit(t, testRepo, "checkout", "-b", "main")
+
 	math := filepath.Join(testRepo, "math.alloy")
 	err := os.WriteFile(math, []byte(contents), 0666)
 	require.NoError(t, err)
@@ -229,6 +233,7 @@ func TestPullUpdatingFromTag(t *testing.T) {
 	testRepo := t.TempDir()
 
 	runGit(t, testRepo, "init", testRepo)
+	runGit(t, testRepo, "checkout", "-b", "main")
 
 	math := filepath.Join(testRepo, "math.alloy")
 	err := os.WriteFile(math, []byte(contents), 0666)
@@ -336,6 +341,7 @@ testImport.add "cc" {
 }
 `
 	runGit(t, testRepo, "init", testRepo)
+	runGit(t, testRepo, "checkout", "-b", "main")
 
 	runGit(t, testRepo, "checkout", "-b", "testor")
 

--- a/internal/runtime/internal/importsource/import_git.go
+++ b/internal/runtime/internal/importsource/import_git.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
 	"github.com/grafana/alloy/internal/vcs"
+	"github.com/grafana/alloy/syntax"
 	"github.com/grafana/alloy/syntax/vm"
 )
 
@@ -53,6 +54,21 @@ type GitArguments struct {
 var DefaultGitArguments = GitArguments{
 	Revision:      "main",
 	PullFrequency: time.Minute,
+}
+
+var (
+	_ syntax.Validator = (*GitArguments)(nil)
+	_ syntax.Defaulter = (*GitArguments)(nil)
+)
+
+// Validate implements syntax.Validator.
+func (args *GitArguments) Validate() error {
+	switch args.Revision {
+	case "HEAD", "FETCH_HEAD", "ORIG_HEAD", "MERGE_HEAD", "CHERRY_PICK_HEAD":
+		return fmt.Errorf("revision cannot be a special git reference such as HEAD, FETCH_HEAD, ORIG_HEAD, MERGE_HEAD, or CHERRY_PICK_HEAD")
+	}
+
+	return nil
 }
 
 // SetToDefault implements syntax.Defaulter.

--- a/internal/runtime/internal/importsource/import_git.go
+++ b/internal/runtime/internal/importsource/import_git.go
@@ -51,7 +51,7 @@ type GitArguments struct {
 }
 
 var DefaultGitArguments = GitArguments{
-	Revision:      "HEAD",
+	Revision:      "main",
 	PullFrequency: time.Minute,
 }
 


### PR DESCRIPTION
#### PR Description

Consider this situation:

* `import.git` is configured to use branch A.
* Alloy is then stopped, and its new configuration is configured to use branch B.
* If branches A and B are divergent, `import.git` will fail to switch to branch B because it's going to try to pull A into B.

The user will get a `"failed to update repository \"git@github.com:org/repo.git\": non-fast-forward update"` error.

I suppose the same thing could also happen if a force push is done to the branch Alloy is monitoring.

Since Alloy is only reading from the repo, but not writing, there is no point in trying to do a pull. It's much easier to just do a fetch and checkout.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
