### PR TITLE
Fix broken link definitions

### DIFF
--- a/docs/sources/get-started/_index.md
+++ b/docs/sources/get-started/_index.md
@@ -138,7 +138,7 @@ For hands-on learning:
 - [Tutorials][] - Build complete data collection pipelines step by step
 - [Components][components] - Browse all available components and their options
 
-[fmt]: ../../reference/cli/fmt/
+[fmt]: ../reference/cli/fmt/
 [Built-in]: ../reference/stdlib/
 [Alloy syntax]: ./syntax/
 [Components]: ./components/

--- a/docs/sources/get-started/components/build-pipelines.md
+++ b/docs/sources/get-started/components/build-pipelines.md
@@ -310,6 +310,6 @@ For hands-on learning:
 
 - [Tutorials][] - Follow step-by-step guides to build complete monitoring solutions
 
-[Component controller]: ./component-controller/
-[Expressions]: ../expressions/
-[Tutorials]: ../../tutorials/
+[Component controller]: ../component-controller/
+[Expressions]: ../../expressions/
+[Tutorials]: ../../../tutorials/

--- a/docs/sources/get-started/components/community-components.md
+++ b/docs/sources/get-started/components/community-components.md
@@ -58,7 +58,7 @@ For component selection guidance:
 
 - [Choose a component][] - Get guidance on selecting the right component for your needs
 
-[backward-compatibility]: ../../introduction/backward-compatibility/
-[Component reference]: ../../reference/components/
-[Configure components]: ./configure-components/
-[Choose a component]: ../../collect/choose-component/
+[backward-compatibility]: ../../../introduction/backward-compatibility/
+[Component reference]: ../../../reference/components/
+[Configure components]: ../configure-components/
+[Choose a component]: ../../../collect/choose-component/

--- a/docs/sources/get-started/components/component-controller.md
+++ b/docs/sources/get-started/components/component-controller.md
@@ -112,7 +112,7 @@ This graceful degradation keeps your monitoring operational even when individual
 
 ## In-memory traffic
 
-Some components that expose HTTP endpoints (such as [`prometheus.exporter.unix`][prometheus.exporter.unix]) support in-memory communication for improved performance.
+Some components that expose HTTP endpoints, such as [`prometheus.exporter.unix`][prometheus.exporter.unix], support in-memory communication for improved performance.
 When components within the same {{< param "PRODUCT_NAME" >}} process communicate, they can bypass the network stack entirely.
 
 Benefits of in-memory traffic:
@@ -147,8 +147,8 @@ For monitoring and troubleshooting:
 - [{{< param "PRODUCT_NAME" >}} run command][run] - Configuration options that affect the controller
 
 [DAG]: https://en.wikipedia.org/wiki/Directed_acyclic_graph
-[prometheus.exporter.unix]: ../../reference/components/prometheus/prometheus.exporter.unix
-[run]: ../../reference/cli/run/
-[Configure components]: ./configure-components/
-[Expressions]: ../expressions/
+[prometheus.exporter.unix]: ../../../reference/components/prometheus/prometheus.exporter.unix
+[run]: ../../../reference/cli/run/
+[Configure components]: ../configure-components/
+[Expressions]: ../../expressions/
 [Monitor the component controller]: ../../../troubleshoot/controller_metrics/

--- a/docs/sources/get-started/components/configure-components.md
+++ b/docs/sources/get-started/components/configure-components.md
@@ -175,17 +175,16 @@ local.file "b" {
 Now that you understand how to configure components, learn about more advanced topics:
 
 - [Build data pipelines][] - Connect components together to create data processing workflows
-- [Component controller][] - Understand how {{< param "PRODUCT_NAME" >}} manages components at runtime
+- [Component controller][controller] - Understand how {{< param "PRODUCT_NAME" >}} manages components at runtime
 - [Expressions][] - Write dynamic configuration using component references and functions
 - [Component reference][] - Explore all available components and their arguments and exports
 
 For practical examples, try the [tutorials][] to build complete data collection pipelines.
 
-[components]: ../../reference/components/
-[controller]: ./component-controller/
-[type]: ../expressions/types_and_values/
-[Build data pipelines]: ./build-pipelines/
-[Component controller]: ./component-controller/
-[Expressions]: ../expressions/
-[Component reference]: ../../reference/components/
-[tutorials]: ../../tutorials/
+[components]: ../../../reference/components/
+[type]: ../../expressions/types_and_values/
+[Build data pipelines]: ../build-pipelines/
+[controller]: ../component-controller/
+[Expressions]: ../../expressions/
+[Component reference]: ../../../reference/components/
+[tutorials]: ../../../tutorials/

--- a/docs/sources/get-started/components/custom-components.md
+++ b/docs/sources/get-started/components/custom-components.md
@@ -29,8 +29,8 @@ The block's label becomes the custom component's name, which you can then use li
 
 Inside a `declare` block, you can use these configuration blocks:
 
-- [`argument`][]: Defines a named input parameter that users must provide when using your custom component. Access the value with `argument.NAME.value`.
-- [`export`][]: Defines a named output value that your custom component exposes to other components.
+- [`argument`][argument]: Defines a named input parameter that users must provide when using your custom component. Access the value with `argument.NAME.value`.
+- [`export`][export]: Defines a named output value that your custom component exposes to other components.
 - Built-in and custom components: The actual pipeline logic that processes data.
 
 The component controller treats custom components the same as built-in components:
@@ -78,7 +78,7 @@ This custom component:
 1. **Can be instantiated**: Create an instance labeled `example` by providing values for `a` and `b`.
 1. **Exposes computed results**: Other components can reference `add.example.sum` to use the result.
 
-For more complex examples that combine multiple built-in components, refer to the [declare block reference][declare].
+For more complex examples that combine multiple built-in components, refer to the [`declare` block reference][declare].
 
 ## Next steps
 
@@ -91,9 +91,9 @@ For sharing and organizing:
 
 - [Modules][] - Share custom components across multiple configuration files
 
-[declare]: ../../reference/config-blocks/declare/
-[argument]: ../../reference/config-blocks/argument/
-[export]: ../../reference/config-blocks/export/
-[Modules]: ../modules/
-[Configuration blocks reference]: ../../reference/config-blocks/
-[Configure components]: ./configure-components/
+[declare]: ../../../reference/config-blocks/declare/
+[argument]: ../../../reference/config-blocks/argument/
+[export]: ../../../reference/config-blocks/export/
+[Modules]: ../../modules/
+[Configuration blocks reference]: ../../../reference/config-blocks/
+[Configure components]: ../configure-components/

--- a/docs/sources/get-started/expressions/function_calls.md
+++ b/docs/sources/get-started/expressions/function_calls.md
@@ -130,7 +130,7 @@ For detailed function reference:
 
 - [Standard library reference][standard library] - Complete documentation of all available functions and their usage
 
-[type]: ./types_and_values/
-[refer to values]: ./referencing_exports/
-[operators]: ./operators/
+[type]: ../types_and_values/
+[refer to values]: ../referencing_exports/
+[operators]: ../operators/
 [standard library]: ../../../reference/stdlib/

--- a/docs/sources/get-started/expressions/operators.md
+++ b/docs/sources/get-started/expressions/operators.md
@@ -160,7 +160,7 @@ For building complete configurations:
 
 - [Component exports][refer to values] - Combine operators with component references to create dynamic pipelines
 
-[type]: ./types_and_values/
-[functions]: ./function_calls/
-[refer to values]: ./referencing_exports/
+[type]: ../types_and_values/
+[functions]: ../function_calls/
+[refer to values]: ../referencing_exports/
 [PEMDAS]: https://en.wikipedia.org/wiki/Order_of_operations

--- a/docs/sources/get-started/expressions/referencing_exports.md
+++ b/docs/sources/get-started/expressions/referencing_exports.md
@@ -80,6 +80,6 @@ Now that you understand component references, continue learning about expression
 - [Function calls][functions] - Use built-in functions to transform values from referenced exports
 - [Operators][operators] - Combine referenced values with other expressions using mathematical and logical operators
 
-[type]: ./types_and_values/
-[functions]: ./function_calls/
-[operators]: ./operators/
+[type]: ../types_and_values/
+[functions]: ../function_calls/
+[operators]: ../operators/

--- a/docs/sources/get-started/expressions/types_and_values.md
+++ b/docs/sources/get-started/expressions/types_and_values.md
@@ -233,9 +233,9 @@ For advanced expression features:
 
 - [Function calls][] - Transform data using standard library functions that work with these types
 
-[component reference]: ../../../../reference/components/
+[component reference]: ../../../reference/components/
 [valid]: ../../syntax#identifiers
-[nonsensitive]: ../../../../reference/stdlib/convert/
-[Component exports]: ./referencing_exports/
-[Operators]: ./operators/
-[Function calls]: ./function_calls/
+[nonsensitive]: ../../../reference/stdlib/convert/
+[Component exports]: ../referencing_exports/
+[Operators]: ../operators/
+[Function calls]: ../function_calls/

--- a/docs/sources/get-started/modules.md
+++ b/docs/sources/get-started/modules.md
@@ -167,11 +167,11 @@ For hands-on module development:
 - [Import configuration blocks][imports] - Detailed reference for different module import methods
 - [Run command reference][run] - Module configuration and execution options
 
-[custom components]: ./components/custom-components/
-[components]: ./components/
-[imports]: ../reference/config-blocks/
-[run]: ../reference/cli/run/
-[import.file]: ../reference/config-blocks/import.file/
-[import.git]: ../reference/config-blocks/import.git/
-[import.http]: ../reference/config-blocks/import.http/
-[import.string]: ../reference/config-blocks/import.string/
+[custom components]: ../components/custom-components/
+[components]: ../components/
+[imports]: ../../reference/config-blocks/
+[run]: ../../reference/cli/run/
+[import.file]: ../../reference/config-blocks/import.file/
+[import.git]: ../../reference/config-blocks/import.git/
+[import.http]: ../../reference/config-blocks/import.http/
+[import.string]: ../../reference/config-blocks/import.string/

--- a/docs/sources/get-started/syntax.md
+++ b/docs/sources/get-started/syntax.md
@@ -270,7 +270,7 @@ For advanced configuration techniques:
 
 - [Formatting][fmt] - Use `alloy fmt` to automatically format your configuration files
 
-[Expressions]: ./expressions/
-[Components]: ./components/
-[fmt]: ../reference/cli/fmt/
+[Expressions]: ../expressions/
+[Components]: ../components/
+[fmt]: ../../reference/cli/fmt/
 [identifier]: #identifiers


### PR DESCRIPTION
A bunch of broken links slipped into the changes merged in PR https://github.com/grafana/alloy/pull/4591

This PR fixes the link definitions.