### PR TITLE
otel/exporters/prometheus: Downgrade from retracted version to fix bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -272,7 +272,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.37.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.37.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.37.0
-	go.opentelemetry.io/otel/exporters/prometheus v0.59.0
+	go.opentelemetry.io/otel/exporters/prometheus v0.58.0
 	go.opentelemetry.io/otel/metric v1.38.0
 	go.opentelemetry.io/otel/sdk v1.37.0
 	go.opentelemetry.io/otel/sdk/metric v1.37.0
@@ -942,7 +942,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.62.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.61.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.62.0
-	go.opentelemetry.io/contrib/otelconf v0.17.0 // indirect
+	go.opentelemetry.io/contrib/otelconf v0.16.0 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.37.0 // indirect
 	go.opentelemetry.io/contrib/propagators/jaeger v1.35.0
 	go.opentelemetry.io/contrib/samplers/jaegerremote v0.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1194,12 +1194,6 @@ github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0 h1:bjh0PVYSVVFxzINqPF
 github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0/go.mod h1:7t5XR+2IA8P2qggOAHTj/GCZfoLBle3OvNSYh1VkRBU=
 github.com/grafana/vmware_exporter v0.0.5-beta.0.20250218170317-73398ba08329 h1:Rs4H1yv2Abk3xE82qpyhMGGA8rswAOA0HQZde/BYkFo=
 github.com/grafana/vmware_exporter v0.0.5-beta.0.20250218170317-73398ba08329/go.mod h1:Z28219aViNlsLlPvuCnlgHDagRdZBAZ7JOnQg1b3eWg=
-github.com/grafana/walqueue v0.0.0-20250818133131-895ab4a263dc h1:5X36phEsn496DFcSQW74ONE97aR26wgg6G6K3jiiVh0=
-github.com/grafana/walqueue v0.0.0-20250818133131-895ab4a263dc/go.mod h1:XxgS7iJBJZF8RDCr4Lz7YukISbZsFwm6tNslz/xNirA=
-github.com/grafana/walqueue v0.0.0-20250911155951-1e7aa6ea934e h1:tHFl7+oO1lI/+fScx0eyjdQh72tuHelqsjs6oCmIJnc=
-github.com/grafana/walqueue v0.0.0-20250911155951-1e7aa6ea934e/go.mod h1:XxgS7iJBJZF8RDCr4Lz7YukISbZsFwm6tNslz/xNirA=
-github.com/grafana/walqueue v0.0.0-20250911192504-2b20d5bba835 h1:KlCek2+77HpiUR/yxPmL71D1SCUN7iqzjz0b5O/MD6c=
-github.com/grafana/walqueue v0.0.0-20250911192504-2b20d5bba835/go.mod h1:XxgS7iJBJZF8RDCr4Lz7YukISbZsFwm6tNslz/xNirA=
 github.com/grafana/walqueue v0.0.0-20250911194149-20ea9d61b667 h1:mmE8xtXofgBK6BatA598euT4+53WBa48QlfbzGE9NBk=
 github.com/grafana/walqueue v0.0.0-20250911194149-20ea9d61b667/go.mod h1:XxgS7iJBJZF8RDCr4Lz7YukISbZsFwm6tNslz/xNirA=
 github.com/grobie/gomemcache v0.0.0-20230213081705-239240bbc445 h1:FlKQKUYPZ5yDCN248M3R7x8yu2E3yEZ0H7aLomE4EoE=
@@ -2660,8 +2654,8 @@ go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.
 go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.61.0/go.mod h1:HfvuU0kW9HewH14VCOLImqKvUgONodURG7Alj/IrnGI=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.62.0 h1:Hf9xI/XLML9ElpiHVDNwvqI0hIFlzV8dgIr35kV1kRU=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.62.0/go.mod h1:NfchwuyNoMcZ5MLHwPrODwUF1HWCXWrL31s8gSAdIKY=
-go.opentelemetry.io/contrib/otelconf v0.17.0 h1:Yh9uifPSe8yiksLshMbeAXGm/ZRmo7LD7Di+/yd1L5w=
-go.opentelemetry.io/contrib/otelconf v0.17.0/go.mod h1:8dHKS6uMiZlvmrA7MGUtb4HwnX+ukdF5iS3p2UPKvLE=
+go.opentelemetry.io/contrib/otelconf v0.16.0 h1:mTYGRlZtpc/zDaTaUQSnsZ1hyoRONaS4Od/Ny5++lhE=
+go.opentelemetry.io/contrib/otelconf v0.16.0/go.mod h1:gnsljuyDyVDg39vUvXKj0BVCiVaokN3b8N5BL/ab8fQ=
 go.opentelemetry.io/contrib/propagators/b3 v1.37.0 h1:0aGKdIuVhy5l4GClAjl72ntkZJhijf2wg1S7b5oLoYA=
 go.opentelemetry.io/contrib/propagators/b3 v1.37.0/go.mod h1:nhyrxEJEOQdwR15zXrCKI6+cJK60PXAkJ/jRyfhr2mg=
 go.opentelemetry.io/contrib/propagators/jaeger v1.35.0 h1:UIrZgRBHUrYRlJ4V419lVb4rs2ar0wFzKNAebaP05XU=
@@ -2689,8 +2683,8 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.37.0 h1:EtFWS
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.37.0/go.mod h1:QjUEoiGCPkvFZ/MjK6ZZfNOS6mfVEVKYE99dFhuN2LI=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.37.0 h1:bDMKF3RUSxshZ5OjOTi8rsHGaPKsAt76FaqgvIUySLc=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.37.0/go.mod h1:dDT67G/IkA46Mr2l9Uj7HsQVwsjASyV9SjGofsiUZDA=
-go.opentelemetry.io/otel/exporters/prometheus v0.59.0 h1:HHf+wKS6o5++XZhS98wvILrLVgHxjA/AMjqHKes+uzo=
-go.opentelemetry.io/otel/exporters/prometheus v0.59.0/go.mod h1:R8GpRXTZrqvXHDEGVH5bF6+JqAZcK8PjJcZ5nGhEWiE=
+go.opentelemetry.io/otel/exporters/prometheus v0.58.0 h1:CJAxWKFIqdBennqxJyOgnt5LqkeFRT+Mz3Yjz3hL+h8=
+go.opentelemetry.io/otel/exporters/prometheus v0.58.0/go.mod h1:7qo/4CLI+zYSNbv0GMNquzuss2FVZo3OYrGh96n4HNc=
 go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.13.0 h1:yEX3aC9KDgvYPhuKECHbOlr5GLwH6KTjLJ1sBSkkxkc=
 go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.13.0/go.mod h1:/GXR0tBmmkxDaCUGahvksvp66mx4yh5+cFXgSlhg0vQ=
 go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.37.0 h1:6VjV6Et+1Hd2iLZEPtdV7vie80Yyqf7oikJLjQ/myi0=

--- a/internal/cmd/integration-tests/tests/otlp-metrics/otlp_alloy_integration_metrics_test.go
+++ b/internal/cmd/integration-tests/tests/otlp-metrics/otlp_alloy_integration_metrics_test.go
@@ -4,19 +4,20 @@ package main
 
 import (
 	"testing"
+
+	"github.com/grafana/alloy/internal/cmd/integration-tests/common"
 )
 
 func TestAlloyIntegrationMetrics(t *testing.T) {
-	// TODO this test is broken and needs deeper investigation
 	// These otel metrics are needed in the k8s-monitoring helm chart (https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring-v1/default_allow_lists/alloy_integration.yaml)
-	//var OTLPMetrics = []string{
-	//	"otelcol_exporter_send_failed_spans_total",
-	//	"otelcol_exporter_sent_spans_total",
-	//	"otelcol_processor_batch_batch_send_size_bucket",
-	//	"otelcol_processor_batch_metadata_cardinality",
-	//	"otelcol_processor_batch_timeout_trigger_send_total",
-	//	"otelcol_receiver_accepted_spans_total",
-	//	"otelcol_receiver_refused_spans_total",
-	//}
-	//common.MimirMetricsTest(t, OTLPMetrics, []string{}, "otlp_integration")
+	var OTLPMetrics = []string{
+		"otelcol_exporter_send_failed_spans_total",
+		"otelcol_exporter_sent_spans_total",
+		"otelcol_processor_batch_batch_send_size_bucket",
+		"otelcol_processor_batch_metadata_cardinality",
+		"otelcol_processor_batch_timeout_trigger_send_total",
+		"otelcol_receiver_accepted_spans_total",
+		"otelcol_receiver_refused_spans_total",
+	}
+	common.MimirMetricsTest(t, OTLPMetrics, []string{}, "otlp_integration")
 }


### PR DESCRIPTION
#### PR Description

Downgrades `go.opentelemetry.io/otel/exporters/prometheus` from `v0.59.0` to `v0.58.0` to avoid a bug that breaks otel component metric naming (https://github.com/open-telemetry/opentelemetry-go/pull/7046). Upgrading to `v0.59.1` is not an option because it requires a newer version of otlptranslator and we currently have a replace to an older version to use `otlptranslator.NormalizeLabel` required by our versions of Loki (pkg/chunkenc/symbols.go) and Prometheus (storage/remote/otlptranslator/prometheusremotewrite/helper.go). 

We can look at updating both dependencies to drop our replace after the release as it's a big jump for both

#### PR Checklist

- [x] Tests updated
