### PR TITLE
Fix descrepancies in otelcol.auth.* docs (#3651)

### DIFF
--- a/docs/sources/reference/components/otelcol/otelcol.auth.basic.md
+++ b/docs/sources/reference/components/otelcol/otelcol.auth.basic.md
@@ -27,7 +27,7 @@ You can specify multiple `otelcol.auth.basic` components by giving them differen
 
 ```alloy
 otelcol.auth.basic "<LABEL>" {
-  username = ">USERNAME>"
+  username = "<USERNAME>"
   password = "<PASSWORD>"
 }
 ```

--- a/docs/sources/reference/components/otelcol/otelcol.auth.bearer.md
+++ b/docs/sources/reference/components/otelcol/otelcol.auth.bearer.md
@@ -49,7 +49,7 @@ If you use a file to store the token, you can use [`local.file`][local.file] to 
 
 ## Blocks
 
-You can use the following blocks with `otelcol.auth.bearer`:
+You can use the following block with `otelcol.auth.bearer`:
 
 | Block                            | Description                                                                | Required |
 | -------------------------------- | -------------------------------------------------------------------------- | -------- |

--- a/docs/sources/reference/components/otelcol/otelcol.auth.headers.md
+++ b/docs/sources/reference/components/otelcol/otelcol.auth.headers.md
@@ -59,13 +59,13 @@ You can use the following blocks with `otelcol.auth.headers`:
 The `header` block defines a custom header to attach to requests.
 It's valid to provide multiple `header` blocks to set more than one header.
 
-| Name             | Type                 | Description                                                 | Default    | Required |
-| ---------------- | -------------------- | ----------------------------------------------------------- | ---------- | -------- |
-| `key`            | `string`             | Name of the header to set.                                  |            | yes      |
-| `action`         | `string`             | An action to perform on the header                          | `"upsert"` | no       |
-| `from_attribute` | `string`             | Metadata name used to retrieve header value                 |            | no       |
-| `from_context`   | `string`             | Authentication attribute name used to retrieve header value |            | no       |
-| `value`          | `string` or `secret` | Value of the header.                                        |            | no       |
+| Name             | Type                 | Description                                                  | Default    | Required |
+| ---------------- | -------------------- | ------------------------------------------------------------ | ---------- | -------- |
+| `key`            | `string`             | Name of the header to set.                                   |            | yes      |
+| `action`         | `string`             | An action to perform on the header.                          | `"upsert"` | no       |
+| `from_attribute` | `string`             | Authentication attribute name used to retrieve header value. |            | no       |
+| `from_context`   | `string`             | Metadata name used to retrieve header value.                 |            | no       |
+| `value`          | `string` or `secret` | Value of the header.                                         |            | no       |
 
 The supported values for `action` are:
 
@@ -74,7 +74,7 @@ The supported values for `action` are:
 * `upsert`: Inserts a header if it doesn't exist and updates the header if it exists.
 * `delete`: Deletes the header.
 
-Exactly one of `value` or `from_context` must be provided for each `header` block.
+Exactly one of `value`, `from_context`, or `from_attribute` must be provided for each `header` block.
 
 The `value` attribute sets the value of the header directly.
 Alternatively, you can use `from_context` to dynamically retrieve the header value from request metadata, or you can use `from_attribute` to dynamically retrieve the header value from request authentication metadata.

--- a/docs/sources/reference/components/otelcol/otelcol.auth.oauth2.md
+++ b/docs/sources/reference/components/otelcol/otelcol.auth.oauth2.md
@@ -46,7 +46,7 @@ You can use the following arguments with `otelcol.auth.oauth2`:
 | `token_url`          | `string`            | The server endpoint URL from which to get tokens.                                  |         | yes      |
 | `client_id_file`     | `string`            | The file path to retrieve the client identifier issued to the client.              |         | no       |
 | `client_id`          | `string`            | The client identifier issued to the client.                                        |         | no       |
-| `client_secret_file` | `secret`            | The file path to retrieve the secret string associated with the client identifier. |         | no       |
+| `client_secret_file` | `string`            | The file path to retrieve the secret string associated with the client identifier. |         | no       |
 | `client_secret`      | `secret`            | The secret string associated with the client identifier.                           |         | no       |
 | `endpoint_params`    | `map(list(string))` | Additional parameters that are sent to the token endpoint.                         | `{}`    | no       |
 | `scopes`             | `list(string)`      | Requested permissions associated for the client.                                   | `[]`    | no       |

--- a/docs/sources/reference/components/otelcol/otelcol.auth.sigv4.md
+++ b/docs/sources/reference/components/otelcol/otelcol.auth.sigv4.md
@@ -84,7 +84,7 @@ The `assume_role` block specifies the configuration needed to assume a role.
 
 If the `assume_role` block is specified in the configuration and `sts_region` isn't set, then `sts_region` will default to the value for `region`.
 
-For cross region authentication, `region` and `sts_region` can be set different to different values.
+For cross region authentication, `region` and `sts_region` can be set to different values.
 
 ### `debug_metrics`
 


### PR DESCRIPTION
Backport 8942fb21932a0ad29d6e092558c562be8e30b4d3 from https://github.com/grafana/alloy/pull/3651