### PR TITLE
fix(loki.source.file): Close file if we cannot find encoding

### DIFF
--- a/internal/component/loki/source/file/internal/tail/file.go
+++ b/internal/component/loki/source/file/internal/tail/file.go
@@ -28,6 +28,7 @@ func NewFile(logger log.Logger, cfg *Config) (*File, error) {
 
 	encoding, err := getEncoding(cfg.Encoding)
 	if err != nil {
+		f.Close()
 		return nil, err
 	}
 


### PR DESCRIPTION
### Pull Request Details
Noticed that we do not close file if we cannot get encoding. Review all other paths and we close file properly.

I really wish go had something like [errdefer like zig does](https://ziglang.org/documentation/master/#errdefer).

### Issue(s) fixed by this Pull Request

<!--
  Uncomment the following line and fill in an issue number if you want a GitHub
  issue to be closed automatically when this PR gets merged.
-->

<!-- Fixes #issue_id -->

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
