### PR TITLE
Fanout: reduce allocation related to staleness tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Enhancements
+
+- Improved performance by reducing allocation in Prometheus write pipelines by ~30% (@thampiotr)
+
 v1.6.0-rc.1
 -----------------
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

We typically send a lot of data through appenders (fanout and interceptor), but we always allocate 0-size slice for
the staleness trackers. This results in high allocation in these methods:

![image](https://github.com/user-attachments/assets/26fd1511-435b-4d90-bdc8-82c0e720e006)

![image](https://github.com/user-attachments/assets/049eeeca-6572-4872-8e6c-9030b31e169d)

In this change I'm capturing how many staleness trackers we had previously and use that value to allocate the array, which results in 50% less allocation in the entire `.Append` chain. 

<img width="938" alt="image" src="https://github.com/user-attachments/assets/1bc4482b-2570-4b54-9889-599677f5b51b" />

There is some more allocation in the constructor now, but overall it is a reduction because the slice doesn't need to grow (in most cases):
<img width="536" alt="image" src="https://github.com/user-attachments/assets/93a32da7-ca19-4490-8273-e84c03216389" />


The gains will be even larger the more Fanouts and Interceptors are used in the pipeline. 

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
