### PR TITLE
feat: add url_encode and url_decode std lib functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ Main (unreleased)
 
 - (_Experimental_) Add a `honor_metadata` configuration argument to the `prometheus.scrape` component.
   When set to `true`, it will propagate metric metadata to downstream components.
+
+- Add `encoding.url_encode` and `encoding.url_decode` std lib functions. (@kalleep)
   
 ### Enhancements
 

--- a/docs/sources/reference/stdlib/encoding.md
+++ b/docs/sources/reference/stdlib/encoding.md
@@ -61,6 +61,29 @@ The `encoding.to_base64` function encodes the original string into RFC4648-compl
 c3RyaW5nMTIzIT8kKiYoKSctPUB-
 ```
 
+## encoding.url_encode
+
+The `encoding.url_encode` function encodes the original string into a RFC3986 "percent encoding" compliant string.
+
+### Example
+
+```
+> encoding.url_encode("string123!?$*&()'-=@~")
+string123%21%3F%24%2A%26%28%29%27-%3D%40~
+```
+
+## encoding.url_decode
+
+The `encoding.url_decode` function decodes a RFC3986 "percent encoding" compliant string.
+`encoding.url_decode` failes if input string is not RFC3986 "percent encoding" compliant.
+
+### Example
+
+```
+> encoding.url_decode("string123%21%3F%24%2A%26%28%29%27-%3D%40~")
+string123!?$*&()'-=@~
+```
+
 ## encoding.to_json
 
 The `encoding.to_json` function encodes the map into a JSON string.

--- a/syntax/internal/stdlib/stdlib.go
+++ b/syntax/internal/stdlib/stdlib.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -82,6 +83,8 @@ var encoding = map[string]interface{}{
 	"to_json":        jsonEncode,
 	"to_base64":      base64Encode,
 	"to_URLbase64":   base64URLEncode,
+	"url_encode":     urlEncode,
+	"url_decode":     urlDecode,
 }
 
 var str = map[string]interface{}{
@@ -446,6 +449,14 @@ func base64URLEncode(in string) (string, error) {
 func base64Encode(in string) (string, error) {
 	encoded := base64.StdEncoding.EncodeToString([]byte(in))
 	return encoded, nil
+}
+
+func urlEncode(in string) (string, error) {
+	return url.QueryEscape(in), nil
+}
+
+func urlDecode(in string) (string, error) {
+	return url.QueryUnescape(in)
 }
 
 func jsonEncode(in interface{}) (string, error) {


### PR DESCRIPTION
#### PR Description
Add `encoding.url_encode` and `encoding.url_decode` std lib functions. These are just simple wrappers over golang `url.QueryEscape` and `url.QueryUnescape`.

#### Which issue(s) this PR fixes

Fixes: https://github.com/grafana/alloy/issues/4161
Fixes: https://github.com/grafana/alloy/issues/4276

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
