### PR TITLE
HACKATHON: component level metrics

### DIFF
--- a/internal/component/common/loki/receiver.go
+++ b/internal/component/common/loki/receiver.go
@@ -30,6 +30,10 @@ func (l *logsReceiver) Chan() chan Entry {
 	return l.entries
 }
 
+func (l *logsReceiver) ComponentID() string {
+	return l.componentID
+}
+
 func (l *logsReceiver) String() string {
 	return l.componentID + ".receiver"
 }

--- a/internal/component/loki/process/process.go
+++ b/internal/component/loki/process/process.go
@@ -73,7 +73,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		processOut:         loki.NewLogsReceiver(),
 		processIn:          loki.NewLogsReceiver(),
 		receiver:           loki.NewLogsReceiver(loki.WithComponentID(o.ID)),
-		fanout:             loki.NewFanout(args.ForwardTo),
+		fanout:             loki.NewFanout(args.ForwardTo, o.Registerer),
 		debugDataPublisher: debugDataPublisher.(livedebugging.DebugDataPublisher),
 	}
 

--- a/internal/component/loki/source/api/api.go
+++ b/internal/component/loki/source/api/api.go
@@ -73,7 +73,7 @@ func New(opts component.Options, args Arguments) (*Component, error) {
 		handler:            loki.NewLogsBatchReceiver(),
 		uncheckedCollector: util.NewUncheckedCollector(nil),
 
-		fanout: loki.NewFanout(args.ForwardTo),
+		fanout: loki.NewFanout(args.ForwardTo, opts.Registerer),
 	}
 	opts.Registerer.MustRegister(c.uncheckedCollector)
 	err := c.Update(args)

--- a/internal/component/loki/source/cloudflare/cloudflare.go
+++ b/internal/component/loki/source/cloudflare/cloudflare.go
@@ -120,7 +120,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		opts:    o,
 		metrics: newMetrics(o.Registerer),
 		handler: loki.NewLogsReceiver(),
-		fanout:  loki.NewFanout(args.ForwardTo),
+		fanout:  loki.NewFanout(args.ForwardTo, o.Registerer),
 		posFile: positionsFile,
 	}
 

--- a/internal/component/loki/source/consume_test.go
+++ b/internal/component/loki/source/consume_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/grafana/loki/pkg/push"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
@@ -14,7 +15,7 @@ import (
 func TestConsume(t *testing.T) {
 	consumer := loki.NewLogsReceiver()
 	producer := loki.NewLogsReceiver()
-	fanout := loki.NewFanout([]loki.LogsReceiver{consumer})
+	fanout := loki.NewFanout([]loki.LogsReceiver{consumer}, prometheus.NewRegistry())
 
 	t.Run("should fanout any consumed entries", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -47,7 +48,7 @@ func TestConsume(t *testing.T) {
 func TestConsumeAndProcess(t *testing.T) {
 	consumer := loki.NewLogsReceiver()
 	producer := loki.NewLogsReceiver()
-	fanout := loki.NewFanout([]loki.LogsReceiver{consumer})
+	fanout := loki.NewFanout([]loki.LogsReceiver{consumer}, prometheus.NewRegistry())
 
 	t.Run("should process and fanout any consumed entries", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -88,7 +89,7 @@ func TestConsumeAndProcess(t *testing.T) {
 func TestConsumeBatch(t *testing.T) {
 	consumer := loki.NewLogsReceiver()
 	producer := loki.NewLogsBatchReceiver()
-	fanout := loki.NewFanout([]loki.LogsReceiver{consumer})
+	fanout := loki.NewFanout([]loki.LogsReceiver{consumer}, prometheus.NewRegistry())
 
 	t.Run("should fanout any consumed entries", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())

--- a/internal/component/loki/source/docker/docker.go
+++ b/internal/component/loki/source/docker/docker.go
@@ -142,7 +142,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		exited:    atomic.NewBool(false),
 		handler:   loki.NewLogsReceiver(),
 		scheduler: source.NewScheduler[string](),
-		fanout:    loki.NewFanout(args.ForwardTo),
+		fanout:    loki.NewFanout(args.ForwardTo, o.Registerer),
 		posFile:   positionsFile,
 	}
 

--- a/internal/component/loki/source/file/file.go
+++ b/internal/component/loki/source/file/file.go
@@ -234,7 +234,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		opts:      o,
 		metrics:   newMetrics(o.Registerer),
 		handler:   loki.NewLogsReceiver(),
-		fanout:    loki.NewFanout(args.ForwardTo),
+		fanout:    loki.NewFanout(args.ForwardTo, o.Registerer),
 		posFile:   positionsFile,
 		scheduler: source.NewScheduler[positions.Entry](),
 		watcher:   time.NewTicker(args.FileMatch.SyncPeriod),

--- a/internal/component/loki/source/journal/journal.go
+++ b/internal/component/loki/source/journal/journal.go
@@ -79,7 +79,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		opts:           o,
 		recv:           loki.NewLogsReceiver(),
 		positions:      positionsFile,
-		fanout:         loki.NewFanout(args.ForwardTo),
+		fanout:         loki.NewFanout(args.ForwardTo, o.Registerer),
 		targetsUpdated: make(chan struct{}, 1),
 		args:           args,
 	}

--- a/internal/component/loki/source/kubernetes_events/kubernetes_events.go
+++ b/internal/component/loki/source/kubernetes_events/kubernetes_events.go
@@ -117,7 +117,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		positions: positionsFile,
 		handler:   loki.NewLogsReceiver(),
 		scheduler: source.NewScheduler[string](),
-		fanout:    loki.NewFanout(args.ForwardTo),
+		fanout:    loki.NewFanout(args.ForwardTo, o.Registerer),
 	}
 	if err := c.Update(args); err != nil {
 		return nil, err

--- a/internal/component/otelcol/connector/connector.go
+++ b/internal/component/otelcol/connector/connector.go
@@ -211,7 +211,7 @@ func (p *Connector) Update(args component.Arguments) error {
 	}
 
 	if len(next.Metrics) > 0 {
-		fanout := fanoutconsumer.Metrics(next.Metrics)
+		fanout := fanoutconsumer.Metrics(next.Metrics, reg)
 		metricsInterceptor := interceptconsumer.Metrics(fanout,
 			func(ctx context.Context, md pmetric.Metrics) error {
 				livedebuggingpublisher.PublishMetricsIfActive(p.debugDataPublisher, p.opts.ID, md, otelcol.GetComponentMetadata(next.Metrics))

--- a/internal/component/otelcol/connector/spanlogs/spanlogs.go
+++ b/internal/component/otelcol/connector/spanlogs/spanlogs.go
@@ -107,7 +107,7 @@ func New(o component.Options, c Arguments) (*Component, error) {
 		return nil, err
 	}
 
-	nextLogs := fanoutconsumer.Logs(c.Output.Logs)
+	nextLogs := fanoutconsumer.Logs(c.Output.Logs, o.Registerer)
 	consumer, err := NewConsumer(c, nextLogs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a traces consumer due to error: %w", err)
@@ -149,7 +149,7 @@ func (c *Component) Update(newConfig component.Arguments) error {
 
 	nextLogs := c.args.Output.Logs
 
-	fanout := fanoutconsumer.Logs(nextLogs)
+	fanout := fanoutconsumer.Logs(nextLogs, c.opts.Registerer)
 	logsInterceptor := interceptconsumer.Logs(fanout,
 		func(ctx context.Context, ld plog.Logs) error {
 			livedebuggingpublisher.PublishLogsIfActive(c.debugDataPublisher, c.opts.ID, ld, otelcol.GetComponentMetadata(nextLogs))

--- a/internal/component/otelcol/internal/fanoutconsumer/consumer.go
+++ b/internal/component/otelcol/internal/fanoutconsumer/consumer.go
@@ -1,0 +1,14 @@
+package fanoutconsumer
+
+import (
+	"github.com/grafana/alloy/internal/component/otelcol"
+)
+
+// componentID returns the component ID of the consumer if it implements
+// otelcol.ComponentMetadata, otherwise returns "undefined".
+func componentID(c any) string {
+	if m, ok := c.(otelcol.ComponentMetadata); ok {
+		return m.ComponentID()
+	}
+	return "undefined"
+}

--- a/internal/component/otelcol/internal/fanoutconsumer/fanoutconsumer_test.go
+++ b/internal/component/otelcol/internal/fanoutconsumer/fanoutconsumer_test.go
@@ -1,0 +1,270 @@
+package fanoutconsumer
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/grafana/alloy/internal/component/otelcol"
+	"github.com/prometheus/client_golang/prometheus"
+	otelconsumer "go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+// fakeConsumer implements otelcol.Consumer for all three signals.
+// It optionally exposes a ComponentID for destination label tests.
+type fakeConsumer struct {
+	traces  *consumertest.TracesSink
+	metrics *consumertest.MetricsSink
+	logs    *consumertest.LogsSink
+
+	id          string // empty = no ComponentMetadata
+	mutatesData bool
+}
+
+func newFakeConsumer(id string) *fakeConsumer {
+	return &fakeConsumer{
+		id:      id,
+		traces:  new(consumertest.TracesSink),
+		metrics: new(consumertest.MetricsSink),
+		logs:    new(consumertest.LogsSink),
+	}
+}
+
+func (f *fakeConsumer) Capabilities() otelconsumer.Capabilities {
+	return otelconsumer.Capabilities{MutatesData: f.mutatesData}
+}
+
+func (f *fakeConsumer) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
+	return f.traces.ConsumeTraces(ctx, td)
+}
+
+func (f *fakeConsumer) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+	return f.metrics.ConsumeMetrics(ctx, md)
+}
+
+func (f *fakeConsumer) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
+	return f.logs.ConsumeLogs(ctx, ld)
+}
+
+func (f *fakeConsumer) ComponentID() string { return f.id }
+
+var _ otelcol.Consumer = (*fakeConsumer)(nil)
+
+// fakeConsumerNoID implements otelcol.Consumer but NOT ComponentMetadata.
+type fakeConsumerNoID struct {
+	traces  *consumertest.TracesSink
+	metrics *consumertest.MetricsSink
+	logs    *consumertest.LogsSink
+}
+
+func newFakeConsumerNoID() *fakeConsumerNoID {
+	return &fakeConsumerNoID{
+		traces:  new(consumertest.TracesSink),
+		metrics: new(consumertest.MetricsSink),
+		logs:    new(consumertest.LogsSink),
+	}
+}
+
+func (f *fakeConsumerNoID) Capabilities() otelconsumer.Capabilities {
+	return otelconsumer.Capabilities{}
+}
+
+func (f *fakeConsumerNoID) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
+	return f.traces.ConsumeTraces(ctx, td)
+}
+
+func (f *fakeConsumerNoID) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+	return f.metrics.ConsumeMetrics(ctx, md)
+}
+
+func (f *fakeConsumerNoID) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
+	return f.logs.ConsumeLogs(ctx, ld)
+}
+
+var _ otelcol.Consumer = (*fakeConsumerNoID)(nil)
+
+// errorConsumer always returns an error for all signal methods.
+type errorConsumer struct{}
+
+func (e *errorConsumer) Capabilities() otelconsumer.Capabilities  { return otelconsumer.Capabilities{} }
+func (e *errorConsumer) ConsumeTraces(_ context.Context, _ ptrace.Traces) error {
+	return errors.New("consume error")
+}
+func (e *errorConsumer) ConsumeMetrics(_ context.Context, _ pmetric.Metrics) error {
+	return errors.New("consume error")
+}
+func (e *errorConsumer) ConsumeLogs(_ context.Context, _ plog.Logs) error {
+	return errors.New("consume error")
+}
+func (e *errorConsumer) ComponentID() string { return "error-consumer" }
+
+var _ otelcol.Consumer = (*errorConsumer)(nil)
+
+// makeTraces creates a ptrace.Traces with the given number of spans.
+func makeTraces(spanCount int) ptrace.Traces {
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	ss := rs.ScopeSpans().AppendEmpty()
+	for i := 0; i < spanCount; i++ {
+		ss.Spans().AppendEmpty()
+	}
+	return td
+}
+
+// makeMetrics creates a pmetric.Metrics with the given number of gauge data points.
+func makeMetrics(dpCount int) pmetric.Metrics {
+	md := pmetric.NewMetrics()
+	rm := md.ResourceMetrics().AppendEmpty()
+	sm := rm.ScopeMetrics().AppendEmpty()
+	for i := 0; i < dpCount; i++ {
+		m := sm.Metrics().AppendEmpty()
+		m.SetEmptyGauge().DataPoints().AppendEmpty()
+	}
+	return md
+}
+
+// makeLogs creates a plog.Logs with the given number of log records.
+func makeLogs(recordCount int) plog.Logs {
+	ld := plog.NewLogs()
+	rl := ld.ResourceLogs().AppendEmpty()
+	sl := rl.ScopeLogs().AppendEmpty()
+	for i := 0; i < recordCount; i++ {
+		sl.LogRecords().AppendEmpty()
+	}
+	return ld
+}
+
+// gatherCounter returns the float64 value of the first metric with the given label value.
+func gatherCounter(t *testing.T, reg *prometheus.Registry, labelVal string) float64 {
+	t.Helper()
+	mf, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather metrics: %v", err)
+	}
+	for _, m := range mf {
+		for _, metric := range m.GetMetric() {
+			for _, lp := range metric.GetLabel() {
+				if lp.GetValue() == labelVal {
+					return metric.GetCounter().GetValue()
+				}
+			}
+		}
+	}
+	return 0
+}
+
+func TestTracesPassthroughCountsSpans(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	sink := newFakeConsumer("dest1")
+	fanout := Traces([]otelcol.Consumer{sink}, reg)
+
+	if err := fanout.ConsumeTraces(context.Background(), makeTraces(3)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := gatherCounter(t, reg, "dest1"); got != 3 {
+		t.Errorf("expected 3 spans counted, got %v", got)
+	}
+}
+
+func TestTracesPassthroughNoCountOnError(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	fanout := Traces([]otelcol.Consumer{&errorConsumer{}}, reg)
+
+	err := fanout.ConsumeTraces(context.Background(), makeTraces(5))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if got := gatherCounter(t, reg, "error-consumer"); got != 0 {
+		t.Errorf("expected 0 spans on error, got %v", got)
+	}
+}
+
+func TestTracesFanoutMultipleConsumers(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	sink1 := newFakeConsumer("dest1")
+	sink2 := newFakeConsumer("dest2")
+	fanout := Traces([]otelcol.Consumer{sink1, sink2}, reg)
+
+	if err := fanout.ConsumeTraces(context.Background(), makeTraces(4)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := gatherCounter(t, reg, "dest1"); got != 4 {
+		t.Errorf("expected 4 spans for dest1, got %v", got)
+	}
+	if got := gatherCounter(t, reg, "dest2"); got != 4 {
+		t.Errorf("expected 4 spans for dest2, got %v", got)
+	}
+}
+
+func TestMetricsPassthroughCountsDataPoints(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	sink := newFakeConsumer("dest1")
+	fanout := Metrics([]otelcol.Consumer{sink}, reg)
+
+	if err := fanout.ConsumeMetrics(context.Background(), makeMetrics(7)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := gatherCounter(t, reg, "dest1"); got != 7 {
+		t.Errorf("expected 7 data points, got %v", got)
+	}
+}
+
+func TestLogsPassthroughCountsLogRecords(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	sink := newFakeConsumer("dest1")
+	fanout := Logs([]otelcol.Consumer{sink}, reg)
+
+	if err := fanout.ConsumeLogs(context.Background(), makeLogs(5)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := gatherCounter(t, reg, "dest1"); got != 5 {
+		t.Errorf("expected 5 log records, got %v", got)
+	}
+}
+
+func TestTracesUndefinedDestinationFallback(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	sink := newFakeConsumerNoID()
+	fanout := Traces([]otelcol.Consumer{sink}, reg)
+
+	if err := fanout.ConsumeTraces(context.Background(), makeTraces(2)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := gatherCounter(t, reg, "undefined"); got != 2 {
+		t.Errorf("expected 2 spans under destination=undefined, got %v", got)
+	}
+}
+
+func TestAlreadyRegisteredCounterReused(t *testing.T) {
+	// Simulates multiple Update() calls on the same opts.Registerer.
+	reg := prometheus.NewRegistry()
+	sink1 := newFakeConsumer("dest1")
+
+	// First call - registers the counter.
+	fanout1 := Traces([]otelcol.Consumer{sink1}, reg)
+	if err := fanout1.ConsumeTraces(context.Background(), makeTraces(3)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Second call - counter already registered; should reuse it.
+	sink2 := newFakeConsumer("dest1")
+	fanout2 := Traces([]otelcol.Consumer{sink2}, reg)
+	if err := fanout2.ConsumeTraces(context.Background(), makeTraces(2)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Total should be 3 + 2 = 5 since the same counter is reused.
+	if got := gatherCounter(t, reg, "dest1"); got != 5 {
+		t.Errorf("expected 5 total spans after two updates, got %v", got)
+	}
+}

--- a/internal/component/otelcol/internal/fanoutconsumer/logs.go
+++ b/internal/component/otelcol/internal/fanoutconsumer/logs.go
@@ -10,17 +10,32 @@ import (
 	"context"
 
 	"github.com/grafana/alloy/internal/component/otelcol"
+	"github.com/prometheus/client_golang/prometheus"
 	otelconsumer "go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/multierr"
 )
 
 // Logs creates a new fanout consumer for logs.
-func Logs(in []otelcol.Consumer) otelconsumer.Logs {
+func Logs(in []otelcol.Consumer, reg prometheus.Registerer) otelconsumer.Logs {
+	counter := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "otelcol_forwarded_log_records_total",
+		Help: "Total number of log records forwarded to downstream components.",
+	}, []string{"destination"})
+	if err := reg.Register(counter); err != nil {
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			counter = are.ExistingCollector.(*prometheus.CounterVec)
+		}
+	}
+
 	if len(in) == 0 {
-		return &logsFanout{}
+		return &logsFanout{logRecordsCounter: counter}
 	} else if len(in) == 1 {
-		return in[0]
+		return &logsPassthrough{
+			consumer:          in[0],
+			destID:            componentID(in[0]),
+			logRecordsCounter: counter,
+		}
 	}
 
 	var passthrough, clone []otelconsumer.Logs
@@ -53,14 +68,34 @@ func Logs(in []otelcol.Consumer) otelconsumer.Logs {
 	}
 
 	return &logsFanout{
-		passthrough: passthrough,
-		clone:       clone,
+		passthrough:       passthrough,
+		clone:             clone,
+		logRecordsCounter: counter,
 	}
 }
 
+type logsPassthrough struct {
+	consumer          otelconsumer.Logs
+	destID            string
+	logRecordsCounter *prometheus.CounterVec
+}
+
+func (p *logsPassthrough) Capabilities() otelconsumer.Capabilities {
+	return p.consumer.Capabilities()
+}
+
+func (p *logsPassthrough) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
+	if err := p.consumer.ConsumeLogs(ctx, ld); err != nil {
+		return err
+	}
+	p.logRecordsCounter.WithLabelValues(p.destID).Add(float64(ld.LogRecordCount()))
+	return nil
+}
+
 type logsFanout struct {
-	passthrough []otelconsumer.Logs // Consumers where data can be passed through directly
-	clone       []otelconsumer.Logs // Consumes which require cloning data
+	passthrough       []otelconsumer.Logs // Consumers where data can be passed through directly
+	clone             []otelconsumer.Logs // Consumes which require cloning data
+	logRecordsCounter *prometheus.CounterVec
 }
 
 func (f *logsFanout) Capabilities() otelconsumer.Capabilities {
@@ -71,16 +106,26 @@ func (f *logsFanout) Capabilities() otelconsumer.Capabilities {
 func (f *logsFanout) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 	var errs error
 
+	logRecordCount := ld.LogRecordCount()
+
 	// Initially pass to clone exporter to avoid the case where the optimization
 	// of sending the incoming data to a mutating consumer is used that may
 	// change the incoming data before cloning.
-	for _, f := range f.clone {
+	for _, c := range f.clone {
 		newLogs := plog.NewLogs()
 		ld.CopyTo(newLogs)
-		errs = multierr.Append(errs, f.ConsumeLogs(ctx, newLogs))
+		if err := c.ConsumeLogs(ctx, newLogs); err != nil {
+			errs = multierr.Append(errs, err)
+		} else {
+			f.logRecordsCounter.WithLabelValues(componentID(c)).Add(float64(logRecordCount))
+		}
 	}
-	for _, f := range f.passthrough {
-		errs = multierr.Append(errs, f.ConsumeLogs(ctx, ld))
+	for _, c := range f.passthrough {
+		if err := c.ConsumeLogs(ctx, ld); err != nil {
+			errs = multierr.Append(errs, err)
+		} else {
+			f.logRecordsCounter.WithLabelValues(componentID(c)).Add(float64(logRecordCount))
+		}
 	}
 
 	return errs

--- a/internal/component/otelcol/internal/fanoutconsumer/metrics.go
+++ b/internal/component/otelcol/internal/fanoutconsumer/metrics.go
@@ -10,17 +10,32 @@ import (
 	"context"
 
 	"github.com/grafana/alloy/internal/component/otelcol"
+	"github.com/prometheus/client_golang/prometheus"
 	otelconsumer "go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/multierr"
 )
 
 // Metrics creates a new fanout consumer for metrics.
-func Metrics(in []otelcol.Consumer) otelconsumer.Metrics {
+func Metrics(in []otelcol.Consumer, reg prometheus.Registerer) otelconsumer.Metrics {
+	counter := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "otelcol_forwarded_metric_points_total",
+		Help: "Total number of metric data points forwarded to downstream components.",
+	}, []string{"destination"})
+	if err := reg.Register(counter); err != nil {
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			counter = are.ExistingCollector.(*prometheus.CounterVec)
+		}
+	}
+
 	if len(in) == 0 {
-		return &metricsFanout{}
+		return &metricsFanout{metricPointsCounter: counter}
 	} else if len(in) == 1 {
-		return in[0]
+		return &metricsPassthrough{
+			consumer:            in[0],
+			destID:              componentID(in[0]),
+			metricPointsCounter: counter,
+		}
 	}
 
 	var passthrough, clone []otelconsumer.Metrics
@@ -50,14 +65,34 @@ func Metrics(in []otelcol.Consumer) otelconsumer.Metrics {
 	}
 
 	return &metricsFanout{
-		passthrough: passthrough,
-		clone:       clone,
+		passthrough:         passthrough,
+		clone:               clone,
+		metricPointsCounter: counter,
 	}
 }
 
+type metricsPassthrough struct {
+	consumer            otelconsumer.Metrics
+	destID              string
+	metricPointsCounter *prometheus.CounterVec
+}
+
+func (p *metricsPassthrough) Capabilities() otelconsumer.Capabilities {
+	return p.consumer.Capabilities()
+}
+
+func (p *metricsPassthrough) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+	if err := p.consumer.ConsumeMetrics(ctx, md); err != nil {
+		return err
+	}
+	p.metricPointsCounter.WithLabelValues(p.destID).Add(float64(md.DataPointCount()))
+	return nil
+}
+
 type metricsFanout struct {
-	passthrough []otelconsumer.Metrics // Consumers where data can be passed through directly
-	clone       []otelconsumer.Metrics // Consumes which require cloning data
+	passthrough         []otelconsumer.Metrics // Consumers where data can be passed through directly
+	clone               []otelconsumer.Metrics // Consumes which require cloning data
+	metricPointsCounter *prometheus.CounterVec
 }
 
 func (f *metricsFanout) Capabilities() otelconsumer.Capabilities {
@@ -68,16 +103,26 @@ func (f *metricsFanout) Capabilities() otelconsumer.Capabilities {
 func (f *metricsFanout) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 	var errs error
 
+	dataPointCount := md.DataPointCount()
+
 	// Initially pass to clone exporter to avoid the case where the optimization
 	// of sending the incoming data to a mutating consumer is used that may
 	// change the incoming data before cloning.
-	for _, f := range f.clone {
+	for _, c := range f.clone {
 		newMetrics := pmetric.NewMetrics()
 		md.CopyTo(newMetrics)
-		errs = multierr.Append(errs, f.ConsumeMetrics(ctx, newMetrics))
+		if err := c.ConsumeMetrics(ctx, newMetrics); err != nil {
+			errs = multierr.Append(errs, err)
+		} else {
+			f.metricPointsCounter.WithLabelValues(componentID(c)).Add(float64(dataPointCount))
+		}
 	}
-	for _, f := range f.passthrough {
-		errs = multierr.Append(errs, f.ConsumeMetrics(ctx, md))
+	for _, c := range f.passthrough {
+		if err := c.ConsumeMetrics(ctx, md); err != nil {
+			errs = multierr.Append(errs, err)
+		} else {
+			f.metricPointsCounter.WithLabelValues(componentID(c)).Add(float64(dataPointCount))
+		}
 	}
 
 	return errs

--- a/internal/component/otelcol/internal/fanoutconsumer/traces.go
+++ b/internal/component/otelcol/internal/fanoutconsumer/traces.go
@@ -10,17 +10,32 @@ import (
 	"context"
 
 	"github.com/grafana/alloy/internal/component/otelcol"
+	"github.com/prometheus/client_golang/prometheus"
 	otelconsumer "go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/multierr"
 )
 
 // Traces creates a new fanout consumer for traces.
-func Traces(in []otelcol.Consumer) otelconsumer.Traces {
+func Traces(in []otelcol.Consumer, reg prometheus.Registerer) otelconsumer.Traces {
+	counter := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "otelcol_forwarded_spans_total",
+		Help: "Total number of spans forwarded to downstream components.",
+	}, []string{"destination"})
+	if err := reg.Register(counter); err != nil {
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			counter = are.ExistingCollector.(*prometheus.CounterVec)
+		}
+	}
+
 	if len(in) == 0 {
-		return &tracesFanout{}
+		return &tracesFanout{spansCounter: counter}
 	} else if len(in) == 1 {
-		return in[0]
+		return &tracesPassthrough{
+			consumer:     in[0],
+			destID:       componentID(in[0]),
+			spansCounter: counter,
+		}
 	}
 
 	var passthrough, clone []otelconsumer.Traces
@@ -50,14 +65,36 @@ func Traces(in []otelcol.Consumer) otelconsumer.Traces {
 	}
 
 	return &tracesFanout{
-		passthrough: passthrough,
-		clone:       clone,
+		passthrough:  passthrough,
+		clone:        clone,
+		spansCounter: counter,
 	}
 }
 
+type tracesPassthrough struct {
+	consumer     otelconsumer.Traces
+	destID       string
+	spansCounter *prometheus.CounterVec
+}
+
+func (p *tracesPassthrough) Capabilities() otelconsumer.Capabilities {
+	return p.consumer.Capabilities()
+}
+
+func (p *tracesPassthrough) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
+	if err := p.consumer.ConsumeTraces(ctx, td); err != nil {
+		return err
+	}
+	p.spansCounter.WithLabelValues(p.destID).Add(float64(td.SpanCount()))
+	return nil
+}
+
 type tracesFanout struct {
-	passthrough []otelconsumer.Traces // Consumers where data can be passed through directly
-	clone       []otelconsumer.Traces // Consumes which require cloning data
+	passthrough    []otelconsumer.Traces // Consumers where data can be passed through directly
+	passthroughIDs []string
+	clone          []otelconsumer.Traces // Consumes which require cloning data
+	cloneIDs       []string
+	spansCounter   *prometheus.CounterVec
 }
 
 func (f *tracesFanout) Capabilities() otelconsumer.Capabilities {
@@ -68,16 +105,26 @@ func (f *tracesFanout) Capabilities() otelconsumer.Capabilities {
 func (f *tracesFanout) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
 	var errs error
 
+	spanCount := td.SpanCount()
+
 	// Initially pass to clone exporter to avoid the case where the optimization
 	// of sending the incoming data to a mutating consumer is used that may
 	// change the incoming data before cloning.
-	for _, f := range f.clone {
+	for _, c := range f.clone {
 		newTraces := ptrace.NewTraces()
 		td.CopyTo(newTraces)
-		errs = multierr.Append(errs, f.ConsumeTraces(ctx, newTraces))
+		if err := c.ConsumeTraces(ctx, newTraces); err != nil {
+			errs = multierr.Append(errs, err)
+		} else {
+			f.spansCounter.WithLabelValues(componentID(c)).Add(float64(spanCount))
+		}
 	}
-	for _, f := range f.passthrough {
-		errs = multierr.Append(errs, f.ConsumeTraces(ctx, td))
+	for _, c := range f.passthrough {
+		if err := c.ConsumeTraces(ctx, td); err != nil {
+			errs = multierr.Append(errs, err)
+		} else {
+			f.spansCounter.WithLabelValues(componentID(c)).Add(float64(spanCount))
+		}
 	}
 
 	return errs

--- a/internal/component/otelcol/processor/discovery/discovery.go
+++ b/internal/component/otelcol/processor/discovery/discovery.go
@@ -108,7 +108,7 @@ func New(o component.Options, c Arguments) (*Component, error) {
 	}
 
 	nextTraces := c.Output.Traces
-	fanout := fanoutconsumer.Traces(nextTraces)
+	fanout := fanoutconsumer.Traces(nextTraces, o.Registerer)
 	tracesInterceptor := interceptconsumer.Traces(fanout,
 		func(ctx context.Context, td ptrace.Traces) error {
 			livedebuggingpublisher.PublishTracesIfActive(debugDataPublisher.(livedebugging.DebugDataPublisher), o.ID, td, otelcol.GetComponentMetadata(nextTraces))
@@ -175,7 +175,7 @@ func (c *Component) Update(newConfig component.Arguments) error {
 		hostLabels[host] = promsdconsumer.NewTargetsWithNonInternalLabels(labels)
 	}
 	nextTraces := c.args.Output.Traces
-	fanout := fanoutconsumer.Traces(nextTraces)
+	fanout := fanoutconsumer.Traces(nextTraces, c.opts.Registerer)
 
 	tracesInterceptor := interceptconsumer.Traces(fanout,
 		func(ctx context.Context, td ptrace.Traces) error {

--- a/internal/component/otelcol/processor/processor.go
+++ b/internal/component/otelcol/processor/processor.go
@@ -187,7 +187,7 @@ func (p *Processor) Update(args component.Arguments) error {
 
 	var tracesProcessor otelprocessor.Traces
 	if len(next.Traces) > 0 {
-		fanout := fanoutconsumer.Traces(next.Traces)
+		fanout := fanoutconsumer.Traces(next.Traces, reg)
 		tracesInterceptor := interceptconsumer.Traces(fanout,
 			func(ctx context.Context, td ptrace.Traces) error {
 				livedebuggingpublisher.PublishTracesIfActive(p.debugDataPublisher, p.opts.ID, td, otelcol.GetComponentMetadata(next.Traces))
@@ -204,7 +204,7 @@ func (p *Processor) Update(args component.Arguments) error {
 
 	var metricsProcessor otelprocessor.Metrics
 	if len(next.Metrics) > 0 {
-		fanout := fanoutconsumer.Metrics(next.Metrics)
+		fanout := fanoutconsumer.Metrics(next.Metrics, reg)
 		metricsInterceptor := interceptconsumer.Metrics(fanout,
 			func(ctx context.Context, md pmetric.Metrics) error {
 				livedebuggingpublisher.PublishMetricsIfActive(p.debugDataPublisher, p.opts.ID, md, otelcol.GetComponentMetadata(next.Metrics))
@@ -221,7 +221,7 @@ func (p *Processor) Update(args component.Arguments) error {
 
 	var logsProcessor otelprocessor.Logs
 	if len(next.Logs) > 0 {
-		fanout := fanoutconsumer.Logs(next.Logs)
+		fanout := fanoutconsumer.Logs(next.Logs, reg)
 		logsInterceptor := interceptconsumer.Logs(fanout,
 			func(ctx context.Context, ld plog.Logs) error {
 				livedebuggingpublisher.PublishLogsIfActive(p.debugDataPublisher, p.opts.ID, ld, otelcol.GetComponentMetadata(next.Logs))

--- a/internal/component/otelcol/receiver/loki/loki.go
+++ b/internal/component/otelcol/receiver/loki/loki.go
@@ -120,7 +120,7 @@ func (c *Component) Update(newConfig component.Arguments) error {
 
 	c.args = newConfig.(Arguments)
 	nextLogs := c.args.Output.Logs
-	fanout := fanoutconsumer.Logs(nextLogs)
+	fanout := fanoutconsumer.Logs(nextLogs, c.opts.Registerer)
 	logsInterceptor := interceptconsumer.Logs(fanout,
 		func(ctx context.Context, ld plog.Logs) error {
 			livedebuggingpublisher.PublishLogsIfActive(c.debugDataPublisher, c.opts.ID, ld, otelcol.GetComponentMetadata(nextLogs))

--- a/internal/component/otelcol/receiver/prometheus/prometheus.go
+++ b/internal/component/otelcol/receiver/prometheus/prometheus.go
@@ -149,7 +149,7 @@ func (c *Component) Update(newConfig component.Arguments) error {
 	settings.TelemetrySettings.Resource = resource
 
 	nextMetrics := cfg.Output.Metrics
-	fanout := fanoutconsumer.Metrics(nextMetrics)
+	fanout := fanoutconsumer.Metrics(nextMetrics, c.opts.Registerer)
 	metricsInterceptor := interceptconsumer.Metrics(fanout,
 		func(ctx context.Context, md pmetric.Metrics) error {
 			livedebuggingpublisher.PublishMetricsIfActive(c.debugDataPublisher, c.opts.ID, md, otelcol.GetComponentMetadata(nextMetrics))

--- a/internal/component/otelcol/receiver/receiver.go
+++ b/internal/component/otelcol/receiver/receiver.go
@@ -175,7 +175,7 @@ func (r *Receiver) Update(args component.Arguments) error {
 	var components []otelcomponent.Component
 
 	if len(next.Traces) > 0 {
-		fanout := fanoutconsumer.Traces(next.Traces)
+		fanout := fanoutconsumer.Traces(next.Traces, reg)
 		tracesInterceptor := interceptconsumer.Traces(fanout,
 			func(ctx context.Context, td ptrace.Traces) error {
 				livedebuggingpublisher.PublishTracesIfActive(r.debugDataPublisher, r.opts.ID, td, otelcol.GetComponentMetadata(next.Traces))
@@ -191,7 +191,7 @@ func (r *Receiver) Update(args component.Arguments) error {
 	}
 
 	if len(next.Metrics) > 0 {
-		fanout := fanoutconsumer.Metrics(next.Metrics)
+		fanout := fanoutconsumer.Metrics(next.Metrics, reg)
 		metricsInterceptor := interceptconsumer.Metrics(fanout,
 			func(ctx context.Context, md pmetric.Metrics) error {
 				livedebuggingpublisher.PublishMetricsIfActive(r.debugDataPublisher, r.opts.ID, md, otelcol.GetComponentMetadata(next.Metrics))
@@ -207,7 +207,7 @@ func (r *Receiver) Update(args component.Arguments) error {
 	}
 
 	if len(next.Logs) > 0 {
-		fanout := fanoutconsumer.Logs(next.Logs)
+		fanout := fanoutconsumer.Logs(next.Logs, reg)
 		logsInterceptor := interceptconsumer.Logs(fanout,
 			func(ctx context.Context, ld plog.Logs) error {
 				livedebuggingpublisher.PublishLogsIfActive(r.debugDataPublisher, r.opts.ID, ld, otelcol.GetComponentMetadata(next.Logs))

--- a/internal/component/prometheus/appenders/new.go
+++ b/internal/component/prometheus/appenders/new.go
@@ -6,7 +6,7 @@ import (
 )
 
 // New returns an appropriate appender based on the number of children.
-func New(children []storage.Appender, store *SeriesRefMappingStore, deadRefThreshold storage.SeriesRef, writeLatency prometheus.Histogram, samplesForwarded prometheus.Counter) storage.Appender {
+func New(children []storage.Appender, store *SeriesRefMappingStore, deadRefThreshold storage.SeriesRef, writeLatency prometheus.Histogram, samplesForwarded *prometheus.CounterVec) storage.Appender {
 	// No destination, no work to do.
 	if len(children) == 0 {
 		return Noop{}

--- a/internal/component/prometheus/appenders/new_test.go
+++ b/internal/component/prometheus/appenders/new_test.go
@@ -48,7 +48,7 @@ func TestNew_PassthroughReceivesDeadRefThreshold(t *testing.T) {
 	threshold := store.Clear()
 	require.Greater(t, uint64(threshold), uint64(0))
 
-	sf := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_forwarded", Help: "test"})
+	sf := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_forwarded", Help: "test"}, []string{"destination"})
 	child := &mockAppender{appendFn: func(ref storage.SeriesRef, _ labels.Labels, _ int64, _ float64) (storage.SeriesRef, error) {
 		return ref, nil // echo back whatever ref we receive
 	}}

--- a/internal/component/prometheus/appenders/passthrough_test.go
+++ b/internal/component/prometheus/appenders/passthrough_test.go
@@ -21,10 +21,10 @@ import (
 
 func TestPassthrough_Append(t *testing.T) {
 	collecting := testappender.NewCollectingAppender()
-	samplesForwarded := prometheus.NewCounter(prometheus.CounterOpts{
+	samplesForwarded := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "test_samples_forwarded",
 		Help: "Test samples forwarded",
-	})
+	}, []string{"destination"})
 	a := NewPassthrough(collecting, 0, nil, samplesForwarded)
 
 	testLabels := labels.FromStrings("metric", "test_metric", "job", "test_job")
@@ -48,7 +48,7 @@ func TestPassthrough_Append(t *testing.T) {
 	expected := `
 		# HELP test_samples_forwarded Test samples forwarded
 		# TYPE test_samples_forwarded counter
-		test_samples_forwarded 1
+		test_samples_forwarded{destination=""} 1
 	`
 	err = testutil.CollectAndCompare(samplesForwarded, strings.NewReader(expected), "test_samples_forwarded")
 	require.NoError(t, err)
@@ -58,10 +58,10 @@ func TestPassthrough_AppendError(t *testing.T) {
 	// Create a failing appender
 	failingAppender := &failingAppender{}
 
-	samplesForwarded := prometheus.NewCounter(prometheus.CounterOpts{
+	samplesForwarded := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "test_samples_forwarded",
 		Help: "Test samples forwarded",
-	})
+	}, []string{"destination"})
 	a := NewPassthrough(failingAppender, 0, nil, samplesForwarded)
 
 	testLabels := labels.FromStrings("metric", "test_metric")
@@ -74,7 +74,7 @@ func TestPassthrough_AppendError(t *testing.T) {
 	expected := `
 		# HELP test_samples_forwarded Test samples forwarded
 		# TYPE test_samples_forwarded counter
-		test_samples_forwarded 0
+		test_samples_forwarded{destination=""} 0
 	`
 	err = testutil.CollectAndCompare(samplesForwarded, strings.NewReader(expected), "test_samples_forwarded")
 	require.NoError(t, err)
@@ -140,10 +140,10 @@ func TestPassthrough_UpdateMetadata(t *testing.T) {
 func TestPassthrough_Commit(t *testing.T) {
 	collecting := testappender.NewCollectingAppender()
 
-	samplesForwarded := prometheus.NewCounter(prometheus.CounterOpts{
+	samplesForwarded := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "test_samples_forwarded",
 		Help: "Test samples forwarded",
-	})
+	}, []string{"destination"})
 	writeLatency := prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name: "test_write_latency",
 		Help: "Test write latency",
@@ -166,10 +166,10 @@ func TestPassthrough_Commit(t *testing.T) {
 func TestPassthrough_Rollback(t *testing.T) {
 	collecting := testappender.NewCollectingAppender()
 
-	samplesForwarded := prometheus.NewCounter(prometheus.CounterOpts{
+	samplesForwarded := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "test_samples_forwarded",
 		Help: "Test samples forwarded",
-	})
+	}, []string{"destination"})
 	writeLatency := prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name: "test_write_latency",
 		Help: "Test write latency",

--- a/internal/component/prometheus/appenders/seriesrefmapping_test.go
+++ b/internal/component/prometheus/appenders/seriesrefmapping_test.go
@@ -399,7 +399,7 @@ func TestSeriesRefMapping_AppendReusesExistingMapping(t *testing.T) {
 	child2 := &mockAppender{}
 
 	writeLatency := prometheus.NewHistogram(prometheus.HistogramOpts{Name: "test_series_ref_mapping_write_latency_reuse", Help: "test"})
-	samplesForwarded := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_series_ref_mapping_samples_forwarded_reuse", Help: "test"})
+	samplesForwarded := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_series_ref_mapping_samples_forwarded_reuse", Help: "test"}, []string{"destination"})
 	app := NewSeriesRefMapping([]storage.Appender{child1, child2}, store, writeLatency, samplesForwarded)
 
 	lbls := labels.FromStrings("job", "test")
@@ -424,7 +424,7 @@ func TestSeriesRefMapping_AppendUpdatesExistingMappingWhenRefsChange(t *testing.
 	child2 := &mockAppender{}
 
 	writeLatency := prometheus.NewHistogram(prometheus.HistogramOpts{Name: "test_series_ref_mapping_write_latency_update", Help: "test"})
-	samplesForwarded := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_series_ref_mapping_samples_forwarded_update", Help: "test"})
+	samplesForwarded := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_series_ref_mapping_samples_forwarded_update", Help: "test"}, []string{"destination"})
 	app := NewSeriesRefMapping([]storage.Appender{child1, child2}, store, writeLatency, samplesForwarded)
 
 	lbls := labels.FromStrings("job", "test")
@@ -446,7 +446,7 @@ func TestSeriesRefMapping_AppendAllChildrenZeroPassesThroughInputRef(t *testing.
 	child2 := &mockAppender{appendFn: zeroFn}
 
 	writeLatency := prometheus.NewHistogram(prometheus.HistogramOpts{Name: "test_all_zero_latency", Help: "test"})
-	samplesForwarded := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_all_zero_forwarded", Help: "test"})
+	samplesForwarded := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_all_zero_forwarded", Help: "test"}, []string{"destination"})
 	app := NewSeriesRefMapping([]storage.Appender{child1, child2}, store, writeLatency, samplesForwarded)
 
 	ref, err := app.Append(42, labels.FromStrings("job", "test"), 1, 1)
@@ -464,7 +464,7 @@ func TestSeriesRefMapping_AppendSingleNonZeroChildReturnsChildRefDirectly(t *tes
 	}}
 
 	writeLatency := prometheus.NewHistogram(prometheus.HistogramOpts{Name: "test_single_nonzero_latency", Help: "test"})
-	samplesForwarded := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_single_nonzero_forwarded", Help: "test"})
+	samplesForwarded := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_single_nonzero_forwarded", Help: "test"}, []string{"destination"})
 	app := NewSeriesRefMapping([]storage.Appender{child1, child2}, store, writeLatency, samplesForwarded)
 
 	// The single non-zero child ref is returned directly — no mapping created.
@@ -487,7 +487,7 @@ func TestSeriesRefMapping_AppendSecondAppendUsesChildRefsFromMapping(t *testing.
 	}}
 
 	writeLatency := prometheus.NewHistogram(prometheus.HistogramOpts{Name: "test_series_ref_mapping_write_latency_single_no_leak", Help: "test"})
-	samplesForwarded := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_series_ref_mapping_samples_forwarded_single_no_leak", Help: "test"})
+	samplesForwarded := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_series_ref_mapping_samples_forwarded_single_no_leak", Help: "test"}, []string{"destination"})
 	app := NewSeriesRefMapping([]storage.Appender{child1, child2}, store, writeLatency, samplesForwarded)
 
 	lbls := labels.FromStrings("job", "single")
@@ -516,7 +516,7 @@ func TestSeriesRefMapping_AppendErrorSkipsMappingUpdate(t *testing.T) {
 	}}
 
 	writeLatency := prometheus.NewHistogram(prometheus.HistogramOpts{Name: "test_series_ref_mapping_write_latency_error", Help: "test"})
-	samplesForwarded := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_series_ref_mapping_samples_forwarded_error", Help: "test"})
+	samplesForwarded := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_series_ref_mapping_samples_forwarded_error", Help: "test"}, []string{"destination"})
 	app := NewSeriesRefMapping([]storage.Appender{child1, child2}, store, writeLatency, samplesForwarded)
 
 	ref, err := app.Append(88, labels.EmptyLabels(), 1, 1)
@@ -535,7 +535,7 @@ func TestSeriesRefMapping_CommitTracksRefsAndAggregatesErrors(t *testing.T) {
 	child2 := &mockAppender{commitFn: func() error { return errors.New("child2 commit failed") }}
 
 	writeLatency := prometheus.NewHistogram(prometheus.HistogramOpts{Name: "test_series_ref_mapping_write_latency_commit", Help: "test"})
-	samplesForwarded := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_series_ref_mapping_samples_forwarded_commit", Help: "test"})
+	samplesForwarded := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_series_ref_mapping_samples_forwarded_commit", Help: "test"}, []string{"destination"})
 	app := NewSeriesRefMapping([]storage.Appender{child1, child2}, store, writeLatency, samplesForwarded)
 
 	_, err := app.Append(101, labels.EmptyLabels(), 1, 1)
@@ -559,7 +559,7 @@ func TestSeriesRefMapping_RollbackTracksRefs(t *testing.T) {
 	child2 := &mockAppender{rollbackFn: func() error { return errors.New("child2 rollback failed") }}
 
 	writeLatency := prometheus.NewHistogram(prometheus.HistogramOpts{Name: "test_series_ref_mapping_write_latency_rollback", Help: "test"})
-	samplesForwarded := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_series_ref_mapping_samples_forwarded_rollback", Help: "test"})
+	samplesForwarded := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_series_ref_mapping_samples_forwarded_rollback", Help: "test"}, []string{"destination"})
 	app := NewSeriesRefMapping([]storage.Appender{child1, child2}, store, writeLatency, samplesForwarded)
 
 	_, err := app.Append(202, labels.EmptyLabels(), 1, 1)
@@ -586,7 +586,7 @@ func TestSeriesRefMapping_MappingReusedOnSubsequentAppends(t *testing.T) {
 	}}
 
 	writeLatency := prometheus.NewHistogram(prometheus.HistogramOpts{Name: "test_series_ref_mapping_reuse_latency", Help: "test"})
-	samplesForwarded := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_series_ref_mapping_reuse_forwarded", Help: "test"})
+	samplesForwarded := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_series_ref_mapping_reuse_forwarded", Help: "test"}, []string{"destination"})
 	app := NewSeriesRefMapping([]storage.Appender{child1, child2}, store, writeLatency, samplesForwarded)
 
 	lbls := labels.FromStrings("job", "test")
@@ -625,7 +625,7 @@ func TestSeriesRefMapping_ChildRefChangeUpdatesMapping(t *testing.T) {
 	}}
 
 	writeLatency := prometheus.NewHistogram(prometheus.HistogramOpts{Name: "test_series_ref_mapping_child_change_latency", Help: "test"})
-	samplesForwarded := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_series_ref_mapping_child_change_forwarded", Help: "test"})
+	samplesForwarded := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_series_ref_mapping_child_change_forwarded", Help: "test"}, []string{"destination"})
 	app := NewSeriesRefMapping([]storage.Appender{child1, child2}, store, writeLatency, samplesForwarded)
 
 	lbls := labels.FromStrings("job", "test")


### PR DESCRIPTION
HACKATHON PROJECT, no review required, keeping this open as a draft :)

### Brief description of Pull Request

This PR adds the `destination` label to the metrics produced by the fanout processor. This can then be used to build live traffic graphs visualizing the data flow across components

### Notes to the Reviewer

HACKATHON PROJECT, no review required, keeping this open as a draft :)

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
