### PR TITLE
pyroscope: Add ID field to RawSample for request ID propagation

### DIFF
--- a/internal/component/pyroscope/appender.go
+++ b/internal/component/pyroscope/appender.go
@@ -31,6 +31,7 @@ type Appender interface {
 }
 
 type RawSample struct {
+	ID string
 	// raw_profile is the set of bytes of the pprof profile
 	RawProfile []byte
 }

--- a/internal/component/pyroscope/receive_http/receive_http.go
+++ b/internal/component/pyroscope/receive_http/receive_http.go
@@ -151,6 +151,7 @@ func apiToAlloySamples(api []*pushv1.RawSample) []*pyroscope.RawSample {
 	)
 	for i := range alloy {
 		alloy[i] = &pyroscope.RawSample{
+			ID:         api[i].ID,
 			RawProfile: api[i].RawProfile,
 		}
 	}

--- a/internal/component/pyroscope/write/write.go
+++ b/internal/component/pyroscope/write/write.go
@@ -340,6 +340,7 @@ func (f *fanOutClient) Append(ctx context.Context, lbs labels.Labels, samples []
 	}
 	for _, sample := range samples {
 		protoSamples = append(protoSamples, &pushv1.RawSample{
+			ID:         sample.ID,
 			RawProfile: sample.RawProfile,
 		})
 	}


### PR DESCRIPTION
## Summary
- Add ID field to pyroscope.RawSample struct for request ID propagation across pyroscope components

## Changes
- Added ID field to RawSample struct in appender.go
- Updated receive_http component to pass ID field
- Updated write component to include ID field in protobuf samples

Co-Authored-By: Claude <noreply@anthropic.com>