### PR TITLE
fix: no longer register remotecfg metrics in isEnabled

### DIFF
--- a/internal/service/remotecfg/remotecfg.go
+++ b/internal/service/remotecfg/remotecfg.go
@@ -354,10 +354,15 @@ func (s *Service) Update(newConfig any) error {
 	// Update the args as the last step to avoid polluting any comparisons
 	s.args = newArgs
 	err = s.registerCollector()
-	s.mut.Unlock()
 	if err != nil {
+		s.mut.Unlock()
 		return err
 	}
+
+	if s.metrics == nil {
+		s.registerMetrics()
+	}
+	s.mut.Unlock()
 
 	// If we've already called Run, then immediately trigger an API call with
 	// the updated Arguments, and/or fall back to the updated cache location.
@@ -546,11 +551,7 @@ func (s *Service) setLastLoadedCfgHash(h string) {
 func (s *Service) isEnabled() bool {
 	s.mut.RLock()
 	defer s.mut.RUnlock()
-	enabled := s.args.URL != "" && s.asClient != nil
-	if enabled && s.metrics == nil {
-		s.registerMetrics()
-	}
-	return enabled
+	return s.args.URL != "" && s.asClient != nil
 }
 
 func (s *Service) setPollFrequency(t time.Duration) {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
While investigating a issue on v 1.8 we noticed that metrics are registered when [isEnabled](https://github.com/grafana/alloy/blob/main/internal/service/remotecfg/remotecfg.go#L550-L552) is called. This mutate the state of the component while only holding a read lock making possible for race conditions to happen. 

I think it should be fine to register the metrics as the last thing in update with the `s.metrics == nil` check still there while holding a write lock. I think this fulfills the same conditions when metrics should be registered.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
