### PR TITLE
database_observability: Consider compound keywords in queries when deciding to denylist them or not

### DIFF
--- a/internal/component/database_observability/explain_plan_output.go
+++ b/internal/component/database_observability/explain_plan_output.go
@@ -35,42 +35,75 @@ const (
 	ExplainPlanJoinAlgorithmNestedLoop ExplainPlanJoinAlgorithm = "nested_loop"
 )
 
+type ExplainReservedWordMetadata struct {
+	ExemptionPrefixes *[]string
+}
+
 // ExplainReservedWordDenyList contains SQL reserved words that indicate write operations
 // to the database. These are primarily DML (Data Manipulation Language) and DDL
 // (Data Definition Language) commands that modify database state.
 // This was extracted from the MySQL and PostgreSQL documentation by Claude Sonnet 4 on Oct 28, 2025
 // and audited by @rgeyer and others in the dbo11y team.
-var ExplainReservedWordDenyList = map[string]bool{
+var ExplainReservedWordDenyList = map[string]ExplainReservedWordMetadata{
 	// Data Manipulation Language (DML) - Write operations
-	"INSERT": true, "UPDATE": true, "DELETE": true, "REPLACE": true, "MERGE": true, "UPSERT": true,
-	"FOR UPDATE": true,
+	"INSERT": ExplainReservedWordMetadata{},
+	"UPDATE": ExplainReservedWordMetadata{
+		ExemptionPrefixes: &[]string{"FOR"},
+	},
+	"DELETE":  ExplainReservedWordMetadata{},
+	"REPLACE": ExplainReservedWordMetadata{},
+	"MERGE":   ExplainReservedWordMetadata{},
+	"UPSERT":  ExplainReservedWordMetadata{},
 
 	// Data Definition Language (DDL) - Schema modifications
-	"CREATE": true, "ALTER": true, "DROP": true, "RENAME": true, "TRUNCATE": true,
+	"CREATE":   ExplainReservedWordMetadata{},
+	"ALTER":    ExplainReservedWordMetadata{},
+	"DROP":     ExplainReservedWordMetadata{},
+	"RENAME":   ExplainReservedWordMetadata{},
+	"TRUNCATE": ExplainReservedWordMetadata{},
 
 	// Transaction control that can commit writes
-	"COMMIT": true, "ROLLBACK": true, "SAVEPOINT": true,
+	"COMMIT":    ExplainReservedWordMetadata{},
+	"ROLLBACK":  ExplainReservedWordMetadata{},
+	"SAVEPOINT": ExplainReservedWordMetadata{},
 
 	// Database/Schema management
-	"USE": true, "DATABASE": true, "SCHEMA": true,
+	"USE":      ExplainReservedWordMetadata{},
+	"DATABASE": ExplainReservedWordMetadata{},
+	"SCHEMA":   ExplainReservedWordMetadata{},
 
 	// Index operations
-	"REINDEX": true, "ANALYZE": true, "OPTIMIZE": true,
-	"REINDEX TABLE": true, "ANALYZE TABLE": true, "OPTIMIZE TABLE": true,
+	"REINDEX":  ExplainReservedWordMetadata{},
+	"ANALYZE":  ExplainReservedWordMetadata{},
+	"OPTIMIZE": ExplainReservedWordMetadata{},
+
 	// User/Permission management
-	"GRANT": true, "REVOKE": true, "CREATE USER": true, "DROP USER": true, "ALTER USER": true,
+	"GRANT":  ExplainReservedWordMetadata{},
+	"REVOKE": ExplainReservedWordMetadata{},
 
 	// MySQL specific write operations
-	"LOAD": true, "DELAYED": true, "IGNORE": true, "ON DUPLICATE KEY": true,
-	"LOW_PRIORITY": true, "HIGH_PRIORITY": true, "QUICK": true,
-	"LOCK IN SHARE MODE": true,
+	"LOAD":          ExplainReservedWordMetadata{},
+	"DELAYED":       ExplainReservedWordMetadata{},
+	"IGNORE":        ExplainReservedWordMetadata{},
+	"LOW_PRIORITY":  ExplainReservedWordMetadata{},
+	"HIGH_PRIORITY": ExplainReservedWordMetadata{},
+	"QUICK":         ExplainReservedWordMetadata{},
 
 	// PostgreSQL specific write operations
-	"COPY": true, "VACUUM": true, "CLUSTER": true, "LISTEN": true, "NOTIFY": true, "DISCARD": true,
-	"PREPARE": true, "EXECUTE": true, "DEALLOCATE": true, "RESET": true, "SET": true,
+	"COPY":       ExplainReservedWordMetadata{},
+	"VACUUM":     ExplainReservedWordMetadata{},
+	"CLUSTER":    ExplainReservedWordMetadata{},
+	"LISTEN":     ExplainReservedWordMetadata{},
+	"NOTIFY":     ExplainReservedWordMetadata{},
+	"DISCARD":    ExplainReservedWordMetadata{},
+	"PREPARE":    ExplainReservedWordMetadata{},
+	"EXECUTE":    ExplainReservedWordMetadata{},
+	"DEALLOCATE": ExplainReservedWordMetadata{},
+	"RESET":      ExplainReservedWordMetadata{},
+	"SET":        ExplainReservedWordMetadata{},
 
 	// dbo11 specific operations we'd like to exclude
-	"EXPLAIN": true,
+	"EXPLAIN": ExplainReservedWordMetadata{},
 }
 
 type ExplainPlanOutput struct {

--- a/internal/component/database_observability/explain_plan_output.go
+++ b/internal/component/database_observability/explain_plan_output.go
@@ -46,64 +46,64 @@ type ExplainReservedWordMetadata struct {
 // and audited by @rgeyer and others in the dbo11y team.
 var ExplainReservedWordDenyList = map[string]ExplainReservedWordMetadata{
 	// Data Manipulation Language (DML) - Write operations
-	"INSERT": ExplainReservedWordMetadata{},
-	"UPDATE": ExplainReservedWordMetadata{
+	"INSERT": {},
+	"UPDATE": {
 		ExemptionPrefixes: &[]string{"FOR"},
 	},
-	"DELETE":  ExplainReservedWordMetadata{},
-	"REPLACE": ExplainReservedWordMetadata{},
-	"MERGE":   ExplainReservedWordMetadata{},
-	"UPSERT":  ExplainReservedWordMetadata{},
+	"DELETE":  {},
+	"REPLACE": {},
+	"MERGE":   {},
+	"UPSERT":  {},
 
 	// Data Definition Language (DDL) - Schema modifications
-	"CREATE":   ExplainReservedWordMetadata{},
-	"ALTER":    ExplainReservedWordMetadata{},
-	"DROP":     ExplainReservedWordMetadata{},
-	"RENAME":   ExplainReservedWordMetadata{},
-	"TRUNCATE": ExplainReservedWordMetadata{},
+	"CREATE":   {},
+	"ALTER":    {},
+	"DROP":     {},
+	"RENAME":   {},
+	"TRUNCATE": {},
 
 	// Transaction control that can commit writes
-	"COMMIT":    ExplainReservedWordMetadata{},
-	"ROLLBACK":  ExplainReservedWordMetadata{},
-	"SAVEPOINT": ExplainReservedWordMetadata{},
+	"COMMIT":    {},
+	"ROLLBACK":  {},
+	"SAVEPOINT": {},
 
 	// Database/Schema management
-	"USE":      ExplainReservedWordMetadata{},
-	"DATABASE": ExplainReservedWordMetadata{},
-	"SCHEMA":   ExplainReservedWordMetadata{},
+	"USE":      {},
+	"DATABASE": {},
+	"SCHEMA":   {},
 
 	// Index operations
-	"REINDEX":  ExplainReservedWordMetadata{},
-	"ANALYZE":  ExplainReservedWordMetadata{},
-	"OPTIMIZE": ExplainReservedWordMetadata{},
+	"REINDEX":  {},
+	"ANALYZE":  {},
+	"OPTIMIZE": {},
 
 	// User/Permission management
-	"GRANT":  ExplainReservedWordMetadata{},
-	"REVOKE": ExplainReservedWordMetadata{},
+	"GRANT":  {},
+	"REVOKE": {},
 
 	// MySQL specific write operations
-	"LOAD":          ExplainReservedWordMetadata{},
-	"DELAYED":       ExplainReservedWordMetadata{},
-	"IGNORE":        ExplainReservedWordMetadata{},
-	"LOW_PRIORITY":  ExplainReservedWordMetadata{},
-	"HIGH_PRIORITY": ExplainReservedWordMetadata{},
-	"QUICK":         ExplainReservedWordMetadata{},
+	"LOAD":          {},
+	"DELAYED":       {},
+	"IGNORE":        {},
+	"LOW_PRIORITY":  {},
+	"HIGH_PRIORITY": {},
+	"QUICK":         {},
 
 	// PostgreSQL specific write operations
-	"COPY":       ExplainReservedWordMetadata{},
-	"VACUUM":     ExplainReservedWordMetadata{},
-	"CLUSTER":    ExplainReservedWordMetadata{},
-	"LISTEN":     ExplainReservedWordMetadata{},
-	"NOTIFY":     ExplainReservedWordMetadata{},
-	"DISCARD":    ExplainReservedWordMetadata{},
-	"PREPARE":    ExplainReservedWordMetadata{},
-	"EXECUTE":    ExplainReservedWordMetadata{},
-	"DEALLOCATE": ExplainReservedWordMetadata{},
-	"RESET":      ExplainReservedWordMetadata{},
-	"SET":        ExplainReservedWordMetadata{},
+	"COPY":       {},
+	"VACUUM":     {},
+	"CLUSTER":    {},
+	"LISTEN":     {},
+	"NOTIFY":     {},
+	"DISCARD":    {},
+	"PREPARE":    {},
+	"EXECUTE":    {},
+	"DEALLOCATE": {},
+	"RESET":      {},
+	"SET":        {},
 
 	// dbo11 specific operations we'd like to exclude
-	"EXPLAIN": ExplainReservedWordMetadata{},
+	"EXPLAIN": {},
 }
 
 type ExplainPlanOutput struct {

--- a/internal/component/database_observability/lexer.go
+++ b/internal/component/database_observability/lexer.go
@@ -64,7 +64,7 @@ func ContainsReservedKeywords(query string, reservedWords map[string]ExplainRese
 							continue
 						}
 						if isCommandKeywordOrIdentifier(tokenBuffer[i]) {
-							if strings.ToUpper(tokenBuffer[i].Value) == strings.ToUpper(currentExemptionPrefix) {
+							if strings.EqualFold(tokenBuffer[i].Value, currentExemptionPrefix) {
 								matchedTokens++
 								if matchedTokens < lookbackCount {
 									currentExemptionPrefix = (*resWord.ExemptionPrefixes)[matchedTokens]

--- a/internal/component/database_observability/lexer.go
+++ b/internal/component/database_observability/lexer.go
@@ -27,37 +27,61 @@ func RedactSql(sql string) string {
 	return obfuscatedSql
 }
 
+func isCommandKeywordOrIdentifier(token sqllexer.Token) bool {
+	return token.Type == sqllexer.COMMAND || token.Type == sqllexer.KEYWORD || token.Type == sqllexer.IDENT
+}
+
 // ContainsReservedKeywords checks if the SQL query contains any reserved keywords
 // that indicate write operations, excluding those in string literals or comments
-func ContainsReservedKeywords(query string, reservedWords map[string]bool, dbms sqllexer.DBMSType) bool {
+func ContainsReservedKeywords(query string, reservedWords map[string]ExplainReservedWordMetadata, dbms sqllexer.DBMSType) (bool, error) {
 	// Use the lexer to tokenize the query
 	lexer := sqllexer.New(query, sqllexer.WithDBMS(dbms))
+	tokenBuffer := make([]sqllexer.Token, 0)
 
 	// Scan all tokens
 	for {
 		token := lexer.Scan()
+		if token.Type == sqllexer.ERROR {
+			return false, fmt.Errorf("lexer failed to scan query, offending token value: %s", token.Value)
+		}
 		if token.Type == sqllexer.EOF {
 			break
 		}
-		if token.Type == sqllexer.ERROR {
-			// If lexing fails, fall back to simple string search for safety
-			uppercaseQuery := strings.ToUpper(query)
-			for word := range reservedWords {
-				if strings.Contains(uppercaseQuery, word) {
-					return true
-				}
-			}
-			return false
-		}
+		tokenBuffer = append(tokenBuffer, *token)
+	}
 
-		// Check commands, keywords, and identifiers (since some reserved words might be classified as identifiers)
-		// but exclude string literals, comments, and other non-SQL-keyword tokens
-		if token.Type == sqllexer.COMMAND || token.Type == sqllexer.KEYWORD || token.Type == sqllexer.IDENT {
-			if _, ok := reservedWords[strings.ToUpper(token.Value)]; ok {
-				return true
+	for tIdx, token := range tokenBuffer {
+		if isCommandKeywordOrIdentifier(token) {
+			if resWord, ok := reservedWords[strings.ToUpper(token.Value)]; ok {
+				if resWord.ExemptionPrefixes != nil && len(*resWord.ExemptionPrefixes) > 0 {
+					lookbackCount := len(*resWord.ExemptionPrefixes)
+					skippedTokens := 0
+					matchedTokens := 0
+					currentExemptionPrefix := (*resWord.ExemptionPrefixes)[0]
+					for i := tIdx - 1; i >= 0; i-- {
+						if tokenBuffer[i].Type == sqllexer.SPACE {
+							skippedTokens++
+							continue
+						}
+						if isCommandKeywordOrIdentifier(tokenBuffer[i]) {
+							if strings.ToUpper(tokenBuffer[i].Value) == strings.ToUpper(currentExemptionPrefix) {
+								matchedTokens++
+								if matchedTokens < lookbackCount {
+									currentExemptionPrefix = (*resWord.ExemptionPrefixes)[matchedTokens]
+								}
+							}
+						}
+					}
+					if matchedTokens == lookbackCount {
+						return false, nil
+					}
+					return true, nil
+				} else {
+					return true, nil
+				}
 			}
 		}
 	}
 
-	return false
+	return false, nil
 }

--- a/internal/component/database_observability/mysql/collector/explain_plans.go
+++ b/internal/component/database_observability/mysql/collector/explain_plans.go
@@ -569,7 +569,11 @@ func (c *ExplainPlans) fetchExplainPlans(ctx context.Context) error {
 			continue
 		}
 
-		containsReservedWord := database_observability.ContainsReservedKeywords(qi.queryText, database_observability.ExplainReservedWordDenyList, sqllexer.DBMSMySQL)
+		containsReservedWord, err := database_observability.ContainsReservedKeywords(qi.queryText, database_observability.ExplainReservedWordDenyList, sqllexer.DBMSMySQL)
+		if err != nil {
+			level.Error(logger).Log("msg", "failed to check for reserved keywords", "err", err)
+			continue
+		}
 
 		if containsReservedWord {
 			level.Debug(logger).Log("msg", "skipping query containing reserved word")

--- a/internal/component/database_observability/postgres/collector/explain_plan.go
+++ b/internal/component/database_observability/postgres/collector/explain_plan.go
@@ -411,7 +411,11 @@ func (c *ExplainPlan) fetchExplainPlans(ctx context.Context) error {
 			continue
 		}
 
-		containsReservedWord := database_observability.ContainsReservedKeywords(qi.queryText, database_observability.ExplainReservedWordDenyList, sqllexer.DBMSPostgres)
+		containsReservedWord, err := database_observability.ContainsReservedKeywords(qi.queryText, database_observability.ExplainReservedWordDenyList, sqllexer.DBMSPostgres)
+		if err != nil {
+			level.Error(logger).Log("msg", "failed to check for reserved keywords", "err", err)
+			continue
+		}
 
 		if containsReservedWord {
 			level.Debug(logger).Log("msg", "skipping query containing reserved word")


### PR DESCRIPTION
#### PR Description
This, almost exclusively solves for no longer denylisting queries which contain `FOR UPDATE`, since `UPDATE` is a keyword in the deny list.

The mechanism allows for one or more "prefix" words to appear in front of the deny listed keyword. If *all* of the prefix words are present, the deny listed word is exempted.

There are tests for the common cases we've encountered now. I.E. read-only queries beginning in `WITH`, and `SELECT` queries containing both `FOR UPDATE` and `LOCK IN SHARE MODE`.

Surely, the third time is the charm, I won't have to change the logic again. (Insert foreshadowing gif here).
