### PR TITLE
fix(database_observability.mysql): Ensure result sets are properly closed

### DIFF
--- a/internal/component/database_observability/mysql/collector/schema_details.go
+++ b/internal/component/database_observability/mysql/collector/schema_details.go
@@ -272,7 +272,6 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 			level.Error(c.logger).Log("msg", "failed to query tables", "err", err)
 			break
 		}
-		defer rs.Close()
 
 		for rs.Next() {
 			var tableName, tableType string
@@ -298,8 +297,11 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 			)
 		}
 
-		if err := rs.Err(); err != nil {
-			return fmt.Errorf("failed to iterate over tables result set: %w", err)
+		iterErr := rs.Err()
+		rs.Close()
+
+		if iterErr != nil {
+			return fmt.Errorf("failed to iterate over tables result set: %w", iterErr)
 		}
 	}
 

--- a/internal/component/database_observability/mysql/collector/setup_consumers.go
+++ b/internal/component/database_observability/mysql/collector/setup_consumers.go
@@ -135,5 +135,9 @@ func (c *SetupConsumers) getSetupConsumers(ctx context.Context) error {
 		}
 	}
 
+	if err := rs.Err(); err != nil {
+		return fmt.Errorf("failed to iterate over setup_consumers result set: %w", err)
+	}
+
 	return nil
 }


### PR DESCRIPTION
### Brief description of Pull Request
Fixes:
- In `schema_details`, moved the `defer rs.Close()` statement to after the loop, to ensure result set is closed at the end of its loop rather than holding connections open until the function returns.
- In `setup_consumers`, added missing error check on result set after iteration.



### Pull Request Details

<!-- Detailed descripion of the Pull Request, if needed. -->


### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->


### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
