### PR TITLE
fix instance key in exporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Breaking changes
+
+- `prometheus.exporter.blackbox`, `prometheus.exporter.snmp` and `prometheus.exporter.statsd` now use the component ID instead of the hostname as
+  their `instance` label in their exported metrics. This is a consequence of a bug fix that could lead to a missing data when using the exporter
+  with clustering. If you would like to retain the previous behaviour, you can use `discovery.relabel` with `action = "replace"` rule to
+  set the `instance` label to `sys.env("HOSTNAME")`. (@thampiotr)
+
 ### Features
 
 - (_Experimental_) Additions to experimental `database_observability.mysql` component:

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.cadvisor.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.cadvisor.md
@@ -17,11 +17,11 @@ The `prometheus.exporter.cadvisor` component collects container metrics using [c
 {{< admonition type="note" >}}
 Take care when using the `prometheus.exporter.cadvisor` component with [clustering](../../../../get-started/clustering/) enabled.
 
-The default instance label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent hashing to distribute targets across instances, and the discovered targets must be the same (and have the same labels) across all cluster instances.
-
-Therefore, when using `prometheus.exporter.cadvisor` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
-it is recommended to use a dedicated `prometheus.scrape` component that is used to scrape `prometheus.exporter.cadvisor`
-and does not have clustering enabled.
+The default `instance` label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent
+hashing to distribute targets across the instances. This approach requires the discovered targets to be the same and have the same
+labels across all cluster instances. When using `prometheus.exporter.cadvisor` within a [cluster](../../../../get-started/clustering/)
+of Alloy instances, it is recommended to use a dedicated `prometheus.scrape` component that is used to
+scrape `prometheus.exporter.cadvisor` and does not have clustering enabled.
 {{< /admonition >}}
 
 ## Usage

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.cadvisor.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.cadvisor.md
@@ -14,17 +14,7 @@ title: prometheus.exporter.cadvisor
 
 The `prometheus.exporter.cadvisor` component collects container metrics using [cAdvisor](https://github.com/google/cadvisor).
 
-{{< admonition type="note" >}}
-Take care when using the `prometheus.exporter.cadvisor` component with [clustering](../../../../get-started/clustering/) enabled.
-
-The default `instance` label set by this exporter is the hostname of the machine running {{< param "PRODUCT_NAME" >}}.
-{{< param "PRODUCT_NAME" >}} clustering uses consistent hashing to distribute targets across the instances.
-This approach requires the discovered targets to be the same and have the same labels across all cluster instances.
-
-When you use `prometheus.exporter.cadvisor` within a [cluster](../../../../get-started/clustering/)
-of {{< param "PRODUCT_NAME" >}} instances, use a dedicated `prometheus.scrape` component that's used to scrape
-`prometheus.exporter.cadvisor` and doesn't have clustering enabled.
-{{< /admonition >}}
+{{< docs/shared lookup="reference/components/exporter-clustering-warning.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ## Usage
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.cadvisor.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.cadvisor.md
@@ -21,6 +21,15 @@ prometheus.exporter.cadvisor "<LABEL>" {
 }
 ```
 
+{{< admonition type="note" >}}
+When using `prometheus.exporter.cadvisor` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
+it is recommended to use a dedicated `prometheus.scrape` component that is used to scrape `prometheus.exporter.cadvisor`
+and does not have clustering enabled.
+
+This is because clustering uses consistent hashing to distribute targets across instances,
+and the instance label (which defaults to hostname) must be same across all cluster instances.
+{{< /admonition >}}
+
 ## Arguments
 
 You can use the following arguments with `prometheus.exporter.cadvisor`:

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.cadvisor.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.cadvisor.md
@@ -14,22 +14,22 @@ title: prometheus.exporter.cadvisor
 
 The `prometheus.exporter.cadvisor` component collects container metrics using [cAdvisor](https://github.com/google/cadvisor).
 
+{{< admonition type="note" >}}
+Take care when using the `prometheus.exporter.cadvisor` component with [clustering](../../../../get-started/clustering/) enabled.
+
+The default instance label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent hashing to distribute targets across instances, and the discovered targets must be the same (and have the same labels) across all cluster instances.
+
+Therefore, when using `prometheus.exporter.cadvisor` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
+it is recommended to use a dedicated `prometheus.scrape` component that is used to scrape `prometheus.exporter.cadvisor`
+and does not have clustering enabled.
+{{< /admonition >}}
+
 ## Usage
 
 ```alloy
 prometheus.exporter.cadvisor "<LABEL>" {
 }
 ```
-
-{{< admonition type="note" >}}
-Take care when using the `prometheus.exporter.cadvisor` component with [clustering](../../../../get-started/clustering/) enabled.
-
-The default instance label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent hashing to distribute targets across instances, and the instance label must be same across all cluster instances.
-
-Therefore, when using `prometheus.exporter.cadvisor` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
-it is recommended to use a dedicated `prometheus.scrape` component that is used to scrape `prometheus.exporter.cadvisor`
-and does not have clustering enabled.
-{{< /admonition >}}
 
 ## Arguments
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.cadvisor.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.cadvisor.md
@@ -17,11 +17,13 @@ The `prometheus.exporter.cadvisor` component collects container metrics using [c
 {{< admonition type="note" >}}
 Take care when using the `prometheus.exporter.cadvisor` component with [clustering](../../../../get-started/clustering/) enabled.
 
-The default `instance` label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent
-hashing to distribute targets across the instances. This approach requires the discovered targets to be the same and have the same
-labels across all cluster instances. When using `prometheus.exporter.cadvisor` within a [cluster](../../../../get-started/clustering/)
-of Alloy instances, it is recommended to use a dedicated `prometheus.scrape` component that is used to
-scrape `prometheus.exporter.cadvisor` and does not have clustering enabled.
+The default `instance` label set by this exporter is the hostname of the machine running {{< param "PRODUCT_NAME" >}}.
+{{< param "PRODUCT_NAME" >}} clustering uses consistent hashing to distribute targets across the instances.
+This approach requires the discovered targets to be the same and have the same labels across all cluster instances.
+
+When you use `prometheus.exporter.cadvisor` within a [cluster](../../../../get-started/clustering/)
+of {{< param "PRODUCT_NAME" >}} instances, use a dedicated `prometheus.scrape` component that's used to scrape
+`prometheus.exporter.cadvisor` and doesn't have clustering enabled.
 {{< /admonition >}}
 
 ## Usage

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.cadvisor.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.cadvisor.md
@@ -22,12 +22,13 @@ prometheus.exporter.cadvisor "<LABEL>" {
 ```
 
 {{< admonition type="note" >}}
-When using `prometheus.exporter.cadvisor` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
+Take care when using the `prometheus.exporter.cadvisor` component with [clustering](../../../../get-started/clustering/) enabled.
+
+The default instance label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent hashing to distribute targets across instances, and the instance label must be same across all cluster instances.
+
+Therefore, when using `prometheus.exporter.cadvisor` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
 it is recommended to use a dedicated `prometheus.scrape` component that is used to scrape `prometheus.exporter.cadvisor`
 and does not have clustering enabled.
-
-This is because clustering uses consistent hashing to distribute targets across instances,
-and the instance label (which defaults to hostname) must be same across all cluster instances.
 {{< /admonition >}}
 
 ## Arguments

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.process.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.process.md
@@ -22,12 +22,13 @@ prometheus.exporter.process "<LABEL>" {
 ```
 
 {{< admonition type="note" >}}
-When using `prometheus.exporter.process` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
+Take care when using the `prometheus.exporter.process` component with [clustering](../../../../get-started/clustering/) enabled.
+
+The default instance label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent hashing to distribute targets across instances, and the instance label must be same across all cluster instances.
+
+Therefore, when using `prometheus.exporter.process` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
 it is recommended to use a dedicated `prometheus.scrape` component that is used to scrape `prometheus.exporter.process`
 and does not have clustering enabled.
-
-This is because clustering uses consistent hashing to distribute targets across instances,
-and the instance label (which defaults to hostname) must be same across all cluster instances.
 {{< /admonition >}}
 
 ## Arguments

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.process.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.process.md
@@ -21,6 +21,15 @@ prometheus.exporter.process "<LABEL>" {
 }
 ```
 
+{{< admonition type="note" >}}
+When using `prometheus.exporter.process` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
+it is recommended to use a dedicated `prometheus.scrape` component that is used to scrape `prometheus.exporter.process`
+and does not have clustering enabled.
+
+This is because clustering uses consistent hashing to distribute targets across instances,
+and the instance label (which defaults to hostname) must be same across all cluster instances.
+{{< /admonition >}}
+
 ## Arguments
 
 You can use the following arguments with `prometheus.exporter.process`:

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.process.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.process.md
@@ -14,22 +14,22 @@ title: prometheus.exporter.process
 
 The `prometheus.exporter.process` component embeds the [`process_exporter`](https://github.com/ncabatoff/process-exporter) for collecting process stats from `/proc`.
 
+{{< admonition type="note" >}}
+Take care when using the `prometheus.exporter.process` component with [clustering](../../../../get-started/clustering/) enabled.
+
+The default instance label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent hashing to distribute targets across instances, and the discovered targets must be the same (and have the same labels) across all cluster instances.
+
+Therefore, when using `prometheus.exporter.process` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
+it is recommended to use a dedicated `prometheus.scrape` component that is used to scrape `prometheus.exporter.process`
+and does not have clustering enabled.
+{{< /admonition >}}
+
 ## Usage
 
 ```alloy
 prometheus.exporter.process "<LABEL>" {
 }
 ```
-
-{{< admonition type="note" >}}
-Take care when using the `prometheus.exporter.process` component with [clustering](../../../../get-started/clustering/) enabled.
-
-The default instance label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent hashing to distribute targets across instances, and the instance label must be same across all cluster instances.
-
-Therefore, when using `prometheus.exporter.process` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
-it is recommended to use a dedicated `prometheus.scrape` component that is used to scrape `prometheus.exporter.process`
-and does not have clustering enabled.
-{{< /admonition >}}
 
 ## Arguments
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.process.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.process.md
@@ -14,17 +14,7 @@ title: prometheus.exporter.process
 
 The `prometheus.exporter.process` component embeds the [`process_exporter`](https://github.com/ncabatoff/process-exporter) for collecting process stats from `/proc`.
 
-{{< admonition type="note" >}}
-Take care when using the `prometheus.exporter.process` component with [clustering](../../../../get-started/clustering/) enabled.
-
-The default `instance` label set by this exporter is the hostname of the machine running {{< param "PRODUCT_NAME" >}}.
-{{< param "PRODUCT_NAME" >}} clustering uses consistent hashing to distribute targets across the instances.
-This approach requires the discovered targets to be the same and have the same labels across all cluster instances.
-
-When you use `prometheus.exporter.process` within a [cluster](../../../../get-started/clustering/)
-of {{< param "PRODUCT_NAME" >}} instances, use a dedicated `prometheus.scrape` component that's used to scrape
-`prometheus.exporter.process` and doesn't have clustering enabled.
-{{< /admonition >}}
+{{< docs/shared lookup="reference/components/exporter-clustering-warning.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ## Usage
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.process.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.process.md
@@ -17,11 +17,11 @@ The `prometheus.exporter.process` component embeds the [`process_exporter`](http
 {{< admonition type="note" >}}
 Take care when using the `prometheus.exporter.process` component with [clustering](../../../../get-started/clustering/) enabled.
 
-The default instance label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent hashing to distribute targets across instances, and the discovered targets must be the same (and have the same labels) across all cluster instances.
-
-Therefore, when using `prometheus.exporter.process` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
-it is recommended to use a dedicated `prometheus.scrape` component that is used to scrape `prometheus.exporter.process`
-and does not have clustering enabled.
+The default `instance` label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent
+hashing to distribute targets across the instances. This approach requires the discovered targets to be the same and have the same
+labels across all cluster instances. When using `prometheus.exporter.process` within a [cluster](../../../../get-started/clustering/)
+of Alloy instances, it is recommended to use a dedicated `prometheus.scrape` component that is used to
+scrape `prometheus.exporter.process` and does not have clustering enabled.
 {{< /admonition >}}
 
 ## Usage

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.process.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.process.md
@@ -17,11 +17,13 @@ The `prometheus.exporter.process` component embeds the [`process_exporter`](http
 {{< admonition type="note" >}}
 Take care when using the `prometheus.exporter.process` component with [clustering](../../../../get-started/clustering/) enabled.
 
-The default `instance` label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent
-hashing to distribute targets across the instances. This approach requires the discovered targets to be the same and have the same
-labels across all cluster instances. When using `prometheus.exporter.process` within a [cluster](../../../../get-started/clustering/)
-of Alloy instances, it is recommended to use a dedicated `prometheus.scrape` component that is used to
-scrape `prometheus.exporter.process` and does not have clustering enabled.
+The default `instance` label set by this exporter is the hostname of the machine running {{< param "PRODUCT_NAME" >}}.
+{{< param "PRODUCT_NAME" >}} clustering uses consistent hashing to distribute targets across the instances.
+This approach requires the discovered targets to be the same and have the same labels across all cluster instances.
+
+When you use `prometheus.exporter.process` within a [cluster](../../../../get-started/clustering/)
+of {{< param "PRODUCT_NAME" >}} instances, use a dedicated `prometheus.scrape` component that's used to scrape
+`prometheus.exporter.process` and doesn't have clustering enabled.
 {{< /admonition >}}
 
 ## Usage

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.self.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.self.md
@@ -17,11 +17,13 @@ The `prometheus.exporter.self` component collects and exposes metrics about {{< 
 {{< admonition type="note" >}}
 Take care when using the `prometheus.exporter.self` component with [clustering](../../../../get-started/clustering/) enabled.
 
-The default `instance` label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent
-hashing to distribute targets across the instances. This approach requires the discovered targets to be the same and have the same
-labels across all cluster instances. When using `prometheus.exporter.self` within a [cluster](../../../../get-started/clustering/)
-of Alloy instances, it is recommended to use a dedicated `prometheus.scrape` component that is used to
-scrape `prometheus.exporter.self` and does not have clustering enabled.
+The default `instance` label set by this exporter is the hostname of the machine running {{< param "PRODUCT_NAME" >}}.
+{{< param "PRODUCT_NAME" >}} clustering uses consistent hashing to distribute targets across the instances.
+This approach requires the discovered targets to be the same and have the same labels across all cluster instances.
+
+When you use `prometheus.exporter.self` within a [cluster](../../../../get-started/clustering/)
+of {{< param "PRODUCT_NAME" >}} instances, use a dedicated `prometheus.scrape` component that's used to scrape
+`prometheus.exporter.self` and doesn't have clustering enabled.
 {{< /admonition >}}
 
 ## Usage

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.self.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.self.md
@@ -14,17 +14,7 @@ title: prometheus.exporter.self
 
 The `prometheus.exporter.self` component collects and exposes metrics about {{< param "PRODUCT_NAME" >}} itself.
 
-{{< admonition type="note" >}}
-Take care when using the `prometheus.exporter.self` component with [clustering](../../../../get-started/clustering/) enabled.
-
-The default `instance` label set by this exporter is the hostname of the machine running {{< param "PRODUCT_NAME" >}}.
-{{< param "PRODUCT_NAME" >}} clustering uses consistent hashing to distribute targets across the instances.
-This approach requires the discovered targets to be the same and have the same labels across all cluster instances.
-
-When you use `prometheus.exporter.self` within a [cluster](../../../../get-started/clustering/)
-of {{< param "PRODUCT_NAME" >}} instances, use a dedicated `prometheus.scrape` component that's used to scrape
-`prometheus.exporter.self` and doesn't have clustering enabled.
-{{< /admonition >}}
+{{< docs/shared lookup="reference/components/exporter-clustering-warning.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ## Usage
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.self.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.self.md
@@ -17,11 +17,11 @@ The `prometheus.exporter.self` component collects and exposes metrics about {{< 
 {{< admonition type="note" >}}
 Take care when using the `prometheus.exporter.self` component with [clustering](../../../../get-started/clustering/) enabled.
 
-The default instance label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent hashing to distribute targets across instances, and the discovered targets must be the same (and have the same labels) across all cluster instances.
-
-Therefore, when using `prometheus.exporter.self` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
-it is recommended to use a dedicated `prometheus.scrape` component that is used to scrape `prometheus.exporter.self`
-and does not have clustering enabled.
+The default `instance` label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent
+hashing to distribute targets across the instances. This approach requires the discovered targets to be the same and have the same
+labels across all cluster instances. When using `prometheus.exporter.self` within a [cluster](../../../../get-started/clustering/)
+of Alloy instances, it is recommended to use a dedicated `prometheus.scrape` component that is used to
+scrape `prometheus.exporter.self` and does not have clustering enabled.
 {{< /admonition >}}
 
 ## Usage

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.self.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.self.md
@@ -21,6 +21,15 @@ prometheus.exporter.self "<LABEL>" {
 }
 ```
 
+{{< admonition type="note" >}}
+When using `prometheus.exporter.self` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
+it is recommended to use a dedicated `prometheus.scrape` component that is used to scrape `prometheus.exporter.self`
+and does not have clustering enabled.
+
+This is because clustering uses consistent hashing to distribute targets across instances,
+and the instance label (which defaults to the hostname) must be same across all cluster instances.
+{{< /admonition >}}
+
 ## Arguments
 
 The `prometheus.exporter.self` component doesn't support any arguments.

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.self.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.self.md
@@ -22,12 +22,13 @@ prometheus.exporter.self "<LABEL>" {
 ```
 
 {{< admonition type="note" >}}
-When using `prometheus.exporter.self` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
+Take care when using the `prometheus.exporter.self` component with [clustering](../../../../get-started/clustering/) enabled.
+
+The default instance label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent hashing to distribute targets across instances, and the instance label must be same across all cluster instances.
+
+Therefore, when using `prometheus.exporter.self` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
 it is recommended to use a dedicated `prometheus.scrape` component that is used to scrape `prometheus.exporter.self`
 and does not have clustering enabled.
-
-This is because clustering uses consistent hashing to distribute targets across instances,
-and the instance label (which defaults to the hostname) must be same across all cluster instances.
 {{< /admonition >}}
 
 ## Arguments

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.self.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.self.md
@@ -14,22 +14,22 @@ title: prometheus.exporter.self
 
 The `prometheus.exporter.self` component collects and exposes metrics about {{< param "PRODUCT_NAME" >}} itself.
 
+{{< admonition type="note" >}}
+Take care when using the `prometheus.exporter.self` component with [clustering](../../../../get-started/clustering/) enabled.
+
+The default instance label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent hashing to distribute targets across instances, and the discovered targets must be the same (and have the same labels) across all cluster instances.
+
+Therefore, when using `prometheus.exporter.self` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
+it is recommended to use a dedicated `prometheus.scrape` component that is used to scrape `prometheus.exporter.self`
+and does not have clustering enabled.
+{{< /admonition >}}
+
 ## Usage
 
 ```alloy
 prometheus.exporter.self "<LABEL>" {
 }
 ```
-
-{{< admonition type="note" >}}
-Take care when using the `prometheus.exporter.self` component with [clustering](../../../../get-started/clustering/) enabled.
-
-The default instance label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent hashing to distribute targets across instances, and the instance label must be same across all cluster instances.
-
-Therefore, when using `prometheus.exporter.self` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
-it is recommended to use a dedicated `prometheus.scrape` component that is used to scrape `prometheus.exporter.self`
-and does not have clustering enabled.
-{{< /admonition >}}
 
 ## Arguments
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.unix.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.unix.md
@@ -22,11 +22,13 @@ You can specify multiple `prometheus.exporter.unix` components by giving them di
 {{< admonition type="note" >}}
 Take care when using the `prometheus.exporter.unix` component with [clustering](../../../../get-started/clustering/) enabled.
 
-The default `instance` label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent
-hashing to distribute targets across the instances. This approach requires the discovered targets to be the same and have the same
-labels across all cluster instances. When using `prometheus.exporter.unix` within a [cluster](../../../../get-started/clustering/)
-of Alloy instances, it is recommended to use a dedicated `prometheus.scrape` component that is used to
-scrape `prometheus.exporter.unix` and does not have clustering enabled.
+The default `instance` label set by this exporter is the hostname of the machine running {{< param "PRODUCT_NAME" >}}.
+{{< param "PRODUCT_NAME" >}} clustering uses consistent hashing to distribute targets across the instances.
+This approach requires the discovered targets to be the same and have the same labels across all cluster instances.
+
+When you use `prometheus.exporter.unix` within a [cluster](../../../../get-started/clustering/)
+of {{< param "PRODUCT_NAME" >}} instances, use a dedicated `prometheus.scrape` component that's used to scrape
+`prometheus.exporter.unix` and doesn't have clustering enabled.
 {{< /admonition >}}
 
 ## Usage

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.unix.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.unix.md
@@ -22,11 +22,11 @@ You can specify multiple `prometheus.exporter.unix` components by giving them di
 {{< admonition type="note" >}}
 Take care when using the `prometheus.exporter.unix` component with [clustering](../../../../get-started/clustering/) enabled.
 
-The default instance label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent hashing to distribute targets across instances, and the discovered targets must be the same (and have the same labels) across all cluster instances.
-
-Therefore, when using `prometheus.exporter.unix` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
-it is recommended to use a dedicated `prometheus.scrape` component that is used to scrape `prometheus.exporter.unix`
-and does not have clustering enabled.
+The default `instance` label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent
+hashing to distribute targets across the instances. This approach requires the discovered targets to be the same and have the same
+labels across all cluster instances. When using `prometheus.exporter.unix` within a [cluster](../../../../get-started/clustering/)
+of Alloy instances, it is recommended to use a dedicated `prometheus.scrape` component that is used to
+scrape `prometheus.exporter.unix` and does not have clustering enabled.
 {{< /admonition >}}
 
 ## Usage

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.unix.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.unix.md
@@ -19,22 +19,22 @@ For more information on collectors, refer to the [`collectors-list`](#collectors
 
 You can specify multiple `prometheus.exporter.unix` components by giving them different labels.
 
+{{< admonition type="note" >}}
+Take care when using the `prometheus.exporter.unix` component with [clustering](../../../../get-started/clustering/) enabled.
+
+The default instance label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent hashing to distribute targets across instances, and the discovered targets must be the same (and have the same labels) across all cluster instances.
+
+Therefore, when using `prometheus.exporter.unix` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
+it is recommended to use a dedicated `prometheus.scrape` component that is used to scrape `prometheus.exporter.unix`
+and does not have clustering enabled.
+{{< /admonition >}}
+
 ## Usage
 
 ```alloy
 prometheus.exporter.unix "<LABEL>" {
 }
 ```
-
-{{< admonition type="note" >}}
-Take care when using the `prometheus.exporter.unix` component with [clustering](../../../../get-started/clustering/) enabled.
-
-The default instance label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent hashing to distribute targets across instances, and the instance label must be same across all cluster instances.
-
-Therefore, when using `prometheus.exporter.unix` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
-it is recommended to use a dedicated `prometheus.scrape` component that is used to scrape `prometheus.exporter.unix`
-and does not have clustering enabled.
-{{< /admonition >}}
 
 ## Arguments
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.unix.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.unix.md
@@ -26,6 +26,15 @@ prometheus.exporter.unix "<LABEL>" {
 }
 ```
 
+{{< admonition type="note" >}}
+When using `prometheus.exporter.unix` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
+it is recommended to use a dedicated `prometheus.scrape` component that is used to scrape `prometheus.exporter.unix`
+and does not have clustering enabled.
+
+This is because clustering uses consistent hashing to distribute targets across instances,
+and the instance label (which defaults to hostname) must be same across all cluster instances.
+{{< /admonition >}}
+
 ## Arguments
 
 You can use the following arguments with `prometheus.exporter.unix`:

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.unix.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.unix.md
@@ -27,12 +27,13 @@ prometheus.exporter.unix "<LABEL>" {
 ```
 
 {{< admonition type="note" >}}
-When using `prometheus.exporter.unix` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
+Take care when using the `prometheus.exporter.unix` component with [clustering](../../../../get-started/clustering/) enabled.
+
+The default instance label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent hashing to distribute targets across instances, and the instance label must be same across all cluster instances.
+
+Therefore, when using `prometheus.exporter.unix` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
 it is recommended to use a dedicated `prometheus.scrape` component that is used to scrape `prometheus.exporter.unix`
 and does not have clustering enabled.
-
-This is because clustering uses consistent hashing to distribute targets across instances,
-and the instance label (which defaults to hostname) must be same across all cluster instances.
 {{< /admonition >}}
 
 ## Arguments

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.unix.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.unix.md
@@ -19,17 +19,7 @@ For more information on collectors, refer to the [`collectors-list`](#collectors
 
 You can specify multiple `prometheus.exporter.unix` components by giving them different labels.
 
-{{< admonition type="note" >}}
-Take care when using the `prometheus.exporter.unix` component with [clustering](../../../../get-started/clustering/) enabled.
-
-The default `instance` label set by this exporter is the hostname of the machine running {{< param "PRODUCT_NAME" >}}.
-{{< param "PRODUCT_NAME" >}} clustering uses consistent hashing to distribute targets across the instances.
-This approach requires the discovered targets to be the same and have the same labels across all cluster instances.
-
-When you use `prometheus.exporter.unix` within a [cluster](../../../../get-started/clustering/)
-of {{< param "PRODUCT_NAME" >}} instances, use a dedicated `prometheus.scrape` component that's used to scrape
-`prometheus.exporter.unix` and doesn't have clustering enabled.
-{{< /admonition >}}
+{{< docs/shared lookup="reference/components/exporter-clustering-warning.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ## Usage
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
@@ -31,6 +31,15 @@ prometheus.exporter.windows "<LABEL>" {
 }
 ```
 
+{{< admonition type="note" >}}
+When using `prometheus.exporter.windows` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
+it is recommended to use a dedicated `prometheus.scrape` component that is used to scrape `prometheus.exporter.windows`
+and does not have clustering enabled.
+
+This is because clustering uses consistent hashing to distribute targets across instances,
+and the instance label (which defaults to hostname) must be same across all cluster instances.
+{{< /admonition >}}
+
 ## Arguments
 
 You can use the following arguments with `prometheus.exporter.windows`:

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
@@ -27,11 +27,11 @@ The `include` and `exclude` arguments are preferred going forward.
 {{< admonition type="note" >}}
 Take care when using the `prometheus.exporter.windows` component with [clustering](../../../../get-started/clustering/) enabled.
 
-The default instance label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent hashing to distribute targets across instances, and the discovered targets must be the same (and have the same labels) across all cluster instances.
-
-Therefore, when using `prometheus.exporter.windows` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
-it is recommended to use a dedicated `prometheus.scrape` component that is used to scrape `prometheus.exporter.windows`
-and does not have clustering enabled.
+The default `instance` label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent
+hashing to distribute targets across the instances. This approach requires the discovered targets to be the same and have the same
+labels across all cluster instances. When using `prometheus.exporter.windows` within a [cluster](../../../../get-started/clustering/)
+of Alloy instances, it is recommended to use a dedicated `prometheus.scrape` component that is used to
+scrape `prometheus.exporter.windows` and does not have clustering enabled.
 {{< /admonition >}}
 
 ## Usage

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
@@ -27,11 +27,13 @@ The `include` and `exclude` arguments are preferred going forward.
 {{< admonition type="note" >}}
 Take care when using the `prometheus.exporter.windows` component with [clustering](../../../../get-started/clustering/) enabled.
 
-The default `instance` label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent
-hashing to distribute targets across the instances. This approach requires the discovered targets to be the same and have the same
-labels across all cluster instances. When using `prometheus.exporter.windows` within a [cluster](../../../../get-started/clustering/)
-of Alloy instances, it is recommended to use a dedicated `prometheus.scrape` component that is used to
-scrape `prometheus.exporter.windows` and does not have clustering enabled.
+The default `instance` label set by this exporter is the hostname of the machine running {{< param "PRODUCT_NAME" >}}.
+{{< param "PRODUCT_NAME" >}} clustering uses consistent hashing to distribute targets across the instances.
+This approach requires the discovered targets to be the same and have the same labels across all cluster instances.
+
+When you use `prometheus.exporter.windows` within a [cluster](../../../../get-started/clustering/)
+of {{< param "PRODUCT_NAME" >}} instances, use a dedicated `prometheus.scrape` component that's used to scrape
+`prometheus.exporter.windows` and doesn't have clustering enabled.
 {{< /admonition >}}
 
 ## Usage

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
@@ -24,17 +24,7 @@ The `include` and `exclude` arguments are preferred going forward.
 
 [windows_exporter]: https://github.com/prometheus-community/windows_exporter/tree/{{< param "PROM_WIN_EXP_VERSION" >}}
 
-{{< admonition type="note" >}}
-Take care when using the `prometheus.exporter.windows` component with [clustering](../../../../get-started/clustering/) enabled.
-
-The default `instance` label set by this exporter is the hostname of the machine running {{< param "PRODUCT_NAME" >}}.
-{{< param "PRODUCT_NAME" >}} clustering uses consistent hashing to distribute targets across the instances.
-This approach requires the discovered targets to be the same and have the same labels across all cluster instances.
-
-When you use `prometheus.exporter.windows` within a [cluster](../../../../get-started/clustering/)
-of {{< param "PRODUCT_NAME" >}} instances, use a dedicated `prometheus.scrape` component that's used to scrape
-`prometheus.exporter.windows` and doesn't have clustering enabled.
-{{< /admonition >}}
+{{< docs/shared lookup="reference/components/exporter-clustering-warning.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ## Usage
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
@@ -24,22 +24,22 @@ The `include` and `exclude` arguments are preferred going forward.
 
 [windows_exporter]: https://github.com/prometheus-community/windows_exporter/tree/{{< param "PROM_WIN_EXP_VERSION" >}}
 
+{{< admonition type="note" >}}
+Take care when using the `prometheus.exporter.windows` component with [clustering](../../../../get-started/clustering/) enabled.
+
+The default instance label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent hashing to distribute targets across instances, and the discovered targets must be the same (and have the same labels) across all cluster instances.
+
+Therefore, when using `prometheus.exporter.windows` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
+it is recommended to use a dedicated `prometheus.scrape` component that is used to scrape `prometheus.exporter.windows`
+and does not have clustering enabled.
+{{< /admonition >}}
+
 ## Usage
 
 ```alloy
 prometheus.exporter.windows "<LABEL>" {
 }
 ```
-
-{{< admonition type="note" >}}
-Take care when using the `prometheus.exporter.windows` component with [clustering](../../../../get-started/clustering/) enabled.
-
-The default instance label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent hashing to distribute targets across instances, and the instance label must be same across all cluster instances.
-
-Therefore, when using `prometheus.exporter.windows` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
-it is recommended to use a dedicated `prometheus.scrape` component that is used to scrape `prometheus.exporter.windows`
-and does not have clustering enabled.
-{{< /admonition >}}
 
 ## Arguments
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
@@ -32,12 +32,13 @@ prometheus.exporter.windows "<LABEL>" {
 ```
 
 {{< admonition type="note" >}}
-When using `prometheus.exporter.windows` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
+Take care when using the `prometheus.exporter.windows` component with [clustering](../../../../get-started/clustering/) enabled.
+
+The default instance label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent hashing to distribute targets across instances, and the instance label must be same across all cluster instances.
+
+Therefore, when using `prometheus.exporter.windows` within a [cluster](../../../../get-started/clustering/) of Alloy instances,
 it is recommended to use a dedicated `prometheus.scrape` component that is used to scrape `prometheus.exporter.windows`
 and does not have clustering enabled.
-
-This is because clustering uses consistent hashing to distribute targets across instances,
-and the instance label (which defaults to hostname) must be same across all cluster instances.
 {{< /admonition >}}
 
 ## Arguments

--- a/docs/sources/shared/reference/components/exporter-clustering-warning.md
+++ b/docs/sources/shared/reference/components/exporter-clustering-warning.md
@@ -1,0 +1,17 @@
+---
+canonical: https://grafana.com/docs/alloy/latest/shared/reference/components/exporter-clustering-warning/
+description: Shared content, exporter clustering warning
+headless: true
+---
+
+{{< admonition type="note" >}}
+We do not recommend using this exporter with [clustering](../../../../get-started/clustering/) enabled.
+
+The default `instance` label set by this exporter is the hostname of the machine running {{< param "PRODUCT_NAME" >}}.
+{{< param "PRODUCT_NAME" >}} clustering uses consistent hashing to distribute targets across the instances.
+This requires the discovered targets to be the same and have the same labels across all cluster instances.
+
+If you do need to use this component in a cluster, use a dedicated `prometheus.scrape` component that's used to scrape
+this exporter and doesn't have clustering enabled. Alternatively, use `discovery.relabel` to set the `instance` label to a
+value that is the same across all cluster instances.
+{{< /admonition >}}

--- a/internal/component/prometheus/exporter/apache/apache.go
+++ b/internal/component/prometheus/exporter/apache/apache.go
@@ -19,8 +19,9 @@ func init() {
 	})
 }
 
-func createExporter(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
+func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
 	a := args.(Arguments)
+	defaultInstanceKey := opts.ID // if cannot resolve instance key, use the component ID
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)
 }
 

--- a/internal/component/prometheus/exporter/azure/azure.go
+++ b/internal/component/prometheus/exporter/azure/azure.go
@@ -19,8 +19,9 @@ func init() {
 	})
 }
 
-func createExporter(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
+func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
 	a := args.(Arguments)
+	defaultInstanceKey := opts.ID // if cannot resolve instance key, use the component ID
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)
 }
 

--- a/internal/component/prometheus/exporter/blackbox/blackbox.go
+++ b/internal/component/prometheus/exporter/blackbox/blackbox.go
@@ -29,8 +29,9 @@ func init() {
 	})
 }
 
-func createExporter(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
+func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
 	a := args.(Arguments)
+	defaultInstanceKey := opts.ID // if cannot resolve instance key, use the component ID
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)
 }
 

--- a/internal/component/prometheus/exporter/cadvisor/cadvisor.go
+++ b/internal/component/prometheus/exporter/cadvisor/cadvisor.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/component/prometheus/exporter"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/common"
 	"github.com/grafana/alloy/internal/featuregate"
 	"github.com/grafana/alloy/internal/static/integrations"
 	"github.com/grafana/alloy/internal/static/integrations/cadvisor"
@@ -21,8 +22,9 @@ func init() {
 	})
 }
 
-func createExporter(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
+func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
 	a := args.(Arguments)
+	defaultInstanceKey := common.HostNameInstanceKey() // if cannot resolve instance key, use the host name for cadvisor
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)
 }
 

--- a/internal/component/prometheus/exporter/cadvisor/cadvisor.go
+++ b/internal/component/prometheus/exporter/cadvisor/cadvisor.go
@@ -23,6 +23,7 @@ func init() {
 }
 
 func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
+	common.WarningIfUsedInCluster(opts)
 	a := args.(Arguments)
 	defaultInstanceKey := common.HostNameInstanceKey() // if cannot resolve instance key, use the host name for cadvisor
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)

--- a/internal/component/prometheus/exporter/catchpoint/catchpoint.go
+++ b/internal/component/prometheus/exporter/catchpoint/catchpoint.go
@@ -18,8 +18,9 @@ func init() {
 	})
 }
 
-func createExporter(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
+func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
 	a := args.(Arguments)
+	defaultInstanceKey := opts.ID // if cannot resolve instance key, use the component ID
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)
 }
 

--- a/internal/component/prometheus/exporter/cloudwatch/cloudwatch.go
+++ b/internal/component/prometheus/exporter/cloudwatch/cloudwatch.go
@@ -21,7 +21,7 @@ func init() {
 	})
 }
 
-func createExporter(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
+func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
 	a := args.(Arguments)
 	exporterConfig, err := ConvertToYACE(a, opts.Logger)
 	if err != nil {

--- a/internal/component/prometheus/exporter/common/cluster_warning.go
+++ b/internal/component/prometheus/exporter/common/cluster_warning.go
@@ -1,0 +1,32 @@
+package common
+
+import (
+	"github.com/grafana/alloy/internal/component"
+	"github.com/grafana/alloy/internal/runtime/logging/level"
+	"github.com/grafana/alloy/internal/service/cluster"
+)
+
+func WarningIfUsedInCluster(o component.Options) {
+	data, err := o.GetServiceData(cluster.ServiceName)
+	if err != nil { // this should never happen as all Alloy instances have clustering service.
+		level.Warn(o.Logger).Log("msg", "error getting clustering service data", "err", err)
+		return
+	}
+
+	clusterData := data.(cluster.Cluster)
+	if clusterData == nil { // this should also never happen, but adding a check just in case
+		level.Warn(o.Logger).Log("msg", "cluster data is nil", "component", o.ID)
+		return
+	}
+
+	if !clusterData.Ready() || len(clusterData.Peers()) > 0 {
+		level.Warn(o.Logger).Log(
+			"msg",
+			"detected clustering is configured while using a host-specific exporter - please make sure your configuration is correct",
+			"exporter",
+			o.ID,
+			"details",
+			"The default instance label set by this exporter is the hostname of the machine running Alloy. Alloy clustering uses consistent hashing to distribute targets across the instances. This approach requires the discovered targets to be the same and have the same labels across all cluster instances. Please make sure you correctly set the instance label for this exporter or use a prometheus.scrape with disabled clustering. Alternatively, you can move this pipeline to a different Alloy deployment that does not use clustering.",
+		)
+	}
+}

--- a/internal/component/prometheus/exporter/common/default_instance.go
+++ b/internal/component/prometheus/exporter/common/default_instance.go
@@ -1,0 +1,19 @@
+package common
+
+import "os"
+
+// HostNameInstanceKey retrieves the hostname identifying the machine the process is
+// running on. It will return the value of $HOSTNAME, if defined, and fall
+// back to Go's os.Hostname. If that fails, it will return "unknown".
+func HostNameInstanceKey() string {
+	hostname := os.Getenv("HOSTNAME")
+	if hostname != "" {
+		return hostname
+	}
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "unknown"
+	}
+	return hostname
+}

--- a/internal/component/prometheus/exporter/consul/consul.go
+++ b/internal/component/prometheus/exporter/consul/consul.go
@@ -21,8 +21,9 @@ func init() {
 	})
 }
 
-func createExporter(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
+func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
 	a := args.(Arguments)
+	defaultInstanceKey := opts.ID // if cannot resolve instance key, use the component ID
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)
 }
 

--- a/internal/component/prometheus/exporter/dnsmasq/dnsmasq.go
+++ b/internal/component/prometheus/exporter/dnsmasq/dnsmasq.go
@@ -19,8 +19,9 @@ func init() {
 	})
 }
 
-func createExporter(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
+func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
 	a := args.(Arguments)
+	defaultInstanceKey := opts.ID // if cannot resolve instance key, use the component ID
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)
 }
 

--- a/internal/component/prometheus/exporter/elasticsearch/elasticsearch.go
+++ b/internal/component/prometheus/exporter/elasticsearch/elasticsearch.go
@@ -22,8 +22,9 @@ func init() {
 	})
 }
 
-func createExporter(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
+func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
 	a := args.(Arguments)
+	defaultInstanceKey := opts.ID // if cannot resolve instance key, use the component ID
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)
 }
 

--- a/internal/component/prometheus/exporter/exporter.go
+++ b/internal/component/prometheus/exporter/exporter.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 	"path"
 	"strings"
 	"sync"
@@ -19,7 +18,7 @@ import (
 )
 
 // Creator is a function provided by an implementation to create a concrete exporter instance.
-type Creator func(component.Options, component.Arguments, string) (integrations.Integration, string, error)
+type Creator func(component.Options, component.Arguments) (integrations.Integration, string, error)
 
 // Exports are simply a list of targets for a scraper to consume.
 type Exports struct {
@@ -86,17 +85,18 @@ func (c *Component) Run(ctx context.Context) error {
 
 // Update implements component.Component.
 func (c *Component) Update(args component.Arguments) error {
-	exporter, instanceKey, err := c.creator(c.opts, args, defaultInstance())
+	exporter, instanceKey, err := c.creator(c.opts, args)
 	if err != nil {
 		return err
 	}
 	c.mut.Lock()
 	c.exporter = exporter
-	if instanceKey != "" {
-		tb := discovery.NewTargetBuilderFrom(c.baseTarget)
-		tb.Set("instance", instanceKey)
-		c.baseTarget = tb.Target()
+	if instanceKey == "" { // exporters should return non-empty instanceKey, but in case of a bug default to 'unknown'.
+		instanceKey = "unknown"
 	}
+	tb := discovery.NewTargetBuilderFrom(c.baseTarget)
+	tb.Set("instance", instanceKey)
+	c.baseTarget = tb.Target()
 
 	var targets []discovery.Target
 	if c.targetBuilderFunc == nil {
@@ -132,8 +132,6 @@ func newExporter(creator Creator, name string, targetBuilderFunc func(discovery.
 			targetBuilderFunc: targetBuilderFunc,
 		}
 		jobName := fmt.Sprintf("integrations/%s", name)
-		instance := defaultInstance()
-
 		data, err := opts.GetServiceData(http_service.ServiceName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get HTTP information: %w", err)
@@ -149,7 +147,6 @@ func newExporter(creator Creator, name string, targetBuilderFunc func(discovery.
 			model.AddressLabel:      httpData.MemoryListenAddr,
 			model.SchemeLabel:       "http",
 			model.MetricsPathLabel:  path.Join(httpData.HTTPPathForComponent(opts.ID), "metrics"),
-			"instance":              instance,
 			"job":                   jobName,
 			"__meta_component_name": componentName,
 			"__meta_component_id":   opts.ID,
@@ -173,20 +170,4 @@ func (c *Component) getHttpHandler(integration integrations.Integration) http.Ha
 		})
 	}
 	return h
-}
-
-// defaultInstance retrieves the hostname identifying the machine the process is
-// running on. It will return the value of $HOSTNAME, if defined, and fall
-// back to Go's os.Hostname. If that fails, it will return "unknown".
-func defaultInstance() string {
-	hostname := os.Getenv("HOSTNAME")
-	if hostname != "" {
-		return hostname
-	}
-
-	hostname, err := os.Hostname()
-	if err != nil {
-		return "unknown"
-	}
-	return hostname
 }

--- a/internal/component/prometheus/exporter/gcp/gcp.go
+++ b/internal/component/prometheus/exporter/gcp/gcp.go
@@ -21,8 +21,9 @@ func init() {
 	})
 }
 
-func createExporter(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
+func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
 	a := args.(Arguments)
+	defaultInstanceKey := opts.ID // if cannot resolve instance key, use the component ID
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)
 }
 

--- a/internal/component/prometheus/exporter/github/github.go
+++ b/internal/component/prometheus/exporter/github/github.go
@@ -21,8 +21,9 @@ func init() {
 	})
 }
 
-func createExporter(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
+func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
 	a := args.(Arguments)
+	defaultInstanceKey := opts.ID // if cannot resolve instance key, use the component ID
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)
 }
 

--- a/internal/component/prometheus/exporter/kafka/kafka.go
+++ b/internal/component/prometheus/exporter/kafka/kafka.go
@@ -102,8 +102,9 @@ func customizeTarget(baseTarget discovery.Target, args component.Arguments) []di
 	return []discovery.Target{targetBuilder.Target()}
 }
 
-func createExporter(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
+func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
 	a := args.(Arguments)
+	defaultInstanceKey := opts.ID // if cannot resolve instance key, use the component ID
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)
 }
 

--- a/internal/component/prometheus/exporter/memcached/memcached.go
+++ b/internal/component/prometheus/exporter/memcached/memcached.go
@@ -22,8 +22,9 @@ func init() {
 	})
 }
 
-func createExporter(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
+func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
 	a := args.(Arguments)
+	defaultInstanceKey := opts.ID // if cannot resolve instance key, use the component ID
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)
 }
 

--- a/internal/component/prometheus/exporter/mongodb/mongodb.go
+++ b/internal/component/prometheus/exporter/mongodb/mongodb.go
@@ -21,8 +21,9 @@ func init() {
 	})
 }
 
-func createExporter(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
+func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
 	a := args.(Arguments)
+	defaultInstanceKey := opts.ID // if cannot resolve instance key, use the component ID
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)
 }
 

--- a/internal/component/prometheus/exporter/mssql/mssql.go
+++ b/internal/component/prometheus/exporter/mssql/mssql.go
@@ -28,8 +28,9 @@ func init() {
 	})
 }
 
-func createExporter(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
+func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
 	a := args.(Arguments)
+	defaultInstanceKey := opts.ID // if cannot resolve instance key, use the component ID
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)
 }
 

--- a/internal/component/prometheus/exporter/mysql/mysql.go
+++ b/internal/component/prometheus/exporter/mysql/mysql.go
@@ -22,8 +22,9 @@ func init() {
 	})
 }
 
-func createExporter(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
+func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
 	a := args.(Arguments)
+	defaultInstanceKey := opts.ID // if cannot resolve instance key, use the component ID
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)
 }
 

--- a/internal/component/prometheus/exporter/oracledb/oracledb.go
+++ b/internal/component/prometheus/exporter/oracledb/oracledb.go
@@ -29,8 +29,9 @@ func init() {
 	})
 }
 
-func createExporter(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
+func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
 	a := args.(Arguments)
+	defaultInstanceKey := opts.ID // if cannot resolve instance key, use the component ID
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)
 }
 

--- a/internal/component/prometheus/exporter/postgres/postgres.go
+++ b/internal/component/prometheus/exporter/postgres/postgres.go
@@ -23,8 +23,9 @@ func init() {
 	})
 }
 
-func createExporter(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
+func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
 	a := args.(Arguments)
+	defaultInstanceKey := opts.ID // default to component ID if no better instance key can be found
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.convert(opts.ID), defaultInstanceKey)
 }
 

--- a/internal/component/prometheus/exporter/process/process.go
+++ b/internal/component/prometheus/exporter/process/process.go
@@ -3,6 +3,7 @@ package process
 import (
 	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/component/prometheus/exporter"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/common"
 	"github.com/grafana/alloy/internal/featuregate"
 	"github.com/grafana/alloy/internal/static/integrations"
 	"github.com/grafana/alloy/internal/static/integrations/process_exporter"
@@ -20,8 +21,9 @@ func init() {
 	})
 }
 
-func createIntegration(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
+func createIntegration(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
 	a := args.(Arguments)
+	defaultInstanceKey := common.HostNameInstanceKey() // if cannot resolve instance key, use the host name for process exporter
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)
 }
 

--- a/internal/component/prometheus/exporter/process/process.go
+++ b/internal/component/prometheus/exporter/process/process.go
@@ -22,6 +22,7 @@ func init() {
 }
 
 func createIntegration(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
+	common.WarningIfUsedInCluster(opts)
 	a := args.(Arguments)
 	defaultInstanceKey := common.HostNameInstanceKey() // if cannot resolve instance key, use the host name for process exporter
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)

--- a/internal/component/prometheus/exporter/redis/redis.go
+++ b/internal/component/prometheus/exporter/redis/redis.go
@@ -25,8 +25,9 @@ func init() {
 	})
 }
 
-func createExporter(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
+func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
 	a := args.(Arguments)
+	defaultInstanceKey := opts.ID // if cannot resolve instance key, use the component ID
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)
 }
 

--- a/internal/component/prometheus/exporter/self/self.go
+++ b/internal/component/prometheus/exporter/self/self.go
@@ -3,6 +3,7 @@ package self
 import (
 	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/component/prometheus/exporter"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/common"
 	"github.com/grafana/alloy/internal/featuregate"
 	"github.com/grafana/alloy/internal/static/integrations"
 	"github.com/grafana/alloy/internal/static/integrations/agent"
@@ -19,8 +20,9 @@ func init() {
 	})
 }
 
-func createExporter(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
+func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
 	a := args.(Arguments)
+	defaultInstanceKey := common.HostNameInstanceKey() // if cannot resolve instance key, use the host name for self exporter
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)
 }
 

--- a/internal/component/prometheus/exporter/self/self.go
+++ b/internal/component/prometheus/exporter/self/self.go
@@ -21,6 +21,8 @@ func init() {
 }
 
 func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
+	// We don't warn if this exporter is used in a cluster as prometheus.exporter.self is not host-specific, but Alloy-specific and
+	// it's frequently used in a cluster with a non-clustered prometheus.scrape component.
 	a := args.(Arguments)
 	defaultInstanceKey := common.HostNameInstanceKey() // if cannot resolve instance key, use the host name for self exporter
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)

--- a/internal/component/prometheus/exporter/snmp/snmp.go
+++ b/internal/component/prometheus/exporter/snmp/snmp.go
@@ -29,8 +29,9 @@ func init() {
 	})
 }
 
-func createExporter(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
+func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
 	a := args.(Arguments)
+	defaultInstanceKey := opts.ID // if cannot resolve instance key, use the component ID
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)
 }
 

--- a/internal/component/prometheus/exporter/snowflake/snowflake.go
+++ b/internal/component/prometheus/exporter/snowflake/snowflake.go
@@ -21,8 +21,9 @@ func init() {
 	})
 }
 
-func createExporter(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
+func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
 	a := args.(Arguments)
+	defaultInstanceKey := opts.ID // if cannot resolve instance key, use the component ID
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)
 }
 

--- a/internal/component/prometheus/exporter/squid/squid.go
+++ b/internal/component/prometheus/exporter/squid/squid.go
@@ -23,8 +23,9 @@ func init() {
 	})
 }
 
-func createExporter(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
+func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
 	a := args.(Arguments)
+	defaultInstanceKey := opts.ID // if cannot resolve instance key, use the component ID
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)
 }
 

--- a/internal/component/prometheus/exporter/statsd/statsd.go
+++ b/internal/component/prometheus/exporter/statsd/statsd.go
@@ -18,11 +18,12 @@ func init() {
 	})
 }
 
-func createExporter(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
+func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
 	a := args.(Arguments)
 	cfg, err := a.Convert()
 	if err != nil {
 		return nil, "", err
 	}
+	defaultInstanceKey := opts.ID // use component ID if there is no better option
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, cfg, defaultInstanceKey)
 }

--- a/internal/component/prometheus/exporter/tests/instance_key_test.go
+++ b/internal/component/prometheus/exporter/tests/instance_key_test.go
@@ -42,7 +42,7 @@ import (
 	"github.com/grafana/alloy/internal/component/prometheus/exporter/statsd"
 	"github.com/grafana/alloy/internal/component/prometheus/exporter/unix"
 	"github.com/grafana/alloy/internal/component/prometheus/exporter/windows"
-	http_service "github.com/grafana/alloy/internal/service/http"
+	httpservice "github.com/grafana/alloy/internal/service/http"
 	"github.com/grafana/alloy/syntax/alloytypes"
 )
 
@@ -95,8 +95,8 @@ func TestInstanceKey(t *testing.T) {
 				},
 			},
 			temporaryHostname: "test-agent",
-			// TODO: this is not desired - the instance should reflect the target being exported
-			expectedInstanceLabel: "test-agent",
+			// Blackbox exporter can target many hosts, so we don't have anything reliable to use.
+			expectedInstanceLabel: "prometheus.exporter.blackbox.test_comp_id",
 		},
 		{
 			testName:      "cadvisor",
@@ -114,8 +114,8 @@ func TestInstanceKey(t *testing.T) {
 			args: catchpoint.Arguments{
 				Port: "9090",
 			},
-			// TODO: this is not desired - catchpoint exporter is a webhook endpoint that is called by catchpoint
-			//       we don't know where it is called from. Port is better than hostname, but not ideal.
+			// Port is better than hostname, but not ideal. Catchpoint is a webhook called externally, so there is no
+			// clearly better option here.
 			expectedInstanceLabel: "9090",
 		},
 		{
@@ -198,7 +198,7 @@ func TestInstanceKey(t *testing.T) {
 				Organizations: []string{"org1", "org2"},
 				Users:         []string{"user1", "user2"},
 			},
-			// TODO: it may not be enough - we may need the repositories and orgs? or use hash?
+			// This is better than hostname, but it may not be enough - we may need the repositories and orgs?
 			expectedInstanceLabel: "api.github.com:8080",
 		},
 		// TODO: kafka exporters won't build successfully if it cannot connect right away to kafka. This is not
@@ -297,7 +297,6 @@ func TestInstanceKey(t *testing.T) {
 					alloytypes.Secret("postgresql://host02:5432/dbname"),
 				},
 			},
-			// TODO: this is a good alternative, but perhaps there are better options?
 			expectedInstanceLabel: "prometheus.exporter.postgres.test_comp_id",
 		},
 		{
@@ -335,8 +334,8 @@ func TestInstanceKey(t *testing.T) {
 				},
 			},
 			temporaryHostname: "test-agent",
-			// TODO: this is likely not desired. SNMP can be multiple remote hosts.
-			expectedInstanceLabel: "test-agent",
+			// SNMP can be used for many targets, there is no better target name we can be certain of
+			expectedInstanceLabel: "prometheus.exporter.snmp.test_comp_id",
 		},
 		{
 			testName:      "snowflake",
@@ -370,8 +369,8 @@ func TestInstanceKey(t *testing.T) {
 				CacheType:  "lru",
 			},
 			temporaryHostname: "test-agent",
-			// TODO: this is likely not desired - statsd opens a listener and receives data from different sources
-			expectedInstanceLabel: "test-agent",
+			// StatsD exporter can receive data from network, so the best default we have is
+			expectedInstanceLabel: "prometheus.exporter.statsd.test_comp_id",
 		},
 		{
 			testName:      "unix",
@@ -408,8 +407,8 @@ func TestInstanceKey(t *testing.T) {
 				ID: tt.componentName + ".test_comp_id",
 				GetServiceData: func(name string) (interface{}, error) {
 					switch name {
-					case http_service.ServiceName:
-						return http_service.Data{
+					case httpservice.ServiceName:
+						return httpservice.Data{
 							HTTPListenAddr:   "localhost:12345",
 							MemoryListenAddr: "alloy.internal:1245",
 							BaseHTTPPath:     "/",

--- a/internal/component/prometheus/exporter/unix/unix.go
+++ b/internal/component/prometheus/exporter/unix/unix.go
@@ -3,6 +3,7 @@ package unix
 import (
 	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/component/prometheus/exporter"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/common"
 	"github.com/grafana/alloy/internal/featuregate"
 	"github.com/grafana/alloy/internal/static/integrations"
 )
@@ -18,7 +19,8 @@ func init() {
 	})
 }
 
-func createExporter(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
+func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
 	a := args.(Arguments)
+	defaultInstanceKey := common.HostNameInstanceKey() // if cannot resolve instance key, use the host name for unix exporter
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)
 }

--- a/internal/component/prometheus/exporter/unix/unix.go
+++ b/internal/component/prometheus/exporter/unix/unix.go
@@ -20,6 +20,7 @@ func init() {
 }
 
 func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
+	common.WarningIfUsedInCluster(opts)
 	a := args.(Arguments)
 	defaultInstanceKey := common.HostNameInstanceKey() // if cannot resolve instance key, use the host name for unix exporter
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)

--- a/internal/component/prometheus/exporter/windows/windows.go
+++ b/internal/component/prometheus/exporter/windows/windows.go
@@ -20,6 +20,7 @@ func init() {
 }
 
 func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
+	common.WarningIfUsedInCluster(opts)
 	a := args.(Arguments)
 	defaultInstanceKey := common.HostNameInstanceKey() // if cannot resolve instance key, use the host name for windows exporter
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(opts.Logger), defaultInstanceKey)

--- a/internal/component/prometheus/exporter/windows/windows.go
+++ b/internal/component/prometheus/exporter/windows/windows.go
@@ -3,6 +3,7 @@ package windows
 import (
 	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/component/prometheus/exporter"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/common"
 	"github.com/grafana/alloy/internal/featuregate"
 	"github.com/grafana/alloy/internal/static/integrations"
 )
@@ -18,7 +19,8 @@ func init() {
 	})
 }
 
-func createExporter(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
+func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
 	a := args.(Arguments)
+	defaultInstanceKey := common.HostNameInstanceKey() // if cannot resolve instance key, use the host name for windows exporter
 	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(opts.Logger), defaultInstanceKey)
 }

--- a/internal/static/integrations/agent/agent.go
+++ b/internal/static/integrations/agent/agent.go
@@ -8,9 +8,10 @@ import (
 	"net/http"
 
 	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
 	"github.com/grafana/alloy/internal/static/integrations"
 	"github.com/grafana/alloy/internal/static/integrations/config"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // Config controls the Agent integration.
@@ -21,9 +22,8 @@ func (c *Config) Name() string {
 	return "agent"
 }
 
-// InstanceKey returns the hostname of the machine.
-func (c *Config) InstanceKey(agentKey string) (string, error) {
-	return agentKey, nil
+func (c *Config) InstanceKey(defaultKey string) (string, error) {
+	return defaultKey, nil
 }
 
 // NewIntegration converts this config into an instance of an integration.

--- a/internal/static/integrations/apache_http/apache_http.go
+++ b/internal/static/integrations/apache_http/apache_http.go
@@ -7,6 +7,7 @@ import (
 	ae "github.com/Lusitaniae/apache_exporter/collector"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+
 	"github.com/grafana/alloy/internal/static/integrations"
 )
 
@@ -38,7 +39,7 @@ func (c *Config) Name() string {
 }
 
 // InstanceKey returns the addr of the apache server.
-func (c *Config) InstanceKey(agentKey string) (string, error) {
+func (c *Config) InstanceKey(_ string) (string, error) {
 	u, err := url.Parse(c.ApacheAddr)
 	if err != nil {
 		return "", err
@@ -64,7 +65,7 @@ func New(logger log.Logger, c *Config) (integrations.Integration, error) {
 		Insecure:     c.ApacheInsecure,
 	}
 
-	//check scrape URI
+	// check scrape URI
 	_, err := url.ParseRequestURI(conf.ScrapeURI)
 	if err != nil {
 		level.Error(logger).Log("msg", "scrape_uri is invalid", "err", err)

--- a/internal/static/integrations/blackbox_exporter/blackbox_exporter.go
+++ b/internal/static/integrations/blackbox_exporter/blackbox_exporter.go
@@ -7,13 +7,14 @@ import (
 	"net/url"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/alloy/internal/static/integrations"
-	"github.com/grafana/alloy/internal/static/integrations/config"
-	"github.com/grafana/alloy/internal/util"
 	blackbox_config "github.com/prometheus/blackbox_exporter/config"
 	"github.com/prometheus/blackbox_exporter/prober"
 	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/yaml.v3"
+
+	"github.com/grafana/alloy/internal/static/integrations"
+	"github.com/grafana/alloy/internal/static/integrations/config"
+	"github.com/grafana/alloy/internal/util"
 )
 
 // DefaultConfig holds the default settings for the blackbox_exporter integration.
@@ -66,9 +67,8 @@ func (c *Config) Name() string {
 	return "blackbox"
 }
 
-// InstanceKey returns the hostname:port of the agent.
-func (c *Config) InstanceKey(agentKey string) (string, error) {
-	return agentKey, nil
+func (c *Config) InstanceKey(defaultKey string) (string, error) {
+	return defaultKey, nil
 }
 
 // NewIntegration creates a new blackbox integration.

--- a/internal/static/integrations/cadvisor/common.go
+++ b/internal/static/integrations/cadvisor/common.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+
 	"github.com/grafana/alloy/internal/static/integrations"
 	integrations_v2 "github.com/grafana/alloy/internal/static/integrations/v2"
 	"github.com/grafana/alloy/internal/static/integrations/v2/metricsutils"
@@ -130,9 +131,8 @@ func (c *Config) Name() string {
 	return name
 }
 
-// InstanceKey returns the agentKey
-func (c *Config) InstanceKey(agentKey string) (string, error) {
-	return agentKey, nil
+func (c *Config) InstanceKey(defaultKey string) (string, error) {
+	return defaultKey, nil
 }
 
 func init() {

--- a/internal/static/integrations/catchpoint_exporter/catchpoint_exporter.go
+++ b/internal/static/integrations/catchpoint_exporter/catchpoint_exporter.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 
 	"github.com/go-kit/log"
+
 	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/grafana/alloy/internal/static/integrations"
 	integrations_v2 "github.com/grafana/alloy/internal/static/integrations/v2"
@@ -34,8 +35,7 @@ func (c *Config) exporterConfig() *collector.Config {
 	}
 }
 
-// Identifier returns a string that identifies the integration.
-func (c *Config) InstanceKey(agentKey string) (string, error) {
+func (c *Config) InstanceKey(_ string) (string, error) {
 	return c.Port, nil
 }
 

--- a/internal/static/integrations/cloudwatch_exporter/config.go
+++ b/internal/static/integrations/cloudwatch_exporter/config.go
@@ -127,7 +127,7 @@ func (c *Config) Name() string {
 	return "cloudwatch_exporter"
 }
 
-func (c *Config) InstanceKey(agentKey string) (string, error) {
+func (c *Config) InstanceKey(_ string) (string, error) {
 	return getHash(c)
 }
 

--- a/internal/static/integrations/consul_exporter/consul_exporter.go
+++ b/internal/static/integrations/consul_exporter/consul_exporter.go
@@ -7,11 +7,12 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	consul_api "github.com/hashicorp/consul/api"
+	"github.com/prometheus/consul_exporter/pkg/exporter"
+
 	"github.com/grafana/alloy/internal/static/integrations"
 	integrations_v2 "github.com/grafana/alloy/internal/static/integrations/v2"
 	"github.com/grafana/alloy/internal/static/integrations/v2/metricsutils"
-	consul_api "github.com/hashicorp/consul/api"
-	"github.com/prometheus/consul_exporter/pkg/exporter"
 )
 
 // DefaultConfig holds the default settings for the consul_exporter integration.
@@ -55,7 +56,7 @@ func (c *Config) Name() string {
 }
 
 // InstanceKey returns the hostname:port of the Consul server.
-func (c *Config) InstanceKey(agentKey string) (string, error) {
+func (c *Config) InstanceKey(_ string) (string, error) {
 	u, err := url.Parse(c.Server)
 	if err != nil {
 		return "", fmt.Errorf("could not parse url: %w", err)

--- a/internal/static/integrations/dnsmasq_exporter/dnsmasq_exporter.go
+++ b/internal/static/integrations/dnsmasq_exporter/dnsmasq_exporter.go
@@ -4,10 +4,11 @@ package dnsmasq_exporter
 import (
 	"github.com/go-kit/log"
 	"github.com/google/dnsmasq_exporter/collector"
+	"github.com/miekg/dns"
+
 	"github.com/grafana/alloy/internal/static/integrations"
 	integrations_v2 "github.com/grafana/alloy/internal/static/integrations/v2"
 	"github.com/grafana/alloy/internal/static/integrations/v2/metricsutils"
-	"github.com/miekg/dns"
 )
 
 // DefaultConfig is the default config for dnsmasq_exporter.
@@ -35,7 +36,7 @@ func (c *Config) Name() string {
 }
 
 // InstanceKey returns the address of the dnsmasq server.
-func (c *Config) InstanceKey(agentKey string) (string, error) {
+func (c *Config) InstanceKey(_ string) (string, error) {
 	return c.DnsmasqAddress, nil
 }
 

--- a/internal/static/integrations/elasticsearch_exporter/elasticsearch_exporter.go
+++ b/internal/static/integrations/elasticsearch_exporter/elasticsearch_exporter.go
@@ -14,11 +14,12 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	promCfg "github.com/prometheus/common/config"
+
 	"github.com/grafana/alloy/internal/static/integrations"
 	integrations_v2 "github.com/grafana/alloy/internal/static/integrations/v2"
 	"github.com/grafana/alloy/internal/static/integrations/v2/metricsutils"
-	"github.com/prometheus/client_golang/prometheus"
-	promCfg "github.com/prometheus/common/config"
 
 	"github.com/prometheus-community/elasticsearch_exporter/collector"
 	"github.com/prometheus-community/elasticsearch_exporter/pkg/clusterinfo"
@@ -101,7 +102,7 @@ func (c *Config) Name() string {
 }
 
 // InstanceKey returns the hostname:port of the elasticsearch node being queried.
-func (c *Config) InstanceKey(agentKey string) (string, error) {
+func (c *Config) InstanceKey(_ string) (string, error) {
 	u, err := url.Parse(c.Address)
 	if err != nil {
 		return "", fmt.Errorf("could not parse url: %w", err)

--- a/internal/static/integrations/github_exporter/github_exporter.go
+++ b/internal/static/integrations/github_exporter/github_exporter.go
@@ -8,10 +8,11 @@ import (
 	"github.com/githubexporter/github-exporter/exporter"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	config_util "github.com/prometheus/common/config"
+
 	"github.com/grafana/alloy/internal/static/integrations"
 	integrations_v2 "github.com/grafana/alloy/internal/static/integrations/v2"
 	"github.com/grafana/alloy/internal/static/integrations/v2/metricsutils"
-	config_util "github.com/prometheus/common/config"
 )
 
 // DefaultConfig holds the default settings for the github_exporter integration
@@ -54,7 +55,7 @@ func (c *Config) Name() string {
 }
 
 // InstanceKey returns the hostname:port of the GitHub API server.
-func (c *Config) InstanceKey(agentKey string) (string, error) {
+func (c *Config) InstanceKey(_ string) (string, error) {
 	u, err := url.Parse(c.APIURL)
 	if err != nil {
 		return "", fmt.Errorf("could not parse url: %w", err)

--- a/internal/static/integrations/integration.go
+++ b/internal/static/integrations/integration.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/go-kit/log"
+
 	"github.com/grafana/alloy/internal/static/integrations/config"
 )
 
@@ -17,13 +18,14 @@ type Config interface {
 	// InstanceKey should return the key that represents the config, which will be
 	// used to populate the value of the `instance` label for metrics.
 	//
-	// InstanceKey is given an agentKey that represents the agent process. This
-	// may be used if the integration being configured applies to an entire
-	// machine.
+	// InstanceKey is given a defaultKey that can be used to represent this exporter if
+	// the implementation cannot provide a better alternative based on config. What defaultKey
+	// is set to, will depend on the scope of the exporter. For example, if the exporter collects
+	// metrics from the entire machine, it may be the hostname of the local machine.
 	//
 	// This method may not be invoked if the instance key for a Config is
 	// overridden.
-	InstanceKey(agentKey string) (string, error)
+	InstanceKey(defaultKey string) (string, error)
 
 	// NewIntegration returns an integration for the given with the given logger.
 	NewIntegration(l log.Logger) (Integration, error)
@@ -51,8 +53,8 @@ type Integration interface {
 
 // NewIntegrationWithInstanceKey uses cfg to construct an integration and
 // return it along its instance key.
-func NewIntegrationWithInstanceKey(l log.Logger, cfg Config, key string) (Integration, string, error) {
-	key, err := cfg.InstanceKey(key)
+func NewIntegrationWithInstanceKey(l log.Logger, cfg Config, defaultKey string) (Integration, string, error) {
+	key, err := cfg.InstanceKey(defaultKey)
 	if err != nil {
 		return nil, key, err
 	}

--- a/internal/static/integrations/kafka_exporter/kafka_exporter.go
+++ b/internal/static/integrations/kafka_exporter/kafka_exporter.go
@@ -7,11 +7,12 @@ import (
 
 	"github.com/IBM/sarama"
 	"github.com/go-kit/log"
+	kafka_exporter "github.com/grafana/kafka_exporter/exporter"
+
 	"github.com/grafana/alloy/internal/runtime/logging/level"
 	"github.com/grafana/alloy/internal/static/integrations"
 	integrations_v2 "github.com/grafana/alloy/internal/static/integrations/v2"
 	"github.com/grafana/alloy/internal/static/integrations/v2/metricsutils"
-	kafka_exporter "github.com/grafana/kafka_exporter/exporter"
 )
 
 // DefaultConfig holds the default settings for the kafka_lag_exporter
@@ -152,7 +153,7 @@ func (c *Config) Name() string {
 // InstanceKey returns the hostname:port of the first Kafka node, if any. If
 // there is not exactly one Kafka node, the user must manually provide
 // their own value for instance key in the common config.
-func (c *Config) InstanceKey(agentKey string) (string, error) {
+func (c *Config) InstanceKey(_ string) (string, error) {
 	if len(c.KafkaURIs) == 1 {
 		return c.KafkaURIs[0], nil
 	}

--- a/internal/static/integrations/memcached_exporter/memcached_exporter.go
+++ b/internal/static/integrations/memcached_exporter/memcached_exporter.go
@@ -2,18 +2,18 @@
 package memcached_exporter
 
 import (
-	"time"
-
 	"crypto/tls"
+	"time"
 
 	config_util "github.com/prometheus/common/config"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/prometheus/memcached_exporter/pkg/exporter"
+
 	"github.com/grafana/alloy/internal/static/integrations"
 	integrations_v2 "github.com/grafana/alloy/internal/static/integrations/v2"
 	"github.com/grafana/alloy/internal/static/integrations/v2/metricsutils"
-	"github.com/prometheus/memcached_exporter/pkg/exporter"
 )
 
 // DefaultConfig is the default config for memcached_exporter.
@@ -48,7 +48,7 @@ func (c *Config) Name() string {
 }
 
 // InstanceKey returns the address:port of the memcached server.
-func (c *Config) InstanceKey(agentKey string) (string, error) {
+func (c *Config) InstanceKey(_ string) (string, error) {
 	return c.MemcachedAddress, nil
 }
 

--- a/internal/static/integrations/mssql/sql_exporter.go
+++ b/internal/static/integrations/mssql/sql_exporter.go
@@ -13,11 +13,12 @@ import (
 
 	"github.com/burningalchemist/sql_exporter"
 	"github.com/burningalchemist/sql_exporter/config"
+	"github.com/prometheus/common/model"
+
 	"github.com/grafana/alloy/internal/static/integrations"
 	integrations_v2 "github.com/grafana/alloy/internal/static/integrations/v2"
 	"github.com/grafana/alloy/internal/static/integrations/v2/metricsutils"
 	"github.com/grafana/alloy/internal/util"
-	"github.com/prometheus/common/model"
 )
 
 // DefaultConfig is the default config for the mssql integration
@@ -67,7 +68,7 @@ func (c Config) validate() error {
 }
 
 // Identifier returns a string that identifies the integration.
-func (c *Config) InstanceKey(agentKey string) (string, error) {
+func (c *Config) InstanceKey(_ string) (string, error) {
 	url, err := url.Parse(string(c.ConnectionString))
 	if err != nil {
 		return "", fmt.Errorf("failed to parse connection string URL: %w", err)

--- a/internal/static/integrations/node_exporter/config.go
+++ b/internal/static/integrations/node_exporter/config.go
@@ -8,12 +8,13 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/alloy/internal/static/integrations"
-	integrations_v2 "github.com/grafana/alloy/internal/static/integrations/v2"
-	"github.com/grafana/alloy/internal/static/integrations/v2/metricsutils"
 	"github.com/grafana/dskit/flagext"
 	"github.com/prometheus/node_exporter/collector"
 	"github.com/prometheus/procfs"
+
+	"github.com/grafana/alloy/internal/static/integrations"
+	integrations_v2 "github.com/grafana/alloy/internal/static/integrations/v2"
+	"github.com/grafana/alloy/internal/static/integrations/v2/metricsutils"
 )
 
 var (
@@ -252,9 +253,8 @@ func (c *Config) Name() string {
 	return "node_exporter"
 }
 
-// InstanceKey returns the hostname:port of the agent process.
-func (c *Config) InstanceKey(agentKey string) (string, error) {
-	return agentKey, nil
+func (c *Config) InstanceKey(defaultKey string) (string, error) {
+	return defaultKey, nil
 }
 
 // NewIntegration converts this config into an instance of an integration.

--- a/internal/static/integrations/process_exporter/config.go
+++ b/internal/static/integrations/process_exporter/config.go
@@ -3,6 +3,7 @@ package process_exporter
 
 import (
 	"github.com/go-kit/log"
+
 	"github.com/grafana/alloy/internal/static/integrations"
 	integrations_v2 "github.com/grafana/alloy/internal/static/integrations/v2"
 	"github.com/grafana/alloy/internal/static/integrations/v2/metricsutils"
@@ -45,9 +46,8 @@ func (c *Config) Name() string {
 	return "process_exporter"
 }
 
-// InstanceKey returns the hostname of the machine.
-func (c *Config) InstanceKey(agentKey string) (string, error) {
-	return agentKey, nil
+func (c *Config) InstanceKey(defaultKey string) (string, error) {
+	return defaultKey, nil
 }
 
 // NewIntegration converts this config into an instance of an integration.

--- a/internal/static/integrations/redis_exporter/redis_exporter.go
+++ b/internal/static/integrations/redis_exporter/redis_exporter.go
@@ -117,7 +117,7 @@ func (c *Config) Name() string {
 }
 
 // InstanceKey returns the addr of the redis server.
-func (c *Config) InstanceKey(agentKey string) (string, error) {
+func (c *Config) InstanceKey(_ string) (string, error) {
 	return c.RedisAddr, nil
 }
 
@@ -154,7 +154,7 @@ func New(log log.Logger, c *Config) (integrations.Integration, error) {
 		exporterConfig.LuaScript = scripts
 	}
 
-	//new version of the exporter takes the file paths directly, for hot-reloading support (https://github.com/oliver006/redis_exporter/pull/526)
+	// new version of the exporter takes the file paths directly, for hot-reloading support (https://github.com/oliver006/redis_exporter/pull/526)
 
 	if (c.TLSClientKeyFile != "") != (c.TLSClientCertFile != "") {
 		return nil, errors.New("TLS client key file and cert file should both be present")

--- a/internal/static/integrations/snmp_exporter/snmp_exporter.go
+++ b/internal/static/integrations/snmp_exporter/snmp_exporter.go
@@ -9,13 +9,14 @@ import (
 	"net/url"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/alloy/internal/static/integrations"
-	"github.com/grafana/alloy/internal/static/integrations/config"
-	snmp_common "github.com/grafana/alloy/internal/static/integrations/snmp_exporter/common"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/snmp_exporter/collector"
 	snmp_config "github.com/prometheus/snmp_exporter/config"
+
+	"github.com/grafana/alloy/internal/static/integrations"
+	"github.com/grafana/alloy/internal/static/integrations/config"
+	snmp_common "github.com/grafana/alloy/internal/static/integrations/snmp_exporter/common"
 )
 
 // DefaultConfig holds the default settings for the snmp_exporter integration.
@@ -62,9 +63,8 @@ func (c *Config) Name() string {
 	return "snmp"
 }
 
-// InstanceKey returns the hostname:port of the agent.
-func (c *Config) InstanceKey(agentKey string) (string, error) {
-	return agentKey, nil
+func (c *Config) InstanceKey(defaultKey string) (string, error) {
+	return defaultKey, nil
 }
 
 // NewIntegration creates a new SNMP integration.

--- a/internal/static/integrations/snowflake_exporter/snowflake_exporter.go
+++ b/internal/static/integrations/snowflake_exporter/snowflake_exporter.go
@@ -2,11 +2,12 @@ package snowflake_exporter
 
 import (
 	"github.com/go-kit/log"
+	"github.com/grafana/snowflake-prometheus-exporter/collector"
+	config_util "github.com/prometheus/common/config"
+
 	"github.com/grafana/alloy/internal/static/integrations"
 	integrations_v2 "github.com/grafana/alloy/internal/static/integrations/v2"
 	"github.com/grafana/alloy/internal/static/integrations/v2/metricsutils"
-	"github.com/grafana/snowflake-prometheus-exporter/collector"
-	config_util "github.com/prometheus/common/config"
 )
 
 // DefaultConfig is the default config for the snowflake integration
@@ -41,8 +42,7 @@ func (c *Config) exporterConfig() *collector.Config {
 	}
 }
 
-// Identifier returns a string that identifies the integration.
-func (c *Config) InstanceKey(agentKey string) (string, error) {
+func (c *Config) InstanceKey(_ string) (string, error) {
 	return c.AccountName, nil
 }
 

--- a/internal/static/integrations/squid_exporter/squid_exporter.go
+++ b/internal/static/integrations/squid_exporter/squid_exporter.go
@@ -8,8 +8,9 @@ import (
 
 	se "github.com/boynux/squid-exporter/collector"
 	"github.com/go-kit/log"
-	"github.com/grafana/alloy/internal/static/integrations"
 	config_util "github.com/prometheus/common/config"
+
+	"github.com/grafana/alloy/internal/static/integrations"
 
 	integrations_v2 "github.com/grafana/alloy/internal/static/integrations/v2"
 	"github.com/grafana/alloy/internal/static/integrations/v2/metricsutils"
@@ -71,7 +72,7 @@ func (c *Config) Name() string {
 }
 
 // InstanceKey returns the addr of the squid instance.
-func (c *Config) InstanceKey(agentKey string) (string, error) {
+func (c *Config) InstanceKey(_ string) (string, error) {
 	return c.Address, nil
 }
 

--- a/internal/static/integrations/statsd_exporter/statsd_exporter.go
+++ b/internal/static/integrations/statsd_exporter/statsd_exporter.go
@@ -12,12 +12,6 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/alloy/internal/build"
-	"github.com/grafana/alloy/internal/runtime/logging"
-	"github.com/grafana/alloy/internal/static/integrations"
-	"github.com/grafana/alloy/internal/static/integrations/config"
-	integrations_v2 "github.com/grafana/alloy/internal/static/integrations/v2"
-	"github.com/grafana/alloy/internal/static/integrations/v2/metricsutils"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/statsd_exporter/pkg/address"
@@ -30,6 +24,13 @@ import (
 	"github.com/prometheus/statsd_exporter/pkg/mappercache/randomreplacement"
 	"github.com/prometheus/statsd_exporter/pkg/relay"
 	"gopkg.in/yaml.v2"
+
+	"github.com/grafana/alloy/internal/build"
+	"github.com/grafana/alloy/internal/runtime/logging"
+	"github.com/grafana/alloy/internal/static/integrations"
+	"github.com/grafana/alloy/internal/static/integrations/config"
+	integrations_v2 "github.com/grafana/alloy/internal/static/integrations/v2"
+	"github.com/grafana/alloy/internal/static/integrations/v2/metricsutils"
 )
 
 // DefaultConfig holds the default settings for the statsd_exporter integration.
@@ -89,9 +90,8 @@ func (c *Config) Name() string {
 	return "statsd_exporter"
 }
 
-// InstanceKey returns the hostname:port of the agent.
-func (c *Config) InstanceKey(agentKey string) (string, error) {
-	return agentKey, nil
+func (c *Config) InstanceKey(defaultKey string) (string, error) {
+	return defaultKey, nil
 }
 
 // NewIntegration converts this config into an instance of an integration.

--- a/internal/static/integrations/vmware_exporter/vmware_exporter.go
+++ b/internal/static/integrations/vmware_exporter/vmware_exporter.go
@@ -7,10 +7,11 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/alloy/internal/runtime/logging"
-	"github.com/grafana/alloy/internal/static/integrations"
 	"github.com/grafana/vmware_exporter/vsphere"
 	config_util "github.com/prometheus/common/config"
+
+	"github.com/grafana/alloy/internal/runtime/logging"
+	"github.com/grafana/alloy/internal/static/integrations"
 )
 
 func init() {
@@ -50,7 +51,7 @@ func (c *Config) Name() string {
 }
 
 // InstanceKey returns a string that identifies the instance of the integration.
-func (c *Config) InstanceKey(agentKey string) (string, error) {
+func (c *Config) InstanceKey(_ string) (string, error) {
 	u, err := url.Parse(c.VSphereURL)
 	if err != nil {
 		return "", err

--- a/internal/static/integrations/windows_exporter/config.go
+++ b/internal/static/integrations/windows_exporter/config.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+
 	"github.com/grafana/alloy/internal/static/integrations"
 	integrations_v2 "github.com/grafana/alloy/internal/static/integrations/v2"
 	"github.com/grafana/alloy/internal/static/integrations/v2/metricsutils"
@@ -49,9 +50,8 @@ func (c *Config) Name() string {
 	return "windows_exporter"
 }
 
-// InstanceKey returns the hostname:port of the agent.
-func (c *Config) InstanceKey(agentKey string) (string, error) {
-	return agentKey, nil
+func (c *Config) InstanceKey(defaultKey string) (string, error) {
+	return defaultKey, nil
 }
 
 // NewIntegration creates an integration based on the given configuration


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

- Changes `instance` label to be the component name instead of the hostname of Alloy for the following exporters:
  - SNMP
  - StatsD
  - Blackbox

- [x] Document that process/windows/unix exporters should not be used with clustering.
- [x] Call out the change and document how to get the old behaviour.
- [x] Add a warning when clustering is enabled for process/windows/unix exporters.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
