### PR TITLE
fix(otelcol.exporter.prometheus): do not drop valid exemplars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -294,6 +294,8 @@ v1.7.0
   previous "legacy" scheme. An experimental flag `--feature.prometheus.metric-validation-scheme` can be used to switch
   it to `utf-8` to experiment with UTF-8 support. (@thampiotr)
 
+- Fix `otelcol.exporter.prometheus` that dropped valid exemplars. (@github-vincent-miszczak)
+
 ### Other changes
 
 - Upgrading to Prometheus v2.54.1. (@ptodev)

--- a/internal/component/otelcol/exporter/prometheus/internal/convert/cache.go
+++ b/internal/component/otelcol/exporter/prometheus/internal/convert/cache.go
@@ -29,6 +29,8 @@ type memorySeries struct {
 	timestamp time.Time // Timestamp used for out-of-order detection.
 	lastSeen  time.Time // Timestamp used for garbage collection.
 
+	exemplarTimestamp time.Time // Timestamp used for exemplars out-of-order detection.
+
 	value float64 // Value used for writing.
 }
 
@@ -60,6 +62,18 @@ func (series *memorySeries) SetTimestamp(newTime time.Time) {
 	series.Lock()
 	defer series.Unlock()
 	series.timestamp = newTime
+}
+
+func (series *memorySeries) SetExemplarTimestamp(newTime time.Time) {
+	series.Lock()
+	defer series.Unlock()
+	series.exemplarTimestamp = newTime
+}
+
+func (series *memorySeries) ExemplarTimestamp() time.Time {
+	series.Lock()
+	defer series.Unlock()
+	return series.exemplarTimestamp
 }
 
 // LastSeen returns the timestamp when this series was last seen.

--- a/internal/component/otelcol/exporter/prometheus/internal/convert/convert.go
+++ b/internal/component/otelcol/exporter/prometheus/internal/convert/convert.go
@@ -348,10 +348,12 @@ func writeSeries(app storage.Appender, series *memorySeries, dp otelcolDataPoint
 
 func (conv *Converter) writeExemplar(app storage.Appender, series *memorySeries, otelExemplar pmetric.Exemplar) error {
 	ts := otelExemplar.Timestamp().AsTime()
-	if ts.Before(series.Timestamp()) {
+	if ts.Before(series.ExemplarTimestamp()) {
 		// Out-of-order; skip.
 		return nil
 	}
+	series.SetExemplarTimestamp(ts)
+
 	promExemplar := conv.convertExemplar(otelExemplar, ts)
 	return series.WriteExemplarsTo(app, promExemplar)
 }

--- a/internal/component/otelcol/exporter/prometheus/internal/convert/convert_test.go
+++ b/internal/component/otelcol/exporter/prometheus/internal/convert/convert_test.go
@@ -166,6 +166,66 @@ func TestConverter(t *testing.T) {
 			enableOpenMetrics: true,
 		},
 		{
+			name: "Histogram out-of-order exemplars",
+			input: `{
+				"resource_metrics": [{
+					"scope_metrics": [{
+						"metrics": [{
+							"name": "test_metric_seconds",
+							"histogram": {
+								"aggregation_temporality": 2,
+								"data_points": [{
+									"start_time_unix_nano": 1000000010,
+									"time_unix_nano": 1000000010,
+									"count": 333,
+									"sum": 100,
+									"bucket_counts": [0, 111, 0, 222],
+									"explicit_bounds": [0.25, 0.5, 0.75, 1.0],
+									"exemplars":[
+										{
+											"time_unix_nano": 1000000001,
+											"as_double": 0.3,
+											"span_id": "aaaaaaaaaaaaaaaa",
+											"trace_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+										},
+										{
+											"time_unix_nano": 1000000000,
+											"as_double": 0.3,
+											"span_id": "dddddddddddddddd",
+											"trace_id": "dddddddddddddddddddddddddddddddd"
+										},
+										{
+											"time_unix_nano": 1000000003,
+											"as_double": 1.5,
+											"span_id": "cccccccccccccccc",
+											"trace_id": "cccccccccccccccccccccccccccccccc"
+										},
+										{
+											"time_unix_nano": 1000000002,
+											"as_double": 0.5,
+											"span_id": "bbbbbbbbbbbbbbbb",
+											"trace_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+										}
+									]
+								}]
+							}
+						}]
+					}]
+				}]
+			}`,
+			expect: `
+				# TYPE test_metric_seconds histogram
+				test_metric_seconds_bucket{le="0.25"} 0
+				test_metric_seconds_bucket{le="0.5"} 111 # {span_id="aaaaaaaaaaaaaaaa",trace_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"} 0.3
+				test_metric_seconds_bucket{le="0.75"} 111 # {span_id="bbbbbbbbbbbbbbbb",trace_id="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"} 0.5
+				test_metric_seconds_bucket{le="1.0"} 333
+				test_metric_seconds_bucket{le="+Inf"} 333 # {span_id="cccccccccccccccc",trace_id="cccccccccccccccccccccccccccccccc"} 1.5
+				test_metric_seconds_sum 100.0
+				test_metric_seconds_count 333
+			`,
+			enableOpenMetrics: true,
+		},
+		{
 			name: "Histogram out-of-order bounds",
 			input: `{
 				"resource_metrics": [{

--- a/internal/component/otelcol/exporter/prometheus/internal/convert/convert_test.go
+++ b/internal/component/otelcol/exporter/prometheus/internal/convert/convert_test.go
@@ -1251,7 +1251,7 @@ func TestConverterExponentialHistograms(t *testing.T) {
 				}]
 			}]
 		}`,
-			// The tests only allow one exemplar/series because it uses a map[series]exemplar as storage. Therefore only the exemplar "bbbbbbbbbbbbbbbb" is stored.
+			// The tests only allow one exemplar/series because it uses a map[series]exemplar as storage. Therefore only the exemplar "cccccccccccccccc" is stored(bbbbbbbbbbbbbbbb is out-of-order).
 			expect: `{
 				"bucket": [
 				  {
@@ -1259,14 +1259,14 @@ func TestConverterExponentialHistograms(t *testing.T) {
 					  "label": [
 						{
 						  "name": "span_id",
-						  "value": "bbbbbbbbbbbbbbbb"
+						  "value": "cccccccccccccccc"
 						},
 						{
 						  "name": "trace_id",
-						  "value": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+						  "value": "cccccccccccccccccccccccccccccccc"
 						}
 					  ],
-					  "value": 1.5
+					  "value": 1.0
 					}
 				  }
 				],


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
`otelcol.exporter. Prometheus` incorrectly rejects exemplars.
For instance, when using a histogram with exemplars, exemplars' timestamp is always lower than the regular samples timestamp.

See 
- https://github.com/open-telemetry/opentelemetry-java/issues/4193#issuecomment-1087245884

Exemplars ordering has to be done regarding other exemplars, not regular samples.

#### Which issue(s) this PR fixes


<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #320 

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated

