### PR TITLE
azure: Ensure we will always set a top for subscription scope if it is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@ Main (unreleased)
 
 - Allow kafka exporter to attempt to connect even if TLS enabled but cert & key are not specified (@dehaansa)
 
+- Fixed bug where all resources were not being collected from `prometheus.exporter.azure` when using `regions` (@kgeckhart)
+
 ### Other changes
 
 - Upgrading to Prometheus v2.55.1. (@ptodev)

--- a/internal/static/integrations/azure_exporter/config.go
+++ b/internal/static/integrations/azure_exporter/config.go
@@ -213,6 +213,12 @@ func (c *Config) ToScrapeSettings() (*metrics.RequestMetricSettings, error) {
 		settings.MetricTop = to.Ptr[int32](100_000_000)
 		settings.MetricOrderBy = "" // Order is only relevant if top won't return all the results our high value should prevent this
 	}
+
+	// Using regions is at subscription scope which adds a default filter that respects top
+	if len(settings.Regions) > 0 && settings.MetricTop == nil {
+		settings.MetricTop = to.Ptr[int32](100_000_000)
+	}
+
 	return &settings, nil
 }
 

--- a/internal/static/integrations/azure_exporter/config_test.go
+++ b/internal/static/integrations/azure_exporter/config_test.go
@@ -96,6 +96,18 @@ func TestConfig_ToScrapeSettings(t *testing.T) {
 				return settings
 			},
 		},
+		{
+			name: "sets regions and top when using regions with no dimensions",
+			configModifier: func(config azure_exporter.Config) azure_exporter.Config {
+				config.Regions = []string{"uswest", "useast"}
+				return config
+			},
+			toExpectedSettings: func(settings metrics.RequestMetricSettings) metrics.RequestMetricSettings {
+				settings.MetricTop = to.Ptr[int32](100_000_000)
+				settings.Regions = []string{"uswest", "useast"}
+				return settings
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
#### PR Description
Azure's metrics APIs require a [top parameter be used with filters](https://learn.microsoft.com/en-us/rest/api/monitor/metrics/list-at-subscription-scope?view=rest-monitor-2023-10-01&tabs=HTTP#uri-parameters)
![image](https://github.com/user-attachments/assets/c474b276-c411-4aee-8a32-c940ad04c09c)

We were only explicitly setting a filter when dimensions are used. When using the exporter with the `regions` config it uses the subscription scope API which requires a filter that the embedded exporter sets. Since we weren't setting top in this case the default of 10 was always being used causing missing data.

Fixes #2735

#### PR Checklist

- [x] CHANGELOG.md updated
- [x] Tests updated
