### PR TITLE
ci: group go.opentelemetry.io deps together with other otel deps

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -61,7 +61,7 @@
       "matchPackageNames": [
         // OpenTelemetry needs special handling due to a temporary fork
         "github.com/open-telemetry/opentelemetry-collector-contrib/**",
-        "go.opentelemetry.io/collector"
+        "go.opentelemetry.io/collector/**"
       ],
       "groupName": "go otel collector dependencies",
       "dependencyDashboardApproval": true


### PR DESCRIPTION
Group go.opentelemetry.io updates into the same PR group as github.com/open-telemetry/opentelemetry-collector-contrib

This should reduce a lot of the size of the non-open telemetry minor/patch updates.
