### PR TITLE
`CI`: Move login-to-gar after image tag creation

### DIFF
--- a/.github/workflows/publish-alloy-devel.yml
+++ b/.github/workflows/publish-alloy-devel.yml
@@ -101,6 +101,10 @@ jobs:
         echo "$(bash ./tools/image-tag-docker)" > .tag-only
         echo "grafana/alloy-dev:$(bash ./tools/image-tag-docker)" > .image-tag
 
+      # This step needs to run after "Checkout code".
+      # That's because the login to GAR generates a new file.
+      # We don't want this file to end up in the repo directory.
+      # Then "tools/image-tag" would get confused because "git status" no longer reports a clean repo.
     - name: Log in to Google Artifact Registry
       uses: grafana/shared-workflows/actions/login-to-gar@login-to-gar-v0.2.2
       with:

--- a/.github/workflows/publish-alloy-devel.yml
+++ b/.github/workflows/publish-alloy-devel.yml
@@ -101,7 +101,7 @@ jobs:
         echo "$(bash ./tools/image-tag-docker)" > .tag-only
         echo "grafana/alloy-dev:$(bash ./tools/image-tag-docker)" > .image-tag
 
-      # This step needs to run after "Checkout code".
+      # This step needs to run after "Get the image tag".
       # That's because the login to GAR generates a new file.
       # We don't want this file to end up in the repo directory.
       # Then "tools/image-tag" would get confused because "git status" no longer reports a clean repo.

--- a/.github/workflows/publish-alloy-devel.yml
+++ b/.github/workflows/publish-alloy-devel.yml
@@ -102,7 +102,7 @@ jobs:
         echo "grafana/alloy-dev:$(bash ./tools/image-tag-docker)" > .image-tag
 
     - name: Log in to Google Artifact Registry
-      uses: grafana/shared-workflows/actions/login-to-gar@main
+      uses: grafana/shared-workflows/actions/login-to-gar@login-to-gar-v0.2.2
       with:
         registry: "us-docker.pkg.dev"
         environment: "prod"

--- a/.github/workflows/publish-alloy-devel.yml
+++ b/.github/workflows/publish-alloy-devel.yml
@@ -85,17 +85,6 @@ jobs:
     - publish_linux_boringcrypto_container
     steps:
 
-    - name: Log in to Google Artifact Registry
-      # This step needs to run before "Checkout code".
-      # That's because the login to GAR generates a new file.
-      # We don't want this file to end up in the repo directory.
-      # Then "tools/image-tag" would get confused because "git status" no longer reports a clean repo.
-      # TODO: Ask the platform team to rework the login to GAR to not generate such files?
-      uses: grafana/shared-workflows/actions/login-to-gar@main
-      with:
-        registry: "us-docker.pkg.dev"
-        environment: "prod"
-
     - name: Get Vault secrets
       uses: grafana/shared-workflows/actions/get-vault-secrets@main
       with:
@@ -111,6 +100,12 @@ jobs:
       run: |
         echo "$(bash ./tools/image-tag-docker)" > .tag-only
         echo "grafana/alloy-dev:$(bash ./tools/image-tag-docker)" > .image-tag
+
+    - name: Log in to Google Artifact Registry
+      uses: grafana/shared-workflows/actions/login-to-gar@main
+      with:
+        registry: "us-docker.pkg.dev"
+        environment: "prod"
 
     - name: Update to latest image
       run: |


### PR DESCRIPTION
#### PR Description

Moves the `login-to-gar` step after the image-tag is done, so the generated files won't interfere with git magic.

Also pins the version, according to the [latest docs](https://github.com/grafana/shared-workflows/tree/main/actions/login-to-gar).

#### Which issue(s) this PR fixes

[Failure on main](https://github.com/grafana/alloy/actions/runs/13543101477/job/37849440397).
