### PR TITLE
fix(go): Update alloy builder image to Go 1.25.9

### DIFF
--- a/.github/workflows/check-linux-build-image.yml
+++ b/.github/workflows/check-linux-build-image.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         build:
-          - runtime: golang:1.25.8-alpine3.23
-          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.25.8-bookworm
+          - runtime: golang:1.25.9-alpine3.23
+          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.25.9-bookworm
     runs-on: ubuntu-latest-8-cores
     steps:
       - name: Checkout

--- a/.github/workflows/create_build_image.yml
+++ b/.github/workflows/create_build_image.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         build:
-          - runtime: golang:1.25.8-alpine3.23
-          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.25.8-bookworm
+          - runtime: golang:1.25.9-alpine3.23
+          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.25.9-bookworm
             suffix: "-boringcrypto"
     runs-on: ubuntu-latest-8-cores
     steps:

--- a/tools/build-image/windows/Dockerfile
+++ b/tools/build-image/windows/Dockerfile
@@ -1,4 +1,4 @@
-FROM library/golang:1.25.8-windowsservercore-ltsc2022@sha256:8231fbb9b76c4acf94daf580a35ef5a64480e545aded8062fb29deaf456c145f
+FROM library/golang:1.25.9-windowsservercore-ltsc2022@sha256:8231fbb9b76c4acf94daf580a35ef5a64480e545aded8062fb29deaf456c145f
 
 SHELL ["powershell", "-command"]
 


### PR DESCRIPTION
First PR to update Go with bug and security fixes:

* CVE-2026-32282
* CVE-2026-32289
* CVE-2026-33810
* CVE-2026-27144
* CVE-2026-27143
* CVE-2026-32288
* CVE-2026-32283
* CVE-2026-27140
