### PR TITLE
database_observability: wrap schema name in backticks in USE statement

### DIFF
--- a/internal/component/database_observability/mysql/collector/explain_plan.go
+++ b/internal/component/database_observability/mysql/collector/explain_plan.go
@@ -615,7 +615,9 @@ func (c *ExplainPlan) fetchExplainPlans(ctx context.Context) error {
 			continue
 		}
 		logger = log.With(logger, "schema_name", *qi.schemaName)
-		if _, err := c.dbConnection.ExecContext(ctx, "USE "+*qi.schemaName); err != nil {
+
+		useStatement := fmt.Sprintf("USE `%s`", *qi.schemaName)
+		if _, err := c.dbConnection.ExecContext(ctx, useStatement); err != nil {
 			level.Error(logger).Log("msg", "failed to set schema", "err", err)
 			continue
 		}


### PR DESCRIPTION
#### PR Description
To avoid issues with special characters in schema names, the schema name is now wrapped in backticks when constructing the USE statement.

#### Which issue(s) this PR fixes
n.a.

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
