### PR TITLE
Add file path join to stdlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Features
+
+- Add the function `path_join` to the stdlib. (@wildum)
+
 ### Bugfixes
 
 

--- a/docs/sources/reference/stdlib/file.md
+++ b/docs/sources/reference/stdlib/file.md
@@ -11,7 +11,7 @@ The `file` namespace contains functions related to files.
 
 ## file.path_join
 
-The `file.path_join` function joins any number of path elements into a single path, separating them with an OS specific separator.
+The `file.path_join` function joins any number of path elements into a single path, separating them with an OS-specific separator.
 
 ### Examples
 

--- a/docs/sources/reference/stdlib/file.md
+++ b/docs/sources/reference/stdlib/file.md
@@ -1,0 +1,24 @@
+---
+canonical: https://grafana.com/docs/alloy/latest/reference/stdlib/file/
+description: Learn about file functions
+menuTitle: file
+title: file
+---
+
+# file
+
+The `file` namespace contains functions related to files.
+
+## file.path_join
+
+The `file.path_join` function joins any number of path elements into a single path, separating them with an OS specific separator.
+
+### Examples
+
+```
+> file.path_join()
+""
+
+> file.path_join("this/is", "a/path")
+"this/is/a/path"
+```

--- a/syntax/internal/stdlib/stdlib.go
+++ b/syntax/internal/stdlib/stdlib.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/grafana/alloy/syntax/alloytypes"
@@ -53,11 +54,16 @@ var Identifiers = map[string]interface{}{
 	"array":    array,
 	"encoding": encoding,
 	"string":   str,
+	"file":     file,
 }
 
 func init() {
 	// Adds the deprecatedIdentifiers to the map of valid identifiers.
 	maps.Copy(Identifiers, DeprecatedIdentifiers)
+}
+
+var file = map[string]interface{}{
+	"path_join": filepath.Join,
 }
 
 var encoding = map[string]interface{}{

--- a/syntax/vm/vm_stdlib_test.go
+++ b/syntax/vm/vm_stdlib_test.go
@@ -215,6 +215,30 @@ func TestStdlib_StringFunc(t *testing.T) {
 	}
 }
 
+func TestStdlibFileFunc(t *testing.T) {
+	tt := []struct {
+		name   string
+		input  string
+		expect interface{}
+	}{
+		{"file.path_join", `file.path_join("this/is", "a/path")`, "this/is/a/path"},
+		{"file.path_join empty", `file.path_join()`, ""},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			expr, err := parser.ParseExpression(tc.input)
+			require.NoError(t, err)
+
+			eval := vm.New(expr)
+
+			rv := reflect.New(reflect.TypeOf(tc.expect))
+			require.NoError(t, eval.Evaluate(nil, rv.Interface()))
+			require.Equal(t, tc.expect, rv.Elem().Interface())
+		})
+	}
+}
+
 func BenchmarkConcat(b *testing.B) {
 	// There's a bit of setup work to do here: we want to create a scope holding
 	// a slice of the Person type, which has a fair amount of data in it.


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Adding this function to the stdlib is needed to move forward with the [relative path solution](https://github.com/grafana/alloy/pull/789) that is implemented for the modules. This function should also be useful in other scenarios.

I put this function in a new namespace called "file". LMK if you would prefer this function to be in another namespace or without a namespace.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
