### PR TITLE
Set signal types according to encoding in otel kafka exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ Main (unreleased)
 - Fixed `expected object or array, got capsule` errors that could be encountered when using targets with `coalesce` and
   `array.combine_maps` functions. (@thampiotr)
 
+- Fixed an issue where the `otelcol.exporter.kafka` component would not start if the `encoding` was specific to a signal type. (@wildum)
+
 ### Other changes
 
 - Upgrading to Prometheus v2.55.1. (@ptodev)

--- a/internal/component/otelcol/exporter/kafka/kafka.go
+++ b/internal/component/otelcol/exporter/kafka/kafka.go
@@ -27,7 +27,17 @@ func init() {
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := kafkaexporter.NewFactory()
-			return exporter.New(opts, fact, args.(Arguments), exporter.TypeSignalConstFunc(exporter.TypeAll))
+			typeSignalFunc := func(opts component.Options, args component.Arguments) exporter.TypeSignal {
+				switch args.(Arguments).Encoding {
+				case "raw":
+					return exporter.TypeLogs
+				case "jaeger_proto", "jaeger_json", "zipkin_proto", "zipkin_json":
+					return exporter.TypeTraces
+				default:
+					return exporter.TypeAll
+				}
+			}
+			return exporter.New(opts, fact, args.(Arguments), typeSignalFunc)
 		},
 	})
 }

--- a/internal/component/otelcol/exporter/kafka/kafka.go
+++ b/internal/component/otelcol/exporter/kafka/kafka.go
@@ -27,19 +27,20 @@ func init() {
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := kafkaexporter.NewFactory()
-			typeSignalFunc := func(opts component.Options, args component.Arguments) exporter.TypeSignal {
-				switch args.(Arguments).Encoding {
-				case "raw":
-					return exporter.TypeLogs
-				case "jaeger_proto", "jaeger_json", "zipkin_proto", "zipkin_json":
-					return exporter.TypeTraces
-				default:
-					return exporter.TypeAll
-				}
-			}
-			return exporter.New(opts, fact, args.(Arguments), typeSignalFunc)
+			return exporter.New(opts, fact, args.(Arguments), GetSignalType)
 		},
 	})
+}
+
+func GetSignalType(opts component.Options, args component.Arguments) exporter.TypeSignal {
+	switch args.(Arguments).Encoding {
+	case "raw":
+		return exporter.TypeLogs
+	case "jaeger_proto", "jaeger_json", "zipkin_proto", "zipkin_json":
+		return exporter.TypeTraces
+	default:
+		return exporter.TypeAll
+	}
 }
 
 // Arguments configures the otelcol.exporter.kafka component.


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

The supported signal type should be set according to the encoding.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #2935

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Tests updated
