### PR TITLE
database_observability: refactor parsing of truncated queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ v1.8.0-rc.2
   - `query_sample`: add option to use TiDB sql parser (@cristiangreco)
   - `query_tables`: rename collector from `query_sample` to better reflect responsibility (@matthewnolf)
   - `query_sample`: add new collector that replaces previous implementation to collect more detailed sample information (@matthewnolf)
+  - `query_sample`: refactor parsing of truncated queries (@cristiangreco)
 
 - Add labels validation in `pyroscope.write` to prevent duplicate labels and invalid label names/values. (@marcsanmi)
 

--- a/internal/component/database_observability/mysql/collector/parser/parser.go
+++ b/internal/component/database_observability/mysql/collector/parser/parser.go
@@ -8,6 +8,7 @@ type Parser interface {
 	StmtType(stmt any) StatementType
 	ParseTableName(t any) string
 	ExtractTableNames(logger log.Logger, digest string, stmt any) []string
+	CleanTruncatedText(sql string) (string, error)
 }
 
 type StatementType string

--- a/internal/component/database_observability/mysql/collector/parser/parser_tidb.go
+++ b/internal/component/database_observability/mysql/collector/parser/parser_tidb.go
@@ -96,3 +96,22 @@ func parseTableName(t *ast.TableName) string {
 	}
 	return tableName
 }
+
+func (p *TiDBSqlParser) CleanTruncatedText(sql string) (string, error) {
+	if !strings.HasSuffix(sql, "...") {
+		return sql, nil
+	}
+
+	// best-effort attempt to detect truncated trailing comment
+	idx := strings.LastIndex(sql, "/*")
+	if idx < 0 {
+		return sql, fmt.Errorf("sql text is truncated")
+	}
+
+	trailingText := sql[idx:]
+	if strings.LastIndex(trailingText, "*/") >= 0 {
+		return sql, fmt.Errorf("sql text is truncated after a comment")
+	}
+
+	return strings.TrimSpace(sql[:idx]), nil
+}

--- a/internal/component/database_observability/mysql/collector/parser/parser_tidb.go
+++ b/internal/component/database_observability/mysql/collector/parser/parser_tidb.go
@@ -105,12 +105,12 @@ func (p *TiDBSqlParser) CleanTruncatedText(sql string) (string, error) {
 	// best-effort attempt to detect truncated trailing comment
 	idx := strings.LastIndex(sql, "/*")
 	if idx < 0 {
-		return sql, fmt.Errorf("sql text is truncated")
+		return "", fmt.Errorf("sql text is truncated")
 	}
 
 	trailingText := sql[idx:]
 	if strings.LastIndex(trailingText, "*/") >= 0 {
-		return sql, fmt.Errorf("sql text is truncated after a comment")
+		return "", fmt.Errorf("sql text is truncated after a comment")
 	}
 
 	return strings.TrimSpace(sql[:idx]), nil

--- a/internal/component/database_observability/mysql/collector/parser/parser_tidb_test.go
+++ b/internal/component/database_observability/mysql/collector/parser/parser_tidb_test.go
@@ -1,6 +1,7 @@
 package parser_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/go-kit/log"
@@ -153,32 +154,32 @@ func TestParserTiDB_CleanTruncatedText(t *testing.T) {
 		name    string
 		sql     string
 		want    string
-		wantErr bool
+		wantErr error
 	}{
 		{
 			name:    "simple select",
 			sql:     "select * from some_table where id = 1",
 			want:    "select * from some_table where id = 1",
-			wantErr: false,
+			wantErr: nil,
 		},
 
 		{
 			name:    "truncated query",
 			sql:     "insert into some_table (`id1`, `id2`, `id3`, `id...",
 			want:    "insert into some_table (`id1`, `id2`, `id3`, `id...",
-			wantErr: true,
+			wantErr: fmt.Errorf("sql text is truncated"),
 		},
 		{
 			name:    "truncated in multi-line comment",
 			sql:     "select * from some_table where id = 1 /*traceparent='00-abc...",
 			want:    "select * from some_table where id = 1",
-			wantErr: false,
+			wantErr: nil,
 		},
 		{
 			name:    "truncated with properly closed comment",
 			sql:     "select * from some_table where id = 1 /* comment that's closed */ and name = 'test...",
 			want:    "select * from some_table where id = 1 /* comment that's closed */ and name = 'test...",
-			wantErr: true,
+			wantErr: fmt.Errorf("sql text is truncated after a comment"),
 		},
 	}
 
@@ -186,8 +187,9 @@ func TestParserTiDB_CleanTruncatedText(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			p := parser.NewTiDBSqlParser()
 			got, err := p.CleanTruncatedText(tc.sql)
-			if tc.wantErr {
+			if tc.wantErr != nil {
 				require.Error(t, err)
+				require.EqualError(t, tc.wantErr, err.Error())
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tc.want, got)

--- a/internal/component/database_observability/mysql/collector/parser/parser_xwb.go
+++ b/internal/component/database_observability/mysql/collector/parser/parser_xwb.go
@@ -150,12 +150,12 @@ func (p *XwbSqlParser) CleanTruncatedText(sql string) (string, error) {
 	// best-effort attempt to detect truncated trailing comment
 	idx := strings.LastIndex(sql, "/*")
 	if idx < 0 {
-		return sql, fmt.Errorf("sql text is truncated")
+		return "", fmt.Errorf("sql text is truncated")
 	}
 
 	trailingText := sql[idx:]
 	if strings.LastIndex(trailingText, "*/") >= 0 {
-		return sql, fmt.Errorf("sql text is truncated after a comment")
+		return "", fmt.Errorf("sql text is truncated after a comment")
 	}
 
 	return strings.TrimSpace(sql[:idx]), nil

--- a/internal/component/database_observability/mysql/collector/parser/parser_xwb.go
+++ b/internal/component/database_observability/mysql/collector/parser/parser_xwb.go
@@ -1,6 +1,9 @@
 package parser
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/go-kit/log"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
 	"github.com/xwb1989/sqlparser"
@@ -137,4 +140,23 @@ func (p *XwbSqlParser) parseTableExprs(logger log.Logger, digest string, tables 
 		}
 	}
 	return parsedTables
+}
+
+func (p *XwbSqlParser) CleanTruncatedText(sql string) (string, error) {
+	if !strings.HasSuffix(sql, "...") {
+		return sql, nil
+	}
+
+	// best-effort attempt to detect truncated trailing comment
+	idx := strings.LastIndex(sql, "/*")
+	if idx < 0 {
+		return sql, fmt.Errorf("sql text is truncated")
+	}
+
+	trailingText := sql[idx:]
+	if strings.LastIndex(trailingText, "*/") >= 0 {
+		return sql, fmt.Errorf("sql text is truncated after a comment")
+	}
+
+	return strings.TrimSpace(sql[:idx]), nil
 }

--- a/internal/component/database_observability/mysql/collector/parser/parser_xwb_test.go
+++ b/internal/component/database_observability/mysql/collector/parser/parser_xwb_test.go
@@ -135,3 +135,51 @@ func TestParserXwb_ExtractTableNames(t *testing.T) {
 		})
 	}
 }
+
+func TestParserXwb_CleanTruncatedText(t *testing.T) {
+	testcases := []struct {
+		name    string
+		sql     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "simple select",
+			sql:     "select * from some_table where id = 1",
+			want:    "select * from some_table where id = 1",
+			wantErr: false,
+		},
+
+		{
+			name:    "truncated query",
+			sql:     "insert into some_table (`id1`, `id2`, `id3`, `id...",
+			want:    "insert into some_table (`id1`, `id2`, `id3`, `id...",
+			wantErr: true,
+		},
+		{
+			name:    "truncated in multi-line comment",
+			sql:     "select * from some_table where id = 1 /*traceparent='00-abc...",
+			want:    "select * from some_table where id = 1",
+			wantErr: false,
+		},
+		{
+			name:    "truncated with properly closed comment",
+			sql:     "select * from some_table where id = 1 /* comment that's closed */ and name = 'test...",
+			want:    "select * from some_table where id = 1 /* comment that's closed */ and name = 'test...",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := parser.NewTiDBSqlParser()
+			got, err := p.CleanTruncatedText(tc.sql)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.want, got)
+			}
+		})
+	}
+}

--- a/internal/component/database_observability/mysql/collector/parser/parser_xwb_test.go
+++ b/internal/component/database_observability/mysql/collector/parser/parser_xwb_test.go
@@ -1,6 +1,7 @@
 package parser_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/go-kit/log"
@@ -141,32 +142,32 @@ func TestParserXwb_CleanTruncatedText(t *testing.T) {
 		name    string
 		sql     string
 		want    string
-		wantErr bool
+		wantErr error
 	}{
 		{
 			name:    "simple select",
 			sql:     "select * from some_table where id = 1",
 			want:    "select * from some_table where id = 1",
-			wantErr: false,
+			wantErr: nil,
 		},
 
 		{
 			name:    "truncated query",
 			sql:     "insert into some_table (`id1`, `id2`, `id3`, `id...",
 			want:    "insert into some_table (`id1`, `id2`, `id3`, `id...",
-			wantErr: true,
+			wantErr: fmt.Errorf("sql text is truncated"),
 		},
 		{
 			name:    "truncated in multi-line comment",
 			sql:     "select * from some_table where id = 1 /*traceparent='00-abc...",
 			want:    "select * from some_table where id = 1",
-			wantErr: false,
+			wantErr: nil,
 		},
 		{
 			name:    "truncated with properly closed comment",
 			sql:     "select * from some_table where id = 1 /* comment that's closed */ and name = 'test...",
 			want:    "select * from some_table where id = 1 /* comment that's closed */ and name = 'test...",
-			wantErr: true,
+			wantErr: fmt.Errorf("sql text is truncated after a comment"),
 		},
 	}
 
@@ -174,8 +175,9 @@ func TestParserXwb_CleanTruncatedText(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			p := parser.NewTiDBSqlParser()
 			got, err := p.CleanTruncatedText(tc.sql)
-			if tc.wantErr {
+			if tc.wantErr != nil {
 				require.Error(t, err)
+				require.EqualError(t, tc.wantErr, err.Error())
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tc.want, got)


### PR DESCRIPTION
#### PR Description
Move parsing of truncated queries to the parser implementations and log out as error when a query is truncated.

The parsers still have code copied, but we'll eventually drop one of the implementations

#### Which issue(s) this PR fixes
n.a.

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
