### PR TITLE
database_observability: refactoring to caching in table schema collector

### DIFF
--- a/internal/component/database_observability/mysql/collector/schema_table.go
+++ b/internal/component/database_observability/mysql/collector/schema_table.go
@@ -98,13 +98,13 @@ type SchemaTable struct {
 }
 
 type tableInfo struct {
-	schema     string
-	tableName  string
-	tableType  string
-	createTime time.Time
-	updateTime time.Time
-	createStmt string
-	tableSpec  string
+	schema        string
+	tableName     string
+	tableType     string
+	createTime    time.Time
+	updateTime    time.Time
+	b64CreateStmt string
+	b64TableSpec  string
 }
 
 type tableSpec struct {
@@ -240,13 +240,13 @@ func (c *SchemaTable) extractSchema(ctx context.Context) error {
 				break
 			}
 			tables = append(tables, &tableInfo{
-				schema:     schema,
-				tableName:  tableName,
-				tableType:  tableType,
-				createTime: createTime,
-				updateTime: updateTime,
-				createStmt: "",
-				tableSpec:  "",
+				schema:        schema,
+				tableName:     tableName,
+				tableType:     tableType,
+				createTime:    createTime,
+				updateTime:    updateTime,
+				b64CreateStmt: "",
+				b64TableSpec:  "",
 			})
 
 			c.entryHandler.Chan() <- loki.Entry{
@@ -307,7 +307,7 @@ func (c *SchemaTable) extractSchema(ctx context.Context) error {
 				Timestamp: time.Unix(0, time.Now().UnixNano()),
 				Line: fmt.Sprintf(
 					`level=info msg="create table" schema="%s" table="%s" create_statement="%s" table_spec="%s"`,
-					table.schema, table.tableName, base64.StdEncoding.EncodeToString([]byte(table.createStmt)), base64.StdEncoding.EncodeToString([]byte(table.tableSpec)),
+					table.schema, table.tableName, table.b64CreateStmt, table.b64TableSpec,
 				),
 			},
 		}
@@ -326,18 +326,22 @@ func (c *SchemaTable) fetchTableDefinitions(ctx context.Context, fullyQualifiedT
 	}
 
 	var tableName, createStmt, characterSetClient, collationConnection string
-	if table.tableType == "BASE TABLE" {
+	switch table.tableType {
+	case "BASE TABLE":
 		if err := row.Scan(&tableName, &createStmt); err != nil {
 			level.Error(c.logger).Log("msg", "failed to scan create table", append(logKVs, "err", err))
 			return nil, err
 		}
-	} else if table.tableType == "VIEW" {
+	case "VIEW":
 		if err := row.Scan(&tableName, &createStmt, &characterSetClient, &collationConnection); err != nil {
 			level.Error(c.logger).Log("msg", "failed to scan create view", append(logKVs, "err", err))
 			return nil, err
 		}
+	default:
+		level.Error(c.logger).Log("msg", "unknown table type", append(logKVs, "table_type", table.tableType))
+		return nil, fmt.Errorf("unknown table type: %s", table.tableType)
 	}
-	table.createStmt = createStmt
+	table.b64CreateStmt = base64.StdEncoding.EncodeToString([]byte(createStmt))
 
 	spec, err := c.fetchColumnsDefinitions(ctx, table.schema, table.tableName)
 	if err != nil {
@@ -349,7 +353,7 @@ func (c *SchemaTable) fetchTableDefinitions(ctx context.Context, fullyQualifiedT
 		level.Error(c.logger).Log("msg", "failed to marshal table spec", append(logKVs, "err", err))
 		return nil, err
 	}
-	table.tableSpec = string(jsonSpec)
+	table.b64TableSpec = base64.StdEncoding.EncodeToString(jsonSpec)
 
 	return table, nil
 }


### PR DESCRIPTION
#### PR Description
Minor change to cache the base64-encoded create statement and table spec in the `tableInfo` struct.

#### Which issue(s) this PR fixes
n.a.

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
