### PR TITLE
improve regexp performance in `loki.process`: call fmt only if debug …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Main (unreleased)
 
 - Upgrade `github.com/goccy/go-json` to v0.10.4, which reduces the memory consumption of an Alloy instance by 20MB.
   If Alloy is running certain otelcol components, this reduction will not apply. (@ptodev)
+- improve performance in regexp component: call fmt only if debug is enabled (@r0ka)
 
 - Update `prometheus.write.queue` library for performance increases in cpu. (@mattdurham)
 

--- a/internal/component/loki/process/stages/regex.go
+++ b/internal/component/loki/process/stages/regex.go
@@ -83,13 +83,17 @@ func (r *regexStage) Process(labels model.LabelSet, extracted map[string]interfa
 
 	if r.config.Source != nil {
 		if _, ok := extracted[*r.config.Source]; !ok {
-			level.Debug(r.logger).Log("msg", "source does not exist in the set of extracted values", "source", *r.config.Source)
+			if Debug {
+				level.Debug(r.logger).Log("msg", "source does not exist in the set of extracted values", "source", *r.config.Source)
+			}
 			return
 		}
 
 		value, err := getString(extracted[*r.config.Source])
 		if err != nil {
-			level.Debug(r.logger).Log("msg", "failed to convert source value to string", "source", *r.config.Source, "err", err, "type", reflect.TypeOf(extracted[*r.config.Source]))
+			if Debug {
+				level.Debug(r.logger).Log("msg", "failed to convert source value to string", "source", *r.config.Source, "err", err, "type", reflect.TypeOf(extracted[*r.config.Source]))
+			}
 			return
 		}
 
@@ -97,13 +101,17 @@ func (r *regexStage) Process(labels model.LabelSet, extracted map[string]interfa
 	}
 
 	if input == nil {
-		level.Debug(r.logger).Log("msg", "cannot parse a nil entry")
+		if Debug {
+			level.Debug(r.logger).Log("msg", "cannot parse a nil entry")
+		}
 		return
 	}
 
 	match := r.expression.FindStringSubmatch(*input)
 	if match == nil {
-		level.Debug(r.logger).Log("msg", "regex did not match", "input", *input, "regex", r.expression)
+		if Debug {
+			level.Debug(r.logger).Log("msg", "regex did not match", "input", *input, "regex", r.expression)
+		}
 		return
 	}
 

--- a/internal/component/loki/process/stages/regex.go
+++ b/internal/component/loki/process/stages/regex.go
@@ -112,7 +112,9 @@ func (r *regexStage) Process(labels model.LabelSet, extracted map[string]interfa
 			extracted[name] = match[i]
 		}
 	}
-	level.Debug(r.logger).Log("msg", "extracted data debug in regex stage", "extracted data", fmt.Sprintf("%v", extracted))
+	if Debug {
+		level.Debug(r.logger).Log("msg", "extracted data debug in regex stage", "extracted data", fmt.Sprintf("%v", extracted))
+	}
 }
 
 // Name implements Stage


### PR DESCRIPTION
PR Description
Which issue(s) this PR fixes
improve regexp performance in loki.process: call fmt only if debug is enabled

Notes to the Reviewer
Was doing promtail vs alloy perf tests, and found that alloy consumes at least 40% more CPU than promtail.
here is the link for cpu.pprof
[alloy cpu pprof](https://pprof.me/223f972295dcd626b35aab26e02aec45/?profileType=profile%253Acpu%253Ananoseconds%253Acpu%253Ananoseconds%253Adelta&color_by=filename)

[promtail cpu pprof](https://pprof.me/86b3eba6c6e5e95582e6a2af5e860302/?profileType=profile%253Acpu%253Ananoseconds%253Acpu%253Ananoseconds%253Adelta&color_by=filename)

PR Checklist
[ X] CHANGELOG.md updated