### PR TITLE
Add a test flag for alloy fmt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,6 +280,8 @@ v1.2.0
 
 - Add a `prometheus.exporter.catchpoint` component to collect metrics from Catchpoint. (@bominrahmani)
 
+- Add the `-t/--test` flag to `alloy fmt` to check if a alloy config file is formatted correctly. (@kavfixnel)
+
 ### Enhancements
 
 - (_Public preview_) Add native histogram support to `otelcol.receiver.prometheus`. (@wildum)

--- a/docs/sources/reference/cli/fmt.md
+++ b/docs/sources/reference/cli/fmt.md
@@ -29,8 +29,13 @@ Otherwise, `fmt` reads and formats the file from disk specified by the argument.
 The `--write` flag can be specified to replace the contents of the original file on disk with the formatted results.
 `--write` can only be provided when `fmt` isn't reading from standard input.
 
+The `--test` flag can be specified to test if the contents of the file are formatted correctly.
+
+The `--write` and `--test` flags are mutually exclusive.
+
 The command fails if the file being formatted has syntactically incorrect {{< param "PRODUCT_NAME" >}} configuration, but doesn't validate whether {{< param "PRODUCT_NAME" >}} components are configured properly.
 
 The following flags are supported:
 
 * `--write`, `-w`: Write the formatted file back to disk when not reading from standard input.
+* `--test`, `-t`: Only test the input and return a non-zero exit code if changes would have been made.


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Implements feature request from #1631

```shell
~/Documents/Projects/alloy on feat/1631-add-fmt-test ❯ cat /tmp/alloy.config
prometheus.remote_write "default" {
        endpoint {
                url          = "http://localhost:9009/api/prom/push"
        }
}
~/Documents/Projects/alloy on feat/1631-add-fmt-test ❯ build/alloy fmt /tmp/alloy.config -t           
Error: File /tmp/alloy.config is not formatted correctly
~/Documents/Projects/alloy on feat/1631-add-fmt-test ❯ echo $?
1
~/Documents/Projects/alloy on feat/1631-add-fmt-test ❯ build/alloy fmt /tmp/alloy.config -w
~/Documents/Projects/alloy on feat/1631-add-fmt-test ❯ build/alloy fmt /tmp/alloy.config -t
~/Documents/Projects/alloy on feat/1631-add-fmt-test ❯ echo $?
0
```

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
