### PR TITLE
tweak OTEL alerts to use SR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Main (unreleased)
 
 - Small fix in UI stylesheet to fit more content into visible table area. (@defanator)
 
+- Changed OTEL alerts in Alloy mixin to use success rate for tracing. (@thampiotr)
+
 v1.4.0-rc.3
 -----------------
 

--- a/operations/alloy-mixin/alerts/opentelemetry.libsonnet
+++ b/operations/alloy-mixin/alerts/opentelemetry.libsonnet
@@ -1,6 +1,17 @@
 local alert = import './utils/alert.jsonnet';
 
 {
+  local successRateQuery(enableK8sCluster, failed, success) =
+        local sumBy = if enableK8sCluster then "cluster, namespace, job" else "job";
+        |||
+          (1 - sum by (%s) (
+                  rate(%s{}[1m])
+                  /
+                  (rate(%s{}[1m]) + rate(%s{}[1m]))
+               )
+          ) < 0.95
+        ||| % [sumBy, failed, failed, success],
+
   newOpenTelemetryAlertsGroup(enableK8sCluster=true):
     alert.newGroup(
       'alloy_otelcol',
@@ -10,28 +21,20 @@ local alert = import './utils/alert.jsonnet';
         // imposed by otelcol.processor.memory_limiter.
         alert.newRule(
           'OtelcolReceiverRefusedSpans',
-          if enableK8sCluster then
-            'sum by (cluster, namespace, job) (rate(otelcol_receiver_refused_spans_total{}[1m])) > 0'
-          else
-            'sum by (job) (rate(otelcol_receiver_refused_spans_total{}[1m])) > 0'
-          ,
+          successRateQuery(enableK8sCluster, "otelcol_receiver_refused_spans_total", "otelcol_receiver_accepted_spans_total"),
           'The receiver could not push some spans to the pipeline.',
           'The receiver could not push some spans to the pipeline under job {{ $labels.job }}. This could be due to reaching a limit such as the ones imposed by otelcol.processor.memory_limiter.',
           '5m',
         ),
 
-        // The exporter failed to send spans to their destination.
+        // The exporter success rate is below 95%.
         // There could be an issue with the payload or with the destination endpoint.
         alert.newRule(
           'OtelcolExporterFailedSpans',
-          if enableK8sCluster then
-            'sum by (cluster, namespace, job) (rate(otelcol_exporter_send_failed_spans_total{}[1m])) > 0'
-          else
-            'sum by (job) (rate(otelcol_exporter_send_failed_spans_total{}[1m])) > 0'
-          ,
-          'The exporter failed to send spans to their destination.',
+          successRateQuery(enableK8sCluster, "otelcol_exporter_send_failed_spans_total", "otelcol_exporter_sent_spans_total"),
+          'The exporter span sending success rate is below 95%.',
           'The exporter failed to send spans to their destination under job {{ $labels.job }}. There could be an issue with the payload or with the destination endpoint.',
-          '5m',
+          '10m',
         ),
       ]
     )

--- a/operations/alloy-mixin/alerts/opentelemetry.libsonnet
+++ b/operations/alloy-mixin/alerts/opentelemetry.libsonnet
@@ -16,15 +16,15 @@ local alert = import './utils/alert.jsonnet';
     alert.newGroup(
       'alloy_otelcol',
       [
-        // An otelcol.exporter component rcould not push some spans to the pipeline.
+        // An otelcol.receiver component could not push over 5% of spans to the pipeline.
         // This could be due to reaching a limit such as the ones
         // imposed by otelcol.processor.memory_limiter.
         alert.newRule(
           'OtelcolReceiverRefusedSpans',
           successRateQuery(enableK8sCluster, "otelcol_receiver_refused_spans_total", "otelcol_receiver_accepted_spans_total"),
-          'The receiver could not push some spans to the pipeline.',
+          'The receiver pushing spans to the pipeline success rate is below 95%.',
           'The receiver could not push some spans to the pipeline under job {{ $labels.job }}. This could be due to reaching a limit such as the ones imposed by otelcol.processor.memory_limiter.',
-          '5m',
+          '10m',
         ),
 
         // The exporter success rate is below 95%.
@@ -32,7 +32,7 @@ local alert = import './utils/alert.jsonnet';
         alert.newRule(
           'OtelcolExporterFailedSpans',
           successRateQuery(enableK8sCluster, "otelcol_exporter_send_failed_spans_total", "otelcol_exporter_sent_spans_total"),
-          'The exporter span sending success rate is below 95%.',
+          'The exporter sending spans success rate is below 95%.',
           'The exporter failed to send spans to their destination under job {{ $labels.job }}. There could be an issue with the payload or with the destination endpoint.',
           '10m',
         ),


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Changes OTEL Collector alerts to use success rate of 95% over 10min period to alert. Otherwise, we may have 99.9999% success rate and still alert. Some level of failures is acceptable for most users, especially for tracing which is frequently sampled.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

Tested in https://github.com/grafana/deployment_tools/pull/174974 

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
