### PR TITLE
mixin: use $__rate_interval in query

### DIFF
--- a/operations/alloy-mixin/dashboards/controller.libsonnet
+++ b/operations/alloy-mixin/dashboards/controller.libsonnet
@@ -280,7 +280,7 @@ local filename = 'alloy-controller.json';
         panel.withQueries([
           panel.newQuery(
             expr= |||
-              increase(alloy_component_evaluation_slow_seconds{%(groupSelector)s}[$__interval])
+              increase(alloy_component_evaluation_slow_seconds{%(groupSelector)s}[$__rate_interval])
             ||| % $._config,
             legendFormat='{{instance}} {{controller_path}} {{component_id}}',
           ),


### PR DESCRIPTION
We should be using `$__rate_interval` in this query to ensure we look at enough data
