### PR TITLE
chore(loki): Add integration test for loki.source.docker

### DIFF
--- a/integration-tests/docker/README.md
+++ b/integration-tests/docker/README.md
@@ -32,7 +32,7 @@ Follow these steps to add a new integration test to the project:
 2. Create a new directory under the tests directory to house the files for the new test.
 3. Within the new test directory, create a file named `config.alloy` to hold the pipeline configuration you want to test.
 4. Create a `_test.go` file within the new test directory. This file should contain the Go code necessary to run the test and verify the data processing through the pipeline. All test file should have `alloyintegrationtests` as a build tag.
-5. If a test folder contains `test.yaml` this file will be read and parsed. This file can specify different setup requirements that the test have like mount or port mapping. See [config.go](./config.go) for the structure of the test configuration.
+5. If a test folder contains `test.yaml` this file will be read and parsed. This file can specify different setup requirements that the test have like mount or port mapping, and can also start additional containers before Alloy is started. Additional containers must specify `image`, and can optionally specify `build` to build and tag that image before the test starts. See [config.go](./config.go) for the structure of the test configuration.
 6. If a test folder contains `docker-compose.yaml` this file will be used instead of testcontainers to spin up services for the test.
 6. Ensure any data is written with a unique `test_name` label that matches your assertions.
    * Since the tests are run concurrently, each Alloy instance used for a test queries for data that will match the `test_name`.

--- a/integration-tests/docker/additional_containers.go
+++ b/integration-tests/docker/additional_containers.go
@@ -44,7 +44,7 @@ func startAdditionalContainers(ctx context.Context, absTestDir, networkName stri
 			Logger:           log.Default(),
 		})
 		if err != nil {
-			terminateAdditionalContainers(ctx, containers)
+			_ = terminateAdditionalContainers(ctx, containers)
 			return nil, fmt.Errorf("failed to start additional container %q: %w", containerCfg.Name, err)
 		}
 

--- a/integration-tests/docker/additional_containers.go
+++ b/integration-tests/docker/additional_containers.go
@@ -14,7 +14,7 @@ import (
 )
 
 func startAdditionalContainers(ctx context.Context, absTestDir, networkName string, cfg TestConfig) ([]testcontainers.Container, error) {
-	containers := make([]testcontainers.Container, 0, len(cfg.AdditionalContainers))
+	requests := make([]testcontainers.ContainerRequest, 0, len(cfg.AdditionalContainers))
 
 	for i, containerCfg := range cfg.AdditionalContainers {
 		if containerCfg.Image == "" {
@@ -38,17 +38,23 @@ func startAdditionalContainers(ctx context.Context, absTestDir, networkName stri
 			}
 		}
 
+		requests = append(requests, req)
+	}
+
+	containers := make([]testcontainers.Container, 0, len(cfg.AdditionalContainers))
+	for _, r := range requests {
 		container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-			ContainerRequest: req,
+			ContainerRequest: r,
 			Started:          true,
 			Logger:           log.Default(),
 		})
 		if err != nil {
 			_ = terminateAdditionalContainers(ctx, containers)
-			return nil, fmt.Errorf("failed to start additional container %q: %w", containerCfg.Name, err)
+			return nil, fmt.Errorf("failed to start additional container %q: %w", r.Name, err)
 		}
 
 		containers = append(containers, container)
+
 	}
 
 	return containers, nil

--- a/integration-tests/docker/additional_containers.go
+++ b/integration-tests/docker/additional_containers.go
@@ -54,7 +54,6 @@ func startAdditionalContainers(ctx context.Context, absTestDir, networkName stri
 		}
 
 		containers = append(containers, container)
-
 	}
 
 	return containers, nil

--- a/integration-tests/docker/additional_containers.go
+++ b/integration-tests/docker/additional_containers.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+
+	"github.com/testcontainers/testcontainers-go"
+)
+
+func startAdditionalContainers(ctx context.Context, absTestDir, networkName string, cfg TestConfig) ([]testcontainers.Container, error) {
+	containers := make([]testcontainers.Container, 0, len(cfg.AdditionalContainers))
+
+	for i, containerCfg := range cfg.AdditionalContainers {
+		if containerCfg.Image == "" {
+			return nil, fmt.Errorf("additional_containers[%d].image must be set", i)
+		}
+
+		if containerCfg.Name == "" {
+			return nil, fmt.Errorf("additional_containers[%d].name must be set", i)
+		}
+
+		req := testcontainers.ContainerRequest{
+			Name:     containerCfg.Name,
+			Image:    containerCfg.Image,
+			Cmd:      containerCfg.Command,
+			Networks: []string{networkName},
+		}
+
+		if containerCfg.Build.Context != "" {
+			if err := buildAdditionalContainerImage(absTestDir, containerCfg); err != nil {
+				return nil, fmt.Errorf("failed to build additional container %q: %w", containerCfg.Name, err)
+			}
+		}
+
+		container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+			ContainerRequest: req,
+			Started:          true,
+			Logger:           log.Default(),
+		})
+		if err != nil {
+			terminateAdditionalContainers(ctx, containers)
+			return nil, fmt.Errorf("failed to start additional container %q: %w", containerCfg.Name, err)
+		}
+
+		containers = append(containers, container)
+	}
+
+	return containers, nil
+}
+
+func buildAdditionalContainerImage(absTestDir string, cfg AdditionalContainerConfig) error {
+	buildContext := cfg.Build.Context
+	if !filepath.IsAbs(buildContext) {
+		buildContext = filepath.Join(absTestDir, buildContext)
+	}
+
+	args := []string{"build", "-t", cfg.Image}
+	if cfg.Build.Dockerfile != "" {
+		dockerfile := cfg.Build.Dockerfile
+		if !filepath.IsAbs(dockerfile) {
+			dockerfile = filepath.Join(buildContext, dockerfile)
+		}
+		args = append(args, "-f", dockerfile)
+	}
+	args = append(args, buildContext)
+
+	cmd := exec.Command("docker", args...)
+	cmd.Dir = absTestDir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("building image %q: %w", cfg.Image, err)
+	}
+
+	return nil
+}
+
+func terminateAdditionalContainers(ctx context.Context, containers []testcontainers.Container) error {
+	var (
+		wg   sync.WaitGroup
+		errs = make(chan error, len(containers))
+	)
+
+	for _, c := range containers {
+		wg.Go(func() {
+			if err := c.Terminate(ctx); err != nil {
+				errs <- err
+			}
+		})
+	}
+
+	wg.Wait()
+	close(errs)
+
+	var all []error
+	for err := range errs {
+		all = append(all, err)
+	}
+
+	return errors.Join(all...)
+}

--- a/integration-tests/docker/config.go
+++ b/integration-tests/docker/config.go
@@ -2,7 +2,8 @@ package main
 
 // TestConfig is used by tests to describe special setup requirements.
 type TestConfig struct {
-	Container ContainerConfig `yaml:"alloy_container"`
+	Container            ContainerConfig             `yaml:"alloy_container"`
+	AdditionalContainers []AdditionalContainerConfig `yaml:"additional_containers"`
 }
 
 // ContainerConfig is used to configure alloy container used for the test.
@@ -10,6 +11,8 @@ type ContainerConfig struct {
 	// UseMount when set to true will create "mount" directory inside test
 	// folder that will be mounted into the container.
 	UseMount bool `yaml:"use_mount"`
+	// UseDockerSock when set to true will mount the host Docker socket into the container.
+	UseDockerSock bool `yaml:"use_docker_sock"`
 	// Ports are all the port mappings required by the test.
 	// These will be configured and exposed for the container.
 	Ports []PortMapping `yaml:"ports"`
@@ -21,6 +24,26 @@ type ContainerConfig struct {
 	SecurityOpt []string `yaml:"security_opts"`
 	// PIDMode is the PID namespace to use for the container.
 	PIDMode string `yaml:"pid_mode"`
+}
+
+// AdditionalContainerConfig is used to configure additional containers used for the test.
+type AdditionalContainerConfig struct {
+	// Name is the Docker container name.
+	Name string `yaml:"name"`
+	// Image is the Docker image to run or tag built from Build.
+	Image string `yaml:"image"`
+	// Build describes how to build the image for this container.
+	Build AdditionalContainerBuildConfig `yaml:"build"`
+	// Command overrides the default image command.
+	Command []string `yaml:"command"`
+}
+
+// AdditionalContainerBuildConfig is used to build an additional container image.
+type AdditionalContainerBuildConfig struct {
+	// Context is the Docker build context directory.
+	Context string `yaml:"context"`
+	// Dockerfile is the Dockerfile path relative to Context.
+	Dockerfile string `yaml:"dockerfile"`
 }
 
 type PortMapping struct {

--- a/integration-tests/docker/tests/loki-docker/Dockerfile
+++ b/integration-tests/docker/tests/loki-docker/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox:1.36
+
+CMD ["sh", "-c", "printf 'line 1\nline 2\nline 3\n'; tail -f /dev/null"]

--- a/integration-tests/docker/tests/loki-docker/config.alloy
+++ b/integration-tests/docker/tests/loki-docker/config.alloy
@@ -1,0 +1,53 @@
+discovery.docker "test" {
+	host             = "unix:///var/run/docker.sock"
+	refresh_interval = "1s"
+}
+
+discovery.relabel "test" {
+	targets = discovery.docker.test.targets
+
+	rule {
+		source_labels = ["__meta_docker_container_name"]
+		regex         = "/producer.*"
+		action        = "keep"
+	}
+
+	rule {
+		source_labels = ["__meta_docker_container_name"]
+		regex         = "/(.*)"
+		target_label  = "container"
+		replacement   = "$1"
+	}
+}
+
+loki.source.docker "test" {
+	host             = "unix:///var/run/docker.sock"
+	targets          = discovery.relabel.test.output
+	forward_to       = [loki.process.test.receiver]
+	refresh_interval = "1s"
+}
+
+loki.process "test" {
+	forward_to = [loki.relabel.test.receiver]
+	
+	stage.static_labels {
+		values = {
+			test_name = "lokidocker",
+		}
+	}
+}
+
+loki.relabel "test" {
+	forward_to = [loki.write.test.receiver]
+
+	rule {
+		source_labels = ["container"]
+		target_label  = "service_name"
+	}
+}
+
+loki.write "test" {
+	endpoint {
+		url = "http://loki:3100/loki/api/v1/push"
+	}
+}

--- a/integration-tests/docker/tests/loki-docker/loki_docker_test.go
+++ b/integration-tests/docker/tests/loki-docker/loki_docker_test.go
@@ -1,0 +1,38 @@
+//go:build alloyintegrationtests
+
+package main
+
+import (
+	"testing"
+
+	"github.com/grafana/alloy/integration-tests/docker/common"
+)
+
+func TestLokiDocker(t *testing.T) {
+	common.AssertLogsPresent(t, 12,
+		common.ExpectedLogResult{
+			Labels: map[string]string{
+				"service_name": "producer-1",
+			},
+			EntryCount: 3,
+		},
+		common.ExpectedLogResult{
+			Labels: map[string]string{
+				"service_name": "producer-2",
+			},
+			EntryCount: 3,
+		},
+		common.ExpectedLogResult{
+			Labels: map[string]string{
+				"service_name": "producer-3",
+			},
+			EntryCount: 3,
+		},
+		common.ExpectedLogResult{
+			Labels: map[string]string{
+				"service_name": "producer-4",
+			},
+			EntryCount: 3,
+		},
+	)
+}

--- a/integration-tests/docker/tests/loki-docker/test.yaml
+++ b/integration-tests/docker/tests/loki-docker/test.yaml
@@ -1,0 +1,17 @@
+alloy_container:
+  use_docker_sock: true
+
+additional_containers:
+  - name: producer-1
+    image: loki-docker-producer:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
+  - name: producer-2
+    image: loki-docker-producer:latest
+  - name: producer-3
+    image: loki-docker-producer:latest
+  - name: producer-4
+    image: loki-docker-producer:latest
+ 
+ 

--- a/integration-tests/docker/tests/otlp-metrics-default-engine/docker-compose.yaml
+++ b/integration-tests/docker/tests/otlp-metrics-default-engine/docker-compose.yaml
@@ -12,8 +12,6 @@ services:
       ]
     volumes:
       - ./config.alloy:/etc/alloy/config.alloy:ro
-    ports:
-      - "12355:12345"
     healthcheck:
       test: ["CMD", "bash", "-c", "echo > /dev/tcp/localhost/12345"]
       interval: 2s

--- a/integration-tests/docker/tests/otlp-metrics-otel-engine-using-alloyengine-extension/docker-compose.yaml
+++ b/integration-tests/docker/tests/otlp-metrics-otel-engine-using-alloyengine-extension/docker-compose.yaml
@@ -5,8 +5,6 @@ services:
     volumes:
       - ./config.yaml:/etc/alloy/config.yaml:ro
       - ./alloy-config.alloy:/etc/alloy/alloy-config.alloy:ro
-    ports:
-      - "13143:13133"
     healthcheck:
       test: ["CMD", "bash", "-c", "echo > /dev/tcp/localhost/13133"]
       interval: 2s

--- a/integration-tests/docker/tests/otlp-metrics-otel-engine/docker-compose.yaml
+++ b/integration-tests/docker/tests/otlp-metrics-otel-engine/docker-compose.yaml
@@ -4,8 +4,6 @@ services:
     entrypoint: ["/bin/otelcol", "--config=/etc/alloy/config.yaml"]
     volumes:
       - ./config.yaml:/etc/alloy/config.yaml:ro
-    ports:
-      - "13133:13133"
     healthcheck:
       test: ["CMD", "bash", "-c", "echo > /dev/tcp/localhost/13133"]
       interval: 2s

--- a/integration-tests/docker/utils.go
+++ b/integration-tests/docker/utils.go
@@ -23,8 +23,11 @@ import (
 	"github.com/grafana/alloy/integration-tests/docker/common"
 )
 
-const alloyImageName = "alloy-integration-tests"
-const dockerComposeFile = "docker-compose.yaml"
+const (
+	alloyImageName    = "alloy-integration-tests"
+	dockerComposeFile = "docker-compose.yaml"
+	networkName       = "alloy-integration-tests_integration-tests"
+)
 
 type TestLog struct {
 	TestDir    string
@@ -126,6 +129,14 @@ func createContainerRequest(dirName, testDir string, port int, networkName strin
 			ReadOnly: true,
 		})
 	}
+	if cfg.Container.UseDockerSock {
+		mounts = append(mounts, mount.Mount{
+			Type:     mount.TypeBind,
+			Source:   "/var/run/docker.sock",
+			Target:   "/var/run/docker.sock",
+			ReadOnly: false,
+		})
+	}
 
 	cmd := []string{"run", "/etc/alloy/config.alloy", "--server.http.listen-addr", fmt.Sprintf("0.0.0.0:%d", port), "--stability.level", "experimental"}
 
@@ -219,8 +230,27 @@ func runTestWithTestcontainers(ctx context.Context, testDir string, port int, st
 		}
 	}
 
+	additionalContainers, err := startAdditionalContainers(ctx, absTestDir, networkName, cfg)
+	if err != nil {
+		addLog(TestLog{
+			TestDir:  dirName,
+			AlloyLog: err.Error(),
+			IsError:  true,
+		})
+		return
+	}
+	defer func() {
+		if err := terminateAdditionalContainers(ctx, additionalContainers); err != nil {
+			addLog(TestLog{
+				TestDir:  dirName,
+				AlloyLog: fmt.Sprintf("failed to terminate additional containers: %v", err),
+				IsError:  true,
+			})
+		}
+	}()
+
 	// Create container request
-	req := createContainerRequest(dirName, testDir, port, "alloy-integration-tests_integration-tests", containerFiles, cfg)
+	req := createContainerRequest(dirName, testDir, port, networkName, containerFiles, cfg)
 
 	// Start container
 	containerStartTime := time.Now()


### PR DESCRIPTION
### Pull Request Details

Add Docker integration test for `loki.source.docker`. This test also includes a simple `loki.relabel` and `loki.process` stages.

### Issue(s) fixed by this Pull Request

Part of: https://github.com/grafana/alloy/issues/4953

### Notes to the Reviewer

This also extends the Docker integration-test so each test can start additional containers, build their images, and mount the Docker socket into the Alloy container.

### PR Checklist

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
