### PR TITLE
feat: provide rendered Alloy built-in dashboards and alerting rules

### DIFF
--- a/.github/workflows/check-alloy-mixin-rendered.yml
+++ b/.github/workflows/check-alloy-mixin-rendered.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   check-rendered:
-    name: Render and verify committed JSON
+    name: Render and verify rendered mixin files
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -25,12 +25,12 @@ jobs:
           cache: true
 
       - name: Render dashboards and alerts
-        run: make alloy-mixin-render
+        run: make generate-rendered-mixin
 
       - name: Verify rendered outputs are up to date
         run: |
           if [ -n "$(git status --porcelain -- operations/alloy-mixin/rendered)" ]; then
-            echo "Error: rendered outputs are not up to date"
+            echo "Error: rendered outputs are not up to date. Make sure to run 'make generate-rendered-mixin' and commit the changes."
             git status -- operations/alloy-mixin/rendered
             git diff -- operations/alloy-mixin/rendered
             exit 1

--- a/.github/workflows/check-alloy-mixin-rendered.yml
+++ b/.github/workflows/check-alloy-mixin-rendered.yml
@@ -1,0 +1,43 @@
+name: Check alloy-mixin rendered outputs
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-rendered:
+    name: Render and verify committed JSON
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Render dashboards and alerts
+        run: make alloy-mixin-render
+
+      - name: Verify rendered outputs are up to date
+        run: |
+          git --no-pager diff -- operations/alloy-mixin/rendered
+          # Also fail if generation produced untracked files (e.g., new dashboards/alerts).
+          untracked="$(git ls-files --others --exclude-standard -- operations/alloy-mixin/rendered)"
+          if [ -n "${untracked}" ]; then
+            echo "${untracked}"
+            echo "${untracked}" | while read -r f; do
+              git --no-pager diff --no-index -- /dev/null "${f}" || true
+            done
+            exit 1
+          fi
+          git diff --exit-code -- operations/alloy-mixin/rendered
+

--- a/.github/workflows/check-alloy-mixin-rendered.yml
+++ b/.github/workflows/check-alloy-mixin-rendered.yml
@@ -29,15 +29,9 @@ jobs:
 
       - name: Verify rendered outputs are up to date
         run: |
-          git --no-pager diff -- operations/alloy-mixin/rendered
-          # Also fail if generation produced untracked files (e.g., new dashboards/alerts).
-          untracked="$(git ls-files --others --exclude-standard -- operations/alloy-mixin/rendered)"
-          if [ -n "${untracked}" ]; then
-            echo "${untracked}"
-            echo "${untracked}" | while read -r f; do
-              git --no-pager diff --no-index -- /dev/null "${f}" || true
-            done
+          if [ -n "$(git status --porcelain -- operations/alloy-mixin/rendered)" ]; then
+            echo "Error: rendered outputs are not up to date"
+            git status -- operations/alloy-mixin/rendered
+            git diff -- operations/alloy-mixin/rendered
             exit 1
           fi
-          git diff --exit-code -- operations/alloy-mixin/rendered
-

--- a/Makefile
+++ b/Makefile
@@ -295,8 +295,8 @@ else
 	go generate ./internal/winmanifest
 endif
 
-.PHONY: alloy-mixin-render
-alloy-mixin-render:
+.PHONY: generate-rendered-mixin
+generate-rendered-mixin:
 ifeq ($(USE_CONTAINER),1)
 	$(RERUN_IN_CONTAINER)
 else

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,8 @@ ALLOY_IMAGE_WINDOWS  ?= grafana/alloy:windowsservercore-ltsc2022
 ALLOY_BINARY         ?= build/alloy
 SERVICE_BINARY       ?= build/alloy-service
 ALLOYLINT_BINARY     ?= build/alloylint
+JSONNET              ?= go run github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0
+JB                   ?= go run github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.6.0
 GOOS                 ?= $(shell go env GOOS)
 GOARCH               ?= $(shell go env GOARCH)
 GOARM                ?= $(shell go env GOARM)
@@ -291,6 +293,18 @@ ifeq ($(USE_CONTAINER),1)
 	$(RERUN_IN_CONTAINER)
 else
 	go generate ./internal/winmanifest
+endif
+
+.PHONY: alloy-mixin-render
+alloy-mixin-render:
+ifeq ($(USE_CONTAINER),1)
+	$(RERUN_IN_CONTAINER)
+else
+	rm -rf operations/alloy-mixin/rendered/alerts operations/alloy-mixin/rendered/dashboards
+	mkdir -p operations/alloy-mixin/rendered/alerts operations/alloy-mixin/rendered/dashboards
+	cd operations/alloy-mixin && $(JB) install
+	$(JSONNET) -J operations/alloy-mixin -J operations/alloy-mixin/vendor -m operations/alloy-mixin/rendered/dashboards -e 'local mixin = import "mixin.libsonnet"; mixin.grafanaDashboards'
+	$(JSONNET) -J operations/alloy-mixin -J operations/alloy-mixin/vendor -m operations/alloy-mixin/rendered/alerts -e 'local mixin = import "mixin.libsonnet"; { [g.name + ".json"]: { groups: [g] } for g in mixin.prometheusAlerts.groups }'
 endif
 
 generate-snmp:

--- a/example/docker-compose/compose.yaml
+++ b/example/docker-compose/compose.yaml
@@ -6,7 +6,7 @@ include:
 
 services:
   alloy:
-    image: grafana/alloy:v1.5.1
+    image: grafana/alloy:latest
     pull_policy: always
     profiles: ["alloy"]
     restart: on-failure

--- a/example/docker-compose/grafana.yaml
+++ b/example/docker-compose/grafana.yaml
@@ -1,6 +1,6 @@
 services:
   grafana:
-    image: grafana/grafana:11.5.1
+    image: grafana/grafana:12.3.0
     restart: on-failure
     command:
       - --config=/etc/grafana-config/grafana.ini

--- a/operations/alloy-mixin/README.md
+++ b/operations/alloy-mixin/README.md
@@ -1,0 +1,70 @@
+# Alloy jsonnet mixin (dashboards + alerts)
+
+This directory contains an Alloy jsonnet mixin that can be rendered into:
+
+- Grafana dashboard JSON files (one file per dashboard).
+- Prometheus alert rule JSON files (one file per rule *group*, i.e. “alert family”).
+
+The rendered outputs are committed under `operations/alloy-mixin/rendered/` and verified in CI to stay up to date.
+
+## Rendering
+
+From the repository root:
+
+```bash
+make alloy-mixin-render
+```
+
+Outputs are written to:
+
+- `operations/alloy-mixin/rendered/dashboards/*.json`
+- `operations/alloy-mixin/rendered/alerts/*.json`
+
+## Importing dashboards into Grafana
+
+### Manual import (Grafana UI)
+
+1. Open Grafana.
+2. Go to **Dashboards** → **New** → **Import**.
+3. Upload or paste the contents of a file from `rendered/dashboards/*.json`.
+4. Select the target folder (or create one) and complete the import.
+
+Grafana docs: `https://grafana.com/docs/grafana/latest/dashboards/manage-dashboards/#import-a-dashboard`
+
+### Provisioning (recommended for environments)
+
+You can provision these dashboards by placing the JSON files on disk and configuring Grafana dashboard provisioning to load them from a directory.
+
+Grafana provisioning docs: `https://grafana.com/docs/grafana/latest/administration/provisioning/#dashboards`
+
+## Using the rendered alert rules
+
+The files under `rendered/alerts/*.json` are Prometheus rule group JSON (each file contains a single entry in a top-level `groups` array). How you load them depends on your alerting backend:
+
+- Prometheus “rule_files”
+- Prometheus Operator / `PrometheusRule` CRD (convert JSON → YAML if needed)
+- Grafana Mimir ruler / compatible rule loaders
+
+Prometheus rule format docs: `https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/`
+
+## Customizing via `config.libsonnet`
+
+`config.libsonnet` controls mixin rendering options and is merged into the mixin’s `$._config`. Some commonly used toggles:
+
+- `enableK8sCluster`: whether to include `cluster`/`namespace` label dimensions in queries and templates.
+- `enableAlloyCluster`: whether to include clustering dashboards/alerts.
+- `enableLokiLogs`: whether to include the logs overview dashboard.
+- `filterSelector` / `logsFilterSelector`: add selectors to narrow metrics/logs to a specific Alloy installation.
+- `dashboardTag`: change the dashboard tag used for cross-dashboard links.
+
+After changing `config.libsonnet`, re-render and commit updates:
+
+```bash
+make alloy-mixin-render
+```
+
+## TODO
+
+- Publish a release archive artifact containing the rendered dashboards and alerts.
+- Publish these dashboards to grafana.com so they can be imported by ID.
+

--- a/operations/alloy-mixin/dashboards/alloy-logs.libsonnet
+++ b/operations/alloy-mixin/dashboards/alloy-logs.libsonnet
@@ -1,4 +1,4 @@
-local g = import 'github.com/grafana/grafonnet/gen/grafonnet-v10.0.0/main.libsonnet';
+local g = import 'github.com/grafana/grafonnet/gen/grafonnet-v11.0.0/main.libsonnet';
 local logsDashboard = import 'github.com/grafana/jsonnet-libs/logs-lib/logs/main.libsonnet';
 
 {

--- a/operations/alloy-mixin/dashboards/alloy-logs.libsonnet
+++ b/operations/alloy-mixin/dashboards/alloy-logs.libsonnet
@@ -1,4 +1,4 @@
-local g = import 'github.com/grafana/grafonnet/gen/grafonnet-v11.0.0/main.libsonnet';
+local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
 local logsDashboard = import 'github.com/grafana/jsonnet-libs/logs-lib/logs/main.libsonnet';
 
 {

--- a/operations/alloy-mixin/jsonnetfile.json
+++ b/operations/alloy-mixin/jsonnetfile.json
@@ -5,7 +5,7 @@
       "source": {
         "git": {
           "remote": "https://github.com/grafana/grafonnet.git",
-          "subdir": "gen/grafonnet-v10.0.0"
+          "subdir": "gen/grafonnet-v11.0.0"
         }
       },
       "version": "main"

--- a/operations/alloy-mixin/jsonnetfile.json
+++ b/operations/alloy-mixin/jsonnetfile.json
@@ -17,7 +17,7 @@
           "subdir": "logs-lib/"
         }
       },
-      "version": "thampiotr/fix-logs-query"
+      "version": "master"
     },
     {
       "source": {
@@ -26,7 +26,7 @@
           "subdir": "logs-lib/logs"
         }
       },
-      "version": "thampiotr/fix-logs-query"
+      "version": "master"
     }
   ],
   "legacyImports": true

--- a/operations/alloy-mixin/jsonnetfile.json
+++ b/operations/alloy-mixin/jsonnetfile.json
@@ -5,7 +5,7 @@
       "source": {
         "git": {
           "remote": "https://github.com/grafana/grafonnet.git",
-          "subdir": "gen/grafonnet-v11.0.0"
+          "subdir": "gen/grafonnet-latest"
         }
       },
       "version": "main"
@@ -17,7 +17,7 @@
           "subdir": "logs-lib/"
         }
       },
-      "version": "master"
+      "version": "thampiotr/fix-logs-query"
     },
     {
       "source": {
@@ -26,7 +26,7 @@
           "subdir": "logs-lib/logs"
         }
       },
-      "version": "master"
+      "version": "thampiotr/fix-logs-query"
     }
   ],
   "legacyImports": true

--- a/operations/alloy-mixin/jsonnetfile.lock.json
+++ b/operations/alloy-mixin/jsonnetfile.lock.json
@@ -38,8 +38,8 @@
           "subdir": "logs-lib/"
         }
       },
-      "version": "197b6dd19f98427171a04ac37d731c15f3b98e97",
-      "sum": "HafaJd9zWVvyiWQbpae7d3eWJjRdllPmrCuzNVdDdyM="
+      "version": "7c3d9f07f8c365c99fbbe1d763edcd83824cd4dd",
+      "sum": "rgzaIMC4Gujx86mPdsVfQnzSfxzfuCg/sZPrDJBV3bU="
     },
     {
       "source": {
@@ -48,8 +48,8 @@
           "subdir": "logs-lib/logs"
         }
       },
-      "version": "197b6dd19f98427171a04ac37d731c15f3b98e97",
-      "sum": "i5hKx0xWyJsDjcQAztuMpntqspU/Cvk+IT1HRKwjhkY="
+      "version": "7c3d9f07f8c365c99fbbe1d763edcd83824cd4dd",
+      "sum": "GkY3L75913fiYk9+Rq/R1JEaHEwkFrtvufIWhJZ6MP8="
     },
     {
       "source": {

--- a/operations/alloy-mixin/jsonnetfile.lock.json
+++ b/operations/alloy-mixin/jsonnetfile.lock.json
@@ -5,6 +5,16 @@
       "source": {
         "git": {
           "remote": "https://github.com/grafana/grafonnet.git",
+          "subdir": "gen/grafonnet-latest"
+        }
+      },
+      "version": "7380c9c64fb973f34c3ec46265621a2b0dee0058",
+      "sum": "V9vAj21qJOc2DlMPDgB1eEjSQU4A+sAA4AXuJ6bd4xc="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet.git",
           "subdir": "gen/grafonnet-v11.0.0"
         }
       },
@@ -14,12 +24,22 @@
     {
       "source": {
         "git": {
+          "remote": "https://github.com/grafana/grafonnet.git",
+          "subdir": "gen/grafonnet-v11.4.0"
+        }
+      },
+      "version": "7380c9c64fb973f34c3ec46265621a2b0dee0058",
+      "sum": "aVAX09paQYNOoCSKVpuk1exVIyBoMt/C50QJI+Q/3nA="
+    },
+    {
+      "source": {
+        "git": {
           "remote": "https://github.com/grafana/jsonnet-libs.git",
           "subdir": "logs-lib/"
         }
       },
-      "version": "968130109ee8ccdb473ecc99ff8b996ac0feb9f5",
-      "sum": "0xwYsW92n4rE9PfO3drN4Ko9VeQBoV/IZ7nvgrnYaWk="
+      "version": "197b6dd19f98427171a04ac37d731c15f3b98e97",
+      "sum": "HafaJd9zWVvyiWQbpae7d3eWJjRdllPmrCuzNVdDdyM="
     },
     {
       "source": {
@@ -28,8 +48,8 @@
           "subdir": "logs-lib/logs"
         }
       },
-      "version": "968130109ee8ccdb473ecc99ff8b996ac0feb9f5",
-      "sum": "PX1ePJnTxPi4x2bmrbrbC6IPxjOX4p0Fv+H8JOiod5g="
+      "version": "197b6dd19f98427171a04ac37d731c15f3b98e97",
+      "sum": "i5hKx0xWyJsDjcQAztuMpntqspU/Cvk+IT1HRKwjhkY="
     },
     {
       "source": {

--- a/operations/alloy-mixin/jsonnetfile.lock.json
+++ b/operations/alloy-mixin/jsonnetfile.lock.json
@@ -5,11 +5,11 @@
       "source": {
         "git": {
           "remote": "https://github.com/grafana/grafonnet.git",
-          "subdir": "gen/grafonnet-v10.0.0"
+          "subdir": "gen/grafonnet-v11.0.0"
         }
       },
-      "version": "1c56af39815c4903e47c27194444456f005f65df",
-      "sum": "xdcrJPJlpkq4+5LpGwN4tPAuheNNLXZjE6tDcyvFjr0="
+      "version": "7380c9c64fb973f34c3ec46265621a2b0dee0058",
+      "sum": "0BvzR0i4bS4hc2O3xDv6i9m52z7mPrjvqxtcPrGhynA="
     },
     {
       "source": {
@@ -18,8 +18,8 @@
           "subdir": "logs-lib/"
         }
       },
-      "version": "21526e83f442793d5a0c5969867d123915422b79",
-      "sum": "IkBo9nj0Qt1eC9w80dO5SI4yvHzmmXcKx5BK8H8U0Mk="
+      "version": "968130109ee8ccdb473ecc99ff8b996ac0feb9f5",
+      "sum": "0xwYsW92n4rE9PfO3drN4Ko9VeQBoV/IZ7nvgrnYaWk="
     },
     {
       "source": {
@@ -28,8 +28,8 @@
           "subdir": "logs-lib/logs"
         }
       },
-      "version": "21526e83f442793d5a0c5969867d123915422b79",
-      "sum": "CemcPbsPzyRUchDLH1TKTxWWgBlg1MRT0jH2X172z6w="
+      "version": "968130109ee8ccdb473ecc99ff8b996ac0feb9f5",
+      "sum": "PX1ePJnTxPi4x2bmrbrbC6IPxjOX4p0Fv+H8JOiod5g="
     },
     {
       "source": {
@@ -48,8 +48,8 @@
           "subdir": ""
         }
       },
-      "version": "63d430b69a95741061c2f7fc9d84b1a778511d9c",
-      "sum": "qiZi3axUSXCVzKUF83zSAxklwrnitMmrDK4XAfjPMdE="
+      "version": "4d7f8cb24d613430799f9d56809cc6964f35cea9",
+      "sum": "hOrwkOx34tOXqoDVnwuI/Uf/dr9HFFSPWpDPOvnEGrk="
     }
   ],
   "legacyImports": false

--- a/operations/alloy-mixin/rendered/alerts/alloy_clustering.json
+++ b/operations/alloy-mixin/rendered/alerts/alloy_clustering.json
@@ -1,0 +1,81 @@
+{
+   "groups": [
+      {
+         "name": "alloy_clustering",
+         "rules": [
+            {
+               "alert": "ClusterNotConverging",
+               "annotations": {
+                  "description": "Cluster is not converging: nodes report different number of peers in the cluster. Job is {{ $labels.job }}",
+                  "summary": "Cluster is not converging."
+               },
+               "expr": "stddev by (cluster, namespace, job, cluster_name) (sum without (state) (cluster_node_peers)) != 0",
+               "for": "10m",
+               "labels": {
+                  "severity": "warning"
+               }
+            },
+            {
+               "alert": "ClusterNodeCountMismatch",
+               "annotations": {
+                  "description": "Nodes report different number of peers vs. the count of observed Alloy metrics. Some Alloy metrics may be missing or the cluster is in a split brain state. Job is {{ $labels.job }}",
+                  "summary": "Nodes report different number of peers vs. the count of observed Alloy metrics."
+               },
+               "expr": "sum without (state) (cluster_node_peers) !=\non (cluster, namespace, job, cluster_name) group_left\ncount by (cluster, namespace, job, cluster_name) (cluster_node_info)\n",
+               "for": "15m",
+               "labels": {
+                  "severity": "warning"
+               }
+            },
+            {
+               "alert": "ClusterNodeUnhealthy",
+               "annotations": {
+                  "description": "Cluster node is reporting a gossip protocol health score > 0. Job is {{ $labels.job }}",
+                  "summary": "Cluster unhealthy."
+               },
+               "expr": "cluster_node_gossip_health_score > 0\n",
+               "for": "10m",
+               "labels": {
+                  "severity": "warning"
+               }
+            },
+            {
+               "alert": "ClusterNodeNameConflict",
+               "annotations": {
+                  "description": "A node tried to join the cluster with a name conflicting with an existing peer. Job is {{ $labels.job }}",
+                  "summary": "Cluster Node Name Conflict."
+               },
+               "expr": "sum by (cluster, namespace, job, cluster_name) (rate(cluster_node_gossip_received_events_total{event=\"node_conflict\"}[2m])) > 0",
+               "for": "10m",
+               "labels": {
+                  "severity": "warning"
+               }
+            },
+            {
+               "alert": "ClusterNodeStuckTerminating",
+               "annotations": {
+                  "description": "There is a node within the cluster that is stuck in Terminating state. Job is {{ $labels.job }}",
+                  "summary": "Cluster node stuck in Terminating state."
+               },
+               "expr": "sum by (cluster, namespace, job, instance, cluster_name) (cluster_node_peers{state=\"terminating\"}) > 0",
+               "for": "10m",
+               "labels": {
+                  "severity": "warning"
+               }
+            },
+            {
+               "alert": "ClusterConfigurationDrift",
+               "annotations": {
+                  "description": "Cluster nodes are not using the same configuration file. Job is {{ $labels.job }}",
+                  "summary": "Cluster configuration drifting."
+               },
+               "expr": "count without (sha256) (\n    max by (cluster, namespace, sha256, job, cluster_name) (alloy_config_hash and on(cluster, namespace, job, cluster_name) cluster_node_info)\n) > 1\n",
+               "for": "5m",
+               "labels": {
+                  "severity": "warning"
+               }
+            }
+         ]
+      }
+   ]
+}

--- a/operations/alloy-mixin/rendered/alerts/alloy_controller.json
+++ b/operations/alloy-mixin/rendered/alerts/alloy_controller.json
@@ -1,0 +1,33 @@
+{
+   "groups": [
+      {
+         "name": "alloy_controller",
+         "rules": [
+            {
+               "alert": "SlowComponentEvaluations",
+               "annotations": {
+                  "description": "Component evaluations are taking too long under job {{ $labels.job }}, component_path {{ $labels.component_path }}, component_id {{ $labels.component_id }}.",
+                  "summary": "Component evaluations are taking too long."
+               },
+               "expr": "sum by (cluster, namespace, job, component_path, component_id) (rate(alloy_component_evaluation_slow_seconds[10m])) > 0",
+               "for": "15m",
+               "labels": {
+                  "severity": "warning"
+               }
+            },
+            {
+               "alert": "UnhealthyComponents",
+               "annotations": {
+                  "description": "Unhealthy components detected under job {{ $labels.job }}",
+                  "summary": "Unhealthy components detected."
+               },
+               "expr": "sum by (cluster, namespace, job) (alloy_component_controller_running_components{health_type!=\"healthy\"}) > 0",
+               "for": "15m",
+               "labels": {
+                  "severity": "warning"
+               }
+            }
+         ]
+      }
+   ]
+}

--- a/operations/alloy-mixin/rendered/alerts/alloy_otelcol.json
+++ b/operations/alloy-mixin/rendered/alerts/alloy_otelcol.json
@@ -1,0 +1,81 @@
+{
+   "groups": [
+      {
+         "name": "alloy_otelcol",
+         "rules": [
+            {
+               "alert": "OtelcolReceiverRefusedSpans",
+               "annotations": {
+                  "description": "The receiver could not push some spans to the pipeline under job {{ $labels.job }}. This could be due to reaching a limit such as the ones imposed by otelcol.processor.memory_limiter.",
+                  "summary": "The receiver pushing spans to the pipeline success rate is below 95%."
+               },
+               "expr": "(1 - (\n        sum by (cluster, namespace, job) (rate(otelcol_receiver_refused_spans_total{}[1m]))\n        /\n        sum by (cluster, namespace, job) (rate(otelcol_receiver_refused_spans_total{}[1m]) + rate(otelcol_receiver_accepted_spans_total{}[1m]))\n     )\n) < 0.95\n",
+               "for": "10m",
+               "labels": {
+                  "severity": "warning"
+               }
+            },
+            {
+               "alert": "OtelcolReceiverRefusedMetrics",
+               "annotations": {
+                  "description": "The receiver could not push some metric points to the pipeline under job {{ $labels.job }}. This could be due to reaching a limit such as the ones imposed by otelcol.processor.memory_limiter.",
+                  "summary": "The receiver pushing metrics to the pipeline success rate is below 95%."
+               },
+               "expr": "(1 - (\n        sum by (cluster, namespace, job) (rate(otelcol_receiver_refused_metric_points_total{}[1m]))\n        /\n        sum by (cluster, namespace, job) (rate(otelcol_receiver_refused_metric_points_total{}[1m]) + rate(otelcol_receiver_accepted_metric_points_total{}[1m]))\n     )\n) < 0.95\n",
+               "for": "10m",
+               "labels": {
+                  "severity": "warning"
+               }
+            },
+            {
+               "alert": "OtelcolReceiverRefusedLogs",
+               "annotations": {
+                  "description": "The receiver could not push some log records to the pipeline under job {{ $labels.job }}. This could be due to reaching a limit such as the ones imposed by otelcol.processor.memory_limiter.",
+                  "summary": "The receiver pushing logs to the pipeline success rate is below 95%."
+               },
+               "expr": "(1 - (\n        sum by (cluster, namespace, job) (rate(otelcol_receiver_refused_log_records_total{}[1m]))\n        /\n        sum by (cluster, namespace, job) (rate(otelcol_receiver_refused_log_records_total{}[1m]) + rate(otelcol_receiver_accepted_log_records_total{}[1m]))\n     )\n) < 0.95\n",
+               "for": "10m",
+               "labels": {
+                  "severity": "warning"
+               }
+            },
+            {
+               "alert": "OtelcolExporterFailedSpans",
+               "annotations": {
+                  "description": "The exporter failed to send spans to their destination under job {{ $labels.job }}. There could be an issue with the payload or with the destination endpoint.",
+                  "summary": "The exporter sending spans success rate is below 95%."
+               },
+               "expr": "(1 - (\n        sum by (cluster, namespace, job) (rate(otelcol_exporter_send_failed_spans_total{}[1m]))\n        /\n        sum by (cluster, namespace, job) (rate(otelcol_exporter_send_failed_spans_total{}[1m]) + rate(otelcol_exporter_sent_spans_total{}[1m]))\n     )\n) < 0.95\n",
+               "for": "10m",
+               "labels": {
+                  "severity": "warning"
+               }
+            },
+            {
+               "alert": "OtelcolExporterFailedMetrics",
+               "annotations": {
+                  "description": "The exporter failed to send metric points to their destination under job {{ $labels.job }}. There could be an issue with the payload or with the destination endpoint.",
+                  "summary": "The exporter sending metrics success rate is below 95%."
+               },
+               "expr": "(1 - (\n        sum by (cluster, namespace, job) (rate(otelcol_exporter_send_failed_metric_points_total{}[1m]))\n        /\n        sum by (cluster, namespace, job) (rate(otelcol_exporter_send_failed_metric_points_total{}[1m]) + rate(otelcol_exporter_sent_metric_points_total{}[1m]))\n     )\n) < 0.95\n",
+               "for": "10m",
+               "labels": {
+                  "severity": "warning"
+               }
+            },
+            {
+               "alert": "OtelcolExporterFailedLogs",
+               "annotations": {
+                  "description": "The exporter failed to send log records to their destination under job {{ $labels.job }}. There could be an issue with the payload or with the destination endpoint.",
+                  "summary": "The exporter sending logs success rate is below 95%."
+               },
+               "expr": "(1 - (\n        sum by (cluster, namespace, job) (rate(otelcol_exporter_send_failed_log_records_total{}[1m]))\n        /\n        sum by (cluster, namespace, job) (rate(otelcol_exporter_send_failed_log_records_total{}[1m]) + rate(otelcol_exporter_sent_log_records_total{}[1m]))\n     )\n) < 0.95\n",
+               "for": "10m",
+               "labels": {
+                  "severity": "warning"
+               }
+            }
+         ]
+      }
+   ]
+}

--- a/operations/alloy-mixin/rendered/dashboards/alloy-cluster-node.json
+++ b/operations/alloy-mixin/rendered/dashboards/alloy-cluster-node.json
@@ -1,0 +1,505 @@
+{
+   "annotations": {
+      "list": [
+         {
+            "datasource": "$loki_datasource",
+            "enable": true,
+            "expr": "{cluster=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "instant": false,
+            "name": "Deployments",
+            "titleFormat": "{{cluster}}/{{namespace}}"
+         }
+      ]
+   },
+   "graphTooltip": 1,
+   "links": [
+      {
+         "icon": "doc",
+         "targetBlank": true,
+         "title": "Documentation",
+         "tooltip": "Clustering documentation",
+         "type": "link",
+         "url": "https://grafana.com/docs/alloy/latest/reference/cli/run/#clustering"
+      },
+      {
+         "asDropdown": true,
+         "icon": "external link",
+         "includeVars": true,
+         "keepTime": true,
+         "tags": [
+            "alloy-mixin"
+         ],
+         "targetBlank": false,
+         "title": "Dashboards",
+         "type": "dashboards"
+      }
+   ],
+   "panels": [
+      {
+         "datasource": "${datasource}",
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+         },
+         "title": "Node Info",
+         "type": "row"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Information about a specific cluster node.\n\n* Lamport clock time: The observed Lamport time on the specific node's clock used to provide partial ordering around gossip messages. Nodes should ideally be observing roughly the same time, meaning they are up-to-date on the cluster state. If a node is falling behind, it means that it has not recently processed the same number of messages and may have an outdated view of its peers.\n\n* Internal cluster state observers: The number of Observer functions that are registered to run whenever the node detects a cluster change.\n\n* Gossip health score: A health score assigned to this node by the memberlist implementation. The lower, the better.\n\n* Gossip protocol version: The protocol version used by nodes to communicate with one another. It should match across all nodes.\n",
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 1
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum(cluster_node_lamport_time{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}) \n",
+               "format": "table",
+               "instant": true,
+               "legendFormat": "__auto",
+               "range": false,
+               "refId": "Lamport clock time"
+            },
+            {
+               "datasource": "${datasource}",
+               "expr": "sum(cluster_node_update_observers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"})\n",
+               "format": "table",
+               "instant": true,
+               "legendFormat": "__auto",
+               "range": false,
+               "refId": "Internal cluster state observers"
+            },
+            {
+               "datasource": "${datasource}",
+               "expr": "sum(cluster_node_gossip_health_score{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"})\n",
+               "format": "table",
+               "instant": true,
+               "legendFormat": "__auto",
+               "range": false,
+               "refId": "Gossip health score"
+            },
+            {
+               "datasource": "${datasource}",
+               "expr": "sum(cluster_node_gossip_proto_version{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"})\n",
+               "format": "table",
+               "instant": true,
+               "legendFormat": "__auto",
+               "range": false,
+               "refId": "Gossip protocol version"
+            }
+         ],
+         "title": "Node Info",
+         "transformations": [
+            {
+               "id": "renameByRegex",
+               "options": {
+                  "regex": "Value #(.*)",
+                  "renamePattern": "$1"
+               }
+            },
+            {
+               "id": "reduce",
+               "options": { }
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": { },
+                  "indexByName": { },
+                  "renameByName": {
+                     "Field": "Metric",
+                     "Max": "Value"
+                  }
+               }
+            }
+         ],
+         "type": "table"
+      },
+      {
+         "datasource": "${datasource}",
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 1
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "rate(cluster_node_gossip_received_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+               "instant": false,
+               "legendFormat": "{{event}}",
+               "range": true
+            }
+         ],
+         "title": "Gossip ops/s",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Known peers to the node (including the local node).\n",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "suffix:peers"
+            }
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 9
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum(cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"})\n",
+               "instant": false,
+               "legendFormat": "__auto",
+               "range": true
+            }
+         ],
+         "title": "Known peers",
+         "type": "stat"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Known peers to the node by state (including the local node).\n",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "suffix:nodes"
+            }
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 9
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+               "instant": false,
+               "legendFormat": "{{state}}",
+               "range": true
+            }
+         ],
+         "title": "Peers by state",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 17
+         },
+         "title": "Gossip Transport",
+         "type": "row"
+      },
+      {
+         "datasource": "${datasource}",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "axisCenteredZero": true
+               },
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 18
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "rate(cluster_transport_rx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+               "instant": false,
+               "legendFormat": "rx",
+               "range": true
+            },
+            {
+               "datasource": "${datasource}",
+               "expr": "-1 * rate(cluster_transport_tx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+               "instant": false,
+               "legendFormat": "tx",
+               "range": true
+            }
+         ],
+         "title": "Transport bandwidth",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "percentunit"
+            }
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 18
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "1 - (\n  rate(cluster_transport_tx_packets_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) /\n  rate(cluster_transport_tx_packets_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n)\n",
+               "instant": false,
+               "legendFormat": "Tx success %",
+               "range": true
+            },
+            {
+               "datasource": "${datasource}",
+               "expr": "1 - (\n  rate(cluster_transport_rx_packets_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) /\n  rate(cluster_transport_rx_packets_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n)\n",
+               "instant": false,
+               "legendFormat": "Rx success %",
+               "range": true
+            }
+         ],
+         "title": "Packet write success rate",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "The number of packets enqueued currently to be decoded or encoded and sent during communication with other nodes.\n\nThe incoming and outgoing packet queue should be as empty as possible; a growing queue means that Alloy cannot keep up with the number of messages required to have all nodes informed of cluster changes, and the nodes may not converge in a timely fashion.\n",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "pkts"
+            }
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 18
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "cluster_transport_tx_packet_queue_length{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+               "instant": false,
+               "legendFormat": "tx queue",
+               "range": true
+            },
+            {
+               "datasource": "${datasource}",
+               "expr": "cluster_transport_rx_packet_queue_length{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+               "instant": false,
+               "legendFormat": "rx queue",
+               "range": true
+            }
+         ],
+         "title": "Pending packet queue",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "axisCenteredZero": true
+               },
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 26
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "rate(cluster_transport_stream_rx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+               "instant": false,
+               "legendFormat": "rx",
+               "range": true
+            },
+            {
+               "datasource": "${datasource}",
+               "expr": "-1 * rate(cluster_transport_stream_tx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+               "instant": false,
+               "legendFormat": "tx",
+               "range": true
+            }
+         ],
+         "title": "Stream bandwidth",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "percentunit"
+            }
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 26
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "1 - (\n  rate(cluster_transport_stream_tx_packets_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) /\n  rate(cluster_transport_stream_tx_packets_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n)\n",
+               "instant": false,
+               "legendFormat": "Tx success %",
+               "range": true
+            },
+            {
+               "datasource": "${datasource}",
+               "expr": "1 - (\n  rate(cluster_transport_stream_rx_packets_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) /\n  rate(cluster_transport_stream_rx_packets_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n)\n",
+               "instant": false,
+               "legendFormat": "Rx success %",
+               "range": true
+            }
+         ],
+         "title": "Stream write success rate",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "The number of open connections from this node to its peers.\n\nEach node picks up a subset of its peers to continuously gossip messages around cluster status using streaming HTTP/2 connections. This panel can be used to detect networking failures that result in cluster communication being disrupted and convergence taking longer than expected or outright failing.\n",
+         "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 26
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "cluster_transport_streams{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+               "instant": false,
+               "legendFormat": "Open streams",
+               "range": true
+            }
+         ],
+         "title": "Open transport streams",
+         "type": "timeseries"
+      }
+   ],
+   "refresh": "10s",
+   "schemaVersion": 36,
+   "tags": [
+      "alloy-mixin"
+   ],
+   "templating": {
+      "list": [
+         {
+            "label": "Data Source",
+            "name": "datasource",
+            "query": "prometheus",
+            "refresh": 1,
+            "sort": 2,
+            "type": "datasource"
+         },
+         {
+            "label": "Loki Data Source",
+            "name": "loki_datasource",
+            "query": "loki",
+            "refresh": 1,
+            "sort": 2,
+            "type": "datasource"
+         },
+         {
+            "datasource": "${datasource}",
+            "label": "cluster",
+            "name": "cluster",
+            "query": {
+               "query": "label_values(alloy_component_controller_running_components, cluster)\n",
+               "refId": "cluster"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         },
+         {
+            "datasource": "${datasource}",
+            "label": "namespace",
+            "name": "namespace",
+            "query": {
+               "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
+               "refId": "namespace"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         },
+         {
+            "datasource": "${datasource}",
+            "label": "job",
+            "name": "job",
+            "query": {
+               "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
+               "refId": "job"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         },
+         {
+            "allValue": ".*",
+            "datasource": "${datasource}",
+            "includeAll": true,
+            "label": "instance",
+            "multi": true,
+            "name": "instance",
+            "query": {
+               "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}, instance)\n",
+               "refId": "instance"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         }
+      ]
+   },
+   "time": {
+      "from": "now-1h",
+      "to": "now"
+   },
+   "timepicker": {
+      "refresh_intervals": [
+         "5s",
+         "10s",
+         "30s",
+         "1m",
+         "5m",
+         "15m",
+         "30m",
+         "1h",
+         "2h",
+         "1d"
+      ],
+      "time_options": [
+         "5m",
+         "15m",
+         "1h",
+         "6h",
+         "12h",
+         "24h",
+         "2d",
+         "7d",
+         "30d",
+         "90d"
+      ]
+   },
+   "timezone": "utc",
+   "title": "Alloy / Cluster Node",
+   "uid": "4047e755d822da63c8158cde32ae4dce"
+}

--- a/operations/alloy-mixin/rendered/dashboards/alloy-cluster-overview.json
+++ b/operations/alloy-mixin/rendered/dashboards/alloy-cluster-overview.json
@@ -1,0 +1,421 @@
+{
+   "annotations": {
+      "list": [
+         {
+            "datasource": "$loki_datasource",
+            "enable": true,
+            "expr": "{cluster=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "instant": false,
+            "name": "Deployments",
+            "titleFormat": "{{cluster}}/{{namespace}}"
+         }
+      ]
+   },
+   "graphTooltip": 1,
+   "links": [
+      {
+         "icon": "doc",
+         "targetBlank": true,
+         "title": "Documentation",
+         "tooltip": "Clustering documentation",
+         "type": "link",
+         "url": "https://grafana.com/docs/alloy/latest/reference/cli/run/#clustering"
+      },
+      {
+         "asDropdown": true,
+         "icon": "external link",
+         "includeVars": true,
+         "keepTime": true,
+         "tags": [
+            "alloy-mixin"
+         ],
+         "targetBlank": false,
+         "title": "Dashboards",
+         "type": "dashboards"
+      }
+   ],
+   "panels": [
+      {
+         "datasource": "${datasource}",
+         "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 0
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "count(cluster_node_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})\n",
+               "instant": true,
+               "legendFormat": "__auto",
+               "range": false
+            }
+         ],
+         "title": "Nodes",
+         "type": "stat"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Nodes info.\n",
+         "fieldConfig": {
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Dashboard"
+                  },
+                  "properties": [
+                     {
+                        "id": "mappings",
+                        "value": [
+                           {
+                              "options": {
+                                 "1": {
+                                    "index": 0,
+                                    "text": "Link"
+                                 }
+                              },
+                              "type": "value"
+                           }
+                        ]
+                     },
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "targetBlank": false,
+                              "title": "Detail dashboard for node",
+                              "url": "/d/4047e755d822da63c8158cde32ae4dce/alloy-cluster-node?var-instance=${__data.fields.instance}&var-datasource=${datasource}&var-loki_datasource=${loki_datasource}&var-job=${job}&var-cluster=${cluster}&var-namespace=${namespace}"
+                           }
+                        ]
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 9,
+            "w": 16,
+            "x": 8,
+            "y": 0
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "cluster_node_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}\n",
+               "format": "table",
+               "instant": true,
+               "legendFormat": "__auto",
+               "range": false
+            }
+         ],
+         "title": "Node table",
+         "transformations": [
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Value": false,
+                     "__name__": true,
+                     "cluster": true,
+                     "namespace": true,
+                     "state": false
+                  },
+                  "indexByName": { },
+                  "renameByName": {
+                     "Value": "Dashboard",
+                     "instance": "",
+                     "state": ""
+                  }
+               }
+            }
+         ],
+         "type": "table"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Whether the cluster state has converged.\n\nIt is normal for the cluster state to be diverged briefly as gossip events propagate. It is not normal for the cluster state to be diverged for a long period of time.\n\nThis will show one of the following:\n\n* Converged: Nodes are aware of all other nodes, with the correct states.\n* Not converged: A subset of nodes aren't aware of their peers, or don't have an updated view of peer states.\n",
+         "fieldConfig": {
+            "defaults": {
+               "mappings": [
+                  {
+                     "options": {
+                        "1": {
+                           "color": "red",
+                           "index": 1,
+                           "text": "Not converged"
+                        }
+                     },
+                     "type": "value"
+                  },
+                  {
+                     "options": {
+                        "match": "null",
+                        "result": {
+                           "color": "green",
+                           "index": 0,
+                           "text": "Converged"
+                        }
+                     },
+                     "type": "special"
+                  }
+               ],
+               "unit": "suffix:nodes"
+            }
+         },
+         "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 9
+         },
+         "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "fields": "",
+               "values": false
+            },
+            "textMode": "auto"
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "clamp((\n  sum(stddev by (state) (cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}) != 0) or\n  (sum(abs(sum without (state) (cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})) - scalar(count(cluster_node_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})) != 0))\n  ),\n  1, 1\n)\n",
+               "format": "time_series",
+               "instant": true,
+               "legendFormat": "__auto",
+               "range": false
+            }
+         ],
+         "title": "Convergance state",
+         "type": "stat"
+      },
+      {
+         "datasource": "${datasource}",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 80,
+                  "spanNulls": true
+               },
+               "mappings": [
+                  {
+                     "options": {
+                        "0": {
+                           "color": "green",
+                           "text": "Yes"
+                        }
+                     },
+                     "type": "value"
+                  },
+                  {
+                     "options": {
+                        "1": {
+                           "color": "red",
+                           "text": "No"
+                        }
+                     },
+                     "type": "value"
+                  }
+               ],
+               "max": 1,
+               "noValue": 0
+            }
+         },
+         "gridPos": {
+            "h": 9,
+            "w": 16,
+            "x": 8,
+            "y": 9
+         },
+         "options": {
+            "mergeValues": true
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "ceil(clamp((\n  sum(stddev by (state) (cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})) or\n  (sum(abs(sum without (state) (cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})) - scalar(count(cluster_node_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}))))\n  ),\n  0, 1\n))\n",
+               "instant": false,
+               "legendFormat": "Converged",
+               "range": true
+            }
+         ],
+         "title": "Convergance state timeline",
+         "type": "state-timeline"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "The number of cluster peers seen by each instance.\n\nWhen cluster is converged, every peer should see all the other instances. When we have a split brain or one\npeer not joining the cluster, we will see two or more groups of instances that report different peer numbers\nfor an extended period of time and not converging.\n\nThis graph helps to identify which instances may be in a split brain state.\n\nThe minimum cluster size shows the value of the --cluster.wait-for-size flag, which specifies the minimum \nnumber of instances required before cluster-enabled components begin processing traffic.\n",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "peers"
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Minimum cluster size"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "red",
+                           "mode": "fixed"
+                        }
+                     },
+                     {
+                        "id": "custom.lineStyle",
+                        "value": {
+                           "dash": [
+                              10,
+                              10
+                           ],
+                           "fill": "dash"
+                        }
+                     },
+                     {
+                        "id": "custom.lineWidth",
+                        "value": 1
+                     },
+                     {
+                        "id": "custom.dashPattern",
+                        "value": [
+                           10,
+                           10
+                        ]
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 12,
+            "w": 24,
+            "x": 0,
+            "y": 18
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by(instance) (cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})\n",
+               "instant": false,
+               "legendFormat": "{{instance}}",
+               "range": true
+            },
+            {
+               "datasource": "${datasource}",
+               "expr": "avg(cluster_minimum_size{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})\n",
+               "instant": false,
+               "legendFormat": "Minimum cluster size",
+               "range": true
+            }
+         ],
+         "title": "Number of peers seen by each instance",
+         "type": "timeseries"
+      }
+   ],
+   "refresh": "10s",
+   "schemaVersion": 36,
+   "tags": [
+      "alloy-mixin"
+   ],
+   "templating": {
+      "list": [
+         {
+            "label": "Data Source",
+            "name": "datasource",
+            "query": "prometheus",
+            "refresh": 1,
+            "sort": 2,
+            "type": "datasource"
+         },
+         {
+            "label": "Loki Data Source",
+            "name": "loki_datasource",
+            "query": "loki",
+            "refresh": 1,
+            "sort": 2,
+            "type": "datasource"
+         },
+         {
+            "datasource": "${datasource}",
+            "label": "cluster",
+            "name": "cluster",
+            "query": {
+               "query": "label_values(alloy_component_controller_running_components, cluster)\n",
+               "refId": "cluster"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         },
+         {
+            "datasource": "${datasource}",
+            "label": "namespace",
+            "name": "namespace",
+            "query": {
+               "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
+               "refId": "namespace"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         },
+         {
+            "datasource": "${datasource}",
+            "label": "job",
+            "name": "job",
+            "query": {
+               "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
+               "refId": "job"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         }
+      ]
+   },
+   "time": {
+      "from": "now-1h",
+      "to": "now"
+   },
+   "timepicker": {
+      "refresh_intervals": [
+         "5s",
+         "10s",
+         "30s",
+         "1m",
+         "5m",
+         "15m",
+         "30m",
+         "1h",
+         "2h",
+         "1d"
+      ],
+      "time_options": [
+         "5m",
+         "15m",
+         "1h",
+         "6h",
+         "12h",
+         "24h",
+         "2d",
+         "7d",
+         "30d",
+         "90d"
+      ]
+   },
+   "timezone": "utc",
+   "title": "Alloy / Cluster Overview",
+   "uid": "3a6b7020692f53d8e53b49196f7637dd"
+}

--- a/operations/alloy-mixin/rendered/dashboards/alloy-controller.json
+++ b/operations/alloy-mixin/rendered/dashboards/alloy-controller.json
@@ -1,0 +1,554 @@
+{
+   "annotations": {
+      "list": [
+         {
+            "datasource": "$loki_datasource",
+            "enable": true,
+            "expr": "{cluster=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "instant": false,
+            "name": "Deployments",
+            "titleFormat": "{{cluster}}/{{namespace}}"
+         }
+      ]
+   },
+   "graphTooltip": 1,
+   "links": [
+      {
+         "icon": "doc",
+         "targetBlank": true,
+         "title": "Documentation",
+         "tooltip": "Component controller documentation",
+         "type": "link",
+         "url": "https://grafana.com/docs/alloy/latest/concepts/component_controller/"
+      },
+      {
+         "asDropdown": true,
+         "icon": "external link",
+         "includeVars": true,
+         "keepTime": true,
+         "tags": [
+            "alloy-mixin"
+         ],
+         "targetBlank": false,
+         "title": "Dashboards",
+         "type": "dashboards"
+      }
+   ],
+   "panels": [
+      {
+         "datasource": "${datasource}",
+         "description": "The number of Alloy instances whose metrics are being sent and reported.\n",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "instances"
+            }
+         },
+         "gridPos": {
+            "h": 4,
+            "w": 10,
+            "x": 0,
+            "y": 0
+         },
+         "options": {
+            "colorMode": "none",
+            "graphMode": "none"
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "count(group(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}) by (instance))\n",
+               "instant": false,
+               "legendFormat": "__auto",
+               "range": true
+            }
+         ],
+         "title": "Running instances",
+         "type": "stat"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "The number of running components across all running instances.\n",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "components"
+            }
+         },
+         "gridPos": {
+            "h": 4,
+            "w": 10,
+            "x": 0,
+            "y": 4
+         },
+         "options": {
+            "colorMode": "none",
+            "graphMode": "none"
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})\n",
+               "instant": false,
+               "legendFormat": "__auto",
+               "range": true
+            }
+         ],
+         "title": "Running components",
+         "type": "stat"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "The percentage of components which are in a healthy state.\n",
+         "fieldConfig": {
+            "defaults": {
+               "max": 1,
+               "min": 0,
+               "noValue": "No components",
+               "unit": "percentunit"
+            }
+         },
+         "gridPos": {
+            "h": 4,
+            "w": 10,
+            "x": 0,
+            "y": 8
+         },
+         "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "text": {
+               "valueSize": 80
+            }
+         },
+         "pluginVersion": "9.0.6",
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\",health_type=\"healthy\"}) /\nsum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})\n",
+               "instant": false,
+               "legendFormat": "__auto",
+               "range": true
+            }
+         ],
+         "title": "Overall component health",
+         "type": "stat"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Breakdown of components by health across all running instances.\n\n* Healthy: components have been evaluated completely and are reporting themselves as healthy.\n* Unhealthy: Components either could not be evaluated or are reporting themselves as unhealthy.\n* Unknown: A component has been created but has not yet been started.\n* Exited: A component has exited. It will not return to the running state.\n\nMore information on a component's health state can be retrieved using\nthe Alloy UI.\n\nNote that components may be in a degraded state even if they report\nthemselves as healthy. Use component-specific dashboards and alerts\nto observe detailed information about the behavior of a component.\n",
+         "fieldConfig": {
+            "defaults": {
+               "min": 0,
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     }
+                  ]
+               }
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Unhealthy"
+                  },
+                  "properties": [
+                     {
+                        "id": "thresholds",
+                        "value": {
+                           "mode": "absolute",
+                           "steps": [
+                              {
+                                 "color": "green",
+                                 "value": null
+                              },
+                              {
+                                 "color": "red",
+                                 "value": 1
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Unknown"
+                  },
+                  "properties": [
+                     {
+                        "id": "thresholds",
+                        "value": {
+                           "mode": "absolute",
+                           "steps": [
+                              {
+                                 "color": "green",
+                                 "value": null
+                              },
+                              {
+                                 "color": "blue",
+                                 "value": 1
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Exited"
+                  },
+                  "properties": [
+                     {
+                        "id": "thresholds",
+                        "value": {
+                           "mode": "absolute",
+                           "steps": [
+                              {
+                                 "color": "green",
+                                 "value": null
+                              },
+                              {
+                                 "color": "orange",
+                                 "value": 1
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 12,
+            "w": 14,
+            "x": 10,
+            "y": 0
+         },
+         "options": {
+            "orientation": "vertical",
+            "showUnfilled": true
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", health_type=\"healthy\"}) or vector(0)\n",
+               "instant": true,
+               "legendFormat": "Healthy",
+               "range": false
+            },
+            {
+               "datasource": "${datasource}",
+               "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", health_type=\"unhealthy\"}) or vector(0)\n",
+               "instant": true,
+               "legendFormat": "Unhealthy",
+               "range": false
+            },
+            {
+               "datasource": "${datasource}",
+               "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", health_type=\"unknown\"}) or vector(0)\n",
+               "instant": true,
+               "legendFormat": "Unknown",
+               "range": false
+            },
+            {
+               "datasource": "${datasource}",
+               "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", health_type=\"exited\"}) or vector(0)\n",
+               "instant": true,
+               "legendFormat": "Exited",
+               "range": false
+            }
+         ],
+         "title": "Components by health",
+         "type": "bargauge"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "The frequency at which components get updated.\n",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "drawStyle": "points",
+                  "pointSize": 3
+               },
+               "unit": "ops"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 0,
+            "y": 12
+         },
+         "options": {
+            "tooltip": {
+               "mode": "multi"
+            }
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by (instance) (rate(alloy_component_evaluation_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n",
+               "instant": false,
+               "legendFormat": "__auto",
+               "range": true
+            }
+         ],
+         "title": "Component evaluation rate",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "The percentiles for how long it takes to complete component evaluations.\n\nComponent evaluations must complete for components to have the latest\narguments. The longer the evaluations take, the slower it will be to\nreconcile the state of components.\n\nIf evaluation is taking too long, consider sharding your components to\ndeal with smaller amounts of data and reuse data as much as possible.\n",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "s"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 8,
+            "y": 12
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "histogram_quantile(0.99, sum(rate(alloy_component_evaluation_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\nor\nhistogram_quantile(0.99, sum by (le) (rate(alloy_component_evaluation_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\n",
+               "instant": false,
+               "legendFormat": "99th percentile",
+               "range": true
+            },
+            {
+               "datasource": "${datasource}",
+               "expr": "histogram_quantile(0.50, sum(rate(alloy_component_evaluation_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\nor\nhistogram_quantile(0.50, sum by (le) (rate(alloy_component_evaluation_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\n",
+               "instant": false,
+               "legendFormat": "50th percentile",
+               "range": true
+            },
+            {
+               "datasource": "${datasource}",
+               "expr": "(\n  histogram_sum(sum(rate(alloy_component_evaluation_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))) /\n  histogram_count(sum(rate(alloy_component_evaluation_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\n)\nor\n(\n  sum(rate(alloy_component_evaluation_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])) /\n  sum(rate(alloy_component_evaluation_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n)\n",
+               "instant": false,
+               "legendFormat": "Average",
+               "range": true
+            }
+         ],
+         "title": "Component evaluation time",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "The maximum duration of slow component evaluations over time.\n\nThis shows components that took longer than 1 minute to evaluate. Ideally, no component \nshould take more than 1 minute to evaluate. The components displayed in this chart\nmay be a sign of a problem with the pipeline or performance issues.\n",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "s"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 16,
+            "y": 12
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "increase(alloy_component_evaluation_slow_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])\n",
+               "instant": false,
+               "legendFormat": "{{instance}} {{controller_path}} {{component_id}}",
+               "range": true
+            }
+         ],
+         "title": "Slow components evaluation times",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Detailed histogram view of how long component evaluations take.\n\nThe goal is to design your config so that evaluations take as little\ntime as possible; under 100ms is a good goal.\n",
+         "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 0,
+            "y": 22
+         },
+         "maxDataPoints": 30,
+         "options": {
+            "calculate": false,
+            "cellGap": 0,
+            "color": {
+               "scheme": "Spectral"
+            },
+            "exemplars": {
+               "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+               "le": 0.10000000000000001
+            },
+            "tooltip": {
+               "show": true,
+               "yHistogram": true
+            },
+            "yAxis": {
+               "unit": "s"
+            }
+         },
+         "pluginVersion": "9.0.6",
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum(increase(alloy_component_evaluation_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\nor ignoring (le)\nsum by (le) (increase(alloy_component_evaluation_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n",
+               "format": "heatmap",
+               "instant": false,
+               "legendFormat": "{{le}}",
+               "range": true
+            }
+         ],
+         "title": "Component evaluation histogram",
+         "type": "heatmap"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Detailed histogram of how long components wait to be evaluated after their dependency is updated.\n\nThe goal is to design your config so that most of the time components do not\nqueue for long; under 10ms is a good goal.\n",
+         "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 8,
+            "y": 22
+         },
+         "maxDataPoints": 30,
+         "options": {
+            "calculate": false,
+            "cellGap": 0,
+            "color": {
+               "scheme": "Spectral"
+            },
+            "exemplars": {
+               "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+               "le": 0.10000000000000001
+            },
+            "tooltip": {
+               "show": true,
+               "yHistogram": true
+            },
+            "yAxis": {
+               "unit": "s"
+            }
+         },
+         "pluginVersion": "9.0.6",
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum(increase(alloy_component_dependencies_wait_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\nor ignoring (le)\nsum by (le) (increase(alloy_component_dependencies_wait_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n",
+               "format": "heatmap",
+               "instant": false,
+               "legendFormat": "{{le}}",
+               "range": true
+            }
+         ],
+         "title": "Component dependency wait histogram",
+         "type": "heatmap"
+      }
+   ],
+   "refresh": "10s",
+   "schemaVersion": 36,
+   "tags": [
+      "alloy-mixin"
+   ],
+   "templating": {
+      "list": [
+         {
+            "label": "Data Source",
+            "name": "datasource",
+            "query": "prometheus",
+            "refresh": 1,
+            "sort": 2,
+            "type": "datasource"
+         },
+         {
+            "label": "Loki Data Source",
+            "name": "loki_datasource",
+            "query": "loki",
+            "refresh": 1,
+            "sort": 2,
+            "type": "datasource"
+         },
+         {
+            "datasource": "${datasource}",
+            "label": "cluster",
+            "name": "cluster",
+            "query": {
+               "query": "label_values(alloy_component_controller_running_components, cluster)\n",
+               "refId": "cluster"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         },
+         {
+            "datasource": "${datasource}",
+            "label": "namespace",
+            "name": "namespace",
+            "query": {
+               "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
+               "refId": "namespace"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         },
+         {
+            "datasource": "${datasource}",
+            "label": "job",
+            "name": "job",
+            "query": {
+               "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
+               "refId": "job"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         }
+      ]
+   },
+   "time": {
+      "from": "now-1h",
+      "to": "now"
+   },
+   "timepicker": {
+      "refresh_intervals": [
+         "5s",
+         "10s",
+         "30s",
+         "1m",
+         "5m",
+         "15m",
+         "30m",
+         "1h",
+         "2h",
+         "1d"
+      ],
+      "time_options": [
+         "5m",
+         "15m",
+         "1h",
+         "6h",
+         "12h",
+         "24h",
+         "2d",
+         "7d",
+         "30d",
+         "90d"
+      ]
+   },
+   "timezone": "utc",
+   "title": "Alloy / Controller",
+   "uid": "bf9f456aad7108b2c808dbd9973e386f"
+}

--- a/operations/alloy-mixin/rendered/dashboards/alloy-logs.json
+++ b/operations/alloy-mixin/rendered/dashboards/alloy-logs.json
@@ -1,0 +1,324 @@
+{
+   "links": [
+      {
+         "asDropdown": true,
+         "icon": "external link",
+         "includeVars": true,
+         "keepTime": true,
+         "tags": [
+            "alloy-mixin"
+         ],
+         "targetBlank": false,
+         "title": "Dashboards",
+         "type": "dashboards"
+      }
+   ],
+   "panels": [
+      {
+         "datasource": {
+            "type": "loki",
+            "uid": "${loki_datasource}"
+         },
+         "description": "Logs volume grouped by \"level\" label.",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "drawStyle": "bars",
+                  "fillOpacity": 50,
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "none"
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "(E|e)merg|(F|f)atal|(A|a)lert|(C|c)rit.*"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "purple",
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "(E|e)(rr.*|RR.*)"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "red",
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "(W|w)(arn.*|ARN.*|rn|RN)"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "orange",
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "(N|n)(otice|ote)|(I|i)(nf.*|NF.*)"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "green",
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "dbg.*|DBG.*|(D|d)(EBUG|ebug)"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "blue",
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "(T|t)(race|RACE)"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "light-blue",
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "logs"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "text",
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 6,
+            "w": 24
+         },
+         "id": 1,
+         "interval": "30s",
+         "options": {
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v10.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "loki",
+                  "uid": "${loki_datasource}"
+               },
+               "expr": "sum by (level) (count_over_time({,cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$job\",instance=~\"$instance\",level=~\"$level\"}\n|~ \"$regex_search\"\n\n[$__interval]))\n",
+               "legendFormat": "{{ level }}"
+            }
+         ],
+         "title": "Logs volume",
+         "transformations": [
+            {
+               "id": "renameByRegex",
+               "options": {
+                  "regex": "Value",
+                  "renamePattern": "logs"
+               }
+            }
+         ],
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "gridPos": {
+            "h": 18,
+            "w": 24
+         },
+         "id": 2,
+         "options": {
+            "dedupStrategy": "exact",
+            "enableLogDetails": true,
+            "prettifyLogMessage": true,
+            "showTime": false,
+            "wrapLogMessage": true
+         },
+         "pluginVersion": "v10.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "loki",
+                  "uid": "${loki_datasource}"
+               },
+               "expr": "{,cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$job\",instance=~\"$instance\",level=~\"$level\"} \n|~ \"$regex_search\"\n\n\n"
+            }
+         ],
+         "title": "Logs",
+         "type": "logs"
+      }
+   ],
+   "refresh": "10s",
+   "schemaVersion": 36,
+   "tags": [
+      "alloy-mixin"
+   ],
+   "templating": {
+      "list": [
+         {
+            "label": "Loki data source",
+            "name": "loki_datasource",
+            "query": "loki",
+            "regex": "",
+            "type": "datasource"
+         },
+         {
+            "allValue": ".*",
+            "datasource": {
+               "type": "loki",
+               "uid": "${loki_datasource}"
+            },
+            "includeAll": true,
+            "label": "Cluster",
+            "multi": true,
+            "name": "cluster",
+            "query": "label_values({}, cluster)",
+            "refresh": 2,
+            "sort": 1,
+            "type": "query"
+         },
+         {
+            "allValue": ".*",
+            "datasource": {
+               "type": "loki",
+               "uid": "${loki_datasource}"
+            },
+            "includeAll": true,
+            "label": "Namespace",
+            "multi": true,
+            "name": "namespace",
+            "query": "label_values({,cluster=~\"$cluster\"}, namespace)",
+            "refresh": 2,
+            "sort": 1,
+            "type": "query"
+         },
+         {
+            "allValue": ".*",
+            "datasource": {
+               "type": "loki",
+               "uid": "${loki_datasource}"
+            },
+            "includeAll": true,
+            "label": "Job",
+            "multi": true,
+            "name": "job",
+            "query": "label_values({,cluster=~\"$cluster\",namespace=~\"$namespace\"}, job)",
+            "refresh": 2,
+            "sort": 1,
+            "type": "query"
+         },
+         {
+            "allValue": ".*",
+            "datasource": {
+               "type": "loki",
+               "uid": "${loki_datasource}"
+            },
+            "includeAll": true,
+            "label": "Instance",
+            "multi": true,
+            "name": "instance",
+            "query": "label_values({,cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$job\"}, instance)",
+            "refresh": 2,
+            "sort": 1,
+            "type": "query"
+         },
+         {
+            "allValue": ".*",
+            "datasource": {
+               "type": "loki",
+               "uid": "${loki_datasource}"
+            },
+            "includeAll": true,
+            "label": "Level",
+            "multi": true,
+            "name": "level",
+            "query": "label_values({,cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$job\",instance=~\"$instance\"}, level)",
+            "refresh": 2,
+            "sort": 1,
+            "type": "query"
+         },
+         {
+            "current": {
+               "selected": false,
+               "text": "",
+               "value": ""
+            },
+            "label": "Regex search",
+            "name": "regex_search",
+            "options": [
+               {
+                  "selected": true,
+                  "text": "",
+                  "value": ""
+               }
+            ],
+            "query": "",
+            "type": "textbox"
+         }
+      ]
+   },
+   "time": {
+      "from": "now-6h",
+      "to": "now"
+   },
+   "timezone": "utc",
+   "title": "Alloy / Logs Overview",
+   "uid": "53c1ecddc3a1d5d4b8d6cd0c23676c31"
+}

--- a/operations/alloy-mixin/rendered/dashboards/alloy-logs.json
+++ b/operations/alloy-mixin/rendered/dashboards/alloy-logs.json
@@ -141,24 +141,26 @@
          },
          "gridPos": {
             "h": 6,
-            "w": 24
+            "w": 24,
+            "x": 0,
+            "y": 0
          },
          "id": 1,
-         "interval": "30s",
+         "maxDataPoints": 100,
          "options": {
             "tooltip": {
                "mode": "multi",
                "sort": "desc"
             }
          },
-         "pluginVersion": "v10.0.0",
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
                "datasource": {
                   "type": "loki",
                   "uid": "${loki_datasource}"
                },
-               "expr": "sum by (level) (count_over_time({,cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$job\",instance=~\"$instance\",level=~\"$level\"}\n|~ \"$regex_search\"\n\n[$__interval]))\n",
+               "expr": "sum by (level) (count_over_time({cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$job\",instance=~\"$instance\",level=~\"$level\"}\n|~ \"$regex_search\"\n\n[$__auto]))\n",
                "legendFormat": "{{ level }}"
             }
          ],
@@ -181,7 +183,9 @@
          },
          "gridPos": {
             "h": 18,
-            "w": 24
+            "w": 24,
+            "x": 0,
+            "y": 18
          },
          "id": 2,
          "options": {
@@ -191,14 +195,14 @@
             "showTime": false,
             "wrapLogMessage": true
          },
-         "pluginVersion": "v10.0.0",
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
                "datasource": {
                   "type": "loki",
                   "uid": "${loki_datasource}"
                },
-               "expr": "{,cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$job\",instance=~\"$instance\",level=~\"$level\"} \n|~ \"$regex_search\"\n\n\n"
+               "expr": "{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$job\",instance=~\"$instance\",level=~\"$level\"} \n|~ \"$regex_search\"\n\n\n"
             }
          ],
          "title": "Logs",
@@ -206,7 +210,7 @@
       }
    ],
    "refresh": "10s",
-   "schemaVersion": 36,
+   "schemaVersion": 39,
    "tags": [
       "alloy-mixin"
    ],

--- a/operations/alloy-mixin/rendered/dashboards/alloy-logs.json
+++ b/operations/alloy-mixin/rendered/dashboards/alloy-logs.json
@@ -248,7 +248,7 @@
             "label": "Namespace",
             "multi": true,
             "name": "namespace",
-            "query": "label_values({,cluster=~\"$cluster\"}, namespace)",
+            "query": "label_values({cluster=~\"$cluster\"}, namespace)",
             "refresh": 2,
             "sort": 1,
             "type": "query"
@@ -263,7 +263,7 @@
             "label": "Job",
             "multi": true,
             "name": "job",
-            "query": "label_values({,cluster=~\"$cluster\",namespace=~\"$namespace\"}, job)",
+            "query": "label_values({cluster=~\"$cluster\",namespace=~\"$namespace\"}, job)",
             "refresh": 2,
             "sort": 1,
             "type": "query"
@@ -278,7 +278,7 @@
             "label": "Instance",
             "multi": true,
             "name": "instance",
-            "query": "label_values({,cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$job\"}, instance)",
+            "query": "label_values({cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$job\"}, instance)",
             "refresh": 2,
             "sort": 1,
             "type": "query"
@@ -293,7 +293,7 @@
             "label": "Level",
             "multi": true,
             "name": "level",
-            "query": "label_values({,cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$job\",instance=~\"$instance\"}, level)",
+            "query": "label_values({cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$job\",instance=~\"$instance\"}, level)",
             "refresh": 2,
             "sort": 1,
             "type": "query"

--- a/operations/alloy-mixin/rendered/dashboards/alloy-loki.json
+++ b/operations/alloy-mixin/rendered/dashboards/alloy-loki.json
@@ -1,0 +1,424 @@
+{
+   "annotations": {
+      "list": [
+         {
+            "datasource": "$loki_datasource",
+            "enable": true,
+            "expr": "{cluster=~\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "instant": false,
+            "name": "Deployments",
+            "titleFormat": "{{cluster}}/{{namespace}}"
+         }
+      ]
+   },
+   "graphTooltip": 1,
+   "links": [
+      {
+         "asDropdown": true,
+         "icon": "external link",
+         "includeVars": true,
+         "keepTime": true,
+         "tags": [
+            "alloy-mixin"
+         ],
+         "targetBlank": false,
+         "title": "Dashboards",
+         "type": "dashboards"
+      }
+   ],
+   "panels": [
+      {
+         "collapsed": false,
+         "datasource": "${datasource}",
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+         },
+         "title": "loki.source.file",
+         "type": "row"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Active files being tailed.\n",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 20,
+                  "gradientMode": "hue",
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "files"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 1
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by(instance) (loki_source_file_files_active_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"})\n",
+               "instant": false,
+               "legendFormat": "__auto",
+               "range": true
+            }
+         ],
+         "title": "Active files count $cluster",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Successful file reads.\n",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 20,
+                  "gradientMode": "hue",
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "cps"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 1
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by (instance) (rate(loki_source_file_read_lines_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))\n",
+               "instant": false,
+               "legendFormat": "__auto",
+               "range": true
+            }
+         ],
+         "title": "Lines read in $cluster",
+         "type": "timeseries"
+      },
+      {
+         "collapsed": false,
+         "datasource": "${datasource}",
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 11
+         },
+         "title": "loki.source.journal",
+         "type": "row"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Successful journal reads.\t\n",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 20,
+                  "gradientMode": "hue",
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "cps"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 12
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by (instance) (rate(loki_source_journal_target_lines_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))\n",
+               "instant": false,
+               "legendFormat": "__auto",
+               "range": true
+            }
+         ],
+         "title": "Journal lines read in $cluster",
+         "type": "timeseries"
+      },
+      {
+         "collapsed": false,
+         "datasource": "${datasource}",
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 22
+         },
+         "title": "loki.write",
+         "type": "row"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Percentage of logs sent by loki.write that succeeded.\n",
+         "fieldConfig": {
+            "defaults": {
+               "max": 100,
+               "unit": "%"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 23
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by(instance) (rate(loki_write_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", status_code=~\"2..\", host=~\"$url\"}[$__rate_interval]))\n/\nsum by(instance) (rate(loki_write_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", host=~\"$url\"}[$__rate_interval])) * 100 \n",
+               "instant": false,
+               "legendFormat": "__auto",
+               "range": true
+            }
+         ],
+         "title": "Write requests success rate in $cluster",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Bytes dropped per second.\n",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "s"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 23
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "histogram_quantile(\n  0.99,\n  sum by (le, instance) (\n\trate(loki_write_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", host=~\"$url\"}[$__rate_interval])\n  )\n)\n",
+               "instant": false,
+               "legendFormat": "{{instance}} p99",
+               "range": true
+            },
+            {
+               "datasource": "${datasource}",
+               "expr": "histogram_quantile(\n  0.95,\n  sum by (le, instance) (\n\trate(loki_write_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", host=~\"$url\"}[$__rate_interval])\n  )\n)\n",
+               "instant": false,
+               "legendFormat": "{{instance}} p95",
+               "range": true
+            },
+            {
+               "datasource": "${datasource}",
+               "expr": "histogram_quantile(\n  0.50,\n  sum by (le, instance) (\n\trate(loki_write_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", host=~\"$url\"}[$__rate_interval])\n  )\n)\n",
+               "instant": false,
+               "legendFormat": "{{instance}} p50",
+               "range": true
+            }
+         ],
+         "title": "Write latency in $cluster",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Bytes sent per second.\n",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 20,
+                  "gradientMode": "hue",
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 23
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by (instance) (rate(loki_write_sent_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", host=~\"$url\"}[$__rate_interval]))\n",
+               "instant": false,
+               "legendFormat": "__auto",
+               "range": true
+            }
+         ],
+         "title": "Bytes sent in $cluster",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Bytes dropped per second.\n",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 20,
+                  "gradientMode": "hue",
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 23
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by(instance) (rate(loki_write_dropped_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", host=~\"$url\"}[$__rate_interval]))\n",
+               "instant": false,
+               "legendFormat": "__auto",
+               "range": true
+            }
+         ],
+         "title": "Bytes dropped in $cluster",
+         "type": "timeseries"
+      }
+   ],
+   "refresh": "10s",
+   "schemaVersion": 36,
+   "tags": [
+      "alloy-mixin"
+   ],
+   "templating": {
+      "list": [
+         {
+            "label": "Data Source",
+            "name": "datasource",
+            "query": "prometheus",
+            "refresh": 1,
+            "sort": 2,
+            "type": "datasource"
+         },
+         {
+            "label": "Loki Data Source",
+            "name": "loki_datasource",
+            "query": "loki",
+            "refresh": 1,
+            "sort": 2,
+            "type": "datasource"
+         },
+         {
+            "datasource": "${datasource}",
+            "label": "cluster",
+            "name": "cluster",
+            "query": {
+               "query": "label_values(alloy_component_controller_running_components, cluster)\n",
+               "refId": "cluster"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         },
+         {
+            "datasource": "${datasource}",
+            "label": "namespace",
+            "name": "namespace",
+            "query": {
+               "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
+               "refId": "namespace"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         },
+         {
+            "datasource": "${datasource}",
+            "label": "job",
+            "name": "job",
+            "query": {
+               "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
+               "refId": "job"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         },
+         {
+            "allValue": ".*",
+            "datasource": "${datasource}",
+            "includeAll": true,
+            "label": "instance",
+            "multi": true,
+            "name": "instance",
+            "query": {
+               "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}, instance)\n",
+               "refId": "instance"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         },
+         {
+            "allValue": ".*",
+            "datasource": "${datasource}",
+            "includeAll": true,
+            "label": "url",
+            "multi": true,
+            "name": "url",
+            "query": {
+               "query": "label_values(loki_write_sent_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=\"$job\", instance=~\"$instance\"}, host)\n",
+               "refId": "url"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         }
+      ]
+   },
+   "time": {
+      "from": "now-1h",
+      "to": "now"
+   },
+   "timepicker": {
+      "refresh_intervals": [
+         "5s",
+         "10s",
+         "30s",
+         "1m",
+         "5m",
+         "15m",
+         "30m",
+         "1h",
+         "2h",
+         "1d"
+      ],
+      "time_options": [
+         "5m",
+         "15m",
+         "1h",
+         "6h",
+         "12h",
+         "24h",
+         "2d",
+         "7d",
+         "30d",
+         "90d"
+      ]
+   },
+   "timezone": "utc",
+   "title": "Alloy / Loki Components",
+   "uid": "73e5f8ebc2c6a45cee18dc2a0066c125"
+}

--- a/operations/alloy-mixin/rendered/dashboards/alloy-opentelemetry.json
+++ b/operations/alloy-mixin/rendered/dashboards/alloy-opentelemetry.json
@@ -1,0 +1,854 @@
+{
+   "graphTooltip": 1,
+   "links": [
+      {
+         "asDropdown": true,
+         "icon": "external link",
+         "includeVars": true,
+         "keepTime": true,
+         "tags": [
+            "alloy-mixin"
+         ],
+         "targetBlank": false,
+         "title": "Dashboards",
+         "type": "dashboards"
+      }
+   ],
+   "panels": [
+      {
+         "datasource": "${datasource}",
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+         },
+         "title": "Receivers [otelcol.receiver.*]",
+         "type": "row"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Number of metric points successfully pushed into the pipeline.\n",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 20,
+                  "gradientMode": "hue",
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "cps"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 6,
+            "x": 0,
+            "y": 0
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by(instance) (rate(otelcol_receiver_accepted_metric_points_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))\n",
+               "instant": false,
+               "legendFormat": "__auto",
+               "range": true
+            }
+         ],
+         "title": "Accepted metric points",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Number of metric points that could not be pushed into the pipeline.\n",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 20,
+                  "gradientMode": "hue",
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "cps"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 6,
+            "x": 6,
+            "y": 0
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by(instance) (rate(otelcol_receiver_refused_metric_points_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))\n",
+               "instant": false,
+               "legendFormat": "__auto",
+               "range": true
+            }
+         ],
+         "title": "Refused metric points",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Number of log records successfully pushed into the pipeline.\n",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 20,
+                  "gradientMode": "hue",
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "cps"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 6,
+            "x": 12,
+            "y": 0
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by(instance) (rate(otelcol_receiver_accepted_log_records_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))\n",
+               "instant": false,
+               "legendFormat": "__auto",
+               "range": true
+            }
+         ],
+         "title": "Accepted logs",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Number of log records that could not be pushed into the pipeline.\n",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 20,
+                  "gradientMode": "hue",
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "cps"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 6,
+            "x": 18,
+            "y": 0
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by(instance) (rate(otelcol_receiver_refused_log_records_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))\n",
+               "instant": false,
+               "legendFormat": "__auto",
+               "range": true
+            }
+         ],
+         "title": "Refused logs",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Number of spans successfully pushed into the pipeline.\n",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 20,
+                  "gradientMode": "hue",
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "cps"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 6,
+            "x": 0,
+            "y": 10
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by(instance) (rate(otelcol_receiver_accepted_spans_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))\n",
+               "instant": false,
+               "legendFormat": "__auto",
+               "range": true
+            }
+         ],
+         "title": "Accepted spans",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Number of spans that could not be pushed into the pipeline.\n",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 20,
+                  "gradientMode": "hue",
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "cps"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 6,
+            "x": 6,
+            "y": 10
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by(instance) (rate(otelcol_receiver_refused_spans_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))\n",
+               "instant": false,
+               "legendFormat": "__auto",
+               "range": true
+            }
+         ],
+         "title": "Refused spans",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "The duration of inbound RPCs for otelcol.receiver.* components.\n",
+         "gridPos": {
+            "h": 10,
+            "w": 6,
+            "x": 12,
+            "y": 10
+         },
+         "maxDataPoints": 30,
+         "options": {
+            "calculate": false,
+            "color": {
+               "exponent": 0.5,
+               "fill": "dark-orange",
+               "mode": "scheme",
+               "scale": "exponential",
+               "scheme": "Oranges",
+               "steps": 65
+            },
+            "exemplars": {
+               "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+               "le": 1.0000000000000001e-09
+            },
+            "tooltip": {
+               "show": true,
+               "yHistogram": true
+            },
+            "yAxis": {
+               "unit": "ms"
+            }
+         },
+         "pluginVersion": "9.0.6",
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by (le) (increase(rpc_server_duration_milliseconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_id=~\"otelcol.receiver.*\"}[$__rate_interval]))\n",
+               "format": "heatmap",
+               "instant": false,
+               "legendFormat": "{{le}}",
+               "range": true
+            }
+         ],
+         "title": "RPC server duration",
+         "type": "heatmap"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "The duration of inbound HTTP requests for otelcol.receiver.* components.\n",
+         "gridPos": {
+            "h": 10,
+            "w": 6,
+            "x": 18,
+            "y": 10
+         },
+         "maxDataPoints": 30,
+         "options": {
+            "calculate": false,
+            "color": {
+               "exponent": 0.5,
+               "fill": "dark-orange",
+               "mode": "scheme",
+               "scale": "exponential",
+               "scheme": "Oranges",
+               "steps": 65
+            },
+            "exemplars": {
+               "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+               "le": 1.0000000000000001e-09
+            },
+            "tooltip": {
+               "show": true,
+               "yHistogram": true
+            },
+            "yAxis": {
+               "unit": "ms"
+            }
+         },
+         "pluginVersion": "9.0.6",
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by (le) (increase(http_server_duration_milliseconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_id=~\"otelcol.receiver.*\"}[$__rate_interval]))\n",
+               "format": "heatmap",
+               "instant": false,
+               "legendFormat": "{{le}}",
+               "range": true
+            }
+         ],
+         "title": "HTTP server duration",
+         "type": "heatmap"
+      },
+      {
+         "datasource": "${datasource}",
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 20
+         },
+         "title": "Batching [otelcol.processor.batch]",
+         "type": "row"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Number of spans, metric datapoints, or log lines in a batch\n",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "short"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 0,
+            "y": 20
+         },
+         "maxDataPoints": 30,
+         "options": {
+            "calculate": false,
+            "color": {
+               "exponent": 0.5,
+               "fill": "dark-orange",
+               "mode": "scheme",
+               "scale": "exponential",
+               "scheme": "Oranges",
+               "steps": 65
+            },
+            "exemplars": {
+               "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+               "le": 1.0000000000000001e-09
+            },
+            "tooltip": {
+               "show": true,
+               "yHistogram": true
+            },
+            "yAxis": {
+               "unit": "short"
+            }
+         },
+         "pluginVersion": "9.0.6",
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by (le) (increase(otelcol_processor_batch_batch_send_size_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))\n",
+               "format": "heatmap",
+               "instant": false,
+               "legendFormat": "{{le}}",
+               "range": true
+            }
+         ],
+         "title": "Number of units in the batch",
+         "type": "heatmap"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Number of distinct metadata value combinations being processed\n",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "short"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 8,
+            "y": 20
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by(instance) (otelcol_processor_batch_metadata_cardinality{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"})\n",
+               "instant": false,
+               "legendFormat": "__auto",
+               "range": true
+            }
+         ],
+         "title": "Distinct metadata values",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Number of times the batch was sent due to a timeout trigger\n",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "cps"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 16,
+            "y": 20
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by(instance) (rate(otelcol_processor_batch_timeout_trigger_send_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))\n",
+               "instant": false,
+               "legendFormat": "__auto",
+               "range": true
+            }
+         ],
+         "title": "Timeout trigger",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 30
+         },
+         "title": "Exporters [otelcol.exporter.*]",
+         "type": "row"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Number of metric points successfully sent to destination.\n",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 20,
+                  "gradientMode": "hue",
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "cps"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 6,
+            "x": 0,
+            "y": 30
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by(instance) (rate(otelcol_exporter_sent_metric_points_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))\n",
+               "instant": false,
+               "legendFormat": "__auto",
+               "range": true
+            }
+         ],
+         "title": "Exported metric points",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Number of metric points that failed to be sent to destination.\n",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 20,
+                  "gradientMode": "hue",
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "cps"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 6,
+            "x": 6,
+            "y": 30
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by(instance) (rate(otelcol_exporter_send_failed_metric_points_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))\n",
+               "instant": false,
+               "legendFormat": "__auto",
+               "range": true
+            }
+         ],
+         "title": "Failed metric points",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Number of log records successfully sent to destination.\n",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 20,
+                  "gradientMode": "hue",
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "cps"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 6,
+            "x": 12,
+            "y": 30
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by(instance) (rate(otelcol_exporter_sent_log_records_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))\n",
+               "instant": false,
+               "legendFormat": "__auto",
+               "range": true
+            }
+         ],
+         "title": "Exported logs",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Number of log records that failed to be sent to destination.\n",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 20,
+                  "gradientMode": "hue",
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "cps"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 6,
+            "x": 18,
+            "y": 30
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by(instance) (rate(otelcol_exporter_send_failed_log_records_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))\n",
+               "instant": false,
+               "legendFormat": "__auto",
+               "range": true
+            }
+         ],
+         "title": "Failed logs",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Number of spans successfully sent to destination.\n",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 20,
+                  "gradientMode": "hue",
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "cps"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 6,
+            "x": 0,
+            "y": 40
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by(instance) (rate(otelcol_exporter_sent_spans_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))\n",
+               "instant": false,
+               "legendFormat": "__auto",
+               "range": true
+            }
+         ],
+         "title": "Exported spans",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Number of spans that failed to be sent to destination.\n",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 20,
+                  "gradientMode": "hue",
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "cps"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 6,
+            "x": 6,
+            "y": 40
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by(instance) (rate(otelcol_exporter_send_failed_spans_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))\n",
+               "instant": false,
+               "legendFormat": "__auto",
+               "range": true
+            }
+         ],
+         "title": "Failed spans",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "The duration of outbound RPCs for otelcol.exporter.* components.\n",
+         "gridPos": {
+            "h": 10,
+            "w": 6,
+            "x": 12,
+            "y": 40
+         },
+         "maxDataPoints": 30,
+         "options": {
+            "calculate": false,
+            "color": {
+               "exponent": 0.5,
+               "fill": "dark-orange",
+               "mode": "scheme",
+               "scale": "exponential",
+               "scheme": "Oranges",
+               "steps": 65
+            },
+            "exemplars": {
+               "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+               "le": 1.0000000000000001e-09
+            },
+            "tooltip": {
+               "show": true,
+               "yHistogram": true
+            },
+            "yAxis": {
+               "unit": "ms"
+            }
+         },
+         "pluginVersion": "9.0.6",
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by (le) (increase(rpc_client_duration_milliseconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_id=~\"otelcol.exporter.*\"}[$__rate_interval]))\n",
+               "format": "heatmap",
+               "instant": false,
+               "legendFormat": "{{le}}",
+               "range": true
+            }
+         ],
+         "title": "RPC client duration",
+         "type": "heatmap"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "The duration of outbound HTTP requests for otelcol.exporter.* components.\n",
+         "gridPos": {
+            "h": 10,
+            "w": 6,
+            "x": 18,
+            "y": 40
+         },
+         "maxDataPoints": 30,
+         "options": {
+            "calculate": false,
+            "color": {
+               "exponent": 0.5,
+               "fill": "dark-orange",
+               "mode": "scheme",
+               "scale": "exponential",
+               "scheme": "Oranges",
+               "steps": 65
+            },
+            "exemplars": {
+               "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+               "le": 1.0000000000000001e-09
+            },
+            "tooltip": {
+               "show": true,
+               "yHistogram": true
+            },
+            "yAxis": {
+               "unit": "ms"
+            }
+         },
+         "pluginVersion": "9.0.6",
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by (le) (increase(http_client_duration_milliseconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_id=~\"otelcol.exporter.*\"}[$__rate_interval]))\n",
+               "format": "heatmap",
+               "instant": false,
+               "legendFormat": "{{le}}",
+               "range": true
+            }
+         ],
+         "title": "HTTP client duration",
+         "type": "heatmap"
+      }
+   ],
+   "refresh": "10s",
+   "schemaVersion": 36,
+   "tags": [
+      "alloy-mixin"
+   ],
+   "templating": {
+      "list": [
+         {
+            "label": "Data Source",
+            "name": "datasource",
+            "query": "prometheus",
+            "refresh": 1,
+            "sort": 2,
+            "type": "datasource"
+         },
+         {
+            "label": "Loki Data Source",
+            "name": "loki_datasource",
+            "query": "loki",
+            "refresh": 1,
+            "sort": 2,
+            "type": "datasource"
+         },
+         {
+            "datasource": "${datasource}",
+            "label": "cluster",
+            "name": "cluster",
+            "query": {
+               "query": "label_values(alloy_component_controller_running_components, cluster)\n",
+               "refId": "cluster"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         },
+         {
+            "datasource": "${datasource}",
+            "label": "namespace",
+            "name": "namespace",
+            "query": {
+               "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
+               "refId": "namespace"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         },
+         {
+            "datasource": "${datasource}",
+            "label": "job",
+            "name": "job",
+            "query": {
+               "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
+               "refId": "job"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         },
+         {
+            "allValue": ".*",
+            "datasource": "${datasource}",
+            "includeAll": true,
+            "label": "instance",
+            "multi": true,
+            "name": "instance",
+            "query": {
+               "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}, instance)\n",
+               "refId": "instance"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         }
+      ]
+   },
+   "time": {
+      "from": "now-1h",
+      "to": "now"
+   },
+   "timepicker": {
+      "refresh_intervals": [
+         "5s",
+         "10s",
+         "30s",
+         "1m",
+         "5m",
+         "15m",
+         "30m",
+         "1h",
+         "2h",
+         "1d"
+      ],
+      "time_options": [
+         "5m",
+         "15m",
+         "1h",
+         "6h",
+         "12h",
+         "24h",
+         "2d",
+         "7d",
+         "30d",
+         "90d"
+      ]
+   },
+   "timezone": "utc",
+   "title": "Alloy / OpenTelemetry",
+   "uid": "9b6d37c8603e19e8922133984faad93d"
+}

--- a/operations/alloy-mixin/rendered/dashboards/alloy-prometheus-remote-write.json
+++ b/operations/alloy-mixin/rendered/dashboards/alloy-prometheus-remote-write.json
@@ -1,0 +1,693 @@
+{
+   "annotations": {
+      "list": [
+         {
+            "datasource": "$loki_datasource",
+            "enable": true,
+            "expr": "{cluster=~\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "instant": false,
+            "name": "Deployments",
+            "titleFormat": "{{cluster}}/{{namespace}}"
+         }
+      ]
+   },
+   "graphTooltip": 1,
+   "links": [
+      {
+         "icon": "doc",
+         "targetBlank": true,
+         "title": "Documentation",
+         "tooltip": "Component documentation",
+         "type": "link",
+         "url": "https://grafana.com/docs/alloy/latest/reference/components/prometheus.remote_write/"
+      },
+      {
+         "asDropdown": true,
+         "icon": "external link",
+         "includeVars": true,
+         "keepTime": true,
+         "tags": [
+            "alloy-mixin"
+         ],
+         "targetBlank": false,
+         "title": "Dashboards",
+         "type": "dashboards"
+      }
+   ],
+   "panels": [
+      {
+         "collapsed": false,
+         "datasource": "${datasource}",
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+         },
+         "title": "prometheus.scrape",
+         "type": "row"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Percentage of targets successfully scraped by prometheus.scrape\ncomponents.\n\nThis metric is calculated by dividing the number of targets\nsuccessfully scraped by the total number of targets scraped,\nacross all the namespaces in the selected cluster.\n\nLow success rates can indicate a problem with scrape targets,\nstale service discovery, or Alloy misconfiguration.\n",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "percentunit"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 1
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum(up{job=~\"$job\", cluster=~\"$cluster\"})\n/\ncount (up{job=~\"$job\", cluster=~\"$cluster\"})\n",
+               "instant": false,
+               "legendFormat": "% of targets successfully scraped",
+               "range": true
+            }
+         ],
+         "title": "Scrape success rate in $cluster",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Duration of successful scrapes by prometheus.scrape components,\nacross all the namespaces in the selected cluster.\n\nThis metric should be below your configured scrape interval.\nHigh durations can indicate a problem with a scrape target or\na performance issue with Alloy.\n",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "s"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 1
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "quantile(0.99, scrape_duration_seconds{job=~\"$job\", cluster=~\"$cluster\"})\n",
+               "instant": false,
+               "legendFormat": "p99",
+               "range": true
+            },
+            {
+               "datasource": "${datasource}",
+               "expr": "quantile(0.95, scrape_duration_seconds{job=~\"$job\", cluster=~\"$cluster\"})\n",
+               "instant": false,
+               "legendFormat": "p95",
+               "range": true
+            },
+            {
+               "datasource": "${datasource}",
+               "expr": "quantile(0.50, scrape_duration_seconds{job=~\"$job\", cluster=~\"$cluster\"})\n",
+               "instant": false,
+               "legendFormat": "p50",
+               "range": true
+            }
+         ],
+         "title": "Scrape duration in $cluster",
+         "type": "timeseries"
+      },
+      {
+         "collapsed": false,
+         "datasource": "${datasource}",
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 11
+         },
+         "title": "prometheus.remote_write",
+         "type": "row"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Percentage of samples sent by prometheus.remote_write that succeeded.\n\nLow success rates can indicate a problem with Alloy or the remote storage.\n",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "percentunit"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 12
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "(\n    1 - \n    (\n        sum(rate(prometheus_remote_storage_samples_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval]))\n    )\n    /\n    (\n        sum(rate(prometheus_remote_storage_samples_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval]))\n    )\n)\n",
+               "instant": false,
+               "legendFormat": "% of samples successfully sent",
+               "range": true
+            }
+         ],
+         "title": "Remote write success rate in $cluster",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Latency of writes to the remote system made by\nprometheus.remote_write.\n",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "s"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 12
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "histogram_quantile(0.99, sum by (le) (\n  rate(prometheus_remote_storage_sent_batch_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n))\n",
+               "instant": false,
+               "legendFormat": "99th percentile",
+               "range": true
+            },
+            {
+               "datasource": "${datasource}",
+               "expr": "histogram_quantile(0.50, sum by (le) (\n  rate(prometheus_remote_storage_sent_batch_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n))\n",
+               "instant": false,
+               "legendFormat": "50th percentile",
+               "range": true
+            },
+            {
+               "datasource": "${datasource}",
+               "expr": "sum(rate(prometheus_remote_storage_sent_batch_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\"}[$__rate_interval])) /\nsum(rate(prometheus_remote_storage_sent_batch_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\"}[$__rate_interval]))\n",
+               "instant": false,
+               "legendFormat": "Average",
+               "range": true
+            }
+         ],
+         "title": "Write latency in $cluster",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "How far behind prometheus.remote_write from samples recently written\nto the WAL.\n\nEach endpoint prometheus.remote_write is configured to send metrics\nhas its own delay. The time shown here is the sum across all\nendpoints for the given component.\n\nIt is normal for the WAL delay to be within 1-3 scrape intervals. If\nthe WAL delay continues to increase beyond that amount, try\nincreasing the number of maximum shards.\n",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "s"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 0,
+            "y": 22
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by (instance, component_path, component_id) (\n  prometheus_remote_storage_highest_timestamp_in_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\"}\n  - ignoring(url, remote_name) group_right(instance)\n  prometheus_remote_storage_queue_highest_sent_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n)\n",
+               "instant": false,
+               "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
+               "range": true
+            }
+         ],
+         "title": "WAL delay",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Rate of data containing samples and metadata sent by\nprometheus.remote_write.\n",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 20,
+                  "gradientMode": "hue",
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 8,
+            "y": 22
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by (instance, component_path, component_id) (\n    rate(prometheus_remote_storage_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval]) +\n    rate(prometheus_remote_storage_metadata_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n)\n",
+               "instant": false,
+               "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
+               "range": true
+            }
+         ],
+         "title": "Data write throughput",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Total number of shards which are concurrently sending samples read\nfrom the Write-Ahead Log.\n\nShards are bound to a minimum and maximum, displayed on the graph.\nThe lowest minimum and the highest maximum across all clients is\nshown.\n\nEach client has its own set of shards, minimum shards, and maximum\nshards; filter to a specific URL to display more granular\ninformation.\n",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "none"
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Minimum"
+                  },
+                  "properties": [
+                     {
+                        "id": "custom.lineStyle",
+                        "value": {
+                           "dash": [
+                              10,
+                              15
+                           ],
+                           "fill": "dash"
+                        }
+                     },
+                     {
+                        "id": "custom.showPoints",
+                        "value": "never"
+                     },
+                     {
+                        "id": "custom.hideFrom",
+                        "value": {
+                           "legend": true,
+                           "tooltip": false,
+                           "viz": false
+                        }
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Maximum"
+                  },
+                  "properties": [
+                     {
+                        "id": "custom.lineStyle",
+                        "value": {
+                           "dash": [
+                              10,
+                              15
+                           ],
+                           "fill": "dash"
+                        }
+                     },
+                     {
+                        "id": "custom.showPoints",
+                        "value": "never"
+                     },
+                     {
+                        "id": "custom.hideFrom",
+                        "value": {
+                           "legend": true,
+                           "tooltip": false,
+                           "viz": false
+                        }
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 16,
+            "y": 22
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by (instance, component_path, component_id) (\n    prometheus_remote_storage_shards{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n)\n",
+               "instant": false,
+               "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
+               "range": true
+            },
+            {
+               "datasource": "${datasource}",
+               "expr": "min (\n    prometheus_remote_storage_shards_min{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n)\n",
+               "instant": false,
+               "legendFormat": "Minimum",
+               "range": true
+            },
+            {
+               "datasource": "${datasource}",
+               "expr": "max (\n    prometheus_remote_storage_shards_max{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n)\n",
+               "instant": false,
+               "legendFormat": "Maximum",
+               "range": true
+            }
+         ],
+         "title": "Shards",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Total outgoing samples sent by prometheus.remote_write.\n",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 20,
+                  "gradientMode": "hue",
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "cps"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 0,
+            "y": 32
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by (instance, component_path, component_id) (\n  rate(prometheus_remote_storage_samples_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n)\n",
+               "instant": false,
+               "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
+               "range": true
+            }
+         ],
+         "title": "Sent samples / second",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Rate of samples which prometheus.remote_write could not send due to\nnon-recoverable errors.\n",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 20,
+                  "gradientMode": "hue",
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "cps"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 8,
+            "y": 32
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by (instance, component_path, component_id) (\n  rate(prometheus_remote_storage_samples_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n)\n",
+               "instant": false,
+               "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
+               "range": true
+            }
+         ],
+         "title": "Failed samples / second",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Rate of samples which prometheus.remote_write attempted to resend\nafter receiving a recoverable error.\n",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 20,
+                  "gradientMode": "hue",
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "cps"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 16,
+            "y": 32
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by (instance, component_path, component_id) (\n  rate(prometheus_remote_storage_samples_retried_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n)\n",
+               "instant": false,
+               "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
+               "range": true
+            }
+         ],
+         "title": "Retried samples / second",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Total number of active series across all components.\n\nAn \"active series\" is a series that prometheus.remote_write recently\nreceived a sample for. Active series are garbage collected whenever a\ntruncation of the WAL occurs.\n\nNOTE: This metric is not available when using prometheus.write.queue component.\n",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "short"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 0,
+            "y": 42
+         },
+         "options": {
+            "legend": {
+               "showLegend": false
+            }
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum(prometheus_remote_write_wal_storage_active_series{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"})\n",
+               "instant": false,
+               "legendFormat": "Series",
+               "range": true
+            }
+         ],
+         "title": "Active series (total)",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Total number of active series which are currently being tracked by\nprometheus.remote_write components, with separate lines for each Alloy instance.\n\nAn \"active series\" is a series that prometheus.remote_write recently\nreceived a sample for. Active series are garbage collected whenever a\ntruncation of the WAL occurs.\n\nNOTE: This metric is not available when using prometheus.write.queue component.\n",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "short"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 8,
+            "y": 42
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "prometheus_remote_write_wal_storage_active_series{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_id!=\"\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n",
+               "instant": false,
+               "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
+               "range": true
+            }
+         ],
+         "title": "Active series (by instance/component)",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Total number of active series which are currently being tracked by\nprometheus.remote_write components, aggregated across all instances.\n\nAn \"active series\" is a series that prometheus.remote_write recently\nreceived a sample for. Active series are garbage collected whenever a\ntruncation of the WAL occurs.\n\nNOTE: This metric is not available when using prometheus.write.queue component.\n",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "short"
+            }
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 16,
+            "y": 42
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "sum by (component_path, component_id) (prometheus_remote_write_wal_storage_active_series{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_id!=\"\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"})\n",
+               "instant": false,
+               "legendFormat": "{{component_path}} {{component_id}}",
+               "range": true
+            }
+         ],
+         "title": "Active series (by component)",
+         "type": "timeseries"
+      }
+   ],
+   "refresh": "10s",
+   "schemaVersion": 36,
+   "tags": [
+      "alloy-mixin"
+   ],
+   "templating": {
+      "list": [
+         {
+            "label": "Data Source",
+            "name": "datasource",
+            "query": "prometheus",
+            "refresh": 1,
+            "sort": 2,
+            "type": "datasource"
+         },
+         {
+            "label": "Loki Data Source",
+            "name": "loki_datasource",
+            "query": "loki",
+            "refresh": 1,
+            "sort": 2,
+            "type": "datasource"
+         },
+         {
+            "datasource": "${datasource}",
+            "label": "cluster",
+            "name": "cluster",
+            "query": {
+               "query": "label_values(alloy_component_controller_running_components, cluster)\n",
+               "refId": "cluster"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         },
+         {
+            "datasource": "${datasource}",
+            "label": "namespace",
+            "name": "namespace",
+            "query": {
+               "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
+               "refId": "namespace"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         },
+         {
+            "datasource": "${datasource}",
+            "label": "job",
+            "name": "job",
+            "query": {
+               "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
+               "refId": "job"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         },
+         {
+            "allValue": ".*",
+            "datasource": "${datasource}",
+            "includeAll": true,
+            "label": "instance",
+            "multi": true,
+            "name": "instance",
+            "query": {
+               "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}, instance)\n",
+               "refId": "instance"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         },
+         {
+            "allValue": ".*",
+            "datasource": "${datasource}",
+            "includeAll": true,
+            "label": "component_path",
+            "multi": true,
+            "name": "component_path",
+            "query": {
+               "query": "label_values(prometheus_remote_write_wal_samples_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_id=~\"prometheus.remote_write.*\", component_path=~\".*\"}, component_path)\n",
+               "refId": "component_path"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         },
+         {
+            "allValue": ".*",
+            "datasource": "${datasource}",
+            "includeAll": true,
+            "label": "component",
+            "multi": true,
+            "name": "component",
+            "query": {
+               "query": "label_values(prometheus_remote_write_wal_samples_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_id=~\"prometheus.remote_write.*\"}, component_id)\n",
+               "refId": "component"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         },
+         {
+            "allValue": ".*",
+            "datasource": "${datasource}",
+            "includeAll": true,
+            "label": "url",
+            "multi": true,
+            "name": "url",
+            "query": {
+               "query": "label_values(prometheus_remote_storage_sent_batch_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", job=\"$job\", instance=~\"$instance\", component_id=~\"$component\"}, url)\n",
+               "refId": "url"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         }
+      ]
+   },
+   "time": {
+      "from": "now-1h",
+      "to": "now"
+   },
+   "timepicker": {
+      "refresh_intervals": [
+         "5s",
+         "10s",
+         "30s",
+         "1m",
+         "5m",
+         "15m",
+         "30m",
+         "1h",
+         "2h",
+         "1d"
+      ],
+      "time_options": [
+         "5m",
+         "15m",
+         "1h",
+         "6h",
+         "12h",
+         "24h",
+         "2d",
+         "7d",
+         "30d",
+         "90d"
+      ]
+   },
+   "timezone": "utc",
+   "title": "Alloy / Prometheus Components",
+   "uid": "e324cc55567d7f3a8e32860ff8e6d0d9"
+}

--- a/operations/alloy-mixin/rendered/dashboards/alloy-resources.json
+++ b/operations/alloy-mixin/rendered/dashboards/alloy-resources.json
@@ -1,0 +1,341 @@
+{
+   "annotations": {
+      "list": [
+         {
+            "datasource": "$loki_datasource",
+            "enable": true,
+            "expr": "{cluster=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "instant": false,
+            "name": "Deployments",
+            "titleFormat": "{{cluster}}/{{namespace}}"
+         }
+      ]
+   },
+   "graphTooltip": 1,
+   "links": [
+      {
+         "asDropdown": true,
+         "icon": "external link",
+         "includeVars": true,
+         "keepTime": true,
+         "tags": [
+            "alloy-mixin"
+         ],
+         "targetBlank": false,
+         "title": "Dashboards",
+         "type": "dashboards"
+      }
+   ],
+   "panels": [
+      {
+         "datasource": "${datasource}",
+         "description": "CPU usage of the Alloy process relative to 1 CPU core.\n\nFor example, 100% means using one entire CPU core.\n",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "percentunit"
+            }
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 0
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "rate(alloy_resources_process_cpu_seconds_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+               "instant": false,
+               "legendFormat": "{{instance}}",
+               "range": true
+            }
+         ],
+         "title": "CPU usage",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Resident memory size of the Alloy process.\n",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "decbytes"
+            }
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 0
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "alloy_resources_process_resident_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+               "instant": false,
+               "legendFormat": "{{instance}}",
+               "range": true
+            }
+         ],
+         "title": "Memory (RSS)",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Rate at which the Alloy process performs garbage collections.\n",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "drawStyle": "points",
+                  "pointSize": 3
+               },
+               "unit": "ops"
+            }
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 8
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "rate(go_gc_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[5m])\nand on(instance)\nalloy_build_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+               "instant": false,
+               "legendFormat": "{{instance}}",
+               "range": true
+            }
+         ],
+         "title": "Garbage collections",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Number of goroutines which are running in parallel. An infinitely\ngrowing number of these indicates a goroutine leak.\n",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "none"
+            }
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 8
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "go_goroutines{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\nand on(instance)\nalloy_build_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+               "instant": false,
+               "legendFormat": "{{instance}}",
+               "range": true
+            }
+         ],
+         "title": "Goroutines",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Heap memory currently in use by the Alloy process.\n",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "decbytes"
+            }
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 8
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\nand on(instance)\nalloy_build_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+               "instant": false,
+               "legendFormat": "{{instance}}",
+               "range": true
+            }
+         ],
+         "title": "Memory (heap inuse)",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Rate of data received across all network interfaces for the machine\nAlloy is running on.\n\nData shown here is across all running processes and not exclusive to\nthe running Alloy process.\n",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 30,
+                  "gradientMode": "none",
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 16
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "rate(alloy_resources_machine_rx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+               "instant": false,
+               "legendFormat": "{{instance}}",
+               "range": true
+            }
+         ],
+         "title": "Network receive bandwidth",
+         "type": "timeseries"
+      },
+      {
+         "datasource": "${datasource}",
+         "description": "Rate of data sent across all network interfaces for the machine\nAlloy is running on.\n\nData shown here is across all running processes and not exclusive to\nthe running Alloy process.\n",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 30,
+                  "gradientMode": "none",
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 16
+         },
+         "targets": [
+            {
+               "datasource": "${datasource}",
+               "expr": "rate(alloy_resources_machine_tx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+               "instant": false,
+               "legendFormat": "{{instance}}",
+               "range": true
+            }
+         ],
+         "title": "Network send bandwidth",
+         "type": "timeseries"
+      }
+   ],
+   "refresh": "10s",
+   "schemaVersion": 36,
+   "tags": [
+      "alloy-mixin"
+   ],
+   "templating": {
+      "list": [
+         {
+            "label": "Data Source",
+            "name": "datasource",
+            "query": "prometheus",
+            "refresh": 1,
+            "sort": 2,
+            "type": "datasource"
+         },
+         {
+            "label": "Loki Data Source",
+            "name": "loki_datasource",
+            "query": "loki",
+            "refresh": 1,
+            "sort": 2,
+            "type": "datasource"
+         },
+         {
+            "datasource": "${datasource}",
+            "label": "cluster",
+            "name": "cluster",
+            "query": {
+               "query": "label_values(alloy_component_controller_running_components, cluster)\n",
+               "refId": "cluster"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         },
+         {
+            "datasource": "${datasource}",
+            "label": "namespace",
+            "name": "namespace",
+            "query": {
+               "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
+               "refId": "namespace"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         },
+         {
+            "datasource": "${datasource}",
+            "label": "job",
+            "name": "job",
+            "query": {
+               "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
+               "refId": "job"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         },
+         {
+            "allValue": ".*",
+            "datasource": "${datasource}",
+            "includeAll": true,
+            "label": "instance",
+            "multi": true,
+            "name": "instance",
+            "query": {
+               "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}, instance)\n",
+               "refId": "instance"
+            },
+            "refresh": 2,
+            "sort": 2,
+            "type": "query"
+         }
+      ]
+   },
+   "time": {
+      "from": "now-1h",
+      "to": "now"
+   },
+   "timepicker": {
+      "refresh_intervals": [
+         "5s",
+         "10s",
+         "30s",
+         "1m",
+         "5m",
+         "15m",
+         "30m",
+         "1h",
+         "2h",
+         "1d"
+      ],
+      "time_options": [
+         "5m",
+         "15m",
+         "1h",
+         "6h",
+         "12h",
+         "24h",
+         "2d",
+         "7d",
+         "30d",
+         "90d"
+      ]
+   },
+   "timezone": "utc",
+   "title": "Alloy / Resources",
+   "uid": "d6a8574c31f3d7cb8f1345ec84d15a67"
+}


### PR DESCRIPTION
#### PR Description
This PR introduces a `make` target to render the Alloy Jsonnet mixin into Grafana dashboards and Prometheus alert rules. It also adds a GitHub Actions workflow to verify that these rendered outputs are always up-to-date and a `README.md` file explaining how to use, import, provision, and customize the generated assets.


#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [ ] CHANGELOG.md updated
-   [x] Documentation added
-   [ ] Tests updated
-   [ ] Config converters updated