### PR TITLE
Add flags to the `run` command for configuring cAdvisor housekeeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ Main (unreleased)
 
 - `prometheus.exporter.unix`: Add an `arp` config block to configure the ARP collector. (@ptodev)
 
+- Make cAdvisor housekeeping configurable via flags for the `run` command (@into-the-v0id)
+
 ### Bugfixes
 
 - Stop `loki.source.kubernetes` discarding log lines with duplicate timestamps. (@ciaranj)


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Goal of this PR is to make cAdvisor housekeeping configurable in grafana alloy (see #4685).

cAdvisor handles the configuration of its housekeeping exclusively via flags. See [cAdvisor housekeeping docs](https://github.com/google/cadvisor/blob/master/docs/runtime_options.md#housekeeping) and [cAdvisor source code](https://github.com/google/cadvisor/blob/5adb1c3bb38b4c5d50b31f39faf3214a44ae479b/manager/container.go#L50). The variable in the source code is also global - so we cannot configure this on an alloy config block level. We would need to keep this setting also global in grafana alloy. Following options:
- global options in alloy config file
- environment variables
- pass through flags

I've went with passing through the flags since most grafana alloy users already pass custom flags to alloy and it's less hassle than a new config option in the config files.

The `run` cli command has now the following flags:

```
--cadvisor.allow-dynamic-housekeeping            Whether to allow the cadvisor housekeeping interval to be dynamic (default true)
--cadvisor.housekeeping-interval duration        Interval between cadvisor container housekeepings (default 1s)
--cadvisor.max-housekeeping-interval duration    Largest interval to allow between cadvisor container housekeepings (default 1m0s)
```

I've also made dynamic housekeeping configurable while I'm at it ([cAdvisor source code](https://github.com/google/cadvisor/blob/5adb1c3bb38b4c5d50b31f39faf3214a44ae479b/manager/manager.go#L69)).

The defaults match the defaults of cAdvisor - so this shouldn't be a breaking change.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #4685

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
