### PR TITLE
enhancement: add support for extra query matchers in loki.rules.kubernetes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ Main (unreleased)
 
 - Pretty print diagnostic errors when using `alloy run` (@kalleep)
 
+- The `loki.rules.kubernetes` component now supports adding extra label matchers
+  to all queries discovered via `PrometheusRule` CRDs. (@QuentinBisson)
+
 ### Bugfixes
 
 - Fix `otelcol.exporter.prometheus` dropping valid exemplars. (@github-vincent-miszczak)

--- a/docs/sources/reference/components/loki/loki.rules.kubernetes.md
+++ b/docs/sources/reference/components/loki/loki.rules.kubernetes.md
@@ -79,23 +79,27 @@ You can use the following blocks with `loki.rules.kubernetes`:
 
 | Block                                                              | Description                                                | Required |
 | ------------------------------------------------------------------ | ---------------------------------------------------------- | -------- |
-| [`authorization`][authorization]                                   | Configure generic authorization to the endpoint.           | no       |
-| [`basic_auth`][basic_auth]                                         | Configure `basic_auth` for authenticating to the endpoint. | no       |
-| [`rule_namespace_selector`][label_selector]                        | Label selector for `Namespace` resources.                  | no       |
-| `rule_namespace_selector` > [`match_expression`][match_expression] | Label match expression for `Namespace` resources.          | no       |
-| [`rule_selector`][label_selector]                                  | Label selector for `PrometheusRule` resources.             | no       |
-| `rule_selector` > [`match_expression`][match_expression]           | Label match expression for `PrometheusRule` resources.     | no       |
-| [`oauth2`][oauth2]                                                 | Configure OAuth 2.0 for authenticating to the endpoint.    | no       |
-| `oauth2` > [`tls_config`][tls_config]                              | Configure TLS settings for connecting to the endpoint.     | no       |
-| [`tls_config`][tls_config]                                         | Configure TLS settings for connecting to the endpoint.     | no       |
+| [`authorization`][authorization]                                   | Configure generic authorization to the endpoint.                      | no       |
+| [`basic_auth`][basic_auth]                                         | Configure `basic_auth` for authenticating to the endpoint.                      | no       |
+| [`extra_query_matchers`][extra_query_matchers]                     | Additional label matchers to add to each query.                         | no       |
+| `extra_query_matchers` > [`matcher`][matcher]                      | A label matcher to add to query.                         | no       |
+| [`rule_namespace_selector`][label_selector]                        | Label selector for `Namespace` resources.                     | no       |
+| `rule_namespace_selector` > [`match_expression`][match_expression] | Label match expression for `Namespace` resources.                     | no       |
+| [`rule_selector`][label_selector]                                  | Label selector for `PrometheusRule` resources.                     | no       |
+| `rule_selector` > [`match_expression`][match_expression]           | Label match expression for `PrometheusRule` resources.                     | no       |
+| [`oauth2`][oauth2]                                                 | Configure OAuth 2.0 for authenticating to the endpoint.                      | no       |
+| `oauth2` > [`tls_config`][tls_config]                              | Configure TLS settings for connecting to the endpoint.                      | no       |
+| [`tls_config`][tls_config]                                         | Configure TLS settings for connecting to the endpoint.                      | no       |
 
 The > symbol indicates deeper levels of nesting.
 For example, `oauth2` > `tls_config` refers to a `tls_config` block defined inside an `oauth2` block.
 
 [authorization]: #authorization
 [basic_auth]: #basic_auth
+[extra_query_matchers]: #extra_query_matchers
 [label_selector]: #rule_selector-and-rule_namespace_selector
 [match_expression]: #match_expression
+[matcher]: #matcher
 [oauth2]: #oauth2
 [tls_config]: #tls_config
 
@@ -106,6 +110,25 @@ For example, `oauth2` > `tls_config` refers to a `tls_config` block defined insi
 ### `basic_auth`
 
 {{< docs/shared lookup="reference/components/basic-auth-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `extra_query_matchers`
+
+The `extra_query_matchers` block has no attributes.
+It contains zero or more [matcher][] blocks.
+These blocks allow you to add extra label matchers to all queries that are discovered by `mimir.rules.kubernetes` component.
+The algorithm of adding the label matchers to queries is the same as the one provided by the [`promtool promql label-matchers set` command](https://prometheus.io/docs/prometheus/latest/command-line/promtool/#promtool-promql).
+
+### `matcher`
+
+The `matcher` block describes a label matcher that's added to each query found in `PrometheusRule` CRDs.
+
+The following arguments are supported:
+
+| Name         | Type     | Description                                         | Default | Required |
+| ------------ | -------- | --------------------------------------------------- | ------- | -------- |
+| `match_type` | `string` | The type of match. One of `=`, `!=`, `=~` and `!~`. |         | yes      |
+| `name`       | `string` | Name of the label to match.                         |         | yes      |
+| `value`      | `string` | Value of the label to match.                        |         | yes      |
 
 ### `rule_selector` and `rule_namespace_selector`
 
@@ -225,6 +248,23 @@ Replace the following:
 * _`<GRAFANA_CLOUD_USER>`_: Your Grafana Cloud user name.
 * _`<GRAFANA_CLOUD_API_KEY>`_: Your Grafana Cloud API key.
 * _`<GRAFANA_CLOUD_API_KEY_PATH>`_: The path to the Grafana Cloud API key.
+
+This example adds label matcher `{cluster=~"prod-.*"}` to all the queries discovered by `loki.rules.kubernetes`.
+
+```alloy
+loki.rules.kubernetes "default" {
+    address = "loki:3100"
+    extra_query_matchers {
+        matcher {
+            name = "cluster"
+            match_type = "=~"
+            value = "prod-.*"
+        }
+    }
+}
+```
+
+If a query in the form of `{app="my-app"}` is found in `PrometheusRule` CRDs, it will be modified to `{app="my-app", cluster=~"prod-.*"}` before sending it to Loki.
 
 The following example is an RBAC configuration for Kubernetes. It authorizes {{< param "PRODUCT_NAME" >}} to query the Kubernetes REST API:
 

--- a/internal/component/loki/rules/kubernetes/events_test.go
+++ b/internal/component/loki/rules/kubernetes/events_test.go
@@ -8,12 +8,12 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/alloy/internal/component/common/kubernetes"
 	lokiClient "github.com/grafana/alloy/internal/loki/client"
 	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	promListers "github.com/prometheus-operator/prometheus-operator/pkg/client/listers/monitoring/v1"
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -22,6 +22,8 @@ import (
 	coreListers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+
+	"github.com/grafana/alloy/internal/component/common/kubernetes"
 )
 
 type fakeLokiClient struct {
@@ -85,17 +87,10 @@ func (m *fakeLokiClient) ListRules(ctx context.Context, namespace string) (map[s
 }
 
 func TestEventLoop(t *testing.T) {
-	nsIndexer := cache.NewIndexer(
-		cache.DeletionHandlingMetaNamespaceKeyFunc,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
-	)
-	nsLister := coreListers.NewNamespaceLister(nsIndexer)
-
-	ruleIndexer := cache.NewIndexer(
-		cache.DeletionHandlingMetaNamespaceKeyFunc,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
-	)
-	ruleLister := promListers.NewPrometheusRuleLister(ruleIndexer)
+	nsIndexer := testNamespaceIndexer()
+	nsLister := testNamespaceLister(nsIndexer)
+	ruleIndexer := testRuleIndexer()
+	ruleLister := testRuleLister(ruleIndexer)
 
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -183,4 +178,139 @@ func TestEventLoop(t *testing.T) {
 		require.NoError(t, err)
 		return len(rules) == 0
 	}, time.Second, 10*time.Millisecond)
+}
+
+func TestExtraQueryMatchers(t *testing.T) {
+	nsIndexer := testNamespaceIndexer()
+	nsLister := testNamespaceLister(nsIndexer)
+	ruleIndexer := testRuleIndexer()
+	ruleLister := testRuleLister(ruleIndexer)
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "namespace",
+			UID:  types.UID("33f8860c-bd06-4c0d-a0b1-a114d6b9937b"),
+		},
+	}
+
+	rule := &v1.PrometheusRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name",
+			Namespace: "namespace",
+			UID:       types.UID("64aab764-c95e-4ee9-a932-cd63ba57e6cf"),
+		},
+		Spec: v1.PrometheusRuleSpec{
+			Groups: []v1.RuleGroup{
+				{
+					Name: "group1",
+					Rules: []v1.Rule{
+						{
+							Record: "record_rule_1",
+							Expr:   intstr.FromString("count_over_time({job=\"bad\", app=\"test\"}[5m]) / count_over_time({app=\"test\"}[5m])"),
+						},
+						{
+							Alert: "alert_1",
+							Expr:  intstr.FromString("count_over_time({message=\"success\"} |= \"my-log\" | json [5m])"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	args := Arguments{
+		LokiNameSpacePrefix: "alloy",
+		ExtraQueryMatchers: &ExtraQueryMatchers{Matchers: []Matcher{
+			{
+				Name:      "cluster",
+				MatchType: "=~",
+				Value:     "prod-.*",
+			},
+			{
+				Name:      "job",
+				MatchType: "=",
+				Value:     "good",
+			},
+		}},
+	}
+
+	component := Component{
+		log:               log.NewLogfmtLogger(os.Stdout),
+		queue:             workqueue.NewTypedRateLimitingQueue[kubernetes.Event](workqueue.DefaultTypedControllerRateLimiter[kubernetes.Event]()),
+		namespaceLister:   nsLister,
+		namespaceSelector: labels.Everything(),
+		ruleLister:        ruleLister,
+		ruleSelector:      labels.Everything(),
+		lokiClient:        newFakeLokiClient(),
+		args:              args,
+		metrics:           newMetrics(),
+	}
+	eventHandler := kubernetes.NewQueuedEventHandler(component.log, component.queue)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	go component.eventLoop(ctx)
+
+	// Add a namespace and rule to kubernetes
+	nsIndexer.Add(ns)
+	ruleIndexer.Add(rule)
+	eventHandler.OnAdd(rule, false)
+
+	// Wait for the rule to be added to loki
+	require.Eventually(t, func() bool {
+		rules, err := component.lokiClient.ListRules(ctx, "")
+		require.NoError(t, err)
+		// The map of rules has only one element.
+		for ruleName, rule := range rules {
+			require.Equal(t, "alloy-namespace-name-64aab764-c95e-4ee9-a932-cd63ba57e6cf", ruleName)
+
+			ruleBuf, err := yaml.Marshal(rule)
+			require.NoError(t, err)
+
+			expectedRule := `- name: group1
+  rules:
+    - expr: "(count_over_time({job=\"good\", app=\"test\", cluster=~\"prod-.*\"}[5m]) / count_over_time({app=\"test\", cluster=~\"prod-.*\", job=\"good\"}[5m]))"
+      record: record_rule_1
+    - alert: alert_1
+      expr: "count_over_time({message=\"success\", cluster=~\"prod-.*\", job=\"good\"} |= \"my-log\" | json[5m])"
+`
+			require.YAMLEq(t, expectedRule, string(ruleBuf))
+		}
+		return len(rules) == 1
+	}, time.Second, 10*time.Millisecond)
+	component.queue.AddRateLimited(kubernetes.Event{Typ: eventTypeSyncLoki})
+
+	// Remove the rule from kubernetes
+	ruleIndexer.Delete(rule)
+	eventHandler.OnDelete(rule)
+
+	// Wait for the rule to be removed from loki
+	require.Eventually(t, func() bool {
+		rules, err := component.lokiClient.ListRules(ctx, "")
+		require.NoError(t, err)
+		return len(rules) == 0
+	}, time.Second, 10*time.Millisecond)
+}
+
+func testRuleIndexer() cache.Indexer {
+	return cache.NewIndexer(
+		cache.DeletionHandlingMetaNamespaceKeyFunc,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+	)
+}
+
+func testNamespaceIndexer() cache.Indexer {
+	return cache.NewIndexer(
+		cache.DeletionHandlingMetaNamespaceKeyFunc,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+	)
+}
+
+func testRuleLister(indexer cache.Indexer) promListers.PrometheusRuleLister {
+	return promListers.NewPrometheusRuleLister(indexer)
+}
+
+func testNamespaceLister(indexer cache.Indexer) coreListers.NamespaceLister {
+	return coreListers.NewNamespaceLister(indexer)
 }

--- a/internal/component/loki/rules/kubernetes/types.go
+++ b/internal/component/loki/rules/kubernetes/types.go
@@ -1,8 +1,12 @@
 package rules
 
 import (
+	"errors"
 	"fmt"
+	"slices"
 	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/alloy/internal/component/common/config"
 	"github.com/grafana/alloy/internal/component/common/kubernetes"
@@ -15,10 +19,21 @@ type Arguments struct {
 	HTTPClientConfig    config.HTTPClientConfig `alloy:",squash"`
 	SyncInterval        time.Duration           `alloy:"sync_interval,attr,optional"`
 	LokiNameSpacePrefix string                  `alloy:"loki_namespace_prefix,attr,optional"`
+	ExtraQueryMatchers  *ExtraQueryMatchers     `alloy:"extra_query_matchers,block,optional"`
 
 	RuleSelector          kubernetes.LabelSelector `alloy:"rule_selector,block,optional"`
 	RuleNamespaceSelector kubernetes.LabelSelector `alloy:"rule_namespace_selector,block,optional"`
 }
+
+var (
+	// This should contain all valid match types for extra query matchers.
+	validMatchTypes = []string{
+		labels.MatchEqual.String(),
+		labels.MatchNotEqual.String(),
+		labels.MatchRegexp.String(),
+		labels.MatchNotRegexp.String(),
+	}
+)
 
 var DefaultArguments = Arguments{
 	SyncInterval:        30 * time.Second,
@@ -39,7 +54,38 @@ func (args *Arguments) Validate() error {
 	if args.LokiNameSpacePrefix == "" {
 		return fmt.Errorf("loki_namespace_prefix must not be empty")
 	}
+	if err := args.ExtraQueryMatchers.Validate(); err != nil {
+		return err
+	}
 
 	// We must explicitly Validate because HTTPClientConfig is squashed and it won't run otherwise
 	return args.HTTPClientConfig.Validate()
+}
+
+type ExtraQueryMatchers struct {
+	Matchers []Matcher `alloy:"matcher,block,optional"`
+}
+
+func (e *ExtraQueryMatchers) Validate() error {
+	if e == nil {
+		return nil
+	}
+	var errs error
+	for _, matcher := range e.Matchers {
+		errs = errors.Join(errs, matcher.Validate())
+	}
+	return errs
+}
+
+type Matcher struct {
+	Name      string `alloy:"name,attr"`
+	Value     string `alloy:"value,attr"`
+	MatchType string `alloy:"match_type,attr"`
+}
+
+func (m Matcher) Validate() error {
+	if !slices.Contains(validMatchTypes, m.MatchType) {
+		return fmt.Errorf("invalid match type: %q", m.MatchType)
+	}
+	return nil
 }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

The goal is to allow loki.rules.kubernetes to add extra matchers to queries to align with this PR https://github.com/grafana/alloy/pull/1773 that was done for mimir.rules.kubernetes.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

I tried to copy the same structure as the code in the mimir.rules.kubernetes component changing mostly the parsing code (using logql instead) which was quite fun to do.

There might be similarities between the 2 code bases that might require some code sharing in places but with the upcoming PRs that I opened for the `mimir.rules.kubernetes` component (#3270 and #3175), I feel like it might be better to refactor this later one.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
