### PR TITLE
beyla.ebpf: fix optional tag in selection > include/exclude

### DIFF
--- a/internal/component/beyla/ebpf/args.go
+++ b/internal/component/beyla/ebpf/args.go
@@ -61,8 +61,8 @@ type Selections []Selection
 
 type Selection struct {
 	Section string   `alloy:"attr,attr"`
-	Include []string `alloy:"include,attr"`
-	Exclude []string `alloy:"exclude,attr"`
+	Include []string `alloy:"include,attr,optional"`
+	Exclude []string `alloy:"exclude,attr,optional"`
 }
 
 type Services []Service


### PR DESCRIPTION
#### PR Description

#### Which issue(s) this PR fixes

In the `beyla.ebpf` section, each attributes selection section has an `include` and an `exclude` section. Despite you should either define one or another, they are optional, as stated in the documentation.

A customer noticed that despite the documentation describes them as optional, they aren't optional in the code: https://github.com/grafana/support-escalations/issues/16805

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [X] Config converters updated
