### PR TITLE
ci: enable go in renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -46,9 +46,9 @@
     },
     {
       "matchManagers": ["gomod"],
-      // "matchUpdateTypes": ["minor", "patch"],
-      // "groupName": "go dependencies (minor, patch)",
-      "enabled": false // TODO: enable when ready
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "go dependencies (minor, patch)",
+      "enabled": true
     },
     {
       "matchManagers": ["helm-values"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -50,15 +50,15 @@
       "groupName": "go dependencies (minor, patch)",
     },
     {
-      // Disable renovate for specific go dependencies
-      // TODO: can renovate help make these updates easier?
+      // Group and hold some otel-specific go dependencies
       "matchManagers": ["gomod"],
       "matchPackageNames": [
-      // OpenTelemetry needs special handling due to a temporary fork
+        // OpenTelemetry needs special handling due to a temporary fork
         "github.com/open-telemetry/opentelemetry-collector-contrib/*",
         "go.opentelemetry.io/collector"
       ],
-      "enabled": false
+      "groupName": "go otel collector dependencies"
+      "dependencyDashboardApproval": true
     }
     {
       "matchManagers": ["helm-values"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,14 +29,14 @@
       "matchManagers": ["docker-compose"],
       // "matchUpdateTypes": ["minor", "patch"],
       // "groupName": "docker-compose dependencies (minor, patch)",
-      "enabled": false // TODO: enable when ready
+      "enabled": false // TODO: remove to enable when ready
     },
     {
       "matchManagers": ["dockerfile"],
       // "matchUpdateTypes": ["minor", "patch"],
       // "groupName": "dockerfile dependencies (minor, patch)",
       // "pinDigests": true,
-      "enabled": false // TODO: enable when ready
+      "enabled": false // TODO: remove to enable when ready
     },
     {
       "matchManagers": ["github-actions"],
@@ -48,25 +48,35 @@
       "matchManagers": ["gomod"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "go dependencies (minor, patch)",
-      "enabled": true
     },
+    {
+      // Disable renovate for specific go dependencies
+      // TODO: can renovate help make these updates easier?
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+      // OpenTelemetry needs special handling due to a temporary fork
+        "github.com/open-telemetry/opentelemetry-collector-contrib/*",
+        "go.opentelemetry.io/collector"
+      ],
+      "enabled": false
+    }
     {
       "matchManagers": ["helm-values"],
       // "matchUpdateTypes": ["minor", "patch"],
       // "groupName": "helm-values dependencies (minor, patch)",
-      "enabled": false // TODO: enable when ready
+      "enabled": false // TODO: remove to enable when ready
     },
     {
       "matchManagers": ["helmv3"],
       // "matchUpdateTypes": ["minor", "patch"],
       // "groupName": "helmv3 dependencies (minor, patch)",
-      "enabled": false // TODO: enable when ready
+      "enabled": false // TODO: remove to enable when ready
     },
     {
       "matchManagers": ["jsonnet-bundler"],
       // "matchUpdateTypes": ["minor", "patch"],
       // "groupName": "jsonnet-bundler dependencies (minor, patch)",
-      "enabled": false // TODO: enable when ready
+      "enabled": false // TODO: remove to enable when ready
     },
     {
       "matchManagers": ["npm"],


### PR DESCRIPTION
Fixes #3185

Enables Go dependency management for Renovatebot in the same way as Node.js.

## Notes:

There are a couple otel collector dependencies that have been handled separately in the past by disabling dependabot from managing them. The renovate config is set up as follows:

- Group these otel dependencies together
- Do not automatically create a PR for them
- Show them on the [dependency dashboard](https://github.com/grafana/alloy/issues/3260)
- If a user checks the box on the dashboard, the singular PR will be created grouping them all together. This PR can be used to make whatever changes are needed to support the updates as a group.
