### PR TITLE
docs: Fix Windows install instructions

### DIFF
--- a/docs/sources/set-up/install/windows.md
+++ b/docs/sources/set-up/install/windows.md
@@ -26,7 +26,7 @@ To do a standard graphical install of {{< param "PRODUCT_NAME" >}} on Windows, p
 
 1. Double-click on `alloy-installer-windows-amd64.exe` to install {{< param "PRODUCT_NAME" >}}.
 
-{{< param "PRODUCT_NAME" >}} is installed into the default directory `%PROGRAMFILES64%\GrafanaLabs\Alloy`.
+{{< param "PRODUCT_NAME" >}} is installed into the default directory `%PROGRAMFILES%\GrafanaLabs\Alloy`.
 
 ## Silent install
 
@@ -78,7 +78,7 @@ The `/RUNTIMEPRIORITY` installation option sets this flag, and if Alloy is not r
 
 ## Uninstall
 
-You can uninstall {{< param "PRODUCT_NAME" >}} with Windows Remove Programs or `%PROGRAMFILES64%\GrafanaLabs\Alloy\uninstaller.exe`.
+You can uninstall {{< param "PRODUCT_NAME" >}} with Windows Remove Programs or `%PROGRAMFILES%\GrafanaLabs\Alloy\uninstall.exe`.
 Uninstalling {{< param "PRODUCT_NAME" >}} stops the service and removes it from disk.
 This includes any configuration files in the installation directory.
 

--- a/docs/sources/set-up/install/windows.md
+++ b/docs/sources/set-up/install/windows.md
@@ -78,7 +78,7 @@ The `/RUNTIMEPRIORITY` installation option sets this flag, and if Alloy is not r
 
 ## Uninstall
 
-You can uninstall {{< param "PRODUCT_NAME" >}} with Windows Remove Programs or `%PROGRAMFILES%\GrafanaLabs\Alloy\uninstall.exe`.
+You can uninstall {{< param "PRODUCT_NAME" >}} with Windows Add or Remove Programs or `%PROGRAMFILES%\GrafanaLabs\Alloy\uninstall.exe`.
 Uninstalling {{< param "PRODUCT_NAME" >}} stops the service and removes it from disk.
 This includes any configuration files in the installation directory.
 


### PR DESCRIPTION
#### PR Description

I just installed Alloy v1.8.3 on Windows 11 on an x64 machine, and found two issues in the instructions. 

This PR:

- Fixes incorrect environment variable name;
- Fixes incorrect uninstaller file name;
- Updates text to use "Add or Remove Programs" to match Windows terminology.

#### Which issue(s) this PR fixes

None.

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
