### PR TITLE
Submit WinGet manifest on release

### DIFF
--- a/.github/workflows/submit-winget-manifest.yml
+++ b/.github/workflows/submit-winget-manifest.yml
@@ -27,8 +27,8 @@ jobs:
       id: get-token
       with:
         export_env: false
-        repo_secrets: |
-          token=winget:token
+        common_secrets: |
+          token=winget-packages:token
 
     - name: Submit WinGet Manifest
       env:

--- a/.github/workflows/submit-winget-manifest.yml
+++ b/.github/workflows/submit-winget-manifest.yml
@@ -34,11 +34,11 @@ jobs:
       env:
         PACKAGE_ID: GrafanaLabs.Alloy
         PACKAGE_VERSION: ${{ github.event.release.tag_name }}
-        WINGET_TOKEN: ${{ fromJSON(steps.get-token.outputs.secrets).token }}
+        WINGET_CREATE_GITHUB_TOKEN: ${{ fromJSON(steps.get-token.outputs.secrets).token }}
       shell: pwsh
       run: |
+        wingetcreate token --store
         wingetcreate update ${env:PACKAGE_ID} `
           --urls "${env:GITHUB_SERVER_URL}/${env:GITHUB_REPOSITORY}/releases/download/${env:PACKAGE_VERSION}/alloy-installer-windows-amd64.exe" `
           --version ${env:PACKAGE_VERSION}.TrimStart("v") `
-          --submit `
-          --token ${env:WINGET_TOKEN}
+          --submit

--- a/.github/workflows/submit-winget-manifest.yml
+++ b/.github/workflows/submit-winget-manifest.yml
@@ -1,0 +1,44 @@
+name: Submit WinGet Manifest
+
+on:
+  release:
+    types: [published]
+
+permissions: {}
+
+jobs:
+  publish:
+    runs-on: windows-2025
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+
+    - name: Install WingetCreate
+      shell: pwsh
+      run: |
+        Import-Module Appx -UseWindowsPowerShell
+        $appxBundleFile = Join-Path ${env:RUNNER_TEMP} "wingetcreate.msixbundle"
+        Invoke-WebRequest https://aka.ms/wingetcreate/latest/msixbundle -OutFile $appxBundleFile
+        Add-AppxPackage $appxBundleFile
+
+    - name: Get WinGet token
+      uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+      id: get-token
+      with:
+        export_env: false
+        repo_secrets: |
+          token=winget:token
+
+    - name: Submit WinGet Manifest
+      env:
+        PACKAGE_ID: GrafanaLabs.Alloy
+        PACKAGE_VERSION: ${{ github.event.release.tag_name }}
+        WINGET_TOKEN: ${{ fromJSON(steps.get-token.outputs.secrets).token }}
+      shell: pwsh
+      run: |
+        wingetcreate update ${env:PACKAGE_ID} `
+          --urls "${env:GITHUB_SERVER_URL}/${env:GITHUB_REPOSITORY}/releases/download/${env:PACKAGE_VERSION}/alloy-installer-windows-amd64.exe" `
+          --version ${env:PACKAGE_VERSION}.TrimStart("v") `
+          --submit `
+          --token ${env:WINGET_TOKEN}


### PR DESCRIPTION
#### PR Description

Add a GitHub Actions workflow that will submit the manifest for a new release of Alloy to the WinGet package manager.

---

[WinGet](https://learn.microsoft.com/windows/package-manager/winget/) provides an easier installation mechanism for Alloy for Windows users, particularly for upgrades from one release to another. WinGet builds upon PowerShell Desired State Configuration (DSC), so this also provides a way to provision Alloy alongside other arbitrary other tools when configuring a new Windows machine (for example I use DSC to to install developer tools on my laptops ([example](https://github.com/martincostello/bootstrap/blob/main/software.admin.dsc)).

For example, all a user needs to do is this in a terminal:

```pwsh
winget install GrafanaLabs.Alloy
```

then afterwards:

```pwsh
winget update GrafanaLabs.Alloy
```

or:

```pwsh
winget update --all
```

I submitted a PR to add the package a few days ago (https://github.com/microsoft/winget-pkgs/pull/294624), and _manually_ submitted a PR using the [WingetCreate](https://github.com/microsoft/winget-create) tool for the subsequent 1.11.0-rc.1 release: https://github.com/microsoft/winget-pkgs/pull/296904

This PR adds a new GitHub Actions workflow that runs after a GitHub release is published, and automatically creates a pull request to submit that new version to the [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) repository.

I've tested the individual steps of the workflow, but cannot end-to-end test it, so this would need to be merged if the concept is accepted, then fix-forward if anything doesn't work.

The installation is based on [this code](https://github.com/JanDeDobbeleer/oh-my-posh/blob/3fc2fb74658151935a990a6cb0e05421510cdb37/packages/winget/build.ps1#L64-L71), and I ran it locally to verify the steps.

The submission was tested using the following command minus the pull request:

```pwsh
wingetcreate update GrafanaLabs.Alloy `
  --urls https://github.com/grafana/alloy/releases/download/v1.11.0-rc.1/alloy-installer-windows-amd64.exe `
  --version 1.11.0-rc.1
```

I then inspected the generated manifest files and compared them to check the appropriate updates were made.

For this to be usable, two things need to be done:

1. Acquire a token for a "real" GitHub bot user (not a GitHub App) so that it is able to fork the repository to submit a pull request (AFAIK, GitHub Apps cannot do this).
2. Add the token for that user to Vault (I believe it needs at least `public_repo` scope so it can access its own fork).

#### Which issue(s) this PR fixes

#3977

#### Notes to the Reviewer

#### PR Checklist

- [ ] ~~CHANGELOG.md updated~~
- [ ] ~~Documentation added~~
- [ ] ~~Tests updated~~
- [ ] ~~Config converters updated~~
