### PR TITLE
remotecfg: bump protocol version, use GET requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/google/renameio/v2 v2.0.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
-	github.com/grafana/alloy-remote-config v0.0.9
+	github.com/grafana/alloy-remote-config v0.0.10
 	github.com/grafana/alloy/syntax v0.1.0
 	github.com/grafana/beyla v1.10.0-alloy // custom beyla 1.10 branch without git lfs
 	github.com/grafana/catchpoint-prometheus-exporter v0.0.0-20240606062944-e55f3668661d

--- a/go.sum
+++ b/go.sum
@@ -1863,8 +1863,8 @@ github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/gosnmp/gosnmp v1.38.0 h1:I5ZOMR8kb0DXAFg/88ACurnuwGwYkXWq3eLpJPHMEYc=
 github.com/gosnmp/gosnmp v1.38.0/go.mod h1:FE+PEZvKrFz9afP9ii1W3cprXuVZ17ypCcyyfYuu5LY=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
-github.com/grafana/alloy-remote-config v0.0.9 h1:gy34SxZ8Iq/HrDTIFZi80+8BlT+FnJhKiP9mryHNEUE=
-github.com/grafana/alloy-remote-config v0.0.9/go.mod h1:kHE1usYo2WAVCikQkIXuoG1Clz8BSdiz3kF+DZSCQ4k=
+github.com/grafana/alloy-remote-config v0.0.10 h1:1Ge7lz2mjXI1rd6SmiZpFHyXeLehBuCi43+XTkdqgV4=
+github.com/grafana/alloy-remote-config v0.0.10/go.mod h1:kHE1usYo2WAVCikQkIXuoG1Clz8BSdiz3kF+DZSCQ4k=
 github.com/grafana/beyla v1.10.0-alloy h1:kGyZtBSS/Br2qdhbvzu8sVYZHuE9a3OzWpbp6gN55EY=
 github.com/grafana/beyla v1.10.0-alloy/go.mod h1:CRWu15fkScScSYBlYUtdJu2Ak8ojGvnuwHToGGkaOXY=
 github.com/grafana/cadvisor v0.0.0-20240729082359-1f04a91701e2 h1:ju6EcY2aEobeBg185ETtFCKj5WzaQ48qfkbsSRRQrF4=

--- a/internal/service/remotecfg/remotecfg.go
+++ b/internal/service/remotecfg/remotecfg.go
@@ -316,6 +316,7 @@ func (s *Service) Update(newConfig any) error {
 		s.asClient = collectorv1connect.NewCollectorServiceClient(
 			httpClient,
 			newArgs.URL,
+			connect.WithHTTPGet(),
 		)
 	}
 	// Combine the new attributes on top of the system attributes
@@ -354,9 +355,9 @@ func (s *Service) fetch() {
 
 func (s *Service) registerCollector() error {
 	req := connect.NewRequest(&collectorv1.RegisterCollectorRequest{
-		Id:         s.args.ID,
-		Attributes: s.attrs,
-		Name:       s.args.Name,
+		Id:              s.args.ID,
+		LocalAttributes: s.attrs,
+		Name:            s.args.Name,
 	})
 	client := s.asClient
 
@@ -428,9 +429,9 @@ func (s *Service) fetchLocal() {
 func (s *Service) getAPIConfig() ([]byte, error) {
 	s.mut.RLock()
 	req := connect.NewRequest(&collectorv1.GetConfigRequest{
-		Id:         s.args.ID,
-		Attributes: s.attrs,
-		Hash:       s.remoteHash,
+		Id:              s.args.ID,
+		LocalAttributes: s.attrs,
+		Hash:            s.remoteHash,
 	})
 	client := s.asClient
 	s.mut.RUnlock()


### PR DESCRIPTION

#### PR Description

This PR bumps the version of the protocol version used by the remotecfg service to v0.0.10. The new version introduces a new `LocalAttributes` field to deprecate `Attributes`.

#### Which issue(s) this PR fixes

None filed.

#### Notes to the Reviewer

cc @erikbaranowski who gathered consensus for the rename. My gut says to not break anything on the Alloy side and leave the 'attribute' field as-is. What do you think?

cc @spartan0x117 since we're changing the remotecfg service, I thought to add [connect.WithHTTPGet](https://connectrpc.com/docs/go/get-requests-and-caching/) to take advantage of the idempotency of the GetConfig request. I think you've looked into this in the past right?

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated (N/A) 
- [ ] Config converters updated (N/A)
