### PR TITLE
fix: normalize attr key in logfmt logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,8 @@ Main (unreleased)
 
 - `loki.source.journal` now supports `legacy_positon` block that can be used to translate Static Agent or Promtail position files. (@kalleep)
 
+- Normalize attr key name in logfmt logger. (@zry98)
+
 ### Bugfixes
 
 - Update `webdevops/go-common` dependency to resolve concurrent map write panic. (@dehaansa)

--- a/internal/runtime/logging/handler.go
+++ b/internal/runtime/logging/handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 )
@@ -139,6 +140,17 @@ func (h *handler) WithGroup(name string) slog.Handler {
 	}
 }
 
+var unsafeKeyCharReplacer = strings.NewReplacer(
+	" ", "_",
+	"=", "_",
+	"\"", "_",
+	"\t", "_",
+	"\n", "_",
+	"\v", "_",
+	"\f", "_",
+	"\r", "_",
+)
+
 func replace(groups []string, a slog.Attr) slog.Attr {
 	if len(groups) > 0 {
 		return a
@@ -192,5 +204,8 @@ func replace(groups []string, a slog.Attr) slog.Attr {
 		}
 	}
 
-	return a
+	return slog.Attr{
+		Key:   unsafeKeyCharReplacer.Replace(strings.TrimSpace(a.Key)),
+		Value: a.Value,
+	}
 }

--- a/internal/runtime/logging/handler_test.go
+++ b/internal/runtime/logging/handler_test.go
@@ -26,6 +26,9 @@ func TestGroups(t *testing.T) {
 	handler := getTestHandler(t, &buf)
 	handler = handler.WithAttrs([]slog.Attr{
 		slog.String("foo", "bar"),
+		slog.String("\tspaced key\n", "baz"),
+		slog.String("key=with=equal", "qux"),
+		slog.String("key\"with\"quote", "quux"),
 	})
 
 	handler = handler.WithGroup("test")
@@ -40,7 +43,7 @@ func TestGroups(t *testing.T) {
 
 	handler.Handle(t.Context(), newTestRecord("hello world"))
 
-	expect := `level=info msg="hello world" foo=bar test.location=home test.inner.genre=jazz` + "\n"
+	expect := `level=info msg="hello world" foo=bar spaced_key=baz key_with_equal=qux key_with_quote=quux test.location=home test.inner.genre=jazz` + "\n"
 	require.Equal(t, expect, buf.String())
 }
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This fixes invalid logfmt key names (mostly containing space) in Alloy's self logs, causing the "failed to decode logfmt" error while ingesting self logs and parsing them with the `stage.logfmt` stage in `loki.process` component.

Some examples are: `"boringcrypto enabled"=true` from [here](https://github.com/grafana/alloy/blob/e45b01c9a17d4576459b956610e5105f5b1ee896/internal/alloycli/cmd_run.go#L250), `"extracted data"=` from [here](https://github.com/grafana/alloy/blob/e45b01c9a17d4576459b956610e5105f5b1ee896/internal/component/loki/process/stages/regex.go#L154), etc. There are still many cases present in the code, despite the efforts put into fixing some of those in https://github.com/grafana/alloy/pull/3495.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Tests updated
