### PR TITLE
ui: enable Graph view to show both local and remote graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Main (unreleased)
 
 - Add `otelcol.receiver.awscloudwatch` component to receive logs from AWS CloudWatch and forward them to other `otelcol.*` components. (@wildum)
 
+- Show the graph of remotecfg component in the UI. (@tpaschalis)
+
 ### Enhancements
 
 - Add `rfc3164_default_to_current_year` argument to `loki.source.syslog` (@dehaansa)

--- a/internal/web/ui/src/features/graph/ComponentGraph.tsx
+++ b/internal/web/ui/src/features/graph/ComponentGraph.tsx
@@ -128,6 +128,7 @@ interface Box {
 
 export interface ComponentGraphProps {
   components: ComponentInfo[];
+  useRemotecfg?: boolean;
 }
 
 /**
@@ -328,7 +329,10 @@ export const ComponentGraph: FC<ComponentGraphProps> = (props) => {
         return `translate(${x}, ${y})`;
       });
 
-    const linkedNodes = nodes.append('a').attr('href', (n) => `${baseComponentPath}/${n.data.localID}`);
+    const linkedNodes = nodes.append('a').attr('href', (n) => {
+      const basePath = props.useRemotecfg ? '/remotecfg/component' : baseComponentPath;
+      return `${basePath}/${n.data.localID}`;
+    });
 
     // Check if above `a` element got rendered with latitude equaling to node's margin
     // If that's the case then we're running in quirks of Firefox SVG rendering

--- a/internal/web/ui/src/pages/Graph.tsx
+++ b/internal/web/ui/src/pages/Graph.tsx
@@ -1,15 +1,33 @@
+import { useState } from 'react';
 import { faDiagramProject } from '@fortawesome/free-solid-svg-icons';
+
+import { RadioButtonGroup } from '@grafana/ui';
 
 import { ComponentGraph } from '../features/graph/ComponentGraph';
 import Page from '../features/layout/Page';
 import { useComponentInfo } from '../hooks/componentInfo';
 
 function Graph() {
-  const [components] = useComponentInfo('', false);
+  const [configType, setConfigType] = useState<string>('local');
+  const [components] = useComponentInfo('', configType === 'remote');
+
+  const options = [
+    { label: 'Local', value: 'local' },
+    { label: 'Remote', value: 'remote' },
+  ];
+
+  const handleConfigChange = (value: string) => {
+    setConfigType(value);
+  };
 
   return (
     <Page name="Graph" desc="Relationships between defined components" icon={faDiagramProject}>
-      {components.length > 0 && <ComponentGraph components={components} />}
+      <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+        <div style={{ marginBottom: '16px' }}>
+          <RadioButtonGroup options={options} value={configType} onChange={handleConfigChange} size="sm" />
+        </div>
+        <div style={{ flex: 1, minHeight: 0 }}>{components.length > 0 && <ComponentGraph components={components} />}</div>
+      </div>
     </Page>
   );
 }

--- a/internal/web/ui/src/pages/Graph.tsx
+++ b/internal/web/ui/src/pages/Graph.tsx
@@ -26,7 +26,9 @@ function Graph() {
         <div style={{ marginBottom: '16px' }}>
           <RadioButtonGroup options={options} value={configType} onChange={handleConfigChange} size="sm" />
         </div>
-        <div style={{ flex: 1, minHeight: 0 }}>{components.length > 0 && <ComponentGraph components={components} />}</div>
+        <div style={{ flex: 1, minHeight: 0 }}>
+          {components.length > 0 && <ComponentGraph components={components} useRemotecfg={configType === 'remote'} />}
+        </div>
       </div>
     </Page>
   );


### PR DESCRIPTION
#### PR Description

https://github.com/user-attachments/assets/c2744507-77e2-4f02-9ad8-6f84c1990d75

This PR adds a toggle to the Graph view so that we can show both the 'local' configuration dependencies as well as the ones from remotecfg components

#### Which issue(s) this PR fixes

No issue filed.

#### Notes to the Reviewer

I know that @wildum has some FE ideas in line, I hope this don't collide with what you wanted to do here.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
- [ ] Config converters updated (N/A)
