### PR TITLE
feat(database_observability.postgres): Add configurable limit to `pg_stat_statements` query

### DIFF
--- a/docs/sources/reference/components/database_observability/database_observability.postgres.md
+++ b/docs/sources/reference/components/database_observability/database_observability.postgres.md
@@ -117,6 +117,7 @@ The `azure` block supplies the identifying information for the database being mo
 | Name               | Type       | Description                                          | Default | Required |
 |--------------------|------------|------------------------------------------------------|---------|----------|
 | `collect_interval` | `duration` | How frequently to collect information from database. | `"1m"`  | no       |
+| `statements_limit` | `integer`  | Max number of recent queries to collect details for. | `100`   | no       |
 
 ### `query_samples`
 

--- a/internal/component/database_observability/postgres/collector/query_details_test.go
+++ b/internal/component/database_observability/postgres/collector/query_details_test.go
@@ -500,6 +500,7 @@ func TestQueryDetails(t *testing.T) {
 			collector, err := NewQueryDetails(QueryDetailsArguments{
 				DB:              db,
 				CollectInterval: time.Second,
+				StatementsLimit: 100,
 				EntryHandler:    lokiClient,
 				TableRegistry:   tc.tableRegistry,
 				Logger:          log.NewLogfmtLogger(os.Stderr),
@@ -507,7 +508,7 @@ func TestQueryDetails(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, collector)
 
-			mock.ExpectQuery(fmt.Sprintf(selectQueriesFromActivity, exclusionClause, "")).WithoutArgs().RowsWillBeClosed().
+			mock.ExpectQuery(fmt.Sprintf(selectQueriesFromActivity, exclusionClause, "", 100)).WithoutArgs().RowsWillBeClosed().
 				WillReturnRows(
 					sqlmock.NewRows([]string{
 						"queryid",
@@ -562,13 +563,14 @@ func TestQueryDetails_SQLDriverErrors(t *testing.T) {
 		collector, err := NewQueryDetails(QueryDetailsArguments{
 			DB:              db,
 			CollectInterval: time.Second,
+			StatementsLimit: 100,
 			EntryHandler:    lokiClient,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
 
-		mock.ExpectQuery(fmt.Sprintf(selectQueriesFromActivity, exclusionClause, "")).WithoutArgs().RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectQueriesFromActivity, exclusionClause, "", 100)).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"queryid", // not enough columns
@@ -576,7 +578,7 @@ func TestQueryDetails_SQLDriverErrors(t *testing.T) {
 					"abc123",
 				))
 
-		mock.ExpectQuery(fmt.Sprintf(selectQueriesFromActivity, exclusionClause, "")).WithoutArgs().RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectQueriesFromActivity, exclusionClause, "", 100)).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"queryid",
@@ -625,13 +627,14 @@ func TestQueryDetails_SQLDriverErrors(t *testing.T) {
 		collector, err := NewQueryDetails(QueryDetailsArguments{
 			DB:              db,
 			CollectInterval: time.Second,
+			StatementsLimit: 100,
 			EntryHandler:    lokiClient,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
 
-		mock.ExpectQuery(fmt.Sprintf(selectQueriesFromActivity, exclusionClause, "")).WithoutArgs().RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectQueriesFromActivity, exclusionClause, "", 100)).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"queryid",
@@ -684,15 +687,16 @@ func TestQueryDetails_SQLDriverErrors(t *testing.T) {
 		collector, err := NewQueryDetails(QueryDetailsArguments{
 			DB:              db,
 			CollectInterval: time.Second,
+			StatementsLimit: 100,
 			EntryHandler:    lokiClient,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
 
-		mock.ExpectQuery(fmt.Sprintf(selectQueriesFromActivity, exclusionClause, "")).WithoutArgs().WillReturnError(fmt.Errorf("connection error"))
+		mock.ExpectQuery(fmt.Sprintf(selectQueriesFromActivity, exclusionClause, "", 100)).WithoutArgs().WillReturnError(fmt.Errorf("connection error"))
 
-		mock.ExpectQuery(fmt.Sprintf(selectQueriesFromActivity, exclusionClause, "")).WithoutArgs().RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectQueriesFromActivity, exclusionClause, "", 100)).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"queryid",
@@ -904,6 +908,7 @@ func TestQueryDetails_ExcludeDatabases(t *testing.T) {
 	collector, err := NewQueryDetails(QueryDetailsArguments{
 		DB:               db,
 		CollectInterval:  time.Second,
+		StatementsLimit:  100,
 		ExcludeDatabases: []string{"excluded_database"},
 		EntryHandler:     lokiClient,
 		Logger:           log.NewLogfmtLogger(os.Stderr),
@@ -911,7 +916,7 @@ func TestQueryDetails_ExcludeDatabases(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, collector)
 
-	mock.ExpectQuery(fmt.Sprintf(selectQueriesFromActivity, buildExcludedDatabasesClause([]string{"excluded_database"}), "")).WithoutArgs().RowsWillBeClosed().
+	mock.ExpectQuery(fmt.Sprintf(selectQueriesFromActivity, buildExcludedDatabasesClause([]string{"excluded_database"}), "", 100)).WithoutArgs().RowsWillBeClosed().
 		WillReturnRows(
 			sqlmock.NewRows([]string{
 				"queryid",
@@ -959,6 +964,7 @@ func TestQueryDetails_ExcludeUsers(t *testing.T) {
 	collector, err := NewQueryDetails(QueryDetailsArguments{
 		DB:              db,
 		CollectInterval: time.Second,
+		StatementsLimit: 100,
 		ExcludeUsers:    []string{"excluded_user"},
 		EntryHandler:    lokiClient,
 		Logger:          log.NewLogfmtLogger(os.Stderr),
@@ -967,7 +973,7 @@ func TestQueryDetails_ExcludeUsers(t *testing.T) {
 	require.NotNil(t, collector)
 
 	expectedExcludedUsersClause := buildExcludedUsersClause([]string{"excluded_user"}, "pg_get_userbyid(pg_stat_statements.userid)")
-	mock.ExpectQuery(fmt.Sprintf(selectQueriesFromActivity, exclusionClause, expectedExcludedUsersClause)).WithoutArgs().RowsWillBeClosed().
+	mock.ExpectQuery(fmt.Sprintf(selectQueriesFromActivity, exclusionClause, expectedExcludedUsersClause, 100)).WithoutArgs().RowsWillBeClosed().
 		WillReturnRows(
 			sqlmock.NewRows([]string{
 				"queryid",

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -70,7 +70,7 @@ type Arguments struct {
 
 	CloudProvider          *CloudProvider         `alloy:"cloud_provider,block,optional"`
 	QuerySampleArguments   QuerySampleArguments   `alloy:"query_samples,block,optional"`
-	QueryTablesArguments   QueryTablesArguments   `alloy:"query_details,block,optional"`
+	QueryDetailsArguments  QueryDetailsArguments  `alloy:"query_details,block,optional"`
 	SchemaDetailsArguments SchemaDetailsArguments `alloy:"schema_details,block,optional"`
 	ExplainPlansArguments  ExplainPlansArguments  `alloy:"explain_plans,block,optional"`
 	HealthCheckArguments   HealthCheckArguments   `alloy:"health_check,block,optional"`
@@ -97,8 +97,9 @@ type QuerySampleArguments struct {
 	ExcludeCurrentUser    bool          `alloy:"exclude_current_user,attr,optional"`
 }
 
-type QueryTablesArguments struct {
+type QueryDetailsArguments struct {
 	CollectInterval time.Duration `alloy:"collect_interval,attr,optional"`
+	StatementsLimit int           `alloy:"statements_limit,attr,optional"`
 }
 
 type SchemaDetailsArguments struct {
@@ -116,8 +117,9 @@ var DefaultArguments = Arguments{
 		DisableQueryRedaction: false,
 		ExcludeCurrentUser:    true,
 	},
-	QueryTablesArguments: QueryTablesArguments{
+	QueryDetailsArguments: QueryDetailsArguments{
 		CollectInterval: 1 * time.Minute,
+		StatementsLimit: 100,
 	},
 	SchemaDetailsArguments: SchemaDetailsArguments{
 		CollectInterval: 1 * time.Minute,
@@ -470,7 +472,8 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 	if collectors[collector.QueryDetailsCollector] {
 		qCollector, err := collector.NewQueryDetails(collector.QueryDetailsArguments{
 			DB:               c.dbConnection,
-			CollectInterval:  c.args.QueryTablesArguments.CollectInterval,
+			CollectInterval:  c.args.QueryDetailsArguments.CollectInterval,
+			StatementsLimit:  c.args.QueryDetailsArguments.StatementsLimit,
 			ExcludeDatabases: c.args.ExcludeDatabases,
 			ExcludeUsers:     c.args.ExcludeUsers,
 			EntryHandler:     entryHandler,


### PR DESCRIPTION
### Brief description of Pull Request
Allow configuring the number of statements collected from `pg_stat_statements` in the `query_details` collector. This allows (roughly) matching the number of statements set in the exporter.

### Pull Request Details

<!-- Add a more detailed descripion of the Pull Request here, if needed. -->

### Issue(s) fixed by this Pull Request
Fixes https://github.com/grafana/grafana-dbo11y-app/issues/2414

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
