### PR TITLE
metrics enrich component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Main (unreleased)
 ### Features
 
 - Add the `otelcol.receiver.fluentforward` receiver to receive logs via Fluent Forward Protocol. (@rucciva)
+- Add the `prometheus.enrich` component to enrich metrics using labels from `discovery.*` components. (@ArkovKonstantin)
 
 ### Enhancements
 

--- a/docs/sources/reference/compatibility/_index.md
+++ b/docs/sources/reference/compatibility/_index.md
@@ -147,6 +147,7 @@ The following components, grouped by namespace, _consume_ Targets.
 {{< /collapse >}}
 
 {{< collapse title="prometheus" >}}
+- [prometheus.enrich](../components/prometheus/prometheus.enrich)
 - [prometheus.scrape](../components/prometheus/prometheus.scrape)
 {{< /collapse >}}
 
@@ -179,6 +180,7 @@ The following components, grouped by namespace, _export_ Prometheus `MetricsRece
 {{< /collapse >}}
 
 {{< collapse title="prometheus" >}}
+- [prometheus.enrich](../components/prometheus/prometheus.enrich)
 - [prometheus.relabel](../components/prometheus/prometheus.relabel)
 - [prometheus.remote_write](../components/prometheus/prometheus.remote_write)
 - [prometheus.write.queue](../components/prometheus/prometheus.write.queue)
@@ -198,6 +200,7 @@ The following components, grouped by namespace, _consume_ Prometheus `MetricsRec
 {{< /collapse >}}
 
 {{< collapse title="prometheus" >}}
+- [prometheus.enrich](../components/prometheus/prometheus.enrich)
 - [prometheus.operator.podmonitors](../components/prometheus/prometheus.operator.podmonitors)
 - [prometheus.operator.probes](../components/prometheus/prometheus.operator.probes)
 - [prometheus.operator.scrapeconfigs](../components/prometheus/prometheus.operator.scrapeconfigs)

--- a/docs/sources/reference/components/prometheus/prometheus.enrich.md
+++ b/docs/sources/reference/components/prometheus/prometheus.enrich.md
@@ -1,0 +1,120 @@
+---
+aliases:
+- /docs/alloy/latest/reference/components/prometheus/prometheus.enrich/
+canonical: https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.enrich/
+title: prometheus.enrich
+labels:
+  stage: experimental
+  products:
+    - oss
+description: The prometheus.enrich component enriches logs with labels from service discovery.
+---
+
+# `prometheus.enrich`
+
+{{< docs/shared lookup="stability/experimental.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+The `prometheus.enrich` component enriches metrics with additional labels from service discovery targets.
+It matches a label from incoming metrics against a label from discovered targets, and copies specified labels from the matched target to the metric sample.
+
+## Usage
+
+```alloy
+prometheus.enrich "<LABEL>" {
+  // List of targets from a discovery component
+  targets = <DISCOVERY_COMPONENT>.targets
+  
+  // Which label from discovered targets to match against
+  target_match_label = "<LABEL>"
+  
+  // Which label from incoming metrics to match against
+  metrics_match_label = "<LABEL>"
+  
+  // List of labels to copy from discovered targets to metrics
+  labels_to_copy = ["<LABEL>", ...]
+  
+  // Where to send enriched metrics
+  forward_to = [<RECEIVER_LIST>]
+}
+```
+
+## Arguments
+
+You can use the following arguments with `prometheus.enrich`:
+
+| Name                  | Type                           | Description                                                                                        | Default                | Required |
+|-----------------------|--------------------------------|----------------------------------------------------------------------------------------------------| ---------------------- | -------- |
+| `forward_to`          | `[]prometheus.MetricsReceiver` | Where the metrics should be forwarded to, after enrichment.                                        |                        | yes      |
+| `target_match_label`  | `string`                       | The label from discovered targets to match against, for example, `"__inventory_consul_service"`.   |                        | yes      |
+| `targets`             | `[]discovery.Target`           | List of targets from a discovery component.                                                        |                        | yes      |
+| `labels_to_copy`      | `[]string`                     | List of labels to copy from discovered targets to logs. If empty, all labels will be copied.       |                        | no       |
+| `metrics_match_label` | `string`                       | The label from incoming metrics to match against discovered targets, for example `"service_name"`. |                        | no       |
+
+If not provided, the `metrics_match_label` attribute will default to the value of `target_match_label`.
+
+## Blocks
+
+The `prometheus.enrich` component doesn't support any blocks. You can configure this component with arguments.
+
+## Exports
+
+The following values are exported:
+
+| Name       | Type                         | Description                                               |
+| ---------- |------------------------------|-----------------------------------------------------------|
+| `receiver` | `prometheus.MetricsReceiver` | The input receiver where samples are sent to be enriched. |
+
+## Example
+
+```alloy
+// Configure HTTP discovery
+discovery.http "default" {
+    url = "http://network-inventory.example.com/prometheus_sd"
+}
+
+prometheus.scrape "scrape_prom_metrics" {
+  targets = [
+    {"__address__" = "example-app:9001"},
+  ]
+
+  forward_to = [prometheus.enrich.enrich_prom_metrics.receiver]
+}
+
+prometheus.enrich "enrich_prom_metrics" {
+	targets = discovery.http.default.targets
+
+	target_match_label = "hostname"
+
+	forward_to = [prometheus.remote_write.enrich_prom_metrics.receiver]
+}
+
+prometheus.remote_write "enrich_prom_metrics" {
+  endpoint {
+    url = "http://mimir:9009/api/v1/push"
+  }
+}
+```
+
+## Component Behavior
+
+The component matches metric samples to discovered targets and enriches them with additional labels.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.enrich` can accept arguments from the following components:
+
+- Components that export [Targets](../../../compatibility/#targets-exporters)
+- Components that export [Prometheus `MetricsReceiver`](../../../compatibility/#prometheus-metricsreceiver-consumers)
+
+`prometheus.enrich` has exports that can be consumed by the following components:
+
+- Components that consume [Prometheus `MetricsReceiver`](../../../compatibility/#prometheus-metricsreceiver-consumers)
+
+{{< admonition type="note" >}}
+Connecting some components may not be sensible or components may require further configuration to make the connection work correctly.
+Refer to the linked documentation for more details.
+{{< /admonition >}}
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/reference/components/prometheus/prometheus.enrich.md
+++ b/docs/sources/reference/components/prometheus/prometheus.enrich.md
@@ -47,7 +47,7 @@ You can use the following arguments with `prometheus.enrich`:
 | `forward_to`          | `[]prometheus.MetricsReceiver` | Where the metrics should be forwarded to, after enrichment.                                        |                        | yes      |
 | `target_match_label`  | `string`                       | The label from discovered targets to match against, for example, `"__inventory_consul_service"`.   |                        | yes      |
 | `targets`             | `[]discovery.Target`           | List of targets from a discovery component.                                                        |                        | yes      |
-| `labels_to_copy`      | `[]string`                     | List of labels to copy from discovered targets to logs. If empty, all labels will be copied.       |                        | no       |
+| `labels_to_copy`      | `[]string`                     | List of labels to copy from discovered targets to metrics. If empty, all labels will be copied.    |                        | no       |
 | `metrics_match_label` | `string`                       | The label from incoming metrics to match against discovered targets, for example `"service_name"`. |                        | no       |
 
 If not provided, the `metrics_match_label` attribute will default to the value of `target_match_label`.

--- a/internal/cmd/integration-tests/tests/prom-enrich/config.alloy
+++ b/internal/cmd/integration-tests/tests/prom-enrich/config.alloy
@@ -1,0 +1,74 @@
+discovery.file "network_devices" {
+   files = ["/etc/alloy/devices.json"]
+}
+
+prometheus.scrape "scrape_prom_metrics" {
+  targets = [
+    {"__address__" = "prom-gen:9001"},
+  ]
+  scrape_classic_histograms = true
+
+  forward_to = [prometheus.enrich.enrich_prom_metrics.receiver, prometheus.enrich.enrich_mismatched.receiver]
+
+  scrape_interval = "1s"
+  scrape_timeout = "500ms"
+}
+
+
+prometheus.enrich "enrich_prom_metrics" {
+	targets = discovery.file.network_devices.targets
+
+	target_match_label = "hostname"
+	metrics_match_label = "instance"
+
+	labels_to_copy = ["datacenter", "environment"]
+
+	forward_to = [prometheus.remote_write.enrich_prom_metrics.receiver]
+}
+
+prometheus.enrich "enrich_mismatched" {
+	targets = discovery.file.network_devices.targets
+
+	target_match_label = "role"
+	metrics_match_label = "instance"
+
+	labels_to_copy = ["datacenter", "environment"]
+
+	forward_to = [prometheus.remote_write.enrich_mismatched.receiver]
+}
+
+prometheus.remote_write "enrich_prom_metrics" {
+  endpoint {
+    url = "http://mimir:9009/api/v1/push"
+    send_native_histograms = true
+
+
+    metadata_config {
+        send_interval = "1s"
+    }
+    queue_config {
+        max_samples_per_send = 100
+    }
+  }
+  external_labels = {
+    test_name = "enrich_prom_metrics",
+  }
+}
+
+prometheus.remote_write "enrich_mismatched" {
+  endpoint {
+    url = "http://mimir:9009/api/v1/push"
+    send_native_histograms = true
+
+
+    metadata_config {
+        send_interval = "1s"
+    }
+    queue_config {
+        max_samples_per_send = 100
+    }
+  }
+  external_labels = {
+    test_name = "enrich_mismatched",
+  }
+}

--- a/internal/cmd/integration-tests/tests/prom-enrich/devices.json
+++ b/internal/cmd/integration-tests/tests/prom-enrich/devices.json
@@ -1,0 +1,22 @@
+[
+  {
+    "targets": ["prom-gen:9001"],
+    "labels": {
+      "hostname": "prom-gen:9001",
+      "environment": "production",
+      "datacenter": "us-east",
+      "role": "core-router",
+      "__meta_rack": "rack1"
+    }
+  },
+  {
+    "targets": ["router2.example.com"],
+    "labels": {
+      "hostname": "router2.example.com",
+      "environment": "production",
+      "datacenter": "us-west",
+      "role": "edge-router",
+      "__meta_rack": "rack2"
+    }
+  }
+]

--- a/internal/cmd/integration-tests/tests/prom-enrich/enrich_test.go
+++ b/internal/cmd/integration-tests/tests/prom-enrich/enrich_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 )
 
-// TODO check metrics availability
 func TestEnrichPromMetrics(t *testing.T) {
 	testName := "enrich_prom_metrics"
 	common.AssertMetricsAvailable(t, common.PromDefaultMetrics, []string{}, testName)

--- a/internal/cmd/integration-tests/tests/prom-enrich/enrich_test.go
+++ b/internal/cmd/integration-tests/tests/prom-enrich/enrich_test.go
@@ -1,0 +1,60 @@
+package prom_enrich
+
+import (
+	"encoding/json"
+	"github.com/grafana/alloy/internal/cmd/integration-tests/common"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+// TODO check metrics availability
+func TestEnrichPromMetrics(t *testing.T) {
+	testName := "enrich_prom_metrics"
+	common.AssertMetricsAvailable(t, common.PromDefaultMetrics, []string{}, testName)
+
+	var resp MetricsResponse
+	err := common.FetchDataFromURL(common.MetricsQuery(testName), &resp)
+	assert.NoError(t, err)
+
+	expectedLabels := map[string]string{
+		"environment": "production",
+		"datacenter":  "us-east",
+	}
+
+	for _, metric := range resp.Data {
+		for name, value := range expectedLabels {
+			assert.Equal(t, value, metric[name],
+				"label %s should be %s for metric %s", name, value, metric["__name__"])
+		}
+	}
+}
+
+func TestEnrichMismatched(t *testing.T) {
+	testName := "enrich_mismatched"
+	common.AssertMetricsAvailable(t, common.PromDefaultMetrics, []string{}, testName)
+
+	var resp MetricsResponse
+	err := common.FetchDataFromURL(common.MetricsQuery(testName), &resp)
+	assert.NoError(t, err)
+
+	missingLabels := []string{
+		"environment",
+		"datacenter",
+	}
+
+	for _, metric := range resp.Data {
+		for _, name := range missingLabels {
+			assert.Equal(t, "", metric[name],
+				"label %s should be empty for metric %s", name, metric["__name__"])
+		}
+	}
+}
+
+type MetricsResponse struct {
+	Status string              `json:"status"`
+	Data   []map[string]string `json:"data"`
+}
+
+func (m *MetricsResponse) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, m)
+}

--- a/internal/component/all/all.go
+++ b/internal/component/all/all.go
@@ -120,6 +120,7 @@ import (
 	_ "github.com/grafana/alloy/internal/component/otelcol/receiver/vcenter"                 // Import otelcol.receiver.vcenter
 	_ "github.com/grafana/alloy/internal/component/otelcol/receiver/zipkin"                  // Import otelcol.receiver.zipkin
 	_ "github.com/grafana/alloy/internal/component/otelcol/storage/file"                     // Import otelcol.storage.file
+	_ "github.com/grafana/alloy/internal/component/prometheus/enrich"                        // Import prometheus.enrich
 	_ "github.com/grafana/alloy/internal/component/prometheus/exporter/apache"               // Import prometheus.exporter.apache
 	_ "github.com/grafana/alloy/internal/component/prometheus/exporter/azure"                // Import prometheus.exporter.azure
 	_ "github.com/grafana/alloy/internal/component/prometheus/exporter/blackbox"             // Import prometheus.exporter.blackbox

--- a/internal/component/prometheus/enrich/enrich.go
+++ b/internal/component/prometheus/enrich/enrich.go
@@ -1,0 +1,240 @@
+package enrich
+
+import (
+	"context"
+	"fmt"
+	"github.com/grafana/alloy/internal/component"
+	"github.com/grafana/alloy/internal/component/discovery"
+	"github.com/grafana/alloy/internal/component/prometheus"
+	"github.com/grafana/alloy/internal/featuregate"
+	"github.com/grafana/alloy/internal/service/labelstore"
+	prometheus_client "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/exemplar"
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
+	"github.com/prometheus/prometheus/storage"
+	"go.uber.org/atomic"
+	"sync"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:      "prometheus.enrich",
+		Stability: featuregate.StabilityExperimental,
+		Args:      Arguments{},
+		Exports:   Exports{},
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			return New(opts, args.(Arguments))
+		},
+	})
+}
+
+// Arguments configures the prometheus.enrich component.
+type Arguments struct {
+	// The targets to use for enrichment
+	Targets []discovery.Target `alloy:"targets,attr"`
+
+	// Which label from targets to use for matching (e.g. "hostname", "ip")
+	TargetMatchLabel string `alloy:"target_match_label,attr"`
+
+	// Which label from logs to match against (e.g. "hostname", "ip")
+	// If not specified, TargetMatchLabel will be used
+	MetricsMatchLabel string `alloy:"metrics_match_label,attr,optional"`
+
+	// List of labels to copy from discovered targets to logs. If empty, all labels will be copied.
+	LabelsToCopy []string `alloy:"labels_to_copy,attr,optional"`
+
+	ForwardTo []storage.Appendable `alloy:"forward_to,attr"`
+}
+
+// Exports holds values which are exported by the prometheus.enrich component.
+type Exports struct {
+	Receiver storage.Appendable `alloy:"receiver,attr"`
+}
+
+type Component struct {
+	opts    component.Options
+	args    Arguments
+	exports Exports
+
+	mut      sync.RWMutex
+	receiver *prometheus.Interceptor
+	ls       labelstore.LabelStore
+	fanout   *prometheus.Fanout
+	exited   atomic.Bool
+
+	targetsCache map[string]model.LabelSet
+	cacheMutex   sync.RWMutex
+
+	cacheSize prometheus_client.Gauge
+}
+
+func New(opts component.Options, args Arguments) (*Component, error) {
+	service, err := opts.GetServiceData(labelstore.ServiceName)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &Component{
+		opts: opts,
+		args: args,
+		ls:   service.(labelstore.LabelStore),
+	}
+
+	c.cacheSize = prometheus_client.NewGauge(prometheus_client.GaugeOpts{
+		Name: "alloy_prometheus_target_cache_size",
+		Help: "Total size of targets cache",
+	})
+
+	for _, metric := range []prometheus_client.Collector{
+		c.cacheSize,
+	} {
+		err = opts.Registerer.Register(metric)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	c.fanout = prometheus.NewFanout(args.ForwardTo, opts.ID, opts.Registerer, c.ls)
+	c.receiver = prometheus.NewInterceptor(
+		c.fanout,
+		c.ls,
+		prometheus.WithAppendHook(func(_ storage.SeriesRef, l labels.Labels, t int64, v float64, next storage.Appender) (storage.SeriesRef, error) {
+			if c.exited.Load() {
+				return 0, fmt.Errorf("%s has exited", opts.ID)
+			}
+
+			newLabels := c.enrich(l)
+
+			return next.Append(0, newLabels, t, v)
+		}),
+		prometheus.WithExemplarHook(func(_ storage.SeriesRef, l labels.Labels, e exemplar.Exemplar, next storage.Appender) (storage.SeriesRef, error) {
+			if c.exited.Load() {
+				return 0, fmt.Errorf("%s has exited", opts.ID)
+			}
+
+			newLabels := c.enrich(l)
+
+			return next.AppendExemplar(0, newLabels, e)
+		}),
+		prometheus.WithMetadataHook(func(_ storage.SeriesRef, l labels.Labels, m metadata.Metadata, next storage.Appender) (storage.SeriesRef, error) {
+			if c.exited.Load() {
+				return 0, fmt.Errorf("%s has exited", opts.ID)
+			}
+
+			newLabels := c.enrich(l)
+
+			return next.UpdateMetadata(0, newLabels, m)
+		}),
+		prometheus.WithHistogramHook(func(_ storage.SeriesRef, l labels.Labels, t int64, h *histogram.Histogram, fh *histogram.FloatHistogram, next storage.Appender) (storage.SeriesRef, error) {
+			if c.exited.Load() {
+				return 0, fmt.Errorf("%s has exited", opts.ID)
+			}
+
+			newLabels := c.enrich(l)
+
+			return next.AppendHistogram(0, newLabels, t, h, fh)
+		}),
+	)
+
+	if err = c.Update(args); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// Run implements component.Component.
+func (c *Component) Run(ctx context.Context) error {
+	defer c.exited.Store(true)
+
+	<-ctx.Done()
+
+	return nil
+}
+
+func (c *Component) Name() string {
+	return "prometheus.enrich"
+}
+
+func (c *Component) Ready() bool {
+	return true
+}
+
+// Update implements component.Component.
+func (c *Component) Update(args component.Arguments) error {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	newArgs := args.(Arguments)
+	c.fanout.UpdateChildren(newArgs.ForwardTo)
+
+	c.refreshCacheFromTargets(newArgs.Targets)
+
+	c.opts.OnStateChange(Exports{Receiver: c.receiver})
+
+	return nil
+}
+
+func (c *Component) enrich(lbls labels.Labels) labels.Labels {
+	var targetSet model.LabelSet
+	var ok bool
+
+	matchLabel := c.args.MetricsMatchLabel
+	if matchLabel == "" {
+		matchLabel = c.args.TargetMatchLabel
+	}
+
+	mlv := lbls.Get(matchLabel)
+	if mlv == "" {
+		return lbls
+	}
+
+	c.cacheMutex.RLock()
+	targetSet, ok = c.targetsCache[mlv]
+	c.cacheMutex.RUnlock()
+
+	if !ok {
+		return lbls
+	}
+
+	newLabels := lbls.Copy()
+
+	if len(c.args.LabelsToCopy) == 0 {
+		for k, v := range targetSet {
+			newLabels = append(newLabels, labels.Label{Name: string(k), Value: string(v)})
+		}
+	} else {
+		for _, label := range c.args.LabelsToCopy {
+			if value, ok := targetSet[model.LabelName(label)]; ok {
+				newLabels = append(newLabels, labels.Label{Name: label, Value: string(value)})
+			}
+		}
+	}
+
+	return newLabels
+}
+
+func (c *Component) refreshCacheFromTargets(targets []discovery.Target) {
+	newCache := make(map[string]model.LabelSet)
+
+	for _, target := range targets {
+		labelSet := make(model.LabelSet)
+		// Copy both own and group labels
+		target.ForEachLabel(func(k, v string) bool {
+			labelSet[model.LabelName(k)] = model.LabelValue(v)
+			return true
+		})
+		if matchValue := string(labelSet[model.LabelName(c.args.TargetMatchLabel)]); matchValue != "" {
+			newCache[matchValue] = labelSet
+		}
+	}
+
+	c.cacheMutex.Lock()
+	c.targetsCache = newCache
+	c.cacheMutex.Unlock()
+
+	c.cacheSize.Set(float64(len(c.targetsCache)))
+}

--- a/internal/component/prometheus/enrich/enrich_test.go
+++ b/internal/component/prometheus/enrich/enrich_test.go
@@ -1,0 +1,113 @@
+package enrich
+
+import (
+	"fmt"
+	"github.com/grafana/alloy/internal/component"
+	"github.com/grafana/alloy/internal/component/discovery"
+	"github.com/grafana/alloy/internal/component/prometheus"
+	"github.com/grafana/alloy/internal/service/labelstore"
+	"github.com/grafana/alloy/internal/util"
+	prom "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestEnricher(t *testing.T) {
+	// Create basic component options
+	tests := []struct {
+		name           string
+		args           Arguments
+		expectedLabels map[string]string
+	}{
+		{
+			name: "test1",
+			args: Arguments{
+				Targets: []discovery.Target{
+					discovery.NewTargetFromMap(map[string]string{
+						"service": "test-service",
+						"env":     "prod",
+						"owner":   "team-a",
+						"foo":     "bar",
+					}),
+				},
+				TargetMatchLabel:  "service",
+				MetricsMatchLabel: "service_name",
+				LabelsToCopy:      []string{"env", "owner"},
+			},
+			expectedLabels: map[string]string{
+				"service_name": "test-service",
+				"env":          "prod",
+				"owner":        "team-a",
+			},
+		},
+		{
+			name: "test2",
+			args: Arguments{
+				Targets: []discovery.Target{
+					discovery.NewTargetFromMap(map[string]string{
+						"service": "unknown",
+						"env":     "prod",
+						"owner":   "team-a",
+						"foo":     "bar",
+					}),
+				},
+				TargetMatchLabel:  "service",
+				MetricsMatchLabel: "service_name",
+				LabelsToCopy:      []string{"env", "owner"},
+			},
+			expectedLabels: map[string]string{
+				"service_name": "test-service",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ls := labelstore.New(nil, prom.DefaultRegisterer)
+			fanout := prometheus.NewInterceptor(
+				nil, ls,
+				prometheus.WithAppendHook(func(ref storage.SeriesRef, l labels.Labels, _ int64, _ float64, _ storage.Appender) (storage.SeriesRef, error) {
+					for name, value := range tt.expectedLabels {
+						require.Equal(t, l.Get(name), value)
+					}
+
+					return ref, nil
+				}))
+
+			var entry storage.Appendable
+			tt.args.ForwardTo = []storage.Appendable{fanout}
+			_, err := New(component.Options{
+				ID:     "1",
+				Logger: util.TestAlloyLogger(t),
+				OnStateChange: func(e component.Exports) {
+					newE := e.(Exports)
+					entry = newE.Receiver
+				},
+				Registerer:     prom.NewRegistry(),
+				GetServiceData: getServiceData,
+			}, tt.args)
+
+			require.NoError(t, err)
+
+			lbls := labels.FromStrings("service_name", "test-service")
+			app := entry.Appender(t.Context())
+
+			_, err = app.Append(0, lbls, time.Now().UnixMilli(), 0)
+			require.NoError(t, err)
+
+			err = app.Commit()
+			require.NoError(t, err)
+		})
+	}
+}
+
+func getServiceData(name string) (interface{}, error) {
+	switch name {
+	case labelstore.ServiceName:
+		return labelstore.New(nil, prom.DefaultRegisterer), nil
+	default:
+		return nil, fmt.Errorf("service not found %s", name)
+	}
+}


### PR DESCRIPTION
#### PR Description
This PR contains an implementation of the component `prometheus.enrich` described in this [proposal](https://github.com/grafana/alloy/issues/4017)

#### Notes to the Reviewer
The integration test demonstrates the enrichment of metrics collected from the `prom-gen` service using file-based discovery sample

#### PR Checklist
- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
