### PR TITLE
chore(doc): admonition for API saturation risk

### DIFF
--- a/docs/sources/reference/components/discovery/discovery.kubernetes.md
+++ b/docs/sources/reference/components/discovery/discovery.kubernetes.md
@@ -15,8 +15,6 @@ title: discovery.kubernetes
 `discovery.kubernetes` allows you to find scrape targets from Kubernetes resources.
 It watches cluster state, and ensures targets are continually synced with what's currently running in your cluster.
 
-If you supply no connection information, this component defaults to an in-cluster configuration.
-A kubeconfig file or manual connection settings can be used to override the defaults.
 {{< admonition type="caution" >}}
 **Kubernetes API Saturation Risk**
 


### PR DESCRIPTION
Added caution about Kubernetes API saturation risk when running Alloy as a DaemonSet, along with recommended solutions

#### PR Description

#### Which issue(s) this PR fixes

Proposition for #4787 #4793 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
