### PR TITLE
Explicitly show unknown frames from libpf.AbortFrame

### DIFF
--- a/internal/component/pyroscope/ebpf/ebpf_linux.go
+++ b/internal/component/pyroscope/ebpf/ebpf_linux.go
@@ -259,6 +259,7 @@ func (args *Arguments) Convert() (*controller.Config, error) {
 	}
 
 	cfg := &controller.Config{Config: cfgProtoType}
+	cfg.SendErrorFrames = true
 	cfg.ReporterInterval = args.CollectInterval
 	cfg.SamplesPerSecond = args.SampleRate
 	cfg.Tracers = args.tracers()

--- a/internal/component/pyroscope/ebpf/reporter/pprof.go
+++ b/internal/component/pyroscope/ebpf/reporter/pprof.go
@@ -256,10 +256,15 @@ func (p *PPROFReporter) createProfile(origin libpf.Origin, events map[samples.Tr
 					}
 
 				case libpf.AbortFrame:
-					// Next step: Figure out how the OTLP protocol
-					// could handle artificial frames, like AbortFrame,
-					// that are not originated from a native or interpreted
-					// program.
+					// Be explicit about unknown frames so that we do introduce unknown unknowns.
+					location.Line = []profile.Line{{
+						Line: 0,
+						Function: b.Function(
+							libpf.Intern("[unknown]"),
+							libpf.Intern("[unknown]"),
+						)},
+					}
+					location.Mapping.HasFunctions = true
 				default:
 					if fr.FunctionName != libpf.NullString {
 						location.Line = []profile.Line{{


### PR DESCRIPTION
Not counting these frames at the root level makes them completely disappear, which make CPU usage incorrect. Showing these as `[unknown]` makes them explicit and matches what flamegraphs from `perf` were doing for eons.

As a practical example, here's nginx + luajit:

* Before:

<img width="737" height="128" alt="image" src="https://github.com/user-attachments/assets/1a94d032-f530-4154-ab1f-13c5f62784ce" />

* After:

<img width="736" height="173" alt="image" src="https://github.com/user-attachments/assets/86cb7739-8bfd-43ad-aed0-85ae2c73894d" />

See also: https://github.com/open-telemetry/opentelemetry-ebpf-profiler/issues/902

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
