### PR TITLE
Only check containers if certain paths have changed

### DIFF
--- a/.github/workflows/check-linux-container.yml
+++ b/.github/workflows/check-linux-container.yml
@@ -3,10 +3,15 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'Dockerfile'
+      - 'tools/ci/docker-containers'
+      - '.github/workflows/check-linux-container.yml'
   pull_request:
     paths:
+      - 'Dockerfile'
+      - 'tools/ci/docker-containers'
       - '.github/workflows/check-linux-container.yml'
-
 jobs:
   publish_windows_container:
     name: Check Linux container

--- a/.github/workflows/check-windows-container.yml
+++ b/.github/workflows/check-windows-container.yml
@@ -3,8 +3,14 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'Dockerfile.windows'
+      - 'tools/ci/docker-containers-windows'
+      - '.github/workflows/check-windows-container.yml'
   pull_request:
     paths:
+      - 'Dockerfile.windows'
+      - 'tools/ci/docker-containers-windows'
       - '.github/workflows/check-windows-container.yml'
 jobs:
   publish_windows_container:


### PR DESCRIPTION
In #2961 I added Actions workflows for checking Windows and Linux containers. Those were migrated from Drone. However, Drone [only ran them](https://github.com/grafana/alloy/blob/v1.6.0/.drone/drone.yml#L213-L218) when certain paths had changed:

```yaml
trigger:
  paths:
  - Dockerfile.windows
  - tools/ci/docker-containers-windows
  ref:
  - refs/heads/main
```

This PR will correct the GitHub Actions to also only run when those paths are modified. However, I also added an extra path - that to the github action workflow itself, so that if someone modifies it it can be tested in a PR.

According to the [Actions docs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore), this is the correct way to use `on`:
> If you define both branches/branches-ignore and paths/paths-ignore, the workflow will only run when both filters are satisfied.
