### PR TITLE
Apply linting rules to pyroscope.* component docs

### DIFF
--- a/docs/sources/reference/components/pyroscope/_index.md
+++ b/docs/sources/reference/components/pyroscope/_index.md
@@ -5,7 +5,7 @@ title: pyroscope
 weight: 100
 ---
 
-# pyroscope
+# `pyroscope`
 
 This section contains reference documentation for the `pyroscope` components.
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
@@ -3,10 +3,12 @@ canonical: https://grafana.com/docs/alloy/latest/reference/components/pyroscope/
 aliases:
   - ../pyroscope.ebpf/ # /docs/alloy/latest/reference/components/pyroscope.ebpf/
 description: Learn about pyroscope.ebpf
+labels:
+  stage: general-availability
 title: pyroscope.ebpf
 ---
 
-# pyroscope.ebpf
+# `pyroscope.ebpf`
 
 `pyroscope.ebpf` configures an eBPF profiling job for the current host.
 The collected performance profiles are forwarded to the list of receivers passed in `forward_to`.
@@ -28,9 +30,9 @@ Currently, the CPU usage for these languages is reported as belonging to the run
 ## Usage
 
 ```alloy
-pyroscope.ebpf "LABEL" {
-  targets    = TARGET_LIST
-  forward_to = RECEIVER_LIST
+pyroscope.ebpf "<LABEL>" {
+  targets    = <TARGET_LIST>
+  forward_to = <RECEIVER_LIST>
 }
 ```
 
@@ -38,32 +40,36 @@ pyroscope.ebpf "LABEL" {
 
 The component configures and starts a new eBPF profiling job to collect performance profiles from the current host.
 
-You can use the following arguments to configure a `pyroscope.ebpf`.
+You can use the following arguments with `pyroscope.ebpf`.
+
 Only the `forward_to` and `targets` fields are required.
 Omitted fields take their default values.
 
-
 | Name                      | Type                     | Description                                                                                                                      | Default | Required |
-|---------------------------|--------------------------|----------------------------------------------------------------------------------------------------------------------------------|---------|----------|
-| `targets`                 | `list(map(string))`      | List of targets to group profiles by container id                                                                                |         | yes      |
+| ------------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------- | ------- | -------- |
 | `forward_to`              | `list(ProfilesReceiver)` | List of receivers to send collected profiles to.                                                                                 |         | yes      |
-| `collect_interval`        | `duration`               | How frequently to collect profiles                                                                                               | `15s`   | no       |
-| `sample_rate`             | `int`                    | How many times per second to collect profile samples                                                                             | 97      | no       |
-| `pid_cache_size`          | `int`                    | The size of the pid -> proc symbols table LRU cache                                                                              | 32      | no       |
+| `targets`                 | `list(map(string))`      | List of targets to group profiles by container id                                                                                |         | yes      |
 | `build_id_cache_size`     | `int`                    | The size of the elf file build id -> symbols table LRU cache                                                                     | 64      | no       |
-| `same_file_cache_size`    | `int`                    | The size of the elf file -> symbols table LRU cache                                                                              | 8       | no       |
-| `container_id_cache_size` | `int`                    | The size of the pid -> container ID table LRU cache                                                                              | 1024    | no       |
-| `collect_user_profile`    | `bool`                   | A flag to enable/disable collection of userspace profiles                                                                        | true    | no       |
+| `collect_interval`        | `duration`               | How frequently to collect profiles                                                                                               | `15s`   | no       |
 | `collect_kernel_profile`  | `bool`                   | A flag to enable/disable collection of kernelspace profiles                                                                      | true    | no       |
-| `go_table_fallback`       | `bool`                   | A flag to enable symbol lookup in `.sym` / `.dynsym` sections when `.gopclntab` lookup failed. May be useful for `cgo` binaries. | false   | no       |
+| `collect_user_profile`    | `bool`                   | A flag to enable/disable collection of userspace profiles                                                                        | true    | no       |
+| `container_id_cache_size` | `int`                    | The size of the PID -> container ID table LRU cache                                                                              | 1024    | no       |
 | `demangle`                | `string`                 | C++ demangle mode. Available options are: `none`, `simplified`, `templates`, or `full`                                           | `none`  | no       |
-| `python_enabled`          | `bool`                   | A flag to enable/disable python profiling                                                                                        | true    | no       |
-| `symbols_map_size`        | `int`                    | The size of eBPF symbols map                                                                                                     | 16384   | no       |
+| `go_table_fallback`       | `bool`                   | A flag to enable symbol lookup in `.sym` / `.dynsym` sections when `.gopclntab` lookup failed. May be useful for `cgo` binaries. | false   | no       |
+| `pid_cache_size`          | `int`                    | The size of the PID -> proc symbols table LRU cache                                                                              | 32      | no       |
 | `pid_map_size`            | `int`                    | The size of eBPF PID map                                                                                                         | 2048    | no       |
+| `python_enabled`          | `bool`                   | A flag to enable/disable python profiling                                                                                        | true    | no       |
+| `same_file_cache_size`    | `int`                    | The size of the elf file -> symbols table LRU cache                                                                              | 8       | no       |
+| `sample_rate`             | `int`                    | How many times per second to collect profile samples                                                                             | 97      | no       |
+| `symbols_map_size`        | `int`                    | The size of eBPF symbols map                                                                                                     | 16384   | no       |
+
+## Blocks
+
+The `pyroscope.ebpf` component doesn't support any blocks. You can configure this component with arguments.
 
 ## Exported fields
 
-`pyroscope.ebpf` does not export any fields that can be referenced by other components.
+`pyroscope.ebpf` doesn't export any fields that can be referenced by other components.
 
 ## Component health
 
@@ -71,17 +77,17 @@ Omitted fields take their default values.
 
 ## Debug information
 
-* `targets` currently tracked active targets.
-* `pid_cache` per process elf symbol tables and their sizes in symbols count.
 * `elf_cache` per build id and per same file symbol tables and their sizes in symbols count.
+* `pid_cache` per process elf symbol tables and their sizes in symbols count.
+* `targets` currently tracked active targets.
 
 ## Debug metrics
 
-* `pyroscope_fanout_latency` (histogram): Write latency for sending to direct and indirect components.
 * `pyroscope_ebpf_active_targets` (gauge): Number of active targets the component tracks.
-* `pyroscope_ebpf_profiling_sessions_total` (counter): Number of profiling sessions completed.
-* `pyroscope_ebpf_profiling_sessions_failing_total` (counter): Number of profiling sessions failed.
 * `pyroscope_ebpf_pprofs_total` (counter): Number of pprof profiles collected by the eBPF component.
+* `pyroscope_ebpf_profiling_sessions_failing_total` (counter): Number of profiling sessions failed.
+* `pyroscope_ebpf_profiling_sessions_total` (counter): Number of profiling sessions completed.
+* `pyroscope_fanout_latency` (histogram): Write latency for sending to direct and indirect components.
 
 ## Profile collecting behavior
 
@@ -91,11 +97,11 @@ You can use the `sample_rate` argument to define the number of stack traces coll
 The following labels are automatically injected into the collected profiles if you haven't defined them.
 These labels can help you pin down a profiling target.
 
-Label              | Description
--------------------|---------------------------------------------------------------------------------------------------------------------------------
-`service_name`     | Pyroscope service name. It's automatically selected from discovery meta labels if possible. Otherwise defaults to `unspecified`.
-`__name__`         | pyroscope metric name. Defaults to `process_cpu`.
-`__container_id__` | The container ID derived from target.
+| Label              | Description                                                                                                                      |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `__container_id__` | The container ID derived from target.                                                                                            |
+| `__name__`         | Pyroscope metric name. Defaults to `process_cpu`.                                                                                |
+| `service_name`     | Pyroscope service name. It's automatically selected from discovery meta labels if possible. Otherwise defaults to `unspecified`. |
 
 ### Targets
 
@@ -103,7 +109,7 @@ One of the following special labels _must_ be included in each target of `target
 
 * `__container_id__`: The container ID.
 * `__meta_docker_container_id`: The ID of the Docker container.
-* `__meta_kubernetes_pod_container_id`: The ID of the Kubernetes pod container.
+* `__meta_kubernetes_pod_container_id`: The ID of the Kubernetes Pod container.
 * `__process_pid__` : The process ID.
 
 Each process is then associated with a specified target from the targets list, determined by a container ID or process PID.
@@ -117,49 +123,49 @@ Otherwise the process isn't profiled.
 The special label `service_name` is required and must always be present.
 If it's not specified, it's attempted to be inferred from multiple sources:
 
-- `__meta_kubernetes_pod_annotation_pyroscope_io_service_name` which is a `pyroscope.io/service_name` pod annotation.
-- `__meta_kubernetes_namespace` and `__meta_kubernetes_pod_container_name`
-- `__meta_docker_container_name`
+* `__meta_docker_container_name`
+* `__meta_kubernetes_namespace` and `__meta_kubernetes_pod_container_name`
+* `__meta_kubernetes_pod_annotation_pyroscope_io_service_name` which is a `pyroscope.io/service_name` Pod annotation.
 
 If `service_name` isn't specified and couldn't be inferred, it's set to `unspecified`.
 
-## Troubleshooting unknown symbols
+## Troubleshoot unknown symbols
 
 Symbols are extracted from various sources, including:
 
-- The `.symtab` and `.dynsym` sections in the ELF file.
-- The `.symtab` and `.dynsym` sections in the debug ELF file.
-- The `.gopclntab` section in Go language ELF files.
+* The `.gopclntab` section in Go language ELF files.
+* The `.symtab` and `.dynsym` sections in the debug ELF file.
+* The `.symtab` and `.dynsym` sections in the ELF file.
 
 The search for debug files follows [gdb algorithm][].
 For example, if the profiler wants to find the debug file for `/lib/x86_64-linux-gnu/libc.so.6` with a `.gnu_debuglink` set to `libc.so.6.debug` and a build ID `0123456789abcdef`.
 The following paths are examined:
 
-- `/usr/lib/debug/.build-id/01/0123456789abcdef.debug`
-- `/lib/x86_64-linux-gnu/libc.so.6.debug`
-- `/lib/x86_64-linux-gnu/.debug/libc.so.6.debug`
-- `/usr/lib/debug/lib/x86_64-linux-gnu/libc.so.6.debug`
+* `/usr/lib/debug/.build-id/01/0123456789abcdef.debug`
+* `/lib/x86_64-linux-gnu/libc.so.6.debug`
+* `/lib/x86_64-linux-gnu/.debug/libc.so.6.debug`
+* `/usr/lib/debug/lib/x86_64-linux-gnu/libc.so.6.debug`
 
-### Dealing with unknown symbols
+### Deal with unknown symbols
 
-Unknown symbols in the profiles you’ve collected indicate that the profiler couldn't access an ELF file associated with a given address in the trace.
-
-This can occur for several reasons:
-
-- The process has terminated, making the ELF file inaccessible.
-- The ELF file is either corrupted or not recognized as an ELF file.
-- There is no corresponding ELF file entry in `/proc/pid/maps` for the address in the stack trace.
-
-### Addressing unresolved symbols
-
-If you only see module names (e.g., `/lib/x86_64-linux-gnu/libc.so.6`) without corresponding function names, this indicates that the symbols couldn't be mapped to their respective function names.
+Unknown symbols in the profiles you've collected indicate that the profiler couldn't access an ELF file associated with a given address in the trace.
 
 This can occur for several reasons:
 
-- The binary has been stripped, leaving no .symtab, .dynsym, or .gopclntab sections in the ELF file.
-- The debug file is missing or could not be located.
+* The process has terminated, making the ELF file inaccessible.
+* The ELF file is either corrupted or not recognized as an ELF file.
+* There is no corresponding ELF file entry in `/proc/pid/maps` for the address in the stack trace.
 
-To fix this for your binaries, ensure that they are either not stripped or that you have separate debug files available.
+### Address unresolved symbols
+
+If you only see module names without corresponding function names, for example, `/lib/x86_64-linux-gnu/libc.so.6`, it indicates that the symbols couldn't be mapped to their respective function names.
+
+This can occur for several reasons:
+
+* The binary has been stripped, leaving no .symtab, .dynsym, or .gopclntab sections in the ELF file.
+* The debug file is missing or couldn't be located.
+
+To fix this for your binaries, ensure that they're either not stripped or that you have separate debug files available.
 You can achieve this by running:
 
 ```bash
@@ -175,26 +181,25 @@ On Ubuntu, for example, you can install debug symbols for `libc` by executing:
 apt install libc6-dbg
 ```
 
-### Understanding flat stack traces
+### Understand flat stack traces
 
 If your profiles show many shallow stack traces, typically 1-2 frames deep, your binary might have been compiled without frame pointers.
 
 To compile your code with frame pointers, include the `-fno-omit-frame-pointer` flag in your compiler options.
 
-
 ## Example
 
 ### Kubernetes discovery
 
-In the following example, performance profiles are collected from pods on the same node, discovered using `discovery.kubernetes`.
-Pod selection relies on the `HOSTNAME` environment variable, which is a pod name if {{< param "PRODUCT_NAME" >}} is used as an {{< param "PRODUCT_NAME" >}} Helm chart.
+In the following example, performance profiles are collected from Pods on the same node, discovered using `discovery.kubernetes`.
+Pod selection relies on the `HOSTNAME` environment variable, which is a Pod name if {{< param "PRODUCT_NAME" >}} is used as an {{< param "PRODUCT_NAME" >}} Helm chart.
 The `service_name` label is set to `{__meta_kubernetes_namespace}/{__meta_kubernetes_pod_container_name}` from Kubernetes meta labels.
 
 ```alloy
 discovery.kubernetes "all_pods" {
   role = "pod"
   selectors {
-    field = "spec.nodeName=" + sys.env("HOSTNAME")
+    field = "spec.nodeName=" + sys.env("<HOSTNAME>")
     role = "pod"
   }
 }
@@ -282,7 +287,7 @@ pyroscope.ebpf "default" {
 }
 ```
 
-[troubleshooting]: #troubleshooting-unknown-symbols
+[troubleshooting]: #troubleshoot-unknown-symbols
 [gdb algorithm]: https://sourceware.org/gdb/onlinedocs/gdb/Separate-Debug-Files.html
 
 <!-- START GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/reference/components/pyroscope/pyroscope.java.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.java.md
@@ -3,10 +3,12 @@ canonical: https://grafana.com/docs/alloy/latest/reference/components/pyroscope/
 aliases:
   - ../pyroscope.java/ # /docs/alloy/latest/reference/components/pyroscope.java/
 description: Learn about pyroscope.java
+labels:
+  stage: general-availability
 title: pyroscope.java
 ---
 
-# pyroscope.java
+# `pyroscope.java`
 
 `pyroscope.java` continuously profiles Java processes running on the local Linux OS using [async-profiler](https://github.com/async-profiler/async-profiler).
 
@@ -17,15 +19,16 @@ To use the  `pyroscope.java` component you must run {{< param "PRODUCT_NAME" >}}
 ## Usage
 
 ```alloy
-pyroscope.java "LABEL" {
-  targets    = TARGET_LIST
-  forward_to = RECEIVER_LIST
+pyroscope.java "<LABEL>" {
+  targets    = <TARGET_LIST>
+  forward_to = <RECEIVER_LIST>
 }
 ```
 
 ## Target JVM configuration
 
-When you use `pyroscope.java` to profile Java applications, you can configure the target JVMs with some command line flags that ensure accurate profiling, especially for inlined methods. Add the following flags to your Java application's startup command:
+When you use `pyroscope.java` to profile Java applications, you can configure the target JVMs with some command line flags that ensure accurate profiling, especially for inlined methods.
+Add the following flags to your Java application's startup command:
 
 ```java
 -XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints
@@ -33,7 +36,7 @@ When you use `pyroscope.java` to profile Java applications, you can configure th
 
 For more details, refer to [Restrictions/Limitations](https://github.com/async-profiler/async-profiler?tab=readme-ov-file#restrictionslimitations) in the async-profiler documentation.
 
-## Additional Configuration for Linux Capabilities
+## Additional configuration for Linux capabilities
 
 If your Kubernetes environment has Linux capabilities enabled, configure the following in your Helm values to ensure `pyroscope.java` functions properly:
 
@@ -49,45 +52,46 @@ alloy:
         - SYS_RESOURCE
         - SYS_ADMIN
 ```
+
 These capabilities enable {{< param "PRODUCT_NAME" >}} to access performance monitoring subsystems, trace processes, override resource limits, and perform necessary system administration tasks for profiling.
 
 {{< admonition type="note" >}}
 Adjust capabilities based on your specific security requirements and environment, following the principle of least privilege.
 The capability behavior depends on Container Runtime Interface (CRI) settings.
-For example, in Docker, capabilities that are not on the allowlist are dropped by default.
+For example, in Docker, capabilities that aren't on the allowlist are dropped by default.
 {{< /admonition >}}
 
 ## Arguments
 
-The following arguments are supported:
+You can use the following arguments with `pyroscope.java`:
 
-Name         | Type                     | Description                                      | Default | Required
--------------|--------------------------|--------------------------------------------------|---------|---------
-`targets`    | `list(map(string))`      | List of java process targets to profile.         |         | yes
-`forward_to` | `list(ProfilesReceiver)` | List of receivers to send collected profiles to. |         | yes
-`tmp_dir`    | `string`                 | Temporary directory to store async-profiler.     | `/tmp`  | no
+| Name         | Type                     | Description                                      | Default | Required |
+| ------------ | ------------------------ | ------------------------------------------------ | ------- | -------- |
+| `forward_to` | `list(ProfilesReceiver)` | List of receivers to send collected profiles to. |         | yes      |
+| `targets`    | `list(map(string))`      | List of java process targets to profile.         |         | yes      |
+| `tmp_dir`    | `string`                 | Temporary directory to store async-profiler.     | `/tmp`  | no       |
 
 ## Profiling behavior
 
 The special label `__process_pid__` _must always_ be present in each target of `targets` and corresponds to the `PID` of the process to profile.
 
-After component startup, `pyroscope.java` creates a temporary directory under `tmp_dir` and extracts the async-profiler binaries for both glibc and musl into the directory with the following layout.
+After component startup, `pyroscope.java` creates a temporary directory under `tmp_dir` and extracts the async-profiler binaries for both `glibc` and `musl` into the directory with the following layout.
 
-```
+```text
 /tmp/alloy-asprof-glibc-{SHA1}/bin/asprof
 /tmp/alloy-asprof-glibc-{SHA1}/lib/libasyncProfiler.so
 /tmp/alloy-asprof-musl-{SHA1}/bin/asprof
 /tmp/alloy-asprof-musl-{SHA1}/lib/libasyncProfiler.so
 ```
 
-After process profiling startup, the component detects libc type and copies according `libAsyncProfiler.so` into the target process file system at the exact same path.
+After process profiling startup, the component detects `libc` type and copies according `libAsyncProfiler.so` into the target process file system at the exact same path.
 
 {{< admonition type="note" >}}
 The `asprof` binary runs with root permissions.
 If you change the `tmp_dir` configuration to something other than `/tmp`, then you must ensure that the directory is only writable by root.
 {{< /admonition >}}
 
-#### `targets` argument
+### `targets`
 
 The special `__process_pid__` label _must always_ be present and corresponds to the process PID that's used for profiling.
 
@@ -95,52 +99,54 @@ Labels starting with a double underscore (`__`) are treated as _internal_, and a
 
 The special label `service_name` is required and must always be present.
 If it's not specified, `pyroscope.scrape` will attempt to infer it from either of the following sources, in this order:
-1. `__meta_kubernetes_pod_annotation_pyroscope_io_service_name` which is a `pyroscope.io/service_name` pod annotation.
-2. `__meta_kubernetes_namespace` and `__meta_kubernetes_pod_container_name`
-3. `__meta_docker_container_name`
-4. `__meta_dockerswarm_container_label_service_name` or `__meta_dockerswarm_service_name`
+
+1. `__meta_kubernetes_pod_annotation_pyroscope_io_service_name` which is a `pyroscope.io/service_name` Pod annotation.
+1. `__meta_kubernetes_namespace` and `__meta_kubernetes_pod_container_name`
+1. `__meta_docker_container_name`
+1. `__meta_dockerswarm_container_label_service_name` or `__meta_dockerswarm_service_name`
 
 If `service_name` isn't specified and couldn't be inferred, then it's set to `unspecified`.
 
 ## Blocks
 
-The following blocks are supported inside the definition of `pyroscope.java`:
+You can use the following block with `pyroscope.java`:
 
-Hierarchy        | Block                | Description                             | Required
------------------|----------------------|-----------------------------------------|---------
-profiling_config | [profiling_config][] | Describes java profiling configuration. | no
+| Block                                 | Description                             | Required |
+| ------------------------------------- | --------------------------------------- | -------- |
+| [profiling_config`][profiling_config] | Describes java profiling configuration. | no       |
 
-[profiling_config]: #profiling_config-block
+[profiling_config]: #profiling_config
 
-### profiling_config block
+### `profiling_config`
 
 The `profiling_config` block describes how async-profiler is invoked.
 
 The following arguments are supported:
 
-Name          | Type       | Description                                                                                                 | Default  | Required
---------------|------------|-------------------------------------------------------------------------------------------------------------|----------|---------
-`interval`    | `duration` | How frequently to collect profiles from the targets.                                                        | "60s"    | no
-`cpu`         | `bool`     | A flag to enable cpu profiling, using `itimer` async-profiler event by default.                             | true     | no
-`sample_rate` | `int`      | CPU profiling sample rate. It is converted from Hz to interval and passed as an `-i` arg to async-profiler. | 100      | no
-`alloc`       | `string`   | Allocation profiling sampling configuration  It is passed as an `--alloc` arg to async-profiler.            | "512k"   | no
-`lock`        | `string`   | Lock profiling sampling configuration. It is passed as an `--lock` arg to async-profiler.                   | "10ms"   | no
-`event`       | `string`   | Sets the CPU profiling event. Can be one of `itimer`, `cpu` or `wall`.                                      | "itimer" | no
-`per_thread`  | `bool`     | Sets per thread mode on async profiler. It is passed as an `-t` arg to async-profiler.                      | false    | no
+| Name          | Type       | Description                                                                                                     | Default    | Required |
+| ------------- | ---------- | --------------------------------------------------------------------------------------------------------------- | ---------- | -------- |
+| `alloc`       | `string`   | Allocation profiling sampling configuration  It's passed as an `--alloc` argument to async-profiler.            | `"512k"`   | no       |
+| `cpu`         | `bool`     | A flag to enable CPU profiling, using `itimer` async-profiler event by default.                                 | `true`     | no       |
+| `event`       | `string`   | Sets the CPU profiling event. Can be one of `itimer`, `cpu` or `wall`.                                          | `"itimer"` | no       |
+| `interval`    | `duration` | How frequently to collect profiles from the targets.                                                            | `"60s"`    | no       |
+| `lock`        | `string`   | Lock profiling sampling configuration. It's passed as an `--lock` argument to async-profiler.                   | `"10ms"`   | no       |
+| `per_thread`  | `bool`     | Sets per thread mode on async profiler. It's passed as an `-t` argument to async-profiler.                      | `false`    | no       |
+| `sample_rate` | `int`      | CPU profiling sample rate. It's converted from Hz to interval and passed as an `-i` argument to async-profiler. | `100`      | no       |
 
 Refer to [profiler-options](https://github.com/async-profiler/async-profiler?tab=readme-ov-file#profiler-options) for more information about async-profiler configuration.
 
-#### `event` argument
+#### `event`
 
-Sets the CPU profiling event:
-* `itimer` - Default. Uses the [`setitimer(ITIMER_PROF)`](http://man7.org/linux/man-pages/man2/setitimer.2.html) 
-   syscall, which generates a signal every time a process consumes CPU. 
+The `event` argument sets the CPU profiling event:
+
+* `itimer` - Default. Uses the [`setitimer(ITIMER_PROF)`](http://man7.org/linux/man-pages/man2/setitimer.2.html) syscall, which generates a signal every time a process consumes CPU.
 * `cpu` - Uses PMU-case sampling (like Intel PEBS or AMD IBS), can be more accurate than `itimer`, but it's not available on every platform.
 * `wall` - This samples all threads equally every given period of time regardless of thread status: Running, Sleeping, or Blocked.
    For example, this can be helpful when profiling application start-up time or IO-intensive processes.
 
-#### `per_thread` argument  
-Sets per thread mode on async profiler. Threads are profiled separately and each stack trace will end with a frame that denotes a single thread.
+#### `per_thread`
+
+The `per_thread` argument sets per thread mode on async profiler. Threads are profiled separately and each stack trace ends with a frame that denotes a single thread.
 
 The Wall-clock profiler (`event=wall`) is most useful in per-thread mode.
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.receive_http.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.receive_http.md
@@ -1,12 +1,12 @@
 ---
 canonical: https://grafana.com/docs/alloy/latest/reference/components/pyroscope/pyroscope.receive_http/
 description: Learn about pyroscope.receive_http
+labels:
+  stage: public-preview
 title: pyroscope.receive_http
 ---
 
-<span class="badge docs-labels__stage docs-labels__item">Public preview</span>
-
-# pyroscope.receive_http
+# `pyroscope.receive_http`
 
 {{< docs/shared lookup="stability/public_preview.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
@@ -18,63 +18,68 @@ This allows `pyroscope.receive_http` to act as a proxy for Pyroscope profiles, e
 ## Usage
 
 ```alloy
-pyroscope.receive_http "LABEL" {
+pyroscope.receive_http "<LABEL>" {
   http {
-    listen_address = "LISTEN_ADDRESS"
-    listen_port = PORT
+    listen_address = "<LISTEN_ADDRESS>"
+    listen_port = "<PORT>"
   }
-  forward_to = RECEIVER_LIST
+  forward_to = <RECEIVER_LIST>
 }
 ```
 
-The component will start an HTTP server supporting the following endpoint.
+The component starts an HTTP server supporting the following endpoint.
 
-* `POST /ingest` - send profiles to the component, which will be forwarded to the receivers as configured in the `forward_to argument`. The request format must match the format of the Pyroscope ingest API.
-* `POST /push.v1.PusherService/Push` - send profiles to the component, which will be forwarded to the receivers as configured in the `forward_to argument`. The request format must match the format of the Pyroscope pushv1.PusherService Connect API.
+* `POST /ingest` - send profiles to the component, which is forwarded to the receivers as configured in the `forward_to argument`.
+  The request format must match the format of the Pyroscope ingest API.
+* `POST /push.v1.PusherService/Push` - send profiles to the component, which is forwarded to the receivers as configured in the `forward_to argument`.
+  The request format must match the format of the Pyroscope pushv1.PusherService Connect API.
 
 ## Arguments
 
-The following arguments are supported:
+You can use the following arguments with `pyroscope.receive_http`:
 
-Name              | Type          | Description                                     | Default | Required
-------------------|---------------|-------------------------------------------------|---------|---------
-`forward_to` | `list(ProfilesReceiver)` | List of receivers to send profiles to. |         | yes
+| Name         | Type                     | Description                            | Default | Required |
+| ------------ | ------------------------ | -------------------------------------- | ------- | -------- |
+| `forward_to` | `list(ProfilesReceiver)` | List of receivers to send profiles to. |         | yes      |
 
 ## Blocks
 
-The following blocks are supported inside the definition of `pyroscope.receive_http`:
+You can use the following blocks `pyroscope.receive_http`:
 
-Hierarchy | Name | Description                                        | Required
-----------|------|----------------------------------------------------|---------
-`http`    | `http` | Configures the HTTP server that receives requests. | no
+| Name           | Description                                        | Required |
+| -------------- | -------------------------------------------------- | -------- |
+| [`http`][http] | Configures the HTTP server that receives requests. | no       |
 
-### http
+[http]: #http
+
+### `http`
 
 The `http` block configures the HTTP server.
 
 You can use the following arguments to configure the `http` block. Any omitted fields take their default values.
 
-Name                   | Type       | Description                                                                                                      | Default  | Required
------------------------|------------|------------------------------------------------------------------------------------------------------------------|----------|---------
-`conn_limit`           | `int`      | Maximum number of simultaneous HTTP connections. Defaults to 100.                                           | `0`      | no
-`listen_address`       | `string`   | Network address on which the server listens for new connections. Defaults to accepting all incoming connections. | `""`     | no
-`listen_port`          | `int`      | Port number on which the server listens for new connections.                                                     | `8080`   | no
-`server_idle_timeout`  | `duration` | Idle timeout for the HTTP server.                                                                                    | `"120s"` | no
-`server_read_timeout`  | `duration` | Read timeout for the HTTP server.                                                                                    | `"30s"`  | no
-`server_write_timeout` | `duration` | Write timeout for the HTTP server.                                                                                   | `"30s"`  | no
+| Name                   | Type       | Description                                                                                                      | Default  | Required |
+| ---------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------- | -------- | -------- |
+| `conn_limit`           | `int`      | Maximum number of simultaneous HTTP connections. Defaults to 100.                                                | `0`      | no       |
+| `listen_address`       | `string`   | Network address on which the server listens for new connections. Defaults to accepting all incoming connections. | `""`     | no       |
+| `listen_port`          | `int`      | Port number on which the server listens for new connections.                                                     | `8080`   | no       |
+| `server_idle_timeout`  | `duration` | Idle timeout for the HTTP server.                                                                                | `"120s"` | no       |
+| `server_read_timeout`  | `duration` | Read timeout for the HTTP server.                                                                                | `"30s"`  | no       |
+| `server_write_timeout` | `duration` | Write timeout for the HTTP server.                                                                               | `"30s"`  | no       |
 
 ## Exported fields
 
-`pyroscope.receive_http` does not export any fields.
+`pyroscope.receive_http` doesn't export any fields.
 
 ## Component health
 
-`pyroscope.receive_http` is reported as unhealthy if it is given an invalid configuration.
+`pyroscope.receive_http` is reported as unhealthy if it's given an invalid configuration.
 
 ## Example
 
 This example creates a `pyroscope.receive_http` component, which starts an HTTP server listening on `0.0.0.0` and port `9999`.
 The server receives profiles and forwards them to multiple `pyroscope.write` components, which write these profiles to different HTTP endpoints.
+
 ```alloy
 // Receives profiles over HTTP
 pyroscope.receive_http "default" {
@@ -102,10 +107,11 @@ pyroscope.write "production" {
 
 {{< admonition type="note" >}}
 This example demonstrates forwarding to multiple `pyroscope.write` components.
-This configuration will duplicate the received profiles and send a copy to each configured `pyroscope.write` component.
+This configuration duplicates the received profiles and send a copy to each configured `pyroscope.write` component.
 {{< /admonition >}}
 
-You can also create multiple `pyroscope.receive_http` components with different configurations to listen on different addresses or ports as needed. This flexibility allows you to design a setup that best fits your infrastructure and profile routing requirements.
+You can also create multiple `pyroscope.receive_http` components with different configurations to listen on different addresses or ports as needed.
+This flexibility allows you to design a setup that best fits your infrastructure and profile routing requirements.
 
 <!-- START GENERATED COMPATIBLE COMPONENTS -->
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.relabel.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.relabel.md
@@ -3,24 +3,27 @@ canonical: https://grafana.com/docs/alloy/latest/reference/components/pyroscope/
 aliases:
   - ../pyroscope.relabel/ # /docs/alloy/latest/reference/components/pyroscope.relabel/
 description: Learn about pyroscope.relabel
+labels:
+  stage: public-preview
 title: pyroscope.relabel
 ---
 
-<span class="badge docs-labels__stage docs-labels__item">Public preview</span>
-
 # `pyroscope.relabel`
+
+{{< docs/shared lookup="stability/public_preview.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 The `pyroscope.relabel` component rewrites the label set of each profile passed to its receiver by applying one or more relabeling rules and forwards the results to the list of receivers.
 
 If no rules are defined or applicable to some profiles, then those profiles are forwarded as-is to each receiver passed in the component's arguments. 
 The profile is dropped if no labels remain after the relabeling rules are applied.
 
-The most common use of `pyroscope.relabel` is to filter profiles or standardize the label set that is passed to one or more downstream receivers. The `rule` blocks are applied to the label set of each profile in order of their appearance in the configuration file.
+The most common use of `pyroscope.relabel` is to filter profiles or standardize the label set that is passed to one or more downstream receivers.
+The `rule` blocks are applied to the label set of each profile in order of their appearance in the configuration file.
 
 ## Usage
 
 ```alloy
-pyroscope.relabel "LABEL" {
+pyroscope.relabel "<LABEL>" {
     forward_to = <RECEIVER_LIST>
 
     rule {
@@ -42,7 +45,7 @@ You can use the following arguments with `pyroscope.relabel`:
 
 ## Blocks
 
-You can use the following blocks with `pyroscope.relabel`:
+You can use the following block with `pyroscope.relabel`:
 
 |      Name      |                      Description                       | Required |
 | -------------- | ------------------------------------------------------ | -------- |

--- a/docs/sources/reference/components/pyroscope/pyroscope.scrape.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.scrape.md
@@ -3,25 +3,28 @@ canonical: https://grafana.com/docs/alloy/latest/reference/components/pyroscope/
 aliases:
   - ../pyroscope.scrape/ # /docs/alloy/latest/reference/components/pyroscope.scrape/
 description: Learn about pyroscope.scrape
+labels:
+  stage: general-availability
 title: pyroscope.scrape
 ---
 
-# pyroscope.scrape
+# `pyroscope.scrape`
 
 `pyroscope.scrape` collects [pprof] performance profiles for a given set of HTTP `targets`.
 
-`pyroscope.scrape` mimcks the scraping behavior of `prometheus.scrape`.
+`pyroscope.scrape` mimics the scraping behavior of `prometheus.scrape`.
 Similarly to how Prometheus scrapes metrics via HTTP, `pyroscope.scrape` collects profiles via HTTP requests.
 
 Unlike Prometheus, which usually only scrapes one `/metrics` endpoint per target, `pyroscope.scrape` may need to scrape multiple endpoints for the same target.
 This is because different types of profiles are scraped on different endpoints.
-For example, "mutex" profiles may be scraped on a `/debug/pprof/delta_mutex` HTTP endpoint, whereas memory consumption may be scraped on a `/debug/pprof/allocs` HTTP endpoint.
+For example, mutex profiles may be scraped on a `/debug/pprof/delta_mutex` HTTP endpoint, whereas memory consumption may be scraped on a `/debug/pprof/allocs` HTTP endpoint.
 
 The profile paths, protocol scheme, scrape interval, scrape timeout, query parameters, as well as any other settings can be configured within `pyroscope.scrape`.
 
 The `pyroscope.scrape` component regards a scrape as successful if it responded with an HTTP `200 OK` status code and returned the body of a valid [pprof] profile.
 
 If a scrape request fails, the [debug UI][] for `pyroscope.scrape` will show:
+
 * Detailed information about the failure.
 * The time of the last successful scrape.
 * The labels last used for scraping.
@@ -35,72 +38,69 @@ Multiple `pyroscope.scrape` components can be specified by giving them different
 ## Usage
 
 ```alloy
-pyroscope.scrape "LABEL" {
-  targets    = TARGET_LIST
-  forward_to = RECEIVER_LIST
+pyroscope.scrape "<LABEL>" {
+  targets    = <TARGET_LIST>
+  forward_to = <RECEIVER_LIST>
 }
 ```
 
 ## Arguments
 
 `pyroscope.scrape` starts a new scrape job to scrape all of the input targets.
-Multiple scrape jobs can be started for a single input target
-when scraping multiple profile types.
+Multiple scrape jobs can be started for a single input target when scraping multiple profile types.
 
-The list of arguments that can be used to configure the block is
-presented below.
+You can use the following arguments with `pyroscope.scrape`:
 
-Any omitted arguments take on their default values.
-If conflicting arguments are being passed (for example, configuring both `bearer_token` and `bearer_token_file`), then `pyroscope.scrape` will fail to start and will report an error.
-
-The following arguments are supported:
-
-Name                | Type                     | Description                                                        | Default        | Required
-------------------- | ------------------------ | ------------------------------------------------------------------ | -------------- | --------
-`targets`           | `list(map(string))`      | List of targets to scrape.                                         |                | yes
-`forward_to`        | `list(ProfilesReceiver)` | List of receivers to send scraped profiles to.                     |                | yes
-`job_name`          | `string`                 | The job name to override the job label with.                       | component name | no
-`params`            | `map(list(string))`      | A set of query parameters with which the target is scraped.        |                | no
-`scrape_interval`   | `duration`               | How frequently to scrape the targets of this scrape configuration. | `"15s"`        | no
-`scrape_timeout`    | `duration`               | The timeout for scraping targets of this configuration. Must be larger than `scrape_interval`. | `"18s"` | no
-`delta_profiling_duration`| `duration` | The duration for a delta profiling to be scraped. Must be larger than 1 second. | `"14s"` | no
-`scheme`            | `string`                 | The URL scheme with which to fetch metrics from targets.           | `"http"`       | no
-`bearer_token_file` | `string`                 | File containing a bearer token to authenticate with.               |                | no
-`bearer_token`      | `secret`                 | Bearer token to authenticate with.                                 |                | no
-`enable_http2`      | `bool`                   | Whether HTTP2 is supported for requests.                           | `true`         | no
-`follow_redirects`  | `bool`                   | Whether redirects returned by the server should be followed.       | `true`         | no
-`proxy_url`         | `string`                 | HTTP proxy to send requests through.                               |                | no
-`no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. | | no
-`proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.              | `false`        | no
-`proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests.      |                | no
+| Name                       | Type                     | Description                                                                                      | Default        | Required |
+| -------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------ | -------------- | -------- |
+| `targets`                  | `list(map(string))`      | List of targets to scrape.                                                                       |                | yes      |
+| `forward_to`               | `list(ProfilesReceiver)` | List of receivers to send scraped profiles to.                                                   |                | yes      |
+| `job_name`                 | `string`                 | The job name to override the job label with.                                                     | component name | no       |
+| `params`                   | `map(list(string))`      | A set of query parameters with which the target is scraped.                                      |                | no       |
+| `scrape_interval`          | `duration`               | How frequently to scrape the targets of this scrape configuration.                               | `"15s"`        | no       |
+| `scrape_timeout`           | `duration`               | The timeout for scraping targets of this configuration. Must be larger than `scrape_interval`.   | `"18s"`        | no       |
+| `delta_profiling_duration` | `duration`               | The duration for a delta profiling to be scraped. Must be larger than 1 second.                  | `"14s"`        | no       |
+| `scheme`                   | `string`                 | The URL scheme with which to fetch metrics from targets.                                         | `"http"`       | no       |
+| `bearer_token_file`        | `string`                 | File containing a bearer token to authenticate with.                                             |                | no       |
+| `bearer_token`             | `secret`                 | Bearer token to authenticate with.                                                               |                | no       |
+| `enable_http2`             | `bool`                   | Whether HTTP2 is supported for requests.                                                         | `true`         | no       |
+| `follow_redirects`         | `bool`                   | Whether redirects returned by the server should be followed.                                     | `true`         | no       |
+| `proxy_url`                | `string`                 | HTTP proxy to send requests through.                                                             |                | no       |
+| `no_proxy`                 | `string`                 | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. |                | no       |
+| `proxy_from_environment`   | `bool`                   | Use the proxy URL indicated by environment variables.                                            | `false`        | no       |
+| `proxy_connect_header`     | `map(list(secret))`      | Specifies headers to send to proxies during CONNECT requests.                                    |                | no       |
 
  At most, one of the following can be provided:
- - [`bearer_token` argument](#arguments).
- - [`bearer_token_file` argument](#arguments).
- - [`basic_auth` block][basic_auth].
- - [`authorization` block][authorization].
- - [`oauth2` block][oauth2].
+
+* [`authorization`][authorization] block
+* [`basic_auth`][basic_auth] block
+* [`bearer_token_file`][arguments] argument
+* [`bearer_token`][arguments] argument
+* [`oauth2`][oauth2] block
+
+Any omitted arguments take on their default values.
+If conflicting arguments are being passed, for example, configuring both `bearer_token` and `bearer_token_file`, then `pyroscope.scrape` will fail to start and will report an error.
 
 [arguments]: #arguments
 
 {{< docs/shared lookup="reference/components/http-client-proxy-config-description.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
-#### `job_name` argument
+### `job_name`
 
-`job_name` defaults to the component's unique identifier.
+The `job_name` argument defaults to the component's unique identifier.
 
 For example, the `job_name` of `pyroscope.scrape "local" { ... }` will be `"pyroscope.scrape.local"`.
 
-#### `targets` argument
+### `targets`
 
 The list of `targets` can be provided [statically][example_static_targets], [dynamically][example_dynamic_targets], or a [combination of both][example_static_and_dynamic_targets].
 
 The following special labels can change the behavior of `pyroscope.scrape`:
 
 * `__address__` is the special label that _must always_ be present and corresponds to the `<host>:<port>` that is used for the scrape request.
+* `__name__` is the special label that indicates the profile type being collected.
 * `__profile_path__` is the special label that holds the path to the profile endpoint on the target (e.g. "/debug/pprof/allocs").
 * `__profile_path_prefix__` is the special label that holds an optional prefix to prepend to the profile path (e.g. "/mimir-prometheus").
-* `__name__` is the special label that indicates the profile type being collected.
 * `service_name` is a required label that identifies the service being profiled.
 
 Labels starting with a double underscore (`__`) are treated as _internal_, and are removed prior to scraping.
@@ -109,34 +109,36 @@ The special label `service_name` is required and must always be present.
 If it's not specified, `pyroscope.scrape` will attempt to infer it from either of the following sources, in this order:
 
 1. `__meta_kubernetes_pod_annotation_pyroscope_io_service_name` which is a `pyroscope.io/service_name` pod annotation.
-2. `__meta_kubernetes_namespace` and `__meta_kubernetes_pod_container_name`
-3. `__meta_docker_container_name`
-4. `__meta_dockerswarm_container_label_service_name` or `__meta_dockerswarm_service_name`
+1. `__meta_kubernetes_namespace` and `__meta_kubernetes_pod_container_name`
+1. `__meta_docker_container_name`
+1. `__meta_dockerswarm_container_label_service_name` or `__meta_dockerswarm_service_name`
 
-If `service_name` is not specified and could not be inferred, then it is set to `unspecified`.
+If `service_name` isn't specified and couldn't be inferred, then it's set to `unspecified`.
 
 The following labels are automatically injected to the scraped profiles so that they can be linked to a scrape target:
 
-Label            | Description
------------------|-----------------------------------------------------------------
-`"job"`          | The `job_name` that the target belongs to.
-`"instance"`     | The `__address__` or `<host>:<port>` of the scrape target's URL.
-`"service_name"` | The inferred Pyroscope service name.
+| Label            | Description                                                      |
+| ---------------- | ---------------------------------------------------------------- |
+| `"job"`          | The `job_name` that the target belongs to.                       |
+| `"instance"`     | The `__address__` or `<host>:<port>` of the scrape target's URL. |
+| `"service_name"` | The inferred Pyroscope service name.                             |
 
-#### `scrape_interval` argument
+#### `scrape_interval`
 
 The `scrape_interval` typically refers to the frequency with which {{< param "PRODUCT_NAME" >}} collects performance profiles from the monitored targets.
 It represents the time interval between consecutive scrapes or data collection events.
 This parameter is important for controlling the trade-off between resource usage and the freshness of the collected data.
 
 If `scrape_interval` is short:
+
 * Advantages:
   * Fewer profiles may be lost if the application being scraped crashes.
 * Disadvantages:
   * Greater consumption of CPU, memory, and network resources during scrapes and remote writes.
-  * The backend database (Pyroscope) will consume more storage space.
+  * The backend database (Pyroscope) consumes more storage space.
 
 If `scrape_interval` is long:
+
 * Advantages:
   * Lower resource consumption.
 * Disadvantages:
@@ -146,249 +148,250 @@ If `scrape_interval` is long:
   * If the [delta argument][] is set to `true`, there is a larger risk of reaching the HTTP server timeouts of the application being scraped.
 
 For example, consider this situation:
+
 * `pyroscope.scrape` is configured with a `scrape_interval` of `"60s"`.
 * The application being scraped is running an HTTP server with a timeout of 30 seconds.
 * Any scrape HTTP requests where the [delta argument][] is set to `true` will fail, because they will attempt to run for 59 seconds.
 
 ## Blocks
 
-The following blocks are supported inside the definition of `pyroscope.scrape`:
+You can use the following blocks with `pyroscope.scrape`:
 
-Hierarchy                                     | Block                          | Description                                                                                 | Required
-----------------------------------------------|--------------------------------|---------------------------------------------------------------------------------------------|---------
-basic_auth                                    | [basic_auth][]                 | Configure basic_auth for authenticating to targets.                                         | no
-authorization                                 | [authorization][]              | Configure generic authorization to targets.                                                 | no
-oauth2                                        | [oauth2][]                     | Configure OAuth2 for authenticating to targets.                                             | no
-oauth2 > tls_config                           | [tls_config][]                 | Configure TLS settings for connecting to targets via OAuth2.                                | no
-tls_config                                    | [tls_config][]                 | Configure TLS settings for connecting to targets.                                           | no
-profiling_config                              | [profiling_config][]           | Configure profiling settings for the scrape job.                                            | no
-profiling_config > profile.memory             | [profile.memory][]             | Collect memory profiles.                                                                    | no
-profiling_config > profile.block              | [profile.block][]              | Collect profiles on blocks.                                                                 | no
-profiling_config > profile.goroutine          | [profile.goroutine][]          | Collect goroutine profiles.                                                                 | no
-profiling_config > profile.mutex              | [profile.mutex][]              | Collect mutex profiles.                                                                     | no
-profiling_config > profile.process_cpu        | [profile.process_cpu][]        | Collect CPU profiles.                                                                       | no
-profiling_config > profile.fgprof             | [profile.fgprof][]             | Collect [fgprof][] profiles.                                                                | no
-profiling_config > profile.godeltaprof_memory | [profile.godeltaprof_memory][] | Collect [godeltaprof][] memory profiles.                                                    | no
-profiling_config > profile.godeltaprof_mutex  | [profile.godeltaprof_mutex][]  | Collect [godeltaprof][] mutex profiles.                                                     | no
-profiling_config > profile.godeltaprof_block  | [profile.godeltaprof_block][]  | Collect [godeltaprof][] block profiles.                                                     | no
-profiling_config > profile.custom             | [profile.custom][]             | Collect custom profiles.                                                                    | no
-clustering                                    | [clustering][]                 | Configure the component for when {{< param "PRODUCT_NAME" >}} is running in clustered mode. | no
+| Block                                                                           | Description                                                                                 | Required |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | -------- |
+| [`authorization`][authorization]                                                | Configure generic authorization to targets.                                                 | no       |
+| [`basic_auth`][basic_auth]                                                      | Configure `basic_auth` for authenticating to targets.                                       | no       |
+| [`clustering`][clustering]                                                      | Configure the component for when {{< param "PRODUCT_NAME" >}} is running in clustered mode. | no       |
+| [`oauth2`][oauth2]                                                              | Configure OAuth 2.0 for authenticating to targets.                                          | no       |
+| `oauth2` > [`tls_config`][tls_config]                                           | Configure TLS settings for connecting to targets via OAuth2.                                | no       |
+| [`profiling_config`][profiling_config]                                          | Configure profiling settings for the scrape job.                                            | no       |
+| `profiling_config` > [`profile.block`][profile.block]                           | Collect profiles on blocks.                                                                 | no       |
+| `profiling_config` > [`profile.custom`][profile.custom]                         | Collect custom profiles.                                                                    | no       |
+| `profiling_config` > [`profile.fgprof`][profile.fgprof]                         | Collect [`fgprof`][fgprof] profiles.                                                        | no       |
+| `profiling_config` > [`profile.godeltaprof_block`][profile.godeltaprof_block]   | Collect [`godeltaprof`][godeltaprof] block profiles.                                        | no       |
+| `profiling_config` > [`profile.godeltaprof_memory`][profile.godeltaprof_memory] | Collect [`godeltaprof`][godeltaprof] memory profiles.                                       | no       |
+| `profiling_config` > [`profile.godeltaprof_mutex`][profile.godeltaprof_mutex]   | Collect [`godeltaprof`][godeltaprof] mutex profiles.                                        | no       |
+| `profiling_config` > [`profile.goroutine`][profile.goroutine]                   | Collect goroutine profiles.                                                                 | no       |
+| `profiling_config` > [`profile.memory`][profile.memory]                         | Collect memory profiles.                                                                    | no       |
+| `profiling_config` > [`profile.mutex`][profile.mutex]                           | Collect mutex profiles.                                                                     | no       |
+| `profiling_config` > [`profile.process_cpu`][profile.process_cpu]               | Collect CPU profiles.                                                                       | no       |
+| [`tls_config`][tls_config]                                                      | Configure TLS settings for connecting to targets.                                           | no       |
 
-The `>` symbol indicates deeper levels of nesting.
-For example, `oauth2 > tls_config` refers to a `tls_config` block defined inside an `oauth2` block.
+The > symbol indicates deeper levels of nesting.
+For example, `oauth2` > `tls_config` refers to a `tls_config` block defined inside an `oauth2` block.
 
 Any omitted blocks take on their default values.
-For example, if `profile.mutex` is not specified in the config, the defaults documented in [profile.mutex][] will be used.
+For example, if `profile.mutex` isn't specified in the configuration, the defaults documented in [profile.mutex][] are used.
 
-[basic_auth]: #basic_auth-block
-[authorization]: #authorization-block
-[oauth2]: #oauth2-block
-[tls_config]: #tls_config-block
-[profiling_config]: #profiling_config-block
-[profile.memory]: #profilememory-block
-[profile.block]: #profileblock-block
-[profile.goroutine]: #profilegoroutine-block
-[profile.mutex]: #profilemutex-block
-[profile.process_cpu]: #profileprocess_cpu-block
-[profile.fgprof]: #profilefgprof-block
-[profile.godeltaprof_memory]: #profilegodeltaprof_memory-block
-[profile.godeltaprof_mutex]: #profilegodeltaprof_mutex-block
-[profile.godeltaprof_block]: #profilegodeltaprof_block-block
-[profile.custom]: #profilecustom-block
+[authorization]: #authorization
+[basic_auth]: #basic_auth
+[clustering]: #clustering
+[oauth2]: #oauth2
 [pprof]: https://github.com/google/pprof/blob/main/doc/README.md
-[clustering]: #clustering-block
+[profile.block]: #profileblock
+[profile.custom]: #profilecustom
+[profile.fgprof]: #profilefgprof
+[profile.godeltaprof_block]: #profilegodeltaprof_block
+[profile.godeltaprof_memory]: #profilegodeltaprof_memory
+[profile.godeltaprof_mutex]: #profilegodeltaprof_mutex
+[profile.goroutine]: #profilegoroutine
+[profile.memory]: #profilememory
+[profile.mutex]: #profilemutex
+[profile.process_cpu]: #profileprocess_cpu
+[profiling_config]: #profiling_config
+[tls_config]: #tls_config
 
 [fgprof]: https://github.com/felixge/fgprof
 [godeltaprof]: https://github.com/grafana/pyroscope-go/tree/main/godeltaprof
 
 [delta argument]: #delta-argument
 
-### basic_auth block
-
-{{< docs/shared lookup="reference/components/basic-auth-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
-
-### authorization block
+### `authorization`
 
 {{< docs/shared lookup="reference/components/authorization-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
-### oauth2 block
+### `basic_auth`
 
-{{< docs/shared lookup="reference/components/oauth2-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+{{< docs/shared lookup="reference/components/basic-auth-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
-### tls_config block
+### `clustering`
 
-{{< docs/shared lookup="reference/components/tls-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
-
-### profiling_config block
-
-The `profiling_config` block configures the profiling settings when scraping targets.
-
-The following arguments are supported:
-
-Name          | Type     | Description                                   | Default | Required
---------------|----------|-----------------------------------------------|---------|---------
-`path_prefix` | `string` | The path prefix to use when scraping targets. |         | no
-
-### profile.memory block
-
-The `profile.memory` block collects profiles on memory consumption.
-
-The following arguments are supported:
-
-Name      | Type      | Description                                 | Default                 | Required
-----------|-----------|---------------------------------------------|-------------------------|---------
-`enabled` | `boolean` | Enable this profile type to be scraped.     | `true`                  | no
-`path`    | `string`  | The path to the profile type on the target. | `"/debug/pprof/allocs"` | no
-`delta`   | `boolean` | Whether to scrape the profile as a delta.   | `false`                 | no
-
-For more information about the `delta` argument, see the [delta argument][] section.
-
-### profile.block block
-
-The `profile.block` block collects profiles on process blocking.
-
-The following arguments are supported:
-
-Name      | Type      | Description                                 | Default                | Required
-----------|-----------|---------------------------------------------|------------------------|---------
-`enabled` | `boolean` | Enable this profile type to be scraped.     | `true`                 | no
-`path`    | `string`  | The path to the profile type on the target. | `"/debug/pprof/block"` | no
-`delta`   | `boolean` | Whether to scrape the profile as a delta.   | `false`                | no
-
-For more information about the `delta` argument, see the [delta argument][] section.
-
-### profile.goroutine block
-
-The `profile.goroutine` block collects profiles on the number of goroutines.
-
-The following arguments are supported:
-
-Name      | Type      | Description                                 | Default                    | Required
-----------|-----------|---------------------------------------------|----------------------------|---------
-`enabled` | `boolean` | Enable this profile type to be scraped.     | `true`                     | no
-`path`    | `string`  | The path to the profile type on the target. | `"/debug/pprof/goroutine"` | no
-`delta`   | `boolean` | Whether to scrape the profile as a delta.   | `false`                    | no
-
-For more information about the `delta` argument, see the [delta argument][] section.
-
-### profile.mutex block
-
-The `profile.mutex` block collects profiles on mutexes.
-
-The following arguments are supported:
-
-Name      | Type      | Description                                 | Default                | Required
-----------|-----------|---------------------------------------------|------------------------|---------
-`enabled` | `boolean` | Enable this profile type to be scraped.     | `true`                 | no
-`path`    | `string`  | The path to the profile type on the target. | `"/debug/pprof/mutex"` | no
-`delta`   | `boolean` | Whether to scrape the profile as a delta.   | `false`                | no
-
-For more information about the `delta` argument, see the [delta argument][] section.
-
-### profile.process_cpu block
-
-The `profile.process_cpu` block collects profiles on CPU consumption for the process.
-
-The following arguments are supported:
-
-Name      | Type      | Description                                 | Default                  | Required
-----------|-----------|---------------------------------------------|--------------------------|---------
-`enabled` | `boolean` | Enable this profile type to be scraped.     | `true`                   | no
-`path`    | `string`  | The path to the profile type on the target. | `"/debug/pprof/profile"` | no
-`delta`   | `boolean` | Whether to scrape the profile as a delta.   | `true`                   | no
-
-For more information about the `delta` argument, see the [delta argument][] section.
-
-### profile.fgprof block
-
-The `profile.fgprof` block collects profiles from an [fgprof][] endpoint.
-
-The following arguments are supported:
-
-Name      | Type      | Description                                 | Default           | Required
-----------|-----------|---------------------------------------------|-------------------|---------
-`enabled` | `boolean` | Enable this profile type to be scraped.     | `false`           | no
-`path`    | `string`  | The path to the profile type on the target. | `"/debug/fgprof"` | no
-`delta`   | `boolean` | Whether to scrape the profile as a delta.   | `true`            | no
-
-For more information about the `delta` argument, see the [delta argument][] section.
-
-### profile.godeltaprof_memory block
-
-The `profile.godeltaprof_memory` block collects profiles from [godeltaprof][] memory endpoint. The delta is computed on the target.
-
-The following arguments are supported:
-
-Name      | Type      | Description                                 | Default                     | Required
-----------|-----------|---------------------------------------------|-----------------------------|---------
-`enabled` | `boolean` | Enable this profile type to be scraped.     | `false`                     | no
-`path`    | `string`  | The path to the profile type on the target. | `"/debug/pprof/delta_heap"` | no
-
-### profile.godeltaprof_mutex block
-
-The `profile.godeltaprof_mutex` block collects profiles from [godeltaprof][] mutex endpoint.
-The delta is computed on the target.
-
-The following arguments are supported:
-
-Name      | Type      | Description                                 | Default                      | Required
-----------|-----------|---------------------------------------------|------------------------------|---------
-`enabled` | `boolean` | Enable this profile type to be scraped.     | `false`                      | no
-`path`    | `string`  | The path to the profile type on the target. | `"/debug/pprof/delta_mutex"` | no
-
-### profile.godeltaprof_block block
-
-The `profile.godeltaprof_block` block collects profiles from [godeltaprof][] block endpoint. The delta is computed on the target.
-
-The following arguments are supported:
-
-Name      | Type      | Description                                 | Default                      | Required
-----------|-----------|---------------------------------------------|------------------------------|---------
-`enabled` | `boolean` | Enable this profile type to be scraped.     | `false`                      | no
-`path`    | `string`  | The path to the profile type on the target. | `"/debug/pprof/delta_block"` | no
-
-
-### profile.custom block
-
-The `profile.custom` block allows for collecting profiles from custom endpoints. Blocks must be specified with a label:
-
-```alloy
-profile.custom "PROFILE_TYPE" {
-  enabled = true
-  path    = "PROFILE_PATH"
-}
-```
-
-Multiple `profile.custom` blocks can be specified.
-Labels assigned to `profile.custom` blocks must be unique across the component.
-
-The following arguments are supported:
-
-Name      | Type      | Description                                 | Default | Required
-----------|-----------|---------------------------------------------|---------|---------
-`enabled` | `boolean` | Enable this profile type to be scraped.     |         | yes
-`path`    | `string`  | The path to the profile type on the target. |         | yes
-`delta`   | `boolean` | Whether to scrape the profile as a delta.   | `false` | no
-
-When the `delta` argument is `true`, a `seconds` query parameter is automatically added to requests.
-The `seconds` used will be equal to `scrape_interval - 1`.
-
-### clustering block
-
-Name      | Type   | Description                                       | Default | Required
-----------|--------|---------------------------------------------------|---------|---------
-`enabled` | `bool` | Enables sharing targets with other cluster nodes. | `false` | yes
+| Name      | Type   | Description                                       | Default | Required |
+| --------- | ------ | ------------------------------------------------- | ------- | -------- |
+| `enabled` | `bool` | Enables sharing targets with other cluster nodes. | `false` | yes      |
 
 When {{< param "PRODUCT_NAME" >}} is [using clustering][], and `enabled` is set to true, then this `pyroscope.scrape` component instance opts-in to participating in the cluster to distribute scrape load between all cluster nodes.
 
 Clustering causes the set of targets to be locally filtered down to a unique subset per node, where each node is roughly assigned the same number of targets.
-If the state of the cluster changes, such as a new node joins, then the subset of targets to scrape per node will be recalculated.
+If the state of the cluster changes, such as a new node joins, then the subset of targets to scrape per node is recalculated.
 
 When clustering mode is enabled, all {{< param "PRODUCT_NAME" >}} instances participating in the cluster must use the same configuration file and have access to the same service discovery APIs.
 
 If {{< param "PRODUCT_NAME" >}} is _not_ running in clustered mode, this block is a no-op.
 
 [using clustering]: ../../../../get-started/clustering/
+
+### `oauth2`
+
+{{< docs/shared lookup="reference/components/oauth2-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `profiling_config`
+
+The `profiling_config` block configures the profiling settings when scraping targets.
+
+The following arguments are supported:
+
+| Name          | Type     | Description                                   | Default | Required |
+| ------------- | -------- | --------------------------------------------- | ------- | -------- |
+| `path_prefix` | `string` | The path prefix to use when scraping targets. |         | no       |
+
+### `profile.block`
+
+The `profile.block` block collects profiles on process blocking.
+
+The following arguments are supported:
+
+| Name      | Type      | Description                                 | Default                | Required |
+| --------- | --------- | ------------------------------------------- | ---------------------- | -------- |
+| `delta`   | `boolean` | Whether to scrape the profile as a delta.   | `false`                | no       |
+| `enabled` | `boolean` | Enable this profile type to be scraped.     | `true`                 | no       |
+| `path`    | `string`  | The path to the profile type on the target. | `"/debug/pprof/block"` | no       |
+
+For more information about the `delta` argument, see the [delta argument][] section.
+
+### `profile.custom`
+
+The `profile.custom` block allows for collecting profiles from custom endpoints.
+Blocks must be specified with a label:
+
+```alloy
+profile.custom "<PROFILE_TYPE>" {
+  enabled = true
+  path    = "<PROFILE_PATH>"
+}
+```
+
+You can specify multiple `profile.custom` blocks.
+Labels assigned to `profile.custom` blocks must be unique across the component.
+
+The following arguments are supported:
+
+| Name      | Type      | Description                                 | Default | Required |
+| --------- | --------- | ------------------------------------------- | ------- | -------- |
+| `delta`   | `boolean` | Whether to scrape the profile as a delta.   | `false` | no       |
+| `enabled` | `boolean` | Enable this profile type to be scraped.     |         | yes      |
+| `path`    | `string`  | The path to the profile type on the target. |         | yes      |
+
+When the `delta` argument is `true`, a `seconds` query parameter is automatically added to requests.
+The `seconds` used will be equal to `scrape_interval - 1`.
+
+### `profile.fgprof`
+
+The `profile.fgprof` block collects profiles from an [fgprof][] endpoint.
+
+The following arguments are supported:
+
+| Name      | Type      | Description                                 | Default           | Required |
+| --------- | --------- | ------------------------------------------- | ----------------- | -------- |
+| `delta`   | `boolean` | Whether to scrape the profile as a delta.   | `true`            | no       |
+| `enabled` | `boolean` | Enable this profile type to be scraped.     | `false`           | no       |
+| `path`    | `string`  | The path to the profile type on the target. | `"/debug/fgprof"` | no       |
+
+For more information about the `delta` argument, see the [delta argument][] section.
+
+### `profile.godeltaprof_block`
+
+The `profile.godeltaprof_block` block collects profiles from [godeltaprof][] block endpoint. The delta is computed on the target.
+
+The following arguments are supported:
+
+| Name      | Type      | Description                                 | Default                      | Required |
+| --------- | --------- | ------------------------------------------- | ---------------------------- | -------- |
+| `enabled` | `boolean` | Enable this profile type to be scraped.     | `false`                      | no       |
+| `path`    | `string`  | The path to the profile type on the target. | `"/debug/pprof/delta_block"` | no       |
+
+### `profile.godeltaprof_memory`
+
+The `profile.godeltaprof_memory` block collects profiles from [godeltaprof][] memory endpoint. The delta is computed on the target.
+
+The following arguments are supported:
+
+| Name      | Type      | Description                                 | Default                     | Required |
+| --------- | --------- | ------------------------------------------- | --------------------------- | -------- |
+| `enabled` | `boolean` | Enable this profile type to be scraped.     | `false`                     | no       |
+| `path`    | `string`  | The path to the profile type on the target. | `"/debug/pprof/delta_heap"` | no       |
+
+### `profile.godeltaprof_mutex`
+
+The `profile.godeltaprof_mutex` block collects profiles from [godeltaprof][] mutex endpoint.
+The delta is computed on the target.
+
+The following arguments are supported:
+
+| Name      | Type      | Description                                 | Default                      | Required |
+| --------- | --------- | ------------------------------------------- | ---------------------------- | -------- |
+| `enabled` | `boolean` | Enable this profile type to be scraped.     | `false`                      | no       |
+| `path`    | `string`  | The path to the profile type on the target. | `"/debug/pprof/delta_mutex"` | no       |
+
+### `profile.goroutine`
+
+The `profile.goroutine` block collects profiles on the number of goroutines.
+
+The following arguments are supported:
+
+| Name      | Type      | Description                                 | Default                    | Required |
+| --------- | --------- | ------------------------------------------- | -------------------------- | -------- |
+| `delta`   | `boolean` | Whether to scrape the profile as a delta.   | `false`                    | no       |
+| `enabled` | `boolean` | Enable this profile type to be scraped.     | `true`                     | no       |
+| `path`    | `string`  | The path to the profile type on the target. | `"/debug/pprof/goroutine"` | no       |
+
+Refer to [delta argument][] for more information about the `delta` argument.
+
+### `profile.memory`
+
+The `profile.memory` block collects profiles on memory consumption.
+
+The following arguments are supported:
+
+| Name      | Type      | Description                                 | Default                 | Required |
+| --------- | --------- | ------------------------------------------- | ----------------------- | -------- |
+| `delta`   | `boolean` | Whether to scrape the profile as a delta.   | `false`                 | no       |
+| `enabled` | `boolean` | Enable this profile type to be scraped.     | `true`                  | no       |
+| `path`    | `string`  | The path to the profile type on the target. | `"/debug/pprof/allocs"` | no       |
+
+Refer to [delta argument][] for more information about the `delta` argument.
+
+### `profile.mutex`
+
+The `profile.mutex` block collects profiles on mutexes.
+
+The following arguments are supported:
+
+| Name      | Type      | Description                                 | Default                | Required |
+| --------- | --------- | ------------------------------------------- | ---------------------- | -------- |
+| `delta`   | `boolean` | Whether to scrape the profile as a delta.   | `false`                | no       |
+| `enabled` | `boolean` | Enable this profile type to be scraped.     | `true`                 | no       |
+| `path`    | `string`  | The path to the profile type on the target. | `"/debug/pprof/mutex"` | no       |
+
+Refer to [delta argument][] for more information about the `delta` argument.
+
+### `profile.process_cpu`
+
+The `profile.process_cpu` block collects profiles on CPU consumption for the process.
+
+The following arguments are supported:
+
+| Name      | Type      | Description                                 | Default                  | Required |
+| --------- | --------- | ------------------------------------------- | ------------------------ | -------- |
+| `delta`   | `boolean` | Whether to scrape the profile as a delta.   | `true`                   | no       |
+| `enabled` | `boolean` | Enable this profile type to be scraped.     | `true`                   | no       |
+| `path`    | `string`  | The path to the profile type on the target. | `"/debug/pprof/profile"` | no       |
+
+For more information about the `delta` argument, see the [delta argument][] section.
+
+### `tls_config`
+
+{{< docs/shared lookup="reference/components/tls-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ## Common configuration
 
@@ -397,18 +400,19 @@ If {{< param "PRODUCT_NAME" >}} is _not_ running in clustered mode, this block i
 When the `delta` argument is `false`, the [pprof][] HTTP query will be instantaneous.
 
 When the `delta` argument is `true`:
-* The [pprof][] HTTP query will run for a certain amount of time.
+
+* The [pprof][] HTTP query runs for a certain amount of time.
 * A `seconds` parameter is automatically added to the HTTP request.
 * The default value for the `seconds` query parameter is `scrape_interval - 1`.
-    If you set `delta_profiling_duration`, then `seconds` is assigned the same value as `delta_profiling_duration`.
-    However, the `delta_profiling_duration` cannot be larger than `scrape_interval`. 
-    For example, if you set `scrape_interval` to `"15s"`, then `seconds` defaults to `14s`
-    If you set `delta_profiling_duration` to `16s`, then `scrape_interval` must be set to at least `17s`.
-  If the HTTP endpoint is `/debug/pprof/profile`, then the HTTP query will become `/debug/pprof/profile?seconds=14`
+  If you set `delta_profiling_duration`, then `seconds` is assigned the same value as `delta_profiling_duration`.
+  However, the `delta_profiling_duration` can't be larger than `scrape_interval`.
+  For example, if you set `scrape_interval` to `"15s"`, then `seconds` defaults to `14s`
+  If you set `delta_profiling_duration` to `16s`, then `scrape_interval` must be set to at least `17s`.
+  If the HTTP endpoint is `/debug/pprof/profile`, then the HTTP query becomes `/debug/pprof/profile?seconds=14`
 
 ## Exported fields
 
-`pyroscope.scrape` does not export any fields that can be referenced by other components.
+`pyroscope.scrape` doesn't export any fields that can be referenced by other components.
 
 ## Component health
 
@@ -450,7 +454,7 @@ pyroscope.write "local" {
 
 These endpoints will be scraped every 15 seconds:
 
-```
+```text
 http://localhost:4040/debug/pprof/allocs
 http://localhost:4040/debug/pprof/block
 http://localhost:4040/debug/pprof/goroutine
@@ -465,10 +469,11 @@ http://localhost:12345/debug/pprof/profile?seconds=14
 ```
 
 `seconds=14` is added to the `/debug/pprof/profile` endpoint, because:
+
 * The `delta` argument of the `profile.process_cpu` block is `true` by default.
 * `scrape_interval` is `"15s"` by default.
 
-The `/debug/fgprof` endpoint will not be scraped, because the `enabled` argument of the `profile.fgprof` block is `false` by default.
+The `/debug/fgprof` endpoint won't be scraped, because the `enabled` argument of the `profile.fgprof` block is `false` by default.
 
 [example_dynamic_targets]: #default-endpoints-of-dynamic-targets
 
@@ -519,8 +524,7 @@ pyroscope.write "local" {
 }
 ```
 
-
-### Enabling and disabling profiles
+### Enable and disable profiles
 
 ```alloy
 pyroscope.scrape "local" {
@@ -546,7 +550,7 @@ pyroscope.scrape "local" {
 
 These endpoints will be scraped every 15 seconds:
 
-```
+```text
 http://localhost:12345/debug/pprof/allocs
 http://localhost:12345/debug/pprof/goroutine
 http://localhost:12345/debug/pprof/profile?seconds=14
@@ -555,7 +559,7 @@ http://localhost:12345/debug/fgprof?seconds=14
 
 These endpoints will **NOT** be scraped because they are explicitly disabled:
 
-```
+```text
 http://localhost:12345/debug/pprof/block
 http://localhost:12345/debug/pprof/mutex
 ```

--- a/docs/sources/reference/components/pyroscope/pyroscope.write.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.write.md
@@ -3,21 +3,23 @@ canonical: https://grafana.com/docs/alloy/latest/reference/components/pyroscope/
 aliases:
   - ../pyroscope.write/ # /docs/alloy/latest/reference/components/pyroscope.write/
 description: Learn about pyroscope.write
+labels:
+  stage: general-availability
 title: pyroscope.write
 ---
 
-# pyroscope.write
+# `pyroscope.write`
 
 `pyroscope.write` receives performance profiles from other components and forwards them to a series of user-supplied endpoints using [Pyroscope' Push API](/oss/pyroscope/).
 
-Multiple `pyroscope.write` components can be specified by giving them different labels.
+You can specify multiple `pyroscope.write` components by giving them different labels.
 
 ## Usage
 
 ```alloy
-pyroscope.write "LABEL" {
+pyroscope.write "<LABEL>" {
   endpoint {
-    url = PYROSCOPE_URL
+    url = "<PYROSCOPE_URL>"
 
     ...
   }
@@ -28,83 +30,84 @@ pyroscope.write "LABEL" {
 
 ## Arguments
 
-The following arguments are supported:
+You can use the following argument with `pyroscope.write`:
 
-Name              | Type          | Description                                      | Default | Required
-------------------|---------------|--------------------------------------------------|---------|---------
-`external_labels` | `map(string)` | Labels to add to profiles sent over the network. |         | no
+| Name              | Type          | Description                                      | Default | Required |
+| ----------------- | ------------- | ------------------------------------------------ | ------- | -------- |
+| `external_labels` | `map(string)` | Labels to add to profiles sent over the network. |         | no       |
 
 ## Blocks
 
 The following blocks are supported inside the definition of `pyroscope.write`:
 
-Hierarchy                      | Block             | Description                                              | Required
--------------------------------|-------------------|----------------------------------------------------------|---------
-endpoint                       | [endpoint][]      | Location to send profiles to.                            | no
-endpoint > basic_auth          | [basic_auth][]    | Configure basic_auth for authenticating to the endpoint. | no
-endpoint > authorization       | [authorization][] | Configure generic authorization to the endpoint.         | no
-endpoint > oauth2              | [oauth2][]        | Configure OAuth2 for authenticating to the endpoint.     | no
-endpoint > oauth2 > tls_config | [tls_config][]    | Configure TLS settings for connecting to the endpoint.   | no
-endpoint > tls_config          | [tls_config][]    | Configure TLS settings for connecting to the endpoint.   | no
+| Block                                              | Description                                                | Required |     |
+| -------------------------------------------------- | ---------------------------------------------------------- | -------- | --- |
+| [`endpoint`][endpoint]                             | Location to send profiles to.                              | no       |     |
+| `endpoint` > [`authorization`][authorization]      | Configure generic authorization to the endpoint.           | no       |     |
+| `endpoint` > [`basic_auth`][basic_auth]            | Configure `basic_auth` for authenticating to the endpoint. | no       |     |
+| `endpoint` > [`oauth2`][oauth2]                    | Configure OAuth 2.0 for authenticating to the endpoint.    | no       |     |
+| `endpoint` > `oauth2` > [`tls_config`][tls_config] | Configure TLS settings for connecting to the endpoint.     | no       |     |
+| `endpoint` > [`tls_config`][tls_config]            | Configure TLS settings for connecting to the endpoint.     | no       |     |
 
-The `>` symbol indicates deeper levels of nesting.
-For example, `endpoint > basic_auth` refers to a `basic_auth` block defined inside an `endpoint` block.
+The > symbol indicates deeper levels of nesting.
+For example, `endpoint` > `basic_auth` refers to a `basic_auth` block defined inside an `endpoint` block.
 
-[endpoint]: #endpoint-block
-[basic_auth]: #basic_auth-block
-[authorization]: #authorization-block
-[oauth2]: #oauth2-block
-[tls_config]: #tls_config-block
+[endpoint]: #endpoint
+[authorization]: #authorization
+[basic_auth]: #basic_auth
+[oauth2]: #oauth2
+[tls_config]: #tls_config
 
-### endpoint block
+### `endpoint`
 
 The `endpoint` block describes a single location to send profiles to.
 Multiple `endpoint` blocks can be provided to send profiles to multiple locations.
 
 The following arguments are supported:
 
-Name                     | Type                | Description                                                   | Default   | Required
--------------------------|---------------------|---------------------------------------------------------------|-----------|---------
-`url`                    | `string`            | Full URL to send metrics to.                                  |           | yes
-`name`                   | `string`            | Optional name to identify the endpoint in metrics.            |           | no
-`remote_timeout`         | `duration`          | Timeout for requests made to the URL.                         | `"10s"`   | no
-`headers`                | `map(string)`       | Extra headers to deliver with the request.                    |           | no
-`min_backoff_period`     | `duration`          | Initial backoff time between retries.                         | `"500ms"` | no
-`max_backoff_period`     | `duration`          | Maximum backoff time between retries.                         | `"5m"`    | no
-`max_backoff_retries`    | `int`               | Maximum number of retries. 0 to retry infinitely.             | 10        | no
-`bearer_token_file`      | `string`            | File containing a bearer token to authenticate with.          |           | no
-`bearer_token`           | `secret`            | Bearer token to authenticate with.                            |           | no
-`enable_http2`           | `bool`              | Whether HTTP2 is supported for requests.                      | `true`    | no
-`follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.  | `true`    | no
-`proxy_url`              | `string`            | HTTP proxy to send requests through.                          |           | no
-`no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. | | no
-`proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.         | `false` | no
-`proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests. |         | no
+| Name                     | Type                | Description                                                                                      | Default   | Required |
+| ------------------------ | ------------------- | ------------------------------------------------------------------------------------------------ | --------- | -------- |
+| `url`                    | `string`            | Full URL to send metrics to.                                                                     |           | yes      |
+| `bearer_token_file`      | `string`            | File containing a bearer token to authenticate with.                                             |           | no       |
+| `bearer_token`           | `secret`            | Bearer token to authenticate with.                                                               |           | no       |
+| `enable_http2`           | `bool`              | Whether HTTP2 is supported for requests.                                                         | `true`    | no       |
+| `follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.                                     | `true`    | no       |
+| `headers`                | `map(string)`       | Extra headers to deliver with the request.                                                       |           | no       |
+| `max_backoff_period`     | `duration`          | Maximum backoff time between retries.                                                            | `"5m"`    | no       |
+| `max_backoff_retries`    | `int`               | Maximum number of retries. 0 to retry infinitely.                                                | 10        | no       |
+| `min_backoff_period`     | `duration`          | Initial backoff time between retries.                                                            | `"500ms"` | no       |
+| `name`                   | `string`            | Optional name to identify the endpoint in metrics.                                               |           | no       |
+| `no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. |           | no       |
+| `proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests.                                    |           | no       |
+| `proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.                                            | `false`   | no       |
+| `proxy_url`              | `string`            | HTTP proxy to send requests through.                                                             |           | no       |
+| `remote_timeout`         | `duration`          | Timeout for requests made to the URL.                                                            | `"10s"`   | no       |
 
  At most, one of the following can be provided:
- - [`bearer_token` argument][endpoint].
- - [`bearer_token_file` argument][endpoint].
- - [`basic_auth` block][basic_auth].
- - [`authorization` block][authorization].
- - [`oauth2` block][oauth2].
+
+* [`authorization`][authorization] block
+* [`basic_auth`][basic_auth] block
+* [`bearer_token_file`][endpoint] argument
+* [`bearer_token`][endpoint] argument
+* [`oauth2`][oauth2] block
 
 {{< docs/shared lookup="reference/components/http-client-proxy-config-description.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
-When multiple `endpoint` blocks are provided, profiles are concurrently forwarded to all configured locations.
+When you provide multiple `endpoint` blocks, profiles are concurrently forwarded to all configured locations.
 
-### basic_auth block
-
-{{< docs/shared lookup="reference/components/basic-auth-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
-
-### authorization block
+### `authorization`
 
 {{< docs/shared lookup="reference/components/authorization-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
-### oauth2 block
+### `basic_auth`
+
+{{< docs/shared lookup="reference/components/basic-auth-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `oauth2`
 
 {{< docs/shared lookup="reference/components/oauth2-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
-### tls_config block
+### `tls_config`
 
 {{< docs/shared lookup="reference/components/tls-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
@@ -112,9 +115,9 @@ When multiple `endpoint` blocks are provided, profiles are concurrently forwarde
 
 The following fields are exported and can be referenced by other components:
 
-Name       | Type       | Description
------------|------------|-----------------------------------------------------------
-`receiver` | `receiver` | A value that other components can use to send profiles to.
+| Name       | Type       | Description                                                |
+| ---------- | ---------- | ---------------------------------------------------------- |
+| `receiver` | `receiver` | A value that other components can use to send profiles to. |
 
 ## Component health
 
@@ -123,7 +126,7 @@ In those cases, exported fields are kept at their last healthy values.
 
 ## Debug information
 
-`pyroscope.write` does not expose any component-specific debug information.
+`pyroscope.write` doesn't expose any component-specific debug information.
 
 ## Example
 


### PR DESCRIPTION
#### PR Description

The Alloy component documentation needs general cleanup, including things like:

- Pretty print tables
- Sort table rows alphabetically - required first, then all optional
- Sort blocks alphabetically
- Fix block heading hierarchy
- Add badge for Required blocks
- Remove block from heading text
- Remove extra spaces and extra CR/LFs
- Tidy markdown - spaces around lists, indentation, etc.

#### Which issue(s) this PR fixes

Fixes #2418 
