### PR TITLE
Make otel scheduler sync

### DIFF
--- a/internal/component/otelcol/auth/auth.go
+++ b/internal/component/otelcol/auth/auth.go
@@ -198,7 +198,7 @@ func (a *Auth) Update(args component.Arguments) error {
 	})
 
 	// Schedule the components to run once our component is running.
-	a.sched.Schedule(host, components...)
+	a.sched.Schedule(a.ctx, host, components...)
 	return nil
 }
 

--- a/internal/component/otelcol/auth/auth.go
+++ b/internal/component/otelcol/auth/auth.go
@@ -198,7 +198,7 @@ func (a *Auth) Update(args component.Arguments) error {
 	})
 
 	// Schedule the components to run once our component is running.
-	a.sched.Schedule(a.ctx, host, components...)
+	a.sched.Schedule(a.ctx, func() {}, host, components...)
 	return nil
 }
 

--- a/internal/component/otelcol/connector/connector.go
+++ b/internal/component/otelcol/connector/connector.go
@@ -117,7 +117,7 @@ func New(opts component.Options, f otelconnector.Factory, args Arguments) (*Conn
 		factory:  f,
 		consumer: consumer,
 
-		sched:     scheduler.New(opts.Logger),
+		sched:     scheduler.NewWithPauseCallbacks(opts.Logger, consumer.Pause, consumer.Resume),
 		collector: collector,
 	}
 	if err := p.Update(args); err != nil {
@@ -214,11 +214,12 @@ func (p *Connector) Update(args component.Arguments) error {
 		return errors.New("unsupported connector type")
 	}
 
+	updateConsumersFunc := func() {
+		p.consumer.SetConsumers(tracesConnector, metricsConnector, logsConnector)
+	}
+
 	// Schedule the components to run once our component is running.
-	p.consumer.Pause()
-	p.consumer.SetConsumers(tracesConnector, metricsConnector, logsConnector)
-	p.sched.Schedule(p.ctx, host, components...)
-	p.consumer.Resume()
+	p.sched.Schedule(p.ctx, updateConsumersFunc, host, components...)
 	return nil
 }
 

--- a/internal/component/otelcol/connector/connector.go
+++ b/internal/component/otelcol/connector/connector.go
@@ -117,7 +117,7 @@ func New(opts component.Options, f otelconnector.Factory, args Arguments) (*Conn
 		factory:  f,
 		consumer: consumer,
 
-		sched:     scheduler.NewWithPauseCallbacks(opts.Logger, consumer.Pause, consumer.Resume),
+		sched:     scheduler.New(opts.Logger),
 		collector: collector,
 	}
 	if err := p.Update(args); err != nil {
@@ -215,8 +215,10 @@ func (p *Connector) Update(args component.Arguments) error {
 	}
 
 	// Schedule the components to run once our component is running.
-	p.sched.Schedule(host, components...)
+	p.consumer.Pause()
 	p.consumer.SetConsumers(tracesConnector, metricsConnector, logsConnector)
+	p.sched.Schedule(p.ctx, host, components...)
+	p.consumer.Resume()
 	return nil
 }
 

--- a/internal/component/otelcol/exporter/exporter.go
+++ b/internal/component/otelcol/exporter/exporter.go
@@ -131,7 +131,7 @@ func New(opts component.Options, f otelexporter.Factory, args Arguments, support
 		factory:  f,
 		consumer: consumer,
 
-		sched:     scheduler.NewWithPauseCallbacks(opts.Logger, consumer.Pause, consumer.Resume),
+		sched:     scheduler.New(opts.Logger),
 		collector: collector,
 
 		supportedSignals: supportedSignals,
@@ -243,8 +243,10 @@ func (e *Exporter) Update(args component.Arguments) error {
 	}
 
 	// Schedule the components to run once our component is running.
-	e.sched.Schedule(host, components...)
+	e.consumer.Pause()
 	e.consumer.SetConsumers(tracesExporter, metricsExporter, logsExporter)
+	e.sched.Schedule(e.ctx, host, components...)
+	e.consumer.Resume()
 	return nil
 }
 

--- a/internal/component/otelcol/extension/extension.go
+++ b/internal/component/otelcol/extension/extension.go
@@ -162,7 +162,7 @@ func (e *Extension) Update(args component.Arguments) error {
 	}
 
 	// Schedule the components to run once our component is running.
-	e.sched.Schedule(host, components...)
+	e.sched.Schedule(e.ctx, host, components...)
 	return nil
 }
 

--- a/internal/component/otelcol/extension/extension.go
+++ b/internal/component/otelcol/extension/extension.go
@@ -162,7 +162,7 @@ func (e *Extension) Update(args component.Arguments) error {
 	}
 
 	// Schedule the components to run once our component is running.
-	e.sched.Schedule(e.ctx, host, components...)
+	e.sched.Schedule(e.ctx, func() {}, host, components...)
 	return nil
 }
 

--- a/internal/component/otelcol/internal/scheduler/scheduler.go
+++ b/internal/component/otelcol/internal/scheduler/scheduler.go
@@ -105,7 +105,7 @@ func (cs *Scheduler) Schedule(ctx context.Context, updateConsumers func(), h ote
 	cs.stopComponents(ctx, cs.schedComponents...)
 
 	// 3. Change the consumers
-	// This is can only be done after stopping the pervious components and before starting the new ones.
+	// This can only be done after stopping the pervious components and before starting the new ones.
 	updateConsumers()
 
 	// 4. Start the new components

--- a/internal/component/otelcol/internal/scheduler/scheduler.go
+++ b/internal/component/otelcol/internal/scheduler/scheduler.go
@@ -138,6 +138,9 @@ func (cs *Scheduler) Run(ctx context.Context) error {
 		cs.schedMut.Lock()
 		defer cs.schedMut.Unlock()
 		cs.stopComponents(context.Background(), cs.schedComponents...)
+		// this Resume call should not be needed but is added for robustness to ensure that
+		// it does not ever exit in "paused" state.
+		cs.onResume()
 	}()
 
 	<-ctx.Done()

--- a/internal/component/otelcol/internal/scheduler/scheduler.go
+++ b/internal/component/otelcol/internal/scheduler/scheduler.go
@@ -74,6 +74,9 @@ func NewWithPauseCallbacks(l log.Logger, onPause func(), onResume func()) *Sched
 //
 // Schedule() completely overrides the set of previously running components.
 // Components which have been removed since the last call to Schedule will be stopped.
+//
+// updateConsumers is called after the components are paused and before starting the new components.
+// It is expected that this function will set the new set of consumers to the wrapping consumer that's assigned to the Alloy component.
 func (cs *Scheduler) Schedule(ctx context.Context, updateConsumers func(), h otelcomponent.Host, cc ...otelcomponent.Component) {
 	cs.schedMut.Lock()
 	defer cs.schedMut.Unlock()
@@ -109,7 +112,7 @@ func (cs *Scheduler) Schedule(ctx context.Context, updateConsumers func(), h ote
 	updateConsumers()
 
 	// 4. Start the new components
-	level.Debug(cs.log).Log("msg", "scheduling components", "count", len(cs.schedComponents))
+	level.Debug(cs.log).Log("msg", "scheduling otelcol components", "count", len(cs.schedComponents))
 	cs.schedComponents = cs.startComponents(ctx, h, cc...)
 	cs.host = h
 	//TODO: What if the trace component failed but the metrics one didn't? Should we resume all consumers?

--- a/internal/component/otelcol/internal/scheduler/scheduler_test.go
+++ b/internal/component/otelcol/internal/scheduler/scheduler_test.go
@@ -30,7 +30,7 @@ func TestScheduler(t *testing.T) {
 		// Schedule our component, which should notify the started trigger once it is
 		// running.
 		component, started, _ := newTriggerComponent()
-		cs.Schedule(context.Background(), h, component)
+		cs.Schedule(context.Background(), func() {}, h, component)
 		require.NoError(t, started.Wait(5*time.Second), "component did not start")
 	})
 
@@ -50,12 +50,12 @@ func TestScheduler(t *testing.T) {
 		// Schedule our component, which should notify the started and stopped
 		// trigger once it starts and stops respectively.
 		component, started, stopped := newTriggerComponent()
-		cs.Schedule(context.Background(), h, component)
+		cs.Schedule(context.Background(), func() {}, h, component)
 
 		// Wait for the component to start, and then unschedule all components, which
 		// should cause our running component to terminate.
 		require.NoError(t, started.Wait(5*time.Second), "component did not start")
-		cs.Schedule(context.Background(), h)
+		cs.Schedule(context.Background(), func() {}, h)
 		require.NoError(t, stopped.Wait(5*time.Second), "component did not shutdown")
 	})
 
@@ -78,7 +78,7 @@ func TestScheduler(t *testing.T) {
 		// Schedule our component which will notify our trigger when Shutdown gets
 		// called.
 		component, started, stopped := newTriggerComponent()
-		cs.Schedule(ctx, h, component)
+		cs.Schedule(ctx, func() {}, h, component)
 
 		// Wait for the component to start, and then stop our scheduler, which
 		// should cause our running component to terminate.

--- a/internal/component/otelcol/internal/scheduler/scheduler_test.go
+++ b/internal/component/otelcol/internal/scheduler/scheduler_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/atomic"
+
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	otelcomponent "go.opentelemetry.io/collector/component"
 
@@ -57,6 +60,65 @@ func TestScheduler(t *testing.T) {
 		require.NoError(t, started.Wait(5*time.Second), "component did not start")
 		cs.Schedule(context.Background(), func() {}, h)
 		require.NoError(t, stopped.Wait(5*time.Second), "component did not shutdown")
+	})
+
+	t.Run("Pause callbacks are called", func(t *testing.T) {
+		var (
+			pauseCalls  = &atomic.Int32{}
+			resumeCalls = &atomic.Int32{}
+			l           = util.TestLogger(t)
+			cs          = scheduler.NewWithPauseCallbacks(
+				l,
+				func() { pauseCalls.Inc() },
+				func() { resumeCalls.Inc() },
+			)
+			h = scheduler.NewHost(l)
+		)
+		ctx, cancel := context.WithCancel(context.Background())
+
+		// Run our scheduler in the background.
+		go func() {
+			err := cs.Run(ctx)
+			require.NoError(t, err)
+		}()
+
+		toInt := func(a *atomic.Int32) int { return int(a.Load()) }
+
+		// The Run function starts the components. They should be paused and then resumed.
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			assert.Equal(t, 1, toInt(pauseCalls), "pause callbacks should be called on run")
+			assert.Equal(t, 1, toInt(resumeCalls), "resume callback should be called on run")
+		}, 5*time.Second, 10*time.Millisecond, "pause/resume callbacks not called correctly")
+
+		// Schedule our component, which should notify the started and stopped
+		// trigger once it starts and stops respectively.
+		component, started, stopped := newTriggerComponent()
+		cs.Schedule(ctx, func() {}, h, component)
+
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			assert.Equal(t, 2, toInt(pauseCalls), "pause callbacks should be called on schedule")
+			assert.Equal(t, 2, toInt(resumeCalls), "resume callback should be called on schedule")
+		}, 5*time.Second, 10*time.Millisecond, "pause/resume callbacks not called correctly")
+
+		// Wait for the component to start, and then unschedule all components, which
+		// should cause our running component to terminate.
+		require.NoError(t, started.Wait(5*time.Second), "component did not start")
+		cs.Schedule(ctx, func() {}, h)
+
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			assert.Equal(t, 3, toInt(pauseCalls), "pause callback should be called on second schedule")
+			assert.Equal(t, 3, toInt(resumeCalls), "resume callback should be called on second schedule")
+		}, 5*time.Second, 10*time.Millisecond, "pause/resume callbacks not called correctly")
+
+		require.NoError(t, stopped.Wait(5*time.Second), "component did not shutdown")
+
+		// Stop the scheduler
+		cancel()
+
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			assert.Equal(t, 3, toInt(pauseCalls), "pause callback should not be called on shutdown")
+			assert.Equal(t, 3, toInt(resumeCalls), "resume callback should not be called on shutdown")
+		}, 5*time.Second, 10*time.Millisecond, "pause/resume callbacks not called correctly")
 	})
 
 	t.Run("Running components get stopped on shutdown", func(t *testing.T) {

--- a/internal/component/otelcol/internal/scheduler/scheduler_test.go
+++ b/internal/component/otelcol/internal/scheduler/scheduler_test.go
@@ -5,10 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	otelcomponent "go.opentelemetry.io/collector/component"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/alloy/internal/component/otelcol/internal/scheduler"
 	"github.com/grafana/alloy/internal/runtime/componenttest"
@@ -32,7 +30,7 @@ func TestScheduler(t *testing.T) {
 		// Schedule our component, which should notify the started trigger once it is
 		// running.
 		component, started, _ := newTriggerComponent()
-		cs.Schedule(h, component)
+		cs.Schedule(context.Background(), h, component)
 		require.NoError(t, started.Wait(5*time.Second), "component did not start")
 	})
 
@@ -52,66 +50,13 @@ func TestScheduler(t *testing.T) {
 		// Schedule our component, which should notify the started and stopped
 		// trigger once it starts and stops respectively.
 		component, started, stopped := newTriggerComponent()
-		cs.Schedule(h, component)
+		cs.Schedule(context.Background(), h, component)
 
 		// Wait for the component to start, and then unschedule all components, which
 		// should cause our running component to terminate.
 		require.NoError(t, started.Wait(5*time.Second), "component did not start")
-		cs.Schedule(h)
+		cs.Schedule(context.Background(), h)
 		require.NoError(t, stopped.Wait(5*time.Second), "component did not shutdown")
-	})
-
-	t.Run("Pause callbacks are called", func(t *testing.T) {
-		var (
-			pauseCalls  = &atomic.Int32{}
-			resumeCalls = &atomic.Int32{}
-			l           = util.TestLogger(t)
-			cs          = scheduler.NewWithPauseCallbacks(
-				l,
-				func() { pauseCalls.Inc() },
-				func() { resumeCalls.Inc() },
-			)
-			h = scheduler.NewHost(l)
-		)
-		ctx, cancel := context.WithCancel(context.Background())
-
-		// Run our scheduler in the background.
-		go func() {
-			err := cs.Run(ctx)
-			require.NoError(t, err)
-		}()
-
-		// Schedule our component, which should notify the started and stopped
-		// trigger once it starts and stops respectively.
-		component, started, stopped := newTriggerComponent()
-		cs.Schedule(h, component)
-
-		toInt := func(a *atomic.Int32) int { return int(a.Load()) }
-
-		require.EventuallyWithT(t, func(t *assert.CollectT) {
-			assert.Equal(t, 0, toInt(pauseCalls), "pause callbacks should not be called on first run")
-			assert.Equal(t, 1, toInt(resumeCalls), "resume callback should be called on first run")
-		}, 5*time.Second, 10*time.Millisecond, "pause/resume callbacks not called correctly")
-
-		// Wait for the component to start, and then unschedule all components, which
-		// should cause our running component to terminate.
-		require.NoError(t, started.Wait(5*time.Second), "component did not start")
-		cs.Schedule(h)
-
-		require.EventuallyWithT(t, func(t *assert.CollectT) {
-			assert.Equal(t, 1, toInt(pauseCalls), "pause callback should be called on second run")
-			assert.Equal(t, 2, toInt(resumeCalls), "resume callback should be called on second run")
-		}, 5*time.Second, 10*time.Millisecond, "pause/resume callbacks not called correctly")
-
-		require.NoError(t, stopped.Wait(5*time.Second), "component did not shutdown")
-
-		// Stop the scheduler
-		cancel()
-
-		require.EventuallyWithT(t, func(t *assert.CollectT) {
-			assert.Equal(t, 2, toInt(pauseCalls), "pause callback should be called on shutdown")
-			assert.Equal(t, 3, toInt(resumeCalls), "resume callback should be called on shutdown")
-		}, 5*time.Second, 10*time.Millisecond, "pause/resume callbacks not called correctly")
 	})
 
 	t.Run("Running components get stopped on shutdown", func(t *testing.T) {
@@ -133,7 +78,7 @@ func TestScheduler(t *testing.T) {
 		// Schedule our component which will notify our trigger when Shutdown gets
 		// called.
 		component, started, stopped := newTriggerComponent()
-		cs.Schedule(h, component)
+		cs.Schedule(ctx, h, component)
 
 		// Wait for the component to start, and then stop our scheduler, which
 		// should cause our running component to terminate.

--- a/internal/component/otelcol/internal/scheduler/scheduler_test.go
+++ b/internal/component/otelcol/internal/scheduler/scheduler_test.go
@@ -117,7 +117,7 @@ func TestScheduler(t *testing.T) {
 
 		require.EventuallyWithT(t, func(t *assert.CollectT) {
 			assert.Equal(t, 3, toInt(pauseCalls), "pause callback should not be called on shutdown")
-			assert.Equal(t, 3, toInt(resumeCalls), "resume callback should not be called on shutdown")
+			assert.Equal(t, 4, toInt(resumeCalls), "resume callback should be called on shutdown")
 		}, 5*time.Second, 10*time.Millisecond, "pause/resume callbacks not called correctly")
 	})
 

--- a/internal/component/otelcol/processor/processor.go
+++ b/internal/component/otelcol/processor/processor.go
@@ -117,7 +117,7 @@ func New(opts component.Options, f otelprocessor.Factory, args Arguments) (*Proc
 		factory:  f,
 		consumer: consumer,
 
-		sched:     scheduler.New(opts.Logger),
+		sched:     scheduler.NewWithPauseCallbacks(opts.Logger, consumer.Pause, consumer.Resume),
 		collector: collector,
 
 		liveDebuggingConsumer: livedebuggingconsumer.New(debugDataPublisher.(livedebugging.DebugDataPublisher), opts.ID),
@@ -237,11 +237,12 @@ func (p *Processor) Update(args component.Arguments) error {
 		}
 	}
 
+	updateConsumersFunc := func() {
+		p.consumer.SetConsumers(tracesProcessor, metricsProcessor, logsProcessor)
+	}
+
 	// Schedule the components to run once our component is running.
-	p.consumer.Pause()
-	p.consumer.SetConsumers(tracesProcessor, metricsProcessor, logsProcessor)
-	p.sched.Schedule(p.ctx, host, components...)
-	p.consumer.Resume()
+	p.sched.Schedule(p.ctx, updateConsumersFunc, host, components...)
 
 	return nil
 }

--- a/internal/component/otelcol/processor/processor.go
+++ b/internal/component/otelcol/processor/processor.go
@@ -117,7 +117,7 @@ func New(opts component.Options, f otelprocessor.Factory, args Arguments) (*Proc
 		factory:  f,
 		consumer: consumer,
 
-		sched:     scheduler.NewWithPauseCallbacks(opts.Logger, consumer.Pause, consumer.Resume),
+		sched:     scheduler.New(opts.Logger),
 		collector: collector,
 
 		liveDebuggingConsumer: livedebuggingconsumer.New(debugDataPublisher.(livedebugging.DebugDataPublisher), opts.ID),
@@ -238,8 +238,11 @@ func (p *Processor) Update(args component.Arguments) error {
 	}
 
 	// Schedule the components to run once our component is running.
-	p.sched.Schedule(host, components...)
+	p.consumer.Pause()
 	p.consumer.SetConsumers(tracesProcessor, metricsProcessor, logsProcessor)
+	p.sched.Schedule(p.ctx, host, components...)
+	p.consumer.Resume()
+
 	return nil
 }
 

--- a/internal/component/otelcol/receiver/receiver.go
+++ b/internal/component/otelcol/receiver/receiver.go
@@ -233,7 +233,7 @@ func (r *Receiver) Update(args component.Arguments) error {
 	}
 
 	// Schedule the components to run once our component is running.
-	r.sched.Schedule(host, components...)
+	r.sched.Schedule(r.ctx, host, components...)
 	return nil
 }
 

--- a/internal/component/otelcol/receiver/receiver.go
+++ b/internal/component/otelcol/receiver/receiver.go
@@ -233,7 +233,7 @@ func (r *Receiver) Update(args component.Arguments) error {
 	}
 
 	// Schedule the components to run once our component is running.
-	r.sched.Schedule(r.ctx, host, components...)
+	r.sched.Schedule(r.ctx, func() {}, host, components...)
 	return nil
 }
 


### PR DESCRIPTION
The fix in https://github.com/grafana/alloy/pull/2027 did not address all the race conditions that could happen with the scheduler. We noticed it when getting rid of our Otel fork brought back the flakiness of a batch processor test.

With this change, the scheduling of otel components is not an async operation anymore. This simplifies the logic and ensures that the components are started before they can start consuming.
