### PR TITLE
perf(prometheus.relabel): Reduce lock contention

### DIFF
--- a/internal/component/prometheus/relabel/relabel.go
+++ b/internal/component/prometheus/relabel/relabel.go
@@ -90,8 +90,7 @@ type Component struct {
 
 	debugDataPublisher livedebugging.DebugDataPublisher
 
-	cacheMut sync.RWMutex
-	cache    *lru.Cache[uint64, labels.Labels]
+	cache *lru.Cache[uint64, labels.Labels]
 }
 
 var (
@@ -299,18 +298,11 @@ func (c *Component) relabel(val float64, lbls labels.Labels) labels.Labels {
 }
 
 func (c *Component) getFromCache(lbls labels.Labels) (labels.Labels, bool) {
-	c.cacheMut.RLock()
-	defer c.cacheMut.RUnlock()
-
 	hash := lbls.Hash()
-	fm, found := c.cache.Get(hash)
-
-	return fm, found
+	return c.cache.Get(hash)
 }
 
 func (c *Component) deleteFromCache(lbls labels.Labels) {
-	c.cacheMut.Lock()
-	defer c.cacheMut.Unlock()
 	c.cacheDeletes.Inc()
 
 	hash := lbls.Hash()
@@ -318,16 +310,11 @@ func (c *Component) deleteFromCache(lbls labels.Labels) {
 }
 
 func (c *Component) clearCache(cacheSize int) {
-	c.cacheMut.Lock()
-	defer c.cacheMut.Unlock()
 	cache, _ := lru.New[uint64, labels.Labels](cacheSize)
 	c.cache = cache
 }
 
 func (c *Component) addToCache(lbls labels.Labels, relabeled labels.Labels, keep bool) {
-	c.cacheMut.Lock()
-	defer c.cacheMut.Unlock()
-
 	hash := lbls.Hash()
 	if !keep {
 		c.cache.Add(hash, labels.EmptyLabels())

--- a/internal/component/prometheus/relabel/relabel_test.go
+++ b/internal/component/prometheus/relabel/relabel_test.go
@@ -113,6 +113,45 @@ func TestMetrics(t *testing.T) {
 	require.True(t, *(m.Counter.Value) == 1)
 }
 
+func BenchmarkCacheParallel(b *testing.B) {
+	fanout := prometheus.NewInterceptor(nil, prometheus.WithAppendHook(func(ref storage.SeriesRef, l labels.Labels, _ int64, _ float64, _ storage.Appender) (storage.SeriesRef, error) {
+		return ref, nil
+	}))
+	var entry storage.Appendable
+	_, err := New(component.Options{
+		ID:     "1",
+		Logger: util.TestAlloyLogger(b),
+		OnStateChange: func(e component.Exports) {
+			newE := e.(Exports)
+			entry = newE.Receiver
+		},
+		Registerer:     prom.NewRegistry(),
+		GetServiceData: getServiceData,
+	}, Arguments{
+		ForwardTo: []storage.Appendable{fanout},
+		MetricRelabelConfigs: []*alloy_relabel.Config{
+			{
+				SourceLabels: []string{"__address__"},
+				Regex:        alloy_relabel.Regexp(relabel.MustNewRegexp("(.+)")),
+				TargetLabel:  "new_label",
+				Replacement:  "new_value",
+				Action:       "replace",
+			},
+		},
+		CacheSize: 100_000,
+	})
+	require.NoError(b, err)
+
+	lbls := labels.FromStrings("__address__", "localhost")
+	b.RunParallel(func(pb *testing.PB) {
+		app := entry.Appender(b.Context())
+		for pb.Next() {
+			app.Append(0, lbls, time.Now().UnixMilli(), 0)
+		}
+		app.Commit()
+	})
+}
+
 func BenchmarkCache(b *testing.B) {
 	fanout := prometheus.NewInterceptor(nil, prometheus.WithAppendHook(func(ref storage.SeriesRef, l labels.Labels, _ int64, _ float64, _ storage.Appender) (storage.SeriesRef, error) {
 		require.True(b, l.Has("new_label"))


### PR DESCRIPTION
### Brief description of Pull Request

Remove `cacheMut`: The LRU cache was protected by both `c.mut` (outer read/write lock) and a separate `cacheMut`. The outer lock already serializes pointer replacement in `clearCache`, and `hashicorp/golang-lru/v2` is internally thread-safe for concurrent reads/writes. `cacheMut` was redundant.

### PR Checklist

- [x] Tests updated