### PR TITLE
chore: Make build image actions matrix actions, and add filespace cleanup to create

### DIFF
--- a/.github/workflows/check-linux-build-image.yml
+++ b/.github/workflows/check-linux-build-image.yml
@@ -8,6 +8,11 @@ on:
 
 jobs:
   check-linux-build-image:
+    strategy:
+      matrix:
+        build:
+          - runtime: golang:1.24.0-alpine3.21
+          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.24.0-bookworm
     runs-on: ubuntu-22.04 # related to https://github.com/docker/setup-qemu-action/issues/198
     steps:
       - name: Checkout
@@ -37,36 +42,4 @@ jobs:
           push: false
           tags: grafana/alloy-build-image:latest
           build-args: |
-            GO_RUNTIME=golang:1.24.0-alpine3.21
-
-  check-linux-boringcrypto-build-image:
-    runs-on: ubuntu-22.04 # related to https://github.com/docker/setup-qemu-action/issues/198
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Remove unnecessary files
-        run: |
-            rm -rf /usr/share/dotnet
-            rm -rf "$AGENT_TOOLSDIRECTORY"
-            rm -rf /opt/ghc
-            rm -rf "/usr/local/share/boost"
-            rm -rf /opt/hostedtoolcache
-
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3.4.0
-        with:
-          image: tonistiigi/binfmt:qemu-v7.0.0-28 # https://github.com/docker/setup-qemu-action/issues/198
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Create test Linux build image for boring crypto
-        uses: docker/build-push-action@v6
-        with:
-          platforms: linux/amd64,linux/arm64
-          context: ./tools/build-image
-          push: false
-          tags: grafana/alloy-build-image:latest
-          build-args: |
-            GO_RUNTIME=mcr.microsoft.com/oss/go/microsoft/golang:1.24.0-bookworm
+            GO_RUNTIME=${{ matrix.build.runtime }}

--- a/.github/workflows/create_build_image.yml
+++ b/.github/workflows/create_build_image.yml
@@ -11,11 +11,25 @@ permissions:
 jobs:
   linux_build_image:
     name: Create a Linux build image
+    strategy:
+      matrix:
+        build:
+          - runtime: golang:1.24.0-alpine3.21
+          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.24.0-bookworm
+            suffix: "-boringcrypto"
     runs-on:
       labels: ubuntu-22.04 # related to https://github.com/docker/setup-qemu-action/issues/198
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+
+    - name: Remove unnecessary files
+      run: |
+          rm -rf /usr/share/dotnet
+          rm -rf "$AGENT_TOOLSDIRECTORY"
+          rm -rf /opt/ghc
+          rm -rf "/usr/local/share/boost"
+          rm -rf /opt/hostedtoolcache
 
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -27,7 +41,7 @@ jobs:
       env:
         FULL_TAG: ${{ github.ref_name }}
       id: get_image_version
-      run: echo "image_tag=${FULL_TAG##*/}" >> $GITHUB_OUTPUT
+      run: echo "image_tag=${FULL_TAG##*/}${{ matrix.build.suffix }}" >> $GITHUB_OUTPUT
 
     - name: Login to DockerHub (from vault)
       uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login-v1.0.1
@@ -47,44 +61,4 @@ jobs:
         context: ./tools/build-image
         tags: grafana/alloy-build-image:${{ steps.get_image_version.outputs.image_tag }}
         build-args: |
-          GO_RUNTIME=golang:1.24.0-alpine3.21
-
-  linux_build_image_boringcrypto:
-    name: Create a Linux build image for boringcrypto
-    runs-on:
-      labels: ubuntu-22.04 # related to https://github.com/docker/setup-qemu-action/issues/198
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: go.mod
-        cache: false
-
-    - name: Get version from Git tag
-      env:
-        FULL_TAG: ${{ github.ref_name }}
-      id: get_image_version
-      run: echo "image_tag=${FULL_TAG##*/}-boringcrypto" >> $GITHUB_OUTPUT
-
-    - name: Login to DockerHub (from vault)
-      uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login-v1.0.1
-
-    - name: Setup QEMU
-      uses: docker/setup-qemu-action@v3.4.0
-      with:
-        image: tonistiigi/binfmt:qemu-v7.0.0-28 # https://github.com/docker/setup-qemu-action/issues/198
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Create Linux build image
-      uses: docker/build-push-action@v6
-      with:
-        platforms: linux/amd64,linux/arm64
-        context: ./tools/build-image
-        tags: grafana/alloy-build-image:${{ steps.get_image_version.outputs.image_tag }}
-        build-args: |
-          GO_RUNTIME=mcr.microsoft.com/oss/go/microsoft/golang:1.24.0-bullseye
+          GO_RUNTIME=${{ matrix.build.runtime }}

--- a/.github/workflows/create_build_image.yml
+++ b/.github/workflows/create_build_image.yml
@@ -52,6 +52,7 @@ jobs:
       with:
         platforms: linux/amd64,linux/arm64
         context: ./tools/build-image
+        push: true
         tags: grafana/alloy-build-image:${{ steps.get_image_version.outputs.image_tag }}
         build-args: |
           GO_RUNTIME=${{ matrix.build.runtime }}

--- a/.github/workflows/create_build_image.yml
+++ b/.github/workflows/create_build_image.yml
@@ -17,8 +17,7 @@ jobs:
           - runtime: golang:1.24.0-alpine3.21
           - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.24.0-bookworm
             suffix: "-boringcrypto"
-    runs-on:
-      labels: ubuntu-22.04 # related to https://github.com/docker/setup-qemu-action/issues/198
+    runs-on: ubuntu-22.04 # related to https://github.com/docker/setup-qemu-action/issues/198
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -30,12 +29,6 @@ jobs:
           rm -rf /opt/ghc
           rm -rf "/usr/local/share/boost"
           rm -rf /opt/hostedtoolcache
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: go.mod
-        cache: false
 
     - name: Get version from Git tag
       env:


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
After the qemu fixes, the create job is running out of space https://github.com/grafana/alloy/actions/runs/13580297110 .

I deduplicated the actions for simplifying future updates, and cleaned up space on the create action.