### PR TITLE
Fix flaky test for structured metadata stage

### DIFF
--- a/internal/component/loki/process/stages/structured_metadata_test.go
+++ b/internal/component/loki/process/stages/structured_metadata_test.go
@@ -1,6 +1,10 @@
 package stages
 
 import (
+	"encoding/json"
+	"maps"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alloy/internal/featuregate"
+	"github.com/grafana/loki/pkg/push"
 )
 
 var pipelineStagesStructuredMetadataFromLogfmt = `
@@ -136,68 +141,102 @@ func Test_StructuredMetadataStage(t *testing.T) {
 	tests := map[string]struct {
 		pipelineStagesYaml         string
 		logLine                    string
-		expectedStructuredMetadata string
+		expectedStructuredMetadata map[string]any
 		expectedLabels             model.LabelSet
 	}{
 		"expected structured metadata to be extracted with logfmt parser and to be added to entry": {
-			pipelineStagesYaml:         pipelineStagesStructuredMetadataFromLogfmt,
-			logLine:                    "app=loki component=ingester",
-			expectedStructuredMetadata: `{"app":"loki"}`,
+			pipelineStagesYaml: pipelineStagesStructuredMetadataFromLogfmt,
+			logLine:            "app=loki component=ingester",
+			expectedStructuredMetadata: map[string]any{
+				"app": "loki",
+			},
 		},
 		"expected structured metadata to be extracted with json parser and to be added to entry": {
-			pipelineStagesYaml:         pipelineStagesStructuredMetadataFromJSON,
-			logLine:                    `{"app":"loki" ,"component":"ingester"}`,
-			expectedStructuredMetadata: `{"app":"loki"}`,
+			pipelineStagesYaml: pipelineStagesStructuredMetadataFromJSON,
+			logLine:            `{"app":"loki" ,"component":"ingester"}`,
+			expectedStructuredMetadata: map[string]any{
+				"app": "loki",
+			},
 		},
 		"expected structured metadata to be extracted with regexp parser and to be added to entry": {
-			pipelineStagesYaml:         pipelineStagesStructuredMetadataWithRegexParser,
-			logLine:                    `2019-01-01T01:00:00.000000001Z stderr P i'm a log message!`,
-			expectedStructuredMetadata: `{"stream":"stderr"}`,
+			pipelineStagesYaml: pipelineStagesStructuredMetadataWithRegexParser,
+			logLine:            `2019-01-01T01:00:00.000000001Z stderr P i'm a log message!`,
+			expectedStructuredMetadata: map[string]any{
+				"stream": "stderr",
+			},
 		},
 		"expected structured metadata to be extracted with json parser and to be added to entry after rendering the template": {
-			pipelineStagesYaml:         pipelineStagesStructuredMetadataFromJSONWithTemplate,
-			logLine:                    `{"app":"loki" ,"component":"ingester"}`,
-			expectedStructuredMetadata: `{"app":"LOKI"}`,
+			pipelineStagesYaml: pipelineStagesStructuredMetadataFromJSONWithTemplate,
+			logLine:            `{"app":"loki" ,"component":"ingester"}`,
+			expectedStructuredMetadata: map[string]any{
+				"app": "LOKI",
+			},
 		},
 		"expected structured metadata and regular labels to be extracted with json parser and to be added to entry": {
-			pipelineStagesYaml:         pipelineStagesStructuredMetadataAndRegularLabelsFromJSON,
-			logLine:                    `{"app":"loki" ,"component":"ingester"}`,
-			expectedStructuredMetadata: `{"app":"loki"}`,
-			expectedLabels:             model.LabelSet{model.LabelName("component"): model.LabelValue("ingester")},
+			pipelineStagesYaml: pipelineStagesStructuredMetadataAndRegularLabelsFromJSON,
+			logLine:            `{"app":"loki" ,"component":"ingester"}`,
+			expectedStructuredMetadata: map[string]any{
+				"app": "loki",
+			},
+			expectedLabels: model.LabelSet{model.LabelName("component"): model.LabelValue("ingester")},
 		},
 		"expected structured metadata and regular labels to be extracted with static labels stage and to be added to entry": {
-			pipelineStagesYaml:         pipelineStagesStructuredMetadataFromStaticLabels,
-			logLine:                    `sample log line`,
-			expectedStructuredMetadata: `{"pod":"loki-querier-664f97db8d-qhnwg"}`,
-			expectedLabels:             model.LabelSet{model.LabelName("component"): model.LabelValue("querier")},
+			pipelineStagesYaml: pipelineStagesStructuredMetadataFromStaticLabels,
+			logLine:            `sample log line`,
+			expectedStructuredMetadata: map[string]any{
+				"pod": "loki-querier-664f97db8d-qhnwg",
+			},
+			expectedLabels: model.LabelSet{model.LabelName("component"): model.LabelValue("querier")},
 		},
 		"expected structured metadata and regular labels to be extracted with static labels stage using different structured key": {
-			pipelineStagesYaml:         pipelineStagesStructuredMetadataFromStaticLabelsDifferentKey,
-			logLine:                    `sample log line`,
-			expectedStructuredMetadata: `{"pod_name":"loki-querier-664f97db8d-qhnwg"}`,
-			expectedLabels:             model.LabelSet{model.LabelName("component"): model.LabelValue("querier")},
+			pipelineStagesYaml: pipelineStagesStructuredMetadataFromStaticLabelsDifferentKey,
+			logLine:            `sample log line`,
+			expectedStructuredMetadata: map[string]any{
+				"pod_name": "loki-querier-664f97db8d-qhnwg",
+			},
+			expectedLabels: model.LabelSet{model.LabelName("component"): model.LabelValue("querier")},
 		},
 		"expected structured metadata and regular labels to be extracted using regex with static labels stage": {
-			pipelineStagesYaml:         pipelineStagesStructuredMetadataFromRegexLabels,
-			logLine:                    `sample log line`,
-			expectedStructuredMetadata: `{"label_app_kubernetes_io_component":"querier","label_app_kubernetes_io_name":"loki"}`,
-			expectedLabels:             model.LabelSet{model.LabelName("component"): model.LabelValue("querier")},
+			pipelineStagesYaml: pipelineStagesStructuredMetadataFromRegexLabels,
+			logLine:            `sample log line`,
+			expectedStructuredMetadata: map[string]any{
+				"label_app_kubernetes_io_component": "querier",
+				"label_app_kubernetes_io_name":      "loki",
+			},
+			expectedLabels: model.LabelSet{model.LabelName("component"): model.LabelValue("querier")},
 		},
 		"expected structured metadata and regular labels to be extracted using regex and non-regex with static labels stage": {
-			pipelineStagesYaml:         pipelineStagesStructuredMetadataFromRegexAndNonRegexLabels,
-			logLine:                    `sample log line`,
-			expectedStructuredMetadata: `{"label_app_kubernetes_io_component":"querier","label_app_kubernetes_io_name":"loki","pod_name":"loki-querier-664f97db8d-qhnwg"}`,
-			expectedLabels:             model.LabelSet{model.LabelName("component"): model.LabelValue("querier")},
+			pipelineStagesYaml: pipelineStagesStructuredMetadataFromRegexAndNonRegexLabels,
+			logLine:            `sample log line`,
+			expectedStructuredMetadata: map[string]any{
+				"label_app_kubernetes_io_component": "querier",
+				"label_app_kubernetes_io_name":      "loki",
+				"pod_name":                          "loki-querier-664f97db8d-qhnwg",
+			},
+			expectedLabels: model.LabelSet{model.LabelName("component"): model.LabelValue("querier")},
 		},
 		"expected structured metadata to be set from extracted values": {
-			pipelineStagesYaml:         pipelineStagesStructuredMetadataFromExtractedValues,
-			logLine:                    `pod=loki-querier-664f97db8d-qhnwg metadata_name=loki metadata_component=querier msg="sample log line"`,
-			expectedStructuredMetadata: `{"metadata_component":"querier","metadata_name":"loki","pod_name":"loki-querier-664f97db8d-qhnwg"}`,
+			pipelineStagesYaml: pipelineStagesStructuredMetadataFromExtractedValues,
+			logLine:            `pod=loki-querier-664f97db8d-qhnwg metadata_name=loki metadata_component=querier msg="sample log line"`,
+			expectedStructuredMetadata: map[string]any{
+				"metadata_component": "querier",
+				"metadata_name":      "loki",
+				"pod_name":           "loki-querier-664f97db8d-qhnwg",
+			},
 		},
 		"expected structured metadata from nested values": {
-			pipelineStagesYaml:         pipelineStagesStructuredMetadataFromNestedValues,
-			logLine:                    `{"app":"loki", "component_nested": {"name":"ingester", "props":{"n1": "v1", "n2": "v2"}}, "component_non_nested": "non_nested_val"}`,
-			expectedStructuredMetadata: `{"component_nested":"{\"name\":\"ingester\",\"props\":{\"n1\":\"v1\",\"n2\":\"v2\"}}","component_non_nested":"non_nested_val"}`,
+			pipelineStagesYaml: pipelineStagesStructuredMetadataFromNestedValues,
+			logLine:            `{"app":"loki", "component_nested": {"name":"ingester", "props":{"n1": "v1", "n2": "v2"}}, "component_non_nested": "non_nested_val"}`,
+			expectedStructuredMetadata: map[string]any{
+				"component_nested": map[string]any{
+					"name": "ingester",
+					"props": map[string]any{
+						"n1": "v1",
+						"n2": "v2",
+					},
+				},
+				"component_non_nested": "non_nested_val",
+			},
 		},
 	}
 	for name, test := range tests {
@@ -207,9 +246,22 @@ func Test_StructuredMetadataStage(t *testing.T) {
 
 			result := processEntries(pl, newEntry(nil, nil, test.logLine, time.Now()))[0]
 
-			sm, err := result.StructuredMetadata.MarshalJSON()
-			require.NoError(t, err)
-			require.Equal(t, test.expectedStructuredMetadata, string(sm))
+			sortedExpected := slices.Sorted(maps.Keys(test.expectedStructuredMetadata))
+			slices.SortFunc(result.StructuredMetadata, func(a, b push.LabelAdapter) int {
+				return strings.Compare(a.Name, b.Name)
+			})
+			for idx, metadata := range result.StructuredMetadata {
+				require.Equal(t, sortedExpected[idx], metadata.Name)
+				switch v := test.expectedStructuredMetadata[metadata.Name].(type) {
+				case string:
+					require.Equal(t, v, metadata.Value)
+				case map[string]any:
+					var actual map[string]any
+					err := json.Unmarshal([]byte(metadata.Value), &actual)
+					require.NoError(t, err)
+					require.Equal(t, v, actual)
+				}
+			}
 
 			if test.expectedLabels != nil {
 				require.Equal(t, test.expectedLabels, result.Labels)


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Example failure from this [test run](https://github.com/grafana/alloy/actions/runs/19311704691/job/55233327173?pr=4642) shown below, `result.StructuredMetadata.MarshalJSON()` did not have guaranteed ordering so it would inconsistently fail.

```
--- FAIL: Test_StructuredMetadataStage (0.00s)
    --- FAIL: Test_StructuredMetadataStage/expected_structured_metadata_from_nested_values (0.00s)
        structured_metadata_test.go:212: 
            	Error Trace:	/Users/runner/work/alloy/alloy/internal/component/loki/process/stages/structured_metadata_test.go:212
            	Error:      	Not equal: 
            	            	expected: "{\"component_nested\":\"{\\\"name\\\":\\\"ingester\\\",\\\"props\\\":{\\\"n1\\\":\\\"v1\\\",\\\"n2\\\":\\\"v2\\\"}}\",\"component_non_nested\":\"non_nested_val\"}"
            	            	actual  : "{\"component_nested\":\"{\\\"name\\\":\\\"ingester\\\",\\\"props\\\":{\\\"n2\\\":\\\"v2\\\",\\\"n1\\\":\\\"v1\\\"}}\",\"component_non_nested\":\"non_nested_val\"}"
            	            	
            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1 +1 @@
            	            	-{"component_nested":"{\"name\":\"ingester\",\"props\":{\"n1\":\"v1\",\"n2\":\"v2\"}}","component_non_nested":"non_nested_val"}
            	            	+{"component_nested":"{\"name\":\"ingester\",\"props\":{\"n2\":\"v2\",\"n1\":\"v1\"}}","component_non_nested":"non_nested_val"}
```