### PR TITLE
chore: Update uses of prometheus registration to be less likely to panic

### DIFF
--- a/internal/component/faro/receiver/exporters.go
+++ b/internal/component/faro/receiver/exporters.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/alloy/internal/component/faro/receiver/internal/payload"
 	"github.com/grafana/alloy/internal/component/otelcol"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
+	"github.com/grafana/alloy/internal/util"
 )
 
 type exporter interface {
@@ -57,7 +58,10 @@ func newMetricsExporter(reg prometheus.Registerer) *metricsExporter {
 		}),
 	}
 
-	reg.MustRegister(exp.totalLogs, exp.totalExceptions, exp.totalMeasurements, exp.totalEvents)
+	exp.totalLogs = util.MustRegisterOrGet(reg, exp.totalLogs).(prometheus.Counter)
+	exp.totalMeasurements = util.MustRegisterOrGet(reg, exp.totalMeasurements).(prometheus.Counter)
+	exp.totalExceptions = util.MustRegisterOrGet(reg, exp.totalExceptions).(prometheus.Counter)
+	exp.totalEvents = util.MustRegisterOrGet(reg, exp.totalEvents).(prometheus.Counter)
 
 	return exp
 }

--- a/internal/component/faro/receiver/handler.go
+++ b/internal/component/faro/receiver/handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/alloy/internal/component/faro/receiver/internal/payload"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
+	"github.com/grafana/alloy/internal/util"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/cors"
 	"go.opentelemetry.io/collector/client"
@@ -36,7 +37,7 @@ func newHandler(l log.Logger, reg prometheus.Registerer, exporters []exporter) *
 		Name: "faro_receiver_exporter_errors_total",
 		Help: "Total number of errors produced by a receiver exporter",
 	}, []string{"exporter"})
-	reg.MustRegister(errorsTotal)
+	errorsTotal = util.MustRegisterOrGet(reg, errorsTotal).(*prometheus.CounterVec)
 
 	return &handler{
 		log:         l,

--- a/internal/component/faro/receiver/server.go
+++ b/internal/component/faro/receiver/server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/gorilla/mux"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
+	"github.com/grafana/alloy/internal/util"
 	"github.com/grafana/dskit/instrument"
 	"github.com/grafana/dskit/middleware"
 	"github.com/prometheus/client_golang/prometheus"
@@ -46,7 +47,11 @@ func newServerMetrics(reg prometheus.Registerer) *serverMetrics {
 			Help: "Current number of inflight requests.",
 		}, []string{"method", "route"}),
 	}
-	reg.MustRegister(m.requestDuration, m.rxMessageSize, m.txMessageSize, m.inflightRequests)
+
+	m.requestDuration = util.MustRegisterOrGet(reg, m.requestDuration).(*prometheus.HistogramVec)
+	m.rxMessageSize = util.MustRegisterOrGet(reg, m.rxMessageSize).(*prometheus.HistogramVec)
+	m.txMessageSize = util.MustRegisterOrGet(reg, m.txMessageSize).(*prometheus.HistogramVec)
+	m.inflightRequests = util.MustRegisterOrGet(reg, m.inflightRequests).(*prometheus.GaugeVec)
 
 	return m
 }

--- a/internal/component/faro/receiver/sourcemaps.go
+++ b/internal/component/faro/receiver/sourcemaps.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-sourcemap/sourcemap"
 	"github.com/grafana/alloy/internal/component/faro/receiver/internal/payload"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
+	"github.com/grafana/alloy/internal/util"
 	"github.com/grafana/alloy/internal/util/wildcard"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/vincent-petithory/dataurl"
@@ -68,7 +69,9 @@ func newSourceMapMetrics(reg prometheus.Registerer) *sourceMapMetrics {
 		}, []string{"origin", "status"}),
 	}
 
-	reg.MustRegister(m.cacheSize, m.downloads, m.fileReads)
+	m.cacheSize = util.MustRegisterOrGet(reg, m.cacheSize).(*prometheus.CounterVec)
+	m.downloads = util.MustRegisterOrGet(reg, m.downloads).(*prometheus.CounterVec)
+	m.fileReads = util.MustRegisterOrGet(reg, m.fileReads).(*prometheus.CounterVec)
 	return m
 }
 

--- a/internal/component/loki/relabel/metrics.go
+++ b/internal/component/loki/relabel/metrics.go
@@ -1,6 +1,7 @@
 package relabel
 
 import (
+	"github.com/grafana/alloy/internal/util"
 	"github.com/prometheus/client_golang/prometheus"
 	prometheus_client "github.com/prometheus/client_golang/prometheus"
 )
@@ -40,13 +41,11 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 	})
 
 	if reg != nil {
-		reg.MustRegister(
-			m.entriesProcessed,
-			m.entriesOutgoing,
-			m.cacheMisses,
-			m.cacheHits,
-			m.cacheSize,
-		)
+		m.entriesProcessed = util.MustRegisterOrGet(reg, m.entriesProcessed).(prometheus_client.Counter)
+		m.entriesOutgoing = util.MustRegisterOrGet(reg, m.entriesOutgoing).(prometheus_client.Counter)
+		m.cacheMisses = util.MustRegisterOrGet(reg, m.cacheMisses).(prometheus_client.Counter)
+		m.cacheHits = util.MustRegisterOrGet(reg, m.cacheHits).(prometheus_client.Counter)
+		m.cacheSize = util.MustRegisterOrGet(reg, m.cacheSize).(prometheus_client.Gauge)
 	}
 
 	return &m

--- a/internal/component/loki/rules/kubernetes/rules.go
+++ b/internal/component/loki/rules/kubernetes/rules.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/alloy/internal/featuregate"
 	lokiClient "github.com/grafana/alloy/internal/loki/client"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
+	"github.com/grafana/alloy/internal/util"
 	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/instrument"
 	promListers "github.com/prometheus-operator/prometheus-operator/pkg/client/listers/monitoring/v1"
@@ -82,13 +83,11 @@ type metrics struct {
 }
 
 func (m *metrics) Register(r prometheus.Registerer) error {
-	r.MustRegister(
-		m.configUpdatesTotal,
-		m.eventsTotal,
-		m.eventsFailed,
-		m.eventsRetried,
-		m.lokiClientTiming,
-	)
+	m.configUpdatesTotal = util.MustRegisterOrGet(r, m.configUpdatesTotal).(prometheus.Counter)
+	m.eventsTotal = util.MustRegisterOrGet(r, m.eventsTotal).(*prometheus.CounterVec)
+	m.eventsFailed = util.MustRegisterOrGet(r, m.eventsFailed).(*prometheus.CounterVec)
+	m.eventsRetried = util.MustRegisterOrGet(r, m.eventsRetried).(*prometheus.CounterVec)
+	m.lokiClientTiming = util.MustRegisterOrGet(r, m.lokiClientTiming).(*prometheus.HistogramVec)
 	return nil
 }
 

--- a/internal/component/loki/source/aws_firehose/internal/metrics.go
+++ b/internal/component/loki/source/aws_firehose/internal/metrics.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"github.com/grafana/alloy/internal/util"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -45,15 +46,11 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 		Help: "Number of errors while processing AWS Firehose static labels",
 	}, []string{"reason", "tenant_id"})
 
-	if reg != nil {
-		reg.MustRegister(
-			m.errorsAPIRequest,
-			m.recordsReceived,
-			m.errorsRecord,
-			m.batchSize,
-			m.invalidStaticLabelsCount,
-		)
-	}
+	m.errorsAPIRequest = util.MustRegisterOrGet(reg, m.errorsAPIRequest).(*prometheus.CounterVec)
+	m.errorsRecord = util.MustRegisterOrGet(reg, m.errorsRecord).(*prometheus.CounterVec)
+	m.recordsReceived = util.MustRegisterOrGet(reg, m.recordsReceived).(*prometheus.CounterVec)
+	m.batchSize = util.MustRegisterOrGet(reg, m.batchSize).(*prometheus.HistogramVec)
+	m.invalidStaticLabelsCount = util.MustRegisterOrGet(reg, m.invalidStaticLabelsCount).(*prometheus.CounterVec)
 
 	return &m
 }

--- a/internal/component/loki/source/cloudflare/internal/cloudflaretarget/metrics.go
+++ b/internal/component/loki/source/cloudflare/internal/cloudflaretarget/metrics.go
@@ -5,7 +5,10 @@ package cloudflaretarget
 // read from the Cloudflare Logpull API and forward entries to other loki
 // components.
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/grafana/alloy/internal/util"
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 // Metrics holds a set of cloudflare metrics.
 type Metrics struct {
@@ -31,10 +34,8 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 	})
 
 	if reg != nil {
-		reg.MustRegister(
-			m.Entries,
-			m.LastEnd,
-		)
+		m.Entries = util.MustRegisterOrGet(reg, m.Entries).(prometheus.Counter)
+		m.LastEnd = util.MustRegisterOrGet(reg, m.LastEnd).(prometheus.Gauge)
 	}
 
 	return &m

--- a/internal/component/loki/source/docker/internal/dockertarget/metrics.go
+++ b/internal/component/loki/source/docker/internal/dockertarget/metrics.go
@@ -4,7 +4,10 @@ package dockertarget
 // The dockertarget package is used to configure and run the targets that can
 // read logs from Docker containers and forward them to other loki components.
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/grafana/alloy/internal/util"
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 // Metrics holds a set of Docker target metrics.
 type Metrics struct {
@@ -30,10 +33,8 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 	})
 
 	if reg != nil {
-		reg.MustRegister(
-			m.dockerEntries,
-			m.dockerErrors,
-		)
+		m.dockerEntries = util.MustRegisterOrGet(reg, m.dockerEntries).(prometheus.Counter)
+		m.dockerErrors = util.MustRegisterOrGet(reg, m.dockerErrors).(prometheus.Counter)
 	}
 
 	return &m

--- a/internal/component/loki/source/file/metrics.go
+++ b/internal/component/loki/source/file/metrics.go
@@ -4,7 +4,10 @@ package file
 // The metrics struct provides a common set of metrics that are reused between all
 // implementations of the reader interface.
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/grafana/alloy/internal/util"
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 // metrics hold the set of file-based metrics.
 type metrics struct {
@@ -47,13 +50,11 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 	})
 
 	if reg != nil {
-		reg.MustRegister(
-			m.readBytes,
-			m.totalBytes,
-			m.readLines,
-			m.encodingFailures,
-			m.filesActive,
-		)
+		m.readBytes = util.MustRegisterOrGet(reg, m.readBytes).(*prometheus.GaugeVec)
+		m.totalBytes = util.MustRegisterOrGet(reg, m.totalBytes).(*prometheus.GaugeVec)
+		m.readLines = util.MustRegisterOrGet(reg, m.readLines).(*prometheus.CounterVec)
+		m.encodingFailures = util.MustRegisterOrGet(reg, m.encodingFailures).(*prometheus.CounterVec)
+		m.filesActive = util.MustRegisterOrGet(reg, m.filesActive).(prometheus.Gauge)
 	}
 
 	return &m

--- a/internal/component/loki/source/gcplog/internal/gcplogtarget/metrics.go
+++ b/internal/component/loki/source/gcplog/internal/gcplogtarget/metrics.go
@@ -5,7 +5,10 @@ package gcplogtarget
 // logs like bucket logs, load balancer logs, and Kubernetes cluster logs
 // from GCP.
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/grafana/alloy/internal/util"
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 // Metrics stores gcplog entry metrics.
 type Metrics struct {
@@ -52,12 +55,10 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 		Help: "Number of parsing errors while receiving gcplog messages",
 	}, []string{"reason"})
 
-	reg.MustRegister(
-		m.gcplogEntries,
-		m.gcplogErrors,
-		m.gcplogTargetLastSuccessScrape,
-		m.gcpPushEntries,
-		m.gcpPushErrors,
-	)
+	m.gcplogEntries = util.MustRegisterOrGet(reg, m.gcplogEntries).(*prometheus.CounterVec)
+	m.gcplogErrors = util.MustRegisterOrGet(reg, m.gcplogErrors).(*prometheus.CounterVec)
+	m.gcplogTargetLastSuccessScrape = util.MustRegisterOrGet(reg, m.gcplogTargetLastSuccessScrape).(*prometheus.GaugeVec)
+	m.gcpPushEntries = util.MustRegisterOrGet(reg, m.gcpPushEntries).(*prometheus.CounterVec)
+	m.gcpPushErrors = util.MustRegisterOrGet(reg, m.gcpPushErrors).(*prometheus.CounterVec)
 	return &m
 }

--- a/internal/component/loki/source/gelf/internal/target/metrics.go
+++ b/internal/component/loki/source/gelf/internal/target/metrics.go
@@ -4,7 +4,10 @@ package target
 // configure and run the targets that can read gelf entries and forward them
 // to other loki components.
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/grafana/alloy/internal/util"
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 // Metrics holds a set of gelf metrics.
 type Metrics struct {
@@ -30,10 +33,8 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 	})
 
 	if reg != nil {
-		reg.MustRegister(
-			m.gelfEntries,
-			m.gelfErrors,
-		)
+		m.gelfEntries = util.MustRegisterOrGet(reg, m.gelfEntries).(prometheus.Counter)
+		m.gelfErrors = util.MustRegisterOrGet(reg, m.gelfErrors).(prometheus.Counter)
 	}
 
 	return &m

--- a/internal/component/loki/source/heroku/internal/herokutarget/metrics.go
+++ b/internal/component/loki/source/heroku/internal/herokutarget/metrics.go
@@ -4,7 +4,10 @@ package herokutarget
 // configure and run the targets that can read heroku entries and forward them
 // to other loki components.
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/grafana/alloy/internal/util"
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 type Metrics struct {
 	herokuEntries prometheus.Counter
@@ -24,6 +27,7 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 		Help: "Number of parsing errors while receiving Heroku messages",
 	})
 
-	reg.MustRegister(m.herokuEntries, m.herokuErrors)
+	m.herokuEntries = util.MustRegisterOrGet(reg, m.herokuEntries).(prometheus.Counter)
+	m.herokuErrors = util.MustRegisterOrGet(reg, m.herokuErrors).(prometheus.Counter)
 	return &m
 }

--- a/internal/component/loki/source/syslog/internal/syslogtarget/metrics.go
+++ b/internal/component/loki/source/syslog/internal/syslogtarget/metrics.go
@@ -4,7 +4,10 @@ package syslogtarget
 // configure and run the targets that can read syslog entries and forward them
 // to other loki components.
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/grafana/alloy/internal/util"
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 // Metrics holds a set of syslog metrics.
 type Metrics struct {
@@ -35,11 +38,9 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 	})
 
 	if reg != nil {
-		reg.MustRegister(
-			m.syslogEntries,
-			m.syslogParsingErrors,
-			m.syslogEmptyMessages,
-		)
+		m.syslogEntries = util.MustRegisterOrGet(reg, m.syslogEntries).(prometheus.Counter)
+		m.syslogParsingErrors = util.MustRegisterOrGet(reg, m.syslogParsingErrors).(prometheus.Counter)
+		m.syslogEmptyMessages = util.MustRegisterOrGet(reg, m.syslogEmptyMessages).(prometheus.Counter)
 	}
 
 	return &m

--- a/internal/component/otelcol/exporter/loki/internal/convert/metrics.go
+++ b/internal/component/otelcol/exporter/loki/internal/convert/metrics.go
@@ -1,6 +1,7 @@
 package convert
 
 import (
+	"github.com/grafana/alloy/internal/util"
 	"github.com/prometheus/client_golang/prometheus"
 	prometheus_client "github.com/prometheus/client_golang/prometheus"
 )
@@ -28,11 +29,9 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 	})
 
 	if reg != nil {
-		reg.MustRegister(
-			m.entriesTotal,
-			m.entriesFailed,
-			m.entriesProcessed,
-		)
+		m.entriesTotal = util.MustRegisterOrGet(reg, m.entriesTotal).(prometheus_client.Counter)
+		m.entriesFailed = util.MustRegisterOrGet(reg, m.entriesFailed).(prometheus_client.Counter)
+		m.entriesProcessed = util.MustRegisterOrGet(reg, m.entriesProcessed).(prometheus_client.Counter)
 	}
 
 	return &m

--- a/internal/component/pyroscope/ebpf/metrics.go
+++ b/internal/component/pyroscope/ebpf/metrics.go
@@ -5,6 +5,7 @@
 package ebpf
 
 import (
+	"github.com/grafana/alloy/internal/util"
 	ebpfmetrics "github.com/grafana/pyroscope/ebpf/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -49,14 +50,12 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 	}
 
 	if reg != nil {
-		reg.MustRegister(
-			m.targetsActive,
-			m.profilingSessionsTotal,
-			m.profilingSessionsFailingTotal,
-			m.pprofsTotal,
-			m.pprofBytesTotal,
-			m.pprofSamplesTotal,
-		)
+		m.targetsActive = util.MustRegisterOrGet(reg, m.targetsActive).(prometheus.Gauge)
+		m.profilingSessionsTotal = util.MustRegisterOrGet(reg, m.profilingSessionsTotal).(prometheus.Counter)
+		m.profilingSessionsFailingTotal = util.MustRegisterOrGet(reg, m.profilingSessionsFailingTotal).(prometheus.Counter)
+		m.pprofsTotal = util.MustRegisterOrGet(reg, m.pprofsTotal).(*prometheus.CounterVec)
+		m.pprofBytesTotal = util.MustRegisterOrGet(reg, m.pprofBytesTotal).(*prometheus.CounterVec)
+		m.pprofSamplesTotal = util.MustRegisterOrGet(reg, m.pprofSamplesTotal).(*prometheus.CounterVec)
 	}
 
 	return m

--- a/internal/component/pyroscope/write/metrics.go
+++ b/internal/component/pyroscope/write/metrics.go
@@ -1,6 +1,9 @@
 package write
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/grafana/alloy/internal/util"
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 type metrics struct {
 	sentBytes       *prometheus.CounterVec
@@ -35,13 +38,11 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 	}
 
 	if reg != nil {
-		reg.MustRegister(
-			m.sentBytes,
-			m.droppedBytes,
-			m.sentProfiles,
-			m.droppedProfiles,
-			m.retries,
-		)
+		m.sentBytes = util.MustRegisterOrGet(reg, m.sentBytes).(*prometheus.CounterVec)
+		m.droppedBytes = util.MustRegisterOrGet(reg, m.droppedBytes).(*prometheus.CounterVec)
+		m.sentProfiles = util.MustRegisterOrGet(reg, m.sentProfiles).(*prometheus.CounterVec)
+		m.droppedProfiles = util.MustRegisterOrGet(reg, m.droppedProfiles).(*prometheus.CounterVec)
+		m.retries = util.MustRegisterOrGet(reg, m.retries).(*prometheus.CounterVec)
 	}
 
 	return m

--- a/internal/component/remote/vault/metrics.go
+++ b/internal/component/remote/vault/metrics.go
@@ -1,6 +1,9 @@
 package vault
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/grafana/alloy/internal/util"
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 type metrics struct {
 	authTotal       prometheus.Counter
@@ -32,13 +35,11 @@ func newMetrics(r prometheus.Registerer) *metrics {
 	})
 
 	if r != nil {
-		r.MustRegister(
-			m.authTotal,
-			m.secretReadTotal,
+		m.authTotal = util.MustRegisterOrGet(r, m.authTotal).(prometheus.Counter)
+		m.secretReadTotal = util.MustRegisterOrGet(r, m.secretReadTotal).(prometheus.Counter)
 
-			m.authLeaseRenewalTotal,
-			m.secretLeaseRenewalTotal,
-		)
+		m.authLeaseRenewalTotal = util.MustRegisterOrGet(r, m.authLeaseRenewalTotal).(prometheus.Counter)
+		m.secretLeaseRenewalTotal = util.MustRegisterOrGet(r, m.secretLeaseRenewalTotal).(prometheus.Counter)
 	}
 	return &m
 }

--- a/internal/static/metrics/wal/wal.go
+++ b/internal/static/metrics/wal/wal.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/alloy/internal/util"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
@@ -84,15 +85,13 @@ func newStorageMetrics(r prometheus.Registerer) *storageMetrics {
 	})
 
 	if r != nil {
-		r.MustRegister(
-			m.numActiveSeries,
-			m.numDeletedSeries,
-			m.totalOutOfOrderSamples,
-			m.totalCreatedSeries,
-			m.totalRemovedSeries,
-			m.totalAppendedSamples,
-			m.totalAppendedExemplars,
-		)
+		m.numActiveSeries = util.MustRegisterOrGet(r, m.numActiveSeries).(prometheus.Gauge)
+		m.numDeletedSeries = util.MustRegisterOrGet(r, m.numDeletedSeries).(prometheus.Gauge)
+		m.totalOutOfOrderSamples = util.MustRegisterOrGet(r, m.totalOutOfOrderSamples).(prometheus.Counter)
+		m.totalCreatedSeries = util.MustRegisterOrGet(r, m.totalCreatedSeries).(prometheus.Counter)
+		m.totalRemovedSeries = util.MustRegisterOrGet(r, m.totalRemovedSeries).(prometheus.Counter)
+		m.totalAppendedSamples = util.MustRegisterOrGet(r, m.totalAppendedSamples).(prometheus.Counter)
+		m.totalAppendedExemplars = util.MustRegisterOrGet(r, m.totalAppendedExemplars).(prometheus.Counter)
 	}
 
 	return &m


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Inspired by https://github.com/grafana/alloy/pull/2177 - I don't see a reason that the possibility of a metric being already registered should cause Alloy to panic.

#### Which issue(s) this PR fixes
None

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

