### PR TITLE
Add docker compose configuration notes

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.exporter.cadvisor.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.cadvisor.md
@@ -15,8 +15,36 @@ The `prometheus.exporter.cadvisor` component collects container metrics using [c
 ## Usage
 
 ```alloy
-prometheus.exporter.cadvisor "<LABEL>" {
+prometheus.exporter.cadvisor "container_metrics" {
+    docker_host      = "unix:///var/run/docker.sock"
+    storage_duration = "5m"
 }
+```
+
+When exporting to Mimir then make sure to set max_label_names_per_series higher than the default, otherwise Mimir will not except the metrics.
+
+```yaml
+limits:
+  max_label_names_per_series: 100
+```
+
+## Docker Configuration
+
+To properly collect container metrics when using Alloy in docker compose, the Alloy container must be run with specific volume mounts and privileges. Here's the required Docker Compose configuration:
+
+```yaml
+services:
+  alloy:
+    privileged: true
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+      - /etc/machine-id:/etc/machine-id:ro
+    devices:
+      - /dev/kmsg
 ```
 
 ## Arguments


### PR DESCRIPTION
Update the Alloy Cadvisor exporter docs with relevant information on how to set Cadvisor up in docker compose.
