### PR TITLE
database_observability: add metric relabel for azure cloud provider

### DIFF
--- a/internal/component/database_observability/relabeling.go
+++ b/internal/component/database_observability/relabeling.go
@@ -10,23 +10,34 @@ func GetRelabelingRules(serverID string, cp *CloudProvider) []*relabel.Config {
 
 	rs := []*relabel.Config{&r}
 
-	if cp != nil && cp.AWS != nil {
-		providerName := relabel.DefaultRelabelConfig
-		providerName.Replacement = "aws"
-		providerName.TargetLabel = "provider_name"
-		providerName.Action = relabel.Replace
+	if cp != nil {
+		if cp.AWS != nil {
+			providerName := relabel.DefaultRelabelConfig
+			providerName.Replacement = "aws"
+			providerName.TargetLabel = "provider_name"
+			providerName.Action = relabel.Replace
 
-		providerRegion := relabel.DefaultRelabelConfig
-		providerRegion.Replacement = cp.AWS.ARN.Region
-		providerRegion.TargetLabel = "provider_region"
-		providerRegion.Action = relabel.Replace
+			providerRegion := relabel.DefaultRelabelConfig
+			providerRegion.Replacement = cp.AWS.ARN.Region
+			providerRegion.TargetLabel = "provider_region"
+			providerRegion.Action = relabel.Replace
 
-		providerAccount := relabel.DefaultRelabelConfig
-		providerAccount.Replacement = cp.AWS.ARN.AccountID
-		providerAccount.TargetLabel = "provider_account"
-		providerAccount.Action = relabel.Replace
+			providerAccount := relabel.DefaultRelabelConfig
+			providerAccount.Replacement = cp.AWS.ARN.AccountID
+			providerAccount.TargetLabel = "provider_account"
+			providerAccount.Action = relabel.Replace
 
-		rs = append(rs, &providerName, &providerRegion, &providerAccount)
+			rs = append(rs, &providerName, &providerRegion, &providerAccount)
+		}
+		if cp.Azure != nil {
+			// We only support Azure provider_name for now.
+			providerName := relabel.DefaultRelabelConfig
+			providerName.Replacement = "azure"
+			providerName.TargetLabel = "provider_name"
+			providerName.Action = relabel.Replace
+
+			rs = append(rs, &providerName)
+		}
 	}
 
 	return rs

--- a/internal/component/database_observability/relabeling_test.go
+++ b/internal/component/database_observability/relabeling_test.go
@@ -45,4 +45,21 @@ func Test_GetRelabelingRules(t *testing.T) {
 		require.Equal(t, "provider_account", rr[3].TargetLabel)
 		require.Equal(t, relabel.Replace, rr[3].Action)
 	})
+
+	t.Run("return relabeling rules with Azure config", func(t *testing.T) {
+		rr := GetRelabelingRules("some-server-id", &CloudProvider{
+			Azure: &AzureCloudProviderInfo{
+				Resource: "some-resource",
+			},
+		})
+
+		require.Equal(t, 2, len(rr))
+		require.Equal(t, "some-server-id", rr[0].Replacement)
+		require.Equal(t, "server_id", rr[0].TargetLabel)
+		require.Equal(t, relabel.Replace, rr[0].Action)
+
+		require.Equal(t, "azure", rr[1].Replacement)
+		require.Equal(t, "provider_name", rr[1].TargetLabel)
+		require.Equal(t, relabel.Replace, rr[1].Action)
+	})
 }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This adds a relabel rule for Azure cloud_provider information. Currently Azure databases are being sent as `unknown` as we do not have any relabelling rules for them.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
