### PR TITLE
Fuzz tests: workaround for panics in fuzzer

### DIFF
--- a/.github/workflows/fuzz-go.yml
+++ b/.github/workflows/fuzz-go.yml
@@ -106,7 +106,8 @@ jobs:
           # support cross-module testing, and the provided directory may be in
           # a different module.
           cd "${{ matrix.package }}"
-          go test -fuzz="${{ matrix.function }}\$" -run="${{ matrix.function }}\$" -fuzztime="${FUZZ_TIME}" .
+          # Note: -parallel=1 is required to avoid race conditions in the fuzzer until https://github.com/golang/go/issues/56238 is fixed.
+          go test -parallel=1 -fuzz="${{ matrix.function }}\$" -run="${{ matrix.function }}\$" -fuzztime="${FUZZ_TIME}" .
         env:
           FUZZ_TIME: ${{ inputs.fuzz-time }}
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

There are panics in the fuzzer that lead to flaky fuzz tests with error 

> fuzzing process hung or terminated unexpectedly: exit status 2

This seems to be the https://github.com/golang/go/issues/56238 issue. One workaround is to set parallelism to 1. Since we run fuzzer for very long time already - 5 minutes, I don't think it is going to impact the coverage much at all, so I propose setting parallelism here to 1.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
