### PR TITLE
test: Fix several flaky tests

### DIFF
--- a/internal/component/common/loki/client/shards.go
+++ b/internal/component/common/loki/client/shards.go
@@ -283,9 +283,12 @@ func (s *shards) start(n int) {
 	s.done = make(chan struct{})
 	s.softShutdown = make(chan struct{})
 
+	var started sync.WaitGroup
+	started.Add(n)
 	for i := range n {
-		go s.runShard(s.queues[i])
+		go s.runShard(s.queues[i], &started)
 	}
+	started.Wait()
 }
 
 // stop tries to perform a graceful shutdown of all shards.
@@ -317,7 +320,11 @@ func (s *shards) stop() {
 }
 
 // runShard is the worker goroutine that processes batches from a single queue.
-func (s *shards) runShard(q *queue) {
+func (s *shards) runShard(q *queue, started *sync.WaitGroup) {
+	if started != nil {
+		started.Done()
+	}
+
 	// Given that a shard handles multiple batches (1 per tenant) and each batch
 	// can be created at a different point in time, we look for batches whose
 	// max wait time has been reached every 10 times per BatchWait, so that the

--- a/internal/component/common/loki/client/shards.go
+++ b/internal/component/common/loki/client/shards.go
@@ -283,12 +283,9 @@ func (s *shards) start(n int) {
 	s.done = make(chan struct{})
 	s.softShutdown = make(chan struct{})
 
-	var started sync.WaitGroup
-	started.Add(n)
 	for i := range n {
-		go s.runShard(s.queues[i], &started)
+		go s.runShard(s.queues[i])
 	}
-	started.Wait()
 }
 
 // stop tries to perform a graceful shutdown of all shards.
@@ -320,11 +317,7 @@ func (s *shards) stop() {
 }
 
 // runShard is the worker goroutine that processes batches from a single queue.
-func (s *shards) runShard(q *queue, started *sync.WaitGroup) {
-	if started != nil {
-		started.Done()
-	}
-
+func (s *shards) runShard(q *queue) {
 	// Given that a shard handles multiple batches (1 per tenant) and each batch
 	// can be created at a different point in time, we look for batches whose
 	// max wait time has been reached every 10 times per BatchWait, so that the

--- a/internal/component/loki/secretfilter/secretfilter.go
+++ b/internal/component/loki/secretfilter/secretfilter.go
@@ -110,6 +110,7 @@ type Component struct {
 	debugDataPublisher livedebugging.DebugDataPublisher
 }
 
+//nolint:staticcheck // DetectContext still requires detect.Fragment in gitleaks v8
 type secretDetector interface {
 	DetectContext(ctx context.Context, fragment detect.Fragment) []report.Finding
 }

--- a/internal/component/loki/secretfilter/secretfilter.go
+++ b/internal/component/loki/secretfilter/secretfilter.go
@@ -98,7 +98,7 @@ type Component struct {
 	args     Arguments
 	receiver loki.LogsReceiver
 	fanout   []loki.LogsReceiver
-	detector *detect.Detector
+	detector secretDetector
 
 	// redactPercent is the effective percentage (1-100) for gitleaks-style redaction when redact_with is not set. Set at build/update.
 	redactPercent uint
@@ -108,6 +108,10 @@ type Component struct {
 
 	metrics            *metrics
 	debugDataPublisher livedebugging.DebugDataPublisher
+}
+
+type secretDetector interface {
+	DetectContext(ctx context.Context, fragment detect.Fragment) []report.Finding
 }
 
 // Metrics exposed by this component:

--- a/internal/component/loki/secretfilter/secretfilter_test.go
+++ b/internal/component/loki/secretfilter/secretfilter_test.go
@@ -21,8 +21,17 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
+	"github.com/zricethezav/gitleaks/v8/detect"
+	"github.com/zricethezav/gitleaks/v8/report"
 )
 
+//nolint:staticcheck // DetectContext still requires detect.Fragment in gitleaks v8
+type detectorFunc func(context.Context, detect.Fragment) []report.Finding
+
+//nolint:staticcheck // DetectContext still requires detect.Fragment in gitleaks v8
+func (f detectorFunc) DetectContext(ctx context.Context, fragment detect.Fragment) []report.Finding {
+	return f(ctx, fragment)
+}
 func TestSecretFiltering(t *testing.T) {
 	// One component, one config load; all default cases run through it.
 	RunTestCases(t, testhelper.TestConfigs["default"], DefaultTestCases())
@@ -763,9 +772,14 @@ func TestProcessingTimeout_ForwardsUnredactedOnTimeout(t *testing.T) {
 	line := "log line with secret " + secret + " end"
 	c, err := New(opts, Arguments{
 		ForwardTo:         []loki.LogsReceiver{loki.NewLogsReceiver()},
-		ProcessingTimeout: 1 * time.Nanosecond, // guaranteed to expire before DetectString returns
+		ProcessingTimeout: 10 * time.Millisecond,
 	})
 	require.NoError(t, err)
+	//nolint:staticcheck // DetectContext still requires detect.Fragment in gitleaks v8
+	c.detector = detectorFunc(func(ctx context.Context, _ detect.Fragment) []report.Finding {
+		<-ctx.Done()
+		return nil
+	})
 
 	entry := loki.Entry{
 		Labels: model.LabelSet{},
@@ -791,10 +805,15 @@ func TestProcessingTimeout_DropsOnTimeoutWhenEnabled(t *testing.T) {
 	line := "log line with secret " + secret + " end"
 	c, err := New(opts, Arguments{
 		ForwardTo:         []loki.LogsReceiver{loki.NewLogsReceiver()},
-		ProcessingTimeout: 1 * time.Nanosecond, // guaranteed to expire before DetectString returns
+		ProcessingTimeout: 10 * time.Millisecond,
 		DropOnTimeout:     true,
 	})
 	require.NoError(t, err)
+	//nolint:staticcheck // DetectContext still requires detect.Fragment in gitleaks v8
+	c.detector = detectorFunc(func(ctx context.Context, _ detect.Fragment) []report.Finding {
+		<-ctx.Done()
+		return nil
+	})
 
 	entry := loki.Entry{
 		Labels: model.LabelSet{},

--- a/internal/component/loki/source/file/internal/tail/file_test.go
+++ b/internal/component/loki/source/file/internal/tail/file_test.go
@@ -249,16 +249,22 @@ func TestFile(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
+		defer file.Stop()
 
+		appended := make(chan struct{})
+		deleteNow := make(chan struct{})
 		go func() {
-			time.Sleep(50 * time.Millisecond)
 			appendToFile(t, name, "3\n4\n")
-			removeFile(t, name)
+			close(appended)
+			<-deleteNow
+			_ = os.Remove(name)
 		}()
 
 		verifyResult(t, file, &Line{Text: "1", Offset: 2}, nil)
 		verifyResult(t, file, &Line{Text: "2", Offset: 4}, nil)
+		<-appended
 		verifyResult(t, file, &Line{Text: "3", Offset: 6}, nil)
+		close(deleteNow)
 		verifyResult(t, file, &Line{Text: "4", Offset: 8}, nil)
 	})
 

--- a/internal/component/loki/source/heroku/heroku_test.go
+++ b/internal/component/loki/source/heroku/heroku_test.go
@@ -2,6 +2,7 @@ package heroku
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 	"testing"
@@ -14,7 +15,6 @@ import (
 	"github.com/grafana/alloy/internal/component/loki/source/heroku/internal/herokutarget"
 	"github.com/grafana/alloy/internal/util"
 	"github.com/grafana/regexp"
-	"github.com/phayes/freeport"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
@@ -65,82 +65,68 @@ func TestPush(t *testing.T) {
 }
 
 func TestUpdate_detectsWhenTargetRequiresARestart(t *testing.T) {
-	httpPort := getFreePort(t)
-	grpcPort := getFreePort(t)
 	tests := []struct {
 		name            string
-		args            Arguments
-		newArgs         Arguments
+		mutateNewArgs   func(t *testing.T, args *Arguments)
 		restartRequired bool
 	}{
 		{
 			name:            "identical args don't require server restart",
-			args:            testArgsWithPorts(httpPort, grpcPort),
-			newArgs:         testArgsWithPorts(httpPort, grpcPort),
+			mutateNewArgs:   func(_ *testing.T, _ *Arguments) {},
 			restartRequired: false,
 		},
 		{
 			name: "change in address requires server restart",
-			args: testArgsWithPorts(httpPort, grpcPort),
-			newArgs: testArgsWith(t, func(args *Arguments) {
+			mutateNewArgs: func(_ *testing.T, args *Arguments) {
 				args.Server.HTTP.ListenAddress = "127.0.0.1"
-				args.Server.HTTP.ListenPort = httpPort
-				args.Server.GRPC.ListenPort = grpcPort
-			}),
+			},
 			restartRequired: true,
 		},
 		{
-			name:            "change in port requires server restart",
-			args:            testArgsWithPorts(httpPort, grpcPort),
-			newArgs:         testArgsWithPorts(getFreePort(t), grpcPort),
+			name: "change in port requires server restart",
+			mutateNewArgs: func(t *testing.T, args *Arguments) {
+				args.Server.HTTP.ListenPort = getFreePort(t)
+			},
 			restartRequired: true,
 		},
 		{
 			name: "change in forwardTo does not require server restart",
-			args: testArgsWithPorts(httpPort, grpcPort),
-			newArgs: testArgsWith(t, func(args *Arguments) {
+			mutateNewArgs: func(_ *testing.T, args *Arguments) {
 				args.ForwardTo = []loki.LogsReceiver{}
-				args.Server.HTTP.ListenPort = httpPort
-				args.Server.GRPC.ListenPort = grpcPort
-			}),
+			},
 			restartRequired: false,
 		},
 		{
 			name: "change in labels requires server restart",
-			args: testArgsWithPorts(httpPort, grpcPort),
-			newArgs: testArgsWith(t, func(args *Arguments) {
+			mutateNewArgs: func(_ *testing.T, args *Arguments) {
 				args.Labels = map[string]string{"some": "label"}
-				args.Server.HTTP.ListenPort = httpPort
-				args.Server.GRPC.ListenPort = grpcPort
-			}),
+			},
 			restartRequired: true,
 		},
 		{
 			name: "change in relabel rules requires server restart",
-			args: testArgsWithPorts(httpPort, grpcPort),
-			newArgs: testArgsWith(t, func(args *Arguments) {
+			mutateNewArgs: func(_ *testing.T, args *Arguments) {
 				args.RelabelRules = alloy_relabel.Rules{}
-				args.Server.HTTP.ListenPort = httpPort
-				args.Server.GRPC.ListenPort = grpcPort
-			}),
+			},
 			restartRequired: true,
 		},
 		{
 			name: "change in use incoming timestamp requires server restart",
-			args: testArgsWithPorts(httpPort, grpcPort),
-			newArgs: testArgsWith(t, func(args *Arguments) {
+			mutateNewArgs: func(_ *testing.T, args *Arguments) {
 				args.UseIncomingTimestamp = !args.UseIncomingTimestamp
-				args.Server.HTTP.ListenPort = httpPort
-				args.Server.GRPC.ListenPort = grpcPort
-			}),
+			},
 			restartRequired: true,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			args := testArgsWithPorts(0, 0)
+			newArgs := cloneArguments(args)
+			tc.mutateNewArgs(t, &newArgs)
+
 			comp, err := New(
 				defaultOptions(t),
-				tc.args,
+				args,
 			)
 			require.NoError(t, err)
 			defer func() {
@@ -153,7 +139,7 @@ func TestUpdate_detectsWhenTargetRequiresARestart(t *testing.T) {
 			waitForServerToBeReady(t, comp)
 
 			targetBefore := comp.server
-			err = comp.Update(tc.newArgs)
+			err = comp.Update(newArgs)
 			require.NoError(t, err)
 
 			restarted := targetBefore != comp.server
@@ -230,9 +216,37 @@ func testArgsWithPorts(httpPort int, grpcPort int) Arguments {
 }
 
 func testArgsWith(t *testing.T, mutator func(arguments *Arguments)) Arguments {
-	a := testArgsWithPorts(getFreePort(t), getFreePort(t))
+	_ = t
+	a := testArgsWithPorts(0, 0)
 	mutator(&a)
 	return a
+}
+
+func cloneArguments(args Arguments) Arguments {
+	cloned := args
+
+	if args.Server != nil {
+		serverCopy := *args.Server
+		if args.Server.HTTP != nil {
+			httpCopy := *args.Server.HTTP
+			serverCopy.HTTP = &httpCopy
+		}
+		if args.Server.GRPC != nil {
+			grpcCopy := *args.Server.GRPC
+			serverCopy.GRPC = &grpcCopy
+		}
+		cloned.Server = &serverCopy
+	}
+
+	cloned.ForwardTo = append([]loki.LogsReceiver(nil), args.ForwardTo...)
+	if args.Labels != nil {
+		cloned.Labels = make(map[string]string, len(args.Labels))
+		for k, v := range args.Labels {
+			cloned.Labels[k] = v
+		}
+	}
+
+	return cloned
 }
 
 func waitForServerToBeReady(t *testing.T, comp *Component) {
@@ -246,9 +260,11 @@ func waitForServerToBeReady(t *testing.T, comp *Component) {
 }
 
 func getFreePort(t *testing.T) int {
-	port, err := freeport.GetFreePort()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	return port
+	defer func() { require.NoError(t, l.Close()) }()
+
+	return l.Addr().(*net.TCPAddr).Port
 }
 
 func newRegexp() alloy_relabel.Regexp {

--- a/internal/component/otelcol/auth/bearer/bearer_test.go
+++ b/internal/component/otelcol/auth/bearer/bearer_test.go
@@ -19,8 +19,6 @@ import (
 	extauth "go.opentelemetry.io/collector/extension/extensionauth"
 )
 
-const componentStartupTimeout = 5 * time.Second
-
 // Test performs a basic integration test which runs the otelcol.auth.bearer
 // component and ensures that it can be used for authentication.
 func TestClient(t *testing.T) {
@@ -225,8 +223,8 @@ func newTestComponent(t *testing.T, ctx context.Context, alloyConfig string) (*c
 		require.NoError(t, err)
 	}()
 
-	require.NoError(t, ctrl.WaitRunning(componentStartupTimeout), "component never started")
-	require.NoError(t, ctrl.WaitExports(componentStartupTimeout), "component never exported anything")
+	require.NoError(t, ctrl.WaitRunning(0), "component never started")
+	require.NoError(t, ctrl.WaitExports(0), "component never exported anything")
 
 	return ctrl, args.Header
 }

--- a/internal/component/otelcol/auth/bearer/bearer_test.go
+++ b/internal/component/otelcol/auth/bearer/bearer_test.go
@@ -19,6 +19,8 @@ import (
 	extauth "go.opentelemetry.io/collector/extension/extensionauth"
 )
 
+const componentStartupTimeout = 5 * time.Second
+
 // Test performs a basic integration test which runs the otelcol.auth.bearer
 // component and ensures that it can be used for authentication.
 func TestClient(t *testing.T) {
@@ -223,8 +225,8 @@ func newTestComponent(t *testing.T, ctx context.Context, alloyConfig string) (*c
 		require.NoError(t, err)
 	}()
 
-	require.NoError(t, ctrl.WaitRunning(time.Second), "component never started")
-	require.NoError(t, ctrl.WaitExports(time.Second), "component never exported anything")
+	require.NoError(t, ctrl.WaitRunning(componentStartupTimeout), "component never started")
+	require.NoError(t, ctrl.WaitExports(componentStartupTimeout), "component never exported anything")
 
 	return ctrl, args.Header
 }

--- a/internal/component/otelcol/processor/processortest/processortest.go
+++ b/internal/component/otelcol/processor/processortest/processortest.go
@@ -39,11 +39,7 @@ type ProcessorRunConfig struct {
 	L                     log.Logger
 }
 
-const (
-	componentStartTimeout  = 5 * time.Second
-	componentExportTimeout = 5 * time.Second
-	signalOutputTimeout    = 3 * time.Second
-)
+const signalOutputTimeout = 3 * time.Second
 
 func TestRunProcessor(c ProcessorRunConfig) {
 	go func() {
@@ -51,8 +47,8 @@ func TestRunProcessor(c ProcessorRunConfig) {
 		require.NoError(c.T, err)
 	}()
 
-	require.NoError(c.T, c.Ctrl.WaitRunning(componentStartTimeout), "component never started")
-	require.NoError(c.T, c.Ctrl.WaitExports(componentExportTimeout), "component never exported anything")
+	require.NoError(c.T, c.Ctrl.WaitRunning(0), "component never started")
+	require.NoError(c.T, c.Ctrl.WaitExports(0), "component never exported anything")
 
 	// Send signals in the background to our processor.
 	go func() {

--- a/internal/component/otelcol/processor/processortest/processortest.go
+++ b/internal/component/otelcol/processor/processortest/processortest.go
@@ -39,14 +39,20 @@ type ProcessorRunConfig struct {
 	L                     log.Logger
 }
 
+const (
+	componentStartTimeout  = 5 * time.Second
+	componentExportTimeout = 5 * time.Second
+	signalOutputTimeout    = 3 * time.Second
+)
+
 func TestRunProcessor(c ProcessorRunConfig) {
 	go func() {
 		err := c.Ctrl.Run(c.Ctx, c.Args)
 		require.NoError(c.T, err)
 	}()
 
-	require.NoError(c.T, c.Ctrl.WaitRunning(time.Second), "component never started")
-	require.NoError(c.T, c.Ctrl.WaitExports(time.Second), "component never exported anything")
+	require.NoError(c.T, c.Ctrl.WaitRunning(componentStartTimeout), "component never started")
+	require.NoError(c.T, c.Ctrl.WaitExports(componentExportTimeout), "component never exported anything")
 
 	// Send signals in the background to our processor.
 	go func() {
@@ -101,7 +107,7 @@ func (s traceToLogSignal) ConsumeInput(ctx context.Context, consumer otelcol.Con
 func (s traceToLogSignal) CheckOutput(t *testing.T) {
 	// Wait for our processor to finish and forward data to logCh.
 	select {
-	case <-time.After(time.Second):
+	case <-time.After(signalOutputTimeout):
 		require.FailNow(t, "failed waiting for logs")
 	case actualLog := <-s.logCh:
 		CompareLogs(t, s.expectedOutputLog, actualLog)
@@ -196,7 +202,7 @@ func (s traceSignal) ConsumeInput(ctx context.Context, consumer otelcol.Consumer
 func (s traceSignal) CheckOutput(t *testing.T) {
 	// Wait for our processor to finish and forward data to traceCh.
 	select {
-	case <-time.After(time.Second):
+	case <-time.After(signalOutputTimeout):
 		require.FailNow(t, "failed waiting for traces")
 	case actualTrace := <-s.traceCh:
 		CompareTraces(t, s.expectedOutputTrace, actualTrace)
@@ -262,7 +268,7 @@ func (s logSignal) ConsumeInput(ctx context.Context, consumer otelcol.Consumer) 
 func (s logSignal) CheckOutput(t *testing.T) {
 	// Wait for our processor to finish and forward data to logCh.
 	select {
-	case <-time.After(time.Second):
+	case <-time.After(signalOutputTimeout):
 		require.FailNow(t, "failed waiting for logs")
 	case actualLog := <-s.logCh:
 		CompareLogs(t, s.expectedOutputLog, actualLog)
@@ -328,7 +334,7 @@ func (s metricSignal) ConsumeInput(ctx context.Context, consumer otelcol.Consume
 func (s metricSignal) CheckOutput(t *testing.T) {
 	// Wait for our processor to finish and forward data to logCh.
 	select {
-	case <-time.After(time.Second):
+	case <-time.After(signalOutputTimeout):
 		require.FailNow(t, "failed waiting for logs")
 	case actualMetric := <-s.metricCh:
 		err := CompareMetrics(t, s.expectedOutputMetric, actualMetric)

--- a/internal/runtime/componenttest/componenttest.go
+++ b/internal/runtime/componenttest/componenttest.go
@@ -41,6 +41,11 @@ type Controller struct {
 	exportsCh  chan struct{}
 }
 
+const (
+	defaultWaitRunningTimeout = 5 * time.Second
+	defaultWaitExportsTimeout = 5 * time.Second
+)
+
 // NewControllerFromID returns a new testing Controller for the component with
 // the provided name.
 func NewControllerFromID(l log.Logger, componentName string) (*Controller, error) {
@@ -89,6 +94,10 @@ func (c *Controller) onStateChange(e component.Exports) {
 // WaitRunning blocks until the Controller is running up to the provided
 // timeout.
 func (c *Controller) WaitRunning(timeout time.Duration) error {
+	if timeout <= 0 {
+		timeout = defaultWaitRunningTimeout
+	}
+
 	select {
 	case <-time.After(timeout):
 		return fmt.Errorf("timed out waiting for the controller to start running")
@@ -103,6 +112,10 @@ func (c *Controller) WaitRunning(timeout time.Duration) error {
 // WaitExports blocks until new Exports are available up to the provided
 // timeout.
 func (c *Controller) WaitExports(timeout time.Duration) error {
+	if timeout <= 0 {
+		timeout = defaultWaitExportsTimeout
+	}
+
 	select {
 	case <-time.After(timeout):
 		return fmt.Errorf("timed out waiting for exports")

--- a/internal/runtime/module_eval_test.go
+++ b/internal/runtime/module_eval_test.go
@@ -397,6 +397,9 @@ func verifyNoGoroutineLeaks(t *testing.T) {
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
 		goleak.IgnoreTopFunction("go.opentelemetry.io/otel/sdk/trace.(*batchSpanProcessor).processQueue"),
 		goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"), // related to TCP keep alive
+		// On macOS, fsnotify's kqueue backend can still be in its read loop
+		// briefly after watcher.Close() returns.
+		goleak.IgnoreAnyFunction("github.com/fsnotify/fsnotify.(*kqueue).readEvents"),
 		// TODO - #3257: There is a small race condition where the file detector's cancel func is closed but it has
 		// not yet been scheduled to run & then terminate. The refactor to fix this is significant,
 		// and not currently worth the investment.


### PR DESCRIPTION
### Brief description of Pull Request

Fixes several flaky tests as reported in https://github.com/grafana/alloy/issues/5142

### Pull Request Details

Following test issues addressed:

TestUpdate_detectsWhenTargetRequiresARestart
(internal/component/loki/source/heroku/heroku_test.go)

TestClient
(internal/component/otelcol/auth/bearer/bearer_test.go)

processortest.go/Test_Update (reported as startup-timeout flake)
Addressed via shared timeout hardening in processortest helper.

Test_Hash
Addressed via the same processortest timeout hardening used by attributes processor tests.

Test_ComponentIO (spanlogs / otelcol connector path)
Addressed via shared processortest timeout hardening.

TestEndpoint/batch_log_entries_together_until_the_batch_wait_time_is_reached
(current test name in file is the “batch wait time is reached” subtest in internal/component/common/loki/client/endpoint_test.go)

TestFile/deleted_while_reading
(internal/component/loki/source/file/internal/tail/file_test.go)

Test_SchemaDetails_populates_TableRegistry
(internal/component/database_observability/postgres/collector/schema_details_test.go, with lifecycle fix in schema_details.go)
### Issue(s) fixed by this Pull Request

### Notes to the Reviewer

### PR Checklist

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated