### PR TITLE
pyroscope.write: Remove broken/unnecessary debug

### DIFF
--- a/internal/component/pyroscope/write/write.go
+++ b/internal/component/pyroscope/write/write.go
@@ -146,7 +146,6 @@ func (c *Component) Run(ctx context.Context) error {
 // Update implements Component.
 func (c *Component) Update(newConfig component.Arguments) error {
 	c.cfg = newConfig.(Arguments)
-	level.Debug(c.opts.Logger).Log("msg", "updating pyroscope.write config", "old", c.cfg, "new", newConfig)
 	receiver, err := NewFanOut(c.opts, newConfig.(Arguments), c.metrics)
 	if err != nil {
 		return err


### PR DESCRIPTION
This shows the same new variable instead of what is says it does, it
also doesn't serialize correctly:

> {"ts":"2025-04-16T16:07:34.939578662Z","level":"debug","msg":"updating pyroscope.write config","component_path":"/components.output_pyroscope.output_pyroscope","component_id":"pyroscope.write.endpoint","old":"!ERROR:json: error calling MarshalText for type config.TLSVersion: unknown TLS version: 0","new":"!ERROR:json: error calling MarshalText for type config.TLSVersion: unknown TLS version: 0"}

The use of this is limited, so I am removing it.
