### PR TITLE
[remotecfg] Add mut.Unlock() calls before returning errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ Main (unreleased)
 
 - Fixed a bug where components could be evaluated concurrently without the full context during a config reload (@wildum)
 
+- Fixed locks that wouldn't be released in the remotecfg service if some errors occurred during the configuration reload (@spartan0x117)
+
 ### Other changes
 
 - Upgrading to Prometheus v2.54.1. (@ptodev)

--- a/internal/service/remotecfg/remotecfg.go
+++ b/internal/service/remotecfg/remotecfg.go
@@ -303,6 +303,7 @@ func (s *Service) Update(newConfig any) error {
 	s.mut.Lock()
 	hash, err := newArgs.Hash()
 	if err != nil {
+		s.mut.Unlock()
 		return err
 	}
 	s.dataPath = filepath.Join(s.opts.StoragePath, ServiceName, hash)
@@ -311,6 +312,7 @@ func (s *Service) Update(newConfig any) error {
 	if !reflect.DeepEqual(s.args.HTTPClientConfig, newArgs.HTTPClientConfig) {
 		httpClient, err := commonconfig.NewClientFromConfig(*newArgs.HTTPClientConfig.Convert(), "remoteconfig")
 		if err != nil {
+			s.mut.Unlock()
 			return err
 		}
 		s.asClient = collectorv1connect.NewCollectorServiceClient(


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Releases the `remotecfg` mutex in a few places before returning the error so the lock doesn't remain held.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
