### PR TITLE
feat: listen http server on unix socket

### DIFF
--- a/internal/service/http/http.go
+++ b/internal/service/http/http.go
@@ -178,7 +178,17 @@ func (s *Service) Run(ctx context.Context, host service.Host) error {
 		}
 	}()
 
-	netLis, err := net.Listen("tcp", s.opts.HTTPListenAddr)
+	var netLis net.Listener
+	var err error
+
+	if strings.HasPrefix(s.opts.HTTPListenAddr, "unix:") {
+		listenAddr := strings.TrimPrefix(strings.TrimLeft(s.opts.HTTPListenAddr, "unix:"), "//")
+		level.Error(s.log).Log("msg", listenAddr)
+		netLis, err = net.Listen("unix", listenAddr)
+	} else {
+		netLis, err = net.Listen("tcp", s.opts.HTTPListenAddr)
+	}
+
 	if err != nil {
 		// There is no recovering from failing to listen on the port.
 		level.Error(s.log).Log("msg", fmt.Sprintf("failed to listen on %s", s.opts.HTTPListenAddr), "err", err)

--- a/internal/service/http/http_test.go
+++ b/internal/service/http/http_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/grafana/alloy/internal/component"
@@ -24,7 +27,7 @@ import (
 func TestHTTP(t *testing.T) {
 	ctx := componenttest.TestContext(t)
 
-	env, err := newTestEnvironment(t)
+	env, err := newTestEnvironment(t, "tcp")
 	require.NoError(t, err)
 	require.NoError(t, env.ApplyConfig(`/* empty */`))
 
@@ -69,10 +72,42 @@ func TestHTTP(t *testing.T) {
 	})
 }
 
+func TestUnixSocket(t *testing.T) {
+	ctx := componenttest.TestContext(t)
+
+	env, err := newTestEnvironment(t, "unix")
+	require.NoError(t, err)
+	require.NoError(t, env.ApplyConfig(`/* empty */`))
+
+	go func() {
+		require.NoError(t, env.Run(ctx))
+	}()
+
+	httpc := http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", strings.TrimPrefix(env.ListenAddr(), "unix://"))
+			},
+		},
+	}
+
+	util.Eventually(t, func(t require.TestingT) {
+		resp, err := httpc.Get("http://unix/-/ready")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		buf, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, "Alloy is ready.\n", string(buf))
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+}
+
 func TestTLS(t *testing.T) {
 	ctx := componenttest.TestContext(t)
 
-	env, err := newTestEnvironment(t)
+	env, err := newTestEnvironment(t, "tcp")
 	require.NoError(t, err)
 	require.NoError(t, env.ApplyConfig(`
 		tls {
@@ -107,7 +142,7 @@ func TestTLS(t *testing.T) {
 func Test_Toggle_TLS(t *testing.T) {
 	ctx := componenttest.TestContext(t)
 
-	env, err := newTestEnvironment(t)
+	env, err := newTestEnvironment(t, "tcp")
 	require.NoError(t, err)
 
 	go func() {
@@ -182,7 +217,7 @@ func Test_Toggle_TLS(t *testing.T) {
 func TestAuth(t *testing.T) {
 	ctx := componenttest.TestContext(t)
 
-	env, err := newTestEnvironment(t)
+	env, err := newTestEnvironment(t, "tcp")
 	require.NoError(t, err)
 	require.NoError(t, env.ApplyConfig(`
 		auth {
@@ -218,7 +253,7 @@ func TestAuth(t *testing.T) {
 func Test_Toggle_Auth(t *testing.T) {
 	ctx := componenttest.TestContext(t)
 
-	env, err := newTestEnvironment(t)
+	env, err := newTestEnvironment(t, "tcp")
 	require.NoError(t, err)
 
 	go func() {
@@ -289,7 +324,7 @@ func Test_Toggle_Auth(t *testing.T) {
 func TestUnhealthy(t *testing.T) {
 	ctx := componenttest.TestContext(t)
 
-	env, err := newTestEnvironment(t)
+	env, err := newTestEnvironment(t, "tcp")
 	require.NoError(t, err)
 
 	env.components = []*component.Info{
@@ -336,10 +371,21 @@ type testEnvironment struct {
 	components []*component.Info
 }
 
-func newTestEnvironment(t *testing.T) (*testEnvironment, error) {
-	port, err := freeport.GetFreePort()
-	if err != nil {
-		return nil, err
+func newTestEnvironment(t *testing.T, network string) (*testEnvironment, error) {
+	var listenAddr string
+
+	if network == "unix" {
+		f, err := os.MkdirTemp("", "*")
+		if err != nil {
+			return nil, err
+		}
+		listenAddr = fmt.Sprintf("unix://%s/alloy-test.sock", f)
+	} else {
+		port, err := freeport.GetFreePort()
+		if err != nil {
+			return nil, err
+		}
+		listenAddr = fmt.Sprintf("127.0.0.1:%d", port)
 	}
 
 	svc := New(Options{
@@ -350,14 +396,14 @@ func newTestEnvironment(t *testing.T) (*testEnvironment, error) {
 		ReadyFunc:  func() bool { return true },
 		ReloadFunc: func() error { return nil },
 
-		HTTPListenAddr:   fmt.Sprintf("127.0.0.1:%d", port),
+		HTTPListenAddr:   listenAddr,
 		MemoryListenAddr: "alloy.internal:12345",
 		EnablePProf:      true,
 	})
 
 	return &testEnvironment{
 		svc:  svc,
-		addr: fmt.Sprintf("127.0.0.1:%d", port),
+		addr: listenAddr,
 	}, nil
 }
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Make possible alloy http server to bind unix socket.

#### Which issue(s) this PR fixes

Fixes #1509

#### Notes to the Reviewer

Didnt test clustering, I guess this cannot work, I could check "if unix AND cluster -> error"?

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
