### PR TITLE
Remove Pyroscope scrape loops for no longer active targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Main (unreleased)
 
 - Fixed a bug in `import.git` which caused a `"non-fast-forward update"` error message. (@ptodev)
 
+- `pyroscope.scrape` no longer tries to scrape endpoints which are not active targets anymore. (@wildum @mattdurham @dehaansa @ptodev)
+
 ### Other changes
 
 - Small fix in UI stylesheet to fit more content into visible table area. (@defanator)

--- a/internal/component/pyroscope/scrape/manager.go
+++ b/internal/component/pyroscope/scrape/manager.go
@@ -112,6 +112,14 @@ func (m *Manager) reload() {
 			wg.Done()
 		}(m.targetsGroups[setName], groups)
 	}
+
+	for tgName, sp := range m.targetsGroups {
+		if _, ok := m.targetSets[tgName]; !ok {
+			sp.stop()
+			delete(m.targetsGroups, tgName)
+		}
+	}
+
 	wg.Wait()
 }
 

--- a/internal/component/pyroscope/scrape/manager_test.go
+++ b/internal/component/pyroscope/scrape/manager_test.go
@@ -11,9 +11,12 @@ import (
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 )
 
 func TestManager(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
+
 	reloadInterval = time.Millisecond
 
 	m := NewManager(Options{}, pyroscope.AppendableFunc(func(ctx context.Context, labels labels.Labels, samples []*pyroscope.RawSample) error {
@@ -61,6 +64,8 @@ func TestManager(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return len(m.TargetsActive()["group2"]) == 10
 	}, time.Second, 10*time.Millisecond)
+
+	require.Equal(t, 1, len(m.targetsGroups))
 
 	for _, ts := range m.targetsGroups {
 		require.Equal(t, 1*time.Second, ts.config.ScrapeInterval)


### PR DESCRIPTION
#### PR Description

There is a bug which causes pyroscope.scrape to keep trying to scrape targets even if they're no longer active. We can also see error logs in internal clusters, but we hadn't noticed them before.

Credits in the changelog go to @mattdurham, @wildum, and @dehaansa. We have a squad meeting once every few weeks for bug fixing and socializing. We chose this bug for today's meeting, so I'm adding all the folks from the meeting to the changelog :)

#### Which issue(s) this PR fixes

Fixes #1789

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
