### PR TITLE
GitHub Actions steps to build Alloy for every pull request

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -222,6 +222,7 @@ volumes:
     path: //./pipe/docker_engine/
   name: docker
 ---
+# TODO: Remove this pipeline later
 kind: pipeline
 name: Build alloy (Linux amd64)
 platform:
@@ -239,6 +240,7 @@ trigger:
   - pull_request
 type: docker
 ---
+# TODO: Remove this pipeline later
 kind: pipeline
 name: Build alloy (Linux arm64)
 platform:
@@ -256,6 +258,7 @@ trigger:
   - pull_request
 type: docker
 ---
+# TODO: Remove this pipeline later
 kind: pipeline
 name: Build alloy (Linux ppc64le)
 platform:
@@ -273,6 +276,7 @@ trigger:
   - pull_request
 type: docker
 ---
+# TODO: Remove this pipeline later
 kind: pipeline
 name: Build alloy (Linux s390x)
 platform:
@@ -290,6 +294,7 @@ trigger:
   - pull_request
 type: docker
 ---
+# TODO: Remove this pipeline later
 kind: pipeline
 name: Build alloy (macOS Intel)
 platform:
@@ -306,6 +311,7 @@ trigger:
   - pull_request
 type: docker
 ---
+# TODO: Remove this pipeline later
 kind: pipeline
 name: Build alloy (macOS Apple Silicon)
 platform:
@@ -322,6 +328,7 @@ trigger:
   - pull_request
 type: docker
 ---
+# TODO: Remove this pipeline later
 kind: pipeline
 name: Build alloy (Windows amd64)
 platform:
@@ -338,6 +345,7 @@ trigger:
   - pull_request
 type: docker
 ---
+# TODO: Remove this pipeline later
 kind: pipeline
 name: Build alloy (FreeBSD amd64)
 platform:
@@ -354,6 +362,7 @@ trigger:
   - pull_request
 type: docker
 ---
+# TODO: Remove this pipeline later
 kind: pipeline
 name: Build alloy (Linux amd64 boringcrypto)
 platform:
@@ -371,6 +380,7 @@ trigger:
   - pull_request
 type: docker
 ---
+# TODO: Remove this pipeline later
 kind: pipeline
 name: Build alloy (Linux arm64 boringcrypto)
 platform:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,128 @@
+name: Build
+on:
+  pull_request:
+concurrency:
+  # Cancel any running workflow for the same branch when new commits are pushed.
+  # We group both by ref_name (available when CI is triggered by a push to a branch/tag)
+  # and head_ref (available when CI is triggered by a PR).
+  group: "${{ github.ref_name }}-${{ github.head_ref }}"
+  cancel-in-progress: true
+jobs:
+  build_linux:
+    name: Build on Linux
+    runs-on: ubuntu-latest
+    container: grafana/alloy-build-image:v0.1.8
+    strategy:
+      matrix:
+        os: [linux]
+        arch: [amd64, arm64, ppc64le, s390x]
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Set ownership
+      # https://github.com/actions/runner/issues/2033#issuecomment-1204205989
+      run: |
+          # this is to fix GIT not liking owner of the checkout dir
+          chown -R $(id -u):$(id -g) $PWD
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        # TODO: Try enabling caching later. It might use up too much disk space on runners so needs extra testing.
+        cache: false
+    - run: make generate-ui
+    - run: GO_TAGS="builtinassets promtail_journal_enabled" GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} GOARM= make alloy
+
+  build_linux_boringcrypto:
+    name: Build on Linux (boringcrypto)
+    runs-on: ubuntu-latest
+    container: grafana/alloy-build-image:v0.1.8-boringcrypto
+    strategy:
+      matrix:
+        os: [linux]
+        arch: [amd64, arm64]
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Set ownership
+      # https://github.com/actions/runner/issues/2033#issuecomment-1204205989
+      run: |
+          # this is to fix GIT not liking owner of the checkout dir
+          chown -R $(id -u):$(id -g) $PWD
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        # TODO: Try enabling caching later. It might use up too much disk space on runners so needs extra testing.
+        cache: false
+    - run: make generate-ui
+    - run: GO_TAGS="builtinassets promtail_journal_enabled" GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} GOARM= GOEXPERIMENT=boringcrypto make alloy
+
+  build_mac_intel:
+    name: Build on MacOS (Intel)
+    runs-on: macos-14-large
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        # TODO: Try enabling caching later. It might use up too much disk space on runners so needs extra testing.
+        cache: false
+    - run: make generate-ui
+    - run: GO_TAGS="builtinassets" GOOS=darwin GOARCH=amd64 GOARM= make alloy
+
+  build_mac_arm:
+    name: Build on MacOS (ARM)
+    runs-on: macos-14-xlarge
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        # TODO: Try enabling caching later. It might use up too much disk space on runners so needs extra testing.
+        cache: false
+    - run: make generate-ui
+    - run: GO_TAGS="builtinassets" GOOS=darwin GOARCH=arm64 GOARM= make alloy
+
+  build_windows:
+    name: Build on Windows (AMD64)
+    runs-on: windows-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        # TODO: Try enabling caching later. It might use up too much disk space on runners so needs extra testing.
+        cache: false
+    - run: make generate-ui
+    - run: echo "GO_TAGS=builtinassets" | Out-File -FilePath $env:GITHUB_ENV -Append
+    - run: echo "GOOS=windows" | Out-File -FilePath $env:GITHUB_ENV -Append
+    - run: echo "GOARCH=amd64" | Out-File -FilePath $env:GITHUB_ENV -Append
+    - run: make alloy
+
+  build_freebsd:
+    name: Build on FreeBSD (AMD64)
+    runs-on: ubuntu-latest
+    container: grafana/alloy-build-image:v0.1.8
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Set ownership
+      # https://github.com/actions/runner/issues/2033#issuecomment-1204205989
+      run: |
+          # this is to fix GIT not liking owner of the checkout dir
+          chown -R $(id -u):$(id -g) $PWD
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        # TODO: Try enabling caching later. It might use up too much disk space on runners so needs extra testing.
+        cache: false
+    - run: make generate-ui
+    - run: GO_TAGS="builtinassets" GOOS=freebsd GOARCH=amd64 GOARM= make alloy


### PR DESCRIPTION
This replicates the Drone builds. The Drone builds will be turned off in a follow-up PR.

In a follow up PR I also intend to enable caching for Go modules. I haven't enabled it yet, because there might be a few issues with it that lead to runners going out of disk space. I will need to test the caching functionality more thoroughly before enabling it.
