### PR TITLE
database_observability: add query tables collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Main (unreleased)
 
 - (_Experimental_) Additions to experimental `database_observability.mysql` component:
   - `query_sample` collector now supports auto-enabling the necessary `setup_consumers` settings (@cristiangreco)
+  - add `query_tables` collector for postgres (@matthewnolf)
 
 ### Enhancements
 

--- a/docs/sources/reference/components/database_observability/database_observability.postgres.md
+++ b/docs/sources/reference/components/database_observability/database_observability.postgres.md
@@ -27,8 +27,17 @@ You can use the following arguments with `database_observability.postgres`:
 
 | Name                               | Type                 | Description                                                                                    | Default | Required |
 |------------------------------------|----------------------|------------------------------------------------------------------------------------------------|---------|----------|
-| `data_source_name`                 | `secret`             | [Data Source Name][] for the Postgres server to connect to.                                       |         | yes      |
+| `data_source_name`                 | `secret`             | [Data Source Name][] for the Postgres server to connect to.                                    |         | yes      |
 | `forward_to`                       | `list(LogsReceiver)` | Where to forward log entries after processing.                                                 |         | yes      |
+| `disable_collectors`               | `list(string)`       | A list of collectors to disable from the default set.                                          |         | no       |
+| `enable_collectors`                | `list(string)`       | A list of collectors to enable on top of the default set.                                      |         | no       |
+
+
+The following collectors are configurable:
+
+| Name              | Description                                              | Enabled by default |
+|-------------------|----------------------------------------------------------|--------------------|
+| `query_tables`    | Collect query table information.                         | no                 |
 
 ## Blocks
 

--- a/internal/component/database_observability/postgres/collector/query_tables.go
+++ b/internal/component/database_observability/postgres/collector/query_tables.go
@@ -1,0 +1,185 @@
+package collector
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/DataDog/go-sqllexer"
+	"github.com/go-kit/log"
+	"go.uber.org/atomic"
+
+	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/component/database_observability"
+	"github.com/grafana/alloy/internal/runtime/logging"
+	"github.com/grafana/alloy/internal/runtime/logging/level"
+)
+
+const (
+	OP_QUERY_ASSOCIATION       = "query_association"
+	OP_QUERY_PARSED_TABLE_NAME = "query_parsed_table_name"
+	QueryTablesName            = "query_tables"
+)
+
+var selectQueriesFromActivity = `
+	SELECT
+		pg_stat_statements.queryid,
+		pg_stat_statements.query,
+		pg_database.datname
+	FROM
+		pg_stat_statements
+	JOIN pg_database
+		ON pg_database.oid = pg_stat_statements.dbid
+	WHERE
+		total_exec_time > (
+			SELECT percentile_cont(0.1)
+				WITHIN GROUP (ORDER BY total_exec_time)
+				FROM pg_stat_statements
+		)
+	ORDER BY total_exec_time DESC
+	LIMIT 100
+`
+
+type QueryTablesArguments struct {
+	DB              *sql.DB
+	InstanceKey     string
+	CollectInterval time.Duration
+	EntryHandler    loki.EntryHandler
+
+	Logger log.Logger
+}
+
+type QueryTables struct {
+	dbConnection    *sql.DB
+	instanceKey     string
+	collectInterval time.Duration
+	entryHandler    loki.EntryHandler
+	normalizer      *sqllexer.Normalizer
+
+	logger  log.Logger
+	running *atomic.Bool
+	ctx     context.Context
+	cancel  context.CancelFunc
+}
+
+func NewQueryTables(args QueryTablesArguments) (*QueryTables, error) {
+	return &QueryTables{
+		dbConnection:    args.DB,
+		instanceKey:     args.InstanceKey,
+		collectInterval: args.CollectInterval,
+		entryHandler:    args.EntryHandler,
+		normalizer:      sqllexer.NewNormalizer(sqllexer.WithCollectTables(true)),
+		logger:          log.With(args.Logger, "collector", QueryTablesName),
+		running:         &atomic.Bool{},
+	}, nil
+}
+
+func (c *QueryTables) Name() string {
+	return QueryTablesName
+}
+
+func (c *QueryTables) Start(ctx context.Context) error {
+	level.Debug(c.logger).Log("msg", QueryTablesName+" collector started")
+
+	c.running.Store(true)
+	ctx, cancel := context.WithCancel(ctx)
+	c.ctx = ctx
+	c.cancel = cancel
+
+	go func() {
+		defer func() {
+			c.Stop()
+			c.running.Store(false)
+		}()
+
+		ticker := time.NewTicker(c.collectInterval)
+
+		for {
+			if err := c.fetchAndAssociate(c.ctx); err != nil {
+				level.Error(c.logger).Log("msg", "collector error", "err", err)
+			}
+
+			select {
+			case <-c.ctx.Done():
+				return
+			case <-ticker.C:
+				// continue loop
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (c *QueryTables) Stopped() bool {
+	return !c.running.Load()
+}
+
+// Stop should be kept idempotent
+func (c *QueryTables) Stop() {
+	c.cancel()
+}
+
+func (c QueryTables) fetchAndAssociate(ctx context.Context) error {
+	rs, err := c.dbConnection.QueryContext(ctx, selectQueriesFromActivity)
+	if err != nil {
+		slog.Error("failed to fetch statements from statements view", "err", err)
+		return err
+	}
+	defer rs.Close()
+
+	for rs.Next() {
+		var queryID, queryText, databaseName string
+		err := rs.Scan(
+			&queryID,
+			&queryText,
+			&databaseName,
+		)
+		if err != nil {
+			slog.Error("failed to scan result set for statements", "err", err)
+			continue
+		}
+
+		c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
+			logging.LevelInfo,
+			OP_QUERY_ASSOCIATION,
+			c.instanceKey,
+			fmt.Sprintf(`queryID="%s" query_text="%s" datName="%s" engine="postgres"`, queryID, queryText, databaseName),
+		)
+
+		tables, err := c.tryTokenizeTableNames(queryText)
+		if err != nil {
+			slog.Error("failed to tokenize table names", "err", err)
+			continue
+		}
+
+		for _, table := range tables {
+			c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
+				logging.LevelInfo,
+				OP_QUERY_PARSED_TABLE_NAME,
+				c.instanceKey,
+				fmt.Sprintf(`queryID="%s" datName="%s" table="%s" engine="postgres"`, queryID, databaseName, table),
+			)
+		}
+	}
+
+	if err := rs.Err(); err != nil {
+		slog.Error("failed to iterate rs", "err", err)
+		return err
+	}
+
+	return nil
+}
+
+func (c QueryTables) tryTokenizeTableNames(sqlText string) ([]string, error) {
+	sqlText = strings.TrimSuffix(sqlText, "...")
+	_, metadata, err := c.normalizer.Normalize(sqlText, sqllexer.WithDBMS(sqllexer.DBMSPostgres))
+	if err != nil {
+		return nil, fmt.Errorf("failed to tokenize sql text: %w", err)
+	}
+
+	return metadata.Tables, nil
+}

--- a/internal/component/database_observability/postgres/collector/query_tables_test.go
+++ b/internal/component/database_observability/postgres/collector/query_tables_test.go
@@ -1,0 +1,520 @@
+package collector
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/go-kit/log"
+	loki_fake "github.com/grafana/alloy/internal/component/common/loki/client/fake"
+	"github.com/grafana/alloy/internal/component/database_observability"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+func TestQueryTables(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	testcases := []struct {
+		name                string
+		eventStatementsRows [][]driver.Value
+		logsLabels          []model.LabelSet
+		logsLines           []string
+	}{
+		{
+			name: "select query",
+			eventStatementsRows: [][]driver.Value{{
+				"abc123",
+				"SELECT * FROM some_table WHERE id = $1",
+				"some_database",
+			}},
+			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "postgres-db"},
+				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "postgres-db"},
+			},
+			logsLines: []string{
+				"level=\"info\" queryID=\"abc123\" query_text=\"SELECT * FROM some_table WHERE id = $1\" datName=\"some_database\" engine=\"postgres\"",
+				`level="info" queryID="abc123" datName="some_database" table="some_table" engine="postgres"`,
+			},
+		},
+		{
+			name: "insert query",
+			eventStatementsRows: [][]driver.Value{{
+				"abc123",
+				"INSERT INTO some_table (id, name) VALUES (...)",
+				"some_database",
+			}},
+			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "postgres-db"},
+				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "postgres-db"},
+			},
+			logsLines: []string{
+				"level=\"info\" queryID=\"abc123\" query_text=\"INSERT INTO some_table (id, name) VALUES (...)\" datName=\"some_database\" engine=\"postgres\"",
+				`level="info" queryID="abc123" datName="some_database" table="some_table" engine="postgres"`,
+			},
+		},
+		{
+			name: "update query",
+			eventStatementsRows: [][]driver.Value{{
+				"abc123",
+				"UPDATE some_table SET active = false, reason = ? WHERE id = $1 AND name = $2",
+				"some_database",
+			}},
+			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "postgres-db"},
+				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "postgres-db"},
+			},
+			logsLines: []string{
+				"level=\"info\" queryID=\"abc123\" query_text=\"UPDATE some_table SET active = false, reason = ? WHERE id = $1 AND name = $2\" datName=\"some_database\" engine=\"postgres\"",
+				`level="info" queryID="abc123" datName="some_database" table="some_table" engine="postgres"`,
+			},
+		},
+		{
+			name: "delete query",
+			eventStatementsRows: [][]driver.Value{{
+				"abc123",
+				"DELETE FROM some_table WHERE id = $1",
+				"some_database",
+			}},
+			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "postgres-db"},
+				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "postgres-db"},
+			},
+			logsLines: []string{
+				"level=\"info\" queryID=\"abc123\" query_text=\"DELETE FROM some_table WHERE id = $1\" datName=\"some_database\" engine=\"postgres\"",
+				`level="info" queryID="abc123" datName="some_database" table="some_table" engine="postgres"`,
+			},
+		},
+		{
+			name: "join two tables",
+			eventStatementsRows: [][]driver.Value{{
+				"abc123",
+				"SELECT t.id, t.val1, o.val2 FROM some_table t INNER JOIN other_table AS o ON t.id = o.id WHERE o.val2 = $1 ORDER BY t.val1 DESC",
+				"some_database",
+			}},
+			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "postgres-db"},
+				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "postgres-db"},
+				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "postgres-db"},
+			},
+			logsLines: []string{
+				"level=\"info\" queryID=\"abc123\" query_text=\"SELECT t.id, t.val1, o.val2 FROM some_table t INNER JOIN other_table AS o ON t.id = o.id WHERE o.val2 = $1 ORDER BY t.val1 DESC\" datName=\"some_database\" engine=\"postgres\"",
+				`level="info" queryID="abc123" datName="some_database" table="some_table" engine="postgres"`,
+				`level="info" queryID="abc123" datName="some_database" table="other_table" engine="postgres"`,
+			},
+		},
+		{
+			name: "truncated query",
+			eventStatementsRows: [][]driver.Value{{
+				"xyz456",
+				"INSERT INTO some_table...",
+				"some_database",
+			}, {
+				"abc123",
+				"SELECT * FROM another_table WHERE id = $1",
+				"some_database",
+			}},
+			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "postgres-db"},
+				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "postgres-db"},
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "postgres-db"},
+				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "postgres-db"},
+			},
+			logsLines: []string{
+				"level=\"info\" queryID=\"xyz456\" query_text=\"INSERT INTO some_table...\" datName=\"some_database\" engine=\"postgres\"",
+				`level="info" queryID="xyz456" datName="some_database" table="some_table" engine="postgres"`,
+				"level=\"info\" queryID=\"abc123\" query_text=\"SELECT * FROM another_table WHERE id = $1\" datName=\"some_database\" engine=\"postgres\"",
+				`level="info" queryID="abc123" datName="some_database" table="another_table" engine="postgres"`,
+			},
+		},
+		{
+			name: "truncated with properly closed comment",
+			eventStatementsRows: [][]driver.Value{{
+				"abc123",
+				"SELECT * FROM some_table WHERE id = $1 AND name =",
+				"some_database",
+			}},
+			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "postgres-db"},
+				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "postgres-db"},
+			},
+			logsLines: []string{
+				"level=\"info\" queryID=\"abc123\" query_text=\"SELECT * FROM some_table WHERE id = $1 AND name =\" datName=\"some_database\" engine=\"postgres\"",
+				`level="info" queryID="abc123" datName="some_database" table="some_table" engine="postgres"`,
+			},
+		},
+		{
+			name: "start transaction",
+			eventStatementsRows: [][]driver.Value{{
+				"abc123",
+				"START TRANSACTION",
+				"some_database",
+			}},
+			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "postgres-db"},
+			},
+			logsLines: []string{
+				`level="info" queryID="abc123" query_text="START TRANSACTION" datName="some_database" engine="postgres"`,
+			},
+		},
+		{
+			name: "sql parse error",
+			eventStatementsRows: [][]driver.Value{{
+				"xyz456",
+				"not valid sql",
+				"some_database",
+			}, {
+				"abc123",
+				"SELECT * FROM some_table WHERE id = $1",
+				"some_database",
+			}},
+			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "postgres-db"},
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "postgres-db"},
+				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "postgres-db"},
+			},
+			logsLines: []string{
+				"level=\"info\" queryID=\"xyz456\" query_text=\"not valid sql\" datName=\"some_database\" engine=\"postgres\"",
+				"level=\"info\" queryID=\"abc123\" query_text=\"SELECT * FROM some_table WHERE id = $1\" datName=\"some_database\" engine=\"postgres\"",
+				`level="info" queryID="abc123" datName="some_database" table="some_table" engine="postgres"`,
+			},
+		},
+		{
+			name: "multiple schemas",
+			eventStatementsRows: [][]driver.Value{{
+				"abc123",
+				"SELECT * FROM some_table WHERE id = $1",
+				"some_database",
+			}, {
+				"abc123",
+				"SELECT * FROM some_table WHERE id = $1",
+				"other_schema",
+			}},
+			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "postgres-db"},
+				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "postgres-db"},
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "postgres-db"},
+				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "postgres-db"},
+			},
+			logsLines: []string{
+				"level=\"info\" queryID=\"abc123\" query_text=\"SELECT * FROM some_table WHERE id = $1\" datName=\"some_database\" engine=\"postgres\"",
+				`level="info" queryID="abc123" datName="some_database" table="some_table" engine="postgres"`,
+				"level=\"info\" queryID=\"abc123\" query_text=\"SELECT * FROM some_table WHERE id = $1\" datName=\"other_schema\" engine=\"postgres\"",
+				`level="info" queryID="abc123" datName="other_schema" table="some_table" engine="postgres"`,
+			},
+		},
+		{
+			name: "subquery and union",
+			eventStatementsRows: [][]driver.Value{{
+				"abc123",
+				"SELECT * FROM (SELECT id, name FROM employees_us_east UNION SELECT id, name FROM employees_us_west) AS employees_us UNION SELECT id, name FROM employees_emea",
+				"some_database",
+			}},
+			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "postgres-db"},
+				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "postgres-db"},
+				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "postgres-db"},
+				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "postgres-db"},
+			},
+			logsLines: []string{
+				"level=\"info\" queryID=\"abc123\" query_text=\"SELECT * FROM (SELECT id, name FROM employees_us_east UNION SELECT id, name FROM employees_us_west) AS employees_us UNION SELECT id, name FROM employees_emea\" datName=\"some_database\" engine=\"postgres\"",
+				`level="info" queryID="abc123" datName="some_database" table="employees_us_east" engine="postgres"`,
+				`level="info" queryID="abc123" datName="some_database" table="employees_us_west" engine="postgres"`,
+				`level="info" queryID="abc123" datName="some_database" table="employees_emea" engine="postgres"`,
+			},
+		},
+		{
+			name: "show create table",
+			eventStatementsRows: [][]driver.Value{{
+				"abc123",
+				"SHOW CREATE TABLE some_table",
+				"some_database",
+			}},
+			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "postgres-db"},
+				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "postgres-db"},
+			},
+			logsLines: []string{
+				"level=\"info\" queryID=\"abc123\" query_text=\"SHOW CREATE TABLE some_table\" datName=\"some_database\" engine=\"postgres\"",
+				`level="info" queryID="abc123" datName="some_database" table="some_table" engine="postgres"`,
+			},
+		},
+		{
+			name: "show variables",
+			eventStatementsRows: [][]driver.Value{{
+				"abc123",
+				"SHOW VARIABLES LIKE $1",
+				"some_database",
+			}},
+			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "postgres-db"},
+			},
+			logsLines: []string{
+				"level=\"info\" queryID=\"abc123\" query_text=\"SHOW VARIABLES LIKE $1\" datName=\"some_database\" engine=\"postgres\"",
+			},
+		},
+		{
+			name: "query is truncated",
+			eventStatementsRows: [][]driver.Value{{
+				"abc123",
+				"SELECT * FROM some_table WHERE",
+				"some_database",
+			}},
+			logsLabels: []model.LabelSet{
+				{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "postgres-db"},
+				{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "postgres-db"},
+			},
+			logsLines: []string{
+				"level=\"info\" queryID=\"abc123\" query_text=\"SELECT * FROM some_table WHERE\" datName=\"some_database\" engine=\"postgres\"",
+				`level="info" queryID="abc123" datName="some_database" table="some_table" engine="postgres"`,
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+			require.NoError(t, err)
+			defer db.Close()
+
+			lokiClient := loki_fake.NewClient(func() {})
+
+			collector, err := NewQueryTables(QueryTablesArguments{
+				DB:              db,
+				InstanceKey:     "postgres-db",
+				CollectInterval: time.Second,
+				EntryHandler:    lokiClient,
+				Logger:          log.NewLogfmtLogger(os.Stderr),
+			})
+			require.NoError(t, err)
+			require.NotNil(t, collector)
+
+			mock.ExpectQuery(selectQueriesFromActivity).WithoutArgs().RowsWillBeClosed().
+				WillReturnRows(
+					sqlmock.NewRows([]string{
+						"queryid",
+						"query",
+						"datname",
+					}).AddRows(
+						tc.eventStatementsRows...,
+					),
+				)
+
+			err = collector.Start(t.Context())
+			require.NoError(t, err)
+
+			require.Eventually(t, func() bool {
+				return len(lokiClient.Received()) == len(tc.logsLines)
+			}, 5*time.Second, 100*time.Millisecond)
+
+			collector.Stop()
+			lokiClient.Stop()
+
+			require.Eventually(t, func() bool {
+				return collector.Stopped()
+			}, 5*time.Second, 100*time.Millisecond)
+
+			err = mock.ExpectationsWereMet()
+			require.NoError(t, err)
+
+			lokiEntries := lokiClient.Received()
+			require.Equal(t, len(tc.logsLines), len(lokiEntries))
+			for i, entry := range lokiEntries {
+				require.Equal(t, tc.logsLabels[i], entry.Labels)
+				require.Equal(t, tc.logsLines[i], entry.Line)
+			}
+		})
+	}
+}
+
+func TestQueryTablesSQLDriverErrors(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	t.Run("recoverable sql error in result set", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki_fake.NewClient(func() {})
+
+		collector, err := NewQueryTables(QueryTablesArguments{
+			DB:              db,
+			InstanceKey:     "postgres-db",
+			CollectInterval: time.Second,
+			EntryHandler:    lokiClient,
+			Logger:          log.NewLogfmtLogger(os.Stderr),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+
+		mock.ExpectQuery(selectQueriesFromActivity).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"queryid", // not enough columns
+				}).AddRow(
+					"abc123",
+				))
+
+		mock.ExpectQuery(selectQueriesFromActivity).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"queryid",
+					"query",
+					"datname",
+				}).AddRow(
+					"abc123",
+					"SELECT * FROM some_table WHERE id = ?",
+					"some_database",
+				),
+			)
+
+		err = collector.Start(t.Context())
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 2
+		}, 5*time.Second, 100*time.Millisecond)
+
+		collector.Stop()
+		lokiClient.Stop()
+
+		require.Eventually(t, func() bool {
+			return collector.Stopped()
+		}, 5*time.Second, 100*time.Millisecond)
+
+		err = mock.ExpectationsWereMet()
+		require.NoError(t, err)
+
+		lokiEntries := lokiClient.Received()
+		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "postgres-db"}, lokiEntries[0].Labels)
+		require.Equal(t, "level=\"info\" queryID=\"abc123\" query_text=\"SELECT * FROM some_table WHERE id = ?\" datName=\"some_database\" engine=\"postgres\"", lokiEntries[0].Line)
+		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "postgres-db"}, lokiEntries[1].Labels)
+		require.Equal(t, `level="info" queryID="abc123" datName="some_database" table="some_table" engine="postgres"`, lokiEntries[1].Line)
+	})
+
+	t.Run("result set iteration error", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki_fake.NewClient(func() {})
+
+		collector, err := NewQueryTables(QueryTablesArguments{
+			DB:              db,
+			InstanceKey:     "postgres-db",
+			CollectInterval: time.Second,
+			EntryHandler:    lokiClient,
+			Logger:          log.NewLogfmtLogger(os.Stderr),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+
+		mock.ExpectQuery(selectQueriesFromActivity).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"queryid",
+					"query",
+					"datname",
+				}).AddRow(
+					"abc123",
+					"SELECT * FROM some_table WHERE id = ?",
+					"some_database",
+				).AddRow(
+					"def456",
+					"SELECT * FROM another_table WHERE id = ?",
+					"another_schema",
+				).RowError(1, fmt.Errorf("rs error")), // error on second row
+			)
+
+		err = collector.Start(t.Context())
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 2
+		}, 5*time.Second, 100*time.Millisecond)
+
+		collector.Stop()
+		lokiClient.Stop()
+
+		require.Eventually(t, func() bool {
+			return collector.Stopped()
+		}, 5*time.Second, 100*time.Millisecond)
+
+		err = mock.ExpectationsWereMet()
+		require.NoError(t, err)
+
+		lokiEntries := lokiClient.Received()
+		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "postgres-db"}, lokiEntries[0].Labels)
+		require.Equal(t, "level=\"info\" queryID=\"abc123\" query_text=\"SELECT * FROM some_table WHERE id = ?\" datName=\"some_database\" engine=\"postgres\"", lokiEntries[0].Line)
+		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "postgres-db"}, lokiEntries[1].Labels)
+		require.Equal(t, `level="info" queryID="abc123" datName="some_database" table="some_table" engine="postgres"`, lokiEntries[1].Line)
+	})
+
+	t.Run("connection error recovery", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki_fake.NewClient(func() {})
+
+		collector, err := NewQueryTables(QueryTablesArguments{
+			DB:              db,
+			InstanceKey:     "postgres-db",
+			CollectInterval: time.Second,
+			EntryHandler:    lokiClient,
+			Logger:          log.NewLogfmtLogger(os.Stderr),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+
+		mock.ExpectQuery(selectQueriesFromActivity).WithoutArgs().WillReturnError(fmt.Errorf("connection error"))
+
+		mock.ExpectQuery(selectQueriesFromActivity).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"queryid",
+					"query",
+					"datname",
+				}).AddRow(
+					"abc123",
+					"SELECT * FROM some_table WHERE id = ?",
+					"some_database",
+				),
+			)
+
+		err = collector.Start(t.Context())
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 2
+		}, 5*time.Second, 100*time.Millisecond)
+
+		collector.Stop()
+		lokiClient.Stop()
+
+		require.Eventually(t, func() bool {
+			return collector.Stopped()
+		}, 5*time.Second, 100*time.Millisecond)
+
+		err = mock.ExpectationsWereMet()
+		require.NoError(t, err)
+
+		lokiEntries := lokiClient.Received()
+		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_ASSOCIATION, "instance": "postgres-db"}, lokiEntries[0].Labels)
+		require.Equal(t, "level=\"info\" queryID=\"abc123\" query_text=\"SELECT * FROM some_table WHERE id = ?\" datName=\"some_database\" engine=\"postgres\"", lokiEntries[0].Line)
+		require.Equal(t, model.LabelSet{"job": database_observability.JobName, "op": OP_QUERY_PARSED_TABLE_NAME, "instance": "postgres-db"}, lokiEntries[1].Labels)
+		require.Equal(t, `level="info" queryID="abc123" datName="some_database" table="some_table" engine="postgres"`, lokiEntries[1].Line)
+	})
+}

--- a/internal/component/database_observability/postgres/component_test.go
+++ b/internal/component/database_observability/postgres/component_test.go
@@ -1,0 +1,104 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/internal/component/database_observability/postgres/collector"
+	"github.com/grafana/alloy/syntax"
+)
+
+func Test_enableOrDisableCollectors(t *testing.T) {
+	t.Run("nothing specified (default behavior)", func(t *testing.T) {
+		exampleDBO11yAlloyConfig := `
+		data_source_name = "postgres://db"
+		forward_to = []
+	`
+
+		var args Arguments
+		err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
+		require.NoError(t, err)
+
+		actualCollectors := enableOrDisableCollectors(args)
+
+		assert.Equal(t, map[string]bool{
+			collector.QueryTablesName: false,
+		}, actualCollectors)
+	})
+
+	t.Run("enable collectors", func(t *testing.T) {
+		exampleDBO11yAlloyConfig := `
+		data_source_name = "postgres://db"
+		forward_to = []
+		enable_collectors = ["query_tables"]
+	`
+
+		var args Arguments
+		err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
+		require.NoError(t, err)
+
+		actualCollectors := enableOrDisableCollectors(args)
+
+		assert.Equal(t, map[string]bool{
+			collector.QueryTablesName: true,
+		}, actualCollectors)
+	})
+
+	t.Run("disable collectors", func(t *testing.T) {
+		exampleDBO11yAlloyConfig := `
+		data_source_name = "postgres://db"
+		forward_to = []
+		disable_collectors = ["query_tables"]
+	`
+
+		var args Arguments
+		err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
+		require.NoError(t, err)
+
+		actualCollectors := enableOrDisableCollectors(args)
+
+		assert.Equal(t, map[string]bool{
+			collector.QueryTablesName: false,
+		}, actualCollectors)
+	})
+
+	t.Run("enable collectors takes precedence over disable collectors", func(t *testing.T) {
+		exampleDBO11yAlloyConfig := `
+		data_source_name = "postgres://db"
+		forward_to = []
+		disable_collectors = ["query_tables"]
+		enable_collectors = ["query_tables"]
+	`
+
+		var args Arguments
+		err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
+		require.NoError(t, err)
+
+		actualCollectors := enableOrDisableCollectors(args)
+
+		assert.Equal(t, map[string]bool{
+			collector.QueryTablesName: true,
+		}, actualCollectors)
+	})
+
+	t.Run("unknown collectors are ignored", func(t *testing.T) {
+		exampleDBO11yAlloyConfig := `
+		data_source_name = "postgres://db"
+		forward_to = []
+		enable_collectors = ["some_string"]
+		disable_collectors = ["another_string"]
+	`
+
+		var args Arguments
+		err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
+		require.NoError(t, err)
+
+		actualCollectors := enableOrDisableCollectors(args)
+
+		assert.Equal(t, map[string]bool{
+			collector.QueryTablesName: false,
+		}, actualCollectors)
+	})
+}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This adds the `QueryTables` collector to the postgres component we have for database observability. It's functionality mirrors that of the mysql counterpart, and is responsible for 2 things:
* producing a mapping of queries, to the tables involved in them
* producing a mapping from queryID to query text

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
