### PR TITLE
Enforces string type

### DIFF
--- a/operations/helm/charts/alloy/templates/containers/_agent.yaml
+++ b/operations/helm/charts/alloy/templates/containers/_agent.yaml
@@ -32,8 +32,9 @@
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    {{- range $values.extraEnv }}
-    - {{- toYaml . | nindent 6 }}
+    {{- range $envValue := $values.extraEnv }}
+        - name: {{ $envValue.name | quote }}
+          value: {{ $envValue.value | quote }}
     {{- end }}
   {{- if $values.envFrom }}
   envFrom:


### PR DESCRIPTION
When you pass --set "alloy.extraEnv[0].value=8443", Helm interprets 8443 as a number, which is incompatible with a template expecting a string.

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
