### PR TITLE
feat(loki.process): Add regex field to logfmt and json stages

### DIFF
--- a/docs/sources/reference/components/loki/loki.process.md
+++ b/docs/sources/reference/components/loki/loki.process.md
@@ -500,12 +500,15 @@ The following arguments are supported:
 
 | Name             | Type          | Description                                           | Default | Required |
 | ---------------- | ------------- | ----------------------------------------------------- | ------- | -------- |
-| `expressions`    | `map(string)` | Key-value pairs of JMESPath expressions.              |         | yes      |
+| `expressions`    | `map(string)` | Key-value pairs of JMESPath expressions.              |         | no       |
+| `regex`          | `string`      | Regular expression matched against JSON keys.         |         | no       |
 | `drop_malformed` | `bool`        | Drop lines whose input can't be parsed as valid JSON. | `false` | no       |
 | `source`         | `string`      | Source of the data to parse as JSON.                  | `""`    | no       |
 
 The `expressions` field is the set of key-value pairs of JMESPath expressions to run.
-The map key defines the name with which the data is extracted, while the map value is the expression used to populate the value.
+The map key defines the name used to extract the data, while the map value is the expression used to populate the value.
+
+The `regex` field is a regular expression. All keys in the JSON source matching the regular expression are extracted.
 
 When configuring a JSON stage, the `source` field defines the source of data to parse as JSON.
 By default, this is the log line itself, but it can also be a previously extracted value.
@@ -673,19 +676,19 @@ The `stage.logfmt` inner block configures a processing stage that reads incoming
 
 The following arguments are supported:
 
-| Name      | Type          | Description                                    | Default | Required |
-| --------- | ------------- | ---------------------------------------------- | ------- | -------- |
-| `mapping` | `map(string)` | Key-value pairs of `logmft` fields to extract. |         | yes      |
-| `source`  | `string`      | Source of the data to parse as `logfmt`.       | `""`    | no       |
+| Name      | Type          | Description                                     | Default | Required |
+| --------- | ------------- | ----------------------------------------------- | ------- | -------- |
+| `mapping` | `map(string)` | Key-value pairs of `logmft` fields to extract.  |         | no       |
+| `regex`   | `string`      | Regular expression matched against logfmt keys. |         | no       |
+| `source`  | `string`      | Source of the data to parse as `logfmt`.        | `""`    | no       |
+
+The `mapping` field is the set of key-value pairs.
+The map key defines the name used to extract the data, while the map value is the logfmt field used to populate the value.
+
+The `regex` field is a regular expression. All logfmt fields matching the regular expression are extracted.
 
 The `source` field defines the source of data to parse as `logfmt`.
 When `source` is missing or empty, the stage parses the log line itself, but it can also be used to parse a previously extracted value.
-
-This stage uses the [go-logfmt][] unmarshaler, so that numeric or boolean types are unmarshalled into their correct form.
-The stage doesn't perform any other type conversions.
-If the extracted value is a complex type, it's treated as a string.
-
-[go-logfmt]: https://github.com/go-logfmt/logfmt
 
 The following log line and stages demonstrates how this works.
 

--- a/internal/component/loki/process/stages/json.go
+++ b/internal/component/loki/process/stages/json.go
@@ -143,58 +143,25 @@ func (j *jsonStage) processEntry(extracted map[string]any, entry *string) error 
 		return errors.New(ErrMalformedJSON)
 	}
 
-	for n, e := range j.expressions {
-		r, err := e.Search(data)
+	for name, expr := range j.expressions {
+		rawResult, err := expr.Search(data)
 		if err != nil {
 			if Debug {
 				level.Debug(j.logger).Log("msg", "failed to search JMES expression", "err", err)
 			}
 			continue
 		}
-
-		switch r.(type) {
-		case float64:
-			// All numbers in JSON are unmarshaled to float64.
-			extracted[n] = r
-		case string:
-			extracted[n] = r
-		case bool:
-			extracted[n] = r
-		case nil:
-			extracted[n] = nil
-		default:
-			// If the value wasn't a string or a number, marshal it back to json
-			jm, err := json.Marshal(r)
-			if err != nil {
-				if Debug {
-					level.Debug(j.logger).Log("msg", "failed to marshal complex type back to string", "err", err)
-				}
-				continue
-			}
-			extracted[n] = string(jm)
+		value, err := j.simplifyType(rawResult)
+		if err == nil {
+			extracted[name] = value
 		}
 	}
 	if j.regex.String() != "" {
-		for key, value := range data {
+		for key, rawValue := range data {
 			if j.regex.MatchString(key) {
-				switch value.(type) {
-				case float64:
+				value, err := j.simplifyType(rawValue)
+				if err == nil {
 					extracted[key] = value
-				case string:
-					extracted[key] = value
-				case bool:
-					extracted[key] = value
-				case nil:
-					extracted[key] = nil
-				default:
-					jm, err := json.Marshal(value)
-					if err != nil {
-						if Debug {
-							level.Debug(j.logger).Log("msg", "failed to marshal complex type back to string", "err", err)
-						}
-						continue
-					}
-					extracted[key] = string(jm)
 				}
 			}
 		}
@@ -203,6 +170,31 @@ func (j *jsonStage) processEntry(extracted map[string]any, entry *string) error 
 		level.Debug(j.logger).Log("msg", "extracted data debug in json stage", "extracted_data", fmt.Sprintf("%v", extracted))
 	}
 	return nil
+}
+
+// extractWithType returns the value if it's a simple type (string, number, bool),
+// otherwise, it returns it as a JSON string
+func (j *jsonStage) simplifyType(value any) (any, error) {
+	switch value.(type) {
+	case float64:
+		return value, nil
+	case string:
+		return value, nil
+	case bool:
+		return value, nil
+	case nil:
+		return nil, nil
+	default:
+		// If the value wasn't a string or a number, marshal it back to json
+		jm, err := json.Marshal(value)
+		if err != nil {
+			if Debug {
+				level.Debug(j.logger).Log("msg", "failed to marshal complex type back to string", "err", err)
+				return nil, err
+			}
+		}
+		return string(jm), nil
+	}
 }
 
 // Cleanup implements Stage.

--- a/internal/component/loki/process/stages/json.go
+++ b/internal/component/loki/process/stages/json.go
@@ -151,16 +151,16 @@ func (j *jsonStage) processEntry(extracted map[string]any, entry *string) error 
 			}
 			continue
 		}
-		value, err := j.simplifyType(rawResult)
-		if err == nil {
+		value, ok := j.simplifyType(rawResult)
+		if ok {
 			extracted[name] = value
 		}
 	}
 	if j.regex.String() != "" {
 		for key, rawValue := range data {
 			if j.regex.MatchString(key) {
-				value, err := j.simplifyType(rawValue)
-				if err == nil {
+				value, ok := j.simplifyType(rawValue)
+				if ok {
 					extracted[key] = value
 				}
 			}
@@ -172,28 +172,28 @@ func (j *jsonStage) processEntry(extracted map[string]any, entry *string) error 
 	return nil
 }
 
-// extractWithType returns the value if it's a simple type (string, number, bool),
-// otherwise, it returns it as a JSON string
-func (j *jsonStage) simplifyType(value any) (any, error) {
+// simplifyType returns the value if it's a simple type (string, number, bool),
+// otherwise, it returns it as a JSON string. If unsuccessful, the second return value is false.
+func (j *jsonStage) simplifyType(value any) (any, bool) {
 	switch value.(type) {
 	case float64:
-		return value, nil
+		return value, true
 	case string:
-		return value, nil
+		return value, true
 	case bool:
-		return value, nil
+		return value, true
 	case nil:
-		return nil, nil
+		return nil, true
 	default:
 		// If the value wasn't a string or a number, marshal it back to json
 		jm, err := json.Marshal(value)
 		if err != nil {
 			if Debug {
 				level.Debug(j.logger).Log("msg", "failed to marshal complex type back to string", "err", err)
-				return nil, err
+				return nil, false
 			}
 		}
-		return string(jm), nil
+		return string(jm), true
 	}
 }
 

--- a/internal/component/loki/process/stages/json.go
+++ b/internal/component/loki/process/stages/json.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"regexp"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
@@ -13,32 +14,33 @@ import (
 
 // Config Errors
 const (
-	ErrExpressionsRequired  = "JMES expression is required"
-	ErrCouldNotCompileJMES  = "could not compile JMES expression"
-	ErrEmptyJSONStageConfig = "empty json stage configuration"
-	ErrEmptyJSONStageSource = "empty source"
-	ErrMalformedJSON        = "malformed json"
+	ErrExpressionsOrRegexRequired = "JMES expressions or regex is required"
+	ErrCouldNotCompileJMES        = "could not compile JMES expression"
+	ErrEmptyJSONStageConfig       = "empty json stage configuration"
+	ErrEmptyJSONStageSource       = "empty source"
+	ErrMalformedJSON              = "malformed json"
 )
 
 // JSONConfig represents a JSON Stage configuration
 type JSONConfig struct {
-	Expressions   map[string]string `alloy:"expressions,attr"`
+	Expressions   map[string]string `alloy:"expressions,attr,optional"`
+	Regex         string            `alloy:"regex,attr,optional"`
 	Source        *string           `alloy:"source,attr,optional"`
 	DropMalformed bool              `alloy:"drop_malformed,attr,optional"`
 }
 
 // validateJSONConfig validates a json config and returns a map of necessary jmespath expressions.
-func validateJSONConfig(c *JSONConfig) (map[string]jmespath.JMESPath, error) {
+func validateJSONConfig(c *JSONConfig) (map[string]jmespath.JMESPath, *regexp.Regexp, error) {
 	if c == nil {
-		return nil, errors.New(ErrEmptyJSONStageConfig)
+		return nil, nil, errors.New(ErrEmptyJSONStageConfig)
 	}
 
-	if len(c.Expressions) == 0 {
-		return nil, errors.New(ErrExpressionsRequired)
+	if len(c.Expressions) == 0 && len(c.Regex) == 0 {
+		return nil, nil, errors.New(ErrExpressionsOrRegexRequired)
 	}
 
 	if c.Source != nil && *c.Source == "" {
-		return nil, errors.New(ErrEmptyJSONStageSource)
+		return nil, nil, errors.New(ErrEmptyJSONStageSource)
 	}
 
 	expressions := map[string]jmespath.JMESPath{}
@@ -52,28 +54,36 @@ func validateJSONConfig(c *JSONConfig) (map[string]jmespath.JMESPath, error) {
 		}
 		expressions[n], err = jmespath.Compile(jmes)
 		if err != nil {
-			return nil, fmt.Errorf("%s: %w", ErrCouldNotCompileJMES, err)
+			return nil, nil, fmt.Errorf("%s: %w", ErrCouldNotCompileJMES, err)
 		}
 	}
-	return expressions, nil
+
+	re, err := regexp.Compile(c.Regex)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return expressions, re, nil
 }
 
 // jsonStage sets extracted data using JMESPath expressions
 type jsonStage struct {
 	cfg         *JSONConfig
 	expressions map[string]jmespath.JMESPath
+	regex       regexp.Regexp
 	logger      log.Logger
 }
 
 // newJSONStage creates a new json pipeline stage from a config.
 func newJSONStage(logger log.Logger, cfg JSONConfig) (Stage, error) {
-	expressions, err := validateJSONConfig(&cfg)
+	expressions, regex, err := validateJSONConfig(&cfg)
 	if err != nil {
 		return nil, err
 	}
 	return &jsonStage{
 		cfg:         &cfg,
 		expressions: expressions,
+		regex:       *regex,
 		logger:      log.With(logger, "component", "stage", "type", "json"),
 	}, nil
 }
@@ -162,6 +172,31 @@ func (j *jsonStage) processEntry(extracted map[string]any, entry *string) error 
 				continue
 			}
 			extracted[n] = string(jm)
+		}
+	}
+	if j.regex.String() != "" {
+		for key, value := range data {
+			if j.regex.MatchString(key) {
+				switch value.(type) {
+				case float64:
+					extracted[key] = value
+				case string:
+					extracted[key] = value
+				case bool:
+					extracted[key] = value
+				case nil:
+					extracted[key] = nil
+				default:
+					jm, err := json.Marshal(value)
+					if err != nil {
+						if Debug {
+							level.Debug(j.logger).Log("msg", "failed to marshal complex type back to string", "err", err)
+						}
+						continue
+					}
+					extracted[key] = string(jm)
+				}
+			}
 		}
 	}
 	if Debug {

--- a/internal/component/loki/process/stages/json_test.go
+++ b/internal/component/loki/process/stages/json_test.go
@@ -28,8 +28,27 @@ stage.json {
 
 stage.json {
     expressions = { "user" = "" }
-	source      = "extra"
+    source      = "extra"
 }`
+
+var testJSONAlloyRegex = `
+stage.json {
+  regex = "pod_.*"
+}
+`
+
+var testJSONAlloyRegexAll = `
+stage.json {
+  regex = ".*"
+}
+`
+
+var testJSONAlloyExpressionsAndRegex = `
+stage.json {
+  expressions = {"out" = "message", "app" = ""}
+  regex = "(app|duration)"
+}
+`
 
 var testJSONLogLine = `
 {
@@ -38,7 +57,7 @@ var testJSONLogLine = `
 	"component": ["parser","type"],
 	"level" : "WARN",
 	"nested" : {"child":"value"},
-    "duration" : 125,
+	"duration" : 125,
 	"message" : "this is a log line",
 	"extra": "{\"user\":\"marco\"}"
 }
@@ -70,6 +89,37 @@ func TestPipeline_JSON(t *testing.T) {
 			map[string]any{
 				"extra": "{\"user\":\"marco\"}",
 				"user":  "marco",
+			},
+		},
+		"successfully extract regex values from json": {
+			testJSONAlloyRegex,
+			`{"time":"2012-11-01T22:08:41+00:00", "pod_name": "my-pod-123", "pod_label": "my-label"}`,
+			map[string]interface{}{
+				"pod_name":  "my-pod-123",
+				"pod_label": "my-label",
+			},
+		},
+		"successfully extract all values from json via regex": {
+			testJSONAlloyRegexAll,
+			testJSONLogLine,
+			map[string]interface{}{
+				"time":      "2012-11-01T22:08:41+00:00",
+				"app":       "loki",
+				"component": `["parser","type"]`,
+				"level":     "WARN",
+				"nested":    `{"child":"value"}`,
+				"duration":  float64(125),
+				"message":   "this is a log line",
+				"extra":     "{\"user\":\"marco\"}",
+			},
+		},
+		"successfully extract values with expressions and regex from json": {
+			testJSONAlloyExpressionsAndRegex,
+			testJSONLogLine,
+			map[string]interface{}{
+				"out":      "this is a log line",
+				"app":      "loki",
+				"duration": float64(125),
 			},
 		},
 	}
@@ -132,7 +182,7 @@ func TestJSONConfig_validate(t *testing.T) {
 		"no expressions": {
 			&JSONConfig{},
 			0,
-			errors.New(ErrExpressionsRequired),
+			errors.New(ErrExpressionsOrRegexRequired),
 		},
 		"invalid expression": {
 			&JSONConfig{
@@ -180,7 +230,7 @@ func TestJSONConfig_validate(t *testing.T) {
 	for tName, tt := range tests {
 		tt := tt
 		t.Run(tName, func(t *testing.T) {
-			got, err := validateJSONConfig(tt.config)
+			got, _, err := validateJSONConfig(tt.config)
 			if tt.err != nil {
 				assert.NotNil(t, err, "JSONConfig.validate() expected error = %v, but got nil", tt.err)
 			}

--- a/internal/component/loki/process/stages/json_test.go
+++ b/internal/component/loki/process/stages/json_test.go
@@ -94,7 +94,7 @@ func TestPipeline_JSON(t *testing.T) {
 		"successfully extract regex values from json": {
 			testJSONAlloyRegex,
 			`{"time":"2012-11-01T22:08:41+00:00", "pod_name": "my-pod-123", "pod_label": "my-label"}`,
-			map[string]interface{}{
+			map[string]any{
 				"pod_name":  "my-pod-123",
 				"pod_label": "my-label",
 			},
@@ -102,7 +102,7 @@ func TestPipeline_JSON(t *testing.T) {
 		"successfully extract all values from json via regex": {
 			testJSONAlloyRegexAll,
 			testJSONLogLine,
-			map[string]interface{}{
+			map[string]any{
 				"time":      "2012-11-01T22:08:41+00:00",
 				"app":       "loki",
 				"component": `["parser","type"]`,
@@ -116,7 +116,7 @@ func TestPipeline_JSON(t *testing.T) {
 		"successfully extract values with expressions and regex from json": {
 			testJSONAlloyExpressionsAndRegex,
 			testJSONLogLine,
-			map[string]interface{}{
+			map[string]any{
 				"out":      "this is a log line",
 				"app":      "loki",
 				"duration": float64(125),

--- a/internal/component/loki/process/stages/logfmt.go
+++ b/internal/component/loki/process/stages/logfmt.go
@@ -3,6 +3,7 @@ package stages
 import (
 	"errors"
 	"reflect"
+	"regexp"
 	"strings"
 	"time"
 
@@ -14,26 +15,27 @@ import (
 
 // Config Errors
 var (
-	ErrMappingRequired        = errors.New("logfmt mapping is required")
+	ErrMappingOrRegexRequired = errors.New("logfmt mapping or regex is required")
 	ErrEmptyLogfmtStageConfig = errors.New("empty logfmt stage configuration")
 )
 
 // LogfmtConfig represents a logfmt Stage configuration
 type LogfmtConfig struct {
-	Mapping map[string]string `alloy:"mapping,attr"`
+	Mapping map[string]string `alloy:"mapping,attr,optional"`
 	Source  string            `alloy:"source,attr,optional"`
+	Regex   string            `alloy:"regex,attr,optional"`
 }
 
 // validateLogfmtConfig validates a logfmt stage config and returns an inverse mapping of configured mapping.
 // Mapping inverse is done to make lookup easier. The key would be the key from parsed logfmt and
 // value would be the key with which the data in extracted map would be set.
-func validateLogfmtConfig(c *LogfmtConfig) (map[string]string, error) {
+func validateLogfmtConfig(c *LogfmtConfig) (map[string]string, *regexp.Regexp, error) {
 	if c == nil {
-		return nil, ErrEmptyLogfmtStageConfig
+		return nil, nil, ErrEmptyLogfmtStageConfig
 	}
 
-	if len(c.Mapping) == 0 {
-		return nil, ErrMappingRequired
+	if len(c.Mapping) == 0 && len(c.Regex) == 0 {
+		return nil, nil, ErrMappingOrRegexRequired
 	}
 
 	inverseMapping := make(map[string]string)
@@ -45,13 +47,19 @@ func validateLogfmtConfig(c *LogfmtConfig) (map[string]string, error) {
 		inverseMapping[v] = k
 	}
 
-	return inverseMapping, nil
+	re, err := regexp.Compile(c.Regex)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return inverseMapping, re, nil
 }
 
 // logfmtStage sets extracted data using logfmt parser
 type logfmtStage struct {
 	cfg            *LogfmtConfig
 	inverseMapping map[string]string
+	regex          regexp.Regexp
 	logger         log.Logger
 }
 
@@ -59,7 +67,7 @@ type logfmtStage struct {
 func newLogfmtStage(logger log.Logger, config LogfmtConfig) (Stage, error) {
 	// inverseMapping would hold the mapping in inverse which would make lookup easier.
 	// To explain it simply, the key would be the key from parsed logfmt and value would be the key with which the data in extracted map would be set.
-	inverseMapping, err := validateLogfmtConfig(&config)
+	inverseMapping, regex, err := validateLogfmtConfig(&config)
 	if err != nil {
 		return nil, err
 	}
@@ -67,6 +75,7 @@ func newLogfmtStage(logger log.Logger, config LogfmtConfig) (Stage, error) {
 	return toStage(&logfmtStage{
 		cfg:            &config,
 		inverseMapping: inverseMapping,
+		regex:          *regex,
 		logger:         log.With(logger, "component", "stage", "type", "logfmt"),
 	}), nil
 }
@@ -97,13 +106,22 @@ func (j *logfmtStage) Process(labels model.LabelSet, extracted map[string]any, t
 		return
 	}
 	decoder := logfmt.NewDecoder(strings.NewReader(*input))
-	extractedEntriesCount := 0
+	mappingExtractedEntriesCount := 0
+	regexExtractedEntriesCount := 0
 	for decoder.ScanRecord() {
 		for decoder.ScanKeyval() {
+			// handle "mapping"
 			mapKey, ok := j.inverseMapping[string(decoder.Key())]
 			if ok {
 				extracted[mapKey] = string(decoder.Value())
-				extractedEntriesCount++
+				mappingExtractedEntriesCount++
+			} else if j.regex.String() != "" {
+				// handle "regex"
+				fmt.Println(j.regex.String(), string(decoder.Key()))
+				if j.regex.MatchString(string(decoder.Key())) {
+					extracted[string(decoder.Key())] = string(decoder.Value())
+					regexExtractedEntriesCount++
+				}
 			}
 		}
 	}
@@ -114,8 +132,11 @@ func (j *logfmtStage) Process(labels model.LabelSet, extracted map[string]any, t
 	}
 
 	if Debug {
-		if extractedEntriesCount != len(j.inverseMapping) {
-			level.Debug(j.logger).Log("msg", "found only some configured mappings in logfmt stage", "found", extractedEntriesCount, "configured", len(j.inverseMapping))
+		if mappingExtractedEntriesCount != len(j.inverseMapping) {
+			level.Debug(j.logger).Log("msg", "found only some configured mappings in logfmt stage", "found", mappingExtractedEntriesCount, "configured", len(j.inverseMapping))
+		}
+		if regexExtractedEntriesCount > 0 {
+			level.Debug(j.logger).Log("msg", "found some mappings via regex in logfmt stage", "found", regexExtractedEntriesCount)
 		}
 		level.Debug(j.logger).Log("msg", "extracted data debug in logfmt stage", "extracted data", extracted)
 	}

--- a/internal/component/loki/process/stages/logfmt.go
+++ b/internal/component/loki/process/stages/logfmt.go
@@ -110,16 +110,17 @@ func (j *logfmtStage) Process(labels model.LabelSet, extracted map[string]any, t
 	regexExtractedEntriesCount := 0
 	for decoder.ScanRecord() {
 		for decoder.ScanKeyval() {
+			key := string(decoder.Key())
 			// handle "mapping"
-			mapKey, ok := j.inverseMapping[string(decoder.Key())]
+			mapKey, ok := j.inverseMapping[key]
 			if ok {
 				extracted[mapKey] = string(decoder.Value())
 				mappingExtractedEntriesCount++
 			}
 			// handle "regex"
 			if j.regex.String() != "" {
-				if j.regex.MatchString(string(decoder.Key())) {
-					extracted[string(decoder.Key())] = string(decoder.Value())
+				if j.regex.MatchString(key) {
+					extracted[key] = string(decoder.Value())
 					regexExtractedEntriesCount++
 				}
 			}

--- a/internal/component/loki/process/stages/logfmt.go
+++ b/internal/component/loki/process/stages/logfmt.go
@@ -115,9 +115,9 @@ func (j *logfmtStage) Process(labels model.LabelSet, extracted map[string]any, t
 			if ok {
 				extracted[mapKey] = string(decoder.Value())
 				mappingExtractedEntriesCount++
-			} else if j.regex.String() != "" {
-				// handle "regex"
-				fmt.Println(j.regex.String(), string(decoder.Key()))
+			}
+			// handle "regex"
+			if j.regex.String() != "" {
 				if j.regex.MatchString(string(decoder.Key())) {
 					extracted[string(decoder.Key())] = string(decoder.Value())
 					regexExtractedEntriesCount++

--- a/internal/component/loki/process/stages/logfmt_test.go
+++ b/internal/component/loki/process/stages/logfmt_test.go
@@ -76,7 +76,7 @@ func TestLogfmt(t *testing.T) {
 		"successfully extract regex values from logfmt": {
 			testLogfmtAlloyRegex,
 			`time=2012-11-01T22:08:41+00:00 pod_name=my-pod-123 pod_label=my-label`,
-			map[string]interface{}{
+			map[string]any{
 				"pod_name":  "my-pod-123",
 				"pod_label": "my-label",
 			},
@@ -84,7 +84,7 @@ func TestLogfmt(t *testing.T) {
 		"successfully extract all values via regex from logfmt": {
 			testLogfmtAlloyRegexAll,
 			testLogfmtLogLine,
-			map[string]interface{}{
+			map[string]any{
 				"time":     "2012-11-01T22:08:41+00:00",
 				"app":      "loki",
 				"level":    "WARN",
@@ -96,7 +96,7 @@ func TestLogfmt(t *testing.T) {
 		"successfully extract values with expressions and regex from logfmt": {
 			testLogfmtAlloyRegexAndMapping,
 			testLogfmtLogLine,
-			map[string]interface{}{
+			map[string]any{
 				"out":      "this is a log line",
 				"app":      "loki",
 				"duration": "125",

--- a/internal/component/loki/process/stages/logfmt_test.go
+++ b/internal/component/loki/process/stages/logfmt_test.go
@@ -26,6 +26,25 @@ stage.logfmt {
 		source  = "extra"
 }`
 
+var testLogfmtAlloyRegex = `
+stage.logfmt {
+    regex = "pod_.*"
+}
+`
+
+var testLogfmtAlloyRegexAll = `
+stage.logfmt {
+    regex = ".*"
+}
+`
+
+var testLogfmtAlloyRegexAndMapping = `
+stage.logfmt {
+    mapping = { "out" = "message", "app" = ""}
+    regex = "(app|duration)"
+}
+`
+
 func TestLogfmt(t *testing.T) {
 	var testLogfmtLogLine = `
 		time=2012-11-01T22:08:41+00:00 app=loki	level=WARN duration=125 message="this is a log line" extra="user=foo""
@@ -52,6 +71,35 @@ func TestLogfmt(t *testing.T) {
 			map[string]any{
 				"extra": "user=foo",
 				"user":  "foo",
+			},
+		},
+		"successfully extract regex values from logfmt": {
+			testLogfmtAlloyRegex,
+			`time=2012-11-01T22:08:41+00:00 pod_name=my-pod-123 pod_label=my-label`,
+			map[string]interface{}{
+				"pod_name":  "my-pod-123",
+				"pod_label": "my-label",
+			},
+		},
+		"successfully extract all values via regex from logfmt": {
+			testLogfmtAlloyRegexAll,
+			testLogfmtLogLine,
+			map[string]interface{}{
+				"time":     "2012-11-01T22:08:41+00:00",
+				"app":      "loki",
+				"level":    "WARN",
+				"duration": "125",
+				"message":  "this is a log line",
+				"extra":    "user=foo",
+			},
+		},
+		"successfully extract values with expressions and regex from logfmt": {
+			testLogfmtAlloyRegexAndMapping,
+			testLogfmtLogLine,
+			map[string]interface{}{
+				"out":      "this is a log line",
+				"app":      "loki",
+				"duration": "125",
 			},
 		},
 	}
@@ -81,7 +129,7 @@ func TestLogfmtConfigValidation(t *testing.T) {
 		"no mapping": {
 			LogfmtConfig{},
 			0,
-			ErrMappingRequired,
+			ErrMappingOrRegexRequired,
 		},
 		"valid without source": {
 			LogfmtConfig{
@@ -108,7 +156,7 @@ func TestLogfmtConfigValidation(t *testing.T) {
 	for tName, tt := range tests {
 		tt := tt
 		t.Run(tName, func(t *testing.T) {
-			got, err := validateLogfmtConfig(&tt.config)
+			got, _, err := validateLogfmtConfig(&tt.config)
 			if tt.err != nil {
 				assert.EqualError(t, err, tt.err.Error())
 			} else {


### PR DESCRIPTION
#### PR Description

After I added the `regex` field to the `structured_metadata` stage in #4629, this PR adds the field to `logfmt` and `json` as well. As pointed out by @bmundt6 in https://github.com/grafana/alloy/issues/2156#issuecomment-3539729140, this is required to fully close #2156.

#### Which issue(s) this PR fixes

Continues the fix for #2156.

#### Notes to the Reviewer

In the documentation, I removed the section about the logfmt-parser preserving the type of booleans and numbers because these types are actually always converted to strings.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
