### PR TITLE
pyroscope.scrape: add __profile_path_prefix__ label handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Main (unreleased)
 
 - Add support for pushv1.PusherService Connect API in `pyroscope.receive_http`. (@simonswine)
 
+- Add support for path prefixes in `pyroscope.scrape` to allow scraping targets behind a proxy or with custom URL paths. (@korniltsev)
+
 v1.6.1
 -----------------
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.scrape.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.scrape.md
@@ -95,8 +95,13 @@ For example, the `job_name` of `pyroscope.scrape "local" { ... }` will be `"pyro
 
 The list of `targets` can be provided [statically][example_static_targets], [dynamically][example_dynamic_targets], or a [combination of both][example_static_and_dynamic_targets].
 
-The special `__address__` label _must always_ be present and corresponds to the
-`<host>:<port>` that is used for the scrape request.
+The following special labels can change the behavior of `pyroscope.scrape`:
+
+* `__address__` is the special label that _must always_ be present and corresponds to the `<host>:<port>` that is used for the scrape request.
+* `__profile_path__` is the special label that holds the path to the profile endpoint on the target (e.g. "/debug/pprof/allocs").
+* `__profile_path_prefix__` is the special label that holds an optional prefix to prepend to the profile path (e.g. "/mimir-prometheus").
+* `__name__` is the special label that indicates the profile type being collected.
+* `service_name` is a required label that identifies the service being profiled.
 
 Labels starting with a double underscore (`__`) are treated as _internal_, and are removed prior to scraping.
 

--- a/internal/component/pyroscope/scrape/scrape.go
+++ b/internal/component/pyroscope/scrape/scrape.go
@@ -104,7 +104,7 @@ type ProfilingConfig struct {
 	GoDeltaProfBlock  ProfilingTarget         `alloy:"profile.godeltaprof_block,block,optional"`
 	Custom            []CustomProfilingTarget `alloy:"profile.custom,block,optional"`
 
-	PprofPrefix string `alloy:"path_prefix,attr,optional"`
+	PathPrefix string `alloy:"path_prefix,attr,optional"`
 }
 
 // AllTargets returns the set of all standard and custom profiling targets,

--- a/internal/component/pyroscope/scrape/scrape_test.go
+++ b/internal/component/pyroscope/scrape/scrape_test.go
@@ -147,7 +147,7 @@ func TestUnmarshalConfig(t *testing.T) {
 					Delta:   true,
 					Name:    "something",
 				})
-				r.ProfilingConfig.PprofPrefix = "v1/"
+				r.ProfilingConfig.PathPrefix = "v1/"
 				return r
 			},
 		},

--- a/internal/component/pyroscope/scrape/target.go
+++ b/internal/component/pyroscope/scrape/target.go
@@ -398,9 +398,6 @@ func targetsFromGroup(group *targetgroup.Group, cfg Arguments, targetTypes map[s
 				lbls = append(lbls, labels.Label{Name: model.AddressLabel, Value: lset.Get(model.AddressLabel)})
 				lbls = append(lbls, labels.Label{Name: model.SchemeLabel, Value: cfg.Scheme})
 				lbls = append(lbls, labels.Label{Name: ProfilePath, Value: lset.Get(ProfilePath)})
-				//ilbls = append(lbls, labels.Label{Name: ProfilePathPrefix, Value: profilePathPrefix})f profilePathPrefix := lset.Get(ProfilePathPrefix); profilePathPrefix != "" {
-				//	lbls = append(lbls, labels.Label{Name: ProfilePathPrefix, Value: profilePathPrefix})
-				//}
 				// Encode scrape query parameters as labels.
 				for k, v := range cfg.Params {
 					if len(v) > 0 {

--- a/internal/component/pyroscope/scrape/target.go
+++ b/internal/component/pyroscope/scrape/target.go
@@ -176,15 +176,6 @@ func (t *Target) DiscoveredLabels() labels.Labels {
 	return lset
 }
 
-// Clone returns a clone of the target.
-func (t *Target) Clone() *Target {
-	return NewTarget(
-		t.Labels(),
-		t.DiscoveredLabels(),
-		t.Params(),
-	)
-}
-
 // SetDiscoveredLabels sets new DiscoveredLabels.
 func (t *Target) SetDiscoveredLabels(l labels.Labels) {
 	t.mtx.Lock()

--- a/internal/component/pyroscope/scrape/target.go
+++ b/internal/component/pyroscope/scrape/target.go
@@ -19,7 +19,6 @@ import (
 	"hash/fnv"
 	"net"
 	"net/url"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -121,13 +120,11 @@ func urlFromTarget(lbls labels.Labels, params url.Values) string {
 		}
 	}
 
-	path := filepath.Join(lbls.Get(ProfilePathPrefix), lbls.Get(ProfilePath))
 	return (&url.URL{
 		Scheme:   lbls.Get(model.SchemeLabel),
 		Host:     lbls.Get(model.AddressLabel),
-		Path:     path,
 		RawQuery: newParams.Encode(),
-	}).String()
+	}).JoinPath(lbls.Get(ProfilePathPrefix), lbls.Get(ProfilePath)).String()
 }
 
 func (t *Target) String() string {

--- a/internal/component/pyroscope/scrape/target_test.go
+++ b/internal/component/pyroscope/scrape/target_test.go
@@ -1,7 +1,6 @@
 package scrape
 
 import (
-	"github.com/stretchr/testify/assert"
 	"net/url"
 	"slices"
 	"sort"
@@ -11,6 +10,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/component/pyroscope/scrape/target_test.go
+++ b/internal/component/pyroscope/scrape/target_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/model/labels"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -597,7 +596,7 @@ func TestProfileURL(t *testing.T) {
 			}
 			slices.Sort(td.expectedUrls)
 			slices.Sort(actualURLs)
-			assert.Equal(t, td.expectedUrls, actualURLs)
+			require.Equal(t, td.expectedUrls, actualURLs)
 		})
 
 	}
@@ -703,9 +702,8 @@ func TestLabelsByProfiles(t *testing.T) {
 	}
 	for _, td := range testdata {
 		t.Run(td.name, func(t *testing.T) {
-
 			actual := LabelsByProfiles(labels.New(td.target...), td.cfg)
-			assert.Equal(t, td.expected, actual)
+			require.Equal(t, td.expected, actual)
 		})
 	}
 }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Introduce `__profile_path_prefix__` special label which is prepended to `__profile_path__` label before scraping URL creation.
#### Which issue(s) this PR fixes
Fixes #2597 #2605
<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
