### PR TITLE
chore: stop storage and wal after test

### DIFF
--- a/internal/component/prometheus/pipeline_test.go
+++ b/internal/component/prometheus/pipeline_test.go
@@ -207,6 +207,11 @@ func newRemoteWriteComponent(t testing.TB, logger log.Logger, ls *labelstore.Ser
 	inMemoryAppendable := testappender.ConstantAppendable{Inner: testappender.NewCollectingAppender()}
 	store := storage.NewFanout(fanoutLogger, walStorage, testStorage{inMemoryAppendable: inMemoryAppendable})
 
+	t.Cleanup(func() {
+		store.Close()
+		walStorage.Close()
+	})
+
 	return remotewrite.NewInterceptor("prometheus.remote_write.test", &atomic.Bool{}, livedebugging.NewLiveDebugging(), ls, store), inMemoryAppendable.Inner
 }
 


### PR DESCRIPTION
These test are broken on windows. The temp directory used cannot be removed because we have open fd:s to files in it. On linux this is not a problem but on windows it is (if you don't open files with proper flags)