### PR TITLE
Fix documentation reference for string.trim_space

### DIFF
--- a/docs/sources/reference/stdlib/string.md
+++ b/docs/sources/reference/stdlib/string.md
@@ -194,13 +194,13 @@ If the string doesn't start with the prefix, the string is returned unchanged.
 "hello"
 ```
 
-## strings.trim_space
+## string.trim_space
 
-`strings.trim_space` removes any whitespace characters from the start and end of a string.
+`string.trim_space` removes any whitespace characters from the start and end of a string.
 
 ### Examples
 
 ```alloy
-> strings.trim_space("  hello\n\n")
+> string.trim_space("  hello\n\n")
 "hello"
 ```


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Docs incorrectly namespace only trim_space as string(s).trim_space where all string functions are namespaced string.trim_space.

#### Which issue(s) this PR fixes
Noted in this escalation https://github.com/grafana/support-escalations/issues/13622#issuecomment-2517118845

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->
