### PR TITLE
remotecfg: support not_modified response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ Main (unreleased)
 
 - Support TLS client settings for clustering (@tiagorossig)
 
+- Add support for `not_modified` response in `remotecfg`. (@spartan0x117)
+
 v1.4.2
 -----------------
 

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/google/renameio/v2 v2.0.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
-	github.com/grafana/alloy-remote-config v0.0.8
+	github.com/grafana/alloy-remote-config v0.0.9
 	github.com/grafana/alloy/syntax v0.1.0
 	github.com/grafana/beyla v1.8.2
 	github.com/grafana/catchpoint-prometheus-exporter v0.0.0-20240606062944-e55f3668661d

--- a/go.sum
+++ b/go.sum
@@ -1192,6 +1192,8 @@ github.com/gosnmp/gosnmp v1.37.0/go.mod h1:GDH9vNqpsD7f2HvZhKs5dlqSEcAS6s6Qp099o
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
 github.com/grafana/alloy-remote-config v0.0.8 h1:bQTk7rkR1Hykss+bfMv7CucpF/fRsi2lixJHfIcOMnc=
 github.com/grafana/alloy-remote-config v0.0.8/go.mod h1:kHE1usYo2WAVCikQkIXuoG1Clz8BSdiz3kF+DZSCQ4k=
+github.com/grafana/alloy-remote-config v0.0.9 h1:gy34SxZ8Iq/HrDTIFZi80+8BlT+FnJhKiP9mryHNEUE=
+github.com/grafana/alloy-remote-config v0.0.9/go.mod h1:kHE1usYo2WAVCikQkIXuoG1Clz8BSdiz3kF+DZSCQ4k=
 github.com/grafana/beyla v1.8.2 h1:AkHpUFnfX2SaRsLZkMtC8BPRtfEZRfP7A7ewRr3ruS0=
 github.com/grafana/beyla v1.8.2/go.mod h1:82jt8ZJA50qq7R5Ri8tHcGFJ6vJmqDexprVTYSdu6cY=
 github.com/grafana/cadvisor v0.0.0-20240729082359-1f04a91701e2 h1:ju6EcY2aEobeBg185ETtFCKj5WzaQ48qfkbsSRRQrF4=

--- a/internal/service/remotecfg/remotecfg.go
+++ b/internal/service/remotecfg/remotecfg.go
@@ -428,11 +428,13 @@ func (s *Service) getAPIConfig() ([]byte, error) {
 		return nil, err
 	}
 	s.metrics.getConfigTime.Observe(time.Since(start).Seconds())
-	if gcr.Msg.Hash != "" {
-		s.remoteHash = gcr.Msg.Hash
-	}
 	if gcr.Msg.NotModified {
 		return nil, errNotModified
+	}
+	if gcr.Msg.Hash != "" {
+		s.mut.Lock()
+		s.remoteHash = gcr.Msg.Hash
+		s.mut.Unlock()
 	}
 	return []byte(gcr.Msg.GetContent()), nil
 }

--- a/internal/service/remotecfg/remotecfg_test.go
+++ b/internal/service/remotecfg/remotecfg_test.go
@@ -48,7 +48,7 @@ func TestOnDiskCache(t *testing.T) {
 	client.registerCollectorFunc = buildRegisterCollectorFunc(&registerCalled)
 
 	// Mock client to return an unparseable response.
-	client.getConfigFunc = buildGetConfigHandler("unparseable config")
+	client.getConfigFunc = buildGetConfigHandler("unparseable config", "", false)
 
 	// Write the cache contents, and run the service.
 	err := os.WriteFile(env.svc.dataPath, []byte(cacheContents), 0644)
@@ -84,7 +84,7 @@ func TestAPIResponse(t *testing.T) {
 	// Mock client to return a valid response.
 	var registerCalled atomic.Bool
 	client.mut.Lock()
-	client.getConfigFunc = buildGetConfigHandler(cfg1)
+	client.getConfigFunc = buildGetConfigHandler(cfg1, "", false)
 	client.registerCollectorFunc = buildRegisterCollectorFunc(&registerCalled)
 	client.mut.Unlock()
 
@@ -103,7 +103,7 @@ func TestAPIResponse(t *testing.T) {
 
 	// Update the response returned by the API.
 	client.mut.Lock()
-	client.getConfigFunc = buildGetConfigHandler(cfg2)
+	client.getConfigFunc = buildGetConfigHandler(cfg2, "", false)
 	client.mut.Unlock()
 
 	// Verify that the service has loaded the updated response.
@@ -114,11 +114,61 @@ func TestAPIResponse(t *testing.T) {
 	cancel()
 }
 
-func buildGetConfigHandler(in string) func(context.Context, *connect.Request[collectorv1.GetConfigRequest]) (*connect.Response[collectorv1.GetConfigResponse], error) {
+func TestAPIResponseNotModified(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	url := "https://example.com/"
+	cfg1 := `loki.process "default" { forward_to = [] }`
+
+	// Create a new service.
+	env := newTestEnvironment(t)
+	require.NoError(t, env.ApplyConfig(fmt.Sprintf(`
+		url            = "%s"
+		poll_frequency = "10s"
+	`, url)))
+
+	client := &collectorClient{}
+	env.svc.asClient = client
+
+	// Mock client to return a valid response.
+	var registerCalled atomic.Bool
+	client.mut.Lock()
+	client.getConfigFunc = buildGetConfigHandler(cfg1, "12345", false)
+	client.registerCollectorFunc = buildRegisterCollectorFunc(&registerCalled)
+	client.mut.Unlock()
+
+	// Run the service.
+	go func() {
+		require.NoError(t, env.Run(ctx))
+	}()
+
+	require.Eventually(t, func() bool { return registerCalled.Load() }, 1*time.Second, 10*time.Millisecond)
+
+	// As the API response was successful, verify that the service has loaded
+	// the valid response.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, getHash([]byte(cfg1)), env.svc.getCfgHash())
+	}, time.Second, 10*time.Millisecond)
+
+	// Update the response returned by the API.
+	client.mut.Lock()
+	client.getConfigFunc = buildGetConfigHandler("", "12345", true)
+	client.mut.Unlock()
+
+	// Verify that the service has loaded the updated response.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, getHash([]byte(cfg1)), env.svc.getCfgHash())
+	}, 1*time.Second, 10*time.Millisecond)
+
+	cancel()
+}
+
+func buildGetConfigHandler(in string, hash string, notModified bool) func(context.Context, *connect.Request[collectorv1.GetConfigRequest]) (*connect.Response[collectorv1.GetConfigResponse], error) {
 	return func(context.Context, *connect.Request[collectorv1.GetConfigRequest]) (*connect.Response[collectorv1.GetConfigResponse], error) {
 		rsp := &connect.Response[collectorv1.GetConfigResponse]{
 			Msg: &collectorv1.GetConfigResponse{
-				Content: in,
+				Content:     in,
+				NotModified: notModified,
+				Hash:        hash,
 			},
 		}
 		return rsp, nil


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Adds support for the remote to send a `hash` to be used to determine if the remote config has changed or not, and to ignore the contents when Alloy receives a `not_modified == true` response.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
- [X] Tests updated
