### PR TITLE
beyla.ebpf: match placeholder stability

### DIFF
--- a/internal/component/beyla/ebpf/beyla_placeholder.go
+++ b/internal/component/beyla/ebpf/beyla_placeholder.go
@@ -13,7 +13,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "beyla.ebpf",
-		Stability: featuregate.StabilityPublicPreview,
+		Stability: featuregate.StabilityGenerallyAvailable,
 		Args:      Arguments{},
 		Exports:   Exports{},
 


### PR DESCRIPTION
#### PR Description
This PR matches the non-linux placeholder stability for the beyla.ebpf component to the 'real' one.

The issue came up when trying to validate Beyla configurations in a non-linux machines failing because the placeholder was still on a public preview.

#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated (N/A)
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
- [ ] Config converters updated (N/A)