### PR TITLE
dbo11y: fix handling of truncated queries with comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Main (unreleased)
   - Use SUM_LOCK_TIME and SUM_CPU_TIME with mysql >= 8.0.28
   - Fix query on perf_schema.events_statements_summary_by_digest
 
+- (_Experimental_) Various changes to the experimental component `database_observability.mysql`:
+  - `query_sample`: better handling of truncated queries (@cristiangreco)
+
 ### Bugfixes
 
 - Fixed an issue where some exporters such as `prometheus.exporter.snmp` couldn't accept targets from other components
@@ -35,7 +38,7 @@ v1.7.0
 - Remove `tls_basic_auth_config_path` attribute from `prometheus.exporter.mongodb` configuration as it does not configure TLS client
   behavior as previously documented.
 
-- Remove `encoding` and `encoding_file_ext` from `otelcol.exporter.awss3` component as it was not wired in to the otel component and 
+- Remove `encoding` and `encoding_file_ext` from `otelcol.exporter.awss3` component as it was not wired in to the otel component and
   Alloy does not currently integrate the upstream encoding extensions that this would utilize.
 
 ### Features
@@ -43,7 +46,7 @@ v1.7.0
 - Add a `otelcol.receiver.tcplog` component to receive OpenTelemetry logs over a TCP connection. (@nosammai)
 
 - (_Public preview_) Add `otelcol.receiver.filelog` component to read otel log entries from files (@dehaansa)
-  
+
 - (_Public preview_) Add a `otelcol.processor.cumulativetodelta` component to convert metrics from
   cumulative temporality to delta. (@madaraszg-tulip)
 
@@ -56,12 +59,12 @@ v1.7.0
 ### Enhancements
 
 - Upgrade to OpenTelemetry Collector v0.119.0 (@dehaansa):
-  - `otelcol.processor.resourcedetection`: additional configuration for the `ec2` detector to configure retry behavior 
+  - `otelcol.processor.resourcedetection`: additional configuration for the `ec2` detector to configure retry behavior
   - `otelcol.processor.resourcedetection`: additional configuration for the `gcp` detector to collect Managed Instance Group attributes
   - `otelcol.processor.resourcedetection`: additional configuration for the `eks` detector to collect cloud account attributes
   - `otelcol.processor.resourcedetection`: add `kubeadm` detector to collect local cluster attributes
   - `otelcol.processor.cumulativetodelta`: add `metric_types` filtering options
-  - `otelcol.exporter.awss3`: support configuring sending_queue behavior 
+  - `otelcol.exporter.awss3`: support configuring sending_queue behavior
   - `otelcol.exporter.otlphttp`: support configuring `compression_params`, which currently only includes `level`
   - `configtls`: opentelemetry components with tls config now support specifying TLS curve preferences
   - `sending_queue`: opentelemetry exporters with a `sending_queue` can now configure the queue to be `blocking`

--- a/internal/component/database_observability/mysql/collector/query_sample.go
+++ b/internal/component/database_observability/mysql/collector/query_sample.go
@@ -130,15 +130,19 @@ func (c *QuerySample) fetchQuerySamples(ctx context.Context) error {
 
 		if strings.HasSuffix(sampleText, "...") {
 			// best-effort attempt to detect truncated trailing comment
-			if idx := strings.LastIndex(sampleText, "/*"); idx >= 0 {
-				trailingPart := sampleText[idx:]
-				if strings.LastIndex(trailingPart, "*/") < 0 {
-					sampleText = sampleText[:idx]
-				}
-			} else {
+			idx := strings.LastIndex(sampleText, "/*")
+			if idx < 0 {
 				level.Debug(c.logger).Log("msg", "skipping parsing truncated query", "schema", schemaName, "digest", digest)
 				continue
 			}
+
+			trailingText := sampleText[idx:]
+			if strings.LastIndex(trailingText, "*/") >= 0 {
+				level.Debug(c.logger).Log("msg", "skipping parsing truncated query with comment", "schema", schemaName, "digest", digest)
+				continue
+			}
+
+			sampleText = sampleText[:idx]
 		}
 
 		stmt, err := ParseSql(sampleText)

--- a/internal/component/database_observability/mysql/collector/query_sample_test.go
+++ b/internal/component/database_observability/mysql/collector/query_sample_test.go
@@ -162,6 +162,18 @@ func TestQuerySample(t *testing.T) {
 			},
 		},
 		{
+			name: "truncated with properly closed comment",
+			rows: [][]driver.Value{{
+				"abc123",
+				"some_schema",
+				"select * from some_table where id = 1 /* comment that's closed */ and name = 'test...",
+				"2024-01-01T00:00:00.000Z",
+				"1000",
+			}},
+			logsLabels: []model.LabelSet{},
+			logsLines:  []string{},
+		},
+		{
 			name: "start transaction",
 			rows: [][]driver.Value{{
 				"abc123",


### PR DESCRIPTION
#### PR Description
With this change, we also skip parsing of queries that are truncated and have a comment that is properly closed. We will only attempt to parse queries that are truncated in the middle of a comment.

#### Which issue(s) this PR fixes
n.a.

#### Notes to the Reviewer

#### PR Checklist
- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
