### PR TITLE
fix(pyroscope): allow slashes in application name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Main (unreleased)
 - Add relevant golang environment variables to the support bundle (@dehaansa)
 
 ### Bugfixes
-
+- Fixed an issue in the `pyroscope.write` component to allow slashes in application names in the same way it is done in the Pyroscope push API (@marcsanmi)
 - Fixed an issue in the `prometheus.exporter.postgres` component that would leak goroutines when the target was not reachable (@dehaansa)
 - Fixed an issue in the `otelcol.exporter.prometheus` component that would set series value incorrectly for stale metrics (@YusifAghalar)
 

--- a/internal/component/pyroscope/write/parser.go
+++ b/internal/component/pyroscope/write/parser.go
@@ -192,7 +192,7 @@ func validateAppName(n string) error {
 }
 
 func isAppNameRuneAllowed(r rune) bool {
-	return r == '-' || r == '.' || isTagKeyRuneAllowed(r)
+	return r == '-' || r == '.' || r == '/' || isTagKeyRuneAllowed(r)
 }
 
 func isTagKeyReserved(k string) bool {

--- a/internal/component/pyroscope/write/parser_test.go
+++ b/internal/component/pyroscope/write/parser_test.go
@@ -1,0 +1,150 @@
+package write
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected *Key
+		wantErr  bool
+	}{
+		{
+			name:  "basic app name",
+			input: "simple-app",
+			expected: &Key{
+				labels: map[string]string{
+					"__name__": "simple-app",
+				},
+			},
+		},
+		{
+			name:  "app name with slashes and tags",
+			input: "my/service/name{environment=prod,version=1.0}",
+			expected: &Key{
+				labels: map[string]string{
+					"__name__":    "my/service/name",
+					"environment": "prod",
+					"version":     "1.0",
+				},
+			},
+		},
+		{
+			name:  "multiple slashes and special characters",
+			input: "app/service/v1.0-beta/component{region=us-west}",
+			expected: &Key{
+				labels: map[string]string{
+					"__name__": "app/service/v1.0-beta/component",
+					"region":   "us-west",
+				},
+			},
+		},
+		{
+			name:    "empty app name",
+			input:   "{}",
+			wantErr: true,
+		},
+		{
+			name:    "invalid characters in tag key",
+			input:   "my/service/name{invalid@key=value}",
+			wantErr: true,
+		},
+		{
+			name:  "whitespace handling",
+			input: "my/service/name{ tag1 = value1 , tag2 = value2 }",
+			expected: &Key{
+				labels: map[string]string{
+					"__name__": "my/service/name",
+					"tag1":     "value1",
+					"tag2":     "value2",
+				},
+			},
+		},
+		{
+			name:  "dots in service name",
+			input: "my/service.name/v1.0{environment=prod}",
+			expected: &Key{
+				labels: map[string]string{
+					"__name__":    "my/service.name/v1.0",
+					"environment": "prod",
+				},
+			},
+		},
+		{
+			name:  "app name with slashes",
+			input: "my/service/name{}",
+			expected: &Key{
+				labels: map[string]string{
+					"__name__": "my/service/name",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseKey(tt.input)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestKey_Normalized(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      *Key
+		expected string
+	}{
+		{
+			name: "simple normalization",
+			key: &Key{
+				labels: map[string]string{
+					"__name__": "my/service/name",
+				},
+			},
+			expected: "my/service/name{}",
+		},
+		{
+			name: "normalization with tags",
+			key: &Key{
+				labels: map[string]string{
+					"__name__":    "my/service/name",
+					"environment": "prod",
+					"version":     "1.0",
+				},
+			},
+			expected: "my/service/name{environment=prod,version=1.0}",
+		},
+		{
+			name: "tags should be sorted",
+			key: &Key{
+				labels: map[string]string{
+					"__name__": "my/service/name",
+					"c":        "3",
+					"b":        "2",
+					"a":        "1",
+				},
+			},
+			expected: "my/service/name{a=1,b=2,c=3}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.key.Normalized()
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

The change extends tag name validation to allow slashes, enabling hierarchical service naming patterns.

#### Which issue(s) this PR fixes

Closes https://github.com/grafana/alloy/issues/2158

Relates to:
- https://github.com/grafana/pyroscope/pull/3722
- https://github.com/grafana/pyroscope-go/pull/137
- https://github.com/grafana/pyroscope-squad/issues/257

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [X] Tests updated
- [ ] Config converters updated
