### PR TITLE
feat(prometheus.enrich): Support multi-label matching

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.enrich.md
+++ b/docs/sources/reference/components/prometheus/prometheus.enrich.md
@@ -13,17 +13,39 @@ title: prometheus.enrich
 {{< docs/shared lookup="stability/experimental.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 The `prometheus.enrich` component enriches metrics with additional labels from service discovery targets.
-It matches a label from incoming metrics against a label from discovered targets, and copies specified labels from the
-matched target to the metric sample. If match doesn't happen, the metrics will be passed through.
+It matches labels from incoming metrics against labels from discovered targets, and copies specified labels from the
+matched target to the metric sample. If no match occurs, the metrics are passed through unchanged.
+
+The component supports two matching modes:
+
+- **Single-label matching (legacy):** Match on a single label pair using `target_match_label` and optionally `metrics_match_label`.
+- **Multi-label matching:** Match on multiple labels simultaneously using `target_to_metric_match`. The map keys are target label names and the values are the corresponding metric label names. All labels in the map must match for enrichment to occur.
 
 ## Usage
+
+### Single-label matching
 
 ```alloy
 prometheus.enrich "<LABEL>" {
   targets = <DISCOVERY_COMPONENT>.targets
-  
+
   target_match_label = "<LABEL>"
-  
+
+  forward_to = [<RECEIVER_LIST>]
+}
+```
+
+### Multi-label matching
+
+```alloy
+prometheus.enrich "<LABEL>" {
+  targets = <DISCOVERY_COMPONENT>.targets
+
+  target_to_metric_match = {
+    "<TARGET_LABEL_1>" = "<METRIC_LABEL_1>",
+    "<TARGET_LABEL_2>" = "<METRIC_LABEL_2>",
+  }
+
   forward_to = [<RECEIVER_LIST>]
 }
 ```
@@ -32,15 +54,21 @@ prometheus.enrich "<LABEL>" {
 
 You can use the following arguments with `prometheus.enrich`:
 
-| Name                  | Type                    | Description                                                                                        | Default | Required |
-|-----------------------|-------------------------|----------------------------------------------------------------------------------------------------|---------|----------|
-| `forward_to`          | `list(MetricsReceiver)` | Where the metrics should be forwarded to, after enrichment.                                        |         | yes      |
-| `target_match_label`  | `string`                | The label from discovered targets to match against, for example, `"__inventory_consul_service"`.   |         | yes      |
-| `targets`             | `list(map(string))`     | List of targets from a discovery component.                                                        |         | yes      |
-| `labels_to_copy`      | `list(string)`          | List of labels to copy from discovered targets to metrics. If empty, all labels are copied.        |         | no       |
-| `metrics_match_label` | `string`                | The label from incoming metrics to match against discovered targets, for example `"service_name"`. |         | no       |
+| Name                                | Type                           | Description                                                                                        | Default | Required |
+|-------------------------------------|--------------------------------|----------------------------------------------------------------------------------------------------|---------|----------|
+| `forward_to`                        | `list(MetricsReceiver)`        | Where the metrics should be forwarded to, after enrichment.                                        |         | yes      |
+| `targets`                           | `list(map(string))`            | List of targets from a discovery component.                                                        |         | yes      |
+| `target_to_metric_match`            | `map(string)`                  | Map of target label name to metric label name. All entries must match for enrichment.                   |         | no       |
+| `target_match_label`                | `string`                       | The label from discovered targets to match against, for example, `"__inventory_consul_service"`.   |         | no       |
+| `metrics_match_label`               | `string`                       | The label from incoming metrics to match against discovered targets, for example `"service_name"`. |         | no       |
+| `labels_to_copy`                    | `list(string)`                 | List of labels to copy from discovered targets to metrics. If empty, all labels are copied.        |         | no       |
 
-If not provided, the `metrics_match_label` attribute defaults to the value of `target_match_label`.
+You must specify exactly one of:
+
+- `target_match_label` (with optional `metrics_match_label`) for single-label matching, or
+- `target_to_metric_match` for multi-label matching.
+
+These two modes are mutually exclusive. If not provided, the `metrics_match_label` attribute defaults to the value of `target_match_label`.
 
 ## Blocks
 
@@ -62,9 +90,9 @@ The following values are exported:
 
 * `prometheus_fanout_latency` (histogram): Write latency for sending to direct and indirect components.
 * `prometheus_forwarded_samples_total` (counter): Total number of samples sent to downstream components.
-* `prometheus_target_cache_size` (gauge): The number of targets in the `targets` list.
+* `prometheus_target_cache_size` (gauge): Total number of cached target entries.
 
-## Example
+## Examples
 
 ### Enrich metrics from `prometheus.scrape`
 
@@ -107,31 +135,71 @@ The following example shows how the `prometheus.enrich` enriches incoming metric
 `prometheus.remote_write.default` component:
 
 ```alloy
-discovery.file "network_devices" {  
-   files = ["/etc/alloy/devices.json"]  
-}  
-  
+discovery.file "network_devices" {
+   files = ["/etc/alloy/devices.json"]
+}
+
 prometheus.receive_http "default" {
   http {
     listen_address = "0.0.0.0"
     listen_port = 9999
   }
-  
+
   forward_to = [prometheus.enrich.default.receiver]
 }
 
-prometheus.enrich "default" {  
-    targets = discovery.file.network_devices.targets  
-  
-    target_match_label = "hostname"  
-    
-    forward_to = [prometheus.remote_write.default.receiver]  
+prometheus.enrich "default" {
+    targets = discovery.file.network_devices.targets
+
+    target_match_label = "hostname"
+
+    forward_to = [prometheus.remote_write.default.receiver]
 }
 
-prometheus.remote_write "default" {  
-  endpoint {  
-    url = "http://mimir:9009/api/v1/push"    
-  }    
+prometheus.remote_write "default" {
+  endpoint {
+    url = "http://mimir:9009/api/v1/push"
+  }
+}
+```
+
+### Multi-label matching with Kubernetes metadata
+
+The following example enriches cadvisor metrics with Kubernetes pod metadata,
+matching on namespace, pod, and container labels simultaneously.
+
+```alloy
+discovery.kubernetes "pods" {
+  role = "pod"
+}
+
+prometheus.scrape "cadvisor" {
+  targets = [
+    {"__address__" = "localhost:10250", "__metrics_path__" = "/metrics/cadvisor"},
+  ]
+  scheme = "https"
+
+  forward_to = [prometheus.enrich.k8s_meta.receiver]
+}
+
+prometheus.enrich "k8s_meta" {
+    targets = discovery.kubernetes.pods.targets
+
+    target_to_metric_match = {
+        "__meta_kubernetes_namespace"          = "namespace",
+        "__meta_kubernetes_pod_name"           = "pod",
+        "__meta_kubernetes_pod_container_name" = "container",
+    }
+
+    labels_to_copy = ["__meta_kubernetes_pod_node_name", "__meta_kubernetes_pod_label_app"]
+
+    forward_to = [prometheus.remote_write.default.receiver]
+}
+
+prometheus.remote_write "default" {
+  endpoint {
+    url = "http://mimir:9009/api/v1/push"
+  }
 }
 ```
 

--- a/docs/sources/reference/components/prometheus/prometheus.enrich.md
+++ b/docs/sources/reference/components/prometheus/prometheus.enrich.md
@@ -16,26 +16,15 @@ The `prometheus.enrich` component enriches metrics with additional labels from s
 It matches labels from incoming metrics against labels from discovered targets, and copies specified labels from the
 matched target to the metric sample. If no match occurs, the metrics are passed through unchanged.
 
-The component supports two matching modes:
+Use the `target_to_metric_match` argument to specify which target labels correspond to which metric labels. The map keys are target label names and the values are the corresponding metric label names. All labels in the map must match for enrichment to occur.
 
-- **Single-label matching (legacy):** Match on a single label pair using `target_match_label` and optionally `metrics_match_label`.
-- **Multi-label matching:** Match on multiple labels simultaneously using `target_to_metric_match`. The map keys are target label names and the values are the corresponding metric label names. All labels in the map must match for enrichment to occur.
+{{< admonition type="warning" >}}
+The `target_match_label` and `metrics_match_label` arguments are deprecated in favor of `target_to_metric_match`.
+If `target_to_metric_match` is set, it takes precedence. Replace `target_match_label = "hostname"` with `target_to_metric_match = {"hostname" = "hostname"}`.
+These deprecated arguments will be removed in a future release.
+{{< /admonition >}}
 
 ## Usage
-
-### Single-label matching
-
-```alloy
-prometheus.enrich "<LABEL>" {
-  targets = <DISCOVERY_COMPONENT>.targets
-
-  target_match_label = "<LABEL>"
-
-  forward_to = [<RECEIVER_LIST>]
-}
-```
-
-### Multi-label matching
 
 ```alloy
 prometheus.enrich "<LABEL>" {
@@ -54,23 +43,14 @@ prometheus.enrich "<LABEL>" {
 
 You can use the following arguments with `prometheus.enrich`:
 
-| Name                                | Type                           | Description                                                                                        | Default | Required |
-|-------------------------------------|--------------------------------|----------------------------------------------------------------------------------------------------|---------|----------|
-| `forward_to`                        | `list(MetricsReceiver)`        | Where the metrics should be forwarded to, after enrichment.                                        |         | yes      |
-| `targets`                           | `list(map(string))`            | List of targets from a discovery component.                                                        |         | yes      |
-| `target_to_metric_match`            | `map(string)`                  | Map of target label name to metric label name. All entries must match for enrichment.              |         | no       |
-| `target_match_label`                | `string`                       | The label from discovered targets to match against, for example, `"__inventory_consul_service"`.   |         | no       |
-| `metrics_match_label`               | `string`                       | The label from incoming metrics to match against discovered targets, for example `"service_name"`. |         | no       |
-| `labels_to_copy`                    | `list(string)`                 | List of labels to copy from discovered targets to metrics. If empty, all labels are copied.        |         | no       |
-
-
-
-You must specify exactly one of the following:
-
-- `target_match_label` (with optional `metrics_match_label`) for single-label matching
-- `target_to_metric_match` for multi-label matching.
-
-These two modes are mutually exclusive. If you don't set the `metrics_match_label`, it defaults to the value of `target_match_label`.
+| Name                                | Type                           | Description                                                                                                     | Default | Required |
+|-------------------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------|---------|----------|
+| `forward_to`                        | `list(MetricsReceiver)`        | Where the metrics should be forwarded to, after enrichment.                                                     |         | yes      |
+| `targets`                           | `list(map(string))`            | List of targets from a discovery component.                                                                     |         | yes      |
+| `target_to_metric_match`            | `map(string)`                  | Map of target label name to metric label name. All entries must match for enrichment.                           |         | no       |
+| `target_match_label`                | `string`                       | (Deprecated) The label from discovered targets to match against, for example, `"__inventory_consul_service"`.   |         | no       |
+| `metrics_match_label`               | `string`                       | (Deprecated) The label from incoming metrics to match against discovered targets, for example `"service_name"`. |         | no       |
+| `labels_to_copy`                    | `list(string)`                 | List of labels to copy from discovered targets to metrics. If empty, all labels are copied.                     |         | no       |
 
 ## Blocks
 
@@ -118,7 +98,9 @@ prometheus.scrape "default" {
 prometheus.enrich "default" {
 	targets = discovery.http.default.targets
 
-	target_match_label = "hostname"
+	target_to_metric_match = {
+		"hostname" = "hostname",
+	}
 
 	forward_to = [prometheus.remote_write.default.receiver]
 }
@@ -132,7 +114,9 @@ prometheus.remote_write "default" {
 
 ### Enrich metrics from `prometheus.receive_http`
 
-The following example enriches cadvisor metrics with Kubernetes Pod metadata, matching on namespace, Pod, and container labels simultaneously.
+The following example shows how the `prometheus.enrich` enriches incoming metrics from
+`prometheus.receive_http.default`, using file-based discovery, and forwards the results to
+`prometheus.remote_write.default` component:
 
 ```alloy
 discovery.file "network_devices" {
@@ -151,7 +135,9 @@ prometheus.receive_http "default" {
 prometheus.enrich "default" {
     targets = discovery.file.network_devices.targets
 
-    target_match_label = "hostname"
+    target_to_metric_match = {
+        "hostname" = "hostname",
+    }
 
     forward_to = [prometheus.remote_write.default.receiver]
 }
@@ -165,8 +151,7 @@ prometheus.remote_write "default" {
 
 ### Multi-label matching with Kubernetes metadata
 
-The following example enriches cadvisor metrics with Kubernetes pod metadata,
-matching on namespace, pod, and container labels simultaneously.
+The following example enriches cadvisor metrics with Kubernetes Pod metadata, matching on namespace, Pod, and container labels simultaneously.
 
 ```alloy
 discovery.kubernetes "pods" {

--- a/docs/sources/reference/components/prometheus/prometheus.enrich.md
+++ b/docs/sources/reference/components/prometheus/prometheus.enrich.md
@@ -58,17 +58,19 @@ You can use the following arguments with `prometheus.enrich`:
 |-------------------------------------|--------------------------------|----------------------------------------------------------------------------------------------------|---------|----------|
 | `forward_to`                        | `list(MetricsReceiver)`        | Where the metrics should be forwarded to, after enrichment.                                        |         | yes      |
 | `targets`                           | `list(map(string))`            | List of targets from a discovery component.                                                        |         | yes      |
-| `target_to_metric_match`            | `map(string)`                  | Map of target label name to metric label name. All entries must match for enrichment.                   |         | no       |
+| `target_to_metric_match`            | `map(string)`                  | Map of target label name to metric label name. All entries must match for enrichment.              |         | no       |
 | `target_match_label`                | `string`                       | The label from discovered targets to match against, for example, `"__inventory_consul_service"`.   |         | no       |
 | `metrics_match_label`               | `string`                       | The label from incoming metrics to match against discovered targets, for example `"service_name"`. |         | no       |
 | `labels_to_copy`                    | `list(string)`                 | List of labels to copy from discovered targets to metrics. If empty, all labels are copied.        |         | no       |
 
-You must specify exactly one of:
 
-- `target_match_label` (with optional `metrics_match_label`) for single-label matching, or
+
+You must specify exactly one of the following:
+
+- `target_match_label` (with optional `metrics_match_label`) for single-label matching
 - `target_to_metric_match` for multi-label matching.
 
-These two modes are mutually exclusive. If not provided, the `metrics_match_label` attribute defaults to the value of `target_match_label`.
+These two modes are mutually exclusive. If you don't set the `metrics_match_label`, it defaults to the value of `target_match_label`.
 
 ## Blocks
 
@@ -130,9 +132,7 @@ prometheus.remote_write "default" {
 
 ### Enrich metrics from `prometheus.receive_http`
 
-The following example shows how the `prometheus.enrich` enriches incoming metrics from
-`prometheus.receive_http.default`, using HTTP discovery, and forwards the results to
-`prometheus.remote_write.default` component:
+The following example enriches cadvisor metrics with Kubernetes Pod metadata, matching on namespace, Pod, and container labels simultaneously.
 
 ```alloy
 discovery.file "network_devices" {

--- a/internal/component/prometheus/enrich/enrich.go
+++ b/internal/component/prometheus/enrich/enrich.go
@@ -3,6 +3,7 @@ package enrich
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 
 	prometheus_client "github.com/prometheus/client_golang/prometheus"
@@ -38,22 +39,101 @@ type Arguments struct {
 	// The targets to use for enrichment
 	Targets []discovery.Target `alloy:"targets,attr"`
 
-	// Which label from targets to use for matching (e.g. "hostname", "ip")
-	TargetMatchLabel string `alloy:"target_match_label,attr"`
+	// Multi-label matching: a map of target_label -> metric_label.
+	// Mutually exclusive with target_match_label / metrics_match_label.
+	TargetToMetricMatch map[string]string `alloy:"target_to_metric_match,attr,optional"`
 
-	// Which label from logs to match against (e.g. "hostname", "ip")
-	// If not specified, TargetMatchLabel will be used
+	// Legacy: which label from targets to use for matching (e.g. "hostname", "ip").
+	// Mutually exclusive with target_to_metric_match.
+	TargetMatchLabel string `alloy:"target_match_label,attr,optional"`
+
+	// Legacy: which label from metrics to match against (e.g. "hostname", "ip").
+	// If not specified, TargetMatchLabel will be used.
+	// Mutually exclusive with target_to_metric_match.
 	MetricsMatchLabel string `alloy:"metrics_match_label,attr,optional"`
 
-	// List of labels to copy from discovered targets to logs. If empty, all labels will be copied.
+	// List of labels to copy from discovered targets to metrics. If empty, all labels will be copied.
 	LabelsToCopy []string `alloy:"labels_to_copy,attr,optional"`
 
 	ForwardTo []storage.Appendable `alloy:"forward_to,attr"`
 }
 
+// Validate implements syntax.Validator.
+func (a Arguments) Validate() error {
+	hasLegacy := a.TargetMatchLabel != "" || a.MetricsMatchLabel != ""
+	hasNew := len(a.TargetToMetricMatch) > 0
+
+	if hasLegacy && hasNew {
+		return fmt.Errorf("target_to_metric_match and legacy fields (target_match_label, metrics_match_label) are mutually exclusive")
+	}
+	if !hasLegacy && !hasNew {
+		return fmt.Errorf("at least one match mechanism must be specified: set target_match_label or target_to_metric_match")
+	}
+	if hasLegacy && a.TargetMatchLabel == "" {
+		return fmt.Errorf("target_match_label must be set when using legacy match fields")
+	}
+	return nil
+}
+
 // Exports holds values which are exported by the prometheus.enrich component.
 type Exports struct {
 	Receiver storage.Appendable `alloy:"receiver,attr"`
+}
+
+// FNV-64a helpers (same algorithm as
+// https://github.com/prometheus/common/blob/0dfcdfb00df68e0b14a98f20d90f4b3ff12432e6/model/fnv.go).
+const (
+	offset64 = 14695981039346656037
+	prime64  = 1099511628211
+	sep      = "\xff" // separator to prevent hash collisions across value boundaries
+)
+
+func hashNew() uint64 {
+	return offset64
+}
+
+func hashAdd(h uint64, s string) uint64 {
+	for i := 0; i < len(s); i++ {
+		h ^= uint64(s[i])
+		h *= prime64
+	}
+	return h
+}
+
+// hashValuesFromLabelSet hashes the values of the given label names (in order)
+// from a model.LabelSet. Returns (0, false) if any label is missing or empty.
+func hashValuesFromLabelSet(ls model.LabelSet, names []string) (uint64, bool) {
+	h := hashNew()
+	for _, name := range names {
+		v := string(ls[model.LabelName(name)])
+		if v == "" {
+			return 0, false
+		}
+		h = hashAdd(h, v)
+		h = hashAdd(h, sep)
+	}
+	return h, true
+}
+
+// hashValuesFromLabels hashes the values of the given label names (in order)
+// from a labels.Labels. Returns (0, false) if any label is missing or empty.
+func hashValuesFromLabels(lbls labels.Labels, names []string) (uint64, bool) {
+	h := hashNew()
+	for _, name := range names {
+		v := lbls.Get(name)
+		if v == "" {
+			return 0, false
+		}
+		h = hashAdd(h, v)
+		h = hashAdd(h, sep)
+	}
+	return h, true
+}
+
+// matchCache holds the hash-based lookup for a match strategy.
+type matchCache struct {
+	sortedMetricLabels []string                  // metric label names to hash, sorted by corresponding target label name
+	cache              map[uint64]model.LabelSet // hash of values -> target label set
 }
 
 type Component struct {
@@ -65,8 +145,8 @@ type Component struct {
 	fanout   *prometheus.Fanout
 	exited   atomic.Bool
 
-	targetsCache map[string]model.LabelSet
-	cacheMutex   sync.RWMutex
+	mc         *matchCache
+	cacheMutex sync.RWMutex
 
 	cacheSize prometheus_client.Gauge
 }
@@ -173,9 +253,10 @@ func (c *Component) Update(args component.Arguments) error {
 	defer c.mut.Unlock()
 
 	newArgs := args.(Arguments)
+	c.args = newArgs
 	c.fanout.UpdateChildren(newArgs.ForwardTo)
 
-	c.refreshCacheFromTargets(newArgs.Targets)
+	c.refreshCacheFromTargets(newArgs)
 
 	c.opts.OnStateChange(Exports{Receiver: c.receiver})
 
@@ -183,24 +264,20 @@ func (c *Component) Update(args component.Arguments) error {
 }
 
 func (c *Component) enrich(lbls labels.Labels) labels.Labels {
-	var targetSet model.LabelSet
-	var ok bool
+	c.cacheMutex.RLock()
+	mc := c.mc
+	c.cacheMutex.RUnlock()
 
-	matchLabel := c.args.MetricsMatchLabel
-	if matchLabel == "" {
-		matchLabel = c.args.TargetMatchLabel
-	}
-
-	mlv := lbls.Get(matchLabel)
-	if mlv == "" {
+	if mc == nil {
 		return lbls
 	}
 
-	c.cacheMutex.RLock()
-	targetSet, ok = c.targetsCache[mlv]
-	c.cacheMutex.RUnlock()
-
+	h, ok := hashValuesFromLabels(lbls, mc.sortedMetricLabels)
 	if !ok {
+		return lbls
+	}
+	targetSet, found := mc.cache[h]
+	if !found {
 		return lbls
 	}
 
@@ -216,28 +293,58 @@ func (c *Component) enrich(lbls labels.Labels) labels.Labels {
 			}
 		}
 	}
-
 	return newLabels.Labels()
 }
 
-func (c *Component) refreshCacheFromTargets(targets []discovery.Target) {
-	newCache := make(map[string]model.LabelSet)
+// sortStrategyMap converts a target_label->metric_label map into sorted
+// parallel slices for deterministic hashing.
+func sortStrategyMap(m map[string]string) (targetLabels, metricLabels []string) {
+	targetLabels = make([]string, 0, len(m))
+	for k := range m {
+		targetLabels = append(targetLabels, k)
+	}
+	sort.Strings(targetLabels)
 
-	for _, target := range targets {
+	metricLabels = make([]string, 0, len(targetLabels))
+	for _, k := range targetLabels {
+		metricLabels = append(metricLabels, m[k])
+	}
+	return targetLabels, metricLabels
+}
+
+func (c *Component) refreshCacheFromTargets(args Arguments) {
+	// Build the strategy map: target_label -> metric_label.
+	strategyMap := args.TargetToMetricMatch
+	if len(strategyMap) == 0 && args.TargetMatchLabel != "" {
+		// Legacy single-label mode: synthesize a strategy map.
+		metricsLabel := args.MetricsMatchLabel
+		if metricsLabel == "" {
+			metricsLabel = args.TargetMatchLabel
+		}
+		strategyMap = map[string]string{args.TargetMatchLabel: metricsLabel}
+	}
+
+	sortedTargetLabels, sortedMetricLabels := sortStrategyMap(strategyMap)
+	cache := make(map[uint64]model.LabelSet)
+	for _, target := range args.Targets {
 		labelSet := make(model.LabelSet)
-		// Copy both own and group labels
 		target.ForEachLabel(func(k, v string) bool {
 			labelSet[model.LabelName(k)] = model.LabelValue(v)
 			return true
 		})
-		if matchValue := string(labelSet[model.LabelName(c.args.TargetMatchLabel)]); matchValue != "" {
-			newCache[matchValue] = labelSet
+		h, ok := hashValuesFromLabelSet(labelSet, sortedTargetLabels)
+		if !ok {
+			continue
 		}
+		cache[h] = labelSet
 	}
 
 	c.cacheMutex.Lock()
-	c.targetsCache = newCache
+	c.mc = &matchCache{
+		sortedMetricLabels: sortedMetricLabels,
+		cache:              cache,
+	}
 	c.cacheMutex.Unlock()
 
-	c.cacheSize.Set(float64(len(c.targetsCache)))
+	c.cacheSize.Set(float64(len(cache)))
 }

--- a/internal/component/prometheus/enrich/enrich.go
+++ b/internal/component/prometheus/enrich/enrich.go
@@ -41,16 +41,14 @@ type Arguments struct {
 	Targets []discovery.Target `alloy:"targets,attr"`
 
 	// Multi-label matching: a map of target_label -> metric_label.
-	// Mutually exclusive with target_match_label / metrics_match_label.
+	// Takes precedence over target_match_label / metrics_match_label.
 	TargetToMetricMatch map[string]string `alloy:"target_to_metric_match,attr,optional"`
 
 	// Legacy: which label from targets to use for matching (e.g. "hostname", "ip").
-	// Mutually exclusive with target_to_metric_match.
 	TargetMatchLabel string `alloy:"target_match_label,attr,optional"`
 
 	// Legacy: which label from metrics to match against (e.g. "hostname", "ip").
 	// If not specified, TargetMatchLabel will be used.
-	// Mutually exclusive with target_to_metric_match.
 	MetricsMatchLabel string `alloy:"metrics_match_label,attr,optional"`
 
 	// List of labels to copy from discovered targets to metrics. If empty, all labels will be copied.
@@ -82,8 +80,12 @@ type Exports struct {
 var sep = []byte{0xff} // separator to prevent hash collisions across value boundaries
 
 // hashValuesFromLabelSet hashes the values of the given label names (in order)
-// from a model.LabelSet. Returns (0, false) if any label is missing or empty.
+// from a model.LabelSet. Returns (0, false) if names is empty or any label is
+// missing or empty.
 func hashValuesFromLabelSet(ls model.LabelSet, names []string) (uint64, bool) {
+	if len(names) == 0 {
+		return 0, false
+	}
 	h := xxhash.New()
 	for _, name := range names {
 		v := string(ls[model.LabelName(name)])
@@ -97,8 +99,12 @@ func hashValuesFromLabelSet(ls model.LabelSet, names []string) (uint64, bool) {
 }
 
 // hashValuesFromLabels hashes the values of the given label names (in order)
-// from a labels.Labels. Returns (0, false) if any label is missing or empty.
+// from a labels.Labels. Returns (0, false) if names is empty or any label is
+// missing or empty.
 func hashValuesFromLabels(lbls labels.Labels, names []string) (uint64, bool) {
+	if len(names) == 0 {
+		return 0, false
+	}
 	h := xxhash.New()
 	for _, name := range names {
 		v := lbls.Get(name)
@@ -115,6 +121,7 @@ func hashValuesFromLabels(lbls labels.Labels, names []string) (uint64, bool) {
 type matchCache struct {
 	sortedMetricLabels []string                  // metric label names to hash, sorted by corresponding target label name
 	cache              map[uint64]model.LabelSet // hash of values -> target label set
+	labelsToCopy       []string                  // snapshot of which target labels to copy (empty means copy all)
 }
 
 type Component struct {
@@ -263,12 +270,12 @@ func (c *Component) enrich(lbls labels.Labels) labels.Labels {
 	}
 
 	newLabels := labels.NewBuilder(lbls.Copy())
-	if len(c.args.LabelsToCopy) == 0 {
+	if len(mc.labelsToCopy) == 0 {
 		for k, v := range targetSet {
 			newLabels.Set(string(k), string(v))
 		}
 	} else {
-		for _, label := range c.args.LabelsToCopy {
+		for _, label := range mc.labelsToCopy {
 			if value, ok := targetSet[model.LabelName(label)]; ok {
 				newLabels.Set(label, string(value))
 			}
@@ -324,6 +331,7 @@ func (c *Component) refreshCacheFromTargets(args Arguments) {
 	c.mc = &matchCache{
 		sortedMetricLabels: sortedMetricLabels,
 		cache:              cache,
+		labelsToCopy:       args.LabelsToCopy,
 	}
 	c.cacheMutex.Unlock()
 

--- a/internal/component/prometheus/enrich/enrich.go
+++ b/internal/component/prometheus/enrich/enrich.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/cespare/xxhash/v2"
 	prometheus_client "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/exemplar"
@@ -78,54 +79,36 @@ type Exports struct {
 	Receiver storage.Appendable `alloy:"receiver,attr"`
 }
 
-// FNV-64a helpers (same algorithm as
-// https://github.com/prometheus/common/blob/0dfcdfb00df68e0b14a98f20d90f4b3ff12432e6/model/fnv.go).
-const (
-	offset64 = 14695981039346656037
-	prime64  = 1099511628211
-	sep      = "\xff" // separator to prevent hash collisions across value boundaries
-)
-
-func hashNew() uint64 {
-	return offset64
-}
-
-func hashAdd(h uint64, s string) uint64 {
-	for i := 0; i < len(s); i++ {
-		h ^= uint64(s[i])
-		h *= prime64
-	}
-	return h
-}
+var sep = []byte{0xff} // separator to prevent hash collisions across value boundaries
 
 // hashValuesFromLabelSet hashes the values of the given label names (in order)
 // from a model.LabelSet. Returns (0, false) if any label is missing or empty.
 func hashValuesFromLabelSet(ls model.LabelSet, names []string) (uint64, bool) {
-	h := hashNew()
+	h := xxhash.New()
 	for _, name := range names {
 		v := string(ls[model.LabelName(name)])
 		if v == "" {
 			return 0, false
 		}
-		h = hashAdd(h, v)
-		h = hashAdd(h, sep)
+		_, _ = h.WriteString(v)
+		_, _ = h.Write(sep)
 	}
-	return h, true
+	return h.Sum64(), true
 }
 
 // hashValuesFromLabels hashes the values of the given label names (in order)
 // from a labels.Labels. Returns (0, false) if any label is missing or empty.
 func hashValuesFromLabels(lbls labels.Labels, names []string) (uint64, bool) {
-	h := hashNew()
+	h := xxhash.New()
 	for _, name := range names {
 		v := lbls.Get(name)
 		if v == "" {
 			return 0, false
 		}
-		h = hashAdd(h, v)
-		h = hashAdd(h, sep)
+		_, _ = h.WriteString(v)
+		_, _ = h.Write(sep)
 	}
-	return h, true
+	return h.Sum64(), true
 }
 
 // matchCache holds the hash-based lookup for a match strategy.

--- a/internal/component/prometheus/enrich/enrich.go
+++ b/internal/component/prometheus/enrich/enrich.go
@@ -63,13 +63,11 @@ func (a Arguments) Validate() error {
 	hasLegacy := a.TargetMatchLabel != "" || a.MetricsMatchLabel != ""
 	hasNew := len(a.TargetToMetricMatch) > 0
 
-	if hasLegacy && hasNew {
-		return fmt.Errorf("target_to_metric_match and legacy fields (target_match_label, metrics_match_label) are mutually exclusive")
-	}
 	if !hasLegacy && !hasNew {
 		return fmt.Errorf("at least one match mechanism must be specified: set target_match_label or target_to_metric_match")
 	}
-	if hasLegacy && a.TargetMatchLabel == "" {
+	// target_to_metric_match takes precedence when set; legacy fields are ignored.
+	if hasLegacy && !hasNew && a.TargetMatchLabel == "" {
 		return fmt.Errorf("target_match_label must be set when using legacy match fields")
 	}
 	return nil

--- a/internal/component/prometheus/enrich/enrich.go
+++ b/internal/component/prometheus/enrich/enrich.go
@@ -126,7 +126,6 @@ type matchCache struct {
 
 type Component struct {
 	opts component.Options
-	args Arguments
 
 	mut      sync.RWMutex
 	receiver *prometheus.Interceptor
@@ -148,7 +147,6 @@ func New(opts component.Options, args Arguments) (*Component, error) {
 
 	c := &Component{
 		opts: opts,
-		args: args,
 	}
 
 	c.cacheSize = prometheus_client.NewGauge(prometheus_client.GaugeOpts{
@@ -241,7 +239,6 @@ func (c *Component) Update(args component.Arguments) error {
 	defer c.mut.Unlock()
 
 	newArgs := args.(Arguments)
-	c.args = newArgs
 	c.fanout.UpdateChildren(newArgs.ForwardTo)
 
 	c.refreshCacheFromTargets(newArgs)

--- a/internal/component/prometheus/enrich/enrich_test.go
+++ b/internal/component/prometheus/enrich/enrich_test.go
@@ -105,6 +105,64 @@ func TestEnricher(t *testing.T) {
 				"service": "test-service",
 			},
 		},
+		{
+			name: "multi-label match on namespace + pod + container",
+			args: Arguments{
+				Targets: []discovery.Target{
+					discovery.NewTargetFromMap(map[string]string{
+						"__meta_kubernetes_namespace":          "default",
+						"__meta_kubernetes_pod_name":           "nginx-abc",
+						"__meta_kubernetes_pod_container_name": "nginx",
+						"pod_ip":                               "10.0.0.1",
+					}),
+				},
+				TargetToMetricMatch: map[string]string{
+					"__meta_kubernetes_namespace":          "namespace",
+					"__meta_kubernetes_pod_name":           "pod",
+					"__meta_kubernetes_pod_container_name": "container",
+				},
+				LabelsToCopy: []string{"pod_ip"},
+			},
+			inputLabels: map[string]string{
+				"namespace": "default",
+				"pod":       "nginx-abc",
+				"container": "nginx",
+			},
+			expectedLabels: map[string]string{
+				"namespace": "default",
+				"pod":       "nginx-abc",
+				"container": "nginx",
+				"pod_ip":    "10.0.0.1",
+			},
+		},
+		{
+			name: "multi-label match: no match when metric missing a label",
+			args: Arguments{
+				Targets: []discovery.Target{
+					discovery.NewTargetFromMap(map[string]string{
+						"__meta_kubernetes_namespace":          "default",
+						"__meta_kubernetes_pod_name":           "nginx-abc",
+						"__meta_kubernetes_pod_container_name": "nginx",
+						"pod_ip":                               "10.0.0.1",
+					}),
+				},
+				TargetToMetricMatch: map[string]string{
+					"__meta_kubernetes_namespace":          "namespace",
+					"__meta_kubernetes_pod_name":           "pod",
+					"__meta_kubernetes_pod_container_name": "container",
+				},
+				LabelsToCopy: []string{"pod_ip"},
+			},
+			// Metric is missing "container", so no match — labels pass through unchanged.
+			inputLabels: map[string]string{
+				"namespace": "default",
+				"pod":       "nginx-abc",
+			},
+			expectedLabels: map[string]string{
+				"namespace": "default",
+				"pod":       "nginx-abc",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -112,7 +170,7 @@ func TestEnricher(t *testing.T) {
 				nil,
 				prometheus.WithAppendHook(func(ref storage.SeriesRef, l labels.Labels, _ int64, _ float64, _ storage.Appender) (storage.SeriesRef, error) {
 					for name, value := range tt.expectedLabels {
-						require.Equal(t, l.Get(name), value)
+						require.Equal(t, value, l.Get(name), "label %s", name)
 					}
 
 					return ref, nil
@@ -141,6 +199,64 @@ func TestEnricher(t *testing.T) {
 
 			err = app.Commit()
 			require.NoError(t, err)
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    Arguments
+		wantErr string
+	}{
+		{
+			name: "valid legacy",
+			args: Arguments{
+				TargetMatchLabel: "service",
+			},
+		},
+		{
+			name: "valid legacy with metrics_match_label",
+			args: Arguments{
+				TargetMatchLabel:  "service",
+				MetricsMatchLabel: "svc",
+			},
+		},
+		{
+			name: "valid new match",
+			args: Arguments{
+				TargetToMetricMatch: map[string]string{"ns": "namespace", "pod_name": "pod"},
+			},
+		},
+		{
+			name:    "error: no match mechanism",
+			args:    Arguments{},
+			wantErr: "at least one match mechanism must be specified",
+		},
+		{
+			name: "error: mutually exclusive",
+			args: Arguments{
+				TargetMatchLabel:    "service",
+				TargetToMetricMatch: map[string]string{"ns": "namespace"},
+			},
+			wantErr: "mutually exclusive",
+		},
+		{
+			name: "error: metrics_match_label without target_match_label",
+			args: Arguments{
+				MetricsMatchLabel: "svc",
+			},
+			wantErr: "target_match_label must be set",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.args.Validate()
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }

--- a/internal/component/prometheus/enrich/enrich_test.go
+++ b/internal/component/prometheus/enrich/enrich_test.go
@@ -2,6 +2,7 @@ package enrich
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -258,6 +259,55 @@ func TestValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestEnrichConcurrentUpdate exercises Append/Update concurrently to surface
+// data races.
+func TestEnrichConcurrentUpdate(t *testing.T) {
+	fanout := prometheus.NewInterceptor(nil,
+		prometheus.WithAppendHook(func(ref storage.SeriesRef, _ labels.Labels, _ int64, _ float64, _ storage.Appender) (storage.SeriesRef, error) {
+			return ref, nil
+		}))
+
+	args := Arguments{
+		Targets: []discovery.Target{
+			discovery.NewTargetFromMap(map[string]string{"service": "svc", "env": "prod"}),
+		},
+		TargetMatchLabel: "service",
+		LabelsToCopy:     []string{"env"},
+		ForwardTo:        []storage.Appendable{fanout},
+	}
+
+	c, err := New(component.Options{
+		ID:             "1",
+		Logger:         util.TestAlloyLogger(t),
+		OnStateChange:  func(component.Exports) {},
+		Registerer:     prom.NewRegistry(),
+		GetServiceData: getServiceData,
+	}, args)
+	require.NoError(t, err)
+
+	const iterations = 1000
+	lbls := labels.FromStrings("service", "svc")
+
+	var wg sync.WaitGroup
+
+	// append samples
+	wg.Go(func() {
+		for range iterations {
+			app := c.receiver.Appender(t.Context())
+			_, _ = app.Append(0, lbls, 0, 0)
+			_ = app.Commit()
+		}
+	})
+
+	// continuously rotate Targets and LabelsToCopy.
+	wg.Go(func() {
+		for range iterations {
+			require.NoError(t, c.Update(args))
+		}
+	})
+	wg.Wait()
 }
 
 func getServiceData(name string) (any, error) {

--- a/internal/component/prometheus/enrich/enrich_test.go
+++ b/internal/component/prometheus/enrich/enrich_test.go
@@ -234,12 +234,11 @@ func TestValidate(t *testing.T) {
 			wantErr: "at least one match mechanism must be specified",
 		},
 		{
-			name: "error: mutually exclusive",
+			name: "new takes precedence over legacy",
 			args: Arguments{
 				TargetMatchLabel:    "service",
 				TargetToMetricMatch: map[string]string{"ns": "namespace"},
 			},
-			wantErr: "mutually exclusive",
 		},
 		{
 			name: "error: metrics_match_label without target_match_label",

--- a/internal/component/prometheus/enrich/enrich_test.go
+++ b/internal/component/prometheus/enrich/enrich_test.go
@@ -14,6 +14,7 @@ import (
 	prom "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -304,7 +305,7 @@ func TestEnrichConcurrentUpdate(t *testing.T) {
 	// continuously rotate Targets and LabelsToCopy.
 	wg.Go(func() {
 		for range iterations {
-			require.NoError(t, c.Update(args))
+			assert.NoError(t, c.Update(args))
 		}
 	})
 	wg.Wait()


### PR DESCRIPTION
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style. For details on this,
  check out the Contributors Guide linked above.
-->

### Brief description of Pull Request

- Add `target_to_metric_match` attribute to `prometheus.enrich` for multi-label matching 
- The strategy is a `map[string]string` (target label → metric label), making the relationship explicit
- Internally uses FNV-64a hashed composite keys (values only, sorted by target label name) for O(1) cache lookup
- Backward compatible: existing `target_match_label` / `metrics_match_label` continue to work, mutually exclusive with new attribute

### Pull Request Details



### Issue(s) fixed by this Pull Request

<!--
  Uncomment the following line and fill in an issue number if you want a GitHub
  issue to be closed automatically when this PR gets merged.
-->

https://github.com/grafana/alloy/issues/5806

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
