### PR TITLE
feat(chart): add optional gateway component

### DIFF
--- a/operations/helm/charts/alloy/ci/gateway-ingress-values.yaml
+++ b/operations/helm/charts/alloy/ci/gateway-ingress-values.yaml
@@ -1,0 +1,163 @@
+# Example values file for NGINX gateway with Ingress integration
+# This demonstrates using Kubernetes Ingress to route to the NGINX gateway
+
+# Enable the gateway
+gateway:
+  # -- Enable the NGINX gateway component.
+  enabled: true
+  # -- Number of gateway replicas.
+  replicas: 2
+
+  # ClusterIP service - Ingress will route to this
+  service:
+    type: ClusterIP
+
+  # Configure upstreams
+  upstreams:
+    otlpGrpc:
+      enabled: true
+      path: /opentelemetry
+      targetPort: 4317
+      protocol: grpc
+
+    otlpHttp:
+      enabled: true
+      path: /otlp/v1
+      targetPort: 4318
+      protocol: http
+
+    loki:
+      enabled: true
+      path: /loki/api/v1/push
+      targetPort: 3100
+      protocol: http
+
+    prometheus:
+      enabled: true
+      path: /api/v1/metrics/write
+      targetPort: 9009
+      protocol: http
+
+  # Performance tuning
+  nginxConfig:
+    enableAccessLog: false
+    workerConnections: 2048
+
+  # Resources
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+# Enable Ingress to route external traffic to gateway
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - alloy.example.com
+  path: /
+  pathType: Prefix
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  tls:
+    - secretName: alloy-tls
+      hosts:
+        - alloy.example.com
+
+# Alloy configuration
+alloy:
+  configMap:
+    content: |
+      logging {
+        level  = "info"
+        format = "logfmt"
+      }
+
+      // OpenTelemetry receiver
+      otelcol.receiver.otlp "default" {
+        grpc {
+          endpoint = "0.0.0.0:4317"
+        }
+
+        http {
+          endpoint = "0.0.0.0:4318"
+        }
+
+        output {
+          metrics = [otelcol.exporter.prometheus.default.input]
+          logs    = [otelcol.exporter.loki.default.input]
+          traces  = [otelcol.exporter.otlp.default.input]
+        }
+      }
+
+      // Loki receiver
+      loki.source.api "default" {
+        http {
+          listen_address = "0.0.0.0"
+          listen_port    = 3100
+        }
+
+        forward_to = [loki.write.default.receiver]
+      }
+
+      // Exporters
+      otelcol.exporter.prometheus "default" {
+        forward_to = [prometheus.remote_write.default.receiver]
+      }
+
+      otelcol.exporter.loki "default" {
+        forward_to = [loki.write.default.receiver]
+      }
+
+      otelcol.exporter.otlp "default" {
+        client {
+          endpoint = env("OTLP_ENDPOINT")
+        }
+      }
+
+      loki.write "default" {
+        endpoint {
+          url = env("LOKI_URL")
+        }
+      }
+
+      prometheus.remote_write "default" {
+        endpoint {
+          url = env("PROMETHEUS_REMOTE_WRITE_URL")
+        }
+      }
+
+  # Expose ports
+  extraPorts:
+  - name: otlp-grpc
+    port: 4317
+    targetPort: 4317
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: 4318
+    protocol: TCP
+  - name: loki
+    port: 3100
+    targetPort: 3100
+    protocol: TCP
+  - name: prometheus
+    port: 9009
+    targetPort: 9009
+    protocol: TCP
+
+# Controller configuration
+controller:
+  type: deployment
+  replicas: 2
+
+# RBAC
+rbac:
+  create: true
+
+# ServiceAccount
+serviceAccount:
+  create: true

--- a/operations/helm/charts/alloy/ci/gateway-values.yaml
+++ b/operations/helm/charts/alloy/ci/gateway-values.yaml
@@ -1,0 +1,229 @@
+# Example values file demonstrating NGINX gateway configuration for Alloy
+# This provides a unified HTTP(S) entry point with path-based routing
+
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - alloy.example.com
+
+# Enable the gateway
+gateway:
+  enabled: true
+  replicas: 2
+
+  # Configure upstreams - enable/disable protocols as needed
+  # You can add custom upstreams by adding new keys here
+  upstreams:
+    # OTLP gRPC endpoint for traces
+    otlpGrpc:
+      enabled: true
+      path: /opentelemetry
+      targetPort: 4317
+      protocol: grpc
+
+    # OTLP HTTP endpoint for logs
+    otlpHttp:
+      enabled: true
+      path: /otlp/v1
+      targetPort: 4318
+      protocol: http
+
+    # Loki endpoint for logs
+    loki:
+      enabled: true
+      path: /loki/api/v1/push
+      targetPort: 3100
+      protocol: http
+
+    # Prometheus remote write endpoint
+    prometheus:
+      enabled: true
+      path: /api/v1/metrics/write
+      targetPort: 9009
+      protocol: http
+
+    # Pyroscope endpoint for continuous profiling
+    pyroscope:
+      enabled: false
+      path: /push.v1.PusherService/Push
+      targetPort: 4100
+      protocol: http
+
+    # Example custom upstream
+    # custom:
+    #   enabled: true
+    #   path: /custom
+    #   targetPort: 9000
+    #   protocol: http
+    #   extraConfig: |
+    #     proxy_pass http://alloy-custom;
+    #     proxy_set_header X-Custom-Header "value";
+
+  # TLS configuration
+  tls:
+    enabled: true
+    secretName: alloy-gateway-tls
+    port: 8443
+
+  # Basic authentication at gateway level
+  auth:
+    enabled: true
+    existingSecret: alloy-gateway-auth
+    realm: "Alloy Gateway"
+
+  # Resource limits
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+  # Enable autoscaling
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 70
+
+  # Pod disruption budget for high availability
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
+
+  # NGINX configuration tuning
+  nginxConfig:
+    workerProcesses: auto
+    workerConnections: 2048
+    clientMaxBodySize: "50m"
+    proxyReadTimeout: "120s"
+    # Disable access logging for better performance
+    enableAccessLog: false
+    # Custom log format (only used if enableAccessLog is true)
+    logFormat: '$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent'
+
+  # Enable metrics collection with nginx-prometheus-exporter sidecar
+  extraContainers:
+    - name: nginx-exporter
+      image: nginx/nginx-prometheus-exporter:1.1.0
+      args:
+        - -nginx.scrape-uri=http://localhost:{{ .Values.gateway.port }}/stub_status
+      ports:
+        - name: metrics
+          containerPort: 9113
+      resources:
+        limits:
+          cpu: 100m
+          memory: 128Mi
+        requests:
+          cpu: 10m
+          memory: 64Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        runAsUser: 101
+
+  # Enable ServiceMonitor for Prometheus Operator
+  serviceMonitor:
+    enabled: true
+    additionalLabels:
+      prometheus: kube-prometheus
+
+# Alloy configuration to listen on required ports
+alloy:
+  configMap:
+    content: |
+      logging {
+        level  = "info"
+        format = "logfmt"
+      }
+
+      // OTLP gRPC receiver
+      otelcol.receiver.otlp "default" {
+        grpc {
+          endpoint = "0.0.0.0:4317"
+        }
+
+        http {
+          endpoint = "0.0.0.0:4318"
+        }
+
+        output {
+          metrics = [otelcol.exporter.prometheus.default.input]
+          logs    = [otelcol.exporter.loki.default.input]
+          traces  = [otelcol.exporter.otlp.default.input]
+        }
+      }
+
+      // Loki receiver
+      loki.source.api "default" {
+        http {
+          listen_address = "0.0.0.0"
+          listen_port    = 3100
+        }
+
+        forward_to = [loki.write.default.receiver]
+      }
+
+      // Prometheus remote write receiver
+      prometheus.remote_write "default" {
+        endpoint {
+          url = env("PROMETHEUS_REMOTE_WRITE_URL")
+        }
+      }
+
+      // Example exporters (configure with your actual endpoints)
+      otelcol.exporter.prometheus "default" {
+        forward_to = [prometheus.remote_write.default.receiver]
+      }
+
+      otelcol.exporter.loki "default" {
+        forward_to = [loki.write.default.receiver]
+      }
+
+      otelcol.exporter.otlp "default" {
+        client {
+          endpoint = env("OTLP_ENDPOINT")
+        }
+      }
+
+      loki.write "default" {
+        endpoint {
+          url = env("LOKI_URL")
+        }
+      }
+
+  # Expose additional ports for telemetry protocols
+  extraPorts:
+  - name: otlp-grpc
+    port: 4317
+    targetPort: 4317
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: 4318
+    protocol: TCP
+  - name: loki
+    port: 3100
+    targetPort: 3100
+    protocol: TCP
+  - name: prometheus
+    port: 9009
+    targetPort: 9009
+    protocol: TCP
+
+# Deploy as StatefulSet for persistent storage
+controller:
+  type: statefulset
+  replicas: 3
+
+# Enable RBAC
+rbac:
+  create: true
+
+# Enable ServiceAccount
+serviceAccount:
+  create: true

--- a/operations/helm/charts/alloy/docs/gateway.md
+++ b/operations/helm/charts/alloy/docs/gateway.md
@@ -1,0 +1,524 @@
+# NGINX Gateway for Grafana Alloy
+
+## NGINX Gateway for Grafana Alloy
+
+The NGINX gateway provides a unified HTTP(S) entry point with path-based routing to Grafana Alloy's multiple protocol endpoints.
+
+## Use case
+
+When operating a centralized Grafana Alloy deployment, it listens on multiple ports for different telemetry protocols (OpenTelemetry on 4317/4318, Loki on 3100, Prometheus on 9009, etc.). In production deployments, this creates several challenges:
+
+- **Multiple endpoints to manage**: Clients need to know and configure different endpoints for each protocol
+- **TLS termination**: Need to configure TLS certificates for each port/service separately
+- **Authentication**: When using multi-user basic auth, auth must be configured per protocol endpoint
+- **Firewall/security rules**: Opening multiple ports increases attack surface and complexity
+
+The NGINX gateway solves these problems by providing:
+
+- Single entry point for all telemetry data
+- Centralized TLS termination
+- Unified authentication layer
+- Path-based routing to different protocol backends
+- Fine-grained control over proxy behavior (buffering, timeouts, connection pooling)
+
+## Architecture
+
+```
+                                    ┌─────────────────────┐
+                                    │   NGINX Gateway     │
+                                    │  (Port 8080/8443)   │
+                                    └──────────┬──────────┘
+                                               │
+                     ┌─────────────────────────┼─────────────────────────┐
+                     │                         │                         │
+         ┌───────────▼────────────┐ ┌─────────▼───────────┐ ┌───────────▼────────────┐
+         │  /opentelemetry → 4317 │ │ /otlp/v1/logs → 4318│ │ /loki/api/v1/push →    │
+         │  (OTLP gRPC)           │ │ (OTLP HTTP)         │ │      3100 (Loki)       │
+         └────────────────────────┘ └─────────────────────┘ └────────────────────────┘
+
+```
+
+## Installation
+
+### Basic setup
+
+To enable the NGINX gateway with default settings:
+
+```yaml
+gateway:
+  enabled: true
+```
+
+This will deploy:
+- NGINX deployment with 2 replicas
+- ClusterIP service on port 8080
+- Default routing for OpenTelemetry, Loki, and Prometheus endpoints
+
+### With TLS
+
+To enable TLS:
+
+```bash
+# Create TLS secret
+kubectl create secret tls alloy-gateway-tls \
+  --cert=path/to/tls.crt \
+  --key=path/to/tls.key
+```
+
+```yaml
+gateway:
+  enabled: true
+  tls:
+    enabled: true
+    secretName: alloy-gateway-tls
+    port: 8443
+```
+
+### With authentication
+
+To enable basic authentication:
+
+```bash
+# Create htpasswd file
+htpasswd -c .htpasswd user1
+htpasswd .htpasswd user2
+
+# Create secret
+kubectl create secret generic alloy-gateway-auth \
+  --from-file=auth=.htpasswd
+```
+
+```yaml
+gateway:
+  enabled: true
+  auth:
+    enabled: true
+    existingSecret: alloy-gateway-auth
+    realm: "Alloy Gateway"
+```
+
+### With LoadBalancer
+
+To expose the gateway externally:
+
+```yaml
+gateway:
+  enabled: true
+  service:
+    type: LoadBalancer
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+```
+
+### With Ingress
+
+The gateway automatically integrates with the existing Ingress configuration. When both `gateway.enabled` and `ingress.enabled` are true, the Ingress will automatically route traffic to the gateway service instead of directly to Grafana Alloy:
+
+```yaml
+gateway:
+  enabled: true
+
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - alloy.example.com
+  tls:
+    - secretName: alloy-tls
+      hosts:
+        - alloy.example.com
+```
+
+This configuration creates:
+- NGINX gateway handling telemetry protocol routing
+- Kubernetes Ingress routing external traffic to the gateway
+- Single external hostname for all telemetry data
+
+The Ingress will route to:
+- `alloy-gateway` service on port 8080 (when gateway is enabled)
+- `alloy` service on port 12347 (when gateway is disabled)
+
+## Configuration
+
+### Upstream protocols
+
+Configure which protocols to enable and their routing:
+
+```yaml
+gateway:
+  enabled: true
+  upstreams:
+    # OpenTelemetry gRPC endpoint for traces
+    otlpGrpc:
+      enabled: true
+      path: /v1/traces
+      targetPort: 4317
+
+    # OpenTelemetry HTTP endpoint for logs
+    otlpHttp:
+      enabled: true
+      path: /v1/logs
+      targetPort: 4318
+
+    # Loki endpoint for logs
+    loki:
+      enabled: true
+      path: /loki/api/v1/push
+      targetPort: 3100
+
+    # Prometheus remote write endpoint
+    prometheus:
+      enabled: true
+      path: /api/v1/push
+      targetPort: 9009
+
+    # Pyroscope endpoint for continuous profiling
+    pyroscope:
+      enabled: true
+      path: /ingest
+      targetPort: 4100
+```
+
+### NGINX tuning
+
+Adjust NGINX configuration for your workload:
+
+```yaml
+gateway:
+  enabled: true
+  nginxConfig:
+    workerProcesses: auto
+    workerConnections: 2048
+    clientMaxBodySize: "50m"
+    proxyConnectTimeout: "60s"
+    proxySendTimeout: "120s"
+    proxyReadTimeout: "120s"
+    # Disable access logging for better performance in high-traffic environments
+    enableAccessLog: false
+    # Custom log format (only used if enableAccessLog is true)
+    logFormat: '$remote_addr - $remote_user [$time_local] "$request" $status'
+```
+
+### Autoscaling
+
+Enable horizontal pod autoscaling:
+
+```yaml
+gateway:
+  enabled: true
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
+```
+
+### High availability
+
+Configure for production deployments:
+
+```yaml
+gateway:
+  enabled: true
+  replicas: 3
+
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 2
+
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/component
+              operator: In
+              values:
+              - gateway
+          topologyKey: kubernetes.io/hostname
+```
+
+### Monitoring
+
+Enable metrics collection with nginx-prometheus-exporter:
+
+```yaml
+gateway:
+  enabled: true
+
+  extraContainers:
+  - name: nginx-exporter
+    image: nginx/nginx-prometheus-exporter:1.1.0
+    args:
+    - -nginx.scrape-uri=http://localhost:8080/stub_status
+    ports:
+    - name: metrics
+      containerPort: 9113
+      protocol: TCP
+
+  serviceMonitor:
+    enabled: true
+    additionalLabels:
+      prometheus: kube-prometheus
+```
+
+### Custom NGINX configuration
+
+Add custom NGINX directives:
+
+```yaml
+gateway:
+  enabled: true
+  nginxConfig:
+    extraHttpConfig: |
+      # Add custom HTTP block configuration
+      gzip on;
+      gzip_types text/plain application/json;
+
+    extraServerConfig: |
+      # Add custom server block configuration
+      location /custom {
+        return 200 "Custom endpoint";
+      }
+```
+
+Add custom configuration per upstream:
+
+```yaml
+gateway:
+  enabled: true
+  upstreams:
+    loki:
+      enabled: true
+      path: /loki/api/v1/push
+      targetPort: 3100
+      protocol: http
+      extraConfig: |
+        proxy_pass http://alloy-loki;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        # Custom headers
+        proxy_set_header X-Scope-OrgID "tenant-1";
+```
+
+Add custom upstreams dynamically:
+
+```yaml
+gateway:
+  enabled: true
+  upstreams:
+    # Add any custom upstream by creating a new key
+    myCustomBackend:
+      enabled: true
+      path: /custom/api
+      targetPort: 9000
+      protocol: http
+      extraConfig: |
+        proxy_pass http://alloy-myCustomBackend;
+        proxy_set_header X-Custom-Header "value";
+```
+
+Override entire NGINX configuration:
+
+```yaml
+gateway:
+  enabled: true
+  nginxConfig:
+    customConfig: |
+      worker_processes 4;
+      events {
+        worker_connections 1024;
+      }
+      http {
+        server {
+          listen {{ .Values.gateway.port }};
+          location / {
+            proxy_pass http://{{ include "alloy.fullname" . }}.{{ include "alloy.namespace" . }}.svc.cluster.local:12345;
+          }
+        }
+      }
+```
+
+The `customConfig` field is passed through Helm's `tpl` function, giving you access to all template variables and functions.
+
+## Grafana Alloy configuration
+
+Configure Grafana Alloy to listen on the required ports:
+
+```yaml
+alloy:
+  configMap:
+    content: |
+      // OpenTelemetry receiver
+      otelcol.receiver.otlp "default" {
+        grpc {
+          endpoint = "0.0.0.0:4317"
+        }
+
+        http {
+          endpoint = "0.0.0.0:4318"
+        }
+
+        output {
+          metrics = [otelcol.exporter.prometheus.default.input]
+          logs    = [otelcol.exporter.loki.default.input]
+          traces  = [otelcol.exporter.otlp.default.input]
+        }
+      }
+
+      // Loki receiver
+      loki.source.api "default" {
+        http {
+          listen_address = "0.0.0.0"
+          listen_port    = 3100
+        }
+
+        forward_to = [loki.write.default.receiver]
+      }
+
+  # Expose additional ports
+  extraPorts:
+  - name: otlp-grpc
+    port: 4317
+    targetPort: 4317
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: 4318
+    protocol: TCP
+  - name: loki
+    port: 3100
+    targetPort: 3100
+    protocol: TCP
+```
+
+## Client configuration
+
+### OpenTelemetry
+
+Configure OpenTelemetry clients to use the gateway:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://alloy-gateway.example.com"
+export OTEL_EXPORTER_OTLP_HEADERS="authorization=Basic dXNlcjpwYXNz"
+```
+
+### Loki
+
+Configure Loki clients:
+
+```yaml
+clients:
+  - url: https://alloy-gateway.example.com/loki/api/v1/push
+    basic_auth:
+      username: user
+      password: pass
+```
+
+### Prometheus
+
+Configure Prometheus remote write:
+
+```yaml
+remote_write:
+  - url: https://alloy-gateway.example.com/api/v1/push
+    basic_auth:
+      username: user
+      password: pass
+```
+
+## Troubleshooting
+
+### Check gateway logs
+
+```bash
+kubectl logs -l app.kubernetes.io/component=gateway -n <namespace>
+```
+
+### Test connectivity
+
+```bash
+# Test health endpoint
+curl http://alloy-gateway:8080/health
+
+# Test with authentication
+curl -u user:pass https://alloy-gateway:8443/health
+
+# Check NGINX stub status
+kubectl exec -it <gateway-pod> -- curl http://localhost:8080/stub_status
+```
+
+### Debug routing
+
+Add debug logging to NGINX:
+
+```yaml
+gateway:
+  enabled: true
+  nginxConfig:
+    extraHttpConfig: |
+      log_format debug '$remote_addr - $remote_user [$time_local] '
+                       '"$request" $status $body_bytes_sent '
+                       '"$http_referer" "$http_user_agent" '
+                       'upstream: $upstream_addr '
+                       'upstream_status: $upstream_status '
+                       'request_time: $request_time '
+                       'upstream_response_time: $upstream_response_time';
+
+      access_log /var/log/nginx/access.log debug;
+```
+
+## Performance considerations
+
+The NGINX gateway introduces an additional network hop, which adds minimal latency (typically <1ms). For high-throughput deployments:
+
+1. Enable connection pooling (enabled by default with keepalive)
+2. Disable proxy buffering for streaming protocols (configured by default)
+3. Scale gateway replicas based on CPU/memory usage
+4. Use LoadBalancer or NodePort for direct external access
+
+## Migration from Ingress
+
+If you currently use Kubernetes Ingress for routing, you can migrate to the NGINX gateway:
+
+**Before (Ingress):**
+```yaml
+ingress:
+  enabled: true
+  annotations:
+    alb.ingress.kubernetes.io/conditions.alloy-grpc: |
+      [{"field":"http-header","httpHeaderConfig":{"httpHeaderName": "Content-Type", "values":["application/grpc"]}}]
+```
+
+**After (Gateway):**
+```yaml
+gateway:
+  enabled: true
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - alloy.example.com
+```
+
+Benefits of using the gateway instead of Ingress:
+
+- Fine-grained control over proxy behavior
+- Consistent configuration across cloud providers
+- Built-in health checks and metrics
+- Simplified authentication setup
+
+## Complete example
+
+Refer to `ci/gateway-values.yaml` for a complete production-ready example.

--- a/operations/helm/charts/alloy/templates/gateway/configmap.yaml
+++ b/operations/helm/charts/alloy/templates/gateway/configmap.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.gateway.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "alloy.fullname" . }}-gateway
+  namespace: {{ include "alloy.namespace" . }}
+  labels:
+    {{- include "alloy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+data:
+  nginx.conf: |- {{- tpl .Values.gateway.nginxConfig.file . | nindent 4 }}
+{{- end }}

--- a/operations/helm/charts/alloy/templates/gateway/deployment.yaml
+++ b/operations/helm/charts/alloy/templates/gateway/deployment.yaml
@@ -1,0 +1,157 @@
+{{- if .Values.gateway.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  {{- with .Values.gateway.annotations }}
+  annotations:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    {{- include "alloy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+    {{- with .Values.gateway.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "alloy.fullname" . }}-gateway
+  namespace: {{ include "alloy.namespace" . }}
+spec:
+  {{- if not .Values.gateway.autoscaling.enabled }}
+  replicas: {{ .Values.gateway.replicas }}
+  {{- end }}
+  {{- with .Values.gateway.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "alloy.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: gateway
+  {{- with .Values.gateway.updateStrategy }}
+  strategy:
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/gateway/configmap.yaml") . | sha256sum }}
+        {{- with .Values.gateway.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "alloy.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: gateway
+        {{- with .Values.gateway.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.gateway.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.gateway.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if $.Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range $.Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      containers:
+        - name: nginx
+        {{- $registry := .Values.gateway.image.registry }}
+        {{- if .Values.global.image.registry }}
+        {{- $registry = .Values.global.image.registry }}
+        {{- end }}
+          image: "{{ $registry }}/{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag }}"
+          imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.gateway.port }}
+              protocol: TCP
+        {{- if .Values.gateway.tls.enabled }}
+            - name: https
+              containerPort: {{ .Values.gateway.tls.port }}
+              protocol: TCP
+        {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+        {{- with .Values.gateway.resources }}
+          resources:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.gateway.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.gateway.extraEnv }}
+          env:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+              readOnly: true
+        {{- if .Values.gateway.auth.enabled }}
+            - name: auth
+              mountPath: /etc/nginx/auth
+              readOnly: true
+        {{- end }}
+        {{- if .Values.gateway.tls.enabled }}
+            - name: tls
+              mountPath: /etc/nginx/tls
+              readOnly: true
+        {{- end }}
+        {{- with .Values.gateway.extraVolumeMounts }}
+        {{- toYaml . | nindent 12 }}
+        {{- end }}
+      {{- with .Values.gateway.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.gateway.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.gateway.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.gateway.extraContainers }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.gateway.terminationGracePeriodSeconds }}
+      {{- with .Values.gateway.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ include "alloy.fullname" . }}-gateway
+      {{- if .Values.gateway.auth.enabled }}
+      - name: auth
+        secret:
+          secretName: {{ .Values.gateway.auth.existingSecret }}
+      {{- end }}
+      {{- if .Values.gateway.tls.enabled }}
+      - name: tls
+        secret:
+          secretName: {{ .Values.gateway.tls.secretName }}
+      {{- end }}
+      {{- with .Values.gateway.extraVolumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+{{- end }}

--- a/operations/helm/charts/alloy/templates/gateway/hpa.yaml
+++ b/operations/helm/charts/alloy/templates/gateway/hpa.yaml
@@ -1,0 +1,34 @@
+{{- if and .Values.gateway.enabled .Values.gateway.autoscaling.enabled -}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "alloy.fullname" . }}-gateway
+  namespace: {{ include "alloy.namespace" . }}
+  labels:
+    {{- include "alloy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "alloy.fullname" . }}-gateway
+  minReplicas: {{ .Values.gateway.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.gateway.autoscaling.maxReplicas }}
+  metrics:
+  {{- if .Values.gateway.autoscaling.targetCPUUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.gateway.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.gateway.autoscaling.targetMemoryUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.gateway.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/operations/helm/charts/alloy/templates/gateway/pdb.yaml
+++ b/operations/helm/charts/alloy/templates/gateway/pdb.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.gateway.enabled .Values.gateway.podDisruptionBudget.enabled -}}
+apiVersion: {{ include "alloy.controller.pdb.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "alloy.fullname" . }}-gateway
+  namespace: {{ include "alloy.namespace" . }}
+  labels:
+    {{- include "alloy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+spec:
+  selector:
+    matchLabels:
+      {{- include "alloy.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: gateway
+  {{- if .Values.gateway.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.gateway.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.gateway.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.gateway.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end }}

--- a/operations/helm/charts/alloy/templates/gateway/service.yaml
+++ b/operations/helm/charts/alloy/templates/gateway/service.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.gateway.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "alloy.fullname" . }}-gateway
+  namespace: {{ include "alloy.namespace" . }}
+  labels:
+    {{- include "alloy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+    {{- with .Values.gateway.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.gateway.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.gateway.service.type }}
+  {{- if .Values.gateway.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.gateway.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.gateway.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml .Values.gateway.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  selector:
+    {{- include "alloy.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+  ports:
+  - name: http
+    port: {{ .Values.gateway.port }}
+    targetPort: http
+    protocol: TCP
+    {{- if and (eq .Values.gateway.service.type "NodePort") .Values.gateway.service.nodePort }}
+    nodePort: {{ .Values.gateway.service.nodePort }}
+    {{- end }}
+  {{- if .Values.gateway.tls.enabled }}
+  - name: https
+    port: {{ .Values.gateway.tls.port }}
+    targetPort: https
+    protocol: TCP
+  {{- end }}
+  {{- if .Values.gateway.serviceMonitor.enabled }}
+  - name: metrics
+    port: 9113
+    targetPort: metrics
+    protocol: TCP
+  {{- end }}
+{{- end }}

--- a/operations/helm/charts/alloy/templates/gateway/servicemonitor.yaml
+++ b/operations/helm/charts/alloy/templates/gateway/servicemonitor.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.gateway.enabled .Values.gateway.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "alloy.fullname" . }}-gateway
+  namespace: {{ include "alloy.namespace" . }}
+  labels:
+    {{- include "alloy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+    {{- with .Values.gateway.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "alloy.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: gateway
+  endpoints:
+  - port: {{ .Values.gateway.serviceMonitor.port }}
+    {{- if .Values.gateway.serviceMonitor.interval }}
+    interval: {{ .Values.gateway.serviceMonitor.interval }}
+    {{- end }}
+    path: {{ .Values.gateway.serviceMonitor.path }}
+{{- end }}

--- a/operations/helm/charts/alloy/templates/ingress.yaml
+++ b/operations/helm/charts/alloy/templates/ingress.yaml
@@ -3,7 +3,12 @@
 {{- $ingressSupportsIngressClassName := eq (include "alloy.ingress.supportsIngressClassName" .) "true" -}}
 {{- $ingressSupportsPathType := eq (include "alloy.ingress.supportsPathType" .) "true" -}}
 {{- $fullName := include "alloy.fullname" . -}}
+{{- $serviceName := $fullName -}}
 {{- $servicePort := .Values.ingress.faroPort -}}
+{{- if .Values.gateway.enabled -}}
+{{- $serviceName = printf "%s-gateway" $fullName -}}
+{{- $servicePort = .Values.gateway.port -}}
+{{- end -}}
 {{- $ingressPath := .Values.ingress.path -}}
 {{- $ingressPathType := .Values.ingress.pathType -}}
 {{- $extraPaths := .Values.ingress.extraPaths -}}
@@ -48,11 +53,11 @@ spec:
             backend:
               {{- if $ingressApiIsStable }}
               service:
-                name: {{ $fullName }}
+                name: {{ $serviceName }}
                 port:
                   number: {{ $servicePort }}
               {{- else }}
-              serviceName: {{ $fullName }}
+              serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
               {{- end }}
   {{- end }}
@@ -62,11 +67,11 @@ spec:
           - backend:
               {{- if $ingressApiIsStable }}
               service:
-                name: {{ $fullName }}
+                name: {{ $serviceName }}
                 port:
                   number: {{ $servicePort }}
               {{- else }}
-              serviceName: {{ $fullName }}
+              serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
               {{- end }}
             {{- with $ingressPath }}

--- a/operations/helm/charts/alloy/values.yaml
+++ b/operations/helm/charts/alloy/values.yaml
@@ -498,7 +498,8 @@ serviceMonitor:
   #   replacement: $1
   #   action: replace
 ingress:
-  # -- Enables ingress for Alloy (Faro port)
+  # -- Enables ingress for Alloy (Faro port).
+  # When gateway.enabled is true, ingress will automatically route to the gateway service instead.
   enabled: false
   # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
   # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
@@ -510,6 +511,7 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   labels: {}
   path: /
+  # -- Port to use for ingress. Automatically uses gateway port when gateway.enabled is true.
   faroPort: 12347
 
   # pathType is only for k8s >= 1.1=
@@ -546,3 +548,408 @@ extraObjects: []
 #   stringData:
 #     PROMETHEUS_HOST: 'https://prometheus-us-central1.grafana.net/api/prom/push'
 #     PROMETHEUS_USERNAME: '123456'
+
+gateway:
+  # -- Enables the NGINX gateway deployment for unified HTTP(S) entry point.
+  enabled: false
+
+  # -- Number of gateway replicas to deploy.
+  replicas: 2
+  revisionHistoryLimit: null
+  dnsConfig: {}
+  # -- Annotations to add to the gateway deployment
+  annotations: {}
+  # -- Labels to add to the the gateway deployment
+  labels: {}
+
+  image:
+    # -- NGINX image registry.
+    registry: "docker.io"
+    # -- NGINX image repository.
+    repository: nginx
+    # -- NGINX image tag.
+    tag: "1.27-alpine"
+    # -- NGINX image pull policy.
+    pullPolicy: IfNotPresent
+    # -- Optional set of image pull secrets for NGINX.
+    pullSecrets: []
+
+  # -- Port for the gateway service to listen on.
+  port: 8080
+
+  # -- Service type for the gateway.
+  service:
+    # -- Service type (ClusterIP, LoadBalancer, NodePort).
+    type: ClusterIP
+    # -- Annotations for the gateway service.
+    annotations: {}
+    # -- Labels for the gateway service.
+    labels: {}
+    # -- NodePort port. Only takes effect when `gateway.service.type: NodePort`.
+    nodePort: null
+    # -- LoadBalancer IP. Only takes effect when `gateway.service.type: LoadBalancer`.
+    loadBalancerIP: null
+    # -- LoadBalancer source ranges. Only takes effect when `gateway.service.type: LoadBalancer`.
+    loadBalancerSourceRanges: []
+
+  # -- Authentication configuration for the gateway.
+  auth:
+    # -- Enables basic authentication at the gateway level.
+    enabled: false
+    # -- Name of existing secret containing .htpasswd file.
+    # The secret must contain a key named 'auth' with htpasswd-formatted content.
+    # Create with: htpasswd -c .htpasswd user
+    existingSecret: null
+    # -- Realm for basic authentication.
+    realm: "Alloy Gateway"
+
+  # -- Protocol upstreams configuration.
+  # Configure which protocols to enable and their routing.
+  # Each key becomes an upstream name, and you can add custom upstreams.
+  upstreams:
+    # -- OTLP gRPC endpoint configuration.
+    otlpGrpc:
+      # -- Enable OTLP gRPC endpoint.
+      enabled: true
+      # -- Path for OTLP gRPC endpoint.
+      path: /opentelemetry
+      # -- Target port on Alloy service for OTLP gRPC.
+      targetPort: 4317
+      # -- Protocol type (http or grpc).
+      protocol: grpc
+      # -- Additional NGINX location block configuration for this upstream.
+      extraConfig: ""
+
+    # -- OTLP HTTP endpoint configuration.
+    otlpHttp:
+      # -- Enable OTLP HTTP endpoint.
+      enabled: true
+      # -- Path for OTLP HTTP endpoint.
+      path: /otlp/v1
+      # -- Target port on Alloy service for OTLP HTTP.
+      targetPort: 4318
+      # -- Protocol type (http or grpc).
+      protocol: http
+      # -- Additional NGINX location block configuration for this upstream.
+      extraConfig: ""
+
+    # -- Loki endpoint configuration.
+    loki:
+      # -- Enable Loki endpoint.
+      enabled: true
+      # -- Path for Loki endpoint.
+      path: /loki/api/v1/push
+      # -- Target port on Alloy service for Loki.
+      targetPort: 3100
+      # -- Protocol type (http or grpc).
+      protocol: http
+      # -- Additional NGINX location block configuration for this upstream.
+      extraConfig: ""
+
+    # -- Prometheus remote write endpoint configuration.
+    prometheus:
+      # -- Enable Prometheus endpoint.
+      enabled: true
+      # -- Path for Prometheus remote write endpoint.
+      path: /api/v1/metrics/write
+      # -- Target port on Alloy service for Prometheus.
+      targetPort: 9009
+      # -- Protocol type (http or grpc).
+      protocol: http
+      # -- Additional NGINX location block configuration for this upstream.
+      extraConfig: ""
+
+    # -- Pyroscope endpoint configuration.
+    pyroscope:
+      # -- Enable Pyroscope endpoint.
+      enabled: false
+      # -- Path for Pyroscope endpoint.
+      path: /push.v1.PusherService/Push
+      # -- Target port on Alloy service for Pyroscope.
+      targetPort: 4100
+      # -- Protocol type (http or grpc).
+      protocol: http
+      # -- Additional NGINX location block configuration for this upstream.
+      extraConfig: ""
+
+  # -- NGINX configuration settings.
+  nginxConfig:
+    # -- Worker processes for NGINX.
+    workerProcesses: auto
+    # -- Worker connections for NGINX.
+    workerConnections: 1024
+    # -- Client body buffer size.
+    clientBodyBufferSize: "128k"
+    # -- Client max body size.
+    clientMaxBodySize: "10m"
+    # -- Client header timeout.
+    clientHeaderTimeout: "10s"
+    # -- Proxy connect timeout.
+    proxyConnectTimeout: "60s"
+    # -- Proxy send timeout.
+    proxySendTimeout: "60s"
+    # -- Proxy read timeout.
+    proxyReadTimeout: "60s"
+    # -- Send timeout.
+    sendTimeout: "60s"
+    # -- Keepalive timeout.
+    keepaliveTimeout: "65s"
+    # -- Enable access logging. Disable for better performance in high-traffic environments.
+    enableAccessLog: true
+    # -- Custom log format for access logs.
+    logFormat: '$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"'
+    # -- Additional NGINX http block configuration.
+    extraHttpConfig: ""
+    # -- Additional NGINX server block configuration.
+    extraServerConfig: ""
+    # -- NGINX configuration file content.
+    # This is passed through 'tpl' allowing Helm variables inside.
+    file: |
+      pid /tmp/nginx.pid; # Required for readOnlyRootFilesystem
+      worker_processes {{ .Values.gateway.nginxConfig.workerProcesses | default "auto" }};
+      error_log /tmp/error.log warn;
+      
+      events {
+        worker_connections {{ .Values.gateway.nginxConfig.workerConnections | default 1024 }};
+      }
+      
+      http {
+        include /etc/nginx/mime.types;
+        default_type application/octet-stream;
+      
+        log_format main '{{ .Values.gateway.nginxConfig.logFormat }}';
+      
+        {{- if .Values.gateway.nginxConfig.enableAccessLog }}
+        map $status $loggable {
+          ~^[23]  0;
+          default 1;
+        }
+        log_format main '$remote_addr - $remote_user [$time_local]  $status '
+          '"$request" $body_bytes_sent "$http_referer" '
+          '"$http_user_agent" "$http_x_forwarded_for"';
+        access_log /var/log/nginx/access.log main if=loggable;
+        {{- else }}
+        access_log off;
+        {{- end }}
+      
+        sendfile on;
+        tcp_nopush on;
+        tcp_nodelay on;
+      
+        keepalive_timeout {{ .Values.gateway.nginxConfig.keepaliveTimeout }};
+        send_timeout {{ .Values.gateway.nginxConfig.sendTimeout }};
+      
+        client_body_buffer_size {{ .Values.gateway.nginxConfig.clientBodyBufferSize }};
+        client_max_body_size {{ .Values.gateway.nginxConfig.clientMaxBodySize | default "50m" }};
+      
+        client_header_timeout {{ .Values.gateway.nginxConfig.clientHeaderTimeout}};
+        proxy_connect_timeout {{ .Values.gateway.nginxConfig.proxyConnectTimeout }};
+        proxy_send_timeout {{ .Values.gateway.nginxConfig.proxySendTimeout }};
+        proxy_read_timeout {{ .Values.gateway.nginxConfig.proxyReadTimeout }};
+      
+        proxy_buffering off;
+        proxy_request_buffering off;
+      
+        # Upstream definitions
+        {{- range $name, $upstream := .Values.gateway.upstreams }}
+        {{- if $upstream.enabled }}
+        upstream {{ include "alloy.fullname" $ }}-{{ $name }} {
+          server {{ include "alloy.fullname" $ }}.{{ include "alloy.namespace" $ }}.svc.cluster.local:{{ $upstream.targetPort }};
+          keepalive 32;
+        }
+        {{- end }}
+        {{- end }}
+      
+        {{- if .Values.gateway.nginxConfig.extraHttpConfig }}
+        {{ .Values.gateway.nginxConfig.extraHttpConfig | nindent 2 }}
+        {{- end }}
+      
+        server {
+          listen {{ .Values.gateway.port }} http2;
+          {{- if .Values.gateway.tls.enabled }}
+          listen {{ .Values.gateway.tls.port }} ssl;
+          ssl_certificate /etc/nginx/tls/tls.crt;
+          ssl_certificate_key /etc/nginx/tls/tls.key;
+          ssl_protocols TLSv1.2 TLSv1.3;
+          ssl_ciphers HIGH:!aNULL:!MD5;
+          ssl_prefer_server_ciphers on;
+          {{- end }}
+      
+          server_name _;
+      
+          # Health check endpoint
+          location /health {
+            access_log off;
+            return 200 "OK";
+            add_header Content-Type text/plain;
+          }
+      
+          # Stub status for monitoring
+          location /stub_status {
+            stub_status on;
+            access_log off;
+            allow 127.0.0.1;
+            deny all;
+          }
+      
+          {{- if .Values.gateway.auth.enabled }}
+          auth_basic "{{ .Values.gateway.auth.realm }}";
+          auth_basic_user_file /etc/nginx/auth/.htpasswd;
+          {{- end }}
+      
+          {{- range $name, $upstream := .Values.gateway.upstreams }}
+          {{- if $upstream.enabled }}
+          # {{ $name }} endpoint
+          location ~ {{ $upstream.path }} {
+            {{- if $upstream.extraConfig }}
+            {{ $upstream.extraConfig | nindent 6 }}
+            {{- else }}
+            {{- if eq $upstream.protocol "grpc" }}
+            grpc_pass grpc://{{ include "alloy.fullname" $ }}-{{ $name }};
+            grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            grpc_set_header X-Real-IP $remote_addr;
+            {{- else }}
+            proxy_pass http://{{ include "alloy.fullname" $ }}-{{ $name }}$request_uri;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Real-IP $remote_addr;
+            {{- end }}
+            {{- end }}
+          }
+          {{- end }}
+          {{- end }}
+      
+          {{- if .Values.gateway.nginxConfig.extraServerConfig }}
+          {{ .Values.gateway.nginxConfig.extraServerConfig | nindent 4 }}
+          {{- end }}
+        }
+      }
+
+
+  # -- TLS configuration for the gateway.
+  tls:
+    # -- Enable TLS.
+    enabled: false
+    # -- Name of secret containing TLS certificate and key.
+    # The secret must contain 'tls.crt' and 'tls.key' keys.
+    secretName: null
+    # -- TLS port.
+    port: 8443
+
+  # -- Grace period to allow the gateway container to shut down before it is killed
+  terminationGracePeriodSeconds: 30
+
+  # -- Resource requests and limits for the gateway.
+  resources: {}
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # limits:
+  #   cpu: 200m
+  #   memory: 256Mi
+
+  # -- nodeSelector for gateway pods.
+  nodeSelector: {}
+
+  # -- Tolerations for gateway pods.
+  tolerations: []
+
+  # -- Affinity configuration for gateway pods.
+  affinity: {}
+
+  # -- Pod annotations for the gateway.
+  podAnnotations: {}
+
+  # -- Pod labels for the gateway.
+  podLabels: {}
+
+  # -- Security context for gateway pods.
+  podSecurityContext:
+    fsGroup: 101
+    runAsGroup: 101
+    runAsNonRoot: true
+    runAsUser: 101
+
+  # -- Security context for gateway container.
+  securityContext: {}
+
+  # -- The SecurityContext for gateway containers
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop: [ ALL ]
+
+  # -- Priority class name for gateway pods.
+  priorityClassName: ""
+
+  # -- Update strategy for the gateway deployment.
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 15%
+
+  # -- PodDisruptionBudget configuration for the gateway.
+  podDisruptionBudget:
+    # -- Whether to create a PodDisruptionBudget.
+    enabled: false
+    # -- Minimum number of pods that must be available.
+    minAvailable: 1
+    # -- Maximum number of pods that can be unavailable.
+    maxUnavailable: null
+
+  # -- HorizontalPodAutoscaler configuration for the gateway.
+  autoscaling:
+    # -- Enable HorizontalPodAutoscaler.
+    enabled: false
+    # -- Minimum number of replicas.
+    minReplicas: 1
+    # -- Maximum number of replicas.
+    maxReplicas: 3
+    # -- Target CPU utilization percentage.
+    targetCPUUtilizationPercentage: 70
+    # -- Target memory utilization percentage.
+    targetMemoryUtilizationPercentage: 70
+
+  # -- ServiceMonitor configuration for the gateway.
+  serviceMonitor:
+    # -- Enable ServiceMonitor for the gateway.
+    enabled: false
+    # -- Additional labels for the service monitor.
+    additionalLabels: {}
+    # -- Scrape interval.
+    interval: ""
+    # -- Scrape path for NGINX metrics (requires nginx-prometheus-exporter sidecar).
+    path: /metrics
+    # -- Scrape port for NGINX metrics.
+    port: metrics
+
+  # -- Extra environment variables for the gateway container.
+  extraEnv: []
+
+  # -- Extra volumes for the gateway pods.
+  extraVolumes:
+    - name: tmp
+      emptyDir: {}
+    - name: varcache
+      emptyDir: {}
+
+  # -- Extra volume mounts for the gateway container.
+  extraVolumeMounts:
+    - name: tmp
+      mountPath: /tmp
+    - name: varcache
+      mountPath: /var/cache/nginx
+
+  # -- Extra containers to run in the gateway pod (e.g., nginx-prometheus-exporter).
+  extraContainers: []
+  # - name: nginx-exporter
+  #   image: nginx/nginx-prometheus-exporter:1.1.0
+  #   args:
+  #     - -nginx.scrape-uri=http://localhost:8080/stub_status
+  #   ports:
+  #   - name: metrics
+  #     containerPort: 9113


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide.

-->

## PR Description

This PR introduces an **optional** NGINX Gateway component to the Alloy Helm chart.

As Alloy deployments scale and handle multiple telemetry protocols (OTLP gRPC/HTTP, Loki, Prometheus, Faro), exposing and managing multiple ports and ingress rules can become increasingly complex—particularly for TLS termination, authentication, and security controls. While some of these challenges can be mitigated using ingress annotations, those configurations can become difficult to maintain at scale.

In addition, Alloy currently has limited authentication support across receivers. For example, OTLP receivers do not yet support multiple basic auth users (planned for a future release), and other receivers such as Loki and Prometheus do not provide authentication mechanisms. This gateway allows authentication and ingress concerns to be handled at the edge, while Alloy remains focused on telemetry processing.

This change only affects the Helm chart and Kubernetes resources. It does **not** modify Alloy runtime behavior.

## Key Features

- **Unified Ingress**
  - Exposes a single “front door” for telemetry traffic using path-based routing  
    (e.g. `/opentelemetry` → OTLP gRPC, `/loki/api/v1/push` → Loki).
  - Reduces the need for multiple ingress rules, ports, and services.

- **Seamless Helm Integration**
  - When enabled, the existing `ingress.enabled` flag automatically targets the Gateway service instead of the Alloy service.
  - Simplifies TLS termination and ingress configuration without changing existing values.

- **Production-Ready Defaults**
  - HorizontalPodAutoscaler (HPA) and PodDisruptionBudget (PDB) support.
  - Security hardening:
    - Runs as a non-root user (UID 101).
    - `readOnlyRootFilesystem` enabled by default.
  - Observability:
    - Optional `nginx-prometheus-exporter` sidecar.
    - Optional `ServiceMonitor` for proxy metrics.

- **Flexible Configuration**
  - NGINX configuration is rendered using Helm’s `tpl` function.
  - Allows users to inject dynamic values, customize routing, or extend authentication logic as needed.

## Which issue(s) this PR fixes

Fixes #5157

## Notes to the Reviewer

- **Default Configuration**
  - A default NGINX configuration is included in `values.yaml`, covering common Alloy backends (OTLP, Loki, Prometheus).
  - Includes a `/health` endpoint used by the Deployment’s liveness and readiness probes.

- **gRPC Support**
  - Uses `grpc_pass` for OTLP gRPC traffic.
  - Disables `proxy_request_buffering` to ensure low-latency telemetry ingestion.

- **Opt-in by Design**
  - The gateway is fully optional (`gateway.enabled: false` by default).
  - Existing Alloy deployments are unaffected unless explicitly enabled.

- **Documentation**
  - Detailed architecture and migration guidance has been added to `docs/gateway.md` to avoid overloading the main README.

## PR Checklist

- [x] Documentation added
- [ ] Tests updated (Helm chart change; no existing test coverage for this area)
- [ ] Config converters updated
