### PR TITLE
docs: document pyroscope.ebpf off_cpu_threshold arg as float instead

### DIFF
--- a/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
@@ -76,7 +76,7 @@ You can use the following arguments with `pyroscope.ebpf`:
 | `load_probe`              | `bool`                   | Enable loading uprobe dynamically during runtime.                                                                    | `false`  | no       |
 | `u_probe_links`           | `list(string)`           | List of user-space symbols to collect stack-trace from, e.g. `["/usr/lib/libc.so.6:malloc"]`.                        |          | no       |
 | `v8_enabled`              | `bool`                   | A flag to enable/disable V8 profiling.                                                                               | `true`   | no       |
-| `off_cpu_threshold`       | `int`                    | A flag to adjust the off-cpu profiling threshold.                                                                    | `0`      | no       | 
+| `off_cpu_threshold`       | `float`                  | A flag to adjust the off-cpu profiling threshold between 0 and 1 as float.                                           | `0`      | no       |
 
 Only the `forward_to` and `targets` fields are required.
 Omitted fields take their default values.

--- a/internal/component/pyroscope/ebpf/args.go
+++ b/internal/component/pyroscope/ebpf/args.go
@@ -21,7 +21,7 @@ type Arguments struct {
 	DotNetEnabled       bool                   `alloy:"dotnet_enabled,attr,optional"`
 	GoEnabled           bool                   `alloy:"go_enabled,attr,optional"`
 	Demangle            string                 `alloy:"demangle,attr,optional"`
-	OffCPUThreshold     float64                `alloy:"off_cpu_threshold,attr,optional"` //TODO: Document this as a float?
+	OffCPUThreshold     float64                `alloy:"off_cpu_threshold,attr,optional"`
 	LoadProbe           bool                   `alloy:"load_probe,attr,optional"`
 	UProbeLinks         []string               `alloy:"u_probe_links,attr,optional"`
 	DeprecatedArguments DeprecatedArguments    `alloy:",squash"`

--- a/internal/component/pyroscope/ebpf/ebpf_linux_test.go
+++ b/internal/component/pyroscope/ebpf/ebpf_linux_test.go
@@ -65,7 +65,7 @@ sample_rate = 239
 			in: `
 	targets = [{"service_name" = "foo", "container_id"= "cid"}]
 	forward_to = []
-	off_cpu_threshold = 1000
+	off_cpu_threshold = 1
 	`,
 			expected: func() Arguments {
 				x := NewDefaultArguments()
@@ -76,7 +76,7 @@ sample_rate = 239
 					}),
 				}
 				x.ForwardTo = []pyroscope.Appendable{}
-				x.OffCPUThreshold = 1000
+				x.OffCPUThreshold = 1
 				return x
 			},
 		},


### PR DESCRIPTION

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
When I made the PR for enable off_cpu_threshold arg, the otel-ebpf-profiler fork was still on the version that was configuring the off_cpu_threshold arg as int, now that it is upgraded it should be documented as float.
#### Which issue(s) this PR fixes
Documentation clarity
<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
