### PR TITLE
fix: datadog url env var (#3700)

### DIFF
--- a/docs/sources/collect/datadog-traces-metrics.md
+++ b/docs/sources/collect/datadog-traces-metrics.md
@@ -154,7 +154,7 @@ You can do this by setting up your Datadog Agent in the following way:
    Or by setting an environment variable:
 
    ```bash
-   DD_DD_URL='{"http://<DATADOG_RECEIVER_HOST>:<DATADOG_RECEIVER_PORT>": ["datadog-receiver"]}'
+   DD_URL='{"http://<DATADOG_RECEIVER_HOST>:<DATADOG_RECEIVER_PORT>": ["datadog-receiver"]}'
    ```
 
 ## Run {{% param "PRODUCT_NAME" %}}


### PR DESCRIPTION
Backport  cfd3d219c44170d6a0deb754af449db60b4ac684 from https://github.com/grafana/alloy/pull/3700

