### PR TITLE
Fix typo in docs components.md

### DIFF
--- a/docs/sources/get-started/components.md
+++ b/docs/sources/get-started/components.md
@@ -74,7 +74,7 @@ The following configuration file represents the pipeline.
 // This component has an exported field called "content", holding the content
 // of the file.
 //
-// local.file.api_key will watch the file and update its exports any time the
+// local.file "api_key" will watch the file and update its exports any time the
 // file changes.
 local.file "api_key" {
   filename  = "/var/data/secrets/api-key"

--- a/docs/sources/get-started/components.md
+++ b/docs/sources/get-started/components.md
@@ -74,7 +74,7 @@ The following configuration file represents the pipeline.
 // This component has an exported field called "content", holding the content
 // of the file.
 //
-// local.file "api_key" will watch the file and update its exports any time the
+// local.file will watch the file and update its exports any time the
 // file changes.
 local.file "api_key" {
   filename  = "/var/data/secrets/api-key"


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
If I understood correctly, the component is "local.file" and its label is "api_key" so the comment seemed to have a typo. Let me know if I have misunderstood!

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
