### PR TITLE
fix: helm - alloy.mounts.extra adds unnecessary newline

### DIFF
--- a/operations/helm/charts/alloy/templates/containers/_agent.yaml
+++ b/operations/helm/charts/alloy/templates/containers/_agent.yaml
@@ -82,7 +82,7 @@
       mountPath: /var/lib/docker/containers
       readOnly: true
     {{- end }}
-    {{- range $values.mounts.extra }}
-    - {{- toYaml . | nindent 6 }}
+    {{- with $values.mounts.extra }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

It's just cosmetics but alloy.mounts.extra is using range for some reason, I have no idea why, but it just adds an unnecessary newline after dash:
```
# values.yaml
alloy:
    mounts:
      extra:
        - name: tmpalloy
          mountPath: /tmp/alloy
```

```
# charts/alloy/templates/controllers/daemonset.yaml
          volumeMounts:
            - name: config
              mountPath: /etc/alloy
            - name: varlog
              mountPath: /var/log
              readOnly: true
            - name: dockercontainers
              mountPath: /var/lib/docker/containers
              readOnly: true
            -
              mountPath: /tmp/alloy
              name: tmpalloy
```
Change from range to with
```
          volumeMounts:
            - name: config
              mountPath: /etc/alloy
            - name: varlog
              mountPath: /var/log
              readOnly: true
            - name: dockercontainers
              mountPath: /var/lib/docker/containers
              readOnly: true
            - mountPath: /tmp/alloy
              name: tmpalloy
```
#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
