### PR TITLE
fix: Allow various SSL configs for kafka exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ Main (unreleased)
 
 - Fix deadlocks in `loki.source.file` when tailing fails (@mblaschke)
 
+- Allow kafka exporter to attempt to connect even if TLS enabled but cert & key are not specified (@dehaansa)
+
 ### Other changes
 
 - Upgrading to Prometheus v2.55.1. (@ptodev)

--- a/internal/static/integrations/kafka_exporter/kafka_exporter.go
+++ b/internal/static/integrations/kafka_exporter/kafka_exporter.go
@@ -178,9 +178,6 @@ func New(logger log.Logger, c *Config) (integrations.Integration, error) {
 	if len(c.KafkaURIs) == 0 || c.KafkaURIs[0] == "" {
 		return nil, fmt.Errorf("empty kafka_uris provided")
 	}
-	if c.UseTLS && (c.CertFile == "" || c.KeyFile == "") {
-		return nil, fmt.Errorf("tls is enabled but key pair was not provided")
-	}
 	if c.UseSASL && (c.SASLPassword == "" || c.SASLUsername == "") {
 		return nil, fmt.Errorf("SASL is enabled but username or password was not provided")
 	}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
The kafka exporter internally does not _require_ cert & key like the Alloy integration to it does. The exporter will attempt to connect with CAs provided on the host if CA & key/cert are not provided, or will use the CA without key/cert if provided. I think the best path here is to avoid examining the TLS-applicable arguments and just allow the exporter to attempt a connection in whichever way it is configured by the user.

This matches expectations already set in the documentation (all three fields are called optional in the docs, with no special note).

#### Which issue(s) this PR fixes
Fixes https://github.com/grafana/alloy/issues/280

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
- [X] Documentation added
