### PR TITLE
pyroscope: Add relabel component for modifying and filtering profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Main (unreleased)
 
 - Add the possibility to export span events as logs in `otelcol.connector.spanlogs`. (@steve-hb)
 
+- Add `pyroscope.relabel` component to modify or filter profiles using Prometheus relabeling rules. (@marcsanmi)
+
 ### Enhancements
 
 - (_Experimental_) Log instance label key in `database_observability.mysql` (@cristiangreco)

--- a/docs/sources/reference/compatibility/_index.md
+++ b/docs/sources/reference/compatibility/_index.md
@@ -392,8 +392,8 @@ The following components, grouped by namespace, _export_ Pyroscope `ProfilesRece
 <!-- START GENERATED SECTION: EXPORTERS OF Pyroscope `ProfilesReceiver` -->
 
 {{< collapse title="pyroscope" >}}
-- [pyroscope.write](../components/pyroscope/pyroscope.write)
 - [pyroscope.relabel](../components/pyroscope/pyroscope.relabel)
+- [pyroscope.write](../components/pyroscope/pyroscope.write)
 {{< /collapse >}}
 
 <!-- END GENERATED SECTION: EXPORTERS OF Pyroscope `ProfilesReceiver` -->
@@ -409,8 +409,8 @@ The following components, grouped by namespace, _consume_ Pyroscope `ProfilesRec
 - [pyroscope.ebpf](../components/pyroscope/pyroscope.ebpf)
 - [pyroscope.java](../components/pyroscope/pyroscope.java)
 - [pyroscope.receive_http](../components/pyroscope/pyroscope.receive_http)
-- [pyroscope.scrape](../components/pyroscope/pyroscope.scrape)
 - [pyroscope.relabel](../components/pyroscope/pyroscope.relabel)
+- [pyroscope.scrape](../components/pyroscope/pyroscope.scrape)
 {{< /collapse >}}
 
 <!-- END GENERATED SECTION: CONSUMERS OF Pyroscope `ProfilesReceiver` -->

--- a/docs/sources/reference/compatibility/_index.md
+++ b/docs/sources/reference/compatibility/_index.md
@@ -393,6 +393,7 @@ The following components, grouped by namespace, _export_ Pyroscope `ProfilesRece
 
 {{< collapse title="pyroscope" >}}
 - [pyroscope.write](../components/pyroscope/pyroscope.write)
+- [pyroscope.relabel](../components/pyroscope/pyroscope.relabel)
 {{< /collapse >}}
 
 <!-- END GENERATED SECTION: EXPORTERS OF Pyroscope `ProfilesReceiver` -->
@@ -409,6 +410,7 @@ The following components, grouped by namespace, _consume_ Pyroscope `ProfilesRec
 - [pyroscope.java](../components/pyroscope/pyroscope.java)
 - [pyroscope.receive_http](../components/pyroscope/pyroscope.receive_http)
 - [pyroscope.scrape](../components/pyroscope/pyroscope.scrape)
+- [pyroscope.relabel](../components/pyroscope/pyroscope.relabel)
 {{< /collapse >}}
 
 <!-- END GENERATED SECTION: CONSUMERS OF Pyroscope `ProfilesReceiver` -->

--- a/docs/sources/reference/components/pyroscope/pyroscope.relabel.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.relabel.md
@@ -6,11 +6,12 @@ description: Learn about pyroscope.relabel
 title: pyroscope.relabel
 ---
 
-# pyroscope.relabel
+# `pyroscope.relabel`
 
-The `pyroscope.relabel` component rewrites the label set of each profile passed to its receiver by applying one or more relabeling `rule`s and forwards the results to the list of receivers in the component's arguments.
+The `pyroscope.relabel` component rewrites the label set of each profile passed to its receiver by applying one or more relabeling rules and forwards the results to the list of receivers.
 
-If no rules are defined or applicable to some profiles, then those profiles are forwarded as-is to each receiver passed in the component's arguments. If no labels remain after the relabeling rules are applied, then the profile is dropped.
+If no rules are defined or applicable to some profiles, then those profiles are forwarded as-is to each receiver passed in the component's arguments. 
+The profile is dropped if no labels remain after the relabeling rules are applied.
 
 The most common use of `pyroscope.relabel` is to filter profiles or standardize the label set that is passed to one or more downstream receivers. The `rule` blocks are applied to the label set of each profile in order of their appearance in the configuration file.
 
@@ -18,7 +19,7 @@ The most common use of `pyroscope.relabel` is to filter profiles or standardize 
 
 ```alloy
 pyroscope.relabel "process" {
-    forward_to = RECEIVER_LIST
+    forward_to = <RECEIVER_LIST>
 
     rule {
         ...
@@ -30,24 +31,24 @@ pyroscope.relabel "process" {
 
 ## Arguments
 
-The following arguments are supported:
+You can use the following arguments with `pyroscope.relabel`:
 
-| Name | Type | Description | Default | Required |
-| ---- | ---- | ----------- | ------- | -------- |
-| `forward_to` | `list(pyroscope.Appendable)` | List of receivers to forward profiles to after relabeling | | yes |
-| `max_cache_size` | `number` | Maximum number of entries in the label cache | 10000 | no |
+| Name             | Type                         | Description                                               | Default | Required |
+| ---------------- | ---------------------------- | --------------------------------------------------------- | ------- | -------- |
+| `forward_to`     | `list(pyroscope.Appendable)` | List of receivers to forward profiles to after relabeling |         | yes      |
+| `max_cache_size` | `number`                     | Maximum number of entries in the label cache              | 10000   | no       |
 
 ## Blocks
 
-The following blocks are supported inside the definition of `pyroscope.relabel`:
+You can use the following blocks with `pyroscope.relabel`:
 
-Hierarchy | Name     | Description                                        | Required
-----------|----------|----------------------------------------------------|---------
-rule      | [rule][] | Relabeling rules to apply to received profile entries. | no
+|      Name      |                      Description                       | Required |
+| -------------- | ------------------------------------------------------ | -------- |
+| [`rule`][rule] | Relabeling rules to apply to received profile entries. | no       |
 
-[rule]: #rule-block
+[rule]: #rule
 
-### rule block
+### rule
 
 {{< docs/shared lookup="reference/components/rule-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
@@ -55,10 +56,10 @@ rule      | [rule][] | Relabeling rules to apply to received profile entries. | 
 
 The following fields are exported and can be referenced by other components:
 
-Name | Type | Description
------|------|------------
-`receiver` | `ProfilesReceiver` | A receiver that accepts profiles for relabeling.
-`rules` | `[]relabel.Config` | The list of relabeling rules.
+| Name       | Type               | Description                                      |
+| ---------- | ------------------ | ------------------------------------------------ |
+| `receiver` | `ProfilesReceiver` | A receiver that accepts profiles for relabeling. |
+| `rules`    | `[]relabel.Config` | The list of relabeling rules.                    |
 
 ## Component health
 
@@ -66,12 +67,12 @@ Name | Type | Description
 
 ## Debug metrics
 
+* `pyroscope_relabel_cache_hits` (counter): Total number of cache hits.
+* `pyroscope_relabel_cache_misses` (counter): Total number of cache misses.
+* `pyroscope_relabel_cache_size` (gauge): Total size of relabel cache.
 * `pyroscope_relabel_profiles_dropped` (counter): Total number of profiles dropped by relabeling rules.
 * `pyroscope_relabel_profiles_processed` (counter): Total number of profiles processed.
 * `pyroscope_relabel_profiles_written` (counter): Total number of profiles forwarded.
-* `pyroscope_relabel_cache_misses` (counter): Total number of cache misses.
-* `pyroscope_relabel_cache_hits` (counter): Total number of cache hits.
-* `pyroscope_relabel_cache_size` (gauge): Total size of relabel cache.
 
 ## Example
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.relabel.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.relabel.md
@@ -1,0 +1,114 @@
+---
+canonical: https://grafana.com/docs/alloy/latest/reference/components/pyroscope/pyroscope.relabel/
+aliases:
+  - ../pyroscope.relabel/ # /docs/alloy/latest/reference/components/pyroscope.relabel/
+description: Learn about pyroscope.relabel
+title: pyroscope.relabel
+---
+
+# pyroscope.relabel
+
+The `pyroscope.relabel` component rewrites the label set of each profile passed to its receiver by applying one or more relabeling `rule`s and forwards the results to the list of receivers in the component's arguments.
+
+If no rules are defined or applicable to some profiles, then those profiles are forwarded as-is to each receiver passed in the component's arguments. If no labels remain after the relabeling rules are applied, then the profile is dropped.
+
+The most common use of `pyroscope.relabel` is to filter profiles or standardize the label set that is passed to one or more downstream receivers. The `rule` blocks are applied to the label set of each profile in order of their appearance in the configuration file.
+
+## Usage
+
+```alloy
+pyroscope.relabel "process" {
+    forward_to = RECEIVER_LIST
+
+    rule {
+        ...
+    }
+
+    ...
+}
+```
+
+## Arguments
+
+The following arguments are supported:
+
+| Name | Type | Description | Default | Required |
+| ---- | ---- | ----------- | ------- | -------- |
+| `forward_to` | `list(pyroscope.Appendable)` | List of receivers to forward profiles to after relabeling | | yes |
+| `max_cache_size` | `number` | Maximum number of entries in the label cache | 10000 | no |
+
+## Blocks
+
+The following blocks are supported inside the definition of `pyroscope.relabel`:
+
+Hierarchy | Name     | Description                                        | Required
+----------|----------|----------------------------------------------------|---------
+rule      | [rule][] | Relabeling rules to apply to received log entries. | no
+
+[rule]: #rule-block
+
+### rule block
+
+{{< docs/shared lookup="reference/components/rule-block-logs.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+## Exported fields
+
+The following fields are exported and can be referenced by other components:
+
+Name | Type | Description
+-----|------|------------
+`receiver` | `ProfilesReceiver` | A receiver that accepts profiles for relabeling.
+`rules` | `[]relabel.Config` | The list of relabeling rules.
+
+## Component health
+
+`pyroscope.relabel` is reported as unhealthy if it is given an invalid configuration.
+
+## Debug metrics
+
+* `pyroscope_relabel_profiles_dropped` (counter): Total number of profiles dropped by relabeling rules.
+* `pyroscope_relabel_profiles_processed` (counter): Total number of profiles processed.
+* `pyroscope_relabel_profiles_written` (counter): Total number of profiles forwarded.
+* `pyroscope_relabel_cache_misses` (counter): Total number of cache misses.
+* `pyroscope_relabel_cache_hits` (counter): Total number of cache hits.
+* `pyroscope_relabel_cache_size` (gauge): Total size of relabel cache.
+
+## Example
+
+```alloy
+pyroscope.relabel "process" {
+    forward_to = [pyroscope.write.backend.receiver]
+
+    # Rules are applied in order
+    rule {
+        source_labels = ["env"]
+        target_label = "environment"
+        action = "replace"
+        regex = "(.)"
+        replacement = "$1"
+    }
+
+    rule {
+        action = "labeldrop"
+        regex = "env"
+    }
+}
+```
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+## Compatible components
+
+`pyroscope.relabel` can accept arguments from the following components:
+
+- Components that export [Pyroscope `ProfilesReceiver`](../../../compatibility/#pyroscope-profilesreceiver-exporters)
+
+`pyroscope.relabel` has exports that can be consumed by the following components:
+
+- Components that consume [Pyroscope `ProfilesReceiver`](../../../compatibility/#pyroscope-profilesreceiver-consumers)
+
+{{< admonition type="note" >}}
+Connecting some components may not be sensible or components may require further configuration to make the connection work correctly.
+Refer to the linked documentation for more details.
+{{< /admonition >}}
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/reference/components/pyroscope/pyroscope.relabel.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.relabel.md
@@ -79,18 +79,22 @@ Name | Type | Description
 pyroscope.relabel "process" {
     forward_to = [pyroscope.write.backend.receiver]
 
-    # Rules are applied in order
+    // This creates a consistent hash value (0 or 1) for each unique combination of labels
+    // Using multiple source labels provides better sampling distribution across your profiles
     rule {
         source_labels = ["env"]
-        target_label = "environment"
-        action = "replace"
-        regex = "(.)"
-        replacement = "$1"
+        target_label = "__tmp_hash"
+        action = "hashmod"
+        modulus = 2
     }
 
+    // This effectively samples ~50% of profile series
+    // The same combination of source label values will always hash to the same number,
+    // ensuring consistent sampling
     rule {
-        action = "labeldrop"
-        regex = "env"
+        source_labels = ["__tmp_hash"]
+        action       = "drop"
+        regex        = "^1$"
     }
 }
 ```

--- a/docs/sources/reference/components/pyroscope/pyroscope.relabel.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.relabel.md
@@ -96,6 +96,7 @@ pyroscope.relabel "process" {
 ```
 
 <!-- START GENERATED COMPATIBLE COMPONENTS -->
+
 ## Compatible components
 
 `pyroscope.relabel` can accept arguments from the following components:

--- a/docs/sources/reference/components/pyroscope/pyroscope.relabel.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.relabel.md
@@ -6,6 +6,8 @@ description: Learn about pyroscope.relabel
 title: pyroscope.relabel
 ---
 
+<span class="badge docs-labels__stage docs-labels__item">Public preview</span>
+
 # `pyroscope.relabel`
 
 The `pyroscope.relabel` component rewrites the label set of each profile passed to its receiver by applying one or more relabeling rules and forwards the results to the list of receivers.
@@ -18,7 +20,7 @@ The most common use of `pyroscope.relabel` is to filter profiles or standardize 
 ## Usage
 
 ```alloy
-pyroscope.relabel "process" {
+pyroscope.relabel "LABEL" {
     forward_to = <RECEIVER_LIST>
 
     rule {
@@ -77,8 +79,17 @@ The following fields are exported and can be referenced by other components:
 ## Example
 
 ```alloy
-pyroscope.relabel "process" {
-    forward_to = [pyroscope.write.backend.receiver]
+pyroscope.receive_http "default" {
+    forward_to = [pyroscope.relabel.filter_profiles.receiver]
+
+    http {
+        listen_address = "0.0.0.0"
+        listen_port = 9999
+    }
+}
+
+pyroscope.relabel "filter_profiles" {
+    forward_to = [pyroscope.write.staging.receiver]
 
     // This creates a consistent hash value (0 or 1) for each unique combination of labels
     // Using multiple source labels provides better sampling distribution across your profiles
@@ -97,6 +108,12 @@ pyroscope.relabel "process" {
         action       = "drop"
         regex        = "^1$"
     }
+}
+
+pyroscope.write "staging" {
+  endpoint {
+    url = "http://pyroscope-staging:4040"
+  }
 }
 ```
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.relabel.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.relabel.md
@@ -43,13 +43,13 @@ The following blocks are supported inside the definition of `pyroscope.relabel`:
 
 Hierarchy | Name     | Description                                        | Required
 ----------|----------|----------------------------------------------------|---------
-rule      | [rule][] | Relabeling rules to apply to received log entries. | no
+rule      | [rule][] | Relabeling rules to apply to received profile entries. | no
 
 [rule]: #rule-block
 
 ### rule block
 
-{{< docs/shared lookup="reference/components/rule-block-logs.md" source="alloy" version="<ALLOY_VERSION>" >}}
+{{< docs/shared lookup="reference/components/rule-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ## Exported fields
 

--- a/internal/component/all/all.go
+++ b/internal/component/all/all.go
@@ -146,6 +146,7 @@ import (
 	_ "github.com/grafana/alloy/internal/component/pyroscope/ebpf"                           // Import pyroscope.ebpf
 	_ "github.com/grafana/alloy/internal/component/pyroscope/java"                           // Import pyroscope.java
 	_ "github.com/grafana/alloy/internal/component/pyroscope/receive_http"                   // Import pyroscope.receive_http
+	_ "github.com/grafana/alloy/internal/component/pyroscope/relabel"                        // Import pyroscope.relabel
 	_ "github.com/grafana/alloy/internal/component/pyroscope/scrape"                         // Import pyroscope.scrape
 	_ "github.com/grafana/alloy/internal/component/pyroscope/write"                          // Import pyroscope.write
 	_ "github.com/grafana/alloy/internal/component/remote/http"                              // Import remote.http

--- a/internal/component/pyroscope/appender.go
+++ b/internal/component/pyroscope/appender.go
@@ -37,6 +37,7 @@ type IncomingProfile struct {
 	Body    io.ReadCloser
 	Headers http.Header
 	URL     *url.URL
+	Labels  labels.Labels
 }
 
 var _ Appendable = (*Fanout)(nil)

--- a/internal/component/pyroscope/receive_http/receive_http_test.go
+++ b/internal/component/pyroscope/receive_http/receive_http_test.go
@@ -25,6 +25,7 @@ import (
 	pushv1 "github.com/grafana/pyroscope/api/gen/proto/go/push/v1"
 	"github.com/grafana/pyroscope/api/gen/proto/go/push/v1/pushv1connect"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+	"github.com/grafana/pyroscope/api/model/labelset"
 )
 
 // TestForwardsProfilesIngest verifies the behavior of the
@@ -44,13 +45,14 @@ func TestForwardsProfilesIngest(t *testing.T) {
 		appendableErrors []error
 		expectedStatus   int
 		expectedForwards int
+		expectedLabels   map[string]string
 	}{
 		{
 			name:             "Small profile",
 			profileSize:      1024, // 1KB
 			method:           "POST",
 			path:             "/ingest",
-			queryParams:      "name=test_app_1&from=1234567890&until=1234567900",
+			queryParams:      "name=test_app&from=1234567890&until=1234567900",
 			headers:          map[string]string{"Content-Type": "application/octet-stream"},
 			appendableErrors: []error{nil, nil},
 			expectedStatus:   http.StatusOK,
@@ -61,7 +63,7 @@ func TestForwardsProfilesIngest(t *testing.T) {
 			profileSize:      1024 * 1024, // 1MB
 			method:           "POST",
 			path:             "/ingest",
-			queryParams:      "name=test_app_2&from=1234567891&until=1234567901&custom=param1",
+			queryParams:      "name=test_app&from=1234567891&until=1234567901&custom=param1",
 			headers:          map[string]string{"X-Scope-OrgID": "1234"},
 			appendableErrors: []error{nil},
 			expectedStatus:   http.StatusOK,
@@ -72,7 +74,7 @@ func TestForwardsProfilesIngest(t *testing.T) {
 			profileSize:      1024,
 			method:           "GET",
 			path:             "/ingest",
-			queryParams:      "name=test_app_3&from=1234567892&until=1234567902",
+			queryParams:      "name=test_app&from=1234567892&until=1234567902",
 			headers:          map[string]string{},
 			appendableErrors: []error{nil, nil},
 			expectedStatus:   http.StatusMethodNotAllowed,
@@ -94,7 +96,7 @@ func TestForwardsProfilesIngest(t *testing.T) {
 			profileSize:      1024,
 			method:           "POST",
 			path:             "/invalid",
-			queryParams:      "name=test_app_4&from=1234567893&until=1234567903",
+			queryParams:      "name=test_app&from=1234567893&until=1234567903",
 			headers:          map[string]string{"Content-Type": "application/octet-stream"},
 			appendableErrors: []error{nil, nil},
 			expectedStatus:   http.StatusNotFound,
@@ -105,7 +107,7 @@ func TestForwardsProfilesIngest(t *testing.T) {
 			profileSize:      2048,
 			method:           "POST",
 			path:             "/ingest",
-			queryParams:      "name=test_app_5&from=1234567894&until=1234567904&scenario=all_fail",
+			queryParams:      "name=test_app&from=1234567894&until=1234567904&scenario=all_fail",
 			headers:          map[string]string{"Content-Type": "application/octet-stream", "X-Test": "fail-all"},
 			appendableErrors: []error{fmt.Errorf("error1"), fmt.Errorf("error2")},
 			expectedStatus:   http.StatusInternalServerError,
@@ -116,11 +118,41 @@ func TestForwardsProfilesIngest(t *testing.T) {
 			profileSize:      4096,
 			method:           "POST",
 			path:             "/ingest",
-			queryParams:      "name=test_app_6&from=1234567895&until=1234567905&scenario=partial_failure",
+			queryParams:      "name=test_app&from=1234567895&until=1234567905&scenario=partial_failure",
 			headers:          map[string]string{"X-Custom-ID": "test-6"},
 			appendableErrors: []error{fmt.Errorf("error"), nil},
 			expectedStatus:   http.StatusInternalServerError,
 			expectedForwards: 2,
+		},
+		{
+			name:             "Valid labels are parsed and forwarded",
+			profileSize:      1024,
+			method:           "POST",
+			path:             "/ingest",
+			queryParams:      "name=test.app{env=prod,region=us-east}",
+			headers:          map[string]string{"Content-Type": "application/octet-stream"},
+			appendableErrors: []error{nil, nil},
+			expectedStatus:   http.StatusOK,
+			expectedForwards: 2,
+			expectedLabels: map[string]string{
+				"__name__": "test.app",
+				"env":      "prod",
+				"region":   "us-east",
+			},
+		},
+		{
+			name:             "Invalid labels still forward profile",
+			profileSize:      1024,
+			method:           "POST",
+			path:             "/ingest",
+			queryParams:      "name=test.app{invalid-label-syntax}",
+			headers:          map[string]string{"Content-Type": "application/octet-stream"},
+			appendableErrors: []error{nil, nil},
+			expectedStatus:   http.StatusOK,
+			expectedForwards: 2,
+			expectedLabels: map[string]string{
+				"__name__": "test.app", // Only __name__ is preserved
+			},
 		},
 	}
 
@@ -136,7 +168,7 @@ func TestForwardsProfilesIngest(t *testing.T) {
 			require.Equal(t, tt.expectedForwards, forwardedCount, "Unexpected number of forwards")
 
 			if tt.expectedForwards > 0 {
-				verifyForwardedProfiles(t, appendables, testProfile, tt.headers, tt.queryParams)
+				verifyForwardedProfiles(t, appendables, testProfile, tt.headers, tt.queryParams, tt.expectedLabels)
 			}
 		})
 	}
@@ -296,10 +328,25 @@ func verifyForwardedProfiles(
 	expectedProfile []byte,
 	expectedHeaders map[string]string,
 	expectedQueryParams string,
+	expectedLabels map[string]string,
 ) {
 	for i, app := range appendables {
 		testApp, ok := app.(*testAppender)
 		require.True(t, ok, "Appendable is not a testAppender")
+
+		// Verify labels if name parameter exists and is valid
+		if nameParam := testApp.lastProfile.URL.Query().Get("name"); nameParam != "" {
+			ls, err := labelset.Parse(nameParam)
+			if err == nil {
+				require.Equal(t, ls.Labels(), testApp.lastProfile.Labels.Map(),
+					"Labels mismatch for appendable %d", i)
+			}
+		}
+
+		if expectedLabels != nil {
+			require.Equal(t, expectedLabels, testApp.lastProfile.Labels.Map(),
+				"Labels mismatch for appendable %d", i)
+		}
 
 		if testApp.lastProfile != nil {
 			// Verify profile body
@@ -446,6 +493,7 @@ func (a *testAppender) AppendIngest(_ context.Context, profile *pyroscope.Incomi
 		Body:    io.NopCloser(&buf),
 		Headers: profile.Headers,
 		URL:     profile.URL,
+		Labels:  profile.Labels,
 	}
 	a.lastProfile = newProfile
 

--- a/internal/component/pyroscope/relabel/metrics.go
+++ b/internal/component/pyroscope/relabel/metrics.go
@@ -1,0 +1,52 @@
+package relabel
+
+import "github.com/prometheus/client_golang/prometheus"
+
+type metrics struct {
+	profilesProcessed prometheus.Counter
+	profilesOutgoing  prometheus.Counter
+	profilesDropped   prometheus.Counter
+	cacheHits         prometheus.Counter
+	cacheMisses       prometheus.Counter
+	cacheSize         prometheus.Gauge
+}
+
+func newMetrics(reg prometheus.Registerer) *metrics {
+	m := &metrics{
+		profilesProcessed: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "pyroscope_relabel_profiles_processed",
+			Help: "Total number of profiles processed",
+		}),
+		profilesOutgoing: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "pyroscope_relabel_profiles_written",
+			Help: "Total number of profiles forwarded",
+		}),
+		profilesDropped: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "pyroscope_relabel_profiles_dropped",
+			Help: "Total number of profiles dropped by relabeling rules",
+		}),
+		cacheHits: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "pyroscope_relabel_cache_hits",
+			Help: "Total number of cache hits",
+		}),
+		cacheMisses: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "pyroscope_relabel_cache_misses",
+			Help: "Total number of cache misses",
+		}),
+		cacheSize: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "pyroscope_relabel_cache_size",
+			Help: "Total size of relabel cache",
+		}),
+	}
+
+	reg.MustRegister(
+		m.profilesProcessed,
+		m.profilesOutgoing,
+		m.profilesDropped,
+		m.cacheHits,
+		m.cacheMisses,
+		m.cacheSize,
+	)
+
+	return m
+}

--- a/internal/component/pyroscope/relabel/relabel.go
+++ b/internal/component/pyroscope/relabel/relabel.go
@@ -1,0 +1,337 @@
+// Package relabel provides label manipulation for Pyroscope profiles.
+//
+// Label Handling:
+// The component handles two types of label representations:
+// - labels.Labels ([]Label): Used by Pyroscope and relabeling logic
+// - model.LabelSet (map[string]string): Used for efficient fingerprinting and cache lookups
+//
+// Cache Implementation:
+// The cache uses model.LabelSet's fingerprinting to store label sets efficiently.
+// Each cache entry contains both the original and relabeled labels to handle collisions
+// and avoid recomputing relabeling rules.
+package relabel
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"sync"
+	"sync/atomic"
+
+	"github.com/grafana/alloy/internal/component"
+	alloy_relabel "github.com/grafana/alloy/internal/component/common/relabel"
+	"github.com/grafana/alloy/internal/component/pyroscope"
+	"github.com/grafana/alloy/internal/featuregate"
+	"github.com/grafana/alloy/internal/runtime/logging/level"
+	"github.com/grafana/pyroscope/api/model/labelset"
+
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/relabel"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:      "pyroscope.relabel",
+		Stability: featuregate.StabilityPublicPreview,
+		Args:      Arguments{},
+		Exports:   Exports{},
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			return New(opts, args.(Arguments))
+		},
+	})
+}
+
+type Arguments struct {
+	// Where the relabeled metrics should be forwarded to.
+	ForwardTo []pyroscope.Appendable `alloy:"forward_to,attr"`
+	// The relabelling rules to apply to each log entry before it's forwarded.
+	RelabelConfigs []*alloy_relabel.Config `alloy:"rule,block,optional"`
+	// The maximum number of items to hold in the component's LRU cache.
+	MaxCacheSize int `alloy:"max_cache_size,attr,optional"`
+}
+
+// DefaultArguments provides the default arguments for the pyroscope.relabel
+// component.
+var DefaultArguments = Arguments{
+	MaxCacheSize: 10_000,
+}
+
+// SetToDefault implements syntax.Defaulter.
+func (a *Arguments) SetToDefault() {
+	*a = DefaultArguments
+}
+
+// Exports holds values which are exported by the pyroscope.relabel component.
+type Exports struct {
+	Receiver pyroscope.Appendable `alloy:"receiver,attr"`
+	Rules    alloy_relabel.Rules  `alloy:"rules,attr"`
+}
+
+// Component implements the pyroscope.relabel component.
+type Component struct {
+	opts         component.Options
+	metrics      *metrics
+	mut          sync.RWMutex
+	rcs          []*relabel.Config
+	fanout       *pyroscope.Fanout
+	cache        *lru.Cache
+	maxCacheSize int
+	exited       atomic.Bool
+}
+
+var (
+	_ component.Component = (*Component)(nil)
+)
+
+// New creates a new pyroscope.relabel component.
+func New(o component.Options, args Arguments) (*Component, error) {
+	cache, err := lru.New(args.MaxCacheSize)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &Component{
+		opts:         o,
+		metrics:      newMetrics(o.Registerer),
+		cache:        cache,
+		maxCacheSize: args.MaxCacheSize,
+	}
+
+	c.fanout = pyroscope.NewFanout(args.ForwardTo, o.ID, o.Registerer)
+
+	o.OnStateChange(Exports{
+		Receiver: c,
+		Rules:    args.RelabelConfigs,
+	})
+
+	if err := c.Update(args); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+func (c *Component) Run(ctx context.Context) error {
+	defer c.exited.Store(true)
+	<-ctx.Done()
+	return nil
+}
+
+func (c *Component) Update(args component.Arguments) error {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	newArgs := args.(Arguments)
+	newRCS := alloy_relabel.ComponentToPromRelabelConfigs(newArgs.RelabelConfigs)
+
+	// If relabeling rules changed, purge the cache
+	if relabelingChanged(c.rcs, newRCS) {
+		level.Debug(c.opts.Logger).Log("msg", "received new relabel configs, purging cache")
+		c.cache.Purge()
+		c.metrics.cacheSize.Set(0)
+	}
+
+	if newArgs.MaxCacheSize != c.maxCacheSize {
+		evicted := c.cache.Resize(newArgs.MaxCacheSize)
+		if evicted > 0 {
+			level.Debug(c.opts.Logger).Log("msg", "resizing cache led to evicting items", "evicted_count", evicted)
+		}
+		c.maxCacheSize = newArgs.MaxCacheSize
+	}
+
+	c.rcs = newRCS
+	c.fanout.UpdateChildren(newArgs.ForwardTo)
+
+	c.opts.OnStateChange(Exports{
+		Receiver: c,
+		Rules:    newArgs.RelabelConfigs,
+	})
+
+	return nil
+}
+
+type ProfileDroppedError struct{}
+
+func (e *ProfileDroppedError) Error() string {
+	return "profile dropped by relabel rules"
+}
+
+func (c *Component) Append(ctx context.Context, lbls labels.Labels, samples []*pyroscope.RawSample) error {
+	if c.exited.Load() {
+		return fmt.Errorf("%s has exited", c.opts.ID)
+	}
+
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+
+	newLabels, keep, err := c.relabel(lbls)
+	if err != nil {
+		return err
+	}
+	if !keep {
+		return &ProfileDroppedError{}
+	}
+
+	return c.fanout.Appender().Append(ctx, newLabels, samples)
+}
+
+func (c *Component) AppendIngest(ctx context.Context, profile *pyroscope.IncomingProfile) error {
+	if c.exited.Load() {
+		return fmt.Errorf("%s has exited", c.opts.ID)
+	}
+
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+
+	lbls, err := extractLabelsFromIncomingProfile(profile)
+	if err != nil {
+		return err
+	}
+	if lbls.IsEmpty() {
+		return c.fanout.Appender().AppendIngest(ctx, profile)
+	}
+
+	newLabels, keep, err := c.relabel(lbls)
+	if err != nil {
+		return fmt.Errorf("processing labels: %w", err)
+	}
+	if !keep {
+		c.metrics.profilesDropped.Inc()
+		return &ProfileDroppedError{}
+	}
+
+	updateProfileLabels(profile, newLabels)
+	return c.fanout.Appender().AppendIngest(ctx, profile)
+}
+
+func (c *Component) Appender() pyroscope.Appender {
+	return c
+}
+
+type cacheItem struct {
+	original  model.LabelSet
+	relabeled model.LabelSet
+}
+
+// relabel applies the configured relabeling rules to the input labels
+// Returns the new labels, whether to keep the profile, and any error
+func (c *Component) relabel(lbls labels.Labels) (labels.Labels, bool, error) {
+	labelSet := toModelLabelSet(lbls)
+	hash := labelSet.Fingerprint()
+
+	// Check cache
+	if result, keep, found := c.getCacheEntry(hash, labelSet); found {
+		return result, keep, nil
+	}
+
+	// Apply relabeling
+	newLabels, keep := relabel.Process(lbls, c.rcs...)
+	if !keep {
+		c.metrics.profilesDropped.Inc()
+		return labels.Labels{}, false, nil
+	}
+
+	// Cache result
+	c.addToCache(hash, labelSet, newLabels)
+
+	return newLabels, true, nil
+}
+
+func (c *Component) getCacheEntry(hash model.Fingerprint, labelSet model.LabelSet) (labels.Labels, bool, bool) {
+	if val, ok := c.cache.Get(hash); ok {
+		for _, item := range val.([]cacheItem) {
+			if labelSet.Equal(item.original) {
+				c.metrics.cacheHits.Inc()
+				if len(item.relabeled) == 0 {
+					c.metrics.profilesDropped.Inc()
+					return labels.Labels{}, false, true
+				}
+				return toLabelsLabels(item.relabeled), true, true
+			}
+		}
+	}
+	c.metrics.cacheMisses.Inc()
+	return labels.Labels{}, false, false
+}
+
+func (c *Component) addToCache(hash model.Fingerprint, original model.LabelSet, relabeled labels.Labels) {
+	var cacheValue []cacheItem
+	if val, exists := c.cache.Get(hash); exists {
+		cacheValue = val.([]cacheItem)
+	}
+	cacheValue = append(cacheValue, cacheItem{
+		original:  original,
+		relabeled: toModelLabelSet(relabeled),
+	})
+	c.cache.Add(hash, cacheValue)
+}
+
+// extractLabelsFromIncomingProfile converts profile labels to Prometheus labels
+func extractLabelsFromIncomingProfile(profile *pyroscope.IncomingProfile) (labels.Labels, error) {
+	nameParam := profile.URL.Query().Get("name")
+	if nameParam == "" {
+		return labels.Labels{}, nil
+	}
+
+	ls, err := labelset.Parse(nameParam)
+	if err != nil {
+		return labels.Labels{}, fmt.Errorf("parsing labels from name parameter: %w", err)
+	}
+
+	var lbls []labels.Label
+	for k, v := range ls.Labels() {
+		lbls = append(lbls, labels.Label{Name: k, Value: v})
+	}
+	return labels.New(lbls...), nil
+}
+
+// updateProfileLabels converts Prometheus labels back to pyroscope format
+func updateProfileLabels(profile *pyroscope.IncomingProfile, lbls labels.Labels) {
+	newLS := labelset.New(make(map[string]string))
+	for _, l := range lbls {
+		newLS.Add(l.Name, l.Value)
+	}
+
+	query := profile.URL.Query()
+	query.Set("name", newLS.Normalized())
+	profile.URL.RawQuery = query.Encode()
+}
+
+// Helper function to detect relabel config changes
+func relabelingChanged(prev, next []*relabel.Config) bool {
+	if len(prev) != len(next) {
+		return true
+	}
+	for i := range prev {
+		if !reflect.DeepEqual(prev[i], next[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+// toModelLabelSet converts labels.Labels to model.LabelSet
+func toModelLabelSet(lbls labels.Labels) model.LabelSet {
+	labelSet := make(model.LabelSet, lbls.Len())
+	lbls.Range(func(l labels.Label) {
+		labelSet[model.LabelName(l.Name)] = model.LabelValue(l.Value)
+	})
+	return labelSet
+}
+
+// toLabelsLabels converts model.LabelSet to labels.Labels
+func toLabelsLabels(ls model.LabelSet) labels.Labels {
+	result := make(labels.Labels, 0, len(ls))
+	for name, value := range ls {
+		result = append(result, labels.Label{
+			Name:  string(name),
+			Value: string(value),
+		})
+	}
+	// Labels need to be sorted
+	sort.Sort(result)
+	return result
+}

--- a/internal/component/pyroscope/relabel/relabel_test.go
+++ b/internal/component/pyroscope/relabel/relabel_test.go
@@ -1,0 +1,371 @@
+package relabel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"sync"
+	"testing"
+
+	"github.com/grafana/alloy/internal/component"
+	alloy_relabel "github.com/grafana/alloy/internal/component/common/relabel"
+	"github.com/grafana/alloy/internal/component/pyroscope"
+	"github.com/grafana/alloy/internal/runtime/componenttest"
+	"github.com/grafana/alloy/internal/util"
+	"github.com/grafana/pyroscope/api/model/labelset"
+	"github.com/grafana/regexp"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRelabeling(t *testing.T) {
+	tests := []struct {
+		name        string
+		rules       []*alloy_relabel.Config
+		inputName   string
+		wantName    string
+		wantDropped bool
+	}{
+		{
+			name: "basic profile without labels",
+			rules: []*alloy_relabel.Config{
+				{
+					SourceLabels: []string{"foo"},
+					TargetLabel:  "bar",
+					Action:       "replace",
+					Regex:        alloy_relabel.Regexp{Regexp: regexp.MustCompile("(.+)")},
+					Replacement:  "$1",
+				},
+			},
+			inputName:   "app.cpu{}",
+			wantName:    "app.cpu{}",
+			wantDropped: false,
+		},
+		{
+			name: "rename label",
+			rules: []*alloy_relabel.Config{
+				{
+					SourceLabels: []string{"foo"},
+					TargetLabel:  "bar",
+					Action:       "replace",
+					Regex:        alloy_relabel.Regexp{Regexp: regexp.MustCompile("(.+)")},
+					Replacement:  "$1",
+				},
+				{
+					Action: "labeldrop",
+					Regex:  alloy_relabel.Regexp{Regexp: regexp.MustCompile("foo")},
+				},
+			},
+			inputName:   "app.cpu{foo=hello}",
+			wantName:    "app.cpu{bar=hello}",
+			wantDropped: false,
+		},
+		{
+			name: "drop profile with matching drop label",
+			rules: []*alloy_relabel.Config{{
+				SourceLabels: []string{"env"},
+				Action:       "drop",
+				Regex:        alloy_relabel.Regexp{Regexp: regexp.MustCompile("dev")},
+			}},
+			inputName:   "app.cpu{env=dev,region=us-1}",
+			wantDropped: true,
+		},
+		{
+			name: "keep profile with matching label",
+			rules: []*alloy_relabel.Config{{
+				SourceLabels: []string{"env"},
+				Action:       "keep",
+				Regex:        alloy_relabel.Regexp{Regexp: regexp.MustCompile("prod")},
+			}},
+			inputName:   "app.cpu{env=prod,region=us-1}",
+			wantName:    "app.cpu{env=prod,region=us-1}",
+			wantDropped: false,
+		},
+		{
+			name: "drop profile not matching keep",
+			rules: []*alloy_relabel.Config{{
+				SourceLabels: []string{"env"},
+				Action:       "keep",
+				Regex:        alloy_relabel.Regexp{Regexp: regexp.MustCompile("prod")},
+			}},
+			inputName:   "app.cpu{env=dev,region=us-1}",
+			wantDropped: true,
+		},
+		{
+			name: "drop __name__ label should affect profile name",
+			rules: []*alloy_relabel.Config{
+				{
+					Action: "labeldrop",
+					Regex:  alloy_relabel.Regexp{Regexp: regexp.MustCompile("__name__")},
+				},
+			},
+			inputName:   "app.cpu{env=prod}",
+			wantName:    "{env=prod}",
+			wantDropped: false,
+		},
+		{
+			name: "drop all labels preserves profile name",
+			rules: []*alloy_relabel.Config{
+				{
+					Action: "labeldrop",
+					Regex:  alloy_relabel.Regexp{Regexp: regexp.MustCompile("env|region")},
+				},
+			},
+			inputName:   "app.cpu{env=prod,region=us-1}",
+			wantName:    "app.cpu{}",
+			wantDropped: false,
+		},
+		{
+			name: "keep profile with no labels when using drop action",
+			rules: []*alloy_relabel.Config{
+				{
+					SourceLabels: []string{"env"},
+					Action:       "drop",
+					Regex:        alloy_relabel.Regexp{Regexp: regexp.MustCompile("dev")},
+				},
+			},
+			inputName:   "app.cpu",
+			wantName:    "app.cpu{}",
+			wantDropped: false,
+		},
+		{
+			name: "drop profile with no name",
+			rules: []*alloy_relabel.Config{
+				{
+					Action: "labeldrop",
+					Regex:  alloy_relabel.Regexp{Regexp: regexp.MustCompile(".*")},
+				},
+			},
+			inputName:   "{env=prod,region=us-1}",
+			wantName:    "",
+			wantDropped: true,
+		},
+		{
+			name: "multiple rules",
+			rules: []*alloy_relabel.Config{
+				{
+					SourceLabels: []string{"env"},
+					TargetLabel:  "environment",
+					Action:       "replace",
+					Regex:        alloy_relabel.Regexp{Regexp: regexp.MustCompile("(.+)")},
+					Replacement:  "$1",
+				},
+				{
+					Action: "labeldrop",
+					Regex:  alloy_relabel.Regexp{Regexp: regexp.MustCompile("^env$")},
+				},
+				{
+					SourceLabels: []string{"region"},
+					TargetLabel:  "zone",
+					Action:       "replace",
+					Regex:        alloy_relabel.Regexp{Regexp: regexp.MustCompile("us-(.+)")},
+					Replacement:  "zone-$1",
+				},
+			},
+			inputName:   "app.cpu{env=prod,region=us-1}",
+			wantName:    "app.cpu{environment=prod,region=us-1,zone=zone-1}",
+			wantDropped: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := NewTestAppender()
+
+			tc, err := componenttest.NewControllerFromID(util.TestLogger(t), "pyroscope.relabel")
+			require.NoError(t, err)
+
+			go func() {
+				err = tc.Run(componenttest.TestContext(t), Arguments{
+					ForwardTo:      []pyroscope.Appendable{app},
+					RelabelConfigs: tt.rules,
+					MaxCacheSize:   10,
+				})
+				require.NoError(t, err)
+			}()
+
+			// Wait for the component to be ready
+			require.NoError(t, tc.WaitExports(time.Second))
+			time.Sleep(100 * time.Millisecond) // Give a little extra time for initialization
+
+			profile := &pyroscope.IncomingProfile{
+				URL: mustParseURL("http://localhost/ingest?name=" + tt.inputName),
+			}
+
+			// Get the actual component
+			comp, err := tc.GetComponent()
+			require.NoError(t, err)
+			c := comp.(*Component)
+
+			err = c.AppendIngest(context.Background(), profile)
+
+			profiles := app.Profiles()
+
+			if tt.wantDropped {
+				require.Error(t, err)
+				if errors.Is(err, labelset.ErrServiceNameIsRequired) {
+					require.Empty(t, profiles, "profile should have been dropped")
+					return
+				}
+				var dropErr *ProfileDroppedError
+				require.ErrorAs(t, err, &dropErr)
+				require.Equal(t, dropErr.Error(), err.Error())
+				require.Empty(t, profiles, "profile should have been dropped")
+				return
+			}
+
+			require.NoError(t, err)
+			require.Len(t, profiles, 1)
+			require.Equal(t, tt.wantName, profiles[0].URL.Query().Get("name"))
+		})
+	}
+}
+
+func TestCache(t *testing.T) {
+	app := NewTestAppender()
+
+	c, err := New(component.Options{
+		Logger:        util.TestAlloyLogger(t),
+		Registerer:    prometheus.NewRegistry(),
+		OnStateChange: func(e component.Exports) {},
+	}, Arguments{
+		ForwardTo: []pyroscope.Appendable{app},
+		RelabelConfigs: []*alloy_relabel.Config{{
+			SourceLabels: []string{"env"},
+			Action:       "replace",
+			TargetLabel:  "environment",
+			Regex:        alloy_relabel.Regexp{Regexp: regexp.MustCompile("(.+)")},
+			Replacement:  "staging",
+		}},
+		MaxCacheSize: 4,
+	})
+	require.NoError(t, err)
+
+	// Initial profiles
+	lsets := []labels.Labels{
+		labels.FromStrings("env", "prod"),
+		labels.FromStrings("env", "dev"),
+		labels.FromStrings("env", "test"),
+	}
+
+	// Add initial entries and verify cache state
+	for _, ls := range lsets {
+		err = c.AppendIngest(context.Background(), &pyroscope.IncomingProfile{
+			URL: mustParseURL(fmt.Sprintf("http://localhost/ingest?name=app.cpu{%s}", formatLabelsForURL(ls))),
+		})
+		require.NoError(t, err)
+	}
+	require.Equal(t, 3, c.cache.Len(), "cache should have 3 entries after initial profiles")
+
+	// Test cache hit
+	err = c.AppendIngest(context.Background(), &pyroscope.IncomingProfile{
+		URL: mustParseURL(fmt.Sprintf("http://localhost/ingest?name=app.cpu{%s}", formatLabelsForURL(lsets[0]))),
+	})
+	require.NoError(t, err)
+	require.Equal(t, 3, c.cache.Len(), "cache length should not change after cache hit")
+
+	// Test colliding entries
+	ls1 := model.LabelSet{
+		"A":        "K6sjsNNczPl",
+		"__name__": "app.cpu",
+	}
+	ls2 := model.LabelSet{
+		"A":        "cswpLMIZpwt",
+		"__name__": "app.cpu",
+	}
+	hash := ls1.Fingerprint()
+	t.Logf("Original fingerprint from ls1: %v", hash)
+	require.Equal(t, ls1.Fingerprint(), ls2.Fingerprint(), "expected labelset fingerprints to collide")
+
+	// Add colliding profiles
+	for _, ls := range []model.LabelSet{ls1, ls2} {
+		// Convert directly to labels.Labels as the component expects
+		// lbls := labels.FromStrings("A", string(ls["A"]))
+		lbls := labels.FromStrings("A", string(ls["A"]), "__name__", string(ls["__name__"]))
+
+		// Log intermediate fingerprint
+		tmpLabelSet := make(model.LabelSet, lbls.Len())
+		lbls.Range(func(l labels.Label) {
+			tmpLabelSet[model.LabelName(l.Name)] = model.LabelValue(l.Value)
+		})
+		t.Logf("Intermediate fingerprint: %v", tmpLabelSet.Fingerprint())
+
+		err = c.AppendIngest(context.Background(), &pyroscope.IncomingProfile{
+			URL: mustParseURL(fmt.Sprintf("http://localhost/ingest?name=app.cpu{%s}", formatLabelsForURL(lbls))),
+		})
+		require.NoError(t, err)
+	}
+
+	t.Logf("Final fingerprint for cache lookup: %v", hash)
+
+	t.Logf("Cache length after adding colliding profiles: %d", c.cache.Len())
+	t.Logf("Attempting to get cache key with fingerprint: %v", hash)
+	for _, k := range c.cache.Keys() {
+		t.Logf("Available cache key: %v", k)
+	}
+
+	// Verify cache state after collisions
+	require.Equal(t, 4, c.cache.Len(), "cache should have 4 entries")
+	val, ok := c.cache.Get(hash)
+	require.True(t, ok, "colliding entry should be in cache")
+	items := val.([]cacheItem)
+	require.Len(t, items, 2, "should have both colliding items under same key")
+}
+
+type TestAppender struct {
+	mu       sync.Mutex
+	profiles []*pyroscope.IncomingProfile
+}
+
+func NewTestAppender() *TestAppender {
+	return &TestAppender{
+		profiles: make([]*pyroscope.IncomingProfile, 0),
+	}
+}
+
+// Appender implements pyroscope.Appendable
+func (t *TestAppender) Appender() pyroscope.Appender {
+	return t
+}
+
+// Append implements pyroscope.Appender
+func (t *TestAppender) Append(_ context.Context, _ labels.Labels, _ []*pyroscope.RawSample) error {
+	return nil
+}
+
+// AppendIngest implements pyroscope.Appender
+func (t *TestAppender) AppendIngest(_ context.Context, profile *pyroscope.IncomingProfile) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.profiles = append(t.profiles, profile)
+	return nil
+}
+
+func (t *TestAppender) Profiles() []*pyroscope.IncomingProfile {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.profiles
+}
+
+func mustParseURL(s string) *url.URL {
+	u, err := url.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+func formatLabelsForURL(lbls labels.Labels) string {
+	var pairs []string
+	lbls.Range(func(l labels.Label) {
+		pairs = append(pairs, fmt.Sprintf("%s=%s", l.Name, l.Value))
+	})
+	return strings.Join(pairs, ",")
+}

--- a/internal/component/pyroscope/write/write.go
+++ b/internal/component/pyroscope/write/write.go
@@ -394,11 +394,14 @@ func (f *fanOutClient) AppendIngest(ctx context.Context, profile *pyroscope.Inco
 
 			// Handle labels
 			query := profile.URL.Query()
-			if nameParam := query.Get("name"); nameParam != "" {
-				ls, err := labelset.Parse(nameParam)
-				if err != nil {
-					return err
-				}
+			if !profile.Labels.IsEmpty() {
+				ls := labelset.New(make(map[string]string))
+
+				profile.Labels.Range(func(l labels.Label) {
+					ls.Add(l.Name, l.Value)
+				})
+
+				// Add external labels (which will override any existing ones)
 				for k, v := range f.config.ExternalLabels {
 					ls.Add(k, v)
 				}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR introduces a new `pyroscope.relabel` component that allows users to modify or filter profiles using Prometheus relabeling rules. This component is particularly useful for:

- Standardizing labels across different profile sources

- Filtering out unwanted profiles based on their labels

- Adding or removing labels before forwarding profiles

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
- [X] Documentation added
- [X] Tests updated
- [ ] Config converters updated
