### PR TITLE
fix(database_observability): Ensure connection_info_monitor goroutine exits on Stop

### DIFF
--- a/internal/component/database_observability/connection_info_monitor.go
+++ b/internal/component/database_observability/connection_info_monitor.go
@@ -3,6 +3,7 @@ package database_observability
 import (
 	"context"
 	"database/sql"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -26,13 +27,12 @@ type ConnectionInfoMonitorConfig struct {
 // After ConnectionChecksThreshold consecutive ping failures it unregisters infoMetric from registry.
 // After ConnectionChecksThreshold consecutive ping successes (when the metric is unregistered) it re-registers
 // infoMetric and sets it to 1 with the given labelValues.
-// The goroutine runs until ctx is done. onStopped is called when the goroutine exits (e.g. when ctx is cancelled).
-// RunConnectionInfoMonitor returns a cancel function that cancels the context passed to the goroutine; the caller
-// should call cancel in Stop() to ensure the goroutine exits.
+// The goroutine runs until the returned stop function is called. onStopped is called when the goroutine exits.
+// The returned stop function cancels the internal context and waits for the goroutine to exit before returning.
 // labelValues must contain exactly 6 values in order: provider_name, provider_region, provider_account,
 // db_instance_identifier, engine, engine_version.
 // If config is non-nil, its CheckInterval and ChecksThreshold override the default constants (used for testing).
-func RunConnectionInfoMonitor(ctx context.Context, db *sql.DB, registry *prometheus.Registry, infoMetric *prometheus.GaugeVec, labelValues []string, onStopped func(), config *ConnectionInfoMonitorConfig) (cancel context.CancelFunc) {
+func RunConnectionInfoMonitor(ctx context.Context, db *sql.DB, registry *prometheus.Registry, infoMetric *prometheus.GaugeVec, labelValues []string, onStopped func(), config *ConnectionInfoMonitorConfig) (stop func()) {
 	interval := ConnectionCheckInterval
 	threshold := ConnectionChecksThreshold
 	if config != nil {
@@ -43,8 +43,9 @@ func RunConnectionInfoMonitor(ctx context.Context, db *sql.DB, registry *prometh
 			threshold = config.ChecksThreshold
 		}
 	}
-	ctx, cancel = context.WithCancel(ctx)
-	go func() {
+	ctx, cancel := context.WithCancel(ctx)
+	var wg sync.WaitGroup
+	wg.Go(func() {
 		defer onStopped()
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
@@ -82,6 +83,9 @@ func RunConnectionInfoMonitor(ctx context.Context, db *sql.DB, registry *prometh
 				// continue loop
 			}
 		}
-	}()
-	return cancel
+	})
+	return func() {
+		cancel()
+		wg.Wait()
+	}
 }

--- a/internal/component/database_observability/connection_info_monitor_test.go
+++ b/internal/component/database_observability/connection_info_monitor_test.go
@@ -46,8 +46,8 @@ func TestRunConnectionInfoMonitor_UnregistersAfterConsecutiveFailures(t *testing
 		CheckInterval:   testCheckInterval,
 		ChecksThreshold: testThreshold,
 	}
-	cancel := RunConnectionInfoMonitor(ctx, db, registry, infoMetric, labelValues, onStopped, config)
-	defer cancel()
+	stop := RunConnectionInfoMonitor(ctx, db, registry, infoMetric, labelValues, onStopped, config)
+	defer stop()
 
 	// Wait for at least 3 tick intervals so the monitor performs 3 failed pings and unregisters
 	time.Sleep(testCheckInterval*time.Duration(testThreshold) + 20*time.Millisecond)
@@ -102,8 +102,8 @@ func TestRunConnectionInfoMonitor_ReregistersAfterConsecutiveSuccesses(t *testin
 		CheckInterval:   testCheckInterval,
 		ChecksThreshold: testThreshold,
 	}
-	cancel := RunConnectionInfoMonitor(ctx, db, registry, infoMetric, labelValues, onStopped, config)
-	defer cancel()
+	stop := RunConnectionInfoMonitor(ctx, db, registry, infoMetric, labelValues, onStopped, config)
+	defer stop()
 
 	// Poll until the metric is re-registered rather than sleeping a fixed duration, which is
 	// unreliable: extra pings after the mock expectations are exhausted return errors, causing
@@ -156,8 +156,8 @@ func TestRunConnectionInfoMonitor_MetricRemainsRegisteredWhilePingsSucceed(t *te
 		CheckInterval:   testCheckInterval,
 		ChecksThreshold: testThreshold,
 	}
-	cancel := RunConnectionInfoMonitor(ctx, db, registry, infoMetric, labelValues, onStopped, config)
-	defer cancel()
+	stop := RunConnectionInfoMonitor(ctx, db, registry, infoMetric, labelValues, onStopped, config)
+	defer stop()
 
 	// Wait for a few tick intervals
 	time.Sleep(testCheckInterval*4 + 20*time.Millisecond)
@@ -206,14 +206,14 @@ func TestRunConnectionInfoMonitor_CancelStopsGoroutine(t *testing.T) {
 		CheckInterval:   testCheckInterval,
 		ChecksThreshold: testThreshold,
 	}
-	cancel := RunConnectionInfoMonitor(ctx, db, registry, infoMetric, labelValues, onStopped, config)
+	stop := RunConnectionInfoMonitor(ctx, db, registry, infoMetric, labelValues, onStopped, config)
 
-	// Cancel immediately; onStopped should be called when the goroutine exits
-	cancel()
+	// Stop immediately; onStopped should be called when the goroutine exits
+	stop()
 	select {
 	case <-stopped:
 		// goroutine exited
 	case <-time.After(2 * time.Second):
-		t.Fatal("onStopped was not called after cancel")
+		t.Fatal("onStopped was not called after stop")
 	}
 }

--- a/internal/component/database_observability/mysql/collector/connection_info.go
+++ b/internal/component/database_observability/mysql/collector/connection_info.go
@@ -31,7 +31,7 @@ type ConnectionInfo struct {
 	dbConnection  *sql.DB
 
 	running *atomic.Bool
-	cancel  context.CancelFunc
+	stop    func()
 }
 
 func NewConnectionInfo(args ConnectionInfoArguments) (*ConnectionInfo, error) {
@@ -114,7 +114,7 @@ func (c *ConnectionInfo) Start(ctx context.Context) error {
 	c.InfoMetric.WithLabelValues(labelValues...).Set(1)
 
 	if c.dbConnection != nil {
-		c.cancel = database_observability.RunConnectionInfoMonitor(
+		c.stop = database_observability.RunConnectionInfoMonitor(
 			ctx,
 			c.dbConnection,
 			c.Registry,
@@ -133,8 +133,8 @@ func (c *ConnectionInfo) Stopped() bool {
 }
 
 func (c *ConnectionInfo) Stop() {
-	if c.cancel != nil {
-		c.cancel()
+	if c.stop != nil {
+		c.stop()
 	}
 	c.Registry.Unregister(c.InfoMetric)
 	c.running.Store(false)

--- a/internal/component/database_observability/mysql/collector/connection_info_test.go
+++ b/internal/component/database_observability/mysql/collector/connection_info_test.go
@@ -135,7 +135,9 @@ func TestConnectionInfo_StopUnregistersMetric(t *testing.T) {
 	require.True(t, found, "metric should be registered after Start")
 
 	col.Stop()
-	require.True(t, col.Stopped())
+	require.Eventually(t, func() bool {
+		return col.Stopped()
+	}, 5*time.Second, 100*time.Millisecond)
 
 	// metric is absent after Stop
 	metrics, err = reg.Gather()
@@ -189,7 +191,9 @@ func TestConnectionInfo_MonitorStartedWithDB(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	col.Stop()
-	require.True(t, col.Stopped())
+	require.Eventually(t, func() bool {
+		return col.Stopped()
+	}, 5*time.Second, 100*time.Millisecond)
 
 	// Metric is unregistered after Stop
 	metrics, err = reg.Gather()

--- a/internal/component/database_observability/postgres/collector/connection_info.go
+++ b/internal/component/database_observability/postgres/collector/connection_info.go
@@ -32,7 +32,7 @@ type ConnectionInfo struct {
 	dbConnection  *sql.DB
 
 	running *atomic.Bool
-	cancel  context.CancelFunc
+	stop    func()
 }
 
 func NewConnectionInfo(args ConnectionInfoArguments) (*ConnectionInfo, error) {
@@ -120,7 +120,7 @@ func (c *ConnectionInfo) Start(ctx context.Context) error {
 	c.InfoMetric.WithLabelValues(labelValues...).Set(1)
 
 	if c.dbConnection != nil {
-		c.cancel = database_observability.RunConnectionInfoMonitor(
+		c.stop = database_observability.RunConnectionInfoMonitor(
 			ctx,
 			c.dbConnection,
 			c.Registry,
@@ -139,8 +139,8 @@ func (c *ConnectionInfo) Stopped() bool {
 }
 
 func (c *ConnectionInfo) Stop() {
-	if c.cancel != nil {
-		c.cancel()
+	if c.stop != nil {
+		c.stop()
 	}
 	c.Registry.Unregister(c.InfoMetric)
 	c.running.Store(false)

--- a/internal/component/database_observability/postgres/collector/connection_info_test.go
+++ b/internal/component/database_observability/postgres/collector/connection_info_test.go
@@ -139,7 +139,9 @@ func TestConnectionInfo_StopUnregistersMetric(t *testing.T) {
 	require.True(t, found, "metric should be registered after Start")
 
 	col.Stop()
-	require.True(t, col.Stopped())
+	require.Eventually(t, func() bool {
+		return col.Stopped()
+	}, 5*time.Second, 100*time.Millisecond)
 
 	// metric is absent after Stop
 	metrics, err = reg.Gather()
@@ -195,7 +197,9 @@ func TestConnectionInfo_MonitorStartedWithDB(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	col.Stop()
-	require.True(t, col.Stopped())
+	require.Eventually(t, func() bool {
+		return col.Stopped()
+	}, 5*time.Second, 100*time.Millisecond)
 
 	// Metric is unregistered after Stop
 	metrics, err = reg.Gather()


### PR DESCRIPTION
### Brief description of Pull Request
Fix race condition where `Stop()` could return before the monitor goroutine had exited.

Followup of https://github.com/grafana/alloy/pull/5796

### Pull Request Details

<!-- Add a more detailed descripion of the Pull Request here, if needed. -->

### Issue(s) fixed by this Pull Request

<!--
  Uncomment the following line and fill in an issue number if you want a GitHub
  issue to be closed automatically when this PR gets merged.
-->

<!-- Fixes #issue_id -->

### Notes to the Reviewer

<!-- Add any relevant notes for the reviewers and testers of this PR. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
