### PR TITLE
chore: Add back in vault tests

### DIFF
--- a/internal/component/remote/vault/vault_test.go
+++ b/internal/component/remote/vault/vault_test.go
@@ -38,7 +38,7 @@ func Test_GetSecrets(t *testing.T) {
 	cfg := fmt.Sprintf(`
 		server = "%s"
 		path   = "secret"
-  		secret = "test"
+  		key = "test"
 
 		reread_frequency = "0s"
 
@@ -144,6 +144,8 @@ func Test_PollSecretsWithoutKey(t *testing.T) {
 }
 
 func Test_PollSecretsWithKey(t *testing.T) {
+	//TODO - understand if this test _should_ work? Introduced in PR #1605, when it was already skipped
+	t.Skip("This test is broken and should be fixed or removed")
 	var (
 		ctx = componenttest.TestContext(t)
 		l   = util.TestLogger(t)
@@ -217,9 +219,6 @@ func Test_PollSecretsWithKey(t *testing.T) {
 }
 
 func getTestVaultServer(t *testing.T) *vaultapi.Client {
-	// TODO: this is broken with go 1.20.6
-	// waiting on https://github.com/testcontainers/testcontainers-go/issues/1359
-	t.Skip()
 	ctx := componenttest.TestContext(t)
 	l := util.TestLogger(t)
 

--- a/internal/component/remote/vault/vault_test.go
+++ b/internal/component/remote/vault/vault_test.go
@@ -72,10 +72,12 @@ func Test_GetSecrets(t *testing.T) {
 }
 
 func Test_PollSecrets(t *testing.T) {
-	for name, tt := range map[string]struct {
+	tests := []struct {
+		name            string
 		cfgFormatString string
 	}{
-		"path and key": {
+		{
+			name: "poll with path and key",
 			cfgFormatString: `
 				server = "%s"
 				path   = "secret"
@@ -88,7 +90,8 @@ func Test_PollSecrets(t *testing.T) {
 				}
 			`,
 		},
-		"path": {
+		{
+			name: "poll with path only",
 			cfgFormatString: `
 				server = "%s"
 				path   = "secret/test"
@@ -100,8 +103,9 @@ func Test_PollSecrets(t *testing.T) {
 				}
 			`,
 		},
-	} {
-		t.Run(name, func(t *testing.T) {
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			var (
 				ctx = componenttest.TestContext(t)
 				l   = util.TestLogger(t)


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Vault tests were skipped with a comment about an issue with go 1.20.6 and we're currently on 1.23.x.

One of the tests, added in https://github.com/grafana/alloy/pull/1605 did not pass as written. The issue is with https://github.com/grafana/alloy/blob/main/internal/component/remote/vault/client.go#L29 , using an empty Path (mount) does not work. I _think_ this is reasonable, but could be revisited.