### PR TITLE
Refactor Pyroscope eBPF to properly handle container IDs and executable reporters

### DIFF
--- a/internal/component/pyroscope/ebpf/ebpf_linux.go
+++ b/internal/component/pyroscope/ebpf/ebpf_linux.go
@@ -65,7 +65,7 @@ func New(logger log.Logger, reg prometheus.Registerer, id string, args Arguments
 	if err != nil {
 		return nil, err
 	}
-	cfg.FileObserver = nfs
+	cfg.ExecutableReporter = nfs
 
 	if dynamicProfilingPolicy {
 		cfg.Policy = &dynamicprofiling.ServiceDiscoveryTargetsOnlyPolicy{Discovery: discovery}
@@ -138,8 +138,10 @@ func (c *Component) Run(ctx context.Context) error {
 	c.metrics.profilingSessionsTotal.Inc()
 	defer func() {
 		ctlr.Shutdown()
-		if c.cfg.FileObserver != nil {
-			c.cfg.FileObserver.Cleanup()
+		if c.cfg.ExecutableReporter != nil {
+			if nfs, ok := c.cfg.ExecutableReporter.(*irsymcache.Resolver); ok {
+				nfs.Cleanup()
+			}
 		}
 	}()
 


### PR DESCRIPTION
This change addresses the container ID handling and symbol resolution in the Pyroscope eBPF profiler by:

- Replacing FileObserver with ExecutableReporter in the configuration to better reflect its purpose and enable proper cleanup with type assertions
- Moving container ID to the proper layer in the event reporting flow by passing it as a parameter to createProfile instead of storing it in ExtraMeta
- Simplifying the type system in tests by using upstream types (libpf.FileID and irsymcache.SourceInfo) instead of wrapper types

These changes improve type safety and align the code with the OpenTelemetry eBPF profiler v0.139.0 API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
