### PR TITLE
Update otelcol.exporter.splunkhec.md

### DIFF
--- a/docs/sources/reference/components/otelcol/otelcol.exporter.splunkhec.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.splunkhec.md
@@ -97,7 +97,7 @@ The following arguments are supported:
 | `max_content_length_traces`  | `uint`   | Maximum trace payload size in bytes. Must be less than 838860800 (~800MB).                                             | `2097152`                      | no       |
 | `max_event_size`             | `uint`   | Maximum event payload size in bytes. Must be less than 838860800 (~800MB).                                             | `5242880`                      | no       |
 | `profiling_data_enabled`     | `bool`   | Enable sending profiling data from the exporter. One of `log_data_enabled` or `profiling_data_enabled` must be `true`. | `true`                         | no       |
-| `source_type`                | `string` | [Splunk source type](https://docs.splunk.com/Splexicon:Sourcetype).                                                    | `""`                           | no       |
+| `sourcetype`                 | `string` | [Splunk source type](https://docs.splunk.com/Splexicon:Sourcetype).                                                    | `""`                           | no       |
 | `source`                     | `string` | [Splunk source](https://docs.splunk.com/Splexicon:Source).                                                             | `""`                           | no       |
 | `splunk_app_name`            | `string` | Used to track telemetry for Splunk Apps by name.                                                                       | `"Alloy"`                      | no       |
 | `splunk_app_version`         | `string` | Used to track telemetry by App version.                                                                                | `""`                           | no       |


### PR DESCRIPTION
#### PR Description
Documentation typo in otelcol.exporter.splunkhec wrapper

Component is a wrapper of the upstream opentelemetry exporter, splunkhecexporter.

Current documentation on the Alloy side states that source_type is an attribute in the splunk block, however, it's sourcetype in the upstream. Causing an error when Alloy loads the configuration. Changing it to sourcetype in the Alloy config resolves the issue.

https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/splunkhecexporter

