### PR TITLE
SNMP exporter: Use a "name" argument for "target" and "walk_param" blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Main (unreleased)
 - The `mimir.rules.kubernetes` component now supports adding extra label matchers
   to all queries discovered via `PrometheusRule` CRDs. (@thampiotr)
 
+- `prometheus.exporter.snmp`: The names of `target` and `walk_param` blocks can now be set 
+  via an argument instead of block label. The block label syntax for
+  the `target` and `walk_param` blocks will be removed in Alloy 2.0. (@ptodev)
+
 ### Bugfixes
 
 - Update windows_exporter from v0.27.2 vo v0.27.3: (@jkroepke)

--- a/internal/cmd/alloylint/internal/syntaxtags/syntaxtags.go
+++ b/internal/cmd/alloylint/internal/syntaxtags/syntaxtags.go
@@ -279,7 +279,7 @@ func lintSyntaxTag(ty *types.Var, tag string) (diagnostics []string) {
 			}
 		}
 
-	case "label":
+	case "label", "label,optional":
 		if name != "" {
 			diagnostics = append(diagnostics, "label field must have an empty value for name")
 		}

--- a/internal/converter/internal/staticconvert/internal/build/snmp_exporter.go
+++ b/internal/converter/internal/staticconvert/internal/build/snmp_exporter.go
@@ -3,7 +3,6 @@ package build
 import (
 	"github.com/grafana/alloy/internal/component/discovery"
 	"github.com/grafana/alloy/internal/component/prometheus/exporter/snmp"
-	"github.com/grafana/alloy/internal/converter/internal/common"
 	"github.com/grafana/alloy/internal/static/integrations/snmp_exporter"
 	snmp_exporter_v2 "github.com/grafana/alloy/internal/static/integrations/v2/snmp_exporter"
 	"github.com/grafana/alloy/syntax/alloytypes"
@@ -37,7 +36,7 @@ func toSnmpExporter(config *snmp_exporter.Config) *snmp.Arguments {
 		}
 
 		walkParams[index] = snmp.WalkParam{
-			Name:                    common.SanitizeIdentifierPanics(name),
+			NameArg:                 name,
 			MaxRepetitions:          p.MaxRepetitions,
 			Retries:                 retries,
 			Timeout:                 p.Timeout,
@@ -86,7 +85,7 @@ func toSnmpExporterV2(config *snmp_exporter_v2.Config) *snmp.Arguments {
 		}
 
 		walkParams[index] = snmp.WalkParam{
-			Name:                    common.SanitizeIdentifierPanics(name),
+			NameArg:                 name,
 			MaxRepetitions:          p.MaxRepetitions,
 			Retries:                 retries,
 			Timeout:                 p.Timeout,

--- a/syntax/internal/syntaxtags/syntaxtags.go
+++ b/syntax/internal/syntaxtags/syntaxtags.go
@@ -277,6 +277,8 @@ func parseFlags(input string) (f Flags, ok bool) {
 		f |= FlagEnum | FlagOptional
 	case "label":
 		f |= FlagLabel
+	case "label,optional":
+		f |= FlagLabel | FlagOptional
 	case "squash":
 		f |= FlagSquash
 	default:

--- a/syntax/internal/syntaxtags/syntaxtags_test.go
+++ b/syntax/internal/syntaxtags/syntaxtags_test.go
@@ -37,6 +37,20 @@ func Test_Get(t *testing.T) {
 	require.Equal(t, expect, fs)
 }
 
+func Test_GetOptionalLabel(t *testing.T) {
+	type Struct struct {
+		Label string `alloy:",label,optional"`
+	}
+
+	fs := syntaxtags.Get(reflect.TypeOf(Struct{}))
+
+	expect := []syntaxtags.Field{
+		{[]string{""}, []int{0}, syntaxtags.FlagLabel | syntaxtags.FlagOptional},
+	}
+
+	require.Equal(t, expect, fs)
+}
+
 func TestEmbedded(t *testing.T) {
 	type InnerStruct struct {
 		InnerField1 string `alloy:"inner_field_1,attr"`
@@ -175,6 +189,15 @@ func Test_Get_Panics(t *testing.T) {
 		type Struct struct {
 			Label1 string `alloy:",label"`
 			Label2 string `alloy:",label"`
+		}
+		expect := `syntax: label field already used by syntaxtags_test.Struct.Label2`
+		expectPanic(t, expect, Struct{})
+	})
+
+	t.Run("Only one label field may exist (with an optional label)", func(t *testing.T) {
+		type Struct struct {
+			Label1 string `alloy:",label"`
+			Label2 string `alloy:",label,optional"`
 		}
 		expect := `syntax: label field already used by syntaxtags_test.Struct.Label2`
 		expectPanic(t, expect, Struct{})

--- a/syntax/vm/vm.go
+++ b/syntax/vm/vm.go
@@ -247,7 +247,7 @@ func (vm *Evaluator) evaluateBlockLabel(node *ast.BlockStmt, tfs []syntaxtags.Fi
 	// the name. We might be able to clean this up in the future by extending
 	// ValueError to have an explicit position.
 	switch {
-	case node.Label == "" && foundField: // No user label, but struct expects one
+	case node.Label == "" && foundField && !labelField.IsOptional(): // No user label, but struct expects one
 		return diag.Diagnostic{
 			Severity: diag.SeverityLevelError,
 			StartPos: node.NamePos.Position(),

--- a/syntax/vm/vm_block_test.go
+++ b/syntax/vm/vm_block_test.go
@@ -640,6 +640,45 @@ func TestVM_Block_Label(t *testing.T) {
 		err := eval.Evaluate(nil, &block{})
 		require.EqualError(t, err, `1:1: block "some_block" requires non-empty label`)
 	})
+
+	t.Run("Block may have an optional label", func(t *testing.T) {
+		type block struct {
+			Label string `alloy:",label,optional"`
+		}
+
+		input := `some_block "asdf" {}`
+		eval := vm.New(parseBlock(t, input))
+
+		var actual block
+		require.NoError(t, eval.Evaluate(nil, &actual))
+		require.Equal(t, "asdf", actual.Label)
+	})
+
+	t.Run("Block may have an optional label with explicit empty value", func(t *testing.T) {
+		type block struct {
+			Label string `alloy:",label,optional"`
+		}
+
+		input := `some_block "" {}`
+		eval := vm.New(parseBlock(t, input))
+
+		var actual block
+		require.NoError(t, eval.Evaluate(nil, &actual))
+		require.Equal(t, "", actual.Label)
+	})
+
+	t.Run("Block may have an optional label with no value", func(t *testing.T) {
+		type block struct {
+			Label string `alloy:",label,optional"`
+		}
+
+		input := `some_block {}`
+		eval := vm.New(parseBlock(t, input))
+
+		var actual block
+		require.NoError(t, eval.Evaluate(nil, &actual))
+		require.Equal(t, "", actual.Label)
+	})
 }
 
 func TestVM_Block_Unmarshaler(t *testing.T) {


### PR DESCRIPTION
#### PR Description

Using an Alloy syntax identifiers restricts the sorts of labels that the SNMP exporter produces. For example, you cannot use `target "network-switch-1"` because identifiers can't contain a dash. 

In the SNMP exporter the name of a `target` block is used as for the value of a `job` Prometheus metric label, so it's not good to restrict the users in this way. They might want the label value to be a FQDM of a device that they are monitoring, and having to change the FQDN to something else is a usability issue.

The name of the `walk_param` block should probably ideally also not be restricted, although TBH I'm not sure if restricting it is a problem in practice.

#### Which issue(s) this PR fixes

Related to #289

#### Notes to the Reviewer

I documented the `name` argument as "required", even though it technically isn't required. But I think the docs look less confusing this way.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated
