### PR TITLE
database_observability: Add mysql engine version to connection_info

### DIFF
--- a/internal/component/database_observability/mysql/collector/connection_info.go
+++ b/internal/component/database_observability/mysql/collector/connection_info.go
@@ -19,13 +19,15 @@ var (
 )
 
 type ConnectionInfoArguments struct {
-	DSN      string
-	Registry *prometheus.Registry
+	DSN       string
+	Registry  *prometheus.Registry
+	DBVersion string
 }
 
 type ConnectionInfo struct {
 	DSN        string
 	Registry   *prometheus.Registry
+	DBVersion  string
 	InfoMetric *prometheus.GaugeVec
 
 	running *atomic.Bool
@@ -36,13 +38,14 @@ func NewConnectionInfo(args ConnectionInfoArguments) (*ConnectionInfo, error) {
 		Namespace: "database_observability",
 		Name:      "connection_info",
 		Help:      "Information about the connection",
-	}, []string{"provider_name", "provider_region", "db_instance_identifier", "engine"})
+	}, []string{"provider_name", "provider_region", "db_instance_identifier", "engine", "db_version"})
 
 	args.Registry.MustRegister(infoMetric)
 
 	return &ConnectionInfo{
 		DSN:        args.DSN,
 		Registry:   args.Registry,
+		DBVersion:  args.DBVersion,
 		InfoMetric: infoMetric,
 		running:    &atomic.Bool{},
 	}, nil
@@ -85,7 +88,7 @@ func (c *ConnectionInfo) Start(ctx context.Context) error {
 		}
 	}
 
-	c.InfoMetric.WithLabelValues(providerName, providerRegion, dbInstanceIdentifier, engine).Set(1)
+	c.InfoMetric.WithLabelValues(providerName, providerRegion, dbInstanceIdentifier, engine, c.DBVersion).Set(1)
 	return nil
 }
 

--- a/internal/component/database_observability/mysql/collector/connection_info.go
+++ b/internal/component/database_observability/mysql/collector/connection_info.go
@@ -19,16 +19,16 @@ var (
 )
 
 type ConnectionInfoArguments struct {
-	DSN       string
-	Registry  *prometheus.Registry
-	DBVersion string
+	DSN           string
+	Registry      *prometheus.Registry
+	EngineVersion string
 }
 
 type ConnectionInfo struct {
-	DSN        string
-	Registry   *prometheus.Registry
-	DBVersion  string
-	InfoMetric *prometheus.GaugeVec
+	DSN           string
+	Registry      *prometheus.Registry
+	EngineVersion string
+	InfoMetric    *prometheus.GaugeVec
 
 	running *atomic.Bool
 }
@@ -43,11 +43,11 @@ func NewConnectionInfo(args ConnectionInfoArguments) (*ConnectionInfo, error) {
 	args.Registry.MustRegister(infoMetric)
 
 	return &ConnectionInfo{
-		DSN:        args.DSN,
-		Registry:   args.Registry,
-		DBVersion:  args.DBVersion,
-		InfoMetric: infoMetric,
-		running:    &atomic.Bool{},
+		DSN:           args.DSN,
+		Registry:      args.Registry,
+		EngineVersion: args.EngineVersion,
+		InfoMetric:    infoMetric,
+		running:       &atomic.Bool{},
 	}, nil
 }
 
@@ -88,7 +88,7 @@ func (c *ConnectionInfo) Start(ctx context.Context) error {
 		}
 	}
 
-	c.InfoMetric.WithLabelValues(providerName, providerRegion, dbInstanceIdentifier, engine, c.DBVersion).Set(1)
+	c.InfoMetric.WithLabelValues(providerName, providerRegion, dbInstanceIdentifier, engine, c.EngineVersion).Set(1)
 	return nil
 }
 

--- a/internal/component/database_observability/mysql/collector/connection_info.go
+++ b/internal/component/database_observability/mysql/collector/connection_info.go
@@ -38,7 +38,7 @@ func NewConnectionInfo(args ConnectionInfoArguments) (*ConnectionInfo, error) {
 		Namespace: "database_observability",
 		Name:      "connection_info",
 		Help:      "Information about the connection",
-	}, []string{"provider_name", "provider_region", "db_instance_identifier", "engine", "db_version"})
+	}, []string{"provider_name", "provider_region", "db_instance_identifier", "engine", "engine_version"})
 
 	args.Registry.MustRegister(infoMetric)
 

--- a/internal/component/database_observability/mysql/collector/connection_info_test.go
+++ b/internal/component/database_observability/mysql/collector/connection_info_test.go
@@ -23,25 +23,25 @@ func TestConnectionInfo(t *testing.T) {
 	testCases := []struct {
 		name            string
 		dsn             string
-		dbVersion       string
+		engineVersion   string
 		expectedMetrics string
 	}{
 		{
 			name:            "generic dsn",
 			dsn:             "user:pass@tcp(localhost:3306)/schema",
-			dbVersion:       "8.0.32",
+			engineVersion:   "8.0.32",
 			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "unknown", "mysql", "8.0.32", "unknown", "unknown"),
 		},
 		{
 			name:            "AWS/RDS dsn",
 			dsn:             "user:pass@tcp(products-db.abc123xyz.us-east-1.rds.amazonaws.com:3306)/schema",
-			dbVersion:       "8.0.32",
+			engineVersion:   "8.0.32",
 			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "products-db", "mysql", "8.0.32", "aws", "us-east-1"),
 		},
 		{
 			name:            "Azure flexibleservers dsn",
 			dsn:             "user:pass@tcp(products-db.mysql.database.azure.com:3306)/schema",
-			dbVersion:       "8.0.32",
+			engineVersion:   "8.0.32",
 			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "products-db", "mysql", "8.0.32", "azure", "unknown"),
 		},
 	}
@@ -50,9 +50,9 @@ func TestConnectionInfo(t *testing.T) {
 		reg := prometheus.NewRegistry()
 
 		collector, err := NewConnectionInfo(ConnectionInfoArguments{
-			DSN:       tc.dsn,
-			Registry:  reg,
-			DBVersion: tc.dbVersion,
+			DSN:           tc.dsn,
+			Registry:      reg,
+			EngineVersion: tc.engineVersion,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)

--- a/internal/component/database_observability/mysql/collector/connection_info_test.go
+++ b/internal/component/database_observability/mysql/collector/connection_info_test.go
@@ -17,7 +17,7 @@ func TestConnectionInfo(t *testing.T) {
 	const baseExpectedMetrics = `
 	# HELP database_observability_connection_info Information about the connection
 	# TYPE database_observability_connection_info gauge
-	database_observability_connection_info{db_instance_identifier="%s",db_version="%s",engine="%s",provider_name="%s",provider_region="%s"} 1
+	database_observability_connection_info{db_instance_identifier="%s",engine="%s",engine_version="%s",provider_name="%s",provider_region="%s"} 1
 `
 
 	testCases := []struct {
@@ -30,19 +30,19 @@ func TestConnectionInfo(t *testing.T) {
 			name:            "generic dsn",
 			dsn:             "user:pass@tcp(localhost:3306)/schema",
 			dbVersion:       "8.0.32",
-			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "unknown", "8.0.32", "mysql", "unknown", "unknown"),
+			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "unknown", "mysql", "8.0.32", "unknown", "unknown"),
 		},
 		{
 			name:            "AWS/RDS dsn",
 			dsn:             "user:pass@tcp(products-db.abc123xyz.us-east-1.rds.amazonaws.com:3306)/schema",
 			dbVersion:       "8.0.32",
-			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "products-db", "8.0.32", "mysql", "aws", "us-east-1"),
+			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "products-db", "mysql", "8.0.32", "aws", "us-east-1"),
 		},
 		{
 			name:            "Azure flexibleservers dsn",
 			dsn:             "user:pass@tcp(products-db.mysql.database.azure.com:3306)/schema",
 			dbVersion:       "8.0.32",
-			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "products-db", "8.0.32", "mysql", "azure", "unknown"),
+			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "products-db", "mysql", "8.0.32", "azure", "unknown"),
 		},
 	}
 

--- a/internal/component/database_observability/mysql/collector/connection_info_test.go
+++ b/internal/component/database_observability/mysql/collector/connection_info_test.go
@@ -17,28 +17,32 @@ func TestConnectionInfo(t *testing.T) {
 	const baseExpectedMetrics = `
 	# HELP database_observability_connection_info Information about the connection
 	# TYPE database_observability_connection_info gauge
-	database_observability_connection_info{db_instance_identifier="%s",engine="%s",provider_name="%s",provider_region="%s"} 1
+	database_observability_connection_info{db_instance_identifier="%s",db_version="%s",engine="%s",provider_name="%s",provider_region="%s"} 1
 `
 
 	testCases := []struct {
 		name            string
 		dsn             string
+		dbVersion       string
 		expectedMetrics string
 	}{
 		{
 			name:            "generic dsn",
 			dsn:             "user:pass@tcp(localhost:3306)/schema",
-			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "unknown", "mysql", "unknown", "unknown"),
+			dbVersion:       "8.0.32",
+			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "unknown", "8.0.32", "mysql", "unknown", "unknown"),
 		},
 		{
 			name:            "AWS/RDS dsn",
 			dsn:             "user:pass@tcp(products-db.abc123xyz.us-east-1.rds.amazonaws.com:3306)/schema",
-			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "products-db", "mysql", "aws", "us-east-1"),
+			dbVersion:       "8.0.32",
+			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "products-db", "8.0.32", "mysql", "aws", "us-east-1"),
 		},
 		{
 			name:            "Azure flexibleservers dsn",
 			dsn:             "user:pass@tcp(products-db.mysql.database.azure.com:3306)/schema",
-			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "products-db", "mysql", "azure", "unknown"),
+			dbVersion:       "8.0.32",
+			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "products-db", "8.0.32", "mysql", "azure", "unknown"),
 		},
 	}
 
@@ -46,8 +50,9 @@ func TestConnectionInfo(t *testing.T) {
 		reg := prometheus.NewRegistry()
 
 		collector, err := NewConnectionInfo(ConnectionInfoArguments{
-			DSN:      tc.dsn,
-			Registry: reg,
+			DSN:       tc.dsn,
+			Registry:  reg,
+			DBVersion: tc.dbVersion,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)

--- a/internal/component/database_observability/mysql/collector/explain_plan.go
+++ b/internal/component/database_observability/mysql/collector/explain_plan.go
@@ -45,8 +45,6 @@ const selectDigestsForExplainPlan = `
 
 const selectExplainPlanPrefix = `EXPLAIN FORMAT=JSON `
 
-const selectDBSchemaVersion = `SELECT VERSION()`
-
 type explainPlanOutputOperation string
 
 const (
@@ -462,6 +460,7 @@ type ExplainPlanArguments struct {
 	PerScrapeRatio  float64
 	EntryHandler    loki.EntryHandler
 	InitialLookback time.Time
+	DBVersion       string
 
 	Logger log.Logger
 }
@@ -484,20 +483,10 @@ type ExplainPlan struct {
 }
 
 func NewExplainPlan(args ExplainPlanArguments) (*ExplainPlan, error) {
-	rs := args.DB.QueryRowContext(context.Background(), selectDBSchemaVersion)
-	if rs.Err() != nil {
-		return nil, rs.Err()
-	}
-
-	var dbVersion string
-	if err := rs.Scan(&dbVersion); err != nil {
-		return nil, err
-	}
-
 	return &ExplainPlan{
 		dbConnection:   args.DB,
 		instanceKey:    args.InstanceKey,
-		dbVersion:      dbVersion,
+		dbVersion:      args.DBVersion,
 		scrapeInterval: args.ScrapeInterval,
 		queryCache:     make([]queryInfo, 0),
 		perScrapeRatio: args.PerScrapeRatio,

--- a/internal/component/database_observability/mysql/collector/explain_plan_test.go
+++ b/internal/component/database_observability/mysql/collector/explain_plan_test.go
@@ -1486,12 +1486,6 @@ func TestExplainPlan(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		mock.ExpectQuery(selectDBSchemaVersion).WithoutArgs().WillReturnRows(sqlmock.NewRows([]string{
-			"version",
-		}).AddRow(
-			"8.0.32",
-		))
-
 		lastSeen := time.Now().Add(-time.Hour)
 		lokiClient := loki_fake.NewClient(func() {})
 		defer lokiClient.Stop()
@@ -1503,6 +1497,7 @@ func TestExplainPlan(t *testing.T) {
 			ScrapeInterval:  time.Second,
 			PerScrapeRatio:  1,
 			EntryHandler:    lokiClient,
+			DBVersion:       "8.0.32",
 			InitialLookback: lastSeen,
 		})
 		require.NoError(t, err)
@@ -1558,12 +1553,6 @@ func TestExplainPlan(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		mock.ExpectQuery(selectDBSchemaVersion).WithoutArgs().WillReturnRows(sqlmock.NewRows([]string{
-			"version",
-		}).AddRow(
-			"8.0.32",
-		))
-
 		lastSeen := time.Now().Add(-time.Hour)
 		lokiClient := loki_fake.NewClient(func() {})
 		defer lokiClient.Stop()
@@ -1577,6 +1566,7 @@ func TestExplainPlan(t *testing.T) {
 			ScrapeInterval:  time.Second,
 			PerScrapeRatio:  1,
 			EntryHandler:    lokiClient,
+			DBVersion:       "8.0.32",
 			InitialLookback: lastSeen,
 		})
 		require.NoError(t, err)

--- a/internal/component/database_observability/mysql/component.go
+++ b/internal/component/database_observability/mysql/component.go
@@ -31,7 +31,7 @@ import (
 
 const name = "database_observability.mysql"
 
-const selectDBSchemaVersion = `SELECT VERSION()`
+const selectEngineVersion = `SELECT VERSION()`
 
 func init() {
 	component.Register(component.Registration{
@@ -281,16 +281,16 @@ func (c *Component) startCollectors() error {
 	}
 	c.dbConnection = dbConnection
 
-	rs := c.dbConnection.QueryRowContext(context.Background(), selectDBSchemaVersion)
+	rs := c.dbConnection.QueryRowContext(context.Background(), selectEngineVersion)
 	err = rs.Err()
 	if err != nil {
-		level.Error(c.opts.Logger).Log("msg", "failed to query DB version", "err", err)
+		level.Error(c.opts.Logger).Log("msg", "failed to query engine version", "err", err)
 		return err
 	}
 
-	var dbVersion string
-	if err := rs.Scan(&dbVersion); err != nil {
-		level.Error(c.opts.Logger).Log("msg", "failed to scan DB version", "err", err)
+	var engineVersion string
+	if err := rs.Scan(&engineVersion); err != nil {
+		level.Error(c.opts.Logger).Log("msg", "failed to scan engine version", "err", err)
 		return err
 	}
 
@@ -408,7 +408,7 @@ func (c *Component) startCollectors() error {
 			ScrapeInterval:  c.args.ExplainPlanCollectInterval,
 			PerScrapeRatio:  c.args.ExplainPlanPerCollectRatio,
 			Logger:          c.opts.Logger,
-			DBVersion:       dbVersion,
+			DBVersion:       engineVersion,
 			EntryHandler:    entryHandler,
 			InitialLookback: time.Now().Add(-c.args.ExplainPlanInitialLookback),
 		})
@@ -425,9 +425,9 @@ func (c *Component) startCollectors() error {
 
 	// Connection Info collector is always enabled
 	ciCollector, err := collector.NewConnectionInfo(collector.ConnectionInfoArguments{
-		DSN:       string(c.args.DataSourceName),
-		Registry:  c.registry,
-		DBVersion: dbVersion,
+		DSN:           string(c.args.DataSourceName),
+		Registry:      c.registry,
+		EngineVersion: engineVersion,
 	})
 	if err != nil {
 		level.Error(c.opts.Logger).Log("msg", "failed to create ConnectionInfo collector", "err", err)


### PR DESCRIPTION
#### PR Description
Adds the MySQL engine version to the labelset for the connection_info collector.