### PR TITLE
Fix only run on fork guard

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   deploy-pr-preview:
-    if: ! github.event.pull_request.head.repo.fork
+    if: ${{ ! github.event.pull_request.head.repo.fork }}
     uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
     with:
       sha: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   deploy-pr-preview:
-    if: github.repository == 'grafana/alloy'
+    if: ! github.event.pull_request.head.repo.fork
     uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
     with:
       sha: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
#### PR Description

The previous guard fails because `github.repository` resolves to the base repository on `pull_request` events.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
