### PR TITLE
feat(database_observability.postgres): Add adaptive burst window mechanism to query_samples collector

### DIFF
--- a/internal/component/database_observability/postgres/collector/dsn.go
+++ b/internal/component/database_observability/postgres/collector/dsn.go
@@ -8,10 +8,12 @@ import (
 
 type databaseConnectionFactory func(dsn string) (*sql.DB, error)
 
-var dsnParseRegex = regexp.MustCompile(`^(\w+:\/\/.+\/)(?<dbname>[\w\-_\$]+)(\??.*$)`)
-var defaultDbConnectionFactory = func(dsn string) (*sql.DB, error) {
-	return sql.Open("postgres", dsn)
-}
+var (
+	dsnParseRegex              = regexp.MustCompile(`^(\w+:\/\/.+\/)(?<dbname>[\w\-_\$]+)(\??.*$)`)
+	defaultDbConnectionFactory = func(dsn string) (*sql.DB, error) {
+		return sql.Open("postgres", dsn)
+	}
+)
 
 // replaceDatabaseNameInDSN safely replaces the database name in a PostgreSQL DSN
 // using regex to ensure only the database name portion is replaced, not other occurrences

--- a/internal/component/database_observability/postgres/collector/dsn.go
+++ b/internal/component/database_observability/postgres/collector/dsn.go
@@ -8,12 +8,10 @@ import (
 
 type databaseConnectionFactory func(dsn string) (*sql.DB, error)
 
-var (
-	dsnParseRegex              = regexp.MustCompile(`^(\w+:\/\/.+\/)(?<dbname>[\w\-_\$]+)(\??.*$)`)
-	defaultDbConnectionFactory = func(dsn string) (*sql.DB, error) {
-		return sql.Open("postgres", dsn)
-	}
-)
+var dsnParseRegex = regexp.MustCompile(`^(\w+:\/\/.+\/)(?<dbname>[\w\-_\$]+)(\??.*$)`)
+var defaultDbConnectionFactory = func(dsn string) (*sql.DB, error) {
+	return sql.Open("postgres", dsn)
+}
 
 // replaceDatabaseNameInDSN safely replaces the database name in a PostgreSQL DSN
 // using regex to ensure only the database name portion is replaced, not other occurrences

--- a/internal/component/database_observability/postgres/collector/query_samples.go
+++ b/internal/component/database_observability/postgres/collector/query_samples.go
@@ -26,10 +26,11 @@ const (
 
 const (
 	queryTextClause     = ", s.query"
+	waitEventTypeLock   = "Lock"
 	stateActive         = "active"
 	stateIdle           = "idle"
-	stateIdleTxnAborted = "idle in transaction (aborted)"
 	stateIdleTxn        = "idle in transaction"
+	stateIdleTxnAborted = "idle in transaction (aborted)"
 )
 
 const selectPgStatActivity = `
@@ -51,7 +52,6 @@ const selectPgStatActivity = `
 		s.state_change,
 		s.wait_event_type,
 		s.wait_event,
-		pg_blocking_pids(s.pid) as blocked_by_pids,
 		s.query_start,
 		s.query_id
 		%s
@@ -69,6 +69,12 @@ const selectPgStatActivity = `
 		AND d.datname NOT IN %s
 		%s
 		%s
+`
+
+const selectBlockingPIDs = `
+    SELECT pid, pg_blocking_pids(pid) 
+    FROM pg_stat_activity 
+    WHERE wait_event_type = 'Lock' AND pid != pg_backend_pid()
 `
 
 const excludeCurrentUserClause = `AND s.usesysid != (select oid from pg_roles where rolname = current_user)`
@@ -331,7 +337,8 @@ func (c *QuerySamples) fetchQuerySample(ctx context.Context) (hasActive bool, er
 
 	defer rows.Close()
 
-	activeKeys := map[SampleKey]struct{}{}
+	var buffered []QuerySamplesInfo
+	hasLockWait := false
 
 	for rows.Next() {
 		sample, scanErr := c.scanRow(rows)
@@ -339,7 +346,47 @@ func (c *QuerySamples) fetchQuerySample(ctx context.Context) (hasActive bool, er
 			level.Error(c.logger).Log("msg", "failed to scan pg_stat_activity", "err", scanErr)
 			continue
 		}
+		if sample.WaitEventType.Valid && sample.WaitEventType.String == waitEventTypeLock {
+			hasLockWait = true
+		}
+		buffered = append(buffered, sample)
+	}
 
+	if err := rows.Err(); err != nil {
+		return false, fmt.Errorf("failed to iterate pg_stat_activity rows: %w", err)
+	}
+
+	// Enrich blocked_by_pids only when there are lock waits
+	blockedByPID := map[int]pq.Int64Array{}
+	if hasLockWait {
+		blockedRows, err := c.dbConnection.QueryContext(ctx, selectBlockingPIDs)
+		if err != nil {
+			level.Error(c.logger).Log("msg", "failed to query blocking pids", "err", err)
+		} else {
+			defer blockedRows.Close()
+			for blockedRows.Next() {
+				var pid int
+				var blocked pq.Int64Array
+				if err := blockedRows.Scan(&pid, &blocked); err != nil {
+					level.Error(c.logger).Log("msg", "failed to scan blocking pids row", "err", err)
+					continue
+				}
+				blockedByPID[pid] = blocked
+			}
+			if err := blockedRows.Err(); err != nil {
+				level.Error(c.logger).Log("msg", "failed to iterate blocking pids rows", "err", err)
+			}
+		}
+	}
+
+	activeKeys := map[SampleKey]struct{}{}
+
+	for _, sample := range buffered {
+		if sample.WaitEventType.Valid && sample.WaitEventType.String == waitEventTypeLock {
+			if blocked, ok := blockedByPID[sample.PID]; ok {
+				sample.BlockedByPIDs = blocked
+			}
+		}
 		key, procErr := c.processRow(sample)
 		if procErr != nil {
 			level.Debug(c.logger).Log("msg", "invalid pg_stat_activity set", "queryid", sample.QueryID.Int64, "err", procErr)
@@ -367,11 +414,6 @@ func (c *QuerySamples) fetchQuerySample(ctx context.Context) (hasActive bool, er
 		c.upsertActiveSample(key, sample)
 		activeKeys[key] = struct{}{}
 		continue
-	}
-
-	if err := rows.Err(); err != nil {
-		level.Error(c.logger).Log("msg", "failed to iterate pg_stat_activity rows", "err", err)
-		return false, err
 	}
 
 	// finalize samples that are no longer active or have EndAt set (idle finalized or one off idle sample)
@@ -404,7 +446,6 @@ func (c *QuerySamples) scanRow(rows *sql.Rows) (QuerySamplesInfo, error) {
 		&sample.StateChange,
 		&sample.WaitEventType,
 		&sample.WaitEvent,
-		&sample.BlockedByPIDs,
 		&sample.QueryStart,
 		&sample.QueryID,
 	}

--- a/internal/component/database_observability/postgres/collector/query_samples_test.go
+++ b/internal/component/database_observability/postgres/collector/query_samples_test.go
@@ -1283,8 +1283,8 @@ func TestComputeBurstWindow(t *testing.T) {
 			observed: 0,
 			wantS:    50 * time.Millisecond,
 			wantW:    0,
-	},
-}
+		},
+	}
 
 	for _, tc := range cases {
 		tc := tc

--- a/internal/component/database_observability/postgres/collector/query_samples_test.go
+++ b/internal/component/database_observability/postgres/collector/query_samples_test.go
@@ -1282,7 +1282,7 @@ func TestComputeBurstWindow(t *testing.T) {
 			ci:       100 * time.Millisecond,
 			observed: 0,
 			wantS:    50 * time.Millisecond,
-		wantW:    0,
+			wantW:    0,
 	},
 }
 
@@ -1337,18 +1337,18 @@ func TestQuerySamples_TestBurstWindow(t *testing.T) {
 		}
 
 		// Active → Active → Empty (emit #1) → Empty (wait CI) → Active → Empty (emit #2)
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause)).WillDelayFor(20 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns).AddRow(
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, "")).WillDelayFor(20 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns).AddRow(
 			now, "testdb", 7000, sql.NullInt64{}, "testuser", "testapp", "127.0.0.1", 5432, "client backend", backendStartTime, sql.NullInt32{}, sql.NullInt32{}, now.Add(-2*time.Minute), "active", now, sql.NullString{}, sql.NullString{}, now, sql.NullInt64{Int64: 7001, Valid: true}, "SELECT 1",
 		))
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause)).WillDelayFor(20 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns).AddRow(
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, "")).WillDelayFor(20 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns).AddRow(
 			now, "testdb", 7000, sql.NullInt64{}, "testuser", "testapp", "127.0.0.1", 5432, "client backend", backendStartTime, sql.NullInt32{}, sql.NullInt32{}, now.Add(-2*time.Minute), "active", now, sql.NullString{}, sql.NullString{}, now, sql.NullInt64{Int64: 7001, Valid: true}, "SELECT 1",
 		))
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause)).WillDelayFor(20 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns))
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause)).WillDelayFor(20 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns))
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause)).WillDelayFor(10 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns).AddRow(
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, "")).WillDelayFor(20 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns))
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, "")).WillDelayFor(20 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns))
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, "")).WillDelayFor(10 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns).AddRow(
 			now, "testdb", 7000, sql.NullInt64{}, "testuser", "testapp", "127.0.0.1", 5432, "client backend", backendStartTime, sql.NullInt32{}, sql.NullInt32{}, now.Add(-2*time.Minute), "active", now, sql.NullString{}, sql.NullString{}, now, sql.NullInt64{Int64: 7001, Valid: true}, "SELECT 1",
 		))
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause)).WillDelayFor(10 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns))
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, "")).WillDelayFor(10 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns))
 
 		require.NoError(t, sampleCollector.Start(t.Context()))
 
@@ -1406,10 +1406,10 @@ func TestQuerySamples_TestBurstWindow(t *testing.T) {
 			"query",
 		}
 
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause)).WillDelayFor(250 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns).AddRow(
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, "")).WillDelayFor(250 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns).AddRow(
 			now, "testdb", 9100, sql.NullInt64{}, "testuser", "testapp", "127.0.0.1", 5432, "client backend", backendStartTime, sql.NullInt32{}, sql.NullInt32{}, now.Add(-2*time.Minute), "active", now, sql.NullString{}, sql.NullString{}, now, sql.NullInt64{Int64: 5001, Valid: true}, "SELECT 1",
 		))
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause)).WillDelayFor(10 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns))
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, "")).WillDelayFor(10 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns))
 
 		require.NoError(t, sampleCollector.Start(t.Context()))
 
@@ -1455,11 +1455,11 @@ func TestQuerySamples_TestBurstWindow(t *testing.T) {
 		}
 
 		for i := 0; i < 7; i++ {
-			mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause)).WillDelayFor(5 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns).AddRow(
+			mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, "")).WillDelayFor(5 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns).AddRow(
 				now, "testdb", 8100, sql.NullInt64{}, "testuser", "testapp", "127.0.0.1", 5432, "client backend", backendStartTime, sql.NullInt32{}, sql.NullInt32{}, now.Add(-2*time.Minute), "active", now, sql.NullString{}, sql.NullString{}, now, sql.NullInt64{Int64: 6001, Valid: true}, "SELECT 1",
 			))
 		}
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause)).WillDelayFor(5 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns))
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, "")).WillDelayFor(5 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns))
 
 		require.NoError(t, sampleCollector.Start(t.Context()))
 

--- a/internal/component/database_observability/postgres/collector/query_samples_test.go
+++ b/internal/component/database_observability/postgres/collector/query_samples_test.go
@@ -1282,9 +1282,9 @@ func TestComputeBurstWindow(t *testing.T) {
 			ci:       100 * time.Millisecond,
 			observed: 0,
 			wantS:    50 * time.Millisecond,
-			wantW:    0,
-		},
-	}
+		wantW:    0,
+	},
+}
 
 	for _, tc := range cases {
 		tc := tc
@@ -1295,4 +1295,182 @@ func TestComputeBurstWindow(t *testing.T) {
 			require.Equal(t, tc.wantW, w)
 		})
 	}
+}
+
+func TestQuerySamples_TestBurstWindow(t *testing.T) {
+	t.Parallel()
+
+	collectInterval := 10 * time.Millisecond
+	observedLatency := 100 * time.Millisecond
+	burstInterval, burstWindow := computeBurstWindow(collectInterval, observedLatency)
+	require.Equal(t, 100*time.Millisecond, burstInterval)
+	require.Equal(t, 0*time.Millisecond, burstWindow)
+
+	t.Run("ends_burst_window_when_inactive", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		logBuffer := syncbuffer.Buffer{}
+		lokiClient := loki.NewCollectingHandler()
+		defer lokiClient.Stop()
+
+		// Use CI = 500ms so burst interval is ~50ms, then verify finalizations spacing reflects CI when inactive
+		sampleCollector, err := NewQuerySamples(QuerySamplesArguments{
+			DB:                    db,
+			CollectInterval:       500 * time.Millisecond,
+			EntryHandler:          lokiClient,
+			Logger:                log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+			DisableQueryRedaction: true,
+		})
+		require.NoError(t, err)
+
+		now := time.Now()
+		backendStartTime := now.Add(-1 * time.Hour)
+		columns := []string{
+			"now", "datname", "pid", "leader_pid",
+			"usename", "application_name", "client_addr", "client_port",
+			"backend_type", "backend_start", "backend_xid", "backend_xmin",
+			"xact_start", "state", "state_change", "wait_event_type",
+			"wait_event", "query_start", "query_id",
+			"query",
+		}
+
+		// Active → Active → Empty (emit #1) → Empty (wait CI) → Active → Empty (emit #2)
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause)).WillDelayFor(20 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns).AddRow(
+			now, "testdb", 7000, sql.NullInt64{}, "testuser", "testapp", "127.0.0.1", 5432, "client backend", backendStartTime, sql.NullInt32{}, sql.NullInt32{}, now.Add(-2*time.Minute), "active", now, sql.NullString{}, sql.NullString{}, now, sql.NullInt64{Int64: 7001, Valid: true}, "SELECT 1",
+		))
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause)).WillDelayFor(20 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns).AddRow(
+			now, "testdb", 7000, sql.NullInt64{}, "testuser", "testapp", "127.0.0.1", 5432, "client backend", backendStartTime, sql.NullInt32{}, sql.NullInt32{}, now.Add(-2*time.Minute), "active", now, sql.NullString{}, sql.NullString{}, now, sql.NullInt64{Int64: 7001, Valid: true}, "SELECT 1",
+		))
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause)).WillDelayFor(20 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns))
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause)).WillDelayFor(20 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns))
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause)).WillDelayFor(10 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns).AddRow(
+			now, "testdb", 7000, sql.NullInt64{}, "testuser", "testapp", "127.0.0.1", 5432, "client backend", backendStartTime, sql.NullInt32{}, sql.NullInt32{}, now.Add(-2*time.Minute), "active", now, sql.NullString{}, sql.NullString{}, now, sql.NullInt64{Int64: 7001, Valid: true}, "SELECT 1",
+		))
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause)).WillDelayFor(10 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns))
+
+		require.NoError(t, sampleCollector.Start(t.Context()))
+
+		var t1, t2 time.Time
+		require.Eventually(t, func() bool {
+			if len(lokiClient.Received()) >= 1 {
+				t1 = time.Now()
+				return true
+			}
+			return false
+		}, 3*time.Second, 20*time.Millisecond)
+		require.Eventually(t, func() bool {
+			if len(lokiClient.Received()) >= 2 {
+				t2 = time.Now()
+				return true
+			}
+			return false
+		}, 3*time.Second, 20*time.Millisecond)
+
+		delta := t2.Sub(t1)
+		require.GreaterOrEqual(t, delta, 900*time.Millisecond)
+
+		sampleCollector.Stop()
+		require.Eventually(t, func() bool { return sampleCollector.Stopped() }, 5*time.Second, 100*time.Millisecond)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	// 2) When observed latency > CI, no burst; next interval equals observed
+	t.Run("respects_delay_greater_than_collect_interval", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		logBuffer := syncbuffer.Buffer{}
+		lokiClient := loki.NewCollectingHandler()
+		defer lokiClient.Stop()
+
+		sampleCollector, err := NewQuerySamples(QuerySamplesArguments{
+			DB:                    db,
+			CollectInterval:       100 * time.Millisecond,
+			EntryHandler:          lokiClient,
+			Logger:                log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+			DisableQueryRedaction: true,
+		})
+		require.NoError(t, err)
+
+		now := time.Now()
+		backendStartTime := now.Add(-1 * time.Hour)
+		columns := []string{
+			"now", "datname", "pid", "leader_pid",
+			"usename", "application_name", "client_addr", "client_port",
+			"backend_type", "backend_start", "backend_xid", "backend_xmin",
+			"xact_start", "state", "state_change", "wait_event_type",
+			"wait_event", "query_start", "query_id",
+			"query",
+		}
+
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause)).WillDelayFor(250 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns).AddRow(
+			now, "testdb", 9100, sql.NullInt64{}, "testuser", "testapp", "127.0.0.1", 5432, "client backend", backendStartTime, sql.NullInt32{}, sql.NullInt32{}, now.Add(-2*time.Minute), "active", now, sql.NullString{}, sql.NullString{}, now, sql.NullInt64{Int64: 5001, Valid: true}, "SELECT 1",
+		))
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause)).WillDelayFor(10 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns))
+
+		require.NoError(t, sampleCollector.Start(t.Context()))
+
+		start := time.Now()
+		require.Eventually(t, func() bool { return len(lokiClient.Received()) >= 1 }, 2*time.Second, 20*time.Millisecond)
+		elapsed := time.Since(start)
+		require.GreaterOrEqual(t, elapsed, 500*time.Millisecond)
+		require.Less(t, elapsed, 600*time.Millisecond)
+
+		sampleCollector.Stop()
+		require.Eventually(t, func() bool { return sampleCollector.Stopped() }, 5*time.Second, 100*time.Millisecond)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	// 3) Multiple polls occur within burst window
+	t.Run("multiple_polls_within_window", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		logBuffer := syncbuffer.Buffer{}
+		lokiClient := loki.NewCollectingHandler()
+		defer lokiClient.Stop()
+
+		sampleCollector, err := NewQuerySamples(QuerySamplesArguments{
+			DB:                    db,
+			CollectInterval:       3 * time.Second,
+			EntryHandler:          lokiClient,
+			Logger:                log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+			DisableQueryRedaction: true,
+		})
+		require.NoError(t, err)
+
+		now := time.Now()
+		backendStartTime := now.Add(-1 * time.Hour)
+		columns := []string{
+			"now", "datname", "pid", "leader_pid",
+			"usename", "application_name", "client_addr", "client_port",
+			"backend_type", "backend_start", "backend_xid", "backend_xmin",
+			"xact_start", "state", "state_change", "wait_event_type",
+			"wait_event", "query_start", "query_id",
+			"query",
+		}
+
+		for i := 0; i < 7; i++ {
+			mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause)).WillDelayFor(5 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns).AddRow(
+				now, "testdb", 8100, sql.NullInt64{}, "testuser", "testapp", "127.0.0.1", 5432, "client backend", backendStartTime, sql.NullInt32{}, sql.NullInt32{}, now.Add(-2*time.Minute), "active", now, sql.NullString{}, sql.NullString{}, now, sql.NullInt64{Int64: 6001, Valid: true}, "SELECT 1",
+			))
+		}
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause)).WillDelayFor(5 * time.Millisecond).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows(columns))
+
+		require.NoError(t, sampleCollector.Start(t.Context()))
+
+		start := time.Now()
+		require.Eventually(t, func() bool { return len(lokiClient.Received()) >= 1 }, 3*time.Second, 20*time.Millisecond)
+		elapsed := time.Since(start)
+		require.GreaterOrEqual(t, elapsed, 700*time.Millisecond)
+		require.Less(t, elapsed, 1000*time.Millisecond)
+
+		sampleCollector.Stop()
+		require.Eventually(t, func() bool { return sampleCollector.Stopped() }, 5*time.Second, 100*time.Millisecond)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
 }


### PR DESCRIPTION
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style. For details on this,
  check out the Contributors Guide linked above.
-->

### Brief description of Pull Request

<!--
  Add a human-readable description of the PR that may be used as the commit body
  (i.e. "Extended description") when it gets merged.
-->

### Pull Request Details

This burst mechanism is designed to capture the active query execution span and wait events more precisely. Whenever we detect an active row, a scrape burst window is opened. The goal is to try to capture the moment when the execution ends as precisely as possible.

The query was changed for improved performance, as `pg_stat_activity` is very lightweight (all data is kept by Postgres in memory), but `pg_blocking_pids` can add some overhead. We will only call the second if there are any Lock wait types in first scrape.

<!-- Add a more detailed descripion of the Pull Request here, if needed. -->

### Issue(s) fixed by this Pull Request

<!--
  Uncomment the following line and fill in an issue number if you want a GitHub
  issue to be closed automatically when this PR gets merged.
-->

<!-- Fixes #issue_id -->

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
