### PR TITLE
Upgrade to Go 1.24.4 and the new Alloy build image.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
   build_linux:
     name: Build on Linux
     runs-on: github-hosted-ubuntu-x64-large
-    container: grafana/alloy-build-image:v0.1.19@sha256:0b87a2b014ab4bed067bad00d10e9778e7e93d999bf1d46ef774e3568a7417a3
+    container: grafana/alloy-build-image:v0.1.20@sha256:e9698b5a96851f353cb3264b6f17a170d5303d44cfb641a2fb2562e909e0924b
     strategy:
       matrix:
         os: [linux]
@@ -42,7 +42,7 @@ jobs:
   build_linux_boringcrypto:
     name: Build on Linux (boringcrypto)
     runs-on: github-hosted-ubuntu-x64-large
-    container: grafana/alloy-build-image:v0.1.19-boringcrypto@sha256:6adc935994d83acd45a31c4da447676a4f71abb2e0d1a80fb3a652a339216e07
+    container: grafana/alloy-build-image:v0.1.20-boringcrypto@sha256:5f50493541cb33d656f7fface79e9b920cfca1a75ed0da4ed61517b8d06e0ef7
     strategy:
       matrix:
         os: [linux]
@@ -123,7 +123,7 @@ jobs:
   build_freebsd:
     name: Build on FreeBSD (AMD64)
     runs-on: github-hosted-ubuntu-x64-large
-    container: grafana/alloy-build-image:v0.1.19@sha256:0b87a2b014ab4bed067bad00d10e9778e7e93d999bf1d46ef774e3568a7417a3
+    container: grafana/alloy-build-image:v0.1.20@sha256:e9698b5a96851f353cb3264b6f17a170d5303d44cfb641a2fb2562e909e0924b
     steps:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/publish-alloy-linux.yml
+++ b/.github/workflows/publish-alloy-linux.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   publish_linux_container:
     name: Publish Alloy Linux container
-    container: grafana/alloy-build-image:v0.1.19@sha256:0b87a2b014ab4bed067bad00d10e9778e7e93d999bf1d46ef774e3568a7417a3
+    container: grafana/alloy-build-image:v0.1.20@sha256:e9698b5a96851f353cb3264b6f17a170d5303d44cfb641a2fb2562e909e0924b
     runs-on:
       labels: github-hosted-ubuntu-x64-large
     permissions:

--- a/.github/workflows/publish-alloy-release.yml
+++ b/.github/workflows/publish-alloy-release.yml
@@ -34,7 +34,7 @@ jobs:
 
   publish_github_release:
     name: Publish GitHub release
-    container: grafana/alloy-build-image:v0.1.19@sha256:0b87a2b014ab4bed067bad00d10e9778e7e93d999bf1d46ef774e3568a7417a3
+    container: grafana/alloy-build-image:v0.1.20@sha256:e9698b5a96851f353cb3264b6f17a170d5303d44cfb641a2fb2562e909e0924b
     runs-on:
       labels: github-hosted-ubuntu-x64-large
     needs:

--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -15,7 +15,7 @@ jobs:
     name: Test (Full)
     runs-on: ubuntu-latest-8-cores
     container:
-      image: grafana/alloy-build-image:v0.1.19@sha256:0b87a2b014ab4bed067bad00d10e9778e7e93d999bf1d46ef774e3568a7417a3
+      image: grafana/alloy-build-image:v0.1.20@sha256:e9698b5a96851f353cb3264b6f17a170d5303d44cfb641a2fb2562e909e0924b
       volumes:
         - /var/run/docker.sock
     steps:

--- a/.github/workflows/test_linux_system_packages.yml
+++ b/.github/workflows/test_linux_system_packages.yml
@@ -17,7 +17,7 @@ jobs:
     name: Test Linux system packages
     runs-on: ubuntu-latest
     container:
-      image: grafana/alloy-build-image:v0.1.19@sha256:0b87a2b014ab4bed067bad00d10e9778e7e93d999bf1d46ef774e3568a7417a3
+      image: grafana/alloy-build-image:v0.1.20@sha256:e9698b5a96851f353cb3264b6f17a170d5303d44cfb641a2fb2562e909e0924b
       volumes:
         - /var/run/docker.sock
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
 # in environment variables.
 
-FROM --platform=$BUILDPLATFORM grafana/alloy-build-image:v0.1.19 AS ui-build
+FROM --platform=$BUILDPLATFORM grafana/alloy-build-image:v0.1.20 AS ui-build
 ARG BUILDPLATFORM
 COPY ./internal/web/ui /ui
 WORKDIR /ui
@@ -12,7 +12,7 @@ RUN --mount=type=cache,target=/ui/node_modules,sharing=locked \
     yarn --network-timeout=1200000                            \
     && yarn run build
 
-FROM --platform=$BUILDPLATFORM grafana/alloy-build-image:v0.1.19 AS build
+FROM --platform=$BUILDPLATFORM grafana/alloy-build-image:v0.1.20 AS build
 
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -15,7 +15,7 @@ docs: check-cloudwatch-integration
 endif
 
 check-cloudwatch-integration:
-	$(PODMAN) run -v "$(shell git rev-parse --show-toplevel):/repo:z" -v "$(shell pwd):/docs:z" -w /repo golang:1.24.3-bullseye go run internal/static/integrations/cloudwatch_exporter/docs/doc.go check /docs/sources/reference/components/prometheus/prometheus.exporter.cloudwatch.md
+	$(PODMAN) run -v "$(shell git rev-parse --show-toplevel):/repo:z" -v "$(shell pwd):/docs:z" -w /repo golang:1.24.4-bullseye go run internal/static/integrations/cloudwatch_exporter/docs/doc.go check /docs/sources/reference/components/prometheus/prometheus.exporter.cloudwatch.md
 
 generate-cloudwatch-integration:
-	$(PODMAN) run -v "$(shell git rev-parse --show-toplevel):/repo:z" -v "$(shell pwd):/docs:z" -w /repo golang:1.24.3-bullseye go run internal/static/integrations/cloudwatch_exporter/docs/doc.go generate
+	$(PODMAN) run -v "$(shell git rev-parse --show-toplevel):/repo:z" -v "$(shell pwd):/docs:z" -w /repo golang:1.24.4-bullseye go run internal/static/integrations/cloudwatch_exporter/docs/doc.go generate

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/alloy
 
-go 1.24.3
+go 1.24.4
 
 require (
 	cloud.google.com/go/pubsub v1.45.3

--- a/internal/cmd/integration-tests/configs/kafka/Dockerfile
+++ b/internal/cmd/integration-tests/configs/kafka/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.3 as build
+FROM golang:1.24.4 as build
 WORKDIR /app/
 COPY go.mod go.sum ./
 COPY syntax/go.mod syntax/go.sum ./syntax/

--- a/internal/cmd/integration-tests/configs/otel-gen/Dockerfile
+++ b/internal/cmd/integration-tests/configs/otel-gen/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.3 as build
+FROM golang:1.24.4 as build
 WORKDIR /app/
 COPY go.mod go.sum ./
 COPY syntax/go.mod syntax/go.sum ./syntax/

--- a/internal/cmd/integration-tests/configs/prom-gen/Dockerfile
+++ b/internal/cmd/integration-tests/configs/prom-gen/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.3 as build
+FROM golang:1.24.4 as build
 WORKDIR /app/
 COPY go.mod go.sum ./
 COPY syntax/go.mod syntax/go.sum ./syntax/

--- a/syntax/go.mod
+++ b/syntax/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/alloy/syntax
 
-go 1.24.3
+go 1.24.4
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/tools/make/build-container.mk
+++ b/tools/make/build-container.mk
@@ -34,7 +34,7 @@
 # variable names should be passed through to the container.
 
 USE_CONTAINER       ?= 0
-BUILD_IMAGE_VERSION ?= v0.1.19
+BUILD_IMAGE_VERSION ?= v0.1.20
 BUILD_IMAGE         ?= grafana/alloy-build-image:$(BUILD_IMAGE_VERSION)
 DOCKER_OPTS         ?= -it
 


### PR DESCRIPTION
This resolves CVEs:
* CVE-2025-22874
* CVE-2025-4673 
* CVE-2025-0913 