### PR TITLE
fix: Ensure the remoteCfg service doesn't immediately stop if not configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Main (unreleased)
 
 - Fix panic in `prometheus.exporter.postgres` when using minimal url as data source name. (@kalleep)
 
+- Fix issue with `remoteCfg` service stopping immediately and logging noop error if not configured (@dehaansa)
+
 ### Other changes
 
 - Update the zap logging adapter used by `otelcol` components to log arrays and objects. (@dehaansa)

--- a/internal/service/remotecfg/noop.go
+++ b/internal/service/remotecfg/noop.go
@@ -10,17 +10,19 @@ import (
 
 type noopClient struct{}
 
+var errNoopClient = errors.New("noop client")
+
 // GetConfig returns the collector's configuration.
 func (c noopClient) GetConfig(context.Context, *connect.Request[collectorv1.GetConfigRequest]) (*connect.Response[collectorv1.GetConfigResponse], error) {
-	return nil, errors.New("noop client")
+	return nil, errNoopClient
 }
 
 // RegisterCollector checks in the current collector to the API on startup.
 func (c noopClient) RegisterCollector(context.Context, *connect.Request[collectorv1.RegisterCollectorRequest]) (*connect.Response[collectorv1.RegisterCollectorResponse], error) {
-	return nil, errors.New("noop client")
+	return nil, errNoopClient
 }
 
 // UnregisterCollector checks out the current collector to the API on shutdown.
 func (c noopClient) UnregisterCollector(context.Context, *connect.Request[collectorv1.UnregisterCollectorRequest]) (*connect.Response[collectorv1.UnregisterCollectorResponse], error) {
-	return nil, errors.New("noop client")
+	return nil, errNoopClient
 }

--- a/internal/service/remotecfg/remotecfg.go
+++ b/internal/service/remotecfg/remotecfg.go
@@ -282,7 +282,7 @@ func (s *Service) Run(ctx context.Context, host service.Host) error {
 
 	s.fetch()
 	err := s.registerCollector()
-	if err != nil {
+	if err != nil && err != errNoopClient {
 		return err
 	}
 
@@ -302,7 +302,7 @@ func (s *Service) Run(ctx context.Context, host service.Host) error {
 		select {
 		case <-s.ticker.C:
 			err := s.fetchRemote()
-			if err != nil {
+			if err != nil && err != errNoopClient {
 				level.Error(s.opts.Logger).Log("msg", "failed to fetch remote configuration from the API", "err", err)
 			}
 		case <-s.updateTickerChan:


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
After recent linter inspired changes to ensure errors to registerCollector were not silently ignored, a regression was introduced that would cause the `remoteCfg` service to immediately fail if remote configuration was not configured.

This is unlikely to be an issue, but if a customer starts an Alloy instance without remote configuration, adds it and attempts to reload config it would not appropriately start remote configuration without an Alloy instance restart.

```
{"ts":"2025-04-08T14:17:18.765072464Z","level":"error","msg":"node exited with error","node":"remotecfg","err":"noop client"}
```

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
