### PR TITLE
adds references to label types

### DIFF
--- a/docs/sources/reference/components/loki/loki.process.md
+++ b/docs/sources/reference/components/loki/loki.process.md
@@ -582,6 +582,8 @@ stage.label_keep {
 
 The `stage.labels` inner block configures a labels processing stage that can read data from the extracted values map and set new labels on incoming log entries.
 
+For labels that are static, see [`stage.static_labels`][stage.static_labels]
+
 The following arguments are supported:
 
 | Name     | Type          | Description                             | Default | Required |
@@ -1460,6 +1462,8 @@ stage.sampling {
 ### `stage.static_labels`
 
 The `stage.static_labels` inner block configures a static_labels processing stage that adds a static set of labels to incoming log entries.
+
+For labels that are dynamic, see [`stage.labels`][stage.labels]
 
 The following arguments are supported:
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Someone came across the issue where they added a static label but used a `stage.labels` instead of `stage.static_labels`. Since this settings page is quite long and details like this can be missed, I added references to the other settings in this docs PR.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->
N/A

#### Notes to the Reviewer
No notes

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->


- [x] Documentation added

