### PR TITLE
database_observability: consider idle states to calculate Postgres query sample times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,10 @@ Main (unreleased)
   - `explain_plans`
     - added the explain plan collector (@rgeyer)
     - collector now passes queries more permissively, expressly to allow queries beginning in `with` (@rgeyer)
-  - add `user` field to wait events within `query_samples` collector (@gaantunes)
-  - rework the query samples collector to buffer per-query execution state across scrapes and emit finalized entries (@gaantunes)
+  - `query_samples`
+    - add `user` field to wait events within `query_samples` collector (@gaantunes)
+    - rework the query samples collector to buffer per-query execution state across scrapes and emit finalized entries (@gaantunes)
+    - process turned idle rows to calculate finalization times precisely and emit first seen idle rows (@gaantunes)
   - enable `explain_plans` collector by default (@rgeyer)
   - safely generate server_id when UDP socket used for database connection (@matthewnolf)
 

--- a/internal/component/database_observability/postgres/collector/query_samples.go
+++ b/internal/component/database_observability/postgres/collector/query_samples.go
@@ -26,6 +26,9 @@ const (
 const (
 	queryTextClause = ", s.query"
 	stateActive     = "active"
+    stateIdle           = "idle"
+    stateIdleTxnAborted = "idle in transaction (aborted)"
+    stateIdleTxn        = "idle in transaction"
 )
 
 const selectPgStatActivity = `
@@ -55,7 +58,6 @@ const selectPgStatActivity = `
 		JOIN pg_database d ON s.datid = d.oid AND NOT d.datistemplate AND d.datallowconn
 	WHERE
 		s.pid != pg_backend_pid() AND
-		s.state != 'idle' AND
 		(
 			s.backend_type != 'client backend' OR
 			(
@@ -112,6 +114,8 @@ type QuerySamples struct {
 
 	// in-memory state of running samples
 	samples map[SampleKey]*SampleState
+    // keep track of keys that were already emitted to avoid duplicates
+    emitted map[SampleKey]time.Time
 }
 
 // SampleKey uses (PID, QueryID, QueryStartNs) so concurrent executions of the same
@@ -137,6 +141,9 @@ type SampleState struct {
 	LastSeenAt  time.Time
 	LastCpuTime string // last cpu_time observed under CPU condition
 	tracker     WaitEventTracker
+    // EndOverride is used to compute durations and timestamps when a query
+    // transitioned to idle or was only observed as idle.
+    EndOverride sql.NullTime
 }
 
 // WaitEventTracker coalesces consecutive identical wait events
@@ -186,7 +193,8 @@ func NewQuerySamples(args QuerySamplesArguments) (*QuerySamples, error) {
 		disableQueryRedaction: args.DisableQueryRedaction,
 		logger:                log.With(args.Logger, "collector", QuerySamplesCollector),
 		running:               &atomic.Bool{},
-		samples:               map[SampleKey]*SampleState{},
+        samples:               map[SampleKey]*SampleState{},
+        emitted:               map[SampleKey]time.Time{},
 	}, nil
 }
 
@@ -269,8 +277,33 @@ func (c *QuerySamples) fetchQuerySample(ctx context.Context) error {
 			continue
 		}
 
-		c.upsertActiveSample(key, sample)
-		activeKeys[key] = struct{}{}
+        // Handle idle states specially: emit finalized sample once
+        if isIdleState(sample.State.String) {
+            if st, hadActive := c.samples[key]; hadActive {
+                st.EndOverride = sample.StateChange
+                st.LastSeenAt = sample.Now
+                st.LastRow.State = sample.State
+                c.emitted[key] = sample.Now // is actually emitted at the end of the loop
+            } else if _, already := c.emitted[key]; !already {
+                // New idle-only sample not yet seen -> create and mark finished
+                newIdleState := &SampleState{LastRow: sample, tracker: newWaitEventTracker()}
+                if sample.StateChange.Valid {
+                    newIdleState.EndOverride = sample.StateChange
+                    newIdleState.LastSeenAt = sample.StateChange.Time
+                } else {
+                    newIdleState.EndOverride = sql.NullTime{Time: sample.Now, Valid: true}
+                    newIdleState.LastSeenAt = sample.Now
+                }
+                newIdleState.LastRow.State = sample.State
+                c.samples[key] = newIdleState
+                c.emitted[key] = sample.Now // is actually emitted at the end of the loop
+            }
+            // do not mark idle as active
+            continue
+        }
+
+        c.upsertActiveSample(key, sample)
+        activeKeys[key] = struct{}{}
 	}
 
 	if err := rows.Err(); err != nil {
@@ -278,13 +311,14 @@ func (c *QuerySamples) fetchQuerySample(ctx context.Context) error {
 		return err
 	}
 
-	// finalize samples that are no longer active
-	for key := range c.samples {
-		if _, stillActive := activeKeys[key]; stillActive {
-			continue
-		}
-		c.emitAndDeleteSample(key)
-	}
+    // finalize samples that are no longer active or have EndOverride set (idle finalized or one off idle sample)
+    for key, st := range c.samples {
+        if _, stillActive := activeKeys[key]; stillActive && !st.EndOverride.Valid {
+            continue
+        }
+        c.emitAndDeleteSample(key)
+    }
+    c.cleanupEmitted(time.Now())
 	return nil
 }
 
@@ -396,13 +430,22 @@ func (c *QuerySamples) emitAndDeleteSample(key SampleKey) {
 	if !ok {
 		return
 	}
-	sampleLabels := c.buildQuerySampleLabels(state)
-	c.entryHandler.Chan() <- database_observability.BuildLokiEntryWithTimestamp(
-		logging.LevelInfo,
-		OP_QUERY_SAMPLE,
-		sampleLabels,
-		state.LastSeenAt.UnixNano(),
-	)
+    var endOverride *time.Time
+    if state.EndOverride.Valid {
+        t := state.EndOverride.Time
+        endOverride = &t
+    }
+    sampleLabels := c.buildQuerySampleLabelsWithEnd(state, endOverride)
+    ts := state.LastSeenAt.UnixNano()
+    if endOverride != nil {
+        ts = endOverride.UnixNano()
+    }
+    c.entryHandler.Chan() <- database_observability.BuildLokiEntryWithTimestamp(
+        logging.LevelInfo,
+        OP_QUERY_SAMPLE,
+        sampleLabels,
+        ts,
+    )
 
 	for _, we := range state.tracker.WaitEvents() {
 		if we.WaitEventType == "" || we.WaitEvent == "" {
@@ -424,6 +467,55 @@ func (s *SampleState) updateCpuTimeIfActive(sample QuerySamplesInfo) {
 	if !sample.WaitEventType.Valid && !sample.WaitEvent.Valid && sample.State.String == stateActive {
 		s.LastCpuTime = calculateDuration(sample.StateChange, sample.Now)
 	}
+}
+
+// buildQuerySampleLabelsWithEnd is like buildQuerySampleLabels but uses the provided end time
+// to compute durations and the timestamp when available (e.g., idle finalized at state_change).
+func (c *QuerySamples) buildQuerySampleLabelsWithEnd(state *SampleState, endOverride *time.Time) string {
+    leaderPID := ""
+    if state.LastRow.LeaderPID.Valid {
+        leaderPID = fmt.Sprintf(`%d`, state.LastRow.LeaderPID.Int64)
+    }
+
+    end := state.LastRow.Now
+    if endOverride != nil {
+        end = *endOverride
+    }
+
+    xactDuration := calculateDuration(state.LastRow.XactStart, end)
+    queryDuration := calculateDuration(state.LastRow.QueryStart, end)
+
+    clientAddr := ""
+    if state.LastRow.ClientAddr.Valid {
+        clientAddr = state.LastRow.ClientAddr.String
+        if state.LastRow.ClientPort.Valid {
+            clientAddr = fmt.Sprintf("%s:%d", clientAddr, state.LastRow.ClientPort.Int32)
+        }
+    }
+
+    labels := fmt.Sprintf(
+        `datname="%s" pid="%d" leader_pid="%s" user="%s" app="%s" client="%s" backend_type="%s" state="%s" xid="%d" xmin="%d" xact_time="%s" query_time="%s" queryid="%d"`,
+        state.LastRow.DatabaseName.String,
+        state.LastRow.PID,
+        leaderPID,
+        state.LastRow.Username.String,
+        state.LastRow.ApplicationName.String,
+        clientAddr,
+        state.LastRow.BackendType.String,
+        state.LastRow.State.String,
+        state.LastRow.BackendXID.Int32,
+        state.LastRow.BackendXmin.Int32,
+        xactDuration,
+        queryDuration,
+        state.LastRow.QueryID.Int64,
+    )
+    if state.LastCpuTime != "" {
+        labels = fmt.Sprintf(`%s cpu_time="%s"`, labels, state.LastCpuTime)
+    }
+    if c.disableQueryRedaction && state.LastRow.Query.Valid {
+        labels = fmt.Sprintf(`%s query="%s"`, labels, state.LastRow.Query.String)
+    }
+    return labels
 }
 
 func (c *QuerySamples) buildQuerySampleLabels(state *SampleState) string {
@@ -523,4 +615,20 @@ func equalPIDSets(a, b []int64) bool {
 		}
 	}
 	return true
+}
+
+func (c *QuerySamples) cleanupEmitted(now time.Time) {
+    const ttl = 10 * time.Minute
+    for k, lastSeen := range c.emitted {
+        if now.Sub(lastSeen) > ttl {
+            delete(c.emitted, k)
+        }
+    }
+}
+
+func isIdleState(state string) bool {
+    if state == stateIdle || state == stateIdleTxnAborted {
+        return true
+    }
+    return false
 }

--- a/internal/component/database_observability/postgres/collector/query_samples_test.go
+++ b/internal/component/database_observability/postgres/collector/query_samples_test.go
@@ -625,3 +625,137 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 }
+
+func TestQuerySamples_IdleScenarios(t *testing.T) {
+    defer goleak.VerifyNone(t)
+
+    now := time.Now()
+    stateChangeTime := now.Add(-10 * time.Second)
+    queryStartTime := now.Add(-30 * time.Second)
+    xactStartTime := now.Add(-2 * time.Minute)
+    backendStartTime := now.Add(-1 * time.Hour)
+
+    columns := []string{
+        "now", "datname", "pid", "leader_pid",
+        "usename", "application_name", "client_addr", "client_port",
+        "backend_type", "backend_start", "backend_xid", "backend_xmin",
+        "xact_start", "state", "state_change", "wait_event_type",
+        "wait_event", "blocked_by_pids", "query_start", "query_id",
+        "query",
+    }
+
+    t.Run("emit at idle state with end at state_change", func(t *testing.T) {
+        db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+        require.NoError(t, err)
+        defer db.Close()
+
+        logBuffer := syncbuffer.Buffer{}
+        lokiClient := loki_fake.NewClient(func() {})
+
+        sampleCollector, err := NewQuerySamples(QuerySamplesArguments{
+            DB:                    db,
+            CollectInterval:       10 * time.Millisecond,
+            EntryHandler:          lokiClient,
+            Logger:                log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+            DisableQueryRedaction: true,
+        })
+        require.NoError(t, err)
+
+        // Scrape 1: active row
+        mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause)).RowsWillBeClosed().
+            WillReturnRows(sqlmock.NewRows(columns).AddRow(
+                now, "testdb", 2000, sql.NullInt64{},
+                "testuser", "testapp", "127.0.0.1", 5432,
+                "client backend", backendStartTime, sql.NullInt32{Int32: 11, Valid: true}, sql.NullInt32{Int32: 22, Valid: true},
+                xactStartTime, "active", now.Add(-10*time.Second), sql.NullString{},
+                sql.NullString{}, nil, queryStartTime, sql.NullInt64{Int64: 20002, Valid: true},
+                "SELECT * FROM t",
+            ))
+        // Scrape 2: same key turns idle; state_change denotes end
+        mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause)).RowsWillBeClosed().
+            WillReturnRows(sqlmock.NewRows(columns).AddRow(
+                now, "testdb", 2000, sql.NullInt64{},
+                "testuser", "testapp", "127.0.0.1", 5432,
+                "client backend", backendStartTime, sql.NullInt32{Int32: 11, Valid: true}, sql.NullInt32{Int32: 22, Valid: true},
+                xactStartTime, "idle", stateChangeTime, sql.NullString{},
+                sql.NullString{}, nil, queryStartTime, sql.NullInt64{Int64: 20002, Valid: true},
+                "SELECT * FROM t",
+            ))
+
+        require.NoError(t, sampleCollector.Start(t.Context()))
+
+        require.EventuallyWithT(t, func(t *assert.CollectT) {
+            entries := lokiClient.Received()
+            require.Len(t, entries, 1)
+            require.Equal(t, model.LabelSet{"op": OP_QUERY_SAMPLE}, entries[0].Labels)
+            require.Contains(t, entries[0].Line, `query_time="20s"`)
+            require.Contains(t, entries[0].Line, `cpu_time="10s"`)
+            expectedTs := time.Unix(0, stateChangeTime.UnixNano())
+            require.True(t, entries[0].Timestamp.Equal(expectedTs))
+        }, 5*time.Second, 50*time.Millisecond)
+
+        // Ensure all expected queries were executed before stopping
+        require.Eventually(t, func() bool { return mock.ExpectationsWereMet() == nil }, 5*time.Second, 50*time.Millisecond)
+
+        sampleCollector.Stop()
+        require.Eventually(t, func() bool { return sampleCollector.Stopped() }, 5*time.Second, 100*time.Millisecond)
+        lokiClient.Stop()
+        time.Sleep(100 * time.Millisecond)
+    })
+
+    t.Run("idle-only emitted once and deduped across scrapes", func(t *testing.T) {
+        db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+        require.NoError(t, err)
+        defer db.Close()
+
+        logBuffer := syncbuffer.Buffer{}
+        lokiClient := loki_fake.NewClient(func() {})
+
+        sampleCollector, err := NewQuerySamples(QuerySamplesArguments{
+            DB:                    db,
+            CollectInterval:       10 * time.Millisecond,
+            EntryHandler:          lokiClient,
+            Logger:                log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+            DisableQueryRedaction: true,
+        })
+        require.NoError(t, err)
+
+        // Scrape 1: only idle row
+        mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause)).RowsWillBeClosed().
+            WillReturnRows(sqlmock.NewRows(columns).AddRow(
+                now, "testdb", 2001, sql.NullInt64{},
+                "testuser", "testapp", "127.0.0.1", 5432,
+                "client backend", backendStartTime, sql.NullInt32{Int32: 0, Valid: false}, sql.NullInt32{Int32: 0, Valid: false},
+                xactStartTime, "idle", stateChangeTime, sql.NullString{},
+                sql.NullString{}, nil, queryStartTime, sql.NullInt64{Int64: 20003, Valid: true},
+                "SELECT * FROM users",
+            ))
+        // Scrape 2: same idle row again -> should not re-emit
+        mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause)).RowsWillBeClosed().
+            WillReturnRows(sqlmock.NewRows(columns).AddRow(
+                now, "testdb", 2001, sql.NullInt64{},
+                "testuser", "testapp", "127.0.0.1", 5432,
+                "client backend", backendStartTime, sql.NullInt32{Int32: 0, Valid: false}, sql.NullInt32{Int32: 0, Valid: false},
+                xactStartTime, "idle", stateChangeTime, sql.NullString{},
+                sql.NullString{}, nil, queryStartTime, sql.NullInt64{Int64: 20003, Valid: true},
+                "SELECT * FROM users",
+            ))
+
+        require.NoError(t, sampleCollector.Start(t.Context()))
+
+        require.EventuallyWithT(t, func(t *assert.CollectT) {
+            entries := lokiClient.Received()
+            require.Len(t, entries, 1)
+            require.Equal(t, model.LabelSet{"op": OP_QUERY_SAMPLE}, entries[0].Labels)
+            require.Contains(t, entries[0].Line, `query_time="20s"`)
+            expectedTs := time.Unix(0, stateChangeTime.UnixNano())
+            require.True(t, entries[0].Timestamp.Equal(expectedTs))
+        }, 5*time.Second, 50*time.Millisecond)
+
+        sampleCollector.Stop()
+        require.Eventually(t, func() bool { return sampleCollector.Stopped() }, 5*time.Second, 100*time.Millisecond)
+        lokiClient.Stop()
+        time.Sleep(100 * time.Millisecond)
+        require.NoError(t, mock.ExpectationsWereMet())
+    })
+}

--- a/internal/component/database_observability/postgres/collector/query_samples_test.go
+++ b/internal/component/database_observability/postgres/collector/query_samples_test.go
@@ -469,7 +469,7 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 				now, "testdb", 301, sql.NullInt64{},
 				"testuser", "testapp", "127.0.0.1", 5432,
 				"client backend", backendStartTime, sql.NullInt32{}, sql.NullInt32{},
-				xactStartTime, "waiting", stateChangeTime, sql.NullString{String: "Lock", Valid: true},
+				xactStartTime, "active", stateChangeTime, sql.NullString{String: "Lock", Valid: true},
 				sql.NullString{String: "relation", Valid: true}, pq.Int64Array{103, 104}, now, sql.NullInt64{Int64: 555, Valid: true},
 				"UPDATE users SET status = 'active'",
 			))
@@ -479,7 +479,7 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 				now, "testdb", 301, sql.NullInt64{},
 				"testuser", "testapp", "127.0.0.1", 5432,
 				"client backend", backendStartTime, sql.NullInt32{}, sql.NullInt32{},
-				xactStartTime, "waiting", now, sql.NullString{},
+				xactStartTime, "active", now, sql.NullString{},
 				sql.NullString{}, nil, now, sql.NullInt64{Int64: 555, Valid: true},
 				"UPDATE users SET status = 'active'",
 			))
@@ -493,9 +493,9 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 			entries := lokiClient.Received()
 			require.Len(t, entries, 2)
 			require.Equal(t, model.LabelSet{"op": OP_QUERY_SAMPLE}, entries[0].Labels)
-			require.Equal(t, `level="info" datname="testdb" pid="301" leader_pid="" user="testuser" app="testapp" client="127.0.0.1:5432" backend_type="client backend" state="waiting" xid="0" xmin="0" xact_time="2m0s" query_time="0s" queryid="555" query="UPDATE users SET status = 'active'"`, entries[0].Line)
+			require.Equal(t, `level="info" datname="testdb" pid="301" leader_pid="" user="testuser" app="testapp" client="127.0.0.1:5432" backend_type="client backend" state="active" xid="0" xmin="0" xact_time="2m0s" query_time="0s" queryid="555" cpu_time="0s" query="UPDATE users SET status = 'active'"`, entries[0].Line)
 			require.Equal(t, model.LabelSet{"op": OP_WAIT_EVENT}, entries[1].Labels)
-			require.Equal(t, `level="info" datname="testdb" pid="301" leader_pid="" user="testuser" backend_type="client backend" state="waiting" xid="0" xmin="0" wait_time="10s" wait_event_type="Lock" wait_event="relation" wait_event_name="Lock:relation" blocked_by_pids="[103 104]" queryid="555"`, entries[1].Line)
+			require.Equal(t, `level="info" datname="testdb" pid="301" leader_pid="" user="testuser" backend_type="client backend" state="active" xid="0" xmin="0" wait_time="10s" wait_event_type="Lock" wait_event="relation" wait_event_name="Lock:relation" blocked_by_pids="[103 104]" queryid="555"`, entries[1].Line)
 		}, 5*time.Second, 50*time.Millisecond)
 
 		sampleCollector.Stop()

--- a/internal/component/database_observability/postgres/collector/query_samples_test.go
+++ b/internal/component/database_observability/postgres/collector/query_samples_test.go
@@ -479,7 +479,7 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 				now, "testdb", 301, sql.NullInt64{},
 				"testuser", "testapp", "127.0.0.1", 5432,
 				"client backend", backendStartTime, sql.NullInt32{}, sql.NullInt32{},
-				xactStartTime, "active", now, sql.NullString{},
+				xactStartTime, "waiting", now, sql.NullString{},
 				sql.NullString{}, nil, now, sql.NullInt64{Int64: 555, Valid: true},
 				"UPDATE users SET status = 'active'",
 			))
@@ -493,9 +493,9 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 			entries := lokiClient.Received()
 			require.Len(t, entries, 2)
 			require.Equal(t, model.LabelSet{"op": OP_QUERY_SAMPLE}, entries[0].Labels)
-			require.Equal(t, `level="info" datname="testdb" pid="301" leader_pid="" user="testuser" app="testapp" client="127.0.0.1:5432" backend_type="client backend" state="active" xid="0" xmin="0" xact_time="2m0s" query_time="0s" queryid="555" cpu_time="0s" query="UPDATE users SET status = 'active'"`, entries[0].Line)
+			require.Equal(t, `level="info" datname="testdb" pid="301" leader_pid="" user="testuser" app="testapp" client="127.0.0.1:5432" backend_type="client backend" state="waiting" xid="0" xmin="0" xact_time="2m0s" query_time="0s" queryid="555" query="UPDATE users SET status = 'active'"`, entries[0].Line)
 			require.Equal(t, model.LabelSet{"op": OP_WAIT_EVENT}, entries[1].Labels)
-			require.Equal(t, `level="info" datname="testdb" pid="301" leader_pid="" user="testuser" backend_type="client backend" state="active" xid="0" xmin="0" wait_time="10s" wait_event_type="Lock" wait_event="relation" wait_event_name="Lock:relation" blocked_by_pids="[103 104]" queryid="555"`, entries[1].Line)
+			require.Equal(t, `level="info" datname="testdb" pid="301" leader_pid="" user="testuser" backend_type="client backend" state="waiting" xid="0" xmin="0" wait_time="10s" wait_event_type="Lock" wait_event="relation" wait_event_name="Lock:relation" blocked_by_pids="[103 104]" queryid="555"`, entries[1].Line)
 		}, 5*time.Second, 50*time.Millisecond)
 
 		sampleCollector.Stop()

--- a/internal/component/database_observability/postgres/collector/schema_details_test.go
+++ b/internal/component/database_observability/postgres/collector/schema_details_test.go
@@ -116,7 +116,6 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 		}, 2*time.Second, 100*time.Millisecond)
 
 		collector.Stop()
-		require.Eventually(t, func() bool { return collector.Stopped() }, 5*time.Second, 100*time.Millisecond)
 		lokiClient.Stop()
 
 		// Run this after Stop() to avoid race conditions
@@ -535,7 +534,6 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 		}, 2*time.Second, 100*time.Millisecond)
 
 		collector.Stop()
-		require.Eventually(t, func() bool { return collector.Stopped() }, 5*time.Second, 100*time.Millisecond)
 		lokiClient.Stop()
 
 		// Run this after Stop() to avoid race conditions
@@ -700,7 +698,6 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 		}, 2*time.Second, 100*time.Millisecond)
 
 		collector.Stop()
-		require.Eventually(t, func() bool { return collector.Stopped() }, 5*time.Second, 100*time.Millisecond)
 		lokiClient.Stop()
 
 		// Run this after Stop() to avoid race conditions
@@ -811,7 +808,6 @@ func Test_Postgres_SchemaDetails_collector_detects_auto_increment_column(t *test
 		}, 2*time.Second, 100*time.Millisecond)
 
 		collector.Stop()
-		require.Eventually(t, func() bool { return collector.Stopped() }, 5*time.Second, 100*time.Millisecond)
 		lokiClient.Stop()
 
 		// Run this after Stop() to avoid race conditions
@@ -919,7 +915,6 @@ func Test_Postgres_SchemaDetails_collector_detects_auto_increment_column(t *test
 		}, 2*time.Second, 100*time.Millisecond)
 
 		collector.Stop()
-		require.Eventually(t, func() bool { return collector.Stopped() }, 5*time.Second, 100*time.Millisecond)
 		lokiClient.Stop()
 
 		// Run this after Stop() to avoid race conditions

--- a/internal/component/database_observability/postgres/collector/schema_details_test.go
+++ b/internal/component/database_observability/postgres/collector/schema_details_test.go
@@ -1024,7 +1024,6 @@ func Test_Postgres_SchemaDetails_collector_detects_auto_increment_column(t *test
 		}, 2*time.Second, 100*time.Millisecond)
 
 		collector.Stop()
-		require.Eventually(t, func() bool { return collector.Stopped() }, 5*time.Second, 100*time.Millisecond)
 		lokiClient.Stop()
 
 		err = mock.ExpectationsWereMet()

--- a/internal/component/database_observability/postgres/collector/schema_details_test.go
+++ b/internal/component/database_observability/postgres/collector/schema_details_test.go
@@ -116,6 +116,7 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 		}, 2*time.Second, 100*time.Millisecond)
 
 		collector.Stop()
+		require.Eventually(t, func() bool { return collector.Stopped() }, 5*time.Second, 100*time.Millisecond)
 		lokiClient.Stop()
 
 		// Run this after Stop() to avoid race conditions
@@ -534,6 +535,7 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 		}, 2*time.Second, 100*time.Millisecond)
 
 		collector.Stop()
+		require.Eventually(t, func() bool { return collector.Stopped() }, 5*time.Second, 100*time.Millisecond)
 		lokiClient.Stop()
 
 		// Run this after Stop() to avoid race conditions
@@ -698,6 +700,7 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 		}, 2*time.Second, 100*time.Millisecond)
 
 		collector.Stop()
+		require.Eventually(t, func() bool { return collector.Stopped() }, 5*time.Second, 100*time.Millisecond)
 		lokiClient.Stop()
 
 		// Run this after Stop() to avoid race conditions
@@ -808,6 +811,7 @@ func Test_Postgres_SchemaDetails_collector_detects_auto_increment_column(t *test
 		}, 2*time.Second, 100*time.Millisecond)
 
 		collector.Stop()
+		require.Eventually(t, func() bool { return collector.Stopped() }, 5*time.Second, 100*time.Millisecond)
 		lokiClient.Stop()
 
 		// Run this after Stop() to avoid race conditions
@@ -915,6 +919,7 @@ func Test_Postgres_SchemaDetails_collector_detects_auto_increment_column(t *test
 		}, 2*time.Second, 100*time.Millisecond)
 
 		collector.Stop()
+		require.Eventually(t, func() bool { return collector.Stopped() }, 5*time.Second, 100*time.Millisecond)
 		lokiClient.Stop()
 
 		// Run this after Stop() to avoid race conditions
@@ -940,6 +945,7 @@ func Test_Postgres_SchemaDetails_collector_detects_auto_increment_column(t *test
 		defer db.Close()
 
 		lokiClient := loki_fake.NewClient(func() {})
+		defer lokiClient.Stop()
 
 		collector, err := NewSchemaDetails(SchemaDetailsArguments{
 			DB:              db,
@@ -1023,6 +1029,7 @@ func Test_Postgres_SchemaDetails_collector_detects_auto_increment_column(t *test
 		}, 2*time.Second, 100*time.Millisecond)
 
 		collector.Stop()
+		require.Eventually(t, func() bool { return collector.Stopped() }, 5*time.Second, 100*time.Millisecond)
 		lokiClient.Stop()
 
 		err = mock.ExpectationsWereMet()


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Including idle states processing, encompassing two scenarios:

Previously captured query actively running becomes idle, emit the sample calculating the duration from the stateChange coming from the idle state row.
Not yet captured query shows up as idle, emit a one-off sample with the information available in the idle row.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

This will generate a lot more samples for our postgres environments. https://github.com/grafana/alloy/pull/4772 will handle it.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
