### PR TITLE
docs: Fix directory path in Monitor Kubernetes Logs document

### DIFF
--- a/docs/sources/monitor/monitor-kubernetes-logs.md
+++ b/docs/sources/monitor/monitor-kubernetes-logs.md
@@ -45,10 +45,10 @@ Follow these steps to clone the scenarios repository and deploy the monitoring e
 
 1. Set up the example Kubernetes environment:
 
-   1. Navigate to the `alloy-scenarios/k8s-logs` directory:
+   1. Navigate to the `alloy-scenarios/k8s/logs` directory:
 
       ```shell
-      cd alloy-scenarios/k8s-logs
+      cd alloy-scenarios/k8s/logs
       ```
 
    1. Create a local Kubernetes cluster using kind.  


### PR DESCRIPTION
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style. For details on this,
  check out the Contributors Guide linked above.
-->

### Brief description of Pull Request

Directory path to the logs dir alloy-scenarios -> k8s -> logs was incorrect in the docs. This dir contains the loki-values.yaml which is essential to follow the tutorial "Monitor Kubernetes logs with Grafana Alloy". This PR fixes the minor discrepancy.

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->
Issue was not created because this was a minor fix in the docs.

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
