### PR TITLE
feat: add targets API endpoint and UI page

### DIFF
--- a/internal/component/prometheus/scrape/scrape.go
+++ b/internal/component/prometheus/scrape/scrape.go
@@ -626,6 +626,38 @@ func (c *Component) DebugInfo() interface{} {
 	}
 }
 
+// GetTargets implements component.TargetsProvider
+func (c *Component) GetTargets() []component.TargetInfo {
+	targets := c.scraper.TargetsActive()
+	var result []component.TargetInfo
+
+	for job, jobTargets := range targets {
+		for _, st := range jobTargets {
+			if st == nil {
+				continue
+			}
+			var lastError string
+			if st.LastError() != nil {
+				lastError = st.LastError().Error()
+			}
+
+			lb := labels.NewBuilder(labels.EmptyLabels())
+			dlb := labels.NewBuilder(labels.EmptyLabels())
+			result = append(result, component.TargetInfo{
+				JobName:            job,
+				Endpoint:           st.URL().String(),
+				State:              string(st.Health()),
+				Labels:             st.Labels(lb).Map(),
+				DiscoveredLabels:   st.DiscoveredLabels(dlb).Map(),
+				LastScrape:         st.LastScrape(),
+				LastScrapeDuration: st.LastScrapeDuration(),
+				LastError:          lastError,
+			})
+		}
+	}
+	return result
+}
+
 func (c *Component) populatePromLabels(targets []discovery.Target, jobName string, args Arguments) []*scrape.Target {
 	// We need to call scrape.TargetsFromGroup to reuse the rather complex logic of populating labels on targets.
 	allTargets := make([]*scrape.Target, 0, len(targets))

--- a/internal/component/pyroscope/scrape/scrape.go
+++ b/internal/component/pyroscope/scrape/scrape.go
@@ -398,3 +398,36 @@ func (c *Component) DebugInfo() interface{} {
 
 	return scrape.ScraperStatus{TargetStatus: res}
 }
+
+// GetTargets implements component.TargetsProvider
+func (c *Component) GetTargets() []component.TargetInfo {
+	var result []component.TargetInfo
+
+	c.mut.RLock()
+	jobName := c.args.JobName
+	if jobName == "" {
+		jobName = c.opts.ID
+	}
+	c.mut.RUnlock()
+
+	for _, st := range c.scraper.TargetsActive() {
+		if st == nil {
+			continue
+		}
+		var lastError string
+		if st.LastError() != nil {
+			lastError = st.LastError().Error()
+		}
+
+		result = append(result, component.TargetInfo{
+			JobName:            jobName,
+			Endpoint:           st.URL(),
+			State:              string(st.Health()),
+			Labels:             st.allLabels.Map(),
+			LastScrape:         st.LastScrape(),
+			LastScrapeDuration: st.LastScrapeDuration(),
+			LastError:          lastError,
+		})
+	}
+	return result
+}

--- a/internal/component/targets.go
+++ b/internal/component/targets.go
@@ -1,0 +1,22 @@
+package component
+
+import "time"
+
+// TargetsProvider is implemented by components that have scrape targets.
+// Components like prometheus.scrape and pyroscope.scrape implement this
+// interface to expose their target status information via the API.
+type TargetsProvider interface {
+	GetTargets() []TargetInfo
+}
+
+// TargetInfo represents the status of a single scrape target.
+type TargetInfo struct {
+	JobName            string            // Name of the scrape job
+	Endpoint           string            // URL being scraped
+	State              string            // Target state: up, down, or unknown
+	Labels             map[string]string // Labels applied to scraped metrics
+	DiscoveredLabels   map[string]string // Labels discovered during service discovery
+	LastScrape         time.Time         // Timestamp of the last scrape attempt
+	LastScrapeDuration time.Duration     // Duration of the last scrape
+	LastError          string            // Error from the last scrape, empty if successful
+}

--- a/internal/web/api/api.go
+++ b/internal/web/api/api.go
@@ -57,6 +57,11 @@ func (a *AlloyAPI) RegisterRoutes(urlPrefix string, r *mux.Router) {
 
 	r.Handle(path.Join(urlPrefix, "/graph"), graph(a.alloy, a.CallbackManager, a.logger))
 	r.Handle(path.Join(urlPrefix, "/graph/{moduleID:.+}"), graph(a.alloy, a.CallbackManager, a.logger))
+
+	// Targets endpoints for scrape target status
+	r.Handle(path.Join(urlPrefix, "/targets"), httputil.CompressionHandler{Handler: getTargetsHandler(a.alloy)})
+	r.Handle(path.Join(urlPrefix, "/remotecfg/targets"), httputil.CompressionHandler{Handler: getTargetsHandlerRemoteCfg(a.alloy)})
+	r.Handle(path.Join(urlPrefix, "/modules/{moduleID:.+}/targets"), httputil.CompressionHandler{Handler: getTargetsHandler(a.alloy)})
 }
 
 func listComponentsHandler(host service.Host) http.HandlerFunc {

--- a/internal/web/api/targets.go
+++ b/internal/web/api/targets.go
@@ -1,0 +1,134 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/grafana/alloy/internal/component"
+	"github.com/grafana/alloy/internal/service"
+	"github.com/grafana/alloy/internal/service/remotecfg"
+)
+
+// TargetsResponse represents the API response for targets endpoint.
+type TargetsResponse struct {
+	Status string       `json:"status"`
+	Data   []TargetData `json:"data"`
+}
+
+// TargetData represents information about a single scrape target.
+type TargetData struct {
+	ComponentID        string            `json:"component_id"`
+	JobName            string            `json:"job"`
+	URL                string            `json:"url"`
+	Health             string            `json:"health"`
+	Labels             map[string]string `json:"labels"`
+	DiscoveredLabels   map[string]string `json:"discovered_labels,omitempty"`
+	LastScrape         string            `json:"last_scrape"`
+	LastScrapeDuration string            `json:"last_scrape_duration,omitempty"`
+	LastError          string            `json:"last_error,omitempty"`
+}
+
+func getTargetsHandler(host service.Host) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		getTargetsHandlerInternal(host, w, r)
+	}
+}
+
+func getTargetsHandlerRemoteCfg(host service.Host) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		remoteCfgHost, err := remotecfg.GetHost(host)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		getTargetsHandlerInternal(remoteCfgHost, w, r)
+	}
+}
+
+func getTargetsHandlerInternal(host service.Host, w http.ResponseWriter, r *http.Request) {
+	var moduleID string
+	if vars := mux.Vars(r); vars != nil {
+		moduleID = vars["moduleID"]
+	}
+
+	// Optional query parameters for filtering
+	jobFilter := r.URL.Query().Get("job")
+	healthFilter := r.URL.Query().Get("health")
+	componentFilter := r.URL.Query().Get("component")
+
+	components, err := host.ListComponents(moduleID, component.InfoOptions{
+		GetHealth: false,
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var allTargets []TargetData
+
+	for _, info := range components {
+		if info.Component == nil {
+			continue
+		}
+
+		// Filter by component ID if specified
+		componentID := info.ID.String()
+		if componentFilter != "" && componentID != componentFilter {
+			continue
+		}
+
+		// Check if component implements TargetsProvider
+		provider, ok := info.Component.(component.TargetsProvider)
+		if !ok {
+			continue
+		}
+
+		targets := provider.GetTargets()
+		for _, t := range targets {
+			// Apply filters
+			if jobFilter != "" && t.JobName != jobFilter {
+				continue
+			}
+			if healthFilter != "" && t.State != healthFilter {
+				continue
+			}
+
+			var lastScrape string
+			if !t.LastScrape.IsZero() {
+				lastScrape = t.LastScrape.Format(time.RFC3339)
+			}
+
+			var lastScrapeDuration string
+			if t.LastScrapeDuration > 0 {
+				lastScrapeDuration = t.LastScrapeDuration.String()
+			}
+
+			allTargets = append(allTargets, TargetData{
+				ComponentID:        componentID,
+				JobName:            t.JobName,
+				URL:                t.Endpoint,
+				Health:             t.State,
+				Labels:             t.Labels,
+				DiscoveredLabels:   t.DiscoveredLabels,
+				LastScrape:         lastScrape,
+				LastScrapeDuration: lastScrapeDuration,
+				LastError:          t.LastError,
+			})
+		}
+	}
+
+	response := TargetsResponse{
+		Status: "success",
+		Data:   allTargets,
+	}
+
+	bb, err := json.Marshal(response)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(bb)
+}

--- a/internal/web/api/targets_test.go
+++ b/internal/web/api/targets_test.go
@@ -1,0 +1,282 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/grafana/alloy/internal/component"
+	"github.com/grafana/alloy/internal/service"
+	"github.com/stretchr/testify/require"
+)
+
+type mockHost struct {
+	components []*component.Info
+}
+
+func (m *mockHost) GetComponent(id component.ID, opts component.InfoOptions) (*component.Info, error) {
+	for _, c := range m.components {
+		if c.ID.String() == id.String() {
+			return c, nil
+		}
+	}
+	return nil, component.ErrComponentNotFound
+}
+
+func (m *mockHost) ListComponents(moduleID string, opts component.InfoOptions) ([]*component.Info, error) {
+	return m.components, nil
+}
+
+func (m *mockHost) GetService(name string) (service.Service, bool) {
+	return nil, false
+}
+
+func (m *mockHost) GetServiceConsumers(serviceName string) []service.Consumer {
+	return nil
+}
+
+func (m *mockHost) NewController(id string) service.Controller {
+	return nil
+}
+
+type mockTargetsProvider struct {
+	targets []component.TargetInfo
+}
+
+func (m *mockTargetsProvider) GetTargets() []component.TargetInfo {
+	return m.targets
+}
+
+func (m *mockTargetsProvider) Run(ctx context.Context) error { return nil }
+func (m *mockTargetsProvider) Update(args component.Arguments) error { return nil }
+
+func TestGetTargetsHandler_NoComponents(t *testing.T) {
+	host := &mockHost{components: []*component.Info{}}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v0/targets", nil)
+	w := httptest.NewRecorder()
+
+	handler := getTargetsHandler(host)
+	handler.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var response TargetsResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	require.Equal(t, "success", response.Status)
+	require.Empty(t, response.Data)
+}
+
+func TestGetTargetsHandler_WithTargets(t *testing.T) {
+	provider := &mockTargetsProvider{
+		targets: []component.TargetInfo{
+			{
+				JobName:            "test-job",
+				Endpoint:           "http://localhost:9090/metrics",
+				State:              "up",
+				Labels:             map[string]string{"job": "test-job", "instance": "localhost:9090"},
+				DiscoveredLabels:   map[string]string{"__address__": "localhost:9090"},
+				LastScrape:         time.Now().Add(-30 * time.Second),
+				LastScrapeDuration: 100 * time.Millisecond,
+				LastError:          "",
+			},
+			{
+				JobName:            "test-job",
+				Endpoint:           "http://localhost:9091/metrics",
+				State:              "down",
+				Labels:             map[string]string{"job": "test-job", "instance": "localhost:9091"},
+				DiscoveredLabels:   map[string]string{"__address__": "localhost:9091"},
+				LastScrape:         time.Now().Add(-60 * time.Second),
+				LastScrapeDuration: 5 * time.Second,
+				LastError:          "connection refused",
+			},
+		},
+	}
+
+	host := &mockHost{
+		components: []*component.Info{
+			{
+				ID:            component.ID{LocalID: "prometheus.scrape.default"},
+				ComponentName: "prometheus.scrape",
+				Component:     provider,
+			},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v0/targets", nil)
+	w := httptest.NewRecorder()
+
+	handler := getTargetsHandler(host)
+	handler.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var response TargetsResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	require.Equal(t, "success", response.Status)
+	require.Len(t, response.Data, 2)
+
+	// Check first target
+	require.Equal(t, "prometheus.scrape.default", response.Data[0].ComponentID)
+	require.Equal(t, "test-job", response.Data[0].JobName)
+	require.Equal(t, "http://localhost:9090/metrics", response.Data[0].URL)
+	require.Equal(t, "up", response.Data[0].Health)
+	require.Equal(t, "100ms", response.Data[0].LastScrapeDuration)
+	require.Empty(t, response.Data[0].LastError)
+
+	// Check second target
+	require.Equal(t, "down", response.Data[1].Health)
+	require.Equal(t, "connection refused", response.Data[1].LastError)
+}
+
+func TestGetTargetsHandler_FilterByJob(t *testing.T) {
+	provider := &mockTargetsProvider{
+		targets: []component.TargetInfo{
+			{
+				JobName:  "job-a",
+				Endpoint: "http://localhost:9090/metrics",
+				State:    "up",
+			},
+			{
+				JobName:  "job-b",
+				Endpoint: "http://localhost:9091/metrics",
+				State:    "up",
+			},
+		},
+	}
+
+	host := &mockHost{
+		components: []*component.Info{
+			{
+				ID:            component.ID{LocalID: "prometheus.scrape.default"},
+				ComponentName: "prometheus.scrape",
+				Component:     provider,
+			},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v0/targets?job=job-a", nil)
+	w := httptest.NewRecorder()
+
+	handler := getTargetsHandler(host)
+	handler.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var response TargetsResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	require.Len(t, response.Data, 1)
+	require.Equal(t, "job-a", response.Data[0].JobName)
+}
+
+func TestGetTargetsHandler_FilterByHealth(t *testing.T) {
+	provider := &mockTargetsProvider{
+		targets: []component.TargetInfo{
+			{
+				JobName:  "test-job",
+				Endpoint: "http://localhost:9090/metrics",
+				State:    "up",
+			},
+			{
+				JobName:  "test-job",
+				Endpoint: "http://localhost:9091/metrics",
+				State:    "down",
+			},
+		},
+	}
+
+	host := &mockHost{
+		components: []*component.Info{
+			{
+				ID:            component.ID{LocalID: "prometheus.scrape.default"},
+				ComponentName: "prometheus.scrape",
+				Component:     provider,
+			},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v0/targets?health=down", nil)
+	w := httptest.NewRecorder()
+
+	handler := getTargetsHandler(host)
+	handler.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var response TargetsResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	require.Len(t, response.Data, 1)
+	require.Equal(t, "down", response.Data[0].Health)
+}
+
+func TestGetTargetsHandler_FilterByComponent(t *testing.T) {
+	providerA := &mockTargetsProvider{
+		targets: []component.TargetInfo{
+			{
+				JobName:  "job-a",
+				Endpoint: "http://localhost:9090/metrics",
+				State:    "up",
+			},
+		},
+	}
+	providerB := &mockTargetsProvider{
+		targets: []component.TargetInfo{
+			{
+				JobName:  "job-b",
+				Endpoint: "http://localhost:9091/metrics",
+				State:    "up",
+			},
+		},
+	}
+
+	host := &mockHost{
+		components: []*component.Info{
+			{
+				ID:            component.ID{LocalID: "prometheus.scrape.a"},
+				ComponentName: "prometheus.scrape",
+				Component:     providerA,
+			},
+			{
+				ID:            component.ID{LocalID: "prometheus.scrape.b"},
+				ComponentName: "prometheus.scrape",
+				Component:     providerB,
+			},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v0/targets?component=prometheus.scrape.a", nil)
+	w := httptest.NewRecorder()
+
+	handler := getTargetsHandler(host)
+	handler.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var response TargetsResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	require.Len(t, response.Data, 1)
+	require.Equal(t, "prometheus.scrape.a", response.Data[0].ComponentID)
+	require.Equal(t, "job-a", response.Data[0].JobName)
+}
+
+func TestTargetsRouteRegistration(t *testing.T) {
+	host := &mockHost{components: []*component.Info{}}
+	api := NewAlloyAPI(host, nil, nil)
+
+	r := mux.NewRouter()
+	api.RegisterRoutes("/api/v0", r)
+
+	// Test that the route is registered
+	req := httptest.NewRequest(http.MethodGet, "/api/v0/targets", nil)
+	match := &mux.RouteMatch{}
+	require.True(t, r.Match(req, match))
+}

--- a/internal/web/ui/src/Router.tsx
+++ b/internal/web/ui/src/Router.tsx
@@ -8,6 +8,7 @@ import PageLiveDebugging from './pages/LiveDebugging';
 import PageComponentList from './pages/PageComponentList';
 import PageRemoteComponentList from './pages/PageRemoteComponentList';
 import RemoteComponentDetailPage from './pages/RemoteComponentDetailPage';
+import TargetsPage from './pages/TargetsPage';
 
 interface Props {
   basePath: string;
@@ -27,6 +28,7 @@ const Router = ({ basePath }: Props) => {
 
           <Route path="/graph/*" element={<Graph />} />
           <Route path="/clustering" element={<PageClusteringPeers />} />
+          <Route path="/targets" element={<TargetsPage />} />
           <Route path="/debug/*" element={<PageLiveDebugging />} />
         </Routes>
       </main>

--- a/internal/web/ui/src/features/layout/Navbar.tsx
+++ b/internal/web/ui/src/features/layout/Navbar.tsx
@@ -23,6 +23,11 @@ function Navbar() {
           </NavLink>
         </li>
         <li>
+          <NavLink to="/targets" className="nav-link">
+            Targets
+          </NavLink>
+        </li>
+        <li>
           <NavLink to="/remotecfg" className="nav-link">
             Remote Configuration
           </NavLink>

--- a/internal/web/ui/src/features/targets/Table.module.css
+++ b/internal/web/ui/src/features/targets/Table.module.css
@@ -1,0 +1,30 @@
+.table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.table td,
+.table th {
+  border: none;
+  padding: 8px;
+  vertical-align: top;
+}
+
+.table tr:nth-child(odd) {
+  background-color: #f4f5f5;
+}
+
+.table tr:nth-child(even) {
+  background-color: white;
+}
+
+.table tr:hover {
+  background-color: #ddd;
+}
+
+.table th {
+  padding: 8px;
+  text-align: left;
+  background-color: #f4f5f5;
+  color: rgba(36, 41, 46, 0.75);
+}

--- a/internal/web/ui/src/features/targets/Table.tsx
+++ b/internal/web/ui/src/features/targets/Table.tsx
@@ -1,0 +1,30 @@
+import { type CSSProperties } from 'react';
+
+import styles from './Table.module.css';
+
+interface Props {
+  tableHeaders: string[];
+  style?: CSSProperties;
+  renderTableData: () => JSX.Element[];
+}
+
+/**
+ * Simple table component for targets display
+ */
+const Table = ({ tableHeaders, style = {}, renderTableData }: Props) => {
+  return (
+    <table className={styles.table}>
+      <colgroup span={1} style={style} />
+      <tbody>
+        <tr>
+          {tableHeaders.map((header) => (
+            <th key={header}>{header}</th>
+          ))}
+        </tr>
+        {renderTableData()}
+      </tbody>
+    </table>
+  );
+};
+
+export default Table;

--- a/internal/web/ui/src/features/targets/TargetsList.module.css
+++ b/internal/web/ui/src/features/targets/TargetsList.module.css
@@ -1,0 +1,80 @@
+.list {
+  border: 1px solid #e4e5e6;
+  border-radius: 3px;
+  box-sizing: border-box;
+  color: rgba(36, 41, 46, 0.75);
+}
+
+.health {
+  display: inline-block;
+  font-size: 12px;
+  padding: 4px 8px;
+  min-width: 50px;
+  color: #ffffff;
+  background-color: #595c60;
+  border: 1px solid #595c60;
+  border-radius: 3px;
+  font-weight: 600;
+  text-transform: capitalize;
+  text-align: center;
+  line-height: 1.2em;
+}
+
+.health.up {
+  color: #ffffff;
+  background-color: #3b8160;
+  border-color: #3b8160;
+}
+
+.health.down {
+  color: #ffffff;
+  background-color: #d2476d;
+  border-color: #d2476d;
+}
+
+.health.unknown {
+  color: #000000;
+  background-color: #f5d65b;
+  border-color: #f5d65b;
+}
+
+.url {
+  word-break: break-all;
+  font-family: monospace;
+  font-size: 0.9em;
+}
+
+.error {
+  color: #d2476d;
+  font-size: 0.9em;
+}
+
+.labels {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.label {
+  display: inline-block;
+  font-size: 11px;
+  padding: 2px 6px;
+  background-color: #e4e5e6;
+  border-radius: 3px;
+  font-family: monospace;
+}
+
+.componentId {
+  font-weight: 500;
+}
+
+.duration {
+  font-family: monospace;
+  font-size: 0.9em;
+}
+
+.emptyMessage {
+  padding: 20px;
+  text-align: center;
+  color: #666;
+}

--- a/internal/web/ui/src/features/targets/TargetsList.tsx
+++ b/internal/web/ui/src/features/targets/TargetsList.tsx
@@ -1,0 +1,84 @@
+import { type TargetInfo } from './types';
+import styles from './TargetsList.module.css';
+import Table from './Table';
+
+interface TargetsListProps {
+  targets: TargetInfo[];
+}
+
+const TABLEHEADERS = ['Component', 'Job', 'URL', 'Health', 'Labels', 'Last Scrape', 'Duration', 'Error'];
+
+const TargetsList = ({ targets }: TargetsListProps) => {
+  const getHealthClass = (health: string) => {
+    const healthLower = health.toLowerCase();
+    if (healthLower === 'up') return `${styles.health} ${styles.up}`;
+    if (healthLower === 'down') return `${styles.health} ${styles.down}`;
+    return `${styles.health} ${styles.unknown}`;
+  };
+
+  const formatLabels = (labels: Record<string, string>) => {
+    return Object.entries(labels).map(([key, value]) => (
+      <span key={key} className={styles.label}>
+        {key}="{value}"
+      </span>
+    ));
+  };
+
+  const formatLastScrape = (lastScrape: string) => {
+    if (!lastScrape) return '-';
+    try {
+      const date = new Date(lastScrape);
+      return date.toLocaleString();
+    } catch {
+      return lastScrape;
+    }
+  };
+
+  /**
+   * Custom renderer for table data
+   */
+  const renderTableData = () => {
+    if (targets.length === 0) {
+      return [
+        <tr key="empty">
+          <td colSpan={8} className={styles.emptyMessage}>
+            No scrape targets found
+          </td>
+        </tr>,
+      ];
+    }
+
+    return targets.map((target, index) => (
+      <tr key={`${target.component_id}-${target.url}-${index}`}>
+        <td>
+          <span className={styles.componentId}>{target.component_id}</span>
+        </td>
+        <td>{target.job}</td>
+        <td>
+          <span className={styles.url}>{target.url}</span>
+        </td>
+        <td>
+          <span className={getHealthClass(target.health)}>{target.health}</span>
+        </td>
+        <td>
+          <div className={styles.labels}>{formatLabels(target.labels || {})}</div>
+        </td>
+        <td>{formatLastScrape(target.last_scrape)}</td>
+        <td>
+          <span className={styles.duration}>{target.last_scrape_duration || '-'}</span>
+        </td>
+        <td>
+          {target.last_error && <span className={styles.error}>{target.last_error}</span>}
+        </td>
+      </tr>
+    ));
+  };
+
+  return (
+    <div className={styles.list}>
+      <Table tableHeaders={TABLEHEADERS} renderTableData={renderTableData} />
+    </div>
+  );
+};
+
+export default TargetsList;

--- a/internal/web/ui/src/features/targets/types.ts
+++ b/internal/web/ui/src/features/targets/types.ts
@@ -1,0 +1,16 @@
+export interface TargetInfo {
+  component_id: string;
+  job: string;
+  url: string;
+  health: string;
+  labels: Record<string, string>;
+  discovered_labels?: Record<string, string>;
+  last_scrape: string;
+  last_scrape_duration?: string;
+  last_error?: string;
+}
+
+export interface TargetsResponse {
+  status: string;
+  data: TargetInfo[];
+}

--- a/internal/web/ui/src/hooks/useTargets.tsx
+++ b/internal/web/ui/src/hooks/useTargets.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+
+import { type TargetInfo, type TargetsResponse } from '../features/targets/types';
+
+interface UseTargetsOptions {
+  job?: string;
+  health?: string;
+  component?: string;
+}
+
+/**
+ * useTargets retrieves the list of scrape targets from the API.
+ */
+export const useTargets = (options?: UseTargetsOptions): TargetInfo[] => {
+  const [targets, setTargets] = useState<TargetInfo[]>([]);
+
+  useEffect(
+    function () {
+      const worker = async () => {
+        const params = new URLSearchParams();
+        if (options?.job) params.set('job', options.job);
+        if (options?.health) params.set('health', options.health);
+        if (options?.component) params.set('component', options.component);
+
+        const queryString = params.toString();
+        const infoPath = `./api/v0/web/targets${queryString ? `?${queryString}` : ''}`;
+
+        // Request is relative to the <base> tag inside of <head>.
+        const resp = await fetch(infoPath, {
+          cache: 'no-cache',
+          credentials: 'same-origin',
+        });
+        const data: TargetsResponse = await resp.json();
+        setTargets(data.data || []);
+      };
+
+      worker().catch(console.error);
+    },
+    [options?.job, options?.health, options?.component]
+  );
+
+  return targets;
+};

--- a/internal/web/ui/src/pages/TargetsPage.tsx
+++ b/internal/web/ui/src/pages/TargetsPage.tsx
@@ -1,0 +1,17 @@
+import { faBullseye } from '@fortawesome/free-solid-svg-icons';
+
+import TargetsList from '../features/targets/TargetsList';
+import Page from '../features/layout/Page';
+import { useTargets } from '../hooks/useTargets';
+
+function TargetsPage() {
+  const targets = useTargets();
+
+  return (
+    <Page name="Targets" desc="Scrape target status" icon={faBullseye}>
+      <TargetsList targets={targets} />
+    </Page>
+  );
+}
+
+export default TargetsPage;


### PR DESCRIPTION
#### PR Description

  This PR adds a new API endpoints to expose scrape target status information, along with a UI page to
  visualize targets.

  - `GET /api/v0/web/targets` - Returns all scrape targets
  - `GET /api/v0/web/remotecfg/targets` - Returns targets from remote config
  - `GET /api/v0/web/modules/{moduleID}/targets` - Returns targets for a specific module


  API Features:
  - Returns all scrape targets from components implementing TargetsProvider interface (`prometheus.scrape`,
  `pyroscope.scrape`)
  - Supports filtering by query parameters: `job`, `health`, `component`
  - Response format aligned with existing DebugInfo structure

  UI Features:
  - New "Targets" page accessible from the navigation bar
  - Displays target information: component, job, URL, health status, labels, last scrape time, duration, and errors
  - Color-coded health status (green=up, red=down)

<img width="1463" height="329" alt="Grafana Alloy Targets" src="https://github.com/user-attachments/assets/9bf4928d-ea71-4f89-b8cd-e2154593fd14" />

  Example API response:
```
curl -s http://127.0.0.1:12345/api/v0/web/targets | jq .
{
  "status": "success",
  "data": [
    {
      "component_id": "prometheus.scrape.will_fail",
      "job": "prometheus.scrape.will_fail",
      "url": "http://localhost:9999/metrics",
      "health": "down",
      "labels": {
        "instance": "instance02",
        "job": "fake_target"
      },
      "discovered_labels": {
        "__address__": "localhost:9999",
        "__metrics_path__": "/metrics",
        "__scheme__": "http",
        "__scrape_interval__": "15s",
        "__scrape_timeout__": "5s",
        "instance": "instance02",
        "job": "fake_target"
      },
      "last_scrape": "2025-12-16T16:44:24+01:00",
      "last_scrape_duration": "2.333049ms",
      "last_error": "Get \"http://localhost:9999/metrics\": dial tcp 127.0.0.1:9999: connect: connection refused"
    },
    {
      "component_id": "prometheus.scrape.default",
      "job": "prometheus.scrape.default",
      "url": "http://alloy.internal:12345/api/v0/component/prometheus.exporter.unix.default/metrics",
      "health": "up",
      "labels": {
        "instance": "instance01",
        "job": "integrations/unix"
      },
      "discovered_labels": {
        "__address__": "alloy.internal:12345",
        "__meta_component_id": "prometheus.exporter.unix.default",
        "__meta_component_name": "prometheus.exporter.unix",
        "__metrics_path__": "/api/v0/component/prometheus.exporter.unix.default/metrics",
        "__scheme__": "http",
        "__scrape_interval__": "1m",
        "__scrape_timeout__": "10s",
        "instance": "instance01",
        "job": "integrations/unix"
      },
      "last_scrape": "2025-12-16T16:43:59+01:00",
      "last_scrape_duration": "142.278551ms"
    }
  ]
}

```

#### Which issue(s) this PR fixes

  Fixes #4233

#### Notes to the Reviewer

  - The TargetsProvider interface is implemented by prometheus.scrape and pyroscope.scrape components
  - Field names in the API response are aligned with the existing DebugInfo format used in the component detail UI
  - The UI follows existing patterns from the Clustering page

#### PR Checklist

- [ ] Documentation added
- [X] Tests updated
