### PR TITLE
Wait for Mimir to be installed in k8s integration test

### DIFF
--- a/internal/cmd/integration-tests-k8s/tests/mimir-alerts-kubernetes/testdata/setup.sh
+++ b/internal/cmd/integration-tests-k8s/tests/mimir-alerts-kubernetes/testdata/setup.sh
@@ -10,4 +10,4 @@ kubectl create namespace mimir-test
 helm repo add grafana https://grafana.github.io/helm-charts
 helm repo update
 # TODO: Upgrade to version 6 of Mimir's Helm chart.
-helm -n mimir-test install mimir grafana/mimir-distributed --version 5.8.0
+helm -n mimir-test install mimir grafana/mimir-distributed --version 5.8.0 --wait


### PR DESCRIPTION
The `helm install` command currently doesn't wait, which sometimes causes the Alertmanager CRDs to fail to install:
```
resource mapping not found for name: "alertmgr-config1" namespace: "testing" from "./testdata/kubernetes.yml": no matches for kind "AlertmanagerConfig" in version "monitoring.coreos.com/v1alpha1"
ensure CRDs are installed first
```

This then results in a failure with the `alertmanager storage object not found` error in the integration test. An example failure is [here](https://github.com/grafana/alloy/actions/runs/20112413059/job/57713020811?pr=5034).