### PR TITLE
converter: use backticks in generated alloy for strings 

### DIFF
--- a/internal/converter/internal/otelcolconvert/testdata/envvars/default_value_format.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/envvars/default_value_format.alloy
@@ -1,6 +1,6 @@
 otelcol.receiver.otlp "default" {
 	grpc {
-		endpoint = coalesce(sys.env("NORMAL_FORMAT"), "https://www.example.com/some/file-path?query={using brackets, spaces,+'and'%20\"quotes\"}")
+		endpoint = `${env:NORMAL_FORMAT:-https://www.example.com/some/file-path?query={using brackets, spaces,+'and'%20"quotes"}}`
 	}
 
 	http {

--- a/internal/converter/internal/otelcolconvert/testdata/filter.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/filter.alloy
@@ -18,17 +18,17 @@ otelcol.processor.filter "default_ottl" {
 	error_mode = "ignore"
 
 	traces {
-		span      = ["attributes[\"container.name\"] == \"app_container_1\"", "resource.attributes[\"host.name\"] == \"localhost\"", "name == \"app_3\""]
-		spanevent = ["attributes[\"grpc\"] == true", "IsMatch(name, \".*grpc.*\")"]
+		span      = [`attributes["container.name"] == "app_container_1"`, `resource.attributes["host.name"] == "localhost"`, `name == "app_3"`]
+		spanevent = [`attributes["grpc"] == true`, `IsMatch(name, ".*grpc.*")`]
 	}
 
 	metrics {
-		metric    = ["name == \"my.metric\" and resource.attributes[\"my_label\"] == \"abc123\"", "type == METRIC_DATA_TYPE_HISTOGRAM"]
-		datapoint = ["metric.type == METRIC_DATA_TYPE_SUMMARY", "resource.attributes[\"service.name\"] == \"my_service_name\""]
+		metric    = [`name == "my.metric" and resource.attributes["my_label"] == "abc123"`, "type == METRIC_DATA_TYPE_HISTOGRAM"]
+		datapoint = ["metric.type == METRIC_DATA_TYPE_SUMMARY", `resource.attributes["service.name"] == "my_service_name"`]
 	}
 
 	logs {
-		log_record = ["IsMatch(body, \".*password.*\")", "severity_number < SEVERITY_NUMBER_WARN"]
+		log_record = [`IsMatch(body, ".*password.*")`, "severity_number < SEVERITY_NUMBER_WARN"]
 	}
 
 	output {

--- a/internal/converter/internal/otelcolconvert/testdata/tail_sampling.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/tail_sampling.alloy
@@ -138,8 +138,8 @@ otelcol.processor.tail_sampling "default" {
 
 		ottl_condition {
 			error_mode = "ignore"
-			span       = ["attributes[\"test_attr_key_1\"] == \"test_attr_val_1\"", "attributes[\"test_attr_key_2\"] != \"test_attr_val_1\""]
-			spanevent  = ["name != \"test_span_event_name\"", "attributes[\"test_event_attr_key_2\"] != \"test_event_attr_val_1\""]
+			span       = [`attributes["test_attr_key_1"] == "test_attr_val_1"`, `attributes["test_attr_key_2"] != "test_attr_val_1"`]
+			spanevent  = [`name != "test_span_event_name"`, `attributes["test_event_attr_key_2"] != "test_event_attr_val_1"`]
 		}
 	}
 

--- a/internal/converter/internal/otelcolconvert/testdata/transform.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/transform.alloy
@@ -19,37 +19,37 @@ otelcol.processor.transform "default" {
 
 	trace_statements {
 		context    = "resource"
-		statements = ["keep_keys(attributes, [\"service.name\", \"service.namespace\", \"cloud.region\", \"process.command_line\"])", "replace_pattern(attributes[\"process.command_line\"], \"password\\\\=[^\\\\s]*(\\\\s?)\", \"password=***\")", "limit(attributes, 100, [])", "truncate_all(attributes, 4096)"]
+		statements = [`keep_keys(attributes, ["service.name", "service.namespace", "cloud.region", "process.command_line"])`, `replace_pattern(attributes["process.command_line"], "password\\=[^\\s]*(\\s?)", "password=***")`, "limit(attributes, 100, [])", "truncate_all(attributes, 4096)"]
 	}
 
 	trace_statements {
 		context    = "span"
-		statements = ["set(status.code, 1) where attributes[\"http.path\"] == \"/health\"", "set(name, attributes[\"http.route\"])", "replace_match(attributes[\"http.target\"], \"/user/*/list/*\", \"/user/{userId}/list/{listId}\")", "limit(attributes, 100, [])", "truncate_all(attributes, 4096)"]
+		statements = [`set(status.code, 1) where attributes["http.path"] == "/health"`, `set(name, attributes["http.route"])`, `replace_match(attributes["http.target"], "/user/*/list/*", "/user/{userId}/list/{listId}")`, "limit(attributes, 100, [])", "truncate_all(attributes, 4096)"]
 	}
 
 	metric_statements {
 		context    = "resource"
-		statements = ["keep_keys(attributes, [\"host.name\"])", "truncate_all(attributes, 4096)"]
+		statements = [`keep_keys(attributes, ["host.name"])`, "truncate_all(attributes, 4096)"]
 	}
 
 	metric_statements {
 		context    = "metric"
-		statements = ["set(description, \"Sum\") where type == \"Sum\"", "convert_sum_to_gauge() where name == \"system.processes.count\"", "convert_gauge_to_sum(\"cumulative\", false) where name == \"prometheus_metric\"", "aggregate_on_attributes(\"sum\") where name == \"system.memory.usage\""]
+		statements = [`set(description, "Sum") where type == "Sum"`, `convert_sum_to_gauge() where name == "system.processes.count"`, `convert_gauge_to_sum("cumulative", false) where name == "prometheus_metric"`, `aggregate_on_attributes("sum") where name == "system.memory.usage"`]
 	}
 
 	metric_statements {
 		context    = "datapoint"
-		statements = ["limit(attributes, 100, [\"host.name\"])", "truncate_all(attributes, 4096)"]
+		statements = [`limit(attributes, 100, ["host.name"])`, "truncate_all(attributes, 4096)"]
 	}
 
 	log_statements {
 		context    = "resource"
-		statements = ["keep_keys(attributes, [\"service.name\", \"service.namespace\", \"cloud.region\"])"]
+		statements = [`keep_keys(attributes, ["service.name", "service.namespace", "cloud.region"])`]
 	}
 
 	log_statements {
 		context    = "log"
-		statements = ["set(severity_text, \"FAIL\") where body == \"request failed\"", "replace_all_matches(attributes, \"/user/*/list/*\", \"/user/{userId}/list/{listId}\")", "replace_all_patterns(attributes, \"value\", \"/account/\\\\d{4}\", \"/account/{accountId}\")", "set(body, attributes[\"http.route\"])"]
+		statements = [`set(severity_text, "FAIL") where body == "request failed"`, `replace_all_matches(attributes, "/user/*/list/*", "/user/{userId}/list/{listId}")`, `replace_all_patterns(attributes, "value", "/account/\\d{4}", "/account/{accountId}")`, `set(body, attributes["http.route"])`]
 	}
 
 	output {

--- a/internal/converter/internal/prometheusconvert/testdata/discovery_relabel.alloy
+++ b/internal/converter/internal/prometheusconvert/testdata/discovery_relabel.alloy
@@ -24,14 +24,14 @@ discovery.relabel "prometheus1" {
 
 	rule {
 		source_labels = ["__address2__"]
-		regex         = "\""
+		regex         = `"`
 		target_label  = "instance"
 		replacement   = "${1}"
 	}
 
 	rule {
 		source_labels = ["__address3__"]
-		regex         = "\""
+		regex         = `"`
 		target_label  = "instance"
 		replacement   = "${1}"
 	}

--- a/internal/converter/internal/staticconvert/testdata-v2/integrations_v2.alloy
+++ b/internal/converter/internal/staticconvert/testdata-v2/integrations_v2.alloy
@@ -747,7 +747,7 @@ prometheus.scrape "integrations_snmp" {
 prometheus.exporter.gcp "integrations_gcp_exporter" {
 	project_ids      = ["<project_id>"]
 	metrics_prefixes = ["loadbalancing.googleapis.com/https/request_bytes_count", "loadbalancing.googleapis.com/https/total_latencies"]
-	extra_filters    = ["loadbalancing.googleapis.com:resource.labels.backend_target_name=\"sample-value\""]
+	extra_filters    = [`loadbalancing.googleapis.com:resource.labels.backend_target_name="sample-value"`]
 }
 
 discovery.relabel "integrations_gcp" {

--- a/internal/converter/internal/staticconvert/testdata/integrations.alloy
+++ b/internal/converter/internal/staticconvert/testdata/integrations.alloy
@@ -760,7 +760,7 @@ prometheus.scrape "integrations_statsd_exporter" {
 prometheus.exporter.gcp "integrations_gcp_exporter" {
 	project_ids      = ["<project_id>"]
 	metrics_prefixes = ["loadbalancing.googleapis.com/https/request_bytes_count", "loadbalancing.googleapis.com/https/total_latencies"]
-	extra_filters    = ["loadbalancing.googleapis.com:resource.labels.backend_target_name=\"sample-value\""]
+	extra_filters    = [`loadbalancing.googleapis.com:resource.labels.backend_target_name="sample-value"`]
 }
 
 discovery.relabel "integrations_gcp_exporter" {

--- a/syntax/token/builder/value_tokens.go
+++ b/syntax/token/builder/value_tokens.go
@@ -3,6 +3,7 @@ package builder
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/grafana/alloy/syntax/internal/value"
 	"github.com/grafana/alloy/syntax/scanner"
@@ -38,7 +39,12 @@ func valueTokens(v value.Value) []Token {
 		toks = append(toks, Token{token.NUMBER, v.Number().ToString()})
 
 	case value.TypeString:
-		toks = append(toks, Token{token.STRING, fmt.Sprintf("%q", v.Text())})
+		str := v.Text()
+		if strings.Contains(str, "\"") {
+			toks = append(toks, Token{token.STRING, fmt.Sprintf("`%s`", str)})
+		} else {
+			toks = append(toks, Token{token.STRING, fmt.Sprintf("%q", str)})
+		}
 
 	case value.TypeBool:
 		toks = append(toks, Token{token.STRING, fmt.Sprintf("%v", v.Bool())})


### PR DESCRIPTION
#### PR Description
If we detect any double quotes we use backticks for generated string 


#### Which issue(s) this PR fixes

Fixes: 3690

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
