### PR TITLE
fix syntax tests in ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ run-alloylint: alloylint
 test:
 	$(GO_ENV) go test $(GO_FLAGS) -race $(shell go list ./... | grep -v /integration-tests/)
 	$(GO_ENV) go test $(GO_FLAGS) ./internal/static/integrations/node_exporter ./internal/static/logs ./internal/component/otelcol/processor/tail_sampling ./internal/component/loki/source/file ./internal/component/loki/source/docker
-	$(GO_ENV) find . -name go.mod -not -path "./go.mod" -execdir go test -race ./... \;
+	$(GO_ENV) cd ./syntax && go test -race ./...
 
 test-packages:
 ifeq ($(USE_CONTAINER),1)

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ run-alloylint: alloylint
 .PHONY: test
 # We have to run test twice: once for all packages with -race and then once
 # more without -race for packages that have known race detection issues. The
-# final command runs tests for all other submodules.
+# final command runs tests for syntax module.
 test:
 	$(GO_ENV) go test $(GO_FLAGS) -race $(shell go list ./... | grep -v /integration-tests/)
 	$(GO_ENV) go test $(GO_FLAGS) ./internal/static/integrations/node_exporter ./internal/static/logs ./internal/component/otelcol/processor/tail_sampling ./internal/component/loki/source/file ./internal/component/loki/source/docker

--- a/syntax/vm/vm_block_test.go
+++ b/syntax/vm/vm_block_test.go
@@ -705,7 +705,7 @@ func TestVM_Block_UnmarshalToMap(t *testing.T) {
 					field_a = 12345
 				}
 			`,
-			expectError: `block "some.settings" requires non-empty label`,
+			expectError: `block "some.settings" requires empty label`,
 		},
 
 		{


### PR DESCRIPTION
#### PR Description
If any tests in syntax module failed in GHA or Drone the pipeline would still succeed. 

Not really sure why status code from `-execdir` is not propagated correctly.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes: #3696

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
