### PR TITLE
feat(loki/stages): add JSON tags to loki process stage config structs

### DIFF
--- a/internal/component/loki/process/metric/counters.go
+++ b/internal/component/loki/process/metric/counters.go
@@ -18,17 +18,17 @@ const (
 // CounterConfig defines a counter metric whose value only goes up.
 type CounterConfig struct {
 	// Shared fields
-	Name        string        `alloy:"name,attr"`
-	Description string        `alloy:"description,attr,optional"`
-	Source      string        `alloy:"source,attr,optional"`
-	Prefix      string        `alloy:"prefix,attr,optional"`
-	MaxIdle     time.Duration `alloy:"max_idle_duration,attr,optional"`
-	Value       string        `alloy:"value,attr,optional"`
+	Name        string        `alloy:"name,attr"                       json:"name"`
+	Description string        `alloy:"description,attr,optional"       json:"description,omitempty"`
+	Source      string        `alloy:"source,attr,optional"            json:"source,omitempty"`
+	Prefix      string        `alloy:"prefix,attr,optional"            json:"prefix,omitempty"`
+	MaxIdle     time.Duration `alloy:"max_idle_duration,attr,optional" json:"-"` // not supported in CRD: time.Duration is nanosecond int64 in JSON
+	Value       string        `alloy:"value,attr,optional"             json:"value,omitempty"`
 
 	// Counter-specific fields
-	Action          string `alloy:"action,attr"`
-	MatchAll        bool   `alloy:"match_all,attr,optional"`
-	CountEntryBytes bool   `alloy:"count_entry_bytes,attr,optional"`
+	Action          string `alloy:"action,attr"                    json:"action"`
+	MatchAll        bool   `alloy:"match_all,attr,optional"        json:"matchAll,omitempty"`
+	CountEntryBytes bool   `alloy:"count_entry_bytes,attr,optional" json:"countEntryBytes,omitempty"`
 }
 
 // DefaultCounterConfig sets the default for a Counter.

--- a/internal/component/loki/process/metric/gauges.go
+++ b/internal/component/loki/process/metric/gauges.go
@@ -29,15 +29,15 @@ var DefaultGaugeConfig = GaugeConfig{
 // GaugeConfig defines a gauge metric whose value can go up or down.
 type GaugeConfig struct {
 	// Shared fields
-	Name        string        `alloy:"name,attr"`
-	Description string        `alloy:"description,attr,optional"`
-	Source      string        `alloy:"source,attr,optional"`
-	Prefix      string        `alloy:"prefix,attr,optional"`
-	MaxIdle     time.Duration `alloy:"max_idle_duration,attr,optional"`
-	Value       string        `alloy:"value,attr,optional"`
+	Name        string        `alloy:"name,attr"                       json:"name"`
+	Description string        `alloy:"description,attr,optional"       json:"description,omitempty"`
+	Source      string        `alloy:"source,attr,optional"            json:"source,omitempty"`
+	Prefix      string        `alloy:"prefix,attr,optional"            json:"prefix,omitempty"`
+	MaxIdle     time.Duration `alloy:"max_idle_duration,attr,optional" json:"-"` // not supported in CRD: time.Duration is nanosecond int64 in JSON
+	Value       string        `alloy:"value,attr,optional"             json:"value,omitempty"`
 
 	// Gauge-specific fields
-	Action string `alloy:"action,attr"`
+	Action string `alloy:"action,attr" json:"action"`
 }
 
 // SetToDefault implements syntax.Defaulter.

--- a/internal/component/loki/process/metric/histograms.go
+++ b/internal/component/loki/process/metric/histograms.go
@@ -18,15 +18,15 @@ var DefaultHistogramConfig = HistogramConfig{
 // HistogramConfig defines a histogram metric whose values are bucketed.
 type HistogramConfig struct {
 	// Shared fields
-	Name        string        `alloy:"name,attr"`
-	Description string        `alloy:"description,attr,optional"`
-	Source      string        `alloy:"source,attr,optional"`
-	Prefix      string        `alloy:"prefix,attr,optional"`
-	MaxIdle     time.Duration `alloy:"max_idle_duration,attr,optional"`
-	Value       string        `alloy:"value,attr,optional"`
+	Name        string        `alloy:"name,attr"                       json:"name"`
+	Description string        `alloy:"description,attr,optional"       json:"description,omitempty"`
+	Source      string        `alloy:"source,attr,optional"            json:"source,omitempty"`
+	Prefix      string        `alloy:"prefix,attr,optional"            json:"prefix,omitempty"`
+	MaxIdle     time.Duration `alloy:"max_idle_duration,attr,optional" json:"-"` // not supported in CRD: time.Duration is nanosecond int64 in JSON
+	Value       string        `alloy:"value,attr,optional"             json:"value,omitempty"`
 
 	// Histogram-specific fields
-	Buckets []float64 `alloy:"buckets,attr"`
+	Buckets []float64 `alloy:"buckets,attr" json:"buckets"`
 }
 
 // SetToDefault implements syntax.Defaulter.

--- a/internal/component/loki/process/stages/cri.go
+++ b/internal/component/loki/process/stages/cri.go
@@ -19,9 +19,9 @@ import (
 // CRIConfig is an empty struct that is used to enable a pre-defined pipeline
 // for decoding entries that are using the CRI logging format.
 type CRIConfig struct {
-	MaxPartialLines            int    `alloy:"max_partial_lines,attr,optional"`
-	MaxPartialLineSize         uint64 `alloy:"max_partial_line_size,attr,optional"`
-	MaxPartialLineSizeTruncate bool   `alloy:"max_partial_line_size_truncate,attr,optional"`
+	MaxPartialLines            int    `alloy:"max_partial_lines,attr,optional"             json:"maxPartialLines,omitempty"`
+	MaxPartialLineSize         uint64 `alloy:"max_partial_line_size,attr,optional"         json:"maxPartialLineSize,omitempty"`
+	MaxPartialLineSizeTruncate bool   `alloy:"max_partial_line_size_truncate,attr,optional" json:"maxPartialLineSizeTruncate,omitempty"`
 }
 
 var (

--- a/internal/component/loki/process/stages/drop.go
+++ b/internal/component/loki/process/stages/drop.go
@@ -31,13 +31,13 @@ var (
 
 // DropConfig contains the configuration for a dropStage
 type DropConfig struct {
-	DropReason string           `alloy:"drop_counter_reason,attr,optional"`
-	Source     string           `alloy:"source,attr,optional"`
-	Value      string           `alloy:"value,attr,optional"`
-	Separator  string           `alloy:"separator,attr,optional"`
-	Expression string           `alloy:"expression,attr,optional"`
-	OlderThan  time.Duration    `alloy:"older_than,attr,optional"`
-	LongerThan units.Base2Bytes `alloy:"longer_than,attr,optional"`
+	DropReason string           `alloy:"drop_counter_reason,attr,optional" json:"dropReason,omitempty"`
+	Source     string           `alloy:"source,attr,optional"              json:"source,omitempty"`
+	Value      string           `alloy:"value,attr,optional"               json:"value,omitempty"`
+	Separator  string           `alloy:"separator,attr,optional"           json:"separator,omitempty"`
+	Expression string           `alloy:"expression,attr,optional"          json:"expression,omitempty"`
+	OlderThan  time.Duration    `alloy:"older_than,attr,optional"          json:"-"`                    // not supported in CRD: time.Duration is nanosecond int64 in JSON
+	LongerThan units.Base2Bytes `alloy:"longer_than,attr,optional"         json:"longerThan,omitempty"` // TextMarshaler: serializes as "5MiB"
 }
 
 // validateDropConfig validates the DropConfig for the dropStage

--- a/internal/component/loki/process/stages/geoip.go
+++ b/internal/component/loki/process/stages/geoip.go
@@ -56,10 +56,10 @@ var fields = map[GeoIPFields]string{
 
 // GeoIPConfig represents GeoIP stage config
 type GeoIPConfig struct {
-	DB            string            `alloy:"db,attr"`
-	Source        *string           `alloy:"source,attr"`
-	DBType        string            `alloy:"db_type,attr,optional"`
-	CustomLookups map[string]string `alloy:"custom_lookups,attr,optional"`
+	DB            string            `alloy:"db,attr"                          json:"db"`
+	Source        *string           `alloy:"source,attr"                      json:"source"`
+	DBType        string            `alloy:"db_type,attr,optional"            json:"dbType,omitempty"`
+	CustomLookups map[string]string `alloy:"custom_lookups,attr,optional"     json:"customLookups,omitempty"`
 }
 
 func validateGeoIPConfig(c GeoIPConfig) (map[string]jmespath.JMESPath, error) {

--- a/internal/component/loki/process/stages/json.go
+++ b/internal/component/loki/process/stages/json.go
@@ -22,9 +22,9 @@ const (
 
 // JSONConfig represents a JSON Stage configuration
 type JSONConfig struct {
-	Expressions   map[string]string `alloy:"expressions,attr"`
-	Source        *string           `alloy:"source,attr,optional"`
-	DropMalformed bool              `alloy:"drop_malformed,attr,optional"`
+	Expressions   map[string]string `alloy:"expressions,attr"              json:"expressions"`
+	Source        *string           `alloy:"source,attr,optional"          json:"source,omitempty"`
+	DropMalformed bool              `alloy:"drop_malformed,attr,optional"  json:"dropMalformed,omitempty"`
 }
 
 // validateJSONConfig validates a json config and returns a map of necessary jmespath expressions.

--- a/internal/component/loki/process/stages/label_drop.go
+++ b/internal/component/loki/process/stages/label_drop.go
@@ -12,7 +12,7 @@ var ErrEmptyLabelDropStageConfig = errors.New("labeldrop stage config cannot be 
 
 // LabelDropConfig contains the slice of labels to be dropped.
 type LabelDropConfig struct {
-	Values []string `alloy:"values,attr"`
+	Values []string `alloy:"values,attr" json:"values"`
 }
 
 func newLabelDropStage(config LabelDropConfig) (Stage, error) {

--- a/internal/component/loki/process/stages/label_keep.go
+++ b/internal/component/loki/process/stages/label_keep.go
@@ -12,7 +12,7 @@ var ErrEmptyLabelAllowStageConfig = errors.New("labelallow stage config cannot b
 
 // LabelAllowConfig contains the slice of labels to allow through.
 type LabelAllowConfig struct {
-	Values []string `alloy:"values,attr"`
+	Values []string `alloy:"values,attr" json:"values"`
 }
 
 func newLabelAllowStage(config LabelAllowConfig) (Stage, error) {

--- a/internal/component/loki/process/stages/labels.go
+++ b/internal/component/loki/process/stages/labels.go
@@ -23,8 +23,8 @@ const (
 
 // LabelsConfig is a set of labels to be extracted
 type LabelsConfig struct {
-	Values     map[string]*string `alloy:"values,attr"`
-	SourceType SourceType         `alloy:"source_type,attr,optional"`
+	Values     map[string]*string `alloy:"values,attr"                json:"values"`
+	SourceType SourceType         `alloy:"source_type,attr,optional"  json:"sourceType,omitempty"`
 }
 
 // validateLabelsConfig validates the Label stage configuration

--- a/internal/component/loki/process/stages/limit.go
+++ b/internal/component/loki/process/stages/limit.go
@@ -24,11 +24,11 @@ const MinReasonableMaxDistinctLabels = 10000 // 80bytes per rate.Limiter ~ 1MiB 
 
 // LimitConfig sets up a Limit stage.
 type LimitConfig struct {
-	Rate              float64 `alloy:"rate,attr"`
-	Burst             int     `alloy:"burst,attr"`
-	Drop              bool    `alloy:"drop,attr,optional"`
-	ByLabelName       string  `alloy:"by_label_name,attr,optional"`
-	MaxDistinctLabels int     `alloy:"max_distinct_labels,attr,optional"`
+	Rate              float64 `alloy:"rate,attr"                        json:"rate"`
+	Burst             int     `alloy:"burst,attr"                       json:"burst"`
+	Drop              bool    `alloy:"drop,attr,optional"               json:"drop,omitempty"`
+	ByLabelName       string  `alloy:"by_label_name,attr,optional"      json:"byLabelName,omitempty"`
+	MaxDistinctLabels int     `alloy:"max_distinct_labels,attr,optional" json:"maxDistinctLabels,omitempty"`
 }
 
 func newLimitStage(logger log.Logger, cfg LimitConfig, registerer prometheus.Registerer) (Stage, error) {

--- a/internal/component/loki/process/stages/logfmt.go
+++ b/internal/component/loki/process/stages/logfmt.go
@@ -20,8 +20,8 @@ var (
 
 // LogfmtConfig represents a logfmt Stage configuration
 type LogfmtConfig struct {
-	Mapping map[string]string `alloy:"mapping,attr"`
-	Source  string            `alloy:"source,attr,optional"`
+	Mapping map[string]string `alloy:"mapping,attr"          json:"mapping"`
+	Source  string            `alloy:"source,attr,optional"  json:"source,omitempty"`
 }
 
 // validateLogfmtConfig validates a logfmt stage config and returns an inverse mapping of configured mapping.

--- a/internal/component/loki/process/stages/luhn.go
+++ b/internal/component/loki/process/stages/luhn.go
@@ -11,10 +11,10 @@ import (
 
 // LuhnFilterConfig configures a processing stage that filters out Luhn-valid numbers.
 type LuhnFilterConfig struct {
-	Replacement string  `alloy:"replacement,attr,optional"`
-	Source      *string `alloy:"source,attr,optional"`
-	MinLength   int     `alloy:"min_length,attr,optional"`
-	Delimiters  string  `alloy:"delimiters,attr,optional"`
+	Replacement string  `alloy:"replacement,attr,optional"  json:"replacement,omitempty"`
+	Source      *string `alloy:"source,attr,optional"       json:"source,omitempty"`
+	MinLength   int     `alloy:"min_length,attr,optional"   json:"minLength,omitempty"`
+	Delimiters  string  `alloy:"delimiters,attr,optional"   json:"delimiters,omitempty"`
 }
 
 // validateLuhnFilterConfig validates the LuhnFilterConfig.

--- a/internal/component/loki/process/stages/match.go
+++ b/internal/component/loki/process/stages/match.go
@@ -27,11 +27,11 @@ var (
 
 // MatchConfig contains the configuration for a matcherStage
 type MatchConfig struct {
-	Selector     string        `alloy:"selector,attr"`
-	Stages       []StageConfig `alloy:"stage,enum,optional"`
-	Action       string        `alloy:"action,attr,optional"`
-	PipelineName string        `alloy:"pipeline_name,attr,optional"`
-	DropReason   string        `alloy:"drop_counter_reason,attr,optional"`
+	Selector     string        `alloy:"selector,attr"                     json:"selector"`
+	Stages       []StageConfig `alloy:"stage,enum,optional"               json:"stages,omitempty"`
+	Action       string        `alloy:"action,attr,optional"              json:"action,omitempty"`
+	PipelineName string        `alloy:"pipeline_name,attr,optional"       json:"pipelineName,omitempty"`
+	DropReason   string        `alloy:"drop_counter_reason,attr,optional" json:"dropReason,omitempty"`
 }
 
 // validateMatcherConfig validates the MatcherConfig for the matcherStage

--- a/internal/component/loki/process/stages/metric.go
+++ b/internal/component/loki/process/stages/metric.go
@@ -22,14 +22,14 @@ const (
 
 // MetricConfig is a single metrics configuration.
 type MetricConfig struct {
-	Counter   *metric.CounterConfig   `alloy:"counter,block,optional"`
-	Gauge     *metric.GaugeConfig     `alloy:"gauge,block,optional"`
-	Histogram *metric.HistogramConfig `alloy:"histogram,block,optional"`
+	Counter   *metric.CounterConfig   `alloy:"counter,block,optional"   json:"counter,omitempty"`
+	Gauge     *metric.GaugeConfig     `alloy:"gauge,block,optional"     json:"gauge,omitempty"`
+	Histogram *metric.HistogramConfig `alloy:"histogram,block,optional" json:"histogram,omitempty"`
 }
 
 // MetricsConfig is a set of configured metrics.
 type MetricsConfig struct {
-	Metrics []MetricConfig `alloy:"metric,enum,optional"`
+	Metrics []MetricConfig `alloy:"metric,enum,optional" json:"metrics,omitempty"`
 }
 
 type cfgCollector struct {

--- a/internal/component/loki/process/stages/output.go
+++ b/internal/component/loki/process/stages/output.go
@@ -19,7 +19,7 @@ var (
 // OutputConfig initializes a configuration stage which sets the log line to a
 // value from the extracted map.
 type OutputConfig struct {
-	Source string `alloy:"source,attr"`
+	Source string `alloy:"source,attr" json:"source"`
 }
 
 // newOutputStage creates a new outputStage

--- a/internal/component/loki/process/stages/pack.go
+++ b/internal/component/loki/process/stages/pack.go
@@ -105,8 +105,8 @@ func (w Packed) MarshalJSON() ([]byte, error) {
 
 // PackConfig contains the configuration for a packStage
 type PackConfig struct {
-	Labels          []string `alloy:"labels,attr"`
-	IngestTimestamp bool     `alloy:"ingest_timestamp,attr,optional"`
+	Labels          []string `alloy:"labels,attr"                    json:"labels"`
+	IngestTimestamp bool     `alloy:"ingest_timestamp,attr,optional" json:"ingestTimestamp,omitempty"`
 }
 
 // DefaultPackConfig sets the defaults.

--- a/internal/component/loki/process/stages/pattern.go
+++ b/internal/component/loki/process/stages/pattern.go
@@ -23,9 +23,9 @@ var (
 // extract values from log lines into the shared values map.
 // See https://grafana.com/docs/loki/latest/query/log_queries/#pattern
 type PatternConfig struct {
-	Pattern          string  `alloy:"pattern,attr"`
-	Source           *string `alloy:"source,attr,optional"`
-	LabelsFromGroups bool    `alloy:"labels_from_groups,attr,optional"`
+	Pattern          string  `alloy:"pattern,attr"                   json:"pattern"`
+	Source           *string `alloy:"source,attr,optional"           json:"source,omitempty"`
+	LabelsFromGroups bool    `alloy:"labels_from_groups,attr,optional" json:"labelsFromGroups,omitempty"`
 }
 
 // validatePatternConfig validates the config and return a regex

--- a/internal/component/loki/process/stages/pipeline.go
+++ b/internal/component/loki/process/stages/pipeline.go
@@ -16,36 +16,36 @@ import (
 // We define these as pointers types so we can use reflection to check that
 // exactly one is set.
 type StageConfig struct {
-	CRIConfig                    *CRIConfig                    `alloy:"cri,block,optional"`
-	DecolorizeConfig             *DecolorizeConfig             `alloy:"decolorize,block,optional"`
-	DockerConfig                 *DockerConfig                 `alloy:"docker,block,optional"`
-	DropConfig                   *DropConfig                   `alloy:"drop,block,optional"`
-	EventLogMessageConfig        *EventLogMessageConfig        `alloy:"eventlogmessage,block,optional"`
-	GeoIPConfig                  *GeoIPConfig                  `alloy:"geoip,block,optional"`
-	JSONConfig                   *JSONConfig                   `alloy:"json,block,optional"`
-	LabelAllowConfig             *LabelAllowConfig             `alloy:"label_keep,block,optional"`
-	LabelDropConfig              *LabelDropConfig              `alloy:"label_drop,block,optional"`
-	LabelsConfig                 *LabelsConfig                 `alloy:"labels,block,optional"`
-	LimitConfig                  *LimitConfig                  `alloy:"limit,block,optional"`
-	LogfmtConfig                 *LogfmtConfig                 `alloy:"logfmt,block,optional"`
-	LuhnFilterConfig             *LuhnFilterConfig             `alloy:"luhn,block,optional"`
-	MatchConfig                  *MatchConfig                  `alloy:"match,block,optional"`
-	MetricsConfig                *MetricsConfig                `alloy:"metrics,block,optional"`
-	MultilineConfig              *MultilineConfig              `alloy:"multiline,block,optional"`
-	OutputConfig                 *OutputConfig                 `alloy:"output,block,optional"`
-	PackConfig                   *PackConfig                   `alloy:"pack,block,optional"`
-	PatternConfig                *PatternConfig                `alloy:"pattern,block,optional"`
-	RegexConfig                  *RegexConfig                  `alloy:"regex,block,optional"`
-	ReplaceConfig                *ReplaceConfig                `alloy:"replace,block,optional"`
-	StaticLabelsConfig           *StaticLabelsConfig           `alloy:"static_labels,block,optional"`
-	StructuredMetadata           *StructuredMetadataConfig     `alloy:"structured_metadata,block,optional"`
-	StructuredMetadataDropConfig *StructuredMetadataDropConfig `alloy:"structured_metadata_drop,block,optional"`
-	SamplingConfig               *SamplingConfig               `alloy:"sampling,block,optional"`
-	TemplateConfig               *TemplateConfig               `alloy:"template,block,optional"`
-	TenantConfig                 *TenantConfig                 `alloy:"tenant,block,optional"`
-	TruncateConfig               *TruncateConfig               `alloy:"truncate,block,optional"`
-	TimestampConfig              *TimestampConfig              `alloy:"timestamp,block,optional"`
-	WindowsEventConfig           *WindowsEventConfig           `alloy:"windowsevent,block,optional"`
+	CRIConfig                    *CRIConfig                    `alloy:"cri,block,optional"                    json:"cri,omitempty"`
+	DecolorizeConfig             *DecolorizeConfig             `alloy:"decolorize,block,optional"             json:"decolorize,omitempty"`
+	DockerConfig                 *DockerConfig                 `alloy:"docker,block,optional"                 json:"docker,omitempty"`
+	DropConfig                   *DropConfig                   `alloy:"drop,block,optional"                   json:"drop,omitempty"`
+	EventLogMessageConfig        *EventLogMessageConfig        `alloy:"eventlogmessage,block,optional"        json:"eventlogmessage,omitempty"`
+	GeoIPConfig                  *GeoIPConfig                  `alloy:"geoip,block,optional"                  json:"geoip,omitempty"`
+	JSONConfig                   *JSONConfig                   `alloy:"json,block,optional"                   json:"json,omitempty"`
+	LabelAllowConfig             *LabelAllowConfig             `alloy:"label_keep,block,optional"             json:"label_keep,omitempty"`
+	LabelDropConfig              *LabelDropConfig              `alloy:"label_drop,block,optional"             json:"label_drop,omitempty"`
+	LabelsConfig                 *LabelsConfig                 `alloy:"labels,block,optional"                 json:"labels,omitempty"`
+	LimitConfig                  *LimitConfig                  `alloy:"limit,block,optional"                  json:"limit,omitempty"`
+	LogfmtConfig                 *LogfmtConfig                 `alloy:"logfmt,block,optional"                 json:"logfmt,omitempty"`
+	LuhnFilterConfig             *LuhnFilterConfig             `alloy:"luhn,block,optional"                   json:"luhn,omitempty"`
+	MatchConfig                  *MatchConfig                  `alloy:"match,block,optional"                  json:"match,omitempty"`
+	MetricsConfig                *MetricsConfig                `alloy:"metrics,block,optional"                json:"metrics,omitempty"`
+	MultilineConfig              *MultilineConfig              `alloy:"multiline,block,optional"              json:"multiline,omitempty"`
+	OutputConfig                 *OutputConfig                 `alloy:"output,block,optional"                 json:"output,omitempty"`
+	PackConfig                   *PackConfig                   `alloy:"pack,block,optional"                   json:"pack,omitempty"`
+	PatternConfig                *PatternConfig                `alloy:"pattern,block,optional"                json:"pattern,omitempty"`
+	RegexConfig                  *RegexConfig                  `alloy:"regex,block,optional"                  json:"regex,omitempty"`
+	ReplaceConfig                *ReplaceConfig                `alloy:"replace,block,optional"                json:"replace,omitempty"`
+	StaticLabelsConfig           *StaticLabelsConfig           `alloy:"static_labels,block,optional"          json:"static_labels,omitempty"`
+	StructuredMetadata           *StructuredMetadataConfig     `alloy:"structured_metadata,block,optional"    json:"structured_metadata,omitempty"`
+	StructuredMetadataDropConfig *StructuredMetadataDropConfig `alloy:"structured_metadata_drop,block,optional" json:"structured_metadata_drop,omitempty"`
+	SamplingConfig               *SamplingConfig               `alloy:"sampling,block,optional"               json:"sampling,omitempty"`
+	TemplateConfig               *TemplateConfig               `alloy:"template,block,optional"               json:"template,omitempty"`
+	TenantConfig                 *TenantConfig                 `alloy:"tenant,block,optional"                 json:"tenant,omitempty"`
+	TruncateConfig               *TruncateConfig               `alloy:"truncate,block,optional"               json:"truncate,omitempty"`
+	TimestampConfig              *TimestampConfig              `alloy:"timestamp,block,optional"              json:"timestamp,omitempty"`
+	WindowsEventConfig           *WindowsEventConfig           `alloy:"windowsevent,block,optional"           json:"windowsevent,omitempty"`
 }
 
 // Pipeline pass down a log entry to each stage for mutation and/or label extraction.

--- a/internal/component/loki/process/stages/regex.go
+++ b/internal/component/loki/process/stages/regex.go
@@ -23,9 +23,9 @@ var (
 // RegexConfig configures a processing stage uses regular expressions to
 // extract values from log lines into the shared values map.
 type RegexConfig struct {
-	Expression       string  `alloy:"expression,attr"`
-	Source           *string `alloy:"source,attr,optional"`
-	LabelsFromGroups bool    `alloy:"labels_from_groups,attr,optional"`
+	Expression       string  `alloy:"expression,attr"                   json:"expression"`
+	Source           *string `alloy:"source,attr,optional"              json:"source,omitempty"`
+	LabelsFromGroups bool    `alloy:"labels_from_groups,attr,optional"  json:"labelsFromGroups,omitempty"`
 }
 
 // validateRegexConfig validates the config and return a regex

--- a/internal/component/loki/process/stages/replace.go
+++ b/internal/component/loki/process/stages/replace.go
@@ -22,9 +22,9 @@ func init() {
 
 // ReplaceConfig contains a regexStage configuration
 type ReplaceConfig struct {
-	Expression string `alloy:"expression,attr"`
-	Source     string `alloy:"source,attr,optional"`
-	Replace    string `alloy:"replace,attr,optional"`
+	Expression string `alloy:"expression,attr"          json:"expression"`
+	Source     string `alloy:"source,attr,optional"     json:"source,omitempty"`
+	Replace    string `alloy:"replace,attr,optional"    json:"replace,omitempty"`
 }
 
 func getExpressionRegex(c ReplaceConfig) (*regexp.Regexp, error) {

--- a/internal/component/loki/process/stages/sampling.go
+++ b/internal/component/loki/process/stages/sampling.go
@@ -19,8 +19,8 @@ var (
 
 // SamplingConfig contains the configuration for a samplingStage
 type SamplingConfig struct {
-	DropReason   string  `alloy:"drop_counter_reason,attr,optional"`
-	SamplingRate float64 `alloy:"rate,attr"`
+	DropReason   string  `alloy:"drop_counter_reason,attr,optional" json:"dropReason,omitempty"`
+	SamplingRate float64 `alloy:"rate,attr"                         json:"rate"`
 }
 
 func (s *SamplingConfig) SetToDefault() {

--- a/internal/component/loki/process/stages/static_labels.go
+++ b/internal/component/loki/process/stages/static_labels.go
@@ -14,7 +14,7 @@ var ErrEmptyStaticLabelStageConfig = errors.New("static_labels stage config cann
 
 // StaticLabelsConfig contains a map of static labels to be set.
 type StaticLabelsConfig struct {
-	Values map[string]*string `alloy:"values,attr"`
+	Values map[string]*string `alloy:"values,attr" json:"values"`
 }
 
 func newStaticLabelsStage(_ log.Logger, config StaticLabelsConfig) (Stage, error) {

--- a/internal/component/loki/process/stages/structured_metadata.go
+++ b/internal/component/loki/process/stages/structured_metadata.go
@@ -13,8 +13,8 @@ import (
 )
 
 type StructuredMetadataConfig struct {
-	Values map[string]*string `alloy:"values,attr,optional"`
-	Regex  string             `alloy:"regex,attr,optional"`
+	Values map[string]*string `alloy:"values,attr,optional" json:"values,omitempty"`
+	Regex  string             `alloy:"regex,attr,optional"  json:"regex,omitempty"`
 }
 
 // validateStructuredMetadataConfig validates the structured metadata stage config.

--- a/internal/component/loki/process/stages/structured_metadata_drop.go
+++ b/internal/component/loki/process/stages/structured_metadata_drop.go
@@ -13,7 +13,7 @@ var ErrEmptyStructuredMetadataDropStageConfig = errors.New("structured_metadata_
 
 // StructuredMetadataDropConfig contains the slice of structured metadata to be dropped.
 type StructuredMetadataDropConfig struct {
-	Values []string `alloy:"values,attr"`
+	Values []string `alloy:"values,attr" json:"values"`
 }
 
 func newStructuredMetadataDropStage(logger log.Logger, config StructuredMetadataDropConfig) (Stage, error) {

--- a/internal/component/loki/process/stages/template.go
+++ b/internal/component/loki/process/stages/template.go
@@ -67,8 +67,8 @@ var _ syntax.Validator = (*TemplateConfig)(nil)
 
 // TemplateConfig configures template value extraction.
 type TemplateConfig struct {
-	Source   string   `alloy:"source,attr"`
-	Template Template `alloy:"template,attr"`
+	Source   string   `alloy:"source,attr"    json:"source"`
+	Template Template `alloy:"template,attr"  json:"template"`
 }
 
 func (t *TemplateConfig) Validate() error {

--- a/internal/component/loki/process/stages/tenant.go
+++ b/internal/component/loki/process/stages/tenant.go
@@ -26,9 +26,9 @@ type tenantStage struct {
 
 // TenantConfig configures a tenant stage.
 type TenantConfig struct {
-	Label  string `alloy:"label,attr,optional"`
-	Source string `alloy:"source,attr,optional"`
-	Value  string `alloy:"value,attr,optional"`
+	Label  string `alloy:"label,attr,optional"  json:"label,omitempty"`
+	Source string `alloy:"source,attr,optional" json:"source,omitempty"`
+	Value  string `alloy:"value,attr,optional"  json:"value,omitempty"`
 }
 
 // validateTenantConfig validates the tenant stage configuration

--- a/internal/component/loki/process/stages/timestamp.go
+++ b/internal/component/loki/process/stages/timestamp.go
@@ -45,11 +45,11 @@ var TimestampActionOnFailureOptions = []string{TimestampActionOnFailureSkip, Tim
 
 // TimestampConfig configures a processing stage for timestamp extraction.
 type TimestampConfig struct {
-	Source          string   `alloy:"source,attr"`
-	Format          string   `alloy:"format,attr"`
-	FallbackFormats []string `alloy:"fallback_formats,attr,optional"`
-	Location        *string  `alloy:"location,attr,optional"`
-	ActionOnFailure string   `alloy:"action_on_failure,attr,optional"`
+	Source          string   `alloy:"source,attr"                       json:"source"`
+	Format          string   `alloy:"format,attr"                       json:"format"`
+	FallbackFormats []string `alloy:"fallback_formats,attr,optional"    json:"fallbackFormats,omitempty"`
+	Location        *string  `alloy:"location,attr,optional"            json:"location,omitempty"`
+	ActionOnFailure string   `alloy:"action_on_failure,attr,optional"   json:"actionOnFailure,omitempty"`
 }
 
 type parser func(string) (time.Time, error)

--- a/internal/component/loki/process/stages/truncate.go
+++ b/internal/component/loki/process/stages/truncate.go
@@ -30,14 +30,14 @@ const (
 
 // TruncateConfig contains the configuration for a truncateStage
 type TruncateConfig struct {
-	Rules []*RuleConfig `alloy:"rule,block"`
+	Rules []*RuleConfig `alloy:"rule,block" json:"rules"`
 }
 
 type RuleConfig struct {
-	Limit      units.Base2Bytes `alloy:"limit,attr"`
-	Suffix     string           `alloy:"suffix,attr,optional"`
-	Sources    []string         `alloy:"sources,attr,optional"`
-	SourceType SourceType       `alloy:"source_type,attr,optional"`
+	Limit      units.Base2Bytes `alloy:"limit,attr"                   json:"limit"` // TextMarshaler: serializes as "5MiB"
+	Suffix     string           `alloy:"suffix,attr,optional"         json:"suffix,omitempty"`
+	Sources    []string         `alloy:"sources,attr,optional"        json:"sources,omitempty"`
+	SourceType SourceType       `alloy:"source_type,attr,optional"    json:"sourceType,omitempty"`
 
 	effectiveLimit units.Base2Bytes
 }

--- a/internal/component/loki/source/podlogs/internal/apis/monitoring/v1alpha2/zz_generated.deepcopy.go
+++ b/internal/component/loki/source/podlogs/internal/apis/monitoring/v1alpha2/zz_generated.deepcopy.go
@@ -5,7 +5,7 @@
 package v1alpha2
 
 import (
-	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 


### PR DESCRIPTION
## Summary

- Adds `json:"..."` tags to all stage config structs in `loki.process/stages/` so they can be serialised/deserialised as JSON.
- Required by the `loki.source.podlogs` PodLogs CRD feature ([#4738](https://github.com/grafana/alloy/issues/4738)) which embeds pipeline stage configs in the Kubernetes CRD spec using JSON.
- All changes are purely additive (new struct tags only); existing alloy tag behaviour and validation are unchanged.