### PR TITLE
[v1.9 fixes] Upgrade a dependency, add windows exporter no-op params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ v1.9.2
 
 - For CRD-based components (`prometheus.operator.*`), retry initializing informers if the apiserver request fails. This rectifies issues where the apiserver is not reachable immediately after node restart. (@dehaansa)
 
+### Other changes
+
+-  Add no-op blocks and attributes to the `prometheus.exporter.windows` component (@ptodev).
+   Version 1.9.0 of Alloy removed the `msmq` block, as well as the `enable_v2_collector`, 
+   `where_clause`, and `use_api` attributes in the `service` block. 
+   This made it difficult for users to upgrade, so those attributes have now been made a no-op instead of being removed.
+
 v1.9.1
 -----------------
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
@@ -71,6 +71,12 @@ You can use the following blocks with `prometheus.exporter.windows`:
 | [`tcp`][tcp]                               | Configures the `tcp` collector.                | no       |
 | [`text_file`][text_file]                   | Configures the `text_file` collector.          | no       |
 
+{{< admonition type="note" >}}
+In previous versions of Alloy there used to be a `msmq` block.
+It is still allowed in Alloy confguration files but its usage now is a no-op.
+Users are advised to remove it from their confguration files because it will be removed completely in upcoming Alloy releases.
+{{< /admonition >}}
+
 [dfsr]: #dfsr
 [dns]: #dns
 [exchange]: #exchange
@@ -275,6 +281,12 @@ User-supplied `exclude` and `include` strings are [wrapped][wrap-regex] in a reg
 For a service to be included, it must match the regular expression specified by `include` and must _not_ match the regular expression specified by `exclude`.
 
 User-supplied `exclude` and `include` strings are [wrapped][wrap-regex] in a regular expression.
+
+{{< admonition type="note" >}}
+In previous versions of Alloy there used to be `use_api`, `where_clause`, and `enable_v2_collector` attributes.
+They are still allowed in Alloy confguration files but their usage is now a no-op.
+Users are advised to remove them from their confguration files because they will be removed completely in upcoming Alloy releases.
+{{< /admonition >}}
 
 ### `smb`
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
@@ -72,9 +72,9 @@ You can use the following blocks with `prometheus.exporter.windows`:
 | [`text_file`][text_file]                   | Configures the `text_file` collector.          | no       |
 
 {{< admonition type="note" >}}
-In previous versions of Alloy there used to be a `msmq` block.
-It is still allowed in Alloy confguration files but its usage now is a no-op.
-Users are advised to remove it from their confguration files because it will be removed completely in upcoming Alloy releases.
+Starting with release 1.9.0, the `msmq` block is deprecated.
+It will be removed in a future release.
+You can still include this block in your configuration files. However, its usage is now a no-op.
 {{< /admonition >}}
 
 [dfsr]: #dfsr
@@ -283,9 +283,9 @@ For a service to be included, it must match the regular expression specified by 
 User-supplied `exclude` and `include` strings are [wrapped][wrap-regex] in a regular expression.
 
 {{< admonition type="note" >}}
-In previous versions of Alloy there used to be `use_api`, `where_clause`, and `enable_v2_collector` attributes.
-They are still allowed in Alloy confguration files but their usage is now a no-op.
-Users are advised to remove them from their confguration files because they will be removed completely in upcoming Alloy releases.
+Starting with release 1.9.0, the `use_api`, `where_clause`, and `enable_v2_collector` attributes are deprecated.
+They will be removed in a future release.
+You can still include these attributes in your configuration files. However, their usage is now a no-op.
 {{< /admonition >}}
 
 ### `smb`

--- a/go.mod
+++ b/go.mod
@@ -509,7 +509,7 @@ require (
 	github.com/checkpoint-restore/go-criu/v6 v6.3.0 // indirect
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
 	github.com/cilium/ebpf v0.17.3 // indirect
-	github.com/cloudflare/circl v1.3.7 // indirect
+	github.com/cloudflare/circl v1.6.1 // indirect
 	github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58 // indirect
 	github.com/cncf/xds/go v0.0.0-20250121191232-2f005788dc42 // indirect
 	github.com/compose-spec/compose-go/v2 v2.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -755,8 +755,8 @@ github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cfssl v0.0.0-20180223231731-4e2dcbde5004 h1:lkAMpLVBDaj17e85keuznYcH5rqI438v41pKcBl4ZxQ=
 github.com/cloudflare/cfssl v0.0.0-20180223231731-4e2dcbde5004/go.mod h1:yMWuSON2oQp+43nFtAV/uvKQIFpSPerB57DCt9t8sSA=
-github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
-github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
+github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
+github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58 h1:F1EaeKL/ta07PY/k9Os/UFtwERei2/XzGemhpGnBKNg=
 github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58/go.mod h1:EOBUe0h4xcZ5GoxqC5SDxFQ8gwyZPKQoEzownBlhI80=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/internal/component/prometheus/exporter/windows/config.go
+++ b/internal/component/prometheus/exporter/windows/config.go
@@ -90,13 +90,13 @@ func (a *Arguments) logDeprecatedFields(logger log.Logger) {
 		level.Warn(logger).Log("msg", "the `msmq` block is deprecated - its usage is a no-op and it will be removed in the future")
 	}
 	if a.Service.UseApi != nil {
-		level.Warn(logger).Log("msg", "the `use_api` inside the `service` block is deprecated - its usage is a no-op and it will be removed in the future")
+		level.Warn(logger).Log("msg", "the `use_api` attribute inside the `service` block is deprecated - its usage is a no-op and it will be removed in the future")
 	}
 	if a.Service.Where != nil {
-		level.Warn(logger).Log("msg", "the `where_clause` inside the `service` block is deprecated - its usage is a no-op and it will be removed in the future")
+		level.Warn(logger).Log("msg", "the `where_clause` attribute inside the `service` block is deprecated - its usage is a no-op and it will be removed in the future")
 	}
 	if a.Service.V2 != nil {
-		level.Warn(logger).Log("msg", "the `enable_v2_collector` inside the `service` block is deprecated - its usage is a no-op and it will be removed in the future")
+		level.Warn(logger).Log("msg", "the `enable_v2_collector` attribute inside the `service` block is deprecated - its usage is a no-op and it will be removed in the future")
 	}
 }
 

--- a/internal/component/prometheus/exporter/windows/config.go
+++ b/internal/component/prometheus/exporter/windows/config.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-kit/log"
+	"github.com/grafana/alloy/internal/runtime/logging/level"
 	windows_integration "github.com/grafana/alloy/internal/static/integrations/windows_exporter"
 )
 
@@ -32,6 +34,7 @@ type Arguments struct {
 	Exchange      ExchangeConfig      `alloy:"exchange,block,optional"`
 	IIS           IISConfig           `alloy:"iis,block,optional"`
 	LogicalDisk   LogicalDiskConfig   `alloy:"logical_disk,block,optional"`
+	MSMQ          *MSMQConfig         `alloy:"msmq,block,optional"`
 	MSSQL         MSSQLConfig         `alloy:"mssql,block,optional"`
 	Network       NetworkConfig       `alloy:"network,block,optional"`
 	PhysicalDisk  PhysicalDiskConfig  `alloy:"physical_disk,block,optional"`
@@ -54,7 +57,9 @@ type Arguments struct {
 }
 
 // Convert converts the component's Arguments to the integration's Config.
-func (a *Arguments) Convert() *windows_integration.Config {
+func (a *Arguments) Convert(logger log.Logger) *windows_integration.Config {
+	a.logDeprecatedFields(logger)
+
 	return &windows_integration.Config{
 		EnabledCollectors:  strings.Join(a.EnabledCollectors, ","),
 		Dfsr:               a.Dfsr.Convert(),
@@ -77,6 +82,21 @@ func (a *Arguments) Convert() *windows_integration.Config {
 		PerformanceCounter: a.PerformanceCounter.Convert(),
 		MSCluster:          a.MSCluster.Convert(),
 		NetFramework:       a.NetFramework.Convert(),
+	}
+}
+
+func (a *Arguments) logDeprecatedFields(logger log.Logger) {
+	if a.MSMQ != nil {
+		level.Warn(logger).Log("msg", "the `msmq` block is deprecated - its usage is a no-op and it will be removed in the future")
+	}
+	if a.Service.UseApi != nil {
+		level.Warn(logger).Log("msg", "the `use_api` inside the `service` block is deprecated - its usage is a no-op and it will be removed in the future")
+	}
+	if a.Service.Where != nil {
+		level.Warn(logger).Log("msg", "the `where_clause` inside the `service` block is deprecated - its usage is a no-op and it will be removed in the future")
+	}
+	if a.Service.V2 != nil {
+		level.Warn(logger).Log("msg", "the `enable_v2_collector` inside the `service` block is deprecated - its usage is a no-op and it will be removed in the future")
 	}
 }
 
@@ -162,8 +182,11 @@ func (t SMTPConfig) Convert() windows_integration.SMTPConfig {
 
 // ServiceConfig handles settings for the windows_exporter service collector
 type ServiceConfig struct {
-	Include string `alloy:"include,attr,optional"`
-	Exclude string `alloy:"exclude,attr,optional"`
+	Include string  `alloy:"include,attr,optional"`
+	Exclude string  `alloy:"exclude,attr,optional"`
+	UseApi  *string `alloy:"use_api,attr,optional"`
+	Where   *string `alloy:"where_clause,attr,optional"`
+	V2      *string `alloy:"enable_v2_collector,attr,optional"`
 }
 
 // Convert converts the component's ServiceConfig to the integration's ServiceConfig.
@@ -236,6 +259,10 @@ func (t MSSQLConfig) Convert() windows_integration.MSSQLConfig {
 	return windows_integration.MSSQLConfig{
 		EnabledClasses: strings.Join(t.EnabledClasses, ","),
 	}
+}
+
+type MSMQConfig struct {
+	Where string `alloy:"where_clause,attr,optional"`
 }
 
 // LogicalDiskConfig handles settings for the windows_exporter logical disk collector

--- a/internal/component/prometheus/exporter/windows/windows.go
+++ b/internal/component/prometheus/exporter/windows/windows.go
@@ -20,5 +20,5 @@ func init() {
 
 func createExporter(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
 	a := args.(Arguments)
-	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)
+	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(opts.Logger), defaultInstanceKey)
 }

--- a/internal/component/prometheus/exporter/windows/windows_test.go
+++ b/internal/component/prometheus/exporter/windows/windows_test.go
@@ -3,6 +3,7 @@ package windows
 import (
 	"testing"
 
+	"github.com/go-kit/log"
 	"github.com/grafana/alloy/syntax"
 	"github.com/stretchr/testify/require"
 )
@@ -135,7 +136,7 @@ func TestConvert(t *testing.T) {
 	err := syntax.Unmarshal([]byte(exampleAlloyConfig), &args)
 	require.NoError(t, err)
 
-	conf := args.Convert()
+	conf := args.Convert(log.NewNopLogger())
 
 	require.Equal(t, "textfile,cpu", conf.EnabledCollectors)
 	require.Equal(t, "example", conf.Exchange.EnabledList)


### PR DESCRIPTION
A dependency was updated to resolve a CVE (see #3875).

The windows exporter change is because users have been complaining about difficulty with upgrades. If the change is approved do a similar change to the main branch.