### PR TITLE
Fix examples for filter and transform processors

### DIFF
--- a/docs/sources/reference/components/otelcol/otelcol.processor.filter.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.filter.md
@@ -197,7 +197,7 @@ information.
 
 ### Drop spans which contain a certain span attribute
 
-This example sets the attribute `test` to `pass` if the attribute `test` does not exist.
+This example drops the signals that have the attribute `container.name` set to the value `app_container_1`.
 
 ```alloy
 otelcol.processor.filter "default" {
@@ -205,7 +205,7 @@ otelcol.processor.filter "default" {
 
   traces {
     span = [
-      "attributes[\"container.name\"] == \"app_container_1\"",
+      `attributes["container.name"] == "app_container_1"`,
     ]
   }
 
@@ -231,8 +231,8 @@ otelcol.processor.filter "default" {
 
   metrics {
     metric = [
-       "name == \"my.metric\" and resource.attributes[\"my_label\"] == \"abc123\"",
-       "type == METRIC_DATA_TYPE_HISTOGRAM",
+       `name == "my.metric" and resource.attributes["my_label"] == "abc123"`,
+       `type == METRIC_DATA_TYPE_HISTOGRAM`,
     ]
   }
 
@@ -257,14 +257,14 @@ otelcol.processor.filter "default" {
 
   traces {
     span = [
-      "attributes[\"http.request.method\"] == nil",
+      `attributes["http.request.method"] == nil`,
     ]
   }
 
   logs {
     log_record = [
-      "IsMatch(body, \".*password.*\")",
-      "severity_number < SEVERITY_NUMBER_WARN",
+      `IsMatch(body, ".*password.*")`,
+      `severity_number < SEVERITY_NUMBER_WARN`,
     ]
   }
 

--- a/docs/sources/reference/components/otelcol/otelcol.processor.transform.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.transform.md
@@ -399,7 +399,7 @@ otelcol.processor.transform "default" {
     context = "resource"
     statements = [
       // The Concat function combines any number of strings, separated by a delimiter.
-      `set(attributes["test"], Concat([attributes["foo"], attributes["bar"]], " "))`,
+      `set(attributes["test"], Concat([attributes["service.name"], attributes["service.version"]], " "))`,
     ]
   }
 


### PR DESCRIPTION
I also used backticks for the filter processor to remove the need to escape every string in the OTTL statements.