### PR TITLE
database_observability: review and simplify parser methods

### DIFF
--- a/internal/component/database_observability/mysql/collector/parser/mock_parser.go
+++ b/internal/component/database_observability/mysql/collector/parser/mock_parser.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"github.com/go-kit/log"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -9,9 +8,9 @@ type MockParser struct {
 	mock.Mock
 }
 
-func (m *MockParser) Parse(sql string) (any, error) {
+func (m *MockParser) Parse(sql string) (StatementAstNode, error) {
 	args := m.Called(sql)
-	return args.Get(0), args.Error(1)
+	return args.Get(0).(StatementAstNode), args.Error(1)
 }
 
 func (m *MockParser) Redact(sql string) (string, error) {
@@ -19,18 +18,8 @@ func (m *MockParser) Redact(sql string) (string, error) {
 	return args.String(0), args.Error(1)
 }
 
-func (m *MockParser) StmtType(stmt any) StatementType {
+func (m *MockParser) ExtractTableNames(stmt StatementAstNode) []string {
 	args := m.Called(stmt)
-	return args.Get(0).(StatementType)
-}
-
-func (m *MockParser) ParseTableName(t any) string {
-	args := m.Called(t)
-	return args.String(0)
-}
-
-func (m *MockParser) ExtractTableNames(logger log.Logger, digest string, stmt any) []string {
-	args := m.Called(logger, digest, stmt)
 	return args.Get(0).([]string)
 }
 

--- a/internal/component/database_observability/mysql/collector/parser/parser.go
+++ b/internal/component/database_observability/mysql/collector/parser/parser.go
@@ -1,23 +1,16 @@
 package parser
 
-import "github.com/go-kit/log"
+import (
+	"github.com/pingcap/tidb/pkg/parser/ast"
+)
 
 type Parser interface {
-	Parse(sql string) (any, error)
+	Parse(sql string) (StatementAstNode, error)
 	Redact(sql string) (string, error)
-	StmtType(stmt any) StatementType
-	ParseTableName(t any) string
-	ExtractTableNames(logger log.Logger, digest string, stmt any) []string
+	ExtractTableNames(stmt StatementAstNode) []string
 	CleanTruncatedText(sql string) (string, error)
 }
 
-type StatementType string
+type StatementAstNode ast.StmtNode
 
-var (
-	StatementTypeSelect StatementType = "select"
-	StatementTypeInsert StatementType = "insert"
-	StatementTypeUpdate StatementType = "update"
-	StatementTypeDelete StatementType = "delete"
-
-	_ Parser = (*TiDBSqlParser)(nil)
-)
+var _ Parser = (*TiDBSqlParser)(nil)

--- a/internal/component/database_observability/mysql/collector/parser/parser_tidb.go
+++ b/internal/component/database_observability/mysql/collector/parser/parser_tidb.go
@@ -8,7 +8,6 @@ import (
 
 	"golang.org/x/exp/maps"
 
-	"github.com/go-kit/log"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -21,7 +20,7 @@ func NewTiDBSqlParser() *TiDBSqlParser {
 	return &TiDBSqlParser{}
 }
 
-func (p *TiDBSqlParser) Parse(sql string) (any, error) {
+func (p *TiDBSqlParser) Parse(sql string) (StatementAstNode, error) {
 	// mysql will redact auth details with <secret> but the tidb parser
 	// will fail to parse it so we replace it with '<secret>'
 	sql = strings.ReplaceAll(sql, "IDENTIFIED BY <secret>", "IDENTIFIED BY '<secret>'")
@@ -48,7 +47,7 @@ func (p *TiDBSqlParser) Parse(sql string) (any, error) {
 		return nil, fmt.Errorf("no statements parsed")
 	}
 
-	return &stmtNodes[0], nil
+	return stmtNodes[0], nil
 }
 
 func (p *TiDBSqlParser) Redact(sql string) (string, error) {
@@ -59,34 +58,14 @@ func (p *TiDBSqlParser) Redact(sql string) (string, error) {
 	return res, nil
 }
 
-func (p *TiDBSqlParser) StmtType(stmt any) StatementType {
-	s := stmt.(*ast.StmtNode)
-	switch (*s).(type) {
-	case *ast.SelectStmt:
-		return StatementTypeSelect
-	case *ast.InsertStmt:
-		return StatementTypeInsert
-	case *ast.UpdateStmt:
-		return StatementTypeUpdate
-	case *ast.DeleteStmt:
-		return StatementTypeDelete
-	default:
-		return ""
-	}
-}
-
-func (p *TiDBSqlParser) ExtractTableNames(_ log.Logger, _ string, stmt any) []string {
+func (p *TiDBSqlParser) ExtractTableNames(stmt StatementAstNode) []string {
 	v := &tableNameVisitor{
 		tables: map[string]struct{}{},
 	}
-	(*stmt.(*ast.StmtNode)).Accept(v)
+	stmt.Accept(v)
 	keys := maps.Keys(v.tables)
 	slices.Sort(keys)
 	return keys
-}
-
-func (p *TiDBSqlParser) ParseTableName(t any) string {
-	return parseTableName(t.(*ast.TableName))
 }
 
 type tableNameVisitor struct {

--- a/internal/component/database_observability/mysql/collector/parser/parser_tidb_test.go
+++ b/internal/component/database_observability/mysql/collector/parser/parser_tidb_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alloy/internal/component/database_observability/mysql/collector/parser"
@@ -157,7 +156,7 @@ func TestParserTiDB_ExtractTableNames(t *testing.T) {
 			stmt, err := p.Parse(tc.sql)
 			require.NoError(t, err)
 
-			got := p.ExtractTableNames(log.NewNopLogger(), "", stmt)
+			got := p.ExtractTableNames(stmt)
 			require.ElementsMatch(t, tc.tables, got)
 		})
 	}

--- a/internal/component/database_observability/mysql/collector/query_tables.go
+++ b/internal/component/database_observability/mysql/collector/query_tables.go
@@ -133,7 +133,7 @@ func (c *QueryTables) tablesFromEventsStatements(ctx context.Context) error {
 			continue
 		}
 
-		tables := c.sqlParser.ExtractTableNames(c.logger, digest, stmt)
+		tables := c.sqlParser.ExtractTableNames(stmt)
 		for _, table := range tables {
 			c.entryHandler.Chan() <- buildLokiEntry(
 				logging.LevelInfo,
@@ -152,7 +152,7 @@ func (c *QueryTables) tablesFromEventsStatements(ctx context.Context) error {
 	return nil
 }
 
-func (c *QueryTables) tryParse(schema, digest, sqlText, fallbackSqlText string) (any, error) {
+func (c *QueryTables) tryParse(schema, digest, sqlText, fallbackSqlText string) (parser.StatementAstNode, error) {
 	sqlText, err := c.sqlParser.CleanTruncatedText(sqlText)
 	if err != nil {
 		sqlText, err = c.sqlParser.CleanTruncatedText(fallbackSqlText)


### PR DESCRIPTION
#### PR Description
Now that we have a single parser implementation, we can simplify it by:
- Removing unused methods from interface
- Avoiding using `any` type

#### Which issue(s) this PR fixes
n.a.

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
