### PR TITLE
Add support for `conditions` and statement-specific `error_mode` in `otelcol.processor.transform`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Main (unreleased)
 
 - Wire in survey block for beyla.ebpf component. (@grcevski, @tpaschalis)
 
+- Add support for `conditions` and statement-specific `error_mode` in `otelcol.processor.transform`. (@ptodev)
+
 ### Bugfixes
 
 - Fix path for correct injection of version into constants at build time. (@adlotsof)

--- a/docs/sources/reference/components/otelcol/otelcol.processor.transform.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.transform.md
@@ -109,6 +109,7 @@ otelcol.processor.transform "<LABEL>" {
 ```
 
 ## Arguments
+[Arguments]: #arguments
 
 You can use the following argument with `otelcol.processor.transform`:
 
@@ -160,10 +161,12 @@ You can use the following blocks with `otelcol.processor.transform`:
 The `log_statements` block specifies statements which transform log telemetry signals.
 Multiple `log_statements` blocks can be specified.
 
-| Name         | Type           | Description                                                      | Default | Required |
-| ------------ | -------------- | ---------------------------------------------------------------- | ------- | -------- |
-| `context`    | `string`       | OTTL Context to use when interpreting the associated statements. |         | yes      |
-| `statements` | `list(string)` | A list of OTTL statements.                                       |         | yes      |
+| Name         | Type           | Description                                                         | Default | Required |
+| ------------ | -------------- | ------------------------------------------------------------------- | ------- | -------- |
+| `context`    | `string`       | OTTL Context to use when interpreting the associated statements.    |         | yes      |
+| `statements` | `list(string)` | A list of OTTL statements.                                          |         | yes      |
+| `conditions` | `list(string)` | Conditions for the statements to be executed.                       |         | no       |
+| `error_mode` | `string`       | How to react to errors if they occur while processing a statement.  |         | no       |
 
 The supported values for `context` are:
 
@@ -173,15 +176,24 @@ The supported values for `context` are:
 
 Refer to [OTTL Context][] for more information about how to use contexts.
 
+`conditions` is a list of multiple `where` clauses which will be processed as global conditions for the accompanying set of statements. 
+The conditions are ORed together, which means only one condition needs to evaluate to true in order for the statements 
+(including their individual `where` clauses) to be executed.
+
+The allowed values for `error_mode` are the same as the ones documented in the [Arguments][] section.
+If `error_mode` is not specified in `log_statements`, the top-level `error_mode` is applied.
+
 ### `metric_statements`
 
 The `metric_statements` block specifies statements which transform metric telemetry signals.
 Multiple `metric_statements` blocks can be specified.
 
-| Name         | Type           | Description                                                      | Default | Required |
-| ------------ | -------------- | ---------------------------------------------------------------- | ------- | -------- |
-| `context`    | `string`       | OTTL Context to use when interpreting the associated statements. |         | yes      |
-| `statements` | `list(string)` | A list of OTTL statements.                                       |         | yes      |
+| Name         | Type           | Description                                                         | Default | Required |
+| ------------ | -------------- | ------------------------------------------------------------------- | ------- | -------- |
+| `context`    | `string`       | OTTL Context to use when interpreting the associated statements.    |         | yes      |
+| `statements` | `list(string)` | A list of OTTL statements.                                          |         | yes      |
+| `conditions` | `list(string)` | Conditions for the statements to be executed.                       |         | no       |
+| `error_mode` | `string`       | How to react to errors if they occur while processing a statement.  |         | no       |
 
 The supported values for `context` are:
 
@@ -191,6 +203,13 @@ The supported values for `context` are:
 * `datapoint`: Use when interacting only with individual OTLP metric data points.
 
 Refer to [OTTL Context][] for more information about how to use contexts.
+
+`conditions` is a list of multiple `where` clauses which will be processed as global conditions for the accompanying set of statements. 
+The conditions are ORed together, which means only one condition needs to evaluate to true in order for the statements 
+(including their individual `where` clauses) to be executed.
+
+The allowed values for `error_mode` are the same as the ones documented in the [Arguments][] section.
+If `error_mode` is not specified in `metric_statements`, the top-level `error_mode` is applied.
 
 ### `statements`
 
@@ -238,10 +257,12 @@ All of this happens automatically, leaving you to write OTTL statements without 
 The `trace_statements` block specifies statements which transform trace telemetry signals.
 Multiple `trace_statements` blocks can be specified.
 
-| Name         | Type           | Description                                                      | Default | Required |
-| ------------ | -------------- | ---------------------------------------------------------------- | ------- | -------- |
-| `context`    | `string`       | OTTL Context to use when interpreting the associated statements. |         | yes      |
-| `statements` | `list(string)` | A list of OTTL statements.                                       |         | yes      |
+| Name         | Type           | Description                                                         | Default | Required |
+| ------------ | -------------- | ------------------------------------------------------------------- | ------- | -------- |
+| `context`    | `string`       | OTTL Context to use when interpreting the associated statements.    |         | yes      |
+| `statements` | `list(string)` | A list of OTTL statements.                                          |         | yes      |
+| `conditions` | `list(string)` | Conditions for the statements to be executed.                       |         | no       |
+| `error_mode` | `string`       | How to react to errors if they occur while processing a statement.  |         | no       |
 
 The supported values for `context` are:
 
@@ -251,6 +272,13 @@ The supported values for `context` are:
 * `spanevent`: Use when interacting only with OTLP span events.
 
 Refer to [OTTL Context][] for more information about how to use contexts.
+
+`conditions` is a list of multiple `where` clauses which will be processed as global conditions for the accompanying set of statements. 
+The conditions are ORed together, which means only one condition needs to evaluate to true in order for the statements 
+(including their individual `where` clauses) to be executed.
+
+The allowed values for `error_mode` are the same as the ones documented in the [Arguments][] section.
+If `error_mode` is not specified in `trace_statements`, the top-level `error_mode` is applied.
 
 ### OTTL Context
 
@@ -597,6 +625,42 @@ otelcol.processor.transform "default" {
 otelcol.exporter.otlp "default" {
   client {
     endpoint = sys.env("OTLP_ENDPOINT")
+  }
+}
+```
+
+### Using conditions
+
+This example only runs the statements if the conditions are met:
+
+```alloy
+otelcol.processor.transform "default" {
+  error_mode = "ignore"
+
+  metric_statements {
+    context = "metric"
+    statements = [
+      `set(metric.description, "Sum")`,
+    ]
+    conditions = [
+      `metric.type == METRIC_DATA_TYPE_SUM`,
+    ]
+  }
+
+  log_statements {
+    context = "log"
+    statements = [
+      `set(log.body, log.attributes["http.route"])`,
+    ]
+    conditions = [
+      `IsMap(log.body) and log.body["object"] != nil`,
+    ]
+  }
+
+  output {
+    metrics = [otelcol.exporter.otlp.default.input]
+    logs    = [otelcol.exporter.otlp.default.input]
+    traces  = [otelcol.exporter.otlp.default.input]
   }
 }
 ```

--- a/internal/component/otelcol/processor/transform/transform.go
+++ b/internal/component/otelcol/processor/transform/transform.go
@@ -59,8 +59,10 @@ type Statements []string
 type ContextStatementsSlice []ContextStatements
 
 type ContextStatements struct {
-	Context    ContextID  `alloy:"context,attr"`
-	Statements Statements `alloy:"statements,attr"`
+	Context    ContextID      `alloy:"context,attr"`
+	Conditions []string       `alloy:"conditions,attr,optional"`
+	Statements Statements     `alloy:"statements,attr"`
+	ErrorMode  ottl.ErrorMode `alloy:"error_mode,attr,optional"`
 }
 
 type NoContextStatements struct {
@@ -149,6 +151,8 @@ func (args *ContextStatements) convert() map[string]interface{} {
 	return map[string]interface{}{
 		"context":    args.Context,
 		"statements": args.Statements,
+		"conditions": args.Conditions,
+		"error_mode": args.ErrorMode,
 	}
 }
 

--- a/internal/component/otelcol/processor/transform/transform_test.go
+++ b/internal/component/otelcol/processor/transform/transform_test.go
@@ -64,6 +64,172 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 			},
 		},
 		{
+			testName: "TransformWithConditions",
+			cfg: `
+			error_mode = "ignore"
+			trace_statements {
+				context = "span"
+				statements = [
+					` + backtick + `set(name, "bear")` + backtick + `,
+				]
+				conditions = [
+					` + backtick + `attributes["http.path"] == "/animal"` + backtick + `,
+				]
+			}
+			metric_statements {
+				context = "datapoint"
+				statements = [
+					` + backtick + `set(metric.name, "bear")` + backtick + `,
+				]
+				conditions = [
+					` + backtick + `attributes["http.path"] == "/animal"` + backtick + `,
+				]
+			}
+			log_statements {
+				context = "log"
+				statements = [
+					` + backtick + `set(body, "bear")` + backtick + `,
+				]
+				conditions = [
+					` + backtick + `attributes["http.path"] == "/animal"` + backtick + `,
+				]
+			}
+
+			output {}
+			`,
+			expected: map[string]interface{}{
+				"error_mode": "ignore",
+				"trace_statements": []interface{}{
+					map[string]interface{}{
+						"context": "span",
+						"statements": []interface{}{
+							`set(name, "bear")`,
+						},
+						"conditions": []interface{}{
+							`attributes["http.path"] == "/animal"`,
+						},
+					},
+				},
+				"metric_statements": []interface{}{
+					map[string]interface{}{
+						"context": "datapoint",
+						"statements": []interface{}{
+							`set(metric.name, "bear")`,
+						},
+						"conditions": []interface{}{
+							`attributes["http.path"] == "/animal"`,
+						},
+					},
+				},
+				"log_statements": []interface{}{
+					map[string]interface{}{
+						"context": "log",
+						"statements": []interface{}{
+							`set(body, "bear")`,
+						},
+						"conditions": []interface{}{
+							`attributes["http.path"] == "/animal"`,
+						},
+					},
+				},
+			},
+		},
+		{
+			testName: "TransformWithContextStatementsErrorMode",
+			cfg: `
+			error_mode = "ignore"
+			trace_statements {
+				error_mode = "propagate"
+				context = "resource"
+				statements = [
+					` + backtick + `set(resource.attributes["name"], "propagate")` + backtick + `,
+				]
+			}
+			trace_statements {
+				context = "resource"
+				statements = [
+					` + backtick + `set(resource.attributes["name"], "ignore")` + backtick + `,
+				]
+			}
+			metric_statements {
+				context = "resource"
+				error_mode = "silent"
+				statements = [
+					` + backtick + `set(resource.attributes["name"], "silent")` + backtick + `,
+				]
+			}
+			metric_statements {
+				context = "resource"
+				statements = [
+					` + backtick + `set(resource.attributes["name"], "ignore")` + backtick + `,
+				]
+			}
+			log_statements {
+				context = "resource"
+				error_mode = "propagate"
+				statements = [
+					` + backtick + `set(resource.attributes["name"], "propagate")` + backtick + `,
+				]
+			}
+			log_statements {
+				context = "resource"
+				statements = [
+					` + backtick + `set(resource.attributes["name"], "ignore")` + backtick + `,
+				]
+			}
+
+			output {}
+			`,
+			expected: map[string]interface{}{
+				"error_mode": "ignore",
+				"trace_statements": []interface{}{
+					map[string]interface{}{
+						"error_mode": "propagate",
+						"context":    "resource",
+						"statements": []interface{}{
+							`set(resource.attributes["name"], "propagate")`,
+						},
+					},
+					map[string]interface{}{
+						"context": "resource",
+						"statements": []interface{}{
+							`set(resource.attributes["name"], "ignore")`,
+						},
+					},
+				},
+				"metric_statements": []interface{}{
+					map[string]interface{}{
+						"error_mode": "silent",
+						"context":    "resource",
+						"statements": []interface{}{
+							`set(resource.attributes["name"], "silent")`,
+						},
+					},
+					map[string]interface{}{
+						"context": "resource",
+						"statements": []interface{}{
+							`set(resource.attributes["name"], "ignore")`,
+						},
+					},
+				},
+				"log_statements": []interface{}{
+					map[string]interface{}{
+						"error_mode": "propagate",
+						"context":    "resource",
+						"statements": []interface{}{
+							`set(resource.attributes["name"], "propagate")`,
+						},
+					},
+					map[string]interface{}{
+						"context": "resource",
+						"statements": []interface{}{
+							`set(resource.attributes["name"], "ignore")`,
+						},
+					},
+				},
+			},
+		},
+		{
 			testName: "RenameAttribute1",
 			cfg: `
 			error_mode = "ignore"

--- a/internal/converter/internal/otelcolconvert/converter_transformprocessor.go
+++ b/internal/converter/internal/otelcolconvert/converter_transformprocessor.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/alloy/internal/component/otelcol/processor/transform"
 	"github.com/grafana/alloy/internal/converter/diag"
 	"github.com/grafana/alloy/internal/converter/internal/common"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componentstatus"
@@ -71,6 +72,8 @@ func toContextStatements(in []map[string]any) []transform.ContextStatements {
 		res = append(res, transform.ContextStatements{
 			Context:    transform.ContextID(encodeString(s["context"])),
 			Statements: s["statements"].([]string),
+			Conditions: s["conditions"].([]string),
+			ErrorMode:  s["error_mode"].(ottl.ErrorMode),
 		})
 	}
 


### PR DESCRIPTION
#### PR Description

This has been part of the upstream transform processor for a while, but wasn't added to Alloy for some reason.

#### Which issue(s) this PR fixes

Fixes #1447

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated
