### PR TITLE
(feat) integrate smartctl exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,6 +231,8 @@
 
 - Mark `stage.windowsevent` block in the `loki.process` component as GA. (@kgeckhart)
 
+- Add `prometheus.exporter.smartctl` component to monitor S.M.A.R.T. disk health metrics from storage devices. Collects temperature, power-on hours, error rates, and detailed SMART attributes for ATA/SATA and NVMe drives. (@parsa97)
+
 ### Enhancements
 
 - Add per-application rate limiting with the `strategy` attribute in the `faro.receiver` component, to prevent one application from consuming the rate limit quota of others. (@hhertout)

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.smartctl.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.smartctl.md
@@ -1,0 +1,314 @@
+---
+canonical: https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.exporter.smartctl/
+description: Learn about prometheus.exporter.smartctl
+labels:
+  stage: general-availability
+  products:
+    - oss
+  tags:
+    - text: Community
+      tooltip: This component is developed, maintained, and supported by the Alloy user community.
+title: prometheus.exporter.smartctl
+---
+
+# `prometheus.exporter.smartctl`
+
+{{< docs/shared lookup="stability/community.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+The `prometheus.exporter.smartctl` component collects SMART disk health metrics from storage devices on the local system.
+It uses the `smartctl` command from the `smartmontools` package to query device health, temperature, power-on hours, and other attributes.
+
+## Usage
+
+```alloy
+prometheus.exporter.smartctl "<LABEL>" {
+}
+```
+
+## Arguments
+
+You can use the following arguments with `prometheus.exporter.smartctl`:
+
+| Name                | Type           | Description                                                | Default                | Required |
+| ------------------- | -------------- | ---------------------------------------------------------- | ---------------------- | -------- |
+| `device_exclude`    | `string`       | Regex pattern to exclude devices from automatic scanning.  | `""`                   | no       |
+| `device_include`    | `string`       | Regex pattern to include only matching devices.            | `""`                   | no       |
+| `devices`           | `list(string)` | List of specific devices to monitor.                       | `[]`                   | no       |
+| `powermode_check`   | `string`       | Power mode threshold to skip checking devices.             | `"standby"`            | no       |
+| `rescan_interval`   | `duration`     | How often to scan again for added or removed devices.      | `"10m"`                | no       |
+| `scan_device_types` | `list(string)` | Device types to scan, for example, `sat`, `scsi`, `nvme`.  | `[]`                   | no       |
+| `scan_interval`     | `duration`     | How often to poll `smartctl` for device data.              | `"60s"`                | no       |
+| `smartctl_path`     | `string`       | Path to the `smartctl` binary.                             | `"/usr/sbin/smartctl"` | no       |
+
+The `smartctl_path` must point to a `smartctl` binary version 7.0 or later with JSON output support.
+
+The `scan_interval` argument controls how frequently {{< param "PRODUCT_NAME" >}} collects device metrics.
+The `smartctl` queries can be slow, especially with many drives, so a 60-second interval prevents system overload.
+
+The `rescan_interval` argument controls how often the component scans again for added or removed devices.
+This only applies when you use automatic device discovery.
+Set to `0` to disable automatic device scanning.
+
+The `devices` argument specifies an explicit list of devices to monitor, for example `["/dev/sda", "/dev/nvme0n1"]`.
+When specified, the component disables automatic device discovery.
+
+The `device_exclude` and `device_include` arguments are mutually exclusive.
+Use them to filter which devices the component monitors during automatic discovery:
+
+- `device_exclude`: Exclude devices matching the regular expression, for example `"^(ram|loop|fd)\\d+$"` excludes RAM disks, loop devices, and floppy drives.
+- `device_include`: Only include devices matching the regular expression, for example `"^(sd|nvme)"` includes only SATA and NVMe devices.
+
+The `scan_device_types` argument controls which device types to scan.
+Common values include:
+
+- `sat`: SATA devices
+- `scsi`: SAS and SCSI devices
+- `nvme`: NVMe devices
+- `auto`: Auto-detect device type, which is the default when not specified
+
+The `powermode_check` argument determines when to skip checking devices based on their power state to avoid waking sleeping drives.
+Valid values are:
+
+- `never`: Always check devices regardless of power state
+- `sleep`: Skip devices in sleep mode or deeper
+- `standby` (default): Skip devices in standby mode or deeper
+- `idle`: Skip devices in idle mode or deeper
+
+## Blocks
+
+The `prometheus.exporter.smartctl` component doesn't support any blocks.
+You can configure this component with arguments.
+
+## Exported fields
+
+{{< docs/shared lookup="reference/components/exporter-component-exports.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+## Component health
+
+`prometheus.exporter.smartctl` is only reported as unhealthy when given an invalid configuration.
+In those cases, exported fields retain their last healthy values.
+
+The `smartctl` command execution failures don't affect component health.
+Instead, the component sets the `smartctl_device_scrape_success` metric to `0` for devices that fail to scrape.
+
+## Debug information
+
+`prometheus.exporter.smartctl` doesn't expose any component-specific debug information.
+
+## Debug metrics
+
+`prometheus.exporter.smartctl` doesn't expose any component-specific debug metrics.
+
+## Collected metrics
+
+The `prometheus.exporter.smartctl` component collects the following metrics:
+
+### General metrics
+
+| Metric name                            | Type  | Description                                          |
+| -------------------------------------- | ----- | ---------------------------------------------------- |
+| `smartctl_version`                     | gauge | `smartctl` version information                       |
+| `smartctl_device`                      | gauge | Device information with labels                       |
+| `smartctl_device_smart_status`         | gauge | Device SMART overall-health test result (1 = passed) |
+| `smartctl_device_status`               | gauge | Device status (1 = available, 0 = unavailable)       |
+| `smartctl_device_smartctl_exit_status` | gauge | Exit status from `smartctl`                          |
+
+### Capacity and hardware metrics
+
+| Metric name                       | Type  | Description                                     |
+| --------------------------------- | ----- | ----------------------------------------------- |
+| `smartctl_device_capacity_blocks` | gauge | Device capacity in blocks                       |
+| `smartctl_device_capacity_bytes`  | gauge | Device capacity in bytes                        |
+| `smartctl_device_block_size`      | gauge | Device block size in bytes, logical or physical |
+| `smartctl_device_rotation_rate`   | gauge | Device rotation rate in RPM, `0` for SSD        |
+| `smartctl_device_interface_speed` | gauge | Device interface speed, maximum or current      |
+
+### Temperature and health metrics
+
+| Metric name                         | Type    | Description                     |
+| ----------------------------------- | ------- | ------------------------------- |
+| `smartctl_device_temperature`       | gauge   | Device temperature in Celsius   |
+| `smartctl_device_power_on_seconds`  | counter | Device power-on time in seconds |
+| `smartctl_device_power_cycle_count` | counter | Device power cycle count        |
+
+### Data transfer metrics
+
+| Metric name                     | Type    | Description                   |
+| ------------------------------- | ------- | ----------------------------- |
+| `smartctl_device_bytes_read`    | counter | Total bytes read from device  |
+| `smartctl_device_bytes_written` | counter | Total bytes written to device |
+
+### Error metrics
+
+| Metric name                           | Type    | Description                 |
+| ------------------------------------- | ------- | --------------------------- |
+| `smartctl_device_media_errors`        | counter | Device media errors         |
+| `smartctl_device_num_err_log_entries` | counter | Number of error log entries |
+
+### NVMe-specific metrics
+
+| Metric name                                 | Type    | Description                          |
+| ------------------------------------------- | ------- | ------------------------------------ |
+| `smartctl_device_percentage_used`           | counter | Percentage of device lifespan used   |
+| `smartctl_device_available_spare`           | counter | Available spare capacity percentage  |
+| `smartctl_device_available_spare_threshold` | counter | Available spare threshold percentage |
+| `smartctl_device_critical_warning`          | counter | Critical warning status              |
+
+### SMART attributes for ATA and SATA only
+
+| Metric name                 | Type  | Description                                               |
+| --------------------------- | ----- | --------------------------------------------------------- |
+| `smartctl_device_attribute` | gauge | SMART attribute values: normalized, raw, worst, threshold |
+
+### Scrape metrics
+
+| Metric name                               | Type  | Description                                     |
+| ----------------------------------------- | ----- | ----------------------------------------------- |
+| `smartctl_device_scrape_success`          | gauge | Device scrape success (1 = success, 0 = failure) |
+| `smartctl_device_scrape_duration_seconds` | gauge | Duration of the `smartctl` scrape in seconds    |
+
+All device metrics include a `device` label with the device path, for example `/dev/sda`.
+
+The `smartctl_device` metric includes comprehensive device information labels:
+
+- `device`: Device path
+- `model_name`: Device model name
+- `model_family`: Device model family
+- `serial_number`: Device serial number
+- `firmware_version`: Firmware version
+- `interface`: Interface type, for example, SAT or NVMe
+- `protocol`: Protocol, for example, ATA or NVMe
+- `form_factor`: Form factor, for example, 2.5 inches or M.2
+- `ata_version`: ATA version string
+- `sata_version`: SATA version string
+
+The `smartctl_device_attribute` metric includes labels:
+
+- `device`: Device path
+- `attribute_id`: SMART attribute ID, for example `5` for Reallocated Sectors
+- `attribute_name`: SMART attribute name
+- `attribute_value_type`: Type of value: normalized, raw, worst, threshold
+- `attribute_flags_short`: Short flags string
+- `attribute_flags_long`: Long flags string with comma-separated values
+
+## Prerequisites
+
+Before you use `prometheus.exporter.smartctl`, ensure you meet the following requirements:
+
+1. Install `smartmontools` version 7.0 or later:
+
+   - Debian/Ubuntu: `sudo apt-get install smartmontools`
+   - RHEL/CentOS: `sudo yum install smartmontools`
+   - macOS: `brew install smartmontools`
+
+1. Make sure the `smartctl` binary has the appropriate elevated privileges to access device data.
+   {{< param "PRODUCT_NAME" >}} must run with one of the following:
+
+   - Root permissions, not recommended for production
+   - `CAP_SYS_RAWIO` capability on Linux
+   - Appropriate device permissions
+
+1. On Linux only, load the appropriate kernel modules for your devices:
+   - SATA and SCSI: Usually enabled by default.
+   - NVMe: The `nvme` kernel module.
+
+## Example
+
+This example uses a [`prometheus.scrape` component][scrape] to collect metrics from `prometheus.exporter.smartctl`:
+
+```alloy
+prometheus.exporter.smartctl "example" {
+  smartctl_path   = "/usr/sbin/smartctl"
+  scan_interval   = "60s"
+  rescan_interval = "10m"
+
+  // Exclude common virtual/pseudo devices
+  device_exclude = "^(ram|loop|fd)\\d+$"
+
+  // Skip devices in standby to avoid waking them
+  powermode_check = "standby"
+}
+
+// Configure a prometheus.scrape component to collect smartctl metrics.
+prometheus.scrape "demo" {
+  targets    = prometheus.exporter.smartctl.example.targets
+  forward_to = [prometheus.remote_write.demo.receiver]
+}
+
+prometheus.remote_write "demo" {
+  endpoint {
+    url = "<PROMETHEUS_REMOTE_WRITE_URL>"
+
+    basic_auth {
+      username = "<USERNAME>"
+      password = "<PASSWORD>"
+    }
+  }
+}
+```
+
+Replace the following:
+
+- _`<PROMETHEUS_REMOTE_WRITE_URL>`_: The URL of the Prometheus `remote_write` compatible server to send metrics to.
+- _`<USERNAME>`_: The username to use for authentication to the `remote_write` API.
+- _`<PASSWORD>`_: The password to use for authentication to the `remote_write` API.
+
+### Explicit device list
+
+This example monitors specific devices only:
+
+```alloy
+prometheus.exporter.smartctl "specific_devices" {
+  smartctl_path = "/usr/sbin/smartctl"
+
+  // Monitor only these devices
+  devices = [
+    "/dev/sda",
+    "/dev/sdb",
+    "/dev/nvme0n1",
+  ]
+}
+
+prometheus.scrape "demo" {
+  targets    = prometheus.exporter.smartctl.specific_devices.targets
+  forward_to = [prometheus.remote_write.demo.receiver]
+}
+```
+
+### Device type filtering
+
+This example monitors only NVMe devices:
+
+```alloy
+prometheus.exporter.smartctl "nvme_only" {
+  smartctl_path = "/usr/sbin/smartctl"
+
+  // Only include NVMe devices
+  device_include = "^/dev/nvme"
+
+  // Use NVMe device type
+  scan_device_types = ["nvme"]
+}
+
+prometheus.scrape "demo" {
+  targets    = prometheus.exporter.smartctl.nvme_only.targets
+  forward_to = [prometheus.remote_write.demo.receiver]
+}
+```
+
+[scrape]: ../prometheus.scrape/
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.exporter.smartctl` has exports that can be consumed by the following components:
+
+- Components that consume [Targets](../../../compatibility/#targets-consumers)
+
+{{< admonition type="note" >}}
+Connecting some components may not be sensible or components may require further configuration to make the connection work correctly.
+Refer to the linked documentation for more details.
+{{< /admonition >}}
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/internal/component/all/all.go
+++ b/internal/component/all/all.go
@@ -152,6 +152,7 @@ import (
 	_ "github.com/grafana/alloy/internal/component/prometheus/exporter/process"              // Import prometheus.exporter.process
 	_ "github.com/grafana/alloy/internal/component/prometheus/exporter/redis"                // Import prometheus.exporter.redis
 	_ "github.com/grafana/alloy/internal/component/prometheus/exporter/self"                 // Import prometheus.exporter.self
+	_ "github.com/grafana/alloy/internal/component/prometheus/exporter/smartctl"             // Import prometheus.exporter.smartctl
 	_ "github.com/grafana/alloy/internal/component/prometheus/exporter/snmp"                 // Import prometheus.exporter.snmp
 	_ "github.com/grafana/alloy/internal/component/prometheus/exporter/snowflake"            // Import prometheus.exporter.snowflake
 	_ "github.com/grafana/alloy/internal/component/prometheus/exporter/squid"                // Import prometheus.exporter.squid

--- a/internal/component/prometheus/exporter/smartctl/collector.go
+++ b/internal/component/prometheus/exporter/smartctl/collector.go
@@ -1,0 +1,674 @@
+package smartctl
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// smartctlCollector implements prometheus.Collector for S.M.A.R.T. metrics
+type smartctlCollector struct {
+	cfg    *Config
+	logger log.Logger
+
+	// Version metrics
+	smartctlVersion *prometheus.Desc
+
+	// Device info and status
+	deviceInfo        *prometheus.Desc
+	deviceSmartStatus *prometheus.Desc
+	deviceStatus      *prometheus.Desc
+	deviceExitStatus  *prometheus.Desc
+
+	// Capacity metrics
+	deviceCapacityBlocks *prometheus.Desc
+	deviceCapacityBytes  *prometheus.Desc
+	deviceBlockSize      *prometheus.Desc
+	deviceRotationRate   *prometheus.Desc
+
+	// Temperature
+	deviceTemperature *prometheus.Desc
+
+	// Power metrics
+	devicePowerOnSeconds  *prometheus.Desc
+	devicePowerCycleCount *prometheus.Desc
+
+	// Data transfer metrics
+	deviceBytesRead    *prometheus.Desc
+	deviceBytesWritten *prometheus.Desc
+
+	// Error metrics
+	deviceMediaErrors      *prometheus.Desc
+	deviceNumErrLogEntries *prometheus.Desc
+
+	// NVMe-specific metrics
+	devicePercentageUsed          *prometheus.Desc
+	deviceAvailableSpare          *prometheus.Desc
+	deviceAvailableSpareThreshold *prometheus.Desc
+	deviceCriticalWarning         *prometheus.Desc
+
+	// Interface speed
+	deviceInterfaceSpeed *prometheus.Desc
+
+	// SMART attributes
+	deviceAttribute *prometheus.Desc
+
+	// Scrape metrics
+	deviceScrapeSuccess  *prometheus.Desc
+	deviceScrapeDuration *prometheus.Desc
+
+	// Device management
+	mu      sync.RWMutex
+	devices []string
+
+	// Filtering
+	includeFilter *regexp.Regexp
+	excludeFilter *regexp.Regexp
+}
+
+// attrFlags represents SMART attribute flags
+type attrFlags struct {
+	Value         int    `json:"value"`
+	String        string `json:"string"`
+	Prefailure    bool   `json:"prefailure"`
+	UpdatedOnline bool   `json:"updated_online"`
+	Performance   bool   `json:"performance"`
+	ErrorRate     bool   `json:"error_rate"`
+	EventCount    bool   `json:"event_count"`
+	AutoKeep      bool   `json:"auto_keep"`
+}
+
+// smartctlDevice represents the full JSON output from smartctl
+type smartctlDevice struct {
+	Device struct {
+		Name     string `json:"name"`
+		InfoName string `json:"info_name"`
+		Type     string `json:"type"`
+		Protocol string `json:"protocol"`
+	} `json:"device"`
+	ModelName       string `json:"model_name"`
+	ModelFamily     string `json:"model_family"`
+	SerialNumber    string `json:"serial_number"`
+	FirmwareVersion string `json:"firmware_version"`
+	UserCapacity    *struct {
+		Blocks int64 `json:"blocks"`
+		Bytes  int64 `json:"bytes"`
+	} `json:"user_capacity"`
+	LogicalBlockSize  int `json:"logical_block_size"`
+	PhysicalBlockSize int `json:"physical_block_size"`
+	FormFactor        *struct {
+		Name string `json:"name"`
+	} `json:"form_factor"`
+	RotationRate int `json:"rotation_rate"`
+	ATAVersion   *struct {
+		String string `json:"string"`
+	} `json:"ata_version"`
+	SATAVersion *struct {
+		String string `json:"string"`
+	} `json:"sata_version"`
+	InterfaceSpeed *struct {
+		Max struct {
+			UnitsPerSecond int64  `json:"units_per_second"`
+			String         string `json:"string"`
+		} `json:"max"`
+		Current struct {
+			UnitsPerSecond int64  `json:"units_per_second"`
+			String         string `json:"string"`
+		} `json:"current"`
+	} `json:"interface_speed"`
+	SmartStatus struct {
+		Passed bool `json:"passed"`
+	} `json:"smart_status"`
+	SmartctlExitStatus int `json:"smartctl_exit_status"`
+	Temperature        *struct {
+		Current int `json:"current"`
+	} `json:"temperature"`
+	PowerOnTime *struct {
+		Hours int64 `json:"hours"`
+	} `json:"power_on_time"`
+	PowerCycleCount int64 `json:"power_cycle_count"`
+
+	// SMART attributes (ATA/SATA)
+	AtaSmartAttributes *struct {
+		Table []struct {
+			ID         int       `json:"id"`
+			Name       string    `json:"name"`
+			Value      int       `json:"value"`
+			Worst      int       `json:"worst"`
+			Thresh     int       `json:"thresh"`
+			WhenFailed string    `json:"when_failed"`
+			Flags      attrFlags `json:"flags"`
+			Raw        struct {
+				Value  int64  `json:"value"`
+				String string `json:"string"`
+			} `json:"raw"`
+		} `json:"table"`
+	} `json:"ata_smart_attributes"`
+
+	// NVMe-specific fields
+	NvmeSmartHealthInformationLog *struct {
+		Temperature             int   `json:"temperature"`
+		AvailableSpare          int   `json:"available_spare"`
+		AvailableSpareThreshold int   `json:"available_spare_threshold"`
+		PercentageUsed          int   `json:"percentage_used"`
+		CriticalWarning         int   `json:"critical_warning"`
+		MediaErrors             int64 `json:"media_errors"`
+		NumErrLogEntries        int64 `json:"num_err_log_entries"`
+		PowerOnHours            int64 `json:"power_on_hours"`
+		PowerCycles             int64 `json:"power_cycles"`
+		DataUnitsRead           int64 `json:"data_units_read"`
+		DataUnitsWritten        int64 `json:"data_units_written"`
+	} `json:"nvme_smart_health_information_log"`
+}
+
+// newSmartctlCollector creates a new smartctl collector
+func newSmartctlCollector(logger log.Logger, cfg *Config) (*smartctlCollector, error) {
+	c := &smartctlCollector{
+		cfg:    cfg,
+		logger: logger,
+
+		smartctlVersion: prometheus.NewDesc(
+			"smartctl_version",
+			"Smartctl version information",
+			[]string{"version", "json_format_version"},
+			nil,
+		),
+
+		deviceInfo: prometheus.NewDesc(
+			"smartctl_device",
+			"Device information",
+			[]string{"device", "model_name", "model_family", "serial_number", "firmware_version", "interface", "protocol", "form_factor", "ata_version", "sata_version"},
+			nil,
+		),
+
+		deviceSmartStatus: prometheus.NewDesc(
+			"smartctl_device_smart_status",
+			"Device SMART overall-health self-assessment test result (1 = PASSED, 0 = FAILED)",
+			[]string{"device"},
+			nil,
+		),
+
+		deviceStatus: prometheus.NewDesc(
+			"smartctl_device_status",
+			"Device status (1 = available, 0 = unavailable)",
+			[]string{"device"},
+			nil,
+		),
+
+		deviceExitStatus: prometheus.NewDesc(
+			"smartctl_device_smartctl_exit_status",
+			"Exit status from smartctl",
+			[]string{"device"},
+			nil,
+		),
+
+		deviceCapacityBlocks: prometheus.NewDesc(
+			"smartctl_device_capacity_blocks",
+			"Device capacity in blocks",
+			[]string{"device"},
+			nil,
+		),
+
+		deviceCapacityBytes: prometheus.NewDesc(
+			"smartctl_device_capacity_bytes",
+			"Device capacity in bytes",
+			[]string{"device"},
+			nil,
+		),
+
+		deviceBlockSize: prometheus.NewDesc(
+			"smartctl_device_block_size",
+			"Device block size in bytes",
+			[]string{"device", "blocks_type"},
+			nil,
+		),
+
+		deviceRotationRate: prometheus.NewDesc(
+			"smartctl_device_rotation_rate",
+			"Device rotation rate in RPM (0 for SSD)",
+			[]string{"device"},
+			nil,
+		),
+
+		deviceTemperature: prometheus.NewDesc(
+			"smartctl_device_temperature",
+			"Device temperature in Celsius",
+			[]string{"device", "temperature_type"},
+			nil,
+		),
+
+		devicePowerOnSeconds: prometheus.NewDesc(
+			"smartctl_device_power_on_seconds",
+			"Device power-on time in seconds",
+			[]string{"device"},
+			nil,
+		),
+
+		devicePowerCycleCount: prometheus.NewDesc(
+			"smartctl_device_power_cycle_count",
+			"Device power cycle count",
+			[]string{"device"},
+			nil,
+		),
+
+		deviceBytesRead: prometheus.NewDesc(
+			"smartctl_device_bytes_read",
+			"Total bytes read from device",
+			[]string{"device"},
+			nil,
+		),
+
+		deviceBytesWritten: prometheus.NewDesc(
+			"smartctl_device_bytes_written",
+			"Total bytes written to device",
+			[]string{"device"},
+			nil,
+		),
+
+		deviceMediaErrors: prometheus.NewDesc(
+			"smartctl_device_media_errors",
+			"Device media errors",
+			[]string{"device"},
+			nil,
+		),
+
+		deviceNumErrLogEntries: prometheus.NewDesc(
+			"smartctl_device_num_err_log_entries",
+			"Number of error log entries",
+			[]string{"device"},
+			nil,
+		),
+
+		devicePercentageUsed: prometheus.NewDesc(
+			"smartctl_device_percentage_used",
+			"Percentage of device lifespan used (NVMe)",
+			[]string{"device"},
+			nil,
+		),
+
+		deviceAvailableSpare: prometheus.NewDesc(
+			"smartctl_device_available_spare",
+			"Available spare capacity percentage (NVMe)",
+			[]string{"device"},
+			nil,
+		),
+
+		deviceAvailableSpareThreshold: prometheus.NewDesc(
+			"smartctl_device_available_spare_threshold",
+			"Available spare threshold percentage (NVMe)",
+			[]string{"device"},
+			nil,
+		),
+
+		deviceCriticalWarning: prometheus.NewDesc(
+			"smartctl_device_critical_warning",
+			"Critical warning status (NVMe)",
+			[]string{"device"},
+			nil,
+		),
+
+		deviceInterfaceSpeed: prometheus.NewDesc(
+			"smartctl_device_interface_speed",
+			"Device interface speed in units per second",
+			[]string{"device", "speed_type"},
+			nil,
+		),
+
+		deviceAttribute: prometheus.NewDesc(
+			"smartctl_device_attribute",
+			"SMART attribute values",
+			[]string{"device", "attribute_id", "attribute_name", "attribute_value_type", "attribute_flags_short", "attribute_flags_long"},
+			nil,
+		),
+
+		deviceScrapeSuccess: prometheus.NewDesc(
+			"smartctl_device_scrape_success",
+			"Whether the smartctl scrape was successful (1 = success, 0 = failure)",
+			[]string{"device"},
+			nil,
+		),
+
+		deviceScrapeDuration: prometheus.NewDesc(
+			"smartctl_device_scrape_duration_seconds",
+			"Duration of the smartctl scrape in seconds",
+			[]string{"device"},
+			nil,
+		),
+	}
+
+	// Compile regex filters if provided
+	var err error
+	if cfg.DeviceInclude != "" {
+		c.includeFilter, err = regexp.Compile(cfg.DeviceInclude)
+		if err != nil {
+			return nil, fmt.Errorf("invalid device_include regex: %w", err)
+		}
+	}
+	if cfg.DeviceExclude != "" {
+		c.excludeFilter, err = regexp.Compile(cfg.DeviceExclude)
+		if err != nil {
+			return nil, fmt.Errorf("invalid device_exclude regex: %w", err)
+		}
+	}
+
+	// Initialize device list
+	if len(cfg.Devices) > 0 {
+		c.devices = cfg.Devices
+	} else {
+		// Discover devices
+		devices, err := c.discoverDevices()
+		if err != nil {
+			level.Warn(logger).Log("msg", "initial device discovery failed, will retry", "err", err)
+		} else {
+			c.devices = devices
+		}
+	}
+
+	return c, nil
+}
+
+// Describe implements prometheus.Collector
+func (c *smartctlCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.smartctlVersion
+	ch <- c.deviceInfo
+	ch <- c.deviceSmartStatus
+	ch <- c.deviceStatus
+	ch <- c.deviceExitStatus
+	ch <- c.deviceCapacityBlocks
+	ch <- c.deviceCapacityBytes
+	ch <- c.deviceBlockSize
+	ch <- c.deviceRotationRate
+	ch <- c.deviceTemperature
+	ch <- c.devicePowerOnSeconds
+	ch <- c.devicePowerCycleCount
+	ch <- c.deviceBytesRead
+	ch <- c.deviceBytesWritten
+	ch <- c.deviceMediaErrors
+	ch <- c.deviceNumErrLogEntries
+	ch <- c.devicePercentageUsed
+	ch <- c.deviceAvailableSpare
+	ch <- c.deviceAvailableSpareThreshold
+	ch <- c.deviceCriticalWarning
+	ch <- c.deviceInterfaceSpeed
+	ch <- c.deviceAttribute
+	ch <- c.deviceScrapeSuccess
+	ch <- c.deviceScrapeDuration
+}
+
+// Collect implements prometheus.Collector
+func (c *smartctlCollector) Collect(ch chan<- prometheus.Metric) {
+	c.mu.RLock()
+	devices := make([]string, len(c.devices))
+	copy(devices, c.devices)
+	c.mu.RUnlock()
+
+	ch <- prometheus.MustNewConstMetric(
+		c.smartctlVersion,
+		prometheus.GaugeValue,
+		1,
+		"7.0+",
+		"2",
+	)
+
+	for _, device := range devices {
+		c.collectDevice(ch, device)
+	}
+}
+
+// collectDevice collects metrics for a single device
+func (c *smartctlCollector) collectDevice(ch chan<- prometheus.Metric, device string) {
+	startTime := time.Now()
+
+	data, err := c.getSmartctlData(device)
+	duration := time.Since(startTime).Seconds()
+
+	ch <- prometheus.MustNewConstMetric(c.deviceScrapeDuration, prometheus.GaugeValue, duration, device)
+
+	if err != nil {
+		level.Debug(c.logger).Log("msg", "failed to get smartctl data", "device", device, "err", err)
+		ch <- prometheus.MustNewConstMetric(c.deviceScrapeSuccess, prometheus.GaugeValue, 0, device)
+		ch <- prometheus.MustNewConstMetric(c.deviceStatus, prometheus.GaugeValue, 0, device)
+		return
+	}
+
+	ch <- prometheus.MustNewConstMetric(c.deviceScrapeSuccess, prometheus.GaugeValue, 1, device)
+	ch <- prometheus.MustNewConstMetric(c.deviceStatus, prometheus.GaugeValue, 1, device)
+
+	// Device info
+	modelFamily := data.ModelFamily
+	formFactor := ""
+	if data.FormFactor != nil {
+		formFactor = data.FormFactor.Name
+	}
+	ataVersion := ""
+	if data.ATAVersion != nil {
+		ataVersion = data.ATAVersion.String
+	}
+	sataVersion := ""
+	if data.SATAVersion != nil {
+		sataVersion = data.SATAVersion.String
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		c.deviceInfo, prometheus.GaugeValue, 1,
+		device, data.ModelName, modelFamily, data.SerialNumber, data.FirmwareVersion,
+		data.Device.Type, data.Device.Protocol, formFactor, ataVersion, sataVersion,
+	)
+
+	// SMART status
+	smartStatusValue := float64(0)
+	if data.SmartStatus.Passed {
+		smartStatusValue = 1
+	}
+	ch <- prometheus.MustNewConstMetric(c.deviceSmartStatus, prometheus.GaugeValue, smartStatusValue, device)
+
+	// Exit status
+	ch <- prometheus.MustNewConstMetric(c.deviceExitStatus, prometheus.GaugeValue, float64(data.SmartctlExitStatus), device)
+
+	// Capacity
+	if data.UserCapacity != nil {
+		ch <- prometheus.MustNewConstMetric(c.deviceCapacityBlocks, prometheus.GaugeValue, float64(data.UserCapacity.Blocks), device)
+		ch <- prometheus.MustNewConstMetric(c.deviceCapacityBytes, prometheus.GaugeValue, float64(data.UserCapacity.Bytes), device)
+	}
+
+	// Block sizes
+	if data.LogicalBlockSize > 0 {
+		ch <- prometheus.MustNewConstMetric(c.deviceBlockSize, prometheus.GaugeValue, float64(data.LogicalBlockSize), device, "logical")
+	}
+	if data.PhysicalBlockSize > 0 {
+		ch <- prometheus.MustNewConstMetric(c.deviceBlockSize, prometheus.GaugeValue, float64(data.PhysicalBlockSize), device, "physical")
+	}
+
+	// Rotation rate
+	ch <- prometheus.MustNewConstMetric(c.deviceRotationRate, prometheus.GaugeValue, float64(data.RotationRate), device)
+
+	// Interface speed
+	if data.InterfaceSpeed != nil {
+		ch <- prometheus.MustNewConstMetric(c.deviceInterfaceSpeed, prometheus.GaugeValue, float64(data.InterfaceSpeed.Max.UnitsPerSecond), device, "max")
+		ch <- prometheus.MustNewConstMetric(c.deviceInterfaceSpeed, prometheus.GaugeValue, float64(data.InterfaceSpeed.Current.UnitsPerSecond), device, "current")
+	}
+
+	// Temperature
+	if data.NvmeSmartHealthInformationLog != nil {
+		ch <- prometheus.MustNewConstMetric(c.deviceTemperature, prometheus.GaugeValue, float64(data.NvmeSmartHealthInformationLog.Temperature), device, "current")
+	} else if data.Temperature != nil && data.Temperature.Current > 0 {
+		ch <- prometheus.MustNewConstMetric(c.deviceTemperature, prometheus.GaugeValue, float64(data.Temperature.Current), device, "current")
+	}
+
+	// NVMe-specific metrics
+	if data.NvmeSmartHealthInformationLog != nil {
+		nvme := data.NvmeSmartHealthInformationLog
+
+		ch <- prometheus.MustNewConstMetric(c.deviceAvailableSpare, prometheus.CounterValue, float64(nvme.AvailableSpare), device)
+		ch <- prometheus.MustNewConstMetric(c.deviceAvailableSpareThreshold, prometheus.CounterValue, float64(nvme.AvailableSpareThreshold), device)
+		ch <- prometheus.MustNewConstMetric(c.devicePercentageUsed, prometheus.CounterValue, float64(nvme.PercentageUsed), device)
+		ch <- prometheus.MustNewConstMetric(c.deviceCriticalWarning, prometheus.CounterValue, float64(nvme.CriticalWarning), device)
+		ch <- prometheus.MustNewConstMetric(c.deviceMediaErrors, prometheus.CounterValue, float64(nvme.MediaErrors), device)
+		ch <- prometheus.MustNewConstMetric(c.deviceNumErrLogEntries, prometheus.CounterValue, float64(nvme.NumErrLogEntries), device)
+		ch <- prometheus.MustNewConstMetric(c.devicePowerOnSeconds, prometheus.CounterValue, float64(nvme.PowerOnHours*3600), device)
+		ch <- prometheus.MustNewConstMetric(c.devicePowerCycleCount, prometheus.CounterValue, float64(nvme.PowerCycles), device)
+		// NVMe data units are in 512-byte blocks (per spec)
+		ch <- prometheus.MustNewConstMetric(c.deviceBytesRead, prometheus.CounterValue, float64(nvme.DataUnitsRead*512), device)
+		ch <- prometheus.MustNewConstMetric(c.deviceBytesWritten, prometheus.CounterValue, float64(nvme.DataUnitsWritten*512), device)
+	} else {
+		// ATA/SATA metrics
+		if data.PowerOnTime != nil && data.PowerOnTime.Hours > 0 {
+			ch <- prometheus.MustNewConstMetric(c.devicePowerOnSeconds, prometheus.CounterValue, float64(data.PowerOnTime.Hours*3600), device)
+		}
+		if data.PowerCycleCount > 0 {
+			ch <- prometheus.MustNewConstMetric(c.devicePowerCycleCount, prometheus.CounterValue, float64(data.PowerCycleCount), device)
+		}
+	}
+
+	// SMART attributes (ATA/SATA)
+	if data.AtaSmartAttributes != nil {
+		for _, attr := range data.AtaSmartAttributes.Table {
+			flagsLong := buildFlagsLong(attr.Flags)
+
+			ch <- prometheus.MustNewConstMetric(c.deviceAttribute, prometheus.GaugeValue, float64(attr.Value), device, strconv.Itoa(attr.ID), attr.Name, "normalized", attr.Flags.String, flagsLong)
+			ch <- prometheus.MustNewConstMetric(c.deviceAttribute, prometheus.GaugeValue, float64(attr.Raw.Value), device, strconv.Itoa(attr.ID), attr.Name, "raw", attr.Flags.String, flagsLong)
+			ch <- prometheus.MustNewConstMetric(c.deviceAttribute, prometheus.GaugeValue, float64(attr.Worst), device, strconv.Itoa(attr.ID), attr.Name, "worst", attr.Flags.String, flagsLong)
+			ch <- prometheus.MustNewConstMetric(c.deviceAttribute, prometheus.GaugeValue, float64(attr.Thresh), device, strconv.Itoa(attr.ID), attr.Name, "threshold", attr.Flags.String, flagsLong)
+		}
+	}
+}
+
+// buildFlagsLong builds a long-form flags string
+func buildFlagsLong(flags attrFlags) string {
+	var parts []string
+	if flags.Prefailure {
+		parts = append(parts, "prefailure")
+	}
+	if flags.UpdatedOnline {
+		parts = append(parts, "updated_online")
+	}
+	if flags.Performance {
+		parts = append(parts, "performance")
+	}
+	if flags.ErrorRate {
+		parts = append(parts, "error_rate")
+	}
+	if flags.EventCount {
+		parts = append(parts, "event_count")
+	}
+	if flags.AutoKeep {
+		parts = append(parts, "auto_keep")
+	}
+	result := ""
+	for i, p := range parts {
+		if i > 0 {
+			result += ","
+		}
+		result += p
+	}
+	return result
+}
+
+// getSmartctlData executes smartctl and parses its JSON output
+func (c *smartctlCollector) getSmartctlData(device string) (*smartctlDevice, error) {
+	args := []string{"-j", "-a"}
+
+	if len(c.cfg.ScanDeviceTypes) > 0 && c.cfg.ScanDeviceTypes[0] != "auto" {
+		args = append(args, "-d", c.cfg.ScanDeviceTypes[0])
+	}
+
+	if c.cfg.PowermodeCheck != "never" {
+		args = append(args, "-n", c.cfg.PowermodeCheck)
+	}
+
+	args = append(args, device)
+
+	cmd := exec.Command(c.cfg.SmartctlPath, args...)
+	output, err := cmd.Output()
+
+	if err != nil && len(output) == 0 {
+		return nil, fmt.Errorf("smartctl execution failed: %w", err)
+	}
+
+	var data smartctlDevice
+	if err := json.Unmarshal(output, &data); err != nil {
+		return nil, fmt.Errorf("failed to parse smartctl JSON: %w", err)
+	}
+
+	return &data, nil
+}
+
+// discoverDevices finds available storage devices
+func (c *smartctlCollector) discoverDevices() ([]string, error) {
+	cmd := exec.Command(c.cfg.SmartctlPath, "--scan-open", "--json")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("device scan failed: %w", err)
+	}
+
+	var scanResult struct {
+		Devices []struct {
+			Name string `json:"name"`
+		} `json:"devices"`
+	}
+
+	if err := json.Unmarshal(output, &scanResult); err != nil {
+		return nil, fmt.Errorf("failed to parse scan JSON: %w", err)
+	}
+
+	var devices []string
+	for _, dev := range scanResult.Devices {
+		if c.shouldIncludeDevice(dev.Name) {
+			devices = append(devices, dev.Name)
+		}
+	}
+
+	level.Debug(c.logger).Log("msg", "discovered devices", "count", len(devices), "devices", fmt.Sprintf("%v", devices))
+
+	return devices, nil
+}
+
+// shouldIncludeDevice checks if a device should be included based on filters
+func (c *smartctlCollector) shouldIncludeDevice(device string) bool {
+	if c.includeFilter != nil {
+		return c.includeFilter.MatchString(device)
+	}
+	if c.excludeFilter != nil {
+		return !c.excludeFilter.MatchString(device)
+	}
+	return true
+}
+
+// Run starts the background scanning process
+func (c *smartctlCollector) Run(ctx context.Context) error {
+	if c.cfg.RescanInterval == 0 || len(c.cfg.Devices) > 0 {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	ticker := time.NewTicker(c.cfg.RescanInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			devices, err := c.discoverDevices()
+			if err != nil {
+				level.Warn(c.logger).Log("msg", "device rescan failed", "err", err)
+				continue
+			}
+
+			c.mu.Lock()
+			c.devices = devices
+			c.mu.Unlock()
+
+			level.Debug(c.logger).Log("msg", "device list updated", "count", len(devices))
+		}
+	}
+}

--- a/internal/component/prometheus/exporter/smartctl/integration.go
+++ b/internal/component/prometheus/exporter/smartctl/integration.go
@@ -1,0 +1,107 @@
+package smartctl
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/grafana/alloy/internal/static/integrations"
+	"github.com/grafana/alloy/internal/static/integrations/config"
+)
+
+// Config controls the smartctl_exporter integration.
+type Config struct {
+	SmartctlPath    string        `yaml:"smartctl_path,omitempty"`
+	ScanInterval    time.Duration `yaml:"scan_interval,omitempty"`
+	RescanInterval  time.Duration `yaml:"rescan_interval,omitempty"`
+	Devices         []string      `yaml:"devices,omitempty"`
+	DeviceExclude   string        `yaml:"device_exclude,omitempty"`
+	DeviceInclude   string        `yaml:"device_include,omitempty"`
+	ScanDeviceTypes []string      `yaml:"scan_device_types,omitempty"`
+	PowermodeCheck  string        `yaml:"powermode_check,omitempty"`
+}
+
+var _ integrations.Config = (*Config)(nil)
+
+// Name returns the name of the integration.
+func (c *Config) Name() string {
+	return "smartctl_exporter"
+}
+
+// InstanceKey returns the instance key for the integration.
+func (c *Config) InstanceKey(defaultKey string) (string, error) {
+	return "localhost", nil
+}
+
+// NewIntegration creates a new smartctl_exporter integration.
+func (c *Config) NewIntegration(l log.Logger) (integrations.Integration, error) {
+	if err := c.validate(); err != nil {
+		return nil, fmt.Errorf("invalid configuration: %w", err)
+	}
+
+	collector, err := newSmartctlCollector(l, c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create smartctl collector: %w", err)
+	}
+
+	level.Info(l).Log("msg", "smartctl_exporter integration initialized",
+		"smartctl_path", c.SmartctlPath,
+		"scan_interval", c.ScanInterval,
+		"rescan_interval", c.RescanInterval)
+
+	return &integration{
+		cfg:       c,
+		logger:    l,
+		collector: collector,
+	}, nil
+}
+
+func (c *Config) validate() error {
+	if c.DeviceExclude != "" && c.DeviceInclude != "" {
+		return fmt.Errorf("device_exclude and device_include are mutually exclusive")
+	}
+
+	validPowermodes := map[string]bool{
+		"never": true, "sleep": true, "standby": true, "idle": true,
+	}
+	if c.PowermodeCheck != "" && !validPowermodes[c.PowermodeCheck] {
+		return fmt.Errorf("invalid powermode_check: %s (must be never, sleep, standby, or idle)", c.PowermodeCheck)
+	}
+
+	return nil
+}
+
+// integration is the smartctl_exporter integration.
+type integration struct {
+	cfg       *Config
+	logger    log.Logger
+	collector *smartctlCollector
+}
+
+// MetricsHandler implements Integration.
+func (i *integration) MetricsHandler() (http.Handler, error) {
+	registry := prometheus.NewRegistry()
+	if err := registry.Register(i.collector); err != nil {
+		return nil, fmt.Errorf("couldn't register smartctl collector: %w", err)
+	}
+	return promhttp.HandlerFor(registry, promhttp.HandlerOpts{}), nil
+}
+
+// Run satisfies Integration.Run.
+func (i *integration) Run(ctx context.Context) error {
+	return i.collector.Run(ctx)
+}
+
+// ScrapeConfigs satisfies Integration.ScrapeConfigs.
+func (i *integration) ScrapeConfigs() []config.ScrapeConfig {
+	return []config.ScrapeConfig{{
+		JobName:     i.cfg.Name(),
+		MetricsPath: "/metrics",
+	}}
+}

--- a/internal/component/prometheus/exporter/smartctl/smartctl.go
+++ b/internal/component/prometheus/exporter/smartctl/smartctl.go
@@ -1,0 +1,104 @@
+// Package smartctl provides an Alloy component for the smartctl_exporter.
+package smartctl
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/grafana/alloy/internal/component"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter"
+	"github.com/grafana/alloy/internal/component/prometheus/exporter/common"
+	"github.com/grafana/alloy/internal/featuregate"
+	"github.com/grafana/alloy/internal/static/integrations"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:      "prometheus.exporter.smartctl",
+		Stability: featuregate.StabilityGenerallyAvailable,
+		Args:      Arguments{},
+		Exports:   exporter.Exports{},
+
+		Build: exporter.New(createExporter, "smartctl"),
+	})
+}
+
+func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, string, error) {
+	common.WarningIfUsedInCluster(opts)
+	a := args.(Arguments)
+	defaultInstanceKey := common.HostNameInstanceKey()
+	return integrations.NewIntegrationWithInstanceKey(opts.Logger, a.Convert(), defaultInstanceKey)
+}
+
+// DefaultArguments holds the default settings for the smartctl exporter.
+var DefaultArguments = Arguments{
+	SmartctlPath:   "/usr/sbin/smartctl",
+	ScanInterval:   60 * time.Second,
+	RescanInterval: 10 * time.Minute,
+	PowermodeCheck: "standby",
+}
+
+// Arguments controls the prometheus.exporter.smartctl component.
+type Arguments struct {
+	// SmartctlPath is the path to the smartctl binary.
+	SmartctlPath string `alloy:"smartctl_path,attr,optional"`
+
+	// ScanInterval is how often to poll smartctl for device data.
+	ScanInterval time.Duration `alloy:"scan_interval,attr,optional"`
+
+	// RescanInterval is how often to rescan for new/removed devices.
+	RescanInterval time.Duration `alloy:"rescan_interval,attr,optional"`
+
+	// Devices is a list of specific devices to monitor.
+	Devices []string `alloy:"devices,attr,optional"`
+
+	// DeviceExclude is a regex pattern to exclude devices from automatic scanning.
+	DeviceExclude string `alloy:"device_exclude,attr,optional"`
+
+	// DeviceInclude is a regex pattern to include only matching devices.
+	DeviceInclude string `alloy:"device_include,attr,optional"`
+
+	// ScanDeviceTypes controls the device types to scan.
+	ScanDeviceTypes []string `alloy:"scan_device_types,attr,optional"`
+
+	// PowermodeCheck determines when to skip checking devices based on power mode.
+	PowermodeCheck string `alloy:"powermode_check,attr,optional"`
+}
+
+// SetToDefault implements syntax.Defaulter.
+func (a *Arguments) SetToDefault() {
+	*a = DefaultArguments
+}
+
+// Validate implements syntax.Validator.
+func (a *Arguments) Validate() error {
+	if a.DeviceExclude != "" && a.DeviceInclude != "" {
+		return fmt.Errorf("device_exclude and device_include are mutually exclusive")
+	}
+
+	validPowermodes := map[string]bool{
+		"never":   true,
+		"sleep":   true,
+		"standby": true,
+		"idle":    true,
+	}
+	if a.PowermodeCheck != "" && !validPowermodes[a.PowermodeCheck] {
+		return fmt.Errorf("invalid powermode_check: %s (must be never, sleep, standby, or idle)", a.PowermodeCheck)
+	}
+
+	return nil
+}
+
+// Convert converts Arguments to the integration's Config type.
+func (a *Arguments) Convert() *Config {
+	return &Config{
+		SmartctlPath:    a.SmartctlPath,
+		ScanInterval:    a.ScanInterval,
+		RescanInterval:  a.RescanInterval,
+		Devices:         a.Devices,
+		DeviceExclude:   a.DeviceExclude,
+		DeviceInclude:   a.DeviceInclude,
+		ScanDeviceTypes: a.ScanDeviceTypes,
+		PowermodeCheck:  a.PowermodeCheck,
+	}
+}

--- a/internal/component/prometheus/exporter/smartctl/smartctl_test.go
+++ b/internal/component/prometheus/exporter/smartctl/smartctl_test.go
@@ -1,0 +1,156 @@
+package smartctl
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/alloy/syntax"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlloyConfigUnmarshal(t *testing.T) {
+	var exampleAlloyConfig = `
+	smartctl_path = "/usr/local/bin/smartctl"
+	scan_interval = "30s"
+	rescan_interval = "5m"
+	devices = ["/dev/sda", "/dev/nvme0n1"]
+	device_exclude = "^(ram|loop)\\d+$"
+	scan_device_types = ["sat", "nvme"]
+	powermode_check = "idle"
+`
+
+	var args Arguments
+	err := syntax.Unmarshal([]byte(exampleAlloyConfig), &args)
+	require.NoError(t, err)
+
+	require.Equal(t, "/usr/local/bin/smartctl", args.SmartctlPath)
+	require.Equal(t, 30*time.Second, args.ScanInterval)
+	require.Equal(t, 5*time.Minute, args.RescanInterval)
+	require.Equal(t, []string{"/dev/sda", "/dev/nvme0n1"}, args.Devices)
+	require.Equal(t, "^(ram|loop)\\d+$", args.DeviceExclude)
+	require.Equal(t, []string{"sat", "nvme"}, args.ScanDeviceTypes)
+	require.Equal(t, "idle", args.PowermodeCheck)
+}
+
+func TestAlloyConfigUnmarshalDefaults(t *testing.T) {
+	var emptyConfig = ``
+
+	var args Arguments
+	err := syntax.Unmarshal([]byte(emptyConfig), &args)
+	require.NoError(t, err)
+
+	// Should have defaults after unmarshaling empty config
+	args.SetToDefault()
+	require.Equal(t, "/usr/sbin/smartctl", args.SmartctlPath)
+	require.Equal(t, 60*time.Second, args.ScanInterval)
+	require.Equal(t, 10*time.Minute, args.RescanInterval)
+	require.Equal(t, "standby", args.PowermodeCheck)
+}
+
+func TestAlloyConfigConvert(t *testing.T) {
+	var exampleAlloyConfig = `
+	smartctl_path = "/usr/local/bin/smartctl"
+	scan_interval = "30s"
+	rescan_interval = "5m"
+	devices = ["/dev/sda", "/dev/nvme0n1"]
+	device_exclude = "^(ram|loop)\\d+$"
+	scan_device_types = ["sat", "nvme"]
+	powermode_check = "idle"
+`
+
+	var args Arguments
+	err := syntax.Unmarshal([]byte(exampleAlloyConfig), &args)
+	require.NoError(t, err)
+
+	c := args.Convert()
+	require.Equal(t, "/usr/local/bin/smartctl", c.SmartctlPath)
+	require.Equal(t, 30*time.Second, c.ScanInterval)
+	require.Equal(t, 5*time.Minute, c.RescanInterval)
+	require.Equal(t, []string{"/dev/sda", "/dev/nvme0n1"}, c.Devices)
+	require.Equal(t, "^(ram|loop)\\d+$", c.DeviceExclude)
+	require.Equal(t, []string{"sat", "nvme"}, c.ScanDeviceTypes)
+	require.Equal(t, "idle", c.PowermodeCheck)
+}
+
+func TestValidate_MutuallyExclusiveFilters(t *testing.T) {
+	args := Arguments{
+		DeviceInclude: "^sd",
+		DeviceExclude: "^loop",
+	}
+	require.Error(t, args.Validate())
+	require.Contains(t, args.Validate().Error(), "mutually exclusive")
+}
+
+func TestValidate_InvalidPowermode(t *testing.T) {
+	args := Arguments{
+		PowermodeCheck: "invalid",
+	}
+	require.Error(t, args.Validate())
+	require.Contains(t, args.Validate().Error(), "invalid powermode_check")
+}
+
+func TestValidate_ValidPowermodes(t *testing.T) {
+	validModes := []string{"never", "sleep", "standby", "idle"}
+
+	for _, mode := range validModes {
+		t.Run("powermode="+mode, func(t *testing.T) {
+			args := Arguments{
+				PowermodeCheck: mode,
+			}
+			require.NoError(t, args.Validate())
+		})
+	}
+}
+
+func TestValidate_ValidConfig(t *testing.T) {
+	args := Arguments{
+		SmartctlPath:    "/usr/sbin/smartctl",
+		ScanInterval:    60 * time.Second,
+		RescanInterval:  10 * time.Minute,
+		DeviceExclude:   "^(ram|loop)\\d+$",
+		PowermodeCheck:  "standby",
+		ScanDeviceTypes: []string{"sat"},
+	}
+	require.NoError(t, args.Validate())
+}
+
+func TestValidate_DeviceIncludeOnly(t *testing.T) {
+	args := Arguments{
+		DeviceInclude: "^sd",
+	}
+	require.NoError(t, args.Validate())
+}
+
+func TestValidate_DeviceExcludeOnly(t *testing.T) {
+	args := Arguments{
+		DeviceExclude: "^loop",
+	}
+	require.NoError(t, args.Validate())
+}
+
+func TestSetToDefault(t *testing.T) {
+	args := Arguments{
+		SmartctlPath:   "/custom/path",
+		ScanInterval:   30 * time.Second,
+		RescanInterval: 5 * time.Minute,
+	}
+
+	args.SetToDefault()
+
+	require.Equal(t, DefaultArguments.SmartctlPath, args.SmartctlPath)
+	require.Equal(t, DefaultArguments.ScanInterval, args.ScanInterval)
+	require.Equal(t, DefaultArguments.RescanInterval, args.RescanInterval)
+	require.Equal(t, DefaultArguments.PowermodeCheck, args.PowermodeCheck)
+}
+
+func TestConfig_Name(t *testing.T) {
+	cfg := &Config{}
+	require.Equal(t, "smartctl_exporter", cfg.Name())
+}
+
+func TestConfig_InstanceKey(t *testing.T) {
+	cfg := &Config{}
+	got, err := cfg.InstanceKey("default")
+	require.NoError(t, err)
+	require.Equal(t, "localhost", got)
+}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide.

-->

#### PR Description

This PR adds a new prometheus.exporter.smartctl component to Grafana Alloy for collecting hardware metrics from S.M.A.R.T enabled devices.


#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
fixes: https://github.com/grafana/alloy/issues/230
fixes: https://github.com/grafana/alloy/issues/3799

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
