### PR TITLE
Use HTTP port instead of GRPC port

### DIFF
--- a/docs/sources/reference/components/otelcol/otelcol.exporter.otlphttp.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.otlphttp.md
@@ -193,7 +193,7 @@ This example creates an exporter to send data to a locally running Grafana Tempo
 ```alloy
 otelcol.exporter.otlphttp "tempo" {
     client {
-        endpoint = "http://tempo:4317"
+        endpoint = "http://tempo:4318"
         tls {
             insecure             = true
             insecure_skip_verify = true


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Fix the port in the example at https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.exporter.otlphttp/#example

Documented to use the port for GPRC and should be port for HTTP.

#### Which issue(s) this PR fixes

Fixes https://github.com/grafana/support-escalations/issues/15683

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
