### PR TITLE
Lowercase scheme for Prometheus ScrapeConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Main (unreleased)
 ### Bugfixes
 
 - Fix `otelcol.receiver.filelog` documentation's default value for `start_at`. (@petewall)
+
 - Fix [#3386](https://github.com/grafana/alloy/issues/3386) lower casing scheme in `prometheus.operator.scrapeconfigs`. (@alex-berger)
 
 ### Other changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Main (unreleased)
 ### Bugfixes
 
 - Fix `otelcol.receiver.filelog` documentation's default value for `start_at`. (@petewall)
+- Fix [#3386](https://github.com/grafana/alloy/issues/3386) lower casing scheme in `prometheus.operator.scrapeconfigs`. (@alex-berger)
 - Fix `mimir.rules.kubernetes` panic on non-leader debug info retrieval (@TheoBrigitte)
 
 ### Other changes

--- a/internal/component/prometheus/operator/configgen/config_gen_scrapeconfig.go
+++ b/internal/component/prometheus/operator/configgen/config_gen_scrapeconfig.go
@@ -4,6 +4,7 @@ package configgen
 
 import (
 	"fmt"
+	"strings"
 
 	promopv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/namespacelabeler"
@@ -92,7 +93,10 @@ func (cg *ConfigGenerator) commonScrapeConfigConfig(m *promopv1alpha1.ScrapeConf
 		cfg.Params = m.Spec.Params
 	}
 	if m.Spec.Scheme != nil {
-		cfg.Scheme = *m.Spec.Scheme
+		// Prometheus Operator ScrapeConfig CRD requires spec.scheme to be uppercase "HTTP" or "HTTPS", but
+		// the implementation expects lowercase "http" or "https" in the final scrape configuration. So, we
+		// have to lowercase the schema.
+		cfg.Scheme = strings.ToLower(*m.Spec.Scheme)
 	}
 	if m.Spec.TLSConfig != nil {
 		if cfg.HTTPClientConfig.TLSConfig, err = cg.generateSafeTLS(*m.Spec.TLSConfig, m.Namespace); err != nil {


### PR DESCRIPTION
Prometheus Operator ScrapeConfig CRD requires `spec.scheme` to be uppercase `"HTTP" or `"HTTPS"`, but the implementation expects lowercase `"http"` or `"https"` in the final scrape configuration.

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #3386

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Tests updated
- [x] Config converters updated
