### PR TITLE
Update build image to use golang 1.24.6

### DIFF
--- a/.github/workflows/check-linux-build-image.yml
+++ b/.github/workflows/check-linux-build-image.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         build:
-          - runtime: golang:1.24.4-alpine3.21
-          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.24.4-bookworm
+          - runtime: golang:1.24.6-alpine3.21
+          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.24.6-bookworm
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/create_build_image.yml
+++ b/.github/workflows/create_build_image.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         build:
-          - runtime: golang:1.24.4-alpine3.21
-          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.24.4-bookworm
+          - runtime: golang:1.24.6-alpine3.21
+          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.24.6-bookworm
             suffix: "-boringcrypto"
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
#### PR Description
Update build image to latest golang release. This includes bug fixes and fixed to two security issues:

1.24.5:
* [CVE-2025-4674](https://github.com/advisories/GHSA-wprm-fgrx-xj42)

1.24.6:
* [CVE-2025-47907](https://github.com/advisories/GHSA-j5pm-7495-qmr3)


#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
