### PR TITLE
docs: Add endpoints deprecation note to docs

### DIFF
--- a/docs/sources/reference/components/discovery/discovery.kubernetes.md
+++ b/docs/sources/reference/components/discovery/discovery.kubernetes.md
@@ -158,7 +158,7 @@ If a Pod backs the endpoint, the component discovers all container ports of the 
 
 {{< admonition type="warning" >}}
 The Endpoints API is deprecated in Kubernetes v1.33+.
-It is recommended to use EndpointSlices instead and switch to the `endpointslice` role below.
+Use the EndpointSlice API instead, and switch to the `endpointslice` role below.
 {{< /admonition >}}
 
 Discovered endpoints include the following labels:


### PR DESCRIPTION
This is similar to a note in the [Prometheus docs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#endpoints).

If users use `endpoints`, Alloy will log a warning.