### PR TITLE
docs: Update prometheus.exporter.cadvisor to add information about permissions

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.exporter.cadvisor.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.cadvisor.md
@@ -26,9 +26,9 @@ The component requires specific permissions and configuration depending on your 
 {{< tabs >}}
 {{< tab-content name="Linux binary" >}}
 
-When you run {{< param "PRODUCT_NAME" >}} as a Linux binary or systemd service or configured to use the non-root `alloy` user, you will need to give the `alloy` user requires permissions to access the container runtime socket and related directories to collect container metrics from containers on the host.
+When you run {{< param "PRODUCT_NAME" >}} as a Linux binary, systemd service, or with the [non-root][nonroot] `alloy` user, you must grant the `alloy` user permissions to access the container runtime socket and related directories to collect metrics from containers on the host.
 
-The component works with Docker, containerd, Container Runtime Interface for OpenShift (CRI-O), and systemd container runtimes.
+The component works with Docker, `containerd`, Container Runtime Interface for OpenShift (CRI-O), and systemd container runtimes.
 
 For Docker, grant permissions using one of these approaches:
 


### PR DESCRIPTION
This PR adds information about how to set permissions to run Alloy in local, Docker and K8s. It was compared against the related Issues, and compared against advice give in the Alloy forums.


Fixes: 
* https://github.com/grafana/alloy/issues/990 
* https://github.com/grafana/alloy/issues/3482
