### PR TITLE
Docs: Fix broken link in sources/troubleshoot/debug (#4653)

### DIFF
--- a/docs/sources/troubleshoot/debug.md
+++ b/docs/sources/troubleshoot/debug.md
@@ -54,7 +54,7 @@ You can click and drag the components to move them around.
 
 To access the graph page of a module, click on the **Graph** button on the module's detail page.
 
-The amount of data that exits a component that supports [live debugging][#live-debugging-page] is shown on the outgoing edges of the component.
+The amount of data that exits a component that supports [live debugging](#live-debugging-page) is shown on the outgoing edges of the component.
 The data is refreshed according to the `window` parameter.
 ### Component detail page
 


### PR DESCRIPTION
Backport https://github.com/grafana/alloy/commit/1aaa7ce2f2e86298bf155190eab219b30fc46680 from https://github.com/grafana/alloy/pull/4653