### PR TITLE
chore(pyroscope.ebpf): cherry-pick ruby panic fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1070,7 +1070,7 @@ exclude (
 
 replace go.opentelemetry.io/obi => github.com/grafana/opentelemetry-ebpf-instrumentation v1.2.4
 
-replace go.opentelemetry.io/ebpf-profiler => github.com/grafana/opentelemetry-ebpf-profiler v0.0.202537-0.20250916073427-281f26b4f64a
+replace go.opentelemetry.io/ebpf-profiler => github.com/grafana/opentelemetry-ebpf-profiler v0.0.202537-0.20250916114748-f2ff2fc6048c
 
 // TODO - remove this once otel updates to go 1.24 & k8s client 0.33.x
 replace k8s.io/client-go => k8s.io/client-go v0.32.6

--- a/go.sum
+++ b/go.sum
@@ -1168,8 +1168,8 @@ github.com/grafana/opentelemetry-collector/featuregate v0.0.0-20240325174506-2fd
 github.com/grafana/opentelemetry-collector/featuregate v0.0.0-20240325174506-2fd1623b2ca0/go.mod h1:mm8+xyQfgDmqhyegZRNIQmoKsNnDTwWKFLsdMoXAb7A=
 github.com/grafana/opentelemetry-ebpf-instrumentation v1.2.4 h1:2dIzC3i612KVMiG6A4sq53JS3YrCg5x4SXuP8zcLTrs=
 github.com/grafana/opentelemetry-ebpf-instrumentation v1.2.4/go.mod h1:EFQ1reX/fEsmFeyZn+G/lzMwGcEKlWBOIP8pECIvXZc=
-github.com/grafana/opentelemetry-ebpf-profiler v0.0.202537-0.20250916073427-281f26b4f64a h1:JOSCfE+qWWykOqsWssMvSy0A0aXaHJzGhYDNXhLr06k=
-github.com/grafana/opentelemetry-ebpf-profiler v0.0.202537-0.20250916073427-281f26b4f64a/go.mod h1:ajmdC82d8daScIWPT0Mmq95lvGmoBNMdAUBlWv/Hwbg=
+github.com/grafana/opentelemetry-ebpf-profiler v0.0.202537-0.20250916114748-f2ff2fc6048c h1:G+o7MkTXTgpEebJM5ctNMZw8DOPOatRM6lOLeqRPL50=
+github.com/grafana/opentelemetry-ebpf-profiler v0.0.202537-0.20250916114748-f2ff2fc6048c/go.mod h1:ajmdC82d8daScIWPT0Mmq95lvGmoBNMdAUBlWv/Hwbg=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=
 github.com/grafana/otel-profiling-go v0.5.1/go.mod h1:ftN/t5A/4gQI19/8MoWurBEtC6gFw8Dns1sJZ9W4Tls=
 github.com/grafana/postgres_exporter v0.0.0-20250714124518-c5d0a4dad445 h1:1rC8i0khfZdRA0/k7RBQQ84PhASNQLssezXHmFcWZ6Y=


### PR DESCRIPTION
Fixes panic https://github.com/grafana/alloy/issues/4438

This cherry-picks panic fix into the version that we have in main https://github.com/grafana/opentelemetry-ebpf-profiler/commits/alloy/1.11/