### PR TITLE
feat: Set Windows process priority for Alloy

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 # Full list of configuration options: https://golangci-lint.run/usage/configuration/
 
 run:
-  timeout: 10m
+  timeout: 15m
 
 output:
   sort-results: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Main (unreleased)
 
 ### Enhancements
 
+- (_Public Preview_) Add a `--windows.priority` flag to the run command, allowing users to set windows process priority for Alloy. (@dehaansa)
+
 - (_Experimental_) Adding a new `prometheus.operator.scrapeconfigs` which discovers and scrapes [ScrapeConfig](https://prometheus-operator.dev/docs/developer/scrapeconfig/) Kubernetes resources. (@alex-berger)
 
 - Add `rfc3164_default_to_current_year` argument to `loki.source.syslog` (@dehaansa)

--- a/docs/sources/reference/cli/run.md
+++ b/docs/sources/reference/cli/run.md
@@ -63,6 +63,13 @@ The following flags are supported:
 * `--feature.prometheus.metric-validation-scheme`: Prometheus metric validation scheme to use. Supported values: `legacy`, `utf-8`. NOTE: this is an experimental flag and may be removed in future releases (default `"legacy"`).
 * `--windows.priority`: The priority to set for the {{< param "PRODUCT_NAME" >}} process when running on Windows. This is only available on Windows. Supported values: `above_normal`, `below_normal`, `normal`, `high`, `idle`, `realtime` (default `"normal"`).
 
+{{< admonition type="note" >}}
+The `--windows.priority` flag is in [Public preview][] and is not covered by {{< param "FULL_PRODUCT_NAME" >}} [backward compatibility][] guarantees.
+
+[Public preview]: https://grafana.com/docs/release-life-cycle/
+[backward compatibility]: ../introduction/backward-compatibility/
+{{< /admonition >}}
+
 ## Update the configuration file
 
 The configuration file can be reloaded from disk by either:

--- a/docs/sources/reference/cli/run.md
+++ b/docs/sources/reference/cli/run.md
@@ -61,6 +61,7 @@ The following flags are supported:
 * `--stability.level`: The minimum permitted stability level of functionality to run. Supported values: `experimental`, `public-preview`, `generally-available` (default `"generally-available"`).
 * `--feature.community-components.enabled`: Enable community components (default `false`).
 * `--feature.prometheus.metric-validation-scheme`: Prometheus metric validation scheme to use. Supported values: `legacy`, `utf-8`. NOTE: this is an experimental flag and may be removed in future releases (default `"legacy"`).
+* `--windows.priority`: The priority to set for the {{< param "PRODUCT_NAME" >}} process when running on Windows. This is only available on Windows. Supported values: `above_normal`, `below_normal`, `normal`, `high`, `idle`, `realtime` (default `"normal"`).
 
 ## Update the configuration file
 

--- a/docs/sources/set-up/install/windows.md
+++ b/docs/sources/set-up/install/windows.md
@@ -56,6 +56,7 @@ To do a silent install of {{< param "PRODUCT_NAME" >}} on Windows, perform the f
 * `/DISABLEREPORTING=<yes|no>` Disable [data collection][]. Default: `no`
 * `/DISABLEPROFILING=<yes|no>` Disable profiling endpoint. Default: `no`
 * `/ENVIRONMENT="KEY=VALUE\0KEY2=VALUE2"` Define environment variables for Windows Service. Default: ``
+* `/RUNTIMEPRIORITY="normal|below_normal|above_normal|high|idle|realtime"` Set the runtime priority of the {{< param "PRODUCT_NAME" >}} process. Default: ``
 
 ## Service Configuration
 

--- a/docs/sources/set-up/install/windows.md
+++ b/docs/sources/set-up/install/windows.md
@@ -57,6 +57,17 @@ To do a silent install of {{< param "PRODUCT_NAME" >}} on Windows, perform the f
 * `/DISABLEPROFILING=<yes|no>` Disable profiling endpoint. Default: `no`
 * `/ENVIRONMENT="KEY=VALUE\0KEY2=VALUE2"` Define environment variables for Windows Service. Default: ``
 * `/RUNTIMEPRIORITY="normal|below_normal|above_normal|high|idle|realtime"` Set the runtime priority of the {{< param "PRODUCT_NAME" >}} process. Default: ``
+  * The default behavior is to leave the runtime priority at normal.
+* `/STABILITY="generally-available|public-preview|experimental"` Set the stability level of {{< param "PRODUCT_NAME" >}} Default: ``
+  * The default behavior is to only allow components and features that are [Generally available][stability].
+
+{{< admonition type="note" >}}
+The `--windows.priority` flag is in [Public preview][stability] and is not covered by {{< param "FULL_PRODUCT_NAME" >}} [backward compatibility][] guarantees.
+The `/RUNTIMEPRIORITY` installation option sets this flag, and if Alloy is not running with an appropriate stability level it will fail to start.
+
+[stability]: https://grafana.com/docs/release-life-cycle/
+[backward compatibility]: ../introduction/backward-compatibility/
+{{< /admonition >}}
 
 ## Service Configuration
 

--- a/internal/alloycli/cmd_run.go
+++ b/internal/alloycli/cmd_run.go
@@ -169,7 +169,7 @@ depending on the nature of the reload error.
 	cmd.Flags().BoolVar(&r.enableCommunityComps, "feature.community-components.enabled", r.enableCommunityComps, "Enable community components.")
 	cmd.Flags().StringVar(&r.prometheusMetricNameValidationScheme, "feature.prometheus.metric-validation-scheme", prometheusLegacyMetricValidationScheme, fmt.Sprintf("Prometheus metric validation scheme to use. Supported values: %q, %q. NOTE: this is an experimental flag and may be removed in future releases.", prometheusLegacyMetricValidationScheme, prometheusUTF8MetricValidationScheme))
 	if runtime.GOOS == "windows" {
-		cmd.Flags().StringVar(&r.windowsPriority, "windows.priority", r.windowsPriority, fmt.Sprintf("Process priority to use when running on windows. Supported values: %s", strings.Join(slices.Collect(windowspriority.PriorityValues()), ", ")))
+		cmd.Flags().StringVar(&r.windowsPriority, "windows.priority", r.windowsPriority, fmt.Sprintf("Process priority to use when running on windows. This flag is currently in public preview. Supported values: %s", strings.Join(slices.Collect(windowspriority.PriorityValues()), ", ")))
 	}
 
 	addDeprecatedFlags(cmd)

--- a/internal/alloycli/cmd_run.go
+++ b/internal/alloycli/cmd_run.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -45,6 +46,7 @@ import (
 	uiservice "github.com/grafana/alloy/internal/service/ui"
 	"github.com/grafana/alloy/internal/static/config/instrumentation"
 	"github.com/grafana/alloy/internal/usagestats"
+	"github.com/grafana/alloy/internal/util/windowspriority"
 	"github.com/grafana/alloy/syntax/diag"
 
 	// Install Components
@@ -73,6 +75,7 @@ func runCommand() *cobra.Command {
 		// For backwards compatibility - use the LegacyValidation of Prometheus metrics name. This is a global variable
 		// setting that has changed upstream. See https://github.com/prometheus/common/pull/724.
 		prometheusMetricNameValidationScheme: prometheusLegacyMetricValidationScheme,
+		windowsPriority:                      windowspriority.PriorityNormal,
 	}
 
 	cmd := &cobra.Command{
@@ -165,6 +168,9 @@ depending on the nature of the reload error.
 	cmd.Flags().Var(&r.minStability, "stability.level", fmt.Sprintf("Minimum stability level of features to enable. Supported values: %s", strings.Join(featuregate.AllowedValues(), ", ")))
 	cmd.Flags().BoolVar(&r.enableCommunityComps, "feature.community-components.enabled", r.enableCommunityComps, "Enable community components.")
 	cmd.Flags().StringVar(&r.prometheusMetricNameValidationScheme, "feature.prometheus.metric-validation-scheme", prometheusLegacyMetricValidationScheme, fmt.Sprintf("Prometheus metric validation scheme to use. Supported values: %q, %q. NOTE: this is an experimental flag and may be removed in future releases.", prometheusLegacyMetricValidationScheme, prometheusUTF8MetricValidationScheme))
+	if runtime.GOOS == "windows" {
+		cmd.Flags().StringVar(&r.windowsPriority, "windows.priority", r.windowsPriority, fmt.Sprintf("Process priority to use when running on windows. Supported values: %s", strings.Join(slices.Collect(windowspriority.PriorityValues()), ", ")))
+	}
 
 	addDeprecatedFlags(cmd)
 	return cmd
@@ -198,6 +204,7 @@ type alloyRun struct {
 	enableCommunityComps                 bool
 	disableSupportBundle                 bool
 	prometheusMetricNameValidationScheme string
+	windowsPriority                      string
 }
 
 func (fr *alloyRun) Run(cmd *cobra.Command, configPath string) error {
@@ -224,6 +231,20 @@ func (fr *alloyRun) Run(cmd *cobra.Command, configPath string) error {
 
 	if err := fr.configurePrometheusMetricNameValidationScheme(l); err != nil {
 		return err
+	}
+
+	// The non-windows path for this is just a return nil, but to protect against
+	// refactoring assumptions we confirm that we're running on windows before setting the priority.
+	if runtime.GOOS == "windows" {
+		if err := windowspriority.SetPriority(fr.windowsPriority); err != nil {
+			if fr.windowsPriority == windowspriority.PriorityNormal {
+				level.Warn(l).Log("msg", "failed to set process priority to normal", "err", err)
+			} else {
+				return fmt.Errorf("setting process priority: %w", err)
+			}
+		} else {
+			level.Debug(l).Log("msg", "set process priority", "priority", fr.windowsPriority)
+		}
 	}
 
 	// Set the global tracer provider to catch global traces, but ideally things

--- a/internal/util/windowspriority/set_priority_nonwindows.go
+++ b/internal/util/windowspriority/set_priority_nonwindows.go
@@ -1,0 +1,24 @@
+//go:build !windows
+// +build !windows
+
+package windowspriority
+
+import (
+	"errors"
+	"iter"
+)
+
+// This is the default value in the alloycli package
+const PriorityNormal = "normal"
+
+func PriorityValues() iter.Seq[string] {
+	return nil
+}
+
+func TranslatePriority(_ string) (uint32, error) {
+	return 0, errors.New("not supported on non-Windows platforms")
+}
+
+func SetPriority(_ string) error {
+	return nil
+}

--- a/internal/util/windowspriority/set_priority_windows.go
+++ b/internal/util/windowspriority/set_priority_windows.go
@@ -1,0 +1,55 @@
+//go:build windows
+// +build windows
+
+package windowspriority
+
+import (
+	"fmt"
+	"iter"
+	"maps"
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+// This is the default value in the alloycli package. We don't need constants
+// for the other values because they are not used in code.
+const PriorityNormal = "normal"
+
+var priorityMap = map[string]uint32{
+	"above_normal": windows.ABOVE_NORMAL_PRIORITY_CLASS,
+	"below_normal": windows.BELOW_NORMAL_PRIORITY_CLASS,
+	"high":         windows.HIGH_PRIORITY_CLASS,
+	"idle":         windows.IDLE_PRIORITY_CLASS,
+	PriorityNormal: windows.NORMAL_PRIORITY_CLASS,
+	"realtime":     windows.REALTIME_PRIORITY_CLASS,
+}
+
+func PriorityValues() iter.Seq[string] {
+	return maps.Keys(priorityMap)
+}
+
+func TranslatePriority(priorityString string) (uint32, error) {
+	priority, ok := priorityMap[strings.ToLower(priorityString)]
+	if !ok {
+		return 0, fmt.Errorf("invalid priority: %s", priorityString)
+	}
+	return priority, nil
+}
+
+func SetPriority(priorityString string) error {
+	if priorityString == "" {
+		return nil
+	}
+
+	priority, err := TranslatePriority(priorityString)
+	if err != nil {
+		return err
+	}
+
+	if err := windows.SetPriorityClass(windows.CurrentProcess(), priority); err != nil {
+		return fmt.Errorf("failed to set priority: %w", err)
+	}
+
+	return nil
+}

--- a/internal/util/windowspriority/set_priority_windows.go
+++ b/internal/util/windowspriority/set_priority_windows.go
@@ -38,10 +38,6 @@ func TranslatePriority(priorityString string) (uint32, error) {
 }
 
 func SetPriority(priorityString string) error {
-	if priorityString == "" {
-		return nil
-	}
-
 	priority, err := TranslatePriority(priorityString)
 	if err != nil {
 		return err

--- a/internal/util/windowspriority/set_priority_windows_test.go
+++ b/internal/util/windowspriority/set_priority_windows_test.go
@@ -1,0 +1,54 @@
+//go:build windows
+// +build windows
+
+package windowspriority
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestWindowsPriority(t *testing.T) {
+	tests := []struct {
+		name          string
+		priority      string
+		expectedError string
+	}{
+		{
+			name:     "normal priority",
+			priority: "normal",
+		},
+		{
+			name:     "high priority",
+			priority: "high",
+		},
+		{
+			name:          "unknown priority",
+			priority:      "weird",
+			expectedError: "invalid priority: weird",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reset the priority before each test
+			defer func() {
+				SetPriority("normal")
+			}()
+
+			err := SetPriority(tc.priority)
+
+			if tc.expectedError != "" {
+				require.ErrorContains(t, err, tc.expectedError)
+				return
+			}
+
+			runningPriority, err := windows.GetPriorityClass(windows.CurrentProcess())
+			require.NoError(t, err)
+			require.Equal(t, priorityMap[tc.priority], runningPriority)
+		})
+	}
+}

--- a/packaging/windows/install_script.nsis
+++ b/packaging/windows/install_script.nsis
@@ -38,6 +38,8 @@ Var DisableProfiling
 Var DisableProfilingFlag
 Var RuntimePriority
 Var RuntimePriorityFlag
+Var Stability
+Var StabilityFlag
 
 # Pages during the installer.
 Page license
@@ -55,6 +57,7 @@ Section "install"
   ${GetOptions} $PassedInParameters "/DISABLEPROFILING=" $DisableProfiling
   ${GetOptions} $PassedInParameters "/DISABLEREPORTING=" $DisableReporting
   ${GetOptions} $PassedInParameters "/RUNTIMEPRIORITY=" $RuntimePriority
+  ${GetOptions} $PassedInParameters "/STABILITY=" $Stability
   ${GetOptions} $PassedInParameters "/ENVIRONMENT=" $Environment
   ${GetOptions} $PassedInParameters "/CONFIG=" $Config
 
@@ -181,6 +184,12 @@ Function InitializeRegistry
     StrCpy $RuntimePriorityFlag ""
   ${EndIf}
 
+  ${If} $Stability != ""
+    StrCpy $StabilityFlag "--stability.level=\"${Stability}\"\0"
+  ${Else}
+    StrCpy $StabilityFlag ""
+  ${EndIf}
+
   ${If} $DisableProfiling == "yes"
     StrCpy $DisableProfilingFlag "--server.http.enable-pprof=false\0"
   ${Else}
@@ -192,7 +201,7 @@ Function InitializeRegistry
   nsExec::ExecToLog 'Reg.exe query "${REGKEY}" /reg:64 /v Arguments'
   Pop $0
   ${If} $0 == 1
-    nsExec::ExecToLog 'Reg.exe add "${REGKEY}" /reg:64 /v Arguments /t REG_MULTI_SZ /d "run"\0"$ConfigFlag"\0"--storage.path=$APPDATA\GrafanaLabs\${APPNAME}\data"\0"$DisableReportingFlag$DisableProfilingFlag$RuntimePriorityFlag"'
+    nsExec::ExecToLog 'Reg.exe add "${REGKEY}" /reg:64 /v Arguments /t REG_MULTI_SZ /d "run"\0"$ConfigFlag"\0"--storage.path=$APPDATA\GrafanaLabs\${APPNAME}\data"\0"$DisableReportingFlag$DisableProfilingFlag$RuntimePriorityFlag$StabilityFlag"'
     Pop $0 # Ignore return result
   ${EndIf}
 

--- a/packaging/windows/install_script.nsis
+++ b/packaging/windows/install_script.nsis
@@ -179,13 +179,13 @@ Function InitializeRegistry
   ${EndIf}
 
   ${If} $RuntimePriority != ""
-    StrCpy $RuntimePriorityFlag "--windows.priority=\"$RuntimePriority\"\0"
+    StrCpy $RuntimePriorityFlag "--windows.priority=$\"$RuntimePriority$\"\0"
   ${Else}
     StrCpy $RuntimePriorityFlag ""
   ${EndIf}
 
   ${If} $Stability != ""
-    StrCpy $StabilityFlag "--stability.level=\"$Stability\"\0"
+    StrCpy $StabilityFlag "--stability.level=$\"$Stability$\"\0"
   ${Else}
     StrCpy $StabilityFlag ""
   ${EndIf}

--- a/packaging/windows/install_script.nsis
+++ b/packaging/windows/install_script.nsis
@@ -179,13 +179,13 @@ Function InitializeRegistry
   ${EndIf}
 
   ${If} $RuntimePriority != ""
-    StrCpy $RuntimePriorityFlag "--windows.priority=\"${RuntimePriority}\"\0"
+    StrCpy $RuntimePriorityFlag "--windows.priority=\"$RuntimePriority\"\0"
   ${Else}
     StrCpy $RuntimePriorityFlag ""
   ${EndIf}
 
   ${If} $Stability != ""
-    StrCpy $StabilityFlag "--stability.level=\"${Stability}\"\0"
+    StrCpy $StabilityFlag "--stability.level=\"$Stability\"\0"
   ${Else}
     StrCpy $StabilityFlag ""
   ${EndIf}

--- a/packaging/windows/install_script.nsis
+++ b/packaging/windows/install_script.nsis
@@ -36,6 +36,8 @@ Var DisableReporting
 Var DisableReportingFlag
 Var DisableProfiling
 Var DisableProfilingFlag
+Var RuntimePriority
+Var RuntimePriorityFlag
 
 # Pages during the installer.
 Page license
@@ -52,6 +54,7 @@ Section "install"
   ${GetParameters} $PassedInParameters
   ${GetOptions} $PassedInParameters "/DISABLEPROFILING=" $DisableProfiling
   ${GetOptions} $PassedInParameters "/DISABLEREPORTING=" $DisableReporting
+  ${GetOptions} $PassedInParameters "/RUNTIMEPRIORITY=" $RuntimePriority
   ${GetOptions} $PassedInParameters "/ENVIRONMENT=" $Environment
   ${GetOptions} $PassedInParameters "/CONFIG=" $Config
 
@@ -172,6 +175,12 @@ Function InitializeRegistry
     StrCpy $DisableReportingFlag ""
   ${EndIf}
 
+  ${If} $RuntimePriority != ""
+    StrCpy $RuntimePriorityFlag "--windows.priority=\"${RuntimePriority}\"\0"
+  ${Else}
+    StrCpy $RuntimePriorityFlag ""
+  ${EndIf}
+
   ${If} $DisableProfiling == "yes"
     StrCpy $DisableProfilingFlag "--server.http.enable-pprof=false\0"
   ${Else}
@@ -183,7 +192,7 @@ Function InitializeRegistry
   nsExec::ExecToLog 'Reg.exe query "${REGKEY}" /reg:64 /v Arguments'
   Pop $0
   ${If} $0 == 1
-    nsExec::ExecToLog 'Reg.exe add "${REGKEY}" /reg:64 /v Arguments /t REG_MULTI_SZ /d "run"\0"$ConfigFlag"\0"--storage.path=$APPDATA\GrafanaLabs\${APPNAME}\data"\0"$DisableReportingFlag$DisableProfilingFlag"'
+    nsExec::ExecToLog 'Reg.exe add "${REGKEY}" /reg:64 /v Arguments /t REG_MULTI_SZ /d "run"\0"$ConfigFlag"\0"--storage.path=$APPDATA\GrafanaLabs\${APPNAME}\data"\0"$DisableReportingFlag$DisableProfilingFlag$RuntimePriorityFlag"'
     Pop $0 # Ignore return result
   ${EndIf}
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Add a new `--windows.priority` flag that allows the user to set the runtime priority of the alloy process. Set this to public preview so that we can change the way this works (move to block, apply from service config) if this doesn't meet user needs.

The flag is applied within the first few actions of the `run` command, and the setting cannot be changed while running.

![image](https://github.com/user-attachments/assets/ea76ee91-fe72-435e-a822-381c312fadd9)


#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes https://github.com/grafana/alloy/issues/2651

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
- [X] Documentation added
- [X] Tests updated
