### PR TITLE
docs: Wrap snake case arguments with backticks

### DIFF
--- a/docs/sources/collect/ecs-opentelemetry-data.md
+++ b/docs/sources/collect/ecs-opentelemetry-data.md
@@ -192,7 +192,7 @@ Complete the following steps to create a sample task.
 
      1. Add a container to the task.
      1. Set the container name to `ecs-exporter`.
-     1. Set the image to a pinned version of the exporter, for example `quay.io/prometheuscommunity/ecs-exporter:v0.1.1`. Check the [ecs_exporter releases](https://github.com/prometheus-community/ecs_exporter/releases) for the latest stable version. You should avoid using the `latest` tag in production.
+     1. Set the image to a pinned version of the exporter, for example `quay.io/prometheuscommunity/ecs-exporter:v0.1.1`. Check the [`ecs_exporter` releases](https://github.com/prometheus-community/ecs_exporter/releases) for the latest stable version. You should avoid using the `latest` tag in production.
      1. Add `tcp/9779` as a port mapping.
 
 1. Follow the ECS Fargate setup instructions to [create a task definition][task] using the template.

--- a/docs/sources/reference/components/database_observability/database_observability.postgres.md
+++ b/docs/sources/reference/components/database_observability/database_observability.postgres.md
@@ -183,13 +183,13 @@ Example log line:
 2026-02-02 21:35:40.130 UTC:10.24.155.141(34110):app_user@books_store:[32032]:2:40001:2026-02-02 21:33:19 UTC:25/112:0:693c34cb.2398::psqlERROR:  canceling statement due to user request
 ```
 
-This is done by setting the log_line_prefix param to `%m:%r:%u@%d:[%p]:%l:%e:%s:%v:%x:%c:%q%a`.
+This is done by setting the `log_line_prefix` parameter to `%m:%r:%u@%d:[%p]:%l:%e:%s:%v:%x:%c:%q%a`.
 
-#### Configure the log_line_prefix
+#### Configure the `log_line_prefix`
 
 **Self hosted Postgres server**
 
-For the logs collector to work correctly, PostgreSQL must be configured with the following log_line_prefix:
+For the logs collector to work correctly, PostgreSQL must be configured with the following `log_line_prefix`:
 
 ```sql
 -- Set log format (requires superuser)

--- a/docs/sources/reference/components/loki/loki.process.md
+++ b/docs/sources/reference/components/loki/loki.process.md
@@ -1488,7 +1488,7 @@ stage.sampling {
 
 ### `stage.static_labels`
 
-The `stage.static_labels` inner block configures a static_labels processing stage that adds a static set of labels to incoming log entries.
+The `stage.static_labels` inner block configures a `static_labels` processing stage that adds a static set of labels to incoming log entries.
 
 For labels that are dynamic, refer to [`stage.labels`][stage.labels]
 
@@ -1894,7 +1894,7 @@ The following block is supported inside the definition of `stage.truncate`:
 
 #### `rule`
 
-Defines a truncation rule that will apply to the log line, labels, structured_metadata, or extracted map.
+Defines a truncation rule that will apply to the log line, labels, structured metadata, or extracted map.
 
 The following arguments are supported:
 
@@ -1910,10 +1910,10 @@ The stage checks the byte length of the log line, label values, or structured me
 If you provide a `suffix`, the limit is reduced by the length of the `suffix`, and the `suffix` is appended to the truncated value.
 
 The `source_type` attribute must be one of `"line"`, `"label"`, `"structured_metadata"`, or `"extracted"`.
-If the `source` attribute is specified, the stage will only truncate a label, structured_metadata, or extracted field of the same name.
-If `source` is empty, all labels, structured_metadata, or extracted fields will be truncated if they exceed the limit.
+If the `source` attribute is specified, the stage will only truncate a label, structured metadata, or extracted field of the same name.
+If `source` is empty, all labels, structured metadata, or extracted fields will be truncated if they exceed the limit.
 
-Whenever a line, label, extracted field, or structured_metadata value is truncated, the metric `loki_process_truncated_fields_total` is incremented.
+Whenever a line, label, extracted field, or structured metadata value is truncated, the metric `loki_process_truncated_fields_total` is incremented.
 The `field` label will either be `line`, `label`, `extracted`, or `structured_metadata`.
 
 If anything has been truncated, the extracted map for the entry contains a `"truncated"` field with a comma delimited list of field types that have been truncated.
@@ -2058,7 +2058,7 @@ The following fields are exported and can be referenced by other components:
 
 * `loki_process_dropped_lines_total` (counter): Number of lines dropped as part of a processing stage.
 * `loki_process_dropped_lines_by_label_total` (counter):  Number of lines dropped when `by_label_name` is non-empty in [stage.limit][].
-* `loki_process_truncated_fields_total` (counter): Number of lines, label values, extracted field values, and structured_metadata values truncated as part of a `truncate` stage.
+* `loki_process_truncated_fields_total` (counter): Number of lines, label values, extracted field values, and structured metadata values truncated as part of a `truncate` stage.
 
 ## Example
 

--- a/docs/sources/reference/components/otelcol/otelcol.auth.oauth2.md
+++ b/docs/sources/reference/components/otelcol/otelcol.auth.oauth2.md
@@ -70,7 +70,7 @@ You can use the following blocks with `otelcol.auth.oauth2`:
 | -------------------------------- | -------------------------------------------------------------------------- | -------- |
 | [`debug_metrics`][debug_metrics] | Configures the metrics that this component generates to monitor its state. | no       |
 | [`tls`][tls]                     | TLS settings for the token client.                                         | no       |
-| `tls` > [`tpm`][tpm]             | TPM settings for the TLS key_file.                                         | no       |
+| `tls` > [`tpm`][tpm]             | TPM settings for the TLS `key_file`.                                       | no       |
 
 [tls]: #tls
 [tpm]: #tpm

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.datadog.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.datadog.md
@@ -146,8 +146,8 @@ By default, the exporter only sends host metadata for a single host, whose name 
 Valid values for `hostname_source` are:
 
 * `"first_resource"` picks the host metadata hostname from the resource attributes on the first OTLP payload that gets to the exporter. 
-  If the first payload lacks hostname-like attributes, it will fallback to 'config_or_system' behavior. **Don't use this hostname source if receiving data from multiple hosts**.
-* `"config_or_system"` picks the host metadata hostname from the 'hostname' setting, falling back to system and cloud provider APIs.
+  If the first payload lacks hostname-like attributes, it will fallback to `config_or_system` behavior. **Don't use this hostname source if receiving data from multiple hosts**.
+* `"config_or_system"` picks the host metadata hostname from the `hostname` setting, falling back to system and cloud provider APIs.
 
 ### `logs`
 

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.faro.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.faro.md
@@ -45,12 +45,12 @@ The `otelcol.exporter.faro` component doesn't support any arguments. You can con
 You can use the following blocks with `otelcol.exporter.faro`:
 
 | Block                                                 | Description                                                                    | Required |
-|-------------------------------------------------------|--------------------------------------------------------------------------------|----------|
+| ----------------------------------------------------- | ------------------------------------------------------------------------------ | -------- |
 | [`client`][client]                                    | Configures the HTTP client to send telemetry data to.                          | yes      |
 | `client` > [`compression_params`][compression_params] | Configure advanced compression options.                                        | no       |
 | `client` > [`cookies`][cookies]                       | Store cookies from server responses and reuse them in subsequent requests.     | no       |
 | `client` > [`tls`][tls]                               | Configures TLS for the HTTP client.                                            | no       |
-| `client` > `tls` > [`tpm`][tpm]                       | Configures TPM settings for the TLS key_file.                                  | no       |
+| `client` > `tls` > [`tpm`][tpm]                       | Configures TPM settings for the TLS `key_file`.                                | no       |
 | [`debug_metrics`][debug_metrics]                      | Configures the metrics that this component generates to monitor its state.     | no       |
 | [`retry_on_failure`][retry_on_failure]                | Configures retry mechanism for failed requests.                                | no       |
 | [`sending_queue`][sending_queue]                      | Configures batching of data before sending.                                    | no       |

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.kafka.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.kafka.md
@@ -73,7 +73,7 @@ When `topic_from_attribute` is set, it will take precedence over the `topic` arg
 You can use the following blocks with `otelcol.exporter.kafka`:
 
 | Block                                                   | Description                                                                    | Required |
-|---------------------------------------------------------|--------------------------------------------------------------------------------|----------|
+| ------------------------------------------------------- | ------------------------------------------------------------------------------ | -------- |
 | [`authentication`][authentication]                      | Configures authentication for connecting to Kafka brokers.                     | no       |
 | `authentication` > [`kerberos`][kerberos]               | Authenticates against Kafka brokers with Kerberos.                             | no       |
 | `authentication` > [`plaintext`][plaintext]             | Authenticates against Kafka brokers with plaintext.                            | no       |
@@ -92,7 +92,7 @@ You can use the following blocks with `otelcol.exporter.kafka`:
 | [`sending_queue`][sending_queue]                        | Configures batching of data before sending.                                    | no       |
 | `sending_queue` > [`batch`][batch]                      | Configures batching requests based on a timeout and a minimum number of items. | no       |
 | [`tls`][tls]                                            | Configures TLS for connecting to the Kafka brokers.                            | no       |
-| `tls` > [`tpm`][tpm]                                    | Configures TPM settings for the TLS key_file.                                  | no       |
+| `tls` > [`tpm`][tpm]                                    | Configures TPM settings for the TLS `key_file`.                                | no       |
 | [`traces`][traces]                                      | Configures how to send traces to Kafka brokers.                                | no       |
 
 The > symbol indicates deeper levels of nesting.

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.loadbalancing.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.loadbalancing.md
@@ -96,7 +96,7 @@ where the list of resolved endpoints changes frequently due to deployments and s
 You can use the following blocks with `otelcol.exporter.loadbalancing`:
 
 | Block                                                     | Description                                                                       | Required |
-|-----------------------------------------------------------|-----------------------------------------------------------------------------------|----------|
+| --------------------------------------------------------- | --------------------------------------------------------------------------------- | -------- |
 | [`resolver`][resolver]                                    | Configures discovering the endpoints to export to.                                | yes      |
 | `resolver` > [`aws_cloud_map`][aws_cloud_map]             | AWS CloudMap-sourced list of endpoints to export to.                              | no       |
 | `resolver` > [`dns`][dns]                                 | DNS-sourced list of endpoints to export to.                                       | no       |
@@ -107,7 +107,7 @@ You can use the following blocks with `otelcol.exporter.loadbalancing`:
 | `protocol` > `otlp` > [`client`][client]                  | Configures the exporter gRPC client.                                              | no       |
 | `protocol` > `otlp` > `client` > [`keepalive`][keepalive] | Configures keepalive settings for the gRPC client.                                | no       |
 | `protocol` > `otlp` > `client` > [`tls`][tls]             | Configures TLS for the gRPC client.                                               | no       |
-| `protocol` > `otlp` > `client` > `tls` > [`tpm`][tpm]     | Configures TPM settings for the TLS key_file.                                     | no       |
+| `protocol` > `otlp` > `client` > `tls` > [`tpm`][tpm]     | Configures TPM settings for the TLS `key_file`.                                   | no       |
 | `protocol` > `otlp` > [`queue`][queue]                    | Configures batching of data before sending.                                       | no       |
 | `protocol` > `otlp` > [`retry`][retry]                    | Configures retry mechanism for failed requests.                                   | no       |
 | [`sending_queue`][queue]                                  | Configures batching of data before sending to the `otlp > protocol` exporter.     | no       |

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.otlp.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.otlp.md
@@ -45,16 +45,16 @@ You can use the following argument with `otelcol.exporter.otlp`:
 
 You can use the following blocks with `otelcol.exporter.otlp`:
 
-| Block                                  | Description                                                                | Required |
-|----------------------------------------|----------------------------------------------------------------------------|----------|
-| [`client`][client]                     | Configures the gRPC client to send telemetry data to.                      | yes      |
-| `client` > [`keepalive`][keepalive]    | Configures keepalive settings for the gRPC client.                         | no       |
-| `client` > [`tls`][tls]                | Configures TLS for the gRPC client.                                        | no       |
-| `client` > `tls` > [`tpm`][tpm]        | Configures TPM settings for the TLS key_file.                              | no       |
-| [`debug_metrics`][debug_metrics]       | Configures the metrics that this component generates to monitor its state. | no       |
-| [`retry_on_failure`][retry_on_failure] | Configures retry mechanism for failed requests.                            | no       |
-| [`sending_queue`][sending_queue]       | Configures batching of data before sending.                                | no       |
-| `sending_queue` > [`batch`][batch]    | Configures batching requests based on a timeout and a minimum number of items. | no       |
+| Block                                  | Description                                                                    | Required |
+| -------------------------------------- | ------------------------------------------------------------------------------ | -------- |
+| [`client`][client]                     | Configures the gRPC client to send telemetry data to.                          | yes      |
+| `client` > [`keepalive`][keepalive]    | Configures keepalive settings for the gRPC client.                             | no       |
+| `client` > [`tls`][tls]                | Configures TLS for the gRPC client.                                            | no       |
+| `client` > `tls` > [`tpm`][tpm]        | Configures TPM settings for the TLS `key_file`.                                | no       |
+| [`debug_metrics`][debug_metrics]       | Configures the metrics that this component generates to monitor its state.     | no       |
+| [`retry_on_failure`][retry_on_failure] | Configures retry mechanism for failed requests.                                | no       |
+| [`sending_queue`][sending_queue]       | Configures batching of data before sending.                                    | no       |
+| `sending_queue` > [`batch`][batch]     | Configures batching requests based on a timeout and a minimum number of items. | no       |
 
 The > symbol indicates deeper levels of nesting.
 For example, `client` > `tls` refers to a `tls` block defined inside a `client` block.

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.otlphttp.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.otlphttp.md
@@ -52,12 +52,12 @@ If set, these arguments override the `client.endpoint` field for the correspondi
 You can use the following blocks with `otelcol.exporter.otlphttp`:
 
 | Block                                                 | Description                                                                    | Required |
-|-------------------------------------------------------|--------------------------------------------------------------------------------|----------|
+| ----------------------------------------------------- | ------------------------------------------------------------------------------ | -------- |
 | [`client`][client]                                    | Configures the HTTP client to send telemetry data to.                          | yes      |
 | `client` > [`compression_params`][compression_params] | Configure advanced compression options.                                        | no       |
 | `client` > [`cookies`][cookies]                       | Store cookies from server responses and reuse them in subsequent requests.     | no       |
 | `client` > [`tls`][tls]                               | Configures TLS for the HTTP client.                                            | no       |
-| `client` > `tls` > [`tpm`][tpm]                       | Configures TPM settings for the TLS key_file.                                  | no       |
+| `client` > `tls` > [`tpm`][tpm]                       | Configures TPM settings for the TLS `key_file`.                                | no       |
 | [`debug_metrics`][debug_metrics]                      | Configures the metrics that this component generates to monitor its state.     | no       |
 | [`retry_on_failure`][retry_on_failure]                | Configures retry mechanism for failed requests.                                | no       |
 | [`sending_queue`][sending_queue]                      | Configures queueing and batching for the exporter.                             | no       |

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.syslog.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.syslog.md
@@ -85,7 +85,7 @@ You can use the following blocks with `otelcol.exporter.syslog`:
 | [`sending_queue`][sending_queue]       | Configures batching of data before sending.                                    | no       |
 | `sending_queue` > [`batch`][batch]     | Configures batching requests based on a timeout and a minimum number of items. | no       |
 | [`tls`][tls]                           | Configures TLS for a TCP connection.                                           | no       |
-| `tls` > [`tpm`][tpm]                   | Configures TPM settings for the TLS key_file.                                  | no       |
+| `tls` > [`tpm`][tpm]                   | Configures TPM settings for the TLS `key_file`.                                | no       |
 
 The > symbol indicates deeper levels of nesting.
 For example, `tls` > `tpm` refers to a `tpm` block defined inside a `tls` block.

--- a/docs/sources/reference/components/otelcol/otelcol.extension.jaeger_remote_sampling.md
+++ b/docs/sources/reference/components/otelcol/otelcol.extension.jaeger_remote_sampling.md
@@ -41,7 +41,7 @@ The `otelcol.extension.jaeger_remote_sampling` component doesn't support any arg
 You can use the following blocks with `otelcol.extension.jaeger_remote_sampling`:
 
 | Block                                                             | Description                                                                      | Required |
-|-------------------------------------------------------------------|----------------------------------------------------------------------------------|----------|
+| ----------------------------------------------------------------- | -------------------------------------------------------------------------------- | -------- |
 | [`source`][source]                                                | Configures the Jaeger remote sampling document.                                  | yes      |
 | `source` > [`remote`][remote]                                     | Configures the gRPC client used to retrieve the Jaeger remote sampling document. | no       |
 | `source` > `remote` > [`keepalive` client][keepalive_client]      | Configures keepalive settings for the gRPC client.                               | no       |
@@ -49,13 +49,13 @@ You can use the following blocks with `otelcol.extension.jaeger_remote_sampling`
 | [`http`][http]                                                    | Configures the HTTP server to serve Jaeger remote sampling.                      | no       |
 | `http` > [`cors`][cors]                                           | Configures CORS for the HTTP server.                                             | no       |
 | `http` > [`tls`][tls]                                             | Configures TLS for the HTTP server.                                              | no       |
-| `http` > `tls` > [`tpm`][tpm]                                     | Configures TPM settings for the TLS key_file.                                    | no       |
+| `http` > `tls` > [`tpm`][tpm]                                     | Configures TPM settings for the TLS `key_file`.                                  | no       |
 | [`grpc`][grpc]                                                    | Configures the gRPC server to serve Jaeger remote sampling.                      | no       |
 | `grpc` > [`keepalive`][keepalive]                                 | Configures keepalive settings for the configured server.                         | no       |
 | `grpc` > `keepalive` > [`enforcement_policy`][enforcement_policy] | Enforcement policy for keepalive settings.                                       | no       |
 | `grpc` > `keepalive` > [`server_parameters`][server_parameters]   | Server parameters used to configure keepalive settings.                          | no       |
 | `grpc` > [`tls`][tls]                                             | Configures TLS for the gRPC server.                                              | no       |
-| `grpc` > `tls` > [`tpm`][tpm]                                     | Configures TPM settings for the TLS key_file.                                    | no       |
+| `grpc` > `tls` > [`tpm`][tpm]                                     | Configures TPM settings for the TLS `key_file`.                                  | no       |
 | [`debug_metrics`][debug_metrics]                                  | Configures the metrics that this component generates to monitor its state.       | no       |
 
 The > symbol indicates deeper levels of nesting.

--- a/docs/sources/reference/components/otelcol/otelcol.processor.metric_start_time.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.metric_start_time.md
@@ -193,7 +193,7 @@ otelcol.exporter.otlphttp "production" {
 }
 ```
 
-### Using subtract_initial_point strategy
+### Using `subtract_initial_point` strategy
 
 This example uses the `subtract_initial_point` strategy, which preserves cumulative semantics and produces correct rates:
 
@@ -219,9 +219,9 @@ otelcol.exporter.otlphttp "production" {
 }
 ```
 
-### Using start_time_metric strategy with custom regex
+### Use a `start_time_metric` strategy with a custom regular expression
 
-This example uses the `start_time_metric` strategy with a custom regex to find the start time metric:
+This example uses the `start_time_metric` strategy with a custom regular expression to find the start time metric:
 
 ```alloy
 otelcol.receiver.prometheus "default" {

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.datadog.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.datadog.md
@@ -60,12 +60,12 @@ To expose the HTTP server to other machines on your network, configure `endpoint
 You can use the following blocks with `otelcol.receiver.datadog`:
 
 | Block                            | Description                                                                | Required |
-|----------------------------------|----------------------------------------------------------------------------|----------|
+| -------------------------------- | -------------------------------------------------------------------------- | -------- |
 | [`output`][output]               | Configures where to send received telemetry data.                          | yes      |
 | [`cors`][cors]                   | Configures CORS for the HTTP server.                                       | no       |
 | [`debug_metrics`][debug_metrics] | Configures the metrics that this component generates to monitor its state. | no       |
 | [`tls`][tls]                     | Configures TLS for the HTTP server.                                        | no       |
-| `tls` > [`tpm`][tpm]             | Configures TPM settings for the TLS key_file.                              | no       |
+| `tls` > [`tpm`][tpm]             | Configures TPM settings for the TLS `key_file`.                            | no       |
 
 The > symbol indicates deeper levels of nesting.
 For example, `tls` > `tpm` refers to a `tpm` block defined inside a `tls` block.

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.faro.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.faro.md
@@ -57,12 +57,12 @@ To expose the HTTP server to other machines on your network, configure `endpoint
 You can use the following blocks with `otelcol.receiver.faro`:
 
 | Block                            | Description                                                                | Required |
-|----------------------------------|----------------------------------------------------------------------------|----------|
+| -------------------------------- | -------------------------------------------------------------------------- | -------- |
 | [`output`][output]               | Configures where to send received telemetry data.                          | yes      |
 | [`cors`][cors]                   | Configures CORS for the HTTP server.                                       | no       |
 | [`debug_metrics`][debug_metrics] | Configures the metrics that this component generates to monitor its state. | no       |
 | [`tls`][tls]                     | Configures TLS for the HTTP server.                                        | no       |
-| `tls` > [`tpm`][tpm]             | Configures TPM settings for the TLS key_file.                              | no       |
+| `tls` > [`tpm`][tpm]             | Configures TPM settings for the TLS `key_file`.                            | no       |
 
 The > symbol indicates deeper levels of nesting.
 For example, `tls` > `tpm` refers to a `tpm` block defined inside a `tls` block.

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.influxdb.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.influxdb.md
@@ -54,12 +54,12 @@ To expose the HTTP server to other machines on your network, configure `endpoint
 You can use the following blocks with `otelcol.receiver.influxdb`:
 
 | Block                            | Description                                           | Required |
-|----------------------------------|-------------------------------------------------------|----------|
+| -------------------------------- | ----------------------------------------------------- | -------- |
 | [`output`][output]               | Configures where to send received metrics.            | yes      |
 | [`cors`][cors]                   | Configures CORS for the HTTP server.                  | no       |
 | [`debug_metrics`][debug_metrics] | Configures the metrics that this component generates. | no       |
 | [`tls`][tls]                     | Configures TLS for the HTTP server.                   | no       |
-| `tls` > [`tpm`][tpm]             | Configures TPM settings for the TLS key_file.         | no       |
+| `tls` > [`tpm`][tpm]             | Configures TPM settings for the TLS `key_file`.       | no       |
 
 The > symbol indicates deeper levels of nesting.
 For example, `tls` > `tpm` refers to a `tpm` block defined inside a `tls` block.

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.jaeger.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.jaeger.md
@@ -51,19 +51,19 @@ The `otelcol.receiver.jaeger` component doesn't support any arguments. You can c
 You can use the following blocks with `otelcol.receiver.jaeger`:
 
 | Block                                                                           | Description                                                                | Required |
-|---------------------------------------------------------------------------------|----------------------------------------------------------------------------|----------|
+| ------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | -------- |
 | [`output`][output]                                                              | Configures where to send received telemetry data.                          | yes      |
 | [`protocols`][protocols]                                                        | Configures the protocols the component can accept traffic over.            | yes      |
 | `protocols` > [`grpc`][grpc]                                                    | Configures a Jaeger gRPC server to receive traces.                         | no       |
 | `protocols` > `grpc` > [`tls`][tls]                                             | Configures TLS for the gRPC server.                                        | no       |
-| `protocols` > `grpc` > `tls` > [`tpm`][tpm]                                     | Configures TPM settings for the TLS key_file.                              | no       |
+| `protocols` > `grpc` > `tls` > [`tpm`][tpm]                                     | Configures TPM settings for the TLS `key_file`.                            | no       |
 | `protocols` > `grpc` > [`keepalive`][keepalive]                                 | Configures keepalive settings for the configured server.                   | no       |
 | `protocols` > `grpc` > `keepalive` > [`server_parameters`][server_parameters]   | Server parameters used to configure keepalive settings.                    | no       |
 | `protocols` > `grpc` > `keepalive` > [`enforcement_policy`][enforcement_policy] | Enforcement policy for keepalive settings.                                 | no       |
 | `protocols` > [`thrift_http`][thrift_http]                                      | Configures a Thrift HTTP server to receive traces.                         | no       |
 | `protocols` > `thrift_http` > [`cors`][cors]                                    | Configures CORS for the Thrift HTTP server.                                | no       |
 | `protocols` > `thrift_http` > [`tls`][tls]                                      | Configures TLS for the Thrift HTTP server.                                 | no       |
-| `protocols` > `thrift_http` > `tls` > [`tpm`][tpm]                              | Configures TPM settings for the TLS key_file.                              | no       |
+| `protocols` > `thrift_http` > `tls` > [`tpm`][tpm]                              | Configures TPM settings for the TLS `key_file`.                            | no       |
 | `protocols` > [`thrift_binary`][thrift_binary]                                  | Configures a Thrift binary UDP server to receive traces.                   | no       |
 | `protocols` > [`thrift_compact`][thrift_compact]                                | Configures a Thrift compact UDP server to receive traces.                  | no       |
 | [`debug_metrics`][debug_metrics]                                                | Configures the metrics that this component generates to monitor its state. | no       |

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.kafka.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.kafka.md
@@ -116,7 +116,7 @@ You can use the following blocks with `otelcol.receiver.kafka`:
 | `authentication` > [`sasl`][sasl]                | Authenticates against Kafka brokers with SASL.                                             | no       |
 | `authentication` > `sasl` > [`aws_msk`][aws_msk] | Additional SASL parameters when using AWS_MSK_IAM_OAUTHBEARER.                             | no       |
 | `authentication` > [`tls`][tls]                  | (Deprecated) Configures TLS for connecting to the Kafka brokers.                           | no       |
-| `authentication` > `tls` > [`tpm`][tpm]          | Configures TPM settings for the TLS key_file.                                              | no       |
+| `authentication` > `tls` > [`tpm`][tpm]          | Configures TPM settings for the TLS `key_file`.                                            | no       |
 | [`autocommit`][autocommit]                       | Configures how to automatically commit updated topic offsets to back to the Kafka brokers. | no       |
 | [`debug_metrics`][debug_metrics]                 | Configures the metrics which this component generates to monitor its state.                | no       |
 | [`logs`][logs]                                   | Configures how to send logs to Kafka brokers.                                              | no       |
@@ -128,7 +128,7 @@ You can use the following blocks with `otelcol.receiver.kafka`:
 | [`metrics`][metrics]                             | Configures how to send metrics to Kafka brokers.                                           | no       |
 | [`traces`][traces]                               | Configures how to send traces to Kafka brokers.                                            | no       |
 | [`tls`][tls][]                                   | Configures TLS for connecting to the Kafka brokers.                                        | no       |
-| `tls` > [`tpm`][tpm]                             | Configures TPM settings for the TLS key_file.                                              | no       |
+| `tls` > [`tpm`][tpm]                             | Configures TPM settings for the TLS `key_file`.                                            | no       |
 
 The > symbol indicates deeper levels of nesting.
 For example, `authentication` > `tls` refers to a `tls` block defined inside an `authentication` block.

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.otlp.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.otlp.md
@@ -48,7 +48,7 @@ The `otelcol.receiver.otlp` component doesn't support any arguments. You can con
 You can use the following blocks with `otelcol.receiver.otlp`:
 
 | Block                                                             | Description                                                                | Required |
-|-------------------------------------------------------------------|----------------------------------------------------------------------------|----------|
+| ----------------------------------------------------------------- | -------------------------------------------------------------------------- | -------- |
 | [`output`][output]                                                | Configures where to send received telemetry data.                          | yes      |
 | [`debug_metrics`][debug_metrics]                                  | Configures the metrics that this component generates to monitor its state. | no       |
 | [`grpc`][grpc]                                                    | Configures the gRPC server to receive telemetry data.                      | no       |
@@ -56,11 +56,11 @@ You can use the following blocks with `otelcol.receiver.otlp`:
 | `grpc` > `keepalive` > [`enforcement_policy`][enforcement_policy] | Enforcement policy for keepalive settings.                                 | no       |
 | `grpc` > `keepalive` > [`server_parameters`][server_parameters]   | Server parameters used to configure keepalive settings.                    | no       |
 | `grpc` > [`tls`][tls]                                             | Configures TLS for the gRPC server.                                        | no       |
-| `grpc` > `tls` > [`tpm`][tpm]                                     | Configures TPM settings for the TLS key_file.                              | no       |
+| `grpc` > `tls` > [`tpm`][tpm]                                     | Configures TPM settings for the TLS `key_file`.                            | no       |
 | [`http`][http]                                                    | Configures the HTTP server to receive telemetry data.                      | no       |
 | `http` > [`cors`][cors]                                           | Configures CORS for the HTTP server.                                       | no       |
 | `http` > [`tls`][tls]                                             | Configures TLS for the HTTP server.                                        | no       |
-| `http` > `tls` > [`tpm`][tpm]                                     | Configures TPM settings for the TLS key_file.                              | no       |
+| `http` > `tls` > [`tpm`][tpm]                                     | Configures TPM settings for the TLS `key_file`.                            | no       |
 
 The > symbol indicates deeper levels of nesting.
 For example, `grpc` > `tls` refers to a `tls` block defined inside a `grpc` block.

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.solace.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.solace.md
@@ -52,7 +52,7 @@ You can use the following arguments with `otelcol.receiver.solace`:
 You can use the following blocks with `otelcol.receiver.solace`:
 
 | Block                                               | Description                                                                                                                      | Required |
-|-----------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|----------|
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | -------- |
 | [`output`][output]                                  | Configures where to send received telemetry data.                                                                                | yes      |
 | [`authentication`][authentication]                  | Configures authentication for connecting to the Solace broker.                                                                   | yes      |
 | `authentication` > [`sasl_external`][sasl_external] | Authenticates against the Solace broker with SASL External.                                                                      | no       |
@@ -62,7 +62,7 @@ You can use the following blocks with `otelcol.receiver.solace`:
 | [`flow`][flow]                                      | Configures the behaviour to use when temporary errors are encountered from the next component.                                   | no       |
 | `flow` > [`delayed_retry`][delayed_retry]           | Sets the flow control strategy to `delayed retry` which will wait before trying to push the message to the next component again. | no       |
 | [`tls`][tls]                                        | Configures TLS for connecting to the Solace broker.                                                                              | no       |
-| `tls` > [`tpm`][tpm]                                | Configures TPM settings for the TLS key_file.                                                                                    | no       |
+| `tls` > [`tpm`][tpm]                                | Configures TPM settings for the TLS `key_file`.                                                                                  | no       |
 
 The > symbol indicates deeper levels of nesting.
 For example, `authentication` > `tls` refers to a `tls` block defined inside an `authentication` block.

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.splunkhec.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.splunkhec.md
@@ -63,13 +63,13 @@ If logs or metrics are exported with `otelcol.exporter.splunkhec` it will check 
 You can use the following blocks with `otelcol.receiver.splunkhec`:
 
 | Block                                                      | Description                                                                | Required |
-|------------------------------------------------------------|----------------------------------------------------------------------------|----------|
+| ---------------------------------------------------------- | -------------------------------------------------------------------------- | -------- |
 | [`output`][output]                                         | Configures where to send received telemetry data.                          | yes      |
 | [`cors`][cors]                                             | Configures CORS for the HTTP server.                                       | no       |
 | [`debug_metrics`][debug_metrics]                           | Configures the metrics that this component generates to monitor its state. | no       |
 | [`hec_metadata_to_otel_attrs`][hec_metadata_to_otel_attrs] | Configures OpenTelemetry attributes from HEC metadata.                     | no       |
 | [`tls`][tls]                                               | Configures TLS for the HTTP server.                                        | no       |
-| `tls` > [`tpm`][tpm]                                       | Configures TPM settings for the TLS key_file.                              | no       |
+| `tls` > [`tpm`][tpm]                                       | Configures TPM settings for the TLS `key_file`.                            | no       |
 
 The > symbol indicates deeper levels of nesting.
 For example, `tls` > `tpm` refers to a `tpm` block defined inside a `tls` block.

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.syslog.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.syslog.md
@@ -80,14 +80,14 @@ The `on_error` argument can take the following values:
 You can use the following blocks with `otelcol.receiver.syslog`:
 
 | Block                                  | Description                                                                                     | Required |
-|----------------------------------------|-------------------------------------------------------------------------------------------------|----------|
+| -------------------------------------- | ----------------------------------------------------------------------------------------------- | -------- |
 | [`output`][output]                     | Configures where to send received telemetry data.                                               | yes      |
 | [`debug_metrics`][debug_metrics]       | Configures the metrics that this component generates to monitor its state.                      | no       |
 | [`retry_on_failure`][retry_on_failure] | Configures the retry behavior when the receiver encounters an error downstream in the pipeline. | no       |
 | [`tcp`][tcp]                           | Configures a TCP syslog server to receive syslog messages.                                      | no*      |
 | `tcp` > [`multiline`][multiline]       | Configures rules for multiline parsing of incoming messages                                     | no       |
 | `tcp` > [`tls`][tls]                   | Configures TLS for the TCP syslog server.                                                       | no       |
-| `tcp` > `tls` > [`tpm`][tpm]           | Configures TPM settings for the TLS key_file.                                                   | no       |
+| `tcp` > `tls` > [`tpm`][tpm]           | Configures TPM settings for the TLS `key_file`.                                                 | no       |
 | [`udp`][udp]                           | Configures a UDP syslog server to receive syslog messages.                                      | no*      |
 | `udp` > [`async`][async]               | Configures rules for asynchronous parsing of incoming messages.                                 | no       |
 | `udp` > [`multiline`][multiline]       | Configures rules for multiline parsing of incoming messages.                                    | no       |

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.tcplog.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.tcplog.md
@@ -58,13 +58,13 @@ The `max_log_size` argument has a minimum value of `64KiB`.
 You can use the following blocks with `otelcol.receiver.tcplog`:
 
 | Block                                  | Description                                                                                     | Required |
-|----------------------------------------|-------------------------------------------------------------------------------------------------|----------|
+| -------------------------------------- | ----------------------------------------------------------------------------------------------- | -------- |
 | [`output`][output]                     | Configures where to send received telemetry data.                                               | yes      |
 | [`debug_metrics`][debug_metrics]       | Configures the metrics that this component generates to monitor its state.                      | no       |
 | [`multiline`][multiline]               | Configures rules for multiline parsing of incoming messages                                     | no       |
 | [`retry_on_failure`][retry_on_failure] | Configures the retry behavior when the receiver encounters an error downstream in the pipeline. | no       |
 | [`tls`][tls]                           | Configures TLS for the TCP server.                                                              | no       |
-| `tls` > [`tpm`][tpm]                   | Configures TPM settings for the TLS key_file.                                                   | no       |
+| `tls` > [`tpm`][tpm]                   | Configures TPM settings for the TLS `key_file`.                                                 | no       |
 
 The > symbol indicates deeper levels of nesting.
 For example, `tls` > `tpm` refers to a `tpm` block defined inside a `tls` block.

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.vcenter.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.vcenter.md
@@ -72,13 +72,13 @@ You can use the following arguments with `otelcol.receiver.vcenter`:
 You can use the following blocks with `otelcol.receiver.vcenter`:
 
 | Block                                        | Description                                                                | Required |
-|----------------------------------------------|----------------------------------------------------------------------------|----------|
+| -------------------------------------------- | -------------------------------------------------------------------------- | -------- |
 | [`output`][output]                           | Configures where to send received telemetry data.                          | yes      |
 | [`debug_metrics`][debug_metrics]             | Configures the metrics that this component generates to monitor its state. | no       |
 | [`metrics`][metrics]                         | Configures which metrics will be sent to downstream components.            | no       |
 | [`resource_attributes`][resource_attributes] | Configures resource attributes for metrics sent to downstream components.  | no       |
 | [`tls`][tls]                                 | Configures TLS for the HTTP client.                                        | no       |
-| `tls` > [`tpm`][tpm]                         | Configures TPM settings for the TLS key_file.                              | no       |
+| `tls` > [`tpm`][tpm]                         | Configures TPM settings for the TLS `key_file`.                            | no       |
 
 The > symbol indicates deeper levels of nesting.
 For example, `tls` > `tpm` refers to a `tpm` block defined inside a `tls` block.

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.zipkin.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.zipkin.md
@@ -56,12 +56,12 @@ String tags and binary annotations that can't be converted remain unchanged.
 You can use the following blocks with `otelcol.receiver.zipkin`:
 
 | Block                            | Description                                                                | Required |
-|----------------------------------|----------------------------------------------------------------------------|----------|
+| -------------------------------- | -------------------------------------------------------------------------- | -------- |
 | [`output`][output]               | Configures where to send received traces.                                  | yes      |
 | [`cors`][cors]                   | Configures CORS for the HTTP server.                                       | no       |
 | [`debug_metrics`][debug_metrics] | Configures the metrics that this component generates to monitor its state. | no       |
 | [`tls`][tls]                     | Configures TLS for the HTTP server.                                        | no       |
-| `tls` > [`tpm`][tpm]             | Configures TPM settings for the TLS key_file.                              | no       |
+| `tls` > [`tpm`][tpm]             | Configures TPM settings for the TLS `key_file`.                            | no       |
 
 The > symbol indicates deeper levels of nesting.
 For example, `tls` > `tpm` refers to a `tpm` block defined inside a `tls` block.


### PR DESCRIPTION
Snake case words in the docs are almost always a reference to an argument, variable, or other value that should be wrapped with backticks (to render as inline code). This PR adds backticks to the snake_case words that were found with a grep.