### PR TITLE
fix(mongodb_exporter): Fix debug output flooding by adding log_level and fixing Enabled() level gating

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.exporter.mongodb.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.mongodb.md
@@ -54,6 +54,7 @@ You can use the following arguments with `prometheus.exporter.mongodb`:
 | `enable_replicaset_status`     | `bool`   | Enables collecting replica set status.                                                                                                 | `false` | no       |
 | `enable_shards`                | `bool`   | Enables collecting sharding information.                                                                                               | `false` | no       |
 | `enable_top_metrics`           | `bool`   | Enables collecting top metrics.                                                                                                        | `false` | no       |
+| `log_level`                    | `string` | Set logging level to `debug`, `info`, `warn`, or `error`.                                                                              | `info`  | no       |
 
 MongoDB node connection URI must be in the [`Standard Connection String Format`](https://docs.mongodb.com/manual/reference/connection-string/#std-label-connections-standard-connection-string-format)
 

--- a/internal/component/prometheus/exporter/mongodb/mongodb.go
+++ b/internal/component/prometheus/exporter/mongodb/mongodb.go
@@ -1,6 +1,8 @@
 package mongodb
 
 import (
+	"fmt"
+
 	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/component/prometheus/exporter"
 	"github.com/grafana/alloy/internal/featuregate"
@@ -29,6 +31,7 @@ func createExporter(opts component.Options, args component.Arguments) (integrati
 
 type Arguments struct {
 	URI                      alloytypes.Secret `alloy:"mongodb_uri,attr"`
+	LogLevel                 string            `alloy:"log_level,attr,optional"`
 	CompatibleMode           bool              `alloy:"compatible_mode,attr,optional"`
 	CollectAll               bool              `alloy:"collect_all,attr,optional"`
 	DirectConnect            bool              `alloy:"direct_connect,attr,optional"`
@@ -48,8 +51,18 @@ type Arguments struct {
 	EnablePBMMetrics         bool              `alloy:"enable_pbm_metrics,attr,optional"`
 }
 
+// Validate implements syntax.Validator.
+func (a *Arguments) Validate() error {
+	switch a.LogLevel {
+	case "debug", "info", "warn", "error":
+		return nil
+	default:
+		return fmt.Errorf("invalid log_level %q: must be one of debug, info, warn, error", a.LogLevel)
+	}
+}
+
 func (a *Arguments) Convert() *mongodb_exporter.Config {
-	return &mongodb_exporter.Config{
+	cfg := &mongodb_exporter.Config{
 		URI:                      config_util.Secret(a.URI),
 		CompatibleMode:           a.CompatibleMode,
 		CollectAll:               a.CollectAll,
@@ -69,10 +82,15 @@ func (a *Arguments) Convert() *mongodb_exporter.Config {
 		EnableFCV:                a.EnableFCV,
 		EnablePBMMetrics:         a.EnablePBMMetrics,
 	}
+	if a.LogLevel != "" {
+		_ = cfg.LogLevel.Set(a.LogLevel)
+	}
+	return cfg
 }
 
 // SetToDefault sets the default values for the Arguments.
 func (a *Arguments) SetToDefault() {
+	a.LogLevel = "info"
 	a.DirectConnect = false
 	a.CompatibleMode = true
 	a.CollectAll = true

--- a/internal/component/prometheus/exporter/mongodb/mongodb_test.go
+++ b/internal/component/prometheus/exporter/mongodb/mongodb_test.go
@@ -1,6 +1,7 @@
 package mongodb
 
 import (
+	"log/slog"
 	"testing"
 
 	"github.com/grafana/alloy/internal/static/integrations/mongodb_exporter"
@@ -21,6 +22,7 @@ func TestAlloyUnmarshal(t *testing.T) {
 
 	expected := Arguments{
 		URI:             "mongodb://127.0.0.1:27017",
+		LogLevel:        "info",
 		DirectConnect:   true,
 		DiscoveringMode: true,
 		CompatibleMode:  true,
@@ -49,5 +51,30 @@ func TestConvert(t *testing.T) {
 		CompatibleMode:  true,
 		CollectAll:      true,
 	}
+	_ = expected.LogLevel.Set("info")
 	require.Equal(t, expected, *res)
+}
+
+func TestConvertNonDefaultLogLevel(t *testing.T) {
+	alloyConfig := `
+	mongodb_uri = "mongodb://127.0.0.1:27017"
+	log_level   = "debug"
+	`
+	var args Arguments
+	err := syntax.Unmarshal([]byte(alloyConfig), &args)
+	require.NoError(t, err)
+	require.Equal(t, "debug", args.LogLevel)
+
+	res := args.Convert()
+	require.Equal(t, slog.LevelDebug, res.LogLevel.Level)
+}
+
+func TestValidateLogLevel(t *testing.T) {
+	for _, valid := range []string{"debug", "info", "warn", "error"} {
+		args := Arguments{URI: "mongodb://127.0.0.1:27017", LogLevel: valid}
+		require.NoError(t, args.Validate(), "expected %q to be valid", valid)
+	}
+
+	args := Arguments{URI: "mongodb://127.0.0.1:27017", LogLevel: "foobar"}
+	require.ErrorContains(t, args.Validate(), "invalid log_level")
 }

--- a/internal/converter/internal/staticconvert/internal/build/mongodb_exporter.go
+++ b/internal/converter/internal/staticconvert/internal/build/mongodb_exporter.go
@@ -1,6 +1,8 @@
 package build
 
 import (
+	"strings"
+
 	"github.com/grafana/alloy/internal/component/discovery"
 	"github.com/grafana/alloy/internal/component/prometheus/exporter/mongodb"
 	"github.com/grafana/alloy/internal/static/integrations/mongodb_exporter"
@@ -15,6 +17,7 @@ func (b *ConfigBuilder) appendMongodbExporter(config *mongodb_exporter.Config, i
 func toMongodbExporter(config *mongodb_exporter.Config) *mongodb.Arguments {
 	return &mongodb.Arguments{
 		URI:                      alloytypes.Secret(config.URI),
+		LogLevel:                 strings.ToLower(config.LogLevel.Level.String()),
 		CompatibleMode:           config.CompatibleMode,
 		CollectAll:               config.CollectAll,
 		DirectConnect:            config.DirectConnect,

--- a/internal/runtime/logging/slgk_handler.go
+++ b/internal/runtime/logging/slgk_handler.go
@@ -29,9 +29,9 @@ func (h SlogGoKitHandler) Enabled(ctx context.Context, level slog.Level) bool {
 	// Sometimes libraries will use this to check if certain logs should be emitted
 	// and then write logs using other methods such as fmt package.
 	// See https://github.com/percona/mongodb_exporter/blob/8290ba50eeb73d6380885d2546619afc878a6016/exporter/debug.go#L26-L42.
-	// We try to assert the concrete type so we can delegate the check.
-	// As a fallback we keep the old behavior.
-	l, ok := h.logger.(*Logger)
+	// We check for the EnabledAware interface so any logger wrapper that
+	// implements Enabled() can participate in level gating, not just *Logger.
+	l, ok := h.logger.(EnabledAware)
 	if !ok {
 		// return always true, we expect the underlying logger to handle the level
 		return true

--- a/internal/runtime/logging/slgk_handler_test.go
+++ b/internal/runtime/logging/slgk_handler_test.go
@@ -2,6 +2,7 @@ package logging_test
 
 import (
 	"bytes"
+	"context"
 	"log/slog"
 	"strings"
 	"testing"
@@ -48,4 +49,50 @@ func TestUpdateLevel(t *testing.T) {
 	require.Contains(t, buffer.String(), "ts=")
 	noTimestamp = strings.Join(strings.Split(buffer.String(), " ")[1:], " ")
 	require.Equal(t, "level=debug msg=hello test=test\n", noTimestamp)
+}
+
+// enabledAwareLogger is a test wrapper that implements both log.Logger and
+// logging.EnabledAware, simulating what mongodb_exporter's levelAwareLogger does.
+type enabledAwareLogger struct {
+	log.Logger
+	minLevel slog.Level
+}
+
+func (l *enabledAwareLogger) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= l.minLevel
+}
+
+func TestEnabledAwareLogger(t *testing.T) {
+	buffer := bytes.NewBuffer(nil)
+	baseLogger, err := logging.New(buffer, logging.Options{Level: logging.LevelDebug, Format: logging.FormatLogfmt})
+	require.NoError(t, err)
+
+	// Wrap with EnabledAware that only allows info and above.
+	wrapper := &enabledAwareLogger{
+		Logger:   baseLogger,
+		minLevel: slog.LevelInfo,
+	}
+
+	sLogger := slog.New(logging.NewSlogGoKitHandler(wrapper))
+
+	// Debug should be suppressed because EnabledAware reports false for debug.
+	require.False(t, sLogger.Enabled(context.Background(), slog.LevelDebug))
+
+	// Info should be allowed.
+	require.True(t, sLogger.Enabled(context.Background(), slog.LevelInfo))
+
+	// Warn and Error should be allowed.
+	require.True(t, sLogger.Enabled(context.Background(), slog.LevelWarn))
+	require.True(t, sLogger.Enabled(context.Background(), slog.LevelError))
+}
+
+func TestEnabledFallbackWithoutEnabledAware(t *testing.T) {
+	// A plain go-kit logger that does NOT implement EnabledAware should
+	// cause Enabled() to return true (the safe fallback).
+	plainLogger := log.NewNopLogger()
+	sLogger := slog.New(logging.NewSlogGoKitHandler(plainLogger))
+
+	// All levels should return true because the fallback is permissive.
+	require.True(t, sLogger.Enabled(context.Background(), slog.LevelDebug))
+	require.True(t, sLogger.Enabled(context.Background(), slog.LevelInfo))
 }

--- a/internal/static/integrations/mongodb_exporter/mongodb_exporter.go
+++ b/internal/static/integrations/mongodb_exporter/mongodb_exporter.go
@@ -1,6 +1,7 @@
 package mongodb_exporter
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -125,6 +126,21 @@ func init() {
 	integrations_v2.RegisterLegacy(&Config{}, integrations_v2.TypeMultiplex, metricsutils.NewNamedShim("mongodb"))
 }
 
+// levelAwareLogger wraps a go-kit log.Logger with an explicit slog.Level
+// so that it satisfies the logging.EnabledAware interface. This is needed
+// because go-kit's level.NewFilter returns an unexported type that does not
+// implement EnabledAware, yet SlogGoKitHandler.Enabled() needs it to gate
+// debug output (e.g. percona/mongodb_exporter's debugResult).
+type levelAwareLogger struct {
+	log.Logger
+	minLevel slog.Level
+}
+
+// Enabled implements logging.EnabledAware.
+func (l *levelAwareLogger) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= l.minLevel
+}
+
 // New creates a new mongodb_exporter integration.
 func New(logger log.Logger, c *Config) (integrations.Integration, error) {
 	var levelOption gokitlevel.Option
@@ -138,7 +154,10 @@ func New(logger log.Logger, c *Config) (integrations.Integration, error) {
 	default:
 		levelOption = gokitlevel.AllowInfo()
 	}
-	filteredLogger := level.NewFilter(logger, levelOption)
+	filteredLogger := &levelAwareLogger{
+		Logger:   level.NewFilter(logger, levelOption),
+		minLevel: c.LogLevel.Level,
+	}
 	slogLogger := slog.New(logging.NewSlogGoKitHandler(filteredLogger))
 
 	exp := exporter.New(&exporter.Opts{

--- a/internal/static/integrations/mongodb_exporter/mongodb_exporter.go
+++ b/internal/static/integrations/mongodb_exporter/mongodb_exporter.go
@@ -5,12 +5,15 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"strings"
 
 	"github.com/go-kit/log"
+	gokitlevel "github.com/go-kit/log/level"
 	"github.com/percona/mongodb_exporter/exporter"
 	config_util "github.com/prometheus/common/config"
 
 	"github.com/grafana/alloy/internal/runtime/logging"
+	"github.com/grafana/alloy/internal/runtime/logging/level"
 	"github.com/grafana/alloy/internal/static/integrations"
 	integrations_v2 "github.com/grafana/alloy/internal/static/integrations/v2"
 	"github.com/grafana/alloy/internal/static/integrations/v2/metricsutils"
@@ -36,10 +39,42 @@ var DefaultConfig = Config{
 	EnablePBMMetrics:         false,
 }
 
+// LogLevel holds the level for logging.
+type LogLevel struct {
+	slog.Level
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler.
+func (l *LogLevel) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var s string
+	if err := unmarshal(&s); err != nil {
+		return err
+	}
+	return l.Set(s)
+}
+
+// Set sets the level.
+func (l *LogLevel) Set(s string) error {
+	switch strings.ToLower(s) {
+	case "debug":
+		l.Level = slog.LevelDebug
+	case "info":
+		l.Level = slog.LevelInfo
+	case "warn":
+		l.Level = slog.LevelWarn
+	case "error":
+		l.Level = slog.LevelError
+	default:
+		return fmt.Errorf("unrecognized log level %q", s)
+	}
+	return nil
+}
+
 // Config controls mongodb_exporter
 type Config struct {
 	// MongoDB connection URI. example:mongodb://user:pass@127.0.0.1:27017/admin?ssl=true"
 	URI                      config_util.Secret `yaml:"mongodb_uri"`
+	LogLevel                 LogLevel           `yaml:"log_level,omitempty"`
 	CompatibleMode           bool               `yaml:"compatible_mode,omitempty"`
 	CollectAll               bool               `yaml:"collect_all,omitempty"`
 	DirectConnect            bool               `yaml:"direct_connect,omitempty"`
@@ -92,11 +127,23 @@ func init() {
 
 // New creates a new mongodb_exporter integration.
 func New(logger log.Logger, c *Config) (integrations.Integration, error) {
-	logrusLogger := slog.New(logging.NewSlogGoKitHandler(logger))
+	var levelOption gokitlevel.Option
+	switch c.LogLevel.Level {
+	case slog.LevelDebug:
+		levelOption = gokitlevel.AllowDebug()
+	case slog.LevelWarn:
+		levelOption = gokitlevel.AllowWarn()
+	case slog.LevelError:
+		levelOption = gokitlevel.AllowError()
+	default:
+		levelOption = gokitlevel.AllowInfo()
+	}
+	filteredLogger := level.NewFilter(logger, levelOption)
+	slogLogger := slog.New(logging.NewSlogGoKitHandler(filteredLogger))
 
 	exp := exporter.New(&exporter.Opts{
 		URI:                    string(c.URI),
-		Logger:                 logrusLogger,
+		Logger:                 slogLogger,
 		DisableDefaultRegistry: true,
 
 		CompatibleMode:           c.CompatibleMode,

--- a/internal/static/integrations/mongodb_exporter/mongodb_exporter.go
+++ b/internal/static/integrations/mongodb_exporter/mongodb_exporter.go
@@ -46,7 +46,7 @@ type LogLevel struct {
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
-func (l *LogLevel) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (l *LogLevel) UnmarshalYAML(unmarshal func(any) error) error {
 	var s string
 	if err := unmarshal(&s); err != nil {
 		return err

--- a/internal/static/integrations/mongodb_exporter/mongodb_test.go
+++ b/internal/static/integrations/mongodb_exporter/mongodb_test.go
@@ -1,7 +1,12 @@
 package mongodb_exporter
 
 import (
+	"context"
+	"log/slog"
 	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alloy/internal/static/config"
 )
@@ -16,4 +21,32 @@ integrations:
     mongodb_uri: secret_password_in_uri
 `
 	config.CheckSecret(t, stringCfg, "secret_password_in_uri")
+}
+
+func TestLevelAwareLogger_Enabled(t *testing.T) {
+	nop := log.NewNopLogger()
+
+	tests := []struct {
+		name     string
+		minLevel slog.Level
+		check    slog.Level
+		want     bool
+	}{
+		{"info blocks debug", slog.LevelInfo, slog.LevelDebug, false},
+		{"info allows info", slog.LevelInfo, slog.LevelInfo, true},
+		{"info allows warn", slog.LevelInfo, slog.LevelWarn, true},
+		{"info allows error", slog.LevelInfo, slog.LevelError, true},
+		{"debug allows debug", slog.LevelDebug, slog.LevelDebug, true},
+		{"error blocks warn", slog.LevelError, slog.LevelWarn, false},
+		{"error blocks info", slog.LevelError, slog.LevelInfo, false},
+		{"error allows error", slog.LevelError, slog.LevelError, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := &levelAwareLogger{Logger: nop, minLevel: tt.minLevel}
+			got := l.Enabled(context.Background(), tt.check)
+			require.Equal(t, tt.want, got)
+		})
+	}
 }


### PR DESCRIPTION
### Brief description of Pull Request

Fix excessive debug output from `prometheus.exporter.mongodb` that floods
stderr with raw MongoDB JSON on every scrape, regardless of configured log level.

The fix has two parts:
1. Add a `log_level` argument (`debug`, `info`, `warn`, `error`) to control exporter verbosity
2. Fix `SlogGoKitHandler.Enabled()` to use the `EnabledAware` interface instead of a concrete `*Logger` type assertion

### Pull Request Details

**Root cause:** The percona/mongodb_exporter `debugResult()` function
([debug.go:26-42](https://github.com/percona/mongodb_exporter/blob/8290ba50eeb73d6380885d2546619afc878a6016/exporter/debug.go#L26-L42))
calls `log.Enabled(ctx, slog.LevelDebug)` and if true, dumps raw MongoDB
JSON via `fmt.Fprintln(os.Stderr, ...)` — bypassing the structured logger entirely.

PR #4812 attempted to fix this by adding a `*Logger` type assertion in
`SlogGoKitHandler.Enabled()`. However, the assertion always fails when the
logger is wrapped by `level.NewFilter()`, which returns go-kit's unexported
`level.logger` type. As a result, `Enabled()` unconditionally returns `true`
and `debugResult()` always fires.

**Fix part 1 — log_level setting:**
- Add `LogLevel` field to `Arguments` with `SetToDefault("info")` and `Validate()`
- Wire go-kit `level.NewFilter` in the static integration `New()` so logs
  respect the configured level
- Map `log_level` in the static-to-Alloy converter
- Add unit tests and documentation

**Fix part 2 — EnabledAware interface:**
- Change `SlogGoKitHandler.Enabled()` from `h.logger.(*Logger)` to
  `h.logger.(EnabledAware)` — any logger wrapper implementing `Enabled()`
  can now participate in level gating, not just the concrete `*Logger` type
- Add `levelAwareLogger` wrapper in `mongodb_exporter` that implements
  `EnabledAware` to bridge go-kit's level-filtered logger with slog level gating
- Add tests for both the `EnabledAware` path and the fallback path

**Tested on production** — confirmed debug JSON output is completely suppressed
with the default `log_level: info`.

### Issue(s) fixed by this Pull Request

- https://github.com/percona/mongodb_exporter/issues/770
- Completes the fix from #4812 (concrete type assertion didn't work with wrapped loggers)

Replaces #5413 (moved from `main` to a dedicated feature branch).

### Notes to the Reviewer

The `SlogGoKitHandler.Enabled()` change in `slgk_handler.go` is a behavioral
fix that affects all `NewSlogGoKitHandler()` callers — but only mongodb_exporter
passes a `level.NewFilter()`-wrapped logger. All other 36 call sites pass either
`*Logger` directly or `log.With()`-wrapped loggers, so for them the behavior is
unchanged (they already implement `EnabledAware` via `*Logger`).

### PR Checklist

- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated