### PR TITLE
fix: Add missing tenant label to some loki.write metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ Main (unreleased)
 
 - Add error body propagation in `pyroscope.write`, for `/ingest` calls. (@simonswine)
 
+- Add `tenant` label to remaining `loki_write_.+` metrics (@towolf)
+
 ### Bugfixes
 
 - Fix deadlocks in `loki.source.file` when tailing fails (@mblaschke)

--- a/internal/component/common/loki/client/client_test.go
+++ b/internal/component/common/loki/client/client_test.go
@@ -83,7 +83,7 @@ func TestClient_Handle(t *testing.T) {
 			expectedMetrics: `
                                # HELP loki_write_sent_entries_total Number of log entries sent to the ingester.
                                # TYPE loki_write_sent_entries_total counter
-                               loki_write_sent_entries_total{host="__HOST__"} 3.0
+                               loki_write_sent_entries_total{host="__HOST__",tenant=""} 3.0
                                # HELP loki_write_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
                                # TYPE loki_write_dropped_entries_total counter
                                loki_write_dropped_entries_total{host="__HOST__",reason="ingester_error",tenant=""} 0
@@ -121,7 +121,7 @@ func TestClient_Handle(t *testing.T) {
 			expectedMetrics: `
                                # HELP loki_write_sent_entries_total Number of log entries sent to the ingester.
                                # TYPE loki_write_sent_entries_total counter
-                               loki_write_sent_entries_total{host="__HOST__"} 2.0
+                               loki_write_sent_entries_total{host="__HOST__",tenant=""} 2.0
                                # HELP loki_write_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
                                # TYPE loki_write_dropped_entries_total counter
                                loki_write_dropped_entries_total{host="__HOST__",reason="ingester_error",tenant=""} 0
@@ -166,7 +166,7 @@ func TestClient_Handle(t *testing.T) {
 			expectedMetrics: `
                                # HELP loki_write_sent_entries_total Number of log entries sent to the ingester.
                                # TYPE loki_write_sent_entries_total counter
-                               loki_write_sent_entries_total{host="__HOST__"} 3.0
+                               loki_write_sent_entries_total{host="__HOST__",tenant=""} 3.0
                                # HELP loki_write_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
                                # TYPE loki_write_dropped_entries_total counter
                                loki_write_dropped_entries_total{host="__HOST__",reason="ingester_error",tenant=""} 0
@@ -208,7 +208,7 @@ func TestClient_Handle(t *testing.T) {
 			expectedMetrics: `
                               # HELP loki_write_sent_entries_total Number of log entries sent to the ingester.
                               # TYPE loki_write_sent_entries_total counter
-                              loki_write_sent_entries_total{host="__HOST__"} 2.0
+                              loki_write_sent_entries_total{host="__HOST__",tenant=""} 2.0
                               # HELP loki_write_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
                               # TYPE loki_write_dropped_entries_total counter
                               loki_write_dropped_entries_total{host="__HOST__",reason="ingester_error",tenant=""} 0
@@ -270,7 +270,7 @@ func TestClient_Handle(t *testing.T) {
                               loki_write_mutated_bytes_total{host="__HOST__",reason="stream_limited",tenant=""} 0
                               # HELP loki_write_sent_entries_total Number of log entries sent to the ingester.
                               # TYPE loki_write_sent_entries_total counter
-                              loki_write_sent_entries_total{host="__HOST__"} 0
+                              loki_write_sent_entries_total{host="__HOST__",tenant=""} 0
                        `,
 		},
 		"do not retry send a batch in case the server responds with a 4xx": {
@@ -306,7 +306,7 @@ func TestClient_Handle(t *testing.T) {
                               loki_write_mutated_bytes_total{host="__HOST__",reason="stream_limited",tenant=""} 0
                               # HELP loki_write_sent_entries_total Number of log entries sent to the ingester.
                               # TYPE loki_write_sent_entries_total counter
-                              loki_write_sent_entries_total{host="__HOST__"} 0
+                              loki_write_sent_entries_total{host="__HOST__",tenant=""} 0
                        `,
 		},
 		"do retry sending a batch in case the server responds with a 429": {
@@ -350,7 +350,7 @@ func TestClient_Handle(t *testing.T) {
                               loki_write_mutated_bytes_total{host="__HOST__",reason="stream_limited",tenant=""} 0
                               # HELP loki_write_sent_entries_total Number of log entries sent to the ingester.
                               # TYPE loki_write_sent_entries_total counter
-                              loki_write_sent_entries_total{host="__HOST__"} 0
+                              loki_write_sent_entries_total{host="__HOST__",tenant=""} 0
                        `,
 		},
 		"do not retry in case of 429 when client is configured to drop rate limited batches": {
@@ -387,7 +387,7 @@ func TestClient_Handle(t *testing.T) {
                               loki_write_mutated_bytes_total{host="__HOST__",reason="stream_limited",tenant=""} 0
                               # HELP loki_write_sent_entries_total Number of log entries sent to the ingester.
                               # TYPE loki_write_sent_entries_total counter
-                              loki_write_sent_entries_total{host="__HOST__"} 0
+                              loki_write_sent_entries_total{host="__HOST__",tenant=""} 0
                        `,
 		},
 		"batch log entries together honoring the client tenant ID": {
@@ -406,7 +406,7 @@ func TestClient_Handle(t *testing.T) {
 			expectedMetrics: `
                               # HELP loki_write_sent_entries_total Number of log entries sent to the ingester.
                               # TYPE loki_write_sent_entries_total counter
-                              loki_write_sent_entries_total{host="__HOST__"} 2.0
+                              loki_write_sent_entries_total{host="__HOST__",tenant="tenant-default"} 2.0
                               # HELP loki_write_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
                               # TYPE loki_write_dropped_entries_total counter
                               loki_write_dropped_entries_total{host="__HOST__", reason="ingester_error", tenant="tenant-default"} 0
@@ -451,7 +451,9 @@ func TestClient_Handle(t *testing.T) {
 			expectedMetrics: `
                               # HELP loki_write_sent_entries_total Number of log entries sent to the ingester.
                               # TYPE loki_write_sent_entries_total counter
-                              loki_write_sent_entries_total{host="__HOST__"} 4.0
+                              loki_write_sent_entries_total{host="__HOST__",tenant="tenant-1"} 2.0
+                              loki_write_sent_entries_total{host="__HOST__",tenant="tenant-2"} 1.0
+                              loki_write_sent_entries_total{host="__HOST__",tenant="tenant-default"} 1.0
                               # HELP loki_write_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
                               # TYPE loki_write_dropped_entries_total counter
                               loki_write_dropped_entries_total{host="__HOST__",reason="ingester_error",tenant="tenant-1"} 0
@@ -604,7 +606,7 @@ func TestClient_StopNow(t *testing.T) {
 			expectedMetrics: `
                               # HELP loki_write_sent_entries_total Number of log entries sent to the ingester.
                               # TYPE loki_write_sent_entries_total counter
-                              loki_write_sent_entries_total{host="__HOST__"} 3.0
+                              loki_write_sent_entries_total{host="__HOST__",tenant=""} 3.0
                               # HELP loki_write_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
                               # TYPE loki_write_dropped_entries_total counter
                               loki_write_dropped_entries_total{host="__HOST__",reason="ingester_error",tenant=""} 0
@@ -635,7 +637,7 @@ func TestClient_StopNow(t *testing.T) {
                               loki_write_dropped_entries_total{host="__HOST__",reason="stream_limited",tenant=""} 0
                               # HELP loki_write_sent_entries_total Number of log entries sent to the ingester.
                               # TYPE loki_write_sent_entries_total counter
-                              loki_write_sent_entries_total{host="__HOST__"} 0
+                              loki_write_sent_entries_total{host="__HOST__", tenant=""} 0
                        `,
 		},
 	}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

We noticed that in the some `loki.write` metrics we find the `tenant` label, but it's missing for `loki_write_send_.+` and in those the tenant label would be useful.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
