### PR TITLE
ci: update renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,7 @@
   ],
 
   "commitMessageAction": "update",
+  "commitMessageTopic": "{{manager}} dependency {{depName}}",
 
   // Tell dependency dashboard to only require PR creation approval for major versions
   "major": {


### PR DESCRIPTION
Change commit messages generated by renovate to always include package manager