### PR TITLE
fix(pyroscope): Set user agent on debuginfo connect-go client

### DIFF
--- a/internal/component/pyroscope/write/write.go
+++ b/internal/component/pyroscope/write/write.go
@@ -283,7 +283,7 @@ func newFanOut(logger log.Logger, tracer trace.Tracer, config Arguments, metrics
 			return nil, err
 		}
 
-		debugInfoConnect := debuginfov1alpha1connect.NewDebuginfoServiceClient(h2Client, endpoint.URL)
+		debugInfoConnect := debuginfov1alpha1connect.NewDebuginfoServiceClient(h2Client, endpoint.URL, WithUserAgent(userAgent))
 		debugInfo := debuginfo.NewClient(logger, debugInfoConnect, metrics.debugInfoUploadBytes, endpointDataPath)
 
 		endpoints = append(endpoints, &endpointClient{


### PR DESCRIPTION
The debuginfo upload client was missing a `WithUserAgent` option, unlike the push client which already sets it. This makes server-side request attribution and debugging easier.

One-line change: pass `WithUserAgent(userAgent)` to `debuginfov1alpha1connect.NewDebuginfoServiceClient`, matching how the push client is constructed on the next line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Reviewed-By: Claude Opus 4.6 (1M context)