### PR TITLE
 fix: propagate update arguments to windows exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ Main (unreleased)
 
 - Fix issue with `faro.receiver` cors not allowing X-Scope-OrgID and traceparent headers. (@mar4uk)
 
+- Fix issue with `prometheus.exporter.windows` not propagating `update` collector config. (@kalleep)
+
 v1.10.0
 -----------------
 

--- a/internal/component/prometheus/exporter/windows/config.go
+++ b/internal/component/prometheus/exporter/windows/config.go
@@ -82,6 +82,7 @@ func (a *Arguments) Convert(logger log.Logger) *windows_integration.Config {
 		MSCluster:          a.MSCluster.Convert(),
 		NetFramework:       a.NetFramework.Convert(),
 		DNS:                a.DNS.Convert(),
+		Update:             a.Update.Convert(),
 	}
 }
 

--- a/internal/component/prometheus/exporter/windows/windows_test.go
+++ b/internal/component/prometheus/exporter/windows/windows_test.go
@@ -2,6 +2,7 @@ package windows
 
 import (
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/alloy/syntax"
@@ -93,6 +94,11 @@ var (
 						"				  state: idle"
 
 		}
+
+		update {
+			online = true
+			scrape_interval = "10h"
+		}
 		`
 )
 
@@ -129,6 +135,8 @@ func TestAlloyUnmarshal(t *testing.T) {
 	require.Equal(t, []string{"example"}, args.Filetime.FilePatterns)
 	// This isn't a real example, and the recommendation would be to use a file rather than a raw string
 	require.Equal(t, "---\t- name: \"Processor\"\t\tcounters:\t\t\t- name: \"% Processor Time\"\t\t\t  instance: \"_Total\"\t\t\t  type: \"counter\"\t\t\t  labels:\t\t\t\t  state: idle", args.PerformanceCounter.Objects)
+	require.Equal(t, true, args.Update.Online)
+	require.Equal(t, 10*time.Hour, args.Update.ScrapeInterval)
 }
 
 func TestConvert(t *testing.T) {
@@ -164,4 +172,6 @@ func TestConvert(t *testing.T) {
 	require.Equal(t, "^(?:.+)$", conf.LogicalDisk.Include)
 	require.Equal(t, "example", conf.TCP.EnabledList)
 	require.Equal(t, []string{"example"}, conf.Filetime.FilePatterns)
+	require.Equal(t, true, conf.Update.Online)
+	require.Equal(t, 10*time.Hour, conf.Update.ScrapeInterval)
 }

--- a/internal/static/integrations/windows_exporter/config_windows.go
+++ b/internal/static/integrations/windows_exporter/config_windows.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/prometheus-community/windows_exporter/pkg/collector"
 	"gopkg.in/yaml.v3"
@@ -223,9 +222,9 @@ var DefaultConfig = Config{
 	TCP: TCPConfig{
 		EnabledList: strings.Join(collector.ConfigDefaults.TCP.CollectorsEnabled, ","),
 	},
-	Update: UpdateConfig{ // fields are not exported
-		Online:         false,
-		ScrapeInterval: 6 * time.Hour,
+	Update: UpdateConfig{
+		Online:         collector.ConfigDefaults.Update.Online,
+		ScrapeInterval: collector.ConfigDefaults.Update.ScrapeInterval,
 	},
 	Filetime: FiletimeConfig{
 		FilePatterns: collector.ConfigDefaults.Filetime.FilePatterns,


### PR DESCRIPTION
#### PR Description
Follow up to https://github.com/grafana/alloy/pull/3943. We did not propagate `update` arguments to windows exporter.
 
#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
