### PR TITLE
`loki.source.podlogs`: Fix issue which disables clustering unintentionally.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Main (unreleased)
 
 - Fix a race condition where the ui service was dependent on starting after the remotecfg service, which is not guaranteed. (@dehaansa & @erikbaranowski)
 
+- `loki.source.podlogs`: Fixed a bug which prevented clustering from working and caused duplicate logs to be sent. (@ptodev)
+
 ### Other changes
 
 - Change the stability of the `livedebugging` feature from "experimental" to "generally available". (@wildum)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,8 @@ Main (unreleased)
 
 - Fix a race condition where the ui service was dependent on starting after the remotecfg service, which is not guaranteed. (@dehaansa & @erikbaranowski)
 
-- `loki.source.podlogs`: Fixed a bug which prevented clustering from working and caused duplicate logs to be sent. (@ptodev)
+- `loki.source.podlogs`: Fixed a bug which prevented clustering from working and caused duplicate logs to be sent.
+  The bug only happened when no `selector` or `namespace_selector` blocks were specified in the Alloy configuration. (@ptodev)
 
 ### Other changes
 

--- a/internal/component/loki/source/podlogs/podlogs.go
+++ b/internal/component/loki/source/podlogs/podlogs.go
@@ -258,6 +258,10 @@ func (c *Component) updateTailer(args Arguments) error {
 // updateReconciler updates the state of the reconciler. This must only be
 // called after updateTailer. mut must be held when calling.
 func (c *Component) updateReconciler(args Arguments) error {
+	// The clustering settings should always be updated,
+	// even if the selectors haven't changed.
+	c.reconciler.SetDistribute(args.Clustering.Enabled)
+
 	var (
 		selectorChanged          = !reflect.DeepEqual(c.args.Selector, args.Selector)
 		namespaceSelectorChanged = !reflect.DeepEqual(c.args.NamespaceSelector, args.NamespaceSelector)
@@ -276,7 +280,6 @@ func (c *Component) updateReconciler(args Arguments) error {
 	}
 
 	c.reconciler.UpdateSelectors(sel, nsSel)
-	c.reconciler.SetDistribute(args.Clustering.Enabled)
 
 	// Request a reconcile so the new selectors get applied.
 	c.controller.RequestReconcile()


### PR DESCRIPTION
#### PR Description

This bug cases multiple logs to be sent. Every Alloy instance in the cluster would send all of the logs which `loki.source.podlogs` discovered.

#### Notes to the Reviewer

It'd be great to write unit tests, but we don't have any tests for `loki.source.podlogs` at the moment other than trivial tests for configs. A test would need to start a fake kubernetes cluster, and I'm not yet sure how to do it. There's [another PR](https://github.com/grafana/alloy/pull/1722) where I've been trying to do a similar thing, and got a bit stuck.

I suspect that `loki.source.podlogs` may also be affected by the same issue as #1716, so I will also investigate this separately and will open another PR for it.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
