### PR TITLE
feat: add support for ScrapeConfig with ec2SdConfigs in `prometheus.operator.scrapeconfigs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ Main (unreleased)
 
 - (_Experimental_) Add a `honor_metadata` configuration argument to the `prometheus.scrape` component.
   When set to `true`, it will propagate metric metadata to downstream components.
+
+- Add support for ScrapeConfig with `ec2SdConfigs` in `prometheus.operator.scrapeconfigs`. (@thomas-gouveia)
   
 ### Enhancements
 

--- a/docs/sources/reference/components/prometheus/prometheus.operator.scrapeconfigs.md
+++ b/docs/sources/reference/components/prometheus/prometheus.operator.scrapeconfigs.md
@@ -26,6 +26,12 @@ You can run {{< param "PRODUCT_NAME" >}} from outside the cluster by supplying c
 `scrapeconfigs` may reference secrets for authenticating to targets to scrape them.
 In these cases, the secrets are loaded and refreshed only when the ScrapeConfig is updated or when this component refreshes its internal state, which happens on a 5-minute refresh cycle.
 
+{{< admonition type="warning" >}}
+Only ScrapeConfig using the discoveries listed below are currently supported :
+- `staticConfigs`
+- `ec2SDConfigs`
+{{< /admonition >}}
+
 ## Usage
 
 ```alloy

--- a/internal/component/prometheus/operator/configgen/config_gen_scrapeconfig.go
+++ b/internal/component/prometheus/operator/configgen/config_gen_scrapeconfig.go
@@ -3,39 +3,57 @@ package configgen
 // SEE https://github.com/prometheus-operator/prometheus-operator/blob/aa8222d7e9b66e9293ed11c9291ea70173021029/pkg/prometheus/promcfg.go
 
 import (
+	"cmp"
 	"fmt"
+	"net/url"
+	"reflect"
+	"slices"
 	"strings"
 
 	promopv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/namespacelabeler"
+	common "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/aws"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/model/relabel"
 )
 
-func (cg *ConfigGenerator) GenerateScrapeConfigConfigs(m *promopv1alpha1.ScrapeConfig) (cfg []*config.ScrapeConfig, errors []error) {
-	cfg, errors = cg.generateStaticScrapeConfigConfigs(m, cfg, errors)
-	return
-}
+func (cg *ConfigGenerator) GenerateScrapeConfigConfigs(m *promopv1alpha1.ScrapeConfig) ([]*config.ScrapeConfig, []error) {
+	var (
+		configs []*config.ScrapeConfig
+		errors  []error
+	)
 
-func (cg *ConfigGenerator) generateStaticScrapeConfigConfigs(m *promopv1alpha1.ScrapeConfig, cfg []*config.ScrapeConfig, errors []error) ([]*config.ScrapeConfig, []error) {
+	// StaticConfigs
 	for i, ep := range m.Spec.StaticConfigs {
 		scrapeConfig, err := cg.generateStaticScrapeConfigConfig(m, ep, i)
 		if err != nil {
 			errors = append(errors, err)
 		} else {
-			cfg = append(cfg, scrapeConfig)
+			configs = append(configs, scrapeConfig)
 		}
 	}
-	return cfg, errors
+
+	// EC2SDConfigs
+	for i, ec2SdConfig := range m.Spec.EC2SDConfigs {
+		scrapeConfig, err := cg.generateEc2ScrapeConfigConfig(m, ec2SdConfig, i)
+		if err != nil {
+			errors = append(errors, err)
+		} else {
+			configs = append(configs, scrapeConfig)
+		}
+	}
+
+	return configs, errors
 }
 
-func (cg *ConfigGenerator) generateStaticScrapeConfigConfig(m *promopv1alpha1.ScrapeConfig, sc promopv1alpha1.StaticConfig, i int) (cfg *config.ScrapeConfig, err error) {
+func (cg *ConfigGenerator) generateStaticScrapeConfigConfig(m *promopv1alpha1.ScrapeConfig, sc promopv1alpha1.StaticConfig, i int) (*config.ScrapeConfig, error) {
 	relabels := cg.initRelabelings()
 	metricRelabels := relabeler{}
-	cfg, err = cg.commonScrapeConfigConfig(m, i, &relabels, &metricRelabels)
+	cfg, err := cg.commonScrapeConfigConfig(m, &relabels, &metricRelabels)
 	cfg.JobName = fmt.Sprintf("scrapeConfig/%s/%s/static/%d", m.Namespace, m.Name, i)
 	if err != nil {
 		return nil, err
@@ -68,7 +86,7 @@ func (cg *ConfigGenerator) generateStaticScrapeConfigConfig(m *promopv1alpha1.Sc
 	return cfg, cfg.Validate(cg.ScrapeOptions.GlobalConfig())
 }
 
-func (cg *ConfigGenerator) commonScrapeConfigConfig(m *promopv1alpha1.ScrapeConfig, _ int, relabels *relabeler, metricRelabels *relabeler) (cfg *config.ScrapeConfig, err error) {
+func (cg *ConfigGenerator) commonScrapeConfigConfig(m *promopv1alpha1.ScrapeConfig, relabels *relabeler, metricRelabels *relabeler) (cfg *config.ScrapeConfig, err error) {
 	cfg = cg.generateDefaultScrapeConfig()
 	if m.Spec.HonorLabels != nil {
 		cfg.HonorLabels = *m.Spec.HonorLabels
@@ -135,4 +153,116 @@ func (cg *ConfigGenerator) commonScrapeConfigConfig(m *promopv1alpha1.ScrapeConf
 	cfg.LabelNameLengthLimit = uint(defaultIfNil(m.Spec.LabelNameLengthLimit, 0))
 	cfg.LabelValueLengthLimit = uint(defaultIfNil(m.Spec.LabelValueLengthLimit, 0))
 	return cfg, err
+}
+
+// generateEc2ScrapeConfigConfig generates a Prometheus scrape config for EC2 service discovery.
+// Adapted from https://github.com/prometheus-operator/prometheus-operator/blob/main/pkg/prometheus/promcfg.go#L3590
+func (cg *ConfigGenerator) generateEc2ScrapeConfigConfig(m *promopv1alpha1.ScrapeConfig, ec2Sd promopv1alpha1.EC2SDConfig, i int) (cfg *config.ScrapeConfig, err error) {
+	relabels := cg.initRelabelings()
+	metricRelabels := relabeler{}
+	cfg, err = cg.commonScrapeConfigConfig(m, &relabels, &metricRelabels)
+	cfg.JobName = fmt.Sprintf("scrapeConfig/%s/%s/ec2/%d", m.Namespace, m.Name, i)
+	if err != nil {
+		return nil, err
+	}
+
+	sdConfig := &aws.EC2SDConfig{}
+
+	if ec2Sd.Region != nil {
+		sdConfig.Region = *ec2Sd.Region
+	}
+
+	if ec2Sd.AccessKey != nil && ec2Sd.SecretKey != nil {
+		accessKey, err := cg.Secrets.GetSecretValue(m.Namespace, *ec2Sd.AccessKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve AWS access key from secret %s: %w", ec2Sd.AccessKey.Name, err)
+		}
+		secretKey, err := cg.Secrets.GetSecretValue(m.Namespace, *ec2Sd.SecretKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve AWS secret key from secret %s: %w", ec2Sd.SecretKey.Name, err)
+		}
+
+		sdConfig.AccessKey = accessKey
+		sdConfig.SecretKey = common.Secret(secretKey)
+	}
+
+	if ec2Sd.RoleARN != nil {
+		sdConfig.RoleARN = *ec2Sd.RoleARN
+	}
+
+	if ec2Sd.RefreshInterval != nil {
+		refreshInterval, err := model.ParseDuration(string(*ec2Sd.RefreshInterval))
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse refresh interval: %w", err)
+		}
+		sdConfig.RefreshInterval = refreshInterval
+	}
+
+	if ec2Sd.Port != nil {
+		sdConfig.Port = int(*ec2Sd.Port)
+	}
+
+	if len(ec2Sd.Filters) > 0 {
+		// Sort the filters by name to generate a deterministic config.
+		slices.SortStableFunc(ec2Sd.Filters, func(a, b promopv1alpha1.Filter) int {
+			return cmp.Compare(a.Name, b.Name)
+		})
+
+		for _, filter := range ec2Sd.Filters {
+			sdConfig.Filters = append(sdConfig.Filters, &aws.EC2Filter{
+				Name:   filter.Name,
+				Values: filter.Values,
+			})
+		}
+	}
+
+	if ec2Sd.FollowRedirects != nil {
+		sdConfig.HTTPClientConfig.FollowRedirects = *ec2Sd.FollowRedirects
+	}
+
+	if ec2Sd.EnableHTTP2 != nil {
+		sdConfig.HTTPClientConfig.EnableHTTP2 = *ec2Sd.EnableHTTP2
+	}
+
+	if ec2Sd.TLSConfig != nil {
+		if sdConfig.HTTPClientConfig.TLSConfig, err = cg.generateSafeTLS(*ec2Sd.TLSConfig, m.Namespace); err != nil {
+			return nil, err
+		}
+	}
+
+	// Proxy settings
+	if !reflect.ValueOf(ec2Sd.ProxyConfig).IsZero() {
+		if ec2Sd.ProxyURL != nil {
+			u, err := url.Parse(*ec2Sd.ProxyURL)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse proxy URL %q: %w", *ec2Sd.ProxyURL, err)
+			}
+			sdConfig.HTTPClientConfig.ProxyURL = common.URL{URL: u}
+		}
+
+		if ec2Sd.NoProxy != nil {
+			sdConfig.HTTPClientConfig.NoProxy = *ec2Sd.NoProxy
+		}
+
+		if ec2Sd.ProxyFromEnvironment != nil {
+			sdConfig.HTTPClientConfig.ProxyFromEnvironment = *ec2Sd.ProxyFromEnvironment
+		}
+
+		if ec2Sd.ProxyConnectHeader != nil {
+			proxyConnectHeader := make(common.ProxyHeader)
+			for k, v := range ec2Sd.ProxyConnectHeader {
+				proxyConnectHeader[k] = make([]common.Secret, len(v))
+				for _, s := range v {
+					value, _ := cg.Secrets.GetSecretValue(m.Namespace, s)
+					proxyConnectHeader[k] = append(proxyConnectHeader[k], common.Secret(value))
+				}
+			}
+			sdConfig.HTTPClientConfig.ProxyConnectHeader = proxyConnectHeader
+		}
+	}
+
+	cfg.ServiceDiscoveryConfigs = append(cfg.ServiceDiscoveryConfigs, sdConfig)
+	cfg.RelabelConfigs = relabels.configs
+	cfg.MetricRelabelConfigs = metricRelabels.configs
+	return cfg, cfg.Validate(cg.ScrapeOptions.GlobalConfig())
 }

--- a/internal/component/prometheus/operator/configgen/config_gen_scrapeconfig_test.go
+++ b/internal/component/prometheus/operator/configgen/config_gen_scrapeconfig_test.go
@@ -2,20 +2,24 @@ package configgen
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"testing"
 	"time"
 
+	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	promopv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	commonConfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/aws"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -188,4 +192,446 @@ func TestGenerateStaticScrapeConfigConfig(t *testing.T) {
 			checkRelabels(mrlcs, tc.expectedMetricRelabels)
 		})
 	}
+}
+
+func TestGenerateEc2ScrapeConfigConfig(t *testing.T) {
+	suite := []struct {
+		name                   string
+		m                      *promopv1alpha1.ScrapeConfig
+		ec2Config              promopv1alpha1.EC2SDConfig
+		expectedRelabels       string
+		expectedMetricRelabels string
+		expected               *config.ScrapeConfig
+		expectError            bool
+	}{
+		{
+			name: "minimal EC2 config",
+			m: &promopv1alpha1.ScrapeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "operator",
+					Name:      "scrapeconfig",
+				},
+			},
+			ec2Config: promopv1alpha1.EC2SDConfig{
+				Region: ptr.To("us-east-1"),
+			},
+			expectedRelabels: util.Untab(`
+				- target_label: __meta_foo
+				  replacement: bar
+				- source_labels: [job]
+				  target_label: __tmp_prometheus_job_name
+				- replacement: operator
+				  target_label: __meta_kubernetes_scrapeconfig_namespace
+				- replacement: scrapeconfig
+				  target_label: __meta_kubernetes_scrapeconfig_name
+			`),
+			expected: &config.ScrapeConfig{
+				JobName:                "scrapeConfig/operator/scrapeconfig/ec2/1",
+				HonorTimestamps:        true,
+				ScrapeInterval:         model.Duration(time.Hour),
+				ScrapeTimeout:          model.Duration(42 * time.Second),
+				ScrapeProtocols:        config.DefaultScrapeProtocols,
+				ScrapeFallbackProtocol: config.PrometheusText0_0_4,
+				EnableCompression:      true,
+				MetricsPath:            "/metrics",
+				Scheme:                 "http",
+				HTTPClientConfig: commonConfig.HTTPClientConfig{
+					FollowRedirects: true,
+					EnableHTTP2:     true,
+				},
+				ServiceDiscoveryConfigs: discovery.Configs{
+					&aws.EC2SDConfig{
+						Region: "us-east-1",
+					},
+				},
+				ConvertClassicHistogramsToNHCB: ptr.To(false),
+				MetricNameValidationScheme:     "legacy",
+				MetricNameEscapingScheme:       "underscores",
+			},
+		},
+		{
+			name: "EC2 config with port and refresh interval",
+			m: &promopv1alpha1.ScrapeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "operator",
+					Name:      "scrapeconfig",
+				},
+			},
+			ec2Config: promopv1alpha1.EC2SDConfig{
+				Region:          ptr.To("eu-west-1"),
+				Port:            ptr.To(int32(9090)),
+				RefreshInterval: ptr.To(v1.Duration("30s")),
+			},
+			expectedRelabels: util.Untab(`
+				- target_label: __meta_foo
+				  replacement: bar
+				- source_labels: [job]
+				  target_label: __tmp_prometheus_job_name
+				- replacement: operator
+				  target_label: __meta_kubernetes_scrapeconfig_namespace
+				- replacement: scrapeconfig
+				  target_label: __meta_kubernetes_scrapeconfig_name
+			`),
+			expected: &config.ScrapeConfig{
+				JobName:                "scrapeConfig/operator/scrapeconfig/ec2/1",
+				HonorTimestamps:        true,
+				ScrapeInterval:         model.Duration(time.Hour),
+				ScrapeTimeout:          model.Duration(42 * time.Second),
+				ScrapeProtocols:        config.DefaultScrapeProtocols,
+				ScrapeFallbackProtocol: config.PrometheusText0_0_4,
+				EnableCompression:      true,
+				MetricsPath:            "/metrics",
+				Scheme:                 "http",
+				HTTPClientConfig: commonConfig.HTTPClientConfig{
+					FollowRedirects: true,
+					EnableHTTP2:     true,
+				},
+				ServiceDiscoveryConfigs: discovery.Configs{
+					&aws.EC2SDConfig{
+						Region:          "eu-west-1",
+						Port:            9090,
+						RefreshInterval: model.Duration(30 * time.Second),
+					},
+				},
+				ConvertClassicHistogramsToNHCB: ptr.To(false),
+				MetricNameValidationScheme:     "legacy",
+				MetricNameEscapingScheme:       "underscores",
+			},
+		},
+		{
+			name: "EC2 config with filters",
+			m: &promopv1alpha1.ScrapeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "operator",
+					Name:      "scrapeconfig",
+				},
+			},
+			ec2Config: promopv1alpha1.EC2SDConfig{
+				Region: ptr.To("us-west-2"),
+				Filters: []promopv1alpha1.Filter{
+					{
+						Name:   "instance-state-name",
+						Values: []string{"running"},
+					},
+					{
+						Name:   "tag:Environment",
+						Values: []string{"production", "staging"},
+					},
+				},
+			},
+			expectedRelabels: util.Untab(`
+				- target_label: __meta_foo
+				  replacement: bar
+				- source_labels: [job]
+				  target_label: __tmp_prometheus_job_name
+				- replacement: operator
+				  target_label: __meta_kubernetes_scrapeconfig_namespace
+				- replacement: scrapeconfig
+				  target_label: __meta_kubernetes_scrapeconfig_name
+			`),
+			expected: &config.ScrapeConfig{
+				JobName:                "scrapeConfig/operator/scrapeconfig/ec2/1",
+				HonorTimestamps:        true,
+				ScrapeInterval:         model.Duration(time.Hour),
+				ScrapeTimeout:          model.Duration(42 * time.Second),
+				ScrapeProtocols:        config.DefaultScrapeProtocols,
+				ScrapeFallbackProtocol: config.PrometheusText0_0_4,
+				EnableCompression:      true,
+				MetricsPath:            "/metrics",
+				Scheme:                 "http",
+				HTTPClientConfig: commonConfig.HTTPClientConfig{
+					FollowRedirects: true,
+					EnableHTTP2:     true,
+				},
+				ServiceDiscoveryConfigs: discovery.Configs{
+					&aws.EC2SDConfig{
+						Region: "us-west-2",
+						Filters: []*aws.EC2Filter{
+							{
+								Name:   "instance-state-name",
+								Values: []string{"running"},
+							},
+							{
+								Name:   "tag:Environment",
+								Values: []string{"production", "staging"},
+							},
+						},
+					},
+				},
+				ConvertClassicHistogramsToNHCB: ptr.To(false),
+				MetricNameValidationScheme:     "legacy",
+				MetricNameEscapingScheme:       "underscores",
+			},
+		},
+		{
+			name: "EC2 config with role ARN",
+			m: &promopv1alpha1.ScrapeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "operator",
+					Name:      "scrapeconfig",
+				},
+			},
+			ec2Config: promopv1alpha1.EC2SDConfig{
+				Region:  ptr.To("ap-southeast-1"),
+				RoleARN: ptr.To("arn:aws:iam::123456789012:role/PrometheusRole"),
+			},
+			expectedRelabels: util.Untab(`
+				- target_label: __meta_foo
+				  replacement: bar
+				- source_labels: [job]
+				  target_label: __tmp_prometheus_job_name
+				- replacement: operator
+				  target_label: __meta_kubernetes_scrapeconfig_namespace
+				- replacement: scrapeconfig
+				  target_label: __meta_kubernetes_scrapeconfig_name
+			`),
+			expected: &config.ScrapeConfig{
+				JobName:                "scrapeConfig/operator/scrapeconfig/ec2/1",
+				HonorTimestamps:        true,
+				ScrapeInterval:         model.Duration(time.Hour),
+				ScrapeTimeout:          model.Duration(42 * time.Second),
+				ScrapeProtocols:        config.DefaultScrapeProtocols,
+				ScrapeFallbackProtocol: config.PrometheusText0_0_4,
+				EnableCompression:      true,
+				MetricsPath:            "/metrics",
+				Scheme:                 "http",
+				HTTPClientConfig: commonConfig.HTTPClientConfig{
+					FollowRedirects: true,
+					EnableHTTP2:     true,
+				},
+				ServiceDiscoveryConfigs: discovery.Configs{
+					&aws.EC2SDConfig{
+						Region:  "ap-southeast-1",
+						RoleARN: "arn:aws:iam::123456789012:role/PrometheusRole",
+					},
+				},
+				ConvertClassicHistogramsToNHCB: ptr.To(false),
+				MetricNameValidationScheme:     "legacy",
+				MetricNameEscapingScheme:       "underscores",
+			},
+		},
+		{
+			name: "EC2 config with HTTP client settings",
+			m: &promopv1alpha1.ScrapeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "operator",
+					Name:      "scrapeconfig",
+				},
+			},
+			ec2Config: promopv1alpha1.EC2SDConfig{
+				Region:          ptr.To("ca-central-1"),
+				FollowRedirects: ptr.To(false),
+				EnableHTTP2:     ptr.To(false),
+			},
+			expectedRelabels: util.Untab(`
+				- target_label: __meta_foo
+				  replacement: bar
+				- source_labels: [job]
+				  target_label: __tmp_prometheus_job_name
+				- replacement: operator
+				  target_label: __meta_kubernetes_scrapeconfig_namespace
+				- replacement: scrapeconfig
+				  target_label: __meta_kubernetes_scrapeconfig_name
+			`),
+			expected: &config.ScrapeConfig{
+				JobName:                "scrapeConfig/operator/scrapeconfig/ec2/1",
+				HonorTimestamps:        true,
+				ScrapeInterval:         model.Duration(time.Hour),
+				ScrapeTimeout:          model.Duration(42 * time.Second),
+				ScrapeProtocols:        config.DefaultScrapeProtocols,
+				ScrapeFallbackProtocol: config.PrometheusText0_0_4,
+				EnableCompression:      true,
+				MetricsPath:            "/metrics",
+				Scheme:                 "http",
+				HTTPClientConfig: commonConfig.HTTPClientConfig{
+					FollowRedirects: true,
+					EnableHTTP2:     true,
+				},
+				ServiceDiscoveryConfigs: discovery.Configs{
+					&aws.EC2SDConfig{
+						Region: "ca-central-1",
+						HTTPClientConfig: commonConfig.HTTPClientConfig{
+							FollowRedirects: false,
+							EnableHTTP2:     false,
+						},
+					},
+				},
+				ConvertClassicHistogramsToNHCB: ptr.To(false),
+				MetricNameValidationScheme:     "legacy",
+				MetricNameEscapingScheme:       "underscores",
+			},
+		},
+		{
+			name: "EC2 config with proxy settings",
+			m: &promopv1alpha1.ScrapeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "operator",
+					Name:      "scrapeconfig",
+				},
+			},
+			ec2Config: promopv1alpha1.EC2SDConfig{
+				Region: ptr.To("eu-central-1"),
+				ProxyConfig: v1.ProxyConfig{
+					ProxyURL:             ptr.To("http://proxy.example.com:8080"),
+					NoProxy:              ptr.To("localhost,127.0.0.1"),
+					ProxyFromEnvironment: ptr.To(true),
+				},
+			},
+			expectedRelabels: util.Untab(`
+				- target_label: __meta_foo
+				  replacement: bar
+				- source_labels: [job]
+				  target_label: __tmp_prometheus_job_name
+				- replacement: operator
+				  target_label: __meta_kubernetes_scrapeconfig_namespace
+				- replacement: scrapeconfig
+				  target_label: __meta_kubernetes_scrapeconfig_name
+			`),
+			expected: &config.ScrapeConfig{
+				JobName:                "scrapeConfig/operator/scrapeconfig/ec2/1",
+				HonorTimestamps:        true,
+				ScrapeInterval:         model.Duration(time.Hour),
+				ScrapeTimeout:          model.Duration(42 * time.Second),
+				ScrapeProtocols:        config.DefaultScrapeProtocols,
+				ScrapeFallbackProtocol: config.PrometheusText0_0_4,
+				EnableCompression:      true,
+				MetricsPath:            "/metrics",
+				Scheme:                 "http",
+				HTTPClientConfig: commonConfig.HTTPClientConfig{
+					FollowRedirects: true,
+					EnableHTTP2:     true,
+				},
+				ServiceDiscoveryConfigs: discovery.Configs{
+					&aws.EC2SDConfig{
+						Region: "eu-central-1",
+						HTTPClientConfig: commonConfig.HTTPClientConfig{
+							ProxyConfig: commonConfig.ProxyConfig{
+								ProxyURL: commonConfig.URL{
+									URL: &url.URL{
+										Scheme: "http",
+										Host:   "proxy.example.com:8080",
+									},
+								},
+								NoProxy:              "localhost,127.0.0.1",
+								ProxyFromEnvironment: true,
+							},
+						},
+					},
+				},
+				ConvertClassicHistogramsToNHCB: ptr.To(false),
+				MetricNameValidationScheme:     "legacy",
+				MetricNameEscapingScheme:       "underscores",
+			},
+		},
+		{
+			name: "EC2 config with invalid refresh interval",
+			m: &promopv1alpha1.ScrapeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "operator",
+					Name:      "scrapeconfig",
+				},
+			},
+			ec2Config: promopv1alpha1.EC2SDConfig{
+				Region:          ptr.To("us-east-1"),
+				RefreshInterval: ptr.To(v1.Duration("invalid")),
+			},
+			expectError: true,
+		},
+		{
+			name: "EC2 config with invalid proxy URL",
+			m: &promopv1alpha1.ScrapeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "operator",
+					Name:      "scrapeconfig",
+				},
+			},
+			ec2Config: promopv1alpha1.EC2SDConfig{
+				Region: ptr.To("us-east-1"),
+				ProxyConfig: v1.ProxyConfig{
+					ProxyURL: ptr.To("://invalid-url"),
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range suite {
+		t.Run(tc.name, func(t *testing.T) {
+			cg := &ConfigGenerator{
+				Client: &kubernetes.ClientArguments{},
+				AdditionalRelabelConfigs: []*alloy_relabel.Config{
+					{TargetLabel: "__meta_foo", Replacement: "bar"},
+				},
+				ScrapeOptions: operator.ScrapeOptions{
+					DefaultScrapeInterval: time.Hour,
+					DefaultScrapeTimeout:  42 * time.Second,
+				},
+				Secrets: &mockSecretStore{},
+			}
+
+			cfg, err := cg.generateEc2ScrapeConfigConfig(tc.m, tc.ec2Config, 1)
+
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			// Check relabel configs separately
+			rlcs := cfg.RelabelConfigs
+			mrlcs := cfg.MetricRelabelConfigs
+			cfg.RelabelConfigs = nil
+			cfg.MetricRelabelConfigs = nil
+
+			assert.Equal(t, tc.expected, cfg)
+
+			checkRelabels := func(actual []*relabel.Config, expected string) {
+				if expected == "" {
+					assert.Empty(t, actual)
+					return
+				}
+				// Load the expected relabel rules as yaml so we get the defaults put in there.
+				ex := []*relabel.Config{}
+				err := yaml.Unmarshal([]byte(expected), &ex)
+				require.NoError(t, err)
+				y, err := yaml.Marshal(ex)
+				require.NoError(t, err)
+				expected = string(y)
+
+				y, err = yaml.Marshal(actual)
+				require.NoError(t, err)
+
+				if !assert.YAMLEq(t, expected, string(y)) {
+					fmt.Fprintln(os.Stderr, string(y))
+					fmt.Fprintln(os.Stderr, expected)
+				}
+			}
+			checkRelabels(rlcs, tc.expectedRelabels)
+			checkRelabels(mrlcs, tc.expectedMetricRelabels)
+		})
+	}
+}
+
+// mockSecretStore is a mock implementation of the SecretStore interface for testing
+type mockSecretStore struct{}
+
+func (m *mockSecretStore) GetSecretValue(_ string, sec corev1.SecretKeySelector) (string, error) {
+	// Return mock values for testing
+	switch sec.Name {
+	case "aws-access-key":
+		return "mock-access-key", nil
+	case "aws-secret-key":
+		return "mock-secret-key", nil
+	default:
+		return "mock-value", nil
+	}
+}
+
+func (m *mockSecretStore) GetConfigMapValue(_ string, _ corev1.ConfigMapKeySelector) (string, error) {
+	panic("not implemented yet")
+}
+
+func (m *mockSecretStore) SecretOrConfigMapValue(_ string, _ v1.SecretOrConfigMap) (string, error) {
+	panic("not implemented yet")
 }


### PR DESCRIPTION
#### PR Description

This PR adds support for `ScrapeConfig` that defines an `ec2SdConfigs` list. It also updates the documentation to mention what are the `ScrapeConfig` supported actually. The actual implementation is adapted from the [prometheus-operator](https://github.com/prometheus-operator/prometheus-operator/blob/main/pkg/prometheus/promcfg.go#L3590).

For the test below, authentication with AWS was done using a service account in Kubernetes mapped to an IAM role.

Example : 

```yaml
apiVersion: monitoring.coreos.com/v1alpha1
kind: ScrapeConfig
metadata:  
  name: clickhouse-transfer-hjar-metrics-custom-scrapeconfig
  namespace: clickhouse-transfer-hjar
  labels:
    prometheus.io/operator: "true"
spec:
  ec2SDConfigs:
  - filters:
    - name: tag:env
      values:
      - staging
    - name: instance-state-name
      values:
      - running
    - name: tag:role
      values:
      - clickhouse-transfer-hjar
    port: 9363
    refreshInterval: 15s
    region: eu-west-1
  honorLabels: false
  metricRelabelings:
  - action: replace
    regex: (.+)
    replacement: chn_${1}
    sourceLabels:
    - __name__
    targetLabel: __name__
  metricsPath: /metrics
  relabelings:
  - action: replace
    replacement: eu-west-1
    targetLabel: region
  - action: replace
    replacement: staging
    targetLabel: env
  - action: replace
    replacement: aws
    targetLabel: cloud
  - action: replace
    replacement: analytics-databases
    targetLabel: unit
  - action: replace
    replacement: dataengineering
    targetLabel: owners
  - action: replace
    replacement: compute
    targetLabel: deployment_type
  - action: labelmap
    regex: __meta_ec2_tag_(.+)
  - action: labelmap
    regex: __meta_ec2_instance_(.+)
  scheme: HTTP
  scrapeInterval: 15s
  scrapeTimeout: 10s
```

Produces  : 

<img width="1430" height="786" alt="Capture d’écran 2025-08-28 à 14 57 41" src="https://github.com/user-attachments/assets/808b0f84-a715-4ada-a6db-27e96cf397d3" />

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

This doesn't fix any issues, it's simply a new feature / improvement. I plan to do another PRs to add `azureSdConfigs` also.

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated
