### PR TITLE
Add more Drone steps to GH Actions

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -287,40 +287,6 @@ trigger:
 type: docker
 ---
 kind: pipeline
-name: Publish Windows alloy-devel container
-platform:
-  arch: amd64
-  os: windows
-  version: "1809"
-steps:
-- commands:
-  - '& "C:/Program Files/git/bin/bash.exe" -c ''mkdir -p $HOME/.docker'''
-  - '& "C:/Program Files/git/bin/bash.exe" -c ''printenv GCR_CREDS > $HOME/.docker/config.json'''
-  - '& "C:/Program Files/git/bin/bash.exe" -c ''docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD'''
-  - '& "C:/Program Files/git/bin/bash.exe" -c ''./tools/ci/docker-containers-windows
-    alloy-devel'''
-  environment:
-    DOCKER_LOGIN:
-      from_secret: docker_login
-    DOCKER_PASSWORD:
-      from_secret: docker_password
-    GCR_CREDS:
-      from_secret: gcr_admin
-  image: grafana/alloy-build-image:v0.1.8-windows
-  name: Build containers
-  volumes:
-  - name: docker
-    path: //./pipe/docker_engine/
-trigger:
-  ref:
-  - refs/heads/main
-type: docker
-volumes:
-- host:
-    path: //./pipe/docker_engine/
-  name: docker
----
-kind: pipeline
 name: Publish Linux alloy container
 platform:
   arch: amd64
@@ -579,6 +545,6 @@ kind: secret
 name: updater_private_key
 ---
 kind: signature
-hmac: 26b5613cbd5e5cd42656c10c372d44dc93af565ec2ae212d3b27c2fe366c6aeb
+hmac: e2780fbbbb87cc7ace40a9777675afdf2d2daf7f2448fd09e15f6837fd53d871
 
 ...

--- a/.github/workflows/check-linux-container.yml
+++ b/.github/workflows/check-linux-container.yml
@@ -1,0 +1,33 @@
+name: Check Linux container
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - '.github/workflows/check-linux-container.yml'
+
+jobs:
+  publish_windows_container:
+    name: Check Linux container
+    container: grafana/alloy-build-image:v0.1.8
+    runs-on:
+      labels: github-hosted-ubuntu-x64-large
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set ownership
+      # https://github.com/actions/runner/issues/2033#issuecomment-1204205989
+      run: |
+          # this is to fix GIT not liking owner of the checkout dir
+          chown -R $(id -u):$(id -g) $PWD
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache: false
+
+    - run: |
+       make alloy-image

--- a/.github/workflows/check-windows-container.yml
+++ b/.github/workflows/check-windows-container.yml
@@ -1,0 +1,24 @@
+name: Check Windows container
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - '.github/workflows/check-windows-container.yml'
+jobs:
+  publish_windows_container:
+    name: Check Windows container
+    runs-on: windows-2022
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache: false
+
+    - run: |
+       & "C:/Program Files/git/bin/bash.exe" -c 'make alloy-image-windows'

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -22,7 +22,7 @@ jobs:
           docker build -t alloy-test:latest -f Dockerfile .
 
   windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
       - name: Build image

--- a/.github/workflows/publish-alloy-devel.yml
+++ b/.github/workflows/publish-alloy-devel.yml
@@ -9,6 +9,29 @@ permissions:
   id-token: write
 
 jobs:
+  publish_windows_container:
+    name: Publish Windows alloy-devel container
+    runs-on: windows-2022
+    steps:
+      # This step needs to run before "Checkout code".
+      # That's because it generates a new file.
+      # We don't want this file to end up in the repo directory.
+      # Then "tools/image-tag" would get confused because "git status" no longer reports a clean repo.
+    - name: Login to DockerHub (from vault)
+      uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login-v1.0.1
+
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache: false
+
+    - run: |
+       & "C:/Program Files/git/bin/bash.exe" -c './tools/ci/docker-containers-windows alloy-devel'
+
   publish_linux_container:
     name: Publish Linux alloy-devel container
     container: grafana/alloy-build-image:v0.1.8

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -5,15 +5,26 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    container:
+      # The build image contains golangci-lint.
+      image: grafana/alloy-build-image:v0.1.8
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+
+    - name: Set ownership
+      # https://github.com/actions/runner/issues/2033#issuecomment-1204205989
+      run: |
+          # this is to fix GIT not liking owner of the checkout dir
+          chown -R $(id -u):$(id -g) $PWD
+
     - name: Set up Go 1.23
       uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
         cache: false
-    - run: sudo apt-get update -y && sudo apt-get install -y libsystemd-dev
+
+    - run: apt-get update -y && apt-get install -y libsystemd-dev
     - run: make lint
 
   test_linux:
@@ -21,10 +32,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4 
+
     - name: Set up Go 1.23
       uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
         cache: false
+
     - run: make GO_TAGS="nodocker" test

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,7 +1,70 @@
-FROM grafana/alloy-build-image:v0.1.8-windows as builder
+FROM library/golang:1.24.1-windowsservercore-ltsc2022 as builder
 ARG VERSION
 ARG RELEASE_BUILD=1
 ARG GO_TAGS
+
+#################### 
+# The snippet below was taken from tools/build-image/windows/Dockerfile.
+# This is so that we don't have to run the CI step inside a build image container.
+# 
+# TODO: Build Alloy outside of the Dockerfile?
+# Then we don't need to install all those dependencies.
+# However, the versions of Windows may not match.
+# GitHub Actions may use one version of Windows ot build Alloy, 
+# and Docker may put it into a container with a different version.
+####################
+SHELL ["powershell", "-command"]
+
+# Use a fixed version of chocolatey to avoid dependency on .net framework install
+# See https://stackoverflow.com/questions/76470752/chocolatey-installation-in-docker-started-to-fail-restart-due-to-net-framework
+ENV chocolateyVersion=1.4.0
+# Install chocolatey for package management
+RUN Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+
+#
+# Go Build Dependencies
+#
+# golang - building go code
+# 7zip - unzipping stuff during TDM GCC install
+# TDM GCC - gcc compiler in windows
+# make - building with a Makefile
+# docker - building images
+# git - bash for windows
+
+RUN choco install 7zip --version 22.1 -y
+
+# TDM GCC doesn't currently have a way to silently install
+ADD https://github.com/jmeubank/tdm-gcc/releases/download/v10.3.0-tdm64-2/tdm64-gcc-10.3.0-2.exe C:\\Windows\\temp\\TDM-GCC-64.exe
+RUN mkdir C:\\TDM-GCC-64; \
+    Start-Process 7z -ArgumentList 'e C:\\Windows\\temp\\TDM-GCC-64.exe -oC:\\TDM-GCC-64 -y' -Wait; \
+    Start-Process 7z -ArgumentList 'e C:\\TDM-GCC-64\\*.tar.xz -oC:\\TDM-GCC-64 -y' -Wait; \
+    Start-Process 7z -ArgumentList 'x C:\\TDM-GCC-64\\*.tar -oC:\\TDM-GCC-64 -y' -Wait; \
+    Remove-Item "C:\\TDM-GCC-64\\*" -Include *.tar.xz, *.tar -Force; \
+    setx /M PATH $('C:\TDM-GCC-64\bin;' + $Env:PATH); \
+    Remove-Item -Path C:\\Windows\\temp\\TDM-GCC-64.exe -Force
+
+RUN choco install make --version 4.3 -y
+RUN choco install docker-cli --version 20.10.22 -y
+RUN choco install git --version 2.39.0 -y
+
+#
+# React App Dependencies
+#
+# nodejs - node server
+# yarn - installs node dependencies
+RUN choco install nodejs.install --version 19.2.0 -y
+RUN choco install yarn --version 1.22.19 -y
+
+# Git tries to prevent misuse of repositories (CVE-2022-24765), but we don't
+# care about this for build containers, where it's expected that the repository
+# will be accessed by other users (the root user of the build container).
+#
+# Disable that safety check.
+RUN git config --global --add safe.directory \*
+
+####################
+# End of snipped from tools/build-image/windows/Dockerfile.
+####################
 
 COPY . /src/alloy
 WORKDIR /src/alloy


### PR DESCRIPTION
Some of the final bits missing from GitHib Actions:
* Migrate steps for checking containers
* Migrate step to publish Windows alloy-devel container

This PR also fixes the Lint step in GH Actions. Apparently it hasn't been working, even though it reported as green.

The PR also fixes an issue with the already existing "Check Docker images" Actions workflow. It didn't complete for Windows, but it completed fine when I upgraded it to a new Windows image.

I tested this PR on another branch:

- [Test of the lint step](https://github.com/grafana/alloy/actions/runs/13794121430/job/38581376026?pr=2749)
- [Check Linux container](https://github.com/grafana/alloy/actions/runs/13794362428/job/38582185739)
- [Check Windows container](https://github.com/grafana/alloy/actions/runs/13793724373/job/38580015145)
- [Publish Windows alloy-devel container](https://github.com/grafana/alloy/actions/runs/13793982804/job/38580896538). I changed the image name to `ptodev/alloy` so that it doesn't publish to the grafana repo.