### PR TITLE
chore: Add test for alloy runtime to check that we start and stop components

### DIFF
--- a/internal/runtime/alloy.go
+++ b/internal/runtime/alloy.go
@@ -289,7 +289,6 @@ func (f *Runtime) Run(ctx context.Context) {
 				components = f.loader.Components()
 				services   = f.loader.Services()
 				imports    = f.loader.Imports()
-				forEachs   = f.loader.ForEachs()
 
 				runnables = make([]controller.RunnableNode, 0, len(components)+len(services)+len(imports))
 			)
@@ -299,10 +298,6 @@ func (f *Runtime) Run(ctx context.Context) {
 
 			for _, i := range imports {
 				runnables = append(runnables, i)
-			}
-
-			for _, fe := range forEachs {
-				runnables = append(runnables, fe)
 			}
 
 			// Only the root controller should run services, since modules share the


### PR DESCRIPTION
Add test that verifies different component statues for alloy runtime, this is to increase confidence with upcoming scheduling changes https://github.com/grafana/alloy/pull/5613#issuecomment-3964960504