### PR TITLE
fix: Update OTEL_VERSION used in links in docs

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -5,7 +5,7 @@ description: Grafana Alloy is a vendor-neutral distribution of the OTel Collecto
 weight: 350
 cascade:
   ALLOY_RELEASE: v1.8.0
-  OTEL_VERSION: v0.116.0
+  OTEL_VERSION: v0.119.0
   PROM_WIN_EXP_VERSION: v0.27.3
   SNMP_VERSION: v0.27.0
   FULL_PRODUCT_NAME: Grafana Alloy

--- a/docs/sources/_index.md.t
+++ b/docs/sources/_index.md.t
@@ -5,7 +5,7 @@ description: Grafana Alloy is a vendor-neutral distribution of the OTel Collecto
 weight: 350
 cascade:
   ALLOY_RELEASE: $ALLOY_VERSION
-  OTEL_VERSION: v0.116.0
+  OTEL_VERSION: v0.119.0
   PROM_WIN_EXP_VERSION: v0.27.3
   SNMP_VERSION: v0.27.0
   FULL_PRODUCT_NAME: Grafana Alloy


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
When updating otel for release 1.7.0, I missed updating the variable that is used for docs links.
