### PR TITLE
fix: Add validation that the right number of messages have processed in relabel test

### DIFF
--- a/internal/component/loki/relabel/relabel_test.go
+++ b/internal/component/loki/relabel/relabel_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/component/common/loki"
@@ -190,8 +192,10 @@ func TestCache(t *testing.T) {
 	require.NoError(t, err)
 	go c.Run(t.Context())
 
+	receivedMessages := atomic.NewInt32(0)
 	go func() {
 		for e := range ch1.Chan() {
+			receivedMessages.Inc()
 			require.Equal(t, "very important log", e.Line)
 		}
 	}()
@@ -220,7 +224,10 @@ func TestCache(t *testing.T) {
 	e.Labels = lsets[2]
 	c.receiver.Chan() <- e
 
-	time.Sleep(100 * time.Millisecond)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		require.Equal(t, int32(3), receivedMessages.Load())
+	}, 250*time.Millisecond, 25*time.Millisecond)
+
 	// Let's look into the cache's structure now!
 	// The cache should have stored each label set by its fingerprint.
 	for i := 0; i < 3; i++ {
@@ -241,6 +248,11 @@ func TestCache(t *testing.T) {
 	// or the underlying stored value.
 	e.Labels = lsets[0]
 	c.receiver.Chan() <- e
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		require.Equal(t, int32(4), receivedMessages.Load())
+	}, 250*time.Millisecond, 25*time.Millisecond)
+
 	require.Equal(t, c.cache.Len(), 3)
 	val, _ := c.cache.Get(lsets[0].Fingerprint())
 	cachedVal := val.([]cacheItem)
@@ -262,7 +274,10 @@ func TestCache(t *testing.T) {
 	e.Labels = ls2
 	c.receiver.Chan() <- e
 
-	time.Sleep(100 * time.Millisecond)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		require.Equal(t, int32(6), receivedMessages.Load())
+	}, 250*time.Millisecond, 25*time.Millisecond)
+
 	// Both of these should be under a single, new cache key which will contain
 	// both entries.
 	require.Equal(t, c.cache.Len(), 4)
@@ -283,13 +298,19 @@ func TestCache(t *testing.T) {
 	e.Labels = lsets[4]
 	c.receiver.Chan() <- e
 
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		require.Equal(t, int32(8), receivedMessages.Load())
+	}, 250*time.Millisecond, 25*time.Millisecond)
+
 	require.Equal(t, c.cache.Len(), 4)
 	wantKeys := []model.Fingerprint{lsets[0].Fingerprint(), ls1.Fingerprint(), lsets[3].Fingerprint(), lsets[4].Fingerprint()}
-	for i, k := range c.cache.Keys() { // Returns the cache keys in LRU order.
+	actualKeys := make([]model.Fingerprint, 0, len(wantKeys))
+	for _, k := range c.cache.Keys() { // Returns the cache keys in LRU order.
 		f, ok := k.(model.Fingerprint)
 		require.True(t, ok)
-		require.Equal(t, f, wantKeys[i])
+		actualKeys = append(actualKeys, f)
 	}
+	require.Equal(t, wantKeys, actualKeys)
 }
 
 func TestEntrySentToTwoRelabelComponents(t *testing.T) {

--- a/internal/component/loki/relabel/relabel_test.go
+++ b/internal/component/loki/relabel/relabel_test.go
@@ -225,7 +225,7 @@ func TestCache(t *testing.T) {
 	c.receiver.Chan() <- e
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		require.Equal(t, int32(3), receivedMessages.Load())
+		require.Equal(t, 3, receivedMessages.Load())
 	}, 250*time.Millisecond, 25*time.Millisecond)
 
 	// Let's look into the cache's structure now!
@@ -250,7 +250,7 @@ func TestCache(t *testing.T) {
 	c.receiver.Chan() <- e
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		require.Equal(t, int32(4), receivedMessages.Load())
+		require.Equal(t, 4, receivedMessages.Load())
 	}, 250*time.Millisecond, 25*time.Millisecond)
 
 	require.Equal(t, c.cache.Len(), 3)
@@ -275,7 +275,7 @@ func TestCache(t *testing.T) {
 	c.receiver.Chan() <- e
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		require.Equal(t, int32(6), receivedMessages.Load())
+		require.Equal(t, 6, receivedMessages.Load())
 	}, 250*time.Millisecond, 25*time.Millisecond)
 
 	// Both of these should be under a single, new cache key which will contain
@@ -299,7 +299,7 @@ func TestCache(t *testing.T) {
 	c.receiver.Chan() <- e
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		require.Equal(t, int32(8), receivedMessages.Load())
+		require.Equal(t, 8, receivedMessages.Load())
 	}, 250*time.Millisecond, 25*time.Millisecond)
 
 	require.Equal(t, c.cache.Len(), 4)


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Added validation to the relabel test that at each point we evaluate the cache we have seen the right number of messages. Also updated the end of the test so similar failures in the future will provide more detail (compare the whole cache content, rather than each key independently, so you can understand if the order is wrong or if the issue is different).

```
--- FAIL: TestCache (0.20s)
    relabel_test.go:291: 
        	Error Trace:	/home/runner/work/alloy/alloy/internal/component/loki/relabel/relabel_test.go:291
        	Error:      	Not equal: 
        	            	expected: 0x73734b052292def9
        	            	actual  : 0x87303522d898b13e
        	Test:       	TestCache
```
        	
