### PR TITLE
scheduler: add component shutdown timeout of 10m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Main (unreleased)
 
 - Fix direction of arrows for pyroscope components in UI graph. (@dehaansa)
 
-- Fix an issue where component shutdown could block indefinitely by adding a warning log message and a deadline of 10 minutes. (@thampiotr)
+- Fix an issue where component shutdown could block indefinitely by adding a warning log message and a deadline of 10 minutes. The deadline can be configured with the `--feature.component-shutdown-deadline` flag if the default is not suitable. (@thampiotr)
 
 v1.11.1
 -----------------

--- a/docs/sources/reference/cli/run.md
+++ b/docs/sources/reference/cli/run.md
@@ -65,6 +65,7 @@ The following flags are supported:
 * `--config.extra-args`: Extra arguments from the original format used by the converter.
 * `--stability.level`: The minimum permitted stability level of functionality. Supported values: `experimental`, `public-preview`, and `generally-available` (default `"generally-available"`).
 * `--feature.community-components.enabled`: Enable community components (default `false`).
+* `--feature.component-shutdown-deadline`: Maximum duration to wait for a component to shut down before giving up and logging an error (default `"10m"`).
 * `--windows.priority`: The priority to set for the {{< param "PRODUCT_NAME" >}} process when running on Windows. This is only available on Windows. Supported values: `above_normal`, `below_normal`, `normal`, `high`, `idle`, or `realtime` (default `"normal"`).
 
 {{< admonition type="note" >}}

--- a/internal/alloycli/cmd_run.go
+++ b/internal/alloycli/cmd_run.go
@@ -68,6 +68,7 @@ func runCommand() *cobra.Command {
 		clusterRejoinInterval: 60 * time.Second,
 		disableSupportBundle:  false,
 		windowsPriority:       windowspriority.PriorityNormal,
+		taskShutdownDeadline:  10 * time.Minute,
 	}
 
 	cmd := &cobra.Command{
@@ -166,6 +167,7 @@ depending on the nature of the reload error.
 	if runtime.GOOS == "windows" {
 		cmd.Flags().StringVar(&r.windowsPriority, "windows.priority", r.windowsPriority, fmt.Sprintf("Process priority to use when running on windows. This flag is currently in public preview. Supported values: %s", strings.Join(slices.Collect(windowspriority.PriorityValues()), ", ")))
 	}
+	cmd.Flags().DurationVar(&r.taskShutdownDeadline, "feature.component-shutdown-deadline", r.taskShutdownDeadline, "Maximum duration to wait for a component to shut down before giving up and logging an error")
 
 	addDeprecatedFlags(cmd)
 	return cmd
@@ -201,6 +203,7 @@ type alloyRun struct {
 	enableCommunityComps         bool
 	disableSupportBundle         bool
 	windowsPriority              string
+	taskShutdownDeadline         time.Duration
 }
 
 func (fr *alloyRun) Run(cmd *cobra.Command, configPath string) error {
@@ -384,6 +387,7 @@ func (fr *alloyRun) Run(cmd *cobra.Command, configPath string) error {
 			remoteCfgService,
 			uiService,
 		},
+		TaskShutdownDeadline: fr.taskShutdownDeadline,
 	})
 
 	ready = f.Ready

--- a/internal/runtime/internal/controller/scheduler_test.go
+++ b/internal/runtime/internal/controller/scheduler_test.go
@@ -32,7 +32,7 @@ func TestScheduler_Synchronize(t *testing.T) {
 			return nil
 		}
 
-		sched := controller.NewScheduler(logger)
+		sched := controller.NewScheduler(logger, 1*time.Minute)
 		sched.Synchronize([]controller.RunnableNode{
 			fakeRunnable{ID: "component-a", Component: mockComponent{RunFunc: runFunc}},
 			fakeRunnable{ID: "component-b", Component: mockComponent{RunFunc: runFunc}},
@@ -54,7 +54,7 @@ func TestScheduler_Synchronize(t *testing.T) {
 			return nil
 		}
 
-		sched := controller.NewScheduler(logger)
+		sched := controller.NewScheduler(logger, 1*time.Minute)
 
 		for i := 0; i < 10; i++ {
 			// If a new runnable is created, runFunc will panic since the WaitGroup
@@ -80,7 +80,7 @@ func TestScheduler_Synchronize(t *testing.T) {
 			return nil
 		}
 
-		sched := controller.NewScheduler(logger)
+		sched := controller.NewScheduler(logger, 1*time.Minute)
 
 		sched.Synchronize([]controller.RunnableNode{
 			fakeRunnable{ID: "component-a", Component: mockComponent{RunFunc: runFunc}},
@@ -120,12 +120,9 @@ func (mc mockComponent) Update(newConfig component.Arguments) error { return mc.
 func TestScheduler_TaskTimeoutLogging(t *testing.T) {
 	// Temporarily modify timeout values for testing
 	originalWarningTimeout := controller.TaskShutdownWarningTimeout
-	originalDeadline := controller.TaskShutdownDeadline
 	controller.TaskShutdownWarningTimeout = 50 * time.Millisecond
-	controller.TaskShutdownDeadline = 150 * time.Millisecond
 	defer func() {
 		controller.TaskShutdownWarningTimeout = originalWarningTimeout
-		controller.TaskShutdownDeadline = originalDeadline
 	}()
 
 	// Create a buffer to capture log output
@@ -144,7 +141,7 @@ func TestScheduler_TaskTimeoutLogging(t *testing.T) {
 		return nil
 	}
 
-	sched := controller.NewScheduler(logger)
+	sched := controller.NewScheduler(logger, 150*time.Millisecond)
 
 	// Start a component
 	err := sched.Synchronize([]controller.RunnableNode{


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Adds a safety mechanism to timeout when components take too long to shut down. Logs a warning when they are taking too long. 

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
