### PR TITLE
Fix minor discrepancies in otelcol topics

### DIFF
--- a/docs/sources/reference/components/otelcol/otelcol.exporter.loadbalancing.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.loadbalancing.md
@@ -61,7 +61,7 @@ You can use the following arguments with `otelcol.exporter.loadbalancing`:
 | `routing_key` | `string`   | Routing strategy for load balancing.                                               | `"traceID"` | no       |
 | `timeout`     | `duration` | Time to wait before marking a request to the `otlp > protocol` exporter as failed. | `"0s"`      | no       |
 
-The `routing_key` attribute determines how to route signals across endpoints. Its value could be one of the following:
+The `routing_key` attribute determines how to route signals across endpoints. Its value can be one of the following:
 
 * `"service"`: spans, logs, and metrics with the same `service.name` will be exported to the same backend.
 

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.otlp.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.otlp.md
@@ -45,7 +45,7 @@ You can use the following blocks with `otelcol.exporter.otlp`:
 
 | Block                                  | Description                                                                | Required |
 | -------------------------------------- | -------------------------------------------------------------------------- | -------- |
-| [`client`][client]                     | Configures the gRPC server to send telemetry data to.                      | yes      |
+| [`client`][client]                     | Configures the gRPC client to send telemetry data to.                      | yes      |
 | `client` > [`keepalive`][keepalive]    | Configures keepalive settings for the gRPC client.                         | no       |
 | `client` > [`tls`][tls]                | Configures TLS for the gRPC client.                                        | no       |
 | [`debug_metrics`][debug_metrics]       | Configures the metrics that this component generates to monitor its state. | no       |

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.otlphttp.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.otlphttp.md
@@ -51,7 +51,7 @@ You can use the following blocks with `otelcol.exporter.otlphttp`:
 
 | Block                                                 | Description                                                                | Required |
 | ----------------------------------------------------- | -------------------------------------------------------------------------- | -------- |
-| [`client`][client]                                    | Configures the HTTP server to send telemetry data to.                      | yes      |
+| [`client`][client]                                    | Configures the HTTP client to send telemetry data to.                      | yes      |
 | `client` > [`compression_params`][compression_params] | Configure advanced compression options.                                    | no       |
 | `client` > [`cookies`][cookies]                       | Store cookies from server responses and reuse them in subsequent requests. | no       |
 | `client` > [`tls`][tls]                               | Configures TLS for the HTTP client.                                        | no       |
@@ -91,7 +91,7 @@ The following arguments are supported:
 | `max_conns_per_host`      | `int`                      | Limits the total (dialing,active, and idle) number of connections per host.                                        | `0`        | no       |
 | `max_idle_conns_per_host` | `int`                      | Limits the number of idle HTTP connections the host can keep open.                                                 | `0`        | no       |
 | `max_idle_conns`          | `int`                      | Limits the number of idle HTTP connections the client can keep open.                                               | `100`      | no       |
-| `proxy_url`               | `string`                   | HTTP proxy to send requests through.                                                                               |            |          |
+| `proxy_url`               | `string`                   | HTTP proxy to send requests through.                                                                               |            | no       |
 | `read_buffer_size`        | `string`                   | Size of the read buffer the HTTP client uses for reading server responses.                                         | `0`        | no       |
 | `timeout`                 | `duration`                 | Time to wait before marking a request as failed.                                                                   | `"30s"`    | no       |
 | `write_buffer_size`       | `string`                   | Size of the write buffer the HTTP client uses for writing requests.                                                | `"512KiB"` | no       |

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.prometheus.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.prometheus.md
@@ -39,7 +39,7 @@ You can use the following arguments with `otelcol.exporter.prometheus`:
 | Name                               | Type                    | Description                                                       | Default | Required |
 | ---------------------------------- | ----------------------- | ----------------------------------------------------------------- | ------- | -------- |
 | `forward_to`                       | `list(MetricsReceiver)` | Where to forward converted Prometheus metrics.                    |         | yes      |
-| `add_metric_suffixes`              | `boolean`               | Whether to add type and unit suffixes to metrics names.           | `true`  | no       |
+| `add_metric_suffixes`              | `boolean`               | Whether to add type and unit suffixes to metric names.            | `true`  | no       |
 | `gc_frequency`                     | `duration`              | How often to clean up stale metrics from memory.                  | `"5m"`  | no       |
 | `include_scope_info`               | `boolean`               | Whether to include `otel_scope_info` metrics.                     | `false` | no       |
 | `include_scope_labels`             | `boolean`               | Whether to include additional OTLP labels in all metrics.         | `true`  | no       |

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.splunkhec.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.splunkhec.md
@@ -48,7 +48,7 @@ The following blocks are supported inside the definition of `otelcol.exporter.sp
 | [`splunk`][splunk]                                    | Configures the Splunk HEC exporter.                                            | yes      |
 | `splunk` > [`batcher`][batcher]                       | Configures batching requests based on a timeout and a minimum number of items. | no       |
 | `splunk` > [`heartbeat`][heartbeat]                   | Configures the exporters heartbeat settings.                                   | no       |
-| `splunk` > [`otel_to_hec_fields`][otel_to_hec_fields] | Configures mapping of Open Telemetry to HEC Fields.                            | no       |
+| `splunk` > [`otel_to_hec_fields`][otel_to_hec_fields] | Configures mapping of OpenTelemetry to HEC Fields.                             | no       |
 | `splunk` > [`telemetry`][telemetry]                   | Configures the exporters telemetry.                                            | no       |
 | [`client`][client]                                    | Configures the HTTP client used to send data to Splunk HEC.                    | yes      |
 | [`debug_metrics`][debug_metrics]                      | Configures the metrics that this component generates to monitor its state.     | no       |
@@ -184,7 +184,7 @@ The following fields are exported and can be referenced by other components:
 
 ## Example
 
-### Open Telemetry Receiver
+### OpenTelemetry Receiver
 
 This example forwards metrics, logs, and traces send to the `otelcol.receiver.otlp.default` receiver to the Splunk HEC exporter.
 
@@ -249,7 +249,7 @@ otelcol.exporter.splunkhec "default" {
 
 ### Forward Prometheus Metrics
 
-This example forwards Prometheus metrics from {{< param "PRODUCT_NAME" >}} through a receiver for conversion to Open Telemetry format before finally sending them to Splunk HEC.
+This example forwards Prometheus metrics from {{< param "PRODUCT_NAME" >}} through a receiver for conversion to OpenTelemetry format before finally sending them to Splunk HEC.
 
 ```alloy
 prometheus.exporter.self "default" {

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.syslog.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.syslog.md
@@ -67,10 +67,10 @@ You can use the following arguments with `otelcol.exporter.syslog`:
 | `timeout`               | `duration` | Time to wait before marking a request as failed.      | `5s`      | no       |
 
 The `network` argument specifies if the syslog endpoint is using the TCP or UDP protocol.
-`network` must be one of `tcp`, `udp`
+`network` must be one of `tcp`, `udp`.
 
 The `protocol` argument specifies the syslog format supported by the endpoint.
-`protocol` must be one of `rfc5424`, `rfc3164`
+`protocol` must be one of `rfc5424`, `rfc3164`.
 
 ## Blocks
 

--- a/docs/sources/reference/components/otelcol/otelcol.processor.attributes.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.attributes.md
@@ -55,8 +55,8 @@ You can use the following blocks with `otelcol.processor.attributes`:
 | `exclude` > [`resource`][resource]         | A list of items to match the resources against.                            | no       |
 | [`include`][include]                       | Filter for data included in this processor's actions.                      | no       |
 | `include` > [`attribute`][attribute]       | A list of attributes to match against.                                     | no       |
-| `include` > [`log_severity`][log_severity] | A list of items to match the implementation library against.               | no       |
-| `include` > [`library`][library]           | How to match against a log record's SeverityNumber, if defined.            | no       |
+| `include` > [`log_severity`][log_severity] | How to match against a log record's SeverityNumber, if defined.            | no       |
+| `include` > [`library`][library]           | A list of items to match the implementation library against.               | no       |
 | `include` > [`regexp`][regexp]             | Regex cache settings.                                                      | no       |
 | `include` > [`resource`][resource]         | A list of items to match the resources against.                            | no       |
 
@@ -156,7 +156,7 @@ consider a processor such as [otelcol.processor.tail_sampling][].
 
 One of the following is also required:
 
-* For spans, one of `services`, `span_names`, `span_kinds`, [attribute][], [resource][], or [library][] must be specified  with a non-empty value for a valid configuration.
+* For spans, one of `services`, `span_names`, `span_kinds`, [attribute][], [resource][], or [library][] must be specified with a non-empty value for a valid configuration.
   The `log_bodies`, `log_severity_texts`, `log_severity`, and `metric_names` attributes are invalid.
 * For logs, one of `log_bodies`, `log_severity_texts`, `log_severity`, [attribute][], [resource][], or [library][] must be specified with a non-empty value for a valid configuration.
   The `span_names`, `span_kinds`, `metric_names`, and `services` attributes are invalid.

--- a/docs/sources/reference/components/otelcol/otelcol.processor.interval.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.interval.md
@@ -61,7 +61,7 @@ You can use the following argument with `otelcol.processor.interval`:
 
 | Name       | Type       | Description                                                         | Default | Required |
 | ---------- | ---------- | ------------------------------------------------------------------- | ------- | -------- |
-| `interval` | `duration` | The interval in the processor should export the aggregated metrics. | `"60s"` | no       |
+| `interval` | `duration` | The interval in which the processor should export aggregated metrics.| `"60s"` | no       |
 
 ## Blocks
 
@@ -71,7 +71,7 @@ You can use the following blocks with `otelcol.processor.interval`:
 | -------------------------------- | -------------------------------------------------------------------------- | -------- |
 | [`output`][output]               | Configures where to send received telemetry data.                          | yes      |
 | [`debug_metrics`][debug_metrics] | Configures the metrics that this component generates to monitor its state. | no       |
-| [`passthrough`][passthrough]     | Configure metric types to be passed through instead of aggregated.         | no       |
+| [`passthrough`][passthrough]     | Configures metric types to be passed through instead of aggregated.        | no       |
 
 [output]: #output
 [debug_metrics]: #debug_metrics


### PR DESCRIPTION
Passing over the otelcol.exporter.* and some of the otelcol.processor collector docs, validating against source.

* Fixing a few minor typos missed in the last pass through the otelcol topics.
* Splitting these fixes across multiple PRs to make it easier to review proposed content changes.