### PR TITLE
fix doc "collect/metamonitoring":  relocate 'replace prometheus.exporter.self "<SELF_LABEL>" instruction' to correct location

### DIFF
--- a/docs/sources/collect/metamonitoring.md
+++ b/docs/sources/collect/metamonitoring.md
@@ -39,6 +39,9 @@ In this task, you use the [`prometheus.exporter.self`][prometheus.exporter.self]
    }
    ```
 
+   Replace the following:
+   * _`<SELF_LABEL>`_: The label for the component such as `default` or `metamonitoring`. The label must be unique across all `prometheus.exporter.self` components in the same configuration file.
+
 1. Add the following `prometheus.scrape` component to your configuration file.
 
    ```alloy
@@ -49,7 +52,6 @@ In this task, you use the [`prometheus.exporter.self`][prometheus.exporter.self]
    ```
 
    Replace the following:
-   * _`<SELF_LABEL>`_: The label for the component such as `default` or `metamonitoring`. The label must be unique across all `prometheus.exporter.self` components in the same configuration file.
    * _`<SCRAPE_LABEL>`_: The label for the scrape component such as `default`. The label must be unique across all `prometheus.scrape` components in the same configuration file.
    * _`<METRICS_RECEIVER_LIST>`_: A comma-delimited list of component receivers to forward metrics to.
      For example, to send to a remote write component, use `prometheus.remote_write.WRITE_LABEL.receiver`.


### PR DESCRIPTION
#### PR Description

fix doc [collect/metamonitoring](https://github.com/grafana/alloy/blob/main/docs/sources/collect/metamonitoring.md) that:

The instruction of 

>Replace the following:
>   * _`<SELF_LABEL>`_: The label for the component such as `default` or `metamonitoring`. The label must be unique across all `prometheus.exporter.self` components in the same configuration file.

should be under the code block of
```alloy
   prometheus.exporter.self "<SELF_LABEL>" {
   }
   ```
instead of the code block of
```alloy
   prometheus.scrape "<SCRAPE_LABEL>" {
     targets    = prometheus.exporter.self.<SELF_LABEL>.targets
     forward_to = [<METRICS_RECEIVER_LIST>]
   }
   ```

#### Which issue(s) this PR fixes

This PR is a trivial fix, no issue is required according to the [Contributing guideline](https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md)

#### Notes to the Reviewer

I found the instruction of replacing the <SELF_LABEL> under step 2 is a bit difficult to follow, so I suggest changing it to step 1. I have also checked the doc of [collect/datadog-traces-metrics](https://github.com/grafana/alloy/blob/main/docs/sources/collect/datadog-traces-metrics.md) to ensure consistency. 

#### PR Checklist

I am not sure if I need to update the CHANGELOG.md as this is just a small fix of the documentation. 
