### PR TITLE
Lower the number of items for tests.

### DIFF
--- a/internal/component/prometheus/write/queue/e2e_test.go
+++ b/internal/component/prometheus/write/queue/e2e_test.go
@@ -127,7 +127,7 @@ func TestE2E(t *testing.T) {
 
 const (
 	iterations = 10
-	items      = 10_000
+	items      = 100
 )
 
 func runTest(t *testing.T, add func(index int, appendable storage.Appender) (float64, labels.Labels), test func(samples *safeSlice[prompb.TimeSeries]), metaTest func(meta *safeSlice[prompb.MetricMetadata])) {
@@ -356,7 +356,7 @@ func newComponent(t *testing.T, l *logging.Logger, url string, exp chan Exports,
 	}, Arguments{
 		TTL: 2 * time.Hour,
 		Persistence: Persistence{
-			MaxSignalsToBatch: 10_000,
+			MaxSignalsToBatch: 10,
 			BatchInterval:     1 * time.Second,
 		},
 		Endpoints: []EndpointConfig{{
@@ -365,7 +365,7 @@ func newComponent(t *testing.T, l *logging.Logger, url string, exp chan Exports,
 			Timeout:          20 * time.Second,
 			RetryBackoff:     5 * time.Second,
 			MaxRetryAttempts: 1,
-			BatchCount:       50,
+			BatchCount:       5,
 			FlushInterval:    1 * time.Second,
 			Parallelism:      1,
 		}},


### PR DESCRIPTION
100k items is probably to many for our ci/cd runners. Make it much lower.