### PR TITLE
database_observability: fix format of log message for locks collector

### DIFF
--- a/internal/component/database_observability/mysql/collector/locks.go
+++ b/internal/component/database_observability/mysql/collector/locks.go
@@ -19,7 +19,7 @@ const (
 	LocksName       = "locks"
 	OP_DATA_LOCKS   = "query_data_locks"
 	selectDataLocks = `
-		SELECT 
+		SELECT
 			waiting_stmt_current.TIMER_WAIT waitingTimerWait,
 			waiting_stmt_current.LOCK_TIME waitingLockTime,
 			waiting_stmt_current.DIGEST waitingDigest,
@@ -40,7 +40,7 @@ const (
 				AND lock_waits.ENGINE = blocking_lock.ENGINE
 		JOIN performance_schema.events_statements_current blocking_stmt_current
 			ON blocking_lock.thread_id = blocking_stmt_current.thread_id
-				AND blocking_stmt_current.EVENT_ID < blocking_lock.EVENT_ID;`
+				AND blocking_stmt_current.EVENT_ID < blocking_lock.EVENT_ID`
 )
 
 type LockArguments struct {
@@ -156,7 +156,7 @@ func (c *LockCollector) fetchLocks(ctx context.Context) error {
 		// only log if the lock_time is longer than the threshold
 		if waitingLockTime > secondsToPicoseconds(c.lockTimeThreshold.Seconds()) {
 			lockMsg := fmt.Sprintf(
-				`waiting_digest="%s" waiting_digest_text="%s" blocking_digest="%s" blocking_digest_text="%s" waiting_timer_wait="%f ms" waiting_lock_time="%f ms" blocking_timer_wait="%f ms" blocking_lock_time="%f ms"`,
+				`waiting_digest="%s" waiting_digest_text="%s" blocking_digest="%s" blocking_digest_text="%s" waiting_timer_wait="%fms" waiting_lock_time="%fms" blocking_timer_wait="%fms" blocking_lock_time="%fms"`,
 				waitingDigest,
 				waitingDigestText,
 				blockingDigest,

--- a/internal/component/database_observability/mysql/collector/locks_test.go
+++ b/internal/component/database_observability/mysql/collector/locks_test.go
@@ -117,7 +117,7 @@ func Test_QueryLocks(t *testing.T) {
 		require.NoError(t, mock.ExpectationsWereMet())
 		lokiEntries := lokiClient.Received()
 		assert.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_DATA_LOCKS, "instance": "mysql-db"}, lokiEntries[0].Labels)
-		assert.Equal(t, `level="info" waiting_digest="abc123" waiting_digest_text="SELECT * FROM users WHERE id = ?" blocking_digest="def456" blocking_digest_text="UPDATE users SET name = ? WHERE id = ?" waiting_timer_wait="1500.000000 ms" waiting_lock_time="1000.000000 ms" blocking_timer_wait="2000.000000 ms" blocking_lock_time="1700.000000 ms"`, lokiEntries[0].Line)
+		assert.Equal(t, `level="info" waiting_digest="abc123" waiting_digest_text="SELECT * FROM users WHERE id = ?" blocking_digest="def456" blocking_digest_text="UPDATE users SET name = ? WHERE id = ?" waiting_timer_wait="1500.000000ms" waiting_lock_time="1000.000000ms" blocking_timer_wait="2000.000000ms" blocking_lock_time="1700.000000ms"`, lokiEntries[0].Line)
 	})
 
 	t.Run("multiple data locks are logged", func(t *testing.T) {
@@ -183,9 +183,9 @@ func Test_QueryLocks(t *testing.T) {
 		lokiEntries := lokiClient.Received()
 		require.Len(t, lokiEntries, 2)
 		assert.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_DATA_LOCKS, "instance": "mysql-db"}, lokiEntries[0].Labels)
-		assert.Equal(t, `level="info" waiting_digest="abc123" waiting_digest_text="SELECT * FROM users WHERE id = ?" blocking_digest="def456" blocking_digest_text="UPDATE users SET name = ? WHERE id = ?" waiting_timer_wait="1500.000000 ms" waiting_lock_time="1000.000000 ms" blocking_timer_wait="2000.000000 ms" blocking_lock_time="1700.000000 ms"`, lokiEntries[0].Line)
+		assert.Equal(t, `level="info" waiting_digest="abc123" waiting_digest_text="SELECT * FROM users WHERE id = ?" blocking_digest="def456" blocking_digest_text="UPDATE users SET name = ? WHERE id = ?" waiting_timer_wait="1500.000000ms" waiting_lock_time="1000.000000ms" blocking_timer_wait="2000.000000ms" blocking_lock_time="1700.000000ms"`, lokiEntries[0].Line)
 		assert.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_DATA_LOCKS, "instance": "mysql-db"}, lokiEntries[1].Labels)
-		assert.Equal(t, `level="info" waiting_digest="xyz789" waiting_digest_text="SELECT * FROM orders WHERE user_id = ?" blocking_digest="ghi012" blocking_digest_text="DELETE FROM sessions WHERE expired = ?" waiting_timer_wait="2500.000000 ms" waiting_lock_time="2000.000000 ms" blocking_timer_wait="3000.000000 ms" blocking_lock_time="2700.000000 ms"`, lokiEntries[1].Line)
+		assert.Equal(t, `level="info" waiting_digest="xyz789" waiting_digest_text="SELECT * FROM orders WHERE user_id = ?" blocking_digest="ghi012" blocking_digest_text="DELETE FROM sessions WHERE expired = ?" waiting_timer_wait="2500.000000ms" waiting_lock_time="2000.000000ms" blocking_timer_wait="3000.000000ms" blocking_lock_time="2700.000000ms"`, lokiEntries[1].Line)
 	})
 
 	t.Run("recoverable sql error in selectDataLocks result set", func(t *testing.T) {
@@ -243,7 +243,7 @@ func Test_QueryLocks(t *testing.T) {
 		lokiEntries := lokiClient.Received()
 		require.Len(t, lokiEntries, 1)
 		assert.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_DATA_LOCKS, "instance": "mysql-db"}, lokiEntries[0].Labels)
-		assert.Equal(t, `level="info" waiting_digest="abc123" waiting_digest_text="SELECT * FROM users WHERE id = ?" blocking_digest="def456" blocking_digest_text="UPDATE users SET name = ? WHERE id = ?" waiting_timer_wait="1500.000000 ms" waiting_lock_time="1000.000000 ms" blocking_timer_wait="2000.000000 ms" blocking_lock_time="1700.000000 ms"`, lokiEntries[0].Line)
+		assert.Equal(t, `level="info" waiting_digest="abc123" waiting_digest_text="SELECT * FROM users WHERE id = ?" blocking_digest="def456" blocking_digest_text="UPDATE users SET name = ? WHERE id = ?" waiting_timer_wait="1500.000000ms" waiting_lock_time="1000.000000ms" blocking_timer_wait="2000.000000ms" blocking_lock_time="1700.000000ms"`, lokiEntries[0].Line)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
@@ -309,7 +309,7 @@ func Test_QueryLocks(t *testing.T) {
 		lokiEntries := lokiClient.Received()
 		require.Len(t, lokiEntries, 1)
 		assert.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_DATA_LOCKS, "instance": "mysql-db"}, lokiEntries[0].Labels)
-		assert.Equal(t, `level="info" waiting_digest="abc123" waiting_digest_text="SELECT * FROM users WHERE id = ?" blocking_digest="def456" blocking_digest_text="UPDATE users SET name = ? WHERE id = ?" waiting_timer_wait="1500.000000 ms" waiting_lock_time="1000.000000 ms" blocking_timer_wait="2000.000000 ms" blocking_lock_time="1700.000000 ms"`, lokiEntries[0].Line)
+		assert.Equal(t, `level="info" waiting_digest="abc123" waiting_digest_text="SELECT * FROM users WHERE id = ?" blocking_digest="def456" blocking_digest_text="UPDATE users SET name = ? WHERE id = ?" waiting_timer_wait="1500.000000ms" waiting_lock_time="1000.000000ms" blocking_timer_wait="2000.000000ms" blocking_lock_time="1700.000000ms"`, lokiEntries[0].Line)
 	})
 
 	t.Run("result set iteration error", func(t *testing.T) {
@@ -378,7 +378,7 @@ func Test_QueryLocks(t *testing.T) {
 		lokiEntries := lokiClient.Received()
 		require.Len(t, lokiEntries, 1)
 		assert.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_DATA_LOCKS, "instance": "mysql-db"}, lokiEntries[0].Labels)
-		assert.Equal(t, `level="info" waiting_digest="abc123" waiting_digest_text="SELECT * FROM users WHERE id = ?" blocking_digest="def456" blocking_digest_text="UPDATE users SET name = ? WHERE id = ?" waiting_timer_wait="1500.000000 ms" waiting_lock_time="1000.000000 ms" blocking_timer_wait="2000.000000 ms" blocking_lock_time="1700.000000 ms"`, lokiEntries[0].Line)
+		assert.Equal(t, `level="info" waiting_digest="abc123" waiting_digest_text="SELECT * FROM users WHERE id = ?" blocking_digest="def456" blocking_digest_text="UPDATE users SET name = ? WHERE id = ?" waiting_timer_wait="1500.000000ms" waiting_lock_time="1000.000000ms" blocking_timer_wait="2000.000000ms" blocking_lock_time="1700.000000ms"`, lokiEntries[0].Line)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 }


### PR DESCRIPTION
#### PR Description
Make sure there's no space between number and unit in time fields, so they can be used with `unwrap`.

No need to add a changelog entry.

#### Which issue(s) this PR fixes
n.a.

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
