### PR TITLE
fix: Update cluster name to not have extra quotes using helm chart

### DIFF
--- a/operations/helm/charts/alloy/templates/containers/_agent.yaml
+++ b/operations/helm/charts/alloy/templates/containers/_agent.yaml
@@ -16,7 +16,7 @@
     - --cluster.enabled=true
     - --cluster.join-addresses={{ include "alloy.fullname" . }}-cluster
     {{- if $values.clustering.name }}
-    - --cluster.name={{ $values.clustering.name | quote }}
+    - --cluster.name={{ $values.clustering.name }}
     {{- end}}
     {{- end}}
     {{- if $values.stabilityLevel }}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Existing helm chart behavior injects extra quotes into the cluster-name variable.

#### Which issue(s) this PR fixes
https://github.com/grafana/alloy/issues/2134

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer
Tested with various values (alloy, alloy cluster, alloy cluster --cluster.name=fred) and all of them were parsed correctly and showed up in the /metrics list appropriately.
