### PR TITLE
feat: Add zone-aware scraping to prometheus operator CRDs

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.operator.podmonitors.md
+++ b/docs/sources/reference/components/prometheus/prometheus.operator.podmonitors.md
@@ -125,9 +125,10 @@ The following arguments are supported:
 
 ### `clustering`
 
-| Name      | Type   | Description                                       | Default | Required |
-| --------- | ------ | ------------------------------------------------- | ------- | -------- |
-| `enabled` | `bool` | Enables sharing targets with other cluster nodes. | `false` | yes      |
+| Name         | Type   | Description                                                              | Default | Required |
+| ------------ | ------ | ------------------------------------------------------------------------ | ------- | -------- |
+| `enabled`    | `bool` | Enables sharing targets with other cluster nodes.                        | `false` | yes      |
+| `zone_aware` | `bool` | Enables availability-zone-aware target filtering when clustering is on.  | `false` | no       |
 
 When {{< param "PRODUCT_NAME" >}} is [using clustering][], and `enabled` is set to true, then this component instance opts-in to participating in the cluster to distribute scrape load between all cluster nodes.
 
@@ -139,6 +140,19 @@ When a node joins or leaves the cluster, every peer recalculates ownership and c
 This performs better than hashmod sharding where _all_ nodes have to be re-distributed, as only 1/N of the target's ownership is transferred, but is eventually consistent (rather than fully consistent like hashmod sharding is).
 
 If {{< param "PRODUCT_NAME" >}} is _not_ running in clustered mode, then the block is a no-op, and `prometheus.operator.podmonitors` scrapes every target it receives in its arguments.
+
+#### Zone-aware clustering
+
+When `zone_aware` is set to `true`, each {{< param "PRODUCT_NAME" >}} instance only scrapes targets that are in the same availability zone as the instance itself.
+Targets in a different zone are skipped before the hash ring is consulted, which reduces cross-zone network traffic.
+Targets whose zone can't be determined fall through to normal hash ring distribution so they aren't dropped.
+You should make sure that {{< param "PRODUCT_NAME" >}} is deployed in all availability zones, e.g. by using `topologySpreadConstraints`.
+
+The component determines the local availability zone by reading the `topology.kubernetes.io/zone` label from the Kubernetes node object.
+This requires the `K8S_NODE_NAME` environment variable to be set, typically through the [Kubernetes downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/).
+The default {{< param "PRODUCT_NAME" >}} Helm chart already sets this variable.
+
+Setting `zone_aware` to `true` requires `enabled` to also be `true`.
 
 [using clustering]: ../../../../get-started/clustering/
 

--- a/docs/sources/reference/components/prometheus/prometheus.operator.probes.md
+++ b/docs/sources/reference/components/prometheus/prometheus.operator.probes.md
@@ -125,9 +125,10 @@ The following arguments are supported:
 
 ### `clustering`
 
-| Name      | Type   | Description                                       | Default | Required |
-| --------- | ------ | ------------------------------------------------- | ------- | -------- |
-| `enabled` | `bool` | Enables sharing targets with other cluster nodes. | `false` | yes      |
+| Name         | Type   | Description                                                              | Default | Required |
+| ------------ | ------ | ------------------------------------------------------------------------ | ------- | -------- |
+| `enabled`    | `bool` | Enables sharing targets with other cluster nodes.                        | `false` | yes      |
+| `zone_aware` | `bool` | Enables availability-zone-aware target filtering when clustering is on.  | `false` | no       |
 
 When {{< param "PRODUCT_NAME" >}} is running in [clustered mode][], and `enabled` is set to true, then this component instance opts-in to participating in the cluster to distribute scrape load between all cluster nodes.
 
@@ -139,6 +140,24 @@ When a node joins or leaves the cluster, every peer recalculates ownership and c
 This performs better than hashmod sharding where _all_ nodes have to be re-distributed, as only 1/N of the target's ownership is transferred, but is eventually consistent (rather than fully consistent like hashmod sharding is).
 
 If {{< param "PRODUCT_NAME" >}} is _not_ running in clustered mode, then the block is a no-op, and `prometheus.operator.probes` scrapes every target it receives in its arguments.
+
+#### Zone-aware clustering
+
+When `zone_aware` is set to `true`, each {{< param "PRODUCT_NAME" >}} instance only scrapes targets that are in the same availability zone as the instance itself.
+Targets in a different zone are skipped before the hash ring is consulted, which reduces cross-zone network traffic.
+Targets whose zone can't be determined fall through to normal hash ring distribution so they aren't dropped.
+You should make sure that {{< param "PRODUCT_NAME" >}} is deployed in all availability zones, e.g. by using `topologySpreadConstraints`.
+
+{{< admonition type="note" >}}
+Zone-aware clustering only applies to targets with Kubernetes pod metadata (when Probe targets are discovered through Kubernetes service discovery).
+For Probe resources that target arbitrary IPs or hostnames without pod metadata, the `zone_aware` setting has no effect and targets are distributed using the global cluster ring.
+{{< /admonition >}}
+
+The component determines the local availability zone by reading the `topology.kubernetes.io/zone` label from the Kubernetes node object.
+This requires the `K8S_NODE_NAME` environment variable to be set, typically through the [Kubernetes downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/).
+The default {{< param "PRODUCT_NAME" >}} Helm chart already sets this variable.
+
+Setting `zone_aware` to `true` requires `enabled` to also be `true`.
 
 [clustered mode]: ../../../cli/run/#clustering
 

--- a/docs/sources/reference/components/prometheus/prometheus.operator.scrapeconfigs.md
+++ b/docs/sources/reference/components/prometheus/prometheus.operator.scrapeconfigs.md
@@ -167,9 +167,10 @@ The following arguments are supported:
 
 ### `clustering`
 
-| Name      | Type   | Description                                       | Default | Required |
-| --------- | ------ | ------------------------------------------------- | ------- | -------- |
-| `enabled` | `bool` | Enables sharing targets with other cluster nodes. | `false` | yes      |
+| Name         | Type   | Description                                                              | Default | Required |
+| ------------ | ------ | ------------------------------------------------------------------------ | ------- | -------- |
+| `enabled`    | `bool` | Enables sharing targets with other cluster nodes.                        | `false` | yes      |
+| `zone_aware` | `bool` | Enables availability-zone-aware target filtering when clustering is on.  | `false` | no       |
 
 When {{< param "PRODUCT_NAME" >}} is [using clustering][], and `enabled` is set to true, then this component instance opts-in to participating in the cluster to distribute scrape load between all cluster nodes.
 
@@ -181,6 +182,24 @@ When a node joins or leaves the cluster, every peer recalculates ownership and c
 This performs better than hashmod sharding where _all_ nodes have to be re-distributed, as only 1/N of the target's ownership is transferred, but is eventually consistent (rather than fully consistent like hashmod sharding is).
 
 If {{< param "PRODUCT_NAME" >}} is _not_ running in clustered mode, then the block is a no-op, and `prometheus.operator.scrapeconfigs` scrapes every target it receives in its arguments.
+
+#### Zone-aware clustering
+
+When `zone_aware` is set to `true`, each {{< param "PRODUCT_NAME" >}} instance only scrapes targets that are in the same availability zone as the instance itself.
+Targets in a different zone are skipped before the hash ring is consulted, which reduces cross-zone network traffic.
+Targets whose zone can't be determined fall through to normal hash ring distribution so they aren't dropped.
+You should make sure that {{< param "PRODUCT_NAME" >}} is deployed in all availability zones, e.g. by using `topologySpreadConstraints`.
+
+{{< admonition type="note" >}}
+Zone-aware clustering only applies to targets discovered via Kubernetes pod service discovery (when ScrapeConfig uses Pod or Endpoint discovery).
+For other service discovery methods (static configs, HTTP SD, etc.), the `zone_aware` setting has no effect and targets are distributed using the global cluster ring.
+{{< /admonition >}}
+
+The component determines the local availability zone by reading the `topology.kubernetes.io/zone` label from the Kubernetes node object.
+This requires the `K8S_NODE_NAME` environment variable to be set, typically through the [Kubernetes downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/).
+The default {{< param "PRODUCT_NAME" >}} Helm chart already sets this variable.
+
+Setting `zone_aware` to `true` requires `enabled` to also be `true`.
 
 [using clustering]: ../../../../get-started/clustering/
 

--- a/docs/sources/reference/components/prometheus/prometheus.operator.servicemonitors.md
+++ b/docs/sources/reference/components/prometheus/prometheus.operator.servicemonitors.md
@@ -126,9 +126,10 @@ The following arguments are supported:
 
 ### `clustering`
 
-| Name      | Type   | Description                                       | Default | Required |
-| --------- | ------ | ------------------------------------------------- | ------- | -------- |
-| `enabled` | `bool` | Enables sharing targets with other cluster nodes. | `false` | yes      |
+| Name         | Type   | Description                                                              | Default | Required |
+| ------------ | ------ | ------------------------------------------------------------------------ | ------- | -------- |
+| `enabled`    | `bool` | Enables sharing targets with other cluster nodes.                        | `false` | yes      |
+| `zone_aware` | `bool` | Enables availability-zone-aware target filtering when clustering is on.  | `false` | no       |
 
 When {{< param "PRODUCT_NAME" >}} is using [clustering][cluster], and `enabled` is set to true, then this component instance opts-in to participating in the cluster to distribute scrape load between all cluster nodes.
 
@@ -140,6 +141,19 @@ When a node joins or leaves the cluster, every peer recalculates ownership and c
 This performs better than hashmod sharding where _all_ nodes have to be re-distributed, as only 1/N of the target's ownership is transferred, but is eventually consistent (rather than fully consistent like hashmod sharding is).
 
 If {{< param "PRODUCT_NAME" >}} is _not_ running in clustered mode, then the block is a no-op, and `prometheus.operator.servicemonitors` scrapes every target it receives in its arguments.
+
+#### Zone-aware clustering
+
+When `zone_aware` is set to `true`, each {{< param "PRODUCT_NAME" >}} instance only scrapes targets that are in the same availability zone as the instance itself.
+Targets in a different zone are skipped before the hash ring is consulted, which reduces cross-zone network traffic.
+Targets whose zone can't be determined fall through to normal hash ring distribution so they aren't dropped.
+You should make sure that {{< param "PRODUCT_NAME" >}} is deployed in all availability zones, e.g. by using `topologySpreadConstraints`.
+
+The component determines the local availability zone by reading the `topology.kubernetes.io/zone` label from the Kubernetes node object.
+This requires the `K8S_NODE_NAME` environment variable to be set, typically through the [Kubernetes downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/).
+The default {{< param "PRODUCT_NAME" >}} Helm chart already sets this variable.
+
+Setting `zone_aware` to `true` requires `enabled` to also be `true`.
 
 [cluster]: ../../../../get-started/clustering/
 

--- a/internal/component/prometheus/operator/common/crdmanager.go
+++ b/internal/component/prometheus/operator/common/crdmanager.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -13,6 +15,7 @@ import (
 	promk8s "github.com/prometheus/prometheus/discovery/kubernetes"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/ckit/peer"
 	"github.com/grafana/ckit/shard"
 	"github.com/grafana/dskit/backoff"
 	promopv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -22,6 +25,7 @@ import (
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/scrape"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -124,6 +128,41 @@ type crdManager struct {
 	k8sFactory K8sFactory
 
 	kind string
+
+	// localZone is the availability zone of the local node, used for zone-aware
+	// clustering. It is determined at startup by reading the topology zone
+	// label from the Kubernetes node object.
+	localZone string
+
+	// localZoneRing is a consistent hash ring containing only the peers that
+	// are in the same availability zone as the local node. When zone-aware
+	// clustering is active, targets whose zone matches localZone are distributed
+	// using this ring instead of the global cluster ring, ensuring that only
+	// same-zone peers can own same-zone targets.
+	localZoneRing shard.Sharder
+
+	// localZonePeerNames stores the names of peers in the local zone ring,
+	// for debug info purposes.
+	localZonePeerNames []string
+
+	// nodeToZone maps Kubernetes node names to their availability zones.
+	// Built from the topology.kubernetes.io/zone label on each node.
+	// Used for zone detection via __meta_kubernetes_pod_node_name on targets.
+	nodeToZone map[string]string
+
+	// lastFilterStats holds the most recent target filtering statistics,
+	// updated after each call to filterTargets.
+	lastFilterStats filterStats
+}
+
+// filterStats tracks statistics from a filterTargets call for debug info.
+type filterStats struct {
+	total    int // total targets seen
+	sameZone int // targets in the same zone as this node
+	diffZone int // targets in a different zone (dropped)
+	noZone   int // targets with no zone info
+	kept     int // targets kept (assigned to this node)
+	dropped  int // targets dropped (assigned to another node or cross-zone)
 }
 
 const (
@@ -131,6 +170,20 @@ const (
 	KindServiceMonitor string = "serviceMonitor"
 	KindProbe          string = "probe"
 	KindScrapeConfig   string = "scrapeConfig"
+
+	// nodeNameEnvVar is the environment variable used to determine the
+	// Kubernetes node name this instance is running on. This is set by the
+	// default Alloy Helm chart via the Kubernetes downward API.
+	nodeNameEnvVar = "K8S_NODE_NAME"
+
+	// topologyZoneLabel is the well-known Kubernetes node label for
+	// availability zone information.
+	topologyZoneLabel = "topology.kubernetes.io/zone"
+
+	// metaPodNodeName is the Kubernetes SD meta label for the node name of the
+	// pod backing a target. It is available on all roles that resolve pods
+	// (endpoint, endpointslice, pod) and does not require attach_metadata.node.
+	metaPodNodeName = "__meta_kubernetes_pod_node_name"
 )
 
 func newCrdManager(opts component.Options, cluster cluster.Cluster, logger log.Logger, args *operator.Arguments, kind string, ls labelstore.LabelStore) *crdManager {
@@ -211,6 +264,16 @@ func (c *crdManager) Run(ctx context.Context) error {
 	}
 	level.Info(c.logger).Log("msg", "informers started")
 
+	// Determine local zone for zone-aware clustering if enabled.
+	if c.args.Clustering.Enabled && c.args.Clustering.ZoneAware {
+		c.localZone = c.lookupLocalZone(ctx)
+		if c.localZone != "" {
+			c.rebuildLocalZoneRing(ctx)
+		} else {
+			level.Warn(c.logger).Log("msg", "zone_aware clustering is enabled but local zone could not be determined; all targets will use the global hash ring")
+		}
+	}
+
 	var cachedTargets map[string][]*targetgroup.Group
 	// Start the target discovery loop to update the scrape manager with new targets.
 	for {
@@ -220,13 +283,38 @@ func (c *crdManager) Run(ctx context.Context) error {
 		case m := <-c.discoveryManager.SyncCh():
 			cachedTargets = m
 			if c.args.Clustering.Enabled {
-				m = filterTargets(m, c.cluster)
+				// Refresh the nodeToZone map on every sync to catch new Kubernetes nodes
+				// that may have been added to the cluster. This ensures targets on newly
+				// added nodes are correctly routed via the local zone ring.
+				if c.localZone != "" {
+					c.nodeToZone = c.buildNodeToZoneMap(ctx)
+				}
+				var stats filterStats
+				m, stats = filterTargets(m, c.cluster, c.localZone, c.localZoneRing, c.nodeToZone)
+				c.mut.Lock()
+				c.lastFilterStats = stats
+				c.mut.Unlock()
+				level.Debug(c.logger).Log("msg", "target filtering complete",
+					"total", stats.total, "kept", stats.kept, "dropped", stats.dropped,
+					"same_zone", stats.sameZone, "diff_zone", stats.diffZone, "no_zone", stats.noZone,
+					"local_zone", c.localZone, "zone_aware", c.args.Clustering.ZoneAware)
 			}
 			targetSetsChan <- m
 		case <-c.clusteringUpdated:
 			// if clustering updates while running, just re-filter the targets and pass them
 			// into scrape manager again, instead of reloading everything
-			targetSetsChan <- filterTargets(cachedTargets, c.cluster)
+			if c.localZone != "" {
+				c.rebuildLocalZoneRing(ctx)
+			}
+			filtered, stats := filterTargets(cachedTargets, c.cluster, c.localZone, c.localZoneRing, c.nodeToZone)
+			c.mut.Lock()
+			c.lastFilterStats = stats
+			c.mut.Unlock()
+			level.Info(c.logger).Log("msg", "target filtering complete (cluster change)",
+				"total", stats.total, "kept", stats.kept, "dropped", stats.dropped,
+				"same_zone", stats.sameZone, "diff_zone", stats.diffZone, "no_zone", stats.noZone,
+				"local_zone", c.localZone, "zone_aware", c.args.Clustering.ZoneAware)
+			targetSetsChan <- filtered
 		}
 	}
 }
@@ -238,11 +326,160 @@ func (c *crdManager) ClusteringUpdated() {
 	}
 }
 
+// lookupLocalZone determines the availability zone of the local Kubernetes node
+// by reading the topology.kubernetes.io/zone label from the node object.
+// It requires the K8S_NODE_NAME environment variable to be set (typically via
+// the Kubernetes downward API). Returns an empty string if the zone cannot be
+// determined.
+func (c *crdManager) lookupLocalZone(ctx context.Context) string {
+	nodeName := os.Getenv(nodeNameEnvVar)
+	if nodeName == "" {
+		level.Warn(c.logger).Log("msg", "zone_aware clustering enabled but K8S_NODE_NAME environment variable is not set; set it via the Kubernetes downward API to enable zone-aware target filtering")
+		return ""
+	}
+
+	node, err := c.client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		level.Warn(c.logger).Log("msg", "zone_aware clustering enabled but failed to look up local node; zone-aware filtering will be disabled", "node", nodeName, "err", err)
+		return ""
+	}
+
+	zone, ok := node.Labels[topologyZoneLabel]
+	if !ok || zone == "" {
+		level.Warn(c.logger).Log("msg", "zone_aware clustering enabled but local node does not have a topology zone label", "node", nodeName, "label", topologyZoneLabel)
+		return ""
+	}
+
+	level.Info(c.logger).Log("msg", "zone_aware clustering enabled, local availability zone determined", "node", nodeName, "zone", zone)
+	return zone
+}
+
+// rebuildLocalZoneRing builds a consistent hash ring containing only the cluster
+// peers that are in the same availability zone as the local node. It queries
+// the Kubernetes API to determine each peer's zone by mapping peer IP -> Pod ->
+// Node -> topology zone label. It also refreshes the nodeToZone map used for
+// target zone lookups.
+func (c *crdManager) rebuildLocalZoneRing(ctx context.Context) {
+	// Refresh the nodeToZone map — used both for peer zone resolution and for
+	// target zone detection via __meta_kubernetes_pod_node_name.
+	c.nodeToZone = c.buildNodeToZoneMap(ctx)
+
+	peers := c.cluster.Peers()
+	peerZones := c.lookupPeerZones(ctx, peers)
+
+	// Build a sub-ring with only the peers in the local zone.
+	var localZonePeers []peer.Peer
+	var peerNames []string
+	for _, p := range peers {
+		zone, ok := peerZones[p.Name]
+		if ok && zone == c.localZone {
+			localZonePeers = append(localZonePeers, p)
+			peerNames = append(peerNames, p.Name)
+		} else if p.Self {
+			// Always include self even if lookup failed.
+			localZonePeers = append(localZonePeers, p)
+			peerNames = append(peerNames, p.Name)
+		}
+	}
+
+	ring := shard.Ring(512)
+	ring.SetPeers(localZonePeers)
+	c.mut.Lock()
+	c.localZoneRing = ring
+	c.localZonePeerNames = peerNames
+	c.mut.Unlock()
+
+	level.Info(c.logger).Log("msg", "rebuilt local zone ring", "local_zone", c.localZone, "total_peers", len(peers), "local_zone_peers", len(localZonePeers), "local_zone_peer_names", strings.Join(peerNames, ","), "nodes_with_zone", len(c.nodeToZone))
+}
+
+// buildNodeToZoneMap lists all Kubernetes nodes and builds a map of node name
+// to availability zone from the topology.kubernetes.io/zone label.
+func (c *crdManager) buildNodeToZoneMap(ctx context.Context) map[string]string {
+	nodeList, err := c.client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		level.Warn(c.logger).Log("msg", "failed to list nodes for zone-aware clustering", "err", err)
+		return nil
+	}
+	nodeToZone := make(map[string]string, len(nodeList.Items))
+	for _, node := range nodeList.Items {
+		if zone, ok := node.Labels[topologyZoneLabel]; ok && zone != "" {
+			nodeToZone[node.Name] = zone
+		}
+	}
+	return nodeToZone
+}
+
+// lookupPeerZones determines the availability zone for each peer by querying the
+// Kubernetes API. It maps peer address (IP) -> Pod -> Node -> zone label.
+// Returns a map of peer name -> zone. Peers whose zone cannot be determined are
+// omitted from the map. Uses c.nodeToZone which must be populated before calling.
+func (c *crdManager) lookupPeerZones(ctx context.Context, peers []peer.Peer) map[string]string {
+	if c.nodeToZone == nil {
+		return nil
+	}
+
+	// For each peer, find the pod by IP and resolve its node's zone.
+	peerZones := make(map[string]string, len(peers))
+	for _, p := range peers {
+		// Extract IP from peer address (host:port).
+		peerIP, _, err := net.SplitHostPort(p.Addr)
+		if err != nil {
+			level.Warn(c.logger).Log("msg", "failed to parse peer address", "peer", p.Name, "addr", p.Addr, "err", err)
+			continue
+		}
+
+		podList, err := c.client.CoreV1().Pods("").List(ctx, metav1.ListOptions{
+			FieldSelector: "status.podIP=" + peerIP,
+		})
+		if err != nil {
+			level.Warn(c.logger).Log("msg", "failed to list pods for peer IP", "peer", p.Name, "ip", peerIP, "err", err)
+			continue
+		}
+		if len(podList.Items) == 0 {
+			level.Warn(c.logger).Log("msg", "no pod found for peer IP", "peer", p.Name, "ip", peerIP)
+			continue
+		}
+
+		nodeName := podList.Items[0].Spec.NodeName
+		if zone, ok := c.nodeToZone[nodeName]; ok {
+			peerZones[p.Name] = zone
+			level.Debug(c.logger).Log("msg", "resolved peer zone", "peer", p.Name, "ip", peerIP, "node", nodeName, "zone", zone)
+		} else {
+			level.Warn(c.logger).Log("msg", "peer node has no topology zone label", "peer", p.Name, "ip", peerIP, "node", nodeName)
+		}
+	}
+
+	return peerZones
+}
+
+// resolveTargetZone determines the availability zone of a target by looking up
+// __meta_kubernetes_pod_node_name in the nodeToZone map. The pod node name is
+// available at the target level for endpoint and endpointslice roles, and at
+// the group level for the pod role. Returns an empty string if the zone cannot
+// be determined.
+func resolveTargetZone(target, groupLabels model.LabelSet, nodeToZone map[string]string) string {
+	if nodeToZone == nil {
+		return ""
+	}
+	if nodeName := string(target[metaPodNodeName]); nodeName != "" {
+		if zone, ok := nodeToZone[nodeName]; ok {
+			return zone
+		}
+	}
+	if nodeName := string(groupLabels[metaPodNodeName]); nodeName != "" {
+		if zone, ok := nodeToZone[nodeName]; ok {
+			return zone
+		}
+	}
+	return ""
+}
+
 // TODO: merge this code with the code in prometheus.scrape. This is a copy of that code, mostly because
 // we operate on slightly different data structures.
-func filterTargets(m map[string][]*targetgroup.Group, c cluster.Cluster) map[string][]*targetgroup.Group {
+func filterTargets(m map[string][]*targetgroup.Group, c cluster.Cluster, localZone string, localZoneRing shard.Sharder, nodeToZone map[string]string) (map[string][]*targetgroup.Group, filterStats) {
+	var stats filterStats
 	if !c.Ready() { // if cluster not ready, we don't take any traffic locally
-		return make(map[string][]*targetgroup.Group)
+		return make(map[string][]*targetgroup.Group), stats
 	}
 	// the key in the map is the job name.
 	// the targetGroups have zero or more targets inside them.
@@ -261,19 +498,52 @@ func filterTargets(m map[string][]*targetgroup.Group, c cluster.Cluster) map[str
 			// We should not need to include the group's common labels, as long
 			// as each node does this consistently.
 			for _, t := range group.Targets {
-				peers, err := c.Lookup(shard.StringKey(nonMetaLabelString(t)), 1, shard.OpReadWrite)
-				if len(peers) == 0 || err != nil {
-					// If the cluster found no peers or returned an error, we fall
-					// back to owning the target ourselves.
+				stats.total++
+				targetKey := shard.StringKey(nonMetaLabelString(t))
+
+				// When zone-aware clustering is active, targets in the local zone
+				// are distributed using the local-zone-only ring so that only
+				// same-zone peers can own them. Targets in a different zone are
+				// skipped (peers in that zone will handle them via their own
+				// local ring). Targets with unknown zone use the global ring.
+				if localZone != "" && localZoneRing != nil {
+					tZone := resolveTargetZone(t, group.Labels, nodeToZone)
+					if tZone != "" && tZone != localZone {
+						// Target is in a different zone; skip it. The peers
+						// in that zone will pick it up using their own ring.
+						stats.diffZone++
+						stats.dropped++
+						continue
+					}
+					if tZone == localZone {
+						// Use local zone ring for targets in the same zone.
+						peers, err := localZoneRing.Lookup(targetKey, 1, shard.OpReadWrite)
+						if len(peers) == 0 || err != nil || peers[0].Self {
+							g2.Targets = append(g2.Targets, t)
+							stats.kept++
+						} else {
+							stats.dropped++
+						}
+						stats.sameZone++
+						continue
+					}
+					// Target zone is unknown; fall through to global ring.
+					stats.noZone++
+				}
+
+				// Use global ring for targets with unknown zone or when zone-aware clustering is disabled.
+				peers, err := c.Lookup(targetKey, 1, shard.OpReadWrite)
+				if len(peers) == 0 || err != nil || peers[0].Self {
 					g2.Targets = append(g2.Targets, t)
-				} else if peers[0].Self {
-					g2.Targets = append(g2.Targets, t)
+					stats.kept++
+				} else {
+					stats.dropped++
 				}
 			}
 			m2[k][i] = g2
 		}
 	}
-	return m2
+	return m2, stats
 }
 
 // nonMetaLabelString returns a string representation of the given label set, excluding meta labels.
@@ -302,6 +572,29 @@ func (c *crdManager) DebugInfo() any {
 	if c.scrapeManager != nil {
 		info.Targets = compscrape.BuildTargetStatuses(c.scrapeManager.TargetsActive())
 	}
+
+	// Populate clustering debug info if clustering is enabled.
+	if c.args.Clustering.Enabled {
+		totalPeers := 0
+		if c.cluster != nil {
+			totalPeers = len(c.cluster.Peers())
+		}
+		clusterInfo := &operator.ClusteringDebugInfo{
+			Enabled:         true,
+			ZoneAware:       c.args.Clustering.ZoneAware,
+			LocalZone:       c.localZone,
+			LocalZonePeers:  c.localZonePeerNames,
+			TotalPeers:      totalPeers,
+			TargetsTotal:    c.lastFilterStats.total,
+			TargetsSameZone: c.lastFilterStats.sameZone,
+			TargetsDiffZone: c.lastFilterStats.diffZone,
+			TargetsNoZone:   c.lastFilterStats.noZone,
+			TargetsKept:     c.lastFilterStats.kept,
+			TargetsDropped:  c.lastFilterStats.dropped,
+		}
+		info.ClusteringInfo = clusterInfo
+	}
+
 	return info
 }
 

--- a/internal/component/prometheus/operator/common/crdmanager_test.go
+++ b/internal/component/prometheus/operator/common/crdmanager_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"fmt"
 	"testing"
 
 	"golang.org/x/exp/maps"
@@ -10,7 +11,10 @@ import (
 	"github.com/grafana/alloy/internal/component/prometheus/operator"
 	"github.com/grafana/alloy/internal/service/cluster"
 	"github.com/grafana/alloy/internal/service/labelstore"
+	"github.com/grafana/ckit/peer"
+	"github.com/grafana/ckit/shard"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
@@ -166,4 +170,557 @@ func (m *mockScrapeManager) TargetsActive() map[string][]*scrape.Target {
 
 func (m *mockScrapeManager) ApplyConfig(cfg *config.Config) error {
 	return nil
+}
+
+// testCluster is a fake cluster implementation for testing filterTargets.
+type testCluster struct {
+	lookupMap map[shard.Key][]peer.Peer
+	peers     []peer.Peer
+	ready     bool
+}
+
+func (f *testCluster) Lookup(key shard.Key, _ int, _ shard.Op) ([]peer.Peer, error) {
+	if peers, ok := f.lookupMap[key]; ok {
+		return peers, nil
+	}
+	// If key not in lookupMap, return an error to trigger fallback behavior.
+	return nil, fmt.Errorf("no peers for key")
+}
+
+func (f *testCluster) Peers() []peer.Peer {
+	return f.peers
+}
+
+func (f *testCluster) Ready() bool {
+	return f.ready
+}
+
+func TestFilterTargetsWithoutZoneAware(t *testing.T) {
+	selfPeer := peer.Peer{Name: "self", Addr: "127.0.0.1", Self: true, State: peer.StateParticipant}
+	otherPeer := peer.Peer{Name: "other", Addr: "127.0.0.2", Self: false, State: peer.StateParticipant}
+
+	target1 := model.LabelSet{"__address__": "10.0.0.1:9090"}
+	target2 := model.LabelSet{"__address__": "10.0.0.2:9090"}
+	target3 := model.LabelSet{
+		"__address__":   "10.0.0.3:9090",
+		metaPodNodeName: "node-3",
+	}
+
+	key1 := shard.StringKey(nonMetaLabelString(target1))
+	key2 := shard.StringKey(nonMetaLabelString(target2))
+	key3 := shard.StringKey(nonMetaLabelString(target3))
+
+	c := &testCluster{
+		ready: true,
+		peers: []peer.Peer{selfPeer, otherPeer},
+		lookupMap: map[shard.Key][]peer.Peer{
+			key1: {selfPeer},
+			key2: {otherPeer},
+			key3: {selfPeer},
+		},
+	}
+
+	input := map[string][]*targetgroup.Group{
+		"job1": {
+			{
+				Source:  "source1",
+				Targets: []model.LabelSet{target1, target2, target3},
+			},
+		},
+	}
+
+	// Without zone-aware (empty localZone, nil ring), all targets go through normal hash ring.
+	result, stats := filterTargets(input, c, "", nil, nil)
+
+	require.Len(t, result["job1"], 1)
+	// target1 -> selfPeer (kept), target2 -> otherPeer (dropped), target3 -> selfPeer (kept)
+	require.Len(t, result["job1"][0].Targets, 2)
+	require.Contains(t, result["job1"][0].Targets, target1)
+	require.Contains(t, result["job1"][0].Targets, target3)
+
+	// Verify stats
+	require.Equal(t, 3, stats.total)
+	require.Equal(t, 2, stats.kept)
+	require.Equal(t, 1, stats.dropped)
+	require.Equal(t, 0, stats.sameZone)
+	require.Equal(t, 0, stats.diffZone)
+	require.Equal(t, 0, stats.noZone)
+}
+
+func TestFilterTargetsZoneAware(t *testing.T) {
+	selfPeer := peer.Peer{Name: "self", Addr: "127.0.0.1:12345", Self: true, State: peer.StateParticipant}
+	sameZonePeer := peer.Peer{Name: "same-zone", Addr: "127.0.0.2:12345", Self: false, State: peer.StateParticipant}
+	diffZonePeer := peer.Peer{Name: "diff-zone", Addr: "127.0.0.3:12345", Self: false, State: peer.StateParticipant}
+
+	// Targets in us-east-1a (same zone as local) via pod node name
+	targetSameZone1 := model.LabelSet{
+		"__address__":   "10.0.0.1:9090",
+		metaPodNodeName: "node-a1",
+	}
+	targetSameZone2 := model.LabelSet{
+		"__address__":   "10.0.0.2:9090",
+		metaPodNodeName: "node-a2",
+	}
+
+	// Target in us-east-1b (different zone) via pod node name
+	targetDiffZone := model.LabelSet{
+		"__address__":   "10.0.0.3:9090",
+		metaPodNodeName: "node-b1",
+	}
+
+	// Target with no zone info (should fall through to global ring)
+	targetNoZone := model.LabelSet{
+		"__address__": "10.0.0.4:9090",
+	}
+
+	nodeToZone := map[string]string{
+		"node-a1": "us-east-1a",
+		"node-a2": "us-east-1a",
+		"node-b1": "us-east-1b",
+	}
+
+	keyNoZone := shard.StringKey(nonMetaLabelString(targetNoZone))
+
+	// Global cluster ring contains all peers (self, same-zone, diff-zone).
+	c := &testCluster{
+		ready: true,
+		peers: []peer.Peer{selfPeer, sameZonePeer, diffZonePeer},
+		lookupMap: map[shard.Key][]peer.Peer{
+			keyNoZone: {selfPeer},
+		},
+	}
+
+	// Local zone ring contains only peers in us-east-1a (self and same-zone peer).
+	localRing := shard.Ring(512)
+	localRing.SetPeers([]peer.Peer{selfPeer, sameZonePeer})
+
+	input := map[string][]*targetgroup.Group{
+		"job1": {
+			{
+				Source:  "source1",
+				Targets: []model.LabelSet{targetSameZone1, targetSameZone2, targetDiffZone, targetNoZone},
+			},
+		},
+	}
+
+	// With zone-aware clustering, localZone = "us-east-1a"
+	result, stats := filterTargets(input, c, "us-east-1a", localRing, nodeToZone)
+
+	require.Len(t, result["job1"], 1)
+	resultTargets := result["job1"][0].Targets
+
+	// targetSameZone1: pod node name -> nodeToZone -> "us-east-1a" (same zone) -> local ring
+	// targetSameZone2: pod node name -> nodeToZone -> "us-east-1a" (same zone) -> local ring
+	// targetDiffZone: pod node name -> nodeToZone -> "us-east-1b" (diff zone) -> dropped
+	// targetNoZone: no pod node name -> no zone -> global ring -> selfPeer owns it -> kept
+	require.Contains(t, resultTargets, targetNoZone)
+	for _, tgt := range resultTargets {
+		// No target from a different zone should appear
+		require.NotEqual(t, targetDiffZone, tgt)
+	}
+
+	// Verify stats
+	require.Equal(t, 4, stats.total)
+	require.Equal(t, 1, stats.diffZone) // targetDiffZone
+	require.Equal(t, 2, stats.sameZone) // targetSameZone1, targetSameZone2
+	require.Equal(t, 1, stats.noZone)   // targetNoZone
+}
+
+func TestFilterTargetsZoneAwareCrossZoneNotDropped(t *testing.T) {
+	// This test verifies the fix for the correctness bug where targets in a
+	// different zone could be scraped by nobody. With the sub-ring approach, each
+	// zone's peers use their own ring for same-zone targets, ensuring coverage.
+
+	// Simulate two nodes: nodeA in zone-1, nodeC in zone-2.
+	selfPeer := peer.Peer{Name: "nodeA", Addr: "127.0.0.1:12345", Self: true, State: peer.StateParticipant}
+	peerC := peer.Peer{Name: "nodeC", Addr: "127.0.0.3:12345", Self: false, State: peer.StateParticipant}
+
+	// Target in zone-2 (via pod node name).
+	targetZone2 := model.LabelSet{
+		"__address__":   "10.0.0.1:9090",
+		metaPodNodeName: "node-b1",
+	}
+
+	// Target in zone-1 (via pod node name).
+	targetZone1 := model.LabelSet{
+		"__address__":   "10.0.0.2:9090",
+		metaPodNodeName: "node-a1",
+	}
+
+	nodeToZone := map[string]string{
+		"node-a1": "us-east-1a",
+		"node-b1": "us-east-1b",
+	}
+
+	// Global cluster has both peers.
+	globalCluster := &testCluster{
+		ready: true,
+		peers: []peer.Peer{selfPeer, peerC},
+	}
+
+	// NodeA's local ring contains only itself (only peer in zone-1).
+	localRingA := shard.Ring(512)
+	localRingA.SetPeers([]peer.Peer{selfPeer})
+
+	input := map[string][]*targetgroup.Group{
+		"job1": {
+			{
+				Source:  "source1",
+				Targets: []model.LabelSet{targetZone2, targetZone1},
+			},
+		},
+	}
+
+	// From NodeA's perspective (zone-1):
+	resultA, statsA := filterTargets(input, globalCluster, "us-east-1a", localRingA, nodeToZone)
+	require.Len(t, resultA["job1"], 1)
+
+	// targetZone2 is in zone-2 -> skipped by NodeA (zone filter).
+	// targetZone1 is in zone-1 -> goes through NodeA's local ring (only self) -> kept.
+	require.Len(t, resultA["job1"][0].Targets, 1)
+	require.Contains(t, resultA["job1"][0].Targets, targetZone1)
+	require.Equal(t, 1, statsA.sameZone)
+	require.Equal(t, 1, statsA.diffZone)
+
+	// Now simulate from NodeC's perspective (zone-2):
+	selfPeerC := peer.Peer{Name: "nodeC", Addr: "127.0.0.3:12345", Self: true, State: peer.StateParticipant}
+	peerA := peer.Peer{Name: "nodeA", Addr: "127.0.0.1:12345", Self: false, State: peer.StateParticipant}
+
+	globalClusterC := &testCluster{
+		ready: true,
+		peers: []peer.Peer{peerA, selfPeerC},
+	}
+
+	// NodeC's local ring contains only itself (only peer in zone-2).
+	localRingC := shard.Ring(512)
+	localRingC.SetPeers([]peer.Peer{selfPeerC})
+
+	resultC, statsC := filterTargets(input, globalClusterC, "us-east-1b", localRingC, nodeToZone)
+	require.Len(t, resultC["job1"], 1)
+
+	// targetZone2 is in zone-2 -> goes through NodeC's local ring (only self) -> kept.
+	// targetZone1 is in zone-1 -> skipped by NodeC (zone filter).
+	require.Len(t, resultC["job1"][0].Targets, 1)
+	require.Contains(t, resultC["job1"][0].Targets, targetZone2)
+	require.Equal(t, 1, statsC.sameZone)
+	require.Equal(t, 1, statsC.diffZone)
+
+	// KEY ASSERTION: Every target is scraped by exactly one node.
+	// targetZone1 -> NodeA (zone-1), targetZone2 -> NodeC (zone-2). No gaps.
+}
+
+func TestFilterTargetsZoneAwareMultipleGroups(t *testing.T) {
+	selfPeer := peer.Peer{Name: "self", Addr: "127.0.0.1:12345", Self: true, State: peer.StateParticipant}
+
+	targetZoneA := model.LabelSet{
+		"__address__":   "10.0.0.1:9090",
+		metaPodNodeName: "node-a1",
+	}
+	targetZoneB := model.LabelSet{
+		"__address__":   "10.0.0.2:9090",
+		metaPodNodeName: "node-b1",
+	}
+
+	nodeToZone := map[string]string{
+		"node-a1": "us-east-1a",
+		"node-b1": "us-east-1b",
+	}
+
+	// Local ring with only self.
+	localRing := shard.Ring(512)
+	localRing.SetPeers([]peer.Peer{selfPeer})
+
+	c := &testCluster{
+		ready: true,
+		peers: []peer.Peer{selfPeer},
+	}
+
+	input := map[string][]*targetgroup.Group{
+		"job1": {
+			{Source: "source1", Targets: []model.LabelSet{targetZoneA}},
+			{Source: "source2", Targets: []model.LabelSet{targetZoneB}},
+		},
+	}
+
+	result, stats := filterTargets(input, c, "us-east-1a", localRing, nodeToZone)
+
+	require.Len(t, result["job1"], 2)
+	// First group: targetZoneA is same zone and selfPeer -> kept
+	require.Len(t, result["job1"][0].Targets, 1)
+	require.Contains(t, result["job1"][0].Targets, targetZoneA)
+	// Second group: targetZoneB is different zone -> empty (but group preserved)
+	require.Len(t, result["job1"][1].Targets, 0)
+	require.Equal(t, 2, stats.total)
+	require.Equal(t, 1, stats.sameZone)
+	require.Equal(t, 1, stats.diffZone)
+}
+
+func TestFilterTargetsClusterNotReady(t *testing.T) {
+	c := &testCluster{
+		ready: false,
+	}
+
+	input := map[string][]*targetgroup.Group{
+		"job1": {
+			{
+				Source: "source1",
+				Targets: []model.LabelSet{
+					{"__address__": "10.0.0.1:9090"},
+				},
+			},
+		},
+	}
+
+	// Should return empty map when cluster is not ready, regardless of zone setting.
+	localRing := shard.Ring(512)
+	result, _ := filterTargets(input, c, "us-east-1a", localRing, nil)
+	require.Len(t, result, 0)
+
+	result, _ = filterTargets(input, c, "", nil, nil)
+	require.Len(t, result, 0)
+}
+
+func TestFilterTargetsZoneAwarePreservesGroupStructure(t *testing.T) {
+	selfPeer := peer.Peer{Name: "self", Addr: "127.0.0.1:12345", Self: true, State: peer.StateParticipant}
+
+	targetDiffZone := model.LabelSet{
+		"__address__":   "10.0.0.1:9090",
+		metaPodNodeName: "node-b1",
+	}
+
+	nodeToZone := map[string]string{
+		"node-b1": "us-east-1b",
+	}
+
+	localRing := shard.Ring(512)
+	localRing.SetPeers([]peer.Peer{selfPeer})
+
+	c := &testCluster{
+		ready: true,
+		peers: []peer.Peer{selfPeer},
+	}
+
+	input := map[string][]*targetgroup.Group{
+		"job1": {
+			{
+				Source:  "source1",
+				Labels:  model.LabelSet{"team": "ops"},
+				Targets: []model.LabelSet{targetDiffZone},
+			},
+		},
+	}
+
+	result, stats := filterTargets(input, c, "us-east-1a", localRing, nodeToZone)
+
+	// The group structure should be preserved even when all targets are filtered out.
+	require.Len(t, result["job1"], 1)
+	require.Len(t, result["job1"][0].Targets, 0)
+	require.Equal(t, "source1", result["job1"][0].Source)
+	require.Equal(t, model.LabelSet{"team": "ops"}, result["job1"][0].Labels)
+	require.Equal(t, 1, stats.total)
+	require.Equal(t, 0, stats.kept)
+	require.Equal(t, 1, stats.dropped)
+	require.Equal(t, 1, stats.diffZone)
+}
+
+func TestFilterTargetsZoneAwarePodNodeName(t *testing.T) {
+	// This test verifies the __meta_kubernetes_pod_node_name -> nodeToZone
+	// lookup for zone detection. This is the primary strategy for determining
+	// target zone in endpoint and endpointslice roles.
+	selfPeer := peer.Peer{Name: "self", Addr: "127.0.0.1:12345", Self: true, State: peer.StateParticipant}
+
+	// Target has pod node name — zone resolved via nodeToZone map.
+	targetSameNode := model.LabelSet{
+		"__address__":   "10.0.0.1:9090",
+		metaPodNodeName: "node-1",
+	}
+	targetDiffNode := model.LabelSet{
+		"__address__":   "10.0.0.2:9090",
+		metaPodNodeName: "node-2",
+	}
+	// Target with a node name that is NOT in the nodeToZone map (unknown zone).
+	targetUnknownNode := model.LabelSet{
+		"__address__":   "10.0.0.3:9090",
+		metaPodNodeName: "node-unknown",
+	}
+
+	localRing := shard.Ring(512)
+	localRing.SetPeers([]peer.Peer{selfPeer})
+
+	keyUnknown := shard.StringKey(nonMetaLabelString(targetUnknownNode))
+	c := &testCluster{
+		ready: true,
+		peers: []peer.Peer{selfPeer},
+		lookupMap: map[shard.Key][]peer.Peer{
+			keyUnknown: {selfPeer},
+		},
+	}
+
+	nodeToZone := map[string]string{
+		"node-1": "us-east-1a",
+		"node-2": "us-east-1b",
+	}
+
+	input := map[string][]*targetgroup.Group{
+		"job1": {
+			{
+				Source:  "source1",
+				Targets: []model.LabelSet{targetSameNode, targetDiffNode, targetUnknownNode},
+			},
+		},
+	}
+
+	result, stats := filterTargets(input, c, "us-east-1a", localRing, nodeToZone)
+
+	require.Len(t, result["job1"], 1)
+	resultTargets := result["job1"][0].Targets
+	// targetSameNode: pod node name -> nodeToZone -> "us-east-1a" (same zone) -> kept
+	// targetDiffNode: pod node name -> nodeToZone -> "us-east-1b" (diff zone) -> dropped
+	// targetUnknownNode: pod node name not in nodeToZone -> no zone -> global ring -> selfPeer -> kept
+	require.Len(t, resultTargets, 2)
+	require.Contains(t, resultTargets, targetSameNode)
+	require.Contains(t, resultTargets, targetUnknownNode)
+
+	require.Equal(t, 3, stats.total)
+	require.Equal(t, 1, stats.sameZone)
+	require.Equal(t, 1, stats.diffZone)
+	require.Equal(t, 1, stats.noZone)
+	require.Equal(t, 2, stats.kept)
+	require.Equal(t, 1, stats.dropped)
+}
+
+func TestFilterTargetsZoneAwareGroupLabelPodNodeName(t *testing.T) {
+	// This test verifies zone detection via pod-node-name from group labels.
+	// In the pod role, __meta_kubernetes_pod_node_name is on group.Labels.
+	selfPeer := peer.Peer{Name: "self", Addr: "127.0.0.1:12345", Self: true, State: peer.StateParticipant}
+
+	// Targets have NO pod node name themselves — zone comes from group labels.
+	targetA := model.LabelSet{"__address__": "10.0.0.1:9090"}
+	targetB := model.LabelSet{"__address__": "10.0.0.2:9090"}
+
+	localRing := shard.Ring(512)
+	localRing.SetPeers([]peer.Peer{selfPeer})
+
+	c := &testCluster{
+		ready: true,
+		peers: []peer.Peer{selfPeer},
+	}
+
+	nodeToZone := map[string]string{
+		"node-1": "us-east-1a",
+		"node-2": "us-east-1b",
+	}
+
+	input := map[string][]*targetgroup.Group{
+		"job1": {
+			{
+				Source: "source-same-node",
+				// Group-level pod node name -> nodeToZone -> same zone
+				Labels:  model.LabelSet{metaPodNodeName: "node-1"},
+				Targets: []model.LabelSet{targetA},
+			},
+			{
+				Source: "source-diff-node",
+				// Group-level pod node name -> nodeToZone -> different zone
+				Labels:  model.LabelSet{metaPodNodeName: "node-2"},
+				Targets: []model.LabelSet{targetB},
+			},
+		},
+	}
+
+	result, stats := filterTargets(input, c, "us-east-1a", localRing, nodeToZone)
+
+	require.Len(t, result["job1"], 2)
+	// First group: group pod node name -> "node-1" -> "us-east-1a" (same zone) -> kept
+	require.Len(t, result["job1"][0].Targets, 1)
+	require.Contains(t, result["job1"][0].Targets, targetA)
+	// Second group: group pod node name -> "node-2" -> "us-east-1b" (diff zone) -> dropped
+	require.Len(t, result["job1"][1].Targets, 0)
+
+	require.Equal(t, 2, stats.total)
+	require.Equal(t, 1, stats.sameZone)
+	require.Equal(t, 1, stats.diffZone)
+	require.Equal(t, 1, stats.kept)
+	require.Equal(t, 1, stats.dropped)
+}
+
+func TestResolveTargetZone(t *testing.T) {
+	nodeToZone := map[string]string{
+		"node-1": "us-east-1a",
+		"node-2": "us-east-1b",
+	}
+
+	tests := []struct {
+		name        string
+		target      model.LabelSet
+		groupLabels model.LabelSet
+		nodeToZone  map[string]string
+		expected    string
+	}{
+		{
+			name:        "no labels at all",
+			target:      model.LabelSet{"__address__": "10.0.0.1:9090"},
+			groupLabels: model.LabelSet{},
+			nodeToZone:  nil,
+			expected:    "",
+		},
+		{
+			name: "pod node name on target with nodeToZone",
+			target: model.LabelSet{
+				"__address__":   "10.0.0.1:9090",
+				metaPodNodeName: "node-1",
+			},
+			groupLabels: model.LabelSet{},
+			nodeToZone:  nodeToZone,
+			expected:    "us-east-1a",
+		},
+		{
+			name:   "pod node name on group with nodeToZone",
+			target: model.LabelSet{"__address__": "10.0.0.1:9090"},
+			groupLabels: model.LabelSet{
+				metaPodNodeName: "node-2",
+			},
+			nodeToZone: nodeToZone,
+			expected:   "us-east-1b",
+		},
+		{
+			name: "target pod node name takes precedence over group",
+			target: model.LabelSet{
+				"__address__":   "10.0.0.1:9090",
+				metaPodNodeName: "node-1",
+			},
+			groupLabels: model.LabelSet{
+				metaPodNodeName: "node-2",
+			},
+			nodeToZone: nodeToZone,
+			expected:   "us-east-1a", // node-1 -> us-east-1a
+		},
+		{
+			name: "pod node name not in nodeToZone",
+			target: model.LabelSet{
+				"__address__":   "10.0.0.1:9090",
+				metaPodNodeName: "node-unknown",
+			},
+			groupLabels: model.LabelSet{},
+			nodeToZone:  nodeToZone,
+			expected:    "",
+		},
+		{
+			name: "skipped when nodeToZone is nil",
+			target: model.LabelSet{
+				"__address__":   "10.0.0.1:9090",
+				metaPodNodeName: "node-1",
+			},
+			groupLabels: model.LabelSet{},
+			nodeToZone:  nil,
+			expected:    "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := resolveTargetZone(tc.target, tc.groupLabels, tc.nodeToZone)
+			require.Equal(t, tc.expected, result)
+		})
+	}
 }

--- a/internal/component/prometheus/operator/types.go
+++ b/internal/component/prometheus/operator/types.go
@@ -94,12 +94,31 @@ func (args *Arguments) Validate() error {
 	if args.KubernetesRole != string(promk8s.RoleEndpointSlice) && args.KubernetesRole != string(promk8s.RoleEndpoint) {
 		return fmt.Errorf("only endpoints and endpointslice are supported")
 	}
+	if args.Clustering.ZoneAware && !args.Clustering.Enabled {
+		return fmt.Errorf("clustering.zone_aware requires clustering.enabled to be true")
+	}
 	return nil
 }
 
 type DebugInfo struct {
 	DiscoveredCRDs []*DiscoveredResource `alloy:"crds,block"`
 	Targets        []scrape.TargetStatus `alloy:"targets,block,optional"`
+	ClusteringInfo *ClusteringDebugInfo  `alloy:"clustering,block,optional"`
+}
+
+// ClusteringDebugInfo contains debug information about zone-aware clustering.
+type ClusteringDebugInfo struct {
+	Enabled         bool     `alloy:"enabled,attr"`
+	ZoneAware       bool     `alloy:"zone_aware,attr"`
+	LocalZone       string   `alloy:"local_zone,attr,optional"`
+	LocalZonePeers  []string `alloy:"local_zone_peers,attr,optional"`
+	TotalPeers      int      `alloy:"total_peers,attr"`
+	TargetsTotal    int      `alloy:"targets_total,attr"`
+	TargetsSameZone int      `alloy:"targets_same_zone,attr"`
+	TargetsDiffZone int      `alloy:"targets_diff_zone,attr"`
+	TargetsNoZone   int      `alloy:"targets_no_zone,attr"`
+	TargetsKept     int      `alloy:"targets_kept,attr"`
+	TargetsDropped  int      `alloy:"targets_dropped,attr"`
 }
 
 type DiscoveredResource struct {

--- a/internal/service/cluster/cluster.go
+++ b/internal/service/cluster/cluster.go
@@ -126,7 +126,8 @@ type Component interface {
 // component. ComponentBlock is intended to be exposed as a block called
 // "clustering".
 type ComponentBlock struct {
-	Enabled bool `alloy:"enabled,attr"`
+	Enabled   bool `alloy:"enabled,attr"`
+	ZoneAware bool `alloy:"zone_aware,attr,optional"`
 }
 
 var (


### PR DESCRIPTION
### Brief description of Pull Request

This pull request adds a new option `zone_aware` to the `clustering` section in the `prometheus.operator.*` components that enables zone-aware clustering. When the option is set to `true`, each Alloy instance has a zone-local hash rings that only contain zone-local targets (determined by a Pod's Node). This option heavily reduces costly cross-zone traffic.

### Pull Request Details

In our Alloy setup, we deploying across three availability zones. Since Alloy is not zone-aware, its scraping behavior results in a lot of expensive cross-zone traffic. While it would be possible to deploy three zone-local alloy deployments that each filter for targets in the own zone, I thought that it would be nicer and more useful for other people to integrate the functionality directly into Alloy.
I tested the change in a 25-node, three-zone cluster with six Alloy instances. The cross-zone traffic by Alloy was reduced from up to 80% to less than 0.5%.
The change is not breaking because the default is `zone_aware=false` which does not change the current behavior.

### Notes to the Reviewer

This PR was created with the help of AI. I reviewed the changes thoroughly, made adaptions where necessary and deployed the code to a live cluster, as mentioned above.
I made some decisions that we can discuss:
- I added the option with the name `zone_aware` to the clustering section of the prometheus.operator components. Maybe there is a better name or place for the option.
- I am using K8S_NODE_NAME to get the current node. Some components use HOSTNAME, but i figured K8S_NODE_NAME is semantically more correct and since #5484 it is always present when rolled out with Helm.
- I am rebuilding the zone-local rings on every update of the discovery manager. Maybe that is too often. We could also do it periodically (unknown nodes fall through to the global ring).
- I was also playing with attach_metadata to attach the node's zone metadata directly to the pod. In the end, using the node name of the pod was the simplest and most reliable approach.
- I added (=generated) a lot of tests. We can also reduce them if you think it's too much.
- I also added debug info and info logs. We can reduce/remove them if you want.
- I originally planned to implement it only for PodMonitors and ServiceMonitors. ScrapeConfigs and Probes came for free. For Probes, the change never applies because they are only discovered through static config or ingress. For ScrapeConfig, it can theoretically apply if `kubernetesSDConfigs` is used.
- @clayton-cornell I added the same documentation to all four components. If you have a better idea, feel free to suggest it.

### PR Checklist

- [x] Documentation added
- [x] Tests updated