### PR TITLE
Update Go version in build image

### DIFF
--- a/.github/workflows/check-linux-build-image.yml
+++ b/.github/workflows/check-linux-build-image.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         build:
-          - runtime: golang:1.24.3-alpine3.21
-          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.24.3-bookworm
+          - runtime: golang:1.24.4-alpine3.21
+          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.24.4-bookworm
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/create_build_image.yml
+++ b/.github/workflows/create_build_image.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         build:
-          - runtime: golang:1.24.3-alpine3.21
-          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.24.3-bookworm
+          - runtime: golang:1.24.4-alpine3.21
+          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.24.4-bookworm
             suffix: "-boringcrypto"
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The new Go version fixes CVE-2025-22874, CVE-2025-4673, and CVE-2025-0913.