### PR TITLE
docs: improve docs for `loki.secretfilter` component

### DIFF
--- a/docs/sources/reference/components/loki/loki.secretfilter.md
+++ b/docs/sources/reference/components/loki/loki.secretfilter.md
@@ -10,9 +10,9 @@ labels:
 
 {{< docs/shared lookup="stability/experimental.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
-`loki.secretfilter` receives log entries and redacts detected secrets from them.
-The detection is based on regular expression patterns, defined in the [Gitleaks configuration file](#arguments) embedded within the component.
-`loki.secretfilter` can also use a custom configuration file based on the Gitleaks configuration file structure.
+`loki.secretfilter` receives log entries and redacts detected secrets from the log lines.
+The detection is based on regular expression patterns, defined in a Gitleaks configuration file embedded within the component.
+`loki.secretfilter` can also use a [custom configuration file](#arguments) based on the [Gitleaks configuration file structure][gitleaks-config].
 
 {{< admonition type="caution" >}}
 Personally Identifiable Information (PII) isn't currently in scope and some secrets could remain undetected.
@@ -23,6 +23,8 @@ Don't rely solely on this component to redact sensitive information.
 {{< admonition type="note" >}}
 This component operates on log lines and doesn't scan labels or other metadata.
 {{< /admonition >}}
+
+[gitleaks-config]: https://github.com/gitleaks/gitleaks/blob/master/config/gitleaks.toml
 
 ## Usage
 
@@ -50,7 +52,7 @@ The `gitleaks_config` argument is the path to the custom `gitleaks.toml` file.
 The Gitleaks configuration file [embedded in the component][embedded-config] is used if you don't provide the path to a custom configuration file.
 
 {{< admonition type="note" >}}
-This component doesn't support all the features of the [Gitleaks configuration file][gitleaks-config].
+This component doesn't support all the features of the Gitleaks configuration file.
 It only supports regular expression-based rules, `secretGroup`, and allowlist regular expressions. `regexTarget` only supports the default value `secret`.
 Other features such as `keywords`, `entropy`, `paths`, and `stopwords` aren't supported.
 The `extend` feature isn't supported.
@@ -98,7 +100,6 @@ The `origin_label` argument specifies which Loki label value to use for the `sec
 This metric tracks how many secrets were redacted in logs from different sources or environments.
 
 [embedded-config]: https://github.com/grafana/alloy/blob/{{< param "ALLOY_RELEASE" >}}/internal/component/loki/secretfilter/gitleaks.toml
-[gitleaks-config]: https://github.com/gitleaks/gitleaks/blob/master/config/gitleaks.toml
 
 ## Blocks
 

--- a/docs/sources/reference/components/loki/loki.secretfilter.md
+++ b/docs/sources/reference/components/loki/loki.secretfilter.md
@@ -11,7 +11,7 @@ labels:
 {{< docs/shared lookup="stability/experimental.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 `loki.secretfilter` receives log entries and redacts detected secrets from the log lines.
-The detection is based on regular expression patterns, defined in a Gitleaks configuration file embedded within the component.
+The detection is based on regular expression patterns, defined in the Gitleaks configuration file embedded within the component.
 `loki.secretfilter` can also use a [custom configuration file](#arguments) based on the [Gitleaks configuration file structure][gitleaks-config].
 
 {{< admonition type="caution" >}}
@@ -99,7 +99,7 @@ For short secrets, at most half of the secret is shown.
 The `origin_label` argument specifies which Loki label value to use for the `secrets_redacted_by_origin` metric.
 This metric tracks how many secrets were redacted in logs from different sources or environments.
 
-[embedded-config]: https://github.com/grafana/alloy/blob/<ALLOY_VERSION>/internal/component/loki/secretfilter/gitleaks.toml
+[embedded-config]: https://github.com/grafana/alloy/blob/{{< param "ALLOY_RELEASE" >}}/internal/component/loki/secretfilter/gitleaks.toml
 
 ## Blocks
 

--- a/docs/sources/reference/components/loki/loki.secretfilter.md
+++ b/docs/sources/reference/components/loki/loki.secretfilter.md
@@ -10,8 +10,8 @@ labels:
 
 {{< docs/shared lookup="stability/experimental.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
-`loki.secretfilter` receives log entries and redacts sensitive information from them, such as secrets.
-The detection is based on regular expression patterns, defined in the [Gitleaks configuration file][gitleaks] embedded within the component.
+`loki.secretfilter` receives log entries and redacts detected secrets from them.
+The detection is based on regular expression patterns, defined in the [Gitleaks configuration file](#arguments) embedded within the component.
 `loki.secretfilter` can also use a custom configuration file based on the Gitleaks configuration file structure.
 
 {{< admonition type="caution" >}}
@@ -23,8 +23,6 @@ Don't rely solely on this component to redact sensitive information.
 {{< admonition type="note" >}}
 This component operates on log lines and doesn't scan labels or other metadata.
 {{< /admonition >}}
-
-[gitleaks]: https://github.com/gitleaks/gitleaks/blob/master/config/gitleaks.toml
 
 ## Usage
 
@@ -49,15 +47,19 @@ loki.secretfilter "<LABEL>" {
 | `types`           | `map(string)`        | Types of secret to look for.                               | All types                        | no       |
 
 The `gitleaks_config` argument is the path to the custom `gitleaks.toml` file.
-The Gitleaks configuration file embedded in the component is used if you don't provide the path to a custom configuration file.
+The Gitleaks configuration file [embedded in the component][embedded-config] is used if you don't provide the path to a custom configuration file.
 
 {{< admonition type="note" >}}
-This component doesn't support all the features of the Gitleaks configuration file.
+This component doesn't support all the features of the [Gitleaks configuration file][gitleaks-config].
 It only supports regular expression-based rules, `secretGroup`, and allowlist regular expressions. `regexTarget` only supports the default value `secret`.
 Other features such as `keywords`, `entropy`, `paths`, and `stopwords` aren't supported.
 The `extend` feature isn't supported.
 If you use a custom configuration file, you must include all the rules you want to use within the configuration file.
 Unsupported fields and values in the configuration file are ignored.
+{{< /admonition >}}
+
+{{< admonition type="note" >}}
+The embedded configuration file can change from one version of Alloy to another. It's advised to use an external configuration file to ensure consistency.
 {{< /admonition >}}
 
 The `types` argument is a map of secret types to look for.
@@ -94,6 +96,9 @@ For short secrets, at most half of the secret is shown.
 
 The `origin_label` argument specifies which Loki label value to use for the `secrets_redacted_by_origin` metric.
 This metric tracks how many secrets were redacted in logs from different sources or environments.
+
+[embedded-config]: https://github.com/grafana/alloy/blob/{{< param "ALLOY_RELEASE" >}}/internal/component/loki/secretfilter/gitleaks.toml
+[gitleaks-config]: https://github.com/gitleaks/gitleaks/blob/master/config/gitleaks.toml
 
 ## Blocks
 

--- a/docs/sources/reference/components/loki/loki.secretfilter.md
+++ b/docs/sources/reference/components/loki/loki.secretfilter.md
@@ -61,7 +61,7 @@ Unsupported fields and values in the configuration file are ignored.
 {{< /admonition >}}
 
 {{< admonition type="note" >}}
-The embedded configuration file may change between Alloy versions.
+The embedded configuration file may change between {{< param "PRODUCT_NAME" >}} versions.
 To ensure consistency, use an external configuration file.
 {{< /admonition >}}
 

--- a/docs/sources/reference/components/loki/loki.secretfilter.md
+++ b/docs/sources/reference/components/loki/loki.secretfilter.md
@@ -11,7 +11,7 @@ labels:
 {{< docs/shared lookup="stability/experimental.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 `loki.secretfilter` receives log entries and redacts detected secrets from the log lines.
-The detection is based on regular expression patterns, defined in the Gitleaks configuration file embedded within the component.
+The detection relies on regular expression patterns, defined in the Gitleaks configuration file embedded within the component.
 `loki.secretfilter` can also use a [custom configuration file](#arguments) based on the [Gitleaks configuration file structure][gitleaks-config].
 
 {{< admonition type="caution" >}}
@@ -49,7 +49,7 @@ loki.secretfilter "<LABEL>" {
 | `types`           | `map(string)`        | Types of secret to look for.                               | All types                        | no       |
 
 The `gitleaks_config` argument is the path to the custom `gitleaks.toml` file.
-The Gitleaks configuration file [embedded in the component][embedded-config] is used if you don't provide the path to a custom configuration file.
+If you don't provide the path to a custom configuration file, the Gitleaks configuration file [embedded in the component][embedded-config] is used.
 
 {{< admonition type="note" >}}
 This component doesn't support all the features of the Gitleaks configuration file.
@@ -61,7 +61,8 @@ Unsupported fields and values in the configuration file are ignored.
 {{< /admonition >}}
 
 {{< admonition type="note" >}}
-The embedded configuration file can change from one version of Alloy to another. It's advised to use an external configuration file to ensure consistency.
+The embedded configuration file may change between Alloy versions.
+To ensure consistency, use an external configuration file.
 {{< /admonition >}}
 
 The `types` argument is a map of secret types to look for.

--- a/docs/sources/reference/components/loki/loki.secretfilter.md
+++ b/docs/sources/reference/components/loki/loki.secretfilter.md
@@ -99,7 +99,7 @@ For short secrets, at most half of the secret is shown.
 The `origin_label` argument specifies which Loki label value to use for the `secrets_redacted_by_origin` metric.
 This metric tracks how many secrets were redacted in logs from different sources or environments.
 
-[embedded-config]: https://github.com/grafana/alloy/blob/{{< param "ALLOY_RELEASE" >}}/internal/component/loki/secretfilter/gitleaks.toml
+[embedded-config]: https://github.com/grafana/alloy/blob/<ALLOY_VERSION>/internal/component/loki/secretfilter/gitleaks.toml
 
 ## Blocks
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR improves the documentation of the `loki.secretfilter` component by making clearer which version of the embedded gitleaks configuration file is included in each version. Also provides advice on using a specific file to ensure consistency when updating Alloy.

#### Which issue(s) this PR fixes
None

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [X] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
