### PR TITLE
fix: support capitalized relabel actions to match with prometheus-operator behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,19 +46,11 @@ Main (unreleased)
 
 ### Bugfixes
 
-- Fixed an issue in the `pyroscope.write` component to prevent TLS connection churn to Pyroscope when the `pyroscope.receive_http` clients don't request keepalive (@madaraszg-tulip)
-
-- Fixed an issue in the `prometheus.operator.servicemonitors`, `prometheus.operator.podmonitors` and `prometheus.operator.probes` to support capitalized actions. (@QuentinBisson)
-
 - Fixed issue with reloading configuration and prometheus metrics duplication in `prometheus.write.queue`. (@mattdurham)
 
 - Updated `prometheus.write.queue` to fix issue with TTL comparing different scales of time. (@mattdurham)
 
-### Other changes
-
-- Change the stability of the `livedebugging` feature from "experimental" to "generally available". (@wildum)
-
-- Use Go 1.23.3 for builds. (@mattdurham)
+- Fixed an issue in the `prometheus.operator.servicemonitors`, `prometheus.operator.podmonitors` and `prometheus.operator.probes` to support capitalized actions. (@QuentinBisson)
 
 v1.5.1
 -----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,8 +88,6 @@ v1.5.1
 
 - Fixed a crash when updating the configuration of `remote.http`. (@kinolaev)
 
-### Other changes
-
 - Fixed an issue in the `otelcol.processor.attribute` component where the actions `delete` and `hash` could not be used with the `pattern` argument. (@wildum) 
 
 - Fixed an issue in the `prometheus.exporter.postgres` component that would leak goroutines when the target was not reachable (@dehaansa)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ Main (unreleased)
 
 - Fixed an issue in the `prometheus.operator.servicemonitors`, `prometheus.operator.podmonitors` and `prometheus.operator.probes` to support capitalized actions. (@QuentinBisson)
 
+### Other changes
+
+- Change the stability of the `livedebugging` feature from "experimental" to "generally available". (@wildum)
+
+- Use Go 1.23.3 for builds. (@mattdurham)
+
 v1.5.1
 -----------------
 
@@ -83,10 +89,6 @@ v1.5.1
 - Fixed a crash when updating the configuration of `remote.http`. (@kinolaev)
 
 ### Other changes
-
-- Change the stability of the `livedebugging` feature from "experimental" to "generally available". (@wildum)
-
-- Use Go 1.23.3 for builds. (@mattdurham)
 
 - Fixed an issue in the `otelcol.processor.attribute` component where the actions `delete` and `hash` could not be used with the `pattern` argument. (@wildum) 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Main (unreleased)
 - For sharding targets during clustering, `loki.source.podlogs` now only takes into account some labels. (@ptodev)
 
 ### Bugfixes
+
 - Fixed an issue in the `pyroscope.write` component to prevent TLS connection churn to Pyroscope when the `pyroscope.receive_http` clients don't request keepalive (@madaraszg-tulip)
 
 - Fixed an issue in the `pyroscope.write` component with multiple endpoints not working correctly for forwarding profiles from `pyroscope.receive_http` (@madaraszg-tulip)
@@ -73,6 +74,8 @@ Main (unreleased)
 - Updated `prometheus.write.queue` to fix issue with TTL comparing different scales of time. (@mattdurham)
 
 - Fixed a crash when updating the configuration of `remote.http`. (@kinolaev)
+
+- Fixed an issue in the `prometheus.operator.servicemonitors`, `prometheus.operator.podmonitors` and `prometheus.operator.probes` to support capitalized actions. (@QuentinBisson)
 
 ### Other changes
 

--- a/internal/component/prometheus/operator/configgen/config_gen.go
+++ b/internal/component/prometheus/operator/configgen/config_gen.go
@@ -4,6 +4,7 @@ package configgen
 
 import (
 	"regexp"
+	"strings"
 
 	promopv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	commonConfig "github.com/prometheus/common/config"
@@ -197,6 +198,7 @@ func (r *relabeler) add(cfgs ...*relabel.Config) {
 		if cfg.Action == "" {
 			cfg.Action = relabel.DefaultRelabelConfig.Action
 		}
+		cfg.Action = relabel.Action(strings.ToLower(string(cfg.Action)))
 		if cfg.Separator == "" {
 			cfg.Separator = relabel.DefaultRelabelConfig.Separator
 		}


### PR DESCRIPTION
#### PR Description

The prometheus operator `ServiceMonitors`, `PodMonitors` and `Probes` relabelings sections support capitalized actions like so: https://github.com/prometheus-operator/prometheus-operator/blob/ccfd2196833a350100658b9d645f0935e3b90a3d/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml#L349

The issue is [prometheus itself](https://github.com/prometheus/prometheus/blob/7f26371af84d6ade4d6c40a8e9eeef32cb51f6e4/model/relabel/relabel.go#L352) only supports lowercase actions so the prometheus-operator maintainers added https://github.com/prometheus-operator/prometheus-operator/blob/ccfd2196833a350100658b9d645f0935e3b90a3d/pkg/prometheus/resource_selector.go#L294 to lowercase actions.

This PR aims to reproduce this as incorrect values like "Replace" actually causes alloy to panic like so:

```
panic: relabel: unknown relabel action type "Replace"

goroutine 906 [running]:
github.com/prometheus/prometheus/model/relabel.relabel(0xc001f343f0, 0xc00a0239a0)
        /go/pkg/mod/github.com/grafana/prometheus@v1.8.2-0.20240514135907-13889ba362e6/model/relabel/relabel.go:314 +0x96e
github.com/prometheus/prometheus/model/relabel.ProcessBuilder(...)
        /go/pkg/mod/github.com/grafana/prometheus@v1.8.2-0.20240514135907-13889ba362e6/model/relabel/relabel.go:233
github.com/prometheus/prometheus/scrape.PopulateLabels(0xc00a0239a0, 0xc003018d88, 0x0)
        /go/pkg/mod/github.com/grafana/prometheus@v1.8.2-0.20240514135907-13889ba362e6/scrape/target.go:445 +0x510
github.com/prometheus/prometheus/scrape.TargetsFromGroup(0xc00a134000, 0xc003018d88, 0x0, {0x0?, 0xa474900?, 0x6b?}, 0xc00a0239a0)
        /go/pkg/mod/github.com/grafana/prometheus@v1.8.2-0.20240514135907-13889ba362e6/scrape/target.go:571 +0x1d5
github.com/prometheus/prometheus/scrape.(*scrapePool).Sync(0xc009f3e1a0, {0xc00a0d38c0, 0x21, 0xc002980f60?})
        /go/pkg/mod/github.com/grafana/prometheus@v1.8.2-0.20240514135907-13889ba362e6/scrape/scrape.go:391 +0x1e6
github.com/prometheus/prometheus/scrape.(*Manager).reload.func1(0xc00365ff60?, {0xc00a0d38c0?, 0x40a2105?, 0xc00300ca80?})
        /go/pkg/mod/github.com/grafana/prometheus@v1.8.2-0.20240514135907-13889ba362e6/scrape/manager.go:180 +0x25
created by github.com/prometheus/prometheus/scrape.(*Manager).reload in goroutine 300
        /go/pkg/mod/github.com/grafana/prometheus@v
```

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Tests updated
