### PR TITLE
database_observability: move time-related functions to a separate file

### DIFF
--- a/internal/component/database_observability/mysql/collector/locks.go
+++ b/internal/component/database_observability/mysql/collector/locks.go
@@ -154,17 +154,17 @@ func (c *LockCollector) fetchLocks(ctx context.Context) error {
 		}
 
 		// only log if the lock_time is longer than the threshold
-		if waitingLockTime > secondsToPicoseconds(c.lockTimeThreshold.Seconds()) {
+		if waitingLockTime > SecondsToPicoseconds(c.lockTimeThreshold.Seconds()) {
 			lockMsg := fmt.Sprintf(
 				`waiting_digest="%s" waiting_digest_text="%s" blocking_digest="%s" blocking_digest_text="%s" waiting_timer_wait="%fms" waiting_lock_time="%fms" blocking_timer_wait="%fms" blocking_lock_time="%fms"`,
 				waitingDigest,
 				waitingDigestText,
 				blockingDigest,
 				blockingDigestText,
-				picosecondsToMilliseconds(waitingTimerWait),
-				picosecondsToMilliseconds(waitingLockTime),
-				picosecondsToMilliseconds(blockingTimerWait),
-				picosecondsToMilliseconds(blockingLockTime),
+				PicosecondsToMilliseconds(waitingTimerWait),
+				PicosecondsToMilliseconds(waitingLockTime),
+				PicosecondsToMilliseconds(blockingTimerWait),
+				PicosecondsToMilliseconds(blockingLockTime),
 			)
 
 			c.entryHandler.Chan() <- buildLokiEntry(logging.LevelInfo, OP_DATA_LOCKS, c.instanceKey, lockMsg)

--- a/internal/component/database_observability/mysql/collector/locks.go
+++ b/internal/component/database_observability/mysql/collector/locks.go
@@ -154,17 +154,17 @@ func (c *LockCollector) fetchLocks(ctx context.Context) error {
 		}
 
 		// only log if the lock_time is longer than the threshold
-		if waitingLockTime > SecondsToPicoseconds(c.lockTimeThreshold.Seconds()) {
+		if waitingLockTime > secondsToPicoseconds(c.lockTimeThreshold.Seconds()) {
 			lockMsg := fmt.Sprintf(
 				`waiting_digest="%s" waiting_digest_text="%s" blocking_digest="%s" blocking_digest_text="%s" waiting_timer_wait="%fms" waiting_lock_time="%fms" blocking_timer_wait="%fms" blocking_lock_time="%fms"`,
 				waitingDigest,
 				waitingDigestText,
 				blockingDigest,
 				blockingDigestText,
-				PicosecondsToMilliseconds(waitingTimerWait),
-				PicosecondsToMilliseconds(waitingLockTime),
-				PicosecondsToMilliseconds(blockingTimerWait),
-				PicosecondsToMilliseconds(blockingLockTime),
+				picosecondsToMilliseconds(waitingTimerWait),
+				picosecondsToMilliseconds(waitingLockTime),
+				picosecondsToMilliseconds(blockingTimerWait),
+				picosecondsToMilliseconds(blockingLockTime),
 			)
 
 			c.entryHandler.Chan() <- buildLokiEntry(logging.LevelInfo, OP_DATA_LOCKS, c.instanceKey, lockMsg)

--- a/internal/component/database_observability/mysql/collector/query_sample.go
+++ b/internal/component/database_observability/mysql/collector/query_sample.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"math"
 	"time"
 
 	"github.com/go-kit/log"
@@ -180,7 +179,7 @@ func (c *QuerySample) initializeBookmark(ctx context.Context) error {
 	}
 
 	c.lastUptime = uptime
-	c.timerBookmark = uptimeSinceOverflow(uptime)
+	c.timerBookmark = UptimeSinceOverflow(uptime)
 	return nil
 }
 
@@ -293,7 +292,7 @@ func (c *QuerySample) fetchQuerySamples(ctx context.Context) error {
 		}
 
 		serverStartTime := now - uptime
-		row.TimestampMilliseconds = c.calculateWallTime(serverStartTime, row.TimerEndPicoseconds.Float64)
+		row.TimestampMilliseconds = CalculateWallTime(serverStartTime, row.TimerEndPicoseconds.Float64, uptime)
 
 		digestText, err := c.sqlParser.CleanTruncatedText(row.DigestText.String)
 		if err != nil {
@@ -307,8 +306,8 @@ func (c *QuerySample) fetchQuerySamples(ctx context.Context) error {
 			continue
 		}
 
-		cpuTime := picosecondsToMilliseconds(row.CPUTime)
-		elapsedTime := picosecondsToMilliseconds(row.ElapsedTimePicoseconds.Float64)
+		cpuTime := PicosecondsToMilliseconds(row.CPUTime)
+		elapsedTime := PicosecondsToMilliseconds(row.ElapsedTimePicoseconds.Float64)
 
 		logMessage := fmt.Sprintf(
 			`schema="%s" thread_id="%s" event_id="%s" end_event_id="%s" digest="%s" digest_text="%s" rows_examined="%d" rows_sent="%d" rows_affected="%d" errors="%d" max_controlled_memory="%db" max_total_memory="%db" cpu_time="%fms" elapsed_time="%fms" elapsed_time_ms="%fms"`,
@@ -339,12 +338,12 @@ func (c *QuerySample) fetchQuerySamples(ctx context.Context) error {
 				OP_QUERY_SAMPLE,
 				c.instanceKey,
 				logMessage,
-				int64(millisecondsToNanoseconds(row.TimestampMilliseconds)),
+				int64(MillisecondsToNanoseconds(row.TimestampMilliseconds)),
 			)
 		}
 
 		if row.WaitEventID.Valid {
-			waitTime := picosecondsToMilliseconds(row.WaitTime.Float64)
+			waitTime := PicosecondsToMilliseconds(row.WaitTime.Float64)
 			waitLogMessage := fmt.Sprintf(
 				`schema="%s" thread_id="%s" digest="%s" digest_text="%s" event_id="%s" wait_event_id="%s" wait_end_event_id="%s" wait_event_name="%s" wait_object_name="%s" wait_object_type="%s" wait_time="%fms"`,
 				row.Schema.String,
@@ -369,7 +368,7 @@ func (c *QuerySample) fetchQuerySamples(ctx context.Context) error {
 				OP_WAIT_EVENT,
 				c.instanceKey,
 				waitLogMessage,
-				int64(millisecondsToNanoseconds(row.TimestampMilliseconds)),
+				int64(MillisecondsToNanoseconds(row.TimestampMilliseconds)),
 			)
 		}
 	}
@@ -382,30 +381,10 @@ func (c *QuerySample) fetchQuerySamples(ctx context.Context) error {
 	return nil
 }
 
-func (c *QuerySample) calculateWallTime(serverStartTime, timer float64) float64 {
-	// timer indicates event timing since server startup.
-	// The timer value is in picoseconds with a column type of bigint unsigned. This value can overflow after about ~213 days.
-	// We need to account for this overflow when calculating the timestamp.
-
-	// Knowing the number of overflows that occurred, we can calculate how much overflow time to compensate.
-	previousOverflows := calculateNumberOfOverflows(c.lastUptime)
-	overflowTime := float64(previousOverflows) * picosecondsOverflowInSeconds
-	// We then add this overflow compensation to the server start time, and also add the timer value (remember this is counted from server start).
-	// The resulting value is the timestamp in seconds at which an event happened.
-	timerSeconds := picosecondsToSeconds(timer)
-	timestampSeconds := serverStartTime + overflowTime + timerSeconds
-
-	return secondsToMilliseconds(timestampSeconds)
-}
-
-func calculateNumberOfOverflows(uptime float64) int {
-	return int(math.Floor(uptime / picosecondsOverflowInSeconds))
-}
-
 func (c *QuerySample) determineTimerClauseAndLimit(uptime float64) (string, float64) {
 	timerClause := endOfTimeline
-	currentOverflows := calculateNumberOfOverflows(uptime)
-	previousOverflows := calculateNumberOfOverflows(c.lastUptime)
+	currentOverflows := CalculateNumberOfOverflows(uptime)
+	previousOverflows := CalculateNumberOfOverflows(c.lastUptime)
 	switch {
 	case currentOverflows > previousOverflows:
 		// if we have just overflowed, collect both the beginning and end of the timeline
@@ -415,43 +394,7 @@ func (c *QuerySample) determineTimerClauseAndLimit(uptime float64) (string, floa
 		c.timerBookmark = 0
 	}
 
-	limit := uptimeSinceOverflow(uptime)
+	limit := UptimeSinceOverflow(uptime)
 
 	return timerClause, limit
-}
-
-// uptimeSinceOverflow calculates the uptime "modulo" overflows (if any): it returns the remainder of the uptime value with any
-// overflowed time removed
-func uptimeSinceOverflow(uptime float64) float64 {
-	overflowAdjustment := float64(calculateNumberOfOverflows(uptime)) * picosecondsOverflowInSeconds
-	return secondsToPicoseconds(uptime - overflowAdjustment)
-}
-
-var picosecondsOverflowInSeconds = picosecondsToSeconds(float64(math.MaxUint64))
-
-const (
-	picosecondsPerSecond      float64 = 1e12
-	millisecondsPerSecond     float64 = 1e3
-	millisecondsPerPicosecond float64 = 1e9
-	nanosecondsPerMillisecond float64 = 1e6
-)
-
-func picosecondsToSeconds(picoseconds float64) float64 {
-	return picoseconds / picosecondsPerSecond
-}
-
-func picosecondsToMilliseconds(picoseconds float64) float64 {
-	return picoseconds / millisecondsPerPicosecond
-}
-
-func millisecondsToNanoseconds(milliseconds float64) float64 {
-	return milliseconds * nanosecondsPerMillisecond
-}
-
-func secondsToPicoseconds(seconds float64) float64 {
-	return seconds * picosecondsPerSecond
-}
-
-func secondsToMilliseconds(seconds float64) float64 {
-	return seconds * millisecondsPerSecond
 }

--- a/internal/component/database_observability/mysql/collector/query_sample_test.go
+++ b/internal/component/database_observability/mysql/collector/query_sample_test.go
@@ -1625,7 +1625,7 @@ func TestQuerySample_initializeTimer(t *testing.T) {
 		mock.ExpectQuery(selectUptime).WithoutArgs().WillReturnRows(sqlmock.NewRows([]string{
 			"uptime",
 		}).AddRow(
-			PicosecondsToSeconds(math.MaxUint64) + 5,
+			picosecondsToSeconds(math.MaxUint64) + 5,
 		))
 
 		c, err := NewQuerySample(QuerySampleArguments{DB: db})
@@ -1832,8 +1832,8 @@ func TestQuerySample_handles_timer_overflows(t *testing.T) {
 				"now",
 				"uptime",
 			}).AddRow(
-				PicosecondsToSeconds(math.MaxUint64)+15,
-				PicosecondsToSeconds(math.MaxUint64)+10,
+				picosecondsToSeconds(math.MaxUint64)+15,
+				picosecondsToSeconds(math.MaxUint64)+10,
 			),
 		)
 		mock.ExpectQuery(fmt.Sprintf(selectQuerySamples, "", digestTextNotNullClause, beginningAndEndOfTimeline)).WithArgs( // asserts that beginningAndEndOfTimeline clause is used
@@ -1869,7 +1869,7 @@ func TestQuerySample_handles_timer_overflows(t *testing.T) {
 
 		require.NoError(t, c.fetchQuerySamples(t.Context()))
 
-		assert.EqualValues(t, PicosecondsToSeconds(math.MaxUint64)+10, c.lastUptime)
+		assert.EqualValues(t, picosecondsToSeconds(math.MaxUint64)+10, c.lastUptime)
 		assert.Equal(t, 10e12, c.timerBookmark)
 	})
 
@@ -1883,8 +1883,8 @@ func TestQuerySample_handles_timer_overflows(t *testing.T) {
 				"now",
 				"uptime",
 			}).AddRow(
-				PicosecondsToSeconds(math.MaxUint64)+15,
-				PicosecondsToSeconds(math.MaxUint64)+10,
+				picosecondsToSeconds(math.MaxUint64)+15,
+				picosecondsToSeconds(math.MaxUint64)+10,
 			),
 		)
 		mock.ExpectQuery(fmt.Sprintf(selectQuerySamples, "", digestTextNotNullClause, beginningAndEndOfTimeline)).WithArgs(
@@ -1925,8 +1925,8 @@ func TestQuerySample_handles_timer_overflows(t *testing.T) {
 				"now",
 				"uptime",
 			}).AddRow(
-				PicosecondsToSeconds(math.MaxUint64)+18,
-				PicosecondsToSeconds(math.MaxUint64)+13,
+				picosecondsToSeconds(math.MaxUint64)+18,
+				picosecondsToSeconds(math.MaxUint64)+13,
 			),
 		)
 		mock.ExpectQuery(fmt.Sprintf(selectQuerySamples, "", digestTextNotNullClause, endOfTimeline)).WithArgs( // asserts revert to endOfTimeline clause
@@ -1955,7 +1955,7 @@ func TestQuerySample_handles_timer_overflows(t *testing.T) {
 		}))
 		require.NoError(t, c.fetchQuerySamples(t.Context()))
 
-		assert.Equal(t, PicosecondsToSeconds(math.MaxUint64)+13, c.lastUptime)
+		assert.Equal(t, picosecondsToSeconds(math.MaxUint64)+13, c.lastUptime)
 		assert.Equal(t, 13e12, c.timerBookmark)
 	})
 
@@ -1968,7 +1968,7 @@ func TestQuerySample_handles_timer_overflows(t *testing.T) {
 				"now",
 				"uptime",
 			}).AddRow(
-				PicosecondsToSeconds(math.MaxUint64)+15,
+				picosecondsToSeconds(math.MaxUint64)+15,
 				10,
 			),
 		)
@@ -2072,7 +2072,7 @@ func TestQuerySample_handles_timer_overflows(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
-		mock.ExpectQuery(selectNowAndUptime).WithoutArgs().WillReturnRows(sqlmock.NewRows([]string{"now", "uptime"}).AddRow(PicosecondsToSeconds(math.MaxUint64)+15, 10))
+		mock.ExpectQuery(selectNowAndUptime).WithoutArgs().WillReturnRows(sqlmock.NewRows([]string{"now", "uptime"}).AddRow(picosecondsToSeconds(math.MaxUint64)+15, 10))
 
 		mock.ExpectQuery(fmt.Sprintf(selectQuerySamples, "", digestTextNotNullClause, endOfTimeline)).WithArgs(3e12, 10e12).WillReturnError(fmt.Errorf("some error"))
 
@@ -2090,7 +2090,7 @@ func TestQuerySample_handles_timer_overflows(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
-		mock.ExpectQuery(selectNowAndUptime).WithoutArgs().WillReturnRows(sqlmock.NewRows([]string{"now", "uptime"}).AddRow(PicosecondsToSeconds(math.MaxUint64)+15, 10))
+		mock.ExpectQuery(selectNowAndUptime).WithoutArgs().WillReturnRows(sqlmock.NewRows([]string{"now", "uptime"}).AddRow(picosecondsToSeconds(math.MaxUint64)+15, 10))
 		mock.ExpectQuery(fmt.Sprintf(selectQuerySamples, "", digestTextNotNullClause, endOfTimeline)).WithArgs(
 			2e12,
 			10e12,
@@ -2163,25 +2163,25 @@ func TestQuerySample_calculateTimerClauseAndLimit(t *testing.T) {
 			lastUptime:          99,
 			uptime:              1000,
 			expectedTimerClause: endOfTimeline,
-			expectedLimit:       SecondsToPicoseconds(1000),
+			expectedLimit:       secondsToPicoseconds(1000),
 		},
 		"just overflowed": {
 			lastUptime:          99,
-			uptime:              PicosecondsToSeconds(float64(math.MaxUint64)) + 10,
+			uptime:              picosecondsToSeconds(float64(math.MaxUint64)) + 10,
 			expectedTimerClause: beginningAndEndOfTimeline, // switches clause
-			expectedLimit:       SecondsToPicoseconds(10),  // uptime "modulo" overflows
+			expectedLimit:       secondsToPicoseconds(10),  // uptime "modulo" overflows
 		},
 		"already overflowed once": {
-			lastUptime:          PicosecondsToSeconds(float64(math.MaxUint64)) + 5,
-			uptime:              PicosecondsToSeconds(float64(math.MaxUint64)) + 10,
+			lastUptime:          picosecondsToSeconds(float64(math.MaxUint64)) + 5,
+			uptime:              picosecondsToSeconds(float64(math.MaxUint64)) + 10,
 			expectedTimerClause: endOfTimeline,
-			expectedLimit:       SecondsToPicoseconds(10),
+			expectedLimit:       secondsToPicoseconds(10),
 		},
 		"second overflow occurs": {
-			lastUptime:          PicosecondsToSeconds(float64(math.MaxUint64)) + 5,
-			uptime:              PicosecondsToSeconds(float64(math.MaxUint64)*2) + 50.0,
+			lastUptime:          picosecondsToSeconds(float64(math.MaxUint64)) + 5,
+			uptime:              picosecondsToSeconds(float64(math.MaxUint64)*2) + 50.0,
 			expectedTimerClause: beginningAndEndOfTimeline,
-			expectedLimit:       SecondsToPicoseconds(50.0), // uptime "modulo" overflows
+			expectedLimit:       secondsToPicoseconds(50.0), // uptime "modulo" overflows
 		},
 	}
 

--- a/internal/component/database_observability/mysql/collector/time.go
+++ b/internal/component/database_observability/mysql/collector/time.go
@@ -2,7 +2,7 @@ package collector
 
 import "math"
 
-var picosecondsOverflowInSeconds = PicosecondsToSeconds(float64(math.MaxUint64))
+var picosecondsOverflowInSeconds = picosecondsToSeconds(float64(math.MaxUint64))
 
 const (
 	picosecondsPerSecond      float64 = 1e12
@@ -11,49 +11,49 @@ const (
 	nanosecondsPerMillisecond float64 = 1e6
 )
 
-// CalculateWallTime calculates the wall-clock timestamp for an event.
+// calculateWallTime calculates the wall-clock timestamp for an event.
 // The timerPicoseconds indicates event timing since server startup.
 // Since this value can overflow after approximately ~213 days (column type of bigint unsigned),
 // this function accounts for overflows by calculating the number of previous overflows and
 // compensating accordingly. Returns the timestamp in milliseconds when the event occurred.
-func CalculateWallTime(serverStartTimeSeconds, timerPicoseconds, uptimeSeconds float64) float64 {
+func calculateWallTime(serverStartTimeSeconds, timerPicoseconds, uptimeSeconds float64) float64 {
 	// Knowing the number of overflows that occurred, we can calculate how much overflow time to compensate
-	previousOverflows := CalculateNumberOfOverflows(uptimeSeconds)
+	previousOverflows := calculateNumberOfOverflows(uptimeSeconds)
 	overflowTime := float64(previousOverflows) * picosecondsOverflowInSeconds
 
 	// We then add this overflow compensation to the server start time, and also add the timer value (remember this is counted from server start).
 	// The resulting value is the timestamp in seconds at which an event happened.
-	timerSeconds := PicosecondsToSeconds(timerPicoseconds)
+	timerSeconds := picosecondsToSeconds(timerPicoseconds)
 	timestampSeconds := serverStartTimeSeconds + overflowTime + timerSeconds
 
 	return secondsToMilliseconds(timestampSeconds)
 }
 
-// CalculateNumberOfOverflows calculates how many timer overflows have occurred based on the given uptime.
-func CalculateNumberOfOverflows(uptimeSeconds float64) int {
+// calculateNumberOfOverflows calculates how many timer overflows have occurred based on the given uptime.
+func calculateNumberOfOverflows(uptimeSeconds float64) int {
 	return int(math.Floor(uptimeSeconds / picosecondsOverflowInSeconds))
 }
 
-// UptimeSinceOverflow calculates the uptime "modulo" overflows (if any): it returns the remainder
+// uptimeSinceOverflow calculates the uptime "modulo" overflows (if any): it returns the remainder
 // of the uptime value with any overflowed time removed, in picoseconds.
-func UptimeSinceOverflow(uptimeSeconds float64) float64 {
-	overflowAdjustment := float64(CalculateNumberOfOverflows(uptimeSeconds)) * picosecondsOverflowInSeconds
-	return SecondsToPicoseconds(uptimeSeconds - overflowAdjustment)
+func uptimeSinceOverflow(uptimeSeconds float64) float64 {
+	overflowAdjustment := float64(calculateNumberOfOverflows(uptimeSeconds)) * picosecondsOverflowInSeconds
+	return secondsToPicoseconds(uptimeSeconds - overflowAdjustment)
 }
 
-func PicosecondsToMilliseconds(picoseconds float64) float64 {
+func picosecondsToMilliseconds(picoseconds float64) float64 {
 	return picoseconds / millisecondsPerPicosecond
 }
 
-func MillisecondsToNanoseconds(milliseconds float64) float64 {
+func millisecondsToNanoseconds(milliseconds float64) float64 {
 	return milliseconds * nanosecondsPerMillisecond
 }
 
-func PicosecondsToSeconds(picoseconds float64) float64 {
+func picosecondsToSeconds(picoseconds float64) float64 {
 	return picoseconds / picosecondsPerSecond
 }
 
-func SecondsToPicoseconds(seconds float64) float64 {
+func secondsToPicoseconds(seconds float64) float64 {
 	return seconds * picosecondsPerSecond
 }
 

--- a/internal/component/database_observability/mysql/collector/time.go
+++ b/internal/component/database_observability/mysql/collector/time.go
@@ -1,0 +1,62 @@
+package collector
+
+import "math"
+
+var picosecondsOverflowInSeconds = PicosecondsToSeconds(float64(math.MaxUint64))
+
+const (
+	picosecondsPerSecond      float64 = 1e12
+	millisecondsPerSecond     float64 = 1e3
+	millisecondsPerPicosecond float64 = 1e9
+	nanosecondsPerMillisecond float64 = 1e6
+)
+
+// CalculateWallTime calculates the wall-clock timestamp for an event.
+// The timerPicoseconds indicates event timing since server startup.
+// Since this value can overflow after approximately ~213 days (column type of bigint unsigned),
+// this function accounts for overflows by calculating the number of previous overflows and
+// compensating accordingly. Returns the timestamp in milliseconds when the event occurred.
+func CalculateWallTime(serverStartTimeSeconds, timerPicoseconds, uptimeSeconds float64) float64 {
+	// Knowing the number of overflows that occurred, we can calculate how much overflow time to compensate
+	previousOverflows := CalculateNumberOfOverflows(uptimeSeconds)
+	overflowTime := float64(previousOverflows) * picosecondsOverflowInSeconds
+
+	// We then add this overflow compensation to the server start time, and also add the timer value (remember this is counted from server start).
+	// The resulting value is the timestamp in seconds at which an event happened.
+	timerSeconds := PicosecondsToSeconds(timerPicoseconds)
+	timestampSeconds := serverStartTimeSeconds + overflowTime + timerSeconds
+
+	return secondsToMilliseconds(timestampSeconds)
+}
+
+// CalculateNumberOfOverflows calculates how many timer overflows have occurred based on the given uptime.
+func CalculateNumberOfOverflows(uptimeSeconds float64) int {
+	return int(math.Floor(uptimeSeconds / picosecondsOverflowInSeconds))
+}
+
+// UptimeSinceOverflow calculates the uptime "modulo" overflows (if any): it returns the remainder
+// of the uptime value with any overflowed time removed, in picoseconds.
+func UptimeSinceOverflow(uptimeSeconds float64) float64 {
+	overflowAdjustment := float64(CalculateNumberOfOverflows(uptimeSeconds)) * picosecondsOverflowInSeconds
+	return SecondsToPicoseconds(uptimeSeconds - overflowAdjustment)
+}
+
+func PicosecondsToMilliseconds(picoseconds float64) float64 {
+	return picoseconds / millisecondsPerPicosecond
+}
+
+func MillisecondsToNanoseconds(milliseconds float64) float64 {
+	return milliseconds * nanosecondsPerMillisecond
+}
+
+func PicosecondsToSeconds(picoseconds float64) float64 {
+	return picoseconds / picosecondsPerSecond
+}
+
+func SecondsToPicoseconds(seconds float64) float64 {
+	return seconds * picosecondsPerSecond
+}
+
+func secondsToMilliseconds(seconds float64) float64 {
+	return seconds * millisecondsPerSecond
+}

--- a/internal/component/database_observability/mysql/collector/time_test.go
+++ b/internal/component/database_observability/mysql/collector/time_test.go
@@ -1,39 +1,37 @@
-package collector_test
+package collector
 
 import (
 	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/grafana/alloy/internal/component/database_observability/mysql/collector"
 )
 
 func Test_CalculateWallTime(t *testing.T) {
 	t.Run("calculates the timestamp at which an event happened", func(t *testing.T) {
 		serverStartTime := 2.0
-		timer := collector.SecondsToPicoseconds(2)
+		timer := secondsToPicoseconds(2)
 		lastUptime := 0.0
 
-		result := collector.CalculateWallTime(serverStartTime, timer, lastUptime)
+		result := calculateWallTime(serverStartTime, timer, lastUptime)
 		require.Equalf(t, 4000.0, result, "got %f, want 4000", result)
 	})
 
 	t.Run("calculates the timestamp, taking into account the overflows", func(t *testing.T) {
 		serverStartTime := 3.0
-		timer := collector.SecondsToPicoseconds(2)
-		lastUptime := collector.PicosecondsToSeconds(math.MaxUint64) + 1
+		timer := secondsToPicoseconds(2)
+		lastUptime := picosecondsToSeconds(math.MaxUint64) + 1
 
-		result := collector.CalculateWallTime(serverStartTime, timer, lastUptime)
+		result := calculateWallTime(serverStartTime, timer, lastUptime)
 		require.Equalf(t, 18446749073.709553, result, "got %f, want 18446749073.709553", result)
 	})
 
 	t.Run("calculates another timestamp when timer approaches overflow", func(t *testing.T) {
 		serverStartTime := 3.0
 		timer := float64(math.MaxUint64 - 5)
-		lastUptime := collector.PicosecondsToSeconds(math.MaxUint64) + 1
+		lastUptime := picosecondsToSeconds(math.MaxUint64) + 1
 
-		result := collector.CalculateWallTime(serverStartTime, timer, lastUptime)
+		result := calculateWallTime(serverStartTime, timer, lastUptime)
 		require.Equalf(t, 3.6893491147419106e+10, result, "got %f, want 3.6893491147419106e+10", result)
 	})
 }
@@ -44,13 +42,13 @@ func Test_CalculateNumberOfOverflows(t *testing.T) {
 		uptime   float64
 	}{
 		"0 overflows": {0, 5},
-		"1 overflow":  {1, collector.PicosecondsToSeconds(math.MaxUint64) + 5},
-		"2 overflows": {2, collector.PicosecondsToSeconds(math.MaxUint64)*2 + 5},
+		"1 overflow":  {1, picosecondsToSeconds(math.MaxUint64) + 5},
+		"2 overflows": {2, picosecondsToSeconds(math.MaxUint64)*2 + 5},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			require.EqualValues(t, tc.expected, collector.CalculateNumberOfOverflows(tc.uptime))
+			require.EqualValues(t, tc.expected, calculateNumberOfOverflows(tc.uptime))
 		})
 	}
 }

--- a/internal/component/database_observability/mysql/collector/time_test.go
+++ b/internal/component/database_observability/mysql/collector/time_test.go
@@ -1,0 +1,56 @@
+package collector_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/internal/component/database_observability/mysql/collector"
+)
+
+func Test_CalculateWallTime(t *testing.T) {
+	t.Run("calculates the timestamp at which an event happened", func(t *testing.T) {
+		serverStartTime := 2.0
+		timer := collector.SecondsToPicoseconds(2)
+		lastUptime := 0.0
+
+		result := collector.CalculateWallTime(serverStartTime, timer, lastUptime)
+		require.Equalf(t, 4000.0, result, "got %f, want 4000", result)
+	})
+
+	t.Run("calculates the timestamp, taking into account the overflows", func(t *testing.T) {
+		serverStartTime := 3.0
+		timer := collector.SecondsToPicoseconds(2)
+		lastUptime := collector.PicosecondsToSeconds(math.MaxUint64) + 1
+
+		result := collector.CalculateWallTime(serverStartTime, timer, lastUptime)
+		require.Equalf(t, 18446749073.709553, result, "got %f, want 18446749073.709553", result)
+	})
+
+	t.Run("calculates another timestamp when timer approaches overflow", func(t *testing.T) {
+		serverStartTime := 3.0
+		timer := float64(math.MaxUint64 - 5)
+		lastUptime := collector.PicosecondsToSeconds(math.MaxUint64) + 1
+
+		result := collector.CalculateWallTime(serverStartTime, timer, lastUptime)
+		require.Equalf(t, 3.6893491147419106e+10, result, "got %f, want 3.6893491147419106e+10", result)
+	})
+}
+
+func Test_CalculateNumberOfOverflows(t *testing.T) {
+	testCases := map[string]struct {
+		expected uint64
+		uptime   float64
+	}{
+		"0 overflows": {0, 5},
+		"1 overflow":  {1, collector.PicosecondsToSeconds(math.MaxUint64) + 5},
+		"2 overflows": {2, collector.PicosecondsToSeconds(math.MaxUint64)*2 + 5},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require.EqualValues(t, tc.expected, collector.CalculateNumberOfOverflows(tc.uptime))
+		})
+	}
+}


### PR DESCRIPTION
#### PR Description
Move stuff related to time, uptime and overflows to a separate file to make it easier to test and reuse.

#### Which issue(s) this PR fixes
n.a.

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
