### PR TITLE
chore(helm): allow disabling config checksums

### DIFF
--- a/operations/helm/charts/alloy/CHANGELOG.md
+++ b/operations/helm/charts/alloy/CHANGELOG.md
@@ -20,6 +20,7 @@ Unreleased
 - Update default configreloader resources to match what is set in prometheus-operator project (@dehaansa)
 - Add Vertical Pod Autoscaler support (@QuentinBisson)
 - Add support for configuring minReadySeconds in Helm chart. (@PabloPie)
+- Add support for disabling config checksum pod annotation. (@korniltsev)
 
 1.0.0 (2025-04-09)
 ----------

--- a/operations/helm/charts/alloy/README.md
+++ b/operations/helm/charts/alloy/README.md
@@ -36,6 +36,7 @@ useful if just using the default DaemonSet isn't sufficient.
 | alloy.clustering.enabled | bool | `false` | Deploy Alloy in a cluster to allow for load distribution. |
 | alloy.clustering.name | string | `""` | Name for the Alloy cluster. Used for differentiating between clusters. |
 | alloy.clustering.portName | string | `"http"` | Name for the port used for clustering, useful if running inside an Istio Mesh |
+| alloy.configMap.checksum | bool | `true` | Create a `checksum/config` pod annotation with sha256sum of the `content`. |
 | alloy.configMap.content | string | `""` | Content to assign to the new ConfigMap.  This is passed into `tpl` allowing for templating from values. |
 | alloy.configMap.create | bool | `true` | Create a new ConfigMap for the config file. |
 | alloy.configMap.key | string | `nil` | Key in ConfigMap to get config from. |

--- a/operations/helm/charts/alloy/templates/controllers/_pod.yaml
+++ b/operations/helm/charts/alloy/templates/controllers/_pod.yaml
@@ -3,7 +3,7 @@
 metadata:
   annotations:
     kubectl.kubernetes.io/default-container: alloy
-    {{- if and $values.configMap.create $values.configMap.content }}
+    {{- if and $values.configMap.create $values.configMap.content $values.configMap.checksum }}
     checksum/config: {{ (tpl  $values.configMap.content .) | sha256sum | trunc 63 }}
     {{- end }}
     {{- with .Values.controller.podAnnotations }}

--- a/operations/helm/charts/alloy/values.yaml
+++ b/operations/helm/charts/alloy/values.yaml
@@ -34,6 +34,8 @@ alloy:
     create: true
     # -- Content to assign to the new ConfigMap.  This is passed into `tpl` allowing for templating from values.
     content: ''
+    # -- Create a `checksum/config` pod annotation with sha256sum of the `content`.
+    checksum: true
 
     # -- Name of existing ConfigMap to use. Used when create is false.
     name: null


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Allow users to disable config checksum pod annotations

Currently changing config causes checksum change and deployment rollout which does not make sense if config-reloader used

https://github.com/grafana/kube-manifests/compare/7237ba4be...194ed0047#diff-e6d52159a08ca6f53cb2f002d37913c72a92e3239555390edd2e5d08d17db11aR24

![image](https://github.com/user-attachments/assets/496ee991-b732-4ceb-be20-3d15f967f4d3)


https://ops.grafana-ops.net/goto/AompN4JHg?orgId=1

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
