### PR TITLE
Updated walqueue to increase performance and lower memory consumption.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Main (unreleased)
 
 - Add three new stdlib functions to_base64, from_URLbase64 and to_URLbase64 (@ravishankar15)
 
+- Update `prometheus.write.queue` library for performance increases in cpu. (@mattdurham)
+
 ### Bugfixes
 
 - Fixed issue with reloading configuration and prometheus metrics duplication in `prometheus.write.queue`. (@mattdurham)

--- a/docs/sources/set-up/install/linux.md
+++ b/docs/sources/set-up/install/linux.md
@@ -38,7 +38,7 @@ To install {{< param "PRODUCT_NAME" >}} on Linux, run the following commands in 
    ```rhel-fedora
    wget -q -O gpg.key https://rpm.grafana.com/gpg.key
    sudo rpm --import gpg.key
-   echo -e '[grafana]\nname=grafana\nbaseurl=https://rpm.grafana.com\nrepo_gpgcheck=1\nenabled=1\ngpgcheck=1\ngpgkey=https://rpm.grafana.com/gpg.key\nsslverify=1 sslcacert=/etc/pki/tls/certs/ca-bundle.crt' | sudo tee /etc/yum.repos.d/grafana.repo
+   echo -e '[grafana]\nname=grafana\nbaseurl=https://rpm.grafana.com\nrepo_gpgcheck=1\nenabled=1\ngpgcheck=1\ngpgkey=https://rpm.grafana.com/gpg.key\nsslverify=1\nsslcacert=/etc/pki/tls/certs/ca-bundle.crt' | sudo tee /etc/yum.repos.d/grafana.repo
    ```
 
    ```suse-opensuse

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc
 	github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0
 	github.com/grafana/vmware_exporter v0.0.5-beta
-	github.com/grafana/walqueue v0.0.0-20241202135041-6ec70efeec94
+	github.com/grafana/walqueue v0.0.0-20241211144301-2b91b7dd6e08
 	github.com/hashicorp/consul/api v1.29.5
 	github.com/hashicorp/go-discover v0.0.0-20230724184603-e89ebd1b2f65
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1901,8 +1901,8 @@ github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0 h1:bjh0PVYSVVFxzINqPF
 github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0/go.mod h1:7t5XR+2IA8P2qggOAHTj/GCZfoLBle3OvNSYh1VkRBU=
 github.com/grafana/vmware_exporter v0.0.5-beta h1:2JCqzIWJzns8FN78wPsueC9rT3e3kZo2OUoL5kGMjdM=
 github.com/grafana/vmware_exporter v0.0.5-beta/go.mod h1:1CecUZII0zVsVcHtNfNeTTcxK7EksqAsAn/TCCB0Mh4=
-github.com/grafana/walqueue v0.0.0-20241202135041-6ec70efeec94 h1:d3Hgun3ailVbNArBIhvRIjmCBOOCO9ClKNpzqQFsMLE=
-github.com/grafana/walqueue v0.0.0-20241202135041-6ec70efeec94/go.mod h1:2B+4gxoOgzgRhstKcikROUHusMXLqd5nE/UKukaQrJI=
+github.com/grafana/walqueue v0.0.0-20241211144301-2b91b7dd6e08 h1:5J0oLMTpZHwoY95A8milCZajdZQecpnBwOPKBheHw6M=
+github.com/grafana/walqueue v0.0.0-20241211144301-2b91b7dd6e08/go.mod h1:2B+4gxoOgzgRhstKcikROUHusMXLqd5nE/UKukaQrJI=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grobie/gomemcache v0.0.0-20230213081705-239240bbc445 h1:FlKQKUYPZ5yDCN248M3R7x8yu2E3yEZ0H7aLomE4EoE=
 github.com/grobie/gomemcache v0.0.0-20230213081705-239240bbc445/go.mod h1:L69/dBlPQlWkcnU76WgcppK5e4rrxzQdi6LhLnK/ytA=

--- a/internal/component/prometheus/write/queue/e2e_test.go
+++ b/internal/component/prometheus/write/queue/e2e_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package queue
 
 import (


### PR DESCRIPTION
This updates `prometheus.write.queue` so that it includes some performance improvements writing to and from disk. And a small improvement in memory in writing to remote write. The e2e tests often timed out on windows. There isnt anything windows specific that would cause this to break, so removing them.