### PR TITLE
feat: add ability to specify extra rules for alloy ClusterRole

### DIFF
--- a/operations/helm/charts/alloy/CHANGELOG.md
+++ b/operations/helm/charts/alloy/CHANGELOG.md
@@ -7,6 +7,13 @@ This document contains a historical list of changes between releases. Only
 changes that impact end-user behavior are listed; changes to documentation or
 internal API changes are not present.
 
+Unreleased
+----------
+
+### Enhancement
+
+- Add ability to specify extra rules for alloy ClusterRole. (@nejec)
+
 0.12.0 (2025-02-24)
 ----------
 

--- a/operations/helm/charts/alloy/README.md.gotmpl
+++ b/operations/helm/charts/alloy/README.md.gotmpl
@@ -113,6 +113,14 @@ components like [discovery.kubernetes][] to work properly.
 
 [discovery.kubernetes]: https://grafana.com/docs/alloy/latest/reference/components/discovery.kubernetes/
 
+### rbac.extraRules
+
+`rbac.extraRules` enabled specifying additional rules for alloy ClusterRole.
+
+Some providers require additional rules to be able to scrape the metrics of the
+api endpoints (e.g. EKS). This configuration option enables configuring special
+rules for such cases.
+
 ### controller.autoscaling
 
 `controller.autoscaling.enabled` enables the creation of a HorizontalPodAutoscaler. It is only used when `controller.type` is set to `deployment` or `statefulset`.

--- a/operations/helm/charts/alloy/ci/clusterrole-extra-rules-values.yaml
+++ b/operations/helm/charts/alloy/ci/clusterrole-extra-rules-values.yaml
@@ -1,0 +1,9 @@
+rbac:
+  create: true
+  extraRules:
+    - apiGroups: ["metrics.eks.amazonaws.com"]
+      resources: [
+        "kcm/metrics",
+        "ksh/metrics"
+      ]
+      verbs: ["get"]

--- a/operations/helm/charts/alloy/values.yaml
+++ b/operations/helm/charts/alloy/values.yaml
@@ -138,6 +138,8 @@ image:
 rbac:
   # -- Whether to create RBAC resources for Alloy.
   create: true
+  # -- Optional additional rules to Alloy ClusterRole
+  extraRules: []
 
 serviceAccount:
   # -- Whether to create a service account for the Grafana Alloy deployment.

--- a/operations/helm/tests/clusterrole-extra-rules/alloy/templates/configmap.yaml
+++ b/operations/helm/tests/clusterrole-extra-rules/alloy/templates/configmap.yaml
@@ -1,0 +1,43 @@
+---
+# Source: alloy/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alloy
+  labels:
+    helm.sh/chart: alloy
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/instance: alloy
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: config
+data:
+  config.alloy: |-
+    logging {
+    	level  = "info"
+    	format = "logfmt"
+    }
+    
+    discovery.kubernetes "pods" {
+    	role = "pod"
+    }
+    
+    discovery.kubernetes "nodes" {
+    	role = "node"
+    }
+    
+    discovery.kubernetes "services" {
+    	role = "service"
+    }
+    
+    discovery.kubernetes "endpoints" {
+    	role = "endpoints"
+    }
+    
+    discovery.kubernetes "endpointslices" {
+    	role = "endpointslice"
+    }
+    
+    discovery.kubernetes "ingresses" {
+    	role = "ingress"
+    }

--- a/operations/helm/tests/clusterrole-extra-rules/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/clusterrole-extra-rules/alloy/templates/controllers/daemonset.yaml
@@ -1,0 +1,75 @@
+---
+# Source: alloy/templates/controllers/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: alloy
+  labels:
+    helm.sh/chart: alloy
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/instance: alloy
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  minReadySeconds: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: alloy
+      app.kubernetes.io/instance: alloy
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: alloy
+      labels:
+        app.kubernetes.io/name: alloy
+        app.kubernetes.io/instance: alloy
+    spec:
+      serviceAccountName: alloy
+      containers:
+        - name: alloy
+          image: docker.io/grafana/alloy:v1.6.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - run
+            - /etc/alloy/config.alloy
+            - --storage.path=/tmp/alloy
+            - --server.http.listen-addr=0.0.0.0:12345
+            - --server.http.ui-path-prefix=/
+            - --stability.level=generally-available
+          env:
+            - name: ALLOY_DEPLOY_MODE
+              value: "helm"
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          ports:
+            - containerPort: 12345
+              name: http-metrics
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 12345
+              scheme: HTTP
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alloy
+        - name: config-reloader
+          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          args:
+            - --volume-dir=/etc/alloy
+            - --webhook-url=http://localhost:12345/-/reload
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alloy
+          resources:
+            requests:
+              cpu: 1m
+              memory: 5Mi
+      dnsPolicy: ClusterFirst
+      volumes:
+        - name: config
+          configMap:
+            name: alloy

--- a/operations/helm/tests/clusterrole-extra-rules/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/clusterrole-extra-rules/alloy/templates/rbac.yaml
@@ -1,10 +1,15 @@
-{{- if .Values.rbac.create }}
+---
+# Source: alloy/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "alloy.fullname" . }}
+  name: alloy
   labels:
-    {{- include "alloy.labels" . | nindent 4 }}
+    helm.sh/chart: alloy
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/instance: alloy
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: rbac
 rules:
   # Rules which allow discovery.kubernetes to function.
@@ -91,24 +96,31 @@ rules:
   - apiGroups: ["extensions"]
     resources: ["replicasets"]
     verbs: ["get", "list", "watch"]
-  {{- if .Values.rbac.extraRules }}
-  {{- toYaml .Values.rbac.extraRules | nindent 2 }}
-  {{- end }}
-
+  - apiGroups:
+    - metrics.eks.amazonaws.com
+    resources:
+    - kcm/metrics
+    - ksh/metrics
+    verbs:
+    - get
 ---
+# Source: alloy/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "alloy.fullname" . }}
+  name: alloy
   labels:
-    {{- include "alloy.labels" . | nindent 4 }}
+    helm.sh/chart: alloy
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/instance: alloy
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: rbac
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "alloy.fullname" . }}
+  name: alloy
 subjects:
   - kind: ServiceAccount
-    name: {{ include "alloy.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
-{{- end }}
+    name: alloy
+    namespace: default

--- a/operations/helm/tests/clusterrole-extra-rules/alloy/templates/service.yaml
+++ b/operations/helm/tests/clusterrole-extra-rules/alloy/templates/service.yaml
@@ -1,0 +1,24 @@
+---
+# Source: alloy/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: alloy
+  labels:
+    helm.sh/chart: alloy
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/instance: alloy
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: networking
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/instance: alloy
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: http-metrics
+      port: 12345
+      targetPort: 12345
+      protocol: "TCP"

--- a/operations/helm/tests/clusterrole-extra-rules/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/clusterrole-extra-rules/alloy/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+---
+# Source: alloy/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: alloy
+  namespace: default
+  labels:
+    helm.sh/chart: alloy
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/instance: alloy
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: rbac


### PR DESCRIPTION
#### PR Description

Adding helm configuration to allow specifying additional rules for ClusterRole, which might be needed in special cases like scraping metrics from hosted kubernetes clusters (e.g. EKS).

#### Which issue(s) this PR fixes

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
