### PR TITLE
fix: Skip explain plans which lookup individual records and return no rows 

### DIFF
--- a/internal/component/database_observability/mysql/collector/explain_plans.go
+++ b/internal/component/database_observability/mysql/collector/explain_plans.go
@@ -692,8 +692,13 @@ func (c *ExplainPlans) fetchExplainPlans(ctx context.Context) error {
 			continue
 		}
 
-		msgBlock, _, _, err := jsonparser.Get(redactedByteExplainPlanJSON, "query_block", "message")
-		if err == nil {
+		msgBlock, msgDatType, _, err := jsonparser.Get(redactedByteExplainPlanJSON, "query_block", "message")
+		if err != nil {
+			// An explain plan response typically will not have a message field if it is successful.
+			if msgDatType != jsonparser.NotExist {
+				level.Error(logger).Log("msg", "failed to parse explain plan json", "err", err)
+			}
+		} else {
 			if strings.Contains(string(msgBlock), "no matching row in const table") {
 				level.Debug(logger).Log("msg", "explain plan query resulted in no rows, skipping", "message", string(msgBlock))
 				continue

--- a/internal/component/database_observability/mysql/collector/explain_plans.go
+++ b/internal/component/database_observability/mysql/collector/explain_plans.go
@@ -692,6 +692,14 @@ func (c *ExplainPlans) fetchExplainPlans(ctx context.Context) error {
 			continue
 		}
 
+		msgBlock, _, _, err := jsonparser.Get(redactedByteExplainPlanJSON, "query_block", "message")
+		if err == nil {
+			if strings.Contains(string(msgBlock), "no matching row in const table") {
+				level.Debug(logger).Log("msg", "explain plan query resulted in no rows, skipping", "message", string(msgBlock))
+				continue
+			}
+		}
+
 		level.Debug(logger).Log("msg", "db native explain plan",
 			"db_native_explain_plan", base64.StdEncoding.EncodeToString(redactedByteExplainPlanJSON))
 


### PR DESCRIPTION
### Brief description of Pull Request
In MySQL, the query we're executing for explain plans gets an updated concrete query in `performance_schema` periodically.

For queries which look up a single row, by a primary key id, for a record which does not exist, no explain plan is created.

This created situations where a customer would sometimes see an explain plan, and sometimes not for a given query.

This PR simply refrains from logging the empty explain plan, such that the dbo11y UI should only find explain plan records with content for a given query.

### Issue(s) fixed by this Pull Request
Fixes #4987

### Notes to the Reviewer
This just debug logs the fact that we're skipping, and does not communicate with the user or the dbo11y UI in any way.

In the future, I'd like to add some additional telemetry which a user can opt-in to with their alloy config to have more visibility to the frequency with which individual queries are dropped for the various reasons.

### PR Checklist
- [x] Tests updated

BEGIN_COMMIT_OVERRIDE
fix(database_observability): Skip explain plans which lookup individual records and return no rows (#5203)
END_COMMIT_OVERRIDE