### PR TITLE
chore(loki.source.kafka, loki.source.azure_event_hubs): Use Fanout and Consume and Drain

### DIFF
--- a/internal/component/loki/source/azure_event_hubs/azure_event_hubs.go
+++ b/internal/component/loki/source/azure_event_hubs/azure_event_hubs.go
@@ -105,6 +105,7 @@ type Component struct {
 func (c *Component) Run(ctx context.Context) error {
 	defer func() {
 		level.Info(c.opts.Logger).Log("msg", "loki.source.azure_event_hubs component shutting down, stopping the targets")
+
 		loki.Drain(c.handler, c.fanout, loki.DefaultDrainTimeout, func() {
 			c.mut.Lock()
 			defer c.mut.Unlock()
@@ -112,7 +113,6 @@ func (c *Component) Run(ctx context.Context) error {
 			if err := c.target.Stop(); err != nil {
 				level.Error(c.opts.Logger).Log("msg", "error while stopping azure_event_hubs target", "err", err)
 			}
-
 		})
 	}()
 

--- a/internal/component/loki/source/kafka/kafka.go
+++ b/internal/component/loki/source/kafka/kafka.go
@@ -129,7 +129,6 @@ func (c *Component) Run(ctx context.Context) error {
 				}
 			}
 		})
-
 	}()
 
 	loki.Consume(ctx, c.handler, c.fanout)


### PR DESCRIPTION
### Pull Request Details
Migrate to use shared functions and structures.

### Issue(s) fixed by this Pull Request

Part of https://github.com/grafana/alloy/pull/5850

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
