### PR TITLE
database_observability: update README with events_waits_current

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1444,12 +1444,6 @@ github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0 h1:bjh0PVYSVVFxzINqPF
 github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0/go.mod h1:7t5XR+2IA8P2qggOAHTj/GCZfoLBle3OvNSYh1VkRBU=
 github.com/grafana/vmware_exporter v0.0.5-beta.0.20250218170317-73398ba08329 h1:Rs4H1yv2Abk3xE82qpyhMGGA8rswAOA0HQZde/BYkFo=
 github.com/grafana/vmware_exporter v0.0.5-beta.0.20250218170317-73398ba08329/go.mod h1:Z28219aViNlsLlPvuCnlgHDagRdZBAZ7JOnQg1b3eWg=
-github.com/grafana/walqueue v0.0.0-20250402195023-cd132d6ff0bc h1:3uxEsWrrkBZy5XbXF8FMFNsmnuB8QHrE1eSiheaCt0Q=
-github.com/grafana/walqueue v0.0.0-20250402195023-cd132d6ff0bc/go.mod h1:mgOAircFKdN03tt2gZUPTVw6EQr8XnRI+M3Qw1oT1NE=
-github.com/grafana/walqueue v0.0.0-20250605193259-9bd9dd45304e h1:oDad8NSAIyrTkgkiux1ZLInLE/t3wddLYebkwd1tJFY=
-github.com/grafana/walqueue v0.0.0-20250605193259-9bd9dd45304e/go.mod h1:ezyqvsW/SYw4FIr+xj8eEeiwC0AuRF6Y8OUcFL3uXzU=
-github.com/grafana/walqueue v0.0.0-20250605195045-126adacf68b1 h1:Rt1muGn0rEXdERZuv/DICMQm4VXcS/Sy1TFNBWdZEms=
-github.com/grafana/walqueue v0.0.0-20250605195045-126adacf68b1/go.mod h1:r5esBN3LfoYHk5JKD+o4/IBwuftA1uCmaqT6C8av21c=
 github.com/grafana/walqueue v0.0.0-20250606153244-9d2294b26901 h1:fOE7XvFsuXvHr9bmmcf0CfCL5ToEUOWBStMu1ruGEWc=
 github.com/grafana/walqueue v0.0.0-20250606153244-9d2294b26901/go.mod h1:r5esBN3LfoYHk5JKD+o4/IBwuftA1uCmaqT6C8av21c=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=

--- a/internal/component/database_observability/README.md
+++ b/internal/component/database_observability/README.md
@@ -88,22 +88,22 @@ Use this statement to enable the consumer if it's disabled:
 UPDATE performance_schema.setup_consumers SET ENABLED = 'YES' WHERE NAME = 'events_statements_cpu';
 ```
 
-7. Optionally enable the `events_waits_history` consumer if you want to collect wait events for each query sample. Verify the current settings:
+7. Optionally enable the `events_waits_current` and `events_waits_history` consumers if you want to collect wait events for each query sample. Verify the current settings:
 
 ```promql
-database_observability_setup_consumers_enabled{job="integrations/db-o11y", consumer_name="events_waits_history"}
+database_observability_setup_consumers_enabled{job="integrations/db-o11y", consumer_name=~"events_waits_(current|history)"}
 ```
 
 or with a sql query:
 
 ```sql
-SELECT * FROM performance_schema.setup_consumers WHERE NAME = 'events_waits_history';
+SELECT * FROM performance_schema.setup_consumers WHERE NAME IN ('events_waits_current', 'events_waits_history');
 ```
 
-Use this statement to enable the consumer if it's disabled:
+Use this statement to enable the consumers if they are disabled:
 
 ```sql
-UPDATE performance_schema.setup_consumers SET ENABLED = 'YES' WHERE NAME = 'events_waits_history';
+UPDATE performance_schema.setup_consumers SET ENABLED = 'YES' WHERE NAME IN ('events_waits_current', 'events_waits_history');
 ```
 
 ## Running and configuring Alloy


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This updates the Database Observability component README to include instructions to enable the `events_waits_current` consumer as well.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer
The go.sum changes come from a `go mod tidy`, let me know if that change is not preferred.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
