### PR TITLE
Build all windows container images on the same Windows version

### DIFF
--- a/.github/workflows/check-windows-container.yml
+++ b/.github/workflows/check-windows-container.yml
@@ -10,6 +10,7 @@ on:
       - '.github/workflows/publish-alloy.yml'
       - '.github/workflows/publish-alloy-devel.yml'
       - '.github/workflows/publish-alloy-release.yml'
+      - '.github/workflows/publish-alloy-windows.yml'
   pull_request:
     paths:
       - 'Dockerfile.windows'
@@ -18,6 +19,7 @@ on:
       - '.github/workflows/publish-alloy.yml'
       - '.github/workflows/publish-alloy-devel.yml'
       - '.github/workflows/publish-alloy-release.yml'
+      - '.github/workflows/publish-alloy-windows.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/publish-alloy-windows.yml
+++ b/.github/workflows/publish-alloy-windows.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Build and publish the container
       # TODO: Run "make alloy-image-windows" instead?
       run: |
-        & "C:/Program Files/git/bin/bash.exe" -c 'PUSH_ALLOY_IMAGE=${SHOULD_PUSH_ALLOY_IMAGE} WINDOWS_VERSION=${{matrix.os}} ALLOY_GO_VERSION=${GO_VERSION} ./tools/ci/docker-containers-windows ${IMG_NAME}'
+        & "C:/Program Files/git/bin/bash.exe" -c 'PUSH_ALLOY_IMAGE=${SHOULD_PUSH_ALLOY_IMAGE} WINDOWS_VERSION=${{matrix.os}} ALLOY_GO_VERSION=${GO_VERSION} ./tools/ci/docker-containers-windows.ps1 ${IMG_NAME}'
       env:
         SHOULD_PUSH_ALLOY_IMAGE: ${{ inputs.push }}
         IMG_NAME: ${{ inputs.img-name }}

--- a/.github/workflows/publish-alloy-windows.yml
+++ b/.github/workflows/publish-alloy-windows.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Build and publish the container
       # TODO: Run "make alloy-image-windows" instead?
       run: |
-        & "C:/Program Files/git/bin/bash.exe" -c 'PUSH_ALLOY_IMAGE=${SHOULD_PUSH_ALLOY_IMAGE} WINDOWS_VERSION=${{matrix.os}} ALLOY_GO_VERSION=${GO_VERSION} ./tools/ci/docker-containers-windows.ps1 ${IMG_NAME}'
+        ./tools/ci/docker-containers-windows.ps1
       env:
         SHOULD_PUSH_ALLOY_IMAGE: ${{ inputs.push }}
         IMG_NAME: ${{ inputs.img-name }}

--- a/.github/workflows/publish-alloy-windows.yml
+++ b/.github/workflows/publish-alloy-windows.yml
@@ -60,6 +60,12 @@ jobs:
         $go_short_version = $go_version_split[0] + "." + $go_version_split[1]
         "alloy_go_version=$go_short_version" >> $env:GITHUB_OUTPUT
 
+    - run: make generate-ui
+    - run: echo "GO_TAGS=builtinassets" | Out-File -FilePath $env:GITHUB_ENV -Append
+    - run: echo "GOOS=windows" | Out-File -FilePath $env:GITHUB_ENV -Append
+    - run: echo "GOARCH=amd64" | Out-File -FilePath $env:GITHUB_ENV -Append
+    - run: make alloy
+
     - name: Build and publish the container
       # TODO: Run "make alloy-image-windows" instead?
       run: |

--- a/.github/workflows/publish-alloy-windows.yml
+++ b/.github/workflows/publish-alloy-windows.yml
@@ -66,6 +66,10 @@ jobs:
     - run: echo "GOARCH=amd64" | Out-File -FilePath $env:GITHUB_ENV -Append
     - run: make alloy
 
+    # TODO: Remove this later
+    - run: pwd
+    - run: ls
+
     - name: Build and publish the container
       # TODO: Run "make alloy-image-windows" instead?
       run: |

--- a/.github/workflows/publish-alloy-windows.yml
+++ b/.github/workflows/publish-alloy-windows.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-2022, windows-2019]
-    runs-on: ${{ matrix.os }}
+    runs-on: github-hosted-windows-x64-large
     steps:
       # This step needs to run before "Checkout code".
       # That's because it generates a new file.

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -3,8 +3,8 @@ ARG BASE_IMAGE_WINDOWS=mcr.microsoft.com/windows/nanoserver:ltsc2022
 # Use the smallest container possible for the final image
 FROM ${BASE_IMAGE_WINDOWS}
 
-COPY ["/src/alloy/build/alloy", "C:/Program Files/GrafanaLabs/Alloy/alloy.exe"]
-COPY ["/src/alloy/example-config.alloy", "C:/Program Files/GrafanaLabs/Alloy/config.alloy"]
+COPY ["./build/alloy", "C:/Program Files/GrafanaLabs/Alloy/alloy.exe"]
+COPY ["./example-config.alloy", "C:/Program Files/GrafanaLabs/Alloy/config.alloy"]
 
 ENTRYPOINT ["C:/Program Files/GrafanaLabs/Alloy/alloy.exe"]
 ENV ALLOY_DEPLOY_MODE=docker

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,95 +1,10 @@
-ARG BASE_IMAGE_GO=library/golang:1.24-windowsservercore-ltsc2022
 ARG BASE_IMAGE_WINDOWS=mcr.microsoft.com/windows/nanoserver:ltsc2022
-
-FROM ${BASE_IMAGE_GO} AS builder
-
-ARG VERSION
-ARG RELEASE_BUILD=1
-ARG GO_TAGS
-
-#################### 
-# The snippet below was taken from tools/build-image/windows/Dockerfile.
-# This is so that we don't have to run the CI step inside a build image container.
-# 
-# TODO: Build Alloy outside of the Dockerfile?
-# Then we don't need to install all those dependencies.
-# However, the versions of Windows may not match.
-# GitHub Actions may use one version of Windows ot build Alloy, 
-# and Docker may put it into a container with a different version.
-####################
-SHELL ["powershell", "-command"]
-
-# Use a fixed version of chocolatey to avoid dependency on .net framework install
-# See https://stackoverflow.com/questions/76470752/chocolatey-installation-in-docker-started-to-fail-restart-due-to-net-framework
-ENV chocolateyVersion=1.4.0
-# Install chocolatey for package management
-RUN Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
-
-#
-# Go Build Dependencies
-#
-# golang - building go code
-# 7zip - unzipping stuff during TDM GCC install
-# TDM GCC - gcc compiler in windows
-# make - building with a Makefile
-# docker - building images
-# git - bash for windows
-
-RUN choco install 7zip --version 22.1 -y
-
-# TDM GCC doesn't currently have a way to silently install
-ADD https://github.com/jmeubank/tdm-gcc/releases/download/v10.3.0-tdm64-2/tdm64-gcc-10.3.0-2.exe C:\\Windows\\temp\\TDM-GCC-64.exe
-RUN mkdir C:\\TDM-GCC-64; \
-    Start-Process 7z -ArgumentList 'e C:\\Windows\\temp\\TDM-GCC-64.exe -oC:\\TDM-GCC-64 -y' -Wait; \
-    Start-Process 7z -ArgumentList 'e C:\\TDM-GCC-64\\*.tar.xz -oC:\\TDM-GCC-64 -y' -Wait; \
-    Start-Process 7z -ArgumentList 'x C:\\TDM-GCC-64\\*.tar -oC:\\TDM-GCC-64 -y' -Wait; \
-    Remove-Item "C:\\TDM-GCC-64\\*" -Include *.tar.xz, *.tar -Force; \
-    setx /M PATH $('C:\TDM-GCC-64\bin;' + $Env:PATH); \
-    Remove-Item -Path C:\\Windows\\temp\\TDM-GCC-64.exe -Force
-
-RUN choco install make --version 4.3 -y
-RUN choco install docker-cli --version 20.10.22 -y
-RUN choco install git --version 2.39.0 -y
-
-#
-# React App Dependencies
-#
-# nodejs - node server
-# yarn - installs node dependencies
-RUN choco install nodejs.install --version 19.2.0 -y
-RUN choco install yarn --version 1.22.19 -y
-
-# Git tries to prevent misuse of repositories (CVE-2022-24765), but we don't
-# care about this for build containers, where it's expected that the repository
-# will be accessed by other users (the root user of the build container).
-#
-# Disable that safety check.
-RUN git config --global --add safe.directory \*
-
-####################
-# End of snipped from tools/build-image/windows/Dockerfile.
-####################
-
-COPY . /src/alloy
-WORKDIR /src/alloy
-
-SHELL ["cmd", "/S", "/C"]
-
-# Creating new layers can be really slow on Windows so we clean up any caches
-# we can before moving on to the next step.
-RUN ""C:\Program Files\git\bin\bash.exe" -c "RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} make generate-ui && rm -rf web/ui/node_modules && yarn cache clean --all""
-
-RUN ""C:\Program Files\git\bin\bash.exe" -c "RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} GO_TAGS=\"builtinassets ${GO_TAGS}\" make alloy""
-# In this case, we're separating the clean command from make alloy to avoid an issue where access to some mod cache
-# files is denied immediately after make alloy, for example:
-# "go: remove C:\go\pkg\mod\golang.org\toolchain@v0.0.1-go1.22.3.windows-amd64\bin\go.exe: Access is denied."
-RUN ""C:\Program Files\git\bin\bash.exe" -c "go clean -cache -modcache""
 
 # Use the smallest container possible for the final image
 FROM ${BASE_IMAGE_WINDOWS}
 
-COPY --from=builder ["/src/alloy/build/alloy", "C:/Program Files/GrafanaLabs/Alloy/alloy.exe"]
-COPY --from=builder ["/src/alloy/example-config.alloy", "C:/Program Files/GrafanaLabs/Alloy/config.alloy"]
+COPY ["/src/alloy/build/alloy", "C:/Program Files/GrafanaLabs/Alloy/alloy.exe"]
+COPY ["/src/alloy/example-config.alloy", "C:/Program Files/GrafanaLabs/Alloy/config.alloy"]
 
 ENTRYPOINT ["C:/Program Files/GrafanaLabs/Alloy/alloy.exe"]
 ENV ALLOY_DEPLOY_MODE=docker

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -3,7 +3,7 @@ ARG BASE_IMAGE_WINDOWS=mcr.microsoft.com/windows/nanoserver:ltsc2022
 # Use the smallest container possible for the final image
 FROM ${BASE_IMAGE_WINDOWS}
 
-COPY ["./build/alloy", "C:/Program Files/GrafanaLabs/Alloy/alloy.exe"]
+COPY ["./build/alloy.exe", "C:/Program Files/GrafanaLabs/Alloy/alloy.exe"]
 COPY ["./example-config.alloy", "C:/Program Files/GrafanaLabs/Alloy/config.alloy"]
 
 ENTRYPOINT ["C:/Program Files/GrafanaLabs/Alloy/alloy.exe"]

--- a/tools/ci/docker-containers-windows
+++ b/tools/ci/docker-containers-windows
@@ -111,6 +111,7 @@ case "$TARGET_CONTAINER" in
       --build-arg GOEXPERIMENT=cngcrypto     \
       --build-arg GO_TAGS=cngcrypto          \
       -f ./Dockerfile.windows                \
+      --isolation=hyperv                     \
       .
 
     if [[ $PUSH_ALLOY_IMAGE == "true"  ]]; then
@@ -128,6 +129,7 @@ case "$TARGET_CONTAINER" in
       --build-arg BASE_IMAGE_GO="$BASE_IMAGE_GO" \
       --build-arg BASE_IMAGE_WINDOWS="$BASE_IMAGE_WINDOWS" \
       -f ./Dockerfile.windows              \
+      --isolation=hyperv                     \
       .
 
     if [[ $PUSH_ALLOY_IMAGE == "true"  ]]; then
@@ -151,6 +153,7 @@ case "$TARGET_CONTAINER" in
       --build-arg GOEXPERIMENT=cngcrypto   \
       --build-arg GO_TAGS=cngcrypto        \
       -f ./Dockerfile.windows              \
+      --isolation=hyperv                     \
       .
 
     if [[ $PUSH_ALLOY_IMAGE == "true"  ]]; then

--- a/tools/ci/docker-containers-windows
+++ b/tools/ci/docker-containers-windows
@@ -87,6 +87,7 @@ case "$TARGET_CONTAINER" in
       --build-arg BASE_IMAGE_GO="$BASE_IMAGE_GO" \
       --build-arg BASE_IMAGE_WINDOWS="$BASE_IMAGE_WINDOWS" \
       -f ./Dockerfile.windows                \
+      --isolation=hyperv                     \
       .
 
     if [[ $PUSH_ALLOY_IMAGE == "true"  ]]; then

--- a/tools/ci/docker-containers-windows
+++ b/tools/ci/docker-containers-windows
@@ -25,11 +25,9 @@ fi
 
 WINDOWS_VERSION=${WINDOWS_VERSION:-}
 if [ "$WINDOWS_VERSION" = "windows-2022" ]; then
-  export BASE_IMAGE_GO="library/golang:${ALLOY_GO_VERSION}-windowsservercore-ltsc2022"
   export BASE_IMAGE_WINDOWS="mcr.microsoft.com/windows/nanoserver:ltsc2022"
   IMAGE_NAME_SUFFIX="windowsservercore-ltsc2022"
 else
-  export BASE_IMAGE_GO="library/golang:${ALLOY_GO_VERSION}-windowsservercore-1809"
   export BASE_IMAGE_WINDOWS="mcr.microsoft.com/windows/nanoserver:ltsc2019"
   # We aren't calling this windows-2019 for backwards compatibility reasons.
   # Alloy used to always call this nanoserver-1809.

--- a/tools/ci/docker-containers-windows
+++ b/tools/ci/docker-containers-windows
@@ -39,11 +39,11 @@ export DEVEL_ALLOY_IMAGE=grafana/alloy-dev
 
 # TODO: Unit test this script? Test cases:
 # * Input:  ALLOY_GO_VERSION=1.24 GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v1.8.0 ./tools/ci/docker-containers-windows alloy
-#   Output: docker build -t grafana/alloy:v1.8.0-nanoserver-1809 -t grafana/alloy:nanoserver-1809 --build-arg VERSION=v1.8.0 --build-arg RELEASE_BUILD=1 --build-arg BASE_IMAGE_GO=library/golang:1.24-windowsservercore-1809 --build-arg BASE_IMAGE_WINDOWS=mcr.microsoft.com/windows/nanoserver:ltsc2019 -f ./Dockerfile.windows .
+#   Output: docker build -t grafana/alloy:v1.8.0-nanoserver-1809 -t grafana/alloy:nanoserver-1809 --build-arg VERSION=v1.8.0 --build-arg RELEASE_BUILD=1 --build-arg BASE_IMAGE_WINDOWS=mcr.microsoft.com/windows/nanoserver:ltsc2019 -f ./Dockerfile.windows .
 # * Input:  ALLOY_GO_VERSION=1.24 GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v1.7.0-rc.4 ./tools/ci/docker-containers-windows alloy
-#   Output: docker build -t grafana/alloy:v1.7.0-rc.4-nanoserver-1809 -t grafana/alloy:v1.7.0-rc.4-nanoserver-1809 --build-arg VERSION=v1.7.0-rc.4 --build-arg RELEASE_BUILD=1 --build-arg BASE_IMAGE_GO=library/golang:1.24-windowsservercore-1809 --build-arg BASE_IMAGE_WINDOWS=mcr.microsoft.com/windows/nanoserver:ltsc2019 -f ./Dockerfile.windows .
+#   Output: docker build -t grafana/alloy:v1.7.0-rc.4-nanoserver-1809 -t grafana/alloy:v1.7.0-rc.4-nanoserver-1809 --build-arg VERSION=v1.7.0-rc.4 --build-arg RELEASE_BUILD=1 --build-arg BASE_IMAGE_WINDOWS=mcr.microsoft.com/windows/nanoserver:ltsc2019 -f ./Dockerfile.windows .
 # * Input:  ALLOY_GO_VERSION=1.24 WINDOWS_VERSION=windows-2022 GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v1.8.0 ./tools/ci/docker-containers-windows alloy
-#   Output: docker build -t grafana/alloy:v1.8.0-windowsservercore-ltsc2022 -t grafana/alloy:windowsservercore-ltsc2022 --build-arg VERSION=v1.8.0 --build-arg RELEASE_BUILD=1 --build-arg BASE_IMAGE_GO=library/golang:1.24-windowsservercore-ltsc2022 --build-arg BASE_IMAGE_WINDOWS=mcr.microsoft.com/windows/nanoserver:ltsc2022 -f ./Dockerfile.windows .
+#   Output: docker build -t grafana/alloy:v1.8.0-windowsservercore-ltsc2022 -t grafana/alloy:windowsservercore-ltsc2022 --build-arg VERSION=v1.8.0 --build-arg RELEASE_BUILD=1 --build-arg BASE_IMAGE_WINDOWS=mcr.microsoft.com/windows/nanoserver:ltsc2022 -f ./Dockerfile.windows .
 if [ -n "$GITHUB_TAG" ]; then
   VERSION=$GITHUB_TAG
 else
@@ -82,7 +82,6 @@ case "$TARGET_CONTAINER" in
       -t "$RELEASE_ALLOY_IMAGE:$BRANCH_TAG"  \
       --build-arg VERSION="$VERSION"         \
       --build-arg RELEASE_BUILD=1            \
-      --build-arg BASE_IMAGE_GO="$BASE_IMAGE_GO" \
       --build-arg BASE_IMAGE_WINDOWS="$BASE_IMAGE_WINDOWS" \
       -f ./Dockerfile.windows                \
       --isolation=hyperv                     \
@@ -104,7 +103,6 @@ case "$TARGET_CONTAINER" in
       -t "$RELEASE_ALLOY_IMAGE:$BRANCH_TAG"  \
       --build-arg VERSION="$VERSION"         \
       --build-arg RELEASE_BUILD=1            \
-      --build-arg BASE_IMAGE_GO="$BASE_IMAGE_GO" \
       --build-arg BASE_IMAGE_WINDOWS="$BASE_IMAGE_WINDOWS" \
       --build-arg GOEXPERIMENT=cngcrypto     \
       --build-arg GO_TAGS=cngcrypto          \
@@ -124,7 +122,6 @@ case "$TARGET_CONTAINER" in
       -t "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"  \
       --build-arg VERSION="$VERSION"       \
       --build-arg RELEASE_BUILD=1          \
-      --build-arg BASE_IMAGE_GO="$BASE_IMAGE_GO" \
       --build-arg BASE_IMAGE_WINDOWS="$BASE_IMAGE_WINDOWS" \
       -f ./Dockerfile.windows              \
       --isolation=hyperv                     \
@@ -146,7 +143,6 @@ case "$TARGET_CONTAINER" in
       -t "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"  \
       --build-arg VERSION="$VERSION"       \
       --build-arg RELEASE_BUILD=1          \
-      --build-arg BASE_IMAGE_GO="$BASE_IMAGE_GO" \
       --build-arg BASE_IMAGE_WINDOWS="$BASE_IMAGE_WINDOWS" \
       --build-arg GOEXPERIMENT=cngcrypto   \
       --build-arg GO_TAGS=cngcrypto        \

--- a/tools/ci/docker-containers-windows.ps1
+++ b/tools/ci/docker-containers-windows.ps1
@@ -1,8 +1,7 @@
     docker build                           \
-      -t "$DEVEL_ALLOY_IMAGE:$VERSION_TAG" \
-      -t "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"  \
-      --build-arg VERSION="$VERSION"       \
+      -t "grafana//alloy-dev" \
+      --build-arg VERSION="paulintest"       \
       --build-arg RELEASE_BUILD=1          \
-      --build-arg BASE_IMAGE_WINDOWS="$BASE_IMAGE_WINDOWS" \
+      --build-arg BASE_IMAGE_WINDOWS="mcr.microsoft.com/windows/nanoserver:ltsc2022" \
       -f ./Dockerfile.windows              \
       --isolation=hyperv                   \

--- a/tools/ci/docker-containers-windows.ps1
+++ b/tools/ci/docker-containers-windows.ps1
@@ -1,7 +1,1 @@
-    docker build                           \
-      -t "grafana//alloy-dev" \
-      --build-arg VERSION="paulintest"       \
-      --build-arg RELEASE_BUILD=1          \
-      --build-arg BASE_IMAGE_WINDOWS="mcr.microsoft.com/windows/nanoserver:ltsc2022" \
-      -f ./Dockerfile.windows              \
-      --isolation=hyperv                   \
+docker build -t "grafana//alloy-dev" --build-arg VERSION="paulintest" --build-arg RELEASE_BUILD=1 --build-arg BASE_IMAGE_WINDOWS="mcr.microsoft.com/windows/nanoserver:ltsc2022" -f ./Dockerfile.windows --isolation=hyperv

--- a/tools/ci/docker-containers-windows.ps1
+++ b/tools/ci/docker-containers-windows.ps1
@@ -1,0 +1,8 @@
+    docker build                           \
+      -t "$DEVEL_ALLOY_IMAGE:$VERSION_TAG" \
+      -t "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"  \
+      --build-arg VERSION="$VERSION"       \
+      --build-arg RELEASE_BUILD=1          \
+      --build-arg BASE_IMAGE_WINDOWS="$BASE_IMAGE_WINDOWS" \
+      -f ./Dockerfile.windows              \
+      --isolation=hyperv                   \


### PR DESCRIPTION
The `windows-2019` GitHub Actions runners are being deprecated (#3727). Alloy's CI has been using them to build 2019-compatible containers. This PR attempts to build 2019 containers on Windows 2022 using [Hyper-V](https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility?tabs=windows-server-2022%2Cwindows-11#hyper-v-isolation-for-containers).