### PR TITLE
Remove experimental flag from stage.windowsevent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Main (unreleased)
 ### Features
 
 - A new `mimir.alerts.kubernetes` component which discovers `AlertmanagerConfig` Kubernetes resources and loads them into a Mimir instance. (@ptodev)
+- Mark `stage.windowsevent` block in the `loki.process` component as GA. (@kgeckhart)
 
 ### Enhancements
 

--- a/internal/component/loki/process/stages/stage.go
+++ b/internal/component/loki/process/stages/stage.go
@@ -50,11 +50,6 @@ const (
 	StageTypeWindowsEvent           = "windowsevent"
 )
 
-// Add stages that are not GA. Stages that are not specified here are considered GA.
-var stagesUnstable = map[string]featuregate.Stability{
-	StageTypeWindowsEvent: featuregate.StabilityExperimental,
-}
-
 // Processor takes an existing set of labels, timestamp and log entry and returns either a possibly mutated
 // timestamp and log entry
 type Processor interface {
@@ -119,14 +114,6 @@ func toStage(p Processor) Stage {
 		Processor: p,
 		inspector: newInspector(os.Stderr, runtime.GOOS == "windows"),
 	}
-}
-
-func checkFeatureStability(stageName string, minStability featuregate.Stability) error {
-	blockStability, exist := stagesUnstable[stageName]
-	if exist {
-		return featuregate.CheckAllowed(blockStability, minStability, fmt.Sprintf("stage %q", stageName))
-	}
-	return nil
 }
 
 // New creates a new stage for the given type and configuration.
@@ -276,10 +263,6 @@ func New(logger log.Logger, jobName *string, cfg StageConfig, registerer prometh
 		}
 	default:
 		panic(fmt.Sprintf("unreachable; should have decoded into one of the StageConfig fields: %+v", cfg))
-	}
-
-	if err := checkFeatureStability(s.Name(), minStability); err != nil {
-		return nil, err
 	}
 
 	return s, nil

--- a/internal/component/loki/process/stages/windowsevent_test.go
+++ b/internal/component/loki/process/stages/windowsevent_test.go
@@ -228,8 +228,3 @@ func TestWindowsEventValidate(t *testing.T) {
 		})
 	}
 }
-
-func TestWindowsEventStabilityLevel(t *testing.T) {
-	_, err := NewPipeline(log.NewNopLogger(), loadConfig(testWindowsEventMsgDefaults), nil, prometheus.DefaultRegisterer, featuregate.StabilityPublicPreview)
-	require.ErrorContains(t, err, `invalid stage config stage "windowsevent" is at stability level "experimental", which is below the minimum allowed stability level "public-preview". Use --stability.level command-line flag to enable "experimental" features`)
-}


### PR DESCRIPTION
#### PR Description

Removes the experimental requirement from stage.windowsevent which hasn't changed since it was originally introduced in Feb. No doc changes required because the docs didn't mention it was experimental.

#### PR Checklist

- [x] CHANGELOG.md updated
