### PR TITLE
loki.secretfilter: Change the way the secret is hashed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ Main (unreleased)
 
 - Add livedebugging support for `prometheus.remote_write` (@ravishankar15)
 
+### Other changes
+
+- Change the way the secret is hashed in `loki.secretfilter`. (@romain-gaillard)
+
 v1.6.1
 -----------------
 

--- a/docs/sources/reference/components/loki/loki.secretfilter.md
+++ b/docs/sources/reference/components/loki/loki.secretfilter.md
@@ -72,7 +72,7 @@ This behavior is consistent with the Gitleaks redaction feature but may not be w
 Currently, the secret types known to have this behavior are: `aws-access-token`.
 {{< /admonition >}}
 
-The `redact_with` argument is a string that can use variables such as `$SECRET_NAME` (replaced with the matching secret type) and `$SECRET_HASH`(replaced with the sha1 hash of the secret).
+The `redact_with` argument is a string that can use variables such as `$SECRET_NAME` (replaced with the matching secret type) and `$SECRET_HASH`(replaced with the first half of the SHA256 hash).
 
 The `include_generic` argument is a boolean that includes the generic API key rule in the Gitleaks configuration file if set to `true`. It's disabled by default because it can generate false positives.
 
@@ -107,7 +107,7 @@ The following fields are exported and can be referenced by other components:
 ## Example
 
 This example shows how to use `loki.secretfilter` to redact secrets from log entries before forwarding them to a Loki receiver.
-It uses a custom redaction string that will include the secret type and its hash.
+It uses a custom redaction string that will include the secret type and the first half of its SHA256 hash.
 
 ```alloy
 local.file_match "local_logs" {

--- a/internal/component/loki/secretfilter/secretfilter.go
+++ b/internal/component/loki/secretfilter/secretfilter.go
@@ -2,7 +2,7 @@ package secretfilter
 
 import (
 	"context"
-	"crypto/sha1"
+	"crypto/sha256"
 	"embed"
 	"fmt"
 	"regexp"
@@ -254,9 +254,14 @@ func (c *Component) redactLine(line string, secret string, ruleName string) stri
 }
 
 func hashSecret(secret string) string {
-	hasher := sha1.New()
+	hasher := sha256.New()
 	hasher.Write([]byte(secret))
-	return fmt.Sprintf("%x", hasher.Sum(nil))
+	hashBytes := hasher.Sum(nil)
+
+	// Only use the first half of the hash
+	firstHalf := hashBytes[:len(hashBytes)/2]
+
+	return fmt.Sprintf("%x", firstHalf)
 }
 
 // Update implements component.Component.

--- a/internal/component/loki/secretfilter/secretfilter_test.go
+++ b/internal/component/loki/secretfilter/secretfilter_test.go
@@ -430,6 +430,31 @@ func TestPartialMasking(t *testing.T) {
 	}
 }
 
+func TestHash(t *testing.T) {
+	// Hash random strings
+	for range 15 {
+		secret := generateRandomString(rand.Intn(50))
+		hashed := hashSecret(secret)
+		require.NotEmpty(t, hashed)
+		require.NotEqual(t, secret, hashed)
+	}
+	// Check against some known values
+	require.Equal(t, "6ca13d52ca70c883e0f0bb101e425a89", hashSecret("abc123"))
+	require.Equal(t, "c7be1ed902fb8dd4d48997c6452f5d7e", hashSecret("This is a test"))
+	require.Equal(t, "54cca69c28704ad067bcf29253f1a4b3", hashSecret("Longer string with more characters"))
+
+}
+
+func generateRandomString(length int) string {
+	// Random string to be used as a secret
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))]
+	}
+	return string(b)
+}
+
 func checkPartialMasking(t *testing.T, partialMasking int, secretLength int, expectedPrefixLength int) {
 	component := &Component{}
 	component.args = Arguments{PartialMask: uint(partialMasking)}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR changes the way the secret is hashed in the experimental component `loki.secretfilter`.

In this context, the hash of the secret is used to be able to identify the redacted secret more easily, without revealing too much information about it in the logs. It's the reason why an algorithm with a shorter output was used (SHA1): it doesn't need to be collision resistant as it is used as an identifier for the redacted secret, not as a signature.

But I thought of a different approach to keep the hash relatively short: hash it with SHA256 and output only the first half of the hash. This approach should help keep the information about the secret minimal, while relying on a more recent hashing algorithm that is more likely to be available to someone investigating a leaked secret in their logs. I believe the first half of a SHA256 hash is unique enough to help identify the secret that leaked without ambiguity, and short enough not to add too much information about the underlying secret in the logs.

@kelnage happy to have your opinion on this!

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
- [X] Documentation added
- [X] Tests updated
- [ ] Config converters updated
