### PR TITLE
fix:  prometheus.operator.podmonitors recognizes portNumber from crd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ Main (unreleased)
 
 - Fix ebpf profiler metrics `pyroscope_ebpf_active_targets`, `pyroscope_ebpf_profiling_sessions_total`, `pyroscope_ebpf_profiling_sessions_failing_total` not being updated. (luweglarz)
 
+- Fix `prometheus.operator.podmonitors` so it now handle portNumber from PodMonitor CRD. (@kalleep)
+
 v1.10.1
 -----------------
 

--- a/internal/component/prometheus/operator/configgen/config_gen_podmonitor.go
+++ b/internal/component/prometheus/operator/configgen/config_gen_podmonitor.go
@@ -179,19 +179,27 @@ func (cg *ConfigGenerator) GeneratePodMonitorConfig(m *promopv1.PodMonitor, ep p
 			Action:       "keep",
 			Regex:        regex,
 		})
+	} else if ep.PortNumber != nil && *ep.PortNumber != 0 {
+		regex, err := relabel.NewRegexp(fmt.Sprint(*ep.PortNumber)) //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
+		if err != nil {
+			return nil, fmt.Errorf("parsing PortNumber as regex: %w", err)
+		}
+		relabels.add(&relabel.Config{
+			SourceLabels: model.LabelNames{"__meta_kubernetes_pod_container_port_number"},
+			Action:       "keep",
+			Regex:        regex,
+		})
 	} else if ep.TargetPort != nil { //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		if ep.TargetPort.StrVal != "" { //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 			regex, err := relabel.NewRegexp(ep.TargetPort.String()) //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 			if err != nil {
 				return nil, fmt.Errorf("parsing TargetPort as regex: %w", err)
 			}
-			if ep.TargetPort.StrVal != "" { //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
-				relabels.add(&relabel.Config{
-					SourceLabels: model.LabelNames{"__meta_kubernetes_pod_container_port_name"},
-					Action:       "keep",
-					Regex:        regex,
-				})
-			}
+			relabels.add(&relabel.Config{
+				SourceLabels: model.LabelNames{"__meta_kubernetes_pod_container_port_name"},
+				Action:       "keep",
+				Regex:        regex,
+			})
 		} else if ep.TargetPort.IntVal != 0 { //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 			regex, err := relabel.NewRegexp(fmt.Sprint(ep.TargetPort.IntValue())) //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 			if err != nil {

--- a/internal/component/prometheus/operator/configgen/config_gen_podmonitor.go
+++ b/internal/component/prometheus/operator/configgen/config_gen_podmonitor.go
@@ -1,6 +1,6 @@
 package configgen
 
-// SEE https://github.com/prometheus-operator/prometheus-operator/blob/aa8222d7e9b66e9293ed11c9291ea70173021029/pkg/prometheus/promcfg.go
+// SEE https://github.com/prometheus-operator/prometheus-operator/blob/4d008d5a5698e425e745daa6222a534357b93b57/pkg/prometheus/promcfg.go
 
 import (
 	"fmt"

--- a/internal/component/prometheus/operator/configgen/config_gen_podmonitor_test.go
+++ b/internal/component/prometheus/operator/configgen/config_gen_podmonitor_test.go
@@ -216,6 +216,65 @@ func TestGeneratePodMonitorConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "portnumber",
+			m: &promopv1.PodMonitor{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "operator",
+					Name:      "podmonitor",
+				},
+			},
+			ep: promopv1.PodMetricsEndpoint{
+				PortNumber: ptr.To[int32](2000),
+			},
+			expectedRelabels: util.Untab(`
+				- target_label: __meta_foo
+				  replacement: bar
+				- source_labels: [job]
+				  target_label: __tmp_prometheus_job_name
+				- source_labels: [__meta_kubernetes_pod_phase]
+				  regex: (Failed|Succeeded)
+				  action: drop
+				- source_labels: ["__meta_kubernetes_pod_container_port_number"]
+				  regex: "2000"
+				  action: "keep"
+				- source_labels: [__meta_kubernetes_namespace]
+				  target_label: namespace
+				- source_labels: [__meta_kubernetes_pod_container_name]
+				  target_label: container
+				- source_labels: [__meta_kubernetes_pod_name]
+				  target_label: pod
+				- target_label: job
+				  replacement: operator/podmonitor
+			`),
+			expected: &config.ScrapeConfig{
+				JobName:           "podMonitor/operator/podmonitor/1",
+				HonorTimestamps:   true,
+				ScrapeInterval:    model.Duration(time.Hour),
+				ScrapeTimeout:     model.Duration(42 * time.Second),
+				ScrapeProtocols:   config.DefaultScrapeProtocols,
+				EnableCompression: true,
+				MetricsPath:       "/metrics",
+				Scheme:            "http",
+				HTTPClientConfig: commonConfig.HTTPClientConfig{
+					FollowRedirects: true,
+					EnableHTTP2:     true,
+				},
+				ServiceDiscoveryConfigs: discovery.Configs{
+					&promk8s.SDConfig{
+						Role: "pod",
+
+						NamespaceDiscovery: promk8s.NamespaceDiscovery{
+							IncludeOwnNamespace: false,
+							Names:               []string{"operator"},
+						},
+					},
+				},
+				ConvertClassicHistogramsToNHCB: ptr.To(false),
+				MetricNameValidationScheme:     "legacy",
+				MetricNameEscapingScheme:       "underscores",
+			},
+		},
+		{
 			name: "defaults_from_scrapeoptions",
 			m: &promopv1.PodMonitor{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
#### PR Description
This pr adds support for `portNumber` from PodMonitor CRD https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.PodMetricsEndpoint
 
 I also updated the reference link we had to point to the current commit we use inside alloy
 
#### Which issue(s) this PR fixes

Fixes #3949 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
