### PR TITLE
1687 otelcol.exporter.awss3 config fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Main (unreleased)
 
 - Update yet-another-cloudwatch-exporter from v0.60.0 vo v0.61.0: (@morremeyer)
   - Fixes a bug where cloudwatch S3 metrics are reported as `0`
+- Issue 1687 - otelcol.exporter.awss3 fails to configure (@cydergoth)
+  - Fix parsing of the Level configuration attribute in debug_metrics config block
+  - Ensure "optional" debug_metrics config block really is optional
 
 ### Other changes
 

--- a/internal/component/otelcol/config/config_debug_metrics.go
+++ b/internal/component/otelcol/config/config_debug_metrics.go
@@ -19,6 +19,13 @@ const (
 	LevelDetailed = "detailed"
 )
 
+var levels = map[Level]bool{
+        LevelNone: true,
+        LevelBasic: true,
+        LevelNormal:true,
+        LevelDetailed: true,
+}
+
 func (l Level) Convert() (configtelemetry.Level, error) {
 	switch l {
 	case LevelNone:
@@ -32,6 +39,16 @@ func (l Level) Convert() (configtelemetry.Level, error) {
 	default:
 		return configtelemetry.LevelBasic, fmt.Errorf("unrecognized debug metric level: %s", l)
 	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler for Level.
+func (l *Level) UnmarshalText(text []byte) error {
+	alloyLevelStr := Level(text)
+	if _, exists := levels[alloyLevelStr]; exists {
+		*l = alloyLevelStr
+		return nil
+	}
+	return fmt.Errorf("unrecognized debug level %q", string(text))
 }
 
 // DebugMetricsArguments configures internal metrics of the components

--- a/internal/component/otelcol/exporter/awss3/awss3.go
+++ b/internal/component/otelcol/exporter/awss3/awss3.go
@@ -44,6 +44,7 @@ var _ exporter.Arguments = Arguments{}
 func (args *Arguments) SetToDefault() {
 	args.MarshalerName.SetToDefault()
 	args.S3Uploader.SetToDefault()
+	args.DebugMetrics.SetToDefault()
 }
 
 func (args Arguments) Convert() (otelcomponent.Config, error) {

--- a/internal/component/otelcol/exporter/awss3/awss3_test.go
+++ b/internal/component/otelcol/exporter/awss3/awss3_test.go
@@ -32,6 +32,19 @@ func TestDebugMetricsConfig(t *testing.T) {
 			},
 		},
 		{
+			testName: "no_optional_debug",
+			agentCfg: `
+			s3_uploader {
+				s3_bucket = "test"
+				s3_prefix = "logs"
+			}
+			`,
+			expected: otelcolCfg.DebugMetricsArguments{
+				DisableHighCardinalityMetrics: true,
+				Level:                         otelcolCfg.LevelDetailed,
+			},
+		},
+		{
 			testName: "explicit_false",
 			agentCfg: `
 			s3_uploader {
@@ -61,6 +74,22 @@ func TestDebugMetricsConfig(t *testing.T) {
 			expected: otelcolCfg.DebugMetricsArguments{
 				DisableHighCardinalityMetrics: true,
 				Level:                         otelcolCfg.LevelDetailed,
+			},
+		},
+		{
+			testName: "explicit_debug_level",
+			agentCfg: `
+			s3_uploader {
+				s3_bucket = "test"
+				s3_prefix = "logs"
+			}
+			debug_metrics {
+				level = "none"
+			}
+			`,
+			expected: otelcolCfg.DebugMetricsArguments{
+				DisableHighCardinalityMetrics: true,
+				Level:                         otelcolCfg.LevelNone,
 			},
 		},
 	}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Second attempt at a PR for #1687 replacing #1725 OTEL AWS S3 exporter config fixes

* Fix missing defaults for optional config block 
* Fix missing conversion of debug level from string to enum
* Add tests for above two errors

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #1687  

#### Notes to the Reviewer

Replacement PR to #1725 to fix the issue with CLA not liking the commit author 

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
- [X] Tests updated
- [X] Config converters updated
