### PR TITLE
fix(prometheus.exporter.postgres): Close DB connections on update

### DIFF
--- a/internal/static/integrations/postgres_exporter/postgres_exporter.go
+++ b/internal/static/integrations/postgres_exporter/postgres_exporter.go
@@ -2,6 +2,7 @@
 package postgres_exporter
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -177,9 +178,20 @@ func New(log log.Logger, cfg *Config) (integrations.Integration, error) {
 		postgres_exporter.WithMetricPrefix("pg"),
 	)
 
+	run := func(ctx context.Context) error {
+		<-ctx.Done()
+		e.CloseServers()
+		return nil
+
+	}
+
 	if cfg.DisableDefaultMetrics {
 		// Don't include the collector metrics if the default metrics are disabled.
-		return integrations.NewCollectorIntegration(cfg.Name(), integrations.WithCollectors(e)), nil
+		return integrations.NewCollectorIntegration(
+			cfg.Name(),
+			integrations.WithCollectors(e),
+			integrations.WithRunner(run),
+		), nil
 	}
 
 	// Build per-instance collector options.
@@ -211,5 +223,9 @@ func New(log log.Logger, cfg *Config) (integrations.Integration, error) {
 		return nil, fmt.Errorf("failed to create postgres_exporter collector: %w", err)
 	}
 
-	return integrations.NewCollectorIntegration(cfg.Name(), integrations.WithCollectors(e, c)), nil
+	return integrations.NewCollectorIntegration(
+		cfg.Name(),
+		integrations.WithCollectors(e, c),
+		integrations.WithRunner(run),
+	), nil
 }

--- a/internal/static/integrations/postgres_exporter/postgres_exporter.go
+++ b/internal/static/integrations/postgres_exporter/postgres_exporter.go
@@ -182,7 +182,6 @@ func New(log log.Logger, cfg *Config) (integrations.Integration, error) {
 		<-ctx.Done()
 		e.CloseServers()
 		return nil
-
 	}
 
 	if cfg.DisableDefaultMetrics {


### PR DESCRIPTION
### Pull Request Details

Close previous postgres exporter on update so replaced exporter instances do not keep stale database pools alive.

When a config update is triggered for exporters we create a [new exporter](https://github.com/grafana/alloy/blob/d2ae8b82e5d751a9c6a6055af01aed0ea2339b2a/internal/component/prometheus/exporter/exporter.go#L88)  and trigger reload which will [cancel the context passed to the previous exporter](https://github.com/grafana/alloy/blob/d2ae8b82e5d751a9c6a6055af01aed0ea2339b2a/internal/component/prometheus/exporter/exporter.go#L63). The problem here is that postgres exporter was using the default run function for exporter i.e. do nothing when context is canceled. So we need pass a custom run that will close all open connections.

### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->

### Notes to the Reviewer


### PR Checklist

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
