### PR TITLE
database_observability: Enable query samples by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Main (unreleased)
 - (_Experimental_) Additions to experimental `database_observability.mysql` component:
   - Add `explain_plan` collector to `database_observability.mysql` component. (@rgeyer)
   - `locks`: addition of data locks collector (@gaantunes @fridgepoet)
+  - Query sample collector is now enabled by default (@matthewnolf)
 
 - (_Experimental_) `prometheus.write.queue` add support for exemplars. (@dehaansa)
 

--- a/internal/component/database_observability/mysql/component.go
+++ b/internal/component/database_observability/mysql/component.go
@@ -240,7 +240,7 @@ func enableOrDisableCollectors(a Arguments) map[string]bool {
 		collector.QueryTablesName:    true,
 		collector.SchemaTableName:    true,
 		collector.SetupConsumersName: true,
-		collector.QuerySampleName:    false,
+		collector.QuerySampleName:    true,
 		collector.ExplainPlanName:    false,
 		collector.LocksName:          false,
 	}

--- a/internal/component/database_observability/mysql/component_test.go
+++ b/internal/component/database_observability/mysql/component_test.go
@@ -76,7 +76,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 		assert.Equal(t, map[string]bool{
 			collector.QueryTablesName:    true,
 			collector.SchemaTableName:    true,
-			collector.QuerySampleName:    false,
+			collector.QuerySampleName:    true,
 			collector.SetupConsumersName: true,
 			collector.ExplainPlanName:    false,
 			collector.LocksName:          false,
@@ -194,7 +194,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 		assert.Equal(t, map[string]bool{
 			collector.QueryTablesName:    true,
 			collector.SchemaTableName:    true,
-			collector.QuerySampleName:    false,
+			collector.QuerySampleName:    true,
 			collector.SetupConsumersName: true,
 			collector.ExplainPlanName:    false,
 			collector.LocksName:          false,


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Make query samples enabled by default now they have been available for some time.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
