### PR TITLE
fix: Prevent panic in import.git when update fails

### DIFF
--- a/internal/nodeconf/importsource/import_git.go
+++ b/internal/nodeconf/importsource/import_git.go
@@ -213,6 +213,9 @@ func (im *ImportGit) Update(args component.Arguments) (err error) {
 		if err != nil {
 			if errors.As(err, &vcs.UpdateFailedError{}) {
 				level.Error(im.log).Log("msg", "failed to update repository", "err", err)
+				if im.repo == nil && r == nil {
+					return err
+				}
 				im.updateHealth(err)
 			} else {
 				return err
@@ -222,7 +225,7 @@ func (im *ImportGit) Update(args component.Arguments) (err error) {
 		im.repoOpts = repoOpts
 	}
 
-	if err := im.pollFile(context.Background(), newArgs); err != nil {
+	if err = im.pollFile(context.Background(), newArgs); err != nil {
 		if errors.As(err, &vcs.UpdateFailedError{}) {
 			level.Error(im.log).Log("msg", "failed to poll file from repository", "err", err)
 			// We don't update the health here because it will be updated via the defer call.


### PR DESCRIPTION
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style. For details on this,
  check out the Contributors Guide linked above.
-->

### Brief description of Pull Request
Avoid panics in import.git update by returning the update failure error appropriately when the local clone of a repo is unavailable.
<!--
  Add a human-readable description of the PR that may be used as the commit body
  (i.e. "Extended description") when it gets merged.
-->
