### PR TITLE
Support kubernetes_role argument for prometheus.operator.servicemonitors

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@5681af892cd0f4997658e2bacc62bd0a894cf564
+        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2
         with:
           image-ref: 'grafana/alloy-dev:latest'
           format: 'template'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Main (unreleased)
 
 - Add support to `loki.source.api` to be able to extract the tenant from the HTTP `X-Scope-OrgID` header (@QuentinBisson)
 
+- Add support to `prometheus.operator.servicemonitors` to allow `endpointslice` role. (@yoyosir)
+
 - (_Experimental_) Add a `loki.secretfilter` component to redact secrets from collected logs.
 
 - (_Experimental_) Add a `prometheus.write.queue` component to add an alternative to `prometheus.remote_write`

--- a/docs/sources/reference/components/prometheus/prometheus.operator.servicemonitors.md
+++ b/docs/sources/reference/components/prometheus/prometheus.operator.servicemonitors.md
@@ -32,10 +32,11 @@ prometheus.operator.servicemonitors "LABEL" {
 
 The following arguments are supported:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`forward_to` | `list(MetricsReceiver)` | List of receivers to send scraped metrics to. | | yes
-`namespaces` | `list(string)` | List of namespaces to search for ServiceMonitor resources. If not specified, all namespaces will be searched. || no
+Name | Type | Description                                                                                                                | Default | Required
+---- | ---- |----------------------------------------------------------------------------------------------------------------------------| ------- | --------
+`forward_to` | `list(MetricsReceiver)` | List of receivers to send scraped metrics to.                                                                              | | yes
+`namespaces` | `list(string)` | List of namespaces to search for ServiceMonitor resources. If not specified, all namespaces will be searched.              || no
+`kubernetes_role` | `string` | The kubernetes role used for discovery. Supports `endpoints` or `endpointslice` If not specified, `endpoints` role will be used. || no
 
 ## Blocks
 

--- a/docs/sources/reference/components/prometheus/prometheus.operator.servicemonitors.md
+++ b/docs/sources/reference/components/prometheus/prometheus.operator.servicemonitors.md
@@ -36,7 +36,7 @@ Name | Type | Description                                                       
 ---- | ---- |----------------------------------------------------------------------------------------------------------------------------|-----------| --------
 `forward_to` | `list(MetricsReceiver)` | List of receivers to send scraped metrics to.                                                                              |           | yes
 `namespaces` | `list(string)` | List of namespaces to search for ServiceMonitor resources. If not specified, all namespaces will be searched.              |           | no
-`kubernetes_role` | `string` | The kubernetes role used for discovery. Supports `endpoints` or `endpointslice` If not specified, `endpoints` role will be used. | endpoints | no
+`kubernetes_role` | `string` | The Kubernetes role used for discovery. Supports `endpoints` or `endpointslice` If not specified, the `endpoints` role is used. | endpoints | no
 
 ## Blocks
 

--- a/docs/sources/reference/components/prometheus/prometheus.operator.servicemonitors.md
+++ b/docs/sources/reference/components/prometheus/prometheus.operator.servicemonitors.md
@@ -32,11 +32,11 @@ prometheus.operator.servicemonitors "LABEL" {
 
 The following arguments are supported:
 
-Name | Type | Description                                                                                                                | Default | Required
----- | ---- |----------------------------------------------------------------------------------------------------------------------------| ------- | --------
-`forward_to` | `list(MetricsReceiver)` | List of receivers to send scraped metrics to.                                                                              | | yes
-`namespaces` | `list(string)` | List of namespaces to search for ServiceMonitor resources. If not specified, all namespaces will be searched.              || no
-`kubernetes_role` | `string` | The kubernetes role used for discovery. Supports `endpoints` or `endpointslice` If not specified, `endpoints` role will be used. || no
+Name | Type | Description                                                                                                                | Default   | Required
+---- | ---- |----------------------------------------------------------------------------------------------------------------------------|-----------| --------
+`forward_to` | `list(MetricsReceiver)` | List of receivers to send scraped metrics to.                                                                              |           | yes
+`namespaces` | `list(string)` | List of namespaces to search for ServiceMonitor resources. If not specified, all namespaces will be searched.              |           | no
+`kubernetes_role` | `string` | The kubernetes role used for discovery. Supports `endpoints` or `endpointslice` If not specified, `endpoints` role will be used. | endpoints | no
 
 ## Blocks
 

--- a/docs/sources/reference/components/prometheus/prometheus.operator.servicemonitors.md
+++ b/docs/sources/reference/components/prometheus/prometheus.operator.servicemonitors.md
@@ -36,7 +36,7 @@ Name | Type | Description                                                       
 ---- | ---- |----------------------------------------------------------------------------------------------------------------------------|-----------| --------
 `forward_to` | `list(MetricsReceiver)` | List of receivers to send scraped metrics to.                                                                              |           | yes
 `namespaces` | `list(string)` | List of namespaces to search for ServiceMonitor resources. If not specified, all namespaces will be searched.              |           | no
-`kubernetes_role` | `string` | The Kubernetes role used for discovery. Supports `endpoints` or `endpointslice` If not specified, the `endpoints` role is used. | endpoints | no
+`kubernetes_role` | `string` | The Kubernetes role used for discovery. Supports `endpoints` or `endpointslice`. | `endpoints` | no
 
 ## Blocks
 

--- a/internal/component/prometheus/operator/common/crdmanager.go
+++ b/internal/component/prometheus/operator/common/crdmanager.go
@@ -470,11 +470,7 @@ func (c *crdManager) addServiceMonitor(sm *promopv1.ServiceMonitor) {
 	mapKeys := []string{}
 	for i, ep := range sm.Spec.Endpoints {
 		var scrapeConfig *config.ScrapeConfig
-		role := promk8s.Role(c.args.KubernetesRole)
-		if role == "" {
-			role = promk8s.RoleEndpoint
-		}
-		scrapeConfig, err = gen.GenerateServiceMonitorConfig(sm, ep, i, role)
+		scrapeConfig, err = gen.GenerateServiceMonitorConfig(sm, ep, i, promk8s.Role(c.args.KubernetesRole))
 		if err != nil {
 			// TODO(jcreixell): Generate Kubernetes event to inform of this error when running `kubectl get <servicemonitor>`.
 			level.Error(c.logger).Log("name", sm.Name, "err", err, "msg", "error generating scrapeconfig from serviceMonitor")

--- a/internal/component/prometheus/operator/common/crdmanager.go
+++ b/internal/component/prometheus/operator/common/crdmanager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	promk8s "github.com/prometheus/prometheus/discovery/kubernetes"
 	"sort"
 	"strings"
 	"sync"
@@ -469,7 +470,11 @@ func (c *crdManager) addServiceMonitor(sm *promopv1.ServiceMonitor) {
 	mapKeys := []string{}
 	for i, ep := range sm.Spec.Endpoints {
 		var scrapeConfig *config.ScrapeConfig
-		scrapeConfig, err = gen.GenerateServiceMonitorConfig(sm, ep, i)
+		role := promk8s.Role(c.args.KubernetesRole)
+		if role == "" {
+			role = promk8s.RoleEndpoint
+		}
+		scrapeConfig, err = gen.GenerateServiceMonitorConfig(sm, ep, i, role)
 		if err != nil {
 			// TODO(jcreixell): Generate Kubernetes event to inform of this error when running `kubectl get <servicemonitor>`.
 			level.Error(c.logger).Log("name", sm.Name, "err", err, "msg", "error generating scrapeconfig from serviceMonitor")

--- a/internal/component/prometheus/operator/configgen/config_gen_servicemonitor_test.go
+++ b/internal/component/prometheus/operator/configgen/config_gen_servicemonitor_test.go
@@ -32,6 +32,7 @@ func TestGenerateServiceMonitorConfig(t *testing.T) {
 		name                   string
 		m                      *promopv1.ServiceMonitor
 		ep                     promopv1.Endpoint
+		role                   promk8s.Role
 		expectedRelabels       string
 		expectedMetricRelabels string
 		expected               *config.ScrapeConfig
@@ -44,7 +45,8 @@ func TestGenerateServiceMonitorConfig(t *testing.T) {
 					Name:      "svcmonitor",
 				},
 			},
-			ep: promopv1.Endpoint{},
+			ep:   promopv1.Endpoint{},
+			role: promk8s.RoleEndpoint,
 			expectedRelabels: util.Untab(`
 				- target_label: __meta_foo
 				  replacement: bar
@@ -110,6 +112,7 @@ func TestGenerateServiceMonitorConfig(t *testing.T) {
 			ep: promopv1.Endpoint{
 				TargetPort: &intstr.IntOrString{StrVal: "http_metrics", Type: intstr.String},
 			},
+			role: promk8s.RoleEndpoint,
 			expectedRelabels: util.Untab(`
 				- target_label: __meta_foo
 				  replacement: bar
@@ -180,6 +183,7 @@ func TestGenerateServiceMonitorConfig(t *testing.T) {
 			ep: promopv1.Endpoint{
 				TargetPort: &intstr.IntOrString{IntVal: 4242, Type: intstr.Int},
 			},
+			role: promk8s.RoleEndpoint,
 			expectedRelabels: util.Untab(`
 				- target_label: __meta_foo
 				  replacement: bar
@@ -230,6 +234,77 @@ func TestGenerateServiceMonitorConfig(t *testing.T) {
 				ServiceDiscoveryConfigs: discovery.Configs{
 					&promk8s.SDConfig{
 						Role: "endpoints",
+
+						NamespaceDiscovery: promk8s.NamespaceDiscovery{
+							IncludeOwnNamespace: false,
+							Names:               []string{"operator"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "role_endpointslice",
+			m: &promopv1.ServiceMonitor{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "operator",
+					Name:      "svcmonitor",
+				},
+			},
+			ep: promopv1.Endpoint{
+				TargetPort: &intstr.IntOrString{IntVal: 4242, Type: intstr.Int},
+			},
+			role: promk8s.RoleEndpointSlice,
+			expectedRelabels: util.Untab(`
+				- target_label: __meta_foo
+				  replacement: bar
+				- source_labels: [job]
+				  target_label: __tmp_prometheus_job_name
+				- source_labels: ["__meta_kubernetes_pod_container_port_number"]
+				  regex: "4242"
+				  action: "keep"
+				- source_labels: [__meta_kubernetes_endpointslice_address_target_kind, __meta_kubernetes_endpointslice_address_target_name]
+				  regex: Node;(.*)
+				  target_label: node
+				  replacement: ${1}
+				- source_labels: [__meta_kubernetes_endpointslice_address_target_kind, __meta_kubernetes_endpointslice_address_target_name]
+				  regex: Pod;(.*)
+				  target_label: pod
+				  action: replace
+				  replacement: ${1}
+				- source_labels: [__meta_kubernetes_namespace]
+				  target_label: namespace
+				- source_labels: [__meta_kubernetes_service_name]
+				  target_label: service
+				- source_labels: [__meta_kubernetes_pod_container_name]
+				  target_label: container
+				- source_labels: [__meta_kubernetes_pod_name]
+				  target_label: pod
+				- source_labels: [__meta_kubernetes_pod_phase]
+				  regex: (Failed|Succeeded)
+				  action: drop
+				- source_labels: [__meta_kubernetes_service_name]
+				  target_label: job
+				  replacement: ${1}
+				- target_label: endpoint
+				  replacement: "4242"
+			`),
+			expected: &config.ScrapeConfig{
+				JobName:           "serviceMonitor/operator/svcmonitor/1",
+				HonorTimestamps:   true,
+				ScrapeInterval:    model.Duration(time.Minute),
+				ScrapeTimeout:     model.Duration(10 * time.Second),
+				ScrapeProtocols:   config.DefaultScrapeProtocols,
+				EnableCompression: true,
+				MetricsPath:       "/metrics",
+				Scheme:            "http",
+				HTTPClientConfig: commonConfig.HTTPClientConfig{
+					FollowRedirects: true,
+					EnableHTTP2:     true,
+				},
+				ServiceDiscoveryConfigs: discovery.Configs{
+					&promk8s.SDConfig{
+						Role: "endpointslice",
 
 						NamespaceDiscovery: promk8s.NamespaceDiscovery{
 							IncludeOwnNamespace: false,
@@ -308,6 +383,7 @@ func TestGenerateServiceMonitorConfig(t *testing.T) {
 					},
 				},
 			},
+			role: promk8s.RoleEndpoint,
 			expectedRelabels: util.Untab(`
 				- target_label: __meta_foo
 				  replacement: bar
@@ -427,7 +503,7 @@ func TestGenerateServiceMonitorConfig(t *testing.T) {
 					{TargetLabel: "__meta_foo", Replacement: "bar"},
 				},
 			}
-			cfg, err := cg.GenerateServiceMonitorConfig(tc.m, tc.ep, 1)
+			cfg, err := cg.GenerateServiceMonitorConfig(tc.m, tc.ep, 1, tc.role)
 			require.NoError(t, err)
 			// check relabel configs separately
 			rlcs := cfg.RelabelConfigs

--- a/internal/component/prometheus/operator/types.go
+++ b/internal/component/prometheus/operator/types.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	promk8s "github.com/prometheus/prometheus/discovery/kubernetes"
 	"time"
 
 	"github.com/grafana/alloy/internal/component/common/config"
@@ -56,6 +57,7 @@ var DefaultArguments = Arguments{
 	Client: kubernetes.ClientArguments{
 		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	},
+	KubernetesRole: string(promk8s.RoleEndpoint),
 }
 
 // SetToDefault implements syntax.Defaulter.

--- a/internal/component/prometheus/operator/types.go
+++ b/internal/component/prometheus/operator/types.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"fmt"
 	promk8s "github.com/prometheus/prometheus/discovery/kubernetes"
 	"time"
 
@@ -69,6 +70,9 @@ func (args *Arguments) SetToDefault() {
 func (args *Arguments) Validate() error {
 	if len(args.Namespaces) == 0 {
 		args.Namespaces = []string{apiv1.NamespaceAll}
+	}
+	if args.KubernetesRole != string(promk8s.RoleEndpointSlice) && args.KubernetesRole != string(promk8s.RoleEndpoint) {
+		return fmt.Errorf("only endpoints and endpointslice are supported")
 	}
 	return nil
 }

--- a/internal/component/prometheus/operator/types.go
+++ b/internal/component/prometheus/operator/types.go
@@ -24,6 +24,8 @@ type Arguments struct {
 	// Namespaces to search for monitor resources. Empty implies All namespaces
 	Namespaces []string `alloy:"namespaces,attr,optional"`
 
+	KubernetesRole string `alloy:"kubernetes_role,attr,optional"`
+
 	// LabelSelector allows filtering discovered monitor resources by labels
 	LabelSelector *config.LabelSelector `alloy:"selector,block,optional"`
 


### PR DESCRIPTION
#### PR Description
This PR adds support for endpointslice role in `prometheus.operator.servicemonitors`. Before this PR, the role defaults to endpoints. So there was no way to have servicemonitor to scrape an endpointslice in alloy.

Example config in alloy after this PR.
```
prometheus.operator.servicemonitors "servicemonitors_endpointslice" {
  forward_to = [prometheus.relabel.servicemonitors_filter.receiver]
  selector {
    match_expression {
      key      = "kubernetes-scrape-role"
      operator = "In"
      values   = ["endpointslice"]
    }
  }
  clustering {
      enabled = true
  }

  kubernetes_role = "endpointslice"
}

prometheus.operator.servicemonitors "servicemonitors" {
  forward_to = [prometheus.relabel.servicemonitors_filter.receiver]
  selector {
    match_expression {
      key      = "kubernetes-scrape-role"
      operator = "NotIn"
      values   = ["endpointslice"]
    }
  }

  clustering {
      enabled = true
  }

}
```
 
#### Which issue(s) this PR fixes
Fixes #1714 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
