### PR TITLE
Update mysqld_exporter to v0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Main (unreleased)
 
 - Have `loki.echo` log the `entry_timestamp` and `structured_metadata` for any loki entries received (@dehaansa)
 
+- Update mysqld_exporter to v0.17.1, most notable changes: (@cristiangreco)
+  - Add perf_schema quantile columns to collector
+  - Fix database quoting problem in collector 'info_schema.tables'
+  - Use SUM_LOCK_TIME and SUM_CPU_TIME with mysql >= 8.0.28
+  - Fix query on perf_schema.events_statements_summary_by_digest
+
 v1.7.0
 -----------------
 

--- a/go.mod
+++ b/go.mod
@@ -178,7 +178,7 @@ require (
 	github.com/prometheus/common/sigv4 v0.1.0
 	github.com/prometheus/consul_exporter v0.8.0
 	github.com/prometheus/memcached_exporter v0.13.0
-	github.com/prometheus/mysqld_exporter v0.16.0
+	github.com/prometheus/mysqld_exporter v0.17.1
 	github.com/prometheus/node_exporter v1.6.0
 	github.com/prometheus/procfs v0.15.1
 	github.com/prometheus/prometheus v0.55.1 // replaced by a fork of v2.54.1 further down this file
@@ -952,7 +952,7 @@ replace (
 	//github.com/prometheus/exporter-toolkit => github.com/prometheus/exporter-toolkit v0.11.0
 
 	// TODO(marctc): remove once this PR is merged upstream: https://github.com/prometheus/mysqld_exporter/pull/774
-	github.com/prometheus/mysqld_exporter => github.com/grafana/mysqld_exporter v0.16.1-0.20241128200101-e16f5286d5e9
+	github.com/prometheus/mysqld_exporter => github.com/grafana/mysqld_exporter v0.17.1-0.20250221205929-549bb437afe2
 
 	// TODO(marctc, mattdurham): Replace node_export with custom fork for multi usage. https://github.com/prometheus/node_exporter/pull/2812
 	// this commit is on the refactor_collectors branch in the grafana fork.

--- a/go.sum
+++ b/go.sum
@@ -1277,8 +1277,8 @@ github.com/grafana/loki/pkg/push v0.0.0-20250218135905-f078e0e3f9b6 h1:s4B8mN2Rv
 github.com/grafana/loki/pkg/push v0.0.0-20250218135905-f078e0e3f9b6/go.mod h1:lJEF/Wh5MYlmBem6tOYAFObkLsuikfrEf8Iy9AdMPiQ=
 github.com/grafana/loki/v3 v3.0.0-20250218135905-f078e0e3f9b6 h1:EPS7VmNSFzAdXt4LOvL8pE7k/LbKR1aI3nc2vOLDWQk=
 github.com/grafana/loki/v3 v3.0.0-20250218135905-f078e0e3f9b6/go.mod h1:DqFXiZyJE9AEimFlbVY9XHrV2ahCXKupIY2qP4Ku3EM=
-github.com/grafana/mysqld_exporter v0.16.1-0.20241128200101-e16f5286d5e9 h1:2nQItBsfp7hy+AMq1MBFW6p9Ax08nAsdR8u21rWZItQ=
-github.com/grafana/mysqld_exporter v0.16.1-0.20241128200101-e16f5286d5e9/go.mod h1:ctzLZ0vK3ow5JZmBfbS261ufC/4vtfuwFileKJea3kg=
+github.com/grafana/mysqld_exporter v0.17.1-0.20250221205929-549bb437afe2 h1:YZW1QD0iq+/2q8JO+t668cvBsjDbbyE4kcMcRy4JXRI=
+github.com/grafana/mysqld_exporter v0.17.1-0.20250221205929-549bb437afe2/go.mod h1:iEFA+REkm+0WRvVxy0cA1bBhJlFcQB998yymb45TqMU=
 github.com/grafana/node_exporter v0.18.1-grafana-r01.0.20250218170810-6300fab82195 h1:K7uSltwt72o1IkGGCDFkj/d87uXB4pk3BRfpJZgZX3E=
 github.com/grafana/node_exporter v0.18.1-grafana-r01.0.20250218170810-6300fab82195/go.mod h1:onpUlSx7BWY8aO+tr3DChzBJB06pZfZ4gltVtsRXLFA=
 github.com/grafana/opentelemetry-collector/featuregate v0.0.0-20240325174506-2fd1623b2ca0 h1:i/Ne0XwoRokYj52ZcSmnvuyID3h/uA91n0Ycg/grHU8=


### PR DESCRIPTION
#### PR Description
Update mysqld_exporter to v0.17.1

Continue to use our fork grafana/mysqld_exporter, branch refactor_collector

#### Which issue(s) this PR fixes
n.a.

#### Notes to the Reviewer

#### PR Checklist
- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
