### PR TITLE
feat(database_observability): Introduce wait_event_v2 with pre-classified wait event type

### DIFF
--- a/docs/sources/reference/components/database_observability/database_observability.mysql.md
+++ b/docs/sources/reference/components/database_observability/database_observability.mysql.md
@@ -36,7 +36,6 @@ You can use the following arguments with `database_observability.mysql`:
 | `enable_collectors`                        | `list(string)`       | A list of collectors to enable on top of the default set.                   |         | no       |
 | `exclude_schemas`                          | `list(string)`       | A list of schemas to exclude from monitoring.                               | `["alloydbadmin", "alloydbmetadata", "azure_maintenance", "azure_sys", "cloudsqladmin", "rdsadmin"]` | no       |
 | `allow_update_performance_schema_settings` | `boolean`            | Whether to allow updates to `performance_schema` settings in any collector. Enable this in conjunction with other collector-specific settings where required. | `false` | no       |
-| `enable_pre_classified_wait_events` | `boolean` | When `true`, emits `wait_event_v2` entries with `wait_event_type` pre-classified as `IO Wait`, `Lock Wait`, `Network Wait`, or `Other Wait` in the log body, instead of the baseline `wait_event` entries. | `false` | no |
 
 The following collectors are configurable:
 
@@ -169,6 +168,7 @@ The `gcp` block supplies the identifying information for the GCP Cloud SQL datab
 | `setup_consumers_check_interval` | `duration` | How frequently to check if `setup_consumers` are correctly enabled.            | `"1h"`  | no       |
 | `sample_min_duration`            | `duration` | Minimum duration for query samples to be collected. Set to "0s" to disable filtering and collect all samples regardless of their duration.| `"0s"`  | no       |
 | `wait_event_min_duration`        | `duration` | Minimum duration for a wait event to be collected. Set to "0s" to disable filtering and collect all wait events regardless of their duration.  | `"1us"` | no       |
+| `enable_pre_classified_wait_events` | `boolean` | When `true`, emits `wait_event_v2` entries with `wait_event_type` pre-classified as `IO Wait`, `Lock Wait`, `Network Wait`, or `Other Wait` in the log body, instead of the baseline `wait_event` entries. | `false` | no       |
 
 ### `setup_actors`
 

--- a/docs/sources/reference/components/database_observability/database_observability.mysql.md
+++ b/docs/sources/reference/components/database_observability/database_observability.mysql.md
@@ -36,6 +36,7 @@ You can use the following arguments with `database_observability.mysql`:
 | `enable_collectors`                        | `list(string)`       | A list of collectors to enable on top of the default set.                   |         | no       |
 | `exclude_schemas`                          | `list(string)`       | A list of schemas to exclude from monitoring.                               | `["alloydbadmin", "alloydbmetadata", "azure_maintenance", "azure_sys", "cloudsqladmin", "rdsadmin"]` | no       |
 | `allow_update_performance_schema_settings` | `boolean`            | Whether to allow updates to `performance_schema` settings in any collector. Enable this in conjunction with other collector-specific settings where required. | `false` | no       |
+| `enable_pre_classified_wait_events` | `boolean` | When `true`, emits `wait_event_v2` entries with `wait_event_type` pre-classified as `IO Wait`, `Lock Wait`, `Network Wait`, or `Other Wait` in the log body, instead of the baseline `wait_event` entries. | `false` | no |
 
 The following collectors are configurable:
 

--- a/docs/sources/reference/components/database_observability/database_observability.postgres.md
+++ b/docs/sources/reference/components/database_observability/database_observability.postgres.md
@@ -135,11 +135,12 @@ The `gcp` block supplies the identifying information for the GCP Cloud SQL datab
 
 ### `query_samples`
 
-| Name                      | Type       | Description                                                   | Default | Required |
-|---------------------------|------------|---------------------------------------------------------------|---------|----------|
-| `collect_interval`        | `duration` | How frequently to collect information from database.          | `"15s"` | no       |
-| `disable_query_redaction` | `bool`     | Collect unredacted SQL query text (might include parameters). | `false` | no       |
-| `exclude_current_user`    | `bool`     | Do not collect query samples for current database user.       | `true`  | no       |
+| Name                                  | Type       | Description                                                   | Default | Required |
+|---------------------------------------|------------|---------------------------------------------------------------|---------|----------|
+| `collect_interval`                    | `duration` | How frequently to collect information from database.          | `"15s"` | no       |
+| `disable_query_redaction`             | `bool`     | Collect unredacted SQL query text (might include parameters). | `false` | no       |
+| `exclude_current_user`                | `bool`     | Do not collect query samples for current database user.       | `true`  | no       |
+| `enable_pre_classified_wait_events`   | `boolean`  | When `true`, emits `wait_event_v2` entries with `wait_event_type` pre-classified as `IO Wait`, `Lock Wait`, `Network Wait`, or `Other Wait` in the log body, instead of the baseline `wait_event` entries. | `false` | no       |
 
 ### `schema_details`
 

--- a/internal/component/database_observability/mysql/collector/query_samples.go
+++ b/internal/component/database_observability/mysql/collector/query_samples.go
@@ -492,19 +492,26 @@ func (c *QuerySamples) determineTimerClauseAndLimit(uptime float64) (string, flo
 	return timerClause, limit
 }
 
+// classifyMySQLWaitEventType maps a raw MySQL performance_schema wait event name
+// to a standardized category, aligned with the wait taxonomy used elsewhere:
+//
+//	IO Wait      = wait/io/(file|table).+
+//	Network Wait = wait/io/socket.+
+//	Lock Wait    = wait/(io/lock|synch|lock).+
 func classifyMySQLWaitEventType(waitEventName string) string {
 	rest, ok := strings.CutPrefix(waitEventName, "wait/")
 	if !ok {
-		return waitEventName
+		return "Other Wait"
 	}
-	category, _, _ := strings.Cut(rest, "/")
-	switch category {
-	case "io":
+	switch {
+	case strings.HasPrefix(rest, "io/file/"), strings.HasPrefix(rest, "io/table/"):
 		return "IO Wait"
-	case "lock":
+	case strings.HasPrefix(rest, "io/socket/"):
+		return "Network Wait"
+	case strings.HasPrefix(rest, "io/lock/"),
+		strings.HasPrefix(rest, "synch/"),
+		strings.HasPrefix(rest, "lock/"):
 		return "Lock Wait"
-	case "synch":
-		return "Synch Wait"
 	}
-	return waitEventName
+	return "Other Wait"
 }

--- a/internal/component/database_observability/mysql/collector/query_samples.go
+++ b/internal/component/database_observability/mysql/collector/query_samples.go
@@ -427,9 +427,6 @@ func (c *QuerySamples) fetchQuerySamples(ctx context.Context) error {
 					row.WaitEventName.String, classifyMySQLWaitEventType(row.WaitEventName.String),
 					row.WaitObjectName.String, row.WaitObjectType.String, waitTime,
 				)
-				if c.disableQueryRedaction && row.SQLText.Valid {
-					waitV2LogMessage += fmt.Sprintf(` sql_text="%s"`, row.SQLText.String)
-				}
 				c.entryHandler.Chan() <- database_observability.BuildLokiEntryWithTimestamp(
 					logging.LevelInfo, OP_WAIT_EVENT_V2, waitV2LogMessage,
 					int64(millisecondsToNanoseconds(row.TimestampMilliseconds)),
@@ -442,9 +439,6 @@ func (c *QuerySamples) fetchQuerySamples(ctx context.Context) error {
 					row.StatementEventID.String, row.WaitEventID.String, row.WaitEndEventID.String,
 					row.WaitEventName.String, row.WaitObjectName.String, row.WaitObjectType.String, waitTime,
 				)
-				if c.disableQueryRedaction && row.SQLText.Valid {
-					waitLogMessage += fmt.Sprintf(` sql_text="%s"`, row.SQLText.String)
-				}
 				c.entryHandler.Chan() <- database_observability.BuildLokiEntryWithTimestamp(
 					logging.LevelInfo, OP_WAIT_EVENT, waitLogMessage,
 					int64(millisecondsToNanoseconds(row.TimestampMilliseconds)),

--- a/internal/component/database_observability/mysql/collector/query_samples.go
+++ b/internal/component/database_observability/mysql/collector/query_samples.go
@@ -86,16 +86,16 @@ const updateSetupConsumers = `
 		WHERE name in ('events_statements_cpu', 'events_waits_current', 'events_waits_history')`
 
 type QuerySamplesArguments struct {
-	DB                          *sql.DB
-	EngineVersion               semver.Version
-	CollectInterval             time.Duration
-	ExcludeSchemas              []string
-	EntryHandler                loki.EntryHandler
-	DisableQueryRedaction       bool
-	AutoEnableSetupConsumers    bool
-	SetupConsumersCheckInterval time.Duration
-	SampleMinDuration           time.Duration
-	WaitEventMinDuration        time.Duration
+	DB                            *sql.DB
+	EngineVersion                 semver.Version
+	CollectInterval               time.Duration
+	ExcludeSchemas                []string
+	EntryHandler                  loki.EntryHandler
+	DisableQueryRedaction         bool
+	AutoEnableSetupConsumers      bool
+	SetupConsumersCheckInterval   time.Duration
+	SampleMinDuration             time.Duration
+	WaitEventMinDuration          time.Duration
 	EnablePreClassifiedWaitEvents bool
 	WaitEventCounter              *prometheus.CounterVec
 
@@ -103,16 +103,16 @@ type QuerySamplesArguments struct {
 }
 
 type QuerySamples struct {
-	dbConnection                *sql.DB
-	engineVersion               semver.Version
-	collectInterval             time.Duration
-	excludeSchemas              []string
-	entryHandler                loki.EntryHandler
-	disableQueryRedaction       bool
-	autoEnableSetupConsumers    bool
-	setupConsumersCheckInterval time.Duration
-	sampleMinDuration           time.Duration
-	waitEventMinDuration        time.Duration
+	dbConnection                  *sql.DB
+	engineVersion                 semver.Version
+	collectInterval               time.Duration
+	excludeSchemas                []string
+	entryHandler                  loki.EntryHandler
+	disableQueryRedaction         bool
+	autoEnableSetupConsumers      bool
+	setupConsumersCheckInterval   time.Duration
+	sampleMinDuration             time.Duration
+	waitEventMinDuration          time.Duration
 	enablePreClassifiedWaitEvents bool
 	waitEventCounter              *prometheus.CounterVec
 
@@ -128,20 +128,20 @@ type QuerySamples struct {
 
 func NewQuerySamples(args QuerySamplesArguments) (*QuerySamples, error) {
 	c := &QuerySamples{
-		dbConnection:                args.DB,
-		engineVersion:               args.EngineVersion,
-		collectInterval:             args.CollectInterval,
-		excludeSchemas:              args.ExcludeSchemas,
-		entryHandler:                args.EntryHandler,
-		disableQueryRedaction:       args.DisableQueryRedaction,
-		autoEnableSetupConsumers:    args.AutoEnableSetupConsumers,
-		setupConsumersCheckInterval: args.SetupConsumersCheckInterval,
-		sampleMinDuration:           args.SampleMinDuration,
-		waitEventMinDuration:        args.WaitEventMinDuration,
+		dbConnection:                  args.DB,
+		engineVersion:                 args.EngineVersion,
+		collectInterval:               args.CollectInterval,
+		excludeSchemas:                args.ExcludeSchemas,
+		entryHandler:                  args.EntryHandler,
+		disableQueryRedaction:         args.DisableQueryRedaction,
+		autoEnableSetupConsumers:      args.AutoEnableSetupConsumers,
+		setupConsumersCheckInterval:   args.SetupConsumersCheckInterval,
+		sampleMinDuration:             args.SampleMinDuration,
+		waitEventMinDuration:          args.WaitEventMinDuration,
 		enablePreClassifiedWaitEvents: args.EnablePreClassifiedWaitEvents,
 		waitEventCounter:              args.WaitEventCounter,
-		logger:                      log.With(args.Logger, "collector", QuerySamplesCollector),
-		running:                     &atomic.Bool{},
+		logger:                        log.With(args.Logger, "collector", QuerySamplesCollector),
+		running:                       &atomic.Bool{},
 	}
 
 	return c, nil

--- a/internal/component/database_observability/mysql/collector/query_samples.go
+++ b/internal/component/database_observability/mysql/collector/query_samples.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/atomic"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
@@ -21,6 +23,7 @@ const (
 	QuerySamplesCollector = "query_samples"
 	OP_QUERY_SAMPLE       = "query_sample"
 	OP_WAIT_EVENT         = "wait_event"
+	OP_WAIT_EVENT_V2      = "wait_event_v2"
 
 	cpuTimeField              = `, statements.CPU_TIME`
 	maxControlledMemoryField  = `, statements.MAX_CONTROLLED_MEMORY`
@@ -93,6 +96,8 @@ type QuerySamplesArguments struct {
 	SetupConsumersCheckInterval time.Duration
 	SampleMinDuration           time.Duration
 	WaitEventMinDuration        time.Duration
+	EnablePreClassifiedWaitEvents bool
+	WaitEventCounter              *prometheus.CounterVec
 
 	Logger log.Logger
 }
@@ -108,6 +113,8 @@ type QuerySamples struct {
 	setupConsumersCheckInterval time.Duration
 	sampleMinDuration           time.Duration
 	waitEventMinDuration        time.Duration
+	enablePreClassifiedWaitEvents bool
+	waitEventCounter              *prometheus.CounterVec
 
 	logger  log.Logger
 	running *atomic.Bool
@@ -131,6 +138,8 @@ func NewQuerySamples(args QuerySamplesArguments) (*QuerySamples, error) {
 		setupConsumersCheckInterval: args.SetupConsumersCheckInterval,
 		sampleMinDuration:           args.SampleMinDuration,
 		waitEventMinDuration:        args.WaitEventMinDuration,
+		enablePreClassifiedWaitEvents: args.EnablePreClassifiedWaitEvents,
+		waitEventCounter:              args.WaitEventCounter,
 		logger:                      log.With(args.Logger, "collector", QuerySamplesCollector),
 		running:                     &atomic.Bool{},
 	}
@@ -408,28 +417,44 @@ func (c *QuerySamples) fetchQuerySamples(ctx context.Context) error {
 
 		if row.WaitEventID.Valid && row.WaitTime.Valid {
 			waitTime := picosecondsToMilliseconds(row.WaitTime.Float64)
-			waitLogMessage := fmt.Sprintf(
-				`schema="%s" user="%s" client_host="%s" thread_id="%s" digest="%s" event_id="%s" wait_event_id="%s" wait_end_event_id="%s" wait_event_name="%s" wait_object_name="%s" wait_object_type="%s" wait_time="%fms"`,
-				row.Schema.String,
-				row.User.String,
-				row.Host.String,
-				row.ThreadID.String,
-				row.Digest.String,
-				row.StatementEventID.String,
-				row.WaitEventID.String,
-				row.WaitEndEventID.String,
-				row.WaitEventName.String,
-				row.WaitObjectName.String,
-				row.WaitObjectType.String,
-				waitTime,
-			)
 
-			c.entryHandler.Chan() <- database_observability.BuildLokiEntryWithTimestamp(
-				logging.LevelInfo,
-				OP_WAIT_EVENT,
-				waitLogMessage,
-				int64(millisecondsToNanoseconds(row.TimestampMilliseconds)),
-			)
+			if c.enablePreClassifiedWaitEvents {
+				waitV2LogMessage := fmt.Sprintf(
+					`schema="%s" user="%s" client_host="%s" thread_id="%s" digest="%s" event_id="%s" wait_event_id="%s" wait_end_event_id="%s" wait_event_name="%s" wait_event_type="%s" wait_object_name="%s" wait_object_type="%s" wait_time="%fms"`,
+					row.Schema.String, row.User.String, row.Host.String,
+					row.ThreadID.String, row.Digest.String,
+					row.StatementEventID.String, row.WaitEventID.String, row.WaitEndEventID.String,
+					row.WaitEventName.String, classifyMySQLWaitEventType(row.WaitEventName.String),
+					row.WaitObjectName.String, row.WaitObjectType.String, waitTime,
+				)
+				if c.disableQueryRedaction && row.SQLText.Valid {
+					waitV2LogMessage += fmt.Sprintf(` sql_text="%s"`, row.SQLText.String)
+				}
+				c.entryHandler.Chan() <- database_observability.BuildLokiEntryWithTimestamp(
+					logging.LevelInfo, OP_WAIT_EVENT_V2, waitV2LogMessage,
+					int64(millisecondsToNanoseconds(row.TimestampMilliseconds)),
+				)
+			} else {
+				waitLogMessage := fmt.Sprintf(
+					`schema="%s" user="%s" client_host="%s" thread_id="%s" digest="%s" event_id="%s" wait_event_id="%s" wait_end_event_id="%s" wait_event_name="%s" wait_object_name="%s" wait_object_type="%s" wait_time="%fms"`,
+					row.Schema.String, row.User.String, row.Host.String,
+					row.ThreadID.String, row.Digest.String,
+					row.StatementEventID.String, row.WaitEventID.String, row.WaitEndEventID.String,
+					row.WaitEventName.String, row.WaitObjectName.String, row.WaitObjectType.String, waitTime,
+				)
+				if c.disableQueryRedaction && row.SQLText.Valid {
+					waitLogMessage += fmt.Sprintf(` sql_text="%s"`, row.SQLText.String)
+				}
+				c.entryHandler.Chan() <- database_observability.BuildLokiEntryWithTimestamp(
+					logging.LevelInfo, OP_WAIT_EVENT, waitLogMessage,
+					int64(millisecondsToNanoseconds(row.TimestampMilliseconds)),
+				)
+			}
+
+			if c.waitEventCounter != nil {
+				waitTimeSeconds := waitTime / 1000.0 // waitTime is in ms
+				c.waitEventCounter.WithLabelValues(row.Digest.String, row.Schema.String).Add(waitTimeSeconds)
+			}
 		}
 	}
 
@@ -471,4 +496,21 @@ func (c *QuerySamples) determineTimerClauseAndLimit(uptime float64) (string, flo
 	limit := uptimeSinceOverflow(uptime)
 
 	return timerClause, limit
+}
+
+func classifyMySQLWaitEventType(waitEventName string) string {
+	rest, ok := strings.CutPrefix(waitEventName, "wait/")
+	if !ok {
+		return waitEventName
+	}
+	category, _, _ := strings.Cut(rest, "/")
+	switch category {
+	case "io":
+		return "IO Wait"
+	case "lock":
+		return "Lock Wait"
+	case "synch":
+		return "Synch Wait"
+	}
+	return waitEventName
 }

--- a/internal/component/database_observability/mysql/collector/query_samples_test.go
+++ b/internal/component/database_observability/mysql/collector/query_samples_test.go
@@ -2991,13 +2991,15 @@ func TestClassifyMySQLWaitEventType(t *testing.T) {
 	}{
 		{"wait/io/file/innodb/innodb_data_file", "IO Wait"},
 		{"wait/io/table/sql/handler", "IO Wait"},
+		{"wait/io/socket/sql/client_connection", "Network Wait"},
+		{"wait/io/lock/table/handler", "Lock Wait"},
 		{"wait/lock/table/sql/handler", "Lock Wait"},
 		{"wait/lock/metadata/sql/mdl", "Lock Wait"},
-		{"wait/synch/mutex/sql/LOCK_open", "Synch Wait"},
-		{"wait/synch/rwlock/sql/LOCK_system_variables", "Synch Wait"},
-		{"wait/unknown/something", "wait/unknown/something"},
-		{"not_a_wait_event", "not_a_wait_event"},
-		{"", ""},
+		{"wait/synch/mutex/sql/LOCK_open", "Lock Wait"},
+		{"wait/synch/rwlock/sql/LOCK_system_variables", "Lock Wait"},
+		{"wait/unknown/something", "Other Wait"},
+		{"not_a_wait_event", "Other Wait"},
+		{"", "Other Wait"},
 	}
 
 	for _, tc := range tests {

--- a/internal/component/database_observability/mysql/collector/query_samples_test.go
+++ b/internal/component/database_observability/mysql/collector/query_samples_test.go
@@ -847,7 +847,7 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 		assert.Equal(t, model.LabelSet{"op": OP_QUERY_SAMPLE}, lokiEntries[0].Labels)
 		assert.Equal(t, "level=\"info\" schema=\"some_schema\" user=\"some_user\" client_host=\"some_host\" thread_id=\"890\" event_id=\"123\" end_event_id=\"234\" digest=\"some_digest\" rows_examined=\"5\" rows_sent=\"5\" rows_affected=\"0\" errors=\"0\" max_controlled_memory=\"456b\" max_total_memory=\"457b\" cpu_time=\"0.010000ms\" elapsed_time=\"0.020000ms\" elapsed_time_ms=\"0.020000ms\" sql_text=\"select * from some_table where id = 1\"", lokiEntries[0].Line)
 		assert.Equal(t, model.LabelSet{"op": OP_WAIT_EVENT}, lokiEntries[1].Labels)
-		assert.Equal(t, "level=\"info\" schema=\"some_schema\" user=\"some_user\" client_host=\"some_host\" thread_id=\"890\" digest=\"some_digest\" event_id=\"123\" wait_event_id=\"124\" wait_end_event_id=\"125\" wait_event_name=\"wait/io/file/innodb/innodb_data_file\" wait_object_name=\"wait_object_name\" wait_object_type=\"wait_object_type\" wait_time=\"0.100000ms\" sql_text=\"select * from some_table where id = 1\"", lokiEntries[1].Line)
+		assert.Equal(t, "level=\"info\" schema=\"some_schema\" user=\"some_user\" client_host=\"some_host\" thread_id=\"890\" digest=\"some_digest\" event_id=\"123\" wait_event_id=\"124\" wait_end_event_id=\"125\" wait_event_name=\"wait/io/file/innodb/innodb_data_file\" wait_object_name=\"wait_object_name\" wait_object_type=\"wait_object_type\" wait_time=\"0.100000ms\"", lokiEntries[1].Line)
 	})
 
 	t.Run("wait event below wait_min_duration is filtered by SQL", func(t *testing.T) {

--- a/internal/component/database_observability/mysql/collector/query_samples_test.go
+++ b/internal/component/database_observability/mysql/collector/query_samples_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/blang/semver/v4"
 	"github.com/go-kit/log"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -845,7 +847,7 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 		assert.Equal(t, model.LabelSet{"op": OP_QUERY_SAMPLE}, lokiEntries[0].Labels)
 		assert.Equal(t, "level=\"info\" schema=\"some_schema\" user=\"some_user\" client_host=\"some_host\" thread_id=\"890\" event_id=\"123\" end_event_id=\"234\" digest=\"some_digest\" rows_examined=\"5\" rows_sent=\"5\" rows_affected=\"0\" errors=\"0\" max_controlled_memory=\"456b\" max_total_memory=\"457b\" cpu_time=\"0.010000ms\" elapsed_time=\"0.020000ms\" elapsed_time_ms=\"0.020000ms\" sql_text=\"select * from some_table where id = 1\"", lokiEntries[0].Line)
 		assert.Equal(t, model.LabelSet{"op": OP_WAIT_EVENT}, lokiEntries[1].Labels)
-		assert.Equal(t, "level=\"info\" schema=\"some_schema\" user=\"some_user\" client_host=\"some_host\" thread_id=\"890\" digest=\"some_digest\" event_id=\"123\" wait_event_id=\"124\" wait_end_event_id=\"125\" wait_event_name=\"wait/io/file/innodb/innodb_data_file\" wait_object_name=\"wait_object_name\" wait_object_type=\"wait_object_type\" wait_time=\"0.100000ms\"", lokiEntries[1].Line)
+		assert.Equal(t, "level=\"info\" schema=\"some_schema\" user=\"some_user\" client_host=\"some_host\" thread_id=\"890\" digest=\"some_digest\" event_id=\"123\" wait_event_id=\"124\" wait_end_event_id=\"125\" wait_event_name=\"wait/io/file/innodb/innodb_data_file\" wait_object_name=\"wait_object_name\" wait_object_type=\"wait_object_type\" wait_time=\"0.100000ms\" sql_text=\"select * from some_table where id = 1\"", lokiEntries[1].Line)
 	})
 
 	t.Run("wait event below wait_min_duration is filtered by SQL", func(t *testing.T) {
@@ -2848,4 +2850,243 @@ func TestQuerySamplesExcludeSchemas(t *testing.T) {
 
 	c.fetchQuerySamples(t.Context())
 	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestQuerySamples_WaitEvents_PreClassified(t *testing.T) {
+	t.Run("flag OFF emits only OP_WAIT_EVENT without wait_event_type", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki.NewCollectingHandler()
+
+		collector, err := NewQuerySamples(QuerySamplesArguments{
+			DB:                           db,
+			EngineVersion:                latestCompatibleVersion,
+			CollectInterval:              time.Second,
+			EntryHandler:                 lokiClient,
+			Logger:                       log.NewLogfmtLogger(os.Stderr),
+			EnablePreClassifiedWaitEvents: false,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+
+		mock.ExpectQuery(selectUptime).WithoutArgs().RowsWillBeClosed().WillReturnRows(sqlmock.NewRows([]string{"uptime"}).AddRow("1"))
+		mock.ExpectQuery(selectNowAndUptime).WithoutArgs().WillReturnRows(sqlmock.NewRows([]string{"now", "uptime"}).AddRow(5, 1))
+		mock.ExpectQuery(fmt.Sprintf(selectQuerySamples, cpuTimeField+maxControlledMemoryField+maxTotalMemoryField, "", exclusionClause, digestTextNotNullClause, "", endOfTimeline)).WithArgs(
+			1e12, 1e12,
+		).RowsWillBeClosed().WillReturnRows(
+			sqlmock.NewRows([]string{
+				"statements.CURRENT_SCHEMA", "statements.THREAD_ID", "statements.EVENT_ID",
+				"statements.END_EVENT_ID", "statements.DIGEST", "statements.TIMER_END",
+				"statements.TIMER_WAIT", "statements.ROWS_EXAMINED", "statements.ROWS_SENT",
+				"statements.ROWS_AFFECTED", "statements.ERRORS",
+				"waits.event_id", "waits.end_event_id", "waits.event_name",
+				"waits.object_name", "waits.object_type", "waits.timer_wait",
+				"threads.PROCESSLIST_USER", "threads.PROCESSLIST_HOST",
+				"statements.CPU_TIME", "statements.MAX_CONTROLLED_MEMORY", "statements.MAX_TOTAL_MEMORY",
+			}).AddRow(
+				"some_schema", "890", "123", "234", "some_digest",
+				"70000000", "20000000", "5", "5", "0", "0",
+				"124", "124", "wait/io/file/innodb/innodb_data_file",
+				"wait_object_name", "wait_object_type", "100000000",
+				"some_user", "some_host",
+				"10000000", "456", "457",
+			),
+		)
+
+		err = collector.Start(t.Context())
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 2
+		}, 5*time.Second, 100*time.Millisecond)
+
+		collector.Stop()
+		lokiClient.Stop()
+
+		require.Eventually(t, func() bool {
+			return collector.Stopped()
+		}, 5*time.Second, 100*time.Millisecond)
+
+		require.NoError(t, mock.ExpectationsWereMet())
+
+		lokiEntries := lokiClient.Received()
+		require.Len(t, lokiEntries, 2)
+		assert.Equal(t, model.LabelSet{"op": OP_WAIT_EVENT}, lokiEntries[1].Labels)
+		assert.NotContains(t, lokiEntries[1].Line, "wait_event_type=")
+	})
+
+	t.Run("flag ON emits only OP_WAIT_EVENT_V2 with wait_event_type classified", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki.NewCollectingHandler()
+
+		collector, err := NewQuerySamples(QuerySamplesArguments{
+			DB:                           db,
+			EngineVersion:                latestCompatibleVersion,
+			CollectInterval:              time.Second,
+			EntryHandler:                 lokiClient,
+			Logger:                       log.NewLogfmtLogger(os.Stderr),
+			EnablePreClassifiedWaitEvents: true,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+
+		mock.ExpectQuery(selectUptime).WithoutArgs().RowsWillBeClosed().WillReturnRows(sqlmock.NewRows([]string{"uptime"}).AddRow("1"))
+		mock.ExpectQuery(selectNowAndUptime).WithoutArgs().WillReturnRows(sqlmock.NewRows([]string{"now", "uptime"}).AddRow(5, 1))
+		mock.ExpectQuery(fmt.Sprintf(selectQuerySamples, cpuTimeField+maxControlledMemoryField+maxTotalMemoryField, "", exclusionClause, digestTextNotNullClause, "", endOfTimeline)).WithArgs(
+			1e12, 1e12,
+		).RowsWillBeClosed().WillReturnRows(
+			sqlmock.NewRows([]string{
+				"statements.CURRENT_SCHEMA", "statements.THREAD_ID", "statements.EVENT_ID",
+				"statements.END_EVENT_ID", "statements.DIGEST", "statements.TIMER_END",
+				"statements.TIMER_WAIT", "statements.ROWS_EXAMINED", "statements.ROWS_SENT",
+				"statements.ROWS_AFFECTED", "statements.ERRORS",
+				"waits.event_id", "waits.end_event_id", "waits.event_name",
+				"waits.object_name", "waits.object_type", "waits.timer_wait",
+				"threads.PROCESSLIST_USER", "threads.PROCESSLIST_HOST",
+				"statements.CPU_TIME", "statements.MAX_CONTROLLED_MEMORY", "statements.MAX_TOTAL_MEMORY",
+			}).AddRow(
+				"some_schema", "890", "123", "234", "some_digest",
+				"70000000", "20000000", "5", "5", "0", "0",
+				"124", "124", "wait/io/file/innodb/innodb_data_file",
+				"wait_object_name", "wait_object_type", "100000000",
+				"some_user", "some_host",
+				"10000000", "456", "457",
+			),
+		)
+
+		err = collector.Start(t.Context())
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 2
+		}, 5*time.Second, 100*time.Millisecond)
+
+		collector.Stop()
+		lokiClient.Stop()
+
+		require.Eventually(t, func() bool {
+			return collector.Stopped()
+		}, 5*time.Second, 100*time.Millisecond)
+
+		require.NoError(t, mock.ExpectationsWereMet())
+
+		lokiEntries := lokiClient.Received()
+		require.Len(t, lokiEntries, 2)
+		assert.Equal(t, model.LabelSet{"op": OP_WAIT_EVENT_V2}, lokiEntries[1].Labels)
+		assert.Contains(t, lokiEntries[1].Line, `wait_event_type="IO Wait"`)
+		// structured metadata labels should not contain wait_event_type
+		assert.NotContains(t, string(lokiEntries[1].Labels["wait_event_type"]), "IO Wait")
+	})
+}
+
+func TestClassifyMySQLWaitEventType(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"wait/io/file/innodb/innodb_data_file", "IO Wait"},
+		{"wait/io/table/sql/handler", "IO Wait"},
+		{"wait/lock/table/sql/handler", "Lock Wait"},
+		{"wait/lock/metadata/sql/mdl", "Lock Wait"},
+		{"wait/synch/mutex/sql/LOCK_open", "Synch Wait"},
+		{"wait/synch/rwlock/sql/LOCK_system_variables", "Synch Wait"},
+		{"wait/unknown/something", "wait/unknown/something"},
+		{"not_a_wait_event", "not_a_wait_event"},
+		{"", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			result := classifyMySQLWaitEventType(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestQuerySamples_WaitEventCounter(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lokiClient := loki.NewCollectingHandler()
+
+	// Create a 3-label counter and curry with server_id
+	fullCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "database_observability_wait_event_seconds_total_test",
+		Help: "Test counter",
+	}, []string{"server_id", "digest", "schema"})
+
+	curriedCounter, err := fullCounter.CurryWith(prometheus.Labels{"server_id": "test-server"})
+	require.NoError(t, err)
+
+	collector, err := NewQuerySamples(QuerySamplesArguments{
+		DB:               db,
+		EngineVersion:    latestCompatibleVersion,
+		CollectInterval:  time.Second,
+		EntryHandler:     lokiClient,
+		Logger:           log.NewLogfmtLogger(os.Stderr),
+		WaitEventCounter: curriedCounter,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, collector)
+
+	mock.ExpectQuery(selectUptime).WithoutArgs().RowsWillBeClosed().WillReturnRows(sqlmock.NewRows([]string{"uptime"}).AddRow("1"))
+	mock.ExpectQuery(selectNowAndUptime).WithoutArgs().WillReturnRows(sqlmock.NewRows([]string{"now", "uptime"}).AddRow(5, 1))
+	mock.ExpectQuery(fmt.Sprintf(selectQuerySamples, cpuTimeField+maxControlledMemoryField+maxTotalMemoryField, "", exclusionClause, digestTextNotNullClause, "", endOfTimeline)).WithArgs(
+		1e12, 1e12,
+	).RowsWillBeClosed().WillReturnRows(
+		sqlmock.NewRows([]string{
+			"statements.CURRENT_SCHEMA", "statements.THREAD_ID", "statements.EVENT_ID",
+			"statements.END_EVENT_ID", "statements.DIGEST", "statements.TIMER_END",
+			"statements.TIMER_WAIT", "statements.ROWS_EXAMINED", "statements.ROWS_SENT",
+			"statements.ROWS_AFFECTED", "statements.ERRORS",
+			"waits.event_id", "waits.end_event_id", "waits.event_name",
+			"waits.object_name", "waits.object_type", "waits.timer_wait",
+			"threads.PROCESSLIST_USER", "threads.PROCESSLIST_HOST",
+			"statements.CPU_TIME", "statements.MAX_CONTROLLED_MEMORY", "statements.MAX_TOTAL_MEMORY",
+		}).AddRow(
+			// 100000000 ps = 0.1 ms = 0.0001 s
+			"some_schema", "890", "123", "234", "some_digest",
+			"70000000", "20000000", "5", "5", "0", "0",
+			"124", "124", "wait/io/file/innodb/innodb_data_file",
+			"wait_object_name", "wait_object_type", "100000000",
+			"some_user", "some_host",
+			"10000000", "456", "457",
+		),
+	)
+
+	err = collector.Start(t.Context())
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return len(lokiClient.Received()) == 2
+	}, 5*time.Second, 100*time.Millisecond)
+
+	collector.Stop()
+	lokiClient.Stop()
+
+	require.Eventually(t, func() bool {
+		return collector.Stopped()
+	}, 5*time.Second, 100*time.Millisecond)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+
+	// Verify the counter was incremented with the correct labels and value
+	// 100000000 ps -> 0.1 ms -> 0.0001 s
+	counter, err := fullCounter.GetMetricWith(prometheus.Labels{
+		"server_id": "test-server",
+		"digest":    "some_digest",
+		"schema":    "some_schema",
+	})
+	require.NoError(t, err)
+
+	// Use dto to read the counter value
+	var metric dto.Metric
+	require.NoError(t, counter.Write(&metric))
+	assert.InDelta(t, 0.0001, metric.Counter.GetValue(), 1e-9)
 }

--- a/internal/component/database_observability/mysql/collector/query_samples_test.go
+++ b/internal/component/database_observability/mysql/collector/query_samples_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/blang/semver/v4"
 	"github.com/go-kit/log"
-	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -2861,11 +2861,11 @@ func TestQuerySamples_WaitEvents_PreClassified(t *testing.T) {
 		lokiClient := loki.NewCollectingHandler()
 
 		collector, err := NewQuerySamples(QuerySamplesArguments{
-			DB:                           db,
-			EngineVersion:                latestCompatibleVersion,
-			CollectInterval:              time.Second,
-			EntryHandler:                 lokiClient,
-			Logger:                       log.NewLogfmtLogger(os.Stderr),
+			DB:                            db,
+			EngineVersion:                 latestCompatibleVersion,
+			CollectInterval:               time.Second,
+			EntryHandler:                  lokiClient,
+			Logger:                        log.NewLogfmtLogger(os.Stderr),
 			EnablePreClassifiedWaitEvents: false,
 		})
 		require.NoError(t, err)
@@ -2925,11 +2925,11 @@ func TestQuerySamples_WaitEvents_PreClassified(t *testing.T) {
 		lokiClient := loki.NewCollectingHandler()
 
 		collector, err := NewQuerySamples(QuerySamplesArguments{
-			DB:                           db,
-			EngineVersion:                latestCompatibleVersion,
-			CollectInterval:              time.Second,
-			EntryHandler:                 lokiClient,
-			Logger:                       log.NewLogfmtLogger(os.Stderr),
+			DB:                            db,
+			EngineVersion:                 latestCompatibleVersion,
+			CollectInterval:               time.Second,
+			EntryHandler:                  lokiClient,
+			Logger:                        log.NewLogfmtLogger(os.Stderr),
 			EnablePreClassifiedWaitEvents: true,
 		})
 		require.NoError(t, err)

--- a/internal/component/database_observability/mysql/component.go
+++ b/internal/component/database_observability/mysql/component.go
@@ -67,8 +67,6 @@ type Arguments struct {
 	DisableCollectors             []string            `alloy:"disable_collectors,attr,optional"`
 	ExcludeSchemas                []string            `alloy:"exclude_schemas,attr,optional"`
 	AllowUpdatePerfSchemaSettings bool                `alloy:"allow_update_performance_schema_settings,attr,optional"`
-	// Temporary feature flag for pre-classified wait event emission. Will be removed before Alloy 1.14.0.
-	EnablePreClassifiedWaitEvents bool `alloy:"enable_pre_classified_wait_events,attr,optional"`
 
 	CloudProvider           *CloudProvider               `alloy:"cloud_provider,block,optional"`
 	SetupConsumersArguments SetupConsumersArguments      `alloy:"setup_consumers,block,optional"`
@@ -141,6 +139,8 @@ type QuerySamplesArguments struct {
 	SetupConsumersCheckInterval time.Duration `alloy:"setup_consumers_check_interval,attr,optional"`
 	SampleMinDuration           time.Duration `alloy:"sample_min_duration,attr,optional"`
 	WaitEventMinDuration        time.Duration `alloy:"wait_event_min_duration,attr,optional"`
+	// Temporary feature flag for pre-classified wait event emission. Will be removed before Alloy 1.14.0.
+	EnablePreClassifiedWaitEvents bool `alloy:"enable_pre_classified_wait_events,attr,optional"`
 }
 
 type HealthCheckArguments struct {
@@ -642,7 +642,7 @@ func (c *Component) startCollectors(serverID string, engineVersion string, parse
 			SetupConsumersCheckInterval:   c.args.QuerySamplesArguments.SetupConsumersCheckInterval,
 			SampleMinDuration:             c.args.QuerySamplesArguments.SampleMinDuration,
 			WaitEventMinDuration:          c.args.QuerySamplesArguments.WaitEventMinDuration,
-			EnablePreClassifiedWaitEvents: c.args.EnablePreClassifiedWaitEvents,
+			EnablePreClassifiedWaitEvents: c.args.QuerySamplesArguments.EnablePreClassifiedWaitEvents,
 			WaitEventCounter:              curriedCounter,
 		})
 		if err != nil {

--- a/internal/component/database_observability/mysql/component.go
+++ b/internal/component/database_observability/mysql/component.go
@@ -292,6 +292,14 @@ func new(opts component.Options, args Arguments, openFn func(driverName, dataSou
 		registry:  prometheus.NewRegistry(),
 		healthErr: atomic.NewString(""),
 		openSQL:   openFn,
+		waitEventCounter: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "database_observability_wait_event_seconds_total",
+			Help: "Total wait time in seconds per query, aggregated by server, query digest, and database.",
+		}, []string{"server_id", "digest", "schema"}),
+	}
+
+	if err := c.registry.Register(c.waitEventCounter); err != nil {
+		return nil, fmt.Errorf("failed to register wait event counter: %w", err)
 	}
 
 	instance, err := instanceKey(string(args.DataSourceName))
@@ -617,33 +625,23 @@ func (c *Component) startCollectors(serverID string, engineVersion string, parse
 			level.Warn(c.opts.Logger).Log("msg", "wait_event_min_duration is greater than sample_min_duration, which may result in query samples with no associated wait events")
 		}
 
-		if c.waitEventCounter != nil {
-			c.registry.Unregister(c.waitEventCounter)
-		}
-		c.waitEventCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "database_observability_wait_event_seconds_total",
-			Help: "Total wait time in seconds per query, aggregated by server, query digest, and database.",
-		}, []string{"server_id", "digest", "schema"})
-		if err := c.registry.Register(c.waitEventCounter); err != nil {
-			level.Warn(c.opts.Logger).Log("msg", "failed to register wait event counter", "err", err)
-		}
 		curriedCounter, err := c.waitEventCounter.CurryWith(prometheus.Labels{"server_id": serverID})
 		if err != nil {
-			level.Warn(c.opts.Logger).Log("msg", "failed to curry wait event counter", "err", err)
+			return fmt.Errorf("failed to curry wait event counter with server_id=%q: %w", serverID, err)
 		}
 
 		qsCollector, err := collector.NewQuerySamples(collector.QuerySamplesArguments{
-			DB:                          c.dbConnection,
-			EngineVersion:               parsedEngineVersion,
-			CollectInterval:             c.args.QuerySamplesArguments.CollectInterval,
-			ExcludeSchemas:              c.args.ExcludeSchemas,
-			EntryHandler:                entryHandler,
-			Logger:                      c.opts.Logger,
-			DisableQueryRedaction:       c.args.QuerySamplesArguments.DisableQueryRedaction,
-			AutoEnableSetupConsumers:    c.args.AllowUpdatePerfSchemaSettings && c.args.QuerySamplesArguments.AutoEnableSetupConsumers,
-			SetupConsumersCheckInterval: c.args.QuerySamplesArguments.SetupConsumersCheckInterval,
-			SampleMinDuration:           c.args.QuerySamplesArguments.SampleMinDuration,
-			WaitEventMinDuration:        c.args.QuerySamplesArguments.WaitEventMinDuration,
+			DB:                            c.dbConnection,
+			EngineVersion:                 parsedEngineVersion,
+			CollectInterval:               c.args.QuerySamplesArguments.CollectInterval,
+			ExcludeSchemas:                c.args.ExcludeSchemas,
+			EntryHandler:                  entryHandler,
+			Logger:                        c.opts.Logger,
+			DisableQueryRedaction:         c.args.QuerySamplesArguments.DisableQueryRedaction,
+			AutoEnableSetupConsumers:      c.args.AllowUpdatePerfSchemaSettings && c.args.QuerySamplesArguments.AutoEnableSetupConsumers,
+			SetupConsumersCheckInterval:   c.args.QuerySamplesArguments.SetupConsumersCheckInterval,
+			SampleMinDuration:             c.args.QuerySamplesArguments.SampleMinDuration,
+			WaitEventMinDuration:          c.args.QuerySamplesArguments.WaitEventMinDuration,
 			EnablePreClassifiedWaitEvents: c.args.EnablePreClassifiedWaitEvents,
 			WaitEventCounter:              curriedCounter,
 		})

--- a/internal/component/database_observability/mysql/component.go
+++ b/internal/component/database_observability/mysql/component.go
@@ -67,6 +67,8 @@ type Arguments struct {
 	DisableCollectors             []string            `alloy:"disable_collectors,attr,optional"`
 	ExcludeSchemas                []string            `alloy:"exclude_schemas,attr,optional"`
 	AllowUpdatePerfSchemaSettings bool                `alloy:"allow_update_performance_schema_settings,attr,optional"`
+	// Temporary feature flag for pre-classified wait event emission. Will be removed before Alloy 1.14.0.
+	EnablePreClassifiedWaitEvents bool `alloy:"enable_pre_classified_wait_events,attr,optional"`
 
 	CloudProvider           *CloudProvider               `alloy:"cloud_provider,block,optional"`
 	SetupConsumersArguments SetupConsumersArguments      `alloy:"setup_consumers,block,optional"`
@@ -274,6 +276,7 @@ type Component struct {
 	healthErr         *atomic.String
 	openSQL           func(driverName, dataSourceName string) (*sql.DB, error)
 	exporterCollector prometheus.Collector
+	waitEventCounter  *prometheus.CounterVec
 }
 
 func New(opts component.Options, args Arguments) (*Component, error) {
@@ -614,6 +617,21 @@ func (c *Component) startCollectors(serverID string, engineVersion string, parse
 			level.Warn(c.opts.Logger).Log("msg", "wait_event_min_duration is greater than sample_min_duration, which may result in query samples with no associated wait events")
 		}
 
+		if c.waitEventCounter != nil {
+			c.registry.Unregister(c.waitEventCounter)
+		}
+		c.waitEventCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "database_observability_wait_event_seconds_total",
+			Help: "Total wait time in seconds per query, aggregated by server, query digest, and database.",
+		}, []string{"server_id", "digest", "schema"})
+		if err := c.registry.Register(c.waitEventCounter); err != nil {
+			level.Warn(c.opts.Logger).Log("msg", "failed to register wait event counter", "err", err)
+		}
+		curriedCounter, err := c.waitEventCounter.CurryWith(prometheus.Labels{"server_id": serverID})
+		if err != nil {
+			level.Warn(c.opts.Logger).Log("msg", "failed to curry wait event counter", "err", err)
+		}
+
 		qsCollector, err := collector.NewQuerySamples(collector.QuerySamplesArguments{
 			DB:                          c.dbConnection,
 			EngineVersion:               parsedEngineVersion,
@@ -626,6 +644,8 @@ func (c *Component) startCollectors(serverID string, engineVersion string, parse
 			SetupConsumersCheckInterval: c.args.QuerySamplesArguments.SetupConsumersCheckInterval,
 			SampleMinDuration:           c.args.QuerySamplesArguments.SampleMinDuration,
 			WaitEventMinDuration:        c.args.QuerySamplesArguments.WaitEventMinDuration,
+			EnablePreClassifiedWaitEvents: c.args.EnablePreClassifiedWaitEvents,
+			WaitEventCounter:              curriedCounter,
 		})
 		if err != nil {
 			logStartError(collector.QuerySamplesCollector, "create", err)

--- a/internal/component/database_observability/postgres/collector/query_samples.go
+++ b/internal/component/database_observability/postgres/collector/query_samples.go
@@ -23,6 +23,7 @@ const (
 	QuerySamplesCollector = "query_samples"
 	OP_QUERY_SAMPLE       = "query_sample"
 	OP_WAIT_EVENT         = "wait_event"
+	OP_WAIT_EVENT_V2      = "wait_event_v2"
 )
 
 const (
@@ -101,24 +102,26 @@ type QuerySamplesInfo struct {
 }
 
 type QuerySamplesArguments struct {
-	DB                    *sql.DB
-	CollectInterval       time.Duration
-	ExcludeDatabases      []string
-	ExcludeUsers          []string
-	EntryHandler          loki.EntryHandler
-	Logger                log.Logger
-	DisableQueryRedaction bool
-	ExcludeCurrentUser    bool
+	DB                            *sql.DB
+	CollectInterval               time.Duration
+	ExcludeDatabases              []string
+	ExcludeUsers                  []string
+	EntryHandler                  loki.EntryHandler
+	Logger                        log.Logger
+	DisableQueryRedaction         bool
+	ExcludeCurrentUser            bool
+	EnablePreClassifiedWaitEvents bool
 }
 
 type QuerySamples struct {
-	dbConnection          *sql.DB
-	collectInterval       time.Duration
-	excludeDatabases      []string
-	excludeUsers          []string
-	entryHandler          loki.EntryHandler
-	disableQueryRedaction bool
-	excludeCurrentUser    bool
+	dbConnection                  *sql.DB
+	collectInterval               time.Duration
+	excludeDatabases              []string
+	excludeUsers                  []string
+	entryHandler                  loki.EntryHandler
+	disableQueryRedaction         bool
+	excludeCurrentUser            bool
+	enablePreClassifiedWaitEvents bool
 
 	logger  log.Logger
 	running *atomic.Bool
@@ -221,17 +224,18 @@ func NewQuerySamples(args QuerySamplesArguments) (*QuerySamples, error) {
 	const emittedCacheTTL = 10 * time.Minute
 
 	return &QuerySamples{
-		dbConnection:          args.DB,
-		collectInterval:       args.CollectInterval,
-		excludeDatabases:      args.ExcludeDatabases,
-		excludeUsers:          args.ExcludeUsers,
-		entryHandler:          args.EntryHandler,
-		disableQueryRedaction: args.DisableQueryRedaction,
-		excludeCurrentUser:    args.ExcludeCurrentUser,
-		logger:                log.With(args.Logger, "collector", QuerySamplesCollector),
-		running:               &atomic.Bool{},
-		samples:               map[SampleKey]*SampleState{},
-		idleEmitted:           expirable.NewLRU[SampleKey, struct{}](emittedCacheSize, nil, emittedCacheTTL),
+		dbConnection:                  args.DB,
+		collectInterval:               args.CollectInterval,
+		excludeDatabases:              args.ExcludeDatabases,
+		excludeUsers:                  args.ExcludeUsers,
+		entryHandler:                  args.EntryHandler,
+		disableQueryRedaction:         args.DisableQueryRedaction,
+		excludeCurrentUser:            args.ExcludeCurrentUser,
+		enablePreClassifiedWaitEvents: args.EnablePreClassifiedWaitEvents,
+		logger:                        log.With(args.Logger, "collector", QuerySamplesCollector),
+		running:                       &atomic.Bool{},
+		samples:                       map[SampleKey]*SampleState{},
+		idleEmitted:                   expirable.NewLRU[SampleKey, struct{}](emittedCacheSize, nil, emittedCacheTTL),
 	}, nil
 }
 
@@ -484,13 +488,21 @@ func (c *QuerySamples) emitAndDeleteSample(key SampleKey) {
 		if we.WaitEventType == "" || we.WaitEvent == "" {
 			continue
 		}
-		waitEventLabels := c.buildWaitEventLabels(state, we)
-		c.entryHandler.Chan() <- database_observability.BuildLokiEntryWithTimestamp(
-			logging.LevelInfo,
-			OP_WAIT_EVENT,
-			waitEventLabels,
-			we.LastTimestamp.UnixNano(),
-		)
+		if c.enablePreClassifiedWaitEvents {
+			c.entryHandler.Chan() <- database_observability.BuildLokiEntryWithTimestamp(
+				logging.LevelInfo,
+				OP_WAIT_EVENT_V2,
+				c.buildWaitEventV2Labels(state, we),
+				we.LastTimestamp.UnixNano(),
+			)
+		} else {
+			c.entryHandler.Chan() <- database_observability.BuildLokiEntryWithTimestamp(
+				logging.LevelInfo,
+				OP_WAIT_EVENT,
+				c.buildWaitEventLabels(state, we),
+				we.LastTimestamp.UnixNano(),
+			)
+		}
 	}
 
 	delete(c.samples, key)
@@ -605,4 +617,43 @@ func isIdleState(state string) bool {
 		return true
 	}
 	return false
+}
+
+func (c *QuerySamples) buildWaitEventV2Labels(state *SampleState, we WaitEventOccurrence) string {
+	waitEventFullName := fmt.Sprintf("%s:%s", we.WaitEventType, we.WaitEvent)
+	leaderPID := ""
+	if state.LastRow.LeaderPID.Valid {
+		leaderPID = fmt.Sprintf(`%d`, state.LastRow.LeaderPID.Int64)
+	}
+	return fmt.Sprintf(
+		`datname="%s" pid="%d" leader_pid="%s" user="%s" backend_type="%s" state="%s" xid="%d" xmin="%d" wait_time="%s" wait_event_type="%s" wait_event="%s" wait_event_name="%s" blocked_by_pids="%v" queryid="%d"`,
+		state.LastRow.DatabaseName.String,
+		state.LastRow.PID,
+		leaderPID,
+		state.LastRow.Username.String,
+		state.LastRow.BackendType.String,
+		we.LastState,
+		state.LastRow.BackendXID.Int64,
+		state.LastRow.BackendXmin.Int64,
+		we.LastWaitTime,
+		classifyPostgresWaitEventType(we.WaitEventType),
+		we.WaitEvent,
+		waitEventFullName,
+		we.BlockedByPIDs,
+		state.LastRow.QueryID.Int64,
+	)
+}
+
+// classifyPostgresWaitEventType maps a raw PostgreSQL wait event type to a standardized category.
+func classifyPostgresWaitEventType(rawType string) string {
+	switch rawType {
+	case "IO":
+		return "IO Wait"
+	case "Lock", "LWLock", "Activity", "Extension", "InjectionPoint", "IPC", "Timeout", "BufferPin":
+		return "Lock Wait"
+	case "Client":
+		return "Network Wait"
+	default:
+		return "Other Wait"
+	}
 }

--- a/internal/component/database_observability/postgres/collector/query_samples_test.go
+++ b/internal/component/database_observability/postgres/collector/query_samples_test.go
@@ -1167,6 +1167,161 @@ func TestQuerySamples_ExcludeDatabases(t *testing.T) {
 	}, 5*time.Second, 100*time.Millisecond)
 }
 
+func TestQuerySamples_WaitEvents_PreClassifiedFlag(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"))
+
+	now := time.Now()
+	xactStartTime := now.Add(-2 * time.Minute)
+	backendStartTime := now.Add(-1 * time.Hour)
+
+	columns := []string{
+		"now", "datname", "pid", "leader_pid",
+		"usename", "application_name", "client_addr", "client_port",
+		"backend_type", "backend_start", "backend_xid", "backend_xmin",
+		"xact_start", "state", "state_change", "wait_event_type",
+		"wait_event", "blocked_by_pids", "query_start", "query_id",
+	}
+
+	t.Run("flag OFF emits only OP_WAIT_EVENT", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		logBuffer := syncbuffer.Buffer{}
+		lokiClient := loki.NewCollectingHandler()
+		defer lokiClient.Stop()
+
+		sampleCollector, err := NewQuerySamples(QuerySamplesArguments{
+			DB:                            db,
+			CollectInterval:               time.Millisecond,
+			EntryHandler:                  lokiClient,
+			Logger:                        log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+			ExcludeCurrentUser:            true,
+			EnablePreClassifiedWaitEvents: false,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, sampleCollector)
+
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, "", exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows(columns).AddRow(
+				now, "testdb", 500, sql.NullInt64{},
+				"testuser", "testapp", "127.0.0.1", 5432,
+				"client backend", backendStartTime, sql.NullInt32{}, sql.NullInt32{},
+				xactStartTime, "waiting", now.Add(-5*time.Second), sql.NullString{String: "IO", Valid: true},
+				sql.NullString{String: "DataFileRead", Valid: true}, pq.Int64Array{}, now, sql.NullInt64{Int64: 5001, Valid: true},
+			))
+		// Second scrape: empty to trigger finalization
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, "", exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows(columns))
+
+		require.NoError(t, sampleCollector.Start(t.Context()))
+
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 2
+		}, 5*time.Second, 100*time.Millisecond)
+
+		entries := lokiClient.Received()
+		require.Len(t, entries, 2)
+		// First entry is query_sample, second is wait_event
+		require.Equal(t, model.LabelSet{"op": OP_QUERY_SAMPLE}, entries[0].Labels)
+		require.Equal(t, model.LabelSet{"op": OP_WAIT_EVENT}, entries[1].Labels)
+		// The wait_event entry must contain the raw wait_event_type, not a classified value
+		require.Contains(t, entries[1].Line, `wait_event_type="IO"`)
+		require.NotContains(t, entries[1].Line, `wait_event_type="IO Wait"`)
+
+		sampleCollector.Stop()
+		require.Eventually(t, func() bool {
+			return sampleCollector.Stopped()
+		}, 5*time.Second, 100*time.Millisecond)
+		require.Eventually(t, func() bool {
+			return mock.ExpectationsWereMet() == nil
+		}, 5*time.Second, 100*time.Millisecond)
+	})
+
+	t.Run("flag ON emits only OP_WAIT_EVENT_V2 with classified wait_event_type", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		logBuffer := syncbuffer.Buffer{}
+		lokiClient := loki.NewCollectingHandler()
+		defer lokiClient.Stop()
+
+		sampleCollector, err := NewQuerySamples(QuerySamplesArguments{
+			DB:                            db,
+			CollectInterval:               time.Millisecond,
+			EntryHandler:                  lokiClient,
+			Logger:                        log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+			ExcludeCurrentUser:            true,
+			EnablePreClassifiedWaitEvents: true,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, sampleCollector)
+
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, "", exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows(columns).AddRow(
+				now, "testdb", 501, sql.NullInt64{},
+				"testuser", "testapp", "127.0.0.1", 5432,
+				"client backend", backendStartTime, sql.NullInt32{}, sql.NullInt32{},
+				xactStartTime, "waiting", now.Add(-5*time.Second), sql.NullString{String: "IO", Valid: true},
+				sql.NullString{String: "DataFileRead", Valid: true}, pq.Int64Array{}, now, sql.NullInt64{Int64: 5002, Valid: true},
+			))
+		// Second scrape: empty to trigger finalization
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, "", exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows(columns))
+
+		require.NoError(t, sampleCollector.Start(t.Context()))
+
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 2
+		}, 5*time.Second, 100*time.Millisecond)
+
+		entries := lokiClient.Received()
+		require.Len(t, entries, 2)
+		// First entry is query_sample, second is wait_event_v2
+		require.Equal(t, model.LabelSet{"op": OP_QUERY_SAMPLE}, entries[0].Labels)
+		require.Equal(t, model.LabelSet{"op": OP_WAIT_EVENT_V2}, entries[1].Labels)
+		// The wait_event_v2 entry must contain the classified wait_event_type
+		require.Contains(t, entries[1].Line, `wait_event_type="IO Wait"`)
+		// Must not contain a raw "IO" as wait_event_type value
+		require.NotContains(t, entries[1].Line, `wait_event_type="IO"`)
+
+		sampleCollector.Stop()
+		require.Eventually(t, func() bool {
+			return sampleCollector.Stopped()
+		}, 5*time.Second, 100*time.Millisecond)
+		require.Eventually(t, func() bool {
+			return mock.ExpectationsWereMet() == nil
+		}, 5*time.Second, 100*time.Millisecond)
+	})
+}
+
+func TestClassifyPostgresWaitEventType(t *testing.T) {
+	testCases := []struct {
+		rawType  string
+		expected string
+	}{
+		{"IO", "IO Wait"},
+		{"Lock", "Lock Wait"},
+		{"LWLock", "Lock Wait"},
+		{"Activity", "Lock Wait"},
+		{"Client", "Network Wait"},
+		{"unknown_type", "Other Wait"},
+		{"", "Other Wait"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.rawType, func(t *testing.T) {
+			result := classifyPostgresWaitEventType(tc.rawType)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
 func TestQuerySamples_ExcludeUsers(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"))
 

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -73,6 +73,9 @@ type Arguments struct {
 	ExcludeDatabases  []string            `alloy:"exclude_databases,attr,optional"`
 	ExcludeUsers      []string            `alloy:"exclude_users,attr,optional"`
 
+	// Temporary feature flag for pre-classified wait event emission. Will be removed before Alloy 1.14.0.
+	EnablePreClassifiedWaitEvents bool `alloy:"enable_pre_classified_wait_events,attr,optional"`
+
 	CloudProvider          *CloudProvider               `alloy:"cloud_provider,block,optional"`
 	QuerySampleArguments   QuerySampleArguments         `alloy:"query_samples,block,optional"`
 	QueryDetailsArguments  QueryDetailsArguments        `alloy:"query_details,block,optional"`
@@ -608,14 +611,15 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 
 	if collectors[collector.QuerySamplesCollector] {
 		aCollector, err := collector.NewQuerySamples(collector.QuerySamplesArguments{
-			DB:                    c.dbConnection,
-			CollectInterval:       c.args.QuerySampleArguments.CollectInterval,
-			ExcludeDatabases:      c.args.ExcludeDatabases,
-			ExcludeUsers:          c.args.ExcludeUsers,
-			EntryHandler:          entryHandler,
-			Logger:                c.opts.Logger,
-			DisableQueryRedaction: c.args.QuerySampleArguments.DisableQueryRedaction,
-			ExcludeCurrentUser:    c.args.QuerySampleArguments.ExcludeCurrentUser,
+			DB:                            c.dbConnection,
+			CollectInterval:               c.args.QuerySampleArguments.CollectInterval,
+			ExcludeDatabases:              c.args.ExcludeDatabases,
+			ExcludeUsers:                  c.args.ExcludeUsers,
+			EntryHandler:                  entryHandler,
+			Logger:                        c.opts.Logger,
+			DisableQueryRedaction:         c.args.QuerySampleArguments.DisableQueryRedaction,
+			ExcludeCurrentUser:            c.args.QuerySampleArguments.ExcludeCurrentUser,
+			EnablePreClassifiedWaitEvents: c.args.EnablePreClassifiedWaitEvents,
 		})
 		if err != nil {
 			logStartError(collector.QuerySamplesCollector, "create", err)

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -73,9 +73,6 @@ type Arguments struct {
 	ExcludeDatabases  []string            `alloy:"exclude_databases,attr,optional"`
 	ExcludeUsers      []string            `alloy:"exclude_users,attr,optional"`
 
-	// Temporary feature flag for pre-classified wait event emission. Will be removed before Alloy 1.14.0.
-	EnablePreClassifiedWaitEvents bool `alloy:"enable_pre_classified_wait_events,attr,optional"`
-
 	CloudProvider          *CloudProvider               `alloy:"cloud_provider,block,optional"`
 	QuerySampleArguments   QuerySampleArguments         `alloy:"query_samples,block,optional"`
 	QueryDetailsArguments  QueryDetailsArguments        `alloy:"query_details,block,optional"`
@@ -109,6 +106,8 @@ type QuerySampleArguments struct {
 	CollectInterval       time.Duration `alloy:"collect_interval,attr,optional"`
 	DisableQueryRedaction bool          `alloy:"disable_query_redaction,attr,optional"`
 	ExcludeCurrentUser    bool          `alloy:"exclude_current_user,attr,optional"`
+	// Temporary feature flag for pre-classified wait event emission. Will be removed before Alloy 1.14.0.
+	EnablePreClassifiedWaitEvents bool `alloy:"enable_pre_classified_wait_events,attr,optional"`
 }
 
 type QueryDetailsArguments struct {
@@ -619,7 +618,7 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 			Logger:                        c.opts.Logger,
 			DisableQueryRedaction:         c.args.QuerySampleArguments.DisableQueryRedaction,
 			ExcludeCurrentUser:            c.args.QuerySampleArguments.ExcludeCurrentUser,
-			EnablePreClassifiedWaitEvents: c.args.EnablePreClassifiedWaitEvents,
+			EnablePreClassifiedWaitEvents: c.args.QuerySampleArguments.EnablePreClassifiedWaitEvents,
 		})
 		if err != nil {
 			logStartError(collector.QuerySamplesCollector, "create", err)


### PR DESCRIPTION
### Brief description

Introduces `wait_event_v2` — a cleaner alternative to the baseline `wait_event` op that pre-classifies `wait_event_type` in Alloy at emit time rather than computing it with a 6-level `label_replace` chain at query time.

Also adds a `database_observability_wait_event_seconds_total` Prometheus counter (MySQL only) as a pre-aggregated alternative for wide-window TotalWaitEventsTime queries that hit Loki's series limit.

Context and benchmark results: https://github.com/grafana/grafana-dbo11y-app/issues/2350

### What changed

**New op: `wait_event_v2`** (MySQL + PostgreSQL)
- Identical fields to `wait_event` (v1) plus `wait_event_type` pre-classified into `IO Wait`, `Lock Wait`, `Network Wait`, or `Other Wait` in the log body
- Controlled by the new `enable_pre_classified_wait_events` flag (replaces the experimental `enable_structured_metadata` flag)
- When the flag is ON, `wait_event_v2` is emitted **instead of** `wait_event` (v1) — never both

**Prometheus counter: `database_observability_wait_event_seconds_total`** (MySQL only)
- Labels: `server_id`, `digest`, `schema`
- Increments unconditionally on every wait event row, regardless of which Loki op is active
- Exposed at the component's `/metrics` endpoint via the existing registry

**Not changed**
- `query_sample`, `query_sample_v2`, `query_association`, `query_association_v2` — untouched

### Why pre-classification

Benchmarks (n=143–144 iterations, 30m–2h windows) showed:
- `wait_event_v2` delivers **−83 to −90% p95** on WaitEventsPanel duration queries by eliminating the Loki 500-series fallback retry loop
- The retry loop adds 2–7s of latency at wide unfiltered windows for v1
- SM-based versions (old v2/v3/v5) hit the same series limit at 2h+ windows for TotalWaitEventTime — net zero benefit

### PR Checklist

- [x] Documentation updated (`enable_pre_classified_wait_events` in both component docs)
- [x] Tests updated (mutual exclusion tests, `TestClassifyMySQLWaitEventType`, `TestQuerySamples_WaitEventCounter`)

To be used with https://github.com/grafana/grafana-dbo11y-app/pull/2693