### PR TITLE
database_observability: attach csp labels to mysql metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Main (unreleased)
 
 - (_Experimental_) Additions to experimental `database_observability.mysql` component:
   - `explain_plans` collector now changes schema before returning the connection to the pool (@cristiangreco)
+  - metrics now include cloud provider labels when configured (@matthewnolf)
 
 - (_Experimental_) Additions to experimental `database_observability.postgres` component:
   - `explain_plans` added the explain plan collector (@rgeyer)

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -274,7 +274,7 @@ func (c *Component) Update(args component.Arguments) error {
 	targets := make([]discovery.Target, 0, len(c.args.Targets)+1)
 	for _, t := range c.args.Targets {
 		builder := discovery.NewTargetBuilderFrom(t)
-		if relabel.ProcessBuilder(builder, database_observability.GetRelabelingRules(systemID)...) {
+		if relabel.ProcessBuilder(builder, database_observability.GetRelabelingRules(systemID, nil)...) {
 			targets = append(targets, builder.Target())
 		}
 	}

--- a/internal/component/database_observability/relabeling.go
+++ b/internal/component/database_observability/relabeling.go
@@ -2,10 +2,35 @@ package database_observability
 
 import "github.com/grafana/alloy/internal/component/common/relabel"
 
-func GetRelabelingRules(serverID string) []*relabel.Config {
+func GetRelabelingRules(serverID string, cp *CloudProvider) []*relabel.Config {
+	rs := make([]*relabel.Config, 1)
 	r := relabel.DefaultRelabelConfig // use default to avoid defining all fields
+
 	r.Replacement = serverID
 	r.TargetLabel = "server_id"
 	r.Action = relabel.Replace
-	return []*relabel.Config{&r}
+	rs[0] = &r
+
+	if cp != nil {
+		if cp.AWS != nil {
+			providerName := relabel.DefaultRelabelConfig
+			providerName.Replacement = "aws"
+			providerName.TargetLabel = "provider_name"
+			providerName.Action = relabel.Replace
+
+			providerRegion := relabel.DefaultRelabelConfig
+			providerRegion.Replacement = cp.AWS.ARN.Region
+			providerRegion.TargetLabel = "provider_region"
+			providerRegion.Action = relabel.Replace
+
+			providerAccount := relabel.DefaultRelabelConfig
+			providerAccount.Replacement = cp.AWS.ARN.AccountID
+			providerAccount.TargetLabel = "provider_account"
+			providerAccount.Action = relabel.Replace
+
+			rs = append(rs, &providerName, &providerRegion, &providerAccount)
+		}
+	}
+
+	return rs
 }

--- a/internal/component/database_observability/relabeling_test.go
+++ b/internal/component/database_observability/relabeling_test.go
@@ -1,0 +1,48 @@
+package database_observability
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/grafana/alloy/internal/component/common/relabel"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_GetRelabelingRules(t *testing.T) {
+	t.Run("return relabeling rules", func(t *testing.T) {
+		rr := GetRelabelingRules("some-server-id", nil)
+
+		require.Equal(t, 1, len(rr))
+		require.Equal(t, "some-server-id", rr[0].Replacement)
+		require.Equal(t, "server_id", rr[0].TargetLabel)
+		require.Equal(t, relabel.Replace, rr[0].Action)
+	})
+
+	t.Run("return relabeling rules with AWS config", func(t *testing.T) {
+		rr := GetRelabelingRules("some-server-id", &CloudProvider{
+			AWS: &AWSCloudProviderInfo{
+				ARN: arn.ARN{
+					Region:    "some-region",
+					AccountID: "some-account",
+				},
+			},
+		})
+
+		require.Equal(t, 4, len(rr))
+		require.Equal(t, "some-server-id", rr[0].Replacement)
+		require.Equal(t, "server_id", rr[0].TargetLabel)
+		require.Equal(t, relabel.Replace, rr[0].Action)
+
+		require.Equal(t, "aws", rr[1].Replacement)
+		require.Equal(t, "provider_name", rr[1].TargetLabel)
+		require.Equal(t, relabel.Replace, rr[1].Action)
+
+		require.Equal(t, "some-region", rr[2].Replacement)
+		require.Equal(t, "provider_region", rr[2].TargetLabel)
+		require.Equal(t, relabel.Replace, rr[2].Action)
+
+		require.Equal(t, "some-account", rr[3].Replacement)
+		require.Equal(t, "provider_account", rr[3].TargetLabel)
+		require.Equal(t, relabel.Replace, rr[3].Action)
+	})
+}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Add cloud provider labels (`provider_name`, `provider_account`, `provider_region`) to mysql metrics via a relabel rule when supplied via configuration. This provides better attribution of metrics to RDS entities. 

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
