### PR TITLE
database_observability: improve error handling for MySQL and Postgres

### DIFF
--- a/internal/component/database_observability/mysql/component_test.go
+++ b/internal/component/database_observability/mysql/component_test.go
@@ -1,18 +1,25 @@
 package mysql
 
 import (
+	"database/sql"
+	"net/http/httptest"
+	"regexp"
 	"testing"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	kitlog "github.com/go-kit/log"
+	cmp "github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/component/common/loki"
 	loki_fake "github.com/grafana/alloy/internal/component/common/loki/client/fake"
 	"github.com/grafana/alloy/internal/component/database_observability"
 	"github.com/grafana/alloy/internal/component/database_observability/mysql/collector"
+	http_service "github.com/grafana/alloy/internal/service/http"
 	"github.com/grafana/alloy/syntax"
 )
 
@@ -275,4 +282,96 @@ func Test_addLokiLabels(t *testing.T) {
 		}, lokiClient.Received()[0].Labels)
 		assert.Equal(t, "some-message", lokiClient.Received()[0].Line)
 	})
+}
+
+// TestMySQL_Update_DBUnavailable_ReportsUnhealthy tests that the component does not return an error when the database is unavailable,
+// but reports unhealthy with the error message from the database.
+func TestMySQL_Update_DBUnavailable_ReportsUnhealthy(t *testing.T) {
+	t.Parallel()
+
+	args := Arguments{DataSourceName: "user:pass@tcp(127.0.0.1:1)/db"}
+	var gotExports cmp.Exports
+	opts := cmp.Options{
+		ID:     "test.mysql",
+		Logger: kitlog.NewNopLogger(),
+		GetServiceData: func(name string) (interface{}, error) {
+			return http_service.Data{MemoryListenAddr: "127.0.0.1:0", BaseHTTPPath: "/component"}, nil
+		},
+		OnStateChange: func(e cmp.Exports) { gotExports = e },
+	}
+	c, err := New(opts, args)
+	require.NoError(t, err)
+	exported, ok := gotExports.(Exports)
+	require.True(t, ok)
+	require.Len(t, exported.Targets, 1)
+	time.Sleep(10 * time.Millisecond)
+	h := c.CurrentHealth()
+	assert.Equal(t, cmp.HealthTypeUnhealthy, h.Health)
+	assert.NotEmpty(t, h.Message)
+}
+
+// TestMySQL_StartCollectors_ReportsUnhealthy_StackedErrors tests that the component tries to start collectors on a best effort basis,
+// reports unhealthy stacking errors for the collectors that failed to start and generate metrics for the collectors that started successfully.
+func TestMySQL_StartCollectors_ReportsUnhealthy_StackedErrors(t *testing.T) {
+	t.Parallel()
+
+	args := Arguments{
+		DataSourceName:    "user:pass@tcp(127.0.0.1:3306)/db",
+		DisableCollectors: []string{"query_details", "schema_details", "setup_consumers", "explain_plans"},
+		EnableCollectors:  []string{"query_samples", "locks"},
+		QuerySampleArguments: QuerySampleArguments{
+			CollectInterval:       time.Second,
+			DisableQueryRedaction: true,
+		},
+		LocksArguments: LocksArguments{
+			CollectInterval: time.Second,
+			Threshold:       time.Second,
+		},
+	}
+	var gotExports cmp.Exports
+	opts := cmp.Options{
+		ID:     "test.mysql",
+		Logger: kitlog.NewNopLogger(),
+		GetServiceData: func(name string) (interface{}, error) {
+			return http_service.Data{MemoryListenAddr: "127.0.0.1:0", BaseHTTPPath: "/component"}, nil
+		},
+		OnStateChange: func(e cmp.Exports) { gotExports = e },
+	}
+
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	require.NoError(t, err)
+	defer db.Close()
+
+	// First ping to the database succeeds, so we can start collectors
+	mock.ExpectPing().WillDelayFor(10 * time.Millisecond)
+	// Engine info succeeds (if reached)
+	mock.ExpectQuery(`SELECT @@server_uuid, VERSION\(\)`).WillReturnRows(sqlmock.NewRows([]string{"server_uuid", "version"}).AddRow("uuid-1", "8.0.0"))
+	// QuerySample constructor queries uptime and fails
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT variable_value FROM performance_schema.global_status WHERE variable_name = 'UPTIME'")).
+		WillReturnError(assert.AnError)
+	// Locks constructor Ping fails
+	mock.ExpectPing().WillReturnError(assert.AnError)
+
+	t.Cleanup(func() { mysqlOpenSQL = sql.Open })
+	mysqlOpenSQL = func(_ string, _ string) (*sql.DB, error) { return db, nil }
+
+	c, err := New(opts, args)
+	require.NoError(t, err)
+
+	h := c.CurrentHealth()
+	assert.Equal(t, cmp.HealthTypeUnhealthy, h.Health)
+	assert.Contains(t, h.Message, collector.QuerySampleName)
+	assert.Contains(t, h.Message, collector.LocksName)
+
+	exported, ok := gotExports.(Exports)
+	require.True(t, ok)
+	require.NotEmpty(t, exported.Targets)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	c.Handler().ServeHTTP(rec, req)
+	body := rec.Body.String()
+	assert.Contains(t, body, "database_observability_connection_info")
+	assert.Contains(t, body, "engine=\"mysql\"")
+	assert.Contains(t, body, "engine_version=\"8.0.0\"")
 }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

This is improving error handling for both `database_observability.mysql` and `database_observability.postgres` components, by not returning errors arising when the collectors are started, but rather logging it and reporting unhealthy.

Additionally, a best-effort approach was implemented, so that if one collector fails it does not stop other collectors to start, if possible.

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
