### PR TITLE
database_observability: Add backoff and denylisting for explain plan errors

### DIFF
--- a/docs/sources/reference/components/database_observability/database_observability.mysql.md
+++ b/docs/sources/reference/components/database_observability/database_observability.mysql.md
@@ -36,6 +36,8 @@ You can use the following arguments with `database_observability.mysql`:
 | `explain_plan_collect_interval`    | `duration`           | How frequently to collect explain plan information from database.                              | `"1m"`  | no       |
 | `explain_plan_per_collect_ratio`   | `float`              | Ratio of explain plan queries to collect per collect interval.                                 | `1.0`   | no       |
 | `explain_plan_initial_lookback`    | `duration`           | How far back to look for explain plan queries on the first collection interval.                | `"24h"` | no       |
+| `explain_plan_failure_backoff_rounds` | `int`              | Number of rounds to skip after a query fails.                                                 | `5`     | no       |
+| `explain_plan_max_failure_count`   | `int`              | Number of failures before a query is denylisted.                                              | `2`     | no       |
 | `locks_collect_interval`           | `duration`           | How frequently to collect locks information from database.                                     | `"30s"` | no       |
 | `locks_threshold`                  | `duration`           | Threshold for locks to be considered slow. If a lock exceeds this duration, it will be logged. | `"1s"`  | no       |
 | `setup_consumers_collect_interval` | `duration`           | How frequently to collect performance_schema.setup_consumers information from the database.    | `"1h"`  | no       |

--- a/internal/component/database_observability/mysql/collector/explain_plan.go
+++ b/internal/component/database_observability/mysql/collector/explain_plan.go
@@ -451,7 +451,6 @@ type queryInfo struct {
 	schemaName             string
 	digest                 string
 	queryText              string
-	failureBackoff         bool
 	failureCount           int
 	roundsSinceLastFailure int
 }
@@ -479,6 +478,7 @@ type ExplainPlan struct {
 	dbVersion            string
 	scrapeInterval       time.Duration
 	queryCache           map[string]*queryInfo
+	queryBackoffList     map[string]*queryInfo
 	queryDenylist        map[string]*queryInfo
 	perScrapeRatio       float64
 	currentBatchSize     int
@@ -510,6 +510,7 @@ func NewExplainPlan(args ExplainPlanArguments) (*ExplainPlan, error) {
 		scrapeInterval:       args.ScrapeInterval,
 		queryCache:           make(map[string]*queryInfo),
 		queryDenylist:        make(map[string]*queryInfo),
+		queryBackoffList:     make(map[string]*queryInfo),
 		perScrapeRatio:       args.PerScrapeRatio,
 		failureBackoffRounds: args.FailureBackoffRounds,
 		maxFailureCount:      args.MaxFailureCount,
@@ -573,6 +574,15 @@ func (c *ExplainPlan) populateQueryCache(ctx context.Context) error {
 	}
 	defer rs.Close()
 
+	// Add queries with expired backoff first
+	for _, qi := range c.queryBackoffList {
+		if qi.roundsSinceLastFailure >= c.failureBackoffRounds {
+			qi.roundsSinceLastFailure = 0
+			c.queryCache[qi.key()] = qi
+			delete(c.queryBackoffList, qi.key())
+		}
+	}
+
 	// Populate cache
 	for rs.Next() {
 		if err := rs.Err(); err != nil {
@@ -581,7 +591,6 @@ func (c *ExplainPlan) populateQueryCache(ctx context.Context) error {
 		}
 
 		qi := &queryInfo{
-			failureBackoff:         false,
 			failureCount:           0,
 			roundsSinceLastFailure: 0,
 		}
@@ -610,35 +619,29 @@ func (c *ExplainPlan) fetchExplainPlans(ctx context.Context) error {
 		}
 	}
 
+	for _, bqi := range c.queryBackoffList {
+		bqi.roundsSinceLastFailure++
+	}
+
 	processedCount := 0
 	for _, qi := range c.queryCache {
 		failed := false
 		if processedCount >= c.currentBatchSize {
 			break
 		}
-		if qi.failureBackoff {
-			if qi.roundsSinceLastFailure >= c.failureBackoffRounds {
-				qi.failureBackoff = false
-				qi.roundsSinceLastFailure = 0
-			} else {
-				qi.roundsSinceLastFailure++
-				continue
-			}
-		}
 		logger := log.With(c.logger, "digest", qi.digest)
 
 		defer func(failed *bool) {
 			if *failed {
 				qi.failureCount++
-				qi.failureBackoff = true
 				if qi.failureCount >= c.maxFailureCount {
-					delete(c.queryCache, qi.key())
 					c.queryDenylist[qi.key()] = qi
 					level.Info(c.logger).Log("msg", "query denylisted", "digest", qi.digest)
+				} else {
+					c.queryBackoffList[qi.key()] = qi
 				}
-			} else {
-				delete(c.queryCache, qi.key())
 			}
+			delete(c.queryCache, qi.key())
 			processedCount++
 		}(&failed)
 

--- a/internal/component/database_observability/mysql/collector/explain_plan.go
+++ b/internal/component/database_observability/mysql/collector/explain_plan.go
@@ -3,12 +3,12 @@ package collector
 import (
 	"bytes"
 	"context"
+	"crypto/md5"
 	"database/sql"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"math"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -448,37 +448,48 @@ func parseUnionResultNode(logger log.Logger, unionResultNode []byte) (planNode, 
 }
 
 type queryInfo struct {
-	schemaName string
-	digest     string
-	queryText  string
+	schemaName             string
+	digest                 string
+	queryText              string
+	failureBackoff         bool
+	failureCount           int
+	roundsSinceLastFailure int
+}
+
+func (qi *queryInfo) key() string {
+	return fmt.Sprintf("%x", md5.Sum([]byte(qi.schemaName+"|"+qi.digest)))
 }
 
 type ExplainPlanArguments struct {
-	DB              *sql.DB
-	InstanceKey     string
-	ScrapeInterval  time.Duration
-	PerScrapeRatio  float64
-	EntryHandler    loki.EntryHandler
-	InitialLookback time.Time
+	DB                   *sql.DB
+	InstanceKey          string
+	ScrapeInterval       time.Duration
+	PerScrapeRatio       float64
+	EntryHandler         loki.EntryHandler
+	InitialLookback      time.Time
+	FailureBackoffRounds int
+	MaxFailureCount      int
 
 	Logger log.Logger
 }
 
 type ExplainPlan struct {
-	dbConnection     *sql.DB
-	instanceKey      string
-	dbVersion        string
-	scrapeInterval   time.Duration
-	queryCache       []queryInfo
-	perScrapeRatio   float64
-	currentBatchSize int
-	entryHandler     loki.EntryHandler
-	lastSeen         time.Time
-
-	logger  log.Logger
-	running *atomic.Bool
-	ctx     context.Context
-	cancel  context.CancelFunc
+	dbConnection         *sql.DB
+	instanceKey          string
+	dbVersion            string
+	scrapeInterval       time.Duration
+	queryCache           map[string]*queryInfo
+	queryDenylist        map[string]*queryInfo
+	perScrapeRatio       float64
+	currentBatchSize     int
+	entryHandler         loki.EntryHandler
+	lastSeen             time.Time
+	failureBackoffRounds int
+	maxFailureCount      int
+	logger               log.Logger
+	running              *atomic.Bool
+	ctx                  context.Context
+	cancel               context.CancelFunc
 }
 
 func NewExplainPlan(args ExplainPlanArguments) (*ExplainPlan, error) {
@@ -493,16 +504,19 @@ func NewExplainPlan(args ExplainPlanArguments) (*ExplainPlan, error) {
 	}
 
 	return &ExplainPlan{
-		dbConnection:   args.DB,
-		instanceKey:    args.InstanceKey,
-		dbVersion:      dbVersion,
-		scrapeInterval: args.ScrapeInterval,
-		queryCache:     make([]queryInfo, 0),
-		perScrapeRatio: args.PerScrapeRatio,
-		entryHandler:   args.EntryHandler,
-		lastSeen:       args.InitialLookback,
-		logger:         log.With(args.Logger, "collector", ExplainPlanName),
-		running:        atomic.NewBool(false),
+		dbConnection:         args.DB,
+		instanceKey:          args.InstanceKey,
+		dbVersion:            dbVersion,
+		scrapeInterval:       args.ScrapeInterval,
+		queryCache:           make(map[string]*queryInfo),
+		queryDenylist:        make(map[string]*queryInfo),
+		perScrapeRatio:       args.PerScrapeRatio,
+		failureBackoffRounds: args.FailureBackoffRounds,
+		maxFailureCount:      args.MaxFailureCount,
+		entryHandler:         args.EntryHandler,
+		lastSeen:             args.InitialLookback,
+		logger:               log.With(args.Logger, "collector", ExplainPlanName),
+		running:              atomic.NewBool(false),
 	}, nil
 }
 
@@ -566,13 +580,19 @@ func (c *ExplainPlan) populateQueryCache(ctx context.Context) error {
 			return err
 		}
 
-		var qi queryInfo
+		qi := &queryInfo{
+			failureBackoff:         false,
+			failureCount:           0,
+			roundsSinceLastFailure: 0,
+		}
 		var ls time.Time
 		if err = rs.Scan(&qi.schemaName, &qi.digest, &qi.queryText, &ls); err != nil {
 			level.Error(c.logger).Log("msg", "failed to scan digest for explain plans", "err", err)
 			return err
 		}
-		c.queryCache = append(c.queryCache, qi)
+		if _, ok := c.queryDenylist[qi.key()]; !ok {
+			c.queryCache[qi.key()] = qi
+		}
 		if ls.After(c.lastSeen) {
 			c.lastSeen = ls
 		}
@@ -591,16 +611,36 @@ func (c *ExplainPlan) fetchExplainPlans(ctx context.Context) error {
 	}
 
 	processedCount := 0
-	for i, qi := range c.queryCache {
+	for _, qi := range c.queryCache {
+		failed := false
 		if processedCount >= c.currentBatchSize {
 			break
 		}
+		if qi.failureBackoff {
+			if qi.roundsSinceLastFailure >= c.failureBackoffRounds {
+				qi.failureBackoff = false
+				qi.roundsSinceLastFailure = 0
+			} else {
+				qi.roundsSinceLastFailure++
+				continue
+			}
+		}
 		logger := log.With(c.logger, "digest", qi.digest)
 
-		defer func(index int) {
-			c.queryCache = slices.Delete(c.queryCache, index, index+1)
+		defer func(failed *bool) {
+			if *failed {
+				qi.failureCount++
+				qi.failureBackoff = true
+				if qi.failureCount >= c.maxFailureCount {
+					delete(c.queryCache, qi.key())
+					c.queryDenylist[qi.key()] = qi
+					level.Info(c.logger).Log("msg", "query denylisted", "digest", qi.digest)
+				}
+			} else {
+				delete(c.queryCache, qi.key())
+			}
 			processedCount++
-		}(i)
+		}(&failed)
 
 		if strings.HasSuffix(qi.queryText, "...") {
 			level.Debug(logger).Log("msg", "skipping truncated query")
@@ -613,30 +653,33 @@ func (c *ExplainPlan) fetchExplainPlans(ctx context.Context) error {
 
 		logger = log.With(logger, "schema_name", qi.schemaName)
 
-		byteExplainPlanJSON, err := c.fetchExplainPlanJSON(ctx, qi)
+		byteExplainPlanJSON, err := c.fetchExplainPlanJSON(ctx, *qi)
 		if err != nil {
 			level.Error(logger).Log("msg", "failed to fetch explain plan json bytes", "err", err)
+			failed = true
 			continue
 		}
 
 		if len(byteExplainPlanJSON) == 0 {
 			level.Error(logger).Log("msg", "explain plan json bytes is empty")
+			failed = true
 			continue
 		}
 
 		if !utf8.Valid(byteExplainPlanJSON) {
 			level.Error(logger).Log("msg", "explain plan json bytes is not valid UTF-8")
+			failed = true
 			continue
 		}
 
 		redactedByteExplainPlanJSON, _, err := redactAttachedConditions(byteExplainPlanJSON)
 		if err != nil {
 			level.Error(logger).Log("msg", "failed to redact explain plan json", "err", err)
+			failed = true
 			continue
 		}
 
 		level.Debug(logger).Log("msg", "db native explain plan",
-			"digest", qi.digest,
 			"db_native_explain_plan", base64.StdEncoding.EncodeToString(redactedByteExplainPlanJSON))
 
 		generatedAt := time.Now().Format(time.RFC3339)
@@ -645,6 +688,7 @@ func (c *ExplainPlan) fetchExplainPlans(ctx context.Context) error {
 		explainPlanOutputJSON, err := json.Marshal(explainPlanOutput)
 		if err != nil {
 			level.Error(logger).Log("msg", "failed to marshal explain plan output", "err", err)
+			failed = true
 			continue
 		}
 
@@ -654,6 +698,7 @@ func (c *ExplainPlan) fetchExplainPlans(ctx context.Context) error {
 				"incomplete_explain_plan", base64.StdEncoding.EncodeToString(explainPlanOutputJSON),
 				"err", genErr,
 			)
+			failed = true
 			continue
 		}
 

--- a/internal/component/database_observability/mysql/collector/explain_plan.go
+++ b/internal/component/database_observability/mysql/collector/explain_plan.go
@@ -448,7 +448,7 @@ func parseUnionResultNode(logger log.Logger, unionResultNode []byte) (planNode, 
 }
 
 type queryInfo struct {
-	schemaName *string
+	schemaName string
 	digest     string
 	queryText  string
 }
@@ -611,10 +611,7 @@ func (c *ExplainPlan) fetchExplainPlans(ctx context.Context) error {
 			continue
 		}
 
-		if qi.schemaName == nil {
-			continue
-		}
-		logger = log.With(logger, "schema_name", *qi.schemaName)
+		logger = log.With(logger, "schema_name", qi.schemaName)
 
 		byteExplainPlanJSON, err := c.fetchExplainPlanJSON(ctx, qi)
 		if err != nil {
@@ -662,7 +659,7 @@ func (c *ExplainPlan) fetchExplainPlans(ctx context.Context) error {
 
 		logMessage := fmt.Sprintf(
 			`schema="%s" digest="%s" explain_plan_output="%s"`,
-			*qi.schemaName,
+			qi.schemaName,
 			qi.digest,
 			base64.StdEncoding.EncodeToString(explainPlanOutputJSON),
 		)
@@ -687,7 +684,7 @@ func (c *ExplainPlan) fetchExplainPlanJSON(ctx context.Context, qi queryInfo) ([
 	}
 	defer conn.Close()
 
-	useStatement := fmt.Sprintf("USE `%s`", *qi.schemaName)
+	useStatement := fmt.Sprintf("USE `%s`", qi.schemaName)
 	if _, err := conn.ExecContext(ctx, useStatement); err != nil {
 		return nil, fmt.Errorf("failed to set schema: %w", err)
 	}

--- a/internal/component/database_observability/mysql/collector/explain_plan_test.go
+++ b/internal/component/database_observability/mysql/collector/explain_plan_test.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"bytes"
+	"crypto/md5"
 	"fmt"
 	"os"
 	"testing"
@@ -1678,5 +1679,172 @@ func TestExplainPlan(t *testing.T) {
 
 		err = mock.ExpectationsWereMet()
 		require.NoError(t, err)
+	})
+}
+
+func TestQueryFailureBackoff(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	mock.ExpectQuery(selectDBSchemaVersion).WithoutArgs().WillReturnRows(sqlmock.NewRows([]string{
+		"version",
+	}).AddRow(
+		"8.0.32",
+	))
+
+	lastSeen := time.Now().Add(-time.Hour)
+	lokiClient := loki_fake.NewClient(func() {})
+	defer lokiClient.Stop()
+
+	logBuffer := bytes.NewBuffer(nil)
+
+	queryUnderTestHash := fmt.Sprintf("%x", md5.Sum([]byte("some_schema|some_digest1")))
+
+	c, err := NewExplainPlan(ExplainPlanArguments{
+		DB:                   db,
+		Logger:               log.NewLogfmtLogger(log.NewSyncWriter(logBuffer)),
+		InstanceKey:          "mysql-db",
+		ScrapeInterval:       time.Second,
+		PerScrapeRatio:       1,
+		EntryHandler:         lokiClient,
+		InitialLookback:      lastSeen,
+		FailureBackoffRounds: 5,
+		MaxFailureCount:      3,
+	})
+	require.NoError(t, err)
+
+	mock.ExpectQuery(selectDigestsForExplainPlan).WithArgs(lastSeen).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows([]string{
+		"schema_name",
+		"digest",
+		"query_sample_text",
+		"last_seen",
+	}).AddRow(
+		"some_schema",
+		"some_digest1",
+		"select * from some_table where id = 1",
+		lastSeen,
+	))
+
+	c.populateQueryCache(t.Context())
+	t.Run("failure increments counter", func(t *testing.T) {
+		lokiClient.Clear()
+		logBuffer.Reset()
+
+		mock.ExpectExec("USE `some_schema`").WithoutArgs().WillReturnResult(sqlmock.NewResult(0, 0))
+
+		mock.ExpectQuery(selectExplainPlanPrefix + "select * from some_table where id = 1").WillReturnError(fmt.Errorf("some error"))
+
+		err = c.fetchExplainPlans(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, 1, len(c.queryCache))
+		require.Equal(t, 0, c.queryCache[queryUnderTestHash].roundsSinceLastFailure)
+		require.Equal(t, 1, c.queryCache[queryUnderTestHash].failureCount)
+	})
+
+	t.Run("subsequent rounds do not process failed queries, increment rounds since last failure", func(t *testing.T) {
+		lokiClient.Clear()
+		logBuffer.Reset()
+
+		err = c.fetchExplainPlans(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, 1, len(c.queryCache))
+		require.Equal(t, 1, c.queryCache[queryUnderTestHash].failureCount)
+		require.Equal(t, 1, c.queryCache[queryUnderTestHash].roundsSinceLastFailure)
+	})
+
+	t.Run("failure backoff expires after defined rounds", func(t *testing.T) {
+		lokiClient.Clear()
+		logBuffer.Reset()
+
+		err = c.fetchExplainPlans(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, 1, len(c.queryCache))
+		require.Equal(t, 1, c.queryCache[queryUnderTestHash].failureCount)
+		require.Equal(t, 2, c.queryCache[queryUnderTestHash].roundsSinceLastFailure)
+
+		err = c.fetchExplainPlans(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, 1, len(c.queryCache))
+		require.Equal(t, 1, c.queryCache[queryUnderTestHash].failureCount)
+		require.Equal(t, 3, c.queryCache[queryUnderTestHash].roundsSinceLastFailure)
+
+		err = c.fetchExplainPlans(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, 1, len(c.queryCache))
+		require.Equal(t, 1, c.queryCache[queryUnderTestHash].failureCount)
+		require.Equal(t, 4, c.queryCache[queryUnderTestHash].roundsSinceLastFailure)
+
+		err = c.fetchExplainPlans(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, 1, len(c.queryCache))
+		require.Equal(t, 1, c.queryCache[queryUnderTestHash].failureCount)
+		require.Equal(t, 5, c.queryCache[queryUnderTestHash].roundsSinceLastFailure)
+
+		mock.ExpectExec("USE `some_schema`").WithoutArgs().WillReturnResult(sqlmock.NewResult(0, 0))
+
+		mock.ExpectQuery(selectExplainPlanPrefix + "select * from some_table where id = 1").WillReturnError(fmt.Errorf("some error"))
+
+		err = c.fetchExplainPlans(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, 1, len(c.queryCache))
+		require.Equal(t, 2, c.queryCache[queryUnderTestHash].failureCount)
+		require.Equal(t, 0, c.queryCache[queryUnderTestHash].roundsSinceLastFailure)
+	})
+
+	t.Run("query denylisted after max failure count", func(t *testing.T) {
+		lokiClient.Clear()
+		logBuffer.Reset()
+
+		// Manipulate the skipped rounds manually
+		queryUnderTest := c.queryCache[queryUnderTestHash]
+		queryUnderTest.roundsSinceLastFailure = c.failureBackoffRounds
+
+		mock.ExpectExec("USE `some_schema`").WithoutArgs().WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectQuery(selectExplainPlanPrefix + "select * from some_table where id = 1").WillReturnError(fmt.Errorf("some error"))
+
+		err = c.fetchExplainPlans(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, 0, len(c.queryCache))
+		require.Equal(t, 1, len(c.queryDenylist))
+	})
+
+	t.Run("denylisted queries are added to query cache", func(t *testing.T) {
+		lokiClient.Clear()
+		logBuffer.Reset()
+
+		mock.ExpectQuery(selectDigestsForExplainPlan).WithArgs(lastSeen).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows([]string{
+			"schema_name",
+			"digest",
+			"query_sample_text",
+			"last_seen",
+		}).AddRow(
+			"some_schema",
+			"some_digest1",
+			"select * from some_table where id = 1",
+			lastSeen,
+		).AddRow(
+			"some_schema",
+			"some_digest2",
+			"select * from some_table where id = 2",
+			lastSeen,
+		))
+
+		err = c.populateQueryCache(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, 1, len(c.queryCache))
+		require.Equal(t, 1, len(c.queryDenylist))
+
+		mock.ExpectExec("USE `some_schema`").WithoutArgs().WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectQuery(selectExplainPlanPrefix + "select * from some_table where id = 2").WillReturnRows(sqlmock.NewRows([]string{
+			"json",
+		}).AddRow(
+			[]byte(`{"query_block": {"select_id": 1}}`),
+		))
+
+		err = c.fetchExplainPlans(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, 0, len(c.queryCache))
+		require.Equal(t, 1, len(c.queryDenylist))
 	})
 }

--- a/internal/component/database_observability/mysql/collector/explain_plan_test.go
+++ b/internal/component/database_observability/mysql/collector/explain_plan_test.go
@@ -1737,49 +1737,75 @@ func TestQueryFailureBackoff(t *testing.T) {
 
 		err = c.fetchExplainPlans(t.Context())
 		require.NoError(t, err)
-		require.Equal(t, 1, len(c.queryCache))
-		require.Equal(t, 0, c.queryCache[queryUnderTestHash].roundsSinceLastFailure)
-		require.Equal(t, 1, c.queryCache[queryUnderTestHash].failureCount)
+		require.Equal(t, 0, len(c.queryCache))
+		require.Equal(t, 1, len(c.queryBackoffList))
+		require.Equal(t, 0, c.queryBackoffList[queryUnderTestHash].roundsSinceLastFailure)
+		require.Equal(t, 1, c.queryBackoffList[queryUnderTestHash].failureCount)
 	})
 
 	t.Run("subsequent rounds do not process failed queries, increment rounds since last failure", func(t *testing.T) {
 		lokiClient.Clear()
 		logBuffer.Reset()
 
+		mock.ExpectQuery(selectDigestsForExplainPlan).WithArgs(lastSeen).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows([]string{}))
+
 		err = c.fetchExplainPlans(t.Context())
 		require.NoError(t, err)
-		require.Equal(t, 1, len(c.queryCache))
-		require.Equal(t, 1, c.queryCache[queryUnderTestHash].failureCount)
-		require.Equal(t, 1, c.queryCache[queryUnderTestHash].roundsSinceLastFailure)
+		require.Equal(t, 0, len(c.queryCache))
+		require.Equal(t, 1, len(c.queryBackoffList))
+		require.Equal(t, 1, c.queryBackoffList[queryUnderTestHash].failureCount)
+		require.Equal(t, 1, c.queryBackoffList[queryUnderTestHash].roundsSinceLastFailure)
+	})
+
+	t.Run("new queries can be added and processed while others are on backoff", func(t *testing.T) {
+		lokiClient.Clear()
+		logBuffer.Reset()
+
+		mock.ExpectQuery(selectDigestsForExplainPlan).WithArgs(lastSeen).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows([]string{
+			"schema_name",
+			"digest",
+			"query_sample_text",
+			"last_seen",
+		}).AddRow(
+			"some_schema",
+			"some_digest2",
+			"select * from some_table where id = 2",
+			lastSeen,
+		))
+
+		mock.ExpectExec("USE `some_schema`").WithoutArgs().WillReturnResult(sqlmock.NewResult(0, 0))
+
+		mock.ExpectQuery(selectExplainPlanPrefix + "select * from some_table where id = 2").WillReturnRows(sqlmock.NewRows([]string{
+			"json",
+		}).AddRow(
+			[]byte(`{"query_block": {"select_id": 1}}`),
+		))
+
+		err = c.fetchExplainPlans(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, 0, len(c.queryCache))
+		require.Equal(t, 1, len(c.queryBackoffList))
+		require.Equal(t, 2, c.queryBackoffList[queryUnderTestHash].roundsSinceLastFailure)
+		require.Equal(t, 1, c.queryBackoffList[queryUnderTestHash].failureCount)
 	})
 
 	t.Run("failure backoff expires after defined rounds", func(t *testing.T) {
 		lokiClient.Clear()
 		logBuffer.Reset()
 
-		err = c.fetchExplainPlans(t.Context())
-		require.NoError(t, err)
-		require.Equal(t, 1, len(c.queryCache))
-		require.Equal(t, 1, c.queryCache[queryUnderTestHash].failureCount)
-		require.Equal(t, 2, c.queryCache[queryUnderTestHash].roundsSinceLastFailure)
+		c.queryBackoffList[queryUnderTestHash].roundsSinceLastFailure = c.failureBackoffRounds
+		mock.ExpectQuery(selectDigestsForExplainPlan).WithArgs(lastSeen).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows([]string{}))
 
-		err = c.fetchExplainPlans(t.Context())
-		require.NoError(t, err)
-		require.Equal(t, 1, len(c.queryCache))
-		require.Equal(t, 1, c.queryCache[queryUnderTestHash].failureCount)
-		require.Equal(t, 3, c.queryCache[queryUnderTestHash].roundsSinceLastFailure)
+		require.Equal(t, 1, len(c.queryBackoffList))
+		require.Contains(t, c.queryBackoffList, queryUnderTestHash)
 
-		err = c.fetchExplainPlans(t.Context())
+		err = c.populateQueryCache(t.Context())
 		require.NoError(t, err)
+		require.Equal(t, 0, len(c.queryBackoffList))
 		require.Equal(t, 1, len(c.queryCache))
+		require.Contains(t, c.queryCache, queryUnderTestHash)
+		require.Equal(t, 0, c.queryCache[queryUnderTestHash].roundsSinceLastFailure)
 		require.Equal(t, 1, c.queryCache[queryUnderTestHash].failureCount)
-		require.Equal(t, 4, c.queryCache[queryUnderTestHash].roundsSinceLastFailure)
-
-		err = c.fetchExplainPlans(t.Context())
-		require.NoError(t, err)
-		require.Equal(t, 1, len(c.queryCache))
-		require.Equal(t, 1, c.queryCache[queryUnderTestHash].failureCount)
-		require.Equal(t, 5, c.queryCache[queryUnderTestHash].roundsSinceLastFailure)
 
 		mock.ExpectExec("USE `some_schema`").WithoutArgs().WillReturnResult(sqlmock.NewResult(0, 0))
 
@@ -1787,18 +1813,17 @@ func TestQueryFailureBackoff(t *testing.T) {
 
 		err = c.fetchExplainPlans(t.Context())
 		require.NoError(t, err)
-		require.Equal(t, 1, len(c.queryCache))
-		require.Equal(t, 2, c.queryCache[queryUnderTestHash].failureCount)
-		require.Equal(t, 0, c.queryCache[queryUnderTestHash].roundsSinceLastFailure)
+		require.Equal(t, 0, len(c.queryCache))
+		require.Equal(t, 2, c.queryBackoffList[queryUnderTestHash].failureCount)
+		require.Equal(t, 0, c.queryBackoffList[queryUnderTestHash].roundsSinceLastFailure)
 	})
 
 	t.Run("query denylisted after max failure count", func(t *testing.T) {
 		lokiClient.Clear()
 		logBuffer.Reset()
 
-		// Manipulate the skipped rounds manually
-		queryUnderTest := c.queryCache[queryUnderTestHash]
-		queryUnderTest.roundsSinceLastFailure = c.failureBackoffRounds
+		c.queryBackoffList[queryUnderTestHash].roundsSinceLastFailure = c.failureBackoffRounds
+		mock.ExpectQuery(selectDigestsForExplainPlan).WithArgs(lastSeen).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows([]string{}))
 
 		mock.ExpectExec("USE `some_schema`").WithoutArgs().WillReturnResult(sqlmock.NewResult(0, 0))
 		mock.ExpectQuery(selectExplainPlanPrefix + "select * from some_table where id = 1").WillReturnError(fmt.Errorf("some error"))
@@ -1809,7 +1834,7 @@ func TestQueryFailureBackoff(t *testing.T) {
 		require.Equal(t, 1, len(c.queryDenylist))
 	})
 
-	t.Run("denylisted queries are added to query cache", func(t *testing.T) {
+	t.Run("denylisted queries are not added to query cache", func(t *testing.T) {
 		lokiClient.Clear()
 		logBuffer.Reset()
 

--- a/internal/component/database_observability/mysql/component.go
+++ b/internal/component/database_observability/mysql/component.go
@@ -60,9 +60,11 @@ type Arguments struct {
 	SetupConsumersCollectInterval time.Duration `alloy:"setup_consumers_collect_interval,attr,optional"`
 
 	// collector: 'explain_plan'
-	ExplainPlanCollectInterval time.Duration `alloy:"explain_plan_collect_interval,attr,optional"`
-	ExplainPlanPerCollectRatio float64       `alloy:"explain_plan_per_collect_ratio,attr,optional"`
-	ExplainPlanInitialLookback time.Duration `alloy:"explain_plan_initial_lookback,attr,optional"`
+	ExplainPlanCollectInterval      time.Duration `alloy:"explain_plan_collect_interval,attr,optional"`
+	ExplainPlanPerCollectRatio      float64       `alloy:"explain_plan_per_collect_ratio,attr,optional"`
+	ExplainPlanInitialLookback      time.Duration `alloy:"explain_plan_initial_lookback,attr,optional"`
+	ExplainPlanFailureBackoffRounds int           `alloy:"explain_plan_failure_backoff_rounds,attr,optional"`
+	ExplainPlanMaxFailureCount      int           `alloy:"explain_plan_max_failure_count,attr,optional"`
 
 	// collector: 'locks'
 	LocksCollectInterval time.Duration `alloy:"locks_collect_interval,attr,optional"`
@@ -79,9 +81,11 @@ var DefaultArguments = Arguments{
 	SetupConsumersCollectInterval: 1 * time.Hour,
 
 	// collector: 'explain_plan'
-	ExplainPlanCollectInterval: 1 * time.Minute,
-	ExplainPlanPerCollectRatio: 1.0,
-	ExplainPlanInitialLookback: 24 * time.Hour,
+	ExplainPlanCollectInterval:      1 * time.Minute,
+	ExplainPlanPerCollectRatio:      1.0,
+	ExplainPlanInitialLookback:      24 * time.Hour,
+	ExplainPlanFailureBackoffRounds: 5,
+	ExplainPlanMaxFailureCount:      2,
 
 	// collector: 'locks'
 	LocksCollectInterval: 30 * time.Second,
@@ -380,13 +384,15 @@ func (c *Component) startCollectors() error {
 
 	if collectors[collector.ExplainPlanName] {
 		epCollector, err := collector.NewExplainPlan(collector.ExplainPlanArguments{
-			DB:              dbConnection,
-			InstanceKey:     c.instanceKey,
-			ScrapeInterval:  c.args.ExplainPlanCollectInterval,
-			PerScrapeRatio:  c.args.ExplainPlanPerCollectRatio,
-			Logger:          c.opts.Logger,
-			EntryHandler:    entryHandler,
-			InitialLookback: time.Now().Add(-c.args.ExplainPlanInitialLookback),
+			DB:                   dbConnection,
+			InstanceKey:          c.instanceKey,
+			ScrapeInterval:       c.args.ExplainPlanCollectInterval,
+			PerScrapeRatio:       c.args.ExplainPlanPerCollectRatio,
+			Logger:               c.opts.Logger,
+			EntryHandler:         entryHandler,
+			InitialLookback:      time.Now().Add(-c.args.ExplainPlanInitialLookback),
+			FailureBackoffRounds: c.args.ExplainPlanFailureBackoffRounds,
+			MaxFailureCount:      c.args.ExplainPlanMaxFailureCount,
 		})
 		if err != nil {
 			level.Error(c.opts.Logger).Log("msg", "failed to create ExplainPlan collector", "err", err)


### PR DESCRIPTION
#### PR Description
This adds a backoff mechanism for explain queries which are experiencing errors.

When an error occurs while trying to execute an explain plan, that query is added to a backoff list. That query will wait `explain_plan_failure_backoff_rounds` (default 5) scrape intervals (rounds) before trying again.

If `explain_plan_max_failure_count` (default 2) failures occur, the query is deny listed for the duration of the lifespan of the current alloy process.

While queries are on backoff, other queries can be fetched from the performance_schema, and have explain plans executed for them.

#### PR Checklist
- [ ] CHANGELOG.md updated
- [X] Documentation added
- [X] Tests updated
- [ ] Config converters updated
