### PR TITLE
refactor(pyroscope.write): Forward content-type header only.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,8 @@ Main (unreleased)
 
 - Change the stability of the `beyla.ebpf` component from "public preview" to "generally available". (@marctc)
 
+- The ingest API of `pyrscope.receive_http` no longer forwards all received headers, instead only passes through the `Content-Type` header. 
+
 v1.7.5
 -----------------
 

--- a/internal/component/pyroscope/receive_http/receive_http.go
+++ b/internal/component/pyroscope/receive_http/receive_http.go
@@ -266,10 +266,10 @@ func (c *Component) handleIngest(w http.ResponseWriter, r *http.Request) {
 		go func() {
 			defer wg.Done()
 			profile := &pyroscope.IncomingProfile{
-				RawBody: buf.Bytes(),
-				Headers: r.Header.Clone(),
-				URL:     r.URL,
-				Labels:  lbls,
+				RawBody:     buf.Bytes(),
+				ContentType: r.Header.Values(pyroscope.HeaderContentType),
+				URL:         r.URL,
+				Labels:      lbls,
 			}
 
 			if err := appendable.Appender().AppendIngest(r.Context(), profile); err != nil {

--- a/internal/component/pyroscope/write/write_test.go
+++ b/internal/component/pyroscope/write/write_test.go
@@ -281,8 +281,8 @@ func Test_Write_AppendIngest(t *testing.T) {
 			require.Equal(t, expectedPath, r.URL.Path, "Unexpected path")
 
 			// Header assertions
-			require.Equal(t, "endpoint-value", r.Header.Get("X-Test-Header"))
-			require.Equal(t, []string{"profile-value1", "profile-value2"}, r.Header["X-Profile-Header"])
+			require.Equal(t, "i-am-so-good", r.Header.Get("X-Good-Header"))
+			require.Equal(t, []string{"profile-value1", "profile-value2"}, r.Header["Content-Type"])
 
 			// Label assertions - parse the name parameter once
 			ls, err := labelset.Parse(r.URL.Query().Get("name"))
@@ -321,7 +321,8 @@ func Test_Write_AppendIngest(t *testing.T) {
 			URL:           servers[i].URL,
 			RemoteTimeout: GetDefaultEndpointOptions().RemoteTimeout,
 			Headers: map[string]string{
-				"X-Test-Header": "endpoint-value",
+				"ContentType":   "evil-content-type",
+				"X-Good-Header": "i-am-so-good",
 				"X-Server-ID":   strconv.Itoa(int(i)),
 			},
 		})
@@ -356,9 +357,8 @@ func Test_Write_AppendIngest(t *testing.T) {
 
 	incomingProfile := &pyroscope.IncomingProfile{
 		RawBody: testData,
-		Headers: http.Header{
-			"X-Test-Header":    []string{"profile-value"},                    // This should be overridden by endpoint
-			"X-Profile-Header": []string{"profile-value1", "profile-value2"}, // This should be preserved
+		ContentType: []string{
+			"profile-value1", "profile-value2", // This should be preserved
 		},
 		URL: &url.URL{
 			Path:     "/ingest",


### PR DESCRIPTION
We currently forward all incoming headers of the profile /ingest request
to the endpoints defined in `pyroscope.write`.

I think this is risky. We already had bugs (like #2201) and there probably
a couple more in there already, as I noticed we send on headers like
`Content-Length`.

I think we should change this and only forward `Content-Type`, before
anyone starts relying on this, as this is the only header used:

https://github.com/simonswine/pyroscope/blob/b57274a5acbfa867660938ba7e7f5171c3114d68/pkg/ingester/pyroscope/ingest_handler.go#L132

This is still technically a breaking change, but I think it should go
forward, as the stabililty of the component is only "public-preview"
after all.

Fixes #2612
