### PR TITLE
Loki Write: Remove Internal Labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ Main (unreleased)
 
 - Fix issue in `loki.source.file` where scheduling files could take too long. (@kalleep)
 
+- Fix `loki.write` no longer includes internal labels `__`.  (@matt-gp)
+
 v1.11.3
 -----------------
 

--- a/internal/component/common/loki/client/batch_test.go
+++ b/internal/component/common/loki/client/batch_test.go
@@ -180,7 +180,48 @@ func BenchmarkLabelsMapToString(b *testing.B) {
 	var r string
 	for i := 0; i < b.N; i++ {
 		// store in r prevent the compiler eliminating the function call.
-		r = labelsMapToString(labelSet, ReservedLabelTenantID)
+		r = labelsMapToString(labelSet)
 	}
 	result = r
+}
+
+func TestLabelsMapToString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    model.LabelSet
+		expected string
+	}{
+		{
+			name:     "empty label set",
+			input:    model.LabelSet{},
+			expected: "{}",
+		},
+		{
+			name:     "single label",
+			input:    model.LabelSet{"app": "my-app"},
+			expected: `{app="my-app"}`,
+		},
+		{
+			name:     "multiple labels",
+			input:    model.LabelSet{"app": "my-app", "env": "prod"},
+			expected: `{app="my-app", env="prod"}`,
+		},
+		{
+			name:     "labels with reserved labels",
+			input:    model.LabelSet{"app": "my-app", "__meta_label_abc": "meta-abc", "__meta_label_def": "meta-def", "abc": "123"},
+			expected: `{abc="123", app="my-app"}`,
+		},
+		{
+			name:     "only reserved labels",
+			input:    model.LabelSet{"__meta_label_abc": "meta-abc", "__meta_label_def": "meta-def"},
+			expected: "{}",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := labelsMapToString(tc.input)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
 }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This change is to add logic so that labels that start with `__` are filtered out. Labels that start with `__` are used internally for things such as metadata. If a user want to preserve the contents of one of these internal labels, then can do so using relabelling to remove the `__`.

This change also adds tests which check various different scenarios.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #4412 

#### Notes to the Reviewer
The docs already state that labels with `__` get removed, so I don't see the need to update these.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Tests updated
