### PR TITLE
Fix URLs to remotecfg components in graph UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Main (unreleased)
 
 ### Bugfixes
 
+- Fix graph UI so it generates correct URLs for components in `remotecfg` modules. (@patrickeasters)
+
 v1.11.0-rc.2
 -----------------
 

--- a/internal/web/ui/src/features/graph/ComponentGraph.tsx
+++ b/internal/web/ui/src/features/graph/ComponentGraph.tsx
@@ -67,12 +67,14 @@ const ComponentGraph: React.FC<GraphProps> = ({ components, moduleID, enabled, w
   // On click, open the component details page in a new tab.
   const onNodeClick = (_event: React.MouseEvent, node: Node) => {
     const baseUrl = globalThis.window.location.origin + pathPrefix;
+    const moduleID = typeof node.data.moduleID === 'string' ? node.data.moduleID : '';
+    const remoteCfgPrefix = moduleID.startsWith('remotecfg/') ? 'remotecfg/' : '';
     const path =
       node.data.moduleID && node.data.moduleID !== ''
         ? `component/${node.data.moduleID}/${node.data.localID}`
         : `component/${node.data.localID}`;
 
-    globalThis.window.open(baseUrl + path, '_blank');
+    globalThis.window.open(baseUrl + remoteCfgPrefix + path, '_blank');
   };
 
   return (


### PR DESCRIPTION
#### PR Description

Updates graph UI component to properly generate URLs for components in `remotecfg` modules.

#### Which issue(s) this PR fixes

Fixes #3935 

#### Notes to the Reviewer

I tested this with a mix of local components, local modules, and remote modules.

#### PR Checklist

- [x] CHANGELOG.md updated
