### PR TITLE
improve regexp performance in `loki.process`: call fmt only if debug …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Main (unreleased)
 
 - Use a forked `github.com/goccy/go-json` module which reduces the memory consumption of an Alloy instance by 20MB.
   If Alloy is running certain otelcol components, this reduction will not apply. (@ptodev)
+- improve performance in regexp component: call fmt only if debug is enabled (@r0ka)
 
 ### Bugfixes
 

--- a/internal/component/loki/process/stages/regex.go
+++ b/internal/component/loki/process/stages/regex.go
@@ -112,7 +112,9 @@ func (r *regexStage) Process(labels model.LabelSet, extracted map[string]interfa
 			extracted[name] = match[i]
 		}
 	}
-	level.Debug(r.logger).Log("msg", "extracted data debug in regex stage", "extracted data", fmt.Sprintf("%v", extracted))
+    if level.Debug(r.logger).Enabled() {
+      level.Debug(r.logger).Log("msg", "extracted data debug in regex stage", "extracted data", fmt.Sprintf("%v", extracted))
+    }
 }
 
 // Name implements Stage


### PR DESCRIPTION
#### PR Description

#### Which issue(s) this PR fixes

improve regexp performance in `loki.process`: call fmt only if debug is enabled

#### Notes to the Reviewer

Was doing promtail vs alloy perf tests, and found that alloy consumes at least 40% more CPU than promtail. 
here is the link for cpu.pprof 
[cpu pprof](https://pprof.me/223f972295dcd626b35aab26e02aec45/?profileType=profile%253Acpu%253Ananoseconds%253Acpu%253Ananoseconds%253Adelta&color_by=filename)

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ X] CHANGELOG.md updated
