### PR TITLE
docs: Fix the hostname env variables name

### DIFF
--- a/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
@@ -199,7 +199,7 @@ The `service_name` label is set to `{__meta_kubernetes_namespace}/{__meta_kubern
 discovery.kubernetes "all_pods" {
   role = "pod"
   selectors {
-    field = "spec.nodeName=" + sys.env("<HOSTNAME>")
+    field = "spec.nodeName=" + sys.env("HOSTNAME")
     role = "pod"
   }
 }


### PR DESCRIPTION
It should use the right variable, which is set in most cases correctly.