### PR TITLE
fix backticks in EC2 and Kuma discovery page

### DIFF
--- a/docs/sources/reference/components/discovery/discovery.ec2.md
+++ b/docs/sources/reference/components/discovery/discovery.ec2.md
@@ -66,7 +66,7 @@ Block                                 | Description                             
 [`filter`][filter]                    | Filters discoverable resources.                            | no
 [`oauth2`][oauth2]                    | Configure OAuth 2.0 for authenticating to the endpoint.    | no
 `oauth2` > [`tls_config`][tls_config] | Configure TLS settings for connecting to the endpoint.     | no
-[``tls_config][tls_config]            | Configure TLS settings for connecting to the endpoint.     | no
+[`tls_config`][tls_config]            | Configure TLS settings for connecting to the endpoint.     | no
 
 The > symbol indicates deeper levels of nesting.
 For example, `oauth2 > tls_config` refers to a `tls_config` block defined inside an `oauth2` block.

--- a/docs/sources/reference/components/discovery/discovery.kuma.md
+++ b/docs/sources/reference/components/discovery/discovery.kuma.md
@@ -62,7 +62,7 @@ Block                                 | Description                             
 [`basic_auth`][basic_auth]            | Configure `basic_auth` for authenticating to the endpoint. | no
 [`oauth2`][oauth2]                    | Configure OAuth 2.0 for authenticating to the endpoint.    | no
 `oauth2` > [`tls_config`][tls_config] | Configure TLS settings for connecting to the endpoint.     | no
-[``tls_config][tls_config]            | Configure TLS settings for connecting to the endpoint.     | no
+[`tls_config`][tls_config]            | Configure TLS settings for connecting to the endpoint.     | no
 
 The `>` symbol indicates deeper levels of nesting.
 For example, `oauth2 > tls_config` refers to a `tls_config` block defined inside an `oauth2` block.


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

The `tls_config` block is not rendered correctly, for example, on this page[discovery.ec2, Grafana Alloy](https://grafana.com/docs/alloy/latest/reference/components/discovery/discovery.ec2/):

![Screenshot 2025-02-05 at 17 57 49@2x](https://github.com/user-attachments/assets/f1618c56-2d33-48e3-9827-9f7097808f12)


#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
