### PR TITLE
Fix slicelabels tests with timeouts

### DIFF
--- a/internal/service/labelstore/service_test.go
+++ b/internal/service/labelstore/service_test.go
@@ -16,11 +16,7 @@ import (
 
 func TestAddingMarker(t *testing.T) {
 	mapping := New(log.NewNopLogger(), prometheus.DefaultRegisterer)
-	l := labels.Labels{}
-	l = append(l, labels.Label{
-		Name:  "__name__",
-		Value: "test",
-	})
+	l := labels.FromStrings("__name__", "test")
 	globalID := mapping.GetOrAddGlobalRefID(l)
 	shouldBeSameGlobalID := mapping.GetOrAddGlobalRefID(l)
 	require.True(t, globalID == shouldBeSameGlobalID)
@@ -29,16 +25,8 @@ func TestAddingMarker(t *testing.T) {
 
 func TestAddingDifferentMarkers(t *testing.T) {
 	mapping := New(log.NewNopLogger(), prometheus.DefaultRegisterer)
-	l := labels.Labels{}
-	l = append(l, labels.Label{
-		Name:  "__name__",
-		Value: "test",
-	})
-	l2 := labels.Labels{}
-	l2 = append(l2, labels.Label{
-		Name:  "__name__",
-		Value: "roar",
-	})
+	l := labels.FromStrings("__name__", "test")
+	l2 := labels.FromStrings("__name__", "roar")
 	globalID := mapping.GetOrAddGlobalRefID(l)
 	shouldBeDifferentID := mapping.GetOrAddGlobalRefID(l2)
 	require.True(t, globalID != shouldBeDifferentID)
@@ -47,11 +35,7 @@ func TestAddingDifferentMarkers(t *testing.T) {
 
 func TestAddingLocalMapping(t *testing.T) {
 	mapping := New(log.NewNopLogger(), prometheus.DefaultRegisterer)
-	l := labels.Labels{}
-	l = append(l, labels.Label{
-		Name:  "__name__",
-		Value: "test",
-	})
+	l := labels.FromStrings("__name__", "test")
 
 	globalID := mapping.GetOrAddGlobalRefID(l)
 	shouldBeSameGlobalID := mapping.GetOrAddLink("1", 1, l)
@@ -65,11 +49,7 @@ func TestAddingLocalMapping(t *testing.T) {
 
 func TestAddingLocalMappings(t *testing.T) {
 	mapping := New(log.NewNopLogger(), prometheus.DefaultRegisterer)
-	l := labels.Labels{}
-	l = append(l, labels.Label{
-		Name:  "__name__",
-		Value: "test",
-	})
+	l := labels.FromStrings("__name__", "test")
 
 	globalID := mapping.GetOrAddGlobalRefID(l)
 	shouldBeSameGlobalID := mapping.GetOrAddLink("1", 1, l)
@@ -90,11 +70,7 @@ func TestAddingLocalMappings(t *testing.T) {
 
 func TestAddingLocalMappingsWithoutCreatingGlobalUpfront(t *testing.T) {
 	mapping := New(log.NewNopLogger(), prometheus.DefaultRegisterer)
-	l := labels.Labels{}
-	l = append(l, labels.Label{
-		Name:  "__name__",
-		Value: "test",
-	})
+	l := labels.FromStrings("__name__", "test")
 
 	shouldBeSameGlobalID := mapping.GetOrAddLink("1", 1, l)
 	shouldBeSameGlobalID2 := mapping.GetOrAddLink("2", 1, l)
@@ -113,16 +89,8 @@ func TestAddingLocalMappingsWithoutCreatingGlobalUpfront(t *testing.T) {
 
 func TestStaleness(t *testing.T) {
 	mapping := New(log.NewNopLogger(), prometheus.DefaultRegisterer)
-	l := labels.Labels{}
-	l = append(l, labels.Label{
-		Name:  "__name__",
-		Value: "test",
-	})
-	l2 := labels.Labels{}
-	l2 = append(l2, labels.Label{
-		Name:  "__name__",
-		Value: "test2",
-	})
+	l := labels.FromStrings("__name__", "test")
+	l2 := labels.FromStrings("__name__", "test2")
 
 	global1 := mapping.GetOrAddLink("1", 1, l)
 	_ = mapping.GetOrAddLink("2", 1, l2)
@@ -144,11 +112,7 @@ func TestStaleness(t *testing.T) {
 
 func TestRemovingStaleness(t *testing.T) {
 	mapping := New(log.NewNopLogger(), prometheus.DefaultRegisterer)
-	l := labels.Labels{}
-	l = append(l, labels.Label{
-		Name:  "__name__",
-		Value: "test",
-	})
+	l := labels.FromStrings("__name__", "test")
 
 	global1 := mapping.GetOrAddLink("1", 1, l)
 	mapping.TrackStaleness([]StalenessTracker{


### PR DESCRIPTION
#### PR Description

Resolves build and lint failures when the `slicelabels` build tag is enabled. The `labels.Labels` type, when `slicelabels` is active, is a struct, making `append()` an invalid operation for label creation. Updated `internal/service/labelstore/service_test.go` to use `labels.FromStrings()` for correct label initialization.

#### Which issue(s) this PR fixes

Addresses CI lint failures observed in #4636.

#### Notes to the Reviewer

This fix ensures `internal/service/labelstore/service_test.go` correctly initializes `labels.Labels` when built with the `slicelabels` tag, resolving issues with `go test -tags slicelabels ./...`.

#### PR Checklist

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated

---
<a href="https://cursor.com/background-agent?bcId=bc-9586eb49-7447-4dc2-a4dd-367cf5d7052b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9586eb49-7447-4dc2-a4dd-367cf5d7052b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

