### PR TITLE
database_observability: split out sqlparser functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Main (unreleased)
   - `query_sample`: capture schema name for query samples (@cristiangreco)
   - `query_sample`: fix error handling during result set iteration (@cristiangreco)
   - `query_sample`: improve parsing of truncated queries (@cristiangreco)
+  - `query_sample`: split out sql parsing logic to a separate file (@cristiangreco)
   - `schema_table`: add table columns parsing (@cristiagreco)
   - `schema_table`: correctly quote schema and table name in SHOW CREATE (@cristiangreco)
   - `schema_table`: fix handling of view table types when detecting schema (@matthewnolf)
@@ -55,7 +56,7 @@ Main (unreleased)
 
 - Ensure consistent service_name label handling in `pyroscope.receive_http` to match Pyroscope's behavior. (@marcsanmi)
 
-- Improved memory and CPU performance of Prometheus pipelines by changing the underlying implementation of targets (@thampiotr)  
+- Improved memory and CPU performance of Prometheus pipelines by changing the underlying implementation of targets (@thampiotr)
 
 - Add `config_merge_strategy` in `prometheus.exporter.snmp` to optionally merge custom snmp config with embedded config instead of replacing. Useful for providing SNMP auths. (@v-zhuravlev)
 

--- a/internal/component/database_observability/mysql/collector/query_sample_test.go
+++ b/internal/component/database_observability/mysql/collector/query_sample_test.go
@@ -120,49 +120,6 @@ func TestQuerySample(t *testing.T) {
 			},
 		},
 		{
-			name: "subquery",
-			rows: [][]driver.Value{{
-				"abc123",
-				"some_schema",
-				`select ifnull(schema_name, 'none') as schema_name, digest, count_star from
-				(select * from performance_schema.events_statements_summary_by_digest where schema_name not in ('mysql', 'performance_schema', 'information_schema')
-				and last_seen > date_sub(now(), interval 86400 second) order by last_seen desc)q
-				group by q.schema_name, q.digest, q.count_star limit 100`,
-				"2024-01-01T00:00:00.000Z",
-				"1000",
-			}},
-			logsLabels: []model.LabelSet{
-				{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"},
-				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
-			},
-			logsLines: []string{
-				`level=info msg="query samples fetched" schema="some_schema" digest="abc123" query_type="select" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" ` +
-					`query_sample_redacted="select ifnull(schema_name, :redacted1) as schema_name, digest, count_star from (select * from ` +
-					`performance_schema.events_statements_summary_by_digest where schema_name not in ::redacted2 ` +
-					`and last_seen > date_sub(now(), interval :redacted3 second) order by last_seen desc) as q ` +
-					`group by q.schema_name, q.digest, q.count_star limit :redacted4"`,
-				`level=info msg="table name parsed" schema="some_schema" digest="abc123" table="performance_schema.events_statements_summary_by_digest"`,
-			},
-		},
-		{
-			name: "with comment",
-			rows: [][]driver.Value{{
-				"abc123",
-				"some_schema",
-				"select val1, /* val2,*/ val3 from some_table where id = 1",
-				"2024-01-01T00:00:00.000Z",
-				"1000",
-			}},
-			logsLabels: []model.LabelSet{
-				{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"},
-				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
-			},
-			logsLines: []string{
-				`level=info msg="query samples fetched" schema="some_schema" digest="abc123" query_type="select" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="select val1, val3 from some_table where id = :redacted1"`,
-				`level=info msg="table name parsed" schema="some_schema" digest="abc123" table="some_table"`,
-			},
-		},
-		{
 			name: "truncated query",
 			rows: [][]driver.Value{{
 				"xyz456",
@@ -221,40 +178,6 @@ func TestQuerySample(t *testing.T) {
 			},
 		},
 		{
-			name: "commit",
-			rows: [][]driver.Value{{
-				"abc123",
-				"some_schema",
-				"COMMIT",
-				"2024-01-01T00:00:00.000Z",
-				"1000",
-			}},
-			logsLabels: []model.LabelSet{
-				{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"},
-			},
-			logsLines: []string{
-				`level=info msg="query samples fetched" schema="some_schema" digest="abc123" query_type="" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="commit"`,
-			},
-		},
-		{
-			name: "alter table",
-			rows: [][]driver.Value{{
-				"abc123",
-				"some_schema",
-				"alter table some_table modify enumerable enum('val1', 'val2') not null",
-				"2024-01-01T00:00:00.000Z",
-				"1000",
-			}},
-			logsLabels: []model.LabelSet{
-				{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"},
-				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
-			},
-			logsLines: []string{
-				`level=info msg="query samples fetched" schema="some_schema" digest="abc123" query_type="" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="alter table some_table"`,
-				`level=info msg="table name parsed" schema="some_schema" digest="abc123" table="some_table"`,
-			},
-		},
-		{
 			name: "sql parse error",
 			rows: [][]driver.Value{{
 				"xyz456",
@@ -307,50 +230,6 @@ func TestQuerySample(t *testing.T) {
 			},
 		},
 		{
-			name: "union query",
-			rows: [][]driver.Value{{
-				"abc123",
-				"some_schema",
-				"SELECT id, name FROM employees_ny UNION SELECT id, name FROM employees_ca UNION SELECT id, name FROM employees_tx",
-				"2024-01-01T00:00:00.000Z",
-				"1000",
-			}},
-			logsLabels: []model.LabelSet{
-				{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"},
-				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
-				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
-				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
-			},
-			logsLines: []string{
-				`level=info msg="query samples fetched" schema="some_schema" digest="abc123" query_type="select" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="select id, name from employees_ny union select id, name from employees_ca union select id, name from employees_tx"`,
-				`level=info msg="table name parsed" schema="some_schema" digest="abc123" table="employees_ny"`,
-				`level=info msg="table name parsed" schema="some_schema" digest="abc123" table="employees_ca"`,
-				`level=info msg="table name parsed" schema="some_schema" digest="abc123" table="employees_tx"`,
-			},
-		},
-		{
-			name: "from subquery with union",
-			rows: [][]driver.Value{{
-				"abc123",
-				"some_schema",
-				"SELECT COUNT(DISTINCT t.role_id) AS roles, COUNT(DISTINCT r.id) AS fixed_roles FROM (SELECT role_id FROM user_role UNION ALL SELECT role_id FROM team_role) AS t LEFT JOIN (SELECT id FROM role WHERE name LIKE 'prefix%') AS r ON t.role_id = r.id",
-				"2024-01-01T00:00:00.000Z",
-				"1000",
-			}},
-			logsLabels: []model.LabelSet{
-				{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"},
-				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
-				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
-				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
-			},
-			logsLines: []string{
-				`level=info msg="query samples fetched" schema="some_schema" digest="abc123" query_type="select" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="select COUNT(distinct t.role_id) as roles, COUNT(distinct r.id) as fixed_roles from (select role_id from user_role union all select role_id from team_role) as t left join (select id from role where name like :redacted1) as r on t.role_id = r.id"`,
-				`level=info msg="table name parsed" schema="some_schema" digest="abc123" table="user_role"`,
-				`level=info msg="table name parsed" schema="some_schema" digest="abc123" table="team_role"`,
-				`level=info msg="table name parsed" schema="some_schema" digest="abc123" table="role"`,
-			},
-		},
-		{
 			name: "subquery and union",
 			rows: [][]driver.Value{{
 				"abc123",
@@ -370,74 +249,6 @@ func TestQuerySample(t *testing.T) {
 				`level=info msg="table name parsed" schema="some_schema" digest="abc123" table="employees_us_east"`,
 				`level=info msg="table name parsed" schema="some_schema" digest="abc123" table="employees_us_west"`,
 				`level=info msg="table name parsed" schema="some_schema" digest="abc123" table="employees_emea"`,
-			},
-		},
-		{
-			name: "insert with subquery and union",
-			rows: [][]driver.Value{{
-				"abc123",
-				"some_schema",
-				"INSERT INTO customers (id, name) SELECT id, name FROM customers_us UNION SELECT id, name FROM customers_eu",
-				"2024-01-01T00:00:00.000Z",
-				"1000",
-			}},
-			logsLabels: []model.LabelSet{
-				{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"},
-				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
-				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
-				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
-			},
-			logsLines: []string{
-				`level=info msg="query samples fetched" schema="some_schema" digest="abc123" query_type="insert" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="insert into customers(id, name) select id, name from customers_us union select id, name from customers_eu"`,
-				`level=info msg="table name parsed" schema="some_schema" digest="abc123" table="customers"`,
-				`level=info msg="table name parsed" schema="some_schema" digest="abc123" table="customers_us"`,
-				`level=info msg="table name parsed" schema="some_schema" digest="abc123" table="customers_eu"`,
-			},
-		},
-		{
-			name: "join with subquery and union",
-			rows: [][]driver.Value{{
-				"abc123",
-				"some_schema",
-				"SELECT * FROM departments dep JOIN (SELECT id, name FROM employees_us UNION SELECT id, name FROM employees_eu) employees ON dep.id = employees.id",
-				"2024-01-01T00:00:00.000Z",
-				"1000",
-			}},
-			logsLabels: []model.LabelSet{
-				{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"},
-				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
-				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
-				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
-			},
-			logsLines: []string{
-				`level=info msg="query samples fetched" schema="some_schema" digest="abc123" query_type="select" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="select * from departments as dep join (select id, name from employees_us union select id, name from employees_eu) as employees on dep.id = employees.id"`,
-				`level=info msg="table name parsed" schema="some_schema" digest="abc123" table="departments"`,
-				`level=info msg="table name parsed" schema="some_schema" digest="abc123" table="employees_us"`,
-				`level=info msg="table name parsed" schema="some_schema" digest="abc123" table="employees_eu"`,
-			},
-		},
-		{
-			name: "insert with subquery and join",
-			rows: [][]driver.Value{{
-				"abc123",
-				"some_schema",
-				"INSERT INTO some_table SELECT * FROM departments dep JOIN (SELECT id, name FROM employees_us UNION SELECT id, name FROM employees_eu) employees ON dep.id = employees.id",
-				"2024-01-01T00:00:00.000Z",
-				"1000",
-			}},
-			logsLabels: []model.LabelSet{
-				{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"},
-				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
-				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
-				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
-				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
-			},
-			logsLines: []string{
-				`level=info msg="query samples fetched" schema="some_schema" digest="abc123" query_type="insert" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="insert into some_table select * from departments as dep join (select id, name from employees_us union select id, name from employees_eu) as employees on dep.id = employees.id"`,
-				`level=info msg="table name parsed" schema="some_schema" digest="abc123" table="some_table"`,
-				`level=info msg="table name parsed" schema="some_schema" digest="abc123" table="departments"`,
-				`level=info msg="table name parsed" schema="some_schema" digest="abc123" table="employees_us"`,
-				`level=info msg="table name parsed" schema="some_schema" digest="abc123" table="employees_eu"`,
 			},
 		},
 		{
@@ -470,24 +281,6 @@ func TestQuerySample(t *testing.T) {
 			},
 			logsLines: []string{
 				`level=info msg="query samples fetched" schema="some_schema" digest="abc123" query_type="" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="show variables"`,
-			},
-		},
-		{
-			name: "drop table",
-			rows: [][]driver.Value{{
-				"abc123",
-				"some_schema",
-				"DROP TABLE IF EXISTS some_table",
-				"2024-01-01T00:00:00.000Z",
-				"1000",
-			}},
-			logsLabels: []model.LabelSet{
-				{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"},
-				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
-			},
-			logsLines: []string{
-				`level=info msg="query samples fetched" schema="some_schema" digest="abc123" query_type="" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="drop table if exists some_table"`,
-				`level=info msg="table name parsed" schema="some_schema" digest="abc123" table="some_table"`,
 			},
 		},
 	}

--- a/internal/component/database_observability/mysql/collector/sqlparser.go
+++ b/internal/component/database_observability/mysql/collector/sqlparser.go
@@ -1,0 +1,133 @@
+package collector
+
+import (
+	"github.com/go-kit/log"
+	"github.com/grafana/alloy/internal/runtime/logging/level"
+	"github.com/xwb1989/sqlparser"
+)
+
+func ParseSql(sql string) (sqlparser.Statement, error) {
+	return sqlparser.Parse(sql)
+}
+
+func RedactSQL(sql string) (string, error) {
+	return sqlparser.RedactSQLQuery(sql)
+}
+
+func StmtType(stmt sqlparser.Statement) string {
+	switch stmt.(type) {
+	case *sqlparser.Select:
+		return "select"
+	case *sqlparser.Insert:
+		return "insert"
+	case *sqlparser.Update:
+		return "update"
+	case *sqlparser.Delete:
+		return "delete"
+	case *sqlparser.Union:
+		return "select" // label union as a select
+	default:
+		return ""
+	}
+}
+
+func ParseTableName(t sqlparser.TableName) string {
+	qualifier := t.Qualifier.String()
+	tableName := t.Name.String()
+	if qualifier != "" {
+		return qualifier + "." + tableName
+	}
+	return tableName
+}
+
+func ExtractTableNames(logger log.Logger, digest string, stmt sqlparser.Statement) []string {
+	var parsedTables []string
+
+	switch stmt := stmt.(type) {
+	case *sqlparser.Select:
+		for _, selExpr := range stmt.SelectExprs {
+			if expr, ok := selExpr.(*sqlparser.AliasedExpr); ok {
+				switch exp := expr.Expr.(type) {
+				case *sqlparser.Subquery:
+					parsedTables = append(parsedTables, ExtractTableNames(logger, digest, exp.Select)...)
+				default:
+					level.Error(logger).Log("msg", "unknown aliased select type", "digest", digest)
+				}
+			}
+		}
+		parsedTables = append(parsedTables, parseTableExprs(logger, digest, stmt.From)...)
+	case *sqlparser.Update:
+		parsedTables = parseTableExprs(logger, digest, stmt.TableExprs)
+	case *sqlparser.Delete:
+		parsedTables = parseTableExprs(logger, digest, stmt.TableExprs)
+	case *sqlparser.Insert:
+		parsedTables = []string{ParseTableName(stmt.Table)}
+		switch insRowsStmt := stmt.Rows.(type) {
+		case sqlparser.Values:
+			// ignore raw values
+		case *sqlparser.Select:
+			parsedTables = append(parsedTables, ExtractTableNames(logger, digest, insRowsStmt)...)
+		case *sqlparser.Union:
+			for _, side := range []sqlparser.SelectStatement{insRowsStmt.Left, insRowsStmt.Right} {
+				parsedTables = append(parsedTables, ExtractTableNames(logger, digest, side)...)
+			}
+		case *sqlparser.ParenSelect:
+			parsedTables = append(parsedTables, ExtractTableNames(logger, digest, insRowsStmt.Select)...)
+		default:
+			level.Error(logger).Log("msg", "unknown insert type", "digest", digest)
+		}
+	case *sqlparser.Union:
+		for _, side := range []sqlparser.SelectStatement{stmt.Left, stmt.Right} {
+			parsedTables = append(parsedTables, ExtractTableNames(logger, digest, side)...)
+		}
+	case *sqlparser.Show:
+		if stmt.HasOnTable() {
+			parsedTables = append(parsedTables, ParseTableName(stmt.OnTable))
+		}
+	case *sqlparser.DDL:
+		parsedTables = append(parsedTables, ParseTableName(stmt.Table))
+	case *sqlparser.Begin, *sqlparser.Commit, *sqlparser.Rollback, *sqlparser.Set, *sqlparser.DBDDL:
+		// ignore
+	default:
+		level.Error(logger).Log("msg", "unknown statement type", "digest", digest)
+	}
+
+	return parsedTables
+}
+
+func parseTableExprs(logger log.Logger, digest string, tables sqlparser.TableExprs) []string {
+	parsedTables := []string{}
+	for i := 0; i < len(tables); i++ {
+		t := tables[i]
+		switch tableExpr := t.(type) {
+		case *sqlparser.AliasedTableExpr:
+			switch expr := tableExpr.Expr.(type) {
+			case sqlparser.TableName:
+				parsedTables = append(parsedTables, ParseTableName(expr))
+			case *sqlparser.Subquery:
+				switch subqueryExpr := expr.Select.(type) {
+				case *sqlparser.Select:
+					parsedTables = append(parsedTables, parseTableExprs(logger, digest, subqueryExpr.From)...)
+				case *sqlparser.Union:
+					for _, side := range []sqlparser.SelectStatement{subqueryExpr.Left, subqueryExpr.Right} {
+						parsedTables = append(parsedTables, ExtractTableNames(logger, digest, side)...)
+					}
+				case *sqlparser.ParenSelect:
+					parsedTables = append(parsedTables, ExtractTableNames(logger, digest, subqueryExpr.Select)...)
+				default:
+					level.Error(logger).Log("msg", "unknown subquery type", "digest", digest)
+				}
+			default:
+				level.Error(logger).Log("msg", "unknown nested table expression", "digest", digest, "table", tableExpr)
+			}
+		case *sqlparser.JoinTableExpr:
+			// continue parsing both sides of join
+			tables = append(tables, tableExpr.LeftExpr, tableExpr.RightExpr)
+		case *sqlparser.ParenTableExpr:
+			tables = append(tables, tableExpr.Exprs...)
+		default:
+			level.Error(logger).Log("msg", "unknown table type", "digest", digest, "table", t)
+		}
+	}
+	return parsedTables
+}

--- a/internal/component/database_observability/mysql/collector/sqlparser_test.go
+++ b/internal/component/database_observability/mysql/collector/sqlparser_test.go
@@ -1,0 +1,141 @@
+package collector
+
+import (
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractTableNames(t *testing.T) {
+	testcases := []struct {
+		name   string
+		sql    string
+		tables []string
+	}{
+		{
+			name:   "simple select",
+			sql:    "select * from some_table",
+			tables: []string{"some_table"},
+		},
+		{
+			name:   "simple insert",
+			sql:    "insert into some_table (`id`, `name`) values (1, 'foo')",
+			tables: []string{"some_table"},
+		},
+		{
+			name:   "simple update",
+			sql:    "update some_table set active=false, reason=null where id = 1 and  name = 'foo'",
+			tables: []string{"some_table"},
+		},
+		{
+			name:   "simple delete",
+			sql:    "delete from some_table where id = 1",
+			tables: []string{"some_table"},
+		},
+		{
+			name:   "select with join",
+			sql:    "select t.id, t.val1, o.val2 FROM some_table t inner join other_table as o on t.id = o.id where o.val2 = 1 order by t.val1 desc",
+			tables: []string{"some_table", "other_table"},
+		},
+		{
+			name: "select with subquery",
+			sql: `select ifnull(schema_name, 'none') as schema_name, digest, count_star from
+				(select * from performance_schema.events_statements_summary_by_digest where schema_name not in ('mysql', 'performance_schema', 'information_schema')
+				and last_seen > date_sub(now(), interval 86400 second) order by last_seen desc)q
+				group by q.schema_name, q.digest, q.count_star limit 100`,
+			tables: []string{"performance_schema.events_statements_summary_by_digest"},
+		},
+		{
+			name:   "select with aggregate",
+			sql:    "select count(*) from some_table group by id",
+			tables: []string{"some_table"},
+		},
+		{
+			name:   "select with comment",
+			sql:    "select val1, /* val2,*/ val3 from some_table where id = 1",
+			tables: []string{"some_table"},
+		},
+		{
+			name:   "select with case statement",
+			sql:    "select case when enabled then 'yes' else 'no' end as enabled from some_table where id = 1",
+			tables: []string{"some_table"},
+		},
+		{
+			name:   "parentheses in select",
+			sql:    "select (select count(*) from some_table) as count from other_table",
+			tables: []string{"some_table", "other_table"},
+		},
+		{
+			name:   "start transaction",
+			sql:    "START TRANSACTION",
+			tables: nil,
+		},
+		{
+			name:   "commit",
+			sql:    "COMMIT",
+			tables: nil,
+		},
+		{
+			name:   "alter table",
+			sql:    "alter table some_table modify enumerable enum('val1', 'val2') not null",
+			tables: []string{"some_table"},
+		},
+		{
+			name:   "simple union",
+			sql:    "SELECT id, name FROM employees_ny UNION SELECT id, name FROM employees_ca UNION SELECT id, name FROM employees_tx",
+			tables: []string{"employees_ny", "employees_ca", "employees_tx"},
+		},
+		{
+			name:   "subquery with union",
+			sql:    "SELECT COUNT(DISTINCT t.role_id) AS roles, COUNT(DISTINCT r.id) AS fixed_roles FROM (SELECT role_id FROM user_role UNION ALL SELECT role_id FROM team_role) AS t LEFT JOIN (SELECT id FROM role WHERE name LIKE 'prefix%') AS r ON t.role_id = r.id",
+			tables: []string{"user_role", "team_role", "role"},
+		},
+		{
+			name:   "subquery with union and alias",
+			sql:    "SELECT * FROM (SELECT id, name FROM employees_us_east UNION SELECT id, name FROM employees_us_west) as employees_us UNION SELECT id, name FROM employees_emea",
+			tables: []string{"employees_us_east", "employees_us_west", "employees_emea"},
+		},
+		{
+			name:   "insert with subquery and union",
+			sql:    "INSERT INTO customers (id, name) SELECT id, name FROM customers_us UNION SELECT id, name FROM customers_eu",
+			tables: []string{"customers", "customers_us", "customers_eu"},
+		},
+		{
+			name:   "join with subquery and union",
+			sql:    "SELECT * FROM departments dep JOIN (SELECT id, name FROM employees_us UNION SELECT id, name FROM employees_eu) employees ON dep.id = employees.id",
+			tables: []string{"departments", "employees_us", "employees_eu"},
+		},
+		{
+			name:   "insert with subquery and join",
+			sql:    "INSERT INTO some_table SELECT * FROM departments dep JOIN (SELECT id, name FROM employees_us UNION SELECT id, name FROM employees_eu) employees ON dep.id = employees.id",
+			tables: []string{"some_table", "departments", "employees_us", "employees_eu"},
+		},
+		// TODO(cristian): currently unsupported
+		// {
+		// 	name:   "show create table",
+		// 	sql:    "SHOW CREATE TABLE some_table",
+		// 	tables: []string{"some_table"},
+		// },
+		{
+			name:   "show variables",
+			sql:    "SHOW VARIABLES LIKE 'version'",
+			tables: nil,
+		},
+		{
+			name:   "drop table",
+			sql:    "DROP TABLE IF EXISTS some_table",
+			tables: []string{"some_table"},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			stmt, err := ParseSql(tc.sql)
+			require.NoError(t, err)
+
+			got := ExtractTableNames(log.NewNopLogger(), "", stmt)
+			require.Equal(t, tc.tables, got)
+		})
+	}
+}


### PR DESCRIPTION
#### PR Description
Move the sqlparser functions from query_sample to a new file. This should allow swapping the parser for a different implementation, if needed. We're still tied to types from the underlying library, but I think it's fine for now.

Tests are moved around while maintaining the same coverage percentage. Now the query_sample tests are more focussed on testing the collector logic rather than the parsing of sql queries.

#### Which issue(s) this PR fixes
n.a.

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
