### PR TITLE
fix : prometheus.unix.exporter to pass hwmon config correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,8 @@ Main (unreleased)
 
 - Fix alloy health handler so header is written before response body. (@kalleep)
 
+- Fix `prometheus.exporter.unix` to pass hwmon config correctly. (@kalleep)
+
 ### Other changes
 
 - Update the zap logging adapter used by `otelcol` components to log arrays and objects. (@dehaansa)

--- a/internal/static/integrations/node_exporter/config.go
+++ b/internal/static/integrations/node_exporter/config.go
@@ -498,11 +498,6 @@ func (c *Config) mapConfigToNodeConfig() *collector.NodeCollectorConfig {
 		Softirq: &blankBool,
 	}
 
-	cfg.HwMon = collector.HwMonConfig{
-		ChipInclude: &blankString,
-		ChipExclude: &blankString,
-	}
-
 	cfg.Qdisc = collector.QdiscConfig{
 		Fixtures:         &blankString,
 		DeviceInclude:    &blankString,


### PR DESCRIPTION
#### PR Description
When these arguments was added to alloy in https://github.com/grafana/alloy/pull/1369 the where added higher up in the function and these was not touched. So the config was always overwritten with empty strings before being passed to the exporter.

#### Which issue(s) this PR fixes

Fixes #3670 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
