### PR TITLE
integration-tests: Always run down and use stable network name

### DIFF
--- a/internal/cmd/integration-tests/tests/unix/unix_metrics_test.go
+++ b/internal/cmd/integration-tests/tests/unix/unix_metrics_test.go
@@ -1,13 +1,14 @@
 package main
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/grafana/alloy/internal/cmd/integration-tests/common"
 )
 
 func TestUnixMetrics(t *testing.T) {
-	var unixMetrics = []string{
+	var expectedMetrics = []string{
 		"node_arp_entries",
 		"node_boot_time_seconds",
 		"node_context_switches_total",
@@ -43,11 +44,6 @@ func TestUnixMetrics(t *testing.T) {
 		"node_memory_CommitLimit_bytes",
 		"node_memory_Committed_AS_bytes",
 		"node_memory_Dirty_bytes",
-		"node_memory_HugePages_Free",
-		"node_memory_HugePages_Rsvd",
-		"node_memory_HugePages_Surp",
-		"node_memory_HugePages_Total",
-		"node_memory_Hugepagesize_bytes",
 		"node_memory_Inactive_anon_bytes",
 		"node_memory_Inactive_bytes",
 		"node_memory_Inactive_file_bytes",
@@ -154,5 +150,19 @@ func TestUnixMetrics(t *testing.T) {
 		"node_vmstat_pswpin",
 		"node_vmstat_pswpout",
 	}
-	common.MimirMetricsTest(t, unixMetrics, []string{}, "unix_metrics")
+
+	switch runtime.GOOS {
+	case "windows":
+		t.Skip("Skipping Unix metrics test on Windows")
+	// darwin does not support hugepages (aka super pages on mac), so we only add them for linux
+	case "linux":
+		expectedMetrics = append(expectedMetrics,
+			"node_memory_HugePages_Free",
+			"node_memory_HugePages_Rsvd",
+			"node_memory_HugePages_Surp",
+			"node_memory_HugePages_Total",
+			"node_memory_Hugepagesize_bytes")
+	}
+
+	common.MimirMetricsTest(t, expectedMetrics, []string{}, "unix_metrics")
 }


### PR DESCRIPTION
#### PR Description

Adjusts the way the integration tests are run so that we will still run down when a test fails, ensures that we will always use a stable docker compose network name, and adds some guards to the unix test so that it can still pass on mac + windows.

#### Notes to the Reviewer

Locally, the unix integration test failed because mac does not have huge page support. As soon as a test run fails you are required to take manual steps to be able to run the tests again because of the hard os.Exit on failure. Even if you cleanup the remaining docker containers you must manually remove the network or risk the network logic accidentally picking the old unused network resulting in really confusing errors like,

```
ts=2025-08-18T19:39:30.165204143Z level=warn msg="Failed to send batch, retrying" component_path=/ component_id=prometheus.remote_write.node_exporter subcomponent=rw remote_name=aa1415 url=http://mimir:9009/api/v1/push err="Post \"http://mimir:9009/api/v1/push\": dial tcp: lookup mimir on 127.0.0.11:53: no such host"
ts=2025-08-18T19:40:32.883688331Z level=warn msg="Failed to send batch, retrying" component_path=/ component_id=prometheus.remote_write.node_exporter subcomponent=rw remote_name=aa1415 url=http://mimir:9009/api/v1/push err="Post \"http://mimir:9009/api/v1/push\": dial tcp: lookup mimir on 127.0.0.11:53: no such host"
```

Making sure we always run down and use a stable network name should hopefully make any other problems a lot more obvious.