### PR TITLE
fix: Ensure the squid exporter wrapper properly brackets ipv6 addresses [backport]

### DIFF
--- a/internal/static/integrations/squid_exporter/squid_exporter.go
+++ b/internal/static/integrations/squid_exporter/squid_exporter.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"strconv"
 
 	se "github.com/boynux/squid-exporter/collector"
@@ -44,7 +45,13 @@ func (c *Config) validate() error {
 	if host == "" {
 		return ErrNoHostname
 	}
-	c.Host = host
+
+	if ip, err := netip.ParseAddr(host); err == nil && ip.IsValid() && ip.Is6() {
+		// Restore the explicit brackets for IPv6 addresses
+		c.Host = fmt.Sprintf("[%s]", host)
+	} else {
+		c.Host = host
+	}
 
 	if port == "" {
 		return ErrNoPort
@@ -95,7 +102,7 @@ func New(c *Config) (integrations.Integration, error) {
 	}
 
 	seExporter := se.New(&se.CollectorConfig{
-		Hostname: c.Host,
+		Hostname: fmt.Sprintf("[%s]", c.Host),
 		Port:     c.Port,
 		Login:    c.Username,
 		Password: string(c.Password),


### PR DESCRIPTION
(cherry picked from commit ee2316252e6e0ee901b0ff57c55d6d07750d14ab)
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style. For details on this,
  check out the Contributors Guide linked above.
-->

### Brief description of Pull Request
Ensure that the squid exporter component properly brackets IPv6 addresses when passing the hostname to the exporter module.

<!--
  Add a human-readable description of the PR that may be used as the commit body
  (i.e. "Extended description") when it gets merged.
-->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Tests updated
