### PR TITLE
ci: stop using windows-2019 runners

### DIFF
--- a/.github/workflows/check-windows-build-image.yml
+++ b/.github/workflows/check-windows-build-image.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   check-windows-build-image:
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/publish-alloy-windows.yml
+++ b/.github/workflows/publish-alloy-windows.yml
@@ -24,7 +24,7 @@ jobs:
     name: Publish Alloy Windows container
     strategy:
       matrix:
-        os: [windows-2022, windows-2019]
+        os: [windows-2022, windows-2025]
     runs-on: ${{ matrix.os }}
     steps:
       # This step needs to run before "Checkout code".


### PR DESCRIPTION
The windows-2019 runners are deprecated as of 2025-06-01 and will be fully unsupported by 2025-06-30. There will be multiple brown-outs over the course of this month which might affect builds and releases unless we remove those runners.

See https://github.com/actions/runner-images/issues/12045 for details.