### PR TITLE
Update loki.source.docker.md

### DIFF
--- a/docs/sources/reference/components/loki/loki.source.docker.md
+++ b/docs/sources/reference/components/loki/loki.source.docker.md
@@ -140,7 +140,7 @@ loki.source.docker "default" {
 
 loki.write "local" {
   endpoint {
-    url = "loki:3100/loki/api/v1/push"
+    url = "http://loki:3100/loki/api/v1/push"
   }
 }
 ```


### PR DESCRIPTION
You need to specify a protocol at:

```
loki.write "local" {
  endpoint {
    url = "loki:3100/loki/api/v1/push"  <-----
  }
}
```

I tried this config from the documentation and got this error:
unsupported protocol scheme \"loki\""