### PR TITLE
Fix location of loki.secretfilter in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Main (unreleased)
 
 - Add the function `path_join` to the stdlib. (@wildum)
 - Add support to `loki.source.syslog` for the RFC3164 format ("BSD syslog"). (@sushain97)
+- (_Experimental_) Add a `loki.secretfilter` component to redact secrets from collected logs.
 
 ### Enhancements
 
@@ -75,7 +76,6 @@ v1.4.0
 - Added Datadog Exporter community component, enabling exporting of otel-formatted Metrics and traces to Datadog. (@polyrain)
 - (_Experimental_) Add an `otelcol.processor.interval` component to aggregate metrics and periodically
   forward the latest values to the next component in the pipeline.
-- (_Experimental_) Add a `loki.secretfilter` component to redact secrets from collected logs.
 
 
 ### Enhancements


### PR DESCRIPTION
When #1593 was merged, it added the changelog entry to the RC, even though the change is not on the [release branch](https://github.com/grafana/alloy/tree/release/v1.4/docs/sources/reference/components/loki). I suppose this happened during a git rebase. I edited this out of the [release announcement](https://github.com/grafana/alloy/releases/tag/v1.4.0) just now. 

This PR fixes the changelog so that we can announce the component in the next release.