### PR TITLE
backport windows installer fix

### DIFF
--- a/.github/workflows/publish-alloy-release.yml
+++ b/.github/workflows/publish-alloy-release.yml
@@ -150,7 +150,7 @@ jobs:
     # This step bypasses make so that Go does not rebuild the executables and lose the signed files from the previous job
     - name: Build unsigned Windows installer containing signed files
       run: |
-        RELEASE_BUILD=1 makensis -V4 -DVERSION=$(VERSION) -DOUT="../../dist/alloy-installer-windows-amd64.exe" ./packaging/windows/install_script.nsis
+        RELEASE_BUILD=1 makensis -V4 -DVERSION=${VERSION} -DOUT="../../dist/alloy-installer-windows-amd64.exe" ./packaging/windows/install_script.nsis
       env:
         VERSION: ${{ github.ref_name }}
 


### PR DESCRIPTION
Cherry picked https://github.com/grafana/alloy/commit/e6421dc630ce113f7093f87cbe21f662a183418e to make sure installer has correct version before we release