### PR TITLE
Fix mimir.rules.kubernetes panic on non-leader debug info retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Main (unreleased)
 ### Bugfixes
 
 - Fix `otelcol.receiver.filelog` documentation's default value for `start_at`. (@petewall)
+- Fix `mimir.rules.kubernetes` panic on non-leader debug info retrieval (@TheoBrigitte)
 
 ### Other changes
 

--- a/internal/component/mimir/rules/kubernetes/debug.go
+++ b/internal/component/mimir/rules/kubernetes/debug.go
@@ -23,6 +23,10 @@ type DebugMimirNamespace struct {
 func (c *Component) DebugInfo() interface{} {
 	var output DebugInfo
 
+	if c.eventProcessor == nil {
+		return output
+	}
+
 	currentState := c.eventProcessor.getMimirState()
 	for namespace := range currentState {
 		if !isManagedMimirNamespace(c.args.MimirNameSpacePrefix, namespace) {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR fixes an issue where a panic occurs when trying to retrieve debug info for `mimir.rules.kubernetes` component on non-leader instance. This is due to the `eventProcessor` being nil in this case.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #3450 3450

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
