### PR TITLE
[release/v1.3] Update version to v1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This document contains a historical list of changes between releases. Only
 changes that impact end-user behavior are listed; changes to documentation or
 internal API changes are not present.
 
-v1.3.2
+v1.3.3
 -----------------
 
 ### Security fixes

--- a/VERSION
+++ b/VERSION
@@ -20,4 +20,4 @@
 #
 # Lines starting with "#" and blank lines are ignored.
 
-v1.3.1
+v1.3.3

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -4,7 +4,7 @@ title: Grafana Alloy
 description: Grafana Alloy is a a vendor-neutral distribution of the OTel Collector
 weight: 350
 cascade:
-  ALLOY_RELEASE: v1.3.1
+  ALLOY_RELEASE: v1.3.3
   OTEL_VERSION: v0.105.0
   FULL_PRODUCT_NAME: Grafana Alloy
   PRODUCT_NAME: Alloy


### PR DESCRIPTION
I created a v1.3.2 tag, but I'd forgotten to update the version to v1.3.2 🤦  So now I need to go straight to v1.3.3...