### PR TITLE
remotecfg: Fix errNotModified handling of metrics and logging

### DIFF
--- a/internal/service/remotecfg/remotecfg.go
+++ b/internal/service/remotecfg/remotecfg.go
@@ -383,7 +383,7 @@ func (s *Service) fetchRemote() error {
 	if err == nil {
 		s.metrics.lastLoadSuccess.Set(1)
 		s.metrics.lastFetchSuccessTime.SetToCurrentTime()
-	} else {
+	} else if err != errNotModified {
 		s.metrics.totalFailures.Add(1)
 		s.metrics.lastLoadSuccess.Set(0)
 		return err


### PR DESCRIPTION
#2926 fixed the remotecfg_last_load_successful being set to 1 when an errored config was unchanged, but as a result the behavior is now reversed. The metric is being incorrectly set to 0 when a good config is unchanged. This also has the side effect of spamming the logs with false error messages, as errNotModified gets returned from the function before it can be suppressed by the following if statement.

This PR fixes the issue by simply changing the else to an "else if not errNotModified". This will cause errNotModified to leave the remotecfg_last_load_successful metric unchanged if the config was not modified, as well as allowing the next if statement to suppress the log message from being printed.

