### PR TITLE
fix: set stable locale before sorting

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank.yaml
+++ b/.github/ISSUE_TEMPLATE/blank.yaml
@@ -120,8 +120,8 @@ body:
       - otelcol.receiver.awscloudwatch
       - otelcol.receiver.datadog
       - otelcol.receiver.faro
-      - otelcol.receiver.filelog
       - otelcol.receiver.file_stats
+      - otelcol.receiver.filelog
       - otelcol.receiver.fluentforward
       - otelcol.receiver.googlecloudpubsub
       - otelcol.receiver.influxdb

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -120,8 +120,8 @@ body:
       - otelcol.receiver.awscloudwatch
       - otelcol.receiver.datadog
       - otelcol.receiver.faro
-      - otelcol.receiver.filelog
       - otelcol.receiver.file_stats
+      - otelcol.receiver.filelog
       - otelcol.receiver.fluentforward
       - otelcol.receiver.googlecloudpubsub
       - otelcol.receiver.influxdb

--- a/.github/ISSUE_TEMPLATE/docs.yaml
+++ b/.github/ISSUE_TEMPLATE/docs.yaml
@@ -123,8 +123,8 @@ body:
       - otelcol.receiver.awscloudwatch
       - otelcol.receiver.datadog
       - otelcol.receiver.faro
-      - otelcol.receiver.filelog
       - otelcol.receiver.file_stats
+      - otelcol.receiver.filelog
       - otelcol.receiver.fluentforward
       - otelcol.receiver.googlecloudpubsub
       - otelcol.receiver.influxdb

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -120,8 +120,8 @@ body:
       - otelcol.receiver.awscloudwatch
       - otelcol.receiver.datadog
       - otelcol.receiver.faro
-      - otelcol.receiver.filelog
       - otelcol.receiver.file_stats
+      - otelcol.receiver.filelog
       - otelcol.receiver.fluentforward
       - otelcol.receiver.googlecloudpubsub
       - otelcol.receiver.influxdb

--- a/.github/ISSUE_TEMPLATE/proposal.yaml
+++ b/.github/ISSUE_TEMPLATE/proposal.yaml
@@ -120,8 +120,8 @@ body:
       - otelcol.receiver.awscloudwatch
       - otelcol.receiver.datadog
       - otelcol.receiver.faro
-      - otelcol.receiver.filelog
       - otelcol.receiver.file_stats
+      - otelcol.receiver.filelog
       - otelcol.receiver.fluentforward
       - otelcol.receiver.googlecloudpubsub
       - otelcol.receiver.influxdb

--- a/.github/ISSUE_TEMPLATE/scripts/update-gh-issue-templates.sh
+++ b/.github/ISSUE_TEMPLATE/scripts/update-gh-issue-templates.sh
@@ -27,7 +27,7 @@ if [ ${#LIST[@]} -eq 0 ]; then
     exit 1
 fi
 
-IFS=$'\n' LIST=($(sort <<<"${LIST[*]}"))
+IFS=$'\n' LIST=($(LC_ALL=C sort <<<"${LIST[*]}"))
 # Reset IFS to default
 unset IFS
 


### PR DESCRIPTION
#### PR Description
After https://github.com/grafana/alloy/pull/4018 the order changed. Sort can behave differently depending on what locale is set on the machine. e.g. https://github.com/grafana/alloy/pull/4287 is failing the step to verify the order and my machine would sort it in the order it currently is. 

To fix this we can override locale before sorting to make it consistent.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
