### PR TITLE
fix(prometheus.exporter.cloudwatch): Respect debug flag

### DIFF
--- a/internal/static/integrations/cloudwatch_exporter/cloudwatch_exporter_decoupled.go
+++ b/internal/static/integrations/cloudwatch_exporter/cloudwatch_exporter_decoupled.go
@@ -38,10 +38,12 @@ func NewDecoupledCloudwatchExporter(name string, logger log.Logger, conf yaceMod
 	var factory cachingFactory
 	var err error
 
+	l := slog.New(newSlogHandler(logging.NewSlogGoKitHandler(logger), debug))
+
 	if useAWSSDKVersionV2 {
-		factory, err = yaceClientsV2.NewFactory(slog.New(logging.NewSlogGoKitHandler(logger)), conf, fipsEnabled)
+		factory, err = yaceClientsV2.NewFactory(l, conf, fipsEnabled)
 	} else {
-		factory = yaceClientsV1.NewFactory(slog.New(logging.NewSlogGoKitHandler(logger)), conf, fipsEnabled)
+		factory = yaceClientsV1.NewFactory(l, conf, fipsEnabled)
 	}
 
 	if err != nil {
@@ -50,7 +52,7 @@ func NewDecoupledCloudwatchExporter(name string, logger log.Logger, conf yaceMod
 
 	return &asyncExporter{
 		name:                 name,
-		logger:               slog.New(logging.NewSlogGoKitHandler(logger)),
+		logger:               l,
 		cachingClientFactory: factory,
 		scrapeConf:           conf,
 		registry:             atomic.Pointer[prometheus.Registry]{},

--- a/internal/static/integrations/cloudwatch_exporter/cloudwatch_exporter_decoupled_test.go
+++ b/internal/static/integrations/cloudwatch_exporter/cloudwatch_exporter_decoupled_test.go
@@ -1,0 +1,42 @@
+package cloudwatch_exporter
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	yaceModel "github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecoupledCloudwatchExporterIntegrationProperSetup(t *testing.T) {
+	givenName := "test_exporter"
+	var logbuff bytes.Buffer
+	givenLogger := log.NewJSONLogger(&logbuff)
+	givenConfig := yaceModel.JobsConfig{
+		StsRegion:           "us-east-1",
+		DiscoveryJobs:       []yaceModel.DiscoveryJob{},
+		StaticJobs:          []yaceModel.StaticJob{},
+		CustomNamespaceJobs: []yaceModel.CustomNamespaceJob{},
+	}
+	givenFipsEnabled := false
+	givenLabelsSnakeCase := true
+	givenDebug := false
+	givenuseAWSSDKVersionV2 := true
+	givenScrapeInterval := 30 * time.Second
+
+	e, err := NewDecoupledCloudwatchExporter(givenName, givenLogger, givenConfig, givenScrapeInterval, givenFipsEnabled, givenLabelsSnakeCase, givenDebug, givenuseAWSSDKVersionV2)
+	require.NoError(t, err, "failed to construct cloudwatch exporter")
+
+	logbuff.Reset()
+	require.Equal(t, givenName, e.name, "exporter name should be set correctly")
+	require.Equal(t, givenLabelsSnakeCase, e.labelsSnakeCase, "labelsSnakeCase should be set correctly")
+	require.NotNil(t, e.logger, "logger should be initialized")
+	require.NotNil(t, e.cachingClientFactory, "cachingClientFactory should be initialized")
+
+	e.logger.Debug("debug")
+	if bytes.Contains(logbuff.Bytes(), []byte("debug")) != givenDebug {
+		t.Error("logger does not respect debug flag")
+	}
+}

--- a/internal/static/integrations/cloudwatch_exporter/cloudwatch_exporter_test.go
+++ b/internal/static/integrations/cloudwatch_exporter/cloudwatch_exporter_test.go
@@ -1,0 +1,40 @@
+package cloudwatch_exporter
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/go-kit/log"
+	yaceModel "github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloudwatchExporterIntegrationProperSetup(t *testing.T) {
+	givenName := "test_exporter"
+	var logbuff bytes.Buffer
+	givenLogger := log.NewJSONLogger(&logbuff)
+	givenConfig := yaceModel.JobsConfig{
+		StsRegion:           "us-east-1",
+		DiscoveryJobs:       []yaceModel.DiscoveryJob{},
+		StaticJobs:          []yaceModel.StaticJob{},
+		CustomNamespaceJobs: []yaceModel.CustomNamespaceJob{},
+	}
+	givenFipsEnabled := false
+	givenLabelsSnakeCase := true
+	givenDebug := false
+	givenuseAWSSDKVersionV2 := true
+
+	e, err := NewCloudwatchExporter(givenName, givenLogger, givenConfig, givenFipsEnabled, givenLabelsSnakeCase, givenDebug, givenuseAWSSDKVersionV2)
+	require.NoError(t, err, "failed to construct cloudwatch exporter")
+
+	logbuff.Reset()
+	require.Equal(t, givenName, e.name, "exporter name should be set correctly")
+	require.Equal(t, givenLabelsSnakeCase, e.labelsSnakeCase, "labelsSnakeCase should be set correctly")
+	require.NotNil(t, e.logger, "logger should be initialized")
+	require.NotNil(t, e.cachingClientFactory, "cachingClientFactory should be initialized")
+
+	e.logger.Debug("debug")
+	if bytes.Contains(logbuff.Bytes(), []byte("debug")) != givenDebug {
+		t.Error("logger does not respect debug flag")
+	}
+}

--- a/internal/static/integrations/cloudwatch_exporter/config.go
+++ b/internal/static/integrations/cloudwatch_exporter/config.go
@@ -143,10 +143,10 @@ func (c *Config) NewIntegration(l log.Logger) (integrations.Integration, error) 
 		if v := c.DecoupledScrape.ScrapeInterval; v != nil {
 			scrapeInterval = *v
 		}
-		return NewDecoupledCloudwatchExporter(c.Name(), l, exporterConfig, scrapeInterval, fipsEnabled, c.Debug, labelsSnakeCase, c.UseAWSSDKVersion2)
+		return NewDecoupledCloudwatchExporter(c.Name(), l, exporterConfig, scrapeInterval, fipsEnabled, labelsSnakeCase, c.Debug, c.UseAWSSDKVersion2)
 	}
 
-	return NewCloudwatchExporter(c.Name(), l, exporterConfig, fipsEnabled, c.Debug, labelsSnakeCase, c.UseAWSSDKVersion2)
+	return NewCloudwatchExporter(c.Name(), l, exporterConfig, fipsEnabled, labelsSnakeCase, c.Debug, c.UseAWSSDKVersion2)
 }
 
 // getHash calculates the MD5 hash of the yaml representation of the config


### PR DESCRIPTION
### Brief description of Pull Request

This PR 

1. adds a logging wrapper for the decoupled cloudwatch exporter
2. fixes arguments in cloudwatch exporter construction calls

The changes are related to https://github.com/grafana/alloy/pull/4553 where 1. was added for the "normal" cloudwatch exporter. 

### Issue(s) fixed by this Pull Request
Fixes #4541


### Notes to the Reviewer

I could not run alloy locally since I currently have no access to cloudwatch. I verified that build works and added some Unittests to cover the changes to the logger.  The golang-ci linter takes ages on my machine due to some network hickups today so I could not run all linters.

### PR Checklist

- [X] Tests updated

