### PR TITLE
Fix more Windows tests

### DIFF
--- a/internal/cmd/integration-tests/tests/loki-enrich/enrich_test.go
+++ b/internal/cmd/integration-tests/tests/loki-enrich/enrich_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package main
 
 import (


### PR DESCRIPTION
The integration test shouldn't run for Windows. It is failing because the integration tests aren't being bootstrapped - this only happens on Linux.

The secretfilter tests are failing because the file isn't closed. I also added a few more safety checks to make sure the component has stopped, but I think they're not really necesary. There's something about the file handling on Windows that causes this error. On the Linux tests it doesn't happen.