### PR TITLE
ci: increase test (full) runner size

### DIFF
--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   test_linux:
     name: Test (Full)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     container:
       image: grafana/alloy-build-image:v0.1.17
       volumes:


### PR DESCRIPTION
using 8 core ubuntu latest which should provide 300GB disk instead of 14
