### PR TITLE
database_observability: log query association in `query_tables`

### DIFF
--- a/internal/component/database_observability/mysql/collector/query_tables_test.go
+++ b/internal/component/database_observability/mysql/collector/query_tables_test.go
@@ -36,9 +36,11 @@ func TestQueryTables(t *testing.T) {
 				"select * from some_table where id = 1",
 			}},
 			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 			},
 			logsLines: []string{
+				"level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SELECT * FROM `some_table` WHERE `id` = ?\"",
 				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
 			},
 		},
@@ -51,9 +53,11 @@ func TestQueryTables(t *testing.T) {
 				"insert into some_table (`id`, `name`) values (1, 'foo')",
 			}},
 			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 			},
 			logsLines: []string{
+				"level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"INSERT INTO `some_table` (`id`, `name`) VALUES (...)\"",
 				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
 			},
 		},
@@ -66,9 +70,11 @@ func TestQueryTables(t *testing.T) {
 				"update some_table set active=false, reason=null where id = 1 and name = 'foo'",
 			}},
 			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 			},
 			logsLines: []string{
+				"level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"UPDATE `some_table` SET `active` = false, `reason` = ? WHERE `id` = ? AND `name` = ?\"",
 				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
 			},
 		},
@@ -81,9 +87,11 @@ func TestQueryTables(t *testing.T) {
 				"delete from some_table where id = 1",
 			}},
 			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 			},
 			logsLines: []string{
+				"level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"DELETE FROM `some_table` WHERE `id` = ?\"",
 				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
 			},
 		},
@@ -96,10 +104,12 @@ func TestQueryTables(t *testing.T) {
 				"select t.id, t.val1, o.val2 FROM some_table t inner join other_table as o on t.id = o.id where o.val2 = 1 order by t.val1 desc",
 			}},
 			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 			},
 			logsLines: []string{
+				"level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SELECT `t`.`id`, `t`.`val1`, `o`.`val2` FROM `some_table` `t` INNER JOIN `other_table` AS `o` ON `t`.`id` = `o`.`id` WHERE `o`.`val2` = ? ORDER BY `t`.`val1` DESC\"",
 				`level="info" schema="some_schema" digest="abc123" table="other_table"`,
 				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
 			},
@@ -118,11 +128,15 @@ func TestQueryTables(t *testing.T) {
 				"select * from another_table where id = 1",
 			}},
 			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 			},
 			logsLines: []string{
+				"level=\"info\" schema=\"some_schema\" parseable=\"false\" digest=\"xyz456\" digest_text=\"INSERT INTO `some_table`...\"",
 				`level="info" schema="some_schema" digest="xyz456" table="some_table"`,
+				"level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SELECT * FROM `another_table` WHERE `id` = ?\"",
 				`level="info" schema="some_schema" digest="abc123" table="another_table"`,
 			},
 		},
@@ -135,9 +149,11 @@ func TestQueryTables(t *testing.T) {
 				"select * from some_table where id = 1 /*traceparent='00-abc...",
 			}},
 			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 			},
 			logsLines: []string{
+				"level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SELECT * FROM `some_table` WHERE `id` = ?\"",
 				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
 			},
 		},
@@ -150,9 +166,11 @@ func TestQueryTables(t *testing.T) {
 				"select * from some_table where id = 1 /* comment that's closed */ and name = 'test...",
 			}},
 			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 			},
 			logsLines: []string{
+				"level=\"info\" schema=\"some_schema\" parseable=\"false\" digest=\"abc123\" digest_text=\"SELECT * FROM `some_table` WHERE `id` = ? AND `name` =\"",
 				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
 			},
 		},
@@ -164,8 +182,12 @@ func TestQueryTables(t *testing.T) {
 				"some_schema",
 				"START TRANSACTION",
 			}},
-			logsLabels: []model.LabelSet{},
-			logsLines:  []string{},
+			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "mysql-db"},
+			},
+			logsLines: []string{
+				`level="info" schema="some_schema" parseable="true" digest="abc123" digest_text="START TRANSACTION"`,
+			},
 		},
 		{
 			name: "sql parse error",
@@ -181,9 +203,11 @@ func TestQueryTables(t *testing.T) {
 				"select * from some_table where id = 1",
 			}},
 			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 			},
 			logsLines: []string{
+				"level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SELECT * FROM `some_table` WHERE `id` = ?\"",
 				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
 			},
 		},
@@ -201,11 +225,15 @@ func TestQueryTables(t *testing.T) {
 				"select * from some_table where id = 1",
 			}},
 			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 			},
 			logsLines: []string{
+				"level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SELECT * FROM `some_table` WHERE `id` = ?\"",
 				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
+				"level=\"info\" schema=\"other_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SELECT * FROM `some_table` WHERE `id` = ?\"",
 				`level="info" schema="other_schema" digest="abc123" table="some_table"`,
 			},
 		},
@@ -218,11 +246,13 @@ func TestQueryTables(t *testing.T) {
 				"SELECT * FROM (SELECT id, name FROM employees_us_east UNION SELECT id, name FROM employees_us_west) as employees_us UNION SELECT id, name FROM employees_emea",
 			}},
 			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 			},
 			logsLines: []string{
+				"level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SELECT * FROM (SELECT `id`, `name` FROM `employees_us_east` UNION SELECT `id`, `name` FROM `employees_us_west`) AS `employees_us` UNION SELECT `id`, `name` FROM `employees_emea`\"",
 				`level="info" schema="some_schema" digest="abc123" table="employees_emea"`,
 				`level="info" schema="some_schema" digest="abc123" table="employees_us_east"`,
 				`level="info" schema="some_schema" digest="abc123" table="employees_us_west"`,
@@ -237,9 +267,11 @@ func TestQueryTables(t *testing.T) {
 				"SHOW CREATE TABLE some_table",
 			}},
 			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 			},
 			logsLines: []string{
+				"level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SHOW CREATE TABLE `some_table`\"",
 				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
 			},
 		},
@@ -251,8 +283,12 @@ func TestQueryTables(t *testing.T) {
 				"some_schema",
 				"SHOW VARIABLES LIKE 'version'",
 			}},
-			logsLabels: []model.LabelSet{},
-			logsLines:  []string{},
+			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "mysql-db"},
+			},
+			logsLines: []string{
+				`level="info" schema="some_schema" parseable="true" digest="abc123" digest_text="SHOW VARIABLES LIKE ?"`,
+			},
 		},
 		{
 			name: "query truncated with dots fallback to digest_text",
@@ -263,9 +299,11 @@ func TestQueryTables(t *testing.T) {
 				"select * from some_table whe...",
 			}},
 			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 			},
 			logsLines: []string{
+				"level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SELECT * FROM `some_table` WHERE `id` = ?\"",
 				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
 			},
 		},
@@ -278,9 +316,11 @@ func TestQueryTables(t *testing.T) {
 				"select * from some_table where",
 			}},
 			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 			},
 			logsLines: []string{
+				"level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SELECT * FROM `some_table` WHERE `id` = ?\"",
 				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
 			},
 		},
@@ -293,9 +333,11 @@ func TestQueryTables(t *testing.T) {
 				"select * from some_table where",
 			}},
 			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 			},
 			logsLines: []string{
+				"level=\"info\" schema=\"some_schema\" parseable=\"false\" digest=\"abc123\" digest_text=\"SELECT * FROM `some_table` WHERE\"",
 				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
 			},
 		},
@@ -308,9 +350,11 @@ func TestQueryTables(t *testing.T) {
 				"select * from `s...",
 			}},
 			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "mysql-db"},
 				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"},
 			},
 			logsLines: []string{
+				"level=\"info\" schema=\"some_schema\" parseable=\"false\" digest=\"abc123\" digest_text=\"SELECT * FROM `some_table` WHERE\"",
 				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
 			},
 		},
@@ -424,7 +468,7 @@ func TestQueryTablesSQLDriverErrors(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
-			return len(lokiClient.Received()) == 1
+			return len(lokiClient.Received()) == 2
 		}, 5*time.Second, 100*time.Millisecond)
 
 		collector.Stop()
@@ -438,8 +482,10 @@ func TestQueryTablesSQLDriverErrors(t *testing.T) {
 		require.NoError(t, err)
 
 		lokiEntries := lokiClient.Received()
-		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"}, lokiEntries[0].Labels)
-		require.Equal(t, `level="info" schema="some_schema" digest="abc123" table="some_table"`, lokiEntries[0].Line)
+		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "mysql-db"}, lokiEntries[0].Labels)
+		require.Equal(t, "level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SELECT * FROM `some_table` WHERE `id` = ?\"", lokiEntries[0].Line)
+		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"}, lokiEntries[1].Labels)
+		require.Equal(t, `level="info" schema="some_schema" digest="abc123" table="some_table"`, lokiEntries[1].Line)
 	})
 
 	t.Run("result set iteration error", func(t *testing.T) {
@@ -485,7 +531,7 @@ func TestQueryTablesSQLDriverErrors(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
-			return len(lokiClient.Received()) == 1
+			return len(lokiClient.Received()) == 2
 		}, 5*time.Second, 100*time.Millisecond)
 
 		collector.Stop()
@@ -499,8 +545,10 @@ func TestQueryTablesSQLDriverErrors(t *testing.T) {
 		require.NoError(t, err)
 
 		lokiEntries := lokiClient.Received()
-		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"}, lokiEntries[0].Labels)
-		require.Equal(t, `level="info" schema="some_schema" digest="abc123" table="some_table"`, lokiEntries[0].Line)
+		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "mysql-db"}, lokiEntries[0].Labels)
+		require.Equal(t, "level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SELECT * FROM `some_table` WHERE `id` = ?\"", lokiEntries[0].Line)
+		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"}, lokiEntries[1].Labels)
+		require.Equal(t, `level="info" schema="some_schema" digest="abc123" table="some_table"`, lokiEntries[1].Line)
 	})
 
 	t.Run("connection error recovery", func(t *testing.T) {
@@ -543,7 +591,7 @@ func TestQueryTablesSQLDriverErrors(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
-			return len(lokiClient.Received()) == 1
+			return len(lokiClient.Received()) == 2
 		}, 5*time.Second, 100*time.Millisecond)
 
 		collector.Stop()
@@ -557,7 +605,9 @@ func TestQueryTablesSQLDriverErrors(t *testing.T) {
 		require.NoError(t, err)
 
 		lokiEntries := lokiClient.Received()
-		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"}, lokiEntries[0].Labels)
-		require.Equal(t, `level="info" schema="some_schema" digest="abc123" table="some_table"`, lokiEntries[0].Line)
+		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "mysql-db"}, lokiEntries[0].Labels)
+		require.Equal(t, "level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SELECT * FROM `some_table` WHERE `id` = ?\"", lokiEntries[0].Line)
+		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "mysql-db"}, lokiEntries[1].Labels)
+		require.Equal(t, `level="info" schema="some_schema" digest="abc123" table="some_table"`, lokiEntries[1].Line)
 	})
 }


### PR DESCRIPTION


#### PR Description

As part of the work required to stop using `digest_text` from metrics, log the entire digest_text within the `query_tables` collector.

#### Which issue(s) this PR fixes
n.a.

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
