### PR TITLE
feat(database_observability): Make targets optional

### DIFF
--- a/docs/sources/reference/components/database_observability/database_observability.mysql.md
+++ b/docs/sources/reference/components/database_observability/database_observability.mysql.md
@@ -20,7 +20,6 @@ It forwards this data as log entries to Loki receivers and exports targets for P
 database_observability.mysql "<LABEL>" {
   data_source_name = <DATA_SOURCE_NAME>
   forward_to       = [<LOKI_RECEIVERS>]
-  targets          = "<TARGET_LIST>"
 }
 ```
 
@@ -32,7 +31,7 @@ You can use the following arguments with `database_observability.mysql`:
 |--------------------------------------------|----------------------|-----------------------------------------------------------------------------|---------|----------|
 | `data_source_name`                         | `secret`             | [Data Source Name][] for the MySQL server to connect to.                    |         | yes      |
 | `forward_to`                               | `list(LogsReceiver)` | Where to forward log entries after processing.                              |         | yes      |
-| `targets`                                  | `list(map(string))`  | List of targets to scrape.                                                  |         | yes      |
+| `targets`                                  | `list(map(string))`  | List of external targets to scrape.                                         |         | no       |
 | `disable_collectors`                       | `list(string)`       | A list of collectors to disable from the default set.                       |         | no       |
 | `enable_collectors`                        | `list(string)`       | A list of collectors to enable on top of the default set.                   |         | no       |
 | `exclude_schemas`                          | `list(string)`       | A list of schemas to exclude from monitoring.                               |         | no       |
@@ -56,19 +55,20 @@ You can use the following blocks with `database_observability.mysql`:
 
 {{< docs/alloy-config >}}
 
-| Block                                | Description                                       | Required |
-|--------------------------------------|---------------------------------------------------|----------|
-| [`cloud_provider`][cloud_provider]   | Provide Cloud Provider information.               | no       |
-| `cloud_provider` > [`aws`][aws]      | Provide AWS database host information.            | no       |
-| `cloud_provider` > [`azure`][azure]  | Provide Azure database host information.          | no       |
-| [`setup_consumers`][setup_consumers] | Configure the `setup_consumers` collector.        | no       |
-| [`setup_actors`][setup_actors]       | Configure the `setup_actors` collector.           | no       |
-| [`query_details`][query_details]     | Configure the queries collector.                  | no       |
-| [`schema_details`][schema_details]   | Configure the schema and table details collector. | no       |
-| [`explain_plans`][explain_plans]     | Configure the explain plans collector.            | no       |
-| [`locks`][locks]                     | Configure the locks collector.                    | no       |
-| [`query_samples`][query_samples]     | Configure the query samples collector.            | no       |
-| [`health_check`][health_check]       | Configure the health check collector.             | no       |
+| Block                                            | Description                                       | Required |
+|--------------------------------------------------|---------------------------------------------------|----------|
+| [`cloud_provider`][cloud_provider]               | Provide Cloud Provider information.               | no       |
+| `cloud_provider` > [`aws`][aws]                  | Provide AWS database host information.            | no       |
+| `cloud_provider` > [`azure`][azure]              | Provide Azure database host information.          | no       |
+| [`setup_consumers`][setup_consumers]             | Configure the `setup_consumers` collector.        | no       |
+| [`setup_actors`][setup_actors]                   | Configure the `setup_actors` collector.           | no       |
+| [`query_details`][query_details]                 | Configure the queries collector.                  | no       |
+| [`schema_details`][schema_details]               | Configure the schema and table details collector. | no       |
+| [`explain_plans`][explain_plans]                 | Configure the explain plans collector.            | no       |
+| [`locks`][locks]                                 | Configure the locks collector.                    | no       |
+| [`query_samples`][query_samples]                 | Configure the query samples collector.            | no       |
+| [`health_check`][health_check]                   | Configure the health check collector.             | no       |
+| [`prometheus_exporter`][prometheus_exporter]     | Configure the embedded mysqld_exporter.           | no       |
 
 [cloud_provider]: #cloud_provider
 [aws]: #aws
@@ -81,6 +81,7 @@ You can use the following blocks with `database_observability.mysql`:
 [query_samples]: #query_samples
 [setup_actors]: #setup_actors
 [health_check]: #health_check
+[prometheus_exporter]: #prometheus_exporter
 
 {{< /docs/alloy-config >}}
 
@@ -166,12 +167,18 @@ The `azure` block supplies the identifying information for the database being mo
 | `collect_interval`         | `duration` | How frequently to check if `setup_actors` are configured correctly.    | `"1h"`  | no       |
 
 
-### `health_checks`
+### `health_check`
 
 | Name                       | Type       | Description                                                            | Default | Required |
 | -------------------------- | ---------- | ---------------------------------------------------------------------- | ------- | -------- |
 | `collect_interval`         | `duration` | How frequently to run health checks.                                   | `"1h"`  | no       |
 
+### `prometheus_exporter`
+
+The `prometheus_exporter` block configures the embedded mysqld_exporter scrapers.
+The `data_source_name` is inherited from the parent block.
+
+Refer to [`prometheus.exporter.mysql`](../../prometheus/prometheus.exporter.mysql/) docs for the full list of supported arguments and sub-blocks.
 
 ## Example
 

--- a/docs/sources/reference/components/database_observability/database_observability.postgres.md
+++ b/docs/sources/reference/components/database_observability/database_observability.postgres.md
@@ -20,7 +20,6 @@ It forwards this data as log entries to Loki receivers and exports targets for P
 database_observability.postgres "<LABEL>" {
   data_source_name = <DATA_SOURCE_NAME>
   forward_to       = [<LOKI_RECEIVERS>]
-  targets          = "<TARGET_LIST>"
 }
 ```
 
@@ -32,7 +31,7 @@ You can use the following arguments with `database_observability.postgres`:
 |----------------------|----------------------|-------------------------------------------------------------|---------|----------|
 | `data_source_name`   | `secret`             | [Data Source Name][] for the Postgres server to connect to. |         | yes      |
 | `forward_to`         | `list(LogsReceiver)` | Where to forward log entries after processing.              |         | yes      |
-| `targets`            | `list(map(string))`  | List of targets to scrape.                                  |         | yes      |
+| `targets`            | `list(map(string))`  | List of external targets to scrape for Prometheus metrics.  |         | no       |
 | `disable_collectors` | `list(string)`       | A list of collectors to disable from the default set.       |         | no       |
 | `enable_collectors`  | `list(string)`       | A list of collectors to enable on top of the default set.   |         | no       |
 | `exclude_databases`  | `list(string)`       | A list of databases to exclude from monitoring.             |         | no       |
@@ -76,7 +75,8 @@ You can use the following blocks with `database_observability.postgres`:
 | [`query_samples`][query_samples]   | Configure the query samples collector.            | no       |
 | [`schema_details`][schema_details] | Configure the schema and table details collector. | no       |
 | [`explain_plans`][explain_plans]   | Configure the explain plans collector.            | no       |
-| [`health_check`][health_check]     | Configure the health check collector.             | no       |
+| [`health_check`][health_check]               | Configure the health check collector.   | no       |
+| [`prometheus_exporter`][prometheus_exporter] | Configure the embedded postgres_exporter. | no       |
 
 [cloud_provider]: #cloud_provider
 [aws]: #aws
@@ -86,6 +86,7 @@ You can use the following blocks with `database_observability.postgres`:
 [schema_details]: #schema_details
 [explain_plans]: #explain_plans
 [health_check]: #health_check
+[prometheus_exporter]: #prometheus_exporter
 
 {{< /docs/alloy-config >}}
 
@@ -151,6 +152,13 @@ The `azure` block supplies the identifying information for the database being mo
 | Name               | Type       | Description                                          | Default | Required |
 |--------------------|------------|------------------------------------------------------|---------|----------|
 | `collect_interval` | `duration` | How frequently to collect information from database. | `"1h"`  | no       |
+
+### `prometheus_exporter`
+
+The `prometheus_exporter` block configures the embedded postgres_exporter scrapers.
+The `data_source_name` is inherited from the parent block.
+
+Refer to [`prometheus.exporter.postgres`](../../prometheus/prometheus.exporter.postgres/) docs for the full list of supported arguments and sub-blocks.
 
 ## `logs` collector
 

--- a/internal/component/database_observability/mysql/component.go
+++ b/internal/component/database_observability/mysql/component.go
@@ -62,7 +62,7 @@ var (
 type Arguments struct {
 	DataSourceName                alloytypes.Secret   `alloy:"data_source_name,attr"`
 	ForwardTo                     []loki.LogsReceiver `alloy:"forward_to,attr"`
-	Targets                       []discovery.Target  `alloy:"targets,attr"`
+	Targets                       []discovery.Target  `alloy:"targets,attr,optional"`
 	EnableCollectors              []string            `alloy:"enable_collectors,attr,optional"`
 	DisableCollectors             []string            `alloy:"disable_collectors,attr,optional"`
 	ExcludeSchemas                []string            `alloy:"exclude_schemas,attr,optional"`
@@ -460,7 +460,11 @@ func (c *Component) connectAndStartCollectors(ctx context.Context) error {
 		c.exporterCollector = nil
 	}
 
-	if c.args.PrometheusExporter != nil {
+	if len(c.args.Targets) == 0 {
+		if c.args.PrometheusExporter == nil {
+			d := PrometheusExporterArguments(exporter_mysql.DefaultArguments)
+			c.args.PrometheusExporter = &d
+		}
 		exporterArgs := exporter_mysql.Arguments(*c.args.PrometheusExporter)
 		exporterCfg := exporterArgs.Convert()
 		scrapers := mysqld_exporter.GetScrapers(exporterCfg)

--- a/internal/component/database_observability/mysql/component_test.go
+++ b/internal/component/database_observability/mysql/component_test.go
@@ -564,7 +564,6 @@ func Test_PrometheusExporterBlock(t *testing.T) {
 		cfg := `
 			data_source_name = ""
 			forward_to = []
-			targets = []
 		`
 		var args Arguments
 		err := syntax.Unmarshal([]byte(cfg), &args)
@@ -576,7 +575,6 @@ func Test_PrometheusExporterBlock(t *testing.T) {
 		cfg := `
 			data_source_name = ""
 			forward_to = []
-			targets = []
 			prometheus_exporter {}
 		`
 		var args Arguments
@@ -587,11 +585,10 @@ func Test_PrometheusExporterBlock(t *testing.T) {
 		assert.Equal(t, 2, exporterArgs.LockWaitTimeout) // default value
 	})
 
-	t.Run("present with defaults when empty block", func(t *testing.T) {
+	t.Run("present with custom collectors", func(t *testing.T) {
 		cfg := `
 			data_source_name = ""
 			forward_to = []
-			targets = []
 			prometheus_exporter {
 			  enable_collectors = ["perf_schema.eventsstatements", "perf_schema.eventswaits"]
 			}

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -67,7 +67,7 @@ var (
 type Arguments struct {
 	DataSourceName    alloytypes.Secret   `alloy:"data_source_name,attr"`
 	ForwardTo         []loki.LogsReceiver `alloy:"forward_to,attr"`
-	Targets           []discovery.Target  `alloy:"targets,attr"`
+	Targets           []discovery.Target  `alloy:"targets,attr,optional"`
 	EnableCollectors  []string            `alloy:"enable_collectors,attr,optional"`
 	DisableCollectors []string            `alloy:"disable_collectors,attr,optional"`
 	ExcludeDatabases  []string            `alloy:"exclude_databases,attr,optional"`
@@ -400,7 +400,11 @@ func (c *Component) connectAndStartCollectors(ctx context.Context) error {
 	}
 	c.exporterCollectors = nil
 
-	if c.args.PrometheusExporter != nil {
+	if len(c.args.Targets) == 0 {
+		if c.args.PrometheusExporter == nil {
+			d := PrometheusExporterArguments(exporter_postgres.DefaultArguments)
+			c.args.PrometheusExporter = &d
+		}
 		exporterArgs := exporter_postgres.Arguments(*c.args.PrometheusExporter)
 		slogLogger := slog.New(logging.NewSlogGoKitHandler(c.opts.Logger))
 		dsn := string(c.args.DataSourceName)

--- a/internal/component/database_observability/postgres/component_test.go
+++ b/internal/component/database_observability/postgres/component_test.go
@@ -741,7 +741,6 @@ func Test_PrometheusExporterBlock(t *testing.T) {
 		cfg := `
 			data_source_name = "postgresql://user:pass@localhost:5432/db"
 			forward_to = []
-			targets = []
 		`
 		var args Arguments
 		err := syntax.Unmarshal([]byte(cfg), &args)
@@ -753,7 +752,6 @@ func Test_PrometheusExporterBlock(t *testing.T) {
 		cfg := `
 			data_source_name = "postgresql://user:pass@localhost:5432/db"
 			forward_to = []
-			targets = []
 			prometheus_exporter {}
 		`
 		var args Arguments
@@ -769,7 +767,6 @@ func Test_PrometheusExporterBlock(t *testing.T) {
 		cfg := `
 			data_source_name = "postgresql://user:pass@localhost:5432/db"
 			forward_to = []
-			targets = []
 			prometheus_exporter {
 				disable_settings_metrics = true
 			}


### PR DESCRIPTION
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style. For details on this,
  check out the Contributors Guide linked above.
-->

### Brief description of Pull Request

<!-- Human-readable description of the PR used as squash commit body. -->
This change makes the `targets` for database_observability components optional. If it is not provided, we instead create an embedded prometheus exporter to scrape required metrics.

This removes the need for users to configure the `prometheus.exporter.mysql` and `prometheus.exporter.postgres` components in addition to the respective `database_observability` components. 

### Pull Request Details

<!-- Detailed descripion of the Pull Request, if needed. -->


### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->


### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
