### PR TITLE
Support for TLS client settings for clustering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Main (unreleased)
 
 - Changed OTEL alerts in Alloy mixin to use success rate for tracing. (@thampiotr)
 
+- Support TLS client settings for clustering (@tiagorossig)
+
 v1.4.0-rc.3
 -----------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Main (unreleased)
 - Changed OTEL alerts in Alloy mixin to use success rate for tracing. (@thampiotr)
 
 - Support TLS client settings for clustering (@tiagorossig)
+
 v1.4.1
 -----------------
 

--- a/docs/sources/reference/cli/run.md
+++ b/docs/sources/reference/cli/run.md
@@ -52,6 +52,11 @@ The following flags are supported:
 * `--cluster.max-join-peers`: Number of peers to join from the discovered set (default `5`).
 * `--cluster.name`: Name to prevent nodes without this identifier from joining the cluster (default `""`).
 * `--cluster.use-discovery-v1`: Use the older, v1 version of cluster peer discovery mechanism (default `false`). Note that this flag will be deprecated in the future and eventually removed.
+* `--cluster.enable-tls`: Specifies whether TLS should be used for communication between peers (default `false`). 
+* `--cluster.tls-ca-path`: Path to the CA certificate file used for peer communication over TLS. 
+* `--cluster.tls-cert-path`: Path to the certificate file used for peer communication over TLS.
+* `--cluster.tls-key-path`: Path to the key file used for peer communication over TLS.
+* `--cluster.tls-server-name`: Server name used for peer communication over TLS.
 * `--config.format`: The format of the source file. Supported formats: `alloy`, `otelcol`, `prometheus`, `promtail`, `static` (default `"alloy"`).
 * `--config.bypass-conversion-errors`: Enable bypassing errors when converting (default `false`).
 * `--config.extra-args`: Extra arguments from the original format used by the converter.
@@ -100,7 +105,7 @@ The rest of the `--cluster.*` command-line flags can be used to configure how no
 Each cluster member’s name must be unique within the cluster.
 Nodes which try to join with a conflicting name are rejected and will fall back to bootstrapping a new cluster of their own.
 
-Peers communicate over HTTP/2 on the built-in HTTP server.
+Peers communicate over HTTP/2 on the built-in HTTP server. 
 Each node must be configured to accept connections on `--server.http.listen-addr` and the address defined or inferred in `--cluster.advertise-address`.
 
 If the `--cluster.advertise-address` flag isn't explicitly set, {{< param "PRODUCT_NAME" >}} tries to infer a suitable one from `--cluster.advertise-interfaces`.
@@ -111,6 +116,9 @@ Since Windows doesn't use the interface names `eth0` or `en0`, Windows users mus
 The comma-separated list of addresses provided in `--cluster.join-addresses` can either be IP addresses or DNS names to lookup (supports SRV and A/AAAA records). 
 In both cases, the port number can be specified with a `:<port>` suffix. If ports are not provided, default of the port used for the HTTP listener is used.
 If you do not provide the port number explicitly, you must ensure that all instances use the same port for the HTTP listener.
+
+The `--cluster.enable-tls` flag can be set to enable TLS for peer-to-peer communications. Additional arguments are required to configure the TLS client, including the CA certificate (`--cluster.tls-ca-path`), 
+the certificate (`--cluster.tls-cert-path`), the key (`--cluster.tls-key-path`), and the server name (`--cluster.tls-server-name`).
 
 The `--cluster.discover-peers` command-line flag expects a list of tuples in the form of `provider=XXX key=val key=val ...`.
 Clustering uses the [go-discover] package to discover peers and fetch their IP addresses, based on the chosen provider and the filtering key-values it supports.

--- a/docs/sources/reference/cli/run.md
+++ b/docs/sources/reference/cli/run.md
@@ -105,7 +105,7 @@ The rest of the `--cluster.*` command-line flags can be used to configure how no
 Each cluster member’s name must be unique within the cluster.
 Nodes which try to join with a conflicting name are rejected and will fall back to bootstrapping a new cluster of their own.
 
-Peers communicate over HTTP/2 on the built-in HTTP server. 
+Peers communicate over HTTP/2 on the built-in HTTP server.
 Each node must be configured to accept connections on `--server.http.listen-addr` and the address defined or inferred in `--cluster.advertise-address`.
 
 If the `--cluster.advertise-address` flag isn't explicitly set, {{< param "PRODUCT_NAME" >}} tries to infer a suitable one from `--cluster.advertise-interfaces`.
@@ -117,8 +117,8 @@ The comma-separated list of addresses provided in `--cluster.join-addresses` can
 In both cases, the port number can be specified with a `:<port>` suffix. If ports are not provided, default of the port used for the HTTP listener is used.
 If you do not provide the port number explicitly, you must ensure that all instances use the same port for the HTTP listener.
 
-The `--cluster.enable-tls` flag can be set to enable TLS for peer-to-peer communications. Additional arguments are required to configure the TLS client, including the CA certificate (`--cluster.tls-ca-path`), 
-the certificate (`--cluster.tls-cert-path`), the key (`--cluster.tls-key-path`), and the server name (`--cluster.tls-server-name`).
+The `--cluster.enable-tls` flag can be set to enable TLS for peer-to-peer communications.
+Additional arguments are required to configure the TLS client, including the CA certificate, the TLS certificate, the key, and the server name.
 
 The `--cluster.discover-peers` command-line flag expects a list of tuples in the form of `provider=XXX key=val key=val ...`.
 Clustering uses the [go-discover] package to discover peers and fetch their IP addresses, based on the chosen provider and the filtering key-values it supports.

--- a/go.mod
+++ b/go.mod
@@ -917,3 +917,6 @@ replace github.com/prometheus/procfs => github.com/prometheus/procfs v0.12.0
 // It's important to remove it asap because in version v0.13.1 there is a fix for Beyla.
 // PR to track it: https://github.com/opencontainers/runc/pull/4397
 replace github.com/opencontainers/runc => github.com/rafaelroquetto/runc v1.1.14-1
+
+// Temporary replace until ckit changes are merged upstream
+replace github.com/grafana/ckit => github.com/tiagorossig/ckit v0.0.0-20240920184404-077657c65a6f

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/grafana/alloy/syntax v0.1.0
 	github.com/grafana/beyla v1.8.2
 	github.com/grafana/catchpoint-prometheus-exporter v0.0.0-20240606062944-e55f3668661d
-	github.com/grafana/ckit v0.0.0-20240913130805-0ee98bafad88
+	github.com/grafana/ckit v0.0.0-20241001124237-ee134485edd3
 	github.com/grafana/cloudflare-go v0.0.0-20230110200409-c627cf6792f2
 	github.com/grafana/dskit v0.0.0-20240104111617-ea101a3b86eb
 	github.com/grafana/go-gelf/v2 v2.0.1
@@ -154,7 +154,7 @@ require (
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.66.0
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.66.0
 	github.com/prometheus/blackbox_exporter v0.24.1-0.20230623125439-bd22efa1c900
-	github.com/prometheus/client_golang v1.20.3
+	github.com/prometheus/client_golang v1.20.4
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.55.0
 	github.com/prometheus/common/sigv4 v0.1.0
@@ -917,6 +917,3 @@ replace github.com/prometheus/procfs => github.com/prometheus/procfs v0.12.0
 // It's important to remove it asap because in version v0.13.1 there is a fix for Beyla.
 // PR to track it: https://github.com/opencontainers/runc/pull/4397
 replace github.com/opencontainers/runc => github.com/rafaelroquetto/runc v1.1.14-1
-
-// Temporary replace until ckit changes are merged upstream
-replace github.com/grafana/ckit => github.com/tiagorossig/ckit v0.0.0-20240920184404-077657c65a6f

--- a/go.sum
+++ b/go.sum
@@ -1198,8 +1198,6 @@ github.com/grafana/cadvisor v0.0.0-20240729082359-1f04a91701e2 h1:ju6EcY2aEobeBg
 github.com/grafana/cadvisor v0.0.0-20240729082359-1f04a91701e2/go.mod h1:8sLW/G7rcFe1CKMaA4pYT4mX3P1xQVGqM6luzEzx/2g=
 github.com/grafana/catchpoint-prometheus-exporter v0.0.0-20240606062944-e55f3668661d h1:6sNPBwOokfCxAyateu7iLdtyWDUzaLLShPs7F4eTLfw=
 github.com/grafana/catchpoint-prometheus-exporter v0.0.0-20240606062944-e55f3668661d/go.mod h1:aGPSALDAkw18nn8M7gumhM/MbJG+zgOA3jNWTwPYtLg=
-github.com/grafana/ckit v0.0.0-20240913130805-0ee98bafad88 h1:GgbYRGz2+/Vgz8/lk19Ht8TQDsAudl51Qenuw+COs5k=
-github.com/grafana/ckit v0.0.0-20240913130805-0ee98bafad88/go.mod h1:dDqep1rKTbq2ppMYEgIM88GaPXHp4i6Cp3qantiloA0=
 github.com/grafana/cloudflare-go v0.0.0-20230110200409-c627cf6792f2 h1:qhugDMdQ4Vp68H0tp/0iN17DM2ehRo1rLEdOFe/gB8I=
 github.com/grafana/cloudflare-go v0.0.0-20230110200409-c627cf6792f2/go.mod h1:w/aiO1POVIeXUQyl0VQSZjl5OAGDTL5aX+4v0RA1tcw=
 github.com/grafana/dskit v0.0.0-20240104111617-ea101a3b86eb h1:AWE6+kvtE18HP+lRWNUCyvymyrFSXs6TcS2vXIXGIuw=
@@ -2394,6 +2392,8 @@ github.com/testcontainers/testcontainers-go v0.33.0 h1:zJS9PfXYT5O0ZFXM2xxXfk4J5
 github.com/testcontainers/testcontainers-go v0.33.0/go.mod h1:W80YpTa8D5C3Yy16icheD01UTDu+LmXIA2Keo+jWtT8=
 github.com/tg123/go-htpasswd v1.2.2 h1:tmNccDsQ+wYsoRfiONzIhDm5OkVHQzN3w4FOBAlN6BY=
 github.com/tg123/go-htpasswd v1.2.2/go.mod h1:FcIrK0J+6zptgVwK1JDlqyajW/1B4PtuJ/FLWl7nx8A=
+github.com/tiagorossig/ckit v0.0.0-20240920184404-077657c65a6f h1:k8YmA8sNzKYlbHtrMkZXikDSajqkYuLdM9Eerw14qBA=
+github.com/tiagorossig/ckit v0.0.0-20240920184404-077657c65a6f/go.mod h1:dDqep1rKTbq2ppMYEgIM88GaPXHp4i6Cp3qantiloA0=
 github.com/tidwall/gjson v1.6.0/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
 github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/go.sum
+++ b/go.sum
@@ -1198,6 +1198,8 @@ github.com/grafana/cadvisor v0.0.0-20240729082359-1f04a91701e2 h1:ju6EcY2aEobeBg
 github.com/grafana/cadvisor v0.0.0-20240729082359-1f04a91701e2/go.mod h1:8sLW/G7rcFe1CKMaA4pYT4mX3P1xQVGqM6luzEzx/2g=
 github.com/grafana/catchpoint-prometheus-exporter v0.0.0-20240606062944-e55f3668661d h1:6sNPBwOokfCxAyateu7iLdtyWDUzaLLShPs7F4eTLfw=
 github.com/grafana/catchpoint-prometheus-exporter v0.0.0-20240606062944-e55f3668661d/go.mod h1:aGPSALDAkw18nn8M7gumhM/MbJG+zgOA3jNWTwPYtLg=
+github.com/grafana/ckit v0.0.0-20241001124237-ee134485edd3 h1:t1oO5eBWAwnryyW5e+MvJocf88HRtR0x/UsR4M0z290=
+github.com/grafana/ckit v0.0.0-20241001124237-ee134485edd3/go.mod h1:h3W376FaLy2VAhqm2w6IAkJjJxr2bGkdsdIcjadWMbs=
 github.com/grafana/cloudflare-go v0.0.0-20230110200409-c627cf6792f2 h1:qhugDMdQ4Vp68H0tp/0iN17DM2ehRo1rLEdOFe/gB8I=
 github.com/grafana/cloudflare-go v0.0.0-20230110200409-c627cf6792f2/go.mod h1:w/aiO1POVIeXUQyl0VQSZjl5OAGDTL5aX+4v0RA1tcw=
 github.com/grafana/dskit v0.0.0-20240104111617-ea101a3b86eb h1:AWE6+kvtE18HP+lRWNUCyvymyrFSXs6TcS2vXIXGIuw=
@@ -2149,8 +2151,8 @@ github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
 github.com/prometheus/client_golang v1.11.1/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
 github.com/prometheus/client_golang v1.12.1/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
-github.com/prometheus/client_golang v1.20.3 h1:oPksm4K8B+Vt35tUhw6GbSNSgVlVSBH0qELP/7u83l4=
-github.com/prometheus/client_golang v1.20.3/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
+github.com/prometheus/client_golang v1.20.4 h1:Tgh3Yr67PaOv/uTqloMsCEdeuFTatm5zIq5+qNN23vI=
+github.com/prometheus/client_golang v1.20.4/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
 github.com/prometheus/client_model v0.0.0-20171117100541-99fa1f4be8e5/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
@@ -2392,8 +2394,6 @@ github.com/testcontainers/testcontainers-go v0.33.0 h1:zJS9PfXYT5O0ZFXM2xxXfk4J5
 github.com/testcontainers/testcontainers-go v0.33.0/go.mod h1:W80YpTa8D5C3Yy16icheD01UTDu+LmXIA2Keo+jWtT8=
 github.com/tg123/go-htpasswd v1.2.2 h1:tmNccDsQ+wYsoRfiONzIhDm5OkVHQzN3w4FOBAlN6BY=
 github.com/tg123/go-htpasswd v1.2.2/go.mod h1:FcIrK0J+6zptgVwK1JDlqyajW/1B4PtuJ/FLWl7nx8A=
-github.com/tiagorossig/ckit v0.0.0-20240920184404-077657c65a6f h1:k8YmA8sNzKYlbHtrMkZXikDSajqkYuLdM9Eerw14qBA=
-github.com/tiagorossig/ckit v0.0.0-20240920184404-077657c65a6f/go.mod h1:dDqep1rKTbq2ppMYEgIM88GaPXHp4i6Cp3qantiloA0=
 github.com/tidwall/gjson v1.6.0/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
 github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/internal/alloycli/cluster_builder.go
+++ b/internal/alloycli/cluster_builder.go
@@ -38,6 +38,11 @@ type clusterOptions struct {
 	ClusterName               string
 	EnableStateUpdatesLimiter bool
 	EnableDiscoveryV2         bool
+	EnableTLS                 bool
+	TLSCAPath                 string
+	TLSCertPath               string
+	TLSKeyPath                string
+	TLSServerName             string
 }
 
 func buildClusterService(opts clusterOptions) (*cluster.Service, error) {
@@ -54,6 +59,11 @@ func buildClusterService(opts clusterOptions) (*cluster.Service, error) {
 		ClusterMaxJoinPeers:       opts.ClusterMaxJoinPeers,
 		ClusterName:               opts.ClusterName,
 		EnableStateUpdatesLimiter: opts.EnableStateUpdatesLimiter,
+		EnableTLS:                 opts.EnableTLS,
+		TLSCAPath:                 opts.TLSCAPath,
+		TLSCertPath:               opts.TLSCertPath,
+		TLSKeyPath:                opts.TLSKeyPath,
+		TLSServerName:             opts.TLSServerName,
 	}
 
 	if config.NodeName == "" {

--- a/internal/alloycli/cmd_run.go
+++ b/internal/alloycli/cmd_run.go
@@ -131,6 +131,16 @@ depending on the nature of the reload error.
 		IntVar(&r.clusterMaxJoinPeers, "cluster.max-join-peers", r.clusterMaxJoinPeers, "Number of peers to join from the discovered set")
 	cmd.Flags().
 		StringVar(&r.clusterName, "cluster.name", r.clusterName, "The name of the cluster to join")
+	cmd.Flags().
+		BoolVar(&r.clusterEnableTLS, "cluster.enable-tls", r.clusterEnableTLS, "Specifies whether TLS should be used for communication between peers")
+	cmd.Flags().
+		StringVar(&r.clusterTLSCAPath, "cluster.tls-ca-path", r.clusterTLSCAPath, "Path to the CA certificate file")
+	cmd.Flags().
+		StringVar(&r.clusterTLSCertPath, "cluster.tls-cert-path", r.clusterTLSCertPath, "Path to the certificate file")
+	cmd.Flags().
+		StringVar(&r.clusterTLSKeyPath, "cluster.tls-key-path", r.clusterTLSKeyPath, "Path to the key file")
+	cmd.Flags().
+		StringVar(&r.clusterTLSServerName, "cluster.tls-server-name", r.clusterTLSServerName, "Server name to use for TLS communication")
 	// TODO(alloy/#1274): make this flag a no-op once we have more confidence in this feature, and add issue to
 	// remove it in the next major release
 	cmd.Flags().
@@ -168,6 +178,11 @@ type alloyRun struct {
 	clusterMaxJoinPeers          int
 	clusterName                  string
 	clusterUseDiscoveryV1        bool
+	clusterEnableTLS             bool
+	clusterTLSCAPath             string
+	clusterTLSCertPath           string
+	clusterTLSKeyPath            string
+	clusterTLSServerName         string
 	configFormat                 string
 	configBypassConversionErrors bool
 	configExtraArgs              string
@@ -258,6 +273,11 @@ func (fr *alloyRun) Run(configPath string) error {
 		//TODO(alloy/#1274): graduate to GA once we have more confidence in this feature
 		EnableStateUpdatesLimiter: fr.minStability.Permits(featuregate.StabilityPublicPreview),
 		EnableDiscoveryV2:         !fr.clusterUseDiscoveryV1,
+		EnableTLS:                 fr.clusterEnableTLS,
+		TLSCertPath:               fr.clusterTLSCertPath,
+		TLSCAPath:                 fr.clusterTLSCAPath,
+		TLSKeyPath:                fr.clusterTLSKeyPath,
+		TLSServerName:             fr.clusterTLSServerName,
 	})
 	if err != nil {
 		return err

--- a/internal/service/cluster/cluster.go
+++ b/internal/service/cluster/cluster.go
@@ -186,7 +186,7 @@ func loadTLSConfigFromFile(TLSCAPath string, TLSCertPath string, TLSKeyPath stri
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(pem)
 	if !caCertPool.AppendCertsFromPEM(pem) {
-		return nil, fmt.Errorf("failed to append CA from PEM with path %w", TLSCAPath)
+		return nil, fmt.Errorf("failed to append CA from PEM with path %s", TLSCAPath)
 	}
 
 	cert, err := tls.LoadX509KeyPair(TLSCertPath, TLSKeyPath)

--- a/internal/service/cluster/cluster.go
+++ b/internal/service/cluster/cluster.go
@@ -198,7 +198,6 @@ func loadTLSConfigFromFile(TLSCAPath string, TLSCertPath string, TLSKeyPath stri
 		Certificates: []tls.Certificate{cert},
 		RootCAs:      caCertPool,
 		ServerName:   serverName,
-		ClientAuth:   tls.RequireAndVerifyClientCert,
 	}, nil
 }
 

--- a/internal/service/cluster/cluster.go
+++ b/internal/service/cluster/cluster.go
@@ -198,6 +198,7 @@ func loadTLSConfigFromFile(TLSCAPath string, TLSCertPath string, TLSKeyPath stri
 		Certificates: []tls.Certificate{cert},
 		RootCAs:      caCertPool,
 		ServerName:   serverName,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
 	}, nil
 }
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

### PR Description

Clustering in TLS environments was not possible before these changes.

#### Why is this change required
My organization runs alloy pods in environments that require all pod communication to be over HTTPS with TLS encryption. When enabling clustering, we noticed that communication between pods was blocked because it was going over HTTP.

#### Testing
Built `alloy` from this branch and used the `enable-tls` CLI flag with the appropriate certificate material to configure the TLS client. Made sure that pods can still communicate amongst themselves and constantly converge on the cluster's state.

Some logs that confirm pod communication still works:
```
{"ts":"2024-09-20T22:36:54.802881244Z","level":"debug","service":"cluster","component":"memberlist","ts":"2024/09/20 22:36:54","caller":"[DEBUG] memberlist: Initiating push/pull sync with: <ip>.ec2.internal <pod1-ip>"}
{"ts":"2024-09-20T22:36:54.804031852Z","level":"debug","msg":"merging remote state","service":"cluster","remote_time":34}
{"ts":"2024-09-20T22:37:02.656126162Z","level":"debug","msg":"received DNS query response","service":"cluster","addr":"<cluster-address>","record_type":"A/AAAA","records_count":3}
{"ts":"2024-09-20T22:37:02.656152001Z","level":"debug","msg":"discovered peers","service":"cluster","peers_count":3,"peers":"<pod0-ip>,<pod1-ip>,<pod2-ip>"}
{"ts":"2024-09-20T22:37:02.656158483Z","level":"info","msg":"rejoining peers","service":"cluster","peers_count":3,"peers":"<pod0-ip>,<pod1-ip>,<pod2-ip>"}
{"ts":"2024-09-20T22:37:02.657273362Z","level":"debug","service":"cluster","component":"memberlist","ts":"2024/09/20 22:37:02","caller":"[DEBUG] memberlist: Initiating push/pull sync with:  <pod0-ip>"}
{"ts":"2024-09-20T22:37:02.658438004Z","level":"debug","msg":"merging remote state","service":"cluster","remote_time":35}
{"ts":"2024-09-20T22:37:02.65934668Z","level":"debug","service":"cluster","component":"memberlist","ts":"2024/09/20 22:37:02","caller":"[DEBUG] memberlist: Initiating push/pull sync with:  <pod1-ip>"}
{"ts":"2024-09-20T22:37:02.660418062Z","level":"debug","msg":"merging remote state","service":"cluster","remote_time":34}
{"ts":"2024-09-20T22:37:02.660630938Z","level":"debug","service":"cluster","component":"memberlist","ts":"2024/09/20 22:37:02","caller":"[DEBUG] memberlist: Stream connection from=<pod2-ip>"}
{"ts":"2024-09-20T22:37:02.660723496Z","level":"debug","service":"cluster","component":"memberlist","ts":"2024/09/20 22:37:02","caller":"[DEBUG] memberlist: Initiating push/pull sync with:  <pod2-ip>"}
{"ts":"2024-09-20T22:37:02.661081355Z","level":"debug","msg":"merging remote state","service":"cluster","remote_time":36}
```

Grafana Alloy debugging UI also shows that clustered pods can still recognize each other:
<img width="1418" alt="Screenshot 2024-09-20 at 5 49 24 PM" src="https://github.com/user-attachments/assets/5f3269e4-ad63-45c1-bb57-81cbf56204a9">


### Which issue(s) this PR fixes

Fixes https://github.com/grafana/alloy/issues/367

### Notes to the Reviewer

This PR depends on https://github.com/grafana/ckit/pull/63, which has not yet been merged.

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
