### PR TITLE
Update changelog for v1.4.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Main (unreleased)
   - Fixes a bug where cloudwatch S3 metrics are reported as `0`
 
 
-v1.4.0-rc.0
+v1.4.0-rc.2
 -----------------
 
 ### Breaking changes


### PR DESCRIPTION
I created the v1.4.0-rc.1 tag, but then realised that I hadn't updated the changelog 🤦  So I'll update the changelog, then will create a v1.4.0-rc.2 and publish v1.4.0-rc.2 officially on GitHub