### PR TITLE
Fix Windows installer values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ Main (unreleased)
 
 - Add `application_host` and `network_inter_zone` features to `beyla.ebpf` component. (@marctc)
 
+- Set the publisher name in the Windows installer to "Grafana Labs". (@martincostello)
+
 ### Bugfixes
 
 - Fix issues with propagating cluster peers change notifications to components configured with remotecfg. (@dehaansa)
@@ -66,6 +68,8 @@ Main (unreleased)
 - Fixed a bug in `prometheus.write.queue` which caused retries even when `max_retry_attempts` was set to `0`. (@ptodev)
 
 - Fix issue with `faro.receiver` cors not allowing X-Scope-OrgID and traceparent headers. (@mar4uk)
+
+- Fix URLs in the Windows installer being wrapped in quotes. (@martincostello)
 
 v1.10.0
 -----------------

--- a/packaging/windows/install_script.nsis
+++ b/packaging/windows/install_script.nsis
@@ -13,6 +13,7 @@ Unicode true
 !include .\macros.nsis
 
 !define APPNAME     "Alloy"
+!define PUBLISHER   "Grafana Labs"
 !define HELPURL     "https://grafana.com/docs/alloy/latest"
 !define UPDATEURL   "https://github.com/grafana/alloy/releases"
 !define ABOUTURL    "https://github.com/grafana/alloy"
@@ -98,7 +99,7 @@ Section "install"
   WriteRegStr   HKLM "${UNINSTALLKEY}" "QuietUninstallString" '"$INSTDIR\uninstall.exe" /S'
   WriteRegStr   HKLM "${UNINSTALLKEY}" "InstallLocation"      '"$INSTDIR"'
   WriteRegStr   HKLM "${UNINSTALLKEY}" "DisplayIcon"          '"$INSTDIR\logo.ico"'
-  WriteRegStr   HKLM "${UNINSTALLKEY}" "Publisher"            '${ABOUTURL}'
+  WriteRegStr   HKLM "${UNINSTALLKEY}" "Publisher"            '${PUBLISHER}'
   WriteRegStr   HKLM "${UNINSTALLKEY}" "HelpLink"             '${HELPURL}'
   WriteRegStr   HKLM "${UNINSTALLKEY}" "URLUpdateInfo"        '${UPDATEURL}'
   WriteRegStr   HKLM "${UNINSTALLKEY}" "URLInfoAbout"         '${ABOUTURL}'

--- a/packaging/windows/install_script.nsis
+++ b/packaging/windows/install_script.nsis
@@ -98,10 +98,10 @@ Section "install"
   WriteRegStr   HKLM "${UNINSTALLKEY}" "QuietUninstallString" '"$INSTDIR\uninstall.exe" /S'
   WriteRegStr   HKLM "${UNINSTALLKEY}" "InstallLocation"      '"$INSTDIR"'
   WriteRegStr   HKLM "${UNINSTALLKEY}" "DisplayIcon"          '"$INSTDIR\logo.ico"'
-  WriteRegStr   HKLM "${UNINSTALLKEY}" "Publisher"            '"${ABOUTURL}"'
-  WriteRegStr   HKLM "${UNINSTALLKEY}" "HelpLink"             '"${HELPURL}"'
-  WriteRegStr   HKLM "${UNINSTALLKEY}" "URLUpdateInfo"        '"${UPDATEURL}"'
-  WriteRegStr   HKLM "${UNINSTALLKEY}" "URLInfoAbout"         '"${ABOUTURL}"'
+  WriteRegStr   HKLM "${UNINSTALLKEY}" "Publisher"            '${ABOUTURL}'
+  WriteRegStr   HKLM "${UNINSTALLKEY}" "HelpLink"             '${HELPURL}'
+  WriteRegStr   HKLM "${UNINSTALLKEY}" "URLUpdateInfo"        '${UPDATEURL}'
+  WriteRegStr   HKLM "${UNINSTALLKEY}" "URLInfoAbout"         '${ABOUTURL}'
   WriteRegDWORD HKLM "${UNINSTALLKEY}" "NoModify" 1
   WriteRegDWORD HKLM "${UNINSTALLKEY}" "NoRepair" 1
 


### PR DESCRIPTION
#### PR Description

- Fix URLs appearing within quotes in the Windows installer.
- Set the publisher as Grafana Labs.

<img width="587" height="111" alt="image" src="https://github.com/user-attachments/assets/5164c873-8dc1-4ad1-83ed-dc2612d4d709" />

<img width="676" height="351" alt="image" src="https://github.com/user-attachments/assets/55305501-c840-47e7-8bb4-59b0b29cf9ee" />

#### Which issue(s) this PR fixes

None.

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] ~~Documentation added~~
- [ ] ~~Tests updated~~
- [ ] ~~Config converters updated~~
