### PR TITLE
database_observability: fix excess logging in select expressions

### DIFF
--- a/internal/component/database_observability/mysql/collector/sqlparser.go
+++ b/internal/component/database_observability/mysql/collector/sqlparser.go
@@ -51,7 +51,7 @@ func ExtractTableNames(logger log.Logger, digest string, stmt sqlparser.Statemen
 				case *sqlparser.Subquery:
 					parsedTables = append(parsedTables, ExtractTableNames(logger, digest, exp.Select)...)
 				default:
-					level.Error(logger).Log("msg", "unknown aliased select type", "digest", digest)
+					// ignore anything else
 				}
 			}
 		}


### PR DESCRIPTION
#### PR Description
Ignore anything that is not a subquery. We might change this behaviour in the future, but for now, we are only interested in subqueries.


#### Which issue(s) this PR fixes
n.a.

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
