### PR TITLE
chore(promhttp2): Use less reflection&unsafe, nosemgrep: use-of-unsafe-block

### DIFF
--- a/internal/component/pyroscope/write/promhttp2/http_config.go
+++ b/internal/component/pyroscope/write/promhttp2/http_config.go
@@ -248,7 +248,10 @@ func NewRoundTripperFromConfigWithContext(ctx context.Context, cfg commonconfig.
 					return nil, fmt.Errorf("unable to use client secret: %w", err)
 				}
 			}
-			rt = newOAuth2RoundTripper(oauthCredential, cfg.OAuth2, rt, &opts)
+			rt, err = newOAuth2RoundTripper(oauthCredential, cfg.OAuth2, rt, &opts)
+			if err != nil {
+				return nil, fmt.Errorf("unable to create OAuth2RoundTripper: %w", err)
+			}
 		}
 
 		if cfg.HTTPHeaders != nil {

--- a/internal/component/pyroscope/write/promhttp2/http_config_test.go
+++ b/internal/component/pyroscope/write/promhttp2/http_config_test.go
@@ -1527,7 +1527,8 @@ endpoint_params:
 	require.Truef(t, reflect.DeepEqual(unmarshalledConfig, expectedConfig), "Got unmarshalled config %v, expected %v", unmarshalledConfig, expectedConfig)
 
 	secret := commonconfig.NewInlineSecret(string(expectedConfig.ClientSecret))
-	rt := newOAuth2RoundTripper(secret, &expectedConfig, http.DefaultTransport, &defaultHTTPClientOptions)
+	rt, err := newOAuth2RoundTripper(secret, &expectedConfig, http.DefaultTransport, &defaultHTTPClientOptions)
+	require.NoError(t, err)
 
 	client := http.Client{
 		Transport: rt,
@@ -1661,7 +1662,8 @@ endpoint_params:
 	require.Truef(t, reflect.DeepEqual(unmarshalledConfig, expectedConfig), "Got unmarshalled config %v, expected %v", unmarshalledConfig, expectedConfig)
 
 	secret := commonconfig.NewFileSecret(expectedConfig.ClientSecretFile)
-	rt := newOAuth2RoundTripper(secret, &expectedConfig, http.DefaultTransport, &defaultHTTPClientOptions)
+	rt, err := newOAuth2RoundTripper(secret, &expectedConfig, http.DefaultTransport, &defaultHTTPClientOptions)
+	require.NoError(t, err)
 
 	client := http.Client{
 		Transport: rt,
@@ -1777,7 +1779,8 @@ endpoint_params:
 	require.Truef(t, reflect.DeepEqual(unmarshalledConfig, expectedConfig), "Got unmarshalled config %v, expected %v", unmarshalledConfig, expectedConfig)
 
 	clientCertificateKey := commonconfig.NewFileSecret(expectedConfig.ClientCertificateKeyFile)
-	rt := newOAuth2RoundTripper(clientCertificateKey, &expectedConfig, http.DefaultTransport, &defaultHTTPClientOptions)
+	rt, err := newOAuth2RoundTripper(clientCertificateKey, &expectedConfig, http.DefaultTransport, &defaultHTTPClientOptions)
+	require.NoError(t, err)
 
 	client := http.Client{
 		Transport: rt,

--- a/internal/component/pyroscope/write/promhttp2/reflect_oauth2.go
+++ b/internal/component/pyroscope/write/promhttp2/reflect_oauth2.go
@@ -1,6 +1,7 @@
 package promhttp2
 
 import (
+	"fmt"
 	"net/http"
 	"reflect"
 	"unsafe"
@@ -15,26 +16,27 @@ import (
 // We use reflect to create a new instance of the prometheus type and copy each
 // field from our local struct. This is safe as long as the struct layouts match,
 // which is asserted by unit tests in reflect_oauth2_test.go.
-func newOAuth2RoundTripper(oauthCredential commonconfig.SecretReader, config *commonconfig.OAuth2, next http.RoundTripper, opts *httpClientOptions) http.RoundTripper {
+func newOAuth2RoundTripper(oauthCredential commonconfig.SecretReader, config *commonconfig.OAuth2, next http.RoundTripper, opts *httpClientOptions) (http.RoundTripper, error) {
+	if oauthCredential == nil {
+		oauthCredential = commonconfig.NewInlineSecret("")
+	}
+	if config == nil {
+		return nil, fmt.Errorf("newOAuth2RoundTripper: config == nil")
+	}
+	if next == nil {
+		return nil, fmt.Errorf("newOAuth2RoundTripper: next == nil")
+	}
+	if opts == nil {
+		return nil, fmt.Errorf("newOAuth2RoundTripper: opts == nil")
+	}
 	fn := reflect.ValueOf(commonconfig.NewOAuth2RoundTripper)
-	optsType := fn.Type().In(3).Elem()
-	promOpts := reflect.New(optsType)
-	promPtr := promOpts.UnsafePointer()
-	for i := 0; i < optsType.NumField(); i++ {
-		field := optsType.Field(i)
-		src := reflect.NewAt(field.Type, unsafe.Add(unsafe.Pointer(opts), field.Offset)).Elem()
-		dst := reflect.NewAt(field.Type, unsafe.Add(promPtr, field.Offset)).Elem()
-		dst.Set(src)
+	args := []reflect.Value{
+		reflect.ValueOf(oauthCredential),
+		reflect.ValueOf(config),
+		reflect.ValueOf(next),
+		// it is fine to use unsafe as long as the layout of the structs are the same and the tests
+		// in reflect_oauth2_test.go pass and catch any change in the unexported struct layout upstream
+		reflect.NewAt(fn.Type().In(3).Elem(), unsafe.Pointer(opts)), // nosemgrep: use-of-unsafe-block
 	}
-	fnType := fn.Type()
-	args := make([]reflect.Value, 4)
-	for i, v := range []any{oauthCredential, config, next} {
-		if v != nil {
-			args[i] = reflect.ValueOf(v)
-		} else {
-			args[i] = reflect.Zero(fnType.In(i))
-		}
-	}
-	args[3] = promOpts
-	return fn.Call(args)[0].Interface().(http.RoundTripper)
+	return fn.Call(args)[0].Interface().(http.RoundTripper), nil
 }

--- a/internal/component/pyroscope/write/promhttp2/reflect_oauth2_test.go
+++ b/internal/component/pyroscope/write/promhttp2/reflect_oauth2_test.go
@@ -67,7 +67,7 @@ func TestNewOAuth2RoundTripperSignature(t *testing.T) {
 // calls through to the upstream function and returns a non-nil RoundTripper.
 func TestNewOAuth2RoundTripper(t *testing.T) {
 	opts := defaultHTTPClientOptions
-	rt := newOAuth2RoundTripper(
+	rt, err := newOAuth2RoundTripper(
 		commonconfig.NewInlineSecret("test-secret"),
 		&commonconfig.OAuth2{
 			ClientID: "test-client",
@@ -77,13 +77,14 @@ func TestNewOAuth2RoundTripper(t *testing.T) {
 		&opts,
 	)
 	require.NotNil(t, rt)
+	require.NoError(t, err)
 }
 
 // TestNewOAuth2RoundTripperNilCredential verifies that newOAuth2RoundTripper
 // handles a nil SecretReader (the credential arg) without panicking.
 func TestNewOAuth2RoundTripperNilCredential(t *testing.T) {
 	opts := defaultHTTPClientOptions
-	rt := newOAuth2RoundTripper(
+	rt, err := newOAuth2RoundTripper(
 		nil,
 		&commonconfig.OAuth2{
 			ClientID: "test-client",
@@ -93,13 +94,12 @@ func TestNewOAuth2RoundTripperNilCredential(t *testing.T) {
 		&opts,
 	)
 	require.NotNil(t, rt)
+	require.NoError(t, err)
 }
 
-// TestNewOAuth2RoundTripperNilNext verifies that newOAuth2RoundTripper
-// handles a nil next RoundTripper without panicking.
 func TestNewOAuth2RoundTripperNilNext(t *testing.T) {
 	opts := defaultHTTPClientOptions
-	rt := newOAuth2RoundTripper(
+	rt, err := newOAuth2RoundTripper(
 		commonconfig.NewInlineSecret("test-secret"),
 		&commonconfig.OAuth2{
 			ClientID: "test-client",
@@ -108,14 +108,13 @@ func TestNewOAuth2RoundTripperNilNext(t *testing.T) {
 		nil,
 		&opts,
 	)
-	require.NotNil(t, rt)
+	require.Nil(t, rt)
+	require.Error(t, err)
 }
 
-// TestNewOAuth2RoundTripperAllNils verifies that newOAuth2RoundTripper
-// handles all nil interface arguments without panicking.
 func TestNewOAuth2RoundTripperAllNils(t *testing.T) {
 	opts := defaultHTTPClientOptions
-	rt := newOAuth2RoundTripper(
+	rt, err := newOAuth2RoundTripper(
 		nil,
 		&commonconfig.OAuth2{
 			ClientID: "test-client",
@@ -124,7 +123,8 @@ func TestNewOAuth2RoundTripperAllNils(t *testing.T) {
 		nil,
 		&opts,
 	)
-	require.NotNil(t, rt)
+	require.Nil(t, rt)
+	require.Error(t, err)
 }
 
 // TestHttpClientOptionsDefaultsMatch asserts that our defaultHTTPClientOptions


### PR DESCRIPTION
…e-block

<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style. For details on this,
  check out the Contributors Guide linked above.
-->

### Brief description of Pull Request

<!-- Human-readable description of the PR used as squash commit body. -->
Change the way we use unsafe in promhttp2 package
- Do not use unsafe to set each field one by one
- just transpose one struct pointer to another once
- remove nil interface check handling
- nosemgrep: use-of-unsafe-block
Context:
https://raintank-corp.slack.com/archives/C03NCLB4GG7/p1774413479849249

### Pull Request Details

<!-- Detailed descripion of the Pull Request, if needed. -->


### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->


### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
