### PR TITLE
docs(pyroscope): add timeout chain troubleshooting for pyroscope components

### DIFF
--- a/docs/sources/reference/components/pyroscope/pyroscope.receive_http.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.receive_http.md
@@ -80,7 +80,7 @@ You can use the following arguments to configure the `http` block. Any omitted f
 `pyroscope_receive_http_tcp_connections` (gauge): Current number of accepted TCP connections.
 `pyroscope_receive_http_tcp_connections_limit` (gauge): The maximum number of TCP connections that the component can accept. A value of 0 means no limit.
 
-## Troubleshooting
+## Troubleshoot
 
 {{< docs/shared lookup="reference/components/pyroscope-troubleshooting.md" source="alloy" version="<ALLOY_VERSION>" >}}
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.write.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.write.md
@@ -157,7 +157,7 @@ All metrics include an `endpoint` label identifying the specific endpoint URL. T
 - `ingest_endpoint`: Per-endpoint latency for ingest operations
 - `ingest_downstream`: Downstream request latency for ingest operations
 
-## Troubleshooting
+## Troubleshoot
 
 {{< docs/shared lookup="reference/components/pyroscope-troubleshooting.md" source="alloy" version="<ALLOY_VERSION>" >}}
 


### PR DESCRIPTION
## Summary

- Document the timeout chain issue that occurs when chaining `pyroscope.write` → `pyroscope.receive_http` → `pyroscope.write`
- Add clear explanation of the problem and multiple solution approaches
- Provide configuration examples for proper timeout settings

## Problem

When pyroscope components are chained together, the default 10-second timeout on both `pyroscope.write` components can cause issues:
- The request context deadline is passed through the entire chain
- If the downstream `pyroscope.write` takes the full 10 seconds (e.g., due to broken TCP connection), there's no time left for retries
- This results in `deadline_exceeded: context deadline exceeded` errors

## Solutions Documented

1. **Increase timeout on the first pyroscope.write** - provides buffer for downstream processing and retries
2. **Decrease timeout on downstream pyroscope.write** - ensures faster failures and allows retry attempts  
3. **Configure both appropriately** - optimal approach considering expected latency and retry requirements



🤖 Generated with [Claude Code](https://claude.ai/code)