### PR TITLE
Fix potential deadlock in import statements

### DIFF
--- a/internal/runtime/internal/controller/node_config_import.go
+++ b/internal/runtime/internal/controller/node_config_import.go
@@ -47,12 +47,14 @@ type ImportConfigNode struct {
 
 	importChildrenUpdateChan chan struct{} // used to trigger an update of the running children
 
+	// NOTE: To avoid deadlocks, whenever we need both locks we must always first lock the mut, then healthMut.
 	mut                       sync.RWMutex
 	importedContent           map[string]string
 	importConfigNodesChildren map[string]*ImportConfigNode
 	importChildrenRunning     bool
 	importedDeclares          map[string]ast.Body
 
+	// NOTE: To avoid deadlocks, whenever we need both locks we must always first lock the mut, then healthMut.
 	healthMut     sync.RWMutex
 	evalHealth    component.Health // Health of the last source evaluation
 	runHealth     component.Health // Health of running
@@ -156,10 +158,14 @@ func (cn *ImportConfigNode) setContentHealth(t component.HealthType, msg string)
 //  4. Health reported from the source.
 //  5. Health reported from the nested imports.
 func (cn *ImportConfigNode) CurrentHealth() component.Health {
-	cn.healthMut.RLock()
-	defer cn.healthMut.RUnlock()
+	// NOTE: Since other code paths such asonContentUpdate -> setContentHealth will
+	// also end up acquiring both of these mutexes, it's _essential_ to keep the
+	// order in which they're locked consistent to avoid deadlocks. We must always first
+	// lock the mut, then healthMut.
 	cn.mut.RLock()
 	defer cn.mut.RUnlock()
+	cn.healthMut.RLock()
+	defer cn.healthMut.RUnlock()
 
 	health := component.LeastHealthy(
 		cn.runHealth,


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

There were codepaths where mutexes were acquired in different order, likely causing deadlocks without panics.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
