### PR TITLE
fix changelog (sync with 1.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,6 @@ Main (unreleased)
 
 - (_Experimental_) A new `otelcol.receiver.awss3` component to receive traces previously stored in S3 by the [AWS S3 Exporter](https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.exporter.awss3/). (@x1unix)
 
-- A new `mimir.alerts.kubernetes` component which discovers `AlertmanagerConfig` Kubernetes resources and loads them into a Mimir instance. (@ptodev)
-
-- Mark `stage.windowsevent` block in the `loki.process` component as GA. (@kgeckhart)
-
 - (_Experimental_) Add `pyroscope.enrich` component to enrich profiles using labels from `discovery.*` components. (@AndreZiviani)
 
 - Add htpasswd file based authentication for `otelcol.auth.basic` (@pkarakal)
@@ -28,16 +24,13 @@ Main (unreleased)
 
 - Added `send_traceparent` option for `tracing` config to enable traceparent header propagation. (@MyDigitalLife)
 
-- Add `meta_cache_address` to `beyla.ebpf` component. (@skl)
-
 ### Bugfixes
 
-- `loki.source.api` no longer drops request when relabel rules drops a specific stream. (@kalleep)
 
 - (_Public Preview_) Additions to `database_observability.postgres` component:
     - fixes collection of Postgres schema details for mixed case table names (@fridgepoet)
 
-v1.12.0-rc.0
+v1.12.0-rc.3
 -----------------
 
 ### Breaking changes
@@ -104,6 +97,9 @@ v1.12.0-rc.0
   - The `otelcol.processor.servicegraph` component now supports defining the maximum number of buckets for generated exponential histograms.
   - See the upstream [core][https://github.com/open-telemetry/opentelemetry-collector/blob/v0.139.0/CHANGELOG.md] and [contrib][https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.139.0/CHANGELOG.md] changelogs for more details.
 
+- A new `mimir.alerts.kubernetes` component which discovers `AlertmanagerConfig` Kubernetes resources and loads them into a Mimir instance. (@ptodev)
+
+- Mark `stage.windowsevent` block in the `loki.process` component as GA. (@kgeckhart)
 
 ### Enhancements
 
@@ -140,6 +136,8 @@ v1.12.0-rc.0
 
 - `kubernetes.discovery` Add support for attaching namespace metadata. (@kgeckhart)
 
+- Add `meta_cache_address` to `beyla.ebpf` component. (@skl)
+
 ### Bugfixes
 
 - Stop `loki.source.kubernetes` discarding log lines with duplicate timestamps. (@ciaranj)
@@ -171,6 +169,8 @@ v1.12.0-rc.0
 - Fix the `loki.write` endpoint block's `enable_http2` attribute to actually affect the client. HTTP2 was previously disabled regardless of configuration. (@dehaansa)
 
 - Optionally remove trailing newlines before appending entries in `stage.multiline`. (@dehaansa)
+
+- `loki.source.api` no longer drops request when relabel rules drops a specific stream. (@kalleep)
 
 v1.11.3
 -----------------

--- a/docs/developer/release/08-announce-release.md
+++ b/docs/developer/release/08-announce-release.md
@@ -6,15 +6,6 @@ You made it! This is the last step for any release.
 
 1. Announce the release in the Grafana Labs Community `#alloy` channel.
 
-    - Example RCV message:
-
-    ```
-    :alloy: Grafana Alloy RELEASE_VERSION is now available! :alloy:
-    Release: https://github.com/grafana/alloy/releases/tag/RELEASE_VERSION
-    Full changelog: https://github.com/grafana/alloy/blob/RELEASE_VERSION/CHANGELOG.md
-    We'll be publishing STABLE_RELEASE_VERSION on STABLE_RELEASE_DATE if we haven't heard about any major issues.
-    ```
-
     - Example Stable Release or Patch Release message:
 
     ```


### PR DESCRIPTION
It had gotten out of sync since 1.12 rc.0

also updated release docs since we no longer announce RCs.

- [x] CHANGELOG.md updated
