### PR TITLE
chore: Only Write to dev0 Wave Key When Deploying Canary Image

### DIFF
--- a/.github/workflows/publish-alloy-devel.yml
+++ b/.github/workflows/publish-alloy-devel.yml
@@ -96,11 +96,6 @@ jobs:
           "update_jsonnet_attribute_configs": [
             {
               "file_path": "ksonnet/lib/alloy/waves/alloy.libsonnet",
-              "jsonnet_key": "dev_canary",
-              "jsonnet_value_file": ".image-tag"
-            },
-            {
-              "file_path": "ksonnet/lib/alloy/waves/alloy.libsonnet",
               "jsonnet_key": "dev0",
               "jsonnet_value_file": ".image-tag"
             }


### PR DESCRIPTION
This is the last step in deprecating/removing wavesv1 keys :broom:

part of [#337](https://github.com/grafana/alloy-internal/issues/337)