### PR TITLE
ci: update build image to v0.1.24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
   build_linux:
     name: Build on Linux
     runs-on: github-hosted-ubuntu-x64-large
-    container: grafana/alloy-build-image:v0.1.23@sha256:89dad4df5afe167898860bfa06c2eea290f4da0c2cff668fdf43299ddca867dc
+    container: grafana/alloy-build-image:v0.1.24@sha256:b9e3a399fbe04179cf26896c8efdc65ad294a425e955a3be1cbd0885d87d7025
     strategy:
       matrix:
         os: [linux]
@@ -42,7 +42,7 @@ jobs:
   build_linux_boringcrypto:
     name: Build on Linux (boringcrypto)
     runs-on: github-hosted-ubuntu-x64-large
-    container: grafana/alloy-build-image:v0.1.23-boringcrypto@sha256:ea758e67ff9feff60a3ad3c7ac803a2b0061abbbe3061a765712283035f8d2d3
+    container: grafana/alloy-build-image:v0.1.24-boringcrypto@sha256:6af93ad037707c36bc86017e0534a719800b498a31fc981bb183a54ea0403b44
     strategy:
       matrix:
         os: [linux]
@@ -123,7 +123,7 @@ jobs:
   build_freebsd:
     name: Build on FreeBSD (AMD64)
     runs-on: github-hosted-ubuntu-x64-large
-    container: grafana/alloy-build-image:v0.1.23@sha256:89dad4df5afe167898860bfa06c2eea290f4da0c2cff668fdf43299ddca867dc
+    container: grafana/alloy-build-image:v0.1.24@sha256:b9e3a399fbe04179cf26896c8efdc65ad294a425e955a3be1cbd0885d87d7025
     steps:
     - name: Checkout code
       uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1

--- a/.github/workflows/publish-alloy-linux.yml
+++ b/.github/workflows/publish-alloy-linux.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   publish_linux_container:
     name: Publish Alloy Linux container
-    container: grafana/alloy-build-image:v0.1.23@sha256:89dad4df5afe167898860bfa06c2eea290f4da0c2cff668fdf43299ddca867dc
+    container: grafana/alloy-build-image:v0.1.24@sha256:b9e3a399fbe04179cf26896c8efdc65ad294a425e955a3be1cbd0885d87d7025
     runs-on:
       labels: github-hosted-ubuntu-x64-large
     permissions:

--- a/.github/workflows/release-publish-alloy-artifacts.yml
+++ b/.github/workflows/release-publish-alloy-artifacts.yml
@@ -33,7 +33,7 @@ jobs:
 
   build_alloy:
     name: Build Alloy
-    container: grafana/alloy-build-image:v0.1.23@sha256:89dad4df5afe167898860bfa06c2eea290f4da0c2cff668fdf43299ddca867dc
+    container: grafana/alloy-build-image:v0.1.24@sha256:b9e3a399fbe04179cf26896c8efdc65ad294a425e955a3be1cbd0885d87d7025
     runs-on:
       labels: github-hosted-ubuntu-x64-large
     needs:
@@ -115,7 +115,7 @@ jobs:
 
   build_alloy_windows_installer:
     name: Build Alloy Windows installer with signed executables
-    container: grafana/alloy-build-image:v0.1.23@sha256:89dad4df5afe167898860bfa06c2eea290f4da0c2cff668fdf43299ddca867dc
+    container: grafana/alloy-build-image:v0.1.24@sha256:b9e3a399fbe04179cf26896c8efdc65ad294a425e955a3be1cbd0885d87d7025
     runs-on:
       labels: github-hosted-ubuntu-x64-large
     needs:
@@ -193,7 +193,7 @@ jobs:
 
   upload_release_artifacts:
     name: Upload release artifacts
-    container: grafana/alloy-build-image:v0.1.23@sha256:89dad4df5afe167898860bfa06c2eea290f4da0c2cff668fdf43299ddca867dc
+    container: grafana/alloy-build-image:v0.1.24@sha256:b9e3a399fbe04179cf26896c8efdc65ad294a425e955a3be1cbd0885d87d7025
     runs-on:
       labels: github-hosted-ubuntu-x64-large
     needs:

--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -15,7 +15,7 @@ jobs:
     name: Test (Full)
     runs-on: ubuntu-latest-8-cores
     container:
-      image: grafana/alloy-build-image:v0.1.23@sha256:89dad4df5afe167898860bfa06c2eea290f4da0c2cff668fdf43299ddca867dc
+      image: grafana/alloy-build-image:v0.1.24@sha256:b9e3a399fbe04179cf26896c8efdc65ad294a425e955a3be1cbd0885d87d7025
       volumes:
         - /var/run/docker.sock
     steps:

--- a/.github/workflows/test_linux_system_packages.yml
+++ b/.github/workflows/test_linux_system_packages.yml
@@ -17,7 +17,7 @@ jobs:
     name: Test Linux system packages
     runs-on: ubuntu-latest
     container:
-      image: grafana/alloy-build-image:v0.1.23@sha256:89dad4df5afe167898860bfa06c2eea290f4da0c2cff668fdf43299ddca867dc
+      image: grafana/alloy-build-image:v0.1.24@sha256:b9e3a399fbe04179cf26896c8efdc65ad294a425e955a3be1cbd0885d87d7025
       volumes:
         - /var/run/docker.sock
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
 # in environment variables.
 
-FROM --platform=$BUILDPLATFORM grafana/alloy-build-image:v0.1.23 AS ui-build
+FROM --platform=$BUILDPLATFORM grafana/alloy-build-image:v0.1.24 AS ui-build
 ARG BUILDPLATFORM
 COPY ./internal/web/ui /ui
 WORKDIR /ui
@@ -12,7 +12,7 @@ RUN --mount=type=cache,target=/ui/node_modules,sharing=locked \
     npm install                                               \
     && npm run build
 
-FROM --platform=$BUILDPLATFORM grafana/alloy-build-image:v0.1.23 AS build
+FROM --platform=$BUILDPLATFORM grafana/alloy-build-image:v0.1.24 AS build
 
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM

--- a/tools/make/build-container.mk
+++ b/tools/make/build-container.mk
@@ -34,7 +34,7 @@
 # variable names should be passed through to the container.
 
 USE_CONTAINER       ?= 0
-BUILD_IMAGE_VERSION ?= v0.1.23
+BUILD_IMAGE_VERSION ?= v0.1.24
 BUILD_IMAGE         ?= grafana/alloy-build-image:$(BUILD_IMAGE_VERSION)
 DOCKER_OPTS         ?= -it
 


### PR DESCRIPTION
Build image hashes:

https://hub.docker.com/layers/grafana/alloy-build-image/v0.1.24/images/sha256-f456dbaa73e5e3ae4f3d4eb3ce6981df5fdb5a68ceaa7c3ed3645540e9f73e49

https://hub.docker.com/layers/grafana/alloy-build-image/v0.1.24-boringcrypto/images/sha256-82691bddf00c4ac0dfc5c27b8893c2c461bc9fac282226bf9350511d8ad358ac

