### PR TITLE
Add dedicated mutex to data flow edges

### DIFF
--- a/internal/runtime/internal/controller/node_builtin_component.go
+++ b/internal/runtime/internal/controller/node_builtin_component.go
@@ -121,6 +121,7 @@ type BuiltinComponentNode struct {
 	exportsMut sync.RWMutex
 	exports    component.Exports // Evaluated exports for the managed component
 
+	dataFlowEdgeMut  sync.RWMutex
 	dataFlowEdgeRefs []string
 }
 
@@ -465,19 +466,19 @@ func (cn *BuiltinComponentNode) ModuleIDs() []string {
 }
 
 func (cn *BuiltinComponentNode) AddDataFlowEdgeTo(nodeID string) {
-	cn.mut.Lock()
-	defer cn.mut.Unlock()
+	cn.dataFlowEdgeMut.Lock()
+	defer cn.dataFlowEdgeMut.Unlock()
 	cn.dataFlowEdgeRefs = append(cn.dataFlowEdgeRefs, nodeID)
 }
 
 func (cn *BuiltinComponentNode) GetDataFlowEdgesTo() []string {
-	cn.mut.RLock()
-	defer cn.mut.RUnlock()
+	cn.dataFlowEdgeMut.RLock()
+	defer cn.dataFlowEdgeMut.RUnlock()
 	return cn.dataFlowEdgeRefs
 }
 
 func (cn *BuiltinComponentNode) ResetDataFlowEdgeTo() {
-	cn.mut.Lock()
-	defer cn.mut.Unlock()
+	cn.dataFlowEdgeMut.Lock()
+	defer cn.dataFlowEdgeMut.Unlock()
 	cn.dataFlowEdgeRefs = []string{}
 }

--- a/internal/runtime/internal/controller/node_config_foreach.go
+++ b/internal/runtime/internal/controller/node_config_foreach.go
@@ -48,10 +48,9 @@ type ForeachConfigNode struct {
 	forEachChildrenUpdateChan chan struct{} // used to trigger an update of the running children
 	forEachChildrenRunning    bool
 
-	mut              sync.RWMutex
-	block            *ast.BlockStmt
-	args             ForEachArguments
-	dataFlowEdgeRefs []string
+	mut   sync.RWMutex
+	block *ast.BlockStmt
+	args  ForEachArguments
 
 	moduleControllerFactory func(opts ModuleControllerOpts) ModuleController
 	moduleControllerOpts    ModuleControllerOpts
@@ -59,6 +58,9 @@ type ForeachConfigNode struct {
 	healthMut  sync.RWMutex
 	evalHealth component.Health // Health of the last evaluate
 	runHealth  component.Health // Health of running the component
+
+	dataFlowEdgeMut  sync.RWMutex
+	dataFlowEdgeRefs []string
 }
 
 var _ ComponentNode = (*ForeachConfigNode)(nil)
@@ -344,20 +346,20 @@ func (fn *ForeachConfigNode) setRunHealth(t component.HealthType, msg string) {
 }
 
 func (fn *ForeachConfigNode) AddDataFlowEdgeTo(nodeID string) {
-	fn.mut.Lock()
-	defer fn.mut.Unlock()
+	fn.dataFlowEdgeMut.Lock()
+	defer fn.dataFlowEdgeMut.Unlock()
 	fn.dataFlowEdgeRefs = append(fn.dataFlowEdgeRefs, nodeID)
 }
 
 func (fn *ForeachConfigNode) GetDataFlowEdgesTo() []string {
-	fn.mut.RLock()
-	defer fn.mut.RUnlock()
+	fn.dataFlowEdgeMut.RLock()
+	defer fn.dataFlowEdgeMut.RUnlock()
 	return fn.dataFlowEdgeRefs
 }
 
 func (fn *ForeachConfigNode) ResetDataFlowEdgeTo() {
-	fn.mut.Lock()
-	defer fn.mut.Unlock()
+	fn.dataFlowEdgeMut.Lock()
+	defer fn.dataFlowEdgeMut.Unlock()
 	fn.dataFlowEdgeRefs = []string{}
 }
 

--- a/internal/runtime/internal/controller/node_custom_component.go
+++ b/internal/runtime/internal/controller/node_custom_component.go
@@ -55,6 +55,7 @@ type CustomComponentNode struct {
 	exportsMut sync.RWMutex
 	exports    component.Exports // Evaluated exports for the managed custom component
 
+	dataFlowEdgeMut  sync.RWMutex
 	dataFlowEdgeRefs []string
 }
 
@@ -330,19 +331,19 @@ func (cn *CustomComponentNode) ModuleIDs() []string {
 }
 
 func (cn *CustomComponentNode) AddDataFlowEdgeTo(nodeID string) {
-	cn.mut.Lock()
-	defer cn.mut.Unlock()
+	cn.dataFlowEdgeMut.Lock()
+	defer cn.dataFlowEdgeMut.Unlock()
 	cn.dataFlowEdgeRefs = append(cn.dataFlowEdgeRefs, nodeID)
 }
 
 func (cn *CustomComponentNode) GetDataFlowEdgesTo() []string {
-	cn.mut.RLock()
-	defer cn.mut.RUnlock()
+	cn.dataFlowEdgeMut.RLock()
+	defer cn.dataFlowEdgeMut.RUnlock()
 	return cn.dataFlowEdgeRefs
 }
 
 func (cn *CustomComponentNode) ResetDataFlowEdgeTo() {
-	cn.mut.Lock()
-	defer cn.mut.Unlock()
+	cn.dataFlowEdgeMut.Lock()
+	defer cn.dataFlowEdgeMut.Unlock()
 	cn.dataFlowEdgeRefs = []string{}
 }


### PR DESCRIPTION
A dedicated mutex is used for the dataFlowEdgeRefs to reduce the risk of deadlocks during runtime evaluation