### PR TITLE
database_observability: Add engine label to connection info collector

### DIFF
--- a/internal/component/database_observability/mysql/collector/connection_info.go
+++ b/internal/component/database_observability/mysql/collector/connection_info.go
@@ -33,7 +33,7 @@ func NewConnectionInfo(args ConnectionInfoArguments) (*ConnectionInfo, error) {
 		Namespace: "database_observability",
 		Name:      "connection_info",
 		Help:      "Information about the connection",
-	}, []string{"provider_name", "provider_region", "db_instance_identifier"})
+	}, []string{"provider_name", "provider_region", "db_instance_identifier", "engine"})
 
 	args.Registry.MustRegister(infoMetric)
 
@@ -61,6 +61,7 @@ func (c *ConnectionInfo) Start(ctx context.Context) error {
 		providerName         = "unknown"
 		providerRegion       = "unknown"
 		dbInstanceIdentifier = "unknown"
+		engine               = "mysql"
 	)
 
 	host, _, err := net.SplitHostPort(cfg.Addr)
@@ -75,7 +76,7 @@ func (c *ConnectionInfo) Start(ctx context.Context) error {
 		}
 	}
 
-	c.InfoMetric.WithLabelValues(providerName, providerRegion, dbInstanceIdentifier).Set(1)
+	c.InfoMetric.WithLabelValues(providerName, providerRegion, dbInstanceIdentifier, engine).Set(1)
 	return nil
 }
 

--- a/internal/component/database_observability/mysql/collector/connection_info_test.go
+++ b/internal/component/database_observability/mysql/collector/connection_info_test.go
@@ -17,7 +17,7 @@ func TestConnectionInfo(t *testing.T) {
 	const baseExpectedMetrics = `
 	# HELP database_observability_connection_info Information about the connection
 	# TYPE database_observability_connection_info gauge
-	database_observability_connection_info{db_instance_identifier="%s",provider_name="%s",provider_region="%s"} 1
+	database_observability_connection_info{db_instance_identifier="%s",engine="%s",provider_name="%s",provider_region="%s"} 1
 `
 
 	testCases := []struct {
@@ -28,12 +28,12 @@ func TestConnectionInfo(t *testing.T) {
 		{
 			name:            "generic dsn",
 			dsn:             "user:pass@tcp(localhost:3306)/schema",
-			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "unknown", "unknown", "unknown"),
+			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "unknown", "mysql", "unknown", "unknown"),
 		},
 		{
 			name:            "AWS/RDS dsn",
 			dsn:             "user:pass@tcp(products-db.abc123xyz.us-east-1.rds.amazonaws.com:3306)/schema",
-			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "products-db", "aws", "us-east-1"),
+			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "products-db", "mysql", "aws", "us-east-1"),
 		},
 	}
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Adds the `engine` label to the `database_observability_connection_info` metric so that we can distinguish between mysql and postgres database connections in the future.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
