### PR TITLE
Fix metadata propagation from scrape to otel components

### DIFF
--- a/internal/component/otelcol/exporter/prometheus/prometheus.go
+++ b/internal/component/otelcol/exporter/prometheus/prometheus.go
@@ -87,7 +87,7 @@ func New(o component.Options, c Arguments) (*Component, error) {
 		return nil, err
 	}
 	ls := service.(labelstore.LabelStore)
-	fanout := prometheus.NewFanout(nil, o.ID, o.Registerer, ls)
+	fanout := prometheus.NewFanout(nil, o.ID, o.Registerer, ls, prometheus.NoopMetadataStore{})
 
 	converter := convert.New(o.Logger, fanout, convertArgumentsToConvertOptions(c))
 

--- a/internal/component/otelcol/receiver/prometheus/internal/transaction.go
+++ b/internal/component/otelcol/receiver/prometheus/internal/transaction.go
@@ -542,8 +542,9 @@ func (t *transaction) Rollback() error {
 	return nil
 }
 
-func (t *transaction) UpdateMetadata(_ storage.SeriesRef, _ labels.Labels, _ metadata.Metadata) (storage.SeriesRef, error) {
-	// TODO: implement this func
+func (t *transaction) UpdateMetadata(_ storage.SeriesRef, lbls labels.Labels, m metadata.Metadata) (storage.SeriesRef, error) {
+	// There's no need to implement this.
+	// The metadata will be retrieved from the context.
 	return 0, nil
 }
 

--- a/internal/component/otelcol/receiver/prometheus/prometheus_test.go
+++ b/internal/component/otelcol/receiver/prometheus/prometheus_test.go
@@ -2,9 +2,11 @@ package prometheus_test
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
+	alloyprometheus "github.com/grafana/alloy/internal/component/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/exemplar"
@@ -19,16 +21,33 @@ import (
 	"github.com/grafana/alloy/internal/component/otelcol"
 	"github.com/grafana/alloy/internal/component/otelcol/internal/fakeconsumer"
 	"github.com/grafana/alloy/internal/component/otelcol/receiver/prometheus"
-	alloyprometheus "github.com/grafana/alloy/internal/component/prometheus"
 	"github.com/grafana/alloy/internal/runtime/componenttest"
 	"github.com/grafana/alloy/internal/util"
 	"github.com/grafana/alloy/syntax"
 )
 
-// Test performs a basic integration test which runs the
+// testMetadataStore implements scrape.MetricMetadataStore for testing
+type testMetadataStore map[string]scrape.MetricMetadata
+
+func (tmc testMetadataStore) GetMetadata(familyName string) (scrape.MetricMetadata, bool) {
+	lookup, ok := tmc[familyName]
+	return lookup, ok
+}
+
+func (tmc testMetadataStore) ListMetadata() []scrape.MetricMetadata { return nil }
+
+func (tmc testMetadataStore) SizeMetadata() int { return 0 }
+
+func (tmc testMetadataStore) LengthMetadata() int {
+	return len(tmc)
+}
+
+// TestComprehensive performs a comprehensive integration test which runs the
 // otelcol.receiver.prometheus component and ensures that it can receive and
-// forward metric data.
-func Test(t *testing.T) {
+// forward different types of metrics: native histograms, classic histograms,
+// gauges, and sum/counter metrics, verifying each gets converted to the
+// appropriate OTLP metric type.
+func TestComprehensive(t *testing.T) {
 	ctx := componenttest.TestContext(t)
 	l := util.TestLogger(t)
 
@@ -57,20 +76,9 @@ func Test(t *testing.T) {
 
 	exports := ctrl.Exports().(prometheus.Exports)
 
-	// Use the exported Appendable to send metrics to the receiver in the
-	// background.
+	// Use the exported Appendable to send different types of metrics to the receiver.
 	go func() {
-		l := labels.Labels{
-			{Name: model.MetricNameLabel, Value: "testMetric"},
-			{Name: model.JobLabel, Value: "testJob"},
-			{Name: model.InstanceLabel, Value: "otelcol.receiver.prometheus"},
-			{Name: "foo", Value: "bar"},
-			{Name: model.MetricNameLabel, Value: "otel_scope_info"},
-			{Name: "otel_scope_name", Value: "go.opentelemetry.io.contrib.instrumentation.net.http.otelhttp"},
-			{Name: "otel_scope_version", Value: "v0.24.0"},
-		}
 		ts := time.Now().Unix()
-		v := 100.
 
 		exemplarLabels := labels.Labels{
 			{Name: model.MetricNameLabel, Value: "testMetric"},
@@ -85,7 +93,28 @@ func Test(t *testing.T) {
 		}
 
 		ctx := t.Context()
-		ctx = scrape.ContextWithMetricMetadataStore(ctx, alloyprometheus.NoopMetadataStore{})
+		ctx = scrape.ContextWithMetricMetadataStore(ctx, testMetadataStore{
+			"testGauge": scrape.MetricMetadata{
+				MetricFamily: "testGauge",
+				Type:         model.MetricTypeGauge,
+				Help:         "A test gauge metric",
+			},
+			"testCounter": scrape.MetricMetadata{
+				MetricFamily: "testCounter",
+				Type:         model.MetricTypeCounter,
+				Help:         "A test counter metric",
+			},
+			"testClassicHistogram": scrape.MetricMetadata{
+				MetricFamily: "testClassicHistogram",
+				Type:         model.MetricTypeHistogram,
+				Help:         "A test classic histogram metric",
+			},
+			"testNativeHistogram": scrape.MetricMetadata{
+				MetricFamily: "testNativeHistogram",
+				Type:         model.MetricTypeHistogram,
+				Help:         "A test native histogram metric",
+			},
+		})
 		ctx = scrape.ContextWithTarget(ctx, scrape.NewTarget(
 			labels.EmptyLabels(),
 			&config.DefaultScrapeConfig,
@@ -93,28 +122,146 @@ func Test(t *testing.T) {
 			model.LabelSet{},
 		))
 		app := exports.Receiver.Appender(ctx)
-		_, err := app.Append(0, l, ts, v)
+
+		// 1. Send a gauge metric
+		gaugeLabels := labels.Labels{
+			{Name: model.MetricNameLabel, Value: "testGauge"},
+			{Name: model.JobLabel, Value: "testJob"},
+			{Name: model.InstanceLabel, Value: "otelcol.receiver.prometheus"},
+			{Name: "foo", Value: "bar"},
+		}
+		_, err := app.Append(0, gaugeLabels, ts, 100.0)
 		require.NoError(t, err)
-		_, err = app.AppendExemplar(0, l, exemplar)
+		_, err = app.AppendExemplar(0, gaugeLabels, exemplar)
 		require.NoError(t, err)
+
+		// 2. Send a counter/sum metric (using _total suffix to indicate it's a counter)
+		counterLabels := labels.Labels{
+			{Name: model.MetricNameLabel, Value: "testCounter_total"},
+			{Name: model.JobLabel, Value: "testJob"},
+			{Name: model.InstanceLabel, Value: "otelcol.receiver.prometheus"},
+			{Name: "service", Value: "api"},
+		}
+		_, err = app.Append(0, counterLabels, ts, 42.0)
+		require.NoError(t, err)
+
+		// 3. Send a classic/traditional histogram (bucket, count, sum)
+		histogramName := "testClassicHistogram"
+
+		// Histogram buckets
+		buckets := []float64{0.1, 0.5, 1.0, 5.0, 10.0}
+		counts := []float64{1, 3, 5, 8, 10} // cumulative counts
+
+		for i, bucket := range buckets {
+			bucketLabels := labels.Labels{
+				{Name: model.MetricNameLabel, Value: histogramName + "_bucket"},
+				{Name: model.JobLabel, Value: "testJob"},
+				{Name: model.InstanceLabel, Value: "otelcol.receiver.prometheus"},
+				{Name: "le", Value: strconv.FormatFloat(bucket, 'f', -1, 64)},
+				{Name: "method", Value: "GET"},
+			}
+			_, err = app.Append(0, bucketLabels, ts, counts[i])
+			require.NoError(t, err)
+		}
+
+		// Histogram +Inf bucket
+		infBucketLabels := labels.Labels{
+			{Name: model.MetricNameLabel, Value: histogramName + "_bucket"},
+			{Name: model.JobLabel, Value: "testJob"},
+			{Name: model.InstanceLabel, Value: "otelcol.receiver.prometheus"},
+			{Name: "le", Value: "+Inf"},
+			{Name: "method", Value: "GET"},
+		}
+		_, err = app.Append(0, infBucketLabels, ts, 10.0)
+		require.NoError(t, err)
+
+		// Histogram count
+		countLabels := labels.Labels{
+			{Name: model.MetricNameLabel, Value: histogramName + "_count"},
+			{Name: model.JobLabel, Value: "testJob"},
+			{Name: model.InstanceLabel, Value: "otelcol.receiver.prometheus"},
+			{Name: "method", Value: "GET"},
+		}
+		_, err = app.Append(0, countLabels, ts, 10.0)
+		require.NoError(t, err)
+
+		// Histogram sum
+		sumLabels := labels.Labels{
+			{Name: model.MetricNameLabel, Value: histogramName + "_sum"},
+			{Name: model.JobLabel, Value: "testJob"},
+			{Name: model.InstanceLabel, Value: "otelcol.receiver.prometheus"},
+			{Name: "method", Value: "GET"},
+		}
+		_, err = app.Append(0, sumLabels, ts, 23.5)
+		require.NoError(t, err)
+
+		// 4. Send a native exponential histogram
+		nativeHistLabels := labels.Labels{
+			{Name: model.MetricNameLabel, Value: "testNativeHistogram"},
+			{Name: model.JobLabel, Value: "testJob"},
+			{Name: model.InstanceLabel, Value: "otelcol.receiver.prometheus"},
+			{Name: "endpoint", Value: "/api/v1"},
+		}
+		h := tsdbutil.GenerateTestHistogram(42)
+		_, err = app.AppendHistogram(0, nativeHistLabels, ts, h, nil)
+		require.NoError(t, err)
+
 		require.NoError(t, app.Commit())
 	}()
 
-	// Wait for our client to get the metric.
+	// Wait for our client to get the metrics.
 	select {
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		require.FailNow(t, "failed waiting for metrics")
 	case m := <-metricCh:
-		require.Equal(t, 1, m.MetricCount())
-		require.Equal(t, "testMetric", m.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Name())
-		require.Equal(t, "go.opentelemetry.io.contrib.instrumentation.net.http.otelhttp", m.ResourceMetrics().At(0).ScopeMetrics().At(0).Scope().Name())
-		require.Equal(t, "v0.24.0", m.ResourceMetrics().At(0).ScopeMetrics().At(0).Scope().Version())
-		require.Equal(t, "Gauge", m.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Type().String())
-		require.Equal(t, 1, m.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Gauge().DataPoints().Len())
-		require.Equal(t, 1, m.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Gauge().DataPoints().At(0).Exemplars().Len())
-		require.Equal(t, "123456789abcdef0123456789abcdef0", m.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Gauge().DataPoints().At(0).Exemplars().At(0).TraceID().String())
-		require.Equal(t, "123456789abcdef0", m.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Gauge().DataPoints().At(0).Exemplars().At(0).SpanID().String())
-		require.Equal(t, 2.0, m.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Gauge().DataPoints().At(0).Exemplars().At(0).DoubleValue())
+		// Should have 4 metrics: gauge, counter, classic histogram, native histogram
+		require.Equal(t, 4, m.MetricCount())
+
+		metrics := make(map[string]pmetric.Metric)
+		for i := 0; i < m.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len(); i++ {
+			metric := m.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(i)
+			metrics[metric.Name()] = metric
+		}
+
+		// 1. Verify gauge metric
+		gaugeMetric, exists := metrics["testGauge"]
+		require.True(t, exists, "testGauge metric should exist")
+		require.Equal(t, pmetric.MetricTypeGauge, gaugeMetric.Type())
+		require.Equal(t, "Gauge", gaugeMetric.Type().String())
+		require.Equal(t, 1, gaugeMetric.Gauge().DataPoints().Len())
+		require.Equal(t, 100.0, gaugeMetric.Gauge().DataPoints().At(0).DoubleValue())
+		require.Equal(t, 1, gaugeMetric.Gauge().DataPoints().At(0).Exemplars().Len())
+		require.Equal(t, "A test gauge metric", gaugeMetric.Description())
+
+		// 2. Verify counter/sum metric
+		counterMetric, exists := metrics["testCounter_total"]
+		require.True(t, exists, "testCounter_total metric should exist")
+		require.Equal(t, pmetric.MetricTypeSum, counterMetric.Type()) // NoopMetadataStore makes it gauge
+		require.Equal(t, "Sum", counterMetric.Type().String())
+		require.Equal(t, 1, counterMetric.Sum().DataPoints().Len())
+		require.Equal(t, 42.0, counterMetric.Sum().DataPoints().At(0).DoubleValue())
+		require.Equal(t, "A test counter metric", counterMetric.Description())
+
+		// 3. Verify classic histogram
+		classicHistMetric, exists := metrics["testClassicHistogram"]
+		require.True(t, exists, "testClassicHistogram metric should exist")
+		require.Equal(t, pmetric.MetricTypeHistogram, classicHistMetric.Type()) // NoopMetadataStore makes it gauge
+		require.Equal(t, "Histogram", classicHistMetric.Type().String())
+		require.Equal(t, 1, classicHistMetric.Histogram().DataPoints().Len())
+		require.Equal(t, "A test classic histogram metric", classicHistMetric.Description())
+
+		// 4. Verify native exponential histogram
+		nativeHistMetric, exists := metrics["testNativeHistogram"]
+		require.True(t, exists, "testNativeHistogram metric should exist")
+		require.Equal(t, pmetric.MetricTypeExponentialHistogram, nativeHistMetric.Type())
+		require.Equal(t, "ExponentialHistogram", nativeHistMetric.Type().String())
+		require.Equal(t, 1, nativeHistMetric.ExponentialHistogram().DataPoints().Len())
+		require.Equal(t, "A test native histogram metric", nativeHistMetric.Description())
+
+		expHistDP := nativeHistMetric.ExponentialHistogram().DataPoints().At(0)
+		require.Greater(t, expHistDP.Count(), uint64(0))
+		require.True(t, expHistDP.HasSum())
+		require.NotEqual(t, int32(0), expHistDP.Scale()) // Should have a valid scale
 	}
 }
 

--- a/internal/component/prometheus/fanout.go
+++ b/internal/component/prometheus/fanout.go
@@ -32,6 +32,7 @@ type Fanout struct {
 	writeLatency   prometheus.Histogram
 	samplesCounter prometheus.Counter
 	ls             labelstore.LabelStore
+	metadataStore  UpdateableMetadataStore
 
 	// lastSeriesCount stores the number of series that were sent through the last appender. It helps to estimate how
 	// much memory to allocate for the staleness trackers.
@@ -39,7 +40,7 @@ type Fanout struct {
 }
 
 // NewFanout creates a fanout appendable.
-func NewFanout(children []storage.Appendable, componentID string, register prometheus.Registerer, ls labelstore.LabelStore) *Fanout {
+func NewFanout(children []storage.Appendable, componentID string, register prometheus.Registerer, ls labelstore.LabelStore, ms UpdateableMetadataStore) *Fanout {
 	wl := prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name:    "prometheus_fanout_latency",
 		Help:    "Write latency for sending to direct and indirect components",
@@ -59,6 +60,7 @@ func NewFanout(children []storage.Appendable, componentID string, register prome
 		writeLatency:   wl,
 		samplesCounter: s,
 		ls:             ls,
+		metadataStore:  ms,
 	}
 }
 
@@ -79,13 +81,16 @@ func (f *Fanout) Appender(ctx context.Context) storage.Appender {
 	// contain both a scrape target and a metadata store, and fails the
 	// conversion if they are missing. We should find a way around this as both
 	// Targets and Metadata will be handled in a different way in Alloy.
+	// TODO(@ptodev): What exactly fails if we don't include the target in the context?
+	// Can we instead use the more recent translator package:
+	// https://github.com/prometheus/otlptranslator
 	ctx = scrape.ContextWithTarget(ctx, scrape.NewTarget(
 		labels.EmptyLabels(),
 		&config.DefaultScrapeConfig,
 		model.LabelSet{},
 		model.LabelSet{},
 	))
-	ctx = scrape.ContextWithMetricMetadataStore(ctx, NoopMetadataStore{})
+	ctx = scrape.ContextWithMetricMetadataStore(ctx, f.metadataStore)
 
 	app := &appender{
 		children:          make([]storage.Appender, 0),
@@ -210,6 +215,13 @@ func (a *appender) UpdateMetadata(ref storage.SeriesRef, l labels.Labels, m meta
 	if ref == 0 {
 		ref = storage.SeriesRef(a.fanout.ls.GetOrAddGlobalRefID(l))
 	}
+
+	// Store metadata in our local store
+	familyName := l.Get(model.MetricNameLabel)
+	if familyName != "" {
+		a.fanout.metadataStore.UpdateMetadata(familyName, m)
+	}
+
 	var multiErr error
 	for _, x := range a.children {
 		_, err := x.UpdateMetadata(ref, l, m)
@@ -270,20 +282,3 @@ func (a *appender) AppendHistogramCTZeroSample(ref storage.SeriesRef, l labels.L
 	}
 	return ref, multiErr
 }
-
-// NoopMetadataStore implements the MetricMetadataStore interface.
-type NoopMetadataStore map[string]scrape.MetricMetadata
-
-// GetMetadata implements the MetricMetadataStore interface.
-func (ms NoopMetadataStore) GetMetadata(_ string) (scrape.MetricMetadata, bool) {
-	return scrape.MetricMetadata{}, false
-}
-
-// ListMetadata implements the MetricMetadataStore interface.
-func (ms NoopMetadataStore) ListMetadata() []scrape.MetricMetadata { return nil }
-
-// SizeMetadata implements the MetricMetadataStore interface.
-func (ms NoopMetadataStore) SizeMetadata() int { return 0 }
-
-// LengthMetadata implements the MetricMetadataStore interface.
-func (ms NoopMetadataStore) LengthMetadata() int { return 0 }

--- a/internal/component/prometheus/fanout_test.go
+++ b/internal/component/prometheus/fanout_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestRollback(t *testing.T) {
 	ls := labelstore.New(nil, prometheus.DefaultRegisterer)
-	fanout := NewFanout([]storage.Appendable{NewFanout(nil, "1", prometheus.DefaultRegisterer, ls)}, "", prometheus.DefaultRegisterer, ls)
+	fanout := NewFanout([]storage.Appendable{NewFanout(nil, "1", prometheus.DefaultRegisterer, ls, NoopMetadataStore{})}, "", prometheus.DefaultRegisterer, ls, NoopMetadataStore{})
 	app := fanout.Appender(t.Context())
 	err := app.Rollback()
 	require.NoError(t, err)
@@ -21,7 +21,7 @@ func TestRollback(t *testing.T) {
 
 func TestCommit(t *testing.T) {
 	ls := labelstore.New(nil, prometheus.DefaultRegisterer)
-	fanout := NewFanout([]storage.Appendable{NewFanout(nil, "1", prometheus.DefaultRegisterer, ls)}, "", prometheus.DefaultRegisterer, ls)
+	fanout := NewFanout([]storage.Appendable{NewFanout(nil, "1", prometheus.DefaultRegisterer, ls, NoopMetadataStore{})}, "", prometheus.DefaultRegisterer, ls, NoopMetadataStore{})
 	app := fanout.Appender(t.Context())
 	err := app.Commit()
 	require.NoError(t, err)

--- a/internal/component/prometheus/metadatastore.go
+++ b/internal/component/prometheus/metadatastore.go
@@ -1,0 +1,90 @@
+package prometheus
+
+import (
+	"sync"
+
+	"github.com/prometheus/prometheus/model/metadata"
+	"github.com/prometheus/prometheus/scrape"
+)
+
+// UpdateableMetadataStore is a MetricMetadataStore that can be updated.
+type UpdateableMetadataStore interface {
+	scrape.MetricMetadataStore
+	UpdateMetadata(familyName string, md metadata.Metadata)
+}
+
+// MetadataStore implements UpdateableMetadataStore and stores metadata from UpdateMetadata calls.
+type MetadataStore struct {
+	mut      sync.RWMutex
+	metadata map[string]scrape.MetricMetadata
+}
+
+// NewMetadataStore creates a new MetadataStore.
+func NewMetadataStore() *MetadataStore {
+	return &MetadataStore{
+		metadata: make(map[string]scrape.MetricMetadata),
+	}
+}
+
+// GetMetadata implements the MetricMetadataStore interface.
+func (ms *MetadataStore) GetMetadata(familyName string) (scrape.MetricMetadata, bool) {
+	ms.mut.RLock()
+	defer ms.mut.RUnlock()
+	metadata, ok := ms.metadata[familyName]
+	return metadata, ok
+}
+
+// ListMetadata implements the MetricMetadataStore interface.
+func (ms *MetadataStore) ListMetadata() []scrape.MetricMetadata {
+	ms.mut.RLock()
+	defer ms.mut.RUnlock()
+	result := make([]scrape.MetricMetadata, 0, len(ms.metadata))
+	for _, md := range ms.metadata {
+		result = append(result, md)
+	}
+	return result
+}
+
+// SizeMetadata implements the MetricMetadataStore interface.
+func (ms *MetadataStore) SizeMetadata() (s int) {
+	ms.mut.RLock()
+	defer ms.mut.RUnlock()
+	for _, m := range ms.metadata {
+		s += len(m.Help) + len(m.Unit) + len(m.Type)
+	}
+	return s
+}
+
+// LengthMetadata implements the MetricMetadataStore interface.
+func (ms *MetadataStore) LengthMetadata() int {
+	ms.mut.RLock()
+	defer ms.mut.RUnlock()
+	return len(ms.metadata)
+}
+
+// UpdateMetadata stores metadata for a metric family.
+func (ms *MetadataStore) UpdateMetadata(familyName string, md metadata.Metadata) {
+	ms.mut.Lock()
+	defer ms.mut.Unlock()
+	ms.metadata[familyName] = scrape.MetricMetadata{
+		MetricFamily: familyName,
+		Type:         md.Type,
+		Unit:         md.Unit,
+		Help:         md.Help,
+	}
+}
+
+// NoopMetadataStore implements the MetricMetadataStore interface.
+type NoopMetadataStore map[string]scrape.MetricMetadata
+
+func (ms NoopMetadataStore) GetMetadata(_ string) (scrape.MetricMetadata, bool) {
+	return scrape.MetricMetadata{}, false
+}
+
+func (ms NoopMetadataStore) ListMetadata() []scrape.MetricMetadata { return nil }
+
+func (ms NoopMetadataStore) SizeMetadata() int { return 0 }
+
+func (ms NoopMetadataStore) LengthMetadata() int { return 0 }
+
+func (ms NoopMetadataStore) UpdateMetadata(familyName string, md metadata.Metadata) {}

--- a/internal/component/prometheus/operator/common/crdmanager.go
+++ b/internal/component/prometheus/operator/common/crdmanager.go
@@ -145,7 +145,7 @@ func (c *crdManager) Run(ctx context.Context) error {
 	}()
 
 	// Start prometheus scrape manager.
-	alloyAppendable := prometheus.NewFanout(c.args.ForwardTo, c.opts.ID, c.opts.Registerer, c.ls)
+	alloyAppendable := prometheus.NewFanout(c.args.ForwardTo, c.opts.ID, c.opts.Registerer, c.ls, prometheus.NoopMetadataStore{})
 	opts := &scrape.Options{}
 	c.scrapeManager, err = scrape.NewManager(opts, slog.New(logging.NewSlogGoKitHandler(c.logger)), nil, alloyAppendable, unregisterer)
 	if err != nil {

--- a/internal/component/prometheus/receive_http/receive_http.go
+++ b/internal/component/prometheus/receive_http/receive_http.go
@@ -65,7 +65,7 @@ func New(opts component.Options, args Arguments) (*Component, error) {
 		return nil, err
 	}
 	ls := service.(labelstore.LabelStore)
-	fanout := alloyprom.NewFanout(args.ForwardTo, opts.ID, opts.Registerer, ls)
+	fanout := alloyprom.NewFanout(args.ForwardTo, opts.ID, opts.Registerer, ls, alloyprom.NoopMetadataStore{})
 
 	uncheckedCollector := util.NewUncheckedCollector(nil)
 	opts.Registerer.MustRegister(uncheckedCollector)

--- a/internal/component/prometheus/relabel/relabel.go
+++ b/internal/component/prometheus/relabel/relabel.go
@@ -153,7 +153,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		}
 	}
 
-	c.fanout = prometheus.NewFanout(args.ForwardTo, o.ID, o.Registerer, c.ls)
+	c.fanout = prometheus.NewFanout(args.ForwardTo, o.ID, o.Registerer, c.ls, prometheus.NoopMetadataStore{})
 	c.receiver = prometheus.NewInterceptor(
 		c.fanout,
 		c.ls,

--- a/internal/component/prometheus/scrape/scrape.go
+++ b/internal/component/prometheus/scrape/scrape.go
@@ -138,6 +138,8 @@ type Arguments struct {
 	// If the growth factor of one bucket to the next is smaller than this,
 	// buckets will be merged to stay within the limit. Disabled when set zero.
 	NativeHistogramMinBucketFactor float64 `alloy:"native_histogram_min_bucket_factor,attr,optional"`
+	// Whether the metric metadata should be passed to the downstream components.
+	HonorMetadata bool `alloy:"honor_metadata,attr,optional"`
 
 	Clustering cluster.ComponentBlock `alloy:"clustering,block,optional"`
 }
@@ -288,13 +290,22 @@ func New(o component.Options, args Arguments) (*Component, error) {
 	}
 	ls := service.(labelstore.LabelStore)
 
-	alloyAppendable := prometheus.NewFanout(args.ForwardTo, o.ID, o.Registerer, ls)
+	var metadataStore prometheus.UpdateableMetadataStore
+	if args.HonorMetadata {
+		metadataStore = prometheus.NewMetadataStore()
+	} else {
+		metadataStore = prometheus.NoopMetadataStore{}
+	}
+
+	alloyAppendable := prometheus.NewFanout(args.ForwardTo, o.ID, o.Registerer, ls, metadataStore)
 	scrapeOptions := &scrape.Options{
 		ExtraMetrics: args.ExtraMetrics,
 		HTTPClientOptions: []config_util.HTTPClientOption{
 			config_util.WithDialContextFunc(httpData.DialFunc),
 		},
 		EnableNativeHistogramsIngestion: args.ScrapeNativeHistograms,
+		// TODO: Check if this has performance implications.
+		AppendMetadata: args.HonorMetadata,
 	}
 
 	unregisterer := util.WrapWithUnregisterer(o.Registerer)

--- a/internal/component/prometheus/scrape/scrape_test.go
+++ b/internal/component/prometheus/scrape/scrape_test.go
@@ -5,25 +5,34 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/grafana/ckit/memconn"
 	prometheus_client "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/exemplar"
+	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
+	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alloy/internal/component"
 	component_config "github.com/grafana/alloy/internal/component/common/config"
+	"github.com/grafana/alloy/internal/component/discovery"
 	"github.com/grafana/alloy/internal/component/prometheus"
 	"github.com/grafana/alloy/internal/service/cluster"
 	http_service "github.com/grafana/alloy/internal/service/http"
 	"github.com/grafana/alloy/internal/service/labelstore"
 	"github.com/grafana/alloy/internal/service/livedebugging"
 	"github.com/grafana/alloy/internal/util"
+	"github.com/grafana/alloy/internal/util/testappender"
 	"github.com/grafana/alloy/syntax"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAlloyConfig(t *testing.T) {
@@ -124,6 +133,57 @@ func TestBadAlloyConfig(t *testing.T) {
 	require.ErrorContains(t, err, "at most one of basic_auth, authorization, oauth2, bearer_token & bearer_token_file must be configured")
 }
 
+// contextCapturingAppendable is a test helper that captures the context when Appender is called
+type contextCapturingAppendable struct {
+	capturedCtx context.Context
+	next        storage.Appendable
+}
+
+func (c *contextCapturingAppendable) Appender(ctx context.Context) storage.Appender {
+	c.capturedCtx = ctx
+	if c.next != nil {
+		return c.next.Appender(ctx)
+	}
+	return &noopAppender{}
+}
+
+// noopAppender is a minimal appender implementation for testing
+type noopAppender struct{}
+
+func (n *noopAppender) AppendHistogramCTZeroSample(ref storage.SeriesRef, l labels.Labels, t int64, ct int64, h *histogram.Histogram, fh *histogram.FloatHistogram) (storage.SeriesRef, error) {
+	return ref, nil
+}
+
+func (n *noopAppender) SetOptions(opts *storage.AppendOptions) {}
+
+func (n *noopAppender) Append(ref storage.SeriesRef, l labels.Labels, t int64, v float64) (storage.SeriesRef, error) {
+	return ref, nil
+}
+
+func (n *noopAppender) Commit() error {
+	return nil
+}
+
+func (n *noopAppender) Rollback() error {
+	return nil
+}
+
+func (n *noopAppender) AppendExemplar(ref storage.SeriesRef, l labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
+	return ref, nil
+}
+
+func (n *noopAppender) UpdateMetadata(ref storage.SeriesRef, l labels.Labels, m metadata.Metadata) (storage.SeriesRef, error) {
+	return ref, nil
+}
+
+func (n *noopAppender) AppendHistogram(ref storage.SeriesRef, l labels.Labels, t int64, h *histogram.Histogram, fh *histogram.FloatHistogram) (storage.SeriesRef, error) {
+	return ref, nil
+}
+
+func (n *noopAppender) AppendCTZeroSample(ref storage.SeriesRef, l labels.Labels, t, ct int64) (storage.SeriesRef, error) {
+	return ref, nil
+}
+
 func TestForwardingToAppendable(t *testing.T) {
 	opts := component.Options{
 		Logger:     util.TestAlloyLogger(t),
@@ -154,6 +214,7 @@ func TestForwardingToAppendable(t *testing.T) {
 
 	var args Arguments
 	args.SetToDefault()
+	args.HonorMetadata = true
 	args.ForwardTo = nilReceivers
 
 	s, err := New(opts, args)
@@ -170,14 +231,27 @@ func TestForwardingToAppendable(t *testing.T) {
 	// Update the component with a mock receiver; it should be passed along to the Appendable.
 	var receivedTs int64
 	var receivedSamples labels.Labels
+	var receivedMetadataLabels labels.Labels
+	var receivedMetadata metadata.Metadata
 	ls := labelstore.New(nil, prometheus_client.DefaultRegisterer)
-	fanout := prometheus.NewInterceptor(nil, ls, prometheus.WithAppendHook(func(ref storage.SeriesRef, l labels.Labels, t int64, _ float64, _ storage.Appender) (storage.SeriesRef, error) {
-		receivedTs = t
-		receivedSamples = l
-		return ref, nil
-	}))
+	fanout := prometheus.NewInterceptor(nil, ls,
+		prometheus.WithAppendHook(func(ref storage.SeriesRef, l labels.Labels, t int64, _ float64, _ storage.Appender) (storage.SeriesRef, error) {
+			receivedTs = t
+			receivedSamples = l
+			return ref, nil
+		}),
+		prometheus.WithMetadataHook(func(ref storage.SeriesRef, l labels.Labels, m metadata.Metadata, _ storage.Appender) (storage.SeriesRef, error) {
+			receivedMetadataLabels = l
+			receivedMetadata = m
+			return ref, nil
+		}),
+	)
+
+	// Add a context-capturing appendable to test metadata store in context
+	contextCapture := &contextCapturingAppendable{next: fanout}
+
 	require.NoError(t, err)
-	args.ForwardTo = []storage.Appendable{fanout}
+	args.ForwardTo = []storage.Appendable{contextCapture}
 	err = s.Update(args)
 	require.NoError(t, err)
 
@@ -188,12 +262,47 @@ func TestForwardingToAppendable(t *testing.T) {
 	_, err = appender.Append(0, sample, timestamp, 42.0)
 	require.NoError(t, err)
 
+	// Forwarding metadata to the mock receiver should succeed.
+	testMetadata := metadata.Metadata{
+		Type: model.MetricTypeCounter,
+		Unit: "bytes",
+		Help: "Test metric for unit testing",
+	}
+	metadataLabels := labels.FromStrings("__name__", "test_metric")
+	_, err = appender.UpdateMetadata(0, metadataLabels, testMetadata)
+	require.NoError(t, err)
+
 	err = appender.Commit()
 	require.NoError(t, err)
 
 	require.Equal(t, receivedTs, timestamp)
 	require.Len(t, receivedSamples, 1)
 	require.Equal(t, receivedSamples, sample)
+
+	// Verify metadata was received correctly
+	require.Equal(t, receivedMetadataLabels, metadataLabels)
+	require.Equal(t, receivedMetadata.Type, model.MetricTypeCounter)
+	require.Equal(t, receivedMetadata.Unit, "bytes")
+	require.Equal(t, receivedMetadata.Help, "Test metric for unit testing")
+
+	// Test that the metadata store in the context has been set appropriately
+	require.NotNil(t, contextCapture.capturedCtx, "Context should have been captured")
+
+	// Extract metadata store from context
+	metadataStore, ok := scrape.MetricMetadataStoreFromContext(contextCapture.capturedCtx)
+	require.True(t, ok, "MetricMetadataStore should be present in context")
+	require.NotNil(t, metadataStore, "MetricMetadataStore should not be nil")
+
+	// Verify the metadata store contains the metadata we sent
+	storedMetadata, found := metadataStore.GetMetadata("test_metric")
+	require.True(t, found, "Metadata for 'test_metric' should be found in the store")
+	require.Equal(t, "test_metric", storedMetadata.MetricFamily)
+	require.Equal(t, model.MetricTypeCounter, storedMetadata.Type)
+	require.Equal(t, "bytes", storedMetadata.Unit)
+	require.Equal(t, "Test metric for unit testing", storedMetadata.Help)
+
+	// Verify that the metadata store is not empty/noop
+	require.Greater(t, metadataStore.LengthMetadata(), 0, "MetadataStore should contain at least one metadata entry")
 }
 
 // TestCustomDialer ensures that prometheus.scrape respects the custom dialer
@@ -539,4 +648,325 @@ func TestAlloyConfigDefaultsAndValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+// setupTestCounter creates and initializes a test counter metric
+func setupTestCounter() prometheus_client.Counter {
+	counter := prometheus_client.NewCounter(prometheus_client.CounterOpts{
+		Name: "test_counter_total",
+		Help: "A test counter metric",
+	})
+	counter.Add(42.5)
+	return counter
+}
+
+// setupTestGauge creates and initializes a test gauge metric
+func setupTestGauge() prometheus_client.Gauge {
+	gauge := prometheus_client.NewGauge(prometheus_client.GaugeOpts{
+		Name: "test_gauge",
+		Help: "A test gauge metric",
+	})
+	gauge.Set(123.45)
+	return gauge
+}
+
+// setupTestHistogram creates and initializes a test classic histogram metric
+func setupTestHistogram() prometheus_client.Histogram {
+	histogram := prometheus_client.NewHistogram(prometheus_client.HistogramOpts{
+		Name:    "test_histogram",
+		Help:    "A test histogram metric",
+		Buckets: []float64{0.1, 0.5, 1.0, 2.5, 5.0, 10.0},
+	})
+	// Add observations to match expected values
+	histogram.Observe(0.3) // Falls in 0.5 bucket
+	histogram.Observe(0.7) // Falls in 1.0 bucket
+	histogram.Observe(1.2) // Falls in 2.5 bucket
+	histogram.Observe(4.5) // Falls in 5.0 bucket
+	return histogram
+}
+
+// setupTestNativeHistogram creates and initializes a test native histogram metric
+func setupTestNativeHistogram() prometheus_client.Histogram {
+	nativeHistogram := prometheus_client.NewHistogram(prometheus_client.HistogramOpts{
+		Name:                            "test_native_histogram",
+		Help:                            "A test native histogram metric",
+		NativeHistogramBucketFactor:     1.1,
+		NativeHistogramMaxBucketNumber:  100,
+		NativeHistogramMinResetDuration: 1 * time.Hour,
+	})
+	// Add observations to match expected values (total sum: 1.5 + 2.8 + 3.5 = 7.8)
+	nativeHistogram.Observe(1.5)
+	nativeHistogram.Observe(2.8)
+	nativeHistogram.Observe(3.5)
+	return nativeHistogram
+}
+
+// setupTestSummary creates and initializes a test summary metric
+func setupTestSummary() prometheus_client.Summary {
+	summary := prometheus_client.NewSummary(prometheus_client.SummaryOpts{
+		Name: "test_summary",
+		Help: "A test summary metric",
+		Objectives: map[float64]float64{
+			0.5:  0.05,
+			0.9:  0.01,
+			0.99: 0.001,
+		},
+	})
+	// Add observations to get expected count and sum (total sum: 0.5 + 0.9 + 1.5 + 0.0 = 2.9)
+	summary.Observe(0.5)
+	summary.Observe(0.9)
+	summary.Observe(1.5)
+	summary.Observe(0.0)
+	return summary
+}
+
+// setupTestMetrics creates a registry with all test metrics
+func setupTestMetrics() *prometheus_client.Registry {
+	reg := prometheus_client.NewRegistry()
+
+	counter := setupTestCounter()
+	gauge := setupTestGauge()
+	histogram := setupTestHistogram()
+	nativeHistogram := setupTestNativeHistogram()
+	summary := setupTestSummary()
+
+	reg.MustRegister(counter, gauge, histogram, nativeHistogram, summary)
+	return reg
+}
+
+func TestScrapingAllMetricTypes(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	expectedSamples := []struct {
+		name  string
+		value float64
+	}{
+		{name: "test_counter_total", value: 42.5},
+		{name: "test_gauge", value: 123.45},
+		// Histogram samples
+		{name: "test_histogram_count", value: 4.0},
+		{name: "test_histogram_sum", value: 6.7}, // 0.3 + 0.7 + 1.2 + 4.5
+		// Summary samples
+		{name: "test_summary_count", value: 4.0},
+		{name: "test_summary_sum", value: 2.9}, // 0.5 + 0.9 + 1.5 + 0.0
+	}
+
+	expectedMetadata := []struct {
+		name         string
+		expectedType model.MetricType
+		expectedHelp string
+	}{
+		{
+			name:         "test_counter_total",
+			expectedType: model.MetricTypeCounter,
+			expectedHelp: "A test counter metric",
+		},
+		{
+			name:         "test_gauge",
+			expectedType: model.MetricTypeGauge,
+			expectedHelp: "A test gauge metric",
+		},
+		{
+			name:         "test_histogram_bucket",
+			expectedType: model.MetricTypeHistogram,
+			expectedHelp: "A test histogram metric",
+		},
+		{
+			name:         "test_native_histogram",
+			expectedType: model.MetricTypeHistogram,
+			expectedHelp: "A test native histogram metric",
+		},
+		{
+			name:         "test_summary",
+			expectedType: model.MetricTypeSummary,
+			expectedHelp: "A test summary metric",
+		},
+	}
+
+	expectedHistograms := []struct {
+		name          string
+		expectedCount uint64
+		expectedSum   float64
+	}{
+		{
+			name:          "test_native_histogram",
+			expectedCount: 3,
+			expectedSum:   7.8,
+		},
+	}
+
+	// Create a Prometheus registry and metrics for protobuf format
+	reg := setupTestMetrics()
+
+	// Create HTTP server that serves metrics in protobuf format
+	server := &http.Server{
+		Addr: "127.0.0.1:0", // Let the OS choose a free port
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/metrics" {
+				// Create a promhttp handler that prefers protobuf format
+				handler := promhttp.HandlerFor(reg, promhttp.HandlerOpts{
+					EnableOpenMetrics: true,
+				})
+				handler.ServeHTTP(w, r)
+			} else {
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}),
+	}
+
+	listener, err := net.Listen("tcp", server.Addr)
+	require.NoError(t, err)
+	serverAddr := listener.Addr().String()
+
+	go func() {
+		server.Serve(listener)
+	}()
+	defer server.Shutdown(ctx)
+
+	// Wait a moment for server to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Test that the server is working by making a direct request
+	resp, err := http.Get(fmt.Sprintf("http://%s/metrics", serverAddr))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Set up test appender using the testappender utility
+	appender := testappender.NewCollectingAppender()
+
+	// Create appendable wrapper using testappender utility
+	mockAppendable := testappender.ConstantAppendable{Inner: appender}
+
+	// Set up component options
+	opts := component.Options{
+		Logger:     util.TestAlloyLogger(t),
+		Registerer: prometheus_client.NewRegistry(),
+		GetServiceData: func(name string) (interface{}, error) {
+			switch name {
+			case http_service.ServiceName:
+				return http_service.Data{
+					HTTPListenAddr:   "localhost:12345",
+					MemoryListenAddr: "alloy.internal:1245",
+					BaseHTTPPath:     "/",
+					DialFunc:         (&net.Dialer{}).DialContext,
+				}, nil
+			case cluster.ServiceName:
+				return cluster.Mock(), nil
+			case labelstore.ServiceName:
+				return labelstore.New(nil, prometheus_client.DefaultRegisterer), nil
+			case livedebugging.ServiceName:
+				return livedebugging.NewLiveDebugging(), nil
+			default:
+				return nil, fmt.Errorf("service %q does not exist", name)
+			}
+		},
+	}
+
+	// Configure scrape arguments
+	var args Arguments
+	args.SetToDefault()
+	args.HonorMetadata = true
+	args.Targets = []discovery.Target{
+		discovery.NewTargetFromLabelSet(model.LabelSet{"__address__": model.LabelValue(serverAddr)}),
+	}
+	args.ForwardTo = []storage.Appendable{mockAppendable}
+	args.ScrapeInterval = 50 * time.Millisecond // Frequent scraping for test
+	args.ScrapeTimeout = 25 * time.Millisecond
+	args.JobName = "test_job"
+	args.MetricsPath = "/metrics"
+	args.ScrapeNativeHistograms = true // Enable native histogram scraping
+	args.ScrapeProtocols = []string{
+		"PrometheusProto",
+		"OpenMetricsText1.0.0",
+		"OpenMetricsText0.0.1",
+		"PrometheusText0.0.4",
+	}
+
+	// Validate arguments to set default values for validation and escaping schemes
+	require.NoError(t, args.Validate())
+
+	// Create and start the scrape component
+	scrapeComponent, err := New(opts, args)
+	require.NoError(t, err)
+
+	go scrapeComponent.Run(ctx)
+
+	// Wait for scraping to occur and commit data
+	require.EventuallyWithT(t, func(collectT *assert.CollectT) {
+		// Check if appender has collected samples, metadata, and histograms
+		actualSamples := appender.CollectedSamples()
+		actualMetadata := appender.CollectedMetadata()
+		actualHistograms := appender.CollectedHistograms()
+
+		// Verify we have captured samples
+		require.Greater(collectT, len(actualSamples), 0, "Should have captured some samples")
+
+		// Verify we have captured metadata
+		require.Greater(collectT, len(actualMetadata), 0, "Should have captured some metadata")
+
+		// Verify we have captured native histograms (since we enabled native histogram scraping)
+		require.Greater(collectT, len(actualHistograms), 0, "Should have captured some native histograms")
+	}, 10*time.Second, 100*time.Millisecond, "Should have captured samples, metadata, and histograms")
+
+	// Get the collected samples and metadata
+	actualSamples := appender.CollectedSamples()
+	actualMetadata := appender.CollectedMetadata()
+	actualHistograms := appender.CollectedHistograms()
+
+	// First loop: Validate samples
+	for _, expected := range expectedSamples {
+		found := false
+		for _, sample := range actualSamples {
+			if sample.Labels.Get("__name__") == expected.name {
+				require.Equal(t, expected.value, sample.Value, "Value should match for sample %s", expected.name)
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "Should have found expected sample: %s", expected.name)
+	}
+
+	// Second loop: Validate metadata
+	for _, expected := range expectedMetadata {
+		found := false
+		for labelString, meta := range actualMetadata {
+			// Check if this metadata entry is for our expected metric by looking for the metric name in the label string
+			if strings.Contains(labelString, fmt.Sprintf(`__name__="%s"`, expected.name)) {
+				require.Equal(t, expected.expectedType, meta.Type, "Metadata type should match for %s", expected.name)
+				require.Equal(t, expected.expectedHelp, meta.Help, "Metadata help should match for %s", expected.name)
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "Should have found expected metadata: %s", expected.name)
+	}
+
+	// Third loop: Validate histograms
+	for _, expected := range expectedHistograms {
+		found := false
+		for _, histogram := range actualHistograms {
+			if histogram.Labels.Get("__name__") == expected.name {
+				if histogram.Histogram != nil {
+					require.Equal(t, expected.expectedCount, histogram.Histogram.Count, "Histogram count should match for %s", expected.name)
+					require.Equal(t, expected.expectedSum, histogram.Histogram.Sum, "Histogram sum should match for %s", expected.name)
+				} else if histogram.FloatHistogram != nil {
+					require.Equal(t, float64(expected.expectedCount), histogram.FloatHistogram.Count, "Float histogram count should match for %s", expected.name)
+					require.Equal(t, expected.expectedSum, histogram.FloatHistogram.Sum, "Float histogram sum should match for %s", expected.name)
+				}
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "Should have found expected histogram: %s", expected.name)
+	}
+
+	// Verify job label was added correctly
+	for _, sample := range actualSamples {
+		job := sample.Labels.Get("job")
+		require.Equal(t, "test_job", job, "Job label should be added to all metrics")
+	}
+
+	t.Logf("Successfully scraped %d samples with %d metadata entries and %d histograms", len(actualSamples), len(actualMetadata), len(actualHistograms))
 }

--- a/internal/util/testappender/collectingappender.go
+++ b/internal/util/testappender/collectingappender.go
@@ -18,22 +18,35 @@ type MetricSample struct {
 	Labels    labels.Labels
 }
 
+type HistogramSample struct {
+	Timestamp      int64
+	Labels         labels.Labels
+	Histogram      *histogram.Histogram
+	FloatHistogram *histogram.FloatHistogram
+}
+
 // CollectingAppender is an Appender that collects the samples it receives in a map. Useful for testing and verifying
 // the samples that are being written.
 type CollectingAppender interface {
 	storage.Appender
 	CollectedSamples() map[string]*MetricSample
+	CollectedMetadata() map[string]metadata.Metadata
+	CollectedHistograms() map[string]*HistogramSample
 	LatestSampleFor(labels string) *MetricSample
 }
 
 type collectingAppender struct {
 	mut           sync.Mutex
 	latestSamples map[string]*MetricSample
+	metadata      map[string]metadata.Metadata
+	histograms    map[string]*HistogramSample
 }
 
 func NewCollectingAppender() CollectingAppender {
 	return &collectingAppender{
 		latestSamples: map[string]*MetricSample{},
+		metadata:      map[string]metadata.Metadata{},
+		histograms:    map[string]*HistogramSample{},
 	}
 }
 
@@ -42,6 +55,22 @@ func (c *collectingAppender) CollectedSamples() map[string]*MetricSample {
 	defer c.mut.Unlock()
 	cp := map[string]*MetricSample{}
 	maps.Copy(cp, c.latestSamples)
+	return cp
+}
+
+func (c *collectingAppender) CollectedMetadata() map[string]metadata.Metadata {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+	cp := map[string]metadata.Metadata{}
+	maps.Copy(cp, c.metadata)
+	return cp
+}
+
+func (c *collectingAppender) CollectedHistograms() map[string]*HistogramSample {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+	cp := map[string]*HistogramSample{}
+	maps.Copy(cp, c.histograms)
 	return cp
 }
 
@@ -75,11 +104,22 @@ func (c *collectingAppender) AppendExemplar(ref storage.SeriesRef, l labels.Labe
 }
 
 func (c *collectingAppender) AppendHistogram(ref storage.SeriesRef, l labels.Labels, t int64, h *histogram.Histogram, fh *histogram.FloatHistogram) (storage.SeriesRef, error) {
-	panic("not implemented yet")
+	c.mut.Lock()
+	defer c.mut.Unlock()
+	c.histograms[l.String()] = &HistogramSample{
+		Timestamp:      t,
+		Labels:         l,
+		Histogram:      h,
+		FloatHistogram: fh,
+	}
+	return ref, nil
 }
 
 func (c *collectingAppender) UpdateMetadata(ref storage.SeriesRef, l labels.Labels, m metadata.Metadata) (storage.SeriesRef, error) {
-	panic("not implemented yet")
+	c.mut.Lock()
+	defer c.mut.Unlock()
+	c.metadata[l.String()] = m
+	return ref, nil
 }
 
 func (c *collectingAppender) AppendCTZeroSample(ref storage.SeriesRef, l labels.Labels, t, ct int64) (storage.SeriesRef, error) {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Fixes propagation of metric metadata, but only for pipelines which start with a prometheus.scrape and transition into otelcol components. The metrics need to be sent by an otelcol exporter. 

I can see the metadata in live debugging. Before:

<img width="848" height="602" alt="Screenshot 2025-07-31 at 18 26 58" src="https://github.com/user-attachments/assets/5b6239e8-6473-4550-855b-bab8e1aeed91" />


After:

<img width="1128" height="731" alt="Screenshot 2025-07-31 at 18 39 12" src="https://github.com/user-attachments/assets/8ec6636a-5893-4476-b966-f4ab6fc2acb0" />


#### Which issue(s) this PR fixes

Related to [#547](https://github.com/grafana/alloy/issues/547)

#### Notes to the Reviewer

I need to assess the performance impact of this feature before writing the docs and before opening the PR for review.
For now it'd be good to keep it as an experimental opt-in feature until we're sure it's stable and without consuming much more resources.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
