### PR TITLE
feat: Add string concatenation for secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Main (unreleased)
 ### Features
 
 - Add `otelcol.receiver.awscloudwatch` component to receive logs from AWS CloudWatch and forward them to other `otelcol.*` components. (@wildum)
+- Add string concatenation for secrets type (@ravishankar15)
 
 ### Enhancements
 

--- a/docs/sources/get-started/configuration-syntax/expressions/operators.md
+++ b/docs/sources/get-started/configuration-syntax/expressions/operators.md
@@ -27,7 +27,7 @@ Operator | Description
 
 Operator | Description
 ---------|-------------------------
-`+`      | Concatenate two strings.
+`+`      | Concatenate two strings/secrets.
 
 ## Comparison operators
 

--- a/docs/sources/get-started/configuration-syntax/expressions/operators.md
+++ b/docs/sources/get-started/configuration-syntax/expressions/operators.md
@@ -27,7 +27,7 @@ Operator | Description
 
 Operator | Description
 ---------|-------------------------
-`+`      | Concatenate two strings/secrets.
+`+`      | Concatenate two strings or two secrets or string and secret.
 
 ## Comparison operators
 

--- a/docs/sources/get-started/configuration-syntax/expressions/operators.md
+++ b/docs/sources/get-started/configuration-syntax/expressions/operators.md
@@ -27,7 +27,7 @@ Operator | Description
 
 Operator | Description
 ---------|-------------------------
-`+`      | Concatenate two strings or two secrets or string and secret.
+`+`      | Concatenate two strings or two secrets, or a string and a secret.
 
 ## Comparison operators
 

--- a/syntax/vm/op_binary_test.go
+++ b/syntax/vm/op_binary_test.go
@@ -59,14 +59,43 @@ func TestVM_OptionalSecret_Conversion(t *testing.T) {
 			expect: bool(false),
 		},
 		{
-			name:        "secret + string",
-			input:       `secret_val + string_val`,
-			expectError: "secret_val should be one of [number string] for binop +",
+			name:        "secret - string",
+			input:       `secret_val - string_val`,
+			expectError: "secret_val should be one of [number] for binop -, got capsule",
 		},
 		{
-			name:        "string + secret",
-			input:       `string_val + secret_val`,
-			expectError: "secret_val should be one of [number string] for binop +",
+			name:        "string - secret",
+			input:       `string_val - secret_val`,
+			expectError: "string_val should be one of [number] for binop -, got capsule",
+		},
+		{
+			name:  "secret + string",
+			input: `secret_val + string_val`,
+			expect: alloytypes.OptionalSecret{
+				Value: "secrethello", IsSecret: true,
+			},
+		},
+		{
+			name:  "string + secret",
+			input: `string_val + secret_val`,
+			expect: alloytypes.OptionalSecret{
+				Value: "hellosecret", IsSecret: true,
+			},
+		},
+		{
+			name:   "secret + string",
+			input:  `non_secret_val + string_val`,
+			expect: string("worldhello"),
+		},
+		{
+			name:   "string + secret",
+			input:  `string_val + non_secret_val`,
+			expect: string("helloworld"),
+		},
+		{
+			name:   "string + string",
+			input:  `string_val + string_val`,
+			expect: string("hellohello"),
 		},
 	}
 

--- a/syntax/vm/op_binary_test.go
+++ b/syntax/vm/op_binary_test.go
@@ -10,11 +10,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestVM_OptionalSecret_Conversion(t *testing.T) {
+func TestVM_Capsule_Conversion(t *testing.T) {
 	scope := vm.NewScope(map[string]any{
-		"string_val":     "hello",
-		"non_secret_val": alloytypes.OptionalSecret{IsSecret: false, Value: "world"},
-		"secret_val":     alloytypes.OptionalSecret{IsSecret: true, Value: "secret"},
+		"string_val":      "hello",
+		"non_secret_val":  alloytypes.OptionalSecret{IsSecret: false, Value: "world"},
+		"secret_val":      alloytypes.OptionalSecret{IsSecret: true, Value: "secret"},
+		"secret_type_val": alloytypes.Secret("welcome"),
 	})
 
 	tt := []struct {
@@ -44,51 +45,91 @@ func TestVM_OptionalSecret_Conversion(t *testing.T) {
 			expect: bool(true),
 		},
 		{
-			name:   "capsule (secret) == capsule (secret)",
+			name:   "capsule (optionalsecret(true)) == capsule (optionalsecret(true))",
 			input:  `secret_val == secret_val`,
 			expect: bool(true),
 		},
 		{
-			name:   "capsule (non secret) == capsule (non secret)",
+			name:   "capsule (optionalsecret(false)) == capsule (optionalsecret(false))",
 			input:  `non_secret_val == non_secret_val`,
 			expect: bool(true),
 		},
 		{
-			name:   "capsule (non secret) == capsule (secret)",
+			name:   "capsule (optionalsecret(false)) == capsule (optionalsecret(true))",
 			input:  `non_secret_val == secret_val`,
 			expect: bool(false),
 		},
 		{
-			name:        "secret - string",
+			name:        "capsule (optionalsecret(true)) - string",
 			input:       `secret_val - string_val`,
 			expectError: "secret_val should be one of [number] for binop -, got capsule",
 		},
 		{
-			name:        "string - secret",
+			name:        "string - capsule (optionalsecret(true))",
 			input:       `string_val - secret_val`,
 			expectError: "string_val should be one of [number] for binop -, got capsule",
 		},
 		{
-			name:  "secret + string",
+			name:  "capsule (optionalsecret(true)) + string",
 			input: `secret_val + string_val`,
 			expect: alloytypes.OptionalSecret{
 				Value: "secrethello", IsSecret: true,
 			},
 		},
 		{
-			name:  "string + secret",
+			name:   "capsule (optionalsecret(false)) + string",
+			input:  `non_secret_val + string_val`,
+			expect: string("worldhello"),
+		},
+		{
+			name:   "capsule (optionalsecret(false)) + capsule (optionalsecret(false))",
+			input:  `non_secret_val + non_secret_val`,
+			expect: alloytypes.Secret("worldworld"),
+		},
+		{
+			name:   "capsule (optionalsecret(true)) + capsule (optionalsecret(false))",
+			input:  `secret_val + non_secret_val`,
+			expect: alloytypes.Secret("secretworld"),
+		},
+		{
+			name:   "capsule (optionalsecret(false)) + capsule (optionalsecret(true))",
+			input:  `non_secret_val + secret_val`,
+			expect: alloytypes.Secret("worldsecret"),
+		},
+		{
+			name:   "capsule (optionalsecret(false)) + secret",
+			input:  `non_secret_val + secret_type_val`,
+			expect: alloytypes.Secret("worldwelcome"),
+		},
+		{
+			name:   "capsule (secret) + string",
+			input:  `secret_type_val + string_val`,
+			expect: alloytypes.Secret("welcomehello"),
+		},
+		{
+			name:   "capsule (secret) + capsule (optionalsecret(false))",
+			input:  `secret_type_val + non_secret_val`,
+			expect: alloytypes.Secret("welcomeworld"),
+		},
+		{
+			name:   "capsule (secret) + capsule (optionalsecret(true))",
+			input:  `secret_type_val + secret_val`,
+			expect: alloytypes.Secret("welcomesecret"),
+		},
+		{
+			name:   "capsule (secret) + capsule (secret)",
+			input:  `secret_type_val + secret_type_val`,
+			expect: alloytypes.Secret("welcomewelcome"),
+		},
+		{
+			name:  "string + capsule (optionalsecret(true))",
 			input: `string_val + secret_val`,
 			expect: alloytypes.OptionalSecret{
 				Value: "hellosecret", IsSecret: true,
 			},
 		},
 		{
-			name:   "secret + string",
-			input:  `non_secret_val + string_val`,
-			expect: string("worldhello"),
-		},
-		{
-			name:   "string + secret",
+			name:   "string + capsule (optionalsecret(false))",
 			input:  `string_val + non_secret_val`,
 			expect: string("helloworld"),
 		},
@@ -96,6 +137,11 @@ func TestVM_OptionalSecret_Conversion(t *testing.T) {
 			name:   "string + string",
 			input:  `string_val + string_val`,
 			expect: string("hellohello"),
+		},
+		{
+			name:   "string + capsule (secret)",
+			input:  `string_val + secret_type_val`,
+			expect: alloytypes.Secret("hellowelcome"),
 		},
 	}
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Adds string concatenation for the secrets type

#### Which issue(s) this PR fixes
Fixes #1514

#### Note to reviewers
I am not sure why we have `secrets` and `optionalsecrets`. I believe secrets was the older implementation. Hence i skipped adding this functionality on the secrets type. Let me know if we have to add this to the secrets type it is easily extendable.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
