### PR TITLE
runtime: propagate EnableCommunityComps to new controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ Main (unreleased)
 
 - Fix path for correct injection of version into constants at build time. (@adlotsof)
 
+- Propagate the `-feature.community-components.enabled` flag for remote
+  configuration components. (@tpaschalis)
+
 ### Other changes
 
 - Mark `pyroscope.receive_http` and `pyroscope.relabel` components as GA. (@marcsanmi)

--- a/internal/runtime/alloy_services.go
+++ b/internal/runtime/alloy_services.go
@@ -73,14 +73,15 @@ func (f *Runtime) NewController(id string) service.Controller {
 	return ServiceController{
 		f: newController(controllerOptions{
 			Options: Options{
-				ControllerID:    id,
-				Logger:          f.opts.Logger,
-				Tracer:          f.opts.Tracer,
-				DataPath:        f.opts.DataPath,
-				MinStability:    f.opts.MinStability,
-				Reg:             f.opts.Reg,
-				Services:        f.opts.Services,
-				OnExportsChange: nil, // NOTE(@tpaschalis, @wildum) The isolated controller shouldn't be able to export any values.
+				ControllerID:         id,
+				Logger:               f.opts.Logger,
+				Tracer:               f.opts.Tracer,
+				DataPath:             f.opts.DataPath,
+				MinStability:         f.opts.MinStability,
+				Reg:                  f.opts.Reg,
+				Services:             f.opts.Services,
+				EnableCommunityComps: f.opts.EnableCommunityComps,
+				OnExportsChange:      nil, // NOTE(@tpaschalis, @wildum) The isolated controller shouldn't be able to export any values.
 			},
 			IsModule:       true,
 			ModuleRegistry: newModuleRegistry(),


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR amends the runtime's NewController function that remotecfg currently uses so that EnableCommunityComps is properly propagated and the option to enable community components works there as well. 

#### Which issue(s) this PR fixes

No issue filed.

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
- [ ] Documentation added (N/A)
- [ ] Tests updated
