### PR TITLE
Consider samples when deciding how long we should keep a series during WAL replay

### DIFF
--- a/internal/static/metrics/wal/wal.go
+++ b/internal/static/metrics/wal/wal.go
@@ -399,6 +399,8 @@ func (w *Storage) loadWAL(r *wlog.Reader, duplicateRefToValidRef map[chunks.Head
 		case []record.RefSample:
 			for _, s := range v {
 				if ref, ok := duplicateRefToValidRef[s.Ref]; ok {
+					// Make sure we keep the duplicate SeriesRef in checkpoints until we get past the current segment.
+					w.deleted[s.Ref] = currentSegmentOrCheckpoint
 					s.Ref = ref
 				}
 				series := w.series.GetByID(s.Ref)


### PR DESCRIPTION
#### PR Description
Follow up to https://github.com/grafana/alloy/pull/3927 to also consider the last segment where we found a sample for deletion. 

#### Notes to the Reviewer
I was finding instances of `found sample referencing non-existing series` when Alloy was restarted, a checkpoint was allowed to run, and Alloy was restarted again. I believe these to be duplicate series that were marked for deletion on replay that still had samples in segments beyond the segment where the series was found. This causes their samples to be retained in the next checkpoint while the series is deleted.

It's possible this does not fully prevent this error because a series is included or excluded from the checkpoint based on its last known segment and a sample is included or excluded based on the sample timestamp. Nothing really enforces that being passed segments X means we have sent samples beyond Y time. 

The warn is largely superficial and does not impact anything at runtime. The checkpoint is just holding some extra samples it doesn't need to hold and those will be dropped when the next checkpoint runs. I could always remove the WARN log as the upstream inspriation for the WAL (https://github.com/prometheus/prometheus/blob/e83dc66bdb67a01ff06a96e81faf66b0095d9948/tsdb/head_wal.go#L276-L308) doesn't check for this condition but wasn't trying to go that far without input from others.