### PR TITLE
chore: move toplevel loki/mimir clients

### DIFF
--- a/internal/component/common/kubernetes/mimir_rule_group_diff.go
+++ b/internal/component/common/kubernetes/mimir_rule_group_diff.go
@@ -5,16 +5,16 @@ import (
 
 	"gopkg.in/yaml.v3" // Used for prometheus rulefmt compatibility instead of gopkg.in/yaml.v2
 
-	"github.com/grafana/alloy/internal/mimir/client"
+	"github.com/grafana/alloy/internal/component/mimir/mimirclient"
 )
 
 type MimirRuleGroupDiff struct {
 	Kind    RuleGroupDiffKind
-	Actual  client.MimirRuleGroup
-	Desired client.MimirRuleGroup
+	Actual  mimirclient.MimirRuleGroup
+	Desired mimirclient.MimirRuleGroup
 }
 
-type MimirRuleGroupsByNamespace map[string][]client.MimirRuleGroup
+type MimirRuleGroupsByNamespace map[string][]mimirclient.MimirRuleGroup
 type MimirRuleGroupDiffsByNamespace map[string][]MimirRuleGroupDiff
 
 func DiffMimirRuleGroupState(desired, actual MimirRuleGroupsByNamespace) MimirRuleGroupDiffsByNamespace {
@@ -48,7 +48,7 @@ func DiffMimirRuleGroupState(desired, actual MimirRuleGroupsByNamespace) MimirRu
 	return diff
 }
 
-func diffMimirRuleGroupNamespaceState(desired []client.MimirRuleGroup, actual []client.MimirRuleGroup) []MimirRuleGroupDiff {
+func diffMimirRuleGroupNamespaceState(desired []mimirclient.MimirRuleGroup, actual []mimirclient.MimirRuleGroup) []MimirRuleGroupDiff {
 	var diff []MimirRuleGroupDiff
 
 	seenGroups := map[string]bool{}
@@ -92,7 +92,7 @@ desiredGroups:
 	return diff
 }
 
-func equalMimirRuleGroups(a, b client.MimirRuleGroup) bool {
+func equalMimirRuleGroups(a, b mimirclient.MimirRuleGroup) bool {
 	aBuf, err := yaml.Marshal(a)
 	if err != nil {
 		return false

--- a/internal/component/common/kubernetes/mimir_rule_group_diff_test.go
+++ b/internal/component/common/kubernetes/mimir_rule_group_diff_test.go
@@ -4,14 +4,15 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/grafana/alloy/internal/mimir/client"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/internal/component/mimir/mimirclient"
 )
 
-func parseMimirRuleGroups(t *testing.T, buf []byte) []client.MimirRuleGroup {
+func parseMimirRuleGroups(t *testing.T, buf []byte) []mimirclient.MimirRuleGroup {
 	t.Helper()
 
-	groups, errs := client.Parse(buf)
+	groups, errs := mimirclient.Parse(buf)
 	require.Empty(t, errs)
 
 	return groups.Groups
@@ -41,24 +42,24 @@ groups:
 
 	type testCase struct {
 		name     string
-		desired  map[string][]client.MimirRuleGroup
-		actual   map[string][]client.MimirRuleGroup
+		desired  map[string][]mimirclient.MimirRuleGroup
+		actual   map[string][]mimirclient.MimirRuleGroup
 		expected map[string][]MimirRuleGroupDiff
 	}
 
 	testCases := []testCase{
 		{
 			name:     "empty sets",
-			desired:  map[string][]client.MimirRuleGroup{},
-			actual:   map[string][]client.MimirRuleGroup{},
+			desired:  map[string][]mimirclient.MimirRuleGroup{},
+			actual:   map[string][]mimirclient.MimirRuleGroup{},
 			expected: map[string][]MimirRuleGroupDiff{},
 		},
 		{
 			name: "add rule group",
-			desired: map[string][]client.MimirRuleGroup{
+			desired: map[string][]mimirclient.MimirRuleGroup{
 				managedNamespace: ruleGroupsA,
 			},
-			actual: map[string][]client.MimirRuleGroup{},
+			actual: map[string][]mimirclient.MimirRuleGroup{},
 			expected: map[string][]MimirRuleGroupDiff{
 				managedNamespace: {
 					{
@@ -70,8 +71,8 @@ groups:
 		},
 		{
 			name:    "remove rule group",
-			desired: map[string][]client.MimirRuleGroup{},
-			actual: map[string][]client.MimirRuleGroup{
+			desired: map[string][]mimirclient.MimirRuleGroup{},
+			actual: map[string][]mimirclient.MimirRuleGroup{
 				managedNamespace: ruleGroupsA,
 			},
 			expected: map[string][]MimirRuleGroupDiff{
@@ -85,10 +86,10 @@ groups:
 		},
 		{
 			name: "update rule group",
-			desired: map[string][]client.MimirRuleGroup{
+			desired: map[string][]mimirclient.MimirRuleGroup{
 				managedNamespace: ruleGroupsA,
 			},
-			actual: map[string][]client.MimirRuleGroup{
+			actual: map[string][]mimirclient.MimirRuleGroup{
 				managedNamespace: ruleGroupsAModified,
 			},
 			expected: map[string][]MimirRuleGroupDiff{
@@ -103,10 +104,10 @@ groups:
 		},
 		{
 			name: "unchanged rule groups",
-			desired: map[string][]client.MimirRuleGroup{
+			desired: map[string][]mimirclient.MimirRuleGroup{
 				managedNamespace: ruleGroupsA,
 			},
-			actual: map[string][]client.MimirRuleGroup{
+			actual: map[string][]mimirclient.MimirRuleGroup{
 				managedNamespace: ruleGroupsA,
 			},
 			expected: map[string][]MimirRuleGroupDiff{},

--- a/internal/component/loki/rules/kubernetes/events_test.go
+++ b/internal/component/loki/rules/kubernetes/events_test.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/grafana/alloy/internal/component/common/kubernetes"
-	lokiClient "github.com/grafana/alloy/internal/loki/client"
+	"github.com/grafana/alloy/internal/component/loki/rules/lokiclient"
 )
 
 type fakeLokiClient struct {
@@ -31,7 +31,7 @@ type fakeLokiClient struct {
 	rules    map[string][]rulefmt.RuleGroup
 }
 
-var _ lokiClient.Interface = &fakeLokiClient{}
+var _ lokiclient.Interface = &fakeLokiClient{}
 
 func newFakeLokiClient() *fakeLokiClient {
 	return &fakeLokiClient{

--- a/internal/component/loki/rules/kubernetes/rules.go
+++ b/internal/component/loki/rules/kubernetes/rules.go
@@ -9,8 +9,8 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/alloy/internal/component"
 	commonK8s "github.com/grafana/alloy/internal/component/common/kubernetes"
+	"github.com/grafana/alloy/internal/component/loki/rules/lokiclient"
 	"github.com/grafana/alloy/internal/featuregate"
-	lokiClient "github.com/grafana/alloy/internal/loki/client"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
 	"github.com/grafana/alloy/internal/util"
 	"github.com/grafana/dskit/backoff"
@@ -48,7 +48,7 @@ type Component struct {
 	opts component.Options
 	args Arguments
 
-	lokiClient   lokiClient.Interface
+	lokiClient   lokiclient.Interface
 	k8sClient    kubernetes.Interface
 	promClient   promVersioned.Interface
 	ruleLister   promListers.PrometheusRuleLister
@@ -263,7 +263,7 @@ func (c *Component) init() error {
 
 	httpClient := c.args.HTTPClientConfig.Convert()
 
-	c.lokiClient, err = lokiClient.New(c.log, lokiClient.Config{
+	c.lokiClient, err = lokiclient.New(c.log, lokiclient.Config{
 		ID:               c.args.TenantID,
 		Address:          c.args.Address,
 		UseLegacyRoutes:  c.args.UseLegacyRoutes,

--- a/internal/component/loki/rules/lokiclient/client.go
+++ b/internal/component/loki/rules/lokiclient/client.go
@@ -1,4 +1,4 @@
-package client
+package lokiclient
 
 import (
 	"bufio"
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	log "github.com/go-kit/log"
-	"github.com/grafana/alloy/internal/loki/client/internal"
 	"github.com/grafana/alloy/internal/useragent"
 	"github.com/grafana/dskit/instrument"
 	"github.com/grafana/dskit/user"
@@ -50,7 +49,7 @@ type LokiClient struct {
 	id string
 
 	endpoint *url.URL
-	client   internal.Requester
+	client   Requester
 	apiPath  string
 	logger   log.Logger
 }
@@ -72,7 +71,7 @@ func New(logger log.Logger, cfg Config, timingHistogram *prometheus.HistogramVec
 	}
 
 	collector := instrument.NewHistogramCollector(timingHistogram)
-	timedClient := internal.NewTimedClient(client, collector)
+	timedClient := NewTimedClient(client, collector)
 
 	return &LokiClient{
 		id:       cfg.ID,
@@ -154,7 +153,7 @@ func buildRequest(op, p, m string, endpoint url.URL, payload []byte) (*http.Requ
 	if err != nil {
 		return nil, err
 	}
-	r = r.WithContext(context.WithValue(r.Context(), internal.OperationNameContextKey, op))
+	r = r.WithContext(context.WithValue(r.Context(), OperationNameContextKey, op))
 
 	return r, nil
 }

--- a/internal/component/loki/rules/lokiclient/client_test.go
+++ b/internal/component/loki/rules/lokiclient/client_test.go
@@ -1,4 +1,4 @@
-package client
+package lokiclient
 
 import (
 	"net/http"

--- a/internal/component/loki/rules/lokiclient/rules.go
+++ b/internal/component/loki/rules/lokiclient/rules.go
@@ -1,4 +1,4 @@
-package client
+package lokiclient
 
 import (
 	"context"

--- a/internal/component/loki/rules/lokiclient/rules_test.go
+++ b/internal/component/loki/rules/lokiclient/rules_test.go
@@ -1,4 +1,4 @@
-package client
+package lokiclient
 
 import (
 	"fmt"

--- a/internal/component/loki/rules/lokiclient/timed_client.go
+++ b/internal/component/loki/rules/lokiclient/timed_client.go
@@ -1,7 +1,6 @@
 // copied from https://github.com/weaveworks/common/blob/master/http/client/client.go
 // because it is not included in dskit
-
-package internal
+package lokiclient
 
 import (
 	"context"

--- a/internal/component/loki/rules/lokiclient/timed_client_test.go
+++ b/internal/component/loki/rules/lokiclient/timed_client_test.go
@@ -1,7 +1,6 @@
-//copied from https://github.com/weaveworks/common/blob/master/http/client/client_test.go
+// copied from https://github.com/weaveworks/common/blob/master/http/client/client_test.go
 // because it is not included in dskit
-
-package internal
+package lokiclient
 
 import (
 	"context"

--- a/internal/component/mimir/mimirclient/client.go
+++ b/internal/component/mimir/mimirclient/client.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/alloy/internal/mimir/client/internal"
 	"github.com/grafana/alloy/internal/useragent"
 	"github.com/grafana/dskit/instrument"
 	"github.com/grafana/dskit/user"
@@ -49,7 +48,7 @@ type MimirClient struct {
 	id string
 
 	endpoint *url.URL
-	client   internal.Requester
+	client   Requester
 	apiPath  string
 	logger   log.Logger
 }
@@ -74,7 +73,7 @@ func New(logger log.Logger, cfg Config, timingHistogram *prometheus.HistogramVec
 	}
 
 	collector := instrument.NewHistogramCollector(timingHistogram)
-	timedClient := internal.NewTimedClient(client, collector)
+	timedClient := NewTimedClient(client, collector)
 
 	return &MimirClient{
 		id:       cfg.ID,
@@ -155,7 +154,7 @@ func buildRequest(op, p, m string, endpoint url.URL, payload []byte) (*http.Requ
 	if err != nil {
 		return nil, err
 	}
-	r = r.WithContext(context.WithValue(r.Context(), internal.OperationNameContextKey, op))
+	r = r.WithContext(context.WithValue(r.Context(), OperationNameContextKey, op))
 
 	return r, nil
 }

--- a/internal/component/mimir/mimirclient/client.go
+++ b/internal/component/mimir/mimirclient/client.go
@@ -1,4 +1,4 @@
-package client
+package mimirclient
 
 import (
 	"bufio"

--- a/internal/component/mimir/mimirclient/client_test.go
+++ b/internal/component/mimir/mimirclient/client_test.go
@@ -1,4 +1,4 @@
-package client
+package mimirclient
 
 import (
 	"io"

--- a/internal/component/mimir/mimirclient/rules.go
+++ b/internal/component/mimir/mimirclient/rules.go
@@ -1,4 +1,4 @@
-package client
+package mimirclient
 
 import (
 	"context"

--- a/internal/component/mimir/mimirclient/rules_test.go
+++ b/internal/component/mimir/mimirclient/rules_test.go
@@ -1,4 +1,4 @@
-package client
+package mimirclient
 
 import (
 	"fmt"

--- a/internal/component/mimir/mimirclient/timed_client.go
+++ b/internal/component/mimir/mimirclient/timed_client.go
@@ -1,7 +1,6 @@
 // copied from https://github.com/weaveworks/common/blob/master/http/client/client.go
 // because it is not included in dskit
-
-package internal
+package mimirclient
 
 import (
 	"context"

--- a/internal/component/mimir/mimirclient/timed_client_test.go
+++ b/internal/component/mimir/mimirclient/timed_client_test.go
@@ -1,7 +1,6 @@
-//copied from https://github.com/weaveworks/common/blob/master/http/client/client_test.go
+// copied from https://github.com/weaveworks/common/blob/master/http/client/client_test.go
 // because it is not included in dskit
-
-package internal
+package mimirclient
 
 import (
 	"context"

--- a/internal/component/mimir/mimirclient/types.go
+++ b/internal/component/mimir/mimirclient/types.go
@@ -1,4 +1,4 @@
-package client
+package mimirclient
 
 import (
 	"bytes"

--- a/internal/component/mimir/mimirclient/types_test.go
+++ b/internal/component/mimir/mimirclient/types_test.go
@@ -1,4 +1,4 @@
-package client
+package mimirclient
 
 import (
 	"testing"

--- a/internal/component/mimir/rules/kubernetes/events_test.go
+++ b/internal/component/mimir/rules/kubernetes/events_test.go
@@ -23,23 +23,23 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/grafana/alloy/internal/component/common/kubernetes"
-	"github.com/grafana/alloy/internal/mimir/client"
+	"github.com/grafana/alloy/internal/component/mimir/mimirclient"
 )
 
 type fakeMimirClient struct {
 	rulesMut sync.RWMutex
-	rules    map[string][]client.MimirRuleGroup
+	rules    map[string][]mimirclient.MimirRuleGroup
 }
 
-var _ client.Interface = &fakeMimirClient{}
+var _ mimirclient.Interface = &fakeMimirClient{}
 
 func newFakeMimirClient() *fakeMimirClient {
 	return &fakeMimirClient{
-		rules: make(map[string][]client.MimirRuleGroup),
+		rules: make(map[string][]mimirclient.MimirRuleGroup),
 	}
 }
 
-func (m *fakeMimirClient) CreateRuleGroup(_ context.Context, namespace string, rule client.MimirRuleGroup) error {
+func (m *fakeMimirClient) CreateRuleGroup(_ context.Context, namespace string, rule mimirclient.MimirRuleGroup) error {
 	m.rulesMut.Lock()
 	defer m.rulesMut.Unlock()
 	m.deleteLocked(namespace, rule.Name)
@@ -73,10 +73,10 @@ func (m *fakeMimirClient) deleteLocked(namespace, group string) {
 	}
 }
 
-func (m *fakeMimirClient) ListRules(_ context.Context, namespace string) (map[string][]client.MimirRuleGroup, error) {
+func (m *fakeMimirClient) ListRules(_ context.Context, namespace string) (map[string][]mimirclient.MimirRuleGroup, error) {
 	m.rulesMut.RLock()
 	defer m.rulesMut.RUnlock()
-	output := make(map[string][]client.MimirRuleGroup)
+	output := make(map[string][]mimirclient.MimirRuleGroup)
 	for ns, v := range m.rules {
 		if namespace != "" && namespace != ns {
 			continue
@@ -251,7 +251,7 @@ func TestAdditionalLabels(t *testing.T) {
 	eventHandler.OnAdd(rule, false)
 
 	// Wait for the rule to be added to mimir
-	rules := map[string][]client.MimirRuleGroup{}
+	rules := map[string][]mimirclient.MimirRuleGroup{}
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		var err error
 		rules, err = processor.mimirClient.ListRules(ctx, "")
@@ -366,7 +366,7 @@ func TestExtraQueryMatchers(t *testing.T) {
 	eventHandler.OnAdd(rule, false)
 
 	// Wait for the rule to be added to mimir
-	rules := map[string][]client.MimirRuleGroup{}
+	rules := map[string][]mimirclient.MimirRuleGroup{}
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		var err error
 		rules, err = processor.mimirClient.ListRules(ctx, "")
@@ -464,7 +464,7 @@ func TestSourceTenants(t *testing.T) {
 	eventHandler.OnAdd(rule, false)
 
 	// Wait for the rule to be added to mimir
-	rules := map[string][]client.MimirRuleGroup{}
+	rules := map[string][]mimirclient.MimirRuleGroup{}
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		var err error
 		rules, err = processor.mimirClient.ListRules(ctx, "")

--- a/internal/component/mimir/rules/kubernetes/rules.go
+++ b/internal/component/mimir/rules/kubernetes/rules.go
@@ -28,8 +28,8 @@ import (
 
 	"github.com/grafana/alloy/internal/component"
 	commonK8s "github.com/grafana/alloy/internal/component/common/kubernetes"
+	"github.com/grafana/alloy/internal/component/mimir/mimirclient"
 	"github.com/grafana/alloy/internal/featuregate"
-	mimirClient "github.com/grafana/alloy/internal/mimir/client"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
 	"github.com/grafana/alloy/internal/service/cluster"
 )
@@ -60,7 +60,7 @@ type Component struct {
 	opts component.Options
 	args Arguments
 
-	mimirClient       mimirClient.Interface
+	mimirClient       mimirclient.Interface
 	k8sClient         kubernetes.Interface
 	promClient        promVersioned.Interface
 	namespaceSelector labels.Selector
@@ -370,7 +370,7 @@ func (c *Component) init() error {
 
 	httpClient := c.args.HTTPClientConfig.Convert()
 
-	c.mimirClient, err = mimirClient.New(c.log, mimirClient.Config{
+	c.mimirClient, err = mimirclient.New(c.log, mimirclient.Config{
 		ID:                   c.args.TenantID,
 		Address:              c.args.Address,
 		UseLegacyRoutes:      c.args.UseLegacyRoutes,


### PR DESCRIPTION
These packages felt really out of place so I checked where it's used.

They are only used by one component each (and the mimir is helper a common package). So I moved them further down the tree