### PR TITLE
fix: HTTP/2 is no longer always disabled in loki.write

### DIFF
--- a/internal/component/common/loki/client/shards.go
+++ b/internal/component/common/loki/client/shards.go
@@ -213,7 +213,7 @@ func newShards(metrics *metrics, logger log.Logger, markerHandler SentDataMarker
 		return nil, err
 	}
 
-	client, err := config.NewClientFromConfig(cfg.Client, useragent.ProductName, config.WithHTTP2Disabled())
+	client, err := config.NewClientFromConfig(cfg.Client, useragent.ProductName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Brief description of Pull Request
No longer configure loki.write client to always disable http2 but respect the configuration.

### Pull Request Details
https://github.com/grafana/alloy/pull/4835 attempted to fix this but it was only fixed for client used when WAL was enbaled.

Since https://github.com/grafana/alloy/pull/4882 both WAL and non WAL uses the same uses the same code to build client and since the none WAL implementation always forced HTTP/1 it got carried over.

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
