### PR TITLE
chore: point out breaking change in prometheus.scrape for v1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ v1.11.0
 
     [1_11-release-notes]: https://grafana.com/docs/alloy/latest/release-notes/#v111
 
-- `scrape_native_histograms` attribute for `prometheus.scrape` is now set to false previously default was true. This means that it is no longer enough to just configure `scrape_protocols` to start with `PrometheusProto` to scrape native histograms but it has to be enabled. If `scrape_native_histograms` is enabled without `scrape_protocols` set it will be configured correctly for you, otherwise Alloy will validate that `PrometheusProto` is in the `scrape_protocols` list.
+- `scrape_native_histograms` attribute for `prometheus.scrape` is now set to `false`, whereas in previous versions of Alloy it would default to `true`. This means that it is no longer enough to just configure `scrape_protocols` to start with `PrometheusProto` to scrape native histograms - `scrape_native_histograms` has to be enabled. If `scrape_native_histograms` is enabled, `scrape_protocols` will automatically be configured correctly for you to include `PrometheusProto`. If you configure it explicitly, Alloy will validate that `PrometheusProto` is in the `scrape_protocols` list.
 
 - Add `otel_attrs_to_hec_metadata` configuration block to `otelcol.exporter.splunkhec` to match `otelcol.receiver.splunkhec`. (@cgetzen)
 

--- a/docs/sources/release-notes.md
+++ b/docs/sources/release-notes.md
@@ -36,8 +36,7 @@ See the upstream [Prometheus v3 migration guide](https://prometheus.io/docs/prom
 
 ### Breaking changes in `prometheus.scrape`
 
-`scrape_native_histograms` attribute for `prometheus.scrape` is now set to `false`,
-whereas in previous versions of Alloy it would default to `true`. 
+`scrape_native_histograms` attribute for `prometheus.scrape` is now set to `false`, whereas in previous versions of Alloy it would default to `true`. 
 This means that it is no longer enough to just configure `scrape_protocols` to start with `PrometheusProto` to scrape native histograms - `scrape_native_histograms` has to be enabled. 
 If `scrape_native_histograms` is enabled, `scrape_protocols` will automatically be configured correctly for you to include `PrometheusProto`.
 If you configure it explicitly, Alloy will validate that `PrometheusProto` is in the `scrape_protocols` list.


### PR DESCRIPTION
#### PR Description
In https://github.com/grafana/alloy/pull/4044  the default value for `scrape_native_histograms` was changed from true to false. This setting alone was not enough to enable native histogram scraping but you would also have to configure `scrape_protocols` to start with `PrometheusProto`. 

In the mentioned pr we changed this behavior so that just configuring scrape_protocols is not enough by default anymore e.g. 
```
prometheus.scrape "test" {
  scrape_protocols = ["PrometheusProto"]
}
``` 

But now you need to explicitly enable it. We also added validation for `scrape_protocols` when this is configured and automatically change the [default protocols](https://github.com/grafana/alloy/blob/777fa641a1a1ac960782e33ca7ef64937ff4e995/internal/component/prometheus/scrape/scrape.go#L191-L195).
```
prometheus.scrape "test" {
  scrape_native_histograms = true
}
``` 


#### Which issue(s) this PR fixes

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
