### PR TITLE
docs: Add Explicit Mention of OpenTelemetry Component Versions in OTel Engine Docs

### DIFF
--- a/docs/sources/introduction/otel_alloy.md
+++ b/docs/sources/introduction/otel_alloy.md
@@ -36,7 +36,7 @@ The {{< param "OTEL_ENGINE" >}} bundle includes:
 - A curated selection of components from contributor repositories
 - The `alloyengine` extension
 
-{{< param "PRODUCT_NAME" >}} {{< param ALLOY_RELEASE >}} currently bundles versions {{< param "OTEL_VERSION" >}} of OpenTelemetry Collector components.
+{{< param "PRODUCT_NAME" >}} {{< param ALLOY_RELEASE >}} bundles versions {{< param "OTEL_VERSION" >}} of OpenTelemetry Collector components.
 You can find more information about the bundled version in both the [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector/tree/{{< param "OTEL_VERSION" >}}) and [OpenTelemetry Collector Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}) repositories.
 
 The following sections list all included components:


### PR DESCRIPTION
We link to the current version in the components section, but it's worth explicitly stating this so that users understand the current functionality