### PR TITLE
fix: Add concurrency safety and change timeout to be more generous in cluster test

### DIFF
--- a/internal/service/cluster/cluster_test.go
+++ b/internal/service/cluster/cluster_test.go
@@ -111,8 +111,8 @@ func TestReadyToAdmitTraffic(t *testing.T) {
 			name:                 "deadline passed",
 			enableClustering:     true,
 			minimumClusterSize:   5,
-			waitTimeout:          10 * time.Millisecond,
-			sleepFor:             15 * time.Millisecond,
+			waitTimeout:          150 * time.Millisecond,
+			sleepFor:             200 * time.Millisecond,
 			peerCount:            1, // less than minimum
 			expectedReady:        true,
 			expectNotifyCallback: true,
@@ -149,13 +149,13 @@ func TestReadyToAdmitTraffic(t *testing.T) {
 			t.Parallel()
 			peers := buildPeers(tt.peerCount)
 
-			notifyChangeCallbackCalled := false
+			notifyChangeCallbackCalled := atomic.NewBool(false)
 			s := newTestService(Options{
 				EnableClustering:       tt.enableClustering,
 				MinimumClusterSize:     tt.minimumClusterSize,
 				MinimumSizeWaitTimeout: tt.waitTimeout,
 			}, peers, func() {
-				notifyChangeCallbackCalled = true
+				notifyChangeCallbackCalled.Store(true)
 			})
 			defer s.alloyCluster.shutdown()
 
@@ -165,7 +165,7 @@ func TestReadyToAdmitTraffic(t *testing.T) {
 
 			s.alloyCluster.updateReadyState()
 			assert.Equal(t, tt.expectedReady, s.alloyCluster.Ready())
-			assert.Equal(t, tt.expectNotifyCallback, notifyChangeCallbackCalled)
+			assert.Equal(t, tt.expectNotifyCallback, notifyChangeCallbackCalled.Load())
 		})
 	}
 }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Cluster test was flaky on OSX, and also had a race condition. Added atomic, made the timer a little more permissive so it doesn't fight the innate lack of precision of go timers as much.

```
2025-04-08T19:48:34.3359500Z ==================
2025-04-08T19:48:34.3359700Z WARNING: DATA RACE
2025-04-08T19:48:34.3360020Z Read at 0x00c001db049f by goroutine 203:
2025-04-08T19:48:34.3360510Z   github.com/grafana/alloy/internal/service/cluster.TestReadyToAdmitTraffic.func1()
2025-04-08T19:48:34.3363580Z       /Users/runner/work/alloy/alloy/internal/service/cluster/cluster_test.go:168 +0x26c
2025-04-08T19:48:34.3363980Z   testing.tRunner()
2025-04-08T19:48:34.3364600Z       /Users/runner/hostedtoolcache/go/1.24.1/arm64/src/testing/testing.go:1792 +0x180
2025-04-08T19:48:34.3365310Z   testing.(*T).Run.gowrap1()
2025-04-08T19:48:34.3365860Z       /Users/runner/hostedtoolcache/go/1.24.1/arm64/src/testing/testing.go:1851 +0x40
2025-04-08T19:48:34.3366170Z 
2025-04-08T19:48:34.3366340Z Previous write at 0x00c001db049f by goroutine 208:
2025-04-08T19:48:34.3366840Z   github.com/grafana/alloy/internal/service/cluster.TestReadyToAdmitTraffic.func1.1()
2025-04-08T19:48:34.3367560Z       /Users/runner/work/alloy/alloy/internal/service/cluster/cluster_test.go:158 +0x2c
2025-04-08T19:48:34.3368180Z   github.com/grafana/alloy/internal/service/cluster.(*alloyCluster).transitionToStateDeadlinePassed()
2025-04-08T19:48:34.3368940Z       /Users/runner/work/alloy/alloy/internal/service/cluster/cluster_readonly.go:239 +0x69c
2025-04-08T19:48:34.3369480Z   github.com/grafana/alloy/internal/service/cluster.newAlloyCluster.func1()
2025-04-08T19:48:34.3370170Z       /Users/runner/work/alloy/alloy/internal/service/cluster/cluster_readonly.go:121 +0x80
2025-04-08T19:48:34.3370430Z 
2025-04-08T19:48:34.3370550Z Goroutine 203 (running) created at:
2025-04-08T19:48:34.3370750Z   testing.(*T).Run()
2025-04-08T19:48:34.3371230Z       /Users/runner/hostedtoolcache/go/1.24.1/arm64/src/testing/testing.go:1851 +0x684
2025-04-08T19:48:34.3371770Z   github.com/grafana/alloy/internal/service/cluster.TestReadyToAdmitTraffic()
2025-04-08T19:48:34.3372430Z       /Users/runner/work/alloy/alloy/internal/service/cluster/cluster_test.go:148 +0x88
2025-04-08T19:48:34.3372750Z   testing.tRunner()
2025-04-08T19:48:34.3373200Z       /Users/runner/hostedtoolcache/go/1.24.1/arm64/src/testing/testing.go:1792 +0x180
2025-04-08T19:48:34.3373520Z   testing.(*T).Run.gowrap1()
2025-04-08T19:48:34.3374030Z       /Users/runner/hostedtoolcache/go/1.24.1/arm64/src/testing/testing.go:1851 +0x40
2025-04-08T19:48:34.3374270Z 
2025-04-08T19:48:34.3374350Z Goroutine 208 (finished) created at:
2025-04-08T19:48:34.3374580Z   time.goFunc()
2025-04-08T19:48:34.3375020Z       /Users/runner/hostedtoolcache/go/1.24.1/arm64/src/time/sleep.go:215 +0x40
2025-04-08T19:48:34.3375330Z ==================
2025-04-08T19:48:34.3375530Z --- FAIL: TestReadyToAdmitTraffic (0.00s)
2025-04-08T19:48:34.3376410Z     --- FAIL: TestReadyToAdmitTraffic/deadline_passed (0.02s)
2025-04-08T19:48:34.3376780Z         cluster_test.go:167: 
2025-04-08T19:48:34.3377600Z             	Error Trace:	/Users/runner/work/alloy/alloy/internal/service/cluster/cluster_test.go:167
2025-04-08T19:48:34.3378110Z             	Error:      	Not equal: 
2025-04-08T19:48:34.3378570Z             	            	expected: true
2025-04-08T19:48:34.3379030Z             	            	actual  : false
2025-04-08T19:48:34.3379690Z             	Test:       	TestReadyToAdmitTraffic/deadline_passed
2025-04-08T19:48:34.3380200Z         testing.go:1490: race detected during execution of test
```
