### PR TITLE
database_observability: extract table schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,23 +22,18 @@ Main (unreleased)
 
 - Add the possibility to export span events as logs in `otelcol.connector.spanlogs`. (@steve-hb)
 
-- (_Experimental_) Log instance label key in `database_observability.mysql` (@cristiangreco)
-
-- (_Experimental_) Improve parsing of truncated queries in `database_observability.mysql` (@cristiangreco)
-
-- (_Experimental_) Capture schema name for query samples in `database_observability.mysql` (@cristiangreco)
-
-- (_Experimental_) Fix handling of view table types when detecting schema in `database_observability.mysql` (@matthewnolf)
-
-- (_Experimental_) Fix error handling during result set iteration in `database_observability.mysql` (@cristiangreco)
-
-- (_Experimental_) Better support for table name parsing in `database_observability.mysql` (@cristiangreco)
-
-- (_Experimental_) Better error handling for `database_observability.mysql` (@cristiangreco)
-
-- (_Experimental_) Add namespace to `connection_info` metric in `database_observability.mysql` (@cristiangreco)
-
 - Add json format support for log export via faro receiver (@ravishankar15)
+
+- (_Experimental_) Various changes to the experimental component `database_observability.mysql`:
+  - Always log `instance` label key (@cristiangreco)
+  - Improve parsing of truncated queries (@cristiangreco)
+  - Capture schema name for query samples (@cristiangreco)
+  - Fix handling of view table types when detecting schema (@matthewnolf)
+  - Fix error handling during result set iteration (@cristiangreco)
+  - Better support for table name parsing (@cristiangreco)
+  - Better error handling for components (@cristiangreco)
+  - Add namespace to `connection_info` metric in `database_observability.mysql` (@cristiangreco)
+  - Added table columns parsing (@cristiagreco)
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Main (unreleased)
   - Fix error handling during result set iteration (@cristiangreco)
   - Better support for table name parsing (@cristiangreco)
   - Better error handling for components (@cristiangreco)
-  - Add namespace to `connection_info` metric in `database_observability.mysql` (@cristiangreco)
+  - Add namespace to `connection_info` metric (@cristiangreco)
   - Added table columns parsing (@cristiagreco)
 
 ### Bugfixes

--- a/internal/component/database_observability/mysql/collector/schema_table.go
+++ b/internal/component/database_observability/mysql/collector/schema_table.go
@@ -3,13 +3,17 @@ package collector
 import (
 	"context"
 	"database/sql"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/prometheus/common/model"
+	"github.com/xwb1989/sqlparser"
 	"go.uber.org/atomic"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
@@ -83,6 +87,17 @@ type tableInfo struct {
 	createTime time.Time
 	updateTime time.Time
 	createStmt string
+}
+
+type tableSpec struct {
+	Columns []columnSpec `json:"columns"`
+}
+type columnSpec struct {
+	Name          string `json:"name"`
+	Type          string `json:"type"`
+	NotNull       bool   `json:"not_null,omitempty"`
+	AutoIncrement bool   `json:"auto_increment,omitempty"`
+	DefaultValue  string `json:"default_value,omitempty"`
 }
 
 func NewSchemaTable(args SchemaTableArguments) (*SchemaTable, error) {
@@ -219,6 +234,11 @@ func (c *SchemaTable) extractSchema(ctx context.Context) error {
 		}
 	}
 
+	if len(tables) == 0 {
+		level.Info(c.logger).Log("msg", "no tables detected from information_schema.tables")
+		return nil
+	}
+
 	// TODO(cristian): consider moving this into the loop above
 	for _, table := range tables {
 		fullyQualifiedTable := fmt.Sprintf("%s.%s", table.schema, table.tableName)
@@ -231,7 +251,7 @@ func (c *SchemaTable) extractSchema(ctx context.Context) error {
 
 		row := c.dbConnection.QueryRowContext(ctx, showCreateTable+" "+fullyQualifiedTable)
 		if row.Err() != nil {
-			level.Error(c.logger).Log("msg", "failed to show create table", "table", table.tableName, "err", row.Err())
+			level.Error(c.logger).Log("msg", "failed to show create table", "schema", table.schema, "table", table.tableName, "err", row.Err())
 			break
 		}
 
@@ -241,12 +261,12 @@ func (c *SchemaTable) extractSchema(ctx context.Context) error {
 		var collationConnection string
 		if table.tableType == "BASE TABLE" {
 			if err = row.Scan(&tableName, &createStmt); err != nil {
-				level.Error(c.logger).Log("msg", "failed to scan create table", "table", table.tableName, "err", err)
+				level.Error(c.logger).Log("msg", "failed to scan create table", "schema", table.schema, "table", table.tableName, "err", err)
 				break
 			}
 		} else if table.tableType == "VIEW" {
 			if err = row.Scan(&tableName, &createStmt, &characterSetClient, &collationConnection); err != nil {
-				level.Error(c.logger).Log("msg", "failed to scan create view", "table", table.tableName, "err", err)
+				level.Error(c.logger).Log("msg", "failed to scan create view", "schema", table.schema, "table", table.tableName, "err", err)
 				break
 			}
 		}
@@ -254,14 +274,112 @@ func (c *SchemaTable) extractSchema(ctx context.Context) error {
 		table.createStmt = createStmt
 		c.cache.Add(cacheKey, table)
 
+		spec, err := c.parseTableSpec(table.schema, table.tableName, createStmt)
+		if err != nil {
+			break
+		}
+		jsonSpec, err := json.Marshal(spec)
+		if err != nil {
+			level.Error(c.logger).Log("msg", "failed to marshal table spec", "schema", table.schema, "table", table.tableName, "err", err)
+			break
+		}
+
 		c.entryHandler.Chan() <- loki.Entry{
 			Labels: model.LabelSet{"job": database_observability.JobName},
 			Entry: logproto.Entry{
 				Timestamp: time.Unix(0, time.Now().UnixNano()),
-				Line:      fmt.Sprintf(`level=info msg="create table" op="%s" instance="%s" schema="%s" table="%s" create_statement="%s"`, OP_CREATE_STATEMENT, c.instanceKey, table.schema, table.tableName, createStmt),
+				Line: fmt.Sprintf(
+					`level=info msg="create table" op="%s" instance="%s" schema="%s" table="%s" create_statement="%s" table_spec="%s"`,
+					OP_CREATE_STATEMENT, c.instanceKey, table.schema, table.tableName, base64.StdEncoding.EncodeToString([]byte(createStmt)), base64.StdEncoding.EncodeToString(jsonSpec),
+				),
 			},
 		}
 	}
 
 	return nil
+}
+
+func (c *SchemaTable) parseTableSpec(schemaName string, tableName string, createStmt string) (*tableSpec, error) {
+	// TODO(cristian): find a better way to parse the create statement.
+	// For now, remove CONSTRAINT clauses as they are not supported by xwb1989/sqlparser.
+	lines := strings.Split(createStmt, "\n")
+	filteredLines := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(strings.ToUpper(trimmed), "CONSTRAINT") {
+			level.Info(c.logger).Log("msg", "skipping parsing of unsupported DDL feature", "schema", schemaName, "table", tableName, "line", line)
+			continue
+		}
+		filteredLines = append(filteredLines, line)
+	}
+	if len(lines) != len(filteredLines) && len(filteredLines) > 1 {
+		// Remove trailing comma from the last line
+		createStmt = strings.Join(filteredLines, "\n")
+		if c := strings.LastIndex(createStmt, ","); c > 0 {
+			createStmt = createStmt[:c] + createStmt[c+1:]
+		}
+	}
+
+	stmt, err := sqlparser.Parse(createStmt)
+	if err != nil {
+		level.Error(c.logger).Log("msg", "failed to parse create table sql query", "schema", schemaName, "table", tableName, "err", err)
+		return nil, err
+	}
+
+	ddl, ok := stmt.(*sqlparser.DDL)
+	if !ok {
+		level.Error(c.logger).Log("msg", "failed to parse create table sql query as DDL", "schema", schemaName, "table", tableName, "err", err)
+		return nil, err
+	}
+
+	tblSpec := &tableSpec{Columns: []columnSpec{}}
+
+	if ddl.TableSpec != nil {
+		for _, col := range ddl.TableSpec.Columns {
+			colSpec := columnSpec{
+				Name: col.Name.String(),
+				Type: col.Type.Type,
+			}
+
+			typeLen := ""
+			if col.Type.Length != nil {
+				typeLen = string(col.Type.Length.Val)
+			}
+
+			enumVals := ""
+			if col.Type.Type == "enum" && len(col.Type.EnumValues) > 0 {
+				enumVals = strings.Join(col.Type.EnumValues, ",")
+			}
+			if typeLen != "" {
+				colSpec.Type += "(" + typeLen + ")"
+			} else if enumVals != "" {
+				colSpec.Type += "(" + enumVals + ")"
+			}
+
+			if col.Type.NotNull {
+				colSpec.NotNull = true
+			}
+
+			if col.Type.Autoincrement {
+				colSpec.AutoIncrement = true
+			}
+
+			defaultVal := ""
+			if col.Type.Default != nil {
+				switch col.Type.Default.Type {
+				case sqlparser.StrVal, sqlparser.IntVal, sqlparser.FloatVal, sqlparser.BitVal, sqlparser.ValArg:
+					defaultVal = string(col.Type.Default.Val)
+				default:
+					level.Info(c.logger).Log("msg", "unsupported default value type", "schema", schemaName, "table", tableName, "column", col.Name.String(), "type", col.Type.Default.Type)
+				}
+			}
+			if defaultVal != "" {
+				colSpec.DefaultValue = defaultVal
+			}
+
+			tblSpec.Columns = append(tblSpec.Columns, colSpec)
+		}
+	}
+
+	return tblSpec, nil
 }

--- a/internal/component/database_observability/mysql/collector/schema_table_test.go
+++ b/internal/component/database_observability/mysql/collector/schema_table_test.go
@@ -77,6 +77,25 @@ func TestSchemaTable(t *testing.T) {
 				),
 			)
 
+		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"COLUMN_NAME",
+					"COLUMN_DEFAULT",
+					"IS_NULLABLE",
+					"COLUMN_TYPE",
+					"COLUMN_KEY",
+					"EXTRA",
+				}).AddRow(
+					"id",
+					"null",
+					"NO",
+					"int",
+					"PRI",
+					"auto_increment",
+				),
+			)
+
 		err = collector.Start(context.Background())
 		require.NoError(t, err)
 
@@ -100,7 +119,7 @@ func TestSchemaTable(t *testing.T) {
 		}
 		require.Equal(t, `level=info msg="schema detected" op="schema_detection" instance="mysql-db" schema="some_schema"`, lokiEntries[0].Line)
 		require.Equal(t, `level=info msg="table detected" op="table_detection" instance="mysql-db" schema="some_schema" table="some_table"`, lokiEntries[1].Line)
-		require.Equal(t, fmt.Sprintf(`level=info msg="create table" op="create_statement" instance="mysql-db" schema="some_schema" table="some_table" create_statement="%s" table_spec="%s"`, base64.StdEncoding.EncodeToString([]byte("CREATE TABLE some_table (id INT)")), base64.StdEncoding.EncodeToString([]byte(`{"columns":[{"name":"id","type":"int"}]}`))), lokiEntries[2].Line)
+		require.Equal(t, fmt.Sprintf(`level=info msg="create table" op="create_statement" instance="mysql-db" schema="some_schema" table="some_table" create_statement="%s" table_spec="%s"`, base64.StdEncoding.EncodeToString([]byte("CREATE TABLE some_table (id INT)")), base64.StdEncoding.EncodeToString([]byte(`{"columns":[{"name":"id","type":"int","not_null":true,"auto_increment":true,"primary_key":true,"default_value":"null"}]}`))), lokiEntries[2].Line)
 	})
 	t.Run("detect view schema", func(t *testing.T) {
 		t.Parallel()
@@ -162,6 +181,25 @@ func TestSchemaTable(t *testing.T) {
 				),
 			)
 
+		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"COLUMN_NAME",
+					"COLUMN_DEFAULT",
+					"IS_NULLABLE",
+					"COLUMN_TYPE",
+					"COLUMN_KEY",
+					"EXTRA",
+				}).AddRow(
+					"id",
+					"null",
+					"NO",
+					"int",
+					"PRI",
+					"auto_increment",
+				),
+			)
+
 		err = collector.Start(context.Background())
 		require.NoError(t, err)
 
@@ -185,7 +223,7 @@ func TestSchemaTable(t *testing.T) {
 		}
 		require.Equal(t, `level=info msg="schema detected" op="schema_detection" instance="mysql-db" schema="some_schema"`, lokiEntries[0].Line)
 		require.Equal(t, `level=info msg="table detected" op="table_detection" instance="mysql-db" schema="some_schema" table="some_table"`, lokiEntries[1].Line)
-		require.Equal(t, fmt.Sprintf(`level=info msg="create table" op="create_statement" instance="mysql-db" schema="some_schema" table="some_table" create_statement="%s" table_spec="%s"`, base64.StdEncoding.EncodeToString([]byte("CREATE VIEW some_view (id INT)")), base64.StdEncoding.EncodeToString([]byte(`{"columns":[]}`))), lokiEntries[2].Line)
+		require.Equal(t, fmt.Sprintf(`level=info msg="create table" op="create_statement" instance="mysql-db" schema="some_schema" table="some_table" create_statement="%s" table_spec="%s"`, base64.StdEncoding.EncodeToString([]byte("CREATE VIEW some_view (id INT)")), base64.StdEncoding.EncodeToString([]byte(`{"columns":[{"name":"id","type":"int","not_null":true,"auto_increment":true,"primary_key":true,"default_value":"null"}]}`))), lokiEntries[2].Line)
 	})
 	t.Run("schemas result set iteration error", func(t *testing.T) {
 		t.Parallel()
@@ -354,6 +392,25 @@ func TestSchemaTable(t *testing.T) {
 			),
 		)
 
+		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"COLUMN_NAME",
+					"COLUMN_DEFAULT",
+					"IS_NULLABLE",
+					"COLUMN_TYPE",
+					"COLUMN_KEY",
+					"EXTRA",
+				}).AddRow(
+					"id",
+					"null",
+					"NO",
+					"int",
+					"PRI",
+					"auto_increment",
+				),
+			)
+
 		err = collector.Start(context.Background())
 		require.NoError(t, err)
 
@@ -374,6 +431,6 @@ func TestSchemaTable(t *testing.T) {
 		}
 		require.Equal(t, `level=info msg="schema detected" op="schema_detection" instance="mysql-db" schema="some_schema"`, lokiEntries[0].Line)
 		require.Equal(t, `level=info msg="table detected" op="table_detection" instance="mysql-db" schema="some_schema" table="some_table"`, lokiEntries[1].Line)
-		require.Equal(t, fmt.Sprintf(`level=info msg="create table" op="create_statement" instance="mysql-db" schema="some_schema" table="some_table" create_statement="%s" table_spec="%s"`, base64.StdEncoding.EncodeToString([]byte("CREATE TABLE some_table (id INT)")), base64.StdEncoding.EncodeToString([]byte(`{"columns":[{"name":"id","type":"int"}]}`))), lokiEntries[2].Line)
+		require.Equal(t, fmt.Sprintf(`level=info msg="create table" op="create_statement" instance="mysql-db" schema="some_schema" table="some_table" create_statement="%s" table_spec="%s"`, base64.StdEncoding.EncodeToString([]byte("CREATE TABLE some_table (id INT)")), base64.StdEncoding.EncodeToString([]byte(`{"columns":[{"name":"id","type":"int","not_null":true,"auto_increment":true,"primary_key":true,"default_value":"null"}]}`))), lokiEntries[2].Line)
 	})
 }

--- a/internal/component/database_observability/mysql/collector/schema_table_test.go
+++ b/internal/component/database_observability/mysql/collector/schema_table_test.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"testing"
@@ -99,7 +100,7 @@ func TestSchemaTable(t *testing.T) {
 		}
 		require.Equal(t, `level=info msg="schema detected" op="schema_detection" instance="mysql-db" schema="some_schema"`, lokiEntries[0].Line)
 		require.Equal(t, `level=info msg="table detected" op="table_detection" instance="mysql-db" schema="some_schema" table="some_table"`, lokiEntries[1].Line)
-		require.Equal(t, `level=info msg="create table" op="create_statement" instance="mysql-db" schema="some_schema" table="some_table" create_statement="CREATE TABLE some_table (id INT)"`, lokiEntries[2].Line)
+		require.Equal(t, fmt.Sprintf(`level=info msg="create table" op="create_statement" instance="mysql-db" schema="some_schema" table="some_table" create_statement="%s" table_spec="%s"`, base64.StdEncoding.EncodeToString([]byte("CREATE TABLE some_table (id INT)")), base64.StdEncoding.EncodeToString([]byte(`{"columns":[{"name":"id","type":"int"}]}`))), lokiEntries[2].Line)
 	})
 	t.Run("detect view schema", func(t *testing.T) {
 		t.Parallel()
@@ -184,7 +185,7 @@ func TestSchemaTable(t *testing.T) {
 		}
 		require.Equal(t, `level=info msg="schema detected" op="schema_detection" instance="mysql-db" schema="some_schema"`, lokiEntries[0].Line)
 		require.Equal(t, `level=info msg="table detected" op="table_detection" instance="mysql-db" schema="some_schema" table="some_table"`, lokiEntries[1].Line)
-		require.Equal(t, `level=info msg="create table" op="create_statement" instance="mysql-db" schema="some_schema" table="some_table" create_statement="CREATE VIEW some_view (id INT)"`, lokiEntries[2].Line)
+		require.Equal(t, fmt.Sprintf(`level=info msg="create table" op="create_statement" instance="mysql-db" schema="some_schema" table="some_table" create_statement="%s" table_spec="%s"`, base64.StdEncoding.EncodeToString([]byte("CREATE VIEW some_view (id INT)")), base64.StdEncoding.EncodeToString([]byte(`{"columns":[]}`))), lokiEntries[2].Line)
 	})
 	t.Run("schemas result set iteration error", func(t *testing.T) {
 		t.Parallel()
@@ -373,6 +374,6 @@ func TestSchemaTable(t *testing.T) {
 		}
 		require.Equal(t, `level=info msg="schema detected" op="schema_detection" instance="mysql-db" schema="some_schema"`, lokiEntries[0].Line)
 		require.Equal(t, `level=info msg="table detected" op="table_detection" instance="mysql-db" schema="some_schema" table="some_table"`, lokiEntries[1].Line)
-		require.Equal(t, `level=info msg="create table" op="create_statement" instance="mysql-db" schema="some_schema" table="some_table" create_statement="CREATE TABLE some_table (id INT)"`, lokiEntries[2].Line)
+		require.Equal(t, fmt.Sprintf(`level=info msg="create table" op="create_statement" instance="mysql-db" schema="some_schema" table="some_table" create_statement="%s" table_spec="%s"`, base64.StdEncoding.EncodeToString([]byte("CREATE TABLE some_table (id INT)")), base64.StdEncoding.EncodeToString([]byte(`{"columns":[{"name":"id","type":"int"}]}`))), lokiEntries[2].Line)
 	})
 }


### PR DESCRIPTION
#### PR Description
This is the first iteration of the implementation for extracting the table schema details.

In this PR:
- parse columns information_schema.columns (ignore indexes and other constraints)
- introduce a json structure to represent the table schema
- base64-encode both the schema and the create statement itself

Still a bunch of things to followup on but didn't want to make this PR too big.

#### Which issue(s) this PR fixes
n.a.

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
