### PR TITLE
fix: properly end goroutine in benchmark

### DIFF
--- a/internal/component/prometheus/write/queue/network/benchmark_test.go
+++ b/internal/component/prometheus/write/queue/network/benchmark_test.go
@@ -13,12 +13,11 @@ func BenchmarkMailbox(b *testing.B) {
 	mbx.Start()
 	defer mbx.Stop()
 	go func() {
-		for {
-			<-mbx.ReceiveC()
+		for range mbx.ReceiveC() {
 		}
 	}()
 	ctx := context.Background()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		mbx.Send(ctx, struct{}{})
 	}
 }

--- a/internal/component/prometheus/write/queue/network/benchmark_test.go
+++ b/internal/component/prometheus/write/queue/network/benchmark_test.go
@@ -12,12 +12,21 @@ func BenchmarkMailbox(b *testing.B) {
 	mbx := actor.NewMailbox[struct{}]()
 	mbx.Start()
 	defer mbx.Stop()
+
+	doneC := make(chan any)
+
 	go func() {
-		for range mbx.ReceiveC() {
+		for range b.N {
+			<-mbx.ReceiveC()
 		}
+
+		close(doneC)
 	}()
+
 	ctx := context.Background()
 	for range b.N {
 		mbx.Send(ctx, struct{}{})
 	}
+
+	<-doneC
 }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
For loop used in the benchmark to discard messages was not properly terminated. 
```
for {
	<-mbx.ReceiveC()
}
// <---- this is unreachable code
```
This loop will keep iterating because result from `ReceiveC()` was never checked.

Also, main benchmarks goroutine waits for receiver goroutine to finish.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
