### PR TITLE
Fix git checkout command for release branch

### DIFF
--- a/docs/developer/release/03-tag-release.md
+++ b/docs/developer/release/03-tag-release.md
@@ -9,7 +9,7 @@ A tag is required to create GitHub artifacts and as a prerequisite for publishin
 2. Make sure you are up to date on the release branch:
 
    ``` 
-   git checkout release-VERSION_PREFIX
+   git checkout release/VERSION_PREFIX
    git fetch origin 
    git pull origin 
    ```


### PR DESCRIPTION
Doc was still using old agent-style branch naming