### PR TITLE
fix(loki.process): New `action_on_duplicate_timestamp` config attribute to fudge identical log timestamps

### DIFF
--- a/docs/sources/reference/components/loki/loki.process.md
+++ b/docs/sources/reference/components/loki/loki.process.md
@@ -1880,7 +1880,7 @@ The `action_on_failure` field defines what should happen when the source field d
 
 The supported actions are:
 
-* fudge (default): Change the timestamp to the last known timestamp, summing up 1 nanosecond to guarantee log entries ordering.
+* fudge (default): Change the timestamp to the last known timestamp, summing up 1 nanosecond to guarantee log entries ordering. When parsing succeeds, the stage also ensures that entries whose parsed timestamp is equal to (or before) the last emitted timestamp for that stream are advanced by 1 nanosecond, so that multiple messages with the exact same timestamp keep a stable order in Loki and Grafana.
 * skip: Don't change the timestamp and keep the time when the log entry was scraped.
 
 The following stage fetches the `time` value from the shared values map, parses it as a RFC3339 format, and sets it as the log entry's timestamp.

--- a/docs/sources/reference/components/loki/loki.process.md
+++ b/docs/sources/reference/components/loki/loki.process.md
@@ -1807,7 +1807,7 @@ The following arguments are supported:
 | `format`                        | `string`       | Determines how to parse the source string.                  |           | yes      |
 | `source`                        | `string`       | Name from extracted values map to use for the timestamp.    |           | yes      |
 | `action_on_failure`             | `string`       | What to do when the timestamp can't be extracted or parsed. | `"fudge"` | no       |
-| `action_on_duplicate_timestamp` | `string`       | What to do when parsing duplicate timestamps                | `"fudge"` | no       |
+| `action_on_duplicate_timestamp` | `string`       | What to do when parsing duplicate timestamps.               | `"fudge"` | no       |
 | `fallback_formats`              | `list(string)` | Fallback formats to try if the `format` field fails.        | `[]`      | no       |
 | `location`                      | `string`       | IANA Timezone Database location to use when parsing.        | `""`      | no       |
 

--- a/docs/sources/reference/components/loki/loki.process.md
+++ b/docs/sources/reference/components/loki/loki.process.md
@@ -1802,13 +1802,14 @@ When no timestamp stage is set, the log entry timestamp defaults to the time whe
 
 The following arguments are supported:
 
-| Name                | Type           | Description                                                 | Default   | Required |
-| ------------------- | -------------- | ----------------------------------------------------------- | --------- | -------- |
-| `format`            | `string`       | Determines how to parse the source string.                  |           | yes      |
-| `source`            | `string`       | Name from extracted values map to use for the timestamp.    |           | yes      |
-| `action_on_failure` | `string`       | What to do when the timestamp can't be extracted or parsed. | `"fudge"` | no       |
-| `fallback_formats`  | `list(string)` | Fallback formats to try if the `format` field fails.        | `[]`      | no       |
-| `location`          | `string`       | IANA Timezone Database location to use when parsing.        | `""`      | no       |
+| Name                            | Type           | Description                                                 | Default   | Required |
+| ------------------- ------------| -------------- | ----------------------------------------------------------- | --------- | -------- |
+| `format`                        | `string`       | Determines how to parse the source string.                  |           | yes      |
+| `source`                        | `string`       | Name from extracted values map to use for the timestamp.    |           | yes      |
+| `action_on_failure`             | `string`       | What to do when the timestamp can't be extracted or parsed. | `"fudge"` | no       |
+| `action_on_duplicate_timestamp` | `string`       | What to do when parsing duplicate timestamps                | `"fudge"` | no       |
+| `fallback_formats`              | `list(string)` | Fallback formats to try if the `format` field fails.        | `[]`      | no       |
+| `location`                      | `string`       | IANA Timezone Database location to use when parsing.        | `""`      | no       |
 
 {{< admonition type="note" >}}
 Be careful with further stages which may also override the timestamp.
@@ -1880,8 +1881,15 @@ The `action_on_failure` field defines what should happen when the source field d
 
 The supported actions are:
 
-* fudge (default): Change the timestamp to the last known timestamp, summing up 1 nanosecond to guarantee log entries ordering. When parsing succeeds, the stage also ensures that entries whose parsed timestamp is equal to (or before) the last emitted timestamp for that stream are advanced by 1 nanosecond, so that multiple messages with the exact same timestamp keep a stable order in Loki and Grafana.
+* fudge (default): Change the timestamp to the last known timestamp, summing up 1 nanosecond to guarantee log entries ordering.
 * skip: Don't change the timestamp and keep the time when the log entry was scraped.
+
+The `action_on_duplicate_timestamp` field defines what to do when parsing succeeds but the parsed timestamp is equal to (or before) the last emitted timestamp for that stream (for example, when multiple messages share the same second or millisecond).
+
+The supported actions are:
+
+* fudge (default): Set the entry timestamp to the last emitted timestamp plus 1 nanosecond so that message order is preserved in Loki and Grafana.
+* keep: Leave the parsed timestamp as-is; duplicate timestamps may appear out of order downstream.
 
 The following stage fetches the `time` value from the shared values map, parses it as a RFC3339 format, and sets it as the log entry's timestamp.
 

--- a/docs/sources/reference/components/loki/loki.process.md
+++ b/docs/sources/reference/components/loki/loki.process.md
@@ -1888,7 +1888,7 @@ The `action_on_duplicate_timestamp` field defines what to do when parsing succee
 
 The supported actions are:
 
-* fudge (default): Set the entry timestamp to the last emitted timestamp plus 1 nanosecond so that message order is preserved in Loki and Grafana.
+* fudge: Default. Set the entry timestamp to the last emitted timestamp plus 1 nanosecond so that message order is preserved in Loki and Grafana.
 * keep: Leave the parsed timestamp as-is; duplicate timestamps may appear out of order downstream.
 
 The following stage fetches the `time` value from the shared values map, parses it as a RFC3339 format, and sets it as the log entry's timestamp.

--- a/docs/sources/reference/components/loki/loki.process.md
+++ b/docs/sources/reference/components/loki/loki.process.md
@@ -1884,7 +1884,7 @@ The supported actions are:
 * fudge (default): Change the timestamp to the last known timestamp, summing up 1 nanosecond to guarantee log entries ordering.
 * skip: Don't change the timestamp and keep the time when the log entry was scraped.
 
-The `action_on_duplicate_timestamp` field defines what to do when parsing succeeds but the parsed timestamp is equal to, or before, the last emitted timestamp for that stream, for example, when multiple messages share the same second or millisecond.
+The `action_on_duplicate_timestamp` field defines what to do when parsing succeeds but the parsed timestamp is equal to the last emitted timestamp for that stream, for example, when multiple messages share the same second or millisecond.
 
 The supported actions are:
 

--- a/docs/sources/reference/components/loki/loki.process.md
+++ b/docs/sources/reference/components/loki/loki.process.md
@@ -1884,7 +1884,7 @@ The supported actions are:
 * fudge (default): Change the timestamp to the last known timestamp, summing up 1 nanosecond to guarantee log entries ordering.
 * skip: Don't change the timestamp and keep the time when the log entry was scraped.
 
-The `action_on_duplicate_timestamp` field defines what to do when parsing succeeds but the parsed timestamp is equal to (or before) the last emitted timestamp for that stream (for example, when multiple messages share the same second or millisecond).
+The `action_on_duplicate_timestamp` field defines what to do when parsing succeeds but the parsed timestamp is equal to, or before, the last emitted timestamp for that stream, for example, when multiple messages share the same second or millisecond.
 
 The supported actions are:
 

--- a/docs/sources/reference/components/loki/loki.process.md
+++ b/docs/sources/reference/components/loki/loki.process.md
@@ -1888,7 +1888,7 @@ The `action_on_duplicate_timestamp` field defines what to do when parsing succee
 
 The supported actions are:
 
-* fudge: Default. Set the entry timestamp to the last emitted timestamp plus 1 nanosecond so that message order is preserved in Loki and Grafana.
+* fudge (default): Set the entry timestamp to the last emitted timestamp plus 1 nanosecond so that message order is preserved in Loki and Grafana.
 * keep: Leave the parsed timestamp as-is; duplicate timestamps may appear out of order downstream.
 
 The following stage fetches the `time` value from the shared values map, parses it as a RFC3339 format, and sets it as the log entry's timestamp.

--- a/internal/component/loki/process/stages/timestamp.go
+++ b/internal/component/loki/process/stages/timestamp.go
@@ -15,27 +15,27 @@ import (
 
 // Config errors.
 var (
-	ErrEmptyTimestampStageConfig = errors.New("timestamp stage config cannot be empty")
-	ErrTimestampSourceRequired   = errors.New("timestamp source value is required if timestamp is specified")
-	ErrTimestampFormatRequired   = errors.New("timestamp format is required")
-	ErrInvalidLocation           = errors.New("invalid location specified: %v")
+	ErrEmptyTimestampStageConfig         = errors.New("timestamp stage config cannot be empty")
+	ErrTimestampSourceRequired           = errors.New("timestamp source value is required if timestamp is specified")
+	ErrTimestampFormatRequired           = errors.New("timestamp format is required")
+	ErrInvalidLocation                   = errors.New("invalid location specified: %v")
 	ErrInvalidActionOnFailure            = errors.New("invalid action on failure (supported values are %v)")
 	ErrInvalidActionOnDuplicateTimestamp = errors.New("invalid action on duplicate timestamp (supported values are %v)")
 	ErrTimestampSourceMissing            = errors.New("extracted data did not contain a timestamp")
-	ErrTimestampConversionFailed = errors.New("failed to convert extracted time to string")
-	ErrTimestampParsingFailed    = errors.New("failed to parse time")
+	ErrTimestampConversionFailed         = errors.New("failed to convert extracted time to string")
+	ErrTimestampParsingFailed            = errors.New("failed to parse time")
 
 	Unix   = "Unix"
 	UnixMs = "UnixMs"
 	UnixUs = "UnixUs"
 	UnixNs = "UnixNs"
 
-	TimestampActionOnFailureSkip     = "skip"
-	TimestampActionOnFailureFudge    = "fudge"
-	TimestampActionOnFailureDefault  = TimestampActionOnFailureFudge
+	TimestampActionOnFailureSkip    = "skip"
+	TimestampActionOnFailureFudge   = "fudge"
+	TimestampActionOnFailureDefault = TimestampActionOnFailureFudge
 
-	TimestampActionOnDuplicateTimestampKeep   = "keep"
-	TimestampActionOnDuplicateTimestampFudge  = "fudge"
+	TimestampActionOnDuplicateTimestampKeep    = "keep"
+	TimestampActionOnDuplicateTimestampFudge   = "fudge"
 	TimestampActionOnDuplicateTimestampDefault = TimestampActionOnDuplicateTimestampFudge
 
 	// Maximum number of "streams" for which we keep the last known timestamp

--- a/internal/component/loki/process/stages/timestamp.go
+++ b/internal/component/loki/process/stages/timestamp.go
@@ -144,10 +144,18 @@ func (ts *timestampStage) Process(labels model.LabelSet, extracted map[string]an
 	// Update the log entry timestamp with the parsed one
 	*t = *parsedTs
 
-	// The timestamp has been correctly parsed, so we should store it in the map
-	// containing the last known timestamp used by the "fudge" action on failure.
+	// When fudge is enabled, ensure multiple messages with the exact same parsed
+	// timestamp get distinct timestamps (lastKnown+1ns each) so message order is
+	// preserved in Loki and Grafana.
 	if ts.config.ActionOnFailure == TimestampActionOnFailureFudge {
-		ts.lastKnownTimestamps.Add(labels.String(), *t)
+		labelsStr := labels.String()
+		if lastTimestamp, ok := ts.lastKnownTimestamps.Get(labelsStr); ok {
+			lastKnown := lastTimestamp.(time.Time)
+			if !parsedTs.After(lastKnown) {
+				*t = lastKnown.Add(1 * time.Nanosecond)
+			}
+		}
+		ts.lastKnownTimestamps.Add(labelsStr, *t)
 	}
 }
 

--- a/internal/component/loki/process/stages/timestamp.go
+++ b/internal/component/loki/process/stages/timestamp.go
@@ -19,8 +19,9 @@ var (
 	ErrTimestampSourceRequired   = errors.New("timestamp source value is required if timestamp is specified")
 	ErrTimestampFormatRequired   = errors.New("timestamp format is required")
 	ErrInvalidLocation           = errors.New("invalid location specified: %v")
-	ErrInvalidActionOnFailure    = errors.New("invalid action on failure (supported values are %v)")
-	ErrTimestampSourceMissing    = errors.New("extracted data did not contain a timestamp")
+	ErrInvalidActionOnFailure            = errors.New("invalid action on failure (supported values are %v)")
+	ErrInvalidActionOnDuplicateTimestamp = errors.New("invalid action on duplicate timestamp (supported values are %v)")
+	ErrTimestampSourceMissing            = errors.New("extracted data did not contain a timestamp")
 	ErrTimestampConversionFailed = errors.New("failed to convert extracted time to string")
 	ErrTimestampParsingFailed    = errors.New("failed to parse time")
 
@@ -29,9 +30,13 @@ var (
 	UnixUs = "UnixUs"
 	UnixNs = "UnixNs"
 
-	TimestampActionOnFailureSkip    = "skip"
-	TimestampActionOnFailureFudge   = "fudge"
-	TimestampActionOnFailureDefault = TimestampActionOnFailureFudge
+	TimestampActionOnFailureSkip     = "skip"
+	TimestampActionOnFailureFudge    = "fudge"
+	TimestampActionOnFailureDefault  = TimestampActionOnFailureFudge
+
+	TimestampActionOnDuplicateTimestampKeep   = "keep"
+	TimestampActionOnDuplicateTimestampFudge  = "fudge"
+	TimestampActionOnDuplicateTimestampDefault = TimestampActionOnDuplicateTimestampFudge
 
 	// Maximum number of "streams" for which we keep the last known timestamp
 	maxLastKnownTimestampsCacheSize = 10000
@@ -41,13 +46,18 @@ var (
 // `action_on_failure` field.
 var TimestampActionOnFailureOptions = []string{TimestampActionOnFailureSkip, TimestampActionOnFailureFudge}
 
+// TimestampActionOnDuplicateTimestampOptions defines the available options for the
+// `action_on_duplicate_timestamp` field.
+var TimestampActionOnDuplicateTimestampOptions = []string{TimestampActionOnDuplicateTimestampKeep, TimestampActionOnDuplicateTimestampFudge}
+
 // TimestampConfig configures a processing stage for timestamp extraction.
 type TimestampConfig struct {
-	Source          string   `alloy:"source,attr"`
-	Format          string   `alloy:"format,attr"`
-	FallbackFormats []string `alloy:"fallback_formats,attr,optional"`
-	Location        *string  `alloy:"location,attr,optional"`
-	ActionOnFailure string   `alloy:"action_on_failure,attr,optional"`
+	Source                     string   `alloy:"source,attr"`
+	Format                     string   `alloy:"format,attr"`
+	FallbackFormats            []string `alloy:"fallback_formats,attr,optional"`
+	Location                   *string  `alloy:"location,attr,optional"`
+	ActionOnFailure            string   `alloy:"action_on_failure,attr,optional"`
+	ActionOnDuplicateTimestamp string   `alloy:"action_on_duplicate_timestamp,attr,optional"`
 }
 
 type parser func(string) (time.Time, error)
@@ -74,6 +84,15 @@ func validateTimestampConfig(cfg *TimestampConfig) (parser, error) {
 	} else {
 		if !slices.Contains(TimestampActionOnFailureOptions, cfg.ActionOnFailure) {
 			return nil, fmt.Errorf(ErrInvalidActionOnFailure.Error(), TimestampActionOnFailureOptions)
+		}
+	}
+
+	// Validate the action on duplicate timestamp and enforce the default
+	if cfg.ActionOnDuplicateTimestamp == "" {
+		cfg.ActionOnDuplicateTimestamp = TimestampActionOnDuplicateTimestampDefault
+	} else {
+		if !slices.Contains(TimestampActionOnDuplicateTimestampOptions, cfg.ActionOnDuplicateTimestamp) {
+			return nil, fmt.Errorf(ErrInvalidActionOnDuplicateTimestamp.Error(), TimestampActionOnDuplicateTimestampOptions)
 		}
 	}
 
@@ -104,7 +123,7 @@ func newTimestampStage(logger *slog.Logger, config TimestampConfig) (Stage, erro
 	}
 
 	var lastKnownTimestamps *lru.Cache
-	if config.ActionOnFailure == TimestampActionOnFailureFudge {
+	if config.ActionOnFailure == TimestampActionOnFailureFudge || config.ActionOnDuplicateTimestamp == TimestampActionOnDuplicateTimestampFudge {
 		lastKnownTimestamps, err = lru.New(maxLastKnownTimestampsCacheSize)
 		if err != nil {
 			return nil, err
@@ -144,17 +163,19 @@ func (ts *timestampStage) Process(labels model.LabelSet, extracted map[string]an
 	// Update the log entry timestamp with the parsed one
 	*t = *parsedTs
 
-	// When fudge is enabled, ensure multiple messages with the exact same parsed
-	// timestamp get distinct timestamps (lastKnown+1ns each) so message order is
-	// preserved in Loki and Grafana.
-	if ts.config.ActionOnFailure == TimestampActionOnFailureFudge {
-		labelsStr := labels.String()
+	// When action_on_duplicate_timestamp is fudge, ensure multiple messages with the
+	// exact same parsed timestamp get distinct timestamps (lastKnown+1ns each) so
+	// message order is preserved in Loki and Grafana.
+	labelsStr := labels.String()
+	if ts.config.ActionOnDuplicateTimestamp == TimestampActionOnDuplicateTimestampFudge && ts.lastKnownTimestamps != nil {
 		if lastTimestamp, ok := ts.lastKnownTimestamps.Get(labelsStr); ok {
 			lastKnown := lastTimestamp.(time.Time)
 			if !parsedTs.After(lastKnown) {
 				*t = lastKnown.Add(1 * time.Nanosecond)
 			}
 		}
+	}
+	if (ts.config.ActionOnFailure == TimestampActionOnFailureFudge || ts.config.ActionOnDuplicateTimestamp == TimestampActionOnDuplicateTimestampFudge) && ts.lastKnownTimestamps != nil {
 		ts.lastKnownTimestamps.Add(labelsStr, *t)
 	}
 }

--- a/internal/component/loki/process/stages/timestamp.go
+++ b/internal/component/loki/process/stages/timestamp.go
@@ -138,6 +138,15 @@ func newTimestampStage(logger *slog.Logger, config TimestampConfig) (Stage, erro
 	}), nil
 }
 
+// timestampCacheEntry holds both the original parsed timestamp and the last
+// adjusted (output) timestamp for a given stream. lastParsed is used for
+// equality comparison so fudging only triggers on truly duplicate inputs,
+// while lastAdjusted is the base for computing the next +1ns offset.
+type timestampCacheEntry struct {
+	lastParsed   time.Time
+	lastAdjusted time.Time
+}
+
 type timestampStage struct {
 	config *TimestampConfig
 	logger *slog.Logger
@@ -169,14 +178,14 @@ func (ts *timestampStage) Process(labels model.LabelSet, extracted map[string]an
 	labelsStr := labels.String()
 	if ts.config.ActionOnDuplicateTimestamp == TimestampActionOnDuplicateTimestampFudge && ts.lastKnownTimestamps != nil {
 		if lastTimestamp, ok := ts.lastKnownTimestamps.Get(labelsStr); ok {
-			lastKnown := lastTimestamp.(time.Time)
-			if !parsedTs.After(lastKnown) {
-				*t = lastKnown.Add(1 * time.Nanosecond)
+			entry := lastTimestamp.(timestampCacheEntry)
+			if parsedTs.Equal(entry.lastParsed) {
+				*t = entry.lastAdjusted.Add(1 * time.Nanosecond)
 			}
 		}
 	}
 	if (ts.config.ActionOnFailure == TimestampActionOnFailureFudge || ts.config.ActionOnDuplicateTimestamp == TimestampActionOnDuplicateTimestampFudge) && ts.lastKnownTimestamps != nil {
-		ts.lastKnownTimestamps.Add(labelsStr, *t)
+		ts.lastKnownTimestamps.Add(labelsStr, timestampCacheEntry{lastParsed: *parsedTs, lastAdjusted: *t})
 	}
 }
 
@@ -225,9 +234,10 @@ func (ts *timestampStage) processActionOnFailureFudge(labels model.LabelSet, t *
 		return
 	}
 
-	// Fudge the timestamp
-	*t = lastTimestamp.(time.Time).Add(1 * time.Nanosecond)
+	// Fudge the timestamp based on the last adjusted (output) value
+	entry := lastTimestamp.(timestampCacheEntry)
+	*t = entry.lastAdjusted.Add(1 * time.Nanosecond)
 
 	// Store the fudged timestamp, so that a subsequent fudged timestamp will be 1ns after it
-	ts.lastKnownTimestamps.Add(labelsStr, *t)
+	ts.lastKnownTimestamps.Add(labelsStr, timestampCacheEntry{lastParsed: entry.lastParsed, lastAdjusted: *t})
 }

--- a/internal/component/loki/process/stages/timestamp_test.go
+++ b/internal/component/loki/process/stages/timestamp_test.go
@@ -344,6 +344,23 @@ func TestTimestampStage_ProcessActionOnFailure(t *testing.T) {
 				mustParseTime(time.RFC3339Nano, "2019-10-01T01:02:03.500000000Z"),
 			},
 		},
+		"should add nanoseconds to identical parsed timestamps to preserve message order": {
+			config: TimestampConfig{
+				Source:          "time",
+				Format:          time.RFC3339Nano,
+				ActionOnFailure: TimestampActionOnFailureFudge,
+			},
+			inputEntries: []inputEntry{
+				{timestamp: time.Unix(1, 0), extracted: map[string]any{"time": "2019-10-01T01:02:03.400000000Z"}},
+				{timestamp: time.Unix(1, 0), extracted: map[string]any{"time": "2019-10-01T01:02:03.400000000Z"}},
+				{timestamp: time.Unix(1, 0), extracted: map[string]any{"time": "2019-10-01T01:02:03.400000000Z"}},
+			},
+			expectedTimestamps: []time.Time{
+				mustParseTime(time.RFC3339Nano, "2019-10-01T01:02:03.400000000Z"),
+				mustParseTime(time.RFC3339Nano, "2019-10-01T01:02:03.400000001Z"),
+				mustParseTime(time.RFC3339Nano, "2019-10-01T01:02:03.400000002Z"),
+			},
+		},
 		"should fudge the timestamp based on the last known value on timestamp parsing failure": {
 			config: TimestampConfig{
 				Source: "time",

--- a/internal/component/loki/process/stages/timestamp_test.go
+++ b/internal/component/loki/process/stages/timestamp_test.go
@@ -116,9 +116,23 @@ func TestTimestampValidation(t *testing.T) {
 			},
 			err: nil,
 			expectedConfig: &TimestampConfig{
-				Source:          "source1",
-				Format:          time.RFC3339,
-				ActionOnFailure: "fudge",
+				Source:                     "source1",
+				Format:                     time.RFC3339,
+				ActionOnFailure:            "fudge",
+				ActionOnDuplicateTimestamp: "fudge",
+			},
+		},
+		"sets default action on duplicate timestamp": {
+			config: &TimestampConfig{
+				Source: "source1",
+				Format: time.RFC3339,
+			},
+			err: nil,
+			expectedConfig: &TimestampConfig{
+				Source:                     "source1",
+				Format:                     time.RFC3339,
+				ActionOnFailure:            "fudge",
+				ActionOnDuplicateTimestamp: "fudge",
 			},
 		},
 		"custom format with year": {
@@ -165,6 +179,14 @@ func TestTimestampValidation(t *testing.T) {
 				ActionOnFailure: "foo",
 			},
 			err: fmt.Errorf(ErrInvalidActionOnFailure.Error(), TimestampActionOnFailureOptions),
+		},
+		"should fail on invalid action on duplicate timestamp": {
+			config: &TimestampConfig{
+				Source:                     "source1",
+				Format:                     time.RFC3339,
+				ActionOnDuplicateTimestamp: "invalid",
+			},
+			err: fmt.Errorf(ErrInvalidActionOnDuplicateTimestamp.Error(), TimestampActionOnDuplicateTimestampOptions),
 		},
 		"fallback formats contains the format": {
 			config: &TimestampConfig{
@@ -346,9 +368,10 @@ func TestTimestampStage_ProcessActionOnFailure(t *testing.T) {
 		},
 		"should add nanoseconds to identical parsed timestamps to preserve message order": {
 			config: TimestampConfig{
-				Source:          "time",
-				Format:          time.RFC3339Nano,
-				ActionOnFailure: TimestampActionOnFailureFudge,
+				Source:                     "time",
+				Format:                     time.RFC3339Nano,
+				ActionOnFailure:            TimestampActionOnFailureFudge,
+				ActionOnDuplicateTimestamp: TimestampActionOnDuplicateTimestampFudge,
 			},
 			inputEntries: []inputEntry{
 				{timestamp: time.Unix(1, 0), extracted: map[string]any{"time": "2019-10-01T01:02:03.400000000Z"}},
@@ -359,6 +382,24 @@ func TestTimestampStage_ProcessActionOnFailure(t *testing.T) {
 				mustParseTime(time.RFC3339Nano, "2019-10-01T01:02:03.400000000Z"),
 				mustParseTime(time.RFC3339Nano, "2019-10-01T01:02:03.400000001Z"),
 				mustParseTime(time.RFC3339Nano, "2019-10-01T01:02:03.400000002Z"),
+			},
+		},
+		"action_on_duplicate_timestamp=keep leaves identical timestamps unchanged": {
+			config: TimestampConfig{
+				Source:                     "time",
+				Format:                     time.RFC3339Nano,
+				ActionOnFailure:            TimestampActionOnFailureFudge,
+				ActionOnDuplicateTimestamp: TimestampActionOnDuplicateTimestampKeep,
+			},
+			inputEntries: []inputEntry{
+				{timestamp: time.Unix(1, 0), extracted: map[string]any{"time": "2019-10-01T01:02:03.400000000Z"}},
+				{timestamp: time.Unix(1, 0), extracted: map[string]any{"time": "2019-10-01T01:02:03.400000000Z"}},
+				{timestamp: time.Unix(1, 0), extracted: map[string]any{"time": "2019-10-01T01:02:03.400000000Z"}},
+			},
+			expectedTimestamps: []time.Time{
+				mustParseTime(time.RFC3339Nano, "2019-10-01T01:02:03.400000000Z"),
+				mustParseTime(time.RFC3339Nano, "2019-10-01T01:02:03.400000000Z"),
+				mustParseTime(time.RFC3339Nano, "2019-10-01T01:02:03.400000000Z"),
 			},
 		},
 		"should fudge the timestamp based on the last known value on timestamp parsing failure": {

--- a/internal/component/loki/process/stages/timestamp_test.go
+++ b/internal/component/loki/process/stages/timestamp_test.go
@@ -122,19 +122,6 @@ func TestTimestampValidation(t *testing.T) {
 				ActionOnDuplicateTimestamp: "fudge",
 			},
 		},
-		"sets default action on duplicate timestamp": {
-			config: &TimestampConfig{
-				Source: "source1",
-				Format: time.RFC3339,
-			},
-			err: nil,
-			expectedConfig: &TimestampConfig{
-				Source:                     "source1",
-				Format:                     time.RFC3339,
-				ActionOnFailure:            "fudge",
-				ActionOnDuplicateTimestamp: "fudge",
-			},
-		},
 		"custom format with year": {
 			config: &TimestampConfig{
 				Source: "source1",

--- a/internal/component/loki/process/stages/timestamp_test.go
+++ b/internal/component/loki/process/stages/timestamp_test.go
@@ -109,7 +109,7 @@ func TestTimestampValidation(t *testing.T) {
 			testString:   "2012-11-01T22:08:41-04:00",
 			expectedTime: time.Date(2012, 11, 01, 22, 8, 41, 0, time.FixedZone("", -4*60*60)),
 		},
-		"sets default action on failure": {
+		"sets default action on failure and on duplicate timestamp": {
 			config: &TimestampConfig{
 				Source: "source1",
 				Format: time.RFC3339,


### PR DESCRIPTION
### Brief description of Pull Request

When multiple log entries parse to the exact same timestamp (e.g. millisecond precision), they kept that identical value and their order was not guaranteed in Loki/Grafana. This change extends the existing "fudge" behaviour to the success path: when action_on_failure is "fudge", entries whose parsed timestamp is equal to or before the last emitted timestamp for that stream are advanced by 1 nanosecond so message order is preserved.

### Pull Request Details
**Problem:** With stage.timestamp, lines that parse to the same timestamp (common with limited precision formats) kept the same value. Alloy did not guarantee their relative order, so Loki could return them in any order and Grafana dashboards could show lines shuffled on refresh.

**Solution:** When action_on_failure = "fudge" (default), the stage now also applies fudge on success: if the parsed timestamp is not strictly after the last known timestamp for that stream, the entry’s timestamp is set to lastKnown + 1ns and the cache is updated. This reuses the existing LRU cache and 1ns step; no new config. With action_on_failure = "skip", behaviour is unchanged.

**Code:** In timestamp.go, the success path checks the last known timestamp when fudge is enabled and, when parsedTs <= lastKnown, assigns lastKnown.Add(1*time.Nanosecond) and updates the cache.
Test: New case in TestTimestampStage_ProcessActionOnFailure: multiple entries with the same "time" value; expected output timestamps are strictly increasing (parsed, +1ns, +2ns).

**Docs:** loki.process.md updated to state that with fudge, successfully parsed timestamps that are equal to or before the last emitted for the stream are advanced by 1ns to preserve message order.

### Issue(s) fixed by this Pull Request
Fixes: #3837
 
### Notes to the Reviewer

Fudge-on-success only runs when action_on_failure = "fudge"; the cache is already created in that case, so no extra allocation.
Existing test "should keep the parsed timestamp on success" still passes (distinct timestamps 03.400 vs 03.500, so no fudging).
Run: go test -v -race ./internal/component/loki/process/stages/... -run TestTimestampStage to verify.


### PR Checklist

- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
