### PR TITLE
Fix linux release workflow

### DIFF
--- a/tools/ci/docker-containers
+++ b/tools/ci/docker-containers
@@ -101,13 +101,13 @@ case "$TARGET_CONTAINER" in
     ;;
 
   alloy-devel)
-    docker buildx build $DOCKER_FLAGS         \
-      --platform $BUILD_PLATFORMS             \
-      --build-arg RELEASE_BUILD=1             \
-      --build-arg VERSION="$VERSION"          \
-      -t "$DEVEL_ALLOY_IMAGE:$TAG_VERSION"    \
-      -t "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"     \
-      -f Dockerfile                           \
+    docker buildx build $DOCKER_FLAGS      \
+      --platform $BUILD_PLATFORMS          \
+      --build-arg RELEASE_BUILD=1          \
+      --build-arg VERSION="$VERSION"       \
+      -t "$DEVEL_ALLOY_IMAGE:$TAG_VERSION" \
+      -t "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"  \
+      -f Dockerfile                        \
       .
     ;;
 

--- a/tools/ci/docker-containers
+++ b/tools/ci/docker-containers
@@ -73,6 +73,7 @@ case "$TARGET_CONTAINER" in
       --platform $BUILD_PLATFORMS            \
       --build-arg RELEASE_BUILD=1            \
       --build-arg VERSION="$VERSION"         \
+      --output=type=image                    \
       -t "$RELEASE_ALLOY_IMAGE:$TAG_VERSION" \
       -t "$RELEASE_ALLOY_IMAGE:$BRANCH_TAG"  \
       -f Dockerfile                          \
@@ -94,6 +95,7 @@ case "$TARGET_CONTAINER" in
       --build-arg RELEASE_BUILD=1                         \
       --build-arg VERSION="$VERSION"                      \
       --build-arg GOEXPERIMENT=boringcrypto               \
+      --output=type=image                                 \
       -t "$RELEASE_ALLOY_IMAGE:$TAG_VERSION-boringcrypto" \
       -t "$RELEASE_ALLOY_IMAGE:$BRANCH_TAG"               \
       -f Dockerfile                                       \
@@ -110,6 +112,7 @@ case "$TARGET_CONTAINER" in
       --platform $BUILD_PLATFORMS          \
       --build-arg RELEASE_BUILD=1          \
       --build-arg VERSION="$VERSION"       \
+      --output=type=image                  \
       -t "$DEVEL_ALLOY_IMAGE:$TAG_VERSION" \
       -t "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"  \
       -f Dockerfile                        \
@@ -131,6 +134,7 @@ case "$TARGET_CONTAINER" in
       --build-arg RELEASE_BUILD=1                       \
       --build-arg VERSION="$VERSION"                    \
       --build-arg GOEXPERIMENT=boringcrypto             \
+      --output=type=image                               \
       -t "$DEVEL_ALLOY_IMAGE:$TAG_VERSION-boringcrypto" \
       -t "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"               \
       -f Dockerfile                                     \

--- a/tools/ci/docker-containers
+++ b/tools/ci/docker-containers
@@ -103,8 +103,6 @@ case "$TARGET_CONTAINER" in
     ;;
 
   alloy-devel)
-	echo $PUSH_ALLOY_IMAGE
-
     docker buildx build $DOCKER_FLAGS         \
       --platform $BUILD_PLATFORMS             \
       --build-arg RELEASE_BUILD=1             \

--- a/tools/ci/docker-containers
+++ b/tools/ci/docker-containers
@@ -78,7 +78,6 @@ case "$TARGET_CONTAINER" in
       --platform $BUILD_PLATFORMS            \
       --build-arg RELEASE_BUILD=1            \
       --build-arg VERSION="$VERSION"         \
-      --output=type=image                    \
       -t "$RELEASE_ALLOY_IMAGE:$TAG_VERSION" \
       -t "$RELEASE_ALLOY_IMAGE:$BRANCH_TAG"  \
       -f Dockerfile                          \
@@ -95,7 +94,6 @@ case "$TARGET_CONTAINER" in
       --build-arg RELEASE_BUILD=1                         \
       --build-arg VERSION="$VERSION"                      \
       --build-arg GOEXPERIMENT=boringcrypto               \
-      --output=type=image                                 \
       -t "$RELEASE_ALLOY_IMAGE:$TAG_VERSION-boringcrypto" \
       -t "$RELEASE_ALLOY_IMAGE:$BRANCH_TAG"               \
       -f Dockerfile                                       \
@@ -123,7 +121,6 @@ case "$TARGET_CONTAINER" in
       --build-arg RELEASE_BUILD=1                       \
       --build-arg VERSION="$VERSION"                    \
       --build-arg GOEXPERIMENT=boringcrypto             \
-      --output=type=image                               \
       -t "$DEVEL_ALLOY_IMAGE:$TAG_VERSION-boringcrypto" \
       -t "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"               \
       -f Dockerfile                                     \

--- a/tools/ci/docker-containers
+++ b/tools/ci/docker-containers
@@ -23,6 +23,12 @@ else
   export GITHUB_TAG=""
 fi
 
+# We only set PUSH_IMAGE variable if $PUSH_ALLOY_IMAGE is set to 'true'.
+# All other cases would this variable is unset (missing, set to another value etc).
+if [[ $PUSH_ALLOY_IMAGE == "true"  ]]; then
+	PUSH_IMAGE=true
+fi
+
 export RELEASE_ALLOY_IMAGE=grafana/alloy
 export DEVEL_ALLOY_IMAGE=grafana/alloy-dev
 
@@ -69,7 +75,7 @@ export BUILD_PLATFORMS_BORINGCRYPTO=linux/amd64,linux/arm64
 
 case "$TARGET_CONTAINER" in
   alloy)
-    docker buildx build                      \
+    docker buildx build ${PUSH_IMAGE:+--push}\
       --platform $BUILD_PLATFORMS            \
       --build-arg RELEASE_BUILD=1            \
       --build-arg VERSION="$VERSION"         \
@@ -78,11 +84,6 @@ case "$TARGET_CONTAINER" in
       -t "$RELEASE_ALLOY_IMAGE:$BRANCH_TAG"  \
       -f Dockerfile                          \
       .
-
-    if [[ $PUSH_ALLOY_IMAGE == "true"  ]]; then
-      docker push "$RELEASE_ALLOY_IMAGE:$TAG_VERSION"
-      docker push "$RELEASE_ALLOY_IMAGE:$BRANCH_TAG"
-    fi
     ;;
 
   alloy-boringcrypto)
@@ -90,7 +91,7 @@ case "$TARGET_CONTAINER" in
       BRANCH_TAG=$BORINGCRYPTO_LATEST
     fi
 
-    docker buildx build                                   \
+    docker buildx build ${PUSH_IMAGE:+--push}             \
       --platform $BUILD_PLATFORMS_BORINGCRYPTO            \
       --build-arg RELEASE_BUILD=1                         \
       --build-arg VERSION="$VERSION"                      \
@@ -100,28 +101,19 @@ case "$TARGET_CONTAINER" in
       -t "$RELEASE_ALLOY_IMAGE:$BRANCH_TAG"               \
       -f Dockerfile                                       \
       .
-
-    if [[ $PUSH_ALLOY_IMAGE == "true"  ]]; then
-      docker push "$RELEASE_ALLOY_IMAGE:$TAG_VERSION-boringcrypto"
-      docker push "$RELEASE_ALLOY_IMAGE:$BRANCH_TAG"
-    fi
     ;;
 
   alloy-devel)
-    docker buildx build                    \
-      --platform $BUILD_PLATFORMS          \
-      --build-arg RELEASE_BUILD=1          \
-      --build-arg VERSION="$VERSION"       \
-      --output=type=image                  \
-      -t "$DEVEL_ALLOY_IMAGE:$TAG_VERSION" \
-      -t "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"  \
-      -f Dockerfile                        \
-      .
+	echo $PUSH_ALLOY_IMAGE
 
-    if [[ $PUSH_ALLOY_IMAGE == "true"  ]]; then
-      docker push "$DEVEL_ALLOY_IMAGE:$TAG_VERSION"
-      docker push "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"
-    fi
+    docker buildx build ${PUSH_IMAGE:+--push} \
+      --platform $BUILD_PLATFORMS             \
+      --build-arg RELEASE_BUILD=1             \
+      --build-arg VERSION="$VERSION"          \
+      -t "$DEVEL_ALLOY_IMAGE:$TAG_VERSION"    \
+      -t "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"     \
+      -f Dockerfile                           \
+      .
     ;;
 
   alloy-devel-boringcrypto)
@@ -129,7 +121,7 @@ case "$TARGET_CONTAINER" in
       BRANCH_TAG=$BORINGCRYPTO_LATEST
     fi
 
-    docker buildx build                                 \
+    docker buildx build ${PUSH_IMAGE:+--push}           \
       --platform $BUILD_PLATFORMS_BORINGCRYPTO          \
       --build-arg RELEASE_BUILD=1                       \
       --build-arg VERSION="$VERSION"                    \
@@ -139,11 +131,6 @@ case "$TARGET_CONTAINER" in
       -t "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"               \
       -f Dockerfile                                     \
       .
-
-    if [[ $PUSH_ALLOY_IMAGE == "true"  ]]; then
-      docker push "$DEVEL_ALLOY_IMAGE:$TAG_VERSION-boringcrypto"
-      docker push "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"
-    fi
     ;;
 
   *)

--- a/tools/ci/docker-containers
+++ b/tools/ci/docker-containers
@@ -23,10 +23,9 @@ else
   export GITHUB_TAG=""
 fi
 
-# We only set PUSH_IMAGE variable if $PUSH_ALLOY_IMAGE is set to 'true'.
-# All other cases would this variable is unset (missing, set to another value etc).
+DOCKER_FLAGS=""
 if [[ $PUSH_ALLOY_IMAGE == "true"  ]]; then
-	PUSH_IMAGE=true
+	DOCKER_FLAGS="--push"
 fi
 
 export RELEASE_ALLOY_IMAGE=grafana/alloy
@@ -75,7 +74,7 @@ export BUILD_PLATFORMS_BORINGCRYPTO=linux/amd64,linux/arm64
 
 case "$TARGET_CONTAINER" in
   alloy)
-    docker buildx build ${PUSH_IMAGE:+--push}\
+    docker buildx build $DOCKER_FLAGS        \
       --platform $BUILD_PLATFORMS            \
       --build-arg RELEASE_BUILD=1            \
       --build-arg VERSION="$VERSION"         \
@@ -91,7 +90,7 @@ case "$TARGET_CONTAINER" in
       BRANCH_TAG=$BORINGCRYPTO_LATEST
     fi
 
-    docker buildx build ${PUSH_IMAGE:+--push}             \
+    docker buildx build $DOCKER_FLAGS                     \
       --platform $BUILD_PLATFORMS_BORINGCRYPTO            \
       --build-arg RELEASE_BUILD=1                         \
       --build-arg VERSION="$VERSION"                      \
@@ -106,7 +105,7 @@ case "$TARGET_CONTAINER" in
   alloy-devel)
 	echo $PUSH_ALLOY_IMAGE
 
-    docker buildx build ${PUSH_IMAGE:+--push} \
+    docker buildx build $DOCKER_FLAGS         \
       --platform $BUILD_PLATFORMS             \
       --build-arg RELEASE_BUILD=1             \
       --build-arg VERSION="$VERSION"          \
@@ -121,7 +120,7 @@ case "$TARGET_CONTAINER" in
       BRANCH_TAG=$BORINGCRYPTO_LATEST
     fi
 
-    docker buildx build ${PUSH_IMAGE:+--push}           \
+    docker buildx build $DOCKER_FLAGS                   \
       --platform $BUILD_PLATFORMS_BORINGCRYPTO          \
       --build-arg RELEASE_BUILD=1                       \
       --build-arg VERSION="$VERSION"                    \


### PR DESCRIPTION
#### PR Description
In https://github.com/grafana/alloy/pull/3606 we change to use GHA for releases. We also changed our docker build script for linux to no longer use `--push` and instead push if we have a env set.

~Reading through the documentation I noticed that [--push](https://docs.docker.com/reference/cli/docker/buildx/build/#push) is a shorthand for [--output=type=registry](https://docs.docker.com/reference/cli/docker/buildx/build/#registry). And that one is a shorthand for `--output=type=image,push=true`. The output flag does not have a default value to I am pretty sure that setting [--output=type=image](https://docs.docker.com/reference/cli/docker/buildx/build/#image) should solve the issue.~

This does not work for multi platform images. So instead we conditionally add `---push` flag.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
