### PR TITLE
pyroscpoe.scrape: collect delta map sizes metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Main (unreleased)
 
 - Add support for proxy and headers in `prometheus.write.queue`. (@mattdurham)
 
+- Add `pyroscope_delta_map_size` metric to `pyroscope.scrape` component. (@korniltsev)
+
 v1.7.1
 -----------------
 

--- a/internal/component/pyroscope/scrape/delta_metric_collector.go
+++ b/internal/component/pyroscope/scrape/delta_metric_collector.go
@@ -1,0 +1,49 @@
+package scrape
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type deltaMetricCollector struct {
+	manager *Manager
+	desc    *prometheus.Desc
+	label   string
+}
+
+func newDeltaMetricCollector(manager *Manager) *deltaMetricCollector {
+	return &deltaMetricCollector{
+		manager: manager,
+		desc:    prometheus.NewDesc("pyroscope_delta_map_size", "Size of the DeltaMap", []string{"aggregation"}, nil),
+		label:   "namespace",
+	}
+}
+
+func (d *deltaMetricCollector) Describe(descs chan<- *prometheus.Desc) {
+	descs <- d.desc
+}
+
+func (d *deltaMetricCollector) Collect(metrics chan<- prometheus.Metric) {
+	m := d.manager
+	m.mtxScrape.Lock()
+	defer m.mtxScrape.Unlock()
+
+	aggregation := make(map[string]int64)
+	for _, sp := range m.targetsGroups {
+		loops := sp.activeScrapeLoops()
+		for _, loop := range loops {
+			if da, ok := loop.appender.(*deltaAppender); ok {
+				size := da.deltaMapSize()
+				k := loop.Target.allLabels.Get(d.label)
+				aggregation[k] += int64(size)
+			}
+		}
+	}
+
+	for namespace, size := range aggregation {
+		metric, err := prometheus.NewConstMetric(d.desc, prometheus.GaugeValue, float64(size), namespace)
+		if err != nil {
+			continue
+		}
+		metrics <- metric
+	}
+}

--- a/internal/component/pyroscope/scrape/delta_profiles_manager_test.go
+++ b/internal/component/pyroscope/scrape/delta_profiles_manager_test.go
@@ -1,0 +1,178 @@
+package scrape
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log/level"
+	"github.com/grafana/alloy/internal/component/pyroscope"
+	"github.com/grafana/alloy/internal/util"
+	googlev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+func TestDeltaProfilesManager(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
+
+	reloadInterval = time.Millisecond
+	defer func() {
+		reloadInterval = 5 * time.Second
+	}()
+	var servers []*httptest.Server
+	var serverAddresses []string
+	p1 := newMemoryProfile(0, (15 * time.Second).Nanoseconds())
+	p2 := newMemoryProfile(int64(15*time.Second), (15 * time.Second).Nanoseconds())
+	p2.Sample[0].Value[0] += 10
+
+	for i := range []int{0, 1, 2} {
+		server := httptest.NewServer(&sliceProfileHandler{
+			t: t,
+			profiles: map[string][]*googlev1.Profile{
+				"/debug/pprof/allocs": {p1, p1, p2},
+			},
+		})
+
+		t.Logf("Created server %d for  at %s", i, server.URL)
+		servers = append(servers, server)
+		serverAddresses = append(serverAddresses, server.URL)
+	}
+
+	defer func() {
+		for _, server := range servers {
+			server.Close()
+		}
+	}()
+
+	registry := prometheus.NewRegistry()
+	appendedProfiles := make(chan *pyroscope.RawSample, 100)
+	logger := util.TestLogger(t)
+	logger = level.NewFilter(logger, level.AllowAll())
+	m := NewManager(Options{}, pyroscope.AppendableFunc(func(ctx context.Context, lbs labels.Labels, samples []*pyroscope.RawSample) error {
+		t.Logf("Appending %d samples with labels: %v", len(samples), lbs)
+		for _, sample := range samples {
+			select {
+			case appendedProfiles <- sample:
+			default:
+				t.Logf("Failed to send sample to channel")
+			}
+		}
+		return nil
+	}), logger, registry)
+	defer m.Stop()
+
+	a := NewDefaultArguments()
+	a.ScrapeInterval = 1 * time.Second
+	a.ProfilingConfig.ProcessCPU.Enabled = false
+	a.ProfilingConfig.Goroutine.Enabled = false
+	a.ProfilingConfig.Block.Enabled = false
+	a.ProfilingConfig.Mutex.Enabled = false
+	require.NoError(t, m.ApplyConfig(a))
+
+	targetSetsChan := make(chan map[string][]*targetgroup.Group)
+	go m.Run(targetSetsChan)
+
+	var targets []model.LabelSet
+	for i, serverURL := range serverAddresses {
+		targets = append(targets, model.LabelSet{
+			model.AddressLabel: model.LabelValue(strings.TrimPrefix(serverURL, "http://")),
+			serviceNameLabel:   model.LabelValue(fmt.Sprintf("service-%d", i)),
+			"namespace":        model.LabelValue(fmt.Sprintf("namespace-%d", i)),
+		})
+	}
+
+	targetSetsChan <- map[string][]*targetgroup.Group{"profile_group": {{Targets: targets}}}
+
+	require.Eventually(t, func() bool {
+		gs := m.TargetsActive()
+		t.Logf("Active targets: %v", gs)
+		return len(gs["profile_group"]) == 3
+	}, time.Second, 10*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		count := len(appendedProfiles)
+		expected := len(serverAddresses) * 2
+		return count == expected
+	}, 15*time.Second, 100*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		metrics, err := registry.Gather()
+		if err != nil {
+			t.Logf("Error gathering metrics: %v", err)
+			return false
+		}
+
+		for _, metric := range metrics {
+			if metric.GetName() == "pyroscope_delta_map_size" {
+				return len(metric.GetMetric()) > 0
+			}
+		}
+		t.Logf("pyroscope_delta_map_size metric not found")
+		return false
+	}, 2*time.Second, 100*time.Millisecond)
+
+	metricFamilies, err := registry.Gather()
+	require.NoError(t, err)
+
+	var deltaMapSizeMetric *dto.MetricFamily
+	for _, mf := range metricFamilies {
+		if mf.GetName() == "pyroscope_delta_map_size" {
+			deltaMapSizeMetric = mf
+			break
+		}
+	}
+	require.NotNil(t, deltaMapSizeMetric, "pyroscope_delta_map_size metric not found")
+
+	expected := map[string]float64{
+		"namespace-0": 1.0,
+		"namespace-1": 1.0,
+		"namespace-2": 1.0,
+	}
+	actual := map[string]float64{}
+	for _, m := range deltaMapSizeMetric.GetMetric() {
+		for _, label := range m.GetLabel() {
+			ns := label.GetValue()
+			if label.GetName() == "aggregation" {
+				v := m.GetGauge().GetValue()
+				actual[ns] = v
+				require.Greater(t, v, 0.0, "Delta map size should be greater than 0")
+				t.Logf("Delta map size : %v %v", ns, v)
+			}
+		}
+	}
+	require.Equal(t, expected, actual, "Delta map size metrics should match expected values")
+}
+
+type sliceProfileHandler struct {
+	t         *testing.T
+	profileMu sync.Mutex
+	profiles  map[string][]*googlev1.Profile
+}
+
+func (d *sliceProfileHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	d.profileMu.Lock()
+	defer d.profileMu.Unlock()
+
+	u := r.URL
+	ps := d.profiles[u.Path]
+	if len(ps) == 0 {
+		w.WriteHeader(404)
+		return
+	}
+	p := ps[0]
+	d.profiles[u.Path] = ps[1:]
+
+	data := marshal(d.t, p)
+	w.Write(data)
+}

--- a/internal/component/pyroscope/scrape/internal/fastdelta/fd.go
+++ b/internal/component/pyroscope/scrape/internal/fastdelta/fd.go
@@ -382,3 +382,12 @@ type valueType struct {
 	Type []byte
 	Unit []byte
 }
+
+// DeltaMapSize returns the number of entries in the underlying DeltaMap.
+// This can be used to monitor memory usage of the delta computer.
+func (dc *DeltaComputer) DeltaMapSize() int {
+	if dc.deltaMap == nil {
+		return 0
+	}
+	return len(dc.deltaMap.m)
+}

--- a/internal/component/pyroscope/scrape/manager_test.go
+++ b/internal/component/pyroscope/scrape/manager_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/grafana/alloy/internal/component/pyroscope"
 	"github.com/grafana/alloy/internal/util"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/model/labels"
@@ -21,7 +22,7 @@ func TestManager(t *testing.T) {
 
 	m := NewManager(Options{}, pyroscope.AppendableFunc(func(ctx context.Context, labels labels.Labels, samples []*pyroscope.RawSample) error {
 		return nil
-	}), util.TestLogger(t))
+	}), util.TestLogger(t), prometheus.NewRegistry())
 
 	defer m.Stop()
 	targetSetsChan := make(chan map[string][]*targetgroup.Group)

--- a/internal/component/pyroscope/scrape/scrape.go
+++ b/internal/component/pyroscope/scrape/scrape.go
@@ -274,7 +274,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 			config_util.WithDialContextFunc(httpData.DialFunc),
 		},
 	}
-	scraper := NewManager(scrapeHttpOptions, alloyAppendable, o.Logger)
+	scraper := NewManager(scrapeHttpOptions, alloyAppendable, o.Logger, o.Registerer)
 	c := &Component{
 		opts:          o,
 		cluster:       clusterData,

--- a/internal/component/pyroscope/scrape/scrape_loop.go
+++ b/internal/component/pyroscope/scrape/scrape_loop.go
@@ -144,6 +144,17 @@ func (tg *scrapePool) ActiveTargets() []*Target {
 	return result
 }
 
+func (tg *scrapePool) activeScrapeLoops() map[uint64]*scrapeLoop {
+	tg.mtx.RLock()
+	defer tg.mtx.RUnlock()
+
+	result := make(map[uint64]*scrapeLoop, len(tg.activeTargets))
+	for k, v := range tg.activeTargets {
+		result[k] = v
+	}
+	return result
+}
+
 type scrapeLoop struct {
 	*Target
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Introduce new `pyroscope_delta_map_size` metric reflecting the size of the `DeltaMap`s 

example:
```
pyroscope_delta_map_size{aggregation="alloy-ns",component_id="pyroscope.scrape.pyroscope",component_path="/"} 1174
pyroscope_delta_map_size{aggregation="pyroscope-ns",component_id="pyroscope.scrape.pyroscope",component_path="/"} 3670
```
#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->
The metric will help investigating who's consuming memory https://github.com/grafana/alloy/issues/2840
#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
