### PR TITLE
Add support for attaching namespace metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,8 @@ Main (unreleased)
 
 - `loki.source.api` during component shutdown will now reject all the inflight requests with status code 503 after `graceful_shutdown_timeout` has expired. (@kalleep)
 
+- `kubernetes.discovery` Add support for attaching namespace metadata. (@kgeckhart)
+
 ### Bugfixes
 
 - Stop `loki.source.kubernetes` discarding log lines with duplicate timestamps. (@ciaranj)

--- a/docs/sources/reference/components/discovery/discovery.kubernetes.md
+++ b/docs/sources/reference/components/discovery/discovery.kubernetes.md
@@ -233,11 +233,11 @@ For example, `oauth2` > `tls_config` refers to a `tls_config` block defined insi
 ### `attach_metadata`
 
 The `attach_metadata` block allows you to attach node metadata to discovered targets.
-This block is valid for the `pod`, `endpoints`, and `endpointslice` roles.
 
-| Name   | Type   | Description           | Default | Required |
-| ------ | ------ | --------------------- | ------- | -------- |
-| `node` | `bool` | Attach node metadata. |         | no       |
+| Name        | Type   | Description                                                                                                                                                               | Default | Required |
+|-------------|--------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|----------|
+| `node`      | `bool` | Attach node metadata. Alloy must have permissions to list/watch Nodes. This is valid for the `pod`, `endpoints`, and `endpointslice` roles.                               |         | no       |
+| `namespace` | `bool` | Attach namespace metadata. Alloy must have permissions to list/watch Namespaces. Valid for roles the `pod`, `endpoints`, `endpointslice`, `service`, and `ingress` roles. |         | no       |
 
 ### `authorization`
 

--- a/internal/component/discovery/kubernetes/kubernetes.go
+++ b/internal/component/discovery/kubernetes/kubernetes.go
@@ -95,11 +95,13 @@ func (sc *SelectorConfig) convert() *promk8s.SelectorConfig {
 }
 
 type AttachMetadataConfig struct {
-	Node bool `alloy:"node,attr,optional"`
+	Node      bool `alloy:"node,attr,optional"`
+	Namespace bool `alloy:"namespace,attr,optional"`
 }
 
 func (am *AttachMetadataConfig) convert() *promk8s.AttachMetadataConfig {
 	return &promk8s.AttachMetadataConfig{
-		Node: am.Node,
+		Node:      am.Node,
+		Namespace: am.Namespace,
 	}
 }

--- a/internal/component/discovery/kubernetes/kubernetes_test.go
+++ b/internal/component/discovery/kubernetes/kubernetes_test.go
@@ -3,8 +3,9 @@ package kubernetes
 import (
 	"testing"
 
-	"github.com/grafana/alloy/syntax"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/syntax"
 )
 
 func TestAlloyConfig(t *testing.T) {
@@ -45,6 +46,7 @@ func TestAttachMetadata(t *testing.T) {
         role = "pod"
     attach_metadata {
 	    node = true
+		namespace = true
     }
 `
 

--- a/internal/converter/internal/prometheusconvert/component/kubernetes.go
+++ b/internal/converter/internal/prometheusconvert/component/kubernetes.go
@@ -1,13 +1,14 @@
 package component
 
 import (
+	prom_kubernetes "github.com/prometheus/prometheus/discovery/kubernetes"
+
 	"github.com/grafana/alloy/internal/component/common/config"
 	"github.com/grafana/alloy/internal/component/discovery"
 	"github.com/grafana/alloy/internal/component/discovery/kubernetes"
 	"github.com/grafana/alloy/internal/converter/diag"
 	"github.com/grafana/alloy/internal/converter/internal/common"
 	"github.com/grafana/alloy/internal/converter/internal/prometheusconvert/build"
-	prom_kubernetes "github.com/prometheus/prometheus/discovery/kubernetes"
 )
 
 func appendDiscoveryKubernetes(pb *build.PrometheusBlocks, label string, sdConfig *prom_kubernetes.SDConfig) discovery.Exports {
@@ -61,6 +62,7 @@ func toSelectorConfig(selectors []prom_kubernetes.SelectorConfig) []kubernetes.S
 
 func toAttachMetadata(amConfig *prom_kubernetes.AttachMetadataConfig) kubernetes.AttachMetadataConfig {
 	return kubernetes.AttachMetadataConfig{
-		Node: amConfig.Node,
+		Node:      amConfig.Node,
+		Namespace: amConfig.Namespace,
 	}
 }


### PR DESCRIPTION
#### PR Description

Pulls through a new configuration for kubernetes service discovery to attach namespace metadata introduced in prometheus 3.6.0 (https://github.com/prometheus/prometheus/pull/16831)

#### Which issue(s) this PR fixes

Related to https://github.com/grafana/alloy/issues/4274

#### PR Checklist

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
