### PR TITLE
Fix OTEL alerts query

### DIFF
--- a/operations/alloy-mixin/alerts/opentelemetry.libsonnet
+++ b/operations/alloy-mixin/alerts/opentelemetry.libsonnet
@@ -4,13 +4,13 @@ local alert = import './utils/alert.jsonnet';
   local successRateQuery(enableK8sCluster, failed, success) =
         local sumBy = if enableK8sCluster then "cluster, namespace, job" else "job";
         |||
-          (1 - sum by (%s) (
-                  rate(%s{}[1m])
+          (1 - (
+                  sum by (%s) (rate(%s{}[1m]))
                   /
-                  (rate(%s{}[1m]) + rate(%s{}[1m]))
+                  sum by (%s) (rate(%s{}[1m]) + rate(%s{}[1m]))
                )
           ) < 0.95
-        ||| % [sumBy, failed, failed, success],
+        ||| % [sumBy, failed, sumBy, failed, success],
 
   newOpenTelemetryAlertsGroup(enableK8sCluster=true):
     alert.newGroup(


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This is a fix to yet unreleased change to OTEL alerts queries that was added in this PR: https://github.com/grafana/alloy/pull/1721

There was a mistake in original PR: we were calculating the failure rate of each time series and then doing `sum by (cluster, namespace, job)` on these, so if we had 200 instances with 1% failure rate, we would end up with 200% failure rate.

Instead we should `sum by (cluster, namespace, job)` for the nominator (number of failures) and the denominator (total number of events) to get a correct SR for the entire cluster/namespace/job. 

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
