### PR TITLE
fix: panic when using minimal url for `prometheus.postgres.exporter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Main (unreleased)
 
 - Add binary version to constants exposed in configuration file syntatx. (@adlots)
 
+### Bugfixes
+
+- Fix panic in `prometheus.exporter.postgres` when using minimal url as data source name. (@kalleep)
+
 ### Other changes
 
 - Update the zap logging adapter used by `otelcol` components to log arrays and objects. (@dehaansa)

--- a/internal/component/prometheus/exporter/postgres/postgres_test.go
+++ b/internal/component/prometheus/exporter/postgres/postgres_test.go
@@ -115,19 +115,3 @@ func TestRiverConfigValidate(t *testing.T) {
 		})
 	}
 }
-
-func TestParsePostgresURL(t *testing.T) {
-	dsn := "postgresql://linus:42secret@localhost:5432/postgres?sslmode=disable"
-	expected := map[string]string{
-		"dbname":   "postgres",
-		"host":     "localhost",
-		"password": "42secret",
-		"port":     "5432",
-		"sslmode":  "disable",
-		"user":     "linus",
-	}
-
-	actual, err := parsePostgresURL(dsn)
-	require.NoError(t, err)
-	require.Equal(t, actual, expected)
-}

--- a/internal/static/integrations/postgres_exporter/postgres_exporter.go
+++ b/internal/static/integrations/postgres_exporter/postgres_exporter.go
@@ -88,7 +88,7 @@ func (c *Config) InstanceKey(_ string) (string, error) {
 }
 
 func parsePostgresURL(url string) (map[string]string, error) {
-	if url == "postgresql://" || url == "postgres://" {
+	if url == "postgres://" {
 		return map[string]string{}, nil
 	}
 

--- a/internal/static/integrations/postgres_exporter/postgres_exporter.go
+++ b/internal/static/integrations/postgres_exporter/postgres_exporter.go
@@ -88,6 +88,10 @@ func (c *Config) InstanceKey(_ string) (string, error) {
 }
 
 func parsePostgresURL(url string) (map[string]string, error) {
+	if url == "postgresql://" || url == "postgres://" {
+		return map[string]string{}, nil
+	}
+
 	raw, err := pq.ParseURL(url)
 	if err != nil {
 		return nil, err
@@ -97,10 +101,10 @@ func parsePostgresURL(url string) (map[string]string, error) {
 
 	unescaper := strings.NewReplacer(`\'`, `'`, `\\`, `\`)
 
-	for _, keypair := range strings.Split(raw, " ") {
+	for keypair := range strings.SplitSeq(raw, " ") {
 		parts := strings.SplitN(keypair, "=", 2)
 		if len(parts) != 2 {
-			panic(fmt.Sprintf("unexpected keypair %s from pq", keypair))
+			return nil, fmt.Errorf("unexpected keypair %s from pq", keypair)
 		}
 
 		key := parts[0]

--- a/internal/static/integrations/postgres_exporter/postgres_exporter.go
+++ b/internal/static/integrations/postgres_exporter/postgres_exporter.go
@@ -88,7 +88,7 @@ func (c *Config) InstanceKey(_ string) (string, error) {
 }
 
 func parsePostgresURL(url string) (map[string]string, error) {
-	if url == "postgres://" {
+	if url == "postgresql://" || url == "postgres://" {
 		return map[string]string{}, nil
 	}
 

--- a/internal/static/integrations/postgres_exporter/postgres_exporter_test.go
+++ b/internal/static/integrations/postgres_exporter/postgres_exporter_test.go
@@ -22,7 +22,6 @@ func Test_ParsePostgresURL(t *testing.T) {
 		actual, err := parsePostgresURL(dsn)
 		require.NoError(t, err)
 		require.Equal(t, actual, expected)
-
 	})
 
 	t.Run("with minimal url", func(t *testing.T) {

--- a/internal/static/integrations/postgres_exporter/postgres_exporter_test.go
+++ b/internal/static/integrations/postgres_exporter/postgres_exporter_test.go
@@ -8,19 +8,30 @@ import (
 )
 
 func Test_ParsePostgresURL(t *testing.T) {
-	dsn := "postgresql://linus:42secret@localhost:5432/postgres?sslmode=disable"
-	expected := map[string]string{
-		"dbname":   "postgres",
-		"host":     "localhost",
-		"password": "42secret",
-		"port":     "5432",
-		"sslmode":  "disable",
-		"user":     "linus",
-	}
+	t.Run("with valid url", func(t *testing.T) {
+		dsn := "postgresql://linus:42secret@localhost:5432/postgres?sslmode=disable"
+		expected := map[string]string{
+			"dbname":   "postgres",
+			"host":     "localhost",
+			"password": "42secret",
+			"port":     "5432",
+			"sslmode":  "disable",
+			"user":     "linus",
+		}
 
-	actual, err := parsePostgresURL(dsn)
-	require.NoError(t, err)
-	require.Equal(t, actual, expected)
+		actual, err := parsePostgresURL(dsn)
+		require.NoError(t, err)
+		require.Equal(t, actual, expected)
+
+	})
+
+	t.Run("with minimal url", func(t *testing.T) {
+		minimal := "postgres://"
+		expected := map[string]string{}
+		actual, err := parsePostgresURL(minimal)
+		require.NoError(t, err)
+		require.Equal(t, actual, expected)
+	})
 }
 
 func Test_getDataSourceNames(t *testing.T) {


### PR DESCRIPTION
#### PR Description
When using minimal postgres url `postgres://` or `postgresql://` we encounter a panic. This function is only used when computing [InstanceKey](https://github.com/grafana/alloy/blob/main/internal/static/integrations/postgres_exporter/postgres_exporter.go#L56) where we add _default_ values for `host` and `post` if they are missing.

When reading the description of `pg.ParseURL` I can see:
```
// A minimal example:
//
//	"postgres://"
//
// This will be blank, causing driver.Open to use all of the defaults

```

So while it should work to connect using something like this the upstream exporter prevent us from doing so
https://github.com/prometheus-community/postgres_exporter/blob/master/cmd/postgres_exporter/util.go#L184.

With this fix we at least won't panic and alloy will start. But it will not be able to connect to a postgres db

#### Which issue(s) this PR fixes

Fixes: https://github.com/grafana/alloy/issues/3181

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
