### PR TITLE
Fix attribute name in Beyla configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ Main (unreleased)
   - `query_sample`: better handling of truncated queries (@cristiangreco)
   - `query_sample`: add option to use TiDB sql parser (@cristiangreco)
 
+### Bugfixes
+
+- Fixed the parsing of application and network filter blocks for Beyla
+
 ### Other changes
 
 - Upgrading to Prometheus v2.55.1. (@ptodev)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,9 +39,9 @@ Main (unreleased)
   - `query_sample`: better handling of truncated queries (@cristiangreco)
   - `query_sample`: add option to use TiDB sql parser (@cristiangreco)
 
-### Bugfixes
+### Breaking changes
 
-- Fixed the parsing of application and network filter blocks for Beyla
+- Fixed the parsing of selections, application and network filter blocks for Beyla
 
 ### Other changes
 

--- a/docs/sources/reference/components/beyla/beyla.ebpf.md
+++ b/docs/sources/reference/components/beyla/beyla.ebpf.md
@@ -155,10 +155,10 @@ The `instance_id` block configures instance ID settings.
 #### `select`
 
 The `select` block configures which attributes to include or exclude for specific metric/trace sections.
-Each selected attribute is defined as a labeled block with the attribute name as the label.
 
 | Name      | Type           | Description                                            | Default | Required |
 | --------- | -------------- | ------------------------------------------------------ | ------- | -------- |
+| `attr`    | `string`       | The attribute name to select.                          | `[]`    | yes      |
 | `exclude` | `list(string)` | List of attributes to exclude.                         | `[]`    | no       |
 | `include` | `list(string)` | List of attributes to include. Use `*` to include all. | `[]`    | no       |
 

--- a/docs/sources/reference/components/beyla/beyla.ebpf.md
+++ b/docs/sources/reference/components/beyla/beyla.ebpf.md
@@ -245,10 +245,11 @@ It contains the following blocks:
 
 #### `application`
 
-The `application` block configures filtering of application attributes. Each attribute filter is defined as a labeled block with the attribute name as the label.
+The `application` block configures filtering of application attributes.
 
-| Name        | Type     | Description                                          | Required |
-| ----------- | -------- | ---------------------------------------------------- | -------- |
+| Name        | Type     | Description                              | Required |
+| ----------- | -------- | -----------------------------------------| -------- |
+| `attr`      | `string` | The name of the attribute to match.      | yes      |
 | `match`     | `string` | String to match attribute values.        | no       |
 | `not_match` | `string` | String to exclude matching values.       | no       |
 
@@ -258,10 +259,11 @@ wildcards).
 
 #### `network` filters
 
-The `network` block configures filtering of network attributes. Each attribute filter is defined as a labeled block with the attribute name as the label.
+The `network` block configures filtering of network attributes.
 
-| Name        | Type     | Description                                          | Required |
-| ----------- | -------- | ---------------------------------------------------- | -------- |
+| Name        | Type     | Description                              | Required |
+| ----------- | -------- | ---------------------------------------- | -------- |
+| `attr`      | `string` | The name of the attribute to match.      | yes      |
 | `match`     | `string` | String to match attribute values.        | no       |
 | `not_match` | `string` | String to exclude matching values.       | no       |
 

--- a/internal/component/beyla/ebpf/args.go
+++ b/internal/component/beyla/ebpf/args.go
@@ -132,7 +132,7 @@ type Filters struct {
 type AttributeFamilies []AttributeFamily
 
 type AttributeFamily struct {
-	Attr     string `alloy:",label"`
+	Attr     string `alloy:"attr,attr"`
 	Match    string `alloy:"match,attr,optional"`
 	NotMatch string `alloy:"not_match,attr,optional"`
 }

--- a/internal/component/beyla/ebpf/args.go
+++ b/internal/component/beyla/ebpf/args.go
@@ -57,7 +57,7 @@ type InstanceIDConfig struct {
 type Selections []Selection
 
 type Selection struct {
-	Section string   `alloy:",label"`
+	Section string   `alloy:"attr,attr"`
 	Include []string `alloy:"include,attr"`
 	Exclude []string `alloy:"exclude,attr"`
 }

--- a/internal/component/beyla/ebpf/beyla_linux_test.go
+++ b/internal/component/beyla/ebpf/beyla_linux_test.go
@@ -39,7 +39,8 @@ func TestArguments_UnmarshalSyntax(t *testing.T) {
 				disable_informers = ["node"]
 				meta_restrict_local_node = true
 			}
-			select "sql_client_duration" {
+			select {
+				attr = "sql_client_duration"
 				include = ["*"]
 				exclude = ["db_statement"]
 			}
@@ -97,10 +98,12 @@ func TestArguments_UnmarshalSyntax(t *testing.T) {
 			heuristic_sql_detect = true
 		}
 		filters {
-			application "transport" {
+			application {
+				attr = "transport"
 				not_match = "UDP"
 			}
-			network "dst_port" {
+			network {
+				attr = "dst_port"
 				match = "53"
 			}
 		}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

The Beyla configuration for network and application filters rely on the block label for the attribute name, i.e.

```
            filters {
              network "k8s.src.owner.name" {
                match = "*"
              }
            }
```

however, attribute names such as "k8s.src.owner.name" are not valid label identifiers, rendering the above config unparsable by the alloy config syntax.

This PR changes the code so that attributes need to be explicitly specified using the `attr` field:

```
	filters {
		network {
			attr = "k8s.src.owner.name"
			match = "*"
		}

		network {
			attr = "k8s.src.owner.name2"
			match = "*"
		}
	}
```

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
