### PR TITLE
chore: Run "go mod tidy" as part of generate-otel-collector to avoid invalid go.mod state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,6 +273,9 @@ generate-otel-collector-distro:
 ifeq ($(USE_CONTAINER),1)
 	$(RERUN_IN_CONTAINER)
 else
+	@if [ -f ./collector/go.mod ]; then \
+		cd ./collector && go mod tidy; \
+	fi
 	# Here we clear the GOOS and GOARCH env variables so we're not accidentally cross compiling the builder tool within generate
 	cd ./collector && GOOS= GOARCH= BUILDER_VERSION=$(BUILDER_VERSION) go generate
 endif


### PR DESCRIPTION
This PR addresses an edge case in the collector generation:

It could be that a dependency in the collector that has been brought in transitively through either `alloy` or `alloyengine` has been updated in `alloy`/`alloyengine` go mod file. This leads us to the state where:

* We attempt to build the collector via the `generator.go` file
* That file belongs in the collector directory, and therefore go will attempt to understand the state of its go.mod and download any missing dependencies
* The go.mod file is out of date, since the transitive dependencies have been updated and `go mod tidy` needs to be run

As a real-life example, if you run:

```
go get cloud.google.com/go/auth@v0.18.0
```

in the alloyengine module, and then attempt to build/generate the collector. You will run into the following error

```
➜  alloy git:(blewis12/run-go-mod-tidy-for-collector-before-generating) ✗ make generate-otel-collector-distro 
cd ./collector && GOOS= GOARCH= BUILDER_VERSION=v0.139.0 go generate
go: updates to go.mod needed; to update it:
        go mod tidy
make: *** [generate-otel-collector-distro] Error 1
```

This is sort of a chicken and egg situation, since the generator is what outputs the go.mod file, but the go.mod file needs to be tidy in order for the generation script to even run.

To get around this for now, we can check for the existence of a go.mod file in the collector directory, and if it exists then run `go mod tidy` as a pre-step to the generation step. I have added the check for the go.mod file, since technically it should be possible to generate the code completely from scratch (ie no existing go.mod file), and if we run `go mod tidy` when there is no `go.mod` file present, we get an error. 