### PR TITLE
Temporarily Add Slicelabels Tag to the Doc Generator

### DIFF
--- a/internal/tools/docs_generator/docs_updated_test.go
+++ b/internal/tools/docs_generator/docs_updated_test.go
@@ -18,7 +18,7 @@ import (
 var moduleRoot = "../../../"
 
 // Run the below generate command to automatically update the Markdown docs with generated content
-//go:generate go test -fix-tests -v
+//go:generate go test -tags slicelabels -fix-tests -v
 
 var fixTestsFlag = flag.Bool("fix-tests", false, "update the test files with the current generated content")
 


### PR DESCRIPTION
#### PR Description
We currently have some code still that is not string label compliant, this is being addressed in [this PR ](https://github.com/grafana/alloy/pull/4756). However, folks cannot currently run `make generate-docs` due to code being compiled without the `slicelabels` tag.

This PR adds that tag in - to be removed when we enable stringlabels later