### PR TITLE
fix: Pretty print diagnostic errors when using run command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Main (unreleased)
   - `schema_table`: add support for index expressions (@cristiangreco)
   - `query_tables`: improve queries parsing (@cristiangreco)
 
+- Pretty print diagnostic errors when using `alloy run` (@kalleep)
+
 ### Bugfixes
 
 - Fix `otelcol.exporter.prometheus` dropping valid exemplars. (@github-vincent-miszczak)

--- a/internal/alloycli/cmd_run.go
+++ b/internal/alloycli/cmd_run.go
@@ -297,7 +297,7 @@ func (fr *alloyRun) Run(cmd *cobra.Command, configPath string) error {
 	// To work around this, we lazily create variables for the functions the HTTP
 	// service needs and set them after the Alloy controller exists.
 	var (
-		reload func() (*alloy_runtime.Source, error)
+		reload func() (map[string][]byte, error)
 		ready  func() bool
 	)
 
@@ -340,8 +340,11 @@ func (fr *alloyRun) Run(cmd *cobra.Command, configPath string) error {
 		Tracer:   t,
 		Gatherer: prometheus.DefaultGatherer,
 
-		ReadyFunc:  func() bool { return ready() },
-		ReloadFunc: func() (*alloy_runtime.Source, error) { return reload() },
+		ReadyFunc: func() bool { return ready() },
+		ReloadFunc: func() error {
+			_, err := reload()
+			return err
+		},
 
 		HTTPListenAddr:   fr.httpListenAddr,
 		MemoryListenAddr: fr.inMemoryAddr,
@@ -398,19 +401,26 @@ func (fr *alloyRun) Run(cmd *cobra.Command, configPath string) error {
 	})
 
 	ready = f.Ready
-	reload = func() (*alloy_runtime.Source, error) {
-		alloySource, err := loadAlloySource(configPath, fr.configFormat, fr.configBypassConversionErrors, fr.configExtraArgs)
-		defer instrumentation.InstrumentConfig(err == nil, alloySource.SHA256(), fr.clusterName)
-
+	reload = func() (map[string][]byte, error) {
+		sources, err := loadSourceFiles(configPath, fr.configFormat, fr.configBypassConversionErrors, fr.configExtraArgs)
 		if err != nil {
+			instrumentation.InstrumentConfig(false, [32]byte{}, fr.clusterName)
 			return nil, fmt.Errorf("reading config path %q: %w", configPath, err)
 		}
-		httpService.SetSources(alloySource.SourceFiles())
-		if err := f.LoadSource(alloySource, nil, configPath); err != nil {
-			return alloySource, fmt.Errorf("error during the initial load: %w", err)
+
+		alloySource, err := alloy_runtime.ParseSources(sources)
+		if err != nil {
+			instrumentation.InstrumentConfig(false, [32]byte{}, fr.clusterName)
+			return sources, fmt.Errorf("reading config path %q: %w", configPath, err)
 		}
 
-		return alloySource, nil
+		httpService.SetSources(alloySource.SourceFiles())
+		if err := f.LoadSource(alloySource, nil, configPath); err != nil {
+			instrumentation.InstrumentConfig(false, [32]byte{}, fr.clusterName)
+			return sources, fmt.Errorf("error during the initial load: %w", err)
+		}
+
+		return sources, nil
 	}
 
 	// Alloy controller
@@ -447,7 +457,7 @@ func (fr *alloyRun) Run(cmd *cobra.Command, configPath string) error {
 				ContextLinesBefore: 1,
 				ContextLinesAfter:  1,
 			})
-			_ = p.Fprint(os.Stderr, source.RawConfigs(), diags)
+			_ = p.Fprint(os.Stderr, source, diags)
 
 			// Print newline after the diagnostics.
 			fmt.Println()
@@ -521,7 +531,7 @@ func getEnabledComponentsFunc(f *alloy_runtime.Runtime) func() map[string]interf
 	}
 }
 
-func loadAlloySource(path string, converterSourceFormat string, converterBypassErrors bool, configExtraArgs string) (*alloy_runtime.Source, error) {
+func loadSourceFiles(path string, converterSourceFormat string, converterBypassErrors bool, configExtraArgs string) (map[string][]byte, error) {
 	fi, err := os.Stat(path)
 	if err != nil {
 		return nil, err
@@ -553,7 +563,7 @@ func loadAlloySource(path string, converterSourceFormat string, converterBypassE
 			return nil, err
 		}
 
-		return alloy_runtime.ParseSources(sources)
+		return sources, nil
 	}
 
 	bb, err := os.ReadFile(path)
@@ -575,7 +585,7 @@ func loadAlloySource(path string, converterSourceFormat string, converterBypassE
 		}
 	}
 
-	return alloy_runtime.ParseSource(path, bb)
+	return map[string][]byte{path: bb}, nil
 }
 
 // addDeprecatedFlags adds flags that are deprecated, but we keep them for backwards compatibility.

--- a/internal/runtime/source.go
+++ b/internal/runtime/source.go
@@ -1,7 +1,6 @@
 package runtime
 
 import (
-	"crypto/sha256"
 	"errors"
 	"fmt"
 	"sort"
@@ -17,7 +16,6 @@ import (
 type Source struct {
 	sourceMap map[string][]byte // Map that links parsed Alloy source's name with its content.
 	fileMap   map[string]*ast.File
-	hash      [sha256.Size]byte // Hash of all files in sourceMap sorted by name.
 
 	// Components holds the list of raw Alloy AST blocks describing components.
 	// The Alloy controller can interpret them.
@@ -45,7 +43,6 @@ func ParseSource(name string, bb []byte) (*Source, error) {
 	}
 	source.sourceMap = map[string][]byte{name: bb}
 	source.fileMap = map[string]*ast.File{name: node}
-	source.hash = sha256.Sum256(bb)
 	return source, nil
 }
 
@@ -117,7 +114,6 @@ func ParseSources(sources map[string][]byte) (*Source, error) {
 			sourceMap: sources,
 			fileMap:   make(map[string]*ast.File, len(sources)),
 		}
-		hash = sha256.New() // Combined hash of all the sources.
 	)
 
 	// Sorted slice so ParseSources always does the same thing.
@@ -134,8 +130,6 @@ func ParseSources(sources map[string][]byte) (*Source, error) {
 
 	// Parse each .alloy source and compute new hash for the whole sourceMap
 	for _, namedSource := range sortedSources {
-		hash.Write(namedSource.Content)
-
 		sourceFragment, err := ParseSource(namedSource.Name, namedSource.Content)
 		if err != nil {
 			// If we encounter diagnostic errors we combine them and
@@ -159,7 +153,6 @@ func ParseSources(sources map[string][]byte) (*Source, error) {
 		return nil, mergedDiags
 	}
 
-	mergedSource.hash = [32]byte(hash.Sum(nil))
 	return mergedSource, nil
 }
 
@@ -179,13 +172,4 @@ func (s *Source) SourceFiles() map[string]*ast.File {
 		return nil
 	}
 	return s.fileMap
-}
-
-// SHA256 returns the sha256 checksum of the source.
-// Do not modify the returned byte array.
-func (s *Source) SHA256() [sha256.Size]byte {
-	if s == nil {
-		return [sha256.Size]byte{}
-	}
-	return s.hash
 }

--- a/internal/service/cluster/cluster_e2e_test.go
+++ b/internal/service/cluster/cluster_e2e_test.go
@@ -563,7 +563,7 @@ func startNewNode(t *testing.T, state *testState, nodeName string) {
 		Gatherer: reg,
 
 		ReadyFunc:  func() bool { return true },
-		ReloadFunc: func() (*runtime.Source, error) { return nil, nil },
+		ReloadFunc: func() error { return nil },
 
 		HTTPListenAddr: nodeAddress,
 	})

--- a/internal/service/http/http.go
+++ b/internal/service/http/http.go
@@ -22,7 +22,6 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/featuregate"
-	alloy_runtime "github.com/grafana/alloy/internal/runtime"
 	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
 	"github.com/grafana/alloy/internal/service"
@@ -52,7 +51,7 @@ type Options struct {
 	Gatherer prometheus.Gatherer  // Where to collect metrics from.
 
 	ReadyFunc  func() bool
-	ReloadFunc func() (*alloy_runtime.Source, error)
+	ReloadFunc func() error
 
 	HTTPListenAddr   string                // Address to listen for HTTP traffic on.
 	MemoryListenAddr string                // Address to accept in-memory traffic on.
@@ -268,8 +267,7 @@ func (s *Service) Run(ctx context.Context, host service.Host) error {
 		r.HandleFunc("/-/reload", func(w http.ResponseWriter, _ *http.Request) {
 			level.Info(s.log).Log("msg", "reload requested via /-/reload endpoint")
 
-			_, err := s.opts.ReloadFunc()
-			if err != nil {
+			if err := s.opts.ReloadFunc(); err != nil {
 				level.Error(s.log).Log("msg", "failed to reload config", "err", err.Error())
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return

--- a/internal/service/http/http_test.go
+++ b/internal/service/http/http_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/featuregate"
-	"github.com/grafana/alloy/internal/runtime"
 	"github.com/grafana/alloy/internal/runtime/componenttest"
 	"github.com/grafana/alloy/internal/service"
 	"github.com/grafana/alloy/internal/service/remotecfg"
@@ -349,7 +348,7 @@ func newTestEnvironment(t *testing.T) (*testEnvironment, error) {
 		Gatherer: prometheus.NewRegistry(),
 
 		ReadyFunc:  func() bool { return true },
-		ReloadFunc: func() (*runtime.Source, error) { return nil, nil },
+		ReloadFunc: func() error { return nil },
 
 		HTTPListenAddr:   fmt.Sprintf("127.0.0.1:%d", port),
 		MemoryListenAddr: "alloy.internal:12345",


### PR DESCRIPTION
#### PR Description
Extracted from https://github.com/grafana/alloy/pull/3220.

This change is related to that work but is useful on its own. 

Before this change if we had any Diagnostic errors when calling `alloy run` there where not pretty printed

Before:
![2025-04-09-11:45:04](https://github.com/user-attachments/assets/8365a30d-5376-4ffd-bd4b-333eb2d619f8)
After:
![2025-04-09-11:46:24](https://github.com/user-attachments/assets/26dda1fe-b4fe-49d2-9372-250473a390c6)

Other notable change are if config are from several files we continue to parse other files if on fails so we can report diagnostic from multiple files.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
