### PR TITLE
ci: update backport workflow permissions

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,6 +14,10 @@ permissions:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout Actions
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
synchronizing permissions with ones listed in the upstream workflow we're calling.

NOTE: This "looks" right, but remains untested until it's integrated into main and used.