### PR TITLE
Ensure cluster notifications are sent to remotecfg components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ Main (unreleased)
 
 - Add `protobuf_message` argument to `prometheus.remote_write` endpoint configuration to support both Prometheus Remote Write v1 and v2 protocols. The default remains `"prometheus.WriteRequest"` (v1) for backward compatibility. (@thampiotr)
 
+### Bugfixes
+
+- Fix issues with propagating cluster peers change notifications to components configured with remotecfg. (@dehaansa)
+
+- Fix issues with statistics reporter not including components only configured with remotecfg. (@dehaansa)
+
 v1.10.0
 -----------------
 

--- a/internal/alloycli/cmd_run.go
+++ b/internal/alloycli/cmd_run.go
@@ -485,7 +485,7 @@ func (fr *alloyRun) Run(cmd *cobra.Command, configPath string) error {
 func getEnabledComponentsFunc(f *alloy_runtime.Runtime) func() map[string]interface{} {
 	return func() map[string]interface{} {
 		components := component.GetAllComponents(f, component.InfoOptions{})
-		if remoteCfgHost, err := remotecfgservice.GetRemoteCfgHost(f); err == nil {
+		if remoteCfgHost, err := remotecfgservice.GetHost(f); err == nil {
 			components = append(components, component.GetAllComponents(remoteCfgHost, component.InfoOptions{})...)
 		}
 		componentNames := map[string]struct{}{}

--- a/internal/alloycli/cmd_run.go
+++ b/internal/alloycli/cmd_run.go
@@ -485,6 +485,9 @@ func (fr *alloyRun) Run(cmd *cobra.Command, configPath string) error {
 func getEnabledComponentsFunc(f *alloy_runtime.Runtime) func() map[string]interface{} {
 	return func() map[string]interface{} {
 		components := component.GetAllComponents(f, component.InfoOptions{})
+		if remoteCfgHost, err := remotecfgservice.GetRemoteCfgHost(f); err == nil {
+			components = append(components, component.GetAllComponents(remoteCfgHost, component.InfoOptions{})...)
+		}
 		componentNames := map[string]struct{}{}
 		for _, c := range components {
 			if c.Type != component.TypeBuiltin {

--- a/internal/service/cluster/cluster.go
+++ b/internal/service/cluster/cluster.go
@@ -418,10 +418,8 @@ func (s *Service) notifyComponentsOfClusterChanges(ctx context.Context, limiter 
 	// Notify all components about the clustering change.
 	components := component.GetAllComponents(host, component.InfoOptions{})
 
-	if remoteCfgHost, err := remotecfg.GetRemoteCfgHost(host); err == nil {
+	if remoteCfgHost, err := remotecfg.GetHost(host); err == nil {
 		components = append(components, component.GetAllComponents(remoteCfgHost, component.InfoOptions{})...)
-	} else {
-		level.Warn(s.log).Log("msg", "failed to get remotecfg service host when iterating components", "err", err)
 	}
 
 	for _, comp := range components {

--- a/internal/service/http/http.go
+++ b/internal/service/http/http.go
@@ -702,7 +702,7 @@ func printFileRedacted(f *ast.File) ([]byte, error) {
 
 func remoteCfgHostProvider(host service.Host) func() (service.Host, error) {
 	return func() (service.Host, error) {
-		return remotecfg.GetRemoteCfgHost(host)
+		return remotecfg.GetHost(host)
 	}
 }
 

--- a/internal/service/http/http.go
+++ b/internal/service/http/http.go
@@ -702,12 +702,7 @@ func printFileRedacted(f *ast.File) ([]byte, error) {
 
 func remoteCfgHostProvider(host service.Host) func() (service.Host, error) {
 	return func() (service.Host, error) {
-		svc, ok := host.GetService(remotecfg.ServiceName)
-		if !ok {
-			// This will never happen as the service dependency is explicit.
-			return nil, fmt.Errorf("failed to get the remotecfg service")
-		}
-		return svc.Data().(remotecfg.Data).Host, nil
+		return remotecfg.GetRemoteCfgHost(host)
 	}
 }
 

--- a/internal/service/remotecfg/remotecfg.go
+++ b/internal/service/remotecfg/remotecfg.go
@@ -592,7 +592,7 @@ func (i *agentInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFun
 	return next
 }
 
-func GetRemoteCfgHost(host service.Host) (service.Host, error) {
+func GetHost(host service.Host) (service.Host, error) {
 	svc, found := host.GetService(ServiceName)
 	if !found {
 		return nil, fmt.Errorf("remote config service not available")

--- a/internal/service/remotecfg/remotecfg.go
+++ b/internal/service/remotecfg/remotecfg.go
@@ -591,3 +591,16 @@ func (i *agentInterceptor) WrapStreamingClient(next connect.StreamingClientFunc)
 func (i *agentInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
 	return next
 }
+
+func GetRemoteCfgHost(host service.Host) (service.Host, error) {
+	svc, found := host.GetService(ServiceName)
+	if !found {
+		return nil, fmt.Errorf("remote config service not available")
+	}
+
+	data := svc.Data().(Data)
+	if data.Host == nil {
+		return nil, fmt.Errorf("remote config service startup in progress")
+	}
+	return data.Host, nil
+}

--- a/internal/web/api/api.go
+++ b/internal/web/api/api.go
@@ -6,7 +6,6 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
 	"math/rand"
 	"net/http"
 	"path"
@@ -60,19 +59,6 @@ func (a *AlloyAPI) RegisterRoutes(urlPrefix string, r *mux.Router) {
 	r.Handle(path.Join(urlPrefix, "/graph/{moduleID:.+}"), graph(a.alloy, a.CallbackManager, a.logger))
 }
 
-func getRemoteCfgHost(host service.Host) (service.Host, error) {
-	svc, found := host.GetService(remotecfg.ServiceName)
-	if !found {
-		return nil, fmt.Errorf("remote config service not available")
-	}
-
-	data := svc.Data().(remotecfg.Data)
-	if data.Host == nil {
-		return nil, fmt.Errorf("remote config service startup in progress")
-	}
-	return data.Host, nil
-}
-
 func listComponentsHandler(host service.Host) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		listComponentsHandlerInternal(host, w, r)
@@ -81,7 +67,7 @@ func listComponentsHandler(host service.Host) http.HandlerFunc {
 
 func listComponentsHandlerRemoteCfg(host service.Host) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		remoteCfgHost, err := getRemoteCfgHost(host)
+		remoteCfgHost, err := remotecfg.GetRemoteCfgHost(host)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -122,7 +108,7 @@ func getComponentHandler(host service.Host) http.HandlerFunc {
 
 func getComponentHandlerRemoteCfg(host service.Host) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		remoteCfgHost, err := getRemoteCfgHost(host)
+		remoteCfgHost, err := remotecfg.GetRemoteCfgHost(host)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -353,7 +339,7 @@ func liveDebugging(h service.Host, callbackManager livedebugging.CallbackManager
 
 func resolveServiceHost(host service.Host, id string) (service.Host, error) {
 	if strings.HasPrefix(id, "remotecfg/") {
-		remoteCfgHost, err := getRemoteCfgHost(host)
+		remoteCfgHost, err := remotecfg.GetRemoteCfgHost(host)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/web/api/api.go
+++ b/internal/web/api/api.go
@@ -67,7 +67,7 @@ func listComponentsHandler(host service.Host) http.HandlerFunc {
 
 func listComponentsHandlerRemoteCfg(host service.Host) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		remoteCfgHost, err := remotecfg.GetRemoteCfgHost(host)
+		remoteCfgHost, err := remotecfg.GetHost(host)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -108,7 +108,7 @@ func getComponentHandler(host service.Host) http.HandlerFunc {
 
 func getComponentHandlerRemoteCfg(host service.Host) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		remoteCfgHost, err := remotecfg.GetRemoteCfgHost(host)
+		remoteCfgHost, err := remotecfg.GetHost(host)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -339,7 +339,7 @@ func liveDebugging(h service.Host, callbackManager livedebugging.CallbackManager
 
 func resolveServiceHost(host service.Host, id string) (service.Host, error) {
 	if strings.HasPrefix(id, "remotecfg/") {
-		remoteCfgHost, err := remotecfg.GetRemoteCfgHost(host)
+		remoteCfgHost, err := remotecfg.GetHost(host)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Components loaded through remotecfg that are clustering aware were not getting their cluster alert notifications.

While I was fixing this, I also fixed the only other use of GetAllComponents, used for statistics reporting.

I tested this by configuring the following remotecfg pipeline in GC Fleet Management and running two alloy instances locally, 

```
prometheus.scrape "alloy" {
	clustering {
		enabled = true
	}
	targets = [
		{
			__address__ = "localhost:12345",
			job         = "alloy1",
		},
		{
			__address__ = "localhost:12346",
			job         = "alloy2",
		},
	]

	forward_to = [prometheus.remote_write.metrics_service.receiver]
}

prometheus.remote_write "metrics_service" {
	endpoint {
		url = "<prom_endpoint>"

		basic_auth {
			username = "<user>"
			password = "<password>"
		}
	}
}
```

I used a local remotecfg block with the collector ID coming from an environment variable (`id = sys.env("FLEET_ID")`) and started the two nodes manually in terminal.

```
FLEET_ID=alloy1 ./build/alloy run --server.http.listen-addr=0.0.0.0:12345 --cluster.join-addresses=127.0.0.1:12346 --server.http.ui-path-prefix=/ --cluster.enabled=true --cluster.name=alloy-cluster --cluster.node-name=alloy1 ./local/cluster_test.alloy

FLEET_ID=alloy2 ./build/alloy run --server.http.listen-addr=0.0.0.0:12346 --cluster.join-addresses=127.0.0.1:12345 --server.http.ui-path-prefix=/ --cluster.enabled=true --cluster.name=alloy-cluster --cluster.node-name=alloy2 ./local/cluster_test.alloy
```

I confirmed that each node only had one target using the local UI `http://localhost:12345/remotecfg/component/remotecfg/cluster_failover_test.default/prometheus.scrape.alloy` and then stopped one instance, and confirmed that the still running instance got both targets. Before the change the targets list would not change based on peers joining or leaving the cluster.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

I'm open to any recommendations for adding unit tests here, but did not see a good way to create them offhand. We need to revisit unit tests for remotecfg.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
- [ ] Tests updated
