### PR TITLE
Add missing information to the prometheus.exporter.oracledb component documentation

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.exporter.oracledb.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.oracledb.md
@@ -26,7 +26,8 @@ When you run the standalone binary, you must install the [Oracle Instant Client 
 Only the basic version is required for the exporter.
 
 {{< admonition type="note" >}}
-The {{< param "PRODUCT_NAME" >}} Docker image includes the Oracle Instant Client, so this prerequisite only applies to standalone binary installations.
+You must also provide Oracle Instant Client Basic when you run {{< param "PRODUCT_NAME" >}} in Docker or Kubernetes.
+The `prometheus.exporter.oracledb` component relies on Oracle Instant Client libraries that are available in the container image or host environment.
 {{< /admonition >}}
 
 ### Environment variables


### PR DESCRIPTION
#### PR Description

Add missing prerequisite and env var information to the `prometheus.exporter.oracledb` component documentation.

#### Which issue(s) this PR fixes

Fixes https://github.com/grafana/alloy/issues/3891
