### PR TITLE
Add Stringer implementation for OptionalSecret type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ Main (unreleased)
 
 - Fix [#3386](https://github.com/grafana/alloy/issues/3386) lower casing scheme in `prometheus.operator.scrapeconfigs`. (@alex-berger)
 
+- Fix [#1470](https://github.com/grafana/alloy/issues/1470) allow formatting of an OptionalSecret (from `local.file`) as a string. (@stuart-warren)
+
 ### Other changes
 
 - Update the zap logging adapter used by `otelcol` components to log arrays and objects. (@dehaansa)

--- a/syntax/alloytypes/optional_secret.go
+++ b/syntax/alloytypes/optional_secret.go
@@ -82,3 +82,13 @@ func (s OptionalSecret) AlloyTokenize() []builder.Token {
 		Lit: fmt.Sprintf("%q", s.Value),
 	}}
 }
+
+// String returns a string representation of the OptionalSecret. If IsSecret is
+// true, the value will be hidden and replaced with "(secret)". Otherwise,
+// the value will be returned as a string.
+func (s OptionalSecret) String() string {
+	if s.IsSecret {
+		return "(secret)"
+	}
+	return s.Value
+}

--- a/syntax/alloytypes/optional_secret_test.go
+++ b/syntax/alloytypes/optional_secret_test.go
@@ -1,6 +1,7 @@
 package alloytypes_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/grafana/alloy/syntax/alloytypes"
@@ -87,6 +88,25 @@ func TestOptionalSecret_Write(t *testing.T) {
 			be := builder.NewExpr()
 			be.SetValue(tc.value)
 			require.Equal(t, tc.expect, string(be.Bytes()))
+		})
+	}
+}
+
+func TestOptionalSecret_Format(t *testing.T) {
+	tt := []struct {
+		name   string
+		value  interface{}
+		expect string
+	}{
+		{"non-sensitive", alloytypes.OptionalSecret{Value: "foobar"}, `foobar`},
+		{"sensitive", alloytypes.OptionalSecret{IsSecret: true, Value: "foobar"}, `(secret)`},
+		{"non-sensitive pointer", &alloytypes.OptionalSecret{Value: "foobar"}, `foobar`},
+		{"sensitive pointer", &alloytypes.OptionalSecret{IsSecret: true, Value: "foobar"}, `(secret)`},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expect, fmt.Sprintf("%s", tc.value))
 		})
 	}
 }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Add Stringer implementation for OptionalSecret type

Trying to format an OptionalSecret type to a string currently returns `{%!s(bool=false) foobar}` rather than a string

Example config to show issue:
```
local.file "iloip" {
  filename = file.path_join(sys.env("SNAP_DATA"), "config", "iloip.txt")
}

// https://github.com/FlxPeters/redfish_exporter
prometheus.scrape "redfish_exporter" {
  targets = [
    {"__address__" = "localhost:9610",
     "__metrics_path__" = "/redfish",
     "__param_target" = coalesce(local.file.iloip.content,"notfound")},
  ]

}
```

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #1470

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
