### PR TITLE
chore(loki.source.syslog): Use Fanout and Consume and Drain

### DIFF
--- a/internal/component/loki/source/syslog/syslog.go
+++ b/internal/component/loki/source/syslog/syslog.go
@@ -94,14 +94,18 @@ func (c *Component) Run(ctx context.Context) error {
 		})
 	}()
 
-	var wg sync.WaitGroup
+	var (
+		wg                 sync.WaitGroup
+		consumeCtx, cancel = context.WithCancel(context.Background())
+	)
 
-	wg.Go(func() { loki.Consume(ctx, c.handler, c.fanout) })
+	wg.Go(func() { loki.Consume(consumeCtx, c.handler, c.fanout) })
 
 	wg.Go(func() {
 		for {
 			select {
 			case <-ctx.Done():
+				cancel()
 				return
 			case <-c.targetsUpdated:
 				c.reloadTargets()


### PR DESCRIPTION
### Pull Request Details
Now that we run target reload loop and consume loop in seperate go routine we don't have to start drain updating targets. We also use loki.Drain during shutdown.

### Issue(s) fixed by this Pull Request

Part of https://github.com/grafana/alloy/issues/5826

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
