### PR TITLE
Fix retries in prometheus.write.queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ Main (unreleased)
 
 - Fix issues with `prometheus.exporter.windows` not propagating `dns` collector config. (@dehaansa)
 
+- Fixed a bug in `prometheus.write.queue` which caused retries even when `max_retry_attempts` was set to `0`. (@ptodev)
+
 v1.10.0
 -----------------
 

--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,7 @@ require (
 	github.com/grafana/snowflake-prometheus-exporter v0.0.0-20250627131542-0c2feac3a700
 	github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0
 	github.com/grafana/vmware_exporter v0.0.5-beta.0.20250218170317-73398ba08329
-	github.com/grafana/walqueue v0.0.0-20250630130829-559914d5cae4
+	github.com/grafana/walqueue v0.0.0-20250725102104-86087dfeca27
 	github.com/hashicorp/consul/api v1.32.1
 	github.com/hashicorp/go-discover v1.1.0
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1346,8 +1346,8 @@ github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0 h1:bjh0PVYSVVFxzINqPF
 github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0/go.mod h1:7t5XR+2IA8P2qggOAHTj/GCZfoLBle3OvNSYh1VkRBU=
 github.com/grafana/vmware_exporter v0.0.5-beta.0.20250218170317-73398ba08329 h1:Rs4H1yv2Abk3xE82qpyhMGGA8rswAOA0HQZde/BYkFo=
 github.com/grafana/vmware_exporter v0.0.5-beta.0.20250218170317-73398ba08329/go.mod h1:Z28219aViNlsLlPvuCnlgHDagRdZBAZ7JOnQg1b3eWg=
-github.com/grafana/walqueue v0.0.0-20250630130829-559914d5cae4 h1:osKhTsqD4Kg9w+YVYL7gsNeIpft1ZrMRdN2VPNKqbhU=
-github.com/grafana/walqueue v0.0.0-20250630130829-559914d5cae4/go.mod h1:uhuBvXxR2H4BStQrYrb8PPdG5nGWo9WUpOCzYUFZEqU=
+github.com/grafana/walqueue v0.0.0-20250725102104-86087dfeca27 h1:Wb0TpBAxlHwgIZcDBhNqjwvdwz0vZzzGCIw35xFFleU=
+github.com/grafana/walqueue v0.0.0-20250725102104-86087dfeca27/go.mod h1:uhuBvXxR2H4BStQrYrb8PPdG5nGWo9WUpOCzYUFZEqU=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grobie/gomemcache v0.0.0-20230213081705-239240bbc445 h1:FlKQKUYPZ5yDCN248M3R7x8yu2E3yEZ0H7aLomE4EoE=
 github.com/grobie/gomemcache v0.0.0-20230213081705-239240bbc445/go.mod h1:L69/dBlPQlWkcnU76WgcppK5e4rrxzQdi6LhLnK/ytA=


### PR DESCRIPTION
#### PR Description

Fixed a [bug](https://github.com/grafana/walqueue/pull/47) in the WAL queue. I noticed this on a container which was consuming lots of disk space due to an endpoint returning HTTP 500. Alloy was persisting too many samples and using up all its disk quota.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
