### PR TITLE
database_observability: Revert explain plans for 'with' queries

### DIFF
--- a/internal/component/database_observability/mysql/collector/explain_plan.go
+++ b/internal/component/database_observability/mysql/collector/explain_plan.go
@@ -607,7 +607,7 @@ func (c *ExplainPlan) fetchExplainPlans(ctx context.Context) error {
 			continue
 		}
 
-		if !strings.HasPrefix(strings.ToLower(qi.queryText), "select") && !strings.HasPrefix(strings.ToLower(qi.queryText), "with") {
+		if !strings.HasPrefix(strings.ToLower(qi.queryText), "select") {
 			continue
 		}
 

--- a/internal/component/database_observability/mysql/collector/explain_plan_test.go
+++ b/internal/component/database_observability/mysql/collector/explain_plan_test.go
@@ -1676,43 +1676,6 @@ func TestExplainPlan(t *testing.T) {
 			)
 		})
 
-		t.Run("passes queries beginning in with", func(t *testing.T) {
-			lokiClient.Clear()
-			logBuffer.Reset()
-			mock.ExpectQuery(selectDigestsForExplainPlan).WithArgs(lastSeen).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows([]string{
-				"schema_name",
-				"digest",
-				"query_sample_text",
-				"last_seen",
-			}).AddRow(
-				"some_schema",
-				"some_digest",
-				"with cte as (select * from some_table where id = 1) select * from cte",
-				lastSeen,
-			))
-
-			mock.ExpectExec("USE `some_schema`").WithoutArgs().WillReturnResult(sqlmock.NewResult(0, 0))
-
-			mock.ExpectQuery(selectExplainPlanPrefix + "with cte as (select * from some_table where id = 1) select * from cte").WillReturnRows(sqlmock.NewRows([]string{
-				"json",
-			}).AddRow(
-				[]byte(`{"query_block": {"select_id": 1}}`),
-			))
-
-			err = c.fetchExplainPlans(t.Context())
-			require.NoError(t, err)
-
-			require.NotContains(t, logBuffer.String(), "error")
-
-			require.Eventually(
-				t,
-				func() bool { return len(lokiClient.Received()) == 1 },
-				5*time.Second,
-				10*time.Millisecond,
-				"did not receive the explain plan output log message within the timeout",
-			)
-		})
-
 		err = mock.ExpectationsWereMet()
 		require.NoError(t, err)
 	})


### PR DESCRIPTION
#### PR Description

We need more rigor to insure that we're not running explain plans for queries which can write to (or delete from) a schema.