### PR TITLE
docs: Add note for using proxy_from_environment

### DIFF
--- a/docs/sources/reference/cli/environment-variables.md
+++ b/docs/sources/reference/cli/environment-variables.md
@@ -40,10 +40,10 @@ Argument               | Description                                            
 ## HTTP_PROXY, HTTPS_PROXY, NO_PROXY
 
 {{< admonition type="note" >}}
-For many {{< param "PRODUCT_NAME" >}} components, there is an attribute named `proxy_from_environment` that must be set to `true` for the component's
-HTTP client to use the proxy related environment variables. For example, in the `prometheus.remote_write` component this attribute is found within the 
-`endpoint` block. If {{< param "PRODUCT_NAME" >}} does not appear to be respecting your proxy configuration, please ensure the component is
-configured properly to utilize proxy environment variables.
+For many {{< param "PRODUCT_NAME" >}} components, there is an attribute named `proxy_from_environment` that must be set to `true` for the component's HTTP client to use the proxy-related environment variables.
+For example, in the `prometheus.remote_write` component, this attribute is found within the `endpoint` block.
+
+If {{< param "PRODUCT_NAME" >}} doesn't appear to be respecting your proxy configuration, make sure you configure the component to use proxy environment variables.
 {{< /admonition >}}
 
 You can use the `HTTP_PROXY` environment variable to define the hostname or IP address of the proxy server for HTTP requests. For example, you can set the proxy to `http://proxy.example.com`.

--- a/docs/sources/reference/cli/environment-variables.md
+++ b/docs/sources/reference/cli/environment-variables.md
@@ -41,7 +41,7 @@ Argument               | Description                                            
 
 {{< admonition type="note" >}}
 For many {{< param "PRODUCT_NAME" >}} components, there is an attribute named `proxy_from_environment` that must be set to `true` for the component's
-http client to use the proxy related environment variables. For example, in the `prometheus.remote_write` component this attribute is found within the 
+HTTP client to use the proxy related environment variables. For example, in the `prometheus.remote_write` component this attribute is found within the 
 `endpoint` block. If {{< param "PRODUCT_NAME" >}} does not appear to be respecting your proxy configuration, please ensure the component is
 configured properly to utilize proxy environment variables.
 {{< /admonition >}}

--- a/docs/sources/reference/cli/environment-variables.md
+++ b/docs/sources/reference/cli/environment-variables.md
@@ -40,7 +40,7 @@ Argument               | Description                                            
 ## HTTP_PROXY, HTTPS_PROXY, NO_PROXY
 
 {{< admonition type="note" >}}
-For many {{< param "PRODUCT_NAME" >}} components, there is an attribute named `proxy_from_environment` that must be set for the component's
+For many {{< param "PRODUCT_NAME" >}} components, there is an attribute named `proxy_from_environment` that must be set to `true` for the component's
 http client to use the proxy related environment variables. For example, in the `prometheus.remote_write` component this attribute is found within the 
 `endpoint` block. If {{< param "PRODUCT_NAME" >}} does not appear to be respecting your proxy configuration, please ensure the component is
 configured properly to utilize proxy environment variables.

--- a/docs/sources/reference/cli/environment-variables.md
+++ b/docs/sources/reference/cli/environment-variables.md
@@ -39,6 +39,13 @@ Argument               | Description                                            
 
 ## HTTP_PROXY, HTTPS_PROXY, NO_PROXY
 
+{{< admonition type="note" >}}
+For many {{< param "PRODUCT_NAME" >}} components, there is an attribute named `proxy_from_environment` that must be set for the component's
+http client to use the proxy related environment variables. For example, in the `prometheus.remote_write` component this attribute is found within the 
+`endpoint` block. If {{< param "PRODUCT_NAME" >}} does not appear to be respecting your proxy configuration, please ensure the component is
+configured properly to utilize proxy environment variables.
+{{< /admonition >}}
+
 You can use the `HTTP_PROXY` environment variable to define the hostname or IP address of the proxy server for HTTP requests. For example, you can set the proxy to `http://proxy.example.com`.
 
 You can use the `HTTPS_PROXY` environment variable to define the proxy server for HTTPS requests in the same manner as `HTTP_PROXY`.


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
A user was confused why Alloy was not utilizing their proxy environment variables, and the Alloy docs for environment variables do not point out the requirement to set `proxy_from_environment` for prometheus-styled components.