### PR TITLE
Downgrade Go to 1.22.7 in build pipeline

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -10,7 +10,7 @@ steps:
   - docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
   - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   - docker buildx create --name multiarch --driver docker-container --use
-  - docker buildx build --build-arg="GO_RUNTIME=golang:1.23.1-bullseye" --push --platform
+  - docker buildx build --build-arg="GO_RUNTIME=golang:1.22.7-bullseye" --push --platform
     linux/amd64,linux/arm64 -t grafana/alloy-build-image:$IMAGE_TAG ./tools/build-image
   environment:
     DOCKER_LOGIN:
@@ -44,7 +44,7 @@ steps:
   - docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
   - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   - docker buildx create --name multiarch --driver docker-container --use
-  - docker buildx build --build-arg="GO_RUNTIME=mcr.microsoft.com/oss/go/microsoft/golang:1.23.1-bullseye"
+  - docker buildx build --build-arg="GO_RUNTIME=mcr.microsoft.com/oss/go/microsoft/golang:1.22.7-bullseye"
     --push --platform linux/amd64,linux/arm64 -t grafana/alloy-build-image:$IMAGE_TAG
     ./tools/build-image
   environment:
@@ -835,6 +835,6 @@ kind: secret
 name: updater_private_key
 ---
 kind: signature
-hmac: d897b4d4c0e2b92087e4eab9ca27b1dbbe2f475172109656ad2d842cb4a5b945
+hmac: b5171473370161e16d4432b2914ef8b4fa90b078f0ed9e6e531b61afa1cb0857
 
 ...

--- a/.drone/pipelines/build_images.jsonnet
+++ b/.drone/pipelines/build_images.jsonnet
@@ -32,7 +32,7 @@ local locals = {
         'docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD',
         'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes',
         'docker buildx create --name multiarch --driver docker-container --use',
-        'docker buildx build --build-arg="GO_RUNTIME=golang:1.23.1-bullseye" --push --platform linux/amd64,linux/arm64 -t grafana/alloy-build-image:$IMAGE_TAG ./tools/build-image',
+        'docker buildx build --build-arg="GO_RUNTIME=golang:1.22.7-bullseye" --push --platform linux/amd64,linux/arm64 -t grafana/alloy-build-image:$IMAGE_TAG ./tools/build-image',
       ],
     }],
     volumes: [{
@@ -55,7 +55,7 @@ local locals = {
         'docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD',
         'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes',
         'docker buildx create --name multiarch --driver docker-container --use',
-        'docker buildx build --build-arg="GO_RUNTIME=mcr.microsoft.com/oss/go/microsoft/golang:1.23.1-bullseye" --push --platform linux/amd64,linux/arm64 -t grafana/alloy-build-image:$IMAGE_TAG ./tools/build-image',
+        'docker buildx build --build-arg="GO_RUNTIME=mcr.microsoft.com/oss/go/microsoft/golang:1.22.7-bullseye" --push --platform linux/amd64,linux/arm64 -t grafana/alloy-build-image:$IMAGE_TAG ./tools/build-image',
       ],
     }],
     volumes: [{

--- a/.github/workflows/check-linux-build-image.yml
+++ b/.github/workflows/check-linux-build-image.yml
@@ -25,7 +25,7 @@ jobs:
           push: false
           tags: grafana/alloy-build-image:latest
           build-args: |
-            GO_RUNTIME=golang:1.23.1-bullseye
+            GO_RUNTIME=golang:1.22.7-bullseye
 
       - name: Create test Linux build image for boring crypto
         uses: docker/build-push-action@v6
@@ -34,4 +34,4 @@ jobs:
           push: false
           tags: grafana/alloy-build-image:latest
           build-args: |
-            GO_RUNTIME=mcr.microsoft.com/oss/go/microsoft/golang:1.23.1-bullseye
+            GO_RUNTIME=mcr.microsoft.com/oss/go/microsoft/golang:1.22.7-bullseye

--- a/tools/build-image/Dockerfile
+++ b/tools/build-image/Dockerfile
@@ -4,7 +4,7 @@
 # default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
 # in environment variables.
 
-# NOTE: The GO_RUNTIME is used to switch between the default Google go runtime and mcr.microsoft.com/oss/go/microsoft/golang:1.23.1-bullseye which is a Microsoft
+# NOTE: The GO_RUNTIME is used to switch between the default Google go runtime and mcr.microsoft.com/oss/go/microsoft/golang:1.22.7-bullseye which is a Microsoft
 # fork of go that allows using windows crypto instead of boring crypto. Details at https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
 ARG GO_RUNTIME=mustoverride
 

--- a/tools/build-image/windows/Dockerfile
+++ b/tools/build-image/windows/Dockerfile
@@ -1,4 +1,4 @@
-FROM library/golang:1.23.1-windowsservercore-1809
+FROM library/golang:1.22.7-windowsservercore-1809
 
 SHELL ["powershell", "-command"]
 


### PR DESCRIPTION
We can't build the linux images for Go 1.23.1 because of this issue: https://github.com/golang/go/issues/68976

We need 1.22.7 version because we need to upgrade the pyroscope dependency following the update of the cilium/ebpf pkg (see https://github.com/grafana/pyroscope/blob/main/ebpf/go.mod)