### PR TITLE
database_observability: Fix a few small things discovered in dogfooding

### DIFF
--- a/internal/component/database_observability/explain_plan_output.go
+++ b/internal/component/database_observability/explain_plan_output.go
@@ -63,6 +63,7 @@ var ExplainReservedWordDenyList = map[string]ExplainReservedWordMetadata{
 	"TRUNCATE": {},
 
 	// Transaction control that can commit writes
+	"BEGIN":     {},
 	"COMMIT":    {},
 	"ROLLBACK":  {},
 	"SAVEPOINT": {},

--- a/internal/component/database_observability/explain_plan_output.go
+++ b/internal/component/database_observability/explain_plan_output.go
@@ -101,6 +101,7 @@ var ExplainReservedWordDenyList = map[string]ExplainReservedWordMetadata{
 	"DEALLOCATE": {},
 	"RESET":      {},
 	"SET":        {},
+	"UNLISTEN":   {},
 
 	// dbo11 specific operations we'd like to exclude
 	"EXPLAIN": {},

--- a/internal/component/database_observability/explain_plan_output.go
+++ b/internal/component/database_observability/explain_plan_output.go
@@ -103,6 +103,8 @@ var ExplainReservedWordDenyList = map[string]ExplainReservedWordMetadata{
 	"RESET":      {},
 	"SET":        {},
 	"UNLISTEN":   {},
+	"DECLARE":    {},
+	"CLOSE":      {},
 
 	// dbo11 specific operations we'd like to exclude
 	"EXPLAIN": {},

--- a/internal/component/database_observability/postgres/collector/explain_plan.go
+++ b/internal/component/database_observability/postgres/collector/explain_plan.go
@@ -521,8 +521,7 @@ func (c *ExplainPlan) fetchExplainPlanJSON(ctx context.Context, qi queryInfo) ([
 
 	explainQuery := fmt.Sprintf("%s%s", selectExplainPlanPrefix, preparedStatementName)
 	paramCount := len(paramCountRegex.FindAllString(qi.queryText, -1))
-	if paramCount == 0 {
-	} else {
+	if paramCount > 0 {
 		nullParams := strings.Repeat("null,", paramCount)
 		if paramCount > 0 {
 			nullParams = nullParams[:len(nullParams)-1]

--- a/internal/component/database_observability/postgres/collector/explain_plan.go
+++ b/internal/component/database_observability/postgres/collector/explain_plan.go
@@ -44,8 +44,9 @@ const selectQueriesForExplainPlanTemplate = `
 const selectExplainPlanPrefix = `EXPLAIN (FORMAT JSON) EXECUTE `
 
 var unrecoverablePostgresSQLErrors = []string{
-	"pq: permission denied for table",
+	"pq: permission denied",
 	"pq: pg_hba.conf rejects connection for host",
+	"pq: syntax error",
 }
 
 var paramCountRegex = regexp.MustCompile(`\$\d+`)

--- a/internal/component/database_observability/postgres/collector/explain_plan_test.go
+++ b/internal/component/database_observability/postgres/collector/explain_plan_test.go
@@ -2947,6 +2947,73 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 			require.NotContains(t, logBuffer.String(), "error")
 		})
 
+		t.Run("explain prepared statement for queries without params executed without parens", func(t *testing.T) {
+			db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+			require.NoError(t, err)
+			defer db.Close()
+
+			lokiClient.Clear()
+			logBuffer.Reset()
+			dbConnFactory := &mockDbConnectionFactory{
+				db:                 db,
+				Mock:               &mock,
+				InstantiationCount: 0,
+			}
+			explainPlan = &ExplainPlan{
+				dbConnection:        db,
+				dbDSN:               "postgres://user:pass@host:1234/database",
+				dbConnectionFactory: dbConnFactory.NewDBConnection,
+				dbVersion:           post17ver,
+				queryCache: map[string]*queryInfo{
+					"testdb123456": {
+						datname:    "testdb",
+						queryId:    "123456",
+						queryText:  "select * from some_table",
+						calls:      int64(10),
+						callsReset: time.Now(),
+					},
+				},
+				queryDenylist:      map[string]*queryInfo{},
+				finishedQueryCache: map[string]*queryInfo{},
+				excludeSchemas:     []string{},
+				perScrapeRatio:     1.0,
+				logger:             log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+				currentBatchSize:   1,
+				entryHandler:       lokiClient,
+			}
+
+			archive, err := txtar.ParseFile("./testdata/explain_plan/complex_aggregation_with_case.txtar")
+			require.NoError(t, err)
+			require.Equal(t, 1, len(archive.Files))
+			jsonFile := archive.Files[0]
+			require.Equal(t, "complex_aggregation_with_case.json", jsonFile.Name)
+			jsonData := jsonFile.Data
+
+			mock.ExpectExec("PREPARE explain_plan_123456 AS select * from some_table").WillReturnResult(sqlmock.NewResult(0, 1))
+			mock.ExpectExec("SET search_path TO testdb, public").WillReturnResult(sqlmock.NewResult(0, 1))
+			mock.ExpectExec("SET plan_cache_mode = force_generic_plan").WillReturnResult(sqlmock.NewResult(0, 1))
+			mock.ExpectQuery("EXPLAIN (FORMAT JSON) EXECUTE explain_plan_123456").WillReturnRows(sqlmock.NewRows([]string{"json"}).AddRow(jsonData))
+			mock.ExpectExec("DEALLOCATE explain_plan_123456").WillReturnResult(sqlmock.NewResult(0, 1))
+
+			err = explainPlan.fetchExplainPlans(t.Context())
+			require.NoError(t, err)
+
+			assert.NoError(t, mock.ExpectationsWereMet())
+			assert.Equal(t, 1, dbConnFactory.InstantiationCount)
+
+			require.Eventually(
+				t,
+				func() bool {
+					return len(lokiClient.Received()) == 1
+				},
+				5*time.Second,
+				10*time.Millisecond,
+				"did not receive the explain plan output log message within the timeout",
+			)
+
+			require.NotContains(t, logBuffer.String(), "error")
+		})
+
 		err = mock.ExpectationsWereMet()
 		require.NoError(t, err)
 	})


### PR DESCRIPTION
#### PR Description
##### Explain Plan prepared statements for queries without params
When a query has no parameters, I need to execute the prepared statement I'm creating WITHOUT parens. I.E. `EXPLAIN (FORMAT JSON) EXECUTE explain_plan_123` vs `EXPLAIN (FORMAT JSON) EXECUTE explain_plan_123()`

##### Missed reserved words which can not appear in an explain request
Added a few more keywords to the denylist which were not caught previously

##### Broader denylisting of queries when errors are encoutered
Specifically *any* permissions error, and syntax errors.

This will result in any query with a syntax error to be logged as an error only once the first time it is tried, then the query won't be attempted again unless alloy is restarted.

Fixes grafana/grafana-dbo11y-app#1787
