### PR TITLE
Fix static converters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ Main (unreleased)
 
 - Fixed an issue where the `otelcol.processor.interval` could not be used because the debug metrics were not set to default. (@wildum)
 
+- Fix conversion of static config to Alloy for `discovery.azure` and `otelcol.exporter.prometheus`. (@wildum) 
+
 ### Other changes
 
 - Change the stability of the `livedebugging` feature from "experimental" to "generally available". (@wildum)

--- a/internal/converter/internal/prometheusconvert/testdata/azure.alloy
+++ b/internal/converter/internal/prometheusconvert/testdata/azure.alloy
@@ -6,20 +6,10 @@ discovery.azure "prometheus1" {
 		tenant_id     = "tenant"
 		client_secret = "secret"
 	}
-
-	managed_identity {
-		client_id = "client"
-	}
 }
 
 discovery.azure "prometheus2" {
 	subscription_id = "subscription"
-
-	oauth {
-		client_id     = "client"
-		tenant_id     = "tenant"
-		client_secret = "secret"
-	}
 
 	managed_identity {
 		client_id = "client"

--- a/internal/converter/internal/prometheusconvert/testdata/azure.yaml
+++ b/internal/converter/internal/prometheusconvert/testdata/azure.yaml
@@ -15,6 +15,7 @@ scrape_configs:
         client_secret: "secret"
         proxy_url: "proxy"
         follow_redirects: false
+        authentication_method: "ManagedIdentity"
 
 remote_write:
   - name: "remote1"

--- a/internal/converter/internal/prometheusconvert/testdata/discovery.alloy
+++ b/internal/converter/internal/prometheusconvert/testdata/discovery.alloy
@@ -6,10 +6,6 @@ discovery.azure "prometheus1" {
 		tenant_id     = "tenant1"
 		client_secret = "secret1"
 	}
-
-	managed_identity {
-		client_id = "client1"
-	}
 }
 
 discovery.azure "prometheus1_2" {
@@ -19,10 +15,6 @@ discovery.azure "prometheus1_2" {
 		client_id     = "client2"
 		tenant_id     = "tenant2"
 		client_secret = "secret2"
-	}
-
-	managed_identity {
-		client_id = "client2"
 	}
 }
 

--- a/internal/converter/internal/prometheusconvert/testdata/discovery_relabel.alloy
+++ b/internal/converter/internal/prometheusconvert/testdata/discovery_relabel.alloy
@@ -6,10 +6,6 @@ discovery.azure "prometheus2" {
 		tenant_id     = "tenant"
 		client_secret = "secret"
 	}
-
-	managed_identity {
-		client_id = "client"
-	}
 }
 
 discovery.relabel "prometheus1" {

--- a/internal/converter/internal/promtailconvert/testdata/azure.alloy
+++ b/internal/converter/internal/promtailconvert/testdata/azure.alloy
@@ -6,10 +6,6 @@ discovery.azure "fun" {
 		tenant_id     = "tenant"
 		client_secret = "secret"
 	}
-
-	managed_identity {
-		client_id = "client"
-	}
 }
 
 local.file_match "fun" {

--- a/internal/converter/internal/staticconvert/internal/build/converter_remotewriteexporter.go
+++ b/internal/converter/internal/staticconvert/internal/build/converter_remotewriteexporter.go
@@ -91,13 +91,20 @@ func toremotewriteexporterConfig(cfg *remotewriteexporter.Config, forwardTo []st
 	defaultArgs := &prometheus.Arguments{}
 	defaultArgs.SetToDefault()
 
-	return &prometheus.Arguments{
+	args := &prometheus.Arguments{
 		IncludeTargetInfo:             defaultArgs.IncludeTargetInfo,
 		IncludeScopeInfo:              defaultArgs.IncludeScopeInfo,
 		IncludeScopeLabels:            defaultArgs.IncludeScopeLabels,
-		GCFrequency:                   cfg.StaleTime,
+		GCFrequency:                   defaultArgs.GCFrequency,
 		ForwardTo:                     forwardTo,
 		AddMetricSuffixes:             defaultArgs.AddMetricSuffixes,
 		ResourceToTelemetryConversion: defaultArgs.ResourceToTelemetryConversion,
 	}
+
+	// Override default only if > 0 because GCFrequency of 0 is not allowed
+	if cfg.StaleTime > 0 {
+		args.GCFrequency = cfg.StaleTime
+	}
+
+	return args
 }

--- a/internal/converter/internal/staticconvert/testdata/prom_scrape.alloy
+++ b/internal/converter/internal/staticconvert/testdata/prom_scrape.alloy
@@ -6,10 +6,6 @@ discovery.azure "metrics_agent_promobee" {
 		tenant_id     = "tenant"
 		client_secret = "secret"
 	}
-
-	managed_identity {
-		client_id = "client"
-	}
 	proxy_url = "proxy"
 }
 
@@ -20,10 +16,6 @@ discovery.azure "metrics_agent_promobee_2" {
 		client_id     = "client"
 		tenant_id     = "tenant"
 		client_secret = "secret"
-	}
-
-	managed_identity {
-		client_id = "client"
 	}
 	proxy_url = "proxy"
 }

--- a/internal/converter/internal/staticconvert/testdata/traces.alloy
+++ b/internal/converter/internal/staticconvert/testdata/traces.alloy
@@ -52,10 +52,6 @@ discovery.azure "_0_default_prometheus1" {
 		tenant_id     = "tenant1"
 		client_secret = "secret1"
 	}
-
-	managed_identity {
-		client_id = "client1"
-	}
 }
 
 discovery.lightsail "_0_default_prometheus1" {
@@ -118,8 +114,7 @@ prometheus.relabel "_0_default" {
 }
 
 otelcol.exporter.prometheus "_0_default" {
-	gc_frequency = "0s"
-	forward_to   = [prometheus.relabel._0_default.receiver]
+	forward_to = [prometheus.relabel._0_default.receiver]
 }
 
 otelcol.exporter.loadbalancing "_0_default" {
@@ -204,8 +199,7 @@ prometheus.relabel "_1_default" {
 }
 
 otelcol.exporter.prometheus "_1_default" {
-	gc_frequency = "0s"
-	forward_to   = [prometheus.relabel._1_default.receiver]
+	forward_to = [prometheus.relabel._1_default.receiver]
 }
 
 otelcol.exporter.otlp "_1_0" {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

https://github.com/grafana/alloy/pull/2262 I discovered a few bugs with the static converters:
- the spanmetrics connector is starting a goroutine on start. If the component is not stopped, it will panic. We don't have this panic on main because the component is not started. With the fix above, the component is started on creation.
- the azure static converter is always adding two auth methods but only one is allowed
- the otelcol.exporter.prometheus is not using the default value for the gc_frequency which result in an error when the value is not provided

As explained in the comment in testing.go, we need to run the controller to cleanup the component that are starting go routines on Start. But we can't do it for all components because some have config errors and others panic. Because these are only static converters tests, I decided to add the workaround that the controller will run only when the config contains a spanmetrics connector for now. LMK if you're ok with it or if you want to explore alternatives.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Tests updated
- [x] Config converters updated
