### PR TITLE
feat: Set service account with Windows silent install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Main (unreleased)
 
 ### Enhancements
 
+- Add the ability to set user for Windows Service with silent install (@dehaansa)
+
 - Add livedebugging support for structured_metadata in `loki.process` (@dehaansa)
 
 - (_Public Preview_) Add a `--windows.priority` flag to the run command, allowing users to set windows process priority for Alloy. (@dehaansa)

--- a/docs/sources/set-up/install/windows.md
+++ b/docs/sources/set-up/install/windows.md
@@ -58,8 +58,8 @@ To do a silent install of {{< param "PRODUCT_NAME" >}} on Windows, perform the f
 * `/ENVIRONMENT="KEY=VALUE\0KEY2=VALUE2"` Define environment variables for Windows Service. Default: ``
 * `/RUNTIMEPRIORITY="normal|below_normal|above_normal|high|idle|realtime"` Set the runtime priority of the {{< param "PRODUCT_NAME" >}} process. Default: `normal`
 * `/STABILITY="generally-available|public-preview|experimental"` Set the stability level of {{< param "PRODUCT_NAME" >}}. Default: `generally-available`
-* `/USERNAME="<username>"` Set the user that Windows will use to run the service. Default: `LocalSystem`
-* `/PASSWORD="<password>"` Set the password of the user that Windows will use to run the service. This is not required for standard Windows Service Accounts like LocalSystem, LocalService, or NetworkService. Default: ``
+* `/USERNAME="<username>"` Set the fully qualified user that Windows will use to run the service. Default: `NT AUTHORITY\LocalSystem`
+* `/PASSWORD="<password>"` Set the password of the user that Windows will use to run the service. This is not required for standard Windows Service Accounts like LocalSystem. Default: ``
 
 {{< admonition type="note" >}}
 The `--windows.priority` flag is in [Public preview][stability] and is not covered by {{< param "FULL_PRODUCT_NAME" >}} [backward compatibility][] guarantees.

--- a/docs/sources/set-up/install/windows.md
+++ b/docs/sources/set-up/install/windows.md
@@ -56,10 +56,10 @@ To do a silent install of {{< param "PRODUCT_NAME" >}} on Windows, perform the f
 * `/DISABLEREPORTING=<yes|no>` Disable [data collection][]. Default: `no`
 * `/DISABLEPROFILING=<yes|no>` Disable profiling endpoint. Default: `no`
 * `/ENVIRONMENT="KEY=VALUE\0KEY2=VALUE2"` Define environment variables for Windows Service. Default: ``
-* `/RUNTIMEPRIORITY="normal|below_normal|above_normal|high|idle|realtime"` Set the runtime priority of the {{< param "PRODUCT_NAME" >}} process. Default: ``
-  * The default behavior is to leave the runtime priority at normal.
-* `/STABILITY="generally-available|public-preview|experimental"` Set the stability level of {{< param "PRODUCT_NAME" >}} Default: ``
-  * The default behavior is to only allow components and features that are [Generally available][stability].
+* `/RUNTIMEPRIORITY="normal|below_normal|above_normal|high|idle|realtime"` Set the runtime priority of the {{< param "PRODUCT_NAME" >}} process. Default: `normal`
+* `/STABILITY="generally-available|public-preview|experimental"` Set the stability level of {{< param "PRODUCT_NAME" >}}. Default: `generally-available`
+* `/USERNAME="<username>"` Set the user that Windows will use to run the service. Default: `LocalSystem`
+* `/PASSWORD="<password>"` Set the password of the user that Windows will use to run the service. This is not required for standard Windows Service Accounts like LocalSystem, LocalService, or NetworkService. Default: ``
 
 {{< admonition type="note" >}}
 The `--windows.priority` flag is in [Public preview][stability] and is not covered by {{< param "FULL_PRODUCT_NAME" >}} [backward compatibility][] guarantees.

--- a/packaging/windows/install_script.nsis
+++ b/packaging/windows/install_script.nsis
@@ -168,7 +168,7 @@ Function CreateDataDirectory
     ${If} $User != ""
       AccessControl::SetOnFile    "$APPDATA\GrafanaLabs\${APPNAME}\data" "$User" "FullAccess"
     ${EndIf}
-    
+
     Return
 FunctionEnd
 
@@ -247,7 +247,6 @@ Function SetFolderPermissions
     AccessControl::GrantOnFile  $INSTDIR "Everyone" "GenericExecute"
     AccessControl::GrantOnFile  $INSTDIR "Everyone" "GenericRead"
     AccessControl::GrantOnFile  $INSTDIR "Everyone" "ReadAttributes"
-
     ${If} $User != ""
       AccessControl::SetOnFile    $INSTDIR "$User" "FullAccess"
     ${EndIf}

--- a/packaging/windows/install_script.nsis
+++ b/packaging/windows/install_script.nsis
@@ -118,11 +118,6 @@ Section "install"
   # Create the service.
   nsExec::ExecToLog 'sc create "Alloy" start= delayed-auto $AuthFlag binpath= "\"$INSTDIR\alloy-service-windows-amd64.exe\""'
   Pop $0
-  ${If} $0 <> 0
-    DetailPrint "Failed to create service."
-    Abort
-  ${EndIf}
-  
 
   # Start the service.
   nsExec::ExecToLog 'sc start "Alloy"'

--- a/packaging/windows/install_script.nsis
+++ b/packaging/windows/install_script.nsis
@@ -63,7 +63,7 @@ Section "install"
   ${GetOptions} $PassedInParameters "/STABILITY=" $Stability
   ${GetOptions} $PassedInParameters "/ENVIRONMENT=" $Environment
   ${GetOptions} $PassedInParameters "/CONFIG=" $Config
-  ${GetOptions} $PassedInParameters "/USER=" $User
+  ${GetOptions} $PassedInParameters "/USERNAME=" $User
   ${GetOptions} $PassedInParameters "/PASSWORD=" $Password
 
   # Calls to functions like nsExec::ExecToLog below push the exit code to the

--- a/packaging/windows/install_script.nsis
+++ b/packaging/windows/install_script.nsis
@@ -40,6 +40,9 @@ Var RuntimePriority
 Var RuntimePriorityFlag
 Var Stability
 Var StabilityFlag
+Var User
+Var Password
+Var AuthFlag
 
 # Pages during the installer.
 Page license
@@ -60,6 +63,8 @@ Section "install"
   ${GetOptions} $PassedInParameters "/STABILITY=" $Stability
   ${GetOptions} $PassedInParameters "/ENVIRONMENT=" $Environment
   ${GetOptions} $PassedInParameters "/CONFIG=" $Config
+  ${GetOptions} $PassedInParameters "/USER=" $User
+  ${GetOptions} $PassedInParameters "/PASSWORD=" $Password
 
   # Calls to functions like nsExec::ExecToLog below push the exit code to the
   # stack, and must be popped after calling.
@@ -103,8 +108,15 @@ Section "install"
   Call CreateDataDirectory
   Call InitializeRegistry
 
+  ${If} $User != ""
+    StrCpy $AuthFlag "obj= $\"$User$\""
+    ${If} $Password != ""
+      StrCpy $AuthFlag "$AuthFlag password= $\"$Password$\""
+    ${EndIf}  
+  ${EndIf}
+
   # Create the service.
-  nsExec::ExecToLog 'sc create "Alloy" start= delayed-auto binpath= "\"$INSTDIR\alloy-service-windows-amd64.exe\""'
+  nsExec::ExecToLog 'sc create "Alloy" start= delayed-auto $AuthFlag binpath= "\"$INSTDIR\alloy-service-windows-amd64.exe\""'
   Pop $0
 
   # Start the service.

--- a/packaging/windows/install_script.nsis
+++ b/packaging/windows/install_script.nsis
@@ -118,6 +118,11 @@ Section "install"
   # Create the service.
   nsExec::ExecToLog 'sc create "Alloy" start= delayed-auto $AuthFlag binpath= "\"$INSTDIR\alloy-service-windows-amd64.exe\""'
   Pop $0
+  ${If} $0 <> 0
+    DetailPrint "Failed to create service."
+    Abort
+  ${EndIf}
+  
 
   # Start the service.
   nsExec::ExecToLog 'sc start "Alloy"'
@@ -142,6 +147,10 @@ Function CreateConfig
     AccessControl::SetOnFile    "$INSTDIR\config.alloy" "SYSTEM" "FullAccess"
     AccessControl::GrantOnFile  "$INSTDIR\config.alloy" "Everyone" "ListDirectory"
     AccessControl::GrantOnFile  "$INSTDIR\config.alloy" "Everyone" "ReadAttributes"
+    ${If} $User != ""
+      AccessControl::SetOnFile    "$INSTDIR\config.alloy" "$User" "FullAccess"
+    ${EndIf}
+
     Return
 FunctionEnd
 
@@ -161,6 +170,10 @@ Function CreateDataDirectory
     AccessControl::SetOnFile    "$APPDATA\GrafanaLabs\${APPNAME}\data" "SYSTEM" "FullAccess"
     AccessControl::GrantOnFile  "$APPDATA\GrafanaLabs\${APPNAME}\data" "Everyone" "ListDirectory"
     AccessControl::GrantOnFile  "$APPDATA\GrafanaLabs\${APPNAME}\data" "Everyone" "ReadAttributes"
+    ${If} $User != ""
+      AccessControl::SetOnFile    "$APPDATA\GrafanaLabs\${APPNAME}\data" "$User" "FullAccess"
+    ${EndIf}
+    
     Return
 FunctionEnd
 
@@ -239,6 +252,10 @@ Function SetFolderPermissions
     AccessControl::GrantOnFile  $INSTDIR "Everyone" "GenericExecute"
     AccessControl::GrantOnFile  $INSTDIR "Everyone" "GenericRead"
     AccessControl::GrantOnFile  $INSTDIR "Everyone" "ReadAttributes"
+
+    ${If} $User != ""
+      AccessControl::SetOnFile    $INSTDIR "$User" "FullAccess"
+    ${EndIf}
 FunctionEnd
 
 # Automatically called when uninstalling.


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Adds the ability to set the user (& password) that will run the Windows Service in the silent install.

#### Which issue(s) this PR fixes
Fixes https://github.com/grafana/alloy/issues/3160

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
- [X] Documentation added
