### PR TITLE
fix: Don't panic in loki journal source for re-registered prom metrics

### DIFF
--- a/internal/component/loki/source/journal/internal/target/metrics.go
+++ b/internal/component/loki/source/journal/internal/target/metrics.go
@@ -4,7 +4,10 @@ package target
 // configure and run the targets that can read journal entries and forward them
 // to other loki components.
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/grafana/alloy/internal/util"
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 // Metrics holds a set of journal target metrics.
 type Metrics struct {
@@ -30,10 +33,8 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 	})
 
 	if reg != nil {
-		reg.MustRegister(
-			m.journalErrors,
-			m.journalLines,
-		)
+		m.journalErrors = util.MustRegisterOrGet(reg, m.journalErrors).(*prometheus.CounterVec)
+		m.journalLines = util.MustRegisterOrGet(reg, m.journalLines).(prometheus.Counter)
 	}
 
 	return &m


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Prometheus' MustRegister function panics on a reregistered metric. There is already a utility function to not panic on a reregistered metric in Alloy's internals, and we can use it here to prevent a panic when a component is restarted.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->
Fixes https://github.com/grafana/alloy/issues/2105

#### Notes to the Reviewer
In testing on OSX I was not able to reproduce the issue as the journal source is a no-op.

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

