### PR TITLE
fix: Use read-write mutex locks to prevent concurrent tagsCache map reads and writes

### DIFF
--- a/syntax/internal/value/tag_cache.go
+++ b/syntax/internal/value/tag_cache.go
@@ -70,10 +70,6 @@ func getCachedTags(t reflect.Type) *objectFields {
 	}
 
 	tagsCacheMutex.Lock()
-	if entry, ok := tagsCache[t]; ok {
-		tagsCacheMutex.Unlock()
-		return entry
-	}
 	tagsCache[t] = tree
 	tagsCacheMutex.Unlock()
 


### PR DESCRIPTION
Fixes cause of panic described in https://github.com/grafana/alloy/issues/5533