### PR TITLE
ci: Improve release artifact workflow

### DIFF
--- a/.github/workflows/release-publish-alloy-artifacts.yml
+++ b/.github/workflows/release-publish-alloy-artifacts.yml
@@ -308,13 +308,3 @@ jobs:
         RELEASE_TAG: ${{ env.RELEASE_TAG }}
         GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
-  submit_winget_manifest:
-    name: Submit WinGet Manifest
-    needs:
-    - upload_release_artifacts
-    uses: ./.github/workflows/release-submit-winget-manifest.yml
-    permissions:
-      contents: read
-      id-token: write
-    with:
-      release-tag: ${{ github.ref_name }}

--- a/.github/workflows/release-winget-on-publish.yml
+++ b/.github/workflows/release-winget-on-publish.yml
@@ -1,0 +1,17 @@
+name: Submit WinGet manifest on release publish
+
+on:
+  release:
+    types: [released]
+
+permissions: {}
+
+jobs:
+  submit_winget_manifest:
+    name: Submit WinGet Manifest
+    uses: ./.github/workflows/release-submit-winget-manifest.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      release-tag: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
Parallelizes the binary build pipeline with container publishing, and moves WinGet manifest submission to trigger on release publish rather than tag push.

The binary build pipeline previously waited for all three container builds (including the Windows container at ~49 minutes) before starting. These are independent operations and can run in parallel.

WinGet submission now triggers on `release: released`, which only fires for non-pre-release publishes. This prevents RC releases from being submitted to WinGet and fixes the broken URL issue where draft release assets aren't publicly accessible.