### PR TITLE
fix: return in component handler when we have an invalid path

### DIFF
--- a/internal/service/http/http.go
+++ b/internal/service/http/http.go
@@ -434,6 +434,7 @@ func (s *Service) componentHandler(getHost func() (service.Host, error), pathPre
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			_, _ = fmt.Fprintf(w, "failed to parse URL path %q: %s\n", r.URL.Path, err)
+			return
 		}
 
 		info, err := host.GetComponent(componentID, component.InfoOptions{})


### PR DESCRIPTION
#### PR Description
Noticed this when I was testing out `prometheus.exporter.unix`. I called the handler manually e.g. `GET http://localhost:12345/api/v0/component/prometheus.exporter.unix.default/metrics`. I by mistake misspelled the label of the component and noticed that I got a log with:
```
2025/05/23 14:19:39 http: superfluous response.WriteHeader call from go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux/internal/request.(*RespWriterWrapper).writeHeader (resp_writer_wrapper.go:83)
```

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
