### PR TITLE
Fix changelog for v1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,8 +92,6 @@ v1.4.2
 
 - Fix issue where `loki.source.kubernetes` took into account all labels, instead of specific logs labels. Resulting in duplication. (@mattdurham)
 
-- Fix an issue where some `faro.receiver` would drop multiple fields defined in `payload.meta.browser`, as fields were defined in the struct 
-
 v1.4.1
 -----------------
 


### PR DESCRIPTION
The Faro change is listed, but it's not actually on the release/v1.4 branch.
https://github.com/grafana/alloy/pull/1824 included unintended changes to the changelog which https://github.com/grafana/alloy/pull/1836 then fixed partially, but not completely.