### PR TITLE
Fix broken and redirect links in Alloy docs

### DIFF
--- a/docs/sources/monitor/monitor-windows.md
+++ b/docs/sources/monitor/monitor-windows.md
@@ -155,7 +155,7 @@ prometheus.remote_write "demo" {
 
 [prometheus.exporter.windows]: https://grafana.com/docs/alloy/<ALLOY_VERSION>/reference/components/prometheus/prometheus.exporter.windows/
 [prometheus.scrape]: https://grafana.com/docs/alloy/<ALLOY_VERSION>/reference/components/prometheus/prometheus.scrape/
-[prometheus.remote_write]: https://grafana.com/docs/alloy/<ALLOY_VERSION>/reference/components/prometheus/prometheus.remote.write/
+[prometheus.remote_write]: https://grafana.com/docs/alloy/<ALLOY_VERSION>/reference/components/prometheus/prometheus.remote_write/
 
 ### Configure logging
 

--- a/docs/sources/reference/cli/run.md
+++ b/docs/sources/reference/cli/run.md
@@ -69,7 +69,7 @@ The following flags are supported:
 The `--windows.priority` flag is in [Public preview][] and is not covered by {{< param "FULL_PRODUCT_NAME" >}} [backward compatibility][] guarantees.
 
 [Public preview]: https://grafana.com/docs/release-life-cycle/
-[backward compatibility]: ../introduction/backward-compatibility/
+[backward compatibility]: ../../../introduction/backward-compatibility/
 {{< /admonition >}}
 
 ## Update the configuration file

--- a/docs/sources/reference/components/prometheus/prometheus.remote_write.md
+++ b/docs/sources/reference/components/prometheus/prometheus.remote_write.md
@@ -392,9 +392,9 @@ To troubleshoot, take the following steps in order:
    ./promtool tsdb dump --match='{__name__="otelcol_connector_spanmetrics_duration_seconds_bucket", http_method="GET", job="ExampleJobName"}' /path/to/wal/
    ```
 
-[clustering]: ../../../configure/clustering
+[clustering]: ../../../../configure/clustering
 [mimir-ooo-err]: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#err-mimir-sample-out-of-order
-[run-cmd]: ../../cli/run/
+[run-cmd]: ../../../cli/run/
 [promtool]: https://prometheus.io/docs/prometheus/latest/command-line/promtool/#promtool-tsdb
 
 ## Technical details

--- a/docs/sources/reference/stdlib/encoding.md
+++ b/docs/sources/reference/stdlib/encoding.md
@@ -140,5 +140,5 @@ null
 "Hello, world!"
 ```
 
-[`local.file`]: ../components/local/local.file/
-[`prometheus.exporter.blackbox`]: ../components/prometheus/prometheus.exporter.blackbox
+[`local.file`]: ../../components/local/local.file/
+[`prometheus.exporter.blackbox`]: ../../components/prometheus/prometheus.exporter.blackbox

--- a/docs/sources/set-up/install/windows.md
+++ b/docs/sources/set-up/install/windows.md
@@ -66,7 +66,7 @@ The `--windows.priority` flag is in [Public preview][stability] and is not cover
 The `/RUNTIMEPRIORITY` installation option sets this flag, and if Alloy is not running with an appropriate stability level it will fail to start.
 
 [stability]: https://grafana.com/docs/release-life-cycle/
-[backward compatibility]: ../introduction/backward-compatibility/
+[backward compatibility]: ../../../introduction/backward-compatibility/
 {{< /admonition >}}
 
 ## Service Configuration


### PR DESCRIPTION
Some bad/broken links have started showing up in the Alloy docs - a result of other doc changes, moving pages etc.

Related Issue: https://github.com/grafana/alloy/issues/3465