### PR TITLE
database_observability: refactor component config

### DIFF
--- a/docs/sources/reference/components/database_observability/database_observability.mysql.md
+++ b/docs/sources/reference/components/database_observability/database_observability.mysql.md
@@ -25,49 +25,51 @@ database_observability.mysql "<LABEL>" {
 
 You can use the following arguments with `database_observability.mysql`:
 
-| Name                               | Type                 | Description                                                                                    | Default | Required |
-|------------------------------------|----------------------|------------------------------------------------------------------------------------------------|---------|----------|
-| `data_source_name`                 | `secret`             | [Data Source Name][] for the MySQL server to connect to.                                       |         | yes      |
-| `forward_to`                       | `list(LogsReceiver)` | Where to forward log entries after processing.                                                 |         | yes      |
-| `collect_interval`                 | `duration`           | How frequently to collect information from database.                                           | `"1m"`  | no       |
-| `disable_collectors`               | `list(string)`       | A list of collectors to disable from the default set.                                          |         | no       |
-| `disable_query_redaction`          | `bool`               | Collect unredacted SQL query text including parameters.                                        | `false` | no       |
-| `enable_collectors`                | `list(string)`       | A list of collectors to enable on top of the default set.                                      |         | no       |
-| `explain_plan_collect_interval`    | `duration`           | How frequently to collect explain plan information from database.                              | `"1m"`  | no       |
-| `explain_plan_per_collect_ratio`   | `float`              | Ratio of explain plan queries to collect per collect interval.                                 | `1.0`   | no       |
-| `explain_plan_initial_lookback`    | `duration`           | How far back to look for explain plan queries on the first collection interval.                | `"24h"` | no       |
-| `explain_plan_exclude_schemas`     | `list(string)`       | List of schemas to exclude from explain plan collection.                                       |         | no       |
-| `locks_collect_interval`           | `duration`           | How frequently to collect locks information from database.                                     | `"30s"` | no       |
-| `locks_threshold`                  | `duration`           | Threshold for locks to be considered slow. If a lock exceeds this duration, it will be logged. | `"1s"`  | no       |
-| `setup_consumers_collect_interval` | `duration`           | How frequently to collect `performance_schema.setup_consumers` information from the database.    | `"1h"`  | no       |
-| `allow_update_performance_schema_settings` | `boolean`     | Whether to allow updates to `performance_schema` settings in any collector. | `false` | no |
-| `query_sample_auto_enable_setup_consumers` | `boolean`     | Whether to allow the `query_sample` collector to enable some specific `performance_schema.setup_consumers` settings. | `false` | no |
+| Name                                       | Type                 | Description                                                                 | Default | Required |
+|--------------------------------------------|----------------------|-----------------------------------------------------------------------------|---------|----------|
+| `data_source_name`                         | `secret`             | [Data Source Name][] for the MySQL server to connect to.                    |         | yes      |
+| `forward_to`                               | `list(LogsReceiver)` | Where to forward log entries after processing.                              |         | yes      |
+| `disable_collectors`                       | `list(string)`       | A list of collectors to disable from the default set.                       |         | no       |
+| `enable_collectors`                        | `list(string)`       | A list of collectors to enable on top of the default set.                   |         | no       |
+| `allow_update_performance_schema_settings` | `boolean`            | Whether to allow updates to `performance_schema` settings in any collector. | `false` | no       |
 
 The following collectors are configurable:
 
 | Name              | Description                                              | Enabled by default |
 |-------------------|----------------------------------------------------------|--------------------|
-| `query_tables`    | Collect query table information.                         | yes                |
-| `schema_table`    | Collect schemas and tables from `information_schema`.    | yes                |
-| `query_sample`    | Collect query samples.                                   | yes                |
+| `query_details`   | Collect queries information.                             | yes                |
+| `schema_details`  | Collect schemas and tables from `information_schema`.    | yes                |
+| `query_samples`   | Collect query samples.                                   | yes                |
 | `setup_consumers` | Collect enabled `performance_schema.setup_consumers`.    | yes                |
 | `locks`           | Collect queries that are waiting/blocking other queries. | no                 |
-| `explain_plan`    | Collect explain plan information.                        | no                 |
+| `explain_plans`   | Collect explain plans information.                       | no                 |
 
 ## Blocks
 
 You can use the following blocks with `database_observability.mysql`:
 
-| Block                              | Description                            | Required |
-|------------------------------------|----------------------------------------|----------|
-| [`cloud_provider`][cloud_provider] | Provide Cloud Provider information.    | no       |
-| `cloud_provider` > [`aws`][aws]    | Provide AWS database host information. | no       | 
+| Block                                | Description                                       | Required |
+|--------------------------------------|---------------------------------------------------|----------|
+| [`cloud_provider`][cloud_provider]   | Provide Cloud Provider information.               | no       |
+| `cloud_provider` > [`aws`][aws]      | Provide AWS database host information.            | no       |
+| [`setup_consumers`][setup_consumers] | Configure the `setup_consumers` collector.        | no       |
+| [`query_details`][query_details]     | Configure the queries collector.                  | no       |
+| [`schema_details`][schema_details]   | Configure the schema and table details collector. | no       |
+| [`explain_plans`][explain_plans]     | Configure the explain plans collector.            | no       |
+| [`locks`][locks]                     | Configure the locks collector.                    | no       |
+| [`query_samples`][query_samples]     | Configure the query samples collector.            | no       |
 
 The > symbol indicates deeper levels of nesting.
 For example, `cloud_provider` > `aws` refers to a `aws` block defined inside an `cloud_provider` block.
 
 [cloud_provider]: #cloud_provider
 [aws]: #aws
+[setup_consumers]: #setup_consumers
+[query_details]: #query_details
+[schema_details]: #schema_details
+[explain_plans]: #explain_plans
+[locks]: #locks
+[query_samples]: #query_samples
 
 ### `cloud_provider`
 
@@ -84,6 +86,52 @@ The `aws` block supplies the [ARN](https://docs.aws.amazon.com/IAM/latest/UserGu
 | Name  | Type     | Description                                             | Default | Required |
 |-------|----------|---------------------------------------------------------|---------|----------|
 | `arn` | `string` | The ARN associated with the database under observation. |         | yes      |
+
+### `setup_consumers`
+
+| Name               | Type       | Description                                                                                   | Default | Required |
+|--------------------|------------|-----------------------------------------------------------------------------------------------|---------|----------|
+| `collect_interval` | `duration` | How frequently to collect `performance_schema.setup_consumers` information from the database. | `"1h"`  | no       |
+
+### `query_details`
+
+| Name               | Type       | Description                                          | Default | Required |
+|--------------------|------------|------------------------------------------------------|---------|----------|
+| `collect_interval` | `duration` | How frequently to collect information from database. | `"1m"`  | no       |
+
+### `schema_details`
+
+| Name               | Type       | Description                                                           | Default | Required |
+|--------------------|------------|-----------------------------------------------------------------------|---------|----------|
+| `collect_interval` | `duration` | How frequently to collect information from database.                  | `"1m"`  | no       |
+| `cache_enabled`    | `boolean`  | Whether to enable caching of table definitions.                       | `true`  | no       |
+| `cache_size`       | `integer`  | Cache size.                                                           | `256`   | no       |
+| `cache_ttl`        | `duration` | Cache TTL.                                                            | `"10m"` | no       |
+
+### `explain_plans`
+
+| Name                | Type       | Description                                                                     | Default | Required |
+|---------------------|------------|---------------------------------------------------------------------------------|---------|----------|
+| `collect_interval`  | `duration` | How frequently to collect information from database.                            | `"1m"`  | no       |
+| `per_collect_ratio` | `float`    | Ratio of explain plan queries to collect per collect interval.                  | `1.0`   | no       |
+| `initial_lookback`  | `duration` | How far back to look for explain plan queries on the first collection interval. | `"24h"` | no       |
+| `explain_plan_exclude_schemas`     | `list(string)`       | List of schemas to exclude from explain plan collection.                                       |         | no       |
+
+### `locks`
+
+| Name               | Type       | Description                                                                                    | Default | Required |
+|--------------------|------------|------------------------------------------------------------------------------------------------|---------|----------|
+| `collect_interval` | `duration` | How frequently to collect information from database.                                           | `"1m"`  | no       |
+| `threshold`        | `duration` | Threshold for locks to be considered slow. Locks that exceed this duration are logged. | `"1s"`  | no       |
+
+### `query_samples`
+
+| Name                             | Type       | Description                                                                    | Default | Required |
+|----------------------------------|------------|--------------------------------------------------------------------------------|---------|----------|
+| `collect_interval`               | `duration` | How frequently to collect information from database.                           | `"1m"`  | no       |
+| `disable_query_redaction`        | `bool`     | Collect unredacted SQL query text including parameters.                        | `false` | no       |
+| `auto_enable_setup_consumers`    | `boolean`  | Whether to enable some specific `performance_schema.setup_consumers` settings. | `false` | no       |
+| `setup_consumers_check_interval` | `duration` | How frequently to check if `setup_consumers` are correctly enabled.            | `"1h"`  | no       |
 
 ## Example
 

--- a/docs/sources/reference/components/database_observability/database_observability.mysql.md
+++ b/docs/sources/reference/components/database_observability/database_observability.mysql.md
@@ -110,18 +110,18 @@ The `aws` block supplies the [ARN](https://docs.aws.amazon.com/IAM/latest/UserGu
 
 ### `explain_plans`
 
-| Name                | Type       | Description                                                                     | Default | Required |
-|---------------------|------------|---------------------------------------------------------------------------------|---------|----------|
-| `collect_interval`  | `duration` | How frequently to collect information from database.                            | `"1m"`  | no       |
-| `per_collect_ratio` | `float`    | Ratio of explain plan queries to collect per collect interval.                  | `1.0`   | no       |
-| `initial_lookback`  | `duration` | How far back to look for explain plan queries on the first collection interval. | `"24h"` | no       |
-| `explain_plan_exclude_schemas`     | `list(string)`       | List of schemas to exclude from explain plan collection.                                       |         | no       |
+| Name                           | Type           | Description                                                                     | Default | Required |
+| ------------------------------ | -------------- | ------------------------------------------------------------------------------- | ------- | -------- |
+| `collect_interval`             | `duration`     | How frequently to collect information from database.                            | `"1m"`  | no       |
+| `explain_plan_exclude_schemas` | `list(string)` | List of schemas to exclude from explain plan collection.                        |         | no       |
+| `initial_lookback`             | `duration`     | How far back to look for explain plan queries on the first collection interval. | `"24h"` | no       |
+| `per_collect_ratio`            | `float`        | Ratio of explain plan queries to collect per collect interval.                  | `1.0`   | no       |
 
 ### `locks`
 
-| Name               | Type       | Description                                                                                    | Default | Required |
-|--------------------|------------|------------------------------------------------------------------------------------------------|---------|----------|
-| `collect_interval` | `duration` | How frequently to collect information from database.                                           | `"1m"`  | no       |
+| Name               | Type       | Description                                                                            | Default | Required |
+| ------------------ | ---------- | -------------------------------------------------------------------------------------- | ------- | -------- |
+| `collect_interval` | `duration` | How frequently to collect information from database.                                   | `"1m"`  | no       |
 | `threshold`        | `duration` | Threshold for locks to be considered slow. Locks that exceed this duration are logged. | `"1s"`  | no       |
 
 ### `query_samples`

--- a/docs/sources/reference/components/database_observability/database_observability.postgres.md
+++ b/docs/sources/reference/components/database_observability/database_observability.postgres.md
@@ -25,27 +25,51 @@ database_observability.postgres "<LABEL>" {
 
 You can use the following arguments with `database_observability.postgres`:
 
-| Name                               | Type                 | Description                                                                                    | Default | Required |
-|------------------------------------|----------------------|------------------------------------------------------------------------------------------------|---------|----------|
-| `data_source_name`                 | `secret`             | [Data Source Name][] for the Postgres server to connect to.                                    |         | yes      |
-| `forward_to`                       | `list(LogsReceiver)` | Where to forward log entries after processing.                                                 |         | yes      |
-| `collect_interval`                 | `duration`           | How frequently to collect information from database.                                           | `"1m"`  | no       |
-| `disable_collectors`               | `list(string)`       | A list of collectors to disable from the default set.                                          |         | no       |
-| `disable_query_redaction`          | `bool`               | Collect unredacted SQL query text including parameters.                                        | `false` | no       |
-| `enable_collectors`                | `list(string)`       | A list of collectors to enable on top of the default set.                                      |         | no       |
-| `query_sample_collect_interval`    | `duration`           | How frequently to collect query samples from database.                                         | `"15s"` | no       |
+| Name                 | Type                 | Description                                                 | Default | Required |
+|----------------------|----------------------|-------------------------------------------------------------|---------|----------|
+| `data_source_name`   | `secret`             | [Data Source Name][] for the Postgres server to connect to. |         | yes      |
+| `forward_to`         | `list(LogsReceiver)` | Where to forward log entries after processing.              |         | yes      |
+| `disable_collectors` | `list(string)`       | A list of collectors to disable from the default set.       |         | no       |
+| `enable_collectors`  | `list(string)`       | A list of collectors to enable on top of the default set.   |         | no       |
 
 The following collectors are configurable:
 
-| Name           | Description                                                                                             | Enabled by default |
-|----------------|---------------------------------------------------------------------------------------------------------|--------------------|
-| `query_sample` | Collect PostgreSQL activity information from pg_stat_activity, including query samples and wait events. | no                 |
-| `query_tables` | Collect query table information.                                                                        | no                 |
-| `schema_table` | Collect schemas, tables, and columns from PostgreSQL system catalogs.                                   | no                 |
+| Name             | Description                                                           | Enabled by default |
+|------------------|-----------------------------------------------------------------------|--------------------|
+| `query_details`  | Collect queries information.                                          | no                 |
+| `query_samples`  | Collect query samples and wait events information.                    | no                 |
+| `schema_details` | Collect schemas, tables, and columns from PostgreSQL system catalogs. | no                 |
 
 ## Blocks
 
-The `database_observability.postgres` component doesn't support any blocks. You can configure this component with arguments.
+You can use the following blocks with `database_observability.postgres`:
+
+| Block                              | Description                                       | Required |
+|------------------------------------|---------------------------------------------------|----------|
+| [`query_details`][query_details]   | Configure the queries collector.                  | no       |
+| [`query_samples`][query_samples]   | Configure the query samples collector.            | no       |
+| [`schema_details`][schema_details] | Configure the schema and table details collector. | no       |
+
+[query_details]: #query_details
+[query_samples]: #query_samples
+[schema_details]: #schema_details
+
+### `query_details`
+
+| Name               | Type       | Description                                          | Default | Required |
+|--------------------|------------|------------------------------------------------------|---------|----------|
+| `collect_interval` | `duration` | How frequently to collect information from database. | `"1m"`  | no       |
+
+### `query_samples`
+
+| Name                      | Type       | Description                                             | Default | Required |
+|---------------------------|------------|---------------------------------------------------------|---------|----------|
+| `collect_interval`        | `duration` | How frequently to collect information from database.    | `"15s"` | no       |
+| `disable_query_redaction` | `bool`     | Collect unredacted SQL query text including parameters. | `false` | no       |
+
+### `schema_details`
+
+This collector has no config options.
 
 ## Example
 
@@ -53,7 +77,7 @@ The `database_observability.postgres` component doesn't support any blocks. You 
 database_observability.postgres "orders_db" {
   data_source_name = "postgres://user:pass@localhost:5432/mydb"
   forward_to = [loki.write.logs_service.receiver]
-  enable_collectors = ["query_sample", "query_tables", "schema_table"]
+  enable_collectors = ["query_details", "query_samples", "schema_details"]
 }
 
 prometheus.scrape "orders_db" {

--- a/internal/component/database_observability/README.md
+++ b/internal/component/database_observability/README.md
@@ -100,14 +100,16 @@ and additionally enable these options:
 
 ```
 database_observability.mysql "mysql_<your_DB_name>" {
-  enable_collectors = ["query_sample"]
+  enable_collectors = ["query_samples"]
 
   // Global option to allow writing to performance_schema tables
   allow_update_performance_schema_settings = true
 
-  // Option to allow the `query_sample` collector to
+  // Option to allow the `query_samples` collector to
   // enable the 'events_statements_cpu' consumer
-  query_sample_auto_enable_setup_consumers = true
+  query_samples {
+    auto_enable_setup_consumers = true
+  }
 }
 ```
 
@@ -156,15 +158,16 @@ prometheus.exporter.mysql "integrations_mysqld_exporter_<your_DB_name>" {
 database_observability.mysql "mysql_<your_DB_name>" {
   data_source_name  = local.file.mysql_secret_<your_DB_name>.content
   forward_to        = [loki.relabel.database_observability_mysql_<your_DB_name>.receiver]
-  collect_interval  = "1m"
 
   // OPTIONAL: enable collecting samples of queries with their execution metrics. The sql text will be redacted to hide sensitive params.
-  enable_collectors = ["query_sample"]
+  enable_collectors = ["query_samples"]
 
-  // OPTIONAL: if `query_sample` collector is enabled, you can use
+  // OPTIONAL: if `query_samples` collector is enabled, you can use
   // the following setting to disable sql text redaction (by default
   // query samples are redacted).
-  disable_query_redaction = true
+  query_samples {
+    disable_query_redaction = true
+  }
 }
 
 loki.relabel "database_observability_mysql_<your_DB_name>" {
@@ -300,8 +303,7 @@ prometheus.exporter.mysql "integrations_mysqld_exporter_example_db_1" {
 database_observability.mysql "mysql_example_db_1" {
   data_source_name  = local.file.mysql_secret_example_db_1.content
   forward_to        = [loki.relabel.database_observability_mysql_example_db_1.receiver]
-  collect_interval  = "1m"
-  enable_collectors = ["query_sample"]
+  enable_collectors = ["query_samples"]
 }
 
 loki.relabel "database_observability_mysql_example_db_1" {
@@ -339,8 +341,7 @@ prometheus.exporter.mysql "integrations_mysqld_exporter_example_db_2" {
 database_observability.mysql "mysql_example_db_2" {
   data_source_name  = local.file.mysql_secret_example_db_2.content
   forward_to        = [loki.relabel.database_observability_mysql_example_db_2.receiver]
-  collect_interval  = "1m"
-  enable_collectors = ["query_sample"]
+  enable_collectors = ["query_samples"]
 }
 
 loki.relabel "database_observability_mysql_example_db_2" {
@@ -429,7 +430,6 @@ prometheus.exporter.postgres "integrations_postgres_exporter_<your_DB_name>" {
 database_observability.postgres "postgres_<your_DB_name>" {
   data_source_name  = local.file.postgres_secret_<your_DB_name>.content
   forward_to        = [loki.relabel.database_observability_postgres_<your_DB_name>.receiver]
-  collect_interval  = "1m"
 }
 
 loki.relabel "database_observability_postgres_<your_DB_name>" {

--- a/internal/component/database_observability/mysql/collector/explain_plan.go
+++ b/internal/component/database_observability/mysql/collector/explain_plan.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	OP_EXPLAIN_PLAN_OUTPUT = "explain_plan_output"
-	ExplainPlanName        = "explain_plan"
+	ExplainPlanName        = "explain_plans"
 )
 
 const selectDigestsForExplainPlan = `
@@ -476,7 +476,6 @@ var unrecoverableSQLCodes = []knownSQLCodes{
 
 type ExplainPlanArguments struct {
 	DB              *sql.DB
-	InstanceKey     string
 	ScrapeInterval  time.Duration
 	PerScrapeRatio  float64
 	ExcludeSchemas  []string

--- a/internal/component/database_observability/mysql/collector/explain_plan_test.go
+++ b/internal/component/database_observability/mysql/collector/explain_plan_test.go
@@ -1493,7 +1493,6 @@ func TestExplainPlan(t *testing.T) {
 		c, err := NewExplainPlan(ExplainPlanArguments{
 			DB:              db,
 			Logger:          log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout)),
-			InstanceKey:     "mysql-db",
 			ScrapeInterval:  time.Second,
 			PerScrapeRatio:  1,
 			EntryHandler:    lokiClient,
@@ -1562,7 +1561,6 @@ func TestExplainPlan(t *testing.T) {
 		c, err := NewExplainPlan(ExplainPlanArguments{
 			DB:              db,
 			Logger:          log.NewLogfmtLogger(log.NewSyncWriter(logBuffer)),
-			InstanceKey:     "mysql-db",
 			ScrapeInterval:  time.Second,
 			PerScrapeRatio:  1,
 			EntryHandler:    lokiClient,
@@ -1687,7 +1685,6 @@ func TestQueryFailureDenylist(t *testing.T) {
 	c, err := NewExplainPlan(ExplainPlanArguments{
 		DB:              db,
 		Logger:          log.NewLogfmtLogger(log.NewSyncWriter(logBuffer)),
-		InstanceKey:     "mysql-db",
 		ScrapeInterval:  time.Second,
 		PerScrapeRatio:  1,
 		EntryHandler:    lokiClient,
@@ -1777,7 +1774,6 @@ func TestSchemaDenylist(t *testing.T) {
 	c, err := NewExplainPlan(ExplainPlanArguments{
 		DB:              db,
 		Logger:          log.NewLogfmtLogger(log.NewSyncWriter(logBuffer)),
-		InstanceKey:     "mysql-db",
 		ScrapeInterval:  time.Second,
 		PerScrapeRatio:  1,
 		ExcludeSchemas:  []string{"some_schema"},

--- a/internal/component/database_observability/mysql/collector/query_sample.go
+++ b/internal/component/database_observability/mysql/collector/query_sample.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	QuerySampleName = "query_sample"
+	QuerySampleName = "query_samples"
 	OP_QUERY_SAMPLE = "query_sample"
 	OP_WAIT_EVENT   = "wait_event"
 
@@ -78,7 +78,6 @@ const updateSetupConsumers = `
 
 type QuerySampleArguments struct {
 	DB                          *sql.DB
-	InstanceKey                 string
 	CollectInterval             time.Duration
 	EntryHandler                loki.EntryHandler
 	DisableQueryRedaction       bool

--- a/internal/component/database_observability/mysql/collector/query_sample_test.go
+++ b/internal/component/database_observability/mysql/collector/query_sample_test.go
@@ -394,7 +394,6 @@ func TestQuerySample(t *testing.T) {
 
 			collector, err := NewQuerySample(QuerySampleArguments{
 				DB:              db,
-				InstanceKey:     "mysql-db",
 				CollectInterval: time.Second,
 				EntryHandler:    lokiClient,
 				Logger:          log.NewLogfmtLogger(os.Stderr),
@@ -491,7 +490,6 @@ func TestQuerySample_WaitEvents(t *testing.T) {
 
 		collector, err := NewQuerySample(QuerySampleArguments{
 			DB:              db,
-			InstanceKey:     "mysql-db",
 			CollectInterval: time.Second,
 			EntryHandler:    lokiClient,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
@@ -588,7 +586,6 @@ func TestQuerySample_WaitEvents(t *testing.T) {
 
 		collector, err := NewQuerySample(QuerySampleArguments{
 			DB:              db,
-			InstanceKey:     "mysql-db",
 			CollectInterval: time.Second,
 			EntryHandler:    lokiClient,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
@@ -760,7 +757,6 @@ func TestQuerySample_WaitEvents(t *testing.T) {
 
 		collector, err := NewQuerySample(QuerySampleArguments{
 			DB:              db,
-			InstanceKey:     "mysql-db",
 			CollectInterval: time.Second,
 			EntryHandler:    lokiClient,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
@@ -882,7 +878,6 @@ func TestQuerySample_WaitEvents(t *testing.T) {
 
 		collector, err := NewQuerySample(QuerySampleArguments{
 			DB:                    db,
-			InstanceKey:           "mysql-db",
 			CollectInterval:       time.Second,
 			EntryHandler:          lokiClient,
 			Logger:                log.NewLogfmtLogger(os.Stderr),
@@ -1001,7 +996,6 @@ func TestQuerySampleDisableQueryRedaction(t *testing.T) {
 
 		collector, err := NewQuerySample(QuerySampleArguments{
 			DB:                    db,
-			InstanceKey:           "mysql-db",
 			CollectInterval:       time.Second,
 			EntryHandler:          lokiClient,
 			Logger:                log.NewLogfmtLogger(os.Stderr),
@@ -1111,7 +1105,6 @@ func TestQuerySampleDisableQueryRedaction(t *testing.T) {
 
 		collector, err := NewQuerySample(QuerySampleArguments{
 			DB:                    db,
-			InstanceKey:           "mysql-db",
 			CollectInterval:       time.Second,
 			EntryHandler:          lokiClient,
 			Logger:                log.NewLogfmtLogger(os.Stderr),
@@ -1223,7 +1216,6 @@ func TestQuerySampleSQLDriverErrors(t *testing.T) {
 
 		collector, err := NewQuerySample(QuerySampleArguments{
 			DB:              db,
-			InstanceKey:     "mysql-db",
 			CollectInterval: time.Second,
 			EntryHandler:    lokiClient,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
@@ -1353,7 +1345,6 @@ func TestQuerySampleSQLDriverErrors(t *testing.T) {
 
 		collector, err := NewQuerySample(QuerySampleArguments{
 			DB:              db,
-			InstanceKey:     "mysql-db",
 			CollectInterval: time.Second,
 			EntryHandler:    lokiClient,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
@@ -1482,7 +1473,6 @@ func TestQuerySampleSQLDriverErrors(t *testing.T) {
 
 		collector, err := NewQuerySample(QuerySampleArguments{
 			DB:              db,
-			InstanceKey:     "mysql-db",
 			CollectInterval: time.Second,
 			EntryHandler:    lokiClient,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
@@ -1608,9 +1598,7 @@ func TestQuerySample_initializeTimer(t *testing.T) {
 			5,
 		))
 
-		c, err := NewQuerySample(QuerySampleArguments{
-			DB: db,
-		})
+		c, err := NewQuerySample(QuerySampleArguments{DB: db})
 		require.NoError(t, err)
 
 		require.NoError(t, c.initializeBookmark(t.Context()))
@@ -1629,9 +1617,7 @@ func TestQuerySample_initializeTimer(t *testing.T) {
 			picosecondsToSeconds(math.MaxUint64) + 5,
 		))
 
-		c, err := NewQuerySample(QuerySampleArguments{
-			DB: db,
-		})
+		c, err := NewQuerySample(QuerySampleArguments{DB: db})
 		require.NoError(t, err)
 
 		require.NoError(t, c.initializeBookmark(t.Context()))
@@ -2058,9 +2044,7 @@ func TestQuerySample_handles_timer_overflows(t *testing.T) {
 
 		mock.ExpectQuery(selectNowAndUptime).WithoutArgs().WillReturnError(fmt.Errorf("some error"))
 
-		c, err := NewQuerySample(QuerySampleArguments{
-			DB: db,
-		})
+		c, err := NewQuerySample(QuerySampleArguments{DB: db})
 		require.NoError(t, err)
 
 		err = c.fetchQuerySamples(t.Context())
@@ -2214,7 +2198,6 @@ func TestQuerySample_AutoEnableSetupConsumers(t *testing.T) {
 
 		collector, err := NewQuerySample(QuerySampleArguments{
 			DB:                          db,
-			InstanceKey:                 "mysql-db",
 			CollectInterval:             time.Second,
 			EntryHandler:                lokiClient,
 			Logger:                      log.NewLogfmtLogger(os.Stderr),
@@ -2325,7 +2308,6 @@ func TestQuerySample_AutoEnableSetupConsumers(t *testing.T) {
 
 		collector, err := NewQuerySample(QuerySampleArguments{
 			DB:                          db,
-			InstanceKey:                 "mysql-db",
 			CollectInterval:             time.Second,
 			EntryHandler:                lokiClient,
 			Logger:                      log.NewLogfmtLogger(os.Stderr),

--- a/internal/component/database_observability/mysql/collector/query_tables.go
+++ b/internal/component/database_observability/mysql/collector/query_tables.go
@@ -20,7 +20,7 @@ import (
 const (
 	OP_QUERY_ASSOCIATION       = "query_association"
 	OP_QUERY_PARSED_TABLE_NAME = "query_parsed_table_name"
-	QueryTablesName            = "query_tables"
+	QueryTablesName            = "query_details"
 )
 
 const selectQueryTablesSamples = `
@@ -35,7 +35,6 @@ const selectQueryTablesSamples = `
 
 type QueryTablesArguments struct {
 	DB              *sql.DB
-	InstanceKey     string
 	CollectInterval time.Duration
 	EntryHandler    loki.EntryHandler
 

--- a/internal/component/database_observability/mysql/collector/query_tables_test.go
+++ b/internal/component/database_observability/mysql/collector/query_tables_test.go
@@ -371,7 +371,6 @@ func TestQueryTables(t *testing.T) {
 
 			collector, err := NewQueryTables(QueryTablesArguments{
 				DB:              db,
-				InstanceKey:     "mysql-db",
 				CollectInterval: time.Second,
 				EntryHandler:    lokiClient,
 				Logger:          log.NewLogfmtLogger(os.Stderr),
@@ -432,7 +431,6 @@ func TestQueryTablesSQLDriverErrors(t *testing.T) {
 
 		collector, err := NewQueryTables(QueryTablesArguments{
 			DB:              db,
-			InstanceKey:     "mysql-db",
 			CollectInterval: time.Second,
 			EntryHandler:    lokiClient,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
@@ -498,7 +496,6 @@ func TestQueryTablesSQLDriverErrors(t *testing.T) {
 
 		collector, err := NewQueryTables(QueryTablesArguments{
 			DB:              db,
-			InstanceKey:     "mysql-db",
 			CollectInterval: time.Second,
 			EntryHandler:    lokiClient,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
@@ -561,7 +558,6 @@ func TestQueryTablesSQLDriverErrors(t *testing.T) {
 
 		collector, err := NewQueryTables(QueryTablesArguments{
 			DB:              db,
-			InstanceKey:     "mysql-db",
 			CollectInterval: time.Second,
 			EntryHandler:    lokiClient,
 			Logger:          log.NewLogfmtLogger(os.Stderr),

--- a/internal/component/database_observability/mysql/collector/schema_table.go
+++ b/internal/component/database_observability/mysql/collector/schema_table.go
@@ -23,7 +23,7 @@ const (
 	OP_SCHEMA_DETECTION = "schema_detection"
 	OP_TABLE_DETECTION  = "table_detection"
 	OP_CREATE_STATEMENT = "create_statement"
-	SchemaTableName     = "schema_table"
+	SchemaTableName     = "schema_details"
 )
 
 const (

--- a/internal/component/database_observability/mysql/component.go
+++ b/internal/component/database_observability/mysql/component.go
@@ -54,31 +54,18 @@ var (
 
 type Arguments struct {
 	DataSourceName                alloytypes.Secret   `alloy:"data_source_name,attr"`
-	CollectInterval               time.Duration       `alloy:"collect_interval,attr,optional"`
 	ForwardTo                     []loki.LogsReceiver `alloy:"forward_to,attr"`
 	EnableCollectors              []string            `alloy:"enable_collectors,attr,optional"`
 	DisableCollectors             []string            `alloy:"disable_collectors,attr,optional"`
 	AllowUpdatePerfSchemaSettings bool                `alloy:"allow_update_performance_schema_settings,attr,optional"`
 
-	// collector: 'setup_consumers'
-	SetupConsumersCollectInterval time.Duration `alloy:"setup_consumers_collect_interval,attr,optional"`
-
-	// collector: 'explain_plan'
-	ExplainPlanCollectInterval time.Duration `alloy:"explain_plan_collect_interval,attr,optional"`
-	ExplainPlanPerCollectRatio float64       `alloy:"explain_plan_per_collect_ratio,attr,optional"`
-	ExplainPlanInitialLookback time.Duration `alloy:"explain_plan_initial_lookback,attr,optional"`
-	ExplainPlanExcludeSchemas  []string      `alloy:"explain_plan_exclude_schemas,attr,optional"`
-
-	// collector: 'locks'
-	LocksCollectInterval time.Duration `alloy:"locks_collect_interval,attr,optional"`
-	LocksThreshold       time.Duration `alloy:"locks_threshold,attr,optional"`
-
-	// collector: 'query_sample'
-	DisableQueryRedaction                  bool          `alloy:"disable_query_redaction,attr,optional"`
-	AutoEnableSetupConsumers               bool          `alloy:"query_sample_auto_enable_setup_consumers,attr,optional"`
-	QuerySampleSetupConsumersCheckInterval time.Duration `alloy:"query_sample_setup_consumers_check_interval,attr,optional"`
-
-	CloudProvider *CloudProvider `alloy:"cloud_provider,block,optional"`
+	CloudProvider           *CloudProvider          `alloy:"cloud_provider,block,optional"`
+	SetupConsumersArguments SetupConsumersArguments `alloy:"setup_consumers,block,optional"`
+	QueryTablesArguments    QueryTablesArguments    `alloy:"query_details,block,optional"`
+	SchemaTableArguments    SchemaTableArguments    `alloy:"schema_details,block,optional"`
+	ExplainPlanArguments    ExplainPlanArguments    `alloy:"explain_plans,block,optional"`
+	LocksArguments          LocksArguments          `alloy:"locks,block,optional"`
+	QuerySampleArguments    QuerySampleArguments    `alloy:"query_samples,block,optional"`
 }
 
 type CloudProvider struct {
@@ -89,26 +76,75 @@ type AWSCloudProviderInfo struct {
 	ARN string `alloy:"arn,attr"`
 }
 
+type QueryTablesArguments struct {
+	CollectInterval time.Duration `alloy:"collect_interval,attr,optional"`
+}
+
+type SchemaTableArguments struct {
+	CollectInterval time.Duration `alloy:"collect_interval,attr,optional"`
+	CacheEnabled    bool          `alloy:"cache_enabled,attr,optional"`
+	CacheSize       int           `alloy:"cache_size,attr,optional"`
+	CacheTTL        time.Duration `alloy:"cache_ttl,attr,optional"`
+}
+
+type SetupConsumersArguments struct {
+	CollectInterval time.Duration `alloy:"collect_interval,attr,optional"`
+}
+
+type ExplainPlanArguments struct {
+	CollectInterval           time.Duration `alloy:"collect_interval,attr,optional"`
+	PerCollectRatio           float64       `alloy:"per_collect_ratio,attr,optional"`
+	InitialLookback           time.Duration `alloy:"initial_lookback,attr,optional"`
+	ExplainPlanExcludeSchemas []string      `alloy:"explain_plan_exclude_schemas,attr,optional"`
+}
+
+type LocksArguments struct {
+	CollectInterval time.Duration `alloy:"collect_interval,attr,optional"`
+	Threshold       time.Duration `alloy:"threshold,attr,optional"`
+}
+
+type QuerySampleArguments struct {
+	CollectInterval             time.Duration `alloy:"collect_interval,attr,optional"`
+	DisableQueryRedaction       bool          `alloy:"disable_query_redaction,attr,optional"`
+	AutoEnableSetupConsumers    bool          `alloy:"auto_enable_setup_consumers,attr,optional"`
+	SetupConsumersCheckInterval time.Duration `alloy:"setup_consumers_check_interval,attr,optional"`
+}
+
 var DefaultArguments = Arguments{
-	CollectInterval:               1 * time.Minute,
 	AllowUpdatePerfSchemaSettings: false,
 
-	// collector: 'setup_consumers'
-	SetupConsumersCollectInterval: 1 * time.Hour,
+	QueryTablesArguments: QueryTablesArguments{
+		CollectInterval: 1 * time.Minute,
+	},
 
-	// collector: 'explain_plan'
-	ExplainPlanCollectInterval: 1 * time.Minute,
-	ExplainPlanPerCollectRatio: 1.0,
-	ExplainPlanInitialLookback: 24 * time.Hour,
+	SchemaTableArguments: SchemaTableArguments{
+		CollectInterval: 1 * time.Minute,
+		CacheEnabled:    true,
+		CacheSize:       256,
+		CacheTTL:        10 * time.Minute,
+	},
 
-	// collector: 'locks'
-	LocksCollectInterval: 30 * time.Second,
-	LocksThreshold:       1 * time.Second,
+	SetupConsumersArguments: SetupConsumersArguments{
+		CollectInterval: 1 * time.Hour,
+	},
 
-	// collector: 'query_sample'
-	DisableQueryRedaction:                  false,
-	AutoEnableSetupConsumers:               false,
-	QuerySampleSetupConsumersCheckInterval: 1 * time.Hour,
+	ExplainPlanArguments: ExplainPlanArguments{
+		CollectInterval: 1 * time.Minute,
+		PerCollectRatio: 1.0,
+		InitialLookback: 24 * time.Hour,
+	},
+
+	LocksArguments: LocksArguments{
+		CollectInterval: 30 * time.Second,
+		Threshold:       1 * time.Second,
+	},
+
+	QuerySampleArguments: QuerySampleArguments{
+		CollectInterval:             1 * time.Minute,
+		DisableQueryRedaction:       false,
+		AutoEnableSetupConsumers:    false,
+		SetupConsumersCheckInterval: 1 * time.Hour,
+	},
 }
 
 func (a *Arguments) SetToDefault() {
@@ -327,7 +363,7 @@ func (c *Component) startCollectors() error {
 	if collectors[collector.QueryTablesName] {
 		qtCollector, err := collector.NewQueryTables(collector.QueryTablesArguments{
 			DB:              dbConnection,
-			CollectInterval: c.args.CollectInterval,
+			CollectInterval: c.args.QueryTablesArguments.CollectInterval,
 			EntryHandler:    entryHandler,
 			Logger:          c.opts.Logger,
 		})
@@ -345,14 +381,13 @@ func (c *Component) startCollectors() error {
 	if collectors[collector.SchemaTableName] {
 		stCollector, err := collector.NewSchemaTable(collector.SchemaTableArguments{
 			DB:              dbConnection,
-			CollectInterval: c.args.CollectInterval,
-			EntryHandler:    entryHandler,
-			Logger:          c.opts.Logger,
+			CollectInterval: c.args.SchemaTableArguments.CollectInterval,
+			CacheEnabled:    c.args.SchemaTableArguments.CacheEnabled,
+			CacheSize:       c.args.SchemaTableArguments.CacheSize,
+			CacheTTL:        c.args.SchemaTableArguments.CacheTTL,
 
-			// TODO(cristian): make these configurable
-			CacheEnabled: true,
-			CacheSize:    256,
-			CacheTTL:     10 * time.Minute,
+			EntryHandler: entryHandler,
+			Logger:       c.opts.Logger,
 		})
 		if err != nil {
 			level.Error(c.opts.Logger).Log("msg", "failed to create SchemaTable collector", "err", err)
@@ -368,12 +403,12 @@ func (c *Component) startCollectors() error {
 	if collectors[collector.QuerySampleName] {
 		qsCollector, err := collector.NewQuerySample(collector.QuerySampleArguments{
 			DB:                          dbConnection,
-			CollectInterval:             c.args.CollectInterval,
+			CollectInterval:             c.args.QuerySampleArguments.CollectInterval,
 			EntryHandler:                entryHandler,
 			Logger:                      c.opts.Logger,
-			DisableQueryRedaction:       c.args.DisableQueryRedaction,
-			AutoEnableSetupConsumers:    c.args.AllowUpdatePerfSchemaSettings && c.args.AutoEnableSetupConsumers,
-			SetupConsumersCheckInterval: c.args.QuerySampleSetupConsumersCheckInterval,
+			DisableQueryRedaction:       c.args.QuerySampleArguments.DisableQueryRedaction,
+			AutoEnableSetupConsumers:    c.args.AllowUpdatePerfSchemaSettings && c.args.QuerySampleArguments.AutoEnableSetupConsumers,
+			SetupConsumersCheckInterval: c.args.QuerySampleArguments.SetupConsumersCheckInterval,
 		})
 		if err != nil {
 			level.Error(c.opts.Logger).Log("msg", "failed to create QuerySample collector", "err", err)
@@ -391,7 +426,7 @@ func (c *Component) startCollectors() error {
 			DB:              dbConnection,
 			Registry:        c.registry,
 			Logger:          c.opts.Logger,
-			CollectInterval: c.args.SetupConsumersCollectInterval,
+			CollectInterval: c.args.SetupConsumersArguments.CollectInterval,
 		})
 		if err != nil {
 			level.Error(c.opts.Logger).Log("msg", "failed to create SetupConsumer collector", "err", err)
@@ -407,8 +442,8 @@ func (c *Component) startCollectors() error {
 	if collectors[collector.LocksName] {
 		locksCollector, err := collector.NewLock(collector.LockArguments{
 			DB:                dbConnection,
-			CollectInterval:   c.args.LocksCollectInterval,
-			LockWaitThreshold: c.args.LocksThreshold,
+			CollectInterval:   c.args.LocksArguments.CollectInterval,
+			LockWaitThreshold: c.args.LocksArguments.Threshold,
 			Logger:            c.opts.Logger,
 			EntryHandler:      entryHandler,
 		})
@@ -426,13 +461,12 @@ func (c *Component) startCollectors() error {
 	if collectors[collector.ExplainPlanName] {
 		epCollector, err := collector.NewExplainPlan(collector.ExplainPlanArguments{
 			DB:              dbConnection,
-			ScrapeInterval:  c.args.ExplainPlanCollectInterval,
-			PerScrapeRatio:  c.args.ExplainPlanPerCollectRatio,
-			ExcludeSchemas:  c.args.ExplainPlanExcludeSchemas,
+			ScrapeInterval:  c.args.ExplainPlanArguments.CollectInterval,
+			PerScrapeRatio:  c.args.ExplainPlanArguments.PerCollectRatio,
 			Logger:          c.opts.Logger,
 			DBVersion:       engineVersion,
 			EntryHandler:    entryHandler,
-			InitialLookback: time.Now().Add(-c.args.ExplainPlanInitialLookback),
+			InitialLookback: time.Now().Add(-c.args.ExplainPlanArguments.InitialLookback),
 		})
 		if err != nil {
 			level.Error(c.opts.Logger).Log("msg", "failed to create ExplainPlan collector", "err", err)

--- a/internal/component/database_observability/mysql/component_test.go
+++ b/internal/component/database_observability/mysql/component_test.go
@@ -23,14 +23,16 @@ func Test_collectSQLText(t *testing.T) {
 		exampleDBO11yAlloyConfig := `
 		data_source_name = ""
 		forward_to = []
-		disable_query_redaction = true
+		query_samples {
+			disable_query_redaction = true
+		}
 	`
 
 		var args Arguments
 		err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
 		require.NoError(t, err)
 
-		assert.True(t, args.DisableQueryRedaction)
+		assert.True(t, args.QuerySampleArguments.DisableQueryRedaction)
 	})
 
 	t.Run("disable sql text when not provided (default behavior)", func(t *testing.T) {
@@ -45,7 +47,7 @@ func Test_collectSQLText(t *testing.T) {
 		err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
 		require.NoError(t, err)
 
-		assert.False(t, args.DisableQueryRedaction)
+		assert.False(t, args.QuerySampleArguments.DisableQueryRedaction)
 	})
 
 	t.Run("setup consumers scrape interval is correctly parsed from config", func(t *testing.T) {
@@ -54,14 +56,16 @@ func Test_collectSQLText(t *testing.T) {
 		exampleDBO11yAlloyConfig := `
 		data_source_name = ""
 		forward_to = []
-		setup_consumers_collect_interval = "1h"
+		setup_consumers {
+			collect_interval = "1h"
+		}
 	`
 
 		var args Arguments
 		err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
 		require.NoError(t, err)
 
-		assert.Equal(t, time.Hour, args.SetupConsumersCollectInterval)
+		assert.Equal(t, time.Hour, args.SetupConsumersArguments.CollectInterval)
 	})
 }
 
@@ -130,7 +134,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 		exampleDBO11yAlloyConfig := `
 		data_source_name = ""
 		forward_to = []
-		enable_collectors = ["query_tables", "schema_table", "query_sample", "setup_consumers", "explain_plan", "locks"]
+		enable_collectors = ["query_details", "schema_details", "query_samples", "setup_consumers", "explain_plans", "locks"]
 	`
 
 		var args Arguments
@@ -153,7 +157,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 		exampleDBO11yAlloyConfig := `
 		data_source_name = ""
 		forward_to = []
-		disable_collectors = ["query_tables", "schema_table", "query_sample", "setup_consumers", "explain_plan"]
+		disable_collectors = ["query_details", "schema_details", "query_samples", "setup_consumers", "explain_plans"]
 	`
 
 		var args Arguments
@@ -176,8 +180,8 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 		exampleDBO11yAlloyConfig := `
 		data_source_name = ""
 		forward_to = []
-		disable_collectors = ["query_tables", "schema_table", "query_sample", "setup_consumers", "explain_plan", "locks"]
-		enable_collectors = ["query_tables", "schema_table", "query_sample", "setup_consumers", "explain_plan", "locks"]
+		disable_collectors = ["query_details", "schema_details", "query_samples", "setup_consumers", "explain_plans", "locks"]
+		enable_collectors = ["query_details", "schema_details", "query_samples", "setup_consumers", "explain_plans", "locks"]
 	`
 
 		var args Arguments
@@ -200,8 +204,8 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 		exampleDBO11yAlloyConfig := `
 		data_source_name = ""
 		forward_to = []
-		disable_collectors = ["schema_table", "query_sample", "setup_consumers", "explain_plan", "locks"]
-		enable_collectors = ["query_tables"]
+		disable_collectors = ["schema_details", "query_samples", "setup_consumers", "explain_plans", "locks"]
+		enable_collectors = ["query_details"]
 	`
 
 		var args Arguments

--- a/internal/component/database_observability/mysql/component_test.go
+++ b/internal/component/database_observability/mysql/component_test.go
@@ -76,7 +76,6 @@ func Test_parseCloudProvider(t *testing.T) {
 		exampleDBO11yAlloyConfig := `
 		data_source_name = ""
 		forward_to = []
-		disable_query_redaction = true
 		cloud_provider {
 			aws {
 				arn = "arn:aws:rds:some-region:some-account:db:some-db-instance"
@@ -96,7 +95,6 @@ func Test_parseCloudProvider(t *testing.T) {
 		exampleDBO11yAlloyConfig := `
 		data_source_name = ""
 		forward_to = []
-		disable_query_redaction = true
 	`
 
 		var args Arguments

--- a/internal/component/database_observability/postgres/collector/query_sample.go
+++ b/internal/component/database_observability/postgres/collector/query_sample.go
@@ -19,7 +19,7 @@ import (
 const (
 	OP_QUERY_SAMPLE = "query_sample"
 	OP_WAIT_EVENT   = "wait_event"
-	QuerySampleName = "query_sample"
+	QuerySampleName = "query_samples"
 )
 
 const selectPgStatActivity = `

--- a/internal/component/database_observability/postgres/collector/query_tables.go
+++ b/internal/component/database_observability/postgres/collector/query_tables.go
@@ -19,7 +19,7 @@ import (
 const (
 	OP_QUERY_ASSOCIATION       = "query_association"
 	OP_QUERY_PARSED_TABLE_NAME = "query_parsed_table_name"
-	QueryTablesName            = "query_tables"
+	QueryTablesName            = "query_details"
 )
 
 var selectQueriesFromActivity = `
@@ -43,7 +43,6 @@ var selectQueriesFromActivity = `
 
 type QueryTablesArguments struct {
 	DB              *sql.DB
-	InstanceKey     string
 	CollectInterval time.Duration
 	EntryHandler    loki.EntryHandler
 

--- a/internal/component/database_observability/postgres/collector/query_tables_test.go
+++ b/internal/component/database_observability/postgres/collector/query_tables_test.go
@@ -338,7 +338,6 @@ func TestQueryTables(t *testing.T) {
 
 			collector, err := NewQueryTables(QueryTablesArguments{
 				DB:              db,
-				InstanceKey:     "postgres-db",
 				CollectInterval: time.Second,
 				EntryHandler:    lokiClient,
 				Logger:          log.NewLogfmtLogger(os.Stderr),
@@ -398,7 +397,6 @@ func TestQueryTablesSQLDriverErrors(t *testing.T) {
 
 		collector, err := NewQueryTables(QueryTablesArguments{
 			DB:              db,
-			InstanceKey:     "postgres-db",
 			CollectInterval: time.Second,
 			EntryHandler:    lokiClient,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
@@ -462,7 +460,6 @@ func TestQueryTablesSQLDriverErrors(t *testing.T) {
 
 		collector, err := NewQueryTables(QueryTablesArguments{
 			DB:              db,
-			InstanceKey:     "postgres-db",
 			CollectInterval: time.Second,
 			EntryHandler:    lokiClient,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
@@ -522,7 +519,6 @@ func TestQueryTablesSQLDriverErrors(t *testing.T) {
 
 		collector, err := NewQueryTables(QueryTablesArguments{
 			DB:              db,
-			InstanceKey:     "postgres-db",
 			CollectInterval: time.Second,
 			EntryHandler:    lokiClient,
 			Logger:          log.NewLogfmtLogger(os.Stderr),

--- a/internal/component/database_observability/postgres/collector/schema_table_test.go
+++ b/internal/component/database_observability/postgres/collector/schema_table_test.go
@@ -33,7 +33,6 @@ func TestSchemaTable(t *testing.T) {
 
 		collector, err := NewSchemaTable(SchemaTableArguments{
 			DB:           db,
-			InstanceKey:  "postgres-db",
 			EntryHandler: lokiClient,
 			Logger:       log.NewLogfmtLogger(os.Stderr),
 		})
@@ -112,7 +111,6 @@ func TestSchemaTable(t *testing.T) {
 
 		collector, err := NewSchemaTable(SchemaTableArguments{
 			DB:           db,
-			InstanceKey:  "postgres-db",
 			EntryHandler: lokiClient,
 			Logger:       log.NewLogfmtLogger(os.Stderr),
 		})
@@ -236,7 +234,6 @@ func TestSchemaTable(t *testing.T) {
 
 		collector, err := NewSchemaTable(SchemaTableArguments{
 			DB:           db,
-			InstanceKey:  "postgres-db",
 			EntryHandler: lokiClient,
 			Logger:       log.NewLogfmtLogger(os.Stderr),
 		})
@@ -287,7 +284,6 @@ func TestSchemaTable(t *testing.T) {
 
 		collector, err := NewSchemaTable(SchemaTableArguments{
 			DB:           db,
-			InstanceKey:  "postgres-db",
 			EntryHandler: lokiClient,
 			Logger:       log.NewLogfmtLogger(os.Stderr),
 		})
@@ -370,7 +366,6 @@ func Test_collector_detects_auto_increment_column(t *testing.T) {
 
 		collector, err := NewSchemaTable(SchemaTableArguments{
 			DB:           db,
-			InstanceKey:  "postgres-db",
 			EntryHandler: lokiClient,
 			Logger:       log.NewLogfmtLogger(os.Stderr),
 		})
@@ -448,7 +443,6 @@ func Test_collector_detects_auto_increment_column(t *testing.T) {
 
 		collector, err := NewSchemaTable(SchemaTableArguments{
 			DB:           db,
-			InstanceKey:  "postgres-db",
 			EntryHandler: lokiClient,
 			Logger:       log.NewLogfmtLogger(os.Stderr),
 		})

--- a/internal/component/database_observability/postgres/component_test.go
+++ b/internal/component/database_observability/postgres/component_test.go
@@ -142,7 +142,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 		exampleDBO11yAlloyConfig := `
 		data_source_name = "postgres://db"
 		forward_to = []
-		enable_collectors = ["schema_table"]
+		enable_collectors = ["schema_details"]
 	`
 
 		var args Arguments

--- a/internal/component/database_observability/postgres/component_test.go
+++ b/internal/component/database_observability/postgres/component_test.go
@@ -40,7 +40,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 		exampleDBO11yAlloyConfig := `
 		data_source_name = "postgres://db"
 		forward_to = []
-		enable_collectors = ["query_tables"]
+		enable_collectors = ["query_details"]
 	`
 
 		var args Arguments
@@ -60,7 +60,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 		exampleDBO11yAlloyConfig := `
 		data_source_name = "postgres://db"
 		forward_to = []
-		disable_collectors = ["query_tables"]
+		disable_collectors = ["query_details"]
 	`
 
 		var args Arguments
@@ -80,8 +80,8 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 		exampleDBO11yAlloyConfig := `
 		data_source_name = "postgres://db"
 		forward_to = []
-		disable_collectors = ["query_tables"]
-		enable_collectors = ["query_tables"]
+		disable_collectors = ["query_details"]
+		enable_collectors = ["query_details"]
 	`
 
 		var args Arguments
@@ -122,7 +122,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 		exampleDBO11yAlloyConfig := `
 		data_source_name = "postgres://db"
 		forward_to = []
-		enable_collectors = ["query_sample"]
+		enable_collectors = ["query_samples"]
 	`
 
 		var args Arguments
@@ -162,7 +162,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 		exampleDBO11yAlloyConfig := `
 		data_source_name = "postgres://db"
 		forward_to = []
-		enable_collectors = ["query_tables", "query_sample"]
+		enable_collectors = ["query_details", "query_samples"]
 	`
 
 		var args Arguments
@@ -182,7 +182,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 		exampleDBO11yAlloyConfig := `
 		data_source_name = "postgres://db"
 		forward_to = []
-		disable_collectors = ["query_sample"]
+		disable_collectors = ["query_samples"]
 	`
 
 		var args Arguments
@@ -204,41 +204,45 @@ func TestQueryRedactionConfig(t *testing.T) {
 		exampleDBO11yAlloyConfig := `
 		data_source_name = "postgres://db"
 		forward_to = []
-		enable_collectors = ["query_sample"]
+		enable_collectors = ["query_samples"]
 	`
 
 		var args Arguments
 		err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
 		require.NoError(t, err)
-		assert.False(t, args.DisableQueryRedaction, "query redaction should be enabled by default")
+		assert.False(t, args.QuerySampleArguments.DisableQueryRedaction, "query redaction should be enabled by default")
 	})
 
 	t.Run("explicitly disable query redaction", func(t *testing.T) {
 		exampleDBO11yAlloyConfig := `
 		data_source_name = "postgres://db"
 		forward_to = []
-		enable_collectors = ["query_sample"]
-		disable_query_redaction = true
+		enable_collectors = ["query_samples"]
+		query_samples {
+			disable_query_redaction = true
+		}
 	`
 
 		var args Arguments
 		err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
 		require.NoError(t, err)
-		assert.True(t, args.DisableQueryRedaction, "query redaction should be disabled when explicitly set")
+		assert.True(t, args.QuerySampleArguments.DisableQueryRedaction, "query redaction should be disabled when explicitly set")
 	})
 
 	t.Run("explicitly enable query redaction", func(t *testing.T) {
 		exampleDBO11yAlloyConfig := `
 		data_source_name = "postgres://db"
 		forward_to = []
-		enable_collectors = ["query_sample"]
-		disable_query_redaction = false
+		enable_collectors = ["query_samples"]
+		query_samples {
+			disable_query_redaction = false
+		}
 	`
 
 		var args Arguments
 		err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
 		require.NoError(t, err)
-		assert.False(t, args.DisableQueryRedaction, "query redaction should be enabled when explicitly set to false")
+		assert.False(t, args.QuerySampleArguments.DisableQueryRedaction, "query redaction should be enabled when explicitly set to false")
 	})
 }
 
@@ -252,51 +256,22 @@ func TestCollectionIntervals(t *testing.T) {
 		var args Arguments
 		err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
 		require.NoError(t, err)
-		assert.Equal(t, DefaultArguments.CollectInterval, args.CollectInterval, "collect_interval should default to 1 minute")
-		assert.Equal(t, DefaultArguments.QuerySampleCollectInterval, args.QuerySampleCollectInterval, "query_sample_collect_interval should default to 15 seconds")
+		assert.Equal(t, DefaultArguments.QuerySampleArguments.CollectInterval, args.QuerySampleArguments.CollectInterval, "collect_interval for query_samples should default to 15 seconds")
 	})
 
 	t.Run("custom intervals", func(t *testing.T) {
 		exampleDBO11yAlloyConfig := `
 		data_source_name = "postgres://db"
 		forward_to = []
-		collect_interval = "30s"
-		query_sample_collect_interval = "5s"
+		query_samples {
+			collect_interval = "5s"
+		}
 		`
 
 		var args Arguments
 		err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
 		require.NoError(t, err)
-		assert.Equal(t, 30*time.Second, args.CollectInterval, "collect_interval should be set to 30 seconds")
-		assert.Equal(t, 5*time.Second, args.QuerySampleCollectInterval, "query_sample_collect_interval should be set to 5 seconds")
-	})
-
-	t.Run("only collect_interval set", func(t *testing.T) {
-		exampleDBO11yAlloyConfig := `
-		data_source_name = "postgres://db"
-		forward_to = []
-		collect_interval = "30s"
-		`
-
-		var args Arguments
-		err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
-		require.NoError(t, err)
-		assert.Equal(t, 30*time.Second, args.CollectInterval, "collect_interval should be set to 30 seconds")
-		assert.Equal(t, DefaultArguments.QuerySampleCollectInterval, args.QuerySampleCollectInterval, "query_sample_collect_interval should default to 15 seconds")
-	})
-
-	t.Run("only query_sample_collect_interval set", func(t *testing.T) {
-		exampleDBO11yAlloyConfig := `
-		data_source_name = "postgres://db"
-		forward_to = []
-		query_sample_collect_interval = "5s"
-		`
-
-		var args Arguments
-		err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
-		require.NoError(t, err)
-		assert.Equal(t, DefaultArguments.CollectInterval, args.CollectInterval, "collect_interval should default to 1 minute")
-		assert.Equal(t, 5*time.Second, args.QuerySampleCollectInterval, "query_sample_collect_interval should be set to 5 seconds")
+		assert.Equal(t, 5*time.Second, args.QuerySampleArguments.CollectInterval, "collect_interval for query_samples should be set to 5 seconds")
 	})
 }
 


### PR DESCRIPTION
#### PR Description
This refactors the `database_observability.mysql` and `database_observability.postgres` components to use dedicated config blocks for their collectors (instead of having to prefix each option with the collector name, like in `query_sample_auto_enable_setup_consumers`).

Here we also remove `collect_interval` from the component and move it to each collector instead.

#### Which issue(s) this PR fixes
n.a.

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
