### PR TITLE
fix: Only alert on cluster drift when cluster_name is set

### DIFF
--- a/operations/alloy-mixin/alerts/clustering.libsonnet
+++ b/operations/alloy-mixin/alerts/clustering.libsonnet
@@ -80,11 +80,11 @@ local alert = import './utils/alert.jsonnet';
           'ClusterConfigurationDrift',
           if enableK8sCluster then |||
             count without (sha256) (
-                max by (cluster, namespace, sha256, job, cluster_name) (alloy_config_hash and on(cluster, namespace, job, cluster_name) cluster_node_info)
+                max by (cluster, namespace, sha256, job, cluster_name) (alloy_config_hash{cluster_name!=""} and on(cluster, namespace, job, cluster_name) cluster_node_info)
             ) > 1
           ||| else |||
             count without (sha256) (
-                max by (sha256, job) (alloy_config_hash and on(job) cluster_node_info)
+                max by (sha256, job) (alloy_config_hash{cluster_name!=""} and on(job) cluster_node_info)
             ) > 1
           |||
           ,

--- a/operations/alloy-mixin/rendered/alerts/alloy_clustering.yaml
+++ b/operations/alloy-mixin/rendered/alerts/alloy_clustering.yaml
@@ -51,7 +51,7 @@
       "summary": "Cluster configuration drifting."
     "expr": |
       count without (sha256) (
-          max by (cluster, namespace, sha256, job, cluster_name) (alloy_config_hash and on(cluster, namespace, job, cluster_name) cluster_node_info)
+          max by (cluster, namespace, sha256, job, cluster_name) (alloy_config_hash{cluster_name!=""} and on(cluster, namespace, job, cluster_name) cluster_node_info)
       ) > 1
     "for": "5m"
     "labels":


### PR DESCRIPTION
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style. For details on this,
  check out the Contributors Guide linked above.
-->

### Brief description of Pull Request
Prevent spurious alerts from the ClusterConfigurationDrift alert by only alerting when cluster_name != "".

<!--
  Add a human-readable description of the PR that may be used as the commit body
  (i.e. "Extended description") when it gets merged.
-->

### Pull Request Details

<!-- Add a more detailed descripion of the Pull Request here, if needed. -->

### Issue(s) fixed by this Pull Request
Fixes https://github.com/grafana/alloy/issues/4945

<!--
  Uncomment the following line and fill in an issue number if you want a GitHub
  issue to be closed automatically when this PR gets merged.
-->