### PR TITLE
Add links from Alloy otelcol components to the upstream OTelCol components

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -5,7 +5,7 @@ description: Grafana Alloy is a vendor-neutral distribution of the OTel Collecto
 weight: 350
 cascade:
   ALLOY_RELEASE: v1.10.0
-  OTEL_VERSION: v0.122.0
+  OTEL_VERSION: v0.125.0
   PROM_WIN_EXP_VERSION: v0.30.6
   SNMP_VERSION: v0.29.0
   BEYLA_VERSION: v2.1

--- a/docs/sources/_index.md.t
+++ b/docs/sources/_index.md.t
@@ -5,7 +5,7 @@ description: Grafana Alloy is a vendor-neutral distribution of the OTel Collecto
 weight: 350
 cascade:
   ALLOY_RELEASE: $ALLOY_VERSION
-  OTEL_VERSION: v0.122.0
+  OTEL_VERSION: v0.125.0
   PROM_WIN_EXP_VERSION: v0.30.6
   SNMP_VERSION: v0.29.0
   BEYLA_VERSION: v2.1

--- a/docs/sources/reference/components/otelcol/otelcol.auth.basic.md
+++ b/docs/sources/reference/components/otelcol/otelcol.auth.basic.md
@@ -17,8 +17,10 @@ title: otelcol.auth.basic
 This component supports both server and client authentication.
 
 {{< admonition type="note" >}}
-`otelcol.auth.basic` is a wrapper over the upstream OpenTelemetry Collector `basicauth` extension.
+`otelcol.auth.basic` is a wrapper over the upstream OpenTelemetry Collector [`basicauth`][] extension.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`basicauth`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/extension/basicauthextension
 {{< /admonition >}}
 
 You can specify multiple `otelcol.auth.basic` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.auth.bearer.md
+++ b/docs/sources/reference/components/otelcol/otelcol.auth.bearer.md
@@ -17,8 +17,10 @@ title: otelcol.auth.bearer
 This component supports both server and client authentication.
 
 {{< admonition type="note" >}}
-`otelcol.auth.bearer` is a wrapper over the upstream OpenTelemetry Collector `bearertokenauth` extension.
+`otelcol.auth.bearer` is a wrapper over the upstream OpenTelemetry Collector [`bearertokenauth`][] extension.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`bearertokenauth`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/extension/bearertokenauthextension
 {{< /admonition >}}
 
 You can specify multiple `otelcol.auth.bearer` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.auth.headers.md
+++ b/docs/sources/reference/components/otelcol/otelcol.auth.headers.md
@@ -17,8 +17,10 @@ title: otelcol.auth.headers
 This component only supports client authentication.
 
 {{< admonition type="note" >}}
-`otelcol.auth.headers` is a wrapper over the upstream OpenTelemetry Collector `headerssetter` extension.
+`otelcol.auth.headers` is a wrapper over the upstream OpenTelemetry Collector [`headerssetter`][] extension.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`headerssetter`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/extension/headerssetterextension
 {{< /admonition >}}
 
 You can specify multiple `otelcol.auth.headers` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.auth.oauth2.md
+++ b/docs/sources/reference/components/otelcol/otelcol.auth.oauth2.md
@@ -21,8 +21,10 @@ This component can fetch and refresh expired tokens automatically.
 Refer to the [OAuth 2.0 Authorization Framework](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4) for more information about the Auth 2.0 Client Credentials flow.
 
 {{< admonition type="note" >}}
-`otelcol.auth.oauth2` is a wrapper over the upstream OpenTelemetry Collector `oauth2client` extension.
+`otelcol.auth.oauth2` is a wrapper over the upstream OpenTelemetry Collector [`oauth2client`][] extension.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`oauth2client`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/extension/oauth2clientauthextension
 {{< /admonition >}}
 
 You can specify multiple `otelcol.auth.oauth2` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.auth.sigv4.md
+++ b/docs/sources/reference/components/otelcol/otelcol.auth.sigv4.md
@@ -20,8 +20,10 @@ This component only supports client authentication.
 [Signing AWS API requests]: https://docs.aws.amazon.com/general/latest/gr/signing-aws-api-requests.html
 
 {{< admonition type="note" >}}
-`otelcol.auth.sigv4` is a wrapper over the upstream OpenTelemetry Collector `sigv4auth` extension.
+`otelcol.auth.sigv4` is a wrapper over the upstream OpenTelemetry Collector [`sigv4auth`][] extension.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`sigv4auth`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/extension/sigv4authextension
 {{< /admonition >}}
 
 You can specify multiple `otelcol.auth.sigv4` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.connector.servicegraph.md
+++ b/docs/sources/reference/components/otelcol/otelcol.connector.servicegraph.md
@@ -19,8 +19,10 @@ Those metrics can then be used by a data visualization application, for example,
 [Grafana]: https://grafana.com/docs/grafana/latest/explore/trace-integration/#service-graph
 
 {{< admonition type="note" >}}
-`otelcol.connector.servicegraph` is a wrapper over the upstream OpenTelemetry Collector `servicegraph` connector.
+`otelcol.connector.servicegraph` is a wrapper over the upstream OpenTelemetry Collector [`servicegraph`][] connector.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`servicegraph`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/connector/servicegraphconnector
 {{< /admonition >}}
 
 You can specify multiple `otelcol.connector.servicegraph` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.connector.spanmetrics.md
+++ b/docs/sources/reference/components/otelcol/otelcol.connector.spanmetrics.md
@@ -39,8 +39,10 @@ title: otelcol.connector.spanmetrics
   ```
 
 {{< admonition type="note" >}}
-`otelcol.connector.spanmetrics` is a wrapper over the upstream OpenTelemetry Collector `spanmetrics` connector.
+`otelcol.connector.spanmetrics` is a wrapper over the upstream OpenTelemetry Collector [`spanmetrics`][] connector.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`spanmetrics`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/connector/spanmetricsconnector
 {{< /admonition >}}
 
 You can specify multiple `otelcol.connector.spanmetrics` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.awss3.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.awss3.md
@@ -17,8 +17,10 @@ title: otelcol.exporter.awss3
 `otelcol.exporter.awss3` accepts telemetry data from other `otelcol` components and writes them to an AWS S3 bucket.
 
 {{< admonition type="note" >}}
-`otelcol.exporter.awss3` is a wrapper over the upstream OpenTelemetry Collector Contrib `awss3` exporter.
+`otelcol.exporter.awss3` is a wrapper over the upstream OpenTelemetry Collector [`awss3`][] exporter.
 Bug reports or feature requests will be redirected to the upstream repository if necessary.
+
+[`awss3`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/exporter/awss3exporter
 {{< /admonition >}}
 
 You can specify multiple `otelcol.exporter.awss3` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.datadog.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.datadog.md
@@ -18,8 +18,10 @@ title: otelcol.exporter.datadog
 `otelcol.exporter.datadog` accepts metrics and traces telemetry data from other `otelcol` components and sends it to Datadog.
 
 {{< admonition type="note" >}}
-`otelcol.exporter.datadog` is a wrapper over the upstream OpenTelemetry Collector `datadog` exporter from the `otelcol-contrib`  distribution.
+`otelcol.exporter.datadog` is a wrapper over the upstream OpenTelemetry Collector [`datadog`][] exporter.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`datadog`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/exporter/datadogexporter
 {{< /admonition >}}
 
 You can specify multiple `otelcol.exporter.datadog` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.debug.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.debug.md
@@ -16,8 +16,10 @@ title: otelcol.exporter.debug
 You can control the verbosity of the logs.
 
 {{< admonition type="note" >}}
-`otelcol.exporter.debug` is a wrapper over the upstream OpenTelemetry Collector `debug` exporter.
+`otelcol.exporter.debug` is a wrapper over the upstream OpenTelemetry Collector [`debug`][] exporter.
 If necessary, bug reports or feature requests are redirected to the upstream repository.
+
+[`debug`]: https://github.com/open-telemetry/opentelemetry-collector/tree/{{< param "OTEL_VERSION" >}}/exporter/debugexporter
 {{< /admonition >}}
 
 You can specify multiple `otelcol.exporter.debug` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.googlecloud.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.googlecloud.md
@@ -16,8 +16,10 @@ title: otelcol.exporter.googlecloud
 `otelcol.exporter.googlecloud` accepts metrics, traces, and logs from other `otelcol` components and sends it to Google Cloud.
 
 {{< admonition type="note" >}}
-`otelcol.exporter.googlecloud` is a wrapper over the upstream OpenTelemetry Collector `googlecloud` exporter from the `otelcol-contrib`  distribution.
+`otelcol.exporter.googlecloud` is a wrapper over the upstream OpenTelemetry Collector [`googlecloud`][] exporter.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`googlecloud`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/exporter/googlecloudexporter
 {{< /admonition >}}
 
 You can specify multiple `otelcol.exporter.googlecloud` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.kafka.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.kafka.md
@@ -17,8 +17,10 @@ title: otelcol.exporter.kafka
 It's important to use `otelcol.exporter.kafka` together with `otelcol.processor.batch` to make sure `otelcol.exporter.kafka` doesn't slow down due to sending Kafka a huge number of small payloads.
 
 {{< admonition type="note" >}}
-`otelcol.exporter.kafka` is a wrapper over the upstream OpenTelemetry Collector `kafka` exporter from the `otelcol-contrib`  distribution.
+`otelcol.exporter.kafka` is a wrapper over the upstream OpenTelemetry Collector [`kafka`][] exporter.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`kafka`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/exporter/kafkaexporter
 {{< /admonition >}}
 
 Multiple `otelcol.exporter.kafka` components can be specified by giving them

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.loadbalancing.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.loadbalancing.md
@@ -17,8 +17,10 @@ title: otelcol.exporter.loadbalancing
 `otelcol.exporter.loadbalancing` accepts logs and traces from other `otelcol` components and writes them over the network using the OpenTelemetry Protocol (OTLP) protocol.
 
 {{< admonition type="note" >}}
-`otelcol.exporter.loadbalancing` is a wrapper over the upstream OpenTelemetry Collector `loadbalancing` exporter.
+`otelcol.exporter.loadbalancing` is a wrapper over the upstream OpenTelemetry Collector [`loadbalancing`][] exporter.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`loadbalancing`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/exporter/loadbalancingexporter
 {{< /admonition >}}
 
 You can specify multiple `otelcol.exporter.loadbalancing` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.otlp.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.otlp.md
@@ -15,8 +15,10 @@ title: otelcol.exporter.otlp
 `otelcol.exporter.otlp` accepts telemetry data from other `otelcol` components and writes them over the network using the OTLP gRPC protocol.
 
 {{< admonition type="note" >}}
-`otelcol.exporter.otlp` is a wrapper over the upstream OpenTelemetry Collector `otlp` exporter.
+`otelcol.exporter.otlp` is a wrapper over the upstream OpenTelemetry Collector [`otlp`][] exporter.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`otlp`]: https://github.com/open-telemetry/opentelemetry-collector/tree/{{< param "OTEL_VERSION" >}}/exporter/otlpexporter
 {{< /admonition >}}
 
 You can specify multiple `otelcol.exporter.otlp` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.otlphttp.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.otlphttp.md
@@ -15,8 +15,10 @@ title: otelcol.exporter.otlphttp
 `otelcol.exporter.otlphttp` accepts telemetry data from other `otelcol` components and writes them over the network using the OTLP HTTP protocol.
 
 {{< admonition type="note" >}}
-`otelcol.exporter.otlphttp` is a wrapper over the upstream OpenTelemetry Collector `otlphttp` exporter.
+`otelcol.exporter.otlphttp` is a wrapper over the upstream OpenTelemetry Collector [`otlphttp`][] exporter.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`otlphttp`]: https://github.com/open-telemetry/opentelemetry-collector/tree/{{< param "OTEL_VERSION" >}}/exporter/otlphttpexporter
 {{< /admonition >}}
 
 You can specify multiple `otelcol.exporter.otlphttp` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.splunkhec.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.splunkhec.md
@@ -16,8 +16,10 @@ title: otelcol.exporter.splunkhec
 `otelcol.exporter.splunkhec` accepts metrics and traces telemetry data from other `otelcol` components and sends it to Splunk HEC.
 
 {{< admonition type="note" >}}
-`otelcol.exporter.splunkhec` is a wrapper over the upstream OpenTelemetry Collector `splunkhec` exporter from the `otelcol-contrib`  distribution.
+`otelcol.exporter.splunkhec` is a wrapper over the upstream OpenTelemetry Collector [`splunkhec`][] exporter.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`splunkhec`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/exporter/splunkhecexporter
 {{< /admonition >}}
 
 You can specify multiple `otelcol.exporter.splunkhec` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.syslog.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.syslog.md
@@ -16,8 +16,10 @@ title: otelcol.exporter.syslog
 It supports syslog protocols [RFC5424][] and [RFC3164][] and can send data over `TCP` or `UDP`.
 
 {{< admonition type="note" >}}
-`otelcol.exporter.syslog` is a wrapper over the upstream OpenTelemetry Collector `syslog` exporter.
+`otelcol.exporter.syslog` is a wrapper over the upstream OpenTelemetry Collector [`syslog`][] exporter.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`syslog`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/exporter/syslogexporter
 {{< /admonition >}}
 
 You can specify multiple `otelcol.exporter.syslog` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.extension.jaeger_remote_sampling.md
+++ b/docs/sources/reference/components/otelcol/otelcol.extension.jaeger_remote_sampling.md
@@ -15,8 +15,10 @@ title: otelcol.extension.jaeger_remote_sampling
 `otelcol.extension.jaeger_remote_sampling` serves a specified Jaeger remote sampling document.
 
 {{< admonition type="note" >}}
-`otelcol.extension.jaeger_remote_sampling` is a wrapper over the upstream OpenTelemetry Collector `jaegerremotesampling` extension.
+`otelcol.extension.jaeger_remote_sampling` is a wrapper over the upstream OpenTelemetry Collector [`jaegerremotesampling`][] extension.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`jaegerremotesampling`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/extension/jaegerremotesampling
 {{< /admonition >}}
 
 You can specify multiple `otelcol.extension.jaeger_remote_sampling` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.processor.attributes.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.attributes.md
@@ -16,8 +16,10 @@ title: otelcol.processor.attributes
 It also supports the ability to filter and match input data to determine if it should be included or excluded for attribute modifications.
 
 {{< admonition type="note" >}}
-`otelcol.processor.attributes` is a wrapper over the upstream OpenTelemetry Collector `attributes` processor.
+`otelcol.processor.attributes` is a wrapper over the upstream OpenTelemetry Collector [`attributes`][] processor.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`attributes`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/processor/attributesprocessor
 {{< /admonition >}}
 
 You can specify multiple `otelcol.processor.attributes` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.processor.batch.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.batch.md
@@ -21,8 +21,10 @@ The batch processor should be defined in the pipeline after the `otelcol.process
 This is because batching should happen after any data drops such as sampling.
 
 {{< admonition type="note" >}}
-`otelcol.processor.batch` is a wrapper over the upstream OpenTelemetry Collector `batch` processor.
+`otelcol.processor.batch` is a wrapper over the upstream OpenTelemetry Collector [`batch`][] processor.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`batch`]: https://github.com/open-telemetry/opentelemetry-collector/tree/{{< param "OTEL_VERSION" >}}/processor/batchprocessor
 {{< /admonition >}}
 
 You can specify multiple `otelcol.processor.batch` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.processor.cumulativetodelta.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.cumulativetodelta.md
@@ -17,8 +17,10 @@ title: otelcol.processor.cumulativetodelta
 `otelcol.processor.cumulativetodelta` accepts metrics from other `otelcol` components and converts metrics with the cumulative temporality to delta.
 
 {{< admonition type="note" >}}
-`otelcol.processor.cumulativetodelta` is a wrapper over the upstream OpenTelemetry Collector `cumulativetodelta` processor.
+`otelcol.processor.cumulativetodelta` is a wrapper over the upstream OpenTelemetry Collector [`cumulativetodelta`][] processor.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`cumulativetodelta`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/processor/cumulativetodeltaprocessor
 {{< /admonition >}}
 
 You can specify multiple `otelcol.processor.cumulativetodelta` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.processor.deltatocumulative.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.deltatocumulative.md
@@ -17,8 +17,10 @@ title: otelcol.processor.deltatocumulative
 `otelcol.processor.deltatocumulative` accepts metrics from other `otelcol` components and converts metrics with the delta temporality to cumulative.
 
 {{< admonition type="note" >}}
-`otelcol.processor.deltatocumulative` is a wrapper over the upstream OpenTelemetry Collector `deltatocumulative` processor.
+`otelcol.processor.deltatocumulative` is a wrapper over the upstream OpenTelemetry Collector [`deltatocumulative`][] processor.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`deltatocumulative`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/processor/deltatocumulativeprocessor
 {{< /admonition >}}
 
 You can specify multiple `otelcol.processor.deltatocumulative` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.processor.filter.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.filter.md
@@ -43,8 +43,10 @@ For example, the OTTL statement `attributes["grpc"] == true` is written in {{< p
 {{< /admonition >}}
 
 {{< admonition type="note" >}}
-`otelcol.processor.filter` is a wrapper over the upstream OpenTelemetry Collector `filter` processor.
+`otelcol.processor.filter` is a wrapper over the upstream OpenTelemetry Collector [`filter`][] processor.
 If necessary, bug reports or feature requests will be redirected to the upstream repository.
+
+[`filter`]: https://github.com/open-telemetry/opentelemetry-collector/tree/{{< param "OTEL_VERSION" >}}/filter
 {{< /admonition >}}
 
 You can specify multiple `otelcol.processor.filter` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.processor.groupbyattrs.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.groupbyattrs.md
@@ -13,8 +13,10 @@ title: otelcol.processor.groupbyattrs
 `otelcol.processor.groupbyattrs` accepts spans, metrics, and traces from other `otelcol` components and groups them under the same resource.
 
 {{< admonition type="note" >}}
-`otelcol.processor.groupbyattrs` is a wrapper over the upstream OpenTelemetry Collector `groupbyattrs` processor.
+`otelcol.processor.groupbyattrs` is a wrapper over the upstream OpenTelemetry Collector [`groupbyattrs`][] processor.
 If necessary, bug reports or feature requests will be redirected to the upstream repository.
+
+[`groupbyattrs`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/processor/groupbyattrsprocessor
 {{< /admonition >}}
 
 We recommend you use the groupbyattrs processor together with [`otelcol.processor.batch`][otelcol.processor.batch], as a consecutive step.

--- a/docs/sources/reference/components/otelcol/otelcol.processor.interval.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.interval.md
@@ -41,8 +41,10 @@ If no new metrics come in, the next interval will export nothing.
 {{< /admonition >}}
 
 {{< admonition type="note" >}}
-`otelcol.processor.interval` is a wrapper over the upstream OpenTelemetry Collector `interval` processor.
+`otelcol.processor.interval` is a wrapper over the upstream OpenTelemetry Collector [`interval`][] processor.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`interval`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/processor/intervalprocessor
 {{< /admonition >}}
 
 ## Usage

--- a/docs/sources/reference/components/otelcol/otelcol.processor.k8sattributes.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.k8sattributes.md
@@ -15,8 +15,10 @@ title: otelcol.processor.k8sattributes
 `otelcol.processor.k8sattributes` accepts telemetry data from other `otelcol` components and adds Kubernetes metadata to the resource attributes of spans, logs, or metrics.
 
 {{< admonition type="note" >}}
-`otelcol.processor.k8sattributes` is a wrapper over the upstream OpenTelemetry Collector `k8sattributes` processor.
+`otelcol.processor.k8sattributes` is a wrapper over the upstream OpenTelemetry Collector [`k8sattributes`][] processor.
 If necessary, bug reports or feature requests will be redirected to the upstream repository.
+
+[`k8sattributes`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/processor/k8sattributesprocessor
 {{< /admonition >}}
 
 You can specify multiple `otelcol.processor.k8sattributes` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.processor.memory_limiter.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.memory_limiter.md
@@ -21,8 +21,10 @@ When usage exceeds the hard limit, the processor forces a garbage collection to 
 When usage is below the soft limit, no data is dropped and no forced garbage collection is performed.
 
 {{< admonition type="note" >}}
-`otelcol.processor.memory_limiter` is a wrapper over the upstream OpenTelemetry Collector `memorylimiter` processor.
+`otelcol.processor.memory_limiter` is a wrapper over the upstream OpenTelemetry Collector [`memorylimiter`][] processor.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`memorylimiter`]: https://github.com/open-telemetry/opentelemetry-collector/tree/{{< param "OTEL_VERSION" >}}/processor/memorylimiterprocessor
 {{< /admonition >}}
 
 You can specify multiple `otelcol.processor.memory_limiter` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.processor.probabilistic_sampler.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.probabilistic_sampler.md
@@ -31,8 +31,10 @@ When the TraceID isn't defined, the sampler can be configured to apply hashing t
 This sampler also supports sampling priority.
 
 {{< admonition type="note" >}}
-`otelcol.processor.probabilistic_sampler` is a wrapper over the upstream OpenTelemetry Collector Contrib `probabilistic_sampler` processor.
+`otelcol.processor.probabilistic_sampler` is a wrapper over the upstream OpenTelemetry Collector Contrib [`probabilistic_sampler`][] processor.
 If necessary, bug reports or feature requests will be redirected to the upstream repository.
+
+[`probabilistic_sampler`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/processor/probabilisticsamplerprocessor
 {{< /admonition >}}
 
 You can specify multiple `otelcol.processor.probabilistic_sampler` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.processor.resourcedetection.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.resourcedetection.md
@@ -17,8 +17,10 @@ description: Learn about otelcol.processor.resourcedetection
 [OpenTelemetry resource semantic conventions]: https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/resource/semantic_conventions/
 
 {{< admonition type="note" >}}
-`otelcol.processor.resourcedetection` is a wrapper over the upstream OpenTelemetry Collector Contrib `resourcedetection` processor.
+`otelcol.processor.resourcedetection` is a wrapper over the upstream OpenTelemetry Collector Contrib [`resourcedetection`][] processor.
 If necessary, bug reports or feature requests are redirected to the upstream repository.
+
+[`resourcedetection`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/processor/resourcedetectionprocessor
 {{< /admonition >}}
 
 You can specify multiple `otelcol.processor.resourcedetection` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.processor.span.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.span.md
@@ -16,8 +16,10 @@ title: otelcol.processor.span
 It also supports the ability to filter input data to determine if it should be included or excluded from this processor.
 
 {{< admonition type="note" >}}
-`otelcol.processor.span` is a wrapper over the upstream OpenTelemetry Collector `span` processor.
+`otelcol.processor.span` is a wrapper over the upstream OpenTelemetry Collector [`span`][] processor.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`span`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/processor/spanprocessor
 {{< /admonition >}}
 
 You can specify multiple `otelcol.processor.span` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.processor.tail_sampling.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.tail_sampling.md
@@ -16,8 +16,10 @@ title: otelcol.processor.tail_sampling
 All spans for a given trace _must_ be received by the same collector instance for effective sampling decisions.
 
 {{< admonition type="note" >}}
-`otelcol.processor.tail_sampling` is a wrapper over the upstream OpenTelemetry Collector Contrib `tail_sampling` processor.
+`otelcol.processor.tail_sampling` is a wrapper over the upstream OpenTelemetry Collector Contrib [`tail_sampling`][] processor.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`tail_sampling`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/processor/tailsamplingprocessor
 {{< /admonition >}}
 
 You can specify multiple `otelcol.processor.tail_sampling` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.processor.transform.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.transform.md
@@ -66,8 +66,10 @@ Raw strings are generally more convenient for writing OTTL statements.
 {{< /admonition >}}
 
 {{< admonition type="note" >}}
-`otelcol.processor.transform` is a wrapper over the upstream OpenTelemetry Collector `transform` processor.
+`otelcol.processor.transform` is a wrapper over the upstream OpenTelemetry Collector [`transform`][] processor.
 If necessary, bug reports or feature requests will be redirected to the upstream repository.
+
+[`transform`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/processor/transformprocessor
 {{< /admonition >}}
 
 You can specify multiple `otelcol.processor.transform` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.awscloudwatch.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.awscloudwatch.md
@@ -15,8 +15,10 @@ title: otelcol.receiver.awscloudwatch
 `otelcol.receiver.awscloudwatch` receives logs from Amazon CloudWatch and forwards them to other `otelcol.*` components.
 
 {{< admonition type="note" >}}
-`otelcol.receiver.awscloudwatch` is a wrapper over the upstream OpenTelemetry Collector `awscloudwatch` receiver.
+`otelcol.receiver.awscloudwatch` is a wrapper over the upstream OpenTelemetry Collector [`awscloudwatch`][] receiver.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`awscloudwatch`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/receiver/awscloudwatchreceiver
 {{< /admonition >}}
 
 You can specify multiple `otelcol.receiver.awscloudwatch` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.datadog.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.datadog.md
@@ -18,6 +18,13 @@ title: otelcol.receiver.datadog
 
 You can specify multiple `otelcol.receiver.datadog` components by giving them different labels.
 
+{{< admonition type="note" >}}
+`otelcol.receiver.datadog` is a wrapper over the upstream OpenTelemetry Collector [`datadog`][] receiver.
+Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`datadog`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/receiver/datadogreceiver
+{{< /admonition >}}
+
 ## Usage
 
 ```alloy

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.file_stats.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.file_stats.md
@@ -15,8 +15,10 @@ description: Learn about otelcol.receiver.file_stats
 `otelcol.receiver.file_stats` collects metrics from files and folders specified with a glob pattern.
 
 {{< admonition type="note" >}}
-`otelcol.receiver.file_stats` is a wrapper over the upstream OpenTelemetry Collector `filestats` receiver from the `otelcol-contrib` distribution.
+`otelcol.receiver.file_stats` is a wrapper over the upstream OpenTelemetry Collector [`filestats`][] receiver.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`filestats`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/receiver/filestatsreceiver
 {{< /admonition >}}
 
 Multiple `otelcol.receiver.file_stats` components can be specified by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.filelog.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.filelog.md
@@ -15,8 +15,10 @@ title: otelcol.receiver.filelog
 `otelcol.receiver.filelog` reads log entries from files and forwards them to other `otelcol.*` components.
 
 {{< admonition type="note" >}}
-`otelcol.receiver.filelog` is a wrapper over the upstream OpenTelemetry Collector `filelog` receiver.
+`otelcol.receiver.filelog` is a wrapper over the upstream OpenTelemetry Collector [`filelog`][] receiver.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`filelog`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/receiver/filelogreceiver
 {{< /admonition >}}
 
 You can specify multiple `otelcol.receiver.filelog` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.influxdb.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.influxdb.md
@@ -14,6 +14,13 @@ title: otelcol.receiver.influxdb
 
 You can specify multiple `otelcol.receiver.influxdb` components by giving them different labels.
 
+{{< admonition type="note" >}}
+`otelcol.receiver.influxdb` is a wrapper over the upstream OpenTelemetry Collector [`influxdb`][] receiver.
+Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`influxdb`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/receiver/influxdbreceiver
+{{< /admonition >}}
+
 ## Usage
 
 ```alloy

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.jaeger.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.jaeger.md
@@ -15,8 +15,10 @@ title: otelcol.receiver.jaeger
 `otelcol.receiver.jaeger` accepts Jaeger-formatted data over the network and forwards it to other `otelcol.*` components.
 
 {{< admonition type="note" >}}
-`otelcol.receiver.jaeger` is a wrapper over the upstream OpenTelemetry Collector `jaeger` receiver.
+`otelcol.receiver.jaeger` is a wrapper over the upstream OpenTelemetry Collector [`jaeger`][] receiver.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`jaeger`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/receiver/jaegerreceiver
 {{< /admonition >}}
 
 You can specify multiple `otelcol.receiver.jaeger` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.kafka.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.kafka.md
@@ -15,8 +15,10 @@ title: otelcol.receiver.kafka
 `otelcol.receiver.kafka` accepts telemetry data from a Kafka broker and forwards it to other `otelcol.*` components.
 
 {{< admonition type="note" >}}
-`otelcol.receiver.kafka` is a wrapper over the upstream OpenTelemetry Collector `kafka` receiver from the `otelcol-contrib` distribution.
+`otelcol.receiver.kafka` is a wrapper over the upstream OpenTelemetry Collector [`kafka`][] receiver.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`kafka`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/receiver/kafkareceiver
 {{< /admonition >}}
 
 You can specify multiple `otelcol.receiver.kafka` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.loki.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.loki.md
@@ -16,6 +16,10 @@ title: otelcol.receiver.loki
 
 You can specify multiple `otelcol.receiver.loki` components by giving them different labels.
 
+{{< admonition type="note" >}}
+`otelcol.receiver.loki` is a custom component unrelated to any processors from the OpenTelemetry Collector.
+{{< /admonition >}}
+
 ## Usage
 
 ```alloy

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.opencensus.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.opencensus.md
@@ -15,8 +15,10 @@ title: otelcol.receiver.opencensus
 `otelcol.receiver.opencensus` accepts telemetry data via gRPC or HTTP using the [OpenCensus](https://opencensus.io/) format and forwards it to other `otelcol.*` components.
 
 {{< admonition type="note" >}}
-`otelcol.receiver.opencensus` is a wrapper over the upstream OpenTelemetry Collector `opencensus` receiver from the `otelcol-contrib` distribution.
+`otelcol.receiver.opencensus` is a wrapper over the upstream OpenTelemetry Collector [`opencensus`][] receiver.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`opencensus`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/receiver/opencensusreceiver
 {{< /admonition >}}
 
 You can specify multiple `otelcol.receiver.opencensus` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.otlp.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.otlp.md
@@ -15,8 +15,10 @@ title: otelcol.receiver.otlp
 `otelcol.receiver.otlp` accepts OTLP-formatted data over the network and forwards it to other `otelcol.*` components.
 
 {{< admonition type="note" >}}
-`otelcol.receiver.otlp` is a wrapper over the upstream OpenTelemetry Collector `otlp` receiver.
+`otelcol.receiver.otlp` is a wrapper over the upstream OpenTelemetry Collector [`otlp`][] receiver.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`otlp`]: https://github.com/open-telemetry/opentelemetry-collector/tree/{{< param "OTEL_VERSION" >}}/receiver/otlpreceiver
 {{< /admonition >}}
 
 Multiple `otelcol.receiver.otlp` components can be specified by giving them

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.prometheus.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.prometheus.md
@@ -18,6 +18,10 @@ title: otelcol.receiver.prometheus
 
 You can specify multiple `otelcol.receiver.prometheus` components by giving them different labels.
 
+{{< admonition type="note" >}}
+`otelcol.receiver.prometheus` is a custom component unrelated to any processors from the OpenTelemetry Collector.
+{{< /admonition >}}
+
 ## Usage
 
 ```alloy

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.solace.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.solace.md
@@ -13,8 +13,10 @@ title: otelcol.receiver.solace
 `otelcol.receiver.solace` accepts traces from a [Solace PubSub+ Event Broker](https://solace.com/products/event-broker/) and forwards it to other `otelcol.*` components.
 
 {{< admonition type="note" >}}
-`otelcol.receiver.solace` is a wrapper over the upstream OpenTelemetry Collector `solace` receiver from the `otelcol-contrib` distribution.
+`otelcol.receiver.solace` is a wrapper over the upstream OpenTelemetry Collector [`solace`][] receiver.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`solace`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/receiver/solacereceiver
 {{< /admonition >}}
 
 You can specify multiple `otelcol.receiver.solace` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.splunkhec.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.splunkhec.md
@@ -16,8 +16,10 @@ title: otelcol.receiver.splunkhec
 The receiver accepts data formatted as JSON HEC events under any path or as EOL separated log raw data if sent to the `raw_path` path.
 
 {{< admonition type="note" >}}
-`otelcol.receiver.splunkhec` is a wrapper over the upstream OpenTelemetry Collector `splunkhec` receiver.
+`otelcol.receiver.splunkhec` is a wrapper over the upstream OpenTelemetry Collector [`splunkhec`][] receiver.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`splunkhec`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/receiver/splunkhecreceiver
 {{< /admonition >}}
 
 You can specify multiple `otelcol.receiver.splunkhec` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.syslog.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.syslog.md
@@ -16,8 +16,10 @@ title: otelcol.receiver.syslog
 It supports syslog protocols [RFC5424][] and [RFC3164][] and can receive data over `TCP` or `UDP`.
 
 {{< admonition type="note" >}}
-`otelcol.receiver.syslog` is a wrapper over the upstream OpenTelemetry Collector `syslog` receiver.
+`otelcol.receiver.syslog` is a wrapper over the upstream OpenTelemetry Collector [`syslog`][] receiver.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`syslog`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/receiver/syslogreceiver
 {{< /admonition >}}
 
 You can specify multiple `otelcol.receiver.syslog` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.tcplog.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.tcplog.md
@@ -15,8 +15,10 @@ title: otelcol.receiver.tcplog
 `otelcol.receiver.tcplog` accepts log messages over a TCP connection and forwards them as logs to other `otelcol.*` components.
 
 {{< admonition type="note" >}}
-`otelcol.receiver.tcplog` is a wrapper over the upstream OpenTelemetry Collector `tcplog` receiver.
+`otelcol.receiver.tcplog` is a wrapper over the upstream OpenTelemetry Collector [`tcplog`][] receiver.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`tcplog`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/receiver/tcplogreceiver
 {{< /admonition >}}
 
 You can specify multiple `otelcol.receiver.tcplog` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.vcenter.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.vcenter.md
@@ -17,8 +17,10 @@ description: Learn about otelcol.receiver.vcenter
 `otelcol.receiver.vcenter` accepts metrics from a vCenter or ESXi host running VMware vSphere APIs and forwards it to other `otelcol.*` components.
 
 {{< admonition type="note" >}}
-`otelcol.receiver.vcenter` is a wrapper over the upstream OpenTelemetry Collector `vcenter` receiver from the `otelcol-contrib` distribution.
+`otelcol.receiver.vcenter` is a wrapper over the upstream OpenTelemetry Collector [`vcenter`][] receiver.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`vcenter`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/receiver/vcenterreceiver
 {{< /admonition >}}
 
 You can specify multiple `otelcol.receiver.vcenter` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.zipkin.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.zipkin.md
@@ -15,8 +15,10 @@ title: otelcol.receiver.zipkin
 `otelcol.receiver.zipkin` accepts Zipkin-formatted traces over the network and forwards it to other `otelcol.*` components.
 
 {{< admonition type="note" >}}
-`otelcol.receiver.zipkin` is a wrapper over the upstream OpenTelemetry Collector `zipkin` receiver.
+`otelcol.receiver.zipkin` is a wrapper over the upstream OpenTelemetry Collector [`zipkin`][] receiver.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`zipkin`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/receiver/zipkinreceiver
 {{< /admonition >}}
 
 You can specify multiple `otelcol.receiver.zipkin` components by giving them different labels.

--- a/docs/sources/reference/components/otelcol/otelcol.storage.file.md
+++ b/docs/sources/reference/components/otelcol/otelcol.storage.file.md
@@ -16,8 +16,10 @@ labels:
 The current implementation of this component uses [`bbolt`][] to store and read data on disk.
 
 {{< admonition type="note" >}}
-`otelcol.storage.file` is a wrapper over the upstream OpenTelemetry Collector `filestorage` extension.
+`otelcol.storage.file` is a wrapper over the upstream OpenTelemetry Collector [`filestorage`][] extension.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`filestorage`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/extension/storage/filestorage
 {{< /admonition >}}
 
 You can specify multiple `otelcol.storage.file` components by giving them different labels.


### PR DESCRIPTION
#### PR Description

Add links from Alloy otelcol components to the upstream OTelCol components and tidy up text for consistency.

#### Which issue(s) this PR fixes

Fixes https://github.com/grafana/alloy/issues/3772