### PR TITLE
chore: Fix TestMultiplePatterns test which fails on Windows

### DIFF
--- a/internal/component/local/file_match/file_test.go
+++ b/internal/component/local/file_match/file_test.go
@@ -322,7 +322,7 @@ func TestMultiplePatterns(t *testing.T) {
 
 	foundFiles := c.getWatchedFiles()
 
-	// Expected files: 3 directories × 3 extensions (filepath so separators match OS, e.g. \ on Windows)
+	// Expected files: 3 directories × 3 extensions.
 	// Use filepath.Join so that we get "/" separators on Linux and "\" on Windows.
 	expectedFiles := []string{
 		filepath.Join("nginx", "access.log"),


### PR DESCRIPTION
Fixing a test which has been [failing](https://github.com/grafana/alloy/actions/runs/22381132299/job/64781904503) on Windows since it has been [added](https://github.com/grafana/alloy/pull/5470/changes#diff-75bf56b8a0a10932c665b57e426b68cbf240f612484479649295cc42774f6b64R239) two weeks ago.

```
--- FAIL: TestMultiplePatterns (0.04s)
    file_test.go:342: 
        	Error Trace:	D:/a/alloy/alloy/internal/component/local/file_match/file_test.go:342
        	Error:      	Should be true
        	Test:       	TestMultiplePatterns
        	Messages:   	nginx/access.log should be matched
FAIL
FAIL	github.com/grafana/alloy/internal/component/local/file_match	0.681s
```