### PR TITLE
ci: Disallow claude from release attribution

### DIFF
--- a/tools/release/internal/github/client.go
+++ b/tools/release/internal/github/client.go
@@ -556,5 +556,8 @@ func (c *Client) GraphQL(ctx context.Context, query string, variables map[string
 
 // IsBot checks if a username appears to be a bot account.
 func IsBot(username string) bool {
-	return strings.HasSuffix(username, "[bot]") || strings.HasSuffix(username, "-bot") || username == "Copilot"
+	return strings.HasSuffix(username, "[bot]") ||
+		strings.HasSuffix(username, "-bot") ||
+		username == "Copilot" ||
+		username == "claude"
 }


### PR DESCRIPTION
This PR prevents claude from showing up in the release notes as a contributor. Commits will still contain AI agents as co-authors, where appropriate.