### PR TITLE
perf(loki/stages): add SyncStage to reduce pipeline goroutines (N+3 → 1 per PodLogs)

### DIFF
--- a/internal/component/loki/process/metric/counters.go
+++ b/internal/component/loki/process/metric/counters.go
@@ -18,17 +18,17 @@ const (
 // CounterConfig defines a counter metric whose value only goes up.
 type CounterConfig struct {
 	// Shared fields
-	Name        string        `alloy:"name,attr"`
-	Description string        `alloy:"description,attr,optional"`
-	Source      string        `alloy:"source,attr,optional"`
-	Prefix      string        `alloy:"prefix,attr,optional"`
-	MaxIdle     time.Duration `alloy:"max_idle_duration,attr,optional"`
-	Value       string        `alloy:"value,attr,optional"`
+	Name        string        `alloy:"name,attr"                       json:"name"`
+	Description string        `alloy:"description,attr,optional"       json:"description,omitempty"`
+	Source      string        `alloy:"source,attr,optional"            json:"source,omitempty"`
+	Prefix      string        `alloy:"prefix,attr,optional"            json:"prefix,omitempty"`
+	MaxIdle     time.Duration `alloy:"max_idle_duration,attr,optional" json:"-"` // not supported in CRD: time.Duration is nanosecond int64 in JSON
+	Value       string        `alloy:"value,attr,optional"             json:"value,omitempty"`
 
 	// Counter-specific fields
-	Action          string `alloy:"action,attr"`
-	MatchAll        bool   `alloy:"match_all,attr,optional"`
-	CountEntryBytes bool   `alloy:"count_entry_bytes,attr,optional"`
+	Action          string `alloy:"action,attr"                    json:"action"`
+	MatchAll        bool   `alloy:"match_all,attr,optional"        json:"matchAll,omitempty"`
+	CountEntryBytes bool   `alloy:"count_entry_bytes,attr,optional" json:"countEntryBytes,omitempty"`
 }
 
 // DefaultCounterConfig sets the default for a Counter.

--- a/internal/component/loki/process/metric/gauges.go
+++ b/internal/component/loki/process/metric/gauges.go
@@ -29,15 +29,15 @@ var DefaultGaugeConfig = GaugeConfig{
 // GaugeConfig defines a gauge metric whose value can go up or down.
 type GaugeConfig struct {
 	// Shared fields
-	Name        string        `alloy:"name,attr"`
-	Description string        `alloy:"description,attr,optional"`
-	Source      string        `alloy:"source,attr,optional"`
-	Prefix      string        `alloy:"prefix,attr,optional"`
-	MaxIdle     time.Duration `alloy:"max_idle_duration,attr,optional"`
-	Value       string        `alloy:"value,attr,optional"`
+	Name        string        `alloy:"name,attr"                       json:"name"`
+	Description string        `alloy:"description,attr,optional"       json:"description,omitempty"`
+	Source      string        `alloy:"source,attr,optional"            json:"source,omitempty"`
+	Prefix      string        `alloy:"prefix,attr,optional"            json:"prefix,omitempty"`
+	MaxIdle     time.Duration `alloy:"max_idle_duration,attr,optional" json:"-"` // not supported in CRD: time.Duration is nanosecond int64 in JSON
+	Value       string        `alloy:"value,attr,optional"             json:"value,omitempty"`
 
 	// Gauge-specific fields
-	Action string `alloy:"action,attr"`
+	Action string `alloy:"action,attr" json:"action"`
 }
 
 // SetToDefault implements syntax.Defaulter.

--- a/internal/component/loki/process/metric/histograms.go
+++ b/internal/component/loki/process/metric/histograms.go
@@ -18,15 +18,15 @@ var DefaultHistogramConfig = HistogramConfig{
 // HistogramConfig defines a histogram metric whose values are bucketed.
 type HistogramConfig struct {
 	// Shared fields
-	Name        string        `alloy:"name,attr"`
-	Description string        `alloy:"description,attr,optional"`
-	Source      string        `alloy:"source,attr,optional"`
-	Prefix      string        `alloy:"prefix,attr,optional"`
-	MaxIdle     time.Duration `alloy:"max_idle_duration,attr,optional"`
-	Value       string        `alloy:"value,attr,optional"`
+	Name        string        `alloy:"name,attr"                       json:"name"`
+	Description string        `alloy:"description,attr,optional"       json:"description,omitempty"`
+	Source      string        `alloy:"source,attr,optional"            json:"source,omitempty"`
+	Prefix      string        `alloy:"prefix,attr,optional"            json:"prefix,omitempty"`
+	MaxIdle     time.Duration `alloy:"max_idle_duration,attr,optional" json:"-"` // not supported in CRD: time.Duration is nanosecond int64 in JSON
+	Value       string        `alloy:"value,attr,optional"             json:"value,omitempty"`
 
 	// Histogram-specific fields
-	Buckets []float64 `alloy:"buckets,attr"`
+	Buckets []float64 `alloy:"buckets,attr" json:"buckets"`
 }
 
 // SetToDefault implements syntax.Defaulter.

--- a/internal/component/loki/process/stages/cri.go
+++ b/internal/component/loki/process/stages/cri.go
@@ -96,82 +96,7 @@ const (
 )
 
 func (c *cri) Run(in chan Entry) chan Entry {
-	return RunWithSkipOrSendMany(in, func(e Entry) ([]Entry, bool) {
-		parsed, ok := crip.ParseCRI(e.Line)
-		if !ok {
-			return []Entry{e}, false
-		}
-
-		// NOTE: Previous implementation used a "sub-pipeline"
-		// to parse CRI logs where the regex stage added these fields
-		// as "extracted" values so the other stages could operate on them.
-		// We don't need this anymore but it would be a breaking change to
-		// no longer set these.
-		e.Extracted[criFlags] = parsed.Flag.String()
-		e.Extracted[criStream] = parsed.Stream.String()
-		e.Extracted[criContent] = parsed.Content
-		e.Extracted[criTime] = parsed.Timestamp
-
-		e.Line = parsed.Content
-
-		ts, err := time.Parse(time.RFC3339Nano, parsed.Timestamp)
-		if err == nil {
-			e.Timestamp = ts
-		}
-
-		e.Labels[criStream] = model.LabelValue(parsed.Stream.String())
-
-		fingerprint := e.Labels.Fingerprint()
-		// We received partial-line (tag: "P")
-		if parsed.Flag == crip.FlagPartial {
-			if len(c.partialLines) >= c.cfg.MaxPartialLines {
-				level.Warn(c.logger).Log("msg", "cri stage: partial lines upperbound exceeded. merging it to single line", "threshold", c.cfg.MaxPartialLines)
-				if c.partialLinesFlushedMetric != nil {
-					c.partialLinesFlushedMetric.Add(float64(len(c.partialLines)))
-				}
-
-				// Merge existing partialLines
-				entries := make([]Entry, 0, len(c.partialLines))
-				for _, v := range c.partialLines {
-					entries = append(entries, v)
-				}
-
-				c.partialLines = make(map[model.Fingerprint]Entry, c.cfg.MaxPartialLines)
-				c.ensureTruncateIfRequired(&e)
-				c.partialLines[fingerprint] = e
-
-				return entries, false
-			}
-
-			prev, ok := c.partialLines[fingerprint]
-			if ok {
-				var builder strings.Builder
-				builder.WriteString(prev.Line)
-				builder.WriteString(e.Line)
-				e.Line = builder.String()
-			}
-			c.ensureTruncateIfRequired(&e)
-			c.partialLines[fingerprint] = e
-
-			// it's a partial-line so skip it.
-			return nil, true
-		}
-
-		// We got full-line 'F'.
-		// If any old partial lines matches with this full-line stream, merge it,
-		// else just return the full line.
-		prev, ok := c.partialLines[fingerprint]
-		if ok {
-			var builder strings.Builder
-			builder.WriteString(prev.Line)
-			builder.WriteString(e.Line)
-			e.Line = builder.String()
-			c.ensureTruncateIfRequired(&e)
-			delete(c.partialLines, fingerprint)
-		}
-
-		return []Entry{e}, false
-	})
+	return RunWithSkipOrSendMany(in, c.processLine)
 }
 
 func (c *cri) ensureTruncateIfRequired(e *Entry) {
@@ -185,55 +110,53 @@ func (c *cri) ensureTruncateIfRequired(e *Entry) {
 
 func (c *cri) Cleanup() {}
 
-// ProcessEntry implements SyncStage. It applies CRI parsing inline without goroutines.
-func (c *cri) ProcessEntry(e Entry) []Entry {
-	entries, skip := func(e Entry) ([]Entry, bool) {
-		parsed, ok := crip.ParseCRI(e.Line)
-		if !ok {
-			return []Entry{e}, false
-		}
+// processLine parses a single CRI log entry and manages partial-line merging.
+// Returns the resulting entries and whether the entry should be skipped.
+func (c *cri) processLine(e Entry) ([]Entry, bool) {
+	parsed, ok := crip.ParseCRI(e.Line)
+	if !ok {
+		return []Entry{e}, false
+	}
 
-		e.Extracted[criFlags] = parsed.Flag.String()
-		e.Extracted[criStream] = parsed.Stream.String()
-		e.Extracted[criContent] = parsed.Content
-		e.Extracted[criTime] = parsed.Timestamp
+	// NOTE: Previous implementation used a "sub-pipeline"
+	// to parse CRI logs where the regex stage added these fields
+	// as "extracted" values so the other stages could operate on them.
+	// We don't need this anymore but it would be a breaking change to
+	// no longer set these.
+	e.Extracted[criFlags] = parsed.Flag.String()
+	e.Extracted[criStream] = parsed.Stream.String()
+	e.Extracted[criContent] = parsed.Content
+	e.Extracted[criTime] = parsed.Timestamp
 
-		e.Line = parsed.Content
+	e.Line = parsed.Content
 
-		ts, err := time.Parse(time.RFC3339Nano, parsed.Timestamp)
-		if err == nil {
-			e.Timestamp = ts
-		}
+	ts, err := time.Parse(time.RFC3339Nano, parsed.Timestamp)
+	if err == nil {
+		e.Timestamp = ts
+	}
 
-		e.Labels[criStream] = model.LabelValue(parsed.Stream.String())
+	e.Labels[criStream] = model.LabelValue(parsed.Stream.String())
 
-		fingerprint := e.Labels.Fingerprint()
-		if parsed.Flag == crip.FlagPartial {
-			if len(c.partialLines) >= c.cfg.MaxPartialLines {
-				level.Warn(c.logger).Log("msg", "cri stage: partial lines upperbound exceeded. merging it to single line", "threshold", c.cfg.MaxPartialLines)
-				if c.partialLinesFlushedMetric != nil {
-					c.partialLinesFlushedMetric.Add(float64(len(c.partialLines)))
-				}
-				entries := make([]Entry, 0, len(c.partialLines))
-				for _, v := range c.partialLines {
-					entries = append(entries, v)
-				}
-				c.partialLines = make(map[model.Fingerprint]Entry, c.cfg.MaxPartialLines)
-				c.ensureTruncateIfRequired(&e)
-				c.partialLines[fingerprint] = e
-				return entries, false
+	fingerprint := e.Labels.Fingerprint()
+	// We received partial-line (tag: "P")
+	if parsed.Flag == crip.FlagPartial {
+		if len(c.partialLines) >= c.cfg.MaxPartialLines {
+			level.Warn(c.logger).Log("msg", "cri stage: partial lines upperbound exceeded. merging it to single line", "threshold", c.cfg.MaxPartialLines)
+			if c.partialLinesFlushedMetric != nil {
+				c.partialLinesFlushedMetric.Add(float64(len(c.partialLines)))
 			}
 
-			prev, ok := c.partialLines[fingerprint]
-			if ok {
-				var builder strings.Builder
-				builder.WriteString(prev.Line)
-				builder.WriteString(e.Line)
-				e.Line = builder.String()
+			// Merge existing partialLines
+			entries := make([]Entry, 0, len(c.partialLines))
+			for _, v := range c.partialLines {
+				entries = append(entries, v)
 			}
+
+			c.partialLines = make(map[model.Fingerprint]Entry, c.cfg.MaxPartialLines)
 			c.ensureTruncateIfRequired(&e)
 			c.partialLines[fingerprint] = e
-			return nil, true
+
+			return entries, false
 		}
 
 		prev, ok := c.partialLines[fingerprint]
@@ -242,13 +165,33 @@ func (c *cri) ProcessEntry(e Entry) []Entry {
 			builder.WriteString(prev.Line)
 			builder.WriteString(e.Line)
 			e.Line = builder.String()
-			c.ensureTruncateIfRequired(&e)
-			delete(c.partialLines, fingerprint)
 		}
+		c.ensureTruncateIfRequired(&e)
+		c.partialLines[fingerprint] = e
 
-		return []Entry{e}, false
-	}(e)
+		// it's a partial-line so skip it.
+		return nil, true
+	}
 
+	// We got full-line 'F'.
+	// If any old partial lines matches with this full-line stream, merge it,
+	// else just return the full line.
+	prev, ok := c.partialLines[fingerprint]
+	if ok {
+		var builder strings.Builder
+		builder.WriteString(prev.Line)
+		builder.WriteString(e.Line)
+		e.Line = builder.String()
+		c.ensureTruncateIfRequired(&e)
+		delete(c.partialLines, fingerprint)
+	}
+
+	return []Entry{e}, false
+}
+
+// ProcessEntry implements SyncStage.
+func (c *cri) ProcessEntry(e Entry) []Entry {
+	entries, skip := c.processLine(e)
 	if skip {
 		return nil
 	}

--- a/internal/component/loki/process/stages/cri.go
+++ b/internal/component/loki/process/stages/cri.go
@@ -184,3 +184,73 @@ func (c *cri) ensureTruncateIfRequired(e *Entry) {
 }
 
 func (c *cri) Cleanup() {}
+
+// ProcessEntry implements SyncStage. It applies CRI parsing inline without goroutines.
+func (c *cri) ProcessEntry(e Entry) []Entry {
+	entries, skip := func(e Entry) ([]Entry, bool) {
+		parsed, ok := crip.ParseCRI(e.Line)
+		if !ok {
+			return []Entry{e}, false
+		}
+
+		e.Extracted[criFlags] = parsed.Flag.String()
+		e.Extracted[criStream] = parsed.Stream.String()
+		e.Extracted[criContent] = parsed.Content
+		e.Extracted[criTime] = parsed.Timestamp
+
+		e.Line = parsed.Content
+
+		ts, err := time.Parse(time.RFC3339Nano, parsed.Timestamp)
+		if err == nil {
+			e.Timestamp = ts
+		}
+
+		e.Labels[criStream] = model.LabelValue(parsed.Stream.String())
+
+		fingerprint := e.Labels.Fingerprint()
+		if parsed.Flag == crip.FlagPartial {
+			if len(c.partialLines) >= c.cfg.MaxPartialLines {
+				level.Warn(c.logger).Log("msg", "cri stage: partial lines upperbound exceeded. merging it to single line", "threshold", c.cfg.MaxPartialLines)
+				if c.partialLinesFlushedMetric != nil {
+					c.partialLinesFlushedMetric.Add(float64(len(c.partialLines)))
+				}
+				entries := make([]Entry, 0, len(c.partialLines))
+				for _, v := range c.partialLines {
+					entries = append(entries, v)
+				}
+				c.partialLines = make(map[model.Fingerprint]Entry, c.cfg.MaxPartialLines)
+				c.ensureTruncateIfRequired(&e)
+				c.partialLines[fingerprint] = e
+				return entries, false
+			}
+
+			prev, ok := c.partialLines[fingerprint]
+			if ok {
+				var builder strings.Builder
+				builder.WriteString(prev.Line)
+				builder.WriteString(e.Line)
+				e.Line = builder.String()
+			}
+			c.ensureTruncateIfRequired(&e)
+			c.partialLines[fingerprint] = e
+			return nil, true
+		}
+
+		prev, ok := c.partialLines[fingerprint]
+		if ok {
+			var builder strings.Builder
+			builder.WriteString(prev.Line)
+			builder.WriteString(e.Line)
+			e.Line = builder.String()
+			c.ensureTruncateIfRequired(&e)
+			delete(c.partialLines, fingerprint)
+		}
+
+		return []Entry{e}, false
+	}(e)
+
+	if skip {
+		return nil
+	}
+	return entries
+}

--- a/internal/component/loki/process/stages/cri.go
+++ b/internal/component/loki/process/stages/cri.go
@@ -19,9 +19,9 @@ import (
 // CRIConfig is an empty struct that is used to enable a pre-defined pipeline
 // for decoding entries that are using the CRI logging format.
 type CRIConfig struct {
-	MaxPartialLines            int    `alloy:"max_partial_lines,attr,optional"`
-	MaxPartialLineSize         uint64 `alloy:"max_partial_line_size,attr,optional"`
-	MaxPartialLineSizeTruncate bool   `alloy:"max_partial_line_size_truncate,attr,optional"`
+	MaxPartialLines            int    `alloy:"max_partial_lines,attr,optional"             json:"maxPartialLines,omitempty"`
+	MaxPartialLineSize         uint64 `alloy:"max_partial_line_size,attr,optional"         json:"maxPartialLineSize,omitempty"`
+	MaxPartialLineSizeTruncate bool   `alloy:"max_partial_line_size_truncate,attr,optional" json:"maxPartialLineSizeTruncate,omitempty"`
 }
 
 var (

--- a/internal/component/loki/process/stages/decolorize.go
+++ b/internal/component/loki/process/stages/decolorize.go
@@ -35,3 +35,9 @@ func (m *decolorizeStage) Run(in chan Entry) chan Entry {
 func (*decolorizeStage) Cleanup() {
 	// no-op
 }
+
+// ProcessEntry implements SyncStage.
+func (m *decolorizeStage) ProcessEntry(e Entry) []Entry {
+	e.Entry.Line = string(ansiRegex.ReplaceAll([]byte(e.Line), []byte{}))
+	return []Entry{e}
+}

--- a/internal/component/loki/process/stages/drop.go
+++ b/internal/component/loki/process/stages/drop.go
@@ -36,7 +36,7 @@ type DropConfig struct {
 	Value      string           `alloy:"value,attr,optional"               json:"value,omitempty"`
 	Separator  string           `alloy:"separator,attr,optional"           json:"separator,omitempty"`
 	Expression string           `alloy:"expression,attr,optional"          json:"expression,omitempty"`
-	OlderThan  time.Duration    `alloy:"older_than,attr,optional"          json:"-"`                    // not supported in CRD: time.Duration is nanosecond int64 in JSON
+	OlderThan  time.Duration    `alloy:"older_than,attr,optional"          json:"olderThan,omitempty"`
 	LongerThan units.Base2Bytes `alloy:"longer_than,attr,optional"         json:"longerThan,omitempty"` // TextMarshaler: serializes as "5MiB"
 }
 

--- a/internal/component/loki/process/stages/drop.go
+++ b/internal/component/loki/process/stages/drop.go
@@ -225,3 +225,12 @@ func splitSource(s string) []string {
 func (*dropStage) Cleanup() {
 	// no-op
 }
+
+// ProcessEntry implements SyncStage.
+func (m *dropStage) ProcessEntry(e Entry) []Entry {
+	if m.shouldDrop(e) {
+		m.dropCount.WithLabelValues(m.cfg.DropReason).Inc()
+		return nil
+	}
+	return []Entry{e}
+}

--- a/internal/component/loki/process/stages/drop.go
+++ b/internal/component/loki/process/stages/drop.go
@@ -31,13 +31,13 @@ var (
 
 // DropConfig contains the configuration for a dropStage
 type DropConfig struct {
-	DropReason string           `alloy:"drop_counter_reason,attr,optional"`
-	Source     string           `alloy:"source,attr,optional"`
-	Value      string           `alloy:"value,attr,optional"`
-	Separator  string           `alloy:"separator,attr,optional"`
-	Expression string           `alloy:"expression,attr,optional"`
-	OlderThan  time.Duration    `alloy:"older_than,attr,optional"`
-	LongerThan units.Base2Bytes `alloy:"longer_than,attr,optional"`
+	DropReason string           `alloy:"drop_counter_reason,attr,optional" json:"dropReason,omitempty"`
+	Source     string           `alloy:"source,attr,optional"              json:"source,omitempty"`
+	Value      string           `alloy:"value,attr,optional"               json:"value,omitempty"`
+	Separator  string           `alloy:"separator,attr,optional"           json:"separator,omitempty"`
+	Expression string           `alloy:"expression,attr,optional"          json:"expression,omitempty"`
+	OlderThan  time.Duration    `alloy:"older_than,attr,optional"          json:"-"`                    // not supported in CRD: time.Duration is nanosecond int64 in JSON
+	LongerThan units.Base2Bytes `alloy:"longer_than,attr,optional"         json:"longerThan,omitempty"` // TextMarshaler: serializes as "5MiB"
 }
 
 // validateDropConfig validates the DropConfig for the dropStage

--- a/internal/component/loki/process/stages/geoip.go
+++ b/internal/component/loki/process/stages/geoip.go
@@ -56,10 +56,10 @@ var fields = map[GeoIPFields]string{
 
 // GeoIPConfig represents GeoIP stage config
 type GeoIPConfig struct {
-	DB            string            `alloy:"db,attr"`
-	Source        *string           `alloy:"source,attr"`
-	DBType        string            `alloy:"db_type,attr,optional"`
-	CustomLookups map[string]string `alloy:"custom_lookups,attr,optional"`
+	DB            string            `alloy:"db,attr"                          json:"db"`
+	Source        *string           `alloy:"source,attr"                      json:"source"`
+	DBType        string            `alloy:"db_type,attr,optional"            json:"dbType,omitempty"`
+	CustomLookups map[string]string `alloy:"custom_lookups,attr,optional"     json:"customLookups,omitempty"`
 }
 
 func validateGeoIPConfig(c GeoIPConfig) (map[string]jmespath.JMESPath, error) {

--- a/internal/component/loki/process/stages/geoip.go
+++ b/internal/component/loki/process/stages/geoip.go
@@ -341,3 +341,9 @@ func (g *geoIPStage) populateExtractedWithCustomFields(ip net.IP, extracted map[
 		extracted[key] = r
 	}
 }
+
+// ProcessEntry implements SyncStage.
+func (g *geoIPStage) ProcessEntry(e Entry) []Entry {
+	g.process(e.Labels, e.Extracted)
+	return []Entry{e}
+}

--- a/internal/component/loki/process/stages/json.go
+++ b/internal/component/loki/process/stages/json.go
@@ -22,9 +22,9 @@ const (
 
 // JSONConfig represents a JSON Stage configuration
 type JSONConfig struct {
-	Expressions   map[string]string `alloy:"expressions,attr"`
-	Source        *string           `alloy:"source,attr,optional"`
-	DropMalformed bool              `alloy:"drop_malformed,attr,optional"`
+	Expressions   map[string]string `alloy:"expressions,attr"              json:"expressions"`
+	Source        *string           `alloy:"source,attr,optional"          json:"source,omitempty"`
+	DropMalformed bool              `alloy:"drop_malformed,attr,optional"  json:"dropMalformed,omitempty"`
 }
 
 // validateJSONConfig validates a json config and returns a map of necessary jmespath expressions.

--- a/internal/component/loki/process/stages/json.go
+++ b/internal/component/loki/process/stages/json.go
@@ -174,3 +174,12 @@ func (j *jsonStage) processEntry(extracted map[string]any, entry *string) error 
 func (*jsonStage) Cleanup() {
 	// no-op
 }
+
+// ProcessEntry implements SyncStage.
+func (j *jsonStage) ProcessEntry(e Entry) []Entry {
+	err := j.processEntry(e.Extracted, &e.Line)
+	if err != nil && j.cfg.DropMalformed {
+		return nil
+	}
+	return []Entry{e}
+}

--- a/internal/component/loki/process/stages/label_drop.go
+++ b/internal/component/loki/process/stages/label_drop.go
@@ -12,7 +12,7 @@ var ErrEmptyLabelDropStageConfig = errors.New("labeldrop stage config cannot be 
 
 // LabelDropConfig contains the slice of labels to be dropped.
 type LabelDropConfig struct {
-	Values []string `alloy:"values,attr"`
+	Values []string `alloy:"values,attr" json:"values"`
 }
 
 func newLabelDropStage(config LabelDropConfig) (Stage, error) {

--- a/internal/component/loki/process/stages/label_keep.go
+++ b/internal/component/loki/process/stages/label_keep.go
@@ -12,7 +12,7 @@ var ErrEmptyLabelAllowStageConfig = errors.New("labelallow stage config cannot b
 
 // LabelAllowConfig contains the slice of labels to allow through.
 type LabelAllowConfig struct {
-	Values []string `alloy:"values,attr"`
+	Values []string `alloy:"values,attr" json:"values"`
 }
 
 func newLabelAllowStage(config LabelAllowConfig) (Stage, error) {

--- a/internal/component/loki/process/stages/labels.go
+++ b/internal/component/loki/process/stages/labels.go
@@ -151,3 +151,14 @@ func (l *labelStage) addLabelsFromStructuredMetadata(labels model.LabelSet, meta
 func (*labelStage) Cleanup() {
 	// no-op
 }
+
+// ProcessEntry implements SyncStage.
+func (l *labelStage) ProcessEntry(e Entry) []Entry {
+	switch l.cfg.SourceType {
+	case SourceTypeExtractedMap:
+		l.addLabelFromExtractedMap(e.Labels, e.Extracted)
+	case SourceTypeStructuredMetadata:
+		l.addLabelsFromStructuredMetadata(e.Labels, e.StructuredMetadata)
+	}
+	return []Entry{e}
+}

--- a/internal/component/loki/process/stages/labels.go
+++ b/internal/component/loki/process/stages/labels.go
@@ -23,8 +23,8 @@ const (
 
 // LabelsConfig is a set of labels to be extracted
 type LabelsConfig struct {
-	Values     map[string]*string `alloy:"values,attr"`
-	SourceType SourceType         `alloy:"source_type,attr,optional"`
+	Values     map[string]*string `alloy:"values,attr"                json:"values"`
+	SourceType SourceType         `alloy:"source_type,attr,optional"  json:"sourceType,omitempty"`
 }
 
 // validateLabelsConfig validates the Label stage configuration

--- a/internal/component/loki/process/stages/limit.go
+++ b/internal/component/loki/process/stages/limit.go
@@ -193,3 +193,11 @@ func registerCounterVec(registerer prometheus.Registerer, namespace, name, help 
 	}
 	return vec
 }
+
+// ProcessEntry implements SyncStage.
+func (m *limitStage) ProcessEntry(e Entry) []Entry {
+	if m.shouldThrottle(e.Labels) {
+		return nil
+	}
+	return []Entry{e}
+}

--- a/internal/component/loki/process/stages/limit.go
+++ b/internal/component/loki/process/stages/limit.go
@@ -24,11 +24,11 @@ const MinReasonableMaxDistinctLabels = 10000 // 80bytes per rate.Limiter ~ 1MiB 
 
 // LimitConfig sets up a Limit stage.
 type LimitConfig struct {
-	Rate              float64 `alloy:"rate,attr"`
-	Burst             int     `alloy:"burst,attr"`
-	Drop              bool    `alloy:"drop,attr,optional"`
-	ByLabelName       string  `alloy:"by_label_name,attr,optional"`
-	MaxDistinctLabels int     `alloy:"max_distinct_labels,attr,optional"`
+	Rate              float64 `alloy:"rate,attr"                        json:"rate"`
+	Burst             int     `alloy:"burst,attr"                       json:"burst"`
+	Drop              bool    `alloy:"drop,attr,optional"               json:"drop,omitempty"`
+	ByLabelName       string  `alloy:"by_label_name,attr,optional"      json:"byLabelName,omitempty"`
+	MaxDistinctLabels int     `alloy:"max_distinct_labels,attr,optional" json:"maxDistinctLabels,omitempty"`
 }
 
 func newLimitStage(logger log.Logger, cfg LimitConfig, registerer prometheus.Registerer) (Stage, error) {

--- a/internal/component/loki/process/stages/logfmt.go
+++ b/internal/component/loki/process/stages/logfmt.go
@@ -20,8 +20,8 @@ var (
 
 // LogfmtConfig represents a logfmt Stage configuration
 type LogfmtConfig struct {
-	Mapping map[string]string `alloy:"mapping,attr"`
-	Source  string            `alloy:"source,attr,optional"`
+	Mapping map[string]string `alloy:"mapping,attr"          json:"mapping"`
+	Source  string            `alloy:"source,attr,optional"  json:"source,omitempty"`
 }
 
 // validateLogfmtConfig validates a logfmt stage config and returns an inverse mapping of configured mapping.

--- a/internal/component/loki/process/stages/luhn.go
+++ b/internal/component/loki/process/stages/luhn.go
@@ -11,10 +11,10 @@ import (
 
 // LuhnFilterConfig configures a processing stage that filters out Luhn-valid numbers.
 type LuhnFilterConfig struct {
-	Replacement string  `alloy:"replacement,attr,optional"`
-	Source      *string `alloy:"source,attr,optional"`
-	MinLength   int     `alloy:"min_length,attr,optional"`
-	Delimiters  string  `alloy:"delimiters,attr,optional"`
+	Replacement string  `alloy:"replacement,attr,optional"  json:"replacement,omitempty"`
+	Source      *string `alloy:"source,attr,optional"       json:"source,omitempty"`
+	MinLength   int     `alloy:"min_length,attr,optional"   json:"minLength,omitempty"`
+	Delimiters  string  `alloy:"delimiters,attr,optional"   json:"delimiters,omitempty"`
 }
 
 // validateLuhnFilterConfig validates the LuhnFilterConfig.

--- a/internal/component/loki/process/stages/match.go
+++ b/internal/component/loki/process/stages/match.go
@@ -193,3 +193,35 @@ func (m *matcherStage) Cleanup() {
 		m.pipeline.Cleanup()
 	}
 }
+
+// canProcessSync implements syncChecker. It reports whether this stage can
+// participate in a synchronous pipeline: drop actions never need a nested
+// pipeline, and keep actions require their nested pipeline to be sync-capable.
+func (m *matcherStage) canProcessSync() bool {
+	if m.action == MatchActionDrop {
+		return true
+	}
+	return m.pipeline != nil && m.pipeline.CanProcessSync()
+}
+
+// ProcessEntry implements SyncStage.
+func (m *matcherStage) ProcessEntry(e Entry) []Entry {
+	switch m.action {
+	case MatchActionDrop:
+		if _, ok := m.processLogQL(e); ok {
+			m.dropCount.WithLabelValues(m.dropReason).Inc()
+			return nil
+		}
+		return []Entry{e}
+	case MatchActionKeep:
+		e, ok := m.processLogQL(e)
+		if !ok {
+			// Entry does not match the selector: pass through unchanged.
+			return []Entry{e}
+		}
+		// Entry matches: run it through the nested pipeline.
+		// CanProcessSync guarantees all nested stages implement SyncStage.
+		return m.pipeline.processEntryFull(e)
+	}
+	panic("matcherStage: unexpected action " + m.action)
+}

--- a/internal/component/loki/process/stages/match.go
+++ b/internal/component/loki/process/stages/match.go
@@ -27,11 +27,11 @@ var (
 
 // MatchConfig contains the configuration for a matcherStage
 type MatchConfig struct {
-	Selector     string        `alloy:"selector,attr"`
-	Stages       []StageConfig `alloy:"stage,enum,optional"`
-	Action       string        `alloy:"action,attr,optional"`
-	PipelineName string        `alloy:"pipeline_name,attr,optional"`
-	DropReason   string        `alloy:"drop_counter_reason,attr,optional"`
+	Selector     string        `alloy:"selector,attr"                     json:"selector"`
+	Stages       []StageConfig `alloy:"stage,enum,optional"               json:"stages,omitempty"`
+	Action       string        `alloy:"action,attr,optional"              json:"action,omitempty"`
+	PipelineName string        `alloy:"pipeline_name,attr,optional"       json:"pipelineName,omitempty"`
+	DropReason   string        `alloy:"drop_counter_reason,attr,optional" json:"dropReason,omitempty"`
 }
 
 // validateMatcherConfig validates the MatcherConfig for the matcherStage

--- a/internal/component/loki/process/stages/metric.go
+++ b/internal/component/loki/process/stages/metric.go
@@ -22,14 +22,14 @@ const (
 
 // MetricConfig is a single metrics configuration.
 type MetricConfig struct {
-	Counter   *metric.CounterConfig   `alloy:"counter,block,optional"`
-	Gauge     *metric.GaugeConfig     `alloy:"gauge,block,optional"`
-	Histogram *metric.HistogramConfig `alloy:"histogram,block,optional"`
+	Counter   *metric.CounterConfig   `alloy:"counter,block,optional"   json:"counter,omitempty"`
+	Gauge     *metric.GaugeConfig     `alloy:"gauge,block,optional"     json:"gauge,omitempty"`
+	Histogram *metric.HistogramConfig `alloy:"histogram,block,optional" json:"histogram,omitempty"`
 }
 
 // MetricsConfig is a set of configured metrics.
 type MetricsConfig struct {
-	Metrics []MetricConfig `alloy:"metric,enum,optional"`
+	Metrics []MetricConfig `alloy:"metric,enum,optional" json:"metrics,omitempty"`
 }
 
 type cfgCollector struct {

--- a/internal/component/loki/process/stages/metric.go
+++ b/internal/component/loki/process/stages/metric.go
@@ -331,3 +331,9 @@ func getFloatFromString(str string) (float64, error) {
 	}
 	return dur, nil
 }
+
+// ProcessEntry implements SyncStage.
+func (m *metricStage) ProcessEntry(e Entry) []Entry {
+	m.Process(e.Labels, e.Extracted, &e.Timestamp, &e.Line)
+	return []Entry{e}
+}

--- a/internal/component/loki/process/stages/output.go
+++ b/internal/component/loki/process/stages/output.go
@@ -19,7 +19,7 @@ var (
 // OutputConfig initializes a configuration stage which sets the log line to a
 // value from the extracted map.
 type OutputConfig struct {
-	Source string `alloy:"source,attr"`
+	Source string `alloy:"source,attr" json:"source"`
 }
 
 // newOutputStage creates a new outputStage

--- a/internal/component/loki/process/stages/pack.go
+++ b/internal/component/loki/process/stages/pack.go
@@ -105,8 +105,8 @@ func (w Packed) MarshalJSON() ([]byte, error) {
 
 // PackConfig contains the configuration for a packStage
 type PackConfig struct {
-	Labels          []string `alloy:"labels,attr"`
-	IngestTimestamp bool     `alloy:"ingest_timestamp,attr,optional"`
+	Labels          []string `alloy:"labels,attr"                    json:"labels"`
+	IngestTimestamp bool     `alloy:"ingest_timestamp,attr,optional" json:"ingestTimestamp,omitempty"`
 }
 
 // DefaultPackConfig sets the defaults.

--- a/internal/component/loki/process/stages/pack.go
+++ b/internal/component/loki/process/stages/pack.go
@@ -201,3 +201,8 @@ func (m *packStage) pack(e Entry) Entry {
 func (*packStage) Cleanup() {
 	// no-op
 }
+
+// ProcessEntry implements SyncStage.
+func (m *packStage) ProcessEntry(e Entry) []Entry {
+	return []Entry{m.pack(e)}
+}

--- a/internal/component/loki/process/stages/pattern.go
+++ b/internal/component/loki/process/stages/pattern.go
@@ -23,9 +23,9 @@ var (
 // extract values from log lines into the shared values map.
 // See https://grafana.com/docs/loki/latest/query/log_queries/#pattern
 type PatternConfig struct {
-	Pattern          string  `alloy:"pattern,attr"`
-	Source           *string `alloy:"source,attr,optional"`
-	LabelsFromGroups bool    `alloy:"labels_from_groups,attr,optional"`
+	Pattern          string  `alloy:"pattern,attr"                   json:"pattern"`
+	Source           *string `alloy:"source,attr,optional"           json:"source,omitempty"`
+	LabelsFromGroups bool    `alloy:"labels_from_groups,attr,optional" json:"labelsFromGroups,omitempty"`
 }
 
 // validatePatternConfig validates the config and return a regex

--- a/internal/component/loki/process/stages/pipeline.go
+++ b/internal/component/loki/process/stages/pipeline.go
@@ -48,6 +48,85 @@ type StageConfig struct {
 	WindowsEventConfig           *WindowsEventConfig           `alloy:"windowsevent,block,optional"           json:"windowsevent,omitempty"`
 }
 
+// PodLogsStageConfig defines a single processing stage for use in the PodLogs CRD.
+// It mirrors StageConfig but excludes stages that are incompatible with a shared
+// per-PodLogs pipeline:
+//   - multiline: log lines from different pods interleave in the shared pipeline,
+//     causing incorrect multi-line merging across pod boundaries.
+//   - windowsevent / eventlogmessage: not applicable to Linux pod logs.
+type PodLogsStageConfig struct {
+	CRIConfig                    *CRIConfig                    `json:"cri,omitempty"`
+	DecolorizeConfig             *DecolorizeConfig             `json:"decolorize,omitempty"`
+	DockerConfig                 *DockerConfig                 `json:"docker,omitempty"`
+	DropConfig                   *DropConfig                   `json:"drop,omitempty"`
+	GeoIPConfig                  *GeoIPConfig                  `json:"geoip,omitempty"`
+	JSONConfig                   *JSONConfig                   `json:"json,omitempty"`
+	LabelAllowConfig             *LabelAllowConfig             `json:"label_keep,omitempty"`
+	LabelDropConfig              *LabelDropConfig              `json:"label_drop,omitempty"`
+	LabelsConfig                 *LabelsConfig                 `json:"labels,omitempty"`
+	LimitConfig                  *LimitConfig                  `json:"limit,omitempty"`
+	LogfmtConfig                 *LogfmtConfig                 `json:"logfmt,omitempty"`
+	LuhnFilterConfig             *LuhnFilterConfig             `json:"luhn,omitempty"`
+	MatchConfig                  *MatchConfig                  `json:"match,omitempty"`
+	MetricsConfig                *MetricsConfig                `json:"metrics,omitempty"`
+	OutputConfig                 *OutputConfig                 `json:"output,omitempty"`
+	PackConfig                   *PackConfig                   `json:"pack,omitempty"`
+	PatternConfig                *PatternConfig                `json:"pattern,omitempty"`
+	RegexConfig                  *RegexConfig                  `json:"regex,omitempty"`
+	ReplaceConfig                *ReplaceConfig                `json:"replace,omitempty"`
+	SamplingConfig               *SamplingConfig               `json:"sampling,omitempty"`
+	StaticLabelsConfig           *StaticLabelsConfig           `json:"static_labels,omitempty"`
+	StructuredMetadata           *StructuredMetadataConfig     `json:"structured_metadata,omitempty"`
+	StructuredMetadataDropConfig *StructuredMetadataDropConfig `json:"structured_metadata_drop,omitempty"`
+	TemplateConfig               *TemplateConfig               `json:"template,omitempty"`
+	TenantConfig                 *TenantConfig                 `json:"tenant,omitempty"`
+	TimestampConfig              *TimestampConfig              `json:"timestamp,omitempty"`
+	TruncateConfig               *TruncateConfig               `json:"truncate,omitempty"`
+}
+
+// ToStageConfig converts a PodLogsStageConfig to the full StageConfig for use with NewPipeline.
+func (c PodLogsStageConfig) ToStageConfig() StageConfig {
+	return StageConfig{
+		CRIConfig:                    c.CRIConfig,
+		DecolorizeConfig:             c.DecolorizeConfig,
+		DockerConfig:                 c.DockerConfig,
+		DropConfig:                   c.DropConfig,
+		GeoIPConfig:                  c.GeoIPConfig,
+		JSONConfig:                   c.JSONConfig,
+		LabelAllowConfig:             c.LabelAllowConfig,
+		LabelDropConfig:              c.LabelDropConfig,
+		LabelsConfig:                 c.LabelsConfig,
+		LimitConfig:                  c.LimitConfig,
+		LogfmtConfig:                 c.LogfmtConfig,
+		LuhnFilterConfig:             c.LuhnFilterConfig,
+		MatchConfig:                  c.MatchConfig,
+		MetricsConfig:                c.MetricsConfig,
+		OutputConfig:                 c.OutputConfig,
+		PackConfig:                   c.PackConfig,
+		PatternConfig:                c.PatternConfig,
+		RegexConfig:                  c.RegexConfig,
+		ReplaceConfig:                c.ReplaceConfig,
+		SamplingConfig:               c.SamplingConfig,
+		StaticLabelsConfig:           c.StaticLabelsConfig,
+		StructuredMetadata:           c.StructuredMetadata,
+		StructuredMetadataDropConfig: c.StructuredMetadataDropConfig,
+		TemplateConfig:               c.TemplateConfig,
+		TenantConfig:                 c.TenantConfig,
+		TimestampConfig:              c.TimestampConfig,
+		TruncateConfig:               c.TruncateConfig,
+	}
+}
+
+// ConvertPodLogsStages converts a slice of PodLogsStageConfig to []StageConfig
+// for use with NewPipeline.
+func ConvertPodLogsStages(in []PodLogsStageConfig) []StageConfig {
+	out := make([]StageConfig, len(in))
+	for i, s := range in {
+		out[i] = s.ToStageConfig()
+	}
+	return out
+}
+
 // Pipeline pass down a log entry to each stage for mutation and/or label extraction.
 type Pipeline struct {
 	logger    log.Logger

--- a/internal/component/loki/process/stages/pipeline.go
+++ b/internal/component/loki/process/stages/pipeline.go
@@ -48,6 +48,29 @@ type StageConfig struct {
 	WindowsEventConfig           *WindowsEventConfig           `alloy:"windowsevent,block,optional"           json:"windowsevent,omitempty"`
 }
 
+// PodLogsMatchConfig is the match stage config for use in the PodLogs CRD.
+// It mirrors MatchConfig but uses PodLogsStageConfig for nested stages so that
+// incompatible stage types (multiline, windowsevent, eventlogmessage) are
+// excluded recursively.
+type PodLogsMatchConfig struct {
+	Selector     string               `json:"selector"`
+	Stages       []PodLogsStageConfig `json:"stages,omitempty"`
+	Action       string               `json:"action,omitempty"`
+	PipelineName string               `json:"pipelineName,omitempty"`
+	DropReason   string               `json:"dropReason,omitempty"`
+}
+
+// toMatchConfig converts a PodLogsMatchConfig to MatchConfig for use with newMatcherStage.
+func (c *PodLogsMatchConfig) toMatchConfig() MatchConfig {
+	return MatchConfig{
+		Selector:     c.Selector,
+		Stages:       ConvertPodLogsStages(c.Stages),
+		Action:       c.Action,
+		PipelineName: c.PipelineName,
+		DropReason:   c.DropReason,
+	}
+}
+
 // PodLogsStageConfig defines a single processing stage for use in the PodLogs CRD.
 // It mirrors StageConfig but excludes stages that are incompatible with a shared
 // per-PodLogs pipeline:
@@ -67,7 +90,7 @@ type PodLogsStageConfig struct {
 	LimitConfig                  *LimitConfig                  `json:"limit,omitempty"`
 	LogfmtConfig                 *LogfmtConfig                 `json:"logfmt,omitempty"`
 	LuhnFilterConfig             *LuhnFilterConfig             `json:"luhn,omitempty"`
-	MatchConfig                  *MatchConfig                  `json:"match,omitempty"`
+	MatchConfig                  *PodLogsMatchConfig           `json:"match,omitempty"`
 	MetricsConfig                *MetricsConfig                `json:"metrics,omitempty"`
 	OutputConfig                 *OutputConfig                 `json:"output,omitempty"`
 	PackConfig                   *PackConfig                   `json:"pack,omitempty"`
@@ -86,6 +109,11 @@ type PodLogsStageConfig struct {
 
 // ToStageConfig converts a PodLogsStageConfig to the full StageConfig for use with NewPipeline.
 func (c PodLogsStageConfig) ToStageConfig() StageConfig {
+	var matchConfig *MatchConfig
+	if c.MatchConfig != nil {
+		converted := c.MatchConfig.toMatchConfig()
+		matchConfig = &converted
+	}
 	return StageConfig{
 		CRIConfig:                    c.CRIConfig,
 		DecolorizeConfig:             c.DecolorizeConfig,
@@ -99,7 +127,7 @@ func (c PodLogsStageConfig) ToStageConfig() StageConfig {
 		LimitConfig:                  c.LimitConfig,
 		LogfmtConfig:                 c.LogfmtConfig,
 		LuhnFilterConfig:             c.LuhnFilterConfig,
-		MatchConfig:                  c.MatchConfig,
+		MatchConfig:                  matchConfig,
 		MetricsConfig:                c.MetricsConfig,
 		OutputConfig:                 c.OutputConfig,
 		PackConfig:                   c.PackConfig,
@@ -151,18 +179,50 @@ func NewPipeline(logger log.Logger, stages []StageConfig, registerer prometheus.
 	}, nil
 }
 
+// syncChecker is an optional interface that stages with nested pipelines (e.g.
+// matcherStage) can implement to report whether their internal pipeline also
+// supports synchronous processing. Pipeline.CanProcessSync checks this in
+// addition to the SyncStage interface so that a match stage with a non-sync
+// inner pipeline does not falsely advertise sync capability.
+type syncChecker interface {
+	canProcessSync() bool
+}
+
 // CanProcessSync returns true when every stage in the pipeline implements
-// SyncStage. If true, ProcessEntry can be used instead of Start to avoid
-// spawning N+3 goroutines: one goroutine per stage plus two adapter goroutines.
-// The match stage does not currently implement SyncStage, so pipelines that
-// contain it return false and fall back to Start.
+// SyncStage and, for stages with nested pipelines (match), that nested pipeline
+// also supports synchronous processing.
 func (p *Pipeline) CanProcessSync() bool {
 	for _, s := range p.stages {
 		if _, ok := s.(SyncStage); !ok {
 			return false
 		}
+		if sc, ok := s.(syncChecker); ok && !sc.canProcessSync() {
+			return false
+		}
 	}
 	return true
+}
+
+// processEntryFull applies all pipeline stages to an already-initialized Entry,
+// preserving the existing Extracted map. This is the inner loop used by
+// ProcessEntry and by matcherStage.ProcessEntry for nested pipelines; it does
+// NOT reinitialize Extracted from labels (unlike the public ProcessEntry).
+// All stages must implement SyncStage; callers are responsible for ensuring
+// CanProcessSync() is true before calling this method.
+func (p *Pipeline) processEntryFull(e Entry) []Entry {
+	entries := []Entry{e}
+	for _, stage := range p.stages {
+		if len(entries) == 0 {
+			break
+		}
+		ss := stage.(SyncStage) // safe: caller guarantees CanProcessSync
+		var next []Entry
+		for _, entry := range entries {
+			next = append(next, ss.ProcessEntry(entry)...)
+		}
+		entries = next
+	}
+	return entries
 }
 
 // ProcessEntry applies all stages to a single entry synchronously.
@@ -170,28 +230,18 @@ func (p *Pipeline) CanProcessSync() bool {
 // It initialises the Extracted map from the entry labels, applies each stage in
 // order, and returns the resulting entries (empty = dropped, multiple = expanded).
 func (p *Pipeline) ProcessEntry(e loki.Entry) []loki.Entry {
-	entries := []Entry{{
+	inner := Entry{
 		Extracted: make(map[string]any, len(e.Labels)),
 		Entry:     e,
-	}}
+	}
 	for k, v := range e.Labels {
-		entries[0].Extracted[string(k)] = string(v)
+		inner.Extracted[string(k)] = string(v)
 	}
 
-	for _, stage := range p.stages {
-		if len(entries) == 0 {
-			break
-		}
-		ss := stage.(SyncStage) // safe: CanProcessSync guarantees this
-		var next []Entry
-		for _, entry := range entries {
-			next = append(next, ss.ProcessEntry(entry)...)
-		}
-		entries = next
-	}
+	processed := p.processEntryFull(inner)
 
-	result := make([]loki.Entry, len(entries))
-	for i, entry := range entries {
+	result := make([]loki.Entry, len(processed))
+	for i, entry := range processed {
 		result[i] = entry.Entry
 	}
 	return result

--- a/internal/component/loki/process/stages/pipeline.go
+++ b/internal/component/loki/process/stages/pipeline.go
@@ -151,6 +151,87 @@ func NewPipeline(logger log.Logger, stages []StageConfig, registerer prometheus.
 	}, nil
 }
 
+// CanProcessSync returns true when every stage in the pipeline implements
+// SyncStage. If true, ProcessEntry can be used instead of Start to avoid
+// spawning N+3 goroutines: one goroutine per stage plus two adapter goroutines.
+// The match stage does not currently implement SyncStage, so pipelines that
+// contain it return false and fall back to Start.
+func (p *Pipeline) CanProcessSync() bool {
+	for _, s := range p.stages {
+		if _, ok := s.(SyncStage); !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// ProcessEntry applies all stages to a single entry synchronously.
+// The pipeline must support synchronous processing (CanProcessSync() == true).
+// It initialises the Extracted map from the entry labels, applies each stage in
+// order, and returns the resulting entries (empty = dropped, multiple = expanded).
+func (p *Pipeline) ProcessEntry(e loki.Entry) []loki.Entry {
+	entries := []Entry{{
+		Extracted: make(map[string]any, len(e.Labels)),
+		Entry:     e,
+	}}
+	for k, v := range e.Labels {
+		entries[0].Extracted[string(k)] = string(v)
+	}
+
+	for _, stage := range p.stages {
+		if len(entries) == 0 {
+			break
+		}
+		ss := stage.(SyncStage) // safe: CanProcessSync guarantees this
+		var next []Entry
+		for _, entry := range entries {
+			next = append(next, ss.ProcessEntry(entry)...)
+		}
+		entries = next
+	}
+
+	result := make([]loki.Entry, len(entries))
+	for i, entry := range entries {
+		result[i] = entry.Entry
+	}
+	return result
+}
+
+// StartSync starts the pipeline using a single goroutine instead of the N+3
+// goroutine chain produced by Start. It requires CanProcessSync() == true.
+//
+// Resource usage comparison (N = number of stages):
+//
+//	Start:     N+3 goroutines (1 label-init RunWith + 1 per stage + 2 adapters)
+//	StartSync: 1 goroutine
+func (p *Pipeline) StartSync(in chan loki.Entry, out chan<- loki.Entry) loki.EntryHandler {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var (
+		wg   sync.WaitGroup
+		once sync.Once
+	)
+
+	wg.Go(func() {
+		defer p.Cleanup()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case e := <-in:
+				for _, result := range p.ProcessEntry(e) {
+					out <- result
+				}
+			}
+		}
+	})
+
+	return loki.NewEntryHandler(in, func() {
+		once.Do(func() { cancel() })
+		wg.Wait()
+	})
+}
+
 // Start will start the pipeline and forward entries to next.
 // The returned EntryHandler should be used to pass entries through the pipeline.
 func (p *Pipeline) Start(in chan loki.Entry, out chan<- loki.Entry) loki.EntryHandler {

--- a/internal/component/loki/process/stages/pipeline.go
+++ b/internal/component/loki/process/stages/pipeline.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
+	"github.com/alecthomas/units"
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -48,6 +50,41 @@ type StageConfig struct {
 	WindowsEventConfig           *WindowsEventConfig           `alloy:"windowsevent,block,optional"           json:"windowsevent,omitempty"`
 }
 
+// PodLogsDropConfig is the drop stage config for use in the PodLogs CRD.
+// It mirrors DropConfig but replaces OlderThan (time.Duration, which marshals
+// as a nanosecond int64 in JSON) with a human-readable duration string like
+// "5m" or "1h30s".
+type PodLogsDropConfig struct {
+	DropReason string           `json:"dropReason,omitempty"`
+	Source     string           `json:"source,omitempty"`
+	Value      string           `json:"value,omitempty"`
+	Separator  string           `json:"separator,omitempty"`
+	Expression string           `json:"expression,omitempty"`
+	OlderThan  string           `json:"olderThan,omitempty"` // human-readable duration e.g. "5m"
+	LongerThan units.Base2Bytes `json:"longerThan,omitempty"`
+}
+
+// toDropConfig converts a PodLogsDropConfig to DropConfig.
+// Returns an error if OlderThan is set but cannot be parsed as a duration.
+func (c *PodLogsDropConfig) toDropConfig() (DropConfig, error) {
+	cfg := DropConfig{
+		DropReason: c.DropReason,
+		Source:     c.Source,
+		Value:      c.Value,
+		Separator:  c.Separator,
+		Expression: c.Expression,
+		LongerThan: c.LongerThan,
+	}
+	if c.OlderThan != "" {
+		d, err := time.ParseDuration(c.OlderThan)
+		if err != nil {
+			return DropConfig{}, fmt.Errorf("invalid olderThan duration %q: %w", c.OlderThan, err)
+		}
+		cfg.OlderThan = d
+	}
+	return cfg, nil
+}
+
 // PodLogsMatchConfig is the match stage config for use in the PodLogs CRD.
 // It mirrors MatchConfig but uses PodLogsStageConfig for nested stages so that
 // incompatible stage types (multiline, windowsevent, eventlogmessage) are
@@ -61,14 +98,18 @@ type PodLogsMatchConfig struct {
 }
 
 // toMatchConfig converts a PodLogsMatchConfig to MatchConfig for use with newMatcherStage.
-func (c *PodLogsMatchConfig) toMatchConfig() MatchConfig {
+func (c *PodLogsMatchConfig) toMatchConfig() (MatchConfig, error) {
+	converted, err := ConvertPodLogsStages(c.Stages)
+	if err != nil {
+		return MatchConfig{}, err
+	}
 	return MatchConfig{
 		Selector:     c.Selector,
-		Stages:       ConvertPodLogsStages(c.Stages),
+		Stages:       converted,
 		Action:       c.Action,
 		PipelineName: c.PipelineName,
 		DropReason:   c.DropReason,
-	}
+	}, nil
 }
 
 // PodLogsStageConfig defines a single processing stage for use in the PodLogs CRD.
@@ -81,7 +122,7 @@ type PodLogsStageConfig struct {
 	CRIConfig                    *CRIConfig                    `json:"cri,omitempty"`
 	DecolorizeConfig             *DecolorizeConfig             `json:"decolorize,omitempty"`
 	DockerConfig                 *DockerConfig                 `json:"docker,omitempty"`
-	DropConfig                   *DropConfig                   `json:"drop,omitempty"`
+	DropConfig                   *PodLogsDropConfig            `json:"drop,omitempty"`
 	GeoIPConfig                  *GeoIPConfig                  `json:"geoip,omitempty"`
 	JSONConfig                   *JSONConfig                   `json:"json,omitempty"`
 	LabelAllowConfig             *LabelAllowConfig             `json:"label_keep,omitempty"`
@@ -107,18 +148,31 @@ type PodLogsStageConfig struct {
 	TruncateConfig               *TruncateConfig               `json:"truncate,omitempty"`
 }
 
-// ToStageConfig converts a PodLogsStageConfig to the full StageConfig for use with NewPipeline.
-func (c PodLogsStageConfig) ToStageConfig() StageConfig {
+// ToStageConfig converts a PodLogsStageConfig to the full StageConfig for use
+// with NewPipeline. Returns an error if any field value is invalid (e.g. an
+// unparseable duration in a drop stage).
+func (c PodLogsStageConfig) ToStageConfig() (StageConfig, error) {
+	var dropConfig *DropConfig
+	if c.DropConfig != nil {
+		converted, err := c.DropConfig.toDropConfig()
+		if err != nil {
+			return StageConfig{}, err
+		}
+		dropConfig = &converted
+	}
 	var matchConfig *MatchConfig
 	if c.MatchConfig != nil {
-		converted := c.MatchConfig.toMatchConfig()
+		converted, err := c.MatchConfig.toMatchConfig()
+		if err != nil {
+			return StageConfig{}, err
+		}
 		matchConfig = &converted
 	}
 	return StageConfig{
 		CRIConfig:                    c.CRIConfig,
 		DecolorizeConfig:             c.DecolorizeConfig,
 		DockerConfig:                 c.DockerConfig,
-		DropConfig:                   c.DropConfig,
+		DropConfig:                   dropConfig,
 		GeoIPConfig:                  c.GeoIPConfig,
 		JSONConfig:                   c.JSONConfig,
 		LabelAllowConfig:             c.LabelAllowConfig,
@@ -142,17 +196,21 @@ func (c PodLogsStageConfig) ToStageConfig() StageConfig {
 		TenantConfig:                 c.TenantConfig,
 		TimestampConfig:              c.TimestampConfig,
 		TruncateConfig:               c.TruncateConfig,
-	}
+	}, nil
 }
 
 // ConvertPodLogsStages converts a slice of PodLogsStageConfig to []StageConfig
 // for use with NewPipeline.
-func ConvertPodLogsStages(in []PodLogsStageConfig) []StageConfig {
+func ConvertPodLogsStages(in []PodLogsStageConfig) ([]StageConfig, error) {
 	out := make([]StageConfig, len(in))
 	for i, s := range in {
-		out[i] = s.ToStageConfig()
+		converted, err := s.ToStageConfig()
+		if err != nil {
+			return nil, err
+		}
+		out[i] = converted
 	}
-	return out
+	return out, nil
 }
 
 // Pipeline pass down a log entry to each stage for mutation and/or label extraction.

--- a/internal/component/loki/process/stages/pipeline.go
+++ b/internal/component/loki/process/stages/pipeline.go
@@ -16,36 +16,36 @@ import (
 // We define these as pointers types so we can use reflection to check that
 // exactly one is set.
 type StageConfig struct {
-	CRIConfig                    *CRIConfig                    `alloy:"cri,block,optional"`
-	DecolorizeConfig             *DecolorizeConfig             `alloy:"decolorize,block,optional"`
-	DockerConfig                 *DockerConfig                 `alloy:"docker,block,optional"`
-	DropConfig                   *DropConfig                   `alloy:"drop,block,optional"`
-	EventLogMessageConfig        *EventLogMessageConfig        `alloy:"eventlogmessage,block,optional"`
-	GeoIPConfig                  *GeoIPConfig                  `alloy:"geoip,block,optional"`
-	JSONConfig                   *JSONConfig                   `alloy:"json,block,optional"`
-	LabelAllowConfig             *LabelAllowConfig             `alloy:"label_keep,block,optional"`
-	LabelDropConfig              *LabelDropConfig              `alloy:"label_drop,block,optional"`
-	LabelsConfig                 *LabelsConfig                 `alloy:"labels,block,optional"`
-	LimitConfig                  *LimitConfig                  `alloy:"limit,block,optional"`
-	LogfmtConfig                 *LogfmtConfig                 `alloy:"logfmt,block,optional"`
-	LuhnFilterConfig             *LuhnFilterConfig             `alloy:"luhn,block,optional"`
-	MatchConfig                  *MatchConfig                  `alloy:"match,block,optional"`
-	MetricsConfig                *MetricsConfig                `alloy:"metrics,block,optional"`
-	MultilineConfig              *MultilineConfig              `alloy:"multiline,block,optional"`
-	OutputConfig                 *OutputConfig                 `alloy:"output,block,optional"`
-	PackConfig                   *PackConfig                   `alloy:"pack,block,optional"`
-	PatternConfig                *PatternConfig                `alloy:"pattern,block,optional"`
-	RegexConfig                  *RegexConfig                  `alloy:"regex,block,optional"`
-	ReplaceConfig                *ReplaceConfig                `alloy:"replace,block,optional"`
-	StaticLabelsConfig           *StaticLabelsConfig           `alloy:"static_labels,block,optional"`
-	StructuredMetadata           *StructuredMetadataConfig     `alloy:"structured_metadata,block,optional"`
-	StructuredMetadataDropConfig *StructuredMetadataDropConfig `alloy:"structured_metadata_drop,block,optional"`
-	SamplingConfig               *SamplingConfig               `alloy:"sampling,block,optional"`
-	TemplateConfig               *TemplateConfig               `alloy:"template,block,optional"`
-	TenantConfig                 *TenantConfig                 `alloy:"tenant,block,optional"`
-	TruncateConfig               *TruncateConfig               `alloy:"truncate,block,optional"`
-	TimestampConfig              *TimestampConfig              `alloy:"timestamp,block,optional"`
-	WindowsEventConfig           *WindowsEventConfig           `alloy:"windowsevent,block,optional"`
+	CRIConfig                    *CRIConfig                    `alloy:"cri,block,optional"                    json:"cri,omitempty"`
+	DecolorizeConfig             *DecolorizeConfig             `alloy:"decolorize,block,optional"             json:"decolorize,omitempty"`
+	DockerConfig                 *DockerConfig                 `alloy:"docker,block,optional"                 json:"docker,omitempty"`
+	DropConfig                   *DropConfig                   `alloy:"drop,block,optional"                   json:"drop,omitempty"`
+	EventLogMessageConfig        *EventLogMessageConfig        `alloy:"eventlogmessage,block,optional"        json:"eventlogmessage,omitempty"`
+	GeoIPConfig                  *GeoIPConfig                  `alloy:"geoip,block,optional"                  json:"geoip,omitempty"`
+	JSONConfig                   *JSONConfig                   `alloy:"json,block,optional"                   json:"json,omitempty"`
+	LabelAllowConfig             *LabelAllowConfig             `alloy:"label_keep,block,optional"             json:"label_keep,omitempty"`
+	LabelDropConfig              *LabelDropConfig              `alloy:"label_drop,block,optional"             json:"label_drop,omitempty"`
+	LabelsConfig                 *LabelsConfig                 `alloy:"labels,block,optional"                 json:"labels,omitempty"`
+	LimitConfig                  *LimitConfig                  `alloy:"limit,block,optional"                  json:"limit,omitempty"`
+	LogfmtConfig                 *LogfmtConfig                 `alloy:"logfmt,block,optional"                 json:"logfmt,omitempty"`
+	LuhnFilterConfig             *LuhnFilterConfig             `alloy:"luhn,block,optional"                   json:"luhn,omitempty"`
+	MatchConfig                  *MatchConfig                  `alloy:"match,block,optional"                  json:"match,omitempty"`
+	MetricsConfig                *MetricsConfig                `alloy:"metrics,block,optional"                json:"metrics,omitempty"`
+	MultilineConfig              *MultilineConfig              `alloy:"multiline,block,optional"              json:"multiline,omitempty"`
+	OutputConfig                 *OutputConfig                 `alloy:"output,block,optional"                 json:"output,omitempty"`
+	PackConfig                   *PackConfig                   `alloy:"pack,block,optional"                   json:"pack,omitempty"`
+	PatternConfig                *PatternConfig                `alloy:"pattern,block,optional"                json:"pattern,omitempty"`
+	RegexConfig                  *RegexConfig                  `alloy:"regex,block,optional"                  json:"regex,omitempty"`
+	ReplaceConfig                *ReplaceConfig                `alloy:"replace,block,optional"                json:"replace,omitempty"`
+	StaticLabelsConfig           *StaticLabelsConfig           `alloy:"static_labels,block,optional"          json:"static_labels,omitempty"`
+	StructuredMetadata           *StructuredMetadataConfig     `alloy:"structured_metadata,block,optional"    json:"structured_metadata,omitempty"`
+	StructuredMetadataDropConfig *StructuredMetadataDropConfig `alloy:"structured_metadata_drop,block,optional" json:"structured_metadata_drop,omitempty"`
+	SamplingConfig               *SamplingConfig               `alloy:"sampling,block,optional"               json:"sampling,omitempty"`
+	TemplateConfig               *TemplateConfig               `alloy:"template,block,optional"               json:"template,omitempty"`
+	TenantConfig                 *TenantConfig                 `alloy:"tenant,block,optional"                 json:"tenant,omitempty"`
+	TruncateConfig               *TruncateConfig               `alloy:"truncate,block,optional"               json:"truncate,omitempty"`
+	TimestampConfig              *TimestampConfig              `alloy:"timestamp,block,optional"              json:"timestamp,omitempty"`
+	WindowsEventConfig           *WindowsEventConfig           `alloy:"windowsevent,block,optional"           json:"windowsevent,omitempty"`
 }
 
 // Pipeline pass down a log entry to each stage for mutation and/or label extraction.

--- a/internal/component/loki/process/stages/regex.go
+++ b/internal/component/loki/process/stages/regex.go
@@ -23,9 +23,9 @@ var (
 // RegexConfig configures a processing stage uses regular expressions to
 // extract values from log lines into the shared values map.
 type RegexConfig struct {
-	Expression       string  `alloy:"expression,attr"`
-	Source           *string `alloy:"source,attr,optional"`
-	LabelsFromGroups bool    `alloy:"labels_from_groups,attr,optional"`
+	Expression       string  `alloy:"expression,attr"                   json:"expression"`
+	Source           *string `alloy:"source,attr,optional"              json:"source,omitempty"`
+	LabelsFromGroups bool    `alloy:"labels_from_groups,attr,optional"  json:"labelsFromGroups,omitempty"`
 }
 
 // validateRegexConfig validates the config and return a regex

--- a/internal/component/loki/process/stages/replace.go
+++ b/internal/component/loki/process/stages/replace.go
@@ -22,9 +22,9 @@ func init() {
 
 // ReplaceConfig contains a regexStage configuration
 type ReplaceConfig struct {
-	Expression string `alloy:"expression,attr"`
-	Source     string `alloy:"source,attr,optional"`
-	Replace    string `alloy:"replace,attr,optional"`
+	Expression string `alloy:"expression,attr"          json:"expression"`
+	Source     string `alloy:"source,attr,optional"     json:"source,omitempty"`
+	Replace    string `alloy:"replace,attr,optional"    json:"replace,omitempty"`
 }
 
 func getExpressionRegex(c ReplaceConfig) (*regexp.Regexp, error) {

--- a/internal/component/loki/process/stages/sampling.go
+++ b/internal/component/loki/process/stages/sampling.go
@@ -19,8 +19,8 @@ var (
 
 // SamplingConfig contains the configuration for a samplingStage
 type SamplingConfig struct {
-	DropReason   string  `alloy:"drop_counter_reason,attr,optional"`
-	SamplingRate float64 `alloy:"rate,attr"`
+	DropReason   string  `alloy:"drop_counter_reason,attr,optional" json:"dropReason,omitempty"`
+	SamplingRate float64 `alloy:"rate,attr"                         json:"rate"`
 }
 
 func (s *SamplingConfig) SetToDefault() {

--- a/internal/component/loki/process/stages/sampling.go
+++ b/internal/component/loki/process/stages/sampling.go
@@ -71,3 +71,12 @@ func (m *samplingStage) Run(in chan Entry) chan Entry {
 func (*samplingStage) Cleanup() {
 	// no-op
 }
+
+// ProcessEntry implements SyncStage.
+func (m *samplingStage) ProcessEntry(e Entry) []Entry {
+	if m.sampler.ShouldSample() {
+		return []Entry{e}
+	}
+	m.dropCount.WithLabelValues(m.cfg.DropReason).Inc()
+	return nil
+}

--- a/internal/component/loki/process/stages/stage.go
+++ b/internal/component/loki/process/stages/stage.go
@@ -28,6 +28,15 @@ type Stage interface {
 	Cleanup()
 }
 
+// SyncStage is an optional interface that Stage implementations may satisfy to
+// support single-entry processing without spawning goroutines.
+// ProcessEntry returns the resulting entries: nil means the entry was dropped,
+// a single-element slice is the common case, and multiple elements mean the
+// stage expanded one entry into many.
+type SyncStage interface {
+	ProcessEntry(e Entry) []Entry
+}
+
 // stageProcessor Allow to transform a Processor (old synchronous pipeline stage) into an async Stage
 type stageProcessor struct {
 	Processor
@@ -38,6 +47,14 @@ func (s stageProcessor) Run(in chan Entry) chan Entry {
 		s.Process(e.Labels, e.Extracted, &e.Timestamp, &e.Line)
 		return e
 	})
+}
+
+// ProcessEntry implements SyncStage. All Processor-wrapped stages (regex, json,
+// logfmt, labels, template, tenant, timestamp, output, replace, pattern, luhn,
+// label_drop, label_keep, static_labels, docker, …) get this for free.
+func (s stageProcessor) ProcessEntry(e Entry) []Entry {
+	s.Process(e.Labels, e.Extracted, &e.Timestamp, &e.Line)
+	return []Entry{e}
 }
 
 func toStage(p Processor) Stage {

--- a/internal/component/loki/process/stages/static_labels.go
+++ b/internal/component/loki/process/stages/static_labels.go
@@ -14,7 +14,7 @@ var ErrEmptyStaticLabelStageConfig = errors.New("static_labels stage config cann
 
 // StaticLabelsConfig contains a map of static labels to be set.
 type StaticLabelsConfig struct {
-	Values map[string]*string `alloy:"values,attr"`
+	Values map[string]*string `alloy:"values,attr" json:"values"`
 }
 
 func newStaticLabelsStage(_ log.Logger, config StaticLabelsConfig) (Stage, error) {

--- a/internal/component/loki/process/stages/structured_metadata.go
+++ b/internal/component/loki/process/stages/structured_metadata.go
@@ -13,8 +13,8 @@ import (
 )
 
 type StructuredMetadataConfig struct {
-	Values map[string]*string `alloy:"values,attr,optional"`
-	Regex  string             `alloy:"regex,attr,optional"`
+	Values map[string]*string `alloy:"values,attr,optional" json:"values,omitempty"`
+	Regex  string             `alloy:"regex,attr,optional"  json:"regex,omitempty"`
 }
 
 // validateStructuredMetadataConfig validates the structured metadata stage config.

--- a/internal/component/loki/process/stages/structured_metadata.go
+++ b/internal/component/loki/process/stages/structured_metadata.go
@@ -176,10 +176,16 @@ func (s *structuredMetadataStage) ProcessEntry(e Entry) []Entry {
 			if s.regex.MatchString(lName) {
 				str, err := getString(lValue)
 				if err != nil {
+					if Debug {
+						level.Debug(s.logger).Log("msg", "failed to convert extracted label value to string", "err", err, "type", reflect.TypeOf(lValue))
+					}
 					continue
 				}
 				labelValue := model.LabelValue(str)
 				if !labelValue.IsValid() {
+					if Debug {
+						level.Debug(s.logger).Log("msg", "invalid label value parsed", "value", labelValue)
+					}
 					continue
 				}
 				e.StructuredMetadata = append(e.StructuredMetadata, push.LabelAdapter{Name: lName, Value: string(labelValue)})

--- a/internal/component/loki/process/stages/structured_metadata.go
+++ b/internal/component/loki/process/stages/structured_metadata.go
@@ -165,3 +165,26 @@ func (s *structuredMetadataStage) extractFromLabels(e Entry) Entry {
 	e.Labels = labels
 	return e
 }
+
+// ProcessEntry implements SyncStage.
+func (s *structuredMetadataStage) ProcessEntry(e Entry) []Entry {
+	processLabelsConfigs(s.logger, e.Extracted, s.labelsConfig, func(labelName model.LabelName, labelValue model.LabelValue) {
+		e.StructuredMetadata = append(e.StructuredMetadata, push.LabelAdapter{Name: string(labelName), Value: string(labelValue)})
+	})
+	if s.regex.String() != "" {
+		for lName, lValue := range e.Extracted {
+			if s.regex.MatchString(lName) {
+				str, err := getString(lValue)
+				if err != nil {
+					continue
+				}
+				labelValue := model.LabelValue(str)
+				if !labelValue.IsValid() {
+					continue
+				}
+				e.StructuredMetadata = append(e.StructuredMetadata, push.LabelAdapter{Name: lName, Value: string(labelValue)})
+			}
+		}
+	}
+	return []Entry{s.extractFromLabels(e)}
+}

--- a/internal/component/loki/process/stages/structured_metadata_drop.go
+++ b/internal/component/loki/process/stages/structured_metadata_drop.go
@@ -13,7 +13,7 @@ var ErrEmptyStructuredMetadataDropStageConfig = errors.New("structured_metadata_
 
 // StructuredMetadataDropConfig contains the slice of structured metadata to be dropped.
 type StructuredMetadataDropConfig struct {
-	Values []string `alloy:"values,attr"`
+	Values []string `alloy:"values,attr" json:"values"`
 }
 
 func newStructuredMetadataDropStage(logger log.Logger, config StructuredMetadataDropConfig) (Stage, error) {

--- a/internal/component/loki/process/stages/structured_metadata_drop.go
+++ b/internal/component/loki/process/stages/structured_metadata_drop.go
@@ -48,3 +48,13 @@ func (s *structuredMetadataDropStage) Run(in chan Entry) chan Entry {
 		return e
 	})
 }
+
+// ProcessEntry implements SyncStage.
+func (s *structuredMetadataDropStage) ProcessEntry(e Entry) []Entry {
+	for _, value := range s.config.Values {
+		e.StructuredMetadata = slices.DeleteFunc(e.StructuredMetadata, func(l push.LabelAdapter) bool {
+			return l.Name == value
+		})
+	}
+	return []Entry{e}
+}

--- a/internal/component/loki/process/stages/template.go
+++ b/internal/component/loki/process/stages/template.go
@@ -67,8 +67,8 @@ var _ syntax.Validator = (*TemplateConfig)(nil)
 
 // TemplateConfig configures template value extraction.
 type TemplateConfig struct {
-	Source   string   `alloy:"source,attr"`
-	Template Template `alloy:"template,attr"`
+	Source   string   `alloy:"source,attr"    json:"source"`
+	Template Template `alloy:"template,attr"  json:"template"`
 }
 
 func (t *TemplateConfig) Validate() error {

--- a/internal/component/loki/process/stages/tenant.go
+++ b/internal/component/loki/process/stages/tenant.go
@@ -26,9 +26,9 @@ type tenantStage struct {
 
 // TenantConfig configures a tenant stage.
 type TenantConfig struct {
-	Label  string `alloy:"label,attr,optional"`
-	Source string `alloy:"source,attr,optional"`
-	Value  string `alloy:"value,attr,optional"`
+	Label  string `alloy:"label,attr,optional"  json:"label,omitempty"`
+	Source string `alloy:"source,attr,optional" json:"source,omitempty"`
+	Value  string `alloy:"value,attr,optional"  json:"value,omitempty"`
 }
 
 // validateTenantConfig validates the tenant stage configuration

--- a/internal/component/loki/process/stages/timestamp.go
+++ b/internal/component/loki/process/stages/timestamp.go
@@ -45,11 +45,11 @@ var TimestampActionOnFailureOptions = []string{TimestampActionOnFailureSkip, Tim
 
 // TimestampConfig configures a processing stage for timestamp extraction.
 type TimestampConfig struct {
-	Source          string   `alloy:"source,attr"`
-	Format          string   `alloy:"format,attr"`
-	FallbackFormats []string `alloy:"fallback_formats,attr,optional"`
-	Location        *string  `alloy:"location,attr,optional"`
-	ActionOnFailure string   `alloy:"action_on_failure,attr,optional"`
+	Source          string   `alloy:"source,attr"                       json:"source"`
+	Format          string   `alloy:"format,attr"                       json:"format"`
+	FallbackFormats []string `alloy:"fallback_formats,attr,optional"    json:"fallbackFormats,omitempty"`
+	Location        *string  `alloy:"location,attr,optional"            json:"location,omitempty"`
+	ActionOnFailure string   `alloy:"action_on_failure,attr,optional"   json:"actionOnFailure,omitempty"`
 }
 
 type parser func(string) (time.Time, error)

--- a/internal/component/loki/process/stages/truncate.go
+++ b/internal/component/loki/process/stages/truncate.go
@@ -222,3 +222,65 @@ func getTruncateCountMetric(registerer prometheus.Registerer) *prometheus.Counte
 	}, []string{"field"})
 	return util.MustRegisterOrGet(registerer, truncateCount).(*prometheus.CounterVec)
 }
+
+// ProcessEntry implements SyncStage.
+func (m *truncateStage) ProcessEntry(e Entry) []Entry {
+	truncated := map[string]struct{}{}
+	for _, r := range m.cfg.Rules {
+		switch r.SourceType {
+		case SourceTypeLine:
+			if len(e.Line) > int(r.effectiveLimit) {
+				e.Line = e.Line[:r.effectiveLimit] + r.Suffix
+				markTruncated(m.truncatedCount, truncated, truncateLineField)
+			}
+		case SourceTypeLabel:
+			if len(r.Sources) > 0 {
+				for _, source := range r.Sources {
+					name := model.LabelName(source)
+					if v, ok := e.Labels[name]; ok {
+						m.tryTruncateLabel(r, e.Labels, name, v, truncated)
+					}
+				}
+			} else {
+				for k, v := range e.Labels {
+					m.tryTruncateLabel(r, e.Labels, k, v, truncated)
+				}
+			}
+		case SourceTypeStructuredMetadata:
+			if len(r.Sources) > 0 {
+				for i, v := range e.StructuredMetadata {
+					if slices.Contains(r.Sources, v.Name) {
+						e.StructuredMetadata[i] = m.tryTruncateStructuredMetadata(r, v, truncated)
+					}
+				}
+			} else {
+				for i, v := range e.StructuredMetadata {
+					e.StructuredMetadata[i] = m.tryTruncateStructuredMetadata(r, v, truncated)
+				}
+			}
+		case SourceTypeExtractedMap:
+			if len(r.Sources) > 0 {
+				for _, source := range r.Sources {
+					if v, ok := e.Extracted[source]; ok {
+						m.tryTruncateExtracted(r, e.Extracted, source, v, truncated)
+					}
+				}
+			} else {
+				for k, v := range e.Extracted {
+					m.tryTruncateExtracted(r, e.Extracted, k, v, truncated)
+				}
+			}
+		}
+	}
+	if len(truncated) > 0 {
+		if existing, ok := e.Extracted["truncated"]; ok {
+			if strExisting, ok := existing.(string); ok {
+				for s := range strings.SplitSeq(strExisting, ",") {
+					truncated[s] = struct{}{}
+				}
+			}
+		}
+		e.Extracted["truncated"] = strings.Join(slices.Sorted(maps.Keys(truncated)), ",")
+	}
+	return []Entry{e}
+}

--- a/internal/component/loki/process/stages/truncate.go
+++ b/internal/component/loki/process/stages/truncate.go
@@ -97,78 +97,75 @@ type truncateStage struct {
 }
 
 func (m *truncateStage) Run(in chan Entry) chan Entry {
-	out := make(chan Entry)
-	go func() {
-		defer close(out)
-		for e := range in {
-			truncated := map[string]struct{}{}
-			for _, r := range m.cfg.Rules {
-				switch r.SourceType {
-				case SourceTypeLine:
-					if len(e.Line) > int(r.effectiveLimit) {
-						e.Line = e.Line[:r.effectiveLimit] + r.Suffix
-						markTruncated(m.truncatedCount, truncated, truncateLineField)
+	return RunWith(in, m.applyRules)
+}
 
-						if Debug {
-							level.Debug(m.logger).Log("msg", "line has been truncated", "limit", r.effectiveLimit, "truncated_line", e.Line)
-						}
-					}
-				case SourceTypeLabel:
-					if len(r.Sources) > 0 {
-						for _, source := range r.Sources {
-							name := model.LabelName(source)
-							if v, ok := e.Labels[name]; ok {
-								m.tryTruncateLabel(r, e.Labels, name, v, truncated)
-							}
-						}
-					} else {
-						for k, v := range e.Labels {
-							m.tryTruncateLabel(r, e.Labels, k, v, truncated)
-						}
-					}
-				case SourceTypeStructuredMetadata:
-					if len(r.Sources) > 0 {
-						for i, v := range e.StructuredMetadata {
-							if slices.Contains(r.Sources, v.Name) {
-								// Returns unmodified if no truncation was required
-								e.StructuredMetadata[i] = m.tryTruncateStructuredMetadata(r, v, truncated)
-							}
-						}
-					} else {
-						for i, v := range e.StructuredMetadata {
-							// Returns unmodified if no truncation was required
-							e.StructuredMetadata[i] = m.tryTruncateStructuredMetadata(r, v, truncated)
-						}
-					}
-				case SourceTypeExtractedMap:
-					if len(r.Sources) > 0 {
-						for _, source := range r.Sources {
-							if v, ok := e.Extracted[source]; ok {
-								m.tryTruncateExtracted(r, e.Extracted, source, v, truncated)
-							}
-						}
-					} else {
-						for k, v := range e.Extracted {
-							m.tryTruncateExtracted(r, e.Extracted, k, v, truncated)
-						}
-					}
-				}
-				if len(truncated) > 0 {
-					// Ensure that we properly support multiple stages truncating different fields
-					if existing, ok := e.Extracted["truncated"]; ok {
-						if strExisting, ok := existing.(string); ok {
-							for s := range strings.SplitSeq(strExisting, ",") {
-								truncated[s] = struct{}{}
-							}
-						}
-					}
-					e.Extracted["truncated"] = strings.Join(slices.Sorted(maps.Keys(truncated)), ",")
+// applyRules applies all truncation rules to a single entry and returns the
+// (possibly mutated) entry. It is used by both Run and ProcessEntry.
+func (m *truncateStage) applyRules(e Entry) Entry {
+	truncated := map[string]struct{}{}
+	for _, r := range m.cfg.Rules {
+		switch r.SourceType {
+		case SourceTypeLine:
+			if len(e.Line) > int(r.effectiveLimit) {
+				e.Line = e.Line[:r.effectiveLimit] + r.Suffix
+				markTruncated(m.truncatedCount, truncated, truncateLineField)
+
+				if Debug {
+					level.Debug(m.logger).Log("msg", "line has been truncated", "limit", r.effectiveLimit, "truncated_line", e.Line)
 				}
 			}
-			out <- e
+		case SourceTypeLabel:
+			if len(r.Sources) > 0 {
+				for _, source := range r.Sources {
+					name := model.LabelName(source)
+					if v, ok := e.Labels[name]; ok {
+						m.tryTruncateLabel(r, e.Labels, name, v, truncated)
+					}
+				}
+			} else {
+				for k, v := range e.Labels {
+					m.tryTruncateLabel(r, e.Labels, k, v, truncated)
+				}
+			}
+		case SourceTypeStructuredMetadata:
+			if len(r.Sources) > 0 {
+				for i, v := range e.StructuredMetadata {
+					if slices.Contains(r.Sources, v.Name) {
+						e.StructuredMetadata[i] = m.tryTruncateStructuredMetadata(r, v, truncated)
+					}
+				}
+			} else {
+				for i, v := range e.StructuredMetadata {
+					e.StructuredMetadata[i] = m.tryTruncateStructuredMetadata(r, v, truncated)
+				}
+			}
+		case SourceTypeExtractedMap:
+			if len(r.Sources) > 0 {
+				for _, source := range r.Sources {
+					if v, ok := e.Extracted[source]; ok {
+						m.tryTruncateExtracted(r, e.Extracted, source, v, truncated)
+					}
+				}
+			} else {
+				for k, v := range e.Extracted {
+					m.tryTruncateExtracted(r, e.Extracted, k, v, truncated)
+				}
+			}
 		}
-	}()
-	return out
+	}
+	if len(truncated) > 0 {
+		// Ensure that we properly support multiple stages truncating different fields
+		if existing, ok := e.Extracted["truncated"]; ok {
+			if strExisting, ok := existing.(string); ok {
+				for s := range strings.SplitSeq(strExisting, ",") {
+					truncated[s] = struct{}{}
+				}
+			}
+		}
+		e.Extracted["truncated"] = strings.Join(slices.Sorted(maps.Keys(truncated)), ",")
+	}
+	return e
 }
 
 func (m *truncateStage) tryTruncateLabel(rule *RuleConfig, l model.LabelSet, name model.LabelName, val model.LabelValue, truncated map[string]struct{}) {
@@ -225,62 +222,5 @@ func getTruncateCountMetric(registerer prometheus.Registerer) *prometheus.Counte
 
 // ProcessEntry implements SyncStage.
 func (m *truncateStage) ProcessEntry(e Entry) []Entry {
-	truncated := map[string]struct{}{}
-	for _, r := range m.cfg.Rules {
-		switch r.SourceType {
-		case SourceTypeLine:
-			if len(e.Line) > int(r.effectiveLimit) {
-				e.Line = e.Line[:r.effectiveLimit] + r.Suffix
-				markTruncated(m.truncatedCount, truncated, truncateLineField)
-			}
-		case SourceTypeLabel:
-			if len(r.Sources) > 0 {
-				for _, source := range r.Sources {
-					name := model.LabelName(source)
-					if v, ok := e.Labels[name]; ok {
-						m.tryTruncateLabel(r, e.Labels, name, v, truncated)
-					}
-				}
-			} else {
-				for k, v := range e.Labels {
-					m.tryTruncateLabel(r, e.Labels, k, v, truncated)
-				}
-			}
-		case SourceTypeStructuredMetadata:
-			if len(r.Sources) > 0 {
-				for i, v := range e.StructuredMetadata {
-					if slices.Contains(r.Sources, v.Name) {
-						e.StructuredMetadata[i] = m.tryTruncateStructuredMetadata(r, v, truncated)
-					}
-				}
-			} else {
-				for i, v := range e.StructuredMetadata {
-					e.StructuredMetadata[i] = m.tryTruncateStructuredMetadata(r, v, truncated)
-				}
-			}
-		case SourceTypeExtractedMap:
-			if len(r.Sources) > 0 {
-				for _, source := range r.Sources {
-					if v, ok := e.Extracted[source]; ok {
-						m.tryTruncateExtracted(r, e.Extracted, source, v, truncated)
-					}
-				}
-			} else {
-				for k, v := range e.Extracted {
-					m.tryTruncateExtracted(r, e.Extracted, k, v, truncated)
-				}
-			}
-		}
-	}
-	if len(truncated) > 0 {
-		if existing, ok := e.Extracted["truncated"]; ok {
-			if strExisting, ok := existing.(string); ok {
-				for s := range strings.SplitSeq(strExisting, ",") {
-					truncated[s] = struct{}{}
-				}
-			}
-		}
-		e.Extracted["truncated"] = strings.Join(slices.Sorted(maps.Keys(truncated)), ",")
-	}
-	return []Entry{e}
+	return []Entry{m.applyRules(e)}
 }

--- a/internal/component/loki/process/stages/truncate.go
+++ b/internal/component/loki/process/stages/truncate.go
@@ -30,14 +30,14 @@ const (
 
 // TruncateConfig contains the configuration for a truncateStage
 type TruncateConfig struct {
-	Rules []*RuleConfig `alloy:"rule,block"`
+	Rules []*RuleConfig `alloy:"rule,block" json:"rules"`
 }
 
 type RuleConfig struct {
-	Limit      units.Base2Bytes `alloy:"limit,attr"`
-	Suffix     string           `alloy:"suffix,attr,optional"`
-	Sources    []string         `alloy:"sources,attr,optional"`
-	SourceType SourceType       `alloy:"source_type,attr,optional"`
+	Limit      units.Base2Bytes `alloy:"limit,attr"                   json:"limit"` // TextMarshaler: serializes as "5MiB"
+	Suffix     string           `alloy:"suffix,attr,optional"         json:"suffix,omitempty"`
+	Sources    []string         `alloy:"sources,attr,optional"        json:"sources,omitempty"`
+	SourceType SourceType       `alloy:"source_type,attr,optional"    json:"sourceType,omitempty"`
 
 	effectiveLimit units.Base2Bytes
 }

--- a/internal/component/loki/source/kubernetes/kubernetes.go
+++ b/internal/component/loki/source/kubernetes/kubernetes.go
@@ -186,7 +186,7 @@ func (c *Component) resyncTargets(targets []discovery.Target) {
 			level.Error(c.log).Log("msg", "failed to process input target", "target", lset.String(), "err", err)
 			continue
 		}
-		tailTargets = append(tailTargets, kubetail.NewTarget(lset, processed, false))
+		tailTargets = append(tailTargets, kubetail.NewTarget(lset, processed, false, nil))
 	}
 
 	// This will never fail because it only fails if the context gets canceled.

--- a/internal/component/loki/source/kubernetes/kubetail/tailer.go
+++ b/internal/component/loki/source/kubernetes/kubetail/tailer.go
@@ -111,8 +111,16 @@ func (t *tailer) Run(ctx context.Context) {
 	})
 	defer handler.Stop()
 
+	// When using the per-target pipeline handler, entries bypass the mutator
+	// handler (which normally calls bo.Reset on every received line). Provide an
+	// explicit reset callback so backoff works correctly on the pipeline path.
+	onEntrySent := func() {}
+	if t.target.Handler() != nil {
+		onEntrySent = bo.Reset
+	}
+
 	for bo.Ongoing() {
-		err := t.tail(ctx, handler)
+		err := t.tail(ctx, handler, onEntrySent)
 		if err == nil {
 			// Check if we should stop tailing this container
 			// Fetch pod info once and use different logic for job pods vs regular pods
@@ -151,7 +159,7 @@ func (t *tailer) Run(ctx context.Context) {
 	}
 }
 
-func (t *tailer) tail(ctx context.Context, handler loki.EntryHandler) error {
+func (t *tailer) tail(ctx context.Context, handler loki.EntryHandler, onEntrySent func()) error {
 	// Set a maximum lifetime of the tail to ensure that connections are
 	// reestablished. This avoids an issue where the Kubernetes API server stops
 	// responding with new logs while the connection is kept open.
@@ -266,12 +274,12 @@ func (t *tailer) tail(ctx context.Context, handler loki.EntryHandler) error {
 
 	level.Info(t.log).Log("msg", "opened log stream", "start time", lastReadTime)
 
-	return t.processLogStream(ctx, stream, handler, lastReadTime, positionsEnt, calc)
+	return t.processLogStream(ctx, stream, handler, lastReadTime, positionsEnt, calc, onEntrySent)
 }
 
 // processLogStream reads log lines from a reader and processes them.
 // It returns when the context is done, the stream ends, or an error occurs.
-func (t *tailer) processLogStream(ctx context.Context, stream io.ReadCloser, handler loki.EntryHandler, lastReadTime time.Time, positionsEnt positions.Entry, calc *rollingAverageCalculator) error {
+func (t *tailer) processLogStream(ctx context.Context, stream io.ReadCloser, handler loki.EntryHandler, lastReadTime time.Time, positionsEnt positions.Entry, calc *rollingAverageCalculator, onEntrySent func()) error {
 	// Use per-target handler if set (routes entries through a PodLogs pipeline),
 	// otherwise fall back to the global handler from Options.
 	ch := handler.Chan()
@@ -305,6 +313,7 @@ func (t *tailer) processLogStream(ctx context.Context, stream io.ReadCloser, han
 			case <-ctx.Done():
 				return nil
 			case ch <- entry:
+				onEntrySent()
 				// Save position after it's been sent over the channel.
 				t.opts.Positions.Put(positionsEnt.Path, positionsEnt.Labels, entryTimestamp.UnixMicro())
 				t.target.Report(entryTimestamp, nil)

--- a/internal/component/loki/source/kubernetes/kubetail/tailer.go
+++ b/internal/component/loki/source/kubernetes/kubetail/tailer.go
@@ -46,9 +46,12 @@ func (tt *tailerTask) Equals(other runner.Task) bool {
 	}
 
 	// Slow path: check individual fields which are part of the task.
+	// Handler is compared by pointer: a different pipeline means a different
+	// handler instance, so the tailer must be restarted to pick up the new one.
 	return tt.Options == otherTask.Options &&
 		tt.Target.UID() == otherTask.Target.UID() &&
-		labels.Equal(tt.Target.Labels(), otherTask.Target.Labels())
+		labels.Equal(tt.Target.Labels(), otherTask.Target.Labels()) &&
+		tt.Target.Handler() == otherTask.Target.Handler()
 }
 
 // A tailer tails the logs of a Kubernetes container. It is created by a
@@ -269,7 +272,12 @@ func (t *tailer) tail(ctx context.Context, handler loki.EntryHandler) error {
 // processLogStream reads log lines from a reader and processes them.
 // It returns when the context is done, the stream ends, or an error occurs.
 func (t *tailer) processLogStream(ctx context.Context, stream io.ReadCloser, handler loki.EntryHandler, lastReadTime time.Time, positionsEnt positions.Entry, calc *rollingAverageCalculator) error {
+	// Use per-target handler if set (routes entries through a PodLogs pipeline),
+	// otherwise fall back to the global handler from Options.
 	ch := handler.Chan()
+	if h := t.target.Handler(); h != nil {
+		ch = h.Chan()
+	}
 	reader := bufio.NewReader(stream)
 	for {
 		line, err := reader.ReadString('\n')

--- a/internal/component/loki/source/kubernetes/kubetail/tailer_test.go
+++ b/internal/component/loki/source/kubernetes/kubetail/tailer_test.go
@@ -170,7 +170,7 @@ func Test_processLogStream(t *testing.T) {
 			lset, err := PrepareLabelsWithMetaPreservation(lset, "test", tc.preserveMetaLabels)
 			require.NoError(t, err)
 
-			target := NewTarget(lset, lset, tc.preserveMetaLabels)
+			target := NewTarget(lset, lset, tc.preserveMetaLabels, nil)
 			opts := &Options{
 				Positions: &mockPositions{},
 			}

--- a/internal/component/loki/source/kubernetes/kubetail/tailer_test.go
+++ b/internal/component/loki/source/kubernetes/kubetail/tailer_test.go
@@ -199,7 +199,7 @@ func Test_processLogStream(t *testing.T) {
 
 			// Process the log stream in a goroutine
 			go func() {
-				_ = tailer.processLogStream(ctx, stream, handler, tc.lastReadTime, positionsEnt, calc)
+				_ = tailer.processLogStream(ctx, stream, handler, tc.lastReadTime, positionsEnt, calc, func() {})
 			}()
 
 			// Collect all entries

--- a/internal/component/loki/source/kubernetes/kubetail/target.go
+++ b/internal/component/loki/source/kubernetes/kubetail/target.go
@@ -10,6 +10,8 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/grafana/alloy/internal/component/common/loki"
 )
 
 // Internal labels which indicate what container to tail logs from.
@@ -51,13 +53,20 @@ type Target struct {
 	uid            string // UID from pod
 	hash           uint64 // Hash of public labels and id
 
+	// handler is an optional per-target entry handler. When set, the tailer
+	// sends log entries to this handler instead of the global Options.Handler.
+	// This is used to route entries through a per-PodLogs processing pipeline.
+	handler loki.EntryHandler
+
 	mut       sync.RWMutex
 	lastError error
 	lastEntry time.Time
 }
 
-// NewTarget creates a new Target which can be passed to a tailer.
-func NewTarget(origLabels labels.Labels, lset labels.Labels, preserveMetaLabels bool) *Target {
+// NewTarget creates a new Target which can be passed to a tailer. handler is
+// optional: when non-nil the tailer will send log entries to it instead of the
+// global Options.Handler, allowing per-target processing pipelines.
+func NewTarget(origLabels labels.Labels, lset labels.Labels, preserveMetaLabels bool, handler loki.EntryHandler) *Target {
 	// Precompute some values based on labels so we don't have to continually
 	// search them.
 	var (
@@ -90,8 +99,13 @@ func NewTarget(origLabels labels.Labels, lset labels.Labels, preserveMetaLabels 
 		id:             id,
 		uid:            uid,
 		hash:           hash,
+		handler:        handler,
 	}
 }
+
+// Handler returns the optional per-target entry handler. When non-nil, the
+// tailer uses this handler instead of the global Options.Handler.
+func (t *Target) Handler() loki.EntryHandler { return t.handler }
 
 func publicLabels(lset labels.Labels, preserveMetaLabels bool) labels.Labels {
 	lb := labels.NewBuilder(lset)

--- a/internal/component/loki/source/podlogs/internal/apis/monitoring/v1alpha2/types.go
+++ b/internal/component/loki/source/podlogs/internal/apis/monitoring/v1alpha2/types.go
@@ -3,6 +3,8 @@ package v1alpha2
 import (
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/grafana/alloy/internal/component/loki/process/stages"
 )
 
 // +genclient
@@ -28,6 +30,13 @@ type PodLogsSpec struct {
 
 	// RelabelConfigs to apply to logs before delivering.
 	RelabelConfigs []*promv1.RelabelConfig `json:"relabelings,omitempty"`
+
+	// PipelineStages defines optional log processing stages applied to each
+	// log line collected by this PodLogs before forwarding. Stages are applied
+	// in order. Note: multiline, windowsevent, and eventlogmessage stages are
+	// not supported because log lines from different pods share the same
+	// pipeline and would be incorrectly merged.
+	PipelineStages []stages.PodLogsStageConfig `json:"pipelineStages,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/internal/component/loki/source/podlogs/internal/apis/monitoring/v1alpha2/zz_generated.deepcopy.go
+++ b/internal/component/loki/source/podlogs/internal/apis/monitoring/v1alpha2/zz_generated.deepcopy.go
@@ -5,7 +5,7 @@
 package v1alpha2
 
 import (
-	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/internal/component/loki/source/podlogs/podlogs.go
+++ b/internal/component/loki/source/podlogs/podlogs.go
@@ -124,9 +124,12 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		return nil, err
 	}
 
+	handler := loki.NewLogsReceiver()
+
 	var (
 		tailer     = kubetail.NewManager(o.Logger, nil)
-		reconciler = newReconciler(o.Logger, tailer, data.(cluster.Cluster))
+		reconciler = newReconciler(o.Logger, tailer, data.(cluster.Cluster),
+			o.Registerer, o.MinStability, handler.Chan())
 		controller = newController(o.Logger, reconciler)
 	)
 
@@ -139,7 +142,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		controller: controller,
 
 		positions: positionsFile,
-		handler:   loki.NewLogsReceiver(),
+		handler:   handler,
 		fanout:    loki.NewFanout(args.ForwardTo),
 	}
 	if err := c.Update(args); err != nil {
@@ -152,6 +155,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 func (c *Component) Run(ctx context.Context) error {
 	defer func() {
 		defer c.positions.Stop()
+		defer c.reconciler.CleanupAllPipelines()
 		loki.Drain(c.handler, c.fanout, loki.DefaultDrainTimeout, func() {
 			c.mut.Lock()
 			defer c.mut.Unlock()

--- a/internal/component/loki/source/podlogs/reconciler.go
+++ b/internal/component/loki/source/podlogs/reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/ckit/shard"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	promlabels "github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
@@ -21,8 +23,11 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/component/loki/process/stages"
 	"github.com/grafana/alloy/internal/component/loki/source/kubernetes/kubetail"
 	monitoringv1alpha2 "github.com/grafana/alloy/internal/component/loki/source/podlogs/internal/apis/monitoring/v1alpha2"
+	"github.com/grafana/alloy/internal/featuregate"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
 	"github.com/grafana/alloy/internal/service/cluster"
 )
@@ -59,12 +64,31 @@ const (
 	kubePodControllerName    = "__meta_kubernetes_pod_controller_name"
 )
 
+// managedPipeline holds the runtime state of a per-PodLogs processing pipeline.
+type managedPipeline struct {
+	// entryHandler is the input end of the pipeline. Tailers send entries here.
+	// Call Stop() to tear down the pipeline's goroutines.
+	entryHandler loki.EntryHandler
+	// stageConfig is kept for change-detection via reflect.DeepEqual.
+	stageConfig []stages.PodLogsStageConfig
+}
+
 // The reconciler reconciles the state of PodLogs on Kubernetes with targets to
 // collect logs from.
 type reconciler struct {
 	log     log.Logger
 	tailer  *kubetail.Manager
 	cluster cluster.Cluster
+
+	// Pipeline management: per-PodLogs processing pipelines.
+	// mainOutChan is where pipeline output is written (= component.handler.Chan()).
+	registerer   prometheus.Registerer
+	minStability featuregate.Stability
+	mainOutChan  chan loki.Entry
+
+	pipelinesMut    sync.Mutex
+	pipelines       map[string]*managedPipeline // key: "namespace/name"
+	replacedPipelines []loki.EntryHandler       // old handlers replaced this reconcile cycle; stopped after SyncTargets
 
 	reconcileMut             sync.RWMutex
 	podLogsSelector          labels.Selector
@@ -81,11 +105,23 @@ type reconciler struct {
 
 // newReconciler creates a new reconciler which synchronizes targets with the
 // provided tailer whenever Reconcile is called.
-func newReconciler(l log.Logger, tailer *kubetail.Manager, cluster cluster.Cluster) *reconciler {
+//
+// registerer, minStability, and mainOutChan are used to manage per-PodLogs
+// processing pipelines. mainOutChan should be the component's main handler
+// channel (component.handler.Chan()); pipeline output is written there so that
+// the existing loki.Consume loop forwards entries to the fanout unchanged.
+func newReconciler(l log.Logger, tailer *kubetail.Manager, cluster cluster.Cluster,
+	registerer prometheus.Registerer, minStability featuregate.Stability, mainOutChan chan loki.Entry,
+) *reconciler {
 	return &reconciler{
 		log:     l,
 		tailer:  tailer,
 		cluster: cluster,
+
+		registerer:   registerer,
+		minStability: minStability,
+		mainOutChan:  mainOutChan,
+		pipelines:    make(map[string]*managedPipeline),
 
 		podLogsSelector:          labels.Everything(),
 		podLogsNamespaceSelector: labels.Everything(),
@@ -165,6 +201,8 @@ func (r *reconciler) Reconcile(ctx context.Context, cli client.Client) error {
 		return fmt.Errorf("could not list PodLogs: %w", err)
 	}
 
+	activePipelineKeys := make(map[string]struct{})
+
 	for _, podLogs := range podLogsList.Items {
 		key := client.ObjectKeyFromObject(podLogs)
 
@@ -178,6 +216,10 @@ func (r *reconciler) Reconcile(ctx context.Context, cli client.Client) error {
 			continue
 		}
 
+		if len(podLogs.Spec.PipelineStages) > 0 {
+			activePipelineKeys[podLogs.Namespace+"/"+podLogs.Name] = struct{}{}
+		}
+
 		targets, discoveredPodLogs := r.reconcilePodLogs(ctx, cli, podLogs)
 
 		newTasks = append(newTasks, targets...)
@@ -189,9 +231,18 @@ func (r *reconciler) Reconcile(ctx context.Context, cli client.Client) error {
 		newTasks = distributeTargets(r.cluster, newTasks)
 	}
 
+	// SyncTargets stops removed tailer workers and waits for them to exit
+	// before returning. Pipelines must only be stopped after this point so
+	// that no tailer goroutine is left trying to write to a dead pipeline
+	// channel.
 	if err := r.tailer.SyncTargets(ctx, newTasks); err != nil {
 		level.Error(r.log).Log("msg", "failed to apply new tailers to run", "err", err)
 	}
+
+	// Now it is safe to tear down pipelines: all tailers that referenced them
+	// have exited.
+	r.cleanupStalePipelines(activePipelineKeys)
+	r.stopReplacedPipelines()
 
 	r.debugMut.Lock()
 	r.debugInfo = newDebugInfo
@@ -265,6 +316,21 @@ func (r *reconciler) reconcilePodLogs(ctx context.Context, cli client.Client, po
 		discoveredPodLogs.ReconcileError = fmt.Sprintf("invalid relabelings: %s", err)
 		level.Error(r.log).Log("msg", "failed to reconcile PodLogs", "operation", "convert relabelings", "key", key, "err", err)
 		return targets, discoveredPodLogs
+	}
+
+	// Determine the per-target entry handler. When PipelineStages are configured,
+	// entries are routed through a dedicated processing pipeline for this PodLogs.
+	// Otherwise nil means the global handler (Options.Handler) is used.
+	var targetHandler loki.EntryHandler
+	if len(podLogs.Spec.PipelineStages) > 0 {
+		pipelineKey := podLogs.Namespace + "/" + podLogs.Name
+		handler, err := r.ensurePipeline(pipelineKey, podLogs.Spec.PipelineStages)
+		if err != nil {
+			discoveredPodLogs.ReconcileError = fmt.Sprintf("invalid pipeline stages: %s", err)
+			level.Error(r.log).Log("msg", "failed to reconcile PodLogs", "operation", "build pipeline", "key", key, "err", err)
+			return targets, discoveredPodLogs
+		}
+		targetHandler = handler
 	}
 
 	sel, err := metav1.LabelSelectorAsSelector(&podLogs.Spec.Selector)
@@ -351,7 +417,7 @@ func (r *reconciler) reconcilePodLogs(ctx context.Context, cli client.Client, po
 				return
 			}
 
-			target := kubetail.NewTarget(targetLabels.Copy(), finalLabels, preserveMetaLabels)
+			target := kubetail.NewTarget(targetLabels.Copy(), finalLabels, preserveMetaLabels, targetHandler)
 			if processedLabels.Len() != 0 {
 				targets = append(targets, target)
 			}
@@ -373,6 +439,98 @@ func (r *reconciler) reconcilePodLogs(ctx context.Context, cli client.Client, po
 	}
 
 	return targets, discoveredPodLogs
+}
+
+// ensurePipeline returns the entry handler for a PodLogs pipeline, creating or
+// replacing it if the stage config has changed. The returned handler's Chan()
+// is the pipeline input; entries written there are processed and forwarded to
+// r.mainOutChan.
+func (r *reconciler) ensurePipeline(key string, stageConfigs []stages.PodLogsStageConfig) (loki.EntryHandler, error) {
+	r.pipelinesMut.Lock()
+	defer r.pipelinesMut.Unlock()
+
+	if existing, ok := r.pipelines[key]; ok && reflect.DeepEqual(existing.stageConfig, stageConfigs) {
+		// Stage config unchanged — reuse existing pipeline.
+		return existing.entryHandler, nil
+	}
+
+	// Stages changed (or this is first time): queue the old pipeline for
+	// deferred stop. It must not be stopped here because tailer goroutines
+	// targeting the old pipeline may still be running; they are stopped
+	// by SyncTargets (which waits for worker exit) before we drain
+	// replacedPipelines in Reconcile.
+	if existing, ok := r.pipelines[key]; ok {
+		r.replacedPipelines = append(r.replacedPipelines, existing.entryHandler)
+		delete(r.pipelines, key)
+	}
+
+	// Build a namespaced registerer so per-PodLogs metrics don't conflict.
+	ns, name, _ := strings.Cut(key, "/")
+	pipelineRegisterer := prometheus.WrapRegistererWith(prometheus.Labels{
+		"podlogs_namespace": ns,
+		"podlogs_name":      name,
+	}, r.registerer)
+
+	pipeline, err := stages.NewPipeline(r.log, stages.ConvertPodLogsStages(stageConfigs), pipelineRegisterer, r.minStability)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Pipeline.Start spawns N_stages+3 goroutines per PodLogs resource.
+	// At large scale (hundreds of PodLogs with stages) this adds up. A future
+	// improvement would be to add a synchronous Pipeline.Process(entry) path so
+	// stages can be applied inline inside each tailer goroutine (zero overhead).
+	pipelineIn := loki.NewLogsReceiver()
+	entryHandler := pipeline.Start(pipelineIn.Chan(), r.mainOutChan)
+
+	r.pipelines[key] = &managedPipeline{
+		entryHandler: entryHandler,
+		stageConfig:  stageConfigs,
+	}
+
+	level.Debug(r.log).Log("msg", "started processing pipeline for PodLogs", "key", key, "stages", len(stageConfigs))
+	return entryHandler, nil
+}
+
+// cleanupStalePipelines stops pipelines for PodLogs keys that are no longer
+// in the active set. Must be called after reconciliation is complete.
+func (r *reconciler) cleanupStalePipelines(activeKeys map[string]struct{}) {
+	r.pipelinesMut.Lock()
+	defer r.pipelinesMut.Unlock()
+
+	for key, p := range r.pipelines {
+		if _, active := activeKeys[key]; !active {
+			p.entryHandler.Stop()
+			delete(r.pipelines, key)
+			level.Debug(r.log).Log("msg", "stopped processing pipeline for PodLogs", "key", key)
+		}
+	}
+}
+
+// stopReplacedPipelines stops pipelines that were replaced during this reconcile
+// cycle (stage config changed). Must be called after SyncTargets so that all
+// tailer goroutines referencing the old handlers have already exited.
+func (r *reconciler) stopReplacedPipelines() {
+	r.pipelinesMut.Lock()
+	replaced := r.replacedPipelines
+	r.replacedPipelines = nil
+	r.pipelinesMut.Unlock()
+
+	for _, h := range replaced {
+		h.Stop()
+	}
+}
+
+// CleanupAllPipelines stops all running pipelines. Called on component shutdown.
+func (r *reconciler) CleanupAllPipelines() {
+	r.pipelinesMut.Lock()
+	defer r.pipelinesMut.Unlock()
+
+	for key, p := range r.pipelines {
+		p.entryHandler.Stop()
+		delete(r.pipelines, key)
+		level.Debug(r.log).Log("msg", "stopped processing pipeline for PodLogs on shutdown", "key", key)
+	}
 }
 
 // DebugInfo returns the current debug information for the reconciler.

--- a/internal/component/loki/source/podlogs/reconciler.go
+++ b/internal/component/loki/source/podlogs/reconciler.go
@@ -478,7 +478,11 @@ func (r *reconciler) ensurePipeline(key string, stageConfigs []stages.PodLogsSta
 		"podlogs_name":      name,
 	}, r.registerer)
 
-	pipeline, err := stages.NewPipeline(r.log, stages.ConvertPodLogsStages(stageConfigs), pipelineRegisterer, r.minStability)
+	converted, err := stages.ConvertPodLogsStages(stageConfigs)
+	if err != nil {
+		return nil, err
+	}
+	pipeline, err := stages.NewPipeline(r.log, converted, pipelineRegisterer, r.minStability)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/component/loki/source/podlogs/reconciler.go
+++ b/internal/component/loki/source/podlogs/reconciler.go
@@ -483,12 +483,16 @@ func (r *reconciler) ensurePipeline(key string, stageConfigs []stages.PodLogsSta
 		return nil, err
 	}
 
-	// TODO: Pipeline.Start spawns N_stages+3 goroutines per PodLogs resource.
-	// At large scale (hundreds of PodLogs with stages) this adds up. A future
-	// improvement would be to add a synchronous Pipeline.Process(entry) path so
-	// stages can be applied inline inside each tailer goroutine (zero overhead).
+	// Use StartSync (1 goroutine) when all stages implement SyncStage.
+	// Fall back to Start (N+3 goroutines) only for pipelines containing
+	// stages that don't yet support synchronous processing (e.g. match).
 	pipelineIn := loki.NewLogsReceiver()
-	entryHandler := pipeline.Start(pipelineIn.Chan(), r.mainOutChan)
+	var entryHandler loki.EntryHandler
+	if pipeline.CanProcessSync() {
+		entryHandler = pipeline.StartSync(pipelineIn.Chan(), r.mainOutChan)
+	} else {
+		entryHandler = pipeline.Start(pipelineIn.Chan(), r.mainOutChan)
+	}
 
 	r.pipelines[key] = &managedPipeline{
 		entryHandler: entryHandler,

--- a/internal/component/loki/source/podlogs/reconciler.go
+++ b/internal/component/loki/source/podlogs/reconciler.go
@@ -216,11 +216,18 @@ func (r *reconciler) Reconcile(ctx context.Context, cli client.Client) error {
 			continue
 		}
 
-		if len(podLogs.Spec.PipelineStages) > 0 {
-			activePipelineKeys[podLogs.Namespace+"/"+podLogs.Name] = struct{}{}
-		}
-
 		targets, discoveredPodLogs := r.reconcilePodLogs(ctx, cli, podLogs)
+
+		// Populate activePipelineKeys only when a pipeline was successfully created
+		// (ensurePipeline may fail or reconcilePodLogs may return early). Checking
+		// r.pipelines after the call is safe: ensurePipeline holds pipelinesMut while
+		// inserting, so by the time reconcilePodLogs returns the map is up to date.
+		pipelineKey := podLogs.Namespace + "/" + podLogs.Name
+		r.pipelinesMut.Lock()
+		if _, ok := r.pipelines[pipelineKey]; ok {
+			activePipelineKeys[pipelineKey] = struct{}{}
+		}
+		r.pipelinesMut.Unlock()
 
 		newTasks = append(newTasks, targets...)
 		newDebugInfo = append(newDebugInfo, discoveredPodLogs)

--- a/internal/component/loki/source/podlogs/reconciler_test.go
+++ b/internal/component/loki/source/podlogs/reconciler_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/util/strutil"
@@ -15,9 +16,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	lokicommon "github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/component/loki/source/kubernetes/kubetail"
 	monitoringv1alpha2 "github.com/grafana/alloy/internal/component/loki/source/podlogs/internal/apis/monitoring/v1alpha2"
+	"github.com/grafana/alloy/internal/featuregate"
 )
+
+// newTestReconciler creates a reconciler suitable for unit tests.
+// tailer and cluster are nil (not exercised by most tests).
+func newTestReconciler() *reconciler {
+	ch := make(chan lokicommon.Entry, 100)
+	return newReconciler(log.NewNopLogger(), nil, nil,
+		prometheus.NewRegistry(), featuregate.StabilityGenerallyAvailable, ch)
+}
 
 func TestBuildPodLogsTargetLabels(t *testing.T) {
 	tests := []struct {
@@ -177,7 +188,7 @@ func TestReconcilePodLogs_DefaultLabels(t *testing.T) {
 
 	// Create a reconciler. The tailer and cluster are not used by reconcilePodLogs,
 	// so we can pass nil.
-	r := newReconciler(log.NewNopLogger(), nil, nil)
+	r := newTestReconciler()
 
 	// Call reconcilePodLogs.
 	targets, _ := r.reconcilePodLogs(t.Context(), cl, podLogs)
@@ -391,7 +402,7 @@ func TestReconcilePodLogs_NodeFiltering(t *testing.T) {
 			}).Build()
 
 			// Create a reconciler and configure node filtering
-			r := newReconciler(log.NewNopLogger(), nil, nil)
+			r := newTestReconciler()
 			r.UpdateNodeFilter(tt.nodeFilterEnabled, tt.nodeFilterName)
 
 			// Call reconcilePodLogs.
@@ -434,7 +445,7 @@ func TestReconcilePodLogs_NodeFiltering(t *testing.T) {
 }
 
 func TestNodeFilterConfiguration(t *testing.T) {
-	r := newReconciler(log.NewNopLogger(), nil, nil)
+	r := newTestReconciler()
 
 	// Test initial state
 	if r.getNodeFilterName() != "" {
@@ -469,7 +480,7 @@ func TestNodeFilterConfiguration(t *testing.T) {
 
 func TestPreserveDiscoveredLabels_MetaLabelPreservation(t *testing.T) {
 	// Create a reconciler with preserve discovered labels enabled
-	r := newReconciler(log.NewNopLogger(), nil, nil)
+	r := newTestReconciler()
 	r.UpdatePreserveMetaLabels(true)
 
 	// Verify the preserveMetaLabels field is set correctly

--- a/operations/helm/charts/alloy/charts/crds/crds/monitoring.grafana.com_podlogs.yaml
+++ b/operations/helm/charts/alloy/charts/crds/crds/monitoring.grafana.com_podlogs.yaml
@@ -151,6 +151,423 @@ spec:
                       type: string
                   type: object
                 type: array
+              pipelineStages:
+                description: PipelineStages defines optional log processing stages
+                  applied to each log line before forwarding. Stages are applied in
+                  order. Note that multiline, windowsevent, and eventlogmessage stages
+                  are not supported.
+                items:
+                  description: PodLogsStageConfig defines a single log processing
+                    stage. Exactly one field should be set.
+                  properties:
+                    cri:
+                      description: CRI is a pre-processing stage for CRI-formatted
+                        log lines.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    decolorize:
+                      description: Decolorize strips ANSI color codes from log lines.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    docker:
+                      description: Docker is a pre-processing stage for Docker-formatted
+                        log lines.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    drop:
+                      description: Drop configures dropping log lines that match a
+                        condition.
+                      properties:
+                        dropReason:
+                          description: Custom reason to report for dropped lines in
+                            metrics.
+                          type: string
+                        expression:
+                          description: RE2 regular expression; lines matching it are
+                            dropped.
+                          type: string
+                        longerThan:
+                          description: Drop lines longer than this size (e.g. "8KiB").
+                          type: string
+                        separator:
+                          description: Separator used when joining multiple source
+                            values.
+                          type: string
+                        source:
+                          description: Name of the extracted value to match against.
+                            Defaults to the log line.
+                          type: string
+                        value:
+                          description: Exact string the source value must equal to
+                            trigger a drop.
+                          type: string
+                      type: object
+                    geoip:
+                      description: GeoIP adds geo-location labels derived from an
+                        IP address.
+                      properties:
+                        customLookups:
+                          additionalProperties:
+                            type: string
+                          description: Custom lookup fields to add from the database.
+                          type: object
+                        db:
+                          description: Path to the MaxMind GeoIP database file.
+                          type: string
+                        dbType:
+                          description: 'Database type: city, asn, or country.'
+                          type: string
+                        source:
+                          description: Label or extracted key holding the IP address.
+                          type: string
+                      type: object
+                    json:
+                      description: JSON extracts fields from a JSON log line.
+                      properties:
+                        dropMalformed:
+                          description: Drop lines that cannot be parsed as JSON.
+                          type: boolean
+                        expressions:
+                          additionalProperties:
+                            type: string
+                          description: Map of extracted key to optional JMESPath expression.
+                          type: object
+                        source:
+                          description: If set, parse this extracted value instead of
+                            the log line.
+                          type: string
+                      type: object
+                    label_drop:
+                      description: LabelDrop removes labels from the label set.
+                      properties:
+                        values:
+                          description: List of label names to remove.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    label_keep:
+                      description: LabelKeep retains only the listed labels.
+                      properties:
+                        values:
+                          description: List of label names to keep.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    labels:
+                      description: Labels promotes extracted values to log labels.
+                      properties:
+                        sourceType:
+                          description: 'Source of values: extracted (default) or structured_metadata.'
+                          type: string
+                        values:
+                          additionalProperties:
+                            type: string
+                          description: Map of label name to optional extracted key.
+                          type: object
+                      type: object
+                    limit:
+                      description: Limit rate-limits or drops log lines.
+                      properties:
+                        burst:
+                          description: Maximum burst size in lines.
+                          format: int64
+                          type: integer
+                        byLabelName:
+                          description: Apply per-value limits keyed by this label.
+                          type: string
+                        drop:
+                          description: Drop lines that exceed the rate limit instead
+                            of blocking.
+                          type: boolean
+                        maxDistinctLabels:
+                          description: Maximum number of distinct label values to
+                            track for byLabelName.
+                          type: integer
+                        rate:
+                          description: Steady-state rate limit in lines per second.
+                          format: int64
+                          type: integer
+                      required:
+                      - burst
+                      - rate
+                      type: object
+                    logfmt:
+                      description: Logfmt parses a logfmt-formatted log line.
+                      properties:
+                        mapping:
+                          additionalProperties:
+                            type: string
+                          description: Map of extracted key to logfmt field name.
+                          type: object
+                        source:
+                          description: Parse this extracted value instead of the log
+                            line.
+                          type: string
+                      type: object
+                    luhn:
+                      description: Luhn redacts Luhn-valid numbers (e.g. credit card
+                        numbers) from log lines.
+                      properties:
+                        delimiters:
+                          description: Characters that may appear between digits.
+                          type: string
+                        minLength:
+                          description: Minimum digit length to consider.
+                          type: integer
+                        replacement:
+                          description: Replacement string for redacted numbers.
+                          type: string
+                        source:
+                          description: Extracted key to redact instead of the log
+                            line.
+                          type: string
+                      type: object
+                    match:
+                      description: Match applies nested stages only to lines matching
+                        a LogQL stream selector.
+                      properties:
+                        action:
+                          description: 'Action when the selector matches: keep (default)
+                            or drop.'
+                          type: string
+                        dropReason:
+                          description: Custom drop reason for metrics when action is
+                            drop.
+                          type: string
+                        pipelineName:
+                          description: Optional name for the nested pipeline, used
+                            in metrics.
+                          type: string
+                        selector:
+                          description: LogQL stream selector expression.
+                          type: string
+                        stages:
+                          description: Nested pipeline stages applied to matching
+                            lines.
+                          items:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          type: array
+                      required:
+                      - selector
+                      type: object
+                    metrics:
+                      description: Metrics generates Prometheus metrics from log lines.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    output:
+                      description: Output sets the log line to an extracted value.
+                      properties:
+                        source:
+                          description: Extracted key whose value becomes the new log
+                            line.
+                          type: string
+                      required:
+                      - source
+                      type: object
+                    pack:
+                      description: Pack converts labels into a packed log line format.
+                      properties:
+                        ingestTimestamp:
+                          description: Use the ingestion timestamp instead of the
+                            log timestamp.
+                          type: boolean
+                        labels:
+                          description: Labels to pack into the log line.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - labels
+                      type: object
+                    pattern:
+                      description: Pattern extracts values using a Loki pattern expression.
+                      properties:
+                        labelsFromGroups:
+                          description: Promote captured groups directly to labels.
+                          type: boolean
+                        pattern:
+                          description: Loki pattern expression.
+                          type: string
+                        source:
+                          description: Extracted key to match instead of the log line.
+                          type: string
+                      required:
+                      - pattern
+                      type: object
+                    regex:
+                      description: Regex extracts values using a RE2 named-group expression.
+                      properties:
+                        expression:
+                          description: RE2 expression with named capture groups.
+                          type: string
+                        labelsFromGroups:
+                          description: Promote capture groups directly to labels.
+                          type: boolean
+                        source:
+                          description: Extracted key to match instead of the log line.
+                          type: string
+                      required:
+                      - expression
+                      type: object
+                    replace:
+                      description: Replace performs a regex find-and-replace on the
+                        log line or an extracted value.
+                      properties:
+                        expression:
+                          description: RE2 expression to match.
+                          type: string
+                        replace:
+                          description: Replacement string (supports capture group references).
+                          type: string
+                        source:
+                          description: Extracted key to operate on instead of the
+                            log line.
+                          type: string
+                      required:
+                      - expression
+                      type: object
+                    sampling:
+                      description: Sampling randomly drops a fraction of log lines.
+                      properties:
+                        dropReason:
+                          description: Custom reason for dropped lines in metrics.
+                          type: string
+                        rate:
+                          description: Fraction of lines to keep (0.0–1.0).
+                          type: number
+                      required:
+                      - rate
+                      type: object
+                    static_labels:
+                      description: StaticLabels adds a fixed set of labels to every
+                        log entry.
+                      properties:
+                        values:
+                          additionalProperties:
+                            type: string
+                          description: Map of label name to static value.
+                          type: object
+                      type: object
+                    structured_metadata:
+                      description: StructuredMetadata promotes extracted values to
+                        Loki structured metadata.
+                      properties:
+                        regex:
+                          additionalProperties:
+                            type: string
+                          description: Map of metadata key to regex to extract from
+                            log line.
+                          type: object
+                        values:
+                          additionalProperties:
+                            type: string
+                          description: Map of metadata key to optional extracted key.
+                          type: object
+                      type: object
+                    structured_metadata_drop:
+                      description: StructuredMetadataDrop removes structured metadata
+                        keys.
+                      properties:
+                        values:
+                          description: List of structured metadata keys to remove.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    template:
+                      description: Template uses Go templates to create or modify extracted
+                        values.
+                      properties:
+                        source:
+                          description: Extracted key to set.
+                          type: string
+                        template:
+                          description: Go template string; can reference other extracted
+                            values with {{.Value}}.
+                          type: string
+                      required:
+                      - source
+                      - template
+                      type: object
+                    tenant:
+                      description: Tenant overrides the tenant ID for log entries.
+                      properties:
+                        label:
+                          description: Label whose value is used as the tenant ID.
+                          type: string
+                        source:
+                          description: Extracted key whose value is used as the tenant
+                            ID.
+                          type: string
+                        value:
+                          description: Static tenant ID value.
+                          type: string
+                      type: object
+                    timestamp:
+                      description: Timestamp parses a timestamp from an extracted
+                        value and sets it as the log entry timestamp.
+                      properties:
+                        actionOnFailure:
+                          description: 'Action when parsing fails: skip (default)
+                            or fudge.'
+                          type: string
+                        fallbackFormats:
+                          description: Additional formats to try if the primary format
+                            fails.
+                          items:
+                            type: string
+                          type: array
+                        format:
+                          description: Timestamp format (Go reference time, Unix,
+                            UnixMs, UnixUs, UnixNs, or RFC3339).
+                          type: string
+                        location:
+                          description: IANA timezone name for formats without timezone
+                            info.
+                          type: string
+                        source:
+                          description: Extracted key containing the timestamp string.
+                          type: string
+                      required:
+                      - format
+                      - source
+                      type: object
+                    truncate:
+                      description: Truncate shortens log lines or extracted values.
+                      properties:
+                        rules:
+                          description: Truncation rules to apply.
+                          items:
+                            description: TruncateRuleConfig defines a single truncation
+                              rule.
+                            properties:
+                              limit:
+                                description: Maximum length in bytes; 0 means no limit.
+                                type: integer
+                              sourceType:
+                                description: 'Source type: line or label.'
+                                type: string
+                              sources:
+                                description: Label names to truncate (when sourceType
+                                  is label).
+                                items:
+                                  type: string
+                                type: array
+                              suffix:
+                                description: String appended to truncated values.
+                                type: string
+                            required:
+                            - limit
+                            type: object
+                          type: array
+                      required:
+                      - rules
+                      type: object
+                  type: object
+                type: array
               selector:
                 description: Selector to select Pod objects. Required.
                 properties:


### PR DESCRIPTION
## Summary

> **Merge order:** this PR depends on #5999 and #6000 and should be merged last.

Adds a `SyncStage` optional interface to the `loki.process` stages package so that pipelines whose stages all support synchronous processing can run in a single goroutine instead of the `N+3` goroutine chain produced by `Pipeline.Start`.

This is particularly important for `loki.source.podlogs` (#6000), where each PodLogs CRD with `pipelineStages` creates one pipeline. At scale (100–500 PodLogs CRDs), the goroutine savings are significant.

### Changes

**`SyncStage` interface + `Pipeline.StartSync`**
- New optional `SyncStage` interface: `ProcessEntry(e Entry) []Entry`
- `Pipeline.CanProcessSync()` returns true when all stages implement `SyncStage` (deep-checks nested match pipelines via `syncChecker`)
- `Pipeline.StartSync()` runs the whole pipeline in 1 goroutine instead of N+3
- `Pipeline.processEntryFull()` private method applies stages to an already-initialised `Entry` (used by `matcherStage`)

**Stages that now implement `SyncStage`**
- All `Processor`-based stages (regex, json, logfmt, labels, template, tenant, timestamp, output, replace, pattern, luhn, label_drop, label_keep, static_labels, docker, …) get `ProcessEntry` for free via `stageProcessor`
- `cri`: `processLine()` helper extracted — `Run` and `ProcessEntry` share the same implementation
- `truncate`: `applyRules()` helper extracted — `Run` simplified to `RunWith(in, m.applyRules)`
- `drop`: `ProcessEntry` added
- `geoip`: `ProcessEntry` added
- `sampling`: `ProcessEntry` added
- `pack`: `ProcessEntry` added
- `limit`: `ProcessEntry` added
- `match`: `ProcessEntry` + `canProcessSync()` — keep actions are sync-safe when the nested pipeline is also sync-capable; drop actions are always sync-safe

**Goroutine comparison (N = number of stages)**

| Path | Goroutines |
|---|---|
| `Pipeline.Start` | N + 3 |
| `Pipeline.StartSync` | 1 |

## Test plan

- [ ] All existing stage tests pass
- [ ] `Pipeline.CanProcessSync()` returns false for pipelines containing multiline
- [ ] `Pipeline.CanProcessSync()` returns true for all-sync pipelines including nested match
- [ ] A match stage with a non-sync inner pipeline does not incorrectly report sync support

Refs: #4738

🤖 Generated with [Claude Code](https://claude.com/claude-code)