### PR TITLE
pyroscope.receive_http: fix shutdown condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ Main (unreleased)
 
 - Fix `prometheus.operator.podmonitors` so it now handle portNumber from PodMonitor CRD. (@kalleep)
 
+- Fix `pyroscope.receive_http` so it does not restart server if the server configuration has not changed. (@korniltsev)
+
 v1.10.1
 -----------------
 

--- a/internal/component/pyroscope/receive_http/receive_http.go
+++ b/internal/component/pyroscope/receive_http/receive_http.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"connectrpc.com/connect"
+
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
@@ -63,6 +64,7 @@ func (a *Arguments) SetToDefault() {
 type Component struct {
 	opts               component.Options
 	server             *fnet.TargetServer
+	serverConfig       *fnet.HTTPConfig
 	uncheckedCollector *util.UncheckedCollector
 	appendables        []pyroscope.Appendable
 	mut                sync.Mutex
@@ -98,6 +100,13 @@ func (c *Component) Run(ctx context.Context) error {
 }
 
 func (c *Component) Update(args component.Arguments) error {
+	_, err := c.update(args)
+	return err
+}
+
+// returns true if the server was shutdown
+func (c *Component) update(args component.Arguments) (bool, error) {
+	shutdown := false
 	newArgs := args.(Arguments)
 
 	c.mut.Lock()
@@ -122,12 +131,14 @@ func (c *Component) Update(args component.Arguments) error {
 		}
 	}
 
-	serverNeedsRestarting := c.server == nil || !reflect.DeepEqual(c.server, *newArgs.Server.HTTP)
+	serverNeedsRestarting := !reflect.DeepEqual(c.serverConfig, newArgs.Server.HTTP)
 	if !serverNeedsRestarting {
-		return nil
+		return shutdown, nil
 	}
-
+	shutdown = true
 	c.shutdownServer()
+	c.server = nil
+	c.serverConfig = nil
 
 	// [server.Server] registers new metrics every time it is created. To
 	// avoid issues with re-registering metrics with the same name, we create a
@@ -138,11 +149,12 @@ func (c *Component) Update(args component.Arguments) error {
 
 	srv, err := fnet.NewTargetServer(c.opts.Logger, "pyroscope_receive_http", serverRegistry, newArgs.Server)
 	if err != nil {
-		return fmt.Errorf("failed to create server: %w", err)
+		return shutdown, fmt.Errorf("failed to create server: %w", err)
 	}
 	c.server = srv
+	c.serverConfig = newArgs.Server.HTTP
 
-	return c.server.MountAndRun(func(router *mux.Router) {
+	return shutdown, c.server.MountAndRun(func(router *mux.Router) {
 		// this mounts the og pyroscope ingest API, mostly used by SDKs
 		router.HandleFunc("/ingest", c.handleIngest).Methods(http.MethodPost)
 

--- a/internal/component/pyroscope/receive_http/receive_http_test.go
+++ b/internal/component/pyroscope/receive_http/receive_http_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+
 	"github.com/phayes/freeport"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
@@ -577,4 +578,20 @@ func TestUpdateArgs(t *testing.T) {
 	})
 
 	waitForServerReady(t, ports[1])
+
+	shutdown, err := comp.update(Arguments{
+		Server: &fnet.ServerConfig{
+			HTTP: &fnet.HTTPConfig{
+				ListenAddress: "localhost",
+				ListenPort:    ports[1],
+			},
+		},
+		ForwardTo: forwardTo,
+	})
+	require.NoError(t, err)
+	require.False(t, shutdown)
+
 }
+
+//todo write a test for deep reflect bug
+//todo write a test for default connection limit bug


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
The current check does `reflect.DeepEqual(c.server, *newArgs.Server.HTTP)` and the provided arguments are of different type, so the check always fails
#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
