### PR TITLE
database_observability: improve query tables parsing fallback

### DIFF
--- a/internal/component/database_observability/mysql/collector/query_tables.go
+++ b/internal/component/database_observability/mysql/collector/query_tables.go
@@ -147,8 +147,15 @@ func (c *QueryTables) fetchQueryTables(ctx context.Context) error {
 
 		stmt, err := c.sqlParser.Parse(sqlText)
 		if err != nil {
-			level.Warn(c.logger).Log("msg", "failed to parse sql query", "schema", schemaName, "digest", digest, "err", err)
-			continue
+			level.Warn(c.logger).Log("msg", "failed to parse sql query from sample_text", "schema", schemaName, "digest", digest, "err", err)
+
+			if sqlText != digestText {
+				stmt, err = c.sqlParser.Parse(digestText)
+				if err != nil {
+					level.Warn(c.logger).Log("msg", "failed to parse sql query from digest_text", "schema", schemaName, "digest", digest, "err", err)
+					continue
+				}
+			}
 		}
 
 		tables := c.sqlParser.ExtractTableNames(c.logger, digest, stmt)

--- a/internal/component/database_observability/mysql/collector/query_tables_test.go
+++ b/internal/component/database_observability/mysql/collector/query_tables_test.go
@@ -244,12 +244,27 @@ func TestQueryTables(t *testing.T) {
 			logsLines:  []string{},
 		},
 		{
-			name: "fallback to digest_text",
+			name: "query truncated with dots fallback to digest_text",
 			rows: [][]driver.Value{{
 				"abc123",
 				"SELECT * FROM `some_table` WHERE `id` = ?",
 				"some_schema",
 				"select * from some_table whe...",
+			}},
+			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
+			},
+			logsLines: []string{
+				`schema="some_schema" digest="abc123" table="some_table"`,
+			},
+		},
+		{
+			name: "query truncated without dots fallback to digest_text",
+			rows: [][]driver.Value{{
+				"abc123",
+				"SELECT * FROM `some_table` WHERE `id` = ?",
+				"some_schema",
+				"select * from some_table where",
 			}},
 			logsLabels: []model.LabelSet{
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},


### PR DESCRIPTION
#### PR Description
Followup on a previous change to improve the parsing of query tables. In some cases we can't detect that the sample_text is truncated with dots, so when doing the actual parsing -if it fails- we should attempt to parse the digest_text as a fallback.

Followup of https://github.com/grafana/alloy/pull/3281

#### Which issue(s) this PR fixes

n.a.

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
