### PR TITLE
database_observability: add namespace to connection_info metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Main (unreleased)
 
 - (_Experimental_) Better error handling for `database_observability.mysql` (@cristiangreco)
 
+- (_Experimental_) Add namespace to `connection_info` metric in `database_observability.mysql` (@cristiangreco)
+
 - Add json format support for log export via faro receiver (@ravishankar15)
 
 ### Bugfixes

--- a/internal/component/database_observability/mysql/collector/connection_info.go
+++ b/internal/component/database_observability/mysql/collector/connection_info.go
@@ -28,8 +28,9 @@ type ConnectionInfo struct {
 
 func NewConnectionInfo(args ConnectionInfoArguments) (*ConnectionInfo, error) {
 	infoMetric := prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "connection_info",
-		Help: "Information about the connection",
+		Namespace: "database_observability",
+		Name:      "connection_info",
+		Help:      "Information about the connection",
 	}, []string{"provider_name", "region", "db_instance_identifier"})
 
 	args.Registry.MustRegister(infoMetric)

--- a/internal/component/database_observability/mysql/collector/connection_info_test.go
+++ b/internal/component/database_observability/mysql/collector/connection_info_test.go
@@ -16,9 +16,9 @@ func TestConnectionInfo(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
 	const baseExpectedMetrics = `
-	# HELP connection_info Information about the connection
-	# TYPE connection_info gauge
-	connection_info{db_instance_identifier="%s",provider_name="%s",region="%s"} 1
+	# HELP database_observability_connection_info Information about the connection
+	# TYPE database_observability_connection_info gauge
+	database_observability_connection_info{db_instance_identifier="%s",provider_name="%s",region="%s"} 1
 `
 
 	testCases := []struct {


### PR DESCRIPTION
#### PR Description
Add the namespace `database_observability` to the `connection_info` metric. A breaking change, but this is still unused.

#### Which issue(s) this PR fixes
n.a.

#### Notes to the Reviewer

#### PR Checklist



- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
