### PR TITLE
Update snmp doc

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.exporter.snmp.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.snmp.md
@@ -48,7 +48,7 @@ Omitted fields take their default values.
 | `targets`     | `list(map(string))`  | SNMP targets.                                    |         | no       |
 
 The `config_file` argument points to a YAML file defining which snmp_exporter modules to use.
-Refer to [snmp_exporter](https://github.com/prometheus/snmp_exporter#generating-configuration) for details on how to generate a configuration file.
+Refer to [snmp_exporter](https://github.com/prometheus/snmp_exporter/tree/v0.26.0?tab=readme-ov-file#configuration) for details on how to generate a configuration file.
 
 The `config` argument must be a YAML document as string defining which SNMP modules and auths to use.
 `config` is typically loaded by using the exports of another component. For example,

--- a/go.mod
+++ b/go.mod
@@ -164,7 +164,7 @@ require (
 	github.com/prometheus/node_exporter v1.6.0
 	github.com/prometheus/procfs v0.15.1
 	github.com/prometheus/prometheus v0.54.1 // a.k.a. v2.51.2
-	github.com/prometheus/snmp_exporter v0.26.0
+	github.com/prometheus/snmp_exporter v0.26.0 // if you update the snmp_exporter version, make sure to update the links in prometheus.exporter.snmp
 	github.com/prometheus/statsd_exporter v0.22.8
 	github.com/richardartoul/molecule v1.0.1-0.20221107223329-32cfee06a052
 	github.com/rogpeppe/go-internal v1.12.0


### PR DESCRIPTION
It's likely that it won't work if you try to use a snmp.yml file that does not match the snmp exporter version in your Alloy. This change will redirect users to the version of the snmp exporter that matches the one used in Alloy