### PR TITLE
Fix Windows container build issues

### DIFF
--- a/.github/workflows/publish-alloy-devel.yml
+++ b/.github/workflows/publish-alloy-devel.yml
@@ -10,27 +10,9 @@ permissions:
 
 jobs:
   publish_windows_container:
-    name: Publish Windows alloy-devel container
-    runs-on: windows-2022
-    steps:
-      # This step needs to run before "Checkout code".
-      # That's because it generates a new file.
-      # We don't want this file to end up in the repo directory.
-      # Then "tools/image-tag" would get confused because "git status" no longer reports a clean repo.
-    - name: Login to DockerHub (from vault)
-      uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login-v1.0.1
-
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: go.mod
-        cache: false
-
-    - run: |
-       & "C:/Program Files/git/bin/bash.exe" -c './tools/ci/docker-containers-windows alloy-devel'
+    uses: ./.github/workflows/publish-alloy.yaml
+    with:
+      img-name: alloy-devel
 
   publish_linux_container:
     name: Publish Linux alloy-devel container

--- a/.github/workflows/publish-alloy-release.yaml
+++ b/.github/workflows/publish-alloy-release.yaml
@@ -1,34 +1,11 @@
 name: Publish alloy release containers
-# TODO: Reuse the config from publish-alloy-devel.yml
 on:
   push:
     tags:
       - v*
 
-permissions:
-  contents: read
-  id-token: write
-
 jobs:
   publish_windows_container:
-    name: Publish Windows alloy container
-    runs-on: windows-2022
-    steps:
-      # This step needs to run before "Checkout code".
-      # That's because it generates a new file.
-      # We don't want this file to end up in the repo directory.
-      # Then "tools/image-tag" would get confused because "git status" no longer reports a clean repo.
-    - name: Login to DockerHub (from vault)
-      uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login-v1.0.1
-
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: go.mod
-        cache: false
-
-    - run: |
-       & "C:/Program Files/git/bin/bash.exe" -c './tools/ci/docker-containers-windows alloy'
+    uses: ./.github/workflows/publish-alloy.yaml
+    with:
+      img-name: alloy

--- a/.github/workflows/publish-alloy.yaml
+++ b/.github/workflows/publish-alloy.yaml
@@ -1,0 +1,49 @@
+name: Shared container publish workflow
+
+on:
+  workflow_call:
+    inputs:
+      img-name:
+        required: true
+        type: string
+        
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish_windows_container:
+    name: Publish Windows alloy container
+    strategy:
+      matrix:
+        os: [windows-2022, windows-2019]
+    runs-on: ${{ matrix.os }}
+    steps:
+      # This step needs to run before "Checkout code".
+      # That's because it generates a new file.
+      # We don't want this file to end up in the repo directory.
+      # Then "tools/image-tag" would get confused because "git status" no longer reports a clean repo.
+    - name: Login to DockerHub (from vault)
+      uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login-v1.0.1
+
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache: false
+
+    - name: Get Go version from go.mod
+      id: get_go_version
+      # Use only the major and minor versions.
+      # Don't use the patch number, because those docker images sometimes get deleted.
+      run: |
+        $go_version = go mod edit -json | ConvertFrom-Json | select -exp Go
+        $go_version_split = $go_version.ToString().split(".")
+        $go_short_version = $go_version_split[0] + "." + $go_version_split[1]
+        "alloy_go_version=$go_short_version" >> $env:GITHUB_OUTPUT
+  
+    - run: |
+       & "C:/Program Files/git/bin/bash.exe" -c 'WINDOWS_VERSION=${{matrix.os}} ALLOY_GO_VERSION=${{steps.get_go_version.outputs.alloy_go_version}} ./tools/ci/docker-containers-windows ${{ inputs.img-name }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Main (unreleased)
 
 - Update the zap logging adapter used by `otelcol` components to log arrays and objects. (@dehaansa)
 
+- A new `grafana/alloy:vX.Y.Z-windowsservercore-ltsc2022` Docker image is now published on DockerHub. (@ptodev)
+
 v1.8.0-rc.2
 -----------------
 

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,4 +1,8 @@
-FROM library/golang:1.24-windowsservercore-ltsc2022 as builder
+ARG BASE_IMAGE_GO=library/golang:1.24-windowsservercore-ltsc2022
+ARG BASE_IMAGE_WINDOWS=mcr.microsoft.com/windows/nanoserver:ltsc2022
+
+FROM ${BASE_IMAGE_GO} AS builder
+
 ARG VERSION
 ARG RELEASE_BUILD=1
 ARG GO_TAGS
@@ -82,7 +86,7 @@ RUN ""C:\Program Files\git\bin\bash.exe" -c "RELEASE_BUILD=${RELEASE_BUILD} VERS
 RUN ""C:\Program Files\git\bin\bash.exe" -c "go clean -cache -modcache""
 
 # Use the smallest container possible for the final image
-FROM mcr.microsoft.com/windows/nanoserver:1809
+FROM ${BASE_IMAGE_WINDOWS}
 
 COPY --from=builder ["/src/alloy/build/alloy", "C:/Program Files/GrafanaLabs/Alloy/alloy.exe"]
 COPY --from=builder ["/src/alloy/example-config.alloy", "C:/Program Files/GrafanaLabs/Alloy/config.alloy"]

--- a/tools/ci/docker-containers-windows
+++ b/tools/ci/docker-containers-windows
@@ -3,7 +3,7 @@
 # This script builds and pushes windows Docker containers.
 #
 # This script expects to be run from the repo root and has checks for running
-# from a Drone trigger.
+# from a GitHub Actions trigger.
 
 set -euxo pipefail
 
@@ -14,13 +14,38 @@ set -euxo pipefail
 # If the environment variables are unset, the variables below default to an
 # empty string.
 export TARGET_CONTAINER=${1:-}
-export DRONE_TAG=${DRONE_TAG:-}
+
+if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+  export GITHUB_TAG="$GITHUB_REF_NAME"
+else
+  export GITHUB_TAG=""
+fi
+
+WINDOWS_VERSION=${WINDOWS_VERSION:-}
+if [ "$WINDOWS_VERSION" = "windows-2022" ]; then
+  export BASE_IMAGE_GO="library/golang:${ALLOY_GO_VERSION}-windowsservercore-ltsc2022"
+  export BASE_IMAGE_WINDOWS="mcr.microsoft.com/windows/nanoserver:ltsc2022"
+  IMAGE_NAME_SUFFIX="windowsservercore-ltsc2022"
+else
+  export BASE_IMAGE_GO="library/golang:${ALLOY_GO_VERSION}-windowsservercore-1809"
+  export BASE_IMAGE_WINDOWS="mcr.microsoft.com/windows/nanoserver:ltsc2019"
+  # We aren't calling this windows-2019 for backwards compatibility reasons.
+  # Alloy used to always call this nanoserver-1809.
+  IMAGE_NAME_SUFFIX="nanoserver-1809"
+fi
 
 export RELEASE_ALLOY_IMAGE=grafana/alloy
 export DEVEL_ALLOY_IMAGE=grafana/alloy-dev
 
-if [ -n "$DRONE_TAG" ]; then
-  VERSION=$DRONE_TAG
+# TODO: Unit test this script? Test cases:
+# * Input:  ALLOY_GO_VERSION=1.24 GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v1.8.0 ./tools/ci/docker-containers-windows alloy
+#   Output: docker build -t grafana/alloy:v1.8.0-nanoserver-1809 -t grafana/alloy:nanoserver-1809 --build-arg VERSION=v1.8.0 --build-arg RELEASE_BUILD=1 --build-arg BASE_IMAGE_GO=library/golang:1.24-windowsservercore-1809 --build-arg BASE_IMAGE_WINDOWS=mcr.microsoft.com/windows/nanoserver:ltsc2019 -f ./Dockerfile.windows .
+# * Input:  ALLOY_GO_VERSION=1.24 GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v1.7.0-rc.4 ./tools/ci/docker-containers-windows alloy
+#   Output: docker build -t grafana/alloy:v1.7.0-rc.4-nanoserver-1809 -t grafana/alloy:v1.7.0-rc.4-nanoserver-1809 --build-arg VERSION=v1.7.0-rc.4 --build-arg RELEASE_BUILD=1 --build-arg BASE_IMAGE_GO=library/golang:1.24-windowsservercore-1809 --build-arg BASE_IMAGE_WINDOWS=mcr.microsoft.com/windows/nanoserver:ltsc2019 -f ./Dockerfile.windows .
+# * Input:  ALLOY_GO_VERSION=1.24 WINDOWS_VERSION=windows-2022 GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v1.8.0 ./tools/ci/docker-containers-windows alloy
+#   Output: docker build -t grafana/alloy:v1.8.0-windowsservercore-ltsc2022 -t grafana/alloy:windowsservercore-ltsc2022 --build-arg VERSION=v1.8.0 --build-arg RELEASE_BUILD=1 --build-arg BASE_IMAGE_GO=library/golang:1.24-windowsservercore-ltsc2022 --build-arg BASE_IMAGE_WINDOWS=mcr.microsoft.com/windows/nanoserver:ltsc2022 -f ./Dockerfile.windows .
+if [ -n "$GITHUB_TAG" ]; then
+  VERSION=$GITHUB_TAG
 else
   # NOTE(rfratto): Do not use ./tools/image-tag-docker here, which doesn't
   # produce valid semver.
@@ -28,23 +53,23 @@ else
 fi
 
 # DEFAULT_LATEST is the default tag to use for the "latest" tag.
-DEFAULT_LATEST=nanoserver-1809
-CNGCRYPTO_LATEST=nanoserver-1809-cngcrypto
+DEFAULT_LATEST=$IMAGE_NAME_SUFFIX
+CNGCRYPTO_LATEST=$IMAGE_NAME_SUFFIX-cngcrypto
 
 # The VERSION_TAG is the version to use for the Docker tag. It is sanitized to
 # force it to be a valid Docker tag name (primarily by removing the +
 # characters that may have been emitted by ./tools/image-tag).
-VERSION_TAG=${VERSION//+/-}-nanoserver-1809
+VERSION_TAG=${VERSION//+/-}-$IMAGE_NAME_SUFFIX
 
 # We also need to know which "branch tag" to update. Branch tags are used as a
 # secondary tag for Docker containers. The branch tag is "latest" when being
 # tagged from a stable release (i.e., not a release candidate) or when building
 # a dev image.
 #
-# If we're not running from drone, we'll set the branch tag to match the
+# If we're not running from GitHub Actions, we'll set the branch tag to match the
 # version. This effectively acts as a no-op because it will tag the same Docker
 # image twice.
-if [[ -n "$DRONE_TAG" && "$DRONE_TAG" != *"-rc."* ]] || [[ "$TARGET_CONTAINER" == *"-devel"* ]]; then
+if [[ -n "$GITHUB_TAG" && "$GITHUB_TAG" != *"-rc."* ]] || [[ "$TARGET_CONTAINER" == *"-devel"* ]]; then
   BRANCH_TAG=$DEFAULT_LATEST
 else
   BRANCH_TAG=$VERSION_TAG
@@ -57,6 +82,8 @@ case "$TARGET_CONTAINER" in
       -t "$RELEASE_ALLOY_IMAGE:$BRANCH_TAG"  \
       --build-arg VERSION="$VERSION"         \
       --build-arg RELEASE_BUILD=1            \
+      --build-arg BASE_IMAGE_GO="$BASE_IMAGE_GO" \
+      --build-arg BASE_IMAGE_WINDOWS="$BASE_IMAGE_WINDOWS" \
       -f ./Dockerfile.windows                \
       .
 
@@ -74,6 +101,8 @@ case "$TARGET_CONTAINER" in
       -t "$RELEASE_ALLOY_IMAGE:$BRANCH_TAG"  \
       --build-arg VERSION="$VERSION"         \
       --build-arg RELEASE_BUILD=1            \
+      --build-arg BASE_IMAGE_GO="$BASE_IMAGE_GO" \
+      --build-arg BASE_IMAGE_WINDOWS="$BASE_IMAGE_WINDOWS" \
       --build-arg GOEXPERIMENT=cngcrypto     \
       --build-arg GO_TAGS=cngcrypto          \
       -f ./Dockerfile.windows                \
@@ -89,6 +118,8 @@ case "$TARGET_CONTAINER" in
       -t "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"  \
       --build-arg VERSION="$VERSION"       \
       --build-arg RELEASE_BUILD=1          \
+      --build-arg BASE_IMAGE_GO="$BASE_IMAGE_GO" \
+      --build-arg BASE_IMAGE_WINDOWS="$BASE_IMAGE_WINDOWS" \
       -f ./Dockerfile.windows              \
       .
 
@@ -106,6 +137,8 @@ case "$TARGET_CONTAINER" in
       -t "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"  \
       --build-arg VERSION="$VERSION"       \
       --build-arg RELEASE_BUILD=1          \
+      --build-arg BASE_IMAGE_GO="$BASE_IMAGE_GO" \
+      --build-arg BASE_IMAGE_WINDOWS="$BASE_IMAGE_WINDOWS" \
       --build-arg GOEXPERIMENT=cngcrypto   \
       --build-arg GO_TAGS=cngcrypto        \
       -f ./Dockerfile.windows              \


### PR DESCRIPTION
#### PR Description

Fixing a few issues:

* The Windows dockerfile was using a Windows 2022 image when it should have been using 2019. 2022 and 2019 images are not compatible, so this would break users who rely on our current `nanoserver-1809` image.
* Adding a new 2022 image.
* I also added a way for the container GH Actions steps to detect the Go version in the go.mod file, and use the appropriate Go image.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
