### PR TITLE
docs: Fix broken link in writing exporter components

### DIFF
--- a/docs/developer/writing-exporter-components.md
+++ b/docs/developer/writing-exporter-components.md
@@ -63,7 +63,7 @@ prometheus.exporter.blackbox "example" {
 
 ## Registering the component
 
-In order to make the component visible to Alloy configurations, it needs to be added to [all.go](../../component/all/all.go) file.
+In order to make the component visible to Alloy configurations, it needs to be added to [all.go](../../internal/component/all/all.go) file.
 
 ## Documentation
 


### PR DESCRIPTION


<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

The link for all.go was pointing to an older version before `internal` was added. This updates it so that it points to the approriate file.
