### PR TITLE
database_observability: extend `query_tables` with prepared statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Main (unreleased)
   - `schema_table`: add support for index expressions (@cristiangreco)
   - `query_sample`: enable opt-in support to extract unredacted sql query (sql_text) (@matthewnolf)
   - `query_tables`: improve queries parsing (@cristiangreco)
+  - `query_tables`: add support for prepared statements (@cristiangreco)
   - make tidbparser the default choice (@cristiangreco)
 
 - Mixin dashboards improvements: added minimum cluster size to Cluster Overview dashboard, fixed units in OpenTelemetry dashboard, fixed slow components evaluation time units in Controller dashboard and updated Prometheus dashboard to correctly aggregate across instances. (@thampiotr)

--- a/internal/component/database_observability/mysql/collector/parser/parser_tidb.go
+++ b/internal/component/database_observability/mysql/collector/parser/parser_tidb.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"golang.org/x/exp/maps"
@@ -75,7 +76,9 @@ func (p *TiDBSqlParser) ExtractTableNames(_ log.Logger, _ string, stmt any) []st
 		tables: map[string]struct{}{},
 	}
 	(*stmt.(*ast.StmtNode)).Accept(v)
-	return maps.Keys(v.tables)
+	keys := maps.Keys(v.tables)
+	slices.Sort(keys)
+	return keys
 }
 
 func (p *TiDBSqlParser) ParseTableName(t any) string {

--- a/internal/component/database_observability/mysql/collector/query_tables.go
+++ b/internal/component/database_observability/mysql/collector/query_tables.go
@@ -103,7 +103,7 @@ func (c *QueryTables) Start(ctx context.Context) error {
 		ticker := time.NewTicker(c.collectInterval)
 
 		for {
-			if err := c.tablesFromQuerySamples(c.ctx); err != nil {
+			if err := c.tablesFromEventsStatements(c.ctx); err != nil {
 				level.Error(c.logger).Log("msg", "collector error", "err", err)
 			}
 			if err := c.tablesFromPreparedStatements(c.ctx); err != nil {
@@ -131,7 +131,7 @@ func (c *QueryTables) Stop() {
 	c.cancel()
 }
 
-func (c *QueryTables) tablesFromQuerySamples(ctx context.Context) error {
+func (c *QueryTables) tablesFromEventsStatements(ctx context.Context) error {
 	rs, err := c.dbConnection.QueryContext(ctx, selectQueryTablesSamples)
 	if err != nil {
 		level.Error(c.logger).Log("msg", "failed to fetch summary table samples", "err", err)

--- a/internal/component/database_observability/mysql/collector/query_tables.go
+++ b/internal/component/database_observability/mysql/collector/query_tables.go
@@ -2,7 +2,9 @@ package collector
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -28,6 +30,15 @@ const selectQueryTablesSamples = `
 	FROM performance_schema.events_statements_summary_by_digest
 	WHERE schema_name NOT IN ('mysql', 'performance_schema', 'information_schema')
 	AND last_seen > DATE_SUB(NOW(), INTERVAL 1 DAY)`
+
+const selectPreparedStatements = `
+	SELECT
+		ps.sql_text as sql_text,
+		sc.current_schema as current_schema
+	FROM performance_schema.prepared_statements_instances ps
+	INNER JOIN performance_schema.events_statements_current sc on ps.owner_thread_id = sc.thread_id
+	WHERE sc.current_schema is not null
+	GROUP BY ps.sql_text, sc.current_schema`
 
 type QueryTablesArguments struct {
 	DB              *sql.DB
@@ -92,7 +103,10 @@ func (c *QueryTables) Start(ctx context.Context) error {
 		ticker := time.NewTicker(c.collectInterval)
 
 		for {
-			if err := c.fetchQueryTables(c.ctx); err != nil {
+			if err := c.tablesFromQuerySamples(c.ctx); err != nil {
+				level.Error(c.logger).Log("msg", "collector error", "err", err)
+			}
+			if err := c.tablesFromPreparedStatements(c.ctx); err != nil {
 				level.Error(c.logger).Log("msg", "collector error", "err", err)
 			}
 
@@ -117,7 +131,7 @@ func (c *QueryTables) Stop() {
 	c.cancel()
 }
 
-func (c *QueryTables) fetchQueryTables(ctx context.Context) error {
+func (c *QueryTables) tablesFromQuerySamples(ctx context.Context) error {
 	rs, err := c.dbConnection.QueryContext(ctx, selectQueryTablesSamples)
 	if err != nil {
 		level.Error(c.logger).Log("msg", "failed to fetch summary table samples", "err", err)
@@ -126,16 +140,15 @@ func (c *QueryTables) fetchQueryTables(ctx context.Context) error {
 	defer rs.Close()
 
 	for rs.Next() {
-		var digest, digestText, schemaName, sampleText string
-		err := rs.Scan(&digest, &digestText, &schemaName, &sampleText)
-		if err != nil {
-			level.Error(c.logger).Log("msg", "failed to scan result set from summary table samples", "schema", schemaName, "err", err)
+		var digest, digestText, schema, sampleText string
+		if err := rs.Scan(&digest, &digestText, &schema, &sampleText); err != nil {
+			level.Error(c.logger).Log("msg", "failed to scan result set from summary table samples", "schema", schema, "err", err)
 			continue
 		}
 
-		stmt, err := c.tryParse(schemaName, digest, digestText, sampleText)
+		stmt, err := c.tryParse(schema, digest, sampleText, digestText)
 		if err != nil {
-			level.Warn(c.logger).Log("msg", "failed to parse sql query", "schema", schemaName, "digest", digest, "err", err)
+			// let tryParse log the error
 			continue
 		}
 
@@ -144,7 +157,7 @@ func (c *QueryTables) fetchQueryTables(ctx context.Context) error {
 			c.entryHandler.Chan() <- buildLokiEntry(
 				OP_QUERY_PARSED_TABLE_NAME,
 				c.instanceKey,
-				fmt.Sprintf(`schema="%s" digest="%s" table="%s"`, schemaName, digest, table),
+				fmt.Sprintf(`schema="%s" digest="%s" table="%s"`, schema, digest, table),
 			)
 		}
 	}
@@ -157,30 +170,87 @@ func (c *QueryTables) fetchQueryTables(ctx context.Context) error {
 	return nil
 }
 
-func (c *QueryTables) tryParse(schema, digest, digestText, sampleText string) (any, error) {
-	sqlText, err := c.sqlParser.CleanTruncatedText(sampleText)
+func (c *QueryTables) tablesFromPreparedStatements(ctx context.Context) error {
+	rs, err := c.dbConnection.QueryContext(ctx, selectPreparedStatements)
 	if err != nil {
-		level.Warn(c.logger).Log("msg", "failed to handle truncated sample_text", "schema", schema, "digest", digest, "err", err)
+		level.Error(c.logger).Log("msg", "failed to fetch prepared statements", "err", err)
+		return err
+	}
+	defer rs.Close()
 
-		// try to switch to digest_text
-		sqlText, err = c.sqlParser.CleanTruncatedText(digestText)
+	digestsSeen := map[string]struct{}{}
+
+	for rs.Next() {
+		var sqlText, schema string
+		if err := rs.Scan(&sqlText, &schema); err != nil {
+			level.Error(c.logger).Log("msg", "failed to scan result set from prepared_statements_instances", "schema", schema, "err", err)
+			continue
+		}
+
+		sqlTextRedacted, err := c.sqlParser.Redact(sqlText)
 		if err != nil {
-			level.Warn(c.logger).Log("msg", "failed to handle truncated digest_text", "schema", schema, "digest", digest, "err", err)
+			level.Error(c.logger).Log("msg", "failed to redact prepared statement", "err", err)
+			continue
+		}
+
+		// artificially compute our own digest as mysql doesn't do it for prepared statements
+		hash := sha256.Sum256([]byte(sqlTextRedacted))
+		digest := hex.EncodeToString(hash[:])
+
+		// Some statements in the prepared_statements_instances table have parameters
+		// that our parser will strip away during redaction and might produce the same
+		// hash, so we need to keep track of seen digests to avoid duplicates
+		// (e.g. "INTERVAL 1 DAY" and "INTERVAL 7 DAYS" are tracked as separate
+		// statements but once normalized they'll have the same digest)
+		if _, ok := digestsSeen[digest]; ok {
+			continue
+		}
+		digestsSeen[digest] = struct{}{}
+
+		stmt, err := c.tryParse(schema, digest, sqlText, sqlTextRedacted)
+		if err != nil {
+			// let tryParse log the error
+			continue
+		}
+
+		tables := c.sqlParser.ExtractTableNames(c.logger, schema, stmt)
+		for _, table := range tables {
+			c.entryHandler.Chan() <- buildLokiEntry(
+				OP_QUERY_PARSED_TABLE_NAME,
+				c.instanceKey,
+				fmt.Sprintf(`schema="%s" digest="%s" table="%s"`, schema, digest, table),
+			)
+		}
+	}
+
+	if err := rs.Err(); err != nil {
+		level.Error(c.logger).Log("msg", "error during iterating over prepared statements result set", "err", err)
+		return err
+	}
+
+	return nil
+}
+
+func (c *QueryTables) tryParse(schema, digest, sqlText, fallbackSqlText string) (any, error) {
+	sqlText, err := c.sqlParser.CleanTruncatedText(sqlText)
+	if err != nil {
+		sqlText, err = c.sqlParser.CleanTruncatedText(fallbackSqlText)
+		if err != nil {
+			level.Warn(c.logger).Log("msg", "failed to handle truncated sql text", "schema", schema, "digest", digest, "err", err)
 			return nil, err
 		}
 	}
 
 	stmt, err := c.sqlParser.Parse(sqlText)
 	if err != nil {
-		level.Warn(c.logger).Log("msg", "failed to parse sql query from sample_text", "schema", schema, "digest", digest, "err", err)
-
-		if digestText == "" || sqlText == digestText {
+		if fallbackSqlText == sqlText {
+			level.Warn(c.logger).Log("msg", "failed to parse sql text (without fallback)", "schema", schema, "digest", digest, "err", err)
 			return nil, err
 		}
 
-		stmt, err = c.sqlParser.Parse(digestText)
+		stmt, err = c.sqlParser.Parse(fallbackSqlText)
 		if err != nil {
-			level.Warn(c.logger).Log("msg", "failed to parse sql query from digest_text", "schema", schema, "digest", digest, "err", err)
+			level.Warn(c.logger).Log("msg", "failed to parse sql text (fallback)", "schema", schema, "digest", digest, "err", err)
 			return nil, err
 		}
 	}


### PR DESCRIPTION
#### PR Description
Extend the `query_tables` collector to also parse prepared statements from the `prepared_statements_instances` table.

Follow similar logic as the one used for the `query_samples` table, but we calculate a digest locally as mysql does not provide one for prepared statements (this also requires redacting the statement first, and making sure no duplicates are processed after redaction).




#### Which issue(s) this PR fixes
n.a.

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
