### PR TITLE
docs: Fix uniqueness of top-level configuration blocks

### DIFF
--- a/docs/sources/reference/config-blocks/_index.md
+++ b/docs/sources/reference/config-blocks/_index.md
@@ -8,7 +8,7 @@ weight: 200
 # Configuration blocks
 
 Configuration blocks are optional top-level blocks that can be used to configure various parts of the {{< param "PRODUCT_NAME" >}} process.
-Each configuration block can only be defined once.
+Unlabeled configuration blocks can only be defined once.
 
 Configuration blocks are _not_ components, so they have no exports.
 


### PR DESCRIPTION
#### PR Description

Changes the wording on the uniqueness requirement of top-level configuration blocks to be specifically about _unlabeled_ blocks.

#### Which issue(s) this PR fixes

Labeled top-level configuration blocks like `declare` can be specified multiple times, so the current wording is misleading.

#### Notes to the Reviewer

#### PR Checklist

- [x] Documentation updated
