### PR TITLE
chore: Update github workflows for build image after qemu segfault fix

### DIFF
--- a/.github/workflows/check-linux-build-image.yml
+++ b/.github/workflows/check-linux-build-image.yml
@@ -13,7 +13,7 @@ jobs:
         build:
           - runtime: golang:1.24.1-alpine3.21
           - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.24.1-bookworm
-    runs-on: ubuntu-22.04 # related to https://github.com/docker/setup-qemu-action/issues/198
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,9 +27,7 @@ jobs:
             rm -rf /opt/hostedtoolcache
 
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3.4.0
-        with:
-          image: tonistiigi/binfmt:qemu-v7.0.0-28 # https://github.com/docker/setup-qemu-action/issues/198
+        uses: docker/setup-qemu-action@v3.6.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/create_build_image.yml
+++ b/.github/workflows/create_build_image.yml
@@ -17,7 +17,7 @@ jobs:
           - runtime: golang:1.24.1-alpine3.21
           - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.24.1-bookworm
             suffix: "-boringcrypto"
-    runs-on: ubuntu-22.04 # related to https://github.com/docker/setup-qemu-action/issues/198
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -40,9 +40,7 @@ jobs:
       uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login-v1.0.1
 
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@v3.4.0
-      with:
-        image: tonistiigi/binfmt:qemu-v7.0.0-28 # https://github.com/docker/setup-qemu-action/issues/198
+      uses: docker/setup-qemu-action@v3.6.0
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
As https://github.com/docker/setup-qemu-action/issues/198 has been resolved, we should be able to have stable build images again on latest qemu action & ubuntu.

#### Which issue(s) this PR fixes