### PR TITLE
[faro receiver] Move location of changelog entry and waitgroup wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Main (unreleased)
 
 - Improved performance by reducing allocation in Prometheus write pipelines by ~30% (@thampiotr)
 
+- Add json format support for log export via faro receiver (@ravishankar15)
+
 v1.6.0-rc.1
 -----------------
 
@@ -75,7 +77,6 @@ v1.6.0-rc.1
   - Add perf_schema quantile columns to collector
 
 - Live Debugging button should appear in UI only for supported components (@ravishankar15)
-- Add json format support for log export via faro receiver (@ravishankar15)
 - Add three new stdlib functions to_base64, from_URLbase64 and to_URLbase64 (@ravishankar15)
 - Add `ignore_older_than` option for local.file_match (@ravishankar15)
 - Add livedebugging support for discovery components (@ravishankar15)

--- a/internal/component/faro/receiver/receiver_test.go
+++ b/internal/component/faro/receiver/receiver_test.go
@@ -163,6 +163,7 @@ func newFakeLogsReceiver(t *testing.T) *fakeLogsReceiver {
 	lr.wg.Add(1)
 	go func() {
 		defer close(lr.ch)
+		defer lr.wg.Done()
 
 		select {
 		case <-ctx.Done():
@@ -178,7 +179,6 @@ func newFakeLogsReceiver(t *testing.T) *fakeLogsReceiver {
 				},
 			})
 			lr.entriesMut.Unlock()
-			lr.wg.Done()
 		}
 	}()
 


### PR DESCRIPTION
Minor cleanup after #2276. The PR was not quite up to date, so the changelog entry went in the RC instead of `main`. I didn't want to ask the contributor (@ravishankar15) to rebase, since I'd already asked once before and didn't get around to merging it 😅 

I'm also moving the waitgroup Wait to a defer statement so that it gets executed at the end of the goroutine. I don't think it makes a huge difference for the test, but it's technically more correct.