### PR TITLE
Reduce allocation in Loki middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ v1.10.0-rc.0
 
 - Add `storage` and `start_from` args to cloudwatch logs receiver. (@boernd)
 
+- Reduced allocation in Loki processing pipelines (@thampiotr)
+
 ### Bugfixes
 
 - Fix path for correct injection of version into constants at build time. (@adlotsof)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ v1.10.0-rc.0
 
 - Add `storage` and `start_from` args to cloudwatch logs receiver. (@boernd)
 
-- Reduced allocation in Loki processing pipelines (@thampiotr)
+- Reduced allocation in Loki processing pipelines. (@thampiotr)
 
 ### Bugfixes
 

--- a/internal/component/common/loki/types.go
+++ b/internal/component/common/loki/types.go
@@ -170,7 +170,7 @@ func NewEntryMutatorHandler(next EntryHandler, f EntryMutatorFunc) EntryHandler 
 func AddLabelsMiddleware(additionalLabels model.LabelSet) EntryMiddleware {
 	return EntryMiddlewareFunc(func(eh EntryHandler) EntryHandler {
 		return NewEntryMutatorHandler(eh, func(e Entry) Entry {
-			// NOTE: this is a hot spot that came up in profiles, we want to avoid allocations if possible.
+			// Iterate and mutate the labels in place to avoid allocations.
 			for k, v := range additionalLabels {
 				if _, ok := e.Labels[k]; !ok {
 					e.Labels[k] = v

--- a/internal/component/common/loki/types.go
+++ b/internal/component/common/loki/types.go
@@ -170,6 +170,14 @@ func NewEntryMutatorHandler(next EntryHandler, f EntryMutatorFunc) EntryHandler 
 func AddLabelsMiddleware(additionalLabels model.LabelSet) EntryMiddleware {
 	return EntryMiddlewareFunc(func(eh EntryHandler) EntryHandler {
 		return NewEntryMutatorHandler(eh, func(e Entry) Entry {
+			if len(additionalLabels) == 0 {
+				return e
+			}
+
+			if e.Labels == nil {
+				e.Labels = make(model.LabelSet, len(additionalLabels))
+			}
+
 			// Iterate and mutate the labels in place to avoid allocations.
 			for k, v := range additionalLabels {
 				if _, ok := e.Labels[k]; !ok {

--- a/internal/component/common/loki/types_test.go
+++ b/internal/component/common/loki/types_test.go
@@ -25,7 +25,7 @@ func TestAddLabelsMiddleware(t *testing.T) {
 			},
 			inputEntry: Entry{
 				Labels: nil,
-				Entry: testEntry(),
+				Entry:  testEntry(),
 			},
 			expectedLabels: model.LabelSet{
 				"service": "test-service",
@@ -34,7 +34,7 @@ func TestAddLabelsMiddleware(t *testing.T) {
 			},
 		},
 		{
-			name: "nil additional labels",
+			name:             "nil additional labels",
 			additionalLabels: nil,
 			inputEntry: Entry{
 				Labels: model.LabelSet{

--- a/internal/component/common/loki/types_test.go
+++ b/internal/component/common/loki/types_test.go
@@ -17,6 +17,36 @@ func TestAddLabelsMiddleware(t *testing.T) {
 		expectedLabels   model.LabelSet
 	}{
 		{
+			name: "nil labels",
+			additionalLabels: model.LabelSet{
+				"service": "test-service",
+				"env":     "production",
+				"region":  "us-west-1",
+			},
+			inputEntry: Entry{
+				Labels: nil,
+				Entry: testEntry(),
+			},
+			expectedLabels: model.LabelSet{
+				"service": "test-service",
+				"env":     "production",
+				"region":  "us-west-1",
+			},
+		},
+		{
+			name: "nil additional labels",
+			additionalLabels: nil,
+			inputEntry: Entry{
+				Labels: model.LabelSet{
+					"level": "info",
+				},
+				Entry: testEntry(),
+			},
+			expectedLabels: model.LabelSet{
+				"level": "info",
+			},
+		},
+		{
 			name: "add multiple labels",
 			additionalLabels: model.LabelSet{
 				"service": "test-service",

--- a/internal/component/common/loki/types_test.go
+++ b/internal/component/common/loki/types_test.go
@@ -9,14 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// testEntry creates a consistent logproto.Entry for testing
-func testEntry() logproto.Entry {
-	return logproto.Entry{
-		Timestamp: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
-		Line:      "test log line",
-	}
-}
-
 func TestAddLabelsMiddleware(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -60,19 +52,19 @@ func TestAddLabelsMiddleware(t *testing.T) {
 			},
 		},
 		{
-			name:             "set label to empty value",
+			name: "set label to empty value",
 			additionalLabels: model.LabelSet{
 				"service": "",
 			},
 			inputEntry: Entry{
 				Labels: model.LabelSet{
-					"level": "info",
+					"level":   "info",
 					"service": "test-service",
 				},
 				Entry: testEntry(),
 			},
 			expectedLabels: model.LabelSet{
-				"level": "info",
+				"level":   "info",
 				"service": "test-service",
 			},
 		},
@@ -101,5 +93,12 @@ func TestAddLabelsMiddleware(t *testing.T) {
 				t.Fatal("timeout waiting for entry")
 			}
 		})
+	}
+}
+
+func testEntry() logproto.Entry {
+	return logproto.Entry{
+		Timestamp: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
+		Line:      "test log line",
 	}
 }

--- a/internal/component/common/loki/types_test.go
+++ b/internal/component/common/loki/types_test.go
@@ -1,0 +1,105 @@
+package loki
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// testEntry creates a consistent logproto.Entry for testing
+func testEntry() logproto.Entry {
+	return logproto.Entry{
+		Timestamp: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
+		Line:      "test log line",
+	}
+}
+
+func TestAddLabelsMiddleware(t *testing.T) {
+	tests := []struct {
+		name             string
+		additionalLabels model.LabelSet
+		inputEntry       Entry
+		expectedLabels   model.LabelSet
+	}{
+		{
+			name: "add multiple labels",
+			additionalLabels: model.LabelSet{
+				"service": "test-service",
+				"env":     "production",
+				"region":  "us-west-1",
+			},
+			inputEntry: Entry{
+				Labels: model.LabelSet{
+					"level": "error",
+				},
+				Entry: testEntry(),
+			},
+			expectedLabels: model.LabelSet{
+				"level":   "error",
+				"service": "test-service",
+				"env":     "production",
+				"region":  "us-west-1",
+			},
+		},
+		{
+			name: "try override existing label",
+			additionalLabels: model.LabelSet{
+				"level": "debug",
+			},
+			inputEntry: Entry{
+				Labels: model.LabelSet{
+					"level": "info",
+				},
+				Entry: testEntry(),
+			},
+			expectedLabels: model.LabelSet{
+				"level": "info",
+			},
+		},
+		{
+			name:             "set label to empty value",
+			additionalLabels: model.LabelSet{
+				"service": "",
+			},
+			inputEntry: Entry{
+				Labels: model.LabelSet{
+					"level": "info",
+					"service": "test-service",
+				},
+				Entry: testEntry(),
+			},
+			expectedLabels: model.LabelSet{
+				"level": "info",
+				"service": "test-service",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a test entry handler that captures the received entry
+			var receivedEntry Entry
+			received := make(chan Entry, 1)
+			testHandler := NewEntryHandler(received, func() {})
+
+			// Create the middleware and wrap the test handler
+			middleware := AddLabelsMiddleware(tt.additionalLabels)
+			wrappedHandler := middleware.Wrap(testHandler)
+
+			// Send the input entry
+			wrappedHandler.Chan() <- tt.inputEntry
+			wrappedHandler.Stop()
+
+			// Check the received entry
+			select {
+			case receivedEntry = <-received:
+				assert.Equal(t, tt.expectedLabels, receivedEntry.Labels)
+			case <-time.After(time.Second):
+				t.Fatal("timeout waiting for entry")
+			}
+		})
+	}
+}

--- a/internal/component/loki/source/file/decompresser.go
+++ b/internal/component/loki/source/file/decompresser.go
@@ -288,7 +288,9 @@ func (d *decompressor) readLines(handler loki.EntryHandler, done chan struct{}) 
 		d.metrics.readLines.WithLabelValues(d.path).Inc()
 
 		entries <- loki.Entry{
-			Labels: model.LabelSet{},
+			// Allocate the expected size of labels. This matches the number of labels added by the middleware
+			// as configured in Run().
+			Labels: make(model.LabelSet, len(d.labels)+1),
 			Entry: logproto.Entry{
 				Timestamp: time.Now(),
 				Line:      finalText,

--- a/internal/component/loki/source/file/decompresser_test.go
+++ b/internal/component/loki/source/file/decompresser_test.go
@@ -92,6 +92,8 @@ func BenchmarkReadlines(b *testing.B) {
 				running:  atomic.NewBool(false),
 				receiver: loki.NewLogsReceiver(),
 				path:     tc.file,
+				positions: &noopPositions{},
+				labels:    model.LabelSet{"foo": "bar", "baz": "boo"},
 			}
 
 			for i := 0; i < b.N; i++ {

--- a/internal/component/loki/source/file/decompresser_test.go
+++ b/internal/component/loki/source/file/decompresser_test.go
@@ -88,10 +88,10 @@ func BenchmarkReadlines(b *testing.B) {
 	for _, tc := range scenarios {
 		b.Run(tc.name, func(b *testing.B) {
 			decBase := &decompressor{
-				logger:   log.NewNopLogger(),
-				running:  atomic.NewBool(false),
-				receiver: loki.NewLogsReceiver(),
-				path:     tc.file,
+				logger:    log.NewNopLogger(),
+				running:   atomic.NewBool(false),
+				receiver:  loki.NewLogsReceiver(),
+				path:      tc.file,
 				positions: &noopPositions{},
 				labels:    model.LabelSet{"foo": "bar", "baz": "boo"},
 			}

--- a/internal/component/loki/source/file/tailer.go
+++ b/internal/component/loki/source/file/tailer.go
@@ -313,7 +313,9 @@ func (t *tailer) readLines(handler loki.EntryHandler, done chan struct{}) {
 
 		t.metrics.readLines.WithLabelValues(t.path).Inc()
 		entries <- loki.Entry{
-			Labels: model.LabelSet{},
+			// Allocate the expected size of labels. This matches the number of labels added by the middleware
+			// as configured in initRun().
+			Labels: make(model.LabelSet, len(t.labels)+1),
 			Entry: logproto.Entry{
 				Timestamp: line.Time,
 				Line:      text,


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This was identified as a hotspot for allocation. We can reduce it by manually setting entries on an existing map, without creating a new one in Merge function.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
