### PR TITLE
fix(go): Upgrade to Go 1.25.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
   build_linux:
     name: Build on Linux
     runs-on: github-hosted-ubuntu-x64-large
-    container: grafana/alloy-build-image:v0.1.29@sha256:2500d89efb3bc1cf0a94a00a197ec0f316cc409b7fc031a8de0f6092a782bdd6
+    container: grafana/alloy-build-image:v0.1.30@sha256:5ec4c2b765b604d71a6a78b55ed59740d143a79fd84cb7a2bc34fd76a9a3c6e6
     strategy:
       matrix:
         os: [linux]
@@ -41,7 +41,7 @@ jobs:
   build_linux_boringcrypto:
     name: Build on Linux (boringcrypto)
     runs-on: github-hosted-ubuntu-x64-large
-    container: grafana/alloy-build-image:v0.1.29-boringcrypto@sha256:a0256f8a06b634446f2d856b0325ed416ebd46f2ca097eebbf3c8359912821b4
+    container: grafana/alloy-build-image:v0.1.30-boringcrypto@sha256:0cec8ae144d98fdbc834ae28ddf0f2636deb07c53c985648d09897b5a61b3222
     strategy:
       matrix:
         os: [linux]
@@ -118,7 +118,7 @@ jobs:
   build_freebsd:
     name: Build on FreeBSD (AMD64)
     runs-on: github-hosted-ubuntu-x64-large
-    container: grafana/alloy-build-image:v0.1.29@sha256:2500d89efb3bc1cf0a94a00a197ec0f316cc409b7fc031a8de0f6092a782bdd6
+    container: grafana/alloy-build-image:v0.1.30@sha256:5ec4c2b765b604d71a6a78b55ed59740d143a79fd84cb7a2bc34fd76a9a3c6e6
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/check-sync-module-dependencies.yml
+++ b/.github/workflows/check-sync-module-dependencies.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.25.x'
+          go-version-file: go.mod
 
       - name: Run tests
         run: |

--- a/.github/workflows/publish-alloy-linux.yml
+++ b/.github/workflows/publish-alloy-linux.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   publish_linux_container:
     name: Publish Alloy Linux container
-    container: grafana/alloy-build-image:v0.1.29@sha256:2500d89efb3bc1cf0a94a00a197ec0f316cc409b7fc031a8de0f6092a782bdd6
+    container: grafana/alloy-build-image:v0.1.30@sha256:5ec4c2b765b604d71a6a78b55ed59740d143a79fd84cb7a2bc34fd76a9a3c6e6
     runs-on:
       labels: github-hosted-ubuntu-x64-large
     permissions:

--- a/.github/workflows/release-publish-alloy-artifacts.yml
+++ b/.github/workflows/release-publish-alloy-artifacts.yml
@@ -76,7 +76,7 @@ jobs:
 
   build_alloy:
     name: Build Alloy
-    container: grafana/alloy-build-image:v0.1.29@sha256:2500d89efb3bc1cf0a94a00a197ec0f316cc409b7fc031a8de0f6092a782bdd6
+    container: grafana/alloy-build-image:v0.1.30@sha256:5ec4c2b765b604d71a6a78b55ed59740d143a79fd84cb7a2bc34fd76a9a3c6e6
     runs-on:
       labels: github-hosted-ubuntu-x64-large
     needs:
@@ -156,7 +156,7 @@ jobs:
 
   build_alloy_windows_installer:
     name: Build Alloy Windows installer with signed executables
-    container: grafana/alloy-build-image:v0.1.29@sha256:2500d89efb3bc1cf0a94a00a197ec0f316cc409b7fc031a8de0f6092a782bdd6
+    container: grafana/alloy-build-image:v0.1.30@sha256:5ec4c2b765b604d71a6a78b55ed59740d143a79fd84cb7a2bc34fd76a9a3c6e6
     runs-on:
       labels: github-hosted-ubuntu-x64-large
     needs:
@@ -234,7 +234,7 @@ jobs:
 
   upload_release_artifacts:
     name: Upload release artifacts
-    container: grafana/alloy-build-image:v0.1.29@sha256:2500d89efb3bc1cf0a94a00a197ec0f316cc409b7fc031a8de0f6092a782bdd6
+    container: grafana/alloy-build-image:v0.1.30@sha256:5ec4c2b765b604d71a6a78b55ed59740d143a79fd84cb7a2bc34fd76a9a3c6e6
     runs-on:
       labels: github-hosted-ubuntu-x64-large
     needs:

--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -15,7 +15,7 @@ jobs:
     name: Test (Full)
     runs-on: ubuntu-latest-8-cores
     container:
-      image: grafana/alloy-build-image:v0.1.29@sha256:2500d89efb3bc1cf0a94a00a197ec0f316cc409b7fc031a8de0f6092a782bdd6
+      image: grafana/alloy-build-image:v0.1.30@sha256:5ec4c2b765b604d71a6a78b55ed59740d143a79fd84cb7a2bc34fd76a9a3c6e6
       volumes:
         - /var/run/docker.sock
     steps:

--- a/.github/workflows/test_linux_system_packages.yml
+++ b/.github/workflows/test_linux_system_packages.yml
@@ -17,7 +17,7 @@ jobs:
     name: Test Linux system packages
     runs-on: ubuntu-latest
     container:
-      image: grafana/alloy-build-image:v0.1.29@sha256:2500d89efb3bc1cf0a94a00a197ec0f316cc409b7fc031a8de0f6092a782bdd6
+      image: grafana/alloy-build-image:v0.1.30@sha256:5ec4c2b765b604d71a6a78b55ed59740d143a79fd84cb7a2bc34fd76a9a3c6e6
       volumes:
         - /var/run/docker.sock
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
 # in environment variables.
 
-FROM --platform=$BUILDPLATFORM grafana/alloy-build-image:v0.1.29@sha256:2500d89efb3bc1cf0a94a00a197ec0f316cc409b7fc031a8de0f6092a782bdd6 AS ui-build
+FROM --platform=$BUILDPLATFORM grafana/alloy-build-image:v0.1.30@sha256:5ec4c2b765b604d71a6a78b55ed59740d143a79fd84cb7a2bc34fd76a9a3c6e6 AS ui-build
 ARG BUILDPLATFORM
 COPY ./internal/web/ui /ui
 WORKDIR /ui
@@ -12,7 +12,7 @@ RUN --mount=type=cache,target=/ui/node_modules,sharing=locked \
     npm install                                               \
     && npm run build
 
-FROM --platform=$BUILDPLATFORM grafana/alloy-build-image:v0.1.29@sha256:2500d89efb3bc1cf0a94a00a197ec0f316cc409b7fc031a8de0f6092a782bdd6 AS build
+FROM --platform=$BUILDPLATFORM grafana/alloy-build-image:v0.1.30@sha256:5ec4c2b765b604d71a6a78b55ed59740d143a79fd84cb7a2bc34fd76a9a3c6e6 AS build
 
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM

--- a/collector/go.mod
+++ b/collector/go.mod
@@ -2,7 +2,7 @@
 
 module github.com/grafana/alloy/otel_engine
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/grafana/alloy v0.0.0-00010101000000-000000000000

--- a/example/docker-compose/images/grizzly/Dockerfile
+++ b/example/docker-compose/images/grizzly/Dockerfile
@@ -1,3 +1,3 @@
-FROM golang:1.25.8-alpine@sha256:d4c4845f5d60c6a974c6000ce58ae079328d03ab7f721a0734277e69905473e5
+FROM golang:1.25.9-alpine@sha256:d4c4845f5d60c6a974c6000ce58ae079328d03ab7f721a0734277e69905473e5
 
 RUN go install github.com/grafana/grizzly/cmd/grr@v0.7.1

--- a/example/docker-compose/images/grizzly/Dockerfile
+++ b/example/docker-compose/images/grizzly/Dockerfile
@@ -1,3 +1,3 @@
-FROM golang:1.25.9-alpine@sha256:d4c4845f5d60c6a974c6000ce58ae079328d03ab7f721a0734277e69905473e5
+FROM golang:1.25.9-alpine@sha256:7a00384194cf2cb68924bbb918d675f1517357433c8541bac0ab2f929b9d5447
 
 RUN go install github.com/grafana/grizzly/cmd/grr@v0.7.1

--- a/example/docker-compose/images/jb/Dockerfile
+++ b/example/docker-compose/images/jb/Dockerfile
@@ -1,3 +1,3 @@
-FROM golang:1.25.9-alpine@sha256:d4c4845f5d60c6a974c6000ce58ae079328d03ab7f721a0734277e69905473e5
+FROM golang:1.25.9-alpine@sha256:7a00384194cf2cb68924bbb918d675f1517357433c8541bac0ab2f929b9d5447
 
 RUN go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.5.1

--- a/example/docker-compose/images/jb/Dockerfile
+++ b/example/docker-compose/images/jb/Dockerfile
@@ -1,3 +1,3 @@
-FROM golang:1.25.8-alpine@sha256:d4c4845f5d60c6a974c6000ce58ae079328d03ab7f721a0734277e69905473e5
+FROM golang:1.25.9-alpine@sha256:d4c4845f5d60c6a974c6000ce58ae079328d03ab7f721a0734277e69905473e5
 
 RUN go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.5.1

--- a/extension/alloyengine/go.mod
+++ b/extension/alloyengine/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/alloy/extension/alloyengine
 
-go 1.25.8
+go 1.25.9
 
 replace github.com/grafana/alloy => ../..
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/alloy
 
-go 1.25.8
+go 1.25.9
 
 // This local replace is required for local development and testing of the syntax submodule.
 // It is intentionally kept outside the generated block to avoid being overwritten by dependency management tools.

--- a/integration-tests/docker/configs/kafka/Dockerfile
+++ b/integration-tests/docker/configs/kafka/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.8@sha256:c83e68f3ebb6943a2904fa66348867d108119890a2c6a2e6f07b38d0eb6c25c5 as build
+FROM golang:1.25.9@sha256:c83e68f3ebb6943a2904fa66348867d108119890a2c6a2e6f07b38d0eb6c25c5 as build
 WORKDIR /app/
 COPY go.mod go.sum ./
 COPY syntax/go.mod syntax/go.sum ./syntax/

--- a/integration-tests/docker/configs/kafka/Dockerfile
+++ b/integration-tests/docker/configs/kafka/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.9@sha256:c83e68f3ebb6943a2904fa66348867d108119890a2c6a2e6f07b38d0eb6c25c5 as build
+FROM golang:1.25.9@sha256:5ab234a9519e05043f4a97a505a59f21dc40eee172d6b17d411863d6bba599bb as build
 WORKDIR /app/
 COPY go.mod go.sum ./
 COPY syntax/go.mod syntax/go.sum ./syntax/

--- a/integration-tests/docker/configs/otel-gen/Dockerfile
+++ b/integration-tests/docker/configs/otel-gen/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.8@sha256:c83e68f3ebb6943a2904fa66348867d108119890a2c6a2e6f07b38d0eb6c25c5 as build
+FROM golang:1.25.9@sha256:c83e68f3ebb6943a2904fa66348867d108119890a2c6a2e6f07b38d0eb6c25c5 as build
 WORKDIR /app/
 COPY go.mod go.sum ./
 COPY syntax/go.mod syntax/go.sum ./syntax/

--- a/integration-tests/docker/configs/otel-gen/Dockerfile
+++ b/integration-tests/docker/configs/otel-gen/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.9@sha256:c83e68f3ebb6943a2904fa66348867d108119890a2c6a2e6f07b38d0eb6c25c5 as build
+FROM golang:1.25.9@sha256:5ab234a9519e05043f4a97a505a59f21dc40eee172d6b17d411863d6bba599bb as build
 WORKDIR /app/
 COPY go.mod go.sum ./
 COPY syntax/go.mod syntax/go.sum ./syntax/

--- a/integration-tests/docker/configs/prom-gen/Dockerfile
+++ b/integration-tests/docker/configs/prom-gen/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.8@sha256:c83e68f3ebb6943a2904fa66348867d108119890a2c6a2e6f07b38d0eb6c25c5 as build
+FROM golang:1.25.9@sha256:c83e68f3ebb6943a2904fa66348867d108119890a2c6a2e6f07b38d0eb6c25c5 as build
 WORKDIR /app/
 COPY go.mod go.sum ./
 COPY syntax/go.mod syntax/go.sum ./syntax/

--- a/integration-tests/docker/configs/prom-gen/Dockerfile
+++ b/integration-tests/docker/configs/prom-gen/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.9@sha256:c83e68f3ebb6943a2904fa66348867d108119890a2c6a2e6f07b38d0eb6c25c5 as build
+FROM golang:1.25.9@sha256:5ab234a9519e05043f4a97a505a59f21dc40eee172d6b17d411863d6bba599bb as build
 WORKDIR /app/
 COPY go.mod go.sum ./
 COPY syntax/go.mod syntax/go.sum ./syntax/

--- a/syntax/go.mod
+++ b/syntax/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/alloy/syntax
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/tools/generate-module-dependencies/go.mod
+++ b/tools/generate-module-dependencies/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/replace-generator
 
-go 1.25.8
+go 1.25.9
 
 require gopkg.in/yaml.v3 v3.0.1
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/alloy/tools
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/google/go-github/v57 v57.0.0


### PR DESCRIPTION
Follow-up PR to update Go with bug and security fixes:

* CVE-2026-32282
* CVE-2026-32289
* CVE-2026-33810
* CVE-2026-27144
* CVE-2026-27143
* CVE-2026-32288
* CVE-2026-32283
* CVE-2026-27140

See: https://github.com/grafana/alloy/pull/6012