### PR TITLE
chore: Fix flaky test

### DIFF
--- a/internal/component/common/loki/client/endpoint_test.go
+++ b/internal/component/common/loki/client/endpoint_test.go
@@ -404,7 +404,6 @@ func TestEndpoint(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			reg := prometheus.NewRegistry()
 
 			// Create a buffer channel where we do enqueue received requests


### PR DESCRIPTION
This is a really flaky test. `testing/synctest` is sadly a bad fit because we are doing [external I/O](https://go.dev/blog/synctest#io).