### PR TITLE
Fix Windows unit tests

### DIFF
--- a/internal/component/loki/source/azure_event_hubs/internal/parser/parser_test.go
+++ b/internal/component/loki/source/azure_event_hubs/internal/parser/parser_test.go
@@ -264,7 +264,7 @@ func Test_parseMessage_message_without_time_with_time_stamp(t *testing.T) {
 	assert.Len(t, entries, 1)
 
 	expectedLine1 := "{\n      \"timeStamp\": \"2024-09-18T00:45:09+00:00\",\n      \"resourceId\": \"/RESOURCE_ID\",\n      \"operationName\": \"ApplicationGatewayAccess\",\n      \"category\": \"ApplicationGatewayAccessLog\"\n    }"
-	assert.Equal(t, expectedLine1, entries[0].Line)
+	assert.Equal(t, expectedLine1, removeCRLFIfWindows(entries[0].Line))
 
 	assert.Equal(t, time.Date(2024, time.September, 18, 00, 45, 9, 0, time.UTC), entries[0].Timestamp)
 }

--- a/internal/converter/internal/staticconvert/testdata-v2_windows/integrations_v2.alloy
+++ b/internal/converter/internal/staticconvert/testdata-v2_windows/integrations_v2.alloy
@@ -1,6 +1,6 @@
 prometheus.remote_write "metrics_default" {
 	endpoint {
-		name = "default-149bbd"
+		name = "default-c3a75f"
 		url  = "http://localhost:9009/api/prom/push"
 
 		queue_config { }


### PR DESCRIPTION
There are 3 Windows unit test failures on the `main` branch. This PR will fix 2 of them.