### PR TITLE
feat: update go version from 1.23.5 to 1.23.6 to fix vuln CVE-2025-22866

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -15,7 +15,7 @@ docs: check-cloudwatch-integration
 endif
 
 check-cloudwatch-integration:
-	$(PODMAN) run -v "$(shell git rev-parse --show-toplevel):/repo:z" -v "$(shell pwd):/docs:z" -w /repo golang:1.23.5-bullseye go run internal/static/integrations/cloudwatch_exporter/docs/doc.go check /docs/sources/reference/components/prometheus/prometheus.exporter.cloudwatch.md
+	$(PODMAN) run -v "$(shell git rev-parse --show-toplevel):/repo:z" -v "$(shell pwd):/docs:z" -w /repo golang:1.23.6-bullseye go run internal/static/integrations/cloudwatch_exporter/docs/doc.go check /docs/sources/reference/components/prometheus/prometheus.exporter.cloudwatch.md
 
 generate-cloudwatch-integration:
-	$(PODMAN) run -v "$(shell git rev-parse --show-toplevel):/repo:z" -v "$(shell pwd):/docs:z" -w /repo golang:1.23.5-bullseye go run internal/static/integrations/cloudwatch_exporter/docs/doc.go generate
+	$(PODMAN) run -v "$(shell git rev-parse --show-toplevel):/repo:z" -v "$(shell pwd):/docs:z" -w /repo golang:1.23.6-bullseye go run internal/static/integrations/cloudwatch_exporter/docs/doc.go generate

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/alloy
 
-go 1.23.5
+go 1.23.6
 
 require (
 	cloud.google.com/go/pubsub v1.42.0

--- a/internal/cmd/integration-tests/configs/kafka/Dockerfile
+++ b/internal/cmd/integration-tests/configs/kafka/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.5 as build
+FROM golang:1.23.6 as build
 WORKDIR /app/
 COPY go.mod go.sum ./
 COPY syntax/go.mod syntax/go.sum ./syntax/

--- a/internal/cmd/integration-tests/configs/otel-gen/Dockerfile
+++ b/internal/cmd/integration-tests/configs/otel-gen/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.5 as build
+FROM golang:1.23.6 as build
 WORKDIR /app/
 COPY go.mod go.sum ./
 COPY syntax/go.mod syntax/go.sum ./syntax/

--- a/internal/cmd/integration-tests/configs/prom-gen/Dockerfile
+++ b/internal/cmd/integration-tests/configs/prom-gen/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.5 as build
+FROM golang:1.23.6 as build
 WORKDIR /app/
 COPY go.mod go.sum ./
 COPY syntax/go.mod syntax/go.sum ./syntax/


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR will bump the Go version used by Grafana Alloy from `1.23.5` to `1.23.6`. The currently used Go version is affected by CVE-2025-22866 - A issue with crypto/elliptic: timing sidechannel for P-256 on ppc64le. The Go team released a It's an update of the minor version should have no effect on existing code as this version change does not change Go's operating system support. It may remove certain reports from vulnerability scanners that detect which version of this Go version.

#### Which issue(s) this PR fixes

_Severity CVE:_
* CISA-ADP of CVE-2025-22866 score: MEDIUM
* Details: https://go.dev/issue/71383

_Links and information regarding the CVE:_
* https://groups.google.com/g/golang-announce/c/xU1ZCHUZw3k 
* GitHub Advisory Database: https://github.com/advisories/GHSA-3whm-j4xm-rv8x

#### Notes to the Reviewer

I'm not part of the Grafana Org, hence I'm not so familar with topics like `drone.yml` (which I can not generate) or might needed updates of `alloy-build-image` image tag in context of the go update. Please feel free to adjust my PR as needed. Thanks a lot :-)

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
