### PR TITLE
chore: Reduce TestEndpoint flakiness: increase lkelyhood of separate batches

### DIFF
--- a/internal/component/common/loki/client/endpoint_test.go
+++ b/internal/component/common/loki/client/endpoint_test.go
@@ -77,14 +77,14 @@ func TestEndpoint(t *testing.T) {
                        `,
 		},
 		{
-			name: "batch log entries together until the batch wait time is reached",
+			name: "batch log entries separately when the batch wait time is reached",
 			endpointConfig: Config{
 				BatchSize: int(1 * units.GB),
-				BatchWait: 100 * time.Millisecond,
+				BatchWait: 50 * time.Millisecond,
 			},
 			serverResponseStatus: 200,
 			inputEntries:         []loki.Entry{logEntries[0], logEntries[1]},
-			inputDelay:           200 * time.Millisecond,
+			inputDelay:           700 * time.Millisecond,
 			expectedReqs: []util.RemoteWriteRequest{
 				{
 					TenantID: "",


### PR DESCRIPTION
This test has been [flaky](https://github.com/grafana/alloy/actions/runs/22396622611/job/64831836019) on windows. It expects two different write requests, but sometimes there is only one because both batch sizes are written within the same batch wait timeout.

<details>

<summary>Test output</summary>
```
--- FAIL: TestEndpoint (2.07s)
    --- FAIL: TestEndpoint/batch_log_entries_together_until_the_batch_wait_time_is_reached (1.66s)
        endpoint_test.go:458: 
            	Error Trace:	D:/a/alloy/alloy/internal/component/common/loki/client/endpoint_test.go:458
            	Error:      	elements differ
            	            	
            	            	extra elements in list A:
            	            	([]interface {}) (len=2) {
            	            	 (util.RemoteWriteRequest) {
            	            	  TenantID: (string) "",
            	            	  Request: (push.PushRequest) {
            	            	   Streams: ([]push.Stream) (len=1) {
            	            	    (push.Stream) {
            	            	     Labels: (string) (len=2) "{}",
            	            	     Entries: ([]push.Entry) (len=1) {
            	            	      (push.Entry) {
            	            	       Timestamp: (time.Time) {
            	            	        wall: (uint64) 0,
            	            	        ext: (int64) 62135596801,
            	            	        loc: (*time.Location)(<nil>)
            	            	       },
            	            	       Line: (string) (len=5) "line1",
            	            	       StructuredMetadata: (push.LabelsAdapter) <nil>,
            	            	       Parsed: (push.LabelsAdapter) <nil>
            	            	      }
            	            	     },
            	            	     Hash: (uint64) 0
            	            	    }
            	            	   },
            	            	   Format: (string) ""
            	            	  }
            	            	 },
            	            	 (util.RemoteWriteRequest) {
            	            	  TenantID: (string) "",
            	            	  Request: (push.PushRequest) {
            	            	   Streams: ([]push.Stream) (len=1) {
            	            	    (push.Stream) {
            	            	     Labels: (string) (len=2) "{}",
            	            	     Entries: ([]push.Entry) (len=1) {
            	            	      (push.Entry) {
            	            	       Timestamp: (time.Time) {
            	            	        wall: (uint64) 0,
            	            	        ext: (int64) 62135596802,
            	            	        loc: (*time.Location)(<nil>)
            	            	       },
            	            	       Line: (string) (len=5) "line2",
            	            	       StructuredMetadata: (push.LabelsAdapter) <nil>,
            	            	       Parsed: (push.LabelsAdapter) <nil>
            	            	      }
            	            	     },
            	            	     Hash: (uint64) 0
            	            	    }
            	            	   },
            	            	   Format: (string) ""
            	            	  }
            	            	 }
            	            	}
            	            	
            	            	
            	            	extra elements in list B:
            	            	([]interface {}) (len=1) {
            	            	 (util.RemoteWriteRequest) {
            	            	  TenantID: (string) "",
            	            	  Request: (push.PushRequest) {
            	            	   Streams: ([]push.Stream) (len=1) {
            	            	    (push.Stream) {
            	            	     Labels: (string) (len=2) "{}",
            	            	     Entries: ([]push.Entry) (len=2) {
            	            	      (push.Entry) {
            	            	       Timestamp: (time.Time) {
            	            	        wall: (uint64) 0,
            	            	        ext: (int64) 62135596801,
            	            	        loc: (*time.Location)(<nil>)
            	            	       },
            	            	       Line: (string) (len=5) "line1",
            	            	       StructuredMetadata: (push.LabelsAdapter) <nil>,
            	            	       Parsed: (push.LabelsAdapter) <nil>
            	            	      },
            	            	      (push.Entry) {
            	            	       Timestamp: (time.Time) {
            	            	        wall: (uint64) 0,
            	            	        ext: (int64) 62135596802,
            	            	        loc: (*time.Location)(<nil>)
            	            	       },
            	            	       Line: (string) (len=5) "line2",
            	            	       StructuredMetadata: (push.LabelsAdapter) <nil>,
            	            	       Parsed: (push.LabelsAdapter) <nil>
            	            	      }
            	            	     },
            	            	     Hash: (uint64) 0
            	            	    }
            	            	   },
            	            	   Format: (string) ""
            	            	  }
            	            	 }
            	            	}
            	            	
            	            	
            	            	listA:
            	            	([]util.RemoteWriteRequest) (len=2) {
            	            	 (util.RemoteWriteRequest) {
            	            	  TenantID: (string) "",
            	            	  Request: (push.PushRequest) {
            	            	   Streams: ([]push.Stream) (len=1) {
            	            	    (push.Stream) {
            	            	     Labels: (string) (len=2) "{}",
            	            	     Entries: ([]push.Entry) (len=1) {
            	            	      (push.Entry) {
            	            	       Timestamp: (time.Time) {
            	            	        wall: (uint64) 0,
            	            	        ext: (int64) 62135596801,
            	            	        loc: (*time.Location)(<nil>)
            	            	       },
            	            	       Line: (string) (len=5) "line1",
            	            	       StructuredMetadata: (push.LabelsAdapter) <nil>,
            	            	       Parsed: (push.LabelsAdapter) <nil>
            	            	      }
            	            	     },
            	            	     Hash: (uint64) 0
            	            	    }
            	            	   },
            	            	   Format: (string) ""
            	            	  }
            	            	 },
            	            	 (util.RemoteWriteRequest) {
            	            	  TenantID: (string) "",
            	            	  Request: (push.PushRequest) {
            	            	   Streams: ([]push.Stream) (len=1) {
            	            	    (push.Stream) {
            	            	     Labels: (string) (len=2) "{}",
            	            	     Entries: ([]push.Entry) (len=1) {
            	            	      (push.Entry) {
            	            	       Timestamp: (time.Time) {
            	            	        wall: (uint64) 0,
            	            	        ext: (int64) 62135596802,
            	            	        loc: (*time.Location)(<nil>)
            	            	       },
            	            	       Line: (string) (len=5) "line2",
            	            	       StructuredMetadata: (push.LabelsAdapter) <nil>,
            	            	       Parsed: (push.LabelsAdapter) <nil>
            	            	      }
            	            	     },
            	            	     Hash: (uint64) 0
            	            	    }
            	            	   },
            	            	   Format: (string) ""
            	            	  }
            	            	 }
            	            	}
            	            	
            	            	
            	            	listB:
            	            	([]util.RemoteWriteRequest) (len=1) {
            	            	 (util.RemoteWriteRequest) {
            	            	  TenantID: (string) "",
            	            	  Request: (push.PushRequest) {
            	            	   Streams: ([]push.Stream) (len=1) {
            	            	    (push.Stream) {
            	            	     Labels: (string) (len=2) "{}",
            	            	     Entries: ([]push.Entry) (len=2) {
            	            	      (push.Entry) {
            	            	       Timestamp: (time.Time) {
            	            	        wall: (uint64) 0,
            	            	        ext: (int64) 62135596801,
            	            	        loc: (*time.Location)(<nil>)
            	            	       },
            	            	       Line: (string) (len=5) "line1",
            	            	       StructuredMetadata: (push.LabelsAdapter) <nil>,
            	            	       Parsed: (push.LabelsAdapter) <nil>
            	            	      },
            	            	      (push.Entry) {
            	            	       Timestamp: (time.Time) {
            	            	        wall: (uint64) 0,
            	            	        ext: (int64) 62135596802,
            	            	        loc: (*time.Location)(<nil>)
            	            	       },
            	            	       Line: (string) (len=5) "line2",
            	            	       StructuredMetadata: (push.LabelsAdapter) <nil>,
            	            	       Parsed: (push.LabelsAdapter) <nil>
            	            	      }
            	            	     },
            	            	     Hash: (uint64) 0
            	            	    }
            	            	   },
            	            	   Format: (string) ""
            	            	  }
            	            	 }
            	            	}
            	Test:       	TestEndpoint/batch_log_entries_together_until_the_batch_wait_time_is_reached
FAIL
FAIL	github.com/grafana/alloy/internal/component/common/loki/client	11.383s
```
</details>