### PR TITLE
ci: Create backport label when first RC is cut

### DIFF
--- a/docs/developer/shepherding-releases.md
+++ b/docs/developer/shepherding-releases.md
@@ -46,6 +46,8 @@ out the section below on modifying a PR's changelog entry after it's been merged
      - Uncheck the `Dry run` box.
    - This will trigger workflows to create a tag for the RC, draft a release on GitHub, build the
      release artifacts, and attach them to the release.
+   - The first RC automatically creates the `backport/vX.Y` label, so PRs can be labeled for
+     backporting during the RC validation phase.
 2. Once everything is attached, add any relevant changelog details to the RC draft release and
    publish it from either the CLI or github.com. For example:
    ```sh
@@ -76,7 +78,8 @@ cut a new RC and repeat step 3.
    attach them to the release.
 3. Once everything is attached, publish the release either from the CLI or from the Releases page on
    github.com.
-4. This will automatically create the corresponding `release/vX.Y` branch and `backport/vX.Y` label.
+4. This will automatically create the corresponding `release/vX.Y` branch (and `backport/vX.Y` label
+   if it wasn't already created during the RC phase).
 
 ### 6. Update Helm Chart
 

--- a/tools/release/backport/main.go
+++ b/tools/release/backport/main.go
@@ -67,13 +67,17 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// Verify the target release branch exists
+	// Verify the target release branch exists. If it doesn't, the release
+	// hasn't been finalized yet (we're still in RC mode) and the change will
+	// be included in the release implicitly since it's already on main.
 	exists, err := git.BranchExistsOnRemote(targetBranch)
 	if err != nil {
 		log.Fatalf("Failed to check if target branch exists: %v", err)
 	}
 	if !exists {
-		log.Fatalf("Target branch %s does not exist", targetBranch)
+		fmt.Printf("ℹ️  Target branch %s does not exist yet (release is likely still in RC phase).\n", targetBranch)
+		fmt.Printf("   No backport needed — this change will be included in the release implicitly.\n")
+		return
 	}
 
 	// Check if backport branch already exists (means there's an open PR or work in progress)

--- a/tools/release/create-rc/main.go
+++ b/tools/release/create-rc/main.go
@@ -15,6 +15,25 @@ import (
 	"github.com/grafana/alloy/tools/release/internal/version"
 )
 
+const (
+	backportLabelPrefix = "backport/v"
+	releaseBranchPrefix = "release/v"
+)
+
+// rcInfo holds the resolved parameters for creating a release candidate.
+type rcInfo struct {
+	PR        *github.PullRequest
+	Version   string
+	RCNumber  int
+	RCTag     string
+	BranchSHA string
+	Branch    string
+}
+
+func (info rcInfo) isFirstMinorRC() bool {
+	return info.RCNumber == 0 && info.Branch == "main"
+}
+
 // prereleaseParams holds parameters for creating a draft prerelease.
 type prereleaseParams struct {
 	Tag       string // Tag name (e.g., "v1.0.0-rc.0")
@@ -25,6 +44,29 @@ type prereleaseParams struct {
 }
 
 func main() {
+	branch, dryRun := parseFlags()
+
+	ctx := context.Background()
+	client, err := gh.NewClientFromEnv(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	info := resolveRCInfo(ctx, client, branch)
+
+	if dryRun {
+		printDryRun(info)
+		return
+	}
+
+	createRCRelease(ctx, client, info)
+
+	if info.isFirstMinorRC() {
+		ensureBackportLabelForRC(ctx, client, info)
+	}
+}
+
+func parseFlags() (string, bool) {
 	var (
 		dryRun bool
 		branch string
@@ -36,21 +78,15 @@ func main() {
 	if branch == "" {
 		log.Fatal("Branch is required (use --branch flag, e.g., --branch main)")
 	}
-
 	if branch != "main" {
 		if _, err := version.ParseReleaseBranch(branch); err != nil {
 			log.Fatal(err)
 		}
 	}
+	return branch, dryRun
+}
 
-	ctx := context.Background()
-
-	client, err := gh.NewClientFromEnv(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// Find the release-please PR for the specified branch
+func resolveRCInfo(ctx context.Context, client *gh.Client, branch string) rcInfo {
 	pr, err := findReleasePleasePR(ctx, client, branch)
 	if err != nil {
 		log.Fatalf("Failed to find release-please PR: %v", err)
@@ -60,7 +96,6 @@ func main() {
 	fmt.Printf("Base branch: %s\n", pr.GetBase().GetRef())
 	fmt.Printf("Head branch: %s\n", pr.GetHead().GetRef())
 
-	// Extract version from PR title
 	ver, err := extractVersionFromTitle(pr.GetTitle())
 	if err != nil {
 		log.Fatalf("Failed to extract version from PR title: %v", err)
@@ -76,7 +111,6 @@ func main() {
 		log.Fatalf("Cannot create a patch release RC from main. Use the release branch instead: --branch release/v%s", mm)
 	}
 
-	// Find existing RC tags and determine next RC number
 	rcNumber, err := findNextRCNumber(ctx, client, ver)
 	if err != nil {
 		log.Fatalf("Failed to determine next RC number: %v", err)
@@ -85,43 +119,78 @@ func main() {
 	rcTag := fmt.Sprintf("v%s-rc.%d", ver, rcNumber)
 	fmt.Printf("Next RC tag: %s\n", rcTag)
 
-	// Get the SHA of the PR branch head
 	branchSHA := pr.GetHead().GetSHA()
 	fmt.Printf("Branch HEAD SHA: %s\n", branchSHA)
 
-	if dryRun {
-		fmt.Println("\n🏃 DRY RUN - No changes made")
-		fmt.Printf("Would create tag: %s\n", rcTag)
-		fmt.Printf("Base branch: %s\n", branch)
-		fmt.Printf("Release-please branch: %s\n", pr.GetHead().GetRef())
-		fmt.Printf("Head commit: %s\n", branchSHA)
-		return
+	return rcInfo{
+		PR:        pr,
+		Version:   ver,
+		RCNumber:  rcNumber,
+		RCTag:     rcTag,
+		BranchSHA: branchSHA,
+		Branch:    branch,
 	}
+}
 
+func printDryRun(info rcInfo) {
+	fmt.Println("\n🏃 DRY RUN - No changes made")
+	fmt.Printf("Would create tag: %s\n", info.RCTag)
+	fmt.Printf("Base branch: %s\n", info.Branch)
+	fmt.Printf("Release-please branch: %s\n", info.PR.GetHead().GetRef())
+	fmt.Printf("Head commit: %s\n", info.BranchSHA)
+	if info.isFirstMinorRC() {
+		majorMinor, _ := version.MajorMinor(info.Version)
+		fmt.Printf("Would ensure backport label exists: %s\n", backportLabelPrefix+majorMinor)
+	}
+}
+
+func createRCRelease(ctx context.Context, client *gh.Client, info rcInfo) {
 	// Draft releases don't create tags until published. Tag creation is what triggers artifacts to
 	// build and get attached to releases. So we create a tag here like how release-please does with
 	// force-tag-creation.
 	if err := client.CreateTag(ctx, gh.CreateTagParams{
-		Tag:     rcTag,
-		SHA:     branchSHA,
-		Message: fmt.Sprintf("Release candidate %s", rcTag),
+		Tag:     info.RCTag,
+		SHA:     info.BranchSHA,
+		Message: fmt.Sprintf("Release candidate %s", info.RCTag),
 	}); err != nil {
 		log.Fatalf("Failed to create tag: %v", err)
 	}
-	fmt.Printf("Created tag: %s -> %s\n", rcTag, branchSHA[:12])
+	fmt.Printf("Created tag: %s -> %s\n", info.RCTag, info.BranchSHA[:12])
 
-	// Create draft prerelease pointing to the existing tag
 	releaseURL, err := createDraftPrerelease(ctx, client, prereleaseParams{
-		Tag:       rcTag,
-		TargetSHA: branchSHA,
-		Version:   ver,
-		RCNumber:  rcNumber,
-		PRNumber:  pr.GetNumber(),
+		Tag:       info.RCTag,
+		TargetSHA: info.BranchSHA,
+		Version:   info.Version,
+		RCNumber:  info.RCNumber,
+		PRNumber:  info.PR.GetNumber(),
 	})
 	if err != nil {
 		log.Fatalf("Failed to create draft prerelease: %v", err)
 	}
 	fmt.Printf("✅ Created draft prerelease: %s\n", releaseURL)
+}
+
+func ensureBackportLabelForRC(ctx context.Context, client *gh.Client, info rcInfo) {
+	majorMinor, err := version.MajorMinor(info.Version)
+	if err != nil {
+		log.Fatalf("Failed to parse major.minor from version %q: %v", info.Version, err)
+	}
+	backportLabel := backportLabelPrefix + majorMinor
+	branchName := releaseBranchPrefix + majorMinor
+
+	created, err := client.EnsureLabel(ctx, gh.CreateLabelParams{
+		Name:        backportLabel,
+		Color:       gh.BackportLabelColor,
+		Description: fmt.Sprintf("Backport to %s", branchName),
+	})
+	if err != nil {
+		log.Fatalf("Failed to ensure backport label: %v", err)
+	}
+	if created {
+		fmt.Printf("✅ Created backport label: %s\n", backportLabel)
+	} else {
+		fmt.Printf("Backport label %s already exists\n", backportLabel)
+	}
 }
 
 func findReleasePleasePR(ctx context.Context, client *gh.Client, baseBranch string) (*github.PullRequest, error) {

--- a/tools/release/create-release-branch/main.go
+++ b/tools/release/create-release-branch/main.go
@@ -11,11 +11,7 @@ import (
 )
 
 const (
-	// backportLabelColor is the hex color for backport labels (without '#' prefix).
-	backportLabelColor = "63a504"
-	// releaseBranchPrefix is the prefix for release branches.
 	releaseBranchPrefix = "release/v"
-	// backportLabelPrefix is the prefix for backport labels.
 	backportLabelPrefix = "backport/v"
 )
 
@@ -87,15 +83,17 @@ func main() {
 	fmt.Printf("✅ Created branch: %s\n", branchName)
 	fmt.Printf("🔗 https://github.com/%s/%s/tree/%s\n", client.Owner(), client.Repo(), branchName)
 
-	// Create the backport label
-	err = client.CreateLabel(ctx, gh.CreateLabelParams{
+	created, err := client.EnsureLabel(ctx, gh.CreateLabelParams{
 		Name:        backportLabel,
-		Color:       backportLabelColor,
+		Color:       gh.BackportLabelColor,
 		Description: fmt.Sprintf("Backport to %s", branchName),
 	})
 	if err != nil {
-		log.Fatalf("Failed to create label: %v", err)
+		log.Fatalf("Failed to ensure label: %v", err)
 	}
-
-	fmt.Printf("✅ Created label: %s\n", backportLabel)
+	if created {
+		fmt.Printf("✅ Created label: %s\n", backportLabel)
+	} else {
+		fmt.Printf("Label %s already exists\n", backportLabel)
+	}
 }

--- a/tools/release/internal/github/client.go
+++ b/tools/release/internal/github/client.go
@@ -65,6 +65,9 @@ type FindCommitParams struct {
 	Pattern string
 }
 
+// BackportLabelColor is the hex color for backport labels (without '#' prefix).
+const BackportLabelColor = "63a504"
+
 // CreateLabelParams holds parameters for CreateLabel.
 type CreateLabelParams struct {
 	Name        string // Label name
@@ -389,8 +392,9 @@ func (c *Client) IsBranchMergedInto(ctx context.Context, source, target string) 
 	return status == "behind" || status == "identical", nil
 }
 
-// CreateLabel creates a new label in the repository.
-func (c *Client) CreateLabel(ctx context.Context, p CreateLabelParams) error {
+// EnsureLabel creates a label if it doesn't already exist.
+// Returns true if the label was created, false if it already existed.
+func (c *Client) EnsureLabel(ctx context.Context, p CreateLabelParams) (bool, error) {
 	label := &github.Label{
 		Name:        github.String(p.Name),
 		Color:       github.String(p.Color),
@@ -398,11 +402,20 @@ func (c *Client) CreateLabel(ctx context.Context, p CreateLabelParams) error {
 	}
 
 	_, _, err := c.api.Issues.CreateLabel(ctx, c.owner, c.repo, label)
-	if err != nil {
-		return fmt.Errorf("creating label %q: %w", p.Name, err)
+	if err == nil {
+		return true, nil
 	}
 
-	return nil
+	var errResp *github.ErrorResponse
+	if errors.As(err, &errResp) {
+		for _, e := range errResp.Errors {
+			if e.Code == "already_exists" {
+				return false, nil
+			}
+		}
+	}
+
+	return false, fmt.Errorf("creating label %q: %w", p.Name, err)
 }
 
 // GetReleaseByTag fetches a release by its tag name.


### PR DESCRIPTION
The logic will still ensure it exists at release branch creation time (for the case of no RCs).

Ensures that if a PR marked as backport is merged during RC mode, it will be handled gracefully rather than failing outright.

Refactor some logic to reduce cognitive complexity.