### PR TITLE
docs: Add helm chart details to OTel Engine docs

### DIFF
--- a/docs/sources/opentelemetry/get-started.md
+++ b/docs/sources/opentelemetry/get-started.md
@@ -175,7 +175,7 @@ ports:
   metrics:
     enabled: true
 
-config:
+alternateConfig:
   extensions:
     health_check:
       endpoint: 0.0.0.0:13133 # This is necessary for the k8s liveliness check
@@ -223,6 +223,11 @@ Replace the following:
 - _`<USERNAME>`_: Your username. If you are using Grafana Cloud this is your Grafana Cloud instance ID.
 - _`<PASSWORD>`_: Your password. If you are using Grafana Cloud this is your Grafana Cloud API token.
 - _`<URL>`_: The URL to export data to. If you are using Grafana Cloud this is your Grafana Cloud OTLP endpoint URL.
+
+The Helm chart ships with a default OpenTelemetry Collector configuration in the `config` field, which is described in the upstream Helm chart [documentation](https://opentelemetry.io/docs/platforms/kubernetes/helm/collector/#configuration).
+If you want to completely override that default configuration, you can use the `alternateConfig` field.
+In the example above, `alternateConfig` field is used to ensure the configuration matches the other examples in this Getting Started document and does not inherit any of the chart’s defaults. 
+Alternatively, you can omit both config and alternateConfig to use the default configuration as-is, or provide your own `config` block that will be merged with the chart’s default configuration.
 
 Refer to the [upstream documentation](https://opentelemetry.io/docs/platforms/kubernetes/helm/collector/) for more information about how to configure the helm chart to work for your use case.
 


### PR DESCRIPTION
Adds a leftover TODO from this [previous PR](https://github.com/grafana/alloy/pull/5404) - this PR adds documentation on how to use the new OTel Engine with the upstream collector helm chart

I've included a basic example that utilizes the same config as the other "getting started" examples to avoid too much confusion, and pointed users to upstream documentation for more information on how to configure the deployment

It also adds a small note on experimental flags

Part of https://github.com/grafana/alloy/issues/4722