### PR TITLE
only ignore alloy at top level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ node_modules
 # file of the pair will detect a dirty work tree and detect the wrong tag name.
 .tag-only
 .image-tag
-alloy
+/alloy
 
 # local testing files
 /targets.yaml


### PR DESCRIPTION
Looks like this one slipped through in #4452 

Adding `alloy` to the ignores had the unintended side effect of ignoring *all* files and folders named alloy, such as `operations/helm/charts/alloy/*`.

Since these files already exist in the repo, this change didn't _appear_ to affect things, however I noticed this because none of these files were searchable in my IDE (due to following .gitignore directives).

We would likely have noticed this in the future if we ever needed to add additional files to this/these folders.

I'm assuming this is here because under some circumstances a binary gets built named `alloy` and placed in the root of the repo. I haven't yet hunted down where this is, but it should be a goal to track this down, prevent it from happening in CI, and then remove this ignore directive.