### PR TITLE
ci: fix publish-alloy-release workflow

### DIFF
--- a/.github/workflows/publish-alloy-release.yml
+++ b/.github/workflows/publish-alloy-release.yml
@@ -253,34 +253,29 @@ jobs:
           ALLOYBOT_APP_ID=alloybot:app_id
           ALLOYBOT_PRIVATE_KEY=alloybot:private_key
 
-    - name: Get GitHub app token
-      uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
-      id: get-token
+    - name: Create GitHub app token
+      uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+      id: app-token
       with:
         app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).ALLOYBOT_APP_ID }}
         private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).ALLOYBOT_PRIVATE_KEY }}
-        permission-contents: write
+        owner: grafana
+        repositories: alloy
 
-    - name: Get GitHub App
-      env:
-        APP_SLUG: ${{ steps.get-token.outputs.app-slug }}
-        GH_TOKEN: ${{ steps.get-token.outputs.token }}
-      id: get-app
-      run: |
-        APP_ID="$(gh api "/apps/${APP_SLUG}" --jq .id)" || exit 1
-        echo "app-id=${APP_ID}" >> "${GITHUB_OUTPUT}"
-        echo "app-login=${APP_SLUG}[bot]" >> "${GITHUB_OUTPUT}"
+    - name: Checkout
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        fetch-depth: 0
+        token: ${{ steps.app-token.outputs.token }}
+        persist-credentials: false
 
     - name: Configure Git
-      env:
-        APP_ID: ${{ steps.get-app.outputs.app-id }}
-        APP_LOGIN: ${{ steps.get-app.outputs.app-login }}
       run: |
-        git config --global user.name "${APP_LOGIN}"
-        git config --global user.email "${APP_ID}+${APP_LOGIN}@users.noreply.github.com"
+        git config user.name "$GITHUB_ACTOR"
+        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
     - name: Publish
       run: |
         VERSION="${GITHUB_REF_NAME}" RELEASE_DOC_TAG=$(echo "${GITHUB_REF_NAME}" | awk -F '.' '{print $1"."$2}') ./tools/release
       env:
-        GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
+        GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
gh command is was not found. Replace it with the way we do this elsewhere in the repo
