### PR TITLE
database_observability: fix scan type for nullable digests and digest texts

### DIFF
--- a/internal/component/database_observability/mysql/collector/locks.go
+++ b/internal/component/database_observability/mysql/collector/locks.go
@@ -144,7 +144,7 @@ func (c *LockCollector) fetchLocks(ctx context.Context) error {
 
 	for rsdl.Next() {
 		var waitingTimerWait, waitingLockTime, blockingTimerWait, blockingLockTime float64
-		var waitingDigest, waitingDigestText, blockingDigest, blockingDigestText string
+		var waitingDigest, waitingDigestText, blockingDigest, blockingDigestText sql.NullString
 
 		err := rsdl.Scan(&waitingTimerWait, &waitingLockTime, &waitingDigest, &waitingDigestText,
 			&blockingTimerWait, &blockingLockTime, &blockingDigest, &blockingDigestText)
@@ -157,10 +157,10 @@ func (c *LockCollector) fetchLocks(ctx context.Context) error {
 		if waitingLockTime > secondsToPicoseconds(c.lockTimeThreshold.Seconds()) {
 			lockMsg := fmt.Sprintf(
 				`waiting_digest="%s" waiting_digest_text="%s" blocking_digest="%s" blocking_digest_text="%s" waiting_timer_wait="%fms" waiting_lock_time="%fms" blocking_timer_wait="%fms" blocking_lock_time="%fms"`,
-				waitingDigest,
-				waitingDigestText,
-				blockingDigest,
-				blockingDigestText,
+				waitingDigest.String,
+				waitingDigestText.String,
+				blockingDigest.String,
+				blockingDigestText.String,
 				picosecondsToMilliseconds(waitingTimerWait),
 				picosecondsToMilliseconds(waitingLockTime),
 				picosecondsToMilliseconds(blockingTimerWait),


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR fixes the type that waiting/block Digest and Digest Text scan to as they are nullable fields.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
