### PR TITLE
fix: Move operator.scrapeconfigs into the correct part of changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Main (unreleased)
 
 ### Enhancements
 
+- (_Experimental_) Adding a new `prometheus.operator.scrapeconfigs` which discovers and scrapes [ScrapeConfig](https://prometheus-operator.dev/docs/developer/scrapeconfig/) Kubernetes resources. (@alex-berger)
+
 - Add `rfc3164_default_to_current_year` argument to `loki.source.syslog` (@dehaansa)
 
 - Add `connection_name` support for `prometheus.exporter.mssql` (@bck01215)
@@ -145,8 +147,6 @@ v1.7.0
   cumulative temporality to delta. (@madaraszg-tulip)
 
 - (_Experimental_) Add a `stage.windowsevent` block in the `loki.process` component. This aims to replace the existing `stage.eventlogmessage`. (@wildum)
-
-- (_Experimental_) Adding a new `prometheus.operator.scrapeconfigs` which discovers and scrapes [ScrapeConfig](https://prometheus-operator.dev/docs/developer/scrapeconfig/) Kubernetes resources. (@alex-berger)
 
 - Add `pyroscope.relabel` component to modify or filter profiles using Prometheus relabeling rules. (@marcsanmi)
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
When https://github.com/grafana/alloy/pull/2638 was merged, the changelog entry was in the wrong place. It is not in 1.7.0, it will be in next release.
