### PR TITLE
Fix docs description for probabilistic sampler

### DIFF
--- a/docs/sources/reference/components/otelcol/otelcol.processor.probabilistic_sampler.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.probabilistic_sampler.md
@@ -2,7 +2,7 @@
 canonical: https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.processor.probabilistic_sampler/
 aliases:
   - ../otelcol.processor.probabilistic_sampler/ # /docs/alloy/latest/reference/otelcol.processor.probabilistic_sampler/
-description: Learn about telcol.processor.probabilistic_sampler
+description: Learn about otelcol.processor.probabilistic_sampler
 labels:
   stage: general-availability
   products:


### PR DESCRIPTION
Noticed a missing character in a slack link expansion.