### PR TITLE
clarifies component name and export references

### DIFF
--- a/docs/sources/get-started/configuration-syntax/_index.md
+++ b/docs/sources/get-started/configuration-syntax/_index.md
@@ -116,7 +116,8 @@ You can use expressions for any attribute in a component definition.
 The most common expression references a component's exports, such as `local.file.password_file.content`.
 You form a reference by combining the component's name (for example, `local.file`), label (for example, `password_file`), and export name (for example, `content`), separated by periods.
 
-While a label is an arbitrary designation you can choose yourself, the component's name and its exports are predefined. You can find an extensive list of available components, and corresponding descriptions including the exported fields [here](https://grafana.com/docs/alloy/latest/reference/components).
+While a label is an arbitrary designation you can choose yourself, the component's name and its exports are predefined.
+Refer to the list of [components](https://grafana.com/docs/alloy/<ALLOY_VERSION>/reference/components) for more information about the available components, their descriptions, and the exported fields.
 
 ## Configuration syntax design goals
 


### PR DESCRIPTION
Added a note about component names and exports in configuration syntax.

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Clarifies how component export references are composed in "Grafana Alloy configuration syntax" description.

#### Which issue(s) this PR fixes

n.a.

#### Notes to the Reviewer

This PR includes only documentation updates, no code changes.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
