### PR TITLE
Enable native frame demangling by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Main (unreleased)
 
 - Remove SendSIGKILL=no from unit files and recommendations (@oleg-kozlyuk-grafana)
 
+- Enabled native frame demangling by default (@oleg-kozlyuk-grafana)
+
 ### Bugfixes
 
 v1.11.0

--- a/internal/component/pyroscope/ebpf/ebpf_linux.go
+++ b/internal/component/pyroscope/ebpf/ebpf_linux.go
@@ -225,7 +225,7 @@ func NewDefaultArguments() Arguments {
 	return Arguments{
 		CollectInterval: 15 * time.Second,
 		SampleRate:      19,
-		Demangle:        "none",
+		Demangle:        "templates",
 		PythonEnabled:   true,
 		PerlEnabled:     true,
 		PHPEnabled:      true,


### PR DESCRIPTION
#### PR Description

This change enables demangling of C++ frames by default. While a small performance hit is expected, this change would significantly improve OOBE experience for native profiling users

#### Which issue(s) this PR fixes

#### PR Checklist

- [x] CHANGELOG.md updated
