### PR TITLE
database_observability: check digest is not null in query_sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Main (unreleased)
   - `query_sample`: better handling of timer overflows (@fridgepoet)
   - collect metrics on enabled `performance_schema.setup_consumers` (@fridgepoet)
   - `query_sample`: base log entries on calculated timestamp from rows, not now() (@fridgepoet)
+  - `query_sample`: check digest is not null (@cristiangreco)
 
 - Mixin dashboards improvements: added minimum cluster size to Cluster Overview dashboard, fixed units in OpenTelemetry dashboard, fixed slow components evaluation time units in Controller dashboard and updated Prometheus dashboard to correctly aggregate across instances. (@thampiotr)
 


### PR DESCRIPTION
#### PR Description
When looking for query samples in the `events_statements_history` table, check that digest is not null. Additionally, check on digest_text or sql_text depending on the redaction setting.

#### Which issue(s) this PR fixes
n.a.

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
