### PR TITLE
fix(helm): handle empty rbac.rules and rbac.clusterRules arrays

### DIFF
--- a/operations/helm/charts/alloy/templates/rbac.yaml
+++ b/operations/helm/charts/alloy/templates/rbac.yaml
@@ -11,7 +11,12 @@ metadata:
     {{- include "alloy.labels" $ | nindent 4 }}
     app.kubernetes.io/component: rbac
 rules:
-  {{- $.Values.rbac.rules | toYaml | nindent 2 }}
+  {{- $rules := $.Values.rbac.rules | default list }}
+  {{- if $rules }}
+  {{- $rules | toYaml | nindent 2 }}
+  {{- else }}
+  []
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -40,8 +45,12 @@ metadata:
     {{- include "alloy.labels" . | nindent 4 }}
     app.kubernetes.io/component: rbac
 rules:
-  {{- .Values.rbac.rules | toYaml | nindent 2 }}
-  {{- .Values.rbac.clusterRules | toYaml | nindent 2 }}
+  {{- $rules := concat (.Values.rbac.rules | default list) (.Values.rbac.clusterRules | default list) }}
+  {{- if $rules }}
+  {{- $rules | toYaml | nindent 2 }}
+  {{- else }}
+  []
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Summary

Closes #4778

When `rbac.rules` or `rbac.clusterRules` is set to an empty array (`[]`) in Helm values, the `rbac.yaml` template rendered two separate `toYaml` outputs back-to-back under the same `rules:` key:

```yaml
rules:
  []
  []
```

This produces invalid YAML, causing `helm template` to fail with:

```
Error: YAML parse error on alloy/templates/rbac.yaml:
error converting YAML to JSON: yaml: line 14: did not find expected key
```

## Root cause

The ClusterRole template rendered `rbac.rules` and `rbac.clusterRules` as two independent `toYaml` calls under a single `rules:` key. When both are empty arrays, Helm's `toYaml` emits `[]` twice, producing invalid YAML.

## Fix

- **ClusterRole**: merge `rules` and `clusterRules` into a single list via `concat` before rendering. If the combined list is empty, explicitly emit `[]` instead of nothing.
- **Role** (namespace-scoped): add the same empty-list guard for `rbac.rules`.

## Testing

```yaml
# values.yaml
rbac:
  create: true
  rules: []
  clusterRules: []
```

```sh
helm template alloy ./operations/helm/charts/alloy -f values.yaml
```

Before fix: ❌ YAML parse error  
After fix: ✅ renders correctly with `rules: []`

The default `values.yaml` (with non-empty rules) continues to render identically. Tested both the ClusterRole path and the Role path (when `rbac.namespaces` is set).