### PR TITLE
Add integration test for remote write v2 with remote_write

### DIFF
--- a/internal/cmd/integration-tests/common/metric.go
+++ b/internal/cmd/integration-tests/common/metric.go
@@ -21,7 +21,7 @@ type MetricData struct {
 }
 
 type HistogramRawData struct {
-	Timestamp int64
+	Timestamp float64
 	Data      HistogramData
 }
 

--- a/internal/cmd/integration-tests/docker-compose.yaml
+++ b/internal/cmd/integration-tests/docker-compose.yaml
@@ -1,7 +1,7 @@
 name: alloy-integration-tests
 services:
   mimir:
-    image: grafana/mimir:2.10.4
+    image: grafana/mimir:2.17.0
     volumes:
       - ./configs/mimir:/etc/mimir-config
     entrypoint:

--- a/internal/cmd/integration-tests/tests/scrape-prom-metrics/config.alloy
+++ b/internal/cmd/integration-tests/tests/scrape-prom-metrics/config.alloy
@@ -11,6 +11,7 @@ prometheus.scrape "scrape_prom_metrics" {
   forward_to = [
     prometheus.write.queue.scrape_prom_metrics.receiver,
     prometheus.remote_write.scrape_prom_metrics.receiver,
+    prometheus.remote_write.scrape_prom_metrics_prw_v2.receiver,
     otelcol.receiver.prometheus.scrape_prom_metrics_to_otlp.receiver,
   ]
   scrape_classic_histograms = true
@@ -65,4 +66,14 @@ otelcol.exporter.otlphttp "scrape_prom_metrics_to_otlp" {
       insecure_skip_verify = true
     }
   }
+}
+
+prometheus.remote_write "scrape_prom_metrics_prw_v2" {
+    external_labels = {
+      test_name = "scrape_prom_metrics_prw_v2",
+    }
+	endpoint {
+	    protobuf_message = "io.prometheus.write.v2.Request"
+		url = "http://mimir:9009/api/v1/push"
+	}
 }

--- a/internal/cmd/integration-tests/tests/scrape-prom-metrics/scrape_prom_metrics_prw_v2_test.go
+++ b/internal/cmd/integration-tests/tests/scrape-prom-metrics/scrape_prom_metrics_prw_v2_test.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package main
+
+import (
+	"testing"
+
+	"github.com/grafana/alloy/internal/cmd/integration-tests/common"
+)
+
+// PRWv2 = prometheus remote write v2 format https://prometheus.io/docs/specs/prw/remote_write_spec_2_0/
+func TestScrapePromMetricsPRWv2(t *testing.T) {
+	common.MimirMetricsTest(t, common.PromDefaultMetrics, nil, "scrape_prom_metrics_prw_v2")
+}

--- a/internal/cmd/integration-tests/tests/scrape-prom-metrics/scrape_prom_metrics_remote_write_test.go
+++ b/internal/cmd/integration-tests/tests/scrape-prom-metrics/scrape_prom_metrics_remote_write_test.go
@@ -8,6 +8,6 @@ import (
 	"github.com/grafana/alloy/internal/cmd/integration-tests/common"
 )
 
-func TestScrapePromMetrics(t *testing.T) {
+func TestScrapePromMetricsRemoteWrite(t *testing.T) {
 	common.MimirMetricsTest(t, common.PromDefaultMetrics, nil, "scrape_prom_metrics_remote_write")
 }


### PR DESCRIPTION
#### PR Description
Adds an integration test for prometheus remote write v2 support with `remote_write`

#### Which issue(s) this PR fixes
Related to: https://github.com/grafana/alloy/issues/4126
