### PR TITLE
Update the otelcol.receiver.vcenter doc

### DIFF
--- a/docs/sources/reference/components/otelcol/otelcol.receiver.vcenter.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.vcenter.md
@@ -98,7 +98,7 @@ isn't provided, TLS won't be used for connections to the server.
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `vcenter.cluster.cpu.effective` | [metric][] | Enables the `vcenter.cluster.cpu.effective` metric. | `true` | no
-`vcenter.cluster.cpu.usage` | [metric][] | Enables the `vcenter.cluster.cpu.usage` metric. | `true` | no
+`vcenter.cluster.cpu.limit` | [metric][] | Enables the `vcenter.cluster.cpu.limit` metric. | `true` | no
 `vcenter.cluster.host.count` | [metric][] | Enables the `vcenter.cluster.host.count` metric. | `true` | no
 `vcenter.cluster.memory.effective` | [metric][] | Enables the `vcenter.cluster.memory.effective` metric. | `true` | no
 `vcenter.cluster.memory.limit` | [metric][] | Enables the `vcenter.cluster.memory.limit` metric. | `true` | no


### PR DESCRIPTION
#### PR Description

Community feedback:

The second entry in https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.receiver.vcenter/#metrics-block for `vcenter.cluster.cpu.usage` should be `vcenter.cluster.cpu.limit` instead as seen in https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.116.0/receiver/vcenterreceiver/documentation.md#vcenterclustercpulimit. 

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
