### PR TITLE
log entry_timestamp and structured_metadata with `loki.echo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Enhancements
+- Have `loki.echo` log the `entry_timestamp` and `structured_metadata` for any loki entries received (@dehaansa)
+
 v1.7.0-rc.2
 -----------------
 

--- a/internal/component/loki/echo/echo.go
+++ b/internal/component/loki/echo/echo.go
@@ -79,7 +79,12 @@ func (c *Component) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			return nil
 		case entry := <-c.receiver.Chan():
-			level.Info(c.opts.Logger).Log("receiver", c.opts.ID, "entry", entry.Line, "labels", entry.Labels.String())
+			structured_metadata, err := entry.StructuredMetadata.MarshalJSON()
+			if err != nil {
+				level.Error(c.opts.Logger).Log("receiver", c.opts.ID, "error", err)
+				structured_metadata = []byte("{}")
+			}
+			level.Info(c.opts.Logger).Log("receiver", c.opts.ID, "entry", entry.Line, "entry_timestamp", entry.Timestamp, "labels", entry.Labels.String(), "structured_metadata", string(structured_metadata))
 		}
 	}
 }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Some users were misled by the `ts` field of the `loki.echo` logs, believing that that field represented the entry's timestamp, not just the timestamp when the internal logger wrote the loki entries to the Alloy log. I believe it would be a clear improvement to add the `entry_timestamp`, and since I was updating this I added `structured_metadata` as well for better ability to debug `structured_metadata` changes.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
