### PR TITLE
database_observability: add support for Azure Flexible Servers

### DIFF
--- a/internal/component/database_observability/mysql/collector/connection_info.go
+++ b/internal/component/database_observability/mysql/collector/connection_info.go
@@ -13,7 +13,10 @@ import (
 
 const ConnectionInfoName = "connection_info"
 
-var rdsRegex = regexp.MustCompile(`(?P<identifier>[^\.]+)\.([^\.]+)\.(?P<region>[^\.]+)\.rds\.amazonaws\.com`)
+var (
+	rdsRegex   = regexp.MustCompile(`(?P<identifier>[^\.]+)\.([^\.]+)\.(?P<region>[^\.]+)\.rds\.amazonaws\.com`)
+	azureRegex = regexp.MustCompile(`(?P<identifier>[^\.]+)\.mysql\.database\.azure\.com`)
+)
 
 type ConnectionInfoArguments struct {
 	DSN      string
@@ -71,6 +74,12 @@ func (c *ConnectionInfo) Start(ctx context.Context) error {
 			if len(matches) > 3 {
 				dbInstanceIdentifier = matches[1]
 				providerRegion = matches[3]
+			}
+		} else if strings.HasSuffix(host, "mysql.database.azure.com") {
+			providerName = "azure"
+			matches := azureRegex.FindStringSubmatch(host)
+			if len(matches) > 1 {
+				dbInstanceIdentifier = matches[1]
 			}
 		}
 	}

--- a/internal/component/database_observability/mysql/collector/connection_info_test.go
+++ b/internal/component/database_observability/mysql/collector/connection_info_test.go
@@ -35,6 +35,11 @@ func TestConnectionInfo(t *testing.T) {
 			dsn:             "user:pass@tcp(products-db.abc123xyz.us-east-1.rds.amazonaws.com:3306)/schema",
 			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "products-db", "aws", "us-east-1"),
 		},
+		{
+			name:            "Azure flexibleservers dsn",
+			dsn:             "user:pass@tcp(products-db.mysql.database.azure.com:3306)/schema",
+			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "products-db", "azure", "unknown"),
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
#### PR Description
Parse Azure FlexibleServer for Mysql connection name.

#### Which issue(s) this PR fixes
n.a.

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
