### PR TITLE
prepare patch v1.8.1 on release branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ v1.8.1
 
 - `rfc3164_default_to_current_year` argument was not fully added to `loki.source.syslog` (@dehaansa)
 
+- Fix issue with `remoteCfg` service stopping immediately and logging noop error if not configured (@dehaansa)
+
 v1.8.0
 -----------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ v1.8.1
 
 - Fix issue with `remoteCfg` service stopping immediately and logging noop error if not configured (@dehaansa)
 
+- Fix potential race condition in `remoteCfg` service metrics registration (@kalleep)
+
 v1.8.0
 -----------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ This document contains a historical list of changes between releases. Only
 changes that impact end-user behavior are listed; changes to documentation or
 internal API changes are not present.
 
+v1.8.1
+-----------------
+
+### Bugfixes
+
+- `rfc3164_default_to_current_year` argument was not fully added to `loki.source.syslog` (@dehaansa)
+
 v1.8.0
 -----------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ v1.8.1
 
 - Fix potential race condition in `remoteCfg` service metrics registration (@kalleep)
 
+- Fix panic in `prometheus.exporter.postgres` when using minimal url as data source name. (@kalleep)
+
 v1.8.0
 -----------------
 

--- a/internal/component/loki/source/syslog/types.go
+++ b/internal/component/loki/source/syslog/types.go
@@ -13,16 +13,17 @@ import (
 
 // ListenerConfig defines a syslog listener.
 type ListenerConfig struct {
-	ListenAddress        string              `alloy:"address,attr"`
-	ListenProtocol       string              `alloy:"protocol,attr,optional"`
-	IdleTimeout          time.Duration       `alloy:"idle_timeout,attr,optional"`
-	LabelStructuredData  bool                `alloy:"label_structured_data,attr,optional"`
-	Labels               map[string]string   `alloy:"labels,attr,optional"`
-	UseIncomingTimestamp bool                `alloy:"use_incoming_timestamp,attr,optional"`
-	UseRFC5424Message    bool                `alloy:"use_rfc5424_message,attr,optional"`
-	MaxMessageLength     int                 `alloy:"max_message_length,attr,optional"`
-	TLSConfig            config.TLSConfig    `alloy:"tls_config,block,optional"`
-	SyslogFormat         config.SysLogFormat `alloy:"syslog_format,attr,optional"`
+	ListenAddress               string              `alloy:"address,attr"`
+	ListenProtocol              string              `alloy:"protocol,attr,optional"`
+	IdleTimeout                 time.Duration       `alloy:"idle_timeout,attr,optional"`
+	LabelStructuredData         bool                `alloy:"label_structured_data,attr,optional"`
+	Labels                      map[string]string   `alloy:"labels,attr,optional"`
+	UseIncomingTimestamp        bool                `alloy:"use_incoming_timestamp,attr,optional"`
+	UseRFC5424Message           bool                `alloy:"use_rfc5424_message,attr,optional"`
+	RFC3164DefaultToCurrentYear bool                `alloy:"rfc3164_default_to_current_year,attr,optional"`
+	MaxMessageLength            int                 `alloy:"max_message_length,attr,optional"`
+	TLSConfig                   config.TLSConfig    `alloy:"tls_config,block,optional"`
+	SyslogFormat                config.SysLogFormat `alloy:"syslog_format,attr,optional"`
 }
 
 // DefaultListenerConfig provides the default arguments for a syslog listener.
@@ -65,16 +66,17 @@ func (sc ListenerConfig) Convert() (*scrapeconfig.SyslogTargetConfig, error) {
 	}
 
 	return &scrapeconfig.SyslogTargetConfig{
-		ListenAddress:        sc.ListenAddress,
-		ListenProtocol:       sc.ListenProtocol,
-		IdleTimeout:          sc.IdleTimeout,
-		LabelStructuredData:  sc.LabelStructuredData,
-		Labels:               lbls,
-		UseIncomingTimestamp: sc.UseIncomingTimestamp,
-		UseRFC5424Message:    sc.UseRFC5424Message,
-		MaxMessageLength:     sc.MaxMessageLength,
-		TLSConfig:            *sc.TLSConfig.Convert(),
-		SyslogFormat:         syslogFormat,
+		ListenAddress:               sc.ListenAddress,
+		ListenProtocol:              sc.ListenProtocol,
+		IdleTimeout:                 sc.IdleTimeout,
+		LabelStructuredData:         sc.LabelStructuredData,
+		Labels:                      lbls,
+		UseIncomingTimestamp:        sc.UseIncomingTimestamp,
+		UseRFC5424Message:           sc.UseRFC5424Message,
+		RFC3164DefaultToCurrentYear: sc.RFC3164DefaultToCurrentYear,
+		MaxMessageLength:            sc.MaxMessageLength,
+		TLSConfig:                   *sc.TLSConfig.Convert(),
+		SyslogFormat:                syslogFormat,
 	}, nil
 }
 

--- a/internal/component/prometheus/exporter/postgres/postgres_test.go
+++ b/internal/component/prometheus/exporter/postgres/postgres_test.go
@@ -115,19 +115,3 @@ func TestRiverConfigValidate(t *testing.T) {
 		})
 	}
 }
-
-func TestParsePostgresURL(t *testing.T) {
-	dsn := "postgresql://linus:42secret@localhost:5432/postgres?sslmode=disable"
-	expected := map[string]string{
-		"dbname":   "postgres",
-		"host":     "localhost",
-		"password": "42secret",
-		"port":     "5432",
-		"sslmode":  "disable",
-		"user":     "linus",
-	}
-
-	actual, err := parsePostgresURL(dsn)
-	require.NoError(t, err)
-	require.Equal(t, actual, expected)
-}

--- a/internal/service/remotecfg/noop.go
+++ b/internal/service/remotecfg/noop.go
@@ -10,17 +10,19 @@ import (
 
 type noopClient struct{}
 
+var errNoopClient = errors.New("noop client")
+
 // GetConfig returns the collector's configuration.
 func (c noopClient) GetConfig(context.Context, *connect.Request[collectorv1.GetConfigRequest]) (*connect.Response[collectorv1.GetConfigResponse], error) {
-	return nil, errors.New("noop client")
+	return nil, errNoopClient
 }
 
 // RegisterCollector checks in the current collector to the API on startup.
 func (c noopClient) RegisterCollector(context.Context, *connect.Request[collectorv1.RegisterCollectorRequest]) (*connect.Response[collectorv1.RegisterCollectorResponse], error) {
-	return nil, errors.New("noop client")
+	return nil, errNoopClient
 }
 
 // UnregisterCollector checks out the current collector to the API on shutdown.
 func (c noopClient) UnregisterCollector(context.Context, *connect.Request[collectorv1.UnregisterCollectorRequest]) (*connect.Response[collectorv1.UnregisterCollectorResponse], error) {
-	return nil, errors.New("noop client")
+	return nil, errNoopClient
 }

--- a/internal/service/remotecfg/remotecfg.go
+++ b/internal/service/remotecfg/remotecfg.go
@@ -354,10 +354,15 @@ func (s *Service) Update(newConfig any) error {
 	// Update the args as the last step to avoid polluting any comparisons
 	s.args = newArgs
 	err = s.registerCollector()
-	s.mut.Unlock()
 	if err != nil {
+		s.mut.Unlock()
 		return err
 	}
+
+	if s.metrics == nil {
+		s.registerMetrics()
+	}
+	s.mut.Unlock()
 
 	// If we've already called Run, then immediately trigger an API call with
 	// the updated Arguments, and/or fall back to the updated cache location.
@@ -546,11 +551,7 @@ func (s *Service) setLastLoadedCfgHash(h string) {
 func (s *Service) isEnabled() bool {
 	s.mut.RLock()
 	defer s.mut.RUnlock()
-	enabled := s.args.URL != "" && s.asClient != nil
-	if enabled && s.metrics == nil {
-		s.registerMetrics()
-	}
-	return enabled
+	return s.args.URL != "" && s.asClient != nil
 }
 
 func (s *Service) setPollFrequency(t time.Duration) {

--- a/internal/service/remotecfg/remotecfg.go
+++ b/internal/service/remotecfg/remotecfg.go
@@ -282,7 +282,7 @@ func (s *Service) Run(ctx context.Context, host service.Host) error {
 
 	s.fetch()
 	err := s.registerCollector()
-	if err != nil {
+	if err != nil && err != errNoopClient {
 		return err
 	}
 
@@ -302,7 +302,7 @@ func (s *Service) Run(ctx context.Context, host service.Host) error {
 		select {
 		case <-s.ticker.C:
 			err := s.fetchRemote()
-			if err != nil {
+			if err != nil && err != errNoopClient {
 				level.Error(s.opts.Logger).Log("msg", "failed to fetch remote configuration from the API", "err", err)
 			}
 		case <-s.updateTickerChan:

--- a/internal/static/integrations/postgres_exporter/postgres_exporter.go
+++ b/internal/static/integrations/postgres_exporter/postgres_exporter.go
@@ -88,6 +88,10 @@ func (c *Config) InstanceKey(_ string) (string, error) {
 }
 
 func parsePostgresURL(url string) (map[string]string, error) {
+	if url == "postgresql://" || url == "postgres://" {
+		return map[string]string{}, nil
+	}
+
 	raw, err := pq.ParseURL(url)
 	if err != nil {
 		return nil, err
@@ -97,10 +101,10 @@ func parsePostgresURL(url string) (map[string]string, error) {
 
 	unescaper := strings.NewReplacer(`\'`, `'`, `\\`, `\`)
 
-	for _, keypair := range strings.Split(raw, " ") {
+	for keypair := range strings.SplitSeq(raw, " ") {
 		parts := strings.SplitN(keypair, "=", 2)
 		if len(parts) != 2 {
-			panic(fmt.Sprintf("unexpected keypair %s from pq", keypair))
+			return nil, fmt.Errorf("unexpected keypair %s from pq", keypair)
 		}
 
 		key := parts[0]

--- a/internal/static/integrations/postgres_exporter/postgres_exporter_test.go
+++ b/internal/static/integrations/postgres_exporter/postgres_exporter_test.go
@@ -8,19 +8,29 @@ import (
 )
 
 func Test_ParsePostgresURL(t *testing.T) {
-	dsn := "postgresql://linus:42secret@localhost:5432/postgres?sslmode=disable"
-	expected := map[string]string{
-		"dbname":   "postgres",
-		"host":     "localhost",
-		"password": "42secret",
-		"port":     "5432",
-		"sslmode":  "disable",
-		"user":     "linus",
-	}
+	t.Run("with valid url", func(t *testing.T) {
+		dsn := "postgresql://linus:42secret@localhost:5432/postgres?sslmode=disable"
+		expected := map[string]string{
+			"dbname":   "postgres",
+			"host":     "localhost",
+			"password": "42secret",
+			"port":     "5432",
+			"sslmode":  "disable",
+			"user":     "linus",
+		}
 
-	actual, err := parsePostgresURL(dsn)
-	require.NoError(t, err)
-	require.Equal(t, actual, expected)
+		actual, err := parsePostgresURL(dsn)
+		require.NoError(t, err)
+		require.Equal(t, actual, expected)
+	})
+
+	t.Run("with minimal url", func(t *testing.T) {
+		minimal := "postgres://"
+		expected := map[string]string{}
+		actual, err := parsePostgresURL(minimal)
+		require.NoError(t, err)
+		require.Equal(t, actual, expected)
+	})
 }
 
 func Test_getDataSourceNames(t *testing.T) {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Includes
* Fix for syslog new rfc3164 year estimation feature https://github.com/grafana/alloy/pull/3271
* remoteCfg node exit (+ panic on reload) when not configured https://github.com/grafana/alloy/pull/3232
* remoteCfg race condition for metrics registration https://github.com/grafana/alloy/pull/3272
