### PR TITLE
Add an extra parameter to the `array.combine_maps` standard library function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,9 @@ Main (unreleased)
 
 - Normalize attr key name in logfmt logger. (@zry98)
 
+- (_Experimental_) Add an extra parameter to the `array.combine_maps` standard library function
+  to enable preserving the first input list even if there is no match. (@ptodev)
+
 ### Bugfixes
 
 - Update `webdevops/go-common` dependency to resolve concurrent map write panic. (@dehaansa)

--- a/docs/sources/reference/stdlib/array.md
+++ b/docs/sources/reference/stdlib/array.md
@@ -43,6 +43,9 @@ It takes three arguments:
 * The first two arguments are a of type `list(map(string))`. The keys of the map are strings.
   The value for each key could be of any Alloy type such as a `string`, `integer`, `map`, or a `capsule`.
 * The third input is an `array` containing strings. The strings are the keys whose value has to match for maps to be combined.
+* (optional) The fourth input is a `boolean` which defaults to `false`. 
+  When it is set to `true`, each item from the first argument will be passed through even if there is no match.
+  This is helpful if you want to enrich the first list with attributes from the second list, without losing any of the information from the first list.
 
 The maps that don't contain all the keys provided in the third argument will be discarded. When maps are combined and both contain the same keys, the last value from the second argument will be used.
 
@@ -73,12 +76,23 @@ for every map in arg1:
 Examples using discovery and exporter components:
 
 ```alloy
-> array.combine_maps(discovery.kubernetes.k8s_pods.targets, prometheus.exporter.postgres, ["instance"])
+> array.combine_maps(prometheus.exporter.postgres.example.targets, discovery.kubernetes.k8s_pods.targets, ["instance"], true)
 
-> array.combine_maps(prometheus.exporter.redis.default.targets, [{"instance"="1.1.1.1", "testLabelKey" = "testLabelVal"}], ["instance"])
+> array.combine_maps(prometheus.exporter.redis.default.targets, [{"instance"="1.1.1.1", "testLabelKey" = "testLabelVal"}], ["instance"], true)
 ```
 
+In the examples above the fourth argument is set to `true` so that the original targets from the exporters will still be preserved and scraped
+even if they cannot be enriched with values from the second argument.
+
 You can find more examples in the [tests][].
+
+{{< admonition type="note" >}}
+`array.combine_maps` can be useful for enriching Prometheus service discovery targets prior to a Prometheus scrape.
+It cannot be used to enrich Prometheus metrics with labels from service discovery components.
+You can use the [prometheus.enrich][] component for this purpose.
+
+[prometheus.enrich](../components/prometheus/prometheus.enrich)
+{{< /admonition >}}
 
 [tests]: https://github.com/grafana/alloy/blob/main/syntax/vm/vm_stdlib_test.go
 

--- a/syntax/internal/stdlib/stdlib.go
+++ b/syntax/internal/stdlib/stdlib.go
@@ -318,9 +318,10 @@ func concatMaps(left, right value.Value) (value.Value, error) {
 // args[0]: []map[string]string: lhs array
 // args[1]: []map[string]string: rhs array
 // args[2]: []string:            merge conditions
+// args[3]: bool:                (optional) retain unmatched elements from the lhs array
 var combineMaps = value.RawFunction(func(funcValue value.Value, args ...value.Value) (value.Value, error) {
-	if len(args) != 3 {
-		return value.Value{}, fmt.Errorf("combine_maps: expected 3 arguments, got %d", len(args))
+	if len(args) != 3 && len(args) != 4 {
+		return value.Value{}, fmt.Errorf("combine_maps: expected 3 or 4 arguments, got %d", len(args))
 	}
 
 	// Validate args[0] and args[1]
@@ -376,6 +377,23 @@ var combineMaps = value.RawFunction(func(funcValue value.Value, args ...value.Va
 		}
 	}
 
+	// Validate args[3]
+	passthrough_lhs := false
+	if len(args) == 4 {
+		if args[3].Type() != value.TypeBool {
+			return value.Null, value.ArgError{
+				Function: funcValue,
+				Argument: args[3],
+				Index:    3,
+				Inner: value.TypeError{
+					Value:    args[3],
+					Expected: value.TypeBool,
+				},
+			}
+		}
+		passthrough_lhs = args[3].Bool()
+	}
+
 	convertIfNeeded := func(v value.Value) value.Value {
 		if v.Type() != value.TypeObject {
 			obj, _ := v.TryConvertToObject() // no need to check result as arguments were validated earlier.
@@ -388,6 +406,10 @@ var combineMaps = value.RawFunction(func(funcValue value.Value, args ...value.Va
 	// how well the merge is going to go. If none of the merge conditions are met,
 	// the result array will be empty.
 	res := []value.Value{}
+	// However, if passthrough_lhs is set to true, then we know the size of the result array.
+	if passthrough_lhs {
+		res = make([]value.Value, 0, args[0].Len())
+	}
 
 	for i := 0; i < args[0].Len(); i++ {
 		for j := 0; j < args[1].Len(); j++ {
@@ -400,6 +422,8 @@ var combineMaps = value.RawFunction(func(funcValue value.Value, args ...value.Va
 					return value.Null, err
 				}
 				res = append(res, val)
+			} else if passthrough_lhs {
+				res = append(res, args[0].Index(i))
 			}
 		}
 	}

--- a/syntax/internal/stdlib/stdlib.go
+++ b/syntax/internal/stdlib/stdlib.go
@@ -378,7 +378,7 @@ var combineMaps = value.RawFunction(func(funcValue value.Value, args ...value.Va
 	}
 
 	// Validate args[3]
-	passthrough_lhs := false
+	passthroughLHS := false
 	if len(args) == 4 {
 		if args[3].Type() != value.TypeBool {
 			return value.Null, value.ArgError{
@@ -391,7 +391,7 @@ var combineMaps = value.RawFunction(func(funcValue value.Value, args ...value.Va
 				},
 			}
 		}
-		passthrough_lhs = args[3].Bool()
+		passthroughLHS = args[3].Bool()
 	}
 
 	convertIfNeeded := func(v value.Value) value.Value {
@@ -406,8 +406,8 @@ var combineMaps = value.RawFunction(func(funcValue value.Value, args ...value.Va
 	// how well the merge is going to go. If none of the merge conditions are met,
 	// the result array will be empty.
 	res := []value.Value{}
-	// However, if passthrough_lhs is set to true, then we know the size of the result array.
-	if passthrough_lhs {
+	// However, if passthroughLHS is set to true, then we know the size of the result array.
+	if passthroughLHS {
 		res = make([]value.Value, 0, args[0].Len())
 	}
 
@@ -422,7 +422,7 @@ var combineMaps = value.RawFunction(func(funcValue value.Value, args ...value.Va
 					return value.Null, err
 				}
 				res = append(res, val)
-			} else if passthrough_lhs {
+			} else if passthroughLHS {
 				res = append(res, args[0].Index(i))
 			}
 		}

--- a/syntax/vm/vm_stdlib_test.go
+++ b/syntax/vm/vm_stdlib_test.go
@@ -87,6 +87,18 @@ func TestVM_Stdlib(t *testing.T) {
 			[]map[string]interface{}{},
 		},
 		{
+			// Not enough matches for a join, but all elements from the first array are passed through.
+			"array.combine_maps",
+			`array.combine_maps([{"a" = 1, "b" = 4.2, "c" = 5}, {"d" = "asdf"}], [{"a" = 2, "b" = "5.3"}], ["a"], true)`,
+			[]map[string]interface{}{{"a": 1, "b": 4.2, "c": 5}, {"d": "asdf"}},
+		},
+		{
+			// Only one element from the first array matches, but all elements from the first array are passed through.
+			"array.combine_maps",
+			`array.combine_maps([{"a" = 1, "b" = 4.2, "c" = 5}, {"d" = "asdf"}, {"a" = 2, "b" = "1", "z" = "z1"}], [{"a" = 2, "b" = "5.3"}], ["a"], true)`,
+			[]map[string]interface{}{{"a": 1, "b": 4.2, "c": 5}, {"d": "asdf"}, {"a": 2, "z": "z1", "b": "5.3"}},
+		},
+		{
 			// Not enough matches for a join.
 			// The "a" value has differing types.
 			"array.combine_maps",


### PR DESCRIPTION
#### PR Description

This would make `array.combine_maps` more useful when enriching Prometheus Exporter targets with service discovery labels. In many cases everything should still be scraped even if the targets can't be enriched.

#### PR Checklist

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
