### PR TITLE
pyroscope.write: add latency metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ Main (unreleased)
 
 - Fix `pyroscope.write` component's `AppendIngest` method to respect configured timeout and implement retry logic. The method now properly uses the configured `remote_timeout`, includes retry logic with exponential backoff, and tracks metrics for sent/dropped bytes and profiles consistently with the `Append` method. (@korniltsev)
 
+- Add comprehensive latency metrics to `pyroscope.write` component with endpoint-specific tracking for both push and ingest operations. (@korniltsev, @claude)
+
 - `prometheus.scrape` now supports `convert_classic_histograms_to_nhcb`, `enable_compression`, `metric_name_validation_scheme`, `metric_name_escaping_scheme`, `native_histogram_bucket_limit`, and `native_histogram_min_bucket_factor` arguments. See reference documentation for more details. (@thampiotr)
 
 - Add `max_send_message_size` configuration option to `loki.source.api` component to control the maximum size of requests to the push API. (@thampiotr)

--- a/docs/sources/reference/components/pyroscope/pyroscope.write.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.write.md
@@ -135,6 +135,28 @@ In those cases, exported fields are kept at their last healthy values.
 
 `pyroscope.write` doesn't expose any component-specific debug information.
 
+## Metrics
+
+`pyroscope.write` exposes the following metrics:
+
+| Metric                                | Type      | Description                                         |
+| ------------------------------------- | --------- | --------------------------------------------------- |
+| `pyroscope_write_sent_bytes_total`    | Counter   | Total number of compressed bytes sent to Pyroscope endpoints. |
+| `pyroscope_write_dropped_bytes_total` | Counter   | Total number of compressed bytes dropped by Pyroscope endpoints. |
+| `pyroscope_write_sent_profiles_total` | Counter   | Total number of profiles sent to Pyroscope endpoints. |
+| `pyroscope_write_dropped_profiles_total` | Counter | Total number of profiles dropped by Pyroscope endpoints. |
+| `pyroscope_write_retries_total`       | Counter   | Total number of retries to Pyroscope endpoints.    |
+| `pyroscope_write_latency`             | Histogram | Write latency for sending profiles to Pyroscope endpoints. |
+
+All metrics include an `endpoint` label identifying the specific endpoint URL. The `pyroscope_write_latency` metric includes an additional `type` label with the following values:
+
+- `push_total`: Total latency for push operations
+- `push_endpoint`: Per-endpoint latency for push operations  
+- `push_downstream`: Downstream request latency for push operations
+- `ingest_total`: Total latency for ingest operations
+- `ingest_endpoint`: Per-endpoint latency for ingest operations
+- `ingest_downstream`: Downstream request latency for ingest operations
+
 ## Connection limit errors
 
 If you encounter errors like `"failed to push to endpoint" err="deadline_exceeded: context deadline exceeded"` when `pyroscope.write` is pushing to a `pyroscope.receive_http` component, this may indicate that the receiving component has reached its TCP connection limit.

--- a/docs/sources/reference/components/pyroscope/pyroscope.write.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.write.md
@@ -139,14 +139,14 @@ In those cases, exported fields are kept at their last healthy values.
 
 `pyroscope.write` exposes the following metrics:
 
-| Metric                                | Type      | Description                                         |
-| ------------------------------------- | --------- | --------------------------------------------------- |
-| `pyroscope_write_sent_bytes_total`    | Counter   | Total number of compressed bytes sent to Pyroscope endpoints. |
-| `pyroscope_write_dropped_bytes_total` | Counter   | Total number of compressed bytes dropped by Pyroscope endpoints. |
-| `pyroscope_write_sent_profiles_total` | Counter   | Total number of profiles sent to Pyroscope endpoints. |
-| `pyroscope_write_dropped_profiles_total` | Counter | Total number of profiles dropped by Pyroscope endpoints. |
-| `pyroscope_write_retries_total`       | Counter   | Total number of retries to Pyroscope endpoints.    |
-| `pyroscope_write_latency`             | Histogram | Write latency for sending profiles to Pyroscope endpoints. |
+| Metric                                   | Type      | Description                                                      |
+|------------------------------------------|-----------|------------------------------------------------------------------|
+| `pyroscope_write_sent_bytes_total`       | Counter   | Total number of compressed bytes sent to Pyroscope endpoints.    |
+| `pyroscope_write_dropped_bytes_total`    | Counter   | Total number of compressed bytes dropped by Pyroscope endpoints. |
+| `pyroscope_write_sent_profiles_total`    | Counter   | Total number of profiles sent to Pyroscope endpoints.            |
+| `pyroscope_write_dropped_profiles_total` | Counter   | Total number of profiles dropped by Pyroscope endpoints.         |
+| `pyroscope_write_retries_total`          | Counter   | Total number of retries to Pyroscope endpoints.                  |
+| `pyroscope_write_latency`                | Histogram | Write latency for sending profiles to Pyroscope endpoints.       |
 
 All metrics include an `endpoint` label identifying the specific endpoint URL. The `pyroscope_write_latency` metric includes an additional `type` label with the following values:
 

--- a/internal/component/pyroscope/write/metrics.go
+++ b/internal/component/pyroscope/write/metrics.go
@@ -11,6 +11,7 @@ type metrics struct {
 	sentProfiles    *prometheus.CounterVec
 	droppedProfiles *prometheus.CounterVec
 	retries         *prometheus.CounterVec
+	latency         *prometheus.HistogramVec
 }
 
 func newMetrics(reg prometheus.Registerer) *metrics {
@@ -35,6 +36,10 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 			Name: "pyroscope_write_retries_total",
 			Help: "Total number of retries to Pyroscope.",
 		}, []string{"endpoint"}),
+		latency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name: "pyroscope_write_latency",
+			Help: "Write latency for sending profiles to pyroscope",
+		}, []string{"endpoint", "type"}),
 	}
 
 	if reg != nil {
@@ -43,6 +48,7 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 		m.sentProfiles = util.MustRegisterOrGet(reg, m.sentProfiles).(*prometheus.CounterVec)
 		m.droppedProfiles = util.MustRegisterOrGet(reg, m.droppedProfiles).(*prometheus.CounterVec)
 		m.retries = util.MustRegisterOrGet(reg, m.retries).(*prometheus.CounterVec)
+		m.latency = util.MustRegisterOrGet(reg, m.latency).(*prometheus.HistogramVec)
 	}
 
 	return m

--- a/internal/component/pyroscope/write/write.go
+++ b/internal/component/pyroscope/write/write.go
@@ -199,6 +199,7 @@ func (f *fanOutClient) Push(
 	ctx context.Context,
 	req *connect.Request[pushv1.PushRequest],
 ) (*connect.Response[pushv1.PushResponse], error) {
+
 	defer f.observeLatency("-", "push_total")()
 	var (
 		wg                    sync.WaitGroup

--- a/internal/component/pyroscope/write/write.go
+++ b/internal/component/pyroscope/write/write.go
@@ -199,7 +199,7 @@ func (f *fanOutClient) Push(
 	ctx context.Context,
 	req *connect.Request[pushv1.PushRequest],
 ) (*connect.Response[pushv1.PushResponse], error) {
-
+	defer f.observeLatency("-", "push_total")()
 	var (
 		wg                    sync.WaitGroup
 		errs                  error
@@ -220,6 +220,7 @@ func (f *fanOutClient) Push(
 		)
 		wg.Add(1)
 		go func() {
+			defer f.observeLatency(f.config.Endpoints[i].URL, "push_endpoint")()
 			defer wg.Done()
 			req := connect.NewRequest(req.Msg)
 			for k, v := range f.config.Endpoints[i].Headers {
@@ -227,6 +228,7 @@ func (f *fanOutClient) Push(
 			}
 			for {
 				err = func() error {
+					defer f.observeLatency(f.config.Endpoints[i].URL, "push_downstream")()
 					ctx, cancel := context.WithTimeout(ctx, f.config.Endpoints[i].RemoteTimeout)
 					defer cancel()
 
@@ -375,6 +377,7 @@ func (e *PyroscopeWriteError) readBody(resp *http.Response) {
 
 // AppendIngest implements the pyroscope.Appender interface.
 func (f *fanOutClient) AppendIngest(ctx context.Context, profile *pyroscope.IncomingProfile) error {
+	defer f.observeLatency("-", "ingest_total")()
 	var (
 		wg                    sync.WaitGroup
 		errs                  error
@@ -416,10 +419,12 @@ func (f *fanOutClient) AppendIngest(ctx context.Context, profile *pyroscope.Inco
 		)
 		wg.Add(1)
 		go func() {
+			defer f.observeLatency(endpoint.URL, "ingest_endpoint")()
 			defer wg.Done()
 
 			for {
 				err = func() error {
+					defer f.observeLatency(endpoint.URL, "ingest_downstream")()
 					u, err := url.Parse(endpoint.URL)
 					if err != nil {
 						return fmt.Errorf("parse URL for endpoint[%d]: %w", i, err)
@@ -501,6 +506,13 @@ func (f *fanOutClient) AppendIngest(ctx context.Context, profile *pyroscope.Inco
 	wg.Wait()
 
 	return errs
+}
+
+func (f *fanOutClient) observeLatency(endpoint, latencyType string) func() {
+	t := time.Now()
+	return func() {
+		f.metrics.latency.WithLabelValues(endpoint, latencyType).Observe(time.Since(t).Seconds())
+	}
 }
 
 // WithUserAgent returns a `connect.ClientOption` that sets the User-Agent header on.


### PR DESCRIPTION
## Summary

This PR fixes and enhances latency metrics tracking in the `pyroscope.write` component, addressing multiple issues that prevented proper observability of performance characteristics.


### Changes Made

**`internal/component/pyroscope/write/metrics.go`:**
- Added `latency *prometheus.HistogramVec` field to metrics struct
- Added latency histogram initialization and registration with labels `["endpoint", "type"]`

**`internal/component/pyroscope/write/write.go`:**
- Added `observeLatency()` helper function for consistent latency measurement
- Enhanced `Push` method with comprehensive latency tracking:
  - `push_total`: Total operation latency
  - `push_endpoint`: Per-endpoint operation latency  
  - `push_downstream`: Downstream request latency
- Enhanced `AppendIngest` method with comprehensive latency tracking:
  - `ingest_total`: Total operation latency
  - `ingest_endpoint`: Per-endpoint operation latency (now uses correct endpoint URLs)
  - `ingest_downstream`: Downstream request latency (now uses correct endpoint URLs)

**`CHANGELOG.md`:**
- Documented enhancement in the Enhancements section

### Metrics Available After This Change

The following latency metrics are now properly tracked with endpoint-specific labels:

```
pyroscope_write_latency{endpoint="-", type="push_total"}
pyroscope_write_latency{endpoint="<endpoint_url>", type="push_endpoint"} 
pyroscope_write_latency{endpoint="<endpoint_url>", type="push_downstream"}
pyroscope_write_latency{endpoint="-", type="ingest_total"}
pyroscope_write_latency{endpoint="<endpoint_url>", type="ingest_endpoint"}
pyroscope_write_latency{endpoint="<endpoint_url>", type="ingest_downstream"}
```

This provides granular visibility into performance at different levels of the push/ingest pipeline for each configured endpoint.



🤖 Generated with [Claude Code](https://claude.ai/code)