### PR TITLE
Fix unnecessary `loki.process` config reloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ Main (unreleased)
   - Fixes a bug where cloudwatch S3 metrics are reported as `0`
 
 - Fixed a bug in `import.git` which caused a `"non-fast-forward update"` error message. (@ptodev)
+ 
+- Fixed an issue with `loki.process` where `stage.luhn` and `stage.timestamp` would not apply 
+  default configuration settings correctly (@thampiotr)
+
+- Fixed an issue with `loki.process` where configuration could be reloaded even if there
+  were no changes. (@ptodev, @thampiotr)
 
 ### Other changes
 

--- a/internal/component/loki/process/stages/drop_test.go
+++ b/internal/component/loki/process/stages/drop_test.go
@@ -7,12 +7,13 @@ import (
 	"time"
 
 	"github.com/alecthomas/units"
-	"github.com/grafana/alloy/internal/util"
 	dskit "github.com/grafana/dskit/server"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/internal/util"
 )
 
 // Not all these are tested but are here to make sure the different types marshal without error
@@ -411,7 +412,7 @@ func Test_dropStage_Process(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateDropConfig(tt.config)
+			_, err := validateDropConfig(tt.config)
 			if err != nil {
 				t.Error(err)
 			}
@@ -465,7 +466,7 @@ func Test_validateDropConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := validateDropConfig(tt.config); ((err != nil) && (err.Error() != tt.wantErr.Error())) || (err == nil && tt.wantErr != nil) {
+			if _, err := validateDropConfig(tt.config); ((err != nil) && (err.Error() != tt.wantErr.Error())) || (err == nil && tt.wantErr != nil) {
 				t.Errorf("validateDropConfig() error = %v, wantErr = %v", err, tt.wantErr)
 			}
 		})

--- a/internal/component/loki/process/stages/geoip.go
+++ b/internal/component/loki/process/stages/geoip.go
@@ -7,15 +7,15 @@ import (
 	"reflect"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/alloy/internal/runtime/logging/level"
 	"github.com/jmespath/go-jmespath"
 	"github.com/oschwald/geoip2-golang"
 	"github.com/oschwald/maxminddb-golang"
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/alloy/internal/runtime/logging/level"
 )
 
 var (
-	ErrEmptyGeoIPStageConfig                = errors.New("geoip stage config cannot be empty")
 	ErrEmptyDBPathGeoIPStageConfig          = errors.New("db path cannot be empty")
 	ErrEmptySourceGeoIPStageConfig          = errors.New("source cannot be empty")
 	ErrEmptyDBTypeGeoIPStageConfig          = errors.New("db type should be either city or asn")

--- a/internal/component/loki/process/stages/labels_test.go
+++ b/internal/component/loki/process/stages/labels_test.go
@@ -72,10 +72,8 @@ func TestLabelsPipelineWithMissingKey_Labels(t *testing.T) {
 }
 
 var (
-	lv1  = "lv1"
-	lv2c = "l2"
-	lv3  = ""
-	lv3c = "l3"
+	lv1 = "lv1"
+	lv3 = ""
 )
 
 var emptyLabelsConfig = LabelsConfig{nil}
@@ -84,19 +82,19 @@ func TestLabels(t *testing.T) {
 	tests := map[string]struct {
 		config       LabelsConfig
 		err          error
-		expectedCfgs LabelsConfig
+		expectedCfgs map[string]string
 	}{
 		"missing config": {
 			config:       emptyLabelsConfig,
 			err:          errors.New(ErrEmptyLabelStageConfig),
-			expectedCfgs: emptyLabelsConfig,
+			expectedCfgs: nil,
 		},
 		"invalid label name": {
 			config: LabelsConfig{
 				Values: map[string]*string{"#*FDDS*": nil},
 			},
 			err:          fmt.Errorf(ErrInvalidLabelName, "#*FDDS*"),
-			expectedCfgs: emptyLabelsConfig,
+			expectedCfgs: nil,
 		},
 		"label value is set from name": {
 			config: LabelsConfig{Values: map[string]*string{
@@ -105,18 +103,18 @@ func TestLabels(t *testing.T) {
 				"l3": &lv3,
 			}},
 			err: nil,
-			expectedCfgs: LabelsConfig{Values: map[string]*string{
-				"l1": &lv1,
-				"l2": &lv2c,
-				"l3": &lv3c,
-			}},
+			expectedCfgs: map[string]string{
+				"l1": lv1,
+				"l2": "l2",
+				"l3": "l3",
+			},
 		},
 	}
 	for name, test := range tests {
 		test := test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			err := validateLabelsConfig(test.config)
+			actual, err := validateLabelsConfig(test.config)
 			if (err != nil) != (test.err != nil) {
 				t.Errorf("validateLabelsConfig() expected error = %v, actual error = %v", test.err, err)
 				return
@@ -125,8 +123,8 @@ func TestLabels(t *testing.T) {
 				t.Errorf("validateLabelsConfig() expected error = %v, actual error = %v", test.err, err)
 				return
 			}
-			if test.expectedCfgs.Values != nil {
-				assert.Equal(t, test.expectedCfgs, test.config)
+			if test.expectedCfgs != nil {
+				assert.Equal(t, test.expectedCfgs, actual)
 			}
 		})
 	}

--- a/internal/component/loki/process/stages/luhn.go
+++ b/internal/component/loki/process/stages/luhn.go
@@ -17,7 +17,7 @@ type LuhnFilterConfig struct {
 }
 
 // validateLuhnFilterConfig validates the LuhnFilterConfig.
-func validateLuhnFilterConfig(c LuhnFilterConfig) error {
+func validateLuhnFilterConfig(c *LuhnFilterConfig) error {
 	if c.Replacement == "" {
 		c.Replacement = "**REDACTED**"
 	}
@@ -32,7 +32,7 @@ func validateLuhnFilterConfig(c LuhnFilterConfig) error {
 
 // newLuhnFilterStage creates a new LuhnFilterStage.
 func newLuhnFilterStage(config LuhnFilterConfig) (Stage, error) {
-	if err := validateLuhnFilterConfig(config); err != nil {
+	if err := validateLuhnFilterConfig(&config); err != nil {
 		return nil, err
 	}
 	return toStage(&luhnFilterStage{

--- a/internal/component/loki/process/stages/match.go
+++ b/internal/component/loki/process/stages/match.go
@@ -13,13 +13,11 @@ import (
 
 // Configuration errors.
 var (
-	ErrEmptyMatchStageConfig = errors.New("match stage config cannot be empty")
-	ErrPipelineNameRequired  = errors.New("match stage pipeline name can be omitted but cannot be an empty string")
-	ErrSelectorRequired      = errors.New("selector statement required for match stage")
-	ErrMatchRequiresStages   = errors.New("match stage requires at least one additional stage to be defined in '- stages'")
-	ErrSelectorSyntax        = errors.New("invalid selector syntax for match stage")
-	ErrStagesWithDropLine    = errors.New("match stage configured to drop entries cannot contains stages")
-	ErrUnknownMatchAction    = errors.New("match stage action should be 'keep' or 'drop'")
+	ErrSelectorRequired    = errors.New("selector statement required for match stage")
+	ErrMatchRequiresStages = errors.New("match stage requires at least one additional stage to be defined in '- stages'")
+	ErrSelectorSyntax      = errors.New("invalid selector syntax for match stage")
+	ErrStagesWithDropLine  = errors.New("match stage configured to drop entries cannot contains stages")
+	ErrUnknownMatchAction  = errors.New("match stage action should be 'keep' or 'drop'")
 
 	MatchActionKeep = "keep"
 	MatchActionDrop = "drop"

--- a/internal/component/loki/process/stages/match_test.go
+++ b/internal/component/loki/process/stages/match_test.go
@@ -5,9 +5,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/alloy/internal/util"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/internal/util"
 )
 
 var testMatchAlloy = `
@@ -191,19 +193,26 @@ func TestValidateMatcherConfig(t *testing.T) {
 	emptyStages := []StageConfig{}
 	defaultStage := []StageConfig{{MatchConfig: &MatchConfig{}}}
 	tests := []struct {
-		name    string
-		cfg     *MatchConfig
-		wantErr bool
+		name     string
+		cfg      *MatchConfig
+		wantErr  bool
+		expected *MatchConfig
 	}{
-		{"pipeline name required", &MatchConfig{}, true},
-		{"selector required", &MatchConfig{Selector: ""}, true},
-		{"nil stages without dropping", &MatchConfig{PipelineName: "", Selector: `{app="foo"}`, Action: MatchActionKeep, Stages: nil}, true},
-		{"empty stages without dropping", &MatchConfig{Selector: `{app="foo"}`, Action: MatchActionKeep, Stages: emptyStages}, true},
-		{"stages with dropping", &MatchConfig{Selector: `{app="foo"}`, Action: MatchActionDrop, Stages: defaultStage}, true},
-		{"empty stages dropping", &MatchConfig{Selector: `{app="foo"}`, Action: MatchActionDrop, Stages: emptyStages}, false},
-		{"stages without dropping", &MatchConfig{Selector: `{app="foo"}`, Action: MatchActionKeep, Stages: defaultStage}, false},
-		{"bad selector", &MatchConfig{Selector: `{app="foo}`, Action: MatchActionKeep, Stages: defaultStage}, true},
-		{"bad action", &MatchConfig{Selector: `{app="foo}`, Action: "nope", Stages: emptyStages}, true},
+		{name: "pipeline name required", cfg: &MatchConfig{}, wantErr: true},
+		{name: "selector required", cfg: &MatchConfig{Selector: ""}, wantErr: true},
+		{name: "nil stages without dropping", cfg: &MatchConfig{PipelineName: "", Selector: `{app="foo"}`, Action: MatchActionKeep, Stages: nil}, wantErr: true},
+		{name: "empty stages without dropping", cfg: &MatchConfig{Selector: `{app="foo"}`, Action: MatchActionKeep, Stages: emptyStages}, wantErr: true},
+		{name: "stages with dropping", cfg: &MatchConfig{Selector: `{app="foo"}`, Action: MatchActionDrop, Stages: defaultStage}, wantErr: true},
+		{name: "empty stages dropping", cfg: &MatchConfig{Selector: `{app="foo"}`, Action: MatchActionDrop, Stages: emptyStages}},
+		{name: "stages without dropping", cfg: &MatchConfig{Selector: `{app="foo"}`, Action: MatchActionKeep, Stages: defaultStage}},
+		{name: "bad selector", cfg: &MatchConfig{Selector: `{app="foo}`, Action: MatchActionKeep, Stages: defaultStage}, wantErr: true},
+		{name: "bad action", cfg: &MatchConfig{Selector: `{app="foo}`, Action: "nope", Stages: emptyStages}, wantErr: true},
+		{
+			name:     "sets default action to keep",
+			cfg:      &MatchConfig{Selector: `{app="foo"}`, Stages: defaultStage},
+			wantErr:  false,
+			expected: &MatchConfig{Selector: `{app="foo"}`, Action: MatchActionKeep, Stages: defaultStage},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -211,6 +220,9 @@ func TestValidateMatcherConfig(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("validateMatcherConfig() error = %v, wantErr %v", err, tt.wantErr)
 				return
+			}
+			if tt.expected != nil {
+				require.Equal(t, tt.expected, tt.cfg)
 			}
 		})
 	}

--- a/internal/component/loki/process/stages/multiline.go
+++ b/internal/component/loki/process/stages/multiline.go
@@ -18,9 +18,8 @@ import (
 
 // Configuration errors.
 var (
-	ErrMultilineStageEmptyConfig        = errors.New("multiline stage config must define `firstline` regular expression")
-	ErrMultilineStageInvalidRegex       = errors.New("multiline stage first line regex compilation error")
-	ErrMultilineStageInvalidMaxWaitTime = errors.New("multiline stage `max_wait_time` parse error")
+	ErrMultilineStageEmptyConfig  = errors.New("multiline stage config must define `firstline` regular expression")
+	ErrMultilineStageInvalidRegex = errors.New("multiline stage first line regex compilation error")
 )
 
 // MultilineConfig contains the configuration for a Multiline stage.
@@ -28,7 +27,6 @@ type MultilineConfig struct {
 	Expression  string        `alloy:"firstline,attr"`
 	MaxLines    uint64        `alloy:"max_lines,attr,optional"`
 	MaxWaitTime time.Duration `alloy:"max_wait_time,attr,optional"`
-	regex       *regexp.Regexp
 }
 
 // DefaultMultilineConfig applies the default values on
@@ -51,24 +49,24 @@ func (args *MultilineConfig) Validate() error {
 	return nil
 }
 
-func validateMultilineConfig(cfg *MultilineConfig) error {
+func validateMultilineConfig(cfg MultilineConfig) (*regexp.Regexp, error) {
 	if cfg.Expression == "" {
-		return ErrMultilineStageEmptyConfig
+		return nil, ErrMultilineStageEmptyConfig
 	}
 
 	expr, err := regexp.Compile(cfg.Expression)
 	if err != nil {
-		return fmt.Errorf("%v: %w", ErrMultilineStageInvalidRegex, err)
+		return nil, fmt.Errorf("%v: %w", ErrMultilineStageInvalidRegex, err)
 	}
-	cfg.regex = expr
 
-	return nil
+	return expr, nil
 }
 
 // multilineStage matches lines to determine whether the following lines belong to a block and should be collapsed
 type multilineStage struct {
 	logger log.Logger
 	cfg    MultilineConfig
+	regex  *regexp.Regexp
 }
 
 // multilineState captures the internal state of a running multiline stage.
@@ -80,7 +78,7 @@ type multilineState struct {
 
 // newMultilineStage creates a MulitlineStage from config
 func newMultilineStage(logger log.Logger, config MultilineConfig) (Stage, error) {
-	err := validateMultilineConfig(&config)
+	regex, err := validateMultilineConfig(config)
 	if err != nil {
 		return nil, err
 	}
@@ -88,6 +86,7 @@ func newMultilineStage(logger log.Logger, config MultilineConfig) (Stage, error)
 	return &multilineStage{
 		logger: log.With(logger, "component", "stage", "type", "multiline"),
 		cfg:    config,
+		regex:  regex,
 	}, nil
 }
 
@@ -96,7 +95,7 @@ func (m *multilineStage) Run(in chan Entry) chan Entry {
 	go func() {
 		defer close(out)
 
-		streams := make(map[model.Fingerprint](chan Entry))
+		streams := make(map[model.Fingerprint]chan Entry)
 		wg := new(sync.WaitGroup)
 
 		for e := range in {
@@ -104,7 +103,7 @@ func (m *multilineStage) Run(in chan Entry) chan Entry {
 			s, ok := streams[key]
 			if !ok {
 				// Pass through entries until we hit first start line.
-				if !m.cfg.regex.MatchString(e.Line) {
+				if !m.regex.MatchString(e.Line) {
 					level.Debug(m.logger).Log("msg", "pass through entry", "stream", key)
 					out <- e
 					continue
@@ -152,7 +151,7 @@ func (m *multilineStage) runMultiline(in chan Entry, out chan Entry, wg *sync.Wa
 				return
 			}
 
-			isFirstLine := m.cfg.regex.MatchString(e.Line)
+			isFirstLine := m.regex.MatchString(e.Line)
 			if isFirstLine {
 				level.Debug(m.logger).Log("msg", "flush multiline block because new start line", "block", state.buffer.String(), "stream", e.Labels.FastFingerprint())
 				m.flush(out, state)

--- a/internal/component/loki/process/stages/multiline_test.go
+++ b/internal/component/loki/process/stages/multiline_test.go
@@ -17,11 +17,12 @@ import (
 func TestMultilineStageProcess(t *testing.T) {
 	logger := util.TestAlloyLogger(t)
 	mcfg := MultilineConfig{Expression: "^START", MaxWaitTime: 3 * time.Second}
-	err := validateMultilineConfig(&mcfg)
+	regex, err := validateMultilineConfig(mcfg)
 	require.NoError(t, err)
 
 	stage := &multilineStage{
 		cfg:    mcfg,
+		regex:  regex,
 		logger: logger,
 	}
 
@@ -44,11 +45,12 @@ func TestMultilineStageProcess(t *testing.T) {
 func TestMultilineStageMultiStreams(t *testing.T) {
 	logger := util.TestAlloyLogger(t)
 	mcfg := MultilineConfig{Expression: "^START", MaxWaitTime: 3 * time.Second}
-	err := validateMultilineConfig(&mcfg)
+	regex, err := validateMultilineConfig(mcfg)
 	require.NoError(t, err)
 
 	stage := &multilineStage{
 		cfg:    mcfg,
+		regex:  regex,
 		logger: logger,
 	}
 
@@ -84,11 +86,12 @@ func TestMultilineStageMultiStreams(t *testing.T) {
 func TestMultilineStageMaxWaitTime(t *testing.T) {
 	logger := util.TestAlloyLogger(t)
 	mcfg := MultilineConfig{Expression: "^START", MaxWaitTime: 100 * time.Millisecond}
-	err := validateMultilineConfig(&mcfg)
+	regex, err := validateMultilineConfig(mcfg)
 	require.NoError(t, err)
 
 	stage := &multilineStage{
 		cfg:    mcfg,
+		regex:  regex,
 		logger: logger,
 	}
 

--- a/internal/component/loki/process/stages/replace.go
+++ b/internal/component/loki/process/stages/replace.go
@@ -2,7 +2,6 @@ package stages
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -10,14 +9,9 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/alloy/internal/runtime/logging/level"
 	"github.com/prometheus/common/model"
-)
 
-// Config Errors
-var (
-	ErrEmptyReplaceStageConfig = errors.New("empty replace stage configuration")
-	ErrEmptyReplaceStageSource = errors.New("empty source in replace stage")
+	"github.com/grafana/alloy/internal/runtime/logging/level"
 )
 
 func init() {

--- a/internal/component/loki/process/stages/static_labels.go
+++ b/internal/component/loki/process/stages/static_labels.go
@@ -7,8 +7,9 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/alloy/internal/runtime/logging/level"
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/alloy/internal/runtime/logging/level"
 )
 
 // ErrEmptyStaticLabelStageConfig error returned if the config is empty.
@@ -26,7 +27,7 @@ func newStaticLabelsStage(logger log.Logger, config StaticLabelsConfig) (Stage, 
 	}
 
 	return toStage(&staticLabelStage{
-		Config: config,
+		config: config,
 		logger: logger,
 	}), nil
 }
@@ -45,13 +46,13 @@ func validateLabelStaticConfig(c StaticLabelsConfig) error {
 
 // staticLabelStage implements Stage.
 type staticLabelStage struct {
-	Config StaticLabelsConfig
+	config StaticLabelsConfig
 	logger log.Logger
 }
 
 // Process implements Stage.
 func (l *staticLabelStage) Process(labels model.LabelSet, extracted map[string]interface{}, t *time.Time, entry *string) {
-	for lName, lSrc := range l.Config.Values {
+	for lName, lSrc := range l.config.Values {
 		if lSrc == nil || *lSrc == "" {
 			continue
 		}

--- a/internal/component/loki/process/stages/template.go
+++ b/internal/component/loki/process/stages/template.go
@@ -13,16 +13,16 @@ import (
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/go-kit/log"
-	"github.com/grafana/alloy/internal/runtime/logging/level"
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/alloy/internal/runtime/logging/level"
 
 	"golang.org/x/crypto/sha3"
 )
 
 // Config Errors.
 var (
-	ErrEmptyTemplateStageConfig = errors.New("template stage config cannot be empty")
-	ErrTemplateSourceRequired   = errors.New("template source value is required")
+	ErrTemplateSourceRequired = errors.New("template source value is required")
 )
 
 var extraFunctionMap = template.FuncMap{

--- a/internal/component/loki/process/stages/timestamp.go
+++ b/internal/component/loki/process/stages/timestamp.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"reflect"
 	"time"
+	_ "time/tzdata" // embed timezone data
 
 	"github.com/go-kit/log"
-	"github.com/grafana/alloy/internal/runtime/logging/level"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/prometheus/common/model"
 
-	_ "time/tzdata" // embed timezone data
+	"github.com/grafana/alloy/internal/runtime/logging/level"
 )
 
 // Config errors.
@@ -53,7 +53,7 @@ type TimestampConfig struct {
 
 type parser func(string) (time.Time, error)
 
-func validateTimestampConfig(cfg TimestampConfig) (parser, error) {
+func validateTimestampConfig(cfg *TimestampConfig) (parser, error) {
 	if cfg.Source == "" {
 		return nil, ErrTimestampSourceRequired
 	}
@@ -99,7 +99,7 @@ func validateTimestampConfig(cfg TimestampConfig) (parser, error) {
 
 // newTimestampStage creates a new timestamp extraction pipeline stage.
 func newTimestampStage(logger log.Logger, config TimestampConfig) (Stage, error) {
-	parser, err := validateTimestampConfig(config)
+	parser, err := validateTimestampConfig(&config)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

As discussed offline, this is a different implementation of https://github.com/grafana/alloy/pull/1426.

We're addressing only the mutation of configuration that is provided to `loki.process`, which is a local solution to address too frequent config reloads.

A more global (in the future) solution would ideally be implemented on the framework / runtime level that would prevent updating config when they didn't change. Or making configs truly immutable. 

NOTE 1: mutating arguments doesn't always lead to issues, as they are passed by value (struct) to the component and to each `newXXXStage` function. The problem starts when the arguments contain a slice, map or a pointer to another struct and it gets mutated.

NOTE 2: I also caught a couple of stages not correctly applying their defaults because they were mutating a function-local copy of the configuration only. 

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
