### PR TITLE
feat: Database_observability: expose `exclude_schemas` and `exclude_databases` settings

### DIFF
--- a/docs/sources/reference/components/database_observability/database_observability.mysql.md
+++ b/docs/sources/reference/components/database_observability/database_observability.mysql.md
@@ -33,7 +33,7 @@ You can use the following arguments with `database_observability.mysql`:
 | `targets`                                  | `list(map(string))`  | List of targets to scrape.                                                  |         | yes      |
 | `disable_collectors`                       | `list(string)`       | A list of collectors to disable from the default set.                       |         | no       |
 | `enable_collectors`                        | `list(string)`       | A list of collectors to enable on top of the default set.                   |         | no       |
-| `exclude_schemas`                          | `list(string)`       | A list of databases to exclude from monitoring.                             |         | no       |
+| `exclude_schemas`                          | `list(string)`       | A list of schemas to exclude from monitoring.                               |         | no       |
 | `allow_update_performance_schema_settings` | `boolean`            | Whether to allow updates to `performance_schema` settings in any collector. Enable this in conjunction with other collector-specific settings where required. | `false` | no       |
 
 The following collectors are configurable:

--- a/docs/sources/reference/components/database_observability/database_observability.mysql.md
+++ b/docs/sources/reference/components/database_observability/database_observability.mysql.md
@@ -133,7 +133,7 @@ The `azure` block supplies the identifying information for the database being mo
 | Name                           | Type           | Description                                                                     | Default | Required |
 | ------------------------------ | -------------- | ------------------------------------------------------------------------------- | ------- | -------- |
 | `collect_interval`             | `duration`     | How frequently to collect information from database.                            | `"1m"`  | no       |
-| `explain_plan_exclude_schemas` | `list(string)` | List of schemas to exclude from explain plan collection.                        |         | no       |
+| `exclude_schemas`              | `list(string)` | List of schemas to exclude from explain plan collection.                        | `[]`    | no       |
 | `initial_lookback`             | `duration`     | How far back to look for explain plan queries on the first collection interval. | `"24h"` | no       |
 | `per_collect_ratio`            | `float`        | Ratio of explain plan queries to collect per collect interval.                  | `1.0`   | no       |
 

--- a/docs/sources/reference/components/database_observability/database_observability.mysql.md
+++ b/docs/sources/reference/components/database_observability/database_observability.mysql.md
@@ -33,6 +33,7 @@ You can use the following arguments with `database_observability.mysql`:
 | `targets`                                  | `list(map(string))`  | List of targets to scrape.                                                  |         | yes      |
 | `disable_collectors`                       | `list(string)`       | A list of collectors to disable from the default set.                       |         | no       |
 | `enable_collectors`                        | `list(string)`       | A list of collectors to enable on top of the default set.                   |         | no       |
+| `exclude_schemas`                          | `list(string)`       | A list of databases to exclude from monitoring.                             |         | no       |
 | `allow_update_performance_schema_settings` | `boolean`            | Whether to allow updates to `performance_schema` settings in any collector. Enable this in conjunction with other collector-specific settings where required. | `false` | no       |
 
 The following collectors are configurable:
@@ -133,7 +134,6 @@ The `azure` block supplies the identifying information for the database being mo
 | Name                           | Type           | Description                                                                     | Default | Required |
 | ------------------------------ | -------------- | ------------------------------------------------------------------------------- | ------- | -------- |
 | `collect_interval`             | `duration`     | How frequently to collect information from database.                            | `"1m"`  | no       |
-| `exclude_schemas`              | `list(string)` | List of schemas to exclude from explain plan collection.                        | `[]`    | no       |
 | `initial_lookback`             | `duration`     | How far back to look for explain plan queries on the first collection interval. | `"24h"` | no       |
 | `per_collect_ratio`            | `float`        | Ratio of explain plan queries to collect per collect interval.                  | `1.0`   | no       |
 

--- a/docs/sources/reference/components/database_observability/database_observability.postgres.md
+++ b/docs/sources/reference/components/database_observability/database_observability.postgres.md
@@ -33,6 +33,7 @@ You can use the following arguments with `database_observability.postgres`:
 | `targets`            | `list(map(string))`  | List of targets to scrape.                                  |         | yes      |
 | `disable_collectors` | `list(string)`       | A list of collectors to disable from the default set.       |         | no       |
 | `enable_collectors`  | `list(string)`       | A list of collectors to enable on top of the default set.   |         | no       |
+| `exclude_databases`  | `list(string)`       | A list of databases to exclude from monitoring.             |         | no       |
 
 The following collectors are configurable:
 
@@ -126,7 +127,6 @@ The `azure` block supplies the identifying information for the database being mo
 |---------------------|----------------|------------------------------------------------------|---------|----------|
 | `collect_interval`  | `duration`     | How frequently to collect information from database. | `"1m"`  | no       |
 | `per_collect_ratio` | `float64`      | The ratio of queries to collect explain plans for.   | `1.0`   | no       |
-| `exclude_schemas`   | `list(string)` | Schemas to exclude from explain plans.               | `[]`    | no       |
 
 ### `health_check`
 

--- a/docs/sources/reference/components/database_observability/database_observability.postgres.md
+++ b/docs/sources/reference/components/database_observability/database_observability.postgres.md
@@ -122,11 +122,11 @@ The `azure` block supplies the identifying information for the database being mo
 
 ### `explain_plans`
 
-| Name                           | Type           | Description                                          | Default | Required |
-|--------------------------------|----------------|------------------------------------------------------|---------|----------|
-| `collect_interval`             | `duration`     | How frequently to collect information from database. | `"1m"`  | no       |
-| `per_collect_ratio`            | `float64`      | The ratio of queries to collect explain plans for.   | `1.0`   | no       |
-| `explain_plan_exclude_schemas` | `list(string)` | Schemas to exclude from explain plans.               | `[]`    | no       |
+| Name                | Type           | Description                                          | Default | Required |
+|---------------------|----------------|------------------------------------------------------|---------|----------|
+| `collect_interval`  | `duration`     | How frequently to collect information from database. | `"1m"`  | no       |
+| `per_collect_ratio` | `float64`      | The ratio of queries to collect explain plans for.   | `1.0`   | no       |
+| `exclude_schemas`   | `list(string)` | Schemas to exclude from explain plans.               | `[]`    | no       |
 
 ### `health_check`
 

--- a/internal/component/database_observability/mysql/collector/explain_plans.go
+++ b/internal/component/database_observability/mysql/collector/explain_plans.go
@@ -397,9 +397,9 @@ type ExplainPlansArguments struct {
 	DB              *sql.DB
 	ScrapeInterval  time.Duration
 	PerScrapeRatio  float64
+	InitialLookback time.Time
 	ExcludeSchemas  []string
 	EntryHandler    loki.EntryHandler
-	InitialLookback time.Time
 	DBVersion       string
 
 	Logger log.Logger
@@ -427,12 +427,12 @@ func NewExplainPlans(args ExplainPlansArguments) (*ExplainPlans, error) {
 		dbConnection:   args.DB,
 		dbVersion:      args.DBVersion,
 		scrapeInterval: args.ScrapeInterval,
+		perScrapeRatio: args.PerScrapeRatio,
+		excludeSchemas: args.ExcludeSchemas,
+		lastSeen:       args.InitialLookback,
 		queryCache:     make(map[string]*queryInfo),
 		queryDenylist:  make(map[string]*queryInfo),
-		excludeSchemas: args.ExcludeSchemas,
-		perScrapeRatio: args.PerScrapeRatio,
 		entryHandler:   args.EntryHandler,
-		lastSeen:       args.InitialLookback,
 		logger:         log.With(args.Logger, "collector", ExplainPlansCollector),
 		running:        atomic.NewBool(false),
 	}, nil

--- a/internal/component/database_observability/mysql/component.go
+++ b/internal/component/database_observability/mysql/component.go
@@ -110,10 +110,10 @@ type SetupActorsArguments struct {
 }
 
 type ExplainPlansArguments struct {
-	CollectInterval           time.Duration `alloy:"collect_interval,attr,optional"`
-	PerCollectRatio           float64       `alloy:"per_collect_ratio,attr,optional"`
-	InitialLookback           time.Duration `alloy:"initial_lookback,attr,optional"`
-	ExplainPlanExcludeSchemas []string      `alloy:"explain_plan_exclude_schemas,attr,optional"`
+	CollectInterval time.Duration `alloy:"collect_interval,attr,optional"`
+	PerCollectRatio float64       `alloy:"per_collect_ratio,attr,optional"`
+	InitialLookback time.Duration `alloy:"initial_lookback,attr,optional"`
+	ExcludeSchemas  []string      `alloy:"exclude_schemas,attr,optional"`
 }
 
 type LocksArguments struct {
@@ -160,6 +160,7 @@ var DefaultArguments = Arguments{
 		CollectInterval: 1 * time.Minute,
 		PerCollectRatio: 1.0,
 		InitialLookback: 24 * time.Hour,
+		ExcludeSchemas:  []string{},
 	},
 
 	LocksArguments: LocksArguments{
@@ -568,10 +569,11 @@ func (c *Component) startCollectors(serverID string, engineVersion string, parse
 			DB:              c.dbConnection,
 			ScrapeInterval:  c.args.ExplainPlansArguments.CollectInterval,
 			PerScrapeRatio:  c.args.ExplainPlansArguments.PerCollectRatio,
+			ExcludeSchemas:  c.args.ExplainPlansArguments.ExcludeSchemas,
+			InitialLookback: time.Now().Add(-c.args.ExplainPlansArguments.InitialLookback),
 			Logger:          c.opts.Logger,
 			DBVersion:       engineVersion,
 			EntryHandler:    entryHandler,
-			InitialLookback: time.Now().Add(-c.args.ExplainPlansArguments.InitialLookback),
 		})
 		if err != nil {
 			logStartError(collector.ExplainPlansCollector, "create", err)

--- a/internal/component/database_observability/mysql/component.go
+++ b/internal/component/database_observability/mysql/component.go
@@ -60,6 +60,7 @@ type Arguments struct {
 	Targets                       []discovery.Target  `alloy:"targets,attr"`
 	EnableCollectors              []string            `alloy:"enable_collectors,attr,optional"`
 	DisableCollectors             []string            `alloy:"disable_collectors,attr,optional"`
+	ExcludeSchemas                []string            `alloy:"exclude_schemas,attr,optional"`
 	AllowUpdatePerfSchemaSettings bool                `alloy:"allow_update_performance_schema_settings,attr,optional"`
 
 	CloudProvider           *CloudProvider          `alloy:"cloud_provider,block,optional"`
@@ -113,7 +114,6 @@ type ExplainPlansArguments struct {
 	CollectInterval time.Duration `alloy:"collect_interval,attr,optional"`
 	PerCollectRatio float64       `alloy:"per_collect_ratio,attr,optional"`
 	InitialLookback time.Duration `alloy:"initial_lookback,attr,optional"`
-	ExcludeSchemas  []string      `alloy:"exclude_schemas,attr,optional"`
 }
 
 type LocksArguments struct {
@@ -133,6 +133,7 @@ type HealthCheckArguments struct {
 }
 
 var DefaultArguments = Arguments{
+	ExcludeSchemas:                []string{},
 	AllowUpdatePerfSchemaSettings: false,
 
 	QueryDetailsArguments: QueryDetailsArguments{
@@ -160,7 +161,6 @@ var DefaultArguments = Arguments{
 		CollectInterval: 1 * time.Minute,
 		PerCollectRatio: 1.0,
 		InitialLookback: 24 * time.Hour,
-		ExcludeSchemas:  []string{},
 	},
 
 	LocksArguments: LocksArguments{
@@ -569,7 +569,7 @@ func (c *Component) startCollectors(serverID string, engineVersion string, parse
 			DB:              c.dbConnection,
 			ScrapeInterval:  c.args.ExplainPlansArguments.CollectInterval,
 			PerScrapeRatio:  c.args.ExplainPlansArguments.PerCollectRatio,
-			ExcludeSchemas:  c.args.ExplainPlansArguments.ExcludeSchemas,
+			ExcludeSchemas:  c.args.ExcludeSchemas,
 			InitialLookback: time.Now().Add(-c.args.ExplainPlansArguments.InitialLookback),
 			Logger:          c.opts.Logger,
 			DBVersion:       engineVersion,

--- a/internal/component/database_observability/postgres/collector/explain_plans.go
+++ b/internal/component/database_observability/postgres/collector/explain_plans.go
@@ -210,14 +210,13 @@ func newQueryInfo(datname, queryId, queryText string, calls int64, callsReset ti
 }
 
 type ExplainPlansArguments struct {
-	DB              *sql.DB
-	DSN             string
-	ScrapeInterval  time.Duration
-	PerScrapeRatio  float64
-	ExcludeSchemas  []string
-	EntryHandler    loki.EntryHandler
-	InitialLookback time.Time
-	DBVersion       string
+	DB             *sql.DB
+	DSN            string
+	ScrapeInterval time.Duration
+	PerScrapeRatio float64
+	ExcludeSchemas []string
+	EntryHandler   loki.EntryHandler
+	DBVersion      string
 
 	Logger log.Logger
 }
@@ -247,11 +246,11 @@ func NewExplainPlan(args ExplainPlansArguments) (*ExplainPlans, error) {
 		dbDSN:               args.DSN,
 		dbConnectionFactory: defaultDbConnectionFactory,
 		scrapeInterval:      args.ScrapeInterval,
+		perScrapeRatio:      args.PerScrapeRatio,
+		excludeSchemas:      args.ExcludeSchemas,
 		queryCache:          make(map[string]*queryInfo),
 		queryDenylist:       make(map[string]*queryInfo),
 		finishedQueryCache:  make(map[string]*queryInfo),
-		excludeSchemas:      args.ExcludeSchemas,
-		perScrapeRatio:      args.PerScrapeRatio,
 		entryHandler:        args.EntryHandler,
 		logger:              log.With(args.Logger, "collector", ExplainPlanCollector),
 		running:             atomic.NewBool(false),

--- a/internal/component/database_observability/postgres/collector/explain_plans.go
+++ b/internal/component/database_observability/postgres/collector/explain_plans.go
@@ -210,13 +210,13 @@ func newQueryInfo(datname, queryId, queryText string, calls int64, callsReset ti
 }
 
 type ExplainPlansArguments struct {
-	DB             *sql.DB
-	DSN            string
-	ScrapeInterval time.Duration
-	PerScrapeRatio float64
-	ExcludeSchemas []string
-	EntryHandler   loki.EntryHandler
-	DBVersion      string
+	DB               *sql.DB
+	DSN              string
+	ScrapeInterval   time.Duration
+	PerScrapeRatio   float64
+	ExcludeDatabases []string
+	EntryHandler     loki.EntryHandler
+	DBVersion        string
 
 	Logger log.Logger
 }
@@ -230,7 +230,7 @@ type ExplainPlans struct {
 	queryCache          map[string]*queryInfo
 	queryDenylist       map[string]*queryInfo
 	finishedQueryCache  map[string]*queryInfo
-	excludeSchemas      []string
+	excludeDatabases    []string
 	perScrapeRatio      float64
 	currentBatchSize    int
 	entryHandler        loki.EntryHandler
@@ -247,7 +247,7 @@ func NewExplainPlan(args ExplainPlansArguments) (*ExplainPlans, error) {
 		dbConnectionFactory: defaultDbConnectionFactory,
 		scrapeInterval:      args.ScrapeInterval,
 		perScrapeRatio:      args.PerScrapeRatio,
-		excludeSchemas:      args.ExcludeSchemas,
+		excludeDatabases:    args.ExcludeDatabases,
 		queryCache:          make(map[string]*queryInfo),
 		queryDenylist:       make(map[string]*queryInfo),
 		finishedQueryCache:  make(map[string]*queryInfo),
@@ -379,7 +379,7 @@ func (c *ExplainPlans) populateQueryCache(ctx context.Context) error {
 			return fmt.Errorf("failed to scan query for explain plan: %w", err)
 		}
 
-		if slices.ContainsFunc(c.excludeSchemas, func(schema string) bool {
+		if slices.ContainsFunc(c.excludeDatabases, func(schema string) bool {
 			return strings.EqualFold(schema, datname)
 		}) {
 

--- a/internal/component/database_observability/postgres/collector/explain_plans_test.go
+++ b/internal/component/database_observability/postgres/collector/explain_plans_test.go
@@ -2261,15 +2261,14 @@ func TestNewExplainPlan(t *testing.T) {
 		require.NoError(t, err)
 
 		args := ExplainPlansArguments{
-			DB:              db,
-			DSN:             "postgres://user:pass@localhost:5432/testdb",
-			ScrapeInterval:  time.Minute,
-			PerScrapeRatio:  0.1,
-			ExcludeSchemas:  []string{"information_schema", "pg_catalog"},
-			EntryHandler:    entryHandler,
-			InitialLookback: time.Now().Add(-time.Hour),
-			DBVersion:       pre17ver,
-			Logger:          logger,
+			DB:             db,
+			DSN:            "postgres://user:pass@localhost:5432/testdb",
+			ScrapeInterval: time.Minute,
+			PerScrapeRatio: 0.1,
+			ExcludeSchemas: []string{"information_schema", "pg_catalog"},
+			EntryHandler:   entryHandler,
+			DBVersion:      pre17ver,
+			Logger:         logger,
 		}
 
 		explainPlan, err := NewExplainPlan(args)

--- a/internal/component/database_observability/postgres/collector/explain_plans_test.go
+++ b/internal/component/database_observability/postgres/collector/explain_plans_test.go
@@ -2261,14 +2261,14 @@ func TestNewExplainPlan(t *testing.T) {
 		require.NoError(t, err)
 
 		args := ExplainPlansArguments{
-			DB:             db,
-			DSN:            "postgres://user:pass@localhost:5432/testdb",
-			ScrapeInterval: time.Minute,
-			PerScrapeRatio: 0.1,
-			ExcludeSchemas: []string{"information_schema", "pg_catalog"},
-			EntryHandler:   entryHandler,
-			DBVersion:      pre17ver,
-			Logger:         logger,
+			DB:               db,
+			DSN:              "postgres://user:pass@localhost:5432/testdb",
+			ScrapeInterval:   time.Minute,
+			PerScrapeRatio:   0.1,
+			ExcludeDatabases: []string{"information_schema", "pg_catalog"},
+			EntryHandler:     entryHandler,
+			DBVersion:        pre17ver,
+			Logger:           logger,
 		}
 
 		explainPlan, err := NewExplainPlan(args)
@@ -2280,7 +2280,7 @@ func TestNewExplainPlan(t *testing.T) {
 		assert.Equal(t, pre17semver, explainPlan.dbVersion)
 		assert.Equal(t, args.ScrapeInterval, explainPlan.scrapeInterval)
 		assert.Equal(t, args.PerScrapeRatio, explainPlan.perScrapeRatio)
-		assert.Equal(t, args.ExcludeSchemas, explainPlan.excludeSchemas)
+		assert.Equal(t, args.ExcludeDatabases, explainPlan.excludeDatabases)
 		assert.Equal(t, entryHandler, explainPlan.entryHandler)
 		assert.NotNil(t, explainPlan.queryCache)
 		assert.NotNil(t, explainPlan.queryDenylist)
@@ -2519,7 +2519,7 @@ func TestExplainPlan_PopulateQueryCache(t *testing.T) {
 				queryCache:         make(map[string]*queryInfo),
 				queryDenylist:      make(map[string]*queryInfo),
 				finishedQueryCache: make(map[string]*queryInfo),
-				excludeSchemas:     []string{},
+				excludeDatabases:   []string{},
 				perScrapeRatio:     1.0,
 				logger:             logger,
 				entryHandler:       lokiClient,
@@ -2559,7 +2559,7 @@ func TestExplainPlan_PopulateQueryCache(t *testing.T) {
 				queryCache:         make(map[string]*queryInfo),
 				queryDenylist:      make(map[string]*queryInfo),
 				finishedQueryCache: make(map[string]*queryInfo),
-				excludeSchemas:     []string{"information_schema"},
+				excludeDatabases:   []string{"information_schema"},
 				perScrapeRatio:     0.5,
 				logger:             logger,
 				entryHandler:       lokiClient,
@@ -2747,7 +2747,7 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 		queryCache:          make(map[string]*queryInfo),
 		queryDenylist:       make(map[string]*queryInfo),
 		finishedQueryCache:  make(map[string]*queryInfo),
-		excludeSchemas:      []string{},
+		excludeDatabases:    []string{},
 		perScrapeRatio:      1.0,
 		logger:              logger,
 	}
@@ -2793,7 +2793,7 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 				},
 				queryDenylist:      map[string]*queryInfo{},
 				finishedQueryCache: map[string]*queryInfo{},
-				excludeSchemas:     []string{},
+				excludeDatabases:   []string{},
 				perScrapeRatio:     1.0,
 				logger:             log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
 				entryHandler:       lokiClient,
@@ -2848,7 +2848,7 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 				},
 				queryDenylist:      map[string]*queryInfo{},
 				finishedQueryCache: map[string]*queryInfo{},
-				excludeSchemas:     []string{},
+				excludeDatabases:   []string{},
 				perScrapeRatio:     1.0,
 				logger:             log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
 				entryHandler:       lokiClient,
@@ -2901,7 +2901,7 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 				},
 				queryDenylist:      map[string]*queryInfo{},
 				finishedQueryCache: map[string]*queryInfo{},
-				excludeSchemas:     []string{},
+				excludeDatabases:   []string{},
 				perScrapeRatio:     1.0,
 				logger:             log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
 				currentBatchSize:   1,
@@ -2968,7 +2968,7 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 				},
 				queryDenylist:      map[string]*queryInfo{},
 				finishedQueryCache: map[string]*queryInfo{},
-				excludeSchemas:     []string{},
+				excludeDatabases:   []string{},
 				perScrapeRatio:     1.0,
 				logger:             log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
 				currentBatchSize:   1,
@@ -3035,7 +3035,7 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 				},
 				queryDenylist:      map[string]*queryInfo{},
 				finishedQueryCache: map[string]*queryInfo{},
-				excludeSchemas:     []string{},
+				excludeDatabases:   []string{},
 				perScrapeRatio:     1.0,
 				logger:             log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
 				currentBatchSize:   1,

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -70,7 +70,7 @@ type Arguments struct {
 	QuerySampleArguments   QuerySampleArguments   `alloy:"query_samples,block,optional"`
 	QueryTablesArguments   QueryTablesArguments   `alloy:"query_details,block,optional"`
 	SchemaDetailsArguments SchemaDetailsArguments `alloy:"schema_details,block,optional"`
-	ExplainPlanArguments   ExplainPlanArguments   `alloy:"explain_plans,block,optional"`
+	ExplainPlansArguments  ExplainPlansArguments  `alloy:"explain_plans,block,optional"`
 	HealthCheckArguments   HealthCheckArguments   `alloy:"health_check,block,optional"`
 }
 
@@ -121,19 +121,20 @@ var DefaultArguments = Arguments{
 		CacheSize:       256,
 		CacheTTL:        10 * time.Minute,
 	},
-	ExplainPlanArguments: ExplainPlanArguments{
+	ExplainPlansArguments: ExplainPlansArguments{
 		CollectInterval: 1 * time.Minute,
 		PerCollectRatio: 1.0,
+		ExcludeSchemas:  []string{},
 	},
 	HealthCheckArguments: HealthCheckArguments{
 		CollectInterval: 1 * time.Hour,
 	},
 }
 
-type ExplainPlanArguments struct {
-	CollectInterval           time.Duration `alloy:"collect_interval,attr,optional"`
-	PerCollectRatio           float64       `alloy:"per_collect_ratio,attr,optional"`
-	ExplainPlanExcludeSchemas []string      `alloy:"explain_plan_exclude_schemas,attr,optional"`
+type ExplainPlansArguments struct {
+	CollectInterval time.Duration `alloy:"collect_interval,attr,optional"`
+	PerCollectRatio float64       `alloy:"per_collect_ratio,attr,optional"`
+	ExcludeSchemas  []string      `alloy:"exclude_schemas,attr,optional"`
 }
 
 type HealthCheckArguments struct {
@@ -464,8 +465,9 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 		epCollector, err := collector.NewExplainPlan(collector.ExplainPlansArguments{
 			DB:             c.dbConnection,
 			DSN:            string(c.args.DataSourceName),
-			ScrapeInterval: c.args.ExplainPlanArguments.CollectInterval,
-			PerScrapeRatio: c.args.ExplainPlanArguments.PerCollectRatio,
+			ScrapeInterval: c.args.ExplainPlansArguments.CollectInterval,
+			PerScrapeRatio: c.args.ExplainPlansArguments.PerCollectRatio,
+			ExcludeSchemas: c.args.ExplainPlansArguments.ExcludeSchemas,
 			Logger:         c.opts.Logger,
 			DBVersion:      engineVersion,
 			EntryHandler:   entryHandler,


### PR DESCRIPTION
### Brief description of Pull Request
Correctly expose and wire setting to exclude schemas (mysql) and databases (postgres) from data collection. At the moment, this only applies to the `explain_plans` collectors.

### Pull Request Details

<!-- Add a more detailed descripion of the Pull Request here, if needed. -->

### Issue(s) fixed by this Pull Request

<!--
  Uncomment the following line and fill in an issue number if you want a GitHub
  issue to be closed automatically when this PR gets merged.
-->

<!-- Fixes #issue_id -->

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
