### PR TITLE
Change log level in eventlogmessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ Main (unreleased)
 
 - Fixed an issue where the `otelcol.processor.interval` could not be used because the debug metrics were not set to default. (@wildum)
 
+- Change the log level in the `eventlogmessage` stage of the `loki.process` component from `warn` to `debug`. (@wildum)
+
 ### Other changes
 
 - Change the stability of the `livedebugging` feature from "experimental" to "generally available". (@wildum)

--- a/docs/sources/reference/components/loki/loki.process.md
+++ b/docs/sources/reference/components/loki/loki.process.md
@@ -258,6 +258,9 @@ If set to `false`, the `_extracted` suffix will be appended to an already existi
 When `drop_invalid_labels` is set to `true`, the stage drops fields that are not valid label names.
 If set to `false`, the stage will automatically convert them into valid labels replacing invalid characters with underscores.
 
+Only lines that have the key:value format will be extracted. All non-alpha characters in the key are replaced with underscores.
+For example, `\tSecurity ID` will be available in the extracted map as `_Security_ID` to be used in later stages.
+
 #### Example combined with `stage.json`
 
 ```alloy

--- a/docs/sources/reference/components/loki/loki.process.md
+++ b/docs/sources/reference/components/loki/loki.process.md
@@ -258,8 +258,9 @@ If set to `false`, the `_extracted` suffix will be appended to an already existi
 When `drop_invalid_labels` is set to `true`, the stage drops fields that are not valid label names.
 If set to `false`, the stage will automatically convert them into valid labels replacing invalid characters with underscores.
 
-Only lines that have the key:value format will be extracted. All non-alpha characters in the key are replaced with underscores.
-For example, `\tSecurity ID` will be available in the extracted map as `_Security_ID` to be used in later stages.
+The `eventlogmessage` stage only extracts lines with the key:value format.
+All non-alpha characters in the key are replaced with underscores.
+For example, `\tSecurity ID` is extracted as `_Security_ID`.
 
 #### Example combined with `stage.json`
 

--- a/internal/component/loki/process/stages/eventlogmessage.go
+++ b/internal/component/loki/process/stages/eventlogmessage.go
@@ -78,7 +78,7 @@ func (m *eventLogMessageStage) processEntry(extracted map[string]interface{}, ke
 	for _, line := range lines {
 		parts := strings.SplitN(line, ":", 2)
 		if len(parts) < 2 {
-			level.Warn(m.logger).Log("msg", "invalid line parsed from message", "line", line)
+			level.Debug(m.logger).Log("msg", "invalid line parsed from message", "line", line)
 			continue
 		}
 		mkey := parts[0]


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

It's common in windows messages to have lines that don't follow the key:value format. There should not be a warning for these.

Changing the log-level and updating the doc is only a first step. The next step would be to improving the parser to not lose the info that does not follow the key:value format (such as the description) and support multi-lines value for the key:value pairs

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #982

Follow up issue to improve this stage: https://github.com/grafana/alloy/issues/2337

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
