### PR TITLE
Db-o11y: parse pg queries with quotes correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Main (unreleased)
     - add `user` field to wait events within `query_samples` collector (@gaantunes)
     - rework the query samples collector to buffer per-query execution state across scrapes and emit finalized entries (@gaantunes)
     - process turned idle rows to calculate finalization times precisely and emit first seen idle rows (@gaantunes)
+  - `query_details`
+    - escape queries that come with quotes (@gaantunes)
   - enable `explain_plans` collector by default (@rgeyer)
   - safely generate server_id when UDP socket used for database connection (@matthewnolf)
   - add table registry and include "validated" in parsed table name logs (@fridgepoet)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Main (unreleased)
     - rework the query samples collector to buffer per-query execution state across scrapes and emit finalized entries (@gaantunes)
     - process turned idle rows to calculate finalization times precisely and emit first seen idle rows (@gaantunes)
   - `query_details`
-    - escape queries that come with quotes (@gaantunes)
+    - escape queries comming from pg_stat_statements with quotes (@gaantunes)
   - enable `explain_plans` collector by default (@rgeyer)
   - safely generate server_id when UDP socket used for database connection (@matthewnolf)
   - add table registry and include "validated" in parsed table name logs (@fridgepoet)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Main (unreleased)
     - rework the query samples collector to buffer per-query execution state across scrapes and emit finalized entries (@gaantunes)
     - process turned idle rows to calculate finalization times precisely and emit first seen idle rows (@gaantunes)
   - `query_details`
-    - escape queries comming from pg_stat_statements with quotes (@gaantunes)
+    - escape queries coming from pg_stat_statements with quotes (@gaantunes)
   - enable `explain_plans` collector by default (@rgeyer)
   - safely generate server_id when UDP socket used for database connection (@matthewnolf)
   - add table registry and include "validated" in parsed table name logs (@fridgepoet)

--- a/internal/component/database_observability/postgres/collector/query_details.go
+++ b/internal/component/database_observability/postgres/collector/query_details.go
@@ -142,7 +142,7 @@ func (c QueryDetails) fetchAndAssociate(ctx context.Context) error {
 		c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
 			logging.LevelInfo,
 			OP_QUERY_ASSOCIATION,
-			fmt.Sprintf(`queryid="%s" querytext="%s" datname="%s" engine="postgres"`, queryID, queryText, databaseName),
+			fmt.Sprintf(`queryid="%s" querytext=%q datname="%s" engine="postgres"`, queryID, queryText, databaseName),
 		)
 
 		tables, err := c.tryTokenizeTableNames(queryText)
@@ -160,7 +160,7 @@ func (c QueryDetails) fetchAndAssociate(ctx context.Context) error {
 			c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
 				logging.LevelInfo,
 				OP_QUERY_PARSED_TABLE_NAME,
-				fmt.Sprintf(`queryid="%s" datname="%s" table="%s" engine="postgres" validated="%t"`, queryID, databaseName, table, validated),
+				fmt.Sprintf(`queryid=%q datname=%q table=%q engine="postgres" validated="%t"`, queryID, databaseName, table, validated),
 			)
 		}
 	}

--- a/internal/component/database_observability/postgres/collector/query_details.go
+++ b/internal/component/database_observability/postgres/collector/query_details.go
@@ -160,7 +160,7 @@ func (c QueryDetails) fetchAndAssociate(ctx context.Context) error {
 			c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
 				logging.LevelInfo,
 				OP_QUERY_PARSED_TABLE_NAME,
-				fmt.Sprintf(`queryid=%q datname=%q table=%q engine="postgres" validated="%t"`, queryID, databaseName, table, validated),
+				fmt.Sprintf(`queryid="%s" datname="%s" table="%s" engine="postgres" validated="%t"`, queryID, databaseName, table, validated),
 			)
 		}
 	}

--- a/internal/component/database_observability/postgres/collector/query_details_test.go
+++ b/internal/component/database_observability/postgres/collector/query_details_test.go
@@ -361,7 +361,7 @@ func TestQueryDetails(t *testing.T) {
 			},
 		},
 		{
-			name: "correctly parse quoted queries",
+			name: "correctly escape quoted queries",
 			eventStatementsRows: [][]driver.Value{
 				{
 					"3871016669222913500",

--- a/internal/component/database_observability/postgres/collector/query_details_test.go
+++ b/internal/component/database_observability/postgres/collector/query_details_test.go
@@ -360,6 +360,53 @@ func TestQueryDetails(t *testing.T) {
 				`level="info" queryid="abc123" datname="some_database" table="some_table" engine="postgres" validated="false"`,
 			},
 		},
+		{
+			name: "correctly parse quoted queries",
+			eventStatementsRows: [][]driver.Value{
+				{
+					"3871016669222913500",
+					`SELECT "pizza_to_ingredients"."pizza_id", "i"."id", "i"."name", "i"."calories_per_slice", "i"."vegetarian", "i"."type" FROM "ingredients" AS "i" JOIN "pizza_to_ingredients" AS "pizza_to_ingredients" ON ("pizza_to_ingredients"."pizza_id") IN ($1 /*, ... */) WHERE ("i"."id" = "pizza_to_ingredients"."ingredient_id")`,
+					"quickpizza",
+				},
+				{
+					"7865322458849960000",
+					`SELECT "quote"."name" FROM "quotes" AS "quote"`,
+					"quickpizza",
+				},
+				{
+					"5775615007769463000",
+					`SELECT "classical_name"."name" FROM "classical_names" AS "classical_name"`,
+					"quickpizza",
+				},
+				{
+					"7007034463187741000",
+					`SELECT "dough"."id", "dough"."name", "dough"."calories_per_slice" FROM "doughs" AS "dough"`,
+					"quickpizza",
+				},
+			},
+			logsLabels: []model.LabelSet{
+				{"op": OP_QUERY_ASSOCIATION},
+				{"op": OP_QUERY_PARSED_TABLE_NAME},
+				{"op": OP_QUERY_PARSED_TABLE_NAME},
+				{"op": OP_QUERY_ASSOCIATION},
+				{"op": OP_QUERY_PARSED_TABLE_NAME},
+				{"op": OP_QUERY_ASSOCIATION},
+				{"op": OP_QUERY_PARSED_TABLE_NAME},
+				{"op": OP_QUERY_ASSOCIATION},
+				{"op": OP_QUERY_PARSED_TABLE_NAME},
+			},
+			logsLines: []string{
+				`level="info" queryid="3871016669222913500" querytext="SELECT \"pizza_to_ingredients\".\"pizza_id\", \"i\".\"id\", \"i\".\"name\", \"i\".\"calories_per_slice\", \"i\".\"vegetarian\", \"i\".\"type\" FROM \"ingredients\" AS \"i\" JOIN \"pizza_to_ingredients\" AS \"pizza_to_ingredients\" ON (\"pizza_to_ingredients\".\"pizza_id\") IN ($1 /*, ... */) WHERE (\"i\".\"id\" = \"pizza_to_ingredients\".\"ingredient_id\")" datname="quickpizza" engine="postgres"`,
+				`level="info" queryid="3871016669222913500" datname="quickpizza" table="ingredients" engine="postgres" validated="false"`,
+				`level="info" queryid="3871016669222913500" datname="quickpizza" table="pizza_to_ingredients" engine="postgres" validated="false"`,
+				`level="info" queryid="7865322458849960000" querytext="SELECT \"quote\".\"name\" FROM \"quotes\" AS \"quote\"" datname="quickpizza" engine="postgres"`,
+				`level="info" queryid="7865322458849960000" datname="quickpizza" table="quotes" engine="postgres" validated="false"`,
+				`level="info" queryid="5775615007769463000" querytext="SELECT \"classical_name\".\"name\" FROM \"classical_names\" AS \"classical_name\"" datname="quickpizza" engine="postgres"`,
+				`level="info" queryid="5775615007769463000" datname="quickpizza" table="classical_names" engine="postgres" validated="false"`,
+				`level="info" queryid="7007034463187741000" querytext="SELECT \"dough\".\"id\", \"dough\".\"name\", \"dough\".\"calories_per_slice\" FROM \"doughs\" AS \"dough\"" datname="quickpizza" engine="postgres"`,
+				`level="info" queryid="7007034463187741000" datname="quickpizza" table="doughs" engine="postgres" validated="false"`,
+			},
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

When a queryText is fetched from pg_stat_statements with quotes, we need to escape it correctly.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
