### PR TITLE
prometheus.exporter.unix: Expose ARP collector config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ Main (unreleased)
 
 - Improve debug info output from exported receivers (loki, prometheus and pyroscope). (@kalleep)
 
+- `prometheus.exporter.unix`: Add an `arp` config block to configure the ARP collector. (@ptodev)
+
 ### Bugfixes
 
 - Stop `loki.source.kubernetes` discarding log lines with duplicate timestamps. (@ciaranj)

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.unix.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.unix.md
@@ -58,6 +58,7 @@ You can use the following blocks with `prometheus.exporter.unix`:
 
 | Name                         | Description                             | Required |
 | ---------------------------- | --------------------------------------- | -------- |
+| [`arp`][arp]                 | Configures the `arp` collector.         | no       |
 | [`bcache`][bcache]           | Configures the `bcache` collector.      | no       |
 | [`cpu`][cpu]                 | Configures the `cpu` collector.         | no       |
 | [`disk`][disk]               | Configures the `diskstats` collector.   | no       |
@@ -79,6 +80,7 @@ You can use the following blocks with `prometheus.exporter.unix`:
 | [`textfile`][textfile]       | Configures the `textfile` collector.    | no       |
 | [`vmstat`][vmstat]           | Configures the `vmstat` collector.      | no       |
 
+[arp]: #arp
 [bcache]: #bcache
 [cpu]: #cpu
 [disk]: #disk
@@ -99,6 +101,16 @@ You can use the following blocks with `prometheus.exporter.unix`:
 [tapestats]: #tapestats
 [textfile]: #textfile
 [vmstat]: #vmstat
+
+### `arp`
+
+| Name             | Type      | Description                                                                                             | Default | Required |
+| ---------------- | --------- | --------------------------------------------------------------------------------------------------------| ------- | -------- |
+| `device_exclude` | `string`  | Regular expression of devices to exclude for `arp` collector. Mutually exclusive with `device_include`. |         | no       |
+| `device_include` | `string`  | Regular expression of devices to include for `arp` collector. Mutually exclusive with `device_exclude`. |         | no       |
+| `netlink`        | `boolean` | Use netlink to gather ARP stats instead of `/proc/net/arp`.                                             | `false` | no       |
+
+It is recommended to set `netlink` to `true` on systems with InfiniBand or other non-Ethernet devices.
 
 ### `bcache`
 
@@ -323,7 +335,7 @@ You can choose to enable a subset of collectors to limit the amount of metrics e
 
 | Name               | Description                                                                                                                                                                     | OS                                                                 | Enabled by default |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------ |
-| `arp`              | Exposes ARP statistics from `/proc/net/arp`.                                                                                                                                    | Linux                                                              | yes                |
+| `arp`              | Exposes ARP statistics from `/proc/net/arp` or via netlink.                                                     | Linux                                                              | yes                |
 | `bcache`           | Exposes bcache statistics from `/sys/fs/bcache`.                                                                                                                                | Linux                                                              | yes                |
 | `bonding`          | Exposes the number of configured and active slaves of Linux bonding interfaces.                                                                                                 | Linux                                                              | yes                |
 | `boottime`         | Exposes system boot time derived from the `kern.boottime sysctl`.                                                                                                               | Darwin, Dragonfly, FreeBSD, NetBSD, OpenBSD, Oracle Solaris        | yes                |

--- a/internal/component/prometheus/exporter/unix/config.go
+++ b/internal/component/prometheus/exporter/unix/config.go
@@ -80,6 +80,7 @@ type Arguments struct {
 	SetCollectors flagext.StringSlice `alloy:"set_collectors,attr,optional"`
 
 	// Collector-specific config options
+	Arp         ArpConfig         `alloy:"arp,block,optional"`
 	BCache      BCacheConfig      `alloy:"bcache,block,optional"`
 	CPU         CPUConfig         `alloy:"cpu,block,optional"`
 	Disk        DiskStatsConfig   `alloy:"disk,block,optional"`
@@ -113,6 +114,9 @@ func (a *Arguments) Convert() *node_integration.Config {
 		EnableCollectors:                 a.EnableCollectors,
 		DisableCollectors:                a.DisableCollectors,
 		SetCollectors:                    a.SetCollectors,
+		ArpDeviceExclude:                 a.Arp.DeviceExclude,
+		ArpDeviceInclude:                 a.Arp.DeviceInclude,
+		ArpNetlink:                       a.Arp.Netlink,
 		BcachePriorityStats:              a.BCache.PriorityStats,
 		CPUBugsInclude:                   a.CPU.BugsInclude,
 		CPUEnableCPUGuest:                a.CPU.EnableCPUGuest,
@@ -255,6 +259,13 @@ type FilesystemConfig struct {
 // IPVSConfig contains config specific to the ipvs collector.
 type IPVSConfig struct {
 	BackendLabels []string `alloy:"backend_labels,attr,optional"`
+}
+
+// ArpConfig contains config specific to the arp collector.
+type ArpConfig struct {
+	DeviceExclude string `alloy:"device_exclude,attr,optional"`
+	DeviceInclude string `alloy:"device_include,attr,optional"`
+	Netlink       bool   `alloy:"netlink,attr,optional"`
 }
 
 // BCacheConfig contains config specific to the bcache collector.

--- a/internal/static/integrations/node_exporter/config.go
+++ b/internal/static/integrations/node_exporter/config.go
@@ -100,6 +100,9 @@ type Config struct {
 	SetCollectors flagext.StringSlice `yaml:"set_collectors,omitempty"`
 
 	// Collector-specific config options
+	ArpDeviceExclude                 string              `yaml:"arp_device_exclude,omitempty"`
+	ArpDeviceInclude                 string              `yaml:"arp_device_include,omitempty"`
+	ArpNetlink                       bool                `yaml:"arp_netlink,omitempty"`
 	BcachePriorityStats              bool                `yaml:"enable_bcache_priority_stats,omitempty"`
 	CPUBugsInclude                   string              `yaml:"cpu_bugs_include,omitempty"`
 	CPUEnableCPUGuest                bool                `yaml:"enable_cpu_guest_seconds_metric,omitempty"`
@@ -489,9 +492,9 @@ func (c *Config) mapConfigToNodeConfig() *collector.NodeCollectorConfig {
 	}
 
 	cfg.Arp = collector.ArpConfig{
-		DeviceInclude: &blankString,
-		DeviceExclude: &blankString,
-		Netlink:       &blankBool,
+		DeviceInclude: &c.ArpDeviceInclude,
+		DeviceExclude: &c.ArpDeviceExclude,
+		Netlink:       &c.ArpNetlink,
 	}
 
 	cfg.Stat = collector.StatConfig{


### PR DESCRIPTION
#### PR Description

This is useful for customers who use non-Ethernet networking devices like Infiniband.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
