### PR TITLE
Update cloudwatch logs receiver with latest upstream changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Main (unreleased)
 
 - Update secret-filter gitleaks.toml from v8.19.0 to v8.26.0 (@andrejshapal)
 
+- Add `storage` and `start_from` args to cloudwatch logs receiver. (@boernd)
+
 ### Bugfixes
 
 - Fix the `validate` command not understanding the `livedebugging` block. (@dehaansa)

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.awscloudwatch.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.awscloudwatch.md
@@ -39,11 +39,12 @@ otelcol.receiver.awscloudwatch "<LABEL>" {
 
 You can use the following arguments with `otelcol.receiver.awscloudwatch`:
 
-| Name            | Type     | Description                      | Default | Required |
-| --------------- | -------- | -------------------------------- | ------- | -------- |
-| `region`        | `string` | AWS region to collect logs from. |         | yes      |
-| `imds_endpoint` | `string` | Custom EC2 IMDS endpoint to use. |         | no       |
-| `profile`       | `string` | AWS credentials profile to use.  |         | no       |
+| Name            | Type                       | Description                                                               | Default | Required |
+| --------------- | -------------------------- | ------------------------------------------------------------------------- | ------- | -------- |
+| `region`        | `string`                   | AWS region to collect logs from.                                          |         | yes      |
+| `imds_endpoint` | `string`                   | Custom EC2 IMDS endpoint to use.                                          |         | no       |
+| `profile`       | `string`                   | AWS credentials profile to use.                                           |         | no       |
+| `storage`       | `capsule(otelcol.Handler)` | Handler from an `otelcol.storage` component to use for persisting state.  |         | no       |
 
 If `imds_endpoint` isn't specified, and the environment variable `AWS_EC2_METADATA_SERVICE_ENDPOINT` has a value, it will be used as the IMDS endpoint.
 
@@ -81,6 +82,7 @@ The following arguments are supported:
 | ------------------------ | ---------- | -------------------------------------------------------------- | ------- | -------- |
 | `max_events_per_request` | `int`      | Maximum number of events to process per request to CloudWatch. | `1000`  | no       |
 | `poll_interval`          | `duration` | How frequently to poll for new log entries.                    | `"1m"`  | no       |
+| `start_from`             | `string`   | Timestamp in RFC3339 format where to start reading logs.       | `""`    | no       |
 
 The `logs` block supports the following blocks:
 

--- a/internal/component/otelcol/receiver/awscloudwatch/awscloudwatch_test.go
+++ b/internal/component/otelcol/receiver/awscloudwatch/awscloudwatch_test.go
@@ -25,6 +25,7 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 			expected: awscloudwatchreceiver.Config{
 				Region: "us-west-2",
 				Logs: &awscloudwatchreceiver.LogsConfig{
+					StartFrom:           "",
 					PollInterval:        time.Minute,
 					MaxEventsPerRequest: 1000,
 					Groups: awscloudwatchreceiver.GroupConfig{
@@ -156,6 +157,32 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 				},
 			},
 		},
+		{
+			testName: "start_from configuration set",
+			cfg: `
+				region = "us-west-2"
+				logs {
+					poll_interval = "1m"
+					start_from = "2025-06-25T00:00:00Z"
+				}
+				output {}
+			`,
+			expected: awscloudwatchreceiver.Config{
+				Region: "us-west-2",
+				Logs: &awscloudwatchreceiver.LogsConfig{
+					StartFrom:           "2025-06-25T00:00:00Z",
+					PollInterval:        time.Minute,
+					MaxEventsPerRequest: 1000,
+					Groups: awscloudwatchreceiver.GroupConfig{
+						AutodiscoverConfig: &awscloudwatchreceiver.AutodiscoverConfig{
+							Limit:   50,
+							Streams: awscloudwatchreceiver.StreamConfig{},
+						},
+						NamedConfigs: map[string]awscloudwatchreceiver.StreamConfig{},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -232,6 +259,18 @@ func TestArguments_Validate(t *testing.T) {
 				output {}
 			`,
 			expectedError: "both autodiscover and named configs are configured, Only one or the other is permitted",
+		},
+		{
+			testName: "invalid start_from configuration set",
+			cfg: `
+				region = "us-west-2"
+				logs {
+					poll_interval = "1m"
+					start_from = "earliest"
+				}
+				output {}
+			`,
+			expectedError: "invalid start_from time format",
 		},
 	}
 

--- a/internal/component/otelcol/receiver/awscloudwatch/config_awscloudwatch.go
+++ b/internal/component/otelcol/receiver/awscloudwatch/config_awscloudwatch.go
@@ -13,6 +13,7 @@ type LogsConfig struct {
 	PollInterval        time.Duration `alloy:"poll_interval,attr,optional"`
 	MaxEventsPerRequest int           `alloy:"max_events_per_request,attr,optional"`
 	Groups              GroupConfig   `alloy:"groups,block,optional"`
+	StartFrom           string        `alloy:"start_from,attr,optional"`
 }
 
 func (args *LogsConfig) Convert() *awscloudwatchreceiver.LogsConfig {
@@ -23,6 +24,7 @@ func (args *LogsConfig) Convert() *awscloudwatchreceiver.LogsConfig {
 		PollInterval:        args.PollInterval,
 		MaxEventsPerRequest: args.MaxEventsPerRequest,
 		Groups:              args.Groups.Convert(),
+		StartFrom:           args.StartFrom,
 	}
 }
 


### PR DESCRIPTION
#### PR Description

Starting with Alloy 1.9.x the cloudwatch logs starts reading from the start which causes duplicate logs in case of restarts.

* Add `start_from` arg
* Add storage capabilities

Relates-To: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/39007

#### PR Checklist

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [x] Config converters updated
