### PR TITLE
fix: convert loki metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@ Main (unreleased)
 
 - Fix issue in prometheus remote_write WAL which could allow it to hold an active series forever. (@kgeckhart)
 
+- Fix issue in static and promtail converter where metrics type was not properly handled. (@kalleep)
+
 v1.10.2
 -----------------
 

--- a/internal/converter/internal/staticconvert/testdata/promtail_metrics.alloy
+++ b/internal/converter/internal/staticconvert/testdata/promtail_metrics.alloy
@@ -1,0 +1,35 @@
+discovery.kubernetes "logs_config_with_metrics" {
+	role = "pod"
+}
+
+local.file_match "logs_config_with_metrics" {
+	path_targets = discovery.kubernetes.logs_config_with_metrics.targets
+}
+
+loki.process "logs_config_with_metrics" {
+	forward_to = [loki.write.logs_config.receiver]
+
+	stage.metrics {
+		metric.counter {
+			name              = "byte_count_total"
+			description       = "A running counter of all bytes per stream with their corresponding labels"
+			max_idle_duration = "0s"
+			action            = "add"
+			match_all         = true
+			count_entry_bytes = true
+		}
+	}
+}
+
+loki.source.file "logs_config_with_metrics" {
+	targets               = local.file_match.logs_config_with_metrics.targets
+	forward_to            = [loki.process.logs_config_with_metrics.receiver]
+	legacy_positions_file = "/path/config.yml"
+}
+
+loki.write "logs_config" {
+	endpoint {
+		url = "http://localhost/loki/api/v1/push"
+	}
+	external_labels = {}
+}

--- a/internal/converter/internal/staticconvert/testdata/promtail_metrics.diags
+++ b/internal/converter/internal/staticconvert/testdata/promtail_metrics.diags
@@ -1,0 +1,1 @@
+(Warning) Please review your agent command line flags and ensure they are set in your Alloy config file where necessary.

--- a/internal/converter/internal/staticconvert/testdata/promtail_metrics.yaml
+++ b/internal/converter/internal/staticconvert/testdata/promtail_metrics.yaml
@@ -1,0 +1,19 @@
+logs:
+  positions_directory: /path
+  configs:
+    - name: config
+      clients:
+        - url: http://localhost/loki/api/v1/push
+      scrape_configs:
+        - job_name: with_metrics
+          kubernetes_sd_configs:
+            - role: "pod"
+          pipeline_stages:
+            - metrics:
+                byte_count_total:
+                  config:
+                    action: "add"
+                    count_entry_bytes: true
+                    match_all: true
+                  description: "A running counter of all bytes per stream with their corresponding labels"
+                  type: "Counter"


### PR DESCRIPTION
#### PR Description
Noticed when using converter an internal static pipeline. Exposed types for metrics are all lowercase but documentation e.g. https://grafana.com/docs/loki/latest/send-data/promtail/stages/metrics/#metric_gauge uses uppercase.

In promtail code the type is lower cased before checked if valid https://grafana.com/docs/loki/latest/send-data/promtail/stages/metrics/#metric_gauge  

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
