### PR TITLE
feat: Add option to "logging" block to redirect logs to Windows Event Log

### DIFF
--- a/docs/sources/reference/config-blocks/logging.md
+++ b/docs/sources/reference/config-blocks/logging.md
@@ -25,13 +25,14 @@ logging {
 
 You can use the following arguments with `logging`:
 
-| Name       | Type                 | Description                                | Default    | Required |
-| ---------- | -------------------- | ------------------------------------------ | ---------- | -------- |
-| `format`   | `string`             | Format to use for writing log lines        | `"logfmt"` | no       |
-| `level`    | `string`             | Level at which log lines should be written | `"info"`   | no       |
-| `write_to` | `list(LogsReceiver)` | List of receivers to send log entries to   | `[]`       | no       |
+| Name          | Type                 | Description                                  | Default       | Required |
+| ------------- | -------------------- | -------------------------------------------- | ------------- | -------- |
+| `destination` | `string`             | Primary log destination.                     | __See below__ | no       |
+| `format`      | `string`             | Format to use for writing log lines.         | `"logfmt"`    | no       |
+| `level`       | `string`             | Level at which log lines should be written.  | `"info"`      | no       |
+| `write_to`    | `list(LogsReceiver)` | List of receivers to send log entries to.    | `[]`          | no       |
 
-### Log level
+### `level`
 
 The following strings are recognized as valid log levels:
 
@@ -40,30 +41,29 @@ The following strings are recognized as valid log levels:
 * `"info"`: Only write logs at _info_ level or above.
 * `"debug"`: Write all logs, including _debug_ level logs.
 
-### Log format
+### `format`
 
 The following strings are recognized as valid log line formats:
 
 * `"json"`: Write logs as JSON objects.
 * `"logfmt"`: Write logs as [`logfmt`][logfmt] lines.
 
-### Log receivers
+### `write_to`
 
 The `write_to` argument allows {{< param "PRODUCT_NAME" >}} to tee its log entries to one or more `loki.*` component log receivers in addition to the default [location][].
 This, for example can be the export of a `loki.write` component to send log entries directly to Loki, or a `loki.relabel` component to add a certain label first.
 
-## Log location
+### `destination`
 
-{{< param "PRODUCT_NAME" >}} writes all logs to `stderr`.
+The following strings are recognized as valid log destinations:
 
-When you run {{< param "PRODUCT_NAME" >}} as a systemd service, you can view logs written to `stderr` through `journald`.
+* `"stderr"`: Write logs to `stderr`.
+* `"windows_event_log"`:  Windows only. Write logs to the Windows Event Log under the "Alloy" source.
 
-When you run {{< param "PRODUCT_NAME" >}} as a container, you can view logs written to `stderr` through `docker logs` or `kubectl logs`, depending on whether Docker or Kubernetes was used for deploying {{< param "PRODUCT_NAME" >}}.
+The default value of `destination` is set to `"windows_event_log"` when {{< param "PRODUCT_NAME" >}} runs as a Windows service.
+Otherwise, `destination` defaults to `"stderr"`.
 
-When you run {{< param "PRODUCT_NAME" >}} as a Windows service, logs are written as event logs.
-You can view the logs through Event Viewer.
-
-In other cases, redirect `stderr` of the {{< param "PRODUCT_NAME" >}} process to a file for logs to persist on disk.
+{{< param "PRODUCT_NAME" >}} fails to start if `destination` is set to `"windows_event_log"` and {{< param "PRODUCT_NAME" >}} is not running on Windows.
 
 ## Retrieve logs
 
@@ -72,6 +72,9 @@ You can retrieve the logs in different ways depending on your platform and insta
 **Linux:**
 
 * If you're running {{< param "PRODUCT_NAME" >}} with systemd, use `journalctl -u alloy`.
+
+**Docker:**
+
 * If you're running {{< param "PRODUCT_NAME" >}} in a Docker container, use `docker logs CONTAINER_ID`.
 
 **macOS:**
@@ -89,6 +92,7 @@ You can retrieve the logs in different ways depending on your platform and insta
 **All platforms:**
 
 * {{< param "PRODUCT_NAME" >}} writes logs to `stderr` if started directly without a service manager.
+  Redirect `stderr` of the {{< param "PRODUCT_NAME" >}} process to a file for logs to persist on disk.
 
 ## Example
 

--- a/integration-tests/windows-service/windows_service_test.go
+++ b/integration-tests/windows-service/windows_service_test.go
@@ -84,6 +84,8 @@ func TestWindowsService(t *testing.T) {
 		assert.FileExists(c, uninstallerPath, "uninstaller should exist after install")
 	}, waitTimeout*waitAttempts, waitTimeout)
 
+	// TODO: Use unique component names and check for logs and metrics containing that component name.
+	//       It could be a hash. This way we guarantee that we won't be using stale logs or metrics.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		util.EnsureServiceRunning(c, t, serviceName)
 	}, waitTimeout*waitAttempts, waitTimeout)

--- a/internal/converter/internal/otelcolconvert/converter_service_telemetry.go
+++ b/internal/converter/internal/otelcolconvert/converter_service_telemetry.go
@@ -57,8 +57,9 @@ func convertLogging(file *builder.File, tel otelconftelemetry.LogsConfig) diag.D
 	diags.AddAll(formatDiags)
 
 	logOpts := &logging.Options{
-		Level:  convertLoggingLevel(tel.Level),
-		Format: format,
+		Level:       convertLoggingLevel(tel.Level),
+		Format:      format,
+		Destination: logging.LogDestinationStderr,
 	}
 
 	block := common.NewBlockWithOverride([]string{"logging"}, "", logOpts)

--- a/internal/converter/internal/staticconvert/internal/build/builder_logging.go
+++ b/internal/converter/internal/staticconvert/internal/build/builder_logging.go
@@ -21,7 +21,8 @@ func (b *ConfigBuilder) appendLogging(config *server.Config) {
 
 func toLogging(config *server.Config) *logging.Options {
 	return &logging.Options{
-		Level:  logging.Level(config.LogLevel.String()),
-		Format: logging.Format(config.LogFormat),
+		Level:       logging.Level(config.LogLevel.String()),
+		Format:      logging.Format(config.LogFormat),
+		Destination: logging.LogDestinationStderr,
 	}
 }

--- a/internal/runtime/logging/eventlog/eventlog.go
+++ b/internal/runtime/logging/eventlog/eventlog.go
@@ -1,0 +1,14 @@
+package eventlog
+
+// EventLog is the interface for writing to the Windows Event Log.
+// It can be implemented by the real Windows event log or by a mock for testing.
+type EventLog interface {
+	Info(id uint32, msg string) error
+	Warning(id uint32, msg string) error
+	Error(id uint32, msg string) error
+	Close() error
+}
+
+// EventLogOpener opens an event log for the given service name.
+// When nil, the default opener is used (real on Windows, stub on other platforms).
+type EventLogOpener func(serviceName string) (EventLog, error)

--- a/internal/runtime/logging/eventlog/eventlog_unix.go
+++ b/internal/runtime/logging/eventlog/eventlog_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package eventlog
+
+import "errors"
+
+var errNotSupported = errors.New("windows event log not supported on this platform")
+
+// getEventLogOpener returns the platform's EventLogOpener (stub on non-Windows).
+func GetEventLogOpener() EventLogOpener {
+	return func(serviceName string) (EventLog, error) {
+		return nil, errNotSupported
+	}
+}

--- a/internal/runtime/logging/eventlog/eventlog_windows.go
+++ b/internal/runtime/logging/eventlog/eventlog_windows.go
@@ -1,0 +1,47 @@
+//go:build windows
+
+package eventlog
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/sys/windows/svc/eventlog"
+)
+
+// GetEventLogOpener returns the platform's EventLogOpener (real on Windows, stub elsewhere).
+func GetEventLogOpener() EventLogOpener {
+	return openEventLogWindows
+}
+
+// realEventLog wraps the Windows event log and implements EventLog.
+type realEventLog struct {
+	el *eventlog.Log
+}
+
+var _ EventLog = (*realEventLog)(nil)
+
+func (r *realEventLog) Info(id uint32, msg string) error    { return r.el.Info(id, msg) }
+func (r *realEventLog) Warning(id uint32, msg string) error { return r.el.Warning(id, msg) }
+func (r *realEventLog) Error(id uint32, msg string) error   { return r.el.Error(id, msg) }
+func (r *realEventLog) Close() error {
+	if r.el != nil {
+		return r.el.Close()
+	}
+	return nil
+}
+
+// openEventLogWindows installs the event source (if needed) and opens the event log.
+// It is the default EventLogOpener on Windows.
+func openEventLogWindows(serviceName string) (EventLog, error) {
+	eventTypes := uint32(eventlog.Info | eventlog.Warning | eventlog.Error)
+	err := eventlog.InstallAsEventCreate(serviceName, eventTypes)
+	if err != nil && !strings.Contains(err.Error(), "already exists") {
+		return nil, fmt.Errorf("failed to install event source: %w", err)
+	}
+	el, err := eventlog.Open(serviceName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open event log: %w", err)
+	}
+	return &realEventLog{el: el}, nil
+}

--- a/internal/runtime/logging/eventlog/eventlog_windows.go
+++ b/internal/runtime/logging/eventlog/eventlog_windows.go
@@ -6,8 +6,11 @@ import (
 	"fmt"
 	"strings"
 
+	"golang.org/x/sys/windows/registry"
 	"golang.org/x/sys/windows/svc/eventlog"
 )
+
+const eventLogAppRegPath = `SYSTEM\CurrentControlSet\Services\EventLog\Application\`
 
 // GetEventLogOpener returns the platform's EventLogOpener (real on Windows, stub elsewhere).
 func GetEventLogOpener() EventLogOpener {
@@ -31,13 +34,45 @@ func (r *realEventLog) Close() error {
 	return nil
 }
 
+// isEventSourceRegistered reports whether the named event source has a
+// registry entry under HKLM\...\EventLog\Application. Uses read-only
+// QUERY_VALUE access on the subkey, which is granted to all users by
+// default — no admin rights required. A false return means "not present,
+// or we can't tell"; the caller then falls through to
+// InstallAsEventCreate, which surfaces any deeper permission issue.
+func isEventSourceRegistered(serviceName string) bool {
+	key, err := registry.OpenKey(
+		registry.LOCAL_MACHINE,
+		eventLogAppRegPath+serviceName,
+		registry.QUERY_VALUE,
+	)
+	if err != nil {
+		return false
+	}
+	_ = key.Close()
+	return true
+}
+
 // openEventLogWindows installs the event source (if needed) and opens the event log.
 // It is the default EventLogOpener on Windows.
+//
+// Registering a new event source writes to HKLM and requires administrator
+// rights. To let non-admin runs proceed when the source is already
+// registered, we probe the registry read-only first and skip the install
+// entirely on a hit.
+//
+// TODO: Also do the registration in the Alloy Windows installer.
+// That way users don't have to run Alloy with admin rights one time just for this to be installed.
 func openEventLogWindows(serviceName string) (EventLog, error) {
-	eventTypes := uint32(eventlog.Info | eventlog.Warning | eventlog.Error)
-	err := eventlog.InstallAsEventCreate(serviceName, eventTypes)
-	if err != nil && !strings.Contains(err.Error(), "already exists") {
-		return nil, fmt.Errorf("failed to install event source: %w", err)
+	if !isEventSourceRegistered(serviceName) {
+		eventTypes := uint32(eventlog.Info | eventlog.Warning | eventlog.Error)
+		if err := eventlog.InstallAsEventCreate(serviceName, eventTypes); err != nil &&
+			!strings.Contains(err.Error(), "already exists") {
+			return nil, fmt.Errorf(
+				"event source %q is not registered and registration requires administrator rights; "+
+					"register it once via the Alloy installer or by running Alloy as administrator (underlying error: %w)",
+				serviceName, err)
+		}
 	}
 	el, err := eventlog.Open(serviceName)
 	if err != nil {

--- a/internal/runtime/logging/eventlog/testutil/mock.go
+++ b/internal/runtime/logging/eventlog/testutil/mock.go
@@ -1,0 +1,48 @@
+package testutil
+
+import (
+	"sync"
+)
+
+// MockEventLog is an EventLog implementation for testing on any OS.
+type MockEventLog struct {
+	mu       sync.Mutex
+	Infos    []string
+	Warnings []string
+	Errors   []string
+	closed   bool
+}
+
+func (m *MockEventLog) Info(id uint32, msg string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Infos = append(m.Infos, msg)
+	return nil
+}
+func (m *MockEventLog) Warning(id uint32, msg string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Warnings = append(m.Warnings, msg)
+	return nil
+}
+func (m *MockEventLog) Error(id uint32, msg string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Errors = append(m.Errors, msg)
+	return nil
+}
+func (m *MockEventLog) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.closed = true
+	return nil
+}
+
+// reset clears recorded messages for reuse in subtests.
+func (m *MockEventLog) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Infos = nil
+	m.Warnings = nil
+	m.Errors = nil
+}

--- a/internal/runtime/logging/eventlog/testutil/mock.go
+++ b/internal/runtime/logging/eventlog/testutil/mock.go
@@ -38,6 +38,13 @@ func (m *MockEventLog) Close() error {
 	return nil
 }
 
+// Closed reports whether Close has been called.
+func (m *MockEventLog) Closed() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.closed
+}
+
 // reset clears recorded messages for reuse in subtests.
 func (m *MockEventLog) Reset() {
 	m.mu.Lock()

--- a/internal/runtime/logging/handler.go
+++ b/internal/runtime/logging/handler.go
@@ -37,6 +37,17 @@ type handler struct {
 	currentFormat Format
 	inner         slog.Handler
 	replacer      func(groups []string, a slog.Attr) slog.Attr
+
+	eventLogPool sync.Pool
+}
+
+// eventLogScratch bundles a reusable buffer with a slog handler that
+// writes into it. format records which Format the cached handler was
+// built for, so a runtime format change triggers a rebuild.
+type eventLogScratch struct {
+	buf    *bytes.Buffer
+	hdlr   slog.Handler
+	format Format
 }
 
 // nesting is used since attrs and groups need to be nested in the order they were entered.
@@ -78,26 +89,37 @@ func (h *handler) Handle(ctx context.Context, r slog.Record) error {
 // which knows about the event log and the record level. Only used when
 // the event log destination is active.
 func (h *handler) handleWithEventLog(ctx context.Context, r slog.Record) error {
-	buf := bytesPool.Get().(*bytes.Buffer)
-	buf.Reset()
+	// A pool (rather than buildHandler's single shared handler) because this
+	// path reads buf.Bytes() back after Handle to pass them plus the level to Dispatch.
+	s := h.getEventLogScratch()
 	defer func() {
-		buf.Reset()
-		bytesPool.Put(buf)
+		s.buf.Reset()
+		h.eventLogPool.Put(s)
 	}()
 
-	if err := h.newSlogHandler(buf).Handle(ctx, r); err != nil {
+	if err := s.hdlr.Handle(ctx, r); err != nil {
 		return err
 	}
-	if buf.Len() == 0 {
+	if s.buf.Len() == 0 {
 		return nil // No need to dispatch empty log entries.
 	}
-	return h.w.Dispatch(buf.Bytes(), &r.Level)
+	return h.w.Dispatch(s.buf.Bytes(), &r.Level)
 }
 
-// bytesPool reuses bytes.Buffer instances across event-log slow-path
-// calls to avoid an allocation per record.
-var bytesPool = sync.Pool{
-	New: func() any { return new(bytes.Buffer) },
+// getEventLogScratch returns scratch space whose cached handler matches
+// the current format, rebuilding the handler only when the format
+// changed (or on first use). The returned buffer is already empty.
+func (h *handler) getEventLogScratch() *eventLogScratch {
+	expectFormat := h.formatter.Format()
+	s, _ := h.eventLogPool.Get().(*eventLogScratch)
+	if s == nil {
+		s = &eventLogScratch{buf: new(bytes.Buffer)}
+	}
+	if s.hdlr == nil || s.format != expectFormat {
+		s.hdlr = h.newSlogHandler(s.buf)
+		s.format = expectFormat
+	}
+	return s
 }
 
 // newSlogHandler constructs a fresh slog handler writing into w, with the

--- a/internal/runtime/logging/handler.go
+++ b/internal/runtime/logging/handler.go
@@ -22,10 +22,8 @@ import (
 // JSON or logfmt, and create a new inner handler if needed.
 
 type handler struct {
-	// w owns every sink: innerWriter (stderr), lokiWriter, tmpWriter, and the
-	// optional Windows event log. Records are formatted through a pooled slog
-	// handler that writes into a leveledWriter, which forwards the bytes plus
-	// the record's level to w.Dispatch.
+	// w owns every sink: innerWriter (stderr), lokiWriter, tmpWriter,
+	// and the optional Windows event log.
 	w         *writerVar
 	leveler   slog.Leveler
 	formatter formatter
@@ -41,14 +39,15 @@ type handler struct {
 	scratchPool sync.Pool
 }
 
-// scratch bundles a leveledWriter with a slog handler that writes through it.
-// The slog handler formats the record and writes the bytes straight to the
-// configured sinks via the leveledWriter, which carries the record's level.
-// format records which Format the cached handler was built for, so a runtime
-// format change triggers a rebuild.
 type scratch struct {
-	lw     *leveledWriter
-	hdlr   slog.Handler
+	// Carries the record's level.
+	lw *leveledWriter
+
+	// Formats the record and writes the bytes straight to the configured sinks.
+	hdlr slog.Handler
+
+	// Records which format the cached handler was built for,
+	// so a runtime format change triggers a rebuild.
 	format Format
 }
 
@@ -70,12 +69,6 @@ func (h *handler) Enabled(ctx context.Context, l slog.Level) bool {
 }
 
 func (h *handler) Handle(ctx context.Context, r slog.Record) error {
-	// Record the level on the leveledWriter, then let the cached slog handler
-	// format the record and write straight through to writerVar.Dispatch. The
-	// level lets Dispatch pick the event log's Info/Warning/Error API when one
-	// is attached; the stderr/loki/tmp sinks ignore it. Dispatch fans out to
-	// whichever sinks are active (writing nowhere if none are), so there's no
-	// separate "is anything listening?" pre-check here.
 	s := h.getScratch()
 	defer h.scratchPool.Put(s)
 
@@ -92,15 +85,15 @@ func (h *handler) getScratch() *scratch {
 		s = &scratch{lw: &leveledWriter{w: h.w}}
 	}
 	if s.hdlr == nil || s.format != expectFormat {
-		s.hdlr = h.newSlogHandler(s.lw)
+		s.hdlr = h.buildHandler(s.lw)
 		s.format = expectFormat
 	}
 	return s
 }
 
-// newSlogHandler constructs a fresh slog handler writing into w, with the
+// buildHandler constructs a fresh slog handler writing into w, with the
 // current format and the WithAttrs/WithGroup chain applied.
-func (h *handler) newSlogHandler(w io.Writer) slog.Handler {
+func (h *handler) buildHandler(w io.Writer) slog.Handler {
 	handlerOpts := slog.HandlerOptions{
 		AddSource: false,
 		Level:     h.leveler,

--- a/internal/runtime/logging/handler.go
+++ b/internal/runtime/logging/handler.go
@@ -1,7 +1,6 @@
 package logging
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -23,29 +22,32 @@ import (
 // JSON or logfmt, and create a new inner handler if needed.
 
 type handler struct {
-	// w owns every sink (innerWriter, lokiWriter, tmpWriter, and the optional event log).
-	// It also implements io.Writer so it can be passed straight into slog.NewTextHandler
-	// and slog.JSONHandler on the fast path. The slow path (event log attached) uses
-	// *writerVar's Dispatch method directly.
+	// w owns every sink: innerWriter (stderr), lokiWriter, tmpWriter, and the
+	// optional Windows event log. Records are formatted through a pooled slog
+	// handler that writes into a leveledWriter, which forwards the bytes plus
+	// the record's level to w.Dispatch.
 	w         *writerVar
 	leveler   slog.Leveler
 	formatter formatter
+	replacer  func(groups []string, a slog.Attr) slog.Attr
 
 	nested []nesting
 
-	mut           sync.RWMutex
-	currentFormat Format
-	inner         slog.Handler
-	replacer      func(groups []string, a slog.Attr) slog.Attr
-
-	eventLogPool sync.Pool
+	// scratchPool holds per-call scratch (a cached slog handler + leveledWriter).
+	// It's per handler instance so each scratch's cached handler matches this
+	// handler's nested attrs/groups, and pooled (rather than a single shared
+	// handler) because the per-call level on the leveledWriter is mutable state
+	// that can't be shared across goroutines.
+	scratchPool sync.Pool
 }
 
-// eventLogScratch bundles a reusable buffer with a slog handler that
-// writes into it. format records which Format the cached handler was
-// built for, so a runtime format change triggers a rebuild.
-type eventLogScratch struct {
-	buf    *bytes.Buffer
+// scratch bundles a leveledWriter with a slog handler that writes through it.
+// The slog handler formats the record and writes the bytes straight to the
+// configured sinks via the leveledWriter, which carries the record's level.
+// format records which Format the cached handler was built for, so a runtime
+// format change triggers a rebuild.
+type scratch struct {
+	lw     *leveledWriter
 	hdlr   slog.Handler
 	format Format
 }
@@ -63,69 +65,41 @@ type formatter interface {
 var _ slog.Handler = (*handler)(nil)
 
 func (h *handler) Enabled(ctx context.Context, l slog.Level) bool {
-	// Bypass the cache and check the underlying leveler directly.
+	// Check the underlying leveler directly rather than going through a handler.
 	return l >= h.leveler.Level()
 }
 
 func (h *handler) Handle(ctx context.Context, r slog.Record) error {
-	hasSink, hasEventLog := h.w.FastPathFlags()
-	if !hasSink {
-		// Skip formatting entirely when no sink is listening.
-		return nil
-	}
-	if !hasEventLog {
-		// Stderr happy path.
-		// The cached slog handler writes directly into writerVar via
-		// the io.Writer interface, no buffer, no per-call rebuild.
-		return h.buildHandler().Handle(ctx, r)
-	}
-	// Event log attached: format once into a buffer so we can hand both
-	// the bytes and the record level to writerVar.Dispatch.
-	return h.handleWithEventLog(ctx, r)
+	// Record the level on the leveledWriter, then let the cached slog handler
+	// format the record and write straight through to writerVar.Dispatch. The
+	// level lets Dispatch pick the event log's Info/Warning/Error API when one
+	// is attached; the stderr/loki/tmp sinks ignore it. Dispatch fans out to
+	// whichever sinks are active (writing nowhere if none are), so there's no
+	// separate "is anything listening?" pre-check here.
+	s := h.getScratch()
+	defer h.scratchPool.Put(s)
+
+	s.lw.level = r.Level
+	return s.hdlr.Handle(ctx, r)
 }
 
-// handleWithEventLog formats the record into a per-call buffer using a
-// freshly-built slog handler, then dispatches via writerVar.Dispatch
-// which knows about the event log and the record level. Only used when
-// the event log destination is active.
-func (h *handler) handleWithEventLog(ctx context.Context, r slog.Record) error {
-	// A pool (rather than buildHandler's single shared handler) because this
-	// path reads buf.Bytes() back after Handle to pass them plus the level to Dispatch.
-	s := h.getEventLogScratch()
-	defer func() {
-		s.buf.Reset()
-		h.eventLogPool.Put(s)
-	}()
-
-	if err := s.hdlr.Handle(ctx, r); err != nil {
-		return err
-	}
-	if s.buf.Len() == 0 {
-		return nil // No need to dispatch empty log entries.
-	}
-	return h.w.Dispatch(s.buf.Bytes(), &r.Level)
-}
-
-// getEventLogScratch returns scratch space whose cached handler matches
-// the current format, rebuilding the handler only when the format
-// changed (or on first use). The returned buffer is already empty.
-func (h *handler) getEventLogScratch() *eventLogScratch {
+// getScratch returns scratch space whose cached handler matches the current
+// format, rebuilding the handler only when the format changed (or on first use).
+func (h *handler) getScratch() *scratch {
 	expectFormat := h.formatter.Format()
-	s, _ := h.eventLogPool.Get().(*eventLogScratch)
+	s, _ := h.scratchPool.Get().(*scratch)
 	if s == nil {
-		s = &eventLogScratch{buf: new(bytes.Buffer)}
+		s = &scratch{lw: &leveledWriter{w: h.w}}
 	}
 	if s.hdlr == nil || s.format != expectFormat {
-		s.hdlr = h.newSlogHandler(s.buf)
+		s.hdlr = h.newSlogHandler(s.lw)
 		s.format = expectFormat
 	}
 	return s
 }
 
 // newSlogHandler constructs a fresh slog handler writing into w, with the
-// current format and the WithAttrs/WithGroup chain applied. Used by both
-// buildHandler (which caches the result for the fast path) and the
-// event-log slow path (which can't cache because the writer is per-call).
+// current format and the WithAttrs/WithGroup chain applied.
 func (h *handler) newSlogHandler(w io.Writer) slog.Handler {
 	handlerOpts := slog.HandlerOptions{
 		AddSource: false,
@@ -152,31 +126,6 @@ func (h *handler) newSlogHandler(w io.Writer) slog.Handler {
 		}
 	}
 	return hdlr
-}
-
-// buildHandler returns a cached slog handler bound to h.w. Used by the
-// fast path (no event log) so each Log call avoids the cost of
-// reconstructing the WithAttrs/WithGroup chain.
-func (h *handler) buildHandler() slog.Handler {
-	// Get the expected format for the duration of this call. It's possible
-	// that this will be stale by the time the call returns, but it will be
-	// correct on the next call.
-	expectFormat := h.formatter.Format()
-
-	// Fast path: if our cached handler is still valid, immediately return it.
-	h.mut.RLock()
-	if h.currentFormat == expectFormat && h.inner != nil {
-		defer h.mut.RUnlock()
-		return h.inner
-	}
-	h.mut.RUnlock()
-
-	// Slow path: build a new handler and cache it.
-	h.mut.Lock()
-	defer h.mut.Unlock()
-	h.inner = h.newSlogHandler(h.w)
-	h.currentFormat = expectFormat
-	return h.inner
 }
 
 func (h *handler) WithAttrs(attrs []slog.Attr) slog.Handler {

--- a/internal/runtime/logging/handler.go
+++ b/internal/runtime/logging/handler.go
@@ -39,6 +39,27 @@ type handler struct {
 	scratchPool sync.Pool
 }
 
+func newHandler(
+	w *writerVar,
+	leveler slog.Leveler,
+	formatter formatter,
+	replacer func(groups []string, a slog.Attr) slog.Attr,
+	nested []nesting,
+) *handler {
+	return &handler{
+		w:         w,
+		leveler:   leveler,
+		formatter: formatter,
+		replacer:  replacer,
+		nested:    nested,
+		scratchPool: sync.Pool{
+			New: func() any {
+				return &scratch{lw: &leveledWriter{w: w}}
+			},
+		},
+	}
+}
+
 type scratch struct {
 	// Carries the record's level.
 	lw *leveledWriter
@@ -80,10 +101,7 @@ func (h *handler) Handle(ctx context.Context, r slog.Record) error {
 // format, rebuilding the handler only when the format changed (or on first use).
 func (h *handler) getScratch() *scratch {
 	expectFormat := h.formatter.Format()
-	s, _ := h.scratchPool.Get().(*scratch)
-	if s == nil {
-		s = &scratch{lw: &leveledWriter{w: h.w}}
-	}
+	s := h.scratchPool.Get().(*scratch)
 	if s.hdlr == nil || s.format != expectFormat {
 		s.hdlr = h.buildHandler(s.lw)
 		s.format = expectFormat
@@ -128,14 +146,7 @@ func (h *handler) WithAttrs(attrs []slog.Attr) slog.Handler {
 		attrs: attrs,
 	})
 
-	return &handler{
-		w:         h.w,
-		leveler:   h.leveler,
-		formatter: h.formatter,
-
-		nested:   newNest,
-		replacer: h.replacer,
-	}
+	return newHandler(h.w, h.leveler, h.formatter, h.replacer, newNest)
 }
 
 func (h *handler) WithGroup(name string) slog.Handler {
@@ -144,14 +155,7 @@ func (h *handler) WithGroup(name string) slog.Handler {
 	newNest = append(newNest, nesting{
 		group: name,
 	})
-	return &handler{
-		w:         h.w,
-		leveler:   h.leveler,
-		formatter: h.formatter,
-
-		nested:   newNest,
-		replacer: h.replacer,
-	}
+	return newHandler(h.w, h.leveler, h.formatter, h.replacer, newNest)
 }
 
 var unsafeKeyCharReplacer = strings.NewReplacer(

--- a/internal/runtime/logging/handler.go
+++ b/internal/runtime/logging/handler.go
@@ -81,23 +81,18 @@ func (h *handler) Handle(ctx context.Context, r slog.Record) error {
 // which knows about the event log and the record level. Only used when
 // the event log destination is active.
 func (h *handler) handleWithEventLog(ctx context.Context, r slog.Record) error {
-	// Cheap level filter before we allocate the buffer and build the
-	// per-call slog handler. The inner slog handler filters too, but doing
-	// it here also skips the event-log dispatch (which would otherwise
-	// receive an empty message).
-	if !h.Enabled(ctx, r.Level) {
-		return nil
-	}
-
 	buf := bytesPool.Get().(*bytes.Buffer)
 	buf.Reset()
-	defer bytesPool.Put(buf)
+	defer func() {
+		buf.Reset()
+		bytesPool.Put(buf)
+	}()
 
 	if err := h.newSlogHandler(buf).Handle(ctx, r); err != nil {
 		return err
 	}
 	if buf.Len() == 0 {
-		return nil // belt-and-suspenders for handlers that drop records silently
+		return nil // No need to dispatch empty log entries.
 	}
 	return h.w.Dispatch(buf.Bytes(), &r.Level)
 }

--- a/internal/runtime/logging/handler.go
+++ b/internal/runtime/logging/handler.go
@@ -27,7 +27,7 @@ type handler struct {
 	// optional event log). It also implements io.Writer so it can be
 	// passed straight into slog.NewTextHandler/JSONHandler on the fast
 	// path. The slow path (event log attached) uses *writerVar methods
-	// directly — Write + WriteRecord + FastPathFlags.
+	// directly — FastPathFlags + Dispatch.
 	w         *writerVar
 	leveler   slog.Leveler
 	formatter formatter
@@ -72,12 +72,12 @@ func (h *handler) Handle(ctx context.Context, r slog.Record) error {
 		return h.buildHandler().Handle(ctx, r)
 	}
 	// Event log attached: format once into a buffer so we can hand both
-	// the bytes and the record level to writerVar.WriteRecord.
+	// the bytes and the record level to writerVar.Dispatch.
 	return h.handleWithEventLog(ctx, r)
 }
 
 // handleWithEventLog formats the record into a per-call buffer using a
-// freshly-built slog handler, then dispatches via writerVar.WriteRecord
+// freshly-built slog handler, then dispatches via writerVar.Dispatch
 // which knows about the event log and the record level. Only used when
 // the event log destination is active.
 func (h *handler) handleWithEventLog(ctx context.Context, r slog.Record) error {

--- a/internal/runtime/logging/handler.go
+++ b/internal/runtime/logging/handler.go
@@ -46,6 +46,7 @@ func newHandler(
 	replacer func(groups []string, a slog.Attr) slog.Attr,
 	nested []nesting,
 ) *handler {
+
 	return &handler{
 		w:         w,
 		leveler:   leveler,

--- a/internal/runtime/logging/handler.go
+++ b/internal/runtime/logging/handler.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -22,7 +23,12 @@ import (
 // JSON or logfmt, and create a new inner handler if needed.
 
 type handler struct {
-	w         io.Writer
+	// w owns every sink (innerWriter, lokiWriter, tmpWriter, and the
+	// optional event log). It also implements io.Writer so it can be
+	// passed straight into slog.NewTextHandler/JSONHandler on the fast
+	// path. The slow path (event log attached) uses *writerVar methods
+	// directly — Write + WriteRecord + FastPathFlags.
+	w         *writerVar
 	leveler   slog.Leveler
 	formatter formatter
 
@@ -52,13 +58,95 @@ func (h *handler) Enabled(ctx context.Context, l slog.Level) bool {
 }
 
 func (h *handler) Handle(ctx context.Context, r slog.Record) error {
-	return h.buildHandler().Handle(ctx, r)
+	hasSink, hasEventLog := h.w.FastPathFlags()
+	if !hasSink {
+		// Skip formatting entirely when no sink is listening — the slog
+		// text/JSON handler would otherwise allocate, run ReplaceAttr on
+		// every attribute, and hand the bytes to io.Discard.
+		return nil
+	}
+	if !hasEventLog {
+		// Stderr happy path: the cached slog handler writes directly into
+		// writerVar via the io.Writer interface, no buffer, no per-call
+		// rebuild.
+		return h.buildHandler().Handle(ctx, r)
+	}
+	// Event log attached: format once into a buffer so we can hand both
+	// the bytes and the record level to writerVar.WriteRecord.
+	return h.handleWithEventLog(ctx, r)
 }
 
+// handleWithEventLog formats the record into a per-call buffer using a
+// freshly-built slog handler, then dispatches via writerVar.WriteRecord
+// which knows about the event log and the record level. Only used when
+// the event log destination is active.
+func (h *handler) handleWithEventLog(ctx context.Context, r slog.Record) error {
+	// Cheap level filter before we allocate the buffer and build the
+	// per-call slog handler. The inner slog handler filters too, but doing
+	// it here also skips the event-log dispatch (which would otherwise
+	// receive an empty message).
+	if !h.Enabled(ctx, r.Level) {
+		return nil
+	}
+
+	buf := bytesPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer bytesPool.Put(buf)
+
+	if err := h.newSlogHandler(buf).Handle(ctx, r); err != nil {
+		return err
+	}
+	if buf.Len() == 0 {
+		return nil // belt-and-suspenders for handlers that drop records silently
+	}
+	return h.w.Dispatch(buf.Bytes(), &r.Level)
+}
+
+// bytesPool reuses bytes.Buffer instances across event-log slow-path
+// calls to avoid an allocation per record.
+var bytesPool = sync.Pool{
+	New: func() any { return new(bytes.Buffer) },
+}
+
+// newSlogHandler constructs a fresh slog handler writing into w, with the
+// current format and the WithAttrs/WithGroup chain applied. Used by both
+// buildHandler (which caches the result for the fast path) and the
+// event-log slow path (which can't cache because the writer is per-call).
+func (h *handler) newSlogHandler(w io.Writer) slog.Handler {
+	handlerOpts := slog.HandlerOptions{
+		AddSource: false,
+		Level:     h.leveler,
+		// Replace attributes with how they were represented in go-kit/log
+		// for consistency.
+		ReplaceAttr: h.replacer,
+	}
+	var hdlr slog.Handler
+	switch h.formatter.Format() {
+	case FormatLogfmt:
+		hdlr = slog.NewTextHandler(w, &handlerOpts)
+	case FormatJSON:
+		hdlr = slog.NewJSONHandler(w, &handlerOpts)
+	default:
+		panic(fmt.Sprintf("unknown format %v", h.formatter.Format()))
+	}
+	// Replay our groups and attrs in the order they were entered.
+	for _, n := range h.nested {
+		if n.group != "" {
+			hdlr = hdlr.WithGroup(n.group)
+		} else {
+			hdlr = hdlr.WithAttrs(n.attrs)
+		}
+	}
+	return hdlr
+}
+
+// buildHandler returns a cached slog handler bound to h.w. Used by the
+// fast path (no event log) so each Log call avoids the cost of
+// reconstructing the WithAttrs/WithGroup chain.
 func (h *handler) buildHandler() slog.Handler {
-	// Get the expected format for the duration of this call. It's possible that
-	// this will be stale by the time the call returns, but it will be correct on
-	// the next call.
+	// Get the expected format for the duration of this call. It's possible
+	// that this will be stale by the time the call returns, but it will be
+	// correct on the next call.
 	expectFormat := h.formatter.Format()
 
 	// Fast path: if our cached handler is still valid, immediately return it.
@@ -69,42 +157,12 @@ func (h *handler) buildHandler() slog.Handler {
 	}
 	h.mut.RUnlock()
 
-	// Slow path: we need to build a new handler.
+	// Slow path: build a new handler and cache it.
 	h.mut.Lock()
 	defer h.mut.Unlock()
-
-	var newHandler slog.Handler
-
-	handlerOpts := slog.HandlerOptions{
-		AddSource: false,
-		Level:     h.leveler,
-
-		// Replace attributes with how they were represented in go-kit/log for
-		// consistency.
-		ReplaceAttr: h.replacer,
-	}
-
-	switch expectFormat {
-	case FormatLogfmt:
-		newHandler = slog.NewTextHandler(h.w, &handlerOpts)
-	case FormatJSON:
-		newHandler = slog.NewJSONHandler(h.w, &handlerOpts)
-	default:
-		panic(fmt.Sprintf("unknown format %v", expectFormat))
-	}
-
-	// Need to replay our groups and attrs in the correct order.
-	for _, n := range h.nested {
-		if n.group != "" {
-			newHandler = newHandler.WithGroup(n.group)
-		} else {
-			newHandler = newHandler.WithAttrs(n.attrs)
-		}
-	}
-
+	h.inner = h.newSlogHandler(h.w)
 	h.currentFormat = expectFormat
-	h.inner = newHandler
-	return newHandler
+	return h.inner
 }
 
 func (h *handler) WithAttrs(attrs []slog.Attr) slog.Handler {

--- a/internal/runtime/logging/handler.go
+++ b/internal/runtime/logging/handler.go
@@ -23,11 +23,10 @@ import (
 // JSON or logfmt, and create a new inner handler if needed.
 
 type handler struct {
-	// w owns every sink (innerWriter, lokiWriter, tmpWriter, and the
-	// optional event log). It also implements io.Writer so it can be
-	// passed straight into slog.NewTextHandler/JSONHandler on the fast
-	// path. The slow path (event log attached) uses *writerVar methods
-	// directly — FastPathFlags + Dispatch.
+	// w owns every sink (innerWriter, lokiWriter, tmpWriter, and the optional event log).
+	// It also implements io.Writer so it can be passed straight into slog.NewTextHandler
+	// and slog.JSONHandler on the fast path. The slow path (event log attached) uses
+	// *writerVar's Dispatch method directly.
 	w         *writerVar
 	leveler   slog.Leveler
 	formatter formatter
@@ -60,15 +59,13 @@ func (h *handler) Enabled(ctx context.Context, l slog.Level) bool {
 func (h *handler) Handle(ctx context.Context, r slog.Record) error {
 	hasSink, hasEventLog := h.w.FastPathFlags()
 	if !hasSink {
-		// Skip formatting entirely when no sink is listening — the slog
-		// text/JSON handler would otherwise allocate, run ReplaceAttr on
-		// every attribute, and hand the bytes to io.Discard.
+		// Skip formatting entirely when no sink is listening.
 		return nil
 	}
 	if !hasEventLog {
-		// Stderr happy path: the cached slog handler writes directly into
-		// writerVar via the io.Writer interface, no buffer, no per-call
-		// rebuild.
+		// Stderr happy path.
+		// The cached slog handler writes directly into writerVar via
+		// the io.Writer interface, no buffer, no per-call rebuild.
 		return h.buildHandler().Handle(ctx, r)
 	}
 	// Event log attached: format once into a buffer so we can hand both

--- a/internal/runtime/logging/logger.go
+++ b/internal/runtime/logging/logger.go
@@ -347,31 +347,6 @@ func (w *writerVar) SwitchToInnerOnly() error {
 	return err
 }
 
-// FastPathFlags returns whether any sink is active and whether the event
-// log sink in particular is attached.
-//
-// io.Discard is treated as "no sink": tests and benchmarks pass it as
-// the underlying writer when they want to measure the logger path
-// without actually consuming bytes, and the bytes handler should skip
-// formatting in that case.
-func (w *writerVar) FastPathFlags() (hasSink, hasEventLog bool) {
-	w.mut.RLock()
-	defer w.mut.RUnlock()
-	hasEventLog = w.eventLog != nil
-	hasSink = hasEventLog ||
-		(w.innerWriter != nil && w.innerWriter != io.Discard && !w.suppressInner) ||
-		w.lokiWriter != nil ||
-		w.tmpWriter != nil
-	return
-}
-
-// HasSink reports whether any active sink will accept bytes. Kept for
-// callers that don't need to distinguish the event-log case.
-func (w *writerVar) HasSink() bool {
-	hasSink, _ := w.FastPathFlags()
-	return hasSink
-}
-
 // Dispatch is the canonical write entry point. It fans p out to every
 // active sink: innerWriter (unless suppressed), lokiWriter, tmpWriter,
 // and, when attached, the event log.
@@ -435,6 +410,22 @@ func (w *writerVar) Dispatch(p []byte, eventLogLevel *slog.Level) error {
 // write is handled when the event log is attached.
 func (w *writerVar) Write(p []byte) (int, error) {
 	if err := w.Dispatch(p, nil); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+// leveledWriter is an io.Writer that remembers the slog level of the record
+// currently being formatted, so writerVar.Dispatch can route it to the event
+// log's Info/Warning/Error API. It is the event-log counterpart of
+// writerVar.Write, which carries no level (fast/stderr path).
+type leveledWriter struct {
+	w     *writerVar
+	level slog.Level
+}
+
+func (lw *leveledWriter) Write(p []byte) (int, error) {
+	if err := lw.w.Dispatch(p, &lw.level); err != nil {
 		return 0, err
 	}
 	return len(p), nil

--- a/internal/runtime/logging/logger.go
+++ b/internal/runtime/logging/logger.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/runtime/logging/eventlog"
 	"github.com/grafana/alloy/internal/slogadapter"
 	"github.com/grafana/loki/pkg/push"
 )
@@ -22,17 +23,23 @@ type EnabledAware interface {
 // Logger is the logging subsystem of Alloy. It supports being dynamically
 // updated at runtime.
 type Logger struct {
-	inner io.Writer // Writer passed to New.
-
 	bufferMut    sync.RWMutex
 	buffer       []*bufferedItem // Store logs before correctly determine the log format
 	hasLogFormat bool            // Confirmation whether log format has been determined
 
-	level        *slog.LevelVar       // Current configured level.
-	format       *formatVar           // Current configured format.
-	writer       *writerVar           // Current configured multiwriter (inner + write_to).
-	handler      *handler             // Handler which handles logs.
-	deferredSlog *deferredSlogHandler // This handles deferred logging for slog.
+	level  *slog.LevelVar // Current configured level.
+	format *formatVar     // Current configured format.
+	writer *writerVar     // Current configured multiwriter (inner + write_to + event log).
+
+	// handler is the single slog.Handler dispatched to by both the
+	// gokit and slog paths. It is set once in NewDeferred and never
+	// reassigned. Its writer (a *writerVar) owns every sink, including
+	// the optional Windows Event Log; Update toggles state on writerVar
+	// rather than swapping handlers.
+	handler      *handler
+	deferredSlog *deferredSlogHandler // Buffers slog output until config is loaded, then delegates to handler.
+
+	eventLogOpener eventlog.EventLogOpener // Opens the Windows event log; set in NewDeferred, overridable in tests.
 }
 
 var _ EnabledAware = (*Logger)(nil)
@@ -72,23 +79,27 @@ func NewDeferred(w io.Writer) (*Logger, error) {
 	var (
 		leveler slog.LevelVar
 		format  formatVar
-		writer  writerVar
 	)
-	l := &Logger{
-		inner: w,
+	// innerWriter is stable for the life of the Logger; destinations that
+	// want to suppress it (windows_event_log) flip writerVar.suppressInner
+	// instead of swapping the writer.
+	writer := &writerVar{innerWriter: w}
+	bh := &handler{
+		w:         writer,
+		leveler:   &leveler,
+		formatter: &format,
+		replacer:  replace,
+	}
 
+	l := &Logger{
 		buffer:       []*bufferedItem{},
 		hasLogFormat: false,
 
-		level:  &leveler,
-		format: &format,
-		writer: &writer,
-		handler: &handler{
-			w:         &writer,
-			leveler:   &leveler,
-			formatter: &format,
-			replacer:  replace,
-		},
+		level:          &leveler,
+		format:         &format,
+		writer:         writer,
+		handler:        bh,
+		eventLogOpener: eventlog.GetEventLogOpener(),
 	}
 	l.deferredSlog = newDeferredHandler(l)
 
@@ -124,43 +135,84 @@ func (l *Logger) Update(o Options) error {
 	l.bufferMut.Lock()
 	l.level.Set(slogLevel(o.Level).Level())
 	l.format.Set(o.Format)
-
-	l.writer.SetInnerWriter(l.inner)
+	if err := l.applyDestination(o.Destination); err != nil {
+		l.bufferMut.Unlock()
+		return err
+	}
 	l.writer.SetLokiWriter(o.WriteTo)
 	l.bufferMut.Unlock()
 
-	// Build deferred handlers outside bufferMut to avoid a deadlock: concurrent
-	// Handle() calls hold a child handler's RLock while waiting for bufferMut
-	// (via addRecord), while Update holding bufferMut and waiting for the child's
-	// write lock in buildHandlers creates a cycle.
+	// Rebuild deferred slog handlers outside bufferMut to avoid a deadlock
+	// with concurrent Handle() calls (they hold a child handler's RLock
+	// while waiting for bufferMut via addRecord).
 	if l.deferredSlog != nil {
 		l.deferredSlog.buildHandlers(nil)
 	}
+	l.flushBuffer()
+	return nil
+}
 
-	// Flip hasLogFormat and drain/replay while holding bufferMut so new Log()
-	// calls block on RLock until replay finishes — preserving the original
-	// guarantee that buffered logs are emitted before newly-arriving ones.
+// applyDestination toggles state on l.writer to match the new destination.
+// Must be called with l.bufferMut held by the caller.
+//
+// The architecture is loss-free by construction:
+//   - l.handler is stable — Update never reassigns it.
+//   - l.writer owns every sink (stderr, write_to, tmp, event log) and
+//     each mutator (SetSuppressInner, SetEventLog, CloseEventLog) takes
+//     the write lock, draining any in-flight Write/WriteRecord before
+//     flipping state. In-flight Logs always finish against the
+//     configuration that was active when they started.
+//
+// Adding a future "none" destination: extend the suppress condition
+// below so it also covers `none` — one line.
+func (l *Logger) applyDestination(d LogDestination) error {
+	willHaveEventLog := d == LogDestinationWindowsEventLog
+
+	if willHaveEventLog {
+		// Open the event log lazily on the first event_log Update.
+		// Subsequent event_log → event_log reloads reuse the handle.
+		if _, hasEL := l.writer.FastPathFlags(); !hasEL {
+			el, err := l.eventLogOpener("Alloy")
+			if err != nil {
+				return fmt.Errorf("failed to open Windows Event Log: %w", err)
+			}
+			l.writer.SetEventLog(el)
+		}
+		l.writer.SetSuppressInner(true)
+	} else {
+		// Unsuppress first so in-flight Logs that were in event_log mode
+		// can still deliver bytes to stderr via writerVar; then close the
+		// event log (Close drains any in-flight WriteRecord calls before
+		// releasing the OS handle).
+		l.writer.SetSuppressInner(false)
+		_ = l.writer.CloseEventLog()
+	}
+	return nil
+}
+
+// flushBuffer drains and replays any logs that were buffered before
+// Update finished resolving the log format. It must be called AFTER the
+// new destination has been applied (so replayed records go through the
+// right handler) and AFTER l.deferredSlog.buildHandlers has run (so
+// child handlers point at the new l.handler).
+//
+// Holds bufferMut for the entire replay so concurrent Log() calls block
+// until the buffer is drained, preserving the order guarantee that
+// buffered logs appear before newly-arriving ones.
+func (l *Logger) flushBuffer() {
 	l.bufferMut.Lock()
 	defer l.bufferMut.Unlock()
 	l.hasLogFormat = true
 	buffer := l.buffer
 	l.buffer = nil
 
-	for _, bufferedLogChunk := range buffer {
-		if len(bufferedLogChunk.kvps) > 0 {
-			// the buffered logs are currently only sent to the standard output
-			// because the components with the receivers are not running yet
-			slogadapter.GoKit(l.handler).Log(bufferedLogChunk.kvps...)
-		} else {
-			// We can now check whether our buffered log is at the right level.
-			if bufferedLogChunk.handler.Enabled(context.Background(), bufferedLogChunk.record.Level) {
-				// These will always be valid due to the build handlers call above.
-				_ = bufferedLogChunk.handler.Handle(context.Background(), bufferedLogChunk.record)
-			}
+	for _, item := range buffer {
+		if len(item.kvps) > 0 {
+			slogadapter.GoKit(l.handler).Log(item.kvps...)
+		} else if item.handler.Enabled(context.Background(), item.record.Level) {
+			_ = item.handler.Handle(context.Background(), item.record)
 		}
 	}
-
-	return nil
 }
 
 func (l *Logger) SetTemporaryWriter(w io.Writer) {
@@ -173,7 +225,7 @@ func (l *Logger) RemoveTemporaryWriter() {
 
 // Log implements log.Logger.
 func (l *Logger) Log(kvps ...any) error {
-	// Buffer logs before confirming log format is configured in `logging` block
+	// Buffer logs before confirming log format is configured in `logging` block.
 	l.bufferMut.RLock()
 	if !l.hasLogFormat {
 		l.bufferMut.RUnlock()
@@ -189,7 +241,7 @@ func (l *Logger) Log(kvps ...any) error {
 		l.bufferMut.RUnlock()
 	}
 
-	// NOTE(rfratto): this method is a temporary shim while log/slog is still
+	// NOTE(rfratto): slogadapter is a temporary shim while log/slog is still
 	// being adopted throughout the codebase.
 	return slogadapter.GoKit(l.handler).Log(kvps...)
 }
@@ -254,9 +306,17 @@ func (f *formatVar) Set(format Format) {
 type writerVar struct {
 	mut sync.RWMutex
 
-	lokiWriter  *lokiWriter
-	innerWriter io.Writer
-	tmpWriter   io.Writer
+	lokiWriter    *lokiWriter
+	innerWriter   io.Writer
+	tmpWriter     io.Writer
+	suppressInner bool // when true, Write skips innerWriter
+
+	// eventLog is the optional Windows Event Log sink. When non-nil,
+	// WriteRecord additionally maps the record's level to Info/Warning/Error
+	// and forwards the formatted bytes. Protected by mut so concurrent
+	// Write/WriteRecord calls drain before CloseEventLog releases the OS
+	// handle.
+	eventLog eventlog.EventLog
 }
 
 func (w *writerVar) SetTemporaryWriter(writer io.Writer) {
@@ -271,13 +331,7 @@ func (w *writerVar) RemoveTemporaryWriter() {
 	w.tmpWriter = nil
 }
 
-func (w *writerVar) SetInnerWriter(writer io.Writer) {
-	w.mut.Lock()
-	defer w.mut.Unlock()
-	w.innerWriter = writer
-}
-
-func (w *writerVar) SetLokiWriter(receivers []loki.LogsReceiver) {
+func (w *writerVar) SetLokiWriter(receivers []loki.LogsReceiverr) {
 	w.mut.Lock()
 	defer w.mut.Unlock()
 	if len(receivers) > 0 {
@@ -287,32 +341,123 @@ func (w *writerVar) SetLokiWriter(receivers []loki.LogsReceiver) {
 	}
 }
 
-func (w *writerVar) Write(p []byte) (int, error) {
+// SetSuppressInner toggles whether Write delivers bytes to innerWriter.
+// Acquires the write lock, so it waits for any in-flight Write calls to
+// finish before flipping — guaranteeing in-flight Logs complete against
+// the previous state.
+func (w *writerVar) SetSuppressInner(b bool) {
+	w.mut.Lock()
+	defer w.mut.Unlock()
+	w.suppressInner = b
+}
+
+// SetEventLog installs the Windows Event Log sink. Subsequent calls to
+// WriteRecord forward records to el with the level mapped to
+// Info/Warning/Error.
+func (w *writerVar) SetEventLog(el eventlog.EventLog) {
+	w.mut.Lock()
+	defer w.mut.Unlock()
+	w.eventLog = el
+}
+
+// CloseEventLog closes and detaches the Windows Event Log sink. Takes the
+// write lock, so it waits for any in-flight WriteRecord/Write calls to
+// finish before releasing the underlying OS handle. Idempotent.
+func (w *writerVar) CloseEventLog() error {
+	w.mut.Lock()
+	defer w.mut.Unlock()
+	if w.eventLog == nil {
+		return nil
+	}
+	err := w.eventLog.Close()
+	w.eventLog = nil
+	return err
+}
+
+// FastPathFlags returns whether any sink is active and whether the event
+// log sink in particular is attached. Both checks happen under a single
+// RLock so callers see a consistent snapshot. Used by handler.Handle
+// to decide between the fast path (no buffer; direct slog handler write
+// to writerVar) and the slow path (capture bytes + dispatch with level).
+//
+// io.Discard is treated as "no sink": tests and benchmarks pass it as
+// the underlying writer when they want to measure the logger path
+// without actually consuming bytes, and the bytes handler should skip
+// formatting in that case.
+func (w *writerVar) FastPathFlags() (hasSink, hasEventLog bool) {
+	w.mut.RLock()
+	defer w.mut.RUnlock()
+	hasEventLog = w.eventLog != nil
+	hasSink = hasEventLog ||
+		(w.innerWriter != nil && w.innerWriter != io.Discard && !w.suppressInner) ||
+		w.lokiWriter != nil ||
+		w.tmpWriter != nil
+	return
+}
+
+// HasSink reports whether any active sink will accept bytes. Kept for
+// callers that don't need to distinguish the event-log case.
+func (w *writerVar) HasSink() bool {
+	hasSink, _ := w.FastPathFlags()
+	return hasSink
+}
+
+// Dispatch is the canonical write entry point. It fans p out to every
+// active byte-stream sink (innerWriter unless suppressed/nil, lokiWriter,
+// tmpWriter). If eventLogLevel is non-nil and an event log is attached, p
+// is also forwarded to the event log with the level mapped to
+// Info/Warning/Error.
+//
+// The trailing newline added by slog's TextHandler/JSONHandler is trimmed
+// before handing the message to the event log API, which renders cleaner
+// in Event Viewer.
+//
+// A nil eventLogLevel is the only way to skip the event log explicitly —
+// passing slog.Level(0) would dispatch as Info, because zero is a valid
+// slog.Level.
+func (w *writerVar) Dispatch(p []byte, eventLogLevel *slog.Level) error {
 	w.mut.RLock()
 	defer w.mut.RUnlock()
 
-	if w.innerWriter == nil {
-		return 0, fmt.Errorf("no writer available")
+	if !w.suppressInner && w.innerWriter != nil {
+		if _, err := w.innerWriter.Write(p); err != nil {
+			return err
+		}
 	}
-
-	// The following is effectively an io.Multiwriter, but without updating
-	// the Multiwriter each time tmpWriter is added or removed.
-	if _, err := w.innerWriter.Write(p); err != nil {
-		return 0, err
-	}
-
 	if w.lokiWriter != nil {
 		if _, err := w.lokiWriter.Write(p); err != nil {
-			return 0, err
+			return err
 		}
 	}
-
 	if w.tmpWriter != nil {
 		if _, err := w.tmpWriter.Write(p); err != nil {
-			return 0, err
+			return err
 		}
 	}
+	if eventLogLevel == nil || w.eventLog == nil {
+		return nil
+	}
+	msg := p
+	if n := len(msg); n > 0 && msg[n-1] == '\n' {
+		msg = msg[:n-1]
+	}
+	switch *eventLogLevel {
+	case slog.LevelWarn:
+		return w.eventLog.Warning(1, string(msg))
+	case slog.LevelError:
+		return w.eventLog.Error(1, string(msg))
+	default:
+		return w.eventLog.Info(1, string(msg))
+	}
+}
 
+// Write is the io.Writer adapter used by the fast-path slog handler.
+// Equivalent to Dispatch(p, nil) — byte-stream sinks only, no event log.
+// For the event-log path use Dispatch directly with a non-nil level.
+func (w *writerVar) Write(p []byte) (int, error) {
+	if err := w.Dispatch(p, nil); err != nil {
+		return 0, err
+	}
 	return len(p), nil
 }
 

--- a/internal/runtime/logging/logger.go
+++ b/internal/runtime/logging/logger.go
@@ -157,37 +157,27 @@ func (l *Logger) Update(o Options) error {
 //
 // The architecture is loss-free by construction:
 //   - l.handler is stable — Update never reassigns it.
-//   - l.writer owns every sink (stderr, write_to, tmp, event log) and
-//     each mutator (SetSuppressInner, SetEventLog, CloseEventLog) takes
-//     the write lock, draining any in-flight Write/WriteRecord before
-//     flipping state. In-flight Logs always finish against the
-//     configuration that was active when they started.
-//
-// Adding a future "none" destination: extend the suppress condition
-// below so it also covers `none` — one line.
+//   - l.writer owns every sink (stderr, write_to, tmp, event log).
+//     Transitions are atomic from Dispatch's point of view:
+//     SwitchToEventLog and SwitchToInnerOnly each hold the write lock
+//     across every state change they make, so a single Dispatch never
+//     observes a mid-transition mix of suppressInner and eventLog.
+//   - A record may straddle a destination switch — handler.Handle reads
+//     FastPathFlags before Dispatch acquires its own RLock, so the two
+//     can observe different configurations. Dispatch's fallback handles
+//     this: when bytes can't reach the event log (no level supplied or
+//     event log detached), they fall through to innerWriter even if
+//     suppressInner is true. A switching record may land on stderr
+//     instead of the event log, but it is never dropped.
 func (l *Logger) applyDestination(d LogDestination) error {
-	willHaveEventLog := d == LogDestinationWindowsEventLog
-
-	if willHaveEventLog {
-		// Open the event log lazily on the first event_log Update.
-		// Subsequent event_log → event_log reloads reuse the handle.
-		if _, hasEL := l.writer.FastPathFlags(); !hasEL {
-			el, err := l.eventLogOpener("Alloy")
-			if err != nil {
-				return fmt.Errorf("failed to open Windows Event Log: %w", err)
-			}
-			l.writer.SetEventLog(el)
+	if d == LogDestinationWindowsEventLog {
+		el, err := l.eventLogOpener("Alloy")
+		if err != nil {
+			return fmt.Errorf("failed to open Windows Event Log: %w", err)
 		}
-		l.writer.SetSuppressInner(true)
-	} else {
-		// Unsuppress first so in-flight Logs that were in event_log mode
-		// can still deliver bytes to stderr via writerVar; then close the
-		// event log (Close drains any in-flight WriteRecord calls before
-		// releasing the OS handle).
-		l.writer.SetSuppressInner(false)
-		_ = l.writer.CloseEventLog()
+		return l.writer.SwitchToEventLog(el)
 	}
-	return nil
+	return l.writer.SwitchToInnerOnly()
 }
 
 // flushBuffer drains and replays any logs that were buffered before
@@ -311,11 +301,11 @@ type writerVar struct {
 	tmpWriter     io.Writer
 	suppressInner bool // when true, Write skips innerWriter
 
-	// eventLog is the optional Windows Event Log sink. When non-nil,
-	// WriteRecord additionally maps the record's level to Info/Warning/Error
-	// and forwards the formatted bytes. Protected by mut so concurrent
-	// Write/WriteRecord calls drain before CloseEventLog releases the OS
-	// handle.
+	// eventLog is the optional Windows Event Log sink. When non-nil and the
+	// caller of Dispatch supplied a level, Dispatch maps the level to
+	// Info/Warning/Error and forwards the formatted bytes. Protected by mut
+	// so concurrent Dispatch calls drain before SwitchToInnerOnly /
+	// SwitchToEventLog release or replace the underlying OS handle.
 	eventLog eventlog.EventLog
 }
 
@@ -341,31 +331,37 @@ func (w *writerVar) SetLokiWriter(receivers []loki.LogsReceiver) {
 	}
 }
 
-// SetSuppressInner toggles whether Write delivers bytes to innerWriter.
-// Acquires the write lock, so it waits for any in-flight Write calls to
-// finish before flipping — guaranteeing in-flight Logs complete against
-// the previous state.
-func (w *writerVar) SetSuppressInner(b bool) {
+// SwitchToEventLog atomically installs el as the event log sink and
+// flips suppressInner=true. If an event log was already attached, it is
+// closed first. The write lock is held across the close + install +
+// flip, so no Dispatch ever observes the mid-state where suppressInner
+// and eventLog disagree about whether bytes belong on stderr or the
+// event log.
+//
+// Returns the previous event log's Close error, if any. Callers should
+// open el fresh — event_log → event_log reloads close + reopen the
+// handle, which is cheap (DeregisterEventSource + RegisterEventSource).
+func (w *writerVar) SwitchToEventLog(el eventlog.EventLog) error {
 	w.mut.Lock()
 	defer w.mut.Unlock()
-	w.suppressInner = b
-}
-
-// SetEventLog installs the Windows Event Log sink. Subsequent calls to
-// WriteRecord forward records to el with the level mapped to
-// Info/Warning/Error.
-func (w *writerVar) SetEventLog(el eventlog.EventLog) {
-	w.mut.Lock()
-	defer w.mut.Unlock()
+	var closeErr error
+	if w.eventLog != nil {
+		closeErr = w.eventLog.Close()
+	}
 	w.eventLog = el
+	w.suppressInner = true
+	return closeErr
 }
 
-// CloseEventLog closes and detaches the Windows Event Log sink. Takes the
-// write lock, so it waits for any in-flight WriteRecord/Write calls to
-// finish before releasing the underlying OS handle. Idempotent.
-func (w *writerVar) CloseEventLog() error {
+// SwitchToInnerOnly atomically flips suppressInner=false and closes any
+// attached event log. The write lock is held across both state changes
+// and the Close, so Dispatch never observes the mid-state where
+// suppressInner=false and eventLog!=nil (which would double-deliver to
+// stderr and the event log). Idempotent.
+func (w *writerVar) SwitchToInnerOnly() error {
 	w.mut.Lock()
 	defer w.mut.Unlock()
+	w.suppressInner = false
 	if w.eventLog == nil {
 		return nil
 	}
@@ -403,10 +399,17 @@ func (w *writerVar) HasSink() bool {
 }
 
 // Dispatch is the canonical write entry point. It fans p out to every
-// active byte-stream sink (innerWriter unless suppressed/nil, lokiWriter,
-// tmpWriter). If eventLogLevel is non-nil and an event log is attached, p
-// is also forwarded to the event log with the level mapped to
-// Info/Warning/Error.
+// active byte-stream sink (innerWriter, lokiWriter, tmpWriter). If
+// eventLogLevel is non-nil and an event log is attached, p is also
+// forwarded to the event log with the level mapped to Info/Warning/Error.
+//
+// Suppression of innerWriter only applies when the bytes can actually
+// reach the event log. If they can't — because the caller didn't supply
+// a level (fast path) or because the event log was detached by a
+// concurrent reload — innerWriter receives the bytes regardless of
+// w.suppressInner. This is the loss-prevention property: during a
+// destination switch, a record may land on stderr instead of the event
+// log, but it is never dropped.
 //
 // The trailing newline added by slog's TextHandler/JSONHandler is trimmed
 // before handing the message to the event log API, which renders cleaner
@@ -419,7 +422,9 @@ func (w *writerVar) Dispatch(p []byte, eventLogLevel *slog.Level) error {
 	w.mut.RLock()
 	defer w.mut.RUnlock()
 
-	if !w.suppressInner && w.innerWriter != nil {
+	canReachEventLog := eventLogLevel != nil && w.eventLog != nil
+	writeInner := w.innerWriter != nil && (!w.suppressInner || !canReachEventLog)
+	if writeInner {
 		if _, err := w.innerWriter.Write(p); err != nil {
 			return err
 		}
@@ -434,7 +439,7 @@ func (w *writerVar) Dispatch(p []byte, eventLogLevel *slog.Level) error {
 			return err
 		}
 	}
-	if eventLogLevel == nil || w.eventLog == nil {
+	if !canReachEventLog {
 		return nil
 	}
 	msg := p

--- a/internal/runtime/logging/logger.go
+++ b/internal/runtime/logging/logger.go
@@ -399,32 +399,31 @@ func (w *writerVar) HasSink() bool {
 }
 
 // Dispatch is the canonical write entry point. It fans p out to every
-// active byte-stream sink (innerWriter, lokiWriter, tmpWriter). If
-// eventLogLevel is non-nil and an event log is attached, p is also
-// forwarded to the event log with the level mapped to Info/Warning/Error.
+// active sink: innerWriter (unless suppressed), lokiWriter, tmpWriter,
+// and, when attached, the event log.
 //
-// Suppression of innerWriter only applies when the bytes can actually
-// reach the event log. If they can't — because the caller didn't supply
-// a level (fast path) or because the event log was detached by a
-// concurrent reload — innerWriter receives the bytes regardless of
-// w.suppressInner. This is the loss-prevention property: during a
-// destination switch, a record may land on stderr instead of the event
-// log, but it is never dropped.
+// SwitchToEventLog / SwitchToInnerOnly hold the write lock across every
+// state change they make, so any Dispatch RLock observes one of two
+// states: (suppressInner=false, eventLog=nil) — stderr mode — or
+// (suppressInner=true, eventLog!=nil) — event_log mode.
+//
+// Loss-prevention property: in event_log mode, a fast-path Write call
+// (eventLogLevel=nil) can still occur if a destination switch happened
+// between handler.Handle's FastPathFlags read and the slog handler's
+// Write. Rather than dropping the record or misrouting it to stderr,
+// Dispatch defaults to Info and delivers it to the event log — the
+// operator's configured destination. The level may be slightly off
+// (the original record's level is embedded in the formatted text), but
+// the message reaches Event Viewer.
 //
 // The trailing newline added by slog's TextHandler/JSONHandler is trimmed
 // before handing the message to the event log API, which renders cleaner
 // in Event Viewer.
-//
-// A nil eventLogLevel is the only way to skip the event log explicitly —
-// passing slog.Level(0) would dispatch as Info, because zero is a valid
-// slog.Level.
 func (w *writerVar) Dispatch(p []byte, eventLogLevel *slog.Level) error {
 	w.mut.RLock()
 	defer w.mut.RUnlock()
 
-	canReachEventLog := eventLogLevel != nil && w.eventLog != nil
-	writeInner := w.innerWriter != nil && (!w.suppressInner || !canReachEventLog)
-	if writeInner {
+	if !w.suppressInner && w.innerWriter != nil {
 		if _, err := w.innerWriter.Write(p); err != nil {
 			return err
 		}
@@ -439,26 +438,27 @@ func (w *writerVar) Dispatch(p []byte, eventLogLevel *slog.Level) error {
 			return err
 		}
 	}
-	if !canReachEventLog {
+	if w.eventLog == nil {
 		return nil
 	}
 	msg := p
 	if n := len(msg); n > 0 && msg[n-1] == '\n' {
 		msg = msg[:n-1]
 	}
-	switch *eventLogLevel {
-	case slog.LevelWarn:
-		return w.eventLog.Warning(1, string(msg))
-	case slog.LevelError:
-		return w.eventLog.Error(1, string(msg))
-	default:
-		return w.eventLog.Info(1, string(msg))
+	if eventLogLevel != nil {
+		switch *eventLogLevel {
+		case slog.LevelWarn:
+			return w.eventLog.Warning(1, string(msg))
+		case slog.LevelError:
+			return w.eventLog.Error(1, string(msg))
+		}
 	}
+	return w.eventLog.Info(1, string(msg))
 }
 
 // Write is the io.Writer adapter used by the fast-path slog handler.
-// Equivalent to Dispatch(p, nil) — byte-stream sinks only, no event log.
-// For the event-log path use Dispatch directly with a non-nil level.
+// Equivalent to Dispatch(p, nil); see Dispatch for how a fast-path
+// write is handled when the event log is attached.
 func (w *writerVar) Write(p []byte) (int, error) {
 	if err := w.Dispatch(p, nil); err != nil {
 		return 0, err

--- a/internal/runtime/logging/logger.go
+++ b/internal/runtime/logging/logger.go
@@ -84,12 +84,7 @@ func NewDeferred(w io.Writer) (*Logger, error) {
 		innerWriter:    w,
 		eventLogOpener: eventlog.GetEventLogOpener(),
 	}
-	bh := &handler{
-		w:         writer,
-		leveler:   &leveler,
-		formatter: &format,
-		replacer:  replace,
-	}
+	bh := newHandler(writer, &leveler, &format, replace, nil)
 
 	l := &Logger{
 		buffer:       []*bufferedItem{},

--- a/internal/runtime/logging/logger.go
+++ b/internal/runtime/logging/logger.go
@@ -34,8 +34,7 @@ type Logger struct {
 	// handler is the single slog.Handler dispatched to by both the
 	// gokit and slog paths. It is set once in NewDeferred and never
 	// reassigned. Its writer (a *writerVar) owns every sink, including
-	// the optional Windows Event Log; Update toggles state on writerVar
-	// rather than swapping handlers.
+	// the optional Windows Event Log.
 	handler      *handler
 	deferredSlog *deferredSlogHandler // Buffers slog output until config is loaded, then delegates to handler.
 
@@ -154,21 +153,6 @@ func (l *Logger) Update(o Options) error {
 
 // applyDestination toggles state on l.writer to match the new destination.
 // Must be called with l.bufferMut held by the caller.
-//
-// The architecture is loss-free by construction:
-//   - l.handler is stable — Update never reassigns it.
-//   - l.writer owns every sink (stderr, write_to, tmp, event log).
-//     Transitions are atomic from Dispatch's point of view:
-//     SwitchToEventLog and SwitchToInnerOnly each hold the write lock
-//     across every state change they make, so a single Dispatch never
-//     observes a mid-transition mix of suppressInner and eventLog.
-//   - A record may straddle a destination switch — handler.Handle reads
-//     FastPathFlags before Dispatch acquires its own RLock, so the two
-//     can observe different configurations. Dispatch's fallback handles
-//     this: when bytes can't reach the event log (no level supplied or
-//     event log detached), they fall through to innerWriter even if
-//     suppressInner is true. A switching record may land on stderr
-//     instead of the event log, but it is never dropped.
 func (l *Logger) applyDestination(d LogDestination) error {
 	if d == LogDestinationWindowsEventLog {
 		el, err := l.eventLogOpener("Alloy")
@@ -296,17 +280,14 @@ func (f *formatVar) Set(format Format) {
 type writerVar struct {
 	mut sync.RWMutex
 
-	lokiWriter    *lokiWriter
+	// Inner writer is stderr on the production path.
+	// Tests may set it to something else.
 	innerWriter   io.Writer
-	tmpWriter     io.Writer
-	suppressInner bool // when true, Write skips innerWriter
+	suppressInner bool // when true, Write() and Dispatch() skip innerWriter
 
-	// eventLog is the optional Windows Event Log sink. When non-nil and the
-	// caller of Dispatch supplied a level, Dispatch maps the level to
-	// Info/Warning/Error and forwards the formatted bytes. Protected by mut
-	// so concurrent Dispatch calls drain before SwitchToInnerOnly /
-	// SwitchToEventLog release or replace the underlying OS handle.
-	eventLog eventlog.EventLog
+	lokiWriter *lokiWriter
+	tmpWriter  io.Writer
+	eventLog   eventlog.EventLog
 }
 
 func (w *writerVar) SetTemporaryWriter(writer io.Writer) {
@@ -337,10 +318,6 @@ func (w *writerVar) SetLokiWriter(receivers []loki.LogsReceiver) {
 // flip, so no Dispatch ever observes the mid-state where suppressInner
 // and eventLog disagree about whether bytes belong on stderr or the
 // event log.
-//
-// Returns the previous event log's Close error, if any. Callers should
-// open el fresh — event_log → event_log reloads close + reopen the
-// handle, which is cheap (DeregisterEventSource + RegisterEventSource).
 func (w *writerVar) SwitchToEventLog(el eventlog.EventLog) error {
 	w.mut.Lock()
 	defer w.mut.Unlock()
@@ -371,10 +348,7 @@ func (w *writerVar) SwitchToInnerOnly() error {
 }
 
 // FastPathFlags returns whether any sink is active and whether the event
-// log sink in particular is attached. Both checks happen under a single
-// RLock so callers see a consistent snapshot. Used by handler.Handle
-// to decide between the fast path (no buffer; direct slog handler write
-// to writerVar) and the slow path (capture bytes + dispatch with level).
+// log sink in particular is attached.
 //
 // io.Discard is treated as "no sink": tests and benchmarks pass it as
 // the underlying writer when they want to measure the logger path
@@ -403,22 +377,9 @@ func (w *writerVar) HasSink() bool {
 // and, when attached, the event log.
 //
 // SwitchToEventLog / SwitchToInnerOnly hold the write lock across every
-// state change they make, so any Dispatch RLock observes one of two
-// states: (suppressInner=false, eventLog=nil) — stderr mode — or
-// (suppressInner=true, eventLog!=nil) — event_log mode.
-//
-// Loss-prevention property: in event_log mode, a fast-path Write call
-// (eventLogLevel=nil) can still occur if a destination switch happened
-// between handler.Handle's FastPathFlags read and the slog handler's
-// Write. Rather than dropping the record or misrouting it to stderr,
-// Dispatch defaults to Info and delivers it to the event log — the
-// operator's configured destination. The level may be slightly off
-// (the original record's level is embedded in the formatted text), but
-// the message reaches Event Viewer.
-//
-// The trailing newline added by slog's TextHandler/JSONHandler is trimmed
-// before handing the message to the event log API, which renders cleaner
-// in Event Viewer.
+// state change they make, so any Dispatch RLock observes one of two states:
+// 1. (suppressInner=false, eventLog=nil) — stderr mode.
+// 2. (suppressInner=true, eventLog!=nil) — event_log mode.
 func (w *writerVar) Dispatch(p []byte, eventLogLevel *slog.Level) error {
 	w.mut.RLock()
 	defer w.mut.RUnlock()
@@ -441,10 +402,23 @@ func (w *writerVar) Dispatch(p []byte, eventLogLevel *slog.Level) error {
 	if w.eventLog == nil {
 		return nil
 	}
+
+	// The trailing newline added by slog's TextHandler/JSONHandler is trimmed
+	// before handing the message to the event log API, which renders cleaner
+	// in Event Viewer.
 	msg := p
 	if n := len(msg); n > 0 && msg[n-1] == '\n' {
 		msg = msg[:n-1]
 	}
+
+	// Loss-prevention property: in event_log mode, a fast-path Write call
+	// (eventLogLevel=nil) can still occur if a destination switch happened
+	// between handler.Handle's FastPathFlags read and the slog handler's
+	// Write. Rather than dropping the record or misrouting it to stderr,
+	// Dispatch defaults to Info and delivers it to the event log — the
+	// operator's configured destination. The level may be slightly off
+	// (the original record's level is embedded in the formatted text), but
+	// the message reaches Event Viewer.
 	if eventLogLevel != nil {
 		switch *eventLogLevel {
 		case slog.LevelWarn:

--- a/internal/runtime/logging/logger.go
+++ b/internal/runtime/logging/logger.go
@@ -37,8 +37,6 @@ type Logger struct {
 	// the optional Windows Event Log.
 	handler      *handler
 	deferredSlog *deferredSlogHandler // Buffers slog output until config is loaded, then delegates to handler.
-
-	eventLogOpener eventlog.EventLogOpener // Opens the Windows event log; set in NewDeferred, overridable in tests.
 }
 
 var _ EnabledAware = (*Logger)(nil)
@@ -80,9 +78,12 @@ func NewDeferred(w io.Writer) (*Logger, error) {
 		format  formatVar
 	)
 	// innerWriter is stable for the life of the Logger; destinations that
-	// want to suppress it (windows_event_log) flip writerVar.suppressInner
-	// instead of swapping the writer.
-	writer := &writerVar{innerWriter: w}
+	// want to suppress it (windows_event_log) lazily open an event log via
+	// the writer's own opener instead of swapping the writer.
+	writer := &writerVar{
+		innerWriter:    w,
+		eventLogOpener: eventlog.GetEventLogOpener(),
+	}
 	bh := &handler{
 		w:         writer,
 		leveler:   &leveler,
@@ -94,11 +95,10 @@ func NewDeferred(w io.Writer) (*Logger, error) {
 		buffer:       []*bufferedItem{},
 		hasLogFormat: false,
 
-		level:          &leveler,
-		format:         &format,
-		writer:         writer,
-		handler:        bh,
-		eventLogOpener: eventlog.GetEventLogOpener(),
+		level:   &leveler,
+		format:  &format,
+		writer:  writer,
+		handler: bh,
 	}
 	l.deferredSlog = newDeferredHandler(l)
 
@@ -134,7 +134,7 @@ func (l *Logger) Update(o Options) error {
 	l.bufferMut.Lock()
 	l.level.Set(slogLevel(o.Level).Level())
 	l.format.Set(o.Format)
-	if err := l.applyDestination(o.Destination); err != nil {
+	if err := l.writer.SetDestination(o.Destination); err != nil {
 		l.bufferMut.Unlock()
 		return err
 	}
@@ -149,19 +149,6 @@ func (l *Logger) Update(o Options) error {
 	}
 	l.flushBuffer()
 	return nil
-}
-
-// applyDestination toggles state on l.writer to match the new destination.
-// Must be called with l.bufferMut held by the caller.
-func (l *Logger) applyDestination(d LogDestination) error {
-	if d == LogDestinationWindowsEventLog {
-		el, err := l.eventLogOpener("Alloy")
-		if err != nil {
-			return fmt.Errorf("failed to open Windows Event Log: %w", err)
-		}
-		return l.writer.SwitchToEventLog(el)
-	}
-	return l.writer.SwitchToInnerOnly()
 }
 
 // flushBuffer drains and replays any logs that were buffered before
@@ -282,12 +269,21 @@ type writerVar struct {
 
 	// Inner writer is stderr on the production path.
 	// Tests may set it to something else.
-	innerWriter   io.Writer
-	suppressInner bool // when true, Write() and Dispatch() skip innerWriter
+	innerWriter io.Writer
 
 	lokiWriter *lokiWriter
 	tmpWriter  io.Writer
-	eventLog   eventlog.EventLog
+
+	// eventLogOpener lazily creates the Windows Event Log handle the first
+	// time SetDestination enters event-log mode. Set in NewDeferred,
+	// overridable in tests.
+	eventLogOpener eventlog.EventLogOpener
+
+	// eventLog is the single switch between the two primary-sink modes:
+	// when nil, Dispatch writes to innerWriter (stderr); when non-nil,
+	// innerWriter is suppressed and Dispatch routes to the event log
+	// instead. lokiWriter and tmpWriter are always written to regardless.
+	eventLog eventlog.EventLog
 }
 
 func (w *writerVar) SetTemporaryWriter(writer io.Writer) {
@@ -312,33 +308,22 @@ func (w *writerVar) SetLokiWriter(receivers []loki.LogsReceiver) {
 	}
 }
 
-// SwitchToEventLog atomically installs el as the event log sink and
-// flips suppressInner=true. If an event log was already attached, it is
-// closed first. The write lock is held across the close + install +
-// flip, so no Dispatch ever observes the mid-state where suppressInner
-// and eventLog disagree about whether bytes belong on stderr or the
-// event log.
-func (w *writerVar) SwitchToEventLog(el eventlog.EventLog) error {
+func (w *writerVar) SetDestination(d LogDestination) error {
 	w.mut.Lock()
 	defer w.mut.Unlock()
-	var closeErr error
-	if w.eventLog != nil {
-		closeErr = w.eventLog.Close()
-	}
-	w.eventLog = el
-	w.suppressInner = true
-	return closeErr
-}
 
-// SwitchToInnerOnly atomically flips suppressInner=false and closes any
-// attached event log. The write lock is held across both state changes
-// and the Close, so Dispatch never observes the mid-state where
-// suppressInner=false and eventLog!=nil (which would double-deliver to
-// stderr and the event log). Idempotent.
-func (w *writerVar) SwitchToInnerOnly() error {
-	w.mut.Lock()
-	defer w.mut.Unlock()
-	w.suppressInner = false
+	if d == LogDestinationWindowsEventLog {
+		if w.eventLog != nil {
+			return nil // already open; reuse the handle
+		}
+		el, err := w.eventLogOpener("Alloy")
+		if err != nil {
+			return fmt.Errorf("failed to open Windows Event Log: %w", err)
+		}
+		w.eventLog = el
+		return nil
+	}
+
 	if w.eventLog == nil {
 		return nil
 	}
@@ -351,15 +336,15 @@ func (w *writerVar) SwitchToInnerOnly() error {
 // active sink: innerWriter (unless suppressed), lokiWriter, tmpWriter,
 // and, when attached, the event log.
 //
-// SwitchToEventLog / SwitchToInnerOnly hold the write lock across every
-// state change they make, so any Dispatch RLock observes one of two states:
-// 1. (suppressInner=false, eventLog=nil) — stderr mode.
-// 2. (suppressInner=true, eventLog!=nil) — event_log mode.
+// SetDestination holds the write lock across the swap it makes, so any
+// Dispatch RLock observes one of two states:
+// 1. eventLog=nil — stderr mode.
+// 2. eventLog!=nil — event_log mode.
 func (w *writerVar) Dispatch(p []byte, eventLogLevel *slog.Level) error {
 	w.mut.RLock()
 	defer w.mut.RUnlock()
 
-	if !w.suppressInner && w.innerWriter != nil {
+	if w.eventLog == nil && w.innerWriter != nil {
 		if _, err := w.innerWriter.Write(p); err != nil {
 			return err
 		}

--- a/internal/runtime/logging/logger.go
+++ b/internal/runtime/logging/logger.go
@@ -331,7 +331,7 @@ func (w *writerVar) RemoveTemporaryWriter() {
 	w.tmpWriter = nil
 }
 
-func (w *writerVar) SetLokiWriter(receivers []loki.LogsReceiverr) {
+func (w *writerVar) SetLokiWriter(receivers []loki.LogsReceiver) {
 	w.mut.Lock()
 	defer w.mut.Unlock()
 	if len(receivers) > 0 {

--- a/internal/runtime/logging/logger_event_log_test.go
+++ b/internal/runtime/logging/logger_event_log_test.go
@@ -26,7 +26,7 @@ func TestLogger_EventLog_LevelReloadTakesEffect(t *testing.T) {
 	var inner bytes.Buffer
 	l, err := NewDeferred(&inner)
 	require.NoError(t, err)
-	l.eventLogOpener = func(_ string) (eventlog.EventLog, error) {
+	l.writer.eventLogOpener = func(_ string) (eventlog.EventLog, error) {
 		return mock, nil
 	}
 
@@ -61,6 +61,34 @@ func TestLogger_EventLog_LevelReloadTakesEffect(t *testing.T) {
 	require.Contains(t, mock.Infos[0], "debug-after")
 }
 
+// TestLogger_EventLog_ReloadDoesNotReopenHandle verifies that a config
+// reload which keeps the windows_event_log destination reuses the existing
+// handle: the opener is called exactly once and the handle is never closed.
+// Reopening on every reload would churn the Event Log source registration.
+func TestLogger_EventLog_ReloadDoesNotReopenHandle(t *testing.T) {
+	mock := &testutil.MockEventLog{}
+	var inner bytes.Buffer
+	l, err := NewDeferred(&inner)
+	require.NoError(t, err)
+
+	var opens int
+	l.writer.eventLogOpener = func(_ string) (eventlog.EventLog, error) {
+		opens++
+		return mock, nil
+	}
+
+	for i := 0; i < 3; i++ {
+		require.NoError(t, l.Update(Options{
+			Level:       LevelInfo,
+			Format:      FormatLogfmt,
+			Destination: LogDestinationWindowsEventLog,
+		}))
+	}
+
+	require.Equal(t, 1, opens, "event log handle should be opened once, not reopened on every reload")
+	require.False(t, mock.Closed(), "the handle must not be closed while staying on windows_event_log")
+}
+
 // TestLogger_EventLog_RespectsFormatChoice is the whole point of routing
 // the event log through the shared handler: the message that lands in the
 // Windows Event Log is the same formatted line that goes to stderr/
@@ -90,7 +118,7 @@ func TestLogger_EventLog_RespectsFormatChoice(t *testing.T) {
 			var inner bytes.Buffer
 			l, err := NewDeferred(&inner)
 			require.NoError(t, err)
-			l.eventLogOpener = func(_ string) (eventlog.EventLog, error) {
+			l.writer.eventLogOpener = func(_ string) (eventlog.EventLog, error) {
 				return mock, nil
 			}
 
@@ -123,7 +151,7 @@ func TestLogger_EventLog_TransitionToStderrClosesHandle(t *testing.T) {
 	var inner bytes.Buffer
 	l, err := NewDeferred(&inner)
 	require.NoError(t, err)
-	l.eventLogOpener = func(_ string) (eventlog.EventLog, error) {
+	l.writer.eventLogOpener = func(_ string) (eventlog.EventLog, error) {
 		return mock, nil
 	}
 
@@ -149,16 +177,15 @@ func TestLogger_EventLog_TransitionToStderrClosesHandle(t *testing.T) {
 
 // TestDispatch_FastPathRaceRoutesToEventLogAsInfo locks in the loss-prevention
 // behavior for the fast-path race: when a Write(p) arrives with eventLogLevel=nil
-// in state B (suppressInner=true, eventLog!=nil), Dispatch defaults to Info on
-// the event log instead of misrouting to stderr. This preserves the operator's
-// destination choice across a destination switch.
+// in state B (eventLog!=nil), Dispatch defaults to Info on the event log
+// instead of misrouting to stderr. This preserves the operator's destination
+// choice across a destination switch.
 func TestDispatch_FastPathRaceRoutesToEventLogAsInfo(t *testing.T) {
 	mock := &testutil.MockEventLog{}
 	var inner bytes.Buffer
 	w := &writerVar{
-		innerWriter:   &inner,
-		eventLog:      mock,
-		suppressInner: true,
+		innerWriter: &inner,
+		eventLog:    mock,
 	}
 
 	require.NoError(t, w.Dispatch([]byte("fast-path race bytes\n"), nil))
@@ -172,7 +199,7 @@ func TestDispatch_FastPathRaceRoutesToEventLogAsInfo(t *testing.T) {
 // TestUpdate_NoLossDuringConcurrentDestinationFlips is a stress test that runs
 // many Handle calls in parallel with rapid destination switches between
 // stderr and windows_event_log. With Dispatch's loss-prevention fallback AND
-// atomic destination transitions (SwitchToEventLog / SwitchToInnerOnly), every
+// atomic destination transitions (SetDestination), every
 // record lands on exactly one of inner or the event log: never dropped, never
 // duplicated. We assert strict equality.
 func TestUpdate_NoLossDuringConcurrentDestinationFlips(t *testing.T) {
@@ -190,7 +217,7 @@ func TestUpdate_NoLossDuringConcurrentDestinationFlips(t *testing.T) {
 	inner := &countingWriter{}
 	l, err := NewDeferred(inner)
 	require.NoError(t, err)
-	l.eventLogOpener = func(_ string) (eventlog.EventLog, error) {
+	l.writer.eventLogOpener = func(_ string) (eventlog.EventLog, error) {
 		// Re-use the same mock across reopens so cumulative counts make sense.
 		return mock, nil
 	}

--- a/internal/runtime/logging/logger_event_log_test.go
+++ b/internal/runtime/logging/logger_event_log_test.go
@@ -3,7 +3,11 @@ package logging
 import (
 	"bytes"
 	"log/slog"
+	"runtime"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/grafana/alloy/internal/runtime/logging/eventlog"
 	"github.com/grafana/alloy/internal/runtime/logging/eventlog/testutil"
@@ -141,4 +145,148 @@ func TestLogger_EventLog_TransitionToStderrClosesHandle(t *testing.T) {
 	require.Empty(t, mock.Infos, "no further records should reach the event log after transition")
 	require.Contains(t, inner.String(), "stderr-only",
 		"bytes path should now reach the stderr writer")
+}
+
+// TestUpdate_NoLossDuringConcurrentDestinationFlips is a stress test that runs
+// many Handle calls in parallel with rapid destination switches between
+// stderr and windows_event_log. With Dispatch's loss-prevention fallback AND
+// atomic destination transitions (SwitchToEventLog / SwitchToInnerOnly), every
+// record lands on exactly one of inner or the event log: never dropped, never
+// duplicated. We assert strict equality.
+func TestUpdate_NoLossDuringConcurrentDestinationFlips(t *testing.T) {
+	if testing.Short() {
+		t.Skip("stress test")
+	}
+
+	const (
+		hammerGoroutines = 4
+		hammerIters      = 2000
+		flipIters        = 200
+	)
+
+	mock := &testutil.MockEventLog{}
+	inner := &countingWriter{}
+	l, err := NewDeferred(inner)
+	require.NoError(t, err)
+	l.eventLogOpener = func(_ string) (eventlog.EventLog, error) {
+		// Re-use the same mock across reopens so cumulative counts make sense.
+		return mock, nil
+	}
+
+	require.NoError(t, l.Update(Options{
+		Level:       LevelInfo,
+		Format:      FormatLogfmt,
+		Destination: LogDestinationStderr,
+	}))
+
+	sl := l.Slog()
+	var totalHandles atomic.Int64
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Hammer Handle from N goroutines.
+	for i := 0; i < hammerGoroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < hammerIters; j++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				sl.Info("hammer", "g", id, "j", j)
+				totalHandles.Add(1)
+				runtime.Gosched()
+			}
+		}(i)
+	}
+
+	// Flip destination between default and event_log.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < flipIters; i++ {
+			dest := LogDestinationStderr
+			if i%2 == 0 {
+				dest = LogDestinationWindowsEventLog
+			}
+			err := l.Update(Options{
+				Level:       LevelInfo,
+				Format:      FormatLogfmt,
+				Destination: dest,
+			})
+			if err != nil {
+				t.Errorf("Update failed: %v", err)
+				close(stop)
+				return
+			}
+			time.Sleep(50 * time.Microsecond)
+		}
+	}()
+
+	// Bound the test so a hang doesn't wedge CI.
+	doneAll := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(doneAll)
+	}()
+	select {
+	case <-doneAll:
+	case <-time.After(30 * time.Second):
+		close(stop)
+		t.Fatal("stress test timed out")
+	}
+
+	// End the test in the default destination so the final accounting is
+	// stable.
+	require.NoError(t, l.Update(Options{
+		Level:       LevelInfo,
+		Format:      FormatLogfmt,
+		Destination: LogDestinationStderr,
+	}))
+
+	innerLines := inner.Lines()
+	// Safe to read directly: the goroutines have all returned (wg.Wait) and
+	// the final Update has settled, so no concurrent writes to the mock.
+	eventLogCount := len(mock.Infos) + len(mock.Warnings) + len(mock.Errors)
+
+	got := int64(innerLines + eventLogCount)
+	want := totalHandles.Load()
+	require.Equal(t, want, got,
+		"each handle should deliver exactly once: handles=%d inner=%d eventlog=%d (sum=%d)",
+		want, innerLines, eventLogCount, got)
+}
+
+// countingWriter is an io.Writer that records every byte and counts complete
+// lines (terminated by '\n'). It mirrors a tracking stderr so the test can
+// reconcile delivered records against handle counts.
+type countingWriter struct {
+	mu    sync.Mutex
+	buf   bytes.Buffer
+	lines int
+}
+
+func (c *countingWriter) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, b := range p {
+		if b == '\n' {
+			c.lines++
+		}
+	}
+	return c.buf.Write(p)
+}
+
+func (c *countingWriter) Lines() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.lines
+}
+
+func (c *countingWriter) String() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.buf.String()
 }

--- a/internal/runtime/logging/logger_event_log_test.go
+++ b/internal/runtime/logging/logger_event_log_test.go
@@ -1,0 +1,147 @@
+package logging
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/grafana/alloy/internal/runtime/logging/eventlog"
+	"github.com/grafana/alloy/internal/runtime/logging/eventlog/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLogger_EventLog_LevelReloadTakesEffect verifies that changing the
+// log level on an event_log → event_log reload actually propagates to
+// the event-log dispatch path. The event log doesn't have its own slog
+// handler anymore — formatting and level filtering both go through the
+// shared handler — so this exercises that the handler's leveler is
+// the live one Update mutates.
+func TestLogger_EventLog_LevelReloadTakesEffect(t *testing.T) {
+	mock := &testutil.MockEventLog{}
+	var inner bytes.Buffer
+	l, err := NewDeferred(&inner)
+	require.NoError(t, err)
+	l.eventLogOpener = func(_ string) (eventlog.EventLog, error) {
+		return mock, nil
+	}
+
+	// Start at Info level on event_log destination.
+	require.NoError(t, l.Update(Options{
+		Level:       LevelInfo,
+		Format:      FormatLogfmt,
+		Destination: LogDestinationWindowsEventLog,
+	}))
+
+	h := l.Slog().Handler()
+	ctx := t.Context()
+
+	// Debug record should be filtered at Info level.
+	require.False(t, h.Enabled(ctx, slog.LevelDebug),
+		"handler should report debug as disabled at Info level")
+	require.NoError(t, h.Handle(ctx,
+		slog.NewRecord(time.Now(), slog.LevelDebug, "debug-before", 0)))
+	require.Empty(t, mock.Infos, "debug record at Info level should be filtered")
+
+	// Reload at Debug level, same destination — no reopen.
+	require.NoError(t, l.Update(Options{
+		Level:       LevelDebug,
+		Format:      FormatLogfmt,
+		Destination: LogDestinationWindowsEventLog,
+	}))
+
+	// Debug record should now pass through.
+	require.True(t, h.Enabled(ctx, slog.LevelDebug),
+		"handler should report debug as enabled at Debug level")
+	require.NoError(t, h.Handle(ctx,
+		slog.NewRecord(time.Now(), slog.LevelDebug, "debug-after", 0)))
+	require.Len(t, mock.Infos, 1, "debug record at Debug level should reach event log")
+	require.Contains(t, mock.Infos[0], "debug-after")
+}
+
+// TestLogger_EventLog_RespectsFormatChoice is the whole point of routing
+// the event log through the shared handler: the message that lands in the
+// Windows Event Log is the same formatted line that goes to stderr/
+// write_to, so logfmt → logfmt, json → json. Operators with log
+// forwarders parsing the event log get parseable output.
+func TestLogger_EventLog_RespectsFormatChoice(t *testing.T) {
+	tests := []struct {
+		name   string
+		format Format
+		// expectations on the event log message body
+		mustContain []string
+	}{
+		{
+			name:        "logfmt",
+			format:      FormatLogfmt,
+			mustContain: []string{"level=info", "msg=hello", "k=v"},
+		},
+		{
+			name:        "json",
+			format:      FormatJSON,
+			mustContain: []string{`"level":"info"`, `"msg":"hello"`, `"k":"v"`},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := &testutil.MockEventLog{}
+			var inner bytes.Buffer
+			l, err := NewDeferred(&inner)
+			require.NoError(t, err)
+			l.eventLogOpener = func(_ string) (eventlog.EventLog, error) {
+				return mock, nil
+			}
+
+			require.NoError(t, l.Update(Options{
+				Level:       LevelInfo,
+				Format:      tc.format,
+				Destination: LogDestinationWindowsEventLog,
+			}))
+
+			require.NoError(t, l.Log("msg", "hello", "k", "v"))
+
+			require.Len(t, mock.Infos, 1)
+			got := mock.Infos[0]
+			for _, want := range tc.mustContain {
+				require.Contains(t, got, want, "event log entry should be %s-formatted", tc.format)
+			}
+			// Event log message shouldn't have the trailing newline slog
+			// would emit for stdio output — it's a single API message.
+			require.NotContains(t, got, "\n", "event log message should be a single line")
+		})
+	}
+}
+
+// TestLogger_EventLog_TransitionToStderrClosesHandle verifies that
+// genuinely leaving the windows_event_log destination DOES close the
+// handle and subsequent logs no longer reach it. The bytes path then
+// reaches the stderr writer through writerVar's inner writer.
+func TestLogger_EventLog_TransitionToStderrClosesHandle(t *testing.T) {
+	mock := &testutil.MockEventLog{}
+	var inner bytes.Buffer
+	l, err := NewDeferred(&inner)
+	require.NoError(t, err)
+	l.eventLogOpener = func(_ string) (eventlog.EventLog, error) {
+		return mock, nil
+	}
+
+	require.NoError(t, l.Update(Options{
+		Level:       LevelInfo,
+		Format:      FormatLogfmt,
+		Destination: LogDestinationWindowsEventLog,
+	}))
+
+	require.NoError(t, l.Update(Options{
+		Level:       LevelInfo,
+		Format:      FormatLogfmt,
+		Destination: LogDestinationStderr,
+	}))
+	_, hasEL := l.writer.FastPathFlags()
+	require.False(t, hasEL, "event_log → stderr should close the event log handle")
+
+	mock.Reset()
+	require.NoError(t, l.Log("msg", "stderr-only"))
+	require.Empty(t, mock.Infos, "no further records should reach the event log after transition")
+	require.Contains(t, inner.String(), "stderr-only",
+		"bytes path should now reach the stderr writer")
+}

--- a/internal/runtime/logging/logger_event_log_test.go
+++ b/internal/runtime/logging/logger_event_log_test.go
@@ -5,9 +5,10 @@ import (
 	"log/slog"
 	"runtime"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
+
+	"go.uber.org/atomic"
 
 	"github.com/grafana/alloy/internal/runtime/logging/eventlog"
 	"github.com/grafana/alloy/internal/runtime/logging/eventlog/testutil"

--- a/internal/runtime/logging/logger_event_log_test.go
+++ b/internal/runtime/logging/logger_event_log_test.go
@@ -147,6 +147,28 @@ func TestLogger_EventLog_TransitionToStderrClosesHandle(t *testing.T) {
 		"bytes path should now reach the stderr writer")
 }
 
+// TestDispatch_FastPathRaceRoutesToEventLogAsInfo locks in the loss-prevention
+// behavior for the fast-path race: when a Write(p) arrives with eventLogLevel=nil
+// in state B (suppressInner=true, eventLog!=nil), Dispatch defaults to Info on
+// the event log instead of misrouting to stderr. This preserves the operator's
+// destination choice across a destination switch.
+func TestDispatch_FastPathRaceRoutesToEventLogAsInfo(t *testing.T) {
+	mock := &testutil.MockEventLog{}
+	var inner bytes.Buffer
+	w := &writerVar{
+		innerWriter:   &inner,
+		eventLog:      mock,
+		suppressInner: true,
+	}
+
+	require.NoError(t, w.Dispatch([]byte("fast-path race bytes\n"), nil))
+
+	require.Empty(t, inner.String(), "inner should stay suppressed; bytes belong on the event log")
+	require.Len(t, mock.Infos, 1, "event log should receive the record as Info")
+	require.Equal(t, "fast-path race bytes", mock.Infos[0],
+		"trailing newline should be trimmed for the event log API")
+}
+
 // TestUpdate_NoLossDuringConcurrentDestinationFlips is a stress test that runs
 // many Handle calls in parallel with rapid destination switches between
 // stderr and windows_event_log. With Dispatch's loss-prevention fallback AND

--- a/internal/runtime/logging/logger_event_log_test.go
+++ b/internal/runtime/logging/logger_event_log_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"log/slog"
 	"testing"
-	"time"
 
 	"github.com/grafana/alloy/internal/runtime/logging/eventlog"
 	"github.com/grafana/alloy/internal/runtime/logging/eventlog/testutil"
@@ -33,14 +32,13 @@ func TestLogger_EventLog_LevelReloadTakesEffect(t *testing.T) {
 		Destination: LogDestinationWindowsEventLog,
 	}))
 
-	h := l.Slog().Handler()
+	sl := l.Slog()
 	ctx := t.Context()
 
 	// Debug record should be filtered at Info level.
-	require.False(t, h.Enabled(ctx, slog.LevelDebug),
+	require.False(t, sl.Handler().Enabled(ctx, slog.LevelDebug),
 		"handler should report debug as disabled at Info level")
-	require.NoError(t, h.Handle(ctx,
-		slog.NewRecord(time.Now(), slog.LevelDebug, "debug-before", 0)))
+	sl.Log(ctx, slog.LevelDebug, "debug-before")
 	require.Empty(t, mock.Infos, "debug record at Info level should be filtered")
 
 	// Reload at Debug level, same destination — no reopen.
@@ -51,10 +49,9 @@ func TestLogger_EventLog_LevelReloadTakesEffect(t *testing.T) {
 	}))
 
 	// Debug record should now pass through.
-	require.True(t, h.Enabled(ctx, slog.LevelDebug),
+	require.True(t, sl.Handler().Enabled(ctx, slog.LevelDebug),
 		"handler should report debug as enabled at Debug level")
-	require.NoError(t, h.Handle(ctx,
-		slog.NewRecord(time.Now(), slog.LevelDebug, "debug-after", 0)))
+	sl.Log(ctx, slog.LevelDebug, "debug-after")
 	require.Len(t, mock.Infos, 1, "debug record at Debug level should reach event log")
 	require.Contains(t, mock.Infos[0], "debug-after")
 }

--- a/internal/runtime/logging/logger_event_log_test.go
+++ b/internal/runtime/logging/logger_event_log_test.go
@@ -138,8 +138,7 @@ func TestLogger_EventLog_TransitionToStderrClosesHandle(t *testing.T) {
 		Format:      FormatLogfmt,
 		Destination: LogDestinationStderr,
 	}))
-	_, hasEL := l.writer.FastPathFlags()
-	require.False(t, hasEL, "event_log → stderr should close the event log handle")
+	require.True(t, mock.Closed(), "event_log → stderr should close the event log handle")
 
 	mock.Reset()
 	require.NoError(t, l.Log("msg", "stderr-only"))

--- a/internal/runtime/logging/options.go
+++ b/internal/runtime/logging/options.go
@@ -49,21 +49,26 @@ func defaultDestination() LogDestination {
 	return LogDestinationStderr
 }
 
-// DefaultOptions holds defaults for creating a Logger.
-var DefaultOptions = Options{
-	Level:       LevelDefault,
-	Format:      FormatDefault,
-	Destination: defaultDestination(),
+// defaultOptions builds a fresh set of Logger defaults, evaluating the
+// platform-appropriate destination at call time.
+func defaultOptions() Options {
+	return Options{
+		Level:       LevelDefault,
+		Format:      FormatDefault,
+		Destination: defaultDestination(),
+	}
 }
+
+// DefaultOptions holds defaults for creating a Logger.
+var DefaultOptions = defaultOptions()
 
 var _ syntax.Defaulter = (*Options)(nil)
 
-// SetToDefault implements syntax.Defaulter. Destination is re-evaluated so
-// tests that stub isWindowsService after package init still observe the
-// expected default.
+// SetToDefault implements syntax.Defaulter. It re-evaluates the defaults at
+// call time (rather than reusing DefaultOptions) so that tests which stub
+// isWindowsService after package init still observe the expected destination.
 func (o *Options) SetToDefault() {
-	*o = DefaultOptions
-	o.Destination = defaultDestination()
+	*o = defaultOptions()
 }
 
 // Level represents how verbose logging should be.

--- a/internal/runtime/logging/options.go
+++ b/internal/runtime/logging/options.go
@@ -12,23 +12,58 @@ import (
 
 // Options is a set of options used to construct and configure a Logger.
 type Options struct {
-	Level  Level  `alloy:"level,attr,optional"`
-	Format Format `alloy:"format,attr,optional"`
+	Level       Level          `alloy:"level,attr,optional"`
+	Format      Format         `alloy:"format,attr,optional"`
+	Destination LogDestination `alloy:"destination,attr,optional"`
 
 	WriteTo []loki.LogsReceiver `alloy:"write_to,attr,optional"`
 }
 
+// LogDestination is where to send the primary log output.
+type LogDestination string
+
+// TODO: Add a "none" destination to disable primary output.
+const (
+	LogDestinationStderr          LogDestination = "stderr"
+	LogDestinationWindowsEventLog LogDestination = "windows_event_log"
+)
+
+var _ encoding.TextUnmarshaler = (*LogDestination)(nil)
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (d *LogDestination) UnmarshalText(text []byte) error {
+	switch LogDestination(text) {
+	case LogDestinationStderr, LogDestinationWindowsEventLog:
+		*d = LogDestination(text)
+		return nil
+	default:
+		return fmt.Errorf("unrecognized log destination %q", string(text))
+	}
+}
+
+// defaultDestination returns the platform-appropriate default log destination.
+func defaultDestination() LogDestination {
+	if isWindowsService() {
+		return LogDestinationWindowsEventLog
+	}
+	return LogDestinationStderr
+}
+
 // DefaultOptions holds defaults for creating a Logger.
 var DefaultOptions = Options{
-	Level:  LevelDefault,
-	Format: FormatDefault,
+	Level:       LevelDefault,
+	Format:      FormatDefault,
+	Destination: defaultDestination(),
 }
 
 var _ syntax.Defaulter = (*Options)(nil)
 
-// SetToDefault implements syntax.Defaulter.
+// SetToDefault implements syntax.Defaulter. Destination is re-evaluated so
+// tests that stub isWindowsService after package init still observe the
+// expected default.
 func (o *Options) SetToDefault() {
 	*o = DefaultOptions
+	o.Destination = defaultDestination()
 }
 
 // Level represents how verbose logging should be.

--- a/internal/runtime/logging/options_test.go
+++ b/internal/runtime/logging/options_test.go
@@ -1,0 +1,90 @@
+package logging
+
+import (
+	"testing"
+
+	"github.com/grafana/alloy/syntax"
+	"github.com/stretchr/testify/require"
+)
+
+// stubIsWindowsService replaces isWindowsService for the duration of the test
+// and restores the original on cleanup.
+func stubIsWindowsService(t *testing.T, value bool) {
+	t.Helper()
+	orig := isWindowsService
+	t.Cleanup(func() { isWindowsService = orig })
+	isWindowsService = func() bool { return value }
+}
+
+// TestOptions_EndToEnd drives the real syntax decoder to verify that:
+//   - when `destination` is omitted, the platform-appropriate default is used
+//     (windows_event_log when running as a service, stderr otherwise);
+//   - when the user sets `destination` explicitly, that value wins regardless
+//     of the platform;
+//   - an unrecognized destination is rejected at decode time.
+func TestOptions_EndToEnd(t *testing.T) {
+	tests := []struct {
+		name             string
+		runningAsService bool
+		config           string
+		want             LogDestination
+		wantErr          bool
+	}{
+		{
+			name:             "destination omitted on service uses windows_event_log",
+			runningAsService: true,
+			config:           `level = "info"`,
+			want:             LogDestinationWindowsEventLog,
+		},
+		{
+			name:             "destination omitted off service uses stderr",
+			runningAsService: false,
+			config:           `level = "info"`,
+			want:             LogDestinationStderr,
+		},
+		{
+			name:             "user explicit stderr overrides service default",
+			runningAsService: true,
+			config:           `destination = "stderr"`,
+			want:             LogDestinationStderr,
+		},
+		{
+			name:             "user explicit windows_event_log overrides non-service default",
+			runningAsService: false,
+			config:           `destination = "windows_event_log"`,
+			want:             LogDestinationWindowsEventLog,
+		},
+		{
+			name:             "user picks stderr off service (matches default)",
+			runningAsService: false,
+			config:           `destination = "stderr"`,
+			want:             LogDestinationStderr,
+		},
+		{
+			name:             "user picks windows_event_log on service (matches default)",
+			runningAsService: true,
+			config:           `destination = "windows_event_log"`,
+			want:             LogDestinationWindowsEventLog,
+		},
+		{
+			name:    "unrecognized destination is rejected",
+			config:  `destination = "not_a_destination"`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stubIsWindowsService(t, tc.runningAsService)
+
+			var o Options
+			err := syntax.Unmarshal([]byte(tc.config), &o)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, o.Destination)
+		})
+	}
+}

--- a/internal/runtime/logging/service_other.go
+++ b/internal/runtime/logging/service_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package logging
+
+// isWindowsService always returns false on non-Windows platforms. Stored as
+// a var so tests can stub it.
+var isWindowsService = func() bool {
+	return false
+}

--- a/internal/runtime/logging/service_windows.go
+++ b/internal/runtime/logging/service_windows.go
@@ -1,0 +1,72 @@
+//go:build windows
+
+package logging
+
+import (
+	"os"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc"
+)
+
+// isWindowsService reports whether the current process is running as a Windows
+// service. It tries two approaches in order:
+//  1. svc.IsWindowsService: checks whether the direct parent is services.exe.
+//     It does not walk up the process tree but it's the "official" way to check.
+//  2. hasServiceAncestor: walks the full ancestor chain looking for services.exe,
+//     covering cases where a launcher sits between the SCM and this process.
+//
+// Stored as a var so tests can stub it; reassigning is the only supported way
+// to control its return value in tests.
+var isWindowsService = func() bool {
+	if ok, err := svc.IsWindowsService(); err == nil && ok {
+		return true
+	}
+	return hasServiceAncestor()
+}
+
+// hasServiceAncestor takes a snapshot of all running processes and walks the
+// ancestor chain of the current process. It returns true if any ancestor is
+// named services.exe.
+func hasServiceAncestor() bool {
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return false
+	}
+	defer windows.CloseHandle(snapshot)
+
+	type procInfo struct {
+		parentPID uint32
+		name      string
+	}
+
+	procs := make(map[uint32]procInfo)
+	var entry windows.ProcessEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+	for err = windows.Process32First(snapshot, &entry); err == nil; err = windows.Process32Next(snapshot, &entry) {
+		procs[entry.ProcessID] = procInfo{
+			parentPID: entry.ParentProcessID,
+			name:      windows.UTF16ToString(entry.ExeFile[:]),
+		}
+	}
+
+	visited := make(map[uint32]bool)
+	for pid := uint32(os.Getpid()); ; {
+		if visited[pid] {
+			break
+		}
+		visited[pid] = true
+
+		info, ok := procs[pid]
+		if !ok {
+			break
+		}
+		if strings.EqualFold(info.name, "services.exe") {
+			return true
+		}
+		pid = info.parentPID
+	}
+	return false
+}


### PR DESCRIPTION
### Pull Request Details

Currently, Alloy can send its own logs to stderr and to loki components. This PR adds the ability to send to the Windows Event log instead of stderr.

### Issue(s) fixed by this Pull Request

Fixes #4070

In subsequent PRs I will add a new "none" destination to disable logging.

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated

BEGIN_COMMIT_OVERRIDE
BREAKING CHANGE: If Alloy is ran in a Windows service, it will now send logs to Windows Event Log by default.
END_COMMIT_OVERRIDE