### PR TITLE
fix: Enhance zap adapter to leverage configured log level to avoid allocations

### DIFF
--- a/internal/component/otelcol/auth/auth.go
+++ b/internal/component/otelcol/auth/auth.go
@@ -227,7 +227,7 @@ func (a *Auth) Update(args component.Arguments) error {
 	settings := otelextension.Settings{
 		ID: otelcomponent.NewIDWithName(a.factory.Type(), a.opts.ID),
 		TelemetrySettings: otelcomponent.TelemetrySettings{
-			Logger:         zapadapter.New(a.opts.Logger),
+			Logger:         zapadapter.NewWithLevel(a.opts.Logger, a.opts.Leveler),
 			TracerProvider: a.opts.Tracer,
 			MeterProvider:  mp,
 		},

--- a/internal/component/otelcol/auth/auth.go
+++ b/internal/component/otelcol/auth/auth.go
@@ -227,7 +227,7 @@ func (a *Auth) Update(args component.Arguments) error {
 	settings := otelextension.Settings{
 		ID: otelcomponent.NewIDWithName(a.factory.Type(), a.opts.ID),
 		TelemetrySettings: otelcomponent.TelemetrySettings{
-			Logger:         zapadapter.NewWithLevel(a.opts.Logger, a.opts.Leveler),
+			Logger:         zapadapter.New(a.opts.Logger, a.opts.Leveler),
 			TracerProvider: a.opts.Tracer,
 			MeterProvider:  mp,
 		},

--- a/internal/component/otelcol/connector/connector.go
+++ b/internal/component/otelcol/connector/connector.go
@@ -166,7 +166,7 @@ func (p *Connector) Update(args component.Arguments) error {
 	settings := otelconnector.Settings{
 		ID: otelcomponent.NewIDWithName(p.factory.Type(), p.opts.ID),
 		TelemetrySettings: otelcomponent.TelemetrySettings{
-			Logger:         zapadapter.New(p.opts.Logger),
+			Logger:         zapadapter.NewWithLevel(p.opts.Logger, p.opts.Leveler),
 			TracerProvider: p.opts.Tracer,
 			MeterProvider:  mp,
 		},

--- a/internal/component/otelcol/connector/connector.go
+++ b/internal/component/otelcol/connector/connector.go
@@ -166,7 +166,7 @@ func (p *Connector) Update(args component.Arguments) error {
 	settings := otelconnector.Settings{
 		ID: otelcomponent.NewIDWithName(p.factory.Type(), p.opts.ID),
 		TelemetrySettings: otelcomponent.TelemetrySettings{
-			Logger:         zapadapter.NewWithLevel(p.opts.Logger, p.opts.Leveler),
+			Logger:         zapadapter.New(p.opts.Logger, p.opts.Leveler),
 			TracerProvider: p.opts.Tracer,
 			MeterProvider:  mp,
 		},

--- a/internal/component/otelcol/exporter/exporter.go
+++ b/internal/component/otelcol/exporter/exporter.go
@@ -183,7 +183,7 @@ func (e *Exporter) Update(args component.Arguments) error {
 	settings := otelexporter.Settings{
 		ID: otelcomponent.NewIDWithName(e.factory.Type(), e.opts.ID),
 		TelemetrySettings: otelcomponent.TelemetrySettings{
-			Logger:         zapadapter.New(e.opts.Logger),
+			Logger:         zapadapter.NewWithLevel(e.opts.Logger, e.opts.Leveler),
 			TracerProvider: e.opts.Tracer,
 			MeterProvider:  mp,
 		},

--- a/internal/component/otelcol/exporter/exporter.go
+++ b/internal/component/otelcol/exporter/exporter.go
@@ -183,7 +183,7 @@ func (e *Exporter) Update(args component.Arguments) error {
 	settings := otelexporter.Settings{
 		ID: otelcomponent.NewIDWithName(e.factory.Type(), e.opts.ID),
 		TelemetrySettings: otelcomponent.TelemetrySettings{
-			Logger:         zapadapter.NewWithLevel(e.opts.Logger, e.opts.Leveler),
+			Logger:         zapadapter.New(e.opts.Logger, e.opts.Leveler),
 			TracerProvider: e.opts.Tracer,
 			MeterProvider:  mp,
 		},

--- a/internal/component/otelcol/extension/extension.go
+++ b/internal/component/otelcol/extension/extension.go
@@ -142,7 +142,7 @@ func (e *Extension) Update(args component.Arguments) error {
 	settings := otelextension.Settings{
 		ID: otelcomponent.NewIDWithName(e.factory.Type(), e.opts.ID),
 		TelemetrySettings: otelcomponent.TelemetrySettings{
-			Logger:         zapadapter.New(e.opts.Logger),
+			Logger:         zapadapter.NewWithLevel(e.opts.Logger, e.opts.Leveler),
 			TracerProvider: e.opts.Tracer,
 			MeterProvider:  mp,
 		},

--- a/internal/component/otelcol/extension/extension.go
+++ b/internal/component/otelcol/extension/extension.go
@@ -142,7 +142,7 @@ func (e *Extension) Update(args component.Arguments) error {
 	settings := otelextension.Settings{
 		ID: otelcomponent.NewIDWithName(e.factory.Type(), e.opts.ID),
 		TelemetrySettings: otelcomponent.TelemetrySettings{
-			Logger:         zapadapter.NewWithLevel(e.opts.Logger, e.opts.Leveler),
+			Logger:         zapadapter.New(e.opts.Logger, e.opts.Leveler),
 			TracerProvider: e.opts.Tracer,
 			MeterProvider:  mp,
 		},

--- a/internal/component/otelcol/processor/processor.go
+++ b/internal/component/otelcol/processor/processor.go
@@ -160,7 +160,7 @@ func (p *Processor) Update(args component.Arguments) error {
 	settings := otelprocessor.Settings{
 		ID: otelcomponent.NewIDWithName(p.factory.Type(), p.opts.ID),
 		TelemetrySettings: otelcomponent.TelemetrySettings{
-			Logger:         zapadapter.New(p.opts.Logger),
+			Logger:         zapadapter.NewWithLevel(p.opts.Logger, p.opts.Leveler),
 			TracerProvider: p.opts.Tracer,
 			MeterProvider:  mp,
 		},

--- a/internal/component/otelcol/processor/processor.go
+++ b/internal/component/otelcol/processor/processor.go
@@ -160,7 +160,7 @@ func (p *Processor) Update(args component.Arguments) error {
 	settings := otelprocessor.Settings{
 		ID: otelcomponent.NewIDWithName(p.factory.Type(), p.opts.ID),
 		TelemetrySettings: otelcomponent.TelemetrySettings{
-			Logger:         zapadapter.NewWithLevel(p.opts.Logger, p.opts.Leveler),
+			Logger:         zapadapter.New(p.opts.Logger, p.opts.Leveler),
 			TracerProvider: p.opts.Tracer,
 			MeterProvider:  mp,
 		},

--- a/internal/component/otelcol/receiver/prometheus/prometheus.go
+++ b/internal/component/otelcol/receiver/prometheus/prometheus.go
@@ -133,7 +133,7 @@ func (c *Component) Update(newConfig component.Arguments) error {
 	settings := otelreceiver.Settings{
 		ID: otelcomponent.NewIDWithName(otelcomponent.MustNewType("prometheus"), c.opts.ID),
 		TelemetrySettings: otelcomponent.TelemetrySettings{
-			Logger: zapadapter.New(c.opts.Logger),
+			Logger: zapadapter.NewWithLevel(c.opts.Logger, c.opts.Leveler),
 			// TODO(tpaschalis): expose tracing and logging statistics.
 			TracerProvider: traceNoop.NewTracerProvider(),
 			MeterProvider:  mp,

--- a/internal/component/otelcol/receiver/prometheus/prometheus.go
+++ b/internal/component/otelcol/receiver/prometheus/prometheus.go
@@ -133,7 +133,7 @@ func (c *Component) Update(newConfig component.Arguments) error {
 	settings := otelreceiver.Settings{
 		ID: otelcomponent.NewIDWithName(otelcomponent.MustNewType("prometheus"), c.opts.ID),
 		TelemetrySettings: otelcomponent.TelemetrySettings{
-			Logger: zapadapter.NewWithLevel(c.opts.Logger, c.opts.Leveler),
+			Logger: zapadapter.New(c.opts.Logger, c.opts.Leveler),
 			// TODO(tpaschalis): expose tracing and logging statistics.
 			TracerProvider: traceNoop.NewTracerProvider(),
 			MeterProvider:  mp,

--- a/internal/component/otelcol/receiver/receiver.go
+++ b/internal/component/otelcol/receiver/receiver.go
@@ -149,7 +149,7 @@ func (r *Receiver) Update(args component.Arguments) error {
 	settings := otelreceiver.Settings{
 		ID: otelcomponent.NewIDWithName(r.factory.Type(), r.opts.ID),
 		TelemetrySettings: otelcomponent.TelemetrySettings{
-			Logger:         zapadapter.New(r.opts.Logger),
+			Logger:         zapadapter.NewWithLevel(r.opts.Logger, r.opts.Leveler),
 			TracerProvider: r.opts.Tracer,
 			MeterProvider:  mp,
 		},

--- a/internal/component/otelcol/receiver/receiver.go
+++ b/internal/component/otelcol/receiver/receiver.go
@@ -149,7 +149,7 @@ func (r *Receiver) Update(args component.Arguments) error {
 	settings := otelreceiver.Settings{
 		ID: otelcomponent.NewIDWithName(r.factory.Type(), r.opts.ID),
 		TelemetrySettings: otelcomponent.TelemetrySettings{
-			Logger:         zapadapter.NewWithLevel(r.opts.Logger, r.opts.Leveler),
+			Logger:         zapadapter.New(r.opts.Logger, r.opts.Leveler),
 			TracerProvider: r.opts.Tracer,
 			MeterProvider:  mp,
 		},

--- a/internal/component/registry.go
+++ b/internal/component/registry.go
@@ -3,6 +3,7 @@ package component
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"reflect"
 	"strings"
 
@@ -71,6 +72,13 @@ type Options struct {
 	// Logger the component may use for logging. Logs emitted with the logger
 	// always include the component ID as a field.
 	Logger log.Logger
+
+	// Leveler reports the active minimum log level. When non-nil, logging
+	// adapters (such as the zap adapter) can consult it to short-circuit
+	// disabled log levels before encoding fields, avoiding unnecessary
+	// allocations. The value is read dynamically, so hot-reloaded level
+	// changes are reflected immediately.
+	Leveler slog.Leveler
 
 	// A path to a directory with this component may use for storage. The path is
 	// guaranteed to be unique across all running components.

--- a/internal/runtime/internal/controller/node_builtin_component.go
+++ b/internal/runtime/internal/controller/node_builtin_component.go
@@ -183,8 +183,9 @@ func getManagedOptions(globals ComponentGlobals, cn *BuiltinComponentNode) compo
 	cn.registry = prometheus.NewRegistry()
 	parent, id := splitPath(cn.globalID)
 	return component.Options{
-		ID:     cn.globalID,
-		Logger: log.With(globals.Logger, "component_path", parent, "component_id", id),
+		ID:      cn.globalID,
+		Logger:  log.With(globals.Logger, "component_path", parent, "component_id", id),
+		Leveler: globals.Logger,
 		Registerer: prometheus.WrapRegistererWith(prometheus.Labels{
 			"component_path": parent,
 			"component_id":   id,

--- a/internal/runtime/logging/logger.go
+++ b/internal/runtime/logging/logger.go
@@ -42,6 +42,12 @@ func (l *Logger) Enabled(ctx context.Context, level slog.Level) bool {
 	return l.handler.Enabled(ctx, level)
 }
 
+// Level implements slog.Leveler, returning the currently configured minimum log level.
+// The returned value is live: it reflects any subsequent calls to Update.
+func (l *Logger) Level() slog.Level {
+	return l.level.Level()
+}
+
 // New creates a New logger with the default log level and format.
 func New(w io.Writer, o Options) (*Logger, error) {
 	l, err := NewDeferred(w)

--- a/internal/static/integrations/azure_exporter/config.go
+++ b/internal/static/integrations/azure_exporter/config.go
@@ -112,7 +112,7 @@ func (c *Config) NewIntegration(l log.Logger) (integrations.Integration, error) 
 
 	return Exporter{
 		cfg:               *c,
-		logger:            zapadapter.New(l).Sugar(),
+		logger:            zapadapter.New(l, nil).Sugar(),
 		ConcurrencyConfig: concurrencyConfig,
 	}, nil
 }

--- a/internal/util/zapadapter/zapadapter.go
+++ b/internal/util/zapadapter/zapadapter.go
@@ -16,23 +16,13 @@ import (
 )
 
 // New returns a new zap.Logger instance which will forward logs to the
-// provided log.Logger. The github.com/go-kit/log/level package will be used
-// for specifying log levels.
-//
-// Because log.Logger has no way to report its minimum level, all levels are
-// reported as enabled. Use NewWithLevel to avoid unnecessary work when a level
-// is disabled.
-func New(l log.Logger) *zap.Logger {
-	return zap.New(&loggerCore{inner: l})
-}
-
-// NewWithLevel returns a new zap.Logger instance which will forward logs to
-// the provided log.Logger. leveler is consulted on every log call so that
+// provided log.Logger. leveler is consulted on every log call so that
 // zap's early-exit optimisation fires correctly when a level is disabled,
 // preventing unnecessary field encoding and allocation. Because leveler is
 // read on every call (not snapshotted), dynamic level changes — such as
-// Alloy's hot-reload — are reflected immediately.
-func NewWithLevel(l log.Logger, leveler slog.Leveler) *zap.Logger {
+// Alloy's hot-reload — are reflected immediately. leveler may be nil, in
+// which case all levels are reported as enabled.
+func New(l log.Logger, leveler slog.Leveler) *zap.Logger {
 	return zap.New(&loggerCore{inner: l, leveler: leveler})
 }
 
@@ -166,34 +156,32 @@ func (fe *fieldEncoder) Close() error {
 }
 
 func (fe *fieldEncoder) AddArray(key string, marshaler zapcore.ArrayMarshaler) error {
-	fe.fields = append(fe.fields, fe.keyName(key), lazyStringer{f: func() string {
-		enc := newArrayFieldEncoder()
-		err := marshaler.MarshalLogArray(enc)
-		if err != nil {
-			return err.Error()
-		}
-		b, err := enc.jsonMarshal()
-		if err != nil {
-			return err.Error()
-		}
-		return string(b)
-	}})
+	enc := newArrayFieldEncoder()
+	if err := marshaler.MarshalLogArray(enc); err != nil {
+		fe.fields = append(fe.fields, fe.keyName(key), err.Error())
+		return nil
+	}
+	b, err := enc.jsonMarshal()
+	if err != nil {
+		fe.fields = append(fe.fields, fe.keyName(key), err.Error())
+		return nil
+	}
+	fe.fields = append(fe.fields, fe.keyName(key), string(b))
 	return nil
 }
 
 func (fe *fieldEncoder) AddObject(key string, marshaler zapcore.ObjectMarshaler) error {
-	fe.fields = append(fe.fields, fe.keyName(key), lazyStringer{f: func() string {
-		enc := newObjectFieldEncoder()
-		err := marshaler.MarshalLogObject(enc)
-		if err != nil {
-			return err.Error()
-		}
-		b, err := enc.jsonMarshal()
-		if err != nil {
-			return err.Error()
-		}
-		return string(b)
-	}})
+	enc := newObjectFieldEncoder()
+	if err := marshaler.MarshalLogObject(enc); err != nil {
+		fe.fields = append(fe.fields, fe.keyName(key), err.Error())
+		return nil
+	}
+	b, err := enc.jsonMarshal()
+	if err != nil {
+		fe.fields = append(fe.fields, fe.keyName(key), err.Error())
+		return nil
+	}
+	fe.fields = append(fe.fields, fe.keyName(key), string(b))
 	return nil
 }
 
@@ -527,10 +515,3 @@ func (fe *arrayFieldEncoder) AppendReflected(value any) error {
 	return nil
 }
 
-type lazyStringer struct {
-	f func() string
-}
-
-func (l lazyStringer) String() string {
-	return l.f()
-}

--- a/internal/util/zapadapter/zapadapter_test.go
+++ b/internal/util/zapadapter/zapadapter_test.go
@@ -114,7 +114,7 @@ func Test(t *testing.T) {
 
 			inner := log.NewLogfmtLogger(log.NewSyncWriter(&buf))
 
-			zapLogger := zapadapter.New(inner)
+			zapLogger := zapadapter.New(inner, nil)
 			zapLogger.Info("Hello, world!", tc.field...)
 
 			require.Equal(t, tc.expect, strings.TrimSpace(buf.String()))
@@ -122,39 +122,6 @@ func Test(t *testing.T) {
 	}
 }
 
-/*
-	As of 2025-06-04:
-
-goos: darwin
-goarch: arm64
-pkg: github.com/grafana/alloy/internal/util/zapadapter
-cpu: Apple M2
-Benchmark
-Benchmark/No_fields_enabled-8         	 1352374	       864.7 ns/op
-Benchmark/No_fields_disabled-8        	 6223372	       193.1 ns/op
-Benchmark/Any_enabled-8               	 1000000	      1332 ns/op
-Benchmark/Any_disabled-8              	 4654744	       240.5 ns/op
-Benchmark/Bool_enabled-8              	 1000000	      1015 ns/op
-Benchmark/Bool_disabled-8             	 5353936	       253.2 ns/op
-Benchmark/Duration_enabled-8          	 1000000	      1062 ns/op
-Benchmark/Duration_disabled-8         	 5175646	       238.0 ns/op
-Benchmark/Error_enabled-8             	 1000000	      1105 ns/op
-Benchmark/Error_disabled-8            	 4905226	       267.0 ns/op
-Benchmark/Float32_enabled-8           	 1000000	      1203 ns/op
-Benchmark/Float32_disabled-8          	 4813323	       233.6 ns/op
-Benchmark/Float64_enabled-8           	 1000000	      1037 ns/op
-Benchmark/Float64_disabled-8          	 5130016	       232.8 ns/op
-Benchmark/Int_enabled-8               	 1000000	      1065 ns/op
-Benchmark/Int_disabled-8              	 5154585	       241.0 ns/op
-Benchmark/String_enabled-8            	 1000000	      1025 ns/op
-Benchmark/String_disabled-8           	 5105998	       233.3 ns/op
-Benchmark/Time_enabled-8              	 1000000	      1143 ns/op
-Benchmark/Time_disabled-8             	 4857289	       248.3 ns/op
-Benchmark/Array_enabled-8             	  327018	      3529 ns/op
-Benchmark/Array_disabled-8            	 4889307	       252.8 ns/op
-Benchmark/Object_enabled-8            	  285597	      4187 ns/op
-Benchmark/Object_disabled-8           	 4864752	       245.3 ns/op
-*/
 func Benchmark(b *testing.B) {
 	// Benchmark various fields that may be commonly printed.
 
@@ -195,7 +162,7 @@ func runBenchmark(b *testing.B, name string, fields ...zap.Field) {
 	err = innerLogger.Update(logging.Options{Level: logging.LevelInfo, Format: logging.FormatLogfmt})
 	require.NoError(b, err)
 
-	zapLogger := zapadapter.New(innerLogger)
+	zapLogger := zapadapter.New(innerLogger, innerLogger)
 
 	b.Run(name+" enabled", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
@@ -209,13 +176,13 @@ func runBenchmark(b *testing.B, name string, fields ...zap.Field) {
 	})
 }
 
-func TestNewWithLevel(t *testing.T) {
+func TestNew(t *testing.T) {
 	t.Run("suppresses debug logs when level is info", func(t *testing.T) {
 		var buf bytes.Buffer
 		inner, err := logging.New(&buf, logging.Options{Level: logging.LevelInfo, Format: logging.FormatLogfmt})
 		require.NoError(t, err)
 
-		zapLogger := zapadapter.NewWithLevel(inner, inner)
+		zapLogger := zapadapter.New(inner, inner)
 		zapLogger.Debug("should not appear")
 
 		require.Empty(t, strings.TrimSpace(buf.String()))
@@ -226,7 +193,7 @@ func TestNewWithLevel(t *testing.T) {
 		inner, err := logging.New(&buf, logging.Options{Level: logging.LevelDebug, Format: logging.FormatLogfmt})
 		require.NoError(t, err)
 
-		zapLogger := zapadapter.NewWithLevel(inner, inner)
+		zapLogger := zapadapter.New(inner, inner)
 		zapLogger.Debug("should appear")
 
 		require.Contains(t, buf.String(), "should appear")
@@ -237,7 +204,7 @@ func TestNewWithLevel(t *testing.T) {
 		inner, err := logging.New(&buf, logging.Options{Level: logging.LevelInfo, Format: logging.FormatLogfmt})
 		require.NoError(t, err)
 
-		child := zapadapter.NewWithLevel(inner, inner).With(zap.String("key", "val"))
+		child := zapadapter.New(inner, inner).With(zap.String("key", "val"))
 		child.Debug("should not appear")
 
 		require.Empty(t, strings.TrimSpace(buf.String()))
@@ -248,7 +215,7 @@ func TestNewWithLevel(t *testing.T) {
 		inner, err := logging.New(&buf, logging.Options{Level: logging.LevelInfo, Format: logging.FormatLogfmt})
 		require.NoError(t, err)
 
-		zapLogger := zapadapter.NewWithLevel(inner, inner)
+		zapLogger := zapadapter.New(inner, inner)
 
 		zapLogger.Debug("should not appear before reload")
 		require.Empty(t, strings.TrimSpace(buf.String()))
@@ -267,7 +234,7 @@ func TestNewWithLevel(t *testing.T) {
 		inner, err := logging.New(&buf, logging.Options{Level: logging.LevelDebug, Format: logging.FormatLogfmt})
 		require.NoError(t, err)
 
-		zapLogger := zapadapter.NewWithLevel(inner, inner)
+		zapLogger := zapadapter.New(inner, inner)
 
 		zapLogger.Debug("should appear before reload")
 		require.Contains(t, buf.String(), "should appear before reload")
@@ -286,7 +253,7 @@ func TestNewWithLevel(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create the child logger before the reload.
-		child := zapadapter.NewWithLevel(inner, inner).With(zap.String("key", "val"))
+		child := zapadapter.New(inner, inner).With(zap.String("key", "val"))
 
 		child.Debug("should appear before reload")
 		require.Contains(t, buf.String(), "should appear before reload")
@@ -300,17 +267,17 @@ func TestNewWithLevel(t *testing.T) {
 	})
 }
 
-// TestNewWithLevelAllocations verifies that disabled log levels produce minimal
-// allocations with NewWithLevel, confirming zap's early-exit optimisation fires.
+// TestNewAllocations verifies that disabled log levels produce minimal
+// allocations with New, confirming zap's early-exit optimisation fires.
 //
 // When a level is disabled, the only unavoidable allocation is the []Field
 // slice that the Go runtime constructs for the variadic ...Field parameter
 // before calling Debug/Info/etc.
-func TestNewWithLevelAllocations(t *testing.T) {
+func TestNewAllocations(t *testing.T) {
 	makeLogger := func(level logging.Level) (*logging.Logger, *zap.Logger) {
 		inner, err := logging.New(io.Discard, logging.Options{Level: level, Format: logging.FormatLogfmt})
 		require.NoError(t, err)
-		return inner, zapadapter.NewWithLevel(inner, inner)
+		return inner, zapadapter.New(inner, inner)
 	}
 
 	t.Run("zero allocs with no fields when debug is disabled", func(t *testing.T) {
@@ -333,24 +300,12 @@ func TestNewWithLevelAllocations(t *testing.T) {
 
 	t.Run("at most one alloc with zap.Any when debug is disabled", func(t *testing.T) {
 		// zap.Any with a struct would normally trigger json.Marshal via the
-		// fieldEncoder. With NewWithLevel that path is never reached.
+		// fieldEncoder. With New that path is never reached.
 		_, lg := makeLogger(logging.LevelInfo)
 		allocs := testing.AllocsPerRun(100, func() {
 			lg.Debug("msg", zap.Any("obj", struct{ X, Y int }{1, 2}))
 		})
 		require.LessOrEqual(t, allocs, float64(1))
-	})
-
-	t.Run("more than one alloc when debug is disabled without leveler", func(t *testing.T) {
-		// Regression baseline: New always reports Enabled()=true, so Write() runs
-		// and the full encoding pipeline executes even for suppressed levels.
-		inner, err := logging.New(io.Discard, logging.Options{Level: logging.LevelInfo, Format: logging.FormatLogfmt})
-		require.NoError(t, err)
-		lg := zapadapter.New(inner)
-		allocs := testing.AllocsPerRun(100, func() {
-			lg.Debug("msg", zap.String("k", "v"), zap.Bool("b", true), zap.Int("n", 42))
-		})
-		require.Greater(t, allocs, float64(1))
 	})
 
 	t.Run("at most one alloc after hot-reload to error", func(t *testing.T) {


### PR DESCRIPTION
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style. For details on this,
  check out the Contributors Guide linked above.
-->

### Brief description of Pull Request
The zap logging adapter was not able to leverage zap's internal early exit optimizations due to missing understanding of the configured log level in Alloy. With this change, it can avoid extra allocations, especially in heavy debug logging situations.

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Tests updated
