### PR TITLE
ci: Update build images to go 1.25.7

### DIFF
--- a/.github/workflows/check-linux-build-image.yml
+++ b/.github/workflows/check-linux-build-image.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         build:
-          - runtime: golang:1.25.6-alpine3.23
-          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.25.6-bookworm
+          - runtime: golang:1.25.7-alpine3.23
+          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.25.7-bookworm
     runs-on: ubuntu-latest-8-cores
     steps:
       - name: Checkout

--- a/.github/workflows/create_build_image.yml
+++ b/.github/workflows/create_build_image.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         build:
-          - runtime: golang:1.25.6-alpine3.23
-          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.25.6-bookworm
+          - runtime: golang:1.25.7-alpine3.23
+          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.25.7-bookworm
             suffix: "-boringcrypto"
     runs-on: ubuntu-latest-8-cores
     steps:

--- a/tools/build-image/windows/Dockerfile
+++ b/tools/build-image/windows/Dockerfile
@@ -1,4 +1,4 @@
-FROM library/golang:1.24.0-windowsservercore-ltsc2022
+FROM library/golang:1.25.7-windowsservercore-ltsc2022
 
 SHELL ["powershell", "-command"]
 


### PR DESCRIPTION
## Post-merge TODO:

- [x] tag the image `build-image/v0.1.27`