### PR TITLE
chore: Add h2c support to pyroscope.write

### DIFF
--- a/internal/component/pyroscope/write/debuginfo_client.go
+++ b/internal/component/pyroscope/write/debuginfo_client.go
@@ -19,9 +19,9 @@ func newDebugInfoGRPCClient(u *url.URL, e *EndpointOptions) (*grpc.ClientConn, e
 	var creds credentials.TransportCredentials
 	var auth *basicAuthCredential
 	switch u.Scheme {
-	case "http":
+	case SchemeHTTP:
 		creds = insecure.NewCredentials()
-	case "https":
+	case SchemeHTTPS:
 		if promTLSConfig := e.HTTPClientConfig.TLSConfig.Convert(); promTLSConfig != nil {
 			tlsConf, err := commonconfig.NewTLSConfig(promTLSConfig)
 			if err != nil {
@@ -48,7 +48,7 @@ func newDebugInfoGRPCClient(u *url.URL, e *EndpointOptions) (*grpc.ClientConn, e
 	target := u.Host
 	if u.Port() == "" {
 		defaultPort := "80"
-		if u.Scheme == "https" {
+		if u.Scheme == SchemeHTTPS {
 			defaultPort = "443"
 		}
 		target = fmt.Sprintf("%s:%s", u.Hostname(), defaultPort)

--- a/internal/component/pyroscope/write/promhttp2/http_config.go
+++ b/internal/component/pyroscope/write/promhttp2/http_config.go
@@ -28,6 +28,13 @@ import (
 	"golang.org/x/net/http2"
 )
 
+// HTTPClientConfigMirror wraps commonconfig.HTTPClientConfig with
+// extra fields that cannot be expressed via the upstream type.
+type HTTPClientConfigMirror struct {
+	commonconfig.HTTPClientConfig
+	H2C bool // use HTTP/2 cleartext (h2c) instead of standard transport
+}
+
 type httpClientOptions struct {
 	dialContextFunc   commonconfig.DialContextFunc
 	newTLSConfigFunc  commonconfig.NewTLSConfigFunc
@@ -130,11 +137,12 @@ func newClient(rt http.RoundTripper) *http.Client {
 	return &http.Client{Transport: rt}
 }
 
-// NewClientFromConfig returns a new HTTP client configured for the
-// given config.HTTPClientConfig and config.HTTPClientOption.
-// The name is used as go-conntrack metric label.
 func NewClientFromConfig(cfg commonconfig.HTTPClientConfig, name string, optFuncs ...HTTPClientOption) (*http.Client, error) {
-	rt, err := NewRoundTripperFromConfig(cfg, name, optFuncs...)
+	return NewClientFromConfigMirror(HTTPClientConfigMirror{HTTPClientConfig: cfg}, name, optFuncs...)
+}
+
+func NewClientFromConfigMirror(cfg HTTPClientConfigMirror, name string, optFuncs ...HTTPClientOption) (*http.Client, error) {
+	rt, err := newRoundTripperFromConfigWithContext(context.Background(), cfg, name, optFuncs...)
 	if err != nil {
 		return nil, err
 	}
@@ -151,13 +159,13 @@ func NewClientFromConfig(cfg commonconfig.HTTPClientConfig, name string, optFunc
 // given config.HTTPClientConfig and config.HTTPClientOption.
 // The name is used as go-conntrack metric label.
 func NewRoundTripperFromConfig(cfg commonconfig.HTTPClientConfig, name string, optFuncs ...HTTPClientOption) (http.RoundTripper, error) {
-	return NewRoundTripperFromConfigWithContext(context.Background(), cfg, name, optFuncs...)
+	return newRoundTripperFromConfigWithContext(context.Background(), HTTPClientConfigMirror{HTTPClientConfig: cfg}, name, optFuncs...)
 }
 
-// NewRoundTripperFromConfigWithContext returns a new HTTP RoundTripper configured for the
+// newRoundTripperFromConfigWithContext returns a new HTTP RoundTripper configured for the
 // given config.HTTPClientConfig and config.HTTPClientOption.
 // The name is used as go-conntrack metric label.
-func NewRoundTripperFromConfigWithContext(ctx context.Context, cfg commonconfig.HTTPClientConfig, name string, optFuncs ...HTTPClientOption) (http.RoundTripper, error) {
+func newRoundTripperFromConfigWithContext(ctx context.Context, cfg HTTPClientConfigMirror, name string, optFuncs ...HTTPClientOption) (http.RoundTripper, error) {
 	opts := defaultHTTPClientOptions
 	for _, opt := range optFuncs {
 		opt.applyToHTTPClientOptions(&opts)
@@ -179,25 +187,36 @@ func NewRoundTripperFromConfigWithContext(ctx context.Context, cfg commonconfig.
 	newRT := func(tlsConfig *tls.Config) (http.RoundTripper, error) {
 		// The only timeout we care about is the configured scrape timeout.
 		// It is applied on request. So we leave out any timings here.
-		var rt http.RoundTripper = &http.Transport{
-			Proxy:                 cfg.Proxy(),
-			ProxyConnectHeader:    cfg.GetProxyConnectHeader(),
-			MaxIdleConns:          20000,
-			MaxIdleConnsPerHost:   1000, // see https://github.com/golang/go/issues/13801
-			DisableKeepAlives:     !opts.keepAlivesEnabled,
-			TLSClientConfig:       tlsConfig,
-			DisableCompression:    true,
-			IdleConnTimeout:       opts.idleConnTimeout,
-			TLSHandshakeTimeout:   10 * time.Second,
-			ExpectContinueTimeout: 1 * time.Second,
-			DialContext:           dialContext,
-		}
-		if opts.http2Enabled && cfg.EnableHTTP2 {
-			http2t, err := http2.ConfigureTransports(rt.(*http.Transport))
-			if err != nil {
-				return nil, err
+		var rt http.RoundTripper
+		if cfg.H2C {
+			rt = &http2.Transport{
+				AllowHTTP: true,
+				DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+					return dialContext(ctx, network, addr)
+				},
+				ReadIdleTimeout: time.Minute,
 			}
-			http2t.ReadIdleTimeout = time.Minute
+		} else {
+			rt = &http.Transport{
+				Proxy:                 cfg.Proxy(),
+				ProxyConnectHeader:    cfg.GetProxyConnectHeader(),
+				MaxIdleConns:          20000,
+				MaxIdleConnsPerHost:   1000, // see https://github.com/golang/go/issues/13801
+				DisableKeepAlives:     !opts.keepAlivesEnabled,
+				TLSClientConfig:       tlsConfig,
+				DisableCompression:    true,
+				IdleConnTimeout:       opts.idleConnTimeout,
+				TLSHandshakeTimeout:   10 * time.Second,
+				ExpectContinueTimeout: 1 * time.Second,
+				DialContext:           dialContext,
+			}
+			if opts.http2Enabled && cfg.EnableHTTP2 {
+				http2t, err := http2.ConfigureTransports(rt.(*http.Transport))
+				if err != nil {
+					return nil, err
+				}
+				http2t.ReadIdleTimeout = time.Minute
+			}
 		}
 
 		// If a authorization_credentials is provided, create a round tripper that will set the

--- a/internal/component/pyroscope/write/write.go
+++ b/internal/component/pyroscope/write/write.go
@@ -38,6 +38,9 @@ import (
 	"google.golang.org/grpc"
 )
 
+const SchemeHTTPS = "https"
+const SchemeHTTP = "http"
+
 var (
 	DefaultArguments = func() Arguments {
 		return Arguments{
@@ -211,24 +214,28 @@ func (c *Component) Update(newConfig Arguments) error {
 	return nil
 }
 
+type endpointClient struct {
+	options      *EndpointOptions
+	pushClient   pushv1connect.PusherServiceClient
+	debugInfo    *debuginfo.Client
+	ingestClient *http.Client
+
+	h2cClient *http.Client
+}
+
 type fanOutClient struct {
-	// The list of push clients to fan out to.
-	pushClients []pushv1connect.PusherServiceClient
-
-	debugInfos []*debuginfo.Client
-
-	ingestClients map[*EndpointOptions]*http.Client
-	config        Arguments
-	metrics       *metrics
-	tracer        trace.Tracer
-	logger        log.Logger
+	endpoints []*endpointClient
+	config    Arguments
+	metrics   *metrics
+	tracer    trace.Tracer
+	logger    log.Logger
 
 	uploaderWg sync.WaitGroup
 }
 
 func (f *fanOutClient) Client() debuginfogrpc.DebuginfoServiceClient {
-	for _, client := range f.debugInfos {
-		cl := client.Client()
+	for _, ec := range f.endpoints {
+		cl := ec.debugInfo.Client()
 		if cl != nil {
 			return cl
 		}
@@ -237,13 +244,14 @@ func (f *fanOutClient) Client() debuginfogrpc.DebuginfoServiceClient {
 }
 
 func (f *fanOutClient) Upload(j debuginfo.UploadJob) {
-	for _, u := range f.debugInfos {
-		u.Upload(j)
+	for _, ec := range f.endpoints {
+		ec.debugInfo.Upload(j)
 	}
 }
 
 func (f *fanOutClient) Start(ctx context.Context) {
-	for _, u := range f.debugInfos {
+	for _, ec := range f.endpoints {
+		u := ec.debugInfo
 		f.uploaderWg.Add(1)
 		go func(c *debuginfo.Client) {
 			defer f.uploaderWg.Done()
@@ -260,9 +268,7 @@ func (f *fanOutClient) Wait() {
 
 // newFanOut creates a new fan out client that will fan out to all endpoints.
 func newFanOut(logger log.Logger, tracer trace.Tracer, config Arguments, metrics *metrics, userAgent string, uid string, dataPath string) (*fanOutClient, error) {
-	pushClients := make([]pushv1connect.PusherServiceClient, 0, len(config.Endpoints))
-	debugInfos := make([]*debuginfo.Client, 0, len(config.Endpoints))
-	ingestClients := make(map[*EndpointOptions]*http.Client)
+	endpoints := make([]*endpointClient, 0, len(config.Endpoints))
 
 	for i, endpoint := range config.Endpoints {
 		u, err := url.Parse(endpoint.URL)
@@ -279,27 +285,31 @@ func newFanOut(logger log.Logger, tracer trace.Tracer, config Arguments, metrics
 		}
 		configureTracing(config, httpClient)
 
-		pushClients = append(
-			pushClients,
-			pushv1connect.NewPusherServiceClient(httpClient, endpoint.URL, WithUserAgent(userAgent)),
-		)
-		ingestClients[endpoint] = httpClient
-
 		endpointDataPath := filepath.Join(dataPath, fmt.Sprintf("endpoint-%d", i))
 		debugInfo := debuginfo.NewClient(logger, func() (*grpc.ClientConn, error) {
 			return newDebugInfoGRPCClient(u, endpoint)
 		}, metrics.debugInfoUploadBytes, endpointDataPath)
-		debugInfos = append(debugInfos, debugInfo)
+
+		h2Client, err := newHTTP2Client(endpoint)
+		if err != nil {
+			return nil, err
+		}
+
+		endpoints = append(endpoints, &endpointClient{
+			options:      endpoint,
+			pushClient:   pushv1connect.NewPusherServiceClient(httpClient, endpoint.URL, WithUserAgent(userAgent)),
+			debugInfo:    debugInfo,
+			ingestClient: httpClient,
+			h2cClient:    h2Client,
+		})
 	}
 
 	return &fanOutClient{
-		logger:        logger,
-		tracer:        tracer,
-		pushClients:   pushClients,
-		debugInfos:    debugInfos,
-		ingestClients: ingestClients,
-		config:        config,
-		metrics:       metrics,
+		logger:    logger,
+		tracer:    tracer,
+		endpoints: endpoints,
+		config:    config,
+		metrics:   metrics,
 	}, nil
 }
 
@@ -342,42 +352,41 @@ func (f *fanOutClient) Push(
 		)
 	}()
 
-	for i, client := range f.pushClients {
+	for _, ec := range f.endpoints {
 		var (
-			client  = client
-			i       = i
+			ec      = ec
 			backoff = backoff.New(ctx, backoff.Config{
-				MinBackoff: f.config.Endpoints[i].MinBackoff,
-				MaxBackoff: f.config.Endpoints[i].MaxBackoff,
-				MaxRetries: f.config.Endpoints[i].MaxBackoffRetries,
+				MinBackoff: ec.options.MinBackoff,
+				MaxBackoff: ec.options.MaxBackoff,
+				MaxRetries: ec.options.MaxBackoffRetries,
 			})
 			err error
 		)
 		wg.Add(1)
 		go func() {
-			defer f.observeLatency(f.config.Endpoints[i].URL, "push_endpoint")()
+			defer f.observeLatency(ec.options.URL, "push_endpoint")()
 			defer wg.Done()
 			req := connect.NewRequest(req.Msg)
-			for k, v := range f.config.Endpoints[i].Headers {
+			for k, v := range ec.options.Headers {
 				req.Header().Set(k, v)
 			}
 			for {
 				err = func() error {
-					defer f.observeLatency(f.config.Endpoints[i].URL, "push_downstream")()
-					ctx, cancel := context.WithTimeout(ctx, f.config.Endpoints[i].RemoteTimeout)
+					defer f.observeLatency(ec.options.URL, "push_downstream")()
+					ctx, cancel := context.WithTimeout(ctx, ec.options.RemoteTimeout)
 					defer cancel()
 
-					_, err := client.Push(ctx, req)
+					_, err := ec.pushClient.Push(ctx, req)
 					return err
 				}()
 				if err == nil {
-					f.metrics.sentBytes.WithLabelValues(f.config.Endpoints[i].URL).Add(float64(reqSize))
-					f.metrics.sentProfiles.WithLabelValues(f.config.Endpoints[i].URL).Add(float64(profileCount))
+					f.metrics.sentBytes.WithLabelValues(ec.options.URL).Add(float64(reqSize))
+					f.metrics.sentProfiles.WithLabelValues(ec.options.URL).Add(float64(profileCount))
 					break
 				}
 				_ = level.Debug(l).Log("msg",
 					"failed to push to endpoint",
-					"endpoint", f.config.Endpoints[i].URL,
+					"endpoint", ec.options.URL,
 					"retries", backoff.NumRetries(),
 					"err", err,
 				)
@@ -388,12 +397,12 @@ func (f *fanOutClient) Push(
 				if !backoff.Ongoing() {
 					break
 				}
-				f.metrics.retries.WithLabelValues(f.config.Endpoints[i].URL).Inc()
+				f.metrics.retries.WithLabelValues(ec.options.URL).Inc()
 			}
 			if err != nil {
-				f.metrics.droppedBytes.WithLabelValues(f.config.Endpoints[i].URL).Add(float64(reqSize))
-				f.metrics.droppedProfiles.WithLabelValues(f.config.Endpoints[i].URL).Add(float64(profileCount))
-				err = fmt.Errorf("failed to push to endpoint %s (%d retries): %w", f.config.Endpoints[i].URL, backoff.NumRetries(), err)
+				f.metrics.droppedBytes.WithLabelValues(ec.options.URL).Add(float64(reqSize))
+				f.metrics.droppedProfiles.WithLabelValues(ec.options.URL).Add(float64(profileCount))
+				err = fmt.Errorf("failed to push to endpoint %s (%d retries): %w", ec.options.URL, backoff.NumRetries(), err)
 				util.ErrorsJoinConcurrent(&errs, err, &errorMut)
 			}
 		}()
@@ -569,25 +578,24 @@ func (f *fanOutClient) AppendIngest(ctx context.Context, profile *pyroscope.Inco
 	query.Set("name", ls.Normalized())
 
 	// Send to each endpoint concurrently
-	for endpointIdx, endpoint := range f.config.Endpoints {
+	for _, ec := range f.endpoints {
 		var (
-			endpoint = endpoint
-			i        = endpointIdx
-			backoff  = backoff.New(ctx, backoff.Config{
-				MinBackoff: f.config.Endpoints[i].MinBackoff,
-				MaxBackoff: f.config.Endpoints[i].MaxBackoff,
-				MaxRetries: f.config.Endpoints[i].MaxBackoffRetries,
+			ec      = ec
+			backoff = backoff.New(ctx, backoff.Config{
+				MinBackoff: ec.options.MinBackoff,
+				MaxBackoff: ec.options.MaxBackoff,
+				MaxRetries: ec.options.MaxBackoffRetries,
 			})
 			err error
 		)
 		wg.Add(1)
 		go func() {
-			defer f.observeLatency(endpoint.URL, "ingest_endpoint")()
+			defer f.observeLatency(ec.options.URL, "ingest_endpoint")()
 			defer wg.Done()
 			for {
 				err = func() error {
-					defer f.observeLatency(endpoint.URL, "ingest_downstream")()
-					u, err := url.Parse(endpoint.URL)
+					defer f.observeLatency(ec.options.URL, "ingest_downstream")()
+					u, err := url.Parse(ec.options.URL)
 					if err != nil {
 						return fmt.Errorf("parse URL: %w", err)
 					}
@@ -597,7 +605,7 @@ func (f *fanOutClient) AppendIngest(ctx context.Context, profile *pyroscope.Inco
 					// attach labels
 					u.RawQuery = query.Encode()
 
-					ctx, cancel := context.WithTimeout(ctx, f.config.Endpoints[i].RemoteTimeout)
+					ctx, cancel := context.WithTimeout(ctx, ec.options.RemoteTimeout)
 					defer cancel()
 
 					req, err := http.NewRequestWithContext(ctx, "POST", u.String(), bytes.NewReader(profile.RawBody))
@@ -606,7 +614,7 @@ func (f *fanOutClient) AppendIngest(ctx context.Context, profile *pyroscope.Inco
 					}
 
 					// set headers from endpoint
-					for k, v := range endpoint.Headers {
+					for k, v := range ec.options.Headers {
 						req.Header.Set(k, v)
 					}
 
@@ -619,7 +627,7 @@ func (f *fanOutClient) AppendIngest(ctx context.Context, profile *pyroscope.Inco
 						req.Header.Add(pyroscope.HeaderContentType, profile.ContentType[idx])
 					}
 
-					resp, err := f.ingestClients[endpoint].Do(req)
+					resp, err := ec.ingestClient.Do(req)
 					if err != nil {
 						return fmt.Errorf("do request: %w", err)
 					}
@@ -640,13 +648,13 @@ func (f *fanOutClient) AppendIngest(ctx context.Context, profile *pyroscope.Inco
 					return nil
 				}()
 				if err == nil {
-					f.metrics.sentBytes.WithLabelValues(f.config.Endpoints[i].URL).Add(float64(reqSize))
-					f.metrics.sentProfiles.WithLabelValues(f.config.Endpoints[i].URL).Add(float64(profileCount))
+					f.metrics.sentBytes.WithLabelValues(ec.options.URL).Add(float64(reqSize))
+					f.metrics.sentProfiles.WithLabelValues(ec.options.URL).Add(float64(profileCount))
 					break
 				}
 				_ = level.Debug(l).Log(
 					"msg", "failed to ingest to endpoint",
-					"endpoint", f.config.Endpoints[i].URL,
+					"endpoint", ec.options.URL,
 					"retries", backoff.NumRetries(),
 					"err", err)
 				if !shouldRetry(err) {
@@ -656,12 +664,12 @@ func (f *fanOutClient) AppendIngest(ctx context.Context, profile *pyroscope.Inco
 				if !backoff.Ongoing() {
 					break
 				}
-				f.metrics.retries.WithLabelValues(f.config.Endpoints[i].URL).Inc()
+				f.metrics.retries.WithLabelValues(ec.options.URL).Inc()
 			}
 			if err != nil {
-				f.metrics.droppedBytes.WithLabelValues(f.config.Endpoints[i].URL).Add(float64(reqSize))
-				f.metrics.droppedProfiles.WithLabelValues(f.config.Endpoints[i].URL).Add(float64(profileCount))
-				err = fmt.Errorf("failed to ingest to endpoint %s (%d retries): %w", f.config.Endpoints[i].URL, backoff.NumRetries(), err)
+				f.metrics.droppedBytes.WithLabelValues(ec.options.URL).Add(float64(reqSize))
+				f.metrics.droppedProfiles.WithLabelValues(ec.options.URL).Add(float64(profileCount))
+				err = fmt.Errorf("failed to ingest to endpoint %s (%d retries): %w", ec.options.URL, backoff.NumRetries(), err)
 				util.ErrorsJoinConcurrent(&errs, err, &errorMut)
 			}
 		}()
@@ -753,6 +761,33 @@ func validateLabels(lbls labels.Labels) error {
 	})
 
 	return err
+}
+
+// newHTTP2Client creates an HTTP/2-guaranteed client for this endpoint.
+// For http:// URLs it uses h2c; for https:// it uses HTTP/2 over TLS.
+func newHTTP2Client(opt *EndpointOptions) (*http.Client, error) {
+	u, err := url.Parse(opt.URL)
+	if err != nil {
+		return nil, err
+	}
+	cfg := *opt.HTTPClientConfig.Convert()
+	switch u.Scheme {
+	case SchemeHTTP:
+		return promhttp2.NewClientFromConfigMirror(promhttp2.HTTPClientConfigMirror{
+			HTTPClientConfig: cfg,
+			H2C:              true,
+		}, opt.Name)
+	case SchemeHTTPS:
+		httpCfg := cfg
+		httpCfg.EnableHTTP2 = true
+		return promhttp2.NewClientFromConfigMirror(promhttp2.HTTPClientConfigMirror{HTTPClientConfig: httpCfg}, opt.Name)
+	default:
+		return nil, fmt.Errorf("unsupported scheme for HTTP/2 client: %s", u.Scheme)
+	}
+}
+
+func (ec *endpointClient) http2Client() *http.Client {
+	return ec.h2cClient
 }
 
 func configureTracing(config Arguments, httpClient *http.Client) {

--- a/internal/component/pyroscope/write/write_transport_test.go
+++ b/internal/component/pyroscope/write/write_transport_test.go
@@ -1,0 +1,113 @@
+package write
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	alloyconfig "github.com/grafana/alloy/internal/component/common/config"
+	pyrotestlogger "github.com/grafana/alloy/internal/component/pyroscope/util/testlog"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+)
+
+func TestTransport(t *testing.T) {
+	protoHandler := func(proto string) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, proto, r.Proto)
+			w.WriteHeader(http.StatusOK)
+		})
+	}
+
+	newTestComponent := func(url string, httpCfg *alloyconfig.HTTPClientConfig) *Component {
+		opts := GetDefaultEndpointOptions()
+		opts.URL = url
+		opts.HTTPClientConfig = httpCfg
+		args := DefaultArguments()
+		args.Endpoints = []*EndpointOptions{&opts}
+		c, err := New(
+			pyrotestlogger.TestLogger(t),
+			noop.Tracer{},
+			prometheus.NewRegistry(),
+			func(Exports) {},
+			"test-agent", "", t.TempDir(),
+			args,
+		)
+		require.NoError(t, err)
+		return c
+	}
+
+	t.Run("http1", func(t *testing.T) {
+		srv := httptest.NewUnstartedServer(protoHandler("HTTP/1.1"))
+		srv.Start()
+		defer srv.Close()
+
+		cfg := alloyconfig.CloneDefaultHTTPClientConfig()
+		cfg.EnableHTTP2 = false
+		c := newTestComponent(srv.URL, cfg)
+		client := c.receiver.endpoints[0].ingestClient
+
+		resp, err := client.Get(srv.URL)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("http1_tls", func(t *testing.T) {
+		srv := httptest.NewUnstartedServer(protoHandler("HTTP/1.1"))
+		srv.StartTLS()
+		defer srv.Close()
+
+		cfg := alloyconfig.CloneDefaultHTTPClientConfig()
+		cfg.EnableHTTP2 = false
+		cfg.TLSConfig.InsecureSkipVerify = true
+		c := newTestComponent(srv.URL, cfg)
+		client := c.receiver.endpoints[0].ingestClient
+
+		resp, err := client.Get(srv.URL)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("http2_tls", func(t *testing.T) {
+		srv := httptest.NewUnstartedServer(protoHandler("HTTP/2.0"))
+		srv.EnableHTTP2 = true
+		srv.StartTLS()
+		defer srv.Close()
+
+		cfg := alloyconfig.CloneDefaultHTTPClientConfig()
+		cfg.EnableHTTP2 = true
+		cfg.TLSConfig.InsecureSkipVerify = true
+		c := newTestComponent(srv.URL, cfg)
+		client := c.receiver.endpoints[0].http2Client()
+
+		resp, err := client.Get(srv.URL)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("h2c", func(t *testing.T) {
+		srv := httptest.NewUnstartedServer(h2c.NewHandler(protoHandler("HTTP/2.0"), &http2.Server{}))
+		srv.Start()
+		defer srv.Close()
+
+		c := newTestComponent(srv.URL, alloyconfig.CloneDefaultHTTPClientConfig())
+		client := c.receiver.endpoints[0].http2Client()
+
+		resp, err := client.Get(srv.URL)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+}


### PR DESCRIPTION
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style. For details on this,
  check out the Contributors Guide linked above.
-->

### Brief description of Pull Request
This PR updates `promhttp2` package to allow configuring `h2c` communications.
Updates `pyroscope.write` component to create the new `http2` compatible http clients for each endpoint, but does not use them yet.

This is prerequisite for https://github.com/grafana/alloy/pull/5891 
<!--
  Add a human-readable description of the PR that may be used as the commit body
  (i.e. "Extended description") when it gets merged.
-->

### Pull Request Details

<!-- Add a more detailed descripion of the Pull Request here, if needed. -->

### Issue(s) fixed by this Pull Request

<!--
  Uncomment the following line and fill in an issue number if you want a GitHub
  issue to be closed automatically when this PR gets merged.
-->

<!-- Fixes #issue_id -->

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
