### PR TITLE
database_observability: extend auto-enable to wait consumers

### DIFF
--- a/internal/component/database_observability/mysql/collector/query_sample.go
+++ b/internal/component/database_observability/mysql/collector/query_sample.go
@@ -74,7 +74,7 @@ WHERE
 const updateSetupConsumers = `
 	UPDATE performance_schema.setup_consumers
 		SET enabled = 'yes'
-		WHERE name = 'events_statements_cpu'`
+		WHERE name in ('events_statements_cpu', 'events_waits_current', 'events_waits_history')`
 
 type QuerySampleArguments struct {
 	DB                          *sql.DB

--- a/internal/component/database_observability/mysql/collector/query_sample_test.go
+++ b/internal/component/database_observability/mysql/collector/query_sample_test.go
@@ -2238,7 +2238,7 @@ func TestQuerySample_AutoEnableSetupConsumers(t *testing.T) {
 				),
 			)
 
-		mock.ExpectExec(updateSetupConsumers).WithoutArgs().WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectExec(updateSetupConsumers).WithoutArgs().WillReturnResult(sqlmock.NewResult(0, 3))
 
 		mock.ExpectQuery(selectNowAndUptime).WithoutArgs().WillReturnRows(
 			sqlmock.NewRows([]string{


### PR DESCRIPTION
#### PR Description
In the mysql collector `query_sample`, extend the auto-enable functionality to also turn on `events_waits_{current,history}` consumers.

Followup of https://github.com/grafana/alloy/pull/3922

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer
No need to update changelog as the entry from previous PR is generic enough.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
