### PR TITLE
Fix incorrect conversion between integer types

### DIFF
--- a/internal/component/loki/source/file/decompresser.go
+++ b/internal/component/loki/source/file/decompresser.go
@@ -214,7 +214,7 @@ func (d *decompressor) readLines() {
 	maxLoglineSize := 2000000 // 2 MB
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(buffer, maxLoglineSize)
-	for line := 1; ; line++ {
+	for line := int64(1); ; line++ {
 		if !scanner.Scan() {
 			break
 		}
@@ -227,7 +227,7 @@ func (d *decompressor) readLines() {
 			break
 		}
 
-		if line <= int(d.position) {
+		if line <= d.position {
 			// skip already seen lines.
 			continue
 		}

--- a/internal/component/pyroscope/java/java.go
+++ b/internal/component/pyroscope/java/java.go
@@ -126,7 +126,13 @@ func (j *javaComponent) updateTargets(args Arguments) {
 
 	active := make(map[int]struct{})
 	for _, target := range args.Targets {
-		pid, err := strconv.Atoi(target[labelProcessID])
+		pid64, err := strconv.ParseInt(target[labelProcessID], 10, 32)
+		if err != nil {
+			_ = level.Error(j.opts.Logger).Log("msg", "could not convert process ID to a 32 bit integer", "pid", target[labelProcessID], "err", err)
+			continue
+		}
+		pid := int(pid64)
+
 		_ = level.Debug(j.opts.Logger).Log("msg", "active target",
 			"target", fmt.Sprintf("%+v", target),
 			"pid", pid)


### PR DESCRIPTION
Fixing two CodeQL issues.

For java.go, the [suggestion](https://github.com/grafana/alloy/security/code-scanning/3) is:

> If a string is parsed into an int using strconv.Atoi, and subsequently that int is converted into another integer type of a smaller size, the result can produce unexpected values.

For decompressor.go, the [suggestion](https://github.com/grafana/alloy/security/code-scanning/2) is:

> If a string is parsed into an int using strconv.Atoi, and subsequently that int is converted into another integer type of a smaller size, the result can produce unexpected values.
