### PR TITLE
Add missing mutex to tail.reader usage

### DIFF
--- a/internal/component/loki/source/file/internal/tail/tail.go
+++ b/internal/component/loki/source/file/internal/tail/tail.go
@@ -394,6 +394,8 @@ func (tail *Tail) seekTo(pos SeekInfo) error {
 		return fmt.Errorf("Seek error on %s: %s", tail.Filename, err)
 	}
 	// Reset the read buffer whenever the file is re-seek'ed
+	tail.readerMut.Lock()
 	tail.reader.Reset(tail.file)
+	tail.readerMut.Unlock()
 	return nil
 }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Race [detected](https://github.com/grafana/alloy/actions/runs/19321022772/job/55262368245?pr=4816) in tests.
```
WARNING: DATA RACE
Read at 0x00c0057833b0 by goroutine 1267:
  bufio.(*Reader).Buffered()
      /opt/hostedtoolcache/go/1.25.1/x64/src/bufio/bufio.go:339 +0x1b2
  github.com/grafana/alloy/internal/component/loki/source/file/internal/tail.(*Tail).Tell()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/internal/tail/tail.go:136 +0x178
  github.com/grafana/alloy/internal/component/loki/source/file.(*tailer).markPositionAndSize()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/tailer.go:354 +0x3ee
  github.com/grafana/alloy/internal/component/loki/source/file.(*tailer).stop()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/tailer.go:370 +0x46
  github.com/grafana/alloy/internal/component/loki/source/file.(*tailer).Run()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/tailer.go:186 +0x3f3
  github.com/grafana/alloy/internal/component/loki/source/file.(*SourceWithRetry[go.shape.struct { Path string "yaml:\"path\""; Labels string "yaml:\"labels\"" }]).Run()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/scheduler.go:120 +0x178
  github.com/grafana/alloy/internal/component/loki/source/file.(*SourceWithRetry[github.com/grafana/alloy/internal/component/common/loki/positions.Entry]).Run()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/scheduler.go:116 +0x4a
  github.com/grafana/alloy/internal/component/loki/source/file.(*Scheduler[go.shape.struct { Path string "yaml:\"path\""; Labels string "yaml:\"labels\"" }]).ScheduleSource.func1()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/scheduler.go:50 +0x37
  sync.(*WaitGroup).Go.func1()
      /opt/hostedtoolcache/go/1.25.1/x64/src/sync/waitgroup.go:239 +0x5d

Previous write at 0x00c0057833b0 by goroutine 1271:
  bufio.(*Reader).reset()
      /opt/hostedtoolcache/go/1.25.1/x64/src/bufio/bufio.go:88 +0x2c5
  bufio.(*Reader).Reset()
      /opt/hostedtoolcache/go/1.25.1/x64/src/bufio/bufio.go:84 +0x234
  github.com/grafana/alloy/internal/component/loki/source/file/internal/tail.(*Tail).seekTo()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/internal/tail/tail.go:397 +0x16f
  github.com/grafana/alloy/internal/component/loki/source/file/internal/tail.(*Tail).tailFileSync()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/internal/tail/tail.go:294 +0x3b8
  github.com/grafana/alloy/internal/component/loki/source/file/internal/tail.TailFile.gowrap1()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/internal/tail/tail.go:109 +0x33

Goroutine 1267 (running) created at:
  sync.(*WaitGroup).Go()
      /opt/hostedtoolcache/go/1.25.1/x64/src/sync/waitgroup.go:237 +0x86
  github.com/grafana/alloy/internal/component/loki/source/file.(*Scheduler[go.shape.struct { Path string "yaml:\"path\""; Labels string "yaml:\"labels\"" }]).ScheduleSource()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/scheduler.go:49 +0x304
  github.com/grafana/alloy/internal/component/loki/source/file.(*Component).scheduleSources-range1()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/file.go:342 +0x128f
  github.com/grafana/alloy/internal/component/loki/source/file.(*staticResolver).Resolve.func1()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/resolver.go:45 +0x166
  github.com/grafana/alloy/internal/component/loki/source/file.(*Component).scheduleSources()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/file.go:290 +0x229
  github.com/grafana/alloy/internal/component/loki/source/file.(*Component).Update()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/file.go:278 +0x424
  github.com/grafana/alloy/internal/component/loki/source/file.New()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/file.go:169 +0x546
  github.com/grafana/alloy/internal/component/loki/source/file.init.0.func1()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/file.go:32 +0x177
  github.com/grafana/alloy/internal/runtime/componenttest.(*Controller).buildComponent()
      /home/runner/work/alloy/alloy/internal/runtime/componenttest/componenttest.go:192 +0x527
  github.com/grafana/alloy/internal/runtime/componenttest.(*Controller).Run()
      /home/runner/work/alloy/alloy/internal/runtime/componenttest/componenttest.go:130 +0x131
  github.com/grafana/alloy/internal/component/loki/source/file.TestLegacyConversion.func1()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/legacy_file_test.go:61 +0x3c8

Goroutine 1271 (running) created at:
  github.com/grafana/alloy/internal/component/loki/source/file/internal/tail.TailFile()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/internal/tail/tail.go:109 +0x4e4
  github.com/grafana/alloy/internal/component/loki/source/file.(*tailer).initRun()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/tailer.go:229 +0xa3d
  github.com/grafana/alloy/internal/component/loki/source/file.(*tailer).Run()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/tailer.go:156 +0x79
  github.com/grafana/alloy/internal/component/loki/source/file.(*SourceWithRetry[go.shape.struct { Path string "yaml:\"path\""; Labels string "yaml:\"labels\"" }]).Run()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/scheduler.go:120 +0x178
  github.com/grafana/alloy/internal/component/loki/source/file.(*SourceWithRetry[github.com/grafana/alloy/internal/component/common/loki/positions.Entry]).Run()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/scheduler.go:116 +0x4a
  github.com/grafana/alloy/internal/component/loki/source/file.(*Scheduler[go.shape.struct { Path string "yaml:\"path\""; Labels string "yaml:\"labels\"" }]).ScheduleSource.func1()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/scheduler.go:50 +0x37
  sync.(*WaitGroup).Go.func1()
      /opt/hostedtoolcache/go/1.25.1/x64/src/sync/waitgroup.go:239 +0x5d
==================
==================
WARNING: DATA RACE
Read at 0x00c0057833a8 by goroutine 1267:
  bufio.(*Reader).Buffered()
      /opt/hostedtoolcache/go/1.25.1/x64/src/bufio/bufio.go:339 +0x1d0
  github.com/grafana/alloy/internal/component/loki/source/file/internal/tail.(*Tail).Tell()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/internal/tail/tail.go:136 +0x178
  github.com/grafana/alloy/internal/component/loki/source/file.(*tailer).markPositionAndSize()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/tailer.go:354 +0x3ee
  github.com/grafana/alloy/internal/component/loki/source/file.(*tailer).stop()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/tailer.go:370 +0x46
  github.com/grafana/alloy/internal/component/loki/source/file.(*tailer).Run()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/tailer.go:186 +0x3f3
  github.com/grafana/alloy/internal/component/loki/source/file.(*SourceWithRetry[go.shape.struct { Path string "yaml:\"path\""; Labels string "yaml:\"labels\"" }]).Run()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/scheduler.go:120 +0x178
  github.com/grafana/alloy/internal/component/loki/source/file.(*SourceWithRetry[github.com/grafana/alloy/internal/component/common/loki/positions.Entry]).Run()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/scheduler.go:116 +0x4a
  github.com/grafana/alloy/internal/component/loki/source/file.(*Scheduler[go.shape.struct { Path string "yaml:\"path\""; Labels string "yaml:\"labels\"" }]).ScheduleSource.func1()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/scheduler.go:50 +0x37
  sync.(*WaitGroup).Go.func1()
      /opt/hostedtoolcache/go/1.25.1/x64/src/sync/waitgroup.go:239 +0x5d

Previous write at 0x00c0057833a8 by goroutine 1271:
  bufio.(*Reader).reset()
      /opt/hostedtoolcache/go/1.25.1/x64/src/bufio/bufio.go:88 +0x2c5
  bufio.(*Reader).Reset()
      /opt/hostedtoolcache/go/1.25.1/x64/src/bufio/bufio.go:84 +0x234
  github.com/grafana/alloy/internal/component/loki/source/file/internal/tail.(*Tail).seekTo()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/internal/tail/tail.go:397 +0x16f
  github.com/grafana/alloy/internal/component/loki/source/file/internal/tail.(*Tail).tailFileSync()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/internal/tail/tail.go:294 +0x3b8
  github.com/grafana/alloy/internal/component/loki/source/file/internal/tail.TailFile.gowrap1()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/internal/tail/tail.go:109 +0x33

Goroutine 1267 (running) created at:
  sync.(*WaitGroup).Go()
      /opt/hostedtoolcache/go/1.25.1/x64/src/sync/waitgroup.go:237 +0x86
  github.com/grafana/alloy/internal/component/loki/source/file.(*Scheduler[go.shape.struct { Path string "yaml:\"path\""; Labels string "yaml:\"labels\"" }]).ScheduleSource()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/scheduler.go:49 +0x304
  github.com/grafana/alloy/internal/component/loki/source/file.(*Component).scheduleSources-range1()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/file.go:342 +0x128f
  github.com/grafana/alloy/internal/component/loki/source/file.(*staticResolver).Resolve.func1()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/resolver.go:45 +0x166
  github.com/grafana/alloy/internal/component/loki/source/file.(*Component).scheduleSources()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/file.go:290 +0x229
  github.com/grafana/alloy/internal/component/loki/source/file.(*Component).Update()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/file.go:278 +0x424
  github.com/grafana/alloy/internal/component/loki/source/file.New()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/file.go:169 +0x546
  github.com/grafana/alloy/internal/component/loki/source/file.init.0.func1()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/file.go:32 +0x177
  github.com/grafana/alloy/internal/runtime/componenttest.(*Controller).buildComponent()
      /home/runner/work/alloy/alloy/internal/runtime/componenttest/componenttest.go:192 +0x527
  github.com/grafana/alloy/internal/runtime/componenttest.(*Controller).Run()
      /home/runner/work/alloy/alloy/internal/runtime/componenttest/componenttest.go:130 +0x131
  github.com/grafana/alloy/internal/component/loki/source/file.TestLegacyConversion.func1()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/legacy_file_test.go:61 +0x3c8

Goroutine 1271 (running) created at:
  github.com/grafana/alloy/internal/component/loki/source/file/internal/tail.TailFile()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/internal/tail/tail.go:109 +0x4e4
  github.com/grafana/alloy/internal/component/loki/source/file.(*tailer).initRun()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/tailer.go:229 +0xa3d
  github.com/grafana/alloy/internal/component/loki/source/file.(*tailer).Run()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/tailer.go:156 +0x79
  github.com/grafana/alloy/internal/component/loki/source/file.(*SourceWithRetry[go.shape.struct { Path string "yaml:\"path\""; Labels string "yaml:\"labels\"" }]).Run()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/scheduler.go:120 +0x178
  github.com/grafana/alloy/internal/component/loki/source/file.(*SourceWithRetry[github.com/grafana/alloy/internal/component/common/loki/positions.Entry]).Run()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/scheduler.go:116 +0x4a
  github.com/grafana/alloy/internal/component/loki/source/file.(*Scheduler[go.shape.struct { Path string "yaml:\"path\""; Labels string "yaml:\"labels\"" }]).ScheduleSource.func1()
      /home/runner/work/alloy/alloy/internal/component/loki/source/file/scheduler.go:50 +0x37
  sync.(*WaitGroup).Go.func1()
      /opt/hostedtoolcache/go/1.25.1/x64/src/sync/waitgroup.go:239 +0x5d
```