### PR TITLE
chore: Fix windows test

### DIFF
--- a/internal/component/common/loki/client/endpoint_test.go
+++ b/internal/component/common/loki/client/endpoint_test.go
@@ -80,7 +80,7 @@ func TestEndpoint(t *testing.T) {
 				// end up in the same batch so we need to wait longer to make
 				// sure everything is running.
 				if runtime.GOOS == "windows" {
-					return 10 * time.Second
+					return 2 * time.Second
 				}
 				return 700 * time.Millisecond
 			}(),


### PR DESCRIPTION
### Pull Request Details

This test never passes in our ci and in my vm I could also not get it to pass.

Seems like it have to do with go scheduling, the shard loop is not started before we queue entries.

### Issue(s) fixed by this Pull Request

<!--
  Uncomment the following line and fill in an issue number if you want a GitHub
  issue to be closed automatically when this PR gets merged.
-->

<!-- Fixes #issue_id -->

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
