### PR TITLE
Fix MacOS ARM builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
         # TODO: Try enabling caching later. It might use up too much disk space on runners so needs extra testing.
         cache: false
     - run: make generate-ui
-    - run: GO_TAGS="builtinassets" GOOS=darwin GOARCH=arm64 GOARM= make alloy
+    - run: CGO_LDFLAGS="-ld_classic $CGO_LDFLAGS" GO_TAGS="builtinassets" GOOS=darwin GOARCH=arm64 GOARM= make alloy
 
   build_windows:
     name: Build on Windows (AMD64)


### PR DESCRIPTION
The Mac OS ARM build is [failing](https://github.com/grafana/alloy/actions/runs/16910203661/job/47909611982?pr=4175#step:5:867) on GitHub Actions with this sort of error log:

<details>

<summary>Build log</summary>

```
go: downloading github.com/bits-and-blooms/bitset v1.10.0
go: downloading github.com/go-openapi/analysis v0.23.0
go: downloading github.com/go-openapi/loads v0.22.0
go: downloading github.com/go-openapi/spec v0.21.0
# github.com/grafana/alloy
/Users/runner/hostedtoolcache/go/1.24.4/arm64/pkg/tool/darwin_arm64/link: running clang failed: exit status 1
/usr/bin/clang -arch arm64 -Wl,-headerpad,1144 -o $WORK/b001/exe/a.out -Qunused-arguments /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/go.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000000.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000001.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000002.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000003.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000004.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000005.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000006.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000007.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000008.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000009.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000010.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000011.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000012.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000013.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000014.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000015.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000016.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000017.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000018.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000019.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000020.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000021.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000022.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000023.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000024.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000025.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000026.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000027.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000028.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000029.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000030.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000031.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000032.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000033.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000034.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000035.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000036.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000037.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000038.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000039.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000040.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000041.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000042.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000043.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000044.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000045.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000046.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000047.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000048.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000049.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000050.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000051.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000052.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000053.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000054.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000055.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000056.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000057.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000058.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000059.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000060.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000061.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000062.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000063.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000064.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000065.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000066.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000067.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000068.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000069.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000070.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000071.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000072.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000073.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000074.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000075.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000076.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000077.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000078.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000079.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000080.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000081.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000082.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000083.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000084.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000085.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000086.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000087.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000088.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000089.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000090.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000091.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000092.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000093.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000094.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000095.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000096.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000097.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000098.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000099.o /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/000100.o -O2 -g -O2 -g -framework CoreFoundation -O2 -g -lresolv -O2 -g -O2 -g -O2 -g -framework IOKit -framework CoreFoundation -framework IOKit -framework CoreFoundation -framework CoreFoundation -framework Security -O2 -g -framework CoreFoundation -framework IOKit -O2 -g -framework CoreFoundation -framework IOKit -O2 -g -O2 -g -framework CoreFoundation -framework CoreFoundation -framework CoreFoundation -framework Security -framework CoreFoundation -framework Security -O2 -g -O2 -g -lproc -lproc
ld: warning: ignoring duplicate libraries: '-lproc'
ld: B/BL out of range -135330212 (max +/-128MB) from 0x1081187C4 ('_runtime.cmpstring.island' from 'branch-islands-file') to 0x100008E20 ('_runtime.cmpstring' from '/private/var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/go-link-1735969031/go.o')
final section layout:
    __PAGEZERO           addr=0x00000000, size=0x100000000, fileOffset=0x00000000
    __TEXT               addr=0x100000000, size=0x0a54c000, fileOffset=0x00000000
        __text           addr=0x100004c30, size=0x081f52c8, fileOffset=0x00004c30
        __stubs          addr=0x1081f9ef8, size=0x00000720, fileOffset=0x081f9ef8
        __init_offsets   addr=0x1081fa618, size=0x00000004, fileOffset=0x081fa618
        __rodata         addr=0x1081fa620, size=0x0233e1e1, fileOffset=0x081fa620
        __cstring        addr=0x10a538801, size=0x00008917, fileOffset=0x0a538801
        __const          addr=0x10a541120, size=0x00005a6c, fileOffset=0x0a541120
        __unwind_info    addr=0x10a546b8c, size=0x000019f0, fileOffset=0x0a546b8c
        __eh_frame       addr=0x10a548580, size=0x00000158, fileOffset=0x0a548580
    __DATA_CONST         addr=0x10a54c000, size=0x082f0000, fileOffset=0x0a54c000
        __got            addr=0x10a54c000, size=0x000008d0, fileOffset=0x0a54c000
        __const          addr=0x10a54c8d0, size=0x000008f8, fileOffset=0x0a54c8d0
        __cfstring       addr=0x10a54d1c8, size=0x00000360, fileOffset=0x0a54d1c8
        __rodata         addr=0x10a54d540, size=0x02b09cf8, fileOffset=0x0a54d540
        __typelink       addr=0x10d057240, size=0x0008a5ec, fileOffset=0x0d057240
        __itablink       addr=0x10d0e1840, size=0x00026888, fileOffset=0x0d0e1840
        __gopclntab      addr=0x10d1080e0, size=0x057324e0, fileOffset=0x0d1080e0
    __DATA               addr=0x11283c000, size=0x00dec000, fileOffset=0x1283c000
        __data           addr=0x11283c000, size=0x0032e048, fileOffset=0x1283c000
        __go_buildinfo   addr=0x112b6a050, size=0x00016730, fileOffset=0x12b6a050
        __go_fipsinfo    addr=0x112b80780, size=0x00000078, fileOffset=0x12b80780
        __noptrdata      addr=0x112b80800, size=0x00a12161, fileOffset=0x12b80800
        __bss            addr=0x113592980, size=0x00074b61, fileOffset=0x00000000
        __noptrbss       addr=0x113607500, size=0x0001eff0, fileOffset=0x00000000
        __common         addr=0x1136264f0, size=0x00000070, fileOffset=0x00000000
    __LINKEDIT           addr=0x113628000, size=0x04af0000, fileOffset=0x13594000
clang: error: linker command failed with exit code 1 (use -v to see invocation)

make: *** [alloy] Error 1
```
</details>

I could not reproduce the problem, but I think this PR will resolve it. The same problem was reported in a [Go issue](https://github.com/golang/go/issues/67854) and I see that the project which reported it [fixed it](https://github.com/bytebase/bytebase/pull/12876) by enabling an older linker. The `ld_classic` command was [added](https://stackoverflow.com/a/79049477) to XCode to fix issues people seem to have with the new linker. I suppose it's still less smart than the old linker in certain cases. Interestingly, for some reason we already use `ld_classic` in the [MacOS test workflow](https://github.com/grafana/alloy/blob/v1.10.1/.github/workflows/test_mac.yml#L32).

By the way, I came across an [interesting investigation](https://www.uber.com/en-GB/blog/fixing-gos-linker/) by Uber on a similar topic. If we ever need to go deeper in such issues, this could be an interesting read.