### PR TITLE
chore: Update dev0 canary wavesv2 key in addition to dev_canary wavesV1 key

### DIFF
--- a/.github/workflows/publish-alloy-devel.yml
+++ b/.github/workflows/publish-alloy-devel.yml
@@ -98,6 +98,11 @@ jobs:
               "file_path": "ksonnet/lib/alloy/waves/alloy.libsonnet",
               "jsonnet_key": "dev_canary",
               "jsonnet_value_file": ".image-tag"
+            },
+            {
+              "file_path": "ksonnet/lib/alloy/waves/alloy.libsonnet",
+              "jsonnet_key": "dev0",
+              "jsonnet_value_file": ".image-tag"
             }
           ]
         }


### PR DESCRIPTION
As part of the work to migrate to wavesv2 ([issue](https://github.com/grafana/alloy-internal/issues/337)), I'd like to update our automation steps for updating the dev canary alloy image in deployment tools.

Currently we have an automation where we update the `dev_canary` wavesv1 key with alloy devel image version. We currently have an unused `dev0` wavesv2 key which is simply being [mapped to the wavesv1 value](https://github.com/grafana/deployment_tools/blob/2948728e292c146f0bb7cd6cbbfb7c590277229a/ksonnet/lib/alloy/waves/alloy.libsonnet#L21).

This change will mean that we are updating _both_ keys. Once both are being updated I would like to then

1. Enable workloads to use wavesv2 ([draft PR](https://github.com/grafana/deployment_tools/pull/446395))
2. Remove the now unused wavesv1 keys aside from `dev_canary`, since i'm not sure if a missing key will cause the `publish-alloy-devel` action to fail
3. Modify the `publish-alloy-devel` action to only update `dev0` and not `dev_canary`
4. Remove the final wavesv1 `dev_canary` key