### PR TITLE
fix: increase timeout for informer on loki.source.podlogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ Main (unreleased)
 
 - `pyroscope.scrape` no longer tries to scrape endpoints which are not active targets anymore. (@wildum @mattdurham @dehaansa @ptodev)
 
+- Fixed a bug with `loki.source.podlogs` not starting in large clusters due to short informer sync timeout. (@elburnetto-intapp) 
+
 ### Other changes
 
 - Small fix in UI stylesheet to fit more content into visible table area. (@defanator)

--- a/internal/component/loki/source/podlogs/controller.go
+++ b/internal/component/loki/source/podlogs/controller.go
@@ -32,7 +32,7 @@ type controller struct {
 }
 
 // Generous timeout period for configuring all informers
-const informerSyncTimeout = 10 * time.Second
+const informerSyncTimeout = 10 * time.Minute
 
 // newController creates a new, unstarted controller. The controller will
 // request a reconcile when the state of Kubernetes changes.


### PR DESCRIPTION
#### PR Description

This PR is to fix #1852 where on a busy Kubernetes cluster, the loki.source.podlogs component times-out after 10 seconds with error 'failed to configure informers: Timeout exceeded while configuring informers. Check the connection to the Kubernetes API is stable and that Alloy has appropriate RBAC permissions'.

#### Which issue(s) this PR fixes

Fixes #1852 

#### Notes to the Reviewer

Similar issue was seen (#233) where the fix was to increase the timeout on the informer. I have validated this works on a busy K8s cluster and resolves the issue of the component not starting.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
