### PR TITLE
test(loki.secretfilter): Add tests for skipping `tokenId` variants

### DIFF
--- a/internal/component/loki/secretfilter/extend/extend_test.go
+++ b/internal/component/loki/secretfilter/extend/extend_test.go
@@ -46,3 +46,25 @@ func TestSecretFiltering_WithGitleaksConfigFile(t *testing.T) {
 
 	secretfilter.RunTestCases(t, config, cases)
 }
+
+func TestSecretFiltering_RequestTimingsLog(t *testing.T) {
+	configPath := gitleaksConfigPath(t)
+	if _, err := os.Stat(configPath); err != nil {
+		t.Skipf("gitleaks.toml not found at %s: %v", configPath, err)
+	}
+
+	config := fmt.Sprintf(`
+		forward_to = []
+		gitleaks_config = %q
+	`, configPath)
+
+	cases := []secretfilter.TestCase{
+		{
+			Name: "request_timings_empty_token_id",
+			// Structured from real logs; token_id is empty and `total=6.928165ms` gets redacted instead
+			InputLog:     `user=1 token_id= total=6.928165ms auth=40.984µs downstream=6.805953ms conn_send=81.228µs path=/foo status=200 query_hash=1`,
+			ShouldRedact: false,
+		},
+	}
+	secretfilter.RunTestCases(t, config, cases)
+}

--- a/internal/component/loki/secretfilter/extend/gitleaks.toml
+++ b/internal/component/loki/secretfilter/extend/gitleaks.toml
@@ -12,3 +12,8 @@ id = "generic-api-key"
   regexes = [
     '''^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$''',
   ]
+  # Ignore finding when the match is tokenId and its variants
+  [[rules.allowlists]]
+  description = "ignore tokenId keyword for generic-api-key"
+  regexTarget = "match"
+  regexes = [ "(?i)token_?id" ]


### PR DESCRIPTION
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style. For details on this,
  check out the Contributors Guide linked above.
-->

### Brief description of Pull Request

<!-- Human-readable description of the PR used as squash commit body. -->

Skip `token_id` and its variants redactions in `loki.secretfilter`.


### Pull Request Details

<!-- Detailed descripion of the Pull Request, if needed. -->

Add test for skipping `token_id` and its variants in the custom gitleaks extended configuration file.

### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->

We noticed that we had `generic-api-key` redactions happening but no actual value being redacted ([slack](https://raintank-corp.slack.com/archives/C044LC5GMGF/p1774378872467969)). The reason for this is the substring `… token_id= total=123.456 … foo bar`. There is no value for `token_id` so it’s just a space, but then `total=123.456` has enough entropy to cause a redaction. When this happens we see `token_id= <ALLOY-REDACTED-SECRET:… foo bar` — notice that `total` is now missing from the log line.

We’ve considered allowing `token_id` because it triggers a lot of `generic-api-key` redactions that are false positives, but now that we see it’s leading to incorrect reductions it seems to be the best path forward. This adds a test that demonstrates the behavior, and asserts that when it’s added to `gitleaks.toml`, we properly skip redaction.

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests updated