### PR TITLE
docs: Update nonroot.md to include how to set the securityContext for the configReloader sidecar

### DIFF
--- a/docs/sources/configure/nonroot.md
+++ b/docs/sources/configure/nonroot.md
@@ -34,9 +34,15 @@ alloy:
   securityContext:
     runAsUser: 473
     runAsGroup: 473
+
+configReloader:
+  securityContext:
+    # this is the UID of the "nobody" user that the configReloader image runs as
+    runAsUser: 65534
+    runAsGroup: 65534
 ```
 
-This configuration makes the {{< param "PRODUCT_NAME" >}} binary run with UID 473 and GID 473 rather than as root.
+This configuration makes the {{< param "PRODUCT_NAME" >}} binary run with UID 473 and GID 473 rather than as root. It also runs the config reloader sidecar as UID 65534 and GID 65534.
 
 ## Is the root user a security risk?
 


### PR DESCRIPTION
Backport be141c0cfcd1d11059558178cdd953e915ef1a17 from https://github.com/grafana/alloy/pull/3239