### PR TITLE
faro/receiver - fix/simplify uncontrolled data used in path expression

### DIFF
--- a/internal/component/faro/receiver/sourcemaps.go
+++ b/internal/component/faro/receiver/sourcemaps.go
@@ -46,7 +46,7 @@ type (
 type osFileService struct{}
 
 func (fs osFileService) ValidateFilePath(name string) (string, error) {
-	if strings.Contains(name, "/") || strings.Contains(name, "\\") || strings.Contains(name, "..") {
+	if strings.Contains(name, "\\") || strings.Contains(name, "..") {
 		return "", fmt.Errorf("invalid file name: %s", name)
 	}
 	return name, nil

--- a/internal/component/faro/receiver/sourcemaps_test.go
+++ b/internal/component/faro/receiver/sourcemaps_test.go
@@ -625,10 +625,9 @@ func (cl *mockHTTPClient) Get(url string) (resp *http.Response, err error) {
 }
 
 type mockFileService struct {
-	files       map[string][]byte
-	stats       []string
-	reads       []string
-	validateErr error
+	files map[string][]byte
+	stats []string
+	reads []string
 }
 
 func (s *mockFileService) Stat(name string) (fs.FileInfo, error) {
@@ -650,9 +649,6 @@ func (s *mockFileService) ReadFile(name string) ([]byte, error) {
 }
 
 func (s *mockFileService) ValidateFilePath(name string) (string, error) {
-	if s.validateErr != nil {
-		return "", s.validateErr
-	}
 	return name, nil
 }
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Addresses overly restrictive fix for uncontrolled data paths in faro receiver. 

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->
https://github.com/grafana/alloy/issues/3608

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

