### PR TITLE
fix filelog test on Windows

### DIFF
--- a/internal/component/otelcol/receiver/filelog/filelog_test.go
+++ b/internal/component/otelcol/receiver/filelog/filelog_test.go
@@ -31,7 +31,7 @@ func Test(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := fmt.Sprintf(`
-		include = ["%s"]
+		include = [%q]
 
 		output {
 			// no-op: will be overridden by test code.


### PR DESCRIPTION
On Windows, the path would be something like
\"C:\\Users\\William\\AppData\\Local\\Temp\\Test2588855952\\001\\example1761374715\"

This was not correctly parsed by the [syntax ](https://github.com/grafana/alloy/blob/main/syntax/scanner/scanner.go#L502)

By using %q instead of %s will escape the escape chars again, resulting in:
\"C:\\\\Users\\\\William\\\\AppData\\\\Local\\\\Temp\\\\Test2588855952\\\\001\\\\example1761374715\"

This is what the parser actually does normally if you run:

otelcol.receiver.filelog "default" {
	include = ["C:\\Users\\William\\Desktop\\alloytest\\*.log"]
	  output {
      logs = [otelcol.exporter.debug.default.input]
  }
}

it will be scanned as: "C:\\\\Users\\\\William\\\\Desktop\\\\alloytest\\\\*.log

I also tested the component on Windows and I works well