### PR TITLE
fix: Enforce Singleton For Running Alloy Extension Instances

### DIFF
--- a/docs/sources/set-up/otel_engine.md
+++ b/docs/sources/set-up/otel_engine.md
@@ -133,7 +133,7 @@ service:
 
 Replace the following:
 
-- _`<ALLOY_CONFIG_PATH>`_: The path to your {{< param "DEFAULT_ENGINE" >}} configuration file.
+- _`<ALLOY_CONFIG_PATH>`_: The path to your {{< param "DEFAULT_ENGINE" >}} configuration file or directory. If you provide a directory, {{< param "PRODUCT_NAME" >}} finds `*.alloy` files in it and loads them as a single configuration source. See the [run command reference](../../reference/cli/run/) for details.
 - _`<USERNAME>`_: Your username. If you're using Grafana Cloud, this is your Grafana Cloud instance ID.
 - _`<PASSWORD>`_: Your password. If you're using Grafana Cloud, this is your Grafana Cloud API token.
 - _`<URL>`_: The URL to export data to. If you're using Grafana Cloud, this is your Grafana Cloud OTLP endpoint URL.

--- a/docs/sources/set-up/otel_engine.md
+++ b/docs/sources/set-up/otel_engine.md
@@ -150,7 +150,7 @@ The output of both engines is visible in the logs.
 You can access the {{< param "DEFAULT_ENGINE" >}} UI and metrics on port `12345`.
 
 {{< admonition type="warning" >}}
-Only one `alloyengine` extension can be active per process, please ensure you only specify a single extension in your `service.extensions` definition. If you specify multiple, you will see a clear error indicating that only one alloy engine extension can be live at once per collector instance. 
+Only one `alloyengine` extension can be active per process.
 {{< /admonition >}}
 
 ## Run with the OpenTelemetry Collector Helm chart

--- a/docs/sources/set-up/otel_engine.md
+++ b/docs/sources/set-up/otel_engine.md
@@ -150,7 +150,7 @@ The output of both engines is visible in the logs.
 You can access the {{< param "DEFAULT_ENGINE" >}} UI and metrics on port `12345`.
 
 {{< admonition type="warning" >}}
-Only one `alloyengine` extension can be active per process, please ensure you only specify a single extension in your `service.pipelines` definition. If you specify multiple, you will see a clear error indicating that only one alloy engine extension can be live at once per collector instance. 
+Only one `alloyengine` extension can be active per process, please ensure you only specify a single extension in your `service.extensions` definition. If you specify multiple, you will see a clear error indicating that only one alloy engine extension can be live at once per collector instance. 
 {{< /admonition >}}
 
 ## Run with the OpenTelemetry Collector Helm chart

--- a/docs/sources/set-up/otel_engine.md
+++ b/docs/sources/set-up/otel_engine.md
@@ -149,6 +149,10 @@ This command starts both the {{< param "DEFAULT_ENGINE" >}} and {{< param "OTEL_
 The output of both engines is visible in the logs.
 You can access the {{< param "DEFAULT_ENGINE" >}} UI and metrics on port `12345`.
 
+{{< admonition type="warning" >}}
+Only one `alloyengine` extension can be active per process, please ensure you only specify a single extension in your `service.pipelines` definition. If you specify multiple, you will see a clear error indicating that only one alloy engine extension can be live at once per collector instance. 
+{{< /admonition >}}
+
 ## Run with the OpenTelemetry Collector Helm chart
 
 Use the upstream [OpenTelemetry Collector Helm chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector) to run the {{< param "OTEL_ENGINE" >}}.

--- a/docs/sources/set-up/otel_engine.md
+++ b/docs/sources/set-up/otel_engine.md
@@ -133,7 +133,9 @@ service:
 
 Replace the following:
 
-- _`<ALLOY_CONFIG_PATH>`_: The path to your {{< param "DEFAULT_ENGINE" >}} configuration file or directory. If you provide a directory, {{< param "PRODUCT_NAME" >}} finds `*.alloy` files in it and loads them as a single configuration source. See the [run command reference](../../reference/cli/run/) for details.
+- _`<ALLOY_CONFIG_PATH>`_: The path to your {{< param "DEFAULT_ENGINE" >}} configuration file or directory.
+  If you provide a directory, {{< param "PRODUCT_NAME" >}} finds `*.alloy` files in it and loads them as a single configuration source.
+  Refer to the [run command reference](../../reference/cli/run/) for more information.
 - _`<USERNAME>`_: Your username. If you're using Grafana Cloud, this is your Grafana Cloud instance ID.
 - _`<PASSWORD>`_: Your password. If you're using Grafana Cloud, this is your Grafana Cloud API token.
 - _`<URL>`_: The URL to export data to. If you're using Grafana Cloud, this is your Grafana Cloud OTLP endpoint URL.

--- a/extension/alloyengine/README.md
+++ b/extension/alloyengine/README.md
@@ -57,6 +57,12 @@ The extension manages the lifecycle of the embedded default engine:
 - **Ready**: The extension reports ready once the default engine has successfully started
 - **Shutdown**: When the extension is shut down, it gracefully terminates the default engine and waits for it to exit
 
+## Limitations
+
+Only one alloyengine instance can be active per process. The embedded Default Engine uses process-global state (Prometheus registry, controller ID, storage path and so forth), so running multiple instances will cause conflicts. If you configure multiple alloyengine extensions, only the first to start will succeed; subsequent instances will fail at startup with a clear error.
+
+Please note that if extensions fail to start, the collector will also fail to start. This means that the errors described above will ultimately mean you cannot start the collector without ensuring that you specify which of the alloyengine extensions you wish to run
+
 ## Stability
 
 This extension is currently marked as **experimental** stability level. The API and behavior may change in future releases.

--- a/extension/alloyengine/README.md
+++ b/extension/alloyengine/README.md
@@ -61,7 +61,7 @@ The extension manages the lifecycle of the embedded default engine:
 
 Only one alloyengine instance can be active per process. The embedded Default Engine uses process-global state (Prometheus registry, controller ID, storage path and so forth), so running multiple instances will cause conflicts. If you configure multiple alloyengine extensions, only the first to start will succeed; subsequent instances will fail at startup with a clear error.
 
-Please note that if extensions fail to start, the collector will also fail to start. This means that the errors described above will ultimately mean you cannot start the collector without ensuring that you specify which of the alloyengine extensions you wish to run
+Please note that if extensions fail to start, the collector will also fail to start. This means that the errors described above will ultimately mean you cannot start the collector without ensuring that you specify which of the alloyengine extensions you wish to run.
 
 ## Stability
 

--- a/extension/alloyengine/extension.go
+++ b/extension/alloyengine/extension.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -17,6 +18,10 @@ import (
 )
 
 var _ extension.Extension = (*alloyEngineExtension)(nil)
+
+// running tracks whether any alloyengine instance is currently active.
+// Only one instance can be active per process
+var running = &atomic.Bool{}
 
 type state int
 
@@ -86,19 +91,33 @@ func newAlloyEngineExtension(config *Config, settings component.TelemetrySetting
 }
 
 func (e *alloyEngineExtension) Start(ctx context.Context, host component.Host) error {
+	var startErr error
+	defer func() {
+		if startErr != nil {
+			running.Store(false)
+		}
+	}()
+
 	currentState := e.getState()
 	switch currentState {
 	case stateNotStarted:
 		break
 	default:
-		return fmt.Errorf("cannot start alloyengine extension in current state: %s", currentState)
+		startErr = fmt.Errorf("cannot start alloyengine extension in current state: %s", currentState)
+		return startErr
+	}
+
+	// The Default Engine uses process-global state, so we only want one instance per process.
+	if !running.CompareAndSwap(false, true) {
+		startErr = fmt.Errorf("only one alloyengine extension can be active per process; an instance is already running")
+		return startErr
 	}
 
 	runCommand := e.runCommandFactory()
 	runCommand.SetArgs([]string{e.config.AlloyConfig.File})
-	err := runCommand.ParseFlags(e.config.flagsAsSlice())
-	if err != nil {
-		return fmt.Errorf("failed to parse flags: %w", err)
+	if err := runCommand.ParseFlags(e.config.flagsAsSlice()); err != nil {
+		startErr = fmt.Errorf("failed to parse flags: %w", err)
+		return startErr
 	}
 
 	runCtx, runCancel := context.WithCancel(context.Background())
@@ -112,7 +131,10 @@ func (e *alloyEngineExtension) Start(ctx context.Context, host component.Host) e
 	e.setState(stateStarting)
 
 	go func() {
-		defer close(e.runExited)
+		defer func() {
+			running.Store(false)
+			close(e.runExited)
+		}()
 
 		err := e.runWithBackoffRetry(runCommand, runCtx)
 

--- a/extension/alloyengine/extension.go
+++ b/extension/alloyengine/extension.go
@@ -89,7 +89,7 @@ func newAlloyEngineExtension(config *Config, settings component.TelemetrySetting
 	}
 }
 
-func (e *alloyEngineExtension) Start(ctx context.Context, host component.Host) error {
+func (e *alloyEngineExtension) Start(_ context.Context, host component.Host) error {
 	var startErr error
 	defer func() {
 		if startErr != nil {

--- a/extension/alloyengine/extension.go
+++ b/extension/alloyengine/extension.go
@@ -106,17 +106,16 @@ func (e *alloyEngineExtension) Start(ctx context.Context, host component.Host) e
 		return startErr
 	}
 
-	// Here we check if another extension instance is already running, if so we return an error
-	if !running.CompareAndSwap(false, true) {
-		startErr = fmt.Errorf("only one alloyengine extension can be active per process; an instance is already running")
-		return startErr
-	}
-
 	runCommand := e.runCommandFactory()
 	runCommand.SetArgs([]string{e.config.AlloyConfig.File})
 	if err := runCommand.ParseFlags(e.config.flagsAsSlice()); err != nil {
 		startErr = fmt.Errorf("failed to parse flags: %w", err)
 		return startErr
+	}
+
+	// Here we check if another extension instance is already running, if so we return an error
+	if !running.CompareAndSwap(false, true) {
+		return fmt.Errorf("only one alloyengine extension can be active per process; an instance is already running")
 	}
 
 	runCtx, runCancel := context.WithCancel(context.Background())

--- a/extension/alloyengine/extension.go
+++ b/extension/alloyengine/extension.go
@@ -20,7 +20,6 @@ import (
 var _ extension.Extension = (*alloyEngineExtension)(nil)
 
 // running tracks whether any alloyengine instance is currently active.
-// Only one instance can be active per process
 var running = &atomic.Bool{}
 
 type state int
@@ -107,7 +106,7 @@ func (e *alloyEngineExtension) Start(ctx context.Context, host component.Host) e
 		return startErr
 	}
 
-	// The Default Engine uses process-global state, so we only want one instance per process.
+	// Here we check if another extension instance is already running, if so we return an error
 	if !running.CompareAndSwap(false, true) {
 		startErr = fmt.Errorf("only one alloyengine extension can be active per process; an instance is already running")
 		return startErr

--- a/extension/alloyengine/extension.go
+++ b/extension/alloyengine/extension.go
@@ -90,27 +90,18 @@ func newAlloyEngineExtension(config *Config, settings component.TelemetrySetting
 }
 
 func (e *alloyEngineExtension) Start(_ context.Context, host component.Host) error {
-	var startErr error
-	defer func() {
-		if startErr != nil {
-			running.Store(false)
-		}
-	}()
-
 	currentState := e.getState()
 	switch currentState {
 	case stateNotStarted:
 		break
 	default:
-		startErr = fmt.Errorf("cannot start alloyengine extension in current state: %s", currentState)
-		return startErr
+		return fmt.Errorf("cannot start alloyengine extension in current state: %s", currentState)
 	}
 
 	runCommand := e.runCommandFactory()
 	runCommand.SetArgs([]string{e.config.AlloyConfig.File})
 	if err := runCommand.ParseFlags(e.config.flagsAsSlice()); err != nil {
-		startErr = fmt.Errorf("failed to parse flags: %w", err)
-		return startErr
+		return fmt.Errorf("failed to parse flags: %w", err)
 	}
 
 	// Here we check if another extension instance is already running, if so we return an error

--- a/extension/alloyengine/extension_test.go
+++ b/extension/alloyengine/extension_test.go
@@ -143,6 +143,23 @@ func TestLifecycle_StartTwiceFails(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestLifecycle_SecondInstanceFailsWhileFirstRunning(t *testing.T) {
+	ext1 := newTestExtension(t, blockingCommand, defaultTestConfig())
+	ext2 := newTestExtension(t, blockingCommand, defaultTestConfig())
+
+	require.NoError(t, ext1.Start(context.Background(), componenttest.NewNopHost()))
+	require.Eventually(t, func() bool { return ext1.getState() == stateRunning }, 1*time.Second, 25*time.Millisecond, "first extension did not reach stateRunning")
+
+	err := ext2.Start(context.Background(), componenttest.NewNopHost())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "only one alloyengine extension can be active per process")
+
+	// Cleanup: shutdown first extension so slot is released
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	t.Cleanup(cancel)
+	require.NoError(t, ext1.Shutdown(shutdownCtx))
+}
+
 func TestLifecycle_NotReadyWhenNotStarted(t *testing.T) {
 	e := newTestExtension(t, blockingCommand, defaultTestConfig())
 	require.Error(t, e.Ready())

--- a/extension/alloyengine/extension_test.go
+++ b/extension/alloyengine/extension_test.go
@@ -141,6 +141,11 @@ func TestLifecycle_StartTwiceFails(t *testing.T) {
 	require.NoError(t, e.Start(context.Background(), componenttest.NewNopHost()))
 	err := e.Start(context.Background(), componenttest.NewNopHost())
 	require.Error(t, err)
+
+	// Cleanup: release the singleton slot so subsequent tests can start extensions
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	t.Cleanup(cancel)
+	require.NoError(t, e.Shutdown(shutdownCtx))
 }
 
 func TestLifecycle_SecondInstanceFailsWhileFirstRunning(t *testing.T) {

--- a/extension/alloyengine/extension_test.go
+++ b/extension/alloyengine/extension_test.go
@@ -119,10 +119,7 @@ func TestLifecycle_SuccessfulStartAndShutdown(t *testing.T) {
 	require.NoError(t, e.Ready())
 	require.NoError(t, e.NotReady())
 
-	// Perform graceful shutdown with timeout to avoid hanging tests.
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	t.Cleanup(cancel)
-	require.NoError(t, e.Shutdown(shutdownCtx))
+	require.NoError(t, e.Shutdown(context.Background()))
 
 	// Verify the run goroutine has exited and state is terminated.
 	require.Eventually(t, func() bool {
@@ -181,9 +178,7 @@ func TestLifecycle_StayInStartingWhenReadyNotCalled(t *testing.T) {
 	// We should still be in stateStarting since the ready callback was never invoked.
 	require.Equal(t, stateStarting, e.getState())
 
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	t.Cleanup(cancel)
-	require.NoError(t, e.Shutdown(shutdownCtx))
+	require.NoError(t, e.Shutdown(context.Background()))
 }
 
 func TestLifecycle_ShutdownWithRunCommandError(t *testing.T) {
@@ -193,9 +188,7 @@ func TestLifecycle_ShutdownWithRunCommandError(t *testing.T) {
 	require.NoError(t, e.Start(context.Background(), componenttest.NewNopHost()))
 	require.Eventually(t, func() bool { return e.getState() == stateRunning }, 1*time.Second, 25*time.Millisecond, "extension did not reach stateRunning")
 
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	t.Cleanup(cancel)
-	require.NoError(t, e.Shutdown(shutdownCtx))
+	require.NoError(t, e.Shutdown(context.Background()))
 
 	// The internal goroutine should have transitioned to terminated even on error during shutdown.
 	require.Eventually(t, func() bool {

--- a/extension/alloyengine/extension_test.go
+++ b/extension/alloyengine/extension_test.go
@@ -179,6 +179,17 @@ func TestLifecycle_StayInStartingWhenReadyNotCalled(t *testing.T) {
 	require.Equal(t, stateStarting, e.getState())
 
 	require.NoError(t, e.Shutdown(context.Background()))
+
+	// Verify the run goroutine has exited and state is terminated.
+	require.Eventually(t, func() bool {
+		select {
+		case <-e.runExited:
+			return true
+		default:
+			return false
+		}
+	}, 1*time.Second, 25*time.Millisecond, "run command did not exit in time")
+	require.Equal(t, stateTerminated, e.getState())
 }
 
 func TestLifecycle_ShutdownWithRunCommandError(t *testing.T) {

--- a/extension/alloyengine/extension_test.go
+++ b/extension/alloyengine/extension_test.go
@@ -111,15 +111,14 @@ func TestConfig_MissingPath(t *testing.T) {
 func TestLifecycle_SuccessfulStartAndShutdown(t *testing.T) {
 	e := newTestExtension(t, blockingCommand, defaultTestConfig())
 
-	ctx := context.Background()
 	host := componenttest.NewNopHost()
 
-	require.NoError(t, e.Start(ctx, host))
+	require.NoError(t, e.Start(t.Context(), host))
 	require.Eventually(t, func() bool { return e.getState() == stateRunning }, 1*time.Second, 25*time.Millisecond, "extension did not reach stateRunning")
 	require.NoError(t, e.Ready())
 	require.NoError(t, e.NotReady())
 
-	require.NoError(t, e.Shutdown(context.Background()))
+	require.NoError(t, e.Shutdown(t.Context()))
 
 	// Verify the run goroutine has exited and state is terminated.
 	require.Eventually(t, func() bool {
@@ -135,12 +134,12 @@ func TestLifecycle_SuccessfulStartAndShutdown(t *testing.T) {
 
 func TestLifecycle_StartTwiceFails(t *testing.T) {
 	e := newTestExtension(t, blockingCommand, defaultTestConfig())
-	require.NoError(t, e.Start(context.Background(), componenttest.NewNopHost()))
-	err := e.Start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, e.Start(t.Context(), componenttest.NewNopHost()))
+	err := e.Start(t.Context(), componenttest.NewNopHost())
 	require.Error(t, err)
 
 	// Cleanup: release the singleton slot so subsequent tests can start extensions
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	shutdownCtx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 	t.Cleanup(cancel)
 	require.NoError(t, e.Shutdown(shutdownCtx))
 }
@@ -149,15 +148,15 @@ func TestLifecycle_SecondInstanceFailsWhileFirstRunning(t *testing.T) {
 	ext1 := newTestExtension(t, blockingCommand, defaultTestConfig())
 	ext2 := newTestExtension(t, blockingCommand, defaultTestConfig())
 
-	require.NoError(t, ext1.Start(context.Background(), componenttest.NewNopHost()))
+	require.NoError(t, ext1.Start(t.Context(), componenttest.NewNopHost()))
 	require.Eventually(t, func() bool { return ext1.getState() == stateRunning }, 1*time.Second, 25*time.Millisecond, "first extension did not reach stateRunning")
 
-	err := ext2.Start(context.Background(), componenttest.NewNopHost())
+	err := ext2.Start(t.Context(), componenttest.NewNopHost())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "only one alloyengine extension can be active per process")
 
 	// Cleanup: shutdown first extension so slot is released
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	shutdownCtx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 	t.Cleanup(cancel)
 	require.NoError(t, ext1.Shutdown(shutdownCtx))
 }
@@ -170,7 +169,7 @@ func TestLifecycle_NotReadyWhenNotStarted(t *testing.T) {
 
 func TestLifecycle_StayInStartingWhenReadyNotCalled(t *testing.T) {
 	e := newTestExtension(t, blockingCommandWithoutReady, defaultTestConfig())
-	require.NoError(t, e.Start(context.Background(), componenttest.NewNopHost()))
+	require.NoError(t, e.Start(t.Context(), componenttest.NewNopHost()))
 
 	// Give the run goroutine time to start and block (without calling ready).
 	time.Sleep(50 * time.Millisecond)
@@ -178,7 +177,7 @@ func TestLifecycle_StayInStartingWhenReadyNotCalled(t *testing.T) {
 	// We should still be in stateStarting since the ready callback was never invoked.
 	require.Equal(t, stateStarting, e.getState())
 
-	require.NoError(t, e.Shutdown(context.Background()))
+	require.NoError(t, e.Shutdown(t.Context()))
 
 	// Verify the run goroutine has exited and state is terminated.
 	require.Eventually(t, func() bool {
@@ -196,10 +195,10 @@ func TestLifecycle_ShutdownWithRunCommandError(t *testing.T) {
 	expected := errors.New("shutdown error")
 	e := newTestExtension(t, func() *cobra.Command { return shutdownErrorCommand(expected) }, defaultTestConfig())
 
-	require.NoError(t, e.Start(context.Background(), componenttest.NewNopHost()))
+	require.NoError(t, e.Start(t.Context(), componenttest.NewNopHost()))
 	require.Eventually(t, func() bool { return e.getState() == stateRunning }, 1*time.Second, 25*time.Millisecond, "extension did not reach stateRunning")
 
-	require.NoError(t, e.Shutdown(context.Background()))
+	require.NoError(t, e.Shutdown(t.Context()))
 
 	// The internal goroutine should have transitioned to terminated even on error during shutdown.
 	require.Eventually(t, func() bool {
@@ -219,7 +218,7 @@ func TestLifecycle_RunSucceedsAfterRetries(t *testing.T) {
 	cfg := defaultTestConfig()
 	e := newTestExtension(t, factory, cfg)
 
-	require.NoError(t, e.Start(context.Background(), componenttest.NewNopHost()))
+	require.NoError(t, e.Start(t.Context(), componenttest.NewNopHost()))
 
 	// Wait for the command to eventually exit
 	require.Eventually(t, func() bool {

--- a/extension/alloyengine/extension_test.go
+++ b/extension/alloyengine/extension_test.go
@@ -14,6 +14,31 @@ import (
 	"go.uber.org/zap"
 )
 
+func shutdownExtensionWithTestTimeout(e *alloyEngineExtension) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return e.Shutdown(ctx)
+}
+
+func requireRunExited(t *testing.T, e *alloyEngineExtension, wait, tick time.Duration) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		select {
+		case <-e.runExited:
+			return true
+		default:
+			return false
+		}
+	}, wait, tick, "run command did not exit in time")
+}
+
+func requireShutdownAndTerminated(t *testing.T, e *alloyEngineExtension) {
+	t.Helper()
+	require.NoError(t, shutdownExtensionWithTestTimeout(e))
+	requireRunExited(t, e, time.Second, 25*time.Millisecond)
+	require.Equal(t, stateTerminated, e.getState())
+}
+
 // defaultTestConfig returns a default test configuration.
 func defaultTestConfig() *Config {
 	return &Config{
@@ -29,6 +54,7 @@ func newTestExtension(t *testing.T, factory func() *cobra.Command, config *Confi
 	t.Helper()
 	e := newAlloyEngineExtension(config, component.TelemetrySettings{Logger: zap.NewNop()})
 	e.runCommandFactory = factory
+	t.Cleanup(func() { _ = shutdownExtensionWithTestTimeout(e) })
 	return e
 }
 
@@ -118,18 +144,7 @@ func TestLifecycle_SuccessfulStartAndShutdown(t *testing.T) {
 	require.NoError(t, e.Ready())
 	require.NoError(t, e.NotReady())
 
-	require.NoError(t, e.Shutdown(t.Context()))
-
-	// Verify the run goroutine has exited and state is terminated.
-	require.Eventually(t, func() bool {
-		select {
-		case <-e.runExited:
-			return true
-		default:
-			return false
-		}
-	}, 1*time.Second, 25*time.Millisecond, "run command did not exit in time")
-	require.Equal(t, stateTerminated, e.getState())
+	requireShutdownAndTerminated(t, e)
 }
 
 func TestLifecycle_StartTwiceFails(t *testing.T) {
@@ -137,7 +152,7 @@ func TestLifecycle_StartTwiceFails(t *testing.T) {
 	require.NoError(t, e.Start(t.Context(), componenttest.NewNopHost()))
 	err := e.Start(t.Context(), componenttest.NewNopHost())
 	require.Error(t, err)
-	require.NoError(t, e.Shutdown(t.Context())) //
+	requireShutdownAndTerminated(t, e)
 }
 
 func TestLifecycle_SecondInstanceFailsWhileFirstRunning(t *testing.T) {
@@ -150,11 +165,6 @@ func TestLifecycle_SecondInstanceFailsWhileFirstRunning(t *testing.T) {
 	err := ext2.Start(t.Context(), componenttest.NewNopHost())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "only one alloyengine extension can be active per process")
-
-	// Cleanup: shutdown first extension so slot is released
-	shutdownCtx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
-	t.Cleanup(cancel)
-	require.NoError(t, ext1.Shutdown(shutdownCtx))
 }
 
 func TestLifecycle_NotReadyWhenNotStarted(t *testing.T) {
@@ -173,18 +183,7 @@ func TestLifecycle_StayInStartingWhenReadyNotCalled(t *testing.T) {
 	// We should still be in stateStarting since the ready callback was never invoked.
 	require.Equal(t, stateStarting, e.getState())
 
-	require.NoError(t, e.Shutdown(t.Context()))
-
-	// Verify the run goroutine has exited and state is terminated.
-	require.Eventually(t, func() bool {
-		select {
-		case <-e.runExited:
-			return true
-		default:
-			return false
-		}
-	}, 1*time.Second, 25*time.Millisecond, "run command did not exit in time")
-	require.Equal(t, stateTerminated, e.getState())
+	requireShutdownAndTerminated(t, e)
 }
 
 func TestLifecycle_ShutdownWithRunCommandError(t *testing.T) {
@@ -194,18 +193,7 @@ func TestLifecycle_ShutdownWithRunCommandError(t *testing.T) {
 	require.NoError(t, e.Start(t.Context(), componenttest.NewNopHost()))
 	require.Eventually(t, func() bool { return e.getState() == stateRunning }, 1*time.Second, 25*time.Millisecond, "extension did not reach stateRunning")
 
-	require.NoError(t, e.Shutdown(t.Context()))
-
-	// The internal goroutine should have transitioned to terminated even on error during shutdown.
-	require.Eventually(t, func() bool {
-		select {
-		case <-e.runExited:
-			return true
-		default:
-			return false
-		}
-	}, 1*time.Second, 25*time.Millisecond, "run command did not exit in time")
-	require.Equal(t, stateTerminated, e.getState())
+	requireShutdownAndTerminated(t, e)
 }
 
 func TestLifecycle_RunSucceedsAfterRetries(t *testing.T) {
@@ -216,15 +204,7 @@ func TestLifecycle_RunSucceedsAfterRetries(t *testing.T) {
 
 	require.NoError(t, e.Start(t.Context(), componenttest.NewNopHost()))
 
-	// Wait for the command to eventually exit
-	require.Eventually(t, func() bool {
-		select {
-		case <-e.runExited:
-			return true
-		default:
-			return false
-		}
-	}, 10*time.Second, 100*time.Millisecond, "extension did not exit in time")
+	requireRunExited(t, e, 10*time.Second, 100*time.Millisecond)
 
 	// Verify it succeeded after 3 attempts (2 failures + 1 success)
 	require.Equal(t, 3, state.attempts)

--- a/extension/alloyengine/extension_test.go
+++ b/extension/alloyengine/extension_test.go
@@ -137,11 +137,7 @@ func TestLifecycle_StartTwiceFails(t *testing.T) {
 	require.NoError(t, e.Start(t.Context(), componenttest.NewNopHost()))
 	err := e.Start(t.Context(), componenttest.NewNopHost())
 	require.Error(t, err)
-
-	// Cleanup: release the singleton slot so subsequent tests can start extensions
-	shutdownCtx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
-	t.Cleanup(cancel)
-	require.NoError(t, e.Shutdown(shutdownCtx))
+	require.NoError(t, e.Shutdown(t.Context())) //
 }
 
 func TestLifecycle_SecondInstanceFailsWhileFirstRunning(t *testing.T) {


### PR DESCRIPTION
### Brief description of Pull Request
This addresses an issue brought up in https://github.com/grafana/alloy/issues/5669, where if you attempt to run _multiple_ instances of the `alloyengine` extension you will encounter errors. These errors are because the default engine has global state that gets mucked up when you try to run multiple pipelines in the same process 

### Pull Request Details
My proposal is: I don't think we should support this. We don't currently have a way of doing that outside of the extension, and if we enable the ability to run multiple default pipelines in one collector instance via the extension, it opens up for quite some complexity. Instead, I think we should do what extensions like `pprof` do and enforce a rule that only one extension instance can be started/running at once. I have stolen [their implementation](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/acb90fdf6aa319b6aaf717d2895b95f843e59eba/extension/pprofextension/pprofextension.go#L22) and applied it here to the alloy engine extension, and adjusted the documentation accordingly

This change means that users can do something like 

```
extensions:
  alloyengine/one:
    config:
      file: /opt/pwd/config.alloy
    flags:
      server.http.listen-addr: 0.0.0.0:12345
  alloyengine/two:
    config:
      file: /opt/pwd/config.alloy
    flags:
      server.http.listen-addr: 0.0.0.0:12346

service:
  extensions: [alloyengine/one]
```

but as soon as they add an extension to their running list like

```
service:
  extensions: [alloyengine/one, alloyengine/two]
```

they will encounter an error with a clear indicator that only one extension can be running.

The other approach could be to _merge_ the config for multiple extensions into one running extension - but this isn't very conceptually clean, and we already allow users to pass in a directory (since the extension just exposes the same functionality as the `run` CLI command). I've made it a bit more clear in the docs here that you can indeed pass a directory through the extension, I feel that wasn't so clear before. 