### PR TITLE
fix loki.source.file docs re legacy positions file

### DIFF
--- a/docs/sources/reference/components/loki/loki.source.file.md
+++ b/docs/sources/reference/components/loki/loki.source.file.md
@@ -52,9 +52,8 @@ You can use the `tail_from_end` argument when you want to tail a large file with
 When set to true, only new logs are read, ignoring the existing ones.
 
 {{< admonition type="note" >}}
-The `legacy_positions_file` argument is used when you are transitioning from legacy. The legacy positions file is rewritten into the new format.
-This operation only occurs if the positions file doesn't exist and the `legacy_positions_file` is valid.
-After the configuration is successfully converted, the `legacy_positions_file` is deleted.
+The `legacy_positions_file` argument is used when you are transitioning from legacy. The legacy positions file is converted to the new format.
+This operation only occurs if the new positions file doesn't exist and the `legacy_positions_file` is valid.
 If you add any labels before `loki.source.file`, then the positions file conversion won't work.
 The legacy positions file didn't have a concept of labels in the positions file, so the conversion assumes no labels.
 {{< /admonition >}}

--- a/internal/component/common/loki/positions/positions.go
+++ b/internal/component/common/loki/positions/positions.go
@@ -15,8 +15,9 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/alloy/internal/runtime/logging/level"
 	yaml "gopkg.in/yaml.v2"
+
+	"github.com/grafana/alloy/internal/runtime/logging/level"
 )
 
 const (
@@ -106,14 +107,15 @@ type LegacyFile struct {
 // 2. There is a file at the legacy path and that it is valid yaml
 func ConvertLegacyPositionsFile(legacyPath, newPath string, l log.Logger) {
 	legacyPositions := readLegacyFile(legacyPath, l)
-	// LegacyPositions did not exist or was invalid so return.
+	// legacyPositions did not exist or was invalid so return.
 	if legacyPositions == nil {
+		level.Info(l).Log("msg", "will not convert the legacy positions file as it is not valid or does not exist", "legacy_path", legacyPath)
 		return
 	}
 	fi, err := os.Stat(newPath)
 	// If the newpath exists, then don't convert.
 	if err == nil && fi.Size() > 0 {
-		level.Info(l).Log("msg", "new positions file already exists", "path", newPath)
+		level.Info(l).Log("msg", "will not convert the legacy positions file as the new positions file already exists", "path", newPath)
 		return
 	}
 
@@ -125,11 +127,11 @@ func ConvertLegacyPositionsFile(legacyPath, newPath string, l log.Logger) {
 			Labels: "{}",
 		}] = v
 	}
-	// After conversion remove the file.
 	err = writePositionFile(newPath, newPositions)
 	if err != nil {
-		level.Error(l).Log("msg", "error writing new positions file from legacy", "path", newPath, "error", err)
+		level.Error(l).Log("msg", "error writing new positions file converted from legacy", "path", newPath, "error", err)
 	}
+	level.Info(l).Log("msg", "successfully converted legacy positions file to the new format", "path", newPath, "legacy_path", legacyPath)
 }
 
 func readLegacyFile(legacyPath string, l log.Logger) *LegacyFile {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

The legacy positions file is not being deleted, contrary to what the docs say. 

I think it's fine - it does not need to be deleted, because if the new positions file exists, we won't be attempting the conversion. I think it's safer to leave it where it is, in case someone wants to attempt the migration again or had misconfigured the location where the new positions file lives. 

So I'm fixing the docs here. 

Also adding some logging to make things more clear.
