### PR TITLE
chore: fix broken tests

### DIFF
--- a/internal/component/loki/source/docker/docker_test.go
+++ b/internal/component/loki/source/docker/docker_test.go
@@ -116,7 +116,6 @@ func TestRestart(t *testing.T) {
 	expectedLogLine := "caller=module_service.go:114 msg=\"module stopped\" module=distributor"
 
 	tailer, entryHandler := setupTailer(t, client)
-	defer entryHandler.Stop()
 	go tailer.Run(t.Context())
 
 	// The container is already running, expect log lines.
@@ -155,7 +154,6 @@ func TestTargetNeverStarted(t *testing.T) {
 	expectedLogLine := "caller=module_service.go:114 msg=\"module stopped\" module=distributor"
 
 	tailer, entryHandler := setupTailer(t, client)
-	defer entryHandler.Stop()
 
 	ctx, cancel := context.WithCancel(t.Context())
 	go tailer.Run(ctx)

--- a/internal/component/loki/source/docker/internal/dockertarget/target_test.go
+++ b/internal/component/loki/source/docker/internal/dockertarget/target_test.go
@@ -34,7 +34,6 @@ func TestDockerTarget(t *testing.T) {
 	w := log.NewSyncWriter(os.Stderr)
 	logger := log.NewLogfmtLogger(w)
 	entryHandler := loki.NewCollectingHandler()
-	defer entryHandler.Stop()
 	client, err := client.NewClientWithOpts(client.WithHost(server.URL))
 	require.NoError(t, err)
 
@@ -95,7 +94,6 @@ func TestStartStopStressTest(t *testing.T) {
 
 	logger := log.NewNopLogger()
 	entryHandler := loki.NewCollectingHandler()
-	defer entryHandler.Stop()
 
 	ps, err := positions.New(logger, positions.Config{
 		SyncPeriod:    10 * time.Second,


### PR DESCRIPTION
In https://github.com/grafana/alloy/pull/4904 I added defer to stop handler in docker tests. 

This causes problems where we stop handler before we stop target. For now just don't stop handler like before.