### PR TITLE
fix cluster drift alert

### DIFF
--- a/operations/alloy-mixin/alerts/clustering.libsonnet
+++ b/operations/alloy-mixin/alerts/clustering.libsonnet
@@ -80,11 +80,11 @@ local alert = import './utils/alert.jsonnet';
           'ClusterConfigurationDrift',
           if enableK8sCluster then |||
             count without (sha256) (
-                max by (cluster, namespace, sha256, job, cluster_name) (alloy_config_hash and on(cluster, namespace, job, cluster_name) cluster_node_info)
+                max by (cluster, namespace, sha256, job, cluster_name, app) (alloy_config_hash and on(cluster, namespace, job, cluster_name) cluster_node_info)
             ) > 1
           ||| else |||
             count without (sha256) (
-                max by (sha256, job) (alloy_config_hash and on(job) cluster_node_info)
+                max by (sha256, job, app) (alloy_config_hash and on(job) cluster_node_info)
             ) > 1
           |||
           ,


### PR DESCRIPTION
In case the job name is equal (for e.g. k8s-monitoring installation) multiple instances of alloy get deployed into a cluster alloy-logs, alloy-singleton which results in an alert firing for configuration drift. This CL addresses the issue by grouping together on the app label which matches alloy-logs and alloy-metrics in the case of k8s-monitoring.

Fixes #4945

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

This is only a proposed change, lets discuss the details in #4945 first and settle on the right solution.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
