### PR TITLE
Reduce allocation in discovery by ~30%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ Main (unreleased)
 
 - Update `async-profiler` binaries for `pyroscope.java` to 3.0-fa937db (@aleks-p)
 
+- Reduced memory allocation in discovery components by up to 30% (@thampiotr)
+
 ### Bugfixes
 
 - Fixed issue with automemlimit logging bad messages and trying to access cgroup on non-linux builds (@dehaansa)

--- a/internal/component/discovery/discovery_test.go
+++ b/internal/component/discovery/discovery_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Masterminds/goutils"
 	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
@@ -199,6 +200,49 @@ func TestDiscoveryUpdates(t *testing.T) {
 				assert.Equal(t, tc.expectedFinalExports, publishedExports)
 			}, 3*time.Second, time.Millisecond)
 		})
+	}
+}
+
+/*
+on darwin/arm64/Apple M2:
+Benchmark_ToAlloyTargets-8   	     150	   7549967 ns/op	12768249 B/op	   40433 allocs/op
+Benchmark_ToAlloyTargets-8   	     169	   7257841 ns/op	12767441 B/op	   40430 allocs/op
+Benchmark_ToAlloyTargets-8   	     171	   7026276 ns/op	12767394 B/op	   40430 allocs/op
+Benchmark_ToAlloyTargets-8   	     170	   7060700 ns/op	12767377 B/op	   40430 allocs/op
+Benchmark_ToAlloyTargets-8   	     170	   7034392 ns/op	12767427 B/op	   40430 allocs/op
+*/
+func Benchmark_ToAlloyTargets(b *testing.B) {
+	sharedLabels := 5
+	labelsPerTarget := 5
+	labelsLength := 10
+	targetsCount := 20_000
+
+	genLabelSet := func(size int) model.LabelSet {
+		ls := model.LabelSet{}
+		for i := 0; i < size; i++ {
+			name, _ := goutils.RandomAlphaNumeric(labelsLength)
+			value, _ := goutils.RandomAlphaNumeric(labelsLength)
+			ls[model.LabelName(name)] = model.LabelValue(value)
+		}
+		return ls
+	}
+
+	var targets = []model.LabelSet{}
+	for i := 0; i < targetsCount; i++ {
+		targets = append(targets, genLabelSet(labelsPerTarget))
+	}
+
+	cache := map[string]*targetgroup.Group{}
+	cache["test"] = &targetgroup.Group{
+		Targets: targets,
+		Labels:  genLabelSet(sharedLabels),
+		Source:  "test",
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		toAlloyTargets(cache)
 	}
 }
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This is a low hanging fruit fix to reduce allocation in discovery components by around 30%. More work may still be required in the future. 

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

```
thampiotr@MacWork ~/w/alloy (thampiotr/reduce-disco-allocation)> go test -count 5 -bench=Benchmark_ToAlloyTargets -benchmem ./internal/component/discovery/ | tee after.txt; benchstat before.txt after.txt
goos: darwin
goarch: arm64
pkg: github.com/grafana/alloy/internal/component/discovery
cpu: Apple M2
Benchmark_ToAlloyTargets-8   	     150	   7549967 ns/op	12768249 B/op	   40433 allocs/op
Benchmark_ToAlloyTargets-8   	     169	   7257841 ns/op	12767441 B/op	   40430 allocs/op
Benchmark_ToAlloyTargets-8   	     171	   7026276 ns/op	12767394 B/op	   40430 allocs/op
Benchmark_ToAlloyTargets-8   	     170	   7060700 ns/op	12767377 B/op	   40430 allocs/op
Benchmark_ToAlloyTargets-8   	     170	   7034392 ns/op	12767427 B/op	   40430 allocs/op
PASS
ok  	github.com/grafana/alloy/internal/component/discovery	15.349s
goos: darwin
goarch: arm64
pkg: github.com/grafana/alloy/internal/component/discovery
cpu: Apple M2
                  │  before.txt  │              after.txt              │
                  │    sec/op    │    sec/op     vs base               │
_ToAlloyTargets-8   9.679m ± ∞ ¹   7.061m ± ∞ ¹  -27.05% (p=0.008 n=5)
¹ need >= 6 samples for confidence interval at level 0.95

                  │  before.txt   │              after.txt               │
                  │     B/op      │     B/op       vs base               │
_ToAlloyTargets-8   18.24Mi ± ∞ ¹   12.18Mi ± ∞ ¹  -33.24% (p=0.008 n=5)
¹ need >= 6 samples for confidence interval at level 0.95

                  │  before.txt  │              after.txt              │
                  │  allocs/op   │  allocs/op    vs base               │
_ToAlloyTargets-8   60.45k ± ∞ ¹   40.43k ± ∞ ¹  -33.12% (p=0.008 n=5)
```

And the before:
```
cat before.txt
goos: darwin
goarch: arm64
pkg: github.com/grafana/alloy/internal/component/discovery
cpu: Apple M2
Benchmark_ToAlloyTargets-8   	     123	  10320177 ns/op	19125568 B/op	   60453 allocs/op
Benchmark_ToAlloyTargets-8   	     122	   9597422 ns/op	19124639 B/op	   60450 allocs/op
Benchmark_ToAlloyTargets-8   	     123	   9639463 ns/op	19125584 B/op	   60454 allocs/op
Benchmark_ToAlloyTargets-8   	     123	   9684174 ns/op	19124906 B/op	   60451 allocs/op
Benchmark_ToAlloyTargets-8   	     120	   9678773 ns/op	19125101 B/op	   60452 allocs/op
PASS
ok  	github.com/grafana/alloy/internal/component/discovery	16.564s
```

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
