### PR TITLE
Add unit tests for remote.kubernetes components

### DIFF
--- a/internal/component/remote/kubernetes/client_builder.go
+++ b/internal/component/remote/kubernetes/client_builder.go
@@ -1,0 +1,31 @@
+package kubernetes
+
+import (
+	"fmt"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/alloy/internal/component/common/kubernetes"
+	client_go "k8s.io/client-go/kubernetes"
+)
+
+type ClientBuidler interface {
+	GetKubernetesClient(log.Logger, *kubernetes.ClientArguments) (client_go.Interface, error)
+}
+
+type RestClientBuidler struct{}
+
+func (b RestClientBuidler) GetKubernetesClient(log log.Logger,
+	clientArgs *kubernetes.ClientArguments) (client_go.Interface, error) {
+
+	restConfig, err := clientArgs.BuildRESTConfig(log)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := client_go.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("creating kubernetes client: %w", err)
+	}
+
+	return client, nil
+}

--- a/internal/component/remote/kubernetes/configmap/configmap_test.go
+++ b/internal/component/remote/kubernetes/configmap/configmap_test.go
@@ -1,0 +1,46 @@
+package configmap
+
+import (
+	"testing"
+
+	"github.com/grafana/alloy/internal/component/remote/kubernetes"
+	"github.com/grafana/alloy/internal/component/remote/kubernetes/internal/test_util"
+	"github.com/grafana/alloy/syntax/alloytypes"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func Test(t *testing.T) {
+	tester := test_util.Tester{
+		T:             t,
+		ComponentName: "remote.kubernetes.configmap",
+		ComponentCfg: `
+			namespace = "testNamespace"
+			name = "testConfigMapName"`,
+		KubeObjects: []runtime.Object{
+			&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testConfigMapName",
+					Namespace: "testNamespace",
+					Labels: map[string]string{
+						"label1": "value1",
+					},
+				},
+				Data: map[string]string{
+					"test.txt": "random json",
+				},
+			},
+		},
+		Expected: kubernetes.Exports{
+			Data: map[string]alloytypes.OptionalSecret{
+				"test.txt": {
+					IsSecret: false,
+					Value:    "random json",
+				},
+			},
+		},
+	}
+
+	tester.Test()
+}

--- a/internal/component/remote/kubernetes/internal/test_util/util.go
+++ b/internal/component/remote/kubernetes/internal/test_util/util.go
@@ -1,0 +1,111 @@
+package test_util
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	kubernetes_common "github.com/grafana/alloy/internal/component/common/kubernetes"
+	"github.com/grafana/alloy/internal/component/remote/kubernetes"
+	"github.com/grafana/alloy/internal/runtime/componenttest"
+	"github.com/grafana/alloy/internal/runtime/logging/level"
+	"github.com/grafana/alloy/internal/util"
+	"github.com/grafana/alloy/syntax"
+	"github.com/grafana/dskit/backoff"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	client_go "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+type FakeClientBuidler struct {
+	KubeObjects []runtime.Object
+}
+
+func (b FakeClientBuidler) GetKubernetesClient(_ log.Logger,
+	_ *kubernetes_common.ClientArguments) (client_go.Interface, error) {
+
+	fakeClientset := fake.NewClientset(b.KubeObjects...)
+
+	return fakeClientset, nil
+}
+
+func Eventually(t *testing.T, min, max time.Duration, retries int, f func() error) {
+	t.Helper()
+
+	l := util.TestLogger(t)
+
+	bo := backoff.New(t.Context(), backoff.Config{
+		MinBackoff: min,
+		MaxBackoff: max,
+		MaxRetries: retries,
+	})
+	for bo.Ongoing() {
+		err := f()
+		if err == nil {
+			return
+		}
+
+		level.Error(l).Log("msg", "condition failed", "err", err)
+		bo.Wait()
+		continue
+	}
+
+	require.NoError(t, bo.Err(), "condition failed")
+}
+
+type Tester struct {
+	T             *testing.T
+	ComponentName string
+	ComponentCfg  string
+	KubeObjects   []runtime.Object
+	Expected      kubernetes.Exports
+}
+
+func (t *Tester) Test() {
+	ctx := componenttest.TestContext(t.T)
+
+	ctrl, err := componenttest.NewControllerFromID(util.TestLogger(t.T), t.ComponentName)
+	require.NoError(t.T, err)
+
+	var args kubernetes.Arguments
+	require.NoError(t.T, syntax.Unmarshal([]byte(t.ComponentCfg), &args))
+
+	fakeClientBuidler := FakeClientBuidler{
+		KubeObjects: t.KubeObjects,
+	}
+
+	go func() {
+		component, cleanup, err := ctrl.BuildWithoutRun(ctx, args)
+		require.NoError(t.T, err)
+		defer cleanup()
+
+		cfgMapComponent := component.(*kubernetes.Component)
+		cfgMapComponent.ClientBuidler = &fakeClientBuidler
+
+		err = component.Run(ctx)
+		require.NoError(t.T, err)
+	}()
+
+	require.NoError(t.T, ctrl.WaitRunning(time.Second), "component never started")
+	require.NoError(t.T, ctrl.WaitExports(time.Second), "component never exported anything")
+
+	requireExports := func(expect kubernetes.Exports) {
+		Eventually(t.T, 10*time.Millisecond, 10*time.Second, 5, func() error {
+			actual := ctrl.Exports().(kubernetes.Exports)
+
+			if len(actual.Data) != len(expect.Data) {
+				return fmt.Errorf("expected %#v piece of data, got %#v", len(expect.Data), len(actual.Data))
+			}
+
+			if !reflect.DeepEqual(expect.Data, actual.Data) {
+				return fmt.Errorf("expected %#v, got %#v", expect, actual)
+			}
+			return nil
+		})
+	}
+
+	requireExports(t.Expected)
+}

--- a/internal/component/remote/kubernetes/secret/secret_test.go
+++ b/internal/component/remote/kubernetes/secret/secret_test.go
@@ -1,0 +1,46 @@
+package secret
+
+import (
+	"testing"
+
+	"github.com/grafana/alloy/internal/component/remote/kubernetes"
+	"github.com/grafana/alloy/internal/component/remote/kubernetes/internal/test_util"
+	"github.com/grafana/alloy/syntax/alloytypes"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func Test(t *testing.T) {
+	tester := test_util.Tester{
+		T:             t,
+		ComponentName: "remote.kubernetes.secret",
+		ComponentCfg: `
+			namespace = "testNamespace"
+			name = "testSecretName"`,
+		KubeObjects: []runtime.Object{
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testSecretName",
+					Namespace: "testNamespace",
+					Labels: map[string]string{
+						"label1": "value1",
+					},
+				},
+				Data: map[string][]byte{
+					"test.txt": []byte("random json"),
+				},
+			},
+		},
+		Expected: kubernetes.Exports{
+			Data: map[string]alloytypes.OptionalSecret{
+				"test.txt": {
+					IsSecret: true,
+					Value:    "random json",
+				},
+			},
+		},
+	}
+
+	tester.Test()
+}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Adding unit tests for `remote.kubernetes` components which use a fake K8s to test whether the correct exports are produced.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
