### PR TITLE
Fix splunkhec receiver auth registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ Main (unreleased)
 - Propagate the `-feature.community-components.enabled` flag for remote
   configuration components. (@tpaschalis)
 
+- Fix extension registration for `otelcol.receiver.splunkhec` auth extensions. (@dehaansa)
+
 ### Other changes
 
 - Mark `pyroscope.receive_http` and `pyroscope.relabel` components as GA. (@marcsanmi)


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
The `splunkhec` receiver would log the following error when attempting to use authentication as the extensions were not recognized in the internal host interface implementation.
```
ts=... level=error msg="failed to start scheduled component" component_path=/ component_id=otelcol.receiver.splunkhec.splunk_hec err="failed to resolve authenticator \"bearertokenauth/otelcol_auth_bearer_creds_server\": authenticator not found"
```


<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer
A simple config like the following will show the error on main, and no error on this branch.

```
otelcol.auth.bearer "creds" {
	scheme = "Splunk"
	token  = "test_token"
}

otelcol.receiver.splunkhec "splunk_hec" {
	auth = otelcol.auth.bearer.creds.handler

	output {
		logs    = [otelcol.exporter.debug.default.input]
	}
}

otelcol.exporter.debug "default" {}
```

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
