### PR TITLE
Fix dead link for PodLogs RelabelConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ Main (unreleased)
 
 - Add support for `not_modified` response in `remotecfg`. (@spartan0x117)
 
+- Fix dead link for RelabelConfig in the PodLog documentation page (@TheoBrigitte)
+
 v1.4.2
 -----------------
 

--- a/docs/sources/reference/components/loki/loki.source.podlogs.md
+++ b/docs/sources/reference/components/loki/loki.source.podlogs.md
@@ -105,7 +105,7 @@ In addition to the meta labels, the following labels are exposed to tell
 * `__pod_uid__`: The UID of the Pod.
 
 [LabelSelector]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#labelselector-v1-meta
-[RelabelConfig]: https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.RelabelConfig
+[RelabelConfig]: https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.RelabelConfig
 
 ## Blocks
 


### PR DESCRIPTION
This PR fixes a dead link on the PodLog page which points to the Prometheus operator relabeling config.
