### PR TITLE
fix(prometheus.exporter.redis): pass MaxDistinctKeyGroups option to exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Main (unreleased)
 
 - Add support of `tls` in components `loki.source.(awsfirehose|gcplog|heroku|api)` and `prometheus.receive_http` and `pyroscope.receive_http`. (@fgouteroux)
 
+### Bugfixes
+
+- Fix `prometheus.exporter.redis` component so that it no longer ignores the `MaxDistinctKeyGroups` configuration option. If key group metrics are enabled, this will increase the cardinality of the generated metrics. (@stegosaurus21)
+
 v1.11.0-rc.0
 -----------------
 

--- a/internal/static/integrations/redis_exporter/redis_exporter.go
+++ b/internal/static/integrations/redis_exporter/redis_exporter.go
@@ -82,6 +82,7 @@ func (c Config) GetExporterOptions() re.Options {
 		CheckKeys:                 c.CheckKeys,
 		CheckKeysBatchSize:        c.CheckKeyGroupsBatchSize,
 		CheckKeyGroups:            c.CheckKeyGroups,
+		MaxDistinctKeyGroups:      c.MaxDistinctKeyGroups,
 		CheckSingleKeys:           c.CheckSingleKeys,
 		CheckStreams:              c.CheckStreams,
 		CheckSingleStreams:        c.CheckSingleStreams,


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Changes the `MaxDistinctKeyGroups` configuration option to be passed into the Redis exporter instance. Previously it was accepted in Alloy's configuration but not passed through, which would cause it to default to zero regardless of how Alloy was configured.

Note that this would cause a cardinality increase in generated metrics for instances of this component with key group metrics enabled.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
