### PR TITLE
dashboard prototyping fixes

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,0 +1,2 @@
+# Add here any additional datasources for testing
+config/grafana/datasources/datasource-dev.yml

--- a/example/README.md
+++ b/example/README.md
@@ -20,7 +20,7 @@ dashboards for monitoring Grafana Alloy.
 To start the environment, run:
 
 ```bash
-docker compose up -d
+docker compose up --build -d
 ```
 
 To stop the environment, run:
@@ -39,7 +39,7 @@ To run Alloy within Docker Compose, pass `--profile=alloy` to `docker compose`
 when starting and stopping the environment:
 
 ```bash
-docker compose --profile=alloy up -d
+docker compose --profile=alloy up --build -d
 ```
 
 ```bash

--- a/example/databases.yaml
+++ b/example/databases.yaml
@@ -1,6 +1,6 @@
 services:
   mimir:
-    image: grafana/mimir:2.12.0
+    image: grafana/mimir:2.14.3
     restart: on-failure
     command:
       - -config.file=/etc/mimir-config/mimir.yaml
@@ -10,13 +10,13 @@ services:
       - "9009:9009"
 
   loki:
-    image: grafana/loki:3.0.0
+    image: grafana/loki:3.4.1
     restart: on-failure
     ports:
       - "3100:3100"
 
   tempo:
-    image: grafana/tempo:2.4.1
+    image: grafana/tempo:2.7.0
     restart: on-failure
     command:
       - "-storage.trace.backend=local"                  # tell tempo where to permanently put traces

--- a/example/grafana.yaml
+++ b/example/grafana.yaml
@@ -1,6 +1,6 @@
 services:
   grafana:
-    image: grafana/grafana:10.1.9
+    image: grafana/grafana:11.5.1
     restart: on-failure
     command:
       - --config=/etc/grafana-config/grafana.ini
@@ -53,6 +53,6 @@ services:
     volumes:
       - ../operations/alloy-mixin:/etc/alloy-mixin
     working_dir: /etc/alloy-mixin
-    command: grr watch dashboards/ grizzly/dashboards.jsonnet
+    command: grr watch . ./grizzly.jsonnet
 
 

--- a/example/grafana.yaml
+++ b/example/grafana.yaml
@@ -10,11 +10,15 @@ services:
     ports:
       - "3000:3000"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/healthz"]
+      test: [ "CMD", "curl", "-f", "http://localhost:3000/healthz" ]
       interval: 1s
       start_interval: 0s
       timeout: 10s
       retries: 5
+    env_file:
+      # Use this optional env file to add any secrets required by data sources you can add to config/grafana/datasources
+      - path: ~/.grafana_dev_datasources
+        required: false
 
   install-dashboard-dependencies:
     build: images/jb

--- a/example/images/grizzly/Dockerfile
+++ b/example/images/grizzly/Dockerfile
@@ -1,3 +1,3 @@
 FROM golang:1.23-alpine
 
-RUN go install github.com/grafana/grizzly/cmd/grr@v0.4.3
+RUN go install github.com/grafana/grizzly/cmd/grr@v0.7.1

--- a/operations/alloy-mixin/dashboards/opentelemetry.libsonnet
+++ b/operations/alloy-mixin/dashboards/opentelemetry.libsonnet
@@ -44,9 +44,10 @@ local stackedPanelMixin = {
         panel.withQueries([
           panel.newQuery(
             expr= |||
-              sum by(instance) (rate(otelcol_receiver_accepted_spans_total{%(instanceSelector)s}[$__rate_interval]))
+              rate(otelcol_receiver_accepted_spans_total{%(instanceSelector)s}[$__rate_interval])
             ||| % $._config,
-            legendFormat='{{ instance }}',
+            //TODO: How will the dashboard look if there is more than one receiver component? The legend is not unique enough?
+            legendFormat='{{ pod }} / {{ transport }}',
           ),
         ])
       ),
@@ -61,9 +62,9 @@ local stackedPanelMixin = {
         panel.withQueries([
           panel.newQuery(
             expr= |||
-              sum by(instance) (rate(otelcol_receiver_refused_spans_total{%(instanceSelector)s}[$__rate_interval]))
+              rate(otelcol_receiver_refused_spans_total{%(instanceSelector)s}[$__rate_interval])
             ||| % $._config,
-            legendFormat='{{ instance }}',
+            legendFormat='{{ pod }} / {{ transport }}',
           ),
         ])
       ),
@@ -118,9 +119,9 @@ local stackedPanelMixin = {
         panel.withQueries([
           panel.newQuery(
             expr= |||
-              sum by(instance) (otelcol_processor_batch_metadata_cardinality{%(instanceSelector)s})
+              otelcol_processor_batch_metadata_cardinality{%(instanceSelector)s}
             ||| % $._config,
-            legendFormat='{{ instance }}',
+            legendFormat='{{ pod }}',
           ),
         ])
       ),
@@ -133,9 +134,9 @@ local stackedPanelMixin = {
         panel.withQueries([
           panel.newQuery(
             expr= |||
-              sum by(instance) (rate(otelcol_processor_batch_timeout_trigger_send_total{%(instanceSelector)s}[$__rate_interval]))
+              rate(otelcol_processor_batch_timeout_trigger_send_total{%(instanceSelector)s}[$__rate_interval])
             ||| % $._config,
-            legendFormat='{{ instance }}',
+            legendFormat='{{ pod }}',
           ),
         ])
       ),
@@ -155,9 +156,9 @@ local stackedPanelMixin = {
         panel.withQueries([
           panel.newQuery(
             expr= ||| 
-              sum by(instance) (rate(otelcol_exporter_sent_spans_total{%(instanceSelector)s}[$__rate_interval]))
+              rate(otelcol_exporter_sent_spans_total{%(instanceSelector)s}[$__rate_interval])
             ||| % $._config,
-            legendFormat='{{ instance }}',
+            legendFormat='{{ pod }}',
           ),
         ])
       ),
@@ -171,9 +172,9 @@ local stackedPanelMixin = {
         panel.withQueries([
           panel.newQuery(
             expr= |||
-              sum by(instance) (rate(otelcol_exporter_send_failed_spans_total{%(instanceSelector)s}[$__rate_interval]))
+              rate(otelcol_exporter_send_failed_spans_total{%(instanceSelector)s}[$__rate_interval])
             ||| % $._config,
-            legendFormat='{{ instance }}',
+            legendFormat='{{ pod }}',
           ),
         ])
       ),

--- a/operations/alloy-mixin/dashboards/opentelemetry.libsonnet
+++ b/operations/alloy-mixin/dashboards/opentelemetry.libsonnet
@@ -44,10 +44,9 @@ local stackedPanelMixin = {
         panel.withQueries([
           panel.newQuery(
             expr= |||
-              rate(otelcol_receiver_accepted_spans_total{%(instanceSelector)s}[$__rate_interval])
+              sum by(instance) (rate(otelcol_receiver_accepted_spans_total{%(instanceSelector)s}[$__rate_interval]))
             ||| % $._config,
-            //TODO: How will the dashboard look if there is more than one receiver component? The legend is not unique enough?
-            legendFormat='{{ pod }} / {{ transport }}',
+            legendFormat='{{ instance }}',
           ),
         ])
       ),
@@ -62,9 +61,9 @@ local stackedPanelMixin = {
         panel.withQueries([
           panel.newQuery(
             expr= |||
-              rate(otelcol_receiver_refused_spans_total{%(instanceSelector)s}[$__rate_interval])
+              sum by(instance) (rate(otelcol_receiver_refused_spans_total{%(instanceSelector)s}[$__rate_interval]))
             ||| % $._config,
-            legendFormat='{{ pod }} / {{ transport }}',
+            legendFormat='{{ instance }}',
           ),
         ])
       ),
@@ -119,9 +118,9 @@ local stackedPanelMixin = {
         panel.withQueries([
           panel.newQuery(
             expr= |||
-              otelcol_processor_batch_metadata_cardinality{%(instanceSelector)s}
+              sum by(instance) (otelcol_processor_batch_metadata_cardinality{%(instanceSelector)s})
             ||| % $._config,
-            legendFormat='{{ pod }}',
+            legendFormat='{{ instance }}',
           ),
         ])
       ),
@@ -134,9 +133,9 @@ local stackedPanelMixin = {
         panel.withQueries([
           panel.newQuery(
             expr= |||
-              rate(otelcol_processor_batch_timeout_trigger_send_total{%(instanceSelector)s}[$__rate_interval])
+              sum by(instance) (rate(otelcol_processor_batch_timeout_trigger_send_total{%(instanceSelector)s}[$__rate_interval]))
             ||| % $._config,
-            legendFormat='{{ pod }}',
+            legendFormat='{{ instance }}',
           ),
         ])
       ),
@@ -156,9 +155,9 @@ local stackedPanelMixin = {
         panel.withQueries([
           panel.newQuery(
             expr= ||| 
-              rate(otelcol_exporter_sent_spans_total{%(instanceSelector)s}[$__rate_interval])
+              sum by(instance) (rate(otelcol_exporter_sent_spans_total{%(instanceSelector)s}[$__rate_interval]))
             ||| % $._config,
-            legendFormat='{{ pod }}',
+            legendFormat='{{ instance }}',
           ),
         ])
       ),
@@ -172,9 +171,9 @@ local stackedPanelMixin = {
         panel.withQueries([
           panel.newQuery(
             expr= |||
-              rate(otelcol_exporter_send_failed_spans_total{%(instanceSelector)s}[$__rate_interval])
+              sum by(instance) (rate(otelcol_exporter_send_failed_spans_total{%(instanceSelector)s}[$__rate_interval]))
             ||| % $._config,
-            legendFormat='{{ pod }}',
+            legendFormat='{{ instance }}',
           ),
         ])
       ),


### PR DESCRIPTION
* updates the versions of grafana/loki/mimir/tempo used in the example
* fixes the issue with grizzly by updating it and fixing its run path
* adds an easy support for extra datasources through `~/.grafana_dev_datasources` file