### PR TITLE
fix(loki.process): Prevent stage.structured_metadata from adding the same metadata several times

### DIFF
--- a/internal/component/loki/process/process_test.go
+++ b/internal/component/loki/process/process_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/log"
 	"github.com/grafana/loki/pkg/push"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -31,51 +30,141 @@ import (
 )
 
 func TestComponent(t *testing.T) {
-	t.Run("update with invalid stage config", func(t *testing.T) {
-		ctrl, err := componenttest.NewControllerFromID(log.NewNopLogger(), "loki.process")
-		require.NoError(t, err)
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
 
-		collector := loki.NewCollectingHandler()
-		defer collector.Stop()
+	type testCase struct {
+		name    string
+		cfg     string
+		inputs  []loki.Entry
+		outputs []loki.Entry
+	}
 
-		ctx, cancel := context.WithCancel(context.Background())
+	criTimestamp := time.Date(2024, time.January, 2, 3, 4, 5, 6, time.UTC)
 
-		var wg sync.WaitGroup
-		wg.Go(func() {
-			require.NoError(t, ctrl.Run(ctx, Arguments{ForwardTo: []loki.LogsReceiver{collector.Receiver()}}))
-		})
-		require.NoError(t, ctrl.WaitExports(time.Minute))
+	tests := []testCase{
+		{
+			name: "simple cri pipeline",
+			cfg: `
+			forward_to = []
 
-		recv := ctrl.Exports().(Exports).Receiver
-		fanout := loki.NewFanout([]loki.LogsReceiver{recv})
+			stage.cri {}
 
-		wg.Go(func() {
-			for {
-				// We get error if context is canceled
-				if err := fanout.Send(ctx, loki.Entry{}); err != nil {
-					return
+			stage.structured_metadata {
+					values = {
+						filename = "",
+						stream = "",
+					}
+				}
+
+			stage.static_labels {
+				values = {
+					foo = "bar",
 				}
 			}
-		})
 
-		err = ctrl.Update(Arguments{
-			ForwardTo: []loki.LogsReceiver{collector.Receiver()},
-			Stages: []stages.StageConfig{
-				{
-					MatchConfig: &stages.MatchConfig{
-						// {} is not a valid selector.
-						Selector: "{}",
-					},
-				},
+			`,
+			inputs: []loki.Entry{
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "file1"}, 0, push.Entry{
+					Timestamp: time.Now(),
+					Line:      criTimestamp.Format(time.RFC3339Nano) + " stdout P partial for file 1 stdout",
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "file1"}, 0, push.Entry{
+					Timestamp: time.Now(),
+					Line:      criTimestamp.Format(time.RFC3339Nano) + " stderr P partial for file 1 stderr",
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "file2"}, 0, push.Entry{
+					Timestamp: time.Now(),
+					Line:      criTimestamp.Format(time.RFC3339Nano) + " stdout P partial for file2",
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "file1"}, 0, push.Entry{
+					Timestamp: time.Now(),
+					Line:      criTimestamp.Format(time.RFC3339Nano) + " stderr F full file 1 stderr",
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "file2"}, 0, push.Entry{
+					Timestamp: time.Now(),
+					Line:      criTimestamp.Format(time.RFC3339Nano) + " stderr F full file 2",
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "file1"}, 0, push.Entry{
+					Timestamp: time.Now(),
+					Line:      criTimestamp.Format(time.RFC3339Nano) + " stderr F full file 1 stdout",
+				}),
 			},
-		})
-		require.Error(t, err)
+			outputs: []loki.Entry{
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
+					Timestamp: criTimestamp,
+					Line:      "partial for file 1 stderrfull file 1 stderr",
+					StructuredMetadata: push.LabelsAdapter{
+						{Name: "filename", Value: "file1"},
+						{Name: "stream", Value: "stderr"},
+					},
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
+					Timestamp: criTimestamp,
+					Line:      "full file 2",
+					StructuredMetadata: push.LabelsAdapter{
+						{Name: "filename", Value: "file2"},
+						{Name: "stream", Value: "stderr"},
+					},
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
+					Timestamp: criTimestamp,
+					Line:      "full file 1 stdout",
+					StructuredMetadata: push.LabelsAdapter{
+						{Name: "filename", Value: "file1"},
+						{Name: "stream", Value: "stderr"},
+					},
+				}),
+			},
+		},
+	}
 
-		// Keep sending for a while after update have failed.
-		time.Sleep(100 * time.Millisecond)
-		cancel()
-		wg.Wait()
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outputCollector := loki.NewCollectingHandler()
+			defer outputCollector.Stop()
+
+			var args Arguments
+			require.NoError(t, syntax.Unmarshal([]byte(tt.cfg), &args))
+			args.ForwardTo = []loki.LogsReceiver{outputCollector.Receiver()}
+
+			opts := component.Options{
+				Logger:         util.TestAlloyLogger(t),
+				Registerer:     prometheus.NewRegistry(),
+				OnStateChange:  func(component.Exports) {},
+				GetServiceData: getServiceData,
+			}
+
+			c, err := New(opts, args)
+			require.NoError(t, err)
+
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+
+			runErr := make(chan error, 1)
+			go func() {
+				runErr <- c.Run(ctx)
+			}()
+
+			for _, input := range tt.inputs {
+				c.receiver.Chan() <- input
+			}
+
+			require.Eventually(t, func() bool {
+				select {
+				case err := <-runErr:
+					require.NoError(t, err)
+					require.FailNow(t, "component stopped before producing all expected entries")
+				default:
+				}
+				return len(outputCollector.Received()) == len(tt.outputs)
+			}, 5*time.Second, 10*time.Millisecond)
+
+			require.Equal(t, tt.outputs, outputCollector.Received())
+
+			cancel()
+			require.NoError(t, <-runErr)
+		})
+	}
 }
 
 const logline = `{"log":"log message\n","stream":"stderr","time":"2019-04-30T02:12:41.8443515Z","extra":"{\"user\":\"smith\"}"}`

--- a/internal/component/loki/process/process_test.go
+++ b/internal/component/loki/process/process_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/grafana/loki/pkg/push"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -170,6 +171,52 @@ func TestComponent(t *testing.T) {
 			require.NoError(t, <-runErr)
 		})
 	}
+}
+
+func TestComponent_UpdateInvalidConfig(t *testing.T) {
+	ctrl, err := componenttest.NewControllerFromID(log.NewNopLogger(), "loki.process")
+	require.NoError(t, err)
+
+	collector := loki.NewCollectingHandler()
+	defer collector.Stop()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		require.NoError(t, ctrl.Run(ctx, Arguments{ForwardTo: []loki.LogsReceiver{collector.Receiver()}}))
+	})
+	require.NoError(t, ctrl.WaitExports(time.Minute))
+
+	recv := ctrl.Exports().(Exports).Receiver
+	fanout := loki.NewFanout([]loki.LogsReceiver{recv})
+
+	wg.Go(func() {
+		for {
+			// We get error if context is canceled
+			if err := fanout.Send(ctx, loki.Entry{}); err != nil {
+				return
+			}
+		}
+	})
+
+	err = ctrl.Update(Arguments{
+		ForwardTo: []loki.LogsReceiver{collector.Receiver()},
+		Stages: []stages.StageConfig{
+			{
+				MatchConfig: &stages.MatchConfig{
+					// {} is not a valid selector.
+					Selector: "{}",
+				},
+			},
+		},
+	})
+	require.Error(t, err)
+
+	// Keep sending for a while after update have failed.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	wg.Wait()
 }
 
 const logline = `{"log":"log message\n","stream":"stderr","time":"2019-04-30T02:12:41.8443515Z","extra":"{\"user\":\"smith\"}"}`

--- a/internal/component/loki/process/process_test.go
+++ b/internal/component/loki/process/process_test.go
@@ -33,10 +33,10 @@ func TestComponent(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
 
 	type testCase struct {
-		name    string
-		cfg     string
-		inputs  []loki.Entry
-		outputs []loki.Entry
+		name     string
+		cfg      string
+		inputs   []loki.Entry
+		expected []loki.Entry
 	}
 
 	criTimestamp := time.Date(2024, time.January, 2, 3, 4, 5, 6, time.UTC)
@@ -89,7 +89,7 @@ func TestComponent(t *testing.T) {
 					Line:      criTimestamp.Format(time.RFC3339Nano) + " stderr F full file 1 stdout",
 				}),
 			},
-			outputs: []loki.Entry{
+			expected: []loki.Entry{
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
 					Timestamp: criTimestamp,
 					Line:      "partial for file 1 stderrfull file 1 stderr",
@@ -120,12 +120,12 @@ func TestComponent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			outputCollector := loki.NewCollectingHandler()
-			defer outputCollector.Stop()
+			collector := loki.NewCollectingHandler()
+			defer collector.Stop()
 
 			var args Arguments
 			require.NoError(t, syntax.Unmarshal([]byte(tt.cfg), &args))
-			args.ForwardTo = []loki.LogsReceiver{outputCollector.Receiver()}
+			args.ForwardTo = []loki.LogsReceiver{collector.Receiver()}
 
 			opts := component.Options{
 				Logger:         util.TestAlloyLogger(t),
@@ -138,7 +138,6 @@ func TestComponent(t *testing.T) {
 			require.NoError(t, err)
 
 			ctx, cancel := context.WithCancel(t.Context())
-			defer cancel()
 
 			runErr := make(chan error, 1)
 			go func() {
@@ -156,10 +155,16 @@ func TestComponent(t *testing.T) {
 					require.FailNow(t, "component stopped before producing all expected entries")
 				default:
 				}
-				return len(outputCollector.Received()) == len(tt.outputs)
+				return len(collector.Received()) == len(tt.expected)
 			}, 5*time.Second, 10*time.Millisecond)
 
-			require.Equal(t, tt.outputs, outputCollector.Received())
+			got := collector.Received()
+			for i := range tt.expected {
+				require.Equal(t, tt.expected[i].Line, got[i].Line)
+				require.Equal(t, tt.expected[i].Timestamp, got[i].Timestamp)
+				require.EqualValues(t, tt.expected[i].Labels, got[i].Labels)
+				require.ElementsMatch(t, tt.expected[i].StructuredMetadata, got[i].StructuredMetadata)
+			}
 
 			cancel()
 			require.NoError(t, <-runErr)

--- a/internal/component/loki/process/stages/structured_metadata.go
+++ b/internal/component/loki/process/stages/structured_metadata.go
@@ -99,7 +99,7 @@ func (s *structuredMetadataStage) Run(in chan Entry) chan Entry {
 		// Try to add structured metadata from labels using labelsConfig.
 		processEntryLabelsByConfig(e.Labels, s.labelsConfig, appendStructureMetadata)
 
-		// Tru to add structured metadata from labels using regex.
+		// Try to add structured metadata from labels using regex.
 		processEntryLabelsByRegex(e.Labels, s.regex, appendStructureMetadata)
 
 		return e

--- a/internal/component/loki/process/stages/structured_metadata.go
+++ b/internal/component/loki/process/stages/structured_metadata.go
@@ -90,7 +90,7 @@ func (s *structuredMetadataStage) Run(in chan Entry) chan Entry {
 			e.StructuredMetadata = append(e.StructuredMetadata, metadata)
 		}
 
-		// Try to add structured metdata from extracted map using labelsConfig.
+		// Try to add structured metadata from extracted map using labelsConfig.
 		processExtractedLabelsByConfig(s.logger, e.Extracted, s.labelsConfig, appendStructureMetadata)
 
 		// Try to add structured metadata from extraced map using regex.

--- a/internal/component/loki/process/stages/structured_metadata.go
+++ b/internal/component/loki/process/stages/structured_metadata.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"slices"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
@@ -75,40 +76,32 @@ func (*structuredMetadataStage) Cleanup() {
 
 func (s *structuredMetadataStage) Run(in chan Entry) chan Entry {
 	return RunWith(in, func(e Entry) Entry {
-		// Handle extracted values in values map
-		processLabelsConfigs(s.logger, e.Extracted, s.labelsConfig, func(labelName model.LabelName, labelValue model.LabelValue) {
-			e.StructuredMetadata = append(e.StructuredMetadata, push.LabelAdapter{Name: string(labelName), Value: string(labelValue)})
-		})
-		// Handle extracted values matching the regex
-		if s.regex.String() != "" {
-			for lName, lValue := range e.Extracted {
-				if s.regex.MatchString(lName) {
-					str, err := getString(lValue)
-					if err != nil {
-						if Debug {
-							level.Debug(s.logger).Log("msg", "failed to convert extracted label value to string", "err", err, "type", reflect.TypeOf(lValue))
-						}
-						continue
-					}
-					labelValue := model.LabelValue(str)
-					if !labelValue.IsValid() {
-						if Debug {
-							level.Debug(s.logger).Log("msg", "invalid label value parsed", "value", labelValue)
-						}
-						continue
-					}
-					e.StructuredMetadata = append(e.StructuredMetadata, push.LabelAdapter{Name: lName, Value: string(labelValue)})
-				}
+		appendStructureMetadata := func(labelName model.LabelName, labelValue model.LabelValue) {
+			if !containsStructuredMetadataLabel(e.StructuredMetadata, string(labelName)) {
+				e.StructuredMetadata = append(e.StructuredMetadata, push.LabelAdapter{Name: string(labelName), Value: string(labelValue)})
 			}
 		}
 
-		return s.extractFromLabels(e)
+		// Try to add structured metdata from extracted map using labelsConfig.
+		processExtractedLabelsByConfig(s.logger, e.Extracted, s.labelsConfig, appendStructureMetadata)
+
+		// Try to add structured metadata from extraced map using regex.
+		processExtractedLabelsByRegex(s.logger, e.Extracted, s.regex, appendStructureMetadata)
+
+		// Try to add structured metadata from labels using labelsConfig.
+		processEntryLabelsByConfig(e.Labels, s.labelsConfig, appendStructureMetadata)
+
+		// Tru to add structured metadata from labels using regex.
+		processEntryLabelsByRegex(e.Labels, s.regex, appendStructureMetadata)
+
+		return e
 	})
 }
 
 type labelsConsumer func(labelName model.LabelName, labelValue model.LabelValue)
 
-func processLabelsConfigs(logger log.Logger, extracted map[string]any, labelsConfig map[string]string, consumer labelsConsumer) {
+// processExtractedLabelsByConfig adds structured metadata from extracted values selected by labelsConfig.
+func processExtractedLabelsByConfig(logger log.Logger, extracted map[string]any, labelsConfig map[string]string, consumer labelsConsumer) {
 	for lName, lSrc := range labelsConfig {
 		if lValue, ok := extracted[lSrc]; ok {
 			s, err := getString(lValue)
@@ -130,38 +123,75 @@ func processLabelsConfigs(logger log.Logger, extracted map[string]any, labelsCon
 	}
 }
 
-func (s *structuredMetadataStage) extractFromLabels(e Entry) Entry {
-	labels := e.Labels
-	foundLabels := []model.LabelName{}
+// processExtractedLabelsByRegex adds structured metadata from extracted values whose keys match the configured regex.
+func processExtractedLabelsByRegex(logger log.Logger, extracted map[string]any, regex regexp.Regexp, consumer labelsConsumer) {
+	if regex.String() == "" {
+		return
+	}
 
-	// Handle labels in values map
-	for lName, lSrc := range s.labelsConfig {
+	for lName, lValue := range extracted {
+		if !regex.MatchString(lName) {
+			continue
+		}
+
+		str, err := getString(lValue)
+		if err != nil {
+			if Debug {
+				level.Debug(logger).Log("msg", "failed to convert extracted label value to string", "err", err, "type", reflect.TypeOf(lValue))
+			}
+			continue
+		}
+
+		labelValue := model.LabelValue(str)
+		if !labelValue.IsValid() {
+			if Debug {
+				level.Debug(logger).Log("msg", "invalid label value parsed", "value", labelValue)
+			}
+			continue
+		}
+
+		consumer(model.LabelName(lName), labelValue)
+	}
+}
+
+// processEntryLabelsByConfig adds structured metadata from entry labels selected by explicit config mappings and removes those labels.
+func processEntryLabelsByConfig(labels model.LabelSet, labelsConfig map[string]string, consumer labelsConsumer) {
+	foundLabels := make([]model.LabelName, 0, len(labelsConfig))
+
+	for lName, lSrc := range labelsConfig {
 		labelKey := model.LabelName(lSrc)
 		if lValue, ok := labels[labelKey]; ok {
-			e.StructuredMetadata = append(e.StructuredMetadata, push.LabelAdapter{Name: lName, Value: string(lValue)})
+			consumer(model.LabelName(lName), lValue)
 			foundLabels = append(foundLabels, labelKey)
 		}
 	}
 
-	// Remove found labels, do this after append to structure metadata
 	for _, fl := range foundLabels {
 		delete(labels, fl)
 	}
+}
 
-	if s.regex.String() != "" {
-		// Handle remaining labels matching the regex
-		foundLabels = []model.LabelName{}
-		for lName, lValue := range labels {
-			if s.regex.MatchString(string(lName)) {
-				e.StructuredMetadata = append(e.StructuredMetadata, push.LabelAdapter{Name: string(lName), Value: string(lValue)})
-				foundLabels = append(foundLabels, lName)
-			}
-		}
-		for _, fl := range foundLabels {
-			delete(labels, fl)
+// processEntryLabelsByRegex adds structured metadata from entry labels whose keys match the configured regex and removes those labels.
+func processEntryLabelsByRegex(labels model.LabelSet, regex regexp.Regexp, consumer labelsConsumer) {
+	if regex.String() == "" {
+		return
+	}
+
+	foundLabels := make([]model.LabelName, 0)
+	for lName, lValue := range labels {
+		if regex.MatchString(string(lName)) {
+			consumer(lName, lValue)
+			foundLabels = append(foundLabels, lName)
 		}
 	}
 
-	e.Labels = labels
-	return e
+	for _, fl := range foundLabels {
+		delete(labels, fl)
+	}
+}
+
+func containsStructuredMetadataLabel(labels push.LabelsAdapter, name string) bool {
+	return slices.ContainsFunc(labels, func(label push.LabelAdapter) bool {
+		return label.Name == name
+	})
 }

--- a/internal/component/loki/process/stages/structured_metadata.go
+++ b/internal/component/loki/process/stages/structured_metadata.go
@@ -93,7 +93,7 @@ func (s *structuredMetadataStage) Run(in chan Entry) chan Entry {
 		// Try to add structured metadata from extracted map using labelsConfig.
 		processExtractedLabelsByConfig(s.logger, e.Extracted, s.labelsConfig, appendStructureMetadata)
 
-		// Try to add structured metadata from extraced map using regex.
+		// Try to add structured metadata from extracted map using regex.
 		processExtractedLabelsByRegex(s.logger, e.Extracted, s.regex, appendStructureMetadata)
 
 		// Try to add structured metadata from labels using labelsConfig.

--- a/internal/component/loki/process/stages/structured_metadata.go
+++ b/internal/component/loki/process/stages/structured_metadata.go
@@ -77,9 +77,17 @@ func (*structuredMetadataStage) Cleanup() {
 func (s *structuredMetadataStage) Run(in chan Entry) chan Entry {
 	return RunWith(in, func(e Entry) Entry {
 		appendStructureMetadata := func(labelName model.LabelName, labelValue model.LabelValue) {
-			if !containsStructuredMetadataLabel(e.StructuredMetadata, string(labelName)) {
-				e.StructuredMetadata = append(e.StructuredMetadata, push.LabelAdapter{Name: string(labelName), Value: string(labelValue)})
+			metadata := push.LabelAdapter{Name: string(labelName), Value: string(labelValue)}
+
+			i := slices.IndexFunc(e.StructuredMetadata, func(label push.LabelAdapter) bool {
+				return label.Name == metadata.Name
+			})
+			if i != -1 {
+				e.StructuredMetadata[i] = metadata
+				return
 			}
+
+			e.StructuredMetadata = append(e.StructuredMetadata, metadata)
 		}
 
 		// Try to add structured metdata from extracted map using labelsConfig.
@@ -188,10 +196,4 @@ func processEntryLabelsByRegex(labels model.LabelSet, regex regexp.Regexp, consu
 	for _, fl := range foundLabels {
 		delete(labels, fl)
 	}
-}
-
-func containsStructuredMetadataLabel(labels push.LabelsAdapter, name string) bool {
-	return slices.ContainsFunc(labels, func(label push.LabelAdapter) bool {
-		return label.Name == name
-	})
 }

--- a/internal/component/loki/process/stages/structured_metadata_test.go
+++ b/internal/component/loki/process/stages/structured_metadata_test.go
@@ -1,253 +1,254 @@
 package stages
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/loki/pkg/push"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alloy/internal/featuregate"
-	"github.com/grafana/loki/pkg/push"
 )
 
-var pipelineStagesStructuredMetadataFromLogfmt = `
-stage.logfmt {
-	mapping = { "app" = ""}
-}
-
-stage.structured_metadata { 
-	values = {"app" = ""}
-}
-`
-
-var pipelineStagesStructuredMetadataFromJSON = `
-stage.json {
-	expressions = {app = ""}
-}
-
-stage.structured_metadata { 
-	values = {"app" = ""}
-}
-`
-
-var pipelineStagesStructuredMetadataWithRegexParser = `
-stage.regex {
-	expression = "^(?s)(?P<time>\\S+?) (?P<stream>stdout|stderr) (?P<flags>\\S+?) (?P<content>.*)$"
-}
-
-stage.structured_metadata { 
-	values = {"stream" = ""}
-}
-`
-
-var pipelineStagesStructuredMetadataFromJSONWithTemplate = `
-stage.json {
-	expressions = {app = ""}
-}
-
-stage.template {
-    source   = "app"
-    template = "{{ ToUpper .Value }}"
-}
-
-stage.structured_metadata { 
-	values = {"app" = ""}
-}
-`
-
-var pipelineStagesStructuredMetadataAndRegularLabelsFromJSON = `
-stage.json {
-	expressions = {app = "", component = "" }
-}
-
-stage.structured_metadata { 
-	values = {"app" = ""}
-}
-
-stage.labels { 
-	values = {"component" = ""}
-}
-`
-
-var pipelineStagesStructuredMetadataFromStaticLabels = `
-stage.static_labels {
-	values = {"component" = "querier", "pod" = "loki-querier-664f97db8d-qhnwg"}
-}
-
-stage.structured_metadata {
-	values = {"pod" = ""}
-}
-`
-
-var pipelineStagesStructuredMetadataFromStaticLabelsDifferentKey = `
-stage.static_labels {
-	values = {"component" = "querier", "pod" = "loki-querier-664f97db8d-qhnwg"}
-}
-
-stage.structured_metadata {
-	values = {"pod_name" = "pod"}
-}
-`
-
-var pipelineStagesStructuredMetadataFromRegexLabels = `
-stage.static_labels {
-  values = {"component" = "querier", "label_app_kubernetes_io_name" = "loki", "label_app_kubernetes_io_component" = "querier"}
-}
-
-stage.structured_metadata {
-  regex = "label_.*"
-}
-`
-var pipelineStagesStructuredMetadataFromRegexAndNonRegexLabels = `
-stage.static_labels {
-  values = {"component" = "querier", "pod" = "loki-querier-664f97db8d-qhnwg", "label_app_kubernetes_io_name" = "loki", "label_app_kubernetes_io_component" = "querier"}
-}
-
-stage.structured_metadata {
-  values = {"pod_name" = "pod"}
-  regex = "label_.*"
-}
-`
-
-var pipelineStagesStructuredMetadataFromExtractedValues = `
-stage.logfmt {
-  mapping = { "pod" = "", "metadata_name" = "", "metadata_component" = "" }
-}
-
-stage.structured_metadata {
-  values = {"pod_name" = "pod"}
-  regex = "metadata_.*"
-}
-`
-
-var pipelineStagesStructuredMetadataFromNestedValues = `
-stage.json {
-	expressions = {app = "", component_nested = "", component_non_nested = "" }
-}
-
-stage.structured_metadata {
-  regex = "component_.*"
-}
-`
-
-func Test_StructuredMetadataStage(t *testing.T) {
-	tests := map[string]struct {
-		pipelineStagesYaml         string
-		logLine                    string
-		expectedStructuredMetadata map[string]any
+func TestStructuredMetadataStage(t *testing.T) {
+	type testCase struct {
+		name                       string
+		config                     string
+		line                       string
 		expectedLabels             model.LabelSet
-	}{
-		"expected structured metadata to be extracted with logfmt parser and to be added to entry": {
-			pipelineStagesYaml: pipelineStagesStructuredMetadataFromLogfmt,
-			logLine:            "app=loki component=ingester",
-			expectedStructuredMetadata: map[string]any{
-				"app": "loki",
-			},
+		expectedStructuredMetadata push.LabelsAdapter
+	}
+
+	tests := []testCase{
+		{
+			name: "expected structured metadata to be extracted with logfmt parser and to be added to entry",
+			config: `
+				stage.logfmt {
+					mapping = { "app" = "" }
+				}
+
+				stage.structured_metadata {
+					values = { "app" = "" }
+				}
+			`,
+			line:                       "app=loki component=ingester",
+			expectedStructuredMetadata: push.LabelsAdapter{{Name: "app", Value: "loki"}},
 		},
-		"expected structured metadata to be extracted with json parser and to be added to entry": {
-			pipelineStagesYaml: pipelineStagesStructuredMetadataFromJSON,
-			logLine:            `{"app":"loki" ,"component":"ingester"}`,
-			expectedStructuredMetadata: map[string]any{
-				"app": "loki",
-			},
+		{
+			name: "expected structured metadata to be extracted with json parser and to be added to entry",
+			config: `
+				stage.json {
+					expressions = { app = "" }
+				}
+
+				stage.structured_metadata {
+					values = { "app" = "" }
+				}
+			`,
+			line:                       `{"app":"loki" ,"component":"ingester"}`,
+			expectedStructuredMetadata: push.LabelsAdapter{{Name: "app", Value: "loki"}},
 		},
-		"expected structured metadata to be extracted with regexp parser and to be added to entry": {
-			pipelineStagesYaml: pipelineStagesStructuredMetadataWithRegexParser,
-			logLine:            `2019-01-01T01:00:00.000000001Z stderr P i'm a log message!`,
-			expectedStructuredMetadata: map[string]any{
-				"stream": "stderr",
-			},
+		{
+			name: "expected structured metadata to be extracted with regexp parser and to be added to entry",
+			config: `
+				stage.regex {
+					expression = "^(?s)(?P<time>\\S+?) (?P<stream>stdout|stderr) (?P<flags>\\S+?) (?P<content>.*)$"
+				}
+
+				stage.structured_metadata {
+					values = { "stream" = "" }
+				}
+			`,
+			line:                       `2019-01-01T01:00:00.000000001Z stderr P i'm a log message!`,
+			expectedStructuredMetadata: push.LabelsAdapter{{Name: "stream", Value: "stderr"}},
 		},
-		"expected structured metadata to be extracted with json parser and to be added to entry after rendering the template": {
-			pipelineStagesYaml: pipelineStagesStructuredMetadataFromJSONWithTemplate,
-			logLine:            `{"app":"loki" ,"component":"ingester"}`,
-			expectedStructuredMetadata: map[string]any{
-				"app": "LOKI",
-			},
+		{
+			name: "expected structured metadata to be extracted once when values and regex both match extracted values",
+			config: `
+				stage.regex {
+					expression = "^(?s)(?P<time>\\S+?) (?P<stream>stdout|stderr) (?P<flags>\\S+?) (?P<content>.*)$"
+				}
+
+				stage.structured_metadata {
+					values = { "stream" = "" }
+					regex  = "stream"
+				}
+			`,
+			line:                       `2019-01-01T01:00:00.000000001Z stderr P i'm a log message!`,
+			expectedStructuredMetadata: push.LabelsAdapter{{Name: "stream", Value: "stderr"}},
 		},
-		"expected structured metadata and regular labels to be extracted with json parser and to be added to entry": {
-			pipelineStagesYaml: pipelineStagesStructuredMetadataAndRegularLabelsFromJSON,
-			logLine:            `{"app":"loki" ,"component":"ingester"}`,
-			expectedStructuredMetadata: map[string]any{
-				"app": "loki",
-			},
-			expectedLabels: model.LabelSet{model.LabelName("component"): model.LabelValue("ingester")},
+		{
+			name: "expected structured metadata to be extracted once when present in both extracted values and labels",
+			config: `
+				stage.cri {}
+
+				stage.structured_metadata {
+					values = { "stream" = "" }
+				}
+			`,
+			line:                       `2019-01-01T01:00:00.000000001Z stderr F i'm a log message!`,
+			expectedStructuredMetadata: push.LabelsAdapter{{Name: "stream", Value: "stderr"}},
 		},
-		"expected structured metadata and regular labels to be extracted with static labels stage and to be added to entry": {
-			pipelineStagesYaml: pipelineStagesStructuredMetadataFromStaticLabels,
-			logLine:            `sample log line`,
-			expectedStructuredMetadata: map[string]any{
-				"pod": "loki-querier-664f97db8d-qhnwg",
+		{
+			name: "expected structured metadata to be extracted with json parser and to be added to entry after rendering the template",
+			config: `
+				stage.json {
+					expressions = { app = "" }
+				}
+
+				stage.template {
+					source   = "app"
+					template = "{{ ToUpper .Value }}"
+				}
+
+				stage.structured_metadata {
+					values = { "app" = "" }
+				}
+			`,
+			line:                       `{"app":"loki" ,"component":"ingester"}`,
+			expectedStructuredMetadata: push.LabelsAdapter{{Name: "app", Value: "LOKI"}},
+		},
+		{
+			name: "expected structured metadata and regular labels to be extracted with json parser and to be added to entry",
+			config: `
+				stage.json {
+					expressions = { app = "", component = "" }
+				}
+
+				stage.structured_metadata {
+					values = { "app" = "" }
+				}
+
+				stage.labels {
+					values = { "component" = "" }
+				}
+			`,
+			line:                       `{"app":"loki" ,"component":"ingester"}`,
+			expectedStructuredMetadata: push.LabelsAdapter{{Name: "app", Value: "loki"}},
+			expectedLabels:             model.LabelSet{model.LabelName("component"): model.LabelValue("ingester")},
+		},
+		{
+			name: "expected structured metadata and regular labels to be extracted with static labels stage and to be added to entry",
+			config: `
+				stage.static_labels {
+					values = { "component" = "querier", "pod" = "loki-querier-664f97db8d-qhnwg" }
+				}
+
+				stage.structured_metadata {
+					values = { "pod" = "" }
+				}
+			`,
+			line:                       `sample log line`,
+			expectedStructuredMetadata: push.LabelsAdapter{{Name: "pod", Value: "loki-querier-664f97db8d-qhnwg"}},
+			expectedLabels:             model.LabelSet{model.LabelName("component"): model.LabelValue("querier")},
+		},
+		{
+			name: "expected structured metadata and regular labels to be extracted with static labels stage using different structured key",
+			config: `
+				stage.static_labels {
+					values = { "component" = "querier", "pod" = "loki-querier-664f97db8d-qhnwg" }
+				}
+
+				stage.structured_metadata {
+					values = { "pod_name" = "pod" }
+				}
+			`,
+			line:                       `sample log line`,
+			expectedStructuredMetadata: push.LabelsAdapter{{Name: "pod_name", Value: "loki-querier-664f97db8d-qhnwg"}},
+			expectedLabels:             model.LabelSet{model.LabelName("component"): model.LabelValue("querier")},
+		},
+		{
+			name: "expected structured metadata and regular labels to be extracted using regex with static labels stage",
+			config: `
+				stage.static_labels {
+					values = { "component" = "querier", "label_app_kubernetes_io_name" = "loki", "label_app_kubernetes_io_component" = "querier" }
+				}
+
+				stage.structured_metadata {
+					regex = "label_.*"
+				}
+			`,
+			line: `sample log line`,
+			expectedStructuredMetadata: push.LabelsAdapter{
+				{Name: "label_app_kubernetes_io_component", Value: "querier"},
+				{Name: "label_app_kubernetes_io_name", Value: "loki"},
 			},
 			expectedLabels: model.LabelSet{model.LabelName("component"): model.LabelValue("querier")},
 		},
-		"expected structured metadata and regular labels to be extracted with static labels stage using different structured key": {
-			pipelineStagesYaml: pipelineStagesStructuredMetadataFromStaticLabelsDifferentKey,
-			logLine:            `sample log line`,
-			expectedStructuredMetadata: map[string]any{
-				"pod_name": "loki-querier-664f97db8d-qhnwg",
+		{
+			name: "expected structured metadata and regular labels to be extracted using regex and non-regex with static labels stage",
+			config: `
+				stage.static_labels {
+					values = { "component" = "querier", "pod" = "loki-querier-664f97db8d-qhnwg", "label_app_kubernetes_io_name" = "loki", "label_app_kubernetes_io_component" = "querier" }
+				}
+
+				stage.structured_metadata {
+					values = { "pod_name" = "pod" }
+					regex  = "label_.*"
+				}
+			`,
+			line: `sample log line`,
+			expectedStructuredMetadata: push.LabelsAdapter{
+				{Name: "label_app_kubernetes_io_component", Value: "querier"},
+				{Name: "label_app_kubernetes_io_name", Value: "loki"},
+				{Name: "pod_name", Value: "loki-querier-664f97db8d-qhnwg"},
 			},
 			expectedLabels: model.LabelSet{model.LabelName("component"): model.LabelValue("querier")},
 		},
-		"expected structured metadata and regular labels to be extracted using regex with static labels stage": {
-			pipelineStagesYaml: pipelineStagesStructuredMetadataFromRegexLabels,
-			logLine:            `sample log line`,
-			expectedStructuredMetadata: map[string]any{
-				"label_app_kubernetes_io_component": "querier",
-				"label_app_kubernetes_io_name":      "loki",
-			},
-			expectedLabels: model.LabelSet{model.LabelName("component"): model.LabelValue("querier")},
-		},
-		"expected structured metadata and regular labels to be extracted using regex and non-regex with static labels stage": {
-			pipelineStagesYaml: pipelineStagesStructuredMetadataFromRegexAndNonRegexLabels,
-			logLine:            `sample log line`,
-			expectedStructuredMetadata: map[string]any{
-				"label_app_kubernetes_io_component": "querier",
-				"label_app_kubernetes_io_name":      "loki",
-				"pod_name":                          "loki-querier-664f97db8d-qhnwg",
-			},
-			expectedLabels: model.LabelSet{model.LabelName("component"): model.LabelValue("querier")},
-		},
-		"expected structured metadata to be set from extracted values": {
-			pipelineStagesYaml: pipelineStagesStructuredMetadataFromExtractedValues,
-			logLine:            `pod=loki-querier-664f97db8d-qhnwg metadata_name=loki metadata_component=querier msg="sample log line"`,
-			expectedStructuredMetadata: map[string]any{
-				"metadata_component": "querier",
-				"metadata_name":      "loki",
-				"pod_name":           "loki-querier-664f97db8d-qhnwg",
+		{
+			name: "expected structured metadata to be set from extracted values",
+			config: `
+				stage.logfmt {
+					mapping = { "pod" = "", "metadata_name" = "", "metadata_component" = "" }
+				}
+
+				stage.structured_metadata {
+					values = { "pod_name" = "pod" }
+					regex  = "metadata_.*"
+				}
+			`,
+			line: `pod=loki-querier-664f97db8d-qhnwg metadata_name=loki metadata_component=querier msg="sample log line"`,
+			expectedStructuredMetadata: push.LabelsAdapter{
+				{Name: "metadata_component", Value: "querier"},
+				{Name: "metadata_name", Value: "loki"},
+				{Name: "pod_name", Value: "loki-querier-664f97db8d-qhnwg"},
 			},
 		},
-		"expected structured metadata from nested values": {
-			pipelineStagesYaml: pipelineStagesStructuredMetadataFromNestedValues,
-			logLine:            `{"app":"loki", "component_nested": {"name":"ingester", "props":{"n1": "v1", "n2": "v2"}}, "component_non_nested": "non_nested_val"}`,
-			expectedStructuredMetadata: map[string]any{
-				"component_nested": map[string]any{
-					"name": "ingester",
-					"props": map[string]any{
-						"n1": "v1",
-						"n2": "v2",
-					},
-				},
-				"component_non_nested": "non_nested_val",
+		{
+			name: "expected structured metadata from nested values",
+			config: `
+				stage.json {
+					expressions = { app = "", component_nested = "", component_non_nested = "" }
+				}
+
+				stage.structured_metadata {
+					regex = "component_.*"
+				}
+			`,
+			line: `{"app":"loki", "component_nested": {"name":"ingester", "props":{"n1": "v1", "n2": "v2"}}, "component_non_nested": "non_nested_val"}`,
+			expectedStructuredMetadata: push.LabelsAdapter{
+				{Name: "component_nested", Value: `{"name":"ingester","props":{"n1":"v1","n2":"v2"}}`},
+				{Name: "component_non_nested", Value: "non_nested_val"},
 			},
 		},
 	}
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			pl, err := NewPipeline(log.NewNopLogger(), loadConfig(test.pipelineStagesYaml), prometheus.DefaultRegisterer, featuregate.StabilityGenerallyAvailable)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pl, err := NewPipeline(log.NewNopLogger(), loadConfig(tt.config), prometheus.DefaultRegisterer, featuregate.StabilityGenerallyAvailable)
 			require.NoError(t, err)
 
-			result := processEntries(pl, newEntry(nil, nil, test.logLine, time.Now()))[0]
+			result := processEntries(pl, newEntry(nil, nil, tt.line, time.Now()))[0]
 
-			actualStructuredMetadata := convertStructuredMetadataToMap(result.StructuredMetadata)
-			require.Equal(t, test.expectedStructuredMetadata, actualStructuredMetadata)
+			require.ElementsMatch(t, normalizeStructuredMetadata(tt.expectedStructuredMetadata), normalizeStructuredMetadata(result.StructuredMetadata))
 
-			if test.expectedLabels != nil {
-				require.Equal(t, test.expectedLabels, result.Labels)
+			if tt.expectedLabels != nil {
+				require.Equal(t, tt.expectedLabels, result.Labels)
 			} else {
 				require.Empty(t, result.Labels)
 			}
@@ -255,18 +256,29 @@ func Test_StructuredMetadataStage(t *testing.T) {
 	}
 }
 
-// Convert result.StructuredMetadata to map[string]any for easier comparison
-func convertStructuredMetadataToMap(sm push.LabelsAdapter) map[string]any {
-	result := make(map[string]any)
-	for _, keyValPair := range sm {
-		// Try to unmarshal as JSON object first
-		var jsonValue map[string]any
-		if err := json.Unmarshal([]byte(keyValPair.Value), &jsonValue); err == nil {
-			result[keyValPair.Name] = jsonValue
-		} else {
-			// If not valid JSON object, use the string value
-			result[keyValPair.Name] = keyValPair.Value
-		}
+func normalizeStructuredMetadata(labels push.LabelsAdapter) push.LabelsAdapter {
+	normalized := make(push.LabelsAdapter, 0, len(labels))
+
+	for _, label := range labels {
+		normalized = append(normalized, push.LabelAdapter{
+			Name:  label.Name,
+			Value: canonicalizeJSON(label.Value),
+		})
 	}
-	return result
+
+	return normalized
+}
+
+func canonicalizeJSON(value string) string {
+	var decoded any
+	if err := json.Unmarshal([]byte(value), &decoded); err != nil {
+		return value
+	}
+
+	encoded, err := json.Marshal(decoded)
+	if err != nil {
+		return value
+	}
+
+	return string(bytes.TrimSpace(encoded))
 }

--- a/internal/component/loki/process/stages/structured_metadata_test.go
+++ b/internal/component/loki/process/stages/structured_metadata_test.go
@@ -263,11 +263,11 @@ func TestStructuredMetadataStage(t *testing.T) {
 				}
 			`,
 			entry: newTestEntry(map[string]any{"app": "from-extracted"}, model.LabelSet{
-					"app": "from-labels",
-				}, push.Entry{
-					Line:               `sample log line`,
-					StructuredMetadata: push.LabelsAdapter{{Name: "app", Value: "original"}},
-				}),
+				"app": "from-labels",
+			}, push.Entry{
+				Line:               `sample log line`,
+				StructuredMetadata: push.LabelsAdapter{{Name: "app", Value: "original"}},
+			}),
 			expectedStructuredMetadata: push.LabelsAdapter{{Name: "app", Value: "from-labels"}},
 		},
 	}

--- a/internal/component/loki/process/stages/structured_metadata_test.go
+++ b/internal/component/loki/process/stages/structured_metadata_test.go
@@ -17,9 +17,10 @@ import (
 
 func TestStructuredMetadataStage(t *testing.T) {
 	type testCase struct {
-		name                       string
-		config                     string
-		line                       string
+		name   string
+		config string
+		entry  Entry
+
 		expectedLabels             model.LabelSet
 		expectedStructuredMetadata push.LabelsAdapter
 	}
@@ -36,7 +37,7 @@ func TestStructuredMetadataStage(t *testing.T) {
 					values = { "app" = "" }
 				}
 			`,
-			line:                       "app=loki component=ingester",
+			entry:                      newTestEntry(nil, nil, push.Entry{Line: "app=loki component=ingester"}),
 			expectedStructuredMetadata: push.LabelsAdapter{{Name: "app", Value: "loki"}},
 		},
 		{
@@ -50,7 +51,7 @@ func TestStructuredMetadataStage(t *testing.T) {
 					values = { "app" = "" }
 				}
 			`,
-			line:                       `{"app":"loki" ,"component":"ingester"}`,
+			entry:                      newTestEntry(nil, nil, push.Entry{Line: `{"app":"loki" ,"component":"ingester"}`}),
 			expectedStructuredMetadata: push.LabelsAdapter{{Name: "app", Value: "loki"}},
 		},
 		{
@@ -64,7 +65,7 @@ func TestStructuredMetadataStage(t *testing.T) {
 					values = { "stream" = "" }
 				}
 			`,
-			line:                       `2019-01-01T01:00:00.000000001Z stderr P i'm a log message!`,
+			entry:                      newTestEntry(nil, nil, push.Entry{Line: `2019-01-01T01:00:00.000000001Z stderr P i'm a log message!`}),
 			expectedStructuredMetadata: push.LabelsAdapter{{Name: "stream", Value: "stderr"}},
 		},
 		{
@@ -79,7 +80,7 @@ func TestStructuredMetadataStage(t *testing.T) {
 					regex  = "stream"
 				}
 			`,
-			line:                       `2019-01-01T01:00:00.000000001Z stderr P i'm a log message!`,
+			entry:                      newTestEntry(nil, nil, push.Entry{Line: `2019-01-01T01:00:00.000000001Z stderr P i'm a log message!`}),
 			expectedStructuredMetadata: push.LabelsAdapter{{Name: "stream", Value: "stderr"}},
 		},
 		{
@@ -91,7 +92,7 @@ func TestStructuredMetadataStage(t *testing.T) {
 					values = { "stream" = "" }
 				}
 			`,
-			line:                       `2019-01-01T01:00:00.000000001Z stderr F i'm a log message!`,
+			entry:                      newTestEntry(nil, nil, push.Entry{Line: `2019-01-01T01:00:00.000000001Z stderr F i'm a log message!`}),
 			expectedStructuredMetadata: push.LabelsAdapter{{Name: "stream", Value: "stderr"}},
 		},
 		{
@@ -110,7 +111,7 @@ func TestStructuredMetadataStage(t *testing.T) {
 					values = { "app" = "" }
 				}
 			`,
-			line:                       `{"app":"loki" ,"component":"ingester"}`,
+			entry:                      newTestEntry(nil, nil, push.Entry{Line: `{"app":"loki" ,"component":"ingester"}`}),
 			expectedStructuredMetadata: push.LabelsAdapter{{Name: "app", Value: "LOKI"}},
 		},
 		{
@@ -128,7 +129,7 @@ func TestStructuredMetadataStage(t *testing.T) {
 					values = { "component" = "" }
 				}
 			`,
-			line:                       `{"app":"loki" ,"component":"ingester"}`,
+			entry:                      newTestEntry(nil, nil, push.Entry{Line: `{"app":"loki" ,"component":"ingester"}`}),
 			expectedStructuredMetadata: push.LabelsAdapter{{Name: "app", Value: "loki"}},
 			expectedLabels:             model.LabelSet{model.LabelName("component"): model.LabelValue("ingester")},
 		},
@@ -143,7 +144,7 @@ func TestStructuredMetadataStage(t *testing.T) {
 					values = { "pod" = "" }
 				}
 			`,
-			line:                       `sample log line`,
+			entry:                      newTestEntry(nil, nil, push.Entry{Line: `sample log line`}),
 			expectedStructuredMetadata: push.LabelsAdapter{{Name: "pod", Value: "loki-querier-664f97db8d-qhnwg"}},
 			expectedLabels:             model.LabelSet{model.LabelName("component"): model.LabelValue("querier")},
 		},
@@ -158,7 +159,7 @@ func TestStructuredMetadataStage(t *testing.T) {
 					values = { "pod_name" = "pod" }
 				}
 			`,
-			line:                       `sample log line`,
+			entry:                      newTestEntry(nil, nil, push.Entry{Line: `sample log line`}),
 			expectedStructuredMetadata: push.LabelsAdapter{{Name: "pod_name", Value: "loki-querier-664f97db8d-qhnwg"}},
 			expectedLabels:             model.LabelSet{model.LabelName("component"): model.LabelValue("querier")},
 		},
@@ -173,7 +174,7 @@ func TestStructuredMetadataStage(t *testing.T) {
 					regex = "label_.*"
 				}
 			`,
-			line: `sample log line`,
+			entry: newTestEntry(nil, nil, push.Entry{Line: `sample log line`}),
 			expectedStructuredMetadata: push.LabelsAdapter{
 				{Name: "label_app_kubernetes_io_component", Value: "querier"},
 				{Name: "label_app_kubernetes_io_name", Value: "loki"},
@@ -192,7 +193,7 @@ func TestStructuredMetadataStage(t *testing.T) {
 					regex  = "label_.*"
 				}
 			`,
-			line: `sample log line`,
+			entry: newTestEntry(nil, nil, push.Entry{Line: `sample log line`}),
 			expectedStructuredMetadata: push.LabelsAdapter{
 				{Name: "label_app_kubernetes_io_component", Value: "querier"},
 				{Name: "label_app_kubernetes_io_name", Value: "loki"},
@@ -212,7 +213,7 @@ func TestStructuredMetadataStage(t *testing.T) {
 					regex  = "metadata_.*"
 				}
 			`,
-			line: `pod=loki-querier-664f97db8d-qhnwg metadata_name=loki metadata_component=querier msg="sample log line"`,
+			entry: newTestEntry(nil, nil, push.Entry{Line: `pod=loki-querier-664f97db8d-qhnwg metadata_name=loki metadata_component=querier msg="sample log line"`}),
 			expectedStructuredMetadata: push.LabelsAdapter{
 				{Name: "metadata_component", Value: "querier"},
 				{Name: "metadata_name", Value: "loki"},
@@ -230,11 +231,44 @@ func TestStructuredMetadataStage(t *testing.T) {
 					regex = "component_.*"
 				}
 			`,
-			line: `{"app":"loki", "component_nested": {"name":"ingester", "props":{"n1": "v1", "n2": "v2"}}, "component_non_nested": "non_nested_val"}`,
+			entry: newTestEntry(nil, nil, push.Entry{Line: `{"app":"loki", "component_nested": {"name":"ingester", "props":{"n1": "v1", "n2": "v2"}}, "component_non_nested": "non_nested_val"}`}),
 			expectedStructuredMetadata: push.LabelsAdapter{
 				{Name: "component_nested", Value: `{"name":"ingester","props":{"n1":"v1","n2":"v2"}}`},
 				{Name: "component_non_nested", Value: "non_nested_val"},
 			},
+		},
+		{
+			name: "expected later structured metadata stage to replace earlier stage output",
+			config: `
+				stage.logfmt {
+					mapping = { "app" = "", "next_app" = "" }
+				}
+
+				stage.structured_metadata {
+					values = { "app" = "app" }
+				}
+
+				stage.structured_metadata {
+					values = { "app" = "next_app" }
+				}
+			`,
+			entry:                      newTestEntry(nil, nil, push.Entry{Line: `app=first next_app=second`}),
+			expectedStructuredMetadata: push.LabelsAdapter{{Name: "app", Value: "second"}},
+		},
+		{
+			name: "expected later source within a stage to replace existing structured metadata",
+			config: `
+				stage.structured_metadata {
+					values = { "app" = "" }
+				}
+			`,
+			entry: newTestEntry(map[string]any{"app": "from-extracted"}, model.LabelSet{
+					"app": "from-labels",
+				}, push.Entry{
+					Line:               `sample log line`,
+					StructuredMetadata: push.LabelsAdapter{{Name: "app", Value: "original"}},
+				}),
+			expectedStructuredMetadata: push.LabelsAdapter{{Name: "app", Value: "from-labels"}},
 		},
 	}
 
@@ -243,7 +277,10 @@ func TestStructuredMetadataStage(t *testing.T) {
 			pl, err := NewPipeline(log.NewNopLogger(), loadConfig(tt.config), prometheus.DefaultRegisterer, featuregate.StabilityGenerallyAvailable)
 			require.NoError(t, err)
 
-			result := processEntries(pl, newEntry(nil, nil, tt.line, time.Now()))[0]
+			entry := tt.entry
+			entry.Timestamp = time.Now()
+
+			result := processEntries(pl, entry)[0]
 
 			require.ElementsMatch(t, normalizeStructuredMetadata(tt.expectedStructuredMetadata), normalizeStructuredMetadata(result.StructuredMetadata))
 

--- a/internal/component/loki/process/stages/util_test.go
+++ b/internal/component/loki/process/stages/util_test.go
@@ -31,6 +31,22 @@ func newEntry(ex map[string]any, lbs model.LabelSet, line string, ts time.Time) 
 	}
 }
 
+func newTestEntry(extracted map[string]any, labels model.LabelSet, entry push.Entry) Entry {
+	if extracted == nil {
+		extracted = map[string]any{}
+	}
+	if labels == nil {
+		labels = model.LabelSet{}
+	}
+	return Entry{
+		Extracted: extracted,
+		Entry: loki.Entry{
+			Labels: labels,
+			Entry:  entry,
+		},
+	}
+}
+
 // nolint
 func mustParseTime(layout, value string) time.Time {
 	t, err := time.Parse(layout, value)


### PR DESCRIPTION
### Pull Request Details
I was working with increasing test coverage for `loki.process`. I wanted to setup more full pipeline tests for this component.

When writing the first test case "simple cri pipeline" I notcied that `stage.structured_metadata` can add metadata several times. StructuredMetadata is stored as a slice and we would just append to it.

So when using something like `stage.cri` before this one we will have `stream` both as a label _and_ in the extracted map. To fix this we check if it already exists and if it does we replace it otherwise we append.

I also cleanup both the stage and tests  for it and added regression test to make sure we don't add metadata several times.

### Issue(s) fixed by this Pull Request

Relates to https://github.com/grafana/alloy/issues/4953

### Notes to the Reviewer

Part of cleaning up this stage is to have similar function for every place / way we try to extract metadata.

Before we had `processLabelsConfigs`, inline regex check for extracted map and later we called `extractFromLabels`.

I created a function for each combination of source and config instead so we have:
* `processExtractedLabelsByConfig` - source is extracted using labelConfig
* `processExtractedLabelsByRegex` - source is extracted using regex
* `processEntryLabelsByConfig` - source is labels using labelConfig
* `processEntryLabelsByRegex` - source is labels using regex


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
