### PR TITLE
fix: Alloy configuration of syslog rfc3164 default year behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Main (unreleased)
 
 - Fix `otelcol.exporter.prometheus` dropping valid exemplars. (@github-vincent-miszczak)
 
+- `rfc3164_default_to_current_year` argument was not fully added to `loki.source.syslog` (@dehaansa)
+
 ### Other changes
 
 - Update the zap logging adapter used by `otelcol` components to log arrays and objects. (@dehaansa)

--- a/internal/component/loki/source/syslog/types.go
+++ b/internal/component/loki/source/syslog/types.go
@@ -13,16 +13,17 @@ import (
 
 // ListenerConfig defines a syslog listener.
 type ListenerConfig struct {
-	ListenAddress        string              `alloy:"address,attr"`
-	ListenProtocol       string              `alloy:"protocol,attr,optional"`
-	IdleTimeout          time.Duration       `alloy:"idle_timeout,attr,optional"`
-	LabelStructuredData  bool                `alloy:"label_structured_data,attr,optional"`
-	Labels               map[string]string   `alloy:"labels,attr,optional"`
-	UseIncomingTimestamp bool                `alloy:"use_incoming_timestamp,attr,optional"`
-	UseRFC5424Message    bool                `alloy:"use_rfc5424_message,attr,optional"`
-	MaxMessageLength     int                 `alloy:"max_message_length,attr,optional"`
-	TLSConfig            config.TLSConfig    `alloy:"tls_config,block,optional"`
-	SyslogFormat         config.SysLogFormat `alloy:"syslog_format,attr,optional"`
+	ListenAddress               string              `alloy:"address,attr"`
+	ListenProtocol              string              `alloy:"protocol,attr,optional"`
+	IdleTimeout                 time.Duration       `alloy:"idle_timeout,attr,optional"`
+	LabelStructuredData         bool                `alloy:"label_structured_data,attr,optional"`
+	Labels                      map[string]string   `alloy:"labels,attr,optional"`
+	UseIncomingTimestamp        bool                `alloy:"use_incoming_timestamp,attr,optional"`
+	UseRFC5424Message           bool                `alloy:"use_rfc5424_message,attr,optional"`
+	RFC3164DefaultToCurrentYear bool                `alloy:"rfc3164_default_to_current_year,attr,optional"`
+	MaxMessageLength            int                 `alloy:"max_message_length,attr,optional"`
+	TLSConfig                   config.TLSConfig    `alloy:"tls_config,block,optional"`
+	SyslogFormat                config.SysLogFormat `alloy:"syslog_format,attr,optional"`
 }
 
 // DefaultListenerConfig provides the default arguments for a syslog listener.
@@ -65,16 +66,17 @@ func (sc ListenerConfig) Convert() (*scrapeconfig.SyslogTargetConfig, error) {
 	}
 
 	return &scrapeconfig.SyslogTargetConfig{
-		ListenAddress:        sc.ListenAddress,
-		ListenProtocol:       sc.ListenProtocol,
-		IdleTimeout:          sc.IdleTimeout,
-		LabelStructuredData:  sc.LabelStructuredData,
-		Labels:               lbls,
-		UseIncomingTimestamp: sc.UseIncomingTimestamp,
-		UseRFC5424Message:    sc.UseRFC5424Message,
-		MaxMessageLength:     sc.MaxMessageLength,
-		TLSConfig:            *sc.TLSConfig.Convert(),
-		SyslogFormat:         syslogFormat,
+		ListenAddress:               sc.ListenAddress,
+		ListenProtocol:              sc.ListenProtocol,
+		IdleTimeout:                 sc.IdleTimeout,
+		LabelStructuredData:         sc.LabelStructuredData,
+		Labels:                      lbls,
+		UseIncomingTimestamp:        sc.UseIncomingTimestamp,
+		UseRFC5424Message:           sc.UseRFC5424Message,
+		RFC3164DefaultToCurrentYear: sc.RFC3164DefaultToCurrentYear,
+		MaxMessageLength:            sc.MaxMessageLength,
+		TLSConfig:                   *sc.TLSConfig.Convert(),
+		SyslogFormat:                syslogFormat,
 	}, nil
 }
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
In the previous PR to address https://github.com/grafana/alloy/issues/2287 the configuration was set up for the syslog internals, but not in the user-facing configuration.
