### PR TITLE
fix(dbo11y): Surface nested event for MySQL wait/io/table/sql/handler waits

### DIFF
--- a/internal/component/database_observability/mysql/collector/query_samples.go
+++ b/internal/component/database_observability/mysql/collector/query_samples.go
@@ -443,7 +443,7 @@ func (c *QuerySamples) fetchQuerySamples(ctx context.Context) error {
 			// wrapper; use the nested event instead when available to surface the
 			// actual underlying I/O wait.
 			// See https://dev.mysql.com/doc/refman/5.7/en/performance-schema-atom-molecule-events.html
-			if row.NestedWaitEventID.Valid && row.WaitEventName.String == "wait/io/table/sql/handler" {
+			if row.NestedWaitEventID.Valid && row.NestedWaitTime.Valid && row.WaitEventName.String == "wait/io/table/sql/handler" {
 				eventID = row.NestedWaitEventID.String
 				endEventID = row.NestedWaitEndEventID.String
 				eventName = row.NestedWaitEventName.String

--- a/internal/component/database_observability/mysql/collector/query_samples.go
+++ b/internal/component/database_observability/mysql/collector/query_samples.go
@@ -59,6 +59,12 @@ SELECT
 	waits.object_name as WAIT_OBJECT_NAME,
 	waits.object_type as WAIT_OBJECT_TYPE,
 	waits.timer_wait as WAIT_TIMER_WAIT,
+	nested_waits.event_id as NESTED_WAIT_EVENT_ID,
+	nested_waits.end_event_id as NESTED_WAIT_END_EVENT_ID,
+	nested_waits.event_name as NESTED_WAIT_EVENT_NAME,
+	nested_waits.object_name as NESTED_WAIT_OBJECT_NAME,
+	nested_waits.object_type as NESTED_WAIT_OBJECT_TYPE,
+	nested_waits.timer_wait as NESTED_WAIT_TIMER_WAIT,
 	threads.PROCESSLIST_USER as QUERY_USER,
 	threads.PROCESSLIST_HOST as QUERY_HOST
 	%s
@@ -69,6 +75,11 @@ LEFT JOIN
 	ON statements.thread_id = waits.thread_id
 	AND statements.EVENT_ID = waits.NESTING_EVENT_ID
 	%s
+LEFT JOIN
+	performance_schema.events_waits_history nested_waits
+	ON waits.thread_id = nested_waits.thread_id
+	AND waits.event_id = nested_waits.nesting_event_id
+	AND waits.event_name = 'wait/io/table/sql/handler'
 LEFT JOIN
 	performance_schema.threads threads
 	ON statements.THREAD_ID = threads.THREAD_ID
@@ -312,13 +323,21 @@ func (c *QuerySamples) fetchQuerySamples(ctx context.Context) error {
 			MaxControlledMemory uint64
 			MaxTotalMemory      uint64
 
-			// sample wait info, if any
+			// wait event info
 			WaitEventID    sql.NullString
 			WaitEndEventID sql.NullString
 			WaitEventName  sql.NullString
 			WaitObjectName sql.NullString
 			WaitObjectType sql.NullString
 			WaitTime       sql.NullFloat64
+
+			// nested wait event info (when outer event is wait/io/table/sql/handler)
+			NestedWaitEventID    sql.NullString
+			NestedWaitEndEventID sql.NullString
+			NestedWaitEventName  sql.NullString
+			NestedWaitObjectName sql.NullString
+			NestedWaitObjectType sql.NullString
+			NestedWaitTime       sql.NullFloat64
 
 			// user and host who issued the query
 			User sql.NullString
@@ -343,6 +362,12 @@ func (c *QuerySamples) fetchQuerySamples(ctx context.Context) error {
 			&row.WaitObjectName,
 			&row.WaitObjectType,
 			&row.WaitTime,
+			&row.NestedWaitEventID,
+			&row.NestedWaitEndEventID,
+			&row.NestedWaitEventName,
+			&row.NestedWaitObjectName,
+			&row.NestedWaitObjectType,
+			&row.NestedWaitTime,
 			&row.User,
 			&row.Host,
 		}
@@ -407,7 +432,27 @@ func (c *QuerySamples) fetchQuerySamples(ctx context.Context) error {
 		}
 
 		if row.WaitEventID.Valid && row.WaitTime.Valid {
-			waitTime := picosecondsToMilliseconds(row.WaitTime.Float64)
+			eventID := row.WaitEventID.String
+			endEventID := row.WaitEndEventID.String
+			eventName := row.WaitEventName.String
+			objectName := row.WaitObjectName.String
+			objectType := row.WaitObjectType.String
+			waitTime := row.WaitTime.Float64
+
+			// When the outer event is wait/io/table/sql/handler it is just a handler
+			// wrapper; use the nested event instead when available to surface the
+			// actual underlying I/O wait.
+			// See https://dev.mysql.com/doc/refman/5.7/en/performance-schema-atom-molecule-events.html
+			if row.NestedWaitEventID.Valid && row.WaitEventName.String == "wait/io/table/sql/handler" {
+				eventID = row.NestedWaitEventID.String
+				endEventID = row.NestedWaitEndEventID.String
+				eventName = row.NestedWaitEventName.String
+				objectName = row.NestedWaitObjectName.String
+				objectType = row.NestedWaitObjectType.String
+				waitTime = row.NestedWaitTime.Float64
+			}
+
+			waitTimeMs := picosecondsToMilliseconds(waitTime)
 			waitLogMessage := fmt.Sprintf(
 				`schema="%s" user="%s" client_host="%s" thread_id="%s" digest="%s" event_id="%s" wait_event_id="%s" wait_end_event_id="%s" wait_event_name="%s" wait_object_name="%s" wait_object_type="%s" wait_time="%fms"`,
 				row.Schema.String,
@@ -416,12 +461,12 @@ func (c *QuerySamples) fetchQuerySamples(ctx context.Context) error {
 				row.ThreadID.String,
 				row.Digest.String,
 				row.StatementEventID.String,
-				row.WaitEventID.String,
-				row.WaitEndEventID.String,
-				row.WaitEventName.String,
-				row.WaitObjectName.String,
-				row.WaitObjectType.String,
-				waitTime,
+				eventID,
+				endEventID,
+				eventName,
+				objectName,
+				objectType,
+				waitTimeMs,
 			)
 
 			c.entryHandler.Chan() <- database_observability.BuildLokiEntryWithTimestamp(

--- a/internal/component/database_observability/mysql/collector/query_samples_test.go
+++ b/internal/component/database_observability/mysql/collector/query_samples_test.go
@@ -1242,18 +1242,18 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 					"5",
 					"0",
 					"0",
-					"200",                           // WAIT_EVENT_ID (outer table handler)
-					"201",                           // WAIT_END_EVENT_ID
-					"wait/io/table/sql/handler",      // WAIT_EVENT_NAME (the handler wrapper)
-					"books",                         // WAIT_OBJECT_NAME
-					"TABLE",                         // WAIT_OBJECT_TYPE
-					"900000000",                     // WAIT_TIMER_WAIT (900ms)
-					"210",                           // NESTED_WAIT_EVENT_ID
-					"211",                           // NESTED_WAIT_END_EVENT_ID
+					"200",                                  // WAIT_EVENT_ID (outer table handler)
+					"201",                                  // WAIT_END_EVENT_ID
+					"wait/io/table/sql/handler",            // WAIT_EVENT_NAME (the handler wrapper)
+					"books",                                // WAIT_OBJECT_NAME
+					"TABLE",                                // WAIT_OBJECT_TYPE
+					"900000000",                            // WAIT_TIMER_WAIT (900ms)
+					"210",                                  // NESTED_WAIT_EVENT_ID
+					"211",                                  // NESTED_WAIT_END_EVENT_ID
 					"wait/io/file/innodb/innodb_data_file", // NESTED_WAIT_EVENT_NAME (actual I/O)
-					"ibdata1",                       // NESTED_WAIT_OBJECT_NAME
-					"FILE",                          // NESTED_WAIT_OBJECT_TYPE
-					"500000000",                     // NESTED_WAIT_TIMER_WAIT (500ms)
+					"ibdata1",                              // NESTED_WAIT_OBJECT_NAME
+					"FILE",                                 // NESTED_WAIT_OBJECT_TYPE
+					"500000000",                            // NESTED_WAIT_TIMER_WAIT (500ms)
 					"some_user",
 					"some_host",
 					"10000000",
@@ -1351,13 +1351,13 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 					"5",
 					"0",
 					"0",
-					"200",                      // WAIT_EVENT_ID
-					"201",                      // WAIT_END_EVENT_ID
+					"200",                       // WAIT_EVENT_ID
+					"201",                       // WAIT_END_EVENT_ID
 					"wait/io/table/sql/handler", // WAIT_EVENT_NAME (no nested event available)
-					"books",                    // WAIT_OBJECT_NAME
-					"TABLE",                    // WAIT_OBJECT_TYPE
-					"900000000",                // WAIT_TIMER_WAIT (900ms)
-					nil,                        // NESTED_WAIT_EVENT_ID (no nested event)
+					"books",                     // WAIT_OBJECT_NAME
+					"TABLE",                     // WAIT_OBJECT_TYPE
+					"900000000",                 // WAIT_TIMER_WAIT (900ms)
+					nil,                         // NESTED_WAIT_EVENT_ID (no nested event)
 					nil,
 					nil,
 					nil,
@@ -2647,11 +2647,11 @@ func TestQuerySamples_handles_timer_overflows(t *testing.T) {
 				nil,
 				nil,
 				nil,
-				"some_user",   // PROCESSLIST_USER
-				"some_host",   // PROCESSLIST_HOST
-				555555,        // cpu_time
-				1048576,       // max_controlled_memory (1MB)
-				2097152,       // max_total_memory (2MB)
+				"some_user", // PROCESSLIST_USER
+				"some_host", // PROCESSLIST_HOST
+				555555,      // cpu_time
+				1048576,     // max_controlled_memory (1MB)
+				2097152,     // max_total_memory (2MB)
 			),
 		)
 
@@ -3102,11 +3102,11 @@ func TestQuerySamples_handles_timer_overflows(t *testing.T) {
 				nil,
 				nil,
 				nil,
-				"some_user",   // PROCESSLIST_USER
-				"some_host",   // PROCESSLIST_HOST
-				555555,        // cpu_time
-				1048576,       // max_controlled_memory (1MB)
-				2097152,       // max_total_memory (2MB)
+				"some_user", // PROCESSLIST_USER
+				"some_host", // PROCESSLIST_HOST
+				555555,      // cpu_time
+				1048576,     // max_controlled_memory (1MB)
+				2097152,     // max_total_memory (2MB)
 			),
 		)
 		mockParser := &parser.MockParser{}

--- a/internal/component/database_observability/mysql/collector/query_samples_test.go
+++ b/internal/component/database_observability/mysql/collector/query_samples_test.go
@@ -53,6 +53,12 @@ func TestQuerySamples(t *testing.T) {
 				nil,
 				nil,
 				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
 				"some_user",
 				"some_host",
 				"10000000",
@@ -86,6 +92,12 @@ func TestQuerySamples(t *testing.T) {
 				nil,
 				nil,
 				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
 				"some_user",
 				"some_host",
 				"10000000",
@@ -103,6 +115,12 @@ func TestQuerySamples(t *testing.T) {
 				"5",
 				"0",
 				"0",
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
 				nil,
 				nil,
 				nil,
@@ -188,6 +206,12 @@ func TestQuerySamples(t *testing.T) {
 						"waits.object_name",
 						"waits.object_type",
 						"waits.timer_wait",
+						"nested_waits.event_id",
+						"nested_waits.end_event_id",
+						"nested_waits.event_name",
+						"nested_waits.object_name",
+						"nested_waits.object_type",
+						"nested_waits.timer_wait",
 						"threads.PROCESSLIST_USER",
 						"threads.PROCESSLIST_HOST",
 						"statements.CPU_TIME",
@@ -274,6 +298,12 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 					"waits.object_name",
 					"waits.object_type",
 					"waits.timer_wait",
+					"nested_waits.event_id",
+					"nested_waits.end_event_id",
+					"nested_waits.event_name",
+					"nested_waits.object_name",
+					"nested_waits.object_type",
+					"nested_waits.timer_wait",
 					"threads.PROCESSLIST_USER",
 					"threads.PROCESSLIST_HOST",
 					"statements.CPU_TIME",
@@ -298,6 +328,12 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 						"wait_object_name",
 						"wait_object_type",
 						"100000000",
+						nil,
+						nil,
+						nil,
+						nil,
+						nil,
+						nil,
 						"some_user",
 						"some_host",
 						"10000000",
@@ -373,6 +409,12 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 					"waits.object_name",
 					"waits.object_type",
 					"waits.timer_wait",
+					"nested_waits.event_id",
+					"nested_waits.end_event_id",
+					"nested_waits.event_name",
+					"nested_waits.object_name",
+					"nested_waits.object_type",
+					"nested_waits.timer_wait",
 					"threads.PROCESSLIST_USER",
 					"threads.PROCESSLIST_HOST",
 					"statements.CPU_TIME",
@@ -397,6 +439,12 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 						"wait_object_name",
 						"wait_object_type",
 						nil, // NULL timer_wait
+						nil,
+						nil,
+						nil,
+						nil,
+						nil,
+						nil,
 						"some_user",
 						"some_host",
 						"10000000",
@@ -472,6 +520,12 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 					"waits.object_name",
 					"waits.object_type",
 					"waits.timer_wait",
+					"nested_waits.event_id",
+					"nested_waits.end_event_id",
+					"nested_waits.event_name",
+					"nested_waits.object_name",
+					"nested_waits.object_type",
+					"nested_waits.timer_wait",
 					"threads.PROCESSLIST_USER",
 					"threads.PROCESSLIST_HOST",
 					"statements.CPU_TIME",
@@ -496,6 +550,12 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 						"books",
 						"TABLE",
 						"150000",
+						nil,
+						nil,
+						nil,
+						nil,
+						nil,
+						nil,
 						"some_user",
 						"some_host",
 						"10000000",
@@ -520,6 +580,12 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 						"categories",
 						"TABLE",
 						"350000",
+						nil,
+						nil,
+						nil,
+						nil,
+						nil,
+						nil,
 						"some_user",
 						"some_host",
 						"10000000",
@@ -544,6 +610,12 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 						"books",
 						"TABLE",
 						"500000",
+						nil,
+						nil,
+						nil,
+						nil,
+						nil,
+						nil,
 						"some_user",
 						"some_host",
 						"10000000",
@@ -568,6 +640,12 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 						"categories",
 						"TABLE",
 						"700000",
+						nil,
+						nil,
+						nil,
+						nil,
+						nil,
+						nil,
 						"some_user",
 						"some_host",
 						"10000000",
@@ -649,6 +727,12 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 					"waits.object_name",
 					"waits.object_type",
 					"waits.timer_wait",
+					"nested_waits.event_id",
+					"nested_waits.end_event_id",
+					"nested_waits.event_name",
+					"nested_waits.object_name",
+					"nested_waits.object_type",
+					"nested_waits.timer_wait",
 					"threads.PROCESSLIST_USER",
 					"threads.PROCESSLIST_HOST",
 					"statements.CPU_TIME",
@@ -673,6 +757,12 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 						"books",
 						"TABLE",
 						"150000",
+						nil,
+						nil,
+						nil,
+						nil,
+						nil,
+						nil,
 						"some_user",
 						"some_host",
 						"10000000",
@@ -691,6 +781,12 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 						"5",
 						"0",
 						"0",
+						nil,
+						nil,
+						nil,
+						nil,
+						nil,
+						nil,
 						nil,
 						nil,
 						nil,
@@ -791,6 +887,12 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 					"waits.object_name",
 					"waits.object_type",
 					"waits.timer_wait",
+					"nested_waits.event_id",
+					"nested_waits.end_event_id",
+					"nested_waits.event_name",
+					"nested_waits.object_name",
+					"nested_waits.object_type",
+					"nested_waits.timer_wait",
 					"threads.PROCESSLIST_USER",
 					"threads.PROCESSLIST_HOST",
 					"statements.CPU_TIME",
@@ -815,6 +917,12 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 					"wait_object_name",
 					"wait_object_type",
 					"100000000",
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
 					"some_user",
 					"some_host",
 					"10000000",
@@ -891,6 +999,12 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 					"waits.object_name",
 					"waits.object_type",
 					"waits.timer_wait",
+					"nested_waits.event_id",
+					"nested_waits.end_event_id",
+					"nested_waits.event_name",
+					"nested_waits.object_name",
+					"nested_waits.object_type",
+					"nested_waits.timer_wait",
 					"threads.PROCESSLIST_USER",
 					"threads.PROCESSLIST_HOST",
 					"statements.CPU_TIME",
@@ -910,6 +1024,12 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 						"0",
 						"0",
 						nil, // no wait joined (filtered by SQL)
+						nil,
+						nil,
+						nil,
+						nil,
+						nil,
+						nil,
 						nil,
 						nil,
 						nil,
@@ -989,6 +1109,12 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 					"waits.object_name",
 					"waits.object_type",
 					"waits.timer_wait",
+					"nested_waits.event_id",
+					"nested_waits.end_event_id",
+					"nested_waits.event_name",
+					"nested_waits.object_name",
+					"nested_waits.object_type",
+					"nested_waits.timer_wait",
 					"threads.PROCESSLIST_USER",
 					"threads.PROCESSLIST_HOST",
 					"statements.CPU_TIME",
@@ -1013,6 +1139,12 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 						"wait_object_name",
 						"wait_object_type",
 						"1000000000", // 1ms in picoseconds
+						nil,
+						nil,
+						nil,
+						nil,
+						nil,
+						nil,
 						"some_user",
 						"some_host",
 						"10000000",
@@ -1043,6 +1175,224 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 		assert.Equal(t, model.LabelSet{"op": OP_QUERY_SAMPLE}, lokiEntries[0].Labels)
 		assert.Equal(t, model.LabelSet{"op": OP_WAIT_EVENT}, lokiEntries[1].Labels)
 		assert.Equal(t, "level=\"info\" schema=\"some_schema\" user=\"some_user\" client_host=\"some_host\" thread_id=\"890\" digest=\"some_digest\" event_id=\"123\" wait_event_id=\"124\" wait_end_event_id=\"124\" wait_event_name=\"wait/io/file/innodb/innodb_data_file\" wait_object_name=\"wait_object_name\" wait_object_type=\"wait_object_type\" wait_time=\"1.000000ms\"", lokiEntries[1].Line)
+	})
+
+	t.Run("wait/io/table/sql/handler with nested event uses nested event data", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki.NewCollectingHandler()
+
+		collector, err := NewQuerySamples(QuerySamplesArguments{
+			DB:              db,
+			EngineVersion:   latestCompatibleVersion,
+			CollectInterval: time.Second,
+			EntryHandler:    lokiClient,
+			Logger:          log.NewLogfmtLogger(os.Stderr),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+
+		mock.ExpectQuery(selectUptime).WithoutArgs().RowsWillBeClosed().WillReturnRows(sqlmock.NewRows([]string{"uptime"}).AddRow("1"))
+		mock.ExpectQuery(selectNowAndUptime).WithoutArgs().WillReturnRows(sqlmock.NewRows([]string{"now", "uptime"}).AddRow(5, 1))
+		mock.ExpectQuery(fmt.Sprintf(selectQuerySamples, cpuTimeField+maxControlledMemoryField+maxTotalMemoryField, "", exclusionClause, digestTextNotNullClause, "", endOfTimeline)).WithArgs(
+			1e12,
+			1e12,
+		).RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"statements.CURRENT_SCHEMA",
+					"statements.THREAD_ID",
+					"statements.EVENT_ID",
+					"statements.END_EVENT_ID",
+					"statements.DIGEST",
+					"statements.TIMER_END",
+					"statements.TIMER_WAIT",
+					"statements.ROWS_EXAMINED",
+					"statements.ROWS_SENT",
+					"statements.ROWS_AFFECTED",
+					"statements.ERRORS",
+					"waits.event_id",
+					"waits.end_event_id",
+					"waits.event_name",
+					"waits.object_name",
+					"waits.object_type",
+					"waits.timer_wait",
+					"nested_waits.event_id",
+					"nested_waits.end_event_id",
+					"nested_waits.event_name",
+					"nested_waits.object_name",
+					"nested_waits.object_type",
+					"nested_waits.timer_wait",
+					"threads.PROCESSLIST_USER",
+					"threads.PROCESSLIST_HOST",
+					"statements.CPU_TIME",
+					"statements.MAX_CONTROLLED_MEMORY",
+					"statements.MAX_TOTAL_MEMORY",
+				}).AddRow(
+					"some_schema",
+					"890",
+					"123",
+					"234",
+					"some_digest",
+					"70000000",
+					"20000000",
+					"5",
+					"5",
+					"0",
+					"0",
+					"200",                           // WAIT_EVENT_ID (outer table handler)
+					"201",                           // WAIT_END_EVENT_ID
+					"wait/io/table/sql/handler",      // WAIT_EVENT_NAME (the handler wrapper)
+					"books",                         // WAIT_OBJECT_NAME
+					"TABLE",                         // WAIT_OBJECT_TYPE
+					"900000000",                     // WAIT_TIMER_WAIT (900ms)
+					"210",                           // NESTED_WAIT_EVENT_ID
+					"211",                           // NESTED_WAIT_END_EVENT_ID
+					"wait/io/file/innodb/innodb_data_file", // NESTED_WAIT_EVENT_NAME (actual I/O)
+					"ibdata1",                       // NESTED_WAIT_OBJECT_NAME
+					"FILE",                          // NESTED_WAIT_OBJECT_TYPE
+					"500000000",                     // NESTED_WAIT_TIMER_WAIT (500ms)
+					"some_user",
+					"some_host",
+					"10000000",
+					"456",
+					"457",
+				),
+			)
+
+		err = collector.Start(t.Context())
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 2
+		}, 5*time.Second, 100*time.Millisecond)
+
+		collector.Stop()
+		lokiClient.Stop()
+
+		require.Eventually(t, func() bool {
+			return collector.Stopped()
+		}, 5*time.Second, 100*time.Millisecond)
+
+		err = mock.ExpectationsWereMet()
+		require.NoError(t, err)
+
+		lokiEntries := lokiClient.Received()
+		assert.Equal(t, model.LabelSet{"op": OP_QUERY_SAMPLE}, lokiEntries[0].Labels)
+		assert.Equal(t, model.LabelSet{"op": OP_WAIT_EVENT}, lokiEntries[1].Labels)
+		// The wait event log should use the NESTED wait event details, not the outer handler
+		assert.Equal(t, "level=\"info\" schema=\"some_schema\" user=\"some_user\" client_host=\"some_host\" thread_id=\"890\" digest=\"some_digest\" event_id=\"123\" wait_event_id=\"210\" wait_end_event_id=\"211\" wait_event_name=\"wait/io/file/innodb/innodb_data_file\" wait_object_name=\"ibdata1\" wait_object_type=\"FILE\" wait_time=\"0.500000ms\"", lokiEntries[1].Line)
+	})
+
+	t.Run("wait/io/table/sql/handler without nested event falls back to outer event data", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki.NewCollectingHandler()
+
+		collector, err := NewQuerySamples(QuerySamplesArguments{
+			DB:              db,
+			EngineVersion:   latestCompatibleVersion,
+			CollectInterval: time.Second,
+			EntryHandler:    lokiClient,
+			Logger:          log.NewLogfmtLogger(os.Stderr),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+
+		mock.ExpectQuery(selectUptime).WithoutArgs().RowsWillBeClosed().WillReturnRows(sqlmock.NewRows([]string{"uptime"}).AddRow("1"))
+		mock.ExpectQuery(selectNowAndUptime).WithoutArgs().WillReturnRows(sqlmock.NewRows([]string{"now", "uptime"}).AddRow(5, 1))
+		mock.ExpectQuery(fmt.Sprintf(selectQuerySamples, cpuTimeField+maxControlledMemoryField+maxTotalMemoryField, "", exclusionClause, digestTextNotNullClause, "", endOfTimeline)).WithArgs(
+			1e12,
+			1e12,
+		).RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"statements.CURRENT_SCHEMA",
+					"statements.THREAD_ID",
+					"statements.EVENT_ID",
+					"statements.END_EVENT_ID",
+					"statements.DIGEST",
+					"statements.TIMER_END",
+					"statements.TIMER_WAIT",
+					"statements.ROWS_EXAMINED",
+					"statements.ROWS_SENT",
+					"statements.ROWS_AFFECTED",
+					"statements.ERRORS",
+					"waits.event_id",
+					"waits.end_event_id",
+					"waits.event_name",
+					"waits.object_name",
+					"waits.object_type",
+					"waits.timer_wait",
+					"nested_waits.event_id",
+					"nested_waits.end_event_id",
+					"nested_waits.event_name",
+					"nested_waits.object_name",
+					"nested_waits.object_type",
+					"nested_waits.timer_wait",
+					"threads.PROCESSLIST_USER",
+					"threads.PROCESSLIST_HOST",
+					"statements.CPU_TIME",
+					"statements.MAX_CONTROLLED_MEMORY",
+					"statements.MAX_TOTAL_MEMORY",
+				}).AddRow(
+					"some_schema",
+					"890",
+					"123",
+					"234",
+					"some_digest",
+					"70000000",
+					"20000000",
+					"5",
+					"5",
+					"0",
+					"0",
+					"200",                      // WAIT_EVENT_ID
+					"201",                      // WAIT_END_EVENT_ID
+					"wait/io/table/sql/handler", // WAIT_EVENT_NAME (no nested event available)
+					"books",                    // WAIT_OBJECT_NAME
+					"TABLE",                    // WAIT_OBJECT_TYPE
+					"900000000",                // WAIT_TIMER_WAIT (900ms)
+					nil,                        // NESTED_WAIT_EVENT_ID (no nested event)
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					"some_user",
+					"some_host",
+					"10000000",
+					"456",
+					"457",
+				),
+			)
+
+		err = collector.Start(t.Context())
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 2
+		}, 5*time.Second, 100*time.Millisecond)
+
+		collector.Stop()
+		lokiClient.Stop()
+
+		require.Eventually(t, func() bool {
+			return collector.Stopped()
+		}, 5*time.Second, 100*time.Millisecond)
+
+		err = mock.ExpectationsWereMet()
+		require.NoError(t, err)
+
+		lokiEntries := lokiClient.Received()
+		assert.Equal(t, model.LabelSet{"op": OP_QUERY_SAMPLE}, lokiEntries[0].Labels)
+		assert.Equal(t, model.LabelSet{"op": OP_WAIT_EVENT}, lokiEntries[1].Labels)
+		// Without nested event data, the outer handler event details are used as fallback
+		assert.Equal(t, "level=\"info\" schema=\"some_schema\" user=\"some_user\" client_host=\"some_host\" thread_id=\"890\" digest=\"some_digest\" event_id=\"123\" wait_event_id=\"200\" wait_end_event_id=\"201\" wait_event_name=\"wait/io/table/sql/handler\" wait_object_name=\"books\" wait_object_type=\"TABLE\" wait_time=\"0.900000ms\"", lokiEntries[1].Line)
 	})
 }
 
@@ -1090,6 +1440,12 @@ func TestQuerySamples_SampleMinDuration(t *testing.T) {
 					"waits.object_name",
 					"waits.object_type",
 					"waits.timer_wait",
+					"nested_waits.event_id",
+					"nested_waits.end_event_id",
+					"nested_waits.event_name",
+					"nested_waits.object_name",
+					"nested_waits.object_type",
+					"nested_waits.timer_wait",
 					"threads.PROCESSLIST_USER",
 					"threads.PROCESSLIST_HOST",
 					"statements.CPU_TIME",
@@ -1160,6 +1516,12 @@ func TestQuerySamples_SampleMinDuration(t *testing.T) {
 					"waits.object_name",
 					"waits.object_type",
 					"waits.timer_wait",
+					"nested_waits.event_id",
+					"nested_waits.end_event_id",
+					"nested_waits.event_name",
+					"nested_waits.object_name",
+					"nested_waits.object_type",
+					"nested_waits.timer_wait",
 					"threads.PROCESSLIST_USER",
 					"threads.PROCESSLIST_HOST",
 					"statements.CPU_TIME",
@@ -1177,6 +1539,12 @@ func TestQuerySamples_SampleMinDuration(t *testing.T) {
 					"5",
 					"0",
 					"0",
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
 					nil,
 					nil,
 					nil,
@@ -1273,6 +1641,12 @@ func TestQuerySamples_DisableQueryRedaction(t *testing.T) {
 					"waits.object_name",
 					"waits.object_type",
 					"waits.timer_wait",
+					"nested_waits.event_id",
+					"nested_waits.end_event_id",
+					"nested_waits.event_name",
+					"nested_waits.object_name",
+					"nested_waits.object_type",
+					"nested_waits.timer_wait",
 					"threads.PROCESSLIST_USER",
 					"threads.PROCESSLIST_HOST",
 					"statements.CPU_TIME",
@@ -1291,6 +1665,12 @@ func TestQuerySamples_DisableQueryRedaction(t *testing.T) {
 					"5",
 					"0",
 					"0",
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
 					nil,
 					nil,
 					nil,
@@ -1385,6 +1765,12 @@ func TestQuerySamples_DisableQueryRedaction(t *testing.T) {
 					"waits.object_name",
 					"waits.object_type",
 					"waits.timer_wait",
+					"nested_waits.event_id",
+					"nested_waits.end_event_id",
+					"nested_waits.event_name",
+					"nested_waits.object_name",
+					"nested_waits.object_type",
+					"nested_waits.timer_wait",
 					"threads.PROCESSLIST_USER",
 					"threads.PROCESSLIST_HOST",
 					"statements.CPU_TIME",
@@ -1402,6 +1788,12 @@ func TestQuerySamples_DisableQueryRedaction(t *testing.T) {
 					"5",
 					"0",
 					"0",
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
 					nil,
 					nil,
 					nil,
@@ -1472,6 +1864,12 @@ func TestQuerySamplesMySQLVersions(t *testing.T) {
 				"waits.object_name",
 				"waits.object_type",
 				"waits.timer_wait",
+				"nested_waits.event_id",
+				"nested_waits.end_event_id",
+				"nested_waits.event_name",
+				"nested_waits.object_name",
+				"nested_waits.object_type",
+				"nested_waits.timer_wait",
 				"threads.PROCESSLIST_USER",
 				"threads.PROCESSLIST_HOST",
 			},
@@ -1488,6 +1886,12 @@ func TestQuerySamplesMySQLVersions(t *testing.T) {
 				"5",
 				"0",
 				"0",
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
 				nil,
 				nil,
 				nil,
@@ -1520,6 +1924,12 @@ func TestQuerySamplesMySQLVersions(t *testing.T) {
 				"waits.object_name",
 				"waits.object_type",
 				"waits.timer_wait",
+				"nested_waits.event_id",
+				"nested_waits.end_event_id",
+				"nested_waits.event_name",
+				"nested_waits.object_name",
+				"nested_waits.object_type",
+				"nested_waits.timer_wait",
 				"threads.PROCESSLIST_USER",
 				"threads.PROCESSLIST_HOST",
 				"statements.CPU_TIME",
@@ -1537,6 +1947,12 @@ func TestQuerySamplesMySQLVersions(t *testing.T) {
 				"5",
 				"0",
 				"0",
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
 				nil,
 				nil,
 				nil,
@@ -1570,6 +1986,12 @@ func TestQuerySamplesMySQLVersions(t *testing.T) {
 				"waits.object_name",
 				"waits.object_type",
 				"waits.timer_wait",
+				"nested_waits.event_id",
+				"nested_waits.end_event_id",
+				"nested_waits.event_name",
+				"nested_waits.object_name",
+				"nested_waits.object_type",
+				"nested_waits.timer_wait",
 				"threads.PROCESSLIST_USER",
 				"threads.PROCESSLIST_HOST",
 				"statements.CPU_TIME",
@@ -1589,6 +2011,12 @@ func TestQuerySamplesMySQLVersions(t *testing.T) {
 				"5",
 				"0",
 				"0",
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
 				nil,
 				nil,
 				nil,
@@ -1753,6 +2181,12 @@ func TestQuerySamples_SQLDriverErrors(t *testing.T) {
 					"waits.object_name",
 					"waits.object_type",
 					"waits.timer_wait",
+					"nested_waits.event_id",
+					"nested_waits.end_event_id",
+					"nested_waits.event_name",
+					"nested_waits.object_name",
+					"nested_waits.object_type",
+					"nested_waits.timer_wait",
 					"threads.PROCESSLIST_USER",
 					"threads.PROCESSLIST_HOST",
 					"statements.CPU_TIME",
@@ -1770,6 +2204,12 @@ func TestQuerySamples_SQLDriverErrors(t *testing.T) {
 					"5",
 					"0",
 					"0",
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
 					nil,
 					nil,
 					nil,
@@ -1862,6 +2302,12 @@ func TestQuerySamples_SQLDriverErrors(t *testing.T) {
 					"waits.object_name",
 					"waits.object_type",
 					"waits.timer_wait",
+					"nested_waits.event_id",
+					"nested_waits.end_event_id",
+					"nested_waits.event_name",
+					"nested_waits.object_name",
+					"nested_waits.object_type",
+					"nested_waits.timer_wait",
 					"threads.PROCESSLIST_USER",
 					"threads.PROCESSLIST_HOST",
 					"statements.CPU_TIME",
@@ -1885,6 +2331,12 @@ func TestQuerySamples_SQLDriverErrors(t *testing.T) {
 					nil,
 					nil,
 					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
 					"some_user",
 					"some_host",
 					"10000000",
@@ -1902,6 +2354,12 @@ func TestQuerySamples_SQLDriverErrors(t *testing.T) {
 					"5",
 					"0",
 					"0",
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
 					nil,
 					nil,
 					nil,
@@ -2011,6 +2469,12 @@ func TestQuerySamples_SQLDriverErrors(t *testing.T) {
 					"waits.object_name",
 					"waits.object_type",
 					"waits.timer_wait",
+					"nested_waits.event_id",
+					"nested_waits.end_event_id",
+					"nested_waits.event_name",
+					"nested_waits.object_name",
+					"nested_waits.object_type",
+					"nested_waits.timer_wait",
 					"threads.PROCESSLIST_USER",
 					"threads.PROCESSLIST_HOST",
 					"statements.CPU_TIME",
@@ -2028,6 +2492,12 @@ func TestQuerySamples_SQLDriverErrors(t *testing.T) {
 					"5",
 					"0",
 					"0",
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
 					nil,
 					nil,
 					nil,
@@ -2141,6 +2611,12 @@ func TestQuerySamples_handles_timer_overflows(t *testing.T) {
 			"waits.object_name",
 			"waits.object_type",
 			"waits.timer_wait",
+			"nested_waits.event_id",
+			"nested_waits.end_event_id",
+			"nested_waits.event_name",
+			"nested_waits.object_name",
+			"nested_waits.object_type",
+			"nested_waits.timer_wait",
 			"threads.PROCESSLIST_USER",
 			"threads.PROCESSLIST_HOST",
 			"statements.CPU_TIME",
@@ -2165,6 +2641,12 @@ func TestQuerySamples_handles_timer_overflows(t *testing.T) {
 				nil,           // WAIT_OBJECT_NAME
 				nil,           // WAIT_OBJECT_TYPE
 				nil,           // WAIT_TIME
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
 				"some_user",   // PROCESSLIST_USER
 				"some_host",   // PROCESSLIST_HOST
 				555555,        // cpu_time
@@ -2239,6 +2721,12 @@ func TestQuerySamples_handles_timer_overflows(t *testing.T) {
 			"waits.object_name",
 			"waits.object_type",
 			"waits.timer_wait",
+			"nested_waits.event_id",
+			"nested_waits.end_event_id",
+			"nested_waits.event_name",
+			"nested_waits.object_name",
+			"nested_waits.object_type",
+			"nested_waits.timer_wait",
 			"threads.PROCESSLIST_USER",
 			"threads.PROCESSLIST_HOST",
 			"cpu_time",
@@ -2291,6 +2779,12 @@ func TestQuerySamples_handles_timer_overflows(t *testing.T) {
 			"waits.object_name",
 			"waits.object_type",
 			"waits.timer_wait",
+			"nested_waits.event_id",
+			"nested_waits.end_event_id",
+			"nested_waits.event_name",
+			"nested_waits.object_name",
+			"nested_waits.object_type",
+			"nested_waits.timer_wait",
 			"threads.PROCESSLIST_USER",
 			"threads.PROCESSLIST_HOST",
 			"cpu_time",
@@ -2343,6 +2837,12 @@ func TestQuerySamples_handles_timer_overflows(t *testing.T) {
 			"waits.object_name",
 			"waits.object_type",
 			"waits.timer_wait",
+			"nested_waits.event_id",
+			"nested_waits.end_event_id",
+			"nested_waits.event_name",
+			"nested_waits.object_name",
+			"nested_waits.object_type",
+			"nested_waits.timer_wait",
 			"threads.PROCESSLIST_USER",
 			"threads.PROCESSLIST_HOST",
 			"cpu_time",
@@ -2385,6 +2885,12 @@ func TestQuerySamples_handles_timer_overflows(t *testing.T) {
 			"waits.object_name",
 			"waits.object_type",
 			"waits.timer_wait",
+			"nested_waits.event_id",
+			"nested_waits.end_event_id",
+			"nested_waits.event_name",
+			"nested_waits.object_name",
+			"nested_waits.object_type",
+			"nested_waits.timer_wait",
 			"threads.PROCESSLIST_USER",
 			"threads.PROCESSLIST_HOST",
 			"cpu_time",
@@ -2429,6 +2935,12 @@ func TestQuerySamples_handles_timer_overflows(t *testing.T) {
 			"waits.object_name",
 			"waits.object_type",
 			"waits.timer_wait",
+			"nested_waits.event_id",
+			"nested_waits.end_event_id",
+			"nested_waits.event_name",
+			"nested_waits.object_name",
+			"nested_waits.object_type",
+			"nested_waits.timer_wait",
 			"threads.PROCESSLIST_USER",
 			"threads.PROCESSLIST_HOST",
 			"cpu_time",
@@ -2475,6 +2987,12 @@ func TestQuerySamples_handles_timer_overflows(t *testing.T) {
 			"waits.object_name",
 			"waits.object_type",
 			"waits.timer_wait",
+			"nested_waits.event_id",
+			"nested_waits.end_event_id",
+			"nested_waits.event_name",
+			"nested_waits.object_name",
+			"nested_waits.object_type",
+			"nested_waits.timer_wait",
 			"threads.PROCESSLIST_USER",
 			"threads.PROCESSLIST_HOST",
 			"cpu_time",
@@ -2551,6 +3069,12 @@ func TestQuerySamples_handles_timer_overflows(t *testing.T) {
 			"waits.object_name",
 			"waits.object_type",
 			"waits.timer_wait",
+			"nested_waits.event_id",
+			"nested_waits.end_event_id",
+			"nested_waits.event_name",
+			"nested_waits.object_name",
+			"nested_waits.object_type",
+			"nested_waits.timer_wait",
 			"threads.PROCESSLIST_USER",
 			"threads.PROCESSLIST_HOST",
 			"cpu_time",
@@ -2572,6 +3096,12 @@ func TestQuerySamples_handles_timer_overflows(t *testing.T) {
 				nil,           // WAIT_OBJECT_NAME
 				nil,           // WAIT_OBJECT_TYPE
 				nil,           // WAIT_TIME
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
 				"some_user",   // PROCESSLIST_USER
 				"some_host",   // PROCESSLIST_HOST
 				555555,        // cpu_time
@@ -2710,6 +3240,12 @@ func TestQuerySamples_AutoEnableSetupConsumers(t *testing.T) {
 					"waits.object_name",
 					"waits.object_type",
 					"waits.timer_wait",
+					"nested_waits.event_id",
+					"nested_waits.end_event_id",
+					"nested_waits.event_name",
+					"nested_waits.object_name",
+					"nested_waits.object_type",
+					"nested_waits.timer_wait",
 					"threads.PROCESSLIST_USER",
 					"threads.PROCESSLIST_HOST",
 					"statements.CPU_TIME",
@@ -2727,6 +3263,12 @@ func TestQuerySamples_AutoEnableSetupConsumers(t *testing.T) {
 					"5",
 					"0",
 					"0",
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
 					nil,
 					nil,
 					nil,

--- a/internal/component/database_observability/mysql/collector/query_samples_test.go
+++ b/internal/component/database_observability/mysql/collector/query_samples_test.go
@@ -1247,13 +1247,13 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 					"wait/io/table/sql/handler",            // WAIT_EVENT_NAME (the handler wrapper)
 					"books",                                // WAIT_OBJECT_NAME
 					"TABLE",                                // WAIT_OBJECT_TYPE
-					"900000000",                            // WAIT_TIMER_WAIT (900ms)
+					"900000000",                            // WAIT_TIMER_WAIT (0.9ms)
 					"210",                                  // NESTED_WAIT_EVENT_ID
 					"211",                                  // NESTED_WAIT_END_EVENT_ID
 					"wait/io/file/innodb/innodb_data_file", // NESTED_WAIT_EVENT_NAME (actual I/O)
 					"ibdata1",                              // NESTED_WAIT_OBJECT_NAME
 					"FILE",                                 // NESTED_WAIT_OBJECT_TYPE
-					"500000000",                            // NESTED_WAIT_TIMER_WAIT (500ms)
+					"500000000",                            // NESTED_WAIT_TIMER_WAIT (0.5ms)
 					"some_user",
 					"some_host",
 					"10000000",


### PR DESCRIPTION
Superceded by https://github.com/grafana/alloy/pull/6143

## Summary

- When MySQL Performance Schema reports a wait event of type `wait/io/table/sql/handler`, it is a molecule (wrapper) event, not an atomic I/O event. The real underlying wait is a nested child event recorded in `events_waits_history`.
- Added a second `LEFT JOIN` on `events_waits_history` (as `nested_waits`) to fetch the nested event alongside the outer event in a single query pass.
- When a `wait/io/table/sql/handler` outer event has a nested event, the nested event's fields (event ID, name, object, type, timer) are used in the emitted `OP_WAIT_EVENT` log — surfacing the actual I/O operation (e.g. `wait/io/file/innodb/innodb_data_file`) to the end user. Falls back to outer event data unchanged when no nested event is available.

Fixes https://github.com/grafana/grafana-dbo11y-app/issues/1301

## Test plan

- [x] Updated all existing test mocks to include the 6 new nested wait columns
- [x] Added `wait/io/table/sql/handler with nested event uses nested event data` — verifies the fix correctly substitutes nested event fields
- [x] Added `wait/io/table/sql/handler without nested event falls back to outer event data` — verifies backward compatibility when no nested event exists
- [x] All existing tests continue to pass (`go test -race -tags=nodocker ./internal/component/database_observability/mysql/...`)

## PR Checklist

- [ ] CHANGELOG.md updated
- [x] Tests updated

Made with [Cursor](https://cursor.com)