### PR TITLE
Fix lint in targets.go and add a test for potential issue

### DIFF
--- a/internal/component/discovery/target.go
+++ b/internal/component/discovery/target.go
@@ -32,7 +32,8 @@ var (
 		return stringSlicesPool.Get().([]string)
 	}
 	releaseLabelsSlice = func(labels []string) {
-		stringSlicesPool.Put(labels[:0])
+		// We can ignore linter warning here, because slice headers are small and the underlying array will be reused.
+		stringSlicesPool.Put(labels[:0]) //nolint:staticcheck // SA6002
 	}
 
 	_ syntax.Capsule                = Target{}

--- a/internal/component/discovery/target_test.go
+++ b/internal/component/discovery/target_test.go
@@ -800,9 +800,9 @@ func TestHashLabelsWithPredicateClearsStringSlicePool(t *testing.T) {
 			"job": "hash-test",
 			"env": "prod",
 		})
-		recordedLens []int
-		scratch      []string
-		originalBorrow = borrowLabelsSlice
+		recordedLens    []int
+		scratch         []string
+		originalBorrow  = borrowLabelsSlice
 		originalRelease = releaseLabelsSlice
 	)
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

1. Fix the lint in targets.go

2. There was no actual issue in production, but only because we got lucky:

When we do `labelsInOrder[:]` we don't trim the slice. It was meant to be `labelsInOrder[:0]` to trim it. So this looks like a bug where the slices pool may have elements with leftover entries in them (!)

However, after testing this further I realised that all slices in the pool had 0 length because we got lucky: The original `defer stringSlicesPool.Put(labelsInOrder[:])` was actually returning the pre-append slice header because defer captures arguments at declaration time. Even though we re-assigned `labelsInOrder` during `ForEachLabel`, the deferred call still held the original slice value, so runtime behaviour never reused a non-zero-length slice.

Despite the lack of a production bug, the intent was unclear: readers could easily assume the current `labelsInOrder` (with appended keys) was being pooled, which would be unsafe. The new regression test overrides the pool helper hooks so both hash calls reuse the same backing array. It fails if the slice isn’t trimmed before being returned, exercising precisely the scenario that could confuse reviewers.
