### PR TITLE
fix: replace sleep with wg.Wait() in faro test

### DIFF
--- a/internal/component/faro/receiver/exporters_test.go
+++ b/internal/component/faro/receiver/exporters_test.go
@@ -327,8 +327,8 @@ func Test_LogsExporter_Export(t *testing.T) {
 			})
 			ctx := componenttest.TestContext(t)
 			require.NoError(t, exp.Export(ctx, tc.payload))
-			// Sleep for 2ms since fake logger process in separate go routine
-			time.Sleep(2 * time.Millisecond)
+
+			lr.wg.Wait() // Wait for the fakelogreceiver goroutine to process
 			require.Len(t, lr.GetEntries(), 1)
 			require.Equal(t, tc.expect, lr.entries[0])
 		})


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Observed a flaky test in [drone](https://drone.grafana.net/grafana/alloy/7397/2/2). There was a 2ms wait, but the other faro test using the same component was not flaky, as it was waiting on a wg that is ready after the log entries process. Copied that test behavior to prevent flake.