### PR TITLE
pyroscope.scrape: single scrape pool

### DIFF
--- a/internal/component/discovery/target.go
+++ b/internal/component/discovery/target.go
@@ -351,6 +351,12 @@ func (t Target) hashLabelsInOrder(order []string) uint64 {
 }
 
 func ComponentTargetsToPromTargetGroups(jobName string, tgs []Target) map[string][]*targetgroup.Group {
+	allGroups := ComponentTargetsToPromTargetGroupsForSingleJob(jobName, tgs)
+
+	return map[string][]*targetgroup.Group{jobName: allGroups}
+}
+
+func ComponentTargetsToPromTargetGroupsForSingleJob(jobName string, tgs []Target) []*targetgroup.Group {
 	targetIndWithCommonGroupLabels := map[uint64][]int{} // target group hash --> index of target in tgs array
 	for ind, t := range tgs {
 		fp := t.groupLabelsHash()
@@ -394,6 +400,5 @@ func ComponentTargetsToPromTargetGroups(jobName string, tgs []Target) map[string
 			Targets: hashConflicts,
 		})
 	}
-
-	return map[string][]*targetgroup.Group{jobName: allGroups}
+	return allGroups
 }

--- a/internal/component/pyroscope/scrape/manager.go
+++ b/internal/component/pyroscope/scrape/manager.go
@@ -27,17 +27,26 @@ type Manager struct {
 	graceShut  chan struct{}
 	appendable pyroscope.Appendable
 
-	mtxScrape     sync.Mutex // Guards the fields below.
-	config        Arguments
-	targetsGroups map[string]*scrapePool
-	targetSets    map[string][]*targetgroup.Group
+	mtxScrape sync.Mutex // Guards the fields below.
+	config    Arguments
+	sp        *scrapePool
+	targetSet []*targetgroup.Group
 
 	triggerReload chan struct{}
 }
 
-func NewManager(o Options, appendable pyroscope.Appendable, logger log.Logger) *Manager {
+func NewManager(o Options, config Arguments, appendable pyroscope.Appendable, logger log.Logger) (*Manager, error) {
 	if logger == nil {
 		logger = log.NewNopLogger()
+	}
+	sp, err := newScrapePool(
+		o.HTTPClientOptions,
+		config,
+		appendable,
+		logger,
+	)
+	if err != nil {
+		return nil, err
 	}
 	return &Manager{
 		options:       o,
@@ -45,14 +54,13 @@ func NewManager(o Options, appendable pyroscope.Appendable, logger log.Logger) *
 		appendable:    appendable,
 		graceShut:     make(chan struct{}),
 		triggerReload: make(chan struct{}, 1),
-		targetsGroups: make(map[string]*scrapePool),
-		targetSets:    make(map[string][]*targetgroup.Group),
-	}
+		sp:            sp,
+	}, nil
 }
 
 // Run receives and saves target set updates and triggers the scraping loops reloading.
 // Reloading happens in the background so that it doesn't block receiving targets updates.
-func (m *Manager) Run(tsets <-chan map[string][]*targetgroup.Group) {
+func (m *Manager) Run(tsets <-chan []*targetgroup.Group) {
 	go m.reloader()
 	for {
 		select {
@@ -94,33 +102,7 @@ func (m *Manager) reload() {
 	m.mtxScrape.Lock()
 	defer m.mtxScrape.Unlock()
 
-	var wg sync.WaitGroup
-	for setName, groups := range m.targetSets {
-		if _, ok := m.targetsGroups[setName]; !ok {
-			sp, err := newScrapePool(m.options.HTTPClientOptions, m.config, m.appendable, log.With(m.logger, "scrape_pool", setName))
-			if err != nil {
-				level.Error(m.logger).Log("msg", "error creating new scrape pool", "err", err, "scrape_pool", setName)
-				continue
-			}
-			m.targetsGroups[setName] = sp
-		}
-
-		wg.Add(1)
-		// Run the sync in parallel as these take a while and at high load can't catch up.
-		go func(sp *scrapePool, groups []*targetgroup.Group) {
-			sp.sync(groups)
-			wg.Done()
-		}(m.targetsGroups[setName], groups)
-	}
-
-	for tgName, sp := range m.targetsGroups {
-		if _, ok := m.targetSets[tgName]; !ok {
-			sp.stop()
-			delete(m.targetsGroups, tgName)
-		}
-	}
-
-	wg.Wait()
+	m.sp.sync(m.targetSet)
 }
 
 // ApplyConfig resets the manager's target providers and job configurations as defined by the new cfg.
@@ -131,12 +113,10 @@ func (m *Manager) ApplyConfig(cfg Arguments) error {
 	var failed bool
 	m.config = cfg
 
-	for name, sp := range m.targetsGroups {
-		err := sp.reload(cfg)
-		if err != nil {
-			level.Error(m.logger).Log("msg", "error reloading scrape pool", "err", err, "scrape_pool", name)
-			failed = true
-		}
+	err := m.sp.reload(cfg)
+	if err != nil {
+		level.Error(m.logger).Log("msg", "error reloading scrape pool", "err", err)
+		failed = true
 	}
 
 	if failed {
@@ -145,62 +125,29 @@ func (m *Manager) ApplyConfig(cfg Arguments) error {
 	return nil
 }
 
-func (m *Manager) updateTsets(tsets map[string][]*targetgroup.Group) {
+func (m *Manager) updateTsets(tset []*targetgroup.Group) {
 	m.mtxScrape.Lock()
-	m.targetSets = tsets
+	m.targetSet = tset
 	m.mtxScrape.Unlock()
 }
 
 // TargetsAll returns active and dropped targets grouped by job_name.
-func (m *Manager) TargetsAll() map[string][]*Target {
-	m.mtxScrape.Lock()
-	defer m.mtxScrape.Unlock()
-
-	targets := make(map[string][]*Target, len(m.targetsGroups))
-	for tset, sp := range m.targetsGroups {
-		targets[tset] = sp.ActiveTargets()
-	}
-	return targets
+func (m *Manager) TargetsAll() []*Target {
+	return m.TargetsActive()
 }
 
 // TargetsActive returns the active targets currently being scraped.
-func (m *Manager) TargetsActive() map[string][]*Target {
+func (m *Manager) TargetsActive() []*Target {
 	m.mtxScrape.Lock()
 	defer m.mtxScrape.Unlock()
 
-	var (
-		wg  sync.WaitGroup
-		mtx sync.Mutex
-	)
-
-	targets := make(map[string][]*Target, len(m.targetsGroups))
-	wg.Add(len(m.targetsGroups))
-	for tset, sp := range m.targetsGroups {
-		// Running in parallel limits the blocking time of scrapePool to scrape
-		// interval when there's an update from SD.
-		go func(tset string, sp *scrapePool) {
-			mtx.Lock()
-			targets[tset] = sp.ActiveTargets()
-			mtx.Unlock()
-			wg.Done()
-		}(tset, sp)
-	}
-	wg.Wait()
-	return targets
+	return m.sp.ActiveTargets()
 }
 
 func (m *Manager) Stop() {
 	m.mtxScrape.Lock()
 	defer m.mtxScrape.Unlock()
 
-	wg := sync.WaitGroup{}
-	for _, sp := range m.targetsGroups {
-		wg.Add(1)
-		go func(sp *scrapePool) {
-			defer wg.Done()
-			sp.stop()
-		}(sp)
-	}
-	wg.Wait()
+	m.sp.stop()
 	close(m.graceShut)
 }

--- a/internal/component/pyroscope/scrape/manager_test.go
+++ b/internal/component/pyroscope/scrape/manager_test.go
@@ -19,28 +19,26 @@ func TestManager(t *testing.T) {
 
 	reloadInterval = time.Millisecond
 
-	m := NewManager(Options{}, pyroscope.AppendableFunc(func(ctx context.Context, labels labels.Labels, samples []*pyroscope.RawSample) error {
+	m, _ := NewManager(Options{}, NewDefaultArguments(), pyroscope.AppendableFunc(func(ctx context.Context, labels labels.Labels, samples []*pyroscope.RawSample) error {
 		return nil
 	}), util.TestLogger(t))
 
 	defer m.Stop()
-	targetSetsChan := make(chan map[string][]*targetgroup.Group)
+	targetSetsChan := make(chan []*targetgroup.Group)
 	require.NoError(t, m.ApplyConfig(NewDefaultArguments()))
 	go m.Run(targetSetsChan)
 
-	targetSetsChan <- map[string][]*targetgroup.Group{
-		"group1": {
-			{
-				Targets: []model.LabelSet{
-					{model.AddressLabel: "localhost:9090", serviceNameLabel: "s"},
-					{model.AddressLabel: "localhost:8080", serviceNameK8SLabel: "k"},
-				},
-				Labels: model.LabelSet{"foo": "bar"},
+	targetSetsChan <- []*targetgroup.Group{
+		{
+			Targets: []model.LabelSet{
+				{model.AddressLabel: "localhost:9090", serviceNameLabel: "s"},
+				{model.AddressLabel: "localhost:8080", serviceNameK8SLabel: "k"},
 			},
+			Labels: model.LabelSet{"foo": "bar"},
 		},
 	}
 	require.Eventually(t, func() bool {
-		return len(m.TargetsActive()["group1"]) == 10
+		return len(m.TargetsActive()) == 10
 	}, time.Second, 10*time.Millisecond)
 
 	new := NewDefaultArguments()
@@ -49,31 +47,26 @@ func TestManager(t *testing.T) {
 	// Trigger a config reload
 	require.NoError(t, m.ApplyConfig(new))
 
-	targetSetsChan <- map[string][]*targetgroup.Group{
-		"group2": {
-			{
-				Targets: []model.LabelSet{
-					{model.AddressLabel: "localhost:9090", serviceNameLabel: "s"},
-					{model.AddressLabel: "localhost:8080", serviceNameK8SLabel: "k"},
-				},
-				Labels: model.LabelSet{"foo": "bar"},
+	targetSetsChan <- []*targetgroup.Group{
+		{
+			Targets: []model.LabelSet{
+				{model.AddressLabel: "localhost:9090", serviceNameLabel: "s"},
+				{model.AddressLabel: "localhost:8080", serviceNameK8SLabel: "k"},
+				{model.AddressLabel: "localhost:8081", serviceNameK8SLabel: "k2"},
 			},
+			Labels: model.LabelSet{"foo": "bar"},
 		},
 	}
 
 	require.Eventually(t, func() bool {
-		return len(m.TargetsActive()["group2"]) == 10
+		return len(m.TargetsActive()) == 15
 	}, time.Second, 10*time.Millisecond)
 
-	require.Equal(t, 1, len(m.targetsGroups))
+	require.Equal(t, 1*time.Second, m.sp.config.ScrapeInterval)
 
-	for _, ts := range m.targetsGroups {
-		require.Equal(t, 1*time.Second, ts.config.ScrapeInterval)
-	}
-
-	targetSetsChan <- map[string][]*targetgroup.Group{"group1": {}, "group2": {}}
+	targetSetsChan <- []*targetgroup.Group{}
 
 	require.Eventually(t, func() bool {
-		return len(m.TargetsAll()["group2"]) == 0 && len(m.TargetsAll()["group1"]) == 0
+		return 0 == len(m.TargetsAll())
 	}, time.Second, 10*time.Millisecond)
 }

--- a/internal/component/pyroscope/scrape/scrape.go
+++ b/internal/component/pyroscope/scrape/scrape.go
@@ -274,7 +274,10 @@ func New(o component.Options, args Arguments) (*Component, error) {
 			config_util.WithDialContextFunc(httpData.DialFunc),
 		},
 	}
-	scraper, _ := NewManager(scrapeHttpOptions, args, alloyAppendable, o.Logger)
+	scraper, err := NewManager(scrapeHttpOptions, args, alloyAppendable, o.Logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create scraper manager: %w", err)
+	}
 	c := &Component{
 		opts:          o,
 		cluster:       clusterData,


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This pr changes the `pyroscope.scrape` manager implementation to only handle one `scrapeLoop` instead of a map of `scrapeLoops` of size = 1. This simplifies code and removes a goroutine for target  sync.
#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
