### PR TITLE
database_observability: extend parsing to handle more redacted values

### DIFF
--- a/internal/component/database_observability/mysql/collector/parser/parser_tidb.go
+++ b/internal/component/database_observability/mysql/collector/parser/parser_tidb.go
@@ -24,11 +24,15 @@ func NewTiDBSqlParser() *TiDBSqlParser {
 func (p *TiDBSqlParser) Parse(sql string) (any, error) {
 	// mysql will redact auth details with <secret> but the tidb parser
 	// will fail to parse it so we replace it with '<secret>'
-	sql = strings.Replace(sql, "IDENTIFIED BY <secret>", "IDENTIFIED BY '<secret>'", 1)
+	sql = strings.ReplaceAll(sql, "IDENTIFIED BY <secret>", "IDENTIFIED BY '<secret>'")
 
 	// tidb parser doesn't support text line IN (...), so we replace it with (?)
-	sql = strings.Replace(sql, "( ... )", "(?)", 1)
-	sql = strings.Replace(sql, "(...)", "(?)", 1)
+	sql = strings.ReplaceAll(sql, "( ... )", "(?)")
+	sql = strings.ReplaceAll(sql, "(...)", "(?)")
+
+	// similar cleanup for functions with redacted values
+	sql = strings.ReplaceAll(sql, ", ... )", ", ?)")
+	sql = strings.ReplaceAll(sql, ", ...)", ", ?)")
 
 	tParser := parser.New()
 	stmtNodes, _, err := tParser.ParseSQL(sql)

--- a/internal/component/database_observability/mysql/collector/parser/parser_tidb_test.go
+++ b/internal/component/database_observability/mysql/collector/parser/parser_tidb_test.go
@@ -145,6 +145,11 @@ func TestParserTiDB_ExtractTableNames(t *testing.T) {
 			sql:    "SELECT TRIM (TRAILING '/' FROM url)",
 			tables: nil,
 		},
+		{
+			name:   "if with redacted values",
+			sql:    "SELECT IF(`some_table`.`url` IS NULL, ?, ...) AS `url` FROM `some_table`",
+			tables: []string{"some_table"},
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
#### PR Description
Run an additional cleanup step to replace redacted values in functions before passing the SQL to the parser.

#### Which issue(s) this PR fixes
n.a.

#### Notes to the Reviewer

#### PR Checklist
- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
