### PR TITLE
Reorder CI steps so Docker image tag generation can work

### DIFF
--- a/.github/workflows/publish-alloy-devel.yml
+++ b/.github/workflows/publish-alloy-devel.yml
@@ -77,22 +77,21 @@ jobs:
     - publish_linux_boringcrypto_container
     steps:
 
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Set ownership
-      # https://github.com/actions/runner/issues/2033#issuecomment-1204205989
-      run: |
-          # this is to fix GIT not liking owner of the checkout dir
-          chown -R $(id -u):$(id -g) $PWD
-
     - name: Log in to Google Artifact Registry
+      # This step needs to run before "Checkout code".
+      # That's because the login to GAR generates a new file.
+      # We don't want this file to end up in the repo directory.
+      # Then "tools/image-tag" would get confused because "git status" no longer reports a clean repo.
+      # TODO: Ask the platform team to rework the login to GAR to not generate such files?
       uses: grafana/shared-workflows/actions/login-to-gar@main
       with:
         registry: "us-docker.pkg.dev"
         environment: "prod"
 
-    - name: Update to latest image
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Get the image tag
       run: |
         echo "$(bash ./tools/image-tag-docker)" > .tag-only
         echo "grafana/alloy-dev:$(bash ./tools/image-tag-docker)" > .image-tag
@@ -102,6 +101,8 @@ jobs:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       run: |
         set -e -o pipefail
+
+        echo "The image tag is: $(cat .image-tag)"
 
         cat << EOF > config.json
         {


### PR DESCRIPTION
This should hopefully fix the CI step which updates deployment_tools.