### PR TITLE
remotecfg: add User-Agent header to outgoing requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ v1.10.0-rc.0
 
 - Upgrade `otelcol.exporter.windows` to v0.30.8 to get bugfixes and fix `update` collector support. (@dehaansa)
 
+- Add `User-Agent` header to remotecfg requests. (@tpaschalis)
+
 v1.9.2
 -----------------
 


### PR DESCRIPTION
#### PR Description

This PR reuses the useragent package and adds a gRPC interceptor to decorate remotecfg requests with a User-Agent header.

#### Which issue(s) this PR fixes

No issue filed.

#### Notes to the Reviewer

#### PR Checklist

- [X] CHANGELOG.md updated
- [ ] Documentation added (N/A)
- [ ] Tests updated