### PR TITLE
fix docker build

### DIFF
--- a/internal/web/ui/package.json
+++ b/internal/web/ui/package.json
@@ -64,5 +64,6 @@
     "not ie <= 11",
     "not op_mini all"
   ],
-  "proxy": "http://localhost:12345"
+  "proxy": "http://localhost:12345",
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
#### PR Description

This does not fix the issue with the version but only the `+dirty` part. When building the ui during docker build we get:
```
#12 0.084 cd ./internal/web/ui && yarn --network-timeout=1200000 && yarn run build
#12 0.512 ! Corepack is about to download https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz
#12 1.083 ! The local project doesn't define a 'packageManager' field. Corepack will now add one referencing yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e.
#12 1.083 ! For more details about this field, consult the documentation at https://nodejs.org/api/packages.html#packagemanager
```

#### Which issue(s) this PR fixes

Part of https://github.com/grafana/alloy/issues/3538

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
