### PR TITLE
fix breaking change in prom metrics validation scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Bugfixes
+
+- Fix an issue where Prometheus metric name validation scheme was set by default to UTF-8. It is now set back to the
+  previous "legacy" scheme. An experimental flag `--feature.prometheus.metric-validation-scheme` can be used to switch 
+  it to `utf-8` to experiment with UTF-8 support.
 
 v1.7.0-rc.1
 -----------------

--- a/docs/sources/reference/cli/run.md
+++ b/docs/sources/reference/cli/run.md
@@ -60,7 +60,7 @@ The following flags are supported:
 * `--config.extra-args`: Extra arguments from the original format used by the converter.
 * `--stability.level`: The minimum permitted stability level of functionality to run. Supported values: `experimental`, `public-preview`, `generally-available` (default `"generally-available"`).
 * `--feature.community-components.enabled`: Enable community components (default `false`).
-* `--feature.prometheus.metric-validation-scheme`: Prometheus metric validation scheme to use. Supported values: `legacy`, `utf-8`. NOTE: this is an experimental flag and may be removed in future releases. (default `"legacy"`)
+* `--feature.prometheus.metric-validation-scheme`: Prometheus metric validation scheme to use. Supported values: `legacy`, `utf-8`. NOTE: this is an experimental flag and may be removed in future releases (default `"legacy"`).
 
 ## Update the configuration file
 

--- a/docs/sources/reference/cli/run.md
+++ b/docs/sources/reference/cli/run.md
@@ -60,6 +60,7 @@ The following flags are supported:
 * `--config.extra-args`: Extra arguments from the original format used by the converter.
 * `--stability.level`: The minimum permitted stability level of functionality to run. Supported values: `experimental`, `public-preview`, `generally-available` (default `"generally-available"`).
 * `--feature.community-components.enabled`: Enable community components (default `false`).
+* `--feature.prometheus.metric-validation-scheme`: Prometheus metric validation scheme to use. Supported values: `legacy`, `utf-8`. NOTE: this is an experimental flag and may be removed in future releases. (default `"legacy"`)
 
 ## Update the configuration file
 

--- a/internal/alloycli/cmd_run.go
+++ b/internal/alloycli/cmd_run.go
@@ -222,7 +222,7 @@ func (fr *alloyRun) Run(cmd *cobra.Command, configPath string) error {
 		return fmt.Errorf("building tracer: %w", err)
 	}
 
-	if err := fr.configurePrometheusMetricNameValidationScheme(); err != nil {
+	if err := fr.configurePrometheusMetricNameValidationScheme(l); err != nil {
 		return err
 	}
 
@@ -450,7 +450,7 @@ func (fr *alloyRun) Run(cmd *cobra.Command, configPath string) error {
 	}
 }
 
-func (fr *alloyRun) configurePrometheusMetricNameValidationScheme() error {
+func (fr *alloyRun) configurePrometheusMetricNameValidationScheme(l log.Logger) error {
 	switch fr.prometheusMetricNameValidationScheme {
 	case prometheusLegacyMetricValidationScheme:
 		model.NameValidationScheme = model.LegacyValidation
@@ -462,7 +462,10 @@ func (fr *alloyRun) configurePrometheusMetricNameValidationScheme() error {
 		); err != nil {
 			return err
 		}
+		level.Warn(l).Log("msg", "Using experimental UTF-8 Prometheus metric name validation scheme")
 		model.NameValidationScheme = model.UTF8Validation
+	default:
+		return fmt.Errorf("invalid prometheus metric name validation scheme: %q", fr.prometheusMetricNameValidationScheme)
 	}
 	return nil
 }

--- a/internal/alloycli/cmd_run_test.go
+++ b/internal/alloycli/cmd_run_test.go
@@ -1,0 +1,72 @@
+package alloycli
+
+import (
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/internal/featuregate"
+)
+
+func TestConfigurePrometheusMetricNameValidationScheme(t *testing.T) {
+	tests := []struct {
+		name           string
+		run            alloyRun
+		expectedError  string
+		expectedScheme model.ValidationScheme
+	}{
+		{
+			name: "legacy validation scheme",
+			run: alloyRun{
+				prometheusMetricNameValidationScheme: prometheusLegacyMetricValidationScheme,
+				minStability:                         featuregate.StabilityGenerallyAvailable,
+			},
+			expectedScheme: model.LegacyValidation,
+		},
+		{
+			name: "utf8 validation scheme with experimental stability",
+			run: alloyRun{
+				prometheusMetricNameValidationScheme: prometheusUTF8MetricValidationScheme,
+				minStability:                         featuregate.StabilityExperimental,
+			},
+			expectedScheme: model.UTF8Validation,
+		},
+		{
+			name: "utf8 validation scheme with GA stability should fail",
+			run: alloyRun{
+				prometheusMetricNameValidationScheme: prometheusUTF8MetricValidationScheme,
+				minStability:                         featuregate.StabilityGenerallyAvailable,
+			},
+			expectedError: `Prometheus utf-8 metric name validation scheme is at stability level "experimental", which is below the minimum allowed stability level "generally-available"`,
+		},
+		{
+			name: "invalid validation scheme",
+			run: alloyRun{
+				prometheusMetricNameValidationScheme: "invalid",
+				minStability:                         featuregate.StabilityGenerallyAvailable,
+			},
+			expectedError: `invalid prometheus metric name validation scheme: "invalid"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reset the global validation scheme before each test
+			defer func() {
+				model.NameValidationScheme = model.LegacyValidation
+			}()
+
+			err := tc.run.configurePrometheusMetricNameValidationScheme(log.NewNopLogger())
+
+			if tc.expectedError != "" {
+				require.ErrorContains(t, err, tc.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedScheme, model.NameValidationScheme)
+		})
+	}
+}


### PR DESCRIPTION
The recent upgrade of prommetheus/common brought in this PR: https://github.com/prometheus/common/pull/724 which is a breaking change for Alloy. 

In this PR I restore the old behaviour manually in Alloy's run command and expose the option to enable the new utf-8 behaviour optionally. This is done via CLI flag in first iteration, but may change in the future, so the flag is marked as experimental right away.