### PR TITLE
add tests for exporters instance label

### DIFF
--- a/internal/component/prometheus/exporter/tests/instance_key_test.go
+++ b/internal/component/prometheus/exporter/tests/instance_key_test.go
@@ -353,12 +353,11 @@ func TestInstanceKey(t *testing.T) {
 			testName:      "statsd",
 			componentName: "prometheus.exporter.statsd",
 			args: statsd.Arguments{
-				ListenUDP:     "localhost:9125",
-				ListenTCP:     "localhost:9125",
-				MappingConfig: "test_mapping.yml",
-				ReadBuffer:    8192,
-				CacheSize:     1000,
-				CacheType:     "lru",
+				ListenUDP:  "localhost:9125",
+				ListenTCP:  "localhost:9125",
+				ReadBuffer: 8192,
+				CacheSize:  1000,
+				CacheType:  "lru",
 			},
 			temporaryHostname: "test-agent",
 			// TODO: this is likely not desired - statsd opens a listener and receives data from different sources

--- a/internal/component/prometheus/exporter/tests/instance_key_test.go
+++ b/internal/component/prometheus/exporter/tests/instance_key_test.go
@@ -1,0 +1,380 @@
+package exporter_test
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/internal/component"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/apache"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/azure"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/blackbox"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/cadvisor"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/catchpoint"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/cloudwatch"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/consul"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/dnsmasq"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/elasticsearch"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/gcp"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/github"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/kafka"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/memcached"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/mongodb"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/mssql"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/mysql"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/oracledb"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/postgres"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/process"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/redis"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/self"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/snmp"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/snowflake"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/squid"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/statsd"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/unix"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/windows"
+	http_service "github.com/grafana/alloy/internal/service/http"
+	"github.com/grafana/alloy/syntax/alloytypes"
+)
+
+type testConfig struct {
+	testName              string
+	componentName         string
+	args                  component.Arguments
+	expectedInstanceLabel string
+	expectedErrorContains string
+}
+
+func TestInstanceKey(t *testing.T) {
+	tests := []testConfig{
+		{
+			testName:              "agent / self",
+			componentName:         "prometheus.exporter.self",
+			args:                  self.Arguments{},
+			expectedInstanceLabel: "test-agent",
+		},
+		{
+			testName:      "apache",
+			componentName: "prometheus.exporter.apache",
+			args: apache.Arguments{
+				ApacheAddr: "http://host01:8080/server-status?auto",
+			},
+			expectedInstanceLabel: "host01:8080",
+		},
+		{
+			testName:      "azure",
+			componentName: "prometheus.exporter.azure",
+			args: azure.Arguments{
+				Subscriptions: []string{"test-subscription"},
+				ResourceType:  "Microsoft.Storage/storageAccounts",
+				Metrics:       []string{"Availability"},
+			},
+			expectedInstanceLabel: "af485df9ca7bb55236b1bf40f2566dcc",
+		},
+		{
+			testName:      "blackbox",
+			componentName: "prometheus.exporter.blackbox",
+			args: blackbox.Arguments{
+				Targets: blackbox.TargetBlock{
+					{
+						Name:   "test-target",
+						Target: "http://localhost:9115",
+						Module: "http_2xx",
+					},
+					{
+						Name:   "test-target2",
+						Target: "http://localhost:9115/2",
+						Module: "http_2xx",
+					},
+				},
+			},
+			expectedInstanceLabel: "prometheus.exporter.blackbox.test",
+		},
+		{
+			testName:      "cadvisor",
+			componentName: "prometheus.exporter.cadvisor",
+			args: cadvisor.Arguments{
+				StoreContainerLabels: true,
+				ContainerdNamespace:  "foo",
+			},
+			expectedInstanceLabel: "prometheus.exporter.cadvisor.test",
+		},
+		{
+			testName:      "catchpoint",
+			componentName: "prometheus.exporter.catchpoint",
+			args: catchpoint.Arguments{
+				Port: "9090",
+			},
+			expectedInstanceLabel: "9090",
+		},
+		{
+			testName:      "cloudwatch",
+			componentName: "prometheus.exporter.cloudwatch",
+			args: cloudwatch.Arguments{
+				STSRegion:    "us-west-2",
+				FIPSDisabled: true,
+			},
+			expectedInstanceLabel: "bf5b9f2a97b9a0c0a713b0dfe566f981",
+		},
+		{
+			testName:      "consul",
+			componentName: "prometheus.exporter.consul",
+			args: consul.Arguments{
+				Server: "http://host01:8500",
+			},
+			expectedInstanceLabel: "host01:8500",
+		},
+		{
+			testName:      "dnsmasq",
+			componentName: "prometheus.exporter.dnsmasq",
+			args: dnsmasq.Arguments{
+				Address: "host01:53",
+			},
+			expectedInstanceLabel: "host01:53",
+		},
+		{
+			testName:      "elasticsearch",
+			componentName: "prometheus.exporter.elasticsearch",
+			args: elasticsearch.Arguments{
+				Address: "http://host01:9200",
+			},
+			expectedInstanceLabel: "host01:9200",
+		},
+		{
+			testName:      "gcp",
+			componentName: "prometheus.exporter.gcp",
+			args: gcp.Arguments{
+				ProjectIDs:     []string{"project1"},
+				MetricPrefixes: []string{"compute.googleapis.com"},
+			},
+			expectedInstanceLabel: "d624903751412e27de94ecfce264e25e",
+		},
+		{
+			testName:      "github",
+			componentName: "prometheus.exporter.github",
+			args: github.Arguments{
+				APIURL:        "https://api.github.com:8080",
+				Repositories:  []string{"owner/repo1", "owner/repo2"},
+				Organizations: []string{"org1", "org2"},
+				Users:         []string{"user1", "user2"},
+			},
+			expectedInstanceLabel: "api.github.com:8080",
+		},
+		{
+			testName:      "kafka",
+			componentName: "prometheus.exporter.kafka",
+			args: kafka.Arguments{
+				KafkaURIs:        []string{"kafka2:9092"},
+				UseSASL:          true,
+				UseSASLHandshake: true,
+				SASLUsername:     "kafka-user",
+				SASLPassword:     "kafka-password",
+				KafkaVersion:     "2.8.0",
+			},
+			expectedInstanceLabel: "kafka2:9092",
+		},
+		{
+			testName:      "kafka error",
+			componentName: "prometheus.exporter.kafka",
+			args: kafka.Arguments{
+				KafkaURIs:        []string{"kafka2:9092", "kafka3:9092"},
+				UseSASL:          true,
+				UseSASLHandshake: true,
+				SASLUsername:     "kafka-user",
+				SASLPassword:     "kafka-password",
+				KafkaVersion:     "2.8.0",
+			},
+			expectedErrorContains: "cannot be determined from 2 kafka servers",
+		},
+		{
+			testName:      "kafka manually set",
+			componentName: "prometheus.exporter.kafka",
+			args: kafka.Arguments{
+				Instance: "my-kafka-instance",
+			},
+			expectedInstanceLabel: "my-kafka-instance",
+		},
+		{
+			testName:      "memcached",
+			componentName: "prometheus.exporter.memcached",
+			args: memcached.Arguments{
+				Address: "host01:11211",
+			},
+			expectedInstanceLabel: "host01:11211",
+		},
+		{
+			testName:      "mongodb",
+			componentName: "prometheus.exporter.mongodb",
+			args: mongodb.Arguments{
+				URI:             "mongodb://user:pass@host01:27017",
+				DirectConnect:   true,
+				DiscoveringMode: true,
+			},
+			expectedInstanceLabel: "host01:27017",
+		},
+		{
+			testName:      "mssql",
+			componentName: "prometheus.exporter.mssql",
+			args: mssql.Arguments{
+				ConnectionString: "sqlserver://user:pass@host01:1433?database=master",
+			},
+			expectedInstanceLabel: "host01:1433",
+		},
+		{
+			testName:      "mysql",
+			componentName: "prometheus.exporter.mysql",
+			args: mysql.Arguments{
+				DataSourceName: "user:pass@tcp(host01:3306)/dbname?timeout=5s",
+			},
+			expectedInstanceLabel: "tcp(host01:3306)/dbname",
+		},
+		{
+			testName:      "oracledb",
+			componentName: "prometheus.exporter.oracledb",
+			args: oracledb.Arguments{
+				ConnectionString: "oracle://user:pass@host01:1521/service",
+			},
+			expectedInstanceLabel: "host01:1521",
+		},
+		{
+			testName:      "postgres",
+			componentName: "prometheus.exporter.postgres",
+			args: postgres.Arguments{
+				DataSourceNames: []alloytypes.Secret{"postgres://user:pass@host01:5432/dbname?sslmode=disable"},
+			},
+			expectedInstanceLabel: "postgresql://host01:5432/dbname",
+		},
+		{
+			testName:      "postgres multiple",
+			componentName: "prometheus.exporter.postgres",
+			args: postgres.Arguments{
+				DataSourceNames: []alloytypes.Secret{"postgres://user:pass@host01:5432/dbname?sslmode=disable", "postgres://user:pass@host02:5432/dbname?sslmode=disable"},
+			},
+			expectedInstanceLabel: "postgresql://host01:5432/dbname,postgresql://host02:5432/dbname",
+		},
+		{
+			testName:      "process",
+			componentName: "prometheus.exporter.process",
+			args: process.Arguments{
+				ProcFSPath: "/proc",
+				Children:   true,
+			},
+			expectedInstanceLabel: "test-agent",
+		},
+		{
+			testName:      "redis",
+			componentName: "prometheus.exporter.redis",
+			args: redis.Arguments{
+				RedisAddr:     "host01:6379",
+				RedisUser:     "user",
+				RedisPassword: "pass",
+				Namespace:     "redis",
+			},
+			expectedInstanceLabel: "host01:6379",
+		},
+		{
+			testName:              "snmp",
+			componentName:         "prometheus.exporter.snmp",
+			args:                  &snmp.Arguments{},
+			expectedInstanceLabel: "prometheus.exporter.snmp.test",
+		},
+		{
+			testName:      "snowflake",
+			componentName: "prometheus.exporter.snowflake",
+			args: snowflake.Arguments{
+				AccountName: "test-account",
+				Username:    "test-user",
+				Password:    "test-password",
+				Role:        "ACCOUNTADMIN",
+			},
+			expectedInstanceLabel: "test-account",
+		},
+		{
+			testName:      "squid",
+			componentName: "prometheus.exporter.squid",
+			args: squid.Arguments{
+				SquidAddr: "host01:3128",
+			},
+			expectedInstanceLabel: "host01:3128",
+		},
+		{
+			testName:      "statsd",
+			componentName: "prometheus.exporter.statsd",
+			args: statsd.Arguments{
+				ListenUDP:     "localhost:9125",
+				ListenTCP:     "localhost:9125",
+				MappingConfig: "mapping.yml",
+				ReadBuffer:    8192,
+				CacheSize:     1000,
+			},
+			expectedInstanceLabel: "test-agent",
+		},
+		{
+			testName:      "unix",
+			componentName: "prometheus.exporter.unix",
+			args: unix.Arguments{
+				ProcFSPath: "/proc",
+				SysFSPath:  "/sys",
+			},
+			expectedInstanceLabel: "test-agent",
+		},
+		{
+			testName:      "windows",
+			componentName: "prometheus.exporter.windows",
+			args: windows.Arguments{
+				EnabledCollectors: []string{"cpu", "cs", "logical_disk", "net", "os", "service", "system"},
+			},
+			expectedInstanceLabel: "test-agent",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			var capturedExports exporter.Exports
+			opts := component.Options{
+				ID: tt.componentName + "test_comp_id",
+				GetServiceData: func(name string) (interface{}, error) {
+					switch name {
+					case http_service.ServiceName:
+						return http_service.Data{
+							HTTPListenAddr:   "localhost:12345",
+							MemoryListenAddr: "alloy.internal:1245",
+							BaseHTTPPath:     "/",
+							DialFunc:         (&net.Dialer{}).DialContext,
+						}, nil
+					default:
+						return nil, fmt.Errorf("service %q does not exist", name)
+					}
+				},
+				OnStateChange: func(e component.Exports) {
+					if exports, ok := e.(exporter.Exports); ok {
+						capturedExports = exports
+					} else {
+						t.Fatalf("failed to convert component.Exports to exporter.Exports")
+					}
+				},
+			}
+			reg, ok := component.Get(tt.componentName)
+			require.True(t, ok, "expected component to exist in registry")
+
+			c, err := reg.Build(opts, tt.args)
+			if tt.expectedErrorContains != "" {
+				require.Error(t, err, "expected component to be created with error")
+				assert.Contains(t, err.Error(), tt.expectedErrorContains, "expected error to contain %q", tt.expectedErrorContains)
+				return
+			}
+			require.NoError(t, err, "expected component to be created without error")
+			require.NotNil(t, c, "expected component to be created")
+
+			require.NotNil(t, capturedExports, "expected exports to be captured")
+			require.Len(t, capturedExports.Targets, 1, "expected 1 target")
+			actualInstance, ok := capturedExports.Targets[0].Get("instance")
+			require.True(t, ok, "expected instance label to be present")
+			require.Equal(t, tt.expectedInstanceLabel, actualInstance, "expected instance label to be %q, got %q", tt.expectedInstanceLabel, actualInstance)
+		})
+	}
+}

--- a/internal/component/prometheus/exporter/tests/instance_key_test.go
+++ b/internal/component/prometheus/exporter/tests/instance_key_test.go
@@ -416,11 +416,7 @@ func TestInstanceKey(t *testing.T) {
 			require.True(t, ok, "expected component to exist in registry")
 
 			if tt.temporaryHostname != "" {
-				ogHostname := os.Getenv("HOSTNAME")
-				assert.NoError(t, os.Setenv("HOSTNAME", tt.temporaryHostname))
-				defer func() {
-					assert.NoError(t, os.Setenv("HOSTNAME", ogHostname))
-				}()
+				t.Setenv("HOSTNAME", tt.temporaryHostname)
 			}
 			c, err := reg.Build(opts, tt.args)
 			if tt.expectedErrorContains != "" {

--- a/internal/component/prometheus/exporter/tests/instance_key_test.go
+++ b/internal/component/prometheus/exporter/tests/instance_key_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/grafana/alloy/internal/component/prometheus/exporter/consul"
 	"github.com/grafana/alloy/internal/component/prometheus/exporter/dnsmasq"
 	"github.com/grafana/alloy/internal/component/prometheus/exporter/elasticsearch"
-	"github.com/grafana/alloy/internal/component/prometheus/exporter/gcp"
 	"github.com/grafana/alloy/internal/component/prometheus/exporter/github"
 	"github.com/grafana/alloy/internal/component/prometheus/exporter/kafka"
 	"github.com/grafana/alloy/internal/component/prometheus/exporter/memcached"
@@ -170,15 +169,17 @@ func TestInstanceKey(t *testing.T) {
 			},
 			expectedInstanceLabel: "host01:9200",
 		},
-		{
-			testName:      "gcp",
-			componentName: "prometheus.exporter.gcp",
-			args: gcp.Arguments{
-				ProjectIDs:     []string{"project1"},
-				MetricPrefixes: []string{"compute.googleapis.com"},
-			},
-			expectedInstanceLabel: "d624903751412e27de94ecfce264e25e",
-		},
+		// TODO: currently gcp tries to connect to remote servers on construction and fails if it cannot login.
+		//       This makes this test hard to implement and may not be desired behaviour anyway.
+		// {
+		// 	testName:      "gcp",
+		// 	componentName: "prometheus.exporter.gcp",
+		// 	args: gcp.Arguments{
+		// 		ProjectIDs:     []string{"project1"},
+		// 		MetricPrefixes: []string{"compute.googleapis.com"},
+		// 	},
+		// 	expectedInstanceLabel: "d624903751412e27de94ecfce264e25e",
+		// },
 		{
 			testName:      "github",
 			componentName: "prometheus.exporter.github",


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

As pointed out in https://github.com/grafana/alloy/issues/1009 
the instance label is not always set to something useful in exporters and it can particularly be harmful when using clustering.

In this PR I add a test that makes it clear what exporter uses what for its instance label and add TODOs to fix those that don't make sense. 

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
