### PR TITLE
test: fix wal backoff timer unit test

### DIFF
--- a/internal/component/common/loki/wal/timer_test.go
+++ b/internal/component/common/loki/wal/timer_test.go
@@ -14,9 +14,9 @@ const (
 func TestBackoffTimer(t *testing.T) {
 	var min = time.Millisecond * 300
 	var max = time.Second
-	timer := newBackoffTimer(min, max)
 
 	start := time.Now()
+	timer := newBackoffTimer(min, max)
 	<-timer.C
 	verifyElapsedTime(t, min, time.Since(start))
 


### PR DESCRIPTION
test had intermittent failure due to current time being grabbed after the timer already started