### PR TITLE
fix(profiler): Backport Go 1.26 gopclntab textStart fix

### DIFF
--- a/collector/builder-config.yaml
+++ b/collector/builder-config.yaml
@@ -81,7 +81,7 @@ replaces:
   # Replace OpenTelemetry OBI with Grafana fork
   - go.opentelemetry.io/obi => github.com/grafana/opentelemetry-ebpf-instrumentation v1.4.11
   # Replace OpenTelemetry eBPF profiler with Grafana fork
-  - go.opentelemetry.io/ebpf-profiler => github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260217121301-aa2759218aeb
+  - go.opentelemetry.io/ebpf-profiler => github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260218104523-8370a3e0bc2f
   # Update openshift/client-go to version compatible with structured-merge-diff v6
   - github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235
   # Do not remove until bug in walqueue backwards compatibility is resolved: https://github.com/deneonet/benc/issues/13

--- a/collector/go.mod
+++ b/collector/go.mod
@@ -1048,7 +1048,7 @@ replace github.com/github/smimesign => github.com/grafana/smimesign v0.2.1-0.202
 
 replace go.opentelemetry.io/obi => github.com/grafana/opentelemetry-ebpf-instrumentation v1.4.11
 
-replace go.opentelemetry.io/ebpf-profiler => github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260217121301-aa2759218aeb
+replace go.opentelemetry.io/ebpf-profiler => github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260218104523-8370a3e0bc2f
 
 replace github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235
 

--- a/collector/go.sum
+++ b/collector/go.sum
@@ -1165,8 +1165,8 @@ github.com/grafana/opentelemetry-collector/featuregate v0.0.0-20240325174506-2fd
 github.com/grafana/opentelemetry-collector/featuregate v0.0.0-20240325174506-2fd1623b2ca0/go.mod h1:mm8+xyQfgDmqhyegZRNIQmoKsNnDTwWKFLsdMoXAb7A=
 github.com/grafana/opentelemetry-ebpf-instrumentation v1.4.11 h1:Pi46xuPzRjAeB6XB4PzdF8kV93jl4NB58OZj08Bi33U=
 github.com/grafana/opentelemetry-ebpf-instrumentation v1.4.11/go.mod h1:rrgRM6X22UVa3bKaoNz43ab59Qx0CNrVOc2uiCVfBwU=
-github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260217121301-aa2759218aeb h1:qmTR6a7xR/jQFNIKPS/rK/pVLL6i7WwygbCw98VZ3BA=
-github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260217121301-aa2759218aeb/go.mod h1:oqSk8XwYnL4saX2ZdpfnTJV9vURSNaVjK6yomOAVIPI=
+github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260218104523-8370a3e0bc2f h1:lM3jBf19yCa8TssYj1jkx6LjlO6S9pcfT247FotLiSs=
+github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260218104523-8370a3e0bc2f/go.mod h1:oqSk8XwYnL4saX2ZdpfnTJV9vURSNaVjK6yomOAVIPI=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=
 github.com/grafana/otel-profiling-go v0.5.1/go.mod h1:ftN/t5A/4gQI19/8MoWurBEtC6gFw8Dns1sJZ9W4Tls=
 github.com/grafana/postgres_exporter v0.0.0-20250930111128-c8f6a9f4d363 h1:/vCopugIegPx9brm+E9+4bMQ6uIsZujCoE7su3bLLbk=

--- a/dependency-replacements.yaml
+++ b/dependency-replacements.yaml
@@ -103,7 +103,7 @@ replaces:
 
   - comment: Replace OpenTelemetry eBPF profiler with Grafana fork
     dependency: go.opentelemetry.io/ebpf-profiler
-    replacement: github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260217121301-aa2759218aeb
+    replacement: github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260218104523-8370a3e0bc2f
 
   - comment: Update openshift/client-go to version compatible with structured-merge-diff v6
     dependency: github.com/openshift/client-go

--- a/extension/alloyengine/go.mod
+++ b/extension/alloyengine/go.mod
@@ -1043,7 +1043,7 @@ replace github.com/github/smimesign => github.com/grafana/smimesign v0.2.1-0.202
 replace go.opentelemetry.io/obi => github.com/grafana/opentelemetry-ebpf-instrumentation v1.4.11
 
 // Replace OpenTelemetry eBPF profiler with Grafana fork
-replace go.opentelemetry.io/ebpf-profiler => github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260217121301-aa2759218aeb
+replace go.opentelemetry.io/ebpf-profiler => github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260218104523-8370a3e0bc2f
 
 // Update openshift/client-go to version compatible with structured-merge-diff v6
 replace github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235

--- a/extension/alloyengine/go.sum
+++ b/extension/alloyengine/go.sum
@@ -1183,8 +1183,8 @@ github.com/grafana/opentelemetry-collector/featuregate v0.0.0-20240325174506-2fd
 github.com/grafana/opentelemetry-collector/featuregate v0.0.0-20240325174506-2fd1623b2ca0/go.mod h1:mm8+xyQfgDmqhyegZRNIQmoKsNnDTwWKFLsdMoXAb7A=
 github.com/grafana/opentelemetry-ebpf-instrumentation v1.4.11 h1:Pi46xuPzRjAeB6XB4PzdF8kV93jl4NB58OZj08Bi33U=
 github.com/grafana/opentelemetry-ebpf-instrumentation v1.4.11/go.mod h1:rrgRM6X22UVa3bKaoNz43ab59Qx0CNrVOc2uiCVfBwU=
-github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260217121301-aa2759218aeb h1:qmTR6a7xR/jQFNIKPS/rK/pVLL6i7WwygbCw98VZ3BA=
-github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260217121301-aa2759218aeb/go.mod h1:oqSk8XwYnL4saX2ZdpfnTJV9vURSNaVjK6yomOAVIPI=
+github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260218104523-8370a3e0bc2f h1:lM3jBf19yCa8TssYj1jkx6LjlO6S9pcfT247FotLiSs=
+github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260218104523-8370a3e0bc2f/go.mod h1:oqSk8XwYnL4saX2ZdpfnTJV9vURSNaVjK6yomOAVIPI=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=
 github.com/grafana/otel-profiling-go v0.5.1/go.mod h1:ftN/t5A/4gQI19/8MoWurBEtC6gFw8Dns1sJZ9W4Tls=
 github.com/grafana/postgres_exporter v0.0.0-20250930111128-c8f6a9f4d363 h1:/vCopugIegPx9brm+E9+4bMQ6uIsZujCoE7su3bLLbk=

--- a/go.mod
+++ b/go.mod
@@ -1084,7 +1084,7 @@ replace github.com/github/smimesign => github.com/grafana/smimesign v0.2.1-0.202
 replace go.opentelemetry.io/obi => github.com/grafana/opentelemetry-ebpf-instrumentation v1.4.11
 
 // Replace OpenTelemetry eBPF profiler with Grafana fork
-replace go.opentelemetry.io/ebpf-profiler => github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260217121301-aa2759218aeb
+replace go.opentelemetry.io/ebpf-profiler => github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260218104523-8370a3e0bc2f
 
 // Update openshift/client-go to version compatible with structured-merge-diff v6
 replace github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235

--- a/go.sum
+++ b/go.sum
@@ -1193,8 +1193,8 @@ github.com/grafana/opentelemetry-collector/featuregate v0.0.0-20240325174506-2fd
 github.com/grafana/opentelemetry-collector/featuregate v0.0.0-20240325174506-2fd1623b2ca0/go.mod h1:mm8+xyQfgDmqhyegZRNIQmoKsNnDTwWKFLsdMoXAb7A=
 github.com/grafana/opentelemetry-ebpf-instrumentation v1.4.11 h1:Pi46xuPzRjAeB6XB4PzdF8kV93jl4NB58OZj08Bi33U=
 github.com/grafana/opentelemetry-ebpf-instrumentation v1.4.11/go.mod h1:rrgRM6X22UVa3bKaoNz43ab59Qx0CNrVOc2uiCVfBwU=
-github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260217121301-aa2759218aeb h1:qmTR6a7xR/jQFNIKPS/rK/pVLL6i7WwygbCw98VZ3BA=
-github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260217121301-aa2759218aeb/go.mod h1:oqSk8XwYnL4saX2ZdpfnTJV9vURSNaVjK6yomOAVIPI=
+github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260218104523-8370a3e0bc2f h1:lM3jBf19yCa8TssYj1jkx6LjlO6S9pcfT247FotLiSs=
+github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260218104523-8370a3e0bc2f/go.mod h1:oqSk8XwYnL4saX2ZdpfnTJV9vURSNaVjK6yomOAVIPI=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=
 github.com/grafana/otel-profiling-go v0.5.1/go.mod h1:ftN/t5A/4gQI19/8MoWurBEtC6gFw8Dns1sJZ9W4Tls=
 github.com/grafana/postgres_exporter v0.0.0-20250930111128-c8f6a9f4d363 h1:/vCopugIegPx9brm+E9+4bMQ6uIsZujCoE7su3bLLbk=


### PR DESCRIPTION
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style. For details on this,
  check out the Contributors Guide linked above.
-->

### Brief description of Pull Request

<!--
  Add a human-readable description of the PR that may be used as the commit body
  (i.e. "Extended description") when it gets merged.
-->

#### Summary
- Updates the eBPF profiler dependency to include the Go 1.26 `textStart` fix
- Minimal diff: only the profiler replace directive changes, no transitive dependency updates

#### Context
This is a follow-up to #5553 (dotnet nibble map backport). After deploying that fix, we discovered a second panic caused by Go 1.26 binaries on the cluster. This likely coincided with a Go 1.26 service being deployed or profiled for the first time — the panic wasn't visible earlier because no Go 1.26 binaries were being profiled when we validated the nibble map fix.

Go 1.26 sets `textStart` to 0 in pclntab. The v1.13 profiler had an initial workaround (`61a202a`) that reads the `.text` section address, but this doesn't always match the real `textStart` (e.g. cgo binaries, `-linkmode=external`). The mismatch causes integer overflow in PC offset calculations → `slice bounds out of range [-2147483344:]` **panic**.

The fix (`188cf50`) reads `textStart` from the `.go.module` section instead.

Both fixes are already included in main via #5543 (full upstream merge).

### Pull Request Details

<!-- Add a more detailed descripion of the Pull Request here, if needed. -->

### Issue(s) fixed by this Pull Request

<!--
  Uncomment the following line and fill in an issue number if you want a GitHub
  issue to be closed automatically when this PR gets merged.
-->

<!-- Fixes #issue_id -->

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->

You can see panics stopped after I deploy the test image with this fix https://dev.grafana-dev.net/goto/bfdm0fox36mtcf?orgId=stacks-13

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
