### PR TITLE
database_observability: add table registry cache to schema_details and add "validated" to parsed table name logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Main (unreleased)
   - rework the query samples collector to buffer per-query execution state across scrapes and emit finalized entries (@gaantunes)
   - enable `explain_plans` collector by default (@rgeyer)
   - safely generate server_id when UDP socket used for database connection (@matthewnolf)
+  - add table registry and include "validated" in parsed table name logs (@fridgepoet)
 
 - Add `otelcol.exporter.googlecloudpubsub` community component to export metrics, traces, and logs to Google Cloud Pub/Sub topic. (@eraac)
 

--- a/internal/component/database_observability/postgres/collector/query_details.go
+++ b/internal/component/database_observability/postgres/collector/query_details.go
@@ -127,7 +127,8 @@ func (c QueryDetails) fetchAndAssociate(ctx context.Context) error {
 	defer rs.Close()
 
 	for rs.Next() {
-		var queryID, queryText, databaseName string
+		var queryID, queryText string
+		var databaseName database
 		err := rs.Scan(
 			&queryID,
 			&queryText,

--- a/internal/component/database_observability/postgres/collector/query_details_test.go
+++ b/internal/component/database_observability/postgres/collector/query_details_test.go
@@ -42,10 +42,10 @@ func TestQueryDetails(t *testing.T) {
 				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres" validated="true"`,
 			},
 			tableRegistry: &TableRegistry{
-				tables: map[database]map[schema]map[table]bool{
+				tables: map[database]map[schema]map[table]struct{}{
 					"some_database": {
 						"public": {
-							"some_table": true,
+							"some_table": struct{}{},
 						},
 					},
 				},
@@ -67,10 +67,10 @@ func TestQueryDetails(t *testing.T) {
 				`level="info" queryid="abc123" datname="some_database" table="public.users" engine="postgres" validated="true"`,
 			},
 			tableRegistry: &TableRegistry{
-				tables: map[database]map[schema]map[table]bool{
+				tables: map[database]map[schema]map[table]struct{}{
 					"some_database": {
 						"public": {
-							"users": true,
+							"users": struct{}{},
 						},
 					},
 				},

--- a/internal/component/database_observability/postgres/collector/query_details_test.go
+++ b/internal/component/database_observability/postgres/collector/query_details_test.go
@@ -9,10 +9,11 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/go-kit/log"
-	loki_fake "github.com/grafana/alloy/internal/component/common/loki/client/fake"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+
+	loki_fake "github.com/grafana/alloy/internal/component/common/loki/client/fake"
 )
 
 func TestQueryDetails(t *testing.T) {
@@ -41,7 +42,7 @@ func TestQueryDetails(t *testing.T) {
 				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres" validated="true"`,
 			},
 			tableRegistry: &TableRegistry{
-				tables: map[string]map[string]map[string]bool{
+				tables: map[database]map[schema]map[table]bool{
 					"some_database": {
 						"public": {
 							"some_table": true,
@@ -66,7 +67,7 @@ func TestQueryDetails(t *testing.T) {
 				`level="info" queryid="abc123" datname="some_database" table="public.users" engine="postgres" validated="true"`,
 			},
 			tableRegistry: &TableRegistry{
-				tables: map[string]map[string]map[string]bool{
+				tables: map[database]map[schema]map[table]bool{
 					"some_database": {
 						"public": {
 							"users": true,

--- a/internal/component/database_observability/postgres/collector/query_details_test.go
+++ b/internal/component/database_observability/postgres/collector/query_details_test.go
@@ -23,6 +23,7 @@ func TestQueryDetails(t *testing.T) {
 		eventStatementsRows [][]driver.Value
 		logsLabels          []model.LabelSet
 		logsLines           []string
+		tableRegistry       *TableRegistry
 	}{
 		{
 			name: "select query",
@@ -37,7 +38,41 @@ func TestQueryDetails(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" queryid=\"abc123\" querytext=\"SELECT * FROM some_table WHERE id = $1\" datname=\"some_database\" engine=\"postgres\"",
-				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres"`,
+				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres" validated="true"`,
+			},
+			tableRegistry: &TableRegistry{
+				tables: map[string]map[string]map[string]bool{
+					"some_database": {
+						"public": {
+							"some_table": true,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "select query with schema-qualified table",
+			eventStatementsRows: [][]driver.Value{{
+				"abc123",
+				"SELECT * FROM public.users WHERE id = $1",
+				"some_database",
+			}},
+			logsLabels: []model.LabelSet{
+				{"op": OP_QUERY_ASSOCIATION},
+				{"op": OP_QUERY_PARSED_TABLE_NAME},
+			},
+			logsLines: []string{
+				"level=\"info\" queryid=\"abc123\" querytext=\"SELECT * FROM public.users WHERE id = $1\" datname=\"some_database\" engine=\"postgres\"",
+				`level="info" queryid="abc123" datname="some_database" table="public.users" engine="postgres" validated="true"`,
+			},
+			tableRegistry: &TableRegistry{
+				tables: map[string]map[string]map[string]bool{
+					"some_database": {
+						"public": {
+							"users": true,
+						},
+					},
+				},
 			},
 		},
 		{
@@ -53,7 +88,7 @@ func TestQueryDetails(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" queryid=\"abc123\" querytext=\"WITH some_with_table AS (SELECT * FROM some_table WHERE id = $1) SELECT * FROM some_with_table\" datname=\"some_database\" engine=\"postgres\"",
-				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres"`,
+				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres" validated="false"`,
 			},
 		},
 		{
@@ -69,7 +104,7 @@ func TestQueryDetails(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" queryid=\"abc123\" querytext=\"INSERT INTO some_table (id, name) VALUES (...)\" datname=\"some_database\" engine=\"postgres\"",
-				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres"`,
+				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres" validated="false"`,
 			},
 		},
 		{
@@ -86,8 +121,8 @@ func TestQueryDetails(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" queryid=\"abc123\" querytext=\"WITH some_with_table AS (SELECT id, name FROM some_other_table WHERE id = $1) INSERT INTO some_table (id, name) SELECT id, name FROM some_with_table\" datname=\"some_database\" engine=\"postgres\"",
-				`level="info" queryid="abc123" datname="some_database" table="some_other_table" engine="postgres"`,
-				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres"`,
+				`level="info" queryid="abc123" datname="some_database" table="some_other_table" engine="postgres" validated="false"`,
+				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres" validated="false"`,
 			},
 		},
 		{
@@ -103,7 +138,7 @@ func TestQueryDetails(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" queryid=\"abc123\" querytext=\"UPDATE some_table SET active = false, reason = ? WHERE id = $1 AND name = $2\" datname=\"some_database\" engine=\"postgres\"",
-				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres"`,
+				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres" validated="false"`,
 			},
 		},
 		{
@@ -119,7 +154,7 @@ func TestQueryDetails(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" queryid=\"abc123\" querytext=\"DELETE FROM some_table WHERE id = $1\" datname=\"some_database\" engine=\"postgres\"",
-				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres"`,
+				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres" validated="false"`,
 			},
 		},
 		{
@@ -136,8 +171,8 @@ func TestQueryDetails(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" queryid=\"abc123\" querytext=\"WITH some_with_table AS (SELECT id, name FROM some_other_table WHERE id = $1) DELETE FROM some_table WHERE id IN (SELECT id FROM some_with_table)\" datname=\"some_database\" engine=\"postgres\"",
-				`level="info" queryid="abc123" datname="some_database" table="some_other_table" engine="postgres"`,
-				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres"`,
+				`level="info" queryid="abc123" datname="some_database" table="some_other_table" engine="postgres" validated="false"`,
+				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres" validated="false"`,
 			},
 		},
 		{
@@ -154,8 +189,8 @@ func TestQueryDetails(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" queryid=\"abc123\" querytext=\"SELECT t.id, t.val1, o.val2 FROM some_table t INNER JOIN other_table AS o ON t.id = o.id WHERE o.val2 = $1 ORDER BY t.val1 DESC\" datname=\"some_database\" engine=\"postgres\"",
-				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres"`,
-				`level="info" queryid="abc123" datname="some_database" table="other_table" engine="postgres"`,
+				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres" validated="false"`,
+				`level="info" queryid="abc123" datname="some_database" table="other_table" engine="postgres" validated="false"`,
 			},
 		},
 		{
@@ -177,9 +212,9 @@ func TestQueryDetails(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" queryid=\"xyz456\" querytext=\"INSERT INTO some_table...\" datname=\"some_database\" engine=\"postgres\"",
-				`level="info" queryid="xyz456" datname="some_database" table="some_table" engine="postgres"`,
+				`level="info" queryid="xyz456" datname="some_database" table="some_table" engine="postgres" validated="false"`,
 				"level=\"info\" queryid=\"abc123\" querytext=\"SELECT * FROM another_table WHERE id = $1\" datname=\"some_database\" engine=\"postgres\"",
-				`level="info" queryid="abc123" datname="some_database" table="another_table" engine="postgres"`,
+				`level="info" queryid="abc123" datname="some_database" table="another_table" engine="postgres" validated="false"`,
 			},
 		},
 		{
@@ -195,7 +230,7 @@ func TestQueryDetails(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" queryid=\"abc123\" querytext=\"SELECT * FROM some_table WHERE id = $1 AND name =\" datname=\"some_database\" engine=\"postgres\"",
-				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres"`,
+				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres" validated="false"`,
 			},
 		},
 		{
@@ -231,7 +266,7 @@ func TestQueryDetails(t *testing.T) {
 			logsLines: []string{
 				"level=\"info\" queryid=\"xyz456\" querytext=\"not valid sql\" datname=\"some_database\" engine=\"postgres\"",
 				"level=\"info\" queryid=\"abc123\" querytext=\"SELECT * FROM some_table WHERE id = $1\" datname=\"some_database\" engine=\"postgres\"",
-				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres"`,
+				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres" validated="false"`,
 			},
 		},
 		{
@@ -253,9 +288,9 @@ func TestQueryDetails(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" queryid=\"abc123\" querytext=\"SELECT * FROM some_table WHERE id = $1\" datname=\"some_database\" engine=\"postgres\"",
-				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres"`,
+				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres" validated="false"`,
 				"level=\"info\" queryid=\"abc123\" querytext=\"SELECT * FROM some_table WHERE id = $1\" datname=\"other_schema\" engine=\"postgres\"",
-				`level="info" queryid="abc123" datname="other_schema" table="some_table" engine="postgres"`,
+				`level="info" queryid="abc123" datname="other_schema" table="some_table" engine="postgres" validated="false"`,
 			},
 		},
 		{
@@ -273,9 +308,9 @@ func TestQueryDetails(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" queryid=\"abc123\" querytext=\"SELECT * FROM (SELECT id, name FROM employees_us_east UNION SELECT id, name FROM employees_us_west) AS employees_us UNION SELECT id, name FROM employees_emea\" datname=\"some_database\" engine=\"postgres\"",
-				`level="info" queryid="abc123" datname="some_database" table="employees_us_east" engine="postgres"`,
-				`level="info" queryid="abc123" datname="some_database" table="employees_us_west" engine="postgres"`,
-				`level="info" queryid="abc123" datname="some_database" table="employees_emea" engine="postgres"`,
+				`level="info" queryid="abc123" datname="some_database" table="employees_us_east" engine="postgres" validated="false"`,
+				`level="info" queryid="abc123" datname="some_database" table="employees_us_west" engine="postgres" validated="false"`,
+				`level="info" queryid="abc123" datname="some_database" table="employees_emea" engine="postgres" validated="false"`,
 			},
 		},
 		{
@@ -291,7 +326,7 @@ func TestQueryDetails(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" queryid=\"abc123\" querytext=\"SHOW CREATE TABLE some_table\" datname=\"some_database\" engine=\"postgres\"",
-				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres"`,
+				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres" validated="false"`,
 			},
 		},
 		{
@@ -321,7 +356,7 @@ func TestQueryDetails(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" queryid=\"abc123\" querytext=\"SELECT * FROM some_table WHERE\" datname=\"some_database\" engine=\"postgres\"",
-				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres"`,
+				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres" validated="false"`,
 			},
 		},
 	}
@@ -340,6 +375,7 @@ func TestQueryDetails(t *testing.T) {
 				DB:              db,
 				CollectInterval: time.Second,
 				EntryHandler:    lokiClient,
+				TableRegistry:   tc.tableRegistry,
 				Logger:          log.NewLogfmtLogger(os.Stderr),
 			})
 			require.NoError(t, err)
@@ -446,7 +482,7 @@ func TestQueryDetails_SQLDriverErrors(t *testing.T) {
 		require.Equal(t, model.LabelSet{"op": OP_QUERY_ASSOCIATION}, lokiEntries[0].Labels)
 		require.Equal(t, "level=\"info\" queryid=\"abc123\" querytext=\"SELECT * FROM some_table WHERE id = ?\" datname=\"some_database\" engine=\"postgres\"", lokiEntries[0].Line)
 		require.Equal(t, model.LabelSet{"op": OP_QUERY_PARSED_TABLE_NAME}, lokiEntries[1].Labels)
-		require.Equal(t, `level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres"`, lokiEntries[1].Line)
+		require.Equal(t, `level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres" validated="false"`, lokiEntries[1].Line)
 	})
 
 	t.Run("result set iteration error", func(t *testing.T) {
@@ -505,7 +541,7 @@ func TestQueryDetails_SQLDriverErrors(t *testing.T) {
 		require.Equal(t, model.LabelSet{"op": OP_QUERY_ASSOCIATION}, lokiEntries[0].Labels)
 		require.Equal(t, "level=\"info\" queryid=\"abc123\" querytext=\"SELECT * FROM some_table WHERE id = ?\" datname=\"some_database\" engine=\"postgres\"", lokiEntries[0].Line)
 		require.Equal(t, model.LabelSet{"op": OP_QUERY_PARSED_TABLE_NAME}, lokiEntries[1].Labels)
-		require.Equal(t, `level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres"`, lokiEntries[1].Line)
+		require.Equal(t, `level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres" validated="false"`, lokiEntries[1].Line)
 	})
 
 	t.Run("connection error recovery", func(t *testing.T) {
@@ -562,6 +598,6 @@ func TestQueryDetails_SQLDriverErrors(t *testing.T) {
 		require.Equal(t, model.LabelSet{"op": OP_QUERY_ASSOCIATION}, lokiEntries[0].Labels)
 		require.Equal(t, "level=\"info\" queryid=\"abc123\" querytext=\"SELECT * FROM some_table WHERE id = ?\" datname=\"some_database\" engine=\"postgres\"", lokiEntries[0].Line)
 		require.Equal(t, model.LabelSet{"op": OP_QUERY_PARSED_TABLE_NAME}, lokiEntries[1].Labels)
-		require.Equal(t, `level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres"`, lokiEntries[1].Line)
+		require.Equal(t, `level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres" validated="false"`, lokiEntries[1].Line)
 	})
 }

--- a/internal/component/database_observability/postgres/collector/schema_details.go
+++ b/internal/component/database_observability/postgres/collector/schema_details.go
@@ -252,7 +252,7 @@ func (tr *TableRegistry) IsValid(database database, parsedTableName string) bool
 	schemaName, tableName := parseSchemaQualifiedIfAny(parsedTableName)
 	switch schemaName {
 	case "": // parsedTableName isn't schema-qualified, e.g. SELECT * FROM table_name.
-		// table name can only be validated as "exists somewhere in the database", see limitation: https://github.com/grafana/grafana-dbo11y-app/issues/1838
+		// table name can only be validated as "exists somewhere in the database", see limitation: https://github.com/grafana/alloy/issues/4815
 		for _, tables := range schemas {
 			if _, ok := tables[tableName]; ok {
 				return true

--- a/internal/component/database_observability/postgres/collector/schema_details_test.go
+++ b/internal/component/database_observability/postgres/collector/schema_details_test.go
@@ -1695,11 +1695,11 @@ func Test_SchemaDetails_populates_TableRegistry(t *testing.T) {
 		collector.tableRegistry.mu.RLock()
 		actual := collector.tableRegistry.tables
 		collector.tableRegistry.mu.RUnlock()
-		assert.Equal(t, map[database]map[schema]map[table]bool{
+		assert.Equal(t, map[database]map[schema]map[table]struct{}{
 			"testdb": {
 				"public": {
-					"users":  true,
-					"orders": true,
+					"users":  struct{}{},
+					"orders": struct{}{},
 				},
 			},
 		}, actual)

--- a/internal/component/database_observability/postgres/collector/schema_details_test.go
+++ b/internal/component/database_observability/postgres/collector/schema_details_test.go
@@ -1695,7 +1695,7 @@ func Test_SchemaDetails_populates_TableRegistry(t *testing.T) {
 		collector.tableRegistry.mu.RLock()
 		actual := collector.tableRegistry.tables
 		collector.tableRegistry.mu.RUnlock()
-		assert.Equal(t, map[string]map[string]map[string]bool{
+		assert.Equal(t, map[database]map[schema]map[table]bool{
 			"testdb": {
 				"public": {
 					"users":  true,

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -370,7 +370,6 @@ func (c *Component) startCollectors(systemID string, engineVersion string) error
 	collectors := enableOrDisableCollectors(c.args)
 
 	if collectors[collector.SchemaDetailsCollector] {
-		var err error
 		stCollector, err := collector.NewSchemaDetails(collector.SchemaDetailsArguments{
 			DB:              c.dbConnection,
 			DSN:             string(c.args.DataSourceName),
@@ -393,10 +392,8 @@ func (c *Component) startCollectors(systemID string, engineVersion string) error
 		}
 	}
 
-	var qCollector *collector.QueryDetails
 	if collectors[collector.QueryDetailsCollector] {
-		var err error
-		qCollector, err = collector.NewQueryDetails(collector.QueryDetailsArguments{
+		qCollector, err := collector.NewQueryDetails(collector.QueryDetailsArguments{
 			DB:              c.dbConnection,
 			CollectInterval: c.args.QueryTablesArguments.CollectInterval,
 			EntryHandler:    entryHandler,

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -366,33 +366,11 @@ func (c *Component) startCollectors(systemID string, engineVersion string) error
 
 	entryHandler := addLokiLabels(loki.NewEntryHandler(c.handler.Chan(), func() {}), c.instanceKey, systemID)
 
-	collectors := enableOrDisableCollectors(c.args)
-
 	var tableRegistry *collector.TableRegistry
-	if collectors[collector.SchemaDetailsCollector] {
-		stCollector, err := collector.NewSchemaDetails(collector.SchemaDetailsArguments{
-			DB:              c.dbConnection,
-			DSN:             string(c.args.DataSourceName),
-			CollectInterval: c.args.SchemaDetailsArguments.CollectInterval,
-			CacheEnabled:    c.args.SchemaDetailsArguments.CacheEnabled,
-			CacheSize:       c.args.SchemaDetailsArguments.CacheSize,
-			CacheTTL:        c.args.SchemaDetailsArguments.CacheTTL,
-			EntryHandler:    entryHandler,
-			Logger:          c.opts.Logger,
-		})
-		if err != nil {
-			logStartError(collector.SchemaDetailsCollector, "create", err)
-		}
-		if stCollector != nil {
-			tableRegistry = stCollector.GetTableRegistry()
-			if err := stCollector.Start(context.Background()); err != nil {
-				logStartError(collector.SchemaDetailsCollector, "start", err)
-			}
-			c.collectors = append(c.collectors, stCollector)
-		}
-	}
 
+	collectors := enableOrDisableCollectors(c.args)
 	if collectors[collector.QueryDetailsCollector] {
+		var err error
 		qCollector, err := collector.NewQueryDetails(collector.QueryDetailsArguments{
 			DB:              c.dbConnection,
 			CollectInterval: c.args.QueryTablesArguments.CollectInterval,
@@ -445,6 +423,30 @@ func (c *Component) startCollectors(systemID string, engineVersion string) error
 			logStartError(collector.ConnectionInfoName, "start", err)
 		}
 		c.collectors = append(c.collectors, ciCollector)
+	}
+
+	if collectors[collector.SchemaDetailsCollector] {
+		var err error
+		stCollector, err := collector.NewSchemaDetails(collector.SchemaDetailsArguments{
+			DB:              c.dbConnection,
+			DSN:             string(c.args.DataSourceName),
+			CollectInterval: c.args.SchemaDetailsArguments.CollectInterval,
+			CacheEnabled:    c.args.SchemaDetailsArguments.CacheEnabled,
+			CacheSize:       c.args.SchemaDetailsArguments.CacheSize,
+			CacheTTL:        c.args.SchemaDetailsArguments.CacheTTL,
+			EntryHandler:    entryHandler,
+			Logger:          c.opts.Logger,
+		})
+		if err != nil {
+			logStartError(collector.SchemaDetailsCollector, "create", err)
+		}
+		if stCollector != nil {
+			tableRegistry = stCollector.GetTableRegistry()
+			if err := stCollector.Start(context.Background()); err != nil {
+				logStartError(collector.SchemaDetailsCollector, "start", err)
+			}
+			c.collectors = append(c.collectors, stCollector)
+		}
 	}
 
 	if collectors[collector.ExplainPlanCollector] {

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -388,8 +388,8 @@ func (c *Component) startCollectors(systemID string, engineVersion string) error
 			if err := stCollector.Start(context.Background()); err != nil {
 				logStartError(collector.SchemaDetailsCollector, "start", err)
 			}
-			c.collectors = append(c.collectors, stCollector)
 		}
+		c.collectors = append(c.collectors, stCollector)
 	}
 
 	if collectors[collector.QueryDetailsCollector] {
@@ -407,8 +407,8 @@ func (c *Component) startCollectors(systemID string, engineVersion string) error
 			if err := qCollector.Start(context.Background()); err != nil {
 				logStartError(collector.QueryDetailsCollector, "start", err)
 			}
-			c.collectors = append(c.collectors, qCollector)
 		}
+		c.collectors = append(c.collectors, qCollector)
 	}
 
 	if collectors[collector.QuerySamplesCollector] {
@@ -426,8 +426,8 @@ func (c *Component) startCollectors(systemID string, engineVersion string) error
 			if err := aCollector.Start(context.Background()); err != nil {
 				logStartError(collector.QuerySamplesCollector, "start", err)
 			}
-			c.collectors = append(c.collectors, aCollector)
 		}
+		c.collectors = append(c.collectors, aCollector)
 	}
 
 	// Connection Info collector is always enabled
@@ -444,8 +444,8 @@ func (c *Component) startCollectors(systemID string, engineVersion string) error
 		if err := ciCollector.Start(context.Background()); err != nil {
 			logStartError(collector.ConnectionInfoName, "start", err)
 		}
-		c.collectors = append(c.collectors, ciCollector)
 	}
+	c.collectors = append(c.collectors, ciCollector)
 
 	if collectors[collector.ExplainPlanCollector] {
 		engineSemver, err := semver.ParseTolerant(engineVersion)
@@ -468,8 +468,8 @@ func (c *Component) startCollectors(systemID string, engineVersion string) error
 			if err := epCollector.Start(context.Background()); err != nil {
 				logStartError(collector.ExplainPlanCollector, "start", err)
 			}
-			c.collectors = append(c.collectors, epCollector)
 		}
+		c.collectors = append(c.collectors, epCollector)
 	}
 
 	if len(startErrors) > 0 {

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -383,11 +383,9 @@ func (c *Component) startCollectors(systemID string, engineVersion string) error
 		if err != nil {
 			logStartError(collector.SchemaDetailsCollector, "create", err)
 		}
-		if stCollector != nil {
-			tableRegistry = stCollector.GetTableRegistry()
-			if err := stCollector.Start(context.Background()); err != nil {
-				logStartError(collector.SchemaDetailsCollector, "start", err)
-			}
+		tableRegistry = stCollector.GetTableRegistry()
+		if err := stCollector.Start(context.Background()); err != nil {
+			logStartError(collector.SchemaDetailsCollector, "start", err)
 		}
 		c.collectors = append(c.collectors, stCollector)
 	}
@@ -403,10 +401,8 @@ func (c *Component) startCollectors(systemID string, engineVersion string) error
 		if err != nil {
 			logStartError(collector.QueryDetailsCollector, "create", err)
 		}
-		if qCollector != nil {
-			if err := qCollector.Start(context.Background()); err != nil {
-				logStartError(collector.QueryDetailsCollector, "start", err)
-			}
+		if err := qCollector.Start(context.Background()); err != nil {
+			logStartError(collector.QueryDetailsCollector, "start", err)
 		}
 		c.collectors = append(c.collectors, qCollector)
 	}
@@ -422,10 +418,8 @@ func (c *Component) startCollectors(systemID string, engineVersion string) error
 		if err != nil {
 			logStartError(collector.QuerySamplesCollector, "create", err)
 		}
-		if aCollector != nil {
-			if err := aCollector.Start(context.Background()); err != nil {
-				logStartError(collector.QuerySamplesCollector, "start", err)
-			}
+		if err := aCollector.Start(context.Background()); err != nil {
+			logStartError(collector.QuerySamplesCollector, "start", err)
 		}
 		c.collectors = append(c.collectors, aCollector)
 	}
@@ -440,11 +434,10 @@ func (c *Component) startCollectors(systemID string, engineVersion string) error
 	if err != nil {
 		logStartError(collector.ConnectionInfoName, "create", err)
 	}
-	if ciCollector != nil {
-		if err := ciCollector.Start(context.Background()); err != nil {
-			logStartError(collector.ConnectionInfoName, "start", err)
-		}
+	if err := ciCollector.Start(context.Background()); err != nil {
+		logStartError(collector.ConnectionInfoName, "start", err)
 	}
+
 	c.collectors = append(c.collectors, ciCollector)
 
 	if collectors[collector.ExplainPlanCollector] {
@@ -464,10 +457,8 @@ func (c *Component) startCollectors(systemID string, engineVersion string) error
 		if err != nil {
 			logStartError(collector.ExplainPlanCollector, "create", err)
 		}
-		if epCollector != nil {
-			if err := epCollector.Start(context.Background()); err != nil {
-				logStartError(collector.ExplainPlanCollector, "start", err)
-			}
+		if err := epCollector.Start(context.Background()); err != nil {
+			logStartError(collector.ExplainPlanCollector, "start", err)
 		}
 		c.collectors = append(c.collectors, epCollector)
 	}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR introduces:
* a table registry which caches the databases > schemas > tables from the Schema Details collector
* parsed table names from the query_details collector are validated against this table registry
  * logs in op=query_parsed_table_name now emitted with an additional boolean field "validated"
  * this additional field will be used in the frontend

The Schema Details collector must be enabled in order for table names to be "validated".

Sample logs:
```
2025-11-07 10:56:56.419infolevel="info" queryid="2541281651416271417" datname="books_store" table="book_mix" engine="postgres" validated="false"

2025-11-07 10:56:56.419infolevel="info" queryid="2541281651416271417" datname="books_store" table="reading_list_books" engine="postgres" validated="true"
```

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->
Contributes to https://github.com/grafana/grafana-dbo11y-app/issues/1574

#### Notes to the Reviewer
See also https://github.com/grafana/grafana-dbo11y-app/issues/1838

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
