### PR TITLE
Fix homebrew updater workflow

### DIFF
--- a/.github/actions/homebrew-bump-formula/Formula/test-formula-git-revision.rb
+++ b/.github/actions/homebrew-bump-formula/Formula/test-formula-git-revision.rb
@@ -1,0 +1,21 @@
+class TestFormulaGitRevision < Formula
+  desc "Formula to test Action"
+  homepage "https://github.com/Debian/dh-make-golang"
+  url "https://github.com/Debian/dh-make-golang.git",
+    tag:      "v0.3.2",
+    revision: "82916c0d56b6319398f635199222dff397fafc12"
+  license "MIT"
+  head "https://github.com/Debian/dh-make-golang.git"
+
+  def install
+    (buildpath/"test").write <<~EOS
+      test
+    EOS
+
+    share.install "test"
+  end
+
+  test do
+    sleep 1
+  end
+end

--- a/.github/actions/homebrew-bump-formula/Formula/test-formula-pypi-url.rb
+++ b/.github/actions/homebrew-bump-formula/Formula/test-formula-pypi-url.rb
@@ -1,0 +1,54 @@
+class TestFormulaPypiUrl < Formula
+  include Language::Python::Virtualenv
+
+  desc "Formula to test Action"
+  homepage "https://commitizen-tools.github.io/commitizen/"
+  url "https://files.pythonhosted.org/packages/a1/14/3ad1772b81f1e2f7c91ac99987c0ac72a50ebe2a06967cf9a3eea81dd0d0/commitizen-2.14.0.tar.gz"
+  sha256 "afc68d9d61c8338beeb6145a8276e97a342a16f4f721c8ff654403043240cec0"
+  license "MIT"
+  head "https://github.com/commitizen-tools/commitizen.git"
+
+  depends_on "python@3.9"
+
+  resource "argcomplete" do
+    url "https://files.pythonhosted.org/packages/cb/53/d2e3d11726367351b00c8f078a96dacb7f57aef2aca0d3b6c437afc56b55/argcomplete-1.12.2.tar.gz"
+    sha256 "de0e1282330940d52ea92a80fea2e4b9e0da1932aaa570f84d268939d1897b04"
+  end
+
+  resource "colorama" do
+    url "https://files.pythonhosted.org/packages/1f/bb/5d3246097ab77fa083a61bd8d3d527b7ae063c7d8e8671b1cf8c4ec10cbe/colorama-0.4.4.tar.gz"
+    sha256 "5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"
+  end
+
+  resource "decli" do
+    url "https://files.pythonhosted.org/packages/9f/30/064f53ca7b75c33a892dcc4230f78a1e01bee4b5b9b49c0be1a61601c9bd/decli-0.5.2.tar.gz"
+    sha256 "f2cde55034a75c819c630c7655a844c612f2598c42c21299160465df6ad463ad"
+  end
+
+  resource "Jinja2" do
+    url "https://files.pythonhosted.org/packages/4f/e7/65300e6b32e69768ded990494809106f87da1d436418d5f1367ed3966fd7/Jinja2-2.11.3.tar.gz"
+    sha256 "a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6"
+  end
+
+  resource "MarkupSafe" do
+    url "https://files.pythonhosted.org/packages/b9/2e/64db92e53b86efccfaea71321f597fa2e1b2bd3853d8ce658568f7a13094/MarkupSafe-1.1.1.tar.gz"
+    sha256 "29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"
+  end
+
+  resource "packaging" do
+    url "https://files.pythonhosted.org/packages/86/3c/bcd09ec5df7123abcf695009221a52f90438d877a2f1499453c6938f5728/packaging-20.9.tar.gz"
+    sha256 "5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5"
+  end
+
+  def install
+    (buildpath/"test").write <<~EOS
+      test
+    EOS
+
+    share.install "test"
+  end
+
+  test do
+    sleep 1
+  end
+end

--- a/.github/actions/homebrew-bump-formula/Formula/test-formula-url.rb
+++ b/.github/actions/homebrew-bump-formula/Formula/test-formula-url.rb
@@ -1,0 +1,19 @@
+class TestFormulaUrl < Formula
+  desc "Formula to test Action"
+  homepage "https://github.com/dawidd6/actions-updater"
+  url "https://github.com/dawidd6/actions-updater/archive/v0.1.11.tar.gz"
+  sha256 "b1c83ee9d19289eb403ad0863c235fa9c3b3a980c9b13a43cda9fc9413935df4"
+  license "MIT"
+
+  def install
+    (buildpath/"test").write <<~EOS
+      test
+    EOS
+
+    share.install "test"
+  end
+
+  test do
+    sleep 1
+  end
+end

--- a/.github/actions/homebrew-bump-formula/LICENSE
+++ b/.github/actions/homebrew-bump-formula/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2020 Dawid Dziurla
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/.github/actions/homebrew-bump-formula/README.md
+++ b/.github/actions/homebrew-bump-formula/README.md
@@ -1,0 +1,6 @@
+This folder is a fork of another GitHub Action:
+https://github.com/dawidd6/action-homebrew-bump-formula
+
+The fork is needed in order to incorporate this change:
+https://github.com/dawidd6/action-homebrew-bump-formula/pull/90
+

--- a/.github/actions/homebrew-bump-formula/action.yml
+++ b/.github/actions/homebrew-bump-formula/action.yml
@@ -1,0 +1,116 @@
+name: Homebrew bump formula
+description: Bump (update) a Homebrew formula on new project release
+author: dawidd6
+branding:
+  icon: arrow-up-circle
+  color: yellow
+inputs:
+  token:
+    description: GitHub token (not the default one)
+    required: true
+  user_name:
+    description: Git user name to commit by.
+    required: false
+  user_email:
+    description: Git user email to commit by.
+    required: false
+  message:
+    description: |
+      Additional message to append to created PR.
+    required: false
+  org:
+    description: |
+      Fork tap repository to selected GitHub organization.
+    required: false
+  no_fork:
+    description: |
+      Use the origin repository instead of forking.
+    required: false
+  tap:
+    description: |
+      Formula tap.
+
+      In livecheck mode, if formula input is empty,
+      the Action will check the whole tap.
+
+      Example: dawidd6/tap
+      Example: dawidd6/homebrew-tap
+    required: false
+  tap_url:
+    description: |
+      Formula tap URL.
+
+      Specify this if you don't have the repository named $USER/homebrew-$TAP.
+      Or if your tap is hosted somewhere else.
+      If you specify this input, the `tap` input needs to be set too.
+
+      Example: http://github.com/dawidd6/action-homebrew-bump-formula.git
+    required: false
+  formula:
+    description: |
+      Formula name.
+
+      In livecheck mode, this could take more than one formula,
+      separated by commas or spaces or newlines.
+
+      Example: lazygit
+      Example (livecheck): lazygit, lazydocker, lazynpm
+    required: false
+  tag:
+    description: |
+      Git tag.
+
+      It is determined automatically.
+
+      Example: v1.0.0
+      Example: refs/tags/v1.0.0
+    required: false
+    default: ${{github.ref}}
+  revision:
+    description: |
+      Git revision.
+
+      Only required for formulae that use git to download the source.
+
+      It is determined automatically.
+
+      Example: 130d3a3af72f66780ae4e24cd143ae7a4d757f9d
+    required: false
+    default: ${{github.sha}}
+  force:
+    description: Check open PRs or not (will fail if detected)
+    required: false
+  livecheck:
+    description: |
+      Use `brew livecheck` to determine outdated formulae.
+
+      If tap input is specified - check all formulae in this tap.
+      If formula input is specified - check one or more formulae.
+      If formula and tap inputs are specified - check one or more formulae in that tap.
+    required: false
+runs:
+  using: composite
+  steps:
+    - run: echo /home/linuxbrew/.linuxbrew/bin >> $GITHUB_PATH
+      if: ${{runner.os == 'Linux'}}
+      shell: sh
+    - run: brew developer on
+      shell: sh
+    - run: brew update-reset
+      shell: sh
+    - run: brew ruby $GITHUB_ACTION_PATH/main.rb
+      shell: sh
+      env:
+        HOMEBREW_GITHUB_API_TOKEN: ${{inputs.token}}
+        HOMEBREW_GIT_NAME: ${{inputs.user_name}}
+        HOMEBREW_GIT_EMAIL: ${{inputs.user_email}}
+        HOMEBREW_BUMP_MESSAGE: ${{inputs.message}}
+        HOMEBREW_BUMP_ORG: ${{inputs.org}}
+        HOMEBREW_BUMP_NO_FORK: ${{inputs.no_fork}}
+        HOMEBREW_BUMP_TAP: ${{inputs.tap}}
+        HOMEBREW_BUMP_TAP_URL: ${{inputs.tap_url}}
+        HOMEBREW_BUMP_FORMULA: ${{inputs.formula}}
+        HOMEBREW_BUMP_TAG: ${{inputs.tag}}
+        HOMEBREW_BUMP_REVISION: ${{inputs.revision}}
+        HOMEBREW_BUMP_FORCE: ${{inputs.force}}
+        HOMEBREW_BUMP_LIVECHECK: ${{inputs.livecheck}}

--- a/.github/actions/homebrew-bump-formula/bump-formula-pr.rb.patch
+++ b/.github/actions/homebrew-bump-formula/bump-formula-pr.rb.patch
@@ -1,0 +1,12 @@
+diff --git a/Library/Homebrew/dev-cmd/bump-formula-pr.rb b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+index 167ea9134a..e07aecfe83 100644
+--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
++++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+@@ -472,6 +472,7 @@ module Homebrew
+       def check_pull_requests(formula, tap_remote_repo, state: nil, version: nil)
+         tap = formula.tap
+         return if tap.nil?
++        return if args.force?
+ 
+         # if we haven't already found open requests, try for an exact match across all pull requests
+         GitHub.check_for_duplicate_pull_requests(

--- a/.github/actions/homebrew-bump-formula/main.rb
+++ b/.github/actions/homebrew-bump-formula/main.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+require 'formula'
+
+class Object
+  def false?
+    nil?
+  end
+end
+
+class String
+  def false?
+    empty? || strip == 'false'
+  end
+end
+
+module Homebrew
+  module_function
+
+  def print_command(*cmd)
+    puts "[command]#{cmd.join(' ').gsub("\n", ' ')}"
+  end
+
+  def brew(*args)
+    print_command ENV["HOMEBREW_BREW_FILE"], *args
+    safe_system ENV["HOMEBREW_BREW_FILE"], *args
+  end
+
+  def git(*args)
+    print_command ENV["HOMEBREW_GIT"], *args
+    safe_system ENV["HOMEBREW_GIT"], *args
+  end
+
+  def read_brew(*args)
+    print_command ENV["HOMEBREW_BREW_FILE"], *args
+    output = `#{ENV["HOMEBREW_BREW_FILE"]} #{args.join(' ')}`.chomp
+    odie output if $CHILD_STATUS.exitstatus != 0
+    output
+  end
+
+  # Get inputs
+  message = ENV['HOMEBREW_BUMP_MESSAGE']
+  user_name = ENV['HOMEBREW_GIT_NAME']
+  user_email = ENV['HOMEBREW_GIT_EMAIL']
+  org = ENV['HOMEBREW_BUMP_ORG']
+  no_fork = ENV['HOMEBREW_BUMP_NO_FORK']
+  tap = ENV['HOMEBREW_BUMP_TAP']
+  tap_url = ENV['HOMEBREW_BUMP_TAP_URL']
+  formula = ENV['HOMEBREW_BUMP_FORMULA']
+  tag = ENV['HOMEBREW_BUMP_TAG']
+  revision = ENV['HOMEBREW_BUMP_REVISION']
+  force = ENV['HOMEBREW_BUMP_FORCE']
+  livecheck = ENV['HOMEBREW_BUMP_LIVECHECK']
+
+  # Check inputs
+  if livecheck.false?
+    odie "Need 'formula' input specified" if formula.blank?
+    odie "Need 'tag' input specified" if tag.blank?
+  end
+
+  # Avoid using the GitHub API whenever possible.
+  # This helps users who use application tokens instead of personal access tokens.
+  # Application tokens don't work with GitHub API's `/user` endpoit.
+  if user_name.blank? && user_email.blank?
+    # Get user details
+    user = GitHub::API.open_rest "#{GitHub::API_URL}/user"
+    user_id = user['id']
+    user_login = user['login']
+    user_name = user['name'] || user['login'] if user_name.blank?
+    user_email = user['email'] || (
+      # https://help.github.com/en/github/setting-up-and-managing-your-github-user-account/setting-your-commit-email-address
+      user_created_at = Date.parse user['created_at']
+      plus_after_date = Date.parse '2017-07-18'
+      need_plus_email = (user_created_at - plus_after_date).positive?
+      user_email = "#{user_login}@users.noreply.github.com"
+      user_email = "#{user_id}+#{user_email}" if need_plus_email
+      user_email
+    ) if user_email.blank?
+  end
+
+  # Tell git who you are
+  git 'config', '--global', 'user.name', user_name
+  git 'config', '--global', 'user.email', user_email
+
+  if tap.blank?
+    brew 'tap', 'homebrew/core', '--force'
+  else
+    # Tap the requested tap if applicable
+    brew 'tap', tap, *(tap_url unless tap_url.blank?)
+  end
+
+  # Append additional PR message
+  message = if message.blank?
+              ''
+            else
+              message + "\n\n"
+            end
+  message += '[`action-homebrew-bump-formula`](https://github.com/dawidd6/action-homebrew-bump-formula)'
+
+  unless force.false?
+    brew_repo = read_brew '--repository'
+    git '-C', brew_repo, 'apply', "#{__dir__}/bump-formula-pr.rb.patch"
+  end
+
+  # Do the livecheck stuff or not
+  if livecheck.false?
+    # Change formula name to full name
+    formula = tap + '/' + formula if !tap.blank? && !formula.blank?
+
+    # Get info about formula
+    stable = Formula[formula].stable
+    is_git = stable.downloader.is_a? GitDownloadStrategy
+
+    # Prepare tag and url
+    tag = tag.delete_prefix 'refs/tags/'
+    version = Version.parse tag
+
+    # Finally bump the formula
+    brew 'bump-formula-pr',
+         '--no-audit',
+         '--no-browse',
+         "--message=#{message}",
+         *("--fork-org=#{org}" unless org.blank?),
+         *("--no-fork" unless no_fork.false?),
+         *("--version=#{version}" unless is_git),
+         *("--tag=#{tag}" if is_git),
+         *("--revision=#{revision}" if is_git),
+         *("--force" unless force.false?),
+         formula
+  else
+    # Support multiple formulae in input and change to full names if tap
+    unless formula.blank?
+      formula = formula.split(/[ ,\n]/).reject(&:blank?)
+      formula = formula.map { |f| tap + '/' + f } unless tap.blank?
+    end
+
+    # Get livecheck info
+    json = read_brew 'livecheck',
+                     '--formula',
+                     '--quiet',
+                     '--newer-only',
+                     '--full-name',
+                     '--json',
+                     *("--tap=#{tap}" if !tap.blank? && formula.blank?),
+                     *(formula unless formula.blank?)
+    json = JSON.parse json
+
+    # Define error
+    err = nil
+
+    # Loop over livecheck info
+    json.each do |info|
+      # Skip if there is no version field
+      next unless info['version']
+
+      # Get info about formula
+      formula = info['formula']
+      version = info['version']['latest']
+
+      begin
+        # Finally bump the formula
+        brew 'bump-formula-pr',
+             '--no-audit',
+             '--no-browse',
+             "--message=#{message}",
+             "--version=#{version}",
+             *("--fork-org=#{org}" unless org.blank?),
+             *("--no-fork" unless no_fork.false?),
+             *("--force" unless force.false?),
+             formula
+      rescue ErrorDuringExecution => e
+        # Continue execution on error, but save the exeception
+        err = e
+      end
+    end
+
+    # Die if error occured
+    odie err if err
+  end
+end

--- a/.github/workflows/bump-formula-pr.yml
+++ b/.github/workflows/bump-formula-pr.yml
@@ -8,6 +8,10 @@ jobs:
     name: homebrew-grafana
     runs-on: ubuntu-latest
     steps:
+    # TODO: Remove this when we no longer need a forked action in the "Update Homebrew formula" step.
+    - name: Checkout code
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
     - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
       id: app-token
       with:
@@ -31,23 +35,25 @@ jobs:
         repository: "${{ github.repository }}"
         type: "stable"
 
-    - name: Setup Homebrew
-      uses: Homebrew/actions/setup-homebrew@4a509e36a728d1c8e147158247eb0446838a8d63 # master
-      with:
-        token: ${{ steps.app-token.outputs.token }}
-
-    - name: Tap Grafana formula repository
-      run: brew tap grafana/grafana
-
     - name: Update Homebrew formula
       if: 'steps.latest_release.outputs.release_id == github.event.release.id'
-      run: |
-        brew bump-formula-pr \
-          --no-browse \
-          --no-audit \
-          --no-fork \
-          --url https://github.com/grafana/alloy/archive/refs/tags/${{ github.ref_name }}.tar.gz \
-          grafana/grafana/alloy
-      env:
-        HOMEBREW_DEVELOPER: "1"
-        HOMEBREW_GITHUB_API_TOKEN: ${{ steps.app-token.outputs.token }}
+      # TODO: Use the upstream once they have this change:
+      # https://github.com/dawidd6/action-homebrew-bump-formula/pull/90
+      # uses: dawidd6/action-homebrew-bump-formula@v4
+      uses: ./.github/actions/homebrew-bump-formula
+      with:
+        # Required, custom GitHub access token with the 'public_repo' and 'workflow' scopes
+        token: ${{ steps.app-token.outputs.token }}
+        # Optional, defaults to homebrew/core
+        tap: grafana/grafana
+        # Formula name, required
+        formula: alloy
+        # Optional, will be determined automatically
+        tag: ${{github.ref}}
+        # Optional, will be determined automatically
+        revision: ${{github.sha}}
+        # Optional, if don't want to check for already open PRs
+        force: false # true
+        user_name: grafana-alloybot[bot]
+        user_email: 879451+grafana-alloybot[bot]@users.noreply.github.com
+  


### PR DESCRIPTION
Alloy used to use a standard GitHub action for updating its Homebrew formula until this was [reverted](https://github.com/grafana/alloy/pull/1025) a few months ago. Unfortunately, the Homebrew updater CI doesn't work again. This PR will switch us back to that action, except we will need to use a fork in order to incorporate [this change](https://github.com/dawidd6/action-homebrew-bump-formula/pull/90) to it.

I couldn't test this change in full, because I'd have to create a separate Homebrew repository, etc. I'm not sure how to do this, but I feel confident that it will work since I get this error from this PR when I run it for v1.8.1:

```
==> Downloading https://ghcr.io/v2/homebrew/portable-ruby/portable-ruby/blobs/sha256:2449f1f4cbfe2332caa8410cc487fd92fd26a8a74da9f6b8c98f39eb4235fd9a
#############################################################             84.9%
######################################################################## 100.0%
==> Pouring portable-ruby-3.3.8.x86_64_linux.bottle.tar.gz
git config --global user.name grafana-alloybot[bot]
git config --global user.email ***+grafana-alloybot[bot]@users.noreply.github.com
/home/linuxbrew/.linuxbrew/bin/brew tap grafana/grafana
==> Tapping grafana/grafana
Cloning into '/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/grafana/homebrew-grafana'...
Tapped 6 formulae (21 files, 245.3KB).
/home/linuxbrew/.linuxbrew/bin/brew bump-formula-pr --no-audit --no-browse --message=[`action-homebrew-bump-formula`](https://github.com/dawidd6/action-homebrew-bump-formula) --version=1.8.1 grafana/grafana/alloy
Warning: These  pull requests are duplicates:
Update alloy formula for 1.8.1 https://github.com/grafana/homebrew-grafana/pull/120

Error: You need to bump this formula manually since the new URL
and old URL are both:
  https://github.com/grafana/alloy/archive/refs/tags/v1.8.1.tar.gz
```

This error suggests that the workflow is getting quite far in its execution.