### PR TITLE
feat(loki/podlogs): add pipelineStages processing to PodLogs CRD

### DIFF
--- a/internal/component/loki/process/metric/counters.go
+++ b/internal/component/loki/process/metric/counters.go
@@ -18,17 +18,17 @@ const (
 // CounterConfig defines a counter metric whose value only goes up.
 type CounterConfig struct {
 	// Shared fields
-	Name        string        `alloy:"name,attr"`
-	Description string        `alloy:"description,attr,optional"`
-	Source      string        `alloy:"source,attr,optional"`
-	Prefix      string        `alloy:"prefix,attr,optional"`
-	MaxIdle     time.Duration `alloy:"max_idle_duration,attr,optional"`
-	Value       string        `alloy:"value,attr,optional"`
+	Name        string        `alloy:"name,attr"                       json:"name"`
+	Description string        `alloy:"description,attr,optional"       json:"description,omitempty"`
+	Source      string        `alloy:"source,attr,optional"            json:"source,omitempty"`
+	Prefix      string        `alloy:"prefix,attr,optional"            json:"prefix,omitempty"`
+	MaxIdle     time.Duration `alloy:"max_idle_duration,attr,optional" json:"-"` // not supported in CRD: time.Duration is nanosecond int64 in JSON
+	Value       string        `alloy:"value,attr,optional"             json:"value,omitempty"`
 
 	// Counter-specific fields
-	Action          string `alloy:"action,attr"`
-	MatchAll        bool   `alloy:"match_all,attr,optional"`
-	CountEntryBytes bool   `alloy:"count_entry_bytes,attr,optional"`
+	Action          string `alloy:"action,attr"                    json:"action"`
+	MatchAll        bool   `alloy:"match_all,attr,optional"        json:"matchAll,omitempty"`
+	CountEntryBytes bool   `alloy:"count_entry_bytes,attr,optional" json:"countEntryBytes,omitempty"`
 }
 
 // DefaultCounterConfig sets the default for a Counter.

--- a/internal/component/loki/process/metric/gauges.go
+++ b/internal/component/loki/process/metric/gauges.go
@@ -29,15 +29,15 @@ var DefaultGaugeConfig = GaugeConfig{
 // GaugeConfig defines a gauge metric whose value can go up or down.
 type GaugeConfig struct {
 	// Shared fields
-	Name        string        `alloy:"name,attr"`
-	Description string        `alloy:"description,attr,optional"`
-	Source      string        `alloy:"source,attr,optional"`
-	Prefix      string        `alloy:"prefix,attr,optional"`
-	MaxIdle     time.Duration `alloy:"max_idle_duration,attr,optional"`
-	Value       string        `alloy:"value,attr,optional"`
+	Name        string        `alloy:"name,attr"                       json:"name"`
+	Description string        `alloy:"description,attr,optional"       json:"description,omitempty"`
+	Source      string        `alloy:"source,attr,optional"            json:"source,omitempty"`
+	Prefix      string        `alloy:"prefix,attr,optional"            json:"prefix,omitempty"`
+	MaxIdle     time.Duration `alloy:"max_idle_duration,attr,optional" json:"-"` // not supported in CRD: time.Duration is nanosecond int64 in JSON
+	Value       string        `alloy:"value,attr,optional"             json:"value,omitempty"`
 
 	// Gauge-specific fields
-	Action string `alloy:"action,attr"`
+	Action string `alloy:"action,attr" json:"action"`
 }
 
 // SetToDefault implements syntax.Defaulter.

--- a/internal/component/loki/process/metric/histograms.go
+++ b/internal/component/loki/process/metric/histograms.go
@@ -18,15 +18,15 @@ var DefaultHistogramConfig = HistogramConfig{
 // HistogramConfig defines a histogram metric whose values are bucketed.
 type HistogramConfig struct {
 	// Shared fields
-	Name        string        `alloy:"name,attr"`
-	Description string        `alloy:"description,attr,optional"`
-	Source      string        `alloy:"source,attr,optional"`
-	Prefix      string        `alloy:"prefix,attr,optional"`
-	MaxIdle     time.Duration `alloy:"max_idle_duration,attr,optional"`
-	Value       string        `alloy:"value,attr,optional"`
+	Name        string        `alloy:"name,attr"                       json:"name"`
+	Description string        `alloy:"description,attr,optional"       json:"description,omitempty"`
+	Source      string        `alloy:"source,attr,optional"            json:"source,omitempty"`
+	Prefix      string        `alloy:"prefix,attr,optional"            json:"prefix,omitempty"`
+	MaxIdle     time.Duration `alloy:"max_idle_duration,attr,optional" json:"-"` // not supported in CRD: time.Duration is nanosecond int64 in JSON
+	Value       string        `alloy:"value,attr,optional"             json:"value,omitempty"`
 
 	// Histogram-specific fields
-	Buckets []float64 `alloy:"buckets,attr"`
+	Buckets []float64 `alloy:"buckets,attr" json:"buckets"`
 }
 
 // SetToDefault implements syntax.Defaulter.

--- a/internal/component/loki/process/stages/cri.go
+++ b/internal/component/loki/process/stages/cri.go
@@ -19,9 +19,9 @@ import (
 // CRIConfig is an empty struct that is used to enable a pre-defined pipeline
 // for decoding entries that are using the CRI logging format.
 type CRIConfig struct {
-	MaxPartialLines            int    `alloy:"max_partial_lines,attr,optional"`
-	MaxPartialLineSize         uint64 `alloy:"max_partial_line_size,attr,optional"`
-	MaxPartialLineSizeTruncate bool   `alloy:"max_partial_line_size_truncate,attr,optional"`
+	MaxPartialLines            int    `alloy:"max_partial_lines,attr,optional"             json:"maxPartialLines,omitempty"`
+	MaxPartialLineSize         uint64 `alloy:"max_partial_line_size,attr,optional"         json:"maxPartialLineSize,omitempty"`
+	MaxPartialLineSizeTruncate bool   `alloy:"max_partial_line_size_truncate,attr,optional" json:"maxPartialLineSizeTruncate,omitempty"`
 }
 
 var (

--- a/internal/component/loki/process/stages/drop.go
+++ b/internal/component/loki/process/stages/drop.go
@@ -31,13 +31,13 @@ var (
 
 // DropConfig contains the configuration for a dropStage
 type DropConfig struct {
-	DropReason string           `alloy:"drop_counter_reason,attr,optional"`
-	Source     string           `alloy:"source,attr,optional"`
-	Value      string           `alloy:"value,attr,optional"`
-	Separator  string           `alloy:"separator,attr,optional"`
-	Expression string           `alloy:"expression,attr,optional"`
-	OlderThan  time.Duration    `alloy:"older_than,attr,optional"`
-	LongerThan units.Base2Bytes `alloy:"longer_than,attr,optional"`
+	DropReason string           `alloy:"drop_counter_reason,attr,optional" json:"dropReason,omitempty"`
+	Source     string           `alloy:"source,attr,optional"              json:"source,omitempty"`
+	Value      string           `alloy:"value,attr,optional"               json:"value,omitempty"`
+	Separator  string           `alloy:"separator,attr,optional"           json:"separator,omitempty"`
+	Expression string           `alloy:"expression,attr,optional"          json:"expression,omitempty"`
+	OlderThan  time.Duration    `alloy:"older_than,attr,optional"          json:"-"`                    // not supported in CRD: time.Duration is nanosecond int64 in JSON
+	LongerThan units.Base2Bytes `alloy:"longer_than,attr,optional"         json:"longerThan,omitempty"` // TextMarshaler: serializes as "5MiB"
 }
 
 // validateDropConfig validates the DropConfig for the dropStage

--- a/internal/component/loki/process/stages/geoip.go
+++ b/internal/component/loki/process/stages/geoip.go
@@ -56,10 +56,10 @@ var fields = map[GeoIPFields]string{
 
 // GeoIPConfig represents GeoIP stage config
 type GeoIPConfig struct {
-	DB            string            `alloy:"db,attr"`
-	Source        *string           `alloy:"source,attr"`
-	DBType        string            `alloy:"db_type,attr,optional"`
-	CustomLookups map[string]string `alloy:"custom_lookups,attr,optional"`
+	DB            string            `alloy:"db,attr"                          json:"db"`
+	Source        *string           `alloy:"source,attr"                      json:"source"`
+	DBType        string            `alloy:"db_type,attr,optional"            json:"dbType,omitempty"`
+	CustomLookups map[string]string `alloy:"custom_lookups,attr,optional"     json:"customLookups,omitempty"`
 }
 
 func validateGeoIPConfig(c GeoIPConfig) (map[string]jmespath.JMESPath, error) {

--- a/internal/component/loki/process/stages/json.go
+++ b/internal/component/loki/process/stages/json.go
@@ -22,9 +22,9 @@ const (
 
 // JSONConfig represents a JSON Stage configuration
 type JSONConfig struct {
-	Expressions   map[string]string `alloy:"expressions,attr"`
-	Source        *string           `alloy:"source,attr,optional"`
-	DropMalformed bool              `alloy:"drop_malformed,attr,optional"`
+	Expressions   map[string]string `alloy:"expressions,attr"              json:"expressions"`
+	Source        *string           `alloy:"source,attr,optional"          json:"source,omitempty"`
+	DropMalformed bool              `alloy:"drop_malformed,attr,optional"  json:"dropMalformed,omitempty"`
 }
 
 // validateJSONConfig validates a json config and returns a map of necessary jmespath expressions.

--- a/internal/component/loki/process/stages/label_drop.go
+++ b/internal/component/loki/process/stages/label_drop.go
@@ -12,7 +12,7 @@ var ErrEmptyLabelDropStageConfig = errors.New("labeldrop stage config cannot be 
 
 // LabelDropConfig contains the slice of labels to be dropped.
 type LabelDropConfig struct {
-	Values []string `alloy:"values,attr"`
+	Values []string `alloy:"values,attr" json:"values"`
 }
 
 func newLabelDropStage(config LabelDropConfig) (Stage, error) {

--- a/internal/component/loki/process/stages/label_keep.go
+++ b/internal/component/loki/process/stages/label_keep.go
@@ -12,7 +12,7 @@ var ErrEmptyLabelAllowStageConfig = errors.New("labelallow stage config cannot b
 
 // LabelAllowConfig contains the slice of labels to allow through.
 type LabelAllowConfig struct {
-	Values []string `alloy:"values,attr"`
+	Values []string `alloy:"values,attr" json:"values"`
 }
 
 func newLabelAllowStage(config LabelAllowConfig) (Stage, error) {

--- a/internal/component/loki/process/stages/labels.go
+++ b/internal/component/loki/process/stages/labels.go
@@ -23,8 +23,8 @@ const (
 
 // LabelsConfig is a set of labels to be extracted
 type LabelsConfig struct {
-	Values     map[string]*string `alloy:"values,attr"`
-	SourceType SourceType         `alloy:"source_type,attr,optional"`
+	Values     map[string]*string `alloy:"values,attr"                json:"values"`
+	SourceType SourceType         `alloy:"source_type,attr,optional"  json:"sourceType,omitempty"`
 }
 
 // validateLabelsConfig validates the Label stage configuration

--- a/internal/component/loki/process/stages/limit.go
+++ b/internal/component/loki/process/stages/limit.go
@@ -24,11 +24,11 @@ const MinReasonableMaxDistinctLabels = 10000 // 80bytes per rate.Limiter ~ 1MiB 
 
 // LimitConfig sets up a Limit stage.
 type LimitConfig struct {
-	Rate              float64 `alloy:"rate,attr"`
-	Burst             int     `alloy:"burst,attr"`
-	Drop              bool    `alloy:"drop,attr,optional"`
-	ByLabelName       string  `alloy:"by_label_name,attr,optional"`
-	MaxDistinctLabels int     `alloy:"max_distinct_labels,attr,optional"`
+	Rate              float64 `alloy:"rate,attr"                        json:"rate"`
+	Burst             int     `alloy:"burst,attr"                       json:"burst"`
+	Drop              bool    `alloy:"drop,attr,optional"               json:"drop,omitempty"`
+	ByLabelName       string  `alloy:"by_label_name,attr,optional"      json:"byLabelName,omitempty"`
+	MaxDistinctLabels int     `alloy:"max_distinct_labels,attr,optional" json:"maxDistinctLabels,omitempty"`
 }
 
 func newLimitStage(logger log.Logger, cfg LimitConfig, registerer prometheus.Registerer) (Stage, error) {

--- a/internal/component/loki/process/stages/logfmt.go
+++ b/internal/component/loki/process/stages/logfmt.go
@@ -20,8 +20,8 @@ var (
 
 // LogfmtConfig represents a logfmt Stage configuration
 type LogfmtConfig struct {
-	Mapping map[string]string `alloy:"mapping,attr"`
-	Source  string            `alloy:"source,attr,optional"`
+	Mapping map[string]string `alloy:"mapping,attr"          json:"mapping"`
+	Source  string            `alloy:"source,attr,optional"  json:"source,omitempty"`
 }
 
 // validateLogfmtConfig validates a logfmt stage config and returns an inverse mapping of configured mapping.

--- a/internal/component/loki/process/stages/luhn.go
+++ b/internal/component/loki/process/stages/luhn.go
@@ -11,10 +11,10 @@ import (
 
 // LuhnFilterConfig configures a processing stage that filters out Luhn-valid numbers.
 type LuhnFilterConfig struct {
-	Replacement string  `alloy:"replacement,attr,optional"`
-	Source      *string `alloy:"source,attr,optional"`
-	MinLength   int     `alloy:"min_length,attr,optional"`
-	Delimiters  string  `alloy:"delimiters,attr,optional"`
+	Replacement string  `alloy:"replacement,attr,optional"  json:"replacement,omitempty"`
+	Source      *string `alloy:"source,attr,optional"       json:"source,omitempty"`
+	MinLength   int     `alloy:"min_length,attr,optional"   json:"minLength,omitempty"`
+	Delimiters  string  `alloy:"delimiters,attr,optional"   json:"delimiters,omitempty"`
 }
 
 // validateLuhnFilterConfig validates the LuhnFilterConfig.

--- a/internal/component/loki/process/stages/match.go
+++ b/internal/component/loki/process/stages/match.go
@@ -27,11 +27,11 @@ var (
 
 // MatchConfig contains the configuration for a matcherStage
 type MatchConfig struct {
-	Selector     string        `alloy:"selector,attr"`
-	Stages       []StageConfig `alloy:"stage,enum,optional"`
-	Action       string        `alloy:"action,attr,optional"`
-	PipelineName string        `alloy:"pipeline_name,attr,optional"`
-	DropReason   string        `alloy:"drop_counter_reason,attr,optional"`
+	Selector     string        `alloy:"selector,attr"                     json:"selector"`
+	Stages       []StageConfig `alloy:"stage,enum,optional"               json:"stages,omitempty"`
+	Action       string        `alloy:"action,attr,optional"              json:"action,omitempty"`
+	PipelineName string        `alloy:"pipeline_name,attr,optional"       json:"pipelineName,omitempty"`
+	DropReason   string        `alloy:"drop_counter_reason,attr,optional" json:"dropReason,omitempty"`
 }
 
 // validateMatcherConfig validates the MatcherConfig for the matcherStage

--- a/internal/component/loki/process/stages/metric.go
+++ b/internal/component/loki/process/stages/metric.go
@@ -22,14 +22,14 @@ const (
 
 // MetricConfig is a single metrics configuration.
 type MetricConfig struct {
-	Counter   *metric.CounterConfig   `alloy:"counter,block,optional"`
-	Gauge     *metric.GaugeConfig     `alloy:"gauge,block,optional"`
-	Histogram *metric.HistogramConfig `alloy:"histogram,block,optional"`
+	Counter   *metric.CounterConfig   `alloy:"counter,block,optional"   json:"counter,omitempty"`
+	Gauge     *metric.GaugeConfig     `alloy:"gauge,block,optional"     json:"gauge,omitempty"`
+	Histogram *metric.HistogramConfig `alloy:"histogram,block,optional" json:"histogram,omitempty"`
 }
 
 // MetricsConfig is a set of configured metrics.
 type MetricsConfig struct {
-	Metrics []MetricConfig `alloy:"metric,enum,optional"`
+	Metrics []MetricConfig `alloy:"metric,enum,optional" json:"metrics,omitempty"`
 }
 
 type cfgCollector struct {

--- a/internal/component/loki/process/stages/output.go
+++ b/internal/component/loki/process/stages/output.go
@@ -19,7 +19,7 @@ var (
 // OutputConfig initializes a configuration stage which sets the log line to a
 // value from the extracted map.
 type OutputConfig struct {
-	Source string `alloy:"source,attr"`
+	Source string `alloy:"source,attr" json:"source"`
 }
 
 // newOutputStage creates a new outputStage

--- a/internal/component/loki/process/stages/pack.go
+++ b/internal/component/loki/process/stages/pack.go
@@ -105,8 +105,8 @@ func (w Packed) MarshalJSON() ([]byte, error) {
 
 // PackConfig contains the configuration for a packStage
 type PackConfig struct {
-	Labels          []string `alloy:"labels,attr"`
-	IngestTimestamp bool     `alloy:"ingest_timestamp,attr,optional"`
+	Labels          []string `alloy:"labels,attr"                    json:"labels"`
+	IngestTimestamp bool     `alloy:"ingest_timestamp,attr,optional" json:"ingestTimestamp,omitempty"`
 }
 
 // DefaultPackConfig sets the defaults.

--- a/internal/component/loki/process/stages/pattern.go
+++ b/internal/component/loki/process/stages/pattern.go
@@ -23,9 +23,9 @@ var (
 // extract values from log lines into the shared values map.
 // See https://grafana.com/docs/loki/latest/query/log_queries/#pattern
 type PatternConfig struct {
-	Pattern          string  `alloy:"pattern,attr"`
-	Source           *string `alloy:"source,attr,optional"`
-	LabelsFromGroups bool    `alloy:"labels_from_groups,attr,optional"`
+	Pattern          string  `alloy:"pattern,attr"                   json:"pattern"`
+	Source           *string `alloy:"source,attr,optional"           json:"source,omitempty"`
+	LabelsFromGroups bool    `alloy:"labels_from_groups,attr,optional" json:"labelsFromGroups,omitempty"`
 }
 
 // validatePatternConfig validates the config and return a regex

--- a/internal/component/loki/process/stages/pipeline.go
+++ b/internal/component/loki/process/stages/pipeline.go
@@ -48,6 +48,85 @@ type StageConfig struct {
 	WindowsEventConfig           *WindowsEventConfig           `alloy:"windowsevent,block,optional"           json:"windowsevent,omitempty"`
 }
 
+// PodLogsStageConfig defines a single processing stage for use in the PodLogs CRD.
+// It mirrors StageConfig but excludes stages that are incompatible with a shared
+// per-PodLogs pipeline:
+//   - multiline: log lines from different pods interleave in the shared pipeline,
+//     causing incorrect multi-line merging across pod boundaries.
+//   - windowsevent / eventlogmessage: not applicable to Linux pod logs.
+type PodLogsStageConfig struct {
+	CRIConfig                    *CRIConfig                    `json:"cri,omitempty"`
+	DecolorizeConfig             *DecolorizeConfig             `json:"decolorize,omitempty"`
+	DockerConfig                 *DockerConfig                 `json:"docker,omitempty"`
+	DropConfig                   *DropConfig                   `json:"drop,omitempty"`
+	GeoIPConfig                  *GeoIPConfig                  `json:"geoip,omitempty"`
+	JSONConfig                   *JSONConfig                   `json:"json,omitempty"`
+	LabelAllowConfig             *LabelAllowConfig             `json:"label_keep,omitempty"`
+	LabelDropConfig              *LabelDropConfig              `json:"label_drop,omitempty"`
+	LabelsConfig                 *LabelsConfig                 `json:"labels,omitempty"`
+	LimitConfig                  *LimitConfig                  `json:"limit,omitempty"`
+	LogfmtConfig                 *LogfmtConfig                 `json:"logfmt,omitempty"`
+	LuhnFilterConfig             *LuhnFilterConfig             `json:"luhn,omitempty"`
+	MatchConfig                  *MatchConfig                  `json:"match,omitempty"`
+	MetricsConfig                *MetricsConfig                `json:"metrics,omitempty"`
+	OutputConfig                 *OutputConfig                 `json:"output,omitempty"`
+	PackConfig                   *PackConfig                   `json:"pack,omitempty"`
+	PatternConfig                *PatternConfig                `json:"pattern,omitempty"`
+	RegexConfig                  *RegexConfig                  `json:"regex,omitempty"`
+	ReplaceConfig                *ReplaceConfig                `json:"replace,omitempty"`
+	SamplingConfig               *SamplingConfig               `json:"sampling,omitempty"`
+	StaticLabelsConfig           *StaticLabelsConfig           `json:"static_labels,omitempty"`
+	StructuredMetadata           *StructuredMetadataConfig     `json:"structured_metadata,omitempty"`
+	StructuredMetadataDropConfig *StructuredMetadataDropConfig `json:"structured_metadata_drop,omitempty"`
+	TemplateConfig               *TemplateConfig               `json:"template,omitempty"`
+	TenantConfig                 *TenantConfig                 `json:"tenant,omitempty"`
+	TimestampConfig              *TimestampConfig              `json:"timestamp,omitempty"`
+	TruncateConfig               *TruncateConfig               `json:"truncate,omitempty"`
+}
+
+// ToStageConfig converts a PodLogsStageConfig to the full StageConfig for use with NewPipeline.
+func (c PodLogsStageConfig) ToStageConfig() StageConfig {
+	return StageConfig{
+		CRIConfig:                    c.CRIConfig,
+		DecolorizeConfig:             c.DecolorizeConfig,
+		DockerConfig:                 c.DockerConfig,
+		DropConfig:                   c.DropConfig,
+		GeoIPConfig:                  c.GeoIPConfig,
+		JSONConfig:                   c.JSONConfig,
+		LabelAllowConfig:             c.LabelAllowConfig,
+		LabelDropConfig:              c.LabelDropConfig,
+		LabelsConfig:                 c.LabelsConfig,
+		LimitConfig:                  c.LimitConfig,
+		LogfmtConfig:                 c.LogfmtConfig,
+		LuhnFilterConfig:             c.LuhnFilterConfig,
+		MatchConfig:                  c.MatchConfig,
+		MetricsConfig:                c.MetricsConfig,
+		OutputConfig:                 c.OutputConfig,
+		PackConfig:                   c.PackConfig,
+		PatternConfig:                c.PatternConfig,
+		RegexConfig:                  c.RegexConfig,
+		ReplaceConfig:                c.ReplaceConfig,
+		SamplingConfig:               c.SamplingConfig,
+		StaticLabelsConfig:           c.StaticLabelsConfig,
+		StructuredMetadata:           c.StructuredMetadata,
+		StructuredMetadataDropConfig: c.StructuredMetadataDropConfig,
+		TemplateConfig:               c.TemplateConfig,
+		TenantConfig:                 c.TenantConfig,
+		TimestampConfig:              c.TimestampConfig,
+		TruncateConfig:               c.TruncateConfig,
+	}
+}
+
+// ConvertPodLogsStages converts a slice of PodLogsStageConfig to []StageConfig
+// for use with NewPipeline.
+func ConvertPodLogsStages(in []PodLogsStageConfig) []StageConfig {
+	out := make([]StageConfig, len(in))
+	for i, s := range in {
+		out[i] = s.ToStageConfig()
+	}
+	return out
+}
+
 // Pipeline pass down a log entry to each stage for mutation and/or label extraction.
 type Pipeline struct {
 	logger    log.Logger

--- a/internal/component/loki/process/stages/pipeline.go
+++ b/internal/component/loki/process/stages/pipeline.go
@@ -16,36 +16,36 @@ import (
 // We define these as pointers types so we can use reflection to check that
 // exactly one is set.
 type StageConfig struct {
-	CRIConfig                    *CRIConfig                    `alloy:"cri,block,optional"`
-	DecolorizeConfig             *DecolorizeConfig             `alloy:"decolorize,block,optional"`
-	DockerConfig                 *DockerConfig                 `alloy:"docker,block,optional"`
-	DropConfig                   *DropConfig                   `alloy:"drop,block,optional"`
-	EventLogMessageConfig        *EventLogMessageConfig        `alloy:"eventlogmessage,block,optional"`
-	GeoIPConfig                  *GeoIPConfig                  `alloy:"geoip,block,optional"`
-	JSONConfig                   *JSONConfig                   `alloy:"json,block,optional"`
-	LabelAllowConfig             *LabelAllowConfig             `alloy:"label_keep,block,optional"`
-	LabelDropConfig              *LabelDropConfig              `alloy:"label_drop,block,optional"`
-	LabelsConfig                 *LabelsConfig                 `alloy:"labels,block,optional"`
-	LimitConfig                  *LimitConfig                  `alloy:"limit,block,optional"`
-	LogfmtConfig                 *LogfmtConfig                 `alloy:"logfmt,block,optional"`
-	LuhnFilterConfig             *LuhnFilterConfig             `alloy:"luhn,block,optional"`
-	MatchConfig                  *MatchConfig                  `alloy:"match,block,optional"`
-	MetricsConfig                *MetricsConfig                `alloy:"metrics,block,optional"`
-	MultilineConfig              *MultilineConfig              `alloy:"multiline,block,optional"`
-	OutputConfig                 *OutputConfig                 `alloy:"output,block,optional"`
-	PackConfig                   *PackConfig                   `alloy:"pack,block,optional"`
-	PatternConfig                *PatternConfig                `alloy:"pattern,block,optional"`
-	RegexConfig                  *RegexConfig                  `alloy:"regex,block,optional"`
-	ReplaceConfig                *ReplaceConfig                `alloy:"replace,block,optional"`
-	StaticLabelsConfig           *StaticLabelsConfig           `alloy:"static_labels,block,optional"`
-	StructuredMetadata           *StructuredMetadataConfig     `alloy:"structured_metadata,block,optional"`
-	StructuredMetadataDropConfig *StructuredMetadataDropConfig `alloy:"structured_metadata_drop,block,optional"`
-	SamplingConfig               *SamplingConfig               `alloy:"sampling,block,optional"`
-	TemplateConfig               *TemplateConfig               `alloy:"template,block,optional"`
-	TenantConfig                 *TenantConfig                 `alloy:"tenant,block,optional"`
-	TruncateConfig               *TruncateConfig               `alloy:"truncate,block,optional"`
-	TimestampConfig              *TimestampConfig              `alloy:"timestamp,block,optional"`
-	WindowsEventConfig           *WindowsEventConfig           `alloy:"windowsevent,block,optional"`
+	CRIConfig                    *CRIConfig                    `alloy:"cri,block,optional"                    json:"cri,omitempty"`
+	DecolorizeConfig             *DecolorizeConfig             `alloy:"decolorize,block,optional"             json:"decolorize,omitempty"`
+	DockerConfig                 *DockerConfig                 `alloy:"docker,block,optional"                 json:"docker,omitempty"`
+	DropConfig                   *DropConfig                   `alloy:"drop,block,optional"                   json:"drop,omitempty"`
+	EventLogMessageConfig        *EventLogMessageConfig        `alloy:"eventlogmessage,block,optional"        json:"eventlogmessage,omitempty"`
+	GeoIPConfig                  *GeoIPConfig                  `alloy:"geoip,block,optional"                  json:"geoip,omitempty"`
+	JSONConfig                   *JSONConfig                   `alloy:"json,block,optional"                   json:"json,omitempty"`
+	LabelAllowConfig             *LabelAllowConfig             `alloy:"label_keep,block,optional"             json:"label_keep,omitempty"`
+	LabelDropConfig              *LabelDropConfig              `alloy:"label_drop,block,optional"             json:"label_drop,omitempty"`
+	LabelsConfig                 *LabelsConfig                 `alloy:"labels,block,optional"                 json:"labels,omitempty"`
+	LimitConfig                  *LimitConfig                  `alloy:"limit,block,optional"                  json:"limit,omitempty"`
+	LogfmtConfig                 *LogfmtConfig                 `alloy:"logfmt,block,optional"                 json:"logfmt,omitempty"`
+	LuhnFilterConfig             *LuhnFilterConfig             `alloy:"luhn,block,optional"                   json:"luhn,omitempty"`
+	MatchConfig                  *MatchConfig                  `alloy:"match,block,optional"                  json:"match,omitempty"`
+	MetricsConfig                *MetricsConfig                `alloy:"metrics,block,optional"                json:"metrics,omitempty"`
+	MultilineConfig              *MultilineConfig              `alloy:"multiline,block,optional"              json:"multiline,omitempty"`
+	OutputConfig                 *OutputConfig                 `alloy:"output,block,optional"                 json:"output,omitempty"`
+	PackConfig                   *PackConfig                   `alloy:"pack,block,optional"                   json:"pack,omitempty"`
+	PatternConfig                *PatternConfig                `alloy:"pattern,block,optional"                json:"pattern,omitempty"`
+	RegexConfig                  *RegexConfig                  `alloy:"regex,block,optional"                  json:"regex,omitempty"`
+	ReplaceConfig                *ReplaceConfig                `alloy:"replace,block,optional"                json:"replace,omitempty"`
+	StaticLabelsConfig           *StaticLabelsConfig           `alloy:"static_labels,block,optional"          json:"static_labels,omitempty"`
+	StructuredMetadata           *StructuredMetadataConfig     `alloy:"structured_metadata,block,optional"    json:"structured_metadata,omitempty"`
+	StructuredMetadataDropConfig *StructuredMetadataDropConfig `alloy:"structured_metadata_drop,block,optional" json:"structured_metadata_drop,omitempty"`
+	SamplingConfig               *SamplingConfig               `alloy:"sampling,block,optional"               json:"sampling,omitempty"`
+	TemplateConfig               *TemplateConfig               `alloy:"template,block,optional"               json:"template,omitempty"`
+	TenantConfig                 *TenantConfig                 `alloy:"tenant,block,optional"                 json:"tenant,omitempty"`
+	TruncateConfig               *TruncateConfig               `alloy:"truncate,block,optional"               json:"truncate,omitempty"`
+	TimestampConfig              *TimestampConfig              `alloy:"timestamp,block,optional"              json:"timestamp,omitempty"`
+	WindowsEventConfig           *WindowsEventConfig           `alloy:"windowsevent,block,optional"           json:"windowsevent,omitempty"`
 }
 
 // Pipeline pass down a log entry to each stage for mutation and/or label extraction.

--- a/internal/component/loki/process/stages/regex.go
+++ b/internal/component/loki/process/stages/regex.go
@@ -23,9 +23,9 @@ var (
 // RegexConfig configures a processing stage uses regular expressions to
 // extract values from log lines into the shared values map.
 type RegexConfig struct {
-	Expression       string  `alloy:"expression,attr"`
-	Source           *string `alloy:"source,attr,optional"`
-	LabelsFromGroups bool    `alloy:"labels_from_groups,attr,optional"`
+	Expression       string  `alloy:"expression,attr"                   json:"expression"`
+	Source           *string `alloy:"source,attr,optional"              json:"source,omitempty"`
+	LabelsFromGroups bool    `alloy:"labels_from_groups,attr,optional"  json:"labelsFromGroups,omitempty"`
 }
 
 // validateRegexConfig validates the config and return a regex

--- a/internal/component/loki/process/stages/replace.go
+++ b/internal/component/loki/process/stages/replace.go
@@ -22,9 +22,9 @@ func init() {
 
 // ReplaceConfig contains a regexStage configuration
 type ReplaceConfig struct {
-	Expression string `alloy:"expression,attr"`
-	Source     string `alloy:"source,attr,optional"`
-	Replace    string `alloy:"replace,attr,optional"`
+	Expression string `alloy:"expression,attr"          json:"expression"`
+	Source     string `alloy:"source,attr,optional"     json:"source,omitempty"`
+	Replace    string `alloy:"replace,attr,optional"    json:"replace,omitempty"`
 }
 
 func getExpressionRegex(c ReplaceConfig) (*regexp.Regexp, error) {

--- a/internal/component/loki/process/stages/sampling.go
+++ b/internal/component/loki/process/stages/sampling.go
@@ -19,8 +19,8 @@ var (
 
 // SamplingConfig contains the configuration for a samplingStage
 type SamplingConfig struct {
-	DropReason   string  `alloy:"drop_counter_reason,attr,optional"`
-	SamplingRate float64 `alloy:"rate,attr"`
+	DropReason   string  `alloy:"drop_counter_reason,attr,optional" json:"dropReason,omitempty"`
+	SamplingRate float64 `alloy:"rate,attr"                         json:"rate"`
 }
 
 func (s *SamplingConfig) SetToDefault() {

--- a/internal/component/loki/process/stages/static_labels.go
+++ b/internal/component/loki/process/stages/static_labels.go
@@ -14,7 +14,7 @@ var ErrEmptyStaticLabelStageConfig = errors.New("static_labels stage config cann
 
 // StaticLabelsConfig contains a map of static labels to be set.
 type StaticLabelsConfig struct {
-	Values map[string]*string `alloy:"values,attr"`
+	Values map[string]*string `alloy:"values,attr" json:"values"`
 }
 
 func newStaticLabelsStage(_ log.Logger, config StaticLabelsConfig) (Stage, error) {

--- a/internal/component/loki/process/stages/structured_metadata.go
+++ b/internal/component/loki/process/stages/structured_metadata.go
@@ -13,8 +13,8 @@ import (
 )
 
 type StructuredMetadataConfig struct {
-	Values map[string]*string `alloy:"values,attr,optional"`
-	Regex  string             `alloy:"regex,attr,optional"`
+	Values map[string]*string `alloy:"values,attr,optional" json:"values,omitempty"`
+	Regex  string             `alloy:"regex,attr,optional"  json:"regex,omitempty"`
 }
 
 // validateStructuredMetadataConfig validates the structured metadata stage config.

--- a/internal/component/loki/process/stages/structured_metadata_drop.go
+++ b/internal/component/loki/process/stages/structured_metadata_drop.go
@@ -13,7 +13,7 @@ var ErrEmptyStructuredMetadataDropStageConfig = errors.New("structured_metadata_
 
 // StructuredMetadataDropConfig contains the slice of structured metadata to be dropped.
 type StructuredMetadataDropConfig struct {
-	Values []string `alloy:"values,attr"`
+	Values []string `alloy:"values,attr" json:"values"`
 }
 
 func newStructuredMetadataDropStage(logger log.Logger, config StructuredMetadataDropConfig) (Stage, error) {

--- a/internal/component/loki/process/stages/template.go
+++ b/internal/component/loki/process/stages/template.go
@@ -67,8 +67,8 @@ var _ syntax.Validator = (*TemplateConfig)(nil)
 
 // TemplateConfig configures template value extraction.
 type TemplateConfig struct {
-	Source   string   `alloy:"source,attr"`
-	Template Template `alloy:"template,attr"`
+	Source   string   `alloy:"source,attr"    json:"source"`
+	Template Template `alloy:"template,attr"  json:"template"`
 }
 
 func (t *TemplateConfig) Validate() error {

--- a/internal/component/loki/process/stages/tenant.go
+++ b/internal/component/loki/process/stages/tenant.go
@@ -26,9 +26,9 @@ type tenantStage struct {
 
 // TenantConfig configures a tenant stage.
 type TenantConfig struct {
-	Label  string `alloy:"label,attr,optional"`
-	Source string `alloy:"source,attr,optional"`
-	Value  string `alloy:"value,attr,optional"`
+	Label  string `alloy:"label,attr,optional"  json:"label,omitempty"`
+	Source string `alloy:"source,attr,optional" json:"source,omitempty"`
+	Value  string `alloy:"value,attr,optional"  json:"value,omitempty"`
 }
 
 // validateTenantConfig validates the tenant stage configuration

--- a/internal/component/loki/process/stages/timestamp.go
+++ b/internal/component/loki/process/stages/timestamp.go
@@ -45,11 +45,11 @@ var TimestampActionOnFailureOptions = []string{TimestampActionOnFailureSkip, Tim
 
 // TimestampConfig configures a processing stage for timestamp extraction.
 type TimestampConfig struct {
-	Source          string   `alloy:"source,attr"`
-	Format          string   `alloy:"format,attr"`
-	FallbackFormats []string `alloy:"fallback_formats,attr,optional"`
-	Location        *string  `alloy:"location,attr,optional"`
-	ActionOnFailure string   `alloy:"action_on_failure,attr,optional"`
+	Source          string   `alloy:"source,attr"                       json:"source"`
+	Format          string   `alloy:"format,attr"                       json:"format"`
+	FallbackFormats []string `alloy:"fallback_formats,attr,optional"    json:"fallbackFormats,omitempty"`
+	Location        *string  `alloy:"location,attr,optional"            json:"location,omitempty"`
+	ActionOnFailure string   `alloy:"action_on_failure,attr,optional"   json:"actionOnFailure,omitempty"`
 }
 
 type parser func(string) (time.Time, error)

--- a/internal/component/loki/process/stages/truncate.go
+++ b/internal/component/loki/process/stages/truncate.go
@@ -30,14 +30,14 @@ const (
 
 // TruncateConfig contains the configuration for a truncateStage
 type TruncateConfig struct {
-	Rules []*RuleConfig `alloy:"rule,block"`
+	Rules []*RuleConfig `alloy:"rule,block" json:"rules"`
 }
 
 type RuleConfig struct {
-	Limit      units.Base2Bytes `alloy:"limit,attr"`
-	Suffix     string           `alloy:"suffix,attr,optional"`
-	Sources    []string         `alloy:"sources,attr,optional"`
-	SourceType SourceType       `alloy:"source_type,attr,optional"`
+	Limit      units.Base2Bytes `alloy:"limit,attr"                   json:"limit"` // TextMarshaler: serializes as "5MiB"
+	Suffix     string           `alloy:"suffix,attr,optional"         json:"suffix,omitempty"`
+	Sources    []string         `alloy:"sources,attr,optional"        json:"sources,omitempty"`
+	SourceType SourceType       `alloy:"source_type,attr,optional"    json:"sourceType,omitempty"`
 
 	effectiveLimit units.Base2Bytes
 }

--- a/internal/component/loki/source/kubernetes/kubernetes.go
+++ b/internal/component/loki/source/kubernetes/kubernetes.go
@@ -186,7 +186,7 @@ func (c *Component) resyncTargets(targets []discovery.Target) {
 			level.Error(c.log).Log("msg", "failed to process input target", "target", lset.String(), "err", err)
 			continue
 		}
-		tailTargets = append(tailTargets, kubetail.NewTarget(lset, processed, false))
+		tailTargets = append(tailTargets, kubetail.NewTarget(lset, processed, false, nil))
 	}
 
 	// This will never fail because it only fails if the context gets canceled.

--- a/internal/component/loki/source/kubernetes/kubetail/tailer.go
+++ b/internal/component/loki/source/kubernetes/kubetail/tailer.go
@@ -111,8 +111,16 @@ func (t *tailer) Run(ctx context.Context) {
 	})
 	defer handler.Stop()
 
+	// When using the per-target pipeline handler, entries bypass the mutator
+	// handler (which normally calls bo.Reset on every received line). Provide an
+	// explicit reset callback so backoff works correctly on the pipeline path.
+	onEntrySent := func() {}
+	if t.target.Handler() != nil {
+		onEntrySent = bo.Reset
+	}
+
 	for bo.Ongoing() {
-		err := t.tail(ctx, handler)
+		err := t.tail(ctx, handler, onEntrySent)
 		if err == nil {
 			// Check if we should stop tailing this container
 			// Fetch pod info once and use different logic for job pods vs regular pods
@@ -151,7 +159,7 @@ func (t *tailer) Run(ctx context.Context) {
 	}
 }
 
-func (t *tailer) tail(ctx context.Context, handler loki.EntryHandler) error {
+func (t *tailer) tail(ctx context.Context, handler loki.EntryHandler, onEntrySent func()) error {
 	// Set a maximum lifetime of the tail to ensure that connections are
 	// reestablished. This avoids an issue where the Kubernetes API server stops
 	// responding with new logs while the connection is kept open.
@@ -266,12 +274,12 @@ func (t *tailer) tail(ctx context.Context, handler loki.EntryHandler) error {
 
 	level.Info(t.log).Log("msg", "opened log stream", "start time", lastReadTime)
 
-	return t.processLogStream(ctx, stream, handler, lastReadTime, positionsEnt, calc)
+	return t.processLogStream(ctx, stream, handler, lastReadTime, positionsEnt, calc, onEntrySent)
 }
 
 // processLogStream reads log lines from a reader and processes them.
 // It returns when the context is done, the stream ends, or an error occurs.
-func (t *tailer) processLogStream(ctx context.Context, stream io.ReadCloser, handler loki.EntryHandler, lastReadTime time.Time, positionsEnt positions.Entry, calc *rollingAverageCalculator) error {
+func (t *tailer) processLogStream(ctx context.Context, stream io.ReadCloser, handler loki.EntryHandler, lastReadTime time.Time, positionsEnt positions.Entry, calc *rollingAverageCalculator, onEntrySent func()) error {
 	// Use per-target handler if set (routes entries through a PodLogs pipeline),
 	// otherwise fall back to the global handler from Options.
 	ch := handler.Chan()
@@ -305,6 +313,7 @@ func (t *tailer) processLogStream(ctx context.Context, stream io.ReadCloser, han
 			case <-ctx.Done():
 				return nil
 			case ch <- entry:
+				onEntrySent()
 				// Save position after it's been sent over the channel.
 				t.opts.Positions.Put(positionsEnt.Path, positionsEnt.Labels, entryTimestamp.UnixMicro())
 				t.target.Report(entryTimestamp, nil)

--- a/internal/component/loki/source/kubernetes/kubetail/tailer.go
+++ b/internal/component/loki/source/kubernetes/kubetail/tailer.go
@@ -46,9 +46,12 @@ func (tt *tailerTask) Equals(other runner.Task) bool {
 	}
 
 	// Slow path: check individual fields which are part of the task.
+	// Handler is compared by pointer: a different pipeline means a different
+	// handler instance, so the tailer must be restarted to pick up the new one.
 	return tt.Options == otherTask.Options &&
 		tt.Target.UID() == otherTask.Target.UID() &&
-		labels.Equal(tt.Target.Labels(), otherTask.Target.Labels())
+		labels.Equal(tt.Target.Labels(), otherTask.Target.Labels()) &&
+		tt.Target.Handler() == otherTask.Target.Handler()
 }
 
 // A tailer tails the logs of a Kubernetes container. It is created by a
@@ -269,7 +272,12 @@ func (t *tailer) tail(ctx context.Context, handler loki.EntryHandler) error {
 // processLogStream reads log lines from a reader and processes them.
 // It returns when the context is done, the stream ends, or an error occurs.
 func (t *tailer) processLogStream(ctx context.Context, stream io.ReadCloser, handler loki.EntryHandler, lastReadTime time.Time, positionsEnt positions.Entry, calc *rollingAverageCalculator) error {
+	// Use per-target handler if set (routes entries through a PodLogs pipeline),
+	// otherwise fall back to the global handler from Options.
 	ch := handler.Chan()
+	if h := t.target.Handler(); h != nil {
+		ch = h.Chan()
+	}
 	reader := bufio.NewReader(stream)
 	for {
 		line, err := reader.ReadString('\n')

--- a/internal/component/loki/source/kubernetes/kubetail/tailer_test.go
+++ b/internal/component/loki/source/kubernetes/kubetail/tailer_test.go
@@ -170,7 +170,7 @@ func Test_processLogStream(t *testing.T) {
 			lset, err := PrepareLabelsWithMetaPreservation(lset, "test", tc.preserveMetaLabels)
 			require.NoError(t, err)
 
-			target := NewTarget(lset, lset, tc.preserveMetaLabels)
+			target := NewTarget(lset, lset, tc.preserveMetaLabels, nil)
 			opts := &Options{
 				Positions: &mockPositions{},
 			}

--- a/internal/component/loki/source/kubernetes/kubetail/tailer_test.go
+++ b/internal/component/loki/source/kubernetes/kubetail/tailer_test.go
@@ -199,7 +199,7 @@ func Test_processLogStream(t *testing.T) {
 
 			// Process the log stream in a goroutine
 			go func() {
-				_ = tailer.processLogStream(ctx, stream, handler, tc.lastReadTime, positionsEnt, calc)
+				_ = tailer.processLogStream(ctx, stream, handler, tc.lastReadTime, positionsEnt, calc, func() {})
 			}()
 
 			// Collect all entries

--- a/internal/component/loki/source/kubernetes/kubetail/target.go
+++ b/internal/component/loki/source/kubernetes/kubetail/target.go
@@ -10,6 +10,8 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/grafana/alloy/internal/component/common/loki"
 )
 
 // Internal labels which indicate what container to tail logs from.
@@ -51,13 +53,20 @@ type Target struct {
 	uid            string // UID from pod
 	hash           uint64 // Hash of public labels and id
 
+	// handler is an optional per-target entry handler. When set, the tailer
+	// sends log entries to this handler instead of the global Options.Handler.
+	// This is used to route entries through a per-PodLogs processing pipeline.
+	handler loki.EntryHandler
+
 	mut       sync.RWMutex
 	lastError error
 	lastEntry time.Time
 }
 
-// NewTarget creates a new Target which can be passed to a tailer.
-func NewTarget(origLabels labels.Labels, lset labels.Labels, preserveMetaLabels bool) *Target {
+// NewTarget creates a new Target which can be passed to a tailer. handler is
+// optional: when non-nil the tailer will send log entries to it instead of the
+// global Options.Handler, allowing per-target processing pipelines.
+func NewTarget(origLabels labels.Labels, lset labels.Labels, preserveMetaLabels bool, handler loki.EntryHandler) *Target {
 	// Precompute some values based on labels so we don't have to continually
 	// search them.
 	var (
@@ -90,8 +99,13 @@ func NewTarget(origLabels labels.Labels, lset labels.Labels, preserveMetaLabels 
 		id:             id,
 		uid:            uid,
 		hash:           hash,
+		handler:        handler,
 	}
 }
+
+// Handler returns the optional per-target entry handler. When non-nil, the
+// tailer uses this handler instead of the global Options.Handler.
+func (t *Target) Handler() loki.EntryHandler { return t.handler }
 
 func publicLabels(lset labels.Labels, preserveMetaLabels bool) labels.Labels {
 	lb := labels.NewBuilder(lset)

--- a/internal/component/loki/source/podlogs/internal/apis/monitoring/v1alpha2/types.go
+++ b/internal/component/loki/source/podlogs/internal/apis/monitoring/v1alpha2/types.go
@@ -3,6 +3,8 @@ package v1alpha2
 import (
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/grafana/alloy/internal/component/loki/process/stages"
 )
 
 // +genclient
@@ -28,6 +30,13 @@ type PodLogsSpec struct {
 
 	// RelabelConfigs to apply to logs before delivering.
 	RelabelConfigs []*promv1.RelabelConfig `json:"relabelings,omitempty"`
+
+	// PipelineStages defines optional log processing stages applied to each
+	// log line collected by this PodLogs before forwarding. Stages are applied
+	// in order. Note: multiline, windowsevent, and eventlogmessage stages are
+	// not supported because log lines from different pods share the same
+	// pipeline and would be incorrectly merged.
+	PipelineStages []stages.PodLogsStageConfig `json:"pipelineStages,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/internal/component/loki/source/podlogs/internal/apis/monitoring/v1alpha2/zz_generated.deepcopy.go
+++ b/internal/component/loki/source/podlogs/internal/apis/monitoring/v1alpha2/zz_generated.deepcopy.go
@@ -5,7 +5,7 @@
 package v1alpha2
 
 import (
-	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/internal/component/loki/source/podlogs/podlogs.go
+++ b/internal/component/loki/source/podlogs/podlogs.go
@@ -124,9 +124,12 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		return nil, err
 	}
 
+	handler := loki.NewLogsReceiver()
+
 	var (
 		tailer     = kubetail.NewManager(o.Logger, nil)
-		reconciler = newReconciler(o.Logger, tailer, data.(cluster.Cluster))
+		reconciler = newReconciler(o.Logger, tailer, data.(cluster.Cluster),
+			o.Registerer, o.MinStability, handler.Chan())
 		controller = newController(o.Logger, reconciler)
 	)
 
@@ -139,7 +142,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		controller: controller,
 
 		positions: positionsFile,
-		handler:   loki.NewLogsReceiver(),
+		handler:   handler,
 		fanout:    loki.NewFanout(args.ForwardTo),
 	}
 	if err := c.Update(args); err != nil {
@@ -152,6 +155,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 func (c *Component) Run(ctx context.Context) error {
 	defer func() {
 		defer c.positions.Stop()
+		defer c.reconciler.CleanupAllPipelines()
 		loki.Drain(c.handler, c.fanout, loki.DefaultDrainTimeout, func() {
 			c.mut.Lock()
 			defer c.mut.Unlock()

--- a/internal/component/loki/source/podlogs/reconciler.go
+++ b/internal/component/loki/source/podlogs/reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/ckit/shard"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	promlabels "github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
@@ -21,8 +23,11 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/component/loki/process/stages"
 	"github.com/grafana/alloy/internal/component/loki/source/kubernetes/kubetail"
 	monitoringv1alpha2 "github.com/grafana/alloy/internal/component/loki/source/podlogs/internal/apis/monitoring/v1alpha2"
+	"github.com/grafana/alloy/internal/featuregate"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
 	"github.com/grafana/alloy/internal/service/cluster"
 )
@@ -59,12 +64,31 @@ const (
 	kubePodControllerName    = "__meta_kubernetes_pod_controller_name"
 )
 
+// managedPipeline holds the runtime state of a per-PodLogs processing pipeline.
+type managedPipeline struct {
+	// entryHandler is the input end of the pipeline. Tailers send entries here.
+	// Call Stop() to tear down the pipeline's goroutines.
+	entryHandler loki.EntryHandler
+	// stageConfig is kept for change-detection via reflect.DeepEqual.
+	stageConfig []stages.PodLogsStageConfig
+}
+
 // The reconciler reconciles the state of PodLogs on Kubernetes with targets to
 // collect logs from.
 type reconciler struct {
 	log     log.Logger
 	tailer  *kubetail.Manager
 	cluster cluster.Cluster
+
+	// Pipeline management: per-PodLogs processing pipelines.
+	// mainOutChan is where pipeline output is written (= component.handler.Chan()).
+	registerer   prometheus.Registerer
+	minStability featuregate.Stability
+	mainOutChan  chan loki.Entry
+
+	pipelinesMut    sync.Mutex
+	pipelines       map[string]*managedPipeline // key: "namespace/name"
+	replacedPipelines []loki.EntryHandler       // old handlers replaced this reconcile cycle; stopped after SyncTargets
 
 	reconcileMut             sync.RWMutex
 	podLogsSelector          labels.Selector
@@ -81,11 +105,23 @@ type reconciler struct {
 
 // newReconciler creates a new reconciler which synchronizes targets with the
 // provided tailer whenever Reconcile is called.
-func newReconciler(l log.Logger, tailer *kubetail.Manager, cluster cluster.Cluster) *reconciler {
+//
+// registerer, minStability, and mainOutChan are used to manage per-PodLogs
+// processing pipelines. mainOutChan should be the component's main handler
+// channel (component.handler.Chan()); pipeline output is written there so that
+// the existing loki.Consume loop forwards entries to the fanout unchanged.
+func newReconciler(l log.Logger, tailer *kubetail.Manager, cluster cluster.Cluster,
+	registerer prometheus.Registerer, minStability featuregate.Stability, mainOutChan chan loki.Entry,
+) *reconciler {
 	return &reconciler{
 		log:     l,
 		tailer:  tailer,
 		cluster: cluster,
+
+		registerer:   registerer,
+		minStability: minStability,
+		mainOutChan:  mainOutChan,
+		pipelines:    make(map[string]*managedPipeline),
 
 		podLogsSelector:          labels.Everything(),
 		podLogsNamespaceSelector: labels.Everything(),
@@ -165,6 +201,8 @@ func (r *reconciler) Reconcile(ctx context.Context, cli client.Client) error {
 		return fmt.Errorf("could not list PodLogs: %w", err)
 	}
 
+	activePipelineKeys := make(map[string]struct{})
+
 	for _, podLogs := range podLogsList.Items {
 		key := client.ObjectKeyFromObject(podLogs)
 
@@ -178,6 +216,10 @@ func (r *reconciler) Reconcile(ctx context.Context, cli client.Client) error {
 			continue
 		}
 
+		if len(podLogs.Spec.PipelineStages) > 0 {
+			activePipelineKeys[podLogs.Namespace+"/"+podLogs.Name] = struct{}{}
+		}
+
 		targets, discoveredPodLogs := r.reconcilePodLogs(ctx, cli, podLogs)
 
 		newTasks = append(newTasks, targets...)
@@ -189,9 +231,18 @@ func (r *reconciler) Reconcile(ctx context.Context, cli client.Client) error {
 		newTasks = distributeTargets(r.cluster, newTasks)
 	}
 
+	// SyncTargets stops removed tailer workers and waits for them to exit
+	// before returning. Pipelines must only be stopped after this point so
+	// that no tailer goroutine is left trying to write to a dead pipeline
+	// channel.
 	if err := r.tailer.SyncTargets(ctx, newTasks); err != nil {
 		level.Error(r.log).Log("msg", "failed to apply new tailers to run", "err", err)
 	}
+
+	// Now it is safe to tear down pipelines: all tailers that referenced them
+	// have exited.
+	r.cleanupStalePipelines(activePipelineKeys)
+	r.stopReplacedPipelines()
 
 	r.debugMut.Lock()
 	r.debugInfo = newDebugInfo
@@ -265,6 +316,21 @@ func (r *reconciler) reconcilePodLogs(ctx context.Context, cli client.Client, po
 		discoveredPodLogs.ReconcileError = fmt.Sprintf("invalid relabelings: %s", err)
 		level.Error(r.log).Log("msg", "failed to reconcile PodLogs", "operation", "convert relabelings", "key", key, "err", err)
 		return targets, discoveredPodLogs
+	}
+
+	// Determine the per-target entry handler. When PipelineStages are configured,
+	// entries are routed through a dedicated processing pipeline for this PodLogs.
+	// Otherwise nil means the global handler (Options.Handler) is used.
+	var targetHandler loki.EntryHandler
+	if len(podLogs.Spec.PipelineStages) > 0 {
+		pipelineKey := podLogs.Namespace + "/" + podLogs.Name
+		handler, err := r.ensurePipeline(pipelineKey, podLogs.Spec.PipelineStages)
+		if err != nil {
+			discoveredPodLogs.ReconcileError = fmt.Sprintf("invalid pipeline stages: %s", err)
+			level.Error(r.log).Log("msg", "failed to reconcile PodLogs", "operation", "build pipeline", "key", key, "err", err)
+			return targets, discoveredPodLogs
+		}
+		targetHandler = handler
 	}
 
 	sel, err := metav1.LabelSelectorAsSelector(&podLogs.Spec.Selector)
@@ -351,7 +417,7 @@ func (r *reconciler) reconcilePodLogs(ctx context.Context, cli client.Client, po
 				return
 			}
 
-			target := kubetail.NewTarget(targetLabels.Copy(), finalLabels, preserveMetaLabels)
+			target := kubetail.NewTarget(targetLabels.Copy(), finalLabels, preserveMetaLabels, targetHandler)
 			if processedLabels.Len() != 0 {
 				targets = append(targets, target)
 			}
@@ -373,6 +439,98 @@ func (r *reconciler) reconcilePodLogs(ctx context.Context, cli client.Client, po
 	}
 
 	return targets, discoveredPodLogs
+}
+
+// ensurePipeline returns the entry handler for a PodLogs pipeline, creating or
+// replacing it if the stage config has changed. The returned handler's Chan()
+// is the pipeline input; entries written there are processed and forwarded to
+// r.mainOutChan.
+func (r *reconciler) ensurePipeline(key string, stageConfigs []stages.PodLogsStageConfig) (loki.EntryHandler, error) {
+	r.pipelinesMut.Lock()
+	defer r.pipelinesMut.Unlock()
+
+	if existing, ok := r.pipelines[key]; ok && reflect.DeepEqual(existing.stageConfig, stageConfigs) {
+		// Stage config unchanged — reuse existing pipeline.
+		return existing.entryHandler, nil
+	}
+
+	// Stages changed (or this is first time): queue the old pipeline for
+	// deferred stop. It must not be stopped here because tailer goroutines
+	// targeting the old pipeline may still be running; they are stopped
+	// by SyncTargets (which waits for worker exit) before we drain
+	// replacedPipelines in Reconcile.
+	if existing, ok := r.pipelines[key]; ok {
+		r.replacedPipelines = append(r.replacedPipelines, existing.entryHandler)
+		delete(r.pipelines, key)
+	}
+
+	// Build a namespaced registerer so per-PodLogs metrics don't conflict.
+	ns, name, _ := strings.Cut(key, "/")
+	pipelineRegisterer := prometheus.WrapRegistererWith(prometheus.Labels{
+		"podlogs_namespace": ns,
+		"podlogs_name":      name,
+	}, r.registerer)
+
+	pipeline, err := stages.NewPipeline(r.log, stages.ConvertPodLogsStages(stageConfigs), pipelineRegisterer, r.minStability)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Pipeline.Start spawns N_stages+3 goroutines per PodLogs resource.
+	// At large scale (hundreds of PodLogs with stages) this adds up. A future
+	// improvement would be to add a synchronous Pipeline.Process(entry) path so
+	// stages can be applied inline inside each tailer goroutine (zero overhead).
+	pipelineIn := loki.NewLogsReceiver()
+	entryHandler := pipeline.Start(pipelineIn.Chan(), r.mainOutChan)
+
+	r.pipelines[key] = &managedPipeline{
+		entryHandler: entryHandler,
+		stageConfig:  stageConfigs,
+	}
+
+	level.Debug(r.log).Log("msg", "started processing pipeline for PodLogs", "key", key, "stages", len(stageConfigs))
+	return entryHandler, nil
+}
+
+// cleanupStalePipelines stops pipelines for PodLogs keys that are no longer
+// in the active set. Must be called after reconciliation is complete.
+func (r *reconciler) cleanupStalePipelines(activeKeys map[string]struct{}) {
+	r.pipelinesMut.Lock()
+	defer r.pipelinesMut.Unlock()
+
+	for key, p := range r.pipelines {
+		if _, active := activeKeys[key]; !active {
+			p.entryHandler.Stop()
+			delete(r.pipelines, key)
+			level.Debug(r.log).Log("msg", "stopped processing pipeline for PodLogs", "key", key)
+		}
+	}
+}
+
+// stopReplacedPipelines stops pipelines that were replaced during this reconcile
+// cycle (stage config changed). Must be called after SyncTargets so that all
+// tailer goroutines referencing the old handlers have already exited.
+func (r *reconciler) stopReplacedPipelines() {
+	r.pipelinesMut.Lock()
+	replaced := r.replacedPipelines
+	r.replacedPipelines = nil
+	r.pipelinesMut.Unlock()
+
+	for _, h := range replaced {
+		h.Stop()
+	}
+}
+
+// CleanupAllPipelines stops all running pipelines. Called on component shutdown.
+func (r *reconciler) CleanupAllPipelines() {
+	r.pipelinesMut.Lock()
+	defer r.pipelinesMut.Unlock()
+
+	for key, p := range r.pipelines {
+		p.entryHandler.Stop()
+		delete(r.pipelines, key)
+		level.Debug(r.log).Log("msg", "stopped processing pipeline for PodLogs on shutdown", "key", key)
+	}
 }
 
 // DebugInfo returns the current debug information for the reconciler.

--- a/internal/component/loki/source/podlogs/reconciler.go
+++ b/internal/component/loki/source/podlogs/reconciler.go
@@ -216,11 +216,18 @@ func (r *reconciler) Reconcile(ctx context.Context, cli client.Client) error {
 			continue
 		}
 
-		if len(podLogs.Spec.PipelineStages) > 0 {
-			activePipelineKeys[podLogs.Namespace+"/"+podLogs.Name] = struct{}{}
-		}
-
 		targets, discoveredPodLogs := r.reconcilePodLogs(ctx, cli, podLogs)
+
+		// Populate activePipelineKeys only when a pipeline was successfully created
+		// (ensurePipeline may fail or reconcilePodLogs may return early). Checking
+		// r.pipelines after the call is safe: ensurePipeline holds pipelinesMut while
+		// inserting, so by the time reconcilePodLogs returns the map is up to date.
+		pipelineKey := podLogs.Namespace + "/" + podLogs.Name
+		r.pipelinesMut.Lock()
+		if _, ok := r.pipelines[pipelineKey]; ok {
+			activePipelineKeys[pipelineKey] = struct{}{}
+		}
+		r.pipelinesMut.Unlock()
 
 		newTasks = append(newTasks, targets...)
 		newDebugInfo = append(newDebugInfo, discoveredPodLogs)

--- a/internal/component/loki/source/podlogs/reconciler_test.go
+++ b/internal/component/loki/source/podlogs/reconciler_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/util/strutil"
@@ -15,9 +16,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	lokicommon "github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/component/loki/source/kubernetes/kubetail"
 	monitoringv1alpha2 "github.com/grafana/alloy/internal/component/loki/source/podlogs/internal/apis/monitoring/v1alpha2"
+	"github.com/grafana/alloy/internal/featuregate"
 )
+
+// newTestReconciler creates a reconciler suitable for unit tests.
+// tailer and cluster are nil (not exercised by most tests).
+func newTestReconciler() *reconciler {
+	ch := make(chan lokicommon.Entry, 100)
+	return newReconciler(log.NewNopLogger(), nil, nil,
+		prometheus.NewRegistry(), featuregate.StabilityGenerallyAvailable, ch)
+}
 
 func TestBuildPodLogsTargetLabels(t *testing.T) {
 	tests := []struct {
@@ -177,7 +188,7 @@ func TestReconcilePodLogs_DefaultLabels(t *testing.T) {
 
 	// Create a reconciler. The tailer and cluster are not used by reconcilePodLogs,
 	// so we can pass nil.
-	r := newReconciler(log.NewNopLogger(), nil, nil)
+	r := newTestReconciler()
 
 	// Call reconcilePodLogs.
 	targets, _ := r.reconcilePodLogs(t.Context(), cl, podLogs)
@@ -391,7 +402,7 @@ func TestReconcilePodLogs_NodeFiltering(t *testing.T) {
 			}).Build()
 
 			// Create a reconciler and configure node filtering
-			r := newReconciler(log.NewNopLogger(), nil, nil)
+			r := newTestReconciler()
 			r.UpdateNodeFilter(tt.nodeFilterEnabled, tt.nodeFilterName)
 
 			// Call reconcilePodLogs.
@@ -434,7 +445,7 @@ func TestReconcilePodLogs_NodeFiltering(t *testing.T) {
 }
 
 func TestNodeFilterConfiguration(t *testing.T) {
-	r := newReconciler(log.NewNopLogger(), nil, nil)
+	r := newTestReconciler()
 
 	// Test initial state
 	if r.getNodeFilterName() != "" {
@@ -469,7 +480,7 @@ func TestNodeFilterConfiguration(t *testing.T) {
 
 func TestPreserveDiscoveredLabels_MetaLabelPreservation(t *testing.T) {
 	// Create a reconciler with preserve discovered labels enabled
-	r := newReconciler(log.NewNopLogger(), nil, nil)
+	r := newTestReconciler()
 	r.UpdatePreserveMetaLabels(true)
 
 	// Verify the preserveMetaLabels field is set correctly

--- a/operations/helm/charts/alloy/charts/crds/crds/monitoring.grafana.com_podlogs.yaml
+++ b/operations/helm/charts/alloy/charts/crds/crds/monitoring.grafana.com_podlogs.yaml
@@ -151,6 +151,423 @@ spec:
                       type: string
                   type: object
                 type: array
+              pipelineStages:
+                description: PipelineStages defines optional log processing stages
+                  applied to each log line before forwarding. Stages are applied in
+                  order. Note that multiline, windowsevent, and eventlogmessage stages
+                  are not supported.
+                items:
+                  description: PodLogsStageConfig defines a single log processing
+                    stage. Exactly one field should be set.
+                  properties:
+                    cri:
+                      description: CRI is a pre-processing stage for CRI-formatted
+                        log lines.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    decolorize:
+                      description: Decolorize strips ANSI color codes from log lines.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    docker:
+                      description: Docker is a pre-processing stage for Docker-formatted
+                        log lines.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    drop:
+                      description: Drop configures dropping log lines that match a
+                        condition.
+                      properties:
+                        dropReason:
+                          description: Custom reason to report for dropped lines in
+                            metrics.
+                          type: string
+                        expression:
+                          description: RE2 regular expression; lines matching it are
+                            dropped.
+                          type: string
+                        longerThan:
+                          description: Drop lines longer than this size (e.g. "8KiB").
+                          type: string
+                        separator:
+                          description: Separator used when joining multiple source
+                            values.
+                          type: string
+                        source:
+                          description: Name of the extracted value to match against.
+                            Defaults to the log line.
+                          type: string
+                        value:
+                          description: Exact string the source value must equal to
+                            trigger a drop.
+                          type: string
+                      type: object
+                    geoip:
+                      description: GeoIP adds geo-location labels derived from an
+                        IP address.
+                      properties:
+                        customLookups:
+                          additionalProperties:
+                            type: string
+                          description: Custom lookup fields to add from the database.
+                          type: object
+                        db:
+                          description: Path to the MaxMind GeoIP database file.
+                          type: string
+                        dbType:
+                          description: 'Database type: city, asn, or country.'
+                          type: string
+                        source:
+                          description: Label or extracted key holding the IP address.
+                          type: string
+                      type: object
+                    json:
+                      description: JSON extracts fields from a JSON log line.
+                      properties:
+                        dropMalformed:
+                          description: Drop lines that cannot be parsed as JSON.
+                          type: boolean
+                        expressions:
+                          additionalProperties:
+                            type: string
+                          description: Map of extracted key to optional JMESPath expression.
+                          type: object
+                        source:
+                          description: If set, parse this extracted value instead of
+                            the log line.
+                          type: string
+                      type: object
+                    label_drop:
+                      description: LabelDrop removes labels from the label set.
+                      properties:
+                        values:
+                          description: List of label names to remove.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    label_keep:
+                      description: LabelKeep retains only the listed labels.
+                      properties:
+                        values:
+                          description: List of label names to keep.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    labels:
+                      description: Labels promotes extracted values to log labels.
+                      properties:
+                        sourceType:
+                          description: 'Source of values: extracted (default) or structured_metadata.'
+                          type: string
+                        values:
+                          additionalProperties:
+                            type: string
+                          description: Map of label name to optional extracted key.
+                          type: object
+                      type: object
+                    limit:
+                      description: Limit rate-limits or drops log lines.
+                      properties:
+                        burst:
+                          description: Maximum burst size in lines.
+                          format: int64
+                          type: integer
+                        byLabelName:
+                          description: Apply per-value limits keyed by this label.
+                          type: string
+                        drop:
+                          description: Drop lines that exceed the rate limit instead
+                            of blocking.
+                          type: boolean
+                        maxDistinctLabels:
+                          description: Maximum number of distinct label values to
+                            track for byLabelName.
+                          type: integer
+                        rate:
+                          description: Steady-state rate limit in lines per second.
+                          format: int64
+                          type: integer
+                      required:
+                      - burst
+                      - rate
+                      type: object
+                    logfmt:
+                      description: Logfmt parses a logfmt-formatted log line.
+                      properties:
+                        mapping:
+                          additionalProperties:
+                            type: string
+                          description: Map of extracted key to logfmt field name.
+                          type: object
+                        source:
+                          description: Parse this extracted value instead of the log
+                            line.
+                          type: string
+                      type: object
+                    luhn:
+                      description: Luhn redacts Luhn-valid numbers (e.g. credit card
+                        numbers) from log lines.
+                      properties:
+                        delimiters:
+                          description: Characters that may appear between digits.
+                          type: string
+                        minLength:
+                          description: Minimum digit length to consider.
+                          type: integer
+                        replacement:
+                          description: Replacement string for redacted numbers.
+                          type: string
+                        source:
+                          description: Extracted key to redact instead of the log
+                            line.
+                          type: string
+                      type: object
+                    match:
+                      description: Match applies nested stages only to lines matching
+                        a LogQL stream selector.
+                      properties:
+                        action:
+                          description: 'Action when the selector matches: keep (default)
+                            or drop.'
+                          type: string
+                        dropReason:
+                          description: Custom drop reason for metrics when action is
+                            drop.
+                          type: string
+                        pipelineName:
+                          description: Optional name for the nested pipeline, used
+                            in metrics.
+                          type: string
+                        selector:
+                          description: LogQL stream selector expression.
+                          type: string
+                        stages:
+                          description: Nested pipeline stages applied to matching
+                            lines.
+                          items:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          type: array
+                      required:
+                      - selector
+                      type: object
+                    metrics:
+                      description: Metrics generates Prometheus metrics from log lines.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    output:
+                      description: Output sets the log line to an extracted value.
+                      properties:
+                        source:
+                          description: Extracted key whose value becomes the new log
+                            line.
+                          type: string
+                      required:
+                      - source
+                      type: object
+                    pack:
+                      description: Pack converts labels into a packed log line format.
+                      properties:
+                        ingestTimestamp:
+                          description: Use the ingestion timestamp instead of the
+                            log timestamp.
+                          type: boolean
+                        labels:
+                          description: Labels to pack into the log line.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - labels
+                      type: object
+                    pattern:
+                      description: Pattern extracts values using a Loki pattern expression.
+                      properties:
+                        labelsFromGroups:
+                          description: Promote captured groups directly to labels.
+                          type: boolean
+                        pattern:
+                          description: Loki pattern expression.
+                          type: string
+                        source:
+                          description: Extracted key to match instead of the log line.
+                          type: string
+                      required:
+                      - pattern
+                      type: object
+                    regex:
+                      description: Regex extracts values using a RE2 named-group expression.
+                      properties:
+                        expression:
+                          description: RE2 expression with named capture groups.
+                          type: string
+                        labelsFromGroups:
+                          description: Promote capture groups directly to labels.
+                          type: boolean
+                        source:
+                          description: Extracted key to match instead of the log line.
+                          type: string
+                      required:
+                      - expression
+                      type: object
+                    replace:
+                      description: Replace performs a regex find-and-replace on the
+                        log line or an extracted value.
+                      properties:
+                        expression:
+                          description: RE2 expression to match.
+                          type: string
+                        replace:
+                          description: Replacement string (supports capture group references).
+                          type: string
+                        source:
+                          description: Extracted key to operate on instead of the
+                            log line.
+                          type: string
+                      required:
+                      - expression
+                      type: object
+                    sampling:
+                      description: Sampling randomly drops a fraction of log lines.
+                      properties:
+                        dropReason:
+                          description: Custom reason for dropped lines in metrics.
+                          type: string
+                        rate:
+                          description: Fraction of lines to keep (0.0–1.0).
+                          type: number
+                      required:
+                      - rate
+                      type: object
+                    static_labels:
+                      description: StaticLabels adds a fixed set of labels to every
+                        log entry.
+                      properties:
+                        values:
+                          additionalProperties:
+                            type: string
+                          description: Map of label name to static value.
+                          type: object
+                      type: object
+                    structured_metadata:
+                      description: StructuredMetadata promotes extracted values to
+                        Loki structured metadata.
+                      properties:
+                        regex:
+                          additionalProperties:
+                            type: string
+                          description: Map of metadata key to regex to extract from
+                            log line.
+                          type: object
+                        values:
+                          additionalProperties:
+                            type: string
+                          description: Map of metadata key to optional extracted key.
+                          type: object
+                      type: object
+                    structured_metadata_drop:
+                      description: StructuredMetadataDrop removes structured metadata
+                        keys.
+                      properties:
+                        values:
+                          description: List of structured metadata keys to remove.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    template:
+                      description: Template uses Go templates to create or modify extracted
+                        values.
+                      properties:
+                        source:
+                          description: Extracted key to set.
+                          type: string
+                        template:
+                          description: Go template string; can reference other extracted
+                            values with {{.Value}}.
+                          type: string
+                      required:
+                      - source
+                      - template
+                      type: object
+                    tenant:
+                      description: Tenant overrides the tenant ID for log entries.
+                      properties:
+                        label:
+                          description: Label whose value is used as the tenant ID.
+                          type: string
+                        source:
+                          description: Extracted key whose value is used as the tenant
+                            ID.
+                          type: string
+                        value:
+                          description: Static tenant ID value.
+                          type: string
+                      type: object
+                    timestamp:
+                      description: Timestamp parses a timestamp from an extracted
+                        value and sets it as the log entry timestamp.
+                      properties:
+                        actionOnFailure:
+                          description: 'Action when parsing fails: skip (default)
+                            or fudge.'
+                          type: string
+                        fallbackFormats:
+                          description: Additional formats to try if the primary format
+                            fails.
+                          items:
+                            type: string
+                          type: array
+                        format:
+                          description: Timestamp format (Go reference time, Unix,
+                            UnixMs, UnixUs, UnixNs, or RFC3339).
+                          type: string
+                        location:
+                          description: IANA timezone name for formats without timezone
+                            info.
+                          type: string
+                        source:
+                          description: Extracted key containing the timestamp string.
+                          type: string
+                      required:
+                      - format
+                      - source
+                      type: object
+                    truncate:
+                      description: Truncate shortens log lines or extracted values.
+                      properties:
+                        rules:
+                          description: Truncation rules to apply.
+                          items:
+                            description: TruncateRuleConfig defines a single truncation
+                              rule.
+                            properties:
+                              limit:
+                                description: Maximum length in bytes; 0 means no limit.
+                                type: integer
+                              sourceType:
+                                description: 'Source type: line or label.'
+                                type: string
+                              sources:
+                                description: Label names to truncate (when sourceType
+                                  is label).
+                                items:
+                                  type: string
+                                type: array
+                              suffix:
+                                description: String appended to truncated values.
+                                type: string
+                            required:
+                            - limit
+                            type: object
+                          type: array
+                      required:
+                      - rules
+                      type: object
+                  type: object
+                type: array
               selector:
                 description: Selector to select Pod objects. Required.
                 properties:


### PR DESCRIPTION
## Summary

> **Merge order:** this PR depends on #5999 (JSON tags) and should be merged after it.

Embeds a `loki.process`-style pipeline directly in the `PodLogs` CRD spec so teams can self-service drop/transform logs at collection time, without coupling to a shared `loki.process` component in the global Alloy config.

### What's added

- `PodLogsStageConfig` — a JSON-only subset of `StageConfig` that excludes stages incompatible with a shared per-CRD pipeline:
  - `multiline`: lines from different pods interleave, causing incorrect merging across pod boundaries.
  - `windowsevent` / `eventlogmessage`: not applicable to Linux pod logs.
- `PodLogsDropConfig` — mirrors `DropConfig` but with `OlderThan string` (e.g. `"5m"`) instead of `time.Duration` (which serialises as a nanosecond int64 in JSON).
- `PodLogsMatchConfig` — mirrors `MatchConfig` but uses `[]PodLogsStageConfig` for nested stages, so the exclusions apply recursively.
- `PipelineStages []PodLogsStageConfig` field in `PodLogsSpec`.
- Per-PodLogs pipeline lifecycle in the reconciler: pipelines are created/replaced when stage config changes, stopped after `SyncTargets` (so no tailer goroutine writes to a dead channel), and torn down on component shutdown.
- Per-target `loki.EntryHandler` in `kubetail.Target` so tailers route entries to the pipeline rather than the global handler.
- OpenAPIV3 schema for `pipelineStages` in the CRD YAML.

### Design notes

- One pipeline per PodLogs resource (shared across all matched pods/containers). Multiline is explicitly excluded for correctness.
- Metrics are namespaced per PodLogs via `prometheus.WrapRegistererWith`.
- Backoff reset works correctly on both the default handler path and the pipeline path.

## Test plan

- [ ] PodLogs with `pipelineStages` drops/transforms entries correctly
- [ ] PodLogs without `pipelineStages` behaves identically to today
- [ ] Invalid `olderThan` duration surfaces as a reconcile error, not a silent no-op
- [ ] Changing `pipelineStages` on a live CRD restarts the pipeline without leaking goroutines
- [ ] `node_filter` works correctly with pipelines

Refs: #4738

🤖 Generated with [Claude Code](https://claude.com/claude-code)