### PR TITLE
Add OSS product label to topics that have stages label in the topic metadata

### DIFF
--- a/docs/sources/reference/components/beyla/beyla.ebpf.md
+++ b/docs/sources/reference/components/beyla/beyla.ebpf.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about beyla.ebpf
 labels:
   stage: general-availability
+  products:
+    - oss
 title: beyla.ebpf
 ---
 

--- a/docs/sources/reference/components/database_observability/database_observability.mysql.md
+++ b/docs/sources/reference/components/database_observability/database_observability.mysql.md
@@ -4,6 +4,8 @@ description: Learn about database_observability.mysql
 title: database_observability.mysql
 labels:
   stage: experimental
+  products:
+    - oss
 ---
 
 # `database_observability.mysql`

--- a/docs/sources/reference/components/discovery/discovery.azure.md
+++ b/docs/sources/reference/components/discovery/discovery.azure.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.azure
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.azure
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.consul.md
+++ b/docs/sources/reference/components/discovery/discovery.consul.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.consul
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.consul
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.consulagent.md
+++ b/docs/sources/reference/components/discovery/discovery.consulagent.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.consulagent
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.consulagent
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.digitalocean.md
+++ b/docs/sources/reference/components/discovery/discovery.digitalocean.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.digitalocean
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.digitalocean
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.dns.md
+++ b/docs/sources/reference/components/discovery/discovery.dns.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.dns
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.dns
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.docker.md
+++ b/docs/sources/reference/components/discovery/discovery.docker.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.docker
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.docker
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.dockerswarm.md
+++ b/docs/sources/reference/components/discovery/discovery.dockerswarm.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.dockerswarm
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.dockerswarm
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.ec2.md
+++ b/docs/sources/reference/components/discovery/discovery.ec2.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.ec2
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.ec2
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.eureka.md
+++ b/docs/sources/reference/components/discovery/discovery.eureka.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.eureka
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.eureka
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.file.md
+++ b/docs/sources/reference/components/discovery/discovery.file.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.file
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.file
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.gce.md
+++ b/docs/sources/reference/components/discovery/discovery.gce.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.gce
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.gce
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.hetzner.md
+++ b/docs/sources/reference/components/discovery/discovery.hetzner.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.hetzner
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.hetzner
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.http.md
+++ b/docs/sources/reference/components/discovery/discovery.http.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.http
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.http
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.ionos.md
+++ b/docs/sources/reference/components/discovery/discovery.ionos.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.ionos
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.ionos
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.kubelet.md
+++ b/docs/sources/reference/components/discovery/discovery.kubelet.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.kubelet
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.kubelet
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.kubernetes.md
+++ b/docs/sources/reference/components/discovery/discovery.kubernetes.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.kubernetes
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.kubernetes
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.kuma.md
+++ b/docs/sources/reference/components/discovery/discovery.kuma.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.kuma
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.kuma
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.lightsail.md
+++ b/docs/sources/reference/components/discovery/discovery.lightsail.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.lightsail
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.lightsail
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.linode.md
+++ b/docs/sources/reference/components/discovery/discovery.linode.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.linode
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.linode
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.marathon.md
+++ b/docs/sources/reference/components/discovery/discovery.marathon.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.marathon
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.marathon
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.nerve.md
+++ b/docs/sources/reference/components/discovery/discovery.nerve.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.nerve
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.nerve
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.nomad.md
+++ b/docs/sources/reference/components/discovery/discovery.nomad.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.nomad
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.nomad
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.openstack.md
+++ b/docs/sources/reference/components/discovery/discovery.openstack.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.openstack
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.openstack
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.ovhcloud.md
+++ b/docs/sources/reference/components/discovery/discovery.ovhcloud.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.ovhcloud
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.ovhcloud
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.process.md
+++ b/docs/sources/reference/components/discovery/discovery.process.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.process
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.process
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.puppetdb.md
+++ b/docs/sources/reference/components/discovery/discovery.puppetdb.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.puppetdb
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.puppetdb
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.relabel.md
+++ b/docs/sources/reference/components/discovery/discovery.relabel.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.relabel
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.relabel
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.scaleway.md
+++ b/docs/sources/reference/components/discovery/discovery.scaleway.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.scaleway
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.scaleway
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.serverset.md
+++ b/docs/sources/reference/components/discovery/discovery.serverset.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.serverset
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.serverset
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.triton.md
+++ b/docs/sources/reference/components/discovery/discovery.triton.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.triton
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.triton
 ---
 

--- a/docs/sources/reference/components/discovery/discovery.uyuni.md
+++ b/docs/sources/reference/components/discovery/discovery.uyuni.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about discovery.uyuni
 labels:
   stage: general-availability
+  products:
+    - oss
 title: discovery.uyuni
 ---
 

--- a/docs/sources/reference/components/faro/faro.receiver.md
+++ b/docs/sources/reference/components/faro/faro.receiver.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about the faro.receiver
 labels:
   stage: general-availability
+  products:
+    - oss
 title: faro.receiver
 ---
 

--- a/docs/sources/reference/components/local/local.file.md
+++ b/docs/sources/reference/components/local/local.file.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about local.file
 labels:
   stage: general-availability
+  products:
+    - oss
 title: local.file
 ---
 

--- a/docs/sources/reference/components/local/local.file_match.md
+++ b/docs/sources/reference/components/local/local.file_match.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about local.file_match
 labels:
   stage: general-availability
+  products:
+    - oss
 title: local.file_match
 ---
 

--- a/docs/sources/reference/components/loki/loki.echo.md
+++ b/docs/sources/reference/components/loki/loki.echo.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about loki.echo
 labels:
   stage: general-availability
+  products:
+    - oss
 title: loki.echo
 ---
 

--- a/docs/sources/reference/components/loki/loki.enrich.md
+++ b/docs/sources/reference/components/loki/loki.enrich.md
@@ -5,6 +5,8 @@ canonical: https://grafana.com/docs/alloy/latest/reference/components/loki/loki.
 title: loki.enrich
 labels:
   stage: experimental
+  products:
+    - oss
 description: The loki.enrich component enriches logs with labels from service discovery.
 ---
 

--- a/docs/sources/reference/components/loki/loki.process.md
+++ b/docs/sources/reference/components/loki/loki.process.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about loki.process
 labels:
   stage: general-availability
+  products:
+    - oss
 title: loki.process
 ---
 

--- a/docs/sources/reference/components/loki/loki.relabel.md
+++ b/docs/sources/reference/components/loki/loki.relabel.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about loki.relabel
 labels:
   stage: general-availability
+  products:
+    - oss
 title: loki.relabel
 ---
 

--- a/docs/sources/reference/components/loki/loki.rules.kubernetes.md
+++ b/docs/sources/reference/components/loki/loki.rules.kubernetes.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about loki.rules.kubernetes
 labels:
   stage: general-availability
+  products:
+    - oss
 title: loki.rules.kubernetes
 ---
 

--- a/docs/sources/reference/components/loki/loki.secretfilter.md
+++ b/docs/sources/reference/components/loki/loki.secretfilter.md
@@ -4,6 +4,8 @@ description: Learn about loki.secretfilter
 title: loki.secretfilter
 labels:
   stage: experimental
+  products:
+    - oss
 ---
 
 # `loki.secretfilter`

--- a/docs/sources/reference/components/loki/loki.source.api.md
+++ b/docs/sources/reference/components/loki/loki.source.api.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about loki.source.api
 labels:
   stage: general-availability
+  products:
+    - oss
 title: loki.source.api
 ---
 

--- a/docs/sources/reference/components/loki/loki.source.awsfirehose.md
+++ b/docs/sources/reference/components/loki/loki.source.awsfirehose.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about loki.source.awsfirehose
 labels:
   stage: general-availability
+  products:
+    - oss
 title: loki.source.awsfirehose
 ---
 

--- a/docs/sources/reference/components/loki/loki.source.azure_event_hubs.md
+++ b/docs/sources/reference/components/loki/loki.source.azure_event_hubs.md
@@ -6,6 +6,8 @@ aliases:
 description: Learn about loki.source.azure_event_hubs
 labels:
   stage: general-availability
+  products:
+    - oss
 title: loki.source.azure_event_hubs
 ---
 

--- a/docs/sources/reference/components/loki/loki.source.cloudflare.md
+++ b/docs/sources/reference/components/loki/loki.source.cloudflare.md
@@ -6,6 +6,8 @@ aliases:
 description: Learn about loki.source.cloudflare
 labels:
   stage: general-availability
+  products:
+    - oss
 title: loki.source.cloudflare
 ---
 

--- a/docs/sources/reference/components/loki/loki.source.docker.md
+++ b/docs/sources/reference/components/loki/loki.source.docker.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about loki.source.docker
 labels:
   stage: general-availability
+  products:
+    - oss
 title: loki.source.docker
 ---
 

--- a/docs/sources/reference/components/loki/loki.source.file.md
+++ b/docs/sources/reference/components/loki/loki.source.file.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about loki.source.file
 labels:
   stage: general-availability
+  products:
+    - oss
 title: loki.source.file
 ---
 

--- a/docs/sources/reference/components/loki/loki.source.gcplog.md
+++ b/docs/sources/reference/components/loki/loki.source.gcplog.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about loki.source.gcplog
 labels:
   stage: general-availability
+  products:
+    - oss
 title: loki.source.gcplog
 ---
 

--- a/docs/sources/reference/components/loki/loki.source.gelf.md
+++ b/docs/sources/reference/components/loki/loki.source.gelf.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about loki.source.gelf
 labels:
   stage: general-availability
+  products:
+    - oss
 title: loki.source.gelf
 ---
 

--- a/docs/sources/reference/components/loki/loki.source.heroku.md
+++ b/docs/sources/reference/components/loki/loki.source.heroku.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about loki.source.heroku
 labels:
   stage: general-availability
+  products:
+    - oss
 title: loki.source.heroku
 ---
 

--- a/docs/sources/reference/components/loki/loki.source.journal.md
+++ b/docs/sources/reference/components/loki/loki.source.journal.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about loki.source.journal
 labels:
   stage: general-availability
+  products:
+    - oss
 title: loki.source.journal
 ---
 

--- a/docs/sources/reference/components/loki/loki.source.kafka.md
+++ b/docs/sources/reference/components/loki/loki.source.kafka.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about loki.source.kafka
 labels:
   stage: general-availability
+  products:
+    - oss
 title: loki.source.kafka
 ---
 

--- a/docs/sources/reference/components/loki/loki.source.kubernetes.md
+++ b/docs/sources/reference/components/loki/loki.source.kubernetes.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about loki.source.kubernetes
 labels:
   stage: general-availability
+  products:
+    - oss
 title: loki.source.kubernetes
 ---
 

--- a/docs/sources/reference/components/loki/loki.source.kubernetes_events.md
+++ b/docs/sources/reference/components/loki/loki.source.kubernetes_events.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about loki.source.kubernetes_events
 labels:
   stage: general-availability
+  products:
+    - oss
 title: loki.source.kubernetes_events
 ---
 

--- a/docs/sources/reference/components/loki/loki.source.podlogs.md
+++ b/docs/sources/reference/components/loki/loki.source.podlogs.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about loki.source.podlogs
 labels:
   stage: general-availability
+  products:
+    - oss
 title: loki.source.podlogs
 ---
 

--- a/docs/sources/reference/components/loki/loki.source.syslog.md
+++ b/docs/sources/reference/components/loki/loki.source.syslog.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about loki.source.syslog
 labels:
   stage: general-availability
+  products:
+    - oss
 title: loki.source.syslog
 ---
 

--- a/docs/sources/reference/components/loki/loki.source.windowsevent.md
+++ b/docs/sources/reference/components/loki/loki.source.windowsevent.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about loki.windowsevent
 labels:
   stage: general-availability
+  products:
+    - oss
 title: loki.source.windowsevent
 ---
 

--- a/docs/sources/reference/components/loki/loki.write.md
+++ b/docs/sources/reference/components/loki/loki.write.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about loki.write
 labels:
   stage: general-availability
+  products:
+    - oss
 title: loki.write
 ---
 

--- a/docs/sources/reference/components/mimir/mimir.rules.kubernetes.md
+++ b/docs/sources/reference/components/mimir/mimir.rules.kubernetes.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about mimir.rules.kubernetes
 labels:
   stage: general-availability
+  products:
+    - oss
 title: mimir.rules.kubernetes
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.apache.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.apache.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.exporter.apache
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.exporter.apache
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.azure.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.azure.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.exporter.azure
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.exporter.azure
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.blackbox.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.blackbox.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.exporter.blackbox
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.exporter.blackbox
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.cadvisor.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.cadvisor.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about the prometheus.exporter.cadvisor
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.exporter.cadvisor
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.catchpoint.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.catchpoint.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.exporter.catchpoint
 labels:
   stage: experimental
+  products:
+    - oss
 title: prometheus.exporter.catchpoint
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.cloudwatch.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.cloudwatch.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.exporter.cloudwatch
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.exporter.cloudwatch
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.consul.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.consul.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.exporter.consul
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.exporter.consul
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.dnsmasq.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.dnsmasq.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.exporter.dnsmasq
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.exporter.dnsmasq
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.elasticsearch.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.elasticsearch.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.exporter.elasticsearch
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.exporter.elasticsearch
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.gcp.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.gcp.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.exporter.gcp
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.exporter.gcp
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.github.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.github.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.exporter.github
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.exporter.github
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.kafka.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.kafka.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.exporter.kafka
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.exporter.kafka
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.memcached.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.memcached.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.exporter.memcached
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.exporter.memcached
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.mongodb.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.mongodb.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.exporter.mongodb
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.exporter.mongodb
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.mssql.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.mssql.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.exporter.mssql
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.exporter.mssql
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.mysql.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.mysql.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.exporter.mysql
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.exporter.mysql
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.oracledb.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.oracledb.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.exporter.oracledb
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.exporter.oracledb
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.postgres.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.postgres.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.exporter.postgres
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.exporter.postgres
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.process.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.process.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.exporter.process
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.exporter.process
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.redis.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.redis.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.exporter.redis
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.exporter.redis
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.self.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.self.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.exporter.self
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.exporter.self
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.snmp.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.snmp.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.exporter.snmp
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.exporter.snmp
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.snowflake.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.snowflake.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.exporter.snowflake
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.exporter.snowflake
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.squid.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.squid.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.exporter.squid
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.exporter.squid
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.statsd.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.statsd.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.exporter.statsd
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.exporter.statsd
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.unix.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.unix.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.exporter.unix
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.exporter.unix
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.exporter.windows
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.exporter.windows
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.operator.podmonitors.md
+++ b/docs/sources/reference/components/prometheus/prometheus.operator.podmonitors.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.operator.podmonitors
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.operator.podmonitors
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.operator.probes.md
+++ b/docs/sources/reference/components/prometheus/prometheus.operator.probes.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.operator.probes
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.operator.probes
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.operator.scrapeconfigs.md
+++ b/docs/sources/reference/components/prometheus/prometheus.operator.scrapeconfigs.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.operator.scrapeconfigs
 labels:
   stage: experimental
+  products:
+    - oss
 title: prometheus.operator.scrapeconfigs
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.operator.servicemonitors.md
+++ b/docs/sources/reference/components/prometheus/prometheus.operator.servicemonitors.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.operator.servicemonitors
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.operator.servicemonitors
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.receive_http.md
+++ b/docs/sources/reference/components/prometheus/prometheus.receive_http.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.receive_http
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.receive_http
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.relabel.md
+++ b/docs/sources/reference/components/prometheus/prometheus.relabel.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.relabel
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.relabel
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.remote_write.md
+++ b/docs/sources/reference/components/prometheus/prometheus.remote_write.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.remote_write
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.remote_write
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.scrape.md
+++ b/docs/sources/reference/components/prometheus/prometheus.scrape.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about prometheus.scrape
 labels:
   stage: general-availability
+  products:
+    - oss
 title: prometheus.scrape
 ---
 

--- a/docs/sources/reference/components/prometheus/prometheus.write.queue.md
+++ b/docs/sources/reference/components/prometheus/prometheus.write.queue.md
@@ -3,6 +3,8 @@ canonical: https://grafana.com/docs/alloy/latest/reference/components/prometheus
 description: Learn about prometheus.write.queue
 labels:
   stage: experimental
+  products:
+    - oss
 title: prometheus.write.queue
 ---
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about pyroscope.ebpf
 labels:
   stage: general-availability
+  products:
+    - oss
 title: pyroscope.ebpf
 ---
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.java.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.java.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about pyroscope.java
 labels:
   stage: general-availability
+  products:
+    - oss
 title: pyroscope.java
 ---
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.receive_http.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.receive_http.md
@@ -3,6 +3,8 @@ canonical: https://grafana.com/docs/alloy/latest/reference/components/pyroscope/
 description: Learn about pyroscope.receive_http
 labels:
   stage: public-preview
+  products:
+    - oss
 title: pyroscope.receive_http
 ---
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.relabel.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.relabel.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about pyroscope.relabel
 labels:
   stage: public-preview
+  products:
+    - oss
 title: pyroscope.relabel
 ---
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.scrape.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.scrape.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about pyroscope.scrape
 labels:
   stage: general-availability
+  products:
+    - oss
 title: pyroscope.scrape
 ---
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.write.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.write.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about pyroscope.write
 labels:
   stage: general-availability
+  products:
+    - oss
 title: pyroscope.write
 ---
 

--- a/docs/sources/reference/components/remote/remote.http.md
+++ b/docs/sources/reference/components/remote/remote.http.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about remote.http
 labels:
   stage: general-availability
+  products:
+    - oss
 title: remote.http
 ---
 

--- a/docs/sources/reference/components/remote/remote.kubernetes.configmap.md
+++ b/docs/sources/reference/components/remote/remote.kubernetes.configmap.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about remote.kubernetes.configmap
 labels:
   stage: general-availability
+  products:
+    - oss
 title: remote.kubernetes.configmap
 ---
 

--- a/docs/sources/reference/components/remote/remote.kubernetes.secret.md
+++ b/docs/sources/reference/components/remote/remote.kubernetes.secret.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about remote.kubernetes.secret
 labels:
   stage: general-availability
+  products:
+    - oss
 title: remote.kubernetes.secret
 ---
 

--- a/docs/sources/reference/components/remote/remote.s3.md
+++ b/docs/sources/reference/components/remote/remote.s3.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about remote.s3
 labels:
   stage: general-availability
+  products:
+    - oss
 title: remote.s3
 ---
 

--- a/docs/sources/reference/components/remote/remote.vault.md
+++ b/docs/sources/reference/components/remote/remote.vault.md
@@ -5,6 +5,8 @@ aliases:
 description: Learn about remote.vault
 labels:
   stage: general-availability
+  products:
+    - oss
 title: remote.vault
 ---
 


### PR DESCRIPTION
Some Alloy topics use a product: stage label for the release status. This stage label overrides the top level cascaded label. To fix this, an explicit product: oss label must be added into the metadata on each page with a stages label.

Fixes #3444 
