### PR TITLE
fix: Set content-encoding header in loki.write

### DIFF
--- a/internal/component/common/loki/client/shards.go
+++ b/internal/component/common/loki/client/shards.go
@@ -464,6 +464,11 @@ func (s *shards) sendBatch(tenantID string, batch *batch) {
 
 var userAgent = useragent.Get()
 
+const (
+	contentType     = "application/x-protobuf"
+	contentEncoding = "snappy"
+)
+
 // send performs the HTTP POST request to send a batch to Loki.
 func (s *shards) send(ctx context.Context, tenantID string, buf []byte) (int, error) {
 	ctx, cancel := context.WithTimeout(ctx, s.cfg.Timeout)
@@ -473,9 +478,9 @@ func (s *shards) send(ctx context.Context, tenantID string, buf []byte) (int, er
 		return -1, err
 	}
 
-	const contentType = "application/x-protobuf"
-	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("Content-Encoding", contentEncoding)
 
 	// If the tenant ID is not empty alloy is running in multi-tenant mode, so
 	// we should send it to Loki


### PR DESCRIPTION
### Pull Request Details
`loki.write` always send snappy encoded payloads so we should set `Content-Encoding` header.

### Issue(s) fixed by this Pull Request

Fixes #5339

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
