### PR TITLE
fix: add missing RBAC permission for ScrapeConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Main (unreleased)
 ### Bugfixes
 
 - Fix deadlocks in `loki.source.file` when tailing fails (@mblaschke)
+- Add missing RBAC permission for ScrapeConfig (@.alex-berger)
 
 ### Other changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ Main (unreleased)
 ### Bugfixes
 
 - Fix deadlocks in `loki.source.file` when tailing fails (@mblaschke)
-- Add missing RBAC permission for ScrapeConfig (@.alex-berger)
+- Add missing RBAC permission for ScrapeConfig (@alex-berger)
 
 ### Other changes
 

--- a/operations/helm/charts/alloy/templates/rbac.yaml
+++ b/operations/helm/charts/alloy/templates/rbac.yaml
@@ -62,6 +62,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/additional-serviceaccount-label/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/additional-serviceaccount-label/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/clustering/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/clustering/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/controller-deployment-pdb-max-unavailable/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/controller-deployment-pdb-max-unavailable/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/controller-deployment-pdb-min-available/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/controller-deployment-pdb-min-available/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/controller-statefulset-pdb-max-unavailable/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/controller-statefulset-pdb-max-unavailable/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/controller-statefulset-pdb-min-available/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/controller-statefulset-pdb-min-available/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/controller-volumes-extra/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/controller-volumes-extra/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/create-daemonset-hostnetwork/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/create-daemonset-hostnetwork/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/create-daemonset/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/create-daemonset/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/create-deployment-autoscaling/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/create-deployment-autoscaling/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/create-deployment/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/create-deployment/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/create-statefulset-autoscaling/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/create-statefulset-autoscaling/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/create-statefulset/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/create-statefulset/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/custom-config/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/custom-config/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/default-values/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/default-values/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/enable-servicemonitor-tls/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/enable-servicemonitor-tls/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/enable-servicemonitor/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/enable-servicemonitor/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/envFrom/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/envFrom/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/existing-config/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/existing-config/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/extra-env/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/extra-env/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/extra-manifests/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/extra-manifests/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/extra-ports/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/extra-ports/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/faro-ingress/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/faro-ingress/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/global-image-pullsecrets/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/global-image-pullsecrets/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/global-image-registry/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/global-image-registry/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/host-alias/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/host-alias/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/initcontainers/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/initcontainers/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/lifecycle-hooks/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/lifecycle-hooks/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/livinessprobe/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/livinessprobe/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/local-image-pullsecrets/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/local-image-pullsecrets/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/local-image-registry/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/local-image-registry/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/nodeselectors-and-tolerations/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/nodeselectors-and-tolerations/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/nonroot/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/nonroot/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/pod_annotations/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/pod_annotations/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/sidecars/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/sidecars/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/termination-grace-period/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/termination-grace-period/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/topologyspreadconstraints/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/topologyspreadconstraints/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list

--- a/operations/helm/tests/with-digests/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/with-digests/alloy/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - podmonitors
       - servicemonitors
       - probes
+      - scrapeconfigs
     verbs:
       - get
       - list


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Add missing _RBAC_ permission for _ScrapeConfig_, required for component `prometheus.operator.scrapeconfigs`.

This is a followup to https://github.com/grafana/alloy/pull/2638 and https://github.com/grafana/alloy/issues/1428.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
