### PR TITLE
use GAR instead of GCR for updater image

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -530,7 +530,7 @@ depends_on:
 - Publish Linux alloy-devel container
 - Publish Linux alloy-devel-boringcrypto container
 image_pull_secrets:
-- dockerconfigjson
+- dockerconfigjson_gar
 kind: pipeline
 name: Deploy to deployment_tools
 platform:
@@ -543,7 +543,7 @@ steps:
   - echo "grafana/alloy-dev:$(bash ./tools/image-tag-docker)" > .image-tag
   image: alpine
   name: Create .image-tag
-- image: us.gcr.io/kubernetes-dev/drone/plugins/updater
+- image: us-docker.pkg.dev/grafanalabs-global/docker-deployment-tools-prod/updater
   name: Update deployment_tools
   settings:
     config_json: |
@@ -684,6 +684,12 @@ get:
   path: secret/data/common/gcr
 kind: secret
 name: dockerconfigjson
+---
+get:
+  name: .dockerconfigjson
+  path: secret/data/common/gar
+kind: secret
+name: dockerconfigjson_gar
 ---
 get:
   name: .dockerconfigjson

--- a/.drone/pipelines/publish.jsonnet
+++ b/.drone/pipelines/publish.jsonnet
@@ -183,7 +183,7 @@ linux_containers_jobs + windows_containers_jobs + [
     trigger: {
       ref: ['refs/heads/main'],
     },
-    image_pull_secrets: ['dockerconfigjson'],
+    image_pull_secrets: ['dockerconfigjson_gar'],
     steps: [
       {
         name: 'Create .image-tag',
@@ -196,7 +196,7 @@ linux_containers_jobs + windows_containers_jobs + [
       },
       {
         name: 'Update deployment_tools',
-        image: 'us.gcr.io/kubernetes-dev/drone/plugins/updater',
+        image: 'us-docker.pkg.dev/grafanalabs-global/docker-deployment-tools-prod/updater',
         settings: {
           config_json: |||
             {

--- a/.drone/util/secrets.jsonnet
+++ b/.drone/util/secrets.jsonnet
@@ -11,6 +11,7 @@ local newSecret(name) = {
 
 {
   dockerconfigjson: newSecret('dockerconfigjson').getFrom(path='secret/data/common/gcr', name='.dockerconfigjson'),
+  dockerconfigjson_gar: newSecret('dockerconfigjson_gar').getFrom(path='secret/data/common/gar', name='.dockerconfigjson'),
   gcr_admin: newSecret('gcr_admin').getFrom(path='infra/data/ci/gcr-admin', name='.dockerconfigjson'),
 
   // Agent Github App


### PR DESCRIPTION
- GCR is deprecated and the updater image stored there is no longer being updated
- Updated image URL to GAR version

See https://github.com/grafana/deployment_tools/issues/197258 and https://github.com/grafana/deployment_tools/issues/134736 for more information.