### PR TITLE
postgres_exporter: expose stat_statements.include_query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Main (unreleased)
 
 - Add `node_filter` configuration block to `loki.source.podlogs` component to enable node-based filtering for pod discovery. When enabled, only pods running on the specified node will be discovered and monitored, significantly reducing API server load and network traffic in DaemonSet deployments. (@QuentinBisson)
 
+- Add `stat_statements` configuration block to `prometheus.exporter.postgres` component to enable query export. The new block has a property to enable the query export, the other configures the query's maximum length. (@SimonSerrano) 
+
 - (_Experimental_) Additions to experimental `database_observability.mysql` component:
   - `query_sample` collector now supports auto-enabling the necessary `setup_consumers` settings (@cristiangreco)
   - `query_sample` collector is now compatible with mysql less than 8.0.28 (@cristiangreco)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,6 @@ Main (unreleased)
 
 - Add `node_filter` configuration block to `loki.source.podlogs` component to enable node-based filtering for pod discovery. When enabled, only pods running on the specified node will be discovered and monitored, significantly reducing API server load and network traffic in DaemonSet deployments. (@QuentinBisson)
 
-- Add `stat_statements` configuration block to `prometheus.exporter.postgres` component to enable query export. The new block has a property to enable the query export, the other configures the query's maximum length. (@SimonSerrano) 
-
 - (_Experimental_) Additions to experimental `database_observability.mysql` component:
   - `query_sample` collector now supports auto-enabling the necessary `setup_consumers` settings (@cristiangreco)
   - `query_sample` collector is now compatible with mysql less than 8.0.28 (@cristiangreco)
@@ -67,6 +65,8 @@ Main (unreleased)
 - Add a flag to pyroscope.ebpf alloy configuration to set the off-cpu profiling threshold. (@luweglarz)
 
 - Add `encoding.url_encode` and `encoding.url_decode` std lib functions. (@kalleep)
+
+- Add a `stat_statements` configuration block to the `prometheus.exporter.postgres` component to enable selecting both the query ID and the full SQL statement. The new block includes one option to enable statement selection, and another to configure the maximum length of the statement text. (@SimonSerrano) 
 
 ### Enhancements
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.postgres.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.postgres.md
@@ -122,6 +122,16 @@ If `enabled` is set to `true` and no allowlist or denylist is specified, the exp
 
 If `autodiscovery` is disabled, neither `database_allowlist` nor `database_denylist` has any effect.
 
+### `stat_statements`
+
+The `stat_statements` block configures the selection of both the query ID and the full SQL statement. This configuration takes effect only when the `stat_statements` collector is enabled.
+
+The following aeguments are supported:
+| Name                 | Type           | Description                                                                    | Default | Required |
+|----------------------|----------------|--------------------------------------------------------------------------------|---------|----------|
+| `include_query`      | `bool`         | Enable the selection of query ID and SQL statement.                            | `false` | no       |
+| `query_length`       | `number`       | Maximum length of the statement query text.                                    | `200`   | no       |
+
 ## Exported fields
 
 {{< docs/shared lookup="reference/components/exporter-component-exports.md" source="alloy" version="<ALLOY_VERSION>" >}}

--- a/internal/component/prometheus/exporter/postgres/postgres.go
+++ b/internal/component/prometheus/exporter/postgres/postgres.go
@@ -37,6 +37,10 @@ var DefaultArguments = Arguments{
 	},
 	DisableDefaultMetrics:   false,
 	CustomQueriesConfigPath: "",
+	StatStatementFlags: StatStatementFlags{
+		IncludeQuery: false,
+		QueryLength:  120,
+	},
 }
 
 // Arguments configures the prometheus.exporter.postgres component
@@ -53,7 +57,8 @@ type Arguments struct {
 	EnabledCollectors       []string `alloy:"enabled_collectors,attr,optional"`
 
 	// Blocks
-	AutoDiscovery AutoDiscovery `alloy:"autodiscovery,block,optional"`
+	AutoDiscovery      AutoDiscovery      `alloy:"autodiscovery,block,optional"`
+	StatStatementFlags StatStatementFlags `alloy:"stat_statements,block,optional"`
 }
 
 func (a *Arguments) Validate() error {
@@ -73,6 +78,12 @@ type AutoDiscovery struct {
 	DatabaseDenylist  []string `alloy:"database_denylist,attr,optional"`
 }
 
+// StatStatementFlags describe the flags to pass along the activation of the stat_statements collector
+type StatStatementFlags struct {
+	IncludeQuery bool `alloy:"include_query,attr,optional"`
+	QueryLength  uint `alloy:"query_length,attr,optional"`
+}
+
 // SetToDefault implements syntax.Defaulter.
 func (a *Arguments) SetToDefault() {
 	*a = DefaultArguments
@@ -89,6 +100,8 @@ func (a *Arguments) convert(instanceName string) *postgres_exporter.Config {
 		QueryPath:              a.CustomQueriesConfigPath,
 		Instance:               instanceName,
 		EnabledCollectors:      a.EnabledCollectors,
+		IncludeQuery:           a.StatStatementFlags.IncludeQuery,
+		QueryLength:            a.StatStatementFlags.QueryLength,
 	}
 }
 

--- a/internal/component/prometheus/exporter/postgres/postgres_test.go
+++ b/internal/component/prometheus/exporter/postgres/postgres_test.go
@@ -16,6 +16,11 @@ func TestAlloyConfigUnmarshal(t *testing.T) {
 	disable_settings_metrics = true
 	disable_default_metrics = true
 	custom_queries_config_path = "/tmp/queries.yaml"
+
+	stat_statements {
+	  include_query = true
+		query_length = 200
+	}
 	
 	autodiscovery {
 		enabled = false
@@ -37,6 +42,10 @@ func TestAlloyConfigUnmarshal(t *testing.T) {
 		},
 		DisableDefaultMetrics:   true,
 		CustomQueriesConfigPath: "/tmp/queries.yaml",
+		StatStatementFlags: StatStatementFlags{
+			IncludeQuery: true,
+			QueryLength:  200,
+		},
 	}
 
 	require.Equal(t, expected, args)


### PR DESCRIPTION
#### PR Description

#### Which issue(s) this PR fixes

Fixes #4004 

#### Notes to the Reviewer

To fix this, the code heavily relies on Kingpin and the naming of the argument on the upstream repo https://github.com/prometheus-community/postgres_exporter. This is the best I could come up with without changing the upstream first. If you have another approach given your experience, I will happily change this PR.

#### PR Checklist

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
