### PR TITLE
chore(loki.process): Expand process pipeline component coverage

### DIFF
--- a/internal/component/loki/process/process_test.go
+++ b/internal/component/loki/process/process_test.go
@@ -157,6 +157,10 @@ func TestComponent(t *testing.T) {
 					}
 				}
 
+			stage.structured_metadata_drop {
+				values = ["stream"]
+			}
+
 			stage.static_labels {
 				values = {
 					foo = "bar",
@@ -191,7 +195,6 @@ func TestComponent(t *testing.T) {
 					Line:      "docker stdout line\n",
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "docker.log"},
-						{Name: "stream", Value: "stdout"},
 					},
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
@@ -199,7 +202,6 @@ func TestComponent(t *testing.T) {
 					Line:      "docker stderr line\n",
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "docker.log"},
-						{Name: "stream", Value: "stderr"},
 					},
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
@@ -222,6 +224,7 @@ func TestComponent(t *testing.T) {
 					app = "",
 					service_name = "",
 				}
+				drop_malformed = true
 			}
 
 			stage.labels {
@@ -268,13 +271,6 @@ func TestComponent(t *testing.T) {
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "json.log"},
 						{Name: "app", Value: "api"},
-					},
-				}),
-				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
-					Timestamp: getEntryTS(1),
-					Line:      `not json`,
-					StructuredMetadata: push.LabelsAdapter{
-						{Name: "filename", Value: "json.log"},
 					},
 				}),
 			},
@@ -400,11 +396,65 @@ func TestComponent(t *testing.T) {
 					Timestamp: getEntryTS(0),
 					Line:      formatTs(0, time.RFC3339) + ` stderr somewhere, somehow, an error occurred`,
 				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "/var/log/pods/agent/agent/2.log", "foo": "bar"}, 0, push.Entry{
+					Timestamp: getEntryTS(1),
+					Line:      `not matching`,
+				}),
 			},
 			expected: []loki.Entry{
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "/var/log/pods/agent/agent/1.log", "foo": "bar", "src": "stderr"}, 0, push.Entry{
 					Timestamp: mustParseTime(t, time.RFC3339, formatTs(0, time.RFC3339)),
 					Line:      `somewhere, somehow, an error occurred`,
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "/var/log/pods/agent/agent/2.log", "foo": "bar"}, 0, push.Entry{
+					Timestamp: getEntryTS(1),
+					Line:      `not matching`,
+				}),
+			},
+		},
+		{
+			name: "drop pipeline",
+			cfg: `
+			forward_to = []
+
+			stage.drop {
+				expression = "drop"
+			}
+
+			stage.match {
+				selector = "{filename=\"drop.log\"} |= \"match me\""
+				action   = "drop"
+			}
+
+			stage.limit {
+				rate  = 1
+				burst = 1
+				drop  = true
+			}
+
+			`,
+			inputs: []loki.Entry{
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "drop.log"}, 0, push.Entry{
+					Timestamp: getEntryTS(0),
+					Line:      `drop me`,
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "drop.log"}, 0, push.Entry{
+					Timestamp: getEntryTS(1),
+					Line:      `match me`,
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "drop.log"}, 0, push.Entry{
+					Timestamp: getEntryTS(2),
+					Line:      `keep me`,
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "drop.log"}, 0, push.Entry{
+					Timestamp: getEntryTS(3),
+					Line:      `limit me`,
+				}),
+			},
+			expected: []loki.Entry{
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "drop.log"}, 0, push.Entry{
+					Timestamp: getEntryTS(2),
+					Line:      `keep me`,
 				}),
 			},
 		},

--- a/internal/component/loki/process/process_test.go
+++ b/internal/component/loki/process/process_test.go
@@ -426,7 +426,7 @@ func TestComponent(t *testing.T) {
 					Line:      `no match`,
 				}),
 			},
-			// NOTE: we cannot garantuee ordereing between different sub-pipelines.
+			// NOTE: we cannot guarantee ordering between different sub-pipelines.
 			unorderedFrom: ptr.To(0),
 		},
 		{

--- a/internal/component/loki/process/process_test.go
+++ b/internal/component/loki/process/process_test.go
@@ -89,6 +89,10 @@ func TestComponent(t *testing.T) {
 					Timestamp: time.Now(),
 					Line:      now.Format(time.RFC3339Nano) + " stderr F full file 1 stdout",
 				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "file3"}, 0, push.Entry{
+					Timestamp: now.Add(3 * time.Second),
+					Line:      "not a cri line",
+				}),
 			},
 			expected: []loki.Entry{
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
@@ -113,6 +117,13 @@ func TestComponent(t *testing.T) {
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "file1"},
 						{Name: "stream", Value: "stderr"},
+					},
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
+					Timestamp: now.Add(3 * time.Second),
+					Line:      "not a cri line",
+					StructuredMetadata: push.LabelsAdapter{
+						{Name: "filename", Value: "file3"},
 					},
 				}),
 			},
@@ -185,6 +196,74 @@ func TestComponent(t *testing.T) {
 				}),
 			},
 		},
+		{
+			name: "simple json pipeline",
+			cfg: `
+			forward_to = []
+
+			stage.json {
+				expressions = {
+					msg = "",
+					app = "",
+					service_name = "",
+				}
+			}
+
+			stage.labels {
+				values = {
+					service_name = "",
+				}
+			}
+
+			stage.structured_metadata {
+				values = {
+					filename = "",
+					app = "",
+				}
+			}
+
+			stage.static_labels {
+				values = {
+					foo = "bar",
+				}
+			}
+
+			stage.output {
+				source = "msg"
+			}
+			`,
+			inputs: []loki.Entry{
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "json.log"}, 0, push.Entry{
+					Timestamp: now.Add(4 * time.Second),
+					Line: mustMarshalJSON(t, map[string]string{
+						"msg":          "json line 1",
+						"app":          "api",
+						"service_name": "service-a",
+					}),
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "json.log"}, 0, push.Entry{
+					Timestamp: now.Add(5 * time.Second),
+					Line:      `not json`,
+				}),
+			},
+			expected: []loki.Entry{
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar", "service_name": "service-a"}, 0, push.Entry{
+					Timestamp: now.Add(4 * time.Second),
+					Line:      "json line 1",
+					StructuredMetadata: push.LabelsAdapter{
+						{Name: "filename", Value: "json.log"},
+						{Name: "app", Value: "api"},
+					},
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
+					Timestamp: now.Add(5 * time.Second),
+					Line:      `not json`,
+					StructuredMetadata: push.LabelsAdapter{
+						{Name: "filename", Value: "json.log"},
+					},
+				}),
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -209,23 +288,13 @@ func TestComponent(t *testing.T) {
 			ctx, cancel := context.WithCancel(t.Context())
 
 			runErr := make(chan error, 1)
-			go func() {
-				runErr <- c.Run(ctx)
-			}()
+			go func() { runErr <- c.Run(ctx) }()
 
 			for _, input := range tt.inputs {
 				c.receiver.Chan() <- input
 			}
 
-			require.Eventually(t, func() bool {
-				select {
-				case err := <-runErr:
-					require.NoError(t, err)
-					require.FailNow(t, "component stopped before producing all expected entries")
-				default:
-				}
-				return len(collector.Received()) == len(tt.expected)
-			}, 5*time.Second, 10*time.Millisecond)
+			require.Eventually(t, func() bool { return len(collector.Received()) == len(tt.expected) }, 5*time.Second, 10*time.Millisecond)
 
 			got := collector.Received()
 			for i := range tt.expected {

--- a/internal/component/loki/process/process_test.go
+++ b/internal/component/loki/process/process_test.go
@@ -42,7 +42,16 @@ func TestComponent(t *testing.T) {
 	}
 
 	var (
-		lineTimestamp = time.Now().UTC()
+		// Use entryTs for push.Entry.Timestamp values set directly on test inputs
+		// and for expected outputs from stages that do not rewrite timestamps.
+		entryTs    = time.Now().UTC().Add(-1 * time.Second)
+		getEntryTS = func(pos int) time.Time { return entryTs.Add(time.Duration(pos) * time.Second) }
+
+		// Use ts for timestamps encoded into log lines and later parsed back out
+		// by stages such as cri, docker, and multiline.
+		ts       = time.Now().UTC()
+		getTS    = func(pos int) time.Time { return ts.Add(time.Duration(pos) * time.Second) }
+		formatTs = func(pos int, layout string) string { return getTS(pos).Format(layout) }
 	)
 
 	tests := []testCase{
@@ -68,37 +77,37 @@ func TestComponent(t *testing.T) {
 			`,
 			inputs: []loki.Entry{
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "file1"}, 0, push.Entry{
-					Timestamp: time.Now(),
-					Line:      lineTimestamp.Format(time.RFC3339Nano) + " stdout P partial for file 1 stdout",
+					Timestamp: getEntryTS(0),
+					Line:      formatTs(0, time.RFC3339Nano) + " stdout P partial for file 1 stdout",
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "file1"}, 0, push.Entry{
-					Timestamp: time.Now(),
-					Line:      lineTimestamp.Format(time.RFC3339Nano) + " stderr P partial for file 1 stderr",
+					Timestamp: getEntryTS(1),
+					Line:      formatTs(0, time.RFC3339Nano) + " stderr P partial for file 1 stderr",
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "file2"}, 0, push.Entry{
-					Timestamp: time.Now(),
-					Line:      lineTimestamp.Format(time.RFC3339Nano) + " stdout P partial for file2",
+					Timestamp: getEntryTS(2),
+					Line:      formatTs(0, time.RFC3339Nano) + " stdout P partial for file2",
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "file1"}, 0, push.Entry{
-					Timestamp: time.Now(),
-					Line:      lineTimestamp.Format(time.RFC3339Nano) + " stderr F full file 1 stderr",
+					Timestamp: getEntryTS(3),
+					Line:      formatTs(1, time.RFC3339Nano) + " stderr F full file 1 stderr",
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "file2"}, 0, push.Entry{
-					Timestamp: time.Now(),
-					Line:      lineTimestamp.Format(time.RFC3339Nano) + " stderr F full file 2",
+					Timestamp: getEntryTS(4),
+					Line:      formatTs(1, time.RFC3339Nano) + " stderr F full file 2",
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "file1"}, 0, push.Entry{
-					Timestamp: time.Now(),
-					Line:      lineTimestamp.Format(time.RFC3339Nano) + " stderr F full file 1 stdout",
+					Timestamp: getEntryTS(5),
+					Line:      formatTs(1, time.RFC3339Nano) + " stderr F full file 1 stdout",
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "file3"}, 0, push.Entry{
-					Timestamp: lineTimestamp.Add(3 * time.Second),
+					Timestamp: getEntryTS(6),
 					Line:      "not a cri line",
 				}),
 			},
 			expected: []loki.Entry{
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
-					Timestamp: lineTimestamp,
+					Timestamp: getTS(1),
 					Line:      "partial for file 1 stderrfull file 1 stderr",
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "file1"},
@@ -106,7 +115,7 @@ func TestComponent(t *testing.T) {
 					},
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
-					Timestamp: lineTimestamp,
+					Timestamp: getTS(1),
 					Line:      "full file 2",
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "file2"},
@@ -114,7 +123,7 @@ func TestComponent(t *testing.T) {
 					},
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
-					Timestamp: lineTimestamp,
+					Timestamp: getTS(1),
 					Line:      "full file 1 stdout",
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "file1"},
@@ -122,7 +131,7 @@ func TestComponent(t *testing.T) {
 					},
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
-					Timestamp: lineTimestamp.Add(3 * time.Second),
+					Timestamp: getEntryTS(6),
 					Line:      "not a cri line",
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "file3"},
@@ -152,29 +161,29 @@ func TestComponent(t *testing.T) {
 			`,
 			inputs: []loki.Entry{
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "docker.log"}, 0, push.Entry{
-					Timestamp: time.Now(),
+					Timestamp: getEntryTS(0),
 					Line: mustMarshalJSON(t, map[string]string{
 						"log":    "docker stdout line\n",
 						"stream": "stdout",
-						"time":   lineTimestamp.Format(time.RFC3339Nano),
+						"time":   formatTs(0, time.RFC3339Nano),
 					}),
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "docker.log"}, 0, push.Entry{
-					Timestamp: time.Now(),
+					Timestamp: getEntryTS(1),
 					Line: mustMarshalJSON(t, map[string]string{
 						"log":    "docker stderr line\n",
 						"stream": "stderr",
-						"time":   lineTimestamp.Add(time.Second).Format(time.RFC3339Nano),
+						"time":   formatTs(1, time.RFC3339Nano),
 					}),
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "docker.log"}, 0, push.Entry{
-					Timestamp: lineTimestamp.Add(2 * time.Second),
+					Timestamp: getEntryTS(2),
 					Line:      `{"msg":"not docker format"}`,
 				}),
 			},
 			expected: []loki.Entry{
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
-					Timestamp: lineTimestamp,
+					Timestamp: getTS(0),
 					Line:      "docker stdout line\n",
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "docker.log"},
@@ -182,7 +191,7 @@ func TestComponent(t *testing.T) {
 					},
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
-					Timestamp: lineTimestamp.Add(time.Second),
+					Timestamp: getTS(1),
 					Line:      "docker stderr line\n",
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "docker.log"},
@@ -190,7 +199,7 @@ func TestComponent(t *testing.T) {
 					},
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
-					Timestamp: lineTimestamp.Add(2 * time.Second),
+					Timestamp: getEntryTS(2),
 					Line:      `{"msg":"not docker format"}`,
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "docker.log"},
@@ -236,7 +245,7 @@ func TestComponent(t *testing.T) {
 			`,
 			inputs: []loki.Entry{
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "json.log"}, 0, push.Entry{
-					Timestamp: lineTimestamp.Add(4 * time.Second),
+					Timestamp: getEntryTS(0),
 					Line: mustMarshalJSON(t, map[string]string{
 						"msg":          "json line 1",
 						"app":          "api",
@@ -244,13 +253,13 @@ func TestComponent(t *testing.T) {
 					}),
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "json.log"}, 0, push.Entry{
-					Timestamp: lineTimestamp.Add(5 * time.Second),
+					Timestamp: getEntryTS(1),
 					Line:      `not json`,
 				}),
 			},
 			expected: []loki.Entry{
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar", "service_name": "service-a"}, 0, push.Entry{
-					Timestamp: lineTimestamp.Add(4 * time.Second),
+					Timestamp: getEntryTS(0),
 					Line:      "json line 1",
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "json.log"},
@@ -258,7 +267,7 @@ func TestComponent(t *testing.T) {
 					},
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
-					Timestamp: lineTimestamp.Add(5 * time.Second),
+					Timestamp: getEntryTS(1),
 					Line:      `not json`,
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "json.log"},
@@ -304,17 +313,17 @@ func TestComponent(t *testing.T) {
 			`,
 			inputs: []loki.Entry{
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "logfmt.log"}, 0, push.Entry{
-					Timestamp: lineTimestamp.Add(6 * time.Second),
+					Timestamp: getEntryTS(0),
 					Line:      `msg="logfmt line 1" app=api service_name=service-b`,
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "logfmt.log"}, 0, push.Entry{
-					Timestamp: lineTimestamp.Add(7 * time.Second),
+					Timestamp: getEntryTS(1),
 					Line:      `not logfmt`,
 				}),
 			},
 			expected: []loki.Entry{
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar", "service_name": "service-b"}, 0, push.Entry{
-					Timestamp: lineTimestamp.Add(6 * time.Second),
+					Timestamp: getEntryTS(0),
 					Line:      "logfmt line 1",
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "logfmt.log"},
@@ -322,7 +331,7 @@ func TestComponent(t *testing.T) {
 					},
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
-					Timestamp: lineTimestamp.Add(7 * time.Second),
+					Timestamp: getEntryTS(1),
 					Line:      `not logfmt`,
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "logfmt.log"},
@@ -337,7 +346,7 @@ func TestComponent(t *testing.T) {
 
 			stage.multiline {
 				firstline     = "^\\[\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\]"
-				max_wait_time = "50ms"
+				max_wait_time = "2s"
 			}
 
 			stage.regex {
@@ -367,73 +376,73 @@ func TestComponent(t *testing.T) {
 			`,
 			inputs: []loki.Entry{
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "multiline.log"}, 0, push.Entry{
-					Timestamp: lineTimestamp.Add(8 * time.Second),
+					Timestamp: getEntryTS(0),
 					Line:      `not a multiline start`,
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "multiline.log"}, 0, push.Entry{
-					Timestamp: lineTimestamp.Add(9 * time.Second),
-					Line:      `[2024-01-02 03:04:05] "GET /one HTTP/1.1" 200 -`,
+					Timestamp: getEntryTS(1),
+					Line:      "[" + formatTs(1, "2006-01-02 15:04:05") + `] "GET /one HTTP/1.1" 200 -`,
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "multiline.log"}, 0, push.Entry{
-					Timestamp: lineTimestamp.Add(10 * time.Second),
-					Line:      `[2024-01-02 03:04:06] "POST /two HTTP/1.1" 201 -`,
+					Timestamp: getEntryTS(2),
+					Line:      "[" + formatTs(2, "2006-01-02 15:04:05") + `] "POST /two HTTP/1.1" 201 -`,
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "multiline.log"}, 0, push.Entry{
-					Timestamp: lineTimestamp.Add(11 * time.Second),
+					Timestamp: getEntryTS(3),
 					Line:      `line 1`,
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "other-multiline.log"}, 0, push.Entry{
-					Timestamp: lineTimestamp.Add(11*time.Second + 500*time.Millisecond),
-					Line:      `[2024-01-02 03:04:08] "PATCH /other HTTP/1.1" 204 -`,
+					Timestamp: getEntryTS(4),
+					Line:      "[" + formatTs(4, "2006-01-02 15:04:05") + `] "PATCH /other HTTP/1.1" 204 -`,
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "multiline.log"}, 0, push.Entry{
-					Timestamp: lineTimestamp.Add(12 * time.Second),
+					Timestamp: getEntryTS(5),
 					Line:      `line 2`,
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "multiline.log"}, 0, push.Entry{
-					Timestamp: lineTimestamp.Add(13 * time.Second),
-					Line:      `[2024-01-02 03:04:07] "PUT /three HTTP/1.1" 202 -`,
+					Timestamp: getEntryTS(6),
+					Line:      "[" + formatTs(6, "2006-01-02 15:04:05") + `] "PUT /three HTTP/1.1" 202 -`,
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "other-multiline.log"}, 0, push.Entry{
-					Timestamp: lineTimestamp.Add(13*time.Second + 500*time.Millisecond),
+					Timestamp: getEntryTS(7),
 					Line:      `other line 1`,
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "multiline.log"}, 0, push.Entry{
-					Timestamp: lineTimestamp.Add(14 * time.Second),
+					Timestamp: getEntryTS(8),
 					Line:      `line 1`,
 				}),
 			},
 			expected: []loki.Entry{
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
-					Timestamp: lineTimestamp.Add(8 * time.Second),
+					Timestamp: getEntryTS(0),
 					Line:      `not a multiline start`,
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "multiline.log"},
 					},
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
-					Timestamp: time.Date(2024, time.January, 2, 3, 4, 5, 0, time.UTC),
+					Timestamp: getTS(1).Truncate(time.Second),
 					Line:      `"GET /one HTTP/1.1" 200 -`,
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "multiline.log"},
 					},
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
-					Timestamp: time.Date(2024, time.January, 2, 3, 4, 6, 0, time.UTC),
+					Timestamp: getTS(2).Truncate(time.Second),
 					Line:      "\"POST /two HTTP/1.1\" 201 -\nline 1\nline 2",
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "multiline.log"},
 					},
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
-					Timestamp: time.Date(2024, time.January, 2, 3, 4, 8, 0, time.UTC),
+					Timestamp: getTS(4).Truncate(time.Second),
 					Line:      "\"PATCH /other HTTP/1.1\" 204 -\nother line 1",
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "other-multiline.log"},
 					},
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
-					Timestamp: time.Date(2024, time.January, 2, 3, 4, 7, 0, time.UTC),
+					Timestamp: getTS(6).Truncate(time.Second),
 					Line:      "\"PUT /three HTTP/1.1\" 202 -\nline 1",
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "multiline.log"},
@@ -453,7 +462,7 @@ func TestComponent(t *testing.T) {
 			args.ForwardTo = []loki.LogsReceiver{collector.Receiver()}
 
 			opts := component.Options{
-				Logger:         util.TestAlloyLogger(t),
+				Logger:         log.NewNopLogger(),
 				Registerer:     prometheus.NewRegistry(),
 				OnStateChange:  func(component.Exports) {},
 				GetServiceData: getServiceData,

--- a/internal/component/loki/process/process_test.go
+++ b/internal/component/loki/process/process_test.go
@@ -344,6 +344,36 @@ func TestComponent(t *testing.T) {
 			},
 		},
 		{
+			name: "labe_drop and label_keep pipeline",
+			cfg: `
+			forward_to = []
+
+			stage.static_labels {
+				values = { "foo" = "fooval", "bar" = "barval", "baz" = "bazval", "qux" = "quxval" }
+			}
+
+			stage.label_drop {
+				values = [ "foo", "bar" ]
+			}
+
+			stage.label_keep {
+				values = [ "foo", "baz", "filename" ]
+			}
+			`,
+			inputs: []loki.Entry{
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "/var/log/pods/agent/agent/1.log", "env": "dev"}, 0, push.Entry{
+					Timestamp: getEntryTS(0),
+					Line:      "line",
+				}),
+			},
+			expected: []loki.Entry{
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "/var/log/pods/agent/agent/1.log", "baz": "bazval"}, 0, push.Entry{
+					Timestamp: getEntryTS(0),
+					Line:      "line",
+				}),
+			},
+		},
+		{
 			name: "multiline pipeline",
 			cfg: `
 			forward_to = []
@@ -837,91 +867,6 @@ func TestJSONLabelsStage(t *testing.T) {
 		"[OUT]: timestamp: 2019-04-30T02:12:41.8443515Z, entry: {\"log\":\"log message\\n\",\"stream\":\"stderr\",\"time\":\"2019-04-30T02:12:41.8443515Z\",\"extra\":\"{\\\"user\\\":\\\"smith\\\"}\"}, labels: {filename=\"/var/log/pods/agent/agent/1.log\", foo=\"bar\", stream=\"stderr\", ts=\"2019-04-30T02:12:41.8443515Z\", user=\"smith\"}, structured_metadata: {}",
 	}
 	require.Equal(t, expectedLiveDebuggingLog, liveDebuggingLog.Get())
-}
-
-func TestStaticLabelsLabelAllowLabelDrop(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
-
-	// The following stages manipulate the label set of a log entry.
-	// The first stage will define a static set of labels (foo, bar, baz, qux)
-	// to add to the entry along the `filename` and `dev` labels.
-	// The second stage will drop the foo and bar labels.
-	// The third stage will keep only a subset of the remaining labels.
-	stg := `
-stage.static_labels {
-    values = { "foo" = "fooval", "bar" = "barval", "baz" = "bazval", "qux" = "quxval" }
-}
-stage.label_drop {
-    values = [ "foo", "bar" ]
-}
-stage.label_keep {
-    values = [ "foo", "baz", "filename" ]
-}`
-
-	// Unmarshal the Alloy relabel rules into a custom struct, as we don't have
-	// an easy way to refer to a loki.LogsReceiver value for the forward_to
-	// argument.
-	type cfg struct {
-		Stages []stages.StageConfig `alloy:"stage,enum"`
-	}
-	var stagesCfg cfg
-	err := syntax.Unmarshal([]byte(stg), &stagesCfg)
-	require.NoError(t, err)
-
-	ch1, ch2 := loki.NewLogsReceiver(), loki.NewLogsReceiver()
-
-	// Create and run the component, so that it can process and forwards logs.
-	opts := component.Options{
-		Logger:         util.TestAlloyLogger(t),
-		Registerer:     prometheus.NewRegistry(),
-		OnStateChange:  func(e component.Exports) {},
-		GetServiceData: getServiceData,
-	}
-	args := Arguments{
-		ForwardTo: []loki.LogsReceiver{ch1, ch2},
-		Stages:    stagesCfg.Stages,
-	}
-
-	c, err := New(opts, args)
-	require.NoError(t, err)
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	go c.Run(ctx)
-
-	// Send a log entry to the component's receiver.
-	ts := time.Now()
-	logline := `{"log":"log message\n","stream":"stderr","time":"2022-01-09T08:37:45.8233626Z"}`
-	logEntry := loki.Entry{
-		Labels: model.LabelSet{"filename": "/var/log/pods/agent/agent/1.log", "env": "dev"},
-		Entry: push.Entry{
-			Timestamp: ts,
-			Line:      logline,
-		},
-	}
-
-	c.receiver.Chan() <- logEntry
-
-	wantLabelSet := model.LabelSet{
-		"filename": "/var/log/pods/agent/agent/1.log",
-		"baz":      "bazval",
-	}
-
-	// The log entry should be received in both channels, with the processing
-	// stages correctly applied.
-	for i := 0; i < 2; i++ {
-		select {
-		case logEntry := <-ch1.Chan():
-			require.WithinDuration(t, time.Now(), logEntry.Timestamp, 1*time.Second)
-			require.Equal(t, logline, logEntry.Line)
-			require.Equal(t, wantLabelSet, logEntry.Labels)
-		case logEntry := <-ch2.Chan():
-			require.WithinDuration(t, time.Now(), logEntry.Timestamp, 1*time.Second)
-			require.Equal(t, logline, logEntry.Line)
-			require.Equal(t, wantLabelSet, logEntry.Labels)
-		case <-time.After(5 * time.Second):
-			require.FailNow(t, "failed waiting for log line")
-		}
-	}
 }
 
 func TestRegexTimestampOutput(t *testing.T) {

--- a/internal/component/loki/process/process_test.go
+++ b/internal/component/loki/process/process_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -18,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 	"go.uber.org/goleak"
+	"k8s.io/utils/ptr"
 
 	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/component/common/loki"
@@ -35,10 +38,11 @@ func TestComponent(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
 
 	type testCase struct {
-		name     string
-		cfg      string
-		inputs   []loki.Entry
-		expected []loki.Entry
+		name          string
+		cfg           string
+		inputs        []loki.Entry
+		expected      []loki.Entry
+		unorderedFrom *int
 	}
 
 	var (
@@ -449,6 +453,84 @@ func TestComponent(t *testing.T) {
 					},
 				}),
 			},
+			unorderedFrom: ptr.To(3),
+		},
+		{
+			name: "pattern pipeline parsing nginx",
+			cfg: `
+			forward_to = []
+
+			stage.pattern {
+				pattern = "<_> <_> <user> [<timestamp>] \"<method> <path> <protocol>\" <status> <size> \"<referer>\" \"<useragent>\""
+			}
+
+			stage.timestamp {
+				source = "timestamp"
+				format = "02/Jan/2006:15:04:05 -0700"
+			}
+
+			stage.labels {
+				values = {
+					method = "",
+					status = "",
+				}
+			}
+
+			stage.structured_metadata {
+				values = {
+					filename = "",
+					path = "",
+					user = "",
+				}
+			}
+
+			stage.output {
+				source = "path"
+			}
+			`,
+			inputs: []loki.Entry{
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "access.log"}, 0, push.Entry{
+					Timestamp: getEntryTS(0),
+					Line:      `11.11.11.11 - frank [` + formatTs(0, "02/Jan/2006:15:04:05 -0700") + `] "GET /index.html HTTP/1.1" 200 932 "-" "test-agent"`,
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "access.log"}, 0, push.Entry{
+					Timestamp: getEntryTS(1),
+					Line:      `22.22.22.22 - mary [` + formatTs(1, "02/Jan/2006:15:04:05 -0700") + `] "POST /api/users HTTP/1.1" 201 128 "-" "api-client"`,
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "access.log"}, 0, push.Entry{
+					Timestamp: getEntryTS(2),
+					Line:      `33.33.33.33 - jane [` + formatTs(2, "02/Jan/2006:15:04:05 -0700") + `] "DELETE /api/users/42 HTTP/2.0" 204 0 "-" "cleanup-bot"`,
+				}),
+			},
+			expected: []loki.Entry{
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"method": "GET", "status": "200"}, 0, push.Entry{
+					Timestamp: mustParseTime(t, "02/Jan/2006:15:04:05 -0700", formatTs(0, "02/Jan/2006:15:04:05 -0700")),
+					Line:      "/index.html",
+					StructuredMetadata: push.LabelsAdapter{
+						{Name: "filename", Value: "access.log"},
+						{Name: "path", Value: "/index.html"},
+						{Name: "user", Value: "frank"},
+					},
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"method": "POST", "status": "201"}, 0, push.Entry{
+					Timestamp: mustParseTime(t, "02/Jan/2006:15:04:05 -0700", formatTs(1, "02/Jan/2006:15:04:05 -0700")),
+					Line:      "/api/users",
+					StructuredMetadata: push.LabelsAdapter{
+						{Name: "filename", Value: "access.log"},
+						{Name: "path", Value: "/api/users"},
+						{Name: "user", Value: "mary"},
+					},
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"method": "DELETE", "status": "204"}, 0, push.Entry{
+					Timestamp: mustParseTime(t, "02/Jan/2006:15:04:05 -0700", formatTs(2, "02/Jan/2006:15:04:05 -0700")),
+					Line:      "/api/users/42",
+					StructuredMetadata: push.LabelsAdapter{
+						{Name: "filename", Value: "access.log"},
+						{Name: "path", Value: "/api/users/42"},
+						{Name: "user", Value: "jane"},
+					},
+				}),
+			},
 		},
 	}
 
@@ -483,12 +565,15 @@ func TestComponent(t *testing.T) {
 			require.Eventually(t, func() bool { return len(collector.Received()) == len(tt.expected) }, 5*time.Second, 10*time.Millisecond)
 
 			got := collector.Received()
-			for i := range tt.expected {
-				require.Equal(t, tt.expected[i].Line, got[i].Line)
-				require.Equal(t, tt.expected[i].Timestamp, got[i].Timestamp)
-				require.EqualValues(t, tt.expected[i].Labels, got[i].Labels)
-				require.ElementsMatch(t, tt.expected[i].StructuredMetadata, got[i].StructuredMetadata)
+
+			if tt.unorderedFrom == nil {
+				tt.unorderedFrom = ptr.To(len(tt.expected))
 			}
+
+			for i := range *tt.unorderedFrom {
+				assertEntry(t, tt.expected[i], got[i])
+			}
+			assertEntriesUnordered(t, tt.expected[*tt.unorderedFrom:], got[*tt.unorderedFrom:])
 
 			cancel()
 			require.NoError(t, <-runErr)
@@ -503,6 +588,73 @@ func mustMarshalJSON(t *testing.T, v any) string {
 	require.NoError(t, err)
 
 	return string(data)
+}
+
+func mustParseTime(t *testing.T, layout, value string) time.Time {
+	t.Helper()
+
+	parsed, err := time.Parse(layout, value)
+	require.NoError(t, err)
+
+	return parsed
+}
+
+func assertEntry(t *testing.T, expected, actual loki.Entry) {
+	t.Helper()
+
+	require.Equal(t, expected.Line, actual.Line)
+	require.Equal(t, expected.Timestamp, actual.Timestamp)
+	require.EqualValues(t, expected.Labels, actual.Labels)
+	require.ElementsMatch(t, expected.StructuredMetadata, actual.StructuredMetadata)
+}
+
+func assertEntriesUnordered(t *testing.T, expected, actual []loki.Entry) {
+	t.Helper()
+
+	require.Len(t, actual, len(expected))
+
+	entriesEqual := func(expected, actual loki.Entry) bool {
+		if expected.Line != actual.Line {
+			return false
+		}
+		if !expected.Timestamp.Equal(actual.Timestamp) {
+			return false
+		}
+		if !reflect.DeepEqual(expected.Labels, actual.Labels) {
+			return false
+		}
+
+		expectedStructured := append(push.LabelsAdapter(nil), expected.StructuredMetadata...)
+		actualStructured := append(push.LabelsAdapter(nil), actual.StructuredMetadata...)
+		slices.SortFunc(expectedStructured, func(a, b push.LabelAdapter) int {
+			if a.Name != b.Name {
+				return strings.Compare(a.Name, b.Name)
+			}
+			return strings.Compare(a.Value, b.Value)
+		})
+		slices.SortFunc(actualStructured, func(a, b push.LabelAdapter) int {
+			if a.Name != b.Name {
+				return strings.Compare(a.Name, b.Name)
+			}
+			return strings.Compare(a.Value, b.Value)
+		})
+
+		return reflect.DeepEqual(expectedStructured, actualStructured)
+	}
+
+	remaining := append([]loki.Entry(nil), actual...)
+	for _, exp := range expected {
+		found := -1
+		for i, got := range remaining {
+			if entriesEqual(exp, got) {
+				found = i
+				break
+			}
+		}
+
+		require.NotEqual(t, -1, found)
+		remaining = append(remaining[:found], remaining[found+1:]...)
+	}
 }
 
 func TestComponent_UpdateInvalidConfig(t *testing.T) {

--- a/internal/component/loki/process/process_test.go
+++ b/internal/component/loki/process/process_test.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -40,7 +41,7 @@ func TestComponent(t *testing.T) {
 		expected []loki.Entry
 	}
 
-	criTimestamp := time.Date(2024, time.January, 2, 3, 4, 5, 6, time.UTC)
+	now := time.Now().UTC()
 
 	tests := []testCase{
 		{
@@ -62,37 +63,36 @@ func TestComponent(t *testing.T) {
 					foo = "bar",
 				}
 			}
-
 			`,
 			inputs: []loki.Entry{
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "file1"}, 0, push.Entry{
 					Timestamp: time.Now(),
-					Line:      criTimestamp.Format(time.RFC3339Nano) + " stdout P partial for file 1 stdout",
+					Line:      now.Format(time.RFC3339Nano) + " stdout P partial for file 1 stdout",
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "file1"}, 0, push.Entry{
 					Timestamp: time.Now(),
-					Line:      criTimestamp.Format(time.RFC3339Nano) + " stderr P partial for file 1 stderr",
+					Line:      now.Format(time.RFC3339Nano) + " stderr P partial for file 1 stderr",
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "file2"}, 0, push.Entry{
 					Timestamp: time.Now(),
-					Line:      criTimestamp.Format(time.RFC3339Nano) + " stdout P partial for file2",
+					Line:      now.Format(time.RFC3339Nano) + " stdout P partial for file2",
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "file1"}, 0, push.Entry{
 					Timestamp: time.Now(),
-					Line:      criTimestamp.Format(time.RFC3339Nano) + " stderr F full file 1 stderr",
+					Line:      now.Format(time.RFC3339Nano) + " stderr F full file 1 stderr",
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "file2"}, 0, push.Entry{
 					Timestamp: time.Now(),
-					Line:      criTimestamp.Format(time.RFC3339Nano) + " stderr F full file 2",
+					Line:      now.Format(time.RFC3339Nano) + " stderr F full file 2",
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "file1"}, 0, push.Entry{
 					Timestamp: time.Now(),
-					Line:      criTimestamp.Format(time.RFC3339Nano) + " stderr F full file 1 stdout",
+					Line:      now.Format(time.RFC3339Nano) + " stderr F full file 1 stdout",
 				}),
 			},
 			expected: []loki.Entry{
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
-					Timestamp: criTimestamp,
+					Timestamp: now,
 					Line:      "partial for file 1 stderrfull file 1 stderr",
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "file1"},
@@ -100,7 +100,7 @@ func TestComponent(t *testing.T) {
 					},
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
-					Timestamp: criTimestamp,
+					Timestamp: now,
 					Line:      "full file 2",
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "file2"},
@@ -108,11 +108,79 @@ func TestComponent(t *testing.T) {
 					},
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
-					Timestamp: criTimestamp,
+					Timestamp: now,
 					Line:      "full file 1 stdout",
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "file1"},
 						{Name: "stream", Value: "stderr"},
+					},
+				}),
+			},
+		},
+		{
+			name: "simple docker pipeline",
+			cfg: `
+			forward_to = []
+
+			stage.docker {}
+
+			stage.structured_metadata {
+					values = {
+						filename = "",
+						stream = "",
+					}
+				}
+
+			stage.static_labels {
+				values = {
+					foo = "bar",
+				}
+			}
+			`,
+			inputs: []loki.Entry{
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "docker.log"}, 0, push.Entry{
+					Timestamp: time.Now(),
+					Line: mustMarshalJSON(t, map[string]string{
+						"log":    "docker stdout line\n",
+						"stream": "stdout",
+						"time":   now.Format(time.RFC3339Nano),
+					}),
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "docker.log"}, 0, push.Entry{
+					Timestamp: time.Now(),
+					Line: mustMarshalJSON(t, map[string]string{
+						"log":    "docker stderr line\n",
+						"stream": "stderr",
+						"time":   now.Add(time.Second).Format(time.RFC3339Nano),
+					}),
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "docker.log"}, 0, push.Entry{
+					Timestamp: now.Add(2 * time.Second),
+					Line:      `{"msg":"not docker format"}`,
+				}),
+			},
+			expected: []loki.Entry{
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
+					Timestamp: now,
+					Line:      "docker stdout line\n",
+					StructuredMetadata: push.LabelsAdapter{
+						{Name: "filename", Value: "docker.log"},
+						{Name: "stream", Value: "stdout"},
+					},
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
+					Timestamp: now.Add(time.Second),
+					Line:      "docker stderr line\n",
+					StructuredMetadata: push.LabelsAdapter{
+						{Name: "filename", Value: "docker.log"},
+						{Name: "stream", Value: "stderr"},
+					},
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
+					Timestamp: now.Add(2 * time.Second),
+					Line:      `{"msg":"not docker format"}`,
+					StructuredMetadata: push.LabelsAdapter{
+						{Name: "filename", Value: "docker.log"},
 					},
 				}),
 			},
@@ -171,6 +239,15 @@ func TestComponent(t *testing.T) {
 			require.NoError(t, <-runErr)
 		})
 	}
+}
+
+func mustMarshalJSON(t *testing.T, v any) string {
+	t.Helper()
+
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+
+	return string(data)
 }
 
 func TestComponent_UpdateInvalidConfig(t *testing.T) {

--- a/internal/component/loki/process/process_test.go
+++ b/internal/component/loki/process/process_test.go
@@ -374,6 +374,41 @@ func TestComponent(t *testing.T) {
 			},
 		},
 		{
+			name: "regex pipeline",
+			cfg: `
+			forward_to = []
+
+			stage.regex {
+				expression = "^(?s)(?P<time>\\S+?) (?P<stream>stdout|stderr) (?P<content>.*)$"
+			}
+
+			stage.timestamp {
+				source = "time"
+				format = "RFC3339"
+			}
+
+			stage.output {
+				source = "content"
+			}
+
+			stage.labels {
+				values = { src = "stream" }
+			}
+			`,
+			inputs: []loki.Entry{
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "/var/log/pods/agent/agent/1.log", "foo": "bar"}, 0, push.Entry{
+					Timestamp: getEntryTS(0),
+					Line:      formatTs(0, time.RFC3339) + ` stderr somewhere, somehow, an error occurred`,
+				}),
+			},
+			expected: []loki.Entry{
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "/var/log/pods/agent/agent/1.log", "foo": "bar", "src": "stderr"}, 0, push.Entry{
+					Timestamp: mustParseTime(t, time.RFC3339, formatTs(0, time.RFC3339)),
+					Line:      `somewhere, somehow, an error occurred`,
+				}),
+			},
+		},
+		{
 			name: "multiline pipeline",
 			cfg: `
 			forward_to = []
@@ -867,106 +902,6 @@ func TestJSONLabelsStage(t *testing.T) {
 		"[OUT]: timestamp: 2019-04-30T02:12:41.8443515Z, entry: {\"log\":\"log message\\n\",\"stream\":\"stderr\",\"time\":\"2019-04-30T02:12:41.8443515Z\",\"extra\":\"{\\\"user\\\":\\\"smith\\\"}\"}, labels: {filename=\"/var/log/pods/agent/agent/1.log\", foo=\"bar\", stream=\"stderr\", ts=\"2019-04-30T02:12:41.8443515Z\", user=\"smith\"}, structured_metadata: {}",
 	}
 	require.Equal(t, expectedLiveDebuggingLog, liveDebuggingLog.Get())
-}
-
-func TestRegexTimestampOutput(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
-
-	// The first stage will attempt to parse the input line using a regular
-	// expression with named capture groups. The three capture groups (time,
-	// stream and content) will be extracted in the shared map of values.
-	// Since 'source' is empty, it implies that we want to parse the log line
-	// itself.
-	//
-	// The second stage will parse the extracted `time` value as Unix epoch
-	// time and set it to the log entry timestamp.
-	//
-	// The third stage will set the `content` value as the message value.
-	//
-	// The fourth and final stage will set the `stream` value as the label.
-	stg := `
-stage.regex {
-		expression = "^(?s)(?P<time>\\S+?) (?P<stream>stdout|stderr) (?P<content>.*)$"
-}
-stage.timestamp {
-		source = "time"
-		format = "RFC3339"
-}
-stage.output {
-		source = "content"
-}
-stage.labels {
-		values = { src = "stream" }
-}`
-
-	// Unmarshal the Alloy relabel rules into a custom struct, as we don't have
-	// an easy way to refer to a loki.LogsReceiver value for the forward_to
-	// argument.
-	type cfg struct {
-		Stages []stages.StageConfig `alloy:"stage,enum"`
-	}
-	var stagesCfg cfg
-	err := syntax.Unmarshal([]byte(stg), &stagesCfg)
-	require.NoError(t, err)
-
-	ch1, ch2 := loki.NewLogsReceiver(), loki.NewLogsReceiver()
-
-	// Create and run the component, so that it can process and forwards logs.
-	opts := component.Options{
-		Logger:         util.TestAlloyLogger(t),
-		Registerer:     prometheus.NewRegistry(),
-		OnStateChange:  func(e component.Exports) {},
-		GetServiceData: getServiceData,
-	}
-	args := Arguments{
-		ForwardTo: []loki.LogsReceiver{ch1, ch2},
-		Stages:    stagesCfg.Stages,
-	}
-
-	c, err := New(opts, args)
-	require.NoError(t, err)
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	go c.Run(ctx)
-
-	// Send a log entry to the component's receiver.
-	ts := time.Now()
-	logline := `2022-01-17T08:17:42-07:00 stderr somewhere, somehow, an error occurred`
-	logEntry := loki.Entry{
-		Labels: model.LabelSet{"filename": "/var/log/pods/agent/agent/1.log", "foo": "bar"},
-		Entry: push.Entry{
-			Timestamp: ts,
-			Line:      logline,
-		},
-	}
-
-	c.receiver.Chan() <- logEntry
-
-	wantLabelSet := model.LabelSet{
-		"filename": "/var/log/pods/agent/agent/1.log",
-		"foo":      "bar",
-		"src":      "stderr",
-	}
-	wantTimestamp, err := time.Parse(time.RFC3339, "2022-01-17T08:17:42-07:00")
-	wantLogline := `somewhere, somehow, an error occurred`
-	require.NoError(t, err)
-
-	// The log entry should be received in both channels, with the processing
-	// stages correctly applied.
-	for i := 0; i < 2; i++ {
-		select {
-		case logEntry := <-ch1.Chan():
-			require.Equal(t, wantLogline, logEntry.Line)
-			require.Equal(t, wantTimestamp, logEntry.Timestamp)
-			require.Equal(t, wantLabelSet, logEntry.Labels)
-		case logEntry := <-ch2.Chan():
-			require.Equal(t, wantLogline, logEntry.Line)
-			require.Equal(t, wantTimestamp, logEntry.Timestamp)
-			require.Equal(t, wantLabelSet, logEntry.Labels)
-		case <-time.After(5 * time.Second):
-			require.FailNow(t, "failed waiting for log line")
-		}
-	}
 }
 
 func TestEntrySentToTwoProcessComponents(t *testing.T) {

--- a/internal/component/loki/process/process_test.go
+++ b/internal/component/loki/process/process_test.go
@@ -494,7 +494,7 @@ func TestComponent(t *testing.T) {
 			},
 		},
 		{
-			name: "labe_drop and label_keep pipeline",
+			name: "label_drop and label_keep pipeline",
 			cfg: `
 			forward_to = []
 

--- a/internal/component/loki/process/process_test.go
+++ b/internal/component/loki/process/process_test.go
@@ -338,7 +338,99 @@ func TestComponent(t *testing.T) {
 			},
 		},
 		{
-			name: "simple logfmt pipeline",
+			name: "match pipeline",
+			cfg: `
+			forward_to = []
+
+			stage.match {
+				selector = "{filename=\"match-1.log\"}"
+
+				stage.static_labels {
+					values = {
+						match = "one",
+					}
+				}
+			}
+
+			stage.match {
+				selector = "{filename=\"match-2.log\"} |= \"svc=\""
+
+				stage.logfmt {
+					mapping = {
+						msg = "",
+						svc = "",
+					}
+				}
+
+				stage.labels {
+					values = {
+						svc = "",
+					}
+				}
+
+				stage.output {
+					source = "msg"
+				}
+			}
+
+			stage.match {
+				selector = "{filename=\"match-3.log\"} |= \"prefix: \""
+
+				stage.regex {
+					expression = "^prefix: (?P<body>.*)$"
+				}
+
+				stage.structured_metadata {
+					values = {
+						body = "",
+					}
+				}
+			}
+			`,
+			inputs: []loki.Entry{
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "match-1.log"}, 0, push.Entry{
+					Timestamp: getEntryTS(0),
+					Line:      `first`,
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "match-2.log"}, 0, push.Entry{
+					Timestamp: getEntryTS(1),
+					Line:      `msg="second" svc=api`,
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "match-3.log"}, 0, push.Entry{
+					Timestamp: getEntryTS(2),
+					Line:      `prefix: third`,
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "match-3.log"}, 0, push.Entry{
+					Timestamp: getEntryTS(3),
+					Line:      `no match`,
+				}),
+			},
+			expected: []loki.Entry{
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "match-1.log", "match": "one"}, 0, push.Entry{
+					Timestamp: getEntryTS(0),
+					Line:      `first`,
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "match-2.log", "svc": "api"}, 0, push.Entry{
+					Timestamp: getEntryTS(1),
+					Line:      `second`,
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "match-3.log"}, 0, push.Entry{
+					Timestamp: getEntryTS(2),
+					Line:      `prefix: third`,
+					StructuredMetadata: push.LabelsAdapter{
+						{Name: "body", Value: "third"},
+					},
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "match-3.log"}, 0, push.Entry{
+					Timestamp: getEntryTS(3),
+					Line:      `no match`,
+				}),
+			},
+			// NOTE: we cannot garantuee ordereing between different sub-pipelines.
+			unorderedFrom: ptr.To(0),
+		},
+		{
+			name: "logfmt pipeline",
 			cfg: `
 			forward_to = []
 

--- a/internal/component/loki/process/process_test.go
+++ b/internal/component/loki/process/process_test.go
@@ -276,6 +276,68 @@ func TestComponent(t *testing.T) {
 			},
 		},
 		{
+			name: "template pipeline",
+			cfg: `
+			forward_to = []
+
+			stage.json {
+				expressions = {
+					app = "",
+					level = "",
+					msg = "",
+				}
+			}
+
+			stage.template {
+				source   = "app"
+				template = "{{ .Value | ToUpper }} doki"
+			}
+
+			stage.template {
+				source   = "level"
+				template = "{{ if eq .Value \"WARN\" }}{{ Replace .Value \"WARN\" \"OK\" -1 }}{{ else }}{{ .Value }}{{ end }}"
+			}
+
+			stage.template {
+				source   = "type"
+				template = "{{ .app }}-{{ .level }}"
+			}
+
+			stage.labels {
+				values = {
+					app = "",
+					level = "",
+					type = "",
+				}
+			}
+
+			stage.output {
+				source = "msg"
+			}
+			`,
+			inputs: []loki.Entry{
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "template.log"}, 0, push.Entry{
+					Timestamp: getEntryTS(0),
+					Line: mustMarshalJSON(t, map[string]string{
+						"app":   "loki",
+						"level": "WARN",
+						"msg":   "template line",
+					}),
+				}),
+			},
+			expected: []loki.Entry{
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{
+					"filename": "template.log",
+					"app":      "LOKI doki",
+					"level":    "OK",
+					"type":     "LOKI doki-OK",
+				}, 0, push.Entry{
+					Timestamp: getEntryTS(0),
+					Line:      "template line",
+				}),
+			},
+		},
+		{
 			name: "simple logfmt pipeline",
 			cfg: `
 			forward_to = []

--- a/internal/component/loki/process/process_test.go
+++ b/internal/component/loki/process/process_test.go
@@ -48,12 +48,12 @@ func TestComponent(t *testing.T) {
 	var (
 		// Use entryTs for push.Entry.Timestamp values set directly on test inputs
 		// and for expected outputs from stages that do not rewrite timestamps.
-		entryTs    = time.Now().UTC().Add(-1 * time.Second)
+		entryTs    = time.Date(2024, time.January, 2, 3, 4, 5, 0, time.UTC)
 		getEntryTS = func(pos int) time.Time { return entryTs.Add(time.Duration(pos) * time.Second) }
 
 		// Use ts for timestamps encoded into log lines and later parsed back out
 		// by stages such as cri, docker, and multiline.
-		ts       = time.Now().UTC()
+		ts       = time.Date(2025, time.February, 3, 4, 5, 6, 0, time.UTC)
 		getTS    = func(pos int) time.Time { return ts.Add(time.Duration(pos) * time.Second) }
 		formatTs = func(pos int, layout string) string { return getTS(pos).Format(layout) }
 	)

--- a/internal/component/loki/process/process_test.go
+++ b/internal/component/loki/process/process_test.go
@@ -264,6 +264,70 @@ func TestComponent(t *testing.T) {
 				}),
 			},
 		},
+		{
+			name: "simple logfmt pipeline",
+			cfg: `
+			forward_to = []
+
+			stage.logfmt {
+				mapping = {
+					msg = "",
+					app = "",
+					service_name = "",
+				}
+			}
+
+			stage.labels {
+				values = {
+					service_name = "",
+				}
+			}
+
+			stage.structured_metadata {
+				values = {
+					filename = "",
+					app = "",
+				}
+			}
+
+			stage.static_labels {
+				values = {
+					foo = "bar",
+				}
+			}
+
+			stage.output {
+				source = "msg"
+			}
+			`,
+			inputs: []loki.Entry{
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "logfmt.log"}, 0, push.Entry{
+					Timestamp: now.Add(6 * time.Second),
+					Line:      `msg="logfmt line 1" app=api service_name=service-b`,
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "logfmt.log"}, 0, push.Entry{
+					Timestamp: now.Add(7 * time.Second),
+					Line:      `not logfmt`,
+				}),
+			},
+			expected: []loki.Entry{
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar", "service_name": "service-b"}, 0, push.Entry{
+					Timestamp: now.Add(6 * time.Second),
+					Line:      "logfmt line 1",
+					StructuredMetadata: push.LabelsAdapter{
+						{Name: "filename", Value: "logfmt.log"},
+						{Name: "app", Value: "api"},
+					},
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
+					Timestamp: now.Add(7 * time.Second),
+					Line:      `not logfmt`,
+					StructuredMetadata: push.LabelsAdapter{
+						{Name: "filename", Value: "logfmt.log"},
+					},
+				}),
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/component/loki/process/process_test.go
+++ b/internal/component/loki/process/process_test.go
@@ -41,11 +41,13 @@ func TestComponent(t *testing.T) {
 		expected []loki.Entry
 	}
 
-	now := time.Now().UTC()
+	var (
+		lineTimestamp = time.Now().UTC()
+	)
 
 	tests := []testCase{
 		{
-			name: "simple cri pipeline",
+			name: "cri pipeline",
 			cfg: `
 			forward_to = []
 
@@ -67,36 +69,36 @@ func TestComponent(t *testing.T) {
 			inputs: []loki.Entry{
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "file1"}, 0, push.Entry{
 					Timestamp: time.Now(),
-					Line:      now.Format(time.RFC3339Nano) + " stdout P partial for file 1 stdout",
+					Line:      lineTimestamp.Format(time.RFC3339Nano) + " stdout P partial for file 1 stdout",
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "file1"}, 0, push.Entry{
 					Timestamp: time.Now(),
-					Line:      now.Format(time.RFC3339Nano) + " stderr P partial for file 1 stderr",
+					Line:      lineTimestamp.Format(time.RFC3339Nano) + " stderr P partial for file 1 stderr",
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "file2"}, 0, push.Entry{
 					Timestamp: time.Now(),
-					Line:      now.Format(time.RFC3339Nano) + " stdout P partial for file2",
+					Line:      lineTimestamp.Format(time.RFC3339Nano) + " stdout P partial for file2",
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "file1"}, 0, push.Entry{
 					Timestamp: time.Now(),
-					Line:      now.Format(time.RFC3339Nano) + " stderr F full file 1 stderr",
+					Line:      lineTimestamp.Format(time.RFC3339Nano) + " stderr F full file 1 stderr",
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "file2"}, 0, push.Entry{
 					Timestamp: time.Now(),
-					Line:      now.Format(time.RFC3339Nano) + " stderr F full file 2",
+					Line:      lineTimestamp.Format(time.RFC3339Nano) + " stderr F full file 2",
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "file1"}, 0, push.Entry{
 					Timestamp: time.Now(),
-					Line:      now.Format(time.RFC3339Nano) + " stderr F full file 1 stdout",
+					Line:      lineTimestamp.Format(time.RFC3339Nano) + " stderr F full file 1 stdout",
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "file3"}, 0, push.Entry{
-					Timestamp: now.Add(3 * time.Second),
+					Timestamp: lineTimestamp.Add(3 * time.Second),
 					Line:      "not a cri line",
 				}),
 			},
 			expected: []loki.Entry{
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
-					Timestamp: now,
+					Timestamp: lineTimestamp,
 					Line:      "partial for file 1 stderrfull file 1 stderr",
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "file1"},
@@ -104,7 +106,7 @@ func TestComponent(t *testing.T) {
 					},
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
-					Timestamp: now,
+					Timestamp: lineTimestamp,
 					Line:      "full file 2",
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "file2"},
@@ -112,7 +114,7 @@ func TestComponent(t *testing.T) {
 					},
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
-					Timestamp: now,
+					Timestamp: lineTimestamp,
 					Line:      "full file 1 stdout",
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "file1"},
@@ -120,7 +122,7 @@ func TestComponent(t *testing.T) {
 					},
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
-					Timestamp: now.Add(3 * time.Second),
+					Timestamp: lineTimestamp.Add(3 * time.Second),
 					Line:      "not a cri line",
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "file3"},
@@ -129,7 +131,7 @@ func TestComponent(t *testing.T) {
 			},
 		},
 		{
-			name: "simple docker pipeline",
+			name: "docker pipeline",
 			cfg: `
 			forward_to = []
 
@@ -154,7 +156,7 @@ func TestComponent(t *testing.T) {
 					Line: mustMarshalJSON(t, map[string]string{
 						"log":    "docker stdout line\n",
 						"stream": "stdout",
-						"time":   now.Format(time.RFC3339Nano),
+						"time":   lineTimestamp.Format(time.RFC3339Nano),
 					}),
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "docker.log"}, 0, push.Entry{
@@ -162,17 +164,17 @@ func TestComponent(t *testing.T) {
 					Line: mustMarshalJSON(t, map[string]string{
 						"log":    "docker stderr line\n",
 						"stream": "stderr",
-						"time":   now.Add(time.Second).Format(time.RFC3339Nano),
+						"time":   lineTimestamp.Add(time.Second).Format(time.RFC3339Nano),
 					}),
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "docker.log"}, 0, push.Entry{
-					Timestamp: now.Add(2 * time.Second),
+					Timestamp: lineTimestamp.Add(2 * time.Second),
 					Line:      `{"msg":"not docker format"}`,
 				}),
 			},
 			expected: []loki.Entry{
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
-					Timestamp: now,
+					Timestamp: lineTimestamp,
 					Line:      "docker stdout line\n",
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "docker.log"},
@@ -180,7 +182,7 @@ func TestComponent(t *testing.T) {
 					},
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
-					Timestamp: now.Add(time.Second),
+					Timestamp: lineTimestamp.Add(time.Second),
 					Line:      "docker stderr line\n",
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "docker.log"},
@@ -188,7 +190,7 @@ func TestComponent(t *testing.T) {
 					},
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
-					Timestamp: now.Add(2 * time.Second),
+					Timestamp: lineTimestamp.Add(2 * time.Second),
 					Line:      `{"msg":"not docker format"}`,
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "docker.log"},
@@ -197,7 +199,7 @@ func TestComponent(t *testing.T) {
 			},
 		},
 		{
-			name: "simple json pipeline",
+			name: "json pipeline",
 			cfg: `
 			forward_to = []
 
@@ -234,7 +236,7 @@ func TestComponent(t *testing.T) {
 			`,
 			inputs: []loki.Entry{
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "json.log"}, 0, push.Entry{
-					Timestamp: now.Add(4 * time.Second),
+					Timestamp: lineTimestamp.Add(4 * time.Second),
 					Line: mustMarshalJSON(t, map[string]string{
 						"msg":          "json line 1",
 						"app":          "api",
@@ -242,13 +244,13 @@ func TestComponent(t *testing.T) {
 					}),
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "json.log"}, 0, push.Entry{
-					Timestamp: now.Add(5 * time.Second),
+					Timestamp: lineTimestamp.Add(5 * time.Second),
 					Line:      `not json`,
 				}),
 			},
 			expected: []loki.Entry{
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar", "service_name": "service-a"}, 0, push.Entry{
-					Timestamp: now.Add(4 * time.Second),
+					Timestamp: lineTimestamp.Add(4 * time.Second),
 					Line:      "json line 1",
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "json.log"},
@@ -256,7 +258,7 @@ func TestComponent(t *testing.T) {
 					},
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
-					Timestamp: now.Add(5 * time.Second),
+					Timestamp: lineTimestamp.Add(5 * time.Second),
 					Line:      `not json`,
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "json.log"},
@@ -302,17 +304,17 @@ func TestComponent(t *testing.T) {
 			`,
 			inputs: []loki.Entry{
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "logfmt.log"}, 0, push.Entry{
-					Timestamp: now.Add(6 * time.Second),
+					Timestamp: lineTimestamp.Add(6 * time.Second),
 					Line:      `msg="logfmt line 1" app=api service_name=service-b`,
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "logfmt.log"}, 0, push.Entry{
-					Timestamp: now.Add(7 * time.Second),
+					Timestamp: lineTimestamp.Add(7 * time.Second),
 					Line:      `not logfmt`,
 				}),
 			},
 			expected: []loki.Entry{
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar", "service_name": "service-b"}, 0, push.Entry{
-					Timestamp: now.Add(6 * time.Second),
+					Timestamp: lineTimestamp.Add(6 * time.Second),
 					Line:      "logfmt line 1",
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "logfmt.log"},
@@ -320,10 +322,121 @@ func TestComponent(t *testing.T) {
 					},
 				}),
 				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
-					Timestamp: now.Add(7 * time.Second),
+					Timestamp: lineTimestamp.Add(7 * time.Second),
 					Line:      `not logfmt`,
 					StructuredMetadata: push.LabelsAdapter{
 						{Name: "filename", Value: "logfmt.log"},
+					},
+				}),
+			},
+		},
+		{
+			name: "multiline pipeline",
+			cfg: `
+			forward_to = []
+
+			stage.multiline {
+				firstline     = "^\\[\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\]"
+				max_wait_time = "50ms"
+			}
+
+			stage.regex {
+				expression = "^\\[(?P<time>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2})\\] (?P<msg>(?s:.*))$"
+			}
+
+			stage.timestamp {
+				source = "time"
+				format = "2006-01-02 15:04:05"
+			}
+
+			stage.structured_metadata {
+				values = {
+					filename = "",
+				}
+			}
+
+			stage.static_labels {
+				values = {
+					foo = "bar",
+				}
+			}
+
+			stage.output {
+				source = "msg"
+			}
+			`,
+			inputs: []loki.Entry{
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "multiline.log"}, 0, push.Entry{
+					Timestamp: lineTimestamp.Add(8 * time.Second),
+					Line:      `not a multiline start`,
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "multiline.log"}, 0, push.Entry{
+					Timestamp: lineTimestamp.Add(9 * time.Second),
+					Line:      `[2024-01-02 03:04:05] "GET /one HTTP/1.1" 200 -`,
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "multiline.log"}, 0, push.Entry{
+					Timestamp: lineTimestamp.Add(10 * time.Second),
+					Line:      `[2024-01-02 03:04:06] "POST /two HTTP/1.1" 201 -`,
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "multiline.log"}, 0, push.Entry{
+					Timestamp: lineTimestamp.Add(11 * time.Second),
+					Line:      `line 1`,
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "other-multiline.log"}, 0, push.Entry{
+					Timestamp: lineTimestamp.Add(11*time.Second + 500*time.Millisecond),
+					Line:      `[2024-01-02 03:04:08] "PATCH /other HTTP/1.1" 204 -`,
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "multiline.log"}, 0, push.Entry{
+					Timestamp: lineTimestamp.Add(12 * time.Second),
+					Line:      `line 2`,
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "multiline.log"}, 0, push.Entry{
+					Timestamp: lineTimestamp.Add(13 * time.Second),
+					Line:      `[2024-01-02 03:04:07] "PUT /three HTTP/1.1" 202 -`,
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "other-multiline.log"}, 0, push.Entry{
+					Timestamp: lineTimestamp.Add(13*time.Second + 500*time.Millisecond),
+					Line:      `other line 1`,
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"filename": "multiline.log"}, 0, push.Entry{
+					Timestamp: lineTimestamp.Add(14 * time.Second),
+					Line:      `line 1`,
+				}),
+			},
+			expected: []loki.Entry{
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
+					Timestamp: lineTimestamp.Add(8 * time.Second),
+					Line:      `not a multiline start`,
+					StructuredMetadata: push.LabelsAdapter{
+						{Name: "filename", Value: "multiline.log"},
+					},
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
+					Timestamp: time.Date(2024, time.January, 2, 3, 4, 5, 0, time.UTC),
+					Line:      `"GET /one HTTP/1.1" 200 -`,
+					StructuredMetadata: push.LabelsAdapter{
+						{Name: "filename", Value: "multiline.log"},
+					},
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
+					Timestamp: time.Date(2024, time.January, 2, 3, 4, 6, 0, time.UTC),
+					Line:      "\"POST /two HTTP/1.1\" 201 -\nline 1\nline 2",
+					StructuredMetadata: push.LabelsAdapter{
+						{Name: "filename", Value: "multiline.log"},
+					},
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
+					Timestamp: time.Date(2024, time.January, 2, 3, 4, 8, 0, time.UTC),
+					Line:      "\"PATCH /other HTTP/1.1\" 204 -\nother line 1",
+					StructuredMetadata: push.LabelsAdapter{
+						{Name: "filename", Value: "other-multiline.log"},
+					},
+				}),
+				loki.NewEntryWithCreatedUnixMicro(model.LabelSet{"foo": "bar"}, 0, push.Entry{
+					Timestamp: time.Date(2024, time.January, 2, 3, 4, 7, 0, time.UTC),
+					Line:      "\"PUT /three HTTP/1.1\" 202 -\nline 1",
+					StructuredMetadata: push.LabelsAdapter{
+						{Name: "filename", Value: "multiline.log"},
 					},
 				}),
 			},

--- a/internal/component/loki/process/process_test.go
+++ b/internal/component/loki/process/process_test.go
@@ -601,12 +601,13 @@ func TestComponent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			collector := loki.NewCollectingHandler()
-			defer collector.Stop()
+			collector1, collector2 := loki.NewCollectingHandler(), loki.NewCollectingHandler()
+			defer collector1.Stop()
+			defer collector2.Stop()
 
 			var args Arguments
 			require.NoError(t, syntax.Unmarshal([]byte(tt.cfg), &args))
-			args.ForwardTo = []loki.LogsReceiver{collector.Receiver()}
+			args.ForwardTo = []loki.LogsReceiver{collector1.Receiver(), collector2.Receiver()}
 
 			opts := component.Options{
 				Logger:         log.NewNopLogger(),
@@ -627,18 +628,23 @@ func TestComponent(t *testing.T) {
 				c.receiver.Chan() <- input
 			}
 
-			require.Eventually(t, func() bool { return len(collector.Received()) == len(tt.expected) }, 5*time.Second, 10*time.Millisecond)
-
-			got := collector.Received()
+			require.Eventually(t, func() bool {
+				return len(collector1.Received()) == len(tt.expected) && len(collector2.Received()) == len(tt.expected)
+			}, 5*time.Second, 10*time.Millisecond)
 
 			if tt.unorderedFrom == nil {
 				tt.unorderedFrom = ptr.To(len(tt.expected))
 			}
 
-			for i := range *tt.unorderedFrom {
-				assertEntry(t, tt.expected[i], got[i])
+			assert := func(t *testing.T, unorderedFrom int, expected, got []loki.Entry) {
+				for i := range unorderedFrom {
+					assertEntry(t, expected[i], got[i])
+				}
+				assertEntriesUnordered(t, expected[unorderedFrom:], got[unorderedFrom:])
 			}
-			assertEntriesUnordered(t, tt.expected[*tt.unorderedFrom:], got[*tt.unorderedFrom:])
+
+			assert(t, *tt.unorderedFrom, tt.expected, collector1.Received())
+			assert(t, *tt.unorderedFrom, tt.expected, collector2.Received())
 
 			cancel()
 			require.NoError(t, <-runErr)

--- a/internal/component/loki/process/process_test.go
+++ b/internal/component/loki/process/process_test.go
@@ -805,6 +805,8 @@ func TestComponent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			collector1, collector2 := loki.NewCollectingHandler(), loki.NewCollectingHandler()
 			defer collector1.Stop()
 			defer collector2.Stop()
@@ -878,7 +880,7 @@ func assertEntry(t *testing.T, expected, actual loki.Entry) {
 	t.Helper()
 
 	require.Equal(t, expected.Line, actual.Line)
-	require.Equal(t, expected.Timestamp, actual.Timestamp)
+	require.True(t, expected.Timestamp.Equal(actual.Timestamp))
 	require.EqualValues(t, expected.Labels, actual.Labels)
 	require.ElementsMatch(t, expected.StructuredMetadata, actual.StructuredMetadata)
 }
@@ -899,14 +901,18 @@ func assertEntriesUnordered(t *testing.T, expected, actual []loki.Entry) {
 			return false
 		}
 
-		expectedStructured := append(push.LabelsAdapter(nil), expected.StructuredMetadata...)
-		actualStructured := append(push.LabelsAdapter(nil), actual.StructuredMetadata...)
+		var (
+			actualStructured   = slices.Clone(actual.StructuredMetadata)
+			expectedStructured = slices.Clone(expected.StructuredMetadata)
+		)
+
 		slices.SortFunc(expectedStructured, func(a, b push.LabelAdapter) int {
 			if a.Name != b.Name {
 				return strings.Compare(a.Name, b.Name)
 			}
 			return strings.Compare(a.Value, b.Value)
 		})
+
 		slices.SortFunc(actualStructured, func(a, b push.LabelAdapter) int {
 			if a.Name != b.Name {
 				return strings.Compare(a.Name, b.Name)


### PR DESCRIPTION
### Pull Request Details

Expand loki.process pipeline tests with different kind of setups. I also changed so that the test forwards too two receivers and verify them both.

For tests that includes e.g. `stage.multiline` and `stage.match` we cannot guarantee the order of entries so we need to perform unordered checks.

### Issue(s) fixed by this Pull Request

Part of: https://github.com/grafana/alloy/issues/4953

### Notes to the Reviewer

I merged these two test into the bigger pipeline test
- TestStaticLabelsLabelAllowLabelDrop
- TestRegexTimestampOutput

### PR Checklist

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated