### PR TITLE
fix(database_observability.postgres): Correctly handle table name casing when parsing postgres queries

### DIFF
--- a/collector/go.mod
+++ b/collector/go.mod
@@ -246,7 +246,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/version v0.74.0-rc.3 // indirect
 	github.com/DataDog/datadog-api-client-go/v2 v2.51.0 // indirect
 	github.com/DataDog/datadog-go/v5 v5.8.2 // indirect
-	github.com/DataDog/go-sqllexer v0.1.10 // indirect
+	github.com/DataDog/go-sqllexer v0.1.12 // indirect
 	github.com/DataDog/go-tuf v1.1.1-0.5.2 // indirect
 	github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee // indirect
 	github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 // indirect

--- a/collector/go.sum
+++ b/collector/go.sum
@@ -377,8 +377,8 @@ github.com/DataDog/datadog-api-client-go/v2 v2.51.0/go.mod h1:d3tOEgUd2kfsr9uuHQ
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go/v5 v5.8.2 h1:9IEfH1Mw9AjWwhAMqCAkhbxjuJeMxm2ARX2VdgL+ols=
 github.com/DataDog/datadog-go/v5 v5.8.2/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
-github.com/DataDog/go-sqllexer v0.1.10 h1:lisiFE4du178mdBooAx3KlV3MsdwzJePNHbtdCMmFBw=
-github.com/DataDog/go-sqllexer v0.1.10/go.mod h1:vOw7Ia7z+z6nl3zGZlLIZe0vQlPtCPR906WIPBJadxc=
+github.com/DataDog/go-sqllexer v0.1.12 h1:2eI/Mbs+fcHzXp4iwGz60V6mAWQNFOD/aa98ZluJJ7c=
+github.com/DataDog/go-sqllexer v0.1.12/go.mod h1:vOw7Ia7z+z6nl3zGZlLIZe0vQlPtCPR906WIPBJadxc=
 github.com/DataDog/go-tuf v1.1.1-0.5.2 h1:YWvghV4ZvrQsPcUw8IOUMSDpqc3W5ruOIC+KJxPknv0=
 github.com/DataDog/go-tuf v1.1.1-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee h1:tXibLZk3G6HncIFJKaNItsdzcrk4YqILNDZlXPTNt4k=

--- a/extension/alloyengine/go.mod
+++ b/extension/alloyengine/go.mod
@@ -165,7 +165,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/version v0.74.0-rc.3 // indirect
 	github.com/DataDog/datadog-api-client-go/v2 v2.51.0 // indirect
 	github.com/DataDog/datadog-go/v5 v5.8.2 // indirect
-	github.com/DataDog/go-sqllexer v0.1.10 // indirect
+	github.com/DataDog/go-sqllexer v0.1.12 // indirect
 	github.com/DataDog/go-tuf v1.1.1-0.5.2 // indirect
 	github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee // indirect
 	github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 // indirect

--- a/extension/alloyengine/go.sum
+++ b/extension/alloyengine/go.sum
@@ -377,8 +377,8 @@ github.com/DataDog/datadog-api-client-go/v2 v2.51.0/go.mod h1:d3tOEgUd2kfsr9uuHQ
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go/v5 v5.8.2 h1:9IEfH1Mw9AjWwhAMqCAkhbxjuJeMxm2ARX2VdgL+ols=
 github.com/DataDog/datadog-go/v5 v5.8.2/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
-github.com/DataDog/go-sqllexer v0.1.10 h1:lisiFE4du178mdBooAx3KlV3MsdwzJePNHbtdCMmFBw=
-github.com/DataDog/go-sqllexer v0.1.10/go.mod h1:vOw7Ia7z+z6nl3zGZlLIZe0vQlPtCPR906WIPBJadxc=
+github.com/DataDog/go-sqllexer v0.1.12 h1:2eI/Mbs+fcHzXp4iwGz60V6mAWQNFOD/aa98ZluJJ7c=
+github.com/DataDog/go-sqllexer v0.1.12/go.mod h1:vOw7Ia7z+z6nl3zGZlLIZe0vQlPtCPR906WIPBJadxc=
 github.com/DataDog/go-tuf v1.1.1-0.5.2 h1:YWvghV4ZvrQsPcUw8IOUMSDpqc3W5ruOIC+KJxPknv0=
 github.com/DataDog/go-tuf v1.1.1-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee h1:tXibLZk3G6HncIFJKaNItsdzcrk4YqILNDZlXPTNt4k=

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/Azure/go-autorest/autorest v0.11.30
 	github.com/BurntSushi/toml v1.5.0
 	github.com/DATA-DOG/go-sqlmock v1.5.2
-	github.com/DataDog/go-sqllexer v0.1.10
+	github.com/DataDog/go-sqllexer v0.1.12
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.54.0
 	github.com/IBM/sarama v1.46.3
 	github.com/KimMachineGun/automemlimit v0.7.4

--- a/go.sum
+++ b/go.sum
@@ -379,8 +379,8 @@ github.com/DataDog/datadog-api-client-go/v2 v2.51.0/go.mod h1:d3tOEgUd2kfsr9uuHQ
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go/v5 v5.8.2 h1:9IEfH1Mw9AjWwhAMqCAkhbxjuJeMxm2ARX2VdgL+ols=
 github.com/DataDog/datadog-go/v5 v5.8.2/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
-github.com/DataDog/go-sqllexer v0.1.10 h1:lisiFE4du178mdBooAx3KlV3MsdwzJePNHbtdCMmFBw=
-github.com/DataDog/go-sqllexer v0.1.10/go.mod h1:vOw7Ia7z+z6nl3zGZlLIZe0vQlPtCPR906WIPBJadxc=
+github.com/DataDog/go-sqllexer v0.1.12 h1:2eI/Mbs+fcHzXp4iwGz60V6mAWQNFOD/aa98ZluJJ7c=
+github.com/DataDog/go-sqllexer v0.1.12/go.mod h1:vOw7Ia7z+z6nl3zGZlLIZe0vQlPtCPR906WIPBJadxc=
 github.com/DataDog/go-tuf v1.1.1-0.5.2 h1:YWvghV4ZvrQsPcUw8IOUMSDpqc3W5ruOIC+KJxPknv0=
 github.com/DataDog/go-tuf v1.1.1-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee h1:tXibLZk3G6HncIFJKaNItsdzcrk4YqILNDZlXPTNt4k=

--- a/internal/component/database_observability/postgres/collector/query_details.go
+++ b/internal/component/database_observability/postgres/collector/query_details.go
@@ -74,7 +74,7 @@ func NewQueryDetails(args QueryDetailsArguments) (*QueryDetails, error) {
 		excludeDatabases: args.ExcludeDatabases,
 		entryHandler:     args.EntryHandler,
 		tableRegistry:    args.TableRegistry,
-		normalizer:       sqllexer.NewNormalizer(sqllexer.WithCollectTables(true), sqllexer.WithCollectComments(true)),
+		normalizer:       sqllexer.NewNormalizer(sqllexer.WithCollectTables(true), sqllexer.WithCollectComments(true), sqllexer.WithKeepIdentifierQuotation(true)),
 		logger:           log.With(args.Logger, "collector", QueryDetailsCollector),
 		running:          &atomic.Bool{},
 	}, nil

--- a/internal/component/database_observability/postgres/collector/query_details.go
+++ b/internal/component/database_observability/postgres/collector/query_details.go
@@ -163,14 +163,15 @@ func (c QueryDetails) fetchAndAssociate(ctx context.Context) error {
 
 		for _, table := range tables {
 			validated := false
+			resolvedTable := table
 			if c.tableRegistry != nil {
-				validated = c.tableRegistry.IsValid(databaseName, table)
+				resolvedTable, validated = c.tableRegistry.IsValid(databaseName, table)
 			}
 
 			c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
 				logging.LevelInfo,
 				OP_QUERY_PARSED_TABLE_NAME,
-				fmt.Sprintf(`queryid="%s" datname="%s" table="%s" validated="%t"`, queryID, databaseName, table, validated),
+				fmt.Sprintf(`queryid="%s" datname="%s" table="%s" validated="%t"`, queryID, databaseName, resolvedTable, validated),
 			)
 		}
 	}

--- a/internal/component/database_observability/postgres/collector/query_details_test.go
+++ b/internal/component/database_observability/postgres/collector/query_details_test.go
@@ -80,6 +80,81 @@ func TestQueryDetails(t *testing.T) {
 			},
 		},
 		{
+			name: "select query with uppercase table name matches lowercase registry",
+			eventStatementsRows: [][]driver.Value{{
+				"abc123",
+				"SELECT * FROM SOME_TABLE WHERE id = $1",
+				"some_database",
+			}},
+			logsLabels: []model.LabelSet{
+				{"op": OP_QUERY_ASSOCIATION},
+				{"op": OP_QUERY_PARSED_TABLE_NAME},
+			},
+			logsLines: []string{
+				`level="info" queryid="abc123" querytext="SELECT * FROM SOME_TABLE WHERE id = $1" datname="some_database"`,
+				`level="info" queryid="abc123" datname="some_database" table="SOME_TABLE" validated="true"`,
+			},
+			tableRegistry: &TableRegistry{
+				tables: map[database]map[schema]map[table]struct{}{
+					"some_database": {
+						"public": {
+							"some_table": struct{}{}, // lowercase in registry
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "select query with uppercase schema-qualified name matches lowercase registry",
+			eventStatementsRows: [][]driver.Value{{
+				"abc123",
+				"SELECT * FROM PUBLIC.USERS WHERE id = $1",
+				"some_database",
+			}},
+			logsLabels: []model.LabelSet{
+				{"op": OP_QUERY_ASSOCIATION},
+				{"op": OP_QUERY_PARSED_TABLE_NAME},
+			},
+			logsLines: []string{
+				`level="info" queryid="abc123" querytext="SELECT * FROM PUBLIC.USERS WHERE id = $1" datname="some_database"`,
+				`level="info" queryid="abc123" datname="some_database" table="PUBLIC.USERS" validated="true"`,
+			},
+			tableRegistry: &TableRegistry{
+				tables: map[database]map[schema]map[table]struct{}{
+					"some_database": {
+						"public": {
+							"users": struct{}{}, // lowercase in registry
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "select query with mixed case table name matches lowercase registry",
+			eventStatementsRows: [][]driver.Value{{
+				"abc123",
+				"SELECT * FROM MyTable WHERE id = $1",
+				"some_database",
+			}},
+			logsLabels: []model.LabelSet{
+				{"op": OP_QUERY_ASSOCIATION},
+				{"op": OP_QUERY_PARSED_TABLE_NAME},
+			},
+			logsLines: []string{
+				`level="info" queryid="abc123" querytext="SELECT * FROM MyTable WHERE id = $1" datname="some_database"`,
+				`level="info" queryid="abc123" datname="some_database" table="MyTable" validated="true"`,
+			},
+			tableRegistry: &TableRegistry{
+				tables: map[database]map[schema]map[table]struct{}{
+					"some_database": {
+						"public": {
+							"mytable": struct{}{}, // lowercase in registry
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "select query containing with",
 			eventStatementsRows: [][]driver.Value{{
 				"abc123",

--- a/internal/component/database_observability/postgres/collector/query_details_test.go
+++ b/internal/component/database_observability/postgres/collector/query_details_test.go
@@ -142,13 +142,13 @@ func TestQueryDetails(t *testing.T) {
 			},
 			logsLines: []string{
 				`level="info" queryid="abc123" querytext="SELECT * FROM MyTable WHERE id = $1" datname="some_database"`,
-			`level="info" queryid="abc123" datname="some_database" table="mytable" validated="true"`,
-		},
-		tableRegistry: &TableRegistry{
-			tables: map[database]map[schema]map[table]struct{}{
-				"some_database": {
-					"public": {
-						"mytable": struct{}{}, // lowercase in registry
+				`level="info" queryid="abc123" datname="some_database" table="mytable" validated="true"`,
+			},
+			tableRegistry: &TableRegistry{
+				tables: map[database]map[schema]map[table]struct{}{
+					"some_database": {
+						"public": {
+							"mytable": struct{}{}, // lowercase in registry
 						},
 					},
 				},

--- a/internal/component/database_observability/postgres/collector/query_details_test.go
+++ b/internal/component/database_observability/postgres/collector/query_details_test.go
@@ -92,7 +92,7 @@ func TestQueryDetails(t *testing.T) {
 			},
 			logsLines: []string{
 				`level="info" queryid="abc123" querytext="SELECT * FROM SOME_TABLE WHERE id = $1" datname="some_database"`,
-				`level="info" queryid="abc123" datname="some_database" table="SOME_TABLE" validated="true"`,
+				`level="info" queryid="abc123" datname="some_database" table="some_table" validated="true"`,
 			},
 			tableRegistry: &TableRegistry{
 				tables: map[database]map[schema]map[table]struct{}{
@@ -117,7 +117,7 @@ func TestQueryDetails(t *testing.T) {
 			},
 			logsLines: []string{
 				`level="info" queryid="abc123" querytext="SELECT * FROM PUBLIC.USERS WHERE id = $1" datname="some_database"`,
-				`level="info" queryid="abc123" datname="some_database" table="PUBLIC.USERS" validated="true"`,
+				`level="info" queryid="abc123" datname="some_database" table="public.users" validated="true"`,
 			},
 			tableRegistry: &TableRegistry{
 				tables: map[database]map[schema]map[table]struct{}{
@@ -142,13 +142,13 @@ func TestQueryDetails(t *testing.T) {
 			},
 			logsLines: []string{
 				`level="info" queryid="abc123" querytext="SELECT * FROM MyTable WHERE id = $1" datname="some_database"`,
-				`level="info" queryid="abc123" datname="some_database" table="MyTable" validated="true"`,
-			},
-			tableRegistry: &TableRegistry{
-				tables: map[database]map[schema]map[table]struct{}{
-					"some_database": {
-						"public": {
-							"mytable": struct{}{}, // lowercase in registry
+			`level="info" queryid="abc123" datname="some_database" table="mytable" validated="true"`,
+		},
+		tableRegistry: &TableRegistry{
+			tables: map[database]map[schema]map[table]struct{}{
+				"some_database": {
+					"public": {
+						"mytable": struct{}{}, // lowercase in registry
 						},
 					},
 				},

--- a/internal/component/database_observability/postgres/collector/schema_details.go
+++ b/internal/component/database_observability/postgres/collector/schema_details.go
@@ -292,15 +292,15 @@ func (tr *TableRegistry) IsValid(database database, parsedTableName string) (str
 func parseSchemaQualifiedIfAny(parsedTableName string) (schema, table) {
 	parts := strings.SplitN(parsedTableName, ".", 2)
 	if len(parts) == 2 {
-		return schema(normalizePostgresIdentifier(parts[0])), table(normalizePostgresIdentifier(parts[1]))
+		return schema(formatPostgresIdentifier(parts[0])), table(formatPostgresIdentifier(parts[1]))
 	}
 	return "", table(parsedTableName)
 }
 
-// normalizePostgresIdentifier handles PostgreSQL identifier case folding.
+// formatPostgresIdentifier handles PostgreSQL identifier case folding.
 // Quoted identifiers (e.g., "MyTable") preserve their exact case after stripping quotes.
 // Unquoted identifiers are folded to lowercase to match PostgreSQL's behavior.
-func normalizePostgresIdentifier(identifier string) string {
+func formatPostgresIdentifier(identifier string) string {
 	if len(identifier) >= 2 && identifier[0] == '"' && identifier[len(identifier)-1] == '"' {
 		return identifier[1 : len(identifier)-1]
 	}

--- a/internal/component/database_observability/postgres/collector/schema_details_test.go
+++ b/internal/component/database_observability/postgres/collector/schema_details_test.go
@@ -1697,7 +1697,7 @@ func Test_TableRegistry_IsValid(t *testing.T) {
 	})
 }
 
-func Test_normalizePostgresIdentifier(t *testing.T) {
+func Test_formatPostgresIdentifier(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
@@ -1742,7 +1742,7 @@ func Test_normalizePostgresIdentifier(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := normalizePostgresIdentifier(tc.input)
+			result := formatPostgresIdentifier(tc.input)
 			assert.Equal(t, tc.expected, result)
 		})
 	}

--- a/internal/component/database_observability/postgres/collector/schema_details_test.go
+++ b/internal/component/database_observability/postgres/collector/schema_details_test.go
@@ -1535,8 +1535,13 @@ func Test_TableRegistry_IsValid(t *testing.T) {
 			{database: "mydb", schema: "public", tableName: "orders"},
 		})
 
-		assert.True(t, tr.IsValid("mydb", "users"))
-		assert.True(t, tr.IsValid("mydb", "orders"))
+		resolvedTable, valid := tr.IsValid("mydb", "users")
+		assert.True(t, valid)
+		assert.Equal(t, "users", resolvedTable)
+
+		resolvedTable, valid = tr.IsValid("mydb", "orders")
+		assert.True(t, valid)
+		assert.Equal(t, "orders", resolvedTable)
 	})
 
 	t.Run("returns false when table does not exist in registry", func(t *testing.T) {
@@ -1545,7 +1550,9 @@ func Test_TableRegistry_IsValid(t *testing.T) {
 			{database: "mydb", schema: "public", tableName: "users"},
 		})
 
-		assert.False(t, tr.IsValid("mydb", "nonexistent"))
+		resolvedTable, valid := tr.IsValid("mydb", "nonexistent")
+		assert.False(t, valid)
+		assert.Equal(t, "nonexistent", resolvedTable)
 	})
 
 	t.Run("returns false given nonexistent database", func(t *testing.T) {
@@ -1554,13 +1561,17 @@ func Test_TableRegistry_IsValid(t *testing.T) {
 			{database: "mydb", schema: "public", tableName: "users"},
 		})
 
-		assert.False(t, tr.IsValid("otherdb", "users"))
+		resolvedTable, valid := tr.IsValid("otherdb", "users")
+		assert.False(t, valid)
+		assert.Equal(t, "users", resolvedTable)
 	})
 
 	t.Run("returns false for empty registry", func(t *testing.T) {
 		tr := NewTableRegistry()
 
-		assert.False(t, tr.IsValid("mydb", "users"))
+		resolvedTable, valid := tr.IsValid("mydb", "users")
+		assert.False(t, valid)
+		assert.Equal(t, "users", resolvedTable)
 	})
 
 	t.Run("returns true when table exists in multiple schemas", func(t *testing.T) {
@@ -1570,7 +1581,9 @@ func Test_TableRegistry_IsValid(t *testing.T) {
 			{database: "mydb", schema: "private", tableName: "users"},
 		})
 
-		assert.True(t, tr.IsValid("mydb", "users"))
+		resolvedTable, valid := tr.IsValid("mydb", "users")
+		assert.True(t, valid)
+		assert.Equal(t, "users", resolvedTable)
 	})
 
 	t.Run("returns true when schema-qualified table exists", func(t *testing.T) {
@@ -1579,7 +1592,9 @@ func Test_TableRegistry_IsValid(t *testing.T) {
 			{database: "mydb", schema: "private", tableName: "users"},
 		})
 
-		assert.True(t, tr.IsValid("mydb", "private.users"))
+		resolvedTable, valid := tr.IsValid("mydb", "private.users")
+		assert.True(t, valid)
+		assert.Equal(t, "private.users", resolvedTable)
 	})
 
 	t.Run("unquoted table name matches lowercase registry entry", func(t *testing.T) {
@@ -1589,9 +1604,17 @@ func Test_TableRegistry_IsValid(t *testing.T) {
 		})
 
 		// Unquoted identifier is folded to lowercase by postgres
-		assert.True(t, tr.IsValid("mydb", "USERS"))
-		assert.True(t, tr.IsValid("mydb", "Users"))
-		assert.True(t, tr.IsValid("mydb", "users"))
+		resolvedTable, valid := tr.IsValid("mydb", "USERS")
+		assert.True(t, valid)
+		assert.Equal(t, "users", resolvedTable)
+
+		resolvedTable, valid = tr.IsValid("mydb", "Users")
+		assert.True(t, valid)
+		assert.Equal(t, "users", resolvedTable)
+
+		resolvedTable, valid = tr.IsValid("mydb", "users")
+		assert.True(t, valid)
+		assert.Equal(t, "users", resolvedTable)
 	})
 
 	t.Run("unquoted table name matches mixed case registry entry", func(t *testing.T) {
@@ -1600,8 +1623,13 @@ func Test_TableRegistry_IsValid(t *testing.T) {
 			{database: "mydb", schema: "public", tableName: "MyTable"},
 		})
 
-		assert.True(t, tr.IsValid("mydb", "MyTable"))
-		assert.False(t, tr.IsValid("mydb", "mytable"))
+		resolvedTable, valid := tr.IsValid("mydb", "MyTable")
+		assert.True(t, valid)
+		assert.Equal(t, "MyTable", resolvedTable)
+
+		resolvedTable, valid = tr.IsValid("mydb", "mytable")
+		assert.False(t, valid)
+		assert.Equal(t, "mytable", resolvedTable)
 	})
 
 	t.Run("schema-qualified unquoted table name matches lowercase registry entry", func(t *testing.T) {
@@ -1610,9 +1638,17 @@ func Test_TableRegistry_IsValid(t *testing.T) {
 			{database: "mydb", schema: "public", tableName: "users"},
 		})
 
-		assert.True(t, tr.IsValid("mydb", "PUBLIC.USERS"))
-		assert.True(t, tr.IsValid("mydb", "Public.Users"))
-		assert.True(t, tr.IsValid("mydb", "public.users"))
+		resolvedTable, valid := tr.IsValid("mydb", "PUBLIC.USERS")
+		assert.True(t, valid)
+		assert.Equal(t, "public.users", resolvedTable)
+
+		resolvedTable, valid = tr.IsValid("mydb", "Public.Users")
+		assert.True(t, valid)
+		assert.Equal(t, "public.users", resolvedTable)
+
+		resolvedTable, valid = tr.IsValid("mydb", "public.users")
+		assert.True(t, valid)
+		assert.Equal(t, "public.users", resolvedTable)
 	})
 
 	t.Run("schema-qualified quoted table match exact case", func(t *testing.T) {
@@ -1621,8 +1657,13 @@ func Test_TableRegistry_IsValid(t *testing.T) {
 			{database: "mydb", schema: "public", tableName: "MyTable"},
 		})
 
-		assert.True(t, tr.IsValid("mydb", `public."MyTable"`))
-		assert.False(t, tr.IsValid("mydb", "public.mytable"))
+		resolvedTable, valid := tr.IsValid("mydb", `public."MyTable"`)
+		assert.True(t, valid)
+		assert.Equal(t, "public.MyTable", resolvedTable)
+
+		resolvedTable, valid = tr.IsValid("mydb", "public.mytable")
+		assert.False(t, valid)
+		assert.Equal(t, "public.mytable", resolvedTable)
 	})
 
 	t.Run("schema-qualified with quoted schema match exact case", func(t *testing.T) {
@@ -1631,8 +1672,13 @@ func Test_TableRegistry_IsValid(t *testing.T) {
 			{database: "mydb", schema: "MySchema", tableName: "users"},
 		})
 
-		assert.True(t, tr.IsValid("mydb", `"MySchema".users`))
-		assert.False(t, tr.IsValid("mydb", "myschema.users"))
+		resolvedTable, valid := tr.IsValid("mydb", `"MySchema".users`)
+		assert.True(t, valid)
+		assert.Equal(t, "MySchema.users", resolvedTable)
+
+		resolvedTable, valid = tr.IsValid("mydb", "myschema.users")
+		assert.False(t, valid)
+		assert.Equal(t, "myschema.users", resolvedTable)
 	})
 
 	t.Run("both schema and table quoted match exact case", func(t *testing.T) {
@@ -1641,8 +1687,13 @@ func Test_TableRegistry_IsValid(t *testing.T) {
 			{database: "mydb", schema: "MySchema", tableName: "MyTable"},
 		})
 
-		assert.True(t, tr.IsValid("mydb", `"MySchema"."MyTable"`))
-		assert.False(t, tr.IsValid("mydb", "myschema.mytable"))
+		resolvedTable, valid := tr.IsValid("mydb", `"MySchema"."MyTable"`)
+		assert.True(t, valid)
+		assert.Equal(t, "MySchema.MyTable", resolvedTable)
+
+		resolvedTable, valid = tr.IsValid("mydb", "myschema.mytable")
+		assert.False(t, valid)
+		assert.Equal(t, "myschema.mytable", resolvedTable)
 	})
 }
 


### PR DESCRIPTION
### Brief description of Pull Request
When extracting table names from sql queries for postgres, ensure that the casing of identifiers is handled according to postgres rules. Unquoted identifiers should be folded to lowercase, while quoted identifiers should preserve their case.

This change updates the normalizer in QueryDetails to retain quotation, and updates the TableRegistry validation logic to account for this behavior (the library behaviour seems inconsistent though, hence the lowercasing fallback). Also, if lowercasing is applied, the table is logged with lowercase name.

### Pull Request Details

<!-- Add a more detailed descripion of the Pull Request here, if needed. -->

### Issue(s) fixed by this Pull Request

<!--
  Uncomment the following line and fill in an issue number if you want a GitHub
  issue to be closed automatically when this PR gets merged.
-->

<!-- Fixes #issue_id -->

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
