### PR TITLE
Fix loki integration test

### DIFF
--- a/internal/cmd/integration-tests/tests/read-log-file/read_log_file_test.go
+++ b/internal/cmd/integration-tests/tests/read-log-file/read_log_file_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const query = "http://localhost:3100/loki/api/v1/query?query={test_name=%22read_log_file%22}"
+const query = "http://localhost:3100/loki/api/v1/query_range?query={test_name=%22read_log_file%22}"
 
 func TestReadLogFile(t *testing.T) {
 	var logResponse common.LogResponse


### PR DESCRIPTION
With loki 3.2, query_range should be used instead of query (https://github.com/grafana/loki/pull/13421)