### PR TITLE
Correct `extraEnv` indentation in container template

### DIFF
--- a/operations/helm/charts/alloy/CHANGELOG.md
+++ b/operations/helm/charts/alloy/CHANGELOG.md
@@ -12,6 +12,7 @@ Unreleased
 
 ### Bug fixes
 
+- Correct `extraEnv` indentation in container template (@orkhan-huseyn)
 - Remove invalid creationTimestamp in podlogs.monitoring.grafana.com CRD (@vehagn)
  
 1.4.0 (2025-10-27)

--- a/operations/helm/charts/alloy/templates/containers/_agent.yaml
+++ b/operations/helm/charts/alloy/templates/containers/_agent.yaml
@@ -32,8 +32,8 @@
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    {{- range $values.extraEnv }}
-    - {{- toYaml . | nindent 6 }}
+    {{- with $values.extraEnv }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- if $values.envFrom }}
   envFrom:

--- a/operations/helm/tests/extra-env/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-env/alloy/templates/controllers/daemonset.yaml
@@ -44,14 +44,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            -
-              name: GREETING
+            - name: GREETING
               value: Warm greetings to
-            -
-              name: HONORIFIC
+            - name: HONORIFIC
               value: The Most Honorable
-            -
-              name: NAME
+            - name: NAME
               value: Kubernetes
           ports:
             - containerPort: 12345


### PR DESCRIPTION
#### Fix `extraEnv` indentation error in alloy container template

#### Which issue(s) this PR fixes

When providing `extraEnv` inside `values.yaml` file, it was formatted incorrectly inside `containers.env` property in deployment resource. This was causing unpredictable behavior which in our case was missing environment variables when deployed.

#### Notes to the Reviewer

Add following environment variables to default `values.yaml` file:

```yaml
  extraEnv:
    - name: TZ
      value: Asia/Baku
    - name: POD_NAME
      valueFrom:
        fieldRef:
          fieldPath: metadata.name
    - name: VAULT_SKIP_VERIFY
      value: "true"
    - name: VAULT_ADDR
      value: https://vault.mycompany.az          
    - name: GOMAXPROCS
      value: "4"
    - name: MY_POD_IP
      valueFrom:
        fieldRef:
          fieldPath: status.podIP
```

Run following command to generate example output `helm template alloy . -f values.yaml > rendered.yaml`. Previously output was like below:

```yaml
          env:
            - name: ALLOY_DEPLOY_MODE
              value: "helm"
            - name: HOSTNAME
              valueFrom:
                fieldRef:
                  fieldPath: spec.nodeName
            -
              name: TZ
              value: Asia/Baku
            -
              name: POD_NAME
              valueFrom:
                fieldRef:
                  fieldPath: metadata.name
            -
              name: VAULT_SKIP_VERIFY
              value: "true"
            -
              name: VAULT_ADDR
              value: https://vault.mycompany.az
            -
              name: GOMAXPROCS
              value: "4"
            -
              name: MY_POD_IP
              valueFrom:
                fieldRef:
                  fieldPath: status.podIP
```

After the fix the output should be like following:

```yaml
          env:
            - name: ALLOY_DEPLOY_MODE
              value: "helm"
            - name: HOSTNAME
              valueFrom:
                fieldRef:
                  fieldPath: spec.nodeName
            - name: TZ
              value: Asia/Baku
            - name: POD_NAME
              valueFrom:
                fieldRef:
                  fieldPath: metadata.name
            - name: VAULT_SKIP_VERIFY
              value: "true"
            - name: VAULT_ADDR
              value: https://vault.mycompany.az
            - name: GOMAXPROCS
              value: "4"
            - name: MY_POD_IP
              valueFrom:
                fieldRef:
                  fieldPath: status.podIP
```

#### PR Checklist

- [x] CHANGELOG.md updated
- [x] Tests updated
