### PR TITLE
Apply linting rules to Alloy OtelCol component docs

### DIFF
--- a/docs/sources/reference/components/otelcol/_index.md
+++ b/docs/sources/reference/components/otelcol/_index.md
@@ -5,7 +5,7 @@ title: otelcol
 weight: 100
 ---
 
-# otelcol
+# `otelcol`
 
 This section contains reference documentation for the `otelcol` components.
 

--- a/docs/sources/reference/components/otelcol/otelcol.auth.basic.md
+++ b/docs/sources/reference/components/otelcol/otelcol.auth.basic.md
@@ -3,53 +3,53 @@ canonical: https://grafana.com/docs/alloy/latest/reference/components/otelcol/ot
 aliases:
   - ../otelcol.auth.basic/ # /docs/alloy/latest/reference/components/otelcol.auth.basic/
 description: Learn about otelcol.auth.basic
+labels:
+  stage: general-availability
 title: otelcol.auth.basic
 ---
 
-# otelcol.auth.basic
+# `otelcol.auth.basic`
 
-`otelcol.auth.basic` exposes a `handler` that can be used by other `otelcol`
-components to authenticate requests using basic authentication.
+`otelcol.auth.basic` exposes a `handler` that can be used by other `otelcol` components to authenticate requests using basic authentication.
 
 This component supports both server and client authentication.
 
-> **NOTE**: `otelcol.auth.basic` is a wrapper over the upstream OpenTelemetry
-> Collector `basicauth` extension. Bug reports or feature requests will be
-> redirected to the upstream repository, if necessary.
+{{< admonition type="note" >}}
+`otelcol.auth.basic` is a wrapper over the upstream OpenTelemetry Collector `basicauth` extension.
+Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+{{< /admonition >}}
 
-Multiple `otelcol.auth.basic` components can be specified by giving them
-different labels.
+You can specify multiple `otelcol.auth.basic` components by giving them different labels.
 
 ## Usage
 
 ```alloy
-otelcol.auth.basic "LABEL" {
-  username = "USERNAME"
-  password = "PASSWORD"
+otelcol.auth.basic "<LABEL>" {
+  username = "<USERNAME>"
+  password = "<PASSWORD>"
 }
 ```
 
 ## Arguments
 
-`otelcol.auth.basic` supports the following arguments:
+You can use the following arguments wiht `otelcol.auth.basic`:
 
-Name       | Type     | Description                                        | Default | Required
------------|----------|----------------------------------------------------|---------|---------
-`username` | `string` | Username to use for basic authentication requests. |         | yes
-`password` | `secret` | Password to use for basic authentication requests. |         | yes
+| Name       | Type     | Description                                        | Default | Required |
+| ---------- | -------- | -------------------------------------------------- | ------- | -------- |
+| `password` | `secret` | Password to use for basic authentication requests. |         | yes      |
+| `username` | `string` | Username to use for basic authentication requests. |         | yes      |
 
 ## Blocks
 
-The following blocks are supported inside the definition of
-`otelcol.auth.basic`:
+You can use the following blocks with `otelcol.auth.basic`:
 
-Hierarchy | Block      | Description                          | Required
-----------|------------|--------------------------------------|---------
-debug_metrics  | [debug_metrics][] | Configures the metrics that this component generates to monitor its state. | no
+| Block                            | Description                                                                | Required |
+| -------------------------------- | -------------------------------------------------------------------------- | -------- |
+| [`debug_metrics`][debug_metrics] | Configures the metrics that this component generates to monitor its state. | no       |
 
-[debug_metrics]: #debug_metrics-block
+[debug_metrics]: #debug_metrics
 
-### debug_metrics block
+### `debug_metrics`
 
 {{< docs/shared lookup="reference/components/otelcol-debug-metrics-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
@@ -57,22 +57,21 @@ debug_metrics  | [debug_metrics][] | Configures the metrics that this component 
 
 The following fields are exported and can be referenced by other components:
 
-Name      | Type                       | Description
-----------|----------------------------|----------------------------------------------------------------
-`handler` | `capsule(otelcol.Handler)` | A value that other components can use to authenticate requests.
+| Name      | Type                       | Description                                                     |
+| --------- | -------------------------- | --------------------------------------------------------------- |
+| `handler` | `capsule(otelcol.Handler)` | A value that other components can use to authenticate requests. |
 
 ## Component health
 
-`otelcol.auth.basic` is only reported as unhealthy if given an invalid
-configuration.
+`otelcol.auth.basic` is only reported as unhealthy if given an invalid configuration.
 
 ## Debug information
 
-`otelcol.auth.basic` does not expose any component-specific debug information.
+`otelcol.auth.basic` doesn't expose any component-specific debug information.
 
 ## Example
 
-This example configures [otelcol.exporter.otlp][] to use basic authentication:
+The following example configures [otelcol.exporter.otlp][] to use basic authentication:
 
 ```alloy
 otelcol.exporter.otlp "example" {
@@ -84,7 +83,7 @@ otelcol.exporter.otlp "example" {
 
 otelcol.auth.basic "creds" {
   username = "demo"
-  password = sys.env("API_KEY")
+  password = sys.env("<API_KEY>")
 }
 ```
 

--- a/docs/sources/reference/components/otelcol/otelcol.auth.bearer.md
+++ b/docs/sources/reference/components/otelcol/otelcol.auth.bearer.md
@@ -3,13 +3,14 @@ canonical: https://grafana.com/docs/alloy/latest/reference/components/otelcol/ot
 aliases:
   - ../otelcol.auth.bearer/ # /docs/alloy/latest/reference/components/otelcol.auth.bearer/
 description: Learn about otelcol.auth.bearer
+labels:
+  stage: general-availability
 title: otelcol.auth.bearer
 ---
 
-# otelcol.auth.bearer
+# `otelcol.auth.bearer`
 
-`otelcol.auth.bearer` exposes a `handler` that can be used by other `otelcol`
-components to authenticate requests using bearer token authentication.
+`otelcol.auth.bearer` exposes a `handler` that can be used by other `otelcol` components to authenticate requests using bearer token authentication.
 
 This component supports both server and client authentication.
 
@@ -18,44 +19,43 @@ This component supports both server and client authentication.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
 {{< /admonition >}}
 
-Multiple `otelcol.auth.bearer` components can be specified by giving them different labels.
+You can specify multiple `otelcol.auth.bearer` components by giving them different labels.
 
 ## Usage
 
 ```alloy
-otelcol.auth.bearer "LABEL" {
-  token = "TOKEN"
+otelcol.auth.bearer "<LABEL>" {
+  token = "<TOKEN>"
 }
 ```
 
 ## Arguments
 
-`otelcol.auth.bearer` supports the following arguments:
+You can use the following arguments with `otelcol.auth.bearer`:
 
-Name     | Type     | Description                                      | Default  | Required
----------|----------|--------------------------------------------------|----------|---------
-`token`  | `secret` | Bearer token to use for authenticating requests. |          | yes
-`scheme` | `string` | Authentication scheme name.                      | "Bearer" | no
+| Name     | Type     | Description                                      | Default  | Required |
+| -------- | -------- | ------------------------------------------------ | -------- | -------- |
+| `token`  | `secret` | Bearer token to use for authenticating requests. |          | yes      |
+| `scheme` | `string` | Authentication scheme name.                      | "Bearer" | no       |
 
 When sending the token, the value of `scheme` is prepended to the `token` value.
-The string is then sent out as either a header (in case of HTTP) or as metadata (in case of gRPC).
+The string is then sent out as either a header (for HTTP) or as metadata (for gRPC).
 
-If you use a file to store the token, you can use `[local.file`][local.file] to retrieve the `token` value from the file.
+If you use a file to store the token, you can use [`local.file`][local.file] to retrieve the `token` value from the file.
 
 [local.file]: ../../local/local.file/
 
 ## Blocks
 
-The following blocks are supported inside the definition of
-`otelcol.auth.bearer`:
+You can use the following block with `otelcol.auth.bearer`:
 
-Hierarchy | Block      | Description                          | Required
-----------|------------|--------------------------------------|---------
-debug_metrics | [debug_metrics][] | Configures the metrics that this component generates to monitor its state. | no
+| Block                            | Description                                                                | Required |
+| -------------------------------- | -------------------------------------------------------------------------- | -------- |
+| [`debug_metrics`][debug_metrics] | Configures the metrics that this component generates to monitor its state. | no       |
 
-[debug_metrics]: #debug_metrics-block
+[debug_metrics]: #debug_metrics
 
-### debug_metrics block
+### `debug_metrics`
 
 {{< docs/shared lookup="reference/components/otelcol-debug-metrics-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
@@ -63,26 +63,25 @@ debug_metrics | [debug_metrics][] | Configures the metrics that this component g
 
 The following fields are exported and can be referenced by other components:
 
-Name      | Type                       | Description
-----------|----------------------------|----------------------------------------------------------------
-`handler` | `capsule(otelcol.Handler)` | A value that other components can use to authenticate requests.
+| Name      | Type                       | Description                                                     |
+| --------- | -------------------------- | --------------------------------------------------------------- |
+| `handler` | `capsule(otelcol.Handler)` | A value that other components can use to authenticate requests. |
 
 ## Component health
 
-`otelcol.auth.bearer` is only reported as unhealthy if given an invalid
-configuration.
+`otelcol.auth.bearer` is only reported as unhealthy if given an invalid configuration.
 
 ## Debug information
 
-`otelcol.auth.bearer` does not expose any component-specific debug information.
+`otelcol.auth.bearer` doesn't expose any component-specific debug information.
 
 ## Examples
 
 ### Default scheme via gRPC transport
 
-The example below configures [otelcol.exporter.otlp][] to use a bearer token authentication.
+The following example configures [otelcol.exporter.otlp][] to use a bearer token authentication.
 
-If we assume that the value of the `API_KEY` environment variable is `SECRET_API_KEY`, then the `Authorization` RPC metadata is set to `Bearer SECRET_API_KEY`.
+If you assume that the value of the `API_KEY` environment variable is `SECRET_API_KEY`, then the `Authorization` RPC metadata is set to `Bearer SECRET_API_KEY`.
 
 ```alloy
 otelcol.exporter.otlp "example" {
@@ -93,7 +92,7 @@ otelcol.exporter.otlp "example" {
 }
 
 otelcol.auth.bearer "creds" {
-  token = sys.env("API_KEY")
+  token = sys.env("<API_KEY>")
 }
 ```
 
@@ -101,8 +100,7 @@ otelcol.auth.bearer "creds" {
 
 The example below configures [otelcol.exporter.otlphttp][] to use a bearer token authentication.
 
-If we assume that the value of the `API_KEY` environment variable is `SECRET_API_KEY`, then
-the `Authorization` HTTP header is set to `MyScheme SECRET_API_KEY`.
+If you assume that the value of the `API_KEY` environment variable is `SECRET_API_KEY`, then the `Authorization` HTTP header is set to `MyScheme SECRET_API_KEY`.
 
 ```alloy
 otelcol.exporter.otlphttp "example" {
@@ -113,7 +111,7 @@ otelcol.exporter.otlphttp "example" {
 }
 
 otelcol.auth.bearer "creds" {
-  token = sys.env("API_KEY")
+  token = sys.env("<API_KEY>")
   scheme = "MyScheme"
 }
 ```

--- a/docs/sources/reference/components/otelcol/otelcol.auth.headers.md
+++ b/docs/sources/reference/components/otelcol/otelcol.auth.headers.md
@@ -3,105 +3,104 @@ canonical: https://grafana.com/docs/alloy/latest/reference/components/otelcol/ot
 aliases:
   - ../otelcol.auth.headers/ # /docs/alloy/latest/reference/components/otelcol.auth.headers/
 description: Learn about otelcol.auth.headers
+labels:
+  stage: general-availability
 title: otelcol.auth.headers
 ---
 
-# otelcol.auth.headers
+# `otelcol.auth.headers`
 
-`otelcol.auth.headers` exposes a `handler` that can be used by other `otelcol`
-components to authenticate requests using custom headers.
+`otelcol.auth.headers` exposes a `handler` that can be used by other `otelcol` components to authenticate requests using custom headers.
 
-This component only supports client authentication. 
+This component only supports client authentication.
 
 {{< admonition type="note" >}}
 `otelcol.auth.headers` is a wrapper over the upstream OpenTelemetry Collector `headerssetter` extension.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
 {{< /admonition >}}
 
-Multiple `otelcol.auth.headers` components can be specified by giving them different labels.
+You can specify multiple `otelcol.auth.headers` components by giving them different labels.
 
 ## Usage
 
 ```alloy
-otelcol.auth.headers "LABEL" {
+otelcol.auth.headers "<LABEL>" {
   header {
-    key   = "HEADER_NAME"
-    value = "HEADER_VALUE"
+    key   = "<HEADER_NAME>"
+    value = "<HEADER_VALUE>"
   }
 }
 ```
 
 ## Arguments
 
-`otelcol.auth.headers` doesn't support any arguments and is configured fully
-through inner blocks.
+The `otelcol.auth.headers` doesn't support any arguments. You can configure this component with blocks.
 
 ## Blocks
 
-The following blocks are supported inside the definition of
-`otelcol.auth.headers`:
+You can use the following blocks with `otelcol.auth.headers`:
 
-Hierarchy | Block      | Description                          | Required
-----------|------------|--------------------------------------|---------
-header    | [header][] | Custom header to attach to requests. | no
-debug_metrics | [debug_metrics][] | Configures the metrics that this component generates to monitor its state. | no
+| Block                            | Description                                                                | Required |
+| -------------------------------- | -------------------------------------------------------------------------- | -------- |
+| [`debug_metrics`][debug_metrics] | Configures the metrics that this component generates to monitor its state. | no       |
+| [`header`][header]               | Custom header to attach to requests.                                       | no       |
 
-[header]: #header-block
-[debug_metrics]: #debug_metrics-block
+[header]: #header
+[debug_metrics]: #debug_metrics
 
-### header block
+### `debug_metrics`
 
-The `header` block defines a custom header to attach to requests. It is valid
-to provide multiple `header` blocks to set more than one header.
+{{< docs/shared lookup="reference/components/otelcol-debug-metrics-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
-Name           | Type                 | Description                             | Default  | Required
----------------|----------------------|-----------------------------------------|----------|---------
-`key`          | `string`             | Name of the header to set.              |          | yes
-`value`        | `string` or `secret` | Value of the header.                    |          | no
-`from_context` | `string`             | Metadata name to get header value from. |          | no
-`action`       | `string`             | An action to perform on the header      | "upsert" | no
+### `header`
+
+The `header` block defines a custom header to attach to requests.
+You can provide multiple `header` blocks to set more than one header.
+
+| Name           | Type                 | Description                             | Default    | Required |
+| -------------- | -------------------- | --------------------------------------- | ---------- | -------- |
+| `key`          | `string`             | Name of the header to set.              |            | yes      |
+| `action`       | `string`             | An action to perform on the header      | `"upsert"` | no       |
+| `from_context` | `string`             | Metadata name to get header value from. |            | no       |
+| `value`        | `string` or `secret` | Value of the header.                    |            | no       |
 
 The supported values for `action` are:
-* `insert`: Inserts the new header if it does not exist.
-* `update`: Updates the header value if it exists.
-* `upsert`: Inserts a header if it does not exist and updates the header if it exists.
-* `delete`: Deletes the header.
 
-Exactly one of `value` or `from_context` must be provided for each `header`
-block.
+* `delete`: Deletes the header.
+* `insert`: Inserts the new header if it doesn't exist.
+* `update`: Updates the header value if it exists.
+* `upsert`: Inserts a header if it doesn't exist and updates the header if it exists.
+
+Exactly one of `value` or `from_context` must be provided for each `header` block.
 
 The `value` attribute sets the value of the header directly.
 Alternatively, `from_context` can be used to dynamically retrieve the header value from request metadata.
 
 For `from_context` to work, other components in the pipeline also need to be configured appropriately:
-* If an `otelcol.processor.batch` is present in the pipeline, it must be configured to preserve client metadata. 
+
+* If an `otelcol.processor.batch` is present in the pipeline, it must be configured to preserve client metadata.
   Do this by adding the value that `from_context` needs to the `metadata_keys` of the batch processor.
 * `otelcol` receivers must be configured with `include_metadata` set to `true` so that metadata keys are available to the pipeline.
-
-### debug_metrics block
-
-{{< docs/shared lookup="reference/components/otelcol-debug-metrics-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ## Exported fields
 
 The following fields are exported and can be referenced by other components:
 
-Name | Type | Description
----- | ---- | -----------
-`handler` | `capsule(otelcol.Handler)` | A value that other components can use to authenticate requests.
+| Name      | Type                       | Description                                                     |
+| --------- | -------------------------- | --------------------------------------------------------------- |
+| `handler` | `capsule(otelcol.Handler)` | A value that other components can use to authenticate requests. |
 
 ## Component health
 
-`otelcol.auth.headers` is only reported as unhealthy if given an invalid
-configuration.
+`otelcol.auth.headers` is only reported as unhealthy if given an invalid configuration.
 
 ## Debug information
 
-`otelcol.auth.headers` does not expose any component-specific debug information.
+`otelcol.auth.headers` doesn't expose any component-specific debug information.
 
 ## Example
 
-This example configures [otelcol.exporter.otlp][] to use custom headers:
+The following example configures [otelcol.exporter.otlp][] to use custom headers:
 
 ```alloy
 otelcol.receiver.otlp "default" {
@@ -144,7 +143,7 @@ otelcol.auth.headers "creds" {
 
 otelcol.exporter.otlp "production" {
   client {
-    endpoint = sys.env("OTLP_SERVER_ENDPOINT")
+    endpoint = sys.env("<OTLP_SERVER_ENDPOINT>")
     auth     = otelcol.auth.headers.creds.handler
   }
 }

--- a/docs/sources/reference/components/otelcol/otelcol.auth.oauth2.md
+++ b/docs/sources/reference/components/otelcol/otelcol.auth.oauth2.md
@@ -3,19 +3,20 @@ canonical: https://grafana.com/docs/alloy/latest/reference/components/otelcol/ot
 aliases:
   - ../otelcol.auth.oauth2/ # /docs/alloy/latest/reference/components/otelcol.auth.oauth2/
 description: Learn about otelcol.auth.oauth2
+labels:
+  stage: general-availability
 title: otelcol.auth.oauth2
 ---
 
-# otelcol.auth.oauth2
+# `otelcol.auth.oauth2`
 
 `otelcol.auth.oauth2` exposes a `handler` that can be used by other `otelcol` components to authenticate requests using OAuth 2.0.
 
-This component only supports client authentication. 
+This component only supports client authentication.
 
 The authorization tokens can be used by HTTP and gRPC based OpenTelemetry exporters.
 This component can fetch and refresh expired tokens automatically.
 Refer to the [OAuth 2.0 Authorization Framework](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4) for more information about the Auth 2.0 Client Credentials flow.
-
 
 {{< admonition type="note" >}}
 `otelcol.auth.oauth2` is a wrapper over the upstream OpenTelemetry Collector `oauth2client` extension.
@@ -27,63 +28,66 @@ You can specify multiple `otelcol.auth.oauth2` components by giving them differe
 ## Usage
 
 ```alloy
-otelcol.auth.oauth2 "LABEL" {
-    client_id     = "CLIENT_ID"
-    client_secret = "CLIENT_SECRET"
-    token_url     = "TOKEN_URL"
+otelcol.auth.oauth2 "<LABEL>" {
+    client_id     = "<CLIENT_ID>"
+    client_secret = "<CLIENT_SECRET>"
+    token_url     = "<TOKEN_URL>"
 }
 ```
 
 ## Arguments
 
-Name                 | Type                | Description                                                                        | Default | Required
--------------------- | ------------------- | ---------------------------------------------------------------------------------- | ------- | --------
-`client_id`          | `string`            | The client identifier issued to the client.                                        |         | no
-`client_id_file`     | `string`            | The file path to retrieve the client identifier issued to the client.              |         | no
-`client_secret`      | `secret`            | The secret string associated with the client identifier.                           |         | no
-`client_secret_file` | `secret`            | The file path to retrieve the secret string associated with the client identifier. |         | no
-`token_url`          | `string`            | The server endpoint URL from which to get tokens.                                  |         | yes
-`endpoint_params`    | `map(list(string))` | Additional parameters that are sent to the token endpoint.                         | `{}`    | no
-`scopes`             | `list(string)`      | Requested permissions associated for the client.                                   | `[]`    | no
-`timeout`            | `duration`          | The timeout on the client connecting to `token_url`.                               | `"0s"`  | no
+You can use the following arguments with `otelcol.auth.oauth2`:
+
+| Name                 | Type                | Description                                                                        | Default | Required |
+| -------------------- | ------------------- | ---------------------------------------------------------------------------------- | ------- | -------- |
+| `token_url`          | `string`            | The server endpoint URL from which to get tokens.                                  |         | yes      |
+| `client_id_file`     | `string`            | The file path to retrieve the client identifier issued to the client.              |         | no       |
+| `client_id`          | `string`            | The client identifier issued to the client.                                        |         | no       |
+| `client_secret_file` | `secret`            | The file path to retrieve the secret string associated with the client identifier. |         | no       |
+| `client_secret`      | `secret`            | The secret string associated with the client identifier.                           |         | no       |
+| `endpoint_params`    | `map(list(string))` | Additional parameters that are sent to the token endpoint.                         | `{}`    | no       |
+| `scopes`             | `list(string)`      | Requested permissions associated for the client.                                   | `[]`    | no       |
+| `timeout`            | `duration`          | The timeout on the client connecting to `token_url`.                               | `"0s"`  | no       |
 
 The `timeout` argument is used both for requesting initial tokens and for refreshing tokens. `"0s"` implies no timeout.
 
-At least one of the `client_id` and `client_id_file` pair of arguments must be
-set. In case both are set, `client_id_file` takes precedence.
+At least one of the `client_id` and `client_id_file` pair of arguments must be set.
+If both arguments are set, `client_id_file` takes precedence.
 
 Similarly, at least one of the `client_secret` and `client_secret_file` pair of arguments must be set.
-If both are set, `client_secret_file` also takes precedence.
+If both arguments are set, `client_secret_file` also takes precedence.
 
 ## Blocks
 
-The following blocks are supported inside the definition of `otelcol.auth.oauth2`:
+You can use the following blocks with `otelcol.auth.oauth2`:
 
-Hierarchy | Block   | Description                        | Required
-----------|---------|------------------------------------|---------
-tls       | [tls][] | TLS settings for the token client. | no
-debug_metrics | [debug_metrics][] | Configures the metrics that this component generates to monitor its state. | no
+| Block                            | Description                                                                | Required |
+| -------------------------------- | -------------------------------------------------------------------------- | -------- |
+| [`debug_metrics`][debug_metrics] | Configures the metrics that this component generates to monitor its state. | no       |
+| [`tls`][tls]                     | TLS settings for the token client.                                         | no       |
 
-[tls]: #tls-block
-[debug_metrics]: #debug_metrics-block
+[tls]: #tls
+[debug_metrics]: #debug_metrics
 
-### tls block
-
-The `tls` block configures TLS settings used for connecting to the token client. If the `tls` block isn't provided, TLS won't be used for communication.
-
-{{< docs/shared lookup="reference/components/otelcol-tls-client-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
-
-### debug_metrics block
+### `debug_metrics`
 
 {{< docs/shared lookup="reference/components/otelcol-debug-metrics-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `tls`
+
+The `tls` block configures TLS settings used for connecting to the token client.
+If the `tls` block isn't provided, TLS won't be used for communication.
+
+{{< docs/shared lookup="reference/components/otelcol-tls-client-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ## Exported fields
 
 The following fields are exported and can be referenced by other components:
 
-Name      | Type                       | Description
-----------|----------------------------|----------------------------------------------------------------
-`handler` | `capsule(otelcol.Handler)` | A value that other components can use to authenticate requests.
+| Name      | Type                       | Description                                                     |
+| --------- | -------------------------- | --------------------------------------------------------------- |
+| `handler` | `capsule(otelcol.Handler)` | A value that other components can use to authenticate requests. |
 
 ## Component health
 

--- a/docs/sources/reference/components/otelcol/otelcol.auth.sigv4.md
+++ b/docs/sources/reference/components/otelcol/otelcol.auth.sigv4.md
@@ -3,25 +3,26 @@ canonical: https://grafana.com/docs/alloy/latest/reference/components/otelcol/ot
 aliases:
   - ../otelcol.auth.sigv4/ # /docs/alloy/latest/reference/components/otelcol.auth.sigv4/
 description: Learn about otelcol.auth.sigv4
+labels:
+  stage: general-availability
 title: otelcol.auth.sigv4
 ---
 
-# otelcol.auth.sigv4
+# `otelcol.auth.sigv4`
 
-`otelcol.auth.sigv4` exposes a `handler` that can be used by other `otelcol`
-components to authenticate requests to AWS services using the AWS Signature Version 4 (SigV4) protocol.
+`otelcol.auth.sigv4` exposes a `handler` that can be used by other `otelcol` components to authenticate requests to AWS services using the AWS Signature Version 4 (SigV4) protocol.
 For more information about SigV4 see the AWS documentation about [Signing AWS API requests][].
 
-This component only supports client authentication. 
+This component only supports client authentication.
 
 [Signing AWS API requests]: https://docs.aws.amazon.com/general/latest/gr/signing-aws-api-requests.html
 
-> **NOTE**: `otelcol.auth.sigv4` is a wrapper over the upstream OpenTelemetry
-> Collector `sigv4auth` extension. Bug reports or feature requests will be
-> redirected to the upstream repository, if necessary.
+{{< admonition type="note" >}}
+`otelcol.auth.sigv4` is a wrapper over the upstream OpenTelemetry Collector `sigv4auth` extension.
+Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+{{< /admonition >}}
 
-Multiple `otelcol.auth.sigv4` components can be specified by giving them
-different labels.
+You can specify multiple `otelcol.auth.sigv4` components by giving them different labels.
 
 {{< admonition type="note" >}}
 {{< param "PRODUCT_NAME" >}} must have valid AWS credentials as used by the [AWS SDK for Go][].
@@ -32,23 +33,24 @@ different labels.
 ## Usage
 
 ```alloy
-otelcol.auth.sigv4 "LABEL" {
+otelcol.auth.sigv4 "<LABEL>" {
 }
 ```
 
 ## Arguments
 
-Name      | Type     | Description                   | Default | Required
-----------|----------|-------------------------------|---------|---------
-`region`  | `string` | The AWS region to sign with.  | ""      | no
-`service` | `string` | The AWS service to sign with. | ""      | no
+You can use the following arguments with `otelcol.auth.sigv4`:
 
-If `region` and `service` are left empty, their values are inferred from the URL of the exporter
-using the following rules:
+| Name      | Type     | Description                   | Default | Required |
+| --------- | -------- | ----------------------------- | ------- | -------- |
+| `region`  | `string` | The AWS region to sign with.  | ""      | no       |
+| `service` | `string` | The AWS service to sign with. | ""      | no       |
 
-* If the exporter URL starts with `aps-workspaces` and `service` is empty, `service` will be set to `aps`.
-* If the exporter URL starts with `search-` and `service` is empty, `service` will be set to `es`.
-* If the exporter URL starts with either `aps-workspaces` or `search-` and `region` is empty, `region` will be set to the value between the first and second `.` character in the exporter URL.
+If `region` and `service` are left empty, their values are inferred from the URL of the exporter using the following rules:
+
+* If the exporter URL starts with `aps-workspaces` and `service` is empty, `service` is set to `aps`.
+* If the exporter URL starts with `search-` and `service` is empty, `service` is set to `es`.
+* If the exporter URL starts with either `aps-workspaces` or `search-` and `region` is empty, `region` is set to the value between the first and second `.` character in the exporter URL.
 
 If none of the above rules apply, then `region` and `service` must be specified.
 
@@ -58,32 +60,31 @@ A list of valid AWS regions can be found on Amazon's documentation for [Regions,
 
 ## Blocks
 
-The following blocks are supported inside the definition of
-`otelcol.auth.sigv4`:
+You can use the following blocks with `otelcol.auth.sigv4`:
 
-Hierarchy   | Block           | Description                        | Required
-------------|-----------------|------------------------------------|---------
-assume_role | [assume_role][] | Configuration for assuming a role. | no
-debug_metrics | [debug_metrics][] | Configures the metrics that this component generates to monitor its state. | no
+| Block                            | Description                                                                | Required |
+| -------------------------------- | -------------------------------------------------------------------------- | -------- |
+| [`assume_role`][assume_role]     | Configuration for assuming a role.                                         | no       |
+| [`debug_metrics`][debug_metrics] | Configures the metrics that this component generates to monitor its state. | no       |
 
 [assume_role]: #assume_role-block
 [debug_metrics]: #debug_metrics-block
 
-### assume_role block
+### `assume_role`
 
 The `assume_role` block specifies the configuration needed to assume a role.
 
-Name           | Type     | Description                                                     | Default | Required
----------------|----------|-----------------------------------------------------------------|---------|---------
-`arn`          | `string` | The Amazon Resource Name (ARN) of a role to assume.             | ""      | no
-`session_name` | `string` | The name of a role session.                                     | ""      | no
-`sts_region`   | `string` | The AWS region where STS is used to assume the configured role. | ""      | no
+| Name           | Type     | Description                                                     | Default | Required |
+| -------------- | -------- | --------------------------------------------------------------- | ------- | -------- |
+| `arn`          | `string` | The Amazon Resource Name (ARN) of a role to assume.             | ""      | no       |
+| `session_name` | `string` | The name of a role session.                                     | ""      | no       |
+| `sts_region`   | `string` | The AWS region where STS is used to assume the configured role. | ""      | no       |
 
-If the `assume_role` block is specified in the config and `sts_region` is not set, then `sts_region` will default to the value for `region`.
+If the `assume_role` block is specified in the configuration and `sts_region` is not set, then `sts_region` defaults to the value for `region`.
 
 For cross region authentication, `region` and `sts_region` can be set different to different values.
 
-### debug_metrics block
+### `debug_metrics`
 
 {{< docs/shared lookup="reference/components/otelcol-debug-metrics-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
@@ -91,25 +92,24 @@ For cross region authentication, `region` and `sts_region` can be set different 
 
 The following fields are exported and can be referenced by other components:
 
-Name      | Type                       | Description
-----------|----------------------------|----------------------------------------------------------------
-`handler` | `capsule(otelcol.Handler)` | A value that other components can use to authenticate requests.
+| Name      | Type                       | Description                                                     |
+| --------- | -------------------------- | --------------------------------------------------------------- |
+| `handler` | `capsule(otelcol.Handler)` | A value that other components can use to authenticate requests. |
 
 ## Component health
 
-`otelcol.auth.sigv4` is only reported as unhealthy if given an invalid
-configuration.
+`otelcol.auth.sigv4` is only reported as unhealthy if given an invalid configuration.
 
 ## Debug information
 
-`otelcol.auth.sigv4` does not expose any component-specific debug information.
+`otelcol.auth.sigv4` doesn't expose any component-specific debug information.
 
 ## Examples
 
-### Inferring the "region" and "service" from an "aps-workspaces" exporter endpoint
+### Infer the "region" and "service" from an "aps-workspaces" exporter endpoint
 
-In this example the exporter endpoint starts with `aps-workspaces`. Hence `service` is inferred to be `aps`
-and `region` is inferred to be `us-east-1`.
+In this example the exporter endpoint starts with `aps-workspaces`.
+`service` is inferred to be `aps` and `region` is inferred to be `us-east-1`.
 
 ```alloy
 otelcol.exporter.otlp "example" {
@@ -123,10 +123,10 @@ otelcol.auth.sigv4 "creds" {
 }
 ```
 
-### Inferring the "region" and "service" from a "search-" exporter endpoint
+### Infer the "region" and "service" from a "search-" exporter endpoint
 
-In this example the exporter endpoint starts with `search-`. Hence `service` is inferred to be `es`
-and `region` is inferred to be `us-east-1`.
+In this example the exporter endpoint starts with `search-`.
+`service` is inferred to be `es` and `region` is inferred to be `us-east-1`.
 
 ```alloy
 otelcol.exporter.otlp "example" {
@@ -140,10 +140,10 @@ otelcol.auth.sigv4 "creds" {
 }
 ```
 
-### Specifying "region" and "service" explicitly
+### Specify the "region" and "service" explicitly
 
-In this example the exporter endpoint does not begin with `search-` or with `aps-workspaces`.
-Hence, we need to specify `region` and `service` explicitly.
+In this example the exporter endpoint doesn't begin with `search-` or with `aps-workspaces`.
+You must to specify `region` and `service` explicitly.
 
 ```alloy
 otelcol.exporter.otlp "example" {
@@ -159,9 +159,10 @@ otelcol.auth.sigv4 "creds" {
 }
 ```
 
-### Specifying "region" and "service" explicitly and adding a "role" to assume
+### Specify the "region" and "service" explicitly and add a "role" to assume
 
-In this example we have also specified configuration to assume a role. `sts_region` hasn't been provided, so it will default to the value of `region` which is `example_region`.
+The following example specifies a configuration to assume a role.
+`sts_region` hasn't been provided, so it defaults to the value of `region` which is `example_region`.
 
 ```alloy
 otelcol.exporter.otlp "example" {

--- a/docs/sources/reference/components/otelcol/otelcol.connector.host_info.md
+++ b/docs/sources/reference/components/otelcol/otelcol.connector.host_info.md
@@ -3,17 +3,19 @@ canonical: https://grafana.com/docs/alloy/latest/reference/components/otelcol/ot
 aliases:
   - ../otelcol.connector.host_info/ # /docs/alloy/latest/reference/components/otelcol.connector.host_info/
 description: Learn about otelcol.connector.host_info
+labels:
+  stage: general-availability
 title: otelcol.connector.host_info
 ---
 
-# otelcol.connector.host_info
+# `otelcol.connector.host_info`
 
 `otel.connector.host_info` accepts span data from other `otelcol` components and generates usage metrics.
 
 ## Usage
 
 ```alloy
-otelcol.connector.host_info "LABEL" {
+otelcol.connector.host_info "<LABEL>" {
   output {
     metrics = [...]
   }
@@ -22,7 +24,7 @@ otelcol.connector.host_info "LABEL" {
 
 ## Arguments
 
-`otelcol.connector.host_info` supports the following arguments:
+You can use the following arguments with `otelcol.connector.host_info`:
 
 | Name                     | Type           | Description                                                        | Default       | Required |
 | ------------------------ | -------------- | ------------------------------------------------------------------ | ------------- | -------- |
@@ -31,22 +33,23 @@ otelcol.connector.host_info "LABEL" {
 
 ## Blocks
 
-The following blocks are supported inside the definition of
-`otelcol.connector.host_info`:
+You can use the following blocks with `otelcol.connector.host_info`:
 
-| Hierarchy | Block      | Description                                       | Required |
-| --------- | ---------- | ------------------------------------------------- | -------- |
-| output    | [output][] | Configures where to send received telemetry data. | yes      |
-debug_metrics | [debug_metrics][] | Configures the metrics that this component generates to monitor its state. | no
+| Block                            | Description                                                                | Required |
+| -------------------------------- | -------------------------------------------------------------------------- | -------- |
+| [`output`][output]               | Configures where to send received telemetry data.                          | yes      |
+| [`debug_metrics`][debug_metrics] | Configures the metrics that this component generates to monitor its state. | no       |
 
-[output]: #output-block
-[debug_metrics]: #debug_metrics-block
+[output]: #output
+[debug_metrics]: #debug_metrics
 
-### output block
+### `output`
+
+<span class="badge docs-labels__stage docs-labels__item">Required</span>
 
 {{< docs/shared lookup="reference/components/output-block-metrics.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
-### debug_metrics block
+### `debug_metrics`
 
 {{< docs/shared lookup="reference/components/otelcol-debug-metrics-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
@@ -58,12 +61,12 @@ The following fields are exported and can be referenced by other components:
 | ------- | ------------------ | ---------------------------------------------------------------- |
 | `input` | `otelcol.Consumer` | A value that other components can use to send telemetry data to. |
 
-`input` accepts `otelcol.Consumer` traces telemetry data. It does not accept metrics and logs.
+`input` accepts `otelcol.Consumer` traces telemetry data.
+It doesn't accept metrics and logs.
 
 ## Example
 
-The example below accepts traces, adds the `host.id` resource attribute via the `otelcol.processor.resourcedetection` component,
-creates usage metrics from these traces, and writes the metrics to Mimir.
+The following example accepts traces, adds the `host.id` resource attribute via the `otelcol.processor.resourcedetection` component, creates usage metrics from these traces, and writes the metrics to Mimir.
 
 ```alloy
 otelcol.receiver.otlp "otlp" {
@@ -104,8 +107,8 @@ prometheus.remote_write "default" {
   endpoint {
     url = "https://prometheus-xxx.grafana.net/api/prom/push"
     basic_auth {
-      username = sys.env("PROMETHEUS_USERNAME")
-      password = sys.env("GRAFANA_CLOUD_API_KEY")
+      username = sys.env("<PROMETHEUS_USERNAME>")
+      password = sys.env("<GRAFANA_CLOUD_API_KEY>")
     }
   }
 }

--- a/docs/sources/reference/components/otelcol/otelcol.connector.servicegraph.md
+++ b/docs/sources/reference/components/otelcol/otelcol.connector.servicegraph.md
@@ -3,25 +3,27 @@ canonical: https://grafana.com/docs/alloy/latest/reference/components/otelcol/ot
 aliases:
   - ../otelcol.connector.servicegraph/ # /docs/alloy/latest/reference/components/otelcol.connector.servicegraph/
 description: Learn about otelcol.connector.servicegraph
+labels:
+  stage: general-availability
 title: otelcol.connector.servicegraph
 ---
 
-# otelcol.connector.servicegraph
+# `otelcol.connector.servicegraph`
 
 `otelcol.connector.servicegraph` accepts span data from other `otelcol` components and outputs metrics representing the relationship between various services in a system.
 A metric represents an edge in the service graph.
-Those metrics can then be used by a data visualization application (e.g. [Grafana][]) to draw the service graph.
+Those metrics can then be used by a data visualization application, for example [Grafana][], to draw the service graph.
 
 [Grafana]: https://grafana.com/docs/grafana/latest/explore/trace-integration/#service-graph
 
-> **NOTE**: `otelcol.connector.servicegraph` is a wrapper over the upstream
-> OpenTelemetry Collector `servicegraph` connector. Bug reports or feature requests
-> will be redirected to the upstream repository, if necessary.
+{{< admonition type="note" >}}
+`otelcol.connector.servicegraph` is a wrapper over the upstream OpenTelemetry Collector `servicegraph` connector.
+Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+{{< /admonition >}}
 
-Multiple `otelcol.connector.servicegraph` components can be specified by giving them
-different labels.
+You can specify multiple `otelcol.connector.servicegraph` components by giving them different labels.
 
-This component is based on [Grafana Tempo's service graph processor](https://github.com/grafana/tempo/tree/main/modules/generator/processor/servicegraphs).
+This component is based on the Grafana Tempo [service graph processor](https://github.com/grafana/tempo/tree/main/modules/generator/processor/servicegraphs).
 
 Service graphs are useful for a number of use-cases:
 
@@ -30,21 +32,18 @@ Service graphs are useful for a number of use-cases:
 * Provide a high level overview of the health of your system.
   Service graphs show error rates, latencies, and other relevant data.
 * Provide a historic view of a system’s topology.
-  Distributed systems change very frequently,
-  and service graphs offer a way of seeing how these systems have evolved over time.
+  Distributed systems change very frequently, and service graphs offer a way of seeing how these systems have evolved over time.
 
-Since `otelcol.connector.servicegraph` has to process both sides of an edge,
-it needs to process all spans of a trace to function properly.
-If spans of a trace are spread out over multiple {{< param "PRODUCT_NAME" >}} instances, spans cannot be paired reliably.
-A solution to this problem is using [otelcol.exporter.loadbalancing][]
-in front of {{< param "PRODUCT_NAME" >}} instances running `otelcol.connector.servicegraph`.
+Since `otelcol.connector.servicegraph` has to process both sides of an edge, it needs to process all spans of a trace to function properly.
+If spans of a trace are spread out over multiple {{< param "PRODUCT_NAME" >}} instances, spans can't be paired reliably.
+A solution to this problem is using [otelcol.exporter.loadbalancing][] in front of {{< param "PRODUCT_NAME" >}} instances running `otelcol.connector.servicegraph`.
 
 [otelcol.exporter.loadbalancing]: ../otelcol.exporter.loadbalancing/
 
 ## Usage
 
 ```alloy
-otelcol.connector.servicegraph "LABEL" {
+otelcol.connector.servicegraph "<LABEL>" {
   output {
     metrics = [...]
   }
@@ -53,115 +52,114 @@ otelcol.connector.servicegraph "LABEL" {
 
 ## Arguments
 
-`otelcol.connector.servicegraph` supports the following arguments:
+You can use the following arguments with `otelcol.connector.servicegraph`:
 
-Name                        | Type             | Description                                                         | Default | Required
-----------------------------|------------------|-------------------------------------------------------------------- |---------|---------
-`latency_histogram_buckets` | `list(duration)` | Buckets for latency histogram metrics.                              | `["2ms", "4ms", "6ms", "8ms", "10ms", "50ms", "100ms", "200ms", "400ms", "800ms", "1s", "1400ms", "2s", "5s", "10s", "15s"]` | no
-`dimensions`                | `list(string)`   | A list of dimensions to add with the default dimensions.            | `[]`         | no
-`cache_loop`                | `duration`       | Configures how often to delete series which have not been updated.  | `"1m"`       | no
-`store_expiration_loop`     | `duration`       | The time to expire old entries from the store periodically.         | `"2s"`       | no
-`metrics_flush_interval`    | `duration`       | The interval at which metrics are flushed to downstream components. | `"0s"`       | no
-`database_name_attribute`   | `string`         | The attribute name used to identify the database name from span attributes. | `"db.name"`  | no
+| Name                        | Type             | Description                                                                 | Default                                                                                                                      | Required |
+| --------------------------- | ---------------- | --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `cache_loop`                | `duration`       | Configures how often to delete series which have not been updated.          | `"1m"`                                                                                                                       | no       |
+| `database_name_attribute`   | `string`         | The attribute name used to identify the database name from span attributes. | `"db.name"`                                                                                                                  | no       |
+| `dimensions`                | `list(string)`   | A list of dimensions to add with the default dimensions.                    | `[]`                                                                                                                         | no       |
+| `latency_histogram_buckets` | `list(duration)` | Buckets for latency histogram metrics.                                      | `["2ms", "4ms", "6ms", "8ms", "10ms", "50ms", "100ms", "200ms", "400ms", "800ms", "1s", "1400ms", "2s", "5s", "10s", "15s"]` | no       |
+| `metrics_flush_interval`    | `duration`       | The interval at which metrics are flushed to downstream components.         | `"0s"`                                                                                                                       | no       |
+| `store_expiration_loop`     | `duration`       | The time to expire old entries from the store periodically.                 | `"2s"`                                                                                                                       | no       |
 
 Service graphs work by inspecting traces and looking for spans with parent-children relationship that represent a request.
 `otelcol.connector.servicegraph` uses OpenTelemetry semantic conventions to detect a myriad of requests.
-The following requests are currently supported:
+The following requests are supported:
 
-* A direct request between two services, where the outgoing and the incoming span
-  must have a [Span Kind][] value of `client` and `server` respectively.
-* A request across a messaging system, where the outgoing and the incoming span
-  must have a [Span Kind][] value of `producer` and `consumer` respectively.
-* A database request, where spans have a [Span Kind][] with a value of `client`,
-  as well as an attribute with a key of `db.name`.
+* A direct request between two services, where the outgoing and the incoming span must have a [Span Kind][] value of `client` and `server` respectively.
+* A request across a messaging system, where the outgoing and the incoming span must have a [Span Kind][] value of `producer` and `consumer` respectively.
+* A database request, where spans have a [Span Kind][] with a value of `client`, as well as an attribute with a key of `db.name`.
 
 Every span which can be paired up to form a request is kept in an in-memory store:
-* If the TTL of the span expires before it can be paired, it is deleted from the store.
+
+* If the TTL of the span expires before it can be paired, it is deleted from the store. 
   TTL is configured in the [store][] block.
 * If the span is paired prior to its expiration, a metric is recorded and the span is deleted from the store.
 
 The following metrics are emitted by the processor:
 
-| Metric                                      | Type      | Labels                          | Description                                                  |
-|---------------------------------------------|-----------|---------------------------------|--------------------------------------------------------------|
-| traces_service_graph_request_total          | Counter   | client, server, connection_type | Total count of requests between two nodes                    |
-| traces_service_graph_request_failed_total   | Counter   | client, server, connection_type | Total count of failed requests between two nodes             |
-| traces_service_graph_request_server | Histogram | client, server, connection_type | Number of seconds for a request between two nodes as seen from the server |
-| traces_service_graph_request_client | Histogram | client, server, connection_type | Number of seconds for a request between two nodes as seen from the client |
-| traces_service_graph_unpaired_spans_total   | Counter   | client, server, connection_type | Total count of unpaired spans                                |
-| traces_service_graph_dropped_spans_total    | Counter   | client, server, connection_type | Total count of dropped spans                                 |
+| Metric                                    | Type      | Labels                                | Description                                                               |
+| ----------------------------------------- | --------- | ------------------------------------- | ------------------------------------------------------------------------- |
+| traces_service_graph_dropped_spans_total  | Counter   | `client`, `server`, `connection_type` | Total count of dropped spans                                              |
+| traces_service_graph_request_client       | Histogram | `client`, `server`, `connection_type` | Number of seconds for a request between two nodes as seen from the client |
+| traces_service_graph_request_failed_total | Counter   | `client`, `server`, `connection_type` | Total count of failed requests between two nodes                          |
+| traces_service_graph_request_server       | Histogram | `client`, `server`, `connection_type` | Number of seconds for a request between two nodes as seen from the server |
+| traces_service_graph_request_total        | Counter   | `client`, `server`, `connection_type` | Total count of requests between two nodes                                 |
+| traces_service_graph_unpaired_spans_total | Counter   | `client`, `server`, `connection_type` | Total count of unpaired spans                                             |
 
 Duration is measured both from the client and the server sides.
 
-The `latency_histogram_buckets` argument controls the buckets for
-`traces_service_graph_request_server` and `traces_service_graph_request_client`.
+The `latency_histogram_buckets` argument controls the buckets for `traces_service_graph_request_server` and `traces_service_graph_request_client`.
 
 Each emitted metrics series have a `client` and a `server` label corresponding with the service doing the request and the service receiving the request.
 The value of the label is derived from the `service.name` resource attribute of the two spans.
 
-The `connection_type` label may not be set. If it is set, its value will be either `messaging_system` or `database`.
+The `connection_type` label may not be set.
+If it is set, its value will be either `messaging_system` or `database`.
 
 Additional labels can be included using the `dimensions` configuration option:
+
 * Those labels will have a prefix to mark where they originate (client or server span kinds).
   The `client_` prefix relates to the dimensions coming from spans with a [Span Kind][] of `client`.
   The `server_` prefix relates to the dimensions coming from spans with a [Span Kind][] of `server`.
-* Firstly the resource attributes will be searched. If the attribute is not found, the span attributes will be searched.
+* Firstly the resource attributes will be searched. If the attribute isn't found, the span attributes will be searched.
 
-When `metrics_flush_interval` is set to `0s`, metrics will be flushed on every received batch of traces.
+When `metrics_flush_interval` is set to `0s`, metrics is flushed on every received batch of traces.
 
 [Span Kind]: https://opentelemetry.io/docs/concepts/signals/traces/#span-kind
 
 ## Blocks
 
-The following blocks are supported inside the definition of
-`otelcol.connector.servicegraph`:
+You can use the following blocks with `otelcol.connector.servicegraph`:
 
-Hierarchy | Block      | Description                               | Required
-----------|------------|-------------------------------------------|---------
-store     | [store][]  | Configures the in-memory store for spans. | no
-output    | [output][] | Configures where to send telemetry data.  | yes
-debug_metrics | [debug_metrics][] | Configures the metrics that this component generates to monitor its state. | no
+| Block                            | Description                                                                | Required |
+| -------------------------------- | -------------------------------------------------------------------------- | -------- |
+| [`output`][output]               | Configures where to send telemetry data.                                   | yes      |
+| [`debug_metrics`][debug_metrics] | Configures the metrics that this component generates to monitor its state. | no       |
+| [`store`][store]                 | Configures the in-memory store for spans.                                  | no       |
 
-[store]: #store-block
-[output]: #output-block
-[debug_metrics]: #debug_metrics-block
+[store]: #store
+[output]: #output
+[debug_metrics]: #debug_metrics
 
-### store block
+### `output`
 
-The `store` block configures the in-memory store for spans.
-
-Name        | Type       | Description                                   | Default | Required
-------------|------------|-----------------------------------------------|---------|---------
-`max_items` | `number`   | Maximum number of items to keep in the store. | `1000`  | no
-`ttl`       | `duration` | The time to live for spans in the store.      | `"2s"`  | no
-
-### output block
+<span class="badge docs-labels__stage docs-labels__item">Required</span>
 
 {{< docs/shared lookup="reference/components/output-block-metrics.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
-### debug_metrics block
+### `debug_metrics`
 
 {{< docs/shared lookup="reference/components/otelcol-debug-metrics-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `store`
+
+The `store` block configures the in-memory store for spans.
+
+| Name        | Type       | Description                                   | Default | Required |
+| ----------- | ---------- | --------------------------------------------- | ------- | -------- |
+| `max_items` | `number`   | Maximum number of items to keep in the store. | `1000`  | no       |
+| `ttl`       | `duration` | The time to live for spans in the store.      | `"2s"`  | no       |
 
 ## Exported fields
 
 The following fields are exported and can be referenced by other components:
 
-Name    | Type               | Description
---------|--------------------|-----------------------------------------------------------------
-`input` | `otelcol.Consumer` | A value that other components can use to send telemetry data to.
+| Name    | Type               | Description                                                      |
+| ------- | ------------------ | ---------------------------------------------------------------- |
+| `input` | `otelcol.Consumer` | A value that other components can use to send telemetry data to. |
 
-`input` accepts `otelcol.Consumer` traces telemetry data. It does not accept metrics and logs.
+`input` accepts `otelcol.Consumer` traces telemetry data.
+It doesn't accept metrics and logs.
 
 ## Component health
 
-`otelcol.connector.servicegraph` is only reported as unhealthy if given an invalid
-configuration.
+`otelcol.connector.servicegraph` is only reported as unhealthy if given an invalid configuration.
 
 ## Debug information
 
-`otelcol.connector.servicegraph` does not expose any component-specific debug
-information.
+`otelcol.connector.servicegraph` doesn't expose any component-specific debug information.
 
 ## Example
 
@@ -197,8 +195,8 @@ prometheus.remote_write "mimir" {
     url = "https://prometheus-xxx.grafana.net/api/prom/push"
 
     basic_auth {
-      username = sys.env("PROMETHEUS_USERNAME")
-      password = sys.env("GRAFANA_CLOUD_API_KEY")
+      username = sys.env("<PROMETHEUS_USERNAME>")
+      password = sys.env("<GRAFANA_CLOUD_API_KEY>")
     }
   }
 }
@@ -211,14 +209,14 @@ otelcol.exporter.otlp "grafana_cloud_traces" {
 }
 
 otelcol.auth.basic "grafana_cloud_traces" {
-  username = sys.env("TEMPO_USERNAME")
-  password = sys.env("GRAFANA_CLOUD_API_KEY")
+  username = sys.env("<TEMPO_USERNAME>")
+  password = sys.env("<GRAFANA_CLOUD_API_KEY>")
 }
 ```
 
 Some of the metrics in Mimir may look like this:
 
-```
+```text
 traces_service_graph_request_total{client="shop-backend",failed="false",server="article-service",client_http_method="DELETE",server_http_method="DELETE"}
 traces_service_graph_request_failed_total{client="shop-backend",client_http_method="POST",failed="false",server="auth-service",server_http_method="POST"}
 ```

--- a/docs/sources/reference/components/otelcol/otelcol.connector.spanlogs.md
+++ b/docs/sources/reference/components/otelcol/otelcol.connector.spanlogs.md
@@ -3,18 +3,19 @@ canonical: https://grafana.com/docs/alloy/latest/reference/components/otelcol/ot
 aliases:
   - ../otelcol.connector.spanlogs/ # /docs/alloy/latest/reference/components/otelcol.connector.spanlogs/
 description: Learn about otelcol.connector.spanlogs
+labels:
+  stage: general-availability
 title: otelcol.connector.spanlogs
 ---
 
-# otelcol.connector.spanlogs
+# `otelcol.connector.spanlogs`
 
-`otelcol.connector.spanlogs` accepts traces telemetry data from other `otelcol`
-components and outputs logs telemetry data for each span, root, or process.
+`otelcol.connector.spanlogs` accepts traces telemetry data from other `otelcol` components and outputs logs telemetry data for each span, root, or process.
 This allows you to automatically build a mechanism for trace discovery.
 
 {{< admonition type="note" >}}
 `otelcol.connector.spanlogs` is a custom component unrelated to any components from the OpenTelemetry Collector.
-It is based on the `automatic_logging` component in the [traces][] subsystem of Grafana Agent Static.
+It's based on the `automatic_logging` component in the [traces][] subsystem of Grafana Agent Static.
 
 [traces]: https://grafana.com/docs/agent/latest/static/configuration/traces-config
 {{< /admonition >}}
@@ -24,7 +25,7 @@ You can specify multiple `otelcol.connector.spanlogs` components by giving them 
 ## Usage
 
 ```alloy
-otelcol.connector.spanlogs "LABEL" {
+otelcol.connector.spanlogs "<LABEL>" {
   output {
     logs    = [...]
   }
@@ -33,18 +34,18 @@ otelcol.connector.spanlogs "LABEL" {
 
 ## Arguments
 
-`otelcol.connector.spanlogs` supports the following arguments:
+You can use the follwwing arguments with `otelcol.connector.spanlogs`:
 
 | Name                 | Type           | Description                                   | Default | Required |
 | -------------------- | -------------- | --------------------------------------------- | ------- | -------- |
-| `spans`              | `bool`         | Log one line per span.                        | `false` | no       |
-| `roots`              | `bool`         | Log one line for every root span of a trace.  | `false` | no       |
-| `processes`          | `bool`         | Log one line for every process.               | `false` | no       |
-| `events`             | `bool`         | Log one line for every span event.            | `false` | no       |
-| `span_attributes`    | `list(string)` | Additional span attributes to log.            | `[]`    | no       |
-| `process_attributes` | `list(string)` | Additional process attributes to log.         | `[]`    | no       |
 | `event_attributes`   | `list(string)` | Additional event attributes to log.           | `[]`    | no       |
+| `events`             | `bool`         | Log one line for every span event.            | `false` | no       |
 | `labels`             | `list(string)` | A list of keys that will be logged as labels. | `[]`    | no       |
+| `process_attributes` | `list(string)` | Additional process attributes to log.         | `[]`    | no       |
+| `processes`          | `bool`         | Log one line for every process.               | `false` | no       |
+| `roots`              | `bool`         | Log one line for every root span of a trace.  | `false` | no       |
+| `span_attributes`    | `list(string)` | Additional span attributes to log.            | `[]`    | no       |
+| `spans`              | `bool`         | Log one line per span.                        | `false` | no       |
 
 The values listed in `labels` should be the values of either span, process or event attributes.
 
@@ -54,35 +55,36 @@ Setting either `spans` or `events` to `true` could lead to a high volume of logs
 
 ## Blocks
 
-The following blocks are supported inside the definition of
-`otelcol.connector.spanlogs`:
+You can use the following blocks with `otelcol.connector.spanlogs`:
 
-| Hierarchy | Block         | Description                                       | Required |
-| --------- | ------------- | ------------------------------------------------- | -------- |
-| overrides | [overrides][] | Overrides for keys in the log body.               | no       |
-| output    | [output][]    | Configures where to send received telemetry data. | yes      |
+| Block                    | Description                                       | Required |
+| ------------------------ | ------------------------------------------------- | -------- |
+| [`output`][output]       | Configures where to send received telemetry data. | yes      |
+| [`overrides`][overrides] | Overrides for keys in the log body.               | no       |
 
-[output]: #output-block
-[overrides]: #overrides-block
+[output]: #output
+[overrides]: #overrides
 
-### overrides block
+### `output`
 
-The `overrides` block configures overrides for keys that will be logged in the body of the log line.
+<span class="badge docs-labels__stage docs-labels__item">Required</span>
+
+{{< docs/shared lookup="reference/components/output-block-logs.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `overrides`
+
+The `overrides` block configures overrides for keys that are logged in the body of the log line.
 
 The following attributes are supported:
 
 | Name                | Type     | Description                                                | Default  | Required |
 | ------------------- | -------- | ---------------------------------------------------------- | -------- | -------- |
+| `duration_key`      | `string` | Log key for the duration of the span.                      | `dur`    | no       |
 | `logs_instance_tag` | `string` | Indicates if the log line is for a span, root, or process. | `traces` | no       |
 | `service_key`       | `string` | Log key for the service name of the resource.              | `svc`    | no       |
 | `span_name_key`     | `string` | Log key for the name of the span.                          | `span`   | no       |
 | `status_key`        | `string` | Log key for the status of the span.                        | `status` | no       |
-| `duration_key`      | `string` | Log key for the duration of the span.                      | `dur`    | no       |
 | `trace_id_key`      | `string` | Log key for the trace ID of the span.                      | `tid`    | no       |
-
-### output block
-
-{{< docs/shared lookup="reference/components/output-block-logs.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ## Exported fields
 
@@ -100,14 +102,13 @@ The following fields are exported and can be referenced by other components:
 
 ## Debug information
 
-`otelcol.connector.spanlogs` does not expose any component-specific debug information.
+`otelcol.connector.spanlogs` doesn't expose any component-specific debug information.
 
 ## Example
 
 The following configuration sends logs derived from spans to Loki.
 
-Additionally, `otelcol.processor.attributes` is configured with a "hint" so that
-`otelcol.exporter.loki` promotes the span's "attribute1" attribute to a Loki label.
+Additionally, `otelcol.processor.attributes` is configured with a "hint" so that `otelcol.exporter.loki` promotes the span's "attribute1" attribute to a Loki label.
 
 ```alloy
 otelcol.receiver.otlp "default" {
@@ -156,7 +157,7 @@ loki.write "local" {
 }
 ```
 
-For an input trace like this...
+For an input trace like this:
 
 ```json
 {
@@ -227,7 +228,7 @@ For an input trace like this...
 }
 ```
 
-... the output log coming out of `otelcol.connector.spanlogs` will look like this:
+The output log coming out of `otelcol.connector.spanlogs` looks like this:
 
 ```json
 {
@@ -321,6 +322,7 @@ For an input trace like this...
   ]
 }
 ```
+
 <!-- START GENERATED COMPATIBLE COMPONENTS -->
 
 ## Compatible components


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
The Alloy component documentation needs general cleanup, including things like:

- Pretty print tables
- Sort table rows alphabetically - required first, then all optional
- Sort blocks alphabetically
- Fix block heading hierarchy
- Add badge for Required blocks
- Remove block from heading text
- Remove extra spaces and extra CR/LFs
- Tidy markdown - spaces around lists, indentation, etc.

This PR will also consider the community suggestion in this PR: https://github.com/grafana/alloy/pull/1959

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #2416 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
