### PR TITLE
Fix mixed up descriptions for  `store` and `system_store` in the server block description

### DIFF
--- a/docs/sources/reference/config-blocks/http.md
+++ b/docs/sources/reference/config-blocks/http.md
@@ -29,12 +29,12 @@ The `http` block supports no arguments and is configured completely through inne
 
 The following blocks are supported inside the definition of `http`:
 
-Hierarchy                                 | Block                          | Description                                                   | Required
-------------------------------------------|--------------------------------|---------------------------------------------------------------|---------
-tls                                       | [tls][]                        | Define TLS settings for the HTTP server.                      | no
-tls > windows_certificate_filter          | [windows_certificate_filter][] | Configure Windows certificate store for all certificates.     | no
-tls > windows_certificate_filter > client | [client][]                     | Configure client certificates for Windows certificate filter. | no
-tls > windows_certificate_filter > server | [server][]                     | Configure server certificates for Windows certificate filter. | no
+| Hierarchy                                 | Block                          | Description                                                   | Required |
+| ----------------------------------------- | ------------------------------ | ------------------------------------------------------------- | -------- |
+| tls                                       | [tls][]                        | Define TLS settings for the HTTP server.                      | no       |
+| tls > windows_certificate_filter          | [windows_certificate_filter][] | Configure Windows certificate store for all certificates.     | no       |
+| tls > windows_certificate_filter > client | [client][]                     | Configure client certificates for Windows certificate filter. | no       |
+| tls > windows_certificate_filter > server | [server][]                     | Configure server certificates for Windows certificate filter. | no       |
 
 ### tls block
 
@@ -47,19 +47,19 @@ Similarly, if you remove the `tls` block and reload the configuration when {{< p
 To ensure all connections use TLS, configure the `tls` block before you start {{< param "PRODUCT_NAME" >}}.
 {{< /admonition >}}
 
-Name                | Type           | Description                                                      | Default          | Required
---------------------|----------------|------------------------------------------------------------------|------------------|--------------
-`cert_pem`          | `string`       | PEM data of the server TLS certificate.                          | `""`             | conditionally
-`cert_file`         | `string`       | Path to the server TLS certificate on disk.                      | `""`             | conditionally
-`key_pem`           | `string`       | PEM data of the server TLS key.                                  | `""`             | conditionally
-`key_file`          | `string`       | Path to the server TLS key on disk.                              | `""`             | conditionally
-`client_ca_pem`     | `string`       | PEM data of the client CA to validate requests against.          | `""`             | no
-`client_ca_file`    | `string`       | Path to the client CA file on disk to validate requests against. | `""`             | no
-`client_auth_type`  | `string`       | Client authentication to use.                                    | `"NoClientCert"` | no
-`cipher_suites`     | `list(string)` | Set of cipher suites to use.                                     | `[]`             | no
-`curve_preferences` | `list(string)` | Set of elliptic curves to use in a handshake.                    | `[]`             | no
-`min_version`       | `string`       | Oldest TLS version to accept from clients.                       | `""`             | no
-`max_version`       | `string`       | Newest TLS version to accept from clients.                       | `""`             | no
+| Name                | Type           | Description                                                      | Default          | Required      |
+| ------------------- | -------------- | ---------------------------------------------------------------- | ---------------- | ------------- |
+| `cert_pem`          | `string`       | PEM data of the server TLS certificate.                          | `""`             | conditionally |
+| `cert_file`         | `string`       | Path to the server TLS certificate on disk.                      | `""`             | conditionally |
+| `key_pem`           | `string`       | PEM data of the server TLS key.                                  | `""`             | conditionally |
+| `key_file`          | `string`       | Path to the server TLS key on disk.                              | `""`             | conditionally |
+| `client_ca_pem`     | `string`       | PEM data of the client CA to validate requests against.          | `""`             | no            |
+| `client_ca_file`    | `string`       | Path to the client CA file on disk to validate requests against. | `""`             | no            |
+| `client_auth_type`  | `string`       | Client authentication to use.                                    | `"NoClientCert"` | no            |
+| `cipher_suites`     | `list(string)` | Set of cipher suites to use.                                     | `[]`             | no            |
+| `curve_preferences` | `list(string)` | Set of elliptic curves to use in a handshake.                    | `[]`             | no            |
+| `min_version`       | `string`       | Oldest TLS version to accept from clients.                       | `""`             | no            |
+| `max_version`       | `string`       | Newest TLS version to accept from clients.                       | `""`             | no            |
 
 When the `tls` block is specified, arguments for the TLS certificate (using `cert_pem` or `cert_file`) and for the TLS key (using `key_pem` or `key_file`) are required.
 
@@ -88,36 +88,36 @@ The `cipher_suites` argument determines what cipher suites to use.
 If you don't provide cipher suite, a default list is used.
 The set of cipher suites specified may be from the following:
 
-Cipher                                          | Allowed in BoringCrypto builds
-------------------------------------------------|-------------------------------
-`TLS_RSA_WITH_AES_128_CBC_SHA`                  | no
-`TLS_RSA_WITH_AES_256_CBC_SHA`                  | no
-`TLS_RSA_WITH_AES_128_GCM_SHA256`               | yes
-`TLS_RSA_WITH_AES_256_GCM_SHA384`               | yes
-`TLS_AES_128_GCM_SHA256`                        | no
-`TLS_AES_256_GCM_SHA384`                        | no
-`TLS_CHACHA20_POLY1305_SHA256`                  | no
-`TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA`          | no
-`TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA`          | no
-`TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA`            | no
-`TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA`            | no
-`TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`       | yes
-`TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`       | yes
-`TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`         | yes
-`TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`         | yes
-`TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256`   | no
-`TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256` | no
+| Cipher                                          | Allowed in BoringCrypto builds |
+| ----------------------------------------------- | ------------------------------ |
+| `TLS_RSA_WITH_AES_128_CBC_SHA`                  | no                             |
+| `TLS_RSA_WITH_AES_256_CBC_SHA`                  | no                             |
+| `TLS_RSA_WITH_AES_128_GCM_SHA256`               | yes                            |
+| `TLS_RSA_WITH_AES_256_GCM_SHA384`               | yes                            |
+| `TLS_AES_128_GCM_SHA256`                        | no                             |
+| `TLS_AES_256_GCM_SHA384`                        | no                             |
+| `TLS_CHACHA20_POLY1305_SHA256`                  | no                             |
+| `TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA`          | no                             |
+| `TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA`          | no                             |
+| `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA`            | no                             |
+| `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA`            | no                             |
+| `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`       | yes                            |
+| `TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`       | yes                            |
+| `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`         | yes                            |
+| `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`         | yes                            |
+| `TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256`   | no                             |
+| `TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256` | no                             |
 
 The `curve_preferences` argument determines the set of elliptic curves to prefer during a handshake in preference order.
 If not provided, a default list is used.
 The set of elliptic curves specified may be from the following:
 
-Curve       | Allowed in BoringCrypto builds
-------------|-------------------------------
-`CurveP256` | yes
-`CurveP384` | yes
-`CurveP521` | yes
-`X25519`    | no
+| Curve       | Allowed in BoringCrypto builds |
+| ----------- | ------------------------------ |
+| `CurveP256` | yes                            |
+| `CurveP384` | yes                            |
+| `CurveP521` | yes                            |
+| `X25519`    | no                             |
 
 The `min_version` and `max_version` arguments determine the oldest and newest TLS version that's acceptable from clients.
 If you don't provide the min and max TLS version, a default value is used.
@@ -153,23 +153,23 @@ The `windows_certificate_filter` serves the certificate even if it isn't compati
 The `server` block is used to find the certificate to check the signer.
 If multiple certificates are found, the `windows_certificate_filter` chooses the certificate with the expiration farthest in the future.
 
-Name                  | Type           | Description                                                                                          | Default | Required
-----------------------|----------------|------------------------------------------------------------------------------------------------------|---------|---------
-`store`               | `string`       | Name of the system store to look for the server Certificate, for example, LocalMachine, CurrentUser. | `""`    | yes
-`system_store`        | `string`       | Name of the store to look for the server Certificate, for example, My, CA.                           | `""`    | yes
-`issuer_common_names` | `list(string)` | Issuer common names to check against.                                                                |         | no
-`template_id`         | `string`       | Server Template ID to match in ASN1 format, for example, "1.2.3".                                    | `""`    | no
-`refresh_interval`    | `string`       | How often to check for a new server certificate.                                                     | `"5m"`  | no
+| Name                  | Type           | Description                                                                                                | Default | Required |
+| --------------------- | -------------- | ---------------------------------------------------------------------------------------------------------- | ------- | -------- |
+| `store`               | `string`       | Name of the store to look for the server Certificate. For example, `MY` or `CA`.                           | `""`    | yes      |
+| `system_store`        | `string`       | Name of the system store to look for the server Certificate. For example, `LocalMachine` or `CurrentUser`. | `""`    | yes      |
+| `issuer_common_names` | `list(string)` | Issuer common names to check against.                                                                      |         | no       |
+| `refresh_interval`    | `string`       | How often to check for a new server certificate.                                                           | `"5m"`  | no       |
+| `template_id`         | `string`       | Server Template ID to match in ASN1 format, for example, "1.2.3".                                          | `""`    | no       |
 
 ### client block
 
 The `client` block is used to check the certificate presented to the server.
 
-Name                  | Type           | Description                                                       | Default | Required
-----------------------|----------------|-------------------------------------------------------------------|---------|---------
-`issuer_common_names` | `list(string)` | Issuer common names to check against.                             |         | no
-`subject_regex`       | `string`       | Regular expression to match Subject name.                         | `""`    | no
-`template_id`         | `string`       | Client Template ID to match in ASN1 format, for example, "1.2.3". | `""`    | no
+| Name                  | Type           | Description                                                       | Default | Required |
+| --------------------- | -------------- | ----------------------------------------------------------------- | ------- | -------- |
+| `issuer_common_names` | `list(string)` | Issuer common names to check against.                             |         | no       |
+| `subject_regex`       | `string`       | Regular expression to match Subject name.                         | `""`    | no       |
+| `template_id`         | `string`       | Client Template ID to match in ASN1 format, for example, "1.2.3". | `""`    | no       |
 
 [tls]: #tls-block
 [windows_certificate_filter]: #windows-certificate-filter-block


### PR DESCRIPTION
#### PR Description

Corrected mixed up argument descriptions for `store` and `system_store` in the server block description.

Lines 158 and 159 are where the critical fix was applied.

A general table format was applied at the same time.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #2901 

