### PR TITLE
feat: Add automatic reconnection to database_observability components

### DIFF
--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -232,7 +232,6 @@ func (c *Component) Run(ctx context.Context) error {
 		c.mut.RUnlock()
 	}()
 
-	// Automatic reconnection ticker
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
@@ -251,8 +250,8 @@ func (c *Component) Run(ctx context.Context) error {
 
 				if !hasCollectors {
 					level.Debug(c.opts.Logger).Log("msg", "attempting to reconnect to database")
-					if err := c.tryReconnect(ctx); err == nil {
-						level.Info(c.opts.Logger).Log("msg", "successfully reconnected to database and started collectors")
+					if err := c.tryReconnect(ctx); err != nil {
+						level.Error(c.opts.Logger).Log("msg", "reconnection attempt failed", "err", err)
 					}
 				}
 			}

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -300,6 +300,7 @@ func (c *Component) tryReconnect(ctx context.Context) error {
 	defer c.mut.Unlock()
 
 	if err := c.connectAndStartCollectors(ctx); err != nil {
+		c.reportError("reconnection failed", err)
 		return err
 	}
 


### PR DESCRIPTION
## Summary

Add 30-second automatic reconnection ticker for postgres and mysql components.

Fixes https://github.com/grafana/alloy/issues/5375

## Changes

- Extract connection logic into `connectAndStartCollectors()` 
- Add reconnection ticker in `Run()` with WaitGroup for shutdown
- Refactor `Update()` to reuse connection method
- Add tests for reconnection, health status, and cancellation