### PR TITLE
fix(database_observability): fix schema_details collector to fetch column definitions with case sensitive table names (#4872)

### DIFF
--- a/internal/component/database_observability/postgres/collector/connection_info_test.go
+++ b/internal/component/database_observability/postgres/collector/connection_info_test.go
@@ -15,7 +15,9 @@ import (
 )
 
 func TestConnectionInfo(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	// The goroutine which deletes expired entries runs indefinitely,
+	// see https://github.com/hashicorp/golang-lru/blob/v2.0.7/expirable/expirable_lru.go#L79-L80
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"))
 
 	const baseExpectedMetrics = `
 	# HELP database_observability_connection_info Information about the connection

--- a/internal/component/database_observability/postgres/collector/query_details_test.go
+++ b/internal/component/database_observability/postgres/collector/query_details_test.go
@@ -17,7 +17,9 @@ import (
 )
 
 func TestQueryDetails(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	// The goroutine which deletes expired entries runs indefinitely,
+	// see https://github.com/hashicorp/golang-lru/blob/v2.0.7/expirable/expirable_lru.go#L79-L80
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"))
 
 	testcases := []struct {
 		name                string
@@ -468,7 +470,9 @@ func TestQueryDetails(t *testing.T) {
 }
 
 func TestQueryDetails_SQLDriverErrors(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	// The goroutine which deletes expired entries runs indefinitely,
+	// see https://github.com/hashicorp/golang-lru/blob/v2.0.7/expirable/expirable_lru.go#L79-L80
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"))
 
 	t.Run("recoverable sql error in result set", func(t *testing.T) {
 		t.Parallel()

--- a/internal/component/database_observability/postgres/collector/schema_details_test.go
+++ b/internal/component/database_observability/postgres/collector/schema_details_test.go
@@ -73,7 +73,7 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 				}).AddRow("authors"),
 			)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.authors").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "authors").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"column_name",
@@ -189,7 +189,7 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 				}).AddRow("spatial_ref_sys"),
 			)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.authors").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "authors").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"column_name",
@@ -223,7 +223,7 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 				}),
 			)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.categories").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "categories").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"column_name",
@@ -257,7 +257,7 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 				}),
 			)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("postgis.spatial_ref_sys").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("postgis", "spatial_ref_sys").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"column_name",
@@ -383,7 +383,7 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows([]string{"schema_name"}).AddRow("public"))
 		db1Mock.ExpectQuery(selectTableNames).WithArgs("public").RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("users"))
-		db1Mock.ExpectQuery(selectColumnNames).WithArgs("public.users").RowsWillBeClosed().
+		db1Mock.ExpectQuery(selectColumnNames).WithArgs("public", "users").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{"column_name", "column_type", "not_nullable", "column_default", "identity_generation", "is_primary_key"}).
 					AddRow("id", "integer", true, nil, "", true),
@@ -397,7 +397,7 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows([]string{"schema_name"}).AddRow("public"))
 		db2Mock.ExpectQuery(selectTableNames).WithArgs("public").RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("metrics"))
-		db2Mock.ExpectQuery(selectColumnNames).WithArgs("public.metrics").RowsWillBeClosed().
+		db2Mock.ExpectQuery(selectColumnNames).WithArgs("public", "metrics").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{"column_name", "column_type", "not_nullable", "column_default", "identity_generation", "is_primary_key"}).
 					AddRow("id", "bigint", true, nil, "", true),
@@ -485,7 +485,7 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 				}).AddRow("users"),
 			)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.users").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "users").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"column_name",
@@ -654,7 +654,7 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 				}).AddRow("test_table"),
 			)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.test_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"column_name",
@@ -765,7 +765,7 @@ func Test_Postgres_SchemaDetails_collector_detects_auto_increment_column(t *test
 				}).AddRow("users"),
 			)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.users").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "users").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"column_name",
@@ -871,7 +871,7 @@ func Test_Postgres_SchemaDetails_collector_detects_auto_increment_column(t *test
 				}).AddRow("products"),
 			)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.products").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "products").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"column_name",
@@ -978,7 +978,7 @@ func Test_Postgres_SchemaDetails_collector_detects_auto_increment_column(t *test
 				}).AddRow("books"),
 			)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.books").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "books").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"column_name",
@@ -1085,7 +1085,7 @@ func Test_Postgres_SchemaDetails_caching(t *testing.T) {
 			)
 
 		// selectColumnNames, selectIndexes, selectForeignKeys called only first run
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.test_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"column_name",
@@ -1215,7 +1215,7 @@ func Test_Postgres_SchemaDetails_caching(t *testing.T) {
 					}).AddRow("test_table"),
 				)
 
-			mock.ExpectQuery(selectColumnNames).WithArgs("public.test_table").RowsWillBeClosed().
+			mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").RowsWillBeClosed().
 				WillReturnRows(
 					sqlmock.NewRows([]string{
 						"column_name",
@@ -1322,7 +1322,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.test_table").
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").
 			WillReturnError(fmt.Errorf("column query error"))
 
 		collector := &SchemaDetails{logger: log.NewNopLogger()}
@@ -1347,7 +1347,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 			logger: log.NewNopLogger(),
 		}
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.test_table").
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").
 			WillReturnError(fmt.Errorf("column query error"))
 
 		_, err = collector.fetchColumnsDefinitions(context.Background(), "testdb", "public", "test_table", db)
@@ -1367,7 +1367,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 			logger: log.NewNopLogger(),
 		}
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.test_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{"column_name", "column_type", "not_nullable", "column_default", "identity_generation"}).
 				AddRow("id", "integer", true, nil, ""))
 
@@ -1383,7 +1383,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.test_table").
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").
 			WillReturnRows(
 				sqlmock.NewRows([]string{"column_name", "column_type", "not_nullable", "column_default", "identity_generation", "is_primary_key"}).
 					AddRow("id", "integer", true, nil, "", true).
@@ -1402,7 +1402,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.test_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{"column_name", "column_type", "not_nullable", "column_default", "identity_generation", "is_primary_key"}).
 				AddRow("id", "integer", true, nil, "", true))
 		mock.ExpectQuery(selectIndexes).WithArgs("public", "test_table").
@@ -1421,7 +1421,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.test_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{"column_name", "column_type", "not_nullable", "column_default", "identity_generation", "is_primary_key"}).
 				AddRow("id", "integer", true, nil, "", true))
 		mock.ExpectQuery(selectIndexes).WithArgs("public", "test_table").RowsWillBeClosed().
@@ -1441,7 +1441,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.test_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{"column_name", "column_type", "not_nullable", "column_default", "identity_generation", "is_primary_key"}).
 				AddRow("id", "integer", true, nil, "", true))
 		mock.ExpectQuery(selectIndexes).WithArgs("public", "test_table").
@@ -1464,7 +1464,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.test_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{"column_name", "column_type", "not_nullable", "column_default", "identity_generation", "is_primary_key"}).
 				AddRow("id", "integer", true, nil, "", true))
 		mock.ExpectQuery(selectIndexes).WithArgs("public", "test_table").RowsWillBeClosed().
@@ -1486,7 +1486,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.test_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{"column_name", "column_type", "not_nullable", "column_default", "identity_generation", "is_primary_key"}).
 				AddRow("id", "integer", true, nil, "", true))
 		mock.ExpectQuery(selectIndexes).WithArgs("public", "test_table").RowsWillBeClosed().
@@ -1508,7 +1508,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.test_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{"column_name", "column_type", "not_nullable", "column_default", "identity_generation", "is_primary_key"}).
 				AddRow("id", "integer", true, nil, "", true))
 		mock.ExpectQuery(selectIndexes).WithArgs("public", "test_table").RowsWillBeClosed().
@@ -1627,7 +1627,7 @@ func Test_SchemaDetails_populates_TableRegistry(t *testing.T) {
 					"table_name",
 				}).AddRow("users").AddRow("orders"),
 			)
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.users").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "users").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"column_name",
@@ -1658,7 +1658,7 @@ func Test_SchemaDetails_populates_TableRegistry(t *testing.T) {
 					"referenced_column_name",
 				}),
 			)
-		mock.ExpectQuery(selectColumnNames).WithArgs("public.orders").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("public", "orders").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"column_name",


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix(database_observability): Fix schema_details collector to fetch column definitions with case sensitive table names (#4872)
END_COMMIT_OVERRIDE