### PR TITLE
Cleanup: Remove slicelabels Tag From Docs Generation

### DIFF
--- a/internal/tools/docs_generator/docs_updated_test.go
+++ b/internal/tools/docs_generator/docs_updated_test.go
@@ -18,7 +18,7 @@ import (
 var moduleRoot = "../../../"
 
 // Run the below generate command to automatically update the Markdown docs with generated content
-//go:generate go test -tags slicelabels -fix-tests -v
+//go:generate go test -fix-tests -v
 
 var fixTestsFlag = flag.Bool("fix-tests", false, "update the test files with the current generated content")
 


### PR DESCRIPTION
Forgot this one spot to clean up the `slicelabels` tag 🧹 