### PR TITLE
fix incorrect module version ci builds

### DIFF
--- a/.drone/pipelines/publish.jsonnet
+++ b/.drone/pipelines/publish.jsonnet
@@ -17,6 +17,12 @@ local linux_containers_jobs = std.map(function(container) (
       ref: ['refs/tags/v*'],
     },
     steps: [{
+      name: 'Fetch tags',
+      image: build_image.linux,
+	  commands: [
+        'git fetch --tags',
+	  ],
+    }, {
       // We only need to run this once per machine, so it's OK if it fails. It
       // is also likely to fail when run in parallel on the same machine.
       name: 'Configure QEMU',
@@ -71,6 +77,13 @@ linux_containers_jobs + [
     depends_on: job_names(linux_containers_jobs),
     image_pull_secrets: ['dockerconfigjson'],
     steps: [
+      {
+       name: 'Fetch tags',
+       image: build_image.linux,
+	   commands: [
+        'git fetch --tags',
+       ],
+      },
       {
         name: 'Generate GitHub token',
         image: 'us.gcr.io/kubernetes-dev/github-app-secret-writer:latest',

--- a/.github/workflows/publish-alloy-devel.yml
+++ b/.github/workflows/publish-alloy-devel.yml
@@ -36,6 +36,9 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         persist-credentials: false
+      run: |
+        VERSION=$(sed -e '/^#/d' -e '/^$/d' VERSION | tr -d '\n')
+        git tag -m $VERSION $VERSION-devel
 
     - name: Set ownership
       # https://github.com/actions/runner/issues/2033#issuecomment-1204205989
@@ -75,6 +78,9 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         persist-credentials: false
+      run: |
+        VERSION=$(sed -e '/^#/d' -e '/^$/d' VERSION | tr -d '\n')
+        git tag -m $VERSION $VERSION-devel
 
     - name: Set ownership
       # https://github.com/actions/runner/issues/2033#issuecomment-1204205989

--- a/.github/workflows/publish-alloy.yml
+++ b/.github/workflows/publish-alloy.yml
@@ -34,6 +34,7 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         persist-credentials: false
+        fetch-tags: true
 
     - name: Set up Go
       uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0


### PR DESCRIPTION
In go 1.24 there was a change to go build

>The go build command now sets the [main module’s version](https://tip.golang.org/pkg/runtime/debug#BuildInfo.Main) in the compiled binary based on the version control system tag and/or commit. A +dirty suffix will be appended if there are uncommitted changes. Use the -buildvcs=false flag to omit version control information from the binary.

When publishing containers from drone we never fetch tags. So go cannot determine module version from it:

> The default clone configuration does not use the --tags flag. If you would like to fetch tags you should handle this as a step in your pipeline. For example:

And same for checkout action 
```yaml
# Number of commits to fetch. 0 indicates all history for all branches and tags.
# Default: 1
fetch-depth: ''

# Whether to fetch tags, even if fetch-depth > 0.
# Default: false
fetch-tags: ''
```

The other problem we have is when publishing dev builds. This is done from main branch so we don't have any tags for it.
I added a step to create a temporary tag that matches what would be produced before go 1.24

#### PR Description

#### Which issue(s) this PR fixes
Fixes: https://github.com/grafana/alloy/issues/3538

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
