### PR TITLE
fix: panic that happens when a target gets deleted when using decompression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,12 @@ Main (unreleased)
 ### Bugfixes
 
 - Fix `otelcol.receiver.filelog` documentation's default value for `start_at`. (@petewall)
+
 - Fix `mimir.rules.kubernetes` panic on non-leader debug info retrieval (@TheoBrigitte)
 
 - Fix detection of the “streams limit exceeded” error in the Loki client so that metrics are correctly labeled as `ReasonStreamLimited`. (@maratkhv)
+
+- Fix `loki.source.file` race condition that often lead to panic when using `decompression`. (@kalleep)
 
 ### Other changes
 

--- a/internal/component/loki/source/file/decompresser.go
+++ b/internal/component/loki/source/file/decompresser.go
@@ -222,7 +222,6 @@ func (d *decompressor) updatePosition() {
 // During each iteration, the parsed and decoded log line is then sent to the API with the current timestamp.
 func (d *decompressor) readLines(handler loki.EntryHandler) {
 	level.Info(d.logger).Log("msg", "read lines routine: started", "path", d.path)
-	d.running.Store(true)
 
 	if d.cfg.InitialDelay > 0 {
 		level.Info(d.logger).Log("msg", "sleeping before starting decompression", "path", d.path, "duration", d.cfg.InitialDelay.String())
@@ -230,7 +229,6 @@ func (d *decompressor) readLines(handler loki.EntryHandler) {
 	}
 
 	defer func() {
-		d.running.Store(false)
 		level.Info(d.logger).Log("msg", "read lines routine finished", "path", d.path)
 		close(d.done)
 		close(d.posquit)

--- a/internal/component/loki/source/file/decompresser.go
+++ b/internal/component/loki/source/file/decompresser.go
@@ -167,7 +167,7 @@ func (d *decompressor) Run(ctx context.Context) {
 	done := make(chan struct{})
 	ctx, cancel := context.WithCancel(ctx)
 	go func() {
-		// readLines closes the done on exit
+		// readLines closes done on exit
 		d.readLines(handler, done)
 		cancel()
 	}()

--- a/internal/component/loki/source/file/decompresser.go
+++ b/internal/component/loki/source/file/decompresser.go
@@ -186,10 +186,8 @@ func (d *decompressor) Run(ctx context.Context) {
 	d.running.Store(true)
 	defer d.running.Store(false)
 
-	select {
-	case <-ctx.Done():
-		d.stop()
-	}
+	<-ctx.Done()
+	d.stop()
 }
 
 func (d *decompressor) updatePosition() {
@@ -232,8 +230,8 @@ func (d *decompressor) readLines(handler loki.EntryHandler) {
 		level.Info(d.logger).Log("msg", "read lines routine finished", "path", d.path)
 		close(d.done)
 		close(d.posquit)
-
 	}()
+
 	entries := handler.Chan()
 
 	f, err := os.Open(d.path)

--- a/internal/component/loki/source/file/decompresser_test.go
+++ b/internal/component/loki/source/file/decompresser_test.go
@@ -4,7 +4,6 @@ package file
 // of the reader interface.
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"sync"
@@ -230,7 +229,7 @@ func TestDecompressor(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	go decompressor.Run(context.Background())
+	go decompressor.Run(t.Context())
 
 	select {
 	case logEntry := <-ch1.Chan():
@@ -246,7 +245,7 @@ func TestDecompressor(t *testing.T) {
 	}, time.Second, 50*time.Millisecond)
 
 	// Run the decompressor again
-	go decompressor.Run(context.Background())
+	go decompressor.Run(t.Context())
 	select {
 	case <-ch1.Chan():
 		t.Fatal("no message should be sent because of the position file")
@@ -285,7 +284,7 @@ func TestDecompressorPositionFileEntryDeleted(t *testing.T) {
 		func() bool { return false },
 	)
 	require.NoError(t, err)
-	go decompressor.Run(context.Background())
+	go decompressor.Run(t.Context())
 
 	select {
 	case logEntry := <-ch1.Chan():
@@ -333,7 +332,7 @@ func TestDecompressor_RunCalledTwice(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	decompressor.Run(context.Background())
-	decompressor.Run(context.Background())
+	decompressor.Run(t.Context())
+	decompressor.Run(t.Context())
 	positionsFile.Stop()
 }

--- a/internal/component/loki/source/file/decompresser_test.go
+++ b/internal/component/loki/source/file/decompresser_test.go
@@ -50,6 +50,24 @@ func newNoopClient() *noopClient {
 	return c
 }
 
+var _ positions.Positions = (*noopPositions)(nil)
+
+type noopPositions struct{}
+
+func (n *noopPositions) Get(path string, labels string) (int64, error) { return 0, nil }
+
+func (n *noopPositions) GetString(path string, labels string) string { return "" }
+
+func (n *noopPositions) Put(path string, labels string, pos int64) {}
+
+func (n *noopPositions) PutString(path string, labels string, pos string) {}
+
+func (n *noopPositions) Remove(path string, labels string) {}
+
+func (n *noopPositions) Stop() {}
+
+func (n *noopPositions) SyncPeriod() time.Duration { return 10 * time.Second }
+
 func BenchmarkReadlines(b *testing.B) {
 	entryHandler := newNoopClient()
 
@@ -79,9 +97,9 @@ func BenchmarkReadlines(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				newDec := decBase
 				newDec.metrics = newMetrics(prometheus.NewRegistry())
-				newDec.done = make(chan struct{})
-				newDec.readLines(entryHandler)
-				<-newDec.done
+				done := make(chan struct{})
+				newDec.readLines(entryHandler, done)
+				<-done
 			}
 		})
 	}
@@ -93,21 +111,20 @@ func TestGigantiqueGunzipFile(t *testing.T) {
 	defer handler.Stop()
 
 	d := &decompressor{
-		logger:   log.NewNopLogger(),
-		running:  atomic.NewBool(false),
-		receiver: loki.NewLogsReceiver(),
-		path:     file,
-		done:     make(chan struct{}),
-		posquit:  make(chan struct{}),
-		metrics:  newMetrics(prometheus.NewRegistry()),
-		cfg:      DecompressionConfig{Format: "gz"},
+		logger:    log.NewNopLogger(),
+		running:   atomic.NewBool(false),
+		receiver:  loki.NewLogsReceiver(),
+		path:      file,
+		metrics:   newMetrics(prometheus.NewRegistry()),
+		cfg:       DecompressionConfig{Format: "gz"},
+		positions: &noopPositions{},
 	}
 
-	d.readLines(handler)
+	done := make(chan struct{})
+	d.readLines(handler, done)
+	<-done
 
-	<-d.done
 	time.Sleep(time.Millisecond * 200)
-
 	entries := handler.Received()
 	require.Equal(t, 100000, len(entries))
 }
@@ -124,21 +141,20 @@ func TestOnelineFiles(t *testing.T) {
 		defer handler.Stop()
 
 		d := &decompressor{
-			logger:   log.NewNopLogger(),
-			running:  atomic.NewBool(false),
-			receiver: loki.NewLogsReceiver(),
-			path:     file,
-			done:     make(chan struct{}),
-			posquit:  make(chan struct{}),
-			metrics:  newMetrics(prometheus.NewRegistry()),
-			cfg:      DecompressionConfig{Format: "gz"},
+			logger:    log.NewNopLogger(),
+			running:   atomic.NewBool(false),
+			receiver:  loki.NewLogsReceiver(),
+			path:      file,
+			metrics:   newMetrics(prometheus.NewRegistry()),
+			cfg:       DecompressionConfig{Format: "gz"},
+			positions: &noopPositions{},
 		}
 
-		d.readLines(handler)
+		done := make(chan struct{})
+		d.readLines(handler, done)
+		<-done
 
-		<-d.done
 		time.Sleep(time.Millisecond * 200)
-
 		entries := handler.Received()
 		require.Equal(t, 1, len(entries))
 		require.Equal(t, string(fileContent), entries[0].Line)
@@ -150,19 +166,19 @@ func TestOnelineFiles(t *testing.T) {
 		defer handler.Stop()
 
 		d := &decompressor{
-			logger:   log.NewNopLogger(),
-			running:  atomic.NewBool(false),
-			receiver: loki.NewLogsReceiver(),
-			path:     file,
-			done:     make(chan struct{}),
-			posquit:  make(chan struct{}),
-			metrics:  newMetrics(prometheus.NewRegistry()),
-			cfg:      DecompressionConfig{Format: "bz2"},
+			logger:    log.NewNopLogger(),
+			running:   atomic.NewBool(false),
+			receiver:  loki.NewLogsReceiver(),
+			path:      file,
+			metrics:   newMetrics(prometheus.NewRegistry()),
+			cfg:       DecompressionConfig{Format: "bz2"},
+			positions: &noopPositions{},
 		}
 
-		d.readLines(handler)
+		done := make(chan struct{})
+		d.readLines(handler, done)
+		<-done
 
-		<-d.done
 		time.Sleep(time.Millisecond * 200)
 
 		entries := handler.Received()
@@ -176,19 +192,19 @@ func TestOnelineFiles(t *testing.T) {
 		defer handler.Stop()
 
 		d := &decompressor{
-			logger:   log.NewNopLogger(),
-			running:  atomic.NewBool(false),
-			receiver: loki.NewLogsReceiver(),
-			path:     file,
-			done:     make(chan struct{}),
-			posquit:  make(chan struct{}),
-			metrics:  newMetrics(prometheus.NewRegistry()),
-			cfg:      DecompressionConfig{Format: "gz"},
+			logger:    log.NewNopLogger(),
+			running:   atomic.NewBool(false),
+			receiver:  loki.NewLogsReceiver(),
+			path:      file,
+			metrics:   newMetrics(prometheus.NewRegistry()),
+			cfg:       DecompressionConfig{Format: "gz"},
+			positions: &noopPositions{},
 		}
 
-		d.readLines(handler)
+		done := make(chan struct{})
+		d.readLines(handler, done)
 
-		<-d.done
+		<-done
 		time.Sleep(time.Millisecond * 200)
 
 		entries := handler.Received()

--- a/internal/component/loki/source/file/reader.go
+++ b/internal/component/loki/source/file/reader.go
@@ -1,12 +1,15 @@
 package file
 
-// This code is copied from loki/promtail@a8d5815510bd959a6dd8c176a5d9fd9bbfc8f8b5.
+import "context"
+
+// This code is adopted from loki/promtail@a8d5815510bd959a6dd8c176a5d9fd9bbfc8f8b5.
 // This code accommodates the tailer and decompressor implementations as readers.
 
 // reader contains the set of methods the loki.source.file component uses.
 type reader interface {
-	Run()
-	Stop()
+	// Run will start the reader job and exit if context is canceled or
+	// if job finished. It's not safe to call run on the same reader from different
+	// goroutines.
+	Run(ctx context.Context)
 	IsRunning() bool
-	Path() string
 }

--- a/internal/component/loki/source/file/runner.go
+++ b/internal/component/loki/source/file/runner.go
@@ -2,7 +2,6 @@ package file
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/grafana/alloy/internal/runner"
@@ -51,23 +50,11 @@ func (r *runnerReader) Run(ctx context.Context) {
 		},
 	)
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-
-	go func() {
-		defer wg.Done()
-		<-ctx.Done()
-		r.reader.Stop()
-	}()
-
 	for {
-		r.reader.Run()
+		r.reader.Run(ctx)
 		backoff.Wait()
 		if !backoff.Ongoing() {
 			break
 		}
 	}
-
-	// Wait for the stop function to exit to ensure that the reader was properly stopped.
-	wg.Wait()
 }

--- a/internal/component/loki/source/file/tailer.go
+++ b/internal/component/loki/source/file/tailer.go
@@ -174,10 +174,8 @@ func (t *tailer) Run(ctx context.Context) {
 	t.running.Store(true)
 	defer t.running.Store(false)
 
-	select {
-	case <-ctx.Done():
-		t.stop()
-	}
+	<-ctx.Done()
+	t.stop()
 }
 
 func (t *tailer) initRun() (loki.EntryHandler, error) {
@@ -391,10 +389,7 @@ func (t *tailer) stop() {
 	if !t.componentStopping() {
 		t.positions.Remove(t.path, t.labelsStr)
 	}
-
 }
-
-func (t *tailer) Stop() {}
 
 func (t *tailer) IsRunning() bool {
 	return t.running.Load()

--- a/internal/component/loki/source/file/tailer_test.go
+++ b/internal/component/loki/source/file/tailer_test.go
@@ -91,7 +91,7 @@ func TestGetLastLinePosition(t *testing.T) {
 	}
 }
 
-func TestTailer2(t *testing.T) {
+func TestTailer(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
 	l := util.TestLogger(t)
 	ch1 := loki.NewLogsReceiver()
@@ -126,7 +126,7 @@ func TestTailer2(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	done := make(chan struct{})
 	go func() {
 		tailer.Run(ctx)
@@ -152,7 +152,7 @@ func TestTailer2(t *testing.T) {
 	<-done
 
 	// Run the tailer again
-	ctx, cancel = context.WithCancel(context.Background())
+	ctx, cancel = context.WithCancel(t.Context())
 	done = make(chan struct{})
 	go func() {
 		tailer.Run(ctx)
@@ -184,7 +184,6 @@ func TestTailer2(t *testing.T) {
 
 	positionsFile.Stop()
 	require.NoError(t, logFile.Close())
-
 }
 
 func TestTailerPositionFileEntryDeleted(t *testing.T) {
@@ -221,7 +220,7 @@ func TestTailerPositionFileEntryDeleted(t *testing.T) {
 		func() bool { return false },
 	)
 	require.NoError(t, err)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	go tailer.Run(ctx)
 
 	_, err = logFile.Write([]byte("writing some text\n"))
@@ -292,7 +291,7 @@ func TestTailerDeleteFileInstant(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		tailer.Run(context.Background())
+		tailer.Run(t.Context())
 		positionsFile.Stop()
 		close(done)
 	}()


### PR DESCRIPTION
#### PR Description
Alternative to https://github.com/grafana/alloy/pull/3452. In this pr I am taking a different approach.

Instead of having to call a `Stop` function on readers we instead accept a `context.Context` in `Run`. Run will now block until context is canceled or if it stopped for any other reason, for decompressor this happens when the whole file is read.
Run is also now responsible for cleanups and we don't have to use any locks or check for nil channels. This is all done as an attempt to simplify the logic a bit.

#### Which issue(s) this PR fixes

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
