### PR TITLE
[backport/v1.9] pyroscope.ebpf: Retry after eBPF errors and buffer config updates. (#…

### DIFF
--- a/internal/component/pyroscope/ebpf/ebpf_linux_test.go
+++ b/internal/component/pyroscope/ebpf/ebpf_linux_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -26,11 +27,12 @@ import (
 )
 
 type mockSession struct {
-	options      ebpfspy.SessionOptions
-	collectError error
-	collected    int
-	data         [][]string
-	dataTarget   *sd.Target
+	options         ebpfspy.SessionOptions
+	collectCallback func() error
+	collected       int
+	data            [][]string
+	dataTarget      *sd.Target
+	mtx             sync.Mutex
 }
 
 func (m *mockSession) Start() error {
@@ -42,6 +44,8 @@ func (m *mockSession) Stop() {
 }
 
 func (m *mockSession) Update(options ebpfspy.SessionOptions) error {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
 	m.options = options
 	return nil
 }
@@ -52,8 +56,8 @@ func (m *mockSession) UpdateTargets(_ sd.TargetsOptions) {
 
 func (m *mockSession) CollectProfiles(f pprof.CollectProfilesCallback) error {
 	m.collected++
-	if m.collectError != nil {
-		return m.collectError
+	if m.collectCallback != nil {
+		return m.collectCallback()
 	}
 	for _, stack := range m.data {
 		f(
@@ -104,7 +108,7 @@ func (m *mockSession) DebugInfo() interface{} {
 	}
 }
 
-func TestShutdownOnError(t *testing.T) {
+func TestTargetUpdatesWithLongCollection(t *testing.T) {
 	logger := util.TestAlloyLogger(t)
 	ms := newMetrics(nil)
 	targetFinder, err := sd.NewTargetFinder(os.DirFS("/foo"), logger, sd.TargetsOptions{
@@ -126,9 +130,92 @@ func TestShutdownOnError(t *testing.T) {
 		ms,
 	)
 
-	session.collectError = fmt.Errorf("mocked error collecting profiles")
-	err = c.Run(t.Context())
-	require.Error(t, err)
+	collection := make(chan struct{})
+
+	// simulate a long collection
+	session.collectCallback = func() error {
+		<-collection
+		return nil
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	ctx, cancel := context.WithCancel(t.Context())
+	go func() {
+		err = c.Run(ctx)
+		require.NoError(t, err)
+		wg.Done()
+	}()
+
+	// now schedule 3 updates
+	c.Update(arguments)
+	c.Update(arguments)
+	c.Update(arguments)
+	argX := NewDefaultArguments()
+	argX.SampleRate = 1234
+	c.Update(argX)
+
+	// unblock the collection
+	close(collection)
+
+	// wait for the session to be updated
+	require.Eventually(t, func() bool {
+		session.mtx.Lock()
+		defer session.mtx.Unlock()
+		return session.options.SampleRate == 1234
+	}, time.Second*1, time.Millisecond*10)
+
+	cancel()
+	wg.Wait()
+}
+
+func TestReportingCollectError(t *testing.T) {
+	logger := util.TestAlloyLogger(t)
+	ms := newMetrics(nil)
+	targetFinder, err := sd.NewTargetFinder(os.DirFS("/foo"), logger, sd.TargetsOptions{
+		ContainerCacheSize: 1024,
+	})
+	require.NoError(t, err)
+	session := &mockSession{}
+	arguments := NewDefaultArguments()
+	arguments.CollectInterval = time.Millisecond * 100
+	c := newTestComponent(
+		component.Options{
+			Logger:        logger,
+			Registerer:    prometheus.NewRegistry(),
+			OnStateChange: func(e component.Exports) {},
+		},
+		arguments,
+		session,
+		targetFinder,
+		ms,
+	)
+
+	session.collectCallback = func() error { return fmt.Errorf("mocked error collecting profiles") }
+	var wg sync.WaitGroup
+	wg.Add(1)
+	ctx, cancel := context.WithCancel(t.Context())
+	go func() {
+		err = c.Run(ctx)
+		require.NoError(t, err)
+		wg.Done()
+	}()
+
+	// expect the component to be unhealthy
+	require.Eventually(t, func() bool {
+		if c.CurrentHealth().Health == component.HealthTypeUnhealthy {
+			require.Equal(t, c.CurrentHealth().Message, "ebpf session collectProfiles mocked error collecting profiles")
+			return true
+		}
+		return false
+	}, time.Second*1, time.Millisecond*10)
+
+	// the component should still be handling update requests
+	err = c.Update(arguments)
+	require.NoError(t, err)
+
+	cancel()
+	wg.Wait()
 }
 
 func TestContextShutdown(t *testing.T) {


### PR DESCRIPTION
…3381)

* fix: Keep ebpf component loop running

If the eBPF component encounter an error, it stops the main processing loops, which then caused issues because any config reload for alloy would block the whole agent.

Fixes #3332

Also for long running scrapes we were blocking the component evaluation as we are waiting for the config to be updated. I switched this to be a buffered channel, so the config updated are unblocked.

In case of multiple updated buffered it will skip the in between updates and go straight to the latest version.

Fixes #1371

* Fix data racec in test

* Limit tries to start an ebpf session

* Add info logs at session start/end

* Pass context around to shutdown properly

(cherry picked from commit 9c21229be370614d21f9cc4251aae85b4e689cba)

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
