### PR TITLE
docs: Add OracleDB permissions prerequisites to prometheus.exporter.oracledb

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.exporter.oracledb.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.oracledb.md
@@ -43,7 +43,7 @@ Set the following environment variables for Oracle Client library access:
 ### Database user permissions
 
 The database user specified in the connection string must have permissions to query Oracle system views.
-The user requires the `SELECT_CATALOG_ROLE` privilege, or `SELECT` permission on specific system views.
+The user requires the `SELECT_CATALOG_ROLE` role, or `SELECT` privilege on specific system views.
 
 Refer to the [Oracle AI Database Metrics Exporter Installation guide][oracledb_exporter_install] for the complete list of required permissions.
 


### PR DESCRIPTION
The doc for prometheus.exporter.oracledb was missing important info about Oracle DB permissions requirements.

This PR adds a link to upstream Oracle documentation where the exact permissions are documented. The select statements were not included here because the requirements may change over time and it's best to link to official docs vs duplicate in Alloy docs.

Fixes: https://github.com/grafana/support-escalations/issues/18165