### PR TITLE
pyroscope.java: Document the executable requirement. (#3624)

### DIFF
--- a/docs/sources/reference/components/pyroscope/pyroscope.java.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.java.md
@@ -91,6 +91,8 @@ After process profiling startup, the component detects `libc` type and copies ac
 {{< admonition type="note" >}}
 The `asprof` binary runs with root permissions.
 If you change the `tmp_dir` configuration to something other than `/tmp`, then you must ensure that the directory is only writable by root.
+
+The filesystem mounted at `tmp_dir` in the {{< param "PRODUCT_NAME" >}} and target containers, needs to allow execution of files stored there. Typically a mount option called `noexec` would prevent files from being executed.
 {{< /admonition >}}
 
 ### `targets`


### PR DESCRIPTION
As we are copying in libraries that need to be executed by the target process, we cannot support a mount with `noexec` option.

(cherry picked from commit c79a8ce3e0f56ce570fb4509897f678414fea5f6)