### PR TITLE
database_observability: add auto-enable setup consumers to query_sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ Main (unreleased)
 
 - Add the `otelcol.receiver.fluentforward` receiver to receive logs via Fluent Forward Protocol. (@rucciva)
 
+- (_Experimental_) Additions to experimental `database_observability.mysql` component:
+  - `query_sample` collector now supports auto-enabling the necessary `setup_consumers` settings (@cristiangreco)
+
 ### Enhancements
 
 - `prometheus.scrape` now supports `convert_classic_histograms_to_nhcb`, `enable_compression`, `native_histogram_bucket_limit`, and `native_histogram_min_bucket_factor` arguments. (@thampiotr)

--- a/docs/sources/reference/components/database_observability/database_observability.mysql.md
+++ b/docs/sources/reference/components/database_observability/database_observability.mysql.md
@@ -38,7 +38,9 @@ You can use the following arguments with `database_observability.mysql`:
 | `explain_plan_initial_lookback`    | `duration`           | How far back to look for explain plan queries on the first collection interval.                | `"24h"` | no       |
 | `locks_collect_interval`           | `duration`           | How frequently to collect locks information from database.                                     | `"30s"` | no       |
 | `locks_threshold`                  | `duration`           | Threshold for locks to be considered slow. If a lock exceeds this duration, it will be logged. | `"1s"`  | no       |
-| `setup_consumers_collect_interval` | `duration`           | How frequently to collect performance_schema.setup_consumers information from the database.    | `"1h"`  | no       |
+| `setup_consumers_collect_interval` | `duration`           | How frequently to collect `performance_schema.setup_consumers` information from the database.    | `"1h"`  | no       |
+| `allow_update_performance_schema_settings` | `boolean`     | Whether to allow updates to `performance_schema` settings in any collector. | `false` | no |
+| `query_sample_auto_enable_setup_consumers` | `boolean`     | Whether to allow the `query_sample` collector to enable some specific `performance_schema.setup_consumers` settings. | `false` | no |
 
 The following collectors are configurable:
 
@@ -46,7 +48,7 @@ The following collectors are configurable:
 |-------------------|----------------------------------------------------------|--------------------|
 | `query_tables`    | Collect query table information.                         | yes                |
 | `schema_table`    | Collect schemas and tables from `information_schema`.    | yes                |
-| `query_sample`    | Collect query samples.                                   | no                 |
+| `query_sample`    | Collect query samples.                                   | yes                |
 | `setup_consumers` | Collect enabled `performance_schema.setup_consumers`.    | yes                |
 | `locks`           | Collect queries that are waiting/blocking other queries. | no                 |
 | `explain_plan`    | Collect explain plan information.                        | no                 |

--- a/internal/component/database_observability/README.md
+++ b/internal/component/database_observability/README.md
@@ -90,6 +90,27 @@ Use this statement to enable the consumer if it's disabled:
 UPDATE performance_schema.setup_consumers SET ENABLED = 'YES' WHERE NAME = 'events_statements_cpu';
 ```
 
+Note that the 'events_statements_cpu' consumer might be disabled again when the database is restarted. If you prefer Alloy to verify and enable the consumer on your behalf then extend the grants of the `db-o11y` user:
+
+```sql
+GRANT UPDATE ON performance_schema.setup_consumers TO 'db-o11y'@'%';
+```
+
+and additionally enable these options:
+
+```
+database_observability.mysql "mysql_<your_DB_name>" {
+  enable_collectors = ["query_sample"]
+
+  // Global option to allow writing to performance_schema tables
+  allow_update_performance_schema_settings = true
+
+  // Option to allow the `query_sample` collector to
+  // enable the 'events_statements_cpu' consumer
+  query_sample_auto_enable_setup_consumers = true
+}
+```
+
 7. Optionally enable the `events_waits_current` and `events_waits_history` consumers if you want to collect wait events for each query sample. Verify the current settings:
 
 ```promql

--- a/internal/component/database_observability/mysql/collector/query_sample.go
+++ b/internal/component/database_observability/mysql/collector/query_sample.go
@@ -389,8 +389,7 @@ func (c *QuerySample) fetchQuerySamples(ctx context.Context) error {
 	}
 
 	if err := rs.Err(); err != nil {
-		level.Error(c.logger).Log("msg", "error during iterating over samples result set", "err", err)
-		return err
+		return fmt.Errorf("error during iterating over samples result set: %w", err)
 	}
 
 	return nil
@@ -399,14 +398,12 @@ func (c *QuerySample) fetchQuerySamples(ctx context.Context) error {
 func (c *QuerySample) updateSetupConsumersSettings(ctx context.Context) error {
 	rs, err := c.dbConnection.ExecContext(ctx, updateSetupConsumers)
 	if err != nil {
-		level.Error(c.logger).Log("msg", "failed to update performance_schema.setup_consumers", "err", err)
-		return err
+		return fmt.Errorf("failed to update performance_schema.setup_consumers: %w", err)
 	}
 
 	rowsAffected, err := rs.RowsAffected()
 	if err != nil {
-		level.Error(c.logger).Log("msg", "failed to get rows affected from performance_schema.setup_consumers", "err", err)
-		return err
+		return fmt.Errorf("failed to get rows affected from performance_schema.setup_consumers: %w", err)
 	}
 	level.Debug(c.logger).Log("msg", "updated performance_schema.setup_consumers", "rows_affected", rowsAffected)
 

--- a/internal/component/database_observability/mysql/collector/query_sample_test.go
+++ b/internal/component/database_observability/mysql/collector/query_sample_test.go
@@ -1609,7 +1609,9 @@ func TestQuerySample_initializeTimer(t *testing.T) {
 			5,
 		))
 
-		c, err := NewQuerySample(QuerySampleArguments{DB: db})
+		c, err := NewQuerySample(QuerySampleArguments{
+			DB: db,
+		})
 		require.NoError(t, err)
 
 		require.NoError(t, c.initializeBookmark(t.Context()))
@@ -1628,7 +1630,9 @@ func TestQuerySample_initializeTimer(t *testing.T) {
 			picosecondsToSeconds(math.MaxUint64) + 5,
 		))
 
-		c, err := NewQuerySample(QuerySampleArguments{DB: db})
+		c, err := NewQuerySample(QuerySampleArguments{
+			DB: db,
+		})
 		require.NoError(t, err)
 
 		require.NoError(t, c.initializeBookmark(t.Context()))
@@ -2059,7 +2063,9 @@ func TestQuerySample_handles_timer_overflows(t *testing.T) {
 
 		mock.ExpectQuery(selectNowAndUptime).WithoutArgs().WillReturnError(fmt.Errorf("some error"))
 
-		c, err := NewQuerySample(QuerySampleArguments{DB: db})
+		c, err := NewQuerySample(QuerySampleArguments{
+			DB: db,
+		})
 		require.NoError(t, err)
 
 		err = c.fetchQuerySamples(t.Context())
@@ -2212,12 +2218,13 @@ func TestQuerySample_AutoEnableSetupConsumers(t *testing.T) {
 		lokiClient := loki_fake.NewClient(func() {})
 
 		collector, err := NewQuerySample(QuerySampleArguments{
-			DB:                       db,
-			InstanceKey:              "mysql-db",
-			CollectInterval:          time.Second,
-			EntryHandler:             lokiClient,
-			Logger:                   log.NewLogfmtLogger(os.Stderr),
-			AutoEnableSetupConsumers: true,
+			DB:                          db,
+			InstanceKey:                 "mysql-db",
+			CollectInterval:             time.Second,
+			EntryHandler:                lokiClient,
+			Logger:                      log.NewLogfmtLogger(os.Stderr),
+			AutoEnableSetupConsumers:    true,
+			SetupConsumersCheckInterval: time.Second,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -2322,12 +2329,13 @@ func TestQuerySample_AutoEnableSetupConsumers(t *testing.T) {
 		lokiClient := loki_fake.NewClient(func() {})
 
 		collector, err := NewQuerySample(QuerySampleArguments{
-			DB:                       db,
-			InstanceKey:              "mysql-db",
-			CollectInterval:          time.Second,
-			EntryHandler:             lokiClient,
-			Logger:                   log.NewLogfmtLogger(os.Stderr),
-			AutoEnableSetupConsumers: true,
+			DB:                          db,
+			InstanceKey:                 "mysql-db",
+			CollectInterval:             time.Second,
+			EntryHandler:                lokiClient,
+			Logger:                      log.NewLogfmtLogger(os.Stderr),
+			AutoEnableSetupConsumers:    true,
+			SetupConsumersCheckInterval: time.Second,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)

--- a/internal/component/database_observability/mysql/component.go
+++ b/internal/component/database_observability/mysql/component.go
@@ -70,8 +70,9 @@ type Arguments struct {
 	LocksThreshold       time.Duration `alloy:"locks_threshold,attr,optional"`
 
 	// collector: 'query_sample'
-	DisableQueryRedaction    bool `alloy:"disable_query_redaction,attr,optional"`
-	AutoEnableSetupConsumers bool `alloy:"query_sample_auto_enable_setup_consumers,attr,optional"`
+	DisableQueryRedaction                  bool          `alloy:"disable_query_redaction,attr,optional"`
+	AutoEnableSetupConsumers               bool          `alloy:"query_sample_auto_enable_setup_consumers,attr,optional"`
+	QuerySampleSetupConsumersCheckInterval time.Duration `alloy:"query_sample_setup_consumers_check_interval,attr,optional"`
 }
 
 var DefaultArguments = Arguments{
@@ -91,8 +92,9 @@ var DefaultArguments = Arguments{
 	LocksThreshold:       1 * time.Second,
 
 	// collector: 'query_sample'
-	DisableQueryRedaction:    false,
-	AutoEnableSetupConsumers: false,
+	DisableQueryRedaction:                  false,
+	AutoEnableSetupConsumers:               false,
+	QuerySampleSetupConsumersCheckInterval: 1 * time.Hour,
 }
 
 func (a *Arguments) SetToDefault() {
@@ -326,13 +328,14 @@ func (c *Component) startCollectors() error {
 
 	if collectors[collector.QuerySampleName] {
 		qsCollector, err := collector.NewQuerySample(collector.QuerySampleArguments{
-			DB:                       dbConnection,
-			InstanceKey:              c.instanceKey,
-			CollectInterval:          c.args.CollectInterval,
-			EntryHandler:             entryHandler,
-			Logger:                   c.opts.Logger,
-			DisableQueryRedaction:    c.args.DisableQueryRedaction,
-			AutoEnableSetupConsumers: c.args.AllowUpdatePerfSchemaSettings && c.args.AutoEnableSetupConsumers,
+			DB:                          dbConnection,
+			InstanceKey:                 c.instanceKey,
+			CollectInterval:             c.args.CollectInterval,
+			EntryHandler:                entryHandler,
+			Logger:                      c.opts.Logger,
+			DisableQueryRedaction:       c.args.DisableQueryRedaction,
+			AutoEnableSetupConsumers:    c.args.AllowUpdatePerfSchemaSettings && c.args.AutoEnableSetupConsumers,
+			SetupConsumersCheckInterval: c.args.QuerySampleSetupConsumersCheckInterval,
 		})
 		if err != nil {
 			level.Error(c.opts.Logger).Log("msg", "failed to create QuerySample collector", "err", err)


### PR DESCRIPTION
#### PR Description
Introduce a check in the `query_sample` collector to automatically enable the `events_statements_cpu` consumer in the `performance_schema.setup_consumers` table.

This is guarded by two config options:
- `allow_update_performance_schema_settings`: to enable "updates" to performance_schema settings altogether.
- `auto_enable_setup_consumers`: to start auto-enabling of the setting specific to the `query_sample` collector.

#### Which issue(s) this PR fixes
n.a.

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
