### PR TITLE
Clean up the markdown in the Alloy shared topics

### DIFF
--- a/docs/sources/collect/choose-component.md
+++ b/docs/sources/collect/choose-component.md
@@ -6,7 +6,7 @@ menuTitle: Choose a component
 weight: 100
 ---
 
-# Choose a  {{< param "FULL_PRODUCT_NAME" >}} component
+# Choose a  {{% param "FULL_PRODUCT_NAME" %}} component
 
 [Components][components] are the building blocks of {{< param "FULL_PRODUCT_NAME" >}}, and there is a [large number of them][components-ref].
 The components you select and configure depend on the telemetry signals you want to collect.

--- a/docs/sources/shared/reference/components/authorization-block.md
+++ b/docs/sources/shared/reference/components/authorization-block.md
@@ -4,10 +4,10 @@ description: Shared content, authorization block
 headless: true
 ---
 
-Name               | Type     | Description                                | Default | Required
--------------------|----------|--------------------------------------------|---------|---------
-`credentials_file` | `string` | File containing the secret value.          |         | no
-`credentials`      | `secret` | Secret value.                              |         | no
-`type`             | `string` | Authorization type, for example, "Bearer". |         | no
+| Name               | Type     | Description                                | Default | Required |
+| ------------------ | -------- | ------------------------------------------ | ------- | -------- |
+| `credentials_file` | `string` | File containing the secret value.          |         | no       |
+| `credentials`      | `secret` | Secret value.                              |         | no       |
+| `type`             | `string` | Authorization type, for example, "Bearer". |         | no       |
 
 `credential` and `credentials_file` are mutually exclusive, and only one can be provided inside an `authorization` block.

--- a/docs/sources/shared/reference/components/azure-managed_identity-block.md
+++ b/docs/sources/shared/reference/components/azure-managed_identity-block.md
@@ -4,9 +4,9 @@ description: Shared content, managed_identity block
 headless: true
 ---
 
-Name        | Type     | Description                                             | Default | Required
-------------|----------|---------------------------------------------------------|---------|---------
-`client_id` | `string` | Client ID of the managed identity used to authenticate. |         | yes
+| Name        | Type     | Description                                             | Default | Required |
+| ----------- | -------- | ------------------------------------------------------- | ------- | -------- |
+| `client_id` | `string` | Client ID of the managed identity used to authenticate. |         | yes      |
 
 `client_id` should be a valid [UUID][] in one of the supported formats:
 

--- a/docs/sources/shared/reference/components/azure-oauth-block.md
+++ b/docs/sources/shared/reference/components/azure-oauth-block.md
@@ -4,8 +4,8 @@ description: Shared content, oauth block
 headless: true
 ---
 
-Name            | Type     | Description                                                                                     | Default | Required
-----------------|----------|-------------------------------------------------------------------------------------------------|---------|---------
-`client_id`     | `string` | The client ID of the Azure Active Directory application that is being used to authenticate.     |         | yes
-`client_secret` | `secret` | The client secret of the Azure Active Directory application that is being used to authenticate. |         | yes
-`tenant_id`     | `string` | The tenant ID of the Azure Active Directory application that is being used to authenticate.     |         | yes
+| Name            | Type     | Description                                                                                    | Default | Required |
+| --------------- | -------- | ---------------------------------------------------------------------------------------------- | ------- | -------- |
+| `client_id`     | `string` | The client ID of the Azure Active Directory application that's being used to authenticate.     |         | yes      |
+| `client_secret` | `secret` | The client secret of the Azure Active Directory application that's being used to authenticate. |         | yes      |
+| `tenant_id`     | `string` | The tenant ID of the Azure Active Directory application that's being used to authenticate.     |         | yes      |

--- a/docs/sources/shared/reference/components/azuread-block.md
+++ b/docs/sources/shared/reference/components/azuread-block.md
@@ -4,9 +4,9 @@ description: Shared content, azuread block
 headless: true
 ---
 
-Name    | Type     | Description      | Default         | Required
---------|----------|------------------|-----------------|---------
-`cloud` | `string` | The Azure Cloud. | `"AzurePublic"` | no
+| Name    | Type     | Description      | Default         | Required |
+| ------- | -------- | ---------------- | --------------- | -------- |
+| `cloud` | `string` | The Azure Cloud. | `"AzurePublic"` | no       |
 
 The supported values for `cloud` are:
 

--- a/docs/sources/shared/reference/components/azuread-sdk.md
+++ b/docs/sources/shared/reference/components/azuread-sdk.md
@@ -6,8 +6,8 @@ headless: true
 
 This block configures [Azure SDK authentication][sdk-auth].
 
-Name        | Type     | Description                                                                                 | Default | Required
-------------|----------|---------------------------------------------------------------------------------------------|---------|---------
-`tenant_id` | `string` | The tenant ID of the Azure Active Directory application that is being used to authenticate. |         | yes
+| Name        | Type     | Description                                                                                | Default | Required |
+| ----------- | -------- | ------------------------------------------------------------------------------------------ | ------- | -------- |
+| `tenant_id` | `string` | The tenant ID of the Azure Active Directory application that's being used to authenticate. |         | yes      |
 
 [sdk-auth]: https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication

--- a/docs/sources/shared/reference/components/basic-auth-block.md
+++ b/docs/sources/shared/reference/components/basic-auth-block.md
@@ -4,10 +4,10 @@ description: Shared content, basic auth block
 headless: true
 ---
 
-Name            | Type     | Description                              | Default | Required
-----------------|----------|------------------------------------------|---------|---------
-`password_file` | `string` | File containing the basic auth password. |         | no
-`password`      | `secret` | Basic auth password.                     |         | no
-`username`      | `string` | Basic auth username.                     |         | no
+| Name            | Type     | Description                              | Default | Required |
+| --------------- | -------- | ---------------------------------------- | ------- | -------- |
+| `password_file` | `string` | File containing the basic auth password. |         | no       |
+| `password`      | `secret` | Basic auth password.                     |         | no       |
+| `username`      | `string` | Basic auth username.                     |         | no       |
 
 `password` and `password_file` are mutually exclusive, and only one can be provided inside a `basic_auth` block.

--- a/docs/sources/shared/reference/components/exporter-component-exports.md
+++ b/docs/sources/shared/reference/components/exporter-component-exports.md
@@ -6,9 +6,9 @@ headless: true
 
 The following fields are exported and can be referenced by other components.
 
-Name      | Type                | Description
-----------|---------------------|----------------------------------------------------------
-`targets` | `list(map(string))` | The targets that can be used to collect exporter metrics.
+| Name      | Type                | Description                                               |
+| --------- | ------------------- | --------------------------------------------------------- |
+| `targets` | `list(map(string))` | The targets that can be used to collect exporter metrics. |
 
 For example, the `targets` can either be passed to a `discovery.relabel` component to rewrite the targets' label sets or to a `prometheus.scrape` component that collects the exposed metrics.
 

--- a/docs/sources/shared/reference/components/extract-field-block.md
+++ b/docs/sources/shared/reference/components/extract-field-block.md
@@ -6,12 +6,12 @@ headless: true
 
 The following attributes are supported:
 
-Name        | Type     | Description                                                                                   | Default | Required
-------------|----------|-----------------------------------------------------------------------------------------------|---------|---------
-`from`      | `string` | The source of the labels or annotations. Allowed values are `pod`, `namespace`, and `node`.    | `pod`   | no
-`key_regex` | `string` | A regular expression used to extract a key that matches the regular expression.               | `""`    | no
-`key`       | `string` | The annotation or label name. This key must exactly match an annotation or label name.        | `""`    | no
-`tag_name`  | `string` | The name of the resource attribute added to logs, metrics, or spans.                          | `""`    | no
+| Name        | Type     | Description                                                                                 | Default | Required |
+| ----------- | -------- | ------------------------------------------------------------------------------------------- | ------- | -------- |
+| `from`      | `string` | The source of the labels or annotations. Allowed values are `pod`, `namespace`, and `node`. | `pod`   | no       |
+| `key_regex` | `string` | A regular expression used to extract a key that matches the regular expression.             | `""`    | no       |
+| `key`       | `string` | The annotation or label name. This key must exactly match an annotation or label name.      | `""`    | no       |
+| `tag_name`  | `string` | The name of the resource attribute added to logs, metrics, or spans.                        | `""`    | no       |
 
 When you don't specify the `tag_name`, a default tag name is used with the format:
 

--- a/docs/sources/shared/reference/components/field-filter-block.md
+++ b/docs/sources/shared/reference/components/field-filter-block.md
@@ -6,13 +6,13 @@ headless: true
 
 The following attributes are supported:
 
-Name    | Type     | Description                                                   | Default  | Required
---------|----------|---------------------------------------------------------------|----------|---------
-`key`   | `string` | The key or name of the field or labels that a filter can use. |          | yes
-`value` | `string` | The value associated with the key that a filter can use.      |          | yes
-`op`    | `string` | The filter operation to apply on the given key: value pair.   | `equals` | no
+| Name    | Type     | Description                                                   | Default  | Required |
+| ------- | -------- | ------------------------------------------------------------- | -------- | -------- |
+| `key`   | `string` | The key or name of the field or labels that a filter can use. |          | yes      |
+| `value` | `string` | The value associated with the key that a filter can use.      |          | yes      |
+| `op`    | `string` | The filter operation to apply on the given key: value pair.   | `equals` | no       |
 
-For `op`, the following values are allowed:
+You can use the following values for `op`:
 
 * `equals`: The field value must equal the provided value.
 * `not-equals`: The field value must not be equal to the provided value.

--- a/docs/sources/shared/reference/components/http-client-config-block.md
+++ b/docs/sources/shared/reference/components/http-client-config-block.md
@@ -4,17 +4,17 @@ description: Shared content, http client config block
 headless: true
 ---
 
-Name                     | Type                | Description                                                   | Default | Required
--------------------------|---------------------|---------------------------------------------------------------|---------|---------
-`bearer_token_file`      | `string`            | File containing a bearer token to authenticate with.          |         | no
-`bearer_token`           | `secret`            | Bearer token to authenticate with.                            |         | no
-`enable_http2`           | `bool`              | Whether HTTP2 is supported for requests.                      | `true`  | no
-`follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.  | `true`  | no
-`http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name. | | no
-`proxy_url`              | `string`            | HTTP proxy to send requests through.                          |         | no
-`no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. | | no
-`proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.         | `false` | no
-`proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests. |         | no
+| Name                     | Type                | Description                                                                                      | Default | Required |
+| ------------------------ | ------------------- | ------------------------------------------------------------------------------------------------ | ------- | -------- |
+| `bearer_token_file`      | `string`            | File containing a bearer token to authenticate with.                                             |         | no       |
+| `bearer_token`           | `secret`            | Bearer token to authenticate with.                                                               |         | no       |
+| `enable_http2`           | `bool`              | Whether HTTP2 is supported for requests.                                                         | `true`  | no       |
+| `follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.                                     | `true`  | no       |
+| `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.          |         | no       |
+| `proxy_url`              | `string`            | HTTP proxy to send requests through.                                                             |         | no       |
+| `no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. |         | no       |
+| `proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.                                            | `false` | no       |
+| `proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests.                                    |         | no       |
 
 `bearer_token`, `bearer_token_file`, `basic_auth`, `authorization`, and `oauth2` are mutually exclusive, and only one can be provided inside of a `http_client_config` block.
 

--- a/docs/sources/shared/reference/components/local-file-arguments-text.md
+++ b/docs/sources/shared/reference/components/local-file-arguments-text.md
@@ -8,7 +8,7 @@ headless: true
 
 File change detectors detect when the file needs to be re-read from disk. `local.file` supports two detectors: `fsnotify` and `poll`.
 
-#### fsnotify
+#### `fsnotify`
 
 The `fsnotify` detector subscribes to filesystem events, which indicate when the watched file is updated.
 This detector requires a filesystem that supports events at the operating system level. Network-based filesystems like NFS or FUSE won't work.
@@ -21,6 +21,6 @@ This re-read happens for any filesystem event related to the file, including a p
 `fsnotify` stops receiving filesystem events if the watched file has been deleted, renamed, or moved.
 The subscription is re-established on the next poll once the watched file exists again.
 
-#### poll
+#### `poll`
 
 The `poll` file change detector causes the watched file to be re-read every `poll_frequency`, regardless of whether the file changed.

--- a/docs/sources/shared/reference/components/loki-server-grpc.md
+++ b/docs/sources/shared/reference/components/loki-server-grpc.md
@@ -8,14 +8,14 @@ The `grpc` block configures the gRPC server.
 
 You can use the following arguments to configure the `grpc` block. Any omitted fields take their default values.
 
-Name                            | Type       | Description                                                                                                         | Default      | Required
---------------------------------|------------|---------------------------------------------------------------------------------------------------------------------|--------------|---------
-`conn_limit`                    | `int`      | Maximum number of simultaneous HTTP connections. Defaults to no limit.                                              | `0`          | no
-`listen_address`                | `string`   | Network address on which the server listens for new connections. It defaults to accepting all incoming connections. | `""`         | no
-`listen_port`                   | `int`      | Port number on which the server listens for new connections. Defaults to a random free port.                        | `0`          | no
-`max_connection_age_grace`      | `duration` | An additive period after `max_connection_age` after which the connection is forcibly closed.                        | `"infinity"` | no
-`max_connection_age`            | `duration` | The duration for the maximum time a connection may exist before it's closed.                                        | `"infinity"` | no
-`max_connection_idle`           | `duration` | The duration after which an idle connection is closed.                                                              | `"infinity"` | no
-`server_max_concurrent_streams` | `int`      | Limit on the number of concurrent streams for gRPC calls (0 = unlimited).                                           | `100`        | no
-`server_max_recv_msg_size`      | `int`      | Limit on the size of a gRPC message this server can receive (bytes).                                                | `4MB`        | no
-`server_max_send_msg_size`      | `int`      | Limit on the size of a gRPC message this server can send (bytes).                                                   | `4MB`        | no
+| Name                            | Type       | Description                                                                                                         | Default      | Required |
+| ------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------- | ------------ | -------- |
+| `conn_limit`                    | `int`      | Maximum number of simultaneous HTTP connections. Defaults to no limit.                                              | `0`          | no       |
+| `listen_address`                | `string`   | Network address on which the server listens for new connections. It defaults to accepting all incoming connections. | `""`         | no       |
+| `listen_port`                   | `int`      | Port number on which the server listens for new connections. Defaults to a random free port.                        | `0`          | no       |
+| `max_connection_age_grace`      | `duration` | An additive period after `max_connection_age` after which the connection is forcibly closed.                        | `"infinity"` | no       |
+| `max_connection_age`            | `duration` | The duration for the maximum time a connection may exist before it's closed.                                        | `"infinity"` | no       |
+| `max_connection_idle`           | `duration` | The duration after which an idle connection is closed.                                                              | `"infinity"` | no       |
+| `server_max_concurrent_streams` | `int`      | Limit on the number of concurrent streams for gRPC calls (0 = unlimited).                                           | `100`        | no       |
+| `server_max_recv_msg_size`      | `int`      | Limit on the size of a gRPC message this server can receive (bytes).                                                | `4MB`        | no       |
+| `server_max_send_msg_size`      | `int`      | Limit on the size of a gRPC message this server can send (bytes).                                                   | `4MB`        | no       |

--- a/docs/sources/shared/reference/components/loki-server-http.md
+++ b/docs/sources/shared/reference/components/loki-server-http.md
@@ -8,11 +8,11 @@ The `http` block configures the HTTP server.
 
 You can use the following arguments to configure the `http` block. Any omitted fields take their default values.
 
-Name                   | Type       | Description                                                                                                      | Default  | Required
------------------------|------------|------------------------------------------------------------------------------------------------------------------|----------|---------
-`conn_limit`           | `int`      | Maximum number of simultaneous HTTP connections. Defaults to no limit.                                           | `0`      | no
-`listen_address`       | `string`   | Network address on which the server listens for new connections. Defaults to accepting all incoming connections. | `""`     | no
-`listen_port`          | `int`      | Port number on which the server listens for new connections.                                                     | `8080`   | no
-`server_idle_timeout`  | `duration` | Idle timeout for HTTP server.                                                                                    | `"120s"` | no
-`server_read_timeout`  | `duration` | Read timeout for HTTP server.                                                                                    | `"30s"`  | no
-`server_write_timeout` | `duration` | Write timeout for HTTP server.                                                                                   | `"30s"`  | no
+| Name                   | Type       | Description                                                                                                      | Default  | Required |
+| ---------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------- | -------- | -------- |
+| `conn_limit`           | `int`      | Maximum number of simultaneous HTTP connections. Defaults to no limit.                                           | `0`      | no       |
+| `listen_address`       | `string`   | Network address on which the server listens for new connections. Defaults to accepting all incoming connections. | `""`     | no       |
+| `listen_port`          | `int`      | Port number on which the server listens for new connections.                                                     | `8080`   | no       |
+| `server_idle_timeout`  | `duration` | Idle timeout for HTTP server.                                                                                    | `"120s"` | no       |
+| `server_read_timeout`  | `duration` | Read timeout for HTTP server.                                                                                    | `"30s"`  | no       |
+| `server_write_timeout` | `duration` | Write timeout for HTTP server.                                                                                   | `"30s"`  | no       |

--- a/docs/sources/shared/reference/components/match-properties-block.md
+++ b/docs/sources/shared/reference/components/match-properties-block.md
@@ -6,16 +6,16 @@ headless: true
 
 The following arguments are supported:
 
-Name                 | Type           | Description                                                                    | Default | Required
----------------------|----------------|--------------------------------------------------------------------------------|---------|---------
-`match_type`         | `string`       | Controls how items to match against are interpreted.                           |         | yes
-`log_bodies`         | `list(string)` | A list of strings that the LogRecord's body field must match against.          | `[]`    | no
-`log_severity_texts` | `list(string)` | A list of strings that the LogRecord's severity text field must match against. | `[]`    | no
-`metric_names`       | `list(string)` | A list of strings to match the metric name against.                            | `[]`    | no
-`services`           | `list(string)` | A list of items to match the service name against.                             | `[]`    | no
-`span_kinds`         | `list(string)` | A list of items to match the span kind against.                                | `[]`    | no
-`span_names`         | `list(string)` | A list of items to match the span name against.                                | `[]`    | no
+| Name                 | Type           | Description                                                                    | Default | Required |
+| -------------------- | -------------- | ------------------------------------------------------------------------------ | ------- | -------- |
+| `match_type`         | `string`       | Controls how items to match against are interpreted.                           |         | yes      |
+| `log_bodies`         | `list(string)` | A list of strings that the LogRecord's body field must match against.          | `[]`    | no       |
+| `log_severity_texts` | `list(string)` | A list of strings that the LogRecord's severity text field must match against. | `[]`    | no       |
+| `metric_names`       | `list(string)` | A list of strings to match the metric name against.                            | `[]`    | no       |
+| `services`           | `list(string)` | A list of items to match the service name against.                             | `[]`    | no       |
+| `span_kinds`         | `list(string)` | A list of items to match the span kind against.                                | `[]`    | no       |
+| `span_names`         | `list(string)` | A list of items to match the span name against.                                | `[]`    | no       |
 
-`match_type` is required and must be set to either `"regexp"` or `"strict"`.
+`match_type` is required and you must set it to either `"regexp"` or `"strict"`.
 
 A match occurs if at least one item in the lists matches.

--- a/docs/sources/shared/reference/components/oauth2-block.md
+++ b/docs/sources/shared/reference/components/oauth2-block.md
@@ -4,18 +4,18 @@ description: Shared content, oauth2 block
 headless: true
 ---
 
-Name                     | Type                | Description                                                   | Default | Required
--------------------------|---------------------|---------------------------------------------------------------|---------|---------
-`client_id`              | `string`            | OAuth2 client ID.                                             |         | no
-`client_secret_file`     | `string`            | File containing the OAuth2 client secret.                     |         | no
-`client_secret`          | `secret`            | OAuth2 client secret.                                         |         | no
-`endpoint_params`        | `map(string)`       | Optional parameters to append to the token URL.               |         | no
-`proxy_url`              | `string`            | HTTP proxy to send requests through.                          |         | no
-`no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. | | no
-`proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.         | `false` | no
-`proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests. |         | no
-`scopes`                 | `list(string)`      | List of scopes to authenticate with.                          |         | no
-`token_url`              | `string`            | URL to fetch the token from.                                  |         | no
+| Name                     | Type                | Description                                                                                      | Default | Required |
+| ------------------------ | ------------------- | ------------------------------------------------------------------------------------------------ | ------- | -------- |
+| `client_id`              | `string`            | OAuth2 client ID.                                                                                |         | no       |
+| `client_secret_file`     | `string`            | File containing the OAuth2 client secret.                                                        |         | no       |
+| `client_secret`          | `secret`            | OAuth2 client secret.                                                                            |         | no       |
+| `endpoint_params`        | `map(string)`       | Optional parameters to append to the token URL.                                                  |         | no       |
+| `no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. |         | no       |
+| `proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests.                                    |         | no       |
+| `proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.                                            | `false` | no       |
+| `proxy_url`              | `string`            | HTTP proxy to send requests through.                                                             |         | no       |
+| `scopes`                 | `list(string)`      | List of scopes to authenticate with.                                                             |         | no       |
+| `token_url`              | `string`            | URL to fetch the token from.                                                                     |         | no       |
 
 `client_secret` and `client_secret_file` are mutually exclusive, and only one can be provided inside an `oauth2` block.
 

--- a/docs/sources/shared/reference/components/otelcol-debug-metrics-block.md
+++ b/docs/sources/shared/reference/components/otelcol-debug-metrics-block.md
@@ -8,11 +8,11 @@ The `debug_metrics` block configures the metrics that this component generates t
 
 The following arguments are supported:
 
-Name                               | Type      | Description                                          | Default | Required
------------------------------------|-----------|------------------------------------------------------|---------|---------
-`disable_high_cardinality_metrics` | `boolean` | Whether to disable certain high cardinality metrics. | `true`  | no
+| Name                               | Type      | Description                                          | Default | Required |
+| ---------------------------------- | --------- | ---------------------------------------------------- | ------- | -------- |
+| `disable_high_cardinality_metrics` | `boolean` | Whether to disable certain high cardinality metrics. | `true`  | no       |
 
-`disable_high_cardinality_metrics` is the Grafana Alloy equivalent to the `telemetry.disableHighCardinalityMetrics` feature gate in the OpenTelemetry Collector.
+`disable_high_cardinality_metrics` is the {{< param "PRODUCT_NAME" >}} equivalent to the `telemetry.disableHighCardinalityMetrics` feature gate in the OpenTelemetry Collector.
 It removes attributes that could cause high cardinality metrics.
 For example, attributes with IP addresses and port numbers in metrics about HTTP and gRPC connections are removed.
 

--- a/docs/sources/shared/reference/components/otelcol-filter-attribute-block.md
+++ b/docs/sources/shared/reference/components/otelcol-filter-attribute-block.md
@@ -5,16 +5,16 @@ headless: true
 
 This block specifies an attribute to match against:
 
-* More than one `attribute` block can be defined.
+* You can define more than one `attribute` block.
 * Only `match_type = "strict"` is allowed if `attribute` is specified.
 * All `attribute` blocks must match exactly for a match to occur.
 
 The following arguments are supported:
 
-Name    | Type     | Description                           | Default | Required
---------|----------|---------------------------------------|---------|---------
-`key`   | `string` | The attribute key.                    |         | yes
-`value` | `any`    | The attribute value to match against. |         | no
+| Name    | Type     | Description                           | Default | Required |
+| ------- | -------- | ------------------------------------- | ------- | -------- |
+| `key`   | `string` | The attribute key.                    |         | yes      |
+| `value` | `any`    | The attribute value to match against. |         | no       |
 
-If `value` isn't set, any value will match.
+If `value` isn't set, any value matches.
 The type of `value` could be a number, a string, or a boolean.

--- a/docs/sources/shared/reference/components/otelcol-filter-library-block.md
+++ b/docs/sources/shared/reference/components/otelcol-filter-library-block.md
@@ -10,10 +10,10 @@ This block specifies properties to match the implementation library against:
 
 The following arguments are supported:
 
-Name      | Type     | Description                   | Default | Required
-----------|----------|-------------------------------|---------|---------
-`name`    | `string` | The attribute key.            |         | yes
-`version` | `string` | The version to match against. | null    | no
+| Name      | Type     | Description                   | Default | Required |
+| --------- | -------- | ----------------------------- | ------- | -------- |
+| `name`    | `string` | The attribute key.            |         | yes      |
+| `version` | `string` | The version to match against. | null    | no       |
 
 If `version` is unset, any version matches.
-If `version` is set to an empty string, it only matches a library version, which is also an empty string.
+If you set `version` to an empty string, it only matches a library version, which is also an empty string.

--- a/docs/sources/shared/reference/components/otelcol-filter-log-severity-block.md
+++ b/docs/sources/shared/reference/components/otelcol-filter-log-severity-block.md
@@ -7,41 +7,41 @@ This block defines how to match based on a log record's SeverityNumber field.
 
 The following arguments are supported:
 
-Name              | Type     | Description                                   | Default | Required
-------------------|----------|-----------------------------------------------|---------|---------
-`match_undefined` | `bool`   | Whether logs with "undefined" severity match. |         | yes
-`min`             | `string` | The lowest severity that may be matched.      |         | yes
+| Name              | Type     | Description                                   | Default | Required |
+| ----------------- | -------- | --------------------------------------------- | ------- | -------- |
+| `match_undefined` | `bool`   | Whether logs with "undefined" severity match. |         | yes      |
+| `min`             | `string` | The lowest severity that may be matched.      |         | yes      |
 
 If `match_undefined` is true, entries with undefined severity will match.
 
 The following table lists the severities supported by OTel.
 The value for `min` should be one of the values in the "Log Severity" column.
 
-Log Severity | Severity number
------------- | ---------------
-TRACE        | 1
-TRACE2       | 2
-TRACE3       | 3
-TRACE4       | 4
-DEBUG        | 5
-DEBUG2       | 6
-DEBUG3       | 7
-DEBUG4       | 8
-INFO         | 9
-INFO2        | 10
-INFO3        | 11
-INFO4        | 12
-WARN         | 13
-WARN2        | 14
-WARN3        | 15
-WARN4        | 16
-ERROR        | 17
-ERROR2       | 18
-ERROR3       | 19
-ERROR4       | 20
-FATAL        | 21
-FATAL2       | 22
-FATAL3       | 23
-FATAL4       | 24
+| Log Severity | Severity number |
+| ------------ | --------------- |
+| TRACE        | 1               |
+| TRACE2       | 2               |
+| TRACE3       | 3               |
+| TRACE4       | 4               |
+| DEBUG        | 5               |
+| DEBUG2       | 6               |
+| DEBUG3       | 7               |
+| DEBUG4       | 8               |
+| INFO         | 9               |
+| INFO2        | 10              |
+| INFO3        | 11              |
+| INFO4        | 12              |
+| WARN         | 13              |
+| WARN2        | 14              |
+| WARN3        | 15              |
+| WARN4        | 16              |
+| ERROR        | 17              |
+| ERROR2       | 18              |
+| ERROR3       | 19              |
+| ERROR4       | 20              |
+| FATAL        | 21              |
+| FATAL2       | 22              |
+| FATAL3       | 23              |
+| FATAL4       | 24              |
 
 For example, if the `min` attribute in the `log_severity` block is "INFO", then INFO, WARN, ERROR, and FATAL logs will match.

--- a/docs/sources/shared/reference/components/otelcol-filter-regexp-block.md
+++ b/docs/sources/shared/reference/components/otelcol-filter-regexp-block.md
@@ -8,10 +8,10 @@ It configures a Least Recently Used (LRU) cache.
 
 The following arguments are supported:
 
-Name                    | Type   | Description                                                           | Default | Required
-------------------------|--------|-----------------------------------------------------------------------|---------|---------
-`cache_enabled`         | `bool` | Determines whether match results are LRU cached.                      | `false` | no
-`cache_max_num_entries` | `int`  | The max number of entries of the LRU cache that stores match results. | `0`     | no
+| Name                    | Type   | Description                                                           | Default | Required |
+| ----------------------- | ------ | --------------------------------------------------------------------- | ------- | -------- |
+| `cache_enabled`         | `bool` | Determines whether match results are LRU cached.                      | `false` | no       |
+| `cache_max_num_entries` | `int`  | The max number of entries of the LRU cache that stores match results. | `0`     | no       |
 
 Enabling `cache_enabled` could make subsequent matches faster.
 Cache size is unlimited unless `cache_max_num_entries` is also specified.

--- a/docs/sources/shared/reference/components/otelcol-filter-resource-block.md
+++ b/docs/sources/shared/reference/components/otelcol-filter-resource-block.md
@@ -10,10 +10,10 @@ This block specifies items to match the resources against:
 
 The following arguments are supported:
 
-Name    | Type     | Description                          | Default | Required
---------|----------|--------------------------------------|---------|---------
-`key`   | `string` | The resource key.                    |         | yes
-`value` | `any`    | The resource value to match against. |         | no
+| Name    | Type     | Description                          | Default | Required |
+| ------- | -------- | ------------------------------------ | ------- | -------- |
+| `key`   | `string` | The resource key.                    |         | yes      |
+| `value` | `any`    | The resource value to match against. |         | no       |
 
-If `value` isn't set, any value will match.
+If `value` isn't set, any value matches.
 The type of `value` could be a number, a string, or a boolean.

--- a/docs/sources/shared/reference/components/otelcol-grpc-balancer-name.md
+++ b/docs/sources/shared/reference/components/otelcol-grpc-balancer-name.md
@@ -5,7 +5,7 @@ headless: true
 
 The supported values for `balancer_name` are listed in the gRPC documentation on [Load balancing][]:
 
-* `pick_first`: Tries to connect to the first address. It uses it for all RPCs if it connects, or if it fails, it tries the next address and keeps trying until one connection is successful.
+* `pick_first`: Tries to connect to the first address. It uses the address for all RPCs if it connects, or if it fails, it tries the next address and keeps trying until one connection is successful.
   Because of this, all the RPCs are sent to the same backend.
 * `round_robin`: Connects to all the addresses it sees and sends an RPC to each backend one at a time in order.
   For example, the first RPC is sent to backend-1, the second RPC is sent to backend-2, and the third RPC is sent to backend-1.

--- a/docs/sources/shared/reference/components/otelcol-grpc-balancer-name.md
+++ b/docs/sources/shared/reference/components/otelcol-grpc-balancer-name.md
@@ -5,8 +5,8 @@ headless: true
 
 The supported values for `balancer_name` are listed in the gRPC documentation on [Load balancing][]:
 
-* `pick_first`: Tries to connect to the first address, uses it for all RPCs if it connects, or tries the next address if it fails (and keeps doing that until one connection is successful).
-  Because of this, all the RPCs will be sent to the same backend.
+* `pick_first`: Tries to connect to the first address. It uses it for all RPCs if it connects, or if it fails, it tries the next address and keeps trying until one connection is successful.
+  Because of this, all the RPCs are sent to the same backend.
 * `round_robin`: Connects to all the addresses it sees and sends an RPC to each backend one at a time in order.
   For example, the first RPC is sent to backend-1, the second RPC is sent to backend-2, and the third RPC is sent to backend-1.
 

--- a/docs/sources/shared/reference/components/otelcol-kafka-authentication-kerberos.md
+++ b/docs/sources/shared/reference/components/otelcol-kafka-authentication-kerberos.md
@@ -7,16 +7,16 @@ The `kerberos` block configures Kerberos authentication against the Kafka broker
 
 The following arguments are supported:
 
-Name                       | Type     | Description                                                     | Default | Required
----------------------------|----------|-----------------------------------------------------------------|---------|---------
-`service_name`             | `string` | Kerberos service name.                                          |         | no
-`realm`                    | `string` | Kerberos realm.                                                 |         | no
-`use_keytab`               | `string` | Enables using keytab instead of password.                       |         | no
-`username`                 | `string` | Kerberos username to authenticate as.                           |         | yes
-`password`                 | `secret` | Kerberos password to authenticate with.                         |         | no
-`config_file`              | `string` | Path to Kerberos location, for example, `/etc/krb5.conf`.       |         | no
-`keytab_file`              | `string` | Path to keytab file, for example, `/etc/security/kafka.keytab`. |         | no
-`disable_fast_negotiation` | `bool`   | Disable PA-FX-FAST negotiation.                                 | `false` | no
+| Name                       | Type     | Description                                                     | Default | Required |
+| -------------------------- | -------- | --------------------------------------------------------------- | ------- | -------- |
+| `config_file`              | `string` | Path to Kerberos location, for example, `/etc/krb5.conf`.       |         | no       |
+| `disable_fast_negotiation` | `bool`   | Disable PA-FX-FAST negotiation.                                 | `false` | no       |
+| `keytab_file`              | `string` | Path to keytab file, for example, `/etc/security/kafka.keytab`. |         | no       |
+| `password`                 | `secret` | Kerberos password to authenticate with.                         |         | no       |
+| `realm`                    | `string` | Kerberos realm.                                                 |         | no       |
+| `service_name`             | `string` | Kerberos service name.                                          |         | no       |
+| `use_keytab`               | `string` | Enables using keytab instead of password.                       |         | no       |
+| `username`                 | `string` | Kerberos username to authenticate as.                           |         | yes      |
 
 When `use_keytab` is `false`, the `password` argument is required.
 When `use_keytab` is `true`, the file pointed to by the `keytab_file` argument is used for authentication instead.

--- a/docs/sources/shared/reference/components/otelcol-kafka-authentication-plaintext.md
+++ b/docs/sources/shared/reference/components/otelcol-kafka-authentication-plaintext.md
@@ -7,7 +7,7 @@ The `plaintext` block configures plain text authentication against Kafka brokers
 
 The following arguments are supported:
 
-Name       | Type     | Description                                    | Default | Required
------------|----------|------------------------------------------------|---------|---------
-`username` | `string` | Username to use for plain text authentication. |         | yes
-`password` | `secret` | Password to use for plain text authentication. |         | yes
+| Name       | Type     | Description                                    | Default | Required |
+| ---------- | -------- | ---------------------------------------------- | ------- | -------- |
+| `password` | `secret` | Password to use for plain text authentication. |         | yes      |
+| `username` | `string` | Username to use for plain text authentication. |         | yes      |

--- a/docs/sources/shared/reference/components/otelcol-kafka-authentication-sasl-aws_msk.md
+++ b/docs/sources/shared/reference/components/otelcol-kafka-authentication-sasl-aws_msk.md
@@ -7,7 +7,7 @@ The `aws_msk` block configures extra parameters for SASL authentication when usi
 
 The following arguments are supported:
 
-Name          | Type     | Description                                   | Default | Required
---------------|----------|-----------------------------------------------|---------|---------
-`region`      | `string` | AWS region the MSK cluster is based in.       |         | yes
-`broker_addr` | `string` | MSK address to connect to for authentication. |         | yes
+| Name          | Type     | Description                                   | Default | Required |
+| ------------- | -------- | --------------------------------------------- | ------- | -------- |
+| `broker_addr` | `string` | MSK address to connect to for authentication. |         | yes      |
+| `region`      | `string` | AWS region the MSK cluster is based in.       |         | yes      |

--- a/docs/sources/shared/reference/components/otelcol-kafka-authentication-sasl.md
+++ b/docs/sources/shared/reference/components/otelcol-kafka-authentication-sasl.md
@@ -7,14 +7,14 @@ The `sasl` block configures SASL authentication against Kafka brokers.
 
 The following arguments are supported:
 
-Name        | Type     | Description                                              | Default | Required
-------------|----------|----------------------------------------------------------|---------|---------
-`username`  | `string` | Username to use for SASL authentication.                 |         | yes
-`password`  | `secret` | Password to use for SASL authentication.                 |         | yes
-`mechanism` | `string` | SASL mechanism to use when authenticating.               |         | yes
-`version`   | `number` | Version of the SASL Protocol to use when authenticating. | `0`     | no
+| Name        | Type     | Description                                              | Default | Required |
+| ----------- | -------- | -------------------------------------------------------- | ------- | -------- |
+| `mechanism` | `string` | SASL mechanism to use when authenticating.               |         | yes      |
+| `password`  | `secret` | Password to use for SASL authentication.                 |         | yes      |
+| `username`  | `string` | Username to use for SASL authentication.                 |         | yes      |
+| `version`   | `number` | Version of the SASL Protocol to use when authenticating. | `0`     | no       |
 
-The `mechanism` argument can be set to one of the following strings:
+You can set the `mechanism` argument to one of the following strings:
 
 * `"PLAIN"`
 * `"AWS_MSK_IAM"`

--- a/docs/sources/shared/reference/components/otelcol-kafka-metadata-retry.md
+++ b/docs/sources/shared/reference/components/otelcol-kafka-metadata-retry.md
@@ -7,7 +7,7 @@ The `retry` block configures how to retry retrieving metadata when retrieval fai
 
 The following arguments are supported:
 
-Name          | Type       | Description                                      | Default   | Required
---------------|------------|--------------------------------------------------|-----------|---------
-`max_retries` | `number`   | How many times to reattempt retrieving metadata. | `3`       | no
-`backoff`     | `duration` | Time to wait between retries.                    | `"250ms"` | no
+| Name          | Type       | Description                                      | Default   | Required |
+| ------------- | ---------- | ------------------------------------------------ | --------- | -------- |
+| `backoff`     | `duration` | Time to wait between retries.                    | `"250ms"` | no       |
+| `max_retries` | `number`   | How many times to reattempt retrieving metadata. | `3`       | no       |

--- a/docs/sources/shared/reference/components/otelcol-kafka-metadata.md
+++ b/docs/sources/shared/reference/components/otelcol-kafka-metadata.md
@@ -7,9 +7,9 @@ The `metadata` block configures how to retrieve and store metadata from the Kafk
 
 The following arguments are supported:
 
-Name                 | Type   | Description                                   | Default | Required
----------------------|--------|-----------------------------------------------|---------|---------
-`include_all_topics` | `bool` | When true, maintains metadata for all topics. | `true`  | no
+| Name                 | Type   | Description                                   | Default | Required |
+| -------------------- | ------ | --------------------------------------------- | ------- | -------- |
+| `include_all_topics` | `bool` | When true, maintains metadata for all topics. | `true`  | no       |
 
 If the `include_all_topics` argument is `true`, a full set of metadata for all topics is maintained rather than the minimal set that has been necessary so far.
 Including the full set of metadata is more convenient for users but can consume a substantial amount of memory if you have many topics and partitions.

--- a/docs/sources/shared/reference/components/otelcol-queue-block.md
+++ b/docs/sources/shared/reference/components/otelcol-queue-block.md
@@ -7,7 +7,7 @@ headless: true
 The following arguments are supported:
 
 | Name            | Type                       | Description                                                                                | Default | Required |
-|-----------------|----------------------------|--------------------------------------------------------------------------------------------|---------|----------|
+| --------------- | -------------------------- | ------------------------------------------------------------------------------------------ | ------- | -------- |
 | `blocking`      | `boolean`                  | If `true`, blocks until the queue has room for a new request.                              | `false` | no       |
 | `enabled`       | `boolean`                  | Enables an buffer before sending data to the client.                                       | `true`  | no       |
 | `num_consumers` | `number`                   | Number of readers to send batches written to the queue in parallel.                        | `10`    | no       |
@@ -27,6 +27,6 @@ Larger values of `num_consumers` allow data to be sent more quickly at the expen
 If an `otelcol.storage.*` component is configured and provided in the queue's `storage` argument, the queue uses the
 provided storage extension to provide a persistent queue and the queue is no longer stored in memory.
 Any data persisted will be processed on startup if {{< param "PRODUCT_NAME" >}} is killed or restarted.
-See the [exporterhelper documentation][queue_docs] in the OpenTelemetry Collector repository for more details.
+Refer to the [exporterhelper documentation][queue_docs] in the OpenTelemetry Collector repository for more details.
 
 [queue_docs]: https://github.com/open-telemetry/opentelemetry-collector/blob/<OTEL_VERSION>/exporter/exporterhelper/README.md#persistent-queue

--- a/docs/sources/shared/reference/components/otelcol-retry-block.md
+++ b/docs/sources/shared/reference/components/otelcol-retry-block.md
@@ -6,14 +6,14 @@ headless: true
 
 The following arguments are supported:
 
-Name                   | Type       | Description                                            | Default | Required
------------------------|------------|--------------------------------------------------------|---------|---------
-`enabled`              | `boolean`  | Enables retrying failed requests.                      | `true`  | no
-`initial_interval`     | `duration` | Initial time to wait before retrying a failed request. | `"5s"`  | no
-`max_elapsed_time`     | `duration` | Maximum time to wait before discarding a failed batch. | `"5m"`  | no
-`max_interval`         | `duration` | Maximum time to wait between retries.                  | `"30s"` | no
-`multiplier`           | `number`   | Factor to grow wait time before retrying.              | `1.5`   | no
-`randomization_factor` | `number`   | Factor to randomize wait time before retrying.         | `0.5`   | no
+| Name                   | Type       | Description                                            | Default | Required |
+| ---------------------- | ---------- | ------------------------------------------------------ | ------- | -------- |
+| `enabled`              | `boolean`  | Enables retrying failed requests.                      | `true`  | no       |
+| `initial_interval`     | `duration` | Initial time to wait before retrying a failed request. | `"5s"`  | no       |
+| `max_elapsed_time`     | `duration` | Maximum time to wait before discarding a failed batch. | `"5m"`  | no       |
+| `max_interval`         | `duration` | Maximum time to wait between retries.                  | `"30s"` | no       |
+| `multiplier`           | `number`   | Factor to grow wait time before retrying.              | `1.5`   | no       |
+| `randomization_factor` | `number`   | Factor to randomize wait time before retrying.         | `0.5`   | no       |
 
 When `enabled` is `true`, failed batches are retried after a given interval.
 The `initial_interval` argument specifies how long to wait before the first retry attempt.

--- a/docs/sources/shared/reference/components/otelcol-tls-client-block.md
+++ b/docs/sources/shared/reference/components/otelcol-tls-client-block.md
@@ -6,29 +6,29 @@ headless: true
 
 The following arguments are supported:
 
-Name                           | Type           | Description                                                                                  | Default     | Required
--------------------------------|----------------|----------------------------------------------------------------------------------------------|-------------|---------
-`ca_file`                      | `string`       | Path to the CA file.                                                                         |             | no
-`ca_pem`                       | `string`       | CA PEM-encoded text to validate the server with.                                             |             | no
-`cert_file`                    | `string`       | Path to the TLS certificate.                                                                 |             | no
-`cert_pem`                     | `string`       | Certificate PEM-encoded text for client authentication.                                      |             | no
-`insecure_skip_verify`         | `boolean`      | Ignores insecure server TLS certificates.                                                    |             | no
-`include_system_ca_certs_pool` | `boolean`      | Whether to load the system certificate authorities pool alongside the certificate authority. | `false`     | no
-`insecure`                     | `boolean`      | Disables TLS when connecting to the configured server.                                       |             | no
-`key_file`                     | `string`       | Path to the TLS certificate key.                                                             |             | no
-`key_pem`                      | `secret`       | Key PEM-encoded text for client authentication.                                              |             | no
-`max_version`                  | `string`       | Maximum acceptable TLS version for connections.                                              | `"TLS 1.3"` | no
-`min_version`                  | `string`       | Minimum acceptable TLS version for connections.                                              | `"TLS 1.2"` | no
-`cipher_suites`                | `list(string)` | A list of TLS cipher suites that the TLS transport can use.                                  | `[]`        | no
-`reload_interval`              | `duration`     | The duration after which the certificate is reloaded.                                        | `"0s"`      | no
-`server_name`                  | `string`       | Verifies the hostname of server certificates when set.                                       |             | no
-`curve_preferences`            | `list(string)` | Set of elliptic curves to use in a handshake.                                                | `[]`        | no
+| Name                           | Type           | Description                                                                                  | Default     | Required |
+| ------------------------------ | -------------- | -------------------------------------------------------------------------------------------- | ----------- | -------- |
+| `ca_file`                      | `string`       | Path to the CA file.                                                                         |             | no       |
+| `ca_pem`                       | `string`       | CA PEM-encoded text to validate the server with.                                             |             | no       |
+| `cert_file`                    | `string`       | Path to the TLS certificate.                                                                 |             | no       |
+| `cert_pem`                     | `string`       | Certificate PEM-encoded text for client authentication.                                      |             | no       |
+| `cipher_suites`                | `list(string)` | A list of TLS cipher suites that the TLS transport can use.                                  | `[]`        | no       |
+| `curve_preferences`            | `list(string)` | Set of elliptic curves to use in a handshake.                                                | `[]`        | no       |
+| `include_system_ca_certs_pool` | `boolean`      | Whether to load the system certificate authorities pool alongside the certificate authority. | `false`     | no       |
+| `insecure_skip_verify`         | `boolean`      | Ignores insecure server TLS certificates.                                                    |             | no       |
+| `insecure`                     | `boolean`      | Disables TLS when connecting to the configured server.                                       |             | no       |
+| `key_file`                     | `string`       | Path to the TLS certificate key.                                                             |             | no       |
+| `key_pem`                      | `secret`       | Key PEM-encoded text for client authentication.                                              |             | no       |
+| `max_version`                  | `string`       | Maximum acceptable TLS version for connections.                                              | `"TLS 1.3"` | no       |
+| `min_version`                  | `string`       | Minimum acceptable TLS version for connections.                                              | `"TLS 1.2"` | no       |
+| `reload_interval`              | `duration`     | The duration after which the certificate is reloaded.                                        | `"0s"`      | no       |
+| `server_name`                  | `string`       | Verifies the hostname of server certificates when set.                                       |             | no       |
 
 If the server doesn't support TLS, you must set the `insecure` argument to `true`.
 
 To disable `tls` for connections to the server, set the `insecure` argument to `true`.
 
-If `reload_interval` is set to `"0s"`, the certificate never reloaded.
+If you set `reload_interval` to `"0s"`, the certificate never reloaded.
 
 The following pairs of arguments are mutually exclusive and can't both be set simultaneously:
 
@@ -39,7 +39,7 @@ The following pairs of arguments are mutually exclusive and can't both be set si
 If `cipher_suites` is left blank, a safe default list is used.
 Refer to the [Go TLS documentation][golang-tls] for a list of supported cipher suites.
 
-The `curve_preferences` argument determines the set of elliptic curves to prefer during a handshake in preference order.
+The `curve_preferences` argument determines the set of [elliptic curves][golang-curve] to prefer during a handshake in preference order.
 If not provided, a default list is used.
 The set of elliptic curves available are `X25519`, `P521`, `P256`, and `P384`.
 

--- a/docs/sources/shared/reference/components/otelcol-tls-server-block.md
+++ b/docs/sources/shared/reference/components/otelcol-tls-server-block.md
@@ -6,21 +6,21 @@ headless: true
 
 The following arguments are supported:
 
-Name                           | Type           | Description                                                                                  | Default     | Required
--------------------------------|----------------|----------------------------------------------------------------------------------------------|-------------|---------
-`ca_file`                      | `string`       | Path to the CA file.                                                                         |             | no
-`ca_pem`                       | `string`       | CA PEM-encoded text to validate the server with.                                             |             | no
-`cert_file`                    | `string`       | Path to the TLS certificate.                                                                 |             | no
-`cert_pem`                     | `string`       | Certificate PEM-encoded text for client authentication.                                      |             | no
-`include_system_ca_certs_pool` | `boolean`      | Whether to load the system certificate authorities pool alongside the certificate authority. | `false`     | no
-`key_file`                     | `string`       | Path to the TLS certificate key.                                                             |             | no
-`key_pem`                      | `secret`       | Key PEM-encoded text for client authentication.                                              |             | no
-`max_version`                  | `string`       | Maximum acceptable TLS version for connections.                                              | `"TLS 1.3"` | no
-`min_version`                  | `string`       | Minimum acceptable TLS version for connections.                                              | `"TLS 1.2"` | no
-`cipher_suites`                | `list(string)` | A list of TLS cipher suites that the TLS transport can use.                                  | `[]`        | no
-`reload_interval`              | `duration`     | The duration after which the certificate is reloaded.                                        | `"0s"`      | no
-`client_ca_file`               | `string`       | Path to the TLS cert to use by the server to verify a client certificate.                    |             | no
-`curve_preferences`            | `list(string)` | Set of elliptic curves to use in a handshake.                                                | `[]`        | no
+| Name                           | Type           | Description                                                                                  | Default     | Required |
+| ------------------------------ | -------------- | -------------------------------------------------------------------------------------------- | ----------- | -------- |
+| `ca_file`                      | `string`       | Path to the CA file.                                                                         |             | no       |
+| `ca_pem`                       | `string`       | CA PEM-encoded text to validate the server with.                                             |             | no       |
+| `cert_file`                    | `string`       | Path to the TLS certificate.                                                                 |             | no       |
+| `cert_pem`                     | `string`       | Certificate PEM-encoded text for client authentication.                                      |             | no       |
+| `cipher_suites`                | `list(string)` | A list of TLS cipher suites that the TLS transport can use.                                  | `[]`        | no       |
+| `client_ca_file`               | `string`       | Path to the TLS cert to use by the server to verify a client certificate.                    |             | no       |
+| `curve_preferences`            | `list(string)` | Set of elliptic curves to use in a handshake.                                                | `[]`        | no       |
+| `include_system_ca_certs_pool` | `boolean`      | Whether to load the system certificate authorities pool alongside the certificate authority. | `false`     | no       |
+| `key_file`                     | `string`       | Path to the TLS certificate key.                                                             |             | no       |
+| `key_pem`                      | `secret`       | Key PEM-encoded text for client authentication.                                              |             | no       |
+| `max_version`                  | `string`       | Maximum acceptable TLS version for connections.                                              | `"TLS 1.3"` | no       |
+| `min_version`                  | `string`       | Minimum acceptable TLS version for connections.                                              | `"TLS 1.2"` | no       |
+| `reload_interval`              | `duration`     | The duration after which the certificate is reloaded.                                        | `"0s"`      | no       |
 
 If `reload_interval` is set to `"0s"`, the certificate never reloaded.
 

--- a/docs/sources/shared/reference/components/output-block-logs.md
+++ b/docs/sources/shared/reference/components/output-block-logs.md
@@ -8,9 +8,9 @@ The `output` block configures a set of components to forward resulting telemetry
 
 The following arguments are supported:
 
-Name   | Type                     | Description                        | Default | Required
--------|--------------------------|------------------------------------|---------|---------
-`logs` | `list(otelcol.Consumer)` | List of consumers to send logs to. | `[]`    | no
+| Name   | Type                     | Description                        | Default | Required |
+| ------ | ------------------------ | ---------------------------------- | ------- | -------- |
+| `logs` | `list(otelcol.Consumer)` | List of consumers to send logs to. | `[]`    | no       |
 
 You must specify the `output` block, but all its arguments are optional.
 By default, telemetry data is dropped.

--- a/docs/sources/shared/reference/components/output-block-metrics.md
+++ b/docs/sources/shared/reference/components/output-block-metrics.md
@@ -7,9 +7,9 @@ The `output` block configures a set of components to forward resulting telemetry
 
 The following arguments are supported:
 
-Name      | Type                     | Description                           | Default | Required
-----------|--------------------------|---------------------------------------|---------|---------
-`metrics` | `list(otelcol.Consumer)` | List of consumers to send metrics to. | `[]`    | no
+| Name      | Type                     | Description                           | Default | Required |
+| --------- | ------------------------ | ------------------------------------- | ------- | -------- |
+| `metrics` | `list(otelcol.Consumer)` | List of consumers to send metrics to. | `[]`    | no       |
 
 You must specify the `output` block, but all its arguments are optional.
 By default, telemetry data is dropped.

--- a/docs/sources/shared/reference/components/output-block-traces.md
+++ b/docs/sources/shared/reference/components/output-block-traces.md
@@ -8,9 +8,9 @@ The `output` block configures a set of components to forward resulting telemetry
 
 The following arguments are supported:
 
-Name     | Type                     | Description                          | Default | Required
----------|--------------------------|--------------------------------------|---------|---------
-`traces` | `list(otelcol.Consumer)` | List of consumers to send traces to. | `[]`    | no
+| Name     | Type                     | Description                          | Default | Required |
+| -------- | ------------------------ | ------------------------------------ | ------- | -------- |
+| `traces` | `list(otelcol.Consumer)` | List of consumers to send traces to. | `[]`    | no       |
 
 You must specify the `output` block, but all its arguments are optional.
 By default, telemetry data is dropped.

--- a/docs/sources/shared/reference/components/output-block.md
+++ b/docs/sources/shared/reference/components/output-block.md
@@ -8,11 +8,11 @@ The `output` block configures a set of components to forward resulting telemetry
 
 The following arguments are supported:
 
-Name      | Type                     | Description                           | Default | Required
-----------|--------------------------|---------------------------------------|---------|---------
-`logs`    | `list(otelcol.Consumer)` | List of consumers to send logs to.    | `[]`    | no
-`metrics` | `list(otelcol.Consumer)` | List of consumers to send metrics to. | `[]`    | no
-`traces`  | `list(otelcol.Consumer)` | List of consumers to send traces to.  | `[]`    | no
+| Name      | Type                     | Description                           | Default | Required |
+| --------- | ------------------------ | ------------------------------------- | ------- | -------- |
+| `logs`    | `list(otelcol.Consumer)` | List of consumers to send logs to.    | `[]`    | no       |
+| `metrics` | `list(otelcol.Consumer)` | List of consumers to send metrics to. | `[]`    | no       |
+| `traces`  | `list(otelcol.Consumer)` | List of consumers to send traces to.  | `[]`    | no       |
 
 You must specify the `output` block, but all its arguments are optional.
 By default, telemetry data is dropped.

--- a/docs/sources/shared/reference/components/prom-operator-scrape.md
+++ b/docs/sources/shared/reference/components/prom-operator-scrape.md
@@ -4,7 +4,7 @@ description: Shared content, prom operator scrape
 headless: true
 ---
 
-Name                      | Type       | Description                                                                                                                  | Default | Required
---------------------------|------------|------------------------------------------------------------------------------------------------------------------------------|---------|---------
-`default_scrape_interval` | `duration` | The default interval between scraping targets. Used as the default if the target resource doesn't provide a scrape interval. | `1m`    | no
-`default_scrape_timeout`  | `duration` | The default timeout for scrape requests. Used as the default if the target resource doesn't provide a scrape timeout.        | `10s`   | no
+| Name                      | Type       | Description                                                                                                                  | Default | Required |
+| ------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------- | ------- | -------- |
+| `default_scrape_interval` | `duration` | The default interval between scraping targets. Used as the default if the target resource doesn't provide a scrape interval. | `1m`    | no       |
+| `default_scrape_timeout`  | `duration` | The default timeout for scrape requests. Used as the default if the target resource doesn't provide a scrape timeout.        | `10s`   | no       |

--- a/docs/sources/shared/reference/components/rule-block-logs.md
+++ b/docs/sources/shared/reference/components/rule-block-logs.md
@@ -10,15 +10,15 @@ The transformations are applied in top-down order if more than one `rule` block 
 You can use the following arguments to configure a `rule`.
 All arguments are optional. Omitted fields take their default values.
 
-Name            | Type           | Description                                                                                                                          | Default | Required
-----------------|----------------|--------------------------------------------------------------------------------------------------------------------------------------|---------|---------
-`action`        | `string`       | The relabeling action to perform.                                                                                                    | replace | no
-`modulus`       | `uint`         | A positive integer used to calculate the modulus of the hashed source label values.                                                  |         | no
-`regex`         | `string`       | A valid RE2 expression with support for parenthesized capture groups. Used to match the extracted value from the combination of the `source_label` and `separator` fields or filter labels during the `labelkeep/labeldrop/labelmap` actions. | `(.*)` | no
-`replacement`   | `string`       | The value against which a regular expression replace is performed if the regular expression matches the extracted value. Supports previously captured groups. | `"$1"`      | no
-`separator`     | `string`       | The separator used to concatenate the values present in `source_labels`.                                                             | ;       | no
-`source_labels` | `list(string)` | The list of labels whose values are to be selected. Their content is concatenated using the `separator` and matched against `regex`. |         | no
-`target_label`  | `string`       | Label to which the resulting value is written to.                                                                                    |         | no
+| Name            | Type           | Description                                                                                                                                                                                                                                   | Default | Required |
+| --------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | -------- |
+| `action`        | `string`       | The relabeling action to perform.                                                                                                                                                                                                             | replace | no       |
+| `modulus`       | `uint`         | A positive integer used to calculate the modulus of the hashed source label values.                                                                                                                                                           |         | no       |
+| `regex`         | `string`       | A valid RE2 expression with support for parenthesized capture groups. Used to match the extracted value from the combination of the `source_label` and `separator` fields or filter labels during the `labelkeep/labeldrop/labelmap` actions. | `(.*)`  | no       |
+| `replacement`   | `string`       | The value against which a regular expression replace is performed if the regular expression matches the extracted value. Supports previously captured groups.                                                                                 | `"$1"`  | no       |
+| `separator`     | `string`       | The separator used to concatenate the values present in `source_labels`.                                                                                                                                                                      | ;       | no       |
+| `source_labels` | `list(string)` | The list of labels whose values are to be selected. Their content is concatenated using the `separator` and matched against `regex`.                                                                                                          |         | no       |
+| `target_label`  | `string`       | Label to which the resulting value is written to.                                                                                                                                                                                             |         | no       |
 
 You can use the following actions:
 

--- a/docs/sources/shared/reference/components/rule-block.md
+++ b/docs/sources/shared/reference/components/rule-block.md
@@ -10,15 +10,15 @@ If more than one `rule` block is defined, the transformations are applied in top
 The following arguments can be used to configure a `rule`.
 All arguments are optional. Omitted fields take their default values.
 
-Name            | Type           | Description                                                                                                                          | Default | Required
-----------------|----------------|--------------------------------------------------------------------------------------------------------------------------------------|---------|---------
-`action`        | `string`       | The relabeling action to perform.                                                                                                    | replace | no
-`modulus`       | `uint`         | A positive integer used to calculate the modulus of the hashed source label values.                                                  |         | no
-`regex`         | `string`       | A valid RE2 expression with support for parenthesized capture groups. Used to match the extracted value from the combination of the `source_label` and `separator` fields or filter labels during the `labelkeep/labeldrop/labelmap` actions. | `(.*)` | no
-`replacement`   | `string`       | The value against which a regular expression replace is performed, if the regular expression matches the extracted value. Supports previously captured groups. | `"$1"`      | no
-`separator`     | `string`       | The separator used to concatenate the values present in `source_labels`.                                                             | ;       | no
-`source_labels` | `list(string)` | The list of labels whose values are to be selected. Their content is concatenated using the `separator` and matched against `regex`. |         | no
-`target_label`  | `string`       | Label to which the resulting value will be written to.                                                                               |         | no
+| Name            | Type           | Description                                                                                                                                                                                                                                   | Default | Required |
+| --------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | -------- |
+| `action`        | `string`       | The relabeling action to perform.                                                                                                                                                                                                             | replace | no       |
+| `modulus`       | `uint`         | A positive integer used to calculate the modulus of the hashed source label values.                                                                                                                                                           |         | no       |
+| `regex`         | `string`       | A valid RE2 expression with support for parenthesized capture groups. Used to match the extracted value from the combination of the `source_label` and `separator` fields or filter labels during the `labelkeep/labeldrop/labelmap` actions. | `(.*)`  | no       |
+| `replacement`   | `string`       | The value against which a regular expression replace is performed, if the regular expression matches the extracted value. Supports previously captured groups.                                                                                | `"$1"`  | no       |
+| `separator`     | `string`       | The separator used to concatenate the values present in `source_labels`.                                                                                                                                                                      | ;       | no       |
+| `source_labels` | `list(string)` | The list of labels whose values are to be selected. Their content is concatenated using the `separator` and matched against `regex`.                                                                                                          |         | no       |
+| `target_label`  | `string`       | Label to which the resulting value will be written to.                                                                                                                                                                                        |         | no       |
 
 You can use the following actions:
 

--- a/docs/sources/shared/reference/components/sigv4-block.md
+++ b/docs/sources/shared/reference/components/sigv4-block.md
@@ -4,13 +4,13 @@ description: Shared content, sigv4 block
 headless: true
 ---
 
-Name         | Type     | Description                                         | Default | Required
--------------|----------|-----------------------------------------------------|---------|---------
-`access_key` | `string` | AWS API access key.                                 |         | no
-`profile`    | `string` | Named AWS profile used to authenticate.             |         | no
-`region`     | `string` | AWS region.                                         |         | no
-`role_arn`   | `string` | AWS Role ARN, an alternative to using AWS API keys. |         | no
-`secret_key` | `secret` | AWS API secret key.                                 |         | no
+| Name         | Type     | Description                                         | Default | Required |
+| ------------ | -------- | --------------------------------------------------- | ------- | -------- |
+| `access_key` | `string` | AWS API access key.                                 |         | no       |
+| `profile`    | `string` | Named AWS profile used to authenticate.             |         | no       |
+| `region`     | `string` | AWS region.                                         |         | no       |
+| `role_arn`   | `string` | AWS Role ARN, an alternative to using AWS API keys. |         | no       |
+| `secret_key` | `secret` | AWS API secret key.                                 |         | no       |
 
 If `region` is left blank, the region from the default credentials chain is used.
 

--- a/docs/sources/shared/reference/components/tls-config-block.md
+++ b/docs/sources/shared/reference/components/tls-config-block.md
@@ -4,17 +4,17 @@ description: Shared content, tls config block
 headless: true
 ---
 
-Name                   | Type     | Description                                              | Default | Required
------------------------|----------|----------------------------------------------------------|---------|---------
-`ca_pem`               | `string` | CA PEM-encoded text to validate the server with.         |         | no
-`ca_file`              | `string` | CA certificate to validate the server with.              |         | no
-`cert_pem`             | `string` | Certificate PEM-encoded text for client authentication.  |         | no
-`cert_file`            | `string` | Certificate file for client authentication.              |         | no
-`insecure_skip_verify` | `bool`   | Disables validation of the server certificate.           |         | no
-`key_file`             | `string` | Key file for client authentication.                      |         | no
-`key_pem`              | `secret` | Key PEM-encoded text for client authentication.          |         | no
-`min_version`          | `string` | Minimum acceptable TLS version.                          |         | no
-`server_name`          | `string` | ServerName extension to indicate the name of the server. |         | no
+| Name                   | Type     | Description                                              | Default | Required |
+| ---------------------- | -------- | -------------------------------------------------------- | ------- | -------- |
+| `ca_pem`               | `string` | CA PEM-encoded text to validate the server with.         |         | no       |
+| `ca_file`              | `string` | CA certificate to validate the server with.              |         | no       |
+| `cert_pem`             | `string` | Certificate PEM-encoded text for client authentication.  |         | no       |
+| `cert_file`            | `string` | Certificate file for client authentication.              |         | no       |
+| `insecure_skip_verify` | `bool`   | Disables validation of the server certificate.           |         | no       |
+| `key_file`             | `string` | Key file for client authentication.                      |         | no       |
+| `key_pem`              | `secret` | Key PEM-encoded text for client authentication.          |         | no       |
+| `min_version`          | `string` | Minimum acceptable TLS version.                          |         | no       |
+| `server_name`          | `string` | ServerName extension to indicate the name of the server. |         | no       |
 
 The following pairs of arguments are mutually exclusive and can't both be set simultaneously:
 

--- a/docs/sources/shared/reference/components/write_relabel_config.md
+++ b/docs/sources/shared/reference/components/write_relabel_config.md
@@ -13,29 +13,29 @@ If more than one `write_relabel_config` block is defined, the transformations ar
 The following arguments can be used to configure a `write_relabel_config`.
 All arguments are optional. Omitted fields take their default values.
 
-Name            | Type           | Description                                                                                                                          | Default | Required
-----------------|----------------|--------------------------------------------------------------------------------------------------------------------------------------|---------|---------
-`action`        | `string`       | The relabeling action to perform.                                                                                                    | replace | no
-`modulus`       | `uint`         | A positive integer used to calculate the modulus of the hashed source label values.                                                  |         | no
-`regex`         | `string`       | A valid RE2 expression with support for parenthesized capture groups. Used to match the extracted value from the combination of the `source_label` and `separator` fields or filter labels during the `labelkeep/labeldrop/labelmap` actions. | `(.*)` | no
-`replacement`   | `string`       | The value against which a regular expression replace is performed, if the regular expression matches the extracted value. Supports previously captured groups. | `"$1"`      | no
-`separator`     | `string`       | The separator used to concatenate the values present in `source_labels`.                                                             | ;       | no
-`source_labels` | `list(string)` | The list of labels whose values are to be selected. Their content is concatenated using the `separator` and matched against `regex`. |         | no
-`target_label`  | `string`       | Label to which the resulting value will be written to.                                                                               |         | no
+| Name            | Type           | Description                                                                                                                                                                                                                                   | Default | Required |
+| --------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | -------- |
+| `action`        | `string`       | The relabeling action to perform.                                                                                                                                                                                                             | replace | no       |
+| `modulus`       | `uint`         | A positive integer used to calculate the modulus of the hashed source label values.                                                                                                                                                           |         | no       |
+| `regex`         | `string`       | A valid RE2 expression with support for parenthesized capture groups. Used to match the extracted value from the combination of the `source_label` and `separator` fields or filter labels during the `labelkeep/labeldrop/labelmap` actions. | `(.*)`  | no       |
+| `replacement`   | `string`       | The value against which a regular expression replace is performed, if the regular expression matches the extracted value. Supports previously captured groups.                                                                                | `"$1"`  | no       |
+| `separator`     | `string`       | The separator used to concatenate the values present in `source_labels`.                                                                                                                                                                      | ;       | no       |
+| `source_labels` | `list(string)` | The list of labels whose values are to be selected. Their content is concatenated using the `separator` and matched against `regex`.                                                                                                          |         | no       |
+| `target_label`  | `string`       | Label to which the resulting value will be written to.                                                                                                                                                                                        |         | no       |
 
 You can use the following actions:
 
-* `drop`      - Drops metrics where `regex` matches the string extracted using the `source_labels` and `separator`.
-* `dropequal` - Drop targets for which the concatenated `source_labels` do match `target_label`.
-* `hashmod`   - Hashes the concatenated labels, calculates its modulo `modulus` and writes the result to the `target_label`.
-* `keep`      - Keeps metrics where `regex` matches the string extracted using the `source_labels` and `separator`.
-* `keepequal` - Drop targets for which the concatenated `source_labels` don't match `target_label`.
-* `labeldrop` - Matches `regex` against all label names. Any labels that match are removed from the metric's label set.
-* `labelkeep` - Matches `regex` against all label names. Any labels that don't match are removed from the metric's label set.
-* `labelmap`  - Matches `regex` against all label names. Any labels that match are renamed according to the contents of the `replacement` field.
-* `lowercase` - Sets `target_label` to the lowercase form of the concatenated `source_labels`.
-* `replace`   - Matches `regex` to the concatenated labels. If there's a match, it replaces the content of the `target_label` using the contents of the `replacement` field.
-* `uppercase` - Sets `target_label` to the uppercase form of the concatenated `source_labels`.
+* `drop`: Drops metrics where `regex` matches the string extracted using the `source_labels` and `separator`.
+* `dropequal`: Drop targets for which the concatenated `source_labels` do match `target_label`.
+* `hashmod`: Hashes the concatenated labels, calculates its modulo `modulus` and writes the result to the `target_label`.
+* `keep`: Keeps metrics where `regex` matches the string extracted using the `source_labels` and `separator`.
+* `keepequal`: Drop targets for which the concatenated `source_labels` don't match `target_label`.
+* `labeldrop`: Matches `regex` against all label names. Any labels that match are removed from the metric's label set.
+* `labelkeep`: Matches `regex` against all label names. Any labels that don't match are removed from the metric's label set.
+* `labelmap`: Matches `regex` against all label names. Any labels that match are renamed according to the contents of the `replacement` field.
+* `lowercase`: Sets `target_label` to the lowercase form of the concatenated `source_labels`.
+* `replace`: Matches `regex` to the concatenated labels. If there's a match, it replaces the content of the `target_label` using the contents of the `replacement` field.
+* `uppercase`: Sets `target_label` to the uppercase form of the concatenated `source_labels`.
 
 {{< admonition type="note" >}}
 The regular expression capture groups can be referred to using either the `$CAPTURE_GROUP_NUMBER` or `${CAPTURE_GROUP_NUMBER}` notation.

--- a/docs/sources/shared/stability/experimental.md
+++ b/docs/sources/shared/stability/experimental.md
@@ -6,6 +6,8 @@ headless: true
 
 > **EXPERIMENTAL**: This is an [experimental][] component.
 > Experimental components are subject to frequent breaking changes, and may be removed with no equivalent replacement.
-> The `stability.level` flag must be set to `experimental` to use the component.
+> To enable and use an experimental component, you must set the `stability.level` [flag][] to `experimental`.
 
+[flag]: https://grafana.com/docs/alloy/<ALLOY_VERSION>/reference/cli/run/
 [experimental]: https://grafana.com/docs/release-life-cycle/
+

--- a/docs/sources/shared/stability/experimental_feature.md
+++ b/docs/sources/shared/stability/experimental_feature.md
@@ -6,6 +6,7 @@ headless: true
 
 > **EXPERIMENTAL**: This is an [experimental][] feature.
 > Experimental features are subject to frequent breaking changes, and may be removed with no equivalent replacement.
-> The `stability.level` flag must be set to `experimental` to use the feature.
+> To enable and use an experimental feature, you must set the `stability.level` [flag][] to `experimental`.
 
+[flag]: https://grafana.com/docs/alloy/<ALLOY_VERSION>/reference/cli/run/
 [experimental]: https://grafana.com/docs/release-life-cycle/

--- a/docs/sources/shared/stability/public_preview.md
+++ b/docs/sources/shared/stability/public_preview.md
@@ -6,6 +6,7 @@ headless: true
 
 > **Public preview**: This is a [public preview][] component.
 > Public preview components are subject to breaking changes, and may be replaced with equivalent functionality that cover the same use case.
-> The `stability.level` flag must be set to `public-preview` or below to use the component.
+> To enable and use a public preview component, you must set the `stability.level` [flag][] to `public-preview` or below.
 
+[flag]: https://grafana.com/docs/alloy/<ALLOY_VERSION>/reference/cli/run/
 [public preview]: https://grafana.com/docs/release-life-cycle/


### PR DESCRIPTION
This PR continues the general Alloy doc cleanup that is in progress.  

* Table formatting
* Fix some wording in the Stability statements
* Minor cleanup and fix passive/active in a few places (where the fix is relatively easy)