### PR TITLE
[release/v1.6] docs: improve docs for loki.secretfilter component

### DIFF
--- a/docs/sources/reference/components/loki/loki.secretfilter.md
+++ b/docs/sources/reference/components/loki/loki.secretfilter.md
@@ -97,6 +97,8 @@ If set to `0`, the entire secret is redacted.
 If a secret isn't at least 6 characters long, it's entirely redacted.
 For short secrets, at most half of the secret is shown.
 
+[embedded-config]: https://github.com/grafana/alloy/blob/{{< param "ALLOY_RELEASE" >}}/internal/component/loki/secretfilter/gitleaks.toml
+
 ## Blocks
 
 The `loki.secretfilter` component doesn't support any blocks. You can configure this component with arguments.


### PR DESCRIPTION
Backport https://github.com/grafana/alloy/commit/194a99c4b1c837d60494a14e80228c78e44d0577 from https://github.com/grafana/alloy/pull/3331