### PR TITLE
pyroscope.java: Document the executable requirement.

### DIFF
--- a/docs/sources/reference/components/pyroscope/pyroscope.java.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.java.md
@@ -91,6 +91,8 @@ After process profiling startup, the component detects `libc` type and copies ac
 {{< admonition type="note" >}}
 The `asprof` binary runs with root permissions.
 If you change the `tmp_dir` configuration to something other than `/tmp`, then you must ensure that the directory is only writable by root.
+
+The filesystem mounted at `tmp_dir` in the {{< param "PRODUCT_NAME" >}} and target containers, needs to allow execution of files stored there. Typically a mount option called `noexec` would prevent files from being executed.
 {{< /admonition >}}
 
 ### `targets`


### PR DESCRIPTION
As we are copying in libraries that need to be executed by the target process, we cannot support a mount with `noexec` option.

![image](https://github.com/user-attachments/assets/5031aab3-5eb9-42c8-9c09-e6b2df137501)
