### PR TITLE
Remove the Windows 2019 docker image

### DIFF
--- a/.github/workflows/check-windows-build-image.yml
+++ b/.github/workflows/check-windows-build-image.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   check-windows-build-image:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/publish-alloy-windows.yml
+++ b/.github/workflows/publish-alloy-windows.yml
@@ -24,7 +24,7 @@ jobs:
     name: Publish Alloy Windows container
     strategy:
       matrix:
-        os: [windows-2022, windows-2019]
+        os: [windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
       # This step needs to run before "Checkout code".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Breaking changes
+
+- Removing the `nanoserver-1809` container image for Windows 2019. (@ptodev)
+  This is due to the deprecation of `windows-2019` GitHub Actions runners.
+  The `windowsservercore-ltsc2022` Alloy image is still being published to DockerHub.
+
 ### Bugfixes
 
 - Upgrade `otelcol` components from OpenTelemetry v0.126.0 to v0.128.0 (@korniltsev, @dehaansa)

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@
 include tools/make/*.mk
 
 ALLOY_IMAGE          ?= grafana/alloy:latest
-ALLOY_IMAGE_WINDOWS  ?= grafana/alloy:nanoserver-1809
+ALLOY_IMAGE_WINDOWS  ?= grafana/alloy:windowsservercore-ltsc2022
 ALLOY_BINARY         ?= build/alloy
 SERVICE_BINARY       ?= build/alloy-service
 ALLOYLINT_BINARY     ?= build/alloylint

--- a/docs/sources/set-up/install/docker.md
+++ b/docs/sources/set-up/install/docker.md
@@ -75,7 +75,7 @@ To run {{< param "PRODUCT_NAME" >}} as a Windows Docker container, run the follo
 docker run \
   -v "<CONFIG_FILE_PATH>:C:\Program Files\GrafanaLabs\Alloy\config.alloy" \
   -p 12345:12345 \
-  grafana/alloy:nanoserver-1809 \
+  grafana/alloy:windowsservercore-ltsc2022 \
     run --server.http.listen-addr=0.0.0.0:12345 "--storage.path=C:\ProgramData\GrafanaLabs\Alloy\data" \
     "C:\Program Files\GrafanaLabs\Alloy\config.alloy"
 ```

--- a/tools/build-image/windows/Dockerfile
+++ b/tools/build-image/windows/Dockerfile
@@ -1,4 +1,4 @@
-FROM library/golang:1.24.0-windowsservercore-1809
+FROM library/golang:1.24.0-windowsservercore-ltsc2022
 
 SHELL ["powershell", "-command"]
 

--- a/tools/ci/docker-containers-windows
+++ b/tools/ci/docker-containers-windows
@@ -29,21 +29,15 @@ if [ "$WINDOWS_VERSION" = "windows-2022" ]; then
   export BASE_IMAGE_WINDOWS="mcr.microsoft.com/windows/nanoserver:ltsc2022"
   IMAGE_NAME_SUFFIX="windowsservercore-ltsc2022"
 else
-  export BASE_IMAGE_GO="library/golang:${ALLOY_GO_VERSION}-windowsservercore-1809"
-  export BASE_IMAGE_WINDOWS="mcr.microsoft.com/windows/nanoserver:ltsc2019"
-  # We aren't calling this windows-2019 for backwards compatibility reasons.
-  # Alloy used to always call this nanoserver-1809.
-  IMAGE_NAME_SUFFIX="nanoserver-1809"
+  # Report invalid windows base image and exit with code 1
+  echo "Invalid windows base image: $WINDOWS_VERSION"
+  exit 1
 fi
 
 export RELEASE_ALLOY_IMAGE=grafana/alloy
 export DEVEL_ALLOY_IMAGE=grafana/alloy-dev
 
 # TODO: Unit test this script? Test cases:
-# * Input:  ALLOY_GO_VERSION=1.24 GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v1.8.0 ./tools/ci/docker-containers-windows alloy
-#   Output: docker build -t grafana/alloy:v1.8.0-nanoserver-1809 -t grafana/alloy:nanoserver-1809 --build-arg VERSION=v1.8.0 --build-arg RELEASE_BUILD=1 --build-arg BASE_IMAGE_GO=library/golang:1.24-windowsservercore-1809 --build-arg BASE_IMAGE_WINDOWS=mcr.microsoft.com/windows/nanoserver:ltsc2019 -f ./Dockerfile.windows .
-# * Input:  ALLOY_GO_VERSION=1.24 GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v1.7.0-rc.4 ./tools/ci/docker-containers-windows alloy
-#   Output: docker build -t grafana/alloy:v1.7.0-rc.4-nanoserver-1809 -t grafana/alloy:v1.7.0-rc.4-nanoserver-1809 --build-arg VERSION=v1.7.0-rc.4 --build-arg RELEASE_BUILD=1 --build-arg BASE_IMAGE_GO=library/golang:1.24-windowsservercore-1809 --build-arg BASE_IMAGE_WINDOWS=mcr.microsoft.com/windows/nanoserver:ltsc2019 -f ./Dockerfile.windows .
 # * Input:  ALLOY_GO_VERSION=1.24 WINDOWS_VERSION=windows-2022 GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v1.8.0 ./tools/ci/docker-containers-windows alloy
 #   Output: docker build -t grafana/alloy:v1.8.0-windowsservercore-ltsc2022 -t grafana/alloy:windowsservercore-ltsc2022 --build-arg VERSION=v1.8.0 --build-arg RELEASE_BUILD=1 --build-arg BASE_IMAGE_GO=library/golang:1.24-windowsservercore-ltsc2022 --build-arg BASE_IMAGE_WINDOWS=mcr.microsoft.com/windows/nanoserver:ltsc2022 -f ./Dockerfile.windows .
 if [ -n "$GITHUB_TAG" ]; then


### PR DESCRIPTION
Related to #3727. I tried to avoid this by building the 2019 Alloy image using a 2019 base image on the `windows-2025` runner using Hyper-V. The image built successfully, but unfortunately I wasn't able to run it successfully on Windows 2025 using Hyper-V. I don't have access to a Windows 2019 machine at the moment, so I can't test this either.