### PR TITLE
Replace the jimmidyson/configreloader in helm with config reloader from prometheus

### DIFF
--- a/operations/helm/charts/alloy/CHANGELOG.md
+++ b/operations/helm/charts/alloy/CHANGELOG.md
@@ -10,9 +10,13 @@ internal API changes are not present.
 Unreleased
 ----------
 
+### Breaking changes
+
+- configReloader.customArgs are likely to break as the prometheus maintained config reloader does not have the same arguments as the previous image (@dehaansa)
+
 ### Enhancements
 
-- Change configreloader from jimmydyson/configmap-reload to prometheys-operator/prometheus-config-reloader (@dehaansa)
+- Change configReloader from jimmydyson/configmap-reload to prometheus-operator/prometheus-config-reloader (@dehaansa)
 - Update to Grafana Alloy v1.7.5. (@kimxogus)
 - Add `checksum/config` pod annotation (@kimxogus)
 

--- a/operations/helm/charts/alloy/CHANGELOG.md
+++ b/operations/helm/charts/alloy/CHANGELOG.md
@@ -12,6 +12,7 @@ Unreleased
 
 ### Enhancements
 
+- Change configreloader from jimmydyson/configmap-reload to prometheys-operator/prometheus-config-reloader (@dehaansa)
 - Update to Grafana Alloy v1.7.5. (@kimxogus)
 - Add `checksum/config` pod annotation (@kimxogus)
 

--- a/operations/helm/charts/alloy/README.md
+++ b/operations/helm/charts/alloy/README.md
@@ -64,7 +64,7 @@ useful if just using the default DaemonSet isn't sufficient.
 | configReloader.image.digest | string | `""` | SHA256 digest of image to use for config reloading (either in format "sha256:XYZ" or "XYZ"). When set, will override `configReloader.image.tag` |
 | configReloader.image.registry | string | `"quay.io"` | Config reloader image registry (defaults to docker.io) |
 | configReloader.image.repository | string | `"prometheus-operator/prometheus-config-reloader"` | Repository to get config reloader image from. |
-| configReloader.image.tag | string | `"v0.66.0"` | Tag of image to use for config reloading. |
+| configReloader.image.tag | string | `"v0.81.0"` | Tag of image to use for config reloading. |
 | configReloader.resources | object | `{"requests":{"cpu":"1m","memory":"5Mi"}}` | Resource requests and limits to apply to the config reloader container. |
 | configReloader.securityContext | object | `{}` | Security context to apply to the Grafana configReloader container. |
 | controller.affinity | object | `{}` | Affinity configuration for pods. |

--- a/operations/helm/charts/alloy/README.md
+++ b/operations/helm/charts/alloy/README.md
@@ -62,9 +62,9 @@ useful if just using the default DaemonSet isn't sufficient.
 | configReloader.customArgs | list | `[]` | Override the args passed to the container. |
 | configReloader.enabled | bool | `true` | Enables automatically reloading when the Alloy config changes. |
 | configReloader.image.digest | string | `""` | SHA256 digest of image to use for config reloading (either in format "sha256:XYZ" or "XYZ"). When set, will override `configReloader.image.tag` |
-| configReloader.image.registry | string | `"ghcr.io"` | Config reloader image registry (defaults to docker.io) |
-| configReloader.image.repository | string | `"jimmidyson/configmap-reload"` | Repository to get config reloader image from. |
-| configReloader.image.tag | string | `"v0.14.0"` | Tag of image to use for config reloading. |
+| configReloader.image.registry | string | `"quay.io"` | Config reloader image registry (defaults to docker.io) |
+| configReloader.image.repository | string | `"prometheus-operator/prometheus-config-reloader"` | Repository to get config reloader image from. |
+| configReloader.image.tag | string | `"v0.66.0"` | Tag of image to use for config reloading. |
 | configReloader.resources | object | `{"requests":{"cpu":"1m","memory":"5Mi"}}` | Resource requests and limits to apply to the config reloader container. |
 | configReloader.securityContext | object | `{}` | Security context to apply to the Grafana configReloader container. |
 | controller.affinity | object | `{}` | Affinity configuration for pods. |

--- a/operations/helm/charts/alloy/templates/containers/_watch.yaml
+++ b/operations/helm/charts/alloy/templates/containers/_watch.yaml
@@ -8,8 +8,8 @@
     {{- toYaml .Values.configReloader.customArgs | nindent 4 }}
   {{- else }}
   args:
-    - --volume-dir=/etc/alloy
-    - --webhook-url=http://localhost:{{ $values.listenPort }}/-/reload
+    - --watched-dir=/etc/alloy
+    - --reload-url=http://localhost:{{ $values.listenPort }}/-/reload
   {{- end }}
   volumeMounts:
     - name: config

--- a/operations/helm/charts/alloy/values.yaml
+++ b/operations/helm/charts/alloy/values.yaml
@@ -168,7 +168,7 @@ configReloader:
     # -- Repository to get config reloader image from.
     repository: prometheus-operator/prometheus-config-reloader
     # -- Tag of image to use for config reloading.
-    tag: v0.66.0
+    tag: v0.81.0
     # -- SHA256 digest of image to use for config reloading (either in format "sha256:XYZ" or "XYZ"). When set, will override `configReloader.image.tag`
     digest: ""
   # -- Override the args passed to the container.

--- a/operations/helm/charts/alloy/values.yaml
+++ b/operations/helm/charts/alloy/values.yaml
@@ -164,11 +164,11 @@ configReloader:
   enabled: true
   image:
     # -- Config reloader image registry (defaults to docker.io)
-    registry: "ghcr.io"
+    registry: "quay.io"
     # -- Repository to get config reloader image from.
-    repository: jimmidyson/configmap-reload
+    repository: prometheus-operator/prometheus-config-reloader
     # -- Tag of image to use for config reloading.
-    tag: v0.14.0
+    tag: v0.66.0
     # -- SHA256 digest of image to use for config reloading (either in format "sha256:XYZ" or "XYZ"). When set, will override `configReloader.image.tag`
     digest: ""
   # -- Override the args passed to the container.

--- a/operations/helm/tests/additional-serviceaccount-label/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/additional-serviceaccount-label/alloy/templates/controllers/daemonset.yaml
@@ -58,10 +58,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/additional-serviceaccount-label/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/additional-serviceaccount-label/alloy/templates/controllers/daemonset.yaml
@@ -58,7 +58,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/clustering/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/clustering/alloy/templates/controllers/statefulset.yaml
@@ -63,7 +63,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/clustering/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/clustering/alloy/templates/controllers/statefulset.yaml
@@ -63,10 +63,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/controller-deployment-pdb-max-unavailable/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/controller-deployment-pdb-max-unavailable/alloy/templates/controllers/deployment.yaml
@@ -59,10 +59,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/controller-deployment-pdb-max-unavailable/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/controller-deployment-pdb-max-unavailable/alloy/templates/controllers/deployment.yaml
@@ -59,7 +59,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/controller-deployment-pdb-min-available/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/controller-deployment-pdb-min-available/alloy/templates/controllers/deployment.yaml
@@ -59,10 +59,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/controller-deployment-pdb-min-available/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/controller-deployment-pdb-min-available/alloy/templates/controllers/deployment.yaml
@@ -59,7 +59,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/controller-statefulset-pdb-max-unavailable/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/controller-statefulset-pdb-max-unavailable/alloy/templates/controllers/statefulset.yaml
@@ -61,7 +61,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/controller-statefulset-pdb-max-unavailable/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/controller-statefulset-pdb-max-unavailable/alloy/templates/controllers/statefulset.yaml
@@ -61,10 +61,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/controller-statefulset-pdb-min-available/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/controller-statefulset-pdb-min-available/alloy/templates/controllers/statefulset.yaml
@@ -61,7 +61,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/controller-statefulset-pdb-min-available/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/controller-statefulset-pdb-min-available/alloy/templates/controllers/statefulset.yaml
@@ -61,10 +61,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/controller-volumes-extra/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/controller-volumes-extra/alloy/templates/controllers/daemonset.yaml
@@ -61,7 +61,7 @@ spec:
               mountPath: /cache
               name: cache-volume
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/controller-volumes-extra/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/controller-volumes-extra/alloy/templates/controllers/daemonset.yaml
@@ -61,10 +61,10 @@ spec:
               mountPath: /cache
               name: cache-volume
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/create-daemonset-hostnetwork/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset-hostnetwork/alloy/templates/controllers/daemonset.yaml
@@ -58,10 +58,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/create-daemonset-hostnetwork/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset-hostnetwork/alloy/templates/controllers/daemonset.yaml
@@ -58,7 +58,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/create-daemonset/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset/alloy/templates/controllers/daemonset.yaml
@@ -58,10 +58,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/create-daemonset/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset/alloy/templates/controllers/daemonset.yaml
@@ -58,7 +58,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/create-deployment-autoscaling/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment-autoscaling/alloy/templates/controllers/deployment.yaml
@@ -61,7 +61,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/create-deployment-autoscaling/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment-autoscaling/alloy/templates/controllers/deployment.yaml
@@ -61,10 +61,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/create-deployment/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment/alloy/templates/controllers/deployment.yaml
@@ -59,10 +59,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/create-deployment/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment/alloy/templates/controllers/deployment.yaml
@@ -59,7 +59,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/create-statefulset-autoscaling/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset-autoscaling/alloy/templates/controllers/statefulset.yaml
@@ -63,7 +63,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/create-statefulset-autoscaling/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset-autoscaling/alloy/templates/controllers/statefulset.yaml
@@ -63,10 +63,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/create-statefulset/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset/alloy/templates/controllers/statefulset.yaml
@@ -61,7 +61,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/create-statefulset/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset/alloy/templates/controllers/statefulset.yaml
@@ -61,10 +61,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/custom-config/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/custom-config/alloy/templates/controllers/daemonset.yaml
@@ -59,10 +59,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/custom-config/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/custom-config/alloy/templates/controllers/daemonset.yaml
@@ -59,7 +59,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/default-values/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/default-values/alloy/templates/controllers/daemonset.yaml
@@ -58,10 +58,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/default-values/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/default-values/alloy/templates/controllers/daemonset.yaml
@@ -58,7 +58,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/enable-servicemonitor-tls/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/enable-servicemonitor-tls/alloy/templates/controllers/daemonset.yaml
@@ -58,10 +58,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/enable-servicemonitor-tls/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/enable-servicemonitor-tls/alloy/templates/controllers/daemonset.yaml
@@ -58,7 +58,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/enable-servicemonitor/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/enable-servicemonitor/alloy/templates/controllers/daemonset.yaml
@@ -58,10 +58,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/enable-servicemonitor/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/enable-servicemonitor/alloy/templates/controllers/daemonset.yaml
@@ -58,7 +58,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/envFrom/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/envFrom/alloy/templates/controllers/daemonset.yaml
@@ -61,7 +61,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/envFrom/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/envFrom/alloy/templates/controllers/daemonset.yaml
@@ -61,10 +61,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/existing-config/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/existing-config/alloy/templates/controllers/daemonset.yaml
@@ -58,10 +58,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/existing-config/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/existing-config/alloy/templates/controllers/daemonset.yaml
@@ -58,7 +58,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/extra-env/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-env/alloy/templates/controllers/daemonset.yaml
@@ -67,10 +67,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/extra-env/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-env/alloy/templates/controllers/daemonset.yaml
@@ -67,7 +67,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/extra-manifests/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-manifests/alloy/templates/controllers/daemonset.yaml
@@ -58,10 +58,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/extra-manifests/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-manifests/alloy/templates/controllers/daemonset.yaml
@@ -58,7 +58,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/extra-ports/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-ports/alloy/templates/controllers/daemonset.yaml
@@ -61,7 +61,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/extra-ports/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-ports/alloy/templates/controllers/daemonset.yaml
@@ -61,10 +61,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/faro-ingress/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/faro-ingress/alloy/templates/controllers/daemonset.yaml
@@ -61,7 +61,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/faro-ingress/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/faro-ingress/alloy/templates/controllers/daemonset.yaml
@@ -61,10 +61,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/global-image-pullsecrets/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/global-image-pullsecrets/alloy/templates/controllers/daemonset.yaml
@@ -63,7 +63,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/global-image-pullsecrets/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/global-image-pullsecrets/alloy/templates/controllers/daemonset.yaml
@@ -63,10 +63,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/global-image-registry/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/global-image-registry/alloy/templates/controllers/daemonset.yaml
@@ -58,7 +58,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/global-image-registry/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/global-image-registry/alloy/templates/controllers/daemonset.yaml
@@ -58,10 +58,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/host-alias/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/host-alias/alloy/templates/controllers/daemonset.yaml
@@ -58,10 +58,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/host-alias/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/host-alias/alloy/templates/controllers/daemonset.yaml
@@ -58,7 +58,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/initcontainers/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/initcontainers/alloy/templates/controllers/daemonset.yaml
@@ -79,7 +79,7 @@ spec:
               mountPath: /etc/geoip
               name: geoip
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/initcontainers/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/initcontainers/alloy/templates/controllers/daemonset.yaml
@@ -79,10 +79,10 @@ spec:
               mountPath: /etc/geoip
               name: geoip
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/lifecycle-hooks/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/lifecycle-hooks/alloy/templates/controllers/deployment.yaml
@@ -66,7 +66,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/lifecycle-hooks/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/lifecycle-hooks/alloy/templates/controllers/deployment.yaml
@@ -66,10 +66,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/livinessprobe/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/livinessprobe/alloy/templates/controllers/daemonset.yaml
@@ -68,7 +68,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/livinessprobe/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/livinessprobe/alloy/templates/controllers/daemonset.yaml
@@ -68,10 +68,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/local-image-pullsecrets/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/local-image-pullsecrets/alloy/templates/controllers/daemonset.yaml
@@ -60,7 +60,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/local-image-pullsecrets/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/local-image-pullsecrets/alloy/templates/controllers/daemonset.yaml
@@ -60,10 +60,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/local-image-registry/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/local-image-registry/alloy/templates/controllers/daemonset.yaml
@@ -58,7 +58,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/local-image-registry/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/local-image-registry/alloy/templates/controllers/daemonset.yaml
@@ -58,10 +58,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/nodeselectors-and-tolerations/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/nodeselectors-and-tolerations/alloy/templates/controllers/daemonset.yaml
@@ -58,10 +58,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/nodeselectors-and-tolerations/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/nodeselectors-and-tolerations/alloy/templates/controllers/daemonset.yaml
@@ -58,7 +58,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/nonroot/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/nonroot/alloy/templates/controllers/daemonset.yaml
@@ -63,7 +63,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/nonroot/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/nonroot/alloy/templates/controllers/daemonset.yaml
@@ -63,10 +63,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/pod_annotations/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/pod_annotations/alloy/templates/controllers/daemonset.yaml
@@ -59,10 +59,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/pod_annotations/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/pod_annotations/alloy/templates/controllers/daemonset.yaml
@@ -59,7 +59,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/sidecars/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/sidecars/alloy/templates/controllers/daemonset.yaml
@@ -61,10 +61,10 @@ spec:
               mountPath: /etc/geoip
               name: geoip
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/sidecars/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/sidecars/alloy/templates/controllers/daemonset.yaml
@@ -61,7 +61,7 @@ spec:
               mountPath: /etc/geoip
               name: geoip
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/termination-grace-period/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/termination-grace-period/alloy/templates/controllers/deployment.yaml
@@ -59,10 +59,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/termination-grace-period/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/termination-grace-period/alloy/templates/controllers/deployment.yaml
@@ -59,7 +59,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/topologyspreadconstraints/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/topologyspreadconstraints/alloy/templates/controllers/deployment.yaml
@@ -59,10 +59,10 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/operations/helm/tests/topologyspreadconstraints/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/topologyspreadconstraints/alloy/templates/controllers/deployment.yaml
@@ -59,7 +59,7 @@ spec:
             - name: config
               mountPath: /etc/alloy
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/operations/helm/tests/with-digests/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/with-digests/alloy/templates/controllers/daemonset.yaml
@@ -60,8 +60,8 @@ spec:
         - name: config-reloader
           image: docker.io/jimmidyson/configmap-reload@sha256:5af9d3041d12a3e63f115125f89b66d2ba981fe82e64302ac370c5496055059c
           args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Inspired by https://github.com/prometheus-community/helm-charts/pull/3602 , replacing the jimmidyson image with one maintained by the prometheus project.

<img width="2047" alt="image" src="https://github.com/user-attachments/assets/d8e895cd-ac88-4423-999d-9505f13b5c2a" />


#### Which issue(s) this PR fixes
Fixes https://github.com/grafana/alloy/issues/1830

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer
Should we pin a SHA instead of a tag?

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
- [X] Documentation added
- [X] Tests updated
