### PR TITLE
chore: Backport 5266 to v1.12

### DIFF
--- a/docs/sources/monitor/monitor-logs-from-file.md
+++ b/docs/sources/monitor/monitor-logs-from-file.md
@@ -114,7 +114,7 @@ The [`local.file_match`][local.file_match] component discovers files on the loca
 In this example, the component requires the following arguments:
 
 * `path_targets`: Targets to expand. Looks for glob patterns on the `__path__` key.
-* `sync_period`: How often to sync the filesystem and targets.
+* `sync_period`: How often to sync the filesystem and targets. When files are added or removed, the list of targets is automatically updated based on this configuration. When files are removed, the stored position is removed in the next filesystem sync.
 
 ```alloy
 local.file_match "local_files" {


### PR DESCRIPTION
Backport 4500563ed411e0dbb2955fdcb8aab9c0b10a3fd6 from https://github.com/grafana/alloy/pull/5266