### PR TITLE
fix: Guard pyroscope otel profiler code with unix go build tag

### DIFF
--- a/internal/component/pyroscope/ebpf/discovery/policy.go
+++ b/internal/component/pyroscope/ebpf/discovery/policy.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package discovery
 
 import "go.opentelemetry.io/ebpf-profiler/process"

--- a/internal/component/pyroscope/ebpf/reporter/parca/reporter/elfwriter/elfwriter.go
+++ b/internal/component/pyroscope/ebpf/reporter/parca/reporter/elfwriter/elfwriter.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 // Copyright (C) 2025 go-delve, parca-agent
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/internal/component/pyroscope/ebpf/reporter/parca/reporter/elfwriter/extract.go
+++ b/internal/component/pyroscope/ebpf/reporter/parca/reporter/elfwriter/extract.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package elfwriter
 
 import (

--- a/internal/component/pyroscope/ebpf/reporter/parca/reporter/elfwriter/helpers.go
+++ b/internal/component/pyroscope/ebpf/reporter/parca/reporter/elfwriter/helpers.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 // Copyright 2022-2024 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/component/pyroscope/ebpf/reporter/parca/reporter/elfwriter/nullifying_elfwriter.go
+++ b/internal/component/pyroscope/ebpf/reporter/parca/reporter/elfwriter/nullifying_elfwriter.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 // Copyright 2022-2024 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/component/pyroscope/ebpf/reporter/parca/reporter/elfwriter/options.go
+++ b/internal/component/pyroscope/ebpf/reporter/parca/reporter/elfwriter/options.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 // Copyright 2022-2024 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,10 +17,3 @@
 package elfwriter
 
 type Option func(w *Writer)
-
-// WithCompressDWARFSections compresses DWARF sections.
-func WithCompressDWARFSections() Option {
-	return func(w *Writer) {
-		w.compressDWARFSections = true
-	}
-}

--- a/internal/component/pyroscope/ebpf/symb/irsymcache/cache.go
+++ b/internal/component/pyroscope/ebpf/symb/irsymcache/cache.go
@@ -1,4 +1,6 @@
-package irsymcache // import "go.opentelemetry.io/ebpf-profiler/pyroscope/symb/irsymcache"
+//go:build unix
+
+package irsymcache
 
 import (
 	"debug/elf"

--- a/internal/component/pyroscope/ebpf/symb/irsymcache/cache_test.go
+++ b/internal/component/pyroscope/ebpf/symb/irsymcache/cache_test.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package irsymcache
 
 import (

--- a/internal/component/pyroscope/ebpf/symb/irsymcache/dummy_process_test.go
+++ b/internal/component/pyroscope/ebpf/symb/irsymcache/dummy_process_test.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package irsymcache
 
 import (

--- a/internal/component/pyroscope/ebpf/symb/irsymcache/native_frame_symbols.go
+++ b/internal/component/pyroscope/ebpf/symb/irsymcache/native_frame_symbols.go
@@ -1,4 +1,6 @@
-package irsymcache // import "go.opentelemetry.io/ebpf-profiler/pyroscope/symb/irsymcache"
+//go:build unix
+
+package irsymcache
 
 import (
 	"go.opentelemetry.io/ebpf-profiler/libpf"

--- a/internal/component/pyroscope/ebpf/symb/irsymcache/native_frame_symbols_test.go
+++ b/internal/component/pyroscope/ebpf/symb/irsymcache/native_frame_symbols_test.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package irsymcache
 
 import (

--- a/internal/component/pyroscope/ebpf/symb/irsymcache/table.go
+++ b/internal/component/pyroscope/ebpf/symb/irsymcache/table.go
@@ -1,4 +1,6 @@
-package irsymcache // import "go.opentelemetry.io/ebpf-profiler/pyroscope/symb/irsymcache"
+//go:build unix
+
+package irsymcache
 
 import (
 	"debug/elf"


### PR DESCRIPTION
This should fix pyroscope related failures on windows 

https://github.com/grafana/alloy/actions/runs/21353403225/job/61564920807
