### PR TITLE
docs: Fix broken listener table and format using prettier

### DIFF
--- a/docs/sources/reference/components/loki/loki.source.syslog.md
+++ b/docs/sources/reference/components/loki/loki.source.syslog.md
@@ -311,6 +311,7 @@ loki.write "local" {
 
 - Components that export [Loki `LogsReceiver`](../../../compatibility/#loki-logsreceiver-exporters)
 
+
 {{< admonition type="note" >}}
 Connecting some components may not be sensible or components may require further configuration to make the connection work correctly.
 Refer to the linked documentation for more details.


### PR DESCRIPTION
This page is broken on the latest version 

<img width="1424" height="603" alt="2026-04-02-09:09:37" src="https://github.com/user-attachments/assets/cffecbf4-4e60-4034-b16d-01d01892e7a0" />

