### PR TITLE
Change config names serialization to persistence.

### DIFF
--- a/internal/component/prometheus/write/queue/component.go
+++ b/internal/component/prometheus/write/queue/component.go
@@ -137,8 +137,8 @@ func (s *Queue) createEndpoints() error {
 			return err
 		}
 		serial, err := serialization.NewSerializer(types.SerializerConfig{
-			MaxSignalsInBatch: uint32(s.args.Serialization.MaxSignalsToBatch),
-			FlushFrequency:    s.args.Serialization.BatchInterval,
+			MaxSignalsInBatch: uint32(s.args.Persistence.MaxSignalsToBatch),
+			FlushFrequency:    s.args.Persistence.BatchInterval,
 		}, fq, stats.UpdateSerializer, s.opts.Logger)
 		if err != nil {
 			return err

--- a/internal/component/prometheus/write/queue/e2e_bench_test.go
+++ b/internal/component/prometheus/write/queue/e2e_bench_test.go
@@ -93,7 +93,7 @@ func newComponentBenchmark(t *testing.B, l log.Logger, url string, exp chan Expo
 		Tracer:     nil,
 	}, Arguments{
 		TTL: 2 * time.Hour,
-		Serialization: Serialization{
+		Persistence: Persistence{
 			MaxSignalsToBatch: 100_000,
 			BatchInterval:     1 * time.Second,
 		},

--- a/internal/component/prometheus/write/queue/e2e_test.go
+++ b/internal/component/prometheus/write/queue/e2e_test.go
@@ -355,7 +355,7 @@ func newComponent(t *testing.T, l *logging.Logger, url string, exp chan Exports,
 		Tracer:     nil,
 	}, Arguments{
 		TTL: 2 * time.Hour,
-		Serialization: Serialization{
+		Persistence: Persistence{
 			MaxSignalsToBatch: 10_000,
 			BatchInterval:     1 * time.Second,
 		},

--- a/internal/component/prometheus/write/queue/types.go
+++ b/internal/component/prometheus/write/queue/types.go
@@ -13,7 +13,7 @@ import (
 func defaultArgs() Arguments {
 	return Arguments{
 		TTL: 2 * time.Hour,
-		Serialization: Serialization{
+		Persistence: Persistence{
 			MaxSignalsToBatch: 10_000,
 			BatchInterval:     5 * time.Second,
 		},
@@ -22,12 +22,12 @@ func defaultArgs() Arguments {
 
 type Arguments struct {
 	// TTL is how old a series can be.
-	TTL           time.Duration    `alloy:"ttl,attr,optional"`
-	Serialization Serialization    `alloy:"serialization,block,optional"`
-	Endpoints     []EndpointConfig `alloy:"endpoint,block"`
+	TTL         time.Duration    `alloy:"ttl,attr,optional"`
+	Persistence Persistence      `alloy:"persistence,block,optional"`
+	Endpoints   []EndpointConfig `alloy:"endpoint,block"`
 }
 
-type Serialization struct {
+type Persistence struct {
 	// The batch size to persist to the file queue.
 	MaxSignalsToBatch int `alloy:"max_signals_to_batch,attr,optional"`
 	// How often to flush to the file queue if BatchSize isn't met.


### PR DESCRIPTION
No changelog since the wal has not been released. Note the underlying code is still called serializer since thats what it does, persistence realistically covers filequeue and serializer.