### PR TITLE
build-image: add rust toolchains

### DIFF
--- a/tools/build-image/Dockerfile
+++ b/tools/build-image/Dockerfile
@@ -81,14 +81,19 @@ RUN corepack enable
 #
 # NOTE(rfratto): musl is installed so the Docker binaries from alpine work
 # properly.
-RUN apt-get update                                \
- && apt-get install -qy                           \
-      build-essential file zip unzip gettext git  \
-      musl libsystemd-dev nsis                    \
-      rpm ruby ruby-dev rubygems                  \
-      protobuf-compiler libprotobuf-dev yamllint  \
- && gem install --no-document fpm                 \
- && rm -rf /var/lib/apt/lists/*
+ARG RUST_TOOLCHAIN=1.77
+RUN apt-get update                                                      \
+ && apt-get install -qy                                                 \
+      build-essential file zip unzip gettext git                        \
+      musl libsystemd-dev nsis cmake                                    \
+      rpm ruby ruby-dev rubygems                                        \
+      protobuf-compiler libprotobuf-dev yamllint                        \
+ && gem install --no-document fpm                                       \
+ && rm -rf /var/lib/apt/lists/*                                         \
+ && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs           \
+    | sh -s -- -y --profile minimal --default-toolchain $RUST_TOOLCHAIN \
+ && /root/.cargo/bin/rustup target add aarch64-unknown-linux-musl       \
+ && /root/.cargo/bin/rustup target add x86_64-unknown-linux-musl
 
 COPY --from=golangci /bin/golangci-lint                  /usr/local/bin
 COPY --from=docker   /usr/bin/docker                     /usr/bin/docker
@@ -110,4 +115,4 @@ RUN git config --global --add safe.directory \*
 ENV CC viceroycc
 
 ENV GOPATH /go
-ENV PATH /usr/local/go/bin:/go/bin:$PATH
+ENV PATH /usr/local/go/bin:/go/bin:/root/.cargo/bin/:$PATH


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

- Add `rustup` and add `aarch64-unknown-linux-musl` `x86_64-unknown-linux-musl` targets
- Add `cmake` which is required for `zydis` crate


#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->
This is a preparation for 
https://github.com/grafana/alloy/pull/2920

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
