### PR TITLE
fix: preserve meta labels in loki.source.podlogs

### DIFF
--- a/internal/component/loki/source/kubernetes/kubernetes.go
+++ b/internal/component/loki/source/kubernetes/kubernetes.go
@@ -200,7 +200,7 @@ func (c *Component) resyncTargets(targets []discovery.Target) {
 			level.Error(c.log).Log("msg", "failed to process input target", "target", lset.String(), "err", err)
 			continue
 		}
-		tailTargets = append(tailTargets, kubetail.NewTarget(lset, processed))
+		tailTargets = append(tailTargets, kubetail.NewTarget(lset, processed, false))
 	}
 
 	// This will never fail because it only fails if the context gets canceled.

--- a/internal/component/loki/source/podlogs/reconciler.go
+++ b/internal/component/loki/source/podlogs/reconciler.go
@@ -351,7 +351,7 @@ func (r *reconciler) reconcilePodLogs(ctx context.Context, cli client.Client, po
 				return
 			}
 
-			target := kubetail.NewTarget(targetLabels.Copy(), finalLabels)
+			target := kubetail.NewTarget(targetLabels.Copy(), finalLabels, preserveMetaLabels)
 			if processedLabels.Len() != 0 {
 				targets = append(targets, target)
 			}


### PR DESCRIPTION
#### PR Description
In https://github.com/grafana/alloy/pull/4606 the intention was to add a config option for `loki.source.podlogs` to preserve meta labels to that they could be used in other components.

This do not work because the tailer was stripping all public labels (`__`). So we need to propagate this setting and handle it correctly.

#### Which issue(s) this PR fixes

Fixes #5081

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated

BEGIN_COMMIT_OVERRIDE
fix: Preserve meta labels in loki.source.podlogs (#5097)
END_COMMIT_OVERRIDE