### PR TITLE
chore: Trigger release artifact when tag is created

### DIFF
--- a/.github/workflows/release-publish-alloy-artifacts.yml
+++ b/.github/workflows/release-publish-alloy-artifacts.yml
@@ -1,16 +1,16 @@
 name: Publish Alloy release artifacts
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
     inputs:
       tag:
         description: 'Release tag to publish artifacts for (e.g., v1.14.0-rc.0)'
         required: true
         type: string
-
 env:
-  RELEASE_TAG: ${{ inputs.tag || github.event.release.tag_name }}
+  RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
 
 permissions:
   contents: read
@@ -285,4 +285,4 @@ jobs:
       contents: read
       id-token: write
     with:
-      release-tag: ${{ env.RELEASE_TAG }}
+      release-tag: ${{ inputs.tag || github.event.release.tag_name }}


### PR DESCRIPTION
### Brief description of Pull Request

Switch publish artifacts to run when the tag for the release is created, which triggers at the same time as the draft release is created. `created` is not triggered on draft release,

<img width="651" height="79" alt="image" src="https://github.com/user-attachments/assets/4116ff25-ec0c-41cf-acee-5f97ac6355a5" />

https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#release

I also added a way to manually trigger it so I could get the artifacts for the current release.