### PR TITLE
fix: configure tempo otlp grpc endpoint for example setup 

### DIFF
--- a/example/config/tempo/tempo.yaml
+++ b/example/config/tempo/tempo.yaml
@@ -1,0 +1,6 @@
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4317"

--- a/example/databases.yaml
+++ b/example/databases.yaml
@@ -19,11 +19,14 @@ services:
     image: grafana/tempo:2.7.0
     restart: on-failure
     command:
+      - "-config.file=/etc/tempo-config/tempo.yaml"
       - "-storage.trace.backend=local"                  # tell tempo where to permanently put traces
       - "-storage.trace.local.path=/tmp/tempo/traces"
       - "-storage.trace.wal.path=/tmp/tempo/wal"        # tell tempo where to store the wal
       - "-auth.enabled=false"                           # disables the requirement for the X-Scope-OrgID header
       - "-server.http-listen-port=3200"
+    volumes:
+      - ./config/tempo:/etc/tempo-config
     ports:
       - "3200:3200"
       - "4317:4317"


### PR DESCRIPTION
#### PR Description
Thanks @Jguer for reporting.

Since tempo v2.7 the otel receiver in tempo changed to bind to `localhost` instead of `0.0.0.0`. More information can be found here https://grafana.com/docs/tempo/latest/release-notes/v2-7/#opentelemetry-collector-receiver-listens-on-localhost-by-default

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
