### PR TITLE
Fix Windows tests

### DIFF
--- a/internal/converter/internal/staticconvert/testdata_windows/promtail_prom.alloy
+++ b/internal/converter/internal/staticconvert/testdata_windows/promtail_prom.alloy
@@ -18,7 +18,7 @@ prometheus.scrape "metrics_name_jobName" {
 
 prometheus.remote_write "metrics_name" {
 	endpoint {
-		name = "name-c3a75f"
+		name = "name-b174ee"
 		url  = "http://localhost:9009/api/prom/push"
 
 		queue_config { }


### PR DESCRIPTION
The Windows tests on `main` have been [broken](https://github.com/grafana/alloy/actions/runs/13978740434/job/39138917834).