### PR TITLE
Apply linting rules to mimir.* component docs

### DIFF
--- a/docs/sources/reference/components/remote/_index.md
+++ b/docs/sources/reference/components/remote/_index.md
@@ -5,7 +5,7 @@ title: remote
 weight: 100
 ---
 
-# remote
+# `remote`
 
 This section contains reference documentation for the `remote` components.
 

--- a/docs/sources/reference/components/remote/remote.http.md
+++ b/docs/sources/reference/components/remote/remote.http.md
@@ -3,39 +3,41 @@ canonical: https://grafana.com/docs/alloy/latest/reference/components/remote/rem
 aliases:
   - ../remote.http/ # /docs/alloy/latest/reference/components/remote.http/
 description: Learn about remote.http
+labels:
+  stage: general-availability
 title: remote.http
 ---
 
-# remote.http
+# `remote.http`
 
 `remote.http` exposes the response body of a URL to other components.
 The URL is polled for changes so that the most recent content is always available.
 
 The most common use of `remote.http` is to load discovery targets from an HTTP server.
 
-Multiple `remote.http` components can be specified by giving them different labels.
+You can specify multiple `remote.http` components by giving them different labels.
 
 ## Usage
 
 ```alloy
-remote.http "LABEL" {
-  url = "URL_TO_POLL"
+remote.http "<LABEL>" {
+  url = "<URL_TO_POLL>"
 }
 ```
 
 ## Arguments
 
-The following arguments are supported:
+You can use the following arguments with `remote.http`:
 
-Name             | Type          | Description                                              | Default | Required
------------------|---------------|----------------------------------------------------------|---------|---------
-`url`            | `string`      | URL to poll.                                             |         | yes
-`method`         | `string`      | Define HTTP method for the request                       | `"GET"` | no
-`headers`        | `map(string)` | Custom headers for the request.                          | `{}`    | no
-`body`           | `string`      | The request body.                                        | `""`    | no
-`poll_frequency` | `duration`    | Frequency to poll the URL.                               | `"1m"`  | no
-`poll_timeout`   | `duration`    | Timeout when polling the URL.                            | `"10s"` | no
-`is_secret`      | `bool`        | Whether the response body should be treated as a secret. | false   | no
+| Name             | Type          | Description                                                  | Default | Required |
+| ---------------- | ------------- | ------------------------------------------------------------ | ------- | -------- |
+| `url`            | `string`      | URL to poll.                                                 |         | yes      |
+| `body`           | `string`      | The request body.                                            | `""`    | no       |
+| `headers`        | `map(string)` | Custom headers for the request.                              | `{}`    | no       |
+| `is_secret`      | `bool`        | Whether the response body should be treated as a [secret][]. | false   | no       |
+| `method`         | `string`      | Define HTTP method for the request                           | `"GET"` | no       |
+| `poll_frequency` | `duration`    | Frequency to poll the URL.                                   | `"1m"`  | no       |
+| `poll_timeout`   | `duration`    | Timeout when polling the URL.                                | `"10s"` | no       |
 
 When `remote.http` performs a poll operation, an HTTP `GET` request is made against the URL specified by the `url` argument.
 A poll is triggered by the following:
@@ -52,51 +54,51 @@ After a successful poll, the response body from the URL is exported.
 
 ## Blocks
 
-The following blocks are supported inside the definition of `remote.http`:
+You can use the following blocks with `remote.http`:
 
-Hierarchy                    | Block             | Description                                              | Required
------------------------------|-------------------|----------------------------------------------------------|---------
-client                       | [client][]        | HTTP client settings when connecting to the endpoint.    | no
-client > basic_auth          | [basic_auth][]    | Configure basic_auth for authenticating to the endpoint. | no
-client > authorization       | [authorization][] | Configure generic authorization to the endpoint.         | no
-client > oauth2              | [oauth2][]        | Configure OAuth2 for authenticating to the endpoint.     | no
-client > oauth2 > tls_config | [tls_config][]    | Configure TLS settings for connecting to the endpoint.   | no
-client > tls_config          | [tls_config][]    | Configure TLS settings for connecting to the endpoint.   | no
+| Block                                            | Description                                                | Required |
+| ------------------------------------------------ | ---------------------------------------------------------- | -------- |
+| [`client`][client]                               | HTTP client settings when connecting to the endpoint.      | no       |
+| `client` > [`authorization`][authorization]      | Configure generic authorization to the endpoint.           | no       |
+| `client` > [`basic_auth`][basic_auth]            | Configure `basic_auth` for authenticating to the endpoint. | no       |
+| `client` > [`oauth2`][oauth2]                    | Configure OAuth 2.0 for authenticating to the endpoint.    | no       |
+| `client` > `oauth2` > [`tls_config`][tls_config] | Configure TLS settings for connecting to the endpoint.     | no       |
+| `client` > [`tls_config`][tls_config]            | Configure TLS settings for connecting to the endpoint.     | no       |
 
-The `>` symbol indicates deeper levels of nesting.
-For example, `client > basic_auth` refers to an `basic_auth` block defined inside a `client` block.
+The > symbol indicates deeper levels of nesting.
+For example, `client` > `basic_auth` refers to an `basic_auth` block defined inside a `client` block.
 
-[client]: #client-block
-[basic_auth]: #basic_auth-block
-[authorization]: #authorization-block
-[oauth2]: #oauth2-block
-[tls_config]: #tls_config-block
+[client]: #client
+[authorization]: #authorization
+[basic_auth]: #basic_auth
+[oauth2]: #oauth2
+[tls_config]: #tls_config
 
-### client block
+### `client`
 
 The `client` block configures settings used to connect to the HTTP server.
 
 {{< docs/shared lookup="reference/components/http-client-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
-### basic_auth block
-
-The `basic_auth` block configures basic authentication to use when polling the configured URL.
-
-{{< docs/shared lookup="reference/components/basic-auth-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
-
-### authorization block
+### `authorization`
 
 The `authorization` block configures custom authorization to use when polling the configured URL.
 
 {{< docs/shared lookup="reference/components/authorization-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
-### oauth2 block
+### `basic_auth`
+
+The `basic_auth` block configures basic authentication to use when polling the configured URL.
+
+{{< docs/shared lookup="reference/components/basic-auth-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `oauth2`
 
 The `oauth2` block configures OAuth2 authorization to use when polling the configured URL.
 
 {{< docs/shared lookup="reference/components/oauth2-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
-### tls_config block
+### `tls_config`
 
 The `tls_config` block configures TLS settings for connecting to HTTPS servers.
 
@@ -106,9 +108,9 @@ The `tls_config` block configures TLS settings for connecting to HTTPS servers.
 
 The following field is exported and can be referenced by other components:
 
-Name      | Type                 | Description               | Default | Required
-----------|----------------------|---------------------------|---------|---------
-`content` | `string` or `secret` | The contents of the file. |         | no
+| Name      | Type                 | Description               | Default | Required |
+| --------- | -------------------- | ------------------------- | ------- | -------- |
+| `content` | `string` or `secret` | The contents of the file. |         | no       |
 
 If the `is_secret` argument was `true`, `content` is a secret type.
 

--- a/docs/sources/reference/components/remote/remote.kubernetes.configmap.md
+++ b/docs/sources/reference/components/remote/remote.kubernetes.configmap.md
@@ -69,56 +69,56 @@ For example, `client` > `basic_auth` refers to a `basic_auth` block defined insi
 ### `client`
 
 The `client` block configures the Kubernetes client used to discover Probes.
-If the `client` block isn't provided, the default in-cluster configuration with the service account of the running {{< param "PRODUCT_NAME" >}} pod is used.
+If the `client` block isn't provided, the default in-cluster configuration with the service account of the running {{< param "PRODUCT_NAME" >}} Pod is used.
 
 The following arguments are supported:
 
-Name                     | Type                | Description                                                   | Default | Required
--------------------------|---------------------|---------------------------------------------------------------|---------|---------
-`api_server`             | `string`            | URL of the Kubernetes API server.                             |         | no
-`kubeconfig_file`        | `string`            | Path of the `kubeconfig` file to use for connecting to Kubernetes. |    | no
-`bearer_token_file`      | `string`            | File containing a bearer token to authenticate with.          |         | no
-`bearer_token`           | `secret`            | Bearer token to authenticate with.                            |         | no
-`enable_http2`           | `bool`              | Whether HTTP2 is supported for requests.                      | `true`  | no
-`follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.  | `true`  | no
-`proxy_url`              | `string`            | HTTP proxy to send requests through.                          |         | no
-`no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. | | no
-`proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.         | `false` | no
-`proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests. |         | no
+| Name                     | Type                | Description                                                                                      | Default | Required |
+| ------------------------ | ------------------- | ------------------------------------------------------------------------------------------------ | ------- | -------- |
+| `api_server`             | `string`            | URL of the Kubernetes API server.                                                                |         | no       |
+| `bearer_token_file`      | `string`            | File containing a bearer token to authenticate with.                                             |         | no       |
+| `bearer_token`           | `secret`            | Bearer token to authenticate with.                                                               |         | no       |
+| `enable_http2`           | `bool`              | Whether HTTP2 is supported for requests.                                                         | `true`  | no       |
+| `follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.                                     | `true`  | no       |
+| `kubeconfig_file`        | `string`            | Path of the `kubeconfig` file to use for connecting to Kubernetes.                               |         | no       |
+| `no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. |         | no       |
+| `proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests.                                    |         | no       |
+| `proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.                                            | `false` | no       |
+| `proxy_url`              | `string`            | HTTP proxy to send requests through.                                                             |         | no       |
 
  At most, one of the following can be provided:
- - [`bearer_token` argument][client].
- - [`bearer_token_file` argument][client].
- - [`basic_auth` block][basic_auth].
- - [`authorization` block][authorization].
- - [`oauth2` block][oauth2].
+
+* [`authorization`][authorization] block
+* [`basic_auth`][basic_auth] block
+* [`bearer_token_file`][client] argument
+* [`bearer_token`][client] argument
+* [`oauth2`][oauth2] block
 
 {{< docs/shared lookup="reference/components/http-client-proxy-config-description.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
-### basic_auth block
-
-{{< docs/shared lookup="reference/components/basic-auth-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
-
-### authorization block
+### `authorization`
 
 {{< docs/shared lookup="reference/components/authorization-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
-### oauth2 block
+### `basic_auth`
+
+{{< docs/shared lookup="reference/components/basic-auth-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `oauth2`
 
 {{< docs/shared lookup="reference/components/oauth2-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
-### tls_config block
+### `tls_config`
 
 {{< docs/shared lookup="reference/components/tls-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
-
 
 ## Exported fields
 
 The following fields are exported and can be referenced by other components:
 
-Name   | Type          | Description
--------|---------------|--------------------------------------------------
-`data` | `map(string)` | Data from the ConfigMap obtained from Kubernetes.
+| Name   | Type          | Description                                       |
+| ------ | ------------- | ------------------------------------------------- |
+| `data` | `map(string)` | Data from the ConfigMap obtained from Kubernetes. |
 
 The `data` field contains a mapping from field names to values.
 
@@ -128,11 +128,11 @@ Instances of `remote.kubernetes.configmap` report as healthy if the most recent 
 
 ## Debug information
 
-`remote.kubernetes.configmap` does not expose any component-specific debug information.
+`remote.kubernetes.configmap` doesn't expose any component-specific debug information.
 
 ## Debug metrics
 
-`remote.kubernetes.configmap` does not expose any component-specific debug metrics.
+`remote.kubernetes.configmap` doesn't expose any component-specific debug metrics.
 
 ## Example
 

--- a/docs/sources/reference/components/remote/remote.kubernetes.configmap.md
+++ b/docs/sources/reference/components/remote/remote.kubernetes.configmap.md
@@ -3,34 +3,36 @@ canonical: https://grafana.com/docs/alloy/latest/reference/components/remote/rem
 aliases:
   - ../remote.kubernetes.configmap/ # /docs/alloy/latest/reference/components/remote.kubernetes.configmap/
 description: Learn about remote.kubernetes.configmap
+labels:
+  stage: general-availability
 title: remote.kubernetes.configmap
 ---
 
-# remote.kubernetes.configmap
+# `remote.kubernetes.configmap`
 
 `remote.kubernetes.configmap` reads a ConfigMap from the Kubernetes API server and exposes its data for other components to consume.
 
-This can be useful anytime {{< param "PRODUCT_NAME" >}} needs data from a ConfigMap that is not directly mounted to the {{< param "PRODUCT_NAME" >}} pod.
+This can be useful anytime {{< param "PRODUCT_NAME" >}} needs data from a ConfigMap that is not directly mounted to the {{< param "PRODUCT_NAME" >}} Pod.
 
 ## Usage
 
 ```alloy
-remote.kubernetes.configmap "LABEL" {
-  namespace = "NAMESPACE_OF_CONFIGMAP"
-  name = "NAME_OF_CONFIGMAP"
+remote.kubernetes.configmap "<LABEL>" {
+  namespace = "<NAMESPACE_OF_CONFIGMAP>"
+  name = "<NAME_OF_CONFIGMAP>"
 }
 ```
 
 ## Arguments
 
-The following arguments are supported:
+You can use the following arguments with `remote.kubernetes.configmap`:
 
-Name             | Type       | Description                                            | Default | Required
------------------|------------|--------------------------------------------------------|---------|---------
-`namespace`      | `string`   | Kubernetes namespace containing the desired ConfigMap. |         | yes
-`name`           | `string`   | Name of the Kubernetes ConfigMap                       |         | yes
-`poll_frequency` | `duration` | Frequency to poll the Kubernetes API.                  | `"1m"`  | no
-`poll_timeout`   | `duration` | Timeout when polling the Kubernetes API.               | `"15s"` | no
+| Name             | Type       | Description                                            | Default | Required |
+| ---------------- | ---------- | ------------------------------------------------------ | ------- | -------- |
+| `name`           | `string`   | Name of the Kubernetes ConfigMap                       |         | yes      |
+| `namespace`      | `string`   | Kubernetes namespace containing the desired ConfigMap. |         | yes      |
+| `poll_frequency` | `duration` | Frequency to poll the Kubernetes API.                  | `"1m"`  | no       |
+| `poll_timeout`   | `duration` | Timeout when polling the Kubernetes API.               | `"15s"` | no       |
 
 When this component performs a poll operation, it requests the ConfigMap data from the Kubernetes API.
 A poll is triggered by the following:
@@ -44,27 +46,27 @@ After a successful poll, all data is exported with the same field names as the s
 
 ## Blocks
 
-The following blocks are supported inside the definition of `remote.kubernetes.configmap`:
+You can use the following blocks with `remote.kubernetes.configmap`:
 
-Hierarchy                    | Block             | Description                                                  | Required
------------------------------|-------------------|--------------------------------------------------------------|---------
-client                       | [client][]        | Configures Kubernetes client used to find Probes.            | no
-client > basic_auth          | [basic_auth][]    | Configure basic authentication to the Kubernetes API.        | no
-client > authorization       | [authorization][] | Configure generic authorization to the Kubernetes API.       | no
-client > oauth2              | [oauth2][]        | Configure OAuth2 for authenticating to the Kubernetes API.   | no
-client > oauth2 > tls_config | [tls_config][]    | Configure TLS settings for connecting to the Kubernetes API. | no
-client > tls_config          | [tls_config][]    | Configure TLS settings for connecting to the Kubernetes API. | no
+| Block                                            | Description                                                   | Required |
+| ------------------------------------------------ | ------------------------------------------------------------- | -------- |
+| [`client`][client]                               | Configures Kubernetes client used to find Probes.             | no       |
+| `client` > [`authorization`][authorization]      | Configure generic authorization to the Kubernetes API.        | no       |
+| `client` > [`basic_auth`][basic_auth]            | Configure basic authentication to the Kubernetes API.         | no       |
+| `client` > [`oauth2`][oauth2]                    | Configure OAuth 2.0 for authenticating to the Kubernetes API. | no       |
+| `client` > `oauth2` > [`tls_config`][tls_config] | Configure TLS settings for connecting to the Kubernetes API.  | no       |
+| `client` > [`tls_config`][tls_config]            | Configure TLS settings for connecting to the Kubernetes API.  | no       |
 
-The `>` symbol indicates deeper levels of nesting.
-For example, `client > basic_auth` refers to a `basic_auth` block defined inside a `client` block.
+The > symbol indicates deeper levels of nesting.
+For example, `client` > `basic_auth` refers to a `basic_auth` block defined inside a `client` block.
 
-[client]: #client-block
-[basic_auth]: #basic_auth-block
-[authorization]: #authorization-block
-[oauth2]: #oauth2-block
-[tls_config]: #tls_config-block
+[client]: #client
+[authorization]: #authorization
+[basic_auth]: #basic_auth
+[oauth2]: #oauth2
+[tls_config]: #tls_config
 
-### client block
+### `client`
 
 The `client` block configures the Kubernetes client used to discover Probes.
 If the `client` block isn't provided, the default in-cluster configuration with the service account of the running {{< param "PRODUCT_NAME" >}} pod is used.

--- a/docs/sources/reference/components/remote/remote.kubernetes.secret.md
+++ b/docs/sources/reference/components/remote/remote.kubernetes.secret.md
@@ -8,31 +8,31 @@ labels:
 title: remote.kubernetes.secret
 ---
 
-# remote.kubernetes.secret
+# `remote.kubernetes.secret`
 
 `remote.kubernetes.secret` reads a Secret from the Kubernetes API server and exposes its data for other components to consume.
 
-A common use case for this is loading credentials or other information from secrets that are not already mounted into the {{< param "PRODUCT_NAME" >}} pod at deployment time.
+A common use case for this is loading credentials or other information from secrets that aren't already mounted into the {{< param "PRODUCT_NAME" >}} Pod at deployment time.
 
 ## Usage
 
 ```alloy
-remote.kubernetes.secret "LABEL" {
-  namespace = "NAMESPACE_OF_SECRET"
-  name = "NAME_OF_SECRET"
+remote.kubernetes.secret "<LABEL>" {
+  namespace = "<NAMESPACE_OF_SECRET>"
+  name = "<NAME_OF_SECRET>"
 }
 ```
 
 ## Arguments
 
-The following arguments are supported:
+You can use the following arguments with `remote.kubernetes.secret`:
 
-Name             | Type       | Description                                         | Default | Required
------------------|------------|-----------------------------------------------------|---------|---------
-`namespace`      | `string`   | Kubernetes namespace containing the desired Secret. |         | yes
-`name`           | `string`   | Name of the Kubernetes Secret                       |         | yes
-`poll_frequency` | `duration` | Frequency to poll the Kubernetes API.               | `"1m"`  | no
-`poll_timeout`   | `duration` | Timeout when polling the Kubernetes API.            | `"15s"` | no
+| Name             | Type       | Description                                         | Default | Required |
+| ---------------- | ---------- | --------------------------------------------------- | ------- | -------- |
+| `name`           | `string`   | Name of the Kubernetes Secret                       |         | yes      |
+| `namespace`      | `string`   | Kubernetes namespace containing the desired Secret. |         | yes      |
+| `poll_frequency` | `duration` | Frequency to poll the Kubernetes API.               | `"1m"`  | no       |
+| `poll_timeout`   | `duration` | Timeout when polling the Kubernetes API.            | `"15s"` | no       |
 
 When this component performs a poll operation, it requests the Secret data from the Kubernetes API.
 A poll is triggered by the following:
@@ -46,89 +46,89 @@ After a successful poll, all data is exported with the same field names as the s
 
 ## Blocks
 
-The following blocks are supported inside the definition of `remote.kubernetes.secret`:
+You can use the following blocks with `remote.kubernetes.secret`:
 
-Hierarchy                    | Block             | Description                                                  | Required
------------------------------|-------------------|--------------------------------------------------------------|---------
-client                       | [client][]        | Configures Kubernetes client used to find Probes.            | no
-client > basic_auth          | [basic_auth][]    | Configure basic authentication to the Kubernetes API.        | no
-client > authorization       | [authorization][] | Configure generic authorization to the Kubernetes API.       | no
-client > oauth2              | [oauth2][]        | Configure OAuth2 for authenticating to the Kubernetes API.   | no
-client > oauth2 > tls_config | [tls_config][]    | Configure TLS settings for connecting to the Kubernetes API. | no
-client > tls_config          | [tls_config][]    | Configure TLS settings for connecting to the Kubernetes API. | no
+| Block                                            | Description                                                  | Required |
+| ------------------------------------------------ | ------------------------------------------------------------ | -------- |
+| [`client`][client]                               | Configures Kubernetes client used to find Probes.            | no       |
+| `client` > [`authorization`][authorization]      | Configure generic authorization to the Kubernetes API.       | no       |
+| `client` >[`basic_auth`][basic_auth]             | Configure basic authentication to the Kubernetes API.        | no       |
+| `client` > [`oauth2`][oauth2]                    | Configure OAuth2 for authenticating to the Kubernetes API.   | no       |
+| `client` > `oauth2` > [`tls_config`][tls_config] | Configure TLS settings for connecting to the Kubernetes API. | no       |
+| `client` > [`tls_config`][tls_config]            | Configure TLS settings for connecting to the Kubernetes API. | no       |
 
-The `>` symbol indicates deeper levels of nesting.
-For example, `client > basic_auth` refers to a `basic_auth` block defined inside a `client` block.
+The > symbol indicates deeper levels of nesting.
+For example, `client` > `basic_auth` refers to a `basic_auth` block defined inside a `client` block.
 
-[client]: #client-block
-[basic_auth]: #basic_auth-block
-[authorization]: #authorization-block
-[oauth2]: #oauth2-block
-[tls_config]: #tls_config-block
+[client]: #client
+[authorization]: #authorization
+[basic_auth]: #basic_auth
+[oauth2]: #oauth2
+[tls_config]: #tls_config
 
-### client block
+### `client`
 
 The `client` block configures the Kubernetes client used to discover Probes.
-If the `client` block isn't provided, the default in-cluster configuration with the service account of the running {{< param "PRODUCT_NAME" >}} pod is used.
+If the `client` block isn't provided, the default in-cluster configuration with the service account of the running {{< param "PRODUCT_NAME" >}} Pod is used.
 
 The following arguments are supported:
 
-Name                     | Type                | Description                                                   | Default | Required
--------------------------|---------------------|---------------------------------------------------------------|---------|---------
-`api_server`             | `string`            | URL of the Kubernetes API server.                             |         | no
-`kubeconfig_file`        | `string`            | Path of the `kubeconfig` file to use for connecting to Kubernetes. |    | no
-`bearer_token_file`      | `string`            | File containing a bearer token to authenticate with.          |         | no
-`bearer_token`           | `secret`            | Bearer token to authenticate with.                            |         | no
-`enable_http2`           | `bool`              | Whether HTTP2 is supported for requests.                      | `true`  | no
-`follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.  | `true`  | no
-`proxy_url`              | `string`            | HTTP proxy to send requests through.                          |         | no
-`no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. | | no
-`proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.         | `false` | no
-`proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests. |         | no
+| Name                     | Type                | Description                                                                                      | Default | Required |
+| ------------------------ | ------------------- | ------------------------------------------------------------------------------------------------ | ------- | -------- |
+| `api_server`             | `string`            | URL of the Kubernetes API server.                                                                |         | no       |
+| `kubeconfig_file`        | `string`            | Path of the `kubeconfig` file to use for connecting to Kubernetes.                               |         | no       |
+| `bearer_token_file`      | `string`            | File containing a bearer token to authenticate with.                                             |         | no       |
+| `bearer_token`           | `secret`            | Bearer token to authenticate with.                                                               |         | no       |
+| `enable_http2`           | `bool`              | Whether HTTP2 is supported for requests.                                                         | `true`  | no       |
+| `follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.                                     | `true`  | no       |
+| `proxy_url`              | `string`            | HTTP proxy to send requests through.                                                             |         | no       |
+| `no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. |         | no       |
+| `proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.                                            | `false` | no       |
+| `proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests.                                    |         | no       |
 
  At most, one of the following can be provided:
- - [`bearer_token` argument][client].
- - [`bearer_token_file` argument][client].
- - [`basic_auth` block][basic_auth].
- - [`authorization` block][authorization].
- - [`oauth2` block][oauth2].
+
+* [`authorization`][authorization] block
+* [`basic_auth`][basic_auth] block
+* [`bearer_token_file`][client] argument
+* [`bearer_token`][client] argument
+* [`oauth2`][oauth2] block
 
 {{< docs/shared lookup="reference/components/http-client-proxy-config-description.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
-### basic_auth block
-
-{{< docs/shared lookup="reference/components/basic-auth-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
-
-### authorization block
+### `authorization`
 
 {{< docs/shared lookup="reference/components/authorization-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
-### oauth2 block
+### `basic_auth`
+
+{{< docs/shared lookup="reference/components/basic-auth-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `oauth2`
 
 {{< docs/shared lookup="reference/components/oauth2-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
-### tls_config block
+### `tls_config`
 
 {{< docs/shared lookup="reference/components/tls-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
-
 
 ## Exported fields
 
 The following fields are exported and can be referenced by other components:
 
-Name   | Type          | Description
--------|---------------|-----------------------------------------------
-`data` | `map(secret)` | Data from the secret obtained from Kubernetes.
+| Name   | Type          | Description                                    |
+| ------ | ------------- | ---------------------------------------------- |
+| `data` | `map(secret)` | Data from the secret obtained from Kubernetes. |
 
 The `data` field contains a mapping from field names to values.
 
-If an individual key stored in `data` does not hold sensitive data, it can be converted into a string using [the `convert.nonsensitive` function][convert]:
+If an individual key stored in `data` doesn't hold sensitive data, it can be converted into a string using [the `convert.nonsensitive` function][convert]:
 
 ```alloy
 convert.nonsensitive(remote.kubernetes.secret.LABEL.data.KEY_NAME)
 ```
 
-Using `convert.nonsensitive` allows for using the exports of `remote.kubernetes.secret` for attributes in components that do not support secrets.
+Using `convert.nonsensitive` allows for using the exports of `remote.kubernetes.secret` for attributes in components that don't support secrets.
 
 [convert]: ../../../stdlib/convert/
 
@@ -138,11 +138,11 @@ Instances of `remote.kubernetes.secret` report as healthy if the most recent att
 
 ## Debug information
 
-`remote.kubernetes.secret` does not expose any component-specific debug information.
+`remote.kubernetes.secret` doesn't expose any component-specific debug information.
 
 ## Debug metrics
 
-`remote.kubernetes.secret` does not expose any component-specific debug metrics.
+`remote.kubernetes.secret` doesn't expose any component-specific debug metrics.
 
 ## Example
 

--- a/docs/sources/reference/components/remote/remote.kubernetes.secret.md
+++ b/docs/sources/reference/components/remote/remote.kubernetes.secret.md
@@ -3,6 +3,8 @@ canonical: https://grafana.com/docs/alloy/latest/reference/components/remote/rem
 aliases:
   - ../remote.kubernetes.secret/ # /docs/alloy/latest/reference/components/remote.kubernetes.secret/
 description: Learn about remote.kubernetes.secret
+labels:
+  stage: general-availability
 title: remote.kubernetes.secret
 ---
 

--- a/docs/sources/reference/components/remote/remote.s3.md
+++ b/docs/sources/reference/components/remote/remote.s3.md
@@ -3,6 +3,8 @@ canonical: https://grafana.com/docs/alloy/latest/reference/components/remote/rem
 aliases:
   - ../remote.s3/ # /docs/alloy/latest/reference/components/remote.s3/
 description: Learn about remote.s3
+labels:
+  stage: general-availability
 title: remote.s3
 ---
 

--- a/docs/sources/reference/components/remote/remote.s3.md
+++ b/docs/sources/reference/components/remote/remote.s3.md
@@ -8,15 +8,16 @@ labels:
 title: remote.s3
 ---
 
-# remote.s3
+# `remote.s3`
 
 `remote.s3` exposes the string contents of a file located in [AWS S3](https://aws.amazon.com/s3/) to other components.
-The file will be polled for changes so that the most recent content is always available.
+The file is polled for changes so that the most recent content is always available.
 
 The most common use of `remote.s3` is to load secrets from files.
 
-Multiple `remote.s3` components can be specified using different name
-labels. By default, [AWS environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) are used to authenticate against S3. The `key` and `secret` arguments inside `client` blocks can be used to provide custom authentication.
+You can specify multiple `remote.s3` components by using different name labels.
+By default, [AWS environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) are used to authenticate against S3.
+The `key` and `secret` arguments inside `client` blocks can be used to provide custom authentication.
 
 {{< admonition type="note" >}}
 Other S3-compatible systems can be read  with `remote.s3` but may require specific authentication environment variables.
@@ -26,59 +27,59 @@ There is no  guarantee that `remote.s3` will work with non-AWS S3 systems.
 ## Usage
 
 ```alloy
-remote.s3 "LABEL" {
-  path = S3_FILE_PATH
+remote.s3 "<LABEL>" {
+  path = "<S3_FILE_PATH>"
 }
 ```
 
 ## Arguments
 
-The following arguments are supported:
+You can use the following arguments with `remote.s3`:
 
-Name             | Type       | Description                                                              | Default | Required
------------------|------------|--------------------------------------------------------------------------|---------|---------
-`path`           | `string`   | Path in the format of `"s3://bucket/file"`.                              |         | yes
-`poll_frequency` | `duration` | How often to poll the file for changes. Must be greater than 30 seconds. | `"10m"` | no
-`is_secret`      | `bool`     | Marks the file as containing a [secret][].                               | `false` | no
+| Name             | Type       | Description                                                              | Default | Required |
+| ---------------- | ---------- | ------------------------------------------------------------------------ | ------- | -------- |
+| `path`           | `string`   | Path in the format of `"s3://bucket/file"`.                              |         | yes      |
+| `is_secret`      | `bool`     | Marks the file as containing a [secret][].                               | `false` | no       |
+| `poll_frequency` | `duration` | How often to poll the file for changes. Must be greater than 30 seconds. | `"10m"` | no       |
 
 {{< admonition type="note" >}}
-`path` must include a full path to a file. This does not support reading of directories.
+`path` must include a full path to a file.
+This doesn't support reading of directories.
 {{< /admonition >}}
 
 [secret]: ../../../../get-started/configuration-syntax/expressions/types_and_values/#secrets
 
 ## Blocks
 
-Hierarchy | Name       | Description                                       | Required
-----------|------------|---------------------------------------------------|---------
-client    | [client][] | Additional options for configuring the S3 client. | no
+ | Name               | Description                                       | Required |
+ | ------------------ | ------------------------------------------------- | -------- |
+ | [`client`][client] | Additional options for configuring the S3 client. | no       |
 
-[client]: #client-block
+[client]: #client
 
-### client block
+### `client`
 
 The `client` block customizes options to connect to the S3 server.
 
-Name             | Type     | Description                                                                             | Default | Required
------------------|----------|-----------------------------------------------------------------------------------------|---------|---------
-`key`            | `string` | Used to override default access key.                                                    |         | no
-`secret`         | `secret` | Used to override default secret value.                                                  |         | no
-`endpoint`       | `string` | Specifies a custom url to access, used generally for S3-compatible systems.             |         | no
-`disable_ssl`    | `bool`   | Used to disable SSL, generally used for testing.                                        |         | no
-`use_path_style` | `string` | Path style is a deprecated setting that is generally enabled for S3 compatible systems. | `false` | no
-`region`         | `string` | Used to override default region.                                                        |         | no
-`signing_region` | `string` | Used to override the signing region when using a custom endpoint.                       |         | no
-
+| Name             | Type     | Description                                                                            | Default | Required |
+| ---------------- | -------- | -------------------------------------------------------------------------------------- | ------- | -------- |
+| `key`            | `string` | Used to override default access key.                                                   |         | no       |
+| `secret`         | `secret` | Used to override default secret value.                                                 |         | no       |
+| `endpoint`       | `string` | Specifies a custom URL to access, used generally for S3-compatible systems.            |         | no       |
+| `disable_ssl`    | `bool`   | Used to disable SSL, generally used for testing.                                       |         | no       |
+| `use_path_style` | `string` | Path style is a deprecated setting that's generally enabled for S3 compatible systems. | `false` | no       |
+| `region`         | `string` | Used to override default region.                                                       |         | no       |
+| `signing_region` | `string` | Used to override the signing region when using a custom endpoint.                      |         | no       |
 
 ## Exported fields
 
 The following fields are exported and can be referenced by other components:
 
-Name      | Type                 | Description               | Default | Required
-----------|----------------------|---------------------------|---------|---------
-`content` | `string` or `secret` | The contents of the file. |         | no
+| Name      | Type                 | Description               | Default | Required |
+| --------- | -------------------- | ------------------------- | ------- | -------- |
+| `content` | `string` or `secret` | The contents of the file. |         | no       |
 
-The `content` field will be secret if `is_secret` was set to true.
+The `content` field will be secret if `is_secret` is set to true.
 
 ## Component health
 

--- a/docs/sources/reference/components/remote/remote.vault.md
+++ b/docs/sources/reference/components/remote/remote.vault.md
@@ -3,6 +3,8 @@ canonical: https://grafana.com/docs/alloy/latest/reference/components/remote/rem
 aliases:
   - ../remote.vault/ # /docs/alloy/latest/reference/components/remote.vault/
 description: Learn about remote.vault
+labels:
+  stage: general-availability
 title: remote.vault
 ---
 

--- a/docs/sources/reference/components/remote/remote.vault.md
+++ b/docs/sources/reference/components/remote/remote.vault.md
@@ -8,13 +8,12 @@ labels:
 title: remote.vault
 ---
 
-# remote.vault
+# `remote.vault`
 
 `remote.vault` connects to a [HashiCorp Vault][Vault] server to retrieve secrets.
 It can retrieve a secret using the [KV v2][] secrets engine.
 
-Multiple `remote.vault` components can be specified by giving them different
-labels.
+You can specify multiple `remote.vault` components by giving them different labels.
 
 [Vault]: https://www.vaultproject.io/
 [KV v2]: https://www.vaultproject.io/docs/secrets/kv/kv-v2
@@ -22,123 +21,95 @@ labels.
 ## Usage
 
 ```alloy
-remote.vault "LABEL" {
-  server = "VAULT_SERVER"
-  path   = "VAULT_PATH"
-  key    = "VAULT_KEY"
+remote.vault "<LABEL>" {
+  server = "<VAULT_SERVER>"
+  path   = "<VAULT_PATH>"
+  key    = "<VAULT_KEY>"
 
   // Alternatively, use one of the other auth.* mechanisms.
   auth.token {
-    token = "AUTH_TOKEN"
+    token = "<AUTH_TOKEN>"
   }
 }
 ```
 
 ## Arguments
 
-The following arguments are supported:
+You can use the following arguments with `remote.vault`:
 
-Name               | Type       | Description                                                | Default | Required
--------------------|------------|------------------------------------------------------------|---------|---------
-`server`           | `string`   | The Vault server to connect to.                            |         | yes
-`namespace`        | `string`   | The Vault namespace to connect to (Vault Enterprise only). |         | no
-`path`             | `string`   | The path to retrieve a secret from.                        |         | yes
-`key`              | `string`   | The key to retrieve a secret from.                         |         | no
-`reread_frequency` | `duration` | Rate to re-read keys.                                      | `"0s"`  | no
+| Name               | Type       | Description                                                | Default | Required |
+| ------------------ | ---------- | ---------------------------------------------------------- | ------- | -------- |
+| `server`           | `string`   | The Vault server to connect to.                            |         | yes      |
+| `namespace`        | `string`   | The Vault namespace to connect to (Vault Enterprise only). |         | no       |
+| `path`             | `string`   | The path to retrieve a secret from.                        |         | yes      |
+| `key`              | `string`   | The key to retrieve a secret from.                         |         | no       |
+| `reread_frequency` | `duration` | Rate to re-read keys.                                      | `"0s"`  | no       |
 
-Tokens with a lease will be automatically renewed roughly two-thirds through their lease duration.
-If the leased token isn't renewable, or renewing the lease fails, the token will be re-read.
+Tokens with a lease are automatically renewed roughly two-thirds through their lease duration.
+If the leased token isn't renewable, or renewing the lease fails, the token is re-read.
 
 All tokens, regardless of whether they have a lease, are automatically reread at a frequency specified by the `reread_frequency` argument.
 Setting `reread_frequency` to `"0s"` (the default) disables this behavior.
 
 ## Blocks
 
-The following blocks are supported inside the definition of `remote.vault`:
+You can use the following blocks with `remote.vault`:
 
-Hierarchy       | Block               | Description                                          | Required
-----------------|---------------------|------------------------------------------------------|---------
-client_options  | [client_options][]  | Options for the Vault client.                        | no
-auth.token      | [auth.token][]      | Authenticate to Vault with a token.                  | no
-auth.approle    | [auth.approle][]    | Authenticate to Vault using AppRole.                 | no
-auth.aws        | [auth.aws][]        | Authenticate to Vault using AWS.                     | no
-auth.azure      | [auth.azure][]      | Authenticate to Vault using Azure.                   | no
-auth.gcp        | [auth.gcp][]        | Authenticate to Vault using GCP.                     | no
-auth.kubernetes | [auth.kubernetes][] | Authenticate to Vault using Kubernetes.              | no
-auth.ldap       | [auth.ldap][]       | Authenticate to Vault using LDAP.                    | no
-auth.userpass   | [auth.userpass][]   | Authenticate to Vault using a username and password. | no
-auth.custom     | [auth.custom][]     | Authenticate to Vault with custom authentication.    | no
+| Block                                | Description                                          | Required |
+| ------------------------------------ | ---------------------------------------------------- | -------- |
+| [`auth.approle`][auth.approle]       | Authenticate to Vault using AppRole.                 | no       |
+| [`auth.aws`][auth.aws]               | Authenticate to Vault using AWS.                     | no       |
+| [`auth.azure`][auth.azure]           | Authenticate to Vault using Azure.                   | no       |
+| [`auth.custom`][auth.custom]         | Authenticate to Vault with custom authentication.    | no       |
+| [`auth.gcp`][auth.gcp]               | Authenticate to Vault using GCP.                     | no       |
+| [`auth.kubernetes`][auth.kubernetes] | Authenticate to Vault using Kubernetes.              | no       |
+| [`auth.ldap`][auth.ldap]             | Authenticate to Vault using LDAP.                    | no       |
+| [`auth.token`][auth.token]           | Authenticate to Vault with a token.                  | no       |
+| [`auth.userpass`][auth.userpass]     | Authenticate to Vault using a username and password. | no       |
+| [`client_options`][client_options]   | Options for the Vault client.                        | no       |
 
 Exactly one `auth.*` block **must** be provided, otherwise the component will fail to load.
 
-[client_options]: #client_options-block
-[auth.token]: #authtoken-block
-[auth.approle]: #authapprole-block
-[auth.aws]: #authaws-block
-[auth.azure]: #authazure-block
-[auth.gcp]: #authgcp-block
-[auth.kubernetes]: #authkubernetes-block
-[auth.ldap]: #authldap-block
-[auth.userpass]: #authuserpass-block
-[auth.custom]: #authcustom-block
+[auth.approle]: #authapprole
+[auth.aws]: #authaws
+[auth.azure]: #authazure
+[auth.custom]: #authcustom
+[auth.gcp]: #authgcp
+[auth.kubernetes]: #authkubernetes
+[auth.ldap]: #authldap
+[auth.token]: #authtoken
+[auth.userpass]: #authuserpass
+[client_options]: #client_options
 
-### client_options block
-
-The `client_options` block customizes the connection to vault.
-
-Name             | Type       | Description                                           | Default    | Required
------------------|------------|-------------------------------------------------------|------------|---------
-`min_retry_wait` | `duration` | Minimum time to wait before retrying failed requests. | `"1000ms"` | no
-`max_retry_wait` | `duration` | Maximum time to wait before retrying failed requests. | `"1500ms"` | no
-`max_retries`    | `int`      | Maximum number of times to retry after a 5xx error.   | `2`        | no
-`timeout`        | `duration` | Maximum time to wait before a request times out.      | `"60s"`    | no
-
-Requests which fail due to server errors (HTTP 5xx error codes) can be retried.
-The `max_retries` argument specifies how many times to retry failed requests.
-The `min_retry_wait` and `max_retry_wait` arguments specify how long to wait before retrying.
-The wait period starts at `min_retry_wait` and exponentially increases up to `max_retry_wait`.
-
-Other types of failed requests, including HTTP 4xx error codes, aren't retried.
-
-If the `max_retries` argument is set to `0`, failed requests aren't retried.
-
-### auth.token block
-
-The `auth.token` block authenticates each request to Vault using a token.
-
-Name    | Type     | Description                  | Default | Required
---------|----------|------------------------------|---------|---------
-`token` | `secret` | Authentication token to use. |         | yes
-
-### auth.approle block
+### `auth.approle`
 
 The `auth.token` block authenticates to Vault using the [AppRole auth method][AppRole].
 
-Name             | Type     | Description                      | Default     | Required
------------------|----------|----------------------------------|-------------|---------
-`role_id`        | `string` | Role ID to authenticate as.      |             | yes
-`secret`         | `secret` | Secret to authenticate with.     |             | yes
-`wrapping_token` | `bool`   | Whether to [unwrap][] the token. | `false`     | no
-`mount_path`     | `string` | Mount path for the login.        | `"approle"` | no
+| Name             | Type     | Description                      | Default     | Required |
+| ---------------- | -------- | -------------------------------- | ----------- | -------- |
+| `role_id`        | `string` | Role ID to authenticate as.      |             | yes      |
+| `secret`         | `secret` | Secret to authenticate with.     |             | yes      |
+| `wrapping_token` | `bool`   | Whether to [unwrap][] the token. | `false`     | no       |
+| `mount_path`     | `string` | Mount path for the login.        | `"approle"` | no       |
 
 [AppRole]: https://www.vaultproject.io/docs/auth/approle
 [unwrap]: https://www.vaultproject.io/docs/concepts/response-wrapping
 
-### auth.aws block
+### `auth.aws`
 
 The `auth.aws` block authenticates to Vault using the [AWS auth method][AWS].
 
 Credentials used to connect to AWS are specified by the environment variables `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION`.
 The environment variable `AWS_SHARED_CREDENTIALS_FILE` may be specified to use a credentials file instead.
 
-Name                   | Type     | Description                                       | Default       | Required
------------------------|----------|---------------------------------------------------|---------------|---------
-`type`                 | `string` | Mechanism to authenticate against AWS with.       |               | yes
-`region`               | `string` | AWS region to connect to.                         | `"us-east-1"` | no
-`role`                 | `string` | Overrides the inferred role name inferred.        | `""`          | no
-`iam_server_id_header` | `string` | Configures a `X-Vault-AWS-IAM-Server-ID` header.  | `""`          | no
-`ec2_signature_type`   | `string` | Signature to use when authenticating against EC2. | `"pkcs7"`     | no
-`mount_path`           | `string` | Mount path for the login.                         | `"aws"`       | no
+| Name                   | Type     | Description                                       | Default       | Required |
+| ---------------------- | -------- | ------------------------------------------------- | ------------- | -------- |
+| `type`                 | `string` | Mechanism to authenticate against AWS with.       |               | yes      |
+| `region`               | `string` | AWS region to connect to.                         | `"us-east-1"` | no       |
+| `role`                 | `string` | Overrides the inferred role name inferred.        | `""`          | no       |
+| `iam_server_id_header` | `string` | Configures a `X-Vault-AWS-IAM-Server-ID` header.  | `""`          | no       |
+| `ec2_signature_type`   | `string` | Signature to use when authenticating against EC2. | `"pkcs7"`     | no       |
+| `mount_path`           | `string` | Mount path for the login.                         | `"aws"`       | no       |
 
 The `type` argument must be set to one of `"ec2"` or `"iam"`.
 
@@ -152,30 +123,43 @@ It only applies when `type` is set to `"ec2"`.
 
 [AWS]: https://www.vaultproject.io/docs/auth/aws
 
-### auth.azure block
+### `auth.azure`
 
 The `auth.azure` block authenticates to Vault using the [Azure auth method][Azure].
 
 Credentials are retrieved for the running Azure VM using Managed Identities for Azure Resources.
 
-Name           | Type     | Description                                          | Default   | Required
----------------|----------|------------------------------------------------------|-----------|---------
-`role`         | `string` | Role name to authenticate as.                        |           | yes
-`resource_url` | `string` | Resource URL to include with authentication request. |           | no
-`mount_path`   | `string` | Mount path for the login.                            | `"azure"` | no
+| Name           | Type     | Description                                          | Default   | Required |
+| -------------- | -------- | ---------------------------------------------------- | --------- | -------- |
+| `role`         | `string` | Role name to authenticate as.                        |           | yes      |
+| `resource_url` | `string` | Resource URL to include with authentication request. |           | no       |
+| `mount_path`   | `string` | Mount path for the login.                            | `"azure"` | no       |
 
 [Azure]: https://www.vaultproject.io/docs/auth/azure
 
-### auth.gcp block
+### `auth.custom`
+
+The `auth.custom` blocks allows authenticating against Vault using an arbitrary authentication path like `auth/customservice/login`.
+
+Using `auth.custom` is equivalent to calling `vault write PATH DATA` on the command line.
+
+| Name   | Type          | Description                                            | Default | Required |
+| ------ | ------------- | ------------------------------------------------------ | ------- | -------- |
+| `path` | `string`      | Path to write to for creating an authentication token. |         | yes      |
+| `data` | `map(secret)` | Authentication data.                                   |         | yes      |
+
+All values in the `data` attribute are considered secret, even if they contain nonsensitive information like usernames.
+
+### `auth.gcp`
 
 The `auth.gcp` block authenticates to Vault using the [GCP auth method][GCP].
 
-Name                  | Type     | Description                                | Default | Required
-----------------------|----------|--------------------------------------------|---------|---------
-`role`                | `string` | Role name to authenticate as.              |         | yes
-`type`                | `string` | Mechanism to authenticate against GCP with |         | yes
-`iam_service_account` | `string` | IAM service account name to use.           |         | no
-`mount_path`          | `string` | Mount path for the login.                  | `"gcp"` | no
+| Name                  | Type     | Description                                | Default | Required |
+| --------------------- | -------- | ------------------------------------------ | ------- | -------- |
+| `role`                | `string` | Role name to authenticate as.              |         | yes      |
+| `type`                | `string` | Mechanism to authenticate against GCP with |         | yes      |
+| `iam_service_account` | `string` | IAM service account name to use.           |         | no       |
+| `mount_path`          | `string` | Mount path for the login.                  | `"gcp"` | no       |
 
 The `type` argument must be set to `"gce"` or `"iam"`. When `type` is `"gce"`, credentials are retrieved using the metadata service on GCE VMs.
 When `type` is `"iam"`, credentials are retrieved from the file that the `GOOGLE_APPLICATION_CREDENTIALS` environment variable points to.
@@ -184,65 +168,79 @@ When `type` is `"iam"`, the `iam_service_account` argument determines what servi
 
 [GCP]: https://www.vaultproject.io/docs/auth/gcp
 
-### auth.kubernetes block
+### `auth.kubernetes`
 
 The `auth.kubernetes` block authenticates to Vault using the [Kubernetes auth method][Kubernetes].
 
-Name                   | Type     | Description                                 | Default        | Required
------------------------|----------|---------------------------------------------|----------------|---------
-`role`                 | `string` | Role name to authenticate as.               |                | yes
-`service_account_file` | `string` | Override service account token file to use. |                | no
-`mount_path`           | `string` | Mount path for the login.                   | `"kubernetes"` | no
+| Name                   | Type     | Description                                 | Default        | Required |
+| ---------------------- | -------- | ------------------------------------------- | -------------- | -------- |
+| `role`                 | `string` | Role name to authenticate as.               |                | yes      |
+| `service_account_file` | `string` | Override service account token file to use. |                | no       |
+| `mount_path`           | `string` | Mount path for the login.                   | `"kubernetes"` | no       |
 
 When `service_account_file` is not specified, the JWT token to authenticate with is retrieved from `/var/run/secrets/kubernetes.io/serviceaccount/token`.
 
 [Kubernetes]: https://www.vaultproject.io/docs/auth/kubernetes
 
-### auth.ldap block
+### `auth.ldap`
 
 The `auth.ldap` block authenticates to Vault using the [LDAP auth method][LDAP].
 
-Name         | Type     | Description                       | Default  | Required
--------------|----------|-----------------------------------|----------|---------
-`username`   | `string` | LDAP username to authenticate as. |          | yes
-`password`   | `secret` | LDAP passsword for the user.      |          | yes
-`mount_path` | `string` | Mount path for the login.         | `"ldap"` | no
+| Name         | Type     | Description                       | Default  | Required |
+| ------------ | -------- | --------------------------------- | -------- | -------- |
+| `username`   | `string` | LDAP username to authenticate as. |          | yes      |
+| `password`   | `secret` | LDAP password for the user.       |          | yes      |
+| `mount_path` | `string` | Mount path for the login.         | `"ldap"` | no       |
 
 [LDAP]: https://www.vaultproject.io/docs/auth/ldap
 
-### auth.userpass block
+### `auth.token`
 
-The `auth.userpass` block authenticates to Vault using the [UserPass auth
-method][UserPass].
+The `auth.token` block authenticates each request to Vault using a token.
 
-Name         | Type     | Description                  | Default      | Required
--------------|----------|------------------------------|--------------|---------
-`username`   | `string` | Username to authenticate as. |              | yes
-`password`   | `secret` | Passsword for the user.      |              | yes
-`mount_path` | `string` | Mount path for the login.    | `"userpass"` | no
+| Name    | Type     | Description                  | Default | Required |
+| ------- | -------- | ---------------------------- | ------- | -------- |
+| `token` | `secret` | Authentication token to use. |         | yes      |
+
+### `auth.userpass`
+
+The `auth.userpass` block authenticates to Vault using the [UserPass auth method][UserPass].
+
+| Name         | Type     | Description                  | Default      | Required |
+| ------------ | -------- | ---------------------------- | ------------ | -------- |
+| `username`   | `string` | Username to authenticate as. |              | yes      |
+| `password`   | `secret` | Password for the user.       |              | yes      |
+| `mount_path` | `string` | Mount path for the login.    | `"userpass"` | no       |
 
 [UserPass]: https://www.vaultproject.io/docs/auth/userpass
 
-### auth.custom block
+### `client_options`
 
-The `auth.custom` blocks allows authenticating against Vault using an arbitrary authentication path like `auth/customservice/login`.
+The `client_options` block customizes the connection to vault.
 
-Using `auth.custom` is equivalent to calling `vault write PATH DATA` on the command line.
+| Name             | Type       | Description                                           | Default    | Required |
+| ---------------- | ---------- | ----------------------------------------------------- | ---------- | -------- |
+| `min_retry_wait` | `duration` | Minimum time to wait before retrying failed requests. | `"1000ms"` | no       |
+| `max_retry_wait` | `duration` | Maximum time to wait before retrying failed requests. | `"1500ms"` | no       |
+| `max_retries`    | `int`      | Maximum number of times to retry after a 5xx error.   | `2`        | no       |
+| `timeout`        | `duration` | Maximum time to wait before a request times out.      | `"60s"`    | no       |
 
-Name   | Type          | Description                                            | Default | Required
--------|---------------|--------------------------------------------------------|---------|---------
-`path` | `string`      | Path to write to for creating an authentication token. |         | yes
-`data` | `map(secret)` | Authentication data.                                   |         | yes
+Requests which fail due to server errors (HTTP 5xx error codes) can be retried.
+The `max_retries` argument specifies how many times to retry failed requests.
+The `min_retry_wait` and `max_retry_wait` arguments specify how long to wait before retrying.
+The wait period starts at `min_retry_wait` and exponentially increases up to `max_retry_wait`.
 
-All values in the `data` attribute are considered secret, even if they contain nonsensitive information like usernames.
+Other types of failed requests, including HTTP 4xx error codes, aren't retried.
+
+If the `max_retries` argument is set to `0`, failed requests aren't retried.
 
 ## Exported fields
 
 The following fields are exported and can be referenced by other components:
 
-Name   | Type          | Description
--------|---------------|------------------------------------------
-`data` | `map(secret)` | Data from the secret obtained from Vault.
+| Name   | Type          | Description                               |
+| ------ | ------------- | ----------------------------------------- |
+| `data` | `map(secret)` | Data from the secret obtained from Vault. |
 
 The `data` field contains a mapping from data field names to values.
 There is one mapping for each string-like field stored in the Vault secret.
@@ -251,7 +249,7 @@ Vault permits secret engines to store arbitrary data within the key-value pairs 
 The `remote.vault` component is only able to use values which are strings or can be converted to strings.
 Keys with non-string values are ignored and omitted from the `data` field.
 
-If an individual key stored in `data` doesn't hold sensitive data, it can be converted into a string using [the `nonsensitive` function][nonsensitive]:
+If an individual key stored in `data` doesn't hold sensitive data, it can be converted into a string using [the `nonsensitive` function][convert.nonsensitive]:
 
 ```alloy
 convert.nonsensitive(remote.vault.LABEL.data.KEY_NAME)
@@ -263,7 +261,7 @@ Using `convert.nonsensitive` allows for using the exports of `remote.vault` for 
 
 ## Component health
 
-`remote.vault` will be reported as unhealthy if the latest reread or renewal of secrets was unsuccessful.
+`remote.vault` is reported as unhealthy if the latest reread or renewal of secrets was unsuccessful.
 
 ## Debug information
 


### PR DESCRIPTION
#### PR Description

The Alloy component documentation needs general cleanup, including things like:

Pretty print tables
Sort table rows alphabetically - required first, then all optional
Sort blocks alphabetically
Fix block heading hierarchy
Add badge for Required blocks
Remove block from heading text
Remove extra spaces and extra CR/LFs
Tidy markdown - spaces around lists, indentation, etc.

#### Which issue(s) this PR fixes


 Fixes #2419 

