### PR TITLE
remote_write: Only use a slice when we have a hash conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,8 @@ Main (unreleased)
 - (_Experimental_) Add an extra parameter to the `array.combine_maps` standard library function
   to enable preserving the first input list even if there is no match. (@ptodev)
 
+- Reduce memory overhead of `prometheus.remote_write`'s WAL by bringing in an upstream change to only track series in a slice if there's a hash conflict. (@kgeckhart)
+
 ### Bugfixes
 
 - Update `webdevops/go-common` dependency to resolve concurrent map write panic. (@dehaansa)
@@ -115,7 +117,7 @@ Main (unreleased)
 
 - Increase default connection limit in `pyroscope.receive_http` from 100 to 16k. (@korniltsev)
 
-- Fix issue in prometheus remote_write WAL which could allow it to hold an active series forever. (@kgeckhart)
+- Fix issue in `prometheus.remote_write`'s WAL which could allow it to hold an active series forever. (@kgeckhart)
 
 - Fix issue in static and promtail converter where metrics type was not properly handled. (@kalleep)
 

--- a/internal/static/metrics/wal/series.go
+++ b/internal/static/metrics/wal/series.go
@@ -12,6 +12,8 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunks"
 )
 
+// Upstream prometheus implementation https://github.com/prometheus/prometheus/blob/main/tsdb/agent/series.go
+
 // memSeries is a chunkless version of tsdb.memSeries.
 type memSeries struct {
 	sync.Mutex
@@ -35,14 +37,23 @@ func (m *memSeries) updateTimestamp(newTs int64) bool {
 	return false
 }
 
-// seriesHashmap is a simple hashmap for memSeries by their label set.
-// It is built on top of a regular hashmap and holds a slice of series to
-// resolve hash collisions. Its methods require the hash to be submitted
+// seriesHashmap lets stores a memSeries by its label set, via a 64-bit hash.
+// There is one map for the common case where the hash value is unique, and a
+// second map for the case that two series have the same hash value.
+// Each series is in only one of the maps. Its methods require the hash to be submitted
 // with the label set to avoid re-computing hash throughout the code.
-type seriesHashmap map[uint64][]*memSeries
+type seriesHashmap struct {
+	unique    map[uint64]*memSeries
+	conflicts map[uint64][]*memSeries
+}
 
-func (m seriesHashmap) Get(hash uint64, lset labels.Labels) *memSeries {
-	for _, s := range m[hash] {
+func (m *seriesHashmap) Get(hash uint64, lset labels.Labels) *memSeries {
+	if s, found := m.unique[hash]; found {
+		if labels.Equal(s.lset, lset) {
+			return s
+		}
+	}
+	for _, s := range m.conflicts[hash] {
 		if labels.Equal(s.lset, lset) {
 			return s
 		}
@@ -50,28 +61,49 @@ func (m seriesHashmap) Get(hash uint64, lset labels.Labels) *memSeries {
 	return nil
 }
 
-func (m seriesHashmap) Set(hash uint64, s *memSeries) {
-	seriesSet := m[hash]
+func (m *seriesHashmap) Set(hash uint64, s *memSeries) {
+	if existing, found := m.unique[hash]; !found || labels.Equal(existing.lset, s.lset) {
+		m.unique[hash] = s
+		return
+	}
+	if m.conflicts == nil {
+		m.conflicts = make(map[uint64][]*memSeries)
+	}
+	seriesSet := m.conflicts[hash]
 	for i, prev := range seriesSet {
 		if labels.Equal(prev.lset, s.lset) {
 			seriesSet[i] = s
 			return
 		}
 	}
-	m[hash] = append(seriesSet, s)
+	m.conflicts[hash] = append(seriesSet, s)
 }
 
-func (m seriesHashmap) Delete(hash uint64, ref chunks.HeadSeriesRef) {
+func (m *seriesHashmap) Delete(hash uint64, ref chunks.HeadSeriesRef) {
 	var rem []*memSeries
-	for _, s := range m[hash] {
-		if s.ref != ref {
-			rem = append(rem, s)
+	unique, found := m.unique[hash]
+	switch {
+	case !found: // Supplied hash is not stored.
+		return
+	case unique.ref == ref:
+		conflicts := m.conflicts[hash]
+		if len(conflicts) == 0 { // Exactly one series with this hash was stored
+			delete(m.unique, hash)
+			return
+		}
+		m.unique[hash] = conflicts[0] // First remaining series goes in 'unique'.
+		rem = conflicts[1:]           // Keep the rest.
+	default: // The series to delete is somewhere in 'conflicts'. Keep all the ones that don't match.
+		for _, s := range m.conflicts[hash] {
+			if s.ref != ref {
+				rem = append(rem, s)
+			}
 		}
 	}
 	if len(rem) == 0 {
-		delete(m, hash)
+		delete(m.conflicts, hash)
 	} else {
-		m[hash] = rem
+		m.conflicts[hash] = rem
 	}
 }
 
@@ -107,7 +139,10 @@ func newStripeSeries(stripeSize int) *stripeSeries {
 		s.series[i] = map[chunks.HeadSeriesRef]*memSeries{}
 	}
 	for i := range s.hashes {
-		s.hashes[i] = seriesHashmap{}
+		s.hashes[i] = seriesHashmap{
+			unique:    map[uint64]*memSeries{},
+			conflicts: nil, // Initialized on demand in set().
+		}
 	}
 	for i := range s.exemplars {
 		s.exemplars[i] = map[chunks.HeadSeriesRef]*exemplar.Exemplar{}
@@ -115,8 +150,8 @@ func newStripeSeries(stripeSize int) *stripeSeries {
 	return s
 }
 
-// gc garbage collects old chunks that are strictly before mint and removes
-// series entirely that have no chunks left.
+// gc garbage collects old series that have not received a sample after mint
+// and will fully delete them.
 func (s *stripeSeries) gc(mint int64) map[chunks.HeadSeriesRef]struct{} {
 	// NOTE(rfratto): GC will grab two locks, one for the hash and the other for
 	// series. It's not valid for any other function to grab both locks,
@@ -126,39 +161,48 @@ func (s *stripeSeries) gc(mint int64) map[chunks.HeadSeriesRef]struct{} {
 	defer s.gcMut.Unlock()
 
 	deleted := map[chunks.HeadSeriesRef]struct{}{}
+
+	// For one series, check if it is stale and delete it and the latest exemplar if so.
+	check := func(hashLock int, hash uint64, series *memSeries) {
+		series.Lock()
+
+		// Any series that has received a write since mint is still alive.
+		if series.lastTs >= mint {
+			series.Unlock()
+			return
+		}
+
+		// The series is stale. We need to obtain a second lock for the
+		// ref if it's different than the hash lock.
+		refLock := int(series.ref) & (s.size - 1)
+		if hashLock != refLock {
+			s.locks[refLock].Lock()
+		}
+
+		deleted[series.ref] = struct{}{}
+		delete(s.series[refLock], series.ref)
+		s.hashes[hashLock].Delete(hash, series.ref)
+
+		// Since the series is gone, we'll also delete
+		// the latest stored exemplar.
+		delete(s.exemplars[refLock], series.ref)
+
+		if hashLock != refLock {
+			s.locks[refLock].Unlock()
+		}
+		series.Unlock()
+	}
+
 	for hashLock := 0; hashLock < s.size; hashLock++ {
 		s.locks[hashLock].Lock()
 
-		for hash, all := range s.hashes[hashLock] {
+		for hash, all := range s.hashes[hashLock].conflicts {
 			for _, series := range all {
-				series.Lock()
-
-				// Any series that has received a write since mint is still alive.
-				if series.lastTs >= mint {
-					series.Unlock()
-					continue
-				}
-
-				// The series is stale. We need to obtain a second lock for the
-				// ref if it's different than the hash lock.
-				refLock := int(s.refLock(series.ref))
-				if hashLock != refLock {
-					s.locks[refLock].Lock()
-				}
-
-				deleted[series.ref] = struct{}{}
-				delete(s.series[refLock], series.ref)
-				s.hashes[hashLock].Delete(hash, series.ref)
-
-				// Since the series is gone, we'll also delete
-				// the latest stored exemplar.
-				delete(s.exemplars[refLock], series.ref)
-
-				if hashLock != refLock {
-					s.locks[refLock].Unlock()
-				}
-				series.Unlock()
+				check(hashLock, hash, series)
 			}
+		}
+		for hash, series := range s.hashes[hashLock].unique {
+			check(hashLock, hash, series)
 		}
 
 		s.locks[hashLock].Unlock()

--- a/internal/static/metrics/wal/series_test.go
+++ b/internal/static/metrics/wal/series_test.go
@@ -1,0 +1,123 @@
+package wal
+
+import (
+	"math"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+)
+
+func TestNoDeadlock(t *testing.T) {
+	const numWorkers = 1000
+
+	var (
+		wg           sync.WaitGroup
+		started      = make(chan struct{})
+		stripeSeries = newStripeSeries(3)
+	)
+
+	wg.Add(numWorkers)
+	for i := 0; i < numWorkers; i++ {
+		go func() {
+			defer wg.Done()
+			<-started
+			_ = stripeSeries.gc(math.MaxInt64)
+		}()
+	}
+
+	wg.Add(numWorkers)
+	for i := 0; i < numWorkers; i++ {
+		go func(i int) {
+			defer wg.Done()
+			<-started
+
+			series := &memSeries{
+				ref: chunks.HeadSeriesRef(i),
+				lset: labels.FromMap(map[string]string{
+					"id": strconv.Itoa(i),
+				}),
+			}
+			stripeSeries.Set(series.lset.Hash(), series)
+		}(i)
+	}
+
+	finished := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(finished)
+	}()
+
+	close(started)
+	select {
+	case <-finished:
+		return
+	case <-time.After(15 * time.Second):
+		require.FailNow(t, "deadlock detected")
+	}
+}
+
+func labelsWithHashCollision() (labels.Labels, labels.Labels) {
+	// These two series have the same XXHash; thanks to https://github.com/pstibrany/labels_hash_collisions
+	ls1 := labels.FromStrings("__name__", "metric", "lbl", "HFnEaGl")
+	ls2 := labels.FromStrings("__name__", "metric", "lbl", "RqcXatm")
+
+	if ls1.Hash() != ls2.Hash() {
+		// These ones are the same when using -tags slicelabels
+		ls1 = labels.FromStrings("__name__", "metric", "lbl1", "value", "lbl2", "l6CQ5y")
+		ls2 = labels.FromStrings("__name__", "metric", "lbl1", "value", "lbl2", "v7uDlF")
+	}
+
+	if ls1.Hash() != ls2.Hash() {
+		panic("This code needs to be updated: find new labels with colliding hash values.")
+	}
+
+	return ls1, ls2
+}
+
+// stripeSeriesWithCollidingSeries returns a stripeSeries with two memSeries having the same, colliding, hash.
+func stripeSeriesWithCollidingSeries(*testing.T) (*stripeSeries, *memSeries, *memSeries) {
+	lbls1, lbls2 := labelsWithHashCollision()
+	ms1 := memSeries{
+		lset: lbls1,
+	}
+	ms2 := memSeries{
+		lset: lbls2,
+	}
+	hash := lbls1.Hash()
+	s := newStripeSeries(1)
+
+	s.Set(hash, &ms1)
+	s.Set(hash, &ms2)
+
+	return s, &ms1, &ms2
+}
+
+func TestStripeSeries_Get(t *testing.T) {
+	s, ms1, ms2 := stripeSeriesWithCollidingSeries(t)
+	hash := ms1.lset.Hash()
+
+	// Verify that we can get both of the series despite the hash collision
+	got := s.GetByHash(hash, ms1.lset)
+	require.Same(t, ms1, got)
+	got = s.GetByHash(hash, ms2.lset)
+	require.Same(t, ms2, got)
+}
+
+func TestStripeSeries_gc(t *testing.T) {
+	s, ms1, ms2 := stripeSeriesWithCollidingSeries(t)
+	hash := ms1.lset.Hash()
+
+	s.gc(1)
+
+	// Verify that we can get neither ms1 nor ms2 after gc-ing corresponding series
+	got := s.GetByHash(hash, ms1.lset)
+	require.Nil(t, got)
+	got = s.GetByHash(hash, ms2.lset)
+	require.Nil(t, got)
+}

--- a/internal/static/metrics/wal/wal.go
+++ b/internal/static/metrics/wal/wal.go
@@ -35,6 +35,9 @@ import (
 	"github.com/grafana/alloy/internal/util"
 )
 
+// Upstream prometheus implementation https://github.com/prometheus/prometheus/blob/main/tsdb/agent/db.go
+// 	based on the prometheus tsdb head wal https://github.com/prometheus/prometheus/blob/main/tsdb/head_wal.go
+
 // ErrWALClosed is an error returned when a WAL operation can't run because the
 // storage has already been closed.
 var ErrWALClosed = fmt.Errorf("WAL storage closed")


### PR DESCRIPTION
#### PR Description

Syncs code from the upstream memSeries implemetation (https://github.com/prometheus/prometheus/blob/main/tsdb/agent/series.go) to our version to further reduce the memory footprint of the WAL. The idea is that we do not often have hash conflicts for series and having a lot single entry slices is a lot of unnecessary overhead. Only using a slice when there's a conflict should reduce this by a fair amount.

bench results for reference

```
benchstat series-baseline.txt series-new.txt
goos: darwin
goarch: arm64
pkg: github.com/grafana/alloy/internal/static/metrics/wal
cpu: Apple M3 Pro
                │ series-baseline.txt │           series-new.txt            │
                │       sec/op        │    sec/op     vs base               │
CreateSeries-11           539.8n ± 9%   455.0n ± 11%  -15.70% (p=0.004 n=6)

                │ series-baseline.txt │           series-new.txt           │
                │        B/op         │    B/op      vs base               │
CreateSeries-11            264.0 ± 9%   149.5 ± 33%  -43.37% (p=0.002 n=6)

                │ series-baseline.txt │          series-new.txt           │
                │      allocs/op      │ allocs/op   vs base               │
CreateSeries-11            2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.002 n=6)

```

#### Notes to the Reviewer
After this our there's only a few differences between our implementation and upstream which I will attempt to sync (the WAL bugfix being the most important one). We might be able to switch to using upstream directly here instead but it's not as high of a priority. 

#### PR Checklist

- [x] CHANGELOG.md updated
- [x] Tests updated
