### PR TITLE
pyroscope.write: rework to accept useragent and seed in constructor

### DIFF
--- a/internal/component/pyroscope/write/write.go
+++ b/internal/component/pyroscope/write/write.go
@@ -153,7 +153,14 @@ type Exports struct {
 }
 
 // New creates a new pyroscope.write component.
-func New(logger log.Logger, tracer trace.Tracer, reg prometheus.Registerer, onStateChange func(Exports), userAgent string, uid string, c Arguments) (*Component, error) {
+func New(
+	logger log.Logger,
+	tracer trace.Tracer,
+	reg prometheus.Registerer,
+	onStateChange func(Exports),
+	userAgent, uid string,
+	c Arguments,
+) (*Component, error) {
 
 	m := newMetrics(reg)
 	receiver, err := newFanOut(logger, tracer, c, m, userAgent, uid)

--- a/internal/component/pyroscope/write/write_test.go
+++ b/internal/component/pyroscope/write/write_test.go
@@ -90,10 +90,18 @@ func Test_Write_FanOut(t *testing.T) {
 		t.Helper()
 		var wg sync.WaitGroup
 		wg.Add(1)
-		c, err := New(util.TestAlloyLogger(t), (noop.TracerProvider{}).Tracer(""), prometheus.NewRegistry(), func(e Exports) {
-			defer wg.Done()
-			export = e
-		}, "Alloy/239", "", arg)
+		c, err := New(
+			util.TestAlloyLogger(t),
+			noop.Tracer{},
+			prometheus.NewRegistry(),
+			func(e Exports) {
+				defer wg.Done()
+				export = e
+			},
+			"Alloy/239",
+			"",
+			arg,
+		)
 		require.NoError(t, err)
 		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
@@ -161,10 +169,18 @@ func Test_Write_Update(t *testing.T) {
 	)
 	var wg sync.WaitGroup
 	wg.Add(1)
-	c, err := New(util.TestAlloyLogger(t), noop.Tracer{}, prometheus.NewRegistry(), func(e Exports) {
-		defer wg.Done()
-		export = e
-	}, "Alloy/239", "", argument)
+	c, err := New(
+		util.TestAlloyLogger(t),
+		noop.Tracer{},
+		prometheus.NewRegistry(),
+		func(e Exports) {
+			defer wg.Done()
+			export = e
+		},
+		"Alloy/239",
+		"",
+		argument,
+	)
 	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
@@ -294,10 +310,18 @@ func (s *AppendIngestTestSuite) newComponent(argument Arguments) {
 	wg.Add(1)
 	var err error
 	s.arguments = argument
-	s.component, err = New(util.TestAlloyLogger(s.T()), noop.Tracer{}, prometheus.NewRegistry(), func(e Exports) {
-		defer wg.Done()
-		s.export = e
-	}, "Alloy/239", "", argument)
+	s.component, err = New(
+		util.TestAlloyLogger(s.T()),
+		noop.Tracer{},
+		prometheus.NewRegistry(),
+		func(e Exports) {
+			defer wg.Done()
+			s.export = e
+		},
+		"Alloy/239",
+		"",
+		argument,
+	)
 	s.Require().NoError(err)
 
 	go s.component.Run(s.ctx)
@@ -569,10 +593,17 @@ func Test_Write_FanOut_ValidateLabels(t *testing.T) {
 	var wg sync.WaitGroup
 	var export Exports
 	wg.Add(1)
-	c, err := New(util.TestAlloyLogger(t), noop.Tracer{}, prometheus.NewRegistry(), func(e Exports) {
-		defer wg.Done()
-		export = e
-	}, "Alloy/239", "", argument)
+	c, err := New(
+		util.TestAlloyLogger(t),
+		noop.Tracer{},
+		prometheus.NewRegistry(),
+		func(e Exports) {
+			defer wg.Done()
+			export = e
+		}, "Alloy/239",
+		"",
+		argument,
+	)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(t.Context())

--- a/internal/component/pyroscope/write/write_test.go
+++ b/internal/component/pyroscope/write/write_test.go
@@ -93,7 +93,7 @@ func Test_Write_FanOut(t *testing.T) {
 		c, err := New(util.TestAlloyLogger(t), (noop.TracerProvider{}).Tracer(""), prometheus.NewRegistry(), func(e Exports) {
 			defer wg.Done()
 			export = e
-		}, "Alloy/239", arg)
+		}, "Alloy/239", "", arg)
 		require.NoError(t, err)
 		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
@@ -164,7 +164,7 @@ func Test_Write_Update(t *testing.T) {
 	c, err := New(util.TestAlloyLogger(t), noop.Tracer{}, prometheus.NewRegistry(), func(e Exports) {
 		defer wg.Done()
 		export = e
-	}, "Alloy/239", argument)
+	}, "Alloy/239", "", argument)
 	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
@@ -297,7 +297,7 @@ func (s *AppendIngestTestSuite) newComponent(argument Arguments) {
 	s.component, err = New(util.TestAlloyLogger(s.T()), noop.Tracer{}, prometheus.NewRegistry(), func(e Exports) {
 		defer wg.Done()
 		s.export = e
-	}, "Alloy/239", argument)
+	}, "Alloy/239", "", argument)
 	s.Require().NoError(err)
 
 	go s.component.Run(s.ctx)
@@ -572,7 +572,7 @@ func Test_Write_FanOut_ValidateLabels(t *testing.T) {
 	c, err := New(util.TestAlloyLogger(t), noop.Tracer{}, prometheus.NewRegistry(), func(e Exports) {
 		defer wg.Done()
 		export = e
-	}, "Alloy/239", argument)
+	}, "Alloy/239", "", argument)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(t.Context())

--- a/internal/component/pyroscope/write/write_test.go
+++ b/internal/component/pyroscope/write/write_test.go
@@ -90,16 +90,10 @@ func Test_Write_FanOut(t *testing.T) {
 		t.Helper()
 		var wg sync.WaitGroup
 		wg.Add(1)
-		c, err := New(
-			util.TestAlloyLogger(t),
-			(noop.TracerProvider{}).Tracer(""),
-			prometheus.NewRegistry(),
-			func(e Exports) {
-				defer wg.Done()
-				export = e
-			},
-			arg,
-		)
+		c, err := New(util.TestAlloyLogger(t), (noop.TracerProvider{}).Tracer(""), prometheus.NewRegistry(), func(e Exports) {
+			defer wg.Done()
+			export = e
+		}, "Alloy/239", arg)
 		require.NoError(t, err)
 		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
@@ -167,16 +161,10 @@ func Test_Write_Update(t *testing.T) {
 	)
 	var wg sync.WaitGroup
 	wg.Add(1)
-	c, err := New(
-		util.TestAlloyLogger(t),
-		noop.Tracer{},
-		prometheus.NewRegistry(),
-		func(e Exports) {
-			defer wg.Done()
-			export = e
-		},
-		argument,
-	)
+	c, err := New(util.TestAlloyLogger(t), noop.Tracer{}, prometheus.NewRegistry(), func(e Exports) {
+		defer wg.Done()
+		export = e
+	}, "Alloy/239", argument)
 	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
@@ -306,16 +294,10 @@ func (s *AppendIngestTestSuite) newComponent(argument Arguments) {
 	wg.Add(1)
 	var err error
 	s.arguments = argument
-	s.component, err = New(
-		util.TestAlloyLogger(s.T()),
-		noop.Tracer{},
-		prometheus.NewRegistry(),
-		func(e Exports) {
-			defer wg.Done()
-			s.export = e
-		},
-		argument,
-	)
+	s.component, err = New(util.TestAlloyLogger(s.T()), noop.Tracer{}, prometheus.NewRegistry(), func(e Exports) {
+		defer wg.Done()
+		s.export = e
+	}, "Alloy/239", argument)
 	s.Require().NoError(err)
 
 	go s.component.Run(s.ctx)
@@ -587,16 +569,10 @@ func Test_Write_FanOut_ValidateLabels(t *testing.T) {
 	var wg sync.WaitGroup
 	var export Exports
 	wg.Add(1)
-	c, err := New(
-		util.TestAlloyLogger(t),
-		noop.Tracer{},
-		prometheus.NewRegistry(),
-		func(e Exports) {
-			defer wg.Done()
-			export = e
-		},
-		argument,
-	)
+	c, err := New(util.TestAlloyLogger(t), noop.Tracer{}, prometheus.NewRegistry(), func(e Exports) {
+		defer wg.Done()
+		export = e
+	}, "Alloy/239", argument)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(t.Context())

--- a/internal/component/pyroscope/write/write_test.go
+++ b/internal/component/pyroscope/write/write_test.go
@@ -600,7 +600,8 @@ func Test_Write_FanOut_ValidateLabels(t *testing.T) {
 		func(e Exports) {
 			defer wg.Done()
 			export = e
-		}, "Alloy/239",
+		},
+		"Alloy/239",
 		"",
 		argument,
 	)


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->
- do not use `alloyseed.Get()` inside the component - pass as an argument to constructor
- do not use `useragent.Get()` inside the component - pass as an argument to constructor
#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
