### PR TITLE
fix(prometheus.echo): Return zero for SeriesRef

### DIFF
--- a/internal/component/prometheus/echo/echo.go
+++ b/internal/component/prometheus/echo/echo.go
@@ -146,10 +146,8 @@ func (a *echoAppender) Append(ref storage.SeriesRef, l labels.Labels, t int64, v
 		PrintTimestamp: t > 0,
 	}
 
-	if ref == 0 {
-		ref = storage.SeriesRef(len(a.samples))
-	}
-	return ref, nil
+	// Zero indicates echo does not care about SeriesRefs
+	return 0, nil
 }
 
 func (a *echoAppender) AppendExemplar(ref storage.SeriesRef, l labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
@@ -162,10 +160,8 @@ func (a *echoAppender) AppendExemplar(ref storage.SeriesRef, l labels.Labels, e 
 		Exemplar: e,
 	}
 
-	if ref == 0 {
-		ref = storage.SeriesRef(1)
-	}
-	return ref, nil
+	// Zero indicates echo does not care about SeriesRefs
+	return 0, nil
 }
 
 func (a *echoAppender) AppendHistogram(ref storage.SeriesRef, l labels.Labels, t int64, h *histogram.Histogram, fh *histogram.FloatHistogram) (storage.SeriesRef, error) {
@@ -180,10 +176,8 @@ func (a *echoAppender) AppendHistogram(ref storage.SeriesRef, l labels.Labels, t
 		}
 	}
 
-	if ref == 0 {
-		ref = storage.SeriesRef(len(a.histograms))
-	}
-	return ref, nil
+	// Zero indicates echo does not care about SeriesRefs
+	return 0, nil
 }
 
 func (a *echoAppender) UpdateMetadata(ref storage.SeriesRef, l labels.Labels, m metadata.Metadata) (storage.SeriesRef, error) {
@@ -195,10 +189,8 @@ func (a *echoAppender) UpdateMetadata(ref storage.SeriesRef, l labels.Labels, m 
 		a.metadata[metricName] = m
 	}
 
-	if ref == 0 {
-		ref = storage.SeriesRef(1)
-	}
-	return ref, nil
+	// Zero indicates echo does not care about SeriesRefs
+	return 0, nil
 }
 
 func (a *echoAppender) AppendSTZeroSample(ref storage.SeriesRef, l labels.Labels, t, st int64) (storage.SeriesRef, error) {
@@ -213,10 +205,8 @@ func (a *echoAppender) AppendSTZeroSample(ref storage.SeriesRef, l labels.Labels
 		PrintTimestamp: t > 0,
 	}
 
-	if ref == 0 {
-		ref = storage.SeriesRef(len(a.samples))
-	}
-	return ref, nil
+	// Zero indicates echo does not care about SeriesRefs
+	return 0, nil
 }
 
 func (a *echoAppender) AppendHistogramSTZeroSample(ref storage.SeriesRef, l labels.Labels, t, st int64, h *histogram.Histogram, fh *histogram.FloatHistogram) (storage.SeriesRef, error) {
@@ -231,10 +221,8 @@ func (a *echoAppender) AppendHistogramSTZeroSample(ref storage.SeriesRef, l labe
 		}
 	}
 
-	if ref == 0 {
-		ref = storage.SeriesRef(len(a.histograms))
-	}
-	return ref, nil
+	// Zero indicates echo does not care about SeriesRefs
+	return 0, nil
 }
 
 func (a *echoAppender) Commit() error {

--- a/internal/component/prometheus/echo/echo_test.go
+++ b/internal/component/prometheus/echo/echo_test.go
@@ -75,7 +75,7 @@ func TestAppender_BasicMetrics(t *testing.T) {
 
 	ref, err := appender.Append(0, lbls, time.Now().Unix(), 42.0)
 	require.NoError(t, err)
-	require.NotEqual(t, storage.SeriesRef(0), ref)
+	require.Equal(t, storage.SeriesRef(0), ref)
 
 	err = appender.Commit()
 	require.NoError(t, err)


### PR DESCRIPTION
### Brief description of Pull Request

Make sure prometheus.echo always returns zero for SeriesRefs. The current implementation will return an non-zero unstable SeriesRef which will interfere with the implementation of https://github.com/grafana/alloy/issues/5062. This component shouldn't be returning a SeriesRef as it's not creating or managing one and when it's the only component in use in a pipeline this will prevent unnecessary overhead to manage these unstable refs in fanout + prometheus.scrape.

### Issue(s) fixed by this Pull Request

Related to https://github.com/grafana/alloy/issues/5062

### PR Checklist

- [x] Tests updated
