### PR TITLE
fix: convert journal legacy position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,8 @@ Main (unreleased)
 
 - `prometheus.exporter.azure` supports setting `interval` and `timespan` independently allowing for further look back when querying metrics. (@kgeckhart)
 
+- `loki.source.journal` now supports `legacy_positon` block that can be used to translate Static Agent or Promtail position files. (@kalleep)
+
 ### Bugfixes
 
 - Update `webdevops/go-common` dependency to resolve concurrent map write panic. (@dehaansa)

--- a/docs/sources/reference/components/loki/loki.source.journal.md
+++ b/docs/sources/reference/components/loki/loki.source.journal.md
@@ -70,7 +70,20 @@ The final internal label name would be `__journal__systemd_unit`, with _two_ und
 
 ## Blocks
 
-The `loki.source.journal` component doesn't support any blocks. You can configure this component with arguments.
+You can use the following blocks with `loki.source.journal`:
+
+| Name                                 | Description                                      | Required |
+| ------------------------------------ | ------------------------------------------------ | -------- |
+| [`legacy_position`][legacy_position] | Configure conversion from legacy positions file. | no       |
+
+[legacy_position]: #legacy_position
+
+### `legacy_position`
+
+| Name   | Type     | Description                                          |  Required |
+| ------ | -------- | ---------------------------------------------------- |  -------- |
+| `file` | `string` | File to convert.                                     | yes       |
+| `name` | `string` | Job name used for journal (agent static or promtail) | yes       k:w
 
 ## Component health
 

--- a/docs/sources/reference/components/loki/loki.source.journal.md
+++ b/docs/sources/reference/components/loki/loki.source.journal.md
@@ -83,7 +83,9 @@ You can use the following blocks with `loki.source.journal`:
 | Name   | Type     | Description                                          |  Required |
 | ------ | -------- | ---------------------------------------------------- |  -------- |
 | `file` | `string` | File to convert.                                     | yes       |
-| `name` | `string` | Job name used for journal (agent static or promtail) | yes       k:w
+| `name` | `string` | Job name used for journal (agent static or promtail) | yes       |
+
+The translation of legacy position file will happens if there is no position file already and is a valid yaml file to convert.
 
 ## Component health
 

--- a/internal/component/common/loki/positions/positions_test.go
+++ b/internal/component/common/loki/positions/positions_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
@@ -112,6 +112,36 @@ func TestLegacyConversionWithNoLegacyFile(t *testing.T) {
 		require.True(t, k.Path == "/tmp/newrandom.log")
 		require.True(t, v == "100")
 	}
+}
+
+func TestConvertLegacyPositionsFileJournal(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	journalCursor := "s=96c0493b15cd4824b73d031da667369f;i=25557;b=64c7ff8e6dbc4a21b77425da44ce57f1;m=d9ddfd2be7;t=63d7d20071963;x=336b5294210ef9ec"
+	legacyFile := filepath.Join(tmpDir, "legacy.yaml")
+	legacyPositions := LegacyFile{
+		Positions: map[string]string{
+			"/some/path/test.log": "100",
+			CursorKey("oldjob"):   journalCursor,
+		},
+	}
+
+	f, err := os.Create(legacyFile)
+	require.NoError(t, err)
+	require.NoError(t, yaml.NewEncoder(f).Encode(legacyPositions))
+	require.NoError(t, f.Close())
+
+	newFile := filepath.Join(tmpDir, "new.yaml")
+	ConvertLegacyPositionsFileJournal(legacyFile, "oldjob", newFile, "loki.source.journal.test", log.NewNopLogger())
+
+	f, err = os.Open(newFile)
+	require.NoError(t, err)
+
+	var posFile File
+	require.NoError(t, yaml.NewDecoder(f).Decode(&posFile))
+
+	pos := posFile.Positions[Entry{Path: CursorKey("loki.source.journal.test"), Labels: "{}"}]
+	require.Equal(t, journalCursor, pos)
 }
 
 func TestReadPositionsOK(t *testing.T) {

--- a/internal/component/loki/source/journal/journal.go
+++ b/internal/component/loki/source/journal/journal.go
@@ -53,9 +53,14 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		return nil, err
 	}
 
+	positionFile := filepath.Join(o.DataPath, "positions.yml")
+	if args.LegacyPosition != nil {
+		positions.ConvertLegacyPositionsFileJournal(args.LegacyPosition.File, args.LegacyPosition.Name, positionFile, o.ID, o.Logger)
+	}
+
 	positionsFile, err := positions.New(o.Logger, positions.Config{
 		SyncPeriod:        10 * time.Second,
-		PositionsFile:     filepath.Join(o.DataPath, "positions.yml"),
+		PositionsFile:     positionFile,
 		IgnoreInvalidYaml: false,
 		ReadOnly:          false,
 	})

--- a/internal/component/loki/source/journal/types.go
+++ b/internal/component/loki/source/journal/types.go
@@ -9,13 +9,19 @@ import (
 
 // Arguments are the arguments for the component.
 type Arguments struct {
-	FormatAsJson bool                `alloy:"format_as_json,attr,optional"`
-	MaxAge       time.Duration       `alloy:"max_age,attr,optional"`
-	Path         string              `alloy:"path,attr,optional"`
-	RelabelRules alloy_relabel.Rules `alloy:"relabel_rules,attr,optional"`
-	Matches      string              `alloy:"matches,attr,optional"`
-	Receivers    []loki.LogsReceiver `alloy:"forward_to,attr"`
-	Labels       map[string]string   `alloy:"labels,attr,optional"`
+	FormatAsJson   bool                `alloy:"format_as_json,attr,optional"`
+	MaxAge         time.Duration       `alloy:"max_age,attr,optional"`
+	Path           string              `alloy:"path,attr,optional"`
+	RelabelRules   alloy_relabel.Rules `alloy:"relabel_rules,attr,optional"`
+	Matches        string              `alloy:"matches,attr,optional"`
+	Receivers      []loki.LogsReceiver `alloy:"forward_to,attr"`
+	Labels         map[string]string   `alloy:"labels,attr,optional"`
+	LegacyPosition *LegacyPosition     `alloy:"legacy_position,block,optional"`
+}
+
+type LegacyPosition struct {
+	File string `alloy:"file,attr"`
+	Name string `alloy:"name,attr"`
 }
 
 func defaultArgs() Arguments {


### PR DESCRIPTION
#### PR Description
When transitioning from either promtail or agent static there is no way to pick up the old position file in legacy format.

This pr address this by adding a new function that will read the legacy position file and try to find the journal cursor belonging to the old job and translate it to the new cursor used by alloy.

#### Which issue(s) this PR fixes


#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
