### PR TITLE
chore: ignore canceled context to prevent flaky test

### DIFF
--- a/internal/service/remotecfg/remotecfg_test.go
+++ b/internal/service/remotecfg/remotecfg_test.go
@@ -340,7 +340,7 @@ func TestUserAgentHeader(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		if err := env.Run(ctx); !errors.Is(err, context.Canceled) {
-			require.NoError(t, env.Run(ctx))
+			require.NoError(t, err)
 		}
 	}()
 


### PR DESCRIPTION
#### PR Description
Really flaky test. We just wait for a initial request to be made and when it's done we abort.

This will often lead to [this call failing](https://github.com/grafana/alloy/blob/c0c7d32b0ec1c41d1e10aa43d23e1538fbe9c8ad/internal/service/remotecfg/remotecfg.go#L139) and return `context.Canceled` and we should not care about that here.

#### Which issue(s) this PR fixes

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
