### PR TITLE
Fix streams limit error check so that metrics are correctly labeled as `ReasonStreamLimited`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Main (unreleased)
 - Fix `otelcol.receiver.filelog` documentation's default value for `start_at`. (@petewall)
 - Fix `mimir.rules.kubernetes` panic on non-leader debug info retrieval (@TheoBrigitte)
 
+- Fix detection of the “streams limit exceeded” error in the Loki client so that metrics are correctly labeled as `ReasonStreamLimited`. (@maratkhv)
+
 ### Other changes
 
 - Update the zap logging adapter used by `otelcol` components to log arrays and objects. (@dehaansa)

--- a/internal/component/common/loki/client/batch.go
+++ b/internal/component/common/loki/client/batch.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -16,17 +17,9 @@ import (
 	"github.com/grafana/alloy/internal/component/common/loki"
 )
 
-const (
-	errMaxStreamsLimitExceeded = "streams limit exceeded, streams: %d exceeds limit: %d, stream: '%s'"
+var (
+	errMaxStreamsLimitExceeded = errors.New("streams limit exceeded")
 )
-
-func isErrMaxStreamsLimitExceeded(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	return strings.HasPrefix(err.Error(), "streams limit exceeded")
-}
 
 // SentDataMarkerHandler is a slice of the MarkerHandler interface, that the batch interacts with to report the event that
 // all data in the batch has been delivered or a client failed to do so.
@@ -81,7 +74,7 @@ func (b *batch) add(entry loki.Entry) error {
 
 	streams := len(b.streams)
 	if b.maxStreams > 0 && streams >= b.maxStreams {
-		return fmt.Errorf(errMaxStreamsLimitExceeded, streams, b.maxStreams, labels)
+		return fmt.Errorf("%w, streams: %d exceeds limit: %d, stream: '%s'", errMaxStreamsLimitExceeded, streams, b.maxStreams, labels)
 	}
 	// Add the entry as a new stream
 	b.streams[labels] = &logproto.Stream{
@@ -106,7 +99,7 @@ func (b *batch) addFromWAL(lbs model.LabelSet, entry logproto.Entry, segmentNum 
 
 	streams := len(b.streams)
 	if b.maxStreams > 0 && streams >= b.maxStreams {
-		return fmt.Errorf(errMaxStreamsLimitExceeded, streams, b.maxStreams, labels)
+		return fmt.Errorf("%w, streams: %d exceeds limit: %d, stream: '%s'", errMaxStreamsLimitExceeded, streams, b.maxStreams, labels)
 	}
 
 	// Add the entry as a new stream

--- a/internal/component/common/loki/client/batch.go
+++ b/internal/component/common/loki/client/batch.go
@@ -20,6 +20,14 @@ const (
 	errMaxStreamsLimitExceeded = "streams limit exceeded, streams: %d exceeds limit: %d, stream: '%s'"
 )
 
+func isErrMaxStreamsLimitExceeded(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return strings.HasPrefix(err.Error(), "streams limit exceeded")
+}
+
 // SentDataMarkerHandler is a slice of the MarkerHandler interface, that the batch interacts with to report the event that
 // all data in the batch has been delivered or a client failed to do so.
 type SentDataMarkerHandler interface {

--- a/internal/component/common/loki/client/batch_test.go
+++ b/internal/component/common/loki/client/batch_test.go
@@ -31,7 +31,7 @@ func TestBatch_MaxStreams(t *testing.T) {
 		err := b.add(entry)
 		if err != nil {
 			errCount++
-			assert.EqualError(t, err, fmt.Errorf(errMaxStreamsLimitExceeded, len(b.streams), b.maxStreams, entry.Labels).Error())
+			assert.ErrorIs(t, err, errMaxStreamsLimitExceeded)
 		}
 	}
 	assert.Equal(t, errCount, 2)
@@ -184,30 +184,4 @@ func BenchmarkLabelsMapToString(b *testing.B) {
 		r = labelsMapToString(labelSet, ReservedLabelTenantID)
 	}
 	result = r
-}
-
-func TestIsErrMaxStreamsLimitExceeded(t *testing.T) {
-	testCases := []struct {
-		name     string
-		err      error
-		expected bool
-	}{
-		{
-			name:     "error is max stream limit exceeded",
-			err:      fmt.Errorf(errMaxStreamsLimitExceeded, 1, 2, "foo bar"),
-			expected: true,
-		},
-		{
-			name:     "error is different",
-			err:      fmt.Errorf("some other error"),
-			expected: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			result := isErrMaxStreamsLimitExceeded(tc.err)
-			assert.Equal(t, tc.expected, result)
-		})
-	}
 }

--- a/internal/component/common/loki/client/batch_test.go
+++ b/internal/component/common/loki/client/batch_test.go
@@ -185,3 +185,29 @@ func BenchmarkLabelsMapToString(b *testing.B) {
 	}
 	result = r
 }
+
+func TestIsErrMaxStreamsLimitExceeded(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "error is max stream limit exceeded",
+			err:      fmt.Errorf(errMaxStreamsLimitExceeded, 1, 2, "foo bar"),
+			expected: true,
+		},
+		{
+			name:     "error is different",
+			err:      fmt.Errorf("some other error"),
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := isErrMaxStreamsLimitExceeded(tc.err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/internal/component/common/loki/client/client.go
+++ b/internal/component/common/loki/client/client.go
@@ -310,7 +310,7 @@ func (c *client) run() {
 			if err != nil {
 				level.Error(c.logger).Log("msg", "batch add err", "tenant", tenantID, "error", err)
 				reason := ReasonGeneric
-				if err.Error() == errMaxStreamsLimitExceeded {
+				if isErrMaxStreamsLimitExceeded(err) {
 					reason = ReasonStreamLimited
 				}
 				c.metrics.droppedBytes.WithLabelValues(c.cfg.URL.Host, tenantID, reason).Add(float64(len(e.Line)))

--- a/internal/component/common/loki/client/client.go
+++ b/internal/component/common/loki/client/client.go
@@ -310,7 +310,7 @@ func (c *client) run() {
 			if err != nil {
 				level.Error(c.logger).Log("msg", "batch add err", "tenant", tenantID, "error", err)
 				reason := ReasonGeneric
-				if isErrMaxStreamsLimitExceeded(err) {
+				if errors.Is(err, errMaxStreamsLimitExceeded) {
 					reason = ReasonStreamLimited
 				}
 				c.metrics.droppedBytes.WithLabelValues(c.cfg.URL.Host, tenantID, reason).Add(float64(len(e.Line)))

--- a/internal/component/common/loki/client/queue_client.go
+++ b/internal/component/common/loki/client/queue_client.go
@@ -358,7 +358,7 @@ func (c *queueClient) appendSingleEntry(segmentNum int, lbs model.LabelSet, e lo
 	if err != nil {
 		level.Error(c.logger).Log("msg", "batch add err", "tenant", tenantID, "error", err)
 		reason := ReasonGeneric
-		if isErrMaxStreamsLimitExceeded(err) {
+		if errors.Is(err, errMaxStreamsLimitExceeded) {
 			reason = ReasonStreamLimited
 		}
 		c.metrics.droppedBytes.WithLabelValues(c.cfg.URL.Host, tenantID, reason).Add(float64(len(e.Line)))

--- a/internal/component/common/loki/client/queue_client.go
+++ b/internal/component/common/loki/client/queue_client.go
@@ -358,7 +358,7 @@ func (c *queueClient) appendSingleEntry(segmentNum int, lbs model.LabelSet, e lo
 	if err != nil {
 		level.Error(c.logger).Log("msg", "batch add err", "tenant", tenantID, "error", err)
 		reason := ReasonGeneric
-		if err.Error() == errMaxStreamsLimitExceeded {
+		if isErrMaxStreamsLimitExceeded(err) {
 			reason = ReasonStreamLimited
 		}
 		c.metrics.droppedBytes.WithLabelValues(c.cfg.URL.Host, tenantID, reason).Add(float64(len(e.Line)))


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR fixes an issue where such error check
`if err.Error() == errMaxStreamsLimitExceeded { reason = ReasonStreamLimited  }`
would always fail because batch.add() returns a formatted error, so the metrics are not labeled properly.
#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer
- I believe using a regexp here would be overkill; a simple `HasPrefix` check is sufficient.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Tests updated
