### PR TITLE
Makefile: fixed target name for deb/rpm packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ## Build, test, and generate code for various parts of Alloy.
 ##
-## At least Go 1.19, git, and a moderately recent version of Docker is required
+## At least Go 1.22, git, and a moderately recent version of Docker is required
 ## to be able to use the Makefile. This list isn't exhaustive and there are other
 ## dependencies for the generate-* targets. If you do not have the full list of
 ## build dependencies, you may set USE_CONTAINER=1 to proxy build commands to a
@@ -36,7 +36,7 @@
 ##
 ##   dist                 Produce release assets for everything.
 ##   dist-alloy-binaries  Produce release-ready Alloy binaries.
-##   dist-packages        Produce release-ready DEB and RPM packages.
+##   dist-alloy-packages  Produce release-ready DEB and RPM packages.
 ##   dist-alloy-installer Produce a Windows installer for Alloy.
 ##
 ## Targets for generating assets:


### PR DESCRIPTION
#### PR Description

Small fix in Makefile to reflect actual target name (`dist-alloy-packages` vs `dist-packages`).

While here, bumped minimal Go version required according to go.mod.