### PR TITLE
Add a note about group membership

### DIFF
--- a/docs/sources/reference/components/loki/loki.source.journal.md
+++ b/docs/sources/reference/components/loki/loki.source.journal.md
@@ -12,6 +12,13 @@ title: loki.source.journal
 
 Multiple `loki.source.journal` components can be specified by giving them different labels.
 
+{{< admonition type="note" >}}
+Make sure that the `grafana-alloy` user is a member of the following groups:
+
+* adm
+* systemd-journal
+{{< /admonition >}}
+
 ## Usage
 
 ```alloy
@@ -36,7 +43,9 @@ Name             | Type                 | Description                           
 `relabel_rules`  | `RelabelRules`       | Relabeling rules to apply on log entries.                                                              | `{}`    | no
 `labels`         | `map(string)`        | The labels to apply to every log coming out of the journal.                                            | `{}`    | no
 
-> **NOTE**:  A `job` label is added with the full name of the component `loki.source.journal.LABEL`.
+{{< admonition type="note" >}}
+A `job` label is added with the full name of the component `loki.source.journal.LABEL`.
+{{< /admonition >}}
 
 When the `format_as_json` argument is true, log messages are passed through as
 JSON with all of the original fields from the journal entry. Otherwise, the log


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR addresses a concern raised in the Community forums: https://community.grafana.com/t/cannot-scrape-from-journal/131384/1

The grafana-alloy user must be made a member of the `adm` and `systemd-journal` groups to be able to read from the systemd journal. 

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
