### PR TITLE
ci: pin hashes for workflow dependencies

### DIFF
--- a/.github/workflows/autolock.yml
+++ b/.github/workflows/autolock.yml
@@ -16,7 +16,7 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v5.0.1
+      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5.0.1
         with:
           pr-inactive-days: 30
           issue-inactive-days: 30

--- a/.github/workflows/autolock.yml
+++ b/.github/workflows/autolock.yml
@@ -16,7 +16,7 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v5
+      - uses: dessant/lock-threads@v5.0.1
         with:
           pr-inactive-days: 30
           issue-inactive-days: 30

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "grafana/grafana-github-actions"
           path: ./actions

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           repository: "grafana/grafana-github-actions"
           path: ./actions

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,14 +18,14 @@ jobs:
         arch: [amd64, arm64, ppc64le, s390x]
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set ownership
       # https://github.com/actions/runner/issues/2033#issuecomment-1204205989
       run: |
           # this is to fix GIT not liking owner of the checkout dir
           chown -R $(id -u):$(id -g) $PWD
     - name: Set up Go
-      uses: actions/setup-go@v5.4.0
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
         go-version-file: go.mod
         # TODO: Try enabling caching later. It might use up too much disk space on runners so needs extra testing.
@@ -43,14 +43,14 @@ jobs:
         arch: [amd64, arm64]
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set ownership
       # https://github.com/actions/runner/issues/2033#issuecomment-1204205989
       run: |
           # this is to fix GIT not liking owner of the checkout dir
           chown -R $(id -u):$(id -g) $PWD
     - name: Set up Go
-      uses: actions/setup-go@v5.4.0
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
         go-version-file: go.mod
         # TODO: Try enabling caching later. It might use up too much disk space on runners so needs extra testing.
@@ -63,9 +63,9 @@ jobs:
     runs-on: macos-14-large
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Go
-      uses: actions/setup-go@v5.4.0
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
         go-version-file: go.mod
         # TODO: Try enabling caching later. It might use up too much disk space on runners so needs extra testing.
@@ -78,9 +78,9 @@ jobs:
     runs-on: macos-14-xlarge
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Go
-      uses: actions/setup-go@v5.4.0
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
         go-version-file: go.mod
         # TODO: Try enabling caching later. It might use up too much disk space on runners so needs extra testing.
@@ -93,9 +93,9 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Go
-      uses: actions/setup-go@v5.4.0
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
         go-version-file: go.mod
         # TODO: Try enabling caching later. It might use up too much disk space on runners so needs extra testing.
@@ -112,14 +112,14 @@ jobs:
     container: grafana/alloy-build-image:v0.1.17
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set ownership
       # https://github.com/actions/runner/issues/2033#issuecomment-1204205989
       run: |
           # this is to fix GIT not liking owner of the checkout dir
           chown -R $(id -u):$(id -g) $PWD
     - name: Set up Go
-      uses: actions/setup-go@v5.4.0
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
         go-version-file: go.mod
         # TODO: Try enabling caching later. It might use up too much disk space on runners so needs extra testing.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,14 +18,14 @@ jobs:
         arch: [amd64, arm64, ppc64le, s390x]
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
     - name: Set ownership
       # https://github.com/actions/runner/issues/2033#issuecomment-1204205989
       run: |
           # this is to fix GIT not liking owner of the checkout dir
           chown -R $(id -u):$(id -g) $PWD
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v5.4.0
       with:
         go-version-file: go.mod
         # TODO: Try enabling caching later. It might use up too much disk space on runners so needs extra testing.
@@ -43,14 +43,14 @@ jobs:
         arch: [amd64, arm64]
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
     - name: Set ownership
       # https://github.com/actions/runner/issues/2033#issuecomment-1204205989
       run: |
           # this is to fix GIT not liking owner of the checkout dir
           chown -R $(id -u):$(id -g) $PWD
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v5.4.0
       with:
         go-version-file: go.mod
         # TODO: Try enabling caching later. It might use up too much disk space on runners so needs extra testing.
@@ -63,9 +63,9 @@ jobs:
     runs-on: macos-14-large
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v5.4.0
       with:
         go-version-file: go.mod
         # TODO: Try enabling caching later. It might use up too much disk space on runners so needs extra testing.
@@ -78,9 +78,9 @@ jobs:
     runs-on: macos-14-xlarge
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v5.4.0
       with:
         go-version-file: go.mod
         # TODO: Try enabling caching later. It might use up too much disk space on runners so needs extra testing.
@@ -93,9 +93,9 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v5.4.0
       with:
         go-version-file: go.mod
         # TODO: Try enabling caching later. It might use up too much disk space on runners so needs extra testing.
@@ -112,14 +112,14 @@ jobs:
     container: grafana/alloy-build-image:v0.1.17
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
     - name: Set ownership
       # https://github.com/actions/runner/issues/2033#issuecomment-1204205989
       run: |
           # this is to fix GIT not liking owner of the checkout dir
           chown -R $(id -u):$(id -g) $PWD
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v5.4.0
       with:
         go-version-file: go.mod
         # TODO: Try enabling caching later. It might use up too much disk space on runners so needs extra testing.

--- a/.github/workflows/bump-formula-pr.yml
+++ b/.github/workflows/bump-formula-pr.yml
@@ -8,7 +8,7 @@ jobs:
     name: homebrew-grafana
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/create-github-app-token@v1
+    - uses: actions/create-github-app-token@v1.12.0
       id: app-token
       with:
         app-id: ${{ secrets.ALLOYBOT_APP_ID }}

--- a/.github/workflows/bump-formula-pr.yml
+++ b/.github/workflows/bump-formula-pr.yml
@@ -8,7 +8,7 @@ jobs:
     name: homebrew-grafana
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/create-github-app-token@v1.12.0
+    - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
       id: app-token
       with:
         app-id: ${{ secrets.ALLOYBOT_APP_ID }}
@@ -24,7 +24,7 @@ jobs:
         git config --global user.email "879451+grafana-alloybot[bot]@users.noreply.github.com"
 
     - name: Get latest release
-      uses: rez0n/actions-github-release@main
+      uses: rez0n/actions-github-release@794c12f5e8d629e6ca329cf2e2daeb0f0ce6a3ce # main
       id: latest_release
       with:
         token: ${{ steps.app-token.outputs.token }}
@@ -32,7 +32,7 @@ jobs:
         type: "stable"
 
     - name: Setup Homebrew
-      uses: Homebrew/actions/setup-homebrew@master
+      uses: Homebrew/actions/setup-homebrew@4a509e36a728d1c8e147158247eb0446838a8d63 # master
       with:
         token: ${{ steps.app-token.outputs.token }}
 

--- a/.github/workflows/check-linux-build-image.yml
+++ b/.github/workflows/check-linux-build-image.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Remove unnecessary files
         run: |
@@ -30,10 +30,10 @@ jobs:
         uses: docker/setup-qemu-action@v3.6.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3.10.0
 
       - name: Create test Linux build image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v6.15.0
         with:
           platforms: linux/amd64,linux/arm64
           context: ./tools/build-image

--- a/.github/workflows/check-linux-build-image.yml
+++ b/.github/workflows/check-linux-build-image.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Remove unnecessary files
         run: |
@@ -27,13 +27,13 @@ jobs:
             rm -rf /opt/hostedtoolcache
 
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3.6.0
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.10.0
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Create test Linux build image
-        uses: docker/build-push-action@v6.15.0
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           platforms: linux/amd64,linux/arm64
           context: ./tools/build-image

--- a/.github/workflows/check-linux-container.yml
+++ b/.github/workflows/check-linux-container.yml
@@ -20,7 +20,7 @@ jobs:
       labels: github-hosted-ubuntu-x64-large
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Set ownership
       # https://github.com/actions/runner/issues/2033#issuecomment-1204205989
@@ -29,10 +29,10 @@ jobs:
           chown -R $(id -u):$(id -g) $PWD
 
     - name: Set up Go
-      uses: actions/setup-go@v5.4.0
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
         go-version-file: go.mod
         cache: false
 
     - run: |
-       make alloy-image
+        make alloy-image

--- a/.github/workflows/check-linux-container.yml
+++ b/.github/workflows/check-linux-container.yml
@@ -20,7 +20,7 @@ jobs:
       labels: github-hosted-ubuntu-x64-large
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
 
     - name: Set ownership
       # https://github.com/actions/runner/issues/2033#issuecomment-1204205989
@@ -29,7 +29,7 @@ jobs:
           chown -R $(id -u):$(id -g) $PWD
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v5.4.0
       with:
         go-version-file: go.mod
         cache: false

--- a/.github/workflows/check-versioned-files.yml
+++ b/.github/workflows/check-versioned-files.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Regenerate versioned files
         run: |

--- a/.github/workflows/check-versioned-files.yml
+++ b/.github/workflows/check-versioned-files.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Regenerate versioned files
         run: |

--- a/.github/workflows/check-windows-build-image.yml
+++ b/.github/workflows/check-windows-build-image.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Create test Windows build image
-        uses: mr-smithers-excellent/docker-build-push@v6.4
+        uses: mr-smithers-excellent/docker-build-push@59523c638baec979a74fea99caa9e29d97e5963c # v6.4
         with:
           image: grafana/alloy-build-image
           tags: latest

--- a/.github/workflows/check-windows-build-image.yml
+++ b/.github/workflows/check-windows-build-image.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Create test Windows build image
-        uses: mr-smithers-excellent/docker-build-push@v6
+        uses: mr-smithers-excellent/docker-build-push@v6.4
         with:
           image: grafana/alloy-build-image
           tags: latest

--- a/.github/workflows/check-windows-container.yml
+++ b/.github/workflows/check-windows-container.yml
@@ -20,7 +20,7 @@ on:
       - '.github/workflows/publish-alloy-release.yml'
 jobs:
   check_windows_container:
-    uses: ./.github/workflows/publish-alloy.yaml
+    uses: ./.github/workflows/publish-alloy.yml
     with:
       img-name: alloy-devel
       push: false

--- a/.github/workflows/check_docs.yml
+++ b/.github/workflows/check_docs.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
     - name: "Check out code"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@v4.2.2"
     - name: "Build technical documentation"
       run: >
         docker run

--- a/.github/workflows/check_docs.yml
+++ b/.github/workflows/check_docs.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
     - name: "Check out code"
-      uses: "actions/checkout@v4.2.2"
+      uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
     - name: "Build technical documentation"
       run: >
         docker run

--- a/.github/workflows/create_build_image.yml
+++ b/.github/workflows/create_build_image.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Remove unnecessary files
       run: |
@@ -37,16 +37,16 @@ jobs:
       run: echo "image_tag=${FULL_TAG##*/}${{ matrix.build.suffix }}" >> $GITHUB_OUTPUT
 
     - name: Login to DockerHub (from vault)
-      uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login-v1.0.1
+      uses: grafana/shared-workflows/actions/dockerhub-login@13fb504e3bfe323c1188bf244970d94b2d336e86 # dockerhub-login-v1.0.1
 
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@v3.6.0
+      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3.10.0
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
     - name: Create Linux build image
-      uses: docker/build-push-action@v6.15.0
+      uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
       with:
         platforms: linux/amd64,linux/arm64
         context: ./tools/build-image

--- a/.github/workflows/create_build_image.yml
+++ b/.github/workflows/create_build_image.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
 
     - name: Remove unnecessary files
       run: |
@@ -43,10 +43,10 @@ jobs:
       uses: docker/setup-qemu-action@v3.6.0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v3.10.0
 
     - name: Create Linux build image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v6.15.0
       with:
         platforms: linux/amd64,linux/arm64
         context: ./tools/build-image

--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -1,3 +1,6 @@
+#
+# TODO: Can this be removed in favor of renovatebot?
+#
 name: Check Dependencies
 on:
   workflow_dispatch: {}
@@ -9,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Invoke action
         uses: rfratto/depcheck@main

--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Invoke action
-        uses: rfratto/depcheck@main
+        uses: rfratto/depcheck@95f3e3d75101f21e73363c928d500a222cf03572 # main
         with:
           github-token: ${{ secrets.MANAGE_ISSUES_GH_TOKEN }}

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   deploy-pr-preview:
     if: "!github.event.pull_request.head.repo.fork"
-    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
+    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@e97bf199a578b923363e5cd7db079dad234aeb90 # main
     with:
       branch: ${{ github.head_ref }}
       event_number: ${{ github.event.number }}

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -16,7 +16,7 @@ jobs:
     # We use a large runner for the additional disk space.
     runs-on: github-hosted-ubuntu-x64-large
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
       - name: Build image
         run: |
           docker build -t alloy-test:latest -f Dockerfile .
@@ -24,9 +24,7 @@ jobs:
   windows:
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
       - name: Build image
         run: |
           docker build -t alloy-test:latest -f Dockerfile.windows .
-
-

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -16,7 +16,7 @@ jobs:
     # We use a large runner for the additional disk space.
     runs-on: github-hosted-ubuntu-x64-large
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Build image
         run: |
           docker build -t alloy-test:latest -f Dockerfile .
@@ -24,7 +24,7 @@ jobs:
   windows:
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Build image
         run: |
           docker build -t alloy-test:latest -f Dockerfile.windows .

--- a/.github/workflows/fuzz-go.yml
+++ b/.github/workflows/fuzz-go.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       tests: ${{ steps.find-tests.outputs.tests }}
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Find fuzz tests
         id: find-tests
         run: |
@@ -70,10 +70,10 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.find-tests.outputs.tests) }}
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Go
-        uses: actions/setup-go@v5.4.0
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: go.mod
           cache: false
@@ -82,7 +82,7 @@ jobs:
         run: echo "FUZZ_CACHE=$(go env GOCACHE)/fuzz" >> $GITHUB_ENV
 
       - name: Restore fuzz cache
-        uses: actions/cache@v4.2.3
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ${{ env.FUZZ_CACHE }}
           key: fuzz-${{ matrix.package }}-${{ matrix.function }}-${{ github.sha }}
@@ -121,7 +121,7 @@ jobs:
       - name: Upload fuzz failure as artifact
         id: artifact
         if: ${{ failure() && steps.new-failure.outputs.file != '' }}
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: failure-${{ steps.new-failure.outputs.package }}-${{ steps.new-failure.outputs.function }}
           path: ${{ steps.new-failure.outputs.file }}
@@ -143,7 +143,7 @@ jobs:
 
       - name: Create new issue
         if: ${{ failure() && steps.new-failure.outputs.file != '' && inputs.create-issue }}
-        uses: actions/github-script@v7.0.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const failureName = "${{ steps.new-failure.outputs.name }}";

--- a/.github/workflows/fuzz-go.yml
+++ b/.github/workflows/fuzz-go.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       tests: ${{ steps.find-tests.outputs.tests }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
       - name: Find fuzz tests
         id: find-tests
         run: |
@@ -70,10 +70,10 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.find-tests.outputs.tests) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v5.4.0
         with:
           go-version-file: go.mod
           cache: false
@@ -82,7 +82,7 @@ jobs:
         run: echo "FUZZ_CACHE=$(go env GOCACHE)/fuzz" >> $GITHUB_ENV
 
       - name: Restore fuzz cache
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.3
         with:
           path: ${{ env.FUZZ_CACHE }}
           key: fuzz-${{ matrix.package }}-${{ matrix.function }}-${{ github.sha }}
@@ -121,7 +121,7 @@ jobs:
       - name: Upload fuzz failure as artifact
         id: artifact
         if: ${{ failure() && steps.new-failure.outputs.file != '' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: failure-${{ steps.new-failure.outputs.package }}-${{ steps.new-failure.outputs.function }}
           path: ${{ steps.new-failure.outputs.file }}
@@ -143,7 +143,7 @@ jobs:
 
       - name: Create new issue
         if: ${{ failure() && steps.new-failure.outputs.file != '' && inputs.create-issue }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v7.0.1
         with:
           script: |
             const failureName = "${{ steps.new-failure.outputs.name }}";

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -17,13 +17,13 @@ jobs:
       chartpath: ${{ steps.list-changed.outputs.chartpath }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           path: source
 
       - name: Install chart-testing
-        uses: helm/chart-testing-action@v2.7.0
+        uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0
 
       - name: List changed charts
         id: list-changed
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.setup.outputs.changed == 'true'
     steps:
-      - uses: actions/create-github-app-token@v1.12.0
+      - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         id: app-token
         with:
           app-id: ${{ secrets.ALLOYBOT_APP_ID }}
@@ -72,7 +72,7 @@ jobs:
           repositories: alloy,helm-charts
 
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           path: source
@@ -85,7 +85,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Checkout helm-charts
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           repository: grafana/helm-charts
@@ -99,7 +99,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4.3.0
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
         with:
           version: v3.10.3
 
@@ -142,7 +142,7 @@ jobs:
       # The tag name in grafana/helm-charts is <package>-<version>, while the
       # tag name for grafana/alloy is helm-chart/<version>.
       - name: Make github release
-        uses: softprops/action-gh-release@v2.2.1
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
         with:
           name: ${{ steps.parse-chart.outputs.packagename }}
           repository: grafana/helm-charts

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -101,6 +101,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
         with:
+          # renovate: datasource=github-releases packageName=helm/helm
           version: v3.10.3
 
       - name: Parse Chart.yaml

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -17,7 +17,7 @@ jobs:
       chartpath: ${{ steps.list-changed.outputs.chartpath }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
           path: source
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.setup.outputs.changed == 'true'
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v1.12.0
         id: app-token
         with:
           app-id: ${{ secrets.ALLOYBOT_APP_ID }}
@@ -72,7 +72,7 @@ jobs:
           repositories: alloy,helm-charts
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
           path: source
@@ -85,7 +85,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Checkout helm-charts
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
           repository: grafana/helm-charts
@@ -99,7 +99,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v4.3.0
         with:
           version: v3.10.3
 
@@ -142,7 +142,7 @@ jobs:
       # The tag name in grafana/helm-charts is <package>-<version>, while the
       # tag name for grafana/alloy is helm-chart/<version>.
       - name: Make github release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.2.1
         with:
           name: ${{ steps.parse-chart.outputs.packagename }}
           repository: grafana/helm-charts

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
         with:
+          # renovate: datasource=github-releases packageName=helm/helm
           version: v3.10.3
 
       - name: Regenerate tests
@@ -48,6 +49,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
         with:
+          # renovate: datasource=github-releases packageName=helm/helm
           version: v3.10.3
 
       - name: Install Python

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Regenerate docs
         run: |
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v4.3.0
         with:
           version: v3.10.3
 
@@ -41,17 +41,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v4.3.0
         with:
           version: v3.10.3
 
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.5.0
         with:
           python-version: '3.9'
           check-latest: true

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Regenerate docs
         run: |
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install Helm
-        uses: azure/setup-helm@v4.3.0
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
         with:
           version: v3.10.3
 
@@ -41,23 +41,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Install Helm
-        uses: azure/setup-helm@v4.3.0
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
         with:
           version: v3.10.3
 
       - name: Install Python
-        uses: actions/setup-python@v5.5.0
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
           python-version: '3.9'
           check-latest: true
 
       - name: Install chart-testing
-        uses: helm/chart-testing-action@v2.7.0
+        uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0
 
       - name: Determine changed charts
         id: list-changed
@@ -71,7 +71,7 @@ jobs:
         run: ct lint --config ./operations/helm/ct.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.12.0
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Add dependency chart repos

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup Go
-      uses: actions/setup-go@v5.4.0
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
         go-version-file: go.mod
     - name: Set OTEL Exporter Endpoint

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
     - name: Setup Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v5.4.0
       with:
         go-version-file: go.mod
     - name: Set OTEL Exporter Endpoint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,21 +9,21 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v5.4.0
       with:
         go-version-file: go.mod
         cache: false
 
     - name: Lint alloy module
-      uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd #v7
+      uses: golangci/golangci-lint-action@v7.0.0
       with:
         version: v2.0
 
     - name: Lint syntax module
-      uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd #v7
+      uses: golangci/golangci-lint-action@v7.0.0
       with:
         version: v2.0
         working-directory: ./syntax/
@@ -37,7 +37,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
 
     - name: Shellcheck
       uses: Azbagheri/shell-linter@30a9cf3f6cf25c08fc98f10d7dc4167f7b5c0c00 # v0.8.0
@@ -59,10 +59,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v4.4.0
       with:
         node-version: 22
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,12 +20,14 @@ jobs:
     - name: Lint alloy module
       uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
       with:
-        version: v2.0
+        # renovate: datasource=github-releases packageName=golangci/golangci-lint-action
+        version: v2.1.1
 
     - name: Lint syntax module
       uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
       with:
-        version: v2.0
+        # renovate: datasource=github-releases packageName=golangci/golangci-lint-action
+        version: v2.1.1
         working-directory: ./syntax/
 
     - name: Run custom linters

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,21 +9,21 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Set up Go
-      uses: actions/setup-go@v5.4.0
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
         go-version-file: go.mod
         cache: false
 
     - name: Lint alloy module
-      uses: golangci/golangci-lint-action@v7.0.0
+      uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
       with:
         version: v2.0
 
     - name: Lint syntax module
-      uses: golangci/golangci-lint-action@v7.0.0
+      uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
       with:
         version: v2.0
         working-directory: ./syntax/
@@ -37,7 +37,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Shellcheck
       uses: Azbagheri/shell-linter@30a9cf3f6cf25c08fc98f10d7dc4167f7b5c0c00 # v0.8.0
@@ -59,10 +59,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4.4.0
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: 22
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,13 +20,13 @@ jobs:
     - name: Lint alloy module
       uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
       with:
-        # renovate: datasource=github-releases packageName=golangci/golangci-lint-action
+        # renovate: datasource=github-releases packageName=golangci/golangci-lint
         version: v2.1.1
 
     - name: Lint syntax module
       uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
       with:
-        # renovate: datasource=github-releases packageName=golangci/golangci-lint-action
+        # renovate: datasource=github-releases packageName=golangci/golangci-lint
         version: v2.1.1
         working-directory: ./syntax/
 

--- a/.github/workflows/needs-attention.yml
+++ b/.github/workflows/needs-attention.yml
@@ -10,7 +10,7 @@ jobs:
   needs-attention:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9.1.0
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           days-before-stale: 30
           days-before-close: -1 # never close automatically

--- a/.github/workflows/needs-attention.yml
+++ b/.github/workflows/needs-attention.yml
@@ -10,7 +10,7 @@ jobs:
   needs-attention:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v9.1.0
         with:
           days-before-stale: 30
           days-before-close: -1 # never close automatically

--- a/.github/workflows/publish-alloy-devel.yml
+++ b/.github/workflows/publish-alloy-devel.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   publish_windows_container:
-    uses: ./.github/workflows/publish-alloy.yaml
+    uses: ./.github/workflows/publish-alloy.yml
     with:
       img-name: alloy-devel
 
@@ -25,10 +25,10 @@ jobs:
       # We don't want this file to end up in the repo directory.
       # Then "tools/image-tag" would get confused because "git status" no longer reports a clean repo.
     - name: Login to DockerHub (from vault)
-      uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login-v1.0.1
+      uses: grafana/shared-workflows/actions/dockerhub-login@13fb504e3bfe323c1188bf244970d94b2d336e86 # dockerhub-login-v1.0.1
 
     - name: Checkout code
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Set ownership
       # https://github.com/actions/runner/issues/2033#issuecomment-1204205989
@@ -37,16 +37,16 @@ jobs:
           chown -R $(id -u):$(id -g) $PWD
 
     - name: Set up Go
-      uses: actions/setup-go@v5.4.0
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
         go-version-file: go.mod
         cache: false
 
     - run: |
-       docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-       docker buildx create --name multiarch-alloy-alloy-devel-${GITHUB_SHA} --driver docker-container --use
-       ./tools/ci/docker-containers alloy-devel
-       docker buildx rm multiarch-alloy-alloy-devel-${GITHUB_SHA}
+        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        docker buildx create --name multiarch-alloy-alloy-devel-${GITHUB_SHA} --driver docker-container --use
+        ./tools/ci/docker-containers alloy-devel
+        docker buildx rm multiarch-alloy-alloy-devel-${GITHUB_SHA}
 
   publish_linux_boringcrypto_container:
     name: Publish Linux alloy-devel-boringcrypto container
@@ -59,10 +59,10 @@ jobs:
     # We don't want this file to end up in the repo directory.
     # Then "tools/image-tag" would get confused because "git status" no longer reports a clean repo.
     - name: Login to DockerHub (from vault)
-      uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login-v1.0.1
+      uses: grafana/shared-workflows/actions/dockerhub-login@13fb504e3bfe323c1188bf244970d94b2d336e86 # dockerhub-login-v1.0.1
 
     - name: Checkout code
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Set ownership
       # https://github.com/actions/runner/issues/2033#issuecomment-1204205989
@@ -71,7 +71,7 @@ jobs:
           chown -R $(id -u):$(id -g) $PWD
 
     - name: Set up Go
-      uses: actions/setup-go@v5.4.0
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
         go-version-file: go.mod
         cache: false
@@ -91,7 +91,7 @@ jobs:
     steps:
 
     - name: Get Vault secrets
-      uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.1.0
+      uses: grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760 # get-vault-secrets-v1.1.0
       with:
         common_secrets: |
           GITHUB_APP_ID=updater-app:app-id
@@ -99,7 +99,7 @@ jobs:
           GITHUB_APP_PRIVATE_KEY=updater-app:private-key
 
     - name: Checkout code
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Get the image tag
       run: |
@@ -111,7 +111,7 @@ jobs:
       # We don't want this file to end up in the repo directory.
       # Then "tools/image-tag" would get confused because "git status" no longer reports a clean repo.
     - name: Log in to Google Artifact Registry
-      uses: grafana/shared-workflows/actions/login-to-gar@login-to-gar-v0.2.2
+      uses: grafana/shared-workflows/actions/login-to-gar@ebcac324fecb38bbeb7a2e59c82da34010c14014 # login-to-gar-v0.2.2
       with:
         registry: "us-docker.pkg.dev"
         environment: "prod"

--- a/.github/workflows/publish-alloy-devel.yml
+++ b/.github/workflows/publish-alloy-devel.yml
@@ -28,7 +28,7 @@ jobs:
       uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login-v1.0.1
 
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
 
     - name: Set ownership
       # https://github.com/actions/runner/issues/2033#issuecomment-1204205989
@@ -37,7 +37,7 @@ jobs:
           chown -R $(id -u):$(id -g) $PWD
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v5.4.0
       with:
         go-version-file: go.mod
         cache: false
@@ -62,7 +62,7 @@ jobs:
       uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login-v1.0.1
 
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
 
     - name: Set ownership
       # https://github.com/actions/runner/issues/2033#issuecomment-1204205989
@@ -71,7 +71,7 @@ jobs:
           chown -R $(id -u):$(id -g) $PWD
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v5.4.0
       with:
         go-version-file: go.mod
         cache: false
@@ -91,7 +91,7 @@ jobs:
     steps:
 
     - name: Get Vault secrets
-      uses: grafana/shared-workflows/actions/get-vault-secrets@main
+      uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.1.0
       with:
         common_secrets: |
           GITHUB_APP_ID=updater-app:app-id
@@ -99,7 +99,7 @@ jobs:
           GITHUB_APP_PRIVATE_KEY=updater-app:private-key
 
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
 
     - name: Get the image tag
       run: |

--- a/.github/workflows/publish-alloy-release.yml
+++ b/.github/workflows/publish-alloy-release.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   publish_windows_container:
-    uses: ./.github/workflows/publish-alloy.yaml
+    uses: ./.github/workflows/publish-alloy.yml
     with:
       img-name: alloy

--- a/.github/workflows/publish-alloy.yaml
+++ b/.github/workflows/publish-alloy.yaml
@@ -31,10 +31,10 @@ jobs:
       uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login-v1.0.1
 
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v5.4.0
       with:
         go-version-file: go.mod
         cache: false
@@ -48,7 +48,7 @@ jobs:
         $go_version_split = $go_version.ToString().split(".")
         $go_short_version = $go_version_split[0] + "." + $go_version_split[1]
         "alloy_go_version=$go_short_version" >> $env:GITHUB_OUTPUT
-  
+
     - name: Build and publish the container
       # TODO: Run "make alloy-image-windows" instead?
       run: |

--- a/.github/workflows/publish-alloy.yml
+++ b/.github/workflows/publish-alloy.yml
@@ -28,13 +28,13 @@ jobs:
       # We don't want this file to end up in the repo directory.
       # Then "tools/image-tag" would get confused because "git status" no longer reports a clean repo.
     - name: Login to DockerHub (from vault)
-      uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login-v1.0.1
+      uses: grafana/shared-workflows/actions/dockerhub-login@13fb504e3bfe323c1188bf244970d94b2d336e86 # dockerhub-login-v1.0.1
 
     - name: Checkout code
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Set up Go
-      uses: actions/setup-go@v5.4.0
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
         go-version-file: go.mod
         cache: false

--- a/.github/workflows/publish-documentation-next.yml
+++ b/.github/workflows/publish-documentation-next.yml
@@ -15,7 +15,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
-      - uses: grafana/writers-toolkit/publish-technical-documentation@publish-technical-documentation/v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: grafana/writers-toolkit/publish-technical-documentation@39cdc38767184996e25d611923f8ce697e33bc70 # publish-technical-documentation/v1
         with:
           website_directory: content/docs/alloy/next

--- a/.github/workflows/publish-documentation-next.yml
+++ b/.github/workflows/publish-documentation-next.yml
@@ -15,7 +15,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
       - uses: grafana/writers-toolkit/publish-technical-documentation@publish-technical-documentation/v1
         with:
           website_directory: content/docs/alloy/next

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
       - uses: grafana/writers-toolkit/publish-technical-documentation-release@publish-technical-documentation-release/v1

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -17,10 +17,10 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: grafana/writers-toolkit/publish-technical-documentation-release@publish-technical-documentation-release/v1
+      - uses: grafana/writers-toolkit/publish-technical-documentation-release@d83ba5389fb8de1458b12bcc35ad4a4059883029 # publish-technical-documentation-release/v1
         with:
           release_tag_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
           release_branch_regexp: "^release/v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -10,6 +10,6 @@ on:
 
 jobs:
   snyk-scan-ci:
-    uses: grafana/security-github-actions/.github/workflows/snyk_monitor.yml@main
+    uses: grafana/security-github-actions/.github/workflows/snyk_monitor.yml@ae330403c3a5a8b6aaa653ce6f3d059b3a772488 # main
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -4,12 +4,12 @@ on:
    types: [published]
  push:
     branches:
-      - 'main'
-      - 'master'
+      - main
+      - master
  workflow_dispatch:
 
 jobs:
   snyk-scan-ci:
-    uses: 'grafana/security-github-actions/.github/workflows/snyk_monitor.yml@main'
+    uses: grafana/security-github-actions/.github/workflows/snyk_monitor.yml@main
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -17,14 +17,14 @@ jobs:
         - /var/run/docker.sock
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set ownership
       # https://github.com/actions/runner/issues/2033#issuecomment-1204205989
       run: |
           # this is to fix GIT not liking owner of the checkout dir
           chown -R $(id -u):$(id -g) $PWD
     - name: Set up Go
-      uses: actions/setup-go@v5.4.0
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
         go-version-file: go.mod
         # TODO: Enable caching later.

--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -17,14 +17,14 @@ jobs:
         - /var/run/docker.sock
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
     - name: Set ownership
       # https://github.com/actions/runner/issues/2033#issuecomment-1204205989
       run: |
           # this is to fix GIT not liking owner of the checkout dir
           chown -R $(id -u):$(id -g) $PWD
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v5.4.0
       with:
         go-version-file: go.mod
         # TODO: Enable caching later.

--- a/.github/workflows/test_linux_system_packages.yml
+++ b/.github/workflows/test_linux_system_packages.yml
@@ -18,14 +18,14 @@ jobs:
         - /var/run/docker.sock
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
     - name: Set ownership
       # https://github.com/actions/runner/issues/2033#issuecomment-1204205989
       run: |
           # this is to fix GIT not liking owner of the checkout dir
           chown -R $(id -u):$(id -g) $PWD
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v5.4.0
       with:
         go-version-file: go.mod
         # TODO: Enable caching later

--- a/.github/workflows/test_linux_system_packages.yml
+++ b/.github/workflows/test_linux_system_packages.yml
@@ -18,14 +18,14 @@ jobs:
         - /var/run/docker.sock
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set ownership
       # https://github.com/actions/runner/issues/2033#issuecomment-1204205989
       run: |
           # this is to fix GIT not liking owner of the checkout dir
           chown -R $(id -u):$(id -g) $PWD
     - name: Set up Go
-      uses: actions/setup-go@v5.4.0
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
         go-version-file: go.mod
         # TODO: Enable caching later

--- a/.github/workflows/test_mac.yml
+++ b/.github/workflows/test_mac.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v5.4.0
       with:
         go-version-file: go.mod
         cache: true

--- a/.github/workflows/test_mac.yml
+++ b/.github/workflows/test_mac.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Go
-      uses: actions/setup-go@v5.4.0
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
         go-version-file: go.mod
         cache: true

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v5.4.0
       with:
         go-version-file: go.mod
         cache: false

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Set up Go
-      uses: actions/setup-go@v5.4.0
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
         go-version-file: go.mod
         cache: false

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Go
-      uses: actions/setup-go@v5.4.0
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
         go-version-file: go.mod
         # TODO: Enable caching later.

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -1,6 +1,6 @@
 name: Test (Windows)
 on:
-  # TODO: Run the Windows tests for each PR? 
+  # TODO: Run the Windows tests for each PR?
   # For now we don't do it just because it takes time.
   push:
     # TODO: Also run the tests when a Windows-specific features is changed.
@@ -13,9 +13,9 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v5.4.0
       with:
         go-version-file: go.mod
         # TODO: Enable caching later.

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -24,9 +24,9 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@99baf0d8b4e787c3cfd7b602664c8ce60a43cd38
+        uses: aquasecurity/trivy-action@0.30.0
         with:
           image-ref: 'grafana/alloy-dev:latest'
           format: 'template'
@@ -35,6 +35,6 @@ jobs:
           severity: 'CRITICAL,HIGH,MEDIUM,LOW'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v3.28.15
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -24,9 +24,9 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5 # 0.30.0
         with:
           image-ref: 'grafana/alloy-dev:latest'
           format: 'template'
@@ -35,6 +35,6 @@ jobs:
           severity: 'CRITICAL,HIGH,MEDIUM,LOW'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3.28.15
+        uses: github/codeql-action/upload-sarif@45775bd8235c68ba998cffa5171334d58593da47 # v3.28.15
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/update-make-docs.yml
+++ b/.github/workflows/update-make-docs.yml
@@ -8,5 +8,5 @@ jobs:
     if: github.repository == 'grafana/alloy'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
-      - uses: grafana/writers-toolkit/update-make-docs@update-make-docs/v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: grafana/writers-toolkit/update-make-docs@f65819d6a412b752c0e0263375215f049507b0e6 # update-make-docs/v1

--- a/.github/workflows/update-make-docs.yml
+++ b/.github/workflows/update-make-docs.yml
@@ -8,5 +8,5 @@ jobs:
     if: github.repository == 'grafana/alloy'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
       - uses: grafana/writers-toolkit/update-make-docs@update-make-docs/v1


### PR DESCRIPTION
As per recommended security guidelines, this PR pins all workflow dependencies to specific hashes. Updates will be handled by renovatebot.

Also updates some .yaml workflow files to .yml like the rest.

Big "thank you" to this tool for easing this transition:
https://github.com/mheap/pin-github-action