### PR TITLE
fix(prometheus.exporter.postgres): Update version of the exporter fork to fix pg_settings

### DIFF
--- a/collector/builder-config.yaml
+++ b/collector/builder-config.yaml
@@ -71,7 +71,7 @@ replaces:
   # TODO - remove forks when changes are merged upstream — non-singleton cadvisor
   - github.com/google/cadvisor => github.com/grafana/cadvisor v0.0.0-20240729082359-1f04a91701e2
   # TODO - track exporter-package-v0.18.1 branch of grafana fork; remove once merged upstream
-  - github.com/prometheus-community/postgres_exporter => github.com/grafana/postgres_exporter v0.0.0-20250930111128-c8f6a9f4d363
+  - github.com/prometheus-community/postgres_exporter => github.com/grafana/postgres_exporter v0.0.0-20260218135413-e22add1afabb
   # TODO - remove once PR is merged upstream - https://github.com/prometheus/mysqld_exporter/pull/774
   - github.com/prometheus/mysqld_exporter => github.com/grafana/mysqld_exporter v0.17.2-0.20250226152553-be612e3fdedd
   # TODO: replace node_exporter with custom fork for multi usage. https://github.com/prometheus/node_exporter/pull/2812

--- a/collector/go.mod
+++ b/collector/go.mod
@@ -1038,7 +1038,7 @@ replace github.com/thanos-io/objstore => github.com/grafana/objstore v0.0.0-2025
 
 replace github.com/google/cadvisor => github.com/grafana/cadvisor v0.0.0-20240729082359-1f04a91701e2
 
-replace github.com/prometheus-community/postgres_exporter => github.com/grafana/postgres_exporter v0.0.0-20250930111128-c8f6a9f4d363
+replace github.com/prometheus-community/postgres_exporter => github.com/grafana/postgres_exporter v0.0.0-20260218135413-e22add1afabb
 
 replace github.com/prometheus/mysqld_exporter => github.com/grafana/mysqld_exporter v0.17.2-0.20250226152553-be612e3fdedd
 

--- a/collector/go.sum
+++ b/collector/go.sum
@@ -1169,8 +1169,8 @@ github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260217121301-aa27
 github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260217121301-aa2759218aeb/go.mod h1:oqSk8XwYnL4saX2ZdpfnTJV9vURSNaVjK6yomOAVIPI=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=
 github.com/grafana/otel-profiling-go v0.5.1/go.mod h1:ftN/t5A/4gQI19/8MoWurBEtC6gFw8Dns1sJZ9W4Tls=
-github.com/grafana/postgres_exporter v0.0.0-20250930111128-c8f6a9f4d363 h1:/vCopugIegPx9brm+E9+4bMQ6uIsZujCoE7su3bLLbk=
-github.com/grafana/postgres_exporter v0.0.0-20250930111128-c8f6a9f4d363/go.mod h1:dOdKpz09HRMtkSs8kba90eNmrL81E+LMotcP7eW9/ek=
+github.com/grafana/postgres_exporter v0.0.0-20260218135413-e22add1afabb h1:zYE9mLwsO4EuAOSzqQF+G4fSjwzpwd3K4r/R5uYv0rY=
+github.com/grafana/postgres_exporter v0.0.0-20260218135413-e22add1afabb/go.mod h1:dOdKpz09HRMtkSs8kba90eNmrL81E+LMotcP7eW9/ek=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.8 h1:iwOtYXeeVSAeYefJNaxDytgjKtUuKQbJqgAIjlnicKg=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.8/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/grafana/pyroscope/api v1.2.0 h1:SfHDZcEZ4Vbj/Jj3bTOSpm4IDB33wLA2xBYxROhiL4U=

--- a/dependency-replacements.yaml
+++ b/dependency-replacements.yaml
@@ -81,7 +81,7 @@ replaces:
 
   - comment: TODO - track exporter-package-v0.18.1 branch of grafana fork; remove once merged upstream
     dependency: github.com/prometheus-community/postgres_exporter
-    replacement: github.com/grafana/postgres_exporter v0.0.0-20250930111128-c8f6a9f4d363
+    replacement: github.com/grafana/postgres_exporter v0.0.0-20260218135413-e22add1afabb
 
   - comment: TODO - remove once PR is merged upstream - https://github.com/prometheus/mysqld_exporter/pull/774
     dependency: github.com/prometheus/mysqld_exporter

--- a/extension/alloyengine/go.mod
+++ b/extension/alloyengine/go.mod
@@ -1028,7 +1028,7 @@ replace github.com/thanos-io/objstore => github.com/grafana/objstore v0.0.0-2025
 replace github.com/google/cadvisor => github.com/grafana/cadvisor v0.0.0-20240729082359-1f04a91701e2
 
 // TODO - track exporter-package-v0.18.1 branch of grafana fork; remove once merged upstream
-replace github.com/prometheus-community/postgres_exporter => github.com/grafana/postgres_exporter v0.0.0-20250930111128-c8f6a9f4d363
+replace github.com/prometheus-community/postgres_exporter => github.com/grafana/postgres_exporter v0.0.0-20260218135413-e22add1afabb
 
 // TODO - remove once PR is merged upstream - https://github.com/prometheus/mysqld_exporter/pull/774
 replace github.com/prometheus/mysqld_exporter => github.com/grafana/mysqld_exporter v0.17.2-0.20250226152553-be612e3fdedd

--- a/extension/alloyengine/go.sum
+++ b/extension/alloyengine/go.sum
@@ -1187,8 +1187,8 @@ github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260217121301-aa27
 github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260217121301-aa2759218aeb/go.mod h1:oqSk8XwYnL4saX2ZdpfnTJV9vURSNaVjK6yomOAVIPI=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=
 github.com/grafana/otel-profiling-go v0.5.1/go.mod h1:ftN/t5A/4gQI19/8MoWurBEtC6gFw8Dns1sJZ9W4Tls=
-github.com/grafana/postgres_exporter v0.0.0-20250930111128-c8f6a9f4d363 h1:/vCopugIegPx9brm+E9+4bMQ6uIsZujCoE7su3bLLbk=
-github.com/grafana/postgres_exporter v0.0.0-20250930111128-c8f6a9f4d363/go.mod h1:dOdKpz09HRMtkSs8kba90eNmrL81E+LMotcP7eW9/ek=
+github.com/grafana/postgres_exporter v0.0.0-20260218135413-e22add1afabb h1:zYE9mLwsO4EuAOSzqQF+G4fSjwzpwd3K4r/R5uYv0rY=
+github.com/grafana/postgres_exporter v0.0.0-20260218135413-e22add1afabb/go.mod h1:dOdKpz09HRMtkSs8kba90eNmrL81E+LMotcP7eW9/ek=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.8 h1:iwOtYXeeVSAeYefJNaxDytgjKtUuKQbJqgAIjlnicKg=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.8/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/grafana/pyroscope/api v1.2.0 h1:SfHDZcEZ4Vbj/Jj3bTOSpm4IDB33wLA2xBYxROhiL4U=

--- a/go.mod
+++ b/go.mod
@@ -1069,7 +1069,7 @@ replace github.com/thanos-io/objstore => github.com/grafana/objstore v0.0.0-2025
 replace github.com/google/cadvisor => github.com/grafana/cadvisor v0.0.0-20240729082359-1f04a91701e2
 
 // TODO - track exporter-package-v0.18.1 branch of grafana fork; remove once merged upstream
-replace github.com/prometheus-community/postgres_exporter => github.com/grafana/postgres_exporter v0.0.0-20250930111128-c8f6a9f4d363
+replace github.com/prometheus-community/postgres_exporter => github.com/grafana/postgres_exporter v0.0.0-20260218135413-e22add1afabb
 
 // TODO - remove once PR is merged upstream - https://github.com/prometheus/mysqld_exporter/pull/774
 replace github.com/prometheus/mysqld_exporter => github.com/grafana/mysqld_exporter v0.17.2-0.20250226152553-be612e3fdedd

--- a/go.sum
+++ b/go.sum
@@ -1197,8 +1197,8 @@ github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260217121301-aa27
 github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260217121301-aa2759218aeb/go.mod h1:oqSk8XwYnL4saX2ZdpfnTJV9vURSNaVjK6yomOAVIPI=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=
 github.com/grafana/otel-profiling-go v0.5.1/go.mod h1:ftN/t5A/4gQI19/8MoWurBEtC6gFw8Dns1sJZ9W4Tls=
-github.com/grafana/postgres_exporter v0.0.0-20250930111128-c8f6a9f4d363 h1:/vCopugIegPx9brm+E9+4bMQ6uIsZujCoE7su3bLLbk=
-github.com/grafana/postgres_exporter v0.0.0-20250930111128-c8f6a9f4d363/go.mod h1:dOdKpz09HRMtkSs8kba90eNmrL81E+LMotcP7eW9/ek=
+github.com/grafana/postgres_exporter v0.0.0-20260218135413-e22add1afabb h1:zYE9mLwsO4EuAOSzqQF+G4fSjwzpwd3K4r/R5uYv0rY=
+github.com/grafana/postgres_exporter v0.0.0-20260218135413-e22add1afabb/go.mod h1:dOdKpz09HRMtkSs8kba90eNmrL81E+LMotcP7eW9/ek=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.8 h1:iwOtYXeeVSAeYefJNaxDytgjKtUuKQbJqgAIjlnicKg=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.8/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/grafana/pyroscope/api v1.2.0 h1:SfHDZcEZ4Vbj/Jj3bTOSpm4IDB33wLA2xBYxROhiL4U=


### PR DESCRIPTION
### Brief description of Pull Request
Update version of the grafana fork of postgres_exporter to include a fix for a panic with Cloud Sql Postgres in pg_settings collector.

### Pull Request Details
The upstream fix is included in upstream postgres_exporter v0.19.0, which will be shipped with Alloy 1.14.0. This backport is targeted for Alloy 1.13.

Fork patch: https://github.com/grafana/postgres_exporter/pull/30

### Issue(s) fixed by this Pull Request
Fixes https://github.com/grafana/alloy/issues/5502

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
