### PR TITLE
Db-o11y: Cache pg sample and wait events and send finalized entries

### DIFF
--- a/internal/component/database_observability/postgres/collector/query_samples_test.go
+++ b/internal/component/database_observability/postgres/collector/query_samples_test.go
@@ -56,6 +56,16 @@ func TestQuerySamples_FetchQuerySamples(t *testing.T) {
 						sql.NullString{}, nil, queryStartTime, sql.NullInt64{Int64: 123, Valid: true},
 						"SELECT * FROM users",
 					))
+				// Second scrape: empty to trigger finalization
+				mock.ExpectQuery(selectPgStatActivity).RowsWillBeClosed().
+					WillReturnRows(sqlmock.NewRows([]string{
+						"now", "datname", "pid", "leader_pid",
+						"usename", "application_name", "client_addr", "client_port",
+						"backend_type", "backend_start", "backend_xid", "backend_xmin",
+						"xact_start", "state", "state_change", "wait_event_type",
+						"wait_event", "blocked_by_pids", "query_start", "query_id",
+						"query",
+					}))
 			},
 
 			expectedLabels: []model.LabelSet{
@@ -84,6 +94,16 @@ func TestQuerySamples_FetchQuerySamples(t *testing.T) {
 						sql.NullString{}, nil, now, sql.NullInt64{Int64: 123, Valid: true},
 						"SELECT * FROM large_table",
 					))
+				// Second scrape: empty to trigger finalization
+				mock.ExpectQuery(selectPgStatActivity).RowsWillBeClosed().
+					WillReturnRows(sqlmock.NewRows([]string{
+						"now", "datname", "pid", "leader_pid",
+						"usename", "application_name", "client_addr", "client_port",
+						"backend_type", "backend_start", "backend_xid", "backend_xmin",
+						"xact_start", "state", "state_change", "wait_event_type",
+						"wait_event", "blocked_by_pids", "query_start", "query_id",
+						"query",
+					}))
 			},
 
 			expectedLabels: []model.LabelSet{
@@ -117,6 +137,16 @@ func TestQuerySamples_FetchQuerySamples(t *testing.T) {
 						sql.NullString{String: "relation", Valid: true}, pq.Int64Array{103, 104}, now, sql.NullInt64{Int64: 124, Valid: true},
 						"UPDATE users SET status = 'active'",
 					))
+				// Second scrape: empty to trigger finalization
+				mock.ExpectQuery(selectPgStatActivity).RowsWillBeClosed().
+					WillReturnRows(sqlmock.NewRows([]string{
+						"now", "datname", "pid", "leader_pid",
+						"usename", "application_name", "client_addr", "client_port",
+						"backend_type", "backend_start", "backend_xid", "backend_xmin",
+						"xact_start", "state", "state_change", "wait_event_type",
+						"wait_event", "blocked_by_pids", "query_start", "query_id",
+						"query",
+					}))
 			},
 
 			expectedLabels: []model.LabelSet{
@@ -147,6 +177,16 @@ func TestQuerySamples_FetchQuerySamples(t *testing.T) {
 						sql.NullString{}, nil, now, sql.NullInt64{Int64: 125, Valid: true},
 						"<insufficient privilege>",
 					))
+				// Second scrape: empty to complete cycle
+				mock.ExpectQuery(selectPgStatActivity).RowsWillBeClosed().
+					WillReturnRows(sqlmock.NewRows([]string{
+						"now", "datname", "pid", "leader_pid",
+						"usename", "application_name", "client_addr", "client_port",
+						"backend_type", "backend_start", "backend_xid", "backend_xmin",
+						"xact_start", "state", "state_change", "wait_event_type",
+						"wait_event", "blocked_by_pids", "query_start", "query_id",
+						"query",
+					}))
 			},
 			expectedErrorLine: `err="insufficient privilege to access query`,
 			expectedLabels:    []model.LabelSet{}, // No Loki entries expected
@@ -171,6 +211,16 @@ func TestQuerySamples_FetchQuerySamples(t *testing.T) {
 						sql.NullString{}, nil, now, sql.NullInt64{Int64: 126, Valid: true},
 						"SELECT * FROM users",
 					))
+				// Second scrape: empty to complete cycle
+				mock.ExpectQuery(selectPgStatActivity).RowsWillBeClosed().
+					WillReturnRows(sqlmock.NewRows([]string{
+						"now", "datname", "pid", "leader_pid",
+						"usename", "application_name", "client_addr", "client_port",
+						"backend_type", "backend_start", "backend_xid", "backend_xmin",
+						"xact_start", "state", "state_change", "wait_event_type",
+						"wait_event", "blocked_by_pids", "query_start", "query_id",
+						"query",
+					}))
 			},
 			expectedErrorLine: `err="database name is not valid`,
 			expectedLabels:    []model.LabelSet{}, // No Loki entries expected
@@ -195,6 +245,16 @@ func TestQuerySamples_FetchQuerySamples(t *testing.T) {
 						sql.NullString{}, nil, queryStartTime, sql.NullInt64{Int64: 128, Valid: true},
 						"SELECT * FROM users WHERE id = 123 AND email = 'test@example.com'",
 					))
+				// Second scrape: empty to trigger finalization
+				mock.ExpectQuery(selectPgStatActivity).RowsWillBeClosed().
+					WillReturnRows(sqlmock.NewRows([]string{
+						"now", "datname", "pid", "leader_pid",
+						"usename", "application_name", "client_addr", "client_port",
+						"backend_type", "backend_start", "backend_xid", "backend_xmin",
+						"xact_start", "state", "state_change", "wait_event_type",
+						"wait_event", "blocked_by_pids", "query_start", "query_id",
+						"query",
+					}))
 			},
 			disableQueryRedaction: true,
 			expectedLabels: []model.LabelSet{
@@ -219,7 +279,7 @@ func TestQuerySamples_FetchQuerySamples(t *testing.T) {
 
 			sampleCollector, err := NewQuerySamples(QuerySamplesArguments{
 				DB:                    db,
-				CollectInterval:       time.Second * 5,
+				CollectInterval:       10 * time.Millisecond,
 				EntryHandler:          lokiClient,
 				Logger:                log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
 				DisableQueryRedaction: tc.disableQueryRedaction,
@@ -274,4 +334,249 @@ func TestQuerySamples_FetchQuerySamples(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestQuerySamples_FinalizationScenarios(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	now := time.Now()
+	stateChangeTime := now.Add(-10 * time.Second)
+	queryStartTime := now.Add(-30 * time.Second)
+	xactStartTime := now.Add(-2 * time.Minute)
+	backendStartTime := now.Add(-1 * time.Hour)
+
+	columns := []string{
+		"now", "datname", "pid", "leader_pid",
+		"usename", "application_name", "client_addr", "client_port",
+		"backend_type", "backend_start", "backend_xid", "backend_xmin",
+		"xact_start", "state", "state_change", "wait_event_type",
+		"wait_event", "blocked_by_pids", "query_start", "query_id",
+		"query",
+	}
+
+	t.Run("finalize on disappear after active scrape", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		logBuffer := syncbuffer.Buffer{}
+		lokiClient := loki_fake.NewClient(func() {})
+
+		sampleCollector, err := NewQuerySamples(QuerySamplesArguments{
+			DB:              db,
+			CollectInterval: 10 * time.Millisecond,
+			EntryHandler:    lokiClient,
+			Logger:          log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+		})
+		require.NoError(t, err)
+
+		// First scrape: active row
+		mock.ExpectQuery(selectPgStatActivity).RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows(columns).AddRow(
+				now, "testdb", 1000, sql.NullInt64{},
+				"testuser", "testapp", "127.0.0.1", 5432,
+				"client backend", backendStartTime, sql.NullInt32{Int32: 10, Valid: true}, sql.NullInt32{Int32: 20, Valid: true},
+				xactStartTime, "active", stateChangeTime, sql.NullString{},
+				sql.NullString{}, nil, queryStartTime, sql.NullInt64{Int64: 999, Valid: true},
+				"SELECT * FROM t",
+			))
+		// Second scrape: no rows -> finalize
+		mock.ExpectQuery(selectPgStatActivity).RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows(columns))
+
+		require.NoError(t, sampleCollector.Start(t.Context()))
+
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			entries := lokiClient.Received()
+			require.Len(t, entries, 1)
+			require.Equal(t, model.LabelSet{"op": OP_QUERY_SAMPLE}, entries[0].Labels)
+			require.Contains(t, entries[0].Line, `datname="testdb" pid="1000" leader_pid="" user="testuser" app="testapp" client="127.0.0.1:5432" backend_type="client backend" backend_time="1h0m0s" xid="10" xmin="20" xact_time="2m0s" state="active" query_time="30s" queryid="999" query="SELECT * FROM t" engine="postgres" cpu_time="10s"`)
+			expectedTimestamp := time.Unix(0, now.UnixNano())
+			require.True(t, entries[0].Timestamp.Equal(expectedTimestamp))
+		}, 5*time.Second, 50*time.Millisecond)
+
+		sampleCollector.Stop()
+		require.Eventually(t, func() bool { return sampleCollector.Stopped() }, 5*time.Second, 100*time.Millisecond)
+		lokiClient.Stop()
+		time.Sleep(100 * time.Millisecond)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("xid change finalizes previous sample and starts new", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		logBuffer := syncbuffer.Buffer{}
+		lokiClient := loki_fake.NewClient(func() {})
+
+		sampleCollector, err := NewQuerySamples(QuerySamplesArguments{
+			DB:              db,
+			CollectInterval: 10 * time.Millisecond,
+			EntryHandler:    lokiClient,
+			Logger:          log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+		})
+		require.NoError(t, err)
+
+		// Scrape 1: xid=1
+		mock.ExpectQuery(selectPgStatActivity).RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows(columns).AddRow(
+				now, "testdb", 200, sql.NullInt64{},
+				"testuser", "testapp", "127.0.0.1", 5432,
+				"client backend", now.Add(-1*time.Minute), sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{},
+				now.Add(-30*time.Second), "active", now.Add(-10*time.Second), sql.NullString{},
+				sql.NullString{}, nil, now.Add(-10*time.Second), sql.NullInt64{Int64: 777, Valid: true},
+				"SELECT 1",
+			))
+		// Scrape 2: xid=2 (same pid/queryid)
+		mock.ExpectQuery(selectPgStatActivity).RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows(columns).AddRow(
+				now, "testdb", 200, sql.NullInt64{},
+				"testuser", "testapp", "127.0.0.1", 5432,
+				"client backend", now, sql.NullInt32{Int32: 2, Valid: true}, sql.NullInt32{},
+				now, "active", now, sql.NullString{},
+				sql.NullString{}, nil, now, sql.NullInt64{Int64: 777, Valid: true},
+				"SELECT 1",
+			))
+		// Scrape 3: disappear -> finalize xid=2
+		mock.ExpectQuery(selectPgStatActivity).RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows(columns))
+
+		require.NoError(t, sampleCollector.Start(t.Context()))
+
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			entries := lokiClient.Received()
+			require.Len(t, entries, 2)
+			// First emitted: xid=1
+			require.Equal(t, model.LabelSet{"op": OP_QUERY_SAMPLE}, entries[0].Labels)
+			require.Contains(t, entries[0].Line, `xid="1"`)
+			require.Contains(t, entries[0].Line, `queryid="777"`)
+			require.Contains(t, entries[0].Line, `cpu_time="10s"`)
+			// Second emitted: xid=2
+			require.Equal(t, model.LabelSet{"op": OP_QUERY_SAMPLE}, entries[1].Labels)
+			require.Contains(t, entries[1].Line, `xid="2"`)
+			require.Contains(t, entries[1].Line, `queryid="777"`)
+		}, 5*time.Second, 50*time.Millisecond)
+
+		sampleCollector.Stop()
+		require.Eventually(t, func() bool { return sampleCollector.Stopped() }, 5*time.Second, 100*time.Millisecond)
+		lokiClient.Stop()
+		time.Sleep(100 * time.Millisecond)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("wait-event merges across scrapes with normalized PID set", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		logBuffer := syncbuffer.Buffer{}
+		lokiClient := loki_fake.NewClient(func() {})
+
+		sampleCollector, err := NewQuerySamples(QuerySamplesArguments{
+			DB:              db,
+			CollectInterval: 10 * time.Millisecond,
+			EntryHandler:    lokiClient,
+			Logger:          log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+		})
+		require.NoError(t, err)
+
+		// Scrape 1: wait event with unordered/dup PIDs
+		mock.ExpectQuery(selectPgStatActivity).RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows(columns).AddRow(
+				now, "testdb", 300, sql.NullInt64{},
+				"testuser", "testapp", "127.0.0.1", 5432,
+				"client backend", backendStartTime, sql.NullInt32{}, sql.NullInt32{},
+				xactStartTime, "waiting", now.Add(-10*time.Second), sql.NullString{String: "Lock", Valid: true},
+				sql.NullString{String: "relation", Valid: true}, pq.Int64Array{104, 103}, now, sql.NullInt64{Int64: 124, Valid: true},
+				"UPDATE users SET status = 'active'",
+			))
+		// Scrape 2: same wait event with normalized PIDs
+		mock.ExpectQuery(selectPgStatActivity).RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows(columns).AddRow(
+				now, "testdb", 300, sql.NullInt64{},
+				"testuser", "testapp", "127.0.0.1", 5432,
+				"client backend", backendStartTime, sql.NullInt32{}, sql.NullInt32{},
+				xactStartTime, "waiting", now.Add(-12*time.Second), sql.NullString{String: "Lock", Valid: true},
+				sql.NullString{String: "relation", Valid: true}, pq.Int64Array{103, 104}, now, sql.NullInt64{Int64: 124, Valid: true},
+				"UPDATE users SET status = 'active'",
+			))
+		// Scrape 3: disappear
+		mock.ExpectQuery(selectPgStatActivity).RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows(columns))
+
+		require.NoError(t, sampleCollector.Start(t.Context()))
+
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			entries := lokiClient.Received()
+			require.Len(t, entries, 2)
+			require.Equal(t, model.LabelSet{"op": OP_QUERY_SAMPLE}, entries[0].Labels)
+			require.Equal(t, model.LabelSet{"op": OP_WAIT_EVENT}, entries[1].Labels)
+			require.Contains(t, entries[1].Line, `wait_time="12s"`)
+			require.Contains(t, entries[1].Line, `blocked_by_pids="[103 104]"`)
+		}, 5*time.Second, 50*time.Millisecond)
+
+		sampleCollector.Stop()
+		require.Eventually(t, func() bool { return sampleCollector.Stopped() }, 5*time.Second, 100*time.Millisecond)
+		lokiClient.Stop()
+		time.Sleep(100 * time.Millisecond)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("wait-event closes on no-wait row; single occurrence emitted", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		logBuffer := syncbuffer.Buffer{}
+		lokiClient := loki_fake.NewClient(func() {})
+
+		sampleCollector, err := NewQuerySamples(QuerySamplesArguments{
+			DB:              db,
+			CollectInterval: 10 * time.Millisecond,
+			EntryHandler:    lokiClient,
+			Logger:          log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+		})
+		require.NoError(t, err)
+
+		// Scrape 1: wait event
+		mock.ExpectQuery(selectPgStatActivity).RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows(columns).AddRow(
+				now, "testdb", 301, sql.NullInt64{},
+				"testuser", "testapp", "127.0.0.1", 5432,
+				"client backend", backendStartTime, sql.NullInt32{}, sql.NullInt32{},
+				xactStartTime, "waiting", stateChangeTime, sql.NullString{String: "Lock", Valid: true},
+				sql.NullString{String: "relation", Valid: true}, pq.Int64Array{103, 104}, now, sql.NullInt64{Int64: 555, Valid: true},
+				"UPDATE users SET status = 'active'",
+			))
+		// Scrape 2: active with no wait -> close occurrence
+		mock.ExpectQuery(selectPgStatActivity).RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows(columns).AddRow(
+				now, "testdb", 301, sql.NullInt64{},
+				"testuser", "testapp", "127.0.0.1", 5432,
+				"client backend", backendStartTime, sql.NullInt32{}, sql.NullInt32{},
+				xactStartTime, "active", now, sql.NullString{},
+				sql.NullString{}, nil, now, sql.NullInt64{Int64: 555, Valid: true},
+				"UPDATE users SET status = 'active'",
+			))
+		// Scrape 3: disappear
+		mock.ExpectQuery(selectPgStatActivity).RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows(columns))
+
+		require.NoError(t, sampleCollector.Start(t.Context()))
+
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			entries := lokiClient.Received()
+			require.Len(t, entries, 2)
+			require.Equal(t, model.LabelSet{"op": OP_QUERY_SAMPLE}, entries[0].Labels)
+			require.Equal(t, model.LabelSet{"op": OP_WAIT_EVENT}, entries[1].Labels)
+			require.Contains(t, entries[1].Line, `wait_time="10s"`)
+		}, 5*time.Second, 50*time.Millisecond)
+
+		sampleCollector.Stop()
+		require.Eventually(t, func() bool { return sampleCollector.Stopped() }, 5*time.Second, 100*time.Millisecond)
+		lokiClient.Stop()
+		time.Sleep(100 * time.Millisecond)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
 }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Shifting from sending entries on every scrape, to maintain the entries in memory and only send it when the query ends the execution.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
