### PR TITLE
docs(pyroscope.relabel): Clarify scope of `pyroscope.relabel`

### DIFF
--- a/docs/sources/reference/components/pyroscope/pyroscope.relabel.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.relabel.md
@@ -17,8 +17,8 @@ The `pyroscope.relabel` component rewrites the external label set of each profil
 If no rules are defined or applicable to some profiles, then those profiles are forwarded as-is to each receiver passed in the component's arguments. 
 The profile is dropped if no external labels remain after the relabeling rules are applied.
 
-`pyroscope.relabel` only rewrites labels that are not embedded in the profile itself, such as labels inferred by `pyroscope.scrape` or labels provided through the `/ingest?name=...` query parameter.
-It does not parse or modify labels embedded inside profile payloads like pprof sample labels.
+`pyroscope.relabel` only rewrites labels that aren't embedded in the profile itself, such as labels inferred by `pyroscope.scrape` or labels provided through the `/ingest?name=...` query parameter.
+It doesn't parse or modify labels embedded inside profile payloads like pprof sample labels.
 
 The most common use of `pyroscope.relabel` is to filter profiles or standardize external labels passed to one or more downstream receivers.
 The `rule` blocks are applied to the label set of each profile in order of their appearance in the configuration file.


### PR DESCRIPTION
Addresses confusion in https://github.com/grafana/alloy/issues/4689
