### PR TITLE
[wip] fix node_exporter version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog this is a test
+# Changelog
 
 > _Contributors should read our [contributors guide][] for instructions on how
 > to update the changelog._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changelog this is a test
 
 > _Contributors should read our [contributors guide][] for instructions on how
 > to update the changelog._


### PR DESCRIPTION
#### PR Description
Removes the misleading `node_exporter_build_info` metric from the `prometheus.exporter.unix` component.

Previously, this metric reported Alloy's build version (e.g., v1.10.2) instead of the underlying node_exporter's version, as it was generated using Alloy's `build.NewCollector()`. This fix ensures that the component does not expose incorrect build information.

#### Which issue(s) this PR fixes
Fixes #4330

#### Notes to the Reviewer
The upstream `node_exporter` library (v1.9.1, as used by Alloy) does not expose a `node_exporter_build_info` metric. Removing this incorrect metric aligns with upstream behavior and prevents confusion about the version reported.

#### PR Checklist
- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated

---
[Slack Thread](https://raintank-corp.slack.com/archives/D09NU1N6B0X/p1765292603746379?thread_ts=1765292603.746379&cid=D09NU1N6B0X)

<a href="https://cursor.com/background-agent?bcId=bc-281a2fda-a9be-4d3d-a43c-86add8bf461b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-281a2fda-a9be-4d3d-a43c-86add8bf461b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

