### PR TITLE
database_observability: make tidbparser the default sql parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Main (unreleased)
 - (_Experimental_) Various changes to the experimental component `database_observability.mysql`:
   - `schema_table`: add support for index expressions (@cristiangreco)
   - `query_tables`: improve queries parsing (@cristiangreco)
+  - make tidbparser the default choice (@cristiangreco)
 
 ### Bugfixes
 

--- a/internal/component/database_observability/mysql/component.go
+++ b/internal/component/database_observability/mysql/component.go
@@ -62,7 +62,7 @@ type Arguments struct {
 
 var DefaultArguments = Arguments{
 	CollectInterval: 1 * time.Minute,
-	UseTiDBParser:   false,
+	UseTiDBParser:   true,
 }
 
 func (a *Arguments) SetToDefault() {
@@ -298,6 +298,7 @@ func (c *Component) startCollectors() error {
 			InstanceKey:     c.instanceKey,
 			CollectInterval: c.args.CollectInterval,
 			EntryHandler:    entryHandler,
+			UseTiDBParser:   c.args.UseTiDBParser,
 			Logger:          c.opts.Logger,
 		})
 		if err != nil {


### PR DESCRIPTION
#### PR Description
Switch to use TiDBParser implementation by default for all collectors.

#### Which issue(s) this PR fixes
n.a.

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
