### PR TITLE
Use a Go Windows docker image without patch version

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,4 +1,4 @@
-FROM library/golang:1.24.1-windowsservercore-ltsc2022 as builder
+FROM library/golang:1.24-windowsservercore-ltsc2022 as builder
 ARG VERSION
 ARG RELEASE_BUILD=1
 ARG GO_TAGS


### PR DESCRIPTION
It looks like the `golang:1.24.1-windowsservercore-ltsc2022` image got deleted... There's a `golang:1.24.2-windowsservercore-ltsc2022` image now but if images get deleted like this we're better off not specifying patch versions. They probably get deleted due to security vulnerabilities.