### PR TITLE
added windows event_data XML process

### DIFF
--- a/internal/component/loki/source/windowsevent/format_test.go
+++ b/internal/component/loki/source/windowsevent/format_test.go
@@ -1,0 +1,74 @@
+//go:build windows
+
+package windowsevent
+
+import (
+	"testing"
+
+	jsoniter "github.com/json-iterator/go"
+	"go.uber.org/goleak"
+	"github.com/grafana/loki/v3/clients/pkg/promtail/scrapeconfig"
+	"github.com/grafana/loki/v3/clients/pkg/promtail/targets/windows/win_eventlog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatIncludeEventData(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
+
+	scrapeConfig := &scrapeconfig.WindowsEventsTargetConfig{
+		Locale:               0,
+		EventlogName:         "Application",
+		Query:                "*",
+		UseIncomingTimestamp: false,
+		BookmarkPath:         "",
+		ExcludeEventData:     false,
+		ExcludeEventMessage:  false,
+		ExcludeUserData:      false,
+	}
+
+	event := win_eventlog.Event{
+		EventID: 1234,
+		EventData: win_eventlog.EventData{
+			InnerXML: []byte("<Data Name=\"test_key_name\">test_value</Data><Data Name=\"test_key_name2\">test_value2</Data>"),
+		},
+	}
+
+	formatted, err := formatLine(scrapeConfig, event)
+	require.NoError(t, err)
+	var jdata map[string]interface{}
+	err = jsoniter.Unmarshal([]byte(formatted), &jdata)
+	require.NoError(t, err)
+	require.Equal(t, "test_value", jdata["event_data_map"].(map[string]interface{})["test_key_name"])
+	require.Equal(t, "test_value2", jdata["event_data_map"].(map[string]interface{})["test_key_name2"])
+}
+
+func TestFormatExcludeEventData(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
+
+	scrapeConfig := &scrapeconfig.WindowsEventsTargetConfig{
+		Locale:               0,
+		EventlogName:         "Application",
+		Query:                "*",
+		UseIncomingTimestamp: false,
+		BookmarkPath:         "",
+		ExcludeEventData:     true,
+		ExcludeEventMessage:  false,
+		ExcludeUserData:      false,
+	}
+	
+	event := win_eventlog.Event{
+		EventID: 1234,
+		EventData: win_eventlog.EventData{
+			InnerXML: []byte("<Data Name=\"test_key_name\">test_value</Data><Data Name=\"test_key_name2\">test_value2</Data>"),
+		},
+	}
+
+	formatted, err := formatLine(scrapeConfig, event)
+	require.NoError(t, err)
+	var jdata map[string]interface{}
+	err = jsoniter.Unmarshal([]byte(formatted), &jdata)
+	require.NoError(t, err)
+	require.Nil(t, jdata["event_data_map"])
+	require.Nil(t, jdata["event_data"])
+}	
+	


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Windows event log source creates a JSON object that contains the raw slice of bytes from EventData XML tag which contains information that can be useful. 
The format of EventData is clearly defined by:
https://learn.microsoft.com/en-us/windows/win32/wes/eventschema-datafieldtype-complextype
and can easily converted into a JSON key-value object.

This code modification reads the byte slice from EventData and converts it into a JSON key-value object which is then stored in a new key (event_data_map) in the exported data.

Also, added a unit test for the modification.



