### PR TITLE
fix: Database_observability: update BackendXmin type to int64 to better map to PG BIGINT

### DIFF
--- a/internal/component/database_observability/postgres/collector/query_samples.go
+++ b/internal/component/database_observability/postgres/collector/query_samples.go
@@ -91,7 +91,7 @@ type QuerySamplesInfo struct {
 	State           sql.NullString
 	BackendType     sql.NullString
 	BackendXID      sql.NullInt32
-	BackendXmin     sql.NullInt32
+	BackendXmin     sql.NullInt64
 	QueryID         sql.NullInt64
 	Query           sql.NullString
 	BlockedByPIDs   pq.Int64Array
@@ -515,7 +515,7 @@ func (c *QuerySamples) buildQuerySampleLabelsWithEnd(state *SampleState, endAt s
 		state.LastRow.BackendType.String,
 		state.LastRow.State.String,
 		state.LastRow.BackendXID.Int32,
-		state.LastRow.BackendXmin.Int32,
+		state.LastRow.BackendXmin.Int64,
 		xactDuration,
 		queryDuration,
 		state.LastRow.QueryID.Int64,
@@ -544,7 +544,7 @@ func (c *QuerySamples) buildWaitEventLabels(state *SampleState, we WaitEventOccu
 		state.LastRow.BackendType.String,
 		we.LastState,
 		state.LastRow.BackendXID.Int32,
-		state.LastRow.BackendXmin.Int32,
+		state.LastRow.BackendXmin.Int64,
 		we.LastWaitTime,
 		we.WaitEventType,
 		we.WaitEvent,


### PR DESCRIPTION
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style. For details on this,
  check out the Contributors Guide linked above.
-->

### Brief description of Pull Request
This change updates the integer type used for our representation of `BackendXmin` from int32, to int64 which better maps to Postgres bigint data type

[pg_stat_activity view docs](https://www.postgresql.org/docs/current/monitoring-stats.html#MONITORING-PG-STAT-ACTIVITY-VIEW)
[bigint docs](https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-NUMERIC)

<!--
  Add a human-readable description of the PR that may be used as the commit body
  (i.e. "Extended description") when it gets merged.
-->

### Pull Request Details

<!-- Add a more detailed descripion of the Pull Request here, if needed. -->

### Issue(s) fixed by this Pull Request

<!--
  Uncomment the following line and fill in an issue number if you want a GitHub
  issue to be closed automatically when this PR gets merged.
-->

<!-- Fixes #issue_id -->

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
