### PR TITLE
docs: Update debug metrics for components exposing http server

### DIFF
--- a/docs/sources/reference/components/loki/loki.source.api.md
+++ b/docs/sources/reference/components/loki/loki.source.api.md
@@ -101,9 +101,10 @@ The `tls` block configures TLS for the HTTP server.
 The following are some of the metrics that are exposed when this component is used.
 The metrics include labels such as `status_code` where relevant, which can be used to measure request success rates.
 
-* `loki_source_api_request_duration_seconds`: Histogram metric for HTTP request handling time, in seconds.
-* `loki_source_api_inflight_requests`: Gauge metric for the current number of inflight requests.
-* `loki_source_api_request_message_bytes`: Histogram metric for request message size, in bytes.
+* `loki_source_api_request_duration_seconds` (histogram): HTTP request handling time, in seconds.
+* `loki_source_api_inflight_requests` (gauge): Current number of inflight requests.
+* `loki_source_api_request_message_bytes` (histogram): Request message size, in bytes.
+* `loki_source_api_response_message_bytes` (histogram): Response message size, in bytes.
 * `loki_source_api_tcp_connections` (gauge): Current number of accepted TCP connections.
 * `loki_source_api_entries_written` (counter): Total number of log entries forwarded.
 

--- a/docs/sources/reference/components/loki/loki.source.awsfirehose.md
+++ b/docs/sources/reference/components/loki/loki.source.awsfirehose.md
@@ -141,13 +141,15 @@ The metrics include labels such as `status_code` where relevant, which you can u
 {{< /admonition >}}
 
 * `loki_source_awsfirehose_batch_size` (histogram): Size (in units) of the number of records received per request.
-* `loki_source_awsfirehose_inflight_requests`: Gauge metric for the current number of inflight requests.
-* `loki_source_awsfirehose_request_duration_seconds`: Histogram metric for HTTP request handling time, in seconds.
+* `loki_source_awsfirehose_inflight_requests` (gauge): Current number of inflight requests.
+* `loki_source_awsfirehose_request_duration_seconds` (histogram): HTTP request handling time, in seconds.
 * `loki_source_awsfirehose_invalid_static_labels_errors` (counter): Count number of errors while processing Data Firehose static labels.
-* `loki_source_awsfirehose_request_message_bytes`: Histogram metric for request message size, in bytes.
+* `loki_source_awsfirehose_request_message_bytes` (histogram): Request message size, in bytes.
+* `loki_source_awsfirehose_response_message_bytes` (histogram): Response message size, in bytes.
 * `loki_source_awsfirehose_record_errors` (counter): Count of errors while decoding an individual record.
 * `loki_source_awsfirehose_records_received` (counter): Count of records received.
 * `loki_source_awsfirehose_request_errors` (counter): Count of errors while receiving a request.
+* `loki_source_awsfirehose_tcp_connections` (gauge): Current number of accepted TCP connections.
 
 ## Example
 

--- a/docs/sources/reference/components/loki/loki.source.gcplog.md
+++ b/docs/sources/reference/components/loki/loki.source.gcplog.md
@@ -165,9 +165,11 @@ When using the `pull` strategy, the component exposes the following debug metric
 
 When using the `push` strategy, the component exposes the following debug metrics:
 
-* `loki_source_gcplog_push_inflight_requests`: Gauge metric for the current number of inflight requests.
-* `loki_source_gcplog_push_request_duration_seconds`: Histogram metric for HTTP request handling time, in seconds.
-* `loki_source_gcplog_push_request_message_bytes`: Histogram metric for request message size, in bytes.
+* `loki_source_gcplog_push_inflight_requests` (gauge): Current number of inflight requests.
+* `loki_source_gcplog_push_request_duration_seconds` (histogram): HTTP request handling time, in seconds.
+* `loki_source_gcplog_push_request_message_bytes` (histogram): Request message size, in bytes.
+* `loki_source_gcplog_push_response_message_bytes` (histogram): Response message size, in bytes.
+* `loki_source_gcplog_push_tcp_connections` (gauge): Current number of accepted TCP connections.
 * `loki_source_gcplog_push_entries_total` (counter): Number of entries received by the gcplog target.
 * `loki_source_gcplog_push_parsing_errors_total` (counter): Number of parsing errors while receiving gcplog messages.
 

--- a/docs/sources/reference/components/loki/loki.source.heroku.md
+++ b/docs/sources/reference/components/loki/loki.source.heroku.md
@@ -116,9 +116,11 @@ configuration.
 
 ## Debug metrics
 
-* `loki_source_heroku_drain_target_inflight_requests`: Gauge metric for the current number of inflight requests.
-* `loki_source_heroku_drain_target_request_duration_seconds`: Histogram metric for HTTP request handling time, in seconds.
-* `loki_source_heroku_drain_target_request_message_bytes`: Histogram metric for request message size, in bytes.
+* `loki_source_heroku_drain_target_inflight_requests` (gauge): Current number of inflight requests.
+* `loki_source_heroku_drain_target_request_duration_seconds` (histogram): HTTP request handling time, in seconds.
+* `loki_source_heroku_drain_target_request_message_bytes` (histogram): Request message size, in bytes.
+* `loki_source_heroku_drain_target_response_message_bytes` (histogram): Response message size, in bytes.
+* `loki_source_heroku_drain_target_tcp_connections` (gauge): Current number of accepted TCP connections.
 * `loki_source_heroku_drain_entries_total` (counter): Number of successful entries received by the Heroku target.
 * `loki_source_heroku_drain_parsing_errors_total` (counter): Number of parsing errors while receiving Heroku messages.
 


### PR DESCRIPTION
### Pull Request Details
When starting a http server using dskit.Server we register a bunch of metrics. These are not documented and I went through the list and added the ones I would see useful to have.

The full list ist:
  - `<namespace>_tcp_connections`
  - `<namespace>_tcp_connections_limit`
  - `<namespace>_grpc_concurrent_streams_limit`
  - `<namespace>_request_duration_seconds`
  - `<namespace>_per_tenant_request_duration_seconds`
  - `<namespace>_per_tenant_request_total`
  - `<namespace>_request_message_bytes`
  - `<namespace>_response_message_bytes`
  - `<namespace>_inflight_requests`
  - `<namespace>_request_throughput_samples_processed`
  - `<namespace>_server_invalid_cluster_validation_label_requests_total`

### Issue(s) fixed by this Pull Request

Fixes: https://github.com/grafana/alloy/issues/5751

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
