### PR TITLE
Update the OTEL_VERSION for docs links for v1.11

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -5,7 +5,7 @@ description: Grafana Alloy is a vendor-neutral distribution of the OTel Collecto
 weight: 350
 cascade:
   ALLOY_RELEASE: v1.11.0
-  OTEL_VERSION: v0.128.0
+  OTEL_VERSION: v0.134.0
   PROM_WIN_EXP_VERSION: v0.31.1
   SNMP_VERSION: v0.29.0
   BEYLA_VERSION: v2.5.8

--- a/docs/sources/_index.md.t
+++ b/docs/sources/_index.md.t
@@ -5,7 +5,7 @@ description: Grafana Alloy is a vendor-neutral distribution of the OTel Collecto
 weight: 350
 cascade:
   ALLOY_RELEASE: $ALLOY_VERSION
-  OTEL_VERSION: v0.128.0
+  OTEL_VERSION: v0.134.0
   PROM_WIN_EXP_VERSION: v0.31.1
   SNMP_VERSION: v0.29.0
   BEYLA_VERSION: v2.5.8


### PR DESCRIPTION
Looks like the variable wasn't updated in 1.11 so all of the docs links will link to the wrong upstream version.