### PR TITLE
upgrade Beyla to 2.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ Main (unreleased)
   - [0.27.1] Support dogstatsd extended aggregation
   - [0.27.2] Fix panic on certain invalid lines
   
-- Upgrade `beyla.ebpf` to v2.2.4. The full list of changes can be found in the [Beyla release notes](https://github.com/grafana/beyla/releases/tag/v2.2.4). (@grcevski)
+- Upgrade `beyla.ebpf` to v2.2.4-alloy. The full list of changes can be found in the [Beyla release notes](https://github.com/grafana/beyla/releases/tag/v2.2.4-alloy). (@grcevski)
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ Main (unreleased)
   - [0.27.1] Support dogstatsd extended aggregation
   - [0.27.2] Fix panic on certain invalid lines
   
-- Upgrade `beyla.ebpf` to v2.2.3. The full list of changes can be found in the [Beyla release notes](https://github.com/grafana/beyla/releases/tag/v2.2.3). (@marctc)
+- Upgrade `beyla.ebpf` to v2.2.4. The full list of changes can be found in the [Beyla release notes](https://github.com/grafana/beyla/releases/tag/v2.2.4). (@grcevski)
 
 ### Bugfixes
 

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/grafana/alloy-remote-config v0.0.10
 	github.com/grafana/alloy/syntax v0.1.0
-	github.com/grafana/beyla/v2 v2.2.3-alloy.2
+	github.com/grafana/beyla/v2 v2.2.4
 	github.com/grafana/catchpoint-prometheus-exporter v0.0.0-20250218151502-6e97feaee761
 	github.com/grafana/ckit v0.0.0-20250226083311-4f9f4aacabb5
 	github.com/grafana/cloudflare-go v0.0.0-20230110200409-c627cf6792f2

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/grafana/alloy-remote-config v0.0.10
 	github.com/grafana/alloy/syntax v0.1.0
-	github.com/grafana/beyla/v2 v2.2.4
+	github.com/grafana/beyla/v2 v2.2.4-alloy
 	github.com/grafana/catchpoint-prometheus-exporter v0.0.0-20250218151502-6e97feaee761
 	github.com/grafana/ckit v0.0.0-20250226083311-4f9f4aacabb5
 	github.com/grafana/cloudflare-go v0.0.0-20230110200409-c627cf6792f2

--- a/go.sum
+++ b/go.sum
@@ -1367,8 +1367,8 @@ github.com/gosnmp/gosnmp v1.39.0/go.mod h1:CxVS6bXqmWZlafUj9pZUnQX5e4fAltqPcijxW
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
 github.com/grafana/alloy-remote-config v0.0.10 h1:1Ge7lz2mjXI1rd6SmiZpFHyXeLehBuCi43+XTkdqgV4=
 github.com/grafana/alloy-remote-config v0.0.10/go.mod h1:kHE1usYo2WAVCikQkIXuoG1Clz8BSdiz3kF+DZSCQ4k=
-github.com/grafana/beyla/v2 v2.2.4 h1:Bi41f43uHUVCvmWWyVVBZbPOMmnh9Dx9d2opVL6EDOc=
-github.com/grafana/beyla/v2 v2.2.4/go.mod h1:paDYfhkRs9Au+wENl4Eve5ddjld9Mrhp+Jw2BrZrWvA=
+github.com/grafana/beyla/v2 v2.2.4-alloy h1:kyEjfuBZh4s+o2gquDLu0ouDBACUIowJl6nGP7AAehk=
+github.com/grafana/beyla/v2 v2.2.4-alloy/go.mod h1:paDYfhkRs9Au+wENl4Eve5ddjld9Mrhp+Jw2BrZrWvA=
 github.com/grafana/cadvisor v0.0.0-20240729082359-1f04a91701e2 h1:ju6EcY2aEobeBg185ETtFCKj5WzaQ48qfkbsSRRQrF4=
 github.com/grafana/cadvisor v0.0.0-20240729082359-1f04a91701e2/go.mod h1:8sLW/G7rcFe1CKMaA4pYT4mX3P1xQVGqM6luzEzx/2g=
 github.com/grafana/catchpoint-prometheus-exporter v0.0.0-20250218151502-6e97feaee761 h1:dPJOIEwtQ8uR3Qa79pb/lsSFJQ6j4P9vpCUQ4fKimG4=

--- a/go.sum
+++ b/go.sum
@@ -1367,8 +1367,8 @@ github.com/gosnmp/gosnmp v1.39.0/go.mod h1:CxVS6bXqmWZlafUj9pZUnQX5e4fAltqPcijxW
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
 github.com/grafana/alloy-remote-config v0.0.10 h1:1Ge7lz2mjXI1rd6SmiZpFHyXeLehBuCi43+XTkdqgV4=
 github.com/grafana/alloy-remote-config v0.0.10/go.mod h1:kHE1usYo2WAVCikQkIXuoG1Clz8BSdiz3kF+DZSCQ4k=
-github.com/grafana/beyla/v2 v2.2.3-alloy.2 h1:DX/UetYes/7kPirddGBCfjY3NuXXDG/+AGBq+ejOHKs=
-github.com/grafana/beyla/v2 v2.2.3-alloy.2/go.mod h1:paDYfhkRs9Au+wENl4Eve5ddjld9Mrhp+Jw2BrZrWvA=
+github.com/grafana/beyla/v2 v2.2.4 h1:Bi41f43uHUVCvmWWyVVBZbPOMmnh9Dx9d2opVL6EDOc=
+github.com/grafana/beyla/v2 v2.2.4/go.mod h1:paDYfhkRs9Au+wENl4Eve5ddjld9Mrhp+Jw2BrZrWvA=
 github.com/grafana/cadvisor v0.0.0-20240729082359-1f04a91701e2 h1:ju6EcY2aEobeBg185ETtFCKj5WzaQ48qfkbsSRRQrF4=
 github.com/grafana/cadvisor v0.0.0-20240729082359-1f04a91701e2/go.mod h1:8sLW/G7rcFe1CKMaA4pYT4mX3P1xQVGqM6luzEzx/2g=
 github.com/grafana/catchpoint-prometheus-exporter v0.0.0-20250218151502-6e97feaee761 h1:dPJOIEwtQ8uR3Qa79pb/lsSFJQ6j4P9vpCUQ4fKimG4=


### PR DESCRIPTION
#### PR Description

Upgrades Beyla to version 2.2.4 to handle the new executable event processing, which was missed in 2.2.3. The fix ensures that the target info events are processed, otherwise the instrumentation pipeline will block after instrumenting 10 executables by default.

#### Which issue(s) this PR fixes

Related fix in Beyla:
https://github.com/grafana/beyla/pull/1981

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
