### PR TITLE
Fix docs for memcached example

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.exporter.memcached.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.memcached.md
@@ -72,7 +72,7 @@ prometheus.exporter.memcached "example" {
 }
 
 prometheus.scrape "example" {
-  targets    = [prometheus.exporter.memcached.example.targets]
+  targets    = prometheus.exporter.memcached.example.targets
   forward_to = [prometheus.remote_write.demo.receiver]
 }
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
The docs for the memcached exporter wrapped targets in extra brackets, breaking the alloy config.

#### Which issue(s) this PR fixes
Fixes https://github.com/grafana/alloy/issues/4007