### PR TITLE
database_observability: update readme config examples to use target 

### DIFF
--- a/internal/component/database_observability/README.md
+++ b/internal/component/database_observability/README.md
@@ -162,6 +162,7 @@ prometheus.exporter.mysql "integrations_mysqld_exporter_<your_DB_name>" {
 database_observability.mysql "mysql_<your_DB_name>" {
   data_source_name  = local.file.mysql_secret_<your_DB_name>.content
   forward_to        = [loki.relabel.database_observability_mysql_<your_DB_name>.receiver]
+  targets           = prometheus.exporter.mysql.integrations_mysqld_exporter_<your_DB_name>.targets
 
   // OPTIONAL: enable collecting samples of queries with their execution metrics. The sql text will be redacted to hide sensitive params.
   enable_collectors = ["query_samples"]
@@ -197,7 +198,7 @@ loki.relabel "database_observability_mysql_<your_DB_name>" {
 }
 
 discovery.relabel "database_observability_mysql_<your_DB_name>" {
-  targets = concat(prometheus.exporter.mysql.integrations_mysqld_exporter_<your_DB_name>.targets, database_observability.mysql.mysql_<your_DB_name>.targets)
+  targets = database_observability.mysql.mysql_<your_DB_name>.targets
 
   rule {
     target_label = "job"
@@ -315,6 +316,7 @@ prometheus.exporter.mysql "integrations_mysqld_exporter_example_db_1" {
 database_observability.mysql "mysql_example_db_1" {
   data_source_name  = local.file.mysql_secret_example_db_1.content
   forward_to        = [loki.relabel.database_observability_mysql_example_db_1.receiver]
+  targets           = prometheus.exporter.mysql.integrations_mysqld_exporter_example_db_1.targets
   enable_collectors = ["query_samples"]
 }
 
@@ -323,7 +325,7 @@ loki.relabel "database_observability_mysql_example_db_1" {
 }
 
 discovery.relabel "database_observability_mysql_example_db_1" {
-  targets = concat(prometheus.exporter.mysql.integrations_mysqld_exporter_example_db_1.targets, database_observability.mysql.mysql_example_db_1.targets)
+  targets = database_observability.mysql.mysql_example_db_1.targets
 
   rule {
     target_label = "job"
@@ -353,6 +355,7 @@ prometheus.exporter.mysql "integrations_mysqld_exporter_example_db_2" {
 database_observability.mysql "mysql_example_db_2" {
   data_source_name  = local.file.mysql_secret_example_db_2.content
   forward_to        = [loki.relabel.database_observability_mysql_example_db_2.receiver]
+  targets           = prometheus.exporter.mysql.integrations_mysqld_exporter_example_db_2.targets
   enable_collectors = ["query_samples"]
 }
 
@@ -361,7 +364,7 @@ loki.relabel "database_observability_mysql_example_db_2" {
 }
 
 discovery.relabel "database_observability_mysql_example_db_2" {
-  targets = concat(prometheus.exporter.mysql.integrations_mysqld_exporter_example_db_2.targets, database_observability.mysql.mysql_example_db_2.targets)
+  targets = database_observability.mysql.mysql_example_db_2.targets
 
   rule {
     target_label = "job"
@@ -452,6 +455,7 @@ prometheus.exporter.postgres "integrations_postgres_exporter_<your_DB_name>" {
 database_observability.postgres "postgres_<your_DB_name>" {
   data_source_name  = local.file.postgres_secret_<your_DB_name>.content
   forward_to        = [loki.relabel.database_observability_postgres_<your_DB_name>.receiver]
+  targets           = prometheus.exporter.postgres.integrations_postgres_exporter_<your_DB_name>.targets
 
   // OPTIONAL: enable collecting samples of queries with their execution metrics. The sql text will be redacted to hide sensitive params.
   enable_collectors = ["query_samples", "query_details"]


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This updates our README example configs to include the newly implemented `targets` field for better metric relabelling.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
