### PR TITLE
Expand the details about how local.file_match functions

### DIFF
--- a/docs/sources/reference/components/local/local.file_match.md
+++ b/docs/sources/reference/components/local/local.file_match.md
@@ -31,18 +31,31 @@ You can use the following arguments with `local.file_match`:
 | Name                | Type                | Description                                                                                | Default | Required |
 |---------------------|---------------------|--------------------------------------------------------------------------------------------|---------|----------|
 | `path_targets`      | `list(map(string))` | Targets to expand; looks for glob patterns on the  `__path__` and `__path_exclude__` keys. |         | yes      |
-| `ignore_older_than` | `duration`          | Ignores files which are modified before this duration.                                     | `"0s"`  | no       |
+| `ignore_older_than` | `duration`          | Ignores files with modification times before this duration.                                | `"0s"`  | no       |
 | `sync_period`       | `duration`          | How often to sync filesystem and targets.                                                  | `"10s"` | no       |
 
-`path_targets` uses [doublestar][] style paths.
+### `path_targets` structure
+
+Each target in `path_targets` is a map that can contain the following keys:
+
+| Key                | Description                                                                                         | Required |
+| ------------------ | --------------------------------------------------------------------------------------------------- | -------- |
+| `__path__`         | [doublestar][] glob pattern specifying which files to discover.                                     | Yes      |
+| `__path_exclude__` | [doublestar][] glob pattern specifying which files to exclude from the `__path__` matches.          | No       |
+| *additional keys*  | Any other labels to attach to discovered files. The component preserves these labels in the exported targets. | No       |
+
+The `__path__` field uses [doublestar][] style glob patterns:
 
 * `/tmp/**/*.log` matches all subdirectories of `tmp` and include any files that end in `*.log`.
 * `/tmp/apache/*.log` matches only files in `/tmp/apache/` that end in `*.log`.
 * `/tmp/**` matches all subdirectories of `tmp`, `tmp` itself, and all files.
 
-`local.file_match` doesn't ignore files when `ignore_older_than` is set to the default, `0s`.
+`local.file_match` doesn't ignore files when you set `ignore_older_than` to the default, `0s`.
 
-When `__path_exclude__` is provided, any files matching the `__path__` pattern that also match the `__path_exclude__` pattern will be excluded from the exported list.
+When you provide `__path_exclude__`, the component excludes any files matching the `__path__` pattern that also match the `__path_exclude__` pattern from the exported list.
+
+The component preserves any additional labels you provide in the `path_targets` map and includes them in the exported targets alongside the discovered paths.
+This enables you to add metadata such as service names, instance identifiers, or other contextual information to the discovered files.
 
 ## Blocks
 
@@ -50,15 +63,16 @@ The `local.file_match` component doesn't support any blocks. You can configure t
 
 ## Exported fields
 
-The following fields are exported and can be referenced by other components:
+The following fields export and other components can reference them:
 
 | Name      | Type                | Description                                        |
 |-----------|---------------------|----------------------------------------------------|
 | `targets` | `list(map(string))` | The set of targets discovered from the filesystem. |
 
-Each target includes the following label:
+Each target includes the following labels:
 
-* `__path__`: Absolute path to the file.
+* `__path__`: Absolute path to the discovered file.
+* All additional labels from the corresponding entry in `path_targets` with original values preserved.
 
 ## Component health
 
@@ -80,7 +94,7 @@ The following examples show you how to use `local.file_match` to find and send l
 ### Send `/tmp/logs/*.log` files to Loki
 
 This example discovers all files and folders under `/tmp/logs` except for files in the `/tmp/logs/excluded` directory.
-The absolute paths are used by `loki.source.file.files` targets.
+`loki.source.file.files` targets use the absolute paths.
 
 ```alloy
 local.file_match "tmp" {
@@ -89,6 +103,57 @@ local.file_match "tmp" {
 
 loki.source.file "files" {
   targets    = local.file_match.tmp.targets
+  forward_to = [loki.write.endpoint.receiver]
+}
+
+loki.write "endpoint" {
+  endpoint {
+      url = <LOKI_URL>
+      basic_auth {
+          username = <USERNAME>
+          password = <PASSWORD>
+      }
+  }
+}
+```
+
+Replace the following:
+
+* _`<LOKI_URL>`_: The URL of the Loki server to send logs to.
+* _`<USERNAME>`_: The username to use for authentication to the Loki API.
+* _`<PASSWORD>`_: The password to use for authentication to the Loki API.
+
+### Send files with additional labels
+
+This example shows how to include additional labels with discovered files.
+The component preserves the additional labels in the exported targets and you can use them for filtering or enrichment.
+
+For example, the component attaches the additional labels `instance`, `job`, and `service` to each discovered file.
+Downstream components like `loki.source.file` can access these labels for processing and enrichment.
+
+```alloy
+local.file_match "labeled_logs" {
+  path_targets = [
+    {
+      "__path__"    = "/var/log/apache2/*.log",
+      "__address__" = "localhost",
+      "instance"    = "web-server-01", 
+      "job"         = "apache",
+      "service"     = "web"
+    },
+    {
+      "__path__"       = "/var/log/nginx/*.log",
+      "__path_exclude__" = "/var/log/nginx/*.gz",
+      "__address__"    = "localhost",
+      "instance"       = "web-server-01",
+      "job"            = "nginx", 
+      "service"        = "web"
+    }
+  ]
+}
+
+loki.source.file "web_logs" {
+  targets    = local.file_match.labeled_logs.targets
   forward_to = [loki.write.endpoint.receiver]
 }
 


### PR DESCRIPTION
#### PR Description

The `local.file_match` documentation lacks details about the `path_targets` work. It reference `doublestar` without providing any context or implementation examples

Changes:

* Add a new section about the `path_targets` structure.
* Clarify how this part of the component functions.
* Add a new example showing how to include additional labels with discovered files.

Additional doc tweaks:

* Other changes are for Vale/linting cleanup to reduce passive voice and improve readability.


#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
