### PR TITLE
pyroscope.java: Improve filesystem permission error message

### DIFF
--- a/internal/component/pyroscope/java/asprof/extract.go
+++ b/internal/component/pyroscope/java/asprof/extract.go
@@ -184,7 +184,7 @@ func checkTempDirPermissions(tmpDirFile *os.File) error {
 	} else if sys.Uid == 0 && isSticky {
 		ok = true
 	}
-	if ok {
+	if !ok {
 		return fmt.Errorf("tmp dir %s has wrong permissions: It either needs to be owned by the same uid as this process %d while the dir permission is set to %04o or it needs to be owned by root and the sticky bit set: owner=%d mode=%04o sticky=%v", tmpDirFile.Name(), os.Getuid(), extractPerm, sys.Uid, tmpDirFileStat.Mode().Perm(), isSticky)
 	}
 	return nil


### PR DESCRIPTION
The error message is currently not very descriptive. This updated message explains better what the requirements are. 

cc @korniltsev 


