### PR TITLE
Update Go in Linux build image

### DIFF
--- a/.github/workflows/check-linux-build-image.yml
+++ b/.github/workflows/check-linux-build-image.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       matrix:
         build:
-          - runtime: golang:1.24.0-alpine3.21
-          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.24.0-bookworm
+          - runtime: golang:1.24.1-alpine3.21
+          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.24.1-bookworm
     runs-on: ubuntu-22.04 # related to https://github.com/docker/setup-qemu-action/issues/198
     steps:
       - name: Checkout

--- a/.github/workflows/create_build_image.yml
+++ b/.github/workflows/create_build_image.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         build:
-          - runtime: golang:1.24.0-alpine3.21
-          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.24.0-bookworm
+          - runtime: golang:1.24.1-alpine3.21
+          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.24.1-bookworm
             suffix: "-boringcrypto"
     runs-on: ubuntu-22.04 # related to https://github.com/docker/setup-qemu-action/issues/198
     steps:


### PR DESCRIPTION
There is no need to update the Windows build image. After the GitHub actions migration it is no longer used.