### PR TITLE
fix: remove orphaned wal directories when endpoint is removed from prometheus.write.queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,9 +119,13 @@ Main (unreleased)
 
 - Fix issue in prometheus remote_write WAL which could allow it to hold an active series forever. (@kgeckhart)
 
+<<<<<<< HEAD
 - Fix issue in static and promtail converter where metrics type was not properly handled. (@kalleep)
 
 - Fix `prometheus.operator.*` components to allow them to scrape correctly Prometheus Operator CRDs. (@thomas-gouveia)
+=======
+- Fix issue in `prometheus.write.queue` where wal directories left orphaned if endpoint was removed. (@kalleep)
+>>>>>>> cf2d1574e (update changelog)
 
 v1.10.2
 -----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,13 +119,9 @@ Main (unreleased)
 
 - Fix issue in prometheus remote_write WAL which could allow it to hold an active series forever. (@kgeckhart)
 
-<<<<<<< HEAD
 - Fix issue in static and promtail converter where metrics type was not properly handled. (@kalleep)
 
 - Fix `prometheus.operator.*` components to allow them to scrape correctly Prometheus Operator CRDs. (@thomas-gouveia)
-=======
-- Fix issue in `prometheus.write.queue` where wal directories left orphaned if endpoint was removed. (@kalleep)
->>>>>>> cf2d1574e (update changelog)
 
 v1.10.2
 -----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,8 @@ Main (unreleased)
 - (_Experimental_) Add an extra parameter to the `array.combine_maps` standard library function
   to enable preserving the first input list even if there is no match. (@ptodev)
 
+- `prometheus.write.queue` now remove wal dir if endpoint is removed. (@kalleep)
+
 ### Bugfixes
 
 - Update `webdevops/go-common` dependency to resolve concurrent map write panic. (@dehaansa)

--- a/internal/component/otelcol/auth/auth_test.go
+++ b/internal/component/otelcol/auth/auth_test.go
@@ -69,9 +69,12 @@ func newTestEnvironment(t *testing.T, onCreated func()) *testEnvironment {
 		},
 	}
 
+	ctrl, err := componenttest.NewControllerFromReg(util.TestLogger(t), reg)
+	require.NoError(t, err)
+
 	return &testEnvironment{
 		t:          t,
-		Controller: componenttest.NewControllerFromReg(util.TestLogger(t), reg),
+		Controller: ctrl,
 	}
 }
 

--- a/internal/component/otelcol/exporter/exporter_test.go
+++ b/internal/component/otelcol/exporter/exporter_test.go
@@ -108,9 +108,12 @@ func newTestEnvironment(t *testing.T, fe *fakeExporter) *testEnvironment {
 		},
 	}
 
+	ctrl, err := componenttest.NewControllerFromReg(util.TestLogger(t), reg)
+	require.NoError(t, err)
+
 	return &testEnvironment{
 		t:          t,
-		Controller: componenttest.NewControllerFromReg(util.TestLogger(t), reg),
+		Controller: ctrl,
 	}
 }
 

--- a/internal/component/otelcol/extension/extension_test.go
+++ b/internal/component/otelcol/extension/extension_test.go
@@ -65,9 +65,12 @@ func newTestEnvironment(t *testing.T, onCreated func()) *testEnvironment {
 		},
 	}
 
+	ctrl, err := componenttest.NewControllerFromReg(util.TestLogger(t), reg)
+	require.NoError(t, err)
+
 	return &testEnvironment{
 		t:          t,
-		Controller: componenttest.NewControllerFromReg(util.TestLogger(t), reg),
+		Controller: ctrl,
 	}
 }
 

--- a/internal/component/otelcol/processor/processor_test.go
+++ b/internal/component/otelcol/processor/processor_test.go
@@ -136,9 +136,12 @@ func newTestEnvironment(
 		},
 	}
 
+	ctrl, err := componenttest.NewControllerFromReg(util.TestLogger(t), reg)
+	require.NoError(t, err)
+
 	return &testEnvironment{
 		t:          t,
-		Controller: componenttest.NewControllerFromReg(util.TestLogger(t), reg),
+		Controller: ctrl,
 	}
 }
 

--- a/internal/component/otelcol/receiver/receiver_test.go
+++ b/internal/component/otelcol/receiver/receiver_test.go
@@ -161,9 +161,12 @@ func newTestEnvironment(t *testing.T, onTracesConsumer func(t otelconsumer.Trace
 		},
 	}
 
+	ctrl, err := componenttest.NewControllerFromReg(util.TestLogger(t), reg)
+	require.NoError(t, err)
+
 	return &testEnvironment{
 		t:          t,
-		Controller: componenttest.NewControllerFromReg(util.TestLogger(t), reg),
+		Controller: ctrl,
 	}
 }
 

--- a/internal/component/prometheus/write/queue/component.go
+++ b/internal/component/prometheus/write/queue/component.go
@@ -159,7 +159,7 @@ func (s *Queue) cleanupOrphanedEndpoints() error {
 			continue
 		}
 
-		// We asume that all directories within the data path for this component contains
+		// We assume that all directories within the data path for this component contains
 		// wal dir and we should clean them up.
 		if _, ok := s.endpoints[e.Name()]; !ok {
 			orphaned[e.Name()] = struct{}{}

--- a/internal/component/prometheus/write/queue/component_test.go
+++ b/internal/component/prometheus/write/queue/component_test.go
@@ -1,0 +1,72 @@
+package queue
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/internal/runtime/componenttest"
+	"github.com/grafana/alloy/internal/runtime/logging"
+	"github.com/grafana/alloy/syntax"
+)
+
+func TestWalCleanup(t *testing.T) {
+	var args Arguments
+	err := syntax.Unmarshal([]byte(`
+		endpoint "first" {
+			url = "http://localhost:9009/api/v1/push"
+		}
+		endpoint "second" {
+			url = "http://localhost:9009/api/v1/push"
+		}
+		endpoint "third" {
+			url = "http://localhost:9009/api/v1/push"
+		}
+
+	`), &args)
+	require.NoError(t, err)
+
+	ctrl, err := componenttest.NewControllerFromID(logging.NewNop(), "prometheus.write.queue")
+	require.NoError(t, err)
+
+	go func() {
+		require.NoError(t, ctrl.Run(componenttest.TestContext(t), args))
+	}()
+
+	ctrl.WaitRunning(5 * time.Second)
+
+	verifyWalDirs(t, ctrl.DataPath(), []string{"first", "second", "third"})
+	err = syntax.Unmarshal([]byte(`
+		endpoint "first" {
+			url = "http://localhost:9009/api/v1/push"
+		}
+		endpoint "third" {
+			url = "http://localhost:9009/api/v1/push"
+		}
+
+	`), &args)
+	require.NoError(t, err)
+
+	ctrl.Update(args)
+
+	verifyWalDirs(t, ctrl.DataPath(), []string{"first", "third"})
+}
+
+func verifyWalDirs(t *testing.T, path string, expected []string) {
+	t.Helper()
+
+	entries, err := os.ReadDir(path)
+	require.NoError(t, err)
+
+	found := map[string]bool{}
+	for _, e := range entries {
+		found[e.Name()] = true
+	}
+
+	require.Len(t, found, len(expected))
+	for _, e := range expected {
+		require.True(t, found[e])
+	}
+}


### PR DESCRIPTION
#### PR Description
When endpoints are removed from the configuration we should remove the directories associated with them. This pr also handles scanning for orphaned wal dirs if config is changed during downtime of alloy.

#### Which issue(s) this PR fixes

fixes: #4095

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
