### PR TITLE
mimir.rules.kubernetes: explicitely mark the component as healthy on successful startup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ Main (unreleased)
 
 - Fix deadlocks in `loki.source.file` when tailing fails (@mblaschke)
 
+- Fixed an issue in the `mimir.rules.kubernetes` component that would keep the component as unhealthy even when it managed to start after temporary errors (@nicolasvan)
+
 ### Other changes
 
 - Upgrading to Prometheus v2.55.1. (@ptodev)

--- a/internal/component/mimir/rules/kubernetes/rules.go
+++ b/internal/component/mimir/rules/kubernetes/rules.go
@@ -244,6 +244,7 @@ func (c *Component) startupWithRetries(ctx context.Context, leader leadership, s
 			level.Error(c.log).Log("msg", "starting up component failed, will retry", "err", err)
 			health.reportUnhealthy(err)
 		} else {
+			health.reportHealthy()
 			break
 		}
 		startupBackoff.Wait()


### PR DESCRIPTION
#### PR Description

If the startup temporarily fails, the component is marked as unhealthy and the startup is retried indefinitely until it succeeds. When it succeeds, the component still remains unhealthy.

This change explicitly mark the component as healthy to fix it.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
