### PR TITLE
Add GitHub Actions equivalents for some Drone testing builds

### DIFF
--- a/.github/workflows/test_mac.yml
+++ b/.github/workflows/test_mac.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Test (Mac)
 on:
   # Run tests on main just so the module and build cache can be saved and used
   # in PRs. This speeds up the time it takes to test PRs dramatically.
@@ -9,7 +9,7 @@ on:
   pull_request:
 jobs:
   test:
-    name: Test
+    name: Test (Mac)
     strategy:
       matrix:
         platform: [macos-latest-xlarge]

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -1,0 +1,31 @@
+name: Test
+on:
+  pull_request:
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Set up Go 1.23
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache: false
+    - run: sudo apt-get update -y && sudo apt-get install -y libsystemd-dev
+    - run: make lint
+
+  test_linux:
+    name: Test Linux
+    runs-on: ubuntu-latest
+    container: grafana/alloy-build-image:v0.1.8
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Set up Go 1.23
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache: false
+    - run: make GO_TAGS="nodocker" test

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -1,0 +1,26 @@
+name: Test (Windows)
+on:
+  # TODO: Run the Windows tests for each PR? 
+  # For now we don't do it just because it takes time.
+  push:
+    # TODO: Also run the tests when a Windows-specific features is changed.
+    # For example, the Windows Exporter for Prometheus and Event Log tailers.
+    branches:
+      - main
+jobs:
+  test_windows:
+    name: Test (Windows)
+    runs-on: windows-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Set up Go 1.23
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        # TODO: Enable caching later.
+        # We'll need to make sure the same cache is reused by the workflow to build Windows binaries.
+        cache: false
+    - name: Test
+      run: '& "C:/Program Files/git/bin/bash.exe" -c ''go test -tags="nodocker,nonetwork"
+        ./...'''


### PR DESCRIPTION
The Drone builds will be deleted once the GitHub Actions are more battle tested.
