### PR TITLE
fix(database_observability.mysql): Skip wait events with `NULL` timer_wait

### DIFF
--- a/internal/component/database_observability/mysql/collector/query_samples.go
+++ b/internal/component/database_observability/mysql/collector/query_samples.go
@@ -375,7 +375,7 @@ func (c *QuerySamples) fetchQuerySamples(ctx context.Context) error {
 			)
 		}
 
-		if row.WaitEventID.Valid {
+		if row.WaitEventID.Valid && row.WaitTime.Valid {
 			waitTime := picosecondsToMilliseconds(row.WaitTime.Float64)
 			waitLogMessage := fmt.Sprintf(
 				`schema="%s" thread_id="%s" digest="%s" event_id="%s" wait_event_id="%s" wait_end_event_id="%s" wait_event_name="%s" wait_object_name="%s" wait_object_type="%s" wait_time="%fms"`,


### PR DESCRIPTION
### Brief description of Pull Request
Do not log wait events with NULL timer_wait (currently logged as "0ms" duration), as they do not provide meaningful information.

### Pull Request Details

Avoid logs like

```
wait_event_name="wait/io/socket/sql/client_connection" wait_object_type="SOCKET" wait_time="0.000000ms" sql_text="COMMIT" 
```

### Issue(s) fixed by this Pull Request

<!--
  Uncomment the following line and fill in an issue number if you want a GitHub
  issue to be closed automatically when this PR gets merged.
-->

<!-- Fixes #issue_id -->

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
