### PR TITLE
Fix deadlock due to infinite retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,13 +33,14 @@ Main (unreleased)
 ### Bugfixes
 
 - Fixed an issue in the `prometheus.exporter.postgres` component that would leak goroutines when the target was not reachable (@dehaansa)
+
 - Fixed an issue in the `otelcol.exporter.prometheus` component that would set series value incorrectly for stale metrics (@YusifAghalar)
 
 - Fixed issue with reloading configuration and prometheus metrics duplication in `prometheus.write.queue`. (@mattdurham)
 
 - Fixed an issue in the `otelcol.processor.attribute` component where the actions `delete` and `hash` could not be used with the `pattern` argument. (@wildum)
 
-- Fixed a race condition that could lead to a deadlock when using `import` statements, which could lead to a memory leak on `/metrics` endpoint of an Alloy instance. (@thampiotr) 
+- Fixed a few race conditions that could lead to a deadlock when using `import` statements, which could lead to a memory leak on `/metrics` endpoint of an Alloy instance. (@thampiotr) 
 
 - Fix a race condition where the ui service was dependent on starting after the remotecfg service, which is not guaranteed. (@dehaansa & @erikbaranowski)
 

--- a/internal/runtime/internal/controller/loader.go
+++ b/internal/runtime/internal/controller/loader.go
@@ -10,6 +10,12 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/dskit/backoff"
+	"github.com/hashicorp/go-multierror"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/grafana/alloy/internal/featuregate"
 	"github.com/grafana/alloy/internal/runtime/internal/dag"
 	"github.com/grafana/alloy/internal/runtime/internal/worker"
@@ -19,11 +25,6 @@ import (
 	"github.com/grafana/alloy/syntax/ast"
 	"github.com/grafana/alloy/syntax/diag"
 	"github.com/grafana/alloy/syntax/vm"
-	"github.com/grafana/dskit/backoff"
-	"github.com/hashicorp/go-multierror"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/trace"
 )
 
 // The Loader builds and evaluates ComponentNodes from Alloy blocks.
@@ -92,10 +93,11 @@ func NewLoader(opts LoaderOptions) *Loader {
 		componentNodeManager: NewComponentNodeManager(globals, reg),
 
 		// This is a reasonable default which should work for most cases. If a component is completely stuck, we would
-		// retry and log an error every 10 seconds, at most.
+		// retry and log an error every 10 seconds, at most. We give up after some time to prevent lasting deadlocks.
 		backoffConfig: backoff.Config{
 			MinBackoff: 1 * time.Millisecond,
 			MaxBackoff: 10 * time.Second,
+			MaxRetries: 20, // Give up after 20 attempts - it could be a deadlock instead of an overload.
 		},
 
 		graph: &dag.Graph{},
@@ -736,18 +738,30 @@ func (l *Loader) EvaluateDependants(ctx context.Context, updatedNodes []*QueuedN
 				l.concurrentEvalFn(nodeRef, dependantCtx, tracer, parentRef)
 			})
 			if err != nil {
-				level.Error(l.log).Log(
-					"msg", "failed to submit node for evaluation - Alloy is likely overloaded "+
-						"and cannot keep up with evaluating components - will retry",
+				level.Warn(l.log).Log(
+					"msg", "failed to submit node for evaluation - will retry",
 					"err", err,
 					"node_id", n.NodeID(),
 					"originator_id", parent.Node.NodeID(),
 					"retries", retryBackoff.NumRetries(),
 				)
+				// When backing off, release the mut in case the evaluation requires to interact with the loader itself.
+				l.mut.RUnlock()
 				retryBackoff.Wait()
+				l.mut.RLock()
 			} else {
 				break
 			}
+		}
+		if err != nil && !retryBackoff.Ongoing() {
+			level.Error(l.log).Log(
+				"msg", "retry attempts exhausted when submitting node for evaluation to the worker pool - "+
+					"this could be a deadlock, performance bottleneck or severe overload leading to goroutine starvation",
+				"err", err,
+				"node_id", n.NodeID(),
+				"originator_id", parent.Node.NodeID(),
+				"retries", retryBackoff.NumRetries(),
+			)
 		}
 		span.SetAttributes(attribute.Int("retries", retryBackoff.NumRetries()))
 		if err != nil {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Fixes a deadlock when using modules and running a lot of components (or being starved of CPU).

The symptom was getting a repeated `"failed to submit node for evaluation - Alloy is likely overloaded and cannot keep up with evaluating components - will retry"` logs and slowly growing memory because of getting many calls to `/metrics` that are stuck, until OOMKill in one user's case.

#### Notes to the Reviewer

* When `EvaluateDependants` is called, we submit the dependants of a node that published new exports to a global worker pool for evaluation, so the new export changes can propagate through the graph.
* The worker pool has a queue that is bounded to limit the memory issues.
* In extreme cases where there are, for example, 3k components on one Alloy instance, the worker pool's default queue of 1024 items can become full. 
* We don't error when queue is full, we instead retry with backoff with hope that it's temporary overload due to a slow component evaluation / resource starvation and we will manage later. 
* We retry indefinitely. 
* There are other code paths (see below) that interact with the loader on component evaluation and will require the write mutex to complete. Only once these code paths get the write lock on loader mutex, will they complete and create some more space in the worker pool queue.
* The problem is that these code paths are stuck forever, because we hold on to the loader read mutex while we backoff.  We have a deadlock where the backoff is holding the read mutex, unable to add more tasks to the full queue, but the evaluation tasks queue is not draining because it's waiting for the write mutex.

The code path that grabs the loader write mutex:
- Every custom component [has its own controller and loader](https://github.com/grafana/alloy/blob/b92ac52b9310efee002f280269d822748d7f2a9f/internal/runtime/module.go#L76).
- When these custom components are evaluated (e.g. when the component definition changes because of import.http found a new definition), they [will call LoadBody](https://github.com/grafana/alloy/blob/16814cf9eda7423b3b9b4d53293a5b3a0ac04908/internal/runtime/internal/controller/node_custom_component.go#L205) which will call [loadSource](https://github.com/grafana/alloy/blob/b92ac52b9310efee002f280269d822748d7f2a9f/internal/runtime/module.go#L172) which will [call applyLoaderConfig](https://github.com/grafana/alloy/blob/b92ac52b9310efee002f280269d822748d7f2a9f/internal/runtime/alloy.go#L330) which will call `loader.Apply` which will [grab the write lock of the loader `mut`](https://github.com/grafana/alloy/blob/2422996eb18688cfc700624616735542cce4a1db/internal/runtime/internal/controller/loader.go#L149).

I think that the default queue size of 1024 is still a good default, more than enough for normal, correct operation. So choosing not to expose it as a configuration knob in order to keep Alloy simpler.

I also think that the backoff behaviour doesn't need to be changed other than aborting it after some time. This way we can recover from other deadlocks while printing a good number of error logs in the process.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
