### PR TITLE
feat: add `pyroscope.receive_http` component for profile handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Main (unreleased)
 ### Features
 
 - Add the function `path_join` to the stdlib. (@wildum)
+- Add `pyroscope.receive_http` component to receive and forward Pyroscope profiles (@marcsanmi)
 
 - Add support to `loki.source.syslog` for the RFC3164 format ("BSD syslog"). (@sushain97)
 

--- a/docs/sources/reference/compatibility/_index.md
+++ b/docs/sources/reference/compatibility/_index.md
@@ -394,6 +394,7 @@ The following components, grouped by namespace, _consume_ Pyroscope `ProfilesRec
 {{< collapse title="pyroscope" >}}
 - [pyroscope.ebpf](../components/pyroscope/pyroscope.ebpf)
 - [pyroscope.java](../components/pyroscope/pyroscope.java)
+- [pyroscope.receive_http](../components/pyroscope/pyroscope.receive_http)
 - [pyroscope.scrape](../components/pyroscope/pyroscope.scrape)
 {{< /collapse >}}
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.receive_http.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.receive_http.md
@@ -1,0 +1,119 @@
+---
+canonical: https://grafana.com/docs/alloy/latest/reference/components/pyroscope/pyroscope.receive_http/
+aliases:
+  - ../pyroscope.receive_http/ # /docs/alloy/latest/reference/components/pyroscope.receive_http/
+description: Learn about pyroscope.receive_http
+title: pyroscope.receive_http
+---
+
+# pyroscope.receive_http
+
+`pyroscope.receive_http` listens for HTTP requests containing profiles and forwards them to other components capable of receiving profiles.
+
+The HTTP API exposed is compatible with Pyroscope's [HTTP ingest API](https://grafana.com/docs/pyroscope/latest/configure-server/about-server-api/). This allows `pyroscope.receive_http to act as a proxy for Pyroscope profiles, enabling flexible routing and distribution of profile data.
+
+## Usage
+
+```alloy
+pyroscope.receive_http "LABEL" {
+  http {
+    listen_address = "LISTEN_ADDRESS"
+    listen_port = PORT
+  }
+  forward_to = RECEIVER_LIST
+}
+```
+The component will start an HTTP server supporting the following endpoint:
+
+`POST /ingest` - send profiles to the component, which in turn will be forwarded to the receivers as configured in the `forward_to argument`. The request format must match that of Pyroscope's ingest API.
+
+## Arguments
+
+The following arguments are supported:
+
+Name              | Type          | Description                                     | Default | Required
+------------------|---------------|-------------------------------------------------|---------|---------
+`forward_to` | `list(ProfilesReceiver)` | List of receivers to send profiles to. |         | yes
+
+## Blocks
+
+The following blocks are supported inside the definition of `pyroscope.receive_http`:
+
+Hierarchy | Name | Description                                        | Required
+----------|------|----------------------------------------------------|---------
+`http`    | `http` | Configures the HTTP server that receives requests. | no
+
+### http
+
+The `http` block configures the HTTP server.
+
+You can use the following arguments to configure the `http` block. Any omitted fields take their default values.
+
+Name                   | Type       | Description                                                                                                      | Default  | Required
+-----------------------|------------|------------------------------------------------------------------------------------------------------------------|----------|---------
+`conn_limit`           | `int`      | Maximum number of simultaneous HTTP connections. Defaults to no limit.                                           | `0`      | no
+`listen_address`       | `string`   | Network address on which the server listens for new connections. Defaults to accepting all incoming connections. | `""`     | no
+`listen_port`          | `int`      | Port number on which the server listens for new connections.                                                     | `8080`   | no
+`server_idle_timeout`  | `duration` | Idle timeout for HTTP server.                                                                                    | `"120s"` | no
+`server_read_timeout`  | `duration` | Read timeout for HTTP server.                                                                                    | `"30s"`  | no
+`server_write_timeout` | `duration` | Write timeout for HTTP server.                                                                                   | `"30s"`  | no
+
+## Exported fields
+
+`pyroscope.receive_http` does not export any fields.
+
+## Component health
+
+`pyroscope.receive_http` is reported as unhealthy if it is given an invalid configuration.
+
+## Example
+This example creates a `pyroscope.receive_http` component which starts an HTTP server listening on `0.0.0.0` and port `9999`. The server receives profiles and forwards them to multiple `pyroscope.write` components, which write these profiles to different HTTP endpoints.
+```alloy
+// Receives profiles over HTTP
+pyroscope.receive_http "default" {
+  http {
+    listen_address = "0.0.0.0"
+    listen_port = 9999
+  }
+  forward_to = [pyroscope.write.staging.receiver, pyroscope.write.production.receiver]
+}
+
+// Send profiles to a staging Pyroscope instance
+pyroscope.write "staging" {
+  endpoint {
+    url = "http://pyroscope-staging:4040"
+    headers = {
+      "X-Scope-OrgID" = "squad-1",
+    }
+  }
+}
+
+// Send profiles to a production Pyroscope instance
+pyroscope.write "production" {
+  endpoint {
+    url = "http://pyroscope-production:4040"
+    headers = {
+      "X-Scope-OrgID" = "squad-1",
+    }
+  }
+}
+```
+
+Note: This example demonstrates forwarding to multiple `pyroscope.write` components. Be aware that this configuration will duplicate the received profiles, sending a copy to each configured `pyroscope.write` component.
+
+You can also create multiple `pyroscope.receive_http` components with different configurations to listen on different addresses or ports as needed. This flexibility allows you to design a setup that best fits your infrastructure and profile routing requirements.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`pyroscope.receive_http` can accept arguments from the following components:
+
+- Components that export [Pyroscope `ProfilesReceiver`](../../../compatibility/#pyroscope-profilesreceiver-exporters)
+
+{{< admonition type="note" >}}
+Connecting some components may not be sensible or components may require further configuration to make the connection work correctly.
+Refer to the linked documentation for more details.
+{{< /admonition >}}
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/internal/component/all/all.go
+++ b/internal/component/all/all.go
@@ -139,6 +139,7 @@ import (
 	_ "github.com/grafana/alloy/internal/component/prometheus/scrape"                        // Import prometheus.scrape
 	_ "github.com/grafana/alloy/internal/component/pyroscope/ebpf"                           // Import pyroscope.ebpf
 	_ "github.com/grafana/alloy/internal/component/pyroscope/java"                           // Import pyroscope.java
+	_ "github.com/grafana/alloy/internal/component/pyroscope/receive_http"                   // Import pyroscope.receive_http
 	_ "github.com/grafana/alloy/internal/component/pyroscope/scrape"                         // Import pyroscope.scrape
 	_ "github.com/grafana/alloy/internal/component/pyroscope/write"                          // Import pyroscope.write
 	_ "github.com/grafana/alloy/internal/component/remote/http"                              // Import remote.http

--- a/internal/component/pyroscope/receive_http/receive_http.go
+++ b/internal/component/pyroscope/receive_http/receive_http.go
@@ -1,0 +1,182 @@
+package receive_http
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/gorilla/mux"
+	"github.com/grafana/alloy/internal/component/pyroscope/write"
+	"golang.org/x/sync/errgroup"
+	"io"
+	"net/http"
+	"reflect"
+	"sync"
+
+	"github.com/grafana/alloy/internal/component"
+	fnet "github.com/grafana/alloy/internal/component/common/net"
+	"github.com/grafana/alloy/internal/component/pyroscope"
+	"github.com/grafana/alloy/internal/featuregate"
+	"github.com/grafana/alloy/internal/runtime/logging/level"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:      "pyroscope.receive_http",
+		Stability: featuregate.StabilityGenerallyAvailable,
+		Args:      Arguments{},
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			return New(opts, args.(Arguments))
+		},
+	})
+}
+
+type Arguments struct {
+	Server    *fnet.ServerConfig     `alloy:",squash"`
+	ForwardTo []pyroscope.Appendable `alloy:"forward_to,attr"`
+}
+
+// SetToDefault implements syntax.Defaulter.
+func (a *Arguments) SetToDefault() {
+	*a = Arguments{
+		Server: fnet.DefaultServerConfig(),
+	}
+}
+
+type Component struct {
+	opts        component.Options
+	server      *fnet.TargetServer
+	appendables []pyroscope.Appendable
+	mut         sync.Mutex
+}
+
+func New(opts component.Options, args Arguments) (*Component, error) {
+	c := &Component{
+		opts:        opts,
+		appendables: args.ForwardTo,
+	}
+
+	if err := c.Update(args); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+func (c *Component) Run(ctx context.Context) error {
+	defer func() {
+		c.mut.Lock()
+		defer c.mut.Unlock()
+		c.shutdownServer()
+	}()
+
+	<-ctx.Done()
+	level.Info(c.opts.Logger).Log("msg", "terminating due to context done")
+	return nil
+}
+
+func (c *Component) Update(args component.Arguments) error {
+	newArgs := args.(Arguments)
+
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	c.appendables = newArgs.ForwardTo
+
+	if newArgs.Server == nil {
+		newArgs.Server = fnet.DefaultServerConfig()
+	}
+	if newArgs.Server.HTTP == nil {
+		newArgs.Server.HTTP = &fnet.HTTPConfig{
+			ListenPort:    0,
+			ListenAddress: "127.0.0.1",
+		}
+	}
+
+	serverNeedsRestarting := c.server == nil || !reflect.DeepEqual(c.server, *newArgs.Server.HTTP)
+	if !serverNeedsRestarting {
+		return nil
+	}
+
+	c.shutdownServer()
+
+	srv, err := fnet.NewTargetServer(c.opts.Logger, "pyroscope_receive_http", c.opts.Registerer, newArgs.Server)
+	if err != nil {
+		return fmt.Errorf("failed to create server: %w", err)
+	}
+	c.server = srv
+
+	return c.server.MountAndRun(func(router *mux.Router) {
+		router.HandleFunc("/ingest", c.handleIngest).Methods(http.MethodPost)
+	})
+}
+
+func (c *Component) handleIngest(w http.ResponseWriter, r *http.Request) {
+	c.mut.Lock()
+	appendables := c.appendables
+	c.mut.Unlock()
+
+	// Create a pipe for each appendable
+	pipeWriters := make([]io.Writer, len(appendables))
+	pipeReaders := make([]io.Reader, len(appendables))
+	for i := range appendables {
+		pr, pw := io.Pipe()
+		pipeReaders[i] = pr
+		pipeWriters[i] = pw
+	}
+	mw := io.MultiWriter(pipeWriters...)
+
+	// Create an errgroup with the timeout context
+	g, ctx := errgroup.WithContext(r.Context())
+
+	// Start copying the request body to all pipes
+	g.Go(func() error {
+		defer func() {
+			for _, pw := range pipeWriters {
+				pw.(io.WriteCloser).Close()
+			}
+		}()
+		_, err := io.Copy(mw, r.Body)
+		return err
+	})
+
+	// Process each appendable
+	for i, appendable := range appendables {
+		g.Go(func() error {
+			defer pipeReaders[i].(io.ReadCloser).Close()
+
+			profile := &pyroscope.IncomingProfile{
+				Body:    io.NopCloser(pipeReaders[i]),
+				Headers: r.Header.Clone(),
+				URL:     r.URL,
+			}
+
+			err := appendable.Appender().AppendIngest(ctx, profile)
+			if err != nil {
+				level.Error(c.opts.Logger).Log("msg", "Failed to append profile", "appendable", i, "err", err)
+				return err
+			}
+			level.Debug(c.opts.Logger).Log("msg", "Profile appended successfully", "appendable", i)
+			return nil
+		})
+	}
+
+	err := g.Wait()
+	if err != nil {
+		var writeErr *write.PyroscopeWriteError
+		if errors.As(err, &writeErr) {
+			http.Error(w, http.StatusText(writeErr.StatusCode), writeErr.StatusCode)
+		} else {
+			level.Error(c.opts.Logger).Log("msg", "Failed to process request", "err", err)
+			http.Error(w, "Failed to process request", http.StatusInternalServerError)
+		}
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (c *Component) shutdownServer() {
+	if c.server != nil {
+		c.server.StopAndShutdown()
+		c.server = nil
+	}
+}

--- a/internal/component/pyroscope/receive_http/receive_http_test.go
+++ b/internal/component/pyroscope/receive_http/receive_http_test.go
@@ -1,0 +1,289 @@
+package receive_http
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/phayes/freeport"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/internal/component"
+	fnet "github.com/grafana/alloy/internal/component/common/net"
+	"github.com/grafana/alloy/internal/component/pyroscope"
+	"github.com/grafana/alloy/internal/util"
+)
+
+// TestForwardsProfiles verifies the behavior of the pyroscope.receive_http component
+// under various scenarios. It tests different profile sizes, HTTP methods, paths,
+// query parameters, and error conditions to ensure correct forwarding behavior
+// and proper error handling.
+func TestForwardsProfiles(t *testing.T) {
+	tests := []struct {
+		name             string
+		profileSize      int
+		method           string
+		path             string
+		queryParams      string
+		headers          map[string]string
+		appendableErrors []error
+		expectedStatus   int
+		expectedForwards int
+	}{
+		{
+			name:             "Small profile",
+			profileSize:      1024, // 1KB
+			method:           "POST",
+			path:             "/ingest",
+			queryParams:      "name=test_app_1&from=1234567890&until=1234567900",
+			headers:          map[string]string{"Content-Type": "application/octet-stream"},
+			appendableErrors: []error{nil, nil},
+			expectedStatus:   http.StatusOK,
+			expectedForwards: 2,
+		},
+		{
+			name:             "Large profile with custom headers",
+			profileSize:      1024 * 1024, // 1MB
+			method:           "POST",
+			path:             "/ingest",
+			queryParams:      "name=test_app_2&from=1234567891&until=1234567901&custom=param1",
+			headers:          map[string]string{"X-Scope-OrgID": "1234"},
+			appendableErrors: []error{nil},
+			expectedStatus:   http.StatusOK,
+			expectedForwards: 1,
+		},
+		{
+			name:             "Invalid method",
+			profileSize:      1024,
+			method:           "GET",
+			path:             "/ingest",
+			queryParams:      "name=test_app_3&from=1234567892&until=1234567902",
+			headers:          map[string]string{},
+			appendableErrors: []error{nil, nil},
+			expectedStatus:   http.StatusMethodNotAllowed,
+			expectedForwards: 0,
+		},
+		{
+			name:             "Invalid query params",
+			profileSize:      1024,
+			method:           "GET",
+			path:             "/ingest",
+			queryParams:      "test=test_app",
+			headers:          map[string]string{},
+			appendableErrors: []error{nil, nil},
+			expectedStatus:   http.StatusMethodNotAllowed,
+			expectedForwards: 0,
+		},
+		{
+			name:             "Invalid path",
+			profileSize:      1024,
+			method:           "POST",
+			path:             "/invalid",
+			queryParams:      "name=test_app_4&from=1234567893&until=1234567903",
+			headers:          map[string]string{"Content-Type": "application/octet-stream"},
+			appendableErrors: []error{nil, nil},
+			expectedStatus:   http.StatusNotFound,
+			expectedForwards: 0,
+		},
+		{
+			name:             "All appendables fail",
+			profileSize:      2048,
+			method:           "POST",
+			path:             "/ingest",
+			queryParams:      "name=test_app_5&from=1234567894&until=1234567904&scenario=all_fail",
+			headers:          map[string]string{"Content-Type": "application/octet-stream", "X-Test": "fail-all"},
+			appendableErrors: []error{fmt.Errorf("error1"), fmt.Errorf("error2")},
+			expectedStatus:   http.StatusInternalServerError,
+			expectedForwards: 2,
+		},
+		{
+			name:             "One appendable fails, one succeeds",
+			profileSize:      4096,
+			method:           "POST",
+			path:             "/ingest",
+			queryParams:      "name=test_app_6&from=1234567895&until=1234567905&scenario=partial_failure",
+			headers:          map[string]string{"X-Custom-ID": "test-6"},
+			appendableErrors: []error{fmt.Errorf("error"), nil},
+			expectedStatus:   http.StatusInternalServerError,
+			expectedForwards: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			appendables := createTestAppendables(tt.appendableErrors)
+			port := startComponent(t, appendables)
+
+			testProfile, resp := sendCustomRequest(t, port, tt.method, tt.path, tt.queryParams, tt.headers, tt.profileSize)
+			require.Equal(t, tt.expectedStatus, resp.StatusCode)
+
+			forwardedCount := countForwardedProfiles(appendables)
+			require.Equal(t, tt.expectedForwards, forwardedCount, "Unexpected number of forwards")
+
+			if tt.expectedForwards > 0 {
+				verifyForwardedProfiles(t, appendables, testProfile, tt.headers, tt.queryParams)
+			}
+		})
+	}
+}
+
+func createTestAppendables(errors []error) []pyroscope.Appendable {
+	var appendables []pyroscope.Appendable
+	for _, err := range errors {
+		appendables = append(appendables, testAppendable(err))
+	}
+	return appendables
+}
+
+func countForwardedProfiles(appendables []pyroscope.Appendable) int {
+	count := 0
+	for _, app := range appendables {
+		if testApp, ok := app.(*testAppender); ok && testApp.lastProfile != nil {
+			count++
+		}
+	}
+	return count
+}
+
+func verifyForwardedProfiles(t *testing.T, appendables []pyroscope.Appendable, expectedProfile []byte, expectedHeaders map[string]string, expectedQueryParams string) {
+	for i, app := range appendables {
+		testApp, ok := app.(*testAppender)
+		require.True(t, ok, "Appendable is not a testAppender")
+
+		if testApp.lastProfile != nil {
+			// Verify profile body
+			body, err := io.ReadAll(testApp.lastProfile.Body)
+			require.NoError(t, err, "Failed to read profile body for appendable %d", i)
+			require.Equal(t, expectedProfile, body, "Profile mismatch for appendable %d", i)
+
+			// Verify headers
+			for key, value := range expectedHeaders {
+				require.Equal(t, value, testApp.lastProfile.Headers.Get(key), "Header mismatch for key %s in appendable %d", key, i)
+			}
+
+			// Verify query parameters
+			expectedParams, err := url.ParseQuery(expectedQueryParams)
+			require.NoError(t, err, "Failed to parse expected query parameters")
+			actualParams := testApp.lastProfile.URL.Query()
+			for key, values := range expectedParams {
+				require.Equal(t, values, actualParams[key], "Query parameter mismatch for key %s in appendable %d", key, i)
+			}
+		}
+	}
+}
+
+func startComponent(t *testing.T, appendables []pyroscope.Appendable) int {
+	port, err := freeport.GetFreePort()
+	require.NoError(t, err)
+
+	args := Arguments{
+		Server: &fnet.ServerConfig{
+			HTTP: &fnet.HTTPConfig{
+				ListenAddress: "localhost",
+				ListenPort:    port,
+			},
+		},
+		ForwardTo: appendables,
+	}
+
+	comp, err := New(testOptions(t), args)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	go func() {
+		require.NoError(t, comp.Run(ctx))
+	}()
+
+	waitForServerReady(t, port)
+	return port
+}
+
+func sendCustomRequest(t *testing.T, port int, method, path, queryParams string, headers map[string]string, profileSize int) ([]byte, *http.Response) {
+	t.Helper()
+	testProfile := make([]byte, profileSize)
+	_, err := rand.Read(testProfile)
+	require.NoError(t, err)
+
+	testURL := fmt.Sprintf("http://localhost:%d%s?%s", port, path, queryParams)
+
+	req, err := http.NewRequest(method, testURL, bytes.NewReader(testProfile))
+	require.NoError(t, err)
+
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+
+	return testProfile, resp
+}
+
+func waitForServerReady(t *testing.T, port int) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		resp, err := http.Get(fmt.Sprintf("http://localhost:%d/", port))
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusNotFound
+	}, 2*time.Second, 100*time.Millisecond, "server did not start in time")
+}
+
+func testAppendable(appendErr error) pyroscope.Appendable {
+	return &testAppender{appendErr: appendErr}
+}
+
+type testAppender struct {
+	appendErr   error
+	lastProfile *pyroscope.IncomingProfile
+}
+
+func (a *testAppender) Appender() pyroscope.Appender {
+	return a
+}
+
+func (a *testAppender) Append(_ context.Context, _ labels.Labels, _ []*pyroscope.RawSample) error {
+	return fmt.Errorf("Append method not implemented for test")
+}
+
+func (a *testAppender) AppendIngest(_ context.Context, profile *pyroscope.IncomingProfile) error {
+	var buf bytes.Buffer
+	tee := io.TeeReader(profile.Body, &buf)
+
+	newProfile := &pyroscope.IncomingProfile{
+		Body:    io.NopCloser(&buf),
+		Headers: profile.Headers,
+		URL:     profile.URL,
+	}
+	a.lastProfile = newProfile
+
+	_, err := io.Copy(io.Discard, tee)
+	if err != nil {
+		return err
+	}
+
+	return a.appendErr
+}
+
+func testOptions(t *testing.T) component.Options {
+	return component.Options{
+		ID:         "pyroscope.receive_http.test",
+		Logger:     util.TestAlloyLogger(t),
+		Registerer: prometheus.NewRegistry(),
+	}
+}

--- a/internal/component/pyroscope/scrape/delta_profiles.go
+++ b/internal/component/pyroscope/scrape/delta_profiles.go
@@ -132,6 +132,11 @@ func (d *deltaAppender) Append(ctx context.Context, lbs labels.Labels, samples [
 	return nil
 }
 
+func (d *deltaAppender) AppendIngest(_ context.Context, _ *pyroscope.IncomingProfile) error {
+	// No-op: AppendIngest is not used in deltaAppender
+	return nil
+}
+
 // computeDelta computes the delta between the given profile and the last
 // data is uncompressed if it is gzip compressed.
 // The returned data is always gzip compressed.


### PR DESCRIPTION

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR introduces the new `pyroscope.receive_http` component, which allows for receiving and forwarding Pyroscope profiles. Key features and changes include:

- HTTP server that listens for profile data on the `/ingest` endpoint
- Ability to forward received profiles to multiple `pyroscope.write` components
- Tests covering various scenarios (profile sizes, error conditions, etc.)
- Updated documentation explaining component usage and configuration options

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

Closes https://github.com/grafana/alloy/issues/270

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
- [X] Documentation added
- [X] Tests updated
- [X] Config converters updated
