### PR TITLE
[otelcol.connector.servicegraph] Remove seconds from metric names

### DIFF
--- a/docs/sources/reference/components/otelcol/otelcol.connector.servicegraph.md
+++ b/docs/sources/reference/components/otelcol/otelcol.connector.servicegraph.md
@@ -86,15 +86,15 @@ The following metrics are emitted by the processor:
 |---------------------------------------------|-----------|---------------------------------|--------------------------------------------------------------|
 | traces_service_graph_request_total          | Counter   | client, server, connection_type | Total count of requests between two nodes                    |
 | traces_service_graph_request_failed_total   | Counter   | client, server, connection_type | Total count of failed requests between two nodes             |
-| traces_service_graph_request_server_seconds | Histogram | client, server, connection_type | Time for a request between two nodes as seen from the server |
-| traces_service_graph_request_client_seconds | Histogram | client, server, connection_type | Time for a request between two nodes as seen from the client |
+| traces_service_graph_request_server | Histogram | client, server, connection_type | Number of seconds for a request between two nodes as seen from the server |
+| traces_service_graph_request_client | Histogram | client, server, connection_type | Number of seconds for a request between two nodes as seen from the client |
 | traces_service_graph_unpaired_spans_total   | Counter   | client, server, connection_type | Total count of unpaired spans                                |
 | traces_service_graph_dropped_spans_total    | Counter   | client, server, connection_type | Total count of dropped spans                                 |
 
 Duration is measured both from the client and the server sides.
 
 The `latency_histogram_buckets` argument controls the buckets for
-`traces_service_graph_request_server_seconds` and `traces_service_graph_request_client_seconds`.
+`traces_service_graph_request_server` and `traces_service_graph_request_client`.
 
 Each emitted metrics series have a `client` and a `server` label corresponding with the service doing the request and the service receiving the request.
 The value of the label is derived from the `service.name` resource attribute of the two spans.


### PR DESCRIPTION
There was a [change upstream](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/34511) to remove the `_seconds` suffix.. OTel has a "unit" property which says the unit (seconds in this case).