### PR TITLE
database_observability: attempt to parse queries truncated in a comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Main (unreleased)
 
 - (_Experimental_) Log instance label key in `database_observability.mysql` (@cristiangreco)
 
+- (_Experimental_) Improve parsing of truncated queries in `database_observability.mysql` (@cristiangreco)
+
 - Add json format support for log export via faro receiver (@ravishankar15)
 
 v1.6.0-rc.1

--- a/internal/component/database_observability/mysql/collector/query_sample_test.go
+++ b/internal/component/database_observability/mysql/collector/query_sample_test.go
@@ -112,6 +112,19 @@ func TestQuerySample(t *testing.T) {
 			},
 		},
 		{
+			name: "with comment",
+			rows: [][]driver.Value{{
+				"abc123",
+				"select val1, /* val2,*/ val3 from some_table where id = 1",
+				"2024-01-01T00:00:00.000Z",
+				"1000",
+			}},
+			logs: []string{
+				`level=info msg="query samples fetched" op="query_sample" instance="mysql-db" digest="abc123" query_type="select" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="select val1, val3 from some_table where id = :redacted1"`,
+				`level=info msg="table name parsed" op="query_parsed_table_name" instance="mysql-db" digest="abc123" table="some_table"`,
+			},
+		},
+		{
 			name: "truncated query",
 			rows: [][]driver.Value{{
 				"xyz456",
@@ -121,6 +134,19 @@ func TestQuerySample(t *testing.T) {
 			}, {
 				"abc123",
 				"select * from some_table where id = 1",
+				"2024-01-01T00:00:00.000Z",
+				"1000",
+			}},
+			logs: []string{
+				`level=info msg="query samples fetched" op="query_sample" instance="mysql-db" digest="abc123" query_type="select" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="select * from some_table where id = :redacted1"`,
+				`level=info msg="table name parsed" op="query_parsed_table_name" instance="mysql-db" digest="abc123" table="some_table"`,
+			},
+		},
+		{
+			name: "truncated in multi-line comment",
+			rows: [][]driver.Value{{
+				"abc123",
+				"select * from some_table where id = 1 /*traceparent='00-abc...",
 				"2024-01-01T00:00:00.000Z",
 				"1000",
 			}},


### PR DESCRIPTION
#### PR Description
The `query_sample` collector for now attempts to detect if a query is truncated in a multi-line comment (those between `/*` and `*/`).

This is a best-effort attempt to avoid skipping queries that might be truncated in the middle of a trailing comment that is not closed, but the first part of the query is still valid.

#### Which issue(s) this PR fixes
n.a.

#### Notes to the Reviewer

#### PR Checklist
- [x] CHANGELOG.md updated
- [x] Tests updated
