### PR TITLE
database_observability: Postgres explain plan improvements

### DIFF
--- a/docs/sources/reference/components/database_observability/database_observability.postgres.md
+++ b/docs/sources/reference/components/database_observability/database_observability.postgres.md
@@ -81,7 +81,6 @@ This collector has no config options.
 |--------------------------------|----------------|------------------------------------------------------|---------|----------|
 | `collect_interval`             | `duration`     | How frequently to collect information from database. | `"1m"`  | no       |
 | `per_collect_ratio`            | `float64`      | The ratio of queries to collect explain plans for.   | `1.0`   | no       |
-| `initial_lookback`             | `duration`     | The amount of time to look back for explain plans.   | `24h`   | no       |
 | `explain_plan_exclude_schemas` | `list(string)` | Schemas to exclude from explain plans.               | `[]`    | no       |
 
 ## Example

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -92,14 +92,12 @@ var DefaultArguments = Arguments{
 	ExplainPlanArguments: ExplainPlanArguments{
 		CollectInterval: 1 * time.Minute,
 		PerCollectRatio: 1.0,
-		InitialLookback: 24 * time.Hour,
 	},
 }
 
 type ExplainPlanArguments struct {
 	CollectInterval           time.Duration `alloy:"collect_interval,attr,optional"`
 	PerCollectRatio           float64       `alloy:"per_collect_ratio,attr,optional"`
-	InitialLookback           time.Duration `alloy:"initial_lookback,attr,optional"`
 	ExplainPlanExcludeSchemas []string      `alloy:"explain_plan_exclude_schemas,attr,optional"`
 }
 
@@ -398,14 +396,13 @@ func (c *Component) startCollectors(systemID string, engineVersion string) error
 
 	if collectors[collector.ExplainPlanCollector] {
 		epCollector, err := collector.NewExplainPlan(collector.ExplainPlanArguments{
-			DB:              c.dbConnection,
-			DSN:             string(c.args.DataSourceName),
-			ScrapeInterval:  c.args.ExplainPlanArguments.CollectInterval,
-			PerScrapeRatio:  c.args.ExplainPlanArguments.PerCollectRatio,
-			Logger:          c.opts.Logger,
-			DBVersion:       engineVersion,
-			EntryHandler:    entryHandler,
-			InitialLookback: time.Now().Add(-c.args.ExplainPlanArguments.InitialLookback),
+			DB:             c.dbConnection,
+			DSN:            string(c.args.DataSourceName),
+			ScrapeInterval: c.args.ExplainPlanArguments.CollectInterval,
+			PerScrapeRatio: c.args.ExplainPlanArguments.PerCollectRatio,
+			Logger:         c.opts.Logger,
+			DBVersion:      engineVersion,
+			EntryHandler:   entryHandler,
 		})
 		if err != nil {
 			logStartError(collector.ExplainPlanCollector, "create", err)


### PR DESCRIPTION
#### PR Description
Fast-follow to the initial implementation of postgres explain plans.

This switches to using the pg_stat_statements table for fetching queries for explain plans. Previously pg_stat_activity was used, and it was determined that this might not produce all queries which had been executed.

Using a different table necessitated a different strategy for determining which queries had been executed, since the last scrape interval, which is why the settings for "InitialLookback" was removed.

Now *all* queries will be explained in the first batch. Then only queries which have been executed since the last scrape interval going forward.

Finally, this change *also* uses a temporary prepared statement to execute the explain plan. This is necessary because the queries are parameterized. In a prepared statement, you may provide `null` parameters to the statement, and set the `plan_cache_mode` to `force_generic_plan` in order to get a usable explain plan without real parameter values.

#### Notes to the Reviewer
I did not change the CHANGELOG, since this is a fast-follow update to unreleased functionality.

#### PR Checklist
- [X] Documentation added
