### PR TITLE
Update prometheus.exporter.cloudwatch.md

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.exporter.cloudwatch.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.cloudwatch.md
@@ -93,7 +93,7 @@ To use all of the integration features, use the following AWS IAM Policy:
 ```alloy
 prometheus.exporter.cloudwatch "queues" {
     sts_region      = "us-east-2"
-    aws_sdk_version_v2 = "false"
+    aws_sdk_version_v2 = false
     discovery {
         type        = "AWS/SQS"
         regions     = ["us-east-2"]


### PR DESCRIPTION
aws_sdk_version_v2 is bool, using quotes return a fatal error on start:

Oct 09 09:33:59 ansible alloy[10120]: Error: /etc/alloy/config.alloy:236:35: "true" should be bool, got string
Oct 09 09:33:59 ansible alloy[10120]: 235 |     sts_region              = "eu-west-1"
Oct 09 09:33:59 ansible alloy[10120]: 236 |         aws_sdk_version_v2      = "true"
Oct 09 09:33:59 ansible alloy[10120]: |                                   ^^^^^^
Oct 09 09:33:59 ansible alloy[10120]: 237 |     discovery_exported_tags = {
Oct 09 09:33:59 ansible alloy[10120]: ts=2024-10-09T07:33:59.106222763Z level=error msg="failed to start reporter" err="context canceled"
Oct 09 09:33:59 ansible alloy[10120]: Error: could not perform the initial load successfully

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
