### PR TITLE
Bump versions of Go packages used by the build image CI

### DIFF
--- a/tools/build-image/Dockerfile
+++ b/tools/build-image/Dockerfile
@@ -40,13 +40,13 @@ ENV CONTROLLER_GEN_VERSION v0.9.2
 
 RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@$CONTROLLER_GEN_VERSION \
  && go install github.com/mitchellh/gox@v1.0.1                                         \
- && go install github.com/tcnksm/ghr@v0.15.0                                           \
- && go install github.com/grafana/tanka/cmd/tk@v0.22.1                                 \
- && go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.5.1                \
- && go install github.com/google/go-jsonnet/cmd/jsonnet@v0.18.0                        \
- && go install github.com/golang/protobuf/protoc-gen-go@v1.3.1                         \
- && go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0                    \
- && go install github.com/gogo/protobuf/gogoproto/...@v1.3.0                           \
+ && go install github.com/tcnksm/ghr@v0.17.0                                           \
+ && go install github.com/grafana/tanka/cmd/tk@v0.31.3                                 \
+ && go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.6.0                \
+ && go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0                        \
+ && go install github.com/golang/protobuf/protoc-gen-go@v1.5.4                         \
+ && go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.5.4                    \
+ && go install github.com/gogo/protobuf/gogoproto/...@v1.5.4                           \
  && go install github.com/ahmetb/gen-crd-api-reference-docs@v0.3.1-0.20220618162802-424739b250f5 \
  && go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.11.0
 


### PR DESCRIPTION
The CI [has been failing](https://github.com/grafana/alloy/actions/runs/14088460889/job/39469230064) and I hope that this might fix it...

The failure happens when installing some Go packages:
```
2025-03-26T19:18:15.8063568Z  > [linux/arm64 golang 2/2] RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2  && go install github.com/mitchellh/gox@v1.0.1                                          && go install github.com/tcnksm/ghr@v0.15.0                                            && go install github.com/grafana/tanka/cmd/tk@v0.22.1                                  && go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.5.1                 && go install github.com/google/go-jsonnet/cmd/jsonnet@v0.18.0                         && go install github.com/golang/protobuf/protoc-gen-go@v1.3.1                          && go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0                     && go install github.com/gogo/protobuf/gogoproto/...@v1.3.0                            && go install github.com/ahmetb/gen-crd-api-reference-docs@v0.3.1-0.20220618162802-424739b250f5  && go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.11.0:
2025-03-26T19:18:15.8068064Z 10.24 go: downloading github.com/go-logr/logr v1.2.0
2025-03-26T19:18:15.8068780Z 10.32 go: downloading golang.org/x/sys v0.0.0-20220209214540-3681064d5158
2025-03-26T19:18:15.8069538Z 10.56 go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
2025-03-26T19:18:15.8070233Z 11.02 go: downloading github.com/json-iterator/go v1.1.12
2025-03-26T19:18:15.8070960Z 11.06 go: downloading golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd
2025-03-26T19:18:15.8071771Z 11.87 go: downloading golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3
2025-03-26T19:18:15.8072666Z 13.06 go: downloading github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
2025-03-26T19:18:15.8073478Z 13.17 go: downloading github.com/modern-go/reflect2 v1.0.2
2025-03-26T19:18:15.8074055Z 14.56 go: downloading golang.org/x/text v0.3.7
2025-03-26T19:18:15.8074627Z 285.8 net: gcc: signal: segmentation fault (core dumped)
```

I haven't tested this, but it's a low risk change so I think it's worth to try it out.