### PR TITLE
Improve string format doc

### DIFF
--- a/docs/sources/reference/stdlib/string.md
+++ b/docs/sources/reference/stdlib/string.md
@@ -74,8 +74,8 @@ The specification may contain the following verbs.
 | `%s` | Convert to string and insert the string's characters.                                     |
 | `%q` | Convert to string and produce a JSON quoted string representation.                        |
 
-When using the `string.format` function with a [`secret`] value, you must first convert it to a non-sensitive string using the `convert.nonsensitive` function.
-If the resulting value must be a [`secret`], you can use string concatenation with the `+` operator instead of the `string.format` function.
+When using the `string.format` function with a [`secret`][] value, you must first convert it to a non-sensitive string using the [`convert.nonsensitive`][] function.
+If the resulting value must be a [`secret`][], you can use string concatenation with the `+` operator instead of the `string.format` function.
 
 ## string.join
 
@@ -209,3 +209,4 @@ If the string doesn't start with the prefix, the string is returned unchanged.
 ```
 
 [`secret`]: ../../../get-started/configuration-syntax/expressions/types_and_values/#secrets
+[`convert.nonsensitive`]: ../convert/#nonsensitive

--- a/docs/sources/reference/stdlib/string.md
+++ b/docs/sources/reference/stdlib/string.md
@@ -74,6 +74,9 @@ The specification may contain the following verbs.
 | `%s` | Convert to string and insert the string's characters.                                     |
 | `%q` | Convert to string and produce a JSON quoted string representation.                        |
 
+When using the `string.format` function with a [`secret`] value, you must first convert it to a non-sensitive string using the `convert.nonsensitive` function.
+If the resulting value must be a [`secret`], you can use string concatenation with the `+` operator instead of the `string.format` function.
+
 ## string.join
 
 `string.join` all items in an array into a string, using a character as separator.
@@ -204,3 +207,5 @@ If the string doesn't start with the prefix, the string is returned unchanged.
 > string.trim_space("  hello\n\n")
 "hello"
 ```
+
+[`secret`]: ../../../get-started/configuration-syntax/expressions/types_and_values/#secrets


### PR DESCRIPTION
Some users encountered issues when trying to format secrets. This doc update explains that the secrets can either be converted to string via the convert.nonsensitive function or users can use string concatenation

Related to https://github.com/grafana/alloy/pull/3523