### PR TITLE
test(beyla): add missing trace attribute

### DIFF
--- a/internal/cmd/integration-tests/tests/beyla/config.alloy
+++ b/internal/cmd/integration-tests/tests/beyla/config.alloy
@@ -11,6 +11,18 @@ beyla.ebpf "default" {
       ]
   }
   output {
+    traces = [otelcol.processor.attributes.beyla.input]
+  }
+}
+
+otelcol.processor.attributes "beyla" {
+  action {
+    key = "test_name"
+    value = "beyla"
+    action = "insert"
+  }
+
+  output {
     traces = [otelcol.processor.batch.beyla.input]
   }
 }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

`TestBeylaTraces` integration test fails to find traces matching:

- service.name: "main"
- test_name: "beyla"

This PR fixes this by adding the `test_name: "beyla"` attribute to traces using a `otelcol.processor.attributes` component.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
