### PR TITLE
chore: Update apline version in build image

### DIFF
--- a/tools/build-image/Dockerfile
+++ b/tools/build-image/Dockerfile
@@ -15,15 +15,15 @@ ARG GO_RUNTIME=mustoverride
 #
 
 # Dependency: docker (for building images)
-FROM alpine:3.17 as docker
+FROM alpine:3.23 as docker
 RUN apk add --no-cache docker-cli docker-cli-buildx
 
 # Dependency: helm
-FROM alpine:3.17 as helm
+FROM alpine:3.23 as helm
 RUN apk add --no-cache helm
 
 # Dependency: nsis (for building Windows installers)
-FROM alpine:3.17 as nsis
+FROM alpine:3.23 as nsis
 RUN wget -nv https://nsis.sourceforge.io/mediawiki/images/4/4a/AccessControl.zip \
  && unzip AccessControl.zip -d /usr/share/nsis/ \
  && mkdir -p /usr/share/nsis/Plugins/x86-unicode \


### PR DESCRIPTION
Currently the docker version used in our ci for publishing alloy containers is broken due to version being to old.

We need to update apline version in build image to be able to get a newer version.