### PR TITLE
database_observability: improve parsing of show and ddl statements

### DIFF
--- a/internal/component/database_observability/mysql/collector/query_sample.go
+++ b/internal/component/database_observability/mysql/collector/query_sample.go
@@ -232,6 +232,14 @@ func (c QuerySample) tablesFromQuery(digest string, stmt sqlparser.Statement) []
 		for _, side := range []sqlparser.SelectStatement{stmt.Left, stmt.Right} {
 			parsedTables = append(parsedTables, c.tablesFromQuery(digest, side)...)
 		}
+	case *sqlparser.Show:
+		if stmt.HasOnTable() {
+			parsedTables = append(parsedTables, c.parseTableName(stmt.OnTable))
+		}
+	case *sqlparser.DDL:
+		parsedTables = append(parsedTables, c.parseTableName(stmt.Table))
+	case *sqlparser.Begin, *sqlparser.Commit, *sqlparser.Rollback, *sqlparser.Set, *sqlparser.DBDDL:
+		// ignore
 	default:
 		level.Error(c.logger).Log("msg", "unknown statement type", "digest", digest)
 	}


### PR DESCRIPTION
#### PR Description
Parse SHOW and DDL statements, and ignore a bunch of other types that don't have table names.

#### Which issue(s) this PR fixes
n.a.

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
