### PR TITLE
docs: Update nonroot.md to include how to set the securityContext for the configReloader sidecar

### DIFF
--- a/docs/sources/configure/nonroot.md
+++ b/docs/sources/configure/nonroot.md
@@ -34,9 +34,15 @@ alloy:
   securityContext:
     runAsUser: 473
     runAsGroup: 473
+
+configReloader:
+  securityContext:
+    # this is the UID of the "nobody" user that the configReloader image runs as
+    runAsUser: 65534
+    runAsGroup: 65534
 ```
 
-This configuration makes the {{< param "PRODUCT_NAME" >}} binary run with UID 473 and GID 473 rather than as root.
+This configuration makes the {{< param "PRODUCT_NAME" >}} binary run with UID 473 and GID 473 rather than as root. It also runs the config reloader sidecar as UID 65534 and GID 65534.
 
 ## Is the root user a security risk?
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Adds a small section to the example of running as nonroot to include how to run the config reloader sidecar as nonroot.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->
None that I know of.

#### Notes to the Reviewer

This was something I had to do in order to avoid issues with OPA stopping me from running this helm chart with the config reloader enabled.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [x] Documentation added
