### PR TITLE
chore: increase linter timeout for PRs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 # Full list of configuration options: https://golangci-lint.run/usage/configuration/
 
 run:
-  timeout: 10m
+  timeout: 15m
 
 output:
   sort-results: true


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Increase default lint timeout from 10m to 15m, as we've seen some random timeouts in PRs recently.