### PR TITLE
ci: Fix multi-backport logic

### DIFF
--- a/tools/release/backport/main.go
+++ b/tools/release/backport/main.go
@@ -14,16 +14,14 @@ import (
 	gh "github.com/grafana/alloy/tools/release/internal/github"
 )
 
-type backportCreationParams struct {
-	OriginalPR     *github.PullRequest
-	BackportBranch string
-	TargetBranch   string
-}
-
-type backportFailureParams struct {
+// backportInfo holds all the data gathered during precondition checks that is
+// needed to perform the backport.
+type backportInfo struct {
 	PRNumber       int
-	OriginalTitle  string
+	OriginalPR     *github.PullRequest
 	MergeCommitSHA string
+	CommitSHA      string
+	AppIdentity    gh.AppIdentity
 	TargetBranch   string
 	BackportBranch string
 }
@@ -46,13 +44,20 @@ func main() {
 		log.Fatal("Label is required (use --label flag)")
 	}
 
-	// Parse version from label (backport/v1.15 -> v1.15)
+	if err := run(prNumber, label, dryRun); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// run performs the backport operation. It is broken out into a separate function to allow deferred
+// working copy cleanup.
+func run(prNumber int, label string, dryRun bool) (retErr error) {
 	version := strings.TrimPrefix(label, "backport/")
 	if version == label {
-		log.Fatalf("Invalid backport label format: %s (expected backport/vX.Y)", label)
+		return fmt.Errorf("invalid backport label format: %s (expected backport/vX.Y)", label)
 	}
 	if !strings.HasPrefix(version, "v") {
-		log.Fatalf("Invalid version format: %s (expected vX.Y)", version)
+		return fmt.Errorf("invalid version format: %s (expected vX.Y)", version)
 	}
 
 	targetBranch := fmt.Sprintf("release/%s", version)
@@ -64,130 +69,158 @@ func main() {
 
 	client, err := gh.NewClientFromEnv(ctx)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
+	info, err := resolveBackportInfo(ctx, client, prNumber, targetBranch, backportBranch)
+	if err != nil {
+		return err
+	}
+	if info == nil {
+		return nil
+	}
+
+	if dryRun {
+		fmt.Println("\n🏃 DRY RUN - No changes made")
+		fmt.Printf("Would create backport branch: %s\n", info.BackportBranch)
+		fmt.Printf("Would cherry-pick commit: %s\n", info.CommitSHA)
+		fmt.Printf("Would create PR: %s → %s\n", info.BackportBranch, info.TargetBranch)
+		return nil
+	}
+
+	// Comment on the original PR with manual instructions if anything fails.
+	defer func() {
+		if retErr != nil {
+			commentOnBackportFailure(ctx, client, info, retErr)
+		}
+	}()
+
+	// --- Git operations: branch, cherry-pick, push, create PR ---
+
+	if err := git.ConfigureUser(info.AppIdentity.Name, info.AppIdentity.Email); err != nil {
+		return err
+	}
+
+	if err := git.Fetch(info.TargetBranch); err != nil {
+		return err
+	}
+
+	originalBranch, err := git.CurrentBranch()
+	if err != nil {
+		return err
+	}
+
+	if err := git.CheckoutNewBranch(info.BackportBranch, "origin/"+info.TargetBranch); err != nil {
+		return err
+	}
+	defer resetWorkingCopy(originalBranch, info.BackportBranch)
+
+	if err := git.CherryPick(info.CommitSHA, true); err != nil {
+		return err
+	}
+
+	if err := git.Push(info.BackportBranch); err != nil {
+		return err
+	}
+	fmt.Printf("✅ Pushed backport branch: %s\n", info.BackportBranch)
+
+	backportPR, err := createBackportPR(ctx, client, info)
+	if err != nil {
+		return fmt.Errorf("creating backport PR: %w", err)
+	}
+	fmt.Printf("✅ Created backport PR: %s\n", backportPR.GetHTMLURL())
+
+	return nil
+}
+
+// resolveBackportInfo gathers all the information needed to perform a
+// backport. It returns nil (with no error) when the backport can be skipped
+// (target branch missing, already backported, etc.).
+func resolveBackportInfo(ctx context.Context, client *gh.Client, prNumber int, targetBranch, backportBranch string) (*backportInfo, error) {
 	// Verify the target release branch exists. If it doesn't, the release
 	// hasn't been finalized yet (we're still in RC mode) and the change will
 	// be included in the release implicitly since it's already on main.
 	exists, err := git.BranchExistsOnRemote(targetBranch)
 	if err != nil {
-		log.Fatalf("Failed to check if target branch exists: %v", err)
+		return nil, fmt.Errorf("checking target branch: %w", err)
 	}
 	if !exists {
 		fmt.Printf("ℹ️  Target branch %s does not exist yet (release is likely still in RC phase).\n", targetBranch)
 		fmt.Printf("   No backport needed — this change will be included in the release implicitly.\n")
-		return
+		return nil, nil
 	}
 
 	// Check if backport branch already exists (means there's an open PR or work in progress)
 	branchExists, err := git.BranchExistsOnRemote(backportBranch)
 	if err != nil {
-		log.Fatalf("Failed to check if backport branch exists: %v", err)
+		return nil, fmt.Errorf("checking backport branch: %w", err)
 	}
 	if branchExists {
 		fmt.Printf("ℹ️  Backport branch %s already exists\n", backportBranch)
-		return
+		return nil, nil
 	}
 
-	// Get the original PR details
 	originalPR, err := client.GetPR(ctx, prNumber)
 	if err != nil {
-		log.Fatalf("Failed to get original PR: %v", err)
+		return nil, fmt.Errorf("getting PR #%d: %w", prNumber, err)
 	}
 
-	// Get the merge commit SHA for cherry-pick instructions
-	mergeCommitSHA := originalPR.GetMergeCommitSHA()
-
-	// Get the app identity for git commits
 	appIdentity, err := client.GetAppIdentity(ctx)
 	if err != nil {
-		log.Fatalf("Failed to get app identity: %v", err)
+		return nil, fmt.Errorf("getting app identity: %w", err)
 	}
 
-	// Check if backport was already merged by looking for the original PR title in the release branch history
+	// Check if backport was already merged by looking for the original PR
+	// title in the release branch history.
 	alreadyMerged, err := client.CommitExistsWithPattern(ctx, gh.FindCommitParams{
 		Branch:  targetBranch,
 		Pattern: originalPR.GetTitle(),
 	})
 	if err != nil {
-		log.Fatalf("Failed to check for existing backport commit: %v", err)
+		return nil, fmt.Errorf("checking for existing backport: %w", err)
 	}
 	if alreadyMerged {
 		fmt.Printf("ℹ️  Backport already merged (found commit with title %q in %s)\n", originalPR.GetTitle(), targetBranch)
-		return
+		return nil, nil
 	}
 
-	// Find the commit on main that corresponds to this PR
 	commitSHA, err := client.FindCommitWithPattern(ctx, gh.FindCommitParams{
 		Branch:  "main",
 		Pattern: fmt.Sprintf("(#%d)", prNumber),
 	})
 	if err != nil {
-		log.Fatalf("Failed to find commit for PR #%d: %v", prNumber, err)
+		return nil, fmt.Errorf("finding commit for PR #%d: %w", prNumber, err)
 	}
 	fmt.Printf("   Found commit: %s\n", commitSHA)
 	fmt.Printf("   Backport branch: %s\n", backportBranch)
 
-	if dryRun {
-		fmt.Println("\n🏃 DRY RUN - No changes made")
-		fmt.Printf("Would create backport branch: %s\n", backportBranch)
-		fmt.Printf("Would cherry-pick commit: %s\n", commitSHA)
-		fmt.Printf("Would create PR: %s → %s\n", backportBranch, targetBranch)
-		return
-	}
-
-	// Configure git with app identity for commit authorship
-	if err := git.ConfigureUser(appIdentity.Name, appIdentity.Email); err != nil {
-		log.Fatalf("Failed to configure git: %v", err)
-	}
-
-	// Fetch target branch for cherry-pick
-	if err := git.Fetch(targetBranch); err != nil {
-		log.Fatalf("Failed to fetch target branch: %v", err)
-	}
-
-	// Create backport branch from target branch
-	if err := git.CreateBranchFrom(backportBranch, "origin/"+targetBranch); err != nil {
-		log.Fatalf("Failed to create backport branch: %v", err)
-	}
-
-	// Cherry-pick the commit
-	if err := git.CherryPick(commitSHA, true); err != nil {
-		commentOnBackportFailure(ctx, client, backportFailureParams{
-			PRNumber:       prNumber,
-			OriginalTitle:  originalPR.GetTitle(),
-			MergeCommitSHA: mergeCommitSHA,
-			TargetBranch:   targetBranch,
-			BackportBranch: backportBranch,
-		})
-		fmt.Fprintf(os.Stderr, "Failed to cherry-pick commit: %v. A comment has been added to the original PR (#%d) with instructions for manual backport.\n", err, prNumber)
-		os.Exit(1)
-	}
-
-	// Push the backport branch
-	if err := git.Push(backportBranch); err != nil {
-		log.Fatalf("Failed to push backport branch: %v", err)
-	}
-
-	fmt.Printf("✅ Pushed backport branch: %s\n", backportBranch)
-
-	// Create the backport PR
-	backportPR, err := createBackportPR(ctx, client, backportCreationParams{
+	return &backportInfo{
+		PRNumber:       prNumber,
 		OriginalPR:     originalPR,
-		BackportBranch: backportBranch,
+		MergeCommitSHA: originalPR.GetMergeCommitSHA(),
+		CommitSHA:      commitSHA,
+		AppIdentity:    appIdentity,
 		TargetBranch:   targetBranch,
-	})
-	if err != nil {
-		log.Fatalf("Failed to create backport PR: %v", err)
-	}
-
-	fmt.Printf("✅ Created backport PR: %s\n", backportPR.GetHTMLURL())
+		BackportBranch: backportBranch,
+	}, nil
 }
 
-func createBackportPR(ctx context.Context, client *gh.Client, params backportCreationParams) (*github.PullRequest, error) {
-	// Use the original PR's title with [backport] suffix for conventional commit compatibility
-	title := backportPRTitle(params.OriginalPR.GetTitle())
+// resetWorkingCopy restores the repository to a clean state so subsequent
+// backports in the same run can proceed.
+func resetWorkingCopy(originalBranch, backportBranch string) {
+	fmt.Println("🧹 Resetting working copy for next backport...")
+	_ = git.AbortCherryPick()
+	_ = git.ResetHard()
+	if err := git.Checkout(originalBranch); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to checkout %s: %v\n", originalBranch, err)
+	}
+	if err := git.DeleteLocalBranch(backportBranch); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to delete local branch %s: %v\n", backportBranch, err)
+	}
+}
+
+func createBackportPR(ctx context.Context, client *gh.Client, info *backportInfo) (*github.PullRequest, error) {
+	title := backportPRTitle(info.OriginalPR.GetTitle())
 
 	body := fmt.Sprintf(`## Backport of #%d
 
@@ -202,17 +235,17 @@ This PR backports #%d to %s.
 ---
 *This backport was created automatically.*
 `,
-		params.OriginalPR.GetNumber(),
-		params.OriginalPR.GetNumber(),
-		params.TargetBranch,
-		params.OriginalPR.GetUser().GetLogin(),
-		params.OriginalPR.GetBody(),
+		info.OriginalPR.GetNumber(),
+		info.OriginalPR.GetNumber(),
+		info.TargetBranch,
+		info.OriginalPR.GetUser().GetLogin(),
+		info.OriginalPR.GetBody(),
 	)
 
 	return client.CreatePR(ctx, gh.CreatePRParams{
 		Title: title,
-		Head:  params.BackportBranch,
-		Base:  params.TargetBranch,
+		Head:  info.BackportBranch,
+		Base:  info.TargetBranch,
 		Body:  body,
 	})
 }
@@ -221,10 +254,14 @@ func backportPRTitle(originalTitle string) string {
 	return fmt.Sprintf("%s [backport]", originalTitle)
 }
 
-func commentOnBackportFailure(ctx context.Context, client *gh.Client, params backportFailureParams) {
+func commentOnBackportFailure(ctx context.Context, client *gh.Client, info *backportInfo, backportErr error) {
 	comment := fmt.Sprintf(`## ⚠️ Automatic backport to %s failed
 
-The automatic backport for this PR failed, likely due to merge conflicts. Perform the backport manually:
+The automatic backport for this PR failed:
+
+> %s
+
+To perform the backport manually:
 
 `+"```"+`bash
 git fetch origin main %s
@@ -243,20 +280,21 @@ Then create a PR from `+"`%s`"+` to `+"`%s`"+` with the title:
 
 %s
 `,
-		params.TargetBranch,
-		params.TargetBranch,
-		params.TargetBranch,
-		params.BackportBranch,
-		params.MergeCommitSHA,
-		params.BackportBranch,
-		params.BackportBranch,
-		params.TargetBranch,
-		backportPRTitle(params.OriginalTitle),
+		info.TargetBranch,
+		backportErr,
+		info.TargetBranch,
+		info.TargetBranch,
+		info.BackportBranch,
+		info.MergeCommitSHA,
+		info.BackportBranch,
+		info.BackportBranch,
+		info.TargetBranch,
+		backportPRTitle(info.OriginalPR.GetTitle()),
 	)
 
-	if err := client.CreateIssueComment(ctx, params.PRNumber, comment); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: failed to comment on PR #%d: %v\n", params.PRNumber, err)
+	if err := client.CreateIssueComment(ctx, info.PRNumber, comment); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to comment on PR #%d: %v\n", info.PRNumber, err)
 	} else {
-		fmt.Printf("📝 Added manual backport instructions to PR #%d\n", params.PRNumber)
+		fmt.Printf("📝 Added manual backport instructions to PR #%d\n", info.PRNumber)
 	}
 }

--- a/tools/release/internal/git/git.go
+++ b/tools/release/internal/git/git.go
@@ -45,42 +45,27 @@ func validateSHA(sha string) error {
 	return nil
 }
 
-// run executes a command with stdout/stderr connected to the terminal. Both streams are captured in
-// a buffer for error messaging.
-func run(args ...string) error {
-	cmd := exec.Command(args[0], args[1:]...)
+// run executes a command with stdout/stderr connected to the terminal. Both streams are captured
+// together and returned as a single string.
+func run(args ...string) (string, error) {
 	var combined bytes.Buffer
-	w := io.MultiWriter(os.Stdout, &combined)
-	cmd.Stdout = w
-	cmd.Stderr = w
-	if err := cmd.Run(); err != nil {
-		if msg := strings.TrimSpace(combined.String()); msg != "" {
-			return fmt.Errorf("%w:\n%s", err, msg)
-		}
-		return err
-	}
-	return nil
-}
 
-// runOutput executes a command and returns its stdout.
-// On error, stderr is included in the error message for better diagnostics.
-func runOutput(args ...string) (string, error) {
 	cmd := exec.Command(args[0], args[1:]...)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		if stderr.Len() > 0 {
-			return "", fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
-		}
-		return "", err
+	cmd.Stdout = io.MultiWriter(os.Stdout, &combined)
+	cmd.Stderr = io.MultiWriter(os.Stderr, &combined)
+
+	err := cmd.Run()
+	out := strings.TrimSpace(combined.String())
+	if err != nil {
+		return out, fmt.Errorf("%w:\n%s", err, out)
 	}
-	return strings.TrimSpace(stdout.String()), nil
+
+	return out, nil
 }
 
 // AmendCommit amends the current HEAD commit with any staged changes.
 func AmendCommit() error {
-	if err := run("git", "commit", "--amend", "--no-edit"); err != nil {
+	if _, err := run("git", "commit", "--amend", "--no-edit"); err != nil {
 		return fmt.Errorf("amending commit: %w", err)
 	}
 	return nil
@@ -91,7 +76,7 @@ func BranchExistsOnRemote(branch string) (bool, error) {
 	if err := validateBranchName(branch); err != nil {
 		return false, err
 	}
-	out, err := runOutput("git", "ls-remote", "--heads", "origin", branch)
+	out, err := run("git", "ls-remote", "--heads", "origin", branch)
 	if err != nil {
 		return false, fmt.Errorf("checking remote branch %s: %w", branch, err)
 	}
@@ -103,7 +88,7 @@ func Checkout(branch string) error {
 	if err := validateBranchName(branch); err != nil {
 		return err
 	}
-	if err := run("git", "checkout", branch); err != nil {
+	if _, err := run("git", "checkout", branch); err != nil {
 		return fmt.Errorf("checking out branch %s: %w", branch, err)
 	}
 	return nil
@@ -122,7 +107,7 @@ func CherryPick(sha string, shouldCommit bool) error {
 		args = append(args, "-x") // Adds "(cherry picked from commit ...)" reference
 	}
 	args = append(args, sha)
-	if err := run(args...); err != nil {
+	if _, err := run(args...); err != nil {
 		return fmt.Errorf("cherry-picking commit %s: %w", sha, err)
 	}
 	return nil
@@ -130,10 +115,10 @@ func CherryPick(sha string, shouldCommit bool) error {
 
 // ConfigureUser configures git with the given user identity for commit authorship.
 func ConfigureUser(name, email string) error {
-	if err := run("git", "config", "user.name", name); err != nil {
+	if _, err := run("git", "config", "user.name", name); err != nil {
 		return fmt.Errorf("setting user.name: %w", err)
 	}
-	if err := run("git", "config", "user.email", email); err != nil {
+	if _, err := run("git", "config", "user.email", email); err != nil {
 		return fmt.Errorf("setting user.email: %w", err)
 	}
 	return nil
@@ -149,7 +134,7 @@ func CheckoutNewBranch(branch, base string) error {
 	if err := validateBranchName(baseBranch); err != nil {
 		return fmt.Errorf("invalid base: %w", err)
 	}
-	if err := run("git", "checkout", "-b", branch, base); err != nil {
+	if _, err := run("git", "checkout", "-b", branch, base); err != nil {
 		return fmt.Errorf("checking out new branch %s based on %s: %w", branch, base, err)
 	}
 	return nil
@@ -160,7 +145,7 @@ func Fetch(branch string) error {
 	if err := validateBranchName(branch); err != nil {
 		return err
 	}
-	if err := run("git", "fetch", "origin", branch); err != nil {
+	if _, err := run("git", "fetch", "origin", branch); err != nil {
 		return fmt.Errorf("fetching branch %s: %w", branch, err)
 	}
 	return nil
@@ -172,7 +157,7 @@ func MergeOurs(branch, message string) error {
 	if err := validateBranchName(branch); err != nil {
 		return err
 	}
-	if err := run("git", "merge", "--strategy", "ours", "origin/"+branch, "--message", message); err != nil {
+	if _, err := run("git", "merge", "--strategy", "ours", "origin/"+branch, "--message", message); err != nil {
 		return fmt.Errorf("merging branch %s with ours strategy: %w", branch, err)
 	}
 	return nil
@@ -183,7 +168,7 @@ func Push(branch string) error {
 	if err := validateBranchName(branch); err != nil {
 		return err
 	}
-	if err := run("git", "push", "origin", branch); err != nil {
+	if _, err := run("git", "push", "origin", branch); err != nil {
 		return fmt.Errorf("pushing branch %s: %w", branch, err)
 	}
 	return nil
@@ -194,7 +179,7 @@ func MergeFFOnly(branch string) error {
 	if err := validateBranchName(branch); err != nil {
 		return err
 	}
-	if err := run("git", "merge", "--ff-only", branch); err != nil {
+	if _, err := run("git", "merge", "--ff-only", branch); err != nil {
 		return fmt.Errorf("merging branch %s (ff-only): %w", branch, err)
 	}
 	return nil
@@ -202,16 +187,14 @@ func MergeFFOnly(branch string) error {
 
 // CurrentBranch returns the name of the currently checked-out branch.
 func CurrentBranch() (string, error) {
-	out, err := runOutput("git", "rev-parse", "--abbrev-ref", "HEAD")
+	out, err := run("git", "rev-parse", "--abbrev-ref", "HEAD")
 	if err != nil {
 		return "", fmt.Errorf("getting current branch: %w", err)
 	}
 	return out, nil
 }
 
-// AbortCherryPick attempts to abort an in-progress cherry-pick. Output is
-// suppressed so callers can use this best-effort without noisy errors when no
-// cherry-pick is in progress.
+// AbortCherryPick attempts to abort an in-progress cherry-pick.
 func AbortCherryPick() error {
 	if err := exec.Command("git", "cherry-pick", "--abort").Run(); err != nil {
 		return fmt.Errorf("aborting cherry-pick: %w", err)
@@ -221,7 +204,7 @@ func AbortCherryPick() error {
 
 // ResetHard resets the index and working tree to HEAD, discarding all changes.
 func ResetHard() error {
-	if err := run("git", "reset", "--hard"); err != nil {
+	if _, err := run("git", "reset", "--hard"); err != nil {
 		return fmt.Errorf("resetting working copy: %w", err)
 	}
 	return nil
@@ -232,7 +215,7 @@ func DeleteLocalBranch(branch string) error {
 	if err := validateBranchName(branch); err != nil {
 		return err
 	}
-	if err := run("git", "branch", "-D", branch); err != nil {
+	if _, err := run("git", "branch", "-D", branch); err != nil {
 		return fmt.Errorf("deleting local branch %s: %w", branch, err)
 	}
 	return nil

--- a/tools/release/internal/git/git.go
+++ b/tools/release/internal/git/git.go
@@ -4,6 +4,7 @@ package git
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"regexp"
@@ -44,12 +45,21 @@ func validateSHA(sha string) error {
 	return nil
 }
 
-// run executes a command with stdout/stderr connected to the terminal.
+// run executes a command with stdout/stderr connected to the terminal. Both streams are captured in
+// a buffer for error messaging.
 func run(args ...string) error {
 	cmd := exec.Command(args[0], args[1:]...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	var combined bytes.Buffer
+	w := io.MultiWriter(os.Stdout, &combined)
+	cmd.Stdout = w
+	cmd.Stderr = w
+	if err := cmd.Run(); err != nil {
+		if msg := strings.TrimSpace(combined.String()); msg != "" {
+			return fmt.Errorf("%w:\n%s", err, msg)
+		}
+		return err
+	}
+	return nil
 }
 
 // runOutput executes a command and returns its stdout.
@@ -109,7 +119,7 @@ func CherryPick(sha string, shouldCommit bool) error {
 	if !shouldCommit {
 		args = append(args, "--no-commit")
 	} else {
-		args = append(args, "-x") // no long form; adds "(cherry picked from commit ...)" reference
+		args = append(args, "-x") // Adds "(cherry picked from commit ...)" reference
 	}
 	args = append(args, sha)
 	if err := run(args...); err != nil {
@@ -129,8 +139,8 @@ func ConfigureUser(name, email string) error {
 	return nil
 }
 
-// CreateBranchFrom creates a new branch from a base ref and checks it out.
-func CreateBranchFrom(branch, base string) error {
+// CheckoutNewBranch creates a new branch from a base ref and checks it out.
+func CheckoutNewBranch(branch, base string) error {
 	if err := validateBranchName(branch); err != nil {
 		return err
 	}
@@ -140,7 +150,7 @@ func CreateBranchFrom(branch, base string) error {
 		return fmt.Errorf("invalid base: %w", err)
 	}
 	if err := run("git", "checkout", "-b", branch, base); err != nil {
-		return fmt.Errorf("creating branch %s from %s: %w", branch, base, err)
+		return fmt.Errorf("checking out new branch %s based on %s: %w", branch, base, err)
 	}
 	return nil
 }
@@ -186,6 +196,44 @@ func MergeFFOnly(branch string) error {
 	}
 	if err := run("git", "merge", "--ff-only", branch); err != nil {
 		return fmt.Errorf("merging branch %s (ff-only): %w", branch, err)
+	}
+	return nil
+}
+
+// CurrentBranch returns the name of the currently checked-out branch.
+func CurrentBranch() (string, error) {
+	out, err := runOutput("git", "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("getting current branch: %w", err)
+	}
+	return out, nil
+}
+
+// AbortCherryPick attempts to abort an in-progress cherry-pick. Output is
+// suppressed so callers can use this best-effort without noisy errors when no
+// cherry-pick is in progress.
+func AbortCherryPick() error {
+	if err := exec.Command("git", "cherry-pick", "--abort").Run(); err != nil {
+		return fmt.Errorf("aborting cherry-pick: %w", err)
+	}
+	return nil
+}
+
+// ResetHard resets the index and working tree to HEAD, discarding all changes.
+func ResetHard() error {
+	if err := run("git", "reset", "--hard"); err != nil {
+		return fmt.Errorf("resetting working copy: %w", err)
+	}
+	return nil
+}
+
+// DeleteLocalBranch force-deletes a local branch.
+func DeleteLocalBranch(branch string) error {
+	if err := validateBranchName(branch); err != nil {
+		return err
+	}
+	if err := run("git", "branch", "-D", branch); err != nil {
+		return fmt.Errorf("deleting local branch %s: %w", branch, err)
 	}
 	return nil
 }

--- a/tools/release/internal/github/client.go
+++ b/tools/release/internal/github/client.go
@@ -438,52 +438,6 @@ func (c *Client) UpdateReleaseBody(ctx context.Context, releaseID int64, body st
 	return nil
 }
 
-// WaitForCheckRun polls until the named check run has completed successfully on the given ref,
-// or until the context is done (e.g. timeout). Ref can be a branch name or commit SHA.
-func (c *Client) WaitForCheckRun(ctx context.Context, ref, checkName string) error {
-	opts := &github.ListCheckRunsOptions{
-		Filter: github.String("latest"),
-		ListOptions: github.ListOptions{
-			PerPage: 100,
-		},
-	}
-	for {
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("waiting for check %q: %w", checkName, ctx.Err())
-		default:
-		}
-		result, _, err := c.api.Checks.ListCheckRunsForRef(ctx, c.owner, c.repo, ref, opts)
-		if err != nil {
-			return fmt.Errorf("listing check runs for ref %s: %w", ref, err)
-		}
-		var found *github.CheckRun
-		for _, run := range result.CheckRuns {
-			if run.GetName() == checkName {
-				found = run
-				break
-			}
-		}
-		if found == nil {
-			// Check not yet reported; wait and retry
-			fmt.Printf("⏳ Check %q not yet reported; waiting and retrying...\n", checkName)
-			time.Sleep(20 * time.Second)
-			continue
-		}
-		status := found.GetStatus()
-		if status != "completed" {
-			fmt.Printf("⏳ Check %q not yet completed; waiting and retrying...\n", checkName)
-			time.Sleep(20 * time.Second)
-			continue
-		}
-		conclusion := found.GetConclusion()
-		if conclusion != "success" {
-			return fmt.Errorf("check %q completed with conclusion %q (expected success)", checkName, conclusion)
-		}
-		return nil
-	}
-}
-
 // DeleteBranch deletes the branch ref on the remote.
 func (c *Client) DeleteBranch(ctx context.Context, branch string) error {
 	ref := "refs/heads/" + branch


### PR DESCRIPTION
When backporting a single PR to multiple releases, there was a bug that caused any backport after a failed backport to also fail. 

The fix is to reset the working copy after each backport. This PR also cleans up some of the logic for clarity and separation of concerns.