### PR TITLE
docs: fixed kafka config example

### DIFF
--- a/docs/sources/reference/components/loki/loki.source.kafka.md
+++ b/docs/sources/reference/components/loki/loki.source.kafka.md
@@ -147,7 +147,7 @@ loki.source.kafka "local" {
   brokers                = ["localhost:9092"]
   topics                 = ["quickstart-events"]
   labels                 = {component = "loki.source.kafka"}
-  forward_to             = [loki.relabel.kafka.receiver]
+  forward_to             = [loki.write.local.receiver]
   use_incoming_timestamp = true
   relabel_rules          = loki.relabel.kafka.rules
 }


### PR DESCRIPTION
Example shows `loki.source.kafka "local"` pointing to `loki.relabel.kafka.receiver`. This leads to no new label being added. The correct example should have the Kafka source pointing directly to `loki.write.local.receiver`

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
