### PR TITLE
Use v2 of publishing workflow that checks out HEAD of version branch on tag events

### DIFF
--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: grafana/writers-toolkit/publish-technical-documentation-release@publish-technical-documentation-release/v2 # zizmor: ignore[unpinned-uses]
+      - uses: grafana/writers-toolkit/publish-technical-documentation-release@8cc658b604c6e05c275af30163a1c7728dfe19b2 # publish-technical-documentation-release/v2
         # This internal action's version is left as a tag instead of a pinned hash because renovate
         # does not support this type of tag/version format without custom configuration.
         with:

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -29,8 +29,8 @@ jobs:
         # This internal action's version is left as a tag instead of a pinned hash because renovate
         # does not support this type of tag/version format without custom configuration.
         with:
-          release_tag_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
-          release_branch_regexp: "^release/v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
-          release_branch_with_patch_regexp: "^release/v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
+          release_tag_regexp: "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+          release_branch_regexp: "^release/v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+          release_branch_with_patch_regexp: "^release/v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
           website_directory: content/docs/alloy
           version_suffix: ""

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: grafana/writers-toolkit/publish-technical-documentation-release@d83ba5389fb8de1458b12bcc35ad4a4059883029 # publish-technical-documentation-release/v1 # zizmor: ignore[unpinned-uses]
+      - uses: grafana/writers-toolkit/publish-technical-documentation-release@publish-technical-documentation-release/v2 # zizmor: ignore[unpinned-uses]
         # This internal action's version is left as a tag instead of a pinned hash because renovate
         # does not support this type of tag/version format without custom configuration.
         with:


### PR DESCRIPTION
This uses a script check in the first step of tag events that switches the checkout to the version branch that the tag refers to: https://github.com/grafana/writers-toolkit/blob/main/publish-technical-documentation-release/determine-release-branch.

Implemented in:

- grafana/writers-toolkit@305f989
- grafana/writers-toolkit@541fb6e

Because the script uses Bash regular expression pattern matching, inputs must use Extended Regular Expression syntax.