### PR TITLE
feat(loki.secretfilter): Add configurable `disabled_rules` config option for default gitleaks config

### DIFF
--- a/docs/sources/reference/components/loki/loki.secretfilter.md
+++ b/docs/sources/reference/components/loki/loki.secretfilter.md
@@ -46,17 +46,18 @@ loki.secretfilter "<LABEL>" {
 
 You can use the following arguments with `loki.secretfilter`:
 
-| Name              | Type                 | Description                                                                                                          | Default | Required |
-| ----------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------- | ------- | -------- |
-| `forward_to`      | `list(LogsReceiver)` | List of receivers to send log entries to.                                                                            |         | yes      |
-| `gitleaks_config` | `string`             | Path to a custom Gitleaks TOML config file. If empty, the default Gitleaks config is used.                           | `""`    | no       |
-| `origin_label`    | `string`             | Loki label to use for the `secrets_redacted_by_origin` metric. If empty, that metric is not registered.              | `""`    | no       |
-| `redact_with`     | `string`             | Template for the redaction placeholder. Use `$SECRET_NAME` and `$SECRET_HASH`. E.g.: `"<$SECRET_NAME:$SECRET_HASH>"` | `""`    | no       |
-| `redact_percent`  | `uint`               | When `redact_with` is not set: percent of the secret to redact (1–100), where 100 is full redaction                  | `80`    | no       |
+| Name              | Type                 | Description                                                                                                          | Default               | Required |
+| ----------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------- | --------------------- | -------- |
+| `forward_to`      | `list(LogsReceiver)` | List of receivers to send log entries to.                                                                            |                       | yes      |
+| `gitleaks_config` | `string`             | Path to a custom Gitleaks TOML config file. If empty, the default Gitleaks config is used.                           | `""`                  | no       |
+| `disabled_rules`  | `list(string)`       | When `gitleaks_config` is not set: Gitleaks rule IDs to disable from the default gitleaks config.                    | `["generic-api-key"]` | no       |
+| `origin_label`    | `string`             | Loki label to use for the `secrets_redacted_by_origin` metric. If empty, that metric is not registered.              | `""`                  | no       |
+| `redact_with`     | `string`             | Template for the redaction placeholder. Use `$SECRET_NAME` and `$SECRET_HASH`. E.g.: `"<$SECRET_NAME:$SECRET_HASH>"` | `""`                  | no       |
+| `redact_percent`  | `uint`               | When `redact_with` is not set: percent of the secret to redact (1–100), where 100 is full redaction.                 | `80`                  | no       |
 
 The `gitleaks_config` argument is the path to a custom [Gitleaks TOML config file][gitleaks-config].
 The file supports the standard Gitleaks structure (rules, allowlists, and `[extend]` to extend the default config).
-If `gitleaks_config` is empty, the component uses the default Gitleaks configuration [embedded in the component][embedded-config].
+If `gitleaks_config` is empty, the component uses the default Gitleaks configuration with the rules listed in `disabled_rules` removed (default: `["generic-api-key"]` to reduce noise).
 
 {{< admonition type="note" >}}
 The default configuration may change between {{< param "PRODUCT_NAME" >}} versions.
@@ -74,8 +75,6 @@ For consistent behavior, use an external configuration file via `gitleaks_config
   When `redact_percent` is 0 or unset, 80% redaction is used.
 
 **Origin metric:** The `origin_label` argument specifies which Loki label to use for the `secrets_redacted_by_origin` metric, so you can track how many secrets were redacted per source or environment.
-
-[embedded-config]: https://github.com/grafana/alloy/blob/{{< param "ALLOY_RELEASE" >}}/internal/component/loki/secretfilter/gitleaks.toml
 
 ## Blocks
 

--- a/internal/component/loki/secretfilter/secretfilter_test.go
+++ b/internal/component/loki/secretfilter/secretfilter_test.go
@@ -177,11 +177,12 @@ var tt = []struct {
 		testLogs["npm_token"].log,
 		true,
 	},
+	// Default embedded config disables generic-api-key rule, so no redaction for this pattern.
 	{
 		"generic_api_key",
 		testConfigs["default"],
 		testLogs["generic_api_key"].log,
-		true,
+		false,
 	},
 	{
 		"multiple_secrets",


### PR DESCRIPTION
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style. For details on this,
  check out the Contributors Guide linked above.
-->

### Brief description of Pull Request

This PR adds a new optional argument for secretfilter called `disabled_rules`. This is a set of rule names for gitleaks that will be disabled when `gitleaks_config` is not set, that is, when we're using the default gitleaks config.
It defaults to `['generic-api-key]`. We have added this because we've identified this rule to create too many false positives.

### Additional Details

The gitleaks library provides an easy way to start a detector without having to ship the default config file alongside. In order to keep it that way the loading of the default config has been modified, so as to take into account the `disabled_rules` argument.

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [x] Tests updated

