### PR TITLE
feat(loki.source.file): Track duplicate targets with a metric and logs

### DIFF
--- a/docs/sources/reference/components/loki/loki.source.file.md
+++ b/docs/sources/reference/components/loki/loki.source.file.md
@@ -160,6 +160,7 @@ The component periodically scans the filesystem based on `sync_period` and autom
 
 ## Debug metrics
 
+* `loki_source_file_duplicate_files` (gauge): Number of files being tailed multiple times due to targets with different label sets. Non-zero values indicate duplicate log line ingestion. Check component logs for details on which files and labels are affected.
 * `loki_source_file_encoding_failures_total` (counter): Number of encoding failures.
 * `loki_source_file_file_bytes_total` (gauge): Number of bytes total.
 * `loki_source_file_files_active_total` (gauge): Number of active files.

--- a/internal/component/loki/source/file/duplicates.go
+++ b/internal/component/loki/source/file/duplicates.go
@@ -1,0 +1,149 @@
+package file
+
+import (
+	"iter"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+
+	"github.com/grafana/alloy/internal/component/loki/source/file/internal/tail/fileext"
+	"github.com/grafana/alloy/internal/runtime/logging/level"
+)
+
+// duplicateDetector detects when the same file is being tailed multiple times
+// with different label sets, which causes duplicate log lines.
+type duplicateDetector struct {
+	logger log.Logger
+	metric prometheus.Gauge
+}
+
+// newDuplicateDetector creates a new duplicate detector.
+func newDuplicateDetector(logger log.Logger, metric prometheus.Gauge) *duplicateDetector {
+	return &duplicateDetector{
+		logger: logger,
+		metric: metric,
+	}
+}
+
+// targetInfo holds information about a target for duplicate detection.
+type targetInfo struct {
+	path   string
+	labels model.LabelSet
+}
+
+// Detect iterates through all targets, collects them, and checks for files
+// that have multiple targets with different label sets. It returns an iterator
+// over the collected targets for further processing.
+func (d *duplicateDetector) Detect(it iter.Seq[resolvedTarget]) iter.Seq[resolvedTarget] {
+	var targets []resolvedTarget
+	fileIDToTargets := make(map[string][]targetInfo)
+
+	for target := range it {
+		targets = append(targets, target)
+
+		// Stat for duplicate detection.
+		fi, err := os.Stat(target.Path)
+		if err != nil {
+			continue
+		}
+
+		fileKey := getFileKey(target.Path, fi)
+		fileIDToTargets[fileKey] = append(fileIDToTargets[fileKey], targetInfo{
+			path:   target.Path,
+			labels: target.Labels,
+		})
+	}
+
+	d.detectDuplicates(fileIDToTargets)
+
+	return func(yield func(resolvedTarget) bool) {
+		for _, t := range targets {
+			if !yield(t) {
+				return
+			}
+		}
+	}
+}
+
+// detectDuplicates processes the grouped targets and reports duplicates.
+func (d *duplicateDetector) detectDuplicates(fileIDToTargets map[string][]targetInfo) {
+	duplicateCount := 0
+
+	for fileKey, targets := range fileIDToTargets {
+		if len(targets) <= 1 {
+			continue
+		}
+
+		// Collect all label sets to find which labels differ.
+		allLabelSets := make([]model.LabelSet, 0, len(targets))
+		var paths []string
+		for _, t := range targets {
+			allLabelSets = append(allLabelSets, t.labels)
+			paths = append(paths, t.path)
+		}
+
+		// Find labels that have different values across targets.
+		differingLabels := findDifferingLabels(allLabelSets)
+		if len(differingLabels) == 0 {
+			continue // All label sets are identical, not a real duplicate issue
+		}
+
+		duplicateCount++
+
+		level.Warn(d.logger).Log(
+			"msg", "file has multiple targets with different labels which will cause duplicate log lines",
+			"file_id", fileKey,
+			"paths", strings.Join(paths, ", "),
+			"target_count", len(targets),
+			"differing_labels", strings.Join(differingLabels, ", "),
+		)
+	}
+
+	d.metric.Set(float64(duplicateCount))
+}
+
+// getFileKey returns a unique key for a file, using inode+device when available
+// (on POSIX systems), or falling back to the file path on Windows.
+func getFileKey(path string, fi os.FileInfo) string {
+	if fileID, ok := fileext.NewFileID(fi); ok {
+		return fileID.String()
+	}
+	// Fall back to path on systems where file identity isn't available.
+	return path
+}
+
+// findDifferingLabels returns the names of labels that have different values
+// across the provided label sets.
+func findDifferingLabels(labelSets []model.LabelSet) []string {
+	if len(labelSets) < 2 {
+		return nil
+	}
+
+	// Collect all label names across all sets.
+	allNames := make(map[model.LabelName]struct{})
+	for _, ls := range labelSets {
+		for name := range ls {
+			allNames[name] = struct{}{}
+		}
+	}
+
+	// Check which labels have differing values.
+	var differing []string
+	for name := range allNames {
+		firstValue, firstHas := labelSets[0][name]
+		for _, ls := range labelSets[1:] {
+			value, has := ls[name]
+			if has != firstHas || value != firstValue {
+				differing = append(differing, string(name))
+				break
+			}
+		}
+	}
+
+	slices.Sort(differing)
+	return differing
+}

--- a/internal/component/loki/source/file/duplicates_test.go
+++ b/internal/component/loki/source/file/duplicates_test.go
@@ -1,0 +1,80 @@
+package file
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/grafana/alloy/internal/component"
+	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/syntax"
+)
+
+func TestDuplicateDetectionWithMultipleDifferingLabels(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
+
+	var logBuf bytes.Buffer
+	testLogger := log.NewLogfmtLogger(&logBuf)
+
+	registry := prometheus.NewRegistry()
+
+	opts := component.Options{
+		Logger:        testLogger,
+		Registerer:    registry,
+		OnStateChange: func(e component.Exports) {},
+		DataPath:      t.TempDir(),
+	}
+
+	f, err := os.CreateTemp(opts.DataPath, "multi_label_test")
+	require.NoError(t, err)
+	defer f.Close()
+
+	ch := loki.NewLogsReceiver()
+
+	// Create two targets with multiple differing labels using Alloy syntax.
+	config := fmt.Sprintf(`
+		forward_to = []
+		targets = [
+			{__path__ = %q, app = "myapp", port = "8080", container = "main"},
+			{__path__ = %q, app = "myapp", port = "9090", container = "sidecar"},
+		]
+	`, f.Name(), f.Name())
+
+	var args Arguments
+	err = syntax.Unmarshal([]byte(config), &args)
+	require.NoError(t, err)
+
+	// Set the actual receiver after parsing.
+	args.ForwardTo = []loki.LogsReceiver{ch}
+
+	c, err := New(opts, args)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go c.Run(ctx)
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify that a warning was logged.
+	logOutput := logBuf.String()
+	require.Contains(t, logOutput, "file has multiple targets with different labels which will cause duplicate log lines")
+
+	// Both differing labels should be mentioned.
+	require.True(t, strings.Contains(logOutput, `differing_labels="container, port"`),
+		"expected both differing labels to be mentioned in log, got: %s", logOutput)
+
+	// Verify that the metric is set.
+	metricValue := testutil.ToFloat64(c.metrics.duplicateFilesTally)
+	require.Equal(t, float64(1), metricValue)
+}

--- a/internal/component/loki/source/file/duplicates_test.go
+++ b/internal/component/loki/source/file/duplicates_test.go
@@ -1,7 +1,6 @@
 package file
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -17,13 +16,14 @@ import (
 
 	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/util/syncbuffer"
 	"github.com/grafana/alloy/syntax"
 )
 
 func TestDuplicateDetectionWithMultipleDifferingLabels(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
 
-	var logBuf bytes.Buffer
+	var logBuf syncbuffer.Buffer
 	testLogger := log.NewLogfmtLogger(&logBuf)
 
 	registry := prometheus.NewRegistry()

--- a/internal/component/loki/source/file/duplicates_test.go
+++ b/internal/component/loki/source/file/duplicates_test.go
@@ -8,73 +8,173 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/log"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
-	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/component/discovery"
+	"github.com/grafana/alloy/internal/runtime/componenttest"
+	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/grafana/alloy/internal/util/syncbuffer"
-	"github.com/grafana/alloy/syntax"
 )
 
-func TestDuplicateDetectionWithMultipleDifferingLabels(t *testing.T) {
+func TestDuplicateDetection(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
 
-	var logBuf syncbuffer.Buffer
-	testLogger := log.NewLogfmtLogger(&logBuf)
-
-	registry := prometheus.NewRegistry()
-
-	opts := component.Options{
-		Logger:        testLogger,
-		Registerer:    registry,
-		OnStateChange: func(e component.Exports) {},
-		DataPath:      t.TempDir(),
+	tests := []struct {
+		name string
+		// targetsFn receives two file paths and returns the targets.
+		targetsFn          func(file1, file2 string) []discovery.Target
+		useSameFile        bool
+		expectDuplicate    bool
+		expectedDiffLabels string
+	}{
+		{
+			name: "unique_files_no_duplicates",
+			targetsFn: func(file1, file2 string) []discovery.Target {
+				return []discovery.Target{
+					discovery.NewTargetFromMap(map[string]string{
+						"__path__": file1,
+						"app":      "myapp",
+						"env":      "prod",
+					}),
+					discovery.NewTargetFromMap(map[string]string{
+						"__path__": file2,
+						"app":      "myapp",
+						"env":      "staging",
+					}),
+				}
+			},
+			useSameFile:     false,
+			expectDuplicate: false,
+		},
+		{
+			name: "unique_files_with_differing_internal_labels_no_duplicates",
+			targetsFn: func(file1, file2 string) []discovery.Target {
+				// Internal labels (__meta_*, __internal) have different values but
+				// should be filtered out by NonReservedLabelSet(), so these targets
+				// point to different files and should not be duplicates.
+				return []discovery.Target{
+					discovery.NewTargetFromMap(map[string]string{
+						"__path__":      file1,
+						"__meta_source": "source1",
+						"__internal":    "a",
+						"app":           "myapp",
+					}),
+					discovery.NewTargetFromMap(map[string]string{
+						"__path__":      file2,
+						"__meta_source": "source2",
+						"__internal":    "b",
+						"app":           "myapp",
+					}),
+				}
+			},
+			useSameFile:     false,
+			expectDuplicate: false,
+		},
+		{
+			name: "same_file_differing_labels_duplicates",
+			targetsFn: func(file1, _ string) []discovery.Target {
+				// Both targets point to the same file but have different labels.
+				// Also includes differing internal labels to verify they don't
+				// appear in the differing_labels output.
+				return []discovery.Target{
+					discovery.NewTargetFromMap(map[string]string{
+						"__path__":      file1,
+						"__meta_source": "source1",
+						"__internal":    "a",
+						"app":           "myapp",
+						"port":          "8080",
+						"container":     "main",
+					}),
+					discovery.NewTargetFromMap(map[string]string{
+						"__path__":      file1,
+						"__meta_source": "source2",
+						"__internal":    "b",
+						"app":           "myapp",
+						"port":          "9090",
+						"container":     "sidecar",
+					}),
+				}
+			},
+			useSameFile:        true,
+			expectDuplicate:    true,
+			expectedDiffLabels: "container, port", // Only the non-internal labels should be included.
+		},
 	}
 
-	f, err := os.CreateTemp(opts.DataPath, "multi_label_test")
-	require.NoError(t, err)
-	defer f.Close()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(componenttest.TestContext(t))
+			defer cancel()
 
-	ch := loki.NewLogsReceiver()
+			// Create file(s) for the test.
+			f1, err := os.CreateTemp(t.TempDir(), "test_file1")
+			require.NoError(t, err)
+			defer f1.Close()
 
-	// Create two targets with multiple differing labels using Alloy syntax.
-	config := fmt.Sprintf(`
-		forward_to = []
-		targets = [
-			{__path__ = %q, app = "myapp", port = "8080", container = "main"},
-			{__path__ = %q, app = "myapp", port = "9090", container = "sidecar"},
-		]
-	`, f.Name(), f.Name())
+			file2Path := f1.Name()
+			if !tc.useSameFile {
+				f2, err := os.CreateTemp(t.TempDir(), "test_file2")
+				require.NoError(t, err)
+				defer f2.Close()
+				file2Path = f2.Name()
+			}
 
-	var args Arguments
-	err = syntax.Unmarshal([]byte(config), &args)
-	require.NoError(t, err)
+			var logBuf syncbuffer.Buffer
+			testLogger, err := logging.New(&logBuf, logging.DefaultOptions)
+			require.NoError(t, err)
 
-	// Set the actual receiver after parsing.
-	args.ForwardTo = []loki.LogsReceiver{ch}
+			ctrl, err := componenttest.NewControllerFromID(testLogger, "loki.source.file")
+			require.NoError(t, err)
 
-	c, err := New(opts, args)
-	require.NoError(t, err)
+			ch := loki.NewLogsReceiver()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+			var args Arguments
+			args.SetToDefault()
+			args.Targets = tc.targetsFn(f1.Name(), file2Path)
+			args.ForwardTo = []loki.LogsReceiver{ch}
 
-	go c.Run(ctx)
-	time.Sleep(100 * time.Millisecond)
+			go func() {
+				err := ctrl.Run(ctx, args)
+				require.NoError(t, err)
+			}()
 
-	// Verify that a warning was logged.
-	logOutput := logBuf.String()
-	require.Contains(t, logOutput, "file has multiple targets with different labels which will cause duplicate log lines")
+			ctrl.WaitRunning(time.Minute)
 
-	// Both differing labels should be mentioned.
-	require.True(t, strings.Contains(logOutput, `differing_labels="container, port"`),
-		"expected both differing labels to be mentioned in log, got: %s", logOutput)
+			if tc.expectDuplicate {
+				// Wait for duplicate warning to appear in logs.
+				require.Eventually(t, func() bool {
+					return strings.Contains(logBuf.String(), "file has multiple targets with different labels which will cause duplicate log lines")
+				}, 5*time.Second, 10*time.Millisecond, "expected duplicate warning in log")
 
-	// Verify that the metric is set.
-	metricValue := testutil.ToFloat64(c.metrics.duplicateFilesTally)
-	require.Equal(t, float64(1), metricValue)
+				logOutput := logBuf.String()
+
+				// The log output may have escaped quotes depending on the logger format.
+				require.True(t,
+					strings.Contains(logOutput, fmt.Sprintf(`differing_labels="%s"`, tc.expectedDiffLabels)) ||
+						strings.Contains(logOutput, fmt.Sprintf(`differing_labels=\"%s\"`, tc.expectedDiffLabels)),
+					"expected differing labels %q in log, got: %s", tc.expectedDiffLabels, logOutput)
+
+				// Internal labels should NOT appear in differing labels.
+				require.NotContains(t, logOutput, "__meta_source",
+					"internal labels should not appear in differing labels")
+				require.NotContains(t, logOutput, "__internal",
+					"internal labels should not appear in differing labels")
+			} else {
+				// Wait for tailing to start (indicates targets have been processed).
+				require.Eventually(t, func() bool {
+					return strings.Contains(logBuf.String(), "start tailing file")
+				}, 5*time.Second, 10*time.Millisecond, "expected tailing to start")
+
+				// Wait a bit to ensure duplicate detection has run after tailing started.
+				time.Sleep(500 * time.Millisecond)
+
+				// Verify no duplicate warning was logged.
+				require.NotContains(t, logBuf.String(),
+					"file has multiple targets with different labels",
+					"unexpected duplicate warning in log")
+			}
+		})
+	}
 }

--- a/internal/component/loki/source/file/internal/tail/fileext/file_posix.go
+++ b/internal/component/loki/source/file/internal/tail/fileext/file_posix.go
@@ -3,8 +3,10 @@
 package fileext
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 )
 
 func OpenFile(name string) (file *os.File, err error) {
@@ -25,4 +27,32 @@ func OpenFile(name string) (file *os.File, err error) {
 
 func IsDeletePending(_ *os.File) (bool, error) {
 	return false, nil
+}
+
+// FileID uniquely identifies a file on the filesystem using device and inode.
+// Two different paths pointing to the same file (via symlinks or hard links)
+// will have the same FileID.
+type FileID struct {
+	dev uint64
+	ino uint64
+}
+
+// String returns a string representation of the FileID for use in metrics and logs.
+func (f FileID) String() string {
+	return fmt.Sprintf("%d:%d", f.dev, f.ino)
+}
+
+// NewFileID extracts a unique file identifier from os.FileInfo.
+// On POSIX systems, this uses the device and inode numbers.
+// Returns the FileID and true if successful, or an empty FileID and false
+// if the file identity could not be determined.
+func NewFileID(fi os.FileInfo) (FileID, bool) {
+	stat, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return FileID{}, false
+	}
+	return FileID{
+		dev: uint64(stat.Dev),
+		ino: stat.Ino,
+	}, true
 }

--- a/internal/component/loki/source/file/metrics.go
+++ b/internal/component/loki/source/file/metrics.go
@@ -15,10 +15,11 @@ type metrics struct {
 	reg prometheus.Registerer
 
 	// File-specific metrics
-	readBytes   *prometheus.GaugeVec
-	totalBytes  *prometheus.GaugeVec
-	readLines   *prometheus.CounterVec
-	filesActive prometheus.Gauge
+	readBytes           *prometheus.GaugeVec
+	totalBytes          *prometheus.GaugeVec
+	readLines           *prometheus.CounterVec
+	filesActive         prometheus.Gauge
+	duplicateFilesTally prometheus.Gauge
 }
 
 // newMetrics creates a new set of file metrics. If reg is non-nil, the metrics
@@ -43,12 +44,17 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 		Name: "loki_source_file_files_active_total",
 		Help: "Number of active files.",
 	})
+	m.duplicateFilesTally = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "loki_source_file_duplicate_files",
+		Help: "Number of files being tailed multiple times due to targets with different label sets. Non-zero values indicate duplicate log line ingestion. Check logs for details.",
+	})
 
 	if reg != nil {
 		m.readBytes = util.MustRegisterOrGet(reg, m.readBytes).(*prometheus.GaugeVec)
 		m.totalBytes = util.MustRegisterOrGet(reg, m.totalBytes).(*prometheus.GaugeVec)
 		m.readLines = util.MustRegisterOrGet(reg, m.readLines).(*prometheus.CounterVec)
 		m.filesActive = util.MustRegisterOrGet(reg, m.filesActive).(prometheus.Gauge)
+		m.duplicateFilesTally = util.MustRegisterOrGet(reg, m.duplicateFilesTally).(prometheus.Gauge)
 	}
 
 	return &m


### PR DESCRIPTION
### Pull Request Details

It's possible to send `loki.source.file` the same file target multiple times. This PR adds logs and a metric to help us identify whether this has happened. It is currently very hard to debug this - you'd have to open the Alloy UI and check the `targets` passed to `loki.source.file` to see if any file paths have been listed multiple times with differing non-internal labels (labels which don't start with `__`).

A common way to encounter this problem is if you pair `loki.source.file` with `discovery.kubernetes` and then make a label with a pod port number prior to `loki.source.file`. If the pod has multiple ports, you'd end up tailing the file twice.

### Issue(s) fixed by this Pull Request

Related to [this comment](https://github.com/grafana/alloy/issues/5319#issuecomment-3817873407).

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
