### PR TITLE
chore: Fix windows test tags

### DIFF
--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -31,4 +31,4 @@ jobs:
         # We'll need to make sure the same cache is reused by the workflow to build Windows binaries.
         cache: false
     - name: Test
-      run: '& "C:/Program Files/git/bin/bash.exe" -c ''make GO_TAGS="nodocker,nonetwork" test'''
+      run: '& "C:/Program Files/git/bin/bash.exe" -c ''make GO_TAGS="nodocker nonetwork" test'''


### PR DESCRIPTION
After https://github.com/grafana/alloy/pull/5909 we prepend `gore2regex` tag if it's missing. In go you need to stick to the same separator for tags e.g. spaces _or_ commas. In all places we use space as separator except for windows test. So windows test breaks because we end up with `-tags "gore2regex nodocker,nonetwork"`. 
