### PR TITLE
database_observability: add caching to Postgres schema details collector

### DIFF
--- a/internal/component/database_observability/postgres/collector/schema_details.go
+++ b/internal/component/database_observability/postgres/collector/schema_details.go
@@ -179,6 +179,7 @@ type SchemaDetails struct {
 
 	// Cache of table definitions. Entries are removed after a configurable TTL.
 	// Key is a string of the form "database.schema.table".
+	// TODO: (unlike MySQL) no create/update timestamp available for detecting immediately when a table schema is changed
 	cache *expirable.LRU[string, *tableInfo]
 
 	logger  log.Logger

--- a/internal/component/database_observability/postgres/collector/schema_details.go
+++ b/internal/component/database_observability/postgres/collector/schema_details.go
@@ -179,7 +179,7 @@ type SchemaDetails struct {
 
 	// Cache of table definitions. Entries are removed after a configurable TTL.
 	// Key is a string of the form "database.schema.table".
-	// TODO: (unlike MySQL) no create/update timestamp available for detecting immediately when a table schema is changed
+	// (unlike MySQL) no create/update timestamp available for detecting immediately when a table schema is changed; relying on TTL only
 	cache *expirable.LRU[string, *tableInfo]
 
 	logger  log.Logger

--- a/internal/component/database_observability/postgres/collector/schema_details.go
+++ b/internal/component/database_observability/postgres/collector/schema_details.go
@@ -160,8 +160,9 @@ type indexSpec struct {
 }
 
 type SchemaDetailsArguments struct {
-	DB           *sql.DB
-	EntryHandler loki.EntryHandler
+	DB              *sql.DB
+	CollectInterval time.Duration
+	EntryHandler    loki.EntryHandler
 
 	Logger log.Logger
 }
@@ -180,7 +181,7 @@ type SchemaDetails struct {
 func NewSchemaDetails(args SchemaDetailsArguments) (*SchemaDetails, error) {
 	c := &SchemaDetails{
 		dbConnection:    args.DB,
-		collectInterval: 10 * time.Minute, // TODO: make it configurable again once caching is implemented
+		collectInterval: args.CollectInterval,
 		entryHandler:    args.EntryHandler,
 		logger:          log.With(args.Logger, "collector", SchemaDetailsCollector),
 		running:         &atomic.Bool{},

--- a/internal/component/database_observability/postgres/collector/schema_details.go
+++ b/internal/component/database_observability/postgres/collector/schema_details.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/lib/pq"
 	"go.uber.org/atomic"
 
@@ -164,6 +165,10 @@ type SchemaDetailsArguments struct {
 	CollectInterval time.Duration
 	EntryHandler    loki.EntryHandler
 
+	CacheEnabled bool
+	CacheSize    int
+	CacheTTL     time.Duration
+
 	Logger log.Logger
 }
 
@@ -171,6 +176,10 @@ type SchemaDetails struct {
 	dbConnection    *sql.DB
 	collectInterval time.Duration
 	entryHandler    loki.EntryHandler
+
+	// Cache of table definitions. Entries are removed after a configurable TTL.
+	// Key is a string of the form "database.schema.table".
+	cache *expirable.LRU[string, *tableInfo]
 
 	logger  log.Logger
 	running *atomic.Bool
@@ -185,6 +194,10 @@ func NewSchemaDetails(args SchemaDetailsArguments) (*SchemaDetails, error) {
 		entryHandler:    args.EntryHandler,
 		logger:          log.With(args.Logger, "collector", SchemaDetailsCollector),
 		running:         &atomic.Bool{},
+	}
+
+	if args.CacheEnabled {
+		c.cache = expirable.NewLRU[string, *tableInfo](args.CacheSize, nil, args.CacheTTL)
 	}
 
 	return c, nil
@@ -315,10 +328,25 @@ func (c *SchemaDetails) extractNames(ctx context.Context) error {
 	}
 
 	for _, table := range tables {
-		table, err = c.fetchTableDefinitions(ctx, table)
-		if err != nil {
-			level.Error(c.logger).Log("msg", "failed to get table definitions", "datname", dbName, "schema", table.schema, "err", err)
-			continue
+		cacheKey := fmt.Sprintf("%s.%s.%s", table.database, table.schema, table.tableName)
+
+		cacheHit := false
+		if c.cache != nil {
+			if cached, ok := c.cache.Get(cacheKey); ok {
+				table = cached
+				cacheHit = true
+			}
+		}
+
+		if !cacheHit {
+			table, err = c.fetchTableDefinitions(ctx, table)
+			if err != nil {
+				level.Error(c.logger).Log("msg", "failed to get table definitions", "datname", dbName, "schema", table.schema, "err", err)
+				continue
+			}
+			if c.cache != nil {
+				c.cache.Add(cacheKey, table)
+			}
 		}
 
 		c.entryHandler.Chan() <- database_observability.BuildLokiEntry(

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -66,8 +66,9 @@ type Arguments struct {
 	EnableCollectors  []string            `alloy:"enable_collectors,attr,optional"`
 	DisableCollectors []string            `alloy:"disable_collectors,attr,optional"`
 
-	QuerySampleArguments QuerySampleArguments `alloy:"query_samples,block,optional"`
-	QueryTablesArguments QueryTablesArguments `alloy:"query_details,block,optional"`
+	QuerySampleArguments   QuerySampleArguments   `alloy:"query_samples,block,optional"`
+	QueryTablesArguments   QueryTablesArguments   `alloy:"query_details,block,optional"`
+	SchemaDetailsArguments SchemaDetailsArguments `alloy:"schema_details,block,optional"`
 
 	ExplainPlanArguments ExplainPlanArguments `alloy:"explain_plans,block,optional"`
 }
@@ -81,12 +82,19 @@ type QueryTablesArguments struct {
 	CollectInterval time.Duration `alloy:"collect_interval,attr,optional"`
 }
 
+type SchemaDetailsArguments struct {
+	CollectInterval time.Duration `alloy:"collect_interval,attr,optional"`
+}
+
 var DefaultArguments = Arguments{
 	QuerySampleArguments: QuerySampleArguments{
 		CollectInterval:       15 * time.Second,
 		DisableQueryRedaction: false,
 	},
 	QueryTablesArguments: QueryTablesArguments{
+		CollectInterval: 1 * time.Minute,
+	},
+	SchemaDetailsArguments: SchemaDetailsArguments{
 		CollectInterval: 1 * time.Minute,
 	},
 	ExplainPlanArguments: ExplainPlanArguments{
@@ -383,9 +391,10 @@ func (c *Component) startCollectors(systemID string, engineVersion string) error
 
 	if collectors[collector.SchemaDetailsCollector] {
 		stCollector, err := collector.NewSchemaDetails(collector.SchemaDetailsArguments{
-			DB:           c.dbConnection,
-			EntryHandler: entryHandler,
-			Logger:       c.opts.Logger,
+			DB:              c.dbConnection,
+			CollectInterval: c.args.SchemaDetailsArguments.CollectInterval,
+			EntryHandler:    entryHandler,
+			Logger:          c.opts.Logger,
 		})
 		if err != nil {
 			logStartError(collector.SchemaDetailsCollector, "create", err)

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -84,6 +84,9 @@ type QueryTablesArguments struct {
 
 type SchemaDetailsArguments struct {
 	CollectInterval time.Duration `alloy:"collect_interval,attr,optional"`
+	CacheEnabled    bool          `alloy:"cache_enabled,attr,optional"`
+	CacheSize       int           `alloy:"cache_size,attr,optional"`
+	CacheTTL        time.Duration `alloy:"cache_ttl,attr,optional"`
 }
 
 var DefaultArguments = Arguments{
@@ -96,6 +99,9 @@ var DefaultArguments = Arguments{
 	},
 	SchemaDetailsArguments: SchemaDetailsArguments{
 		CollectInterval: 1 * time.Minute,
+		CacheEnabled:    true,
+		CacheSize:       256,
+		CacheTTL:        10 * time.Minute,
 	},
 	ExplainPlanArguments: ExplainPlanArguments{
 		CollectInterval: 1 * time.Minute,
@@ -393,6 +399,9 @@ func (c *Component) startCollectors(systemID string, engineVersion string) error
 		stCollector, err := collector.NewSchemaDetails(collector.SchemaDetailsArguments{
 			DB:              c.dbConnection,
 			CollectInterval: c.args.SchemaDetailsArguments.CollectInterval,
+			CacheEnabled:    c.args.SchemaDetailsArguments.CacheEnabled,
+			CacheSize:       c.args.SchemaDetailsArguments.CacheSize,
+			CacheTTL:        c.args.SchemaDetailsArguments.CacheTTL,
 			EntryHandler:    entryHandler,
 			Logger:          c.opts.Logger,
 		})

--- a/internal/component/database_observability/postgres/component_test.go
+++ b/internal/component/database_observability/postgres/component_test.go
@@ -335,3 +335,21 @@ func TestPostgres_Update_DBUnavailable_ReportsUnhealthy(t *testing.T) {
 	assert.Equal(t, cmp.HealthTypeUnhealthy, h.Health)
 	assert.NotEmpty(t, h.Message)
 }
+
+func TestPostgres_schema_details_collect_interval_is_parsed_from_config(t *testing.T) {
+	t.Parallel()
+
+	exampleDBO11yAlloyConfig := `
+	data_source_name = "postgres://db"
+	forward_to = []
+	schema_details {
+		collect_interval = "11s"
+	}
+`
+
+	var args Arguments
+	err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
+	require.NoError(t, err)
+
+	assert.Equal(t, 11*time.Second, args.SchemaDetailsArguments.CollectInterval)
+}

--- a/internal/component/database_observability/postgres/component_test.go
+++ b/internal/component/database_observability/postgres/component_test.go
@@ -353,3 +353,42 @@ func TestPostgres_schema_details_collect_interval_is_parsed_from_config(t *testi
 
 	assert.Equal(t, 11*time.Second, args.SchemaDetailsArguments.CollectInterval)
 }
+
+func TestPostgres_schema_details_cache_configuration_is_parsed_from_config(t *testing.T) {
+	t.Run("default cache configuration", func(t *testing.T) {
+		exampleDBO11yAlloyConfig := `
+		data_source_name = "postgres://db"
+		forward_to = []
+		`
+
+		var args Arguments
+		err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
+		require.NoError(t, err)
+
+		assert.Equal(t, DefaultArguments.SchemaDetailsArguments.CacheEnabled, args.SchemaDetailsArguments.CacheEnabled)
+		assert.Equal(t, DefaultArguments.SchemaDetailsArguments.CacheSize, args.SchemaDetailsArguments.CacheSize)
+		assert.Equal(t, DefaultArguments.SchemaDetailsArguments.CacheTTL, args.SchemaDetailsArguments.CacheTTL)
+	})
+
+	t.Run("custom cache configuration", func(t *testing.T) {
+		exampleDBO11yAlloyConfig := `
+		data_source_name = "postgres://db"
+		forward_to = []
+		schema_details {
+			collect_interval = "30s"
+			cache_enabled = false
+			cache_size = 512
+			cache_ttl = "5m"
+		}
+		`
+
+		var args Arguments
+		err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
+		require.NoError(t, err)
+
+		assert.Equal(t, 30*time.Second, args.SchemaDetailsArguments.CollectInterval)
+		assert.False(t, args.SchemaDetailsArguments.CacheEnabled)
+		assert.Equal(t, 512, args.SchemaDetailsArguments.CacheSize)
+		assert.Equal(t, 5*time.Minute, args.SchemaDetailsArguments.CacheTTL)
+	})
+}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR adds to the Postgres schema details collector:
* a configurable collect interval 
* caching for the schema with a TTL of 10 min (see note below)

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer
Unlike MySQL, there is no create/update timestamp available for detecting immediately when a table schema is changed; so we're relying on TTL only. 
Let me know if you have some ideas. 

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
