### PR TITLE
Remove trunc of alloy image ID in helm chart

### DIFF
--- a/operations/helm/charts/alloy/CHANGELOG.md
+++ b/operations/helm/charts/alloy/CHANGELOG.md
@@ -14,6 +14,8 @@ Unreleased
 
 - Fix VPA issue not rendering correctly. (@mattdurham)
 
+- Fix `app.kubernetes.io/version` label not being set correctly. (@wildum)
+
 1.0.3 (2025-05-05)
 ----------
 

--- a/operations/helm/charts/alloy/templates/_helpers.tpl
+++ b/operations/helm/charts/alloy/templates/_helpers.tpl
@@ -58,7 +58,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/* substr trims delimeter prefix char from alloy.imageId output
     e.g. ':' for tags and '@' for digests.
     For digests, we crop the string to a 7-char (short) sha. */}}
-app.kubernetes.io/version: {{ (include "alloy.imageId" .) | trimPrefix "@sha256" | trimPrefix ":" | quote }}
+app.kubernetes.io/version: {{ (include "alloy.imageId" .) | trimPrefix "@sha256" | trimPrefix ":" | trunc 63 | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: alloy
 {{- end }}

--- a/operations/helm/charts/alloy/templates/_helpers.tpl
+++ b/operations/helm/charts/alloy/templates/_helpers.tpl
@@ -58,7 +58,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/* substr trims delimeter prefix char from alloy.imageId output
     e.g. ':' for tags and '@' for digests.
     For digests, we crop the string to a 7-char (short) sha. */}}
-app.kubernetes.io/version: {{ (include "alloy.imageId" .) | trunc 15 | trimPrefix "@sha256" | trimPrefix ":" | quote }}
+app.kubernetes.io/version: {{ (include "alloy.imageId" .) | trimPrefix "@sha256" | trimPrefix ":" | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: alloy
 {{- end }}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

It was detected internally when switching the new test version to v1.10. The added digit broke the deployment because the result of the truncation was an invalid label: https://github.com/grafana/deployment_tools/pull/267870/files.

The truncation was first introduced in the agent via: https://github.com/grafana/agent/pull/6062/files

The maximum length of the label is 63 (see https://kubernetes.io/docs/reference/kubectl/generated/kubectl_label/#:~:text=A%20label%20key%20and%20value,up%20to%2063%20characters%20each.) So I added instead of trunc 63 at the end for safety. Other labels have the same safety truncation

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
