### PR TITLE
feat(database_observability.postgres): add automatic reconnection with 30s ticker

### DIFF
--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -232,9 +232,37 @@ func (c *Component) Run(ctx context.Context) error {
 		c.mut.RUnlock()
 	}()
 
+	// Automatic reconnection ticker
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				c.mut.RLock()
+				hasCollectors := len(c.collectors) > 0
+				c.mut.RUnlock()
+
+				if !hasCollectors {
+					level.Debug(c.opts.Logger).Log("msg", "attempting to reconnect to database")
+					if err := c.tryReconnect(ctx); err == nil {
+						level.Info(c.opts.Logger).Log("msg", "successfully reconnected to database and started collectors")
+					}
+				}
+			}
+		}
+	}()
+
 	for {
 		select {
 		case <-ctx.Done():
+			wg.Wait()
 			return nil
 		case entry := <-c.handler.Chan():
 			c.mut.RLock()
@@ -244,6 +272,18 @@ func (c *Component) Run(ctx context.Context) error {
 			c.mut.RUnlock()
 		}
 	}
+}
+
+func (c *Component) tryReconnect(ctx context.Context) error {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	if err := c.connectAndStartCollectors(ctx); err != nil {
+		return err
+	}
+
+	c.healthErr.Store("")
+	return nil
 }
 
 func (c *Component) getBaseTarget() (discovery.Target, error) {
@@ -267,43 +307,35 @@ func (c *Component) reportError(errorMsg string, err error) {
 	c.healthErr.Store(fmt.Sprintf("%s: %+v", errorMsg, err))
 }
 
-func (c *Component) Update(args component.Arguments) error {
-	c.mut.Lock()
-	defer c.mut.Unlock()
-
+func (c *Component) connectAndStartCollectors(ctx context.Context) error {
 	if c.dbConnection != nil {
 		c.dbConnection.Close()
+		c.dbConnection = nil
 	}
-
-	c.args = args.(Arguments)
 
 	dbConnection, err := c.openSQL("postgres", string(c.args.DataSourceName))
 	if err != nil {
-		c.reportError("failed to open database connection", err)
-		return nil
+		return fmt.Errorf("failed to open database connection: %w", err)
 	}
 
 	if dbConnection == nil {
-		c.reportError("nil DB connection", nil)
-		return nil
+		return fmt.Errorf("nil DB connection")
 	}
+
 	if err = dbConnection.Ping(); err != nil {
-		c.reportError("failed to ping database", err)
-		return nil
+		dbConnection.Close()
+		return fmt.Errorf("failed to ping database: %w", err)
 	}
 	c.dbConnection = dbConnection
 
-	rs := dbConnection.QueryRowContext(context.Background(), selectServerInfo)
-	err = rs.Err()
-	if err != nil {
-		c.reportError("failed to query engine version", err)
-		return nil
+	rs := dbConnection.QueryRowContext(ctx, selectServerInfo)
+	if err := rs.Err(); err != nil {
+		return fmt.Errorf("failed to query engine version: %w", err)
 	}
 
 	var systemID, systemIP, systemPort, engineVersion sql.NullString
 	if err := rs.Scan(&systemID, &systemIP, &systemPort, &engineVersion); err != nil {
-		c.reportError("failed to scan engine version", err)
-		return nil
+		return fmt.Errorf("failed to scan engine version: %w", err)
 	}
 
 	generatedSystemID := fmt.Sprintf("%x", sha256.Sum256([]byte(fmt.Sprintf("%s:%s:%s", systemID.String, systemIP.String, systemPort.String))))
@@ -312,30 +344,30 @@ func (c *Component) Update(args component.Arguments) error {
 	if c.args.CloudProvider != nil {
 		cloudProvider, err := populateCloudProviderFromConfig(c.args.CloudProvider)
 		if err != nil {
-			c.reportError("failed to collect cloud provider information from config", err)
-			return nil
+			return fmt.Errorf("failed to collect cloud provider information from config: %w", err)
 		}
 		cp = cloudProvider
 	} else {
 		cloudProvider, err := populateCloudProviderFromDSN(string(c.args.DataSourceName))
 		if err != nil {
-			c.reportError("failed to collect cloud provider information from DSN", err)
-			return nil
+			return fmt.Errorf("failed to collect cloud provider information from DSN: %w", err)
 		}
 		cp = cloudProvider
 	}
 
-	c.args.Targets = append([]discovery.Target{c.baseTarget}, c.args.Targets...)
-	targets := make([]discovery.Target, 0, len(c.args.Targets)+1)
-	for _, t := range c.args.Targets {
+	allTargets := append([]discovery.Target{c.baseTarget}, c.args.Targets...)
+	targets := make([]discovery.Target, 0, len(allTargets))
+	for _, t := range allTargets {
 		builder := discovery.NewTargetBuilderFrom(t)
 		if relabel.ProcessBuilder(builder, database_observability.GetRelabelingRules(generatedSystemID, cp)...) {
 			targets = append(targets, builder.Target())
 		}
 	}
-	c.opts.OnStateChange(Exports{
+
+	exports := Exports{
 		Targets: targets,
-	})
+	}
+	c.opts.OnStateChange(exports)
 
 	for _, collector := range c.collectors {
 		collector.Stop()
@@ -343,7 +375,20 @@ func (c *Component) Update(args component.Arguments) error {
 	c.collectors = nil
 
 	if err := c.startCollectors(generatedSystemID, engineVersion.String, cp); err != nil {
-		c.reportError("failed to start collectors", err)
+		return fmt.Errorf("failed to start collectors: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Component) Update(args component.Arguments) error {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	c.args = args.(Arguments)
+
+	if err := c.connectAndStartCollectors(context.Background()); err != nil {
+		c.reportError("failed to connect and start collectors", err)
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

Adds automatic database reconnection infrastructure for the postgres database_observability component:

- Automatic reconnection ticker (30s interval) attempts to reconnect when collectors are not running
- Extracts connection logic into reusable `connectAndStartCollectors()` method
- Adds `tryReconnect()` method for clean reconnection attempts
- Refactors `Update()` to use the new connection method
- Returns structured errors for better error handling and debugging
- Adds WaitGroup for graceful shutdown of reconnection goroutine

## Benefits

- **Automatic recovery** from transient database failures without manual intervention
- **Cleaner code separation** - connection logic is now reusable
- **Better error handling** - structured errors instead of side-effect based `reportError()`
- **Graceful shutdown** - no goroutine leaks
- **Foundation for future work** - `connectAndStartCollectors()` can be used by other features

## Testing

- Existing tests pass (verified component still works)
- Manual testing: verified reconnection works after database restart
- Reconnection ticker logs appear every 30s when DB is unavailable

## Test plan

- [ ] Component starts successfully with valid database
- [ ] Component handles invalid database gracefully (logs error, enters reconnect mode)
- [ ] Reconnection succeeds after database becomes available
- [ ] Multiple reconnection attempts work correctly
- [ ] Graceful shutdown completes without hanging
- [ ] All existing postgres tests pass