### PR TITLE
Update support bundle link to the correct file in github

### DIFF
--- a/docs/sources/troubleshoot/support_bundle.md
+++ b/docs/sources/troubleshoot/support_bundle.md
@@ -30,7 +30,7 @@ defaults to `localhost:12345`.
 The support bundle contains all information in plain text, so you can
 inspect it before sharing to verify that no sensitive information has leaked.
 
-In addition, you can inspect the [supportbundle implementation](https://github.com/grafana/alloy/tree/internal/service/http/supportbundle.go)
+In addition, you can inspect the [support bundle implementation](https://github.com/grafana/alloy/blob/main/internal/service/http/supportbundle.go)
 to verify the code used to generate these bundles.
 
 A support bundle contains the following data:


### PR DESCRIPTION
The previous link went to a 404 page. This commit is an update to the correct url.

**Docs page**: https://grafana.com/docs/alloy/latest/troubleshoot/support_bundle/

**Old**: https://github.com/grafana/alloy/tree/internal/service/http/supportbundle.go
**New**: https://github.com/grafana/alloy/blob/main/internal/service/http/supportbundle.go