### PR TITLE
fix(loki.source.podlogs): set validation scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,6 @@ Main (unreleased)
 - (_Public Preview_) Additions to `database_observability.postgres` component:
     - fixes collection of Postgres schema details for mixed case table names (@fridgepoet)
 
-- fix panic in `loki.source.podlogs` caused by unset validation scheme. (@kalleep)
-
 v1.12.0-rc.0
 -----------------
 


### PR DESCRIPTION
#### PR Description
Since Prometheus update this broke. We need to explicitly set validation scheme for all relabel rules.

#### Which issue(s) this PR fixes

Fixes: https://github.com/grafana/alloy/issues/4929

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
