### PR TITLE
chore: Fix flaky endpoint test

### DIFF
--- a/internal/component/common/loki/client/endpoint_test.go
+++ b/internal/component/common/loki/client/endpoint_test.go
@@ -408,10 +408,10 @@ func TestEndpointBlockOnOverflow(t *testing.T) {
 		// Which enqueue fails depends on whether the shard worker has already
 		// consumed the queued batch after the third call. If the third call loses that race,
 		// it returns errQueueIsFull, otherwise the fourth call does.
-		require.True(t,
-			errors.Is(e.enqueue(entry, 0), errQueueIsFull) || errors.Is(e.enqueue(entry, 0), errQueueIsFull),
-			"expected either the third or fourth enqueue to fail with queue full",
-		)
+		err3 := e.enqueue(entry, 0)
+		err4 := e.enqueue(entry, 0)
+		queueIsFull := errors.Is(err3, errQueueIsFull) || errors.Is(err4, errQueueIsFull)
+		require.True(t, queueIsFull, "expected either the third or fourth enqueue to fail with queue full")
 	})
 
 	t.Run("should block until queue has space when BlockOnOverflow is true", func(t *testing.T) {


### PR DESCRIPTION
### Pull Request Details
We can have 3 active batches at the same time but it all depend a bit on timing:
1. First batch gets created for first enqueue call.
2. Second batch gets created and first batch is pushed to the queue after second enqueue call.
3. Third batch can succeed if a shard has consumed the first queued batch.
4. Fourth batch will fail if third succeeded and succeed if third batch failed.

### Issue(s) fixed by this Pull Request

Part of: https://github.com/grafana/alloy/issues/5142

### Notes to the Reviewer


### PR Checklist
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
