### PR TITLE
loki.source.podlogs: For clustering only take into account some labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ Main (unreleased)
   - Change processlist query to support ONLY_FULL_GROUP_BY sql_mode
   - Add perf_schema quantile columns to collector
 
+- For sharding targets during clustering, `loki.source.podlogs` now only takes into account some labels. (@ptodev)
+
 ### Bugfixes
 - Fixed an issue in the `pyroscope.write` component to allow slashes in application names in the same way it is done in the Pyroscope push API (@marcsanmi)
 - Fixed an issue in the `prometheus.exporter.postgres` component that would leak goroutines when the target was not reachable (@dehaansa)

--- a/docs/sources/reference/components/loki/loki.source.kubernetes.md
+++ b/docs/sources/reference/components/loki/loki.source.kubernetes.md
@@ -139,7 +139,7 @@ When {{< param "PRODUCT_NAME" >}} is [using clustering][], and `enabled` is set 
 
 If {{< param "PRODUCT_NAME" >}} is _not_ running in clustered mode, then the block is a no-op and `loki.source.kubernetes` collects logs from every target it receives in its arguments.
 
-Clustering only looks at the following labels for determining the shard key:
+Clustering looks only at the following labels for determining the shard key:
 
 * `__pod_namespace__`
 * `__pod_name__`

--- a/docs/sources/reference/components/loki/loki.source.podlogs.md
+++ b/docs/sources/reference/components/loki/loki.source.podlogs.md
@@ -231,7 +231,7 @@ cluster to distribute the load of log collection between all cluster nodes.
 If {{< param "PRODUCT_NAME" >}} is _not_ running in clustered mode, then the block is a no-op and
 `loki.source.podlogs` collects logs based on every PodLogs resource discovered.
 
-Clustering only looks at the following labels for determining the shard key:
+Clustering looks only at the following labels for determining the shard key:
 
 * `__pod_namespace__`
 * `__pod_name__`

--- a/docs/sources/reference/components/loki/loki.source.podlogs.md
+++ b/docs/sources/reference/components/loki/loki.source.podlogs.md
@@ -231,6 +231,21 @@ cluster to distribute the load of log collection between all cluster nodes.
 If {{< param "PRODUCT_NAME" >}} is _not_ running in clustered mode, then the block is a no-op and
 `loki.source.podlogs` collects logs based on every PodLogs resource discovered.
 
+Clustering only looks at the following labels for determining the shard key:
+
+* `__pod_namespace__`
+* `__pod_name__`
+* `__pod_container_name__`
+* `__pod_uid__`
+* `__meta_kubernetes_namespace`
+* `__meta_kubernetes_pod_name`
+* `__meta_kubernetes_pod_container_name`
+* `__meta_kubernetes_pod_uid`
+* `container`
+* `pod`
+* `job`
+* `namespace`
+
 [using clustering]: ../../../../get-started/clustering/
 
 ## Exported fields


### PR DESCRIPTION
#### PR Description

When clustering, `loki.source.podlogs` currently only takes into account public labels such as `job` and `instance`. I think it'd be safer to take the same approach as `loki.source.kubernetes` took in #1716 and only take into account some labels.

I have not seen this in the wild and I'm not sure if there could be duplicate logs as in #1716, so I'm just labeling this as an enhancement in the changelog rather than a bugfix.

#### Notes to the Reviewer

Unfortunately, it's hard to write a unit test for this since we'd have to fake k8s. I tested this locally on a local k8s cluster.

I don't think this should be classified as a breaking change, because the docs already say that certain labels are required for `loki.source.podlogs` to work:

> In addition to the meta labels, the following labels are exposed to tell `loki.source.podlogs` which container to tail:
> * `__pod_namespace__`: The namespace of the Pod.
> * `__pod_name__`: The name of the Pod.
> * `__pod_container_name__`: The container name within the Pod.
> * `__pod_uid__`: The UID of the Pod.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
