### PR TITLE
fix:  flaky test Test_Toggle_Auth

### DIFF
--- a/internal/service/http/http_test.go
+++ b/internal/service/http/http_test.go
@@ -226,7 +226,7 @@ func Test_Toggle_Auth(t *testing.T) {
 		require.NoError(t, env.Run(ctx))
 	}()
 
-	request := func(cfg config.HTTPClientConfig) *http.Response {
+	request := func(t require.TestingT, cfg config.HTTPClientConfig) *http.Response {
 		cli, err := config.NewClientFromConfig(cfg, "test")
 		require.NoError(t, err)
 
@@ -242,7 +242,7 @@ func Test_Toggle_Auth(t *testing.T) {
 		// Start without auth.
 		require.NoError(t, env.ApplyConfig(`/* empty */`))
 		util.Eventually(t, func(t require.TestingT) {
-			resp := request(config.HTTPClientConfig{})
+			resp := request(t, config.HTTPClientConfig{})
 			require.NoError(t, resp.Body.Close())
 			require.Equal(t, http.StatusOK, resp.StatusCode)
 		})
@@ -263,11 +263,11 @@ func Test_Toggle_Auth(t *testing.T) {
 		`))
 
 		util.Eventually(t, func(t require.TestingT) {
-			resp := request(config.HTTPClientConfig{})
+			resp := request(t, config.HTTPClientConfig{})
 			require.NoError(t, resp.Body.Close())
 			require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 
-			resp = request(config.HTTPClientConfig{BasicAuth: &config.BasicAuth{
+			resp = request(t, config.HTTPClientConfig{BasicAuth: &config.BasicAuth{
 				Username: "user",
 				Password: "password",
 			}})
@@ -280,7 +280,7 @@ func Test_Toggle_Auth(t *testing.T) {
 		// Disable Auth.
 		require.NoError(t, env.ApplyConfig(``))
 		util.Eventually(t, func(t require.TestingT) {
-			resp := request(config.HTTPClientConfig{})
+			resp := request(t, config.HTTPClientConfig{})
 			require.NoError(t, resp.Body.Close())
 			require.Equal(t, http.StatusOK, resp.StatusCode)
 		})


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
`Test_Toggle_Auth` is flaky and only fails sometimes e.g. https://github.com/grafana/alloy/actions/runs/14316503152/job/40123763918. I also managed to reproduce the flaky behavior locally. 

In this test I added a helper function to make [requests](https://github.com/grafana/alloy/blob/main/internal/service/http/http_test.go#L229) but this captures `*testing.T` and because of that will not trigger retries. Retries are necessary because we start the server in a separate goroutine. So the fix is to pass the wrapped testing struct we get from `util.Eventually`.


#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
