### PR TITLE
database_observability: minor updates to README

### DIFF
--- a/docs/sources/reference/components/database_observability/database_observability.mysql.md
+++ b/docs/sources/reference/components/database_observability/database_observability.mysql.md
@@ -140,9 +140,12 @@ The `aws` block supplies the [ARN](https://docs.aws.amazon.com/IAM/latest/UserGu
 database_observability.mysql "orders_db" {
   data_source_name = "user:pass@tcp(mysql:3306)/"
   forward_to       = [loki.write.logs_service.receiver]
-  cloud_provider   = {
-    aws = {
-      arn = "your-db-arn"
+
+  enable_collectors = ["query_samples"]
+
+  cloud_provider {
+    aws {
+      arn = "your-rds-db-arn"
     }
   }
 }

--- a/internal/component/database_observability/README.md
+++ b/internal/component/database_observability/README.md
@@ -74,7 +74,7 @@ SHOW VARIABLES LIKE 'performance_schema_max_digest_length';
 +--------------------------------------+-------+
 ```
 
-6. [OPTIONAL] Enable the `events_statements_cpu` consumer if you want to capture query samples. Verify the current setting with a sql query:
+6. [OPTIONAL] Enable the `events_statements_cpu` consumer if you want to capture CPU activity and time on query samples. Verify the current setting with a sql query:
 
 ```sql
 SELECT * FROM performance_schema.setup_consumers WHERE NAME = 'events_statements_cpu';


### PR DESCRIPTION
#### PR Description

- improve docs about mysql "setup_consumers", avoid referencing metrics when Alloy is not yet up and running
- add `cloud_providers` block in the examples
- other minor changes

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
