### PR TITLE
database_observability: filter out databases where the user lacks connect privileges in postgres schema_details collector 

### DIFF
--- a/internal/component/database_observability/postgres/collector/schema_details.go
+++ b/internal/component/database_observability/postgres/collector/schema_details.go
@@ -32,7 +32,8 @@ const (
 	selectAllDatabases = `
 		SELECT datname 
 		FROM pg_database 
-		WHERE datistemplate = false`
+		WHERE datistemplate = false
+			AND has_database_privilege(datname, 'CONNECT')`
 
 	// selectSchemaNames gets all user-defined schemas, excluding system schemas
 	selectSchemaNames = `


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This adds an additional condition to the selectAllDatabases query so that the user has a connect privilege to the database in question: `has_database_privilege(datname, 'CONNECT')`

Otherwise, like in the case of an RDS-hosted instance, there will be an error connecting to `rdsadmin`: `"failed to query pg_namespace for database rdsadmin: pq: pg_hba.conf rejects connection for host...`

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
