### PR TITLE
[release/v1.8] ]docs: improve docs for loki.secretfilter component

### DIFF
--- a/docs/sources/reference/components/loki/loki.secretfilter.md
+++ b/docs/sources/reference/components/loki/loki.secretfilter.md
@@ -10,9 +10,9 @@ labels:
 
 {{< docs/shared lookup="stability/experimental.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
-`loki.secretfilter` receives log entries and redacts sensitive information from them, such as secrets.
-The detection is based on regular expression patterns, defined in the [Gitleaks configuration file][gitleaks] embedded within the component.
-`loki.secretfilter` can also use a custom configuration file based on the Gitleaks configuration file structure.
+`loki.secretfilter` receives log entries and redacts detected secrets from the log lines.
+The detection relies on regular expression patterns, defined in the Gitleaks configuration file embedded within the component.
+`loki.secretfilter` can also use a [custom configuration file](#arguments) based on the [Gitleaks configuration file structure][gitleaks-config].
 
 {{< admonition type="caution" >}}
 Personally Identifiable Information (PII) isn't currently in scope and some secrets could remain undetected.
@@ -24,7 +24,7 @@ Don't rely solely on this component to redact sensitive information.
 This component operates on log lines and doesn't scan labels or other metadata.
 {{< /admonition >}}
 
-[gitleaks]: https://github.com/gitleaks/gitleaks/blob/master/config/gitleaks.toml
+[gitleaks-config]: https://github.com/gitleaks/gitleaks/blob/master/config/gitleaks.toml
 
 ## Usage
 
@@ -49,7 +49,7 @@ loki.secretfilter "<LABEL>" {
 | `types`           | `map(string)`        | Types of secret to look for.                               | All types                        | no       |
 
 The `gitleaks_config` argument is the path to the custom `gitleaks.toml` file.
-The Gitleaks configuration file embedded in the component is used if you don't provide the path to a custom configuration file.
+If you don't provide the path to a custom configuration file, the Gitleaks configuration file [embedded in the component][embedded-config] is used.
 
 {{< admonition type="note" >}}
 This component doesn't support all the features of the Gitleaks configuration file.
@@ -58,6 +58,11 @@ Other features such as `keywords`, `entropy`, `paths`, and `stopwords` aren't su
 The `extend` feature isn't supported.
 If you use a custom configuration file, you must include all the rules you want to use within the configuration file.
 Unsupported fields and values in the configuration file are ignored.
+{{< /admonition >}}
+
+{{< admonition type="note" >}}
+The embedded configuration file may change between {{< param "PRODUCT_NAME" >}} versions.
+To ensure consistency, use an external configuration file.
 {{< /admonition >}}
 
 The `types` argument is a map of secret types to look for.


### PR DESCRIPTION
Backport 194a99c4b1c837d60494a14e80228c78e44d0577 from https://github.com/grafana/alloy/pull/3331