### PR TITLE
fix: Fix test context and use helper funtion to cleanup test container

### DIFF
--- a/internal/component/remote/vault/vault_test.go
+++ b/internal/component/remote/vault/vault_test.go
@@ -5,7 +5,6 @@ package vault
 import (
 	"fmt"
 	stdlog "log"
-	"strings"
 	"testing"
 	"time"
 
@@ -191,12 +190,7 @@ func getTestVaultServer(t *testing.T) *vaultapi.Client {
 	})
 	require.NoError(t, err)
 
-	t.Cleanup(func() {
-		terminateErr := container.Terminate(ctx)
-		if !strings.Contains(terminateErr.Error(), "context canceled") { // avoid race condition on test context cancelled
-			require.NoError(t, terminateErr)
-		}
-	})
+	defer testcontainers.TerminateContainer(container)
 
 	ep, err := container.PortEndpoint(ctx, nat.Port("80/tcp"), "http")
 	require.NoError(t, err)

--- a/internal/runtime/componenttest/context.go
+++ b/internal/runtime/componenttest/context.go
@@ -7,7 +7,7 @@ import (
 
 // TestContext returns a context which cancels itself when t finishes.
 func TestContext(t testing.TB) context.Context {
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	return ctx
 }


### PR DESCRIPTION
#### PR Description
In a recent change we change to use `t.Context()` instead of `context.Backgroud()`. The context returned by `t.Context()` is canceled before any cleanup hooks are triggered.

I also changed to use helper function to terminate vault container. This function basically calls terminate with `context.Backgroud()` and ignores some "safe" errors.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
