### PR TITLE
update statsd exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,13 @@ Main (unreleased)
 
 - Improve `foreach` UI and add graph support for it. (@wildum)
 
+- Update statsd_exporter to v0.28.0, most notable changes: (@kalleep)
+  - [0.23.0] Support experimental native histograms.
+  - [0.24.1] Support scaling parameter in mapping.
+  - [0.26.0] Add option to honor original labels from event tags over labels specified in mapping configuration.
+  - [0.27.1] Support dogstatsd extended aggregation
+  - [0.27.2] Fix panic on certain invalid lines
+
 ### Bugfixes
 
 - Fix `otelcol.receiver.filelog` documentation's default value for `start_at`. (@petewall)

--- a/go.mod
+++ b/go.mod
@@ -188,7 +188,7 @@ require (
 	github.com/prometheus/procfs v0.15.1
 	github.com/prometheus/prometheus v0.300.1 // replaced by a fork of v2.54.1 further down this file
 	github.com/prometheus/snmp_exporter v0.29.0 // if you update the snmp_exporter version, make sure to update the SNMP_VERSION in _index
-	github.com/prometheus/statsd_exporter v0.22.8
+	github.com/prometheus/statsd_exporter v0.28.0
 	github.com/richardartoul/molecule v1.0.1-0.20240531184615-7ca0df43c0b3
 	github.com/rogpeppe/go-internal v1.13.1
 	github.com/rs/cors v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -2499,8 +2499,6 @@ github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
 github.com/prometheus/snmp_exporter v0.29.0 h1:COShgBj1tmWvA5pAkWQgO/lB3+bL/MFqUIqOELSZaBw=
 github.com/prometheus/snmp_exporter v0.29.0/go.mod h1:WWtqbJ4kYdgHwjh52YRjHwJRne1tzBRHXuqWKtabxm8=
-github.com/prometheus/statsd_exporter v0.22.8 h1:Qo2D9ZzaQG+id9i5NYNGmbf1aa/KxKbB9aKfMS+Yib0=
-github.com/prometheus/statsd_exporter v0.22.8/go.mod h1:/DzwbTEaFTE0Ojz5PqcSk6+PFHOPWGxdXVr6yC8eFOM=
 github.com/prometheus/statsd_exporter v0.28.0 h1:S3ZLyLm/hOKHYZFOF0h4zYmd0EeKyPF9R1pFBYXUgYY=
 github.com/prometheus/statsd_exporter v0.28.0/go.mod h1:Lq41vNkMLfiPANmI+uHb5/rpFFUTxPXiiNpmsAYLvDI=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=

--- a/go.sum
+++ b/go.sum
@@ -2501,6 +2501,8 @@ github.com/prometheus/snmp_exporter v0.29.0 h1:COShgBj1tmWvA5pAkWQgO/lB3+bL/MFqU
 github.com/prometheus/snmp_exporter v0.29.0/go.mod h1:WWtqbJ4kYdgHwjh52YRjHwJRne1tzBRHXuqWKtabxm8=
 github.com/prometheus/statsd_exporter v0.22.8 h1:Qo2D9ZzaQG+id9i5NYNGmbf1aa/KxKbB9aKfMS+Yib0=
 github.com/prometheus/statsd_exporter v0.22.8/go.mod h1:/DzwbTEaFTE0Ojz5PqcSk6+PFHOPWGxdXVr6yC8eFOM=
+github.com/prometheus/statsd_exporter v0.28.0 h1:S3ZLyLm/hOKHYZFOF0h4zYmd0EeKyPF9R1pFBYXUgYY=
+github.com/prometheus/statsd_exporter v0.28.0/go.mod h1:Lq41vNkMLfiPANmI+uHb5/rpFFUTxPXiiNpmsAYLvDI=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/protocolbuffers/protoscope v0.0.0-20221109213918-8e7a6aafa2c9 h1:arwj11zP0yJIxIRiDn22E0H8PxfF7TsTrc2wIPFIsf4=
 github.com/protocolbuffers/protoscope v0.0.0-20221109213918-8e7a6aafa2c9/go.mod h1:SKZx6stCn03JN3BOWTwvVIO2ajMkb/zQdTceXYhKw/4=

--- a/internal/static/integrations/statsd_exporter/metrics.go
+++ b/internal/static/integrations/statsd_exporter/metrics.go
@@ -10,6 +10,7 @@ type Metrics struct {
 	EventsFlushed         prometheus.Counter
 	EventsUnmapped        prometheus.Counter
 	UDPPackets            prometheus.Counter
+	UDPPacketDrops        prometheus.Counter
 	TCPConnections        prometheus.Counter
 	TCPErrors             prometheus.Counter
 	TCPLineTooLong        prometheus.Counter
@@ -45,6 +46,10 @@ func NewMetrics(r prometheus.Registerer) (*Metrics, error) {
 	m.UDPPackets = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "statsd_exporter_udp_packets_total",
 		Help: "The total number of StatsD packets received over UDP.",
+	})
+	m.UDPPacketDrops = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "statsd_exporter_udp_packet_drops_total",
+		Help: "The total number of dropped StatsD packets which received over UDP.",
 	})
 	m.TCPConnections = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "statsd_exporter_tcp_connections_total",

--- a/internal/static/integrations/statsd_exporter/statsd_exporter.go
+++ b/internal/static/integrations/statsd_exporter/statsd_exporter.go
@@ -252,12 +252,14 @@ func (e *Exporter) Run(ctx context.Context) error {
 			Logger:          e.log,
 			LineParser:      parser,
 			UDPPackets:      e.metrics.UDPPackets,
+			UDPPacketDrops:  e.metrics.UDPPacketDrops,
 			LinesReceived:   e.metrics.LinesReceived,
 			EventsFlushed:   e.metrics.EventsFlushed,
 			SampleErrors:    *e.metrics.SampleErrors,
 			SamplesReceived: e.metrics.SamplesReceived,
 			TagErrors:       e.metrics.TagErrors,
 			TagsReceived:    e.metrics.TagsReceived,
+			UdpPacketQueue:  make(chan []byte, 1000),
 		}
 
 		go ul.Listen()

--- a/internal/static/integrations/statsd_exporter/statsd_exporter.go
+++ b/internal/static/integrations/statsd_exporter/statsd_exporter.go
@@ -4,6 +4,7 @@ package statsd_exporter
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -11,8 +12,8 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/grafana/alloy/internal/build"
+	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/grafana/alloy/internal/static/integrations"
 	"github.com/grafana/alloy/internal/static/integrations/config"
 	integrations_v2 "github.com/grafana/alloy/internal/static/integrations/v2"
@@ -109,13 +110,16 @@ type Exporter struct {
 	reg      *prometheus.Registry
 	metrics  *Metrics
 	exporter *exporter.Exporter
-	log      log.Logger
+	log      *slog.Logger
 }
 
 // New creates a new statsd_exporter integration. The integration scrapes
 // metrics from a statsd process.
-func New(log log.Logger, c *Config) (integrations.Integration, error) {
-	reg := prometheus.NewRegistry()
+func New(l log.Logger, c *Config) (integrations.Integration, error) {
+	var (
+		reg = prometheus.NewRegistry()
+		log = slog.New(logging.NewSlogGoKitHandler(l))
+	)
 
 	m, err := NewMetrics(reg)
 	if err != nil {
@@ -125,6 +129,7 @@ func New(log log.Logger, c *Config) (integrations.Integration, error) {
 	if c.ListenUDP == "" && c.ListenTCP == "" && c.ListenUnixgram == "" {
 		return nil, fmt.Errorf("at least one of UDP/TCP/Unixgram listeners must be used")
 	}
+
 	statsdMapper := &mapper.MetricMapper{
 		Registerer:    reg,
 		MappingsCount: m.MappingsCount,
@@ -229,7 +234,7 @@ func (e *Exporter) Run(ctx context.Context) error {
 		defer func() {
 			err := uconn.Close()
 			if err != nil {
-				level.Warn(e.log).Log("msg", "failed to close UDP listener", "err", err)
+				e.log.Warn("failed to close UDP listener", "err", err)
 			}
 		}()
 
@@ -270,7 +275,7 @@ func (e *Exporter) Run(ctx context.Context) error {
 		defer func() {
 			err := tconn.Close()
 			if err != nil {
-				level.Warn(e.log).Log("msg", "failed to close TCP listener", "err", err)
+				e.log.Warn("failed to close TCP listener", "err", err)
 			}
 		}()
 
@@ -309,7 +314,7 @@ func (e *Exporter) Run(ctx context.Context) error {
 		defer func() {
 			err := uxgconn.Close()
 			if err != nil {
-				level.Warn(e.log).Log("msg", "failed to close unixgram listener", "err", err)
+				e.log.Warn("failed to close unixgram listener", "err", err)
 			}
 		}()
 
@@ -345,11 +350,11 @@ func (e *Exporter) Run(ctx context.Context) error {
 			// Convert the string to octet
 			perm, err := strconv.ParseInt("0"+e.cfg.UnixSocketMode, 8, 32)
 			if err != nil {
-				level.Warn(e.log).Log("msg", "bad permission on unixgram socket, ignoring", "permission", e.cfg.UnixSocketMode, "socket", e.cfg.ListenUnixgram, "err", err)
+				e.log.Warn("bad permission on unixgram socket, ignoring", "permission", e.cfg.UnixSocketMode, "socket", e.cfg.ListenUnixgram, "err", err)
 			} else {
 				err = os.Chmod(e.cfg.ListenUnixgram, os.FileMode(perm))
 				if err != nil {
-					level.Warn(e.log).Log("msg", "failed to change unixgram socket permission", "socket", e.cfg.ListenUnixgram, "err", err)
+					e.log.Warn("failed to change unixgram socket permission", "socket", e.cfg.ListenUnixgram, "err", err)
 				}
 			}
 		}


### PR DESCRIPTION
#### PR Description
Update statsd exporter to latest version.

Most notable changes:
  - [0.23.0] Support experimental native histograms.
  - [0.24.1] Support scaling parameter in mapping.
  - [0.26.0] Add option to honor original labels from event tags over labels specified in mapping configuration.
  - [0.27.1] Support dogstatsd extended aggregation
  - [0.27.2] Fix panic on certain invalid lines

No braking changes or new arguments needed for now. I did however notice https://github.com/prometheus/statsd_exporter/pull/491. It would be possible for us to expose the default values used for mappers but we can address that later if we need it.

#### Which issue(s) this PR fixes
Fixes: https://github.com/grafana/alloy/issues/391

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
