### PR TITLE
Add CUSTOM_ARGS to docs to disable reporting when installed as systemd service

### DIFF
--- a/docs/sources/data-collection.md
+++ b/docs/sources/data-collection.md
@@ -70,6 +70,7 @@ If you want to opt out of anonymous usage statistics reporting, set the [CLI fla
 
    ```shell
    sudo systemctl restart alloy
+   ```
 
 [components]: ../get-started/components/
 [command line flag]: ../reference/cli/run/


### PR DESCRIPTION
Backport f32a28b0aa0c0a1cbf0f25d5d8a835916927e6ca from https://github.com/grafana/alloy/pull/4139