### PR TITLE
docs: Add explanation of `sync_period`

### DIFF
--- a/docs/sources/monitor/monitor-logs-from-file.md
+++ b/docs/sources/monitor/monitor-logs-from-file.md
@@ -114,7 +114,7 @@ The [`local.file_match`][local.file_match] component discovers files on the loca
 In this example, the component requires the following arguments:
 
 * `path_targets`: Targets to expand. Looks for glob patterns on the `__path__` key.
-* `sync_period`: How often to sync the filesystem and targets. When files appear or disappear, the list of targets is automatically updated based on this configuration. When disappeared files got synced, the corresponding stored position is cleaned up.
+* `sync_period`: How often to sync the filesystem and targets. When files are added or removed, the list of targets is automatically updated based on this configuration. When files are removed, the stored position is removed in the next filesystem sync.
 
 ```alloy
 local.file_match "local_files" {


### PR DESCRIPTION
### Brief description of Pull Request

I am dealing with old system that generates log file named `<service>_<month>`. The log file would then be replaced every year, so I needded to make sure a certain alloy log scraping behavior. I found a promtail behavior (also with simliar situation as me) in the [community discussion](https://community.grafana.com/t/a-way-of-deleting-log-files-after-promtail-has-scraped-and-forwarded-them-to-loki/60626) and I think it is relevant to be included in the docs ***IF*** the behavior is the same in alloy.
> You actually won’t need to remove the entries from the positions file since promtail is already aware of files being removed (and will cleanup the positions file every -positions.sync-period).

~The description is also moved from `loki` to the more general `monitor` for easier discovery.~

### Notes to the Reviewer

Ensure promtail's `-positions.sync-period` is the same with alloy.

### PR Checklist

- [x] Documentation moved & added
