### PR TITLE
fix(dockerfile): build UI as separate docker target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /src/alloy
 
 # Build the UI before building Alloy, which will then bake the final UI into
 # the binary.
-RUN --mount=type=cache,target=/src/alloy/web/ui/node_modules,sharing=locked \
+RUN --mount=type=cache,target=/src/alloy/internal/web/ui/node_modules,sharing=locked \
     make generate-ui
 
 RUN --mount=type=cache,target=/root/.cache/go-build \


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR builds UI as a separate docker `ui-build` target and then copies over to the `build` target.
#### Which issue(s) this PR fixes
This change fixes thee following issues:
1. Every time a go file changes, the UI is rebuilt, including fetching modules(due to invalid cache path)
2. Every time something in .git changes, the the UI is rebuilt, including fetching modules(due to invalid cache path)
3. The UI is built for each platform if building multiplatform image.
<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
