### PR TITLE
loki.process: Add labels_from_groups attribute to regex stage for automatic label creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ Main (unreleased)
 - Reduced the lag time during targets handover in a cluster in `prometheus.scrape` components by reducing thread contention. (@thampiotr)
 
 - Pretty print diagnostic errors when using `alloy run` (@kalleep)
+  
+- Add `labels_from_groups` attribute to `stage.regex` in `loki.process` to automatically add named capture groups as labels. (@harshrai654)
 
 - The `loki.rules.kubernetes` component now supports adding extra label matchers
   to all queries discovered via `PrometheusRule` CRDs. (@QuentinBisson)

--- a/docs/sources/reference/components/loki/loki.process.md
+++ b/docs/sources/reference/components/loki/loki.process.md
@@ -1140,7 +1140,8 @@ The name of the capture group is then used as the key in the extracted map for t
 
 Because of how {{< param "PRODUCT_NAME" >}} syntax strings work, any backslashes in `expression` must be escaped with a double backslash, for example, `"\\w"` or `"\\S+"`.
 
-When `labels_from_groups` is set to `true`, any named capture groups from the regular expression are automatically added as labels in addition to being added to the extracted map.
+When `labels_from_groups` is set to true, any named capture groups from the regex expression are automatically added as labels in addition to being added to the extracted map.
+If a capture group name matches an existing label name, the existing label's value will be overridden by the extracted value.
 
 If the `source` is empty or missing, then the stage parses the log line itself.
 If it's set, the stage parses a previously extracted value with the same name.

--- a/docs/sources/reference/components/loki/loki.process.md
+++ b/docs/sources/reference/components/loki/loki.process.md
@@ -1127,16 +1127,20 @@ The `stage.regex` inner block configures a processing stage that parses log line
 
 The following arguments are supported:
 
-| Name         | Type     | Description                                                        | Default | Required |
-| ------------ | -------- | ------------------------------------------------------------------ | ------- | -------- |
-| `expression` | `string` | A valid RE2 regular expression. Each capture group must be named.  |         | yes      |
-| `source`     | `string` | Name from extracted data to parse. If empty, uses the log message. | `""`    | no       |
+| Name                 | Type     | Description                                                        | Default | Required |
+| -------------------- | -------- | ------------------------------------------------------------------ | ------- | -------- |
+| `expression`         | `string` | A valid RE2 regular expression. Each capture group must be named.  |         | yes      |
+| `source`             | `string` | Name from extracted data to parse. If empty, uses the log message. | `""`    | no       |
+| `labels_from_groups` | `bool`   | Whether to automatically add named capture groups as labels.       | false   | no       |
+
 
 The `expression` field needs to be a RE2 regular expression string.
 Every matched capture group is added to the extracted map, so it must be named like: `(?P<name>re)`.
 The name of the capture group is then used as the key in the extracted map for the matched value.
 
 Because of how {{< param "PRODUCT_NAME" >}} syntax strings work, any backslashes in `expression` must be escaped with a double backslash, for example, `"\\w"` or `"\\S+"`.
+
+When `labels_from_groups` is set to true, any named capture groups from the regex expression are automatically added as labels in addition to being added to the extracted map.
 
 If the `source` is empty or missing, then the stage parses the log line itself.
 If it's set, the stage parses a previously extracted value with the same name.
@@ -1181,6 +1185,28 @@ time: 2022-01-01T01:00:00.000000001Z
 Then, the regular expression stage parses the value for time from the shared values and appends the subsequent key-value pair back into the extracted values map:
 
 ```text
+year: 2022
+```
+
+The following example demonstrates how `labels_from_groups` can automatically add the matched groups as labels:
+
+```alloy
+{"timestamp":"2022-01-01T01:00:00.000000001Z"}
+
+stage.json {
+    expressions = { time = "timestamp" }
+}
+stage.regex {
+    expression = "^(?P<year>\\d+)"
+    source = "time"
+    labels_from_groups = true   // Sets up an 'year' label, based on the 'year' capture group's value.
+}
+```
+
+This pipeline produces the same extracted values as before:
+
+```text
+time: 2022-01-01T01:00:00.000000001Z
 year: 2022
 ```
 

--- a/docs/sources/reference/components/loki/loki.process.md
+++ b/docs/sources/reference/components/loki/loki.process.md
@@ -1131,7 +1131,7 @@ The following arguments are supported:
 | -------------------- | -------- | ------------------------------------------------------------------ | ------- | -------- |
 | `expression`         | `string` | A valid RE2 regular expression. Each capture group must be named.  |         | yes      |
 | `source`             | `string` | Name from extracted data to parse. If empty, uses the log message. | `""`    | no       |
-| `labels_from_groups` | `bool`   | Whether to automatically add named capture groups as labels.       | false   | no       |
+| `labels_from_groups` | `bool`   | Whether to automatically add named capture groups as labels.       | `false` | no       |
 
 
 The `expression` field needs to be a RE2 regular expression string.
@@ -1140,7 +1140,7 @@ The name of the capture group is then used as the key in the extracted map for t
 
 Because of how {{< param "PRODUCT_NAME" >}} syntax strings work, any backslashes in `expression` must be escaped with a double backslash, for example, `"\\w"` or `"\\S+"`.
 
-When `labels_from_groups` is set to true, any named capture groups from the regex expression are automatically added as labels in addition to being added to the extracted map.
+When `labels_from_groups` is set to `true`, any named capture groups from the regular expression are automatically added as labels in addition to being added to the extracted map.
 
 If the `source` is empty or missing, then the stage parses the log line itself.
 If it's set, the stage parses a previously extracted value with the same name.

--- a/internal/component/loki/process/stages/pipeline.go
+++ b/internal/component/loki/process/stages/pipeline.go
@@ -76,7 +76,7 @@ func NewPipeline(logger log.Logger, stages []StageConfig, jobName *string, regis
 	}, nil
 }
 
-// RunWith will reads from the input channel entries, mutate them with the process function and returns them via the output channel.
+// RunWith will read from the input channel entries, mutate them with the process function and returns them via the output channel.
 func RunWith(input chan Entry, process func(e Entry) Entry) chan Entry {
 	out := make(chan Entry)
 	go func() {

--- a/internal/component/loki/process/stages/regex.go
+++ b/internal/component/loki/process/stages/regex.go
@@ -23,8 +23,9 @@ var (
 // RegexConfig configures a processing stage uses regular expressions to
 // extract values from log lines into the shared values map.
 type RegexConfig struct {
-	Expression string  `alloy:"expression,attr"`
-	Source     *string `alloy:"source,attr,optional"`
+	Expression       string  `alloy:"expression,attr"`
+	Source           *string `alloy:"source,attr,optional"`
+	LabelsFromGroups bool    `alloy:"labels_from_groups,attr,optional"`
 }
 
 // validateRegexConfig validates the config and return a regex
@@ -118,6 +119,9 @@ func (r *regexStage) Process(labels model.LabelSet, extracted map[string]interfa
 	for i, name := range r.expression.SubexpNames() {
 		if i != 0 && name != "" {
 			extracted[name] = match[i]
+			if r.config.LabelsFromGroups {
+				labels[model.LabelName(name)] = model.LabelValue(match[i])
+			}
 		}
 	}
 	if Debug {

--- a/internal/component/loki/process/stages/regex.go
+++ b/internal/component/loki/process/stages/regex.go
@@ -120,7 +120,31 @@ func (r *regexStage) Process(labels model.LabelSet, extracted map[string]interfa
 		if i != 0 && name != "" {
 			extracted[name] = match[i]
 			if r.config.LabelsFromGroups {
-				labels[model.LabelName(name)] = model.LabelValue(match[i])
+				labelName := model.LabelName(name)
+				labelValue := model.LabelValue(match[i])
+
+				if !labelName.IsValid() {
+					if Debug {
+						level.Debug(r.logger).Log("msg", "invalid label name from regex capture group", "labelName", labelName)
+					}
+					continue
+				}
+
+				if !labelValue.IsValid() {
+					if Debug {
+						level.Debug(r.logger).Log("msg", "invalid label value from regex capture group", "labelName", labelName, "labelValue", labelValue)
+					}
+					continue
+				}
+
+				oldLabelValue, ok := labels[labelName]
+
+				// Label from capture group will override existing label with same name
+				if Debug && ok {
+					level.Debug(r.logger).Log("msg", "label from regex capture group is overriding existing label", "label", labelName, "oldValue", oldLabelValue, "newValue", labelValue)
+				}
+
+				labels[labelName] = labelValue
 			}
 		}
 	}

--- a/internal/component/loki/process/stages/regex_test.go
+++ b/internal/component/loki/process/stages/regex_test.go
@@ -41,7 +41,19 @@ stage.regex {
 stage.regex {
     expression = "^HTTP\\/(?P<protocol_version>[0-9\\.]+)$"
     source     = "protocol"
-}	
+}
+`
+
+var testRegexAlloyMultiStageWithExistingLabelsAndLabelFromGroups = `
+stage.static_labels {
+    values = {
+      protocol = "HTTP/2",
+    }
+}
+stage.regex {
+    expression = "^(?P<ip>\\S+) (?P<identd>\\S+) (?P<user>\\S+) \\[(?P<timestamp>[\\w:/]+\\s[+\\-]\\d{4})\\] \"(?P<action>\\S+)\\s?(?P<path>\\S+)?\\s?(?P<protocol>\\S+)?\" (?P<status>\\d{3}|-) (?P<size>\\d+|-)\\s?\"?(?P<referer>[^\"]*)\"?\\s?\"?(?P<useragent>[^\"]*)?\"?$"
+	labels_from_groups = true
+}
 `
 
 var testRegexAlloySourceWithMissingKey = `
@@ -130,6 +142,36 @@ func TestPipeline_Regex(t *testing.T) {
 				"size":             "932",
 				"referer":          "-",
 				"useragent":        "Mozilla/5.0 (Windows; U; Windows NT 5.1; de; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7 GTB6",
+			},
+			model.LabelSet{
+				"ip":        "11.11.11.11",
+				"identd":    "-",
+				"user":      "frank",
+				"timestamp": "25/Jan/2000:14:00:01 -0500",
+				"action":    "GET",
+				"path":      "/1986.js",
+				"protocol":  "HTTP/1.1",
+				"status":    "200",
+				"size":      "932",
+				"referer":   "-",
+				"useragent": "Mozilla/5.0 (Windows; U; Windows NT 5.1; de; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7 GTB6",
+			},
+		},
+		"successfully run a pipeline with regex stage labels overriding existing labels with labels_from_groups": {
+			testRegexAlloyMultiStageWithExistingLabelsAndLabelFromGroups,
+			testRegexLogLine,
+			map[string]interface{}{
+				"ip":        "11.11.11.11",
+				"identd":    "-",
+				"user":      "frank",
+				"timestamp": "25/Jan/2000:14:00:01 -0500",
+				"action":    "GET",
+				"path":      "/1986.js",
+				"protocol":  "HTTP/1.1",
+				"status":    "200",
+				"size":      "932",
+				"referer":   "-",
+				"useragent": "Mozilla/5.0 (Windows; U; Windows NT 5.1; de; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7 GTB6",
 			},
 			model.LabelSet{
 				"ip":        "11.11.11.11",


### PR DESCRIPTION
#### PR Description
Add `labels_from_groups` attribute to `stage.regex` in `loki.process` to automatically add named capture groups as labels. This provides a convenient way to convert extracted regex groups into labels without additional configuration.

#### Which issue(s) this PR fixes
Fixes #3146 

#### Notes to the Reviewer
- Added `labels_from_groups` bool attribute to RegexConfig
- Updated regex stage processing to add matched groups as labels when enabled
- Added tests for the new functionality 
- Updated documentation with examples showing usage
- Added changelog entry under Enhancements

#### PR Checklist
- [x] CHANGELOG.md updated
- [x] Documentation added 
- [x] Tests updated