### PR TITLE
Add the `enable_tracing` attribute to the `prometheus.exporter.snowflake` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Main (unreleased)
 
 - Wire in survey block for beyla.ebpf component. (@grcevski, @tpaschalis)
 
+- Add `enable_tracing` attribute to `prometheus.exporter.snowflake` component to support debugging issues. (@dehaansa)
+
 ### Bugfixes
 
 - Fix path for correct injection of version into constants at build time. (@adlotsof)

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.snowflake.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.snowflake.md
@@ -45,16 +45,17 @@ prometheus.exporter.snowflake "LABEL" {
 
 You can use the following arguments with `prometheus.exporter.snowflake`:
 
-| Name                     | Type     | Description                                                                                       | Default          | Required |
-| ------------------------ | -------- | ------------------------------------------------------------------------------------------------- | ---------------- | -------- |
-| `account_name`           | `string` | The account to collect metrics from.                                                              |                  | yes      |
-| `username`               | `string` | The username for the user used when querying metrics.                                             |                  | yes      |
-| `warehouse`              | `string` | The warehouse to use when querying metrics.                                                       |                  | yes      |
-| `exclude_deleted_tables` |  `bool`  | Whether to exclude deleted tables when querying table storage metrics.                            | `false`          | no       |
-| `password`               | `secret` | The password for the user used when querying metrics (required for password authentication).      |                  | no       |
-| `private_key_password`   | `secret` | The password for the user's RSA private key (required for encrypted RSA key-pair authentication). |                  | no       |
-| `private_key_path`       | `secret` | The path to the user's RSA private key file (required for RSA key-pair authentication).           |                  | no       |
-| `role`                   | `string` | The role to use when querying metrics.                                                            | `"ACCOUNTADMIN"` | no       |
+| Name                       | Type     | Description                                                                                       | Default          | Required |
+|----------------------------|----------|---------------------------------------------------------------------------------------------------|------------------|----------|
+| `account_name`             | `string` | The account to collect metrics from.                                                              |                  | yes      |
+| `username`                 | `string` | The username for the user used when querying metrics.                                             |                  | yes      |
+| `warehouse`                | `string` | The warehouse to use when querying metrics.                                                       |                  | yes      |
+| `enable_tracing`           | `bool`   | Whether to have the snowflake database driver provide trace logging.                              | `false`          | no       |
+| `exclude_deleted_tables`   | `bool`   | Whether to exclude deleted tables when querying table storage metrics.                            | `false`          | no       |
+| `password`                 | `secret` | The password for the user used when querying metrics (required for password authentication).      |                  | no       |
+| `private_key_password`     | `secret` | The password for the user's RSA private key (required for encrypted RSA key-pair authentication). |                  | no       |
+| `private_key_path`         | `secret` | The path to the user's RSA private key file (required for RSA key-pair authentication).           |                  | no       |
+| `role`                     | `string` | The role to use when querying metrics.                                                            | `"ACCOUNTADMIN"` | no       |
 
 One of `password` or `private_key_path` must be specified to authenticate.
 Users with an encrypted private key will also need to provide a `private_key_password`.

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/grafana/pyroscope/api v1.2.0
 	github.com/grafana/pyroscope/ebpf v0.4.11
 	github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc
-	github.com/grafana/snowflake-prometheus-exporter v0.0.0-20250507154309-83bcbaac6b04
+	github.com/grafana/snowflake-prometheus-exporter v0.0.0-20250627131542-0c2feac3a700
 	github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0
 	github.com/grafana/vmware_exporter v0.0.5-beta.0.20250218170317-73398ba08329
 	github.com/grafana/walqueue v0.0.0-20250606153244-9d2294b26901

--- a/go.sum
+++ b/go.sum
@@ -1443,6 +1443,8 @@ github.com/grafana/smimesign v0.2.1-0.20220408144937-2a5adf3481d3 h1:UPkAxuhlAcR
 github.com/grafana/smimesign v0.2.1-0.20220408144937-2a5adf3481d3/go.mod h1:iZiiwNT4HbtGRVqCQu7uJPEZCuEE5sfSSttcnePkDl4=
 github.com/grafana/snowflake-prometheus-exporter v0.0.0-20250507154309-83bcbaac6b04 h1:5tc0sUd4Py49jkO3H2e4g5D9bnu+K70lB+/5bLTM4is=
 github.com/grafana/snowflake-prometheus-exporter v0.0.0-20250507154309-83bcbaac6b04/go.mod h1:TLf/gsyKggD6qiTXOC9dlTDFR0c3v6r/0Ufs6s9+xBc=
+github.com/grafana/snowflake-prometheus-exporter v0.0.0-20250627131542-0c2feac3a700 h1:2WcTPnt3H8OEPJvA5fDQk7dgIPWSAGr8xBBlm0zXm4w=
+github.com/grafana/snowflake-prometheus-exporter v0.0.0-20250627131542-0c2feac3a700/go.mod h1:TLf/gsyKggD6qiTXOC9dlTDFR0c3v6r/0Ufs6s9+xBc=
 github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0 h1:bjh0PVYSVVFxzINqPFYJmAmJNrWPgnVjuSdYJGHmtFU=
 github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0/go.mod h1:7t5XR+2IA8P2qggOAHTj/GCZfoLBle3OvNSYh1VkRBU=
 github.com/grafana/vmware_exporter v0.0.5-beta.0.20250218170317-73398ba08329 h1:Rs4H1yv2Abk3xE82qpyhMGGA8rswAOA0HQZde/BYkFo=

--- a/internal/component/prometheus/exporter/snowflake/snowflake.go
+++ b/internal/component/prometheus/exporter/snowflake/snowflake.go
@@ -33,14 +33,15 @@ var DefaultArguments = Arguments{
 
 // Arguments controls the snowflake exporter.
 type Arguments struct {
-	AccountName          string            `alloy:"account_name,attr"`
-	Username             string            `alloy:"username,attr"`
-	Password             alloytypes.Secret `alloy:"password,attr,optional"`
-	PrivateKeyPath       string            `alloy:"private_key_path,attr,optional"`
-	PrivateKeyPassword   alloytypes.Secret `alloy:"private_key_password,attr,optional"`
-	Role                 string            `alloy:"role,attr,optional"`
-	Warehouse            string            `alloy:"warehouse,attr"`
-	ExcludeDeletedTables bool              `alloy:"exclude_deleted_tables,attr,optional"`
+	AccountName           string            `alloy:"account_name,attr"`
+	Username              string            `alloy:"username,attr"`
+	Password              alloytypes.Secret `alloy:"password,attr,optional"`
+	PrivateKeyPath        string            `alloy:"private_key_path,attr,optional"`
+	PrivateKeyPassword    alloytypes.Secret `alloy:"private_key_password,attr,optional"`
+	Role                  string            `alloy:"role,attr,optional"`
+	Warehouse             string            `alloy:"warehouse,attr"`
+	ExcludeDeletedTables  bool              `alloy:"exclude_deleted_tables,attr,optional"`
+	EnableDriverTraceLogs bool              `alloy:"enable_tracing,attr,optional"`
 }
 
 // SetToDefault implements syntax.Defaulter.
@@ -50,13 +51,14 @@ func (a *Arguments) SetToDefault() {
 
 func (a *Arguments) Convert() *snowflake_exporter.Config {
 	return &snowflake_exporter.Config{
-		AccountName:          a.AccountName,
-		Username:             a.Username,
-		Password:             config_util.Secret(a.Password),
-		PrivateKeyPath:       a.PrivateKeyPath,
-		PrivateKeyPassword:   config_util.Secret(a.PrivateKeyPassword),
-		Role:                 a.Role,
-		Warehouse:            a.Warehouse,
-		ExcludeDeletedTables: a.ExcludeDeletedTables,
+		AccountName:           a.AccountName,
+		Username:              a.Username,
+		Password:              config_util.Secret(a.Password),
+		PrivateKeyPath:        a.PrivateKeyPath,
+		PrivateKeyPassword:    config_util.Secret(a.PrivateKeyPassword),
+		Role:                  a.Role,
+		Warehouse:             a.Warehouse,
+		ExcludeDeletedTables:  a.ExcludeDeletedTables,
+		EnableDriverTraceLogs: a.EnableDriverTraceLogs,
 	}
 }

--- a/internal/component/prometheus/exporter/snowflake/snowflake_test.go
+++ b/internal/component/prometheus/exporter/snowflake/snowflake_test.go
@@ -12,14 +12,14 @@ import (
 
 func TestAlloyUnmarshal(t *testing.T) {
 	alloyConfig := `
-	account_name 				   = "some_account"
-	username     				   = "some_user"
-	password     				 	 = "some_password"
-	private_key_path 		 	 = "/some/path/rsa_key.p8"
-	private_key_password 	 = "some_password"
-	role         					 = "some_role"
-	warehouse    				 	 = "some_warehouse"
-	exclude_deleted_tables = true
+	account_name             = "some_account"
+	username                 = "some_user"
+	password                 = "some_password"
+	private_key_path         = "/some/path/rsa_key.p8"
+	private_key_password     = "some_password"
+	role                     = "some_role"
+	warehouse                = "some_warehouse"
+	exclude_deleted_tables   = true
 	`
 
 	var args Arguments
@@ -27,14 +27,15 @@ func TestAlloyUnmarshal(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := Arguments{
-		AccountName:          "some_account",
-		Username:             "some_user",
-		Password:             alloytypes.Secret("some_password"),
-		PrivateKeyPath:       "/some/path/rsa_key.p8",
-		PrivateKeyPassword:   alloytypes.Secret("some_password"),
-		Role:                 "some_role",
-		Warehouse:            "some_warehouse",
-		ExcludeDeletedTables: true,
+		AccountName:           "some_account",
+		Username:              "some_user",
+		Password:              alloytypes.Secret("some_password"),
+		PrivateKeyPath:        "/some/path/rsa_key.p8",
+		PrivateKeyPassword:    alloytypes.Secret("some_password"),
+		Role:                  "some_role",
+		Warehouse:             "some_warehouse",
+		ExcludeDeletedTables:  true,
+		EnableDriverTraceLogs: false, // Default value
 	}
 
 	require.Equal(t, expected, args)
@@ -42,13 +43,14 @@ func TestAlloyUnmarshal(t *testing.T) {
 
 func TestConvert(t *testing.T) {
 	alloyConfig := `
-	account_name           = "some_account"
-	username               = "some_user"
-	password               = "some_password"
-	private_key_path       = "/some/path/rsa_key.p8"
-	private_key_password   = "some_password"
-	warehouse              = "some_warehouse"
-	exclude_deleted_tables = true
+	account_name             = "some_account"
+	username                 = "some_user"
+	password                 = "some_password"
+	private_key_path         = "/some/path/rsa_key.p8"
+	private_key_password     = "some_password"
+	warehouse                = "some_warehouse"
+	exclude_deleted_tables   = true
+	enable_tracing           = true
 	`
 	var args Arguments
 	err := syntax.Unmarshal([]byte(alloyConfig), &args)
@@ -57,14 +59,15 @@ func TestConvert(t *testing.T) {
 	res := args.Convert()
 
 	expected := snowflake_exporter.Config{
-		AccountName:          "some_account",
-		Username:             "some_user",
-		Password:             config_util.Secret("some_password"),
-		PrivateKeyPath:       "/some/path/rsa_key.p8",
-		PrivateKeyPassword:   config_util.Secret("some_password"),
-		Role:                 DefaultArguments.Role,
-		Warehouse:            "some_warehouse",
-		ExcludeDeletedTables: true,
+		AccountName:           "some_account",
+		Username:              "some_user",
+		Password:              config_util.Secret("some_password"),
+		PrivateKeyPath:        "/some/path/rsa_key.p8",
+		PrivateKeyPassword:    config_util.Secret("some_password"),
+		Role:                  DefaultArguments.Role,
+		Warehouse:             "some_warehouse",
+		ExcludeDeletedTables:  true,
+		EnableDriverTraceLogs: true,
 	}
 	require.Equal(t, expected, *res)
 }

--- a/internal/converter/internal/staticconvert/internal/build/snowflake_exporter.go
+++ b/internal/converter/internal/staticconvert/internal/build/snowflake_exporter.go
@@ -14,10 +14,14 @@ func (b *ConfigBuilder) appendSnowflakeExporter(config *snowflake_exporter.Confi
 
 func toSnowflakeExporter(config *snowflake_exporter.Config) *snowflake.Arguments {
 	return &snowflake.Arguments{
-		AccountName: config.AccountName,
-		Username:    config.Username,
-		Password:    alloytypes.Secret(config.Password),
-		Role:        config.Role,
-		Warehouse:   config.Warehouse,
+		AccountName:           config.AccountName,
+		Username:              config.Username,
+		Password:              alloytypes.Secret(config.Password),
+		PrivateKeyPath:        config.PrivateKeyPath,
+		PrivateKeyPassword:    alloytypes.Secret(config.PrivateKeyPassword),
+		Role:                  config.Role,
+		Warehouse:             config.Warehouse,
+		ExcludeDeletedTables:  config.ExcludeDeletedTables,
+		EnableDriverTraceLogs: config.EnableDriverTraceLogs,
 	}
 }

--- a/internal/static/integrations/snowflake_exporter/snowflake_exporter.go
+++ b/internal/static/integrations/snowflake_exporter/snowflake_exporter.go
@@ -16,14 +16,15 @@ var DefaultConfig = Config{
 
 // Config is the configuration for the snowflake integration
 type Config struct {
-	AccountName          string             `yaml:"account_name,omitempty"`
-	Username             string             `yaml:"username,omitempty"`
-	Password             config_util.Secret `yaml:"password,omitempty"`
-	PrivateKeyPath       string             `yaml:"private_key_path,omitempty"`
-	PrivateKeyPassword   config_util.Secret `yaml:"private_key_password,omitempty"`
-	Role                 string             `yaml:"role,omitempty"`
-	Warehouse            string             `yaml:"warehouse,omitempty"`
-	ExcludeDeletedTables bool               `yaml:"exclude_deleted_tables,omitempty"`
+	AccountName           string             `yaml:"account_name,omitempty"`
+	Username              string             `yaml:"username,omitempty"`
+	Password              config_util.Secret `yaml:"password,omitempty"`
+	PrivateKeyPath        string             `yaml:"private_key_path,omitempty"`
+	PrivateKeyPassword    config_util.Secret `yaml:"private_key_password,omitempty"`
+	Role                  string             `yaml:"role,omitempty"`
+	Warehouse             string             `yaml:"warehouse,omitempty"`
+	ExcludeDeletedTables  bool               `yaml:"exclude_deleted_tables,omitempty"`
+	EnableDriverTraceLogs bool               `yaml:"enable_tracing,omitempty"`
 }
 
 func (c *Config) exporterConfig() *collector.Config {
@@ -36,6 +37,7 @@ func (c *Config) exporterConfig() *collector.Config {
 		Role:               c.Role,
 		Warehouse:          c.Warehouse,
 		ExcludeDeleted:     c.ExcludeDeletedTables,
+		EnableTracing:      c.EnableDriverTraceLogs,
 	}
 }
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Add the `enable_tracing` attribute to the `prometheus.exporter.snowflake` component.

#### Which issue(s) this PR fixes
Adds support for the attribute introduced in this [PR](https://github.com/grafana/snowflake-prometheus-exporter/pull/29) to improve users ability to debug issues with the snowflake connection.

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
- [X] Documentation added
- [X] Tests updated
- [X] Config converters updated
