### PR TITLE
docs: Improve shepherding-releases with CLI commands and numbered steps [BACKPORT]

### DIFF
--- a/docs/developer/shepherding-releases.md
+++ b/docs/developer/shepherding-releases.md
@@ -10,42 +10,62 @@ might encounter and how to handle them.
 - [OTel dependencies](./updating-otel/README.md) should be updated every ~6 weeks.
 - Prometheus dependencies should be updated every ~6 weeks.
 
-### 1. Run the `Create Release Branch` pinned workflow on the Actions page
+### 1. Run the `Create Release Branch` workflow
 
 **_NOTE: Creating a release branch should be considered as "cutting off" the release. Past this
 point, only critical fixes should be merged into the branch until the release is final._**
 
-1. Leave everything as it is except uncheck the `Dry run` box.
-2. (This will create a new release branch, a new backport tag, and open a draft release-please PR.)
+Run the workflow using the GitHub CLI:
 
-### 2. When ready, cut an RC by running the `Create Release Candidate` pinned workflow on the Actions page
+```sh
+gh workflow run release-create-branch.yml --repo grafana/alloy --field dry_run=false
+```
 
-1.  For `Use workflow from`, select the release branch in question.
-2.  Make sure to uncheck the `Dry run` box.
-3.  (This will trigger workflows to create a draft release on GitHub, build the release artifacts,
-    and attach them to the release.)
-4.  Once everything is attached, add any relevant changelog details to the RC draft release and
-    publish it.
+Alternatively, trigger it from the Actions page on github.com by leaving everything as it is except unchecking the `Dry run` box.
 
-### 3. (Optional) Add critical fixes to the release
+This will create a new release branch, a new backport tag, and open a draft release-please PR.
 
-1. If you need to add critical fixes to the release branch after testing an RC, check out the
-   section below on backporting fixes to a release branch.
+### 2. When ready, cut an RC by running the `Create Release Candidate` workflow
 
-### 4. When ready, cut the release
+1. Run the workflow using either the GitHub CLI or github.com.
+   - **From the GitHub CLI**
+      - Run the following, replacing `<VERSION>` with the release branch (e.g. `v1.14`):
+
+        ```sh
+        gh workflow run release-create-rc.yml --repo grafana/alloy --ref release/<VERSION> --field dry_run=false
+        ```
+   - **From github.com**
+      - Navigate to the pinned workflow on the Actions page.
+      - Select the release branch under `Use workflow from`.
+      - Uncheck the `Dry run` box.
+   - This will trigger workflows to create a tag for the RC, draft a release on GitHub, build the release artifacts, and attach them to the release.
+
+2. Once everything is attached, add any relevant changelog details to the RC draft release and publish it from either the CLI or github.com. For example:
+
+   ```sh
+   gh release edit <VERSION>-rc.0 --draft=false --repo grafana/alloy
+   ```
+
+### 3. Validate the RC on internal deployments
+
+1. Deploy the RC to internal clusters following the [Argo Workflows documentation](https://github.com/grafana/alloy-internal/tree/main/Argo-Workflows) in the internal repo.
+2. Validate performance metrics are consistent with the prior version.
+3. Validate components are healthy.
+
+### 4. (Optional) Add critical fixes to the release
+
+If you find issues during validation, check out the section below on backporting fixes to a release
+branch. Once fixes are merged, cut a new RC and repeat step 3.
+
+### 5. When ready, cut the release
 
 1. Move the release-please PR out of draft and review it.
    1. You might realize that some changelog entries don't look the way you want. To address that,
       check out the section below on modifying a PR's changelog entry after it's been merged.
 2. Merge the release-please PR.
-3. (This will trigger workflows to create a draft release on GitHub, build the release artifacts,
-   and attach them to the release.)
+3. This will trigger workflows to create a draft release on GitHub, build the release artifacts,
+   and attach them to the release.
 4. Once everything is attached, publish the release.
-
-### 5. Validate the release on internal deployments
-
-1.  Validate performance metrics are consistent with the prior version.
-2.  Validate components are healthy.
 
 ### 6. Update Helm Chart
 


### PR DESCRIPTION
Needs to be backported in order to backport [this one](https://github.com/grafana/alloy/pull/5797)