### PR TITLE
chore: Alloy mixin dashboard typo fix

### DIFF
--- a/operations/alloy-mixin/dashboards/resources.libsonnet
+++ b/operations/alloy-mixin/dashboards/resources.libsonnet
@@ -133,7 +133,7 @@ local stackedPanelMixin = {
 
       // Memory (Go heap inuse)
       (
-        panel.new(title='Memory (heap inuse)', type='timeseries') +
+        panel.new(title='Memory (heap in use)', type='timeseries') +
         panel.withUnit('decbytes') +
         panel.withDescription(|||
           Heap memory currently in use by the Alloy process.

--- a/operations/alloy-mixin/rendered/dashboards/alloy-resources.json
+++ b/operations/alloy-mixin/rendered/dashboards/alloy-resources.json
@@ -159,7 +159,7 @@
                "range": true
             }
          ],
-         "title": "Memory (heap inuse)",
+         "title": "Memory (heap in use)",
          "type": "timeseries"
       },
       {


### PR DESCRIPTION
### Brief description of Pull Request

fix: Correct typo in Alloy Resources dashboard panel title

### Pull Request Details

Corrected a minor typo in the "Memory (heap inuse)" panel title within the Alloy Resources dashboard. The title is now "Memory (heap in use)". This change is primarily to test the new mixin rollout pipeline.

### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->

### Notes to the Reviewer

This PR addresses a minor visual inconsistency in a dashboard panel title. The primary purpose of this change is to verify the new mixin rollout pipeline. The change should be visible in the Grafana dashboard.

### PR Checklist

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated

---
<p><a href="https://cursor.com/background-agent?bcId=bc-6c0dbf67-d648-4f81-b9d8-dfef146fa279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6c0dbf67-d648-4f81-b9d8-dfef146fa279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

