### PR TITLE
Allow setting trafficDistribution in service spec

### DIFF
--- a/operations/helm/charts/alloy/CHANGELOG.md
+++ b/operations/helm/charts/alloy/CHANGELOG.md
@@ -9,6 +9,9 @@ internal API changes are not present.
 
 Unreleased
 ----------
+### Enhancements
+
+- Allow setting trafficDistribution in the service spec. (@nosammai)
 
 0.12.6 (2025-04-03)
 ----------

--- a/operations/helm/charts/alloy/README.md
+++ b/operations/helm/charts/alloy/README.md
@@ -132,6 +132,7 @@ useful if just using the default DaemonSet isn't sufficient.
 | service.enabled | bool | `true` | Creates a Service for the controller's pods. |
 | service.internalTrafficPolicy | string | `"Cluster"` | Value for internal traffic policy. 'Cluster' or 'Local' |
 | service.nodePort | int | `31128` | NodePort port. Only takes effect when `service.type: NodePort` |
+| service.trafficDistribution | string | `nil` | Value for traffic distribution. Unset or PreferClose |
 | service.type | string | `"ClusterIP"` | Service type |
 | serviceAccount.additionalLabels | object | `{}` | Additional labels to add to the created service account. |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the created service account. |

--- a/operations/helm/charts/alloy/templates/service.yaml
+++ b/operations/helm/charts/alloy/templates/service.yaml
@@ -22,6 +22,9 @@ spec:
   {{- if semverCompare ">=1.26-0" .Capabilities.KubeVersion.Version }}
   internalTrafficPolicy: {{.Values.service.internalTrafficPolicy}}
   {{- end }}
+  {{- if and (semverCompare ">= 1.32-0" .Capabilities.KubeVersion.Version) (.Values.service.trafficDistribution) }}
+  trafficDistribution: {{.Values.service.trafficDistribution}}
+  {{- end }}
   ports:
     - name: http-metrics
       {{- if eq .Values.service.type "NodePort" }}

--- a/operations/helm/charts/alloy/values.yaml
+++ b/operations/helm/charts/alloy/values.yaml
@@ -307,6 +307,8 @@ service:
   clusterIP: ''
   # -- Value for internal traffic policy. 'Cluster' or 'Local'
   internalTrafficPolicy: Cluster
+  # -- Value for traffic distribution. Unset or PreferClose
+  trafficDistribution: null
   annotations: {}
     # cloud.google.com/load-balancer-type: Internal
 


### PR DESCRIPTION
This allows setting [trafficDistribution](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) on the service spec on K8s version >=1.32