### PR TITLE
Live debugging prometheus.scrape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Main (unreleased)
 
 ### Enhancements
 
+- Add livedebugging support for `prometheus.scrape` (@ravishankar15, @wildum)
+
 - Have `loki.echo` log the `entry_timestamp` and `structured_metadata` for any loki entries received (@dehaansa)
 
 - Update mysqld_exporter to v0.17.1, most notable changes: (@cristiangreco)
@@ -221,8 +223,6 @@ v1.6.0
 - Add livedebugging support for discovery components (@ravishankar15)
 - Add livedebugging support for `discover.relabel` (@ravishankar15)
 - Performance optimization for live debugging feature (@ravishankar15)
-
-- Add livedebugging support for `prometheus.scrape` (@ravishankar15, @wildum)
 
 - Upgrade `github.com/goccy/go-json` to v0.10.4, which reduces the memory consumption of an Alloy instance by 20MB.
   If Alloy is running certain otelcol components, this reduction will not apply. (@ptodev)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,8 @@ v1.6.0
 - Add livedebugging support for `discover.relabel` (@ravishankar15)
 - Performance optimization for live debugging feature (@ravishankar15)
 
+- Add livedebugging support for `prometheus.scrape` (@ravishankar15, @wildum)
+
 - Upgrade `github.com/goccy/go-json` to v0.10.4, which reduces the memory consumption of an Alloy instance by 20MB.
   If Alloy is running certain otelcol components, this reduction will not apply. (@ptodev)
 - improve performance in regexp component: call fmt only if debug is enabled (@r0ka)

--- a/docs/sources/troubleshoot/debug.md
+++ b/docs/sources/troubleshoot/debug.md
@@ -113,6 +113,7 @@ Supported components:
 * `prometheus.remote_write`
 * `prometheus.relabel`
 * `discovery.*`
+* `prometheus.scrape`
 {{< /admonition >}}
 
 ## Debug using the UI

--- a/internal/component/prometheus/remotewrite/remote_write.go
+++ b/internal/component/prometheus/remotewrite/remote_write.go
@@ -130,7 +130,7 @@ func New(o component.Options, c Arguments) (*Component, error) {
 				ls.GetOrAddLink(res.opts.ID, uint64(newRef), l)
 			}
 			if res.debugDataPublisher.IsActive(componentID) {
-				res.debugDataPublisher.Publish(componentID, fmt.Sprintf("ts=%d, labels=%s, value=%f", t, l, v))
+				res.debugDataPublisher.Publish(componentID, fmt.Sprintf("sample: ts=%d, labels=%s, value=%f", t, l, v))
 			}
 			return globalRef, nextErr
 		}),
@@ -147,11 +147,11 @@ func New(o component.Options, c Arguments) (*Component, error) {
 			if res.debugDataPublisher.IsActive(componentID) {
 				var data string
 				if h != nil {
-					data = fmt.Sprintf("ts=%d, labels=%s, histogram=%s", t, l, h.String())
+					data = fmt.Sprintf("histogram: ts=%d, labels=%s, value=%s", t, l, h.String())
 				} else if fh != nil {
-					data = fmt.Sprintf("ts=%d, labels=%s, float_histogram=%s", t, l, fh.String())
+					data = fmt.Sprintf("float_histogram: ts=%d, labels=%s, value=%s", t, l, fh.String())
 				} else {
-					data = fmt.Sprintf("ts=%d, labels=%s, no_value", t, l)
+					data = fmt.Sprintf("histogram_with_no_value: ts=%d, labels=%s", t, l)
 				}
 				res.debugDataPublisher.Publish(componentID, data)
 			}
@@ -168,7 +168,7 @@ func New(o component.Options, c Arguments) (*Component, error) {
 				ls.GetOrAddLink(res.opts.ID, uint64(newRef), l)
 			}
 			if res.debugDataPublisher.IsActive(componentID) {
-				res.debugDataPublisher.Publish(componentID, fmt.Sprintf("labels=%s, type=%s, unit=%s, help=%s", l, m.Type, m.Unit, m.Help))
+				res.debugDataPublisher.Publish(componentID, fmt.Sprintf("metadata: labels=%s, type=%q, unit=%q, help=%q", l, m.Type, m.Unit, m.Help))
 			}
 			return globalRef, nextErr
 		}),
@@ -183,7 +183,7 @@ func New(o component.Options, c Arguments) (*Component, error) {
 				ls.GetOrAddLink(res.opts.ID, uint64(newRef), l)
 			}
 			if res.debugDataPublisher.IsActive(componentID) {
-				res.debugDataPublisher.Publish(componentID, fmt.Sprintf("ts=%d, labels=%s, exemplar_labels=%s, value=%f", e.Ts, l, e.Labels, e.Value))
+				res.debugDataPublisher.Publish(componentID, fmt.Sprintf("exemplar: ts=%d, labels=%s, exemplar_labels=%s, value=%f", e.Ts, l, e.Labels, e.Value))
 			}
 			return globalRef, nextErr
 		}),

--- a/internal/component/prometheus/scrape/scrape.go
+++ b/internal/component/prometheus/scrape/scrape.go
@@ -284,7 +284,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 				} else if fh != nil {
 					data = fmt.Sprintf("ts=%d, labels=%s, float_histogram=%s", t, l, fh.String())
 				} else {
-					data = fmt.Sprintf("ts=%d, labels=%s, no_value", t, l)
+					data = fmt.Sprintf("ts=%d, labels=%s, histogram_with_no_value", t, l)
 				}
 				c.debugDataPublisher.Publish(componentID, data)
 			}

--- a/internal/component/prometheus/scrape/scrape.go
+++ b/internal/component/prometheus/scrape/scrape.go
@@ -293,7 +293,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		prometheus.WithMetadataHook(func(globalRef storage.SeriesRef, l labels.Labels, m metadata.Metadata, next storage.Appender) (storage.SeriesRef, error) {
 			_, nextErr := next.UpdateMetadata(globalRef, l, m)
 			if c.debugDataPublisher.IsActive(componentID) {
-				c.debugDataPublisher.Publish(componentID, fmt.Sprintf("labels=%s, type=%s, unit=%s, help=%s", l, m.Type, m.Unit, m.Help))
+				c.debugDataPublisher.Publish(componentID, fmt.Sprintf("labels=%s, type=%q, unit=%q, help=%q", l, m.Type, m.Unit, m.Help))
 			}
 			return globalRef, nextErr
 		}),

--- a/internal/component/prometheus/scrape/scrape.go
+++ b/internal/component/prometheus/scrape/scrape.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/storage"
@@ -28,8 +29,11 @@ import (
 	"github.com/grafana/alloy/internal/service/cluster"
 	"github.com/grafana/alloy/internal/service/http"
 	"github.com/grafana/alloy/internal/service/labelstore"
+	"github.com/grafana/alloy/internal/service/livedebugging"
 	"github.com/grafana/alloy/internal/useragent"
 	"github.com/grafana/alloy/internal/util"
+	"github.com/prometheus/prometheus/model/exemplar"
+	"github.com/prometheus/prometheus/model/metadata"
 )
 
 func init() {
@@ -191,14 +195,22 @@ type Component struct {
 
 	dtMutex            sync.Mutex
 	distributedTargets *discovery.DistributedTargets
+
+	debugDataPublisher livedebugging.DebugDataPublisher
 }
 
 var (
-	_ component.Component = (*Component)(nil)
+	_ component.Component     = (*Component)(nil)
+	_ component.LiveDebugging = (*Component)(nil)
 )
 
 // New creates a new prometheus.scrape component.
 func New(o component.Options, args Arguments) (*Component, error) {
+	debugDataPublisher, err := o.GetServiceData(livedebugging.ServiceName)
+	if err != nil {
+		return nil, err
+	}
+
 	data, err := o.GetServiceData(http.ServiceName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get information about HTTP server: %w", err)
@@ -227,10 +239,6 @@ func New(o component.Options, args Arguments) (*Component, error) {
 	}
 
 	unregisterer := util.WrapWithUnregisterer(o.Registerer)
-	scraper, err := scrape.NewManager(scrapeOptions, o.Logger, alloyAppendable, unregisterer)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create scrape manager: %w", err)
-	}
 
 	targetsGauge := client_prometheus.NewGauge(client_prometheus.GaugeOpts{
 		Name: "prometheus_scrape_targets_gauge",
@@ -252,12 +260,61 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		opts:                o,
 		cluster:             clusterData,
 		reloadTargets:       make(chan struct{}, 1),
-		scraper:             scraper,
+		debugDataPublisher:  debugDataPublisher.(livedebugging.DebugDataPublisher),
 		appendable:          alloyAppendable,
 		targetsGauge:        targetsGauge,
 		movedTargetsCounter: movedTargetsCounter,
 		unregisterer:        unregisterer,
 	}
+	componentID := livedebugging.ComponentID(c.opts.ID)
+	interceptor := prometheus.NewInterceptor(alloyAppendable, ls,
+		prometheus.WithAppendHook(func(globalRef storage.SeriesRef, l labels.Labels, t int64, v float64, next storage.Appender) (storage.SeriesRef, error) {
+			localID := ls.GetLocalRefID(c.opts.ID, uint64(globalRef))
+			_, nextErr := next.Append(storage.SeriesRef(localID), l, t, v)
+			if c.debugDataPublisher.IsActive(componentID) {
+				c.debugDataPublisher.Publish(componentID, fmt.Sprintf("ts=%d, labels=%s, value=%f", t, l, v))
+			}
+			return globalRef, nextErr
+		}),
+		prometheus.WithHistogramHook(func(globalRef storage.SeriesRef, l labels.Labels, t int64, h *histogram.Histogram, fh *histogram.FloatHistogram, next storage.Appender) (storage.SeriesRef, error) {
+			localID := ls.GetLocalRefID(c.opts.ID, uint64(globalRef))
+			_, nextErr := next.AppendHistogram(storage.SeriesRef(localID), l, t, h, fh)
+			if c.debugDataPublisher.IsActive(componentID) {
+				var data string
+				if h != nil {
+					data = fmt.Sprintf("ts=%d, labels=%s, histogram=%s", t, l, h.String())
+				} else if fh != nil {
+					data = fmt.Sprintf("ts=%d, labels=%s, float_histogram=%s", t, l, fh.String())
+				} else {
+					data = fmt.Sprintf("ts=%d, labels=%s, no_value", t, l)
+				}
+				c.debugDataPublisher.Publish(componentID, data)
+			}
+			return globalRef, nextErr
+		}),
+		prometheus.WithMetadataHook(func(globalRef storage.SeriesRef, l labels.Labels, m metadata.Metadata, next storage.Appender) (storage.SeriesRef, error) {
+			localID := ls.GetLocalRefID(c.opts.ID, uint64(globalRef))
+			_, nextErr := next.UpdateMetadata(storage.SeriesRef(localID), l, m)
+			if c.debugDataPublisher.IsActive(componentID) {
+				c.debugDataPublisher.Publish(componentID, fmt.Sprintf("labels=%s, type=%s, unit=%s, help=%s", l, m.Type, m.Unit, m.Help))
+			}
+			return globalRef, nextErr
+		}),
+		prometheus.WithExemplarHook(func(globalRef storage.SeriesRef, l labels.Labels, e exemplar.Exemplar, next storage.Appender) (storage.SeriesRef, error) {
+			localID := ls.GetLocalRefID(c.opts.ID, uint64(globalRef))
+			_, nextErr := next.AppendExemplar(storage.SeriesRef(localID), l, e)
+			if c.debugDataPublisher.IsActive(componentID) {
+				c.debugDataPublisher.Publish(componentID, fmt.Sprintf("ts=%d, labels=%s, exemplar_labels=%s, value=%f", e.Ts, l, e.Labels, e.Value))
+			}
+			return globalRef, nextErr
+		}),
+	)
+
+	scraper, err := scrape.NewManager(scrapeOptions, o.Logger, interceptor, unregisterer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create scrape manager: %w", err)
+	}
+	c.scraper = scraper
 
 	// Call to Update() to set the receivers and targets once at the start.
 	if err := c.Update(args); err != nil {
@@ -505,3 +562,5 @@ func (c *Component) populatePromLabels(targets []discovery.Target, jobName strin
 
 	return allTargets
 }
+
+func (c *Component) LiveDebugging(_ int) {}

--- a/internal/component/prometheus/scrape/scrape.go
+++ b/internal/component/prometheus/scrape/scrape.go
@@ -269,16 +269,14 @@ func New(o component.Options, args Arguments) (*Component, error) {
 	componentID := livedebugging.ComponentID(c.opts.ID)
 	interceptor := prometheus.NewInterceptor(alloyAppendable, ls,
 		prometheus.WithAppendHook(func(globalRef storage.SeriesRef, l labels.Labels, t int64, v float64, next storage.Appender) (storage.SeriesRef, error) {
-			localID := ls.GetLocalRefID(c.opts.ID, uint64(globalRef))
-			_, nextErr := next.Append(storage.SeriesRef(localID), l, t, v)
+			_, nextErr := next.Append(globalRef, l, t, v)
 			if c.debugDataPublisher.IsActive(componentID) {
 				c.debugDataPublisher.Publish(componentID, fmt.Sprintf("ts=%d, labels=%s, value=%f", t, l, v))
 			}
 			return globalRef, nextErr
 		}),
 		prometheus.WithHistogramHook(func(globalRef storage.SeriesRef, l labels.Labels, t int64, h *histogram.Histogram, fh *histogram.FloatHistogram, next storage.Appender) (storage.SeriesRef, error) {
-			localID := ls.GetLocalRefID(c.opts.ID, uint64(globalRef))
-			_, nextErr := next.AppendHistogram(storage.SeriesRef(localID), l, t, h, fh)
+			_, nextErr := next.AppendHistogram(globalRef, l, t, h, fh)
 			if c.debugDataPublisher.IsActive(componentID) {
 				var data string
 				if h != nil {
@@ -293,16 +291,14 @@ func New(o component.Options, args Arguments) (*Component, error) {
 			return globalRef, nextErr
 		}),
 		prometheus.WithMetadataHook(func(globalRef storage.SeriesRef, l labels.Labels, m metadata.Metadata, next storage.Appender) (storage.SeriesRef, error) {
-			localID := ls.GetLocalRefID(c.opts.ID, uint64(globalRef))
-			_, nextErr := next.UpdateMetadata(storage.SeriesRef(localID), l, m)
+			_, nextErr := next.UpdateMetadata(globalRef, l, m)
 			if c.debugDataPublisher.IsActive(componentID) {
 				c.debugDataPublisher.Publish(componentID, fmt.Sprintf("labels=%s, type=%s, unit=%s, help=%s", l, m.Type, m.Unit, m.Help))
 			}
 			return globalRef, nextErr
 		}),
 		prometheus.WithExemplarHook(func(globalRef storage.SeriesRef, l labels.Labels, e exemplar.Exemplar, next storage.Appender) (storage.SeriesRef, error) {
-			localID := ls.GetLocalRefID(c.opts.ID, uint64(globalRef))
-			_, nextErr := next.AppendExemplar(storage.SeriesRef(localID), l, e)
+			_, nextErr := next.AppendExemplar(globalRef, l, e)
 			if c.debugDataPublisher.IsActive(componentID) {
 				c.debugDataPublisher.Publish(componentID, fmt.Sprintf("ts=%d, labels=%s, exemplar_labels=%s, value=%f", e.Ts, l, e.Labels, e.Value))
 			}

--- a/internal/component/prometheus/scrape/scrape.go
+++ b/internal/component/prometheus/scrape/scrape.go
@@ -271,7 +271,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		prometheus.WithAppendHook(func(globalRef storage.SeriesRef, l labels.Labels, t int64, v float64, next storage.Appender) (storage.SeriesRef, error) {
 			_, nextErr := next.Append(globalRef, l, t, v)
 			if c.debugDataPublisher.IsActive(componentID) {
-				c.debugDataPublisher.Publish(componentID, fmt.Sprintf("ts=%d, labels=%s, value=%f", t, l, v))
+				c.debugDataPublisher.Publish(componentID, fmt.Sprintf("ts=%d, type=histogram, labels=%s, value=%f", t, l, v))
 			}
 			return globalRef, nextErr
 		}),

--- a/internal/component/prometheus/scrape/scrape.go
+++ b/internal/component/prometheus/scrape/scrape.go
@@ -528,7 +528,7 @@ func (c *Component) newInterceptor(ls labelstore.LabelStore) *prometheus.Interce
 		prometheus.WithAppendHook(func(globalRef storage.SeriesRef, l labels.Labels, t int64, v float64, next storage.Appender) (storage.SeriesRef, error) {
 			_, nextErr := next.Append(globalRef, l, t, v)
 			if c.debugDataPublisher.IsActive(componentID) {
-				c.debugDataPublisher.Publish(componentID, fmt.Sprintf("ts=%d, type=histogram, labels=%s, value=%f", t, l, v))
+				c.debugDataPublisher.Publish(componentID, fmt.Sprintf("sample: ts=%d, labels=%s, value=%f", t, l, v))
 			}
 			return globalRef, nextErr
 		}),
@@ -537,11 +537,11 @@ func (c *Component) newInterceptor(ls labelstore.LabelStore) *prometheus.Interce
 			if c.debugDataPublisher.IsActive(componentID) {
 				var data string
 				if h != nil {
-					data = fmt.Sprintf("ts=%d, labels=%s, histogram=%s", t, l, h.String())
+					data = fmt.Sprintf("histogram: ts=%d, labels=%s, value=%s", t, l, h.String())
 				} else if fh != nil {
-					data = fmt.Sprintf("ts=%d, labels=%s, float_histogram=%s", t, l, fh.String())
+					data = fmt.Sprintf("float_histogram: ts=%d, labels=%s, value=%s", t, l, fh.String())
 				} else {
-					data = fmt.Sprintf("ts=%d, labels=%s, histogram_with_no_value", t, l)
+					data = fmt.Sprintf("histogram_with_no_value: ts=%d, labels=%s", t, l)
 				}
 				c.debugDataPublisher.Publish(componentID, data)
 			}
@@ -550,14 +550,14 @@ func (c *Component) newInterceptor(ls labelstore.LabelStore) *prometheus.Interce
 		prometheus.WithMetadataHook(func(globalRef storage.SeriesRef, l labels.Labels, m metadata.Metadata, next storage.Appender) (storage.SeriesRef, error) {
 			_, nextErr := next.UpdateMetadata(globalRef, l, m)
 			if c.debugDataPublisher.IsActive(componentID) {
-				c.debugDataPublisher.Publish(componentID, fmt.Sprintf("labels=%s, type=%q, unit=%q, help=%q", l, m.Type, m.Unit, m.Help))
+				c.debugDataPublisher.Publish(componentID, fmt.Sprintf("metadata: labels=%s, type=%q, unit=%q, help=%q", l, m.Type, m.Unit, m.Help))
 			}
 			return globalRef, nextErr
 		}),
 		prometheus.WithExemplarHook(func(globalRef storage.SeriesRef, l labels.Labels, e exemplar.Exemplar, next storage.Appender) (storage.SeriesRef, error) {
 			_, nextErr := next.AppendExemplar(globalRef, l, e)
 			if c.debugDataPublisher.IsActive(componentID) {
-				c.debugDataPublisher.Publish(componentID, fmt.Sprintf("ts=%d, labels=%s, exemplar_labels=%s, value=%f", e.Ts, l, e.Labels, e.Value))
+				c.debugDataPublisher.Publish(componentID, fmt.Sprintf("exemplar: ts=%d, labels=%s, exemplar_labels=%s, value=%f", e.Ts, l, e.Labels, e.Value))
 			}
 			return globalRef, nextErr
 		}),

--- a/internal/component/prometheus/scrape/scrape_clustering_test.go
+++ b/internal/component/prometheus/scrape/scrape_clustering_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/grafana/alloy/internal/service/cluster"
 	"github.com/grafana/alloy/internal/service/http"
 	"github.com/grafana/alloy/internal/service/labelstore"
+	"github.com/grafana/alloy/internal/service/livedebugging"
 	"github.com/grafana/alloy/internal/util"
 	"github.com/grafana/alloy/internal/util/assertmetrics"
 	"github.com/grafana/alloy/internal/util/testappender"
@@ -213,6 +214,8 @@ func testOptions(t *testing.T, alloyMetricsReg *client.Registry, fakeCluster *fa
 				return fakeCluster, nil
 			case labelstore.ServiceName:
 				return labelstore.New(nil, alloyMetricsReg), nil
+			case livedebugging.ServiceName:
+				return livedebugging.NewLiveDebugging(), nil
 			default:
 				return nil, fmt.Errorf("service %q does not exist", name)
 			}

--- a/internal/component/prometheus/scrape/scrape_test.go
+++ b/internal/component/prometheus/scrape/scrape_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/grafana/alloy/internal/service/cluster"
 	http_service "github.com/grafana/alloy/internal/service/http"
 	"github.com/grafana/alloy/internal/service/labelstore"
+	"github.com/grafana/alloy/internal/service/livedebugging"
 	"github.com/grafana/alloy/internal/util"
 	"github.com/grafana/alloy/syntax"
 )
@@ -133,6 +134,8 @@ func TestForwardingToAppendable(t *testing.T) {
 				return cluster.Mock(), nil
 			case labelstore.ServiceName:
 				return labelstore.New(nil, prometheus_client.DefaultRegisterer), nil
+			case livedebugging.ServiceName:
+				return livedebugging.NewLiveDebugging(), nil
 			default:
 				return nil, fmt.Errorf("service %q does not exist", name)
 			}
@@ -239,6 +242,8 @@ func TestCustomDialer(t *testing.T) {
 				return cluster.Mock(), nil
 			case labelstore.ServiceName:
 				return labelstore.New(nil, prometheus_client.DefaultRegisterer), nil
+			case livedebugging.ServiceName:
+				return livedebugging.NewLiveDebugging(), nil
 
 			default:
 				return nil, fmt.Errorf("service %q does not exist", name)


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This adds live debugging to the prometheus.scrape component.

Credits also go to @ravishankar15 who worked on the feature in this PR: https://github.com/grafana/alloy/pull/2298. I created a different PR to fix a bug and test it in different envs. 

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
#1031

#### Notes to the Reviewer

It uses a Prometheus interceptor, just like the remote write component, to access the metrics that are passing through.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [na] Tests updated
- [na] Config converters updated
