### PR TITLE
fix(pyroscope.scrape): Fix duplicated `seconds` query param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ Main (unreleased)
 
 - Fix deadlocks in `loki.source.file` when tailing fails (@mblaschke)
 
+- Fix duplicated `seconds` query parameter when scraping pyroscope profiles (@Pluggi)
+
 ### Other changes
 
 - Upgrading to Prometheus v2.55.1. (@ptodev)

--- a/internal/component/pyroscope/scrape/target.go
+++ b/internal/component/pyroscope/scrape/target.go
@@ -342,7 +342,7 @@ func targetsFromGroup(group *targetgroup.Group, cfg Arguments, targetTypes map[s
 					if cfg.DeltaProfilingDuration != defaultProfilingDuration {
 						seconds = (cfg.DeltaProfilingDuration) / time.Second
 					}
-					params.Add("seconds", strconv.Itoa(int(seconds)))
+					params.Set("seconds", strconv.Itoa(int(seconds)))
 				}
 				targets = append(targets, NewTarget(lbls, params))
 			}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR fixes the duplicated `seconds` query parameter when scraping profiles.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #3026

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
