### PR TITLE
tests: explicitly state the file storage directory in converter test

### DIFF
--- a/internal/converter/internal/otelcolconvert/testdata/filelog.yaml
+++ b/internal/converter/internal/otelcolconvert/testdata/filelog.yaml
@@ -60,6 +60,9 @@ exporters:
 
 extensions:
   file_storage:
+    directory: /var/lib/otelcol/file_storage
+    compaction:
+      directory: /var/lib/otelcol/file_storage
     fsync: true
     
 service:


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
The default values are different between non-Windows & Windows, and the Windows tests were failing in the converter. We don't currently have a pattern for different tests for Windows & non in the otel converter code so this change will make the tests pass on all OSes.

[Failing test run](https://github.com/grafana/alloy/actions/runs/14452709312/job/40528940390)