### PR TITLE
database_observability: further improve parsing tables from query text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Main (unreleased)
 
 - (_Experimental_) Various changes to the experimental component `database_observability.mysql`:
   - `schema_table`: add support for index expressions (@cristiangreco)
+  - `query_tables`: improve queries parsing (@cristiangreco)
 
 ### Bugfixes
 

--- a/internal/component/database_observability/mysql/collector/parser/parser_tidb_test.go
+++ b/internal/component/database_observability/mysql/collector/parser/parser_tidb_test.go
@@ -135,6 +135,16 @@ func TestParserTiDB_ExtractTableNames(t *testing.T) {
 			sql:    "CREATE USER 'exporter'@'%' IDENTIFIED BY <secret>",
 			tables: nil,
 		},
+		{
+			name:   "insert with redacted values",
+			sql:    "INSERT INTO some_table(id, url) VALUES (...)",
+			tables: []string{"some_table"},
+		},
+		{
+			name:   "trim function (sql mode ignore case)",
+			sql:    "SELECT TRIM (TRAILING '/' FROM url)",
+			tables: nil,
+		},
 	}
 
 	for _, tc := range testcases {

--- a/internal/component/database_observability/mysql/collector/query_tables.go
+++ b/internal/component/database_observability/mysql/collector/query_tables.go
@@ -15,7 +15,6 @@ import (
 )
 
 const (
-	OP_QUERY_TABLES            = "query_tables"
 	OP_QUERY_PARSED_TABLE_NAME = "query_parsed_table_name"
 	QueryTablesName            = "query_tables"
 )
@@ -23,10 +22,9 @@ const (
 const selectQueryTablesSamples = `
 	SELECT
 		digest,
+		digest_text,
 		schema_name,
-		query_sample_text,
-		query_sample_seen,
-		query_sample_timer_wait
+		query_sample_text
 	FROM performance_schema.events_statements_summary_by_digest
 	WHERE schema_name NOT IN ('mysql', 'performance_schema', 'information_schema')
 	AND last_seen > DATE_SUB(NOW(), INTERVAL 1 DAY)`
@@ -128,39 +126,30 @@ func (c *QueryTables) fetchQueryTables(ctx context.Context) error {
 	defer rs.Close()
 
 	for rs.Next() {
-		var digest, schemaName, sampleText, sampleSeen, sampleTimerWait string
-		err := rs.Scan(&digest, &schemaName, &sampleText, &sampleSeen, &sampleTimerWait)
+		var digest, digestText, schemaName, sampleText string
+		err := rs.Scan(&digest, &digestText, &schemaName, &sampleText)
 		if err != nil {
 			level.Error(c.logger).Log("msg", "failed to scan result set from summary table samples", "schema", schemaName, "err", err)
 			continue
 		}
 
-		sampleText, err = c.sqlParser.CleanTruncatedText(sampleText)
+		sqlText, err := c.sqlParser.CleanTruncatedText(sampleText)
 		if err != nil {
-			level.Error(c.logger).Log("msg", "failed to handle truncated sql query", "schema", schemaName, "digest", digest, "err", err)
-			continue
+			level.Warn(c.logger).Log("msg", "failed to handle truncated sample_text", "schema", schemaName, "digest", digest, "err", err)
+
+			// try to switch to digest_text
+			sqlText, err = c.sqlParser.CleanTruncatedText(digestText)
+			if err != nil {
+				level.Warn(c.logger).Log("msg", "failed to handle truncated digest_text", "schema", schemaName, "digest", digest, "err", err)
+				continue
+			}
 		}
 
-		stmt, err := c.sqlParser.Parse(sampleText)
+		stmt, err := c.sqlParser.Parse(sqlText)
 		if err != nil {
-			level.Error(c.logger).Log("msg", "failed to parse sql query", "schema", schemaName, "digest", digest, "err", err)
+			level.Warn(c.logger).Log("msg", "failed to parse sql query", "schema", schemaName, "digest", digest, "err", err)
 			continue
 		}
-
-		sampleRedactedText, err := c.sqlParser.Redact(sampleText)
-		if err != nil {
-			level.Error(c.logger).Log("msg", "failed to redact sql query", "schema", schemaName, "digest", digest, "err", err)
-			continue
-		}
-
-		c.entryHandler.Chan() <- buildLokiEntry(
-			OP_QUERY_TABLES,
-			c.instanceKey,
-			fmt.Sprintf(
-				`schema="%s" digest="%s" query_type="%s" query_sample_seen="%s" query_sample_timer_wait="%s" query_sample_redacted="%s"`,
-				schemaName, digest, c.sqlParser.StmtType(stmt), sampleSeen, sampleTimerWait, sampleRedactedText,
-			),
-		)
 
 		tables := c.sqlParser.ExtractTableNames(c.logger, digest, stmt)
 		for _, table := range tables {

--- a/internal/component/database_observability/mysql/collector/query_tables_test.go
+++ b/internal/component/database_observability/mysql/collector/query_tables_test.go
@@ -30,17 +30,14 @@ func TestQueryTables(t *testing.T) {
 			name: "select query",
 			rows: [][]driver.Value{{
 				"abc123",
+				"SELECT * FROM `some_table` WHERE `id` = ?",
 				"some_schema",
 				"select * from some_table where id = 1",
-				"2024-01-01T00:00:00.000Z",
-				"1000",
 			}},
 			logsLabels: []model.LabelSet{
-				{"job": database_observability.JobName, "op": OP_QUERY_TABLES, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 			},
 			logsLines: []string{
-				`schema="some_schema" digest="abc123" query_type="select" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="select * from some_table where id = :redacted1"`,
 				`schema="some_schema" digest="abc123" table="some_table"`,
 			},
 		},
@@ -48,17 +45,14 @@ func TestQueryTables(t *testing.T) {
 			name: "insert query",
 			rows: [][]driver.Value{{
 				"abc123",
+				"INSERT INTO `some_table` (`id`, `name`) VALUES (...)",
 				"some_schema",
 				"insert into some_table (`id`, `name`) values (1, 'foo')",
-				"2024-01-01T00:00:00.000Z",
-				"1000",
 			}},
 			logsLabels: []model.LabelSet{
-				{"job": database_observability.JobName, "op": OP_QUERY_TABLES, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 			},
 			logsLines: []string{
-				`schema="some_schema" digest="abc123" query_type="insert" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="insert into some_table(id, name) values (:redacted1, :redacted2)"`,
 				`schema="some_schema" digest="abc123" table="some_table"`,
 			},
 		},
@@ -66,17 +60,14 @@ func TestQueryTables(t *testing.T) {
 			name: "update query",
 			rows: [][]driver.Value{{
 				"abc123",
+				"UPDATE `some_table` SET `active` = false, `reason` = ? WHERE `id` = ? AND `name` = ?",
 				"some_schema",
-				"update some_table set active=false, reason=null where id = 1 and  name = 'foo'",
-				"2024-01-01T00:00:00.000Z",
-				"1000",
+				"update some_table set active=false, reason=null where id = 1 and name = 'foo'",
 			}},
 			logsLabels: []model.LabelSet{
-				{"job": database_observability.JobName, "op": OP_QUERY_TABLES, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 			},
 			logsLines: []string{
-				`schema="some_schema" digest="abc123" query_type="update" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="update some_table set active = false, reason = null where id = :redacted1 and name = :redacted2"`,
 				`schema="some_schema" digest="abc123" table="some_table"`,
 			},
 		},
@@ -84,17 +75,14 @@ func TestQueryTables(t *testing.T) {
 			name: "delete query",
 			rows: [][]driver.Value{{
 				"abc123",
+				"DELETE FROM `some_table` WHERE `id` = ?",
 				"some_schema",
 				"delete from some_table where id = 1",
-				"2024-01-01T00:00:00.000Z",
-				"1000",
 			}},
 			logsLabels: []model.LabelSet{
-				{"job": database_observability.JobName, "op": OP_QUERY_TABLES, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 			},
 			logsLines: []string{
-				`schema="some_schema" digest="abc123" query_type="delete" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="delete from some_table where id = :redacted1"`,
 				`schema="some_schema" digest="abc123" table="some_table"`,
 			},
 		},
@@ -102,18 +90,15 @@ func TestQueryTables(t *testing.T) {
 			name: "join two tables",
 			rows: [][]driver.Value{{
 				"abc123",
+				"SELECT `t`.`id`, `t`.`val1`, `o`.`val2` FROM `some_table` `t` INNER JOIN `other_table` AS `o` ON `t`.`id` = `o`.`id` WHERE `o`.`val2` = ? ORDER BY `t`.`val1` DESC",
 				"some_schema",
 				"select t.id, t.val1, o.val2 FROM some_table t inner join other_table as o on t.id = o.id where o.val2 = 1 order by t.val1 desc",
-				"2024-01-01T00:00:00.000Z",
-				"1000",
 			}},
 			logsLabels: []model.LabelSet{
-				{"job": database_observability.JobName, "op": OP_QUERY_TABLES, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 			},
 			logsLines: []string{
-				`schema="some_schema" digest="abc123" query_type="select" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="select t.id, t.val1, o.val2 from some_table as t join other_table as o on t.id = o.id where o.val2 = :redacted1 order by t.val1 desc"`,
 				`schema="some_schema" digest="abc123" table="some_table"`,
 				`schema="some_schema" digest="abc123" table="other_table"`,
 			},
@@ -122,41 +107,34 @@ func TestQueryTables(t *testing.T) {
 			name: "truncated query",
 			rows: [][]driver.Value{{
 				"xyz456",
+				"INSERT INTO `some_table`...",
 				"some_schema",
 				"insert into some_table (`id1`, `id2`, `id3`, `id...",
-				"2024-02-02T00:00:00.000Z",
-				"2000",
 			}, {
 				"abc123",
+				"SELECT * FROM `another_table` WHERE `id` = ?",
 				"some_schema",
-				"select * from some_table where id = 1",
-				"2024-01-01T00:00:00.000Z",
-				"1000",
+				"select * from another_table where id = 1",
 			}},
 			logsLabels: []model.LabelSet{
-				{"job": database_observability.JobName, "op": OP_QUERY_TABLES, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 			},
 			logsLines: []string{
-				`schema="some_schema" digest="abc123" query_type="select" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="select * from some_table where id = :redacted1"`,
-				`schema="some_schema" digest="abc123" table="some_table"`,
+				`schema="some_schema" digest="abc123" table="another_table"`,
 			},
 		},
 		{
 			name: "truncated in multi-line comment",
 			rows: [][]driver.Value{{
 				"abc123",
+				"SELECT * FROM `some_table` WHERE `id` = ?",
 				"some_schema",
 				"select * from some_table where id = 1 /*traceparent='00-abc...",
-				"2024-01-01T00:00:00.000Z",
-				"1000",
 			}},
 			logsLabels: []model.LabelSet{
-				{"job": database_observability.JobName, "op": OP_QUERY_TABLES, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 			},
 			logsLines: []string{
-				`schema="some_schema" digest="abc123" query_type="select" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="select * from some_table where id = :redacted1"`,
 				`schema="some_schema" digest="abc123" table="some_table"`,
 			},
 		},
@@ -164,10 +142,9 @@ func TestQueryTables(t *testing.T) {
 			name: "truncated with properly closed comment",
 			rows: [][]driver.Value{{
 				"abc123",
+				"SELECT * FROM `some_table` WHERE `id` = ? AND `name` =",
 				"some_schema",
 				"select * from some_table where id = 1 /* comment that's closed */ and name = 'test...",
-				"2024-01-01T00:00:00.000Z",
-				"1000",
 			}},
 			logsLabels: []model.LabelSet{},
 			logsLines:  []string{},
@@ -176,39 +153,30 @@ func TestQueryTables(t *testing.T) {
 			name: "start transaction",
 			rows: [][]driver.Value{{
 				"abc123",
+				"START TRANSACTION",
 				"some_schema",
 				"START TRANSACTION",
-				"2024-01-01T00:00:00.000Z",
-				"1000",
 			}},
-			logsLabels: []model.LabelSet{
-				{"job": database_observability.JobName, "op": OP_QUERY_TABLES, "instance": "mysql-db"},
-			},
-			logsLines: []string{
-				`schema="some_schema" digest="abc123" query_type="" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="begin"`,
-			},
+			logsLabels: []model.LabelSet{},
+			logsLines:  []string{},
 		},
 		{
 			name: "sql parse error",
 			rows: [][]driver.Value{{
 				"xyz456",
+				"not valid sql",
 				"some_schema",
 				"not valid sql",
-				"2024-02-02T00:00:00.000Z",
-				"2000",
 			}, {
 				"abc123",
+				"SELECT * FROM `some_table` WHERE `id` = ?",
 				"some_schema",
 				"select * from some_table where id = 1",
-				"2024-01-01T00:00:00.000Z",
-				"1000",
 			}},
 			logsLabels: []model.LabelSet{
-				{"job": database_observability.JobName, "op": OP_QUERY_TABLES, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 			},
 			logsLines: []string{
-				`schema="some_schema" digest="abc123" query_type="select" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="select * from some_table where id = :redacted1"`,
 				`schema="some_schema" digest="abc123" table="some_table"`,
 			},
 		},
@@ -216,27 +184,21 @@ func TestQueryTables(t *testing.T) {
 			name: "multiple schemas",
 			rows: [][]driver.Value{{
 				"abc123",
+				"SELECT * FROM `some_table` WHERE `id` = ?",
 				"some_schema",
 				"select * from some_table where id = 1",
-				"2024-01-01T00:00:00.000Z",
-				"1000",
 			}, {
 				"abc123",
+				"SELECT * FROM `some_table` WHERE `id` = ?",
 				"other_schema",
 				"select * from some_table where id = 1",
-				"2024-01-01T00:00:00.000Z",
-				"1000",
 			}},
 			logsLabels: []model.LabelSet{
-				{"job": database_observability.JobName, "op": OP_QUERY_TABLES, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
-				{"job": database_observability.JobName, "op": OP_QUERY_TABLES, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 			},
 			logsLines: []string{
-				`schema="some_schema" digest="abc123" query_type="select" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="select * from some_table where id = :redacted1"`,
 				`schema="some_schema" digest="abc123" table="some_table"`,
-				`schema="other_schema" digest="abc123" query_type="select" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="select * from some_table where id = :redacted1"`,
 				`schema="other_schema" digest="abc123" table="some_table"`,
 			},
 		},
@@ -244,19 +206,16 @@ func TestQueryTables(t *testing.T) {
 			name: "subquery and union",
 			rows: [][]driver.Value{{
 				"abc123",
+				"SELECT * FROM (SELECT `id`, `name` FROM `employees_us_east` UNION SELECT `id`, `name` FROM `employees_us_west`) AS `employees_us` UNION SELECT `id`, `name` FROM `employees_emea`",
 				"some_schema",
 				"SELECT * FROM (SELECT id, name FROM employees_us_east UNION SELECT id, name FROM employees_us_west) as employees_us UNION SELECT id, name FROM employees_emea",
-				"2024-01-01T00:00:00.000Z",
-				"1000",
 			}},
 			logsLabels: []model.LabelSet{
-				{"job": database_observability.JobName, "op": OP_QUERY_TABLES, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 			},
 			logsLines: []string{
-				`schema="some_schema" digest="abc123" query_type="select" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="select * from (select id, name from employees_us_east union select id, name from employees_us_west) as employees_us union select id, name from employees_emea"`,
 				`schema="some_schema" digest="abc123" table="employees_us_east"`,
 				`schema="some_schema" digest="abc123" table="employees_us_west"`,
 				`schema="some_schema" digest="abc123" table="employees_emea"`,
@@ -266,32 +225,37 @@ func TestQueryTables(t *testing.T) {
 			name: "show create table (table name is not parsed)",
 			rows: [][]driver.Value{{
 				"abc123",
+				"SHOW CREATE TABLE `some_table`",
 				"some_schema",
 				"SHOW CREATE TABLE some_table",
-				"2024-01-01T00:00:00.000Z",
-				"1000",
 			}},
-			logsLabels: []model.LabelSet{
-				{"job": database_observability.JobName, "op": OP_QUERY_TABLES, "instance": "mysql-db"},
-			},
-			logsLines: []string{
-				`schema="some_schema" digest="abc123" query_type="" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="show create table"`,
-			},
+			logsLabels: []model.LabelSet{},
+			logsLines:  []string{},
 		},
 		{
 			name: "show variables",
 			rows: [][]driver.Value{{
 				"abc123",
+				"SHOW VARIABLES LIKE ?",
 				"some_schema",
 				"SHOW VARIABLES LIKE 'version'",
-				"2024-01-01T00:00:00.000Z",
-				"1000",
+			}},
+			logsLabels: []model.LabelSet{},
+			logsLines:  []string{},
+		},
+		{
+			name: "fallback to digest_text",
+			rows: [][]driver.Value{{
+				"abc123",
+				"SELECT * FROM `some_table` WHERE `id` = ?",
+				"some_schema",
+				"select * from some_table whe...",
 			}},
 			logsLabels: []model.LabelSet{
-				{"job": database_observability.JobName, "op": OP_QUERY_TABLES, "instance": "mysql-db"},
+				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 			},
 			logsLines: []string{
-				`schema="some_schema" digest="abc123" query_type="" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="show variables"`,
+				`schema="some_schema" digest="abc123" table="some_table"`,
 			},
 		},
 	}
@@ -320,10 +284,9 @@ func TestQueryTables(t *testing.T) {
 				WillReturnRows(
 					sqlmock.NewRows([]string{
 						"digest",
+						"digest_text",
 						"schema_name",
 						"query_sample_text",
-						"query_sample_seen",
-						"query_sample_timer_wait",
 					}).AddRows(
 						tc.rows...,
 					),
@@ -390,16 +353,14 @@ func TestQueryTablesSQLDriverErrors(t *testing.T) {
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"digest",
+					"digest_text",
 					"schema_name",
 					"query_sample_text",
-					"query_sample_seen",
-					"query_sample_timer_wait",
 				}).AddRow(
 					"abc123",
+					"SELECT * FROM `some_table` WHERE `id` = ?",
 					"some_schema",
 					"select * from some_table where id = 1",
-					"2024-01-01T00:00:00.000Z",
-					"1000",
 				),
 			)
 
@@ -407,7 +368,7 @@ func TestQueryTablesSQLDriverErrors(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
-			return len(lokiClient.Received()) == 2
+			return len(lokiClient.Received()) == 1
 		}, 5*time.Second, 100*time.Millisecond)
 
 		collector.Stop()
@@ -421,10 +382,8 @@ func TestQueryTablesSQLDriverErrors(t *testing.T) {
 		require.NoError(t, err)
 
 		lokiEntries := lokiClient.Received()
-		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_TABLES, "instance": "mysql-db"}, lokiEntries[0].Labels)
-		require.Equal(t, `schema="some_schema" digest="abc123" query_type="select" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="select * from some_table where id = :redacted1"`, lokiEntries[0].Line)
-		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"}, lokiEntries[1].Labels)
-		require.Equal(t, `schema="some_schema" digest="abc123" table="some_table"`, lokiEntries[1].Line)
+		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"}, lokiEntries[0].Labels)
+		require.Equal(t, `schema="some_schema" digest="abc123" table="some_table"`, lokiEntries[0].Line)
 	})
 
 	t.Run("result set iteration error", func(t *testing.T) {
@@ -450,22 +409,19 @@ func TestQueryTablesSQLDriverErrors(t *testing.T) {
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"digest",
+					"digest_text",
 					"schema_name",
 					"query_sample_text",
-					"query_sample_seen",
-					"query_sample_timer_wait",
 				}).AddRow(
 					"abc123",
+					"SELECT * FROM `some_table` WHERE `id` = ?",
 					"some_schema",
 					"select * from some_table where id = 1",
-					"2024-01-01T00:00:00.000Z",
-					"1000",
 				).AddRow(
 					"def456",
+					"SELECT * FROM `another_table` WHERE `id` = ?",
 					"another_schema",
 					"select * from another_table where id = 2",
-					"2024-01-01T00:00:00.000Z",
-					"1000",
 				).RowError(1, fmt.Errorf("rs error")), // error on second row
 			)
 
@@ -473,7 +429,7 @@ func TestQueryTablesSQLDriverErrors(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
-			return len(lokiClient.Received()) == 2
+			return len(lokiClient.Received()) == 1
 		}, 5*time.Second, 100*time.Millisecond)
 
 		collector.Stop()
@@ -487,10 +443,8 @@ func TestQueryTablesSQLDriverErrors(t *testing.T) {
 		require.NoError(t, err)
 
 		lokiEntries := lokiClient.Received()
-		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_TABLES, "instance": "mysql-db"}, lokiEntries[0].Labels)
-		require.Equal(t, `schema="some_schema" digest="abc123" query_type="select" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="select * from some_table where id = :redacted1"`, lokiEntries[0].Line)
-		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"}, lokiEntries[1].Labels)
-		require.Equal(t, `schema="some_schema" digest="abc123" table="some_table"`, lokiEntries[1].Line)
+		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"}, lokiEntries[0].Labels)
+		require.Equal(t, `schema="some_schema" digest="abc123" table="some_table"`, lokiEntries[0].Line)
 	})
 
 	t.Run("connection error recovery", func(t *testing.T) {
@@ -518,16 +472,14 @@ func TestQueryTablesSQLDriverErrors(t *testing.T) {
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"digest",
+					"digest_text",
 					"schema_name",
 					"query_sample_text",
-					"query_sample_seen",
-					"query_sample_timer_wait",
 				}).AddRow(
 					"abc123",
+					"SELECT * FROM `some_table` WHERE `id` = ?",
 					"some_schema",
 					"select * from some_table where id = 1",
-					"2024-01-01T00:00:00.000Z",
-					"1000",
 				),
 			)
 
@@ -535,7 +487,7 @@ func TestQueryTablesSQLDriverErrors(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
-			return len(lokiClient.Received()) == 2
+			return len(lokiClient.Received()) == 1
 		}, 5*time.Second, 100*time.Millisecond)
 
 		collector.Stop()
@@ -549,9 +501,7 @@ func TestQueryTablesSQLDriverErrors(t *testing.T) {
 		require.NoError(t, err)
 
 		lokiEntries := lokiClient.Received()
-		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_TABLES, "instance": "mysql-db"}, lokiEntries[0].Labels)
-		require.Equal(t, `schema="some_schema" digest="abc123" query_type="select" query_sample_seen="2024-01-01T00:00:00.000Z" query_sample_timer_wait="1000" query_sample_redacted="select * from some_table where id = :redacted1"`, lokiEntries[0].Line)
-		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"}, lokiEntries[1].Labels)
-		require.Equal(t, `schema="some_schema" digest="abc123" table="some_table"`, lokiEntries[1].Line)
+		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"}, lokiEntries[0].Labels)
+		require.Equal(t, `schema="some_schema" digest="abc123" table="some_table"`, lokiEntries[0].Line)
 	})
 }


### PR DESCRIPTION
#### PR Description
We add a few improvements to the query parsing strategy to have more chances of extracting tables names:
- if the sample_text is truncated, we try to use the digest_text (this might still be truncated, but that's less likely because the text is shortened due to parameters being redacted)
- if query parsing fails, attempt to parse it again with the sql_mode set to 'IGNORE_SPACES' to account for whitespace variations in sql functions
- additionally, cover the case of digest_text with an 'IN (...)' clause

We also drop the 'query_tables' log entry, as it's not really used anywhere; then, additionally simplify the fetch query to not include unnecessary columns.

#### Which issue(s) this PR fixes
n.a.

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
