### PR TITLE
Fix - faro/receiver - uncontrolled data used in path expression

### DIFF
--- a/internal/component/faro/receiver/sourcemaps.go
+++ b/internal/component/faro/receiver/sourcemaps.go
@@ -44,8 +44,18 @@ type (
 
 type osFileService struct{}
 
-func (fs osFileService) Stat(name string) (fs.FileInfo, error) { return os.Stat(name) }
-func (fs osFileService) ReadFile(name string) ([]byte, error)  { return os.ReadFile(name) }
+func (fs osFileService) Stat(name string) (fs.FileInfo, error) {
+	if strings.Contains(name, "/") || strings.Contains(name, "\\") || strings.Contains(name, "..") {
+		return nil, fmt.Errorf("invalid file name: %s", name)
+	}
+	return os.Stat(name)
+}
+func (fs osFileService) ReadFile(name string) ([]byte, error) {
+	if strings.Contains(name, "/") || strings.Contains(name, "\\") || strings.Contains(name, "..") {
+		return nil, fmt.Errorf("invalid file name: %s", name)
+	}
+	return os.ReadFile(name)
+}
 
 type sourceMapMetrics struct {
 	cacheSize *prometheus.CounterVec

--- a/internal/component/faro/receiver/sourcemaps_test.go
+++ b/internal/component/faro/receiver/sourcemaps_test.go
@@ -533,6 +533,40 @@ func Test_urlMatchesOrigins(t *testing.T) {
 	}
 }
 
+func TestOsFileService_RejectsInvalidPaths(t *testing.T) {
+	fs := osFileService{}
+
+	invalidPaths := []string{
+		"file/with/slash",
+		"file\\with\\backslash",
+		"file/../with/parent/dir",
+		"../parent/dir",
+		"./current/dir",
+		"file..with..dots",
+	}
+
+	for _, path := range invalidPaths {
+		_, errStat := fs.Stat(path)
+		if errStat == nil {
+			t.Errorf("Expected error for path %q containing illegal characters, but got nil", path)
+		}
+		_, errReadFile := fs.ReadFile(path)
+		if errReadFile == nil {
+			t.Errorf("Expected error for path %q containing illegal characters, but got nil", path)
+		}
+	}
+
+	validPath := "validfilename.txt"
+	_, errStat := fs.Stat(validPath)
+	if errStat != nil && errStat.Error() == "invalid file name: "+validPath {
+		t.Errorf("Expected valid path %q to not trigger invalid file name error", validPath)
+	}
+	_, errReadFile := fs.ReadFile(validPath)
+	if errReadFile != nil && errReadFile.Error() == "invalid file name: "+validPath {
+		t.Errorf("Expected valid path %q to not trigger invalid file name error", validPath)
+	}
+}
+
 type mockHTTPClient struct {
 	responses []struct {
 		*http.Response


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Minimal-change fix to https://github.com/grafana/alloy/security/code-scanning/52

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] ~~CHANGELOG.md updated~~
- [ ] ~~Documentation added~~
- [x] Tests updated
- [ ] ~~Config converters updated~~
