### PR TITLE
Fix usage for loki enrich documentation

### DIFF
--- a/docs/sources/reference/components/loki/loki.enrich.md
+++ b/docs/sources/reference/components/loki/loki.enrich.md
@@ -25,10 +25,10 @@ loki.enrich "<LABEL>" {
   targets = <DISCOVERY_COMPONENT>.targets
   
   // Which label from discovered targets to match against
-  match_label = "<LABEL>"
+  target_match_label = "<LABEL>"
   
   // Which label from incoming logs to match against
-  source_label = "<LABEL>"
+  logs_match_label = "<LABEL>"
   
   // List of labels to copy from discovered targets to logs
   labels_to_copy = ["<LABEL>", ...]
@@ -48,7 +48,9 @@ You can use the following arguments with `loki.enrich`:
 | `target_match_label` | `string`              | The label from discovered targets to match against, for example, `"__inventory_consul_service"`. |                        | yes      |
 | `targets`            | `[]discovery.Target`  | List of targets from a discovery component.                                                      |                        | yes      |
 | `labels_to_copy`     | `[]string`            | List of labels to copy from discovered targets to logs. If empty, all labels will be copied.     |                        | no       |
-| `logs_match_label`   | `string`              | The label from incoming logs to match against discovered targets, for example `"service_name"`.  | `"target_match_label"` | no       |
+| `logs_match_label`   | `string`              | The label from incoming logs to match against discovered targets, for example `"service_name"`.  |                        | no       |
+
+If not provided, the `logs_match_label` attribute will default to the value of `target_match_label`.
 
 ## Blocks
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
A user in community slack noted that the usage docs had incorrect attribute names in the loki enrich docs.