### PR TITLE
GHA publish workflow: mount version file for updater step

### DIFF
--- a/.github/workflows/publish-alloy-devel.yml
+++ b/.github/workflows/publish-alloy-devel.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-    
+
 permissions:
   contents: read
   id-token: write
@@ -34,7 +34,7 @@ jobs:
       uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login-v1.0.1
 
     - run: |
-       docker run --rm --privileged multiarch/qemu-user-static --reset -p yes     
+       docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
        docker buildx create --name multiarch-alloy-alloy-devel-${GITHUB_SHA} --driver docker-container --use
        ./tools/ci/docker-containers alloy-devel
        docker buildx rm multiarch-alloy-alloy-devel-${GITHUB_SHA}
@@ -64,7 +64,7 @@ jobs:
       uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login-v1.0.1
 
     - run: |
-       docker run --rm --privileged multiarch/qemu-user-static --reset -p yes     
+       docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
        docker buildx create --name multiarch-alloy-alloy-devel-boringcrypto-${GITHUB_SHA} --driver docker-container --use
        ./tools/ci/docker-containers alloy-devel-boringcrypto
        docker buildx rm multiarch-alloy-alloy-devel-boringcrypto-${GITHUB_SHA}
@@ -124,4 +124,6 @@ jobs:
 
         docker run --rm \
           -e GITHUB_TOKEN="$GITHUB_TOKEN" \
-          -e CONFIG_JSON="$(cat config.json)" us-docker.pkg.dev/grafanalabs-global/docker-deployment-tools-prod/updater |& tee updater-output.log
+          -e CONFIG_JSON="$(cat config.json)" \
+          -v ./.image-tag:/app/.image-tag \
+          us-docker.pkg.dev/grafanalabs-global/docker-deployment-tools-prod/updater |& tee updater-output.log


### PR DESCRIPTION
#### PR Description
Attempt to fix the error of missing `.image-tag` file in the updater step of the publish workflow by mounting the file in the container of the updater step at the workdir path.


#### Which issue(s) this PR fixes
n.a.

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
