### PR TITLE
docs: Wrong meta label used

### DIFF
--- a/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
@@ -235,7 +235,7 @@ discovery.relabel "local_pods" {
   }
   rule {
     action = "replace"
-    source_labels = ["__meta_kubernetes_node_name"]
+    source_labels = ["__meta_kubernetes_pod_node_name"]
     target_label = "node"
   }
   rule {


### PR DESCRIPTION
The correct name is: 
> `__meta_kubernetes_pod_node_name`: The name of the node the pod is scheduled onto.

https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config