### PR TITLE
add(helm): Use commonLabels in chart

### DIFF
--- a/operations/helm/charts/alloy/CHANGELOG.md
+++ b/operations/helm/charts/alloy/CHANGELOG.md
@@ -10,6 +10,15 @@ internal API changes are not present.
 Unreleased
 ----------
 
+1.3.1 (2025-10-08)
+----------
+
+### Other changes
+
+- Update values to use commonLabels
+
+------------------
+
 1.3.0 (2025-09-30)
 ----------
 

--- a/operations/helm/charts/alloy/Chart.yaml
+++ b/operations/helm/charts/alloy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: alloy
 description: 'Grafana Alloy'
 type: application
-version: 1.3.0
+version: 1.3.1
 appVersion: 'v1.11.0'
 icon: https://raw.githubusercontent.com/grafana/alloy/main/docs/sources/assets/alloy_icon_orange.svg
 

--- a/operations/helm/charts/alloy/README.md
+++ b/operations/helm/charts/alloy/README.md
@@ -121,6 +121,7 @@ useful if just using the default DaemonSet isn't sufficient.
 | controller.podDisruptionBudget.maxUnavailable | string | `nil` | Maximum number of pods that can be unavailable during a disruption. Note: Only one of minAvailable or maxUnavailable should be set. |
 | controller.podDisruptionBudget.minAvailable | string | `nil` | Minimum number of pods that must be available during a disruption. Note: Only one of minAvailable or maxUnavailable should be set. |
 | controller.podLabels | object | `{}` | Extra pod labels to add. |
+| controller.commonLabels | object | `{}` | Add additional label to all resources. |
 | controller.priorityClassName | string | `""` | priorityClassName to apply to Grafana Alloy pods. |
 | controller.replicas | int | `1` | Number of pods to deploy. Ignored when controller.type is 'daemonset'. |
 | controller.terminationGracePeriodSeconds | string | `nil` | Termination grace period in seconds for the Grafana Alloy pods. The default value used by Kubernetes if unspecifed is 30 seconds. |

--- a/operations/helm/charts/alloy/templates/_helpers.tpl
+++ b/operations/helm/charts/alloy/templates/_helpers.tpl
@@ -54,6 +54,8 @@ helm.sh/chart: {{ include "alloy.chart" . }}
 {{- if index .Values "$chart_tests" }}
 app.kubernetes.io/version: "vX.Y.Z"
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{- toYaml . }}
 {{- else -}}
 {{/* substr trims delimeter prefix char from alloy.imageId output
     e.g. ':' for tags and '@' for digests.
@@ -61,6 +63,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/version: {{ (include "alloy.imageId" .) | trimPrefix "@sha256" | trimPrefix ":" | trunc 63 | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: alloy
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/operations/helm/charts/alloy/values.yaml
+++ b/operations/helm/charts/alloy/values.yaml
@@ -201,6 +201,9 @@ controller:
   # -- Extra labels to add to the controller.
   extraLabels: {}
 
+  # -- Add additional label to all resources
+  commonLabels: {}
+
   # -- Annotations to add to controller.
   extraAnnotations: {}
 


### PR DESCRIPTION
#### PR Description

This PR introduces the use of the commonLabels field in the Alloy Helm chart.
It allows users to define a common set of labels that will be applied to all resources generated by the chart (Deployments, Services, ConfigMaps, etc.), ensuring consistent metadata and easier resource management.

#### Key Changes

- Added the new field commonLabels in values.yaml.

- Updated Helm template helpers to render commonLabels across all chart resources.

- Updated documentation (README.md) to describe the new value.

- Bumped chart version to 1.3.1.

- Updated CHANGELOG.md accordingly.

#### Example Usage:

```
commonLabels:
  app.kubernetes.io/part-of: monitoring
  environment: production
  team: platform
```
This will apply the above labels to all resources created by the chart.

#### Benefits

- Enables better alignment with GitOps practices and resource tracking.

- Simplifies applying organization-wide labels such as team, environment, or owner.

- Improves observability and filtering across Kubernetes and monitoring tools.

#### Which issue(s) this PR fixes

N/A

#### PR Checklist

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Chart version bumped