### PR TITLE
fix: update syslog parser tests to account for new years logic

### DIFF
--- a/internal/component/loki/source/syslog/internal/syslogtarget/syslogparser/syslogparser_test.go
+++ b/internal/component/loki/source/syslog/internal/syslogtarget/syslogparser/syslogparser_test.go
@@ -137,13 +137,13 @@ func TestParseStream_RFC3164TimestampWithYear(t *testing.T) {
 	// Manually calculate the expected year based on the edge case logic (SetYearForLimitedTimeFormat)
 	now := time.Now()
 	expectedYear := now.Year()
-	if now.Month() == 1 {
+	if now.Month() == time.January {
 		expectedYear = now.Year() - 1
-	} else if now.Month() == 12 {
+	} else if now.Month() == time.December {
 		expectedYear = now.Year() + 1
 	}
 
-	require.Equal(t, time.Date(expectedYear, 12, 1, 0, 0, 0, 0, time.UTC), *results[0].Message.(*rfc3164.SyslogMessage).Timestamp)
+	require.Equal(t, time.Date(expectedYear, time.December, 1, 0, 0, 0, 0, time.UTC), *results[0].Message.(*rfc3164.SyslogMessage).Timestamp)
 }
 
 // Tests the edge case where a December log is parsed in January, which should use the previous year.


### PR DESCRIPTION
Happy new year!

Our syslogparser tests began failing, which can be traced back to some special logic handled in [this function](https://github.com/grafana/alloy/blob/923d127c50949f88a37ac808154240de0649df09/internal/util/time.go#L9). Because our tests are now running in January and are parsing the month of December, the output year will _not_ be equal to time.now().year(), instead our SetYearForLimitedTimeFormat function returns now().year()-1. Similarly, if we're attempting to parse a January time in the month of December, our SetYearForLimitedTimeFormat returns now().year()+1

This PR introduces tests so that this behavior is explicit, and adjusts the existing test to account for the logic

BEGIN_COMMIT_OVERRIDE
test: update syslog parser tests to account for new years logic (#5166)
END_COMMIT_OVERRIDE