### PR TITLE
Correct cross reference links that use version variables

### DIFF
--- a/docs/sources/reference/components/beyla/beyla.ebpf.md
+++ b/docs/sources/reference/components/beyla/beyla.ebpf.md
@@ -22,7 +22,7 @@ The component exposes metrics that can be collected by a Prometheus scrape compo
 {{< admonition type="note" >}}
 To run this component, {{< param "PRODUCT_NAME" >}} requires administrative privileges, or at least it needs to be granted the following capabilities: `BPF`, `SYS_PTRACE`, `NET_RAW` `CAP_CHECKPOINT_RESTORENET_RAW`, `DAC_READ_SEARCH`, and `PERFMON`.
 The number of required capabilities depends on the specific use case.
-Refer to the [Beyla capabilities](https://grafana.com/docs/beyla/<BEYLA_VERSION>/security/#list-of-capabilities-required-by-beyla) for more information.
+Refer to the [Beyla capabilities](https://grafana.com/docs/beyla/latest/security/#list-of-capabilities-required-by-beyla) for more information.
 
 In Kubernetes environments, the [AppArmor profile must be `Unconfined`](https://kubernetes.io/docs/tutorials/security/apparmor/#securing-a-pod) for the Deployment or DaemonSet running {{< param "PRODUCT_NAME" >}}.
 {{< /admonition >}}

--- a/docs/sources/set-up/migrate/from-promtail.md
+++ b/docs/sources/set-up/migrate/from-promtail.md
@@ -180,9 +180,9 @@ The following list is specific to the convert command and not {{< param "PRODUCT
 * The logs produced by {{< param "PRODUCT_NAME" >}} differ from those produced by Promtail.
 * {{< param "PRODUCT_NAME" >}} exposes the {{< param "PRODUCT_NAME" >}} [UI][], which differs from the Promtail Web UI.
 
-[Promtail]: https://www.grafana.com/docs/loki/<LOKI_VERSION>/clients/promtail/
+[Promtail]: https://www.grafana.com/docs/loki/latest/clients/promtail/
 [debugging]: #debugging
-[expanded in the configuration file]: https://www.grafana.com/docs/loki/<LOKI_VERSION>/clients/promtail/configuration/#use-environment-variables-in-the-configuration
+[expanded in the configuration file]: https://www.grafana.com/docs/loki/latest/clients/promtail/configuration/#use-environment-variables-in-the-configuration
 [local.file_match]: ../../../reference/components/local/local.file_match/
 [loki.source.file]: ../../../reference/components/loki/loki.source.file/
 [loki.write]: ../../../reference/components/loki/loki.write/


### PR DESCRIPTION
Version variables (`<PRODUCT_VERSION>`) for products outside of the Alloy docs need to be declared in the main `_index.md` or link to an explicit version.

If you don't declare the variable in the cascade, the version substitution will use the Alloy release, and this can result in a 404 link destination. For links pointing at an external topic that isn't version specific, use `latest` in the URL.

The topics included in this PR can use `latest'. 