### PR TITLE
Allow the setting of labels for snmp exporter for both target and targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,11 @@ Main (unreleased)
 ### Features
 
 - Add the function `path_join` to the stdlib. (@wildum)
+
 - Add support to `loki.source.syslog` for the RFC3164 format ("BSD syslog"). (@sushain97)
+
 - Add support to `loki.source.api` to be able to extract the tenant from the HTTP `X-Scope-OrgID` header (@QuentinBisson)
+- 
 - (_Experimental_) Add a `loki.secretfilter` component to redact secrets from collected logs.
 
 ### Enhancements
@@ -30,6 +33,9 @@ Main (unreleased)
 - The `cluster.use-discovery-v1` flag is now deprecated since there were no issues found with the v2 cluster discovery mechanism. (@thampiotr)
 
 - Fix an issue where some `faro.receiver` would drop multiple fields defined in `payload.meta.browser`, as fields were defined in the struct.
+
+- SNMP exporter now supports labels in both `target` and `targets` parameters. (@mattdurham)
+
 
 ### Bugfixes
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.snmp.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.snmp.md
@@ -65,6 +65,8 @@ The following labels can be set to a target:
 * `auth`: The SNMP authentication profile to use.
 * `walk_params`: The config to use for this target.
 
+Any other labels defined are added to the scraped metrics.
+
 ## Blocks
 
 The following blocks are supported inside the definition of
@@ -84,12 +86,14 @@ The `target` block defines an individual SNMP target.
 The `target` block may be specified multiple times to define multiple targets. The label of the block is required and will be used in the target's `job` label.
 
 | Name           | Type     | Description                                                           | Default | Required |
-| -------------- | -------- | --------------------------------------------------------------------- | ------- | -------- |
+|----------------| -------- | --------------------------------------------------------------------- | ------- | -------- |
 | `address`      | `string` | The address of SNMP device.                                           |         | yes      |
 | `module`       | `string` | SNMP module to use for polling.                                       | `""`    | no       |
 | `auth`         | `string` | SNMP authentication profile to use.                                   | `""`    | no       |
 | `walk_params`  | `string` | Config to use for this target.                                        | `""`    | no       |
 | `snmp_context` | `string` | Override the `context_name` parameter in the SNMP configuration file. | `""`    | no       |
+| `labels`       | `string` | Override the `context_name` parameter in the SNMP configuration file. | `""`    | no       |
+
 
 ### walk_param block
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.snmp.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.snmp.md
@@ -85,14 +85,14 @@ The following blocks are supported inside the definition of
 The `target` block defines an individual SNMP target.
 The `target` block may be specified multiple times to define multiple targets. The label of the block is required and will be used in the target's `job` label.
 
-| Name           | Type     | Description                                                           | Default | Required |
-|----------------| -------- | --------------------------------------------------------------------- | ------- | -------- |
-| `address`      | `string` | The address of SNMP device.                                           |         | yes      |
-| `module`       | `string` | SNMP module to use for polling.                                       | `""`    | no       |
-| `auth`         | `string` | SNMP authentication profile to use.                                   | `""`    | no       |
-| `walk_params`  | `string` | Config to use for this target.                                        | `""`    | no       |
-| `snmp_context` | `string` | Override the `context_name` parameter in the SNMP configuration file. | `""`    | no       |
-| `labels`       | `string` | Override the `context_name` parameter in the SNMP configuration file. | `""`    | no       |
+| Name           | Type          | Description                                                           | Default | Required |
+|----------------|---------------| --------------------------------------------------------------------- | ------- | -------- |
+| `address`      | `string`      | The address of SNMP device.                                           |         | yes      |
+| `module`       | `string`      | SNMP module to use for polling.                                       | `""`    | no       |
+| `auth`         | `string`      | SNMP authentication profile to use.                                   | `""`    | no       |
+| `walk_params`  | `string`      | Config to use for this target.                                        | `""`    | no       |
+| `snmp_context` | `string`      | Override the `context_name` parameter in the SNMP configuration file. | `""`    | no       |
+| `labels`       | `map(string)` | Override the `context_name` parameter in the SNMP configuration file. | `""`    | no       |
 
 
 ### walk_param block

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.snmp.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.snmp.md
@@ -86,13 +86,13 @@ The `target` block defines an individual SNMP target.
 The `target` block may be specified multiple times to define multiple targets. The label of the block is required and will be used in the target's `job` label.
 
 | Name           | Type          | Description                                                           | Default | Required |
-|----------------|---------------| --------------------------------------------------------------------- | ------- | -------- |
+|----------------|---------------|-----------------------------------------------------------------------| ------- | -------- |
 | `address`      | `string`      | The address of SNMP device.                                           |         | yes      |
 | `module`       | `string`      | SNMP module to use for polling.                                       | `""`    | no       |
 | `auth`         | `string`      | SNMP authentication profile to use.                                   | `""`    | no       |
 | `walk_params`  | `string`      | Config to use for this target.                                        | `""`    | no       |
 | `snmp_context` | `string`      | Override the `context_name` parameter in the SNMP configuration file. | `""`    | no       |
-| `labels`       | `map(string)` | Override the `context_name` parameter in the SNMP configuration file. | `""`    | no       |
+| `labels`       | `map(string)` | Map of labels to apply to all metrics captured from the target.       | `""`    | no       |
 
 
 ### walk_param block
@@ -140,6 +140,9 @@ prometheus.exporter.snmp "example" {
         address     = "192.168.1.2"
         module      = "if_mib"
         walk_params = "public"
+        labels = {
+            "env" = "dev",
+        }
     }
 
     target "network_router_2" {
@@ -231,6 +234,7 @@ prometheus.exporter.snmp "example" {
             "address"     = "192.168.1.2",
             "module"      = "if_mib",
             "walk_params" = "public",
+            "env"         = "dev",
         },
         {
             "name"        = "network_router_2",

--- a/internal/component/prometheus/exporter/snmp/snmp.go
+++ b/internal/component/prometheus/exporter/snmp/snmp.go
@@ -45,6 +45,10 @@ func buildSNMPTargets(baseTarget discovery.Target, args component.Arguments) []d
 
 	for _, tgt := range snmpTargets {
 		target := make(discovery.Target)
+		// Set extra labels first, meaning that any other labels will override
+		for k, v := range tgt.Labels {
+			target[k] = v
+		}
 		for k, v := range baseTarget {
 			target[k] = v
 		}

--- a/internal/component/prometheus/exporter/snmp/snmp.go
+++ b/internal/component/prometheus/exporter/snmp/snmp.go
@@ -3,6 +3,7 @@ package snmp
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/grafana/alloy/internal/component"
@@ -50,6 +51,7 @@ func buildSNMPTargets(baseTarget discovery.Target, args component.Arguments) []d
 
 		target["job"] = target["job"] + "/" + tgt.Name
 		target["__param_target"] = tgt.Target
+		target["__param_name"] = tgt.Name
 		if tgt.Module != "" {
 			target["__param_module"] = tgt.Module
 		}
@@ -71,12 +73,13 @@ func buildSNMPTargets(baseTarget discovery.Target, args component.Arguments) []d
 
 // SNMPTarget defines a target to be used by the exporter.
 type SNMPTarget struct {
-	Name        string `alloy:",label"`
-	Target      string `alloy:"address,attr"`
-	Module      string `alloy:"module,attr,optional"`
-	Auth        string `alloy:"auth,attr,optional"`
-	WalkParams  string `alloy:"walk_params,attr,optional"`
-	SNMPContext string `alloy:"snmp_context,attr,optional"`
+	Name        string            `alloy:",label"`
+	Target      string            `alloy:"address,attr"`
+	Module      string            `alloy:"module,attr,optional"`
+	Auth        string            `alloy:"auth,attr,optional"`
+	WalkParams  string            `alloy:"walk_params,attr,optional"`
+	SNMPContext string            `alloy:"snmp_context,attr,optional"`
+	Labels      map[string]string `alloy:"labels,attr,optional"`
 }
 
 type TargetBlock []SNMPTarget
@@ -92,6 +95,7 @@ func (t TargetBlock) Convert() []snmp_exporter.SNMPTarget {
 			Auth:        target.Auth,
 			WalkParams:  target.WalkParams,
 			SNMPContext: target.SNMPContext,
+			Labels:      target.Labels,
 		})
 	}
 	return targets
@@ -134,6 +138,22 @@ type Arguments struct {
 
 type TargetsList []map[string]string
 
+// target technically isnt required but its so overloaded within snmp I dont want it leaking.
+var ignoredLabels = []string{"name", "module", "auth", "walk_params", "snmp_context", "address", "__address__", "target"}
+
+func createUserLabels(t map[string]string) map[string]string {
+	// Need to create labels.
+	userLabels := make(map[string]string)
+	for k, v := range t {
+		// ignore the special labels
+		if slices.Contains(ignoredLabels, k) {
+			continue
+		}
+		userLabels[k] = v
+	}
+	return userLabels
+}
+
 func (t TargetsList) Convert() []snmp_exporter.SNMPTarget {
 	targets := make([]snmp_exporter.SNMPTarget, 0, len(t))
 	for _, target := range t {
@@ -145,6 +165,7 @@ func (t TargetsList) Convert() []snmp_exporter.SNMPTarget {
 			Auth:        target["auth"],
 			WalkParams:  target["walk_params"],
 			SNMPContext: target["snmp_context"],
+			Labels:      createUserLabels(target),
 		})
 	}
 	return targets
@@ -161,6 +182,7 @@ func (t TargetsList) convert() []SNMPTarget {
 			Auth:        target["auth"],
 			WalkParams:  target["walk_params"],
 			SNMPContext: target["snmp_context"],
+			Labels:      createUserLabels(target),
 		})
 	}
 	return targets

--- a/internal/converter/internal/staticconvert/internal/build/snmp_exporter.go
+++ b/internal/converter/internal/staticconvert/internal/build/snmp_exporter.go
@@ -25,6 +25,9 @@ func toSnmpExporter(config *snmp_exporter.Config) *snmp.Arguments {
 		target["auth"] = t.Auth
 		target["walk_params"] = t.WalkParams
 		target["snmp_context"] = t.SNMPContext
+		for k, v := range t.Labels {
+			target[k] = v
+		}
 		targets = append(targets, target)
 	}
 

--- a/internal/static/integrations/snmp_exporter/snmp.go
+++ b/internal/static/integrations/snmp_exporter/snmp.go
@@ -36,21 +36,21 @@ func Handler(w http.ResponseWriter, r *http.Request, logger log.Logger, snmpCfg 
 	for _, target := range targets {
 		snmpTargets[target.Name] = target
 	}
-
-	var target string
-	targetName := query.Get("target")
-	if len(query["target"]) != 1 || targetName == "" {
+	address := query.Get("target")
+	if len(query["target"]) != 1 || address == "" {
 		http.Error(w, "'target' parameter must be specified once", http.StatusBadRequest)
 		return
 	}
 
-	t, ok := snmpTargets[targetName]
+	// We only started adding name recently so it may not exist, if it doesnt use target/address.
+	name := query.Get("name")
+	t, ok := snmpTargets[name]
 	if ok {
-		target = t.Target
-	} else {
-		target = targetName
+		address = t.Target
 	}
 
+	// These parameters are passed into the query if it is a known Target so no need to look them up in snmpTargets
+	// Labels are the only special case because encoding them could be painful.
 	moduleName := query.Get("module")
 	if len(query["module"]) > 1 {
 		http.Error(w, "'module' parameter must only be specified once", http.StatusBadRequest)
@@ -109,9 +109,9 @@ func Handler(w http.ResponseWriter, r *http.Request, logger log.Logger, snmpCfg 
 			http.Error(w, fmt.Sprintf("Unknown walk_params '%s'", walkParams), http.StatusBadRequest)
 			return
 		}
-		logger = log.With(logger, "module", moduleName, "target", target, "walk_params", walkParams)
+		logger = log.With(logger, "module", moduleName, "address", address, "walk_params", walkParams)
 	} else {
-		logger = log.With(logger, "module", moduleName, "target", target)
+		logger = log.With(logger, "module", moduleName, "target", address)
 	}
 	var nmodules []*collector.NamedModule
 	nmodules = append(nmodules, collector.NewNamedModule(moduleName, module))
@@ -119,8 +119,16 @@ func Handler(w http.ResponseWriter, r *http.Request, logger log.Logger, snmpCfg 
 
 	start := time.Now()
 	registry := prometheus.NewRegistry()
-	c := collector.New(r.Context(), target, authName, snmpContext, auth, nmodules, logger, NewSNMPMetrics(registry), concurrency, false)
-	registry.MustRegister(c)
+	var c *collector.Collector
+	if len(t.Labels) > 0 {
+		wrapped := prometheus.WrapRegistererWith(t.Labels, registry)
+		c = collector.New(r.Context(), address, authName, snmpContext, auth, nmodules, logger, NewSNMPMetrics(wrapped), concurrency, false)
+		wrapped.MustRegister(c)
+	} else {
+		c = collector.New(r.Context(), address, authName, snmpContext, auth, nmodules, logger, NewSNMPMetrics(registry), concurrency, false)
+		registry.MustRegister(c)
+	}
+
 	// Delegate http serving to Prometheus client library, which will call collector.Collect.
 	h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
 	h.ServeHTTP(w, r)

--- a/internal/static/integrations/snmp_exporter/snmp_exporter.go
+++ b/internal/static/integrations/snmp_exporter/snmp_exporter.go
@@ -192,7 +192,6 @@ func (i *Integration) ScrapeConfigs() []config.ScrapeConfig {
 	for _, target := range i.sh.cfg.SnmpTargets {
 		queryParams := url.Values{}
 		queryParams.Add("target", target.Target)
-		queryParams.Add("name", target.Name)
 		if target.Module != "" {
 			queryParams.Add("module", target.Module)
 		}

--- a/internal/static/integrations/snmp_exporter/snmp_exporter.go
+++ b/internal/static/integrations/snmp_exporter/snmp_exporter.go
@@ -33,6 +33,7 @@ type SNMPTarget struct {
 	Auth        string `yaml:"auth"`
 	WalkParams  string `yaml:"walk_params,omitempty"`
 	SNMPContext string `yaml:"snmp_context,omitempty"`
+	Labels      map[string]string
 }
 
 // Config configures the SNMP integration.
@@ -191,6 +192,7 @@ func (i *Integration) ScrapeConfigs() []config.ScrapeConfig {
 	for _, target := range i.sh.cfg.SnmpTargets {
 		queryParams := url.Values{}
 		queryParams.Add("target", target.Target)
+		queryParams.Add("name", target.Name)
 		if target.Module != "" {
 			queryParams.Add("module", target.Module)
 		}


### PR DESCRIPTION
#### PR Description

This allows setting of labels in both the target and targets fields

#### Which issue(s) this PR fixes

Fixes #1324

#### Notes to the Reviewer

#### PR Checklist


- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated

