### PR TITLE
chore: Copilot comments review

### DIFF
--- a/docs/sources/reference/components/otelcol/otelcol.exporter.kafka.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.kafka.md
@@ -200,7 +200,7 @@ The following arguments are supported:
 
 | Name                 | Type     | Description                                         | Default   | Required |
 | -------------------- | -------- | --------------------------------------------------- | --------- | -------- |
-| `compression`        | `string` | Time to wait between retries.                       | `"none"`  | no       |
+| `compression`        | `string` | Compression codec to use for produced messages.     | `"none"`  | no       |
 | `flush_max_messages` | `number` | Maximum number of messages to buffer before flushing to the broker. | `10000`   | no       |
 | `max_message_bytes`  | `number` | The maximum permitted size of a message in bytes.   | `1000000` | no       |
 | `required_acks`      | `number` | Controls when a message is regarded as transmitted. | `1`       | no       |

--- a/go.mod
+++ b/go.mod
@@ -778,7 +778,7 @@ require (
 	github.com/oklog/ulid/v2 v2.1.1 // indirect
 	github.com/open-telemetry/opamp-go v0.22.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension v0.143.0 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.143.0 // indirect; indirect)
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.143.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages v0.143.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/ecsutil v0.143.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.143.0 // indirect

--- a/internal/component/otelcol/exporter/kafka/kafka.go
+++ b/internal/component/otelcol/exporter/kafka/kafka.go
@@ -161,8 +161,8 @@ type Producer struct {
 	CompressionParams CompressionParams `alloy:"compression_params,block,optional"`
 
 	// The maximum number of messages the producer will send in a single
-	// broker request. Defaults to 0 for unlimited. Similar to
-	// `queue.buffering.max.messages` in the JVM producer.
+	// broker request. Defaults to 10000. Set to 0 for unlimited.
+	// Similar to `queue.buffering.max.messages` in the JVM producer.
 	FlushMaxMessages int `alloy:"flush_max_messages,attr,optional"`
 
 	// Whether or not to allow automatic topic creation.

--- a/internal/component/otelcol/receiver/awscloudwatch/awscloudwatch_test.go
+++ b/internal/component/otelcol/receiver/awscloudwatch/awscloudwatch_test.go
@@ -51,6 +51,8 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 						autodiscover {
 							prefix = "app-"
 							limit = 10
+							account_identifiers = ["111111111111", "222222222222"]
+							include_linked_accounts = true
 							streams {
 								prefixes = ["api-", "web-"]
 								names = ["main", "error"]
@@ -69,8 +71,10 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 					MaxEventsPerRequest: 1000,
 					Groups: awscloudwatchreceiver.GroupConfig{
 						AutodiscoverConfig: &awscloudwatchreceiver.AutodiscoverConfig{
-							Prefix: "app-",
-							Limit:  10,
+							Prefix:                "app-",
+							Limit:                 10,
+							AccountIdentifiers:    []string{"111111111111", "222222222222"},
+							IncludeLinkedAccounts: boolPtr(true),
 							Streams: awscloudwatchreceiver.StreamConfig{
 								Prefixes: []*string{ptr("api-"), ptr("web-")},
 								Names:    []*string{ptr("main"), ptr("error")},
@@ -201,6 +205,23 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 	}
 }
 
+func TestAutodiscoverConfig_Convert_DefaultLimitWhenUnset(t *testing.T) {
+	defaults := awscloudwatch.AutodiscoverConfig{}
+	defaults.SetToDefault()
+	require.NotNil(t, defaults.Limit)
+
+	cfg := &awscloudwatch.AutodiscoverConfig{
+		Prefix: "app-",
+		Streams: awscloudwatch.StreamConfig{
+			Prefixes: []*string{ptr("api-")},
+		},
+	}
+
+	converted := cfg.Convert()
+	require.NotNil(t, converted)
+	require.Equal(t, *defaults.Limit, converted.Limit)
+}
+
 func TestArguments_Validate(t *testing.T) {
 	tests := []struct {
 		testName      string
@@ -285,4 +306,8 @@ func TestArguments_Validate(t *testing.T) {
 // Helper function to create string pointers
 func ptr(s string) *string {
 	return &s
+}
+
+func boolPtr(b bool) *bool {
+	return &b
 }

--- a/internal/component/otelcol/receiver/awscloudwatch/config_awscloudwatch.go
+++ b/internal/component/otelcol/receiver/awscloudwatch/config_awscloudwatch.go
@@ -77,9 +77,15 @@ func (args *AutodiscoverConfig) Convert() *awscloudwatchreceiver.AutodiscoverCon
 	if args == nil {
 		return nil
 	}
+
+	limit := defaultLogGroupLimit
+	if args.Limit != nil {
+		limit = *args.Limit
+	}
+
 	return &awscloudwatchreceiver.AutodiscoverConfig{
 		Prefix:                args.Prefix,
-		Limit:                 *args.Limit,
+		Limit:                 limit,
 		Streams:               args.Streams.Convert(),
 		AccountIdentifiers:    args.AccountIdentifiers,
 		IncludeLinkedAccounts: args.IncludeLinkedAccounts,


### PR DESCRIPTION
### Brief description of Pull Request

Addresses all five Copilot review comments from PR #5605.

### Pull Request Details

This PR incorporates fixes based on Copilot's review of PR #5605, specifically:

*   **awscloudwatch receiver:**
    *   Hardened `AutodiscoverConfig.Convert` to safely handle `Limit == nil` by falling back to `defaultLogGroupLimit`.
    *   Extended `awscloudwatch_test.go` to cover `account_identifiers`, `include_linked_accounts` propagation, and default limit behavior when unset.
*   **kafka exporter:**
    *   Updated `flush_max_messages` comment in `kafka.go` to reflect the default `10000` and clarify `0` for unlimited buffering.
    *   Corrected `compression` description in `otelcol.exporter.kafka.md` documentation.
*   **go.mod:**
    *   Cleaned up a malformed inline comment.

### Issue(s) fixed by this Pull Request

Fixes #5605 (indirectly, by addressing review comments)

### Notes to the Reviewer

These changes directly address the inline review comments provided by Copilot on PR #5605.

### PR Checklist

- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated

---
<p><a href="https://cursor.com/agents?id=bc-58762c54-f7fc-41d8-ba80-fb91792277b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58762c54-f7fc-41d8-ba80-fb91792277b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

