### PR TITLE
feature(prometheus.exporter.mongodb_): Add compatible_mode param for integration

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.exporter.mongodb.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.mongodb.md
@@ -36,6 +36,7 @@ Omitted fields take their default values.
 | `direct_connect`             | `boolean` | Whether or not a direct connect should be made. Direct connections are not valid if multiple hosts are specified or an SRV URI is used. | false   | no       |
 | `discovering_mode`           | `boolean` | Wheter or not to enable autodiscover collections.                                                                                       | false   | no       |
 | `tls_basic_auth_config_path` | `string`  | Path to the file having Prometheus TLS config for basic auth. Only enable if you want to use TLS based authentication.                  |         | no       |
+| `compatible_mode` | `boolean`  | Wheter or not to enable Compatible mode to get old mongodb_exporter metric names.        |         | no       |
 
 MongoDB node connection URI must be in the [`Standard Connection String Format`](https://docs.mongodb.com/manual/reference/connection-string/#std-label-connections-standard-connection-string-format)
 
@@ -69,6 +70,7 @@ from `prometheus.exporter.mongodb`:
 ```alloy
 prometheus.exporter.mongodb "example" {
   mongodb_uri = "mongodb://127.0.0.1:27017"
+  compatible_mode	= true
 }
 
 // Configure a prometheus.scrape component to collect MongoDB metrics.

--- a/internal/component/prometheus/exporter/mongodb/mongodb.go
+++ b/internal/component/prometheus/exporter/mongodb/mongodb.go
@@ -31,6 +31,7 @@ type Arguments struct {
 	DirectConnect          bool              `alloy:"direct_connect,attr,optional"`
 	DiscoveringMode        bool              `alloy:"discovering_mode,attr,optional"`
 	TLSBasicAuthConfigPath string            `alloy:"tls_basic_auth_config_path,attr,optional"`
+	CompatibleMode         bool              `alloy:"compatible_mode,attr,optional"`
 }
 
 func (a *Arguments) Convert() *mongodb_exporter.Config {
@@ -39,5 +40,6 @@ func (a *Arguments) Convert() *mongodb_exporter.Config {
 		DirectConnect:          a.DirectConnect,
 		DiscoveringMode:        a.DiscoveringMode,
 		TLSBasicAuthConfigPath: a.TLSBasicAuthConfigPath,
+		CompatibleMode:         a.CompatibleMode,
 	}
 }

--- a/internal/component/prometheus/exporter/mongodb/mongodb_test.go
+++ b/internal/component/prometheus/exporter/mongodb/mongodb_test.go
@@ -14,6 +14,7 @@ func TestAlloyUnmarshal(t *testing.T) {
 	direct_connect = true
 	discovering_mode = true
 	tls_basic_auth_config_path = "/etc/path-to-file"
+	compatible_mode = true
 	`
 
 	var args Arguments
@@ -25,6 +26,7 @@ func TestAlloyUnmarshal(t *testing.T) {
 		DirectConnect:          true,
 		DiscoveringMode:        true,
 		TLSBasicAuthConfigPath: "/etc/path-to-file",
+		CompatibleMode:         true,
 	}
 
 	require.Equal(t, expected, args)
@@ -36,6 +38,7 @@ func TestConvert(t *testing.T) {
 	direct_connect = true
 	discovering_mode = true
 	tls_basic_auth_config_path = "/etc/path-to-file"
+	compatible_mode = true
 	`
 	var args Arguments
 	err := syntax.Unmarshal([]byte(alloyConfig), &args)
@@ -48,6 +51,7 @@ func TestConvert(t *testing.T) {
 		DirectConnect:          true,
 		DiscoveringMode:        true,
 		TLSBasicAuthConfigPath: "/etc/path-to-file",
+		CompatibleMode:         true,
 	}
 	require.Equal(t, expected, *res)
 }

--- a/internal/static/integrations/mongodb_exporter/mongodb_exporter.go
+++ b/internal/static/integrations/mongodb_exporter/mongodb_exporter.go
@@ -26,6 +26,7 @@ type Config struct {
 	DirectConnect          bool               `yaml:"direct_connect,omitempty"`
 	DiscoveringMode        bool               `yaml:"discovering_mode,omitempty"`
 	TLSBasicAuthConfigPath string             `yaml:"tls_basic_auth_config_path,omitempty"`
+	CompatibleMode         bool               `yaml:"compatible_mode,omitempty"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler for Config
@@ -73,16 +74,11 @@ func New(logger log.Logger, c *Config) (integrations.Integration, error) {
 		URI:                    string(c.URI),
 		Logger:                 logrusLogger,
 		DisableDefaultRegistry: true,
-
-		// NOTE(rfratto): CompatibleMode configures the exporter to use old metric
-		// names from mongodb_exporter <v0.20.0. Many existing dashboards rely on
-		// the old names, so we hard-code it to true now. We may wish to make this
-		// configurable in the future.
-		CompatibleMode:  true,
-		CollectAll:      true,
-		DirectConnect:   c.DirectConnect,
-		DiscoveringMode: c.DiscoveringMode,
-		TLSConfigPath:   c.TLSBasicAuthConfigPath,
+		CompatibleMode:         c.CompatibleMode,
+		CollectAll:             true,
+		DirectConnect:          c.DirectConnect,
+		DiscoveringMode:        c.DiscoveringMode,
+		TLSConfigPath:          c.TLSBasicAuthConfigPath,
 	})
 
 	return integrations.NewHandlerIntegration(c.Name(), exp.Handler()), nil

--- a/internal/static/integrations/mongodb_exporter/mongodb_test.go
+++ b/internal/static/integrations/mongodb_exporter/mongodb_test.go
@@ -14,6 +14,7 @@ integrations:
   mongodb_exporter:
     enabled: true
     mongodb_uri: secret_password_in_uri
+    compatible_mode: true
 `
 	config.CheckSecret(t, stringCfg, "secret_password_in_uri")
 }


### PR DESCRIPTION
#### PR Description
New parameter **compatible_mode** were added for mongodb_exporter integration to have an opportunity to disable or enable this exporter's option.

#### Which issue(s) this PR fixes
Fixes #1510

#### PR Checklist
- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
