### PR TITLE
perf: Optimize discovery.relabel by using label builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ Main (unreleased)
 
 - Add json format support for log export via faro receiver (@ravishankar15)
 
+- Improve preformance of discovery.relabel by using label builder (@simonswine)
+
+
 ### Bugfixes
 
 - Fix log rotation for Windows in `loki.source.file` by refactoring the component to use the runner pkg. This should also reduce CPU consumption when tailing a lot of files in a dynamic environment. (@wildum)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Main (unreleased)
   - Added table columns parsing (@cristiagreco)
   - Add enable/disable collector configurability to `database_observability.mysql`. This removes the `query_samples_enabled` argument, now configurable via enable/disable collector. (@fridgepoet)
 
-- Improve preformance of discovery.relabel by using label builder (@simonswine)
+- Improve performance of discovery.relabel by using label builder (@simonswine)
 
 ### Bugfixes
 


### PR DESCRIPTION
This avoids building labels unnecessarily and uses a retained `LabelBuilder` for relabelling itself.

Both cpu and allocations are reduced significantly:

```
benchstat before.txt after-v2.txt
name        old time/op    new time/op    delta
Relabel-12    10.2ms ± 1%     9.6ms ± 1%   -5.29%  (p=0.000 n=9+9)

name        old alloc/op   new alloc/op   delta
Relabel-12    9.36MB ± 0%    5.15MB ± 0%  -44.91%  (p=0.000 n=10+10)

name        old allocs/op  new allocs/op  delta
Relabel-12      168k ± 0%      132k ± 0%  -21.66%  (p=0.000 n=10+9)
```

Also in a real world deployment this is fairly impactful, both garbage collection and relabel use less cpu:

https://dev.grafana-dev.net/a/grafana-pyroscope-app/profiles-explorer?searchText=&panelType=time-series&layout=grid&hideNoData=off&explorationType=diff-flame-graph&var-serviceName=pyroscope-scrape-dev-001%2Falloy&var-profileMetricId=process_cpu:cpu:nanoseconds:cpu:nanoseconds&var-dataSource=edqsc0bzmfvnkc&var-filters=&var-filtersBaseline=&var-filtersComparison=&var-groupBy=&maxNodes=16384&from=now-30m&to=now&diffFrom=2025-02-04T14:30:26.865Z&diffTo=2025-02-04T14:45:22.388Z&diffFrom-2=2025-02-04T16:30:17.910Z&diffTo-2=2025-02-04T16:44:55.522Z&from-3=2025-02-04T14:00:00.000Z&to-3=2025-02-04T17:00:00.000Z&from-2=2025-02-04T14:00:00.000Z&to-2=2025-02-04T17:00:00.000Z

![image](https://github.com/user-attachments/assets/ea6ee23b-833c-429c-a8d7-79c303b35996)

In terms of allocation bytes they are down by about 46%:

![image](https://github.com/user-attachments/assets/a47aceac-3278-4356-9eb6-003165ca65d2)
