### PR TITLE
Allow configuring interval and timespan independently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ Main (unreleased)
 
 - Add a `stage.pattern` stage to `loki.process` that uses LogQL patterns to parse logs. (@dehaansa)
 
+- `prometheus.exporter.azure` supports setting `interval` and `timespan` independently allowing for further look back when querying metrics. (@kgeckhart)
+
 ### Bugfixes
 
 - Update `webdevops/go-common` dependency to resolve concurrent map write panic. (@dehaansa)

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.azure.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.azure.md
@@ -67,7 +67,7 @@ prometheus.exporter.azure "<LABEL>" {
 You can use the following arguments with `prometheus.exporter.azure`:
 
 | Name                          | Type           | Description                                                                                                                                              | Default                                                                       | Required |
-| ----------------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | -------- |
+|-------------------------------| -------------- |----------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------| -------- |
 | `metrics`                     | `list(string)` | The metrics to scrape from resources.                                                                                                                    |                                                                               | yes      |
 | `resource_type`               | `string`       | The Azure Resource Type to scrape metrics for.                                                                                                           |                                                                               | yes      |
 | `subscriptions`               | `list(string)` | List of subscriptions to scrape metrics from.                                                                                                            |                                                                               | yes      |
@@ -80,7 +80,8 @@ You can use the following arguments with `prometheus.exporter.azure`:
 | `metric_namespace`            | `string`       | Namespace for `resource_type` which have multiple levels of metrics.                                                                                     |                                                                               | no       |
 | `regions`                     | `list(string)` | The list of regions for gathering metrics. Gathers metrics for all resources in the subscription. Can't be used if `resource_graph_query_filter` is set. |                                                                               | no       |
 | `resource_graph_query_filter` | `string`       | The [Kusto query][] filter to apply when searching for resources. Can't be used if `regions` is set.                                                     |                                                                               | no       |
-| `timespan`                    | `string`       | [ISO8601 Duration][] over which the metrics are being queried.                                                                                           | `"PT1M"` (1 minute)                                                           | no       |
+| `timespan`                    | `string`       | [ISO8601 Duration][] over which the metrics are being queried.                                                                                           | `"PT5M"` (5 minute)                                                           | no       |
+| `interval`                    | `string`       | [ISO8601 Duration][] used when to generate individual datapoints in Azure Monitor. Must be smaller than `timespan`.                                      | `"PT1M"` (1 minute)                                                           | no       |
 | `validate_dimensions`         | `bool`         | Enable dimension validation in the azure SDK.                                                                                                            | `false`                                                                       | no       |
 
 The list of available `resource_type` values and their corresponding `metrics` can be found in [Azure Monitor essentials][].
@@ -105,8 +106,12 @@ Tags in `included_resource_tags` will be added as labels with the name `tag_<tag
 
 Valid values for `azure_cloud_environment` are `azurecloud`, `azurechinacloud`, `azuregovernmentcloud` and `azurepprivatecloud`.
 
-`validate_dimensions` is disabled by default to reduce the number of Azure exporter instances requires when a `resource_type` has metrics with varying dimensions.
+`validate_dimensions` is disabled by default to reduce the number of Azure exporter instances required when a `resource_type` has metrics with varying dimensions.
 When `validate_dimensions` is enabled you will need one exporter instance per metric + dimension combination which is more tedious to maintain.
+
+`timespan` and `interval` are used to control how metrics are queried from Azure Monitor. 
+The exporter will query metrics over the `timespan` and return the most recent datapoint at the specified `interval`. 
+If you are having issues with missing metrics, try increasing the `timespan` to a larger value, such as `PT10M` (10 minutes) or `PT15M` (15 minutes).
 
 [Kusto query]: https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/
 [Azure Monitor essentials]: https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported

--- a/internal/component/prometheus/exporter/azure/azure.go
+++ b/internal/component/prometheus/exporter/azure/azure.go
@@ -31,6 +31,7 @@ type Arguments struct {
 	Metrics                  []string `alloy:"metrics,attr"`
 	MetricAggregations       []string `alloy:"metric_aggregations,attr,optional"`
 	Timespan                 string   `alloy:"timespan,attr,optional"`
+	Interval                 string   `alloy:"interval,attr,optional"`
 	IncludedDimensions       []string `alloy:"included_dimensions,attr,optional"`
 	IncludedResourceTags     []string `alloy:"included_resource_tags,attr,optional"`
 	MetricNamespace          string   `alloy:"metric_namespace,attr,optional"`
@@ -44,7 +45,8 @@ type Arguments struct {
 // SetToDefault implements syntax.Defaulter.
 func (a *Arguments) SetToDefault() {
 	*a = Arguments{
-		Timespan:              "PT1M",
+		Timespan:              "PT5M",
+		Interval:              "PT1M",
 		MetricNameTemplate:    "azure_{type}_{metric}_{aggregation}_{unit}",
 		MetricHelpTemplate:    "Azure metric {metric} for {type} with aggregation {aggregation} as {unit}",
 		IncludedResourceTags:  []string{"owner"},
@@ -72,6 +74,7 @@ func (a *Arguments) Convert() *azure_exporter.Config {
 		Metrics:                  a.Metrics,
 		MetricAggregations:       a.MetricAggregations,
 		Timespan:                 a.Timespan,
+		Interval:                 a.Interval,
 		IncludedDimensions:       a.IncludedDimensions,
 		IncludedResourceTags:     a.IncludedResourceTags,
 		MetricNamespace:          a.MetricNamespace,

--- a/internal/converter/internal/staticconvert/internal/build/azure_exporter.go
+++ b/internal/converter/internal/staticconvert/internal/build/azure_exporter.go
@@ -19,6 +19,7 @@ func toAzureExporter(config *azure_exporter.Config) *azure.Arguments {
 		Metrics:                  config.Metrics,
 		MetricAggregations:       config.MetricAggregations,
 		Timespan:                 config.Timespan,
+		Interval:                 config.Interval,
 		IncludedDimensions:       config.IncludedDimensions,
 		IncludedResourceTags:     config.IncludedResourceTags,
 		MetricNamespace:          config.MetricNamespace,

--- a/internal/static/integrations/azure_exporter/config.go
+++ b/internal/static/integrations/azure_exporter/config.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/channelmeter/iso8601duration"
 	"github.com/go-kit/log"
 	azure_config "github.com/webdevops/azure-metrics-exporter/config"
 	"github.com/webdevops/azure-metrics-exporter/metrics"
@@ -29,7 +30,8 @@ func init() {
 
 // DefaultConfig holds the default settings for the azure_exporter integration.
 var DefaultConfig = Config{
-	Timespan:              "PT1M",
+	Timespan:              "PT5M",
+	Interval:              "PT1M",
 	MetricNameTemplate:    "azure_{type}_{metric}_{aggregation}_{unit}",
 	MetricHelpTemplate:    "Azure metric {metric} for {type} with aggregation {aggregation} as {unit}",
 	IncludedResourceTags:  []string{"owner"},
@@ -55,8 +57,11 @@ type Config struct {
 	MetricAggregations []string `yaml:"metric_aggregations"`
 
 	// All fields below are optional
+	// Must be an ISO8601 Duration - defaults to PT5M if not specified
+	Timespan string `yaml:"timespan"`
 	// Must be an ISO8601 Duration - defaults to PT1M if not specified
-	Timespan             string   `yaml:"timespan"`
+	Interval string `yaml:"interval"`
+
 	IncludedDimensions   []string `yaml:"included_dimensions"`
 	IncludedResourceTags []string `yaml:"included_resource_tags"`
 
@@ -151,6 +156,20 @@ func (c *Config) Validate() error {
 		configErrors = append(configErrors, fmt.Errorf("failed to create an azure cloud configuration from azure cloud environment %s, %v", c.AzureCloudEnvironment, err).Error())
 	}
 
+	timespan, tErr := duration.FromString(c.Timespan)
+	if tErr != nil {
+		configErrors = append(configErrors, fmt.Sprintf("timespan %s is not a valid ISO8601 duration, %v", c.Timespan, tErr))
+	}
+
+	interval, iErr := duration.FromString(c.Interval)
+	if iErr != nil {
+		configErrors = append(configErrors, fmt.Sprintf("timespan %s is not a valid ISO8601 duration, %v", c.Timespan, iErr))
+	}
+
+	if tErr == nil && iErr == nil && timespan.ToDuration() < interval.ToDuration() {
+		configErrors = append(configErrors, fmt.Sprintf("timespan %s must be greater than or equal to interval %s", c.Timespan, c.Interval))
+	}
+
 	if len(configErrors) != 0 {
 		return errors.New(strings.Join(configErrors, ","))
 	}
@@ -175,11 +194,10 @@ func (c *Config) ToScrapeSettings() (*metrics.RequestMetricSettings, error) {
 		ValidateDimensions: c.ValidateDimensions,
 		Regions:            c.Regions,
 
-		// Interval controls data aggregation timeframe ie 1 minute or 5 minutes aggregations
 		// Timespan controls query start and end time
-		// Interval == Timespan to ensure we only get a single data point any more than that is useless
 		Timespan: c.Timespan,
-		Interval: to.Ptr[string](c.Timespan),
+		// Interval controls the resolution of the data returned
+		Interval: to.Ptr(c.Interval),
 
 		// Unused settings just here to capture they are intentionally not set
 		Name:  "",
@@ -250,6 +268,11 @@ func MergeConfigWithQueryParams(cfg Config, params url.Values) (Config, error) {
 	timespan := params.Get("timespan")
 	if len(timespan) != 0 {
 		cfg.Timespan = timespan
+	}
+
+	interval := params.Get("interval")
+	if len(interval) != 0 {
+		cfg.Interval = interval
 	}
 
 	if dimensions, exists := params["included_dimensions"]; exists {

--- a/internal/static/integrations/azure_exporter/config_test.go
+++ b/internal/static/integrations/azure_exporter/config_test.go
@@ -20,6 +20,7 @@ func TestConfig_ToScrapeSettings(t *testing.T) {
 		Metrics:                  []string{"MetricA"},
 		MetricAggregations:       []string{"MiNimUm"},
 		Timespan:                 "timespan_me",
+		Interval:                 "interval_me",
 		IncludedResourceTags:     []string{"tag_me"},
 		MetricNamespace:          "namespace_me",
 		MetricNameTemplate:       "name_template_me",
@@ -31,7 +32,7 @@ func TestConfig_ToScrapeSettings(t *testing.T) {
 		ResourceType:    "resourceType",
 		Filter:          "filter_me",
 		Timespan:        "timespan_me",
-		Interval:        to.Ptr("timespan_me"),
+		Interval:        to.Ptr("interval_me"),
 		Metrics:         []string{"MetricA"},
 		MetricNamespace: "namespace_me",
 		Aggregations:    []string{"MiNimUm"},
@@ -85,18 +86,6 @@ func TestConfig_ToScrapeSettings(t *testing.T) {
 			},
 		},
 		{
-			name: "sets config timespan to setting interval and timespan",
-			configModifier: func(config azure_exporter.Config) azure_exporter.Config {
-				config.Timespan = "timespan-value"
-				return config
-			},
-			toExpectedSettings: func(settings metrics.RequestMetricSettings) metrics.RequestMetricSettings {
-				settings.Timespan = "timespan-value"
-				settings.Interval = to.Ptr[string]("timespan-value")
-				return settings
-			},
-		},
-		{
 			name: "sets regions and top when using regions with no dimensions",
 			configModifier: func(config azure_exporter.Config) azure_exporter.Config {
 				config.Regions = []string{"uswest", "useast"}
@@ -126,6 +115,8 @@ func TestConfig_Validate(t *testing.T) {
 		ResourceType:          "resourceType",
 		Metrics:               []string{"MetricA"},
 		AzureCloudEnvironment: "azurecloud",
+		Interval:              "PT1M",
+		Timespan:              "PT5M",
 	}
 
 	baseConfigValid := t.Run("Base Config is Valid", func(t *testing.T) {
@@ -194,6 +185,28 @@ func TestConfig_Validate(t *testing.T) {
 			toInvalidConfig: func(config azure_exporter.Config) azure_exporter.Config {
 				config.ResourceGraphQueryFilter = "filter the resources"
 				config.Regions = []string{"uswest", "useast"}
+				return config
+			},
+		},
+		{
+			name: "invalid interval",
+			toInvalidConfig: func(config azure_exporter.Config) azure_exporter.Config {
+				config.Interval = "Not a valid interval"
+				return config
+			},
+		},
+		{
+			name: "invalid timespan",
+			toInvalidConfig: func(config azure_exporter.Config) azure_exporter.Config {
+				config.Timespan = "Not a valid timespan"
+				return config
+			},
+		},
+		{
+			name: "interval larger than timespan",
+			toInvalidConfig: func(config azure_exporter.Config) azure_exporter.Config {
+				config.Timespan = "PT1M"
+				config.Interval = "PT5M"
 				return config
 			},
 		},


### PR DESCRIPTION
#### PR Description
Allows configuring `interval` and `timespan` independently. There are some Azure Resource Types which have a delay in metric availability and keeping `interval` = `timespan` can cause missing data. These cases often need a `timespan` larger than `interval` which is now the new default so users should encounter this far less often.

#### Which issue(s) this PR fixes

Related to: https://github.com/grafana/alloy/issues/3626

#### PR Checklist

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
