### PR TITLE
chore: Disable systemd collector in test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ test:
 			(cd $$dir && $(GO_ENV) go test $(GO_FLAGS) -race ./...) || exit 1;\
 		fi;\
 	done
-	
+
 test-packages:
 ifeq ($(USE_CONTAINER),1)
 	$(RERUN_IN_CONTAINER)

--- a/internal/static/integrations/node_exporter/node_exporter_test.go
+++ b/internal/static/integrations/node_exporter/node_exporter_test.go
@@ -1,4 +1,4 @@
-//go:build !race && !windows
+//go:build !windows
 
 package node_exporter
 
@@ -28,12 +28,12 @@ import (
 func TestNodeExporter(t *testing.T) {
 	cfg := DefaultConfig
 
-	// Enable all collectors except perf
+	// Enable all collectors except perf, buddyinfo and systemd
 	cfg.SetCollectors = make([]string, 0, len(Collectors))
 	for c := range Collectors {
 		cfg.SetCollectors = append(cfg.SetCollectors, c)
 	}
-	cfg.DisableCollectors = []string{CollectorPerf, CollectorBuddyInfo}
+	cfg.DisableCollectors = []string{CollectorPerf, CollectorBuddyInfo, CollectorSystemd}
 
 	// Check that the flags convert and the integration initializes
 	logger := log.NewNopLogger()


### PR DESCRIPTION
### Pull Request Details
This collector reports error when running tests with `-race`. It should be fixed upstream. We can disable this collector for this simple test for now and not have special handling for this one in tests.

### Issue(s) fixed by this Pull Request

<!--
  Uncomment the following line and fill in an issue number if you want a GitHub
  issue to be closed automatically when this PR gets merged.
-->

<!-- Fixes #issue_id -->

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
