### PR TITLE
Update discovery.docker.md to detail how labelnames are normalized

### DIFF
--- a/docs/sources/reference/components/discovery/discovery.docker.md
+++ b/docs/sources/reference/components/discovery/discovery.docker.md
@@ -145,8 +145,10 @@ Each target includes the following labels:
 Each discovered container maps to one target per unique combination of networks and port mappings used by the container.
 
 {{< admonition type="note" >}}
-Any dot (`.`) in the labelname will be converted to an underscore (`_`) in the resulting label. For example: to get a docker compose service name, use `__meta_docker_container_label_com_docker_compose_service` instead of `com.docker.compose.service`. This conversion is lossy and two labels that would be normalized to the same value will result in one clobbering the other.
-{{< /admonition >}}
+{{< param "PRODUCT_NAME" >}} sanitizes Docker label names in `__meta_docker_container_label_<labelname>` and `__meta_docker_network_label_<labelname>` to comply with Prometheus label naming requirements.
+The component converts dots and other non-alphanumeric characters to underscores. Underscores remain unchanged.
+For example, a Docker label `com.example.app.name` becomes `__meta_docker_container_label_com_example_app_name`.
+{{< /admonition >}
 
 ## Component health
 

--- a/docs/sources/reference/components/discovery/discovery.docker.md
+++ b/docs/sources/reference/components/discovery/discovery.docker.md
@@ -144,6 +144,10 @@ Each target includes the following labels:
 
 Each discovered container maps to one target per unique combination of networks and port mappings used by the container.
 
+{{< admonition type="note" >}}
+Any dot (`.`) in the labelname will be converted to an underscore (`_`) in the resulting label. For example: to get a docker compose service name, use `__meta_docker_container_label_com_docker_compose_service` instead of `com.docker.compose.service`. This conversion is lossy and two labels that would be normalized to the same value will result in one clobbering the other.
+{{< /admonition >}}
+
 ## Component health
 
 `discovery.docker` is only reported as unhealthy when given an invalid configuration.


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Dots in labelnames are converted to underscores, but this isn't clear in the documentation currently. 

For example, if you wanted to extract a docker compose service name, you need to extract the internal docker label `com.docker.compose.service`.

Using the literal format provided in the docs of `__meta_docker_container_label_<labelname>` results in `__meta_docker_container_label_com.docker.compose.service` which is invalid (though you might not get any warnings from alloy about this).

Instead you need to replace dots with underscores like so: `__meta_docker_container_label_com_docker_compose_service` 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
