### PR TITLE
feat(otelcol.receiver): Add awsfirehose receiver

### DIFF
--- a/collector/builder-config.yaml
+++ b/collector/builder-config.yaml
@@ -62,6 +62,7 @@ processors:
 receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.151.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver v0.151.0

--- a/collector/components.go
+++ b/collector/components.go
@@ -63,6 +63,7 @@ import (
 	memorylimiterprocessor "go.opentelemetry.io/collector/processor/memorylimiterprocessor"
 	awscloudwatchreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver"
 	awsecscontainermetricsreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver"
+	awsfirehosereceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver"
 	awss3receiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver"
 	cloudflarereceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver"
 	datadogreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver"
@@ -130,6 +131,7 @@ func components() (otelcol.Factories, error) {
 	factories.Receivers, err = otelcol.MakeFactoryMap[receiver.Factory](
 		awscloudwatchreceiver.NewFactory(),
 		awsecscontainermetricsreceiver.NewFactory(),
+		awsfirehosereceiver.NewFactory(),
 		awss3receiver.NewFactory(),
 		cloudflarereceiver.NewFactory(),
 		datadogreceiver.NewFactory(),
@@ -162,6 +164,7 @@ func components() (otelcol.Factories, error) {
 	factories.ReceiverModules = make(map[component.Type]string, len(factories.Receivers))
 	factories.ReceiverModules[awscloudwatchreceiver.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver v0.151.0"
 	factories.ReceiverModules[awsecscontainermetricsreceiver.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.151.0"
+	factories.ReceiverModules[awsfirehosereceiver.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver v0.151.0"
 	factories.ReceiverModules[awss3receiver.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver v0.151.0"
 	factories.ReceiverModules[cloudflarereceiver.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver v0.151.0"
 	factories.ReceiverModules[datadogreceiver.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver v0.151.0"

--- a/collector/go.mod
+++ b/collector/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.151.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver v0.151.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.151.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver v0.151.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver v0.151.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver v0.151.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver v0.151.0
@@ -722,6 +723,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.151.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension v0.151.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.151.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awscloudwatchmetricstreamsencodingextension v0.151.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension v0.151.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/internal/credentialsfile v0.151.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages v0.151.0 // indirect
@@ -763,6 +765,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/splunk v0.151.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin v0.151.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters v0.151.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/xstreamencoding v0.151.0 // indirect
 	github.com/opencontainers/cgroups v0.0.4 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect

--- a/collector/go.sum
+++ b/collector/go.sum
@@ -1826,6 +1826,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokena
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.151.0/go.mod h1:sbEBDxHUYJQXSi5lF9qR9kTpTvj78EjRZuu3qrEYhgY=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.151.0 h1:FLXTfvYK+xHJOh6SnKBPKRSWoHrHiuwhgfQMNKdYIJg=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.151.0/go.mod h1:Cl8N982myPvflJ83QSCL5sV06OnYM26Nufnaj1qbUPw=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awscloudwatchmetricstreamsencodingextension v0.151.0 h1:n65Fk/+BWC4lhopc/xjjKDPP9v3MLmti7xaeYgC+u4s=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awscloudwatchmetricstreamsencodingextension v0.151.0/go.mod h1:Hf694jjkI/8ThGvVEJ2xVF7V/E/t/xTiaI+Wnk4At84=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/otlpencodingextension v0.151.0 h1:YNx93HYS5N8NcnGBDVx8ZORE0ydYRPimI6QXJ3iX1aw=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/otlpencodingextension v0.151.0/go.mod h1:lXh4gADj7ehRSv3zoeelVjtKrUnmi41IwZkCQ+u/TSM=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension v0.151.0 h1:xuK4kJRGG6pcLsJRDl17Q1MWAzYqs3w1ATYrc2Q33Hw=
@@ -1936,6 +1938,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters v0
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters v0.151.0/go.mod h1:ZFmh3+9rgIfdarU+jnWnsPDhpfR/kbC7B5Mmg9aFzNg=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/xk8stest v0.151.0 h1:CXRtuNomQvEnvurJt21tii+2C6tP54j4CGiKq7fEUOI=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/xk8stest v0.151.0/go.mod h1:9TXqXV9mlgFnXSFV9rl7e7ufnQ51+WlfZMWQtT14J/I=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/xstreamencoding v0.151.0 h1:/aOZNvak6f9+V+mU7i08WnfXUUvdTipJUeTqEFX7j0I=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/xstreamencoding v0.151.0/go.mod h1:7qwTMOLYoj0OmQgorUzfo0j9IgU3Oo8/0hbdjQZ7y+E=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.151.0 h1:7pAo7CebNiz6CpFkVi/e+UfC1Rxi0ptq7PwxKMtDaj4=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.151.0/go.mod h1:KlxjuG7YKJmLjUOzeWdB1Ba+aPFGDQpXXCVYxOi0ZTQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.151.0 h1:calNsVIWKX5CJD9XQ0IrYVYi2IGi5W5H5/TBNcF1u54=
@@ -1968,6 +1972,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatch
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver v0.151.0/go.mod h1:j8x1p7RoG7O9Ft1qv8IGNWDYj3qGX5Ee4MsRYKYC350=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.151.0 h1:s5M9J5fYHUiMwYow2l+a1qkHqxIxbQEuFuIKmT7VSLg=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.151.0/go.mod h1:jV7GDoplubgVr8Yt71nFf84A6xm/wZaAxHpUjWTNQ4E=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver v0.151.0 h1:MhRTwdx+RnPAghQOoMAlTBwTjBpM4VNR6T+mR231bDI=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver v0.151.0/go.mod h1:hAa1/w1UK7pS7sc5tQqL7+mELWs5l13A6G8Eeh7td5s=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver v0.151.0 h1:0uPHgMYJbcfv4jYqRHxoxnwaqMcGcx2ZlhnM1bhgcRE=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver v0.151.0/go.mod h1:4saUJXLlOxLTvKZj2BqUhfsgKHAZ8MHOGxbCgF5LJi4=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver v0.151.0 h1:O/yL9kgRKzzKaObthbwxHNZg4x+/mhYnCVu/kacNvOU=

--- a/docs/sources/reference/compatibility/_index.md
+++ b/docs/sources/reference/compatibility/_index.md
@@ -397,6 +397,7 @@ The following components, grouped by namespace, _consume_ OpenTelemetry `otelcol
 - [otelcol.processor.transform](../components/otelcol/otelcol.processor.transform)
 - [otelcol.receiver.awscloudwatch](../components/otelcol/otelcol.receiver.awscloudwatch)
 - [otelcol.receiver.awsecscontainermetrics](../components/otelcol/otelcol.receiver.awsecscontainermetrics)
+- [otelcol.receiver.awsfirehose](../components/otelcol/otelcol.receiver.awsfirehose)
 - [otelcol.receiver.awss3](../components/otelcol/otelcol.receiver.awss3)
 - [otelcol.receiver.cloudflare](../components/otelcol/otelcol.receiver.cloudflare)
 - [otelcol.receiver.datadog](../components/otelcol/otelcol.receiver.datadog)

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.awsfirehose.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.awsfirehose.md
@@ -40,26 +40,28 @@ otelcol.receiver.awsfirehose "<LABEL>" {
 
 You can use the following arguments with `otelcol.receiver.awsfirehose`:
 
-| Name                      | Type           | Description                                                                | Default                                                     | Required |
-|---------------------------|----------------|----------------------------------------------------------------------------|-------------------------------------------------------------|----------|
-| `access_key`              | `secret`       | The access key to be checked on each request received.                     |                                                             | no       |
-| `compression_algorithms`  | `list(string)` | A list of compression algorithms the server can accept.                    | `["", "gzip", "zstd", "zlib", "snappy", "deflate", "lz4"]` | no       |
-| `encoding`                | `string`       | Encoding of Firehose records.                                              |                                                             | no       |
-| `endpoint`                | `string`       | `host:port` to listen for traffic on.                                      | `"0.0.0.0:4433"`                                            | no       |
-| `include_metadata`        | `bool`         | Propagate incoming connection metadata to downstream consumers.            | `false`                                                     | no       |
-| `keep_alives_enabled`     | `boolean`      | Whether or not HTTP keep-alives are enabled.                               | `true`                                                      | no       |
-| `max_request_body_size`   | `string`       | Maximum request body size the HTTP server will allow. No limit when unset. |                                                             | no       |
+| Name                     | Type           | Description                                                            | Default                                                    | Required |
+| ------------------------ | -------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------- | -------- |
+| `access_key`             | `secret`       | The access key to be checked on each request received.                 |                                                            | no       |
+| `compression_algorithms` | `list(string)` | A list of compression algorithms the server can accept.                | `["", "gzip", "zstd", "zlib", "snappy", "deflate", "lz4"]` | no       |
+| `encoding`               | `string`       | Encoding of Data Firehose records.                                     |                                                            | no       |
+| `endpoint`               | `string`       | `host:port` to listen for traffic on.                                  | `"0.0.0.0:4433"`                                           | no       |
+| `include_metadata`       | `bool`         | Propagate incoming connection metadata to downstream consumers.        | `false`                                                    | no       |
+| `keep_alives_enabled`    | `boolean`      | Whether or not HTTP keep-alives are enabled.                           | `true`                                                     | no       |
+| `max_request_body_size`  | `string`       | Maximum request body size the HTTP server allows. No limit when unset. |                                                            | no       |
 
-`access_key` can be set when creating or updating the delivery stream. See the [AWS Firehose documentation](https://docs.aws.amazon.com/firehose/latest/dev/create-destination.html#create-destination-http) for more details.
-Although the generic `auth` argument is available, it isn't needed here. AWS Firehose authenticates by sending an `access_key` in each request, making `access_key` the recommended way to secure this receiver.
+You can set `access_key` when creating or updating the delivery stream.
+Refer to the [AWS Data Firehose documentation](https://docs.aws.amazon.com/firehose/latest/dev/create-destination.html#create-destination-http) for more information.
+Although the generic `auth` argument is available, it isn't needed here.
+AWS Data Firehose authenticates by sending an `access_key` in each request, making `access_key` the recommended way to secure this receiver.
 
-If `encoding` is not set, the receiver defaults to a signal-specific encoding: `cwmetrics` for metrics and `cwlogs` for logs.
+If `encoding` isn't set, the receiver defaults to a signal-specific encoding: `cwmetrics` for metrics and `cwlogs` for logs.
 
 The supported values for `encoding` are:
 
-* `cwmetrics`: The JSON encoding for CloudWatch metric streams (metrics only). See the [CloudWatch metric stream JSON documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-metric-streams-formats-json.html) for details.
-* `otlp_v1`: The OpenTelemetry 1.0.0 encoding for CloudWatch metric streams (metrics only). See the [CloudWatch metric streams OpenTelemetry documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-metric-streams-formats-opentelemetry-100.html) for details.
-* `cwlogs`: The encoding for CloudWatch log streams delivered via Firehose (logs only). See the [CloudWatch Logs via Firehose documentation](https://docs.aws.amazon.com/firehose/latest/dev/writing-with-cloudwatch-logs.html) for details.
+* `cwmetrics`: The JSON encoding for CloudWatch metric streams. This encoding applies to metrics only. Refer to the [CloudWatch metric stream JSON documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-metric-streams-formats-json.html) for more information.
+* `otlp_v1`: The OpenTelemetry 1.0.0 encoding for CloudWatch metric streams. This encoding applies to metrics only. Refer to the [CloudWatch metric streams OpenTelemetry documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-metric-streams-formats-opentelemetry-100.html) for more information.
+* `cwlogs`: The encoding for CloudWatch log streams delivered through Data Firehose. This encoding applies to logs only. Refer to the [CloudWatch Logs through Data Firehose documentation](https://docs.aws.amazon.com/firehose/latest/dev/writing-with-cloudwatch-logs.html) for more information.
 
 ## Blocks
 
@@ -143,7 +145,7 @@ information.
 
 ## Example
 
-This example forwards received metrics through a batch processor before finally sending it to an OTLP-capable endpoint:
+This example forwards received metrics through a batch processor before sending them to an OTLP-capable endpoint:
 
 ```alloy
 otelcol.receiver.awsfirehose "default" {

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.awsfirehose.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.awsfirehose.md
@@ -1,0 +1,182 @@
+---
+canonical: https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.receiver.awsfirehose/
+description: Learn about otelcol.receiver.awsfirehose
+labels:
+  stage: experimental
+  products:
+    - oss
+title: otelcol.receiver.awsfirehose
+---
+
+# `otelcol.receiver.awsfirehose`
+
+{{< docs/shared lookup="stability/experimental.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+`otelcol.receiver.awsfirehose` receives metrics and logs from Amazon Data Firehose and forwards them to other `otelcol.*` components.
+
+Make sure the receiver is accessible by AWS on port 443.
+
+You can specify multiple `otelcol.receiver.awsfirehose` components by giving them different labels.
+
+{{< admonition type="note" >}}
+`otelcol.receiver.awsfirehose` is a wrapper over the upstream OpenTelemetry Collector [`awsfirehose`][] receiver.
+Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`awsfirehose`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/receiver/awsfirehose
+{{< /admonition >}}
+
+## Usage
+
+```alloy
+otelcol.receiver.awsfirehose "<LABEL>" {
+  endpoint = "HOST:PORT"
+  output {
+    metrics = [...]
+  }
+}
+```
+
+## Arguments
+
+You can use the following arguments with `otelcol.receiver.awsfirehose`:
+
+| Name                      | Type           | Description                                                                | Default                                                     | Required |
+|---------------------------|----------------|----------------------------------------------------------------------------|-------------------------------------------------------------|----------|
+| `access_key`              | `secret`       | The access key to be checked on each request received.                     |                                                             | no       |
+| `compression_algorithms`  | `list(string)` | A list of compression algorithms the server can accept.                    | `["", "gzip", "zstd", "zlib", "snappy", "deflate", "lz4"]` | no       |
+| `encoding`                | `string`       | Encoding of Firehose records.                                              |                                                             | no       |
+| `endpoint`                | `string`       | `host:port` to listen for traffic on.                                      | `"0.0.0.0:4433"`                                            | no       |
+| `include_metadata`        | `bool`         | Propagate incoming connection metadata to downstream consumers.            | `false`                                                     | no       |
+| `keep_alives_enabled`     | `boolean`      | Whether or not HTTP keep-alives are enabled.                               | `true`                                                      | no       |
+| `max_request_body_size`   | `string`       | Maximum request body size the HTTP server will allow. No limit when unset. |                                                             | no       |
+
+`access_key` can be set when creating or updating the delivery stream. See the [AWS Firehose documentation](https://docs.aws.amazon.com/firehose/latest/dev/create-destination.html#create-destination-http) for more details.
+Although the generic `auth` argument is available, it isn't needed here. AWS Firehose authenticates by sending an `access_key` in each request, making `access_key` the recommended way to secure this receiver.
+
+If `encoding` is not set, the receiver defaults to a signal-specific encoding: `cwmetrics` for metrics and `cwlogs` for logs.
+
+The supported values for `encoding` are:
+
+* `cwmetrics`: The JSON encoding for CloudWatch metric streams (metrics only). See the [CloudWatch metric stream JSON documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-metric-streams-formats-json.html) for details.
+* `otlp_v1`: The OpenTelemetry 1.0.0 encoding for CloudWatch metric streams (metrics only). See the [CloudWatch metric streams OpenTelemetry documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-metric-streams-formats-opentelemetry-100.html) for details.
+* `cwlogs`: The encoding for CloudWatch log streams delivered via Firehose (logs only). See the [CloudWatch Logs via Firehose documentation](https://docs.aws.amazon.com/firehose/latest/dev/writing-with-cloudwatch-logs.html) for details.
+
+## Blocks
+
+You can use the following blocks with `otelcol.receiver.awsfirehose`:
+
+| Block                            | Description                                                                | Required |
+| -------------------------------- | -------------------------------------------------------------------------- | -------- |
+| [`output`][output]               | Configures where to send received telemetry data.                          | yes      |
+| [`cors`][cors]                   | Configures CORS for the HTTP server.                                       | no       |
+| [`debug_metrics`][debug_metrics] | Configures the metrics that this component generates to monitor its state. | no       |
+| [`tls`][tls]                     | Configures TLS for the HTTP server.                                        | no       |
+| `tls` > [`tpm`][tpm]             | Configures TPM settings for the TLS `key_file`.                            | no       |
+
+The > symbol indicates deeper levels of nesting.
+For example, `tls` > `tpm` refers to a `tpm` block defined inside a `tls` block.
+
+[tls]: #tls
+[tpm]: #tpm
+[cors]: #cors
+[debug_metrics]: #debug_metrics
+[output]: #output
+
+### `output`
+
+{{< badge text="Required" >}}
+
+{{< docs/shared lookup="reference/components/output-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `cors`
+
+The `cors` block configures CORS settings for an HTTP server.
+
+The following arguments are supported:
+
+| Name              | Type           | Description                                              | Default                | Required |
+|-------------------|----------------|----------------------------------------------------------|------------------------|----------|
+| `allowed_origins` | `list(string)` | Allowed values for the `Origin` header.                  | `[]`                   | no       |
+| `allowed_headers` | `list(string)` | Accepted headers from CORS requests.                     | `["X-Requested-With"]` | no       |
+| `max_age`         | `number`       | Configures the `Access-Control-Max-Age` response header. | `0`                    | no       |
+
+The `allowed_headers` argument specifies which headers are acceptable from a CORS request.
+The following headers are always implicitly allowed:
+
+* `Accept`
+* `Accept-Language`
+* `Content-Type`
+* `Content-Language`
+
+If `allowed_headers` includes `"*"`, all headers are permitted.
+
+### `debug_metrics`
+
+{{< docs/shared lookup="reference/components/otelcol-debug-metrics-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `tls`
+
+The `tls` block configures TLS settings used for a server.
+If the `tls` block isn't provided, TLS won't be used for connections to the server.
+
+{{< docs/shared lookup="reference/components/otelcol-tls-server-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `tpm`
+
+The `tpm` block configures retrieving the TLS `key_file` from a trusted device.
+
+{{< docs/shared lookup="reference/components/otelcol-tls-tpm-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+## Exported fields
+
+`otelcol.receiver.awsfirehose` doesn't export any fields.
+
+## Component health
+
+`otelcol.receiver.awsfirehose` is only reported as unhealthy if given an invalid
+configuration.
+
+## Debug information
+
+`otelcol.receiver.awsfirehose` doesn't expose any component-specific debug
+information.
+
+## Example
+
+This example forwards received metrics through a batch processor before finally sending it to an OTLP-capable endpoint:
+
+```alloy
+otelcol.receiver.awsfirehose "default" {
+  endpoint = "0.0.0.0:4433"
+  output {
+    metrics = [otelcol.processor.batch.default.input]
+  }
+}
+
+otelcol.processor.batch "default" {
+  output {
+    metrics = [otelcol.exporter.otlphttp.default.input]
+  }
+}
+
+otelcol.exporter.otlphttp "default" {
+  client {
+    endpoint = sys.env("OTLP_ENDPOINT")
+  }
+}
+```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.receiver.awsfirehose` can accept arguments from the following components:
+
+- Components that export [OpenTelemetry `otelcol.Consumer`](../../../compatibility/#opentelemetry-otelcolconsumer-exporters)
+
+
+{{< admonition type="note" >}}
+Connecting some components may not be sensible or components may require further configuration to make the connection work correctly.
+Refer to the linked documentation for more details.
+{{< /admonition >}}
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/go.mod
+++ b/go.mod
@@ -160,6 +160,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.151.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver v0.151.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.151.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver v0.151.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver v0.151.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver v0.151.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver v0.151.0
@@ -1090,7 +1091,9 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/nwaples/rardecode/v2 v2.2.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awscloudwatchmetricstreamsencodingextension v0.151.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/internal/credentialsfile v0.151.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/xstreamencoding v0.151.0 // indirect
 	github.com/opencontainers/cgroups v0.0.4 // indirect
 	github.com/outscale/osc-sdk-go/v2 v2.34.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1884,6 +1884,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokena
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.151.0/go.mod h1:sbEBDxHUYJQXSi5lF9qR9kTpTvj78EjRZuu3qrEYhgY=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.151.0 h1:FLXTfvYK+xHJOh6SnKBPKRSWoHrHiuwhgfQMNKdYIJg=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.151.0/go.mod h1:Cl8N982myPvflJ83QSCL5sV06OnYM26Nufnaj1qbUPw=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awscloudwatchmetricstreamsencodingextension v0.151.0 h1:n65Fk/+BWC4lhopc/xjjKDPP9v3MLmti7xaeYgC+u4s=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awscloudwatchmetricstreamsencodingextension v0.151.0/go.mod h1:Hf694jjkI/8ThGvVEJ2xVF7V/E/t/xTiaI+Wnk4At84=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/otlpencodingextension v0.151.0 h1:YNx93HYS5N8NcnGBDVx8ZORE0ydYRPimI6QXJ3iX1aw=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/otlpencodingextension v0.151.0/go.mod h1:lXh4gADj7ehRSv3zoeelVjtKrUnmi41IwZkCQ+u/TSM=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension v0.151.0 h1:xuK4kJRGG6pcLsJRDl17Q1MWAzYqs3w1ATYrc2Q33Hw=
@@ -1970,6 +1972,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin 
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin v0.151.0/go.mod h1:bf/wlST1CMEdgwjrDWHQtxHVahrKFRBiE3piOQEkgK8=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/xk8stest v0.151.0 h1:CXRtuNomQvEnvurJt21tii+2C6tP54j4CGiKq7fEUOI=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/xk8stest v0.151.0/go.mod h1:9TXqXV9mlgFnXSFV9rl7e7ufnQ51+WlfZMWQtT14J/I=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/xstreamencoding v0.151.0 h1:/aOZNvak6f9+V+mU7i08WnfXUUvdTipJUeTqEFX7j0I=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/xstreamencoding v0.151.0/go.mod h1:7qwTMOLYoj0OmQgorUzfo0j9IgU3Oo8/0hbdjQZ7y+E=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.151.0 h1:7pAo7CebNiz6CpFkVi/e+UfC1Rxi0ptq7PwxKMtDaj4=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.151.0/go.mod h1:KlxjuG7YKJmLjUOzeWdB1Ba+aPFGDQpXXCVYxOi0ZTQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.151.0 h1:calNsVIWKX5CJD9XQ0IrYVYi2IGi5W5H5/TBNcF1u54=
@@ -2000,6 +2004,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatch
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver v0.151.0/go.mod h1:j8x1p7RoG7O9Ft1qv8IGNWDYj3qGX5Ee4MsRYKYC350=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.151.0 h1:s5M9J5fYHUiMwYow2l+a1qkHqxIxbQEuFuIKmT7VSLg=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.151.0/go.mod h1:jV7GDoplubgVr8Yt71nFf84A6xm/wZaAxHpUjWTNQ4E=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver v0.151.0 h1:MhRTwdx+RnPAghQOoMAlTBwTjBpM4VNR6T+mR231bDI=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver v0.151.0/go.mod h1:hAa1/w1UK7pS7sc5tQqL7+mELWs5l13A6G8Eeh7td5s=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver v0.151.0 h1:0uPHgMYJbcfv4jYqRHxoxnwaqMcGcx2ZlhnM1bhgcRE=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver v0.151.0/go.mod h1:4saUJXLlOxLTvKZj2BqUhfsgKHAZ8MHOGxbCgF5LJi4=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver v0.151.0 h1:O/yL9kgRKzzKaObthbwxHNZg4x+/mhYnCVu/kacNvOU=

--- a/internal/component/all/all.go
+++ b/internal/component/all/all.go
@@ -109,6 +109,7 @@ import (
 	_ "github.com/grafana/alloy/internal/component/otelcol/processor/transform"              // Import otelcol.processor.transform
 	_ "github.com/grafana/alloy/internal/component/otelcol/receiver/awscloudwatch"           // Import otelcol.receiver.awscloudwatch
 	_ "github.com/grafana/alloy/internal/component/otelcol/receiver/awsecscontainermetrics"  // Import otelcol.receiver.awsecscontainermetrics
+	_ "github.com/grafana/alloy/internal/component/otelcol/receiver/awsfirehose"             // Import otelcol.receiver.awsfirehose
 	_ "github.com/grafana/alloy/internal/component/otelcol/receiver/awss3"                   // Import otelcol.receiver.awss3
 	_ "github.com/grafana/alloy/internal/component/otelcol/receiver/cloudflare"              // Import otelcol.receiver.cloudflare
 	_ "github.com/grafana/alloy/internal/component/otelcol/receiver/datadog"                 // Import otelcol.receiver.datadog

--- a/internal/component/otelcol/receiver/awsfirehose/awsfirehose.go
+++ b/internal/component/otelcol/receiver/awsfirehose/awsfirehose.go
@@ -1,0 +1,96 @@
+// Package awsfirehose provides an otelcol.receiver.awsfirehose component.
+package awsfirehose
+
+import (
+	"github.com/grafana/alloy/internal/component"
+	"github.com/grafana/alloy/internal/component/otelcol"
+	otelcolCfg "github.com/grafana/alloy/internal/component/otelcol/config"
+	"github.com/grafana/alloy/internal/component/otelcol/receiver"
+	"github.com/grafana/alloy/internal/featuregate"
+	"github.com/grafana/alloy/syntax/alloytypes"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver"
+	otelcomponent "go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configopaque"
+	"go.opentelemetry.io/collector/pipeline"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:      "otelcol.receiver.awsfirehose",
+		Stability: featuregate.StabilityExperimental,
+		Args:      Arguments{},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			fact := awsfirehosereceiver.NewFactory()
+			return receiver.New(opts, fact, args.(Arguments))
+		},
+	})
+}
+
+// Arguments configures the otelcol.receiver.awsfirehose component.
+type Arguments struct {
+	// Encoding identifies the encoding of records received from
+	// Firehose. Defaults to telemetry-specific encodings: "cwlog"
+	// for logs, and "cwmetrics" for metrics.
+	Encoding string `alloy:"encoding,attr,optional"`
+
+	// The access key to be checked on each request received.
+	AccessKey alloytypes.Secret `alloy:"access_key,attr,optional"`
+
+	HTTPServer otelcol.HTTPServerArguments `alloy:",squash"`
+
+	// DebugMetrics configures component internal metrics. Optional.
+	DebugMetrics otelcolCfg.DebugMetricsArguments `alloy:"debug_metrics,block,optional"`
+
+	// Output configures where to send received data. Required.
+	Output *otelcol.ConsumerArguments `alloy:"output,block"`
+}
+
+var _ receiver.Arguments = Arguments{}
+
+// DefaultArguments holds default settings for otelcol.receiver.awsfirehose.
+var DefaultArguments = Arguments{
+	Encoding: "cwmetrics",
+	HTTPServer: otelcol.HTTPServerArguments{
+		Endpoint: "0.0.0.0:4433",
+	},
+}
+
+// SetToDefault implements syntax.Defaulter.
+func (args *Arguments) SetToDefault() {
+	*args = DefaultArguments
+	args.DebugMetrics.SetToDefault()
+}
+
+// Convert implements receiver.Arguments.
+func (args Arguments) Convert() (otelcomponent.Config, error) {
+	httpServerConfig, err := args.HTTPServer.ConvertToPtr()
+	if err != nil {
+		return nil, err
+	}
+	return &awsfirehosereceiver.Config{
+		Encoding:     args.Encoding,
+		AccessKey:    configopaque.String(args.AccessKey),
+		ServerConfig: *httpServerConfig,
+	}, nil
+}
+
+// Extensions implements receiver.Arguments.
+func (args Arguments) Extensions() map[otelcomponent.ID]otelcomponent.Component {
+	return args.HTTPServer.Extensions()
+}
+
+// Exporters implements receiver.Arguments.
+func (args Arguments) Exporters() map[pipeline.Signal]map[otelcomponent.ID]otelcomponent.Component {
+	return nil
+}
+
+// NextConsumers implements receiver.Arguments.
+func (args Arguments) NextConsumers() *otelcol.ConsumerArguments {
+	return args.Output
+}
+
+// DebugMetricsConfig implements receiver.Arguments.
+func (args Arguments) DebugMetricsConfig() otelcolCfg.DebugMetricsArguments {
+	return args.DebugMetrics
+}

--- a/internal/component/otelcol/receiver/awsfirehose/awsfirehose.go
+++ b/internal/component/otelcol/receiver/awsfirehose/awsfirehose.go
@@ -52,7 +52,8 @@ var _ receiver.Arguments = Arguments{}
 var DefaultArguments = Arguments{
 	Encoding: "cwmetrics",
 	HTTPServer: otelcol.HTTPServerArguments{
-		Endpoint: "0.0.0.0:4433",
+		Endpoint:              "0.0.0.0:4433",
+		CompressionAlgorithms: append([]string(nil), otelcol.DefaultCompressionAlgorithms...),
 	},
 }
 

--- a/internal/component/otelcol/receiver/awsfirehose/awsfirehose.go
+++ b/internal/component/otelcol/receiver/awsfirehose/awsfirehose.go
@@ -48,18 +48,15 @@ type Arguments struct {
 
 var _ receiver.Arguments = Arguments{}
 
-// DefaultArguments holds default settings for otelcol.receiver.awsfirehose.
-var DefaultArguments = Arguments{
-	Encoding: "cwmetrics",
-	HTTPServer: otelcol.HTTPServerArguments{
-		Endpoint:              "0.0.0.0:4433",
-		CompressionAlgorithms: append([]string(nil), otelcol.DefaultCompressionAlgorithms...),
-	},
-}
-
 // SetToDefault implements syntax.Defaulter.
 func (args *Arguments) SetToDefault() {
-	*args = DefaultArguments
+	*args = Arguments{
+		Encoding: "cwmetrics",
+		HTTPServer: otelcol.HTTPServerArguments{
+			Endpoint:              "0.0.0.0:4433",
+			CompressionAlgorithms: append([]string(nil), otelcol.DefaultCompressionAlgorithms...),
+		},
+	}
 	args.DebugMetrics.SetToDefault()
 }
 

--- a/internal/component/otelcol/receiver/awsfirehose/awsfirehose_test.go
+++ b/internal/component/otelcol/receiver/awsfirehose/awsfirehose_test.go
@@ -1,0 +1,133 @@
+package awsfirehose_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	otelcolCfg "github.com/grafana/alloy/internal/component/otelcol/config"
+	"github.com/grafana/alloy/internal/component/otelcol/receiver/awsfirehose"
+	"github.com/grafana/alloy/internal/runtime/componenttest"
+	"github.com/grafana/alloy/internal/util"
+	"github.com/grafana/alloy/syntax"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRun(t *testing.T) {
+	httpAddr := componenttest.GetFreeAddr(t)
+
+	ctx := componenttest.TestContext(t)
+	l := util.TestLogger(t)
+
+	ctrl, err := componenttest.NewControllerFromID(l, "otelcol.receiver.awsfirehose")
+	require.NoError(t, err)
+
+	cfg := fmt.Sprintf(`
+		endpoint = "%s"
+
+		output { /* no-op */ }
+	`, httpAddr)
+
+	var args awsfirehose.Arguments
+	require.NoError(t, syntax.Unmarshal([]byte(cfg), &args))
+
+	go func() {
+		err := ctrl.Run(ctx, args)
+		require.NoError(t, err)
+	}()
+
+	require.NoError(t, ctrl.WaitRunning(time.Second))
+}
+
+func TestArguments_UnmarshalAlloy(t *testing.T) {
+	t.Run("http", func(t *testing.T) {
+		httpAddr := componenttest.GetFreeAddr(t)
+		in := fmt.Sprintf(`
+		endpoint = "%s"
+		cors {
+			allowed_origins = ["https://*.test.com", "https://test.com"]
+		}
+
+		encoding = "cwmetrics"
+
+		debug_metrics {
+			disable_high_cardinality_metrics = true
+		}
+
+		output { /* no-op */ }
+		`, httpAddr)
+
+		var args awsfirehose.Arguments
+		require.NoError(t, syntax.Unmarshal([]byte(in), &args))
+		require.Equal(t, args.DebugMetricsConfig().DisableHighCardinalityMetrics, true)
+		ext, err := args.Convert()
+		require.NoError(t, err)
+		otelArgs, ok := (ext).(*awsfirehosereceiver.Config)
+
+		require.True(t, ok)
+
+		// Check the arguments
+		require.Equal(t, otelArgs.ServerConfig.Endpoint, httpAddr)
+		require.Equal(t, len(otelArgs.ServerConfig.CORS.Get().AllowedOrigins), 2)
+		require.Equal(t, otelArgs.ServerConfig.CORS.Get().AllowedOrigins[0], "https://*.test.com")
+		require.Equal(t, otelArgs.ServerConfig.CORS.Get().AllowedOrigins[1], "https://test.com")
+		require.Equal(t, otelArgs.Encoding, "cwmetrics")
+	})
+}
+
+func TestDebugMetricsConfig(t *testing.T) {
+	tests := []struct {
+		testName string
+		alloyCfg string
+		expected otelcolCfg.DebugMetricsArguments
+	}{
+		{
+			testName: "default",
+			alloyCfg: `
+			output {}
+			`,
+			expected: otelcolCfg.DebugMetricsArguments{
+				DisableHighCardinalityMetrics: true,
+				Level:                         otelcolCfg.LevelDetailed,
+			},
+		},
+		{
+			testName: "explicit_false",
+			alloyCfg: `
+			debug_metrics {
+				disable_high_cardinality_metrics = false
+			}
+			output {}
+			`,
+			expected: otelcolCfg.DebugMetricsArguments{
+				DisableHighCardinalityMetrics: false,
+				Level:                         otelcolCfg.LevelDetailed,
+			},
+		},
+		{
+			testName: "explicit_true",
+			alloyCfg: `
+			debug_metrics {
+				disable_high_cardinality_metrics = true
+			}
+			output {}
+			`,
+			expected: otelcolCfg.DebugMetricsArguments{
+				DisableHighCardinalityMetrics: true,
+				Level:                         otelcolCfg.LevelDetailed,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			var args awsfirehose.Arguments
+			require.NoError(t, syntax.Unmarshal([]byte(tc.alloyCfg), &args))
+			_, err := args.Convert()
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expected, args.DebugMetricsConfig())
+		})
+	}
+}

--- a/internal/component/otelcol/receiver/awsfirehose/awsfirehose_test.go
+++ b/internal/component/otelcol/receiver/awsfirehose/awsfirehose_test.go
@@ -68,7 +68,7 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 		require.True(t, ok)
 
 		// Check the arguments
-		require.Equal(t, otelArgs.ServerConfig.Endpoint, httpAddr)
+		require.Equal(t, otelArgs.ServerConfig.NetAddr.Endpoint, httpAddr)
 		require.Equal(t, len(otelArgs.ServerConfig.CORS.Get().AllowedOrigins), 2)
 		require.Equal(t, otelArgs.ServerConfig.CORS.Get().AllowedOrigins[0], "https://*.test.com")
 		require.Equal(t, otelArgs.ServerConfig.CORS.Get().AllowedOrigins[1], "https://test.com")

--- a/internal/converter/internal/otelcolconvert/converter_awsfirehosereceiver.go
+++ b/internal/converter/internal/otelcolconvert/converter_awsfirehosereceiver.go
@@ -1,0 +1,65 @@
+package otelcolconvert
+
+import (
+	"fmt"
+
+	"github.com/grafana/alloy/internal/component/otelcol"
+	"github.com/grafana/alloy/internal/component/otelcol/receiver/awsfirehose"
+	"github.com/grafana/alloy/internal/converter/diag"
+	"github.com/grafana/alloy/internal/converter/internal/common"
+	"github.com/grafana/alloy/syntax/alloytypes"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componentstatus"
+	"go.opentelemetry.io/collector/pipeline"
+)
+
+func init() {
+	converters = append(converters, awsFirehoseReceiverConverter{})
+}
+
+type awsFirehoseReceiverConverter struct{}
+
+func (awsFirehoseReceiverConverter) Factory() component.Factory {
+	return awsfirehosereceiver.NewFactory()
+}
+
+func (awsFirehoseReceiverConverter) InputComponentName() string { return "" }
+
+func (awsFirehoseReceiverConverter) ConvertAndAppend(state *State, id componentstatus.InstanceID, cfg component.Config) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	label := state.AlloyComponentLabel()
+
+	args := toAWSFirehoseReceiver(state, id, cfg.(*awsfirehosereceiver.Config))
+	block := common.NewBlockWithOverride([]string{"otelcol", "receiver", "awsfirehose"}, label, args)
+
+	diags.Add(
+		diag.SeverityLevelInfo,
+		fmt.Sprintf("Converted %s into %s", StringifyInstanceID(id), StringifyBlock(block)),
+	)
+
+	state.Body().AppendBlock(block)
+	return diags
+}
+
+func toAWSFirehoseReceiver(state *State, id componentstatus.InstanceID, cfg *awsfirehosereceiver.Config) *awsfirehose.Arguments {
+	var (
+		nextMetrics = state.Next(id, pipeline.SignalMetrics)
+		nextLogs    = state.Next(id, pipeline.SignalLogs)
+	)
+
+	return &awsfirehose.Arguments{
+		Encoding:  cfg.Encoding,
+		AccessKey: alloytypes.Secret(cfg.AccessKey),
+
+		HTTPServer: *toHTTPServerArguments(&cfg.ServerConfig),
+
+		DebugMetrics: common.DefaultValue[awsfirehose.Arguments]().DebugMetrics,
+
+		Output: &otelcol.ConsumerArguments{
+			Metrics: ToTokenizedConsumers(nextMetrics),
+			Logs:    ToTokenizedConsumers(nextLogs),
+		},
+	}
+}

--- a/internal/converter/internal/otelcolconvert/testdata/awsfirehose.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/awsfirehose.alloy
@@ -1,0 +1,23 @@
+otelcol.receiver.awsfirehose "default_metrics" {
+	access_key = "mysecretkey"
+
+	output {
+		metrics = [otelcol.exporter.otlp.default.input]
+	}
+}
+
+otelcol.receiver.awsfirehose "default_logs" {
+	encoding   = "cwlogs"
+	access_key = "mysecretkey"
+	endpoint   = "0.0.0.0:4434"
+
+	output {
+		logs = [otelcol.exporter.otlp.default.input]
+	}
+}
+
+otelcol.exporter.otlp "default" {
+	client {
+		endpoint = "database:4317"
+	}
+}

--- a/internal/converter/internal/otelcolconvert/testdata/awsfirehose.yaml
+++ b/internal/converter/internal/otelcolconvert/testdata/awsfirehose.yaml
@@ -1,0 +1,24 @@
+receivers:
+  awsfirehose/metrics:
+    endpoint: 0.0.0.0:4433
+    encoding: cwmetrics
+    access_key: mysecretkey
+  awsfirehose/logs:
+    endpoint: 0.0.0.0:4434
+    encoding: cwlogs
+    access_key: mysecretkey
+
+exporters:
+  otlp:
+    endpoint: database:4317
+
+service:
+  pipelines:
+    metrics:
+      receivers: [awsfirehose/metrics]
+      processors: []
+      exporters: [otlp]
+    logs:
+      receivers: [awsfirehose/logs]
+      processors: []
+      exporters: [otlp]


### PR DESCRIPTION
### Brief description of Pull Request
Adding an `otelcol.receiver.awsfirehose` component that receives AWS CloudWatch logs and metrics streamed via Amazon Data Firehose.

### Issue(s) fixed by this Pull Request
Fixes #287

### Notes to the Reviewer
This PR is based on work done for grafana/agent, but it seems it didn't make the move to Alloy. See https://github.com/grafana/agent/pull/6005

I tried to keep as much of the original PR intact as possible, while adapting it to Alloy and the new patterns found in the other otelcol receivers.


### PR Checklist

- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated