### PR TITLE
ci: update renovate.json5

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,11 +13,6 @@
   "commitMessageAction": "update",
   "commitMessageTopic": "{{manager}} dependency {{depName}}",
 
-  // Tell dependency dashboard to only require PR creation approval for major versions
-  "major": {
-    "dependencyDashboardApproval": true
-  },
-
   // Updates must be published for at least 7 to be considered
   "minimumReleaseAge": "7 days",
 
@@ -37,27 +32,23 @@
   "packageRules": [
     {
       "matchManagers": ["docker-compose"],
-      // "matchUpdateTypes": ["minor", "patch"],
-      // "groupName": "docker-compose dependencies (minor, patch)",
+      // "groupName": "docker-compose dependencies",
       "enabled": false // TODO: remove to enable when ready
     },
     {
       "matchManagers": ["dockerfile"],
-      // "matchUpdateTypes": ["minor", "patch"],
-      // "groupName": "dockerfile dependencies (minor, patch)",
+      // "groupName": "dockerfile dependencies",
       // "pinDigests": true,
       "enabled": false // TODO: remove to enable when ready
     },
     {
       "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "github-actions dependencies (minor, patch)",
-      "pinDigests": true
+      "groupName": "github-actions dependencies",
+      "pinDigests": true,
     },
     {
       "matchManagers": ["gomod"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "go dependencies (minor, patch)",
+      "groupName": "go dependencies"
     },
     {
       // Group and hold some otel-specific go dependencies
@@ -72,26 +63,28 @@
     },
     {
       "matchManagers": ["helm-values"],
-      // "matchUpdateTypes": ["minor", "patch"],
-      // "groupName": "helm-values dependencies (minor, patch)",
+      // "groupName": "helm-values dependencies",
       "enabled": false // TODO: remove to enable when ready
     },
     {
       "matchManagers": ["helmv3"],
-      // "matchUpdateTypes": ["minor", "patch"],
-      // "groupName": "helmv3 dependencies (minor, patch)",
+      // "groupName": "helmv3 dependencies",
       "enabled": false // TODO: remove to enable when ready
     },
     {
       "matchManagers": ["jsonnet-bundler"],
-      // "matchUpdateTypes": ["minor", "patch"],
-      // "groupName": "jsonnet-bundler dependencies (minor, patch)",
+      // "groupName": "jsonnet-bundler dependencies",
       "enabled": false // TODO: remove to enable when ready
     },
     {
       "matchManagers": ["npm"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "npm dependencies (minor, patch)"
+      "groupName": "npm dependencies",
+    },
+    {
+      // Supersede previous rules to require PR creation approval for major versions
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true,
+      "groupName": "{{manager}} dependency {{depName}}"
     }
-  ]
+  ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -84,6 +84,8 @@
       // Supersede previous rules to require PR creation approval for major versions
       "matchUpdateTypes": ["major"],
       "dependencyDashboardApproval": true,
+      // This forces each dep to have a unique group, resulting in each major update
+      // having its own PR.
       "groupName": "{{manager}} dependency {{depName}}"
     }
   ],


### PR DESCRIPTION
Several Go dependencies were getting ignored because they did not fall under the update categories of "minor" and "patch".

I reworked the config to not rely on those as matching criteria while still separating out major version updates.

I noticed this was an issue because one CVE resolution was not being opened as a PR despite having a fix available.