### PR TITLE
ci: Wait for docker on windows runners

### DIFF
--- a/.github/workflows/check-windows-container.yml
+++ b/.github/workflows/check-windows-container.yml
@@ -10,6 +10,7 @@ on:
       - '.github/workflows/publish-alloy.yml'
       - '.github/workflows/publish-alloy-devel.yml'
       - '.github/workflows/release-publish-alloy-artifacts.yml'
+      - '.github/workflows/publish-alloy-windows.yml'
   pull_request:
     paths:
       - 'Dockerfile.windows'
@@ -18,7 +19,7 @@ on:
       - '.github/workflows/publish-alloy.yml'
       - '.github/workflows/publish-alloy-devel.yml'
       - '.github/workflows/release-publish-alloy-artifacts.yml'
-
+      - '.github/workflows/publish-alloy-windows.yml'
 permissions:
   contents: read
 

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -30,6 +30,23 @@ jobs:
   windows:
     runs-on: windows-2022
     steps:
+      - name: Wait for Docker to be ready
+        run: |
+          $retries = 0
+          $maxRetries = 30
+          while ($retries -lt $maxRetries) {
+            docker info 2>$null
+            if ($LASTEXITCODE -eq 0) {
+              Write-Host "Docker is ready."
+              exit 0
+            }
+            $retries++
+            Write-Host "Waiting for Docker to be ready... (attempt $retries/$maxRetries)"
+            Start-Sleep -Seconds 2
+          }
+          Write-Host "Docker did not become ready after $maxRetries attempts."
+          exit 1
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -30,22 +30,13 @@ jobs:
   windows:
     runs-on: windows-2022
     steps:
-      - name: Wait for Docker to be ready
+      - name: Ensure Docker is running (Docker issue workaround)
+        id: docker-workaround
         run: |
-          $retries = 0
-          $maxRetries = 30
-          while ($retries -lt $maxRetries) {
-            docker info 2>$null
-            if ($LASTEXITCODE -eq 0) {
-              Write-Host "Docker is ready."
-              exit 0
-            }
-            $retries++
-            Write-Host "Waiting for Docker to be ready... (attempt $retries/$maxRetries)"
-            Start-Sleep -Seconds 2
+          $dockerState = Get-Service -Name "docker"
+          if ($dockerState.Status -ne "Running") {
+            Start-Service -Name "docker"
           }
-          Write-Host "Docker did not become ready after $maxRetries attempts."
-          exit 1
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/publish-alloy-windows.yml
+++ b/.github/workflows/publish-alloy-windows.yml
@@ -35,6 +35,23 @@ jobs:
         os: [windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Wait for Docker to be ready
+      run: |
+        $retries = 0
+        $maxRetries = 30
+        while ($retries -lt $maxRetries) {
+          docker info 2>$null
+          if ($LASTEXITCODE -eq 0) {
+            Write-Host "Docker is ready."
+            exit 0
+          }
+          $retries++
+          Write-Host "Waiting for Docker to be ready... (attempt $retries/$maxRetries)"
+          Start-Sleep -Seconds 2
+        }
+        Write-Host "Docker did not become ready after $maxRetries attempts."
+        exit 1
+
       # This step needs to run before "Checkout code".
       # That's because it generates a new file.
       # We don't want this file to end up in the repo directory.

--- a/.github/workflows/publish-alloy-windows.yml
+++ b/.github/workflows/publish-alloy-windows.yml
@@ -35,22 +35,13 @@ jobs:
         os: [windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Wait for Docker to be ready
+    - name: Ensure Docker is running (Docker issue workaround)
+      id: docker-workaround
       run: |
-        $retries = 0
-        $maxRetries = 30
-        while ($retries -lt $maxRetries) {
-          docker info 2>$null
-          if ($LASTEXITCODE -eq 0) {
-            Write-Host "Docker is ready."
-            exit 0
-          }
-          $retries++
-          Write-Host "Waiting for Docker to be ready... (attempt $retries/$maxRetries)"
-          Start-Sleep -Seconds 2
+        $dockerState = Get-Service -Name "docker"
+        if ($dockerState.Status -ne "Running") {
+          Start-Service -Name "docker"
         }
-        Write-Host "Docker did not become ready after $maxRetries attempts."
-        exit 1
 
       # This step needs to run before "Checkout code".
       # That's because it generates a new file.


### PR DESCRIPTION
To avoid errors such as this: https://github.com/grafana/alloy/actions/runs/23961165082