### PR TITLE
unpin writers-toolkit gh action versions

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -13,6 +13,8 @@ jobs:
   deploy-pr-preview:
     if: "!github.event.pull_request.head.repo.fork"
     uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
+    # ^ We can't pin a hash for this action because deploy-preview's checkout step relies on it
+    # having been called against the main branch
     with:
       branch: ${{ github.head_ref }}
       event_number: ${{ github.event.number }}

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   deploy-pr-preview:
     if: "!github.event.pull_request.head.repo.fork"
-    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@8916505070a10d0a5db19e850722f124861bbce2 # main
+    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
     with:
       branch: ${{ github.head_ref }}
       event_number: ${{ github.event.number }}

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   deploy-pr-preview:
     if: "!github.event.pull_request.head.repo.fork"
-    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@e97bf199a578b923363e5cd7db079dad234aeb90 # main
+    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@8916505070a10d0a5db19e850722f124861bbce2 # main
     with:
       branch: ${{ github.head_ref }}
       event_number: ${{ github.event.number }}

--- a/.github/workflows/publish-documentation-next.yml
+++ b/.github/workflows/publish-documentation-next.yml
@@ -17,5 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: grafana/writers-toolkit/publish-technical-documentation@publish-technical-documentation/v1
+        # ^ This action's version is left as a tag instead of a pinned hash because renovate does
+        # not support this type of tag/version format without custom configuration.
         with:
           website_directory: content/docs/alloy/next

--- a/.github/workflows/publish-documentation-next.yml
+++ b/.github/workflows/publish-documentation-next.yml
@@ -16,6 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: grafana/writers-toolkit/publish-technical-documentation@8916505070a10d0a5db19e850722f124861bbce2 # publish-technical-documentation/v1
+      - uses: grafana/writers-toolkit/publish-technical-documentation@publish-technical-documentation/v1
         with:
           website_directory: content/docs/alloy/next

--- a/.github/workflows/publish-documentation-next.yml
+++ b/.github/workflows/publish-documentation-next.yml
@@ -16,6 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: grafana/writers-toolkit/publish-technical-documentation@39cdc38767184996e25d611923f8ce697e33bc70 # publish-technical-documentation/v1
+      - uses: grafana/writers-toolkit/publish-technical-documentation@8916505070a10d0a5db19e850722f124861bbce2 # publish-technical-documentation/v1
         with:
           website_directory: content/docs/alloy/next

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -20,7 +20,10 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+
       - uses: grafana/writers-toolkit/publish-technical-documentation-release@publish-technical-documentation-release/v1
+        # ^ This action's version is left as a tag instead of a pinned hash because renovate does
+        # not support this type of tag/version format without custom configuration.
         with:
           release_tag_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
           release_branch_regexp: "^release/v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: grafana/writers-toolkit/publish-technical-documentation-release@8916505070a10d0a5db19e850722f124861bbce2 # publish-technical-documentation-release/v1
+      - uses: grafana/writers-toolkit/publish-technical-documentation-release@publish-technical-documentation-release/v1
         with:
           release_tag_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
           release_branch_regexp: "^release/v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: grafana/writers-toolkit/publish-technical-documentation-release@d83ba5389fb8de1458b12bcc35ad4a4059883029 # publish-technical-documentation-release/v1
+      - uses: grafana/writers-toolkit/publish-technical-documentation-release@8916505070a10d0a5db19e850722f124861bbce2 # publish-technical-documentation-release/v1
         with:
           release_tag_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
           release_branch_regexp: "^release/v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"

--- a/.github/workflows/update-make-docs.yml
+++ b/.github/workflows/update-make-docs.yml
@@ -9,4 +9,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: grafana/writers-toolkit/update-make-docs@f65819d6a412b752c0e0263375215f049507b0e6 # update-make-docs/v1
+      - uses: grafana/writers-toolkit/update-make-docs@8916505070a10d0a5db19e850722f124861bbce2 # update-make-docs/v1

--- a/.github/workflows/update-make-docs.yml
+++ b/.github/workflows/update-make-docs.yml
@@ -9,4 +9,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: grafana/writers-toolkit/update-make-docs@8916505070a10d0a5db19e850722f124861bbce2 # update-make-docs/v1
+      - uses: grafana/writers-toolkit/update-make-docs@update-make-docs/v1

--- a/.github/workflows/update-make-docs.yml
+++ b/.github/workflows/update-make-docs.yml
@@ -10,3 +10,5 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: grafana/writers-toolkit/update-make-docs@update-make-docs/v1
+        # ^ This action's version is left as a tag instead of a pinned hash because renovate does
+        # not support this type of tag/version format without custom configuration.

--- a/docs/sources/release-notes.md
+++ b/docs/sources/release-notes.md
@@ -8,6 +8,8 @@ weight: 999
 
 # Release notes for {{% param "FULL_PRODUCT_NAME" %}}
 
+## THIS IS A TEST DO NOT MERGE
+
 The release notes provide information about deprecations and breaking changes in {{< param "FULL_PRODUCT_NAME" >}}.
 
 For a complete list of changes to {{< param "FULL_PRODUCT_NAME" >}}, with links to pull requests and related issues when available, refer to the [Changelog][].

--- a/docs/sources/release-notes.md
+++ b/docs/sources/release-notes.md
@@ -22,28 +22,28 @@ A bug in `loki.source.kafka` caused the component to treat all topics as regular
 With the fix introduced in this version, topic values are now treated as exact matches by default.
 Regular expression matching is still supported by prefixing a topic with "^", allowing it to match multiple topics.
 
-### Breaking change: Change decision precedence in `otelcol.processor.tail_sampling` when using `and_sub_policy` and `invert_match`
+### Breaking change: Change decision precedence in `otelcol.processor.tail_sampling` when using `and_sub_policy` and `invert_match` 
 
 Alloy v1.5 upgraded to [OpenTelemetry Collector v0.104.0][otel-v0_104], which included a [fix][#33671] to the tail sampling processor:
 
-> Previously if the decision from a policy evaluation was `NotSampled` or `InvertNotSampled`
+> Previously if the decision from a policy evaluation was `NotSampled` or `InvertNotSampled` 
 > it would return a `NotSampled` decision regardless, effectively downgrading the result.
 > This was breaking the documented behaviour that inverted decisions should take precedence over all others.
 
 The "documented behavior" which the above quote is referring to is in the [processor documentation][tail-sample-docs]:
 
 > Each policy will result in a decision, and the processor will evaluate them to make a final decision:
->
+> 
 > * When there's an "inverted not sample" decision, the trace is not sampled;
 > * When there's a "sample" decision, the trace is sampled;
 > * When there's a "inverted sample" decision and no "not sample" decisions, the trace is sampled;
 > * In all other cases, the trace is NOT sampled
->
+> 
 > An "inverted" decision is the one made based on the "invert_match" attribute, such as the one from the string, numeric or boolean tag policy.
-
+    
 However, in [OpenTelemetry Collector v0.116.0][otel-v0_116] this fix was [reverted][#36673]:
 
-> Reverts [#33671][], allowing for composite policies to specify inverted clauses in conjunction with other policies.
+> Reverts [#33671][], allowing for composite policies to specify inverted clauses in conjunction with other policies. 
 > This is a change bringing the previous state into place, breaking users who rely on what was introduced as part of [#33671][].
 
 [otel-v0_104]: https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.104.0

--- a/docs/sources/release-notes.md
+++ b/docs/sources/release-notes.md
@@ -8,8 +8,6 @@ weight: 999
 
 # Release notes for {{% param "FULL_PRODUCT_NAME" %}}
 
-## THIS IS A TEST DO NOT MERGE
-
 The release notes provide information about deprecations and breaking changes in {{< param "FULL_PRODUCT_NAME" >}}.
 
 For a complete list of changes to {{< param "FULL_PRODUCT_NAME" >}}, with links to pull requests and related issues when available, refer to the [Changelog][].
@@ -24,28 +22,28 @@ A bug in `loki.source.kafka` caused the component to treat all topics as regular
 With the fix introduced in this version, topic values are now treated as exact matches by default.
 Regular expression matching is still supported by prefixing a topic with "^", allowing it to match multiple topics.
 
-### Breaking change: Change decision precedence in `otelcol.processor.tail_sampling` when using `and_sub_policy` and `invert_match` 
+### Breaking change: Change decision precedence in `otelcol.processor.tail_sampling` when using `and_sub_policy` and `invert_match`
 
 Alloy v1.5 upgraded to [OpenTelemetry Collector v0.104.0][otel-v0_104], which included a [fix][#33671] to the tail sampling processor:
 
-> Previously if the decision from a policy evaluation was `NotSampled` or `InvertNotSampled` 
+> Previously if the decision from a policy evaluation was `NotSampled` or `InvertNotSampled`
 > it would return a `NotSampled` decision regardless, effectively downgrading the result.
 > This was breaking the documented behaviour that inverted decisions should take precedence over all others.
 
 The "documented behavior" which the above quote is referring to is in the [processor documentation][tail-sample-docs]:
 
 > Each policy will result in a decision, and the processor will evaluate them to make a final decision:
-> 
+>
 > * When there's an "inverted not sample" decision, the trace is not sampled;
 > * When there's a "sample" decision, the trace is sampled;
 > * When there's a "inverted sample" decision and no "not sample" decisions, the trace is sampled;
 > * In all other cases, the trace is NOT sampled
-> 
+>
 > An "inverted" decision is the one made based on the "invert_match" attribute, such as the one from the string, numeric or boolean tag policy.
-    
+
 However, in [OpenTelemetry Collector v0.116.0][otel-v0_116] this fix was [reverted][#36673]:
 
-> Reverts [#33671][], allowing for composite policies to specify inverted clauses in conjunction with other policies. 
+> Reverts [#33671][], allowing for composite policies to specify inverted clauses in conjunction with other policies.
 > This is a change bringing the previous state into place, breaking users who rely on what was introduced as part of [#33671][].
 
 [otel-v0_104]: https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.104.0


### PR DESCRIPTION
This PR goes back to unpinned dependencies for writers-toolkit since there is a requirement at this time that the `main` branch be used directly.
