### PR TITLE
feat(prometheus.exporter.postgres): Update to version 0.19.1

### DIFF
--- a/collector/builder-config.yaml
+++ b/collector/builder-config.yaml
@@ -121,8 +121,8 @@ replaces:
   - github.com/thanos-io/objstore => github.com/grafana/objstore v0.0.0-20250210100727-533688b5600d
   # TODO - remove forks when changes are merged upstream — non-singleton cadvisor
   - github.com/google/cadvisor => github.com/grafana/cadvisor grafana-v0.54.1-noglobals
-  # TODO - this tracks exporter-package-v0.19.0 branch of grafana fork; remove once all patches are merged upstream
-  - github.com/prometheus-community/postgres_exporter => github.com/grafana/postgres_exporter v0.0.0-20260212092411-d256e52d0faf
+  # TODO - this tracks exporter-package-v0.19.1 branch of grafana fork; remove once all patches are merged upstream
+  - github.com/prometheus-community/postgres_exporter => github.com/grafana/postgres_exporter v0.0.0-20260225165717-9c2c77e3702a
   # TODO - remove once PR is merged upstream - https://github.com/prometheus/mysqld_exporter/pull/774
   - github.com/prometheus/mysqld_exporter => github.com/grafana/mysqld_exporter v0.17.2-0.20250226152553-be612e3fdedd
   # TODO: replace node_exporter with custom fork for multi usage. https://github.com/prometheus/node_exporter/pull/2812

--- a/collector/go.mod
+++ b/collector/go.mod
@@ -1095,7 +1095,7 @@ replace github.com/thanos-io/objstore => github.com/grafana/objstore v0.0.0-2025
 
 replace github.com/google/cadvisor => github.com/grafana/cadvisor v0.0.0-20260204200106-865a22723970
 
-replace github.com/prometheus-community/postgres_exporter => github.com/grafana/postgres_exporter v0.0.0-20260212092411-d256e52d0faf
+replace github.com/prometheus-community/postgres_exporter => github.com/grafana/postgres_exporter v0.0.0-20260225165717-9c2c77e3702a
 
 replace github.com/prometheus/mysqld_exporter => github.com/grafana/mysqld_exporter v0.17.2-0.20250226152553-be612e3fdedd
 

--- a/collector/go.sum
+++ b/collector/go.sum
@@ -1211,8 +1211,8 @@ github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260216144214-2413
 github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260216144214-241376220646/go.mod h1:tspi+K8p4WpFpjT61gNdQRgd2wuai7w/PPpUFPH8wNs=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=
 github.com/grafana/otel-profiling-go v0.5.1/go.mod h1:ftN/t5A/4gQI19/8MoWurBEtC6gFw8Dns1sJZ9W4Tls=
-github.com/grafana/postgres_exporter v0.0.0-20260212092411-d256e52d0faf h1:GaBnxd6zH0+QaZuMBWra2MdjKUWTI8edIQx1dXMLau8=
-github.com/grafana/postgres_exporter v0.0.0-20260212092411-d256e52d0faf/go.mod h1:4zH24t6LEqkdL3ZfBTtp0kGHOBr6komR55CrmL2AAg4=
+github.com/grafana/postgres_exporter v0.0.0-20260225165717-9c2c77e3702a h1:uT3vXB+E1dAMfvrgwQR6PwQbNmgLe6cyvTxHnHcmuns=
+github.com/grafana/postgres_exporter v0.0.0-20260225165717-9c2c77e3702a/go.mod h1:4zH24t6LEqkdL3ZfBTtp0kGHOBr6komR55CrmL2AAg4=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.8 h1:iwOtYXeeVSAeYefJNaxDytgjKtUuKQbJqgAIjlnicKg=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.8/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/grafana/pyroscope/api v1.2.0 h1:SfHDZcEZ4Vbj/Jj3bTOSpm4IDB33wLA2xBYxROhiL4U=

--- a/dependency-replacements.yaml
+++ b/dependency-replacements.yaml
@@ -73,9 +73,9 @@ replaces:
     dependency: github.com/google/cadvisor
     replacement: github.com/grafana/cadvisor grafana-v0.54.1-noglobals
 
-  - comment: TODO - this tracks exporter-package-v0.19.0 branch of grafana fork; remove once all patches are merged upstream
+  - comment: TODO - this tracks exporter-package-v0.19.1 branch of grafana fork; remove once all patches are merged upstream
     dependency: github.com/prometheus-community/postgres_exporter
-    replacement: github.com/grafana/postgres_exporter v0.0.0-20260212092411-d256e52d0faf
+    replacement: github.com/grafana/postgres_exporter v0.0.0-20260225165717-9c2c77e3702a
 
   - comment: TODO - remove once PR is merged upstream - https://github.com/prometheus/mysqld_exporter/pull/774
     dependency: github.com/prometheus/mysqld_exporter

--- a/extension/alloyengine/go.mod
+++ b/extension/alloyengine/go.mod
@@ -1066,8 +1066,8 @@ replace github.com/thanos-io/objstore => github.com/grafana/objstore v0.0.0-2025
 // TODO - remove forks when changes are merged upstream — non-singleton cadvisor
 replace github.com/google/cadvisor => github.com/grafana/cadvisor v0.0.0-20260204200106-865a22723970
 
-// TODO - this tracks exporter-package-v0.19.0 branch of grafana fork; remove once all patches are merged upstream
-replace github.com/prometheus-community/postgres_exporter => github.com/grafana/postgres_exporter v0.0.0-20260212092411-d256e52d0faf
+// TODO - this tracks exporter-package-v0.19.1 branch of grafana fork; remove once all patches are merged upstream
+replace github.com/prometheus-community/postgres_exporter => github.com/grafana/postgres_exporter v0.0.0-20260225165717-9c2c77e3702a
 
 // TODO - remove once PR is merged upstream - https://github.com/prometheus/mysqld_exporter/pull/774
 replace github.com/prometheus/mysqld_exporter => github.com/grafana/mysqld_exporter v0.17.2-0.20250226152553-be612e3fdedd

--- a/extension/alloyengine/go.sum
+++ b/extension/alloyengine/go.sum
@@ -1229,8 +1229,8 @@ github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260216144214-2413
 github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260216144214-241376220646/go.mod h1:tspi+K8p4WpFpjT61gNdQRgd2wuai7w/PPpUFPH8wNs=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=
 github.com/grafana/otel-profiling-go v0.5.1/go.mod h1:ftN/t5A/4gQI19/8MoWurBEtC6gFw8Dns1sJZ9W4Tls=
-github.com/grafana/postgres_exporter v0.0.0-20260212092411-d256e52d0faf h1:GaBnxd6zH0+QaZuMBWra2MdjKUWTI8edIQx1dXMLau8=
-github.com/grafana/postgres_exporter v0.0.0-20260212092411-d256e52d0faf/go.mod h1:4zH24t6LEqkdL3ZfBTtp0kGHOBr6komR55CrmL2AAg4=
+github.com/grafana/postgres_exporter v0.0.0-20260225165717-9c2c77e3702a h1:uT3vXB+E1dAMfvrgwQR6PwQbNmgLe6cyvTxHnHcmuns=
+github.com/grafana/postgres_exporter v0.0.0-20260225165717-9c2c77e3702a/go.mod h1:4zH24t6LEqkdL3ZfBTtp0kGHOBr6komR55CrmL2AAg4=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.8 h1:iwOtYXeeVSAeYefJNaxDytgjKtUuKQbJqgAIjlnicKg=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.8/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/grafana/pyroscope/api v1.2.0 h1:SfHDZcEZ4Vbj/Jj3bTOSpm4IDB33wLA2xBYxROhiL4U=

--- a/go.mod
+++ b/go.mod
@@ -1109,8 +1109,8 @@ replace github.com/thanos-io/objstore => github.com/grafana/objstore v0.0.0-2025
 // TODO - remove forks when changes are merged upstream — non-singleton cadvisor
 replace github.com/google/cadvisor => github.com/grafana/cadvisor v0.0.0-20260204200106-865a22723970
 
-// TODO - this tracks exporter-package-v0.19.0 branch of grafana fork; remove once all patches are merged upstream
-replace github.com/prometheus-community/postgres_exporter => github.com/grafana/postgres_exporter v0.0.0-20260212092411-d256e52d0faf
+// TODO - this tracks exporter-package-v0.19.1 branch of grafana fork; remove once all patches are merged upstream
+replace github.com/prometheus-community/postgres_exporter => github.com/grafana/postgres_exporter v0.0.0-20260225165717-9c2c77e3702a
 
 // TODO - remove once PR is merged upstream - https://github.com/prometheus/mysqld_exporter/pull/774
 replace github.com/prometheus/mysqld_exporter => github.com/grafana/mysqld_exporter v0.17.2-0.20250226152553-be612e3fdedd

--- a/go.sum
+++ b/go.sum
@@ -1239,8 +1239,8 @@ github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260216144214-2413
 github.com/grafana/opentelemetry-ebpf-profiler v0.0.202602-0.20260216144214-241376220646/go.mod h1:tspi+K8p4WpFpjT61gNdQRgd2wuai7w/PPpUFPH8wNs=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=
 github.com/grafana/otel-profiling-go v0.5.1/go.mod h1:ftN/t5A/4gQI19/8MoWurBEtC6gFw8Dns1sJZ9W4Tls=
-github.com/grafana/postgres_exporter v0.0.0-20260212092411-d256e52d0faf h1:GaBnxd6zH0+QaZuMBWra2MdjKUWTI8edIQx1dXMLau8=
-github.com/grafana/postgres_exporter v0.0.0-20260212092411-d256e52d0faf/go.mod h1:4zH24t6LEqkdL3ZfBTtp0kGHOBr6komR55CrmL2AAg4=
+github.com/grafana/postgres_exporter v0.0.0-20260225165717-9c2c77e3702a h1:uT3vXB+E1dAMfvrgwQR6PwQbNmgLe6cyvTxHnHcmuns=
+github.com/grafana/postgres_exporter v0.0.0-20260225165717-9c2c77e3702a/go.mod h1:4zH24t6LEqkdL3ZfBTtp0kGHOBr6komR55CrmL2AAg4=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.8 h1:iwOtYXeeVSAeYefJNaxDytgjKtUuKQbJqgAIjlnicKg=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.8/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/grafana/pyroscope/api v1.2.0 h1:SfHDZcEZ4Vbj/Jj3bTOSpm4IDB33wLA2xBYxROhiL4U=


### PR DESCRIPTION
### Brief description of Pull Request
Update to version 0.19.1 of postgres_exporter. 
See https://github.com/prometheus-community/postgres_exporter/releases/tag/v0.19.1

### Pull Request Details
Update to version 0.19.1 of postgres_exporter, which includes:
- Filter and warn about duplicates in pg_stat_statements
- perf/reliability: Optimize pg_stat_statements queries that uses too many temp files
- fix: ignore setting google_dataplex.max_messages
- wal: Fix collector NULL SUM(size)

### Issue(s) fixed by this Pull Request

<!--
  Uncomment the following line and fill in an issue number if you want a GitHub
  issue to be closed automatically when this PR gets merged.
-->

<!-- Fixes #issue_id -->

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
