### PR TITLE
ci: hold prometheus/common dep as unstable on dashboard

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -82,6 +82,7 @@
         "github.com/prometheus/consul_exporter",
         "github.com/prometheus/memcached_exporter",
         "github.com/prometheus/procfs",
+        "github.com/prometheus/common",
         "github.com/prometheus/sigv4",
         "github.com/testcontainers/testcontainers-go",
         "github.com/testcontainers/testcontainers-go/**",


### PR DESCRIPTION
This dep introduces breaking changes in minor/patch releases, so it is being excluded from the BAU dependency update group. PR creation for this dep must now be done via dependency dashboard.