### PR TITLE
Build Windows container image on GitHub Actions

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -372,44 +372,9 @@ volumes:
     path: /var/run/docker.sock
   name: docker
 ---
-kind: pipeline
-name: Publish Windows alloy container
-platform:
-  arch: amd64
-  os: windows
-  version: "1809"
-steps:
-- commands:
-  - '& "C:/Program Files/git/bin/bash.exe" -c ''mkdir -p $HOME/.docker'''
-  - '& "C:/Program Files/git/bin/bash.exe" -c ''printenv GCR_CREDS > $HOME/.docker/config.json'''
-  - '& "C:/Program Files/git/bin/bash.exe" -c ''docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD'''
-  - '& "C:/Program Files/git/bin/bash.exe" -c ''./tools/ci/docker-containers-windows
-    alloy'''
-  environment:
-    DOCKER_LOGIN:
-      from_secret: docker_login
-    DOCKER_PASSWORD:
-      from_secret: docker_password
-    GCR_CREDS:
-      from_secret: gcr_admin
-  image: grafana/alloy-build-image:v0.1.8-windows
-  name: Build containers
-  volumes:
-  - name: docker
-    path: //./pipe/docker_engine/
-trigger:
-  ref:
-  - refs/tags/v*
-type: docker
-volumes:
-- host:
-    path: //./pipe/docker_engine/
-  name: docker
----
 depends_on:
 - Publish Linux alloy container
 - Publish Linux alloy-boringcrypto container
-- Publish Windows alloy container
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -545,6 +510,6 @@ kind: secret
 name: updater_private_key
 ---
 kind: signature
-hmac: 97f89e50b55b8aae91afb5a7708fe2b37c935ddc48c1a71d66bc0d56953fa68d
+hmac: 89ceb7461db70e853b2d0be511054b745584d503c3fd9b45961c991b47d99727
 
 ...

--- a/.github/workflows/publish-alloy-release.yaml
+++ b/.github/workflows/publish-alloy-release.yaml
@@ -1,0 +1,34 @@
+name: Publish alloy release containers
+# TODO: Reuse the config from publish-alloy-devel.yml
+on:
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish_windows_container:
+    name: Publish Windows alloy container
+    runs-on: windows-2022
+    steps:
+      # This step needs to run before "Checkout code".
+      # That's because it generates a new file.
+      # We don't want this file to end up in the repo directory.
+      # Then "tools/image-tag" would get confused because "git status" no longer reports a clean repo.
+    - name: Login to DockerHub (from vault)
+      uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login-v1.0.1
+
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache: false
+
+    - run: |
+       & "C:/Program Files/git/bin/bash.exe" -c './tools/ci/docker-containers-windows alloy'


### PR DESCRIPTION
We've been building the devel Windows container on GH Actions successfully for the past few weeks. This PR is to build the release container on GH actions too, and to remove the Drone build.

The reason we're doing this now is that the Drone steps are [failing](https://drone.grafana.net/grafana/alloy/7287/3/2) and it's not clear how to fix them easily. 

The reason the Drone steps haven't been migrated yet is that the "Publish release" is still on Drone, and normally it depends on this Windows container step. Migrating the Windows container to GH Actions while "Publish release" is still on Drone means that Drone will do a little extra work to publish a draft GH release even if the container step failed. That's all fine though - the GH release is in draft stage and can be deleted easily.