### PR TITLE
stage.cri: remove wrong output stage

### DIFF
--- a/internal/component/loki/process/stages/extensions.go
+++ b/internal/component/loki/process/stages/extensions.go
@@ -190,7 +190,7 @@ func NewCRI(logger log.Logger, config CRIConfig, registerer prometheus.Registere
 		},
 		{
 			OutputConfig: &OutputConfig{
-				"content",
+				Source: "content",
 			},
 		},
 	}


### PR DESCRIPTION
#### PR Description
Noticed when running with debug logging enabled.

This stage was originally added to promtail in https://github.com/grafana/loki/pull/6177. For some reason it had two output stages, one for `content` and one for `flags`.

stage.Output will replace log line of entries and that should always be `content`. The regexp stage for cri will extract `time`, `stream`, `flags` and content `content`. Because `tags` was never extracted this was never a problem but we should not have this stage.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
