### PR TITLE
docs: Update mimir.rules.kubernetes tenant_id info

### DIFF
--- a/docs/sources/reference/components/mimir/mimir.rules.kubernetes.md
+++ b/docs/sources/reference/components/mimir/mimir.rules.kubernetes.md
@@ -92,7 +92,7 @@ The mimir-distributed Helm chart enables multi-tenancy by default.
 When you enable multi-tenancy, requests to the Mimir Ruler API must include an `X-Scope-OrgID` tenant header.
 The `mimir.rules.kubernetes` component sends this header only when you configure the `tenant_id` argument.
 
-If you don't set `tenant_id`, the Mimir API returns the error `401 Unauthorized: no org id`
+If you don't set `tenant_id`, the Mimir API returns the error: `401 Unauthorized: no org id`.
 
 To resolve this, set the `tenant_id` argument in the component configuration.
 {{< /admonition >}}


### PR DESCRIPTION
This PR improves the `mimir.rules.kubernetes` documentation by clarifying multi-tenancy requirements.

### Changes

- Multi-tenancy clarification
- Updated the tenant_id argument description to clarify it's required when multi-tenancy is enabled
- Added an admonition explaining that the mimir-distributed Helm chart enables multi-tenancy by default
- Documented the `401 Unauthorized: no org id` error users encounter when `tenant_id` is not set with multi-tenant Mimir
- Provided resolution steps for the error
- Converted a bunch of passive voice to active voice
- Semantic line breaks
- Consistency with hyphen use
- Fixed some typos

Fixes: https://github.com/grafana/alloy/issues/1449