### PR TITLE
fix flaky foreach test

### DIFF
--- a/internal/runtime/foreach_stringer_test.go
+++ b/internal/runtime/foreach_stringer_test.go
@@ -52,14 +52,14 @@ func testConfigForEachStringer(t *testing.T, config string, expectedDebugInfo *s
 	if expectedDebugInfo != nil {
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			debugInfo := getDebugInfo[string](t, ctrl, "", "testcomponents.string_receiver.log")
-			require.Equal(t, *expectedDebugInfo, debugInfo)
+			assert.Equal(c, *expectedDebugInfo, debugInfo)
 		}, 3*time.Second, 10*time.Millisecond)
 	}
 
 	if expectedDebugInfo2 != nil {
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			debugInfo := getDebugInfo[string](t, ctrl, "", "testcomponents.string_receiver.log2")
-			require.Equal(t, *expectedDebugInfo2, debugInfo)
+			assert.Equal(c, *expectedDebugInfo2, debugInfo)
 		}, 3*time.Second, 10*time.Millisecond)
 	}
 }


### PR DESCRIPTION
in the EventuallyWithT. the assert.CollectT should be used to collect the assertion.
When the *testing.T is used, it will fail the test on the first try instead of retrying till the condition is true or the timeout triggers. The test was flaky because sometimes it had enough time to get the right data on the first check but sometimes it didnt