### PR TITLE
perf(discovery): Return full slice to pool after use

### DIFF
--- a/internal/component/discovery/target.go
+++ b/internal/component/discovery/target.go
@@ -292,7 +292,7 @@ func (t Target) SpecificLabelsHash(labelNames []string) uint64 {
 func (t Target) HashLabelsWithPredicate(pred func(key string) bool) uint64 {
 	// For hash to be deterministic, we need labels order to be deterministic too. Figure this out first.
 	labelsInOrder := borrowLabelsSlice()
-	defer releaseLabelsSlice(labelsInOrder)
+	defer func() { releaseLabelsSlice(labelsInOrder) }()
 	t.ForEachLabel(func(key string, value string) bool {
 		if pred(key) {
 			labelsInOrder = append(labelsInOrder, key)
@@ -306,7 +306,7 @@ func (t Target) HashLabelsWithPredicate(pred func(key string) bool) uint64 {
 func (t Target) groupLabelsHash() uint64 {
 	// For hash to be deterministic, we need labels order to be deterministic too. Figure this out first.
 	labelsInOrder := borrowLabelsSlice()
-	defer releaseLabelsSlice(labelsInOrder)
+	defer func() { releaseLabelsSlice(labelsInOrder) }()
 
 	for name := range t.group {
 		labelsInOrder = append(labelsInOrder, string(name))

--- a/internal/component/discovery/target.go
+++ b/internal/component/discovery/target.go
@@ -26,7 +26,7 @@ type Target struct {
 var (
 	seps = []byte{'\xff'}
 	// used in tests to simulate hash conflicts
-	labelSetEqualsFn  = func(l1, l2 commonlabels.LabelSet) bool { return &l1 == &l2 || l1.Equal(l2) }
+	labelSetEqualsFn = func(l1, l2 commonlabels.LabelSet) bool { return &l1 == &l2 || l1.Equal(l2) }
 	stringSlicesPool = sync.Pool{New: func() any { return make([]string, 0, 20) }}
 
 	_ syntax.Capsule                = Target{}

--- a/internal/component/discovery/target.go
+++ b/internal/component/discovery/target.go
@@ -27,20 +27,22 @@ var (
 	seps = []byte{'\xff'}
 	// used in tests to simulate hash conflicts
 	labelSetEqualsFn  = func(l1, l2 commonlabels.LabelSet) bool { return &l1 == &l2 || l1.Equal(l2) }
-	stringSlicesPool  = sync.Pool{New: func() any { return make([]string, 0, 20) }}
-	borrowLabelsSlice = func() []string {
-		return stringSlicesPool.Get().([]string)
-	}
-	releaseLabelsSlice = func(labels []string) {
-		// We can ignore linter warning here, because slice headers are small and the underlying array will be reused.
-		stringSlicesPool.Put(labels[:0]) //nolint:staticcheck // SA6002
-	}
+	stringSlicesPool = sync.Pool{New: func() any { return make([]string, 0, 20) }}
 
 	_ syntax.Capsule                = Target{}
 	_ syntax.ConvertibleIntoCapsule = Target{}
 	_ syntax.ConvertibleFromCapsule = &Target{}
 	_ equality.CustomEquality       = Target{}
 )
+
+func borrowLabelsSlice() []string {
+	return stringSlicesPool.Get().([]string)
+}
+
+func releaseLabelsSlice(labels []string) {
+	// We can ignore linter warning here, because slice headers are small and the underlying array will be reused.
+	stringSlicesPool.Put(labels[:0]) //nolint:staticcheck // SA6002
+}
 
 var EmptyTarget = Target{
 	group: commonlabels.LabelSet{},

--- a/internal/component/discovery/target_test.go
+++ b/internal/component/discovery/target_test.go
@@ -794,45 +794,6 @@ func TestHashing(t *testing.T) {
 	}
 }
 
-func TestHashLabelsWithPredicateClearsStringSlicePool(t *testing.T) {
-	var (
-		target = NewTargetFromMap(map[string]string{
-			"job": "hash-test",
-			"env": "prod",
-		})
-		recordedLens    []int
-		scratch         []string
-		originalBorrow  = borrowLabelsSlice
-		originalRelease = releaseLabelsSlice
-	)
-
-	t.Cleanup(func() {
-		borrowLabelsSlice = originalBorrow
-		releaseLabelsSlice = originalRelease
-	})
-
-	borrowLabelsSlice = func() []string {
-		if scratch == nil {
-			scratch = make([]string, 0, 8)
-		}
-		return scratch
-	}
-	releaseLabelsSlice = func(labels []string) {
-		recordedLens = append(recordedLens, len(labels))
-		scratch = labels
-	}
-
-	target.HashLabelsWithPredicate(func(string) bool {
-		return true
-	})
-	target.HashLabelsWithPredicate(func(string) bool {
-		return false
-	})
-
-	require.GreaterOrEqual(t, len(recordedLens), 2)
-	require.Equal(t, 0, recordedLens[len(recordedLens)-1], "pool slice must be cleared before returning")
-}
-
 func TestHashLargeLabelSets(t *testing.T) {
 	sharedLabels := 50
 	ownLabels := 100


### PR DESCRIPTION
### Brief description of Pull Request

Without a closure, `defer`` captures the value as seen when that line was executed, whereas the value we want to put into the pool is the full-sized slice after appending to it. The closure achieves that effect.

Found using https://github.com/egonelbre/exp/tree/main/check-deferslice.

### PR Checklist

