### PR TITLE
mixin: otel metrics and logs support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Main (unreleased)
 
 - Added additional backwards compatibility metrics to `prometheus.write.queue`. (@mattdurham)
 
+- Added OpenTelemetry logs and metrics support to Alloy mixin's dashboards and alerts. (@thampiotr)
+
 v1.7.1
 -----------------
 

--- a/example/grafana.yaml
+++ b/example/grafana.yaml
@@ -54,6 +54,8 @@ services:
         condition: service_completed_successfully
     environment:
       - GRAFANA_URL=http://grafana:3000
+      - MIMIR_ADDRESS=http://mimir:9009
+      - MIMIR_TENANT_ID=fake
     volumes:
       - ../operations/alloy-mixin:/etc/alloy-mixin
     working_dir: /etc/alloy-mixin

--- a/operations/alloy-mixin/alerts/opentelemetry.libsonnet
+++ b/operations/alloy-mixin/alerts/opentelemetry.libsonnet
@@ -1,6 +1,10 @@
 local alert = import './utils/alert.jsonnet';
 
 {
+  local successThreshold = 0.95,
+  local successThresholdText = '95%',
+  local pendingPeriod = '10m',
+
   local successRateQuery(enableK8sCluster, failed, success) =
         local sumBy = if enableK8sCluster then "cluster, namespace, job" else "job";
         |||
@@ -9,8 +13,8 @@ local alert = import './utils/alert.jsonnet';
                   /
                   sum by (%s) (rate(%s{}[1m]) + rate(%s{}[1m]))
                )
-          ) < 0.95
-        ||| % [sumBy, failed, sumBy, failed, success],
+          ) < %g
+        ||| % [sumBy, failed, sumBy, failed, success, successThreshold],
 
   newOpenTelemetryAlertsGroup(enableK8sCluster=true):
     alert.newGroup(
@@ -22,19 +26,55 @@ local alert = import './utils/alert.jsonnet';
         alert.newRule(
           'OtelcolReceiverRefusedSpans',
           successRateQuery(enableK8sCluster, "otelcol_receiver_refused_spans_total", "otelcol_receiver_accepted_spans_total"),
-          'The receiver pushing spans to the pipeline success rate is below 95%.',
+          'The receiver pushing spans to the pipeline success rate is below %s.' % successThresholdText,
           'The receiver could not push some spans to the pipeline under job {{ $labels.job }}. This could be due to reaching a limit such as the ones imposed by otelcol.processor.memory_limiter.',
-          '10m',
+          pendingPeriod,
         ),
 
-        // The exporter success rate is below 95%.
+        // Metrics receiver alerts
+        alert.newRule(
+          'OtelcolReceiverRefusedMetrics',
+          successRateQuery(enableK8sCluster, "otelcol_receiver_refused_metric_points_total", "otelcol_receiver_accepted_metric_points_total"),
+          'The receiver pushing metrics to the pipeline success rate is below %s.' % successThresholdText,
+          'The receiver could not push some metric points to the pipeline under job {{ $labels.job }}. This could be due to reaching a limit such as the ones imposed by otelcol.processor.memory_limiter.',
+          pendingPeriod,
+        ),
+
+        // Logs receiver alerts
+        alert.newRule(
+          'OtelcolReceiverRefusedLogs',
+          successRateQuery(enableK8sCluster, "otelcol_receiver_refused_log_records_total", "otelcol_receiver_accepted_log_records_total"),
+          'The receiver pushing logs to the pipeline success rate is below %s.' % successThresholdText,
+          'The receiver could not push some log records to the pipeline under job {{ $labels.job }}. This could be due to reaching a limit such as the ones imposed by otelcol.processor.memory_limiter.',
+          pendingPeriod,
+        ),
+
+        // The exporter success rate is below threshold.
         // There could be an issue with the payload or with the destination endpoint.
         alert.newRule(
           'OtelcolExporterFailedSpans',
           successRateQuery(enableK8sCluster, "otelcol_exporter_send_failed_spans_total", "otelcol_exporter_sent_spans_total"),
-          'The exporter sending spans success rate is below 95%.',
+          'The exporter sending spans success rate is below %s.' % successThresholdText,
           'The exporter failed to send spans to their destination under job {{ $labels.job }}. There could be an issue with the payload or with the destination endpoint.',
-          '10m',
+          pendingPeriod,
+        ),
+
+        // Metrics exporter alerts
+        alert.newRule(
+          'OtelcolExporterFailedMetrics',
+          successRateQuery(enableK8sCluster, "otelcol_exporter_send_failed_metric_points_total", "otelcol_exporter_sent_metric_points_total"),
+          'The exporter sending metrics success rate is below %s.' % successThresholdText,
+          'The exporter failed to send metric points to their destination under job {{ $labels.job }}. There could be an issue with the payload or with the destination endpoint.',
+          pendingPeriod,
+        ),
+
+        // Logs exporter alerts
+        alert.newRule(
+          'OtelcolExporterFailedLogs',
+          successRateQuery(enableK8sCluster, "otelcol_exporter_send_failed_log_records_total", "otelcol_exporter_sent_log_records_total"),
+          'The exporter sending logs success rate is below %s.' % successThresholdText,
+          'The exporter failed to send log records to their destination under job {{ $labels.job }}. There could be an issue with the payload or with the destination endpoint.',
+          pendingPeriod,
         ),
       ]
     )

--- a/operations/alloy-mixin/dashboards/opentelemetry.libsonnet
+++ b/operations/alloy-mixin/dashboards/opentelemetry.libsonnet
@@ -23,8 +23,8 @@ local stackedPanelMixin = {
       includeInstance=true,
       setenceCaseLabels=$._config.useSetenceCaseTemplateLabels),
 
-  local panelPosition(row, col) = panel.withPosition({x: col*8, y: row*10, w: 8, h: 10}),
-  local panelPosition4(row, col) = panel.withPosition({x: col*6, y: row*10, w: 6, h: 10}),
+  local panelPosition3Across(row, col) = panel.withPosition({x: col*8, y: row*10, w: 8, h: 10}),
+  local panelPosition4Across(row, col) = panel.withPosition({x: col*6, y: row*10, w: 6, h: 10}),
   local rowPosition(row) = panel.withPosition({h: 1, w: 24, x: 0, y: row*10}),
 
   [filename]:
@@ -44,7 +44,7 @@ local stackedPanelMixin = {
           Number of metric points successfully pushed into the pipeline.
         |||) +
         stackedPanelMixin +
-        panelPosition4(row=0, col=0) +
+        panelPosition4Across(row=0, col=0) +
         panel.withQueries([
           panel.newQuery(
             expr= |||
@@ -59,7 +59,7 @@ local stackedPanelMixin = {
           Number of metric points that could not be pushed into the pipeline.
         |||) +
         stackedPanelMixin +
-        panelPosition4(row=0, col=1) +
+        panelPosition4Across(row=0, col=1) +
         panel.withQueries([
           panel.newQuery(
             expr= |||
@@ -74,7 +74,7 @@ local stackedPanelMixin = {
           Number of log records successfully pushed into the pipeline.
         |||) +
         stackedPanelMixin +
-        panelPosition4(row=0, col=2) +
+        panelPosition4Across(row=0, col=2) +
         panel.withQueries([
           panel.newQuery(
             expr= |||
@@ -89,7 +89,7 @@ local stackedPanelMixin = {
           Number of log records that could not be pushed into the pipeline.
         |||) +
         stackedPanelMixin +
-        panelPosition4(row=0, col=3) +
+        panelPosition4Across(row=0, col=3) +
         panel.withQueries([
           panel.newQuery(
             expr= |||
@@ -104,7 +104,7 @@ local stackedPanelMixin = {
           Number of spans successfully pushed into the pipeline.
         |||) +
         stackedPanelMixin +
-        panelPosition4(row=1, col=0) +
+        panelPosition4Across(row=1, col=0) +
         panel.withQueries([
           panel.newQuery(
             expr= |||
@@ -119,7 +119,7 @@ local stackedPanelMixin = {
           Number of spans that could not be pushed into the pipeline.
         |||) +
         stackedPanelMixin +
-        panelPosition4(row=1, col=1) +
+        panelPosition4Across(row=1, col=1) +
         panel.withQueries([
           panel.newQuery(
             expr= |||
@@ -133,7 +133,7 @@ local stackedPanelMixin = {
         panel.withDescription(|||
           The duration of inbound RPCs for otelcol.receiver.* components.
         |||) +
-        panelPosition4(row=1, col=2) +
+        panelPosition4Across(row=1, col=2) +
         panel.withQueries([
           panel.newQuery(
             expr= |||
@@ -149,7 +149,7 @@ local stackedPanelMixin = {
         panel.withDescription(|||
           The duration of inbound HTTP requests for otelcol.receiver.* components.
         |||) +
-        panelPosition4(row=1, col=3) +
+        panelPosition4Across(row=1, col=3) +
         panel.withQueries([
           panel.newQuery(
             expr= |||
@@ -172,7 +172,7 @@ local stackedPanelMixin = {
         panel.withDescription(|||
           Number of spans, metric datapoints, or log lines in a batch
         |||) +
-        panelPosition(row=2, col=0) +
+        panelPosition3Across(row=2, col=0) +
         panel.withQueries([
           panel.newQuery(
             expr= |||
@@ -191,7 +191,7 @@ local stackedPanelMixin = {
         panel.withDescription(|||
           Number of distinct metadata value combinations being processed
         |||) +
-        panelPosition(row=2, col=1) +
+        panelPosition3Across(row=2, col=1) +
         panel.withQueries([
           panel.newQuery(
             expr= |||
@@ -205,7 +205,7 @@ local stackedPanelMixin = {
         panel.withDescription(|||
           Number of times the batch was sent due to a timeout trigger
         |||) +
-        panelPosition(row=2, col=2) +
+        panelPosition3Across(row=2, col=2) +
         panel.withQueries([
           panel.newQuery(
             expr= |||
@@ -226,7 +226,7 @@ local stackedPanelMixin = {
           Number of metric points successfully sent to destination.
         |||) +
         stackedPanelMixin +
-        panelPosition4(row=3, col=0) +
+        panelPosition4Across(row=3, col=0) +
         panel.withQueries([
           panel.newQuery(
             expr= ||| 
@@ -241,7 +241,7 @@ local stackedPanelMixin = {
           Number of metric points that failed to be sent to destination.
         |||) +
         stackedPanelMixin +
-        panelPosition4(row=3, col=1) +
+        panelPosition4Across(row=3, col=1) +
         panel.withQueries([
           panel.newQuery(
             expr= |||
@@ -256,7 +256,7 @@ local stackedPanelMixin = {
           Number of log records successfully sent to destination.
         |||) +
         stackedPanelMixin +
-        panelPosition4(row=3, col=2) +
+        panelPosition4Across(row=3, col=2) +
         panel.withQueries([
           panel.newQuery(
             expr= |||
@@ -271,7 +271,7 @@ local stackedPanelMixin = {
           Number of log records that failed to be sent to destination.
         |||) +
         stackedPanelMixin +
-        panelPosition4(row=3, col=3) +
+        panelPosition4Across(row=3, col=3) +
         panel.withQueries([
           panel.newQuery(
             expr= |||
@@ -286,7 +286,7 @@ local stackedPanelMixin = {
           Number of spans successfully sent to destination.
         |||) +
         stackedPanelMixin +
-        panelPosition4(row=4, col=0) +
+        panelPosition4Across(row=4, col=0) +
         panel.withQueries([
           panel.newQuery(
             expr= |||
@@ -301,7 +301,7 @@ local stackedPanelMixin = {
           Number of spans that failed to be sent to destination.
         |||) +
         stackedPanelMixin +
-        panelPosition4(row=4, col=1) +
+        panelPosition4Across(row=4, col=1) +
         panel.withQueries([
           panel.newQuery(
             expr= |||
@@ -315,7 +315,7 @@ local stackedPanelMixin = {
         panel.withDescription(|||
           The duration of outbound RPCs for otelcol.exporter.* components.
         |||) +
-        panelPosition4(row=4, col=2) +
+        panelPosition4Across(row=4, col=2) +
         panel.withQueries([
           panel.newQuery(
             expr= |||
@@ -331,7 +331,7 @@ local stackedPanelMixin = {
         panel.withDescription(|||
           The duration of outbound HTTP requests for otelcol.exporter.* components.
         |||) +
-        panelPosition4(row=4, col=3) +
+        panelPosition4Across(row=4, col=3) +
         panel.withQueries([
           panel.newQuery(
             expr= |||

--- a/operations/alloy-mixin/dashboards/opentelemetry.libsonnet
+++ b/operations/alloy-mixin/dashboards/opentelemetry.libsonnet
@@ -32,10 +32,62 @@ local stackedPanelMixin = {
     dashboard.withUID(std.md5(filename)) +
     dashboard.withTemplateVariablesMixin(templateVariables) +
     dashboard.withPanelsMixin([
+      // "Receivers for metrics" row
+      (
+        panel.new('Receivers for metrics [otelcol.receiver]', 'row') +
+        rowPosition(0)
+      ),
+      (
+        panel.new(title='Accepted metric points', type='timeseries') +
+        panel.withDescription(|||
+          Number of metric points successfully pushed into the pipeline.
+        |||) +
+        stackedPanelMixin +
+        panelPosition(row=0, col=0) +
+        panel.withQueries([
+          panel.newQuery(
+            expr= |||
+              sum by(instance) (rate(otelcol_receiver_accepted_metric_points_total{%(instanceSelector)s}[$__rate_interval]))
+            ||| % $._config,
+          ),
+        ])
+      ),
+      (
+        panel.new(title='Refused metric points', type='timeseries') +
+        panel.withDescription(|||
+          Number of metric points that could not be pushed into the pipeline.
+        |||) +
+        stackedPanelMixin +
+        panelPosition(row=0, col=1) +
+        panel.withQueries([
+          panel.newQuery(
+            expr= |||
+              sum by(instance) (rate(otelcol_receiver_refused_metric_points_total{%(instanceSelector)s}[$__rate_interval]))
+            ||| % $._config,
+          ),
+        ])
+      ),
+      (
+        panel.newHeatmap('RPC server duration for metrics', 'ms') +
+        panel.withDescription(|||
+          The duration of inbound RPCs for metrics.
+        |||) +
+        panelPosition(row=0, col=2) +
+        panel.withQueries([
+          panel.newQuery(
+            expr= |||
+              sum by (le) (increase(rpc_server_duration_milliseconds_bucket{%(instanceSelector)s, rpc_service="opentelemetry.proto.collector.metrics.v1.MetricsService"}[$__rate_interval]))
+            ||| % $._config,
+            format='heatmap',
+            legendFormat='{{le}}',
+          ),
+        ])
+      ),
+
       // "Receivers for traces" row
       (
         panel.new('Receivers for traces [otelcol.receiver]', 'row') +
-        rowPosition(0)
+        rowPosition(1)
       ),
       (
         panel.new(title='Accepted spans', type='timeseries') +
@@ -43,7 +95,7 @@ local stackedPanelMixin = {
           Number of spans successfully pushed into the pipeline.
         |||) +
         stackedPanelMixin +
-        panelPosition(row=0, col=0) +
+        panelPosition(row=1, col=0) +
         panel.withQueries([
           panel.newQuery(
             expr= |||
@@ -59,7 +111,7 @@ local stackedPanelMixin = {
           Number of spans that could not be pushed into the pipeline.
         |||) +
         stackedPanelMixin +
-        panelPosition(row=0, col=1) +
+        panelPosition(row=1, col=1) +
         panel.withQueries([
           panel.newQuery(
             expr= |||
@@ -73,7 +125,7 @@ local stackedPanelMixin = {
         panel.withDescription(|||
           The duration of inbound RPCs.
         |||) +
-        panelPosition(row=0, col=2) +
+        panelPosition(row=1, col=2) +
         panel.withQueries([
           panel.newQuery(
             expr= |||
@@ -88,7 +140,7 @@ local stackedPanelMixin = {
       // "Batching" row
       (
         panel.new('Batching of logs, metrics, and traces [otelcol.processor.batch]', 'row') +
-        rowPosition(1)
+        rowPosition(2)
       ),
       (
         panel.newHeatmap('Number of units in the batch', 'short') +
@@ -96,7 +148,7 @@ local stackedPanelMixin = {
         panel.withDescription(|||
           Number of spans, metric datapoints, or log lines in a batch
         |||) +
-        panelPosition(row=1, col=0) +
+        panelPosition(row=2, col=0) +
         panel.withQueries([
           panel.newQuery(
             expr= |||
@@ -115,7 +167,7 @@ local stackedPanelMixin = {
         panel.withDescription(|||
           Number of distinct metadata value combinations being processed
         |||) +
-        panelPosition(row=1, col=1) +
+        panelPosition(row=2, col=1) +
         panel.withQueries([
           panel.newQuery(
             expr= |||
@@ -129,7 +181,7 @@ local stackedPanelMixin = {
         panel.withDescription(|||
           Number of times the batch was sent due to a timeout trigger
         |||) +
-        panelPosition(row=1, col=2) +
+        panelPosition(row=2, col=2) +
         panel.withQueries([
           panel.newQuery(
             expr= |||
@@ -142,7 +194,7 @@ local stackedPanelMixin = {
       // "Exporters for traces" row
       (
         panel.new('Exporters for traces [otelcol.exporter]', 'row') +
-        rowPosition(2)
+        rowPosition(3)
       ),
       (
         panel.new(title='Exported sent spans', type='timeseries') +
@@ -150,7 +202,7 @@ local stackedPanelMixin = {
           Number of spans successfully sent to destination.
         |||) +
         stackedPanelMixin +
-        panelPosition(row=2, col=0) +
+        panelPosition(row=3, col=0) +
         panel.withQueries([
           panel.newQuery(
             expr= ||| 
@@ -165,7 +217,7 @@ local stackedPanelMixin = {
           Number of spans in failed attempts to send to destination.
         |||) +
         stackedPanelMixin +
-        panelPosition(row=2, col=1) +
+        panelPosition(row=3, col=1) +
         panel.withQueries([
           panel.newQuery(
             expr= |||

--- a/operations/alloy-mixin/grizzly.jsonnet
+++ b/operations/alloy-mixin/grizzly.jsonnet
@@ -7,11 +7,10 @@
 // mixin and continually deploy all dashboards.
 //
 
-(import './grizzly/dashboards.jsonnet')
+(import './grizzly/dashboards.jsonnet') +
 
-// By default, only dashboards get deployed; not alerts or recording rules.
-// To deploy alerts and recording rules, set up the environment variables used
-// by cortextool to authenticate with a Prometheus or Alertmanager intance and
-// uncomment the line below.
-
-//+ (import './grizzly/alerts.jsonnet')
+// By default, alerts get also deployed; This should work out-of-the-box when 
+// using the example docker-compose environment. If you are using grizzly with
+// a different environemnt, set up the environment variables as documented in
+// https://grafana.github.io/grizzly/configuration/ or comment out the line below.
++ (import './grizzly/alerts.jsonnet')


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

- Add metrics and logs successes and failures to receivers row in OTel dashboard
- Add metrics and logs successes and failures to exporters row in OTel dashboard
- Make sure these rows have both HTTP and RPC latency tracked
- Add alerts for failing OTLP metrics and logs
- Set up example docker-compose environment to sync up alerts correctly from the mixin

#### Notes

The alerts added correctly when tested locally and look good:
<img width="1856" alt="image" src="https://github.com/user-attachments/assets/dc236b78-40ac-457b-be04-65d370bedd42" />

<img width="1834" alt="image" src="https://github.com/user-attachments/assets/ae8fd792-74ed-449d-b9ad-5a39c541dfaa" />

Dashboard for receivers (some aggregation rules may need tweaking internally)
<img width="1898" alt="image" src="https://github.com/user-attachments/assets/514280d3-63d2-4789-b728-671bd0b21407" />

And same for exporters:
<img width="1900" alt="image" src="https://github.com/user-attachments/assets/5a0f7b4c-261e-4819-afe9-5d99d571ba9d" />


#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
