### PR TITLE
Update developer component docs topic to add new elements and style

### DIFF
--- a/docs/developer/writing-component-documentation.md
+++ b/docs/developer/writing-component-documentation.md
@@ -571,11 +571,8 @@ documenting auxiliary artifacts which are related to a component.
 ### `otelcol.processor.transform`
 
 The [`otelcol.processor.transform`][otelcol.processor.transform] component documentation needed to add
-an extra section about OTTL Contexts because there is no appropriate OTEL docs page
-that we could link to. Currently this information is housed on the [transformprocessor][]
-doc page, but because it contains YAML config for the Collector, users might get confused
-how this maps to Alloy and it's better not to link to it. In the future we could try to
-move this information from [transformprocessor][] to the [OTTL Context][ottl context] doc.
+an extra section about [OTTL Contexts][ottl context] because there is no appropriate OTEL docs page
+that we could link to.
 
 [loki.source.podlogs]: ../sources/reference/components/loki.source.podlogs.md
 [otelcol.processor.transform]: ../sources/reference/components/otelcol.processor.transform.md

--- a/docs/developer/writing-component-documentation.md
+++ b/docs/developer/writing-component-documentation.md
@@ -184,7 +184,7 @@ listed using a Markdown table, with the following columns:
 If possible, sort the table rows alphabetically, required first, then optional.
 
 A paragraph with the content "You can use the following arguments with `COMPONENT_NAME`:" should
-always prefix the arguments table.
+always precede the arguments table.
 
 For example:
 
@@ -236,7 +236,7 @@ relevant to the arguments. If there is component behavior relevant to a
 specific block, describe that component behavior in the documentation section
 for that block instead.
 
-It's acceptable to provide configuration snippets for the arguments if it aids
+It's encouraged to provide configuration snippets for the arguments if it aids
 documentation.
 
 ### Blocks
@@ -264,7 +264,7 @@ using a Markdown table, with the following columns:
 If possible, sort the table rows alphabetically, required first, then optional.
 
 A paragraph with the content "You can use the following blocks with `COMPONENT_NAME`:" should
-always prefix the blocks table.
+always precede the blocks table.
 
 For example:
 
@@ -364,7 +364,7 @@ not provided, their Go-inherited defaults will not display in the component UI
 page.
 ```
 
-It's acceptable for block sections to provide configuration snippets for the
+It's encouraged for block sections to provide configuration snippets for the
 block if it aids documentation.
 
 ### Exported fields
@@ -548,7 +548,7 @@ Replace the following:
 If an example includes clarifying comments, make sure that the relevant
 Arguments or block header includes sufficient explanation to be the official
 source for the clarifying comment. Clarifying comments must only be used be
-supplementary information to re-enforce knowledge, and not as the primary source
+supplementary information to reinforce knowledge, and not as the primary source
 of information.
 
 Examples should be formatted using the [`alloy fmt`](https://grafana.com/docs/alloy/latest/reference/cli/fmt/) command.

--- a/docs/developer/writing-component-documentation.md
+++ b/docs/developer/writing-component-documentation.md
@@ -1,14 +1,14 @@
-# Writing documentation for Alloy components
+# Write documentation for Alloy components
 
 This guide outlines best practices for writing reference documentation for Alloy
 components.
 
 Component reference documentation is stored in [docs/sources/reference/components][docs source],
-and published to [Grafana's documentation website][hosted docs].
+and published to the [Grafana documentation website][hosted docs].
 
 Documentation for a component should follow best practices as much as possible
-so that things are kept consistent. Exceptions can be made when needed; see the
-list of [Exceptions][] at the bottom of this page for examples.
+so that things are kept consistent. Exceptions can be made when needed. Refer to the
+list of [Exceptions][] at the bottom of this page for examples of exceptions.
 
 [docs source]: ../sources/alloy/reference/components
 [hosted docs]: https://grafana.com/docs/alloy/latest/reference/components
@@ -24,32 +24,48 @@ list of [Exceptions][] at the bottom of this page for examples.
   components.
 * Refer to the component by its full name as much as possible rather than "the
   component."
-* Do not use backticks in headers.
 
 ## Page structure
 
-Component reference pages should start with YAML frontmatter containing the
-name of the component as the page title:
+Component reference pages should start with YAML front matter containing the
+canonical path, a short description, and the name of the component as the page title:
 
 ```markdown
 ---
+canonical: https://grafana.com/docs/alloy/latest/reference/components/PATH_TO_MARKDOWN_FILE/
+description: SHORT DESCRIPTION OF THE COMPONENT
 title: COMPONENT_NAME
 ---
 ```
 
-If documenting a beta component, include the following inside the frontmatter:
-
-```markdown
-labels:
-  stage: beta
-```
-
 If documenting an experimental component, include the following inside the
-frontmatter:
+front matter:
 
 ```markdown
 labels:
   stage: experimental
+  products:
+    - oss
+```
+
+If documenting a public preview component, include the following inside the
+front matter:
+
+```markdown
+labels:
+  stage: public-preview
+  products:
+    - oss
+```
+
+If documenting an generally available component, include the following inside the
+front matter:
+
+```markdown
+labels:
+  stage: general-availability
+  products:
+    - oss
 ```
 
 All component reference pages should always be broken down into the following
@@ -65,28 +81,27 @@ sections:
 8. Debug metrics
 9. Examples
 
-If a section does not apply to a component (such as a component not exposing
+If a section doesn't apply to a component (such as a component not exposing
 any debug information), the section should still be included, with a sentence
-explicitly documenting that it does not apply to a component. For example:
+explicitly documenting that it doesn't apply to a component. For example:
 
 ```markdown
 ## Debug information
 
-`COMPONENT_NAME` does not expose any component-specific debug information.
+`COMPONENT_NAME` doesn't expose any component-specific debug information.
 ```
 
 Always including the headers removes as much guesswork as possible from
 readers, so they know for certain that there is no debug information, rather
 than assuming it must not exist if it's not documented.
 
-
-### Title
+### `Title`
 
 The Title section is an `h1` section which provides a brief description of the
 component. The header should be named after the component. For example:
 
 ```markdown
-# local.file
+# `local.file`
 
 `local.file` exposes the contents of a file on disk to other components.
 
@@ -95,31 +110,29 @@ files.
 ```
 
 Use backticks when referring to the component in the body of the Title section,
-but do not use backticks in the header.
+and in the header.
 
 The Title section should be kept high-level and as small as possible. Detailed
-information on component behavior should be kept to [Arguments](#Arguments) and
-[Blocks](#Blocks) sections as appropriate.
+information on component behavior should be kept to [Arguments](#arguments) and
+[Blocks](#blocks) sections as appropriate.
+
+If documenting an experimental component, include the following:
+
+```markdown
+{{< docs/shared lookup="stability/experimental.md" source="alloy" version="<ALLOY_VERSION>" >}}
+```
+
+If documenting a public preview component, include the following:
+
+```markdown
+{{< docs/shared lookup="stability/public_preview.md" source="alloy" version="<ALLOY_VERSION>" >}}
+```
 
 If your component supports labels, add the following as the last paragraph of
 the Title section:
 
 ```markdown
-Multiple `COMPONENT_NAME` components can be specified by giving them different
-labels.
-```
-
-If documenting a beta component, include the following after the header, but
-before the description of the component:
-
-```markdown
-{{< docs/shared lookup="stability/beta.md" source="alloy" version="<ALLOY_VERSION>" >}}
-```
-
-If documenting an experimental component, include the following instead:
-
-```markdown
-{{< docs/shared lookup="stability/experimental.md" source="alloy" version="<ALLOY_VERSION>" >}}
+You can specify multiple `COMPONENT_NAME` components by giving them different labels.
 ```
 
 ### Usage
@@ -130,16 +143,16 @@ and blocks to configure a component.
 It starts with an `h2` header called Usage.
 
 The Usage section should be composed of a single Alloy code block, with no
-description. Use `YELLING_SNAKE_CASE` to refer to values the user must replace.
+description. Use `<YELLING_SNAKE_CASE>` to refer to values the user must replace.
 For example:
 
 ````markdown
 ## Usage
 
 ```alloy
-pyroscope.scrape "LABEL" {
-  targets    = TARGET_LIST
-  forward_to = RECEIVER_LIST
+pyroscope.scrape "<LABEL>" {
+  targets    = <TARGET_LIST>
+  forward_to = <RECEIVER_LIST>
 }
 ```
 ````
@@ -150,12 +163,11 @@ The Arguments section details the set of arguments the component supports,
 followed by a detailed descriptions of how the arguments modify the component
 behavior. The section starts with an `h2` header called Arguments.
 
-If the component does not support any arguments, and is only configured through
+If the component doesn't support any arguments, and is only configured through
 blocks, the content of the section should be the following paragraph:
 
 ```markdown
-The `COMPONENT_NAME` component does not support any arguments, and is configured
-fully through child blocks.
+The `COMPONENT_NAME` component doesn't support any arguments. You can configure this component with blocks.
 ```
 
 When arguments are supported by the component, the set of arguments should be
@@ -169,29 +181,28 @@ listed using a Markdown table, with the following columns:
 | Default     | Default value for the argument.   |
 | Required    | Whether the argument is required. |
 
-A paragraph with the content "The following arguments are supported:" should
+Sort the table rows alphabetically, required first, then optional.
+
+A paragraph with the content "You can use the following arguments with `COMPONENT_NAME`:" should
 always prefix the arguments table.
 
 For example:
 
 ```markdown
-The following arguments are supported:
+You can use the following arguments with `COMPONENT_NAME`:
 
 Name             | Type       | Description                            | Default      | Required |
 ---------------- | ---------- | -------------------------------------- | ------------ | -------- |
 `filename`       | `string`   | Path of the file on disk to watch.     |              | yes      |
 `detector`       | `string`   | Which file change detector to use.     | `"fsnotify"` | no       |
-`poll_frequency` | `duration` | How often to poll for file changes.    | `"1m"`       | no       |
 `is_secret`      | `bool`     | Marks the file as containing a secret. | `false`      | no       |
+`poll_frequency` | `duration` | How often to poll for file changes.    | `"1m"`       | no       |
 ```
 
-Values for the Name column should be the backticked argument name, such as ``
-`targets` ``.
+Values for the Name column should be the backticked argument name, such as `` `targets` ``.
 
-Values for the Type column should be the backticked Alloy syntax type (for example,
-`string`, `bool`, `number`). Arrays should be represented as
-`list(INNER_TYPE)`, and dictionaries should be represented as
-`map(VALUE_TYPE)`.
+Values for the Type column should be the backticked Alloy syntax type (for example, `string`, `bool`, `number`).
+Arrays should be represented as `list(INNER_TYPE)`, and dictionaries should be represented as `map(VALUE_TYPE)`.
 
 In addition to the known types, the following are excepted as convention:
 
@@ -215,20 +226,17 @@ The set of documented attributes should only contain attributes in the root
 block of the component. The list of supported blocks and the list of attributes
 for those blocks are documented in other sections.
 
-It is not required for cells in the Markdown table to be aligned with
-whitespace.
-
 A detailed description of component behavior and how arguments affect that
 component behavior should follow the arguments table. To refer to an argument,
 use ``The `ARGUMENT_NAME` argument`` to make it extremely clear what you're
 referring to.
 
-Descriptions for component behavior should be limited to what is directly
+Descriptions for component behavior should be limited to what's directly
 relevant to the arguments. If there is component behavior relevant to a
 specific block, describe that component behavior in the documentation section
 for that block instead.
 
-It is acceptable to provide configuration snippets for the arguments if it aids
+It's acceptable to provide configuration snippets for the arguments if it aids
 documentation.
 
 ### Blocks
@@ -236,12 +244,11 @@ documentation.
 The Blocks section details the hierarchy of blocks the component supports. The
 section starts with an `h2` header called Blocks.
 
-If the component does not support any blocks, the content of the section should
+If the component doesn't support any blocks, the content of the section should
 be the following paragraph:
 
 ```markdown
-The `COMPONENT_NAME` component does not support any blocks, and is configured
-fully through arguments.
+The `COMPONENT_NAME` component does not support any blocks. You can configure this component with arguments.
 ```
 
 When blocks are supported by the component, the set of blocks should be listed
@@ -254,30 +261,33 @@ using a Markdown table, with the following columns:
 | Description | Block description.                |
 | Required    | Whether the block is required.    |
 
+Sort the table rows alphabetically, required first, then optional.
+
+A paragraph with the content "You can use the following blocks with `COMPONENT_NAME`:" should
+always prefix the blocks table.
+
 For example:
 
 ```markdown
-The following blocks are supported:
+You can use the following blocks with `COMPONENT_NAME`:
 
-Hierarchy                    | Block             | Description                        | Required |
----------------------------- | ----------------- | ---------------------------------- | -------- |
-client                       | [client][]        | HTTP client settings.              | no       |
-client > basic_auth          | [basic_auth][]    | Basic authentication settings.     | no       |
-client > authorization       | [authorization][] | Generic authentication settings.   | no       |
-client > oauth2              | [oauth2][]        | OAuth 2.0 authentication settings. | no       |
-client > oauth2 > tls_config | [tls_config][]    | TLS settings for OAuth 2.0.        | no       |
-client > tls_config          | [tls_config][]    | TLS settings the HTTP client.      | no       |
+| Block                                            | Description                        | Required |
+| ------------------------------------------------ | ---------------------------------- | -------- |
+| [`client`][client]                               | HTTP client settings.              | no       |
+| `client` > [`basic_auth`][basic_auth]            | Basic authentication settings.     | no       |
+| `client` > [`authorization`][authorization]      | Generic authentication settings.   | no       |
+| `client` > [`oauth2`][oauth2]                    | OAuth 2.0 authentication settings. | no       |
+| `client` > `oauth2` > [`tls_config`][tls_config] | TLS settings for OAuth 2.0.        | no       |
+| `client` > [`tls_config`][tls_config]            | TLS settings the HTTP client.      | no       |
 ```
 
-Values for the Hierarchy column should be the path to the block from the
-component. Use the `>` character to represent nested blocks. Do not surround
-the value in backticks, as it looks strange when rendered to the table.
+Use the > character to represent nested blocks.
 
 Values for the Block column should contain a link to the header in the same
-documentation page which describes the block. **Do not** link to another
-component page that happens to have the same block; prefer re-documenting
+documentation page which describes the block. **Don't** link to another
+component page that happens to have the same block. Prefer re-documenting
 blocks and being explicit instead of having users jump around. Use the
-[`docs/shared` shortcode][docs-shared] to de-duplicate block definitions across
+[`docs/shared` shortcode][docs-shared] to deduplicate block definitions across
 multiple components.
 
 Values for the Description column should be kept as short as possible to keep
@@ -287,26 +297,22 @@ ending them in periods.
 Values for the Required column should be the text "yes" (for required blocks)
 or "no" (for optional blocks).
 
-If nested blocks are used in the blocks table (like `client > basic_auth` in
-the example), a description of what the `>` symbol means should be included in
+If nested blocks are used in the blocks table (like `client` > `basic_auth` in
+the example), a description of what the > symbol means should be included in
 the following paragraph after the block table:
 
 ```markdown
-The `>` symbol indicates deeper levels of nesting. For example,
-`PARENT_BLOCK > CHILD_BLOCK` refers to a `CHILD_BLOCK` block defined inside
-an `PARENT_BLOCK` block.
+The `>` symbol indicates deeper levels of nesting.
+For example, `PARENT_BLOCK` > `CHILD_BLOCK` refers to a `CHILD_BLOCK` block defined inside a `PARENT_BLOCK` block.
 ```
 
 When including this paragraph, replace `PARENT_BLOCK` and `CHILD_BLOCK` with
 block names from your component to provide a concrete example of what the
 hierarchy represents.
 
-A paragraph with the content "The following blocks are supported:" should
-always prefix the blocks table.
-
 A set of sub-sections for each defined block should follow the Blocks section.
 Each unique block type will only have one Block section, regardless of how many
-times that block type appears in the blocks table. See [Block section](#block-section)
+times that block type appears in the blocks table. Refer to [Block section](#block-section)
 for a description on these sections.
 
 [docs-shared]: https://grafana.com/docs/writers-toolkit/writing-guide/reuse-shared-content/
@@ -317,24 +323,25 @@ The Block section is a sub-section of Blocks describing an individual block
 supported by a component. There is one Block section per recognized block type
 within the component.
 
-The Block section starts with an `h3` header with the name of the block,
-followed by the word "block." Do not surround the name of the block in
-backticks in the header.
+The Block section starts with an `h3` header with the name of the block.
+Use backticks around the name of the block in the header.
 
-Block sections are similar to Arguments section, where it is composed of:
+Block sections are similar to Arguments section, where it's composed of:
 
 1. A brief description of the block.
 2. A table of arguments supported by the block.
 3. Detailed description for how that block impacts component behavior, and how
    the block's arguments can be used to modify that behavior.
 
-See [Arguments](#arguments) for a description of how to write the arguments
+Where possible, document the block sections in the same order as given in the blocks table.
+
+Refer to [Arguments](#arguments) for a description of how to write the arguments
 table and block-level descriptions following that table.
 
 For example:
 
 ```markdown
-### tls block
+### `tls`
 
 The `tls` block configures TLS settings used when connecting to the server. If
 the `tls` block isn't provided, connections to the server are unencrypted.
@@ -345,11 +352,11 @@ Name              | Type       | Description                                    
 ----------------- | ---------- | ------------------------------------------------------------- | ------- | -------- |
 `ca_file`         | `string`   | Path to the CA file.                                          |         | no       |
 `cert_file`       | `string`   | Path to the TLS certificate.                                  |         | no       |
-`key_file`        | `string`   | Path to the TLS certificate key.                              |         | no       |
-`min_version`     | `string`   | Minimum acceptable TLS version for connections.               |         | no       |
-`max_version`     | `string`   | Maximum acceptable TLS version for connections.               |         | no       |
-`reload_interval` | `duration` | Frequency to reload the certificates.                         |         | no       |
 `client_ca_file`  | `string`   | Path to the CA file used to authenticate client certificates. |         | no       |
+`key_file`        | `string`   | Path to the TLS certificate key.                              |         | no       |
+`max_version`     | `string`   | Maximum acceptable TLS version for connections.               |         | no       |
+`min_version`     | `string`   | Minimum acceptable TLS version for connections.               |         | no       |
+`reload_interval` | `duration` | Frequency to reload the certificates.                         |         | no       |
 
 Default values for the `min_version` and `max_version` arguments are inherited
 from Go, currently TLS 1.2 and TLS 1.3 respectively. When these arguments are
@@ -357,7 +364,7 @@ not provided, their Go-inherited defaults will not display in the component UI
 page.
 ```
 
-It is acceptable for block sections to provide configuration snippets for the
+It's acceptable for block sections to provide configuration snippets for the
 block if it aids documentation.
 
 ### Exported fields
@@ -365,21 +372,21 @@ block if it aids documentation.
 The Exported fields section details a list of fields which the component
 exports. The section starts with an `h2` header called Exported fields.
 
-If the component does not export any fields, the content of the section should
+If the component doesn't export any fields, the content of the section should
 be the following paragraph:
 
 ```markdown
-The `COMPONENT_NAME` component does not export any values.
+The `COMPONENT_NAME` component doesn't export any values.
 ```
 
 When the component exports values, it should provide a table of exported values
 with the following columns:
 
-| Column      | Description                       |
-| ----------- | --------------------------------- |
-| Name        | Name of exported value.           |
-| Type        | Alloy syntax type of exported value.     |
-| Description | Description of exported value.    |
+| Column      | Description                          |
+| ----------- | ------------------------------------ |
+| Name        | Name of exported value.              |
+| Type        | Alloy syntax type of exported value. |
+| Description | Description of exported value.       |
 
 Values for the Name column should be the backticked exported field name, such
 as `` `targets` ``.
@@ -403,12 +410,11 @@ fields may be provided, but this normally isn't done.
 The Component health section describes when the component is healthy. The
 section starts with an `h2` header called Component health.
 
-If the component does not have special health logic, the content of the section
+If the component doesn't have special health logic, the content of the section
 should be the following paragraph:
 
 ```markdown
-`COMPONENT_NAME` is only reported as unhealthy if given an invalid
-configuration.
+`COMPONENT_NAME` is only reported as unhealthy if given an invalid configuration.
 ```
 
 Otherwise, write a detailed description for when the component is reported as
@@ -420,15 +426,15 @@ The Debug information section describes debug information exposed in the
 Grafana Alloy UI. The section starts with an `h2` header called Debug
 information.
 
-If the component does not expose any debug information, the content of the
+If the component doesn't expose any debug information, the content of the
 section should be the following paragraph:
 
 ```markdown
-`COMPONENT_NAME` does not expose any component-specific debug information.
+`COMPONENT_NAME` doesn't expose any component-specific debug information.
 ```
 
 Otherwise, write a high-level description for what debug information the
-component provides. Do not document the attributes or blocks which are exposed
+component provides. Don't document the attributes or blocks which are exposed
 through the debug information.
 
 ### Debug metrics
@@ -436,11 +442,11 @@ through the debug information.
 The Debug metrics section describes what Prometheus metrics are exposed by a
 component. The section starts with an `h2` header called Debug metrics.
 
-If the component does not expose any debug metrics, the content of the section
+If the component doesn't expose any debug metrics, the content of the section
 should be the following paragraph:
 
 ```markdown
-`COMPONENT_NAME` does not expose any component-specific debug metrics.
+`COMPONENT_NAME` doesn't expose any component-specific debug metrics.
 ```
 
 When the component exports values, it should provide a table of exposed metrics
@@ -488,7 +494,7 @@ the set of scrape targets:
 
 ```alloy
 remote.http "targets" {
-  url = TARGETS_URL
+  url = <TARGETS_URL>
 }
 
 prometheus.scrape "default" {
@@ -498,22 +504,24 @@ prometheus.scrape "default" {
 
 prometheus.remote_write "default" {
   client {
-    url = PROMETHEUS_URL
+    url = <PROMETHEUS_URL>
   }
 }
 ```
 Replace the following:
-  - `TARGETS_URL`: The URL to fetch the JSON array of objects from.
-  - `PROMETHEUS_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
+  - `<TARGETS_URL>`: The URL to fetch the JSON array of objects from.
+  - `<PROMETHEUS_URL>`: The URL of the Prometheus remote_write-compatible server to send metrics to.
 ````
 
 Each example should be a full pipeline when possible, rather than just the
 individual component being documented.
 
-Placeholders should follow the [Google style guide](https://developers.google.com/style/placeholders#placeholder-text), where they are
-written in all uppercase and underscore delimited, for example: `API_URL`.
+Placeholder variables should follow the [Writer's Toolkit](https://grafana.com/docs/writers-toolkit/write/style-guide/write-for-developers/#placeholder-variables) guidelines, where:
 
-Examples of the new component should avoid using placeholders and instead use
+* Placeholder variables in code blocks are written as `` `<PLACEHOLDER>` ``
+* Placeholder variables in the text are written as ``_`<PLACEHOLDER>`_``
+
+Examples of the new component should avoid using placeholder variables and instead use
 realistic example values. For example, if documenting a `prometheus.scrape` component, use:
 
   ```grafana-alloy
@@ -522,28 +530,28 @@ realistic example values. For example, if documenting a `prometheus.scrape` comp
   }
   ```
 
-If an example includes a placeholder, make sure to include a brief description
-of what the placeholder is. For example:
+If an example includes a placeholder variable, make sure to include a brief description
+of what the placeholder variable is. For example:
 
 ```markdown
-Replace `API_URL` with the URL of the API to query.
+Replace _`<API_URL>`_ with the URL of the API to query.
 ```
 
 or if there are multiple placeholders:
 
 ````markdown
 Replace the following:
-  - `API_URL`: The URL of the API to query.
-  - `API_KEY`: The API key to use when querying the API.
+* _`<API_URL>`_: The URL of the API to query.
+* _`<API_KEY>`_: The API key to use when querying the API.
 ````
 
 If an example includes clarifying comments, make sure that the relevant
 Arguments or block header includes sufficient explanation to be the official
 source for the clarifying comment. Clarifying comments must only be used be
-supplementary information to reenforce knowledge, and not as the primary source
+supplementary information to re-enforce knowledge, and not as the primary source
 of information.
 
-Examples should be formatted using the [alloy fmt](https://grafana.com/docs/alloy/latest/reference/cli/fmt/) command.
+Examples should be formatted using the [`alloy fmt`](https://grafana.com/docs/alloy/latest/reference/cli/fmt/) command.
 
 ## Exceptions
 
@@ -551,22 +559,22 @@ The rules described in this page should be sufficient in most cases for being
 able to write detailed documentation.
 
 However, there have been some cases where the page structure needed to be
-changed to properly document a component. The following sections will describe
+changed to properly document a component. The following sections describe
 some instances where exceptions had to be made.
 
-### loki.source.podlogs
+### `loki.source.podlogs`
 
-The [loki.source.podlogs][] component documentation needed to add an extra
-section to document the PodLogs CRD, since we do not yet have a way of
+The [`loki.source.podlogs`][loki.source.podlogs] component documentation needed to add an extra
+section to document the PodLogs CRD, since we don't yet have a way of
 documenting auxiliary artifacts which are related to a component.
 
-### otelcol.processor.transform
+### `otelcol.processor.transform`
 
-The [otelcol.processor.transform][] component documentation needed to add
+The [`otelcol.processor.transform`][otelcol.processor.transform] component documentation needed to add
 an extra section about OTTL Contexts because there is no appropriate OTEL docs page
 that we could link to. Currently this information is housed on the [transformprocessor][]
-doc page, but because it contains yaml config for the Collector, users might get confused
-how this maps to Alloy and it is better not to link to it. In the future we could try to
+doc page, but because it contains YAML config for the Collector, users might get confused
+how this maps to Alloy and it's better not to link to it. In the future we could try to
 move this information from [transformprocessor][] to the [OTTL Context][ottl context] doc.
 
 [loki.source.podlogs]: ../sources/reference/components/loki.source.podlogs.md

--- a/docs/developer/writing-component-documentation.md
+++ b/docs/developer/writing-component-documentation.md
@@ -181,7 +181,7 @@ listed using a Markdown table, with the following columns:
 | Default     | Default value for the argument.   |
 | Required    | Whether the argument is required. |
 
-Sort the table rows alphabetically, required first, then optional.
+If possible, sort the table rows alphabetically, required first, then optional.
 
 A paragraph with the content "You can use the following arguments with `COMPONENT_NAME`:" should
 always prefix the arguments table.
@@ -261,7 +261,7 @@ using a Markdown table, with the following columns:
 | Description | Block description.                |
 | Required    | Whether the block is required.    |
 
-Sort the table rows alphabetically, required first, then optional.
+If possible, sort the table rows alphabetically, required first, then optional.
 
 A paragraph with the content "You can use the following blocks with `COMPONENT_NAME`:" should
 always prefix the blocks table.


### PR DESCRIPTION
The styles and markdown used in the Alloy component documentation has evolved and changed compared to the guidelines given in the `writing-component-documentation.md` topic.  This PR makes a few updates to this, adding in the new labels, updated stability includes, and general markdown updates.

Fixes: #2469 