### PR TITLE
database_observability: don't error out for `insert` with `values`

### DIFF
--- a/internal/component/database_observability/mysql/collector/query_sample.go
+++ b/internal/component/database_observability/mysql/collector/query_sample.go
@@ -226,6 +226,8 @@ func (c QuerySample) tablesFromQuery(digest string, stmt sqlparser.Statement) []
 	case *sqlparser.Insert:
 		parsedTables = []string{c.parseTableName(stmt.Table)}
 		switch insRowsStmt := stmt.Rows.(type) {
+		case sqlparser.Values:
+			// ignore raw values
 		case *sqlparser.Select:
 			parsedTables = append(parsedTables, c.tablesFromQuery(digest, insRowsStmt)...)
 		case *sqlparser.Union:


### PR DESCRIPTION
#### PR Description
Statements like `insert into table values (...)` were logging an error even though the tables were correctly parsed.

#### Which issue(s) this PR fixes
n.a.

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
