### PR TITLE
feat: http server authentication 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Features
+
+- Add support to configure basic authentication for alloy http server. (@kalleep)
+
 v1.8.0-rc.2
 -----------------
 

--- a/docs/sources/reference/config-blocks/http.md
+++ b/docs/sources/reference/config-blocks/http.md
@@ -208,6 +208,40 @@ The filter block is used to configure which API paths should be protected by aut
 
 | Name                  | Type           | Description                                                                                                            | Default | Required |
 | ----------------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------- | ------- | -------- |
-| `path`                              | `list(string)` | List of API paths to be protected by authentication. The paths are matched using prefix matching.                      | `[]`    | no       |
+| `paths`                             | `list(string)` | List of API paths to be protected by authentication. The paths are matched using prefix matching.                      | `[]`    | no       |
 | `authenticate_matching_paths`       | `bool`         | If true, authentication is required for all matching paths. If false, authentication is excluded for these paths.      | `true`  | no       |
 
+
+Example of enforcing authentication on `/metrics` and every enpoint that has `/v1` as prefix:
+```alloy
+http {
+  auth {
+    basic {
+      username = sys.env("BASIC_AUTH_USERNAME")
+      password = sys.env("BASIC_AUTH_PASSWORD")
+    }
+
+    filter {
+      paths                       = ["/metrics", "/v1"]
+      authenticate_matching_paths = true
+    }
+  }
+}
+```
+
+Example enforcing authentication on all endpoints except `/metrics`:
+```alloy
+http {
+  auth {
+    basic {
+      username = sys.env("BASIC_AUTH_USERNAME")
+      password = sys.env("BASIC_AUTH_PASSWORD")
+    }
+
+    filter {
+      paths                       = ["/metrics"]
+      authenticate_matching_paths = false
+    }
+  }
+}
+```

--- a/docs/sources/reference/config-blocks/http.md
+++ b/docs/sources/reference/config-blocks/http.md
@@ -26,8 +26,8 @@ http {
     }
 
     filter {
-      paths         = ["/"]
-      auth_if_match = true
+      paths                       = ["/"]
+      authenticate_matching_paths = true
     }
   }
 }
@@ -207,7 +207,7 @@ The basic block enables basic HTTP authentication by requiring both a username a
 The filter block is used to configure which API paths should be protected by authentication. It allows you to specify a list of paths, using prefix matching, that will require authentication.
 
 | Name                  | Type           | Description                                                                                                            | Default | Required |
-| --------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------- | ------- | -------- |
-| `path`                | `list(string)` | List of API paths to be protected by authentication. The paths are matched using prefix matching.                      | `[]`    | no       |
-| `auth_if_match`       | `bool`         | If true, authentication is required for all matching paths. If false, authentication is excluded for these paths.      | `true`  | no       |
+| ----------------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------- | ------- | -------- |
+| `path`                              | `list(string)` | List of API paths to be protected by authentication. The paths are matched using prefix matching.                      | `[]`    | no       |
+| `authenticate_matching_paths`       | `bool`         | If true, authentication is required for all matching paths. If false, authentication is excluded for these paths.      | `true`  | no       |
 

--- a/docs/sources/reference/config-blocks/http.md
+++ b/docs/sources/reference/config-blocks/http.md
@@ -18,6 +18,18 @@ http {
     cert_file = sys.env("TLS_CERT_FILE_PATH")
     key_file  = sys.env("TLS_KEY_FILE_PATH")
   }
+
+  http {
+    basic {
+      username = sys.env("BASIC_AUTH_USERNAME")
+      password = sys.env("BASIC_AUTH_PASSWORD")
+    }
+
+    filter {
+      paths         = ["/"]
+      auth_if_match = true
+    }
+  }
 }
 ```
 
@@ -35,6 +47,9 @@ The following blocks are supported inside the definition of `http`:
 | tls > windows_certificate_filter          | [windows_certificate_filter][] | Configure Windows certificate store for all certificates.     | no       |
 | tls > windows_certificate_filter > client | [client][]                     | Configure client certificates for Windows certificate filter. | no       |
 | tls > windows_certificate_filter > server | [server][]                     | Configure server certificates for Windows certificate filter. | no       |
+| auth                                      | [auth][]                       | Configure server authentication.                              | no       |
+| auth > basic                              | [basic][]                      | Configure basic authentication.                               | no       |
+| auth > filter                             | [filter][]                     | Configure authentication filter.                              | no       |
 
 ### tls block
 
@@ -175,3 +190,24 @@ The `client` block is used to check the certificate presented to the server.
 [windows_certificate_filter]: #windows-certificate-filter-block
 [server]: #server-block
 [client]: #client-block
+
+### auth block
+The auth block configures server authentication for the http block. This can be used to enable basic authentication and to set authentication filters for specified API paths.
+
+### basic block
+The basic block enables basic HTTP authentication by requiring both a username and password for access.
+
+| Name                  | Type           | Description                                                       | Default | Required |
+| --------------------- | -------------- | ----------------------------------------------------------------- | ------- | -------- |
+| `username`            | `string`       | The username to use for basic authentication.                     |   N/A   | yes      |
+| `password`            | `string`       | The password to use for basic authentication.                     |   N/A   | yes      |
+
+
+# filter block
+The filter block is used to configure which API paths should be protected by authentication. It allows you to specify a list of paths, using prefix matching, that will require authentication.
+
+| Name                  | Type           | Description                                                                                                            | Default | Required |
+| --------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------- | ------- | -------- |
+| `path`                | `list(string)` | List of API paths to be protected by authentication. The paths are matched using prefix matching.                      | `[]`    | no       |
+| `auth_if_match`       | `bool`         | If true, authentication is required for all matching paths. If false, authentication is excluded for these paths.      | `true`  | no       |
+

--- a/docs/sources/reference/config-blocks/http.md
+++ b/docs/sources/reference/config-blocks/http.md
@@ -203,7 +203,7 @@ The basic block enables basic HTTP authentication by requiring both a username a
 | `password`            | `string`       | The password to use for basic authentication.                     |         | yes      |
 
 
-# filter block
+### filter block
 The filter block is used to configure which API paths should be protected by authentication. It allows you to specify a list of paths, using prefix matching, that will require authentication.
 
 | Name                  | Type           | Description                                                                                                            | Default | Required |

--- a/docs/sources/reference/config-blocks/http.md
+++ b/docs/sources/reference/config-blocks/http.md
@@ -200,7 +200,7 @@ The basic block enables basic HTTP authentication by requiring both a username a
 | Name                  | Type           | Description                                                       | Default | Required |
 | --------------------- | -------------- | ----------------------------------------------------------------- | ------- | -------- |
 | `username`            | `string`       | The username to use for basic authentication.                     |         | yes      |
-| `password`            | `string`       | The password to use for basic authentication.                     |         | yes      |
+| `password`            | `secret`       | The password to use for basic authentication.                     |         | yes      |
 
 
 ### filter block

--- a/docs/sources/reference/config-blocks/http.md
+++ b/docs/sources/reference/config-blocks/http.md
@@ -19,7 +19,7 @@ http {
     key_file  = sys.env("TLS_KEY_FILE_PATH")
   }
 
-  http {
+  auth {
     basic {
       username = sys.env("BASIC_AUTH_USERNAME")
       password = sys.env("BASIC_AUTH_PASSWORD")
@@ -199,8 +199,8 @@ The basic block enables basic HTTP authentication by requiring both a username a
 
 | Name                  | Type           | Description                                                       | Default | Required |
 | --------------------- | -------------- | ----------------------------------------------------------------- | ------- | -------- |
-| `username`            | `string`       | The username to use for basic authentication.                     |   N/A   | yes      |
-| `password`            | `string`       | The password to use for basic authentication.                     |   N/A   | yes      |
+| `username`            | `string`       | The username to use for basic authentication.                     |         | yes      |
+| `password`            | `string`       | The password to use for basic authentication.                     |         | yes      |
 
 
 # filter block

--- a/internal/service/http/auth.go
+++ b/internal/service/http/auth.go
@@ -1,0 +1,51 @@
+package http
+
+import (
+	"crypto/subtle"
+	"errors"
+	"net/http"
+
+	"github.com/grafana/alloy/syntax/alloytypes"
+)
+
+type AuthArguments struct {
+	Basic *BasicAuthArguments `alloy:"basic,block,optional"`
+	// Filter is used to apply authentication to matching api endpoints
+	Filter []string `alloy:"filter,attr,optional"`
+}
+
+type BasicAuthArguments struct {
+	Username string            `alloy:"username,attr"`
+	Password alloytypes.Secret `alloy:"password,attr"`
+}
+
+func (a *AuthArguments) authenticator() authenticator {
+	if a.Basic != nil {
+		return basicAuthenticator(a.Basic.Username, string(a.Basic.Password))
+	}
+	return allowAuthenticator
+}
+
+type authenticator func(w http.ResponseWriter, r *http.Request) error
+
+func allowAuthenticator(w http.ResponseWriter, r *http.Request) error {
+	return nil
+}
+
+func basicAuthenticator(expectedUsername, expectedPassword string) authenticator {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		username, password, ok := r.BasicAuth()
+		if !ok {
+			return errors.New("unauthorized")
+		}
+
+		usernameMatch := subtle.ConstantTimeCompare([]byte(username), []byte(expectedUsername)) == 1
+		passwordMatch := subtle.ConstantTimeCompare([]byte(password), []byte(expectedPassword)) == 1
+
+		if !usernameMatch || !passwordMatch {
+			w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
+			return errors.New("unauthorized")
+		}
+		return nil
+	}
+}

--- a/internal/service/http/auth.go
+++ b/internal/service/http/auth.go
@@ -62,7 +62,7 @@ func basicAuthenticator(username, password string) authenticator {
 	}
 }
 
-// routeAuthenticator will apply provided authenticator if the any of the any filter is a prefix of the path.
+// routeAuthenticator will apply provided authenticator if any filter is a prefix of the path.
 func routeAuthenticator(filter []string, auth authenticator) authenticator {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		for _, f := range filter {

--- a/internal/service/http/auth.go
+++ b/internal/service/http/auth.go
@@ -23,15 +23,15 @@ type BasicAuthArguments struct {
 }
 
 type FilterAuthArguments struct {
-	Paths       []string `alloy:"paths,attr,optional"`
-	AuthIfMatch bool     `alloy:"auth_if_match,attr,optional"`
+	Paths             []string `alloy:"paths,attr,optional"`
+	AuthMatchingPaths bool     `alloy:"authenticate_matching_paths,attr,optional"`
 }
 
 var _ syntax.Defaulter = (*FilterAuthArguments)(nil)
 
 // SetToDefault implements syntax.Defaulter.
 func (f *FilterAuthArguments) SetToDefault() {
-	f.AuthIfMatch = true
+	f.AuthMatchingPaths = true
 }
 
 func (a *AuthArguments) authenticator() authenticator {
@@ -80,9 +80,9 @@ func routeAuthenticator(filter FilterAuthArguments, auth authenticator) authenti
 	return func(w http.ResponseWriter, r *http.Request) error {
 		compare := func(s string) bool { return strings.HasPrefix(r.URL.Path, s) }
 
-		// If AuthIfMatch is true we perform authentication on matching paths
+		// If AuthMatchingPaths is true we perform authentication on matching paths
 		// otherwise we perform authentication on paths that don't match.
-		if filter.AuthIfMatch {
+		if filter.AuthMatchingPaths {
 			if slices.ContainsFunc(filter.Paths, compare) {
 				return auth(w, r)
 			}

--- a/internal/service/http/auth_test.go
+++ b/internal/service/http/auth_test.go
@@ -15,6 +15,7 @@ func Test_basicAuthenticator(t *testing.T) {
 			Username: "username",
 			Password: "password",
 		},
+		Filter: []string{"/v1"},
 	}
 	auth := args.authenticator()
 
@@ -22,31 +23,42 @@ func Test_basicAuthenticator(t *testing.T) {
 		name        string
 		username    string
 		password    string
+		path        string
 		expectError bool
 	}{
 		{
 			name:     "should pass with correct username and password",
 			username: "username",
 			password: "password",
+			path:     "/v1",
 		},
 		{
 			name:        "should fail with invalid username and correct password",
 			username:    "invalid",
 			password:    "password",
+			path:        "/v1",
 			expectError: true,
 		},
 		{
 			name:        "should fail with correct username and invalid password",
 			username:    "username",
 			password:    "invalid",
+			path:        "/v1",
 			expectError: true,
+		},
+		{
+			name:        "should pass with correct username and invalid password when path is not provided in filter",
+			username:    "username",
+			password:    "invalid",
+			path:        "/v2",
+			expectError: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
-			req, err := http.NewRequest(http.MethodGet, "localhost", nil)
+			req, err := http.NewRequest(http.MethodGet, "http://localhost"+tt.path, nil)
 			require.NoError(t, err)
 			req.SetBasicAuth(tt.username, tt.password)
 

--- a/internal/service/http/auth_test.go
+++ b/internal/service/http/auth_test.go
@@ -1,0 +1,63 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_basicAuthenticator(t *testing.T) {
+	args := AuthArguments{
+		Basic: &BasicAuthArguments{
+			Username: "username",
+			Password: "password",
+		},
+	}
+	auth := args.authenticator()
+
+	tests := []struct {
+		name        string
+		username    string
+		password    string
+		expectError bool
+	}{
+		{
+			name:     "should pass with correct username and password",
+			username: "username",
+			password: "password",
+		},
+		{
+			name:        "should fail with invalid username and correct password",
+			username:    "invalid",
+			password:    "password",
+			expectError: true,
+		},
+		{
+			name:        "should fail with correct username and invalid password",
+			username:    "username",
+			password:    "invalid",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := http.NewRequest(http.MethodGet, "localhost", nil)
+			require.NoError(t, err)
+			req.SetBasicAuth(tt.username, tt.password)
+
+			err = auth(w, req)
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Equal(t, w.Header().Get("WWW-Authenticate"), `Basic realm="Restricted"`)
+			} else {
+				assert.NoError(t, err)
+				assert.Empty(t, w.Header().Get("WWW-Authenticate"))
+			}
+		})
+	}
+}

--- a/internal/service/http/auth_test.go
+++ b/internal/service/http/auth_test.go
@@ -16,8 +16,8 @@ func Test_basicAuthenticatorInclude(t *testing.T) {
 			Password: "password",
 		},
 		Filter: FilterAuthArguments{
-			Paths:       []string{"/v1"},
-			AuthIfMatch: true,
+			Paths:             []string{"/v1"},
+			AuthMatchingPaths: true,
 		},
 	}
 
@@ -87,8 +87,8 @@ func Test_basicAuthenticatorExclude(t *testing.T) {
 			Password: "password",
 		},
 		Filter: FilterAuthArguments{
-			Paths:       []string{"/v1/exclude"},
-			AuthIfMatch: false,
+			Paths:             []string{"/v1/exclude"},
+			AuthMatchingPaths: false,
 		},
 	}
 

--- a/internal/service/http/auth_test.go
+++ b/internal/service/http/auth_test.go
@@ -9,47 +9,48 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_basicAuthenticator(t *testing.T) {
+func Test_basicAuthenticatorInclude(t *testing.T) {
 	args := AuthArguments{
 		Basic: &BasicAuthArguments{
 			Username: "username",
 			Password: "password",
 		},
-		Filter: []string{"/v1"},
+		Filter: FilterAuthArguments{
+			Paths:       []string{"/v1"},
+			AuthIfMatch: true,
+		},
 	}
-	auth := args.authenticator()
 
 	tests := []struct {
 		name        string
 		username    string
 		password    string
 		path        string
+		authIfMatch bool
 		expectError bool
 	}{
 		{
-			name:     "should pass with correct username and password",
+			name:     "correct username and password",
 			username: "username",
 			password: "password",
 			path:     "/v1",
 		},
 		{
-			name:        "should fail with invalid username and correct password",
+			name:        "invalid username and correct password",
 			username:    "invalid",
 			password:    "password",
 			path:        "/v1",
 			expectError: true,
 		},
 		{
-			name:        "should fail with correct username and invalid password",
+			name:        "correct username and invalid password",
 			username:    "username",
 			password:    "invalid",
 			path:        "/v1",
 			expectError: true,
 		},
 		{
-			name:        "should pass with correct username and invalid password when path is not provided in filter",
-			username:    "username",
-			password:    "invalid",
+			name:        "path is not provided in filter",
 			path:        "/v2",
 			expectError: false,
 		},
@@ -57,15 +58,91 @@ func Test_basicAuthenticator(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			auth := args.authenticator()
+
 			w := httptest.NewRecorder()
 			req, err := http.NewRequest(http.MethodGet, "http://localhost"+tt.path, nil)
 			require.NoError(t, err)
-			req.SetBasicAuth(tt.username, tt.password)
+
+			if tt.username != "" && tt.password != "" {
+				req.SetBasicAuth(tt.username, tt.password)
+			}
 
 			err = auth(w, req)
 			if tt.expectError {
 				assert.Error(t, err)
-				assert.Equal(t, w.Header().Get("WWW-Authenticate"), `Basic realm="Restricted"`)
+				assert.Equal(t, `Basic realm="Restricted"`, w.Header().Get("WWW-Authenticate"))
+			} else {
+				assert.NoError(t, err)
+				assert.Empty(t, w.Header().Get("WWW-Authenticate"))
+			}
+		})
+	}
+}
+
+func Test_basicAuthenticatorExclude(t *testing.T) {
+	args := AuthArguments{
+		Basic: &BasicAuthArguments{
+			Username: "username",
+			Password: "password",
+		},
+		Filter: FilterAuthArguments{
+			Paths:       []string{"/v1/exclude"},
+			AuthIfMatch: false,
+		},
+	}
+
+	tests := []struct {
+		name        string
+		username    string
+		password    string
+		path        string
+		authIfMatch bool
+		expectError bool
+	}{
+		{
+			name:     "correct username and password",
+			username: "username",
+			password: "password",
+			path:     "/v1",
+		},
+		{
+			name:        "invalid username and correct password",
+			username:    "invalid",
+			password:    "password",
+			path:        "/v1",
+			expectError: true,
+		},
+		{
+			name:        "correct username and invalid password",
+			username:    "username",
+			password:    "invalid",
+			path:        "/v1",
+			expectError: true,
+		},
+		{
+			name:        "when path is excluded",
+			path:        "/v1/exclude",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			auth := args.authenticator()
+
+			w := httptest.NewRecorder()
+			req, err := http.NewRequest(http.MethodGet, "http://localhost"+tt.path, nil)
+			require.NoError(t, err)
+
+			if tt.username != "" && tt.password != "" {
+				req.SetBasicAuth(tt.username, tt.password)
+			}
+
+			err = auth(w, req)
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Equal(t, `Basic realm="Restricted"`, w.Header().Get("WWW-Authenticate"))
 			} else {
 				assert.NoError(t, err)
 				assert.Empty(t, w.Header().Get("WWW-Authenticate"))

--- a/internal/service/http/http.go
+++ b/internal/service/http/http.go
@@ -85,7 +85,7 @@ type Service struct {
 	// Track the raw config for use with the support bundle
 	sources map[string]*ast.File
 
-	authenticatorMut sync.Mutex
+	authenticatorMut sync.RWMutex
 	// authentcator is applied to every request made to http server
 	authenticator authenticator
 
@@ -199,9 +199,9 @@ func (s *Service) Run(ctx context.Context, host service.Host) error {
 	// If none is configured allowAuthenticator is used and no authentication is required.
 	r.Use(func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			s.authenticatorMut.Lock()
+			s.authenticatorMut.RLock()
 			err := s.authenticator(w, r)
-			s.authenticatorMut.Unlock()
+			s.authenticatorMut.RUnlock()
 			if err != nil {
 				level.Info(s.log).Log("msg", "failed to authenticate request", "err", err)
 				w.WriteHeader(http.StatusUnauthorized)

--- a/internal/service/http/http.go
+++ b/internal/service/http/http.go
@@ -195,7 +195,8 @@ func (s *Service) Run(ctx context.Context, host service.Host) error {
 		otelmux.WithTracerProvider(s.tracer),
 	))
 
-	// apply authenticator middleware, if non is configured allowAuthenticator is used and no authentication is required
+	// Apply authenticator middleware.
+	// If none is configured allowAuthenticator is used and no authentication is required.
 	r.Use(func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			s.authenticatorMut.Lock()

--- a/internal/service/http/http.go
+++ b/internal/service/http/http.go
@@ -495,11 +495,13 @@ func (s *Service) Update(newConfig any) error {
 		}
 	}
 
+	s.authenticatorMut.Lock()
 	if newArgs.Auth != nil {
-		s.authenticatorMut.Lock()
 		s.authenticator = newArgs.Auth.authenticator()
-		s.authenticatorMut.Unlock()
+	} else {
+		s.authenticator = allowAuthenticator
 	}
+	s.authenticatorMut.Unlock()
 
 	return nil
 }

--- a/internal/service/http/http.go
+++ b/internal/service/http/http.go
@@ -203,10 +203,11 @@ func (s *Service) Run(ctx context.Context, host service.Host) error {
 			err := s.authenticator(w, r)
 			s.authenticatorMut.RUnlock()
 			if err != nil {
-				level.Info(s.log).Log("msg", "failed to authenticate request", "err", err)
+				level.Info(s.log).Log("msg", "failed to authenticate request", "path", r.URL.Path, "err", err)
 				w.WriteHeader(http.StatusUnauthorized)
 				return
 			}
+
 			h.ServeHTTP(w, r)
 		})
 	})

--- a/internal/service/http/http.go
+++ b/internal/service/http/http.go
@@ -86,7 +86,7 @@ type Service struct {
 	sources map[string]*ast.File
 
 	authenticatorMut sync.RWMutex
-	// authentcator is applied to every request made to http server
+	// authenticator is applied to every request made to http server
 	authenticator authenticator
 
 	// publicLis and tcpLis are used to lazily enable TLS, since TLS is

--- a/internal/service/http/http_test.go
+++ b/internal/service/http/http_test.go
@@ -180,6 +180,110 @@ func Test_Toggle_TLS(t *testing.T) {
 	}
 }
 
+func TestAuth(t *testing.T) {
+	ctx := componenttest.TestContext(t)
+
+	env, err := newTestEnvironment(t)
+	require.NoError(t, err)
+	require.NoError(t, env.ApplyConfig(`
+		auth {
+			basic {
+				username = "username"
+				password = "password"
+			}
+		    filter = ["/"]
+		}
+	`))
+
+	go func() {
+		require.NoError(t, env.Run(ctx))
+	}()
+
+	util.Eventually(t, func(t require.TestingT) {
+		cli, err := config.NewClientFromConfig(config.HTTPClientConfig{}, "test")
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s/-/ready", env.ListenAddr()), nil)
+		require.NoError(t, err)
+
+		resp, err := cli.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+}
+
+func Test_Toggle_Auth(t *testing.T) {
+	ctx := componenttest.TestContext(t)
+
+	env, err := newTestEnvironment(t)
+	require.NoError(t, err)
+
+	go func() {
+		require.NoError(t, env.Run(ctx))
+	}()
+
+	request := func(cfg config.HTTPClientConfig) *http.Response {
+		cli, err := config.NewClientFromConfig(cfg, "test")
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s/-/ready", env.ListenAddr()), nil)
+		require.NoError(t, err)
+
+		resp, err := cli.Do(req)
+		require.NoError(t, err)
+		return resp
+	}
+
+	{
+		// Start without auth.
+		require.NoError(t, env.ApplyConfig(`/* empty */`))
+		util.Eventually(t, func(t require.TestingT) {
+			resp := request(config.HTTPClientConfig{})
+			require.NoError(t, resp.Body.Close())
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+	}
+
+	{
+		// Toggle Auth.
+		require.NoError(t, env.ApplyConfig(`
+			auth {
+				basic {
+					username = "username"
+					password = "password"
+				}
+				filter = ["/"]
+			}
+		`))
+
+		util.Eventually(t, func(t require.TestingT) {
+			resp := request(config.HTTPClientConfig{})
+			require.NoError(t, resp.Body.Close())
+			require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+			resp = request(config.HTTPClientConfig{BasicAuth: &config.BasicAuth{
+				Username: "user",
+				Password: "password",
+			}})
+			require.NoError(t, resp.Body.Close())
+			require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+		})
+	}
+
+	{
+		// Disable Auth.
+		require.NoError(t, env.ApplyConfig(``))
+		util.Eventually(t, func(t require.TestingT) {
+			resp := request(config.HTTPClientConfig{})
+			require.NoError(t, resp.Body.Close())
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+	}
+}
+
 func TestUnhealthy(t *testing.T) {
 	ctx := componenttest.TestContext(t)
 

--- a/internal/service/http/http_test.go
+++ b/internal/service/http/http_test.go
@@ -269,7 +269,6 @@ func Test_Toggle_Auth(t *testing.T) {
 			}})
 			require.NoError(t, resp.Body.Close())
 			require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
-
 		})
 	}
 

--- a/internal/service/http/http_test.go
+++ b/internal/service/http/http_test.go
@@ -191,7 +191,9 @@ func TestAuth(t *testing.T) {
 				username = "username"
 				password = "password"
 			}
-		    filter = ["/"]
+			filter {
+				paths = ["/"]
+			}
 		}
 	`))
 
@@ -254,7 +256,9 @@ func Test_Toggle_Auth(t *testing.T) {
 					username = "username"
 					password = "password"
 				}
-				filter = ["/"]
+				filter {
+					paths = ["/"]
+				}
 			}
 		`))
 

--- a/internal/web/ui/public/index.html
+++ b/internal/web/ui/public/index.html
@@ -15,7 +15,7 @@
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="manifest" crossorigin="use-credentials" href="%PUBLIC_URL%/manifest.json" />
     <title>Grafana Alloy</title>
   </head>
   <body>


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Add support for basic authentication for alloy http server. 

I implement the functionallity suggested in https://github.com/grafana/alloy/issues/637#issuecomment-2602834802.

To configure auth there is a new block under the http block and looks like the following
```
http {
	auth {
		basic {
			username = sys.env("BASIC_AUTH_USERNAME")
			password = sys.env("BASIC_AUTH_PASSWORD")
		}

		filter {
			paths         = []   // Default value
			auth_if_match = true // Default value
		}
	}
}
```

To configure basic authentication both username and password need to be configured. In addition to this we have the filter block. Filter is used to determine what api paths should be protected by authentication using prefix matching. If `auth_if_match` is set to true (default) we will perform authentication on all matching paths. Setting `auth_if_match` to false will reverse it, meaning we will not perform authentication listed paths.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->
Fixes #637

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
