### PR TITLE
Fix key/pattern logic for the attribute processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Main (unreleased)
 
 - Fixed issue with reloading configuration and prometheus metrics duplication in `prometheus.write.queue`. (@mattdurham)
 
+- Fixed an issue in the `otelcol.processor.attribute` component where the actions `delete` and `hash` could not be used with the `pattern` argument. (@wildum) 
+
 ### Other changes
 
 - Change the stability of the `livedebugging` feature from "experimental" to "generally available". (@wildum)

--- a/internal/component/otelcol/processor/attributes/attributes.go
+++ b/internal/component/otelcol/processor/attributes/attributes.go
@@ -55,6 +55,10 @@ func (args *Arguments) SetToDefault() {
 	args.DebugMetrics.SetToDefault()
 }
 
+func (args *Arguments) Validate() error {
+	return args.Actions.Validate()
+}
+
 // Convert implements processor.Arguments.
 func (args Arguments) Convert() (otelcomponent.Config, error) {
 	input := make(map[string]interface{})

--- a/internal/component/otelcol/processor/attributes/attributes_test.go
+++ b/internal/component/otelcol/processor/attributes/attributes_test.go
@@ -134,6 +134,23 @@ func testRunProcessorWithContext(ctx context.Context, t *testing.T, processorCon
 	processortest.TestRunProcessor(prc)
 }
 
+// Test that the validate function is called. The validation logic for the actions is tested in the otelcol pkg.
+func Test_Validate(t *testing.T) {
+	cfg := `
+		action {
+			value = 111111
+			action = "insert"
+		}
+
+		output {
+			// no-op: will be overridden by test code.
+		}
+	`
+	expectedErr := "validation failed for action block number 1: the action insert requires the key argument to be set"
+	var args attributes.Arguments
+	require.ErrorContains(t, syntax.Unmarshal([]byte(cfg), &args), expectedErr)
+}
+
 func Test_Insert(t *testing.T) {
 	cfg := `
 		action {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

The `key` argument was set as required but it's not required upstream for the action "delete" and "hash".
This PR fixed the issue by introducing a validation step that checks for the key and the pattern argument depending on the action.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
#2000

See the upstream code for reference: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/internal/coreinternal/attraction/attraction.go#L173C1-L186C4

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [na] Documentation added // the doc is not updated because it was matching with upstream
- [x] Tests updated
- [na] Config converters updated
