### PR TITLE
docs: add warning about using *_file attributes

### DIFF
--- a/docs/sources/shared/reference/components/authorization-block.md
+++ b/docs/sources/shared/reference/components/authorization-block.md
@@ -11,3 +11,7 @@ headless: true
 | `type`             | `string` | Authorization type, for example, "Bearer". |         | no       |
 
 `credential` and `credentials_file` are mutually exclusive, and only one can be provided inside an `authorization` block.
+
+{{< admonition type="warning" >}}
+Using credentials_file leads to file being read on every outgoing request. Prefer to use `local.file` component
+with credentials attribute instead to avoid unnecessary reads.

--- a/docs/sources/shared/reference/components/basic-auth-block.md
+++ b/docs/sources/shared/reference/components/basic-auth-block.md
@@ -11,3 +11,8 @@ headless: true
 | `username`      | `string` | Basic auth username.                     |         | no       |
 
 `password` and `password_file` are mutually exclusive, and only one can be provided inside a `basic_auth` block.
+
+
+{{< admonition type="warning" >}}
+Using password_file leads to file being read on every outgoing request. Prefer to use `local.file` component
+with password attribute instead to avoid unnecessary reads.

--- a/docs/sources/shared/reference/components/oauth2-block.md
+++ b/docs/sources/shared/reference/components/oauth2-block.md
@@ -19,6 +19,10 @@ headless: true
 
 `client_secret` and `client_secret_file` are mutually exclusive, and only one can be provided inside an `oauth2` block.
 
+{{< admonition type="warning" >}}
+Using client_secret_file leads to file being read on every outgoing request. Prefer to use `local.file` component
+with client_secret attribute instead to avoid unnecessary reads.
+
 The `oauth2` block may also contain a separate `tls_config` sub-block.
 
 {{< docs/shared lookup="reference/components/http-client-proxy-config-description.md" source="alloy" version="<ALLOY_VERSION>" >}}


### PR DESCRIPTION
#### PR Description
Discovered in https://github.com/grafana/alloy/issues/4183. If *_file attributes are configured they will be read on every outgoing request causing unnecessary fs reads. 

We should recommend to use `import.file` instead e.g:
```
local.file "password" {
  filename = "path/to/passwordfile"
  is_secret = true
}

pyroscope.write "write" {
  endpoint {
    username = "<username>"
    password = local.file.password.content
  }
}
```
 
#### Which issue(s) this PR fixes

Fixes: https://github.com/grafana/alloy/issues/4183

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
