### PR TITLE
fix: Remove Parca debug info upload from user configuration

### DIFF
--- a/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
@@ -87,32 +87,7 @@ Several arguments are marked as "Deprecated (no-op)". These arguments were previ
 
 ## Blocks
 
-You can use the following blocks with `pyroscope.ebpf`:
-
-| Hierarchy    | Block        | Description                                             | Required |
-|--------------|--------------|---------------------------------------------------------|----------|
-| `debug_info` | [debug_info] | Configures debug information handling and remote upload. | no       |
-
-[debug_info]: #debug_info
-
-### debug_info
-
-The `debug_info` block configures how the component handles debug information for symbolization. You can use it to enable on-target symbolization, which resolves symbols locally, or to upload debug information to a remote endpoint for server-side symbolization.
-
-You can use the following arguments with the `debug_info` block:
-
-| Name                      | Type   | Description                                                            | Default | Required |
-|---------------------------|--------|------------------------------------------------------------------------|---------|----------|
-| `on_target_symbolization` | `bool` | Enables on-target symbolization using local debug information.         | `true`  | no       |
-| `upload`                  | `bool` | Enables uploading debug information to the remote endpoint.            | `false` | no       |
-| `cache_size`              | `int`  | Size of the LRU cache for tracking uploaded debug information.         | `65536` | no       |
-| `strip_text_section`      | `bool` | Strips the `.text` section from debug information before upload.       | `false` | no       |
-| `queue_size`              | `int`  | Size of the upload queue.                                              | `1024`  | no       |
-| `worker_num`              | `int`  | Number of worker goroutines for uploading debug information.           | `8`     | no       |
-
-When `on_target_symbolization` is enabled, the component resolves symbols locally using debug files found on the host. This is the default behavior and works well when debug symbols are available on the profiled system.
-
-When `upload` is enabled, the component uploads debug information to the configured `pyroscope.write` endpoint, allowing the server to perform symbolization instead. This reduces CPU and memory usage on the profiled host, which is useful in resource-constrained environments.
+`pyroscope.ebpf` doesn't support any blocks.
 
 ## Exported fields
 

--- a/internal/component/pyroscope/ebpf/args.go
+++ b/internal/component/pyroscope/ebpf/args.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/grafana/alloy/internal/component/discovery"
 	"github.com/grafana/alloy/internal/component/pyroscope"
-	"github.com/grafana/alloy/internal/component/pyroscope/write/debuginfo"
 )
 
 type Arguments struct {
@@ -28,8 +27,6 @@ type Arguments struct {
 	VerboseMode         bool                   `alloy:"verbose_mode,attr,optional"`
 	LazyMode            bool                   `alloy:"lazy_mode,attr,optional"`
 	DeprecatedArguments DeprecatedArguments    `alloy:",squash"`
-
-	DebugInfoOptions debuginfo.Arguments `alloy:"debug_info,block,optional"`
 
 	// undocumented
 	PyroscopeDynamicProfilingPolicy bool   `alloy:"targets_only,attr,optional"`

--- a/internal/component/pyroscope/receive_http/debuginfo.go
+++ b/internal/component/pyroscope/receive_http/debuginfo.go
@@ -15,6 +15,7 @@ import (
 
 var errNoDebugInfoClient = status.Error(codes.Unavailable, "no debug info client available")
 
+//nolint:unused
 func (c *Component) mountDebugInfo(router *mux.Router) {
 	c.grpcServer = NewGrpcServer(c.server.Config())
 	debuginfogrpc.RegisterDebuginfoServiceServer(c.grpcServer, c)

--- a/internal/component/pyroscope/receive_http/receive_http.go
+++ b/internal/component/pyroscope/receive_http/receive_http.go
@@ -147,8 +147,6 @@ func (c *Component) update(args component.Arguments) (bool, error) {
 		// mount connect go pushv1
 		pathPush, handlePush := pushv1connect.NewPusherServiceHandler(c)
 		router.PathPrefix(pathPush).Handler(handlePush).Methods(http.MethodPost)
-
-		c.mountDebugInfo(router)
 	})
 }
 

--- a/internal/component/pyroscope/util/internal/cmd/playground/main.go
+++ b/internal/component/pyroscope/util/internal/cmd/playground/main.go
@@ -56,7 +56,7 @@ func newEbpf(forward pyroscope.Appendable, uprobeLinks []string) *ebpf.Component
 	args.ReporterUnsymbolizedStubs = true
 	args.Demangle = "full"
 	args.UProbeLinks = uprobeLinks
-	args.DebugInfoOptions.UploadEnabled = true
+	// args.DebugInfoOptions.UploadEnabled = true
 	e, err := ebpf.New(
 		log.With(l, "component", "ebpf"),
 		reg,


### PR DESCRIPTION
## Summary

We're removing this because we decided to replace grpc with connect https://github.com/grafana/pyroscope/pull/4648#discussion_r2736258264

- Remove `debug_info` block from `pyroscope.ebpf` component arguments
- Remove debug info endpoint handling from `pyroscope.receive_http`
- On-target symbolization is now always enabled internally
- Update documentation to reflect removed configuration options

## Test plan

- [x] Build succeeds
- [x] Existing pyroscope tests pass
- [ ] Manual testing with pyroscope.ebpf component

🤖 Generated with [Claude Code](https://claude.com/claude-code)