### PR TITLE
Fix broken windows unit tests

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
@@ -75,7 +75,7 @@ text_file      | [text_file][]      | Configures the text_file collector.      |
 [scheduled_task]: #scheduledtask-block
 [service]: #service-block
 [smb]: #smb-block
-[smb_client]: #smbclient-block
+[smb_client]: #smb_client-block
 [smtp]: #smtp-block
 [text_file]: #textfile-block
 

--- a/internal/component/prometheus/exporter/windows/config_windows.go
+++ b/internal/component/prometheus/exporter/windows/config_windows.go
@@ -1,6 +1,7 @@
 package windows
 
 import (
+	"slices"
 	"strconv"
 	"strings"
 
@@ -13,10 +14,10 @@ func (a *Arguments) SetToDefault() {
 	*a = Arguments{
 		EnabledCollectors: strings.Split(windows_integration.DefaultConfig.EnabledCollectors, ","),
 		Dfsr: DfsrConfig{
-			SourcesEnabled: col.ConfigDefaults.DFSR.CollectorsEnabled,
+			SourcesEnabled: slices.Clone(col.ConfigDefaults.DFSR.CollectorsEnabled),
 		},
 		Exchange: ExchangeConfig{
-			EnabledList: col.ConfigDefaults.Exchange.CollectorsEnabled,
+			EnabledList: slices.Clone(col.ConfigDefaults.Exchange.CollectorsEnabled),
 		},
 		IIS: IISConfig{
 			AppBlackList:  col.ConfigDefaults.IIS.AppExclude.String(),
@@ -38,7 +39,7 @@ func (a *Arguments) SetToDefault() {
 			Where: *col.ConfigDefaults.Msmq.QueryWhereClause,
 		},
 		MSSQL: MSSQLConfig{
-			EnabledClasses: col.ConfigDefaults.Mssql.CollectorsEnabled,
+			EnabledClasses: slices.Clone(col.ConfigDefaults.Mssql.CollectorsEnabled),
 		},
 		Network: NetworkConfig{
 			BlackList: col.ConfigDefaults.Net.NicExclude.String(),

--- a/internal/converter/internal/staticconvert/internal/build/windows_exporter.go
+++ b/internal/converter/internal/staticconvert/internal/build/windows_exporter.go
@@ -13,14 +13,23 @@ func (b *ConfigBuilder) appendWindowsExporter(config *windows_exporter.Config, i
 	return b.appendExporterBlock(args, config.Name(), instanceKey, "windows")
 }
 
+// Splits a string such as "example1,example2"
+// into a list such as []string{"example1", "example2"}.
+func split(collectorList string) []string {
+	if collectorList == "" {
+		return []string{}
+	}
+	return strings.Split(collectorList, ",")
+}
+
 func toWindowsExporter(config *windows_exporter.Config) *windows.Arguments {
 	return &windows.Arguments{
-		EnabledCollectors: strings.Split(config.EnabledCollectors, ","),
+		EnabledCollectors: split(config.EnabledCollectors),
 		Dfsr: windows.DfsrConfig{
-			SourcesEnabled: strings.Split(config.Dfsr.SourcesEnabled, ","),
+			SourcesEnabled: split(config.Dfsr.SourcesEnabled),
 		},
 		Exchange: windows.ExchangeConfig{
-			EnabledList: strings.Split(config.Exchange.EnabledList, ","),
+			EnabledList: split(config.Exchange.EnabledList),
 		},
 		IIS: windows.IISConfig{
 			AppBlackList:  config.IIS.AppBlackList,
@@ -42,7 +51,7 @@ func toWindowsExporter(config *windows_exporter.Config) *windows.Arguments {
 			Where: config.MSMQ.Where,
 		},
 		MSSQL: windows.MSSQLConfig{
-			EnabledClasses: strings.Split(config.MSSQL.EnabledClasses, ","),
+			EnabledClasses: split(config.MSSQL.EnabledClasses),
 		},
 		Network: windows.NetworkConfig{
 			BlackList: config.Network.BlackList,
@@ -73,10 +82,10 @@ func toWindowsExporter(config *windows_exporter.Config) *windows.Arguments {
 			Where:  config.Service.Where,
 		},
 		SMB: windows.SMBConfig{
-			EnabledList: strings.Split(config.SMB.EnabledList, ","),
+			EnabledList: split(config.SMB.EnabledList),
 		},
 		SMBClient: windows.SMBClientConfig{
-			EnabledList: strings.Split(config.SMBClient.EnabledList, ","),
+			EnabledList: split(config.SMBClient.EnabledList),
 		},
 		SMTP: windows.SMTPConfig{
 			BlackList: config.SMTP.BlackList,

--- a/internal/converter/internal/staticconvert/internal/build/windows_exporter_test.go
+++ b/internal/converter/internal/staticconvert/internal/build/windows_exporter_test.go
@@ -1,0 +1,38 @@
+package build
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_split(t *testing.T) {
+	tests := []struct {
+		testName       string
+		input          string
+		expectedOutput []string
+	}{
+		{
+			testName:       "multiple values",
+			input:          "example1,example2",
+			expectedOutput: []string{"example1", "example2"},
+		},
+		{
+			testName:       "single value",
+			input:          "example1",
+			expectedOutput: []string{"example1"},
+		},
+		{
+			testName:       "empty string",
+			input:          "",
+			expectedOutput: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			got := split(tt.input)
+			require.Equal(t, tt.expectedOutput, got)
+		})
+	}
+}


### PR DESCRIPTION
There were a couple of tests which were [failing](https://drone.grafana.net/grafana/alloy/2903/2/2) on the main branch since #1527 was merged.

One test was about pointer reuse:
```
--- FAIL: TestSetDefault_NoPointerReuse (0.00s)
    --- FAIL: TestSetDefault_NoPointerReuse/prometheus.exporter.windows (0.00s)
        all_test.go:27: 
            	Error Trace:	C:/drone/src/internal/component/all/all_test.go:61
            	            				C:/drone/src/internal/component/all/all_test.go:27
            	Error:      	Detected SetToDefault pointer reuse at github.com/grafana/alloy/internal/component/prometheus/exporter/windows.Arguments.Dfsr.SourcesEnabled
            	Test:       	TestSetDefault_NoPointerReuse/prometheus.exporter.windows
            	Messages:   	Types implementing syntax.Defaulter must not reuse pointers across multiple calls. Doing so leads to default values being changed when unmarshaling configuration files. If you're seeing this error, check the path above and ensure that copies are being made of any pointers in all instances of SetToDefault calls where that field is used.
FAIL
FAIL	github.com/grafana/alloy/internal/component/all	1.160s
```

The other failing tests were for the converters. The integration tests wanted to add `smb` and `smb_client` Alloy config, because the `split` function would output a `[""]` instead of `[]`, and the converter tests thought that Alloy's defaults are different from static mode's defaults.

Btw static mode doesn't even support these `smb` and `smb_client` parameters... But I'm not 100% how to ignore them right now, so I'll leave this for another day 😄  It's not really important, since no one who uses static mode would set them in their config anyway.