### PR TITLE
fix more stdlib functions working with targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ Main (unreleased)
 
 - Fixed an issue where passing targets from some standard library functions was failing with `target::ConvertFrom` error. (@thampiotr)
 
+- Fixed `expected object or array, got capsule` errors that could be encountered when using targets with `coalesce` and
+  `array.combine_maps` functions. (@thampiotr)
+
 ### Other changes
 
 - Upgrading to Prometheus v2.55.1. (@ptodev)

--- a/internal/component/discovery/target_test.go
+++ b/internal/component/discovery/target_test.go
@@ -23,56 +23,56 @@ import (
 
 func TestUsingTargetCapsule(t *testing.T) {
 	type testCase struct {
-		name              string
-		inputTarget       map[string]string
-		expression        string
-		decodeInto        interface{}
-		decodedString     string
-		expectedEvalError string
+		name                  string
+		inputTarget           map[string]string
+		expression            string
+		decodeInto            interface{}
+		expectedDecodedString string
+		expectedEvalError     string
 	}
 
 	testCases := []testCase{
 		{
-			name:          "target to map of string -> string",
-			inputTarget:   map[string]string{"a1a": "beachfront avenue", "ice": "ice"},
-			expression:    "t",
-			decodeInto:    map[string]string{},
-			decodedString: `{"a1a"="beachfront avenue", "ice"="ice"}`,
+			name:                  "target to map of string -> string",
+			inputTarget:           map[string]string{"a1a": "beachfront avenue", "ice": "ice"},
+			expression:            "t",
+			decodeInto:            map[string]string{},
+			expectedDecodedString: `{"a1a"="beachfront avenue", "ice"="ice"}`,
 		},
 		{
-			name:          "target to map of string -> any",
-			inputTarget:   map[string]string{"a1a": "beachfront avenue", "ice": "ice"},
-			expression:    "t",
-			decodeInto:    map[string]any{},
-			decodedString: `{"a1a"="beachfront avenue", "ice"="ice"}`,
+			name:                  "target to map of string -> any",
+			inputTarget:           map[string]string{"a1a": "beachfront avenue", "ice": "ice"},
+			expression:            "t",
+			decodeInto:            map[string]any{},
+			expectedDecodedString: `{"a1a"="beachfront avenue", "ice"="ice"}`,
 		},
 		{
-			name:          "target to map of any -> any",
-			inputTarget:   map[string]string{"a1a": "beachfront avenue", "ice": "ice"},
-			expression:    "t",
-			decodeInto:    map[any]any{},
-			decodedString: `{"a1a"="beachfront avenue", "ice"="ice"}`,
+			name:                  "target to map of any -> any",
+			inputTarget:           map[string]string{"a1a": "beachfront avenue", "ice": "ice"},
+			expression:            "t",
+			decodeInto:            map[any]any{},
+			expectedDecodedString: `{"a1a"="beachfront avenue", "ice"="ice"}`,
 		},
 		{
-			name:          "target to map of string -> syntax.Value",
-			inputTarget:   map[string]string{"a1a": "beachfront avenue"},
-			expression:    "t",
-			decodeInto:    map[string]syntax.Value{},
-			decodedString: `{"a1a"="beachfront avenue"}`,
+			name:                  "target to map of string -> syntax.Value",
+			inputTarget:           map[string]string{"a1a": "beachfront avenue"},
+			expression:            "t",
+			decodeInto:            map[string]syntax.Value{},
+			expectedDecodedString: `{"a1a"="beachfront avenue"}`,
 		},
 		{
-			name:          "target indexing a string value",
-			inputTarget:   map[string]string{"a1a": "beachfront avenue", "hip": "hop"},
-			expression:    `t["hip"]`,
-			decodeInto:    "",
-			decodedString: `hop`,
+			name:                  "target indexing a string value",
+			inputTarget:           map[string]string{"a1a": "beachfront avenue", "hip": "hop"},
+			expression:            `t["hip"]`,
+			decodeInto:            "",
+			expectedDecodedString: `hop`,
 		},
 		{
-			name:          "target indexing a non-existing string value",
-			inputTarget:   map[string]string{"a1a": "beachfront avenue", "hip": "hop"},
-			expression:    `t["boom"]`,
-			decodeInto:    "",
-			decodedString: "<nil>",
+			name:                  "target indexing a non-existing string value",
+			inputTarget:           map[string]string{"a1a": "beachfront avenue", "hip": "hop"},
+			expression:            `t["boom"]`,
+			decodeInto:            "",
+			expectedDecodedString: "<nil>",
 		},
 		{
 			name:              "target indexing a value like an object field",
@@ -80,6 +80,34 @@ func TestUsingTargetCapsule(t *testing.T) {
 			expression:        `t.boom`,
 			decodeInto:        "",
 			expectedEvalError: `field "boom" does not exist`,
+		},
+		{
+			name:                  "targets passed to concat",
+			inputTarget:           map[string]string{"boom": "bap", "hip": "hop"},
+			expression:            `array.concat([t], [t])`,
+			decodeInto:            []Target{},
+			expectedDecodedString: `[{"boom"="bap", "hip"="hop"} {"boom"="bap", "hip"="hop"}]`,
+		},
+		{
+			name:                  "coalesce an empty target",
+			inputTarget:           map[string]string{},
+			expression:            `coalesce(t, [], t, {}, t, 123, t)`,
+			decodeInto:            []Target{},
+			expectedDecodedString: `123`,
+		},
+		{
+			name:                  "coalesce a non-empty target",
+			inputTarget:           map[string]string{"big": "bang"},
+			expression:            `coalesce([], {}, "", t, 321, [])`,
+			decodeInto:            []Target{},
+			expectedDecodedString: `{"big"="bang"}`,
+		},
+		{
+			name:                  "array.combine_maps with targets",
+			inputTarget:           map[string]string{"a": "a1", "b": "b1"},
+			expression:            `array.combine_maps([t, t], [{"a" = "a1", "c" = "c1"}, {"a" = "a2", "c" = "c2"}], ["a"])`,
+			decodeInto:            []Target{},
+			expectedDecodedString: `[map[a:a1 b:b1 c:c1] map[a:a1 b:b1 c:c1]]`,
 		},
 	}
 	for _, tc := range testCases {
@@ -95,7 +123,7 @@ func TestUsingTargetCapsule(t *testing.T) {
 			} else {
 				require.NoError(t, evalError)
 			}
-			require.Equal(t, tc.decodedString, fmt.Sprintf("%v", tc.decodeInto))
+			require.Equal(t, tc.expectedDecodedString, fmt.Sprintf("%v", tc.decodeInto))
 		})
 	}
 }

--- a/syntax/encoding/alloyjson/alloyjson.go
+++ b/syntax/encoding/alloyjson/alloyjson.go
@@ -287,12 +287,9 @@ func buildJSONValue(v value.Value) jsonValue {
 		return jsonValue{Type: "function", Value: v.Describe()}
 
 	case value.TypeCapsule:
-		if v.Implements(reflect.TypeFor[value.ConvertibleIntoCapsule]()) {
-			// Check if this capsule can be converted into Alloy object for more detailed description:
-			newVal := make(map[string]value.Value)
-			if err := v.ReflectAddr().Interface().(value.ConvertibleIntoCapsule).ConvertInto(&newVal); err == nil {
-				return tokenizeObject(value.Encode(newVal))
-			}
+		// Check if this capsule can be converted into Alloy object for more detailed description:
+		if newVal, ok := v.TryConvertToObject(); ok {
+			return tokenizeObject(value.Encode(newVal))
 		}
 		// Otherwise, describe the value
 		return jsonValue{Type: "capsule", Value: v.Describe()}

--- a/syntax/internal/stdlib/stdlib.go
+++ b/syntax/internal/stdlib/stdlib.go
@@ -18,15 +18,13 @@ import (
 	"github.com/grafana/alloy/syntax/internal/value"
 )
 
-// TODO: refactor the stdlib to have consistent naming between namespaces and identifiers.
-
 // ExperimentalIdentifiers contains the full name (namespace + identifier's name) of stdlib
 // identifiers that are considered "experimental".
 var ExperimentalIdentifiers = map[string]bool{
 	"array.combine_maps": true,
 }
 
-// These identifiers are deprecated in favour of the namespaced ones.
+// DeprecatedIdentifiers are deprecated in favour of the namespaced ones.
 var DeprecatedIdentifiers = map[string]interface{}{
 	"env":           os.Getenv,
 	"nonsensitive":  nonSensitive,
@@ -205,10 +203,6 @@ func concatMaps(left, right value.Value) (value.Value, error) {
 	return value.Object(res), nil
 }
 
-// Inputs:
-// args[0]: []map[string]string: lhs array
-// args[1]: []map[string]string: rhs array
-// args[2]: []string:            merge conditions
 var combineMaps = value.RawFunction(func(funcValue value.Value, args ...value.Value) (value.Value, error) {
 	if len(args) != 3 {
 		return value.Value{}, fmt.Errorf("combine_maps: expected 3 arguments, got %d", len(args))
@@ -228,15 +222,19 @@ var combineMaps = value.RawFunction(func(funcValue value.Value, args ...value.Va
 			}
 		}
 		for j := 0; j < args[i].Len(); j++ {
-			if args[i].Index(j).Type() != value.TypeObject {
-				return value.Null, value.ArgError{
-					Function: funcValue,
-					Argument: args[i].Index(j),
-					Index:    j,
-					Inner: value.TypeError{
-						Value:    args[i].Index(j),
-						Expected: value.TypeObject,
-					},
+			elem := args[i].Index(j)
+			// Check if elements are objects or are convertible to objects.
+			if elem.Type() != value.TypeObject {
+				if _, ok := elem.TryConvertToObject(); !ok {
+					return value.Null, value.ArgError{
+						Function: funcValue,
+						Argument: elem,
+						Index:    j,
+						Inner: value.TypeError{
+							Value:    elem,
+							Expected: value.TypeObject,
+						},
+					}
 				}
 			}
 		}
@@ -263,6 +261,14 @@ var combineMaps = value.RawFunction(func(funcValue value.Value, args ...value.Va
 		}
 	}
 
+	convertIfNeeded := func(v value.Value) value.Value {
+		if v.Type() != value.TypeObject {
+			obj, _ := v.TryConvertToObject() // no need to check result as arguments were validated earlier.
+			return value.Object(obj)
+		}
+		return v
+	}
+
 	// We cannot preallocate the size of the result array, because we don't know
 	// how well the merge is going to go. If none of the merge conditions are met,
 	// the result array will be empty.
@@ -270,8 +276,8 @@ var combineMaps = value.RawFunction(func(funcValue value.Value, args ...value.Va
 
 	for i := 0; i < args[0].Len(); i++ {
 		for j := 0; j < args[1].Len(); j++ {
-			left := args[0].Index(i)
-			right := args[1].Index(j)
+			left := convertIfNeeded(args[0].Index(i))
+			right := convertIfNeeded(args[1].Index(j))
 
 			join, err := shouldJoin(left, right, args[2])
 			if err != nil {
@@ -309,7 +315,7 @@ func yamlDecode(in string) (interface{}, error) {
 	return res, nil
 }
 
-func base64Decode(in string) (interface{}, error) {
+func base64Decode(in string) ([]byte, error) {
 	decoded, err := base64.StdEncoding.DecodeString(in)
 	if err != nil {
 		return nil, err
@@ -317,7 +323,7 @@ func base64Decode(in string) (interface{}, error) {
 	return decoded, nil
 }
 
-func base64URLDecode(in string) (interface{}, error) {
+func base64URLDecode(in string) ([]byte, error) {
 	decoded, err := base64.URLEncoding.DecodeString(in)
 	if err != nil {
 		return nil, err
@@ -325,17 +331,17 @@ func base64URLDecode(in string) (interface{}, error) {
 	return decoded, nil
 }
 
-func base64URLEncode(in string) (interface{}, error) {
+func base64URLEncode(in string) (string, error) {
 	encoded := base64.URLEncoding.EncodeToString([]byte(in))
 	return encoded, nil
 }
 
-func base64Encode(in string) (interface{}, error) {
+func base64Encode(in string) (string, error) {
 	encoded := base64.StdEncoding.EncodeToString([]byte(in))
 	return encoded, nil
 }
 
-func jsonPath(jsonString string, path string) (interface{}, error) {
+func jsonPath(jsonString string, path string) ([]interface{}, error) {
 	jsonPathExpr, err := jp.ParseString(path)
 	if err != nil {
 		return nil, err
@@ -360,13 +366,21 @@ var coalesce = value.RawFunction(func(funcValue value.Value, args ...value.Value
 		}
 
 		if !arg.Reflect().IsZero() {
-			if argType := value.AlloyType(arg.Reflect().Type()); (argType == value.TypeArray || argType == value.TypeObject) && arg.Len() == 0 {
+			argType := arg.Type()
+			// Check if it's a capsule that can be converted into an object and the object is empty.
+			if obj, ok := arg.TryConvertToObject(); ok && len(obj) == 0 {
+				continue
+			}
+			// Check if it's an array or an object that's empty.
+			if (argType == value.TypeArray || argType == value.TypeObject) && arg.Len() == 0 {
 				continue
 			}
 
+			// Else we found a non-empty argument.
 			return arg, nil
 		}
 	}
 
+	// Return the last arg if all are empty.
 	return args[len(args)-1], nil
 })

--- a/syntax/internal/stdlib/stdlib.go
+++ b/syntax/internal/stdlib/stdlib.go
@@ -203,6 +203,10 @@ func concatMaps(left, right value.Value) (value.Value, error) {
 	return value.Object(res), nil
 }
 
+// Inputs:
+// args[0]: []map[string]string: lhs array
+// args[1]: []map[string]string: rhs array
+// args[2]: []string:            merge conditions
 var combineMaps = value.RawFunction(func(funcValue value.Value, args ...value.Value) (value.Value, error) {
 	if len(args) != 3 {
 		return value.Value{}, fmt.Errorf("combine_maps: expected 3 arguments, got %d", len(args))

--- a/syntax/internal/value/value.go
+++ b/syntax/internal/value/value.go
@@ -272,6 +272,18 @@ func (v Value) ReflectAddr() reflect.Value {
 	return addrRV
 }
 
+// TryConvertToObject will try to convert v into an Alloy object in a map[string]Value form. Returns (object, true) if
+// successful or (nil, false) if conversion was not possible.
+func (v Value) TryConvertToObject() (map[string]Value, bool) {
+	if v.Type() == TypeCapsule && v.Implements(reflect.TypeFor[ConvertibleIntoCapsule]()) {
+		objVal := make(map[string]Value)
+		if err := v.ReflectAddr().Interface().(ConvertibleIntoCapsule).ConvertInto(&objVal); err == nil {
+			return objVal, true
+		}
+	}
+	return nil, false
+}
+
 // makeValue converts a reflect value into a Value, dereferencing any pointers or
 // interface{} values.
 func makeValue(v reflect.Value) Value {

--- a/syntax/vm/vm.go
+++ b/syntax/vm/vm.go
@@ -357,21 +357,18 @@ func (vm *Evaluator) evaluateExpr(scope *Scope, assoc map[value.Value]ast.Node, 
 
 		switch val.Type() {
 		case value.TypeCapsule:
-			if val.Implements(reflect.TypeFor[value.ConvertibleIntoCapsule]()) {
-				// Check if this capsule can be converted into Alloy object to get the required field
-				newVal := make(map[string]value.Value)
-				if err := val.ReflectAddr().Interface().(value.ConvertibleIntoCapsule).ConvertInto(&newVal); err == nil {
-					field, ok := newVal[expr.Name.Name]
-					if !ok {
-						return value.Null, diag.Diagnostic{
-							Severity: diag.SeverityLevelError,
-							StartPos: ast.StartPos(expr.Name).Position(),
-							EndPos:   ast.EndPos(expr.Name).Position(),
-							Message:  fmt.Sprintf("field %q does not exist", expr.Name.Name),
-						}
+			// Check if this capsule can be converted into Alloy object to get the required field
+			if newVal, ok := val.TryConvertToObject(); ok {
+				field, found := newVal[expr.Name.Name]
+				if !found {
+					return value.Null, diag.Diagnostic{
+						Severity: diag.SeverityLevelError,
+						StartPos: ast.StartPos(expr.Name).Position(),
+						EndPos:   ast.EndPos(expr.Name).Position(),
+						Message:  fmt.Sprintf("field %q does not exist", expr.Name.Name),
 					}
-					return field, nil
 				}
+				return field, nil
 			}
 			return value.Null, value.Error{
 				Value: val,
@@ -435,22 +432,19 @@ func (vm *Evaluator) evaluateExpr(scope *Scope, assoc map[value.Value]ast.Node, 
 			return field, nil
 
 		case value.TypeCapsule:
-			if val.Implements(reflect.TypeFor[value.ConvertibleIntoCapsule]()) {
-				// Check if this capsule can be converted into Alloy object to get the required field
-				newVal := make(map[string]value.Value)
-				if err := val.ReflectAddr().Interface().(value.ConvertibleIntoCapsule).ConvertInto(&newVal); err == nil {
-					// Objects are indexed with a string.
-					if idx.Type() != value.TypeString {
-						return value.Null, value.TypeError{Value: idx, Expected: value.TypeString}
-					}
-
-					field, ok := newVal[idx.Text()]
-					if !ok {
-						// If a key doesn't exist in an object accessed with [], return null.
-						return value.Null, nil
-					}
-					return field, nil
+			// Check if this capsule can be converted into Alloy object to get the required field
+			if newVal, ok := val.TryConvertToObject(); ok {
+				// Objects are indexed with a string.
+				if idx.Type() != value.TypeString {
+					return value.Null, value.TypeError{Value: idx, Expected: value.TypeString}
 				}
+
+				field, ok := newVal[idx.Text()]
+				if !ok {
+					// If a key doesn't exist in an object accessed with [], return null.
+					return value.Null, nil
+				}
+				return field, nil
 			}
 			return value.Null, value.Error{
 				Value: val,


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

- Fixes an issue with `coalesce` and `combine_maps` stdlib functions.
- Adds `val.TryConvertToObject()` to simplify code
- Adds tests and fixes some minor misc things in the code

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
