### PR TITLE
test(pyroscope.ebpf): Add failing test for __GI___clone3 symbol resolution

### DIFF
--- a/internal/component/pyroscope/ebpf/symb/irsymcache/resolve_clone3_test.go
+++ b/internal/component/pyroscope/ebpf/symb/irsymcache/resolve_clone3_test.go
@@ -1,0 +1,32 @@
+//go:build unix
+
+package irsymcache
+
+import (
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+)
+
+// TODO: symbols like __GI___clone3 are confusing in profiles, find a way to use a proper/nicer name.
+func TestResolveClone3(t *testing.T) {
+	resolver, err := NewFSCache(log.NewNopLogger(), tf, Options{
+		Path:        t.TempDir(),
+		SizeEntries: 1024,
+	})
+	require.NoError(t, err)
+	defer resolver.Close()
+
+	fid := testFileId(3)
+	md := testElfRef(testLibcFIle)
+	err = resolver.ObserveExecutable(fid, md)
+	require.NoError(t, err)
+
+	// 0x129c10 has both __clone3 and __GI___clone3 symbols
+	// We expect the resolver to return "__clone3", not "__GI___clone3"
+	si, err := resolver.ResolveAddress(fid, 0x129c10)
+	require.NoError(t, err)
+	require.Equal(t, libpf.Intern("__clone3"), si.FunctionName)
+}


### PR DESCRIPTION
## Summary
- Adds a failing test that verifies the symbol resolver returns `__clone3` instead of `__GI___clone3` for address `0x129c10` in libc
- Related to improving symbol name quality in profiles (glibc internal `__GI_` prefixed names are confusing)

## Test plan
- [ ] Run `go test ./internal/component/pyroscope/ebpf/symb/irsymcache/ -run TestResolveClone3` — expected to fail until the resolver is updated to prefer non-`__GI_` symbol names

🤖 Generated with [Claude Code](https://claude.com/claude-code)