### PR TITLE
fix: Add /FORCEREGISTRY flag to windows installer

### DIFF
--- a/docs/sources/set-up/install/windows.md
+++ b/docs/sources/set-up/install/windows.md
@@ -73,8 +73,8 @@ To do a silent install of {{< param "PRODUCT_NAME" >}} on Windows, perform the f
 - `/DISABLEREPORTING=<yes|no>` Disable [data collection][]. Default: `no`
 - `/DISABLEPROFILING=<yes|no>` Disable profiling endpoint. Default: `no`
 - `/ENVIRONMENT="KEY=VALUE\0KEY2=VALUE2"` Define environment variables for Windows Service. Default: ``
-- `/FORCEREGISTRY=yes` Force the installer to write install options such as `/STABILITY` and `/DISABLEREPORTING` to the Windows registry even when upgrading.
-  By default, the installer preserves registry values on upgrade, so options passed during an upgrade aren't applied unless you use this flag.
+- `/FORCEREGISTRY=yes` At the start of installation, delete all Alloy registry keys and then run the rest of the install as normal so that install options such as `/STABILITY` and `/DISABLEREPORTING` are written fresh.
+  By default, the installer preserves existing registry values on upgrade; use this flag to reset them and apply the options passed on the command line, and to remove any old or unused registry keys from previous versions.
 - `/RUNTIMEPRIORITY="normal|below_normal|above_normal|high|idle|realtime"` Set the runtime priority of the {{< param "PRODUCT_NAME" >}} process. Default: `normal`
 - `/STABILITY="generally-available|public-preview|experimental"` Set the stability level of {{< param "PRODUCT_NAME" >}}. Default: `generally-available`
 - `/USERNAME="<username>"` Set the fully qualified user that Windows uses to run the service. Default: `NT AUTHORITY\LocalSystem`

--- a/packaging/windows/install_script.nsis
+++ b/packaging/windows/install_script.nsis
@@ -72,6 +72,14 @@ Section "install"
   # Calls to functions like nsExec::ExecToLog below push the exit code to the
   # stack, and must be popped after calling.
 
+  # When /FORCEREGISTRY=yes, delete all Alloy registry keys at the start so the
+  # rest of the installation can proceed as normal and write fresh values. This
+  # also cleans up any old or unused keys from previous versions.
+  ${If} $ForceRegistry == "yes"
+    nsExec::ExecToLog 'Reg.exe delete "HKLM\SOFTWARE\GrafanaLabs\Alloy" /reg:64 /f'
+    Pop $0
+  ${EndIf}
+
   # Preemptively stop the existing service if it's running.
   nsExec::ExecToLog 'sc stop "Alloy"'
   Pop $0
@@ -176,28 +184,17 @@ Function CreateDataDirectory
     Return
 FunctionEnd
 
-
 # InitializeRegistry initializes the keys in the registry that the service
-# runner uses. If the registry values already exist, they are not overwritten,
-# unless /FORCEREGISTRY=yes was passed.
+# runner uses. If the registry values already exist, they are not overwritten.
 Function InitializeRegistry
   !define REGKEY "HKLM\Software\GrafanaLabs\Alloy"
 
-  # Define the default key, which points to the service. Write when missing or when /FORCEREGISTRY=yes.
+  # Define the default key, which points to the service.
   nsExec::ExecToLog 'Reg.exe query "${REGKEY}" /reg:64 /ve'
   Pop $0
-
   ${If} $0 == 1
-    StrCpy $1 1
-  ${ElseIf} $ForceRegistry == "yes"
-    StrCpy $1 1
-  ${Else}
-    StrCpy $1 0
-  ${EndIf}
-
-  ${If} $1 == 1
-    nsExec::ExecToLog 'Reg.exe add "${REGKEY}" /reg:64 /ve /d "$INSTDIR\alloy-windows-amd64.exe" /f'
-    Pop $0
+    nsExec::ExecToLog 'Reg.exe add "${REGKEY}" /reg:64 /ve /d  "$INSTDIR\alloy-windows-amd64.exe"'
+    Pop $0 # Ignore return result
   ${EndIf}
 
   ${If} $Config != ""
@@ -230,36 +227,22 @@ Function InitializeRegistry
     StrCpy $DisableProfilingFlag ""
   ${EndIf}
 
-  # Define the arguments key, which holds arguments to pass to the service. Write when missing or when /FORCEREGISTRY=yes.
+  # Define the arguments key, which holds arguments to pass to the
+  # service.
   nsExec::ExecToLog 'Reg.exe query "${REGKEY}" /reg:64 /v Arguments'
   Pop $0
-
   ${If} $0 == 1
-    StrCpy $1 1
-  ${ElseIf} $ForceRegistry == "yes"
-    StrCpy $1 1
-  ${Else}
-    StrCpy $1 0
+    nsExec::ExecToLog 'Reg.exe add "${REGKEY}" /reg:64 /v Arguments /t REG_MULTI_SZ /d "run"\0"$ConfigFlag"\0"--storage.path=$APPDATA\GrafanaLabs\${APPNAME}\data"\0"$DisableReportingFlag$DisableProfilingFlag$RuntimePriorityFlag$StabilityFlag"'
+    Pop $0 # Ignore return result
   ${EndIf}
 
-  ${If} $1 == 1
-    nsExec::ExecToLog 'Reg.exe add "${REGKEY}" /reg:64 /v Arguments /t REG_MULTI_SZ /d "run"\0"$ConfigFlag"\0"--storage.path=$APPDATA\GrafanaLabs\${APPNAME}\data"\0"$DisableReportingFlag$DisableProfilingFlag$RuntimePriorityFlag$StabilityFlag" /f'
-    Pop $0
-  ${EndIf}
-
-  # Define the environment key, which holds environment for service. Write when missing or when /FORCEREGISTRY=yes.
   nsExec::ExecToLog 'Reg.exe query "${REGKEY}" /reg:64 /v Environment'
   Pop $0
   ${If} $0 == 1
-    StrCpy $1 1
-  ${ElseIf} $ForceRegistry == "yes"
-    StrCpy $1 1
-  ${Else}
-    StrCpy $1 0
-  ${EndIf}
-
-  ${If} $1 == 1
-      nsExec::ExecToLog 'Reg.exe add "${REGKEY}" /reg:64 /v Environment /t REG_MULTI_SZ /d "$Environment" /f'
+    # Define the environment key, which holds environment variables to pass to the
+    # service.
+    nsExec::ExecToLog 'Reg.exe add "${REGKEY}" /reg:64 /v Environment /t REG_MULTI_SZ /d "$Environment"'
+    Pop $0 # Ignore return result
   ${EndIf}
 
   Return


### PR DESCRIPTION
### Pull Request Details
When using the windows installer to upgrade alloy it's not possible to update arguments, environment etc if it was previously written. I added a flag that will force set these in windows registry.

### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
