### PR TITLE
http: add support for filtering `/metrics` by component label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Main (unreleased)
 
 - Add entropy support for `loki.secretfilter` (@romain-gaillard)
 
+- Added support for filtering `/metrics` output by `component` label via query parameters. This enables limiting the metrics output to selected components using the `?component=` query string. (@irateswami)
+
 ### Enhancements
 
 - Add `hash_string_id` argument to `foreach` block to hash the string representation of the pipeline id instead of using the string itself. (@wildum)

--- a/docs/sources/reference/http/_index.md
+++ b/docs/sources/reference/http/_index.md
@@ -20,6 +20,15 @@ you can query the `127.0.0.1:12345/metrics` endpoint to see the internal metrics
 
 The `/metrics` endpoint returns the internal metrics of {{< param "PRODUCT_NAME" >}} in the Prometheus exposition format.
 
+#### Component Filtering
+
+You can use the `component` query parameter to filter the metrics output. 
+For example, `/metrics?component=agent&component=otel`.
+
+The endpoint will only return metrics with a `component` label that matches one of the provided values.
+
+If you don't provide a `component` filter, the default behavior is unchanged, and the endpoint returns all metrics.
+
 ### /-/ready
 
 An {{< param "PRODUCT_NAME" >}} instance is ready once it has loaded its initial configuration.

--- a/docs/sources/troubleshoot/component_metrics.md
+++ b/docs/sources/troubleshoot/component_metrics.md
@@ -25,6 +25,18 @@ For example, component-specific metrics for a `prometheus.remote_write` componen
 The [reference documentation][] for each component described the list of component-specific metrics that the component exposes.
 Not all components expose metrics.
 
+## Filter metrics by component label
+
+You can use the `component` query parameter to filter the `/metrics` output.
+
+This parameter allows you to retrieve only metrics emitted by specific components.
+You can pass the `component` parameter multiple times.
+For example, `http://localhost:12345/metrics?component=prometheus.scrape&component=otelcol.receiverz`.
+
+The endpoint will only return metrics that contain a `component` label with one of the provided values.
+
+If you don't provide a `component` filter, the default behavior is unchanged, and the endpoint returns all metrics.
+
 [components]: ../../get-started/components/
 [alloy run]: ../../reference/cli/run/
 [reference documentation]: ../../reference/components/

--- a/internal/service/http/filtered_gatherer.go
+++ b/internal/service/http/filtered_gatherer.go
@@ -1,0 +1,73 @@
+package http
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+type filteredGatherer struct {
+	base       prometheus.Gatherer
+	components map[string]struct{}
+}
+
+func newFilteredGatherer(base prometheus.Gatherer, filters []string) *filteredGatherer {
+	cset := make(map[string]struct{}, len(filters))
+	for _, c := range filters {
+		cset[c] = struct{}{}
+	}
+	return &filteredGatherer{base: base, components: cset}
+}
+
+func (f *filteredGatherer) Gather() ([]*dto.MetricFamily, error) {
+	families, err := f.base.Gather()
+	if err != nil {
+		return nil, err
+	}
+
+	// If no filters are specified, return all metrics
+	if len(f.components) == 0 {
+		return families, nil
+	}
+
+	var filtered []*dto.MetricFamily
+	for _, mf := range families {
+		var kept []*dto.Metric
+		for _, m := range mf.Metric {
+			var componentValue string
+			var hasComponentLabel bool
+			for _, label := range m.Label {
+				if label.GetName() == "component" {
+					componentValue = label.GetValue()
+					hasComponentLabel = true
+					break
+				}
+			}
+			// Only include metrics that have a component label and match one of the filters
+			if hasComponentLabel {
+				if _, ok := f.components[componentValue]; ok {
+					// Create a new metric with only the matching component label
+					newMetric := &dto.Metric{
+						Label:       m.Label,
+						Counter:     m.Counter,
+						Gauge:       m.Gauge,
+						Untyped:     m.Untyped,
+						Summary:     m.Summary,
+						Histogram:   m.Histogram,
+						TimestampMs: m.TimestampMs,
+					}
+					kept = append(kept, newMetric)
+				}
+			}
+		}
+		if len(kept) > 0 {
+			filtered = append(filtered, &dto.MetricFamily{
+				Name:   mf.Name,
+				Help:   mf.Help,
+				Type:   mf.Type,
+				Metric: kept,
+			})
+		}
+	}
+
+	return filtered, nil
+}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Adds support for filtering metrics by component label via query parameters
on the `/metrics` endpoint.

This allows filtering the Prometheus exposition output by supplying one or
more `component` values via the `?component=` query parameter.

Example:
  GET /metrics?component=agent&component=otelcol

Only metrics that contain a `component` label matching one of the supplied
values will be returned.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
