### PR TITLE
ci: Add alloy-cd trigger-argo-workflow Action Invoked on Alloy Release Event 

### DIFF
--- a/.github/workflows/trigger-argo-workflow-on-tag.yml
+++ b/.github/workflows/trigger-argo-workflow-on-tag.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag (e.g., v1.14.0)'
+        description: 'Release tag (e.g. v1.14.0)'
         required: true
         default: ''
         type: string


### PR DESCRIPTION
### Pull Request Details
This PR introduces a workflow that will trigger the `alloy-cd` workflow on Alloy release/publish - it will exit early if `helm-chart/...` or `build-image/...` tags are detected

### Notes to the Reviewer
I tested this out in my own test repo [here](https://github.com/blewis12/test-project/actions), by commenting out the action action invocation and just logging the resolved tag, that [seems to work](https://github.com/blewis12/test-project/actions/runs/22630548081/job/65579125876)

Links to specific tests:
* I added some debug steps [here](https://github.com/blewis12/test-project/actions/runs/22631870213/job/65583936262) that print what would be passed to the argo workflow in the `Print ArgoCD Parameters` step, to me this looks correct 👍 
* I also tested out the validation step [here](https://github.com/blewis12/test-project/actions/runs/22631925054) - I don't think we'd encounter that sort of issue here but it's good to have just in case the first step mucks up and outputs a bad tag

I think it's ok to test this for real when for our v1.14.0 RC/R process, worst case this workflow fails in which case there aren't any side effects - and we can keep an eye on the first PR (auto-merging) that arrives in the `dev1` wave from this triggered workflow to make sure it's working as expected - if not, the workflow can be cancelled in the UI and the PR closed whilst I investigate