### PR TITLE
remotecfg: fix logic around skipping loaded configuration

### DIFF
--- a/internal/service/remotecfg/remotecfg.go
+++ b/internal/service/remotecfg/remotecfg.go
@@ -296,7 +296,7 @@ func (s *Service) Update(newConfig any) error {
 		s.args.HTTPClientConfig = config.CloneDefaultHTTPClientConfig()
 		s.mut.Unlock()
 
-		s.setCfgHash("")
+		s.setLastLoadedCfgHash("")
 		return nil
 	}
 
@@ -397,7 +397,7 @@ func (s *Service) fetchRemote() error {
 
 	// API returned the same configuration as the last one we loaded, no need to reload.
 	newConfigHash := getHash(b)
-	if s.getCfgHash() == newConfigHash {
+	if s.getLastLoadedCfgHash() == newConfigHash {
 		level.Debug(s.opts.Logger).Log("msg", "skipping over API response since it matched the last loaded one")
 		return nil
 	}
@@ -479,7 +479,7 @@ func (s *Service) parseAndLoad(b []byte) error {
 	if len(b) == 0 {
 		return nil
 	}
-	s.setCfgHash(getHash(b))
+	s.setLastLoadedCfgHash(getHash(b))
 	file, err := ctrl.LoadSource(b, nil, s.opts.ConfigPath)
 	if err != nil {
 		return err
@@ -489,7 +489,7 @@ func (s *Service) parseAndLoad(b []byte) error {
 	return nil
 }
 
-func (s *Service) getCfgHash() string {
+func (s *Service) getLastLoadedCfgHash() string {
 	s.mut.RLock()
 	defer s.mut.RUnlock()
 
@@ -502,7 +502,7 @@ func (s *Service) setAstFile(f *ast.File) {
 	s.astFile = f
 }
 
-func (s *Service) setCfgHash(h string) {
+func (s *Service) setLastLoadedCfgHash(h string) {
 	s.mut.Lock()
 	defer s.mut.Unlock()
 	if s.metrics != nil {

--- a/internal/service/remotecfg/remotecfg_test.go
+++ b/internal/service/remotecfg/remotecfg_test.go
@@ -34,7 +34,6 @@ func TestOnDiskCache(t *testing.T) {
 
 	// The contents of the on-disk cache.
 	cacheContents := `loki.process "default" { forward_to = [] }`
-	cacheHash := getHash([]byte(cacheContents))
 
 	// Create a new service.
 	env := newTestEnvironment(t)
@@ -62,8 +61,78 @@ func TestOnDiskCache(t *testing.T) {
 	// As the API response was unparseable, verify that the service has loaded
 	// the on-disk cache contents.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, cacheHash, env.svc.getCfgHash())
+		b, err := env.svc.getCachedConfig()
+		assert.NoError(c, err)
+		assert.Equal(c, cacheContents, string(b))
 	}, time.Second, 10*time.Millisecond)
+}
+
+func TestGoodBadGood(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	url := "https://example.com/"
+	cfgGood := `loki.process "default" { forward_to = [] }`
+	cfgBad := `unparseable config`
+
+	// Create a new service.
+	env := newTestEnvironment(t)
+	require.NoError(t, env.ApplyConfig(fmt.Sprintf(`
+		url            = "%s"
+		poll_frequency = "10s"
+	`, url)))
+
+	client := &collectorClient{}
+	env.svc.asClient = client
+
+	// Mock client to return a valid response.
+	var registerCalled atomic.Bool
+	client.mut.Lock()
+	client.getConfigFunc = buildGetConfigHandler(cfgGood, "", false)
+	client.registerCollectorFunc = buildRegisterCollectorFunc(&registerCalled)
+	client.mut.Unlock()
+
+	// Run the service.
+	go func() {
+		require.NoError(t, env.Run(ctx))
+	}()
+
+	require.Eventually(t, func() bool { return registerCalled.Load() }, 1*time.Second, 10*time.Millisecond)
+
+	// As the API response was successful, verify that the service has loaded
+	// the valid response.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, getHash([]byte(cfgGood)), env.svc.getCfgHash())
+	}, time.Second, 10*time.Millisecond)
+
+	// Update the response returned by the API to an invalid configuration.
+	client.mut.Lock()
+	client.getConfigFunc = buildGetConfigHandler(cfgBad, "", false)
+	client.mut.Unlock()
+
+	// Verify that the service has still the same "good" configuration has
+	// loaded and flushed on disk, but also recorded the "bad" hash saved for
+	// comparison.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		b, err := env.svc.getCachedConfig()
+		assert.NoError(c, err)
+		assert.Equal(c, cfgGood, string(b))
+	}, 1*time.Second, 10*time.Millisecond)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, getHash([]byte(cfgBad)), env.svc.getCfgHash())
+	}, 1*time.Second, 10*time.Millisecond)
+
+	// Update the response returned by the API to the previous "good"
+	// configuration.
+	client.mut.Lock()
+	client.getConfigFunc = buildGetConfigHandler(cfgGood, "", false)
+	client.mut.Unlock()
+
+	// Verify that the service has updated the hash.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, getHash([]byte(cfgGood)), env.svc.getCfgHash())
+	}, 1*time.Second, 10*time.Millisecond)
+
+	cancel()
 }
 
 func TestAPIResponse(t *testing.T) {

--- a/internal/service/remotecfg/remotecfg_test.go
+++ b/internal/service/remotecfg/remotecfg_test.go
@@ -100,7 +100,7 @@ func TestGoodBadGood(t *testing.T) {
 	// As the API response was successful, verify that the service has loaded
 	// the valid response.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, getHash([]byte(cfgGood)), env.svc.getCfgHash())
+		assert.Equal(c, getHash([]byte(cfgGood)), env.svc.getLastLoadedCfgHash())
 	}, time.Second, 10*time.Millisecond)
 
 	// Update the response returned by the API to an invalid configuration.
@@ -118,7 +118,7 @@ func TestGoodBadGood(t *testing.T) {
 	}, 1*time.Second, 10*time.Millisecond)
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, getHash([]byte(cfgBad)), env.svc.getCfgHash())
+		assert.Equal(c, getHash([]byte(cfgBad)), env.svc.getLastLoadedCfgHash())
 	}, 1*time.Second, 10*time.Millisecond)
 
 	// Update the response returned by the API to the previous "good"
@@ -129,7 +129,7 @@ func TestGoodBadGood(t *testing.T) {
 
 	// Verify that the service has updated the hash.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, getHash([]byte(cfgGood)), env.svc.getCfgHash())
+		assert.Equal(c, getHash([]byte(cfgGood)), env.svc.getLastLoadedCfgHash())
 	}, 1*time.Second, 10*time.Millisecond)
 
 	cancel()
@@ -168,7 +168,7 @@ func TestAPIResponse(t *testing.T) {
 	// As the API response was successful, verify that the service has loaded
 	// the valid response.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, getHash([]byte(cfg1)), env.svc.getCfgHash())
+		assert.Equal(c, getHash([]byte(cfg1)), env.svc.getLastLoadedCfgHash())
 	}, time.Second, 10*time.Millisecond)
 
 	// Update the response returned by the API.
@@ -178,7 +178,7 @@ func TestAPIResponse(t *testing.T) {
 
 	// Verify that the service has loaded the updated response.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, getHash([]byte(cfg2)), env.svc.getCfgHash())
+		assert.Equal(c, getHash([]byte(cfg2)), env.svc.getLastLoadedCfgHash())
 	}, 1*time.Second, 10*time.Millisecond)
 
 	cancel()
@@ -216,7 +216,7 @@ func TestAPIResponseNotModified(t *testing.T) {
 	// As the API response was successful, verify that the service has loaded
 	// the valid response.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, getHash([]byte(cfg1)), env.svc.getCfgHash())
+		assert.Equal(c, getHash([]byte(cfg1)), env.svc.getLastLoadedCfgHash())
 	}, time.Second, 10*time.Millisecond)
 
 	// Update the response returned by the API.
@@ -226,7 +226,7 @@ func TestAPIResponseNotModified(t *testing.T) {
 
 	// Verify that the service has loaded the updated response.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, getHash([]byte(cfg1)), env.svc.getCfgHash())
+		assert.Equal(c, getHash([]byte(cfg1)), env.svc.getLastLoadedCfgHash())
 	}, 1*time.Second, 10*time.Millisecond)
 
 	cancel()


### PR DESCRIPTION
#### PR Description

This PR:

1) Renames `currentConfigHash` to `lastLoadedConfigHash`.
2) Makes sure we _always_ set its value in `parseAndLoad`, before we attempt to pass it the configuration to the controller, and nowhere else
3) Skip over applying configurations that are the same as the previously applied ones.
4) Adds a test
5) Renames get/set helpers to mirror the new name

The other thing to do would be to remove this logic entirely and only depend on the server's response as to whether we should skip applying configurations or not.

Given this is likely a breaking change, this is our chance to choose what to do here before removing the `private-preview` label from the next release. Thoughts?

#### Which issue(s) this PR fixes

No issue filed.

#### Notes to the Reviewer


#### PR Checklist

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
