### PR TITLE
Create Linux build images on a runner with more disk space

### DIFF
--- a/.github/workflows/create_build_image.yml
+++ b/.github/workflows/create_build_image.yml
@@ -12,7 +12,7 @@ jobs:
   linux_build_image:
     name: Create a Linux build image
     runs-on:
-      labels: github-hosted-ubuntu-x64-small
+      labels: github-hosted-ubuntu-x64-large
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -40,7 +40,7 @@ jobs:
   linux_build_image_boringcrypto:
     name: Create a Linux build image for boringcrypto
     runs-on:
-      labels: github-hosted-ubuntu-x64-small
+      labels: github-hosted-ubuntu-x64-large
     steps:
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
The builds have been [failing](https://github.com/grafana/alloy/actions/runs/13263383507/job/37026459547) due to lack of disk space.