### PR TITLE
Add doc about profiling Alloy

### DIFF
--- a/docs/sources/troubleshoot/profile.md
+++ b/docs/sources/troubleshoot/profile.md
@@ -19,7 +19,7 @@ A profile may contain sensitive information about your environment.
 You may not want to upload your profiles to a public location.
 {{< /admonition >}}
 
-The port you use to send the HTTP request is governed by Alloy's `--server.http.listen-addr` [command line argument][cmd-cli].
+The port you use to send the HTTP request is controlled by the `--server.http.listen-addr` [command line argument][cmd-cli].
 It is set to `127.0.0.1:12345` by default.
 
 [pprof-pkg]: https://pkg.go.dev/net/http/pprof


### PR DESCRIPTION
We often get asked to help with Alloy consumiing lots of memory. It would be helpful to point people to a doc. 

If there is a bug in Alloy that's causing the high consumption, then the doc would help people gather enough information to submit a GitHub issue. Even if there is no bug in Alloy, this doc could still help some users to gain more insight into what is consuming memory/CPU.