### PR TITLE
chore: change the defaults of otelcol.exporter queue batch block

### DIFF
--- a/docs/sources/shared/reference/components/otelcol-queue-batch-block.md
+++ b/docs/sources/shared/reference/components/otelcol-queue-batch-block.md
@@ -4,13 +4,18 @@ description: Shared content, otelcol queue batch block
 headless: true
 ---
 
+Batching is disabled by default.
+To enable it, explicitly include `batch {}` in your Alloy configuration.
+You do not need to include a `batch {}` block in your `otelcol.exporter` if you already use a `otelcol.processor.batch` component,
+although batching in the exporter is the prefered method because it is more flexible.
+
 The following arguments are supported:
 
 | Name            | Type        | Description                                                                                                | Default      | Required |
 | --------------- | ----------- | ---------------------------------------------------------------------------------------------------------- | ------------ | -------- |
 | `flush_timeout` | `duration`  | Time after which a batch will be sent regardless of its size. Must be a non-zero value.                    |  `"200ms"`   | no       |
-| `min_size`      | `number`    | The minimum size of a batch.                                                                               |  `8192`      | no       |
-| `max_size`      | `number`    | The maximum size of a batch, enables batch splitting.                                                      |              | no       |
+| `min_size`      | `number`    | The minimum size of a batch.                                                                               |  `2000`      | no       |
+| `max_size`      | `number`    | The maximum size of a batch, enables batch splitting.                                                      |  `3000`      | no       |
 | `sizer`         | `string`    | How the queue and batching is measured. Overrides the sizer set at the `sending_queue` level for batching. |  `"items"`   | no       |
 
 If configured, `max_size` must be greater than or equal to `min_size`.

--- a/internal/component/otelcol/config_queue.go
+++ b/internal/component/otelcol/config_queue.go
@@ -153,7 +153,19 @@ type BatchConfig struct {
 	Sizer        string        `alloy:"sizer,attr,optional"`
 }
 
+var _ syntax.Defaulter = (*BatchConfig)(nil)
+
 var defaultBatchConfig = otelexporterhelper.NewDefaultQueueConfig().Batch
+
+// SetToDefault implements syntax.Defaulter.
+func (args *BatchConfig) SetToDefault() {
+	*args = BatchConfig{
+		FlushTimeout: 200 * time.Millisecond,
+		MinSize:      2000,
+		MaxSize:      3000,
+		Sizer:        "items",
+	}
+}
 
 // Validate returns an error if args is invalid.
 func (args *BatchConfig) Validate() error {

--- a/internal/component/otelcol/exporter/otlp/otlp_test.go
+++ b/internal/component/otelcol/exporter/otlp/otlp_test.go
@@ -145,6 +145,81 @@ func createTestTraces() ptrace.Traces {
 	return data
 }
 
+func TestQueueBatchConfig(t *testing.T) {
+	tests := []struct {
+		testName string
+		alloyCfg string
+		expected otelcol.QueueArguments
+	}{
+		{
+			testName: "default",
+			alloyCfg: `
+			client {
+				endpoint = "tempo:4317"
+			}
+			sending_queue {
+				batch {}
+			}
+			`,
+			expected: otelcol.QueueArguments{
+				Enabled:      true,
+				NumConsumers: 10,
+				QueueSize:    1000,
+				Sizer:        "requests",
+				Batch: &otelcol.BatchConfig{
+					FlushTimeout: 200 * time.Millisecond,
+					MinSize:      2000,
+					MaxSize:      3000,
+					Sizer:        "items",
+				},
+			},
+		},
+		{
+			testName: "explicit_batch",
+			alloyCfg: `
+			client {
+				endpoint = "tempo:4317"
+			}
+			sending_queue {
+				batch {
+					flush_timeout = "100ms"
+					min_size      = 4096
+					max_size      = 16384
+					sizer         = "bytes"
+				}
+			}
+			`,
+			expected: otelcol.QueueArguments{
+				Enabled:      true,
+				NumConsumers: 10,
+				QueueSize:    1000,
+				Sizer:        "requests",
+				Batch: &otelcol.BatchConfig{
+					FlushTimeout: 100 * time.Millisecond,
+					MinSize:      4096,
+					MaxSize:      16384,
+					Sizer:        "bytes",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			var args otlp.Arguments
+			require.NoError(t, syntax.Unmarshal([]byte(tc.alloyCfg), &args))
+			_, err := args.Convert()
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expected.Enabled, args.Queue.Enabled)
+			require.Equal(t, tc.expected.NumConsumers, args.Queue.NumConsumers)
+			require.Equal(t, tc.expected.QueueSize, args.Queue.QueueSize)
+			require.Equal(t, tc.expected.Sizer, args.Queue.Sizer)
+			require.Equal(t, tc.expected.Batch, args.Queue.Batch)
+		})
+	}
+}
+
 func TestDebugMetricsConfig(t *testing.T) {
 	tests := []struct {
 		testName string


### PR DESCRIPTION
#### PR Description

Similar to #4363, but for the batch block in the exporters. This makes the defaults more friendly to Grafana Cloud. 

#### Which issue(s) this PR fixes

Fixes #4488

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated

BEGIN_COMMIT_OVERRIDE
feat: Change the defaults for `sending_queue` > `batch` block inside `otelcol.exporter` components (#5061)

BREAKING CHANGE: `otelcol.exporter` > `sending_queue` > `batch` > `min_size` changed from `8192` to `2000` and `max_size` changed from `0` to `3000`
END_COMMIT_OVERRIDE