### PR TITLE
fix: Revert doublestar update

### DIFF
--- a/collector/go.mod
+++ b/collector/go.mod
@@ -326,6 +326,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bitfield/gotestdox v0.2.2 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
+	github.com/bmatcuk/doublestar v1.3.4 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.9.1 // indirect
 	github.com/boynux/squid-exporter v1.10.5-0.20230618153315-c1fae094e18e // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect

--- a/collector/go.sum
+++ b/collector/go.sum
@@ -598,6 +598,8 @@ github.com/bkaradzic/go-lz4 v1.0.0/go.mod h1:0YdlkowM3VswSROI7qDxhRvJ3sLhlFrRRwj
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
+github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=
+github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/bmatcuk/doublestar/v4 v4.9.1 h1:X8jg9rRZmJd4yRy7ZeNDRnM+T3ZfHv15JiBJ/avrEXE=
 github.com/bmatcuk/doublestar/v4 v4.9.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/boynux/squid-exporter v1.10.5-0.20230618153315-c1fae094e18e h1:C1vYe728vM2FpXaICJuDRt5zgGyRdMmUGYnVfM7WcLY=

--- a/extension/alloyengine/go.mod
+++ b/extension/alloyengine/go.mod
@@ -248,6 +248,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bitfield/gotestdox v0.2.2 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
+	github.com/bmatcuk/doublestar v1.3.4 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.9.1 // indirect
 	github.com/boynux/squid-exporter v1.10.5-0.20230618153315-c1fae094e18e // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect

--- a/extension/alloyengine/go.sum
+++ b/extension/alloyengine/go.sum
@@ -608,6 +608,8 @@ github.com/bkaradzic/go-lz4 v1.0.0/go.mod h1:0YdlkowM3VswSROI7qDxhRvJ3sLhlFrRRwj
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
+github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=
+github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/bmatcuk/doublestar/v4 v4.9.1 h1:X8jg9rRZmJd4yRy7ZeNDRnM+T3ZfHv15JiBJ/avrEXE=
 github.com/bmatcuk/doublestar/v4 v4.9.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/boynux/squid-exporter v1.10.5-0.20230618153315-c1fae094e18e h1:C1vYe728vM2FpXaICJuDRt5zgGyRdMmUGYnVfM7WcLY=

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.95.0
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.39.17
 	github.com/blang/semver/v4 v4.0.0
-	github.com/bmatcuk/doublestar/v4 v4.9.1
+	github.com/bmatcuk/doublestar/v4 v4.9.1 // indirect
 	github.com/boynux/squid-exporter v1.10.5-0.20230618153315-c1fae094e18e
 	github.com/buger/jsonparser v1.1.1
 	github.com/burningalchemist/sql_exporter v0.0.0-20240103092044-466b38b6abc4
@@ -1016,6 +1016,7 @@ require (
 require (
 	buf.build/gen/go/parca-dev/parca/grpc/go v1.6.0-20251203114737-dab2f094ec25.1
 	buf.build/gen/go/parca-dev/parca/protocolbuffers/go v1.36.11-20251203114737-dab2f094ec25.1
+	github.com/bmatcuk/doublestar v1.3.4
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -612,6 +612,8 @@ github.com/bkaradzic/go-lz4 v1.0.0/go.mod h1:0YdlkowM3VswSROI7qDxhRvJ3sLhlFrRRwj
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
+github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=
+github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/bmatcuk/doublestar/v4 v4.9.1 h1:X8jg9rRZmJd4yRy7ZeNDRnM+T3ZfHv15JiBJ/avrEXE=
 github.com/bmatcuk/doublestar/v4 v4.9.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/boynux/squid-exporter v1.10.5-0.20230618153315-c1fae094e18e h1:C1vYe728vM2FpXaICJuDRt5zgGyRdMmUGYnVfM7WcLY=

--- a/internal/component/local/file_match/watch.go
+++ b/internal/component/local/file_match/watch.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/bmatcuk/doublestar/v4"
+	"github.com/bmatcuk/doublestar"
 	"github.com/go-kit/log"
 
 	"github.com/grafana/alloy/internal/component/discovery"
@@ -23,14 +23,14 @@ type watch struct {
 func (w *watch) getPaths() ([]discovery.Target, error) {
 	allMatchingPaths := make([]discovery.Target, 0)
 
-	matches, err := doublestar.FilepathGlob(w.getPath())
+	matches, err := doublestar.Glob(w.getPath())
 	if err != nil {
 		return nil, err
 	}
 	exclude := w.getExcludePath()
 	for _, m := range matches {
 		if exclude != "" {
-			if match, _ := doublestar.PathMatch(filepath.FromSlash(exclude), m); match {
+			if match, _ := doublestar.PathMatch(exclude, m); match {
 				continue
 			}
 		}

--- a/internal/component/loki/source/file/resolver.go
+++ b/internal/component/loki/source/file/resolver.go
@@ -4,7 +4,7 @@ import (
 	"iter"
 	"path/filepath"
 
-	"github.com/bmatcuk/doublestar/v4"
+	"github.com/bmatcuk/doublestar"
 	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
 
@@ -72,7 +72,7 @@ func (s *globResolver) Resolve(targets []discovery.Target) iter.Seq[resolvedTarg
 			targetPath, _ := target.Get(labelPath)
 			labels := target.NonReservedLabelSet()
 
-			matches, err := doublestar.FilepathGlob(targetPath)
+			matches, err := doublestar.Glob(targetPath)
 			if err != nil {
 				level.Error(s.logger).Log("msg", "failed to resolve target", "error", err)
 				continue
@@ -82,7 +82,7 @@ func (s *globResolver) Resolve(targets []discovery.Target) iter.Seq[resolvedTarg
 
 			for _, m := range matches {
 				if exclude != "" {
-					if match, _ := doublestar.PathMatch(filepath.FromSlash(exclude), m); match {
+					if match, _ := doublestar.PathMatch(exclude, m); match {
 						continue
 					}
 				}


### PR DESCRIPTION
### Pull Request Details
Discovered that updating to v4 introduces regression on windows around case sensitivity for paths. So we need to revert and look into that before updating.

### Issue(s) fixed by this Pull Request

### Notes to the Reviewer

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
