### PR TITLE
Fix: Update Loki Import Path in Windows Test

### DIFF
--- a/internal/component/loki/source/windowsevent/target_test.go
+++ b/internal/component/loki/source/windowsevent/target_test.go
@@ -14,8 +14,8 @@ import (
 	"go.uber.org/goleak"
 	"golang.org/x/sys/windows/svc/eventlog"
 
+	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/component/common/loki/utils"
-	"github.com/grafana/alloy/internal/loki/promtail/api"
 	"github.com/grafana/alloy/internal/loki/promtail/scrapeconfig"
 )
 
@@ -46,7 +46,7 @@ func TestBookmarkUpdate(t *testing.T) {
 		ExcludeUserData:      false,
 		Labels:               utils.ToLabelSet(map[string]string{"job": "windows"}),
 	}
-	handle := &handler{handler: make(chan api.Entry)}
+	handle := &testHandler{handler: make(chan loki.Entry)}
 	winTarget, err := NewTarget(log.NewLogfmtLogger(os.Stderr), handle, nil, scrapeConfig, 1000*time.Millisecond)
 	require.NoError(t, err)
 


### PR DESCRIPTION
I saw we're getting some errors in our windows CI pipeline ([recent run](https://github.com/grafana/alloy/actions/runs/19130955586/job/54671317208))

```
# github.com/grafana/alloy/internal/component/loki/source/windowsevent
Error: internal\component\loki\source\windowsevent\target_test.go:18:2: no required module provides package github.com/grafana/alloy/internal/loki/promtail/api; to add it:
```

I believe this is some remnants of moving loki related code around - we should be pulling in `github.com/grafana/alloy/internal/component/common/loki` and not `github.com/grafana/alloy/internal/loki/promtail/api`