### PR TITLE
Remove Slicelabels Tag to Enable Stringlabels 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         # TODO: Try enabling caching later. It might use up too much disk space on runners so needs extra testing.
         cache: false
     - run: make generate-ui
-    - run: GO_TAGS="builtinassets promtail_journal_enabled slicelabels" GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} GOARM= make alloy
+    - run: GO_TAGS="builtinassets promtail_journal_enabled" GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} GOARM= make alloy
 
   build_linux_boringcrypto:
     name: Build on Linux (boringcrypto)
@@ -64,7 +64,7 @@ jobs:
         # TODO: Try enabling caching later. It might use up too much disk space on runners so needs extra testing.
         cache: false
     - run: make generate-ui
-    - run: GO_TAGS="builtinassets promtail_journal_enabled slicelabels" GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} GOARM= GOEXPERIMENT=boringcrypto make alloy
+    - run: GO_TAGS="builtinassets promtail_journal_enabled" GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} GOARM= GOEXPERIMENT=boringcrypto make alloy
 
   build_mac_intel:
     name: Build on MacOS (Intel)
@@ -81,7 +81,7 @@ jobs:
         # TODO: Try enabling caching later. It might use up too much disk space on runners so needs extra testing.
         cache: false
     - run: make generate-ui
-    - run: GO_TAGS="builtinassets slicelabels" GOOS=darwin GOARCH=amd64 GOARM= make alloy
+    - run: GO_TAGS="builtinassets" GOOS=darwin GOARCH=amd64 GOARM= make alloy
 
   build_mac_arm:
     name: Build on MacOS (ARM)
@@ -98,7 +98,7 @@ jobs:
         # TODO: Try enabling caching later. It might use up too much disk space on runners so needs extra testing.
         cache: false
     - run: make generate-ui
-    - run: CGO_LDFLAGS="-ld_classic $CGO_LDFLAGS" GO_TAGS="builtinassets slicelabels" GOOS=darwin GOARCH=arm64 GOARM= make alloy
+    - run: CGO_LDFLAGS="-ld_classic $CGO_LDFLAGS" GO_TAGS="builtinassets" GOOS=darwin GOARCH=arm64 GOARM= make alloy
 
   build_windows:
     name: Build on Windows (AMD64)
@@ -115,7 +115,7 @@ jobs:
         # TODO: Try enabling caching later. It might use up too much disk space on runners so needs extra testing.
         cache: false
     - run: make generate-ui
-    - run: echo "GO_TAGS=builtinassets slicelabels" | Out-File -FilePath $env:GITHUB_ENV -Append
+    - run: echo "GO_TAGS=builtinassets" | Out-File -FilePath $env:GITHUB_ENV -Append
     - run: echo "GOOS=windows" | Out-File -FilePath $env:GITHUB_ENV -Append
     - run: echo "GOARCH=amd64" | Out-File -FilePath $env:GITHUB_ENV -Append
     - run: make alloy
@@ -141,4 +141,4 @@ jobs:
         # TODO: Try enabling caching later. It might use up too much disk space on runners so needs extra testing.
         cache: false
     - run: make generate-ui
-    - run: GO_TAGS="builtinassets slicelabels" GOOS=freebsd GOARCH=amd64 GOARM= make alloy
+    - run: GO_TAGS="builtinassets" GOOS=freebsd GOARCH=amd64 GOARM= make alloy

--- a/.github/workflows/fuzz-go.yml
+++ b/.github/workflows/fuzz-go.yml
@@ -107,7 +107,7 @@ jobs:
           # a different module.
           cd "${{ matrix.package }}"
           # Note: -parallel=1 is required to avoid race conditions in the fuzzer until https://github.com/golang/go/issues/56238 is fixed.
-          go test -tags=slicelabels -parallel=1 -fuzz="${{ matrix.function }}\$" -run="${{ matrix.function }}\$" -fuzztime="${FUZZ_TIME}" .
+          go test -parallel=1 -fuzz="${{ matrix.function }}\$" -run="${{ matrix.function }}\$" -fuzztime="${FUZZ_TIME}" .
         env:
           FUZZ_TIME: ${{ inputs.fuzz-time }}
 

--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -34,4 +34,4 @@ jobs:
         go-version-file: go.mod
         # TODO: Enable caching later.
         cache: false
-    - run: K8S_USE_DOCKER_NETWORK=1 GO_TAGS="slicelabels" make test
+    - run: K8S_USE_DOCKER_NETWORK=1 make test

--- a/.github/workflows/test_mac.yml
+++ b/.github/workflows/test_mac.yml
@@ -29,4 +29,4 @@ jobs:
         go-version-file: go.mod
         cache: true
     - name: Test
-      run: CGO_LDFLAGS="-ld_classic $CGO_LDFLAGS" make GO_TAGS="nodocker,slicelabels" test
+      run: CGO_LDFLAGS="-ld_classic $CGO_LDFLAGS" make GO_TAGS="nodocker" test

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -24,4 +24,5 @@ jobs:
         go-version-file: go.mod
         cache: false
 
-    - run: make GO_TAGS="nodocker,slicelabels" test
+    - run: make GO_TAGS="nodocker" test
+

--- a/.github/workflows/test_pyroscope_pr.yml
+++ b/.github/workflows/test_pyroscope_pr.yml
@@ -26,4 +26,4 @@ jobs:
           go-version-file: go.mod
           cache: false
 
-      - run: sudo GO_TAGS="slicelabels" make test-pyroscope
+      - run: sudo make test-pyroscope

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -31,5 +31,5 @@ jobs:
         # We'll need to make sure the same cache is reused by the workflow to build Windows binaries.
         cache: false
     - name: Test
-      run: '& "C:/Program Files/git/bin/bash.exe" -c ''go test -tags="nodocker,nonetwork,slicelabels"
+      run: '& "C:/Program Files/git/bin/bash.exe" -c ''go test -tags="nodocker,nonetwork"
         $(go list ./... |  grep -v -E "/integration-tests/|/integration-tests-k8s/")'''

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,4 @@
 version: "2"
-run:
-  build-tags:
-    - slicelabels
 linters:
   enable:
     - depguard    # Allow/denylist specific imports

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     GOOS="$TARGETOS" GOARCH="$TARGETARCH" GOARM=${TARGETVARIANT#v} \
     RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} \
-    GO_TAGS="netgo builtinassets promtail_journal_enabled slicelabels" \
+    GO_TAGS="netgo builtinassets promtail_journal_enabled" \
     GOEXPERIMENT=${GOEXPERIMENT} \
     make alloy
 

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -77,7 +77,7 @@ SHELL ["cmd", "/S", "/C"]
 # we can before moving on to the next step.
 RUN ""C:\Program Files\git\bin\bash.exe" -c "RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} make generate-ui && rm -rf internal/web/ui/node_modules""
 
-RUN ""C:\Program Files\git\bin\bash.exe" -c "RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} GO_TAGS=\"builtinassets slicelabels ${GO_TAGS}\" make alloy""
+RUN ""C:\Program Files\git\bin\bash.exe" -c "RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} GO_TAGS=\"builtinassets ${GO_TAGS}\" make alloy""
 # In this case, we're separating the clean command from make alloy to avoid an issue where access to some mod cache
 # files is denied immediately after make alloy, for example:
 # "go: remove C:\go\pkg\mod\golang.org\toolchain@v0.0.1-go1.22.3.windows-amd64\bin\go.exe: Access is denied."

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,6 @@ GOARM                ?= $(shell go env GOARM)
 CGO_ENABLED          ?= 1
 RELEASE_BUILD        ?= 0
 GOEXPERIMENT         ?= $(shell go env GOEXPERIMENT)
-GO_TAGS              ?= slicelabels
 
 # Determine the golangci-lint binary path using Make functions where possible.
 # Priority: GOBIN, GOPATH/bin, PATH (via shell), Fallback Name.

--- a/tools/ci/docker-containers-windows
+++ b/tools/ci/docker-containers-windows
@@ -103,7 +103,7 @@ case "$TARGET_CONTAINER" in
       --build-arg BASE_IMAGE_GO="$BASE_IMAGE_GO" \
       --build-arg BASE_IMAGE_WINDOWS="$BASE_IMAGE_WINDOWS" \
       --build-arg GOEXPERIMENT=cngcrypto     \
-      --build-arg GO_TAGS="cngcrypto slicelabels" \
+      --build-arg GO_TAGS="cngcrypto" \
       -f ./Dockerfile.windows                \
       .
 
@@ -143,7 +143,7 @@ case "$TARGET_CONTAINER" in
       --build-arg BASE_IMAGE_GO="$BASE_IMAGE_GO" \
       --build-arg BASE_IMAGE_WINDOWS="$BASE_IMAGE_WINDOWS" \
       --build-arg GOEXPERIMENT=cngcrypto   \
-      --build-arg GO_TAGS="cngcrypto slicelabels" \
+      --build-arg GO_TAGS="cngcrypto" \
       -f ./Dockerfile.windows              \
       .
 

--- a/tools/make/packaging.mk
+++ b/tools/make/packaging.mk
@@ -32,37 +32,37 @@ dist-alloy-binaries: dist/alloy-linux-amd64                    \
                      dist/alloy-windows-amd64.exe              \
                      dist/alloy-freebsd-amd64
 
-dist/alloy-linux-amd64: GO_TAGS += netgo builtinassets promtail_journal_enabled slicelabels
+dist/alloy-linux-amd64: GO_TAGS += netgo builtinassets promtail_journal_enabled
 dist/alloy-linux-amd64: GOOS    := linux
 dist/alloy-linux-amd64: GOARCH  := amd64
 dist/alloy-linux-amd64: generate-ui
 	$(PACKAGING_VARS) ALLOY_BINARY=$@ "$(MAKE)" -f $(PARENT_MAKEFILE) alloy
 
-dist/alloy-linux-arm64: GO_TAGS += netgo builtinassets promtail_journal_enabled slicelabels
+dist/alloy-linux-arm64: GO_TAGS += netgo builtinassets promtail_journal_enabled
 dist/alloy-linux-arm64: GOOS    := linux
 dist/alloy-linux-arm64: GOARCH  := arm64
 dist/alloy-linux-arm64: generate-ui
 	$(PACKAGING_VARS) ALLOY_BINARY=$@ "$(MAKE)" -f $(PARENT_MAKEFILE) alloy
 
-dist/alloy-linux-ppc64le: GO_TAGS += netgo builtinassets promtail_journal_enabled slicelabels
+dist/alloy-linux-ppc64le: GO_TAGS += netgo builtinassets promtail_journal_enabled
 dist/alloy-linux-ppc64le: GOOS    := linux
 dist/alloy-linux-ppc64le: GOARCH  := ppc64le
 dist/alloy-linux-ppc64le: generate-ui
 	$(PACKAGING_VARS) ALLOY_BINARY=$@ "$(MAKE)" -f $(PARENT_MAKEFILE) alloy
 
-dist/alloy-linux-s390x: GO_TAGS += netgo builtinassets promtail_journal_enabled slicelabels
+dist/alloy-linux-s390x: GO_TAGS += netgo builtinassets promtail_journal_enabled
 dist/alloy-linux-s390x: GOOS    := linux
 dist/alloy-linux-s390x: GOARCH  := s390x
 dist/alloy-linux-s390x: generate-ui
 	$(PACKAGING_VARS) ALLOY_BINARY=$@ "$(MAKE)" -f $(PARENT_MAKEFILE) alloy
 
-dist/alloy-darwin-amd64: GO_TAGS += netgo builtinassets slicelabels
+dist/alloy-darwin-amd64: GO_TAGS += netgo builtinassets
 dist/alloy-darwin-amd64: GOOS    := darwin
 dist/alloy-darwin-amd64: GOARCH  := amd64
 dist/alloy-darwin-amd64: generate-ui
 	$(PACKAGING_VARS) ALLOY_BINARY=$@ "$(MAKE)" -f $(PARENT_MAKEFILE) alloy
 
-dist/alloy-darwin-arm64: GO_TAGS += netgo builtinassets slicelabels
+dist/alloy-darwin-arm64: GO_TAGS += netgo builtinassets
 dist/alloy-darwin-arm64: GOOS    := darwin
 dist/alloy-darwin-arm64: GOARCH  := arm64
 dist/alloy-darwin-arm64: generate-ui
@@ -73,7 +73,7 @@ dist/alloy-darwin-arm64: generate-ui
 #
 # TODO(rfratto): add netgo back to Windows builds if a version of Go is
 # released which natively supports resolving DNS short names on Windows.
-dist/alloy-windows-amd64.exe: GO_TAGS += builtinassets slicelabels
+dist/alloy-windows-amd64.exe: GO_TAGS += builtinassets
 dist/alloy-windows-amd64.exe: GOOS    := windows
 dist/alloy-windows-amd64.exe: GOARCH  := amd64
 dist/alloy-windows-amd64.exe: generate-ui generate-winmanifest
@@ -84,7 +84,7 @@ dist/alloy-windows-amd64.exe: generate-ui generate-winmanifest
 #
 # TODO(rfratto): add netgo back to Windows builds if a version of Go is
 # released which natively supports resolving DNS short names on Windows.
-dist/alloy-freebsd-amd64: GO_TAGS += netgo builtinassets slicelabels
+dist/alloy-freebsd-amd64: GO_TAGS += netgo builtinassets
 dist/alloy-freebsd-amd64: GOOS    := freebsd
 dist/alloy-freebsd-amd64: GOARCH  := amd64
 dist/alloy-freebsd-amd64: generate-ui
@@ -97,14 +97,14 @@ dist/alloy-freebsd-amd64: generate-ui
 dist-alloy-boringcrypto-binaries: dist/alloy-boringcrypto-linux-amd64 \
                                   dist/alloy-boringcrypto-linux-arm64
 
-dist/alloy-boringcrypto-linux-amd64: GO_TAGS      += netgo builtinassets promtail_journal_enabled slicelabels
+dist/alloy-boringcrypto-linux-amd64: GO_TAGS      += netgo builtinassets promtail_journal_enabled
 dist/alloy-boringcrypto-linux-amd64: GOEXPERIMENT := boringcrypto
 dist/alloy-boringcrypto-linux-amd64: GOOS         := linux
 dist/alloy-boringcrypto-linux-amd64: GOARCH       := amd64
 dist/alloy-boringcrypto-linux-amd64: generate-ui
 	$(PACKAGING_VARS) ALLOY_BINARY=$@ "$(MAKE)" -f $(PARENT_MAKEFILE) alloy
 
-dist/alloy-boringcrypto-linux-arm64: GO_TAGS      += netgo builtinassets promtail_journal_enabled slicelabels
+dist/alloy-boringcrypto-linux-arm64: GO_TAGS      += netgo builtinassets promtail_journal_enabled
 dist/alloy-boringcrypto-linux-arm64: GOEXPERIMENT := boringcrypto
 dist/alloy-boringcrypto-linux-arm64: GOOS         := linux
 dist/alloy-boringcrypto-linux-arm64: GOARCH       := arm64
@@ -123,7 +123,7 @@ dist/alloy-boringcrypto-linux-arm64: generate-ui
 
 dist-alloy-service-binaries: dist.temp/alloy-service-windows-amd64.exe
 
-dist.temp/alloy-service-windows-amd64.exe: GO_TAGS += builtinassets slicelabels
+dist.temp/alloy-service-windows-amd64.exe: GO_TAGS += builtinassets
 dist.temp/alloy-service-windows-amd64.exe: GOOS    := windows
 dist.temp/alloy-service-windows-amd64.exe: GOARCH  := amd64
 dist.temp/alloy-service-windows-amd64.exe: generate-ui generate-winmanifest


### PR DESCRIPTION
#### PR Description
Enables stringlabels in alloy. Since [prometheus was upgraded](https://github.com/grafana/alloy/pull/4671), stringlabels are the default and so we had to include the `slicelabels` tag in order to have things compile whilst there were still stringlabel incompatible code - this PR removes those tags

#### Which issue(s) this PR fixes
https://github.com/grafana/alloy/issues/4323

#### PR Checklist
- [ ] CHANGELOG.md updated <- shall I add this to the changelog? it should not be user facing - but it could be argued that changes in memory are user facing if they are monitoring this 🤷 