### PR TITLE
docs: fix capability typo in beyla.ebpf component documentation

### DIFF
--- a/docs/sources/reference/components/beyla/beyla.ebpf.md
+++ b/docs/sources/reference/components/beyla/beyla.ebpf.md
@@ -21,7 +21,7 @@ You can configure the component to collect telemetry data from a specific port o
 The component exposes metrics that can be collected by a Prometheus scrape component, and traces that can be forwarded to an OTel exporter component.
 
 {{< admonition type="note" >}}
-To run this component, {{< param "PRODUCT_NAME" >}} requires administrative privileges, or at least it needs to be granted the following capabilities: `BPF`, `SYS_PTRACE`, `NET_RAW` `CAP_CHECKPOINT_RESTORENET_RAW`, `DAC_READ_SEARCH`, and `PERFMON`.
+To run this component, {{< param "PRODUCT_NAME" >}} requires administrative privileges, or at least it needs to be granted the following capabilities: `BPF`, `SYS_PTRACE`, `NET_RAW`, `CAP_CHECKPOINT_RESTORE`, `DAC_READ_SEARCH`, and `PERFMON`.
 The number of required capabilities depends on the specific use case.
 Refer to the [Beyla capabilities](https://grafana.com/docs/beyla/latest/security/#list-of-capabilities-required-by-beyla) for more information.
 


### PR DESCRIPTION
#### PR Description

This PR fixes a typo in the `beyla.ebpf` component documentation where two Linux capabilities were incorrectly concatenated.

**Change**: `CAP_CHECKPOINT_RESTORENET_RAW` → `CAP_CHECKPOINT_RESTORE`

The capability `NET_RAW` was already listed separately in the documentation, so this was simply a concatenation error where `CAP_CHECKPOINT_RESTORE` and `NET_RAW` were joined together.

#### Which issue(s) this PR fixes

This is a trivial documentation fix that doesn't require an associated issue.

#### Notes to the Reviewer

- This is a straightforward typo fix in documentation only
- No functional code changes
- The corrected capability name `CAP_CHECKPOINT_RESTORE` aligns with standard Linux capability naming

#### PR Checklist

- [ ] CHANGELOG.md updated (not needed for trivial documentation typo fix)
- [x] Documentation added (documentation fix itself)
- [ ] Tests updated (not applicable for documentation typo)
- [ ] Config converters updated (not applicable)