### PR TITLE
Change `start_at` default to `end`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Main (unreleased)
 
 - Fix `loki.source.podlogs` add missing labels `__meta_kubernetes_namespace` and `__meta_kubernetes_pod_label_*`. (@kalleep)
 
+- Fix `otelcol.receiver.filelog` documentation's default value for `start_at`. (@petewall)
+
 ### Other changes
 
 - Update the zap logging adapter used by `otelcol` components to log arrays and objects. (@dehaansa)

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.filelog.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.filelog.md
@@ -34,35 +34,35 @@ otelcol.receiver.filelog "<LABEL>" {
 
 You can use the following arguments with `otelcol.receiver.filelog`:
 
-| Name                            | Type                       | Description                                                                                | Default     | Required |
-| ------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------ | ----------- | -------- |
-| `include`                       | `list(string)`             | A list of glob patterns to include files.                                                  |             | yes      |
-| `acquire_fs_lock`               | `bool`                     | Whether to acquire a file system lock while reading the file (Unix only).                  | `false`     | no       |
-| `attributes`                    | `map(string)`              | A map of attributes to add to each log entry.                                              | `{}`        | no       |
-| `compression`                   | `string`                   | The compression type used for the log file.                                                | ``          | no       |
-| `delete_after_read`             | `bool`                     | Whether to delete the file after reading.                                                  | `false`     | no       |
-| `encoding`                      | `string`                   | The encoding of the log file.                                                              | `utf-8`     | no       |
-| `exclude_older_than`            | `time.Duration`            | Exclude files with a modification time older than the specified duration.                  | `0s`        | no       |
-| `exclude`                       | `list(string)`             | A list of glob patterns to exclude files that would be included by the `include` patterns. | `[]`        | no       |
-| `fingerprint_size`              | `units.Base2Bytes`         | The size of the fingerprint used to detect file changes.                                   | `1KiB`      | no       |
-| `force_flush_period`            | `time.Duration`            | The period after which logs are flushed even if the buffer isn't full.                     | `500ms`     | no       |
-| `include_file_name_resolved`    | `bool`                     | Whether to include the resolved file name in the log entry.                                | `false`     | no       |
-| `include_file_name`             | `bool`                     | Whether to include the file name in the log entry.                                         | `true`      | no       |
-| `include_file_owner_group_name` | `bool`                     | Whether to include the file owner's group name in the log entry.                           | `false`     | no       |
-| `include_file_owner_name`       | `bool`                     | Whether to include the file owner's name in the log entry.                                 | `false`     | no       |
-| `include_file_path_resolved`    | `bool`                     | Whether to include the resolved file path in the log entry.                                | `false`     | no       |
-| `include_file_path`             | `bool`                     | Whether to include the file path in the log entry.                                         | `false`     | no       |
-| `include_file_record_number`    | `bool`                     | Whether to include the file record number in the log entry.                                | `false`     | no       |
-| `max_batches`                   | `int`                      | The maximum number of batches to process concurrently.                                     | `10`        | no       |
-| `max_concurrent_files`          | `int`                      | The maximum number of files to read concurrently.                                          | `10`        | no       |
-| `max_log_size`                  | `units.Base2Bytes`         | The maximum size of a log entry.                                                           | `1MiB`      | no       |
-| `operators`                     | `lists(map(string)`        | A list of operators used to parse the log entries.                                         | `[]`        | no       |
-| `poll_interval`                 | `time.Duration`            | The interval at which the file is polled for new entries.                                  | `200ms`     | no       |
-| `preserve_leading_whitespaces`  | `bool`                     | Preserves leading whitespace in messages when set to `true`.                               | `false`     | no       |
-| `preserve_trailing_whitespaces` | `bool`                     | Preserves trailing whitespace in messages when set to `true`.                              | `false`     | no       |
-| `resource`                      | `map(string)`              | A map of resource attributes to associate with each log entry.                             | `{}`        | no       |
-| `start_at`                      | `string`                   | The position to start reading the file from.                                               | `beginning` | no       |
-| `storage`                       | `capsule(otelcol.Handler)` | Handler from an `otelcol.storage` component to use for persisting state.                   |             | no       |
+| Name                            | Type                       | Description                                                                                | Default | Required |
+| ------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------ |---------| -------- |
+| `include`                       | `list(string)`             | A list of glob patterns to include files.                                                  |         | yes      |
+| `acquire_fs_lock`               | `bool`                     | Whether to acquire a file system lock while reading the file (Unix only).                  | `false` | no       |
+| `attributes`                    | `map(string)`              | A map of attributes to add to each log entry.                                              | `{}`    | no       |
+| `compression`                   | `string`                   | The compression type used for the log file.                                                | ``      | no       |
+| `delete_after_read`             | `bool`                     | Whether to delete the file after reading.                                                  | `false` | no       |
+| `encoding`                      | `string`                   | The encoding of the log file.                                                              | `utf-8` | no       |
+| `exclude_older_than`            | `time.Duration`            | Exclude files with a modification time older than the specified duration.                  | `0s`    | no       |
+| `exclude`                       | `list(string)`             | A list of glob patterns to exclude files that would be included by the `include` patterns. | `[]`    | no       |
+| `fingerprint_size`              | `units.Base2Bytes`         | The size of the fingerprint used to detect file changes.                                   | `1KiB`  | no       |
+| `force_flush_period`            | `time.Duration`            | The period after which logs are flushed even if the buffer isn't full.                     | `500ms` | no       |
+| `include_file_name_resolved`    | `bool`                     | Whether to include the resolved file name in the log entry.                                | `false` | no       |
+| `include_file_name`             | `bool`                     | Whether to include the file name in the log entry.                                         | `true`  | no       |
+| `include_file_owner_group_name` | `bool`                     | Whether to include the file owner's group name in the log entry.                           | `false` | no       |
+| `include_file_owner_name`       | `bool`                     | Whether to include the file owner's name in the log entry.                                 | `false` | no       |
+| `include_file_path_resolved`    | `bool`                     | Whether to include the resolved file path in the log entry.                                | `false` | no       |
+| `include_file_path`             | `bool`                     | Whether to include the file path in the log entry.                                         | `false` | no       |
+| `include_file_record_number`    | `bool`                     | Whether to include the file record number in the log entry.                                | `false` | no       |
+| `max_batches`                   | `int`                      | The maximum number of batches to process concurrently.                                     | `10`    | no       |
+| `max_concurrent_files`          | `int`                      | The maximum number of files to read concurrently.                                          | `10`    | no       |
+| `max_log_size`                  | `units.Base2Bytes`         | The maximum size of a log entry.                                                           | `1MiB`  | no       |
+| `operators`                     | `lists(map(string)`        | A list of operators used to parse the log entries.                                         | `[]`    | no       |
+| `poll_interval`                 | `time.Duration`            | The interval at which the file is polled for new entries.                                  | `200ms` | no       |
+| `preserve_leading_whitespaces`  | `bool`                     | Preserves leading whitespace in messages when set to `true`.                               | `false` | no       |
+| `preserve_trailing_whitespaces` | `bool`                     | Preserves trailing whitespace in messages when set to `true`.                              | `false` | no       |
+| `resource`                      | `map(string)`              | A map of resource attributes to associate with each log entry.                             | `{}`    | no       |
+| `start_at`                      | `string`                   | The position to start reading the file from.                                               | `end`   | no       |
+| `storage`                       | `capsule(otelcol.Handler)` | Handler from an `otelcol.storage` component to use for persisting state.                   |         | no       |
 
 `encoding` must be one of `utf-8`, `utf-16le`, `utf-16be`, `ascii`, `big5`, or `nop`.
 Refer to the upstream receiver [documentation][encoding-documentation] for more details.


### PR DESCRIPTION
This matches the default in code (https://github.com/grafana/alloy/blob/main/internal/component/otelcol/receiver/filelog/filelog.go#L124), and upstream (https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/dc2c78737cacceb67aec9dad59a2a00b339de7cd/receiver/filelogreceiver/README.md?plain=1#L25)

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
- [X] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
