### PR TITLE
feat(faro.receiver): Add sourcemap fetching from remote locations

### DIFF
--- a/docs/sources/reference/components/faro/faro.receiver.md
+++ b/docs/sources/reference/components/faro/faro.receiver.md
@@ -64,7 +64,7 @@ You can use the following blocks with `faro.receiver`:
 | `server` >  [`rate_limiting`][rate_limiting] | Configures rate limiting for the HTTP server.        | no       |
 | [`sourcemaps`][sourcemaps]                   | Configures sourcemap retrieval.                      | no       |
 | `sourcemaps` > [`cache`][cache]              | Configures sourcemap caching behavior.               | no       |
-| `sourcemaps` >  [`location`][location]       | Configures on-disk location for sourcemap retrieval. | no       |
+| `sourcemaps` >  [`location`][location]       | Configures the location for sourcemap retrieval.     | no       |
 
 [cache]: #cache
 [location]: #location
@@ -168,7 +168,7 @@ The `*` character indicates a wildcard.
 By default, sourcemap downloads are subject to a timeout of `"1s"`, specified by the `download_timeout` argument.
 Setting `download_timeout` to `"0s"` disables timeouts.
 
-To retrieve sourcemaps from disk instead of the network, specify one or more [`location` blocks][location].
+To retrieve sourcemaps from disk or another network location, specify one or more [`location` blocks][location].
 When `location` blocks are provided, they're checked first for sourcemaps before falling back to downloading.
 
 #### `cache`
@@ -195,10 +195,10 @@ Set `cleanup_check_interval` to adjust this frequency.
 The `location` block declares a location where sourcemaps are stored on the filesystem.
 You can specify the `location` block multiple times to declare multiple locations where sourcemaps are stored.
 
-| Name                   | Type     | Description                                         | Default | Required |
-|------------------------|----------|-----------------------------------------------------|---------|----------|
-| `minified_path_prefix` | `string` | The prefix of the minified path sent from browsers. |         | yes      |
-| `path`                 | `string` | The path on disk where sourcemaps are stored.       |         | yes      |
+| Name                   | Type     | Description                                               | Default | Required |
+|------------------------|----------|-----------------------------------------------------------|---------|----------|
+| `minified_path_prefix` | `string` | The prefix of the minified path sent from browsers.       |         | yes      |
+| `path`                 | `string` | The path on disk or base URL where sourcemaps are stored. |         | yes      |
 
 The `minified_path_prefix` argument determines the prefix of paths to JavaScript files, such as `http://example.com/`.
 The `path` argument then determines where to find the sourcemap for the file.
@@ -219,6 +219,35 @@ To look up the sourcemaps for a file hosted at `http://example.com/example.js`, 
 
 Optionally, the value for the `path` argument may contain `{{ .Release }}` as a template value, such as `/var/my-app/{{ .Release }}/build`.
 The template value is replaced with the release value provided by the [Faro Web App SDK][faro-sdk].
+
+When you specify a remote location, the procedure for retrieving the sourcemaps is the same as for a location block with a local path, except that the component retrieves the sourcemap from a remote HTTP server.
+
+In the following example, the `faro.receiver` sends a GET request to `http://storage.example.com/blob/sourcemaps/example.js.map` and retrieves the sourcemap for a file hosted at
+`http://example.com/example.js`.
+
+You can specify multiple location blocks. For example:
+
+```alloy
+location {
+    path                 = "http://storage.example.com/blob/sourcemaps/"
+    minified_path_prefix = "http://example.com/"
+}
+
+```alloy
+location {
+    path                 = "/var/my-app/build"
+    minified_path_prefix = "http://example.com/"
+}
+location {
+    path                 = "http://storage.example.com/blob/sourcemaps/"
+    minified_path_prefix = "http://example.com/"
+}
+```
+
+The `faro.receiver` component searches through all locations for the sourcemap files.
+Local on-disk paths take precedence over remote paths.
+For a file hosted at `http://example.com/example.js`, the `faro.receiver` first checks
+the path `/var/my-app/build/example.js.map`, and then tries to retrieve `http://storage.example.com/blob/sourcemaps/example.js.map`.
 
 ## Exported fields
 


### PR DESCRIPTION
#### PR Description

This adds the ability to fetch sourcemaps from remote locations over HTTP to the `faro.receiver`. Allowing `sourcemaps > location` blocks to point to an HTTP URL as the path, e.g., `path = "https://foo.com/blob/sourcemaps/"`.

The motivation behind this feature is to support the use case where your frontend is served by an external CDN and Alloy is running on internal infrastructure, where external resources are not readily accessible, and managing and attaching volumes to the Alloy container is complex or undesired. This feature allows you to host your sourcemaps internally, e.g., on a blob storage service. It also fits the use case where you don't want to expose sourcemaps to customers but still want to be able to fetch them internally for `faro.receiver`'s stack-trace transformations.

If multiple location blocks are defined, blocks pointing to on-disk paths will be checked first before attempting to fetch the sourcemaps over HTTP.

#### Which issue(s) this PR fixes

None.

#### Notes to the Reviewer

None.

#### PR Checklist

- [X] CHANGELOG.md updated
- [X] Documentation added
- [X] Tests updated
