### PR TITLE
dbo11y: Change the table used to fetch queries for explain plans

### DIFF
--- a/internal/component/database_observability/mysql/collector/explain_plan.go
+++ b/internal/component/database_observability/mysql/collector/explain_plan.go
@@ -454,12 +454,12 @@ type queryInfo struct {
 }
 
 type ExplainPlanArguments struct {
-	DB             *sql.DB
-	InstanceKey    string
-	ScrapeInterval time.Duration
-	PerScrapeRatio float64
-	EntryHandler   loki.EntryHandler
-	LastSeen       time.Time
+	DB              *sql.DB
+	InstanceKey     string
+	ScrapeInterval  time.Duration
+	PerScrapeRatio  float64
+	EntryHandler    loki.EntryHandler
+	InitialLookback time.Time
 
 	Logger log.Logger
 }
@@ -500,7 +500,7 @@ func NewExplainPlan(args ExplainPlanArguments) (*ExplainPlan, error) {
 		queryCache:     make([]queryInfo, 0),
 		perScrapeRatio: args.PerScrapeRatio,
 		entryHandler:   args.EntryHandler,
-		lastSeen:       args.LastSeen,
+		lastSeen:       args.InitialLookback,
 		logger:         log.With(args.Logger, "collector", ExplainPlanName),
 		running:        atomic.NewBool(false),
 	}, nil

--- a/internal/component/database_observability/mysql/collector/explain_plan.go
+++ b/internal/component/database_observability/mysql/collector/explain_plan.go
@@ -31,14 +31,15 @@ const (
 
 const selectDigestsForExplainPlan = `
 	SELECT
-		CURRENT_SCHEMA,
+		SCHEMA_NAME,
 		DIGEST,
-		SQL_TEXT
-	FROM performance_schema.events_statements_history
-	WHERE TIMER_END > DATE_SUB(NOW(), INTERVAL 1 DAY)
-	AND SQL_TEXT IS NOT NULL
+		QUERY_SAMPLE_TEXT,
+		LAST_SEEN
+	FROM performance_schema.events_statements_summary_by_digest
+	WHERE LAST_SEEN > ?
+	AND QUERY_SAMPLE_TEXT IS NOT NULL
 	AND DIGEST IS NOT NULL
-	AND CURRENT_SCHEMA NOT IN ('mysql', 'performance_schema', 'sys', 'information_schema')`
+	AND SCHEMA_NAME NOT IN ('mysql', 'performance_schema', 'sys', 'information_schema')`
 
 const selectExplainPlanPrefix = `EXPLAIN FORMAT=JSON `
 
@@ -458,6 +459,7 @@ type ExplainPlanArguments struct {
 	ScrapeInterval time.Duration
 	PerScrapeRatio float64
 	EntryHandler   loki.EntryHandler
+	LastSeen       time.Time
 
 	Logger log.Logger
 }
@@ -471,6 +473,7 @@ type ExplainPlan struct {
 	perScrapeRatio   float64
 	currentBatchSize int
 	entryHandler     loki.EntryHandler
+	lastSeen         time.Time
 
 	logger  log.Logger
 	running *atomic.Bool
@@ -497,6 +500,7 @@ func NewExplainPlan(args ExplainPlanArguments) (*ExplainPlan, error) {
 		queryCache:     make([]queryInfo, 0),
 		perScrapeRatio: args.PerScrapeRatio,
 		entryHandler:   args.EntryHandler,
+		lastSeen:       args.LastSeen,
 		logger:         log.With(args.Logger, "collector", ExplainPlanName),
 		running:        atomic.NewBool(false),
 	}, nil
@@ -548,7 +552,7 @@ func (c *ExplainPlan) Stop() {
 }
 
 func (c *ExplainPlan) populateQueryCache(ctx context.Context) error {
-	rs, err := c.dbConnection.QueryContext(ctx, selectDigestsForExplainPlan)
+	rs, err := c.dbConnection.QueryContext(ctx, selectDigestsForExplainPlan, c.lastSeen)
 	if err != nil {
 		level.Error(c.logger).Log("msg", "failed to fetch digests for explain plans", "err", err)
 		return err
@@ -563,11 +567,15 @@ func (c *ExplainPlan) populateQueryCache(ctx context.Context) error {
 		}
 
 		var qi queryInfo
-		if err = rs.Scan(&qi.schemaName, &qi.digest, &qi.queryText); err != nil {
+		var ls time.Time
+		if err = rs.Scan(&qi.schemaName, &qi.digest, &qi.queryText, &ls); err != nil {
 			level.Error(c.logger).Log("msg", "failed to scan digest for explain plans", "err", err)
 			return err
 		}
 		c.queryCache = append(c.queryCache, qi)
+		if ls.After(c.lastSeen) {
+			c.lastSeen = ls
+		}
 	}
 	// Calculate batch size based on current cache size
 	c.currentBatchSize = int(math.Ceil(float64(len(c.queryCache)) * c.perScrapeRatio))

--- a/internal/component/database_observability/mysql/collector/explain_plan_test.go
+++ b/internal/component/database_observability/mysql/collector/explain_plan_test.go
@@ -292,22 +292,22 @@ func TestExplainPlanRedactor(t *testing.T) {
 	}
 }
 
-func TestExplainPlanOutputInvalidJSON(t *testing.T) {
-	notJsonData := []byte("not json data")
-	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
-	_, err := newExplainPlanOutput(logger, "", "", notJsonData, "")
-	require.Error(t, err)
-	require.ErrorContains(t, err, "failed to get query block: Key path not found")
-}
-
-func TestExplainPlanOutputUnknownOperation(t *testing.T) {
-	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
-	explainPlanOutput, err := newExplainPlanOutput(logger, "", "", []byte("{\"query_block\": {\"operation\": \"some unknown thing we've never seen before.\"}}"), "")
-	require.NoError(t, err)
-	require.Equal(t, explainPlanOutputOperationUnknown, explainPlanOutput.Plan.Operation)
-}
-
 func TestExplainPlanOutput(t *testing.T) {
+	t.Run("invalid json", func(t *testing.T) {
+		notJsonData := []byte("not json data")
+		logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
+		_, err := newExplainPlanOutput(logger, "", "", notJsonData, "")
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to get query block: Key path not found")
+	})
+
+	t.Run("unknown operation", func(t *testing.T) {
+		logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
+		explainPlanOutput, err := newExplainPlanOutput(logger, "", "", []byte("{\"query_block\": {\"operation\": \"some unknown thing we've never seen before.\"}}"), "")
+		require.NoError(t, err)
+		require.Equal(t, explainPlanOutputOperationUnknown, explainPlanOutput.Plan.Operation)
+	})
+
 	currentTime := time.Now().Format(time.RFC3339)
 	tests := []struct {
 		dbVersion string

--- a/internal/component/database_observability/mysql/collector/explain_plan_test.go
+++ b/internal/component/database_observability/mysql/collector/explain_plan_test.go
@@ -1496,13 +1496,13 @@ func TestExplainPlan(t *testing.T) {
 		defer lokiClient.Stop()
 
 		c, err := NewExplainPlan(ExplainPlanArguments{
-			DB:             db,
-			Logger:         log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout)),
-			InstanceKey:    "mysql-db",
-			ScrapeInterval: time.Second,
-			PerScrapeRatio: 1,
-			EntryHandler:   lokiClient,
-			LastSeen:       lastSeen,
+			DB:              db,
+			Logger:          log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout)),
+			InstanceKey:     "mysql-db",
+			ScrapeInterval:  time.Second,
+			PerScrapeRatio:  1,
+			EntryHandler:    lokiClient,
+			InitialLookback: lastSeen,
 		})
 		require.NoError(t, err)
 

--- a/internal/component/database_observability/mysql/collector/explain_plan_test.go
+++ b/internal/component/database_observability/mysql/collector/explain_plan_test.go
@@ -1,7 +1,6 @@
 package collector
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -1525,7 +1524,7 @@ func TestExplainPlan(t *testing.T) {
 				nextSeen,
 			))
 			lastSeen = nextSeen
-			err := c.fetchExplainPlans(context.Background())
+			err := c.fetchExplainPlans(t.Context())
 			require.NoError(t, err)
 		})
 
@@ -1541,7 +1540,7 @@ func TestExplainPlan(t *testing.T) {
 				"some_query_text",
 				lastSeen.Add(time.Second*5),
 			))
-			err := c.fetchExplainPlans(context.Background())
+			err := c.fetchExplainPlans(t.Context())
 			require.NoError(t, err)
 		})
 	})

--- a/internal/component/database_observability/mysql/collector/explain_plan_test.go
+++ b/internal/component/database_observability/mysql/collector/explain_plan_test.go
@@ -1493,6 +1493,7 @@ func TestExplainPlan(t *testing.T) {
 
 		lastSeen := time.Now().Add(-time.Hour)
 		lokiClient := loki_fake.NewClient(func() {})
+		defer lokiClient.Stop()
 
 		c, err := NewExplainPlan(ExplainPlanArguments{
 			DB:             db,
@@ -1524,7 +1525,7 @@ func TestExplainPlan(t *testing.T) {
 				nextSeen,
 			))
 			lastSeen = nextSeen
-			err := c.fetchExplainPlans(t.Context())
+			err := c.populateQueryCache(t.Context())
 			require.NoError(t, err)
 		})
 
@@ -1540,7 +1541,7 @@ func TestExplainPlan(t *testing.T) {
 				"some_query_text",
 				lastSeen.Add(time.Second*5),
 			))
-			err := c.fetchExplainPlans(t.Context())
+			err := c.populateQueryCache(t.Context())
 			require.NoError(t, err)
 		})
 	})

--- a/internal/component/database_observability/mysql/component.go
+++ b/internal/component/database_observability/mysql/component.go
@@ -55,6 +55,7 @@ type Arguments struct {
 	SetupConsumersCollectInterval time.Duration       `alloy:"setup_consumers_collect_interval,attr,optional"`
 	ExplainPlanCollectInterval    time.Duration       `alloy:"explain_plan_collect_interval,attr,optional"`
 	ExplainPlanPerCollectRatio    float64             `alloy:"explain_plan_per_collect_ratio,attr,optional"`
+	ExplainPlanInitialLookback    time.Duration       `alloy:"explain_plan_initial_lookback,attr,optional"`
 	LocksCollectInterval          time.Duration       `alloy:"locks_collect_interval,attr,optional"`
 	LocksThreshold                time.Duration       `alloy:"locks_threshold,attr,optional"`
 	ForwardTo                     []loki.LogsReceiver `alloy:"forward_to,attr"`
@@ -69,6 +70,7 @@ var DefaultArguments = Arguments{
 	SetupConsumersCollectInterval: 1 * time.Hour,
 	ExplainPlanCollectInterval:    1 * time.Minute,
 	ExplainPlanPerCollectRatio:    1.0,
+	ExplainPlanInitialLookback:    24 * time.Hour,
 	LocksCollectInterval:          30 * time.Second,
 	LocksThreshold:                1 * time.Second,
 }
@@ -368,6 +370,7 @@ func (c *Component) startCollectors() error {
 			PerScrapeRatio: c.args.ExplainPlanPerCollectRatio,
 			Logger:         c.opts.Logger,
 			EntryHandler:   entryHandler,
+			LastSeen:       time.Now().Add(-c.args.ExplainPlanInitialLookback),
 		})
 		if err != nil {
 			level.Error(c.opts.Logger).Log("msg", "failed to create ExplainPlan collector", "err", err)

--- a/internal/component/database_observability/mysql/component.go
+++ b/internal/component/database_observability/mysql/component.go
@@ -364,13 +364,13 @@ func (c *Component) startCollectors() error {
 
 	if collectors[collector.ExplainPlanName] {
 		epCollector, err := collector.NewExplainPlan(collector.ExplainPlanArguments{
-			DB:             dbConnection,
-			InstanceKey:    c.instanceKey,
-			ScrapeInterval: c.args.ExplainPlanCollectInterval,
-			PerScrapeRatio: c.args.ExplainPlanPerCollectRatio,
-			Logger:         c.opts.Logger,
-			EntryHandler:   entryHandler,
-			LastSeen:       time.Now().Add(-c.args.ExplainPlanInitialLookback),
+			DB:              dbConnection,
+			InstanceKey:     c.instanceKey,
+			ScrapeInterval:  c.args.ExplainPlanCollectInterval,
+			PerScrapeRatio:  c.args.ExplainPlanPerCollectRatio,
+			Logger:          c.opts.Logger,
+			EntryHandler:    entryHandler,
+			InitialLookback: time.Now().Add(-c.args.ExplainPlanInitialLookback),
 		})
 		if err != nil {
 			level.Error(c.opts.Logger).Log("msg", "failed to create ExplainPlan collector", "err", err)


### PR DESCRIPTION
#### PR Description
Changes the performance_schema table used to fetch queries, so that more (all?) digests should be able to be fetched.

I didn't change the Changelog, given that this is a minor improvement to an unreleased feature. I could add a bullet point if we think it's important.

#### PR Checklist

- [X] CHANGELOG.md updated
- [ ] Documentation added
- [X] Tests updated
- [ ] Config converters updated
