### PR TITLE
Fix deadlock in loki.source.file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ Main (unreleased)
 
 - Reduced lock contention in `prometheus.scrape` component (@thampiotr)
 
+### Bugfixes
+
+- Fix deadlocks in `loki.source.file` when tailing fails (@mblaschke)
+
 ### Other changes
 
 - Upgrading to Prometheus v2.55.1. (@ptodev)

--- a/internal/component/loki/source/file/tailer.go
+++ b/internal/component/loki/source/file/tailer.go
@@ -161,11 +161,13 @@ func (t *tailer) Run() {
 	fi, err := os.Stat(t.path)
 	if err != nil {
 		level.Error(t.logger).Log("msg", "failed to tail file", "path", t.path, "err", err)
+		t.mut.Unlock()
 		return
 	}
 	pos, err := t.positions.Get(t.path, t.labelsStr)
 	if err != nil {
 		level.Error(t.logger).Log("msg", "failed to get file position", "err", err)
+		t.mut.Unlock()
 		return
 	}
 
@@ -206,6 +208,7 @@ func (t *tailer) Run() {
 	})
 	if err != nil {
 		level.Error(t.logger).Log("msg", "failed to tail the file", "err", err)
+		t.mut.Unlock()
 		return
 	}
 	t.tail = tail


### PR DESCRIPTION
#### PR Description
Locks are not released if file tailer is failing

#### Which issue(s) this PR fixes
Alloy is running into a deadlock if errors happens

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
