### PR TITLE
Remove explicit 4.x kernel requirement

### DIFF
--- a/docs/sources/introduction/supported-platforms.md
+++ b/docs/sources/introduction/supported-platforms.md
@@ -12,7 +12,6 @@ The following operating systems and hardware architecture are supported.
 
 ## Linux
 
-* Minimum version: kernel 4.x or later
 * Architectures: AMD64, ARM64
 * Within the Linux distribution lifecycle
 


### PR DESCRIPTION
Our docs are currently saying the minimum Linux kernel requirement is 4.x.

We should remove this.

* It's not generally true, there are components like `beyla.ebpf` that require newer kernels, see [https://grafana.com/docs/beyla/latest/#requirements](https://grafana.com/docs/beyla/latest/#requirements).
* 4.x sounds arbitrary. If we wanted to define a minimum kernel version, it should be a [supported Linux kernel](https://endoflife.date/linux), and we should regularly update it as kernels are reaching end-of-live.
* [Go itself requires kernel 3.2](https://go-review.googlesource.com/c/go/+/622015), so unless a component uses any specific feature from a newer kernel Alloy should run on 3.2 kernels.

So, given all the above it's best not to have a generic statement on the required kernel version, but instead document component-specific requirements on the components themselves.
