### PR TITLE
chore: remove unneeded build tags

### DIFF
--- a/internal/alloycli/automemlimit_cgroups_unsupported.go
+++ b/internal/alloycli/automemlimit_cgroups_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package alloycli
 

--- a/internal/alloycli/automemlimit_linux.go
+++ b/internal/alloycli/automemlimit_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package alloycli
 

--- a/internal/alloycli/automemlimit_nonlinux_test.go
+++ b/internal/alloycli/automemlimit_nonlinux_test.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package alloycli
 

--- a/internal/component/loki/source/file/internal/tail/tail_posix.go
+++ b/internal/component/loki/source/file/internal/tail/tail_posix.go
@@ -1,4 +1,4 @@
-// +build linux darwin freebsd netbsd openbsd
+//go:build linux || darwin || freebsd || netbsd || openbsd
 
 package tail
 

--- a/internal/component/loki/source/file/internal/tail/tail_windows.go
+++ b/internal/component/loki/source/file/internal/tail/tail_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package tail
 

--- a/internal/component/loki/source/file/internal/tail/watch/file_posix.go
+++ b/internal/component/loki/source/file/internal/tail/watch/file_posix.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin || freebsd || netbsd || openbsd
-// +build linux darwin freebsd netbsd openbsd
 
 package watch
 

--- a/internal/component/loki/source/file/internal/tail/watch/file_windows.go
+++ b/internal/component/loki/source/file/internal/tail/watch/file_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package watch
 

--- a/internal/component/loki/source/file/internal/tail/winfile/winfile.go
+++ b/internal/component/loki/source/file/internal/tail/winfile/winfile.go
@@ -1,4 +1,4 @@
-// +build windows
+//go:build windows
 
 package winfile
 

--- a/internal/component/loki/source/windowsevent/bookmark.go
+++ b/internal/component/loki/source/windowsevent/bookmark.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 // This code is adapted from loki/promtail. Last revision used to port changes to Alloy was v1.6.2-0.20231004111112-07cbef92268a.
 

--- a/internal/component/loki/source/windowsevent/component_windows.go
+++ b/internal/component/loki/source/windowsevent/component_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package windowsevent
 

--- a/internal/component/loki/source/windowsevent/format.go
+++ b/internal/component/loki/source/windowsevent/format.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 // This code is copied from Promtail v1.6.2-0.20231004111112-07cbef92268a with minor changes.
 

--- a/internal/component/loki/source/windowsevent/target.go
+++ b/internal/component/loki/source/windowsevent/target.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 // This code is adapted from loki/promtail. Last revision used to port changes to Alloy was v1.6.2-0.20231004111112-07cbef92268a.
 

--- a/internal/component/loki/source/windowsevent/win_eventlog/event.go
+++ b/internal/component/loki/source/windowsevent/win_eventlog/event.go
@@ -21,7 +21,6 @@
 // SOFTWARE.
 
 //go:build windows
-// +build windows
 
 // Package win_eventlog Input plugin to collect Windows Event Log messages
 //

--- a/internal/component/loki/source/windowsevent/win_eventlog/syscall_windows.go
+++ b/internal/component/loki/source/windowsevent/win_eventlog/syscall_windows.go
@@ -19,8 +19,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+
 //go:build windows
-// +build windows
 
 // Package win_eventlog Input plugin to collect Windows Event Log messages
 //

--- a/internal/component/loki/source/windowsevent/win_eventlog/util.go
+++ b/internal/component/loki/source/windowsevent/win_eventlog/util.go
@@ -19,8 +19,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+
 //go:build windows
-// +build windows
 
 // Package win_eventlog Input plugin to collect Windows Event Log messages
 //

--- a/internal/component/loki/source/windowsevent/win_eventlog/util_test.go
+++ b/internal/component/loki/source/windowsevent/win_eventlog/util_test.go
@@ -19,8 +19,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+
 //go:build windows
-// +build windows
 
 // Package win_eventlog Input plugin to collect Windows Event Log messages
 //

--- a/internal/component/loki/source/windowsevent/win_eventlog/win_eventlog.go
+++ b/internal/component/loki/source/windowsevent/win_eventlog/win_eventlog.go
@@ -19,8 +19,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+
 //go:build windows
-// +build windows
 
 // Package win_eventlog Input plugin to collect Windows Event Log messages
 //

--- a/internal/component/loki/source/windowsevent/win_eventlog/win_eventlog_notwindows.go
+++ b/internal/component/loki/source/windowsevent/win_eventlog/win_eventlog_notwindows.go
@@ -19,8 +19,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+
 //go:build !windows
-// +build !windows
 
 // Package win_eventlog Input plugin to collect Windows Event Log messages
 //

--- a/internal/component/loki/source/windowsevent/win_eventlog/win_eventlog_test.go
+++ b/internal/component/loki/source/windowsevent/win_eventlog/win_eventlog_test.go
@@ -19,8 +19,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+
 //go:build windows
-// +build windows
 
 // Package win_eventlog Input plugin to collect Windows Event Log messages
 //

--- a/internal/component/loki/source/windowsevent/win_eventlog/zsyscall_windows.go
+++ b/internal/component/loki/source/windowsevent/win_eventlog/zsyscall_windows.go
@@ -19,8 +19,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+
 //go:build windows
-// +build windows
 
 // Package win_eventlog Input plugin to collect Windows Event Log messages
 //

--- a/internal/filedetector/internal/inotifyinfo/inotifyinfo_linux.go
+++ b/internal/filedetector/internal/inotifyinfo/inotifyinfo_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package inotifyinfo
 

--- a/internal/filedetector/internal/inotifyinfo/inotifyinfo_unsupported.go
+++ b/internal/filedetector/internal/inotifyinfo/inotifyinfo_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package inotifyinfo
 

--- a/internal/tools/packaging_test/alloy_linux_packages_test.go
+++ b/internal/tools/packaging_test/alloy_linux_packages_test.go
@@ -1,5 +1,4 @@
 //go:build !nonetwork && !nodocker && packaging
-// +build !nonetwork,!nodocker,packaging
 
 package packaging_test
 

--- a/internal/tools/packaging_test/environment_test.go
+++ b/internal/tools/packaging_test/environment_test.go
@@ -1,5 +1,4 @@
 //go:build !nonetwork && !nodocker && packaging
-// +build !nonetwork,!nodocker,packaging
 
 package packaging_test
 

--- a/internal/util/windowspriority/set_priority_nonwindows.go
+++ b/internal/util/windowspriority/set_priority_nonwindows.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package windowspriority
 

--- a/internal/util/windowspriority/set_priority_windows.go
+++ b/internal/util/windowspriority/set_priority_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package windowspriority
 

--- a/internal/util/windowspriority/set_priority_windows_test.go
+++ b/internal/util/windowspriority/set_priority_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package windowspriority
 


### PR DESCRIPTION
No need to have the old format around for buildtags.
