### PR TITLE
fix: fuzz failure artifact name

### DIFF
--- a/.github/workflows/fuzz-go.yml
+++ b/.github/workflows/fuzz-go.yml
@@ -136,7 +136,7 @@ jobs:
         if: ${{ failure() && steps.new-failure.outputs.file != '' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: failure-${FAILED_PACKAGE}-${FAILED_FUNCTION}
+          name: failure-${{ steps.new-failure.outputs.package }}-${{ steps.new-failure.outputs.function }}
           path: ${{ steps.new-failure.outputs.file }}
 
       - name: Generate reproduction instructions


### PR DESCRIPTION
#### PR Description
Change done in https://github.com/grafana/alloy/pull/3463. This is wrong and should not have been changed. Uploaded artifacts are currently named `failure-${FAILED_PACKAGE}-${FAILED_FUNCTION}` see https://github.com/grafana/alloy/actions/runs/15188127924

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
