### PR TITLE
Add `cloud_provider` block to `database_observability.postgres`

### DIFF
--- a/docs/sources/reference/components/database_observability/database_observability.postgres.md
+++ b/docs/sources/reference/components/database_observability/database_observability.postgres.md
@@ -48,15 +48,38 @@ You can use the following blocks with `database_observability.postgres`:
 
 | Block                              | Description                                       | Required |
 |------------------------------------|---------------------------------------------------|----------|
+| [`cloud_provider`][cloud_provider]   | Provide Cloud Provider information.               | no       |
+| `cloud_provider` > [`aws`][aws]      | Provide AWS database host information.            | no       |
 | [`query_details`][query_details]   | Configure the queries collector.                  | no       |
 | [`query_samples`][query_samples]   | Configure the query samples collector.            | no       |
 | [`schema_details`][schema_details] | Configure the schema and table details collector. | no       |
 | [`explain_plans`][explain_plans]   | Configure the explain plans collector.            | no       |
 
+The > symbol indicates deeper levels of nesting.
+For example, `cloud_provider` > `aws` refers to a `aws` block defined inside an `cloud_provider` block.
+
+[cloud_provider]: #cloud_provider
+[aws]: #aws
 [query_details]: #query_details
 [query_samples]: #query_samples
 [schema_details]: #schema_details
 [explain_plans]: #explain_plans
+
+### `cloud_provider`
+
+The `cloud_provider` block has no attributes.
+It contains zero or more [`aws`][aws] blocks.
+You use the `cloud_provider` block to provide information related to the cloud provider that hosts the database under observation.
+This information is appended as labels to the collected metrics.
+The labels make it easier for you to filter and group your metrics.
+
+### `aws`
+
+The `aws` block supplies the [ARN](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html) identifier for the database being monitored.
+
+| Name  | Type     | Description                                             | Default | Required |
+|-------|----------|---------------------------------------------------------|---------|----------|
+| `arn` | `string` | The ARN associated with the database under observation. |         | yes      |
 
 ### `query_details`
 
@@ -96,6 +119,12 @@ database_observability.postgres "orders_db" {
   data_source_name = "postgres://user:pass@localhost:5432/mydb"
   forward_to = [loki.write.logs_service.receiver]
   enable_collectors = ["query_details", "query_samples", "schema_details"]
+
+  cloud_provider {
+    aws {
+      arn = "your-rds-db-arn"
+    }
+  }
 }
 
 prometheus.scrape "orders_db" {

--- a/internal/component/database_observability/mysql/collector/connection_info.go
+++ b/internal/component/database_observability/mysql/collector/connection_info.go
@@ -7,10 +7,9 @@ import (
 	"strings"
 
 	"github.com/go-sql-driver/mysql"
+	"github.com/grafana/alloy/internal/component/database_observability"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/atomic"
-
-	"github.com/grafana/alloy/internal/component/database_observability"
 )
 
 const ConnectionInfoName = "connection_info"

--- a/internal/component/database_observability/postgres/collector/connection_info_test.go
+++ b/internal/component/database_observability/postgres/collector/connection_info_test.go
@@ -5,10 +5,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+
+	"github.com/grafana/alloy/internal/component/database_observability"
 )
 
 func TestConnectionInfo(t *testing.T) {
@@ -17,32 +20,48 @@ func TestConnectionInfo(t *testing.T) {
 	const baseExpectedMetrics = `
 	# HELP database_observability_connection_info Information about the connection
 	# TYPE database_observability_connection_info gauge
-	database_observability_connection_info{db_instance_identifier="%s",engine="%s",engine_version="%s",provider_name="%s",provider_region="%s"} 1
+	database_observability_connection_info{db_instance_identifier="%s",engine="%s",engine_version="%s",provider_account="%s",provider_name="%s",provider_region="%s"} 1
 `
 
 	testCases := []struct {
 		name            string
 		dsn             string
 		engineVersion   string
+		cloudProvider   *database_observability.CloudProvider
 		expectedMetrics string
 	}{
 		{
 			name:            "generic dsn",
 			dsn:             "postgres://user:pass@localhost:5432/mydb",
 			engineVersion:   "15.4",
-			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "unknown", "postgres", "15.4", "unknown", "unknown"),
+			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "unknown", "postgres", "15.4", "unknown", "unknown", "unknown"),
 		},
 		{
 			name:            "AWS/RDS dsn",
 			dsn:             "postgres://user:pass@products-db.abc123xyz.us-east-1.rds.amazonaws.com:5432/mydb",
 			engineVersion:   "15.4",
-			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "products-db", "postgres", "15.4", "aws", "us-east-1"),
+			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "products-db", "postgres", "15.4", "unknown", "aws", "us-east-1"),
+		},
+		{
+			name:          "AWS/RDS dsn with cloud provider info supplied",
+			dsn:           "postgres://user:pass@products-db.abc123xyz.us-east-1.rds.amazonaws.com:5432/mydb",
+			engineVersion: "15.4",
+			cloudProvider: &database_observability.CloudProvider{
+				AWS: &database_observability.AWSCloudProviderInfo{
+					ARN: arn.ARN{
+						Region:    "us-east-1",
+						AccountID: "some-account-123",
+						Resource:  "db:products-db",
+					},
+				},
+			},
+			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "products-db", "postgres", "15.4", "some-account-123", "aws", "us-east-1"),
 		},
 		{
 			name:            "Azure flexibleservers dsn",
 			dsn:             "postgres://user:pass@products-db.postgres.database.azure.com:5432/mydb",
 			engineVersion:   "15.4",
-			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "products-db", "postgres", "15.4", "azure", "unknown"),
+			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "products-db", "postgres", "15.4", "unknown", "azure", "unknown"),
 		},
 	}
 
@@ -53,6 +72,7 @@ func TestConnectionInfo(t *testing.T) {
 			DSN:           tc.dsn,
 			Registry:      reg,
 			EngineVersion: tc.engineVersion,
+			CloudProvider: tc.cloudProvider,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)


### PR DESCRIPTION
#### PR Description
Copy over functionality from `database_observability.mysql` to populate cloud provider info in `connection_info` collector for Postgres.

#### Which issue(s) this PR fixes
n.a.

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
