### PR TITLE
Use alloybot to run backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,10 +14,10 @@ permissions:
 jobs:
   main:
     runs-on: ubuntu-latest
+    # These permissions are needed to assume roles from Github's OIDC.
     permissions:
       contents: read
-      issues: write
-      pull-requests: write
+      id-token: write
     steps:
       - name: Checkout Actions
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -30,9 +30,31 @@ jobs:
           persist-credentials: false
       - name: Install Actions
         run: npm install --production --prefix ./actions
+      - id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@5d7e361bc7e0a183cde8afe9899fb7b596d2659b # get-vault-secrets-v1.2.0
+        with:
+          repo_secrets: |
+            ALLOYBOT_APP_ID=alloybot:app_id
+            ALLOYBOT_PRIVATE_KEY=alloybot:private_key
+          export_env: false
+      
+      - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        id: app-token
+        with:
+          app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).ALLOYBOT_APP_ID }}
+          private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).ALLOYBOT_PRIVATE_KEY }}
+          owner: grafana
+          repositories: alloy
+
+      # These need to be hard-coded to the bot being used; ideally in the future
+      # we can find a way to automatically determine this based on the token.
+      - name: Setup Git
+        run: |
+          git config --global user.name "grafana-alloybot[bot]"
+          git config --global user.email "879451+grafana-alloybot[bot]@users.noreply.github.com"
       - name: Run backport
         uses: ./actions/backport
         with:
-          token: ${{secrets.GITHUB_TOKEN}}
+          token: ${{ steps.app-token.outputs.token }}
           labelsToAdd: "backport"
           title: "[{{base}}] {{originalTitle}}"


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
I believe this will fix the backport workflow, by utilizing the alloybot to run the backport action. The steps are copied from the bump-formula-pr workflow, and should enable the backports for PRs created on the main grafana repo. 

Backport for community contributions will have to be done manually (unless we imitate the pattern in grafana/grafana, but let's fix this first)
