### PR TITLE
nit: Update otel links that didn't use OTEL_VERSION

### DIFF
--- a/docs/sources/reference/components/otelcol/otelcol.exporter.awss3.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.awss3.md
@@ -112,7 +112,7 @@ Encoding overrides the marshaler if it's present and sets it to use the encoding
 
 Refer to the Open Telemetry [encoding extensions][] documentation for more information.
 
-[encoding]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding
+[encoding]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/extension/encoding
 
 ### Compression
 

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.awss3.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.awss3.md
@@ -110,7 +110,7 @@ Name                    | Type       | Description                              
 
 Encoding overrides the marshaler if it's present and sets it to use the encoding extension defined in the collector configuration.
 
-Refer to the Open Telemetry [encoding extensions][] documentation for more information.
+Refer to the Open Telemetry [encoding extensions][encoding] documentation for more information.
 
 [encoding]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/extension/encoding
 

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.awss3.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.awss3.md
@@ -112,7 +112,7 @@ Encoding overrides the marshaler if it's present and sets it to use the encoding
 
 Refer to the Open Telemetry [encoding extensions][encoding] documentation for more information.
 
-[encoding]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/extension/encoding
+[encoding]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/<OTEL_VERSION>/extension/encoding
 
 ### Compression
 

--- a/docs/sources/reference/components/otelcol/otelcol.processor.filter.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.filter.md
@@ -292,11 +292,11 @@ Some values in the {{< param "PRODUCT_NAME" >}} syntax strings are [escaped][]:
 [OTTL metric context]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/{{< param "OTEL_VERSION" >}}/pkg/ottl/contexts/ottlmetric/README.md
 [OTTL datapoint context]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/{{< param "OTEL_VERSION" >}}/pkg/ottl/contexts/ottldatapoint/README.md
 [OTTL log context]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/{{< param "OTEL_VERSION" >}}/pkg/ottl/contexts/ottllog/README.md
-[OTTL Converter functions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/pkg/ottl/ottlfuncs#converters
-[HasAttrKeyOnDataPoint]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/{{< param "OTEL_VERSION" >}}/processor/filterprocessor/README.md#hasattrkeyondatapoint
-[HasAttrOnDataPoint]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/{{< param "OTEL_VERSION" >}}/processor/filterprocessor/README.md#hasattrondatapoint
-[OTTL booleans]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/pkg/ottl#booleans
-[OTTL math expressions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/pkg/ottl#math-expressions
+[OTTL Converter functions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/<OTEL_VERSION>/pkg/ottl/ottlfuncs#converters
+[HasAttrKeyOnDataPoint]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/<OTEL_VERSION>/processor/filterprocessor/README.md#hasattrkeyondatapoint
+[HasAttrOnDataPoint]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/<OTEL_VERSION>/processor/filterprocessor/README.md#hasattrondatapoint
+[OTTL booleans]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/<OTEL_VERSION>/pkg/ottl#booleans
+[OTTL math expressions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/<OTEL_VERSION>/pkg/ottl#math-expressions
 <!-- START GENERATED COMPATIBLE COMPONENTS -->
 
 ## Compatible components

--- a/docs/sources/reference/components/otelcol/otelcol.processor.filter.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.filter.md
@@ -286,7 +286,7 @@ Some values in the {{< param "PRODUCT_NAME" >}} syntax strings are [escaped][]:
 [escaped]: ../../../../get-started/configuration-syntax/expressions/types_and_values/#strings
 
 
-[OTTL]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/{{< param "OTEL_VERSION" >}}/pkg/ottl/README.md
+[OTTL]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/<OTEL_VERSION>/pkg/ottl/README.md
 [OTTL span context]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/{{< param "OTEL_VERSION" >}}/pkg/ottl/contexts/ottlspan/README.md
 [OTTL spanevent context]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/{{< param "OTEL_VERSION" >}}/pkg/ottl/contexts/ottlspanevent/README.md
 [OTTL metric context]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/{{< param "OTEL_VERSION" >}}/pkg/ottl/contexts/ottlmetric/README.md

--- a/docs/sources/reference/components/otelcol/otelcol.processor.filter.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.filter.md
@@ -287,11 +287,11 @@ Some values in the {{< param "PRODUCT_NAME" >}} syntax strings are [escaped][]:
 
 
 [OTTL]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/<OTEL_VERSION>/pkg/ottl/README.md
-[OTTL span context]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/{{< param "OTEL_VERSION" >}}/pkg/ottl/contexts/ottlspan/README.md
-[OTTL spanevent context]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/{{< param "OTEL_VERSION" >}}/pkg/ottl/contexts/ottlspanevent/README.md
-[OTTL metric context]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/{{< param "OTEL_VERSION" >}}/pkg/ottl/contexts/ottlmetric/README.md
-[OTTL datapoint context]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/{{< param "OTEL_VERSION" >}}/pkg/ottl/contexts/ottldatapoint/README.md
-[OTTL log context]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/{{< param "OTEL_VERSION" >}}/pkg/ottl/contexts/ottllog/README.md
+[OTTL span context]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/<OTEL_VERSION>/pkg/ottl/contexts/ottlspan/README.md
+[OTTL spanevent context]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/<OTEL_VERSION>/pkg/ottl/contexts/ottlspanevent/README.md
+[OTTL metric context]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/<OTEL_VERSION>/pkg/ottl/contexts/ottlmetric/README.md
+[OTTL datapoint context]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/<OTEL_VERSION>/pkg/ottl/contexts/ottldatapoint/README.md
+[OTTL log context]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/<OTEL_VERSION>/pkg/ottl/contexts/ottllog/README.md
 [OTTL Converter functions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/<OTEL_VERSION>/pkg/ottl/ottlfuncs#converters
 [HasAttrKeyOnDataPoint]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/<OTEL_VERSION>/processor/filterprocessor/README.md#hasattrkeyondatapoint
 [HasAttrOnDataPoint]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/<OTEL_VERSION>/processor/filterprocessor/README.md#hasattrondatapoint

--- a/docs/sources/reference/components/otelcol/otelcol.processor.filter.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.filter.md
@@ -286,17 +286,17 @@ Some values in the {{< param "PRODUCT_NAME" >}} syntax strings are [escaped][]:
 [escaped]: ../../../../get-started/configuration-syntax/expressions/types_and_values/#strings
 
 
-[OTTL]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.85.0/pkg/ottl/README.md
+[OTTL]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/{{< param "OTEL_VERSION" >}}/pkg/ottl/README.md
 [OTTL span context]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/{{< param "OTEL_VERSION" >}}/pkg/ottl/contexts/ottlspan/README.md
 [OTTL spanevent context]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/{{< param "OTEL_VERSION" >}}/pkg/ottl/contexts/ottlspanevent/README.md
 [OTTL metric context]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/{{< param "OTEL_VERSION" >}}/pkg/ottl/contexts/ottlmetric/README.md
 [OTTL datapoint context]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/{{< param "OTEL_VERSION" >}}/pkg/ottl/contexts/ottldatapoint/README.md
 [OTTL log context]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/{{< param "OTEL_VERSION" >}}/pkg/ottl/contexts/ottllog/README.md
-[OTTL Converter functions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/ottlfuncs#converters
-[HasAttrKeyOnDataPoint]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/filterprocessor/README.md#hasattrkeyondatapoint
-[HasAttrOnDataPoint]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/filterprocessor/README.md#hasattrondatapoint
-[OTTL booleans]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.85.0/pkg/ottl#booleans
-[OTTL math expressions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.85.0/pkg/ottl#math-expressions
+[OTTL Converter functions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/pkg/ottl/ottlfuncs#converters
+[HasAttrKeyOnDataPoint]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/{{< param "OTEL_VERSION" >}}/processor/filterprocessor/README.md#hasattrkeyondatapoint
+[HasAttrOnDataPoint]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/{{< param "OTEL_VERSION" >}}/processor/filterprocessor/README.md#hasattrondatapoint
+[OTTL booleans]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/pkg/ottl#booleans
+[OTTL math expressions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/pkg/ottl#math-expressions
 <!-- START GENERATED COMPATIBLE COMPONENTS -->
 
 ## Compatible components

--- a/docs/sources/reference/components/otelcol/otelcol.processor.tail_sampling.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.tail_sampling.md
@@ -253,7 +253,7 @@ The following arguments are supported:
 ### ottl_condition block
 
 The `ottl_condition` block configures a policy of type `ottl_condition`. The policy samples based on a given boolean
-[OTTL](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl) condition (span and span event).
+[OTTL](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/pkg/ottl) condition (span and span event).
 
 The following arguments are supported:
 

--- a/docs/sources/reference/components/otelcol/otelcol.processor.tail_sampling.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.tail_sampling.md
@@ -253,7 +253,7 @@ The following arguments are supported:
 ### ottl_condition block
 
 The `ottl_condition` block configures a policy of type `ottl_condition`. The policy samples based on a given boolean
-[OTTL](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/pkg/ottl) condition (span and span event).
+[OTTL](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/<OTEL_VERSION>/pkg/ottl) condition (span and span event).
 
 The following arguments are supported:
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
When editing other docs, I noticed inconsistencies in a few docs using OTEL_VERSION vs main vs an explicit version in their links. While in many cases this is fine, specifically the OTTL functions links could show users functions that are not available in the current Alloy release as OTTL is still being actively developed and acquiring new features relatively quickly.

- [X] Documentation added
