### PR TITLE
pyroscope.ebpf: fix pprof builder locations generation

### DIFF
--- a/internal/component/pyroscope/ebpf/reporter/builder.go
+++ b/internal/component/pyroscope/ebpf/reporter/builder.go
@@ -114,6 +114,8 @@ type functionsKey struct {
 type locationsKey struct {
 	mappingId uint64
 	addr      libpf.AddressOrLineno
+	name      libpf.String
+	line      libpf.SourceLineno
 }
 type mappingKey struct {
 	Start libpf.Address
@@ -206,10 +208,12 @@ func (p *ProfileBuilder) AddValue(v int64, sample *profile.Sample) {
 	sample.Value[0] += v * p.Profile.Period
 }
 
-func (p *ProfileBuilder) Location(m *profile.Mapping, addr libpf.AddressOrLineno) (*profile.Location, bool) {
+func (p *ProfileBuilder) Location(m *profile.Mapping, addr libpf.AddressOrLineno, name libpf.String, line libpf.SourceLineno) (*profile.Location, bool) {
 	key := locationsKey{
 		mappingId: m.ID,
 		addr:      addr,
+		name:      name,
+		line:      line,
 	}
 	loc, ok := p.locations[key]
 	if ok {

--- a/internal/component/pyroscope/ebpf/reporter/pprof.go
+++ b/internal/component/pyroscope/ebpf/reporter/pprof.go
@@ -232,7 +232,7 @@ func (p *PPROFReporter) createProfile(origin libpf.Origin, events map[samples.Tr
 				mapping = fakeMapping
 			}
 
-			location, fresh = b.Location(mapping, fr.AddressOrLineno)
+			location, fresh = b.Location(mapping, fr.AddressOrLineno, fr.FunctionName, fr.SourceLine)
 			if fresh {
 				location.Mapping = mapping
 				location.Address = uint64(fr.AddressOrLineno)


### PR DESCRIPTION
we used to use `m *profile.Mapping, addr libpf.AddressOrLineno` as the hash key.
For interpreter frames, mapping is a fake one, and addr is 0. We need to include interpreter function name and line number