### PR TITLE
fix(ui): make component graph links follow `--server.http.ui-path-prefix`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ Main (unreleased)
 
 - Fix [#3386](https://github.com/grafana/alloy/issues/3386) lower casing scheme in `prometheus.operator.scrapeconfigs`. (@alex-berger)
 
+- Fix [#3437](https://github.com/grafana/alloy/issues/3437) Component Graph links now follow `--server.http.ui-path-prefix`. (@solidcellaMoon)
+
 ### Other changes
 
 - Update the zap logging adapter used by `otelcol` components to log arrays and objects. (@dehaansa)

--- a/internal/web/ui/src/features/graph/ComponentGraph.tsx
+++ b/internal/web/ui/src/features/graph/ComponentGraph.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Edge, Node, ReactFlow, useEdgesState, useNodesState } from '@xyflow/react';
 
 import { useGraph } from '../../hooks/graph';
@@ -20,6 +21,7 @@ type GraphProps = {
 
 // The graph is not updated on config reload. The page must be reloaded to see the changes.
 const ComponentGraph: React.FC<GraphProps> = ({ components, moduleID, enabled, window }) => {
+  const navigate = useNavigate();
   const [baseNodes, baseEdges] = useMemo(() => buildGraph(components), [components]);
   const [data, setData] = useState<DebugData[]>([]);
   const { error } = useGraph(setData, moduleID, window, enabled);
@@ -64,13 +66,12 @@ const ComponentGraph: React.FC<GraphProps> = ({ components, moduleID, enabled, w
 
   // On click, open the component details page in a new tab.
   const onNodeClick = (_event: React.MouseEvent, node: Node) => {
-    const baseUrl = globalThis.window.location.origin;
     const path =
       node.data.moduleID && node.data.moduleID !== ''
         ? `/component/${node.data.moduleID}/${node.data.localID}`
         : `/component/${node.data.localID}`;
 
-    globalThis.window.open(baseUrl + path, '_blank');
+    navigate(path);
   };
 
   return (

--- a/internal/web/ui/src/features/graph/ComponentGraph.tsx
+++ b/internal/web/ui/src/features/graph/ComponentGraph.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { Edge, Node, ReactFlow, useEdgesState, useNodesState } from '@xyflow/react';
 
+import { usePathPrefix } from '../../contexts/PathPrefixContext';
 import { useGraph } from '../../hooks/graph';
 import { parseID } from '../../utils/id';
 import { ComponentInfo } from '../component/types';
@@ -21,7 +21,7 @@ type GraphProps = {
 
 // The graph is not updated on config reload. The page must be reloaded to see the changes.
 const ComponentGraph: React.FC<GraphProps> = ({ components, moduleID, enabled, window }) => {
-  const navigate = useNavigate();
+  const pathPrefix = usePathPrefix();
   const [baseNodes, baseEdges] = useMemo(() => buildGraph(components), [components]);
   const [data, setData] = useState<DebugData[]>([]);
   const { error } = useGraph(setData, moduleID, window, enabled);
@@ -66,12 +66,13 @@ const ComponentGraph: React.FC<GraphProps> = ({ components, moduleID, enabled, w
 
   // On click, open the component details page in a new tab.
   const onNodeClick = (_event: React.MouseEvent, node: Node) => {
+    const baseUrl = globalThis.window.location.origin + pathPrefix;
     const path =
       node.data.moduleID && node.data.moduleID !== ''
-        ? `/component/${node.data.moduleID}/${node.data.localID}`
-        : `/component/${node.data.localID}`;
+        ? `component/${node.data.moduleID}/${node.data.localID}`
+        : `component/${node.data.localID}`;
 
-    navigate(path);
+    globalThis.window.open(baseUrl + path, '_blank');
   };
 
   return (


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This updates `ComponentGraph.tsx` to insert the correct path prefix in `onNodeClick`.

When Alloy runs with `--server.http.ui-path-prefix` (e.g. `/alloy`), clicking a node in the graph incorrectly opens new-tab to `/component/<id>` instead of `/alloy/component/<id>`, resulting in a 404 error (#3437). Users have to manually add the prefix in the address bar to reach the page—an unnecessary extra step.

With this change, clicking a node in the graph opens new-tab to `/<prefix>/component/<id>` when a prefix is set, or `/component/<id>` when no prefix is configured.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #3437 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
