### PR TITLE
ci: update renovate gomod exclusion glob

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -60,7 +60,7 @@
       "matchManagers": ["gomod"],
       "matchPackageNames": [
         // OpenTelemetry needs special handling due to a temporary fork
-        "github.com/open-telemetry/opentelemetry-collector-contrib/*",
+        "github.com/open-telemetry/opentelemetry-collector-contrib/**",
         "go.opentelemetry.io/collector"
       ],
       "groupName": "go otel collector dependencies",


### PR DESCRIPTION
Expression was only matching one directory deep. Adding a second star will match any level of depth.
