### PR TITLE
Fix links to estimate-resource-usage topic

### DIFF
--- a/docs/sources/introduction/estimate-resource-usage.md
+++ b/docs/sources/introduction/estimate-resource-usage.md
@@ -3,7 +3,6 @@ canonical: https://grafana.com/docs/alloy/latest/introduction/estimate-resource-
 aliases:
   - ../tasks/estimate-resource-usage/ # /docs/alloy/latest/tasks/estimate-resource-usage/
 description: Estimate expected Grafana Alloy resource usage
-headless: true
 title: Estimate Grafana Alloy resource usage
 menuTitle: Estimate resource usage
 weight: 300


### PR DESCRIPTION
Links to `estimate-resource-usage` are failing with a 404. The Estimate resource usage topic is not publishing.