### PR TITLE
feat: add node filtering to loki.source.podlogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Main (unreleased)
 
 - Add the `otelcol.receiver.fluentforward` receiver to receive logs via Fluent Forward Protocol. (@rucciva)
 
+- Add `node_filter` configuration block to `loki.source.podlogs` component to enable node-based filtering for pod discovery. When enabled, only pods running on the specified node will be discovered and monitored, significantly reducing API server load and network traffic in DaemonSet deployments. (@username)
+
 ### Enhancements
 
 - `prometheus.scrape` now supports `convert_classic_histograms_to_nhcb`, `enable_compression`, `native_histogram_bucket_limit`, and `native_histogram_min_bucket_factor` arguments. (@thampiotr)
@@ -339,7 +341,7 @@ v1.8.3
 
 - Fix `mimir.rules.kubernetes` panic on non-leader debug info retrieval (@TheoBrigitte)
 
-- Fix detection of the “streams limit exceeded” error in the Loki client so that metrics are correctly labeled as `ReasonStreamLimited`. (@maratkhv)
+- Fix detection of the "streams limit exceeded" error in the Loki client so that metrics are correctly labeled as `ReasonStreamLimited`. (@maratkhv)
 
 - Fix `loki.source.file` race condition that often lead to panic when using `decompression`. (@kalleep)
 

--- a/internal/component/loki/source/podlogs/podlogs.go
+++ b/internal/component/loki/source/podlogs/podlogs.go
@@ -49,7 +49,21 @@ type Arguments struct {
 	NamespaceSelector config.LabelSelector `alloy:"namespace_selector,block,optional"`
 	TailFromEnd       bool                 `alloy:"tail_from_end,attr,optional"`
 
+	// Node filtering settings to limit pod discovery to specific nodes.
+	NodeFilter NodeFilterConfig `alloy:"node_filter,block,optional"`
+
 	Clustering cluster.ComponentBlock `alloy:"clustering,block,optional"`
+}
+
+// NodeFilterConfig configures node-based filtering for pod discovery.
+// When enabled, only pods running on the specified node will be discovered,
+// which is useful for DaemonSet deployments to avoid cross-node log collection.
+type NodeFilterConfig struct {
+	// Enabled controls whether node filtering is active.
+	Enabled bool `alloy:"enabled,attr,optional"`
+	// NodeName specifies the node name to filter by. If empty, the component
+	// will attempt to use the NODE_NAME environment variable.
+	NodeName string `alloy:"node_name,attr,optional"`
 }
 
 // DefaultArguments holds default settings for loki.source.kubernetes.
@@ -267,8 +281,13 @@ func (c *Component) updateReconciler(args Arguments) error {
 	var (
 		selectorChanged          = !reflect.DeepEqual(c.args.Selector, args.Selector)
 		namespaceSelectorChanged = !reflect.DeepEqual(c.args.NamespaceSelector, args.NamespaceSelector)
+		nodeFilterChanged        = !reflect.DeepEqual(c.args.NodeFilter, args.NodeFilter)
 	)
-	if !selectorChanged && !namespaceSelectorChanged {
+
+	// Update node filter configuration
+	c.reconciler.UpdateNodeFilter(args.NodeFilter.Enabled, args.NodeFilter.NodeName)
+
+	if !selectorChanged && !namespaceSelectorChanged && !nodeFilterChanged {
 		return nil
 	}
 

--- a/internal/component/loki/source/podlogs/podlogs_test.go
+++ b/internal/component/loki/source/podlogs/podlogs_test.go
@@ -35,3 +35,96 @@ func TestBadAlloyConfig(t *testing.T) {
 	err := syntax.Unmarshal([]byte(exampleAlloyConfig), &args)
 	require.ErrorContains(t, err, "at most one of basic_auth, authorization, oauth2, bearer_token & bearer_token_file must be configured")
 }
+
+func TestNodeFilterConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         string
+		expectedError  string
+		expectedResult Arguments
+	}{
+		{
+			name: "node filter disabled by default",
+			config: `
+				forward_to = []
+			`,
+			expectedResult: Arguments{
+				NodeFilter: NodeFilterConfig{
+					Enabled:  false,
+					NodeName: "",
+				},
+			},
+		},
+		{
+			name: "node filter enabled with explicit node name",
+			config: `
+				forward_to = []
+				node_filter {
+					enabled = true
+					node_name = "worker-node-1"
+				}
+			`,
+			expectedResult: Arguments{
+				NodeFilter: NodeFilterConfig{
+					Enabled:  true,
+					NodeName: "worker-node-1",
+				},
+			},
+		},
+		{
+			name: "node filter enabled without node name",
+			config: `
+				forward_to = []
+				node_filter {
+					enabled = true
+				}
+			`,
+			expectedResult: Arguments{
+				NodeFilter: NodeFilterConfig{
+					Enabled:  true,
+					NodeName: "",
+				},
+			},
+		},
+		{
+			name: "node filter with only node name specified",
+			config: `
+				forward_to = []
+				node_filter {
+					node_name = "worker-node-2"
+				}
+			`,
+			expectedResult: Arguments{
+				NodeFilter: NodeFilterConfig{
+					Enabled:  false, // default value
+					NodeName: "worker-node-2",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var args Arguments
+			err := syntax.Unmarshal([]byte(tt.config), &args)
+
+			if tt.expectedError != "" {
+				require.ErrorContains(t, err, tt.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedResult.NodeFilter.Enabled, args.NodeFilter.Enabled)
+			require.Equal(t, tt.expectedResult.NodeFilter.NodeName, args.NodeFilter.NodeName)
+		})
+	}
+}
+
+func TestNodeFilterConfigDefaults(t *testing.T) {
+	var args Arguments
+	args.SetToDefault()
+
+	// Verify node filter is disabled by default
+	require.False(t, args.NodeFilter.Enabled)
+	require.Empty(t, args.NodeFilter.NodeName)
+}

--- a/internal/component/loki/source/podlogs/reconciler_test.go
+++ b/internal/component/loki/source/podlogs/reconciler_test.go
@@ -262,3 +262,196 @@ func TestReconcilePodLogs_DefaultLabels(t *testing.T) {
 	assert(discoveryLabelsMap, kubetail.LabelPodNamespace, pod.Namespace)
 	assert(discoveryLabelsMap, kubetail.LabelPodContainerName, container.Name)
 }
+
+func TestReconcilePodLogs_NodeFiltering(t *testing.T) {
+	// Create a PodLogs object with empty selectors.
+	podLogs := &monitoringv1alpha2.PodLogs{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "testlogs",
+		},
+		Spec: monitoringv1alpha2.PodLogsSpec{
+			Selector:          metav1.LabelSelector{}, // matches all Pods
+			NamespaceSelector: metav1.LabelSelector{}, // matches all Namespaces
+		},
+	}
+
+	// Create a Namespace
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+		},
+	}
+
+	// Create pods running on different nodes
+	podOnNode1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "pod-on-node1",
+			UID:       "12345",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "container1", Image: "nginx"},
+			},
+			NodeName: "node1",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
+	}
+
+	podOnNode2 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "pod-on-node2",
+			UID:       "67890",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "container1", Image: "nginx"},
+			},
+			NodeName: "node2",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{
+		corev1.AddToScheme,
+		monitoringv1alpha2.AddToScheme,
+	} {
+		if err := add(scheme); err != nil {
+			t.Fatalf("unable to register scheme: %v", err)
+		}
+	}
+
+	tests := []struct {
+		name                string
+		nodeFilterEnabled   bool
+		nodeFilterName      string
+		nodeNameEnvVar      string
+		expectedTargetCount int
+		expectedPodNames    []string
+	}{
+		{
+			name:                "node filtering disabled",
+			nodeFilterEnabled:   false,
+			nodeFilterName:      "",
+			expectedTargetCount: 2,
+			expectedPodNames:    []string{"pod-on-node1", "pod-on-node2"},
+		},
+		{
+			name:                "node filtering enabled - filter by node1",
+			nodeFilterEnabled:   true,
+			nodeFilterName:      "node1",
+			expectedTargetCount: 1,
+			expectedPodNames:    []string{"pod-on-node1"},
+		},
+		{
+			name:                "node filtering enabled - filter by node2",
+			nodeFilterEnabled:   true,
+			nodeFilterName:      "node2",
+			expectedTargetCount: 1,
+			expectedPodNames:    []string{"pod-on-node2"},
+		},
+		{
+			name:                "node filtering enabled - filter by non-existent node",
+			nodeFilterEnabled:   true,
+			nodeFilterName:      "non-existent-node",
+			expectedTargetCount: 0,
+			expectedPodNames:    []string{},
+		},
+		{
+			name:                "node filtering enabled - use NODE_NAME env var",
+			nodeFilterEnabled:   true,
+			nodeFilterName:      "", // empty, should use env var
+			nodeNameEnvVar:      "node1",
+			expectedTargetCount: 1,
+			expectedPodNames:    []string{"pod-on-node1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up environment variable if specified
+			if tt.nodeNameEnvVar != "" {
+				t.Setenv("NODE_NAME", tt.nodeNameEnvVar)
+			}
+
+			// Build a fake client with the PodLogs, Namespace, and Pods.
+			cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(podLogs, ns, podOnNode1, podOnNode2).Build()
+
+			// Create a reconciler and configure node filtering
+			r := newReconciler(log.NewNopLogger(), nil, nil)
+			r.UpdateNodeFilter(tt.nodeFilterEnabled, tt.nodeFilterName)
+
+			// Call reconcilePodLogs.
+			targets, _ := r.reconcilePodLogs(t.Context(), cl, podLogs)
+
+			// Verify target count
+			if len(targets) != tt.expectedTargetCount {
+				t.Fatalf("expected %d targets, got %d", tt.expectedTargetCount, len(targets))
+			}
+
+			// Verify pod names in targets
+			actualPodNames := make([]string, len(targets))
+			for i, target := range targets {
+				actualPodNames[i] = target.Labels().Get(kubetail.LabelPodName)
+			}
+
+			if len(actualPodNames) != len(tt.expectedPodNames) {
+				t.Fatalf("expected pod names %v, got %v", tt.expectedPodNames, actualPodNames)
+			}
+
+			for _, expectedPod := range tt.expectedPodNames {
+				found := false
+				for _, actualPod := range actualPodNames {
+					if actualPod == expectedPod {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected pod %s not found in actual pods %v", expectedPod, actualPodNames)
+				}
+			}
+		})
+	}
+}
+
+func TestNodeFilterConfiguration(t *testing.T) {
+	r := newReconciler(log.NewNopLogger(), nil, nil)
+
+	// Test initial state
+	if r.getNodeFilterName() != "" {
+		t.Error("expected initial node filter to be empty")
+	}
+
+	// Test enabling with explicit node name
+	r.UpdateNodeFilter(true, "test-node")
+	if r.getNodeFilterName() != "test-node" {
+		t.Errorf("expected node filter name to be 'test-node', got '%s'", r.getNodeFilterName())
+	}
+
+	// Test disabling node filter
+	r.UpdateNodeFilter(false, "test-node")
+	if r.getNodeFilterName() != "" {
+		t.Error("expected node filter to be empty when disabled")
+	}
+
+	// Test enabling with empty name (should use env var)
+	t.Setenv("NODE_NAME", "env-node")
+	r.UpdateNodeFilter(true, "")
+	if r.getNodeFilterName() != "env-node" {
+		t.Errorf("expected node filter name to be 'env-node' from env var, got '%s'", r.getNodeFilterName())
+	}
+
+	// Test explicit name takes precedence over env var
+	r.UpdateNodeFilter(true, "explicit-node")
+	if r.getNodeFilterName() != "explicit-node" {
+		t.Errorf("expected explicit node name to take precedence, got '%s'", r.getNodeFilterName())
+	}
+}


### PR DESCRIPTION
#### PR Description

**Added node filtering** capability to `loki.source.podlogs` **component** - introduces a new `node_filter` configuration block that enables filtering pod discovery to only pods running on a specified node, significantly reducing Kubernetes API server load and preventing duplicate log collection in DaemonSet deployments.

The feature uses Kubernetes field selectors (`spec.nodeName`) for efficient API-level filtering and supports automatic node detection via the `NODE_NAME` environment variable, making it ideal for restart-heavy environments with spot instances.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
