### PR TITLE
chore: Backport 5221 to release v1.12

### DIFF
--- a/docs/sources/reference/components/loki/loki.source.journal.md
+++ b/docs/sources/reference/components/loki/loki.source.journal.md
@@ -17,7 +17,7 @@ title: loki.source.journal
 You can specify multiple `loki.source.journal` components by giving them different labels.
 
 {{< admonition type="note" >}}
-Make sure that the `grafana-alloy` user is a member of the following groups:
+Make sure that the `alloy` user is a member of the following groups:
 
 * `adm`
 * `systemd-journal`


### PR DESCRIPTION
Backport  6b1cdda03f90450689425c22e48de65ff74202fc from https://github.com/grafana/alloy/pull/5221

