### PR TITLE
Add live graph backend (merge to feature branch)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -499,7 +499,7 @@ require (
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.6.0 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.3 // indirect
-	github.com/go-kit/kit v0.13.0 // indirect
+	github.com/go-kit/kit v0.13.0
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
@@ -883,9 +883,6 @@ require (
 	github.com/containers/common v0.61.0 // indirect
 	github.com/deneonet/benc v1.1.2 // indirect
 	github.com/itchyny/timefmt-go v0.1.6 // indirect
-	github.com/onsi/ginkgo/v2 v2.21.0 // indirect
-	github.com/onsi/gomega v1.35.1 // indirect
-	go.etcd.io/bbolt v1.3.11 // indirect
 )
 
 // NOTE: replace directives below must always be *temporary*.

--- a/go.sum
+++ b/go.sum
@@ -1852,17 +1852,11 @@ github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoA
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/gosnmp/gosnmp v1.37.0 h1:/Tf8D3b9wrnNuf/SfbvO+44mPrjVphBhRtcGg22V07Y=
-github.com/gosnmp/gosnmp v1.37.0/go.mod h1:GDH9vNqpsD7f2HvZhKs5dlqSEcAS6s6Qp099oZRCR+M=
 github.com/gosnmp/gosnmp v1.38.0 h1:I5ZOMR8kb0DXAFg/88ACurnuwGwYkXWq3eLpJPHMEYc=
 github.com/gosnmp/gosnmp v1.38.0/go.mod h1:FE+PEZvKrFz9afP9ii1W3cprXuVZ17ypCcyyfYuu5LY=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
 github.com/grafana/alloy-remote-config v0.0.9 h1:gy34SxZ8Iq/HrDTIFZi80+8BlT+FnJhKiP9mryHNEUE=
 github.com/grafana/alloy-remote-config v0.0.9/go.mod h1:kHE1usYo2WAVCikQkIXuoG1Clz8BSdiz3kF+DZSCQ4k=
-github.com/grafana/beyla v0.0.0-20250108110233-3f1b9b55c6dc h1:oY8yQB8IG0dBo1UrLlLC2CspxbiVtSWWExMxXOnfWgk=
-github.com/grafana/beyla v0.0.0-20250108110233-3f1b9b55c6dc/go.mod h1:hpk185gTeIQXjxV/so9vAxhZtSEgm8ODanWXZNVnH2M=
-github.com/grafana/beyla v1.9.1-0.20250122195759-1117708def46 h1:/aw+Ze9lUluE1hNZ0fAtwhmf2CKP0VbsLFumpN8xztY=
-github.com/grafana/beyla v1.9.1-0.20250122195759-1117708def46/go.mod h1:CRWu15fkScScSYBlYUtdJu2Ak8ojGvnuwHToGGkaOXY=
 github.com/grafana/beyla v1.10.0-alloy h1:kGyZtBSS/Br2qdhbvzu8sVYZHuE9a3OzWpbp6gN55EY=
 github.com/grafana/beyla v1.10.0-alloy/go.mod h1:CRWu15fkScScSYBlYUtdJu2Ak8ojGvnuwHToGGkaOXY=
 github.com/grafana/cadvisor v0.0.0-20240729082359-1f04a91701e2 h1:ju6EcY2aEobeBg185ETtFCKj5WzaQ48qfkbsSRRQrF4=
@@ -2126,8 +2120,6 @@ github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
-github.com/ianlancetaylor/demangle v0.0.0-20240312041847-bd984b5ce465 h1:KwWnWVWCNtNq/ewIX7HIKnELmEx2nDP42yskD/pi7QE=
-github.com/ianlancetaylor/demangle v0.0.0-20240312041847-bd984b5ce465/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
 github.com/ianlancetaylor/demangle v0.0.0-20240912202439-0a2b6291aafd h1:EVX1s+XNss9jkRW9K6XGJn2jL2lB1h5H804oKPsxOec=
 github.com/ianlancetaylor/demangle v0.0.0-20240912202439-0a2b6291aafd/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
 github.com/illumos/go-kstat v0.0.0-20210513183136-173c9b0a9973 h1:hk4LPqXIY/c9XzRbe7dA6qQxaT6Axcbny0L/G5a4owQ=

--- a/internal/component/discovery/discovery.go
+++ b/internal/component/discovery/discovery.go
@@ -224,7 +224,12 @@ func (c *Component) runDiscovery(ctx context.Context, d DiscovererWithMetrics) {
 		allTargets := toAlloyTargets(cache)
 		componentID := livedebugging.ComponentID(c.opts.ID)
 		if c.debugDataPublisher.IsActive(componentID) {
-			c.debugDataPublisher.Publish(componentID, fmt.Sprintf("%s", allTargets))
+			c.debugDataPublisher.Publish(componentID, livedebugging.NewFeed(
+				componentID,
+				livedebugging.Target,
+				uint64(len(allTargets)),
+				func() string { return fmt.Sprintf("%s", allTargets) },
+			))
 		}
 		c.opts.OnStateChange(Exports{Targets: allTargets})
 	}

--- a/internal/component/discovery/relabel/relabel.go
+++ b/internal/component/discovery/relabel/relabel.go
@@ -99,7 +99,12 @@ func (c *Component) Update(args component.Arguments) error {
 		}
 		componentID := livedebugging.ComponentID(c.opts.ID)
 		if c.debugDataPublisher.IsActive(componentID) {
-			c.debugDataPublisher.Publish(componentID, fmt.Sprintf("%s => %s", lset.String(), relabelled.String()))
+			c.debugDataPublisher.Publish(componentID, livedebugging.NewFeed(
+				componentID,
+				livedebugging.Target,
+				1,
+				func() string { return fmt.Sprintf("%s => %s", lset.String(), relabelled.String()) },
+			))
 		}
 	}
 

--- a/internal/component/loki/process/process.go
+++ b/internal/component/loki/process/process.go
@@ -164,7 +164,14 @@ func (c *Component) handleIn(ctx context.Context, wg *sync.WaitGroup) {
 		case entry := <-c.receiver.Chan():
 			c.mut.RLock()
 			if c.debugDataPublisher.IsActive(componentID) {
-				c.debugDataPublisher.Publish(componentID, fmt.Sprintf("[IN]: timestamp: %s, entry: %s, labels: %s", entry.Timestamp.Format(time.RFC3339Nano), entry.Line, entry.Labels.String()))
+				c.debugDataPublisher.Publish(componentID, livedebugging.NewFeed(
+					componentID,
+					livedebugging.LokiLog,
+					0, // does not count because we count only the data that exists
+					func() string {
+						return fmt.Sprintf("[IN]: timestamp: %s, entry: %s, labels: %s", entry.Timestamp.Format(time.RFC3339Nano), entry.Line, entry.Labels.String())
+					},
+				))
 			}
 			select {
 			case <-ctx.Done():
@@ -195,7 +202,14 @@ func (c *Component) handleOut(shutdownCh chan struct{}, wg *sync.WaitGroup) {
 			// The log entry is the same for every fanout,
 			// so we can publish it only once.
 			if c.debugDataPublisher.IsActive(componentID) {
-				c.debugDataPublisher.Publish(componentID, fmt.Sprintf("[OUT]: timestamp: %s, entry: %s, labels: %s", entry.Timestamp.Format(time.RFC3339Nano), entry.Line, entry.Labels.String()))
+				c.debugDataPublisher.Publish(componentID, livedebugging.NewFeed(
+					componentID,
+					livedebugging.LokiLog,
+					1,
+					func() string {
+						return fmt.Sprintf("[OUT]: timestamp: %s, entry: %s, labels: %s", entry.Timestamp.Format(time.RFC3339Nano), entry.Line, entry.Labels.String())
+					},
+				))
 			}
 
 			for _, f := range fanout {

--- a/internal/component/loki/process/process_test.go
+++ b/internal/component/loki/process/process_test.go
@@ -651,7 +651,7 @@ func getServiceDataWithLiveDebugging(log *testlivedebugging.Log) func(string) (i
 	ld.AddCallback(
 		"callback1",
 		"",
-		func(data string) { log.Append(data) },
+		func(data *livedebugging.Feed) { log.Append(data.DataFunc()) },
 	)
 
 	return func(name string) (interface{}, error) {

--- a/internal/component/loki/relabel/relabel.go
+++ b/internal/component/loki/relabel/relabel.go
@@ -126,7 +126,18 @@ func (c *Component) Run(ctx context.Context) error {
 			lbls := c.relabel(entry)
 
 			if c.debugDataPublisher.IsActive(componentID) {
-				c.debugDataPublisher.Publish(componentID, fmt.Sprintf("entry: %s, labels: %s => %s", entry.Line, entry.Labels.String(), lbls.String()))
+				count := uint64(1)
+				if len(lbls) == 0 {
+					count = 0 // if no labels are left, the count is not incremented because the log will be filtered out
+				}
+				c.debugDataPublisher.Publish(componentID, livedebugging.NewFeed(
+					componentID,
+					livedebugging.LokiLog,
+					count,
+					func() string {
+						return fmt.Sprintf("entry: %s, labels: %s => %s", entry.Line, entry.Labels.String(), lbls.String())
+					},
+				))
 			}
 
 			if len(lbls) == 0 {

--- a/internal/component/loki/secretfilter/secretfilter.go
+++ b/internal/component/loki/secretfilter/secretfilter.go
@@ -153,7 +153,14 @@ func (c *Component) Run(ctx context.Context) error {
 			// Start processing the log entry to redact secrets
 			newEntry := c.processEntry(entry)
 			if c.debugDataPublisher.IsActive(componentID) {
-				c.debugDataPublisher.Publish(componentID, fmt.Sprintf("%s => %s", entry.Line, newEntry.Line))
+				c.debugDataPublisher.Publish(componentID, livedebugging.NewFeed(
+					componentID,
+					livedebugging.LokiLog,
+					1,
+					func() string {
+						return fmt.Sprintf("%s => %s", entry.Line, newEntry.Line)
+					},
+				))
 			}
 
 			for _, f := range c.fanout {

--- a/internal/component/otelcol/connector/connector.go
+++ b/internal/component/otelcol/connector/connector.go
@@ -105,7 +105,7 @@ func New(opts component.Options, f otelconnector.Factory, args Arguments) (*Conn
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	consumer := lazyconsumer.NewPaused(ctx)
+	consumer := lazyconsumer.NewPaused(ctx, opts.ID)
 
 	// Create a lazy collector where metrics from the upstream component will be
 	// forwarded.

--- a/internal/component/otelcol/connector/spanlogs/spanlogs.go
+++ b/internal/component/otelcol/connector/spanlogs/spanlogs.go
@@ -123,7 +123,7 @@ func New(o component.Options, c Arguments) (*Component, error) {
 	// Export the consumer.
 	// This will remain the same throughout the component's lifetime,
 	// so we do this during component construction.
-	export := lazyconsumer.New(context.Background())
+	export := lazyconsumer.New(context.Background(), o.ID)
 	export.SetConsumers(res.consumer, nil, nil)
 	o.OnStateChange(otelcol.ConsumerExports{Input: export})
 

--- a/internal/component/otelcol/exporter/exporter.go
+++ b/internal/component/otelcol/exporter/exporter.go
@@ -115,7 +115,7 @@ var (
 func New(opts component.Options, f otelexporter.Factory, args Arguments, supportedSignals TypeSignalFunc) (*Exporter, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	consumer := lazyconsumer.NewPaused(ctx)
+	consumer := lazyconsumer.NewPaused(ctx, opts.ID)
 
 	// Create a lazy collector where metrics from the upstream component will be
 	// forwarded.

--- a/internal/component/otelcol/exporter/loki/loki.go
+++ b/internal/component/otelcol/exporter/loki/loki.go
@@ -58,7 +58,7 @@ func New(o component.Options, c Arguments) (*Component, error) {
 	// Construct a consumer based on our converter and export it. This will
 	// remain the same throughout the component's lifetime, so we do this
 	// during component construction.
-	export := lazyconsumer.New(context.Background())
+	export := lazyconsumer.New(context.Background(), o.ID)
 	export.SetConsumers(nil, nil, converter)
 	o.OnStateChange(otelcol.ConsumerExports{Input: export})
 

--- a/internal/component/otelcol/exporter/prometheus/prometheus.go
+++ b/internal/component/otelcol/exporter/prometheus/prometheus.go
@@ -105,7 +105,7 @@ func New(o component.Options, c Arguments) (*Component, error) {
 	// Construct a consumer based on our converter and export it. This will
 	// remain the same throughout the component's lifetime, so we do this during
 	// component construction.
-	export := lazyconsumer.New(context.Background())
+	export := lazyconsumer.New(context.Background(), o.ID)
 	export.SetConsumers(nil, converter, nil)
 	o.OnStateChange(otelcol.ConsumerExports{Input: export})
 

--- a/internal/component/otelcol/internal/lazyconsumer/lazyconsumer.go
+++ b/internal/component/otelcol/internal/lazyconsumer/lazyconsumer.go
@@ -17,6 +17,8 @@ import (
 type Consumer struct {
 	ctx context.Context
 
+	componentID string
+
 	// pauseMut and pausedWg are used to implement Pause & Resume semantics. See Pause method for more info.
 	pauseMut sync.RWMutex
 	pausedWg *sync.WaitGroup
@@ -36,15 +38,20 @@ var (
 // New creates a new Consumer. The provided ctx is used to determine when the
 // Consumer should stop accepting data; if the ctx is closed, no further data
 // will be accepted.
-func New(ctx context.Context) *Consumer {
-	return &Consumer{ctx: ctx}
+func New(ctx context.Context, componentID string) *Consumer {
+	return &Consumer{ctx: ctx, componentID: componentID}
 }
 
 // NewPaused is like New, but returns a Consumer that is paused by calling Pause method.
-func NewPaused(ctx context.Context) *Consumer {
-	c := New(ctx)
+func NewPaused(ctx context.Context, componentID string) *Consumer {
+	c := New(ctx, componentID)
 	c.Pause()
 	return c
+}
+
+// ComponentID returns the componentID associated with the consumer.
+func (c *Consumer) ComponentID() string {
+	return c.componentID
 }
 
 // Capabilities implements otelconsumer.baseConsumer.

--- a/internal/component/otelcol/internal/lazyconsumer/lazyconsumer_test.go
+++ b/internal/component/otelcol/internal/lazyconsumer/lazyconsumer_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func Test_PauseAndResume(t *testing.T) {
-	c := New(componenttest.TestContext(t))
+	c := New(componenttest.TestContext(t), "")
 	require.False(t, c.IsPaused())
 	c.Pause()
 	require.True(t, c.IsPaused())
@@ -25,14 +25,14 @@ func Test_PauseAndResume(t *testing.T) {
 }
 
 func Test_NewPaused(t *testing.T) {
-	c := NewPaused(componenttest.TestContext(t))
+	c := NewPaused(componenttest.TestContext(t), "")
 	require.True(t, c.IsPaused())
 	c.Resume()
 	require.False(t, c.IsPaused())
 }
 
 func Test_PauseResume_MultipleCalls(t *testing.T) {
-	c := New(componenttest.TestContext(t))
+	c := New(componenttest.TestContext(t), "")
 	require.False(t, c.IsPaused())
 	c.Pause()
 	c.Pause()
@@ -46,7 +46,7 @@ func Test_PauseResume_MultipleCalls(t *testing.T) {
 
 func Test_ConsumeWaitsForResume(t *testing.T) {
 	goleak.VerifyNone(t, goleak.IgnoreCurrent())
-	c := NewPaused(componenttest.TestContext(t))
+	c := NewPaused(componenttest.TestContext(t), "")
 	require.True(t, c.IsPaused())
 
 	method := map[string]func(){
@@ -109,7 +109,7 @@ func Test_PauseResume_Multithreaded(t *testing.T) {
 	routines := 5
 	allDone := sync.WaitGroup{}
 
-	c := NewPaused(componenttest.TestContext(t))
+	c := NewPaused(componenttest.TestContext(t), "")
 	require.True(t, c.IsPaused())
 
 	// Run goroutines that constantly try to call Consume* methods

--- a/internal/component/otelcol/processor/discovery/discovery.go
+++ b/internal/component/otelcol/processor/discovery/discovery.go
@@ -137,7 +137,7 @@ func New(o component.Options, c Arguments) (*Component, error) {
 	// Export the consumer.
 	// This will remain the same throughout the component's lifetime,
 	// so we do this during component construction.
-	export := lazyconsumer.New(context.Background())
+	export := lazyconsumer.New(context.Background(), o.ID)
 	export.SetConsumers(res.consumer, nil, nil)
 	o.OnStateChange(otelcol.ConsumerExports{Input: export})
 

--- a/internal/component/otelcol/processor/processor.go
+++ b/internal/component/otelcol/processor/processor.go
@@ -92,7 +92,7 @@ func New(opts component.Options, f otelprocessor.Factory, args Arguments) (*Proc
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	consumer := lazyconsumer.NewPaused(ctx)
+	consumer := lazyconsumer.NewPaused(ctx, opts.ID)
 
 	// Create a lazy collector where metrics from the upstream component will be
 	// forwarded.

--- a/internal/component/prometheus/relabel/relabel.go
+++ b/internal/component/prometheus/relabel/relabel.go
@@ -277,7 +277,18 @@ func (c *Component) relabel(val float64, lbls labels.Labels) labels.Labels {
 
 	componentID := livedebugging.ComponentID(c.opts.ID)
 	if c.debugDataPublisher.IsActive(componentID) {
-		c.debugDataPublisher.Publish(componentID, fmt.Sprintf("%s => %s", lbls.String(), relabelled.String()))
+		count := uint64(1)
+		if relabelled.Len() == 0 {
+			count = 0 // if no labels are left, the count is not incremented because the metric will be filtered out
+		}
+		c.debugDataPublisher.Publish(componentID, livedebugging.NewFeed(
+			componentID,
+			livedebugging.PrometheusMetric,
+			count,
+			func() string {
+				return fmt.Sprintf("%s => %s", lbls.String(), relabelled.String())
+			},
+		))
 	}
 
 	return relabelled

--- a/internal/component/prometheus/remotewrite/remote_write.go
+++ b/internal/component/prometheus/remotewrite/remote_write.go
@@ -130,7 +130,14 @@ func New(o component.Options, c Arguments) (*Component, error) {
 				ls.GetOrAddLink(res.opts.ID, uint64(newRef), l)
 			}
 			if res.debugDataPublisher.IsActive(componentID) {
-				res.debugDataPublisher.Publish(componentID, fmt.Sprintf("ts=%d, labels=%s, value=%f", t, l, v))
+				res.debugDataPublisher.Publish(componentID, livedebugging.NewFeed(
+					componentID,
+					livedebugging.PrometheusMetric,
+					1,
+					func() string {
+						return fmt.Sprintf("ts=%d, labels=%s, value=%f", t, l, v)
+					},
+				))
 			}
 			return globalRef, nextErr
 		}),
@@ -145,15 +152,22 @@ func New(o component.Options, c Arguments) (*Component, error) {
 				ls.GetOrAddLink(res.opts.ID, uint64(newRef), l)
 			}
 			if res.debugDataPublisher.IsActive(componentID) {
-				var data string
-				if h != nil {
-					data = fmt.Sprintf("ts=%d, labels=%s, histogram=%s", t, l, h.String())
-				} else if fh != nil {
-					data = fmt.Sprintf("ts=%d, labels=%s, float_histogram=%s", t, l, fh.String())
-				} else {
-					data = fmt.Sprintf("ts=%d, labels=%s, no_value", t, l)
-				}
-				res.debugDataPublisher.Publish(componentID, data)
+				res.debugDataPublisher.Publish(componentID, livedebugging.NewFeed(
+					componentID,
+					livedebugging.PrometheusMetric,
+					1,
+					func() string {
+						var data string
+						if h != nil {
+							data = fmt.Sprintf("ts=%d, labels=%s, histogram=%s", t, l, h.String())
+						} else if fh != nil {
+							data = fmt.Sprintf("ts=%d, labels=%s, float_histogram=%s", t, l, fh.String())
+						} else {
+							data = fmt.Sprintf("ts=%d, labels=%s, no_value", t, l)
+						}
+						return data
+					},
+				))
 			}
 			return globalRef, nextErr
 		}),
@@ -168,7 +182,14 @@ func New(o component.Options, c Arguments) (*Component, error) {
 				ls.GetOrAddLink(res.opts.ID, uint64(newRef), l)
 			}
 			if res.debugDataPublisher.IsActive(componentID) {
-				res.debugDataPublisher.Publish(componentID, fmt.Sprintf("labels=%s, type=%s, unit=%s, help=%s", l, m.Type, m.Unit, m.Help))
+				res.debugDataPublisher.Publish(componentID, livedebugging.NewFeed(
+					componentID,
+					livedebugging.PrometheusMetric,
+					1,
+					func() string {
+						return fmt.Sprintf("labels=%s, type=%s, unit=%s, help=%s", l, m.Type, m.Unit, m.Help)
+					},
+				))
 			}
 			return globalRef, nextErr
 		}),
@@ -183,7 +204,14 @@ func New(o component.Options, c Arguments) (*Component, error) {
 				ls.GetOrAddLink(res.opts.ID, uint64(newRef), l)
 			}
 			if res.debugDataPublisher.IsActive(componentID) {
-				res.debugDataPublisher.Publish(componentID, fmt.Sprintf("ts=%d, labels=%s, exemplar_labels=%s, value=%f", e.Ts, l, e.Labels, e.Value))
+				res.debugDataPublisher.Publish(componentID, livedebugging.NewFeed(
+					componentID,
+					livedebugging.PrometheusMetric,
+					1,
+					func() string {
+						return fmt.Sprintf("ts=%d, labels=%s, exemplar_labels=%s, value=%f", e.Ts, l, e.Labels, e.Value)
+					},
+				))
 			}
 			return globalRef, nextErr
 		}),

--- a/internal/service/livedebugging/feed.go
+++ b/internal/service/livedebugging/feed.go
@@ -1,0 +1,50 @@
+package livedebugging
+
+type FeedType string
+
+const (
+	Target           FeedType = "target"
+	PrometheusMetric FeedType = "prometheus_metric"
+	LokiLog          FeedType = "loki_log"
+	OtelMetric       FeedType = "otel_metric"
+	OtelLog          FeedType = "otel_log"
+	OtelTrace        FeedType = "otel_trace"
+)
+
+type FeedOption func(*Feed)
+
+func WithTargetComponentIDs(ids []string) FeedOption {
+	return func(f *Feed) {
+		f.TargetComponentIDs = ids
+	}
+}
+
+type Feed struct {
+	// ID of the component that created the feed.
+	ComponentID ComponentID
+	// Ids of the components which will consume the Feed data.
+	// This is needed for components that can export different types of data (most Otel components) to know
+	// where the Feed should go. When left empty, the Feed is expected to be sent to all components consuming data
+	// from the component that created it.
+	TargetComponentIDs []string
+	Type               FeedType
+	// Count is the number of spans, metrics, logs that the Feed represent.
+	Count uint64
+	// The data string is passed as a function to only compute the string if needed.
+	DataFunc func() string
+}
+
+func NewFeed(componentID ComponentID, feedType FeedType, count uint64, dataFunc func() string, opts ...FeedOption) *Feed {
+	feed := &Feed{
+		ComponentID: componentID,
+		Type:        feedType,
+		Count:       count,
+		DataFunc:    dataFunc,
+	}
+
+	for _, opt := range opts {
+		opt(feed)
+	}
+
+	return feed
+}

--- a/internal/util/testlivedebugging/testlivedebugging.go
+++ b/internal/util/testlivedebugging/testlivedebugging.go
@@ -27,6 +27,28 @@ func (h *FakeServiceHost) GetComponent(id component.ID, opts component.InfoOptio
 	return nil, component.ErrComponentNotFound
 }
 
+func (h *FakeServiceHost) ListComponents(moduleID string, opts component.InfoOptions) ([]*component.Info, error) {
+	if moduleID != "" {
+		for key, _ := range h.ComponentsInfo {
+			if key.ModuleID == moduleID {
+				return h.getComponentsInModule(moduleID), nil
+			}
+		}
+		return nil, component.ErrModuleNotFound
+	}
+	return h.getComponentsInModule(""), nil
+}
+
+func (h *FakeServiceHost) getComponentsInModule(module string) []*component.Info {
+	detail := make([]*component.Info, 0, len(h.ComponentsInfo))
+	for key, cp := range h.ComponentsInfo {
+		if key.ModuleID == module {
+			detail = append(detail, &component.Info{ID: key, ComponentName: cp.ComponentName, Component: cp.Component})
+		}
+	}
+	return detail
+}
+
 type FakeComponentLiveDebugging struct {
 	ConsumersCount int
 }

--- a/internal/web/api/data.go
+++ b/internal/web/api/data.go
@@ -1,0 +1,15 @@
+package api
+
+type feed struct {
+	// ID of the component that created the feed.
+	ComponentID string `json:"componentID"`
+	// Ids of the components which will consume the Feed data.
+	// This is needed for components that can export different types of data (most Otel components) to know
+	// where the Feed should go. When left empty, the Feed is expected to be sent to all components consuming data
+	// from the component that created it.
+	TargetComponentIDs []string `json:"targetComponentIDs"`
+	// Type specifies the category of data represented by the count (otel_metric, loki_log, target...).
+	Type string `json:"type"`
+	// Count is the number of spans, metrics, logs that the Feed represent.
+	Count uint64 `json:"count"`
+}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This is the backend part of the new live graph.

The approach is similar to live debugging, except that it adds the callback to all components in the given module.

The live debugging feed is now a struct that contains data needed to build the new graph. Because the data string is not needed for the graph, it's passed around as a function. This way we can use the same struct for the live debugging and the live graph with limited performance overhead.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #2608 

#### Notes to the Reviewer

This was tested manually via curl:
- `curl -N http://localhost:12345/api/v0/web/graph` to get the data from all components at the root
- `curl -N http://localhost:12345/api/v0/web/graph/{moduleID}` to get data from a particular module

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [na] CHANGELOG.md updated (will be done in the feature branch)
- [na] Documentation added (will be done in another branch to the feature branch)
- [x] Tests updated
- [na] Config converters updated
