### PR TITLE
chore: Try to use regular GITHUB_TOKEN in title-checker action

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -16,28 +16,10 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - name: Get GitHub app secrets 🔐
-        id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
-        with:
-          export_env: false
-          repo_secrets: |
-            ALLOYBOT_APP_ID=alloybot:app_id
-            ALLOYBOT_PRIVATE_KEY=alloybot:private_key
-
-      - name: Generate token 🔐
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
-        id: app-token
-        with:
-          app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).ALLOYBOT_APP_ID }}
-          private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).ALLOYBOT_PRIVATE_KEY }}
-          owner: grafana
-          repositories: alloy
-
       - name: Validate PR title 🔎
         uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           # Require conventional commit types
           types: |


### PR DESCRIPTION
### Brief description of Pull Request
We're seeing failures in the title-check GA in community PR's, like so:

<img width="858" height="254" alt="Screenshot 2026-01-07 at 17 06 49" src="https://github.com/user-attachments/assets/935b4a27-717e-4210-81de-45c4e9e814d3" />

I think this is because we're attempting to get an output to `get-vault-secrets` which cannot be done on a forked repo, I see this action only being referenced in our [internal workflows](https://github.com/search?q=repo%3Agrafana%2Falloy%20%22shared-workflows%2Factions%2Fget-vault-secrets%22&type=code) related to releases

I think instead we can use the standard GITHUB_TOKEN that is injected into workflows