### PR TITLE
db-o11y: change the server_id calculation for mysql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,11 @@ Main (unreleased)
 - `loki.source.api` no longer drops request when relabel rules drops a specific stream. (@kalleep)
 
 - (_Public Preview_) Additions to `database_observability.postgres` component:
-    - fixes collection of Postgres schema details for mixed case table names (@fridgepoet)
+  - `schema_details`
+    - fixes collection of schema details for mixed case table names (@fridgepoet)
+
+- (_Public Preview_) Additions to `database_observability.mysql` component:
+  - replace the internal `server_id` label attribution in favor of a hash composed from `@@server_uuid` and `@@hostname`
 
 v1.12.0-rc.0
 -----------------

--- a/internal/component/database_observability/mysql/component_test.go
+++ b/internal/component/database_observability/mysql/component_test.go
@@ -259,7 +259,7 @@ func Test_addLokiLabels(t *testing.T) {
 	t.Run("add required labels to loki entries", func(t *testing.T) {
 		lokiClient := loki.NewCollectingHandler()
 		defer lokiClient.Stop()
-		entryHandler := addLokiLabels(lokiClient, "some-instance-key", "some-server-uuid")
+		entryHandler := addLokiLabels(lokiClient, "some-instance-key", "some-server-id-hash")
 
 		go func() {
 			ts := time.Now().UnixNano()
@@ -279,7 +279,7 @@ func Test_addLokiLabels(t *testing.T) {
 		assert.Equal(t, model.LabelSet{
 			"job":       database_observability.JobName,
 			"instance":  model.LabelValue("some-instance-key"),
-			"server_id": model.LabelValue("some-server-uuid"),
+			"server_id": model.LabelValue("some-server-id-hash"),
 		}, lokiClient.Received()[0].Labels)
 		assert.Equal(t, "some-message", lokiClient.Received()[0].Line)
 	})
@@ -336,7 +336,7 @@ func TestMySQL_StartCollectors_ReportsUnhealthy_StackedErrors(t *testing.T) {
 	// First ping to the database succeeds, so we can start collectors
 	mock.ExpectPing()
 	// Engine info succeeds (if reached)
-	mock.ExpectQuery(`SELECT @@server_uuid, VERSION\(\)`).WillReturnRows(sqlmock.NewRows([]string{"server_uuid", "version"}).AddRow("uuid-1", "8.0.0"))
+	mock.ExpectQuery(`SELECT @@server_uuid, @@hostname, VERSION\(\)`).WillReturnRows(sqlmock.NewRows([]string{"server_uuid", "hostname", "version"}).AddRow("uuid-1", "test-hostname", "8.0.0"))
 	// QuerySample constructor queries uptime and fails
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT variable_value FROM performance_schema.global_status WHERE variable_name = 'UPTIME'")).
 		WillReturnRows(sqlmock.NewRows([]string{"variable_value"}).AddRow(1))


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Changing the way server_id is attributed for MySQL, to generate a hash from `@@server_uuid` and `@@hostname` instead of just using the first, so the id is unique across Aurora SQL clusters.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
