### PR TITLE
database_observability: add database discovery to Postgres schema details collector

### DIFF
--- a/internal/component/database_observability/README.md
+++ b/internal/component/database_observability/README.md
@@ -449,7 +449,7 @@ GRANT pg_read_all_data TO "db-o11y";
 
 2. Add the following configuration block to Alloy.
 - Replace `<your_DB_name>`
-- Create a [`local.file`](https://grafana.com/docs/alloy/latest/reference/components/local/local.file/) with your DB secrets. The content of the file should be the Data Source Name string, for example `"postgresql://user:password@(hostname:port)/dbname?sslmode=require"`.
+- Create a [`local.file`](https://grafana.com/docs/alloy/latest/reference/components/local/local.file/) with your DB secrets. The content of the file should be the Data Source Name string, for example `"postgresql://user:password@(hostname:port)/postgres?sslmode=require"`.
 
 3. Copy this block for each DB you'd like to monitor.
 

--- a/internal/component/database_observability/README.md
+++ b/internal/component/database_observability/README.md
@@ -447,7 +447,7 @@ GRANT pg_read_all_data TO "db-o11y";
 
 1. You need to run the latest Alloy version from the `main` branch. The latest tags are available here on [Docker Hub](https://hub.docker.com/r/grafana/alloy-dev/tags) (for example, `grafana/alloy-dev:v1.10.0-devel-630bcbb` or more recent) . Additionally, the `--stability.level=experimental` CLI flag is necessary for running the `database_observability` component.
 
-2. Add the following configuration block to Alloy for each Postgres DB you'd like to monitor.
+2. Add the following configuration block to Alloy.
 - Replace `<your_DB_name>`
 - Create a [`local.file`](https://grafana.com/docs/alloy/latest/reference/components/local/local.file/) with your DB secrets. The content of the file should be the Data Source Name string, for example `"postgresql://user:password@(hostname:port)/dbname?sslmode=require"`.
 

--- a/internal/component/database_observability/postgres/collector/dsn.go
+++ b/internal/component/database_observability/postgres/collector/dsn.go
@@ -1,0 +1,30 @@
+package collector
+
+import (
+	"database/sql"
+	"errors"
+)
+
+type databaseConnectionFactory func(dsn string) (*sql.DB, error)
+
+var defaultDbConnectionFactory = func(dsn string) (*sql.DB, error) {
+	return sql.Open("postgres", dsn)
+}
+
+// replaceDatabaseNameInDSN safely replaces the database name in a PostgreSQL DSN
+// using regex to ensure only the database name portion is replaced, not other occurrences
+func replaceDatabaseNameInDSN(dsn, newDatabaseName string) (string, error) {
+	// Use the same regex pattern as in NewExplainPlan to find the database name
+	matches := dsnParseRegex.FindStringSubmatch(dsn)
+
+	if len(matches) < 4 {
+		return "", errors.New("failed to parse DSN for database name replacement")
+	}
+
+	// Reconstruct the DSN with the new database name
+	// matches[1] = prefix (protocol://user:pass@host:port/)
+	// matches[2] = original database name (captured group)
+	// matches[3] = suffix (query parameters)
+	newDSN := matches[1] + newDatabaseName + matches[3]
+	return newDSN, nil
+}

--- a/internal/component/database_observability/postgres/collector/dsn.go
+++ b/internal/component/database_observability/postgres/collector/dsn.go
@@ -3,10 +3,12 @@ package collector
 import (
 	"database/sql"
 	"errors"
+	"regexp"
 )
 
 type databaseConnectionFactory func(dsn string) (*sql.DB, error)
 
+var dsnParseRegex = regexp.MustCompile(`^(\w+:\/\/.+\/)(?<dbname>[\w\-_\$]+)(\??.*$)`)
 var defaultDbConnectionFactory = func(dsn string) (*sql.DB, error) {
 	return sql.Open("postgres", dsn)
 }

--- a/internal/component/database_observability/postgres/collector/dsn_test.go
+++ b/internal/component/database_observability/postgres/collector/dsn_test.go
@@ -1,0 +1,80 @@
+package collector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplaceDatabaseNameInDSN(t *testing.T) {
+	tests := []struct {
+		name        string
+		dsn         string
+		newDBName   string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:      "basic postgres DSN",
+			dsn:       "postgres://user:pass@localhost:5432/mydb",
+			newDBName: "newdb",
+			expected:  "postgres://user:pass@localhost:5432/newdb",
+		},
+		{
+			name:      "postgres DSN with query parameters",
+			dsn:       "postgres://user:pass@localhost:5432/mydb?sslmode=disable",
+			newDBName: "newdb",
+			expected:  "postgres://user:pass@localhost:5432/newdb?sslmode=disable",
+		},
+		{
+			name:      "postgres DSN with multiple query parameters",
+			dsn:       "postgres://user:pass@localhost:5432/mydb?sslmode=disable&connect_timeout=10",
+			newDBName: "newdb",
+			expected:  "postgres://user:pass@localhost:5432/newdb?sslmode=disable&connect_timeout=10",
+		},
+		{
+			name:      "problematic case - database name is 'postgres'",
+			dsn:       "postgres://postgres:password@localhost:5432/postgres",
+			newDBName: "testdb",
+			expected:  "postgres://postgres:password@localhost:5432/testdb",
+		},
+		{
+			name:      "database name appears in password",
+			dsn:       "postgres://user:mydb123@localhost:5432/mydb",
+			newDBName: "newdb",
+			expected:  "postgres://user:mydb123@localhost:5432/newdb",
+		},
+		{
+			name:      "database name with special characters",
+			dsn:       "postgres://user:pass@localhost:5432/my-db_test$1",
+			newDBName: "new_db",
+			expected:  "postgres://user:pass@localhost:5432/new_db",
+		},
+		{
+			name:        "invalid DSN format",
+			dsn:         "invalid-dsn-format",
+			newDBName:   "newdb",
+			expectError: true,
+		},
+		{
+			name:        "DSN without database name",
+			dsn:         "postgres://user:pass@localhost:5432/",
+			newDBName:   "newdb",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := replaceDatabaseNameInDSN(tt.dsn, tt.newDBName)
+
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/component/database_observability/postgres/collector/explain_plan.go
+++ b/internal/component/database_observability/postgres/collector/explain_plan.go
@@ -15,11 +15,12 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/go-kit/log"
+	"go.uber.org/atomic"
+
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/component/database_observability"
 	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
-	"go.uber.org/atomic"
 )
 
 const (
@@ -46,7 +47,6 @@ var unrecoverablePostgresSQLErrors = []string{
 	"pq: pg_hba.conf rejects connection for host",
 }
 
-var dsnParseRegex = regexp.MustCompile(`^(\w+:\/\/.+\/)(?<dbname>[\w\-_\$]+)(\??.*$)`)
 var paramCountRegex = regexp.MustCompile(`\$\d+`)
 
 type PgSQLExplainplan struct {

--- a/internal/component/database_observability/postgres/collector/explain_plan.go
+++ b/internal/component/database_observability/postgres/collector/explain_plan.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math"
 	"regexp"
@@ -49,10 +48,6 @@ var unrecoverablePostgresSQLErrors = []string{
 
 var dsnParseRegex = regexp.MustCompile(`^(\w+:\/\/.+\/)(?<dbname>[\w\-_\$]+)(\??.*$)`)
 var paramCountRegex = regexp.MustCompile(`\$\d+`)
-
-var defaultDbConnectionFactory = func(dsn string) (*sql.DB, error) {
-	return sql.Open("postgres", dsn)
-}
 
 type PgSQLExplainplan struct {
 	Plan PlanNode `json:"Plan"`
@@ -218,8 +213,6 @@ func newQueryInfo(datname, queryId, queryText string, calls int64, callsReset ti
 		callsReset: callsReset,
 	}
 }
-
-type databaseConnectionFactory func(dsn string) (*sql.DB, error)
 
 type ExplainPlanArguments struct {
 	DB              *sql.DB
@@ -487,26 +480,8 @@ func (c *ExplainPlan) fetchExplainPlans(ctx context.Context) error {
 	return nil
 }
 
-// replaceDatabaseNameInDSN safely replaces the database name in a PostgreSQL DSN
-// using regex to ensure only the database name portion is replaced, not other occurrences
-func (c *ExplainPlan) replaceDatabaseNameInDSN(dsn, newDatabaseName string) (string, error) {
-	// Use the same regex pattern as in NewExplainPlan to find the database name
-	matches := dsnParseRegex.FindStringSubmatch(dsn)
-
-	if len(matches) < 4 {
-		return "", errors.New("failed to parse DSN for database name replacement")
-	}
-
-	// Reconstruct the DSN with the new database name
-	// matches[1] = prefix (protocol://user:pass@host:port/)
-	// matches[2] = original database name (captured group)
-	// matches[3] = suffix (query parameters)
-	newDSN := matches[1] + newDatabaseName + matches[3]
-	return newDSN, nil
-}
-
 func (c *ExplainPlan) fetchExplainPlanJSON(ctx context.Context, qi queryInfo) ([]byte, error) {
-	querySpecificDSN, err := c.replaceDatabaseNameInDSN(c.dbDSN, qi.datname)
+	querySpecificDSN, err := replaceDatabaseNameInDSN(c.dbDSN, qi.datname)
 	if err != nil {
 		return nil, fmt.Errorf("failed to replace database name in DSN: %w", err)
 	}

--- a/internal/component/database_observability/postgres/collector/explain_plan_test.go
+++ b/internal/component/database_observability/postgres/collector/explain_plan_test.go
@@ -10,13 +10,14 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/blang/semver/v4"
 	"github.com/go-kit/log"
-	"github.com/grafana/alloy/internal/component/common/loki/client/fake"
-	"github.com/grafana/alloy/internal/component/database_observability"
-	"github.com/grafana/alloy/internal/util/syncbuffer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 	"golang.org/x/tools/txtar"
+
+	"github.com/grafana/alloy/internal/component/common/loki/client/fake"
+	"github.com/grafana/alloy/internal/component/database_observability"
+	"github.com/grafana/alloy/internal/util/syncbuffer"
 )
 
 func stringPtr(s string) *string {
@@ -2224,82 +2225,6 @@ func TestExplainPlanOutput(t *testing.T) {
 			output.Metadata.GeneratedAt = currentTime
 			require.Equal(t, tt.result.Metadata, output.Metadata)
 			validatePlan(t, tt.result.Plan, output.Plan)
-		})
-	}
-}
-
-func TestReplaceDatabaseNameInDSN(t *testing.T) {
-	tests := []struct {
-		name        string
-		dsn         string
-		newDBName   string
-		expected    string
-		expectError bool
-	}{
-		{
-			name:      "basic postgres DSN",
-			dsn:       "postgres://user:pass@localhost:5432/mydb",
-			newDBName: "newdb",
-			expected:  "postgres://user:pass@localhost:5432/newdb",
-		},
-		{
-			name:      "postgres DSN with query parameters",
-			dsn:       "postgres://user:pass@localhost:5432/mydb?sslmode=disable",
-			newDBName: "newdb",
-			expected:  "postgres://user:pass@localhost:5432/newdb?sslmode=disable",
-		},
-		{
-			name:      "postgres DSN with multiple query parameters",
-			dsn:       "postgres://user:pass@localhost:5432/mydb?sslmode=disable&connect_timeout=10",
-			newDBName: "newdb",
-			expected:  "postgres://user:pass@localhost:5432/newdb?sslmode=disable&connect_timeout=10",
-		},
-		{
-			name:      "problematic case - database name is 'postgres'",
-			dsn:       "postgres://postgres:password@localhost:5432/postgres",
-			newDBName: "testdb",
-			expected:  "postgres://postgres:password@localhost:5432/testdb",
-		},
-		{
-			name:      "database name appears in password",
-			dsn:       "postgres://user:mydb123@localhost:5432/mydb",
-			newDBName: "newdb",
-			expected:  "postgres://user:mydb123@localhost:5432/newdb",
-		},
-		{
-			name:      "database name with special characters",
-			dsn:       "postgres://user:pass@localhost:5432/my-db_test$1",
-			newDBName: "new_db",
-			expected:  "postgres://user:pass@localhost:5432/new_db",
-		},
-		{
-			name:        "invalid DSN format",
-			dsn:         "invalid-dsn-format",
-			newDBName:   "newdb",
-			expectError: true,
-		},
-		{
-			name:        "DSN without database name",
-			dsn:         "postgres://user:pass@localhost:5432/",
-			newDBName:   "newdb",
-			expectError: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create a minimal ExplainPlan instance for testing
-			ep := &ExplainPlan{}
-
-			result, err := ep.replaceDatabaseNameInDSN(tt.dsn, tt.newDBName)
-
-			if tt.expectError {
-				require.Error(t, err)
-				return
-			}
-
-			require.NoError(t, err)
-			require.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/internal/component/database_observability/postgres/collector/schema_details.go
+++ b/internal/component/database_observability/postgres/collector/schema_details.go
@@ -598,6 +598,7 @@ func (c *SchemaDetails) fetchColumnsDefinitions(ctx context.Context, databaseNam
 
 	if err := fkRS.Err(); err != nil {
 		level.Error(c.logger).Log("msg", "failed to iterate over foreign keys result set", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
+		return nil, err
 	}
 
 	return tblSpec, nil

--- a/internal/component/database_observability/postgres/collector/schema_details.go
+++ b/internal/component/database_observability/postgres/collector/schema_details.go
@@ -28,7 +28,11 @@ const (
 )
 
 const (
-	selectDatabaseName = `SELECT current_database()`
+	// selectAllDatabases makes use of the initial DB connection to discover other databases on the same Postgres instance
+	selectAllDatabases = `
+		SELECT datname 
+		FROM pg_database 
+		WHERE datistemplate = false`
 
 	// selectSchemaNames gets all user-defined schemas, excluding system schemas
 	selectSchemaNames = `
@@ -202,6 +206,7 @@ type foreignKey struct {
 
 type SchemaDetailsArguments struct {
 	DB              *sql.DB
+	DSN             string
 	CollectInterval time.Duration
 	EntryHandler    loki.EntryHandler
 
@@ -210,12 +215,16 @@ type SchemaDetailsArguments struct {
 	CacheTTL     time.Duration
 
 	Logger log.Logger
+
+	dbConnectionFactory databaseConnectionFactory
 }
 
 type SchemaDetails struct {
-	dbConnection    *sql.DB
-	collectInterval time.Duration
-	entryHandler    loki.EntryHandler
+	initialConnection   *sql.DB
+	dbDSN               string
+	dbConnectionFactory databaseConnectionFactory
+	collectInterval     time.Duration
+	entryHandler        loki.EntryHandler
 
 	// Cache of table definitions. Entries are removed after a configurable TTL.
 	// Key is a string of the form "database.schema.table".
@@ -229,12 +238,19 @@ type SchemaDetails struct {
 }
 
 func NewSchemaDetails(args SchemaDetailsArguments) (*SchemaDetails, error) {
+	factory := args.dbConnectionFactory
+	if factory == nil {
+		factory = defaultDbConnectionFactory
+	}
+
 	c := &SchemaDetails{
-		dbConnection:    args.DB,
-		collectInterval: args.CollectInterval,
-		entryHandler:    args.EntryHandler,
-		logger:          log.With(args.Logger, "collector", SchemaDetailsCollector),
-		running:         &atomic.Bool{},
+		initialConnection:   args.DB,
+		dbDSN:               args.DSN,
+		dbConnectionFactory: defaultDbConnectionFactory,
+		collectInterval:     args.CollectInterval,
+		entryHandler:        args.EntryHandler,
+		logger:              log.With(args.Logger, "collector", SchemaDetailsCollector),
+		running:             &atomic.Bool{},
 	}
 
 	if args.CacheEnabled {
@@ -290,14 +306,34 @@ func (c *SchemaDetails) Stop() {
 	c.cancel()
 }
 
-func (c *SchemaDetails) extractNames(ctx context.Context) error {
-	rs := c.dbConnection.QueryRowContext(ctx, selectDatabaseName)
-	var dbName string
-	if err := rs.Scan(&dbName); err != nil {
-		return fmt.Errorf("failed to scan database name: %w", err)
+func (c *SchemaDetails) getAllDatabases(ctx context.Context) ([]string, error) {
+	rows, err := c.initialConnection.QueryContext(ctx, selectAllDatabases)
+	if err != nil {
+		level.Error(c.logger).Log("msg", "failed to discover databases", "err", err)
+		return nil, fmt.Errorf("failed to discover databases: %w", err)
+	}
+	defer rows.Close()
+
+	var databases []string
+	for rows.Next() {
+		var datname string
+		if err := rows.Scan(&datname); err != nil {
+			level.Error(c.logger).Log("msg", "failed to scan database name", "err", err)
+			continue
+		}
+		databases = append(databases, datname)
 	}
 
-	schemaRs, err := c.dbConnection.QueryContext(ctx, selectSchemaNames)
+	if err := rows.Err(); err != nil {
+		level.Error(c.logger).Log("msg", "error iterating database rows", "err", err)
+		return nil, fmt.Errorf("error iterating database rows: %w", err)
+	}
+
+	return databases, nil
+}
+
+func (c *SchemaDetails) extractSchemas(ctx context.Context, dbName string, dbConnection *sql.DB) error {
+	schemaRs, err := dbConnection.QueryContext(ctx, selectSchemaNames)
 	if err != nil {
 		return fmt.Errorf("failed to query pg_namespace for database %s: %w", dbName, err)
 	}
@@ -331,7 +367,7 @@ func (c *SchemaDetails) extractNames(ctx context.Context) error {
 	tables := []*tableInfo{}
 
 	for _, schema := range schemas {
-		rs, err := c.dbConnection.QueryContext(ctx, selectTableNames, schema)
+		rs, err := dbConnection.QueryContext(ctx, selectTableNames, schema)
 		if err != nil {
 			level.Error(c.logger).Log("msg", "failed to query tables", "datname", dbName, "schema", schema, "err", err)
 			break
@@ -380,7 +416,7 @@ func (c *SchemaDetails) extractNames(ctx context.Context) error {
 		}
 
 		if !cacheHit {
-			table, err = c.fetchTableDefinitions(ctx, table)
+			table, err = c.fetchTableDefinitions(ctx, table, dbConnection)
 			if err != nil {
 				level.Error(c.logger).Log("msg", "failed to get table definitions", "datname", dbName, "schema", table.schema, "err", err)
 				continue
@@ -403,8 +439,46 @@ func (c *SchemaDetails) extractNames(ctx context.Context) error {
 	return nil
 }
 
-func (c *SchemaDetails) fetchTableDefinitions(ctx context.Context, table *tableInfo) (*tableInfo, error) {
-	spec, err := c.fetchColumnsDefinitions(ctx, table.database, table.schema, table.tableName)
+func (c *SchemaDetails) extractNames(ctx context.Context) error {
+	databases, err := c.getAllDatabases(ctx)
+	if err != nil {
+		level.Error(c.logger).Log("msg", "failed to discover databases", "err", err)
+		return fmt.Errorf("failed to discover databases: %w", err)
+	}
+
+	for _, dbName := range databases {
+		databaseDSN, err := replaceDatabaseNameInDSN(c.dbDSN, dbName)
+		if err != nil {
+			level.Error(c.logger).Log("msg", "failed to create DSN for database", "datname", dbName, "err", err)
+			continue
+		}
+
+		conn, err := c.dbConnectionFactory(databaseDSN)
+		if err != nil {
+			level.Error(c.logger).Log("msg", "failed to create connection to database", "datname", dbName, "err", err)
+			continue
+		}
+
+		if err := c.extractSchemas(ctx, dbName, conn); err != nil {
+			level.Error(c.logger).Log("msg", "failed to collect schema from database", "datname", dbName, "err", err)
+			if conn != c.initialConnection {
+				conn.Close()
+			}
+			continue
+		}
+
+		if conn != c.initialConnection {
+			if err := conn.Close(); err != nil {
+				level.Warn(c.logger).Log("msg", "failed to close database connection", "datname", dbName, "err", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *SchemaDetails) fetchTableDefinitions(ctx context.Context, table *tableInfo, dbConnection *sql.DB) (*tableInfo, error) {
+	spec, err := c.fetchColumnsDefinitions(ctx, table.database, table.schema, table.tableName, dbConnection)
 	if err != nil {
 		level.Error(c.logger).Log("msg", "failed to analyze table spec", "datname", table.database, "schema", table.schema, "table", table.tableName, "err", err)
 		return table, err
@@ -420,11 +494,11 @@ func (c *SchemaDetails) fetchTableDefinitions(ctx context.Context, table *tableI
 	return table, nil
 }
 
-func (c *SchemaDetails) fetchColumnsDefinitions(ctx context.Context, databaseName, schemaName, tableName string) (*tableSpec, error) {
+func (c *SchemaDetails) fetchColumnsDefinitions(ctx context.Context, dbName, schemaName, tableName string, dbConnection *sql.DB) (*tableSpec, error) {
 	qualifiedTableName := fmt.Sprintf("%s.%s", schemaName, tableName)
-	colRS, err := c.dbConnection.QueryContext(ctx, selectColumnNames, qualifiedTableName)
+	colRS, err := dbConnection.QueryContext(ctx, selectColumnNames, qualifiedTableName)
 	if err != nil {
-		level.Error(c.logger).Log("msg", "failed to query table columns", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
+		level.Error(c.logger).Log("msg", "failed to query table columns", "datname", dbName, "schema", schemaName, "table", tableName, "err", err)
 		return nil, err
 	}
 	defer colRS.Close()
@@ -436,7 +510,7 @@ func (c *SchemaDetails) fetchColumnsDefinitions(ctx context.Context, databaseNam
 		var columnDefault sql.NullString
 		var notNullable, isPrimaryKey bool
 		if err := colRS.Scan(&columnName, &columnType, &notNullable, &columnDefault, &identityGeneration, &isPrimaryKey); err != nil {
-			level.Error(c.logger).Log("msg", "failed to scan table columns", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
+			level.Error(c.logger).Log("msg", "failed to scan table columns", "datname", dbName, "schema", schemaName, "table", tableName, "err", err)
 			return nil, err
 		}
 
@@ -461,13 +535,13 @@ func (c *SchemaDetails) fetchColumnsDefinitions(ctx context.Context, databaseNam
 	}
 
 	if err := colRS.Err(); err != nil {
-		level.Error(c.logger).Log("msg", "failed to iterate over table columns result set", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
+		level.Error(c.logger).Log("msg", "failed to iterate over table columns result set", "datname", dbName, "schema", schemaName, "table", tableName, "err", err)
 		return nil, err
 	}
 
-	indexesRS, err := c.dbConnection.QueryContext(ctx, selectIndexes, schemaName, tableName)
+	indexesRS, err := dbConnection.QueryContext(ctx, selectIndexes, schemaName, tableName)
 	if err != nil {
-		level.Error(c.logger).Log("msg", "failed to query indexes", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
+		level.Error(c.logger).Log("msg", "failed to query indexes", "datname", dbName, "schema", schemaName, "table", tableName, "err", err)
 		return nil, err
 	}
 	defer indexesRS.Close()
@@ -478,7 +552,7 @@ func (c *SchemaDetails) fetchColumnsDefinitions(ctx context.Context, databaseNam
 		var columns, expressions pq.StringArray
 
 		if err := indexesRS.Scan(&indexName, &indexType, &unique, &columns, &expressions, &hasNullableColumn); err != nil {
-			level.Error(c.logger).Log("msg", "failed to scan indexes", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
+			level.Error(c.logger).Log("msg", "failed to scan indexes", "datname", dbName, "schema", schemaName, "table", tableName, "err", err)
 			return nil, err
 		}
 
@@ -496,13 +570,13 @@ func (c *SchemaDetails) fetchColumnsDefinitions(ctx context.Context, databaseNam
 	}
 
 	if err := indexesRS.Err(); err != nil {
-		level.Error(c.logger).Log("msg", "error during iterating over indexes", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
+		level.Error(c.logger).Log("msg", "error during iterating over indexes", "datname", dbName, "schema", schemaName, "table", tableName, "err", err)
 		return nil, err
 	}
 
-	fkRS, err := c.dbConnection.QueryContext(ctx, selectForeignKeys, schemaName, tableName)
+	fkRS, err := dbConnection.QueryContext(ctx, selectForeignKeys, schemaName, tableName)
 	if err != nil {
-		level.Error(c.logger).Log("msg", "failed to query foreign keys", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
+		level.Error(c.logger).Log("msg", "failed to query foreign keys", "datname", dbName, "schema", schemaName, "table", tableName, "err", err)
 		return nil, err
 	}
 	defer fkRS.Close()
@@ -510,7 +584,7 @@ func (c *SchemaDetails) fetchColumnsDefinitions(ctx context.Context, databaseNam
 	for fkRS.Next() {
 		var constraintName, columnName, referencedTableName, referencedColumnName string
 		if err := fkRS.Scan(&constraintName, &columnName, &referencedTableName, &referencedColumnName); err != nil {
-			level.Error(c.logger).Log("msg", "failed to scan foreign keys", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
+			level.Error(c.logger).Log("msg", "failed to scan foreign keys", "datname", dbName, "schema", schemaName, "table", tableName, "err", err)
 			return nil, err
 		}
 
@@ -523,8 +597,7 @@ func (c *SchemaDetails) fetchColumnsDefinitions(ctx context.Context, databaseNam
 	}
 
 	if err := fkRS.Err(); err != nil {
-		level.Error(c.logger).Log("msg", "failed to iterate over foreign keys result set", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
-		return nil, err
+		level.Error(c.logger).Log("msg", "failed to iterate over foreign keys result set", "datname", dbName, "schema", schemaName, "table", tableName, "err", err)
 	}
 
 	return tblSpec, nil

--- a/internal/component/database_observability/postgres/collector/schema_details_test.go
+++ b/internal/component/database_observability/postgres/collector/schema_details_test.go
@@ -329,6 +329,111 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 		require.Equal(t, fmt.Sprintf(`level="info" datname="books_store" schema="postgis" table="spatial_ref_sys" table_spec="%s"`, expectedSpatialTableSpec), lokiEntries[7].Line)
 	})
 
+	t.Run("collector discovers and collects from multiple databases", func(t *testing.T) {
+		t.Parallel()
+
+		initialConnectionDb, initialConnectionMock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer initialConnectionDb.Close()
+
+		db1, db1Mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db1.Close()
+
+		db2, db2Mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db2.Close()
+
+		lokiClient := loki_fake.NewClient(func() {})
+		defer lokiClient.Stop()
+
+		collector, err := NewSchemaDetails(SchemaDetailsArguments{
+			DB:              initialConnectionDb,
+			DSN:             "postgres://user:pass@localhost:5432/postgres",
+			CollectInterval: time.Millisecond,
+			EntryHandler:    lokiClient,
+			Logger:          log.NewLogfmtLogger(os.Stderr),
+			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
+				switch dsn {
+				case "postgres://user:pass@localhost:5432/db1":
+					return db1, nil
+				case "postgres://user:pass@localhost:5432/db2":
+					return db2, nil
+				default:
+					return nil, fmt.Errorf("unexpected DSN: %s", dsn)
+				}
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+
+		initialConnectionMock.ExpectQuery(selectAllDatabases).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{"datname"}).
+					AddRow("db1").
+					AddRow("db2"),
+			)
+
+		db1Mock.ExpectQuery(selectSchemaNames).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{"schema_name"}).AddRow("public"))
+		db1Mock.ExpectQuery(selectTableNames).WithArgs("public").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("users"))
+		db1Mock.ExpectQuery(selectColumnNames).WithArgs("public.users").RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{"column_name", "column_type", "not_nullable", "column_default", "identity_generation", "is_primary_key"}).
+					AddRow("id", "integer", true, nil, "", true),
+			)
+		db1Mock.ExpectQuery(selectIndexes).WithArgs("public", "users").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{"index_name", "index_type", "unique", "column_names", "expressions", "has_nullable_column"}))
+		db1Mock.ExpectQuery(selectForeignKeys).WithArgs("public", "users").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{"constraint_name", "column_name", "referenced_table_name", "referenced_column_name"}))
+
+		db2Mock.ExpectQuery(selectSchemaNames).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{"schema_name"}).AddRow("public"))
+		db2Mock.ExpectQuery(selectTableNames).WithArgs("public").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("metrics"))
+		db2Mock.ExpectQuery(selectColumnNames).WithArgs("public.metrics").RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{"column_name", "column_type", "not_nullable", "column_default", "identity_generation", "is_primary_key"}).
+					AddRow("id", "bigint", true, nil, "", true),
+			)
+		db2Mock.ExpectQuery(selectIndexes).WithArgs("public", "metrics").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{"index_name", "index_type", "unique", "column_names", "expressions", "has_nullable_column"}))
+		db2Mock.ExpectQuery(selectForeignKeys).WithArgs("public", "metrics").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{"constraint_name", "column_name", "referenced_table_name", "referenced_column_name"}))
+
+		err = collector.Start(context.Background())
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 6
+		}, 2*time.Second, 100*time.Millisecond)
+
+		collector.Stop()
+		lokiClient.Stop()
+
+		require.NoError(t, initialConnectionMock.ExpectationsWereMet())
+		require.NoError(t, db1Mock.ExpectationsWereMet())
+		require.NoError(t, db2Mock.ExpectationsWereMet())
+
+		lokiEntries := lokiClient.Received()
+		assert.Len(t, lokiEntries, 6)
+
+		assert.Equal(t, model.LabelSet{"op": OP_SCHEMA_DETECTION}, lokiEntries[0].Labels)
+		assert.Equal(t, `level="info" datname="db1" schema="public"`, lokiEntries[0].Line)
+		assert.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, lokiEntries[1].Labels)
+		assert.Equal(t, `level="info" datname="db1" schema="public" table="users"`, lokiEntries[1].Line)
+		assert.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, lokiEntries[2].Labels)
+		assert.Equal(t, fmt.Sprintf(`level="info" datname="db1" schema="public" table="users" table_spec="%s"`, base64.StdEncoding.EncodeToString([]byte(`{"columns":[{"name":"id","type":"integer","not_null":true,"primary_key":true}]}`))), lokiEntries[2].Line)
+
+		assert.Equal(t, model.LabelSet{"op": OP_SCHEMA_DETECTION}, lokiEntries[3].Labels)
+		assert.Equal(t, `level="info" datname="db2" schema="public"`, lokiEntries[3].Line)
+		assert.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, lokiEntries[4].Labels)
+		assert.Equal(t, `level="info" datname="db2" schema="public" table="metrics"`, lokiEntries[4].Line)
+		assert.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, lokiEntries[5].Labels)
+		assert.Equal(t, fmt.Sprintf(`level="info" datname="db2" schema="public" table="metrics" table_spec="%s"`, base64.StdEncoding.EncodeToString([]byte(`{"columns":[{"name":"id","type":"bigint","not_null":true,"primary_key":true}]}`))), lokiEntries[5].Line)
+	})
+
 	t.Run("collector handles multiple indexes on single table", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/component/database_observability/postgres/collector/schema_details_test.go
+++ b/internal/component/database_observability/postgres/collector/schema_details_test.go
@@ -332,14 +332,19 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 	t.Run("collector discovers and collects from multiple databases", func(t *testing.T) {
 		t.Parallel()
 
+		/*
+			This is the only test that sets up 3 mock connections representing a Postgres instance with 3 separate databases,
+			better representing the individual connections of database discovery.
+			ExpectationsWereMet() is called on each connection at end of the test, asserting that the connections are
+			correctly used.
+			This is the only test that will fail if distinct connections are not made.
+		*/
 		initialConnectionDb, initialConnectionMock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer initialConnectionDb.Close()
-
 		db1, db1Mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db1.Close()
-
 		db2, db2Mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db2.Close()

--- a/internal/component/database_observability/postgres/collector/schema_details_test.go
+++ b/internal/component/database_observability/postgres/collector/schema_details_test.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"context"
+	"database/sql"
 	"encoding/base64"
 	"fmt"
 	"os"
@@ -38,14 +39,18 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 
 		collector, err := NewSchemaDetails(SchemaDetailsArguments{
 			DB:              db,
+			DSN:             "postgres://user:pass@localhost:5432/books_store",
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
+			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
+				return db, nil
+			},
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
 
-		mock.ExpectQuery(selectDatabaseName).WithoutArgs().RowsWillBeClosed().
+		mock.ExpectQuery(selectAllDatabases).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"datname",
@@ -141,14 +146,18 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 
 		collector, err := NewSchemaDetails(SchemaDetailsArguments{
 			DB:              db,
+			DSN:             "postgres://user:pass@localhost:5432/books_store",
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
+			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
+				return db, nil
+			},
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
 
-		mock.ExpectQuery(selectDatabaseName).WithoutArgs().RowsWillBeClosed().
+		mock.ExpectQuery(selectAllDatabases).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"datname",
@@ -332,14 +341,18 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 
 		collector, err := NewSchemaDetails(SchemaDetailsArguments{
 			DB:              db,
+			DSN:             "postgres://user:pass@localhost:5432/testdb",
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
+			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
+				return db, nil
+			},
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
 
-		mock.ExpectQuery(selectDatabaseName).WithoutArgs().RowsWillBeClosed().
+		mock.ExpectQuery(selectAllDatabases).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"datname",
@@ -441,14 +454,18 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 		logBuffer := syncbuffer.Buffer{}
 		collector, err := NewSchemaDetails(SchemaDetailsArguments{
 			DB:              db,
+			DSN:             "postgres://user:pass@localhost:5432/testdb",
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
 			Logger:          log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
+				return db, nil
+			},
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
 
-		mock.ExpectQuery(selectDatabaseName).WithoutArgs().RowsWillBeClosed().
+		mock.ExpectQuery(selectAllDatabases).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"datname",
@@ -493,14 +510,18 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 
 		collector, err := NewSchemaDetails(SchemaDetailsArguments{
 			DB:              db,
+			DSN:             "postgres://user:pass@localhost:5432/testdb",
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
+			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
+				return db, nil
+			},
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
 
-		mock.ExpectQuery(selectDatabaseName).WithoutArgs().RowsWillBeClosed().
+		mock.ExpectQuery(selectAllDatabases).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"datname",
@@ -600,14 +621,18 @@ func Test_Postgres_SchemaDetails_collector_detects_auto_increment_column(t *test
 
 		collector, err := NewSchemaDetails(SchemaDetailsArguments{
 			DB:              db,
+			DSN:             "postgres://user:pass@localhost:5432/testdb",
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
+			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
+				return db, nil
+			},
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
 
-		mock.ExpectQuery(selectDatabaseName).WithoutArgs().RowsWillBeClosed().
+		mock.ExpectQuery(selectAllDatabases).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"datname",
@@ -702,14 +727,18 @@ func Test_Postgres_SchemaDetails_collector_detects_auto_increment_column(t *test
 
 		collector, err := NewSchemaDetails(SchemaDetailsArguments{
 			DB:              db,
+			DSN:             "postgres://user:pass@localhost:5432/testdb",
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
+			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
+				return db, nil
+			},
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
 
-		mock.ExpectQuery(selectDatabaseName).WithoutArgs().RowsWillBeClosed().
+		mock.ExpectQuery(selectAllDatabases).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"datname",
@@ -804,14 +833,18 @@ func Test_Postgres_SchemaDetails_collector_detects_auto_increment_column(t *test
 
 		collector, err := NewSchemaDetails(SchemaDetailsArguments{
 			DB:              db,
+			DSN:             "postgres://user:pass@localhost:5432/testdb",
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
+			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
+				return db, nil
+			},
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
 
-		mock.ExpectQuery(selectDatabaseName).WithoutArgs().RowsWillBeClosed().
+		mock.ExpectQuery(selectAllDatabases).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"datname",
@@ -903,19 +936,23 @@ func Test_Postgres_SchemaDetails_caching(t *testing.T) {
 		lokiClient := loki_fake.NewClient(func() {})
 		collector, err := NewSchemaDetails(SchemaDetailsArguments{
 			DB:              db,
+			DSN:             "postgres://user:pass@localhost:5432/cache_test_db",
 			CollectInterval: time.Millisecond,
 			CacheEnabled:    true,
 			CacheSize:       256,
 			CacheTTL:        10 * time.Minute,
 			EntryHandler:    lokiClient,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
+			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
+				return db, nil
+			},
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
 
 		// first run mock declarations
 		// selectDatabaseName, selectSchemaNames, selectTableNames always called
-		mock.ExpectQuery(selectDatabaseName).WithoutArgs().RowsWillBeClosed().
+		mock.ExpectQuery(selectAllDatabases).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"datname",
@@ -979,7 +1016,7 @@ func Test_Postgres_SchemaDetails_caching(t *testing.T) {
 
 		// second run mock declarations
 		// selectDatabaseName, selectSchemaNames, selectTableNames always called
-		mock.ExpectQuery(selectDatabaseName).WithoutArgs().RowsWillBeClosed().
+		mock.ExpectQuery(selectAllDatabases).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"datname",
@@ -1030,17 +1067,21 @@ func Test_Postgres_SchemaDetails_caching(t *testing.T) {
 
 		collector, err := NewSchemaDetails(SchemaDetailsArguments{
 			DB:              db,
+			DSN:             "postgres://user:pass@localhost:5432/no_cache_test_db",
 			CollectInterval: time.Millisecond,
 			CacheEnabled:    false,
 			EntryHandler:    lokiClient,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
+			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
+				return db, nil
+			},
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
 
 		// declare mocks for two runs
 		for i := 0; i < 2; i++ {
-			mock.ExpectQuery(selectDatabaseName).WithoutArgs().RowsWillBeClosed().
+			mock.ExpectQuery(selectAllDatabases).WithoutArgs().RowsWillBeClosed().
 				WillReturnRows(
 					sqlmock.NewRows([]string{
 						"datname",

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -397,6 +397,7 @@ func (c *Component) startCollectors(systemID string, engineVersion string) error
 	if collectors[collector.SchemaDetailsCollector] {
 		stCollector, err := collector.NewSchemaDetails(collector.SchemaDetailsArguments{
 			DB:              c.dbConnection,
+			DSN:             string(c.args.DataSourceName),
 			CollectInterval: c.args.SchemaDetailsArguments.CollectInterval,
 			CacheEnabled:    c.args.SchemaDetailsArguments.CacheEnabled,
 			CacheSize:       c.args.SchemaDetailsArguments.CacheSize,


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR enables the Postgres Schema Details collector to collect schema details for other databases on the same Postgres instance.

Previously it was collecting schema details for only the database specified in the initial DSN, i.e. "current database".
This PR changes the collector to:
* makes use of the initial connection to the database specified in the DSN to select "all" databases
* creates a new connection for discovered databases
* loop over the list of databases
* collects the schema details
* closes the connection a discovered database

#### Which issue(s) this PR fixes

Closes https://github.com/grafana/grafana-dbo11y-app/issues/1546

#### Notes to the Reviewer

I tested this locally on our PG 17 test instance. I created a couple of additional test databases alongside `books_store` with tables/columns/indexes. I built Alloy and ran it locally, targeting this test instance, connecting as usual to `books_store` with the dedicated db_o11y user and checked that emitted logs for `op=create_statement` included the expected schema_details for the additional databases. 

In future iterations it may be worthwhile to explore:
* configurable exclusions of databases
* configurable limits to the number of databases to discover

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
