### PR TITLE
ci: persist git credentials to push tags

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -95,7 +95,7 @@ jobs:
           fetch-depth: 0
           path: source
           token: ${{ steps.app-token.outputs.token }}
-          persist-credentials: false
+          persist-credentials: true # Needed for `git push origin tag_name`
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
to resolve this issue:

```
fatal: could not read Username for 'https://github.com/': No such device or address
```

https://github.com/grafana/alloy/actions/runs/14891027235/job/41822886344