### PR TITLE
pyroscope.java: Fix java log level parameter

### DIFF
--- a/internal/component/pyroscope/java/loop.go
+++ b/internal/component/pyroscope/java/loop.go
@@ -245,7 +245,7 @@ func (p *profilingLoop) start() error {
 		argv = append(argv, "--lock", cfg.Lock)
 	}
 	if cfg.LogLevel != "" {
-		argv = append(argv, "--loglevel", cfg.LogLevel)
+		argv = append(argv, "-L", cfg.LogLevel)
 	}
 	if cfg.Quiet {
 		argv = append(argv, "--quiet")


### PR DESCRIPTION
The version bundled of the async profiler has no loglevel parameter:

```
ts=2025-09-16T08:16:50.898924708Z level=error component_path=/profiling.feature component_id=pyroscope.java.java_pods pid=1184752 err="failed to start: asprof failed to run: asprof failed to run /tmp/alloy-asprof-ae0261b1093f2bc4df44a87300fef98dcdebccb5/bin/asprof: exit status 1  Unrecognized option: --loglevel\n"
```
