### PR TITLE
Fixed minor typo

### DIFF
--- a/internal/alloycli/cmd_tools.go
+++ b/internal/alloycli/cmd_tools.go
@@ -10,7 +10,7 @@ import (
 func toolsCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tools",
-		Short: "Utilties for various components",
+		Short: "Utilities for various components",
 		Long:  `The tools command contains a collection of utilities for components.`,
 	}
 


### PR DESCRIPTION
This is nothing more than a minor syntax fix. It is shown when calling the help of alloy CLI, so it's placing is quite prominent. Should've no impact on anything, but looks more professional if new users aren't greeted with a typo right away.