### PR TITLE
fix: attempt to reduce allocations when using external labels in loki.write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,8 @@ Main (unreleased)
 
 - Reduce log level from warning for `loki.write` when request fails and will be retried. (@kalleep)
 
+- Reduced allocation in when using external labels for `loki.write`. (@kalleep)
+
 ### Bugfixes
 
 - Update `webdevops/go-common` dependency to resolve concurrent map write panic. (@dehaansa)

--- a/internal/component/common/loki/client/batch.go
+++ b/internal/component/common/loki/client/batch.go
@@ -3,6 +3,7 @@ package client
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -10,7 +11,6 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/prometheus/common/model"
-	"golang.org/x/exp/slices"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 

--- a/internal/component/common/loki/client/client.go
+++ b/internal/component/common/loki/client/client.go
@@ -248,10 +248,7 @@ func (c *client) run() {
 	// We apply a cap of 10ms to the ticker, to avoid too frequent checks in
 	// case the BatchWait is very low.
 	minWaitCheckFrequency := 10 * time.Millisecond
-	maxWaitCheckFrequency := c.cfg.BatchWait / 10
-	if maxWaitCheckFrequency < minWaitCheckFrequency {
-		maxWaitCheckFrequency = minWaitCheckFrequency
-	}
+	maxWaitCheckFrequency := max(c.cfg.BatchWait/10, minWaitCheckFrequency)
 
 	maxWaitCheck := time.NewTicker(maxWaitCheckFrequency)
 

--- a/internal/component/common/loki/client/client.go
+++ b/internal/component/common/loki/client/client.go
@@ -470,7 +470,15 @@ func (c *client) StopNow() {
 
 func (c *client) processEntry(e loki.Entry) (loki.Entry, string) {
 	if len(c.externalLabels) > 0 {
-		e.Labels = c.externalLabels.Merge(e.Labels)
+		if e.Labels == nil {
+			e.Labels = make(model.LabelSet, len(c.externalLabels))
+		}
+
+		for n, v := range c.externalLabels {
+			if _, ok := e.Labels[n]; !ok {
+				e.Labels[n] = v
+			}
+		}
 	}
 	tenantID := c.getTenantID(e.Labels)
 	return e, tenantID


### PR DESCRIPTION
#### PR Description
This shows up on profiles a lot. This is a similar fix to what was done in https://github.com/grafana/alloy/pull/3984.

This can still end up doing allocations if the map don't have enough capacity. But it should reduce allocation in case we have capacity because we are no longer always allocating a new map and copy over labels.

#### Which issue(s) this PR fixes

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
