### PR TITLE
Add option to merge SNMP configs (custom with embedded)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Main (unreleased)
   - Add namespace to `connection_info` metric (@cristiangreco)
   - Added table columns parsing (@cristiagreco)
 
+- Add `config_merge_strategy` in `prometheus.exporter.snmp` to optionally merge custom snmp config with embedded config instead of replacing. Useful for providing SNMP auths. (@v-zhuravlev)
+
 ### Bugfixes
 
 - Fix log rotation for Windows in `loki.source.file` by refactoring the component to use the runner pkg. This should also reduce CPU consumption when tailing a lot of files in a dynamic environment. (@wildum)

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.snmp.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.snmp.md
@@ -59,7 +59,8 @@ The `config` argument must be a YAML document as string defining which SNMP modu
 - `remote.http.LABEL.content`
 - `remote.s3.LABEL.content`
 
-Set `config_merge_strategy` to `merge` in order to add additional configuration to the embedded SNMP config. For example, if you need to add a few custom `auth` settings without regenerating the whole config.
+Set `config_merge_strategy` to `merge` in order to add additional configuration to the embedded SNMP config.
+For example, if you need to add a few custom `auth` settings without regenerating the whole configuration.
 
 The `targets` argument is an alternative to the [target][] block. This is useful when SNMP targets are supplied by another component.
 The following labels can be set to a target:

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.snmp.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.snmp.md
@@ -41,12 +41,13 @@ prometheus.exporter.snmp "LABEL" {
 The following arguments can be used to configure the exporter's behavior.
 Omitted fields take their default values.
 
-| Name          | Type                 | Description                                      | Default | Required |
-| ------------- | -------------------- | ------------------------------------------------ | ------- | -------- |
-| `config_file` | `string`             | SNMP configuration file defining custom modules. |         | no       |
-| `config`      | `string` or `secret` | SNMP configuration as inline string.             |         | no       |
-| `concurrency` | `int`                | SNMP exporter concurrency.                       |   `1`   | no       |
-| `targets`     | `list(map(string))`  | SNMP targets.                                    |         | no       |
+| Name                   | Type                 | Description                                                                                | Default  | Required |
+| -----------------------| -------------------- | -------------------------------------------------------------------------------------------| -------  | -------- |
+| `config_file`          | `string`             | SNMP configuration file defining custom modules.                                           |          | no       |
+| `config`               | `string` or `secret` | SNMP configuration as inline string.                                                       |          | no       |
+| `config_merge_strategy`| `string`             | A strategy defining how `config` or `config_file` contents merge with embedded snmp config. Can be `replace` or `merge`.|`replace `| no       |
+| `concurrency`          | `int`                | SNMP exporter concurrency.                                                                 |   `1`    | no       |
+| `targets`              | `list(map(string))`  | SNMP targets.                                                                              |          | no       |
 
 The `config_file` argument points to a YAML file defining which snmp_exporter modules to use.
 Refer to [snmp_exporter](https://github.com/prometheus/snmp_exporter/tree/{{< param "SNMP_VERSION" >}}?tab=readme-ov-file#configuration) for details on how to generate a configuration file.
@@ -57,6 +58,8 @@ The `config` argument must be a YAML document as string defining which SNMP modu
 - `local.file.LABEL.content`
 - `remote.http.LABEL.content`
 - `remote.s3.LABEL.content`
+
+Set `config_merge_strategy` to `merge` in order to add additional configuration to embedded SNMP config. For example if you need to add few custom `auth` settings without regenerating whole config.
 
 The `targets` argument is an alternative to the [target][] block. This is useful when SNMP targets are supplied by another component.
 The following labels can be set to a target:

--- a/internal/cmd/integration-tests/tests/snmp/config.alloy
+++ b/internal/cmd/integration-tests/tests/snmp/config.alloy
@@ -160,3 +160,45 @@ prometheus.remote_write "snmp_metrics3" {
   }
 }
 
+
+//This test use merge strategy to add custom auth while keep using modules from embedded snmp config
+prometheus.exporter.snmp "snmp_metrics4" {
+  config_merge_strategy = "merge"
+  config = `
+auths:
+  public_custom:
+    community: public
+    security_level: noAuthNoPriv
+    auth_protocol: MD5
+    priv_protocol: DES
+    version: 2
+`
+
+  target "t1" {
+      address     = "localhost:161"
+      module      = "system,hrDevice"
+      auth        = "public_custom"
+  }
+}
+
+prometheus.scrape "snmp_metrics4" {
+  targets    = prometheus.exporter.snmp.snmp_metrics4.targets
+  forward_to = [prometheus.remote_write.snmp_metrics4.receiver]
+  scrape_interval = "1s"
+  scrape_timeout = "500ms"
+}
+
+prometheus.remote_write "snmp_metrics4" {
+  endpoint {
+    url = "http://localhost:9009/api/v1/push"
+    metadata_config {
+        send_interval = "1s"
+    }
+    queue_config {
+        max_samples_per_send = 100
+    }
+  }
+  external_labels = {
+    test_name = "snmp_metrics4",
+  }
+}

--- a/internal/cmd/integration-tests/tests/snmp/snmp_metrics_test.go
+++ b/internal/cmd/integration-tests/tests/snmp/snmp_metrics_test.go
@@ -50,7 +50,29 @@ func TestSNMPMetrics(t *testing.T) {
 		"hrDeviceIndex",
 		"up",
 	}
+	var SNMPMetrics4 = []string{
+		"scrape_duration_seconds",
+		"scrape_samples_post_metric_relabeling",
+		"scrape_samples_scraped",
+		"scrape_series_added",
+		"snmp_packet_duration_seconds_bucket",
+		"snmp_packet_duration_seconds_count",
+		"snmp_packet_duration_seconds_sum",
+		"snmp_packet_retries_total",
+		"snmp_packets_total",
+		"snmp_request_in_flight",
+		"snmp_scrape_duration_seconds",
+		"snmp_scrape_packets_retried",
+		"snmp_scrape_packets_sent",
+		"snmp_scrape_pdus_returned",
+		"snmp_scrape_walk_duration_seconds",
+		"snmp_unexpected_pdu_type_total",
+		"sysDescr",
+		"hrDeviceIndex",
+		"up",
+	}
 	common.MimirMetricsTest(t, SNMPMetrics, []string{}, "snmp_metrics")
 	common.MimirMetricsTest(t, SNMPMetrics, []string{}, "snmp_metrics2")
 	common.MimirMetricsTest(t, SNMPMetrics3, []string{}, "snmp_metrics3")
+	common.MimirMetricsTest(t, SNMPMetrics4, []string{}, "snmp_metrics4")
 }

--- a/internal/component/prometheus/exporter/snmp/snmp.go
+++ b/internal/component/prometheus/exporter/snmp/snmp.go
@@ -132,8 +132,8 @@ func (w WalkParams) Convert() map[string]snmp_config.WalkParams {
 // DefaultArguments holds non-zero default options for Arguments when it is
 // unmarshaled from Alloy.
 var DefaultArguments = Arguments{
-	SnmpConcurrency:    1,
-	ConfigMergeStategy: "replace",
+	SnmpConcurrency:     1,
+	ConfigMergeStrategy: "replace",
 }
 
 // SetToDefault implements syntax.Defaulter.
@@ -142,13 +142,13 @@ func (a *Arguments) SetToDefault() {
 }
 
 type Arguments struct {
-	ConfigFile         string                    `alloy:"config_file,attr,optional"`
-	SnmpConcurrency    int                       `alloy:"concurrency,attr,optional"`
-	Config             alloytypes.OptionalSecret `alloy:"config,attr,optional"`
-	ConfigMergeStategy string                    `alloy:"config_merge_strategy,attr,optional"`
-	Targets            TargetBlock               `alloy:"target,block,optional"`
-	WalkParams         WalkParams                `alloy:"walk_param,block,optional"`
-	ConfigStruct       snmp_config.Config
+	ConfigFile          string                    `alloy:"config_file,attr,optional"`
+	SnmpConcurrency     int                       `alloy:"concurrency,attr,optional"`
+	Config              alloytypes.OptionalSecret `alloy:"config,attr,optional"`
+	ConfigMergeStrategy string                    `alloy:"config_merge_strategy,attr,optional"`
+	Targets             TargetBlock               `alloy:"target,block,optional"`
+	WalkParams          WalkParams                `alloy:"walk_param,block,optional"`
+	ConfigStruct        snmp_config.Config
 
 	// New way of passing targets. This allows the component to receive targets from other components.
 	TargetsList TargetsList `alloy:"targets,attr,optional"`
@@ -220,7 +220,7 @@ func (a *Arguments) UnmarshalAlloy(f func(interface{}) error) error {
 		return errors.New("config and config_file are mutually exclusive")
 	}
 
-	if a.ConfigMergeStategy != "replace" && a.ConfigMergeStategy != "merge" {
+	if a.ConfigMergeStrategy != "replace" && a.ConfigMergeStrategy != "merge" {
 		return errors.New("config_merge_strategy must be `replace` or `merge`")
 	}
 
@@ -255,7 +255,7 @@ func (a *Arguments) Convert() *snmp_exporter.Config {
 	}
 	return &snmp_exporter.Config{
 		SnmpConfigFile:          a.ConfigFile,
-		SnmpConfigMergeStrategy: a.ConfigMergeStategy,
+		SnmpConfigMergeStrategy: a.ConfigMergeStrategy,
 		SnmpConcurrency:         a.SnmpConcurrency,
 		SnmpTargets:             targets,
 		WalkParams:              a.WalkParams.Convert(),

--- a/internal/component/prometheus/exporter/snmp/snmp_test.go
+++ b/internal/component/prometheus/exporter/snmp/snmp_test.go
@@ -16,7 +16,9 @@ import (
 func TestUnmarshalAlloy(t *testing.T) {
 	alloyCfg := `
 		config_file = "modules.yml"
+		config_merge_strategy = "replace"
 		concurrency = 2
+
 		target "network_switch_1" {
 			address = "192.168.1.2"
 			module = "if_mib"
@@ -40,6 +42,7 @@ func TestUnmarshalAlloy(t *testing.T) {
 	err := syntax.Unmarshal([]byte(alloyCfg), &args)
 	require.NoError(t, err)
 	require.Equal(t, 2, args.SnmpConcurrency)
+	require.Equal(t, "replace", args.ConfigMergeStrategy)
 	require.Equal(t, "modules.yml", args.ConfigFile)
 	require.Equal(t, 2, len(args.Targets))
 

--- a/internal/converter/internal/staticconvert/internal/build/snmp_exporter.go
+++ b/internal/converter/internal/staticconvert/internal/build/snmp_exporter.go
@@ -101,11 +101,12 @@ func toSnmpExporterV2(config *snmp_exporter_v2.Config) *snmp.Arguments {
 	}
 
 	return &snmp.Arguments{
-		ConfigFile:      config.SnmpConfigFile,
-		Config:          alloytypes.OptionalSecret{},
-		SnmpConcurrency: config.SnmpConcurrency,
-		TargetsList:     targets,
-		WalkParams:      walkParams,
+		ConfigFile:          config.SnmpConfigFile,
+		Config:              alloytypes.OptionalSecret{},
+		ConfigMergeStrategy: config.SnmpConfigMergeStrategy,
+		SnmpConcurrency:     config.SnmpConcurrency,
+		TargetsList:         targets,
+		WalkParams:          walkParams,
 		ConfigStruct: snmp_config.Config{
 			Auths:   config.SnmpConfig.Auths,
 			Modules: config.SnmpConfig.Modules,

--- a/internal/converter/internal/staticconvert/internal/build/snmp_exporter.go
+++ b/internal/converter/internal/staticconvert/internal/build/snmp_exporter.go
@@ -50,11 +50,12 @@ func toSnmpExporter(config *snmp_exporter.Config) *snmp.Arguments {
 	}
 
 	return &snmp.Arguments{
-		ConfigFile:      config.SnmpConfigFile,
-		Config:          alloytypes.OptionalSecret{},
-		SnmpConcurrency: config.SnmpConcurrency,
-		TargetsList:     targets,
-		WalkParams:      walkParams,
+		ConfigFile:         config.SnmpConfigFile,
+		Config:             alloytypes.OptionalSecret{},
+		ConfigMergeStategy: config.SnmpConfigMergeStrategy,
+		SnmpConcurrency:    config.SnmpConcurrency,
+		TargetsList:        targets,
+		WalkParams:         walkParams,
 		ConfigStruct: snmp_config.Config{
 			Auths:   config.SnmpConfig.Auths,
 			Modules: config.SnmpConfig.Modules,

--- a/internal/converter/internal/staticconvert/internal/build/snmp_exporter.go
+++ b/internal/converter/internal/staticconvert/internal/build/snmp_exporter.go
@@ -50,12 +50,12 @@ func toSnmpExporter(config *snmp_exporter.Config) *snmp.Arguments {
 	}
 
 	return &snmp.Arguments{
-		ConfigFile:         config.SnmpConfigFile,
-		Config:             alloytypes.OptionalSecret{},
-		ConfigMergeStategy: config.SnmpConfigMergeStrategy,
-		SnmpConcurrency:    config.SnmpConcurrency,
-		TargetsList:        targets,
-		WalkParams:         walkParams,
+		ConfigFile:          config.SnmpConfigFile,
+		Config:              alloytypes.OptionalSecret{},
+		ConfigMergeStrategy: config.SnmpConfigMergeStrategy,
+		SnmpConcurrency:     config.SnmpConcurrency,
+		TargetsList:         targets,
+		WalkParams:          walkParams,
 		ConfigStruct: snmp_config.Config{
 			Auths:   config.SnmpConfig.Auths,
 			Modules: config.SnmpConfig.Modules,

--- a/internal/static/integrations/snmp_exporter/snmp_exporter.go
+++ b/internal/static/integrations/snmp_exporter/snmp_exporter.go
@@ -4,6 +4,7 @@ package snmp_exporter
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/url"
 
@@ -19,11 +20,12 @@ import (
 
 // DefaultConfig holds the default settings for the snmp_exporter integration.
 var DefaultConfig = Config{
-	WalkParams:      make(map[string]snmp_config.WalkParams),
-	SnmpConfigFile:  "",
-	SnmpConcurrency: 1,
-	SnmpTargets:     make([]SNMPTarget, 0),
-	SnmpConfig:      snmp_config.Config{},
+	WalkParams:              make(map[string]snmp_config.WalkParams),
+	SnmpConfigFile:          "",
+	SnmpConfigMergeStrategy: "replace",
+	SnmpConcurrency:         1,
+	SnmpTargets:             make([]SNMPTarget, 0),
+	SnmpConfig:              snmp_config.Config{},
 }
 
 // SNMPTarget defines a target device to be used by the integration.
@@ -39,11 +41,12 @@ type SNMPTarget struct {
 
 // Config configures the SNMP integration.
 type Config struct {
-	WalkParams      map[string]snmp_config.WalkParams `yaml:"walk_params,omitempty"`
-	SnmpConfigFile  string                            `yaml:"config_file,omitempty"`
-	SnmpConcurrency int                               `yaml:"concurrency,omitempty"`
-	SnmpTargets     []SNMPTarget                      `yaml:"snmp_targets"`
-	SnmpConfig      snmp_config.Config                `yaml:"snmp_config,omitempty"`
+	WalkParams              map[string]snmp_config.WalkParams `yaml:"walk_params,omitempty"`
+	SnmpConfigFile          string                            `yaml:"config_file,omitempty"`
+	SnmpConfigMergeStrategy string                            `yaml:"config_merge_strategy,omitempty"`
+	SnmpConcurrency         int                               `yaml:"concurrency,omitempty"`
+	SnmpTargets             []SNMPTarget                      `yaml:"snmp_targets"`
+	SnmpConfig              snmp_config.Config                `yaml:"snmp_config,omitempty"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler for Config.
@@ -75,7 +78,7 @@ func init() {
 
 // New creates a new snmp_exporter integration
 func New(log log.Logger, c *Config) (integrations.Integration, error) {
-	snmpCfg, err := LoadSNMPConfig(c.SnmpConfigFile, &c.SnmpConfig)
+	snmpCfg, err := LoadSNMPConfig(c.SnmpConfigFile, &c.SnmpConfig, c.SnmpConfigMergeStrategy)
 	if err != nil {
 		return nil, err
 	}
@@ -101,22 +104,47 @@ func New(log log.Logger, c *Config) (integrations.Integration, error) {
 
 // LoadSNMPConfig loads the SNMP configuration from the given file. If the file is empty, it will
 // load the embedded configuration.
-func LoadSNMPConfig(snmpConfigFile string, snmpCfg *snmp_config.Config) (*snmp_config.Config, error) {
+func LoadSNMPConfig(snmpConfigFile string, customSnmpCfg *snmp_config.Config, strategy string) (*snmp_config.Config, error) {
 	var err error
-	if snmpConfigFile != "" {
-		snmpCfg, err = snmp_config.LoadFile([]string{snmpConfigFile}, false)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load snmp config from file %v: %w", snmpConfigFile, err)
-		}
-	} else {
-		if len(snmpCfg.Modules) == 0 && len(snmpCfg.Auths) == 0 { // If the user didn't specify a config, load the embedded config.
-			snmpCfg, err = snmp_common.LoadEmbeddedConfig()
+
+	if strategy == "replace" {
+		if snmpConfigFile != "" {
+			customSnmpCfg, err = snmp_config.LoadFile([]string{snmpConfigFile}, false)
 			if err != nil {
-				return nil, fmt.Errorf("failed to load embedded snmp config: %w", err)
+				return nil, fmt.Errorf("failed to load snmp config from file %v: %w", snmpConfigFile, err)
+			}
+		} else {
+			if len(customSnmpCfg.Modules) == 0 && len(customSnmpCfg.Auths) == 0 { // If the user didn't specify a config, load the embedded config.
+				customSnmpCfg, err = snmp_common.LoadEmbeddedConfig()
+				if err != nil {
+					return nil, fmt.Errorf("failed to load embedded snmp config: %w", err)
+				}
 			}
 		}
+	} else if strategy == "merge" {
+		var finalCfg *snmp_config.Config
+		finalCfg, err = snmp_common.LoadEmbeddedConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to load embedded snmp config: %w", err)
+		}
+
+		if snmpConfigFile != "" {
+			customSnmpCfg, err = snmp_config.LoadFile([]string{snmpConfigFile}, false)
+			if err != nil {
+				return nil, fmt.Errorf("failed to load snmp config from file %v: %w", snmpConfigFile, err)
+			}
+		}
+
+		if len(customSnmpCfg.Auths) > 0 {
+			maps.Copy(finalCfg.Auths, customSnmpCfg.Auths)
+		}
+		if len(customSnmpCfg.Modules) > 0 {
+			maps.Copy(finalCfg.Modules, customSnmpCfg.Modules)
+		}
+
+		return finalCfg, nil
 	}
-	return snmpCfg, nil
+	return customSnmpCfg, nil
 }
 
 func NewSNMPMetrics(reg prometheus.Registerer) collector.Metrics {

--- a/internal/static/integrations/snmp_exporter/snmp_exporter.go
+++ b/internal/static/integrations/snmp_exporter/snmp_exporter.go
@@ -143,6 +143,8 @@ func LoadSNMPConfig(snmpConfigFile string, customSnmpCfg *snmp_config.Config, st
 		}
 
 		return finalCfg, nil
+	} else {
+		return nil, fmt.Errorf("unsupported snmp config merge strategy is used: '%s'", strategy)
 	}
 	return customSnmpCfg, nil
 }

--- a/internal/static/integrations/snmp_exporter/snmp_exporter_test.go
+++ b/internal/static/integrations/snmp_exporter/snmp_exporter_test.go
@@ -32,6 +32,14 @@ func TestLoadSNMPConfig(t *testing.T) {
 			cfg:                Config{SnmpTargets: []SNMPTarget{{Name: "test", Target: "localhost"}}},
 			expectedNumModules: 39,
 		},
+		{
+			name: "merging embedded config and provided",
+			cfg: Config{
+				SnmpConfig:              snmp_config.Config{Modules: map[string]*snmp_config.Module{"if_mib_custom": {Walk: []string{"1.3.6.1.2.1.2"}}}},
+				SnmpConfigMergeStrategy: "merge",
+				SnmpTargets:             []SNMPTarget{{Name: "test", Target: "localhost"}}},
+			expectedNumModules: 40,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/static/integrations/snmp_exporter/snmp_exporter_test.go
+++ b/internal/static/integrations/snmp_exporter/snmp_exporter_test.go
@@ -19,23 +19,29 @@ func TestLoadSNMPConfig(t *testing.T) {
 		expectedNumAuths   int
 	}{
 		{
-			name:               "passing a config file",
-			cfg:                Config{SnmpConfigFile: "common/snmp.yml", SnmpTargets: []SNMPTarget{{Name: "test", Target: "localhost"}}},
+			name: "passing a config file",
+			cfg: Config{
+				SnmpConfigFile:          "common/snmp.yml",
+				SnmpConfigMergeStrategy: "replace",
+				SnmpTargets:             []SNMPTarget{{Name: "test", Target: "localhost"}}},
 			expectedNumModules: embeddedModulesCount,
 			expectedNumAuths:   embeddedAuthCount,
 		},
 		{
 			name: "passing a snmp config",
 			cfg: Config{
-				SnmpConfig:  snmp_config.Config{Modules: map[string]*snmp_config.Module{"if_mib": {Walk: []string{"1.3.6.1.2.1.2"}}}},
-				SnmpTargets: []SNMPTarget{{Name: "test", Target: "localhost"}},
+				SnmpConfig:              snmp_config.Config{Modules: map[string]*snmp_config.Module{"if_mib": {Walk: []string{"1.3.6.1.2.1.2"}}}},
+				SnmpConfigMergeStrategy: "replace",
+				SnmpTargets:             []SNMPTarget{{Name: "test", Target: "localhost"}},
 			},
 			expectedNumModules: 1,
 			expectedNumAuths:   0,
 		},
 		{
-			name:               "using embedded config",
-			cfg:                Config{SnmpTargets: []SNMPTarget{{Name: "test", Target: "localhost"}}},
+			name: "using embedded config",
+			cfg: Config{
+				SnmpConfigMergeStrategy: "replace",
+				SnmpTargets:             []SNMPTarget{{Name: "test", Target: "localhost"}}},
 			expectedNumModules: embeddedModulesCount,
 			expectedNumAuths:   embeddedAuthCount,
 		},

--- a/internal/static/integrations/snmp_exporter/snmp_exporter_test.go
+++ b/internal/static/integrations/snmp_exporter/snmp_exporter_test.go
@@ -7,17 +7,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const embeddedModulesCount = 39
+const embeddedAuthCount = 2
+
 // TestLoadSNMPConfig tests the LoadSNMPConfig function covers all the cases.
 func TestLoadSNMPConfig(t *testing.T) {
 	tests := []struct {
 		name               string
 		cfg                Config
 		expectedNumModules int
+		expectedNumAuths   int
 	}{
 		{
 			name:               "passing a config file",
 			cfg:                Config{SnmpConfigFile: "common/snmp.yml", SnmpTargets: []SNMPTarget{{Name: "test", Target: "localhost"}}},
-			expectedNumModules: 39,
+			expectedNumModules: embeddedModulesCount,
+			expectedNumAuths:   embeddedAuthCount,
 		},
 		{
 			name: "passing a snmp config",
@@ -26,19 +31,76 @@ func TestLoadSNMPConfig(t *testing.T) {
 				SnmpTargets: []SNMPTarget{{Name: "test", Target: "localhost"}},
 			},
 			expectedNumModules: 1,
+			expectedNumAuths:   0,
 		},
 		{
 			name:               "using embedded config",
 			cfg:                Config{SnmpTargets: []SNMPTarget{{Name: "test", Target: "localhost"}}},
-			expectedNumModules: 39,
+			expectedNumModules: embeddedModulesCount,
+			expectedNumAuths:   embeddedAuthCount,
 		},
 		{
-			name: "merging embedded config and provided",
+			name: "merging embedded config and custom",
 			cfg: Config{
 				SnmpConfig:              snmp_config.Config{Modules: map[string]*snmp_config.Module{"if_mib_custom": {Walk: []string{"1.3.6.1.2.1.2"}}}},
 				SnmpConfigMergeStrategy: "merge",
 				SnmpTargets:             []SNMPTarget{{Name: "test", Target: "localhost"}}},
-			expectedNumModules: 40,
+			expectedNumModules: embeddedModulesCount + 1,
+			expectedNumAuths:   embeddedAuthCount,
+		},
+		{
+			name: "merging embedded config and custom (overriding existing if_mib module)",
+			cfg: Config{
+				SnmpConfig:              snmp_config.Config{Modules: map[string]*snmp_config.Module{"if_mib": {Walk: []string{"1.3.6.1.2.1.2"}}}},
+				SnmpConfigMergeStrategy: "merge",
+				SnmpTargets:             []SNMPTarget{{Name: "test", Target: "localhost"}}},
+			expectedNumModules: embeddedModulesCount,
+			expectedNumAuths:   embeddedAuthCount,
+		},
+		{
+			name: "merging embedded config and custom (add auth)",
+			cfg: Config{
+				SnmpConfig:              snmp_config.Config{Auths: map[string]*snmp_config.Auth{"private": {Community: "private", Version: 2}}},
+				SnmpConfigMergeStrategy: "merge",
+				SnmpTargets:             []SNMPTarget{{Name: "test", Target: "localhost"}}},
+			expectedNumModules: embeddedModulesCount,
+			expectedNumAuths:   embeddedAuthCount + 1,
+		},
+		{
+			name: "merging embedded config and custom (override auth)",
+			cfg: Config{
+				SnmpConfig:              snmp_config.Config{Auths: map[string]*snmp_config.Auth{"public_v2": {Community: "private", Version: 2}}},
+				SnmpConfigMergeStrategy: "merge",
+				SnmpTargets:             []SNMPTarget{{Name: "test", Target: "localhost"}}},
+			expectedNumModules: embeddedModulesCount,
+			expectedNumAuths:   embeddedAuthCount,
+		},
+		{
+			name: "replacing embedded config with custom (add auth)",
+			cfg: Config{
+				SnmpConfig:              snmp_config.Config{Modules: map[string]*snmp_config.Module{"if_mib": {Walk: []string{"1.3.6.1.2.1.2"}}}},
+				SnmpConfigMergeStrategy: "replace",
+				SnmpTargets:             []SNMPTarget{{Name: "test", Target: "localhost"}}},
+			expectedNumModules: 1,
+			expectedNumAuths:   0,
+		},
+		{
+			name: "replacing embedded config with custom (add module)",
+			cfg: Config{
+				SnmpConfig:              snmp_config.Config{Auths: map[string]*snmp_config.Auth{"public_v2": {Community: "private", Version: 2}}},
+				SnmpConfigMergeStrategy: "replace",
+				SnmpTargets:             []SNMPTarget{{Name: "test", Target: "localhost"}}},
+			expectedNumModules: 0,
+			expectedNumAuths:   1,
+		},
+		{
+			name: "merging embedded config and custom (empty config)",
+			cfg: Config{
+				SnmpConfig:              snmp_config.Config{},
+				SnmpConfigMergeStrategy: "merge",
+				SnmpTargets:             []SNMPTarget{{Name: "test", Target: "localhost"}}},
+			expectedNumModules: embeddedModulesCount,
+			expectedNumAuths:   embeddedAuthCount,
 		},
 	}
 	for _, tt := range tests {
@@ -47,6 +109,7 @@ func TestLoadSNMPConfig(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Equal(t, tt.expectedNumModules, len(cfg.Modules))
+			require.Equal(t, tt.expectedNumAuths, len(cfg.Auths))
 		})
 	}
 }

--- a/internal/static/integrations/snmp_exporter/snmp_exporter_test.go
+++ b/internal/static/integrations/snmp_exporter/snmp_exporter_test.go
@@ -35,7 +35,7 @@ func TestLoadSNMPConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg, err := LoadSNMPConfig(tt.cfg.SnmpConfigFile, &tt.cfg.SnmpConfig)
+			cfg, err := LoadSNMPConfig(tt.cfg.SnmpConfigFile, &tt.cfg.SnmpConfig, tt.cfg.SnmpConfigMergeStrategy)
 			require.NoError(t, err)
 
 			require.Equal(t, tt.expectedNumModules, len(cfg.Modules))

--- a/internal/static/integrations/snmp_exporter/snmp_exporter_test.go
+++ b/internal/static/integrations/snmp_exporter/snmp_exporter_test.go
@@ -82,7 +82,7 @@ func TestLoadSNMPConfig(t *testing.T) {
 			expectedNumAuths:   embeddedAuthCount,
 		},
 		{
-			name: "replacing embedded config with custom (add auth)",
+			name: "replacing embedded config with custom (add module)",
 			cfg: Config{
 				SnmpConfig:              snmp_config.Config{Modules: map[string]*snmp_config.Module{"if_mib": {Walk: []string{"1.3.6.1.2.1.2"}}}},
 				SnmpConfigMergeStrategy: "replace",

--- a/internal/static/integrations/snmp_exporter/snmp_exporter_test.go
+++ b/internal/static/integrations/snmp_exporter/snmp_exporter_test.go
@@ -91,7 +91,7 @@ func TestLoadSNMPConfig(t *testing.T) {
 			expectedNumAuths:   0,
 		},
 		{
-			name: "replacing embedded config with custom (add module)",
+			name: "replacing embedded config with custom (add auth)",
 			cfg: Config{
 				SnmpConfig:              snmp_config.Config{Auths: map[string]*snmp_config.Auth{"public_v2": {Community: "private", Version: 2}}},
 				SnmpConfigMergeStrategy: "replace",

--- a/internal/static/integrations/v2/snmp_exporter/snmp_exporter.go
+++ b/internal/static/integrations/v2/snmp_exporter/snmp_exporter.go
@@ -46,7 +46,7 @@ func (c *Config) Identifier(globals integrations_v2.Globals) (string, error) {
 
 // NewIntegration creates a new SNMP integration.
 func (c *Config) NewIntegration(log log.Logger, globals integrations_v2.Globals) (integrations_v2.Integration, error) {
-	// 'replace'' corresponds to classic snmp integration behavior
+
 	snmpCfg, err := snmp_exporter.LoadSNMPConfig(c.SnmpConfigFile, &c.SnmpConfig, c.SnmpConfigMergeStrategy)
 	if err != nil {
 		return nil, err

--- a/internal/static/integrations/v2/snmp_exporter/snmp_exporter.go
+++ b/internal/static/integrations/v2/snmp_exporter/snmp_exporter.go
@@ -11,19 +11,21 @@ import (
 
 // DefaultConfig holds the default settings for the snmp_exporter integration.
 var DefaultConfig = Config{
-	WalkParams:      make(map[string]snmp_config.WalkParams),
-	SnmpConfigFile:  "",
-	SnmpConcurrency: 1,
+	WalkParams:              make(map[string]snmp_config.WalkParams),
+	SnmpConfigFile:          "",
+	SnmpConfigMergeStrategy: "replace",
+	SnmpConcurrency:         1,
 }
 
 // Config configures the SNMP integration.
 type Config struct {
-	WalkParams      map[string]snmp_config.WalkParams `yaml:"walk_params,omitempty"`
-	SnmpConfigFile  string                            `yaml:"config_file,omitempty"`
-	SnmpConcurrency int                               `yaml:"concurrency,omitempty"`
-	SnmpTargets     []snmp_exporter.SNMPTarget        `yaml:"snmp_targets"`
-	SnmpConfig      snmp_config.Config                `yaml:"snmp_config,omitempty"`
-	Common          common.MetricsConfig              `yaml:",inline"`
+	WalkParams              map[string]snmp_config.WalkParams `yaml:"walk_params,omitempty"`
+	SnmpConfigFile          string                            `yaml:"config_file,omitempty"`
+	SnmpConfigMergeStrategy string                            `yaml:"config_merge_strategy,omitempty"`
+	SnmpConcurrency         int                               `yaml:"concurrency,omitempty"`
+	SnmpTargets             []snmp_exporter.SNMPTarget        `yaml:"snmp_targets"`
+	SnmpConfig              snmp_config.Config                `yaml:"snmp_config,omitempty"`
+	Common                  common.MetricsConfig              `yaml:",inline"`
 
 	globals integrations_v2.Globals
 }
@@ -45,7 +47,7 @@ func (c *Config) Identifier(globals integrations_v2.Globals) (string, error) {
 // NewIntegration creates a new SNMP integration.
 func (c *Config) NewIntegration(log log.Logger, globals integrations_v2.Globals) (integrations_v2.Integration, error) {
 	// 'replace'' corresponds to classic snmp integration behavior
-	snmpCfg, err := snmp_exporter.LoadSNMPConfig(c.SnmpConfigFile, &c.SnmpConfig, "replace")
+	snmpCfg, err := snmp_exporter.LoadSNMPConfig(c.SnmpConfigFile, &c.SnmpConfig, c.SnmpConfigMergeStrategy)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/static/integrations/v2/snmp_exporter/snmp_exporter.go
+++ b/internal/static/integrations/v2/snmp_exporter/snmp_exporter.go
@@ -44,7 +44,8 @@ func (c *Config) Identifier(globals integrations_v2.Globals) (string, error) {
 
 // NewIntegration creates a new SNMP integration.
 func (c *Config) NewIntegration(log log.Logger, globals integrations_v2.Globals) (integrations_v2.Integration, error) {
-	snmpCfg, err := snmp_exporter.LoadSNMPConfig(c.SnmpConfigFile, &c.SnmpConfig)
+	// 'replace'' corresponds to classic snmp integration behavior
+	snmpCfg, err := snmp_exporter.LoadSNMPConfig(c.SnmpConfigFile, &c.SnmpConfig, "replace")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION


#### PR Description

This PR adds `config_merge_strategy` in `prometheus.exporter.snmp` to optionally merge custom snmp config with embedded config instead of replacing. Useful for providing SNMP auths.

#### Which issue(s) this PR fixes

Fixes #2493

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated
