### PR TITLE
Mark 1.11 as released in docs

### DIFF
--- a/docs/sources/release-notes.md
+++ b/docs/sources/release-notes.md
@@ -14,7 +14,7 @@ For a complete list of changes to {{< param "FULL_PRODUCT_NAME" >}}, with links 
 
 [Changelog]: https://github.com/grafana/alloy/blob/main/CHANGELOG.md
 
-## v1.11 (unreleased)
+## v1.11
 
 ### Breaking changes due to major version upgrade of Prometheus
 


### PR DESCRIPTION
Oops, live docs show 1.11 as unreleased.

<img width="643" height="228" alt="image" src="https://github.com/user-attachments/assets/c658599d-7f85-45ab-a049-ca28c723e6e7" />
