### PR TITLE
Update prometheus-metrics.md

### DIFF
--- a/docs/sources/collect/prometheus-metrics.md
+++ b/docs/sources/collect/prometheus-metrics.md
@@ -76,7 +76,7 @@ The following example demonstrates configuring `prometheus.remote_write` with mu
 ```alloy
 prometheus.remote_write "default" {
   endpoint {
-    url = "http://localhost:9090/api/prom/push"
+    url = "http://localhost:9009/api/prom/push"
   }
 
   endpoint {
@@ -221,7 +221,7 @@ prometheus.scrape "pods" {
 
 prometheus.remote_write "default" {
   endpoint {
-    url = "http://localhost:9090/api/prom/push"
+    url = "http://localhost:9009/api/prom/push"
   }
 }
 ```
@@ -347,7 +347,7 @@ prometheus.scrape "services" {
 
 prometheus.remote_write "default" {
   endpoint {
-    url = "http://localhost:9090/api/prom/push"
+    url = "http://localhost:9009/api/prom/push"
   }
 }
 ```
@@ -416,7 +416,7 @@ prometheus.scrape "custom_targets" {
 
 prometheus.remote_write "default" {
   endpoint {
-    url = "http://localhost:9090/api/prom/push"
+    url = "http://localhost:9009/api/prom/push"
   }
 }
 ```


### PR DESCRIPTION
Found that the endpoint is not available in traditional prometheus, it instead exists in Mimir which is on port 9009 (not 9090)

#### PR Description

When working through the documentation I found that the `/api/prom/push` does not exist on the traditional Prometheus service. Instead it exists on the Mimir one which is on the default port of 9009.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
