### PR TITLE
fix: resolve race condition in `prometheus.receive_http` test

### DIFF
--- a/internal/component/prometheus/receive_http/receive_http.go
+++ b/internal/component/prometheus/receive_http/receive_http.go
@@ -167,3 +167,15 @@ func (c *Component) shutdownServer() {
 		c.server = nil
 	}
 }
+
+func (c *Component) getServer() *fnet.TargetServer {
+	c.updateMut.RLock()
+	defer c.updateMut.RUnlock()
+	return c.server
+}
+
+func (c *Component) getArgs() Arguments {
+	c.updateMut.RLock()
+	defer c.updateMut.RUnlock()
+	return c.args
+}

--- a/internal/component/prometheus/receive_http/receive_http_test.go
+++ b/internal/component/prometheus/receive_http/receive_http_test.go
@@ -440,18 +440,19 @@ func TestServerRestarts(t *testing.T) {
 				serverExit <- comp.Run(ctx)
 			}()
 
-			waitForServerToBeReady(t, comp.args)
+			waitForServerToBeReady(t, comp.getArgs())
 
-			initialServer := comp.server
+			initialServer := comp.getServer()
 			require.NotNil(t, initialServer)
 
 			err = comp.Update(tc.newArgs)
 			require.NoError(t, err)
 
-			waitForServerToBeReady(t, comp.args)
+			waitForServerToBeReady(t, comp.getArgs())
 
-			require.NotNil(t, comp.server)
-			restarted := initialServer != comp.server
+			currentServer := comp.getServer()
+			require.NotNil(t, currentServer)
+			restarted := initialServer != currentServer
 
 			require.Equal(t, tc.shouldRestart, restarted)
 
@@ -564,7 +565,6 @@ func testAppendable(actualSamples chan testSample) []storage.Appendable {
 		val float64,
 		next storage.Appender,
 	) (storage.SeriesRef, error) {
-
 		actualSamples <- testSample{ts: ts, val: val, l: l}
 		return ref, nil
 	}


### PR DESCRIPTION
#### PR Description
Add thread-safe getter methods for `server` and `args` fields to prevent race condition in `TestServerRestarts`. The test was accessing these fields without proper synchronization while `Update()` modified them under lock, causing intermittent failures.

#### Which issue(s) this PR fixes
n.a.

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
