### PR TITLE
docs: import.git basic_auth block

### DIFF
--- a/docs/sources/reference/config-blocks/import.git.md
+++ b/docs/sources/reference/config-blocks/import.git.md
@@ -62,7 +62,10 @@ You can use the following blocks with `import.git`:
 
 ### `basic_auth`
 
-{{< docs/shared lookup="reference/components/basic-auth-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+| Name       | Type     | Description          | Default | Required |
+| ---------- | -------- | -------------------- | ------- | -------- |
+| `password` | `secret` | Basic auth password. |         | no       |
+| `username` | `string` | Basic auth username. |         | no       |
 
 ### `ssh_key`
 


### PR DESCRIPTION
#### PR Description
Auth block in `import.git` only supports setting username and password directly. We used a common block that we have for shared http client code.

#### Which issue(s) this PR fixes

Fixes: #4052

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
