### PR TITLE
fix: Add nil check to support bundle printer that prints remotecfg & local sources

### DIFF
--- a/docs/sources/troubleshoot/support_bundle.md
+++ b/docs/sources/troubleshoot/support_bundle.md
@@ -6,11 +6,7 @@ menuTitle: Generate a support bundle
 weight: 300
 ---
 
-<span class="badge docs-labels__stage docs-labels__item">Public preview</span>
-
 # Generate a support bundle
-
-{{< docs/public-preview product="Generate support bundle" >}}
 
 The `/-/support?duration=N` endpoint returns a support bundle, a compressed file that contains information
 about a running {{< param "PRODUCT_NAME" >}} instance, and can be used as a baseline of information when trying

--- a/internal/service/http/http.go
+++ b/internal/service/http/http.go
@@ -661,6 +661,10 @@ func remoteCfgRedactedCachedConfig(host service.Host) ([]byte, error) {
 }
 
 func printFileRedacted(f *ast.File) ([]byte, error) {
+	if f == nil {
+		return []byte{}, nil
+	}
+
 	c := printer.Config{
 		RedactSecrets: true,
 	}

--- a/internal/service/http/http.go
+++ b/internal/service/http/http.go
@@ -296,14 +296,6 @@ func (s *Service) generateSupportBundleHandler(host service.Host) func(rw http.R
 		s.supportBundleMut.Lock()
 		defer s.supportBundleMut.Unlock()
 
-		// TODO(dehaansa) remove this check once the support bundle is generally available
-		if !s.opts.MinStability.Permits(featuregate.StabilityPublicPreview) {
-			rw.WriteHeader(http.StatusForbidden)
-			_, _ = rw.Write([]byte("support bundle generation is only available in public preview. Use" +
-				" --stability.level command-line flag to enable public-preview features"))
-			return
-		}
-
 		if s.opts.BundleContext.DisableSupportBundle {
 			rw.WriteHeader(http.StatusForbidden)
 			_, _ = rw.Write([]byte("support bundle generation is disabled; it can be re-enabled by removing the --disable-support-bundle flag"))

--- a/internal/service/http/supportbundle.go
+++ b/internal/service/http/supportbundle.go
@@ -212,20 +212,23 @@ func ServeSupportBundle(rw http.ResponseWriter, b *Bundle, logsBuf *bytes.Buffer
 	rw.Header().Set("Content-Disposition", "attachment; filename=\"alloy-support-bundle.zip\"")
 
 	zipStructure := map[string][]byte{
-		"alloy-metadata.yaml":                b.meta,
-		"alloy-components.json":              b.components,
-		"alloy-peers.json":                   b.peers,
-		"alloy-metrics-sample-start.txt":     b.alloyMetricsStart,
-		"alloy-metrics-sample-end.txt":       b.alloyMetricsEnd,
-		"alloy-runtime-flags.txt":            b.runtimeFlags,
-		"alloy-environment.txt":              b.environmentVariables,
-		"alloy-logs.txt":                     logsBuf.Bytes(),
-		"sources/remote-config/remote.alloy": b.remoteCfg,
-		"pprof/cpu.pprof":                    b.cpuBuf.Bytes(),
-		"pprof/heap.pprof":                   b.heapBuf.Bytes(),
-		"pprof/goroutine.pprof":              b.goroutineBuf.Bytes(),
-		"pprof/mutex.pprof":                  b.mutexBuf.Bytes(),
-		"pprof/block.pprof":                  b.blockBuf.Bytes(),
+		"alloy-metadata.yaml":            b.meta,
+		"alloy-components.json":          b.components,
+		"alloy-peers.json":               b.peers,
+		"alloy-metrics-sample-start.txt": b.alloyMetricsStart,
+		"alloy-metrics-sample-end.txt":   b.alloyMetricsEnd,
+		"alloy-runtime-flags.txt":        b.runtimeFlags,
+		"alloy-environment.txt":          b.environmentVariables,
+		"alloy-logs.txt":                 logsBuf.Bytes(),
+		"pprof/cpu.pprof":                b.cpuBuf.Bytes(),
+		"pprof/heap.pprof":               b.heapBuf.Bytes(),
+		"pprof/goroutine.pprof":          b.goroutineBuf.Bytes(),
+		"pprof/mutex.pprof":              b.mutexBuf.Bytes(),
+		"pprof/block.pprof":              b.blockBuf.Bytes(),
+	}
+
+	if len(b.remoteCfg) > 0 {
+		zipStructure["sources/remote-config/remote.alloy"] = b.remoteCfg
 	}
 
 	for p, s := range b.sources {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
@mattdurham encountered the following panic when testing the RC for 1.6

EDIT: Also removing public preview requirement for support bundle.

```
2025/01/08 12:10:50 http: panic serving 127.0.0.1:60176: runtime error: invalid memory address or nil pointer dereference
goroutine 1288 [running]:
net/http.(*conn).serve.func1()
        /home/mdurham/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.3.linux-amd64/src/net/http/server.go:1947 +0xbe
panic({0x9456080?, 0x114afc70?})
        /home/mdurham/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.3.linux-amd64/src/runtime/panic.go:785 +0x132
github.com/grafana/alloy/syntax/printer.(*walker).walkFile(0xc001d2f1f8, 0x0)
        /home/mdurham/source/alloy_grafana/vendor/github.com/grafana/alloy/syntax/printer/walker.go:35 +0x25
github.com/grafana/alloy/syntax/printer.(*walker).Walk(0x10?, {0xbc0bee0?, 0x0?})
        /home/mdurham/source/alloy_grafana/vendor/github.com/grafana/alloy/syntax/printer/walker.go:20 +0x45
github.com/grafana/alloy/syntax/printer.(*Config).Fprint(0xa9ae0a0?, {0xbc0be40, 0xc00dcf5350}, {0xbc0bee0, 0x0})
        /home/mdurham/source/alloy_grafana/vendor/github.com/grafana/alloy/syntax/printer/printer.go:29 +0x169
github.com/grafana/alloy/internal/service/http.printFileRedacted(0x0)
        /home/mdurham/source/alloy_grafana/internal/service/http/http.go:670 +0x56
github.com/grafana/alloy/internal/service/http.remoteCfgRedactedCachedConfig({0xbcd6920?, 0xc001b4ae00?})
        /home/mdurham/source/alloy_grafana/internal/service/http/http.go:660 +0x52
github.com/grafana/alloy/internal/service/http.(*Service).Run.(*Service).generateSupportBundleHandler.func12({0xbca82f0, 0xc001a1c9c0}, 0xc0009dac80)
        /home/mdurham/source/alloy_grafana/internal/service/http/http.go:341 +0x2ea
net/http.HandlerFunc.ServeHTTP(0xbc9b500?, {0xbca82f0?, 0xc001a1c9c0?}, 0xa9b615a?)
        /home/mdurham/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.3.linux-amd64/src/net/http/server.go:2220 +0x29
go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux.traceware.ServeHTTP({{0xa998833, 0x5}, {0xbc3b528, 0xc00119f680}, {0xbc9df30, 0xc001432340}, {0xbc0c5e0, 0xc001d12d80}, 0xafc8af8, 0x0, ...}, ...)
        /home/mdurham/source/alloy_grafana/vendor/go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux/mux.go:179 +0xb91
github.com/gorilla/mux.(*Router).ServeHTTP(0xc0010d29c0, {0xbc9b500, 0xc001b50380}, 0xc0009da640)
        /home/mdurham/source/alloy_grafana/vendor/github.com/gorilla/mux/mux.go:212 +0x1e2
golang.org/x/net/http2/h2c.h2cHandler.ServeHTTP({{0xbc0d0e0?, 0xc0010d29c0?}, 0xc0005c80e0?}, {0xbc9b500, 0xc001b50380}, 0xc0009da640)
        /home/mdurham/source/alloy_grafana/vendor/golang.org/x/net/http2/h2c/h2c.go:125 +0x673
net/http.serverHandler.ServeHTTP({0xc00dcf5110?}, {0xbc9b500?, 0xc001b50380?}, 0x6?)
        /home/mdurham/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.3.linux-amd64/src/net/http/server.go:3210 +0x8e
net/http.(*conn).serve(0xc03d3a2510, {0xbcc4ac8, 0xc001b84300})
        /home/mdurham/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.3.linux-amd64/src/net/http/server.go:2092 +0x5d0
created by net/http.(*Server).Serve in goroutine 722
        /home/mdurham/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.3.linux-amd64/src/net/http/server.go:3360 +0x485
```

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

