### PR TITLE
General updates and corrections to the Alloy Component docs

### DIFF
--- a/docs/sources/reference/components/beyla/beyla.ebpf.md
+++ b/docs/sources/reference/components/beyla/beyla.ebpf.md
@@ -40,11 +40,11 @@ beyla.ebpf "<LABEL>" {
 
 You can use the following arguments with `beyla.ebpf`:
 
-| Name              | Type     | Description                                                                         | Default | Required |
-| ----------------- | -------- | ----------------------------------------------------------------------------------- | ------- | -------- |
-| `debug`           | `bool`   | Enable debug mode for Beyla.                                                        | `false` | no       |
-| `enforce_sys_caps`| `bool`   | Enforce system capabilities required for eBPF instrumentation.                      | `false` | no       |
-| `trace_printer`   | `string` | Format for printing trace information.                                              | `"disabled"` | no |
+| Name               | Type     | Description                                                    | Default      | Required |
+| ------------------ | -------- | -------------------------------------------------------------- | ------------ | -------- |
+| `debug`            | `bool`   | Enable debug mode for Beyla.                                   | `false`      | no       |
+| `enforce_sys_caps` | `bool`   | Enforce system capabilities required for eBPF instrumentation. | `false`      | no       |
+| `trace_printer`    | `string` | Format for printing trace information.                         | `"disabled"` | no       |
 
 
 `debug` enables debug mode for Beyla. This mode logs BPF logs, network logs, trace representation logs, and other debug information.

--- a/docs/sources/reference/components/discovery/discovery.consul.md
+++ b/docs/sources/reference/components/discovery/discovery.consul.md
@@ -36,7 +36,7 @@ You can use the following arguments with `discovery.consul`:
 | `datacenter`             | `string`            | Data center to query. If not provided, the default is used.                                                     |                  | no       |
 | `enable_http2`           | `bool`              | Whether HTTP2 is supported for requests.                                                                        | `true`           | no       |
 | `follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.                                                    | `true`           | no       |
-| `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.          |                      | no       |
+| `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.                         |                  | no       |
 | `namespace`              | `string`            | Namespace to use. Only supported in Consul Enterprise.                                                          |                  | no       |
 | `no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying.                |                  | no       |
 | `node_meta`              | `map(string)`       | Node metadata key/value pairs to filter nodes for a given service.                                              |                  | no       |
@@ -54,7 +54,7 @@ You can use the following arguments with `discovery.consul`:
 | `token`                  | `secret`            | Secret token used to access the Consul API.                                                                     |                  | no       |
 | `username`               | `string`            | The username to use. Deprecated in favor of the `basic_auth` configuration.                                     |                  | no       |
 
- At most, one of the following can be provided:
+At most, one of the following can be provided:
 
 * [`authorization`][authorization] block
 * [`basic_auth`][basic_auth] block
@@ -101,7 +101,7 @@ The `basic_auth` block configures basic authentication to the endpoint.
 
 ### `oauth2`
 
-The `oauth` block configures OAuth 2.0 authentication to the endpoint.
+The `oauth2` block configures OAuth 2.0 authentication to the endpoint.
 
 {{< docs/shared lookup="reference/components/oauth2-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 

--- a/docs/sources/reference/components/discovery/discovery.consulagent.md
+++ b/docs/sources/reference/components/discovery/discovery.consulagent.md
@@ -111,7 +111,7 @@ discovery.consulagent "example" {
 }
 
 prometheus.scrape "demo" {
-  targets    = discovery.consul.example.targets
+  targets    = discovery.consulagent.example.targets
   forward_to = [prometheus.remote_write.demo.receiver]
 }
 

--- a/docs/sources/reference/components/discovery/discovery.digitalocean.md
+++ b/docs/sources/reference/components/discovery/discovery.digitalocean.md
@@ -36,7 +36,7 @@ You can use the following arguments with `discovery.digitalocean`:
 | `bearer_token`           | `secret`            | Bearer token to authenticate with.                                                               |         | no       |
 | `enable_http2`           | `bool`              | Whether HTTP2 is supported for requests.                                                         | `true`  | no       |
 | `follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.                                     | `true`  | no       |
-| `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.          |                      | no       |
+| `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.          |         | no       |
 | `no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. |         | no       |
 | `port`                   | `number`            | Port to be appended to the `__address__` label for each Droplet.                                 | `80`    | no       |
 | `proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests.                                    |         | no       |

--- a/docs/sources/reference/components/discovery/discovery.dns.md
+++ b/docs/sources/reference/components/discovery/discovery.dns.md
@@ -41,9 +41,9 @@ The `discovery.dns` component doesn't support any blocks. You can configure this
 
 The following field is exported and can be referenced by other components:
 
-| Name      | Type                | Description                                        |
-| --------- | ------------------- | -------------------------------------------------- |
-| `targets` | `list(map(string))` | The set of targets discovered from the docker API. |
+| Name      | Type                | Description                                         |
+| --------- | ------------------- | --------------------------------------------------- |
+| `targets` | `list(map(string))` | The set of targets discovered from the DNS records. |
 
 Each target includes the following labels:
 

--- a/docs/sources/reference/components/discovery/discovery.docker.md
+++ b/docs/sources/reference/components/discovery/discovery.docker.md
@@ -35,7 +35,7 @@ You can use the following arguments with `discovery.docker`:
 | `bearer_token`           | `secret`            | Bearer token to authenticate with.                                                                                  |               | no       |
 | `enable_http2`           | `bool`              | Whether HTTP2 is supported for requests.                                                                            | `true`        | no       |
 | `follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.                                                        | `true`        | no       |
-| `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.          |                      | no       |
+| `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.                             |               | no       |
 | `host_networking_host`   | `string`            | Host to use if the container is in host networking mode.                                                            | `"localhost"` | no       |
 | `match_first_network`    | `bool`              | Match the first network if the container has multiple networks defined, thus avoiding collecting duplicate targets. | `true`        | no       |
 | `no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying.                    |               | no       |
@@ -45,7 +45,7 @@ You can use the following arguments with `discovery.docker`:
 | `proxy_url`              | `string`            | HTTP proxy to send requests through.                                                                                |               | no       |
 | `refresh_interval`       | `duration`          | Frequency to refresh list of containers.                                                                            | `"1m"`        | no       |
 
- At most, one of the following can be provided:
+At most, one of the following can be provided:
 
 * [`authorization`][authorization] block
 * [`basic_auth`][basic_auth] block
@@ -107,7 +107,7 @@ Refer to [List containers][List containers] from the Docker Engine API documenta
 
 ### `oauth2`
 
-The `oauth` block configures OAuth 2.0 authentication to the endpoint.
+The `oauth2` block configures OAuth 2.0 authentication to the endpoint.
 
 {{< docs/shared lookup="reference/components/oauth2-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 

--- a/docs/sources/reference/components/discovery/discovery.dockerswarm.md
+++ b/docs/sources/reference/components/discovery/discovery.dockerswarm.md
@@ -35,7 +35,7 @@ You can use the following arguments with `discovery.dockerswarm`:
 | `bearer_token`           | `secret`            | Bearer token to authenticate with.                                                                                            |         | no       |
 | `enable_http2`           | `bool`              | Whether HTTP2 is supported for requests.                                                                                      | `true`  | no       |
 | `follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.                                                                  | `true`  | no       |
-| `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.          |                      | no       |
+| `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.                                       |         | no       |
 | `no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying.                              |         | no       |
 | `port`                   | `number`            | The port to scrape metrics from, when `role` is nodes, and for discovered tasks and services that don't have published ports. | `80`    | no       |
 | `proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests.                                                                 |         | no       |
@@ -43,7 +43,7 @@ You can use the following arguments with `discovery.dockerswarm`:
 | `proxy_url`              | `string`            | HTTP proxy to send requests through.                                                                                          |         | no       |
 | `refresh_interval`       | `duration`          | Interval at which to refresh the list of targets.                                                                             | `"60s"` | no       |
 
- At most, one of the following can be provided:
+At most, one of the following can be provided:
 
 * [`authorization`][authorization] block
 * [`basic_auth`][basic_auth] block
@@ -64,7 +64,7 @@ You can use the following blocks with `discovery.dockerswarm`:
 | [`authorization`][authorization]      | Configure generic authorization to the endpoint.                                   | no       |
 | [`basic_auth`][basic_auth]            | Configure `basic_auth` for authenticating to the endpoint.                         | no       |
 | [`filter`][filter]                    | Optional filter to limit the discovery process to a subset of available resources. | no       |
-| [`oauth2`][oauth2]                    | Configure OAuth2 for authenticating to the endpoint.                               | no       |
+| [`oauth2`][oauth2]                    | Configure OAuth 2.0 for authenticating to the endpoint.                            | no       |
 | `oauth2` > [`tls_config`][tls_config] | Configure TLS settings for connecting to the endpoint.                             | no       |
 | [`tls_config`][tls_config]            | Configure TLS settings for connecting to the endpoint.                             | no       |
 
@@ -108,7 +108,7 @@ You can use the following arguments to configure a filter.
 
 ### `oauth2`
 
-The `oauth` block configures OAuth 2.0 authentication to the endpoint.
+The `oauth2` block configures OAuth 2.0 authentication to the endpoint.
 
 {{< docs/shared lookup="reference/components/oauth2-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 

--- a/docs/sources/reference/components/discovery/discovery.ec2.md
+++ b/docs/sources/reference/components/discovery/discovery.ec2.md
@@ -36,19 +36,19 @@ You can use the following arguments with `discovery.ec2`:
 | `enable_http2`           | `bool`              | Whether HTTP2 is supported for requests.                                                                                | `true`  | no       |
 | `endpoint`               | `string`            | Custom endpoint to be used.                                                                                             |         | no       |
 | `follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.                                                            | `true`  | no       |
-| `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.          |                      | no       |
+| `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.                                 |         | no       |
 | `no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying.                        |         | no       |
 | `port`                   | `int`               | The port to scrape metrics from. If using the public IP address, this must instead be specified in the relabeling rule. | 80      | no       |
 | `profile`                | `string`            | Named AWS profile used to connect to the API.                                                                           |         | no       |
 | `proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests.                                                           |         | no       |
 | `proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.                                                                   | `false` | no       |
 | `proxy_url`              | `string`            | HTTP proxy to send requests through.                                                                                    |         | no       |
-| `refresh_interval`       | `string`            | Refresh interval to re-read the instance list.                                                                          | 60s     | no       |
+| `refresh_interval`       | `duration`          | Refresh interval to re-read the instance list.                                                                          | 60s     | no       |
 | `region`                 | `string`            | The AWS region. If blank, the region from the instance metadata is used.                                                |         | no       |
 | `role_arn`               | `string`            | AWS Role Amazon Resource Name (ARN), an alternative to using AWS API keys.                                              |         | no       |
 | `secret_key`             | `string`            | The AWS API key secret. If blank, the environment variable `AWS_SECRET_ACCESS_KEY` is used.                             |         | no       |
 
- At most, one of the following can be provided:
+At most, one of the following can be provided:
 
 * [`authorization`][authorization] block
 * [`basic_auth`][basic_auth] block
@@ -56,7 +56,7 @@ You can use the following arguments with `discovery.ec2`:
 * [`bearer_token`](#arguments) argument
 * [`oauth2`][oauth2] block
 
- {{< docs/shared lookup="reference/components/http-client-proxy-config-description.md" source="alloy" version="<ALLOY_VERSION>" >}}
+{{< docs/shared lookup="reference/components/http-client-proxy-config-description.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ## Blocks
 
@@ -109,7 +109,7 @@ Refer to the [Filter API AWS EC2 documentation][filter api] for the list of supp
 
 ### `oauth2`
 
-The `oauth` block configures OAuth 2.0 authentication to the endpoint.
+The `oauth2` block configures OAuth 2.0 authentication to the endpoint.
 
 {{< docs/shared lookup="reference/components/oauth2-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 

--- a/docs/sources/reference/components/discovery/discovery.eureka.md
+++ b/docs/sources/reference/components/discovery/discovery.eureka.md
@@ -35,14 +35,14 @@ You can use the following arguments with `discovery.eureka`:
 | `bearer_token`           | `secret`            | Bearer token to authenticate with.                                                               |         | no       |
 | `enable_http2`           | `bool`              | Whether HTTP2 is supported for requests.                                                         | `true`  | no       |
 | `follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.                                     | `true`  | no       |
-| `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.          |                      | no       |
+| `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.          |         | no       |
 | `no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. |         | no       |
 | `proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests.                                    |         | no       |
 | `proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.                                            | `false` | no       |
 | `proxy_url`              | `string`            | HTTP proxy to send requests through.                                                             |         | no       |
 | `refresh_interval`       | `duration`          | Interval at which to refresh the list of targets.                                                | `30s`   | no       |
 
- At most, one of the following can be provided:
+At most, one of the following can be provided:
 
 * [`authorization`][authorization] block
 * [`basic_auth`][basic_auth] block
@@ -88,7 +88,7 @@ The `basic_auth` block configures basic authentication to the endpoint.
 
 ### `oauth2`
 
-The `oauth` block configures OAuth 2.0 authentication to the endpoint.
+The `oauth2` block configures OAuth 2.0 authentication to the endpoint.
 
 {{< docs/shared lookup="reference/components/oauth2-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 

--- a/docs/sources/reference/components/discovery/discovery.hetzner.md
+++ b/docs/sources/reference/components/discovery/discovery.hetzner.md
@@ -37,7 +37,7 @@ You can use the following arguments with `discovery.hetzner`:
 | `bearer_token`           | `secret`            | Bearer token to authenticate with.                                                               |         | no       |
 | `enable_http2`           | `bool`              | Whether HTTP2 is supported for requests.                                                         | `true`  | no       |
 | `follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.                                     | `true`  | no       |
-| `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.          |                      | no       |
+| `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.          |         | no       |
 | `no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. |         | no       |
 | `port`                   | `int`               | The port to scrape metrics from.                                                                 | `80`    | no       |
 | `proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests.                                    |         | no       |

--- a/docs/sources/reference/components/discovery/discovery.http.md
+++ b/docs/sources/reference/components/discovery/discovery.http.md
@@ -102,14 +102,14 @@ You can use the following arguments with `discovery.http`:
 | `bearer_token`           | `secret`            | Bearer token to authenticate with.                                                               |         | no       |
 | `enable_http2`           | `bool`              | Whether HTTP2 is supported for requests.                                                         | `true`  | no       |
 | `follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.                                     | `true`  | no       |
-| `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.          |                      | no       |
+| `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.          |         | no       |
 | `no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. |         | no       |
 | `proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests.                                    |         | no       |
 | `proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.                                            | `false` | no       |
 | `proxy_url`              | `string`            | HTTP proxy to send requests through.                                                             |         | no       |
 | `refresh_interval`       | `duration`          | How often to refresh targets.                                                                    | `"60s"` | no       |
 
- At most, one of the following can be provided:
+At most, one of the following can be provided:
 
 * [`authorization`][authorization] block
 * [`basic_auth`][basic_auth] block
@@ -129,7 +129,7 @@ You can use the following blocks with `discovery.http`:
 | ------------------------------------- | ---------------------------------------------------------- | -------- |
 | [`authorization`][authorization]      | Configure generic authorization to the endpoint.           | no       |
 | [`basic_auth`][basic_auth]            | Configure `basic_auth` for authenticating to the endpoint. | no       |
-| [`oauth2`][basic_auth]                | Configure OAuth 2.0 for authenticating to the endpoint.    | no       |
+| [`oauth2`][oauth2]                    | Configure OAuth 2.0 for authenticating to the endpoint.    | no       |
 | `oauth2` > [`tls_config`][tls_config] | Configure TLS settings for connecting to the endpoint.     | no       |
 | [`tls_config`][tls_config]            | Configure TLS settings for connecting to the endpoint.     | no       |
 

--- a/docs/sources/reference/components/discovery/discovery.ionos.md
+++ b/docs/sources/reference/components/discovery/discovery.ionos.md
@@ -35,7 +35,7 @@ You can use the following arguments with `discovery.ionos`:
 | `bearer_token`           | `secret`            | Bearer token to authenticate with.                                                               |         | no       |
 | `enable_http2`           | `bool`              | Whether HTTP2 is supported for requests.                                                         | `true`  | no       |
 | `follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.                                     | `true`  | no       |
-| `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.          |                      | no       |
+| `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.          |         | no       |
 | `no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. |         | no       |
 | `port`                   | `int`               | The port to scrape metrics from.                                                                 | 80      | no       |
 | `proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests.                                    |         | no       |
@@ -43,12 +43,12 @@ You can use the following arguments with `discovery.ionos`:
 | `proxy_url`              | `string`            | HTTP proxy to send requests through.                                                             |         | no       |
 | `refresh_interval`       | `duration`          | The time after which the servers are refreshed.                                                  | `60s`   | no       |
 
- At most, one of the following can be provided:
+At most, one of the following can be provided:
 
 * [`authorization`][authorization] block
 * [`basic_auth`][basic_auth] block
 * [`bearer_token_file`][arguments] argument
-* [`bearer_token`][arguments]
+* [`bearer_token`][arguments] argument
 * [`oauth2`][oauth2] block
 
 [arguments]: #arguments
@@ -63,7 +63,7 @@ You can use the following blocks with `discovery.ionos`:
 | ------------------------------------- | ---------------------------------------------------------- | -------- |
 | [`authorization`][authorization]      | Configure generic authorization to the endpoint.           | no       |
 | [`basic_auth`][basic_auth]            | Configure `basic_auth` for authenticating to the endpoint. | no       |
-| [`oauth2`][basic_auth]                | Configure OAuth 2.0 for authenticating to the endpoint.    | no       |
+| [`oauth2`][oauth2]                    | Configure OAuth 2.0 for authenticating to the endpoint.    | no       |
 | `oauth2` > [`tls_config`][tls_config] | Configure TLS settings for connecting to the endpoint.     | no       |
 | [`tls_config`][tls_config]            | Configure TLS settings for connecting to the endpoint.     | no       |
 

--- a/docs/sources/reference/components/discovery/discovery.kubelet.md
+++ b/docs/sources/reference/components/discovery/discovery.kubelet.md
@@ -35,13 +35,13 @@ You can use the following arguments with `discovery.kubelet`:
 | Name                     | Type                | Description                                                                                      | Default                     | Required |
 | ------------------------ | ------------------- | ------------------------------------------------------------------------------------------------ | --------------------------- | -------- |
 | `url`                    | `string`            | URL of the Kubelet server.                                                                       | `"https://localhost:10250"` | no       |
-| `refresh_interval`       | `duration`          | How often the Kubelet should be polled for scrape targets                                        | `5s`                        | no       |
-| `namespaces`             | `list(string)`      | A list of namespaces to extract target Pods from                                                 |                             | no       |
+| `refresh_interval`       | `duration`          | How often the Kubelet should be polled for scrape targets.                                       | `5s`                        | no       |
+| `namespaces`             | `list(string)`      | A list of namespaces to extract target Pods from.                                                |                             | no       |
 | `bearer_token_file`      | `string`            | File containing a bearer token to authenticate with.                                             |                             | no       |
 | `bearer_token`           | `secret`            | Bearer token to authenticate with.                                                               |                             | no       |
 | `enable_http2`           | `bool`              | Whether HTTP2 is supported for requests.                                                         | `true`                      | no       |
 | `follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.                                     | `true`                      | no       |
-| `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.          |                      | no       |
+| `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.          |                             | no       |
 | `proxy_url`              | `string`            | HTTP proxy to send requests through.                                                             |                             | no       |
 | `no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. |                             | no       |
 | `proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.                                            | `false`                     | no       |
@@ -73,7 +73,7 @@ You can use the following blocks with `discovery.kubelet`:
 | Block                                 | Description                                                | Required |
 | ------------------------------------- | ---------------------------------------------------------- | -------- |
 | [`authorization`][authorization]      | Configure generic authorization to the endpoint.           | no       |
-| [`basic_auth`][authorization]         | Configure `basic_auth` for authenticating to the endpoint. | no       |
+| [`basic_auth`][basic_auth]            | Configure `basic_auth` for authenticating to the endpoint. | no       |
 | [`oauth2`][oauth2]                    | Configure OAuth 2.0 for authenticating to the endpoint.    | no       |
 | `oauth2` > [`tls_config`][tls_config] | Configure TLS settings for connecting to the endpoint.     | no       |
 | [`tls_config`][tls_config]            | Configure TLS settings for connecting to the endpoint.     | no       |

--- a/docs/sources/reference/components/discovery/discovery.kubernetes.md
+++ b/docs/sources/reference/components/discovery/discovery.kubernetes.md
@@ -38,7 +38,7 @@ You can use the following arguments with `discovery.kubernetes`:
 | `bearer_token`           | `secret`            | Bearer token to authenticate with.                                                               |         | no       |
 | `enable_http2`           | `bool`              | Whether HTTP2 is supported for requests.                                                         | `true`  | no       |
 | `follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.                                     | `true`  | no       |
-| `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.          |                      | no       |
+| `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.          |         | no       |
 | `kubeconfig_file`        | `string`            | Path of kubeconfig file to use for connecting to Kubernetes.                                     |         | no       |
 | `no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. |         | no       |
 | `proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests.                                    |         | no       |
@@ -217,7 +217,7 @@ You can use the following blocks with `discovery.kubernetes`:
 | [`oauth2`][oauth2]                    | Configure OAuth 2.0 for authenticating to the endpoint.    | no       |
 | `oauth2` > [`tls_config`][tls_config] | Configure TLS settings for connecting to the endpoint.     | no       |
 | [`selectors`][selectors]              | Selectors to filter discovered Kubernetes resources.       | no       |
-| [`tls_config`][selectors]             | Configure TLS settings for connecting to the endpoint.     | no       |
+| [`tls_config`][tls_config]            | Configure TLS settings for connecting to the endpoint.     | no       |
 
 The > symbol indicates deeper levels of nesting.
 For example, `oauth2` > `tls_config` refers to a `tls_config` block defined inside an `oauth2` block.

--- a/docs/sources/reference/components/discovery/discovery.kuma.md
+++ b/docs/sources/reference/components/discovery/discovery.kuma.md
@@ -34,14 +34,14 @@ You can use the following arguments with `discovery.kuma`:
 | `bearer_token_file`      | `string`            | File containing a bearer token to authenticate with.                                             |         | no       |
 | `bearer_token`           | `secret`            | Bearer token to authenticate with.                                                               |         | no       |
 | `enable_http2`           | `bool`              | Whether HTTP2 is supported for requests.                                                         | `true`  | no       |
-| `fetch_timeout`          | `duration`          | The time after which the monitoring assignments are refreshed.                                   | `"2m"`  | no       |
+| `fetch_timeout`          | `duration`          | Timeout for fetching monitoring assignments.                                                     | `2m`    | no       |
 | `follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.                                     | `true`  | no       |
-| `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.          |                      | no       |
+| `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.          |         | no       |
 | `no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. |         | no       |
 | `proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests.                                    |         | no       |
 | `proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.                                            | `false` | no       |
 | `proxy_url`              | `string`            | HTTP proxy to send requests through.                                                             |         | no       |
-| `refresh_interval`       | `duration`          | The time to wait between polling update requests.                                                | `"30s"` | no       |
+| `refresh_interval`       | `duration`          | The time to wait between polling update requests.                                                | `30s`   | no       |
 
  At most, one of the following can be provided:
 

--- a/docs/sources/reference/components/discovery/discovery.lightsail.md
+++ b/docs/sources/reference/components/discovery/discovery.lightsail.md
@@ -35,12 +35,12 @@ You can use the following arguments with `discovery.lightsail`:
 | `follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.                                                            | `true`  | no       |
 | `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.                                 |         | no       |
 | `no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying.                        |         | no       |
-| `port`                   | `int`               | The port to scrape metrics from. If using the public IP address, this must instead be specified in the relabeling rule. | 80      | no       |
+| `port`                   | `int`               | The port to scrape metrics from. If using the public IP address, this must instead be specified in the relabeling rule. | `80`    | no       |
 | `profile`                | `string`            | Named AWS profile used to connect to the API.                                                                           |         | no       |
 | `proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests.                                                           |         | no       |
 | `proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.                                                                   | `false` | no       |
 | `proxy_url`              | `string`            | HTTP proxy to send requests through.                                                                                    |         | no       |
-| `refresh_interval`       | `string`            | Refresh interval to re-read the instance list.                                                                          | 60s     | no       |
+| `refresh_interval`       | `duration`          | Refresh interval to re-read the instance list.                                                                          | `60s`   | no       |
 | `region`                 | `string`            | The AWS region. If blank, the region from the instance metadata is used.                                                |         | no       |
 | `role_arn`               | `string`            | AWS Role ARN, an alternative to using AWS API keys.                                                                     |         | no       |
 | `secret_key`             | `string`            | The AWS API key secret. If blank, the environment variable `AWS_SECRET_ACCESS_KEY` is used.                             |         | no       |


### PR DESCRIPTION
This PR is part of a series of PRs that aim to catch a few minor typos and errors that have crept into the docs through all the recent refactoring and updates.

Most corrections are minor:
* fix  anchor links in the page
* fix occasional typos
* sort out some table formatting that was missed or has shown up from other unrelated edits
* remove some extra spaces at the start/end of lines

This PR also includes validating the args etc. against the source files (as a double check to make sure everything matches).