### PR TITLE
Retry running a CRD Manager if it fails

### DIFF
--- a/internal/component/prometheus/operator/common/component.go
+++ b/internal/component/prometheus/operator/common/component.go
@@ -104,11 +104,22 @@ func (c *Component) Run(ctx context.Context) error {
 			innerCtx, cancel = context.WithCancel(ctx)
 			wg.Add(1)
 			go func() {
-				if err := manager.Run(innerCtx); err != nil {
-					level.Error(c.opts.Logger).Log("msg", "error running crd manager", "err", err)
-					errChan <- err
+				defer wg.Done()
+				retryInterval := 0 * time.Second
+				for {
+					select {
+					case <-innerCtx.Done():
+						//TODO: Log that the manager is exiting?
+						return
+					case <-time.After(retryInterval):
+						if err := manager.Run(innerCtx); err != nil {
+							level.Error(c.opts.Logger).Log("msg", "error running crd manager", "err", err)
+							errChan <- err
+							//TODO: What is a good default value for this?
+							retryInterval = 30 * time.Second
+						}
+					}
 				}
-				wg.Done()
 			}()
 			c.mut.Unlock()
 		}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Setting up a k8s informer may time out (see #2161). In that case, we'd only retry setting up an informer the next time Alloy's config changes. We should retry sooner than that, since the config may never change. 

#### Notes to the Reviewer

A few reasons why the PR is in draft stage:
* No unit tests have been added yet.
* I'm not sure what is a good retry value. I suppose it should be something between 30 seconds and 60 seconds.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
