### PR TITLE
Fix "alloy.controller.volumes.extra" field not being populated

### DIFF
--- a/operations/helm/charts/alloy/CHANGELOG.md
+++ b/operations/helm/charts/alloy/CHANGELOG.md
@@ -10,6 +10,10 @@ internal API changes are not present.
 Unreleased
 ----------
 
+### Bugfixes
+
+- Fix "alloy.controller.volumes.extra" field not being populated. (@tjaacks)
+
 0.7.0 (2024-08-26)
 ------------------
 

--- a/operations/helm/charts/alloy/templates/controllers/_pod.yaml
+++ b/operations/helm/charts/alloy/templates/controllers/_pod.yaml
@@ -77,7 +77,7 @@ spec:
       hostPath:
         path: /var/lib/docker/containers
     {{- end }}
-    {{- if .Values.controller.volumes.extra }}
-    {{- toYaml .Values.controller.volumes.extra | nindent 4 }}
+    {{- if $values.controller.volumes.extra }}
+    {{- toYaml $values.controller.volumes.extra | nindent 4 }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Volumes specified in `alloy.controller.volumes.extra` were not rendered into the resulting `DeamonSet` manifest. Fix this by using `$values` instead of `.Values`.

Example:

```yaml
alloy:
  controller:
    volumes:
      extra:
      - name: myvolume
        hostPath:
          path: /path/to/something
```

Adding the above snippet to the helm chart's `values.yaml` did not add the specified volume to the pod. This can be tested using the following `kubectl` call:

```cmd
kubectl get pod alloy-4pkwb -o jsonpath='{.spec.volumes[?(@.name=="myvolume")]}
```

Before this PR the call did not return anything. After the PR it returns:

```json
{"hostPath":{"path":"/path/to/something","type":""},"name":"myvolume"}
```

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
