### PR TITLE
loki.source.journal: dont fail if journal files do not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Main (unreleased)
   - Comprehensive test coverage including unit tests and deduplication validation
   This resolves the issue where job logs were being missed, particularly for fast-completing jobs or jobs that terminated before discovery. (@QuentinBisson)
 
+- Fix `loki.source.journal` creation failing with an error when the journal file is not found. (@thampiotr)
+
 v1.11.0-rc.0
 -----------------
 

--- a/internal/component/loki/source/journal/journal.go
+++ b/internal/component/loki/source/journal/journal.go
@@ -4,6 +4,7 @@ package journal
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -12,13 +13,13 @@ import (
 	"github.com/grafana/loki/v3/clients/pkg/promtail/scrapeconfig"
 	"github.com/prometheus/common/model"
 
+	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/component/common/loki/positions"
 	alloy_relabel "github.com/grafana/alloy/internal/component/common/relabel"
 	"github.com/grafana/alloy/internal/component/loki/source/journal/internal/target"
 	"github.com/grafana/alloy/internal/featuregate"
-
-	"github.com/grafana/alloy/internal/component"
+	"github.com/grafana/alloy/internal/runtime/logging/level"
 )
 
 func init() {
@@ -37,13 +38,16 @@ var _ component.Component = (*Component)(nil)
 
 // Component represents reading from a journal
 type Component struct {
-	mut       sync.RWMutex
-	t         *target.JournalTarget
-	metrics   *target.Metrics
-	o         component.Options
-	handler   chan loki.Entry
-	positions positions.Positions
-	receivers []loki.LogsReceiver
+	mut           sync.RWMutex
+	t             *target.JournalTarget
+	metrics       *target.Metrics
+	o             component.Options
+	handler       chan loki.Entry
+	positions     positions.Positions
+	receivers     []loki.LogsReceiver
+	argsUpdated   chan struct{}
+	args          Arguments
+	healthErr     error
 }
 
 // New creates a new  component.
@@ -69,11 +73,13 @@ func New(o component.Options, args Arguments) (*Component, error) {
 	}
 
 	c := &Component{
-		metrics:   target.NewMetrics(o.Registerer),
-		o:         o,
-		handler:   make(chan loki.Entry),
-		positions: positionsFile,
-		receivers: args.Receivers,
+		metrics:       target.NewMetrics(o.Registerer),
+		o:             o,
+		handler:       make(chan loki.Entry),
+		positions:     positionsFile,
+		receivers:     args.Receivers,
+		argsUpdated:   make(chan struct{}, 1),
+		args:          args,
 	}
 	err = c.Update(args)
 	return c, err
@@ -84,7 +90,10 @@ func (c *Component) Run(ctx context.Context) error {
 	defer func() {
 		c.mut.RLock()
 		if c.t != nil {
-			c.t.Stop()
+			err := c.t.Stop()
+			if err != nil {
+				level.Warn(c.o.Logger).Log("msg", "error stopping journal target", "err", err)
+			}
 		}
 		c.mut.RUnlock()
 
@@ -103,6 +112,27 @@ func (c *Component) Run(ctx context.Context) error {
 				r.Chan() <- lokiEntry
 			}
 			c.mut.RUnlock()
+		case <-c.argsUpdated:
+			c.mut.Lock()
+			if c.t != nil {
+				err := c.t.Stop()
+				if err != nil {
+					level.Error(c.o.Logger).Log("msg", "error stopping journal target", "err", err)
+				}
+				c.t = nil
+			}
+			rcs := alloy_relabel.ComponentToPromRelabelConfigs(c.args.RelabelRules)
+			entryHandler := loki.NewEntryHandler(c.handler, func() {})
+
+			newTarget, err := target.NewJournalTarget(c.metrics, c.o.Logger, entryHandler, c.positions, c.o.ID, rcs, convertArgs(c.o.ID, c.args))
+			if err != nil {
+				level.Error(c.o.Logger).Log("msg", "error creating journal target", "err", err, "path", c.args.Path)
+				c.healthErr = fmt.Errorf("error creating journal target: %w", err)
+			} else {
+				c.t = newTarget
+				c.healthErr = nil
+			}
+			c.mut.Unlock()
 		}
 	}
 }
@@ -112,21 +142,31 @@ func (c *Component) Update(args component.Arguments) error {
 	newArgs := args.(Arguments)
 	c.mut.Lock()
 	defer c.mut.Unlock()
-	if c.t != nil {
-		err := c.t.Stop()
-		if err != nil {
-			return err
+	c.args = newArgs
+	select {
+	case c.argsUpdated <- struct{}{}:
+	default: // Update notification already sent
+	}
+	return nil
+}
+
+// CurrentHealth implements component.HealthComponent. It returns an unhealthy
+// status if the server has terminated.
+func (c *Component) CurrentHealth() component.Health {
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+	if c.healthErr == nil {
+		return component.Health{
+			Health:     component.HealthTypeHealthy,
+			Message:    "journal target is running",
+			UpdateTime: time.Now(),
 		}
 	}
-	rcs := alloy_relabel.ComponentToPromRelabelConfigs(newArgs.RelabelRules)
-	entryHandler := loki.NewEntryHandler(c.handler, func() {})
-
-	newTarget, err := target.NewJournalTarget(c.metrics, c.o.Logger, entryHandler, c.positions, c.o.ID, rcs, convertArgs(c.o.ID, newArgs))
-	if err != nil {
-		return err
+	return component.Health{
+		Health:     component.HealthTypeUnhealthy,
+		Message:    c.healthErr.Error(),
+		UpdateTime: time.Now(),
 	}
-	c.t = newTarget
-	return nil
 }
 
 func convertArgs(job string, a Arguments) *scrapeconfig.JournalTargetConfig {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This was found when rolling out Fleet Management pipelines: when loki.source.journal component was scheduled on an Alloy that runs on an OS without systemd, it would fail to create the component and thus fail the entire config update. This is not desired - we want the config to be updated, but the component to get into an unhealthy state and log some errors to highlight the potential configuration issue without a dramatic failure.

This PR makes sure we change component health and log an error instead of failing to create the component.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
