### PR TITLE
fix: fully prevent panic in remotecfg ui

### DIFF
--- a/internal/web/api/api.go
+++ b/internal/web/api/api.go
@@ -113,7 +113,13 @@ func getComponentHandlerRemoteCfg(host service.Host) http.HandlerFunc {
 			return
 		}
 
-		getComponentHandlerInternal(svc.Data().(remotecfg.Data).Host, w, r)
+		data := svc.Data().(remotecfg.Data)
+		if data.Host == nil {
+			http.Error(w, "remote config service startup in progress", http.StatusInternalServerError)
+			return
+		}
+
+		getComponentHandlerInternal(data.Host, w, r)
 	}
 }
 

--- a/internal/web/api/api.go
+++ b/internal/web/api/api.go
@@ -66,7 +66,12 @@ func listComponentsHandlerRemoteCfg(host service.Host) http.HandlerFunc {
 			return
 		}
 
-		listComponentsHandlerInternal(svc.Data().(remotecfg.Data).Host, w, r)
+		data := svc.Data().(remotecfg.Data)
+		if data.Host == nil {
+			http.Error(w, "remote config service startup in progress", http.StatusInternalServerError)
+			return
+		}
+		listComponentsHandlerInternal(data.Host, w, r)
 	}
 }
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
While https://github.com/grafana/alloy/pull/2160 removed the race condition from the Remote Config UI, the possibility was still present to get a panic if you attempted to load the UI immediately on startup. This prevents the panic completely.

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

