### PR TITLE
Fix modulecontroller handling in foreach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ Main (unreleased)
 
 - Fix [#3437](https://github.com/grafana/alloy/issues/3437) Component Graph links now follow `--server.http.ui-path-prefix`. (@solidcellaMoon)
 
+- Fix a bug in the `foreach` preventing the UI from showing the components in the template when the block was re-evaluated. (@wildum)
+
 ### Other changes
 
 - Update the zap logging adapter used by `otelcol` components to log arrays and objects. (@dehaansa)

--- a/internal/runtime/internal/controller/node_config_foreach.go
+++ b/internal/runtime/internal/controller/node_config_foreach.go
@@ -196,7 +196,10 @@ func (fn *ForeachConfigNode) evaluate(scope *vm.Scope) error {
 		// a frequent runtime toggle, the overhead of recreating components is acceptable.
 		fn.moduleController = fn.moduleControllerFactory(fn.moduleControllerOpts)
 		fn.customComponents = make(map[string]CustomComponent)
-		fn.runner.ApplyTasks(context.Background(), []*forEachChild{}) // stops all running children
+		err := fn.runner.ApplyTasks(context.Background(), []*forEachChild{}) // stops all running children
+		if err != nil {
+			return fmt.Errorf("error stopping foreach children: %w", err)
+		}
 	}
 	fn.metricsEnabled = args.EnableMetrics
 

--- a/internal/runtime/internal/controller/node_config_foreach_test.go
+++ b/internal/runtime/internal/controller/node_config_foreach_test.go
@@ -287,6 +287,24 @@ func TestCollectionNonArrayValue(t *testing.T) {
 	require.ErrorContains(t, foreachConfigNode.Evaluate(vm.NewScope(make(map[string]interface{}))), `"aaa" should be array, got string`)
 }
 
+func TestModuleControllerUpdate(t *testing.T) {
+	config := `foreach "default" {
+		collection = [1, 2, 3]
+		var = "num"
+		template {
+		}
+	}`
+	foreachConfigNode := NewForeachConfigNode(getBlockFromConfig(t, config), getComponentGlobals(t), nil)
+	require.NoError(t, foreachConfigNode.Evaluate(vm.NewScope(make(map[string]interface{}))))
+	customComponentIds := foreachConfigNode.moduleController.(*ModuleControllerMock).CustomComponents
+	require.ElementsMatch(t, customComponentIds, []string{"foreach_1_1", "foreach_2_1", "foreach_3_1"})
+
+	// Re-evaluate, the module controller should still contain the same custom components
+	require.NoError(t, foreachConfigNode.Evaluate(vm.NewScope(make(map[string]interface{}))))
+	customComponentIds = foreachConfigNode.moduleController.(*ModuleControllerMock).CustomComponents
+	require.ElementsMatch(t, customComponentIds, []string{"foreach_1_1", "foreach_2_1", "foreach_3_1"})
+}
+
 func getBlockFromConfig(t *testing.T, config string) *ast.BlockStmt {
 	file, err := parser.ParseFile("", []byte(config))
 	require.NoError(t, err)

--- a/internal/runtime/testdata/foreach_metrics/foreach_6.txtar
+++ b/internal/runtime/testdata/foreach_metrics/foreach_6.txtar
@@ -1,0 +1,74 @@
+Start with disabled metrics at first and then enable them.
+
+-- main.alloy --
+foreach "testForeach" {
+  collection = [10]
+  var = "num"
+
+  template {
+    testcomponents.pulse "pt" {
+      max = num
+      frequency = "10ms"
+      forward_to = [testcomponents.summation_receiver.sum.receiver]
+    }
+  }
+}
+
+// Similar to testcomponents.summation, but with a "receiver" export
+testcomponents.summation_receiver "sum" {
+}
+
+-- reload_config.alloy --
+foreach "testForeach" {
+  collection = [6, 8, 6]
+  var = "num"
+  enable_metrics = true
+
+  template {
+    testcomponents.pulse "pt" {
+      max = num
+      frequency = "10ms"
+      forward_to = [testcomponents.summation_receiver.sum.receiver]
+    }
+  }
+}
+
+// Similar to testcomponents.summation, but with a "receiver" export
+testcomponents.summation_receiver "sum" {
+}
+
+-- expected_metrics.prom --
+
+# HELP alloy_component_controller_evaluating Tracks if the controller is currently in the middle of a graph evaluation
+# TYPE alloy_component_controller_evaluating gauge
+alloy_component_controller_evaluating{controller_id="",controller_path="/"} 0
+# HELP alloy_component_controller_running_components Total number of running components.
+# TYPE alloy_component_controller_running_components gauge
+alloy_component_controller_running_components{controller_id="",controller_path="/",health_type="healthy"} 2
+# HELP alloy_component_evaluation_queue_size Tracks the number of components waiting to be evaluated in the worker pool
+# TYPE alloy_component_evaluation_queue_size gauge
+alloy_component_evaluation_queue_size{controller_id="",controller_path="/"} 1
+
+-- expected_metrics_after_reload.prom --
+
+# HELP alloy_component_controller_evaluating Tracks if the controller is currently in the middle of a graph evaluation
+# TYPE alloy_component_controller_evaluating gauge
+alloy_component_controller_evaluating{controller_id="",controller_path="/"} 0
+alloy_component_controller_evaluating{controller_id="foreach_6_1",controller_path="/foreach.testForeach"} 0
+alloy_component_controller_evaluating{controller_id="foreach_6_2",controller_path="/foreach.testForeach"} 0
+alloy_component_controller_evaluating{controller_id="foreach_8_1",controller_path="/foreach.testForeach"} 0
+# HELP alloy_component_controller_running_components Total number of running components.
+# TYPE alloy_component_controller_running_components gauge
+alloy_component_controller_running_components{controller_id="",controller_path="/",health_type="healthy"} 2
+alloy_component_controller_running_components{controller_id="foreach_6_1",controller_path="/foreach.testForeach",health_type="healthy"} 1
+alloy_component_controller_running_components{controller_id="foreach_6_2",controller_path="/foreach.testForeach",health_type="healthy"} 1
+alloy_component_controller_running_components{controller_id="foreach_8_1",controller_path="/foreach.testForeach",health_type="healthy"} 1
+# HELP alloy_component_evaluation_queue_size Tracks the number of components waiting to be evaluated in the worker pool
+# TYPE alloy_component_evaluation_queue_size gauge
+alloy_component_evaluation_queue_size{controller_id="",controller_path="/"} 1
+alloy_component_evaluation_queue_size{controller_id="foreach_10_1",controller_path="/foreach.testForeach"} 0
+# HELP pulse_count
+# TYPE pulse_count counter
+pulse_count{component_id="testcomponents.pulse.pt",component_path="/foreach.testForeach/foreach_6_1"} 6
+pulse_count{component_id="testcomponents.pulse.pt",component_path="/foreach.testForeach/foreach_6_2"} 6
+pulse_count{component_id="testcomponents.pulse.pt",component_path="/foreach.testForeach/foreach_8_1"} 8

--- a/internal/runtime/testdata/foreach_metrics/foreach_7.txtar
+++ b/internal/runtime/testdata/foreach_metrics/foreach_7.txtar
@@ -1,0 +1,68 @@
+Start with enabled metrics at first and then disable them.
+
+-- main.alloy --
+foreach "testForeach" {
+  collection = [10]
+  var = "num"
+  enable_metrics = true
+
+  template {
+    testcomponents.pulse "pt" {
+      max = num
+      frequency = "10ms"
+      forward_to = [testcomponents.summation_receiver.sum.receiver]
+    }
+  }
+}
+
+// Similar to testcomponents.summation, but with a "receiver" export
+testcomponents.summation_receiver "sum" {
+}
+
+-- reload_config.alloy --
+foreach "testForeach" {
+  collection = [6, 8, 6]
+  var = "num"
+
+  template {
+    testcomponents.pulse "pt" {
+      max = num
+      frequency = "10ms"
+      forward_to = [testcomponents.summation_receiver.sum.receiver]
+    }
+  }
+}
+
+// Similar to testcomponents.summation, but with a "receiver" export
+testcomponents.summation_receiver "sum" {
+}
+
+-- expected_metrics.prom --
+
+# HELP alloy_component_controller_evaluating Tracks if the controller is currently in the middle of a graph evaluation
+# TYPE alloy_component_controller_evaluating gauge
+alloy_component_controller_evaluating{controller_id="",controller_path="/"} 0
+alloy_component_controller_evaluating{controller_id="foreach_10_1",controller_path="/foreach.testForeach"} 0
+# HELP alloy_component_controller_running_components Total number of running components.
+# TYPE alloy_component_controller_running_components gauge
+alloy_component_controller_running_components{controller_id="",controller_path="/",health_type="healthy"} 2
+alloy_component_controller_running_components{controller_id="foreach_10_1",controller_path="/foreach.testForeach",health_type="healthy"} 1
+# HELP alloy_component_evaluation_queue_size Tracks the number of components waiting to be evaluated in the worker pool
+# TYPE alloy_component_evaluation_queue_size gauge
+alloy_component_evaluation_queue_size{controller_id="",controller_path="/"} 1
+alloy_component_evaluation_queue_size{controller_id="foreach_10_1",controller_path="/foreach.testForeach"} 0
+# HELP pulse_count
+# TYPE pulse_count counter
+pulse_count{component_id="testcomponents.pulse.pt",component_path="/foreach.testForeach/foreach_10_1"} 10
+
+-- expected_metrics_after_reload.prom --
+
+# HELP alloy_component_controller_evaluating Tracks if the controller is currently in the middle of a graph evaluation
+# TYPE alloy_component_controller_evaluating gauge
+alloy_component_controller_evaluating{controller_id="",controller_path="/"} 0
+# HELP alloy_component_controller_running_components Total number of running components.
+# TYPE alloy_component_controller_running_components gauge
+alloy_component_controller_running_components{controller_id="",controller_path="/",health_type="healthy"} 2
+# HELP alloy_component_evaluation_queue_size Tracks the number of components waiting to be evaluated in the worker pool
+# TYPE alloy_component_evaluation_queue_size gauge
+alloy_component_evaluation_queue_size{controller_id="",controller_path="/"} 1


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

The module controller was recreated on every evaluation of the foreach block. The problem is that the foreach custom component children register only once at creation to the current module controller. As a result, the components that were not registered to the latest module controller were not available in the UI.

The fix in this PR is to only recreate the module controller when the enable_metrics param is toggled and when that happens all custom component children are stopped so that they can be recreated by the new module controller. This overhead should be acceptable because this parameter should not be toggled very often.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #3366

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [na] Documentation added
- [x] Tests updated
- [na] Config converters updated
