### PR TITLE
feat: Database_observability: support Azure cloud provider config data

### DIFF
--- a/docs/sources/reference/components/database_observability/database_observability.mysql.md
+++ b/docs/sources/reference/components/database_observability/database_observability.mysql.md
@@ -55,6 +55,7 @@ You can use the following blocks with `database_observability.mysql`:
 |--------------------------------------|---------------------------------------------------|----------|
 | [`cloud_provider`][cloud_provider]   | Provide Cloud Provider information.               | no       |
 | `cloud_provider` > [`aws`][aws]      | Provide AWS database host information.            | no       |
+| `cloud_provider` > [`azure`][azure]  | Provide Azure database host information.          | no       |
 | [`setup_consumers`][setup_consumers] | Configure the `setup_consumers` collector.        | no       |
 | [`setup_actors`][setup_actors]       | Configure the `setup_actors` collector.           | no       |
 | [`query_details`][query_details]     | Configure the queries collector.                  | no       |
@@ -69,6 +70,7 @@ For example, `cloud_provider` > `aws` refers to a `aws` block defined inside an 
 
 [cloud_provider]: #cloud_provider
 [aws]: #aws
+[azure]: #azure
 [setup_consumers]: #setup_consumers
 [query_details]: #query_details
 [schema_details]: #schema_details
@@ -93,6 +95,16 @@ The `aws` block supplies the [ARN](https://docs.aws.amazon.com/IAM/latest/UserGu
 | Name  | Type     | Description                                             | Default | Required |
 |-------|----------|---------------------------------------------------------|---------|----------|
 | `arn` | `string` | The ARN associated with the database under observation. |         | yes      |
+
+### `azure`
+
+The `azure` block supplies the identifying information for the database being monitored.
+
+| Name              | Type     | Description                                          | Default | Required |
+|-------------------|----------|------------------------------------------------------|---------|----------|
+| `subscription_id` | `string` | The Subscription ID for your Azure account.          |         | yes      |
+| `resource_group`  | `string` | The Resource Group that holds the database resource. |         | yes      |
+| `server_name`     | `string` | The database server name.                            |         | no       |
 
 ### `setup_consumers`
 

--- a/docs/sources/reference/components/database_observability/database_observability.postgres.md
+++ b/docs/sources/reference/components/database_observability/database_observability.postgres.md
@@ -51,6 +51,7 @@ You can use the following blocks with `database_observability.postgres`:
 |------------------------------------|---------------------------------------------------|----------|
 | [`cloud_provider`][cloud_provider] | Provide Cloud Provider information.               | no       |
 | `cloud_provider` > [`aws`][aws]    | Provide AWS database host information.            | no       |
+| `cloud_provider` > [`azure`][azure]  | Provide Azure database host information.          | no       |
 | [`query_details`][query_details]   | Configure the queries collector.                  | no       |
 | [`query_samples`][query_samples]   | Configure the query samples collector.            | no       |
 | [`schema_details`][schema_details] | Configure the schema and table details collector. | no       |
@@ -62,6 +63,7 @@ For example, `cloud_provider` > `aws` refers to a `aws` block defined inside an 
 
 [cloud_provider]: #cloud_provider
 [aws]: #aws
+[azure]: #azure
 [query_details]: #query_details
 [query_samples]: #query_samples
 [schema_details]: #schema_details
@@ -83,6 +85,16 @@ The `aws` block supplies the [ARN](https://docs.aws.amazon.com/IAM/latest/UserGu
 | Name  | Type     | Description                                             | Default | Required |
 |-------|----------|---------------------------------------------------------|---------|----------|
 | `arn` | `string` | The ARN associated with the database under observation. |         | yes      |
+
+### `azure`
+
+The `azure` block supplies the identifying information for the database being monitored.
+
+| Name              | Type     | Description                                          | Default | Required |
+|-------------------|----------|------------------------------------------------------|---------|----------|
+| `subscription_id` | `string` | The Subscription ID for your Azure account.          |         | yes      |
+| `resource_group`  | `string` | The Resource Group that holds the database resource. |         | yes      |
+| `server_name`     | `string` | The database server name.                            |         | no       |
 
 ### `query_details`
 

--- a/internal/component/database_observability/cloud_provider.go
+++ b/internal/component/database_observability/cloud_provider.go
@@ -14,7 +14,7 @@ type AWSCloudProviderInfo struct {
 }
 
 type AzureCloudProviderInfo struct {
-	Resource       string
 	SubscriptionID string
 	ResourceGroup  string
+	ServerName     string
 }

--- a/internal/component/database_observability/cloud_provider.go
+++ b/internal/component/database_observability/cloud_provider.go
@@ -12,6 +12,9 @@ type CloudProvider struct {
 type AWSCloudProviderInfo struct {
 	ARN arn.ARN
 }
+
 type AzureCloudProviderInfo struct {
-	Resource string
+	Resource       string
+	SubscriptionID string
+	ResourceGroup  string
 }

--- a/internal/component/database_observability/mysql/cloud_provider.go
+++ b/internal/component/database_observability/mysql/cloud_provider.go
@@ -27,6 +27,13 @@ func populateCloudProviderFromConfig(config *CloudProvider) (*database_observabi
 			ARN: arn,
 		}
 	}
+	if config.Azure != nil {
+		cloudProvider.Azure = &database_observability.AzureCloudProviderInfo{
+			SubscriptionID: config.Azure.SubscriptionID,
+			ResourceGroup:  config.Azure.ResourceGroup,
+			Resource:       config.Azure.ServerName,
+		}
+	}
 	return &cloudProvider, nil
 }
 

--- a/internal/component/database_observability/mysql/cloud_provider.go
+++ b/internal/component/database_observability/mysql/cloud_provider.go
@@ -31,7 +31,7 @@ func populateCloudProviderFromConfig(config *CloudProvider) (*database_observabi
 		cloudProvider.Azure = &database_observability.AzureCloudProviderInfo{
 			SubscriptionID: config.Azure.SubscriptionID,
 			ResourceGroup:  config.Azure.ResourceGroup,
-			Resource:       config.Azure.ServerName,
+			ServerName:     config.Azure.ServerName,
 		}
 	}
 	return &cloudProvider, nil
@@ -60,7 +60,7 @@ func populateCloudProviderFromDSN(dsn string) (*database_observability.CloudProv
 		} else if strings.HasSuffix(host, "mysql.database.azure.com") {
 			if matches := azureRegex.FindStringSubmatch(host); len(matches) >= 2 {
 				cloudProvider.Azure = &database_observability.AzureCloudProviderInfo{
-					Resource: matches[1],
+					ServerName: matches[1],
 				}
 			}
 		}

--- a/internal/component/database_observability/mysql/cloud_provider_test.go
+++ b/internal/component/database_observability/mysql/cloud_provider_test.go
@@ -29,7 +29,7 @@ func TestPopulateCloudProvider(t *testing.T) {
 
 		assert.Equal(t, &database_observability.CloudProvider{
 			Azure: &database_observability.AzureCloudProviderInfo{
-				Resource: "products-db",
+				ServerName: "products-db",
 			},
 		}, got)
 	})

--- a/internal/component/database_observability/mysql/collector/connection_info.go
+++ b/internal/component/database_observability/mysql/collector/connection_info.go
@@ -81,7 +81,7 @@ func (c *ConnectionInfo) Start(ctx context.Context) error {
 		}
 		if c.CloudProvider.Azure != nil {
 			providerName = "azure"
-			dbInstanceIdentifier = c.CloudProvider.Azure.Resource
+			dbInstanceIdentifier = c.CloudProvider.Azure.ServerName
 			providerRegion = c.CloudProvider.Azure.ResourceGroup
 			providerAccount = c.CloudProvider.Azure.SubscriptionID
 		}

--- a/internal/component/database_observability/mysql/collector/connection_info.go
+++ b/internal/component/database_observability/mysql/collector/connection_info.go
@@ -82,6 +82,8 @@ func (c *ConnectionInfo) Start(ctx context.Context) error {
 		if c.CloudProvider.Azure != nil {
 			providerName = "azure"
 			dbInstanceIdentifier = c.CloudProvider.Azure.Resource
+			providerRegion = c.CloudProvider.Azure.ResourceGroup
+			providerAccount = c.CloudProvider.Azure.SubscriptionID
 		}
 	} else {
 		cfg, err := mysql.ParseDSN(c.DSN)

--- a/internal/component/database_observability/mysql/collector/connection_info_test.go
+++ b/internal/component/database_observability/mysql/collector/connection_info_test.go
@@ -60,13 +60,15 @@ func TestConnectionInfo(t *testing.T) {
 		{
 			name:          "Azure with cloud provider info supplied",
 			dsn:           "user:pass@tcp(products-db.mysql.database.azure.com:3306)/schema",
-			engineVersion: "15.4",
+			engineVersion: "8.0.32",
 			cloudProvider: &database_observability.CloudProvider{
 				Azure: &database_observability.AzureCloudProviderInfo{
-					Resource: "products-db",
+					Resource:       "products-db",
+					SubscriptionID: "sub-12345-abcde",
+					ResourceGroup:  "my-resource-group",
 				},
 			},
-			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "products-db", "mysql", "15.4", "unknown", "azure", "unknown"),
+			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "products-db", "mysql", "8.0.32", "sub-12345-abcde", "azure", "my-resource-group"),
 		},
 		{
 			name:            "Azure flexibleservers dsn",

--- a/internal/component/database_observability/mysql/collector/connection_info_test.go
+++ b/internal/component/database_observability/mysql/collector/connection_info_test.go
@@ -63,7 +63,7 @@ func TestConnectionInfo(t *testing.T) {
 			engineVersion: "8.0.32",
 			cloudProvider: &database_observability.CloudProvider{
 				Azure: &database_observability.AzureCloudProviderInfo{
-					Resource:       "products-db",
+					ServerName:     "products-db",
 					SubscriptionID: "sub-12345-abcde",
 					ResourceGroup:  "my-resource-group",
 				},

--- a/internal/component/database_observability/mysql/component.go
+++ b/internal/component/database_observability/mysql/component.go
@@ -74,11 +74,18 @@ type Arguments struct {
 }
 
 type CloudProvider struct {
-	AWS *AWSCloudProviderInfo `alloy:"aws,block,optional"`
+	AWS   *AWSCloudProviderInfo   `alloy:"aws,block,optional"`
+	Azure *AzureCloudProviderInfo `alloy:"azure,block,optional"`
 }
 
 type AWSCloudProviderInfo struct {
 	ARN string `alloy:"arn,attr"`
+}
+
+type AzureCloudProviderInfo struct {
+	SubscriptionID string `alloy:"subscription_id,attr"`
+	ResourceGroup  string `alloy:"resource_group,attr"`
+	ServerName     string `alloy:"server_name,attr,optional"`
 }
 
 type QueryTablesArguments struct {

--- a/internal/component/database_observability/mysql/component_test.go
+++ b/internal/component/database_observability/mysql/component_test.go
@@ -92,6 +92,56 @@ func Test_parseCloudProvider(t *testing.T) {
 
 		assert.Equal(t, "arn:aws:rds:some-region:some-account:db:some-db-instance", args.CloudProvider.AWS.ARN)
 	})
+
+	t.Run("parse azure cloud provider block with all fields", func(t *testing.T) {
+		exampleDBO11yAlloyConfig := `
+		data_source_name = ""
+		forward_to = []
+		targets = []
+		cloud_provider {
+			azure {
+				subscription_id = "sub-12345-abcde"
+				resource_group  = "my-resource-group"
+				server_name     = "my-mysql-server"
+			}
+		}
+	`
+
+		var args Arguments
+		err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
+		require.NoError(t, err)
+
+		require.NotNil(t, args.CloudProvider)
+		require.NotNil(t, args.CloudProvider.Azure)
+		assert.Equal(t, "sub-12345-abcde", args.CloudProvider.Azure.SubscriptionID)
+		assert.Equal(t, "my-resource-group", args.CloudProvider.Azure.ResourceGroup)
+		assert.Equal(t, "my-mysql-server", args.CloudProvider.Azure.ServerName)
+	})
+
+	t.Run("parse azure cloud provider block without optional server_name", func(t *testing.T) {
+		exampleDBO11yAlloyConfig := `
+		data_source_name = ""
+		forward_to = []
+		targets = []
+		cloud_provider {
+			azure {
+				subscription_id = "sub-12345-abcde"
+				resource_group  = "my-resource-group"
+			}
+		}
+	`
+
+		var args Arguments
+		err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
+		require.NoError(t, err)
+
+		require.NotNil(t, args.CloudProvider)
+		require.NotNil(t, args.CloudProvider.Azure)
+		assert.Equal(t, "sub-12345-abcde", args.CloudProvider.Azure.SubscriptionID)
+		assert.Equal(t, "my-resource-group", args.CloudProvider.Azure.ResourceGroup)
+		assert.Empty(t, args.CloudProvider.Azure.ServerName)
+	})
+
 	t.Run("empty cloud provider block", func(t *testing.T) {
 		exampleDBO11yAlloyConfig := `
 		data_source_name = ""

--- a/internal/component/database_observability/postgres/cloud_provider.go
+++ b/internal/component/database_observability/postgres/cloud_provider.go
@@ -26,6 +26,13 @@ func populateCloudProviderFromConfig(config *CloudProvider) (*database_observabi
 			ARN: arn,
 		}
 	}
+	if config.Azure != nil {
+		cloudProvider.Azure = &database_observability.AzureCloudProviderInfo{
+			SubscriptionID: config.Azure.SubscriptionID,
+			ResourceGroup:  config.Azure.ResourceGroup,
+			Resource:       config.Azure.ServerName,
+		}
+	}
 	return &cloudProvider, nil
 }
 

--- a/internal/component/database_observability/postgres/cloud_provider.go
+++ b/internal/component/database_observability/postgres/cloud_provider.go
@@ -30,7 +30,7 @@ func populateCloudProviderFromConfig(config *CloudProvider) (*database_observabi
 		cloudProvider.Azure = &database_observability.AzureCloudProviderInfo{
 			SubscriptionID: config.Azure.SubscriptionID,
 			ResourceGroup:  config.Azure.ResourceGroup,
-			Resource:       config.Azure.ServerName,
+			ServerName:     config.Azure.ServerName,
 		}
 	}
 	return &cloudProvider, nil
@@ -58,7 +58,7 @@ func populateCloudProviderFromDSN(dsn string) (*database_observability.CloudProv
 			matches := azureRegex.FindStringSubmatch(host)
 			if len(matches) > 1 {
 				cloudProvider.Azure = &database_observability.AzureCloudProviderInfo{
-					Resource: matches[1],
+					ServerName: matches[1],
 				}
 			}
 		}

--- a/internal/component/database_observability/postgres/cloud_provider_test.go
+++ b/internal/component/database_observability/postgres/cloud_provider_test.go
@@ -29,7 +29,7 @@ func TestPopulateCloudProvider(t *testing.T) {
 
 		assert.Equal(t, &database_observability.CloudProvider{
 			Azure: &database_observability.AzureCloudProviderInfo{
-				Resource: "products-db",
+				ServerName: "products-db",
 			},
 		}, got)
 	})

--- a/internal/component/database_observability/postgres/collector/connection_info.go
+++ b/internal/component/database_observability/postgres/collector/connection_info.go
@@ -83,6 +83,8 @@ func (c *ConnectionInfo) Start(ctx context.Context) error {
 		if c.CloudProvider.Azure != nil {
 			providerName = "azure"
 			dbInstanceIdentifier = c.CloudProvider.Azure.Resource
+			providerRegion = c.CloudProvider.Azure.ResourceGroup
+			providerAccount = c.CloudProvider.Azure.SubscriptionID
 		}
 	} else {
 		parts, err := ParseURL(c.DSN)

--- a/internal/component/database_observability/postgres/collector/connection_info.go
+++ b/internal/component/database_observability/postgres/collector/connection_info.go
@@ -82,7 +82,7 @@ func (c *ConnectionInfo) Start(ctx context.Context) error {
 		}
 		if c.CloudProvider.Azure != nil {
 			providerName = "azure"
-			dbInstanceIdentifier = c.CloudProvider.Azure.Resource
+			dbInstanceIdentifier = c.CloudProvider.Azure.ServerName
 			providerRegion = c.CloudProvider.Azure.ResourceGroup
 			providerAccount = c.CloudProvider.Azure.SubscriptionID
 		}

--- a/internal/component/database_observability/postgres/collector/connection_info_test.go
+++ b/internal/component/database_observability/postgres/collector/connection_info_test.go
@@ -65,10 +65,12 @@ func TestConnectionInfo(t *testing.T) {
 			engineVersion: "15.4",
 			cloudProvider: &database_observability.CloudProvider{
 				Azure: &database_observability.AzureCloudProviderInfo{
-					Resource: "products-db",
+					Resource:       "products-db",
+					SubscriptionID: "sub-12345-abcde",
+					ResourceGroup:  "my-resource-group",
 				},
 			},
-			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "products-db", "postgres", "15.4", "unknown", "azure", "unknown"),
+			expectedMetrics: fmt.Sprintf(baseExpectedMetrics, "products-db", "postgres", "15.4", "sub-12345-abcde", "azure", "my-resource-group"),
 		},
 		{
 			name:            "Azure flexibleservers dsn",

--- a/internal/component/database_observability/postgres/collector/connection_info_test.go
+++ b/internal/component/database_observability/postgres/collector/connection_info_test.go
@@ -65,7 +65,7 @@ func TestConnectionInfo(t *testing.T) {
 			engineVersion: "15.4",
 			cloudProvider: &database_observability.CloudProvider{
 				Azure: &database_observability.AzureCloudProviderInfo{
-					Resource:       "products-db",
+					ServerName:     "products-db",
 					SubscriptionID: "sub-12345-abcde",
 					ResourceGroup:  "my-resource-group",
 				},

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -75,11 +75,18 @@ type Arguments struct {
 }
 
 type CloudProvider struct {
-	AWS *AWSCloudProviderInfo `alloy:"aws,block,optional"`
+	AWS   *AWSCloudProviderInfo   `alloy:"aws,block,optional"`
+	Azure *AzureCloudProviderInfo `alloy:"azure,block,optional"`
 }
 
 type AWSCloudProviderInfo struct {
 	ARN string `alloy:"arn,attr"`
+}
+
+type AzureCloudProviderInfo struct {
+	SubscriptionID string `alloy:"subscription_id,attr"`
+	ResourceGroup  string `alloy:"resource_group,attr"`
+	ServerName     string `alloy:"server_name,attr,optional"`
 }
 
 type QuerySampleArguments struct {

--- a/internal/component/database_observability/postgres/component_test.go
+++ b/internal/component/database_observability/postgres/component_test.go
@@ -404,3 +404,89 @@ func TestPostgres_schema_details_cache_configuration_is_parsed_from_config(t *te
 		assert.Equal(t, 5*time.Minute, args.SchemaDetailsArguments.CacheTTL)
 	})
 }
+
+func Test_parseCloudProvider(t *testing.T) {
+	t.Run("parse aws cloud provider block", func(t *testing.T) {
+		exampleDBO11yAlloyConfig := `
+		data_source_name = "postgres://db"
+		forward_to = []
+		targets = []
+		cloud_provider {
+			aws {
+				arn = "arn:aws:rds:some-region:some-account:db:some-db-instance"
+			}
+		}
+	`
+
+		var args Arguments
+		err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
+		require.NoError(t, err)
+
+		require.NotNil(t, args.CloudProvider)
+		require.NotNil(t, args.CloudProvider.AWS)
+		assert.Equal(t, "arn:aws:rds:some-region:some-account:db:some-db-instance", args.CloudProvider.AWS.ARN)
+	})
+
+	t.Run("parse azure cloud provider block with all fields", func(t *testing.T) {
+		exampleDBO11yAlloyConfig := `
+		data_source_name = "postgres://db"
+		forward_to = []
+		targets = []
+		cloud_provider {
+			azure {
+				subscription_id = "sub-12345-abcde"
+				resource_group  = "my-resource-group"
+				server_name     = "my-postgres-server"
+			}
+		}
+	`
+
+		var args Arguments
+		err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
+		require.NoError(t, err)
+
+		require.NotNil(t, args.CloudProvider)
+		require.NotNil(t, args.CloudProvider.Azure)
+		assert.Equal(t, "sub-12345-abcde", args.CloudProvider.Azure.SubscriptionID)
+		assert.Equal(t, "my-resource-group", args.CloudProvider.Azure.ResourceGroup)
+		assert.Equal(t, "my-postgres-server", args.CloudProvider.Azure.ServerName)
+	})
+
+	t.Run("parse azure cloud provider block without optional server_name", func(t *testing.T) {
+		exampleDBO11yAlloyConfig := `
+		data_source_name = "postgres://db"
+		forward_to = []
+		targets = []
+		cloud_provider {
+			azure {
+				subscription_id = "sub-12345-abcde"
+				resource_group  = "my-resource-group"
+			}
+		}
+	`
+
+		var args Arguments
+		err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
+		require.NoError(t, err)
+
+		require.NotNil(t, args.CloudProvider)
+		require.NotNil(t, args.CloudProvider.Azure)
+		assert.Equal(t, "sub-12345-abcde", args.CloudProvider.Azure.SubscriptionID)
+		assert.Equal(t, "my-resource-group", args.CloudProvider.Azure.ResourceGroup)
+		assert.Empty(t, args.CloudProvider.Azure.ServerName)
+	})
+
+	t.Run("empty cloud provider block", func(t *testing.T) {
+		exampleDBO11yAlloyConfig := `
+		data_source_name = "postgres://db"
+		forward_to = []
+		targets = []
+	`
+
+		var args Arguments
+		err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
+		require.NoError(t, err)
+
+		assert.Nil(t, args.CloudProvider)
+	})
+}

--- a/internal/component/database_observability/relabeling_test.go
+++ b/internal/component/database_observability/relabeling_test.go
@@ -49,7 +49,7 @@ func Test_GetRelabelingRules(t *testing.T) {
 	t.Run("return relabeling rules with Azure config", func(t *testing.T) {
 		rr := GetRelabelingRules("some-server-id", &CloudProvider{
 			Azure: &AzureCloudProviderInfo{
-				Resource: "some-resource",
+				ServerName: "some-resource",
 			},
 		})
 


### PR DESCRIPTION
### Brief description of Pull Request

Add configuration block `database_observability.cloud_provider.azure` to support Azure database instances in addition to existing AWS support. When data is provided in this block, the corresponding labels are populated.

### Pull Request Details

<!-- Add a more detailed descripion of the Pull Request here, if needed. -->

### Issue(s) fixed by this Pull Request

<!--
  Uncomment the following line and fill in an issue number if you want a GitHub
  issue to be closed automatically when this PR gets merged.
-->

<!-- Fixes #issue_id -->

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
