### PR TITLE
Use auto-merge PRs for dev_canary image updates in deployment tools

### DIFF
--- a/.github/workflows/publish-alloy-devel.yml
+++ b/.github/workflows/publish-alloy-devel.yml
@@ -87,6 +87,11 @@ jobs:
           "git_committer_email": "119986603+updater-for-ci[bot]@users.noreply.github.com",
           "git_author_email": "119986603+updater-for-ci[bot]@users.noreply.github.com",
           "destination_branch": "master",
+          "pull_request_branch_prefix": "auto-merge/updater/alloy",
+          "pull_request_enabled": true,
+          "pull_request_existing_strategy": "replace",
+          "pull_request_message": "Created by https://github.com/grafana/alloy/actions/runs/${{ github.run_id }}. This PR will auto-merge once CI has passed.",
+          "pull_request_team_reviewers": [],
           "repo_name": "deployment_tools",
           "update_jsonnet_attribute_configs": [
             {


### PR DESCRIPTION
This PR modifies the parameters used in the updater during the `publish-alloy-devel.yml` workflow.

After this change the updater will create an auto-merge PR to merge image updates to deployment tools.

This change ensures all CI checks are successful before image updates are merged.

Similar to: https://github.com/grafana/grafana-recommender/pull/35