### PR TITLE
Add Drone PR checks back, fix issue with GitHub Actions tests

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -1,5 +1,7 @@
 local pipelines = import './pipelines.jsonnet';
 
+(import 'pipelines/test.jsonnet') +
 (import 'pipelines/check_containers.jsonnet') +
+(import 'pipelines/crosscompile.jsonnet') +
 (import 'pipelines/publish.jsonnet') +
 (import 'util/secrets.jsonnet').asList

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1,5 +1,75 @@
 ---
 kind: pipeline
+name: Lint
+platform:
+  arch: amd64
+  os: linux
+steps:
+- commands:
+  - apt-get update -y && apt-get install -y libsystemd-dev
+  - make lint
+  image: grafana/alloy-build-image:v0.1.8
+  name: Lint
+trigger:
+  event:
+  - pull_request
+type: docker
+---
+kind: pipeline
+name: Test
+platform:
+  arch: amd64
+  os: linux
+steps:
+- commands:
+  - make GO_TAGS="nodocker" test
+  image: grafana/alloy-build-image:v0.1.8
+  name: Run Go tests
+trigger:
+  event:
+  - pull_request
+type: docker
+---
+kind: pipeline
+name: Test (Full)
+platform:
+  arch: amd64
+  os: linux
+steps:
+- commands:
+  - K8S_USE_DOCKER_NETWORK=1 make test
+  image: grafana/alloy-build-image:v0.1.8
+  name: Run Go tests
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+trigger:
+  ref:
+  - refs/heads/main
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+kind: pipeline
+name: Test (Windows)
+platform:
+  arch: amd64
+  os: windows
+  version: "1809"
+steps:
+- commands:
+  - '& "C:/Program Files/git/bin/bash.exe" -c ''go test -tags="nodocker,nonetwork"
+    ./...'''
+  image: grafana/alloy-build-image:v0.1.8-windows
+  name: Run Go tests
+trigger:
+  ref:
+  - refs/heads/main
+type: docker
+---
+kind: pipeline
 name: Check Linux container (grafana/alloy)
 platform:
   arch: amd64
@@ -49,6 +119,172 @@ volumes:
 - host:
     path: //./pipe/docker_engine/
   name: docker
+---
+kind: pipeline
+name: Build alloy (Linux amd64)
+platform:
+  arch: amd64
+  os: linux
+steps:
+- commands:
+  - make generate-ui
+  - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=amd64 GOARM=
+    make alloy
+  image: grafana/alloy-build-image:v0.1.8
+  name: Build
+trigger:
+  event:
+  - pull_request
+type: docker
+---
+kind: pipeline
+name: Build alloy (Linux arm64)
+platform:
+  arch: amd64
+  os: linux
+steps:
+- commands:
+  - make generate-ui
+  - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=arm64 GOARM=
+    make alloy
+  image: grafana/alloy-build-image:v0.1.8
+  name: Build
+trigger:
+  event:
+  - pull_request
+type: docker
+---
+kind: pipeline
+name: Build alloy (Linux ppc64le)
+platform:
+  arch: amd64
+  os: linux
+steps:
+- commands:
+  - make generate-ui
+  - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=ppc64le GOARM=
+    make alloy
+  image: grafana/alloy-build-image:v0.1.8
+  name: Build
+trigger:
+  event:
+  - pull_request
+type: docker
+---
+kind: pipeline
+name: Build alloy (Linux s390x)
+platform:
+  arch: amd64
+  os: linux
+steps:
+- commands:
+  - make generate-ui
+  - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=s390x GOARM=
+    make alloy
+  image: grafana/alloy-build-image:v0.1.8
+  name: Build
+trigger:
+  event:
+  - pull_request
+type: docker
+---
+kind: pipeline
+name: Build alloy (macOS Intel)
+platform:
+  arch: amd64
+  os: linux
+steps:
+- commands:
+  - make generate-ui
+  - GO_TAGS="builtinassets" GOOS=darwin GOARCH=amd64 GOARM= make alloy
+  image: grafana/alloy-build-image:v0.1.8
+  name: Build
+trigger:
+  event:
+  - pull_request
+type: docker
+---
+kind: pipeline
+name: Build alloy (macOS Apple Silicon)
+platform:
+  arch: amd64
+  os: linux
+steps:
+- commands:
+  - make generate-ui
+  - GO_TAGS="builtinassets" GOOS=darwin GOARCH=arm64 GOARM= make alloy
+  image: grafana/alloy-build-image:v0.1.8
+  name: Build
+trigger:
+  event:
+  - pull_request
+type: docker
+---
+kind: pipeline
+name: Build alloy (Windows amd64)
+platform:
+  arch: amd64
+  os: linux
+steps:
+- commands:
+  - make generate-ui
+  - GO_TAGS="builtinassets" GOOS=windows GOARCH=amd64 GOARM= make alloy
+  image: grafana/alloy-build-image:v0.1.8
+  name: Build
+trigger:
+  event:
+  - pull_request
+type: docker
+---
+kind: pipeline
+name: Build alloy (FreeBSD amd64)
+platform:
+  arch: amd64
+  os: linux
+steps:
+- commands:
+  - make generate-ui
+  - GO_TAGS="builtinassets" GOOS=freebsd GOARCH=amd64 GOARM= make alloy
+  image: grafana/alloy-build-image:v0.1.8
+  name: Build
+trigger:
+  event:
+  - pull_request
+type: docker
+---
+kind: pipeline
+name: Build alloy (Linux amd64 boringcrypto)
+platform:
+  arch: amd64
+  os: linux
+steps:
+- commands:
+  - make generate-ui
+  - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=amd64 GOARM=
+    GOEXPERIMENT=boringcrypto make alloy
+  image: grafana/alloy-build-image:v0.1.8-boringcrypto
+  name: Build
+trigger:
+  event:
+  - pull_request
+type: docker
+---
+kind: pipeline
+name: Build alloy (Linux arm64 boringcrypto)
+platform:
+  arch: amd64
+  os: linux
+steps:
+- commands:
+  - make generate-ui
+  - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=arm64 GOARM=
+    GOEXPERIMENT=boringcrypto make alloy
+  image: grafana/alloy-build-image:v0.1.8-boringcrypto
+  name: Build
+trigger:
+  event:
+  - pull_request
+type: docker
 ---
 kind: pipeline
 name: Publish Windows alloy-devel container
@@ -343,6 +579,6 @@ kind: secret
 name: updater_private_key
 ---
 kind: signature
-hmac: a856a4590fb1229d9a5f749671c3c075cdc91631704f14a321f5d03aa2a53e2f
+hmac: 26b5613cbd5e5cd42656c10c372d44dc93af565ec2ae212d3b27c2fe366c6aeb
 
 ...

--- a/.drone/pipelines/crosscompile.jsonnet
+++ b/.drone/pipelines/crosscompile.jsonnet
@@ -1,0 +1,77 @@
+local build_image = import '../util/build_image.jsonnet';
+local pipelines = import '../util/pipelines.jsonnet';
+
+local go_tags = {
+  linux: 'builtinassets promtail_journal_enabled',
+  windows: 'builtinassets',
+  darwin: 'builtinassets',
+  freebsd: 'builtinassets',
+};
+
+local os_arch_tuples = [
+  // Linux
+  { name: 'Linux amd64', os: 'linux', arch: 'amd64' },
+  { name: 'Linux arm64', os: 'linux', arch: 'arm64' },
+  { name: 'Linux ppc64le', os: 'linux', arch: 'ppc64le' },
+  { name: 'Linux s390x', os: 'linux', arch: 's390x' },
+
+  // Darwin
+  { name: 'macOS Intel', os: 'darwin', arch: 'amd64' },
+  { name: 'macOS Apple Silicon', os: 'darwin', arch: 'arm64' },
+
+  // Windows
+  { name: 'Windows amd64', os: 'windows', arch: 'amd64' },
+
+
+  // FreeBSD
+  { name: 'FreeBSD amd64', os: 'freebsd', arch: 'amd64' },
+];
+
+
+local targets = [
+  'alloy',
+];
+local targets_boringcrypto = [
+  'alloy',
+];
+
+
+local os_arch_types_boringcrypto = [
+  // Linux boringcrypto
+  { name: 'Linux amd64 boringcrypto', os: 'linux', arch: 'amd64', experiment: 'boringcrypto' },
+  { name: 'Linux arm64 boringcrypto', os: 'linux', arch: 'arm64', experiment: 'boringcrypto' },
+];
+
+local build_environments(targets, tuples, image) = std.flatMap(function(target) (
+  std.map(function(platform) (
+    pipelines.linux('Build %s (%s)' % [target, platform.name]) {
+      local env = {
+        GOOS: platform.os,
+        GOARCH: platform.arch,
+        GOARM: if 'arm' in platform then platform.arm else '',
+
+        target: target,
+
+        tags: go_tags[platform.os],
+      } + (if 'experiment' in platform then { GOEXPERIMENT: platform.experiment } else {}),
+
+      trigger: {
+        event: ['pull_request'],
+      },
+
+      steps: [{
+        name: 'Build',
+        image: image,
+        commands: [
+          'make generate-ui',
+          (if 'GOEXPERIMENT' in env
+           then 'GO_TAGS="%(tags)s" GOOS=%(GOOS)s GOARCH=%(GOARCH)s GOARM=%(GOARM)s GOEXPERIMENT=%(GOEXPERIMENT)s make %(target)s' % env
+           else 'GO_TAGS="%(tags)s" GOOS=%(GOOS)s GOARCH=%(GOARCH)s GOARM=%(GOARM)s make %(target)s') % env,
+        ],
+      }],
+    }
+  ), tuples)
+), targets);
+
+build_environments(targets, os_arch_tuples, build_image.linux) +
+build_environments(targets_boringcrypto, os_arch_types_boringcrypto, build_image.boringcrypto)

--- a/.drone/pipelines/test.jsonnet
+++ b/.drone/pipelines/test.jsonnet
@@ -1,0 +1,72 @@
+local build_image = import '../util/build_image.jsonnet';
+local pipelines = import '../util/pipelines.jsonnet';
+
+[
+  pipelines.linux('Lint') {
+    trigger: {
+      event: ['pull_request'],
+    },
+    steps: [{
+      name: 'Lint',
+      image: build_image.linux,
+      commands: [
+        'apt-get update -y && apt-get install -y libsystemd-dev',
+        'make lint',
+      ],
+    }],
+  },
+
+  pipelines.linux('Test') {
+    trigger: {
+      event: ['pull_request'],
+    },
+    steps: [{
+      name: 'Run Go tests',
+      image: build_image.linux,
+
+      commands: [
+        'make GO_TAGS="nodocker" test',
+      ],
+    }],
+  },
+
+  pipelines.linux('Test (Full)') {
+    trigger: {
+      ref: ['refs/heads/main'],
+    },
+    steps: [{
+      name: 'Run Go tests',
+      image: build_image.linux,
+      volumes: [{
+        name: 'docker',
+        path: '/var/run/docker.sock',
+      }],
+
+      commands: [
+        // The operator tests require K8S_USE_DOCKER_NETWORK=1 to be set when
+        // tests are being run inside of a Docker container so it can access the
+        // created k3d cluster properly.
+        'K8S_USE_DOCKER_NETWORK=1 make test',
+      ],
+    }],
+    volumes: [{
+      name: 'docker',
+      host: {
+        path: '/var/run/docker.sock',
+      },
+    }],
+  },
+
+  pipelines.windows('Test (Windows)') {
+    trigger: {
+      ref: ['refs/heads/main'],
+    },
+    steps: [{
+      name: 'Run Go tests',
+      image: build_image.windows,
+      commands: [
+        pipelines.windows_command('go test -tags="nodocker,nonetwork" ./...'),
+      ],
+    }],
+  },
+]

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -19,7 +19,6 @@ jobs:
   test_linux:
     name: Test Linux
     runs-on: ubuntu-latest
-    container: grafana/alloy-build-image:v0.1.8
     steps:
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
I found out that the GH Actions don't actually run all the tests as part of PR checks. This is due to errors such as this:
```
error obtaining VCS status: exit status 128
```
It happens when tests are rain inside a container in GH actions. To fix this, we can either run without a container (which is what I've done here) or we can add a snippet like this:
```
    - name: Set ownership
      # https://github.com/actions/runner/issues/2033#issuecomment-1204205989
      run: |
          # this is to fix GIT not liking owner of the checkout dir
          chown -R $(id -u):$(id -g) $PWD
```

Drone doesn't use a special container for these builds, so I don't think it's necessary.

This PR also reverts #2695. I'll bring back Drone as part of PR review checks for now, until we have more confidence in the GH actions.