### PR TITLE
database_observability: do not stop collectors on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Main (unreleased)
 
 - (_Experimental_) Better support for table name parsing in `database_observability.mysql` (@cristiangreco)
 
+- (_Experimental_) Better error handling for `database_observability.mysql` (@cristiangreco)
+
 - Add json format support for log export via faro receiver (@ravishankar15)
 
 - Add livedebugging support for `prometheus.remote_write` (@ravishankar15)

--- a/internal/component/database_observability/mysql/collector/query_sample.go
+++ b/internal/component/database_observability/mysql/collector/query_sample.go
@@ -88,9 +88,7 @@ func (c *QuerySample) Start(ctx context.Context) error {
 
 		for {
 			if err := c.fetchQuerySamples(c.ctx); err != nil {
-				level.Error(c.logger).Log("msg", "collector stopping due to error", "err", err)
-				c.Stop()
-				break
+				level.Error(c.logger).Log("msg", "collector error", "err", err)
 			}
 
 			select {

--- a/internal/component/database_observability/mysql/collector/schema_table.go
+++ b/internal/component/database_observability/mysql/collector/schema_table.go
@@ -119,9 +119,7 @@ func (c *SchemaTable) Start(ctx context.Context) error {
 
 		for {
 			if err := c.extractSchema(c.ctx); err != nil {
-				level.Error(c.logger).Log("msg", "collector stopping due to error", "err", err)
-				c.Stop()
-				break
+				level.Error(c.logger).Log("msg", "collector error", "err", err)
 			}
 
 			select {

--- a/internal/component/database_observability/mysql/collector/schema_table_test.go
+++ b/internal/component/database_observability/mysql/collector/schema_table_test.go
@@ -17,10 +17,12 @@ import (
 )
 
 func TestSchemaTable(t *testing.T) {
+	// The goroutine which deletes expired entries runs indefinitely,
+	// see https://github.com/hashicorp/golang-lru/blob/v2.0.7/expirable/expirable_lru.go#L79-L80
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"))
+
 	t.Run("detect table schema", func(t *testing.T) {
-		// The goroutine which deletes expired entries runs indefinitely,
-		// see https://github.com/hashicorp/golang-lru/blob/v2.0.7/expirable/expirable_lru.go#L79-L80
-		defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"))
+		t.Parallel()
 
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
@@ -38,6 +40,288 @@ func TestSchemaTable(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
+
+		mock.ExpectQuery(selectSchemaName).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"schema_name",
+				}).AddRow(
+					"some_schema",
+				),
+			)
+
+		mock.ExpectQuery(selectTableName).WithArgs("some_schema").RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"table_name",
+					"table_type",
+					"create_time",
+					"update_time",
+				}).AddRow(
+					"some_table",
+					"BASE TABLE",
+					time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+					time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC),
+				),
+			)
+
+		mock.ExpectQuery("SHOW CREATE TABLE some_schema.some_table").WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"table_name",
+					"create_statement",
+				}).AddRow(
+					"some_schema.some_table",
+					"CREATE TABLE some_table (id INT)",
+				),
+			)
+
+		err = collector.Start(context.Background())
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 3
+		}, 5*time.Second, 100*time.Millisecond)
+
+		collector.Stop()
+		lokiClient.Stop()
+
+		require.Eventually(t, func() bool {
+			return collector.Stopped()
+		}, 5*time.Second, 100*time.Millisecond)
+
+		err = mock.ExpectationsWereMet()
+		require.NoError(t, err)
+
+		lokiEntries := lokiClient.Received()
+		for _, entry := range lokiEntries {
+			require.Equal(t, model.LabelSet{"job": database_observability.JobName}, entry.Labels)
+		}
+		require.Equal(t, `level=info msg="schema detected" op="schema_detection" instance="mysql-db" schema="some_schema"`, lokiEntries[0].Line)
+		require.Equal(t, `level=info msg="table detected" op="table_detection" instance="mysql-db" schema="some_schema" table="some_table"`, lokiEntries[1].Line)
+		require.Equal(t, `level=info msg="create table" op="create_statement" instance="mysql-db" schema="some_schema" table="some_table" create_statement="CREATE TABLE some_table (id INT)"`, lokiEntries[2].Line)
+	})
+	t.Run("detect view schema", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki_fake.NewClient(func() {})
+
+		collector, err := NewSchemaTable(SchemaTableArguments{
+			DB:              db,
+			InstanceKey:     "mysql-db",
+			CollectInterval: time.Second,
+			EntryHandler:    lokiClient,
+			CacheTTL:        time.Minute,
+			Logger:          log.NewLogfmtLogger(os.Stderr),
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+
+		mock.ExpectQuery(selectSchemaName).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"schema_name",
+				}).AddRow(
+					"some_schema",
+				),
+			)
+
+		mock.ExpectQuery(selectTableName).WithArgs("some_schema").RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"table_name",
+					"table_type",
+					"create_time",
+					"update_time",
+				}).AddRow(
+					"some_table",
+					"VIEW",
+					time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+					time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC),
+				),
+			)
+
+		mock.ExpectQuery("SHOW CREATE TABLE some_schema.some_table").WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"table_name",
+					"create_statement",
+					"character_set_client",
+					"collation_connection",
+				}).AddRow(
+					"some_schema.some_table",
+					"CREATE VIEW some_view (id INT)",
+					"some_charset",
+					"some_charset_connection",
+				),
+			)
+
+		err = collector.Start(context.Background())
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 3
+		}, 5*time.Second, 100*time.Millisecond)
+
+		collector.Stop()
+		lokiClient.Stop()
+
+		require.Eventually(t, func() bool {
+			return collector.Stopped()
+		}, 5*time.Second, 100*time.Millisecond)
+
+		err = mock.ExpectationsWereMet()
+		require.NoError(t, err)
+
+		lokiEntries := lokiClient.Received()
+		for _, entry := range lokiEntries {
+			require.Equal(t, model.LabelSet{"job": database_observability.JobName}, entry.Labels)
+		}
+		require.Equal(t, `level=info msg="schema detected" op="schema_detection" instance="mysql-db" schema="some_schema"`, lokiEntries[0].Line)
+		require.Equal(t, `level=info msg="table detected" op="table_detection" instance="mysql-db" schema="some_schema" table="some_table"`, lokiEntries[1].Line)
+		require.Equal(t, `level=info msg="create table" op="create_statement" instance="mysql-db" schema="some_schema" table="some_table" create_statement="CREATE VIEW some_view (id INT)"`, lokiEntries[2].Line)
+	})
+	t.Run("schemas result set iteration error", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki_fake.NewClient(func() {})
+
+		collector, err := NewSchemaTable(SchemaTableArguments{
+			DB:              db,
+			InstanceKey:     "mysql-db",
+			CollectInterval: time.Second,
+			EntryHandler:    lokiClient,
+			CacheTTL:        time.Minute,
+			Logger:          log.NewLogfmtLogger(os.Stderr),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+
+		mock.ExpectQuery(selectSchemaName).WithoutArgs().WillReturnRows(
+			sqlmock.NewRows(
+				[]string{"schema_name"},
+			).AddRow(
+				"some_schema",
+			).RowError(1, fmt.Errorf("rs error"))) // error on the second row
+
+		err = collector.Start(context.Background())
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 1
+		}, 5*time.Second, 100*time.Millisecond)
+
+		collector.Stop()
+		lokiClient.Stop()
+
+		require.Eventually(t, func() bool {
+			return collector.Stopped()
+		}, 5*time.Second, 100*time.Millisecond)
+
+		err = mock.ExpectationsWereMet()
+		require.NoError(t, err)
+
+		lokiEntries := lokiClient.Received()
+		for _, entry := range lokiEntries {
+			require.Equal(t, model.LabelSet{"job": database_observability.JobName}, entry.Labels)
+		}
+		require.Equal(t, `level=info msg="schema detected" op="schema_detection" instance="mysql-db" schema="some_schema"`, lokiEntries[0].Line)
+	})
+	t.Run("tables result set iteration error", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki_fake.NewClient(func() {})
+
+		collector, err := NewSchemaTable(SchemaTableArguments{
+			DB:              db,
+			InstanceKey:     "mysql-db",
+			CollectInterval: time.Second,
+			EntryHandler:    lokiClient,
+			CacheTTL:        time.Minute,
+			Logger:          log.NewLogfmtLogger(os.Stderr),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+
+		mock.ExpectQuery(selectSchemaName).WithoutArgs().WillReturnRows(
+			sqlmock.NewRows([]string{
+				"schema_name",
+			}).AddRow(
+				"some_schema",
+			),
+		)
+		mock.ExpectQuery(selectTableName).WithArgs("some_schema").WillReturnRows(
+			sqlmock.NewRows([]string{
+				"table_name",
+				"table_type",
+				"create_time",
+				"update_time",
+			}).AddRow(
+				"some_table",
+				"BASE TABLE",
+				time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC),
+			).RowError(1, fmt.Errorf("rs error")), // error on the second row
+		)
+
+		err = collector.Start(context.Background())
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 2
+		}, 5*time.Second, 100*time.Millisecond)
+
+		collector.Stop()
+		lokiClient.Stop()
+
+		require.Eventually(t, func() bool {
+			return collector.Stopped()
+		}, 5*time.Second, 100*time.Millisecond)
+
+		err = mock.ExpectationsWereMet()
+		require.NoError(t, err)
+
+		lokiEntries := lokiClient.Received()
+		for _, entry := range lokiEntries {
+			require.Equal(t, model.LabelSet{"job": database_observability.JobName}, entry.Labels)
+		}
+		require.Equal(t, `level=info msg="schema detected" op="schema_detection" instance="mysql-db" schema="some_schema"`, lokiEntries[0].Line)
+		require.Equal(t, `level=info msg="table detected" op="table_detection" instance="mysql-db" schema="some_schema" table="some_table"`, lokiEntries[1].Line)
+	})
+	t.Run("connection error recovery", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki_fake.NewClient(func() {})
+
+		collector, err := NewSchemaTable(SchemaTableArguments{
+			DB:              db,
+			InstanceKey:     "mysql-db",
+			CollectInterval: time.Second,
+			EntryHandler:    lokiClient,
+			CacheTTL:        time.Minute,
+			Logger:          log.NewLogfmtLogger(os.Stderr),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+
+		mock.ExpectQuery(selectSchemaName).WithoutArgs().WillReturnError(fmt.Errorf("connection error"))
 
 		mock.ExpectQuery(selectSchemaName).WithoutArgs().WillReturnRows(
 			sqlmock.NewRows([]string{
@@ -79,6 +363,10 @@ func TestSchemaTable(t *testing.T) {
 		collector.Stop()
 		lokiClient.Stop()
 
+		require.Eventually(t, func() bool {
+			return collector.Stopped()
+		}, 5*time.Second, 100*time.Millisecond)
+
 		lokiEntries := lokiClient.Received()
 		for _, entry := range lokiEntries {
 			require.Equal(t, model.LabelSet{"job": database_observability.JobName}, entry.Labels)
@@ -86,190 +374,5 @@ func TestSchemaTable(t *testing.T) {
 		require.Equal(t, `level=info msg="schema detected" op="schema_detection" instance="mysql-db" schema="some_schema"`, lokiEntries[0].Line)
 		require.Equal(t, `level=info msg="table detected" op="table_detection" instance="mysql-db" schema="some_schema" table="some_table"`, lokiEntries[1].Line)
 		require.Equal(t, `level=info msg="create table" op="create_statement" instance="mysql-db" schema="some_schema" table="some_table" create_statement="CREATE TABLE some_table (id INT)"`, lokiEntries[2].Line)
-
-		err = mock.ExpectationsWereMet()
-		require.NoError(t, err)
-	})
-	t.Run("detect view schema", func(t *testing.T) {
-		// The goroutine which deletes expired entries runs indefinitely,
-		// see https://github.com/hashicorp/golang-lru/blob/v2.0.7/expirable/expirable_lru.go#L79-L80
-		defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"))
-
-		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
-		require.NoError(t, err)
-		defer db.Close()
-
-		lokiClient := loki_fake.NewClient(func() {})
-
-		collector, err := NewSchemaTable(SchemaTableArguments{
-			DB:              db,
-			InstanceKey:     "mysql-db",
-			CollectInterval: time.Second,
-			EntryHandler:    lokiClient,
-			CacheTTL:        time.Minute,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
-		})
-
-		require.NoError(t, err)
-		require.NotNil(t, collector)
-
-		mock.ExpectQuery(selectSchemaName).WithoutArgs().WillReturnRows(
-			sqlmock.NewRows([]string{
-				"schema_name",
-			}).AddRow(
-				"some_schema",
-			),
-		)
-		mock.ExpectQuery(selectTableName).WithArgs("some_schema").WillReturnRows(
-			sqlmock.NewRows([]string{
-				"table_name",
-				"table_type",
-				"create_time",
-				"update_time",
-			}).AddRow(
-				"some_table",
-				"VIEW",
-				time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
-				time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC),
-			),
-		)
-		mock.ExpectQuery("SHOW CREATE TABLE some_schema.some_table").WithoutArgs().WillReturnRows(
-			sqlmock.NewRows([]string{
-				"table_name",
-				"create_statement",
-				"character_set_client",
-				"collation_connection",
-			}).AddRow(
-				"some_schema.some_table",
-				"CREATE VIEW some_view (id INT)",
-				"some_charset",
-				"some_charset_connection",
-			),
-		)
-
-		err = collector.Start(context.Background())
-		require.NoError(t, err)
-
-		require.Eventually(t, func() bool {
-			return len(lokiClient.Received()) == 3
-		}, 5*time.Second, 100*time.Millisecond)
-
-		collector.Stop()
-		lokiClient.Stop()
-
-		lokiEntries := lokiClient.Received()
-		for _, entry := range lokiEntries {
-			require.Equal(t, model.LabelSet{"job": database_observability.JobName}, entry.Labels)
-		}
-		require.Equal(t, `level=info msg="schema detected" op="schema_detection" instance="mysql-db" schema="some_schema"`, lokiEntries[0].Line)
-		require.Equal(t, `level=info msg="table detected" op="table_detection" instance="mysql-db" schema="some_schema" table="some_table"`, lokiEntries[1].Line)
-		require.Equal(t, `level=info msg="create table" op="create_statement" instance="mysql-db" schema="some_schema" table="some_table" create_statement="CREATE VIEW some_view (id INT)"`, lokiEntries[2].Line)
-
-		err = mock.ExpectationsWereMet()
-		require.NoError(t, err)
-	})
-	t.Run("schemas result set iteration error", func(t *testing.T) {
-		// The goroutine which deletes expired entries runs indefinitely,
-		// see https://github.com/hashicorp/golang-lru/blob/v2.0.7/expirable/expirable_lru.go#L79-L80
-		defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"))
-
-		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
-		require.NoError(t, err)
-		defer db.Close()
-
-		lokiClient := loki_fake.NewClient(func() {})
-
-		collector, err := NewSchemaTable(SchemaTableArguments{
-			DB:              db,
-			InstanceKey:     "mysql-db",
-			CollectInterval: time.Second,
-			EntryHandler:    lokiClient,
-			CacheTTL:        time.Minute,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
-		})
-		require.NoError(t, err)
-		require.NotNil(t, collector)
-
-		mock.ExpectQuery(selectSchemaName).WithoutArgs().WillReturnRows(
-			sqlmock.NewRows(
-				[]string{"schema_name"},
-			).AddRow(
-				"some_schema",
-			).RowError(0, fmt.Errorf("rs error")))
-
-		err = collector.Start(context.Background())
-		require.NoError(t, err)
-
-		require.Eventually(t, func() bool {
-			return collector.Stopped()
-		}, 5*time.Second, 100*time.Millisecond)
-
-		collector.Stop()
-		lokiClient.Stop()
-
-		err = mock.ExpectationsWereMet()
-		require.NoError(t, err)
-	})
-	t.Run("tables result set iteration error", func(t *testing.T) {
-		// The goroutine which deletes expired entries runs indefinitely,
-		// see https://github.com/hashicorp/golang-lru/blob/v2.0.7/expirable/expirable_lru.go#L79-L80
-		defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"))
-
-		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
-		require.NoError(t, err)
-		defer db.Close()
-
-		lokiClient := loki_fake.NewClient(func() {})
-
-		collector, err := NewSchemaTable(SchemaTableArguments{
-			DB:              db,
-			InstanceKey:     "mysql-db",
-			CollectInterval: time.Second,
-			EntryHandler:    lokiClient,
-			CacheTTL:        time.Minute,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
-		})
-		require.NoError(t, err)
-		require.NotNil(t, collector)
-
-		mock.ExpectQuery(selectSchemaName).WithoutArgs().WillReturnRows(
-			sqlmock.NewRows([]string{
-				"schema_name",
-			}).AddRow(
-				"some_schema",
-			),
-		)
-		mock.ExpectQuery(selectTableName).WithArgs("some_schema").WillReturnRows(
-			sqlmock.NewRows([]string{
-				"table_name",
-				"table_type",
-				"create_time",
-				"update_time",
-			}).AddRow(
-				"some_table",
-				"BASE TABLE",
-				time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
-				time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC),
-			).RowError(0, fmt.Errorf("rs error")),
-		)
-
-		err = collector.Start(context.Background())
-		require.NoError(t, err)
-
-		require.Eventually(t, func() bool {
-			return len(lokiClient.Received()) == 1
-		}, 5*time.Second, 100*time.Millisecond)
-
-		collector.Stop()
-		lokiClient.Stop()
-
-		lokiEntries := lokiClient.Received()
-		for _, entry := range lokiEntries {
-			require.Equal(t, model.LabelSet{"job": database_observability.JobName}, entry.Labels)
-		}
-		require.Equal(t, `level=info msg="schema detected" op="schema_detection" instance="mysql-db" schema="some_schema"`, lokiEntries[0].Line)
-
-		err = mock.ExpectationsWereMet()
-		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
#### PR Description
When collectors hit an error (e.g. a connection error), they should not stop. Instead, they should log the error and continue to loop with the configured interval.

#### Which issue(s) this PR fixes
n.a.

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
