### PR TITLE
database_observability: add query sample collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Main (unreleased)
   - `query_sample`: better handling of truncated queries (@cristiangreco)
   - `query_sample`: add option to use TiDB sql parser (@cristiangreco)
   - `query_tables`: rename collector from `query_sample` to better reflect responsibility (@matthewnolf)
+  - `query_sample`: add new collector that replaces previous implementation to collect more detailed sample information (@matthewnolf)
 
 - Add labels validation in `pyroscope.write` to prevent duplicate labels and invalid label names/values. (@marcsanmi)
 

--- a/docs/sources/reference/components/database_observability/database_observability.mysql.md
+++ b/docs/sources/reference/components/database_observability/database_observability.mysql.md
@@ -35,8 +35,9 @@ The following collectors are enabled by default:
 
  Name           | Description                                           
 ----------------|-------------------------------------------------------
- `query_tables` | Collect query table information..                                
+ `query_tables` | Collect query table information.
  `schema_table` | Collect schemas and tables from `information_schema`. 
+ `query_sample` | Collect query samples.
 
 ## Blocks
 

--- a/internal/component/database_observability/mysql/collector/query_sample.go
+++ b/internal/component/database_observability/mysql/collector/query_sample.go
@@ -1,0 +1,290 @@
+package collector
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-kit/log"
+	"go.uber.org/atomic"
+
+	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/component/database_observability/mysql/collector/parser"
+	"github.com/grafana/alloy/internal/runtime/logging/level"
+)
+
+const (
+	OP_QUERY_SAMPLE = "query_sample"
+	QuerySampleName = "query_sample"
+)
+
+const selectLatestTimerEnd = `SELECT MAX(TIMER_END) FROM performance_schema.events_statements_history`
+
+const selectQuerySamples = `
+SELECT unix_timestamp()             AS now,
+       global_status.variable_value AS uptime,
+       statements.CURRENT_SCHEMA,
+       statements.DIGEST,
+	   statements.DIGEST_TEXT,
+	   statements.TIMER_START,
+       statements.TIMER_END,
+       statements.TIMER_WAIT,
+       statements.CPU_TIME,
+       statements.ROWS_EXAMINED,
+       statements.ROWS_SENT,
+       statements.ROWS_AFFECTED,
+	   statements.ERRORS,
+       statements.MAX_CONTROLLED_MEMORY,
+       statements.MAX_TOTAL_MEMORY
+FROM performance_schema.events_statements_history AS statements
+JOIN performance_schema.global_status
+WHERE statements.sql_text IS NOT NULL
+  AND global_status.variable_name = 'UPTIME'
+  AND statements.CURRENT_SCHEMA NOT IN ('mysql', 'performance_schema', 'sys', 'information_schema')
+  AND statements.TIMER_END >= ?;`
+
+type QuerySampleArguments struct {
+	DB              *sql.DB
+	InstanceKey     string
+	CollectInterval time.Duration
+	EntryHandler    loki.EntryHandler
+	UseTiDBParser   bool
+
+	Logger log.Logger
+}
+
+type QuerySample struct {
+	dbConnection    *sql.DB
+	instanceKey     string
+	collectInterval time.Duration
+	entryHandler    loki.EntryHandler
+	sqlParser       parser.Parser
+
+	logger  log.Logger
+	running *atomic.Bool
+	ctx     context.Context
+	cancel  context.CancelFunc
+
+	lastSampleSeenTimestamp float64
+}
+
+func NewQuerySample(args QuerySampleArguments) (*QuerySample, error) {
+	c := &QuerySample{
+		dbConnection:    args.DB,
+		instanceKey:     args.InstanceKey,
+		collectInterval: args.CollectInterval,
+		entryHandler:    args.EntryHandler,
+		logger:          log.With(args.Logger, "collector", QuerySampleName),
+		running:         &atomic.Bool{},
+	}
+
+	if args.UseTiDBParser {
+		c.sqlParser = parser.NewTiDBSqlParser()
+	} else {
+		c.sqlParser = parser.NewXwbSqlParser()
+	}
+
+	return c, nil
+}
+
+func (c *QuerySample) Name() string {
+	return QuerySampleName
+}
+
+func (c *QuerySample) Start(ctx context.Context) error {
+	level.Debug(c.logger).Log("msg", QuerySampleName+" collector started")
+
+	c.running.Store(true)
+	ctx, cancel := context.WithCancel(ctx)
+	c.ctx = ctx
+	c.cancel = cancel
+
+	if err := c.setLastSampleSeenTimestamp(c.ctx); err != nil {
+		level.Error(c.logger).Log("msg", "failed to set last sample seen timestamp", "err", err)
+		return err
+	}
+
+	go func() {
+		defer func() {
+			c.Stop()
+			c.running.Store(false)
+		}()
+
+		ticker := time.NewTicker(c.collectInterval)
+
+		for {
+			if err := c.fetchQuerySamples(c.ctx); err != nil {
+				level.Error(c.logger).Log("msg", "collector error", "err", err)
+			}
+
+			select {
+			case <-c.ctx.Done():
+				return
+			case <-ticker.C:
+				// continue loop
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (c *QuerySample) Stopped() bool {
+	return !c.running.Load()
+}
+
+// Stop should be kept idempotent
+func (c *QuerySample) Stop() {
+	c.cancel()
+}
+
+// setLastSampleSeenTimestamp queries the database for the latest sample seen timestamp so that upon startup we don't collect
+// samples that may have been collected previously.
+func (c *QuerySample) setLastSampleSeenTimestamp(ctx context.Context) error {
+	rs, err := c.dbConnection.QueryContext(ctx, selectLatestTimerEnd)
+	if err != nil {
+		return fmt.Errorf("failed to fetch last sample seen timestamp: %w", err)
+	}
+	defer rs.Close()
+
+	for rs.Next() {
+		if err := rs.Err(); err != nil {
+			return fmt.Errorf("failed to iterate rows: %w", err)
+		}
+		var ts sql.NullFloat64
+		err := rs.Scan(&ts)
+		if err != nil {
+			return fmt.Errorf("failed to scan row: %w", err)
+		}
+		if !ts.Valid {
+			return fmt.Errorf("no valid timestamp found: %w", err)
+		}
+		c.lastSampleSeenTimestamp = ts.Float64
+	}
+	return nil
+}
+
+func (c *QuerySample) fetchQuerySamples(ctx context.Context) error {
+	rs, err := c.dbConnection.QueryContext(ctx, selectQuerySamples, c.lastSampleSeenTimestamp)
+	if err != nil {
+		level.Error(c.logger).Log("msg", "failed to fetch history table samples", "err", err)
+		return err
+	}
+	defer rs.Close()
+
+	for rs.Next() {
+		row := struct {
+			// system times
+			NowSeconds    uint64
+			UptimeSeconds uint64
+
+			// sample metadata
+			Schema     sql.NullString
+			Digest     sql.NullString
+			DigestText sql.NullString
+
+			// sample time
+			TimerStartPicoseconds  sql.NullFloat64
+			TimerEndPicoseconds    sql.NullFloat64
+			ElapsedTimePicoseconds sql.NullInt64
+			CPUTime                uint64
+
+			// sample row info
+			RowsExamined uint64
+			RowsSent     uint64
+			RowsAffected uint64
+			Errors       uint64
+
+			// sample memory info
+			MaxControlledMemory uint64
+			MaxTotalMemory      uint64
+		}{}
+
+		err := rs.Scan(
+			&row.NowSeconds,
+			&row.UptimeSeconds,
+			&row.Schema,
+			&row.Digest,
+			&row.DigestText,
+			&row.TimerStartPicoseconds,
+			&row.TimerEndPicoseconds,
+			&row.ElapsedTimePicoseconds,
+			&row.CPUTime,
+			&row.RowsExamined,
+			&row.RowsSent,
+			&row.RowsAffected,
+			&row.Errors,
+			&row.MaxControlledMemory,
+			&row.MaxTotalMemory,
+		)
+		if err != nil {
+			level.Error(c.logger).Log("msg", "failed to scan history table samples", "err", err)
+			continue
+		}
+
+		if row.TimerEndPicoseconds.Valid && row.TimerEndPicoseconds.Float64 > c.lastSampleSeenTimestamp {
+			c.lastSampleSeenTimestamp = row.TimerEndPicoseconds.Float64
+		}
+
+		if strings.HasSuffix(row.DigestText.String, "...") {
+			// best-effort attempt to detect truncated trailing comment
+			idx := strings.LastIndex(row.DigestText.String, "/*")
+			if idx < 0 {
+				level.Debug(c.logger).Log("msg", "skipping parsing truncated query", "schema", row.Schema.String, "digest", row.Digest.String)
+				continue
+			}
+
+			trailingText := row.DigestText.String[idx:]
+			if strings.LastIndex(trailingText, "*/") >= 0 {
+				level.Debug(c.logger).Log("msg", "skipping parsing truncated query with comment", "schema", row.Schema.String, "digest", row.Digest.String)
+				continue
+			}
+
+			row.DigestText = sql.NullString{
+				String: row.DigestText.String[:idx],
+				Valid:  true,
+			}
+		}
+
+		redactedDigestText, err := c.sqlParser.Redact(row.DigestText.String)
+		if err != nil {
+			level.Error(c.logger).Log("msg", "failed to redact sql query", "schema", row.Schema.String, "digest", row.Digest.String, "err", err)
+			continue
+		}
+		row.DigestText = sql.NullString{
+			String: redactedDigestText,
+			Valid:  true,
+		}
+		cpuTime := float64(row.CPUTime) / 1e9
+		elapsedTime := float64(row.ElapsedTimePicoseconds.Int64) / 1e9
+
+		c.entryHandler.Chan() <- buildLokiEntry(
+			OP_QUERY_SAMPLE,
+			c.instanceKey,
+			fmt.Sprintf(
+				`schema="%s" digest="%s" digest_text="%s" rows_examined="%d" rows_sent="%d" rows_affected="%d" errors="%d" max_controlled_memory="%db" max_total_memory="%db" cpu_time="%fms" elapsed_time="%fms" elapsed_time_extracted="%fms"`,
+				row.Schema.String,
+				row.Digest.String,
+				row.DigestText.String,
+				row.RowsExamined,
+				row.RowsSent,
+				row.RowsAffected,
+				row.Errors,
+				row.MaxControlledMemory,
+				row.MaxTotalMemory,
+				cpuTime,
+				elapsedTime,
+				elapsedTime,
+			),
+		)
+	}
+
+	if err := rs.Err(); err != nil {
+		level.Error(c.logger).Log("msg", "error during iterating over samples result set", "err", err)
+		return err
+	}
+
+	return nil
+}

--- a/internal/component/database_observability/mysql/collector/query_sample.go
+++ b/internal/component/database_observability/mysql/collector/query_sample.go
@@ -24,26 +24,26 @@ const selectLatestTimerEnd = `SELECT MAX(TIMER_END) FROM performance_schema.even
 
 const selectQuerySamples = `
 SELECT unix_timestamp()             AS now,
-       global_status.variable_value AS uptime,
-       statements.CURRENT_SCHEMA,
-       statements.DIGEST,
-	   statements.DIGEST_TEXT,
-	   statements.TIMER_START,
-       statements.TIMER_END,
-       statements.TIMER_WAIT,
-       statements.CPU_TIME,
-       statements.ROWS_EXAMINED,
-       statements.ROWS_SENT,
-       statements.ROWS_AFFECTED,
-	   statements.ERRORS,
-       statements.MAX_CONTROLLED_MEMORY,
-       statements.MAX_TOTAL_MEMORY
+	global_status.variable_value AS uptime,
+	statements.CURRENT_SCHEMA,
+	statements.DIGEST,
+	statements.DIGEST_TEXT,
+	statements.TIMER_START,
+	statements.TIMER_END,
+	statements.TIMER_WAIT,
+	statements.CPU_TIME,
+	statements.ROWS_EXAMINED,
+	statements.ROWS_SENT,
+	statements.ROWS_AFFECTED,
+	statements.ERRORS,
+	statements.MAX_CONTROLLED_MEMORY,
+	statements.MAX_TOTAL_MEMORY
 FROM performance_schema.events_statements_history AS statements
 JOIN performance_schema.global_status
 WHERE statements.sql_text IS NOT NULL
-  AND global_status.variable_name = 'UPTIME'
-  AND statements.CURRENT_SCHEMA NOT IN ('mysql', 'performance_schema', 'sys', 'information_schema')
-  AND statements.TIMER_END >= ?;`
+	AND global_status.variable_name = 'UPTIME'
+	AND statements.CURRENT_SCHEMA NOT IN ('mysql', 'performance_schema', 'sys', 'information_schema')
+	AND statements.TIMER_END >= ?;`
 
 type QuerySampleArguments struct {
 	DB              *sql.DB
@@ -150,9 +150,6 @@ func (c *QuerySample) setLastSampleSeenTimestamp(ctx context.Context) error {
 	defer rs.Close()
 
 	for rs.Next() {
-		if err := rs.Err(); err != nil {
-			return fmt.Errorf("failed to iterate rows: %w", err)
-		}
 		var ts sql.NullFloat64
 		err := rs.Scan(&ts)
 		if err != nil {
@@ -162,6 +159,9 @@ func (c *QuerySample) setLastSampleSeenTimestamp(ctx context.Context) error {
 			return fmt.Errorf("no valid timestamp found: %w", err)
 		}
 		c.lastSampleSeenTimestamp = ts.Float64
+	}
+	if err := rs.Err(); err != nil {
+		return fmt.Errorf("failed to iterate rows: %w", err)
 	}
 	return nil
 }
@@ -224,10 +224,16 @@ func (c *QuerySample) fetchQuerySamples(ctx context.Context) error {
 			continue
 		}
 
-		if row.TimerEndPicoseconds.Valid && row.TimerEndPicoseconds.Float64 > c.lastSampleSeenTimestamp {
+		if !row.TimerEndPicoseconds.Valid {
+			level.Debug(c.logger).Log("msg", "skipping query with invalid timer end timestamp", "schema", row.Schema.String, "digest", row.Digest.String, "timer_end", row.TimerEndPicoseconds.Float64)
+			continue
+		}
+
+		if row.TimerEndPicoseconds.Float64 > c.lastSampleSeenTimestamp {
 			c.lastSampleSeenTimestamp = row.TimerEndPicoseconds.Float64
 		}
 
+		digestText := row.DigestText.String
 		if strings.HasSuffix(row.DigestText.String, "...") {
 			// best-effort attempt to detect truncated trailing comment
 			idx := strings.LastIndex(row.DigestText.String, "/*")
@@ -242,21 +248,15 @@ func (c *QuerySample) fetchQuerySamples(ctx context.Context) error {
 				continue
 			}
 
-			row.DigestText = sql.NullString{
-				String: row.DigestText.String[:idx],
-				Valid:  true,
-			}
+			digestText = row.DigestText.String[:idx]
 		}
 
-		redactedDigestText, err := c.sqlParser.Redact(row.DigestText.String)
+		digestText, err = c.sqlParser.Redact(digestText)
 		if err != nil {
 			level.Error(c.logger).Log("msg", "failed to redact sql query", "schema", row.Schema.String, "digest", row.Digest.String, "err", err)
 			continue
 		}
-		row.DigestText = sql.NullString{
-			String: redactedDigestText,
-			Valid:  true,
-		}
+
 		cpuTime := float64(row.CPUTime) / 1e9
 		elapsedTime := float64(row.ElapsedTimePicoseconds.Int64) / 1e9
 
@@ -264,10 +264,10 @@ func (c *QuerySample) fetchQuerySamples(ctx context.Context) error {
 			OP_QUERY_SAMPLE,
 			c.instanceKey,
 			fmt.Sprintf(
-				`schema="%s" digest="%s" digest_text="%s" rows_examined="%d" rows_sent="%d" rows_affected="%d" errors="%d" max_controlled_memory="%db" max_total_memory="%db" cpu_time="%fms" elapsed_time="%fms" elapsed_time_extracted="%fms"`,
+				`schema="%s" digest="%s" digest_text="%s" rows_examined="%d" rows_sent="%d" rows_affected="%d" errors="%d" max_controlled_memory="%db" max_total_memory="%db" cpu_time="%fms" elapsed_time="%fms" elapsed_time_ms="%fms"`,
 				row.Schema.String,
 				row.Digest.String,
-				row.DigestText.String,
+				digestText,
 				row.RowsExamined,
 				row.RowsSent,
 				row.RowsAffected,

--- a/internal/component/database_observability/mysql/collector/query_sample_test.go
+++ b/internal/component/database_observability/mysql/collector/query_sample_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/grafana/alloy/internal/component/database_observability"
 )
 
-func TestQuerySamples(t *testing.T) {
+func TestQuerySample(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
 	testcases := []struct {
@@ -50,7 +50,7 @@ func TestQuerySamples(t *testing.T) {
 				{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"},
 			},
 			logsLines: []string{
-				`schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_extracted="0.020000ms"`,
+				`schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_ms="0.020000ms"`,
 			},
 		},
 		{
@@ -92,7 +92,7 @@ func TestQuerySamples(t *testing.T) {
 				{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"},
 			},
 			logsLines: []string{
-				`schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_extracted="0.020000ms"`,
+				`schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_ms="0.020000ms"`,
 			},
 		},
 		{
@@ -119,7 +119,7 @@ func TestQuerySamples(t *testing.T) {
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 			},
 			logsLines: []string{
-				`schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_extracted="0.020000ms"`,
+				`schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_ms="0.020000ms"`,
 			},
 		},
 		{
@@ -167,7 +167,7 @@ func TestQuerySamples(t *testing.T) {
 				{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"},
 			},
 			logsLines: []string{
-				`schema="some_schema" digest="some_digest" digest_text="begin" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_extracted="0.020000ms"`,
+				`schema="some_schema" digest="some_digest" digest_text="begin" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_ms="0.020000ms"`,
 			},
 		},
 		{
@@ -209,7 +209,7 @@ func TestQuerySamples(t *testing.T) {
 				{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"},
 			},
 			logsLines: []string{
-				`schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_extracted="0.020000ms"`,
+				`schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_ms="0.020000ms"`,
 			},
 		},
 		{
@@ -252,8 +252,8 @@ func TestQuerySamples(t *testing.T) {
 				{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"},
 			},
 			logsLines: []string{
-				`schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_extracted="0.020000ms"`,
-				`schema="some_other_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_extracted="0.020000ms"`,
+				`schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_ms="0.020000ms"`,
+				`schema="some_other_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_ms="0.020000ms"`,
 			},
 		},
 		{
@@ -279,7 +279,7 @@ func TestQuerySamples(t *testing.T) {
 				{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"},
 			},
 			logsLines: []string{
-				`schema="some_schema" digest="some_digest" digest_text="select * from (select id, name from employees_us_east union select id, name from employees_us_west) as employees_us union select id, name from employees_emea" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_extracted="0.020000ms"`,
+				`schema="some_schema" digest="some_digest" digest_text="select * from (select id, name from employees_us_east union select id, name from employees_us_west) as employees_us union select id, name from employees_emea" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_ms="0.020000ms"`,
 			},
 		},
 		{
@@ -305,7 +305,7 @@ func TestQuerySamples(t *testing.T) {
 				{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"},
 			},
 			logsLines: []string{
-				`schema="some_schema" digest="some_digest" digest_text="show create table" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_extracted="0.020000ms"`,
+				`schema="some_schema" digest="some_digest" digest_text="show create table" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_ms="0.020000ms"`,
 			},
 		},
 	}
@@ -390,10 +390,9 @@ func TestQuerySamples(t *testing.T) {
 }
 
 func TestQuerySampleUpdatesLastSampleSeenTimestamp(t *testing.T) {
+	defer goleak.VerifyNone(t)
 	t.Run("fetch new samples after the last sample seen timestamp", func(t *testing.T) {
 		t.Parallel()
-
-		defer goleak.VerifyNone(t)
 
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
@@ -512,8 +511,8 @@ func TestQuerySampleUpdatesLastSampleSeenTimestamp(t *testing.T) {
 
 		lokiEntries := lokiClient.Received()
 		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"}, lokiEntries[0].Labels)
-		require.Equal(t, `schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_extracted="0.020000ms"`, lokiEntries[0].Line)
-		require.Equal(t, `schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_extracted="0.020000ms"`, lokiEntries[0].Line)
+		require.Equal(t, `schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_ms="0.020000ms"`, lokiEntries[0].Line)
+		require.Equal(t, `schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_ms="0.020000ms"`, lokiEntries[0].Line)
 	})
 }
 
@@ -611,7 +610,7 @@ func TestQuerySampleSQLDriverErrors(t *testing.T) {
 
 		lokiEntries := lokiClient.Received()
 		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"}, lokiEntries[0].Labels)
-		require.Equal(t, `schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_extracted="0.020000ms"`, lokiEntries[0].Line)
+		require.Equal(t, `schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_ms="0.020000ms"`, lokiEntries[0].Line)
 	})
 
 	t.Run("result set iteration error", func(t *testing.T) {
@@ -713,7 +712,7 @@ func TestQuerySampleSQLDriverErrors(t *testing.T) {
 
 		lokiEntries := lokiClient.Received()
 		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"}, lokiEntries[0].Labels)
-		require.Equal(t, `schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_extracted="0.020000ms"`, lokiEntries[0].Line)
+		require.Equal(t, `schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_ms="0.020000ms"`, lokiEntries[0].Line)
 	})
 
 	t.Run("connection error recovery", func(t *testing.T) {
@@ -800,6 +799,6 @@ func TestQuerySampleSQLDriverErrors(t *testing.T) {
 
 		lokiEntries := lokiClient.Received()
 		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"}, lokiEntries[0].Labels)
-		require.Equal(t, `schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_extracted="0.020000ms"`, lokiEntries[0].Line)
+		require.Equal(t, `schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_ms="0.020000ms"`, lokiEntries[0].Line)
 	})
 }

--- a/internal/component/database_observability/mysql/collector/query_sample_test.go
+++ b/internal/component/database_observability/mysql/collector/query_sample_test.go
@@ -1,0 +1,805 @@
+package collector
+
+import (
+	"context"
+	"database/sql/driver"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/go-kit/log"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	loki_fake "github.com/grafana/alloy/internal/component/common/loki/client/fake"
+	"github.com/grafana/alloy/internal/component/database_observability"
+)
+
+func TestQuerySamples(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	testcases := []struct {
+		name       string
+		rows       [][]driver.Value
+		logsLabels []model.LabelSet
+		logsLines  []string
+	}{
+		{
+			name: "select query",
+			rows: [][]driver.Value{{
+				"1",
+				"2",
+				"some_schema",
+				"some_digest",
+				"select * from some_table where id = 1",
+				"50000000",
+				"70000000",
+				"20000000",
+				"10000000",
+				"5",
+				"5",
+				"0",
+				"0",
+				"456",
+				"457",
+			}},
+			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"},
+			},
+			logsLines: []string{
+				`schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_extracted="0.020000ms"`,
+			},
+		},
+		{
+			name: "truncated query",
+			rows: [][]driver.Value{{
+				"3",
+				"4",
+				"some_schema",
+				"some_digest",
+				"insert into some_table (`id1`, `id2`, `id3`, `id...",
+				"50000000",
+				"70000000",
+				"20000000",
+				"10000000",
+				"5",
+				"5",
+				"0",
+				"0",
+				"456",
+				"457",
+			}, {
+				"1",
+				"2",
+				"some_schema",
+				"some_digest",
+				"select * from some_table where id = 1",
+				"50000000",
+				"70000000",
+				"20000000",
+				"10000000",
+				"5",
+				"5",
+				"0",
+				"0",
+				"456",
+				"457",
+			}},
+			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"},
+			},
+			logsLines: []string{
+				`schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_extracted="0.020000ms"`,
+			},
+		},
+		{
+			name: "truncated in multi-line comment",
+			rows: [][]driver.Value{{
+				"1",
+				"2",
+				"some_schema",
+				"some_digest",
+				"select * from some_table where id = 1 /*traceparent='00-abc...",
+				"50000000",
+				"70000000",
+				"20000000",
+				"10000000",
+				"5",
+				"5",
+				"0",
+				"0",
+				"456",
+				"457",
+			}},
+			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"},
+				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
+			},
+			logsLines: []string{
+				`schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_extracted="0.020000ms"`,
+			},
+		},
+		{
+			name: "truncated with properly closed comment",
+			rows: [][]driver.Value{{
+				"1",
+				"2",
+				"some_schema",
+				"some_digest",
+				"select * from some_table where id = 1 /* comment that's closed */ and name = 'test...",
+				"50000000",
+				"70000000",
+				"20000000",
+				"10000000",
+				"5",
+				"5",
+				"0",
+				"0",
+				"456",
+				"457",
+			}},
+			logsLabels: []model.LabelSet{},
+			logsLines:  []string{},
+		},
+		{
+			name: "start transaction",
+			rows: [][]driver.Value{{
+				"1",
+				"2",
+				"some_schema",
+				"some_digest",
+				"START TRANSACTION",
+				"50000000",
+				"70000000",
+				"20000000",
+				"10000000",
+				"5",
+				"5",
+				"0",
+				"0",
+				"456",
+				"457",
+			}},
+			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"},
+			},
+			logsLines: []string{
+				`schema="some_schema" digest="some_digest" digest_text="begin" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_extracted="0.020000ms"`,
+			},
+		},
+		{
+			name: "sql parse error",
+			rows: [][]driver.Value{{
+				"1",
+				"2",
+				"some_schema",
+				"some_digest",
+				"select * from some_table where id = 1",
+				"50000000",
+				"70000000",
+				"20000000",
+				"10000000",
+				"5",
+				"5",
+				"0",
+				"0",
+				"456",
+				"457",
+			}, {
+				"1",
+				"2",
+				"some_schema",
+				"some_digest",
+				"not valid sql",
+				"50000000",
+				"70000000",
+				"20000000",
+				"10000000",
+				"5",
+				"5",
+				"0",
+				"0",
+				"456",
+				"457",
+			}},
+			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"},
+			},
+			logsLines: []string{
+				`schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_extracted="0.020000ms"`,
+			},
+		},
+		{
+			name: "multiple schemas",
+			rows: [][]driver.Value{{
+				"1",
+				"2",
+				"some_schema",
+				"some_digest",
+				"select * from some_table where id = 1",
+				"50000000",
+				"70000000",
+				"20000000",
+				"10000000",
+				"5",
+				"5",
+				"0",
+				"0",
+				"456",
+				"457",
+			}, {
+				"1",
+				"2",
+				"some_other_schema",
+				"some_digest",
+				"select * from some_table where id = 1",
+				"50000000",
+				"70000000",
+				"20000000",
+				"10000000",
+				"5",
+				"5",
+				"0",
+				"0",
+				"456",
+				"457",
+			}},
+			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"},
+				{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"},
+			},
+			logsLines: []string{
+				`schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_extracted="0.020000ms"`,
+				`schema="some_other_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_extracted="0.020000ms"`,
+			},
+		},
+		{
+			name: "subquery and union",
+			rows: [][]driver.Value{{
+				"1",
+				"2",
+				"some_schema",
+				"some_digest",
+				"SELECT * FROM (SELECT id, name FROM employees_us_east UNION SELECT id, name FROM employees_us_west) as employees_us UNION SELECT id, name FROM employees_emea",
+				"50000000",
+				"70000000",
+				"20000000",
+				"10000000",
+				"5",
+				"5",
+				"0",
+				"0",
+				"456",
+				"457",
+			}},
+			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"},
+			},
+			logsLines: []string{
+				`schema="some_schema" digest="some_digest" digest_text="select * from (select id, name from employees_us_east union select id, name from employees_us_west) as employees_us union select id, name from employees_emea" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_extracted="0.020000ms"`,
+			},
+		},
+		{
+			name: "show create table (table name is not parsed)",
+			rows: [][]driver.Value{{
+				"1",
+				"2",
+				"some_schema",
+				"some_digest",
+				"SHOW CREATE TABLE some_table",
+				"50000000",
+				"70000000",
+				"20000000",
+				"10000000",
+				"5",
+				"5",
+				"0",
+				"0",
+				"456",
+				"457",
+			}},
+			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"},
+			},
+			logsLines: []string{
+				`schema="some_schema" digest="some_digest" digest_text="show create table" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_extracted="0.020000ms"`,
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+			require.NoError(t, err)
+			defer db.Close()
+
+			lokiClient := loki_fake.NewClient(func() {})
+
+			collector, err := NewQuerySample(QuerySampleArguments{
+				DB:              db,
+				InstanceKey:     "mysql-db",
+				CollectInterval: time.Second,
+				EntryHandler:    lokiClient,
+				Logger:          log.NewLogfmtLogger(os.Stderr),
+			})
+			require.NoError(t, err)
+			require.NotNil(t, collector)
+
+			mock.ExpectQuery(selectLatestTimerEnd).WithoutArgs().RowsWillBeClosed().
+				WillReturnRows(
+					sqlmock.NewRows([]string{
+						"timer_end",
+					}).AddRow(
+						"1",
+					),
+				)
+
+			mock.ExpectQuery(selectQuerySamples).WithArgs(float64(1)).RowsWillBeClosed().
+				WillReturnRows(
+					sqlmock.NewRows([]string{
+						"now",
+						"uptime",
+						"statements.CURRENT_SCHEMA",
+						"statements.DIGEST",
+						"statements.DIGEST_TEXT",
+						"statements.TIMER_START",
+						"statements.TIMER_END",
+						"statements.TIMER_WAIT",
+						"statements.CPU_TIME",
+						"statements.ROWS_EXAMINED",
+						"statements.ROWS_SENT",
+						"statements.ROWS_AFFECTED",
+						"statements.ERRORS",
+						"statements.MAX_CONTROLLED_MEMORY",
+						"statements.MAX_TOTAL_MEMORY",
+					}).AddRows(
+						tc.rows...,
+					),
+				)
+
+			err = collector.Start(context.Background())
+			require.NoError(t, err)
+
+			require.Eventually(t, func() bool {
+				return len(lokiClient.Received()) == len(tc.logsLines)
+			}, 5*time.Second, 100*time.Millisecond)
+
+			collector.Stop()
+			lokiClient.Stop()
+
+			require.Eventually(t, func() bool {
+				return collector.Stopped()
+			}, 5*time.Second, 100*time.Millisecond)
+
+			err = mock.ExpectationsWereMet()
+			require.NoError(t, err)
+
+			lokiEntries := lokiClient.Received()
+			require.Equal(t, len(tc.logsLines), len(lokiEntries))
+			for i, entry := range lokiEntries {
+				require.Equal(t, tc.logsLabels[i], entry.Labels)
+				require.Equal(t, tc.logsLines[i], entry.Line)
+			}
+		})
+	}
+}
+
+func TestQuerySampleUpdatesLastSampleSeenTimestamp(t *testing.T) {
+	t.Run("fetch new samples after the last sample seen timestamp", func(t *testing.T) {
+		t.Parallel()
+
+		defer goleak.VerifyNone(t)
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki_fake.NewClient(func() {})
+
+		collector, err := NewQuerySample(QuerySampleArguments{
+			DB:              db,
+			InstanceKey:     "mysql-db",
+			CollectInterval: time.Second,
+			EntryHandler:    lokiClient,
+			Logger:          log.NewLogfmtLogger(os.Stderr),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+
+		mock.ExpectQuery(selectLatestTimerEnd).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"timer_end",
+				}).AddRow(
+					"1",
+				))
+
+		mock.ExpectQuery(selectQuerySamples).WithArgs(float64(1)).RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"now",
+					"uptime",
+					"statements.CURRENT_SCHEMA",
+					"statements.DIGEST",
+					"statements.DIGEST_TEXT",
+					"statements.TIMER_START",
+					"statements.TIMER_END",
+					"statements.TIMER_WAIT",
+					"statements.CPU_TIME",
+					"statements.ROWS_EXAMINED",
+					"statements.ROWS_SENT",
+					"statements.ROWS_AFFECTED",
+					"statements.ERRORS",
+					"statements.MAX_CONTROLLED_MEMORY",
+					"statements.MAX_TOTAL_MEMORY",
+				}).AddRow(
+					"1",
+					"2",
+					"some_schema",
+					"some_digest",
+					"select * from some_table where id = 1",
+					"50000000",
+					"70000000",
+					"20000000",
+					"10000000",
+					"5",
+					"5",
+					"0",
+					"0",
+					"456",
+					"457",
+				),
+			)
+
+		mock.ExpectQuery(selectQuerySamples).WithArgs(float64(70000000)).RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"now",
+					"uptime",
+					"statements.CURRENT_SCHEMA",
+					"statements.DIGEST",
+					"statements.DIGEST_TEXT",
+					"statements.TIMER_START",
+					"statements.TIMER_END",
+					"statements.TIMER_WAIT",
+					"statements.CPU_TIME",
+					"statements.ROWS_EXAMINED",
+					"statements.ROWS_SENT",
+					"statements.ROWS_AFFECTED",
+					"statements.ERRORS",
+					"statements.MAX_CONTROLLED_MEMORY",
+					"statements.MAX_TOTAL_MEMORY",
+				}).AddRow(
+					"1",
+					"2",
+					"some_schema",
+					"some_digest",
+					"select * from some_table where id = 1",
+					"50000000",
+					"70000000",
+					"20000000",
+					"10000000",
+					"5",
+					"5",
+					"0",
+					"0",
+					"456",
+					"457",
+				),
+			)
+
+		err = collector.Start(context.Background())
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 2
+		}, 5*time.Second, 100*time.Millisecond)
+
+		collector.Stop()
+		lokiClient.Stop()
+
+		require.Eventually(t, func() bool {
+			return collector.Stopped()
+		}, 5*time.Second, 100*time.Millisecond)
+
+		err = mock.ExpectationsWereMet()
+		require.NoError(t, err)
+
+		lokiEntries := lokiClient.Received()
+		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"}, lokiEntries[0].Labels)
+		require.Equal(t, `schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_extracted="0.020000ms"`, lokiEntries[0].Line)
+		require.Equal(t, `schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_extracted="0.020000ms"`, lokiEntries[0].Line)
+	})
+}
+
+func TestQuerySampleSQLDriverErrors(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	t.Run("recoverable sql error in result set", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki_fake.NewClient(func() {})
+
+		collector, err := NewQuerySample(QuerySampleArguments{
+			DB:              db,
+			InstanceKey:     "mysql-db",
+			CollectInterval: time.Second,
+			EntryHandler:    lokiClient,
+			Logger:          log.NewLogfmtLogger(os.Stderr),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+
+		mock.ExpectQuery(selectLatestTimerEnd).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"timer_end",
+				}).AddRow(
+					"1",
+				))
+
+		mock.ExpectQuery(selectQuerySamples).WithArgs(float64(1)).RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"digest", // not enough columns
+				}).AddRow(
+					"abc123",
+				))
+
+		mock.ExpectQuery(selectQuerySamples).WithArgs(float64(1)).RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"now",
+					"uptime",
+					"statements.CURRENT_SCHEMA",
+					"statements.DIGEST",
+					"statements.DIGEST_TEXT",
+					"statements.TIMER_START",
+					"statements.TIMER_END",
+					"statements.TIMER_WAIT",
+					"statements.CPU_TIME",
+					"statements.ROWS_EXAMINED",
+					"statements.ROWS_SENT",
+					"statements.ROWS_AFFECTED",
+					"statements.ERRORS",
+					"statements.MAX_CONTROLLED_MEMORY",
+					"statements.MAX_TOTAL_MEMORY",
+				}).AddRow(
+					"1",
+					"2",
+					"some_schema",
+					"some_digest",
+					"select * from some_table where id = 1",
+					"50000000",
+					"70000000",
+					"20000000",
+					"10000000",
+					"5",
+					"5",
+					"0",
+					"0",
+					"456",
+					"457",
+				),
+			)
+
+		err = collector.Start(context.Background())
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 1
+		}, 5*time.Second, 100*time.Millisecond)
+
+		collector.Stop()
+		lokiClient.Stop()
+
+		require.Eventually(t, func() bool {
+			return collector.Stopped()
+		}, 5*time.Second, 100*time.Millisecond)
+
+		err = mock.ExpectationsWereMet()
+		require.NoError(t, err)
+
+		lokiEntries := lokiClient.Received()
+		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"}, lokiEntries[0].Labels)
+		require.Equal(t, `schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_extracted="0.020000ms"`, lokiEntries[0].Line)
+	})
+
+	t.Run("result set iteration error", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki_fake.NewClient(func() {})
+
+		collector, err := NewQuerySample(QuerySampleArguments{
+			DB:              db,
+			InstanceKey:     "mysql-db",
+			CollectInterval: time.Second,
+			EntryHandler:    lokiClient,
+			Logger:          log.NewLogfmtLogger(os.Stderr),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+
+		mock.ExpectQuery(selectLatestTimerEnd).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"timer_end",
+				}).AddRow(
+					"1",
+				))
+
+		mock.ExpectQuery(selectQuerySamples).WithArgs(float64(1)).RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"now",
+					"uptime",
+					"statements.CURRENT_SCHEMA",
+					"statements.DIGEST",
+					"statements.DIGEST_TEXT",
+					"statements.TIMER_START",
+					"statements.TIMER_END",
+					"statements.TIMER_WAIT",
+					"statements.CPU_TIME",
+					"statements.ROWS_EXAMINED",
+					"statements.ROWS_SENT",
+					"statements.ROWS_AFFECTED",
+					"statements.ERRORS",
+					"statements.MAX_CONTROLLED_MEMORY",
+					"statements.MAX_TOTAL_MEMORY",
+				}).AddRow(
+					"1",
+					"2",
+					"some_schema",
+					"some_digest",
+					"select * from some_table where id = 1",
+					"50000000",
+					"70000000",
+					"20000000",
+					"10000000",
+					"5",
+					"5",
+					"0",
+					"0",
+					"456",
+					"457",
+				).AddRow(
+					"1",
+					"2",
+					"some_schema",
+					"some_digest",
+					"select * from some_table where id = 1",
+					"50000000",
+					"70000000",
+					"20000000",
+					"10000000",
+					"5",
+					"5",
+					"0",
+					"0",
+					"456",
+					"457",
+				).RowError(1, fmt.Errorf("rs error")), // error on second row
+			)
+
+		err = collector.Start(context.Background())
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 1
+		}, 5*time.Second, 100*time.Millisecond)
+
+		collector.Stop()
+		lokiClient.Stop()
+
+		require.Eventually(t, func() bool {
+			return collector.Stopped()
+		}, 5*time.Second, 100*time.Millisecond)
+
+		err = mock.ExpectationsWereMet()
+		require.NoError(t, err)
+
+		lokiEntries := lokiClient.Received()
+		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"}, lokiEntries[0].Labels)
+		require.Equal(t, `schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_extracted="0.020000ms"`, lokiEntries[0].Line)
+	})
+
+	t.Run("connection error recovery", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki_fake.NewClient(func() {})
+
+		collector, err := NewQuerySample(QuerySampleArguments{
+			DB:              db,
+			InstanceKey:     "mysql-db",
+			CollectInterval: time.Second,
+			EntryHandler:    lokiClient,
+			Logger:          log.NewLogfmtLogger(os.Stderr),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+
+		mock.ExpectQuery(selectLatestTimerEnd).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"timer_end",
+				}).AddRow(
+					"1",
+				))
+
+		mock.ExpectQuery(selectQuerySamples).WithArgs(float64(1)).WillReturnError(fmt.Errorf("connection error"))
+		mock.ExpectQuery(selectQuerySamples).WithArgs(float64(1)).RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"now",
+					"uptime",
+					"statements.CURRENT_SCHEMA",
+					"statements.DIGEST",
+					"statements.DIGEST_TEXT",
+					"statements.TIMER_START",
+					"statements.TIMER_END",
+					"statements.TIMER_WAIT",
+					"statements.CPU_TIME",
+					"statements.ROWS_EXAMINED",
+					"statements.ROWS_SENT",
+					"statements.ROWS_AFFECTED",
+					"statements.ERRORS",
+					"statements.MAX_CONTROLLED_MEMORY",
+					"statements.MAX_TOTAL_MEMORY",
+				}).AddRow(
+					"1",
+					"2",
+					"some_schema",
+					"some_digest",
+					"select * from some_table where id = 1",
+					"50000000",
+					"70000000",
+					"20000000",
+					"10000000",
+					"5",
+					"5",
+					"0",
+					"0",
+					"456",
+					"457",
+				),
+			)
+
+		err = collector.Start(context.Background())
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 1
+		}, 5*time.Second, 100*time.Millisecond)
+
+		collector.Stop()
+		lokiClient.Stop()
+
+		require.Eventually(t, func() bool {
+			return collector.Stopped()
+		}, 5*time.Second, 100*time.Millisecond)
+
+		err = mock.ExpectationsWereMet()
+		require.NoError(t, err)
+
+		lokiEntries := lokiClient.Received()
+		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_SAMPLE, "instance": "mysql-db"}, lokiEntries[0].Labels)
+		require.Equal(t, `schema="some_schema" digest="some_digest" digest_text="select * from some_table where id = :redacted1" rows_examined="5" rows_sent="5" rows_affected="0" errors="0" max_controlled_memory="456b" max_total_memory="457b" cpu_time="0.010000ms" elapsed_time="0.020000ms" elapsed_time_extracted="0.020000ms"`, lokiEntries[0].Line)
+	})
+}

--- a/internal/component/database_observability/mysql/collector/query_tables_test.go
+++ b/internal/component/database_observability/mysql/collector/query_tables_test.go
@@ -357,7 +357,7 @@ func TestQueryTables(t *testing.T) {
 	}
 }
 
-func TestQuerySampleSQLDriverErrors(t *testing.T) {
+func TestQueryTablesSQLDriverErrors(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
 	t.Run("recoverable sql error in result set", func(t *testing.T) {

--- a/internal/component/database_observability/mysql/component.go
+++ b/internal/component/database_observability/mysql/component.go
@@ -213,6 +213,7 @@ func enableOrDisableCollectors(a Arguments) map[string]bool {
 	collectors := map[string]bool{
 		collector.QueryTablesName: true,
 		collector.SchemaTableName: true,
+		collector.QuerySampleName: true,
 	}
 
 	for _, disabled := range a.DisableCollectors {

--- a/internal/component/database_observability/mysql/component_test.go
+++ b/internal/component/database_observability/mysql/component_test.go
@@ -26,6 +26,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 		assert.Equal(t, map[string]bool{
 			collector.QueryTablesName: true,
 			collector.SchemaTableName: true,
+			collector.QuerySampleName: true,
 		}, actualCollectors)
 	})
 
@@ -33,7 +34,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 		var exampleDBO11yAlloyConfig = `
 		data_source_name = ""
 		forward_to = []
-		enable_collectors = ["query_tables", "schema_table"]
+		enable_collectors = ["query_tables", "schema_table", "query_sample"]
 	`
 
 		var args Arguments
@@ -45,6 +46,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 		assert.Equal(t, map[string]bool{
 			collector.QueryTablesName: true,
 			collector.SchemaTableName: true,
+			collector.QuerySampleName: true,
 		}, actualCollectors)
 	})
 
@@ -52,7 +54,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 		var exampleDBO11yAlloyConfig = `
 		data_source_name = ""
 		forward_to = []
-		disable_collectors = ["query_tables", "schema_table"]
+		disable_collectors = ["query_tables", "schema_table", "query_sample"]
 	`
 
 		var args Arguments
@@ -64,6 +66,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 		assert.Equal(t, map[string]bool{
 			collector.QueryTablesName: false,
 			collector.SchemaTableName: false,
+			collector.QuerySampleName: false,
 		}, actualCollectors)
 	})
 
@@ -71,8 +74,8 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 		var exampleDBO11yAlloyConfig = `
 		data_source_name = ""
 		forward_to = []
-		disable_collectors = ["query_tables", "schema_table"]
-		enable_collectors = ["query_tables", "schema_table"]
+		disable_collectors = ["query_tables", "schema_table", "query_sample"]
+		enable_collectors = ["query_tables", "schema_table", "query_sample"]
 	`
 
 		var args Arguments
@@ -84,14 +87,15 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 		assert.Equal(t, map[string]bool{
 			collector.QueryTablesName: true,
 			collector.SchemaTableName: true,
+			collector.QuerySampleName: true,
 		}, actualCollectors)
 	})
 
-	t.Run("enabling one and disabling one", func(t *testing.T) {
+	t.Run("enabling one and disabling others", func(t *testing.T) {
 		var exampleDBO11yAlloyConfig = `
 		data_source_name = ""
 		forward_to = []
-		disable_collectors = ["schema_table"]
+		disable_collectors = ["schema_table", "query_sample"]
 		enable_collectors = ["query_tables"]
 	`
 
@@ -104,6 +108,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 		assert.Equal(t, map[string]bool{
 			collector.QueryTablesName: true,
 			collector.SchemaTableName: false,
+			collector.QuerySampleName: false,
 		}, actualCollectors)
 	})
 
@@ -124,6 +129,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 		assert.Equal(t, map[string]bool{
 			collector.QueryTablesName: true,
 			collector.SchemaTableName: true,
+			collector.QuerySampleName: true,
 		}, actualCollectors)
 	})
 }

--- a/internal/component/database_observability/mysql/component_test.go
+++ b/internal/component/database_observability/mysql/component_test.go
@@ -26,7 +26,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 		assert.Equal(t, map[string]bool{
 			collector.QueryTablesName: true,
 			collector.SchemaTableName: true,
-			collector.QuerySampleName: true,
+			collector.QuerySampleName: false,
 		}, actualCollectors)
 	})
 
@@ -129,7 +129,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 		assert.Equal(t, map[string]bool{
 			collector.QueryTablesName: true,
 			collector.SchemaTableName: true,
-			collector.QuerySampleName: true,
+			collector.QuerySampleName: false,
 		}, actualCollectors)
 	})
 }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This change adds a new collector, `query_sample`, to the database_observability component. The collector is responsible for collecting query samples. Query samples enable users to see real invocations of a given query, enabling them to explore outliers and see the real numbers instead of normalised and aggregated statistics.

Note, this replaces the previous sample collector we had, as it works in a slightly different way. Previously we were collecting the sample data available in the `perf_schema.events_statements_summary_by_digest` table, which is controlled/updated by performance_schema. We now use the `perf_schema.events_statements_history` which stores a record of executed queries that we ourselves can sample.

The logic to redact digest_text information is copied from the `table_schema` collector.

#### Which issue(s) this PR fixes
n.a.

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer
We do not collect the `sql_text` (real, non-normalised sql text) as of now. We will optionally support that in a future iteration.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
