### PR TITLE
fix: crash when updating import.http config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ Main (unreleased)
 
 - Updated `prometheus.write.queue` to fix issue with TTL comparing different scales of time. (@mattdurham)
 
-- Fixed a crash when updating import.http config that occurred because `importsource.HTTPArguments` was passed to `component/remote/http.Update` instead of `component/remote/http.Arguments`
+- Fixed a crash when updating the configuration of `remote.http`. (@kinolaev)
 
 ### Other changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ Main (unreleased)
 
 - Updated `prometheus.write.queue` to fix issue with TTL comparing different scales of time. (@mattdurham)
 
+- Fixed a crash when updating import.http config that occurred because `importsource.HTTPArguments` was passed to `component/remote/http.Update` instead of `component/remote/http.Arguments`
+
 ### Other changes
 
 - Change the stability of the `livedebugging` feature from "experimental" to "generally available". (@wildum)

--- a/internal/runtime/internal/importsource/import_http.go
+++ b/internal/runtime/internal/importsource/import_http.go
@@ -66,17 +66,18 @@ func (im *ImportHTTP) Evaluate(scope *vm.Scope) error {
 	if err := im.eval.Evaluate(scope, &arguments); err != nil {
 		return fmt.Errorf("decoding configuration: %w", err)
 	}
+	remoteHttpArguments := remote_http.Arguments{
+		URL:           arguments.URL,
+		PollFrequency: arguments.PollFrequency,
+		PollTimeout:   arguments.PollTimeout,
+		Method:        arguments.Method,
+		Headers:       arguments.Headers,
+		Body:          arguments.Body,
+		Client:        arguments.Client,
+	}
 	if im.managedRemoteHTTP == nil {
 		var err error
-		im.managedRemoteHTTP, err = remote_http.New(im.managedOpts, remote_http.Arguments{
-			URL:           arguments.URL,
-			PollFrequency: arguments.PollFrequency,
-			PollTimeout:   arguments.PollTimeout,
-			Method:        arguments.Method,
-			Headers:       arguments.Headers,
-			Body:          arguments.Body,
-			Client:        arguments.Client,
-		})
+		im.managedRemoteHTTP, err = remote_http.New(im.managedOpts, remoteHttpArguments)
 		if err != nil {
 			return fmt.Errorf("creating http component: %w", err)
 		}
@@ -88,7 +89,7 @@ func (im *ImportHTTP) Evaluate(scope *vm.Scope) error {
 	}
 
 	// Update the existing managed component
-	if err := im.managedRemoteHTTP.Update(arguments); err != nil {
+	if err := im.managedRemoteHTTP.Update(remoteHttpArguments); err != nil {
 		return fmt.Errorf("updating component: %w", err)
 	}
 	im.arguments = arguments


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR fixes a crash when updating import.http config that occurred because `importsource.HTTPArguments` was passed to `component/remote/http.Update` function instead of `component/remote/http.Arguments`.

Crash log:
```
ts=2024-12-02T16:19:30.25946014Z level=info msg="reload requested via /-/reload endpoint" service=http
ts=2024-12-02T16:19:30.260271407Z level=info msg="starting complete graph evaluation" controller_path=/ controller_id="" trace_id=f5a86bef2cca442f28cd0b9c6ecf3ddd
ts=2024-12-02T16:19:30.260547266Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=f5a86bef2cca442f28cd0b9c6ecf3ddd node_id=prometheus.remote_write.default duration=210.501µs
ts=2024-12-02T16:19:30.260684586Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=f5a86bef2cca442f28cd0b9c6ecf3ddd node_id=local.file_match.txlogs duration=90.358µs
ts=2024-12-02T16:19:30.261002744Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=f5a86bef2cca442f28cd0b9c6ecf3ddd node_id=loki.relabel.journal duration=258.232µs
ts=2024-12-02T16:19:30.261154033Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=f5a86bef2cca442f28cd0b9c6ecf3ddd node_id=labelstore duration=80.823µs
ts=2024-12-02T16:19:30.261220731Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=f5a86bef2cca442f28cd0b9c6ecf3ddd node_id=otel duration=32.895µs
ts=2024-12-02T16:19:30.261354245Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=f5a86bef2cca442f28cd0b9c6ecf3ddd node_id=loki.write.default duration=107.018µs
ts=2024-12-02T16:19:30.261517394Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=f5a86bef2cca442f28cd0b9c6ecf3ddd node_id=loki.source.journal.read duration=101.364µs
ts=2024-12-02T16:19:30.261699889Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=f5a86bef2cca442f28cd0b9c6ecf3ddd node_id=loki.relabel.host duration=127.935µs
ts=2024-12-02T16:19:30.261816661Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=f5a86bef2cca442f28cd0b9c6ecf3ddd node_id=tracing duration=47.051µs
ts=2024-12-02T16:19:30.312654144Z level=info msg="finished node evaluation" controller_path=/ controller_id="" trace_id=f5a86bef2cca442f28cd0b9c6ecf3ddd node_id=import.http.tx duration=50.799132ms
ts=2024-12-02T16:19:30.31278222Z level=info msg="finished complete graph evaluation" controller_path=/ controller_id="" trace_id=f5a86bef2cca442f28cd0b9c6ecf3ddd duration=52.844717ms
2024/12/02 19:19:30 http: panic serving 127.0.0.1:56724: interface conversion: component.Arguments is importsource.HTTPArguments, not http.Arguments
goroutine 22012 [running]:
net/http.(*conn).serve.func1()
        /usr/local/go/src/net/http/server.go:1903 +0xbe
panic({0x9501e00?, 0xc003f1a4e0?})
        /usr/local/go/src/runtime/panic.go:770 +0x132
github.com/grafana/alloy/internal/component/remote/http.(*Component).Update(0xc0036c6488, {0xa329800?, 0xc00354dda8?})
        /drone/src/internal/component/remote/http/http.go:269 +0x457
github.com/grafana/alloy/internal/runtime/internal/importsource.(*ImportHTTP).Evaluate(0xc00254b6c0, 0xc0070df0d0)
        /drone/src/internal/runtime/internal/importsource/import_http.go:91 +0x3d5
github.com/grafana/alloy/internal/runtime/internal/controller.(*ImportConfigNode).Evaluate(0xc0035e4000, 0x98ffbe0?)
        /drone/src/internal/runtime/internal/controller/node_config_import.go:180 +0x2e
github.com/grafana/alloy/internal/runtime/internal/controller.(*Loader).evaluate(0xc00254b1e0, {0xbffbd00, 0xc005dd2f00}, {0xc0b2158, 0xc0035e4000})
        /drone/src/internal/runtime/internal/controller/loader.go:823 +0x49
github.com/grafana/alloy/internal/runtime/internal/controller.(*Loader).Apply.func2({0xbffe540, 0xc0035e4000})
        /drone/src/internal/runtime/internal/controller/loader.go:237 +0xad8
github.com/grafana/alloy/internal/runtime/internal/dag.WalkTopological(0xc0033d82a0, {0xc003302d00, 0xc, 0x117d2d50?}, 0xc00354eca0)
        /drone/src/internal/runtime/internal/dag/walk.go:83 +0x222
github.com/grafana/alloy/internal/runtime/internal/controller.(*Loader).Apply(0xc00254b1e0, {0x0, {0xc002d05180, 0xa, 0x10}, {0xc0070de7d0, 0x2, 0x2}, {0x0, 0x0, ...}, ...})
        /drone/src/internal/runtime/internal/controller/loader.go:188 +0xb6d
github.com/grafana/alloy/internal/runtime.(*Runtime).applyLoaderConfig(0xc003269500, {0x0, {0xc002d05180, 0xa, 0x10}, {0xc0070de7d0, 0x2, 0x2}, {0x0, 0x0, ...}, ...})
        /drone/src/internal/runtime/alloy.go:334 +0xd8
github.com/grafana/alloy/internal/runtime.(*Runtime).LoadSource(0xc003269500, 0xc002456a10, 0x0, {0x7ffc3e40de99, 0x17})
        /drone/src/internal/runtime/alloy.go:307 +0x365
github.com/grafana/alloy/internal/alloycli.(*alloyRun).Run.func5()
        /drone/src/internal/alloycli/cmd_run.go:359 +0x285
github.com/grafana/alloy/internal/alloycli.(*alloyRun).Run.func4()
        /drone/src/internal/alloycli/cmd_run.go:296 +0x16
github.com/grafana/alloy/internal/service/http.(*Service).Run.func3({0xc0951d0, 0xc0058606c0}, 0x0?)
        /drone/src/internal/service/http/http.go:215 +0xbe
net/http.HandlerFunc.ServeHTTP(0xc0886a0?, {0xc0951d0?, 0xc0058606c0?}, 0xa8ec140?)
        /usr/local/go/src/net/http/server.go:2171 +0x29
go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux.traceware.ServeHTTP({{0xa8d683d, 0x5}, {0xc029950, 0xc002c920a0}, {0xc089f00, 0xc002734cc0}, {0xbffb840, 0xc0024a04d0}, 0xb07f710, 0x0, ...}, ...)
        /go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux@v0.45.0/mux.go:179 +0xbb2
github.com/gorilla/mux.(*Router).ServeHTTP(0xc002cb6000, {0xc0886a0, 0xc006050540}, 0xc004392b40)
        /go/pkg/mod/github.com/gorilla/mux@v1.8.1/mux.go:212 +0x1e2
golang.org/x/net/http2/h2c.h2cHandler.ServeHTTP({{0xbffc200?, 0xc002cb6000?}, 0xc00320ff10?}, {0xc0886a0, 0xc006050540}, 0xc004392b40)
        /go/pkg/mod/golang.org/x/net@v0.30.0/http2/h2c/h2c.go:125 +0x697
net/http.serverHandler.ServeHTTP({0xc00292cae0?}, {0xc0886a0?, 0xc006050540?}, 0x6?)
        /usr/local/go/src/net/http/server.go:3142 +0x8e
net/http.(*conn).serve(0xc00443c7e0, {0xc0b1150, 0xc002a7a510})
        /usr/local/go/src/net/http/server.go:2044 +0x5e8
created by net/http.(*Server).Serve in goroutine 626
        /usr/local/go/src/net/http/server.go:3290 +0x4b4
```

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
