### PR TITLE
Dont fetch tag during checkout for win release publish

### DIFF
--- a/.github/workflows/publish-alloy-windows.yml
+++ b/.github/workflows/publish-alloy-windows.yml
@@ -38,7 +38,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         persist-credentials: false
-        fetch-tags: true
 
     - name: Tag dev
       if: ${{ inputs.dev }}


### PR DESCRIPTION
This broke the windows release process: https://github.com/grafana/alloy/actions/runs/15209016428/job/42778628744.

Looking at the successful linux release, the difference is that the tag should not be fetched