### PR TITLE
add buffer to promise like channel

### DIFF
--- a/internal/component/prometheus/write/queue/network/manager.go
+++ b/internal/component/prometheus/write/queue/network/manager.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+
 	"github.com/go-kit/log"
 	"github.com/grafana/alloy/internal/component/prometheus/write/queue/types"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
@@ -76,8 +77,7 @@ func (s *manager) SendMetadata(ctx context.Context, data *types.TimeSeriesBinary
 }
 
 func (s *manager) UpdateConfig(ctx context.Context, cc types.ConnectionConfig) error {
-	done := make(chan struct{})
-	defer close(done)
+	done := make(chan struct{}, 1)
 	err := s.configInbox.Send(ctx, configCallback{
 		cc:   cc,
 		done: done,


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

add buffer to promise like channel so main goroutine loop doesn't block

#### Which issue(s) this PR fixes

no issue, just performance improvement 

#### Notes to the Reviewer

hey @mattdurham, I was reviewing usage of go-actor and just noticed this so I wanted to share it with you.

in `DoWork` caller is being notified  after config gets updated. because this channel is not buffered this goroutine will get blocked because caller is also blocked at this point (it's waiting on response from `done` channel). main loop will remain blocked until goroutine that made this request is resumed again (which can take time theoretically speaking).

probably the best approach when implementing logic of `DoWork` (aka workers) is to never have it's code blocked unless it is blocked on reading data from inbound mailboxes - in other words blocked because it's waiting on work.  

in this case, this can be easily achieved by making `done`, promise like channel, to have buffer of size 1. this will ensure that `DoWork` can write to it without waiting on this goroutine to be ready. 

--- 

`defer close(done)` was removed because it is unnecessary, after data transmission, this channel is no longer used so no one will care if this channel is closed or not - eventually it will be garbage collected.


#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
