### PR TITLE
feat(pyroscope.write): Add labels validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ Main (unreleased)
   - `query_sample`: better handling of truncated queries (@cristiangreco)
   - `query_sample`: add option to use TiDB sql parser (@cristiangreco)
 
+- Add labels validation in `pyroscope.write` to prevent duplicate labels and invalid label names/values. (@marcsanmi)
+
 ### Breaking changes
 
 - Fixed the parsing of selections, application and network filter blocks for Beyla

--- a/internal/component/pyroscope/receive_http/receive_http.go
+++ b/internal/component/pyroscope/receive_http/receive_http.go
@@ -298,7 +298,7 @@ func (c *Component) shutdownServer() {
 	}
 }
 
-// rename __name__ to service_name
+// ensureServiceName ensures that the service_name label is set
 func ensureServiceName(lbls labels.Labels) labels.Labels {
 	builder := labels.NewBuilder(lbls)
 	originalName := lbls.Get(pyroscope.LabelName)

--- a/internal/component/pyroscope/write/write.go
+++ b/internal/component/pyroscope/write/write.go
@@ -498,14 +498,11 @@ func validateLabels(lbls labels.Labels) error {
 		}
 
 		// Skip label name validation for pyroscope reserved labels
-		if l.Name == pyroscope.LabelName {
-			lastLabelName = l.Name
-			continue
-		}
-
-		// Validate label name
-		if err := labelset.ValidateLabelName(l.Name); err != nil {
-			return fmt.Errorf("invalid label name: %w", err)
+		if l.Name != pyroscope.LabelName {
+			// Validate label name
+			if err := labelset.ValidateLabelName(l.Name); err != nil {
+				return fmt.Errorf("invalid label name: %w", err)
+			}
 		}
 
 		lastLabelName = l.Name

--- a/internal/component/pyroscope/write/write.go
+++ b/internal/component/pyroscope/write/write.go
@@ -309,6 +309,11 @@ func (f *fanOutClient) Appender() pyroscope.Appender {
 
 // Append implements the Appender interface.
 func (f *fanOutClient) Append(ctx context.Context, lbs labels.Labels, samples []*pyroscope.RawSample) error {
+	// Validate labels first
+	if err := validateLabels(lbs); err != nil {
+		return fmt.Errorf("invalid labels in profile: %w", err)
+	}
+
 	// todo(ctovena): we should probably pool the label pair arrays and label builder to avoid allocs.
 	var (
 		protoLabels  = make([]*typesv1.LabelPair, 0, len(lbs)+len(f.config.ExternalLabels))
@@ -377,6 +382,11 @@ func (f *fanOutClient) AppendIngest(ctx context.Context, profile *pyroscope.Inco
 				ls := labelset.New(make(map[string]string))
 
 				finalLabels := ensureNameMatchesService(profile.Labels)
+
+				if err := validateLabels(finalLabels); err != nil {
+					return fmt.Errorf("invalid labels in profile: %w", err)
+				}
+
 				finalLabels.Range(func(l labels.Label) {
 					ls.Add(l.Name, l.Value)
 				})
@@ -465,4 +475,37 @@ func ensureNameMatchesService(lbls labels.Labels) labels.Labels {
 		return builder.Labels()
 	}
 	return lbls
+}
+
+// validateLabels checks for valid labels and doesn't contain duplicates.
+func validateLabels(lbls labels.Labels) error {
+	if lbls.Len() == 0 {
+		return labelset.ErrServiceNameIsRequired
+	}
+
+	seen := make(map[string]struct{}, lbls.Len())
+
+	for _, l := range lbls {
+		if _, exists := seen[l.Name]; exists {
+			return fmt.Errorf("duplicate label name: %s", l.Name)
+		}
+		seen[l.Name] = struct{}{}
+
+		// Skip validation for reserved labels
+		if l.Name == pyroscope.LabelName {
+			continue
+		}
+
+		// Validate label name
+		if err := labelset.ValidateLabelName(l.Name); err != nil {
+			return fmt.Errorf("invalid label name: %w", err)
+		}
+
+		// Validate label value
+		if !model.LabelValue(l.Value).IsValid() {
+			return fmt.Errorf("invalid label value for %s: %s", l.Name, l.Value)
+		}
+	}
+
+	return nil
 }

--- a/internal/component/pyroscope/write/write_test.go
+++ b/internal/component/pyroscope/write/write_test.go
@@ -594,6 +594,15 @@ func Test_Write_FanOut_ValidateLabels(t *testing.T) {
 			errMsg:  labelset.ErrInvalidLabelName.Error(),
 		},
 		{
+			name: "duplicate reserved labels",
+			labels: labels.FromStrings(
+				"__name__", "test-service",
+				"__name__", "test-service-2",
+			),
+			wantErr: true,
+			errMsg:  "duplicate label name",
+		},
+		{
 			name: "invalid label value",
 			labels: labels.FromStrings(
 				"service_name", "test-service",


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR adds validation for labels in the `pyroscope.write` component to ensure compatibility with Pyroscope's validation requirements. The validation:

- Checks for duplicate labels
- Validates label names & values according to Pyroscope's standards

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->
https://github.com/grafana/pyroscope-squad/issues/357

#### Notes to the Reviewer

- I don't check for `service_name` label existence. As talked, as far as using the `receive_http`, this should come for free with our `ensureServiceName` function and also validated at pyroscope side.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
