### PR TITLE
Update aws_firehose collector to use CW event timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Main (unreleased)
 
 - Add `hash_string_id` argument to `foreach` block to hash the string representation of the pipeline id instead of using the string itself. (@wildum)
 
+### Bugfixes
+
+- Fix `loki.source.firehose` to propagate specific cloudwatch event timestamps when useIncomingTs is set to true. (@michaelPotter)
+
 v1.9.0
 -----------------
 

--- a/internal/component/loki/source/aws_firehose/internal/handler.go
+++ b/internal/component/loki/source/aws_firehose/internal/handler.go
@@ -275,7 +275,7 @@ func (h *Handler) handleCloudwatchLogsRecord(ctx context.Context, data []byte, c
 
 	for _, event := range cwRecord.LogEvents {
 		if h.useIncomingTs {
-			timestamp = time.Unix(event.Timestamp/millisecondsPerSecond, 0)
+			timestamp = time.UnixMilli(event.Timestamp)
 		}
 		h.sender.Send(ctx, loki.Entry{
 			Labels: h.postProcessLabels(cwLogsLabels.Labels()),

--- a/internal/component/loki/source/aws_firehose/internal/handler.go
+++ b/internal/component/loki/source/aws_firehose/internal/handler.go
@@ -274,6 +274,9 @@ func (h *Handler) handleCloudwatchLogsRecord(ctx context.Context, data []byte, c
 	cwLogsLabels.Set("__aws_cw_msg_type", cwRecord.MessageType)
 
 	for _, event := range cwRecord.LogEvents {
+		if h.useIncomingTs {
+			timestamp = time.Unix(event.Timestamp/millisecondsPerSecond, 0)
+		}
 		h.sender.Send(ctx, loki.Entry{
 			Labels: h.postProcessLabels(cwLogsLabels.Labels()),
 			Entry: logproto.Entry{

--- a/internal/component/loki/source/aws_firehose/internal/handler_test.go
+++ b/internal/component/loki/source/aws_firehose/internal/handler_test.go
@@ -36,6 +36,24 @@ const (
 //go:embed testdata/*
 var testData embed.FS
 
+// These timestamps line up with the log entries in the testdata/cw_logs_mixed.json file.
+var cwLogsTimestamps = []int64{
+	1684423980083,
+	1684424003641,
+	1684424003820,
+	1684424003822,
+	1684424003859,
+	1684424003859,
+	1684424005707,
+	1684424005708,
+	1684424005718,
+	1684424005718,
+	1684424007492,
+	1684424007493,
+	1684424007494,
+	1684424007494,
+}
+
 func readTestData(t *testing.T, name string) string {
 	f, err := testData.ReadFile(name)
 	if err != nil {
@@ -196,8 +214,8 @@ func TestHandler(t *testing.T) {
 				require.Equal(t, "86208cf6-2bcc-47e6-9010-02ca9f44a025", r.RequestID)
 
 				require.Len(t, entries, 14)
-				expectedTimestamp := time.Unix(cwRequestTimestamp/1000, 0)
-				for _, e := range entries {
+				for i, e := range entries {
+					var expectedTimestamp = time.Unix(cwLogsTimestamps[i]/1000, 0)
 					require.Equal(t, expectedTimestamp, e.Timestamp, "timestamp is other than expected")
 				}
 			},

--- a/internal/component/loki/source/aws_firehose/internal/handler_test.go
+++ b/internal/component/loki/source/aws_firehose/internal/handler_test.go
@@ -215,7 +215,7 @@ func TestHandler(t *testing.T) {
 
 				require.Len(t, entries, 14)
 				for i, e := range entries {
-					var expectedTimestamp = time.Unix(cwLogsTimestamps[i]/1000, 0)
+					var expectedTimestamp = time.UnixMilli(cwLogsTimestamps[i])
 					require.Equal(t, expectedTimestamp, e.Timestamp, "timestamp is other than expected")
 				}
 			},


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Currently, if the `useIncomingTS` flag is set to true, the timestamps of all incoming log entries are set to the timestamp provided in the firehose envelope. This timestamp represents the moment when AWS Firehose shipped a batch of log entries rather than the timestamp of the individual entries themselves.

This change updates the loki.aws_firehose collector to now use the timestamps attached to specific log entries (when processing cloudwatch logs-subscription data) instead. For direct put data, where entry-specific timestamps are not guaranteed, the timestamp attached to the firehose wrapper is still used.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #1460 

#### Notes to the Reviewer

In my opinion this is a more expected behavior of the useIncomingTs flag, but I am open to feedback if there's a preferred way to attach the event timestamps (e.g. another config flag or use of labels as suggested in the issue).

Thanks for your time!

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Tests updated

