### PR TITLE
fix(mimir.rules.kubernetes): fix namespace prefixes with slashes

### DIFF
--- a/internal/component/mimir/rules/kubernetes/events.go
+++ b/internal/component/mimir/rules/kubernetes/events.go
@@ -386,8 +386,8 @@ func mimirNamespaceForRuleCRD(prefix string, pr *promv1.PrometheusRule) string {
 // Unmanaged namespaces are left as is by the operator.
 func isManagedMimirNamespace(prefix, namespace string) bool {
 	prefixPart := regexp.QuoteMeta(prefix)
-	namespacePart := `.+`
-	namePart := `.+`
+	namespacePart := `[^/]+`
+	namePart := `[^/]+`
 	uuidPart := `[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}`
 	managedNamespaceRegex := regexp.MustCompile(
 		fmt.Sprintf("^%s/%s/%s/%s$", prefixPart, namespacePart, namePart, uuidPart),

--- a/internal/component/mimir/rules/kubernetes/events_test.go
+++ b/internal/component/mimir/rules/kubernetes/events_test.go
@@ -493,6 +493,41 @@ func TestSourceTenants(t *testing.T) {
 	}
 }
 
+func TestIsManagedMimirNamespace(t *testing.T) {
+	tests := []struct {
+		name      string
+		prefix    string
+		namespace string
+		expected  bool
+	}{
+		{
+			name:      "simple prefix matches its own namespace",
+			prefix:    "alloy",
+			namespace: "alloy/namespace/name/64aab764-c95e-4ee9-a932-cd63ba57e6cf",
+			expected:  true,
+		},
+		{
+			name:      "prefix with slash matches its own namespace",
+			prefix:    "prefix/with/slashes",
+			namespace: "prefix/with/slashes/namespace/name/7f93a3fe-405d-4dae-9555-67290acbe173",
+			expected:  true,
+		},
+		{
+			name:      "shorter prefix must not match longer prefix namespace",
+			prefix:    "prefix",
+			namespace: "prefix/with/slashes/namespace/name/7f93a3fe-405d-4dae-9555-67290acbe173",
+			expected:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := isManagedMimirNamespace(tc.prefix, tc.namespace)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
 func testRuleIndexer() cache.Indexer {
 	ruleIndexer := cache.NewIndexer(
 		cache.DeletionHandlingMetaNamespaceKeyFunc,


### PR DESCRIPTION
### Fix alloy namespace matching for prefixes with slashes

*(First contribution! I felt the change was small enough to make a PR alone without a github issue. Please feel free to correct me if that's not the case)*

In the sync logic for `mimir.rules.kubernetes`, when a `mimir_namespace_prefix` has slashes in it, it's possible for another namespace prefix to match it if they start with the same substring.

This is because we're using `.+` in the logic to determine if a prefix matches the one we own. This is regex is too greedy and will match other prefixes.

Even so, `alloy` is happy to create the namespace with the slash-including prefix. This causes alloy to create rule groups, and then remove it during the next sync, causing churn.

I can think of 2 solutions to the problem:

- Fix the regex, as this change does.
- Disallow slashes in the mimir_namespace_prefix somehow. I'd like to use a slash here or there, personally.

### Pull Request Details

In [`isManagedMimirNamespace()`](https://github.com/grafana/alloy/blob/e4123217a7caa879f7910a61c3ec1f0188d75b0e/internal/component/mimir/rules/kubernetes/events.go#L385-L396
), we set:

```go
	prefixPart := regexp.QuoteMeta(prefix)
 	namespacePart := `.+` 
 	namePart := `.+` 
```

A few lines down in the func, we use this regex to figure out if we own a rule group in mimir:

```
		fmt.Sprintf("^%s/%s/%s/%s$", prefixPart, namespacePart, namePart, uuidPart),
```

If I were to have 2 writers with prefixes such as these below, they both match. Each writer then thinks it owns the rule group. See the examples farther down for more.

- `mycluster`
- `mycluster/myapp`

The fix of this PR is simply to change the `.+` regexes to less greedy ones that exclude the slashes, ie. `[^/]+`, like this:

```go
	prefixPart := regexp.QuoteMeta(prefix)
 	namespacePart := `[^/]+`
 	namePart := `[^/]+`
```

#### Example log output from alloy:

```
ts=2026-02-19T03:10:34.065775105Z level=info msg="added rule group" component_path=/ component_id=mimir.rules.kubernetes.myapp_rules namespace=mycluster/myapp/monitoring/myapp-certificates/2aa50786-cf8f-4f46-8989-ff139f638c6e group=myapp-certificates
ts=2026-02-19T03:11:58.359353877Z level=info msg="removed rule group" component_path=/ component_id=mimir.rules.kubernetes.default_rules namespace=mycluster/myapp/monitoring/myapp-certificates/2aa50786-cf8f-4f46-8989-ff139f638c6e group=myapp-certificates
```


#### Example mimir config snippet:

```
            // Sync myapp PrometheusRules to Mimir with an external label
            mimir.rules.kubernetes "myapp_rules" {
              address                = "http://my-mimir-endpoint"
              prometheus_http_prefix = "/prometheus"
              tenant_id              = "default"
              mimir_namespace_prefix = "mycluster/myapp"

              rule_selector {
                match_labels = { "app" = "myapp" }
              }

              external_labels = { "app" = "myapp" }
            }

            // Sync all other PrometheusRules to Mimir without the external label
            mimir.rules.kubernetes "default_rules" {
              address                = "http://my-mimir-endpoint"
              prometheus_http_prefix = "/prometheus"
              tenant_id              = "default"
              mimir_namespace_prefix = "mycluster"

              rule_selector {
                match_expression {
                  key      = "app"
                  operator = "NotIn"
                  values   = ["myapp"]
                }
              }

              external_labels = { "app" = "unknown" }
            }
```

### Notes to the Reviewer

- I'm using 2 components here because I can't pull a label from the PrometheusRule object onto the created rules. Instead, I can only statically add a hard-coded string via `external_labels`. This is might be a feature request.
- I've included a test of this behavior, called `TestIsManagedMimirNamespace`. It failed before the change, and it succeeded afterwards:

#### With the change

```
$ go test ./internal/component/mimir/rules/kubernetes/ -v -count=1 -run TestIsManagedMimirNamespace
=== RUN   TestIsManagedMimirNamespace
=== RUN   TestIsManagedMimirNamespace/simple_prefix_matches_its_own_namespace
=== RUN   TestIsManagedMimirNamespace/prefix_with_slash_matches_its_own_namespace
=== RUN   TestIsManagedMimirNamespace/shorter_prefix_must_not_match_longer_prefix_namespace
--- PASS: TestIsManagedMimirNamespace (0.00s)
    --- PASS: TestIsManagedMimirNamespace/simple_prefix_matches_its_own_namespace (0.00s)
    --- PASS: TestIsManagedMimirNamespace/prefix_with_slash_matches_its_own_namespace (0.00s)
    --- PASS: TestIsManagedMimirNamespace/shorter_prefix_must_not_match_longer_prefix_namespace (0.00s)
PASS
ok      github.com/grafana/alloy/internal/component/mimir/rules/kubernetes      0.549s
```

#### Without the change

```
$ go test ./internal/component/mimir/rules/kubernetes/ -v -count=1 -run TestIsManagedMimirNamespace
=== RUN   TestIsManagedMimirNamespace
=== RUN   TestIsManagedMimirNamespace/simple_prefix_matches_its_own_namespace
=== RUN   TestIsManagedMimirNamespace/prefix_with_slash_matches_its_own_namespace
=== RUN   TestIsManagedMimirNamespace/shorter_prefix_must_not_match_longer_prefix_namespace
    events_test.go:526:
                Error Trace:    /Users/jeff.wang/code/github/grafana/alloy/internal/component/mimir/rules/kubernetes/events_test.go:526
                Error:          Not equal:
                                expected: false
                                actual  : true
                Test:           TestIsManagedMimirNamespace/shorter_prefix_must_not_match_longer_prefix_namespace
--- FAIL: TestIsManagedMimirNamespace (0.00s)
    --- PASS: TestIsManagedMimirNamespace/simple_prefix_matches_its_own_namespace (0.00s)
    --- PASS: TestIsManagedMimirNamespace/prefix_with_slash_matches_its_own_namespace (0.00s)
    --- FAIL: TestIsManagedMimirNamespace/shorter_prefix_must_not_match_longer_prefix_namespace (0.00s)
FAIL
FAIL    github.com/grafana/alloy/internal/component/mimir/rules/kubernetes      0.570s
FAIL
```


### PR Checklist

- [x] Tests updated
