### PR TITLE
[faro collector] add missing struct fields so that payload.meta.browser fields are not lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Main (unreleased)
 
 - Fix issue where `loki.source.kubernetes` took into account all labels, instead of specific logs labels. Resulting in duplication. (@mattdurham)
 
+- Fix an issue where some `faro.receiver` would drop multiple fields defined in `payload.meta.browser`, as fields were defined in the struct 
 
 ### Other changes
 

--- a/internal/component/faro/receiver/internal/payload/payload.go
+++ b/internal/component/faro/receiver/internal/payload/payload.go
@@ -417,8 +417,8 @@ func (b Browser) KeyVal() *KeyVal {
 	KeyValAdd(kv, "mobile", fmt.Sprintf("%v", b.Mobile))
 	KeyValAdd(kv, "userAgent", b.UserAgent)
 	KeyValAdd(kv, "language", b.Language)
-	KeyValAdd(kv, "viewportWidth", fmt.Sprintf("%d", int(b.ViewportWidth))
-	KeyValAdd(kv, "viewportHeight", fmt.Sprintf("%d", int(b.ViewportHeight))
+	KeyValAdd(kv, "viewportWidth", fmt.Sprintf("%d", int(b.ViewportWidth)))
+	KeyValAdd(kv, "viewportHeight", fmt.Sprintf("%d", int(b.ViewportHeight)))
 	return kv
 }
 

--- a/internal/component/faro/receiver/internal/payload/payload.go
+++ b/internal/component/faro/receiver/internal/payload/payload.go
@@ -396,10 +396,16 @@ func (a App) KeyVal() *KeyVal {
 
 // Browser holds metadata about a client's browser
 type Browser struct {
-	Name    string `json:"name,omitempty"`
-	Version string `json:"version,omitempty"`
-	OS      string `json:"os,omitempty"`
-	Mobile  bool   `json:"mobile,omitempty"`
+	Name           string `json:"name,omitempty"`
+	Version        string `json:"version,omitempty"`
+	OS             string `json:"os,omitempty"`
+	Mobile         bool   `json:"mobile,omitempty"`
+	UserAgent      string `json:"userAgent,omitempty"`
+	Language       string `json:"language,omitempty"`
+	// TODO: properly serialize brands
+	// Brands json.RawMessage `json:"brands,omitempty"` 
+	ViewportWidth  float64 `json:"viewportWidth,omitempty"`
+	ViewportHeight float64 `json:"viewportHeight,omitempty"`
 }
 
 // KeyVal produces key->value representation of the Browser metadata
@@ -409,6 +415,10 @@ func (b Browser) KeyVal() *KeyVal {
 	KeyValAdd(kv, "version", b.Version)
 	KeyValAdd(kv, "os", b.OS)
 	KeyValAdd(kv, "mobile", fmt.Sprintf("%v", b.Mobile))
+	KeyValAdd(kv, "userAgent", b.UserAgent)
+	KeyValAdd(kv, "language", b.Language)
+	KeyValAdd(kv, "viewportWidth", fmt.Sprintf("%d", int(b.ViewportWidth))
+	KeyValAdd(kv, "viewportHeight", fmt.Sprintf("%d", int(b.ViewportHeight))
 	return kv
 }
 

--- a/internal/component/faro/receiver/internal/payload/payload.go
+++ b/internal/component/faro/receiver/internal/payload/payload.go
@@ -404,8 +404,8 @@ type Browser struct {
 	Language       string `json:"language,omitempty"`
 	// TODO: properly serialize brands
 	// Brands json.RawMessage `json:"brands,omitempty"` 
-	ViewportWidth  float64 `json:"viewportWidth,omitempty"`
-	ViewportHeight float64 `json:"viewportHeight,omitempty"`
+	ViewportWidth  string `json:"viewportWidth,omitempty"`
+	ViewportHeight string `json:"viewportHeight,omitempty"`
 }
 
 // KeyVal produces key->value representation of the Browser metadata
@@ -417,8 +417,8 @@ func (b Browser) KeyVal() *KeyVal {
 	KeyValAdd(kv, "mobile", fmt.Sprintf("%v", b.Mobile))
 	KeyValAdd(kv, "userAgent", b.UserAgent)
 	KeyValAdd(kv, "language", b.Language)
-	KeyValAdd(kv, "viewportWidth", fmt.Sprintf("%d", int(b.ViewportWidth)))
-	KeyValAdd(kv, "viewportHeight", fmt.Sprintf("%d", int(b.ViewportHeight)))
+	KeyValAdd(kv, "viewportWidth", b.ViewportWidth)
+	KeyValAdd(kv, "viewportHeight", b.ViewportHeight)
 	return kv
 }
 

--- a/internal/component/faro/receiver/internal/payload/payload_test.go
+++ b/internal/component/faro/receiver/internal/payload/payload_test.go
@@ -58,6 +58,10 @@ func TestUnmarshalPayloadJSON(t *testing.T) {
 			Version: "88.12.1",
 			OS:      "linux",
 			Mobile:  false,
+			UserAgent: "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0",
+			Language: "en-US",
+			ViewportWidth: "1920",
+			ViewportHeight: "1080",
 		},
 		View: View{
 			Name: "foobar",

--- a/internal/component/faro/receiver/testdata/payload.json
+++ b/internal/component/faro/receiver/testdata/payload.json
@@ -283,9 +283,9 @@
       "os": "linux",
       "mobile": false,
       "userAgent": "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0",
-      "language": "en",
-      "viewPortWidth": "1920",
-      "viewPortHeight": "1080",
+      "language": "en-US",
+      "viewportWidth": "1920",
+      "viewportHeight": "1080",
     },
     "view": {
       "name": "foobar"

--- a/internal/component/faro/receiver/testdata/payload.json
+++ b/internal/component/faro/receiver/testdata/payload.json
@@ -282,6 +282,10 @@
       "version": "88.12.1",
       "os": "linux",
       "mobile": false
+      "userAgent": "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0",
+			"language": "en",
+			"viewPortWidth": "1920",
+			"viewPortHeight": "1080",
     },
     "view": {
       "name": "foobar"

--- a/internal/component/faro/receiver/testdata/payload.json
+++ b/internal/component/faro/receiver/testdata/payload.json
@@ -285,7 +285,7 @@
       "userAgent": "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0",
       "language": "en-US",
       "viewportWidth": "1920",
-      "viewportHeight": "1080",
+      "viewportHeight": "1080"
     },
     "view": {
       "name": "foobar"

--- a/internal/component/faro/receiver/testdata/payload.json
+++ b/internal/component/faro/receiver/testdata/payload.json
@@ -281,11 +281,11 @@
       "name": "chrome",
       "version": "88.12.1",
       "os": "linux",
-      "mobile": false
+      "mobile": false,
       "userAgent": "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0",
-			"language": "en",
-			"viewPortWidth": "1920",
-			"viewPortHeight": "1080",
+      "language": "en",
+      "viewPortWidth": "1920",
+      "viewPortHeight": "1080",
     },
     "view": {
       "name": "foobar"


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

a few fields are missing in the struct which is used to read the meta.browser object that faro sends, which results in that information being lost. https://github.com/grafana/faro-web-sdk/blob/v1.10.2/packages/core/src/metas/types.ts#L60-L70


#### Which issue(s) this PR fixes

fixes #1832

#### Notes to the Reviewer

i did not do the work for properly parsing `NavigatorUABrandVersion[] | string`, since it's more work, and i mostly really just want viewportWidth and viewportHeight. since that field is already being ignored right now, it should be safe to not do until maybe someone else who needs it can add it. 


#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
