### PR TITLE
docs: Fix spelling errors across Alloy docs

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -65,7 +65,7 @@ Choosing the right tools to collect, process, and export telemetry data can be a
 The broad range of telemetry you need to process and the collectors you choose can vary widely depending on your observability goals.
 In addition, you face the challenge of addressing the constantly evolving needs of your observability strategy.
 For example, you may initially only need application observability, but you then discover that you must add infrastructure observability.
-Many organizations manage and configure multiple collectors to address these challenges, introducing more complexity and potential errors in their obervability strategy.
+Many organizations manage and configure multiple collectors to address these challenges, introducing more complexity and potential errors in their observability strategy.
 
 **All signals, whether application, infrastructure, or both**
 

--- a/docs/sources/_index.md.t
+++ b/docs/sources/_index.md.t
@@ -65,7 +65,7 @@ Choosing the right tools to collect, process, and export telemetry data can be a
 The broad range of telemetry you need to process and the collectors you choose can vary widely depending on your observability goals.
 In addition, you face the challenge of addressing the constantly evolving needs of your observability strategy.
 For example, you may initially only need application observability, but you then discover that you must add infrastructure observability.
-Many organizations manage and configure multiple collectors to address these challenges, introducing more complexity and potential errors in their obervability strategy.
+Many organizations manage and configure multiple collectors to address these challenges, introducing more complexity and potential errors in their observability strategy.
 
 **All signals, whether application, infrastructure, or both**
 

--- a/docs/sources/reference/components/loki/loki.process.md
+++ b/docs/sources/reference/components/loki/loki.process.md
@@ -1534,7 +1534,7 @@ stage.structured_metadata {
 
 ### `stage.structured_metadata_drop`
 
-The `stage.structured_metadata_drop` inner block configures a processing stage that drops structured metadata from incoming log entires.
+The `stage.structured_metadata_drop` inner block configures a processing stage that drops structured metadata from incoming log entries.
 
 The following arguments are supported:
 

--- a/docs/sources/reference/components/mimir/mimir.alerts.kubernetes.md
+++ b/docs/sources/reference/components/mimir/mimir.alerts.kubernetes.md
@@ -152,7 +152,7 @@ The `values` argument must not be provided when `operator` is set to `"Exists"` 
 
 The `alertmanagerconfig_matcher` block describes the strategy used by AlertmanagerConfig objects to match alerts in the routes and inhibition rules.
 
-Depending on how this block is configured, the final Alertmanger config will have different [matchers][] in its [route][] section.
+Depending on how this block is configured, the final Alertmanager config will have different [matchers][] in its [route][] section.
 
 [matchers]: https://prometheus.io/docs/alerting/latest/configuration/#matcher
 [route]: https://prometheus.io/docs/alerting/latest/configuration/#route

--- a/docs/sources/reference/components/otelcol/otelcol.processor.interval.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.interval.md
@@ -152,27 +152,27 @@ otelcol.auth.basic "grafana_cloud" {
 }
 ```
 
-| Timestamp | Metric Name    | Aggregation Temporarility | Attributes          | Value |
-|-----------|----------------|---------------------------|---------------------|------:|
-| 0         | `test_metric`  | Cumulative                | `labelA: example1`  |   4.0 |
-| 2         | `test_metric`  | Cumulative                | `labelA: example2`  |   3.1 |
-| 4         | `other_metric` | Delta                     | `fruitType: orange` |  77.4 |
-| 6         | `test_metric`  | Cumulative                | `labelA: example1`  |   8.2 |
-| 8         | `test_metric`  | Cumulative                | `labelA: example1`  |  12.8 |
-| 10        | `test_metric`  | Cumulative                | `labelA: example2`  |   6.4 |
+| Timestamp | Metric Name    | Aggregation Temporality | Attributes          | Value |
+| --------- | -------------- | ----------------------- | ------------------- | ----: |
+| 0         | `test_metric`  | Cumulative              | `labelA: example1`  |   4.0 |
+| 2         | `test_metric`  | Cumulative              | `labelA: example2`  |   3.1 |
+| 4         | `other_metric` | Delta                   | `fruitType: orange` |  77.4 |
+| 6         | `test_metric`  | Cumulative              | `labelA: example1`  |   8.2 |
+| 8         | `test_metric`  | Cumulative              | `labelA: example1`  |  12.8 |
+| 10        | `test_metric`  | Cumulative              | `labelA: example2`  |   6.4 |
 
 The processor immediately passes the following metric to the next processor in the chain because it's a Delta metric.
 
-| Timestamp | Metric Name    | Aggregation Temporarility | Attributes          | Value |
-|-----------|----------------|---------------------------|---------------------|------:|
-| 4         | `other_metric` | Delta                     | `fruitType: orange` |  77.4 |
+| Timestamp | Metric Name    | Aggregation Temporality | Attributes          | Value |
+| --------- | -------------- | ----------------------- | ------------------- | ----: |
+| 4         | `other_metric` | Delta                   | `fruitType: orange` |  77.4 |
 
 At the next `interval` (15s by default), the processor passed the following metrics to the next processor in the chain.
 
-| Timestamp | Metric Name   | Aggregation Temporarility | Attributes         | Value |
-|-----------|---------------|---------------------------|--------------------|------:|
-| 8         | `test_metric` | Cumulative                | `labelA: example1` |  12.8 |
-| 10        | `test_metric` | Cumulative                | `labelA: example1` |   6.4 |
+| Timestamp | Metric Name   | Aggregation Temporality | Attributes         | Value |
+| --------- | ------------- | ----------------------- | ------------------ | ----: |
+| 8         | `test_metric` | Cumulative              | `labelA: example1` |  12.8 |
+| 10        | `test_metric` | Cumulative              | `labelA: example1` |   6.4 |
 
 <!-- START GENERATED COMPATIBLE COMPONENTS -->
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.process.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.process.md
@@ -74,7 +74,7 @@ The `name` argument can use the following template variables. By default it uses
 * `{{.ExeBase}}`: Basename of the executable from argv[0].
 * `{{.ExeFull}}`: Fully qualified path of the executable.
 * `{{.Username}}`: Username of the effective user.
-* `{{.Matches}}`: Map containing all regular explression capture groups resulting from matching a process with the cmdline rule group.
+* `{{.Matches}}`: Map containing all regular expression capture groups resulting from matching a process with the cmdline rule group.
 * `{{.PID}}`: PID of the process. Note that the PID is copied from the first executable found.
 * `{{.StartTime}}`: The start time of the process. This is useful when combined with PID as PIDS get reused over time.
 * `{{.Cgroups}}`: The cgroups, if supported, of the process (`/proc/self/cgroup`). This is particularly useful for identifying to which container a process belongs.

--- a/docs/sources/reference/stdlib/encoding.md
+++ b/docs/sources/reference/stdlib/encoding.md
@@ -75,7 +75,7 @@ string123%21%3F%24%2A%26%28%29%27-%3D%40~
 ## encoding.url_decode
 
 The `encoding.url_decode` function decodes a RFC3986 "percent encoding" compliant string.
-`encoding.url_decode` failes if input string is not RFC3986 "percent encoding" compliant.
+`encoding.url_decode` fails if input string is not RFC3986 "percent encoding" compliant.
 
 ### Example
 

--- a/docs/sources/shared/reference/components/otelcol-queue-batch-block.md
+++ b/docs/sources/shared/reference/components/otelcol-queue-batch-block.md
@@ -7,7 +7,7 @@ headless: true
 Batching is disabled by default.
 To enable it, explicitly include `batch {}` in your Alloy configuration.
 You do not need to include a `batch {}` block in your `otelcol.exporter` if you already use a `otelcol.processor.batch` component,
-although batching in the exporter is the prefered method because it is more flexible.
+although batching in the exporter is the preferred method because it is more flexible.
 
 The following arguments are supported:
 


### PR DESCRIPTION
Fix some spelling errors that were discovered in the Alloy docs