### PR TITLE
feat: Add healthcheck CLI subcommand for container health checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,8 @@ RUN groupadd --gid $UID $USERNAME \
     && chown -R $USERNAME:$USERNAME /var/lib/alloy \
     && chmod -R 770 /var/lib/alloy
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD ["/bin/alloy", "healthcheck"]
 ENTRYPOINT ["/bin/alloy"]
 ENV ALLOY_DEPLOY_MODE=docker
 CMD ["run", "/etc/alloy/config.alloy", "--storage.path=/var/lib/alloy/data"]

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -92,6 +92,8 @@ COPY --from=builder ["/src/alloy/example-config.alloy", "C:/Program Files/Grafan
 # OpenTelemetry Collector helm chart and other ecosystem tools that expect otelcol binary.
 COPY ["packaging/docker/otelcol.cmd", "C:/Program Files/GrafanaLabs/Alloy/otelcol.cmd"]
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD ["C:/Program Files/GrafanaLabs/Alloy/alloy.exe", "healthcheck"]
 ENTRYPOINT ["C:/Program Files/GrafanaLabs/Alloy/alloy.exe"]
 ENV ALLOY_DEPLOY_MODE=docker
 CMD ["run", "C:/Program Files/GrafanaLabs/Alloy/config.alloy", "--storage.path=C:/ProgramData/GrafanaLabs/Alloy/data"]

--- a/docs/sources/reference/cli/_index.md
+++ b/docs/sources/reference/cli/_index.md
@@ -16,6 +16,7 @@ Available commands:
 
 * [`convert`][convert]: Convert an {{< param "PRODUCT_NAME" >}} configuration file.
 * [`fmt`][fmt]: Format an {{< param "PRODUCT_NAME" >}} configuration file.
+* [`healthcheck`][healthcheck]: Check the health of a running {{< param "PRODUCT_NAME" >}} instance.
 * [`run`][run]: Start {{< param "PRODUCT_NAME" >}} with the Default Engine, given an Alloy syntax configuration file.
 * [`otel`][otel]: Start {{< param "PRODUCT_NAME" >}} with the experimental OTel Engine, given an Open Telemetry Collector YAML configuration file.
 * [`tools`][tools]: Read the WAL and provide statistical information.
@@ -23,6 +24,7 @@ Available commands:
 * `help`: Print help for supported commands.
 
 [run]: ./run/
+[healthcheck]: ./healthcheck/
 [fmt]: ./fmt/
 [convert]: ./convert/
 [otel]: ./otel/

--- a/docs/sources/reference/cli/healthcheck.md
+++ b/docs/sources/reference/cli/healthcheck.md
@@ -1,0 +1,66 @@
+---
+canonical: https://grafana.com/docs/alloy/latest/reference/cli/healthcheck/
+description: Learn about the healthcheck command
+labels:
+  stage: general-availability
+  products:
+    - oss
+title: healthcheck
+weight: 250
+---
+
+# `healthcheck`
+
+The `healthcheck` command checks the health of a running {{< param "PRODUCT_NAME" >}} instance.
+
+## Usage
+
+```shell
+alloy healthcheck [<FLAG> ...]
+```
+
+Replace the following:
+
+* _`<FLAG>`_: One or more flags that define the input and output of the command.
+
+The `healthcheck` command queries a running {{< param "PRODUCT_NAME" >}} instance's health endpoint by making an HTTP `GET` request.
+If the endpoint returns an `HTTP 200` status, the command exits with code `0`.
+Otherwise, the command exits with a non-zero exit code.
+
+By default, the command queries the `/-/ready` endpoint at `127.0.0.1:12345`.
+Use `healthcheck` in Docker `HEALTHCHECK` instructions or other orchestration tools to monitor the health of {{< param "PRODUCT_NAME" >}} without external utilities like `curl` or `wget`.
+
+The following flags are supported:
+
+* `--url`: Full URL to check. Overrides `--addr` and `--path`.
+* `--addr`: Address of the running {{< param "PRODUCT_NAME" >}} instance (default `"127.0.0.1:12345"`).
+* `--path`: Path to the health endpoint (default `"/-/ready"`).
+* `--timeout`: Timeout for the HTTP request (default `"5s"`).
+
+## Docker HEALTHCHECK
+
+To use `healthcheck` in a Docker container, add a `HEALTHCHECK` instruction to your Dockerfile:
+
+```dockerfile
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD ["alloy", "healthcheck"]
+```
+
+If your {{< param "PRODUCT_NAME" >}} instance listens on a custom address, pass the `--addr` flag:
+
+```dockerfile
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD ["alloy", "healthcheck", "--addr=0.0.0.0:9090"]
+```
+
+## Health endpoints
+
+{{< param "PRODUCT_NAME" >}} exposes two health endpoints:
+
+- **`/-/ready`**: Returns `HTTP 200` if {{< param "PRODUCT_NAME" >}} has loaded its initial configuration. Returns `HTTP 503` otherwise. This is the default endpoint used by `healthcheck`.
+- **`/-/healthy`**: Returns `HTTP 200` if all components are healthy. Returns `HTTP 500` with the names of unhealthy components otherwise.
+
+The `/-/ready` endpoint is recommended for container health checks because it indicates whether {{< param "PRODUCT_NAME" >}} is functional.
+The `/-/healthy` endpoint checks individual component health, which can cause unnecessary container restarts during transient component issues.
+
+For more information, refer to the [HTTP endpoints](../../http/) reference.

--- a/internal/alloycli/alloycli.go
+++ b/internal/alloycli/alloycli.go
@@ -24,6 +24,7 @@ func Command() *cobra.Command {
 	cmd.AddCommand(
 		convertCommand(),
 		fmtCommand(),
+		healthcheckCommand(),
 		RunCommand(),
 		toolsCommand(),
 		validateCommand(),

--- a/internal/alloycli/cmd_healthcheck.go
+++ b/internal/alloycli/cmd_healthcheck.go
@@ -1,0 +1,94 @@
+package alloycli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func healthcheckCommand() *cobra.Command {
+	h := &alloyHealthcheck{
+		addr:    "127.0.0.1:12345",
+		path:    "/-/ready",
+		timeout: 5 * time.Second,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "healthcheck [flags]",
+		Short: "Check the health of a running Alloy instance",
+		Long: `The healthcheck subcommand queries a running Alloy instance to determine
+its health.
+
+By default, healthcheck queries the /-/ready endpoint of the instance running
+at 127.0.0.1:12345. A successful health check returns exit code 0. A failed
+health check returns a non-zero exit code.
+
+Use healthcheck in Docker HEALTHCHECK instructions or other orchestration
+tools to monitor the health of Alloy without external utilities like curl
+or wget.`,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return h.Run()
+		},
+	}
+
+	cmd.Flags().StringVar(&h.url, "url", h.url, "Full URL to check. Overrides --addr and --path.")
+	cmd.Flags().StringVar(&h.addr, "addr", h.addr, "Address of the running Alloy instance.")
+	cmd.Flags().StringVar(&h.path, "path", h.path, "Path to the health endpoint.")
+	cmd.Flags().DurationVar(&h.timeout, "timeout", h.timeout, "Timeout for the HTTP request.")
+
+	return cmd
+}
+
+type alloyHealthcheck struct {
+	url     string
+	addr    string
+	path    string
+	timeout time.Duration
+}
+
+func (h *alloyHealthcheck) Run() error {
+	targetURL := h.url
+	if targetURL == "" {
+		targetURL = fmt.Sprintf("http://%s%s", h.addr, h.path)
+	} else if !strings.HasPrefix(targetURL, "http://") && !strings.HasPrefix(targetURL, "https://") {
+		targetURL = "http://" + targetURL
+	}
+
+	client := &http.Client{}
+
+	ctx, cancel := context.WithTimeout(context.Background(), h.timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetURL, nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusOK {
+		fmt.Fprint(os.Stdout, string(body))
+		return nil
+	}
+
+	fmt.Fprint(os.Stderr, string(body))
+	return fmt.Errorf("unhealthy: HTTP status %d", resp.StatusCode)
+}

--- a/internal/alloycli/cmd_healthcheck_test.go
+++ b/internal/alloycli/cmd_healthcheck_test.go
@@ -1,0 +1,125 @@
+package alloycli
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthcheckRun_Ready(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/-/ready", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "Alloy is ready.")
+	}))
+	defer srv.Close()
+
+	h := &alloyHealthcheck{
+		url:     srv.URL + "/-/ready",
+		timeout: 5 * time.Second,
+	}
+	err := h.Run()
+	require.NoError(t, err)
+}
+
+func TestHealthcheckRun_NotReady(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		fmt.Fprintln(w, "Alloy is not ready.")
+	}))
+	defer srv.Close()
+
+	h := &alloyHealthcheck{
+		url:     srv.URL + "/-/ready",
+		timeout: 5 * time.Second,
+	}
+	err := h.Run()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "503")
+}
+
+func TestHealthcheckRun_UnhealthyComponents(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/-/healthy", r.URL.Path)
+		http.Error(w, "unhealthy components: comp1, comp2", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	h := &alloyHealthcheck{
+		url:     srv.URL + "/-/healthy",
+		timeout: 5 * time.Second,
+	}
+	err := h.Run()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestHealthcheckRun_ConnectionRefused(t *testing.T) {
+	h := &alloyHealthcheck{
+		addr:    "127.0.0.1:0",
+		path:    "/-/ready",
+		timeout: 1 * time.Second,
+	}
+	err := h.Run()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "request failed")
+}
+
+func TestHealthcheckRun_URLOverridesAddr(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "OK")
+	}))
+	defer srv.Close()
+
+	h := &alloyHealthcheck{
+		url:     srv.URL + "/-/ready",
+		addr:    "should-not-be-used:9999",
+		path:    "/should-not-be-used",
+		timeout: 5 * time.Second,
+	}
+	err := h.Run()
+	require.NoError(t, err)
+}
+
+func TestHealthcheckRun_URLWithoutScheme(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/-/ready", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "Alloy is ready.")
+	}))
+	defer srv.Close()
+
+	// Strip the "http://" prefix to simulate a user passing a URL without scheme.
+	urlWithoutScheme := strings.TrimPrefix(srv.URL, "http://") + "/-/ready"
+
+	h := &alloyHealthcheck{
+		url:     urlWithoutScheme,
+		timeout: 5 * time.Second,
+	}
+	err := h.Run()
+	require.NoError(t, err)
+}
+
+func TestHealthcheckRun_AddrAndPathConstruction(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/-/healthy", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "All Alloy components are healthy.")
+	}))
+	defer srv.Close()
+
+	h := &alloyHealthcheck{
+		addr:    srv.Listener.Addr().String(),
+		path:    "/-/healthy",
+		timeout: 5 * time.Second,
+	}
+	err := h.Run()
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

- Add a built-in `alloy healthcheck` CLI command that queries a running Alloy instance's health endpoint via HTTP
- Enable Docker `HEALTHCHECK` instructions in both Linux and Windows Dockerfiles without requiring external utilities like `curl` or `wget`
- Add CLI reference documentation for the new command

Closes #1891