### PR TITLE
Actually use tls alloy and not yaml.

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.write.queue.md
+++ b/docs/sources/reference/components/prometheus/prometheus.write.queue.md
@@ -110,7 +110,12 @@ Name            | Type     | Description                              | Default 
 
 ### tls_config block
 
-{{< docs/shared lookup="reference/components/tls-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+Name                   | Type     | Description                                              | Default | Required
+-----------------------|----------|----------------------------------------------------------|---------|---------
+`ca_pem`               | `string` | CA PEM-encoded text to validate the server with.         |         | no
+`cert_pem`             | `string` | Certificate PEM-encoded text for client authentication.  |         | no
+`insecure_skip_verify` | `bool`   | Disables validation of the server certificate.           |         | no
+`key_pem`              | `secret` | Key PEM-encoded text for client authentication.          |         | no
 
 ## Exported fields
 

--- a/internal/component/prometheus/write/queue/types.go
+++ b/internal/component/prometheus/write/queue/types.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/grafana/alloy/syntax/alloytypes"
 	"github.com/grafana/walqueue/types"
-	common "github.com/prometheus/common/config"
 	"github.com/prometheus/common/version"
 	"github.com/prometheus/prometheus/storage"
 )
@@ -67,9 +66,6 @@ func (r *Arguments) Validate() error {
 		if conn.FlushInterval < 1*time.Second {
 			return fmt.Errorf("flush_interval must be greater or equal to 1s, the internal timers resolution is 1s")
 		}
-		if conn.BasicAuth != nil && conn.TLSConfig != nil {
-			return fmt.Errorf("endpoint %s cannot have both BasicAuth and TLSConfig set", conn.Name)
-		}
 	}
 
 	return nil
@@ -93,8 +89,15 @@ type EndpointConfig struct {
 	// How many concurrent queues to have.
 	Parallelism    uint              `alloy:"parallelism,attr,optional"`
 	ExternalLabels map[string]string `alloy:"external_labels,attr,optional"`
-	TLSConfig      *common.TLSConfig `alloy:"tls_config,block,optional"`
+	TLSConfig      *TLSConfig        `alloy:"tls_config,block,optional"`
 	RoundRobin     bool              `alloy:"enable_round_robin,attr,optional"`
+}
+
+type TLSConfig struct {
+	CA                 string            `alloy:"ca_pem,attr,optional"`
+	Cert               string            `alloy:"cert_pem,attr,optional"`
+	Key                alloytypes.Secret `alloy:"key_pem,attr,optional"`
+	InsecureSkipVerify bool              `alloy:"insecure_skip_verify,attr,optional"`
 }
 
 var UserAgent = fmt.Sprintf("Alloy/%s", version.Version)

--- a/internal/component/prometheus/write/queue/types_test.go
+++ b/internal/component/prometheus/write/queue/types_test.go
@@ -3,21 +3,8 @@ package queue
 import (
 	"github.com/grafana/alloy/syntax"
 	"github.com/stretchr/testify/require"
-	"strings"
 	"testing"
 )
-
-func TestBasicAuthAndTLSBothSetError(t *testing.T) {
-	args := defaultArgs()
-	args.Endpoints = make([]EndpointConfig, 1)
-	args.Endpoints[0] = defaultEndpointConfig()
-	args.Endpoints[0].Name = "test"
-	args.Endpoints[0].TLSConfig = &TLSConfig{}
-	args.Endpoints[0].BasicAuth = &BasicAuth{}
-	err := args.Validate()
-	require.Error(t, err)
-	require.True(t, strings.Contains(err.Error(), "cannot have both BasicAuth and TLSConfig"))
-}
 
 func TestParsingTLSConfig(t *testing.T) {
 	var args Arguments

--- a/internal/component/prometheus/write/queue/types_test.go
+++ b/internal/component/prometheus/write/queue/types_test.go
@@ -1,7 +1,7 @@
 package queue
 
 import (
-	common "github.com/prometheus/common/config"
+	"github.com/grafana/alloy/syntax"
 	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
@@ -12,9 +12,28 @@ func TestBasicAuthAndTLSBothSetError(t *testing.T) {
 	args.Endpoints = make([]EndpointConfig, 1)
 	args.Endpoints[0] = defaultEndpointConfig()
 	args.Endpoints[0].Name = "test"
-	args.Endpoints[0].TLSConfig = &common.TLSConfig{}
+	args.Endpoints[0].TLSConfig = &TLSConfig{}
 	args.Endpoints[0].BasicAuth = &BasicAuth{}
 	err := args.Validate()
 	require.Error(t, err)
 	require.True(t, strings.Contains(err.Error(), "cannot have both BasicAuth and TLSConfig"))
+}
+
+func TestParsingTLSConfig(t *testing.T) {
+	var args Arguments
+	err := syntax.Unmarshal([]byte(`
+    endpoint "cloud"  {
+        url = "http://example.com"
+        basic_auth {
+            username = 12345
+            password = "password"
+        }
+        tls_config {
+            insecure_skip_verify = true
+        }
+
+    }
+`), &args)
+
+	require.NoError(t, err)
 }


### PR DESCRIPTION
#### PR Description

Bug in RC that it was using the yaml tls config and not the alloy version. Added tests for the parsering since using direct structs works fine.

#### Notes to the Reviewer

#### PR Checklist

- [x] Documentation added
- [x] Tests updated

