### PR TITLE
ui: remove syntax highlighting from component details view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Main (unreleased)
 
 - Add support to configure basic authentication for alloy http server. (@kalleep)
 
+### Enhancements
+
+- Removed syntax highlighting from the component details UI view to improve
+  rendering performance. (@tpaschalis)
+
 v1.8.0-rc.2
 -----------------
 

--- a/internal/web/ui/src/features/component/ComponentBody.tsx
+++ b/internal/web/ui/src/features/component/ComponentBody.tsx
@@ -1,9 +1,7 @@
 import { Fragment } from 'react';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 
 import { alloyStringify } from '../alloy-syntax-js/stringify';
 
-import { style } from './style';
 import Table from './Table';
 import { PartitionedBody } from './types';
 
@@ -20,14 +18,14 @@ const ComponentBody = ({ partition }: ComponentBodyProps) => {
 
   const renderTableData = () => {
     return partition.attrs.map(({ name, value }, index) => {
+      const stringifiedValue = alloyStringify(value);
+
       return (
         <tr key={name}>
           <td className={styles.nameColumn}>{name}</td>
           <td>
             <pre className={styles.pre}>
-              <SyntaxHighlighter language="javascript" style={style}>
-                {alloyStringify(value)}
-              </SyntaxHighlighter>
+              <code>{stringifiedValue}</code>
             </pre>
           </td>
         </tr>


### PR DESCRIPTION
#### PR Description

While the Alloy UI is invaluable for debugging configuration issues, it is oftentimes crashing when loading big pages (like service discovery or relabeling components with thousands of targets).

In the past @rfratto had identified the culprit being syntax highlighting overhead because it dramatically inflates the DOM. This PR removes syntax highlighting from the component details view, resulting in even h 

#### Which issue(s) this PR fixes

No issue filed

#### Notes to the Reviewer

To test, you can port-forward a live running Alloy instance to port :12345 and run `yarn run start` from the `internal/web/ui/` directory.

#### PR Checklist

- [X] CHANGELOG.md updated
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
- [ ] Config converters updated (N/A)
