### PR TITLE
docs: Update discovery.relabel docs to include static label example

### DIFF
--- a/docs/sources/reference/components/discovery/discovery.relabel.md
+++ b/docs/sources/reference/components/discovery/discovery.relabel.md
@@ -89,6 +89,9 @@ In those cases, exported fields retain their last healthy values.
 
 ## Example
 
+The following example shows how the `discovery.relabel` component applies relabel rules to the incoming targets. In practice, the 
+`targets` slice will come from another `discovery.*` component, but they are enumerated here to help clarify the example.
+
 ```alloy
 discovery.relabel "keep_backend_only" {
   targets = [
@@ -97,6 +100,7 @@ discovery.relabel "keep_backend_only" {
     { "__meta_baz" = "baz", "__address__" = "localhost", "instance" = "three", "app" = "frontend" },
   ]
 
+  # Combine the "__address__" and "instance" labels into a new "destination" label.
   rule {
     source_labels = ["__address__", "instance"]
     separator     = "/"
@@ -104,10 +108,17 @@ discovery.relabel "keep_backend_only" {
     action        = "replace"
   }
 
+  # Drop any targets that do not have the value "backend" in their "app" label.
   rule {
     source_labels = ["app"]
     action        = "keep"
     regex         = "backend"
+  }
+
+  # Add a static label to all remaining targets.
+  rule {
+    target_label = "custom_static_label"
+    replacement = "static_value"
   }
 }
 ```


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Had a few requests over the past few months for how to add static labels, adding an example to discovery.relabel docs so it's a use case that is discoverable in docs.