### PR TITLE
fix: enable logs from containers are transient.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,8 @@ v1.9.0-rc.0
 
 - Fix `prometheus.exporter.unix` to pass hwmon config correctly. (@kalleep)
 
+- Fix [#3408](https://github.com/grafana/alloy/issues/3408) `loki.source.docker` can now collect logs from containers not in the running state. (@adamamsmith)
+
 ### Other changes
 
 - Update the zap logging adapter used by `otelcol` components to log arrays and objects. (@dehaansa)

--- a/internal/component/loki/source/docker/docker_test.go
+++ b/internal/component/loki/source/docker/docker_test.go
@@ -105,10 +105,12 @@ func TestDuplicateTargets(t *testing.T) {
 }
 
 func TestRestart(t *testing.T) {
+	finishedAt := "2024-05-02T13:11:55.879889Z"
 	runningState := true
 	client := clientMock{
-		logLine: "2024-05-02T13:11:55.879889Z caller=module_service.go:114 msg=\"module stopped\" module=distributor",
-		running: func() bool { return runningState },
+		logLine:    "2024-05-02T13:11:55.879889Z caller=module_service.go:114 msg=\"module stopped\" module=distributor",
+		running:    func() bool { return runningState },
+		finishedAt: func() string { return finishedAt },
 	}
 	expectedLogLine := "caller=module_service.go:114 msg=\"module stopped\" module=distributor"
 
@@ -142,16 +144,24 @@ func TestRestart(t *testing.T) {
 
 func TestTargetNeverStarted(t *testing.T) {
 	runningState := false
+	finishedAt := "2024-05-02T13:11:55.879889Z"
 	client := clientMock{
-		logLine: "2024-05-02T13:11:55.879889Z caller=module_service.go:114 msg=\"module stopped\" module=distributor",
-		running: func() bool { return runningState },
+		logLine:    "2024-05-02T13:11:55.879889Z caller=module_service.go:114 msg=\"module stopped\" module=distributor",
+		running:    func() bool { return runningState },
+		finishedAt: func() string { return finishedAt },
 	}
+	expectedLogLine := "caller=module_service.go:114 msg=\"module stopped\" module=distributor"
 
-	tailer, _ := setupTailer(t, client)
+	tailer, entryHandler := setupTailer(t, client)
 	ctx, cancel := context.WithCancel(t.Context())
 	go tailer.Run(ctx)
 
-	time.Sleep(20 * time.Millisecond)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		logLines := entryHandler.Received()
+		if assert.NotEmpty(c, logLines) {
+			assert.Equal(c, expectedLogLine, logLines[0].Line)
+		}
+	}, time.Second, 20*time.Millisecond, "Expected log lines were not found within the time limit after restart.")
 
 	require.NotPanics(t, func() { cancel() })
 }
@@ -190,8 +200,9 @@ func setupTailer(t *testing.T, client clientMock) (tailer *tailer, entryHandler 
 
 type clientMock struct {
 	client.APIClient
-	logLine string
-	running func() bool
+	logLine    string
+	running    func() bool
+	finishedAt func() string
 }
 
 func (mock clientMock) ContainerInspect(ctx context.Context, c string) (container.InspectResponse, error) {
@@ -199,7 +210,8 @@ func (mock clientMock) ContainerInspect(ctx context.Context, c string) (containe
 		ContainerJSONBase: &container.ContainerJSONBase{
 			ID: c,
 			State: &container.State{
-				Running: mock.running(),
+				Running:    mock.running(),
+				FinishedAt: mock.finishedAt(),
 			},
 		},
 		Config: &container.Config{Tty: true},

--- a/internal/component/loki/source/docker/runner.go
+++ b/internal/component/loki/source/docker/runner.go
@@ -109,7 +109,14 @@ func (t *tailer) Run(ctx context.Context) {
 				level.Error(t.log).Log("msg", "error inspecting Docker container", "id", t.target.Name(), "error", err)
 				continue
 			}
-			if res.State.Running {
+
+			finished, err := time.Parse(time.RFC3339Nano, res.State.FinishedAt)
+			if err != nil {
+				level.Error(t.log).Log("msg", "error parsing finished time for Docker container", "id", t.target.Name(), "error", err)
+				finished = time.Unix(0, 0)
+			}
+
+			if res.State.Running || finished.Unix() >= t.target.Last() {
 				t.target.StartIfNotRunning()
 			}
 		case <-ctx.Done():


### PR DESCRIPTION
#### Fix: loki.source.docker only collecting logs for containers in the running state

Slightly different implementation of https://github.com/grafana/alloy/pull/3449. All credit to @RasEza.

From his PR:

Due to the change in https://github.com/grafana/alloy/pull/742 loki.source.docker is no longer able to begin log collection for containers that only briefly have the "running" container state. This means that transient, short-lived or quickly restarting containers may never have their logs collected.

This allows for log collection of containers not in the running state if they have not been collected from already.

#### Which issue(s) this PR fixes

Fixes #3408

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG.md updated
- [x] Tests updated
