### PR TITLE
feat: implement otel-ebpf-profiler uprobe profiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ Main (unreleased)
 
 - Add `prometheus.static.exporter` that exposes metrics specified in a text file in Prometheus exposition format. (@kalleep)
 
+- Add `u_probe_links` & `load_probe` configuration fields to alloy pyroscope.ebpf to extend configuration of the opentelemetry-ebpf-profiler to allow uprobe profiling and dynamic probing. (@luweglarz)
+
 ### Enhancements
 
 - Add support of `tls` in components `loki.source.(awsfirehose|gcplog|heroku|api)` and `prometheus.receive_http` and `pyroscope.receive_http`. (@fgouteroux)

--- a/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
@@ -73,6 +73,8 @@ You can use the following arguments with `pyroscope.ebpf`:
 | `same_file_cache_size`    | `int`                    | Deprecated (no-op), previously controlled the size of the elf file -> symbols table LRU cache.                       | `8`      | no       |
 | `sample_rate`             | `int`                    | How many times per second to collect profile samples.                                                                | `19`     | no       |
 | `symbols_map_size`        | `int`                    | Deprecated (no-op), previously controlled the size of eBPF symbols map .                                             | `16384`  | no       |
+| `load_probe`              | `bool`                   | Enable loading uprobe dynamically during runtime.                                                                    | `false`  | no       |
+| `u_probe_links`           | `list(string)`           | List of user-space symbols to collect stack-trace from, e.g. `["/usr/lib/libc.so.6:malloc"]`.                        |          | no       |
 | `v8_enabled`              | `bool`                   | A flag to enable/disable V8 profiling.                                                                               | `true`   | no       |
 | `off_cpu_threshold`       | `int`                    | A flag to adjust the off-cpu profiling threshold.                                                                    | `0`      | no       | 
 

--- a/internal/component/pyroscope/ebpf/args.go
+++ b/internal/component/pyroscope/ebpf/args.go
@@ -22,6 +22,8 @@ type Arguments struct {
 	GoEnabled           bool                   `alloy:"go_enabled,attr,optional"`
 	Demangle            string                 `alloy:"demangle,attr,optional"`
 	OffCPUThreshold     float64                `alloy:"off_cpu_threshold,attr,optional"` //TODO: Document this as a float?
+	LoadProbe           bool                   `alloy:"load_probe,attr,optional"`
+	UProbeLinks         []string               `alloy:"u_probe_links,attr,optional"`
 	DeprecatedArguments DeprecatedArguments    `alloy:",squash"`
 
 	// undocumented

--- a/internal/component/pyroscope/ebpf/ebpf_linux.go
+++ b/internal/component/pyroscope/ebpf/ebpf_linux.go
@@ -235,6 +235,8 @@ func NewDefaultArguments() Arguments {
 		DotNetEnabled:   true,
 		OffCPUThreshold: 0,
 		GoEnabled:       true,
+		LoadProbe:       false,
+		UProbeLinks:     []string{},
 
 		// undocumented
 		PyroscopeDynamicProfilingPolicy: true,
@@ -263,6 +265,8 @@ func (args *Arguments) Convert() (*controller.Config, error) {
 	cfg.SamplesPerSecond = args.SampleRate
 	cfg.Tracers = args.tracers()
 	cfg.OffCPUThreshold = args.OffCPUThreshold
+	cfg.LoadProbe = args.LoadProbe
+	cfg.UProbeLinks = args.UProbeLinks
 	return cfg, nil
 }
 

--- a/internal/component/pyroscope/ebpf/reporter/builder.go
+++ b/internal/component/pyroscope/ebpf/reporter/builder.go
@@ -78,6 +78,10 @@ func (b *ProfileBuilders) BuilderForSample(
 	case support.TraceOriginOffCPU:
 		sampleType = []*profile.ValueType{{Type: "offcpu", Unit: "nanoseconds"}}
 		period = 1
+	case support.TraceOriginUProbe:
+		sampleType = []*profile.ValueType{{Type: "uprobe", Unit: "count"}}
+		periodType = &profile.ValueType{Type: "uprobe", Unit: "count"}
+		period = 1
 	default:
 		panic(fmt.Sprintf("unknown sample type %v", sampleType))
 	}

--- a/internal/component/pyroscope/ebpf/reporter/pprof.go
+++ b/internal/component/pyroscope/ebpf/reporter/pprof.go
@@ -211,6 +211,8 @@ func (p *PPROFReporter) createProfile(origin libpf.Origin, events map[samples.Tr
 				sum += t
 			}
 			b.AddValue(sum, s)
+		case support.TraceOriginUProbe:
+			b.AddValue(int64(len(traceInfo.Timestamps)), s)
 		}
 
 		for i := range traceInfo.Frames {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Naive implementation of the [opentelemetry-ebpf-rpfoler](https://github.com/open-telemetry/opentelemetry-ebpf-profiler)  uprobe profiling.

Still a WIP as I am not able to make this work on a local setup yet, I am running it with the same uprobe link for opentelemetry-ebpf-profiler in the same environnement:
-Alloy with this PR never report any TraceOriginUProbe in reportProfile PPROF reporter, I cannot find the reason yet.
-The [opentelemetry-ebpf-rpfoler](https://github.com/open-telemetry/opentelemetry-ebpf-profiler) reporter does get TraceOriginUProbe with the same setups and uprobes.
#### Which issue(s) this PR fixes
It fixes https://github.com/grafana/alloy/issues/4660
<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer
Let me know if I am missing a piece in my implementation to make it work
#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [x] Config converters updated
