### PR TITLE
Fix graph late packets

### DIFF
--- a/internal/web/api/api.go
+++ b/internal/web/api/api.go
@@ -253,7 +253,8 @@ func graph(_ service.Host, callbackManager livedebugging.CallbackManager, logger
 					continue
 				}
 
-				_, writeErr := w.Write(jsonData)
+				// Add |;| delimiter to the end of the data to help with parsing when the msg arrives in multiple chunks
+				_, writeErr := w.Write(append(jsonData, []byte("|;|")...))
 				if writeErr != nil {
 					level.Warn(logger).Log("msg", "error writing data to the graph", "error", writeErr)
 					return


### PR DESCRIPTION
After testing with late arriving packets, it ended up with messages merging between each others and the frontend could not parse it properly.

This solution uses a delimiter at the end of the messages to allow the frontend to properly parse messages