### PR TITLE
prometheus.exporter.windows - Convert sentence to note to make important detail stand out

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
@@ -248,7 +248,7 @@ the default will be `C:\Program Files\GrafanaLabs\Alloy\textfile_inputs`.
 When `text_file_directory` is set, only files with the extension `.prom` inside the specified directory are read. 
 
 {{< admonition type="note" >}}
-Each `.prom` file found must end with an empty line feed to work properly.
+The `.prom` files must end with an empty line feed for the component to recognize and read them.
 {{< /admonition >}}
 
 ## Exported fields

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
@@ -245,8 +245,11 @@ By default, `text_file_directory` is set to the `textfile_inputs` directory in t
 For example, if {{< param "PRODUCT_NAME" >}} is installed in `C:\Program Files\GrafanaLabs\Alloy\`,
 the default will be `C:\Program Files\GrafanaLabs\Alloy\textfile_inputs`.
 
-When `text_file_directory` is set, only files with the extension `.prom` inside the specified directory are read. Each `.prom` file found must end with an empty line feed to work properly.
+When `text_file_directory` is set, only files with the extension `.prom` inside the specified directory are read. 
 
+{{< admonition type="note" >}}
+Each `.prom` file found must end with an empty line feed to work properly.
+{{< /admonition >}}
 
 ## Exported fields
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

A Slack conversation came up about an important but often missed detail in the `prometheus.exporter.windows` documentation about `*.prom` files. There is a  mandatory empty CR/LF at the end of the `*.prom` files that users often miss. Converted the sentence to a Note to make it stand out a little more.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
