### PR TITLE
feat(pyroscope.receive_http): Support pushv1.Push in receive_http

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Main (unreleased)
 
 - Bump snmp_exporter and embedded modules to 0.27.0. Add support for multi-module handling by comma separation and expose argument to increase SNMP polling concurrency for `prometheus.exporter.snmp`. (@v-zhuravlev)
 
+- Add support for pushv1.PusherService Connect API in `pyroscope.receive_http`. (@simonswine)
+
 v1.6.1
 -----------------
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.receive_http.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.receive_http.md
@@ -12,7 +12,7 @@ title: pyroscope.receive_http
 
 `pyroscope.receive_http` receives profiles over HTTP and forwards them to `pyroscope.*` components capable of receiving profiles.
 
-The HTTP API exposed is compatible with the Pyroscope [HTTP ingest API](https://grafana.com/docs/pyroscope/latest/configure-server/about-server-api/).
+The HTTP API exposed is compatible with both the Pyroscope [HTTP ingest API](https://grafana.com/docs/pyroscope/latest/configure-server/about-server-api/) and the [pushv1.PusherService](https://github.com/grafana/pyroscope/blob/main/api/push/v1/push.proto) Connect API.
 This allows `pyroscope.receive_http` to act as a proxy for Pyroscope profiles, enabling flexible routing and distribution of profile data.
 
 ## Usage
@@ -30,6 +30,7 @@ pyroscope.receive_http "LABEL" {
 The component will start an HTTP server supporting the following endpoint.
 
 * `POST /ingest` - send profiles to the component, which will be forwarded to the receivers as configured in the `forward_to argument`. The request format must match the format of the Pyroscope ingest API.
+* `POST /push.v1.PusherService/Push` - send profiles to the component, which will be forwarded to the receivers as configured in the `forward_to argument`. The request format must match the format of the Pyroscope pushv1.PusherService Connect API.
 
 ## Arguments
 


### PR DESCRIPTION
The Pyroscope backend has currently two ingest API:
* /ingest, which is predominatnely used by the Pyroscope SDKs
* /push.v1.PusherService/Push which is a connect API used by profilecli and pyroscope.write with pyroscope.ebpf and pyroscope.alloy

This adds the missing support for `/push.v1.PusherService/Push`

Fixes #2301
