### PR TITLE
database observability: move buildLokiEntry for common use

### DIFF
--- a/internal/component/database_observability/loki_entry.go
+++ b/internal/component/database_observability/loki_entry.go
@@ -1,4 +1,4 @@
-package collector
+package database_observability
 
 import (
 	"fmt"
@@ -8,14 +8,13 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
-	"github.com/grafana/alloy/internal/component/database_observability"
 	"github.com/grafana/alloy/internal/runtime/logging"
 )
 
-func buildLokiEntryWithTimestamp(level logging.Level, op, instanceKey, line string, timestamp int64) loki.Entry {
+func BuildLokiEntryWithTimestamp(level logging.Level, op, instanceKey, line string, timestamp int64) loki.Entry {
 	return loki.Entry{
 		Labels: model.LabelSet{
-			"job":      database_observability.JobName,
+			"job":      JobName,
 			"op":       model.LabelValue(op),
 			"instance": model.LabelValue(instanceKey),
 		},
@@ -26,6 +25,6 @@ func buildLokiEntryWithTimestamp(level logging.Level, op, instanceKey, line stri
 	}
 }
 
-func buildLokiEntry(level logging.Level, op, instanceKey, line string) loki.Entry {
-	return buildLokiEntryWithTimestamp(level, op, instanceKey, line, time.Now().UnixNano())
+func BuildLokiEntry(level logging.Level, op, instanceKey, line string) loki.Entry {
+	return BuildLokiEntryWithTimestamp(level, op, instanceKey, line, time.Now().UnixNano())
 }

--- a/internal/component/database_observability/loki_entry_test.go
+++ b/internal/component/database_observability/loki_entry_test.go
@@ -13,7 +13,7 @@ func TestBuildLokiEntry(t *testing.T) {
 	entry := BuildLokiEntry(logging.LevelDebug, "test-operation", "test-instance", "This is a test log line")
 
 	require.Len(t, entry.Labels, 3)
-	require.Equal(t, database_observability.JobName, string(entry.Labels["job"]))
+	require.Equal(t, JobName, string(entry.Labels["job"]))
 	require.Equal(t, "test-operation", string(entry.Labels["op"]))
 	require.Equal(t, "test-instance", string(entry.Labels["instance"]))
 	require.Equal(t, `level="debug" This is a test log line`, entry.Line)

--- a/internal/component/database_observability/loki_entry_test.go
+++ b/internal/component/database_observability/loki_entry_test.go
@@ -1,4 +1,4 @@
-package collector
+package database_observability
 
 import (
 	"testing"
@@ -6,12 +6,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/alloy/internal/component/database_observability"
 	"github.com/grafana/alloy/internal/runtime/logging"
 )
 
 func TestBuildLokiEntry(t *testing.T) {
-	entry := buildLokiEntry(logging.LevelDebug, "test-operation", "test-instance", "This is a test log line")
+	entry := BuildLokiEntry(logging.LevelDebug, "test-operation", "test-instance", "This is a test log line")
 
 	require.Len(t, entry.Labels, 3)
 	require.Equal(t, database_observability.JobName, string(entry.Labels["job"]))
@@ -21,7 +20,7 @@ func TestBuildLokiEntry(t *testing.T) {
 }
 
 func TestBuildLokiEntryWithTimestamp(t *testing.T) {
-	entry := buildLokiEntryWithTimestamp(logging.LevelInfo, "test-operation", "test-instance", "This is a test log line", 5)
+	entry := BuildLokiEntryWithTimestamp(logging.LevelInfo, "test-operation", "test-instance", "This is a test log line", 5)
 
 	require.Equal(t, int64(5), entry.Entry.Timestamp.UnixNano())
 	require.Equal(t, time.Unix(0, 5), entry.Entry.Timestamp)

--- a/internal/component/database_observability/mysql/collector/explain_plan.go
+++ b/internal/component/database_observability/mysql/collector/explain_plan.go
@@ -18,7 +18,9 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/buger/jsonparser"
+
 	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/component/database_observability"
 	"github.com/grafana/alloy/internal/component/database_observability/mysql/collector/parser"
 	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
@@ -667,7 +669,7 @@ func (c *ExplainPlan) fetchExplainPlans(ctx context.Context) error {
 			base64.StdEncoding.EncodeToString(explainPlanOutputJSON),
 		)
 
-		c.entryHandler.Chan() <- buildLokiEntry(
+		c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
 			logging.LevelInfo,
 			OP_EXPLAIN_PLAN_OUTPUT,
 			c.instanceKey,

--- a/internal/component/database_observability/mysql/collector/locks.go
+++ b/internal/component/database_observability/mysql/collector/locks.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/component/database_observability"
 	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
 )
@@ -167,7 +168,7 @@ func (c *LockCollector) fetchLocks(ctx context.Context) error {
 				picosecondsToMilliseconds(blockingLockTime),
 			)
 
-			c.entryHandler.Chan() <- buildLokiEntry(logging.LevelInfo, OP_DATA_LOCKS, c.instanceKey, lockMsg)
+			c.entryHandler.Chan() <- database_observability.BuildLokiEntry(logging.LevelInfo, OP_DATA_LOCKS, c.instanceKey, lockMsg)
 		}
 	}
 

--- a/internal/component/database_observability/mysql/collector/query_sample.go
+++ b/internal/component/database_observability/mysql/collector/query_sample.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/component/database_observability"
 	"github.com/grafana/alloy/internal/component/database_observability/mysql/collector/parser"
 	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
@@ -333,7 +334,7 @@ func (c *QuerySample) fetchQuerySamples(ctx context.Context) error {
 			lastDigestLogged = row.Digest.String
 			lastEventIDLogged = row.StatementEventID.String
 
-			c.entryHandler.Chan() <- buildLokiEntryWithTimestamp(
+			c.entryHandler.Chan() <- database_observability.BuildLokiEntryWithTimestamp(
 				logging.LevelInfo,
 				OP_QUERY_SAMPLE,
 				c.instanceKey,
@@ -363,7 +364,7 @@ func (c *QuerySample) fetchQuerySamples(ctx context.Context) error {
 				waitLogMessage += fmt.Sprintf(` sql_text="%s"`, row.SQLText.String)
 			}
 
-			c.entryHandler.Chan() <- buildLokiEntryWithTimestamp(
+			c.entryHandler.Chan() <- database_observability.BuildLokiEntryWithTimestamp(
 				logging.LevelInfo,
 				OP_WAIT_EVENT,
 				c.instanceKey,

--- a/internal/component/database_observability/mysql/collector/query_tables.go
+++ b/internal/component/database_observability/mysql/collector/query_tables.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/component/database_observability"
 	"github.com/grafana/alloy/internal/component/database_observability/mysql/collector/parser"
 	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
@@ -140,7 +141,7 @@ func (c *QueryTables) tablesFromEventsStatements(ctx context.Context) error {
 			}
 		}
 
-		c.entryHandler.Chan() <- buildLokiEntry(
+		c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
 			logging.LevelInfo,
 			OP_QUERY_ASSOCIATION,
 			c.instanceKey,
@@ -148,7 +149,7 @@ func (c *QueryTables) tablesFromEventsStatements(ctx context.Context) error {
 		)
 
 		for _, table := range tables {
-			c.entryHandler.Chan() <- buildLokiEntry(
+			c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
 				logging.LevelInfo,
 				OP_QUERY_PARSED_TABLE_NAME,
 				c.instanceKey,

--- a/internal/component/database_observability/mysql/collector/schema_table.go
+++ b/internal/component/database_observability/mysql/collector/schema_table.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/component/database_observability"
 	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
 )
@@ -245,7 +246,7 @@ func (c *SchemaTable) extractSchema(ctx context.Context) error {
 		}
 		schemas = append(schemas, schema)
 
-		c.entryHandler.Chan() <- buildLokiEntry(
+		c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
 			logging.LevelInfo,
 			OP_SCHEMA_DETECTION,
 			c.instanceKey,
@@ -290,7 +291,7 @@ func (c *SchemaTable) extractSchema(ctx context.Context) error {
 				b64TableSpec:  "",
 			})
 
-			c.entryHandler.Chan() <- buildLokiEntry(
+			c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
 				logging.LevelInfo,
 				OP_TABLE_DETECTION,
 				c.instanceKey,
@@ -333,7 +334,7 @@ func (c *SchemaTable) extractSchema(ctx context.Context) error {
 			}
 		}
 
-		c.entryHandler.Chan() <- buildLokiEntry(
+		c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
 			logging.LevelInfo,
 			OP_CREATE_STATEMENT,
 			c.instanceKey,


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This moves the buildLokiEntry out of the `mysql` directory to be used anywhere in the database observability component.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
