### PR TITLE
Extend documentation for discovery.process

### DIFF
--- a/docs/sources/reference/components/discovery/discovery.process.md
+++ b/docs/sources/reference/components/discovery/discovery.process.md
@@ -56,7 +56,7 @@ For example, if `join` is specified as the following external targets:
 ]
 ```
 
-And the discovered _process targets_ are:
+And the discovered process targets are:
 
 ```json
 [

--- a/docs/sources/reference/components/discovery/discovery.process.md
+++ b/docs/sources/reference/components/discovery/discovery.process.md
@@ -42,7 +42,7 @@ This component alternatively joins targets by `__meta_kubernetes_pod_container_i
 which allows a simple integration with the output from other discovery components like `discovery.kubernetes`,
 as shown in [this example][example_discovery_kubernetes].
 
-For example, if `join` is specified as follows:
+For example, if `join` is specified as the following _external targets_:
 
 ```json
 [
@@ -57,7 +57,7 @@ For example, if `join` is specified as follows:
 ]
 ```
 
-And the discovered processes are:
+And the discovered _process targets_ are:
 
 ```json
 [
@@ -93,6 +93,13 @@ The resulting targets are:
   }
 ]
 ```
+
+Explanation of the four resulting targets in this example:
+
+1. The first _external target_ merged with the first discovered _process target_, joint by `__container_id__=1`.
+2. The second discovered _process target_, joint with no matching _external target_.
+3. The first original _external target_, joint with no matching discovered _process target_.
+4. The second original _external target_, joint with no matching discovered _process target_.
 
 [example_discovery_kubernetes]: #example-discovering-processes-on-the-local-host-and-joining-with-discoverykubernetes
 

--- a/docs/sources/reference/components/discovery/discovery.process.md
+++ b/docs/sources/reference/components/discovery/discovery.process.md
@@ -93,12 +93,12 @@ The resulting targets are:
 ]
 ```
 
-Explanation of the four resulting targets in this example:
+The four targets are updated as follows:
 
-1. The first _external target_ merged with the first discovered _process target_, joint by `__container_id__=1`.
-2. The second discovered _process target_, joint with no matching _external target_.
-3. The first original _external target_, joint with no matching discovered _process target_.
-4. The second original _external target_, joint with no matching discovered _process target_.
+1. The first external target is merged with the first discovered process target, joined by `__container_id__=1`.
+1. The second discovered process target has no matching external target.
+1. The first original external target has no matching discovered process target.
+1. The second original external target has no matching discovered process target.
 
 [example_discovery_kubernetes]: #example-discovering-processes-on-the-local-host-and-joining-with-discoverykubernetes
 

--- a/docs/sources/reference/components/discovery/discovery.process.md
+++ b/docs/sources/reference/components/discovery/discovery.process.md
@@ -38,6 +38,9 @@ You can use the following arguments with `discovery.process`:
 ### Targets joining
 
 If you specify `join`, `discovery.process` joins the discovered processes based on the `__container_id__` label.
+This component alternatively joins targets by `__meta_kubernetes_pod_container_id` or `__meta_docker_container_id`,
+which allows a simple integration with the output from other discovery components like `discovery.kubernetes`,
+as shown in [this example][example_discovery_kubernetes].
 
 For example, if `join` is specified as follows:
 
@@ -90,6 +93,8 @@ The resulting targets are:
   }
 ]
 ```
+
+[example_discovery_kubernetes]: #example-discovering-processes-on-the-local-host-and-joining-with-discoverykubernetes
 
 ## Blocks
 

--- a/docs/sources/reference/components/discovery/discovery.process.md
+++ b/docs/sources/reference/components/discovery/discovery.process.md
@@ -38,9 +38,8 @@ You can use the following arguments with `discovery.process`:
 ### Targets joining
 
 If you specify `join`, `discovery.process` joins the discovered processes based on the `__container_id__` label.
-This component alternatively joins targets by `__meta_kubernetes_pod_container_id` or `__meta_docker_container_id`,
-which allows a simple integration with the output from other discovery components like `discovery.kubernetes`,
-as shown in [this example][example_discovery_kubernetes].
+This component alternatively joins targets by `__meta_kubernetes_pod_container_id` or `__meta_docker_container_id`, which allows a simple integration with the output from other discovery components like `discovery.kubernetes`.
+The example [discovering processes on the local host and joining with `discovery.kubernetes`][example_discovery_kubernetes] demonstrates this.
 
 For example, if `join` is specified as the following _external targets_:
 

--- a/docs/sources/reference/components/discovery/discovery.process.md
+++ b/docs/sources/reference/components/discovery/discovery.process.md
@@ -41,7 +41,7 @@ If you specify `join`, `discovery.process` joins the discovered processes based 
 This component alternatively joins targets by `__meta_kubernetes_pod_container_id` or `__meta_docker_container_id`, which allows a simple integration with the output from other discovery components like `discovery.kubernetes`.
 The example [discovering processes on the local host and joining with `discovery.kubernetes`][example_discovery_kubernetes] demonstrates this.
 
-For example, if `join` is specified as the following _external targets_:
+For example, if `join` is specified as the following external targets:
 
 ```json
 [


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR adds documentation for `discovery.process` in two ways:
1. Mentions the implicit target join on different attributes
2. Explains the example for "discovery process on kubernetes" more detailed

Motivated by irritations in #3010 and this comment: https://github.com/grafana/alloy/issues/3010#issuecomment-3183194808

#### Which issue(s) this PR fixes

Fixes #3010 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
