### PR TITLE
ci: Make release workflows release-branch-aware

### DIFF
--- a/.github/workflows/release-code-freeze-guard.yml
+++ b/.github/workflows/release-code-freeze-guard.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'release/v*'
     types:
       - opened
       - synchronize
@@ -30,6 +31,7 @@ jobs:
           PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
+          BASE_BRANCH: ${{ github.base_ref }}
         run: |
           # Always allow release-please bot PRs
           if [ "$PR_AUTHOR" = "grafana-alloybot[bot]" ]; then
@@ -43,8 +45,18 @@ jobs:
             exit 0
           fi
 
-          # Fetch the most recent tags sorted by commit date, then find the latest
-          # minor-version tag (vX.Y.0 or vX.Y.0-rc.N), ignoring patch releases.
+          # Determine which tags to consider based on the target branch.
+          # On main: only minor-release tags (vX.Y.0 / vX.Y.0-rc.N).
+          # On release/vX.Y: all tags in that series (vX.Y.Z / vX.Y.Z-rc.N).
+          if echo "$BASE_BRANCH" | grep -qE '^release/v[0-9]+\.[0-9]+$'; then
+            BRANCH_VERSION=$(echo "$BASE_BRANCH" | grep -oE '[0-9]+\.[0-9]+')
+            TAG_FILTER="^v${BRANCH_VERSION}\.[0-9]+(-rc\.[0-9]+)?$"
+            TAG_LABEL="v${BRANCH_VERSION} series"
+          else
+            TAG_FILTER='^v[0-9]+\.[0-9]+\.0(-rc\.[0-9]+)?$'
+            TAG_LABEL="minor-version"
+          fi
+
           LATEST_TAG=$(gh api graphql -f query='
             query($owner: String!, $repo: String!) {
               repository(owner: $owner, name: $repo) {
@@ -54,23 +66,23 @@ jobs:
               }
             }' -f owner="$REPO_OWNER" -f repo="$REPO_NAME" \
             --jq '.data.repository.refs.nodes[].name' \
-            | grep -E '^v[0-9]+\.[0-9]+\.0(-rc\.[0-9]+)?$' \
+            | grep -E "$TAG_FILTER" \
             | head -1)
 
           if [ -z "$LATEST_TAG" ]; then
-            echo "✅ No minor-version tags found. Not in RC mode."
+            echo "✅ No $TAG_LABEL tags found. Not in RC mode."
             exit 0
           fi
 
-          echo "Most recent minor-version tag: $LATEST_TAG"
+          echo "Most recent $TAG_LABEL tag: $LATEST_TAG"
 
           if echo "$LATEST_TAG" | grep -qE '\-rc\.[0-9]+$'; then
-            echo "❌ Code freeze is active. The most recent minor-version tag is $LATEST_TAG."
+            echo "❌ Code freeze is active. The most recent $TAG_LABEL tag is $LATEST_TAG."
             echo ""
-            echo "An RC has been published and main is frozen until the final release."
+            echo "An RC has been published and $BASE_BRANCH is frozen until the final release."
             echo "Only critical fixes approved by the release manager may be merged."
             echo "Add the 'freeze-exempt' label to this PR to bypass the freeze."
             exit 1
           fi
 
-          echo "✅ Latest minor-version tag is $LATEST_TAG (final release). No code freeze."
+          echo "✅ Latest $TAG_LABEL tag is $LATEST_TAG (final release). No code freeze."

--- a/.github/workflows/release-wrong-version-on-branch-guard.yml
+++ b/.github/workflows/release-wrong-version-on-branch-guard.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'release/v*'
 
 concurrency:
   group: "${{ github.ref_name }}-${{ github.head_ref }}-wrong-version-on-branch-guard"


### PR DESCRIPTION
### Brief description of Pull Request

Release workflows now that we release minors from main had some slight gaps when used on release branches. This resolves those issues.

Namely:

- RC tags on a release branch could trigger a code freeze on the main branch, and vice versa.
- Checks would not run on release branches
