### PR TITLE
docs: Replace specific IP and port in example with replaceable variable notation in otelcol.receiver.cloudflare

### DIFF
--- a/docs/sources/reference/components/otelcol/otelcol.receiver.cloudflare.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.cloudflare.md
@@ -141,6 +141,7 @@ Replace the following:
 
 - Components that export [OpenTelemetry `otelcol.Consumer`](../../../compatibility/#opentelemetry-otelcolconsumer-exporters)
 
+
 {{< admonition type="note" >}}
 Connecting some components may not be sensible or components may require further configuration to make the connection work correctly.
 Refer to the linked documentation for more details.


### PR DESCRIPTION
Replace specific IP and port in example with replaceable variable notation.  Add a standard `Replace the following` section below the example

Fixes: https://github.com/grafana/alloy/issues/5150