### PR TITLE
Protect Untar function from a zip slip.

### DIFF
--- a/internal/util/untar.go
+++ b/internal/util/untar.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // Untar untars a tarball to the provided destination path.
@@ -29,6 +30,13 @@ func Untar(tarPath string, destPath string) error {
 			break
 		} else if err != nil {
 			return err
+		}
+
+		// Protect from a zip slip.
+		// https://security.snyk.io/research/zip-slip-vulnerability
+		if strings.Contains(header.Name, `../`) ||
+			strings.Contains(header.Name, `..\`) {
+			return fmt.Errorf("tar: invalid file path: %s", header.Name)
 		}
 
 		fullPath := filepath.Join(destPath, header.Name)


### PR DESCRIPTION
Resolves a [CodeQL issue](https://github.com/grafana/alloy/security/code-scanning/1). The `Untar` function is only used as a utility for testing, so I won't add a test for this particular use case for now. It's not easy to create an archive which contains `../` - you'd have to handcraft it, since most utilities don't allow it.