### PR TITLE
feat(database_observability.postgres): Allow excluding queries ran by specific users

### DIFF
--- a/internal/component/database_observability/postgres/collector/exclude_users.go
+++ b/internal/component/database_observability/postgres/collector/exclude_users.go
@@ -1,0 +1,14 @@
+package collector
+
+import (
+	"fmt"
+
+	"github.com/grafana/alloy/internal/component/database_observability"
+)
+
+func buildExcludedUsersClause(users []string, columnExpr string) string {
+	if len(users) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("AND %s NOT IN %s", columnExpr, database_observability.BuildExclusionClause(users))
+}

--- a/internal/component/database_observability/postgres/collector/query_details.go
+++ b/internal/component/database_observability/postgres/collector/query_details.go
@@ -39,6 +39,7 @@ var selectQueriesFromActivity = `
 				FROM pg_stat_statements
 		)
 		AND pg_database.datname NOT IN %s
+		%s
 	ORDER BY total_exec_time DESC
 	LIMIT 100
 `
@@ -47,6 +48,7 @@ type QueryDetailsArguments struct {
 	DB               *sql.DB
 	CollectInterval  time.Duration
 	ExcludeDatabases []string
+	ExcludeUsers     []string
 	EntryHandler     loki.EntryHandler
 	TableRegistry    *TableRegistry
 
@@ -57,6 +59,7 @@ type QueryDetails struct {
 	dbConnection     *sql.DB
 	collectInterval  time.Duration
 	excludeDatabases []string
+	excludeUsers     []string
 	entryHandler     loki.EntryHandler
 	tableRegistry    *TableRegistry
 	normalizer       *sqllexer.Normalizer
@@ -72,6 +75,7 @@ func NewQueryDetails(args QueryDetailsArguments) (*QueryDetails, error) {
 		dbConnection:     args.DB,
 		collectInterval:  args.CollectInterval,
 		excludeDatabases: args.ExcludeDatabases,
+		excludeUsers:     args.ExcludeUsers,
 		entryHandler:     args.EntryHandler,
 		tableRegistry:    args.TableRegistry,
 		normalizer:       sqllexer.NewNormalizer(sqllexer.WithCollectTables(true), sqllexer.WithCollectComments(true), sqllexer.WithKeepIdentifierQuotation(true)),
@@ -127,7 +131,9 @@ func (c *QueryDetails) Stop() {
 }
 
 func (c QueryDetails) fetchAndAssociate(ctx context.Context) error {
-	query := fmt.Sprintf(selectQueriesFromActivity, buildExcludedDatabasesClause(c.excludeDatabases))
+	excludedDatabasesClause := buildExcludedDatabasesClause(c.excludeDatabases)
+	excludedUsersClause := buildExcludedUsersClause(c.excludeUsers, "pg_get_userbyid(pg_stat_statements.userid)")
+	query := fmt.Sprintf(selectQueriesFromActivity, excludedDatabasesClause, excludedUsersClause)
 	rs, err := c.dbConnection.QueryContext(ctx, query)
 	if err != nil {
 		return fmt.Errorf("failed to fetch statements from pg_stat_statements view: %w", err)

--- a/internal/component/database_observability/postgres/collector/query_samples_test.go
+++ b/internal/component/database_observability/postgres/collector/query_samples_test.go
@@ -50,7 +50,7 @@ func TestQuerySamples_FetchQuerySamples(t *testing.T) {
 		{
 			name: "active query without wait event",
 			setupMock: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, "", exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+				mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, "", exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 					WillReturnRows(sqlmock.NewRows(columns).AddRow(
 						now, "testdb", 100, sql.NullInt64{},
 						"testuser", "testapp", "127.0.0.1", 5432,
@@ -59,7 +59,7 @@ func TestQuerySamples_FetchQuerySamples(t *testing.T) {
 						sql.NullString{}, nil, queryStartTime, sql.NullInt64{Int64: 123, Valid: true},
 					))
 				// Second scrape: empty to trigger finalization
-				mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, "", exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+				mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, "", exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 					WillReturnRows(sqlmock.NewRows(columns))
 			},
 			expectedLabels: []model.LabelSet{
@@ -72,7 +72,7 @@ func TestQuerySamples_FetchQuerySamples(t *testing.T) {
 		{
 			name: "parallel query with leader PID",
 			setupMock: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, "", exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+				mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, "", exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 					WillReturnRows(sqlmock.NewRows(columns).AddRow(
 						now, "testdb", 101, sql.NullInt64{Int64: 100, Valid: true},
 						"testuser", "testapp", "127.0.0.1", 5432,
@@ -81,7 +81,7 @@ func TestQuerySamples_FetchQuerySamples(t *testing.T) {
 						sql.NullString{}, nil, now, sql.NullInt64{Int64: 123, Valid: true},
 					))
 				// Second scrape: empty to trigger finalization
-				mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, "", exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+				mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, "", exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 					WillReturnRows(sqlmock.NewRows(columns))
 			},
 			expectedLabels: []model.LabelSet{
@@ -94,7 +94,7 @@ func TestQuerySamples_FetchQuerySamples(t *testing.T) {
 		{
 			name: "query with wait event",
 			setupMock: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, "", exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+				mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, "", exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 					WillReturnRows(sqlmock.NewRows(columns).AddRow(
 						now, "testdb", 102, sql.NullInt64{},
 						"testuser", "testapp", "127.0.0.1", 5432,
@@ -103,7 +103,7 @@ func TestQuerySamples_FetchQuerySamples(t *testing.T) {
 						sql.NullString{String: "relation", Valid: true}, pq.Int64Array{103, 104}, now, sql.NullInt64{Int64: 124, Valid: true},
 					))
 				// Second scrape: empty to trigger finalization
-				mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, "", exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+				mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, "", exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 					WillReturnRows(sqlmock.NewRows(columns))
 			},
 			expectedLabels: []model.LabelSet{
@@ -118,7 +118,7 @@ func TestQuerySamples_FetchQuerySamples(t *testing.T) {
 		{
 			name: "query with redaction disabled",
 			setupMock: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+				mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 					WillReturnRows(sqlmock.NewRows(append(columns, "query")).AddRow(
 						now, "testdb", 106, sql.NullInt64{},
 						"testuser", "testapp", "127.0.0.1", 5432,
@@ -128,7 +128,7 @@ func TestQuerySamples_FetchQuerySamples(t *testing.T) {
 						"SELECT * FROM users WHERE id = 123 AND email = 'test@example.com'",
 					))
 				// Second scrape: empty to trigger finalization
-				mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+				mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 					WillReturnRows(sqlmock.NewRows(append(columns, "query")))
 			},
 			disableQueryRedaction: true,
@@ -219,7 +219,7 @@ func TestQuerySamples_FetchQuerySamples_ErrorCases(t *testing.T) {
 		{
 			name: "insufficient privilege query",
 			setupMock: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+				mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 					WillReturnRows(sqlmock.NewRows(append(columns, "query")).AddRow(
 						now, "testdb", 103, sql.NullInt64{},
 						"testuser", "testapp", "127.0.0.1", 5432,
@@ -229,10 +229,10 @@ func TestQuerySamples_FetchQuerySamples_ErrorCases(t *testing.T) {
 						"<insufficient privilege>",
 					))
 				// Second scrape: empty to complete cycle
-				mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+				mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 					WillReturnRows(sqlmock.NewRows(append(columns, "query")))
 				// Return error to trigger finalization
-				mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).
+				mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).
 					WillReturnError(errMockQuerySamplesFailed)
 			},
 			disableQueryRedaction: true,
@@ -241,7 +241,7 @@ func TestQuerySamples_FetchQuerySamples_ErrorCases(t *testing.T) {
 		{
 			name: "null database name",
 			setupMock: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, "", exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+				mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, "", exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 					WillReturnRows(sqlmock.NewRows(columns).AddRow(
 						now, sql.NullString{Valid: false}, 104, sql.NullInt64{},
 						"testuser", "testapp", "127.0.0.1", 5432,
@@ -250,10 +250,10 @@ func TestQuerySamples_FetchQuerySamples_ErrorCases(t *testing.T) {
 						sql.NullString{}, nil, now, sql.NullInt64{Int64: 126, Valid: true},
 					))
 				// Second scrape: empty to complete cycle
-				mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, "", exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+				mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, "", exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 					WillReturnRows(sqlmock.NewRows(columns))
 				// Return error to trigger finalization
-				mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, "", exclusionClause, excludeCurrentUserClause)).
+				mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, "", exclusionClause, excludeCurrentUserClause, "")).
 					WillReturnError(errMockQuerySamplesFailed)
 			},
 			expectedErrorLine: `err="database name is not valid`,
@@ -352,7 +352,7 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 		require.NoError(t, err)
 
 		// First scrape: active row
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows(columns).AddRow(
 				now, "testdb", 1000, sql.NullInt64{},
 				"testuser", "testapp", "127.0.0.1", 5432,
@@ -362,7 +362,7 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 				"SELECT * FROM t",
 			))
 		// Second scrape: no rows -> finalize
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows(columns))
 
 		require.NoError(t, sampleCollector.Start(t.Context()))
@@ -410,7 +410,7 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 
 		require.NoError(t, err)
 		// Scrape 1: wait event with unordered/dup PIDs
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows(columns).AddRow(
 				now, "testdb", 300, sql.NullInt64{},
 				"testuser", "testapp", "127.0.0.1", 5432,
@@ -420,7 +420,7 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 				"UPDATE users SET status = 'active'",
 			))
 		// Scrape 2: same wait event with normalized PIDs
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows(columns).AddRow(
 				now, "testdb", 300, sql.NullInt64{},
 				"testuser", "testapp", "127.0.0.1", 5432,
@@ -430,7 +430,7 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 				"UPDATE users SET status = 'active'",
 			))
 		// Scrape 3: disappear
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows(columns))
 
 		require.NoError(t, sampleCollector.Start(t.Context()))
@@ -477,7 +477,7 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 		require.NoError(t, err)
 
 		// Scrape 1: wait event
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows(columns).AddRow(
 				now, "testdb", 301, sql.NullInt64{},
 				"testuser", "testapp", "127.0.0.1", 5432,
@@ -487,7 +487,7 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 				"UPDATE users SET status = 'active'",
 			))
 		// Scrape 2: active with no wait -> close occurrence
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows(columns).AddRow(
 				now, "testdb", 301, sql.NullInt64{},
 				"testuser", "testapp", "127.0.0.1", 5432,
@@ -497,7 +497,7 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 				"UPDATE users SET status = 'active'",
 			))
 		// Scrape 3: disappear
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows(columns))
 
 		require.NoError(t, sampleCollector.Start(t.Context()))
@@ -545,7 +545,7 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 		require.NoError(t, err)
 
 		// Scrape 1: active CPU snapshot (10s)
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows(columns).AddRow(
 				now, "testdb", 402, sql.NullInt64{},
 				"testuser", "testapp", "127.0.0.1", 5432,
@@ -555,7 +555,7 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 				"SELECT * FROM t",
 			))
 		// Scrape 2: waiting with wait_event; state_change 7s ago
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows(columns).AddRow(
 				now, "testdb", 402, sql.NullInt64{},
 				"testuser", "testapp", "127.0.0.1", 5432,
@@ -565,7 +565,7 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 				"SELECT * FROM t",
 			))
 		// Scrape 3: disappear -> finalize
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows(columns))
 
 		require.NoError(t, sampleCollector.Start(t.Context()))
@@ -613,7 +613,7 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 		require.NoError(t, err)
 
 		// Scrape 1: wait event set A
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows(columns).AddRow(
 				now, "testdb", 403, sql.NullInt64{},
 				"testuser", "testapp", "127.0.0.1", 5432,
@@ -623,7 +623,7 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 				"UPDATE t SET c=1",
 			))
 		// Scrape 2: same event, set changes -> new occurrence
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows(columns).AddRow(
 				now, "testdb", 403, sql.NullInt64{},
 				"testuser", "testapp", "127.0.0.1", 5432,
@@ -633,7 +633,7 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 				"UPDATE t SET c=1",
 			))
 		// Scrape 3: disappear -> finalize
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows(columns))
 
 		require.NoError(t, sampleCollector.Start(t.Context()))
@@ -702,7 +702,7 @@ func TestQuerySamples_IdleScenarios(t *testing.T) {
 		require.NoError(t, err)
 
 		// Scrape 1: active row
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows(columns).AddRow(
 				now, "testdb", 2000, sql.NullInt64{},
 				"testuser", "testapp", "127.0.0.1", 5432,
@@ -712,7 +712,7 @@ func TestQuerySamples_IdleScenarios(t *testing.T) {
 				"SELECT * FROM t",
 			))
 		// Scrape 2: same key turns idle; state_change denotes end
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows(columns).AddRow(
 				now, "testdb", 2000, sql.NullInt64{},
 				"testuser", "testapp", "127.0.0.1", 5432,
@@ -768,7 +768,7 @@ func TestQuerySamples_IdleScenarios(t *testing.T) {
 		require.NoError(t, err)
 
 		// Scrape 1: only idle row
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows(columns).AddRow(
 				now, "testdb", 2001, sql.NullInt64{},
 				"testuser", "testapp", "127.0.0.1", 5432,
@@ -778,7 +778,7 @@ func TestQuerySamples_IdleScenarios(t *testing.T) {
 				"SELECT * FROM users",
 			))
 		// Scrape 2: same idle row again -> should not re-emit
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows(columns).AddRow(
 				now, "testdb", 2001, sql.NullInt64{},
 				"testuser", "testapp", "127.0.0.1", 5432,
@@ -788,7 +788,7 @@ func TestQuerySamples_IdleScenarios(t *testing.T) {
 				"SELECT * FROM users",
 			))
 		// Return error to trigger finalization
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).
 			WillReturnError(errMockQuerySamplesFailed)
 
 		require.NoError(t, sampleCollector.Start(t.Context()))
@@ -841,7 +841,7 @@ func TestQuerySamples_IdleScenarios(t *testing.T) {
 		require.NoError(t, err)
 
 		// Scrape 1: idle in transaction (aborted)
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows(columns).AddRow(
 				now, "testdb", 2100, sql.NullInt64{},
 				"testuser", "testapp", "127.0.0.1", 5432,
@@ -851,7 +851,7 @@ func TestQuerySamples_IdleScenarios(t *testing.T) {
 				"SELECT 1",
 			))
 		// Scrape 2: same idle row again -> should not re-emit
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows(columns).AddRow(
 				now, "testdb", 2100, sql.NullInt64{},
 				"testuser", "testapp", "127.0.0.1", 5432,
@@ -861,7 +861,7 @@ func TestQuerySamples_IdleScenarios(t *testing.T) {
 				"SELECT 1",
 			))
 		// Return error to trigger finalization
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).
 			WillReturnError(errMockQuerySamplesFailed)
 
 		require.NoError(t, sampleCollector.Start(t.Context()))
@@ -914,7 +914,7 @@ func TestQuerySamples_IdleScenarios(t *testing.T) {
 		require.NoError(t, err)
 
 		// Scrape 1: two idle-only rows with different keys (PID/QueryID)
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows(columns).
 				AddRow(
 					now, "testdb", 2200, sql.NullInt64{},
@@ -933,7 +933,7 @@ func TestQuerySamples_IdleScenarios(t *testing.T) {
 					"SELECT * FROM b",
 				))
 		// Scrape 2: same idle rows again -> should not re-emit
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows(columns).
 				AddRow(
 					now, "testdb", 2200, sql.NullInt64{},
@@ -952,7 +952,7 @@ func TestQuerySamples_IdleScenarios(t *testing.T) {
 					"SELECT * FROM b",
 				))
 		// Return error to trigger finalization
-		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause)).
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).
 			WillReturnError(errMockQuerySamplesFailed)
 
 		require.NoError(t, sampleCollector.Start(t.Context()))
@@ -1020,12 +1020,12 @@ func TestQuerySamples_ExcludeCurrentUser(t *testing.T) {
 		{
 			name:               "ExcludeCurrentUser enabled",
 			excludeCurrentUser: true,
-			expectedQuery:      fmt.Sprintf(selectPgStatActivity, "", exclusionClause, excludeCurrentUserClause),
+			expectedQuery:      fmt.Sprintf(selectPgStatActivity, "", exclusionClause, excludeCurrentUserClause, ""),
 		},
 		{
 			name:               "ExcludeCurrentUser disabled",
 			excludeCurrentUser: false,
-			expectedQuery:      fmt.Sprintf(selectPgStatActivity, "", exclusionClause, ""),
+			expectedQuery:      fmt.Sprintf(selectPgStatActivity, "", exclusionClause, "", ""),
 		},
 	}
 
@@ -1124,7 +1124,7 @@ func TestQuerySamples_ExcludeDatabases(t *testing.T) {
 	require.NotNil(t, sampleCollector)
 
 	// Verify the query uses the custom exclusion clause that includes both default and user-provided exclusions
-	expectedQuery := fmt.Sprintf(selectPgStatActivity, "", buildExcludedDatabasesClause([]string{"excluded_db"}), "")
+	expectedQuery := fmt.Sprintf(selectPgStatActivity, "", buildExcludedDatabasesClause([]string{"excluded_db"}), "", "")
 
 	// First scrape: return only non-excluded database rows (simulating SQL-level filtering)
 	mock.ExpectQuery(expectedQuery).RowsWillBeClosed().
@@ -1156,6 +1156,78 @@ func TestQuerySamples_ExcludeDatabases(t *testing.T) {
 	for _, entry := range entries {
 		require.Contains(t, entry.Line, "included_db", "included database should appear in logs")
 	}
+
+	sampleCollector.Stop()
+	require.Eventually(t, func() bool {
+		return sampleCollector.Stopped()
+	}, 5*time.Second, 100*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		return mock.ExpectationsWereMet() == nil
+	}, 5*time.Second, 100*time.Millisecond)
+}
+
+func TestQuerySamples_ExcludeUsers(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"))
+
+	now := time.Now()
+	stateChangeTime := now.Add(-10 * time.Second)
+	queryStartTime := now.Add(-30 * time.Second)
+	xactStartTime := now.Add(-2 * time.Minute)
+	backendStartTime := now.Add(-1 * time.Hour)
+
+	columns := []string{
+		"now", "datname", "pid", "leader_pid",
+		"usename", "application_name", "client_addr", "client_port",
+		"backend_type", "backend_start", "backend_xid", "backend_xmin",
+		"xact_start", "state", "state_change", "wait_event_type",
+		"wait_event", "blocked_by_pids", "query_start", "query_id",
+	}
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	logBuffer := syncbuffer.Buffer{}
+	lokiClient := loki.NewCollectingHandler()
+	defer lokiClient.Stop()
+
+	sampleCollector, err := NewQuerySamples(QuerySamplesArguments{
+		DB:              db,
+		CollectInterval: time.Millisecond,
+		ExcludeUsers:    []string{"excluded_user"},
+		EntryHandler:    lokiClient,
+		Logger:          log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, sampleCollector)
+
+	expectedExcludedUsersClause := buildExcludedUsersClause([]string{"excluded_user"}, "s.usename")
+	expectedQuery := fmt.Sprintf(selectPgStatActivity, "", exclusionClause, "", expectedExcludedUsersClause)
+
+	mock.ExpectQuery(expectedQuery).RowsWillBeClosed().
+		WillReturnRows(sqlmock.NewRows(columns).
+			AddRow(
+				now, "testdb", 101, sql.NullInt64{},
+				"included_user", "testapp", "127.0.0.1", 5432,
+				"client backend", backendStartTime, sql.NullInt32{Int32: 501, Valid: true}, sql.NullInt32{Int32: 401, Valid: true},
+				xactStartTime, "active", stateChangeTime, sql.NullString{},
+				sql.NullString{}, nil, queryStartTime, sql.NullInt64{Int64: 456, Valid: true},
+			))
+
+	mock.ExpectQuery(expectedQuery).RowsWillBeClosed().
+		WillReturnRows(sqlmock.NewRows(columns))
+
+	err = sampleCollector.Start(t.Context())
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return len(lokiClient.Received()) == 1
+	}, 5*time.Second, 100*time.Millisecond)
+
+	entries := lokiClient.Received()
+	require.Len(t, entries, 1)
+	require.Contains(t, entries[0].Line, "included_user")
 
 	sampleCollector.Stop()
 	require.Eventually(t, func() bool {

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -66,6 +66,7 @@ type Arguments struct {
 	EnableCollectors  []string            `alloy:"enable_collectors,attr,optional"`
 	DisableCollectors []string            `alloy:"disable_collectors,attr,optional"`
 	ExcludeDatabases  []string            `alloy:"exclude_databases,attr,optional"`
+	ExcludeUsers      []string            `alloy:"exclude_users,attr,optional"`
 
 	CloudProvider          *CloudProvider         `alloy:"cloud_provider,block,optional"`
 	QuerySampleArguments   QuerySampleArguments   `alloy:"query_samples,block,optional"`
@@ -109,6 +110,7 @@ type SchemaDetailsArguments struct {
 
 var DefaultArguments = Arguments{
 	ExcludeDatabases: []string{},
+	ExcludeUsers:     []string{},
 	QuerySampleArguments: QuerySampleArguments{
 		CollectInterval:       15 * time.Second,
 		DisableQueryRedaction: false,
@@ -470,6 +472,7 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 			DB:               c.dbConnection,
 			CollectInterval:  c.args.QueryTablesArguments.CollectInterval,
 			ExcludeDatabases: c.args.ExcludeDatabases,
+			ExcludeUsers:     c.args.ExcludeUsers,
 			EntryHandler:     entryHandler,
 			TableRegistry:    tableRegistry,
 			Logger:           c.opts.Logger,
@@ -488,6 +491,7 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 			DB:                    c.dbConnection,
 			CollectInterval:       c.args.QuerySampleArguments.CollectInterval,
 			ExcludeDatabases:      c.args.ExcludeDatabases,
+			ExcludeUsers:          c.args.ExcludeUsers,
 			EntryHandler:          entryHandler,
 			Logger:                c.opts.Logger,
 			DisableQueryRedaction: c.args.QuerySampleArguments.DisableQueryRedaction,
@@ -525,6 +529,7 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 			ScrapeInterval:   c.args.ExplainPlansArguments.CollectInterval,
 			PerScrapeRatio:   c.args.ExplainPlansArguments.PerCollectRatio,
 			ExcludeDatabases: c.args.ExcludeDatabases,
+			ExcludeUsers:     c.args.ExcludeUsers,
 			Logger:           c.opts.Logger,
 			DBVersion:        engineVersion,
 			EntryHandler:     entryHandler,


### PR DESCRIPTION
### Brief description of Pull Request
Add config setting `exclude_users` that behaves similarly to `exclude_databases`, and cascade it across all collectors.

### Pull Request Details

<!-- Add a more detailed descripion of the Pull Request here, if needed. -->

### Issue(s) fixed by this Pull Request

<!--
  Uncomment the following line and fill in an issue number if you want a GitHub
  issue to be closed automatically when this PR gets merged.
-->

<!-- Fixes #issue_id -->

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
