### PR TITLE
database_observability: add server_id as a common log label

### DIFF
--- a/internal/component/database_observability/mysql/component_test.go
+++ b/internal/component/database_observability/mysql/component_test.go
@@ -211,7 +211,7 @@ func Test_addLokiLabels(t *testing.T) {
 	t.Run("add required labels to loki entries", func(t *testing.T) {
 		lokiClient := loki_fake.NewClient(func() {})
 		defer lokiClient.Stop()
-		entryHandler := addLokiLabels(lokiClient, "some-instance-key")
+		entryHandler := addLokiLabels(lokiClient, "some-instance-key", "some-server-uuid")
 
 		go func() {
 			ts := time.Now().UnixNano()
@@ -229,8 +229,9 @@ func Test_addLokiLabels(t *testing.T) {
 
 		require.Len(t, lokiClient.Received(), 1)
 		assert.Equal(t, model.LabelSet{
-			"job":      database_observability.JobName,
-			"instance": model.LabelValue("some-instance-key"),
+			"job":       database_observability.JobName,
+			"instance":  model.LabelValue("some-instance-key"),
+			"server_id": model.LabelValue("some-server-uuid"),
 		}, lokiClient.Received()[0].Labels)
 		assert.Equal(t, "some-message", lokiClient.Received()[0].Line)
 	})


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This change adds the MySQL server UUID as a loki log label so that we can uniquely identify each database host. The `instance` label which was previously responsible for this is not suitable, as that label is re-used across multiple hosts.

In a followup this will be added to all metrics

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
