### PR TITLE
loki.write: always read and close response body

### DIFF
--- a/internal/component/common/loki/client/consumer_fanout.go
+++ b/internal/component/common/loki/client/consumer_fanout.go
@@ -364,9 +364,11 @@ func (c *client) send(ctx context.Context, tenantID string, buf []byte) (int, er
 
 	// NOTE: it is important in go to fully read the body and
 	// close it so that the connection can be reused.
-	// We only partailly read the body if we encounter a non 2xx error
+	// We only partially read the body if we encounter a non 2xx error
 	// so we should always consume whats left.
 	// https://github.com/golang/go/blob/32a9804c7ba3f4a0e0bd26cc24b9204860a49ec8/src/net/http/response.go#L59-L64
+	// It is unclear that we always need to drain the body but
+	// https://github.com/golang/go/issues/60240#issuecomment-1551060433 seems to indicate that we should.
 	defer func() {
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()

--- a/internal/component/common/loki/client/consumer_wal.go
+++ b/internal/component/common/loki/client/consumer_wal.go
@@ -393,7 +393,7 @@ func (c *walClient) runSendOldBatches() {
 				c.sendQueue.enqueue(qb)
 			}
 
-			batchesToFlush = batchesToFlush[:0] // renew slide
+			batchesToFlush = batchesToFlush[:0] // renew slice
 		}
 	}
 }
@@ -508,9 +508,12 @@ func (c *walClient) send(ctx context.Context, tenantID string, buf []byte) (int,
 
 	// NOTE: it is important in go to fully read the body and
 	// close it so that the connection can be reused.
-	// We only partailly read the body if we encounter a non 2xx error
+	// We only partially read the body if we encounter a non 2xx error
 	// so we should always consume whats left.
 	// https://github.com/golang/go/blob/32a9804c7ba3f4a0e0bd26cc24b9204860a49ec8/src/net/http/response.go#L59-L64
+	// It is unclear that we always need to drain the body but
+	// https://github.com/golang/go/issues/60240#issuecomment-1551060433 seems to indicate that we should.
+
 	defer func() {
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()


### PR DESCRIPTION
While investigate issues I noticed that we don't always fully read the response body.

From go source code docs:
```
// The http Client and Transport guarantee that Body is always
// non-nil, even on responses without a body or responses with
// a zero-length body. It is the caller's responsibility to
// close Body. The default HTTP client's Transport may not
// reuse HTTP/1.x "keep-alive" TCP connections if the Body is
// not read to completion and closed.
```
