### PR TITLE
test: remove tc.wait to fix redis integration tests init

### DIFF
--- a/internal/cmd/integration-tests/main.go
+++ b/internal/cmd/integration-tests/main.go
@@ -49,7 +49,7 @@ func runIntegrationTests(cmd *cobra.Command, args []string) {
 	ctx := cmd.Context()
 
 	fmt.Println("Start test containers with docker compose config")
-	if err = compose.Up(ctx, tc.Wait(true), tc.RemoveOrphans(true)); err != nil {
+	if err = compose.Up(ctx, tc.RemoveOrphans(true)); err != nil {
 		panic(fmt.Errorf("could not start the docker compose: %v", err))
 	}
 

--- a/internal/cmd/integration-tests/tests/redis/init_redis.sh
+++ b/internal/cmd/integration-tests/tests/redis/init_redis.sh
@@ -26,7 +26,3 @@ redis-cli -h redis -p 6379 -n 1 SET db1_key_2 "db1_value2" EX 1800
 echo "Redis test data populated successfully"
 echo "Keys in DB 0: $(redis-cli -h redis -p 6379 DBSIZE)"
 echo "Keys in DB 1: $(redis-cli -h redis -p 6379 -n 1 DBSIZE)"
-
-echo "Sleeping for 30 seconds to satisfy testcontainers"
-sleep 30
-echo "Existing redis-init container"

--- a/internal/cmd/integration-tests/tests/redis/init_redis.sh
+++ b/internal/cmd/integration-tests/tests/redis/init_redis.sh
@@ -26,3 +26,7 @@ redis-cli -h redis -p 6379 -n 1 SET db1_key_2 "db1_value2" EX 1800
 echo "Redis test data populated successfully"
 echo "Keys in DB 0: $(redis-cli -h redis -p 6379 DBSIZE)"
 echo "Keys in DB 1: $(redis-cli -h redis -p 6379 -n 1 DBSIZE)"
+
+echo "Sleeping for 30 seconds to satisfy testcontainers"
+sleep 30
+echo "Existing redis-init container"


### PR DESCRIPTION
Partially reverts a change that waits for all compose containers to be ready before allowing tests to continue.

I introduced a short-lived container which is incompatible with this change, so for now we will remove the `Wait` check until we add proper health checks (or similar).