### PR TITLE
Fix loki.source.docker only starting log collection for containers in running state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Main (unreleased)
 ### Bugfixes
 
 - Fix `otelcol.receiver.filelog` documentation's default value for `start_at`. (@petewall)
-- Fix `loki.source.docker` only starting log collection on running containers.(@RasEza)
+- Fix `loki.source.docker` only starting log collection on running containers. (@RasEza)
 
 ### Other changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Main (unreleased)
 ### Bugfixes
 
 - Fix `otelcol.receiver.filelog` documentation's default value for `start_at`. (@petewall)
+- Fix `loki.source.docker` only starting log collection on running containers.(@RasEza)
 
 ### Other changes
 

--- a/internal/component/loki/source/docker/runner.go
+++ b/internal/component/loki/source/docker/runner.go
@@ -104,14 +104,7 @@ func (t *tailer) Run(ctx context.Context) {
 	for {
 		select {
 		case <-tickerC:
-			res, err := t.opts.client.ContainerInspect(ctx, t.target.Name())
-			if err != nil {
-				level.Error(t.log).Log("msg", "error inspecting Docker container", "id", t.target.Name(), "error", err)
-				continue
-			}
-			if res.State.Running {
-				t.target.StartIfNotRunning()
-			}
+			t.target.StartIfNotRunning()
 		case <-ctx.Done():
 			t.target.Stop()
 			ticker.Stop()


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Due to the change in https://github.com/grafana/alloy/pull/742 loki.source.docker is no longer able to begin log collection for containers that only briefly have the "running" container state. This means that transient, short-lived or quickly restarting containers may never have their logs collected.

This fix removes the condition that target containers must be in the "running" state for the StartIfNotRunning function to be called. Additionally it completely removes a redundant container inspection that is also done by in the processLoop function which is called by StartIfNotRunning.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #3408

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Tests updated