### PR TITLE
ci: Preserve pr title verbatim in backports

### DIFF
--- a/tools/release/backport/main.go
+++ b/tools/release/backport/main.go
@@ -164,7 +164,7 @@ func createBackportPR(ctx context.Context, client *gh.Client, originalPR *github
 This PR backports #%d to %s.
 
 ### Original PR Title
-`+"`%s`"+`
+%s
 
 ### Original PR Author
 @%s


### PR DESCRIPTION
if a pr title had backticks, it would display inccorrectly in the PR description
