### PR TITLE
Update logs-in-kubernetes docs to warn users about daemonsets

### DIFF
--- a/docs/sources/collect/logs-in-kubernetes.md
+++ b/docs/sources/collect/logs-in-kubernetes.md
@@ -166,7 +166,7 @@ Replace the following values:
 You can get pods logs through the log files on each node. In this guide, you get the logs through the Kubernetes API because it doesn't require system privileges for {{< param "PRODUCT_NAME" >}}.
 {{< /admonition >}}
 
-{{< admonition type="tip" >}}
+{{< admonition type="note" >}}
 When deploying {{< param "PRODUCT_NAME" >}} as a daemonset, ensure that you have [configured discovery][discovery.kubernetes.daemonset] appropriately to only collect logs from the same node.
 
 [discovery.kubernetes.daemonset]: ../../reference/components/discovery/discovery.kubernetes/#limit-to-only-pods-on-the-same-node


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Add a tip for ensuring that you use the appropriate configuration to not collect duplicate logs when deploying Alloy as a daemonset.

#### Which issue(s) this PR fixes

See https://github.com/grafana/alloy/issues/1185#issuecomment-3162752392