### PR TITLE
[Helm chart] Add a new `automountServiceAccountToken` configuration value for `serviceAccount`

### DIFF
--- a/operations/helm/charts/alloy/CHANGELOG.md
+++ b/operations/helm/charts/alloy/CHANGELOG.md
@@ -14,6 +14,10 @@ Unreleased
 
 - Set resource namespace correctly (@shinebayar-g)
 
+### Enhancements
+
+- Add a new `automountServiceAccountToken` configuration value for `serviceAccount`. (@ptodev)
+
 0.12.1 (2025-02-26)
 ----------
 

--- a/operations/helm/charts/alloy/README.md
+++ b/operations/helm/charts/alloy/README.md
@@ -133,8 +133,8 @@ useful if just using the default DaemonSet isn't sufficient.
 | service.nodePort | int | `31128` | NodePort port. Only takes effect when `service.type: NodePort` |
 | service.type | string | `"ClusterIP"` | Service type |
 | serviceAccount.additionalLabels | object | `{}` | Additional labels to add to the created service account. |
-| serviceAccount.automountServiceAccountToken | bool | `true` | Whether the Alloy pod should automatically mount the service account token.
 | serviceAccount.annotations | object | `{}` | Annotations to add to the created service account. |
+| serviceAccount.automountServiceAccountToken | bool | `true` |  |
 | serviceAccount.create | bool | `true` | Whether to create a service account for the Grafana Alloy deployment. |
 | serviceAccount.name | string | `nil` | The name of the existing service account to use when serviceAccount.create is false. |
 | serviceMonitor.additionalLabels | object | `{}` | Additional labels for the service monitor. |

--- a/operations/helm/charts/alloy/README.md
+++ b/operations/helm/charts/alloy/README.md
@@ -133,6 +133,7 @@ useful if just using the default DaemonSet isn't sufficient.
 | service.nodePort | int | `31128` | NodePort port. Only takes effect when `service.type: NodePort` |
 | service.type | string | `"ClusterIP"` | Service type |
 | serviceAccount.additionalLabels | object | `{}` | Additional labels to add to the created service account. |
+| serviceAccount.automountServiceAccountToken | bool | `true` | Whether pods running as this service account should have an API token automatically mounted. |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the created service account. |
 | serviceAccount.create | bool | `true` | Whether to create a service account for the Grafana Alloy deployment. |
 | serviceAccount.name | string | `nil` | The name of the existing service account to use when serviceAccount.create is false. |

--- a/operations/helm/charts/alloy/README.md
+++ b/operations/helm/charts/alloy/README.md
@@ -133,7 +133,7 @@ useful if just using the default DaemonSet isn't sufficient.
 | service.nodePort | int | `31128` | NodePort port. Only takes effect when `service.type: NodePort` |
 | service.type | string | `"ClusterIP"` | Service type |
 | serviceAccount.additionalLabels | object | `{}` | Additional labels to add to the created service account. |
-| serviceAccount.automountServiceAccountToken | bool | `true` | Whether pods running as this service account should have an API token automatically mounted. |
+| serviceAccount.automountServiceAccountToken | bool | `true` | Whether the Alloy pod should automatically mount the service account token.
 | serviceAccount.annotations | object | `{}` | Annotations to add to the created service account. |
 | serviceAccount.create | bool | `true` | Whether to create a service account for the Grafana Alloy deployment. |
 | serviceAccount.name | string | `nil` | The name of the existing service account to use when serviceAccount.create is false. |

--- a/operations/helm/charts/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/charts/alloy/templates/serviceaccount.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "alloy.serviceAccountName" . }}
   namespace: {{ include "alloy.namespace" . }}

--- a/operations/helm/charts/alloy/values.yaml
+++ b/operations/helm/charts/alloy/values.yaml
@@ -152,6 +152,8 @@ serviceAccount:
   # -- The name of the existing service account to use when
   # serviceAccount.create is false.
   name: null
+  # Whether pods running as this service account should have an API token automatically mounted.
+  automountServiceAccountToken: true
 
 # Options for the extra controller used for config reloading.
 configReloader:

--- a/operations/helm/charts/alloy/values.yaml
+++ b/operations/helm/charts/alloy/values.yaml
@@ -152,7 +152,7 @@ serviceAccount:
   # -- The name of the existing service account to use when
   # serviceAccount.create is false.
   name: null
-  # Whether pods running as this service account should have an API token automatically mounted.
+  # Whether the Alloy pod should automatically mount the service account token.
   automountServiceAccountToken: true
 
 # Options for the extra controller used for config reloading.

--- a/operations/helm/tests/additional-serviceaccount-label/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/additional-serviceaccount-label/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/clustering/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/clustering/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/controller-deployment-pdb-max-unavailable/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/controller-deployment-pdb-max-unavailable/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/controller-deployment-pdb-min-available/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/controller-deployment-pdb-min-available/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/controller-statefulset-pdb-max-unavailable/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/controller-statefulset-pdb-max-unavailable/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/controller-statefulset-pdb-min-available/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/controller-statefulset-pdb-min-available/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/controller-volumes-extra/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/controller-volumes-extra/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/create-daemonset-hostnetwork/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-daemonset-hostnetwork/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/create-daemonset/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-daemonset/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/create-deployment-autoscaling/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-deployment-autoscaling/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/create-deployment/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-deployment/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/create-statefulset-autoscaling/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-statefulset-autoscaling/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/create-statefulset/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-statefulset/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/custom-config/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/custom-config/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/default-values/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/default-values/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/enable-servicemonitor-tls/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/enable-servicemonitor-tls/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/enable-servicemonitor/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/enable-servicemonitor/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/envFrom/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/envFrom/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/existing-config/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/existing-config/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/extra-env/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/extra-env/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/extra-manifests/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/extra-manifests/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/extra-ports/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/extra-ports/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/faro-ingress/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/faro-ingress/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/global-image-pullsecrets/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/global-image-pullsecrets/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/global-image-registry/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/global-image-registry/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/host-alias/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/host-alias/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/initcontainers/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/initcontainers/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/lifecycle-hooks/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/lifecycle-hooks/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/local-image-pullsecrets/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/local-image-pullsecrets/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/local-image-registry/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/local-image-registry/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/nodeselectors-and-tolerations/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/nodeselectors-and-tolerations/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/nonroot/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/nonroot/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/pod_annotations/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/pod_annotations/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/sidecars/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/sidecars/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/termination-grace-period/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/termination-grace-period/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/topologyspreadconstraints/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/topologyspreadconstraints/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default

--- a/operations/helm/tests/with-digests/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/with-digests/alloy/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: alloy
   namespace: default


### PR DESCRIPTION
#### PR Description

Some users may want to enable this for extra security.

#### Which issue(s) this PR fixes

Fixes #2758

#### Notes to the Reviewer

There was a similar change to the [Prometheus Helm charts](https://github.com/prometheus-community/helm-charts/pull/4170) too.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
