### PR TITLE
feat(prometheus.exporter.mongodb): Add fine-grained metric collection…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Main (unreleased)
 
 ### Enhancements
 
+- `prometheus.exporter.mongodb` now offers fine-grained control over collected metrics with new configuration options. (@TeTeHacko)
+
 - Add binary version to constants exposed in configuration file syntatx. (@adlots)
 
 - Update `loki.secretfilter` to include metrics about redactions (@kelnage)

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.mongodb.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.mongodb.md
@@ -33,12 +33,26 @@ prometheus.exporter.mongodb "<LABEL>" {
 ## Arguments
 
 You can use the following arguments with `prometheus.exporter.mongodb`:
-
-| Name                         | Type      | Description                                                                                                                            | Default | Required |
-| ---------------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------- | -------- |
-| `mongodb_uri`                | `secret`  | MongoDB node connection URI.                                                                                                           |         | yes      |
-| `direct_connect`             | `boolean` | Whether or not a direct connect should be made. Direct connections aren't valid if multiple hosts are specified or an SRV URI is used. | false   | no       |
-| `discovering_mode`           | `boolean` | Whether or not to enable autodiscover collections.                                                                                     | false   | no       |
+| Name                             | Type      | Description                                                                                                                            | Default | Required |
+| -------------------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------- | -------- |
+| `mongodb_uri`                    | `secret`  | MongoDB node connection URI.                                                                                                           |         | yes      |
+| `collect_all`                    | `boolean` | Enables all collectors.                                                                                                                | `true`  | no       |
+| `compatible_mode`                | `boolean` | Enables metric names compatible with `mongodb_exporter` <v0.20.0.                                                                      | `true`  | no       |
+| `direct_connect`                 | `boolean` | Whether or not a direct connect should be made. Direct connections aren't valid if multiple hosts are specified or an SRV URI is used. | `false` | no      |
+| `discovering_mode`               | `boolean` | Whether or not to enable autodiscover collections.                                                                                     | `false` | no       |
+| `enable_coll_stats`              | `boolean` | Enables collecting collection statistics.                                                                                              | `false` | no       |
+| `enable_currentop_metrics`       | `boolean` | Enables collecting current operation metrics.                                                                                          | `false` | no       |
+| `enable_db_stats_free_storage`   | `boolean` | Enables collecting free storage statistics from `dbStats`.                                                                             | `false` | no       |
+| `enable_db_stats`                | `boolean` | Enables collecting database statistics.                                                                                                | `false` | no       |
+| `enable_diagnostic_data`         | `boolean` | Enables collecting diagnostic data.                                                                                                    | `false` | no       |
+| `enable_fcv`                     | `boolean` | Enables collecting Feature Compatibility Version (FCV) metrics.                                                                        | `false` | no       |
+| `enable_index_stats`             | `boolean` | Enables collecting index statistics.                                                                                                   | `false` | no       |
+| `enable_pbm_metrics`             | `boolean` | Enables collecting Percona Backup for MongoDB (PBM) metrics.                                                                           | `false` | no       |
+| `enable_profile`                 | `boolean` | Enables collecting profile metrics.                                                                                                    | `false` | no       |
+| `enable_replicaset_config`       | `boolean` | Enables collecting replica set configuration.                                                                                          | `false` | no       |
+| `enable_replicaset_status`       | `boolean` | Enables collecting replica set status.                                                                                                 | `false` | no       |
+| `enable_shards`                  | `boolean` | Enables collecting sharding information.                                                                                               | `false` | no       |
+| `enable_top_metrics`             | `boolean` | Enables collecting top metrics.                                                                                                        | `false` | no       |
 
 MongoDB node connection URI must be in the [`Standard Connection String Format`](https://docs.mongodb.com/manual/reference/connection-string/#std-label-connections-standard-connection-string-format)
 

--- a/internal/component/prometheus/exporter/mongodb/mongodb.go
+++ b/internal/component/prometheus/exporter/mongodb/mongodb.go
@@ -27,15 +27,66 @@ func createExporter(opts component.Options, args component.Arguments, defaultIns
 }
 
 type Arguments struct {
-	URI             alloytypes.Secret `alloy:"mongodb_uri,attr"`
-	DirectConnect   bool              `alloy:"direct_connect,attr,optional"`
-	DiscoveringMode bool              `alloy:"discovering_mode,attr,optional"`
+	URI                      alloytypes.Secret `alloy:"mongodb_uri,attr"`
+	CompatibleMode           bool              `alloy:"compatible_mode,attr,optional"`
+	CollectAll               bool              `alloy:"collect_all,attr,optional"`
+	DirectConnect            bool              `alloy:"direct_connect,attr,optional"`
+	DiscoveringMode          bool              `alloy:"discovering_mode,attr,optional"`
+	EnableDBStats            bool              `alloy:"enable_db_stats,attr,optional"`
+	EnableDBStatsFreeStorage bool              `alloy:"enable_db_stats_free_storage,attr,optional"`
+	EnableDiagnosticData     bool              `alloy:"enable_diagnostic_data,attr,optional"`
+	EnableReplicasetStatus   bool              `alloy:"enable_replicaset_status,attr,optional"`
+	EnableReplicasetConfig   bool              `alloy:"enable_replicaset_config,attr,optional"`
+	EnableCurrentopMetrics   bool              `alloy:"enable_currentop_metrics,attr,optional"`
+	EnableTopMetrics         bool              `alloy:"enable_top_metrics,attr,optional"`
+	EnableIndexStats         bool              `alloy:"enable_index_stats,attr,optional"`
+	EnableCollStats          bool              `alloy:"enable_coll_stats,attr,optional"`
+	EnableProfile            bool              `alloy:"enable_profile,attr,optional"`
+	EnableShards             bool              `alloy:"enable_shards,attr,optional"`
+	EnableFCV                bool              `alloy:"enable_fcv,attr,optional"`
+	EnablePBMMetrics         bool              `alloy:"enable_pbm_metrics,attr,optional"`
 }
 
 func (a *Arguments) Convert() *mongodb_exporter.Config {
 	return &mongodb_exporter.Config{
-		URI:             config_util.Secret(a.URI),
-		DirectConnect:   a.DirectConnect,
-		DiscoveringMode: a.DiscoveringMode,
+		URI:                      config_util.Secret(a.URI),
+		CompatibleMode:           a.CompatibleMode,
+		CollectAll:               a.CollectAll,
+		DirectConnect:            a.DirectConnect,
+		DiscoveringMode:          a.DiscoveringMode,
+		EnableDBStats:            a.EnableDBStats,
+		EnableDBStatsFreeStorage: a.EnableDBStatsFreeStorage,
+		EnableDiagnosticData:     a.EnableDiagnosticData,
+		EnableReplicasetStatus:   a.EnableReplicasetStatus,
+		EnableReplicasetConfig:   a.EnableReplicasetConfig,
+		EnableCurrentopMetrics:   a.EnableCurrentopMetrics,
+		EnableTopMetrics:         a.EnableTopMetrics,
+		EnableIndexStats:         a.EnableIndexStats,
+		EnableCollStats:          a.EnableCollStats,
+		EnableProfile:            a.EnableProfile,
+		EnableShards:             a.EnableShards,
+		EnableFCV:                a.EnableFCV,
+		EnablePBMMetrics:         a.EnablePBMMetrics,
 	}
+}
+
+// SetToDefault sets the default values for the Arguments.
+func (a *Arguments) SetToDefault() {
+	a.DirectConnect = false
+	a.CompatibleMode = true
+	a.CollectAll = true
+	a.DiscoveringMode = false
+	a.EnableDBStats = false
+	a.EnableDBStatsFreeStorage = false
+	a.EnableDiagnosticData = false
+	a.EnableReplicasetStatus = false
+	a.EnableReplicasetConfig = false
+	a.EnableCurrentopMetrics = false
+	a.EnableTopMetrics = false
+	a.EnableIndexStats = false
+	a.EnableCollStats = false
+	a.EnableProfile = false
+	a.EnableShards = false
+	a.EnableFCV = false
+	a.EnablePBMMetrics = false
 }

--- a/internal/component/prometheus/exporter/mongodb/mongodb_test.go
+++ b/internal/component/prometheus/exporter/mongodb/mongodb_test.go
@@ -23,6 +23,8 @@ func TestAlloyUnmarshal(t *testing.T) {
 		URI:             "mongodb://127.0.0.1:27017",
 		DirectConnect:   true,
 		DiscoveringMode: true,
+		CompatibleMode:  true,
+		CollectAll:      true,
 	}
 
 	require.Equal(t, expected, args)
@@ -44,6 +46,8 @@ func TestConvert(t *testing.T) {
 		URI:             "mongodb://127.0.0.1:27017",
 		DirectConnect:   true,
 		DiscoveringMode: true,
+		CompatibleMode:  true,
+		CollectAll:      true,
 	}
 	require.Equal(t, expected, *res)
 }

--- a/internal/converter/internal/staticconvert/internal/build/mongodb_exporter.go
+++ b/internal/converter/internal/staticconvert/internal/build/mongodb_exporter.go
@@ -14,8 +14,23 @@ func (b *ConfigBuilder) appendMongodbExporter(config *mongodb_exporter.Config, i
 
 func toMongodbExporter(config *mongodb_exporter.Config) *mongodb.Arguments {
 	return &mongodb.Arguments{
-		URI:             alloytypes.Secret(config.URI),
-		DirectConnect:   config.DirectConnect,
-		DiscoveringMode: config.DiscoveringMode,
+		URI:                      alloytypes.Secret(config.URI),
+		CompatibleMode:           config.CompatibleMode,
+		CollectAll:               config.CollectAll,
+		DirectConnect:            config.DirectConnect,
+		DiscoveringMode:          config.DiscoveringMode,
+		EnableDBStats:            config.EnableDBStats,
+		EnableDBStatsFreeStorage: config.EnableDBStatsFreeStorage,
+		EnableDiagnosticData:     config.EnableDiagnosticData,
+		EnableReplicasetStatus:   config.EnableReplicasetStatus,
+		EnableReplicasetConfig:   config.EnableReplicasetConfig,
+		EnableCurrentopMetrics:   config.EnableCurrentopMetrics,
+		EnableTopMetrics:         config.EnableTopMetrics,
+		EnableIndexStats:         config.EnableIndexStats,
+		EnableCollStats:          config.EnableCollStats,
+		EnableProfile:            config.EnableProfile,
+		EnableShards:             config.EnableShards,
+		EnableFCV:                config.EnableFCV,
+		EnablePBMMetrics:         config.EnablePBMMetrics,
 	}
 }

--- a/internal/converter/internal/staticconvert/testdata-v2/integrations_v2.alloy
+++ b/internal/converter/internal/staticconvert/testdata-v2/integrations_v2.alloy
@@ -326,8 +326,9 @@ prometheus.scrape "integrations_memcached" {
 }
 
 prometheus.exporter.mongodb "integrations_mongodb_exporter" {
-	mongodb_uri    = "mongodb://mongodb-a:27017"
-	direct_connect = true
+	mongodb_uri      = "mongodb://mongodb-a:27017"
+	direct_connect   = true
+	discovering_mode = true
 }
 
 discovery.relabel "integrations_mongodb" {

--- a/internal/converter/internal/staticconvert/testdata/integrations.alloy
+++ b/internal/converter/internal/staticconvert/testdata/integrations.alloy
@@ -407,8 +407,9 @@ prometheus.scrape "integrations_memcached_exporter" {
 }
 
 prometheus.exporter.mongodb "integrations_mongodb_exporter" {
-	mongodb_uri    = "mongodb://mongodb-a:27017"
-	direct_connect = true
+	mongodb_uri      = "mongodb://mongodb-a:27017"
+	direct_connect   = true
+	discovering_mode = true
 }
 
 discovery.relabel "integrations_mongodb_exporter" {

--- a/internal/static/integrations/mongodb_exporter/mongodb_exporter.go
+++ b/internal/static/integrations/mongodb_exporter/mongodb_exporter.go
@@ -15,15 +15,46 @@ import (
 )
 
 var DefaultConfig = Config{
-	DirectConnect: true,
+	CompatibleMode:           true,
+	CollectAll:               true,
+	DirectConnect:            true,
+	DiscoveringMode:          true,
+	EnableDBStats:            false,
+	EnableDBStatsFreeStorage: false,
+	EnableDiagnosticData:     false,
+	EnableReplicasetStatus:   false,
+	EnableReplicasetConfig:   false,
+	EnableCurrentopMetrics:   false,
+	EnableTopMetrics:         false,
+	EnableIndexStats:         false,
+	EnableCollStats:          false,
+	EnableProfile:            false,
+	EnableShards:             false,
+	EnableFCV:                false,
+	EnablePBMMetrics:         false,
 }
 
 // Config controls mongodb_exporter
 type Config struct {
 	// MongoDB connection URI. example:mongodb://user:pass@127.0.0.1:27017/admin?ssl=true"
-	URI             config_util.Secret `yaml:"mongodb_uri"`
-	DirectConnect   bool               `yaml:"direct_connect,omitempty"`
-	DiscoveringMode bool               `yaml:"discovering_mode,omitempty"`
+	URI                      config_util.Secret `yaml:"mongodb_uri"`
+	CompatibleMode           bool               `yaml:"compatible_mode,omitempty"`
+	CollectAll               bool               `yaml:"collect_all,omitempty"`
+	DirectConnect            bool               `yaml:"direct_connect,omitempty"`
+	DiscoveringMode          bool               `yaml:"discovering_mode,omitempty"`
+	EnableDBStats            bool               `yaml:"enable_db_stats,omitempty"`
+	EnableDBStatsFreeStorage bool               `yaml:"enable_db_stats_free_storage,omitempty"`
+	EnableDiagnosticData     bool               `yaml:"enable_diagnostic_data,omitempty"`
+	EnableReplicasetStatus   bool               `yaml:"enable_replicaset_status,omitempty"`
+	EnableReplicasetConfig   bool               `yaml:"enable_replicaset_config,omitempty"`
+	EnableCurrentopMetrics   bool               `yaml:"enable_currentop_metrics,omitempty"`
+	EnableTopMetrics         bool               `yaml:"enable_top_metrics,omitempty"`
+	EnableIndexStats         bool               `yaml:"enable_index_stats,omitempty"`
+	EnableCollStats          bool               `yaml:"enable_coll_stats,omitempty"`
+	EnableProfile            bool               `yaml:"enable_profile,omitempty"`
+	EnableShards             bool               `yaml:"enable_shards,omitempty"`
+	EnableFCV                bool               `yaml:"enable_fcv,omitempty"`
+	EnablePBMMetrics         bool               `yaml:"enable_pbm_metrics,omitempty"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler for Config
@@ -66,14 +97,23 @@ func New(logger log.Logger, c *Config) (integrations.Integration, error) {
 		Logger:                 logrusLogger,
 		DisableDefaultRegistry: true,
 
-		// NOTE(rfratto): CompatibleMode configures the exporter to use old metric
-		// names from mongodb_exporter <v0.20.0. Many existing dashboards rely on
-		// the old names, so we hard-code it to true now. We may wish to make this
-		// configurable in the future.
-		CompatibleMode:  true,
-		CollectAll:      true,
-		DirectConnect:   c.DirectConnect,
-		DiscoveringMode: c.DiscoveringMode,
+		CompatibleMode:           c.CompatibleMode,
+		CollectAll:               c.CollectAll,
+		DirectConnect:            c.DirectConnect,
+		DiscoveringMode:          c.DiscoveringMode,
+		EnableDBStats:            c.EnableDBStats,
+		EnableDBStatsFreeStorage: c.EnableDBStatsFreeStorage,
+		EnableDiagnosticData:     c.EnableDiagnosticData,
+		EnableReplicasetStatus:   c.EnableReplicasetStatus,
+		EnableReplicasetConfig:   c.EnableReplicasetConfig,
+		EnableCurrentopMetrics:   c.EnableCurrentopMetrics,
+		EnableTopMetrics:         c.EnableTopMetrics,
+		EnableIndexStats:         c.EnableIndexStats,
+		EnableCollStats:          c.EnableCollStats,
+		EnableProfile:            c.EnableProfile,
+		EnableShards:             c.EnableShards,
+		EnableFCV:                c.EnableFCV,
+		EnablePBMMetrics:         c.EnablePBMMetrics,
 	})
 
 	return integrations.NewHandlerIntegration(c.Name(), exp.Handler()), nil


### PR DESCRIPTION
… control

Introduces new boolean flags to `prometheus.exporter.mongodb` for selective metric collection (e.g., db_stats, replicaset_status, coll_stats). This allows users to tailor monitoring and reduce exporter overhead by choosing specific metric sets.

Component flags default to `false` for minimal collection; static integration defaults to `true` for backward compatibility.

#### PR Description

#### Which issue(s) this PR fixes

Fixes #3085

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated
