### PR TITLE
database_observability: add cloud provider labels to all metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Main (unreleased)
 - (_Public Preview_) Additions to `database_observability.mysql` and `database_observability.postgres` components:
   - `explain_plans`
     - always send an explain plan log message for each query, even skipped or errored queries. (@rgeyer)
+  - Metrics are now appended with cloud provider information labels (@matthewnolf)
 
 - Reduced resource overhead of `prometheus.scrape`, `prometheus.relabel`, `prometheus.enrich`, and `prometheus.remote_write` by removing unnecessary usage of labelstore.LabelStore. (@kgeckhart)
 

--- a/internal/component/database_observability/cloud_provider.go
+++ b/internal/component/database_observability/cloud_provider.go
@@ -1,11 +1,17 @@
 package database_observability
 
-import "github.com/aws/aws-sdk-go-v2/aws/arn"
+import (
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+)
 
 type CloudProvider struct {
-	AWS *AWSCloudProviderInfo
+	AWS   *AWSCloudProviderInfo
+	Azure *AzureCloudProviderInfo
 }
 
 type AWSCloudProviderInfo struct {
 	ARN arn.ARN
+}
+type AzureCloudProviderInfo struct {
+	Resource string
 }

--- a/internal/component/database_observability/mysql/cloud_provider_test.go
+++ b/internal/component/database_observability/mysql/cloud_provider_test.go
@@ -1,0 +1,36 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/grafana/alloy/internal/component/database_observability"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPopulateCloudProvider(t *testing.T) {
+	t.Run("populates AWS RDS details from DSN", func(t *testing.T) {
+		dsn := "user:pass@tcp(products-db.abc123xyz.us-east-1.rds.amazonaws.com:3306)/schema"
+		got, err := populateCloudProviderFromDSN(dsn)
+		require.NoError(t, err)
+
+		assert.Equal(t, &database_observability.CloudProvider{
+			AWS: &database_observability.AWSCloudProviderInfo{
+				ARN: arn.ARN{Resource: "db:products-db", Region: "us-east-1", AccountID: "unknown"},
+			},
+		}, got)
+	})
+
+	t.Run("populates Azure details from DSN", func(t *testing.T) {
+		dsn := "user:pass@tcp(products-db.mysql.database.azure.com:3306)/schema"
+		got, err := populateCloudProviderFromDSN(dsn)
+		require.NoError(t, err)
+
+		assert.Equal(t, &database_observability.CloudProvider{
+			Azure: &database_observability.AzureCloudProviderInfo{
+				Resource: "products-db",
+			},
+		}, got)
+	})
+}

--- a/internal/component/database_observability/postgres/cloud_provider.go
+++ b/internal/component/database_observability/postgres/cloud_provider.go
@@ -1,0 +1,61 @@
+package postgres
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/grafana/alloy/internal/component/database_observability"
+	"github.com/grafana/alloy/internal/component/database_observability/postgres/collector"
+)
+
+var (
+	rdsRegex   = regexp.MustCompile(`(?P<identifier>[^\.]+)\.([^\.]+)\.(?P<region>[^\.]+)\.rds\.amazonaws\.com`)
+	azureRegex = regexp.MustCompile(`(?P<identifier>[^\.]+)\.postgres\.database\.azure\.com`)
+)
+
+func populateCloudProviderFromConfig(config *CloudProvider) (*database_observability.CloudProvider, error) {
+	var cloudProvider database_observability.CloudProvider
+	if config.AWS != nil {
+		arn, err := arn.Parse(config.AWS.ARN)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse AWS cloud provider ARN: %w", err)
+		}
+		cloudProvider.AWS = &database_observability.AWSCloudProviderInfo{
+			ARN: arn,
+		}
+	}
+	return &cloudProvider, nil
+}
+
+func populateCloudProviderFromDSN(dsn string) (*database_observability.CloudProvider, error) {
+	var cloudProvider database_observability.CloudProvider
+
+	parts, err := collector.ParseURL(dsn)
+	if err != nil {
+		return nil, err
+	}
+
+	if host, ok := parts["host"]; ok {
+		if strings.HasSuffix(host, "rds.amazonaws.com") {
+			matches := rdsRegex.FindStringSubmatch(host)
+			cloudProvider.AWS = &database_observability.AWSCloudProviderInfo{
+				ARN: arn.ARN{
+					Resource:  fmt.Sprintf("db:%s", matches[1]),
+					Region:    matches[3],
+					AccountID: "unknown",
+				},
+			}
+		} else if strings.HasSuffix(host, "postgres.database.azure.com") {
+			matches := azureRegex.FindStringSubmatch(host)
+			if len(matches) > 1 {
+				cloudProvider.Azure = &database_observability.AzureCloudProviderInfo{
+					Resource: matches[1],
+				}
+			}
+		}
+	}
+
+	return &cloudProvider, nil
+}

--- a/internal/component/database_observability/postgres/cloud_provider_test.go
+++ b/internal/component/database_observability/postgres/cloud_provider_test.go
@@ -1,0 +1,36 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/grafana/alloy/internal/component/database_observability"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPopulateCloudProvider(t *testing.T) {
+	t.Run("populates AWS RDS details from DSN", func(t *testing.T) {
+		dsn := "postgres://user:pass@products-db.abc123xyz.us-east-1.rds.amazonaws.com:5432/mydb"
+		got, err := populateCloudProviderFromDSN(dsn)
+		require.NoError(t, err)
+
+		assert.Equal(t, &database_observability.CloudProvider{
+			AWS: &database_observability.AWSCloudProviderInfo{
+				ARN: arn.ARN{Resource: "db:products-db", Region: "us-east-1", AccountID: "unknown"},
+			},
+		}, got)
+	})
+
+	t.Run("populates Azure details from DSN", func(t *testing.T) {
+		dsn := "postgres://user:pass@products-db.postgres.database.azure.com:5432/mydb"
+		got, err := populateCloudProviderFromDSN(dsn)
+		require.NoError(t, err)
+
+		assert.Equal(t, &database_observability.CloudProvider{
+			Azure: &database_observability.AzureCloudProviderInfo{
+				Resource: "products-db",
+			},
+		}, got)
+	})
+}

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/blang/semver/v4"
 	"github.com/lib/pq"
 	"github.com/prometheus/client_golang/prometheus"
@@ -292,11 +291,28 @@ func (c *Component) Update(args component.Arguments) error {
 
 	generatedSystemID := fmt.Sprintf("%x", sha256.Sum256([]byte(fmt.Sprintf("%s:%s:%s", systemID.String, systemIP.String, systemPort.String))))
 
+	var cp *database_observability.CloudProvider
+	if c.args.CloudProvider != nil {
+		cloudProvider, err := populateCloudProviderFromConfig(c.args.CloudProvider)
+		if err != nil {
+			c.reportError("failed to collect cloud provider information from config", err)
+			return nil
+		}
+		cp = cloudProvider
+	} else {
+		cloudProvider, err := populateCloudProviderFromDSN(string(c.args.DataSourceName))
+		if err != nil {
+			c.reportError("failed to collect cloud provider information from DSN", err)
+			return nil
+		}
+		cp = cloudProvider
+	}
+
 	c.args.Targets = append([]discovery.Target{c.baseTarget}, c.args.Targets...)
 	targets := make([]discovery.Target, 0, len(c.args.Targets)+1)
 	for _, t := range c.args.Targets {
 		builder := discovery.NewTargetBuilderFrom(t)
-		if relabel.ProcessBuilder(builder, database_observability.GetRelabelingRules(generatedSystemID)...) {
+		if relabel.ProcessBuilder(builder, database_observability.GetRelabelingRules(generatedSystemID, cp)...) {
 			targets = append(targets, builder.Target())
 		}
 	}
@@ -309,7 +325,7 @@ func (c *Component) Update(args component.Arguments) error {
 	}
 	c.collectors = nil
 
-	if err := c.startCollectors(generatedSystemID, engineVersion.String); err != nil {
+	if err := c.startCollectors(generatedSystemID, engineVersion.String, cp); err != nil {
 		c.reportError("failed to start collectors", err)
 		return nil
 	}
@@ -342,26 +358,13 @@ func enableOrDisableCollectors(a Arguments) map[string]bool {
 }
 
 // startCollectors attempts to start all of the enabled collectors. If one or more collectors fail to start, their errors are reported
-func (c *Component) startCollectors(systemID string, engineVersion string) error {
+func (c *Component) startCollectors(systemID string, engineVersion string, cloudProviderInfo *database_observability.CloudProvider) error {
 	var startErrors []string
 
 	logStartError := func(collectorName, action string, err error) {
 		errorString := fmt.Sprintf("failed to %s %s collector: %+v", action, collectorName, err)
 		level.Error(c.opts.Logger).Log("msg", errorString)
 		startErrors = append(startErrors, errorString)
-	}
-
-	var cloudProviderInfo *database_observability.CloudProvider
-	if c.args.CloudProvider != nil && c.args.CloudProvider.AWS != nil {
-		arn, err := arn.Parse(c.args.CloudProvider.AWS.ARN)
-		if err != nil {
-			level.Error(c.opts.Logger).Log("msg", "failed to parse AWS cloud provider ARN", "err", err)
-		}
-		cloudProviderInfo = &database_observability.CloudProvider{
-			AWS: &database_observability.AWSCloudProviderInfo{
-				ARN: arn,
-			},
-		}
 	}
 
 	entryHandler := addLokiLabels(loki.NewEntryHandler(c.handler.Chan(), func() {}), c.instanceKey, systemID)

--- a/internal/component/database_observability/relabeling.go
+++ b/internal/component/database_observability/relabeling.go
@@ -2,10 +2,32 @@ package database_observability
 
 import "github.com/grafana/alloy/internal/component/common/relabel"
 
-func GetRelabelingRules(serverID string) []*relabel.Config {
+func GetRelabelingRules(serverID string, cp *CloudProvider) []*relabel.Config {
 	r := relabel.DefaultRelabelConfig // use default to avoid defining all fields
 	r.Replacement = serverID
 	r.TargetLabel = "server_id"
 	r.Action = relabel.Replace
-	return []*relabel.Config{&r}
+
+	rs := []*relabel.Config{&r}
+
+	if cp != nil && cp.AWS != nil {
+		providerName := relabel.DefaultRelabelConfig
+		providerName.Replacement = "aws"
+		providerName.TargetLabel = "provider_name"
+		providerName.Action = relabel.Replace
+
+		providerRegion := relabel.DefaultRelabelConfig
+		providerRegion.Replacement = cp.AWS.ARN.Region
+		providerRegion.TargetLabel = "provider_region"
+		providerRegion.Action = relabel.Replace
+
+		providerAccount := relabel.DefaultRelabelConfig
+		providerAccount.Replacement = cp.AWS.ARN.AccountID
+		providerAccount.TargetLabel = "provider_account"
+		providerAccount.Action = relabel.Replace
+
+		rs = append(rs, &providerName, &providerRegion, &providerAccount)
+	}
+
+	return rs
 }

--- a/internal/component/database_observability/relabeling_test.go
+++ b/internal/component/database_observability/relabeling_test.go
@@ -1,0 +1,48 @@
+package database_observability
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/grafana/alloy/internal/component/common/relabel"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_GetRelabelingRules(t *testing.T) {
+	t.Run("return relabeling rules", func(t *testing.T) {
+		rr := GetRelabelingRules("some-server-id", nil)
+
+		require.Equal(t, 1, len(rr))
+		require.Equal(t, "some-server-id", rr[0].Replacement)
+		require.Equal(t, "server_id", rr[0].TargetLabel)
+		require.Equal(t, relabel.Replace, rr[0].Action)
+	})
+
+	t.Run("return relabeling rules with AWS config", func(t *testing.T) {
+		rr := GetRelabelingRules("some-server-id", &CloudProvider{
+			AWS: &AWSCloudProviderInfo{
+				ARN: arn.ARN{
+					Region:    "some-region",
+					AccountID: "some-account",
+				},
+			},
+		})
+
+		require.Equal(t, 4, len(rr))
+		require.Equal(t, "some-server-id", rr[0].Replacement)
+		require.Equal(t, "server_id", rr[0].TargetLabel)
+		require.Equal(t, relabel.Replace, rr[0].Action)
+
+		require.Equal(t, "aws", rr[1].Replacement)
+		require.Equal(t, "provider_name", rr[1].TargetLabel)
+		require.Equal(t, relabel.Replace, rr[1].Action)
+
+		require.Equal(t, "some-region", rr[2].Replacement)
+		require.Equal(t, "provider_region", rr[2].TargetLabel)
+		require.Equal(t, relabel.Replace, rr[2].Action)
+
+		require.Equal(t, "some-account", rr[3].Replacement)
+		require.Equal(t, "provider_account", rr[3].TargetLabel)
+		require.Equal(t, relabel.Replace, rr[3].Action)
+	})
+}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Followup to https://github.com/grafana/alloy/pull/4942 - with verified git commit.

This change adds cloud provider information as labels to all metrics exported by the `database_observability` components. This enables more effective correlation and attribution across Grafana Cloud.

Some of the implementation is duplicated across MySQL and Postgres components. The reasoning being that cloud-providers sometimes vary their naming / URI structure to include engine information. Keeping things strongly tied to the database engine helps make this determination easier.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated

