### PR TITLE
labelstore: Use rwlock

### DIFF
--- a/internal/service/labelstore/service.go
+++ b/internal/service/labelstore/service.go
@@ -19,7 +19,7 @@ const ServiceName = "labelstore"
 
 type Service struct {
 	log                 log.Logger
-	mut                 sync.Mutex
+	mut                 sync.RWMutex
 	globalRefID         uint64
 	mappings            map[string]*remoteWriteMapping
 	labelsHashToGlobal  map[uint64]uint64
@@ -188,8 +188,8 @@ func (s *Service) GetOrAddGlobalRefID(l labels.Labels) uint64 {
 
 // GetLocalRefID returns the local refid for a component global combo, or 0 if not found
 func (s *Service) GetLocalRefID(componentID string, globalRefID uint64) uint64 {
-	s.mut.Lock()
-	defer s.mut.Unlock()
+	s.mut.RLock()
+	defer s.mut.RUnlock()
 
 	m, found := s.mappings[componentID]
 	if !found {


### PR DESCRIPTION
#### PR Description

This PR switches labelstore to use a RWMutex with a RLock for `labelstore.GetLocalLink`. I tried to add some concurrency test to show proof of impact but locally I can't seem to get enough concurrency or this doesn't help so I'll do some testing internally in draft. Full breakdown of rational in Notes to the Reviewer

#### Which issue(s) this PR fixes
Related to: 

#### Notes to the Reviewer

With very high append concurrency we have hit scrape timeouts which correlate with high mutex contention.

<img width="1702" height="973" alt="image (1)" src="https://github.com/user-attachments/assets/aa35d850-99bb-459b-b2e5-37c6d94cb923" />

The mutex contention is largely driven by `labelstore.GetLocalLink` which is called on every single append call. During the time period above that function was responsible for over 50% of our mutex wait,
<img width="1674" height="548" alt="image" src="https://github.com/user-attachments/assets/eca235bf-1d17-42be-8070-2076b0ab0d6b" />

Since it's a pure read operation switching to RWLock with RLock _should_ help. 

#### PR Checklist

- [ ] CHANGELOG.md updated
- [x] Tests updated
