### PR TITLE
fix: panic that happens when a target gets deleted when using decompression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Main (unreleased)
 - Fix `otelcol.receiver.filelog` documentation's default value for `start_at`. (@petewall)
 - Fix `mimir.rules.kubernetes` panic on non-leader debug info retrieval (@TheoBrigitte)
 
+- Fix `loki.source.file` race condition that often lead to panic when using `decompression`. (@kalleep)
+
 ### Other changes
 
 - Update the zap logging adapter used by `otelcol` components to log arrays and objects. (@dehaansa)

--- a/internal/component/loki/source/file/decompresser.go
+++ b/internal/component/loki/source/file/decompresser.go
@@ -317,7 +317,7 @@ func (d *decompressor) markPositionAndSize() error {
 
 func (d *decompressor) Stop() {
 	if !d.stopped.CompareAndSwap(false, true) {
-		// We halve already called Stop
+		// We have already called Stop
 		return
 	}
 

--- a/internal/component/loki/source/file/decompresser.go
+++ b/internal/component/loki/source/file/decompresser.go
@@ -61,7 +61,7 @@ type decompressor struct {
 	size     int64
 	cfg      DecompressionConfig
 
-	// initOnce must be called from `Run` and mut most be locked.
+	// initOnce must be called from `Run` and mut must be locked.
 	initOnce          func()
 	componentStopping func() bool
 

--- a/internal/component/loki/source/file/decompresser.go
+++ b/internal/component/loki/source/file/decompresser.go
@@ -321,14 +321,16 @@ func (d *decompressor) Stop() {
 		return
 	}
 
-	// Shut down the position marker thread
-	close(d.posquit)
-	<-d.posdone
-
-	// Wait for readLines() to consume all the remaining messages and exit when the channel is closed
 	d.mut.RLock()
+	// Wait for readLines() to consume all the remaining messages and exit when the channel is closed
 	if d.done != nil {
 		<-d.done
+	}
+
+	// Shut down the position marker thread
+	if d.posquit != nil {
+		close(d.posquit)
+		<-d.posdone
 	}
 	d.mut.RUnlock()
 

--- a/internal/component/loki/source/file/tailer.go
+++ b/internal/component/loki/source/file/tailer.go
@@ -46,7 +46,7 @@ type tailer struct {
 	running *atomic.Bool
 	stopped *atomic.Bool
 
-	// initOnce must be called from when we can successfully run the tailer and mut most be locked.
+	// initOnce must be called from when we can successfully run the tailer and mut must be locked.
 	initOnce          func()
 	componentStopping func() bool
 

--- a/internal/component/loki/source/file/tailer.go
+++ b/internal/component/loki/source/file/tailer.go
@@ -369,7 +369,6 @@ func (t *tailer) Stop() {
 		}
 		err = t.tail.Stop()
 	}
-	t.mut.RUnlock()
 
 	if err != nil {
 		if utils.IsEphemeralOrFileClosed(err) {
@@ -383,7 +382,6 @@ func (t *tailer) Stop() {
 	}
 	level.Debug(t.logger).Log("msg", "waiting for readline and position marker to exit", "path", t.path)
 
-	t.mut.RLock()
 	if t.done != nil {
 		// Wait for readLines() to consume all the remaining messages and exit when the channel is closed
 		<-t.done
@@ -393,7 +391,7 @@ func (t *tailer) Stop() {
 		close(t.posquit)
 		<-t.posdone
 	}
-	t.mut.RLock()
+	t.mut.RUnlock()
 
 	level.Info(t.logger).Log("msg", "stopped tailing file", "path", t.path)
 

--- a/internal/component/loki/source/file/tailer_test.go
+++ b/internal/component/loki/source/file/tailer_test.go
@@ -142,33 +142,6 @@ func TestTailer(t *testing.T) {
 	}, time.Second, 50*time.Millisecond)
 
 	tailer.Stop()
-
-	// Run the tailer again
-	go tailer.Run()
-	select {
-	case <-ch1.Chan():
-		t.Fatal("no message should be sent because of the position file")
-	case <-time.After(1 * time.Second):
-	}
-
-	// Write logs again
-	_, err = logFile.Write([]byte("writing some new text\n"))
-	require.NoError(t, err)
-	select {
-	case logEntry := <-ch1.Chan():
-		require.Equal(t, "writing some new text", logEntry.Line)
-	case <-time.After(1 * time.Second):
-		require.FailNow(t, "failed waiting for log line")
-	}
-
-	tailer.Stop()
-
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		pos, err := positionsFile.Get(logFile.Name(), labels.String())
-		assert.NoError(c, err)
-		assert.Equal(c, int64(40), pos)
-	}, time.Second, 50*time.Millisecond)
-
 	positionsFile.Stop()
 	require.NoError(t, logFile.Close())
 }


### PR DESCRIPTION
#### PR Description
As reported in #3415 we get a panic when a file is remove if decompression is enabled, I also managed to get it sometime by when canceling the job so there is a race condition in here.

This happen after changes done in https://github.com/grafana/alloy/pull/3191 and https://github.com/grafana/alloy/pull/2428

`Run` is called in a [loop](https://github.com/grafana/alloy/blob/main/internal/component/loki/source/file/runner.go#L63-L69) and every time its triggered we ended up spawning a goroutine for `updatePosition`. So when we deleted the file or quick alloy the task is canceled and they all tried to close `posdone`. Because we also used to set these to `nil` we could get a panic for closing nil channel or panic for closing already closed channel.

I have only managed to reproduce this when running with decompression. The decompression job reads and decompress the whole file and is then considered done, so it will be triggered again in the loop.

When running without decompression we tail the file instead so `Run` does not return until the job is canceled so we are not going to call run several times.

With these changes its no longer possible to Start, Stop and Start again. I was kinda possible to do that before but you would leak go-routines if you did and it is never used like that by the component.


#### Which issue(s) this PR fixes

Fixes: #3415

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
