### PR TITLE
feat(otelcol.exporter.prometheus): Add `honor_metadata` config argument

### DIFF
--- a/docs/sources/reference/components/otelcol/otelcol.exporter.prometheus.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.prometheus.md
@@ -36,19 +36,33 @@ otelcol.exporter.prometheus "<LABEL>" {
 
 You can use the following arguments with `otelcol.exporter.prometheus`:
 
-| Name                               | Type                    | Description                                                       | Default | Required |
-| ---------------------------------- | ----------------------- | ----------------------------------------------------------------- | ------- | -------- |
-| `forward_to`                       | `list(MetricsReceiver)` | Where to forward converted Prometheus metrics.                    |         | yes      |
-| `add_metric_suffixes`              | `bool`                  | Whether to add type and unit suffixes to metric names.            | `true`  | no       |
-| `gc_frequency`                     | `duration`              | How often to clean up stale metrics from memory.                  | `"5m"`  | no       |
-| `include_scope_info`               | `bool`                  | Whether to include `otel_scope_info` metrics.                     | `false` | no       |
-| `include_scope_labels`             | `bool`                  | Whether to include additional OTLP labels in all metrics.         | `true`  | no       |
-| `include_target_info`              | `bool`                  | Whether to include `target_info` metrics.                         | `true`  | no       |
-| `resource_to_telemetry_conversion` | `bool`                  | Whether to convert OTel resource attributes to Prometheus labels. | `false` | no       |
+| Name                               | Type                    | Description                                                                    | Default | Required |
+| ---------------------------------- | ----------------------- | ------------------------------------------------------------------------------ | ------- | -------- |
+| `forward_to`                       | `list(MetricsReceiver)` | Where to forward converted Prometheus metrics.                                 |         | yes      |
+| `add_metric_suffixes`              | `bool`                  | Whether to add type and unit suffixes to metric names.                         | `true`  | no       |
+| `gc_frequency`                     | `duration`              | How often to clean up stale metrics from memory.                               | `"5m"`  | no       |
+| `honor_metadata`                   | `bool`                  | (Experimental) Whether to send metric metadata to downstream components.       | `false` | no       |
+| `include_scope_info`               | `bool`                  | Whether to include `otel_scope_info` metrics.                                  | `false` | no       |
+| `include_scope_labels`             | `bool`                  | Whether to include additional OTLP labels in all metrics.                      | `true`  | no       |
+| `include_target_info`              | `bool`                  | Whether to include `target_info` metrics.                                      | `true`  | no       |
+| `resource_to_telemetry_conversion` | `bool`                  | Whether to convert OTel resource attributes to Prometheus labels.              | `false` | no       |
 
 By default, OpenTelemetry resources are converted into `target_info` metrics.
 OpenTelemetry instrumentation scopes are converted into `otel_scope_info` metrics.
 Set the `include_scope_info` and `include_target_info` arguments to `false`, respectively, to disable the custom metrics.
+
+{{< admonition type="warning" >}}
+**EXPERIMENTAL**: The `honor_metadata` argument is an [experimental][] feature.
+If you enable this argument, resource consumption may increase, particularly if you ingest many metrics with different names.
+Some downstream components aren't compatible with Prometheus metadata.
+The following components are compatible:
+
+* `otelcol.receiver.prometheus`
+* `prometheus.remote_write` only when configured for Remote Write v2.
+* `prometheus.write_queue`
+
+[experimental]: ../../../get-started/configuration-syntax/expressions/function_calls/#experimental-functions
+{{< /admonition >}}
 
 When `include_scope_labels` is `true`  the `otel_scope_name` and `otel_scope_version` labels are added to every converted metric sample.
 

--- a/internal/component/otelcol/exporter/prometheus/prometheus.go
+++ b/internal/component/otelcol/exporter/prometheus/prometheus.go
@@ -40,6 +40,7 @@ type Arguments struct {
 	ForwardTo                     []storage.Appendable `alloy:"forward_to,attr"`
 	AddMetricSuffixes             bool                 `alloy:"add_metric_suffixes,attr,optional"`
 	ResourceToTelemetryConversion bool                 `alloy:"resource_to_telemetry_conversion,attr,optional"`
+	HonorMetadata                 bool                 `alloy:"honor_metadata,attr,optional"`
 }
 
 // DefaultArguments holds defaults values.
@@ -50,6 +51,7 @@ var DefaultArguments = Arguments{
 	GCFrequency:                   5 * time.Minute,
 	AddMetricSuffixes:             true,
 	ResourceToTelemetryConversion: false,
+	HonorMetadata:                 false,
 }
 
 // SetToDefault implements syntax.Defaulter.
@@ -159,5 +161,6 @@ func convertArgumentsToConvertOptions(args Arguments) convert.Options {
 		IncludeScopeInfo:              args.IncludeScopeInfo,
 		AddMetricSuffixes:             args.AddMetricSuffixes,
 		ResourceToTelemetryConversion: args.ResourceToTelemetryConversion,
+		HonorMetadata:                 args.HonorMetadata,
 	}
 }

--- a/internal/component/otelcol/exporter/prometheus/prometheus_test.go
+++ b/internal/component/otelcol/exporter/prometheus/prometheus_test.go
@@ -30,6 +30,7 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 				AddMetricSuffixes:             true,
 				ForwardTo:                     []storage.Appendable{},
 				ResourceToTelemetryConversion: false,
+				HonorMetadata:                 false,
 			},
 		},
 		{
@@ -41,6 +42,7 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 					gc_frequency = "1s"
 					add_metric_suffixes = false
 					resource_to_telemetry_conversion = true
+					honor_metadata = true
 					forward_to = []
 				`,
 			expected: prometheus.Arguments{
@@ -51,6 +53,7 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 				AddMetricSuffixes:             false,
 				ForwardTo:                     []storage.Appendable{},
 				ResourceToTelemetryConversion: true,
+				HonorMetadata:                 true,
 			},
 		},
 		{


### PR DESCRIPTION
### Pull Request Details

The new argument defaults to `false`, because:
* Up until #5045, the Prometheus components didn't support metadata properly.
* Even though `otelcol.exporter.prometheus` was trying to add the metadata, it was doing it too early, before the series had been appended.
* Metadata support is experimental throughout Alloy
* The vast majority of users use Remote Write v1, which doesn't yet support metadata in Alloy.

For these reasons I don't consider this to be breaking change.

### Issue(s) fixed by this Pull Request

Fixes #5426

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
