### PR TITLE
Bump walqueue for new LRU cache implementation + disable the metadata cache OOTB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Main (unreleased)
 
 - Add support of `tls` in components `loki.source.(awsfirehose|gcplog|heroku|api)` and `prometheus.receive_http` and `pyroscope.receive_http`. (@fgouteroux)
 
+- Use new cache for metadata cache in `prometheus.write.queue` and support disabling the metadata cache with it disable by default. (@kgeckhart, @dehaansa)
+
 ### Bugfixes
 
 v1.11.0-rc.1

--- a/docs/sources/reference/components/prometheus/prometheus.write.queue.md
+++ b/docs/sources/reference/components/prometheus/prometheus.write.queue.md
@@ -80,6 +80,7 @@ The following arguments are supported:
 | `flush_interval`         | `duration`    | How long to wait until sending if `batch_count` isn't triggered.                 | `"1s"`                      | no       |
 | `headers`                | `map(secret)` | Custom HTTP headers to add to all requests sent to the server.                   |                             | no       |
 | `max_retry_attempts`     | `uint`        | Maximum number of retries before dropping the batch.                             | `0`                         | no       |
+| `metadata_cache_enabled` | `bool`        | Enables an LRU cache for tracking Metadata to support sparse metadata sending.   | `false`                     | no       |
 | `metadata_cache_size`    | `uint`        | Maximum number of metadata entries to keep in cache to track what has been sent. | `1000`                      | no       |
 | `protobuf_message`       | `string`      | Protobuf message format to use for remote write.                                 | `"prometheus.WriteRequest"` | no       |
 | `proxy_url`              | `string`      | URL of the HTTP proxy to use for requests.                                       |                             | no       |
@@ -90,7 +91,7 @@ The following arguments are supported:
 
 `protobuf_message` must be `prometheus.WriteRequest` or `io.prometheus.write.v2.Request`. These values represent prometheus remote write protocol versions 1 and 2.
 
-`metadata_cache_size` is only relevant when using `io.prometheus.write.v2.Request`, and is intended to reduce the frequency of metadata sending to reduce overall network traffic.
+'metadata_cache_enabled' and `metadata_cache_size` are only relevant when using `io.prometheus.write.v2.Request`, and is intended to reduce the frequency of metadata sending to reduce overall network traffic.
 A larger cache_size will consume more memory, but if you are sending many different metrics will also reduce how frequently metadata is sent with samples.
 
 ### `basic_auth`

--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,7 @@ require (
 	github.com/grafana/snowflake-prometheus-exporter v0.0.0-20250627131542-0c2feac3a700
 	github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0
 	github.com/grafana/vmware_exporter v0.0.5-beta.0.20250218170317-73398ba08329
-	github.com/grafana/walqueue v0.0.0-20250916201216-152b1f10cca2
+	github.com/grafana/walqueue v0.0.0-20250919134944-0471c03aa304
 	github.com/hashicorp/consul/api v1.32.1
 	github.com/hashicorp/go-discover v1.1.0
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1196,6 +1196,8 @@ github.com/grafana/vmware_exporter v0.0.5-beta.0.20250218170317-73398ba08329 h1:
 github.com/grafana/vmware_exporter v0.0.5-beta.0.20250218170317-73398ba08329/go.mod h1:Z28219aViNlsLlPvuCnlgHDagRdZBAZ7JOnQg1b3eWg=
 github.com/grafana/walqueue v0.0.0-20250916201216-152b1f10cca2 h1:6HRYKHfWwdIoBF5jvVAYnARFHJiKe+++j1Oxh6A1mNw=
 github.com/grafana/walqueue v0.0.0-20250916201216-152b1f10cca2/go.mod h1:LJm4P3SayTHSbHBYepsAf3WqlY/gwSYQyMs7OLLAi6A=
+github.com/grafana/walqueue v0.0.0-20250919134944-0471c03aa304 h1:0Mllr6XQcAzwxGh/zHQbL/BtVGNRzRmIRBZRHqTiG3E=
+github.com/grafana/walqueue v0.0.0-20250919134944-0471c03aa304/go.mod h1:RokiltsxYrF3qitnIdaFBGLz5UrCo7DZMMoJrrzHyPc=
 github.com/grobie/gomemcache v0.0.0-20230213081705-239240bbc445 h1:FlKQKUYPZ5yDCN248M3R7x8yu2E3yEZ0H7aLomE4EoE=
 github.com/grobie/gomemcache v0.0.0-20230213081705-239240bbc445/go.mod h1:L69/dBlPQlWkcnU76WgcppK5e4rrxzQdi6LhLnK/ytA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=

--- a/internal/component/prometheus/write/queue/types.go
+++ b/internal/component/prometheus/write/queue/types.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/grafana/alloy/syntax/alloytypes"
 	"github.com/grafana/walqueue/types"
 	"github.com/prometheus/common/version"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/storage"
+
+	"github.com/grafana/alloy/syntax/alloytypes"
 )
 
 func defaultArgs() Arguments {
@@ -46,13 +47,14 @@ func (rc *Arguments) SetToDefault() {
 
 func defaultEndpointConfig() EndpointConfig {
 	return EndpointConfig{
-		Timeout:           30 * time.Second,
-		RetryBackoff:      1 * time.Second,
-		MaxRetryAttempts:  0,
-		BatchCount:        1_000,
-		FlushInterval:     1 * time.Second,
-		MetadataCacheSize: 1000,
-		ProtobufMessage:   RemoteWriteProtoMsg(config.RemoteWriteProtoMsgV1),
+		Timeout:              30 * time.Second,
+		RetryBackoff:         1 * time.Second,
+		MaxRetryAttempts:     0,
+		BatchCount:           1_000,
+		FlushInterval:        1 * time.Second,
+		MetadataCacheEnabled: false,
+		MetadataCacheSize:    1000,
+		ProtobufMessage:      RemoteWriteProtoMsg(config.RemoteWriteProtoMsgV1),
 		Parallelism: ParallelismConfig{
 			DriftScaleUp:                60 * time.Second,
 			DriftScaleDown:              30 * time.Second,
@@ -136,7 +138,9 @@ type EndpointConfig struct {
 	ProxyConnectHeaders map[string]alloytypes.Secret `alloy:"proxy_connect_headers,attr,optional"`
 	// ProtobufMessage specifies if Remote Write V1 or V2 should be used
 	ProtobufMessage RemoteWriteProtoMsg `alloy:"protobuf_message,attr,optional"`
-	// MetadataCacheSize specifies the size of the metadata cache if using Remote Write V2
+	// MetadataCacheEnabled enables an LRU cache for tracking Metadata to support sparse metadata sending. Only valid if using Remote Write V2.
+	MetadataCacheEnabled bool `alloy:"metadata_cache_enabled,attr,optional"`
+	// MetadataCacheSize specifies the size of the metadata cache if using Remote Write V2 with the cache enabled.
 	MetadataCacheSize int `alloy:"metadata_cache_size,attr,optional"`
 }
 
@@ -212,6 +216,7 @@ func (cc EndpointConfig) ToNativeType() types.ConnectionConfig {
 		ProxyFromEnvironment: cc.ProxyFromEnvironment,
 		ProxyConnectHeaders:  proxyConnectHeaders,
 		ProtobufMessage:      config.RemoteWriteProtoMsg(cc.ProtobufMessage),
+		EnableMetadataCache:  cc.MetadataCacheEnabled,
 		MetadataCacheSize:    cc.MetadataCacheSize,
 		Parallelism: types.ParallelismConfig{
 			AllowedDrift:                cc.Parallelism.DriftScaleUp,


### PR DESCRIPTION
#### PR Description

Brings in https://github.com/grafana/walqueue/pull/54 after noticing heavy lock contention reading from the metadata cache even when no metadata exists. 

#### PR Checklist

- [x] CHANGELOG.md updated
- [x] Documentation added
