### PR TITLE
Do not bail if Beyla terminates with an error

### DIFF
--- a/internal/component/beyla/ebpf/beyla_linux.go
+++ b/internal/component/beyla/ebpf/beyla_linux.go
@@ -550,9 +550,8 @@ func (c *Component) Run(ctx context.Context) error {
 				cancel()
 				level.Info(c.opts.Logger).Log("msg", "waiting for Beyla to terminate")
 				if err := cancelG.Wait(); err != nil {
-					level.Error(c.opts.Logger).Log("msg", "failed to terminate Beyla", "err", err)
+					level.Error(c.opts.Logger).Log("msg", "Beyla terminated with error", "err", err)
 					c.reportUnhealthy(err)
-					return err
 				}
 			}
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Beyla can sometimes terminate with an error. If that happens, we shouldn't bail, but instead allow the Alloy component to retry (since it's got a new config anyway). Oftentimes the error is just informative, such as "the instrumenter took too long to finalise and was forcefully aborted". 

If we allow an error to be returned here, Beyla will never ever be reloaded again, as the entire Component Run loop will go away.

#### Which issue(s) this PR fixes

Fixes https://github.com/grafana/fleet-management/issues/815

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
