### PR TITLE
fix(helm): Handle empty rbac.rules and rbac.clusterRules arrays

### DIFF
--- a/operations/helm/charts/alloy/templates/rbac.yaml
+++ b/operations/helm/charts/alloy/templates/rbac.yaml
@@ -11,7 +11,10 @@ metadata:
     {{- include "alloy.labels" $ | nindent 4 }}
     app.kubernetes.io/component: rbac
 rules:
+  {{- if $.Values.rbac.rules }}
   {{- $.Values.rbac.rules | toYaml | nindent 2 }}
+  {{- else }} []
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -40,8 +43,14 @@ metadata:
     {{- include "alloy.labels" . | nindent 4 }}
     app.kubernetes.io/component: rbac
 rules:
+  {{- if .Values.rbac.rules }}
   {{- .Values.rbac.rules | toYaml | nindent 2 }}
+  {{- end }}
+  {{- if .Values.rbac.clusterRules }}
   {{- .Values.rbac.clusterRules | toYaml | nindent 2 }}
+  {{- end }}
+  {{- if and (not .Values.rbac.rules) (not .Values.rbac.clusterRules) }} []
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Summary

Fixes Helm template failure when `rbac.rules` or `rbac.clusterRules` is set to an empty array `[]`.

## Why this matters

Setting `rbac.rules: []` or `rbac.clusterRules: []` in values causes `helm template` to fail with a YAML parse error because `toYaml` on an empty array produces `[]` in a position where the YAML parser expects a block sequence or empty value. Users who want to create an RBAC role with only cluster rules (or no rules) hit this error.

## Changes

**File:** `operations/helm/charts/alloy/templates/rbac.yaml`

- Wrapped `toYaml` calls for `rbac.rules` and `rbac.clusterRules` in `{{- if }}` conditionals
- When all rules arrays are empty, outputs `[]` as a valid empty YAML sequence
- Preserves existing behavior when rules are non-empty

## Testing

- Verified the template produces valid YAML when `rbac.rules: []` and `rbac.clusterRules: []`
- Non-empty rule arrays render the same as before (conditional is transparent)

Closes #4778

This contribution was developed with AI assistance (Claude Code).