### PR TITLE
database_observability: fix schema_details collector to fetch column definitions with case sensitive table names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Main (unreleased)
 
 - `loki.source.api` no longer drops request when relabel rules drops a specific stream. (@kalleep)
 
-- (_Experimental_) Additions to experimental `database_observability.postgres` component:
+- (_Public Preview_) Additions to `database_observability.postgres` component:
     - fixes collection of Postgres schema details for mixed case table names (@fridgepoet)
 
 v1.12.0-rc.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Main (unreleased)
 
 - `loki.source.api` no longer drops request when relabel rules drops a specific stream. (@kalleep)
 
+- (_Experimental_) Additions to experimental `database_observability.postgres` component:
+    - fixes collection of Postgres schema details for mixed case table names (@fridgepoet)
+
 v1.12.0-rc.0
 -----------------
 

--- a/internal/component/database_observability/postgres/collector/connection_info_test.go
+++ b/internal/component/database_observability/postgres/collector/connection_info_test.go
@@ -15,7 +15,9 @@ import (
 )
 
 func TestConnectionInfo(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	// The goroutine which deletes expired entries runs indefinitely,
+	// see https://github.com/hashicorp/golang-lru/blob/v2.0.7/expirable/expirable_lru.go#L79-L80
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"))
 
 	const baseExpectedMetrics = `
 	# HELP database_observability_connection_info Information about the connection

--- a/internal/component/database_observability/postgres/collector/query_details_test.go
+++ b/internal/component/database_observability/postgres/collector/query_details_test.go
@@ -17,7 +17,9 @@ import (
 )
 
 func TestQueryDetails(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	// The goroutine which deletes expired entries runs indefinitely,
+	// see https://github.com/hashicorp/golang-lru/blob/v2.0.7/expirable/expirable_lru.go#L79-L80
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"))
 
 	testcases := []struct {
 		name                string
@@ -468,7 +470,9 @@ func TestQueryDetails(t *testing.T) {
 }
 
 func TestQueryDetails_SQLDriverErrors(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	// The goroutine which deletes expired entries runs indefinitely,
+	// see https://github.com/hashicorp/golang-lru/blob/v2.0.7/expirable/expirable_lru.go#L79-L80
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"))
 
 	t.Run("recoverable sql error in result set", func(t *testing.T) {
 		t.Parallel()

--- a/internal/component/database_observability/postgres/collector/schema_details.go
+++ b/internal/component/database_observability/postgres/collector/schema_details.go
@@ -70,7 +70,8 @@ const (
 		pg_attribute: stores column information
 		pg_attrdef: stores default values for columns
 		pg_constraint: stores primary key information
-		attr.attrelid = $1::regclass -- filter by the table name
+		JOIN pg_class to filter by table name
+		JOIN pg_namespace to filter by schema name
 		AND attr.attnum > 0  -- no system columns
 		AND NOT attr.attisdropped -- no dropped columns`
 	*/
@@ -87,10 +88,13 @@ const (
 		END as is_primary_key
 	FROM
 		pg_attribute attr
+		JOIN pg_catalog.pg_class pg_class ON attr.attrelid = pg_class.oid
+		JOIN pg_catalog.pg_namespace pg_namespace ON pg_class.relnamespace = pg_namespace.oid
 		LEFT JOIN pg_catalog.pg_attrdef def ON attr.attrelid = def.adrelid AND attr.attnum = def.adnum
 		LEFT JOIN pg_catalog.pg_constraint constraint_pk ON attr.attrelid = constraint_pk.conrelid AND attr.attnum = ANY(constraint_pk.conkey) AND constraint_pk.contype = 'p'
 	WHERE
-		attr.attrelid = $1::regclass
+		pg_namespace.nspname = $1
+		AND pg_class.relname = $2
 		AND attr.attnum > 0
 		AND NOT attr.attisdropped`
 
@@ -580,8 +584,7 @@ func (c *SchemaDetails) fetchTableDefinitions(ctx context.Context, table *tableI
 }
 
 func (c *SchemaDetails) fetchColumnsDefinitions(ctx context.Context, databaseName database, schemaName schema, tableName table, dbConnection *sql.DB) (*tableSpec, error) {
-	qualifiedTableName := fmt.Sprintf("%s.%s", schemaName, tableName)
-	colRS, err := dbConnection.QueryContext(ctx, selectColumnNames, qualifiedTableName)
+	colRS, err := dbConnection.QueryContext(ctx, selectColumnNames, schemaName, tableName)
 	if err != nil {
 		level.Error(c.logger).Log("msg", "failed to query table columns", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
 		return nil, err

--- a/internal/component/database_observability/postgres/collector/schema_details_test.go
+++ b/internal/component/database_observability/postgres/collector/schema_details_test.go
@@ -73,7 +73,7 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 				}).AddRow("authors"),
 			)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.authors").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "authors").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"column_name",
@@ -189,7 +189,7 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 				}).AddRow("spatial_ref_sys"),
 			)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.authors").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "authors").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"column_name",
@@ -223,7 +223,7 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 				}),
 			)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.categories").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "categories").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"column_name",
@@ -257,7 +257,7 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 				}),
 			)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("postgis.spatial_ref_sys").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("postgis", "spatial_ref_sys").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"column_name",
@@ -383,7 +383,7 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows([]string{"schema_name"}).AddRow("public"))
 		db1Mock.ExpectQuery(selectTableNames).WithArgs("public").RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("users"))
-		db1Mock.ExpectQuery(selectColumnNames).WithArgs("public.users").RowsWillBeClosed().
+		db1Mock.ExpectQuery(selectColumnNames).WithArgs("public", "users").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{"column_name", "column_type", "not_nullable", "column_default", "identity_generation", "is_primary_key"}).
 					AddRow("id", "integer", true, nil, "", true),
@@ -397,7 +397,7 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows([]string{"schema_name"}).AddRow("public"))
 		db2Mock.ExpectQuery(selectTableNames).WithArgs("public").RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("metrics"))
-		db2Mock.ExpectQuery(selectColumnNames).WithArgs("public.metrics").RowsWillBeClosed().
+		db2Mock.ExpectQuery(selectColumnNames).WithArgs("public", "metrics").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{"column_name", "column_type", "not_nullable", "column_default", "identity_generation", "is_primary_key"}).
 					AddRow("id", "bigint", true, nil, "", true),
@@ -485,7 +485,7 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 				}).AddRow("users"),
 			)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.users").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "users").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"column_name",
@@ -654,7 +654,7 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 				}).AddRow("test_table"),
 			)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.test_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"column_name",
@@ -765,7 +765,7 @@ func Test_Postgres_SchemaDetails_collector_detects_auto_increment_column(t *test
 				}).AddRow("users"),
 			)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.users").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "users").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"column_name",
@@ -871,7 +871,7 @@ func Test_Postgres_SchemaDetails_collector_detects_auto_increment_column(t *test
 				}).AddRow("products"),
 			)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.products").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "products").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"column_name",
@@ -978,7 +978,7 @@ func Test_Postgres_SchemaDetails_collector_detects_auto_increment_column(t *test
 				}).AddRow("books"),
 			)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.books").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "books").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"column_name",
@@ -1085,7 +1085,7 @@ func Test_Postgres_SchemaDetails_caching(t *testing.T) {
 			)
 
 		// selectColumnNames, selectIndexes, selectForeignKeys called only first run
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.test_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"column_name",
@@ -1215,7 +1215,7 @@ func Test_Postgres_SchemaDetails_caching(t *testing.T) {
 					}).AddRow("test_table"),
 				)
 
-			mock.ExpectQuery(selectColumnNames).WithArgs("public.test_table").RowsWillBeClosed().
+			mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").RowsWillBeClosed().
 				WillReturnRows(
 					sqlmock.NewRows([]string{
 						"column_name",
@@ -1322,7 +1322,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.test_table").
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").
 			WillReturnError(fmt.Errorf("column query error"))
 
 		collector := &SchemaDetails{logger: log.NewNopLogger()}
@@ -1347,7 +1347,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 			logger: log.NewNopLogger(),
 		}
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.test_table").
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").
 			WillReturnError(fmt.Errorf("column query error"))
 
 		_, err = collector.fetchColumnsDefinitions(context.Background(), "testdb", "public", "test_table", db)
@@ -1367,7 +1367,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 			logger: log.NewNopLogger(),
 		}
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.test_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{"column_name", "column_type", "not_nullable", "column_default", "identity_generation"}).
 				AddRow("id", "integer", true, nil, ""))
 
@@ -1383,7 +1383,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.test_table").
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").
 			WillReturnRows(
 				sqlmock.NewRows([]string{"column_name", "column_type", "not_nullable", "column_default", "identity_generation", "is_primary_key"}).
 					AddRow("id", "integer", true, nil, "", true).
@@ -1402,7 +1402,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.test_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{"column_name", "column_type", "not_nullable", "column_default", "identity_generation", "is_primary_key"}).
 				AddRow("id", "integer", true, nil, "", true))
 		mock.ExpectQuery(selectIndexes).WithArgs("public", "test_table").
@@ -1421,7 +1421,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.test_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{"column_name", "column_type", "not_nullable", "column_default", "identity_generation", "is_primary_key"}).
 				AddRow("id", "integer", true, nil, "", true))
 		mock.ExpectQuery(selectIndexes).WithArgs("public", "test_table").RowsWillBeClosed().
@@ -1441,7 +1441,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.test_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{"column_name", "column_type", "not_nullable", "column_default", "identity_generation", "is_primary_key"}).
 				AddRow("id", "integer", true, nil, "", true))
 		mock.ExpectQuery(selectIndexes).WithArgs("public", "test_table").
@@ -1464,7 +1464,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.test_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{"column_name", "column_type", "not_nullable", "column_default", "identity_generation", "is_primary_key"}).
 				AddRow("id", "integer", true, nil, "", true))
 		mock.ExpectQuery(selectIndexes).WithArgs("public", "test_table").RowsWillBeClosed().
@@ -1486,7 +1486,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.test_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{"column_name", "column_type", "not_nullable", "column_default", "identity_generation", "is_primary_key"}).
 				AddRow("id", "integer", true, nil, "", true))
 		mock.ExpectQuery(selectIndexes).WithArgs("public", "test_table").RowsWillBeClosed().
@@ -1508,7 +1508,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.test_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{"column_name", "column_type", "not_nullable", "column_default", "identity_generation", "is_primary_key"}).
 				AddRow("id", "integer", true, nil, "", true))
 		mock.ExpectQuery(selectIndexes).WithArgs("public", "test_table").RowsWillBeClosed().
@@ -1627,7 +1627,7 @@ func Test_SchemaDetails_populates_TableRegistry(t *testing.T) {
 					"table_name",
 				}).AddRow("users").AddRow("orders"),
 			)
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.users").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "users").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"column_name",
@@ -1658,7 +1658,7 @@ func Test_SchemaDetails_populates_TableRegistry(t *testing.T) {
 					"referenced_column_name",
 				}),
 			)
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.orders").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "orders").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"column_name",


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR modifies the select column query to look up table name from pg_class and schema from pg_namespace, preserving any case sensitivity of the table name.

Previously, the lookup was done with a cast `::regclass`. `::regclass` lowercases unquoted identifiers, so if the table was created with mixed case, the lookup failed.

For example:
If a table like `public.SomeMixedCaseName` exists, then the previous code would fail with an error message like:
`level=error msg="failed to get table definitions" component_path=/ component_id=database_observability.postgres.postgres_postgres_db collector=schema_details database=some_db schema=public err="pq: relation \"public.somemixedcasename\" does not exist"`

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
