### PR TITLE
fix(windows-installer): Increase service restart on failure delays

### DIFF
--- a/packaging/windows/install_script.nsis
+++ b/packaging/windows/install_script.nsis
@@ -135,8 +135,8 @@ Section "install"
   nsExec::ExecToLog 'sc start "Alloy"'
   Pop $0
 
-  # Auto-restart Alloy on failure with progressive delays. Reset failure counter after 1 day without failure.
-  nsExec::ExecToLog `sc failure "Alloy" reset= 86400 actions= restart/30000/restart/60000/restart/300000`
+  # Auto-restart Alloy on failure with delays of 1 minute, 5 minutes, and 5 minutes. Reset failure counter after 1 day without failure.
+  nsExec::ExecToLog `sc failure "Alloy" reset= 86400 actions= restart/60000/restart/300000/restart/300000`
   Pop $0
 SectionEnd
 


### PR DESCRIPTION
Change Alloy service failure handling from 5-second restart to progressive delays (1min, 5min, 5min) and extend reset period from 60 seconds to 1 day to prevent rapid restart loops.

<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style. For details on this,
  check out the Contributors Guide linked above.
-->

### Brief description of Pull Request

Addresses https://github.com/grafana/alloy/issues/3631

### Pull Request Details

<!-- Detailed descripion of the Pull Request, if needed. -->


### Issue(s) fixed by this Pull Request

https://github.com/grafana/alloy/issues/3631

### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


