### PR TITLE
chore: don't error log when context in canceled

### DIFF
--- a/internal/alloycli/cmd_run.go
+++ b/internal/alloycli/cmd_run.go
@@ -429,7 +429,7 @@ func (fr *alloyRun) Run(cmd *cobra.Command, configPath string) error {
 		}
 		go func() {
 			err := reporter.Start(ctx, getEnabledComponentsFunc(f))
-			if err != nil {
+			if err != nil && !errors.Is(err, context.Canceled) {
 				level.Error(l).Log("msg", "failed to start reporter", "err", err)
 			}
 		}()


### PR DESCRIPTION
If reporting is enabled we will always perform this error log when alloy is shutting down because the context we provide will be canceled.
