### PR TITLE
helm: remove curl readiness probe

### DIFF
--- a/operations/helm/charts/alloy/CHANGELOG.md
+++ b/operations/helm/charts/alloy/CHANGELOG.md
@@ -10,16 +10,9 @@ internal API changes are not present.
 Unreleased
 ----------
 
-- Add support to provide extraLabels to alloy.controler (@evkuzin)
-- Add option to not expose http server port. (@kun98-liu)
-
 ### Bug fixes
 
 - Avoid unnecessary pod restarts when the config reloader is enabled by not setting `checksum/config` pod annotation. (@ebuildy)
-
-### Enhancements
-
-- Add support for configuring initialDelaySeconds and timeoutSeconds in Helm chart for readiness probe. (@peter-meltcafe)
 
 1.2.1 (2025-08-07)
 ----------
@@ -27,6 +20,12 @@ Unreleased
 ### Enhancements
 
 - Update to Grafana Alloy v1.10.1. (@kalleep)
+
+- Add support for configuring initialDelaySeconds and timeoutSeconds in Helm chart for readiness probe. (@peter-meltcafe)
+
+- Add option to not expose http server port. (@kun98-liu)
+
+- Add support to provide extraLabels to alloy.controler (@evkuzin)
 
 1.2.0 (2025-07-16)
 ----------

--- a/operations/helm/charts/alloy/CHANGELOG.md
+++ b/operations/helm/charts/alloy/CHANGELOG.md
@@ -14,6 +14,8 @@ Unreleased
 
 - Avoid unnecessary pod restarts when the config reloader is enabled by not setting `checksum/config` pod annotation. (@ebuildy)
 
+- Remove readiness probe using curl when http server port is disabled. (@kalleep)
+
 1.2.1 (2025-08-07)
 ----------
 

--- a/operations/helm/charts/alloy/templates/containers/_agent.yaml
+++ b/operations/helm/charts/alloy/templates/containers/_agent.yaml
@@ -62,15 +62,6 @@
       scheme: {{ $values.listenScheme }}
     initialDelaySeconds: {{ $values.initialDelaySeconds }}
     timeoutSeconds: {{ $values.timeoutSeconds }}
-  {{- else }}
-  readinessProbe:
-    exec:
-      command:
-        - /bin/sh
-        - -c
-        - curl -f {{ $values.listenScheme }}://localhost:{{ $values.listenPort }}/-/ready || exit 1
-    initialDelaySeconds: {{ $values.initialDelaySeconds }}
-    timeoutSeconds: {{ $values.timeoutSeconds }}
   {{- end }}
   {{- with $values.livenessProbe }}
   livenessProbe:

--- a/operations/helm/tests/disable-http-server-port/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/disable-http-server-port/alloy/templates/controllers/daemonset.yaml
@@ -44,14 +44,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          readinessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - curl -f HTTP://localhost:12345/-/ready || exit 1
-            initialDelaySeconds: 10
-            timeoutSeconds: 1
           volumeMounts:
             - name: config
               mountPath: /etc/alloy


### PR DESCRIPTION
### PR Description
As we discussed offline and in https://github.com/grafana/alloy/issues/4226, stock alloy image does not have curl installed so we should not have a readiness probe using curl when http server is disabled.

I also updated the changelog for 1.2.1, missed that when I bumped helm chart last time.

#### Which issue(s) this PR fixes

fixes: #4226

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
