### PR TITLE
chore: Do not use sleep statements in file_match tests

### DIFF
--- a/internal/component/local/file_match/testutil/testutil.go
+++ b/internal/component/local/file_match/testutil/testutil.go
@@ -6,7 +6,6 @@ import (
 	"path"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -18,7 +17,6 @@ func WriteFile(t *testing.T, dir string, name string) {
 	t.Helper()
 	err := os.WriteFile(path.Join(dir, name), []byte("test content"), 0664)
 	require.NoError(t, err)
-	time.Sleep(20 * time.Millisecond)
 }
 
 // ContainsPath checks if any target's __path__ contains the given substring.


### PR DESCRIPTION
Follow up from #5470