### PR TITLE
fix(pyroscope.ebpf): Use meter noop in otel-ebpf-profiler

### DIFF
--- a/internal/component/pyroscope/ebpf/ebpf_linux.go
+++ b/internal/component/pyroscope/ebpf/ebpf_linux.go
@@ -22,10 +22,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/ebpf-profiler/interpreter/python"
+	ebpfmetrics "go.opentelemetry.io/ebpf-profiler/metrics"
 	discovery2 "go.opentelemetry.io/ebpf-profiler/pyroscope/discovery"
 	"go.opentelemetry.io/ebpf-profiler/pyroscope/dynamicprofiling"
 	"go.opentelemetry.io/ebpf-profiler/pyroscope/internalshim/controller"
 	"go.opentelemetry.io/ebpf-profiler/pyroscope/symb/irsymcache"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
 )
 
 func init() {
@@ -40,6 +42,8 @@ func init() {
 		},
 	})
 	python.NoContinueWithNextUnwinder.Store(true)
+	// Disable ebpf profiler metrics
+	ebpfmetrics.Start(metricnoop.Meter{})
 }
 
 func New(logger log.Logger, reg prometheus.Registerer, id string, args Arguments) (*Component, error) {


### PR DESCRIPTION
With a recent change, the default meter provider was no longer
initialized. This change disables the otel-ebpf-profiler internal
metrics to avoid warnings like this to appear:

```
WARN[0121] Invalid metric id 102, skipping
WARN[0121] Invalid metric id 272, skipping
```
