### PR TITLE
Add clustering wait-for-size and wait-timeout to helm chart

### DIFF
--- a/operations/helm/charts/alloy/CHANGELOG.md
+++ b/operations/helm/charts/alloy/CHANGELOG.md
@@ -9,6 +9,7 @@ internal API changes are not present.
 
 Unreleased
 ----------
+- Add clustering waitForSize and waitTimeout. (@evanfreed)
 
 1.1.2 (2025-06-26)
 ----------

--- a/operations/helm/charts/alloy/README.md
+++ b/operations/helm/charts/alloy/README.md
@@ -36,6 +36,8 @@ useful if just using the default DaemonSet isn't sufficient.
 | alloy.clustering.enabled | bool | `false` | Deploy Alloy in a cluster to allow for load distribution. |
 | alloy.clustering.name | string | `""` | Name for the Alloy cluster. Used for differentiating between clusters. |
 | alloy.clustering.portName | string | `"http"` | Name for the port used for clustering, useful if running inside an Istio Mesh |
+| alloy.clustering.waitForSize | int | `0` | Wait for the cluster to reach the specified number of instances before allowing components that use clustering to begin processing. Zero means disabled. |
+| alloy.clustering.waitTimeout | int | `0` | The maximum duration to wait for minimum cluster size before proceeding with available nodes. Zero means no timeout. |
 | alloy.configMap.content | string | `""` | Content to assign to the new ConfigMap.  This is passed into `tpl` allowing for templating from values. |
 | alloy.configMap.create | bool | `true` | Create a new ConfigMap for the config file. |
 | alloy.configMap.key | string | `nil` | Key in ConfigMap to get config from. |

--- a/operations/helm/charts/alloy/templates/containers/_agent.yaml
+++ b/operations/helm/charts/alloy/templates/containers/_agent.yaml
@@ -18,6 +18,12 @@
     {{- if $values.clustering.name }}
     - --cluster.name={{ $values.clustering.name }}
     {{- end}}
+    {{- if $values.clustering.waitForSize }}
+    - --cluster.wait-for-size={{ $values.clustering.waitForSize }}
+    {{- end}}
+    {{- if $values.clustering.waitTimeout }}
+    - --cluster.wait-timeout={{ $values.clustering.waitTimeout }}
+    {{- end}}
     {{- end}}
     {{- if $values.stabilityLevel }}
     - --stability.level={{ $values.stabilityLevel }}

--- a/operations/helm/charts/alloy/values.yaml
+++ b/operations/helm/charts/alloy/values.yaml
@@ -50,6 +50,12 @@ alloy:
     # -- Name for the port used for clustering, useful if running inside an Istio Mesh
     portName: http
 
+    # -- Wait for the cluster to reach the number of instances before allowing clustered components to begin processing.
+    waitForSize: 0
+
+    # -- Maximum duration to wait for minimum cluster size before proceeding with available nodes
+    waitTimeout: 0
+
   # -- Minimum stability level of components and behavior to enable. Must be
   # one of "experimental", "public-preview", or "generally-available".
   stabilityLevel: "generally-available"


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

https://github.com/grafana/alloy/pull/2970 introduced `--cluster.wait-for-size` and `--cluster.wait-timeout` flags.  This adds these to `clustering` in helm.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
