### PR TITLE
feat(database_observability.postgres): Add exclude databases/users for `logs` collector

### DIFF
--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -561,10 +561,12 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 
 	// Logs collector is always enabled
 	logsCollector, err := collector.NewLogs(collector.LogsArguments{
-		Receiver:     c.logsReceiver,
-		EntryHandler: loki.NewEntryHandler(c.logsReceiver.Chan(), func() {}),
-		Logger:       c.opts.Logger,
-		Registry:     c.registry,
+		Receiver:         c.logsReceiver,
+		EntryHandler:     loki.NewEntryHandler(c.logsReceiver.Chan(), func() {}),
+		Logger:           c.opts.Logger,
+		Registry:         c.registry,
+		ExcludeDatabases: c.args.ExcludeDatabases,
+		ExcludeUsers:     c.args.ExcludeUsers,
 	})
 	if err != nil {
 		logStartError(collector.LogsCollector, "create", err)


### PR DESCRIPTION
### Brief description of Pull Request
Like we do in other collectors, propagate `exclude_databases` and `exclude_users` config options to the logs collector, allowing to specify databases and/or users that should be excluded from log parsing and metrics generation.

### Pull Request Details

<!-- Add a more detailed descripion of the Pull Request here, if needed. -->

### Issue(s) fixed by this Pull Request

<!--
  Uncomment the following line and fill in an issue number if you want a GitHub
  issue to be closed automatically when this PR gets merged.
-->

<!-- Fixes #issue_id -->

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
