### PR TITLE
feat: validate custom component from declare statements

### DIFF
--- a/internal/validator/component_registry.go
+++ b/internal/validator/component_registry.go
@@ -34,8 +34,8 @@ func (cr *componentRegistry) Get(name string) (component.Registration, error) {
 	return cr.parent.Get(name)
 }
 
-func (cr *componentRegistry) registerCustomComponent(c *ast.BlockStmt) {
+func (cr *componentRegistry) registerCustomComponent(c *ast.BlockStmt, args any) {
 	// FIXME(kalleep): Figure out how to resolve args and exports for declares and how we could
 	// support doing proper checks of modules.
-	cr.custom[c.Label] = component.Registration{Name: c.Label}
+	cr.custom[c.Label] = component.Registration{Name: c.Label, Args: args}
 }

--- a/internal/validator/testdata/default/invalid_declare.diags
+++ b/internal/validator/testdata/default/invalid_declare.diags
@@ -119,3 +119,20 @@ Error: main.alloy:69:1: cannot find the definition of component name "module_2"
 69 | module_2 "test" {}
    | ^^^^^^^^
 70 | 
+
+Error: main.alloy:78:2: unrecognized attribute name "test"
+
+77 | module_3 "test" {
+78 |     test = "test"
+   |     ^^^^^^^^^^^^^
+79 | }
+
+Error: main.alloy:77:1: missing required attribute "arg"
+
+76 |   
+77 |   module_3 "test" {
+   |  _^^^^^^^^^^^^^^^^^
+78 | |     test = "test"
+79 | | }
+   | |_^
+80 |   

--- a/internal/validator/testdata/default/invalid_declare.txtar
+++ b/internal/validator/testdata/default/invalid_declare.txtar
@@ -69,3 +69,13 @@ declare "module_1" {
 
 // inner module
 module_2 "test" {}
+
+declare "module_3" {
+	argument "arg" {
+		optional = false
+	}
+}
+
+module_3 "test" {
+	test = "test"
+}

--- a/internal/validator/testdata/default/valid.txtar
+++ b/internal/validator/testdata/default/valid.txtar
@@ -65,7 +65,9 @@ declare "self_collect" {
 	}
 }
 
-self_collect "selfmonitor" { }
+self_collect "selfmonitor" {
+	metrics_output = "test"
+}
 
 import.file "math" {
 	filename = "module.alloy"

--- a/internal/validator/testdata/default/valid.txtar
+++ b/internal/validator/testdata/default/valid.txtar
@@ -55,6 +55,10 @@ declare "self_collect" {
 		optional = false
 		comment  = "Where to send collected metrics."
 	}
+	
+	argument "optional" {
+		optional = true
+	}
 
 	prometheus.scrape "selfmonitor" {
 		targets = [{

--- a/internal/validator/validate.go
+++ b/internal/validator/validate.go
@@ -495,7 +495,7 @@ func generateArgumentsStruct(args []*ast.BlockStmt) any {
 		}
 		mem[a.Label] = struct{}{}
 
-		optional := typecheck.TryUnwrapBlockAttr(a, "optional", syntax.ValueFromBool(true))
+		optional := typecheck.TryUnwrapBlockAttr(a, "optional", syntax.ValueFromBool(false))
 
 		var tag string
 		if optional.Bool() {

--- a/syntax/internal/transform/value.go
+++ b/syntax/internal/transform/value.go
@@ -1,4 +1,4 @@
-package vm
+package transform
 
 import (
 	"fmt"
@@ -8,7 +8,7 @@ import (
 	"github.com/grafana/alloy/syntax/token"
 )
 
-func valueFromLiteral(lit string, tok token.Token) (value.Value, error) {
+func ValueFromLiteral(lit string, tok token.Token) (value.Value, error) {
 	// NOTE(rfratto): this function should never return an error, since the
 	// parser only produces valid tokens; it can only fail if a user hand-builds
 	// an AST with invalid literals.

--- a/syntax/typecheck/typecheck.go
+++ b/syntax/typecheck/typecheck.go
@@ -101,6 +101,7 @@ func block(b *ast.BlockStmt, rv reflect.Value) diag.Diagnostics {
 	return diags
 }
 
+// FIXME(kalleep): currently we ignore block maps
 func checkMapBlock(b *ast.BlockStmt, _ reflect.Value) diag.Diagnostics {
 	var diags diag.Diagnostics
 	if b.Label != "" {

--- a/syntax/typecheck/typecheck.go
+++ b/syntax/typecheck/typecheck.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grafana/alloy/syntax/internal/tagcache"
 )
 
-type state struct {
+type structState struct {
 	tags       *tagcache.TagInfo
 	seenAttrs  map[string]struct{}
 	blockCount map[string]int
@@ -25,75 +25,99 @@ func Block(b *ast.BlockStmt, args any) diag.Diagnostics {
 func block(b *ast.BlockStmt, rv reflect.Value) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	s := state{
-		tags:       tagcache.Get(rv.Type()),
-		seenAttrs:  make(map[string]struct{}),
-		blockCount: make(map[string]int),
-	}
-
-	for _, stmt := range b.Body {
-		switch stmt := stmt.(type) {
-		case *ast.BlockStmt:
-			s.blockCount[stmt.GetBlockName()]++
-		}
-	}
-
-	// FIXME(kallep): When we start to check that correct types are set for properties we most likely need to
-	// consider these interfaces.
-	// - value.Defaulter
-	// - value.Unmarshaler
-	// - value.ConvertibleFromCapsule
-	// - value.ConvertibleIntoCapsule
-	// - encoding.TextUnmarshaler
-	for _, stmt := range b.Body {
-		switch n := stmt.(type) {
-		case *ast.BlockStmt:
-			diags.Merge(checkBlock(&s, n, rv))
-		case *ast.AttributeStmt:
-			diags.Merge(checkAttr(&s, n, rv))
-		default:
-			panic(fmt.Sprintf("syntax/vm: unrecognized node type %T", stmt))
-		}
-	}
-
-	for _, t := range s.tags.Tags {
-		if t.IsOptional() {
-			continue
+	switch rv.Kind() {
+	case reflect.Map:
+		return checkMapBlock(b, rv)
+	case reflect.Interface:
+		var m map[string]any
+		rv := reflect.MakeMap(reflect.TypeOf(m))
+		return checkMapBlock(b, rv)
+	case reflect.Struct:
+		s := structState{
+			tags:       tagcache.Get(rv.Type()),
+			seenAttrs:  make(map[string]struct{}),
+			blockCount: make(map[string]int),
 		}
 
-		name := strings.Join(t.Name, ".")
-		if t.IsAttr() {
-			if _, ok := s.seenAttrs[name]; !ok {
-				diags.Add(diag.Diagnostic{
-					Severity: diag.SeverityLevelError,
-					StartPos: ast.StartPos(b).Position(),
-					EndPos:   ast.EndPos(b).Position(),
-					Message:  fmt.Sprintf("missing required attribute %q", name),
-				})
+		for _, stmt := range b.Body {
+			switch stmt := stmt.(type) {
+			case *ast.BlockStmt:
+				s.blockCount[stmt.GetBlockName()]++
 			}
-			continue
 		}
 
-		if t.IsBlock() {
-			if _, ok := s.blockCount[name]; !ok {
-				diags.Add(diag.Diagnostic{
-					Severity: diag.SeverityLevelError,
-					StartPos: ast.StartPos(b).Position(),
-					EndPos:   ast.EndPos(b).Position(),
-					Message:  fmt.Sprintf("missing required block %q", name),
-				})
+		// FIXME(kallep): When we start to check that correct types are set for properties we most likely need to
+		// consider these interfaces.
+		// - value.Defaulter
+		// - value.Unmarshaler
+		// - value.ConvertibleFromCapsule
+		// - value.ConvertibleIntoCapsule
+		// - encoding.TextUnmarshaler
+		for _, stmt := range b.Body {
+			switch n := stmt.(type) {
+			case *ast.BlockStmt:
+				diags.Merge(checkStructBlock(&s, n, rv))
+			case *ast.AttributeStmt:
+				diags.Merge(checkStructAttr(&s, n, rv))
+			default:
+				panic(fmt.Sprintf("syntax/vm: unrecognized node type %T", stmt))
 			}
-			continue
 		}
+
+		for _, t := range s.tags.Tags {
+			if t.IsOptional() {
+				continue
+			}
+
+			name := strings.Join(t.Name, ".")
+			if t.IsAttr() {
+				if _, ok := s.seenAttrs[name]; !ok {
+					diags.Add(diag.Diagnostic{
+						Severity: diag.SeverityLevelError,
+						StartPos: ast.StartPos(b).Position(),
+						EndPos:   ast.EndPos(b).Position(),
+						Message:  fmt.Sprintf("missing required attribute %q", name),
+					})
+				}
+				continue
+			}
+
+			if t.IsBlock() {
+				if _, ok := s.blockCount[name]; !ok {
+					diags.Add(diag.Diagnostic{
+						Severity: diag.SeverityLevelError,
+						StartPos: ast.StartPos(b).Position(),
+						EndPos:   ast.EndPos(b).Position(),
+						Message:  fmt.Sprintf("missing required block %q", name),
+					})
+				}
+				continue
+			}
+		}
+	default:
+		panic(fmt.Sprintf("syntax/typecheck: can only type check arguments of type struct, map and interface, got %s", rv.Kind()))
 	}
 
 	return diags
 }
 
-func checkBlock(s *state, b *ast.BlockStmt, rv reflect.Value) diag.Diagnostics {
+func checkMapBlock(b *ast.BlockStmt, _ reflect.Value) diag.Diagnostics {
+	var diags diag.Diagnostics
+	if b.Label != "" {
+		diags.Add(diag.Diagnostic{
+			Severity: diag.SeverityLevelError,
+			StartPos: b.NamePos.Position(),
+			EndPos:   b.LCurlyPos.Position(),
+			Message:  fmt.Sprintf("block %q requires empty label", b.GetBlockName()),
+		})
+	}
+	return diags
+}
+
+func checkStructBlock(s *structState, b *ast.BlockStmt, rv reflect.Value) diag.Diagnostics {
 	name := b.GetBlockName()
 	if _, ok := s.tags.EnumLookup[name]; ok {
-		return checkEnum(s, b, rv)
+		return checkStructEnum(s, b, rv)
 	}
 
 	tag, ok := s.tags.TagLookup[name]
@@ -149,7 +173,7 @@ func checkBlock(s *state, b *ast.BlockStmt, rv reflect.Value) diag.Diagnostics {
 	}
 }
 
-func checkEnum(s *state, b *ast.BlockStmt, rv reflect.Value) diag.Diagnostics {
+func checkStructEnum(s *structState, b *ast.BlockStmt, rv reflect.Value) diag.Diagnostics {
 	tf, ok := s.tags.EnumLookup[b.GetBlockName()]
 	if !ok {
 		panic("checkEnum called with a non-enum block")
@@ -167,7 +191,7 @@ func checkEnum(s *state, b *ast.BlockStmt, rv reflect.Value) diag.Diagnostics {
 	return block(b, reflectutil.DeferencePointer(reflectutil.GetOrAlloc(elem, tf.BlockField)))
 }
 
-func checkAttr(s *state, a *ast.AttributeStmt, _ reflect.Value) diag.Diagnostics {
+func checkStructAttr(s *structState, a *ast.AttributeStmt, _ reflect.Value) diag.Diagnostics {
 	tf, ok := s.tags.TagLookup[a.Name.Name]
 	if !ok {
 		return diag.Diagnostics{{

--- a/syntax/typecheck/typecheck_test.go
+++ b/syntax/typecheck/typecheck_test.go
@@ -303,3 +303,23 @@ func TestBlock(t *testing.T) {
 		})
 	}
 }
+
+func TestBlockMap(t *testing.T) {
+	type Args struct {
+		Map map[string]any `alloy:"map,block"`
+	}
+
+	src := []byte(`
+		test "name" {
+			map {
+				a = 1
+				b = "str"
+			}
+		}
+	`)
+
+	file, err := parser.ParseFile("", src)
+	require.NoError(t, err)
+	diag := Block(file.Body[0].(*ast.BlockStmt), &Args{})
+	require.Len(t, diag, 0)
+}

--- a/syntax/typecheck/unwrap.go
+++ b/syntax/typecheck/unwrap.go
@@ -1,0 +1,39 @@
+package typecheck
+
+import (
+	"github.com/grafana/alloy/syntax"
+	"github.com/grafana/alloy/syntax/ast"
+	"github.com/grafana/alloy/syntax/internal/transform"
+)
+
+// TryUnwrapBlockAttr tries to unwrap the attribute value.
+// If the attribute are not found or cannot be unwraped defaultValue it returned.
+// The value returned is guaranteed to be of the same kind as defaultValue.
+func TryUnwrapBlockAttr(b *ast.BlockStmt, name string, defaultValue syntax.Value) syntax.Value {
+	aw := &attrWalker{target: name, value: defaultValue}
+	ast.Walk(aw, b)
+
+	return aw.value
+}
+
+type attrWalker struct {
+	target string
+	value  syntax.Value
+}
+
+func (aw *attrWalker) Visit(node ast.Node) ast.Visitor {
+	switch n := node.(type) {
+	case *ast.AttributeStmt:
+		if n.Name.Name == aw.target {
+			switch expr := n.Value.(type) {
+			case *ast.LiteralExpr:
+				v, err := transform.ValueFromLiteral(expr.Value, expr.Kind)
+				if err == nil && v.Type() == aw.value.Type() {
+					aw.value = v
+				}
+			}
+			return nil
+		}
+	}
+	return aw
+}

--- a/syntax/typecheck/unwrap_test.go
+++ b/syntax/typecheck/unwrap_test.go
@@ -1,0 +1,68 @@
+package typecheck
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/syntax"
+	"github.com/grafana/alloy/syntax/ast"
+	"github.com/grafana/alloy/syntax/internal/value"
+	"github.com/grafana/alloy/syntax/parser"
+)
+
+func TestTryUnwrapBlockAttr(t *testing.T) {
+	type TestCase struct {
+		desc     string
+		attr     string
+		dv       syntax.Value
+		src      []byte
+		expected syntax.Value
+	}
+
+	tests := []TestCase{
+		{
+			desc:     "unwrap value",
+			attr:     "optional",
+			dv:       value.Bool(false),
+			expected: value.Bool(true),
+			src: []byte(`
+				argument "test" {
+					optional = true
+				}
+			`),
+		},
+		{
+			desc:     "fallback to default for wrong type",
+			attr:     "optional",
+			dv:       value.Bool(false),
+			expected: value.Bool(false),
+			src: []byte(`
+				argument "test" {
+					optional = "test"
+				}
+			`),
+		},
+		{
+			desc:     "fallback to default for missing",
+			attr:     "optional",
+			dv:       value.Bool(false),
+			expected: value.Bool(false),
+			src: []byte(`
+				argument "test" {}
+			`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			file, err := parser.ParseFile("", tt.src)
+			require.NoError(t, err)
+			v := TryUnwrapBlockAttr(file.Body[0].(*ast.BlockStmt), tt.attr, tt.dv)
+
+			require.Equal(t, v.Type(), tt.expected.Type())
+			require.Equal(t, v.Reflect(), tt.expected.Reflect())
+		})
+	}
+
+}

--- a/syntax/typecheck/unwrap_test.go
+++ b/syntax/typecheck/unwrap_test.go
@@ -64,5 +64,4 @@ func TestTryUnwrapBlockAttr(t *testing.T) {
 			require.Equal(t, v.Reflect(), tt.expected.Reflect())
 		})
 	}
-
 }

--- a/syntax/types.go
+++ b/syntax/types.go
@@ -101,3 +101,6 @@ type Value = value.Value
 
 // ValueFromString creates a new Value from a given string.
 var ValueFromString = value.String
+
+// ValueFromBool creates a new Value from a given bool.
+var ValueFromBool = value.Bool

--- a/syntax/vm/vm.go
+++ b/syntax/vm/vm.go
@@ -181,7 +181,7 @@ func (vm *Evaluator) evaluateMap(scope *Scope, assoc map[value.Value]ast.Node, n
 				Severity: diag.SeverityLevelError,
 				StartPos: node.NamePos.Position(),
 				EndPos:   node.LCurlyPos.Position(),
-				Message:  fmt.Sprintf("block %q requires non-empty label", strings.Join(node.Name, ".")),
+				Message:  fmt.Sprintf("block %q requires empty label", strings.Join(node.Name, ".")),
 			}
 		}
 		stmts = node.Body

--- a/syntax/vm/vm.go
+++ b/syntax/vm/vm.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/alloy/syntax/internal/stdlib"
 	"github.com/grafana/alloy/syntax/internal/syntaxtags"
 	"github.com/grafana/alloy/syntax/internal/tagcache"
+	"github.com/grafana/alloy/syntax/internal/transform"
 	"github.com/grafana/alloy/syntax/internal/value"
 )
 
@@ -303,8 +304,7 @@ func (vm *Evaluator) evaluateExpr(scope *Scope, assoc map[value.Value]ast.Node, 
 
 	switch expr := expr.(type) {
 	case *ast.LiteralExpr:
-		return valueFromLiteral(expr.Value, expr.Kind)
-
+		return transform.ValueFromLiteral(expr.Value, expr.Kind)
 	case *ast.BinaryExpr:
 		lhs, err := vm.evaluateExpr(scope, assoc, expr.Left)
 		if err != nil {


### PR DESCRIPTION
#### PR Description
In this pr I implemented support for validating custom components that was declared using declare statements.

Like everything else it does not validate the type but just properties. When generating the struct I default optional to `false` to match the default value for that field, it will be used if we cannot find the attribute or if its of the wrong type.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
