### PR TITLE
Docs: restrict pod discovery to own node in "Collect Kubernetes logs" example

### DIFF
--- a/docs/sources/collect/logs-in-kubernetes.md
+++ b/docs/sources/collect/logs-in-kubernetes.md
@@ -181,6 +181,11 @@ Here is an example using those stages:
 // It watches cluster state and ensures targets are continually synced with what is currently running in your cluster.
 discovery.kubernetes "pod" {
   role = "pod"
+  // Restrict to pods on the node, see "Limit to only Pods on the same node" in [discovery.kubernetes][discovery.kubernetes_samenode]
+  selectors {
+    role = "pod"
+    field = "spec.nodeName=" + coalesce(sys.env("HOSTNAME"), constants.hostname)
+  }
 }
 
 // discovery.relabel rewrites the label set of the input targets by applying one or more relabeling rules.
@@ -317,6 +322,7 @@ Replace the following values:
 
 [Loki]: https://grafana.com/oss/loki/
 [discovery.kubernetes]: ../../reference/components/discovery/discovery.kubernetes/
+[discovery.kubernetes_samenode]: ../../reference/components/discovery/discovery.kubernetes/#limit-to-only-pods-on-the-same-node
 [loki.write]: ../../reference/components/loki/loki.write/
 [local.file_match]: ../../reference/components/local/local.file_match/
 [loki.source.file]: ../../reference/components/loki/loki.source.file/

--- a/docs/sources/collect/logs-in-kubernetes.md
+++ b/docs/sources/collect/logs-in-kubernetes.md
@@ -181,7 +181,7 @@ Here is an example using those stages:
 // It watches cluster state and ensures targets are continually synced with what is currently running in your cluster.
 discovery.kubernetes "pod" {
   role = "pod"
-  // Restrict to pods on the node, see "Limit to only Pods on the same node" in [discovery.kubernetes][discovery.kubernetes_samenode]
+  // Restrict to pods on the node to reduce cpu & memory usage
   selectors {
     role = "pod"
     field = "spec.nodeName=" + coalesce(sys.env("HOSTNAME"), constants.hostname)
@@ -274,6 +274,10 @@ Replace the following values:
 
 * _`<CLUSTER_NAME>`_: The label for this specific Kubernetes cluster, such as `production` or `us-east-1`.
 * _`<WRITE_COMPONENT_NAME>`_: The name of your `loki.write` component, such as `default`.
+
+{{< admonition type="note" >}}
+Refer to [Limit to only Pods on the same node][discovery.kubernetes_samenode] for more information about restricting to Pods on the same node.
+{{< /admonition >}}
 
 ### Kubernetes Cluster Events
 


### PR DESCRIPTION
#### PR Description

Add a filtering block in the docs for Alloy to prevent large memory/cpu usage in the standard DaemonSet mode.

This seems to be a common issue, cf #1185, and in this example in particular filtering by node is the right thing to do.

#### Which issue(s) this PR fixes

Fixes #1185

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
