### PR TITLE
fix(pyroscope.scrape): godeltaprof hiding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ Main (unreleased)
 
 - Add support for pushv1.PusherService Connect API in `pyroscope.receive_http`. (@simonswine)
 
+- Fixes godeltaprof hiding (renaming `godeltaprof_*` profile names to regular ones). (@korniltsev)
+
 v1.6.1
 -----------------
 

--- a/internal/component/pyroscope/scrape/target.go
+++ b/internal/component/pyroscope/scrape/target.go
@@ -64,23 +64,21 @@ type Target struct {
 // NewTarget creates a reasonably configured target for querying.
 func NewTarget(lbls, discoveredLabels labels.Labels, params url.Values) *Target {
 	publicLabels := make(labels.Labels, 0, len(lbls))
-	for _, l := range lbls {
+	for i, l := range lbls {
 		if strings.HasPrefix(l.Name, model.ReservedLabelPrefix) {
+			// the fact that godeltaprof was used scraping should not be user visible
+			if l.Name == model.MetricNameLabel {
+				switch l.Value {
+				case pprofGoDeltaProfMemory:
+					lbls[i].Value = pprofMemory
+				case pprofGoDeltaProfBlock:
+					lbls[i].Value = pprofBlock
+				case pprofGoDeltaProfMutex:
+					lbls[i].Value = pprofMutex
+				}
+			}
 			continue
 		}
-
-		// the fact that godeltaprof was used scraping should not be user visible
-		if l.Name == pprofGoDeltaProfMemory {
-			switch l.Value {
-			case pprofGoDeltaProfMemory:
-				l.Value = pprofMemory
-			case pprofGoDeltaProfBlock:
-				l.Value = pprofBlock
-			case pprofGoDeltaProfMutex:
-				l.Value = pprofMutex
-			}
-		}
-
 		publicLabels = append(publicLabels, l)
 	}
 	url := urlFromTarget(lbls, params)

--- a/internal/component/pyroscope/scrape/target_test.go
+++ b/internal/component/pyroscope/scrape/target_test.go
@@ -283,6 +283,8 @@ func Test_NewTarget_godeltaprof(t *testing.T) {
 
 	require.NotEqual(t, withGodeltaprof.allLabels, withoutGodeltaprof.allLabels)
 	require.Equal(t, withGodeltaprof.publicLabels, withoutGodeltaprof.publicLabels)
+	assert.Equal(t, pprofMemory, withGodeltaprof.allLabels.Get(model.MetricNameLabel))
+	assert.Equal(t, pprofMemory, withoutGodeltaprof.allLabels.Get(model.MetricNameLabel))
 }
 
 func Test_targetsFromGroup_withSpecifiedDeltaProfilingDuration(t *testing.T) {

--- a/internal/component/pyroscope/scrape/target_test.go
+++ b/internal/component/pyroscope/scrape/target_test.go
@@ -1,6 +1,7 @@
 package scrape
 
 import (
+	"github.com/stretchr/testify/assert"
 	"net/url"
 	"sort"
 	"testing"
@@ -285,6 +286,8 @@ func Test_NewTarget_godeltaprof(t *testing.T) {
 	require.Equal(t, withGodeltaprof.publicLabels, withoutGodeltaprof.publicLabels)
 	assert.Equal(t, pprofMemory, withGodeltaprof.allLabels.Get(model.MetricNameLabel))
 	assert.Equal(t, pprofMemory, withoutGodeltaprof.allLabels.Get(model.MetricNameLabel))
+	assert.Equal(t, "/debug/pprof/heap", withoutGodeltaprof.allLabels.Get(ProfilePath))
+	assert.Equal(t, "/debug/pprof/delta_heap", withGodeltaprof.allLabels.Get(ProfilePath))
 }
 
 func Test_targetsFromGroup_withSpecifiedDeltaProfilingDuration(t *testing.T) {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
The PR fixes the godeltaprof hiding.
The code inside `NewTarget` was checking the wrong label name, also the correct label name is reserved, so it should have been done in a different branch.
Furthermore the test did not check the target values, just inequality

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
