### PR TITLE
Fix handling of multiplexed long lines in Docker logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ Main (unreleased)
 
 - Remove extraneous `output` stage from the `cri` stage pipeline in `loki.process`. (@kalleep)
 
+- Fix Docker log corruption for multiplexed long lines. (@axd1x8a)
+
 v1.12.0
 -----------------
 

--- a/internal/component/loki/source/docker/internal/dockertarget/target.go
+++ b/internal/component/loki/source/docker/internal/dockertarget/target.go
@@ -6,6 +6,7 @@ package dockertarget
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -13,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unsafe"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
@@ -34,6 +36,7 @@ const (
 	dockerLabel                = model.MetaLabelPrefix + "docker_"
 	dockerLabelContainerPrefix = dockerLabel + "container_"
 	dockerLabelLogStream       = dockerLabelContainerPrefix + "log_stream"
+	dockerMaxChunkSize         = 16384
 )
 
 // Target enables reading Docker container logs.
@@ -110,7 +113,12 @@ func (t *Target) processLoop(ctx context.Context, tty bool, reader io.ReadCloser
 		if tty {
 			written, err = io.Copy(wstdout, reader)
 		} else {
-			written, err = stdcopy.StdCopy(wstdout, wstderr, reader)
+			// For non-TTY, wrap the pipe writers with our chunk writer to reassemble frames.
+			wcstdout := newChunkWriter(wstdout, t.logger)
+			defer wcstdout.Close()
+			wcstderr := newChunkWriter(wstderr, t.logger)
+			defer wcstderr.Close()
+			written, err = stdcopy.StdCopy(wcstdout, wcstderr, reader)
 		}
 		if err != nil {
 			level.Warn(t.logger).Log("msg", "could not transfer logs", "written", written, "container", t.containerName, "err", err)
@@ -128,53 +136,33 @@ func (t *Target) processLoop(ctx context.Context, tty bool, reader io.ReadCloser
 	level.Debug(t.logger).Log("msg", "done processing Docker logs", "container", t.containerName)
 }
 
-// extractTs tries for read the timestamp from the beginning of the log line.
-// It's expected to follow the format 2006-01-02T15:04:05.999999999Z07:00.
-func extractTs(line string) (time.Time, string, error) {
-	pair := strings.SplitN(line, " ", 2)
-	if len(pair) != 2 {
-		return time.Now(), line, fmt.Errorf("could not find timestamp in '%s'", line)
+// extractTsFromBytes parses an RFC3339Nano timestamp from the byte slice.
+func extractTsFromBytes(line []byte) (time.Time, []byte, error) {
+	const timestampLayout = "2006-01-02T15:04:05.999999999Z07:00"
+
+	spaceIdx := bytes.IndexByte(line, ' ')
+	if spaceIdx == -1 {
+		return time.Time{}, nil, fmt.Errorf("could not find timestamp in bytes")
 	}
-	ts, err := time.Parse("2006-01-02T15:04:05.999999999Z07:00", pair[0])
+	// We know that the bytes won't be modified during the time.Parse call, so it's safe to use unsafe.String here
+	ts, err := time.Parse(timestampLayout, unsafe.String(&line[0], spaceIdx))
 	if err != nil {
-		return time.Now(), line, fmt.Errorf("could not parse timestamp from '%s': %w", pair[0], err)
+		return time.Time{}, nil, fmt.Errorf("could not parse timestamp: %w", err)
 	}
-	return ts, pair[1], nil
-}
-
-// https://devmarkpro.com/working-big-files-golang
-func readLine(r *bufio.Reader) (string, error) {
-	var (
-		isPrefix = true
-		err      error
-		line, ln []byte
-	)
-
-	for isPrefix && err == nil {
-		line, isPrefix, err = r.ReadLine()
-		ln = append(ln, line...)
-	}
-
-	return string(ln), err
+	return ts, line[spaceIdx+1:], nil
 }
 
 func (t *Target) process(r io.Reader, logStreamLset model.LabelSet) {
-	defer func() {
-		t.wg.Done()
-	}()
+	defer t.wg.Done()
 
-	reader := bufio.NewReader(r)
-	for {
-		line, err := readLine(reader)
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			level.Error(t.logger).Log("msg", "error reading docker log line, skipping line", "err", err)
-			t.metrics.dockerErrors.Inc()
-		}
+	scanner := bufio.NewScanner(r)
+	const maxCapacity = dockerMaxChunkSize * 64
+	buf := make([]byte, 0, maxCapacity)
+	scanner.Buffer(buf, maxCapacity)
+	for scanner.Scan() {
+		line := scanner.Bytes()
 
-		ts, line, err := extractTs(line)
+		ts, content, err := extractTsFromBytes(line)
 		if err != nil {
 			level.Error(t.logger).Log("msg", "could not extract timestamp, skipping line", "err", err)
 			t.metrics.dockerErrors.Inc()
@@ -185,7 +173,7 @@ func (t *Target) process(r io.Reader, logStreamLset model.LabelSet) {
 			Labels: logStreamLset,
 			Entry: push.Entry{
 				Timestamp: ts,
-				Line:      line,
+				Line:      string(content),
 			},
 		}
 		t.metrics.dockerEntries.Inc()
@@ -199,6 +187,10 @@ func (t *Target) process(r io.Reader, logStreamLset model.LabelSet) {
 		t.positions.Put(positions.CursorKey(t.containerName), t.labelsStr, ts.Unix())
 		t.since.Store(ts.Unix())
 		t.last.Store(time.Now().Unix())
+	}
+	if err := scanner.Err(); err != nil {
+		level.Error(t.logger).Log("msg", "error reading docker log line", "err", err)
+		t.metrics.dockerErrors.Inc()
 	}
 }
 
@@ -320,4 +312,74 @@ func (t *Target) getStreamLabels(logStream string) model.LabelSet {
 	})
 
 	return filtered
+}
+
+// dockerChunkWriter implements io.Writer to preprocess and reassemble Docker log frames.
+type dockerChunkWriter struct {
+	writer      io.Writer
+	logger      log.Logger
+	buffer      *bytes.Buffer
+	isBuffering bool
+}
+
+var bufferPool = sync.Pool{
+	New: func() interface{} {
+		buf := &bytes.Buffer{}
+		buf.Grow(dockerMaxChunkSize * 2)
+		return buf
+	},
+}
+
+func newChunkWriter(writer io.Writer, logger log.Logger) *dockerChunkWriter {
+	return &dockerChunkWriter{
+		writer: writer,
+		logger: logger,
+		buffer: bufferPool.Get().(*bytes.Buffer),
+	}
+}
+
+func (fw *dockerChunkWriter) Close() error {
+	if fw.buffer != nil {
+		fw.buffer.Reset()
+		bufferPool.Put(fw.buffer)
+		fw.buffer = nil
+	}
+	return nil
+}
+
+func (fw *dockerChunkWriter) Write(p []byte) (int, error) {
+	if !fw.isBuffering {
+		if len(p) < dockerMaxChunkSize {
+			// Short frame: write directly without buffering.
+			_, err := fw.writer.Write(p)
+			if err != nil {
+				return 0, err
+			}
+			return len(p), nil
+		}
+		// Long frame start: buffer the first chunk.
+		fw.buffer.Write(p)
+		fw.isBuffering = true
+		return len(p), nil
+	}
+
+	// Continuation chunk: strip redundant timestamp and append content.
+	_, content, err := extractTsFromBytes(p)
+	if err != nil {
+		// Should not normally happen, but flog.log has entries like this for some reason.
+		level.Warn(fw.logger).Log("msg", "could not strip timestamp from continuation chunk", "err", err)
+		fw.buffer.Write(p)
+	} else {
+		fw.buffer.Write(content)
+	}
+	if len(p) < dockerMaxChunkSize {
+		// Last chunk: flush the reassembled buffer.
+		fw.isBuffering = false
+		_, err := fw.writer.Write(fw.buffer.Bytes())
+		if err != nil {
+			return 0, err
+		}
+		fw.buffer.Reset()
+	}
+	return len(p), nil
 }


### PR DESCRIPTION
#### PR Description
By default, Docker splits lines over 16KB into multiple frames. `stdcopy.StdCopy` handles multiplexing itself, but not inserted timestamps, which corrupts logs:
```json
{
    "a": 1033461950,
    "b": true
},
2025-10-17T22: 40: 09.574025386Z {
    "a": 1033471950,
    "b": true
},
{
    "a": 1034411950,
    "b": true
},
```
This PR adds a wrapper for `stdcopy.StdCopy` streams that checks if incoming streams are part of a larger log line and concatenates them into one, removing timestamp in the process.

Additionally, functions for reading streams and parsing timestamps were changed to operate on bytes to avoid allocations.
#### Which issue(s) this PR fixes
#4625
#1881
<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer
Not sure about the policy on unsafe code here, but the usage of `unsafe.String` in `extractTsFromBytes` makes sense because we know that the bytes won't be modified and it gives just a little bit more performance from my testing.

#### PR Checklist

- [x] CHANGELOG.md updated
- [x] Tests updated
