### PR TITLE
New loki.process stage structured_metadata_regex, to move all labels matching a regex to structured metadata

### DIFF
--- a/internal/component/loki/process/stages/pipeline.go
+++ b/internal/component/loki/process/stages/pipeline.go
@@ -38,6 +38,7 @@ type StageConfig struct {
 	ReplaceConfig         *ReplaceConfig         `alloy:"replace,block,optional"`
 	StaticLabelsConfig    *StaticLabelsConfig    `alloy:"static_labels,block,optional"`
 	StructuredMetadata    *LabelsConfig          `alloy:"structured_metadata,block,optional"`
+	StructuredMetadataRegex *StructuredMetadataRegexConfig `alloy:"structured_metadata_regex,block,optional"`
 	SamplingConfig        *SamplingConfig        `alloy:"sampling,block,optional"`
 	TemplateConfig        *TemplateConfig        `alloy:"template,block,optional"`
 	TenantConfig          *TenantConfig          `alloy:"tenant,block,optional"`

--- a/internal/component/loki/process/stages/stage.go
+++ b/internal/component/loki/process/stages/stage.go
@@ -40,6 +40,7 @@ const (
 	StageTypeSampling           = "sampling"
 	StageTypeStaticLabels       = "static_labels"
 	StageTypeStructuredMetadata = "structured_metadata"
+	StageTypeStructuredMetadataRegex = "structured_metadata_regex"
 	StageTypeTemplate           = "template"
 	StageTypeTenant             = "tenant"
 	StageTypeTimestamp          = "timestamp"
@@ -155,6 +156,11 @@ func New(logger log.Logger, jobName *string, cfg StageConfig, registerer prometh
 		}
 	case cfg.StructuredMetadata != nil:
 		s, err = newStructuredMetadataStage(logger, *cfg.StructuredMetadata)
+		if err != nil {
+			return nil, err
+		}
+	case cfg.StructuredMetadataRegex != nil:
+		s, err = newStructuredMetadataRegexStage(logger, *cfg.StructuredMetadataRegex)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/component/loki/process/stages/structured_metadata_regex.go
+++ b/internal/component/loki/process/stages/structured_metadata_regex.go
@@ -1,0 +1,52 @@
+package stages
+
+import (
+	"github.com/go-kit/log"
+	"regexp"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+)
+
+type StructuredMetadataRegexConfig struct {
+	Regex string `alloy:"regex,attr"`
+}
+
+func newStructuredMetadataRegexStage(logger log.Logger, configs StructuredMetadataRegexConfig) (Stage, error) {
+
+	re, error := regexp.Compile(configs.Regex)
+
+	if error != nil {
+		return &structuredMetadataRegexStage{}, error
+	}
+
+	return &structuredMetadataRegexStage{
+		logger: logger,
+		regex:  *re,
+	}, nil
+}
+
+type structuredMetadataRegexStage struct {
+	logger log.Logger
+	regex  regexp.Regexp
+}
+
+func (s *structuredMetadataRegexStage) Name() string {
+	return StageTypeStructuredMetadataRegex
+}
+
+// Cleanup implements Stage.
+func (*structuredMetadataRegexStage) Cleanup() {
+	// no-op
+}
+
+func (s *structuredMetadataRegexStage) Run(in chan Entry) chan Entry {
+	return RunWith(in, func(e Entry) Entry {
+		for labelName, labelValue := range e.Labels {
+			if s.regex.MatchString(string(labelName)) {
+				e.StructuredMetadata = append(e.StructuredMetadata, logproto.LabelAdapter{Name: string(labelName), Value: string(labelValue)})
+				delete(e.Labels, labelName)
+			}
+		}
+		return e
+	})
+}

--- a/internal/component/loki/process/stages/structured_metadata_regex_test.go
+++ b/internal/component/loki/process/stages/structured_metadata_regex_test.go
@@ -1,0 +1,52 @@
+package stages
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/push"
+	util_log "github.com/grafana/loki/v3/pkg/util/log"
+)
+
+var pipelineStagesStructuredMetadataRegexFromStaticLabels = `
+stage.static_labels {
+	values = {"component" = "querier", "pod" = "loki-querier-664f97db8d-qhnwg"}
+}
+stage.structured_metadata_regex {
+        regex = "comp.*"
+}
+`
+
+func Test_structuredMetadataRegexStage(t *testing.T) {
+	tests := map[string]struct {
+		pipelineStagesYaml         string
+		logLine                    string
+		expectedStructuredMetadata push.LabelsAdapter
+		expectedLabels             model.LabelSet
+	}{
+		"expected ": {
+			pipelineStagesYaml:         pipelineStagesStructuredMetadataRegexFromStaticLabels,
+			logLine:                    "",
+			expectedStructuredMetadata: push.LabelsAdapter{push.LabelAdapter{Name: "component", Value: "querier"}},
+			expectedLabels:             model.LabelSet{model.LabelName("pod"): model.LabelValue("loki-querier-664f97db8d-qhnwg")},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			pl, err := NewPipeline(util_log.Logger, loadConfig(test.pipelineStagesYaml), nil, prometheus.DefaultRegisterer)
+			require.NoError(t, err)
+
+			result := processEntries(pl, newEntry(nil, nil, test.logLine, time.Now()))[0]
+			require.Equal(t, test.expectedStructuredMetadata, result.StructuredMetadata)
+			if test.expectedLabels != nil {
+				require.Equal(t, test.expectedLabels, result.Labels)
+			} else {
+				require.Empty(t, result.Labels)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This adds a stage to loki.process `structured_metadata_regex`, that takes a string attr `regex`, e.g.

```
        stage.structured_metadata_regex { 
                regex = "kubernetes_pod_.*"
        }
```
All labels that match the regular expression are moved to structured metadata (so removed as labels).

#### Which issue(s) this PR fixes

Fixes #926

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

Please advise: 

Is it reasonable to introduce a new loki.process stage for this? 

I considered extending `loki.relabel` but that is a Loki wrapper around prometheus relabel so I decided against that. Then I considered extending the existing `structured_metadata` stage of `loki.process`, but also decided against that to not modify/embed the existing `LabelsConfig`.

Happy to re-work this per your guidance to get this feature merged.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests updated

