### PR TITLE
Check number of log fields in MongoDB exporter.

### DIFF
--- a/internal/static/integrations/logruskit.go
+++ b/internal/static/integrations/logruskit.go
@@ -51,6 +51,12 @@ func (o output) Write(data []byte) (n int, err error) {
 	}
 	sort.Strings(keys)
 
+	// Protecting against a potential integer overflow as reported by GitHub CodeQL.
+	// The number of fields is expected to be well below this limit.
+	if fieldLen := len(ll.Data); fieldLen > 100000 {
+		return 0, fmt.Errorf("too many fields: %d", fieldLen)
+	}
+
 	vals := make([]interface{}, 0, 2*len(ll.Data)+2)
 	for _, k := range keys {
 		vals = append(vals, k, ll.Data[k])


### PR DESCRIPTION
Minor change to resolve [a CodeQL alert](https://github.com/grafana/alloy/security/code-scanning/34). If we want to make the check super generic, we could also check for [integer overflow](https://stackoverflow.com/questions/33641717/detect-signed-int-overflow-in-go) and for an [allocation that's too big](https://stackoverflow.com/questions/27647737/maximum-length-of-a-slice-in-go). All of this sounds like overkill - after all, the amount of labels on a log line are rarely many. A limit of 100,000 should be ok in practice.