### PR TITLE
fix: Ignore inconsistent metric in foreach validation tests

### DIFF
--- a/internal/runtime/foreach_test.go
+++ b/internal/runtime/foreach_test.go
@@ -157,7 +157,7 @@ func testConfigForEach(t *testing.T, config string, reloadConfig string, update 
 		metricsToCheck := []string{
 			"alloy_component_controller_evaluating",
 			"alloy_component_controller_running_components",
-			"alloy_component_evaluation_queue_size",
+			// "alloy_component_evaluation_queue_size", // TODO - metric value is inconsistent depending on timing
 			"pulse_count",
 		}
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Foreach tests that validate internal telemetry encounter the following flaky failure. Based on conversations in slack, it seems that we can ignore this inconsistency for now for the sake of less flaky tests.

```
--- FAIL: TestForeachMetrics (0.34s)
    --- FAIL: TestForeachMetrics/foreach_2.txtar (0.13s)
        foreach_test.go:165: 
            	Error Trace:	/home/runner/work/alloy/alloy/internal/runtime/foreach_test.go:165
            	            				/home/runner/work/alloy/alloy/internal/runtime/foreach_test.go:59
            	Error:      	Received unexpected error:
            	            	 # HELP alloy_component_controller_evaluating Tracks if the controller is currently in the middle of a graph evaluation
            	            	 # TYPE alloy_component_controller_evaluating gauge
            	            	 alloy_component_controller_evaluating{controller_id="",controller_path="/"} 0
            	            	 alloy_component_controller_evaluating{controller_id="foreach_10_1",controller_path="/foreach.testForeach"} 0
            	            	 # HELP alloy_component_controller_running_components Total number of running components.
            	            	 # TYPE alloy_component_controller_running_components gauge
            	            	 alloy_component_controller_running_components{controller_id="",controller_path="/",health_type="healthy"} 2
            	            	 alloy_component_controller_running_components{controller_id="foreach_10_1",controller_path="/foreach.testForeach",health_type="healthy"} 1
            	            	 # HELP alloy_component_evaluation_queue_size Tracks the number of components waiting to be evaluated in the worker pool
            	            	 # TYPE alloy_component_evaluation_queue_size gauge
            	            	-alloy_component_evaluation_queue_size{controller_id="",controller_path="/"} 0
            	            	+alloy_component_evaluation_queue_size{controller_id="",controller_path="/"} 1
            	            	 alloy_component_evaluation_queue_size{controller_id="foreach_10_1",controller_path="/foreach.testForeach"} 0
            	            	 # HELP pulse_count 
            	            	 # TYPE pulse_count counter
            	            	 pulse_count{component_id="testcomponents.pulse.pt",component_path="/foreach.testForeach/foreach_10_1"} 10
            	            	 
            	Test:       	TestForeachMetrics/foreach_2.txtar
```