### PR TITLE
fix: set Probe scrape timeout correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Main (unreleased)
   seen by each instance in the cluster. This can help diagnose cluster split
   brain issues. (@thampiotr)
 
-- Updated Snowflake exporter with performance improvements for larger environments. 
+- Updated Snowflake exporter with performance improvements for larger environments.
   Also added a new panel to track deleted tables to the Snowflake mixin. (@Caleb-Hurshman)
 - Add a `otelcol.processor.groupbyattrs` component to reassociate collected metrics that match specified attributes
     from opentelemetry. (@kehindesalaam)
@@ -44,6 +44,8 @@ Main (unreleased)
 - A new parameter `aws_sdk_version_v2` is added for the cloudwatch exporters configuration. It enables the use of aws sdk v2 which has shown to have significant performance benefits. (@kgeckhart, @andriikushch)
 
 ### Bugfixes
+
+- Fix a bug where the scrape timeout for a Probe resource was not applied, overwriting the scrape interval instead. (@morremeyer, @stefanandres)
 
 - Fix a bug where custom components don't always get updated when the config is modified in an imported directory. (@ante012)
 
@@ -104,13 +106,13 @@ v1.3.0
 
 - Update Public preview `remotecfg` argument from `metadata` to `attributes`. (@erikbaranowski)
 
-- The default value of the argument `unmatched` in the block `routes` of the component `beyla.ebpf` was changed from `unset` to `heuristic` (@marctc) 
+- The default value of the argument `unmatched` in the block `routes` of the component `beyla.ebpf` was changed from `unset` to `heuristic` (@marctc)
 
 ### Features
 
 - Added community components support, enabling community members to implement and maintain components. (@wildum)
 
-- A new `otelcol.exporter.debug` component for printing OTel telemetry from 
+- A new `otelcol.exporter.debug` component for printing OTel telemetry from
   other `otelcol` components to the console. (@BarunKGP)
 
 ### Enhancements
@@ -148,7 +150,7 @@ v1.3.0
 - `prometheus.exporter.unix` component now exposes hwmon collector config. (@dtrejod)
 
 - Upgrade from OpenTelemetry v0.102.1 to v0.105.0.
-  - [`otelcol.receiver.*`] A new `compression_algorithms` attribute to configure which 
+  - [`otelcol.receiver.*`] A new `compression_algorithms` attribute to configure which
     compression algorithms are allowed by the HTTP server.
     https://github.com/open-telemetry/opentelemetry-collector/pull/10295
   - [`otelcol.exporter.*`] Fix potential deadlock in the batch sender.
@@ -166,7 +168,7 @@ v1.3.0
   - [`otelcol.processor.tail_sampling`] Simple LRU Decision Cache for "keep" decisions.
     https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/33533
   - [`otelcol.processor.tail_sampling`] Fix precedence of inverted match in and policy.
-    Previously if the decision from a policy evaluation was `NotSampled` or `InvertNotSampled` 
+    Previously if the decision from a policy evaluation was `NotSampled` or `InvertNotSampled`
     it would return a `NotSampled` decision regardless, effectively downgrading the result.
     This was breaking the documented behaviour that inverted decisions should take precedence over all others.
     https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/33671
@@ -196,7 +198,7 @@ v1.3.0
     https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33607
   - [`otelcol.receiver.vcenter`] Drop support for vCenter 6.7.
     https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33607
-  - [`otelcol.processor.attributes`] Add an option to extract value from a client address 
+  - [`otelcol.processor.attributes`] Add an option to extract value from a client address
     by specifying `client.address` value in the `from_context` field.
     https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/34048
   - `otelcol.connector.spanmetrics`: Produce delta temporality span metrics with StartTimeUnixNano and TimeUnixNano values representing an uninterrupted series.

--- a/internal/component/prometheus/operator/configgen/config_gen_probe.go
+++ b/internal/component/prometheus/operator/configgen/config_gen_probe.go
@@ -30,7 +30,7 @@ func (cg *ConfigGenerator) GenerateProbeConfig(m *promopv1.Probe) (cfg *config.S
 		cfg.ScrapeInterval, _ = model.ParseDuration(string(m.Spec.Interval))
 	}
 	if m.Spec.ScrapeTimeout != "" {
-		cfg.ScrapeInterval, _ = model.ParseDuration(string(m.Spec.ScrapeTimeout))
+		cfg.ScrapeTimeout, _ = model.ParseDuration(string(m.Spec.ScrapeTimeout))
 	}
 	if m.Spec.ProberSpec.Scheme != "" {
 		cfg.Scheme = m.Spec.ProberSpec.Scheme

--- a/internal/component/prometheus/operator/configgen/config_gen_probe_test.go
+++ b/internal/component/prometheus/operator/configgen/config_gen_probe_test.go
@@ -119,7 +119,9 @@ func TestGenerateProbeConfig(t *testing.T) {
 						Path:     "/probe",
 						ProxyURL: "socks://myproxy:9095",
 					},
-					Module: "http_2xx",
+					Interval:      promopv1.Duration("30s"),
+					ScrapeTimeout: promopv1.Duration("15s"),
+					Module:        "http_2xx",
 					Targets: promopv1.ProbeTargets{
 						StaticConfig: &promopv1.ProbeTargetStaticConfig{
 							Targets: []string{
@@ -161,8 +163,8 @@ func TestGenerateProbeConfig(t *testing.T) {
 			expected: &config.ScrapeConfig{
 				JobName:           "probe/default/testprobe1",
 				HonorTimestamps:   true,
-				ScrapeInterval:    model.Duration(time.Minute),
-				ScrapeTimeout:     model.Duration(10 * time.Second),
+				ScrapeInterval:    model.Duration(30 * time.Second),
+				ScrapeTimeout:     model.Duration(15 * time.Second),
 				ScrapeProtocols:   config.DefaultScrapeProtocols,
 				EnableCompression: true,
 				MetricsPath:       "/probe",
@@ -183,7 +185,7 @@ func TestGenerateProbeConfig(t *testing.T) {
 								{"__address__": "promcon.io"},
 							},
 							Labels: model.LabelSet{
-								"static": "label",
+								"static":    "label",
 								"namespace": "default",
 							},
 						},


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

We discovered that the scrapeTimeout was not set to the value configured in the Probe resource when deploying a Probe with a high scrape timeout today.

After manually verifying that the Blackbox Exporter worked, we looked into the alloy source to discover that when `m.Spec.ScrapeTimeout` is set, instead of setting `cfg.ScrapeTimeout` to the value of `m.Spec.ScrapeTimeout`, the scrape interval was overwritten.

It looks like this happened by accident since the code for both scrape interval and timeout is very similar and might have been copied with this change being overlooked.

#### Which issue(s) this PR fixes

No reported issue, we opted to open this PR directly.
<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Tests updated
