### PR TITLE
Integration tests tempo: set fixed version instead of latest

### DIFF
--- a/internal/cmd/integration-tests/docker-compose.yaml
+++ b/internal/cmd/integration-tests/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       - "9009:9009"
   
   tempo:
-    image: grafana/tempo:latest
+    image: grafana/tempo:2.6.1
     command: [ "-config.file=/etc/tempo.yaml" ]
     volumes:
       - ./configs/tempo/tempo.yaml:/etc/tempo.yaml


### PR DESCRIPTION
The latest image published by tempo on docker is breaking the integration tests. The "latest" tag can sometimes point to older versions of the software which may not have the expected API. It is safer to have a fixed version for tests and to update it manually 