### PR TITLE
Update changelog for v1.4.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This document contains a historical list of changes between releases. Only
 changes that impact end-user behavior are listed; changes to documentation or
 internal API changes are not present.
 
-v1.4.0-rc.0
+v1.4.0-rc.2
 -----------------
 ### Breaking changes
 


### PR DESCRIPTION
Similar change to #1700.

I created the v1.4.0-rc.1 tag, but then realised that I hadn't updated the changelog 🤦  So I'll update the changelog, then will create a v1.4.0-rc.2 and publish v1.4.0-rc.2 officially on GitHub