### PR TITLE
docs(otelcol.exporter.kafka): Update compression argument description for clarity

### DIFF
--- a/docs/sources/reference/components/otelcol/otelcol.exporter.kafka.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.kafka.md
@@ -200,7 +200,7 @@ The following arguments are supported:
 
 | Name                 | Type     | Description                                         | Default   | Required |
 | -------------------- | -------- | --------------------------------------------------- | --------- | -------- |
-| `compression`        | `string` | Time to wait between retries.                       | `"none"`  | no       |
+| `compression`        | `string` | The level of compression to use on messages.        | `"none"`  | no       |
 | `flush_max_messages` | `number` | Time to wait between retries.                       | `0`       | no       |
 | `max_message_bytes`  | `number` | The maximum permitted size of a message in bytes.   | `1000000` | no       |
 | `required_acks`      | `number` | Controls when a message is regarded as transmitted. | `1`       | no       |


### PR DESCRIPTION
### Brief description of Pull Request

Fix incorrect description for the `compression` argument in the `producer` block of `otelcol.exporter.kafka` documentation.

### Pull Request Details

The `compression` argument in the [`producer`](docs/sources/reference/components/otelcol/otelcol.exporter.kafka.md) block had a copy-paste error in its description — it read "Time to wait between retries." (which is the description for `flush_max_messages`) instead of the correct "The level of compression to use on messages."

This is a one-line documentation fix with no code changes.

### Issue(s) fixed by this Pull Request

Fixes #5705

### Notes to the Reviewer

Purely a documentation fix — no functional changes, no tests needed, no config converter changes needed.

### PR Checklist

- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated