### PR TITLE
database_observability:: Fix selectTableName query column order 

### DIFF
--- a/internal/component/database_observability/mysql/collector/schema_table.go
+++ b/internal/component/database_observability/mysql/collector/schema_table.go
@@ -35,8 +35,8 @@ const (
 	selectTableName = `
 	SELECT
 		TABLE_NAME,
-		CREATE_TIME,
 		TABLE_TYPE,
+		CREATE_TIME,
 		ifnull(UPDATE_TIME, CREATE_TIME) AS UPDATE_TIME
 	FROM
 		information_schema.tables


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
The query column order differs between the query, and subsequent scan. This is causing row scanning to fail.
This change fixes the order so that the column order and scan destinations match.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
