### PR TITLE
chore: fix mixin mounts in docker example

### DIFF
--- a/example/docker-compose/grafana.yaml
+++ b/example/docker-compose/grafana.yaml
@@ -13,6 +13,7 @@ services:
       test: [ "CMD", "curl", "-f", "http://localhost:3000/healthz" ]
       interval: 1s
       start_interval: 0s
+      start_period: 10s
       timeout: 10s
       retries: 5
     env_file:
@@ -27,7 +28,7 @@ services:
       grafana:
         condition: service_healthy
     volumes:
-      - ../operations/alloy-mixin:/etc/alloy-mixin
+      - ../../operations/alloy-mixin:/etc/alloy-mixin
     working_dir: /etc/alloy-mixin
     command: jb install
 
@@ -41,7 +42,7 @@ services:
     environment:
       - GRAFANA_URL=http://grafana:3000
     volumes:
-      - ../operations/alloy-mixin:/etc/alloy-mixin
+      - ../../operations/alloy-mixin:/etc/alloy-mixin
     working_dir: /etc/alloy-mixin
     command: grr apply grizzly/dashboards.jsonnet
 


### PR DESCRIPTION
#### PR Description
We forgot to update paths to alloy-mixin in https://github.com/grafana/alloy/pull/3836

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
