### PR TITLE
[pyroscope.java] Clean-up JFR files left behind by previous instances of alloy to reduce risk of filling up disk when alloy's in crash loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ Main (unreleased)
 
 - Fixed an issue where the `otelcol.processor.interval` could not be used because the debug metrics were not set to default. (@wildum)
 
+- Fixed an issue where `pyroscope.java` did not remove unused JFR files created by previous Alloy instances. (@swar8080)
+
 ### Other changes
 
 - Change the stability of the `livedebugging` feature from "experimental" to "generally available". (@wildum)


### PR DESCRIPTION
#### PR Description

Cleans-up unused JFR files that were accumulating on profiling targets' filesystem by previously terminated instances of alloy. This helps reduce the risk of files piling up if alloy is constantly restarting, like if kubernetes memory limits are too low. 

#### Which issue(s) this PR fixes

Fixes #1960

#### Notes to the Reviewer

I tested this manually on our EKS cluster with amd64 linux nodes. I both manually created `asprof` files and used some left behind by terminated alloy pods to test that this new code is executed once during start-up.

<img width="1505" alt="image (18)" src="https://github.com/user-attachments/assets/9a82be34-10c7-44b9-a081-f0a05ca8d747" />

I couldn't find any unit or integration tests for this component so let me know if there's suggestions for further testing.

#### PR Checklist

- [x] CHANGELOG.md updated
- [ ] Tests updated
