### PR TITLE
`loki.secretfilter`: Add explicit message in the docs about labels not being scanned

### DIFF
--- a/docs/sources/reference/components/loki/loki.secretfilter.md
+++ b/docs/sources/reference/components/loki/loki.secretfilter.md
@@ -20,7 +20,7 @@ This component may generate false positives or redact too much.
 Don't rely solely on this component to redact sensitive information.
 {{< /admonition >}}
 
-{{< admonition type="caution" >}}
+{{< admonition type="note" >}}
 This component operates on log lines and doesn't scan labels or other metadata.
 {{< /admonition >}}
 

--- a/docs/sources/reference/components/loki/loki.secretfilter.md
+++ b/docs/sources/reference/components/loki/loki.secretfilter.md
@@ -108,7 +108,7 @@ The following fields are exported and can be referenced by other components:
 
 ## Example
 
-This example shows how to use `loki.secretfilter` to redact secrets from log entries before forwarding them to a Loki receiver.
+This example shows how to use `loki.secretfilter` to redact secrets from log lines before forwarding them to a Loki receiver.
 It uses a custom redaction string that will include the secret type and its hash.
 
 ```alloy

--- a/docs/sources/reference/components/loki/loki.secretfilter.md
+++ b/docs/sources/reference/components/loki/loki.secretfilter.md
@@ -20,6 +20,10 @@ This component may generate false positives or redact too much.
 Don't rely solely on this component to redact sensitive information.
 {{< /admonition >}}
 
+{{< admonition type="caution" >}}
+This component operates on log lines and doesn't scan labels or other metadata.
+{{< /admonition >}}
+
 [gitleaks]: https://github.com/gitleaks/gitleaks/blob/master/config/gitleaks.toml
 
 ## Usage


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This component scans for secrets in log lines and doesn't check metadata such as labels.
Make this behaviour explicit in the docs

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [X] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
