### PR TITLE
Add metadata integration tests for wal.queue

### DIFF
--- a/internal/cmd/integration-tests/common/common.go
+++ b/internal/cmd/integration-tests/common/common.go
@@ -40,17 +40,10 @@ func FetchDataFromURL(url string, target Unmarshaler) error {
 
 // AssertStatefulTestEnv verifies the environment is properly configured if the test is supposed to be stateful
 func AssertStatefulTestEnv(t *testing.T) {
-	// Check if stateful is set
-	statefulEnv := os.Getenv(TestStatefulEnv)
-	if statefulEnv == "" {
-		return
-	}
-
-	isStateful, err := strconv.ParseBool(statefulEnv)
+	isStateful, err := isStatefulFromEnv()
 	if err != nil {
-		t.Fatalf("Invalid value for %s: %s", TestStatefulEnv, err)
+		t.Fatalf("Failed to get stateful test flag from environment: %s", err)
 	}
-
 	if !isStateful {
 		return
 	}
@@ -92,6 +85,28 @@ func startTimeFromEnv() (int64, error) {
 	}
 
 	return parsed, nil
+}
+
+func IsStatefulTest() bool {
+	isStateful, err := isStatefulFromEnv()
+	if err != nil {
+		return false
+	}
+	return isStateful
+}
+
+func isStatefulFromEnv() (bool, error) {
+	statefulEnv := os.Getenv(TestStatefulEnv)
+	if statefulEnv == "" {
+		return false, nil
+	}
+
+	isStateful, err := strconv.ParseBool(statefulEnv)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse %s value %s as a boolean: %s", TestStatefulEnv, statefulEnv, err)
+	}
+
+	return isStateful, nil
 }
 
 func TestTimeoutEnv(t *testing.T) time.Duration {

--- a/internal/cmd/integration-tests/common/metadata_asserts.go
+++ b/internal/cmd/integration-tests/common/metadata_asserts.go
@@ -38,7 +38,7 @@ func MimirMetadataTest(t *testing.T, expectedMetadata map[string]Metadata) {
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		metricMetadata, err = GetMetadata("")
 		assert.NoError(c, err)
-		assert.Subset(t, maps.Keys(metricMetadata.Data), expectedMetricsWithMetadata, "did not find metadata for the expected metrics")
+		assert.Subset(c, maps.Keys(metricMetadata.Data), expectedMetricsWithMetadata, "did not find metadata for the expected metrics")
 	}, TestTimeoutEnv(t), DefaultRetryInterval)
 
 	for metricName, expectedMeta := range expectedMetadata {

--- a/internal/cmd/integration-tests/common/metadata_asserts.go
+++ b/internal/cmd/integration-tests/common/metadata_asserts.go
@@ -1,0 +1,82 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
+)
+
+// Default metrics metadata
+var PromDefaultMetricMetadata = map[string]Metadata{
+	"golang_counter":          {Type: "counter"},
+	"golang_gauge":            {Type: "gauge"},
+	"golang_histogram_bucket": {Type: "histogram"},
+	"golang_histogram_count":  {Type: "histogram"},
+	"golang_histogram_sum":    {Type: "histogram"},
+	"golang_summary":          {Type: "summary"},
+}
+
+// Default native histogram metadata
+var PromDefaultNativeHistogramMetadata = map[string]Metadata{
+	"golang_native_histogram": {Type: "histogram"},
+}
+
+func MimirMetadataTest(t *testing.T, expectedMetadata map[string]Metadata) {
+	AssertStatefulTestEnv(t)
+
+	expectedMetricsWithMetadata := make([]string, 0, len(expectedMetadata))
+	for metricName := range expectedMetadata {
+		expectedMetricsWithMetadata = append(expectedMetricsWithMetadata, metricName)
+	}
+
+	var metricMetadata MetadataResponse
+	var err error
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		metricMetadata, err = GetMetadata("")
+		assert.NoError(c, err)
+		assert.Subset(t, maps.Keys(metricMetadata.Data), expectedMetricsWithMetadata, "did not find metadata for the expected metrics")
+	}, TestTimeoutEnv(t), DefaultRetryInterval)
+
+	for metricName, expectedMeta := range expectedMetadata {
+		actualMetas := metricMetadata.Data[metricName]
+		if assert.Len(t, actualMetas, 1, "expected exactly one metadata entry for metric %s but found %d", metricName, len(actualMetas)) {
+			actualMeta := actualMetas[0]
+			assert.Equal(t, expectedMeta, actualMeta, "metadata for metric %s did not match the expected metadata", metricName)
+		}
+	}
+
+	if IsStatefulTest() {
+		assert.Fail(t, "Metadata queries cannot be done with a timestamp so if we found data it's possible it's from a previous test run. This test fails so you can consider if this is a problem for you or not")
+	}
+}
+
+type Metadata struct {
+	Type string `json:"type"`
+	Help string `json:"help"`
+	Unit string `json:"unit"`
+}
+
+type MetadataResponse struct {
+	Status string                `json:"status"`
+	Data   map[string][]Metadata `json:"data"`
+}
+
+func (m *MetadataResponse) Unmarshal(bytes []byte) error {
+	return json.Unmarshal(bytes, &m)
+}
+
+func MetadataQuery(metricName string) string {
+	return fmt.Sprintf("%smetadata?metric=%s", promURL, metricName)
+}
+
+// GetMetadata returns all available metric metadata or metadata for a specific metric if metricName is provided
+func GetMetadata(optionalMetricName string) (MetadataResponse, error) {
+	var metadataResponse MetadataResponse
+	query := MetadataQuery(optionalMetricName)
+	err := FetchDataFromURL(query, &metadataResponse)
+	return metadataResponse, err
+}

--- a/internal/cmd/integration-tests/common/metadata_asserts.go
+++ b/internal/cmd/integration-tests/common/metadata_asserts.go
@@ -36,7 +36,7 @@ func MimirMetadataTest(t *testing.T, expectedMetadata map[string]Metadata) {
 	var metricMetadata MetadataResponse
 	var err error
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		metricMetadata, err = GetMetadata("")
+		metricMetadata, err = GetMetadata()
 		assert.NoError(c, err)
 		assert.Subset(c, maps.Keys(metricMetadata.Data), expectedMetricsWithMetadata, "did not find metadata for the expected metrics")
 	}, TestTimeoutEnv(t), DefaultRetryInterval)
@@ -69,14 +69,15 @@ func (m *MetadataResponse) Unmarshal(bytes []byte) error {
 	return json.Unmarshal(bytes, &m)
 }
 
-func MetadataQuery(metricName string) string {
-	return fmt.Sprintf("%smetadata?metric=%s", promURL, metricName)
+func MetadataQuery() string {
+	// https://prometheus.io/docs/prometheus/latest/querying/api/#querying-metric-metadata
+	return fmt.Sprintf("%smetadata", promURL)
 }
 
-// GetMetadata returns all available metric metadata or metadata for a specific metric if metricName is provided
-func GetMetadata(optionalMetricName string) (MetadataResponse, error) {
+// GetMetadata returns all available metric metadata
+func GetMetadata() (MetadataResponse, error) {
 	var metadataResponse MetadataResponse
-	query := MetadataQuery(optionalMetricName)
+	query := MetadataQuery()
 	err := FetchDataFromURL(query, &metadataResponse)
 	return metadataResponse, err
 }

--- a/internal/cmd/integration-tests/configs/prom-gen/main.go
+++ b/internal/cmd/integration-tests/configs/prom-gen/main.go
@@ -32,7 +32,7 @@ func main() {
 
 	address, port := getAddressAndPort(cfg.ListenAddress)
 	listenAddress := fmt.Sprintf("%s:%s", address, port)
-	http.Handle("/metrics", promhttp.Handler())
+	http.Handle("/metrics", http.HandlerFunc(handleWithPrefixSupport))
 	server := &http.Server{Addr: listenAddress, Handler: nil}
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -58,6 +58,31 @@ func main() {
 	go handleSummary(setupSummary(labels))
 	stopChan := make(chan struct{})
 	<-stopChan
+}
+
+// When wrapping with a prefix, we need something that can act as a prometheus.Collector, a prometheus.Registerer, and a prometheus.Gatherer
+// which means we need a full prometheus.Registry
+var registry = prometheus.NewRegistry()
+var defaultHandler = promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
+var metricPrefixQueryParam = "metric-prefix"
+
+func handleWithPrefixSupport(w http.ResponseWriter, r *http.Request) {
+	prefix := r.URL.Query().Get(metricPrefixQueryParam)
+	if prefix == "" {
+		log.Printf("serving with no metric prefix")
+		defaultHandler.ServeHTTP(w, r)
+		return
+	}
+
+	// Wrap the registry with the provided prefix and serve the metrics from it
+	log.Printf("serving metrics with prefix %s", prefix)
+
+	reg := prometheus.NewRegistry()
+	prefixedCollector := prometheus.WrapCollectorWithPrefix(prefix, registry)
+	reg.MustRegister(prefixedCollector)
+	h := promhttp.HandlerFor(reg, promhttp.HandlerOpts{})
+	h.ServeHTTP(w, r)
+	return
 }
 
 // getAddressAndPort always defines a non empty address and port
@@ -86,7 +111,7 @@ func setupGauge(labels map[string]string) prometheus.Gauge {
 			Name:        "gauge",
 			ConstLabels: labels,
 		})
-	prometheus.MustRegister(gauge)
+	registry.MustRegister(gauge)
 	return gauge
 }
 
@@ -110,7 +135,7 @@ func setupNativeHistogram(labels map[string]string) prometheus.Histogram {
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: 1 * time.Hour,
 		})
-	prometheus.MustRegister(nativeHistogram)
+	registry.MustRegister(nativeHistogram)
 	return nativeHistogram
 }
 
@@ -122,7 +147,7 @@ func setupHistogram(labels map[string]string) prometheus.Histogram {
 			ConstLabels: labels,
 			Buckets:     []float64{1, 10, 100, 1000},
 		})
-	prometheus.MustRegister(histogram)
+	registry.MustRegister(histogram)
 	return histogram
 }
 
@@ -143,7 +168,7 @@ func setupCounter(labels map[string]string) prometheus.Counter {
 			Name:        "counter",
 			ConstLabels: labels,
 		})
-	prometheus.MustRegister(counter)
+	registry.MustRegister(counter)
 	return counter
 }
 
@@ -164,7 +189,7 @@ func setupSummary(labels map[string]string) prometheus.Summary {
 			ConstLabels: labels,
 			Objectives:  map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		})
-	prometheus.MustRegister(summary)
+	registry.MustRegister(summary)
 	return summary
 }
 

--- a/internal/cmd/integration-tests/configs/prom-gen/main.go
+++ b/internal/cmd/integration-tests/configs/prom-gen/main.go
@@ -69,14 +69,11 @@ var metricPrefixQueryParam = "metric-prefix"
 func handleWithPrefixSupport(w http.ResponseWriter, r *http.Request) {
 	prefix := r.URL.Query().Get(metricPrefixQueryParam)
 	if prefix == "" {
-		log.Printf("serving with no metric prefix")
 		defaultHandler.ServeHTTP(w, r)
 		return
 	}
 
 	// Wrap the registry with the provided prefix and serve the metrics from it
-	log.Printf("serving metrics with prefix %s", prefix)
-
 	reg := prometheus.NewRegistry()
 	prefixedCollector := prometheus.WrapCollectorWithPrefix(prefix, registry)
 	reg.MustRegister(prefixedCollector)

--- a/internal/cmd/integration-tests/tests/prom-metadata/config.alloy
+++ b/internal/cmd/integration-tests/tests/prom-metadata/config.alloy
@@ -1,0 +1,32 @@
+logging {
+    level = "debug"
+}
+
+livedebugging {}
+
+prometheus.scrape "prom_metadata_writequeue" {
+  targets = [
+    {"__address__" = "prom-gen:9001"},
+  ]
+  params = { "metric-prefix" = ["prom_metadata_writequeue_"] }
+  forward_to = [
+    prometheus.write.queue.prom_metadata.receiver,
+  ]
+  scrape_classic_histograms = true
+  scrape_native_histograms = true
+  scrape_interval = "1s"
+  scrape_timeout = "500ms"
+  // Required for metadata support
+  honor_metadata = true
+}
+
+prometheus.write.queue "prom_metadata" {
+    endpoint "mimir" {
+        url = "http://mimir:9009/api/v1/push"
+        flush_interval = "1s"
+        batch_count = 10
+        external_labels = {
+            test_name = "prom_metadata_writequeue",
+        }
+    }
+}

--- a/internal/cmd/integration-tests/tests/prom-metadata/prom_metadata_writequeue_test.go
+++ b/internal/cmd/integration-tests/tests/prom-metadata/prom_metadata_writequeue_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/grafana/alloy/internal/cmd/integration-tests/common"
+)
+
+func TestPromMetadataWriteQueue(t *testing.T) {
+	testName := "prom_metadata_writequeue"
+	toTestMetric := func(metricName string) string {
+		return fmt.Sprintf("%s_%s", testName, metricName)
+	}
+
+	// Metadata queries cannot use a series matcher so the metrics all need to be unqiue to the test
+	metadataTestMetrics := make([]string, 0, len(common.PromDefaultMetrics))
+	for _, metricName := range common.PromDefaultMetrics {
+		metadataTestMetrics = append(metadataTestMetrics, toTestMetric(metricName))
+	}
+
+	metadataTestHistogram := make([]string, 0, len(common.PromDefaultNativeHistogramMetrics))
+	for _, metricName := range common.PromDefaultNativeHistogramMetrics {
+		metadataTestHistogram = append(metadataTestHistogram, toTestMetric(metricName))
+	}
+
+	// Make sure we got the expected metrics before checking metadata
+	common.MimirMetricsTest(t, metadataTestMetrics, metadataTestHistogram, testName)
+	expectedMetadata := make(map[string]common.Metadata, len(common.PromDefaultMetricMetadata)+len(common.PromDefaultNativeHistogramMetadata))
+	for k, v := range common.PromDefaultMetricMetadata {
+		expectedMetadata[toTestMetric(k)] = v
+	}
+	for k, v := range common.PromDefaultNativeHistogramMetadata {
+		expectedMetadata[toTestMetric(k)] = v
+	}
+	common.MimirMetadataTest(t, expectedMetadata)
+}


### PR DESCRIPTION
#### PR Description

Sets up all the necessary infrastructure to write metadata integration tests starting with write.queue

The biggest challenges to writing a metadata integration test comes from limitations in the metadata api (https://prometheus.io/docs/prometheus/latest/querying/api/#querying-metric-metadata),
1. It can only be filtered by metric names
    - We usually use labels for test isolation and that cannot be done here
    - I modified prom-gen so that it could expose metrics with a prefix so we can query unique metric names per test
2. There's no timestamp filtering - so at the end if the asserts pass I still fail it when running in stateful

#### Which issue(s) this PR fixes

Related to: https://github.com/grafana/alloy/issues/547

#### PR Checklist

- [x] Tests updated
