### PR TITLE
chore: use doublestar v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ Main (unreleased)
 
 - `prometheus.exporter.snowflake` dependency has been updated to 20251016132346-6d442402afb2, which updates data ownership queries to use `last_over_time` for a 24 hour period. (@dasomeone)
 
+- `local.file_match` now useses github.com/bmatcuk/doublestar/v4. (@kalleep)
+
 ### Bugfixes
 
 - Stop `loki.source.kubernetes` discarding log lines with duplicate timestamps. (@ciaranj)

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.87.3
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.37.0
 	github.com/blang/semver/v4 v4.0.0
-	github.com/bmatcuk/doublestar v1.3.4
 	github.com/boynux/squid-exporter v1.10.5-0.20230618153315-c1fae094e18e
 	github.com/buger/jsonparser v1.1.1
 	github.com/burningalchemist/sql_exporter v0.0.0-20240103092044-466b38b6abc4
@@ -507,7 +506,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.10.0 // indirect
 	github.com/bits-and-blooms/bloom/v3 v3.7.0 // indirect
-	github.com/bmatcuk/doublestar/v4 v4.9.1 // indirect
+	github.com/bmatcuk/doublestar/v4 v4.9.1
 	github.com/briandowns/spinner v1.23.0 // indirect
 	github.com/c2h5oh/datasize v0.0.0-20231215233829-aa82cc1e6500 // indirect
 	github.com/caarlos0/env/v9 v9.0.0

--- a/go.sum
+++ b/go.sum
@@ -591,8 +591,6 @@ github.com/bkaradzic/go-lz4 v1.0.0/go.mod h1:0YdlkowM3VswSROI7qDxhRvJ3sLhlFrRRwj
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
-github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=
-github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/bmatcuk/doublestar/v4 v4.9.1 h1:X8jg9rRZmJd4yRy7ZeNDRnM+T3ZfHv15JiBJ/avrEXE=
 github.com/bmatcuk/doublestar/v4 v4.9.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/boynux/squid-exporter v1.10.5-0.20230618153315-c1fae094e18e h1:C1vYe728vM2FpXaICJuDRt5zgGyRdMmUGYnVfM7WcLY=

--- a/internal/component/local/file_match/watch.go
+++ b/internal/component/local/file_match/watch.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/bmatcuk/doublestar"
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/go-kit/log"
 
 	"github.com/grafana/alloy/internal/component/common/loki/utils"
@@ -23,7 +23,7 @@ type watch struct {
 func (w *watch) getPaths() ([]discovery.Target, error) {
 	allMatchingPaths := make([]discovery.Target, 0)
 
-	matches, err := doublestar.Glob(w.getPath())
+	matches, err := doublestar.FilepathGlob(w.getPath())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/component/loki/source/file/file.go
+++ b/internal/component/loki/source/file/file.go
@@ -171,7 +171,6 @@ func (c *Component) Run(ctx context.Context) error {
 	}()
 
 	var wg sync.WaitGroup
-	wg.Add(1)
 	wg.Go(func() {
 		for {
 			select {
@@ -224,6 +223,7 @@ func (c *Component) Run(ctx context.Context) error {
 		for {
 			select {
 			case <-ctx.Done():
+				fmt.Println("Stop sync")
 				return
 			case <-ticker.C:
 				c.sync()

--- a/internal/component/loki/source/file/file.go
+++ b/internal/component/loki/source/file/file.go
@@ -10,9 +10,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/grafana/tail/watch"
 	"github.com/prometheus/common/model"
-
 	"go.uber.org/atomic"
 
 	"github.com/grafana/alloy/internal/component"
@@ -84,6 +84,7 @@ type Component struct {
 	metrics *metrics
 
 	tasksMut sync.RWMutex
+	args     Arguments
 	tasks    map[positions.Entry]runnerTask
 
 	handler loki.LogsReceiver
@@ -171,8 +172,7 @@ func (c *Component) Run(ctx context.Context) error {
 
 	var wg sync.WaitGroup
 	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for {
 			select {
 			case <-ctx.Done():
@@ -189,11 +189,9 @@ func (c *Component) Run(ctx context.Context) error {
 				c.receiversMut.RUnlock()
 			}
 		}
-	}()
+	})
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for {
 			select {
 			case <-ctx.Done():
@@ -217,7 +215,21 @@ func (c *Component) Run(ctx context.Context) error {
 				}
 			}
 		}
-	}()
+	})
+
+	wg.Go(func() {
+		ticker := time.NewTicker(10 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				c.sync()
+			}
+		}
+	})
 
 	wg.Wait()
 	return nil
@@ -243,65 +255,89 @@ func (c *Component) Update(args component.Arguments) error {
 		c.receiversMut.RUnlock()
 	}
 
-	c.tasks = make(map[positions.Entry]runnerTask)
+	c.args = newArgs
+	c.createdTasks(newArgs)
+	return nil
+}
 
+func (c *Component) sync() {
+	c.tasksMut.Lock()
+	defer c.tasksMut.Unlock()
+	c.createdTasks(c.args)
+}
+
+func (c *Component) createdTasks(args Arguments) {
+	c.tasks = make(map[positions.Entry]runnerTask)
 	// There are cases where we have several targets with the same path + public labels
 	// but the path no longer exist so we cannot create a task for it. So we need to track
 	// what we have checked separately from the task map to prevent performing checks that
 	// will fail multiple times.
 	checked := make(map[positions.Entry]struct{})
 
-	for _, target := range newArgs.Targets {
-		path, _ := target.Get(pathLabel)
-
+	for _, target := range args.Targets {
+		targetPath, _ := target.Get(pathLabel)
 		labels := target.NonReservedLabelSet()
 
-		// Deduplicate targets which have the same public label set.
-		key := positions.Entry{Path: path, Labels: labels.String()}
-		if _, exists := checked[key]; exists {
-			continue
-		}
-
-		checked[key] = struct{}{}
-
-		fi, err := os.Stat(path)
+		// FIXME handle single file
+		matches, err := doublestar.FilepathGlob(targetPath)
 		if err != nil {
-			level.Error(c.opts.Logger).Log("msg", "failed to tail file, stat failed", "error", err, "filename", path)
-			c.metrics.totalBytes.DeleteLabelValues(path)
+			level.Error(c.opts.Logger).Log("msg", "failed expanding paths")
 			continue
 		}
 
-		if fi.IsDir() {
-			level.Info(c.opts.Logger).Log("msg", "failed to tail file", "error", "file is a directory", "filename", path)
-			c.metrics.totalBytes.DeleteLabelValues(path)
-			continue
-		}
+		for _, m := range matches {
+			path, err := filepath.Abs(m)
+			if err != nil {
+				level.Error(c.opts.Logger).Log("msg", "error getting absolute path", "path", m, "err", err)
+			}
 
-		c.metrics.totalBytes.WithLabelValues(path).Set(float64(fi.Size()))
+			// Deduplicate targets which have the same public label set.
+			key := positions.Entry{Path: path, Labels: labels.String()}
+			if _, exists := checked[key]; exists {
+				continue
+			}
 
-		reader, err := c.createReader(readerOptions{
-			path:                path,
-			labels:              labels,
-			encoding:            newArgs.Encoding,
-			decompressionConfig: newArgs.DecompressionConfig,
-			fileWatch:           newArgs.FileWatch,
-			tailFromEnd:         newArgs.TailFromEnd,
-			legacyPositionUsed:  newArgs.LegacyPositionsFile != "",
-		})
-		if err != nil {
-			continue
-		}
+			checked[key] = struct{}{}
 
-		c.tasks[key] = runnerTask{
-			reader: reader,
-			path:   path,
-			labels: labels.String(),
-			// TODO: Could fastFingerPrint work?
-			readerHash: uint64(labels.Merge(model.LabelSet{filenameLabel: model.LabelValue(path)}).Fingerprint()),
+			fi, err := os.Stat(path)
+			if err != nil {
+				level.Error(c.opts.Logger).Log("msg", "failed to tail file, stat failed", "error", err, "filename", path)
+				c.metrics.totalBytes.DeleteLabelValues(path)
+				continue
+			}
+
+			if fi.IsDir() {
+				level.Info(c.opts.Logger).Log("msg", "failed to tail file", "error", "file is a directory", "filename", path)
+				c.metrics.totalBytes.DeleteLabelValues(path)
+				continue
+			}
+
+			c.metrics.totalBytes.WithLabelValues(path).Set(float64(fi.Size()))
+
+			reader, err := c.createReader(readerOptions{
+				path:                path,
+				labels:              labels,
+				encoding:            args.Encoding,
+				decompressionConfig: args.DecompressionConfig,
+				fileWatch:           args.FileWatch,
+				tailFromEnd:         args.TailFromEnd,
+				legacyPositionUsed:  args.LegacyPositionsFile != "",
+			})
+			if err != nil {
+				continue
+			}
+
+			c.tasks[key] = runnerTask{
+				reader: reader,
+				path:   path,
+				labels: labels.String(),
+				// TODO: Could fastFingerPrint work?
+				readerHash: uint64(labels.Merge(model.LabelSet{filenameLabel: model.LabelValue(path)}).Fingerprint()),
+			}
 		}
 	}
 
-	if len(newArgs.Targets) == 0 {
+	if len(args.Targets) == 0 {
 		level.Debug(c.opts.Logger).Log("msg", "no files targets were passed, nothing will be tailed")
 	}
 
@@ -309,8 +345,6 @@ func (c *Component) Update(args component.Arguments) error {
 	case c.updateReaders <- struct{}{}:
 	default:
 	}
-
-	return nil
 }
 
 // DebugInfo returns information about the status of tailed targets.


### PR DESCRIPTION
#### PR Description
Update to use v4 of doublestar for file globbing. Not sure why we did not use it before because promtail also uses v4 

https://github.com/grafana/loki/blob/main/clients/pkg/promtail/targets/file/filetarget.go#L10
https://github.com/grafana/loki/blob/main/clients/pkg/promtail/targets/file/filetarget.go#L249


#### Which issue(s) this PR fixes

Fixes: https://github.com/grafana/alloy/issues/4423

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
