### PR TITLE
Configure metrics exporter for loadbalancing when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Main (unreleased)
 
 ### Features
 
+- Add support for metrics in `otelcol.exporter.loadbalancing` (@madaraszg-tulip)
+
 - Add `add_cloudwatch_timestamp` to `prometheus.exporter.cloudwatch` metrics. (@captncraig)
 
 - Add support to `prometheus.operator.servicemonitors` to allow `endpointslice` role. (@yoyosir)

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.loadbalancing.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.loadbalancing.md
@@ -65,7 +65,7 @@ The `routing_key` attribute determines how to route signals across endpoints. It
 - `"service"`: spans, logs, and metrics with the same `service.name` will be exported to the same backend.
 This is useful when using processors like the span metrics, so all spans for each service are sent to consistent {{< param "PRODUCT_NAME" >}} instances
 for metric collection. Otherwise, metrics for the same services would be sent to different instances, making aggregations inaccurate.
-- `"traceID"`: spans/logs belonging to the same traceID will be exported to the same backend.
+- `"traceID"`: spans and logs belonging to the same `traceID` will be exported to the same backend.
 - `"resource"`: metrics belonging to the same resource will be exported to the same backend.
 - `"metric"`: metrics with the same name will be exported to the same backend.
 - `"streamID"`: metrics with the same streamID will be exported to the same backend

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.loadbalancing.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.loadbalancing.md
@@ -70,7 +70,7 @@ for metric collection. Otherwise, metrics for the same services would be sent to
 - `"metric"`: metrics with the same name will be exported to the same backend.
 - `"streamID"`: metrics with the same `streamID` will be exported to the same backend.
 
-The loadbalancer will configure the exporter for the singal types supported by the `routing_key`
+The loadbalancer configures the exporter for the signal types supported by the `routing_key`.
 
 Metrics support in `otelcol.exporter.loadbalancing` is considered experimental, so an exporter
 will be configured for metrics only if Alloy is run with `--stability-level=experimental`

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.loadbalancing.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.loadbalancing.md
@@ -67,7 +67,7 @@ This is useful when using processors like the span metrics, so all spans for eac
 for metric collection. Otherwise, metrics for the same services would be sent to different instances, making aggregations inaccurate.
 - `"traceID"`: spans/logs belonging to the same traceID will be exported to the same backend.
 - `"resource"`: metrics belonging to the same resource will be exported to the same backend.
-- `"metric"`: metrics with the same name will be exported to the same backend
+- `"metric"`: metrics with the same name will be exported to the same backend.
 - `"streamID"`: metrics with the same streamID will be exported to the same backend
 
 The loadbalancer will configure the exporter for the singal types supported by the `routing_key`

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.loadbalancing.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.loadbalancing.md
@@ -72,8 +72,9 @@ for metric collection. Otherwise, metrics for the same services would be sent to
 
 The loadbalancer configures the exporter for the signal types supported by the `routing_key`.
 
-Metrics support in `otelcol.exporter.loadbalancing` is considered experimental, so an exporter
-will be configured for metrics only if Alloy is run with `--stability-level=experimental`
+> **EXPERIMENTAL**: Metrics support in `otelcol.exporter.loadbalancing` is an [experimental][] feature.
+> Experimental features are subject to frequent breaking changes, and may be removed with no equivalent replacement.
+> The `stability.level` flag must be set to `experimental` to use the feature.
 
 ## Blocks
 

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.loadbalancing.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.loadbalancing.md
@@ -62,7 +62,7 @@ Name          | Type     | Description                          | Default     | 
 `routing_key` | `string` | Routing strategy for load balancing. | `"traceID"` | no
 
 The `routing_key` attribute determines how to route signals across endpoints. Its value could be one of the following:
-- `"service"`: spans/logs/metrics with the same `service.name` will be exported to the same backend.
+- `"service"`: spans, logs, and metrics with the same `service.name` will be exported to the same backend.
 This is useful when using processors like the span metrics, so all spans for each service are sent to consistent {{< param "PRODUCT_NAME" >}} instances
 for metric collection. Otherwise, metrics for the same services would be sent to different instances, making aggregations inaccurate.
 - `"traceID"`: spans/logs belonging to the same traceID will be exported to the same backend.

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.loadbalancing.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.loadbalancing.md
@@ -62,10 +62,18 @@ Name          | Type     | Description                          | Default     | 
 `routing_key` | `string` | Routing strategy for load balancing. | `"traceID"` | no
 
 The `routing_key` attribute determines how to route signals across endpoints. Its value could be one of the following:
-* `"service"`: spans with the same `service.name` will be exported to the same backend.
+- `"service"`: spans/logs/metrics with the same `service.name` will be exported to the same backend.
 This is useful when using processors like the span metrics, so all spans for each service are sent to consistent {{< param "PRODUCT_NAME" >}} instances
 for metric collection. Otherwise, metrics for the same services would be sent to different instances, making aggregations inaccurate.
-* `"traceID"`: spans belonging to the same traceID will be exported to the same backend.
+- `"traceID"`: spans/logs belonging to the same traceID will be exported to the same backend.
+- `"resource"`: metrics belonging to the same resource will be exported to the same backend.
+- `"metric"`: metrics with the same name will be exported to the same backend
+- `"streamID"`: metrics with the same streamID will be exported to the same backend
+
+The loadbalancer will configure the exporter for the singal types supported by the `routing_key`
+
+Metrics support in `otelcol.exporter.loadbalancing` is considered experimental, so an exporter
+will be configured for metrics only if Alloy is run with `--stability-level=experimental`
 
 ## Blocks
 

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.loadbalancing.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.loadbalancing.md
@@ -68,7 +68,7 @@ for metric collection. Otherwise, metrics for the same services would be sent to
 - `"traceID"`: spans and logs belonging to the same `traceID` will be exported to the same backend.
 - `"resource"`: metrics belonging to the same resource will be exported to the same backend.
 - `"metric"`: metrics with the same name will be exported to the same backend.
-- `"streamID"`: metrics with the same streamID will be exported to the same backend
+- `"streamID"`: metrics with the same `streamID` will be exported to the same backend.
 
 The loadbalancer will configure the exporter for the singal types supported by the `routing_key`
 

--- a/internal/component/otelcol/exporter/awss3/awss3.go
+++ b/internal/component/otelcol/exporter/awss3/awss3.go
@@ -23,7 +23,7 @@ func init() {
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := awss3exporter.NewFactory()
-			return exporter.New(opts, fact, args.(Arguments), exporter.TypeAll)
+			return exporter.New(opts, fact, args.(Arguments), exporter.TypeSignalConstFunc(exporter.TypeAll))
 		},
 	})
 }

--- a/internal/component/otelcol/exporter/datadog/datadog.go
+++ b/internal/component/otelcol/exporter/datadog/datadog.go
@@ -42,7 +42,7 @@ func init() {
 			// Since we don't have that, we disable the feature gate to allow the exporter to compute APM stats.
 			// See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datadogexporter for more
 			featuregate.GlobalRegistry().Set("exporter.datadogexporter.DisableAPMStats", false)
-			return exporter.New(opts, fact, args.(Arguments), exporter.TypeAll)
+			return exporter.New(opts, fact, args.(Arguments), exporter.TypeSignalConstFunc(exporter.TypeAll))
 		},
 	})
 }

--- a/internal/component/otelcol/exporter/debug/debug.go
+++ b/internal/component/otelcol/exporter/debug/debug.go
@@ -25,7 +25,7 @@ func init() {
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := debugexporter.NewFactory()
-			return exporter.New(opts, fact, args.(Arguments), exporter.TypeAll)
+			return exporter.New(opts, fact, args.(Arguments), exporter.TypeSignalConstFunc(exporter.TypeAll))
 		},
 	})
 }

--- a/internal/component/otelcol/exporter/exporter.go
+++ b/internal/component/otelcol/exporter/exporter.go
@@ -100,6 +100,7 @@ type Exporter struct {
 
 	// Signals which the exporter is able to export.
 	// Can be logs, metrics, traces or any combination of them.
+	// This is a function because which signals are supported may depend on the component configuration.
 	supportedSignals TypeSignalFunc
 }
 

--- a/internal/component/otelcol/exporter/exporter_test.go
+++ b/internal/component/otelcol/exporter/exporter_test.go
@@ -105,7 +105,7 @@ func newTestEnvironment(t *testing.T, fe *fakeExporter) *testEnvironment {
 				}, otelcomponent.StabilityLevelUndefined),
 			)
 
-			return exporter.New(opts, factory, args.(exporter.Arguments), exporter.TypeAll)
+			return exporter.New(opts, factory, args.(exporter.Arguments), exporter.TypeSignalConstFunc(exporter.TypeAll))
 		},
 	}
 

--- a/internal/component/otelcol/exporter/kafka/kafka.go
+++ b/internal/component/otelcol/exporter/kafka/kafka.go
@@ -28,7 +28,7 @@ func init() {
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := kafkaexporter.NewFactory()
-			return exporter.New(opts, fact, args.(Arguments), exporter.TypeAll)
+			return exporter.New(opts, fact, args.(Arguments), exporter.TypeSignalConstFunc(exporter.TypeAll))
 		},
 	})
 }

--- a/internal/component/otelcol/exporter/loadbalancing/loadbalancing_test.go
+++ b/internal/component/otelcol/exporter/loadbalancing/loadbalancing_test.go
@@ -1,13 +1,20 @@
 package loadbalancing_test
 
 import (
+	"context"
+	"fmt"
+	"net"
 	"testing"
 	"time"
 
 	"github.com/grafana/alloy/internal/component/otelcol"
 	otelcolCfg "github.com/grafana/alloy/internal/component/otelcol/config"
 	"github.com/grafana/alloy/internal/component/otelcol/exporter/loadbalancing"
+	"github.com/grafana/alloy/internal/runtime/componenttest"
+	"github.com/grafana/alloy/internal/runtime/logging/level"
+	"github.com/grafana/alloy/internal/util"
 	"github.com/grafana/alloy/syntax"
+	"github.com/grafana/dskit/backoff"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/config/configgrpc"
@@ -15,11 +22,214 @@ import (
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+	"google.golang.org/grpc"
 )
 
 func getPtrToUint(v uint16) *uint16 {
 	res := &v
 	return res
+}
+
+// Test performs a basic integration test which runs the otelcol.exporter.loadbalancing
+// component and ensures that it can pass data to an OTLP gRPC server.
+func Test(t *testing.T) {
+	traceCh := make(chan ptrace.Traces)
+	tracesServer := makeTracesServer(t, traceCh)
+
+	ctx := componenttest.TestContext(t)
+	l := util.TestLogger(t)
+
+	ctrl, err := componenttest.NewControllerFromID(l, "otelcol.exporter.loadbalancing")
+	require.NoError(t, err)
+
+	cfgTemplate := `
+			routing_key = "%s"
+			resolver {
+				static {
+					hostnames = ["%s"]
+				}
+			}
+			protocol {
+				otlp {
+					client {
+						compression = "none"
+
+						tls {
+							insecure             = true
+							insecure_skip_verify = true
+						}
+					}
+				}
+			}
+
+			debug_metrics {
+				disable_high_cardinality_metrics = true
+			}
+		`
+
+	cfg := fmt.Sprintf(cfgTemplate, "traceID", tracesServer)
+	var args loadbalancing.Arguments
+	require.NoError(t, syntax.Unmarshal([]byte(cfg), &args))
+	require.Equal(t, args.DebugMetricsConfig().DisableHighCardinalityMetrics, true)
+
+	go func() {
+		err := ctrl.Run(ctx, args)
+		require.NoError(t, err)
+	}()
+
+	require.NoError(t, ctrl.WaitRunning(time.Second), "component never started")
+	require.NoError(t, ctrl.WaitExports(time.Second), "component never exported anything")
+
+	// Send traces in the background to our exporter.
+	go func() {
+		exports := ctrl.Exports().(otelcol.ConsumerExports)
+
+		bo := backoff.New(ctx, backoff.Config{
+			MinBackoff: 10 * time.Millisecond,
+			MaxBackoff: 100 * time.Millisecond,
+		})
+		for bo.Ongoing() {
+			err := exports.Input.ConsumeTraces(ctx, createTestTraces())
+			if err != nil {
+				level.Error(l).Log("msg", "failed to send traces", "err", err)
+				bo.Wait()
+				continue
+			}
+
+			return
+		}
+	}()
+
+	// Wait for our exporter to finish and pass data to our rpc server.
+	select {
+	case <-time.After(time.Second):
+		require.FailNow(t, "failed waiting for traces")
+	case tr := <-traceCh:
+		require.Equal(t, 1, tr.SpanCount())
+	}
+
+	// Update the config to disable traces export
+	cfg = fmt.Sprintf(cfgTemplate, "metric", tracesServer)
+	require.NoError(t, syntax.Unmarshal([]byte(cfg), &args))
+	ctrl.Update(args)
+
+	// Send traces in the background to our exporter.
+	go func() {
+		exports := ctrl.Exports().(otelcol.ConsumerExports)
+
+		bo := backoff.New(ctx, backoff.Config{
+			MaxRetries: 3,
+			MinBackoff: 10 * time.Millisecond,
+			MaxBackoff: 100 * time.Millisecond,
+		})
+		for bo.Ongoing() {
+			err := exports.Input.ConsumeTraces(ctx, createTestTraces())
+			require.ErrorContains(t, err, "telemetry type is not supported")
+			if err != nil {
+				level.Error(l).Log("msg", "failed to send traces", "err", err)
+				bo.Wait()
+				continue
+			}
+
+			return
+		}
+	}()
+
+	// Wait for our exporter to finish and pass data to our rpc server.
+	// no error here, as we we expect to fail sending in the first place
+	select {
+	case <-traceCh:
+		require.FailNow(t, "no traces expected here")
+	case <-time.After(time.Second):
+	}
+
+	// Re-run the test with reenabled traces export
+	cfg = fmt.Sprintf(cfgTemplate, "traceID", tracesServer)
+	require.NoError(t, syntax.Unmarshal([]byte(cfg), &args))
+	ctrl.Update(args)
+
+	// Send traces in the background to our exporter.
+	go func() {
+		exports := ctrl.Exports().(otelcol.ConsumerExports)
+
+		bo := backoff.New(ctx, backoff.Config{
+			MinBackoff: 10 * time.Millisecond,
+			MaxBackoff: 100 * time.Millisecond,
+		})
+		for bo.Ongoing() {
+			err := exports.Input.ConsumeTraces(ctx, createTestTraces())
+			if err != nil {
+				level.Error(l).Log("msg", "failed to send traces", "err", err)
+				bo.Wait()
+				continue
+			}
+
+			return
+		}
+	}()
+
+	// Wait for our exporter to finish and pass data to our rpc server.
+	select {
+	case <-time.After(time.Second):
+		require.FailNow(t, "failed waiting for traces")
+	case tr := <-traceCh:
+		require.Equal(t, 1, tr.SpanCount())
+	}
+}
+
+// makeTracesServer returns a host:port which will accept traces over insecure
+// gRPC.
+func makeTracesServer(t *testing.T, ch chan ptrace.Traces) string {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := grpc.NewServer()
+	ptraceotlp.RegisterGRPCServer(srv, &mockTracesReceiver{ch: ch})
+
+	go func() {
+		err := srv.Serve(lis)
+		require.NoError(t, err)
+	}()
+	t.Cleanup(srv.Stop)
+
+	return lis.Addr().String()
+}
+
+type mockTracesReceiver struct {
+	ptraceotlp.UnimplementedGRPCServer
+	ch chan ptrace.Traces
+}
+
+var _ ptraceotlp.GRPCServer = (*mockTracesReceiver)(nil)
+
+func (ms *mockTracesReceiver) Export(_ context.Context, req ptraceotlp.ExportRequest) (ptraceotlp.ExportResponse, error) {
+	ms.ch <- req.Traces()
+	return ptraceotlp.NewExportResponse(), nil
+}
+
+func createTestTraces() ptrace.Traces {
+	// Matches format from the protobuf definition:
+	// https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/trace/v1/trace.proto
+	bb := `{
+			"resource_spans": [{
+				"scope_spans": [{
+					"spans": [{
+						"name": "TestSpan"
+					}]
+				}]
+			}]
+		}`
+
+	decoder := &ptrace.JSONUnmarshaler{}
+	data, err := decoder.UnmarshalTraces([]byte(bb))
+	if err != nil {
+		panic(err)
+	}
+	return data
 }
 
 func TestConfigConversion(t *testing.T) {

--- a/internal/component/otelcol/exporter/otlp/otlp.go
+++ b/internal/component/otelcol/exporter/otlp/otlp.go
@@ -25,7 +25,7 @@ func init() {
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := otlpexporter.NewFactory()
-			return exporter.New(opts, fact, args.(Arguments), exporter.TypeAll)
+			return exporter.New(opts, fact, args.(Arguments), exporter.TypeSignalConstFunc(exporter.TypeAll))
 		},
 	})
 }

--- a/internal/component/otelcol/exporter/otlphttp/otlphttp.go
+++ b/internal/component/otelcol/exporter/otlphttp/otlphttp.go
@@ -26,7 +26,7 @@ func init() {
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := otlphttpexporter.NewFactory()
-			return exporter.New(opts, fact, args.(Arguments), exporter.TypeAll)
+			return exporter.New(opts, fact, args.(Arguments), exporter.TypeSignalConstFunc(exporter.TypeAll))
 		},
 	})
 }

--- a/internal/component/otelcol/exporter/splunkhec/splunkhec.go
+++ b/internal/component/otelcol/exporter/splunkhec/splunkhec.go
@@ -24,7 +24,7 @@ func init() {
 		Exports:   otelcol.ConsumerExports{},
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := splunkhecexporter.NewFactory()
-			return exporter.New(opts, fact, args.(Arguments), exporter.TypeAll)
+			return exporter.New(opts, fact, args.(Arguments), exporter.TypeSignalConstFunc(exporter.TypeAll))
 		},
 	})
 }

--- a/internal/component/otelcol/exporter/syslog/syslog.go
+++ b/internal/component/otelcol/exporter/syslog/syslog.go
@@ -27,7 +27,7 @@ func init() {
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := syslogexporter.NewFactory()
-			return exporter.New(opts, fact, args.(Arguments), exporter.TypeLogs)
+			return exporter.New(opts, fact, args.(Arguments), exporter.TypeSignalConstFunc(exporter.TypeLogs))
 		},
 	})
 }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Metrics support was turned off in `otelcol.exporter.loadbalancing` for two reasons: 
- metrics support is considered `development` upstream
- the metrics exporter crashed when configured with the default `routing_key = traceID`

Solve both issues by supporting metrics only if the specified `routing_key` supports it and stability level is set to `experimental`

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
