### PR TITLE
update to latest walqueue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Main (unreleased)
   - Use SUM_LOCK_TIME and SUM_CPU_TIME with mysql >= 8.0.28
   - Fix query on perf_schema.events_statements_summary_by_digest
 
-- Added additional backwards compatibility metrics to`prometheus.write.queue`. (@mattdurham)
+- Added additional backwards compatibility metrics to `prometheus.write.queue`. (@mattdurham)
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,16 @@ Main (unreleased)
   - Fix database quoting problem in collector 'info_schema.tables'
   - Use SUM_LOCK_TIME and SUM_CPU_TIME with mysql >= 8.0.28
   - Fix query on perf_schema.events_statements_summary_by_digest
+- 
+- Added additional backwards compatibility metrics to`prometheus.write.queue`. (@mattdurham)
 
 ### Bugfixes
 
 - Fixed an issue where some exporters such as `prometheus.exporter.snmp` couldn't accept targets from other components
   with an error `conversion to '*map[string]string' is not supported"`. (@thampiotr)
+
+- Enable batching of calls to the appender in `prometheus.write.queue` to reduce lock contention when scraping, which 
+  will lead to reduced scrape duration. (@mattdurham)
 
 v1.7.0
 -----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Main (unreleased)
   - Fix database quoting problem in collector 'info_schema.tables'
   - Use SUM_LOCK_TIME and SUM_CPU_TIME with mysql >= 8.0.28
   - Fix query on perf_schema.events_statements_summary_by_digest
-- 
+
 - Added additional backwards compatibility metrics to`prometheus.write.queue`. (@mattdurham)
 
 ### Bugfixes

--- a/docs/sources/reference/components/prometheus/prometheus.write.queue.md
+++ b/docs/sources/reference/components/prometheus/prometheus.write.queue.md
@@ -181,6 +181,12 @@ They generally behave the same, but there are likely edge cases where they diffe
 * `prometheus_remote_write_wal_samples_appended_total` (counter): Total number of samples appended to the WAL.
 * `prometheus_remote_write_wal_storage_created_series_total` (counter): Total number of created series appended to the WAL.
 * `prometheus_remote_write_wal_storage_removed_series_total` (counter): Total number of series removed from the WAL.
+* `prometheus_remote_storage_bytes_total` (counter): Total number of bytes of data sent by queues after compression.
+* `prometheus_remote_storage_sent_bytes_total` (counter): Total number of bytes of data sent by queues after compression. (same as `prometheus_remote_storage_bytes_total`)
+* `prometheus_remote_storage_sent_batch_duration_seconds` (histogram): Duration of send calls to remote storage.
+* `prometheus_remote_storage_shards_max` (gauge): The maximum number of a shards a queue is allowed to run.
+* `prometheus_remote_storage_shards_min` (gauge): The minimum number of shards a queue is allowed to run.
+* `prometheus_remote_storage_shards` (gauge): The number of shards used for concurrent delivery of metrics to an endpoint.
 
 Metrics that are new to `prometheus.write.queue`. These are highly subject to change.
 

--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/grafana/snowflake-prometheus-exporter v0.0.0-20240813124544-9995e8354548
 	github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0
 	github.com/grafana/vmware_exporter v0.0.5-beta.0.20250218170317-73398ba08329
-	github.com/grafana/walqueue v0.0.0-20250222022458-49d08775d0f4
+	github.com/grafana/walqueue v0.0.0-20250226140916-7365e13bbede
 	github.com/hashicorp/consul/api v1.31.0
 	github.com/hashicorp/go-discover v0.0.0-20230724184603-e89ebd1b2f65
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1303,8 +1303,8 @@ github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0 h1:bjh0PVYSVVFxzINqPF
 github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0/go.mod h1:7t5XR+2IA8P2qggOAHTj/GCZfoLBle3OvNSYh1VkRBU=
 github.com/grafana/vmware_exporter v0.0.5-beta.0.20250218170317-73398ba08329 h1:Rs4H1yv2Abk3xE82qpyhMGGA8rswAOA0HQZde/BYkFo=
 github.com/grafana/vmware_exporter v0.0.5-beta.0.20250218170317-73398ba08329/go.mod h1:Z28219aViNlsLlPvuCnlgHDagRdZBAZ7JOnQg1b3eWg=
-github.com/grafana/walqueue v0.0.0-20250222022458-49d08775d0f4 h1:oEDouKyuO62LKR46nb/4Z1nKx2tcxLK9eLMmHJtNdwQ=
-github.com/grafana/walqueue v0.0.0-20250222022458-49d08775d0f4/go.mod h1:++oxbVcfnIzbSKHNxpO3WpQJG5ufmnwtBJqh5rvEmVo=
+github.com/grafana/walqueue v0.0.0-20250226140916-7365e13bbede h1:9xJHxsGrN7RPwXNPDSwmE6ivdJMRVnTRQITopBtxKik=
+github.com/grafana/walqueue v0.0.0-20250226140916-7365e13bbede/go.mod h1:++oxbVcfnIzbSKHNxpO3WpQJG5ufmnwtBJqh5rvEmVo=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grobie/gomemcache v0.0.0-20230213081705-239240bbc445 h1:FlKQKUYPZ5yDCN248M3R7x8yu2E3yEZ0H7aLomE4EoE=
 github.com/grobie/gomemcache v0.0.0-20230213081705-239240bbc445/go.mod h1:L69/dBlPQlWkcnU76WgcppK5e4rrxzQdi6LhLnK/ytA=

--- a/internal/component/prometheus/write/queue/component.go
+++ b/internal/component/prometheus/write/queue/component.go
@@ -65,7 +65,11 @@ func (s *Queue) Run(ctx context.Context) error {
 		}
 	}()
 	for _, ep := range s.endpoints {
-		ep.Start(ctx)
+		// If any of these fail to start thats a problem.
+		err := ep.Start(ctx)
+		if err != nil {
+			return err
+		}
 	}
 	<-ctx.Done()
 	return nil
@@ -110,7 +114,10 @@ func (s *Queue) Update(args component.Arguments) error {
 		if err != nil {
 			return err
 		}
-		end.Start(s.ctx)
+		err = end.Start(s.ctx)
+		if err != nil {
+			return err
+		}
 		s.endpoints[epCfg.Name] = end
 
 	}


### PR DESCRIPTION
Updates to the latest wal queue that fixes issue with high locking and introduces additional backwards compatibility. 
The descriptions from the metrics were taken from remote_write.

#### Notes to the Reviewer

#### PR Checklist


- [x] CHANGELOG.md updated
- [x] Documentation added

