### PR TITLE
Pin GihHub Action for logging in to Google Artifact Registry to v0.1.1

### DIFF
--- a/.github/workflows/publish-alloy-devel.yml
+++ b/.github/workflows/publish-alloy-devel.yml
@@ -87,7 +87,7 @@ jobs:
           chown -R $(id -u):$(id -g) $PWD
 
     - name: Log in to Google Artifact Registry
-      uses: grafana/shared-workflows/actions/login-to-gar@login-to-gar-v0.1.1
+      uses: grafana/shared-workflows/actions/login-to-gar@login-to-gar-v0.2.0
       id: login-to-gar
       with:
         registry: "us-docker.pkg.dev"

--- a/.github/workflows/publish-alloy-devel.yml
+++ b/.github/workflows/publish-alloy-devel.yml
@@ -93,10 +93,10 @@ jobs:
         registry: "us-docker.pkg.dev"
         environment: "prod"
 
-    - name: Create .image-tag
+    - name: Create an IMG_TAG env var
       run: |
-        echo "$(bash ./tools/image-tag-docker)" > .tag-only
-        echo "grafana/alloy-dev:$(bash ./tools/image-tag-docker)" > .image-tag
+        IMG_TAG_INT=$(echo "grafana/alloy-dev:$(bash ./tools/image-tag-docker)")
+        echo "IMG_TAG=$IMG_TAG_INT" >> $GITHUB_ENV
 
     - name: Update to latest image
       env:
@@ -116,7 +116,7 @@ jobs:
             {
               "file_path": "ksonnet/lib/alloy/waves/alloy.libsonnet",
               "jsonnet_key": "dev_canary",
-              "jsonnet_value_file": ".image-tag"
+              "jsonnet_value": "$IMG_TAG"
             }
           ]
         }

--- a/.github/workflows/publish-alloy-devel.yml
+++ b/.github/workflows/publish-alloy-devel.yml
@@ -87,12 +87,13 @@ jobs:
           chown -R $(id -u):$(id -g) $PWD
 
     - name: Log in to Google Artifact Registry
-      uses: grafana/shared-workflows/actions/login-to-gar@main
+      uses: grafana/shared-workflows/actions/login-to-gar@login-to-gar-v0.1.1
+      id: login-to-gar
       with:
         registry: "us-docker.pkg.dev"
         environment: "prod"
 
-    - name: Update to latest image
+    - name: Create .image-tag
       run: |
         echo "$(bash ./tools/image-tag-docker)" > .tag-only
         echo "grafana/alloy-dev:$(bash ./tools/image-tag-docker)" > .image-tag


### PR DESCRIPTION
We get [this error](https://github.com/grafana/alloy/actions/runs/13290421881/job/37110942649) in the logs:
```
Warning: Warning: Authenticating with a Service Account is going to be deprecated on April 30. If you don't want to be affected by this change, either pin your action according to https://github.com/grafana/shared-workflows/blob/main/actions/login-to-gar/README.md or go to your repository config and stop using Service Accounts.
```

Hopefully pinning the action will get rid of it.