### PR TITLE
Add no-op config params in windows exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@ Main (unreleased)
 
 - Upgrade `otelcol` components from OpenTelemetry v0.126.0 to v0.128.0 (@korniltsev)
 
+### Other changes
+
+-  Add no-op blocks and attributes to the `prometheus.exporter.windows` component (@ptodev).
+   Version 1.9.0 of Alloy removed the `msmq` block, as well as the `enable_v2_collector`, 
+   `where_clause`, and `use_api` attributes in the `service` block. 
+   This made it difficult for users to upgrade, so those attributes have now been made a no-op instead of being removed.
+
 v1.9.1
 -----------------
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
@@ -71,6 +71,12 @@ You can use the following blocks with `prometheus.exporter.windows`:
 | [`tcp`][tcp]                               | Configures the `tcp` collector.                | no       |
 | [`text_file`][text_file]                   | Configures the `text_file` collector.          | no       |
 
+{{< admonition type="note" >}}
+Starting with release 1.9.0, the `msmq` block is deprecated.
+It will be removed in a future release.
+You can still include this block in your configuration files. However, its usage is now a no-op.
+{{< /admonition >}}
+
 [dfsr]: #dfsr
 [dns]: #dns
 [exchange]: #exchange
@@ -275,6 +281,12 @@ User-supplied `exclude` and `include` strings are [wrapped][wrap-regex] in a reg
 For a service to be included, it must match the regular expression specified by `include` and must _not_ match the regular expression specified by `exclude`.
 
 User-supplied `exclude` and `include` strings are [wrapped][wrap-regex] in a regular expression.
+
+{{< admonition type="note" >}}
+Starting with release 1.9.0, the `use_api`, `where_clause`, and `enable_v2_collector` attributes are deprecated.
+They will be removed in a future release.
+You can still include these attributes in your configuration files. However, their usage is now a no-op.
+{{< /admonition >}}
 
 ### `smb`
 

--- a/internal/component/prometheus/exporter/windows/windows.go
+++ b/internal/component/prometheus/exporter/windows/windows.go
@@ -20,5 +20,5 @@ func init() {
 
 func createExporter(opts component.Options, args component.Arguments, defaultInstanceKey string) (integrations.Integration, string, error) {
 	a := args.(Arguments)
-	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)
+	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(opts.Logger), defaultInstanceKey)
 }

--- a/internal/component/prometheus/exporter/windows/windows_test.go
+++ b/internal/component/prometheus/exporter/windows/windows_test.go
@@ -3,6 +3,7 @@ package windows
 import (
 	"testing"
 
+	"github.com/go-kit/log"
 	"github.com/grafana/alloy/syntax"
 	"github.com/stretchr/testify/require"
 )
@@ -135,7 +136,7 @@ func TestConvert(t *testing.T) {
 	err := syntax.Unmarshal([]byte(exampleAlloyConfig), &args)
 	require.NoError(t, err)
 
-	conf := args.Convert()
+	conf := args.Convert(log.NewNopLogger())
 
 	require.Equal(t, "textfile,cpu", conf.EnabledCollectors)
 	require.Equal(t, "example", conf.Exchange.EnabledList)


### PR DESCRIPTION
Same as #3899 but for the main branch. This change makes it easier for users to upgrade Alloy versions after a recent breaking change to the config.