### PR TITLE
chore: Ignore false positive trufflehog report

### DIFF
--- a/internal/component/loki/source/cloudflare/cloudflare.go
+++ b/internal/component/loki/source/cloudflare/cloudflare.go
@@ -1,10 +1,5 @@
 package cloudflare
 
-// This code is copied from Promtail (a1c1152b79547a133cc7be520a0b2e6db8b84868).
-// The cloudflaretarget package is used to configure and run a target that can
-// read from the Cloudflare Logpull API and forward entries to other loki
-// components.
-
 import (
 	"context"
 	"fmt"

--- a/internal/component/loki/source/heroku/heroku_test.go
+++ b/internal/component/loki/source/heroku/heroku_test.go
@@ -46,7 +46,7 @@ func TestPush(t *testing.T) {
 
 	// Check the received log entries
 	wantLabelSet := model.LabelSet{"foo": "bar", "host": "host", "app": "heroku", "proc": "router", "log_id": "-"}
-	wantLogLine := "at=info method=GET path=\"/\" host=cryptic-cliffs-27764.herokuapp.com request_id=59da6323-2bc4-4143-8677-cc66ccfb115f fwd=\"181.167.87.140\" dyno=web.1 connect=0ms service=3ms status=200 bytes=6979 protocol=https\n"
+	wantLogLine := "at=info method=GET path=\"/\" host=cryptic-cliffs-27764.herokuapp.com request_id=59da6323-2bc4-4143-8677-cc66ccfb115f fwd=\"181.167.87.140\" dyno=web.1 connect=0ms service=3ms status=200 bytes=6979 protocol=https\n" // trufflehog:ignore
 
 	for i := 0; i < 2; i++ {
 		select {


### PR DESCRIPTION
These are reported on pr. First one was a commit hash from loki repo, don't really see the point keeping this. The second one is a fake request id used in test.

https://github.com/grafana/alloy/pull/5848#issuecomment-4098176764