### PR TITLE
Fix deadlock in live debugging service

### DIFF
--- a/internal/component/loki/process/process_test.go
+++ b/internal/component/loki/process/process_test.go
@@ -646,9 +646,9 @@ func getServiceDataWithLiveDebugging(log *testlivedebugging.Log) func(string) (i
 			component.ParseID(""): {ComponentName: "", Component: &testlivedebugging.FakeComponentLiveDebugging{}},
 		},
 	}
-	ld.SetServiceHost(host)
 	ld.SetEnabled(true)
 	ld.AddCallback(
+		host,
 		"callback1",
 		"",
 		func(data livedebugging.Data) { log.Append(data.DataFunc()) },

--- a/internal/service/livedebugging/livedebugging.go
+++ b/internal/service/livedebugging/livedebugging.go
@@ -16,14 +16,14 @@ type CallbackID string
 type CallbackManager interface {
 	// AddCallback sets a callback for a given componentID.
 	// The callback is used to send debugging data to live debugging consumers.
-	AddCallback(callbackID CallbackID, componentID ComponentID, callback func(Data)) error
+	AddCallback(host service.Host, callbackID CallbackID, componentID ComponentID, callback func(Data)) error
 	// DeleteCallback deletes a callback for a given componentID.
 	DeleteCallback(callbackID CallbackID, componentID ComponentID)
 	// AddCallbackMulti sets a callback to all components.
 	// The callbacks are used to send debugging data to live debugging consumers.
-	AddCallbackMulti(callbackID CallbackID, moduleID ModuleID, callback func(Data)) error
+	AddCallbackMulti(host service.Host, callbackID CallbackID, moduleID ModuleID, callback func(Data)) error
 	// DeleteCallbackMulti deletes callbacks for all components.
-	DeleteCallbackMulti(callbackID CallbackID, moduleID ModuleID)
+	DeleteCallbackMulti(host service.Host, callbackID CallbackID, moduleID ModuleID)
 }
 
 // DebugDataPublisher is used by components to push information to live debugging consumers.
@@ -34,7 +34,6 @@ type DebugDataPublisher interface {
 type liveDebugging struct {
 	loadMut   sync.RWMutex
 	callbacks map[ComponentID]map[CallbackID]func(Data)
-	host      service.Host
 	enabled   bool
 }
 
@@ -61,19 +60,20 @@ func (s *liveDebugging) PublishIfActive(data Data) {
 	}
 }
 
-func (s *liveDebugging) AddCallback(callbackID CallbackID, componentID ComponentID, callback func(Data)) error {
+func (s *liveDebugging) AddCallback(host service.Host, callbackID CallbackID, componentID ComponentID, callback func(Data)) error {
 	s.loadMut.Lock()
-	defer s.loadMut.Unlock()
+	enabled := s.enabled
+	s.loadMut.Unlock()
 
-	if !s.enabled {
+	if !enabled {
 		return fmt.Errorf("the live debugging service is disabled. Check the documentation to find out how to enable it")
 	}
 
-	if s.host == nil {
+	if host == nil {
 		return fmt.Errorf("the live debugging service is not ready yet")
 	}
 
-	info, err := s.host.GetComponent(component.ParseID(string(componentID)), component.InfoOptions{})
+	info, err := host.GetComponent(component.ParseID(string(componentID)), component.InfoOptions{})
 	if err != nil {
 		return err
 	}
@@ -81,6 +81,9 @@ func (s *liveDebugging) AddCallback(callbackID CallbackID, componentID Component
 	if _, ok := info.Component.(component.LiveDebugging); !ok {
 		return fmt.Errorf("the component %q does not support live debugging", info.ComponentName)
 	}
+
+	s.loadMut.Lock()
+	defer s.loadMut.Unlock()
 
 	if _, ok := s.callbacks[componentID]; !ok {
 		s.callbacks[componentID] = make(map[CallbackID]func(Data))
@@ -91,18 +94,19 @@ func (s *liveDebugging) AddCallback(callbackID CallbackID, componentID Component
 }
 
 // live debugging does not need to be enabled for the multi callback because the data func are not computed for the graph.
-func (s *liveDebugging) AddCallbackMulti(callbackID CallbackID, moduleID ModuleID, callback func(Data)) error {
-	s.loadMut.Lock()
-	defer s.loadMut.Unlock()
+func (s *liveDebugging) AddCallbackMulti(host service.Host, callbackID CallbackID, moduleID ModuleID, callback func(Data)) error {
 
-	if s.host == nil {
+	if host == nil {
 		return fmt.Errorf("the live debugging service is not ready yet")
 	}
 
-	components, err := s.host.ListComponents(string(moduleID), component.InfoOptions{GetHealth: true})
+	components, err := host.ListComponents(string(moduleID), component.InfoOptions{GetHealth: true})
 	if err != nil {
 		return err
 	}
+
+	s.loadMut.Lock()
+	defer s.loadMut.Unlock()
 
 	for _, cp := range components {
 		if _, ok := cp.Component.(component.LiveDebugging); !ok {
@@ -123,23 +127,18 @@ func (s *liveDebugging) DeleteCallback(callbackID CallbackID, componentID Compon
 	delete(s.callbacks[componentID], callbackID)
 }
 
-func (s *liveDebugging) DeleteCallbackMulti(callbackID CallbackID, moduleID ModuleID) {
+func (s *liveDebugging) DeleteCallbackMulti(host service.Host, callbackID CallbackID, moduleID ModuleID) {
+	// ignore errors on delete
+	components, _ := host.ListComponents(string(moduleID), component.InfoOptions{})
+
 	s.loadMut.Lock()
 	defer s.loadMut.Unlock()
-	// ignore errors on delete
-	components, _ := s.host.ListComponents(string(moduleID), component.InfoOptions{})
 	for _, cp := range components {
 		delete(s.callbacks[ComponentID(cp.ID.String())], callbackID)
 	}
 	// The s.callbacks[componentID] is not deleted. This is a very small memory leak which could only become significant if a user
 	// has a lot of components and reload the config with always different component labels while having the graph open.
 	// If this ever become a realistic scenario we should cleanup the map here.
-}
-
-func (s *liveDebugging) SetServiceHost(h service.Host) {
-	s.loadMut.Lock()
-	defer s.loadMut.Unlock()
-	s.host = h
 }
 
 func (s *liveDebugging) SetEnabled(enabled bool) {

--- a/internal/service/livedebugging/livedebugging.go
+++ b/internal/service/livedebugging/livedebugging.go
@@ -95,7 +95,6 @@ func (s *liveDebugging) AddCallback(host service.Host, callbackID CallbackID, co
 
 // live debugging does not need to be enabled for the multi callback because the data func are not computed for the graph.
 func (s *liveDebugging) AddCallbackMulti(host service.Host, callbackID CallbackID, moduleID ModuleID, callback func(Data)) error {
-
 	if host == nil {
 		return fmt.Errorf("the live debugging service is not ready yet")
 	}

--- a/internal/service/livedebugging/livedebugging_test.go
+++ b/internal/service/livedebugging/livedebugging_test.go
@@ -202,7 +202,7 @@ func TestMultiCallbacksMultipleStreams(t *testing.T) {
 	require.Equal(t, "test data", receivedData2.DataFunc())
 }
 
-func assertNoDeadlock(t *testing.T, timeout time.Duration, f func()) {
+func assertNoDeadlock(t *testing.T, f func()) {
 	t.Helper()
 	done := make(chan struct{})
 
@@ -214,7 +214,7 @@ func assertNoDeadlock(t *testing.T, timeout time.Duration, f func()) {
 	select {
 	case <-done:
 		return
-	case <-time.After(timeout):
+	case <-time.After(2 * time.Second):
 		t.Fatal("Operation timed out - likely deadlocked")
 	}
 }
@@ -228,19 +228,19 @@ func TestDeadLock(t *testing.T) {
 
 	callbackID1 := CallbackID("callback1")
 
-	assertNoDeadlock(t, 2*time.Second, func() {
+	assertNoDeadlock(t, func() {
 		livedebugging.AddCallback(host, callbackID1, "", func(data Data) {})
 	})
 
-	assertNoDeadlock(t, 2*time.Second, func() {
+	assertNoDeadlock(t, func() {
 		livedebugging.AddCallbackMulti(host, callbackID1, "", func(data Data) {})
 	})
 
-	assertNoDeadlock(t, 2*time.Second, func() {
+	assertNoDeadlock(t, func() {
 		livedebugging.DeleteCallbackMulti(host, callbackID1, "")
 	})
 
-	assertNoDeadlock(t, 2*time.Second, func() {
+	assertNoDeadlock(t, func() {
 		livedebugging.DeleteCallback(callbackID1, "")
 	})
 }
@@ -268,19 +268,19 @@ func TestDeadLock2(t *testing.T) {
 		}
 	}()
 
-	assertNoDeadlock(t, 2*time.Second, func() {
+	assertNoDeadlock(t, func() {
 		livedebugging.AddCallback(host, callbackID1, "", func(data Data) {})
 	})
 
-	assertNoDeadlock(t, 2*time.Second, func() {
+	assertNoDeadlock(t, func() {
 		livedebugging.AddCallbackMulti(host, callbackID1, "", func(data Data) {})
 	})
 
-	assertNoDeadlock(t, 2*time.Second, func() {
+	assertNoDeadlock(t, func() {
 		livedebugging.DeleteCallbackMulti(host, callbackID1, "")
 	})
 
-	assertNoDeadlock(t, 2*time.Second, func() {
+	assertNoDeadlock(t, func() {
 		livedebugging.DeleteCallback(callbackID1, "")
 	})
 }

--- a/internal/service/livedebugging/service.go
+++ b/internal/service/livedebugging/service.go
@@ -45,7 +45,6 @@ func (*Service) Definition() service.Definition {
 
 // Run implements service.Service.
 func (s *Service) Run(ctx context.Context, host service.Host) error {
-	s.liveDebugging.SetServiceHost(host)
 	<-ctx.Done()
 	return nil
 }

--- a/internal/web/api/api.go
+++ b/internal/web/api/api.go
@@ -177,7 +177,7 @@ type dataKey struct {
 	Type        livedebugging.DataType
 }
 
-func graph(_ service.Host, callbackManager livedebugging.CallbackManager, logger log.Logger) http.HandlerFunc {
+func graph(host service.Host, callbackManager livedebugging.CallbackManager, logger log.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var moduleID livedebugging.ModuleID
 		if vars := mux.Vars(r); vars != nil {
@@ -193,7 +193,7 @@ func graph(_ service.Host, callbackManager livedebugging.CallbackManager, logger
 		id := livedebugging.CallbackID(uuid.New().String())
 
 		droppedData := false
-		err := callbackManager.AddCallbackMulti(id, moduleID, func(data livedebugging.Data) {
+		err := callbackManager.AddCallbackMulti(host, id, moduleID, func(data livedebugging.Data) {
 			select {
 			case <-ctx.Done():
 				return
@@ -216,7 +216,7 @@ func graph(_ service.Host, callbackManager livedebugging.CallbackManager, logger
 
 		defer func() {
 			close(dataCh)
-			callbackManager.DeleteCallbackMulti(id, moduleID)
+			callbackManager.DeleteCallbackMulti(host, id, moduleID)
 		}()
 
 		ticker := time.NewTicker(windowSeconds)
@@ -272,7 +272,7 @@ func graph(_ service.Host, callbackManager livedebugging.CallbackManager, logger
 	}
 }
 
-func liveDebugging(_ service.Host, callbackManager livedebugging.CallbackManager, logger log.Logger) http.HandlerFunc {
+func liveDebugging(host service.Host, callbackManager livedebugging.CallbackManager, logger log.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
 		componentID := livedebugging.ComponentID(vars["id"])
@@ -285,7 +285,7 @@ func liveDebugging(_ service.Host, callbackManager livedebugging.CallbackManager
 		id := livedebugging.CallbackID(uuid.New().String())
 
 		droppedData := false
-		err := callbackManager.AddCallback(id, componentID, func(data livedebugging.Data) {
+		err := callbackManager.AddCallback(host, id, componentID, func(data livedebugging.Data) {
 			select {
 			case <-ctx.Done():
 				return


### PR DESCRIPTION
The live debugging service would end up deadlock in some unlucky cases where a info from a component would be retrieved to add a callback while the component was trying to publish data to the live debugging service