### PR TITLE
Configure SELinux label on CloudWatch integration mounts

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -5,13 +5,17 @@ export SHELLOPTS := pipefail:errexit
 MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rule
 
+CHECK_CLOUDWATCH_INTEGRATION ?= 1
+
 include docs.mk
 
+ifeq ($(CHECK_CLOUDWATCH_INTEGRATION),1)
 .PHONY: docs
 docs: check-cloudwatch-integration
+endif
 
 check-cloudwatch-integration:
-	$(PODMAN) run -v $(shell git rev-parse --show-toplevel):/repo -v $(shell pwd):/docs -w /repo golang:1.22.7-bullseye go run internal/static/integrations/cloudwatch_exporter/docs/doc.go check /docs/sources/reference/components/prometheus/prometheus.exporter.cloudwatch.md
+	$(PODMAN) run -v "$(shell git rev-parse --show-toplevel):/repo:z" -v "$(shell pwd):/docs:z" -w /repo golang:1.22.7-bullseye go run internal/static/integrations/cloudwatch_exporter/docs/doc.go check /docs/sources/reference/components/prometheus/prometheus.exporter.cloudwatch.md
 
 generate-cloudwatch-integration:
-	$(PODMAN) run -v $(shell git rev-parse --show-toplevel):/repo -v $(shell pwd):/docs -w /repo golang:1.22.7-bullseye go run internal/static/integrations/cloudwatch_exporter/docs/doc.go generate
+	$(PODMAN) run -v "$(shell git rev-parse --show-toplevel):/repo:z" -v "$(shell pwd):/docs:z" -w /repo golang:1.22.7-bullseye go run internal/static/integrations/cloudwatch_exporter/docs/doc.go generate


### PR DESCRIPTION
Also make it easy to turn off checking the CloudWatch integration.

Without the SELinux label, users running SELinux see permissions issues running this target.
