### PR TITLE
Bump beyla.ebpf component to use Beyla 2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Main (unreleased)
 - Added `--cluster.wait-for-size` and `--cluster.wait-timeout` flags which allow to specify the minimum cluster size
   required before components that use clustering begin processing traffic to ensure adequate cluster capacity is
   available. (@thampiotr)
+- Add `trace_printer` to `beyla.ebpf` component to print trace information in a specific format. (@marctc)
 
 ### Enhancements
 
@@ -111,6 +112,7 @@ Main (unreleased)
   - `otelcol.receiver.vcenter` has three new metrics `vcenter.vm.cpu.time`, `vcenter.vm.network.broadcast.packet.rate` and `vcenter.vm.network.multicast.packet.rate`.
   - `otelcol.exporter.awss3` has two new arguments `acl` and `storage_class`.
 
+- Change the stability of the `beyla.ebpf` component from "public preview" to "generally available". (@marctc)
 
 v1.7.5
 -----------------

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -8,6 +8,7 @@ cascade:
   OTEL_VERSION: v0.122.0
   PROM_WIN_EXP_VERSION: v0.27.3
   SNMP_VERSION: v0.28.0
+  BEYLA_VERSION: v2.1
   FULL_PRODUCT_NAME: Grafana Alloy
   PRODUCT_NAME: Alloy
 hero:

--- a/docs/sources/_index.md.t
+++ b/docs/sources/_index.md.t
@@ -8,6 +8,7 @@ cascade:
   OTEL_VERSION: v0.122.0
   PROM_WIN_EXP_VERSION: v0.27.3
   SNMP_VERSION: v0.28.0
+  BEYLA_VERSION: v2.1
   FULL_PRODUCT_NAME: Grafana Alloy
   PRODUCT_NAME: Alloy
 hero:

--- a/docs/sources/reference/components/beyla/beyla.ebpf.md
+++ b/docs/sources/reference/components/beyla/beyla.ebpf.md
@@ -4,13 +4,16 @@ aliases:
   - ../beyla.ebpf/ # /docs/alloy/latest/reference/components/beyla.ebpf/
 description: Learn about beyla.ebpf
 labels:
-  stage: public-preview
+  stage: general-availability
 title: beyla.ebpf
 ---
 
 # `beyla.ebpf`
 
-{{< docs/shared lookup="stability/public_preview.md" source="alloy" version="<ALLOY_VERSION>" >}}
+{{< admonition type="note" >}}
+`beyla.ebpf` component uses version {{< param "BEYLA_VERSION" >}} of Grafana Beyla.
+{{< /admonition >}}
+
 
 The `beyla.ebpf` component is a wrapper for [Grafana Beyla][] which uses [eBPF][] to automatically inspect application executables and the OS networking layer, and capture trace spans related to web transactions and Rate Errors Duration (RED) metrics for Linux HTTP/S and gRPC services.
 You can configure the component to collect telemetry data from a specific port or executable path, and other criteria from Kubernetes metadata.

--- a/docs/sources/reference/components/beyla/beyla.ebpf.md
+++ b/docs/sources/reference/components/beyla/beyla.ebpf.md
@@ -269,9 +269,18 @@ The `ebpf` block configures eBPF-specific settings.
 | `enable_context_propagation`  | `bool`        | Enable context propagation using Linux Traffic Control probes.             | `false` | no       |
 | `high_request_volume`         | `bool`        | Optimize for immediate request information when response is seen.          | `false` | no       |
 | `heuristic_sql_detect`        | `bool`        | Enable heuristic-based detection of SQL requests.                         | `false` | no       |
+| `trace_printer`              | `string`      | Format for printing trace information. | `"disabled"` | no |
 
 `enable_context_propagation` enables context propagation using Linux Traffic Control probes. 
 For more information about this topic, refer to [Distributed traces with Beyla][].
+
+`trace_printer` is used to print the trace information in a specific format. The following formats are supported:
+
+* `disabled` disables trace printing.
+* `counter` prints the trace information in a counter format.
+* `text` prints the trace information in a text format.
+* `json` prints the trace information in a JSON format.
+* `json_indent` prints the trace information in a JSON format with indentation.
 
 ### `filters`
 

--- a/docs/sources/reference/components/beyla/beyla.ebpf.md
+++ b/docs/sources/reference/components/beyla/beyla.ebpf.md
@@ -11,7 +11,7 @@ title: beyla.ebpf
 # `beyla.ebpf`
 
 {{< admonition type="note" >}}
-`beyla.ebpf` component uses version {{< param "BEYLA_VERSION" >}} of Grafana Beyla.
+The `beyla.ebpf` component uses Grafana Beyla version {{< param "BEYLA_VERSION" >}}.
 {{< /admonition >}}
 
 

--- a/internal/component/beyla/ebpf/args.go
+++ b/internal/component/beyla/ebpf/args.go
@@ -14,6 +14,7 @@ type Arguments struct {
 	// Deprecated: Use discovery.services instead.
 	ExecutableName string                     `alloy:"executable_name,attr,optional"`
 	Debug          bool                       `alloy:"debug,attr,optional"`
+	TracePrinter   string                     `alloy:"trace_printer,attr,optional"`
 	EnforceSysCaps bool                       `alloy:"enforce_sys_caps,attr,optional"`
 	Routes         Routes                     `alloy:"routes,block,optional"`
 	Attributes     Attributes                 `alloy:"attributes,block,optional"`

--- a/internal/component/beyla/ebpf/beyla_linux.go
+++ b/internal/component/beyla/ebpf/beyla_linux.go
@@ -38,7 +38,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "beyla.ebpf",
-		Stability: featuregate.StabilityPublicPreview,
+		Stability: featuregate.StabilityGenerallyAvailable,
 		Args:      Arguments{},
 		Exports:   Exports{},
 
@@ -519,7 +519,7 @@ func (a *Arguments) Convert() (*beyla.Config, error) {
 			Level: &lvl,
 		})).Handler(), a.Debug)
 	}
-	cfg.TracePrinter = debug.TracePrinter(a.TracePrinter)
+
 	return &cfg, nil
 }
 
@@ -528,17 +528,10 @@ func (args *Arguments) Validate() error {
 	hasAppFeature := args.Metrics.hasAppFeature()
 
 	// Validate TracePrinter
-	if args.TracePrinter != "" {
-		validTracePrinters := map[string]struct{}{
-			"disabled":    {},
-			"counter":     {},
-			"text":        {},
-			"json":        {},
-			"json_indent": {},
-		}
-		if _, ok := validTracePrinters[args.TracePrinter]; !ok {
-			return fmt.Errorf("trace_printer: invalid value %q. Valid values are: disabled, counter, text, json, json_indent", args.TracePrinter)
-		}
+	if args.TracePrinter == "" {
+		args.TracePrinter = string(debug.TracePrinterDisabled)
+	} else if !debug.TracePrinter(args.TracePrinter).Valid() {
+		return fmt.Errorf("trace_printer: invalid value %q. Valid values are: disabled, counter, text, json, json_indent", args.TracePrinter)
 	}
 
 	// Services are required only when application observability is enabled

--- a/internal/component/beyla/ebpf/beyla_linux.go
+++ b/internal/component/beyla/ebpf/beyla_linux.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/beyla/v2/pkg/components"
 	beylaCfg "github.com/grafana/beyla/v2/pkg/config"
 	"github.com/grafana/beyla/v2/pkg/export/attributes"
+	"github.com/grafana/beyla/v2/pkg/export/debug"
 	"github.com/grafana/beyla/v2/pkg/export/prom"
 	"github.com/grafana/beyla/v2/pkg/filter"
 	"github.com/grafana/beyla/v2/pkg/kubeflags"
@@ -508,6 +509,7 @@ func (a *Arguments) Convert() (*beyla.Config, error) {
 	cfg.EnforceSysCaps = a.EnforceSysCaps
 	cfg.EBPF = a.EBPF.Convert()
 	cfg.Filters = a.Filters.Convert()
+	cfg.TracePrinter = debug.TracePrinter(a.TracePrinter)
 
 	if a.Debug {
 		// TODO: integrate Beyla internal logging with Alloy global logging
@@ -517,12 +519,27 @@ func (a *Arguments) Convert() (*beyla.Config, error) {
 			Level: &lvl,
 		})).Handler(), a.Debug)
 	}
+	cfg.TracePrinter = debug.TracePrinter(a.TracePrinter)
 	return &cfg, nil
 }
 
 func (args *Arguments) Validate() error {
 	hasNetworkFeature := args.Metrics.hasNetworkFeature()
 	hasAppFeature := args.Metrics.hasAppFeature()
+
+	// Validate TracePrinter
+	if args.TracePrinter != "" {
+		validTracePrinters := map[string]struct{}{
+			"disabled":    {},
+			"counter":     {},
+			"text":        {},
+			"json":        {},
+			"json_indent": {},
+		}
+		if _, ok := validTracePrinters[args.TracePrinter]; !ok {
+			return fmt.Errorf("trace_printer: invalid value %q. Valid values are: disabled, counter, text, json, json_indent", args.TracePrinter)
+		}
+	}
 
 	// Services are required only when application observability is enabled
 	if hasAppFeature {

--- a/internal/component/beyla/ebpf/beyla_linux_test.go
+++ b/internal/component/beyla/ebpf/beyla_linux_test.go
@@ -173,7 +173,6 @@ func TestArguments_UnmarshalSyntax(t *testing.T) {
 	require.Equal(t, debug.TracePrinter("json"), cfg.TracePrinter)
 }
 
-
 func TestArguments_TracePrinterDebug(t *testing.T) {
 	test := func(debugEnabled bool, printer string, expected string) {
 		const format = `
@@ -202,7 +201,7 @@ func TestArguments_TracePrinterDebug(t *testing.T) {
 		require.Equal(t, debug.TracePrinter(expected), cfg.TracePrinter)
 	}
 
-	// when debug is enabled, the printer will always be overriden to "text"
+	// when debug is enabled, the printer will always be overridden to "text"
 	// regardless of what is specified
 	test(true, "json", "text")
 	test(true, "text", "text")

--- a/internal/component/pyroscope/ebpf/ebpf_linux_test.go
+++ b/internal/component/pyroscope/ebpf/ebpf_linux_test.go
@@ -82,6 +82,7 @@ func (m *mockSession) DebugInfo() interface{} {
 					{
 						Name:          "X",
 						Size:          123,
+						MiniDebugInfo: false,
 						LastUsedRound: 1,
 					},
 				},


### PR DESCRIPTION
#### PR Description

- Bumped `beyla.ebpf` component to use last Beyla release (v2.1)
- Added `tracer_printer` field.
- Promote component to GA

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
