### PR TITLE
feat(pyroscope.receive_http): ensure consistent service_name label handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Main (unreleased)
 - Reduce CPU usage of `loki.source.windowsevent` by up to 85% by updating the bookmark file every 10 seconds instead of after every event and by 
   optimizing the retrieval of the process name. (@wildum)
 
+- Ensure consistent service_name label handling in `pyroscope.receive_http` to match Pyroscope's behavior. (@marcsanmi)
+
 ### Bugfixes
 
 - Fix log rotation for Windows in `loki.source.file` by refactoring the component to use the runner pkg. This should also reduce CPU consumption when tailing a lot of files in a dynamic environment. (@wildum)

--- a/internal/component/pyroscope/appender.go
+++ b/internal/component/pyroscope/appender.go
@@ -13,7 +13,9 @@ import (
 )
 
 const (
-	LabelNameDelta = "__delta__"
+	LabelNameDelta   = "__delta__"
+	LabelName        = "__name__"
+	LabelServiceName = "service_name"
 )
 
 var NoopAppendable = AppendableFunc(func(_ context.Context, _ labels.Labels, _ []*RawSample) error { return nil })

--- a/internal/component/pyroscope/receive_http/receive_http.go
+++ b/internal/component/pyroscope/receive_http/receive_http.go
@@ -298,28 +298,16 @@ func (c *Component) shutdownServer() {
 	}
 }
 
-const (
-	labelServiceName = "service_name"
-	labelAppName     = "app_name"
-)
-
+// rename __name__ to service_name
 func ensureServiceName(lbls labels.Labels) labels.Labels {
-	// If service_name is already present, add app_name if not exists
-	if lbls.Has(labelServiceName) {
-		if appName := lbls.Get("__name__"); appName != "" && !lbls.Has(labelAppName) {
-			builder := labels.NewBuilder(lbls)
-			builder.Set(labelAppName, appName)
-			return builder.Labels()
-		}
-		return lbls
+	builder := labels.NewBuilder(lbls)
+	originalName := lbls.Get(pyroscope.LabelName)
+
+	if !lbls.Has(pyroscope.LabelServiceName) {
+		builder.Set(pyroscope.LabelServiceName, originalName)
+	} else {
+		builder.Set("app_name", originalName)
 	}
 
-	// If no service_name, use __name__ value for service_name
-	if appName := lbls.Get("__name__"); appName != "" {
-		builder := labels.NewBuilder(lbls)
-		builder.Set(labelServiceName, appName)
-		return builder.Labels()
-	}
-
-	return lbls
+	return builder.Labels()
 }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR ensures that `pyroscope.receive_http` component sets the `service_name` label consistently from `__name__` to match Pyroscope's behavior. When `service_name` already exists, it sets `app_name` from `__name__` instead.


#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

I decided to duplicate the service name logic in Alloy rather than create a shared abstraction because:
- The logic is simple and stable (see [pkg/ingester/pyroscope/ingest_adapter.go lines 125-149](https://github.com/grafana/pyroscope/blob/048874070c948c05c9209c9054288953034a09ad/pkg/ingester/otlp/ingest_handler.go#L108-L119))
- Both implementations use different label types (Pyroscope's LabelSet vs Prometheus' labels.Labels) and forcing an abstraction would add unnecessary complexity

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
- [ ] Documentation added
- [X] Tests updated
- [ ] Config converters updated
