### PR TITLE
database_observability: fix missing db_instance_identifier for Azure instances

### DIFF
--- a/internal/component/database_observability/mysql/collector/connection_info.go
+++ b/internal/component/database_observability/mysql/collector/connection_info.go
@@ -79,6 +79,10 @@ func (c *ConnectionInfo) Start(ctx context.Context) error {
 				dbInstanceIdentifier = strings.TrimPrefix(resource, "db:")
 			}
 		}
+		if c.CloudProvider.Azure != nil {
+			providerName = "azure"
+			dbInstanceIdentifier = c.CloudProvider.Azure.Resource
+		}
 	} else {
 		cfg, err := mysql.ParseDSN(c.DSN)
 		if err != nil {

--- a/internal/component/database_observability/mysql/collector/connection_info_test.go
+++ b/internal/component/database_observability/mysql/collector/connection_info_test.go
@@ -58,6 +58,17 @@ func TestConnectionInfo(t *testing.T) {
 			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "products-db", "mysql", "8.0.32", "some-account-123", "aws", "us-east-1"),
 		},
 		{
+			name:          "Azure with cloud provider info supplied",
+			dsn:           "user:pass@tcp(products-db.mysql.database.azure.com:3306)/schema",
+			engineVersion: "15.4",
+			cloudProvider: &database_observability.CloudProvider{
+				Azure: &database_observability.AzureCloudProviderInfo{
+					Resource: "products-db",
+				},
+			},
+			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "products-db", "mysql", "15.4", "unknown", "azure", "unknown"),
+		},
+		{
 			name:            "Azure flexibleservers dsn",
 			dsn:             "user:pass@tcp(products-db.mysql.database.azure.com:3306)/schema",
 			engineVersion:   "8.0.32",

--- a/internal/component/database_observability/postgres/collector/connection_info.go
+++ b/internal/component/database_observability/postgres/collector/connection_info.go
@@ -80,6 +80,10 @@ func (c *ConnectionInfo) Start(ctx context.Context) error {
 				dbInstanceIdentifier = strings.TrimPrefix(resource, "db:")
 			}
 		}
+		if c.CloudProvider.Azure != nil {
+			providerName = "azure"
+			dbInstanceIdentifier = c.CloudProvider.Azure.Resource
+		}
 	} else {
 		parts, err := ParseURL(c.DSN)
 		if err != nil {

--- a/internal/component/database_observability/postgres/collector/connection_info_test.go
+++ b/internal/component/database_observability/postgres/collector/connection_info_test.go
@@ -60,6 +60,17 @@ func TestConnectionInfo(t *testing.T) {
 			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "products-db", "postgres", "15.4", "some-account-123", "aws", "us-east-1"),
 		},
 		{
+			name:          "Azure with cloud provider info supplied",
+			dsn:           "postgres://user:pass@products-db.postgres.database.azure.com:5432/mydb",
+			engineVersion: "15.4",
+			cloudProvider: &database_observability.CloudProvider{
+				Azure: &database_observability.AzureCloudProviderInfo{
+					Resource: "products-db",
+				},
+			},
+			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "products-db", "postgres", "15.4", "unknown", "azure", "unknown"),
+		},
+		{
 			name:            "Azure flexibleservers dsn",
 			dsn:             "postgres://user:pass@products-db.postgres.database.azure.com:5432/mydb",
 			engineVersion:   "15.4",


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Fixes a bug introduced in https://github.com/grafana/alloy/pull/4942 where `db_instance_identifier` label was being set to `unknown` for Azure databases. 
Desired behaviour is for `db_instance_identifier` to be set to the Azure database resource name.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
