### PR TITLE
Fix race condition in otelcol component wrappers

### DIFF
--- a/internal/component/otelcol/exporter/exporter.go
+++ b/internal/component/otelcol/exporter/exporter.go
@@ -7,15 +7,6 @@ import (
 	"errors"
 	"os"
 
-	"github.com/grafana/alloy/internal/build"
-	"github.com/grafana/alloy/internal/component"
-	"github.com/grafana/alloy/internal/component/otelcol"
-	otelcolCfg "github.com/grafana/alloy/internal/component/otelcol/config"
-	"github.com/grafana/alloy/internal/component/otelcol/internal/lazycollector"
-	"github.com/grafana/alloy/internal/component/otelcol/internal/lazyconsumer"
-	"github.com/grafana/alloy/internal/component/otelcol/internal/scheduler"
-	"github.com/grafana/alloy/internal/component/otelcol/internal/views"
-	"github.com/grafana/alloy/internal/util/zapadapter"
 	"github.com/prometheus/client_golang/prometheus"
 	otelcomponent "go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configtelemetry"
@@ -26,6 +17,16 @@ import (
 	otelmetric "go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/sdk/metric"
+
+	"github.com/grafana/alloy/internal/build"
+	"github.com/grafana/alloy/internal/component"
+	"github.com/grafana/alloy/internal/component/otelcol"
+	otelcolCfg "github.com/grafana/alloy/internal/component/otelcol/config"
+	"github.com/grafana/alloy/internal/component/otelcol/internal/lazycollector"
+	"github.com/grafana/alloy/internal/component/otelcol/internal/lazyconsumer"
+	"github.com/grafana/alloy/internal/component/otelcol/internal/scheduler"
+	"github.com/grafana/alloy/internal/component/otelcol/internal/views"
+	"github.com/grafana/alloy/internal/util/zapadapter"
 )
 
 // Arguments is an extension of component.Arguments which contains necessary
@@ -108,7 +109,7 @@ var (
 func New(opts component.Options, f otelexporter.Factory, args Arguments, supportedSignals TypeSignal) (*Exporter, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	consumer := lazyconsumer.New(ctx)
+	consumer := lazyconsumer.NewPaused(ctx)
 
 	// Create a lazy collector where metrics from the upstream component will be
 	// forwarded.
@@ -130,7 +131,7 @@ func New(opts component.Options, f otelexporter.Factory, args Arguments, support
 		factory:  f,
 		consumer: consumer,
 
-		sched:     scheduler.New(opts.Logger),
+		sched:     scheduler.NewWithPauseCallbacks(opts.Logger, consumer.Pause, consumer.Resume),
 		collector: collector,
 
 		supportedSignals: supportedSignals,

--- a/internal/component/otelcol/internal/lazyconsumer/lazyconsumer_test.go
+++ b/internal/component/otelcol/internal/lazyconsumer/lazyconsumer_test.go
@@ -1,0 +1,59 @@
+package lazyconsumer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_PauseAndResume(t *testing.T) {
+	c := New(context.Background())
+	require.False(t, c.IsPaused())
+	c.Pause()
+	require.True(t, c.IsPaused())
+	c.Resume()
+	require.False(t, c.IsPaused())
+}
+
+func Test_NewPaused(t *testing.T) {
+	c := NewPaused(context.Background())
+	require.True(t, c.IsPaused())
+	c.Resume()
+	require.False(t, c.IsPaused())
+}
+
+func Test_PauseResume_MultipleCalls(t *testing.T) {
+	c := New(context.Background())
+	require.False(t, c.IsPaused())
+	c.Pause()
+	c.Pause()
+	c.Pause()
+	require.True(t, c.IsPaused())
+	c.Resume()
+	c.Resume()
+	c.Resume()
+	require.False(t, c.IsPaused())
+}
+
+// func Test_PauseResume_Multithreaded(t *testing.T) {
+// TODO(thampiotr): implement this test
+// 	ctx := componenttest.TestContext(t)
+// 	routines := 10
+//
+// 	pauses
+//
+// 	for i := 0; i < routines; i++ {
+// 		go func() {
+// 			for {
+// 				select {
+// 				case <-ctx.Done():
+// 					return
+// 				}
+// 			}
+// 		}()
+// 	}
+//
+//
+//
+// }

--- a/internal/component/otelcol/internal/lazyconsumer/lazyconsumer_test.go
+++ b/internal/component/otelcol/internal/lazyconsumer/lazyconsumer_test.go
@@ -2,13 +2,21 @@ package lazyconsumer
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/goleak"
+
+	"github.com/grafana/alloy/internal/runtime/componenttest"
 )
 
 func Test_PauseAndResume(t *testing.T) {
-	c := New(context.Background())
+	c := New(componenttest.TestContext(t))
 	require.False(t, c.IsPaused())
 	c.Pause()
 	require.True(t, c.IsPaused())
@@ -17,14 +25,14 @@ func Test_PauseAndResume(t *testing.T) {
 }
 
 func Test_NewPaused(t *testing.T) {
-	c := NewPaused(context.Background())
+	c := NewPaused(componenttest.TestContext(t))
 	require.True(t, c.IsPaused())
 	c.Resume()
 	require.False(t, c.IsPaused())
 }
 
 func Test_PauseResume_MultipleCalls(t *testing.T) {
-	c := New(context.Background())
+	c := New(componenttest.TestContext(t))
 	require.False(t, c.IsPaused())
 	c.Pause()
 	c.Pause()
@@ -36,24 +44,118 @@ func Test_PauseResume_MultipleCalls(t *testing.T) {
 	require.False(t, c.IsPaused())
 }
 
-// func Test_PauseResume_Multithreaded(t *testing.T) {
-// TODO(thampiotr): implement this test
-// 	ctx := componenttest.TestContext(t)
-// 	routines := 10
-//
-// 	pauses
-//
-// 	for i := 0; i < routines; i++ {
-// 		go func() {
-// 			for {
-// 				select {
-// 				case <-ctx.Done():
-// 					return
-// 				}
-// 			}
-// 		}()
-// 	}
-//
-//
-//
-// }
+func Test_ConsumeWaitsForResume(t *testing.T) {
+	goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	c := NewPaused(componenttest.TestContext(t))
+	require.True(t, c.IsPaused())
+
+	method := map[string]func(){
+		"ConsumeTraces": func() {
+			_ = c.ConsumeTraces(nil, ptrace.NewTraces())
+		},
+		"ConsumeMetrics": func() {
+			_ = c.ConsumeMetrics(nil, pmetric.NewMetrics())
+		},
+		"ConsumeLogs": func() {
+			_ = c.ConsumeLogs(nil, plog.NewLogs())
+		},
+	}
+
+	for name, fn := range method {
+		t.Run(name, func(t *testing.T) {
+			c.Pause()
+			require.True(t, c.IsPaused())
+
+			started := make(chan struct{})
+			finished := make(chan struct{})
+
+			// Start goroutine that attempts to run Consume* method
+			go func() {
+				started <- struct{}{}
+				fn()
+				finished <- struct{}{}
+			}()
+
+			// Wait to be started
+			select {
+			case <-started:
+			case <-time.After(5 * time.Second):
+				t.Fatal("consumer goroutine never started")
+			}
+
+			// Wait for a bit to ensure the consumer is blocking on Consume* function
+			select {
+			case <-finished:
+				t.Fatal("consumer should not have finished yet - it's paused")
+			case <-time.After(100 * time.Millisecond):
+			}
+
+			// Resume the consumer and verify the Consume* function unblocked
+			c.Resume()
+			select {
+			case <-finished:
+			case <-time.After(5 * time.Second):
+				t.Fatal("consumer should have finished after resuming")
+			}
+
+		})
+	}
+}
+
+func Test_PauseResume_Multithreaded(t *testing.T) {
+	goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	ctx, cancel := context.WithCancel(componenttest.TestContext(t))
+	runs := 500
+	routines := 5
+	allDone := sync.WaitGroup{}
+
+	c := NewPaused(componenttest.TestContext(t))
+	require.True(t, c.IsPaused())
+
+	// Run goroutines that constantly try to call Consume* methods
+	for i := 0; i < routines; i++ {
+		allDone.Add(1)
+		go func() {
+			for {
+				select {
+				case <-ctx.Done():
+					allDone.Done()
+					return
+				default:
+					_ = c.ConsumeLogs(ctx, plog.NewLogs())
+					_ = c.ConsumeMetrics(ctx, pmetric.NewMetrics())
+					_ = c.ConsumeTraces(ctx, ptrace.NewTraces())
+				}
+			}
+		}()
+	}
+
+	// Run goroutines that Pause and then Resume in parallel.
+	// In particular, this verifies we can call .Pause() and .Resume() on an already paused or already resumed consumer.
+	workChan := make(chan struct{}, routines)
+	for i := 0; i < routines; i++ {
+		allDone.Add(1)
+		go func() {
+			for {
+				select {
+				case <-workChan:
+					c.Pause()
+					c.Resume()
+				case <-ctx.Done():
+					allDone.Done()
+					return
+				}
+			}
+		}()
+	}
+
+	for i := 0; i < runs; i++ {
+		workChan <- struct{}{}
+	}
+	cancel()
+
+	allDone.Wait()
+
+	// Should not be paused as last call will always be c.Resume()
+	require.False(t, c.IsPaused())
+}

--- a/internal/component/otelcol/internal/scheduler/scheduler.go
+++ b/internal/component/otelcol/internal/scheduler/scheduler.go
@@ -115,8 +115,9 @@ func (cs *Scheduler) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			return nil
 		case <-cs.newComponentsCh:
-			if !firstRun { // do not pause on first run
-				cs.onPause()
+			if !firstRun {
+				cs.onPause() // do not pause on first run
+			} else {
 				firstRun = false
 			}
 			// Stop the old components before running new scheduled ones.

--- a/internal/component/otelcol/internal/scheduler/scheduler.go
+++ b/internal/component/otelcol/internal/scheduler/scheduler.go
@@ -60,7 +60,8 @@ func New(l log.Logger) *Scheduler {
 
 // NewWithPauseCallbacks is like New, but allows to specify onPause and onResume callbacks. The scheduler is assumed to
 // start paused and only when its components are scheduled, it will call onResume. From then on, each update to running
-// components via Schedule method will trigger a call to onPause and then onResume.
+// components via Schedule method will trigger a call to onPause and then onResume. When scheduler is shutting down, it
+// will call onResume as a last step.
 func NewWithPauseCallbacks(l log.Logger, onPause func(), onResume func()) *Scheduler {
 	return &Scheduler{
 		log:             l,
@@ -104,7 +105,7 @@ func (cs *Scheduler) Run(ctx context.Context) error {
 			cs.onPause()
 		}
 		cs.stopComponents(context.Background(), components...)
-		// We don't resume, as the scheduler is exiting.
+		cs.onResume()
 	}()
 
 	// Wait for a write to cs.newComponentsCh. The initial list of components is

--- a/internal/component/otelcol/internal/scheduler/scheduler_test.go
+++ b/internal/component/otelcol/internal/scheduler/scheduler_test.go
@@ -110,7 +110,7 @@ func TestScheduler(t *testing.T) {
 
 		require.EventuallyWithT(t, func(t *assert.CollectT) {
 			assert.Equal(t, 2, toInt(pauseCalls), "pause callback should be called on shutdown")
-			assert.Equal(t, 2, toInt(resumeCalls), "resume callback should not be called on shutdown")
+			assert.Equal(t, 3, toInt(resumeCalls), "resume callback should be called on shutdown")
 		}, 5*time.Second, 10*time.Millisecond, "pause/resume callbacks not called correctly")
 	})
 

--- a/internal/component/otelcol/internal/scheduler/scheduler_test.go
+++ b/internal/component/otelcol/internal/scheduler/scheduler_test.go
@@ -5,11 +5,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	otelcomponent "go.opentelemetry.io/collector/component"
+	"go.uber.org/atomic"
+
 	"github.com/grafana/alloy/internal/component/otelcol/internal/scheduler"
 	"github.com/grafana/alloy/internal/runtime/componenttest"
 	"github.com/grafana/alloy/internal/util"
-	"github.com/stretchr/testify/require"
-	otelcomponent "go.opentelemetry.io/collector/component"
 )
 
 func TestScheduler(t *testing.T) {
@@ -56,6 +59,59 @@ func TestScheduler(t *testing.T) {
 		require.NoError(t, started.Wait(5*time.Second), "component did not start")
 		cs.Schedule(h)
 		require.NoError(t, stopped.Wait(5*time.Second), "component did not shutdown")
+	})
+
+	t.Run("Pause callbacks are called", func(t *testing.T) {
+		var (
+			pauseCalls  = &atomic.Int32{}
+			resumeCalls = &atomic.Int32{}
+			l           = util.TestLogger(t)
+			cs          = scheduler.NewWithPauseCallbacks(
+				l,
+				func() { pauseCalls.Inc() },
+				func() { resumeCalls.Inc() },
+			)
+			h = scheduler.NewHost(l)
+		)
+		ctx, cancel := context.WithCancel(context.Background())
+
+		// Run our scheduler in the background.
+		go func() {
+			err := cs.Run(ctx)
+			require.NoError(t, err)
+		}()
+
+		// Schedule our component, which should notify the started and stopped
+		// trigger once it starts and stops respectively.
+		component, started, stopped := newTriggerComponent()
+		cs.Schedule(h, component)
+
+		toInt := func(a *atomic.Int32) int { return int(a.Load()) }
+
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			assert.Equal(t, 0, toInt(pauseCalls), "pause callbacks should not be called on first run")
+			assert.Equal(t, 1, toInt(resumeCalls), "resume callback should be called on first run")
+		}, 5*time.Second, 10*time.Millisecond, "pause/resume callbacks not called correctly")
+
+		// Wait for the component to start, and then unschedule all components, which
+		// should cause our running component to terminate.
+		require.NoError(t, started.Wait(5*time.Second), "component did not start")
+		cs.Schedule(h)
+
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			assert.Equal(t, 1, toInt(pauseCalls), "pause callback should be called on second run")
+			assert.Equal(t, 2, toInt(resumeCalls), "resume callback should be called on second run")
+		}, 5*time.Second, 10*time.Millisecond, "pause/resume callbacks not called correctly")
+
+		require.NoError(t, stopped.Wait(5*time.Second), "component did not shutdown")
+
+		// Stop the scheduler
+		cancel()
+
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			assert.Equal(t, 2, toInt(pauseCalls), "pause callback should be called on shutdown")
+			assert.Equal(t, 2, toInt(resumeCalls), "resume callback should not be called on shutdown")
+		}, 5*time.Second, 10*time.Millisecond, "pause/resume callbacks not called correctly")
 	})
 
 	t.Run("Running components get stopped on shutdown", func(t *testing.T) {

--- a/internal/component/otelcol/processor/batch/batch_test.go
+++ b/internal/component/otelcol/processor/batch/batch_test.go
@@ -5,6 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/dskit/backoff"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/processor/batchprocessor"
+
 	"github.com/grafana/alloy/internal/component/otelcol"
 	"github.com/grafana/alloy/internal/component/otelcol/internal/fakeconsumer"
 	"github.com/grafana/alloy/internal/component/otelcol/processor/batch"
@@ -12,10 +17,6 @@ import (
 	"github.com/grafana/alloy/internal/runtime/logging/level"
 	"github.com/grafana/alloy/internal/util"
 	"github.com/grafana/alloy/syntax"
-	"github.com/grafana/dskit/backoff"
-	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/pdata/ptrace"
-	"go.opentelemetry.io/collector/processor/batchprocessor"
 )
 
 // Test performs a basic integration test which runs the
@@ -53,10 +54,7 @@ func Test(t *testing.T) {
 	go func() {
 		exports := ctrl.Exports().(otelcol.ConsumerExports)
 
-		bo := backoff.New(ctx, backoff.Config{
-			MinBackoff: 10 * time.Millisecond,
-			MaxBackoff: 100 * time.Millisecond,
-		})
+		bo := backoff.New(ctx, testBackoffConfig())
 		for bo.Ongoing() {
 			err := exports.Input.ConsumeTraces(ctx, createTestTraces())
 			if err != nil {
@@ -75,6 +73,69 @@ func Test(t *testing.T) {
 		require.FailNow(t, "failed waiting for traces")
 	case tr := <-traceCh:
 		require.Equal(t, 1, tr.SpanCount())
+	}
+}
+
+func Test_Update(t *testing.T) {
+	ctx := componenttest.TestContext(t)
+
+	ctrl, err := componenttest.NewControllerFromID(util.TestLogger(t), "otelcol.processor.batch")
+	require.NoError(t, err)
+
+	args := batch.Arguments{
+		Timeout: 10 * time.Millisecond,
+	}
+	args.SetToDefault()
+
+	// Override our arguments so traces get forwarded to traceCh.
+	traceCh := make(chan ptrace.Traces)
+	args.Output = makeTracesOutput(traceCh)
+
+	go func() {
+		err := ctrl.Run(ctx, args)
+		require.NoError(t, err)
+	}()
+
+	// Verify running and exported
+	require.NoError(t, ctrl.WaitRunning(time.Second), "component never started")
+	require.NoError(t, ctrl.WaitExports(time.Second), "component never exported anything")
+
+	// Update the args
+	args.Timeout = 20 * time.Millisecond
+	require.NoError(t, ctrl.Update(args))
+
+	// Verify running
+	require.NoError(t, ctrl.WaitRunning(time.Second), "component never started")
+
+	// Send traces in the background to our processor.
+	go func() {
+		exports := ctrl.Exports().(otelcol.ConsumerExports)
+
+		bo := backoff.New(ctx, testBackoffConfig())
+		for bo.Ongoing() {
+			err := exports.Input.ConsumeTraces(ctx, createTestTraces())
+			if err != nil {
+				level.Error(util.TestLogger(t)).Log("msg", "failed to send traces", "err", err)
+				bo.Wait()
+				continue
+			}
+			return
+		}
+	}()
+
+	// Wait for our processor to finish and forward data to traceCh.
+	select {
+	case <-time.After(time.Second):
+		require.FailNow(t, "failed waiting for traces")
+	case tr := <-traceCh:
+		require.Equal(t, 1, tr.SpanCount())
+	}
+}
+
+func testBackoffConfig() backoff.Config {
+	return backoff.Config{
+		MinBackoff: 10 * time.Millisecond,
+		MaxBackoff: 100 * time.Millisecond,
 	}
 }
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

We have a general issue with OTel components where consumers may be used before the Start functions in OTel have finished running. This is because in OTel Start functions are non-blocking and sometimes do work to set things up, like it was the case for [batch_processor](https://github.com/open-telemetry/opentelemetry-collector/pull/11594). In Alloy, however we have Run function that is blocking for the lifetime of the component. As soon as it's called, we consider the component Running. In OTel, however, the Start function should be called and exit to consider a component running.

The solution here is to pause the Consumer until we are sure that the OTel component scheduler has called `Start` on all OTel components. The consumer will block any attempts to feed data to it.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

```
thampiotr@MacWork ~/w/alloy (update-otel-112-fix-race)> go test ./internal/component/otelcol/internal/scheduler/ -count 50 -race
ok  	github.com/grafana/alloy/internal/component/otelcol/internal/scheduler	3.543s
thampiotr@MacWork ~/w/alloy (update-otel-112-fix-race)> go test ./internal/component/otelcol/internal/lazyconsumer/ -count 50 -race
ok  	github.com/grafana/alloy/internal/component/otelcol/internal/lazyconsumer	17.495s
```

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [x] Config converters updated
