### PR TITLE
Move changelog that was not appropriately moved during merge conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Main (unreleased)
 
 - Fix panic in `prometheus.exporter.postgres` when using minimal url as data source name. (@kalleep)
 
+- Fix `otelcol.exporter.prometheus` dropping valid exemplars. (@github-vincent-miszczak)
+
 ### Other changes
 
 - Update the zap logging adapter used by `otelcol` components to log arrays and objects. (@dehaansa)
@@ -328,8 +330,6 @@ v1.7.0
 - Fix an issue where Prometheus metric name validation scheme was set by default to UTF-8. It is now set back to the
   previous "legacy" scheme. An experimental flag `--feature.prometheus.metric-validation-scheme` can be used to switch
   it to `utf-8` to experiment with UTF-8 support. (@thampiotr)
-
-- Fix `otelcol.exporter.prometheus` that dropped valid exemplars. (@github-vincent-miszczak)
 
 ### Other changes
 


### PR DESCRIPTION
Changelog for https://github.com/grafana/alloy/pull/2602 was in the release area for 1.7 when it was just merged (post 1.8).