### PR TITLE
fix: add converter for googlecloudpubsubreceiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ Main (unreleased)
 
 - Add `otelcol.receiver.googlecloudpubsub` community component to receive metrics, traces, and logs from Google Cloud Pub/Sub subscription. (@eraac)
 
+- Add otel collector converter for `otelcol.receiver.googlecloudpubsub`. (@kalleep)
+
 ### Enhancements
 
 - Fix `pyroscope.write` component's `AppendIngest` method to respect configured timeout and implement retry logic. The method now properly uses the configured `remote_timeout`, includes retry logic with exponential backoff, and tracks metrics for sent/dropped bytes and profiles consistently with the `Append` method. (@korniltsev)

--- a/internal/converter/internal/otelcolconvert/converter_googlecloudpubsubreceiver.go
+++ b/internal/converter/internal/otelcolconvert/converter_googlecloudpubsubreceiver.go
@@ -1,0 +1,71 @@
+package otelcolconvert
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/grafana/alloy/internal/component/otelcol"
+	otelconfig "github.com/grafana/alloy/internal/component/otelcol/config"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componentstatus"
+	"go.opentelemetry.io/collector/pipeline"
+
+	"github.com/grafana/alloy/internal/converter/diag"
+	"github.com/grafana/alloy/internal/converter/internal/common"
+
+	"github.com/grafana/alloy/internal/component/otelcol/receiver/googlecloudpubsub"
+)
+
+func init() {
+	converters = append(converters, googleCloudPubSubReceiverConverter{})
+}
+
+type googleCloudPubSubReceiverConverter struct{}
+
+func (googleCloudPubSubReceiverConverter) Factory() component.Factory {
+	return googlecloudpubsubreceiver.NewFactory()
+}
+
+func (googleCloudPubSubReceiverConverter) InputComponentName() string {
+	return "otelcol.receiver.googlecloudpubsub"
+}
+
+func (c googleCloudPubSubReceiverConverter) ConvertAndAppend(state *State, id componentstatus.InstanceID, cfg component.Config) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	block := common.NewBlockWithOverride(
+		strings.Split(c.InputComponentName(), "."),
+		state.AlloyComponentLabel(),
+		toGoogleCloudPubSubReceiver(state, id, cfg.(*googlecloudpubsubreceiver.Config)),
+	)
+
+	diags.Add(
+		diag.SeverityLevelInfo,
+		fmt.Sprintf("Converted %s into %s", StringifyInstanceID(id), StringifyBlock(block)),
+	)
+
+	state.Body().AppendBlock(block)
+	return diags
+}
+
+func toGoogleCloudPubSubReceiver(state *State, id componentstatus.InstanceID, cfg *googlecloudpubsubreceiver.Config) *googlecloudpubsub.Arguments {
+	return &googlecloudpubsub.Arguments{
+		ProjectID:           cfg.ProjectID,
+		UserAgent:           cfg.UserAgent,
+		Endpoint:            cfg.Endpoint,
+		Insecure:            cfg.Insecure,
+		Subscription:        cfg.Subscription,
+		Encoding:            cfg.Encoding,
+		Compression:         cfg.Compression,
+		IgnoreEncodingError: cfg.IgnoreEncodingError,
+		ClientID:            cfg.ClientID,
+		Timeout:             cfg.TimeoutSettings.Timeout,
+		DebugMetrics:        common.DefaultValue[otelconfig.DebugMetricsArguments](),
+		Output: &otelcol.ConsumerArguments{
+			Metrics: ToTokenizedConsumers(state.Next(id, pipeline.SignalLogs)),
+			Logs:    ToTokenizedConsumers(state.Next(id, pipeline.SignalMetrics)),
+			Traces:  ToTokenizedConsumers(state.Next(id, pipeline.SignalTraces)),
+		},
+	}
+}

--- a/internal/converter/internal/otelcolconvert/testdata/googlecloud.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/googlecloud.alloy
@@ -1,11 +1,12 @@
-otelcol.receiver.otlp "default" {
-	grpc {
-		endpoint = "localhost:4317"
-	}
-
-	http {
-		endpoint = "localhost:4318"
-	}
+otelcol.receiver.googlecloudpubsub "default" {
+	project               = "otel-project"
+	user_agent            = "alloy"
+	insecure              = true
+	subscription          = "projects/otel-project/subscriptions/otlp-logs"
+	encoding              = "otlp_proto_trace"
+	compression           = "gzip"
+	ignore_encoding_error = true
+	timeout               = "10s"
 
 	output {
 		metrics = [otelcol.exporter.googlecloud.default.input]

--- a/internal/converter/internal/otelcolconvert/testdata/googlecloud.yaml
+++ b/internal/converter/internal/otelcolconvert/testdata/googlecloud.yaml
@@ -1,8 +1,13 @@
 receivers:
-  otlp:
-    protocols:
-      grpc:
-      http:
+  googlecloudpubsub:
+    project: otel-project
+    subscription: projects/otel-project/subscriptions/otlp-logs
+    encoding: otlp_proto_trace
+    user_agent: alloy
+    compression: gzip
+    insecure: true
+    ignore_encoding_error: true
+    timeout: "10s"
 
 exporters:
   googlecloud:
@@ -60,14 +65,14 @@ exporters:
 service:
   pipelines:
     traces:
-      receivers: [otlp]
+      receivers: [googlecloudpubsub]
       processors: []
       exporters: [googlecloud]
     metrics:
-      receivers: [otlp]
+      receivers: [googlecloudpubsub]
       processors: []
       exporters: [googlecloud]
     logs:
-      receivers: [otlp]
+      receivers: [googlecloudpubsub]
       processors: []
       exporters: [googlecloud]


### PR DESCRIPTION
#### PR Description
Missed this is in https://github.com/grafana/alloy/pull/4206.

Add the necessary code to be able to convert between otel collector config to alloy for `otelcol.receiver.googlecloudpubsub` 

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [x] Config converters updated
