### PR TITLE
add docs deploy preview

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -1,0 +1,23 @@
+name: Deploy pr preview
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - closed
+    paths:
+      - "docs/sources/**"
+
+jobs:
+  deploy-pr-preview:
+    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
+    with:
+      sha: ${{ github.event.pull_request.head.sha }}
+      branch: ${{ github.head_ref }}
+      event_number: ${{ github.event.number }}
+      title: ${{ github.event.pull_request.title }}
+      repo: alloy
+      website_directory: content/docs/alloy/latest
+      relative_prefix: /docs/alloy/latest/
+      index_file: true

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,14 +8,14 @@
 
 * @grafana/grafana-alloy-maintainers
 
-#`make docs` procedure and related workflows are owned by @grafana/docs-tooling.
-/.github/workflows/deploy-pr-preview.yml                       @grafana/docs-tooling
-/.github/workflows/publish-technical-documentation-next.yml    @grafana/docs-tooling
-/.github/workflows/publish-technical-documentation-release.yml @grafana/docs-tooling
-/.github/workflows/update-make-docs.yml                        @grafana/docs-tooling
-/docs/docs.mk                                                  @grafana/docs-tooling
-/docs/make-docs                                                @grafana/docs-tooling
-/docs/variables.mk                                             @grafana/docs-tooling
+#`make docs` procedure and related workflows are owned by @jdbaldry.
+/.github/workflows/deploy-pr-preview.yml                       @jdbaldry
+/.github/workflows/publish-technical-documentation-next.yml    @jdbaldry
+/.github/workflows/publish-technical-documentation-release.yml @jdbaldry
+/.github/workflows/update-make-docs.yml                        @jdbaldry
+/docs/docs.mk                                                  @jdbaldry
+/docs/make-docs                                                @jdbaldry
+/docs/variables.mk                                             @jdbaldry
 
 # Documentation:
 /docs/sources/ @clayton-cornell

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,13 +8,14 @@
 
 * @grafana/grafana-alloy-maintainers
 
-#`make docs` procedure and related workflows are owned by @jdbaldry.
-/.github/workflows/publish-technical-documentation-next.yml    @jdbaldry
-/.github/workflows/publish-technical-documentation-release.yml @jdbaldry
-/.github/workflows/update-make-docs.yml                        @jdbaldry
-/docs/docs.mk                                                  @jdbaldry
-/docs/make-docs                                                @jdbaldry
-/docs/variables.mk                                             @jdbaldry
+#`make docs` procedure and related workflows are owned by @grafana/docs-tooling.
+/.github/workflows/deploy-pr-preview.yml                       @grafana/docs-tooling
+/.github/workflows/publish-technical-documentation-next.yml    @grafana/docs-tooling
+/.github/workflows/publish-technical-documentation-release.yml @grafana/docs-tooling
+/.github/workflows/update-make-docs.yml                        @grafana/docs-tooling
+/docs/docs.mk                                                  @grafana/docs-tooling
+/docs/make-docs                                                @grafana/docs-tooling
+/docs/variables.mk                                             @grafana/docs-tooling
 
 # Documentation:
 /docs/sources/ @clayton-cornell


### PR DESCRIPTION
for https://github.com/grafana/website/issues/10101

**What is this feature?**

This PR adds a workflow to deploy the output of the `make docs` command to a public deploy preview.

**Why do we need this feature?**

Docs contributors will no longer need to run `make docs` on their machine, as they will be able to view the deploy preview instead.

**Who is this feature for?**

Everyone.


