### PR TITLE
database_observability: Reduce info level logging noise for explain plans

### DIFF
--- a/internal/component/database_observability/mysql/collector/explain_plans.go
+++ b/internal/component/database_observability/mysql/collector/explain_plans.go
@@ -534,7 +534,7 @@ func (c *ExplainPlans) populateQueryCache(ctx context.Context) error {
 	}
 	// Calculate batch size based on current cache size
 	c.currentBatchSize = int(math.Ceil(float64(len(c.queryCache)) * c.perScrapeRatio))
-	level.Info(c.logger).Log("msg", "fetched digests", "count", len(c.queryCache), "batch_size", c.currentBatchSize)
+	level.Debug(c.logger).Log("msg", "populated query cache", "count", len(c.queryCache), "batch_size", c.currentBatchSize)
 	return nil
 }
 
@@ -557,7 +557,7 @@ func (c *ExplainPlans) fetchExplainPlans(ctx context.Context) error {
 			if *nonRecoverableFailureOccurred {
 				qi.failureCount++
 				c.queryDenylist[qi.uniqueKey] = qi
-				level.Info(c.logger).Log("msg", "query denylisted", "digest", qi.digest)
+				level.Debug(c.logger).Log("msg", "query denylisted", "digest", qi.digest)
 			}
 			delete(c.queryCache, qi.uniqueKey)
 			processedCount++

--- a/internal/component/database_observability/mysql/collector/explain_plans.go
+++ b/internal/component/database_observability/mysql/collector/explain_plans.go
@@ -506,11 +506,6 @@ func (c *ExplainPlans) populateQueryCache(ctx context.Context) error {
 
 	// Populate cache
 	for rs.Next() {
-		if err := rs.Err(); err != nil {
-			level.Error(c.logger).Log("msg", "failed to iterate rs digests for explain plans", "err", err)
-			return err
-		}
-
 		var schemaName, digest, queryText string
 		var ls time.Time
 		if err = rs.Scan(&schemaName, &digest, &queryText, &ls); err != nil {
@@ -532,6 +527,12 @@ func (c *ExplainPlans) populateQueryCache(ctx context.Context) error {
 			c.lastSeen = ls
 		}
 	}
+
+	if err := rs.Err(); err != nil {
+		level.Error(c.logger).Log("msg", "failed to iterate digest rows for explain plans", "err", err)
+		return err
+	}
+
 	// Calculate batch size based on current cache size
 	c.currentBatchSize = int(math.Ceil(float64(len(c.queryCache)) * c.perScrapeRatio))
 	level.Debug(c.logger).Log("msg", "populated query cache", "count", len(c.queryCache), "batch_size", c.currentBatchSize)

--- a/internal/component/database_observability/postgres/collector/explain_plan.go
+++ b/internal/component/database_observability/postgres/collector/explain_plan.go
@@ -339,6 +339,11 @@ func (c *ExplainPlan) populateQueryCache(ctx context.Context) error {
 	defer rs.Close()
 
 	for rs.Next() {
+		if err := rs.Err(); err != nil {
+			level.Error(c.logger).Log("msg", "failed to iterate rs digests for explain plans", "err", err)
+			return err
+		}
+
 		var datname, queryId, query string
 		var calls int64
 		var ls time.Time
@@ -374,7 +379,7 @@ func (c *ExplainPlan) populateQueryCache(ctx context.Context) error {
 	}
 
 	c.currentBatchSize = int(math.Ceil(float64(len(c.queryCache)) * c.perScrapeRatio))
-	level.Info(c.logger).Log("msg", "populated query cache", "count", len(c.queryCache), "batch_size", c.currentBatchSize)
+	level.Debug(c.logger).Log("msg", "populated query cache", "count", len(c.queryCache), "batch_size", c.currentBatchSize)
 	return nil
 }
 

--- a/internal/component/database_observability/postgres/collector/explain_plan.go
+++ b/internal/component/database_observability/postgres/collector/explain_plan.go
@@ -328,7 +328,6 @@ func (c *ExplainPlan) populateQueryCache(ctx context.Context) error {
 
 	rs, err := c.dbConnection.QueryContext(ctx, selectStatement)
 	if err != nil {
-		level.Error(c.logger).Log("msg", "failed to fetch digests for explain plans", "err", err)
 		return fmt.Errorf("failed to fetch digests for explain plans: %w", err)
 	}
 	defer rs.Close()
@@ -395,7 +394,7 @@ func (c *ExplainPlan) fetchExplainPlans(ctx context.Context) error {
 			if *nonRecoverableFailureOccurred {
 				qi.failureCount++
 				c.queryDenylist[qi.uniqueKey] = qi
-				level.Info(c.logger).Log("msg", "query denylisted", "query_id", qi.queryId)
+				level.Debug(c.logger).Log("msg", "query denylisted", "query_id", qi.queryId)
 			} else {
 				c.finishedQueryCache[qi.uniqueKey] = qi
 			}


### PR DESCRIPTION
#### PR Description
We were logging a few things at `info` that belonged at `debug`.

Also caught a missing error check, and sync'd up the log messages a bit better.

#### Which issue(s) this PR fixes
Fixes grafana/grafana-dbo11y-app#1789
