### PR TITLE
[helm] expand `extraObjects` templating

### DIFF
--- a/operations/helm/charts/alloy/CHANGELOG.md
+++ b/operations/helm/charts/alloy/CHANGELOG.md
@@ -9,6 +9,9 @@ internal API changes are not present.
 
 Unreleased
 ----------
+### Enhancements
+
+- Expand `extraObjects` to have more flexibility in templating (@TheRealNoob)
 
 0.12.5 (2025-03-13)
 ----------

--- a/operations/helm/charts/alloy/templates/extra-manifests.yaml
+++ b/operations/helm/charts/alloy/templates/extra-manifests.yaml
@@ -1,4 +1,15 @@
-{{ range .Values.extraObjects }}
+{{- /* Normalize extraObjects to a list, easier to loop over */ -}}
+{{- $extraObjects := .Values.extraObjects | default (list) -}}
+
+{{- if kindIs "map" $extraObjects -}}
+  {{- $extraObjects = values $extraObjects -}}
+{{- end -}}
+
+{{- range $extraObjects }}
 ---
-{{ tpl (toYaml .) $ }}
-{{ end }}
+  {{- if kindIs "map" . }}
+    {{- tpl (toYaml .) $ | nindent 0 }}
+  {{- else if kindIs "string" . }}
+    {{- tpl . $ | nindent 0 }}
+  {{- end }}
+{{- end }}

--- a/operations/helm/charts/alloy/values.yaml
+++ b/operations/helm/charts/alloy/values.yaml
@@ -376,6 +376,8 @@ ingress:
   #      - chart-example.local
 
 # -- Extra k8s manifests to deploy
+# extraObjects can be of type map or slice.  If slice, keys are ignored and only values are used.
+# items contained within extraObjects can be defined as dict or string and are passed through tpl.
 extraObjects: []
 # - apiVersion: v1
 #   kind: Secret


### PR DESCRIPTION
#### PR Description

Expand `extraObjects` to be far more flexible to the consumer of the chart.  Couple top of mind use cases
1. By allowing `extraObjects` as a map, we can now split it across different values files, including encrypted ones.
2. The previous `{{ tpl (toYaml .) $ }}` did not allow templating of `key` names (referencing key, value pairs).  The most common case where someone would want to do this is to when defining a new object that imports the standard labels `{{ include "alloy.labels" . }}` or `{{ include "alloy.selectorLabels" . }}`.

#### Which issue(s) this PR fixes

None

#### Notes to the Reviewer

I've tested this pretty extensively in other projects.  I looked at seeing what I could do for testing here, but to do any kind of adequate testing in this scenario, requires more than simple "does it template" tests IMO.  I have a helm-unittests for this that I've written which I'm happy to share.  Note that it uses `.Values.manifests` and not `.Values.extraObjects`.
https://gist.github.com/TheRealNoob/ca7dee0e862a4e5526a115d54e863ec9



#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
