### PR TITLE
ci: hold back elasticsearch exporter dep

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -68,6 +68,7 @@
       "matchPackageNames": [
         "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector",
         "github.com/KimMachineGun/automemlimit",
+        "github.com/prometheus-community/elasticsearch_exporter", // Introduces breaking changes in minor versions
         "github.com/google/cadvisor",
         "github.com/grafana/beyla/v2",
         "github.com/grafana/jfr-parser/pprof",


### PR DESCRIPTION
The elasticsearch exporter introduces breaking changes in minor versions. This PR holds that dep out of the BAU minor/patch updates.