### PR TITLE
fix(loki.write): Remove noisy log

### DIFF
--- a/internal/component/common/loki/client/endpoint.go
+++ b/internal/component/common/loki/client/endpoint.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/component/common/loki/client/internal"
-	"github.com/grafana/alloy/internal/runtime/logging/level"
 )
 
 type endpoint struct {
@@ -66,8 +65,6 @@ func (e *endpoint) enqueue(entry loki.Entry, segmentNum int) error {
 	tenantID := getTenantID(e.cfg, entry)
 	for !e.shards.enqueue(tenantID, entry, segmentNum) {
 		if !e.cfg.QueueConfig.BlockOnOverflow {
-			// This log is really noisy and we have metrics to cover it so keep this a debug level.
-			level.Debug(e.logger).Log("msg", "dropping entry", "err", errQueueIsFull)
 			e.metrics.droppedEntries.WithLabelValues(e.cfg.URL.Host, tenantID, reasonQueueIsFull).Inc()
 			e.metrics.droppedBytes.WithLabelValues(e.cfg.URL.Host, tenantID, reasonQueueIsFull).Add(float64(entry.Size()))
 			return errQueueIsFull


### PR DESCRIPTION
When using `block_on_overflow` I noticed that this log becomes _really_ noisy. Lets remove it because we already cover it with metrics.

Currently I had to exclude this log from collection in our pipeline and that is a sing it's not that useful
