### PR TITLE
add --formula flag to reinstall command

### DIFF
--- a/docs/sources/configure/macos.md
+++ b/docs/sources/configure/macos.md
@@ -47,7 +47,7 @@ To customize the {{< param "PRODUCT_NAME" >}} service on macOS, perform the foll
 1. Reinstall the {{< param "PRODUCT_NAME" >}} Formula by running the following command in a terminal:
 
    ```shell
-   brew reinstall alloy
+   brew reinstall --formula alloy
    ```
 
 1. Restart the {{< param "PRODUCT_NAME" >}} service by running the command in a terminal:


### PR DESCRIPTION
#### PR Description

Fix `brew reinstall` command

#### Which issue(s) this PR fixes

The currently documented `brew reinstall alloy` command will reinstall a different "alloy" product via cask, not Grafana Alloy formula.

This change prevents reinstalling the unrelated alloy cask instead of Alloy.

Likewise, the settings which are updated in `brew edit alloy` will not take effect on a `reinstall` unless the `--formula` flag is used.

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

I don't think this requires a changelog entry but please let me know if I've missed anything.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
