### PR TITLE
introduce new way of getting process name in loki source windows event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ Main (unreleased)
   - Add namespace to `connection_info` metric (@cristiangreco)
   - Added table columns parsing (@cristiagreco)
 
+- Reduce CPU usage of `loki.source.windowsevent` by up to 85% by updating the bookmark file every 10 seconds instead of after every event and by 
+  optimizing the retrieval of the process name. (@wildum)
+
 ### Bugfixes
 
 - Fix log rotation for Windows in `loki.source.file` by refactoring the component to use the runner pkg. This should also reduce CPU consumption when tailing a lot of files in a dynamic environment. (@wildum)
@@ -44,8 +47,6 @@ Main (unreleased)
 - Add livedebugging support for `otelcol.connector.*` components (@wildum)
 
 - Bump snmp_exporter and embedded modules to 0.27.0. Add support for multi-module handling by comma separation and expose argument to increase SNMP polling concurrency for `prometheus.exporter.snmp`. (@v-zhuravlev)
-
-- Reduce CPU usage of `loki.source.windowsevent` by up to 60% by updating the bookmark file every 10 seconds instead of after every event. (@wildum)
 
 - Add support for pushv1.PusherService Connect API in `pyroscope.receive_http`. (@simonswine)
 

--- a/internal/component/loki/source/windowsevent/format.go
+++ b/internal/component/loki/source/windowsevent/format.go
@@ -123,6 +123,9 @@ func formatLine(cfg *scrapeconfig.WindowsEventsTargetConfig, event win_eventlog.
 	return jsoniter.MarshalToString(structuredEvent)
 }
 
+// This function was tested via manual testing on Windows machines at scale and by changing the
+// size of the buffer to ensure that the dynamic resizing works as expected.
+// TODO: would be better to have a unit test for this (not easy to setup)
 func GetProcessName(pid uint32) (string, error) {
 	// PID 4 is always "System"
 	if pid == 4 {

--- a/internal/component/loki/source/windowsevent/target.go
+++ b/internal/component/loki/source/windowsevent/target.go
@@ -208,7 +208,7 @@ func (t *Target) renderEntries(events []win_eventlog.Event) []api.Entry {
 			entry.Labels[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
 		}
 
-		line, err := formatLine(t.cfg, event)
+		line, err := formatLine(t.cfg, event, t.logger)
 		if err != nil {
 			level.Warn(t.logger).Log("msg", "error formatting event", "err", err)
 			continue

--- a/internal/component/loki/source/windowsevent/target.go
+++ b/internal/component/loki/source/windowsevent/target.go
@@ -208,7 +208,7 @@ func (t *Target) renderEntries(events []win_eventlog.Event) []api.Entry {
 			entry.Labels[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
 		}
 
-		line, err := formatLine(t.cfg, event, t.logger)
+		line, err := formatLine(t.cfg, event)
 		if err != nil {
 			level.Warn(t.logger).Log("msg", "error formatting event", "err", err)
 			continue


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR further reduces the CPU usage of the loki.source.windows component by 70%.

The previous approach was iterating over all processes to find the one corresponding to the received event by comparing the PIDs to retrieve the process name.

The new approach uses the Windows API to query the process name directly using the PID. It also returns directly the names "System" and "Idle Process" which are guaranteed to always have the same PIDs on all Windows machines.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #2615

#### Notes to the Reviewer

The change was tested by running both the old function and the new function side by side and comparing the results with at least 1_000_000 prod events. No discrepancies were found between the two versions.
Profiles showed an improvement of more than 70% compared to the version on main.

Additional manual tests were done locally to test different types of events.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [na] Documentation added
- [na] Tests updated
- [na] Config converters updated
