### PR TITLE
fix: Disable generic API key rule by default in loki.secretfilter

### DIFF
--- a/docs/sources/reference/components/loki/loki.secretfilter.md
+++ b/docs/sources/reference/components/loki/loki.secretfilter.md
@@ -40,7 +40,7 @@ Name                     | Type                 | Description                   
 `gitleaks_config`        | `string`             | Path to the custom `gitleaks.toml` file.        | Embedded Gitleaks file           | no
 `types`                  | `map(string)`        | Types of secret to look for.                    | All types                        | no
 `redact_with`            | `string`             | String to use to redact secrets.                | `<REDACTED-SECRET:$SECRET_NAME>` | no
-`exclude_generic`        | `bool`               | Exclude the generic API key rule.               | `false`                          | no
+`include_generic`        | `bool`               | Include the generic API key rule.               | `false`                          | no
 `allowlist`              | `map(string)`        | List of regexes to allowlist matching secrets.  | `{}`                             | no
 `partial_mask`           | `number`             | Show the first N characters of the secret.      | `0`                              | no
 
@@ -51,7 +51,7 @@ The `types` argument is a map of secret types to look for. The values are used a
 
 The `redact_with` argument is a string that can use variables such as `$SECRET_NAME` (replaced with the matching secret type) and `$SECRET_HASH`(replaced with the sha1 hash of the secret).
 
-The `exclude_generic` argument is a boolean that excludes the generic API key rule in the Gitleaks configuration file if set to `true`.
+The `include_generic` argument is a boolean that includes the generic API key rule in the Gitleaks configuration file if set to `true`. It is disabled by default because it can generate false positives.
 
 The `allowlist` argument is a map of regular expressions to allow matching secrets.
 A secret will not be redacted if it matches any of the regular expressions. The allowlist in the Gitleaks configuration file is also applied.

--- a/docs/sources/reference/components/loki/loki.secretfilter.md
+++ b/docs/sources/reference/components/loki/loki.secretfilter.md
@@ -51,7 +51,7 @@ The `types` argument is a map of secret types to look for. The values are used a
 
 The `redact_with` argument is a string that can use variables such as `$SECRET_NAME` (replaced with the matching secret type) and `$SECRET_HASH`(replaced with the sha1 hash of the secret).
 
-The `include_generic` argument is a boolean that includes the generic API key rule in the Gitleaks configuration file if set to `true`. It is disabled by default because it can generate false positives.
+The `include_generic` argument is a boolean that includes the generic API key rule in the Gitleaks configuration file if set to `true`. It's disabled by default because it can generate false positives.
 
 The `allowlist` argument is a map of regular expressions to allow matching secrets.
 A secret will not be redacted if it matches any of the regular expressions. The allowlist in the Gitleaks configuration file is also applied.

--- a/internal/component/loki/secretfilter/secretfilter.go
+++ b/internal/component/loki/secretfilter/secretfilter.go
@@ -53,7 +53,7 @@ type Arguments struct {
 	GitleaksConfig string              `alloy:"gitleaks_config,attr,optional"` // Path to the custom gitleaks.toml file. If empty, the embedded one is used
 	Types          []string            `alloy:"types,attr,optional"`           // Types of secret to look for (e.g. "aws", "gcp", ...). If empty, all types are included
 	RedactWith     string              `alloy:"redact_with,attr,optional"`     // Redact the secret with this string. Use $SECRET_NAME and $SECRET_HASH to include the secret name and hash
-	ExcludeGeneric bool                `alloy:"exclude_generic,attr,optional"` // Exclude the generic API key rule (default: false)
+	IncludeGeneric bool                `alloy:"include_generic,attr,optional"` // Include the generic API key rule (default: false)
 	AllowList      []string            `alloy:"allowlist,attr,optional"`       // List of regexes to allowlist (on top of what's in the Gitleaks config)
 	PartialMask    uint                `alloy:"partial_mask,attr,optional"`    // Show the first N characters of the secret (default: 0)
 }
@@ -338,7 +338,7 @@ func (c *Component) Update(args component.Arguments) error {
 	}
 
 	// Add the generic API key rule last if needed
-	if ruleGenericApiKey != nil && !c.args.ExcludeGeneric {
+	if ruleGenericApiKey != nil && c.args.IncludeGeneric {
 		c.Rules = append(c.Rules, *ruleGenericApiKey)
 	}
 

--- a/internal/component/loki/secretfilter/secretfilter_test.go
+++ b/internal/component/loki/secretfilter/secretfilter_test.go
@@ -70,9 +70,9 @@ var testConfigs = map[string]string{
 		forward_to = []
 		allowlist = [".*foobar.*"]
 	`,
-	"exclude_generic": `
+	"include_generic": `
 		forward_to = []
-		exclude_generic = true
+		include_generic = true
 	`,
 	"custom_gitleaks_file_simple": `
 		forward_to = []
@@ -230,14 +230,14 @@ var tt = []struct {
 		testConfigs["default"],
 		"",
 		testLogs["simple_secret_generic"].log,
-		replaceSecrets(testLogs["simple_secret_generic"].log, testLogs["simple_secret_generic"].secrets, true, false, defaultRedactionString),
+		testLogs["simple_secret_generic"].log, // Generic secret is excluded so no redaction expected
 	},
 	{
-		"exclude_generic",
-		testConfigs["exclude_generic"],
+		"include_generic",
+		testConfigs["include_generic"],
 		"",
 		testLogs["simple_secret_generic"].log,
-		testLogs["simple_secret_generic"].log, // Generic secret is excluded so no redaction expected
+		replaceSecrets(testLogs["simple_secret_generic"].log, testLogs["simple_secret_generic"].secrets, true, false, defaultRedactionString),
 	},
 	{
 		"custom_gitleaks_file_simple",


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
We have [recently merged](https://github.com/grafana/alloy/pull/1593#event-14380083833) a new component for alloy called `loki.secretfilter`. This component hasn't been released yet and will be in 1.5.0.

However, we have noticed that the inclusion of the `generic-api-key` rule by default creates too many false positive secrets, so we're changing the config so that it's disabled by default.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated -> Don't think it applies since the component hasn't been included in a release yet.
- [X] Documentation added
- [X] Tests updated
