### PR TITLE
Fix two more aliases in Get Started section

### DIFF
--- a/docs/sources/get-started/components/_index.md
+++ b/docs/sources/get-started/components/_index.md
@@ -5,6 +5,8 @@ aliases:
   - ./concepts/components/ # /docs/alloy/latest/concepts/components/
   - ./concepts/configuration-syntax/components/ # /docs/alloy/latest/concepts/configuration-syntax/
   - ./configuration-syntax/components/components/ # /docs/alloy/latest/get-started/configuration-syntax/components/
+  - ./configuration-syntax/ # /docs/alloy/latest/get-started/configuration-syntax/
+  - ./configuration-syntax/files/ # /docs/alloy/latest/get-started/configuration-syntax/files/
 description: Learn about components
 title: Components
 weight: 30


### PR DESCRIPTION
This PR fixes two more missing aliases in the Get Started section of the Alloy docs.