### PR TITLE
fix: update helm chart service for ports

### DIFF
--- a/operations/helm/charts/alloy/templates/service.yaml
+++ b/operations/helm/charts/alloy/templates/service.yaml
@@ -27,10 +27,10 @@ spec:
       {{- if eq .Values.service.type "NodePort" }}
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}
-      port: {{ $values.listenPort }}
-      targetPort: {{ $values.listenPort }}
+      port: {{ .Values.listenPort }}
+      targetPort: {{ .Values.listenPort }}
       protocol: "TCP"
-{{- range $portMap := $values.extraPorts }}
+{{- range $portMap := .Values.extraPorts }}
     - name: {{ $portMap.name }}
       port: {{ $portMap.port }}
       targetPort: {{ $portMap.targetPort }}


### PR DESCRIPTION

#### PR Description

Bug Fix, Inside helm chart service.yaml, `extraPorts` and `listenPort` were not functional. Misspelling the variable access templates.

#### Which issue(s) this PR fixes

**No Issue Opened**

#### Notes to the Reviewer

Quick fix

#### PR Checklist

- [ ] CHANGELOG.md updated
- [X] Documentation added (Already Ok Docs)
