### PR TITLE
fix: race condition UI remotecfg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Main (unreleased)
 
 - Fixed a race condition that could lead to a deadlock when using `import` statements, which could lead to a memory leak on `/metrics` endpoint of an Alloy instance. (@thampiotr) 
 
+- Fix a race condition where the ui service was dependent on starting after the remotecfg service, which is not guaranteed. (@dehaansa & @erikbaranowski)
+
 ### Other changes
 
 - Change the stability of the `livedebugging` feature from "experimental" to "generally available". (@wildum)

--- a/internal/service/ui/ui.go
+++ b/internal/service/ui/ui.go
@@ -78,10 +78,7 @@ func (s *Service) Data() any {
 func (s *Service) ServiceHandler(host service.Host) (base string, handler http.Handler) {
 	r := mux.NewRouter()
 
-	remotecfgSvc, _ := host.GetService(remotecfg_service.ServiceName)
-	remotecfgHost := remotecfgSvc.Data().(remotecfg_service.Data).Host
-
-	fa := api.NewAlloyAPI(host, remotecfgHost, s.opts.CallbackManager)
+	fa := api.NewAlloyAPI(host, s.opts.CallbackManager)
 	fa.RegisterRoutes(path.Join(s.opts.UIPrefix, "/api/v0/web"), r)
 	ui.RegisterRoutes(s.opts.UIPrefix, r)
 

--- a/internal/web/api/api.go
+++ b/internal/web/api/api.go
@@ -66,7 +66,7 @@ func listComponentsHandlerRemoteCfg(host service.Host) http.HandlerFunc {
 			return
 		}
 
-		listComponentsHandlerInternal(svc.Data().(*remotecfg.Data).Host, w, r)
+		listComponentsHandlerInternal(svc.Data().(remotecfg.Data).Host, w, r)
 	}
 }
 
@@ -108,7 +108,7 @@ func getComponentHandlerRemoteCfg(host service.Host) http.HandlerFunc {
 			return
 		}
 
-		getComponentHandlerInternal(svc.Data().(*remotecfg.Data).Host, w, r)
+		getComponentHandlerInternal(svc.Data().(remotecfg.Data).Host, w, r)
 	}
 }
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
There was a race condition where the http service -> ui service required the remotecfg service to have at least run the first line of its Run() function, but they are all started in parallel in goroutines so there was no guarantee of consistent ordering. See https://github.com/grafana/alloy/issues/2157 for a follow up on that concern, but this PR fixes it by only looking to resolve the remotecfg's Data object during HTTP resolution time, where the service should definitely be available.

#### Which issue(s) this PR fixes
Fixes https://github.com/grafana/alloy/issues/2144

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
