### PR TITLE
chore: remove unneeded exclude in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1000,9 +1000,6 @@ replace (
 	// grafana fork of the exporter, or completely into upstream
 	github.com/prometheus-community/postgres_exporter => github.com/grafana/postgres_exporter v0.15.1-0.20250312140329-3046b223bba0
 
-	// Needed until a bunch of exporters are updated, because 0.13.0 breaks compatibility in web.ListenAndServe
-	//github.com/prometheus/exporter-toolkit => github.com/prometheus/exporter-toolkit v0.11.0
-
 	// TODO(marctc): remove once this PR is merged upstream: https://github.com/prometheus/mysqld_exporter/pull/774
 	github.com/prometheus/mysqld_exporter => github.com/grafana/mysqld_exporter v0.17.2-0.20250226152553-be612e3fdedd
 

--- a/go.mod
+++ b/go.mod
@@ -824,7 +824,8 @@ require (
 	github.com/stormcat24/protodep v0.1.8 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
-	github.com/tencentcloud/tencentcloud-sdk-go v1.0.162 // indirect
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.480 // indirect
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.0.480 // indirect
 	github.com/tg123/go-htpasswd v1.2.3 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
@@ -1014,9 +1015,6 @@ replace github.com/github/smimesign => github.com/grafana/smimesign v0.2.1-0.202
 
 // Submodules.
 replace github.com/grafana/alloy/syntax => ./syntax
-
-// Required to avoid an ambiguous import with github.com/tencentcloud/tencentcloud-sdk-go
-exclude github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.194
 
 // Add exclude directives so Go doesn't pick old incompatible k8s.io/client-go
 // versions.

--- a/go.sum
+++ b/go.sum
@@ -2582,8 +2582,10 @@ github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtse
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tbrandon/mbserver v0.0.0-20170611213546-993e1772cc62/go.mod h1:qUzPVlSj2UgxJkVbH0ZwuuiR46U8RBMDT5KLY78Ifpw=
 github.com/tedsuo/ifrit v0.0.0-20191009134036-9a97d0632f00/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
-github.com/tencentcloud/tencentcloud-sdk-go v1.0.162 h1:8fDzz4GuVg4skjY2B0nMN7h6uN61EDVkuLyI2+qGHhI=
-github.com/tencentcloud/tencentcloud-sdk-go v1.0.162/go.mod h1:asUz5BPXxgoPGaRgZaVm1iGcUAuHyYUo1nXqKa83cvI=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.480 h1:Dwnfdrk3KXpYRH9Kwrk9sHpZSOmrE7P9LBoNsYUJKR4=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.480/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.0.480 h1:YEDZmv2ABU8QvwXEVTOQgVEQzDOByhz73vdjL6sERkE=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.0.480/go.mod h1:zaBIuDDs+rC74X8Aog+LSu91GFtHYRYDC196RGTm2jk=
 github.com/tent/http-link-go v0.0.0-20130702225549-ac974c61c2f9/go.mod h1:RHkNRtSLfOK7qBTHaeSX1D6BNpI3qw7NTxsmNr4RvN8=
 github.com/testcontainers/testcontainers-go v0.35.0 h1:uADsZpTKFAtp8SLK+hMwSaa+X+JiERHtd4sQAFmXeMo=
 github.com/testcontainers/testcontainers-go v0.35.0/go.mod h1:oEVBj5zrfJTrgjwONs1SsRbnBtH9OKl+IGl3UMcr2B4=


### PR DESCRIPTION
#### PR Description
I was looking through our go mod  and noticed this exclude. I saw that it was added in https://github.com/grafana/agent/pull/1554. It seems like we no longer need this one but instead `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common` and `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm`.


go mod why `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common`
```
# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common
github.com/grafana/alloy/internal/service/cluster/discovery
github.com/hashicorp/go-discover
github.com/hashicorp/go-discover/provider/tencentcloud
github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common
```

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
