### PR TITLE
Fix the linting action to work appropriately in github actions.

### DIFF
--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -27,6 +27,29 @@ jobs:
     - run: apt-get update -y && apt-get install -y libsystemd-dev
     - run: make lint
 
+  experimental-lint:
+    name: Experimental Lint
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Set up Go 1.23
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache: false
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v6
+      with:
+        version: v1.64.7
+        args: --timeout=10m
+    - name: golangci-lint-syntax
+      uses: golangci/golangci-lint-action@v6
+      with:
+        version: v1.64.7
+        working-directory: ./syntax/
+    - run: make run-alloylint
+
   test_linux:
     name: Test Linux
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Existing linting in GHA and drone does not actually report linting failure as an error due to the way they use find -execdir to attempt to lint all modules. As we currently only have base alloy module & syntax module, I've unfolded that into 2 steps in GHA, and updated the version of golangci-lint as the version we were using was not compatible with go 1.23+

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
