### PR TITLE
fix(database_observability.mysql): Make query sample text nullable in MySQL query details collector

### DIFF
--- a/internal/component/database_observability/mysql/collector/query_details.go
+++ b/internal/component/database_observability/mysql/collector/query_details.go
@@ -131,7 +131,8 @@ func (c *QueryDetails) tablesFromEventsStatements(ctx context.Context) error {
 	defer rs.Close()
 
 	for rs.Next() {
-		var digest, digestText, schema, sampleText string
+		var digest, digestText, schema string
+		var sampleText sql.NullString
 		if err := rs.Scan(&digest, &digestText, &schema, &sampleText); err != nil {
 			level.Error(c.logger).Log("msg", "failed to scan result set from summary table samples", "schema", schema, "err", err)
 			continue
@@ -139,8 +140,8 @@ func (c *QueryDetails) tablesFromEventsStatements(ctx context.Context) error {
 
 		var tables []string
 		var parserErr, lexerErr error
-		if tables, parserErr = c.tryParseTableNames(sampleText, digestText); parserErr != nil {
-			if tables, lexerErr = c.tryTokenizeTableNames(sampleText, digestText); lexerErr != nil {
+		if tables, parserErr = c.tryParseTableNames(sampleText.String, digestText); parserErr != nil {
+			if tables, lexerErr = c.tryTokenizeTableNames(sampleText.String, digestText); lexerErr != nil {
 				level.Warn(c.logger).Log("msg", "failed to extract tables from sql text", "schema", schema, "digest", digest, "parser_err", parserErr, "lexer_err", lexerErr)
 				continue
 			}

--- a/internal/component/database_observability/mysql/collector/query_details_test.go
+++ b/internal/component/database_observability/mysql/collector/query_details_test.go
@@ -356,6 +356,23 @@ func TestQueryTables(t *testing.T) {
 				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
 			},
 		},
+		{
+			name: "null query_sample_text uses digest_text",
+			eventStatementsRows: [][]driver.Value{{
+				"abc123",
+				"SELECT * FROM `some_table` WHERE `id` = ?",
+				"some_schema",
+				nil, // NULL query_sample_text
+			}},
+			logsLabels: []model.LabelSet{
+				{"op": OP_QUERY_ASSOCIATION},
+				{"op": OP_QUERY_PARSED_TABLE_NAME},
+			},
+			logsLines: []string{
+				"level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SELECT * FROM `some_table` WHERE `id` = ?\"",
+				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
+			},
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
This PR handles NULL `query_sample_text` in the MySQL query details collector.

This PR addresses a `sql: Scan error on column index 3, name "query_sample_text": converting NULL to string is unsupported` when scanning results from the `summary table samples`.

The `query_sample_text` column in `internal/component/database_observability/mysql/collector/query_details.go` has been updated from a `string` to `sql.NullString` to correctly handle NULL values from the database.

### PR Checklist

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated

<a href="https://cursor.com/background-agent?bcId=bc-a95f4c5e-11ef-530f-a7b3-448bd2ef0888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a95f4c5e-11ef-530f-a7b3-448bd2ef0888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

