### PR TITLE
fix: demote noisy log in loki client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,8 @@ Main (unreleased)
 
 - Reduce memory overhead of `prometheus.remote_write`'s WAL by bringing in an upstream change to only track series in a slice if there's a hash conflict. (@kgeckhart)
 
+- Reduce log level from warning for `loki.write` when request fails and will be retried. (@kalleep)
+
 ### Bugfixes
 
 - Update `webdevops/go-common` dependency to resolve concurrent map write panic. (@dehaansa)

--- a/internal/component/common/loki/client/client.go
+++ b/internal/component/common/loki/client/client.go
@@ -387,7 +387,7 @@ func (c *client) sendBatch(tenantID string, batch *batch) {
 		}
 	}
 
-	level.Error(c.logger).Log("msg", "final error sending batch", "status", status, "tenant", tenantID, "error", err)
+	level.Error(c.logger).Log("msg", "final error sending batch, no retries left, dropping data", "status", status, "tenant", tenantID, "error", err)
 	// If the reason for the last retry error was rate limiting, count the drops as such, even if the previous errors
 	// were for a different reason
 	dropReason := ReasonGeneric


### PR DESCRIPTION
#### PR Description
This log is really noisy and will happen when we encounter errors that we can retry, e.g. 429 and 500 errors.

Common scenario is when we are getting rate limited and performs retries. We already have a metric that covers number of retries performed and will emit an error log if we cannot send logs after all retries are exhausted.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
