### PR TITLE
feat(otelcol/exporter/splunkhec) Add Splunk HTTP Event Collector (HEC) Exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Main (unreleased)
 - Added Datadog Exporter community component, enabling exporting of otel-formatted Metrics and traces to Datadog. (@polyrain)
 - (_Experimental_) Add an `otelcol.processor.interval` component to aggregate metrics and periodically
   forward the latest values to the next component in the pipeline.
+- Added Splunx HEC Exporter community componment, enabling exporting of logs to Splunk HEC
 
 ### Enhancements
 


### PR DESCRIPTION
#### PR Description
This PR initiates the inclusion of the [OTel Splunk HEC exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/splunkhecexporter/README.md) component to Grafana Alloy as a community component.

#### Which issue(s) this PR fixes
Fixes #1226 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
