### PR TITLE
chore(loki): create shared batchClient

### DIFF
--- a/internal/component/common/loki/client/batch_client.go
+++ b/internal/component/common/loki/client/batch_client.go
@@ -1,0 +1,176 @@
+package client
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/backoff"
+	lokiutil "github.com/grafana/loki/v3/pkg/util"
+	"github.com/prometheus/common/config"
+
+	"github.com/grafana/alloy/internal/runtime/logging/level"
+	"github.com/grafana/alloy/internal/useragent"
+)
+
+const (
+	contentType  = "application/x-protobuf"
+	maxErrMsgLen = 1024
+)
+
+func newBatchClient(m *Metrics, logger log.Logger, cfg Config) (*batchClient, error) {
+	if cfg.URL.URL == nil {
+		return nil, errors.New("client needs target URL")
+	}
+
+	err := cfg.Client.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient, err := config.NewClientFromConfig(cfg.Client, useragent.ProductName, config.WithHTTP2Disabled())
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient.Timeout = cfg.Timeout
+
+	ctx, cancel := context.WithCancel(context.Background())
+	return &batchClient{
+		cfg:     cfg,
+		metrics: m,
+		logger:  logger,
+		client:  httpClient,
+		ctx:     ctx,
+		cancel:  cancel,
+	}, nil
+}
+
+type batchClient struct {
+	cfg     Config
+	metrics *Metrics
+	logger  log.Logger
+
+	client *http.Client
+
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func (c *batchClient) sendBatch(ctx context.Context, tenantID string, batch *batch) {
+	buf, entriesCount, err := batch.encode()
+	if err != nil {
+		level.Error(c.logger).Log("msg", "error encoding batch", "error", err)
+		return
+	}
+	bufBytes := float64(len(buf))
+	c.metrics.encodedBytes.WithLabelValues(c.cfg.URL.Host, tenantID).Add(bufBytes)
+
+	backoff := backoff.New(c.ctx, c.cfg.BackoffConfig)
+	var status int
+	for {
+		start := time.Now()
+		// send uses `timeout` internally, so `context.Background` is good enough.
+		status, err = c.send(ctx, tenantID, buf)
+
+		c.metrics.requestDuration.WithLabelValues(strconv.Itoa(status), c.cfg.URL.Host, tenantID).Observe(time.Since(start).Seconds())
+
+		// Immediately drop rate limited batches to avoid HOL blocking for other tenants not experiencing throttling
+		if c.cfg.DropRateLimitedBatches && batchIsRateLimited(status) {
+			level.Warn(c.logger).Log("msg", "dropping batch due to rate limiting applied at ingester")
+			c.metrics.droppedBytes.WithLabelValues(c.cfg.URL.Host, tenantID, ReasonRateLimited).Add(bufBytes)
+			c.metrics.droppedEntries.WithLabelValues(c.cfg.URL.Host, tenantID, ReasonRateLimited).Add(float64(entriesCount))
+			return
+		}
+
+		if err == nil {
+			c.metrics.sentBytes.WithLabelValues(c.cfg.URL.Host, tenantID).Add(bufBytes)
+			c.metrics.sentEntries.WithLabelValues(c.cfg.URL.Host, tenantID).Add(float64(entriesCount))
+
+			return
+		}
+
+		// Only retry 429s, 500s and connection-level errors.
+		if status > 0 && !batchIsRateLimited(status) && status/100 != 5 {
+			break
+		}
+
+		level.Debug(c.logger).Log("msg", "error sending batch, will retry", "status", status, "tenant", tenantID, "error", err)
+		c.metrics.batchRetries.WithLabelValues(c.cfg.URL.Host, tenantID).Inc()
+		backoff.Wait()
+
+		// Make sure it sends at least once before checking for retry.
+		if !backoff.Ongoing() {
+			break
+		}
+	}
+
+	level.Error(c.logger).Log("msg", "final error sending batch, no retries left, dropping data", "status", status, "tenant", tenantID, "error", err)
+	// If the reason for the last retry error was rate limiting, count the drops as such, even if the previous errors
+	// were for a different reason
+	dropReason := ReasonGeneric
+	if batchIsRateLimited(status) {
+		dropReason = ReasonRateLimited
+	}
+	c.metrics.droppedBytes.WithLabelValues(c.cfg.URL.Host, tenantID, dropReason).Add(bufBytes)
+	c.metrics.droppedEntries.WithLabelValues(c.cfg.URL.Host, tenantID, dropReason).Add(float64(entriesCount))
+}
+
+func (c *batchClient) send(ctx context.Context, tenantID string, buf []byte) (int, error) {
+	ctx, cancel := context.WithTimeout(ctx, c.cfg.Timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, "POST", c.cfg.URL.String(), bytes.NewReader(buf))
+	if err != nil {
+		return -1, err
+	}
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("User-Agent", userAgent)
+
+	// If the tenant ID is not empty promtail is running in multi-tenant mode, so
+	// we should send it to Loki
+	if tenantID != "" {
+		req.Header.Set("X-Scope-OrgID", tenantID)
+	}
+
+	// Add custom headers on request
+	if len(c.cfg.Headers) > 0 {
+		for k, v := range c.cfg.Headers {
+			if req.Header.Get(k) == "" {
+				req.Header.Add(k, v)
+			} else {
+				level.Warn(c.logger).Log("msg", "custom header key already exists, skipping", "key", k)
+			}
+		}
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return -1, err
+	}
+	defer lokiutil.LogError("closing response body", resp.Body.Close)
+
+	if resp.StatusCode/100 != 2 {
+		scanner := bufio.NewScanner(io.LimitReader(resp.Body, maxErrMsgLen))
+		line := ""
+		if scanner.Scan() {
+			line = scanner.Text()
+		}
+		err = fmt.Errorf("server returned HTTP status %s (%d): %s", resp.Status, resp.StatusCode, line)
+	}
+	return resp.StatusCode, err
+}
+
+func (b *batchClient) stop() {
+	b.cancel()
+}
+
+func batchIsRateLimited(status int) bool {
+	return status == 429
+}

--- a/internal/component/common/loki/client/client.go
+++ b/internal/component/common/loki/client/client.go
@@ -1,44 +1,23 @@
 package client
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"errors"
-	"fmt"
-	"io"
-	"net/http"
-	"strconv"
 	"sync"
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/dskit/backoff"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
-
-	lokiutil "github.com/grafana/loki/v3/pkg/util"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
 	"github.com/grafana/alloy/internal/useragent"
-	"github.com/grafana/alloy/internal/util"
 )
 
 const (
-	contentType  = "application/x-protobuf"
-	maxErrMsgLen = 1024
-
 	// Label reserved to override the tenant ID while processing
 	// pipeline stages
 	ReservedLabelTenantID = "__tenant_id__"
-
-	LatencyLabel = "filename"
-	HostLabel    = "host"
-	ClientLabel  = "client"
-	TenantLabel  = "tenant"
-	ReasonLabel  = "reason"
 
 	ReasonGeneric       = "ingester_error"
 	ReasonRateLimited   = "rate_limited"
@@ -49,83 +28,6 @@ const (
 var Reasons = []string{ReasonGeneric, ReasonRateLimited, ReasonStreamLimited, ReasonLineTooLong}
 
 var userAgent = useragent.Get()
-
-type Metrics struct {
-	encodedBytes                 *prometheus.CounterVec
-	sentBytes                    *prometheus.CounterVec
-	droppedBytes                 *prometheus.CounterVec
-	sentEntries                  *prometheus.CounterVec
-	droppedEntries               *prometheus.CounterVec
-	mutatedEntries               *prometheus.CounterVec
-	mutatedBytes                 *prometheus.CounterVec
-	requestDuration              *prometheus.HistogramVec
-	batchRetries                 *prometheus.CounterVec
-	countersWithHostTenant       []*prometheus.CounterVec
-	countersWithHostTenantReason []*prometheus.CounterVec
-}
-
-func NewMetrics(reg prometheus.Registerer) *Metrics {
-	var m Metrics
-
-	m.encodedBytes = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "loki_write_encoded_bytes_total",
-		Help: "Number of bytes encoded and ready to send.",
-	}, []string{HostLabel, TenantLabel})
-	m.sentBytes = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "loki_write_sent_bytes_total",
-		Help: "Number of bytes sent.",
-	}, []string{HostLabel, TenantLabel})
-	m.droppedBytes = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "loki_write_dropped_bytes_total",
-		Help: "Number of bytes dropped because failed to be sent to the ingester after all retries.",
-	}, []string{HostLabel, TenantLabel, ReasonLabel})
-	m.sentEntries = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "loki_write_sent_entries_total",
-		Help: "Number of log entries sent to the ingester.",
-	}, []string{HostLabel, TenantLabel})
-	m.droppedEntries = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "loki_write_dropped_entries_total",
-		Help: "Number of log entries dropped because failed to be sent to the ingester after all retries.",
-	}, []string{HostLabel, TenantLabel, ReasonLabel})
-	m.mutatedEntries = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "loki_write_mutated_entries_total",
-		Help: "The total number of log entries that have been mutated.",
-	}, []string{HostLabel, TenantLabel, ReasonLabel})
-	m.mutatedBytes = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "loki_write_mutated_bytes_total",
-		Help: "The total number of bytes that have been mutated.",
-	}, []string{HostLabel, TenantLabel, ReasonLabel})
-	m.requestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name: "loki_write_request_duration_seconds",
-		Help: "Duration of send requests.",
-	}, []string{"status_code", HostLabel, TenantLabel})
-	m.batchRetries = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "loki_write_batch_retries_total",
-		Help: "Number of times batches has had to be retried.",
-	}, []string{HostLabel, TenantLabel})
-
-	m.countersWithHostTenant = []*prometheus.CounterVec{
-		m.batchRetries, m.encodedBytes, m.sentBytes, m.sentEntries,
-	}
-
-	m.countersWithHostTenantReason = []*prometheus.CounterVec{
-		m.droppedBytes, m.droppedEntries, m.mutatedEntries, m.mutatedBytes,
-	}
-
-	if reg != nil {
-		m.encodedBytes = util.MustRegisterOrGet(reg, m.encodedBytes).(*prometheus.CounterVec)
-		m.sentBytes = util.MustRegisterOrGet(reg, m.sentBytes).(*prometheus.CounterVec)
-		m.droppedBytes = util.MustRegisterOrGet(reg, m.droppedBytes).(*prometheus.CounterVec)
-		m.sentEntries = util.MustRegisterOrGet(reg, m.sentEntries).(*prometheus.CounterVec)
-		m.droppedEntries = util.MustRegisterOrGet(reg, m.droppedEntries).(*prometheus.CounterVec)
-		m.mutatedEntries = util.MustRegisterOrGet(reg, m.mutatedEntries).(*prometheus.CounterVec)
-		m.mutatedBytes = util.MustRegisterOrGet(reg, m.mutatedBytes).(*prometheus.CounterVec)
-		m.requestDuration = util.MustRegisterOrGet(reg, m.requestDuration).(*prometheus.HistogramVec)
-		m.batchRetries = util.MustRegisterOrGet(reg, m.batchRetries).(*prometheus.CounterVec)
-	}
-
-	return &m
-}
 
 // Client pushes entries to Loki and can be stopped
 type Client interface {
@@ -141,15 +43,13 @@ type client struct {
 	metrics *Metrics
 	logger  log.Logger
 	cfg     Config
-	client  *http.Client
 	entries chan loki.Entry
 
 	once sync.Once
 	wg   sync.WaitGroup
 
-	// ctx is used in any upstream calls from the `client`.
-	ctx        context.Context
-	cancel     context.CancelFunc
+	bc *batchClient
+
 	maxStreams int
 }
 
@@ -159,40 +59,25 @@ func New(metrics *Metrics, cfg Config, maxStreams int, logger log.Logger) (Clien
 }
 
 func newClient(metrics *Metrics, cfg Config, maxStreams int, logger log.Logger) (*client, error) {
-	if cfg.URL.URL == nil {
-		return nil, errors.New("client needs target URL")
-	}
-	if metrics == nil {
-		return nil, errors.New("metrics must be instantiated")
-	}
+	logger = log.With(logger, "component", "client", "host", cfg.URL.Host)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	bc, err := newBatchClient(metrics, logger, cfg)
+	if err != nil {
+		return nil, err
+	}
 
 	c := &client{
-		logger:     log.With(logger, "component", "client", "host", cfg.URL.Host),
+		logger:     logger,
+		bc:         bc,
 		cfg:        cfg,
 		entries:    make(chan loki.Entry),
 		metrics:    metrics,
 		name:       GetClientName(cfg),
-		ctx:        ctx,
-		cancel:     cancel,
 		maxStreams: maxStreams,
 	}
 	if cfg.Name != "" {
 		c.name = cfg.Name
 	}
-
-	err := cfg.Client.Validate()
-	if err != nil {
-		return nil, err
-	}
-
-	c.client, err = config.NewClientFromConfig(cfg.Client, useragent.ProductName, config.WithHTTP2Disabled())
-	if err != nil {
-		return nil, err
-	}
-
-	c.client.Timeout = cfg.Timeout
 
 	c.wg.Add(1)
 	go c.run()
@@ -231,7 +116,7 @@ func (c *client) run() {
 		maxWaitCheck.Stop()
 		// Send all pending batches
 		for tenantID, batch := range batches {
-			c.sendBatch(tenantID, batch)
+			c.bc.sendBatch(context.Background(), tenantID, batch)
 		}
 
 		c.wg.Done()
@@ -257,7 +142,7 @@ func (c *client) run() {
 			// If adding the entry to the batch will increase the size over the max
 			// size allowed, we do send the current batch and then create a new one
 			if batch.sizeBytesAfter(e.Entry) > c.cfg.BatchSize {
-				c.sendBatch(tenantID, batch)
+				c.bc.sendBatch(context.Background(), tenantID, batch)
 
 				batches[tenantID] = newBatch(c.maxStreams, e)
 				break
@@ -282,7 +167,7 @@ func (c *client) run() {
 					continue
 				}
 
-				c.sendBatch(tenantID, batch)
+				c.bc.sendBatch(context.Background(), tenantID, batch)
 				delete(batches, tenantID)
 			}
 		}
@@ -291,113 +176,6 @@ func (c *client) run() {
 
 func (c *client) Chan() chan<- loki.Entry {
 	return c.entries
-}
-
-func batchIsRateLimited(status int) bool {
-	return status == 429
-}
-
-func (c *client) sendBatch(tenantID string, batch *batch) {
-	buf, entriesCount, err := batch.encode()
-	if err != nil {
-		level.Error(c.logger).Log("msg", "error encoding batch", "error", err)
-		return
-	}
-	bufBytes := float64(len(buf))
-	c.metrics.encodedBytes.WithLabelValues(c.cfg.URL.Host, tenantID).Add(bufBytes)
-
-	backoff := backoff.New(c.ctx, c.cfg.BackoffConfig)
-	var status int
-	for {
-		start := time.Now()
-		// send uses `timeout` internally, so `context.Background` is good enough.
-		status, err = c.send(context.Background(), tenantID, buf)
-
-		c.metrics.requestDuration.WithLabelValues(strconv.Itoa(status), c.cfg.URL.Host, tenantID).Observe(time.Since(start).Seconds())
-
-		// Immediately drop rate limited batches to avoid HOL blocking for other tenants not experiencing throttling
-		if c.cfg.DropRateLimitedBatches && batchIsRateLimited(status) {
-			level.Warn(c.logger).Log("msg", "dropping batch due to rate limiting applied at ingester")
-			c.metrics.droppedBytes.WithLabelValues(c.cfg.URL.Host, tenantID, ReasonRateLimited).Add(bufBytes)
-			c.metrics.droppedEntries.WithLabelValues(c.cfg.URL.Host, tenantID, ReasonRateLimited).Add(float64(entriesCount))
-			return
-		}
-
-		if err == nil {
-			c.metrics.sentBytes.WithLabelValues(c.cfg.URL.Host, tenantID).Add(bufBytes)
-			c.metrics.sentEntries.WithLabelValues(c.cfg.URL.Host, tenantID).Add(float64(entriesCount))
-
-			return
-		}
-
-		// Only retry 429s, 500s and connection-level errors.
-		if status > 0 && !batchIsRateLimited(status) && status/100 != 5 {
-			break
-		}
-
-		level.Debug(c.logger).Log("msg", "error sending batch, will retry", "status", status, "tenant", tenantID, "error", err)
-		c.metrics.batchRetries.WithLabelValues(c.cfg.URL.Host, tenantID).Inc()
-		backoff.Wait()
-
-		// Make sure it sends at least once before checking for retry.
-		if !backoff.Ongoing() {
-			break
-		}
-	}
-
-	level.Error(c.logger).Log("msg", "final error sending batch, no retries left, dropping data", "status", status, "tenant", tenantID, "error", err)
-	// If the reason for the last retry error was rate limiting, count the drops as such, even if the previous errors
-	// were for a different reason
-	dropReason := ReasonGeneric
-	if batchIsRateLimited(status) {
-		dropReason = ReasonRateLimited
-	}
-	c.metrics.droppedBytes.WithLabelValues(c.cfg.URL.Host, tenantID, dropReason).Add(bufBytes)
-	c.metrics.droppedEntries.WithLabelValues(c.cfg.URL.Host, tenantID, dropReason).Add(float64(entriesCount))
-}
-
-func (c *client) send(ctx context.Context, tenantID string, buf []byte) (int, error) {
-	ctx, cancel := context.WithTimeout(ctx, c.cfg.Timeout)
-	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, "POST", c.cfg.URL.String(), bytes.NewReader(buf))
-	if err != nil {
-		return -1, err
-	}
-	req.Header.Set("Content-Type", contentType)
-	req.Header.Set("User-Agent", userAgent)
-
-	// If the tenant ID is not empty promtail is running in multi-tenant mode, so
-	// we should send it to Loki
-	if tenantID != "" {
-		req.Header.Set("X-Scope-OrgID", tenantID)
-	}
-
-	// Add custom headers on request
-	if len(c.cfg.Headers) > 0 {
-		for k, v := range c.cfg.Headers {
-			if req.Header.Get(k) == "" {
-				req.Header.Add(k, v)
-			} else {
-				level.Warn(c.logger).Log("msg", "custom header key already exists, skipping", "key", k)
-			}
-		}
-	}
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return -1, err
-	}
-	defer lokiutil.LogError("closing response body", resp.Body.Close)
-
-	if resp.StatusCode/100 != 2 {
-		scanner := bufio.NewScanner(io.LimitReader(resp.Body, maxErrMsgLen))
-		line := ""
-		if scanner.Scan() {
-			line = scanner.Text()
-		}
-		err = fmt.Errorf("server returned HTTP status %s (%d): %s", resp.Status, resp.StatusCode, line)
-	}
-	return resp.StatusCode, err
 }
 
 func (c *client) getTenantID(labels model.LabelSet) string {
@@ -424,8 +202,8 @@ func (c *client) Stop() {
 
 // StopNow stops the client without retries
 func (c *client) StopNow() {
-	// cancel will stop retrying http requests.
-	c.cancel()
+	// stop batch client from retrying requests.
+	c.bc.stop()
 	c.Stop()
 }
 

--- a/internal/component/common/loki/client/client_test.go
+++ b/internal/component/common/loki/client/client_test.go
@@ -598,13 +598,13 @@ func TestClient_StopNow(t *testing.T) {
 
 			// StopNow should have cancelled client's ctx
 			cc := cl.(*client)
-			require.NoError(t, cc.ctx.Err())
+			require.NoError(t, cc.bc.ctx.Err())
 
 			// Stop the client: it waits until the current batch is sent
 			cl.StopNow()
 			close(receivedReqsChan)
 
-			require.Error(t, cc.ctx.Err()) // non-nil error if its cancelled.
+			require.Error(t, cc.bc.ctx.Err()) // non-nil error if its cancelled.
 
 			// Get all push requests received on the server side
 			receivedReqs := make([]utils.RemoteWriteRequest, 0)

--- a/internal/component/common/loki/client/manager.go
+++ b/internal/component/common/loki/client/manager.go
@@ -157,6 +157,7 @@ func NewManager(metrics *Metrics, logger log.Logger, maxStreams int, reg prometh
 		pairs:   pairs,
 		entries: make(chan loki.Entry),
 	}
+
 	if walCfg.Enabled {
 		manager.name = buildManagerName("wal", clientCfgs...)
 		manager.startWithConsume()

--- a/internal/component/common/loki/client/metrics.go
+++ b/internal/component/common/loki/client/metrics.go
@@ -5,6 +5,89 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	HostLabel   = "host"
+	TenantLabel = "tenant"
+	ReasonLabel = "reason"
+)
+
+type Metrics struct {
+	encodedBytes                 *prometheus.CounterVec
+	sentBytes                    *prometheus.CounterVec
+	droppedBytes                 *prometheus.CounterVec
+	sentEntries                  *prometheus.CounterVec
+	droppedEntries               *prometheus.CounterVec
+	mutatedEntries               *prometheus.CounterVec
+	mutatedBytes                 *prometheus.CounterVec
+	requestDuration              *prometheus.HistogramVec
+	batchRetries                 *prometheus.CounterVec
+	countersWithHostTenant       []*prometheus.CounterVec
+	countersWithHostTenantReason []*prometheus.CounterVec
+}
+
+func NewMetrics(reg prometheus.Registerer) *Metrics {
+	var m Metrics
+
+	m.encodedBytes = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "loki_write_encoded_bytes_total",
+		Help: "Number of bytes encoded and ready to send.",
+	}, []string{HostLabel, TenantLabel})
+	m.sentBytes = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "loki_write_sent_bytes_total",
+		Help: "Number of bytes sent.",
+	}, []string{HostLabel, TenantLabel})
+	m.droppedBytes = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "loki_write_dropped_bytes_total",
+		Help: "Number of bytes dropped because failed to be sent to the ingester after all retries.",
+	}, []string{HostLabel, TenantLabel, ReasonLabel})
+	m.sentEntries = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "loki_write_sent_entries_total",
+		Help: "Number of log entries sent to the ingester.",
+	}, []string{HostLabel, TenantLabel})
+	m.droppedEntries = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "loki_write_dropped_entries_total",
+		Help: "Number of log entries dropped because failed to be sent to the ingester after all retries.",
+	}, []string{HostLabel, TenantLabel, ReasonLabel})
+	m.mutatedEntries = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "loki_write_mutated_entries_total",
+		Help: "The total number of log entries that have been mutated.",
+	}, []string{HostLabel, TenantLabel, ReasonLabel})
+	m.mutatedBytes = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "loki_write_mutated_bytes_total",
+		Help: "The total number of bytes that have been mutated.",
+	}, []string{HostLabel, TenantLabel, ReasonLabel})
+	m.requestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "loki_write_request_duration_seconds",
+		Help: "Duration of send requests.",
+	}, []string{"status_code", HostLabel, TenantLabel})
+	m.batchRetries = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "loki_write_batch_retries_total",
+		Help: "Number of times batches has had to be retried.",
+	}, []string{HostLabel, TenantLabel})
+
+	m.countersWithHostTenant = []*prometheus.CounterVec{
+		m.batchRetries, m.encodedBytes, m.sentBytes, m.sentEntries,
+	}
+
+	m.countersWithHostTenantReason = []*prometheus.CounterVec{
+		m.droppedBytes, m.droppedEntries, m.mutatedEntries, m.mutatedBytes,
+	}
+
+	if reg != nil {
+		m.encodedBytes = util.MustRegisterOrGet(reg, m.encodedBytes).(*prometheus.CounterVec)
+		m.sentBytes = util.MustRegisterOrGet(reg, m.sentBytes).(*prometheus.CounterVec)
+		m.droppedBytes = util.MustRegisterOrGet(reg, m.droppedBytes).(*prometheus.CounterVec)
+		m.sentEntries = util.MustRegisterOrGet(reg, m.sentEntries).(*prometheus.CounterVec)
+		m.droppedEntries = util.MustRegisterOrGet(reg, m.droppedEntries).(*prometheus.CounterVec)
+		m.mutatedEntries = util.MustRegisterOrGet(reg, m.mutatedEntries).(*prometheus.CounterVec)
+		m.mutatedBytes = util.MustRegisterOrGet(reg, m.mutatedBytes).(*prometheus.CounterVec)
+		m.requestDuration = util.MustRegisterOrGet(reg, m.requestDuration).(*prometheus.HistogramVec)
+		m.batchRetries = util.MustRegisterOrGet(reg, m.batchRetries).(*prometheus.CounterVec)
+	}
+
+	return &m
+}
+
 type QueueClientMetrics struct {
 	lastReadTimestamp *prometheus.GaugeVec
 }

--- a/internal/component/common/loki/client/queue_client.go
+++ b/internal/component/common/loki/client/queue_client.go
@@ -179,8 +179,6 @@ func newQueueClient(metrics *Metrics, qcMetrics *QueueClientMetrics, cfg Config,
 		return nil, err
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-
 	c := &queueClient{
 		logger:       log.With(logger, "component", "client", "host", cfg.URL.Host),
 		cfg:          cfg,
@@ -196,8 +194,6 @@ func newQueueClient(metrics *Metrics, qcMetrics *QueueClientMetrics, cfg Config,
 		series:        make(map[chunks.HeadSeriesRef]model.LabelSet),
 		seriesSegment: make(map[chunks.HeadSeriesRef]int),
 
-		ctx:        ctx,
-		cancel:     cancel,
 		maxStreams: maxStreams,
 	}
 

--- a/internal/component/common/loki/wal/writer.go
+++ b/internal/component/common/loki/wal/writer.go
@@ -115,10 +115,8 @@ func NewWriter(walCfg Config, logger log.Logger, reg prometheus.Registerer) (*Wr
 }
 
 func (wrt *Writer) start(maxSegmentAge time.Duration) {
-	wrt.wg.Add(1)
 	// main WAL writer routine
-	go func() {
-		defer wrt.wg.Done()
+	wrt.wg.Go(func() {
 		for e := range wrt.entries {
 			if err := wrt.entryWriter.WriteEntry(e, wrt.wal, wrt.log); err != nil {
 				level.Error(wrt.log).Log("msg", "failed to write entry", "err", err)
@@ -135,17 +133,12 @@ func (wrt *Writer) start(maxSegmentAge time.Duration) {
 			}
 			wrt.writeSubscribersLock.RUnlock()
 		}
-	}()
+	})
 	// WAL cleanup routine that cleans old segments
-	wrt.wg.Add(1)
-	go func() {
-		defer wrt.wg.Done()
+	wrt.wg.Go(func() {
 		// By cleaning every 10th of the configured threshold for considering a segment old, we are allowing a maximum slip
 		// of 10%. If the configured time is 1 hour, that'd be 6 minutes.
-		triggerEvery := maxSegmentAge / 10
-		if triggerEvery < minimumCleanSegmentsEvery {
-			triggerEvery = minimumCleanSegmentsEvery
-		}
+		triggerEvery := max(maxSegmentAge/10, minimumCleanSegmentsEvery)
 		trigger := time.NewTicker(triggerEvery)
 		for {
 			select {
@@ -159,7 +152,7 @@ func (wrt *Writer) start(maxSegmentAge time.Duration) {
 				return
 			}
 		}
-	}()
+	})
 }
 
 func (wrt *Writer) Chan() chan<- loki.Entry {


### PR DESCRIPTION
#### PR Description
When researching https://github.com/grafana/alloy/issues/4728 I noticed that we duplicate some things between 
`Client` and `QueueClient`, specifically the sending part. 

Just to clean them up a bit and align the implementation I added `batchClient` that they both use.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
