### PR TITLE
docs: Add info about rule block in prometheus.operator.podmonitor docs

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.operator.podmonitors.md
+++ b/docs/sources/reference/components/prometheus/prometheus.operator.podmonitors.md
@@ -23,7 +23,7 @@ The default configuration assumes {{< param "PRODUCT_NAME" >}} is running inside
 You can run it from outside the cluster by supplying connection info in the `client` block, but network level access to Pods is required to scrape metrics from them.
 
 PodMonitors may reference secrets for authenticating to targets to scrape them.
-In these cases, the secrets are loaded and refreshed only when the PodMonitor is updated or when this component refreshes its' internal state, which happens on a 5-minute refresh cycle.
+In these cases, the secrets are loaded and refreshed only when the PodMonitor is updated or when this component refreshes its internal state, which happens on a 5-minute refresh cycle.
 
 ## Usage
 
@@ -37,11 +37,11 @@ prometheus.operator.podmonitors "<LABEL>" {
 
 You can use the following arguments with `prometheus.operator.podmonitors`:
 
-| Name                    | Type                    | Description                                                                                               | Default | Required |
-| ----------------------- | ----------------------- | --------------------------------------------------------------------------------------------------------- | ------- | -------- |
-| `forward_to`            | `list(MetricsReceiver)` | List of receivers to send scraped metrics to.                                                             |         | yes      |
-| `namespaces`            | `list(string)`          | List of namespaces to search for PodMonitor resources. If not specified, all namespaces will be searched. |         | no       |
-| `informer_sync_timeout` | `duration`              | Timeout for initial sync of PodMonitor resources.                                                         | `"1m"`  | no       |
+| Name                    | Type                    | Description                                                                                           | Default | Required |
+| ----------------------- | ----------------------- | ----------------------------------------------------------------------------------------------------- | ------- | -------- |
+| `forward_to`            | `list(MetricsReceiver)` | List of receivers to send scraped metrics to.                                                         |         | yes      |
+| `namespaces`            | `list(string)`          | List of namespaces to search for PodMonitor resources. If not specified, all namespaces are searched. |         | no       |
+| `informer_sync_timeout` | `duration`              | Timeout for initial sync of PodMonitor resources.                                                     | `"1m"`  | no       |
 
 ## Blocks
 
@@ -186,12 +186,12 @@ The `operator` argument must be one of the following strings:
 * `"Exists"`
 * `"DoesNotExist"`
 
-If there are multiple `match_expressions` blocks inside of a `selector` block, they are combined together with AND clauses.
+If there are multiple `match_expressions` blocks inside of a `selector` block, they're combined together with AND clauses.
 
 ## Exported fields
 
 `prometheus.operator.podmonitors` doesn't export any fields.
-It forwards all metrics it scrapes to the receiver configures with the `forward_to` argument.
+It forwards all metrics it scrapes to the receiver configured with the `forward_to` argument.
 
 ## Component health
 
@@ -229,7 +229,7 @@ prometheus.operator.podmonitors "pods" {
 }
 ```
 
-This example will limit discovered PodMonitors to ones with the label `team=ops` in a specific namespace: `my-app`.
+The following example limits discovered PodMonitors to ones with the label `team=ops` in a specific namespace: `my-app`.
 
 ```alloy
 prometheus.operator.podmonitors "pods" {


### PR DESCRIPTION
Update the prometheus.operator.podmonitor docs to add additional clarifying info about rule blocks.

Minor tidy for style and active voice.

Fixes https://github.com/grafana/alloy/issues/4199

