### PR TITLE
fix(podlogs): add missing labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Main (unreleased)
 
 - Fix `otelcol.exporter.prometheus` dropping valid exemplars. (@github-vincent-miszczak)
 
+- Fix `loki.source.podlogs` add missing labels `__meta_kubernetes_pod_name` and `__meta_kubernetes_pod_label_*`. (@kalleep)
+
 ### Other changes
 
 - Update the zap logging adapter used by `otelcol` components to log arrays and objects. (@dehaansa)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Main (unreleased)
 
 - Fix `otelcol.exporter.prometheus` dropping valid exemplars. (@github-vincent-miszczak)
 
-- Fix `loki.source.podlogs` add missing labels `__meta_kubernetes_pod_name` and `__meta_kubernetes_pod_label_*`. (@kalleep)
+- Fix `loki.source.podlogs` add missing labels `__meta_kubernetes_namespace` and `__meta_kubernetes_pod_label_*`. (@kalleep)
 
 ### Other changes
 

--- a/internal/component/loki/source/podlogs/reconciler.go
+++ b/internal/component/loki/source/podlogs/reconciler.go
@@ -275,7 +275,7 @@ func (r *reconciler) reconcilePodLogs(ctx context.Context, cli client.Client, po
 		podTargetLabels := buildPodsAndNamespacesTargetLabels(podLogsTargetLabels, pod, namespace)
 
 		handleContainer := func(container *corev1.Container, initContainer bool) {
-			targetLabels := buildTargetLabels(discoveredContainer{
+			targetLabels := buildContainerTargetLabels(discoveredContainer{
 				PodLogs:       podLogs,
 				Pod:           &pod,
 				Container:     container,
@@ -407,7 +407,8 @@ type discoveredContainer struct {
 	InitContainer bool
 }
 
-func buildTargetLabels(opts discoveredContainer, prediscoveredLabels promlabels.Labels) promlabels.Labels {
+// buildContainerTargetLabels builds the target labels for a container and merge it with prediscoveredLabels.
+func buildContainerTargetLabels(opts discoveredContainer, prediscoveredLabels promlabels.Labels) promlabels.Labels {
 	targetLabels := promlabels.NewBuilder(prediscoveredLabels)
 
 	targetLabels.Set(kubePodContainerInit, fmt.Sprint(opts.InitContainer))

--- a/internal/component/loki/source/podlogs/reconciler.go
+++ b/internal/component/loki/source/podlogs/reconciler.go
@@ -34,6 +34,7 @@ const (
 	kubePodlogsAnnotation        = "__meta_kubernetes_podlogs_annotation_"
 	kubePodlogsAnnotationPresent = "__meta_kubernetes_podlogs_annotationpresent_"
 
+	kubeNamespace                  = "__meta_kubernetes_namespace"
 	kubeNamespaceLabel             = "__meta_kubernetes_namespace_label_"
 	kubeNamespaceLabelPresent      = "__meta_kubernetes_namespace_labelpresent_"
 	kubeNamespaceAnnotation        = "__meta_kubernetes_namespace_annotation_"
@@ -318,6 +319,14 @@ func (r *reconciler) reconcilePodLogs(ctx context.Context, cli client.Client, po
 	return targets, discoveredPodLogs
 }
 
+// DebugInfo returns the current debug information for the reconciler.
+func (r *reconciler) DebugInfo() []DiscoveredPodLogs {
+	r.debugMut.RLock()
+	defer r.debugMut.RUnlock()
+
+	return r.debugInfo
+}
+
 // buildPodLogsTargetLabels builds the target labels for a PodLogs object.
 func buildPodLogsTargetLabels(podLogs *monitoringv1alpha2.PodLogs) promlabels.Labels {
 	podLogsTargetLabels := promlabels.NewBuilder(nil)
@@ -341,7 +350,8 @@ func buildPodLogsTargetLabels(podLogs *monitoringv1alpha2.PodLogs) promlabels.La
 func buildPodsAndNamespacesTargetLabels(podLogsTargetLabels promlabels.Labels, pod corev1.Pod, namespace corev1.Namespace) promlabels.Labels {
 	podTargetLabels := promlabels.NewBuilder(podLogsTargetLabels)
 
-	podTargetLabels.Set(kubetail.LabelPodNamespace, pod.Namespace)
+	// Namespace specific labels
+	podTargetLabels.Set(kubeNamespace, pod.Namespace)
 	for key, value := range namespace.Labels {
 		key = strutil.SanitizeLabelName(key)
 		podTargetLabels.Set(kubeNamespaceLabel+key, value)
@@ -353,27 +363,41 @@ func buildPodsAndNamespacesTargetLabels(podLogsTargetLabels promlabels.Labels, p
 		podTargetLabels.Set(kubeNamespaceAnnotationPresent+key, "true")
 	}
 
+	// Pod specific labels
+	podTargetLabels.Set(kubePodUID, string(pod.UID))
 	podTargetLabels.Set(kubePodName, pod.Name)
+	podTargetLabels.Set(kubePodNodeName, pod.Spec.NodeName)
 	podTargetLabels.Set(kubePodIP, pod.Status.PodIP)
+	podTargetLabels.Set(kubePodHostIP, pod.Status.HostIP)
+	podTargetLabels.Set(kubePodReady, string(podReady(&pod)))
+	podTargetLabels.Set(kubePodPhase, string(pod.Status.Phase))
+
 	for key, value := range pod.Labels {
 		key = strutil.SanitizeLabelName(key)
-		podTargetLabels.Set(kubePodLabelPresent+key, value)
+		podTargetLabels.Set(kubePodLabel+key, value)
 		podTargetLabels.Set(kubePodLabelPresent+key, "true")
 	}
+
 	for key, value := range pod.Annotations {
 		key = strutil.SanitizeLabelName(key)
 		podTargetLabels.Set(kubePodAnnotation+key, value)
 		podTargetLabels.Set(kubePodAnnotationPresent+key, "true")
 	}
+
+	for _, ref := range pod.GetOwnerReferences() {
+		if ref.Controller != nil && *ref.Controller {
+			podTargetLabels.Set(kubePodControllerKind, ref.Kind)
+			podTargetLabels.Set(kubePodControllerName, ref.Name)
+			break
+		}
+	}
+
+	// Add labels needed for collecting.
+	podTargetLabels.Set(kubetail.LabelPodNamespace, pod.Namespace)
+	podTargetLabels.Set(kubetail.LabelPodName, pod.Name)
+	podTargetLabels.Set(kubetail.LabelPodUID, string(pod.GetUID()))
+
 	return podTargetLabels.Labels()
-}
-
-// DebugInfo returns the current debug information for the reconciler.
-func (r *reconciler) DebugInfo() []DiscoveredPodLogs {
-	r.debugMut.RLock()
-	defer r.debugMut.RUnlock()
-
-	return r.debugInfo
 }
 
 type discoveredContainer struct {
@@ -389,25 +413,9 @@ func buildTargetLabels(opts discoveredContainer, prediscoveredLabels promlabels.
 	targetLabels.Set(kubePodContainerInit, fmt.Sprint(opts.InitContainer))
 	targetLabels.Set(kubePodContainerName, opts.Container.Name)
 	targetLabels.Set(kubePodContainerImage, opts.Container.Image)
-	targetLabels.Set(kubePodReady, string(podReady(opts.Pod)))
-	targetLabels.Set(kubePodPhase, string(opts.Pod.Status.Phase))
-	targetLabels.Set(kubePodNodeName, opts.Pod.Spec.NodeName)
-	targetLabels.Set(kubePodHostIP, opts.Pod.Status.HostIP)
-	targetLabels.Set(kubePodUID, string(opts.Pod.UID))
-
-	for _, ref := range opts.Pod.GetOwnerReferences() {
-		if ref.Controller != nil && *ref.Controller {
-			targetLabels.Set(kubePodControllerKind, ref.Kind)
-			targetLabels.Set(kubePodControllerName, ref.Name)
-			break
-		}
-	}
 
 	// Add labels needed for collecting.
-	targetLabels.Set(kubetail.LabelPodNamespace, opts.Pod.Namespace)
-	targetLabels.Set(kubetail.LabelPodName, opts.Pod.Name)
 	targetLabels.Set(kubetail.LabelPodContainerName, opts.Container.Name)
-	targetLabels.Set(kubetail.LabelPodUID, string(opts.Pod.GetUID()))
 
 	// Add default labels (job, instance)
 	targetLabels.Set(model.InstanceLabel, fmt.Sprintf("%s/%s:%s", opts.Pod.Namespace, opts.Pod.Name, opts.Container.Name))

--- a/internal/component/loki/source/podlogs/reconciler_test.go
+++ b/internal/component/loki/source/podlogs/reconciler_test.go
@@ -216,7 +216,6 @@ func TestReconcilePodLogs_DefaultLabels(t *testing.T) {
 	}
 	if discoveryLabelsMap[kubePodlogsName] != podLogs.Name {
 		t.Errorf("expected pod logs name %q, got %q", podLogs.Name, labelsMap[kubePodlogsName])
-
 	}
 
 	for k, v := range podLogs.Labels {


### PR DESCRIPTION
#### PR Description

After https://github.com/grafana/alloy/pull/3024 we no longer set `__meta_kubernetes_namespace` and `__meta_kubernetes_pod_label_*`.

In this pr I also moved some left over pod specific labels into `buildPodsAndNamespacesTargetLabels` from `buildContainerTargetLabels` and added test for `annotation_*` and `label_*` labels for pod, podlog and namespace.

#### Which issue(s) this PR fixes

Fixes https://github.com/grafana/alloy/issues/3311

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
