### PR TITLE
fix(pyroscope.ebpf): send profiles concurrently (#3857)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ This document contains a historical list of changes between releases. Only
 changes that impact end-user behavior are listed; changes to documentation or
 internal API changes are not present.
 
+v1.8.4
+-----------------
+
+### Bugfixes
+
+- Send profiles concurrently from `pyroscope.ebpf`. (@korniltsev)
+
 v1.8.3
 -----------------
 

--- a/internal/component/pyroscope/ebpf/metrics.go
+++ b/internal/component/pyroscope/ebpf/metrics.go
@@ -18,6 +18,7 @@ type metrics struct {
 	pprofBytesTotal               *prometheus.CounterVec
 	pprofSamplesTotal             *prometheus.CounterVec
 	ebpfMetrics                   *ebpfmetrics.Metrics
+	pprofsDroppedTotal            prometheus.Counter
 }
 
 func newMetrics(reg prometheus.Registerer) *metrics {
@@ -38,6 +39,10 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 			Name: "pyroscope_ebpf_pprofs_total",
 			Help: "Total number of pprof profiles collected by the ebpf component",
 		}, []string{"service_name"}),
+		pprofsDroppedTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "pyroscope_ebpf_pprofs_dropped_total",
+			Help: "Total number of pprof profiles dropped by the ebpf component",
+		}),
 		pprofBytesTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "pyroscope_ebpf_pprof_bytes_total",
 			Help: "Total number of pprof profiles collected by the ebpf component",
@@ -56,6 +61,7 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 		m.pprofsTotal = util.MustRegisterOrGet(reg, m.pprofsTotal).(*prometheus.CounterVec)
 		m.pprofBytesTotal = util.MustRegisterOrGet(reg, m.pprofBytesTotal).(*prometheus.CounterVec)
 		m.pprofSamplesTotal = util.MustRegisterOrGet(reg, m.pprofSamplesTotal).(*prometheus.CounterVec)
+		m.pprofsDroppedTotal = util.MustRegisterOrGet(reg, m.pprofsDroppedTotal).(prometheus.Counter)
 	}
 
 	return m

--- a/internal/component/pyroscope/ebpf/pool.go
+++ b/internal/component/pyroscope/ebpf/pool.go
@@ -1,0 +1,29 @@
+package ebpf
+
+import "sync"
+
+// copypaste from https://github.com/grafana/pyroscope/blob/2c7e5971dc682cb442da4a5e234d01a2366a42c5/pkg/experiment/ingester/segment.go#L698
+// with a slight modification - removed `do` func
+type workerPool struct {
+	workers sync.WaitGroup
+	// jobs must not be used after stop
+	jobs chan func()
+}
+
+func (p *workerPool) run(workers int) {
+	p.jobs = make(chan func())
+	p.workers.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer p.workers.Done()
+			for job := range p.jobs {
+				job()
+			}
+		}()
+	}
+}
+
+func (p *workerPool) stop() {
+	close(p.jobs)
+	p.workers.Wait()
+}

--- a/internal/component/pyroscope/ebpf/send.go
+++ b/internal/component/pyroscope/ebpf/send.go
@@ -1,0 +1,64 @@
+//go:build (linux && arm64) || (linux && amd64)
+
+package ebpf
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-kit/log/level"
+	"github.com/grafana/alloy/internal/component/pyroscope"
+	"github.com/grafana/pyroscope/ebpf/pprof"
+)
+
+const maxSendConcurrency = 32
+
+func (c *Component) sendProfiles(ctx context.Context, builders *pprof.ProfileBuilders) {
+	start := time.Now()
+	pool := workerPool{}
+	pool.run(min(maxSendConcurrency, len(builders.Builders)))
+	queued := 0
+	ctx, cancel := context.WithTimeout(ctx, c.args.CollectInterval)
+	defer func() {
+		pool.stop()
+		cancel()
+		level.Debug(c.options.Logger).Log("msg", "sent profiles", "duration", time.Since(start), "queued", queued)
+	}()
+	j := 0
+	for _, builder := range builders.Builders {
+		serviceName := builder.Labels.Get("service_name")
+		c.metrics.pprofsTotal.WithLabelValues(serviceName).Inc()
+		c.metrics.pprofSamplesTotal.WithLabelValues(serviceName).Add(float64(len(builder.Profile.Sample)))
+
+		buf := bytes.NewBuffer(nil)
+		_, err := builder.Write(buf)
+		if err != nil {
+			level.Error(c.options.Logger).Log("err", fmt.Errorf("ebpf profile encode %w", err))
+			continue
+		}
+		rawProfile := buf.Bytes()
+
+		appender := c.appendable.Appender()
+		c.metrics.pprofBytesTotal.WithLabelValues(serviceName).Add(float64(len(rawProfile)))
+
+		job := func() {
+			samples := []*pyroscope.RawSample{{RawProfile: rawProfile}}
+			err = appender.Append(ctx, builder.Labels, samples)
+			if err != nil {
+				level.Error(c.options.Logger).Log("msg", "ebpf pprof write", "err", err)
+			}
+		}
+		select {
+		case pool.jobs <- job:
+			queued++
+		case <-ctx.Done():
+			dropped := len(builders.Builders) - j
+			c.metrics.pprofsDroppedTotal.Add(float64(dropped))
+			level.Debug(c.options.Logger).Log("msg", "dropped profiles", "count", dropped)
+			return
+		}
+		j++
+	}
+}

--- a/internal/component/pyroscope/ebpf/send_test.go
+++ b/internal/component/pyroscope/ebpf/send_test.go
@@ -1,0 +1,131 @@
+//go:build (linux && arm64) || (linux && amd64)
+
+package ebpf
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"go.uber.org/atomic"
+
+	"github.com/grafana/alloy/internal/component/pyroscope"
+	"github.com/grafana/alloy/internal/util"
+	"github.com/grafana/pyroscope/ebpf/pprof"
+	"github.com/grafana/pyroscope/ebpf/sd"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendProfilesConcurrently(t *testing.T) {
+	tests := []struct {
+		name                 string
+		profilesCount        int
+		delay                time.Duration
+		collectionInterval   time.Duration
+		expectedSendDuration time.Duration
+		expectedSuccess      int
+		expectedErrors       int
+		expectedDrops        int
+	}{
+		{
+			name:                 "send 64 profiles in 1 second",
+			profilesCount:        64,
+			delay:                500 * time.Millisecond,
+			collectionInterval:   15 * time.Second,
+			expectedSendDuration: time.Second, // 64 / 32 * 0.5s
+			expectedSuccess:      64,
+			expectedErrors:       0,
+			expectedDrops:        0,
+		},
+		{
+			name: "send 32 profiles in 500ms, " +
+				"start sending another 32," +
+				" fail with timeout, completely the rest 192",
+			profilesCount:        256,
+			delay:                500 * time.Millisecond,
+			collectionInterval:   800 * time.Millisecond,
+			expectedSendDuration: 800 * time.Millisecond,
+			expectedSuccess:      32,
+			expectedErrors:       32,
+			expectedDrops:        192,
+		},
+	}
+	for _, td := range tests {
+		t.Run(td.name, func(t *testing.T) {
+			reg := prometheus.NewRegistry()
+			c := new(Component)
+			c.metrics = newMetrics(reg)
+			c.options.Logger = util.TestAlloyLogger(t)
+			c.args.CollectInterval = td.collectionInterval
+			successes := atomic.Uint32{}
+			failures := atomic.Uint32{}
+			c.appendable = pyroscope.NewFanout([]pyroscope.Appendable{
+				pyroscope.AppendableFunc(func(ctx context.Context, labels labels.Labels, samples []*pyroscope.RawSample) error {
+					after := time.After(td.delay)
+					select {
+					case <-after:
+						successes.Add(1)
+						return nil
+					case <-ctx.Done():
+						failures.Add(1)
+						return ctx.Err()
+					}
+				}),
+			}, "", reg)
+
+			profiles := pprof.NewProfileBuilders(pprof.BuildersOptions{
+				SampleRate: 97,
+			})
+
+			for i := 0; i < td.profilesCount; i++ {
+				cid := fmt.Sprintf("cid_%d", i)
+				pid := uint32(239 + i)
+				target := sd.DiscoveryTarget(map[string]string{
+					"service_name": fmt.Sprintf("service_%d", i),
+				})
+				profiles.AddSample(&pprof.ProfileSample{
+					Target:      sd.NewTargetForTesting(cid, pid, target),
+					Pid:         pid,
+					SampleType:  pprof.SampleTypeCpu,
+					Aggregation: pprof.SampleAggregated,
+					Stack: []string{
+						"func1", "func2",
+					},
+					Value: 42,
+				})
+			}
+
+			t1 := time.Now()
+			c.sendProfiles(t.Context(), profiles)
+			duration := time.Since(t1)
+			expectedDuration := td.expectedSendDuration
+			diff := duration - expectedDuration
+			if diff < 0 {
+				diff = -diff
+			}
+			assert.Less(t, diff, 100*time.Millisecond)
+			require.EqualValues(t, td.expectedErrors, failures.Load())
+			require.EqualValues(t, td.expectedSuccess, successes.Load())
+			require.EqualValues(t, float64(td.expectedDrops), gatherDrops(t, reg))
+		})
+	}
+}
+
+func gatherDrops(t *testing.T, reg *prometheus.Registry) float64 {
+	gather, err := reg.Gather()
+	require.NoError(t, err)
+
+	for _, f := range gather {
+		if *f.Name == "pyroscope_ebpf_pprofs_dropped_total" {
+			require.Len(t, f.Metric, 1)
+			c := f.Metric[0].GetCounter()
+			return *c.Value
+		}
+	}
+	require.Fail(t, "metric not found")
+	return 0
+}


### PR DESCRIPTION
(cherry picked from commit 062df5dda4e0a36fc1a8ccaedbb66710ac4509e0)

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
We noticed an issue when pyrsocope added an artificial delay . If response takes 500ms and we have 128 pprofs, it takes 128*500ms which is suboptimal.
#### Which issue(s) this PR fixes
This pr sends ebpf profiles asynchronously in a pool of gorutines with a cap of 32 
<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated

