### PR TITLE
Update otelcol.exporter.kafka.md

### DIFF
--- a/docs/sources/reference/components/otelcol/otelcol.exporter.kafka.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.kafka.md
@@ -87,7 +87,7 @@ authentication > kerberos        | [kerberos][]         | Authenticates against 
 metadata                         | [metadata][]         | Configures how to retrieve metadata from Kafka brokers.                     | no
 metadata > retry                 | [retry][]            | Configures how to retry metadata retrieval.                                 | no
 retry_on_failure                 | [retry_on_failure][] | Configures retry mechanism for failed requests.                             | no
-queue                            | [queue][]            | Configures batching of data before sending.                                 | no
+sending_queue                    | [sending_queue][]    | Configures batching of data before sending.                                 | no
 producer                         | [producer][]         | Kafka producer configuration,                                               | no
 debug_metrics                    | [debug_metrics][]    | Configures the metrics which this component generates to monitor its state. | no
 
@@ -103,7 +103,7 @@ For example, `authentication > tls` refers to a `tls` block defined inside an `a
 [metadata]: #metadata-block
 [retry]: #retry-block
 [retry_on_failure]: #retry_on_failure-block
-[queue]: #queue-block
+[sending_queue]: #sending_queue-block
 [producer]: #producer-block
 [debug_metrics]: #debug_metrics-block
 
@@ -149,9 +149,9 @@ The `retry_on_failure` block configures how failed requests to Kafka are retried
 
 {{< docs/shared lookup="reference/components/otelcol-retry-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
-### queue block
+### sending_queue block
 
-The `queue` block configures an in-memory buffer of batches before data is sent to the gRPC server.
+The `sending_queue` block configures an in-memory buffer of batches before data is sent to the gRPC server.
 
 {{< docs/shared lookup="reference/components/otelcol-queue-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 


### PR DESCRIPTION
Seems like queue block name is incorrect in documentatin. Based on code it actually sending_queue.

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
