### PR TITLE
(chore): bump from GO from 1.24.1 to 1.24.2 - resolving CVE-2025-22871 (Severity: Critical)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/alloy
 
-go 1.24.1
+go 1.24.2
 
 require (
 	cloud.google.com/go/pubsub v1.45.3


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR will bump the GO version of Alloy from `1.24.1` to `1.24.2` to resolve the CRITICAL security [CVE-2025-22871 / GHSA-g9pc-8g42-g6vq](https://github.com/advisories/GHSA-g9pc-8g42-g6vq):

> The net/http package improperly accepts a bare LF as a line terminator in chunked data chunk-size lines. This can permit request smuggling if a net/http server is used in conjunction with a server that incorrectly accepts a bare LF as part of a chunk-ext.

I ran the following commands:
```
go mod edit -go=1.24.2
go mod tidy
```

#### Notes to the Reviewer

This PR is a small subset of existing renovate PR https://github.com/grafana/alloy/pull/3401. This PR involve many, many GO dependencies (and also the general GO bump to 1.24.2)! - Since testing of this PR might be more complex, I'd like to address this CVE as a small PR here! In case this doesn't fit your processes, please feel free to comment and/or close this PR.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
