### PR TITLE
fix: Use names in otel component IDs

### DIFF
--- a/internal/component/otelcol/auth/auth.go
+++ b/internal/component/otelcol/auth/auth.go
@@ -226,7 +226,7 @@ func (a *Auth) Update(args component.Arguments) error {
 
 	mp := metric.NewMeterProvider(metric.WithReader(promExporter))
 	settings := otelextension.Settings{
-		ID: otelcomponent.NewID(a.factory.Type()),
+		ID: otelcomponent.NewIDWithName(a.factory.Type(), a.opts.ID),
 		TelemetrySettings: otelcomponent.TelemetrySettings{
 			Logger: zapadapter.New(a.opts.Logger),
 
@@ -366,7 +366,7 @@ func (a *Auth) SetupExtension(t ExtensionType, rargs Arguments, settings otelext
 	// auth.basic.creds.LABEL will become auth.basic.creds.LABEL.client or auth.basic.creds.LABEL.server
 	// depending on the type.
 	cTypeStr := NormalizeType(fmt.Sprintf("%s.%s", a.opts.ID, t))
-	eh.ID = otelcomponent.NewID(otelcomponent.MustNewType(cTypeStr))
+	eh.ID = otelcomponent.NewIDWithName(a.factory.Type(), cTypeStr)
 	eh.Extension = otelExtension
 
 	return eh, nil

--- a/internal/component/otelcol/connector/connector.go
+++ b/internal/component/otelcol/connector/connector.go
@@ -165,7 +165,7 @@ func (p *Connector) Update(args component.Arguments) error {
 
 	mp := metric.NewMeterProvider(metric.WithReader(promExporter))
 	settings := otelconnector.Settings{
-		ID: otelcomponent.NewID(p.factory.Type()),
+		ID: otelcomponent.NewIDWithName(p.factory.Type(), p.opts.ID),
 		TelemetrySettings: otelcomponent.TelemetrySettings{
 			Logger: zapadapter.New(p.opts.Logger),
 

--- a/internal/component/otelcol/exporter/exporter.go
+++ b/internal/component/otelcol/exporter/exporter.go
@@ -182,7 +182,7 @@ func (e *Exporter) Update(args component.Arguments) error {
 
 	mp := metric.NewMeterProvider(metricOpts...)
 	settings := otelexporter.Settings{
-		ID: otelcomponent.NewID(e.factory.Type()),
+		ID: otelcomponent.NewIDWithName(e.factory.Type(), e.opts.ID),
 		TelemetrySettings: otelcomponent.TelemetrySettings{
 			Logger: zapadapter.New(e.opts.Logger),
 

--- a/internal/component/otelcol/processor/processor.go
+++ b/internal/component/otelcol/processor/processor.go
@@ -159,7 +159,7 @@ func (p *Processor) Update(args component.Arguments) error {
 
 	mp := metric.NewMeterProvider(metric.WithReader(promExporter))
 	settings := otelprocessor.Settings{
-		ID: otelcomponent.NewID(p.factory.Type()),
+		ID: otelcomponent.NewIDWithName(p.factory.Type(), p.opts.ID),
 		TelemetrySettings: otelcomponent.TelemetrySettings{
 			Logger: zapadapter.New(p.opts.Logger),
 

--- a/internal/component/otelcol/receiver/prometheus/prometheus.go
+++ b/internal/component/otelcol/receiver/prometheus/prometheus.go
@@ -140,7 +140,7 @@ func (c *Component) Update(newConfig component.Arguments) error {
 
 	mp := metricNoop.NewMeterProvider()
 	settings := otelreceiver.Settings{
-		ID: otelcomponent.MustNewID("prometheus"),
+		ID: otelcomponent.NewIDWithName(otelcomponent.MustNewType("prometheus"), c.opts.ID),
 		TelemetrySettings: otelcomponent.TelemetrySettings{
 			Logger: zapadapter.New(c.opts.Logger),
 

--- a/internal/component/otelcol/receiver/receiver.go
+++ b/internal/component/otelcol/receiver/receiver.go
@@ -148,7 +148,7 @@ func (r *Receiver) Update(args component.Arguments) error {
 
 	mp := metric.NewMeterProvider(metricOpts...)
 	settings := otelreceiver.Settings{
-		ID: otelcomponent.NewID(r.factory.Type()),
+		ID: otelcomponent.NewIDWithName(r.factory.Type(), r.opts.ID),
 		TelemetrySettings: otelcomponent.TelemetrySettings{
 			Logger: zapadapter.New(r.opts.Logger),
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
The existing otel component IDs do not use names. When using something like `storage.file` https://github.com/grafana/alloy/pull/3209 the component namespaced file requires a fully unique name per component, and the current IDs do not provide that.

For example, for the following config, the storage.file creates an object named `receiver_filelog_` which would conflict with any other filelog receivers instantiated.

```
otelcol.storage.file "default" {}

otelcol.receiver.filelog "default" {
    storage = otelcol.storage.file.default.handler
    ...
}
```
