### PR TITLE
docs: Edit wording in note in otelcol.receiver.prometheus

### DIFF
--- a/docs/sources/reference/components/otelcol/otelcol.receiver.prometheus.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.prometheus.md
@@ -22,21 +22,17 @@ You can specify multiple `otelcol.receiver.prometheus` components by giving them
 `otelcol.receiver.prometheus` is a custom component built on a fork of the upstream OpenTelemetry receiver.
 {{< /admonition >}}
 
-
 {{< admonition type="note" >}}
-In {{< param "PRODUCT_NAME" >}} v1.14.0, `otelcol.receiver.prometheus` no longer sets OTLP metric [start times][otlp-start-time] for Prometheus metrics. The receiver forwards metrics without adding start times when the Prometheus input does not have a [created time][om-suffixes].
+In {{< param "PRODUCT_NAME" >}} v1.14.0, `otelcol.receiver.prometheus` no longer sets OTLP metric [start times][otlp-start-time] for Prometheus metrics. The receiver forwards metrics without adding start times when the Prometheus input doesn't have a [created time][om-suffixes].
 
-Start time is a way to tell when a cumulative metric such as an OTLP "sum" or a Prometheus "counter" was last reset.
+Start time indicates when a cumulative metric such as an OTLP "sum" or a Prometheus "counter" was last reset.
 If your database uses start times for OTLP metrics, you can use `otelcol.processor.metric_start_time` to set it.
-Grafana Mimir's OTLP endpoint and Grafana Cloud's OTLP Gateway both support OTLP metric start time.
+The OTLP endpoint for Grafana Mimir and the OTLP Gateway for Grafana Cloud both support OTLP metric start time.
 
-To add the start time in the same way that `otelcol.receiver.prometheus` did it prior to {{< param "PRODUCT_NAME" >}} v1.14.0, 
-configure `otelcol.processor.metric_start_time` with `strategy` set to `true_reset_point`.
+To add the start time in the same way that `otelcol.receiver.prometheus` did prior to {{< param "PRODUCT_NAME" >}} v1.14.0, configure `otelcol.processor.metric_start_time` with `strategy` set to `true_reset_point`.
 
-In practice it is only necessary to use `true_reset_point` if your Mimir/Grafana Cloud instance is explicitly configured with a 
-`-distributor.otel-created-timestamp-zero-ingestion-enabled=true` flag, 
-since `true_reset_point` will send a sample with the same start and end time and Mimir by default won't create a zero sample for it.
-For most Mimir and Grafana Cloud use cases there would be no change in behaviour even if no `otelcol.processor.metric_start_time` is added.
+It's only necessary to use `true_reset_point` if your Mimir or Grafana Cloud instance is explicitly configured with a `-distributor.otel-created-timestamp-zero-ingestion-enabled=true` flag, since `true_reset_point` sends a sample with the same start and end time, and Mimir by default doesn't create a zero sample for it.
+For most Mimir and Grafana Cloud use cases, there's no change in behavior even if you don't add `otelcol.processor.metric_start_time`.
 
 [om-suffixes]: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#suffixes
 [otlp-start-time]: https://github.com/open-telemetry/opentelemetry-proto/blob/v1.9.0/opentelemetry/proto/metrics/v1/metrics.proto#L181-L187


### PR DESCRIPTION
The note in `otelcol.receiver.prometheus` needs general cleanup to align wording better with Grafana styles.

Fixes: https://github.com/grafana/alloy/issues/4783