### PR TITLE
fix(installer): do not quote servicepath in registy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@ Main (unreleased)
 
 ### Bugfixes
 
+- Windows installer: Don't quote alloy binary path in registy (@jkroepke)
+
 - Update yet-another-cloudwatch-exporter from v0.60.0 vo v0.61.0: (@morremeyer)
   - Fixes a bug where cloudwatch S3 metrics are reported as `0`
-
 
 ### Other changes
 

--- a/packaging/windows/install_script.nsis
+++ b/packaging/windows/install_script.nsis
@@ -156,7 +156,7 @@ Function InitializeRegistry
   nsExec::ExecToLog 'Reg.exe query "${REGKEY}" /reg:64 /ve'
   Pop $0
   ${If} $0 == 1
-    nsExec::ExecToLog 'Reg.exe add "${REGKEY}" /reg:64 /ve /d  "\"$INSTDIR\alloy-windows-amd64.exe\""'
+    nsExec::ExecToLog 'Reg.exe add "${REGKEY}" /reg:64 /ve /d  "$INSTDIR\alloy-windows-amd64.exe"'
     Pop $0 # Ignore return result
   ${EndIf}
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

See #1764 for context

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

Fixes #1764

#### Notes to the Reviewer

This change reverts a fix in context of CVE-2024-8975. This change needs to be carefully reviewed.

https://grafana.com/blog/2024/09/25/grafana-alloy-and-grafana-agent-flow-security-release-high-severity-fix-for-cve-2024-8975-and-cve-2024-8996/?camp=blog&cnt=Today+we+released+Grafana&mdm=social&src=li

However, the current approach breaks any Windows Setup.

The registry value with quotes is passed to the exec.Command call from go. I needs to be check, if `exec.Command` is affected from `c:\Program.exe` as well. At least I test the potential issue on a Windows Server 2022 and everything still works as expected. The Program.exe in not called.

![Bildschirmfoto 2024-09-26 um 12 28 02](https://github.com/user-attachments/assets/731fbd6c-a0bc-4294-b242-1bcd28e92ed2)


#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
