### PR TITLE
fix(loki.source.docker): Parse timestamp correctly when log line only contains newline

### DIFF
--- a/internal/component/loki/source/docker/tailer.go
+++ b/internal/component/loki/source/docker/tailer.go
@@ -275,6 +275,11 @@ func (t *tailer) process(r io.Reader, logStreamLset model.LabelSet) {
 			continue
 		}
 
+		if len(content) == 0 {
+			level.Debug(t.logger).Log("msg", "empty log, skipping line")
+			continue
+		}
+
 		t.recv.Chan() <- loki.Entry{
 			Labels: logStreamLset,
 			Entry: push.Entry{


### PR DESCRIPTION
### Pull Request Details
Regression from https://github.com/grafana/alloy/pull/4713. Before that pr we parsed log lines that only included newlines.

In this pr I fixed the issue so we no longer report an error but we keep the behavior of not forwarding empty lines and add a debug log for these cases. 

### Issue(s) fixed by this Pull Request
Fixes: https://github.com/grafana/alloy/issues/5476

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
