### PR TITLE
fix: Database_observability: reuse cloud provider regexes

### DIFF
--- a/internal/component/database_observability/cloud_provider.go
+++ b/internal/component/database_observability/cloud_provider.go
@@ -1,7 +1,15 @@
 package database_observability
 
 import (
+	"regexp"
+
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
+)
+
+var (
+	RdsRegex             = regexp.MustCompile(`(?P<identifier>[^\.]+)\.([^\.]+)\.(?P<region>[^\.]+)\.rds\.amazonaws\.com`)
+	AzureMySQLRegex      = regexp.MustCompile(`(?P<identifier>[^\.]+)\.(?:privatelink\.)?mysql\.database\.azure\.com`)
+	AzurePostgreSQLRegex = regexp.MustCompile(`(?P<identifier>[^\.]+)\.(?:privatelink\.)?postgres\.database\.azure\.com`)
 )
 
 type CloudProvider struct {

--- a/internal/component/database_observability/mysql/cloud_provider.go
+++ b/internal/component/database_observability/mysql/cloud_provider.go
@@ -3,17 +3,11 @@ package mysql
 import (
 	"fmt"
 	"net"
-	"regexp"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/go-sql-driver/mysql"
 	"github.com/grafana/alloy/internal/component/database_observability"
-)
-
-var (
-	rdsRegex   = regexp.MustCompile(`(?P<identifier>[^\.]+)\.([^\.]+)\.(?P<region>[^\.]+)\.rds\.amazonaws\.com`)
-	azureRegex = regexp.MustCompile(`(?P<identifier>[^\.]+)\.mysql\.database\.azure\.com`)
 )
 
 func populateCloudProviderFromConfig(config *CloudProvider) (*database_observability.CloudProvider, error) {
@@ -41,7 +35,7 @@ func populateCloudProviderFromDSN(dsn string) (*database_observability.CloudProv
 	host, _, err := net.SplitHostPort(cfg.Addr)
 	if err == nil && host != "" {
 		if strings.HasSuffix(host, "rds.amazonaws.com") {
-			if matches := rdsRegex.FindStringSubmatch(host); len(matches) >= 4 {
+			if matches := database_observability.RdsRegex.FindStringSubmatch(host); len(matches) >= 4 {
 				cloudProvider.AWS = &database_observability.AWSCloudProviderInfo{
 					ARN: arn.ARN{
 						Resource:  fmt.Sprintf("db:%s", matches[1]),
@@ -51,7 +45,7 @@ func populateCloudProviderFromDSN(dsn string) (*database_observability.CloudProv
 				}
 			}
 		} else if strings.HasSuffix(host, "mysql.database.azure.com") {
-			if matches := azureRegex.FindStringSubmatch(host); len(matches) >= 2 {
+			if matches := database_observability.AzureMySQLRegex.FindStringSubmatch(host); len(matches) >= 2 {
 				cloudProvider.Azure = &database_observability.AzureCloudProviderInfo{
 					Resource: matches[1],
 				}

--- a/internal/component/database_observability/mysql/collector/connection_info.go
+++ b/internal/component/database_observability/mysql/collector/connection_info.go
@@ -3,7 +3,6 @@ package collector
 import (
 	"context"
 	"net"
-	"regexp"
 	"strings"
 
 	"github.com/go-sql-driver/mysql"
@@ -13,11 +12,6 @@ import (
 )
 
 const ConnectionInfoName = "connection_info"
-
-var (
-	rdsRegex   = regexp.MustCompile(`(?P<identifier>[^\.]+)\.([^\.]+)\.(?P<region>[^\.]+)\.rds\.amazonaws\.com`)
-	azureRegex = regexp.MustCompile(`(?P<identifier>[^\.]+)\.(?:privatelink\.)?mysql\.database\.azure\.com`)
-)
 
 type ConnectionInfoArguments struct {
 	DSN           string
@@ -93,14 +87,14 @@ func (c *ConnectionInfo) Start(ctx context.Context) error {
 		if err == nil && host != "" {
 			if strings.HasSuffix(host, "rds.amazonaws.com") {
 				providerName = "aws"
-				matches := rdsRegex.FindStringSubmatch(host)
+				matches := database_observability.RdsRegex.FindStringSubmatch(host)
 				if len(matches) > 3 {
 					dbInstanceIdentifier = matches[1]
 					providerRegion = matches[3]
 				}
 			} else if strings.HasSuffix(host, "mysql.database.azure.com") {
 				providerName = "azure"
-				matches := azureRegex.FindStringSubmatch(host)
+				matches := database_observability.AzureMySQLRegex.FindStringSubmatch(host)
 				if len(matches) > 1 {
 					dbInstanceIdentifier = matches[1]
 				}

--- a/internal/component/database_observability/postgres/cloud_provider.go
+++ b/internal/component/database_observability/postgres/cloud_provider.go
@@ -2,17 +2,11 @@ package postgres
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/grafana/alloy/internal/component/database_observability"
 	"github.com/grafana/alloy/internal/component/database_observability/postgres/collector"
-)
-
-var (
-	rdsRegex   = regexp.MustCompile(`(?P<identifier>[^\.]+)\.([^\.]+)\.(?P<region>[^\.]+)\.rds\.amazonaws\.com`)
-	azureRegex = regexp.MustCompile(`(?P<identifier>[^\.]+)\.postgres\.database\.azure\.com`)
 )
 
 func populateCloudProviderFromConfig(config *CloudProvider) (*database_observability.CloudProvider, error) {
@@ -39,7 +33,7 @@ func populateCloudProviderFromDSN(dsn string) (*database_observability.CloudProv
 
 	if host, ok := parts["host"]; ok {
 		if strings.HasSuffix(host, "rds.amazonaws.com") {
-			matches := rdsRegex.FindStringSubmatch(host)
+			matches := database_observability.RdsRegex.FindStringSubmatch(host)
 			cloudProvider.AWS = &database_observability.AWSCloudProviderInfo{
 				ARN: arn.ARN{
 					Resource:  fmt.Sprintf("db:%s", matches[1]),
@@ -48,7 +42,7 @@ func populateCloudProviderFromDSN(dsn string) (*database_observability.CloudProv
 				},
 			}
 		} else if strings.HasSuffix(host, "postgres.database.azure.com") {
-			matches := azureRegex.FindStringSubmatch(host)
+			matches := database_observability.AzurePostgreSQLRegex.FindStringSubmatch(host)
 			if len(matches) > 1 {
 				cloudProvider.Azure = &database_observability.AzureCloudProviderInfo{
 					Resource: matches[1],

--- a/internal/component/database_observability/postgres/collector/connection_info.go
+++ b/internal/component/database_observability/postgres/collector/connection_info.go
@@ -12,11 +12,6 @@ import (
 
 const ConnectionInfoName = "connection_info"
 
-var (
-	rdsRegex   = regexp.MustCompile(`(?P<identifier>[^\.]+)\.([^\.]+)\.(?P<region>[^\.]+)\.rds\.amazonaws\.com`)
-	azureRegex = regexp.MustCompile(`(?P<identifier>[^\.]+)\.(?:privatelink\.)?postgres\.database\.azure\.com`)
-)
-
 var engineVersionRegex = regexp.MustCompile(`(?P<version>^[1-9]+\.[1-9]+)(?P<suffix>.*)?$`)
 
 type ConnectionInfoArguments struct {
@@ -92,14 +87,14 @@ func (c *ConnectionInfo) Start(ctx context.Context) error {
 		if host, ok := parts["host"]; ok {
 			if strings.HasSuffix(host, "rds.amazonaws.com") {
 				providerName = "aws"
-				matches := rdsRegex.FindStringSubmatch(host)
+				matches := database_observability.RdsRegex.FindStringSubmatch(host)
 				if len(matches) > 3 {
 					dbInstanceIdentifier = matches[1]
 					providerRegion = matches[3]
 				}
 			} else if strings.HasSuffix(host, "postgres.database.azure.com") {
 				providerName = "azure"
-				matches := azureRegex.FindStringSubmatch(host)
+				matches := database_observability.AzurePostgreSQLRegex.FindStringSubmatch(host)
 				if len(matches) > 1 {
 					dbInstanceIdentifier = matches[1]
 				}


### PR DESCRIPTION
### Brief description of Pull Request

Consolidate the regexes in a common package and make sure to support Azure privatelink parsing.

### Pull Request Details

This is a followup of https://github.com/grafana/alloy/pull/5260

### Issue(s) fixed by this Pull Request

<!--
  Uncomment the following line and fill in an issue number if you want a GitHub
  issue to be closed automatically when this PR gets merged.
-->

<!-- Fixes #issue_id -->

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
