### PR TITLE
fix(pyroscope.scrape): godeltaprof scraping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ Main (unreleased)
 
 - Fix `otelcol.receiver.filelog` documentation's default value for `start_at`. (@petewall)
 
+- Fix `pyroscope.scrape` scraping godeltaprof profiles. (@korniltsev)
+
 - Fix [#3386](https://github.com/grafana/alloy/issues/3386) lower casing scheme in `prometheus.operator.scrapeconfigs`. (@alex-berger)
 
 ### Other changes

--- a/internal/component/pyroscope/scrape/scrape_loop.go
+++ b/internal/component/pyroscope/scrape/scrape_loop.go
@@ -168,11 +168,15 @@ func newScrapeLoop(t *Target, scrapeClient *http.Client, appendable pyroscope.Ap
 		timeout += interval - time.Second
 	}
 
+	appender := appendable.Appender()
+	if !t.godeltaprof {
+		appender = NewDeltaAppender(appender, t.allLabels)
+	}
 	return &scrapeLoop{
 		Target:       t,
 		logger:       logger,
 		scrapeClient: scrapeClient,
-		appender:     NewDeltaAppender(appendable.Appender(), t.allLabels),
+		appender:     appender,
 		interval:     interval,
 		timeout:      timeout,
 	}

--- a/internal/component/pyroscope/scrape/target.go
+++ b/internal/component/pyroscope/scrape/target.go
@@ -55,10 +55,12 @@ type Target struct {
 	lastScrape         time.Time
 	lastScrapeDuration time.Duration
 	health             TargetHealth
+	godeltaprof        bool
 }
 
 // NewTarget creates a reasonably configured target for querying.
 func NewTarget(lbls labels.Labels, params url.Values) *Target {
+	godeltaprof := false
 	var publicLabels labels.Labels
 	// lbls are sorted. Private labels goes before public labels.
 	// find pivot to calculate publicLabels as subslice, with no allocations
@@ -69,10 +71,13 @@ func NewTarget(lbls labels.Labels, params url.Values) *Target {
 				switch l.Value {
 				case pprofGoDeltaProfMemory:
 					lbls[i].Value = pprofMemory
+					godeltaprof = true
 				case pprofGoDeltaProfBlock:
 					lbls[i].Value = pprofBlock
+					godeltaprof = true
 				case pprofGoDeltaProfMutex:
 					lbls[i].Value = pprofMutex
+					godeltaprof = true
 				}
 			}
 			continue
@@ -87,11 +92,12 @@ func NewTarget(lbls labels.Labels, params url.Values) *Target {
 	_, _ = h.Write([]byte(url))
 
 	return &Target{
-		allLabels: lbls,
-		url:       url,
-		hash:      h.Sum64(),
-		params:    params,
-		health:    HealthUnknown,
+		allLabels:   lbls,
+		url:         url,
+		hash:        h.Sum64(),
+		params:      params,
+		health:      HealthUnknown,
+		godeltaprof: godeltaprof,
 	}
 }
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Pyroscope targets hide scraping godeltaprof_ profiles, by replacing the name from `godeltaprof_memory` to `memory`

The problem is that the scrape pool decides to use `deltaAppender` based on the name and now it does not know it's godeltaprof profile and assumes regular memory profile and tries to compute delta second time on the godeltaprof profiles.

In this PR I pass  a flag to never use `deltaAppender` for godeltaprof profiles 


#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
