### PR TITLE
feat(loki.source.file): Add option to set `max_line_size`

### DIFF
--- a/docs/sources/reference/components/loki/loki.source.file.md
+++ b/docs/sources/reference/components/loki/loki.source.file.md
@@ -45,12 +45,15 @@ You can use the following arguments with `loki.source.file`:
 | `targets`                 | `list(map(string))`  | List of files to read from.                                    |                            | yes      |
 | `encoding`                | `string`             | The encoding to convert from when reading files.               | `""`                       | no       |
 | `legacy_positions_file`   | `string`             | Allows conversion from legacy positions file.                  | `""`                       | no       |
+| `max_line_size`           | `string`             | Maximum size of a single emitted log line.                     | `"1MiB"`                   | no       |
 | `on_positions_file_error` | `string`             | How to handle a corrupt positions file entry for a given file. | `"restart_from_beginning"` | no       |
 | `tail_from_end`           | `bool`               | Whether to tail from end if a stored position isn't found.     | `false`                    | no       |
 
 The `encoding` argument must be a valid [IANA encoding][] name and if not set, it defaults to UTF-8. {{< param "PRODUCT_NAME" >}} can automatically change
 the encoding to `UTF-16` if the file includes a Byte Order Mark (BOM) for either `UTF-16BE` or `UTF-16LE`.
 The BOM will be taken into account even if {{< param "PRODUCT_NAME" >}} resumes tailing a file from the middle of the file. This can happen after {{< param "PRODUCT_NAME" >}} is restarted.
+
+The `max_line_size` argument limits the size of a single emitted log line. If a line grows beyond this limit before a newline is encountered, {{< param "PRODUCT_NAME" >}} emits the first `max_line_size` bytes and continues reading the remainder on subsequent reads. Set `max_line_size` to `0` to disable this limit.
 
 You can use the `tail_from_end` argument when you want to tail a large file without reading its entire content.
 When set to true, only new logs are read, ignoring the existing ones.

--- a/docs/sources/reference/components/loki/loki.source.file.md
+++ b/docs/sources/reference/components/loki/loki.source.file.md
@@ -53,7 +53,9 @@ The `encoding` argument must be a valid [IANA encoding][] name and if not set, i
 the encoding to `UTF-16` if the file includes a Byte Order Mark (BOM) for either `UTF-16BE` or `UTF-16LE`.
 The BOM will be taken into account even if {{< param "PRODUCT_NAME" >}} resumes tailing a file from the middle of the file. This can happen after {{< param "PRODUCT_NAME" >}} is restarted.
 
-The `max_line_size` argument limits the size of a single emitted log line. If a line grows beyond this limit before a newline is encountered, {{< param "PRODUCT_NAME" >}} emits the first `max_line_size` bytes and continues reading the remainder on subsequent reads. Set `max_line_size` to `0` to disable this limit.
+The `max_line_size` argument limits the size of a single emitted log line.
+If a line grows beyond this limit before a newline is encountered, {{< param "PRODUCT_NAME" >}} emits the first `max_line_size` bytes and continues reading the remainder on subsequent reads.
+Set `max_line_size` to `0` to disable this limit.
 
 You can use the `tail_from_end` argument when you want to tail a large file without reading its entire content.
 When set to true, only new logs are read, ignoring the existing ones.

--- a/docs/sources/reference/components/loki/loki.source.file.md
+++ b/docs/sources/reference/components/loki/loki.source.file.md
@@ -45,16 +45,12 @@ You can use the following arguments with `loki.source.file`:
 | `targets`                 | `list(map(string))`  | List of files to read from.                                    |                            | yes      |
 | `encoding`                | `string`             | The encoding to convert from when reading files.               | `""`                       | no       |
 | `legacy_positions_file`   | `string`             | Allows conversion from legacy positions file.                  | `""`                       | no       |
-| `max_line_size`           | `string`             | Maximum size of a single emitted log line.                     | `"1MiB"`                   | no       |
 | `on_positions_file_error` | `string`             | How to handle a corrupt positions file entry for a given file. | `"restart_from_beginning"` | no       |
 | `tail_from_end`           | `bool`               | Whether to tail from end if a stored position isn't found.     | `false`                    | no       |
 
 The `encoding` argument must be a valid [IANA encoding][] name and if not set, it defaults to UTF-8. {{< param "PRODUCT_NAME" >}} can automatically change
 the encoding to `UTF-16` if the file includes a Byte Order Mark (BOM) for either `UTF-16BE` or `UTF-16LE`.
 The BOM will be taken into account even if {{< param "PRODUCT_NAME" >}} resumes tailing a file from the middle of the file. This can happen after {{< param "PRODUCT_NAME" >}} is restarted.
-
-The `max_line_size` argument limits the size of a single emitted log line, set to `0` disable.
-If a line grows beyond this limit before a newline is encountered, {{< param "PRODUCT_NAME" >}} emits the first `max_line_size` bytes and continues reading the remainder on subsequent reads.
 
 You can use the `tail_from_end` argument when you want to tail a large file without reading its entire content.
 When set to true, only new logs are read, ignoring the existing ones.
@@ -84,10 +80,12 @@ You can use the following blocks with `loki.source.file`:
 | [`decompression`][decompression] | Configure reading logs from compressed files.                                | no       |
 | [`file_match`][file_match]       | Configure file discovery using glob patterns for automatic target discovery. | no       |
 | [`file_watch`][file_watch]       | Configure how often files should be polled from disk for changes.            | no       |
+| [`line`][line]                   | Configure how individual log lines are read and processed.                   | no       |
 
 [decompression]: #decompression
 [file_watch]: #file_watch
 [file_match]: #file_match
+[line]: #line
 
 {{< /docs/alloy-config >}}
 
@@ -154,6 +152,18 @@ The glob patterns support the `{a,b,c}` syntax for matching multiple alternative
 
 * `/tmp/*.{log,txt,json}` matches files with `.log`, `.txt`, or `.json` extensions.
 * `/var/log/{nginx,apache}/*.log` matches `.log` files in either the `nginx` or `apache` subdirectories.
+
+### `line`
+
+The `line` block configures how individual log lines are read and processed.
+The following arguments are supported:
+
+| Name       | Type     | Description                                | Default  | Required |
+|------------|----------|--------------------------------------------|----------|----------|
+| `max_size` | `string` | Maximum size of a single emitted log line. | `"1MiB"` | no       |
+
+The `max_size` argument limits the size of a single emitted log line. Set to `0` to disable.
+If a line grows beyond this limit before a newline is encountered, {{< param "PRODUCT_NAME" >}} emits the first `max_size` bytes and continues reading the remainder on subsequent reads.
 
 ## Exported fields
 

--- a/docs/sources/reference/components/loki/loki.source.file.md
+++ b/docs/sources/reference/components/loki/loki.source.file.md
@@ -50,7 +50,8 @@ You can use the following arguments with `loki.source.file`:
 
 The `encoding` argument must be a valid [IANA encoding][] name and if not set, it defaults to UTF-8. {{< param "PRODUCT_NAME" >}} can automatically change
 the encoding to `UTF-16` if the file includes a Byte Order Mark (BOM) for either `UTF-16BE` or `UTF-16LE`.
-The BOM will be taken into account even if {{< param "PRODUCT_NAME" >}} resumes tailing a file from the middle of the file. This can happen after {{< param "PRODUCT_NAME" >}} is restarted.
+The BOM is taken into account even if {{< param "PRODUCT_NAME" >}} resumes tailing a file from the middle of the file.
+This can happen after {{< param "PRODUCT_NAME" >}} is restarted.
 
 You can use the `tail_from_end` argument when you want to tail a large file without reading its entire content.
 When set to true, only new logs are read, ignoring the existing ones.

--- a/docs/sources/reference/components/loki/loki.source.file.md
+++ b/docs/sources/reference/components/loki/loki.source.file.md
@@ -45,7 +45,7 @@ You can use the following arguments with `loki.source.file`:
 | `targets`                 | `list(map(string))`  | List of files to read from.                                    |                            | yes      |
 | `encoding`                | `string`             | The encoding to convert from when reading files.               | `""`                       | no       |
 | `legacy_positions_file`   | `string`             | Allows conversion from legacy positions file.                  | `""`                       | no       |
-| `max_line_size`           | `string`             | Maximum size of a single emitted log line.                     | `"1MiB"`                   | no       |
+| `max_line_size`           | `string`             | Maximum size of a single emitted log line.                     | `""`                       | no       |
 | `on_positions_file_error` | `string`             | How to handle a corrupt positions file entry for a given file. | `"restart_from_beginning"` | no       |
 | `tail_from_end`           | `bool`               | Whether to tail from end if a stored position isn't found.     | `false`                    | no       |
 
@@ -53,9 +53,8 @@ The `encoding` argument must be a valid [IANA encoding][] name and if not set, i
 the encoding to `UTF-16` if the file includes a Byte Order Mark (BOM) for either `UTF-16BE` or `UTF-16LE`.
 The BOM will be taken into account even if {{< param "PRODUCT_NAME" >}} resumes tailing a file from the middle of the file. This can happen after {{< param "PRODUCT_NAME" >}} is restarted.
 
-The `max_line_size` argument limits the size of a single emitted log line.
+The `max_line_size` argument limits the size of a single emitted log line, by default this is set to `0` mening it's disabled.
 If a line grows beyond this limit before a newline is encountered, {{< param "PRODUCT_NAME" >}} emits the first `max_line_size` bytes and continues reading the remainder on subsequent reads.
-Set `max_line_size` to `0` to disable this limit.
 
 You can use the `tail_from_end` argument when you want to tail a large file without reading its entire content.
 When set to true, only new logs are read, ignoring the existing ones.

--- a/docs/sources/reference/components/loki/loki.source.file.md
+++ b/docs/sources/reference/components/loki/loki.source.file.md
@@ -45,7 +45,7 @@ You can use the following arguments with `loki.source.file`:
 | `targets`                 | `list(map(string))`  | List of files to read from.                                    |                            | yes      |
 | `encoding`                | `string`             | The encoding to convert from when reading files.               | `""`                       | no       |
 | `legacy_positions_file`   | `string`             | Allows conversion from legacy positions file.                  | `""`                       | no       |
-| `max_line_size`           | `string`             | Maximum size of a single emitted log line.                     | `""`                       | no       |
+| `max_line_size`           | `string`             | Maximum size of a single emitted log line.                     | `"1MiB"`                   | no       |
 | `on_positions_file_error` | `string`             | How to handle a corrupt positions file entry for a given file. | `"restart_from_beginning"` | no       |
 | `tail_from_end`           | `bool`               | Whether to tail from end if a stored position isn't found.     | `false`                    | no       |
 
@@ -53,7 +53,7 @@ The `encoding` argument must be a valid [IANA encoding][] name and if not set, i
 the encoding to `UTF-16` if the file includes a Byte Order Mark (BOM) for either `UTF-16BE` or `UTF-16LE`.
 The BOM will be taken into account even if {{< param "PRODUCT_NAME" >}} resumes tailing a file from the middle of the file. This can happen after {{< param "PRODUCT_NAME" >}} is restarted.
 
-The `max_line_size` argument limits the size of a single emitted log line, by default this is set to `0` mening it's disabled.
+The `max_line_size` argument limits the size of a single emitted log line, set to `0` disable.
 If a line grows beyond this limit before a newline is encountered, {{< param "PRODUCT_NAME" >}} emits the first `max_line_size` bytes and continues reading the remainder on subsequent reads.
 
 You can use the `tail_from_end` argument when you want to tail a large file without reading its entire content.

--- a/internal/component/loki/source/file/file.go
+++ b/internal/component/loki/source/file/file.go
@@ -358,6 +358,7 @@ func (c *Component) scheduleSources() {
 					decompressionConfig:  c.args.DecompressionConfig,
 					fileWatch:            c.args.FileWatch,
 					tailFromEnd:          c.args.TailFromEnd,
+					maxLineSize:          int(c.args.MaxLineSize),
 					onPositionsFileError: c.args.OnPositionsFileError,
 					legacyPositionUsed:   c.args.LegacyPositionsFile != "",
 				},

--- a/internal/component/loki/source/file/file.go
+++ b/internal/component/loki/source/file/file.go
@@ -84,7 +84,7 @@ func (o *OnPositionsFileError) UnmarshalText(text []byte) error {
 func (a *Arguments) SetToDefault() {
 	a.FileWatch.SetToDefault()
 	a.FileMatch.SetToDefault()
-	a.MaxLineSize = 0
+	a.MaxLineSize = 1 * units.MiB
 	a.OnPositionsFileError = OnPositionsFileErrorRestartBeginning
 }
 

--- a/internal/component/loki/source/file/file.go
+++ b/internal/component/loki/source/file/file.go
@@ -84,7 +84,7 @@ func (o *OnPositionsFileError) UnmarshalText(text []byte) error {
 func (a *Arguments) SetToDefault() {
 	a.FileWatch.SetToDefault()
 	a.FileMatch.SetToDefault()
-	a.MaxLineSize = 1 * units.MiB
+	a.MaxLineSize = 0
 	a.OnPositionsFileError = OnPositionsFileErrorRestartBeginning
 }
 

--- a/internal/component/loki/source/file/file.go
+++ b/internal/component/loki/source/file/file.go
@@ -13,8 +13,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/alecthomas/units"
 	"github.com/grafana/dskit/backoff"
-	"github.com/prometheus/common/model"
 	"go.uber.org/atomic"
 
 	"github.com/grafana/alloy/internal/component"
@@ -49,11 +49,12 @@ type Arguments struct {
 	Targets              []discovery.Target   `alloy:"targets,attr"`
 	ForwardTo            []loki.LogsReceiver  `alloy:"forward_to,attr"`
 	Encoding             string               `alloy:"encoding,attr,optional"`
-	DecompressionConfig  DecompressionConfig  `alloy:"decompression,block,optional"`
+	TailFromEnd          bool                 `alloy:"tail_from_end,attr,optional"`
+	MaxLineSize          units.Base2Bytes     `alloy:"max_line_size,attr,optional"`
 	FileWatch            FileWatch            `alloy:"file_watch,block,optional"`
 	FileMatch            FileMatch            `alloy:"file_match,block,optional"`
-	TailFromEnd          bool                 `alloy:"tail_from_end,attr,optional"`
 	LegacyPositionsFile  string               `alloy:"legacy_positions_file,attr,optional"`
+	DecompressionConfig  DecompressionConfig  `alloy:"decompression,block,optional"`
 	OnPositionsFileError OnPositionsFileError `alloy:"on_positions_file_error,attr,optional"`
 }
 
@@ -83,6 +84,7 @@ func (o *OnPositionsFileError) UnmarshalText(text []byte) error {
 func (a *Arguments) SetToDefault() {
 	a.FileWatch.SetToDefault()
 	a.FileMatch.SetToDefault()
+	a.MaxLineSize = 1 * units.MiB
 	a.OnPositionsFileError = OnPositionsFileErrorRestartBeginning
 }
 
@@ -343,16 +345,33 @@ func (c *Component) scheduleSources() {
 
 			c.metrics.totalBytes.WithLabelValues(target.Path).Set(float64(fi.Size()))
 
-			return c.newSource(sourceOptions{
-				path:                 target.Path,
-				labels:               target.Labels,
-				encoding:             c.args.Encoding,
-				decompressionConfig:  c.args.DecompressionConfig,
-				fileWatch:            c.args.FileWatch,
-				tailFromEnd:          c.args.TailFromEnd,
-				onPositionsFileError: c.args.OnPositionsFileError,
-				legacyPositionUsed:   c.args.LegacyPositionsFile != "",
-			})
+			tailer := newTailer(
+				c.metrics,
+				c.opts.SLogger,
+				c.handler,
+				c.posFile,
+				c.IsStopping,
+				tailerOptions{
+					path:                 target.Path,
+					labels:               target.Labels,
+					encoding:             c.args.Encoding,
+					decompressionConfig:  c.args.DecompressionConfig,
+					fileWatch:            c.args.FileWatch,
+					tailFromEnd:          c.args.TailFromEnd,
+					onPositionsFileError: c.args.OnPositionsFileError,
+					legacyPositionUsed:   c.args.LegacyPositionsFile != "",
+				},
+			)
+
+			// When decompression is enabled we don't wrap it with retries.
+			if c.args.DecompressionConfig.Enabled {
+				return tailer, nil
+			}
+
+			return source.NewSourceWithRetry(tailer, backoff.Config{
+				MinBackoff: 1 * time.Second,
+				MaxBackoff: 10 * time.Second,
+			}), nil
 		},
 	)
 }
@@ -382,39 +401,6 @@ func (c *Component) DebugInfo() any {
 		}
 	}
 	return res
-}
-
-type sourceOptions struct {
-	path                 string
-	labels               model.LabelSet
-	encoding             string
-	decompressionConfig  DecompressionConfig
-	fileWatch            FileWatch
-	tailFromEnd          bool
-	onPositionsFileError OnPositionsFileError
-	legacyPositionUsed   bool
-}
-
-// newSource will return a decompressor source if enabled, otherwise a tailer source.
-func (c *Component) newSource(opts sourceOptions) (source.Source[positions.Entry], error) {
-	tailer := newTailer(
-		c.metrics,
-		c.opts.SLogger,
-		c.handler,
-		c.posFile,
-		c.IsStopping,
-		opts,
-	)
-
-	// When decompression is enabled we don't retry starting tailer.
-	if opts.decompressionConfig.Enabled {
-		return tailer, nil
-	}
-
-	return source.NewSourceWithRetry(tailer, backoff.Config{
-		MinBackoff: 1 * time.Second,
-		MaxBackoff: 10 * time.Second,
-	}), nil
 }
 
 func (c *Component) IsStopping() bool {

--- a/internal/component/loki/source/file/file.go
+++ b/internal/component/loki/source/file/file.go
@@ -23,6 +23,7 @@ import (
 	"github.com/grafana/alloy/internal/component/loki/source"
 	"github.com/grafana/alloy/internal/component/loki/source/internal/positions"
 	"github.com/grafana/alloy/internal/featuregate"
+	"github.com/grafana/alloy/syntax"
 )
 
 func init() {
@@ -50,7 +51,7 @@ type Arguments struct {
 	ForwardTo            []loki.LogsReceiver  `alloy:"forward_to,attr"`
 	Encoding             string               `alloy:"encoding,attr,optional"`
 	TailFromEnd          bool                 `alloy:"tail_from_end,attr,optional"`
-	MaxLineSize          units.Base2Bytes     `alloy:"max_line_size,attr,optional"`
+	Line                 LineConfig           `alloy:"line,block,optional"`
 	FileWatch            FileWatch            `alloy:"file_watch,block,optional"`
 	FileMatch            FileMatch            `alloy:"file_match,block,optional"`
 	LegacyPositionsFile  string               `alloy:"legacy_positions_file,attr,optional"`
@@ -82,9 +83,9 @@ func (o *OnPositionsFileError) UnmarshalText(text []byte) error {
 }
 
 func (a *Arguments) SetToDefault() {
+	a.Line.SetToDefault()
 	a.FileWatch.SetToDefault()
 	a.FileMatch.SetToDefault()
-	a.MaxLineSize = 1 * units.MiB
 	a.OnPositionsFileError = OnPositionsFileErrorRestartBeginning
 }
 
@@ -135,6 +136,17 @@ func (d DecompressionConfig) GetFormat() string {
 		return d.Format.String()
 	}
 	return ""
+}
+
+var _ syntax.Defaulter = (*LineConfig)(nil)
+
+type LineConfig struct {
+	MaxSize units.Base2Bytes `alloy:"max_size,attr,optional"`
+}
+
+// SetToDefault implements syntax.Defaulter.
+func (l *LineConfig) SetToDefault() {
+	l.MaxSize = 1 * units.MiB
 }
 
 func supportedCompressedFormats() map[string]struct{} {
@@ -355,10 +367,10 @@ func (c *Component) scheduleSources() {
 					path:                 target.Path,
 					labels:               target.Labels,
 					encoding:             c.args.Encoding,
-					decompressionConfig:  c.args.DecompressionConfig,
 					fileWatch:            c.args.FileWatch,
 					tailFromEnd:          c.args.TailFromEnd,
-					maxLineSize:          int(c.args.MaxLineSize),
+					lineConfig:           c.args.Line,
+					decompressionConfig:  c.args.DecompressionConfig,
 					onPositionsFileError: c.args.OnPositionsFileError,
 					legacyPositionUsed:   c.args.LegacyPositionsFile != "",
 				},

--- a/internal/component/loki/source/file/file_test.go
+++ b/internal/component/loki/source/file/file_test.go
@@ -39,7 +39,10 @@ func Test_UnmarshalConfig(t *testing.T) {
 				forward_to = []
 				targets = []`,
 			expected: Arguments{
-				MaxLineSize: 1 * units.MiB,
+				Line: LineConfig{
+					MaxSize: 1 * units.MiB,
+				},
+
 				FileWatch: FileWatch{
 					MinPollFrequency: 250 * time.Millisecond,
 					MaxPollFrequency: 250 * time.Millisecond,
@@ -65,7 +68,9 @@ func Test_UnmarshalConfig(t *testing.T) {
 					sync_period = "14s"
 				}`,
 			expected: Arguments{
-				MaxLineSize: 1 * units.MiB,
+				Line: LineConfig{
+					MaxSize: 1 * units.MiB,
+				},
 				FileWatch: FileWatch{
 					MinPollFrequency: 250 * time.Millisecond,
 					MaxPollFrequency: 250 * time.Millisecond,
@@ -95,7 +100,9 @@ func Test_UnmarshalConfig(t *testing.T) {
 					sync_period = "14s"
 				}`,
 			expected: Arguments{
-				MaxLineSize: 1 * units.MiB,
+				Line: LineConfig{
+					MaxSize: 1 * units.MiB,
+				},
 				FileWatch: FileWatch{
 					MinPollFrequency: 250 * time.Millisecond,
 					MaxPollFrequency: 250 * time.Millisecond,

--- a/internal/component/loki/source/file/file_test.go
+++ b/internal/component/loki/source/file/file_test.go
@@ -12,6 +12,7 @@ import (
 	"testing/synctest"
 	"time"
 
+	"github.com/alecthomas/units"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
@@ -38,7 +39,7 @@ func Test_UnmarshalConfig(t *testing.T) {
 				forward_to = []
 				targets = []`,
 			expected: Arguments{
-				MaxLineSize: 0,
+				MaxLineSize: 1 * units.MiB,
 				FileWatch: FileWatch{
 					MinPollFrequency: 250 * time.Millisecond,
 					MaxPollFrequency: 250 * time.Millisecond,
@@ -64,7 +65,7 @@ func Test_UnmarshalConfig(t *testing.T) {
 					sync_period = "14s"
 				}`,
 			expected: Arguments{
-				MaxLineSize: 0,
+				MaxLineSize: 1 * units.MiB,
 				FileWatch: FileWatch{
 					MinPollFrequency: 250 * time.Millisecond,
 					MaxPollFrequency: 250 * time.Millisecond,
@@ -94,7 +95,7 @@ func Test_UnmarshalConfig(t *testing.T) {
 					sync_period = "14s"
 				}`,
 			expected: Arguments{
-				MaxLineSize: 0,
+				MaxLineSize: 1 * units.MiB,
 				FileWatch: FileWatch{
 					MinPollFrequency: 250 * time.Millisecond,
 					MaxPollFrequency: 250 * time.Millisecond,

--- a/internal/component/loki/source/file/file_test.go
+++ b/internal/component/loki/source/file/file_test.go
@@ -12,6 +12,7 @@ import (
 	"testing/synctest"
 	"time"
 
+	"github.com/alecthomas/units"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
@@ -38,6 +39,7 @@ func Test_UnmarshalConfig(t *testing.T) {
 				forward_to = []
 				targets = []`,
 			expected: Arguments{
+				MaxLineSize: 1 * units.MiB,
 				FileWatch: FileWatch{
 					MinPollFrequency: 250 * time.Millisecond,
 					MaxPollFrequency: 250 * time.Millisecond,
@@ -63,6 +65,7 @@ func Test_UnmarshalConfig(t *testing.T) {
 					sync_period = "14s"
 				}`,
 			expected: Arguments{
+				MaxLineSize: 1 * units.MiB,
 				FileWatch: FileWatch{
 					MinPollFrequency: 250 * time.Millisecond,
 					MaxPollFrequency: 250 * time.Millisecond,
@@ -92,6 +95,7 @@ func Test_UnmarshalConfig(t *testing.T) {
 					sync_period = "14s"
 				}`,
 			expected: Arguments{
+				MaxLineSize: 1 * units.MiB,
 				FileWatch: FileWatch{
 					MinPollFrequency: 250 * time.Millisecond,
 					MaxPollFrequency: 250 * time.Millisecond,

--- a/internal/component/loki/source/file/file_test.go
+++ b/internal/component/loki/source/file/file_test.go
@@ -12,7 +12,6 @@ import (
 	"testing/synctest"
 	"time"
 
-	"github.com/alecthomas/units"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
@@ -39,7 +38,7 @@ func Test_UnmarshalConfig(t *testing.T) {
 				forward_to = []
 				targets = []`,
 			expected: Arguments{
-				MaxLineSize: 1 * units.MiB,
+				MaxLineSize: 0,
 				FileWatch: FileWatch{
 					MinPollFrequency: 250 * time.Millisecond,
 					MaxPollFrequency: 250 * time.Millisecond,
@@ -65,7 +64,7 @@ func Test_UnmarshalConfig(t *testing.T) {
 					sync_period = "14s"
 				}`,
 			expected: Arguments{
-				MaxLineSize: 1 * units.MiB,
+				MaxLineSize: 0,
 				FileWatch: FileWatch{
 					MinPollFrequency: 250 * time.Millisecond,
 					MaxPollFrequency: 250 * time.Millisecond,
@@ -95,7 +94,7 @@ func Test_UnmarshalConfig(t *testing.T) {
 					sync_period = "14s"
 				}`,
 			expected: Arguments{
-				MaxLineSize: 1 * units.MiB,
+				MaxLineSize: 0,
 				FileWatch: FileWatch{
 					MinPollFrequency: 250 * time.Millisecond,
 					MaxPollFrequency: 250 * time.Millisecond,

--- a/internal/component/loki/source/file/internal/tail/config.go
+++ b/internal/component/loki/source/file/internal/tail/config.go
@@ -9,6 +9,9 @@ type Config struct {
 	// Filename is the path to the file to tail.
 	Filename string
 
+	// MaxLineSize is the max size in bytes that will be read as a single line.
+	MaxLineSize int
+
 	// Offset is the byte offset in the file where tailing should start.
 	// If 0, tailing starts from the beginning of the file.
 	Offset int64

--- a/internal/component/loki/source/file/internal/tail/file.go
+++ b/internal/component/loki/source/file/internal/tail/file.go
@@ -41,7 +41,7 @@ func NewFile(logger *slog.Logger, cfg *Config) (*File, error) {
 		return nil, err
 	}
 
-	reader, err := newReader(logger, f, cfg.Offset, encoding, cfg.Compression, cfg.StartFromEnd)
+	reader, err := newReader(logger, f, cfg.Offset, cfg.MaxLineSize, encoding, cfg.Compression, cfg.StartFromEnd)
 	if err != nil {
 		f.Close()
 		return nil, err

--- a/internal/component/loki/source/file/internal/tail/file_test.go
+++ b/internal/component/loki/source/file/internal/tail/file_test.go
@@ -68,6 +68,21 @@ func TestFile(t *testing.T) {
 		verifyResult(t, file, &Line{Text: "ij", Offset: 11}, nil)
 	})
 
+	t.Run("does not emit empty line when newline lands on split boundary", func(t *testing.T) {
+		name := createFile(t, "split-max-line-size-boundary", "abcdefgh\r\n")
+		defer removeFile(t, name)
+
+		file, err := NewFile(log.NewNopLogger(), &Config{
+			Filename:    name,
+			MaxLineSize: 4,
+		})
+		require.NoError(t, err)
+		defer file.Stop()
+
+		verifyResult(t, file, &Line{Text: "abcd", Offset: 4}, nil)
+		verifyResult(t, file, &Line{Text: "efgh", Offset: 10}, nil)
+	})
+
 	t.Run("splits oversized compressed final line", func(t *testing.T) {
 		fileName := createCompressedFile(t, "split-max-line-size.gz", "gz", strings.NewReader("abcdefghij"))
 		defer removeFile(t, fileName)

--- a/internal/component/loki/source/file/internal/tail/file_test.go
+++ b/internal/component/loki/source/file/internal/tail/file_test.go
@@ -69,6 +69,21 @@ func TestFile(t *testing.T) {
 	})
 
 	t.Run("does not emit empty line when newline lands on split boundary", func(t *testing.T) {
+		name := createFile(t, "split-max-line-size-boundary", "abcdefgh\n")
+		defer removeFile(t, name)
+
+		file, err := NewFile(log.NewNopLogger(), &Config{
+			Filename:    name,
+			MaxLineSize: 4,
+		})
+		require.NoError(t, err)
+		defer file.Stop()
+
+		verifyResult(t, file, &Line{Text: "abcd", Offset: 4}, nil)
+		verifyResult(t, file, &Line{Text: "efgh", Offset: 9}, nil)
+	})
+
+	t.Run("does not emit empty line when newline lands on split boundary with cr", func(t *testing.T) {
 		name := createFile(t, "split-max-line-size-boundary", "abcdefgh\r\n")
 		defer removeFile(t, name)
 

--- a/internal/component/loki/source/file/internal/tail/file_test.go
+++ b/internal/component/loki/source/file/internal/tail/file_test.go
@@ -52,6 +52,40 @@ func TestFile(t *testing.T) {
 		verifyResult(t, file, &Line{Text: "world", Offset: 4116}, nil)
 	})
 
+	t.Run("splits oversized line", func(t *testing.T) {
+		name := createFile(t, "split-max-line-size", "abcdefghij\n")
+		defer removeFile(t, name)
+
+		file, err := NewFile(log.NewNopLogger(), &Config{
+			Filename:    name,
+			MaxLineSize: 4,
+		})
+		require.NoError(t, err)
+		defer file.Stop()
+
+		verifyResult(t, file, &Line{Text: "abcd", Offset: 4}, nil)
+		verifyResult(t, file, &Line{Text: "efgh", Offset: 8}, nil)
+		verifyResult(t, file, &Line{Text: "ij", Offset: 11}, nil)
+	})
+
+	t.Run("splits oversized compressed final line", func(t *testing.T) {
+		fileName := createCompressedFile(t, "split-max-line-size.gz", "gz", strings.NewReader("abcdefghij"))
+		defer removeFile(t, fileName)
+
+		file, err := NewFile(log.NewNopLogger(), &Config{
+			Filename:    fileName,
+			Compression: "gz",
+			MaxLineSize: 4,
+		})
+		require.NoError(t, err)
+		defer file.Stop()
+
+		verifyResult(t, file, &Line{Text: "abcd", Offset: 4}, nil)
+		verifyResult(t, file, &Line{Text: "efgh", Offset: 8}, nil)
+		verifyResult(t, file, &Line{Text: "ij", Offset: 10}, nil)
+		verifyResult(t, file, nil, io.EOF)
+	})
+
 	t.Run("read", func(t *testing.T) {
 		name := createFile(t, "read", "hello\nworld\ntest\n")
 		defer removeFile(t, name)

--- a/internal/component/loki/source/file/internal/tail/file_test.go
+++ b/internal/component/loki/source/file/internal/tail/file_test.go
@@ -56,7 +56,7 @@ func TestFile(t *testing.T) {
 		name := createFile(t, "split-max-line-size", "abcdefghij\n")
 		defer removeFile(t, name)
 
-		file, err := NewFile(log.NewNopLogger(), &Config{
+		file, err := NewFile(logging.NewSlogNop(), &Config{
 			Filename:    name,
 			MaxLineSize: 4,
 		})
@@ -72,7 +72,7 @@ func TestFile(t *testing.T) {
 		name := createFile(t, "split-max-line-size-boundary", "abcdefgh\n")
 		defer removeFile(t, name)
 
-		file, err := NewFile(log.NewNopLogger(), &Config{
+		file, err := NewFile(logging.NewSlogNop(), &Config{
 			Filename:    name,
 			MaxLineSize: 4,
 		})
@@ -87,7 +87,7 @@ func TestFile(t *testing.T) {
 		name := createFile(t, "split-max-line-size-boundary", "abcdefgh\r\n")
 		defer removeFile(t, name)
 
-		file, err := NewFile(log.NewNopLogger(), &Config{
+		file, err := NewFile(logging.NewSlogNop(), &Config{
 			Filename:    name,
 			MaxLineSize: 4,
 		})
@@ -102,7 +102,7 @@ func TestFile(t *testing.T) {
 		fileName := createCompressedFile(t, "split-max-line-size.gz", "gz", strings.NewReader("abcdefghij"))
 		defer removeFile(t, fileName)
 
-		file, err := NewFile(log.NewNopLogger(), &Config{
+		file, err := NewFile(logging.NewSlogNop(), &Config{
 			Filename:    fileName,
 			Compression: "gz",
 			MaxLineSize: 4,

--- a/internal/component/loki/source/file/internal/tail/reader.go
+++ b/internal/component/loki/source/file/internal/tail/reader.go
@@ -147,10 +147,11 @@ func (r *reader) consumeLine() ([]byte, bool) {
 	}
 
 	i := bytes.Index(r.pending, r.nl)
+	hasCr := bytes.Index(r.pending, r.cr) > 0
 
 	// If we have a full line buffered within maxLineSize plus the optional carriage
 	// return bytes, emit the full line instead of splitting it into a boundary chunk.
-	if i >= 0 && r.fitsMaxLineSize(i, len(r.cr)) {
+	if i >= 0 && r.fitsMaxLineSize(i, hasCr) {
 		// Extract everything up until newline.
 		line := r.pending[:i]
 
@@ -163,7 +164,7 @@ func (r *reader) consumeLine() ([]byte, bool) {
 	}
 
 	// If we have buffered over maxLineSize we emit it as a line and advance position.
-	if !r.fitsMaxLineSize(len(r.pending), 0) {
+	if !r.fitsMaxLineSize(len(r.pending), false) {
 		// Here we need to copy the bytes because we reuse pending between calls.
 		partial := make([]byte, r.maxLineSize)
 		copy(partial, r.pending[:r.maxLineSize])
@@ -180,11 +181,14 @@ func (r *reader) consumeLine() ([]byte, bool) {
 	return nil, false
 }
 
-func (r *reader) fitsMaxLineSize(n, extra int) bool {
+func (r *reader) fitsMaxLineSize(n int, includeCR bool) bool {
 	if r.maxLineSize <= 0 {
 		return true
 	}
-	return n <= r.maxLineSize+extra
+	if includeCR {
+		return n <= r.maxLineSize+len(r.cr)
+	}
+	return n <= r.maxLineSize
 }
 
 // position returns the byte offset for completed lines,

--- a/internal/component/loki/source/file/internal/tail/reader.go
+++ b/internal/component/loki/source/file/internal/tail/reader.go
@@ -141,11 +141,6 @@ func (r *reader) decode(line []byte) (string, error) {
 // consumeLine checks pending for the delimiter; if found, it splits
 // pending into line and remainder.
 func (r *reader) consumeLine() ([]byte, bool) {
-	// If we have no pending data we need to read more.
-	if len(r.pending) == 0 {
-		return nil, false
-	}
-
 	i := bytes.Index(r.pending, r.nl)
 
 	// If we have a full line buffered within maxLineSize plus the optional carriage

--- a/internal/component/loki/source/file/internal/tail/reader.go
+++ b/internal/component/loki/source/file/internal/tail/reader.go
@@ -147,11 +147,10 @@ func (r *reader) consumeLine() ([]byte, bool) {
 	}
 
 	i := bytes.Index(r.pending, r.nl)
-	hasCr := bytes.Index(r.pending, r.cr) > 0
 
 	// If we have a full line buffered within maxLineSize plus the optional carriage
 	// return bytes, emit the full line instead of splitting it into a boundary chunk.
-	if i >= 0 && r.fitsMaxLineSize(i, hasCr) {
+	if i >= 0 && r.fitsMaxLineSize(r.pending[:i], true) {
 		// Extract everything up until newline.
 		line := r.pending[:i]
 
@@ -164,7 +163,9 @@ func (r *reader) consumeLine() ([]byte, bool) {
 	}
 
 	// If we have buffered over maxLineSize we emit it as a line and advance position.
-	if !r.fitsMaxLineSize(len(r.pending), false) {
+	// Do not include trailing CR bytes here, without a confirmed newline they are
+	// still part of the buffered data and may be followed by more content.
+	if !r.fitsMaxLineSize(r.pending, false) {
 		// Here we need to copy the bytes because we reuse pending between calls.
 		partial := make([]byte, r.maxLineSize)
 		copy(partial, r.pending[:r.maxLineSize])
@@ -181,14 +182,17 @@ func (r *reader) consumeLine() ([]byte, bool) {
 	return nil, false
 }
 
-func (r *reader) fitsMaxLineSize(n int, includeCR bool) bool {
+func (r *reader) fitsMaxLineSize(line []byte, includeCr bool) bool {
 	if r.maxLineSize <= 0 {
 		return true
 	}
-	if includeCR {
-		return n <= r.maxLineSize+len(r.cr)
+
+	maxLineSize := r.maxLineSize
+	if includeCr && bytes.HasSuffix(line, r.cr) {
+		maxLineSize += len(r.cr)
 	}
-	return n <= r.maxLineSize
+
+	return len(line) <= maxLineSize
 }
 
 // position returns the byte offset for completed lines,

--- a/internal/component/loki/source/file/internal/tail/reader.go
+++ b/internal/component/loki/source/file/internal/tail/reader.go
@@ -88,11 +88,11 @@ type reader struct {
 // next reads and returns the next complete line from the file.
 // It will return EOF if there is no more data to read.
 func (r *reader) next() (string, error) {
-	for {
-		if line, ok := r.consumeLine(); ok {
-			return r.decode(line)
-		}
+	if line, ok := r.consumeLine(); ok {
+		return r.decode(line)
+	}
 
+	for {
 		// Read more data up until the last byte of nl.
 		chunk, err := r.br.ReadSlice(r.lastNl)
 		if len(chunk) > 0 {
@@ -141,13 +141,29 @@ func (r *reader) decode(line []byte) (string, error) {
 // consumeLine checks pending for the delimiter; if found, it splits
 // pending into line and remainder.
 func (r *reader) consumeLine() ([]byte, bool) {
-	// IF we have no pending data we need more.
+	// If we have no pending data we need to read more.
 	if len(r.pending) == 0 {
 		return nil, false
 	}
 
+	i := bytes.Index(r.pending, r.nl)
+
+	// If we have a full line buffered within maxLineSize plus the optional carriage
+	// return bytes, emit the full line instead of splitting it into a boundary chunk.
+	if i >= 0 && r.fitsMaxLineSize(i, len(r.cr)) {
+		// Extract everything up until newline.
+		line := r.pending[:i]
+
+		// Reset pending. We never buffer beyond newline so it is safe to reset.
+		r.pending = r.pending[:0]
+
+		// Advance the position on bytes we have consumed.
+		r.pos += int64(len(line) + len(r.nl))
+		return line, true
+	}
+
 	// If we have buffered over maxLineSize we emit it as a line and advance position.
-	if r.maxLineSize > 0 && len(r.pending) >= r.maxLineSize {
+	if !r.fitsMaxLineSize(len(r.pending), 0) {
 		// Here we need to copy the bytes because we reuse pending between calls.
 		partial := make([]byte, r.maxLineSize)
 		copy(partial, r.pending[:r.maxLineSize])
@@ -161,20 +177,14 @@ func (r *reader) consumeLine() ([]byte, bool) {
 		return partial, true
 	}
 
-	// If we have a full line buffered we emit it and advance position.
-	if i := bytes.Index(r.pending, r.nl); i >= 0 {
-		// Extract everything up until newline.
-		line := r.pending[:i]
-
-		// Reset pending. We never buffer beyond newline so it is safe to reset.
-		r.pending = r.pending[:0]
-
-		// Advance the position on bytes we have consumed.
-		r.pos += int64(len(line) + len(r.nl))
-		return line, true
-	}
-
 	return nil, false
+}
+
+func (r *reader) fitsMaxLineSize(n, extra int) bool {
+	if r.maxLineSize <= 0 {
+		return true
+	}
+	return n <= r.maxLineSize+extra
 }
 
 // position returns the byte offset for completed lines,

--- a/internal/component/loki/source/file/internal/tail/reader.go
+++ b/internal/component/loki/source/file/internal/tail/reader.go
@@ -63,7 +63,7 @@ func newReader(logger *slog.Logger, f *os.File, offset int64, maxLineSize int, e
 		br:          bufio.NewReader(rr),
 		pos:         offset,
 		pending:     make([]byte, 0, defaultBufSize),
-		maxLineSize: maxLineSize,
+		maxLineSize: max(0, maxLineSize),
 		decoder:     decoder,
 		nl:          nl,
 		lastNl:      nl[len(nl)-1],

--- a/internal/component/loki/source/file/internal/tail/reader.go
+++ b/internal/component/loki/source/file/internal/tail/reader.go
@@ -19,7 +19,7 @@ const defaultBufSize = 4096
 
 // newReader creates a new reader that is used to read from file.
 // It is important that the provided file is positioned at the start of the file.
-func newReader(logger *slog.Logger, f *os.File, offset int64, enc encoding.Encoding, compression string, startFromEnd bool) (*reader, error) {
+func newReader(logger *slog.Logger, f *os.File, offset int64, maxLineSize int, enc encoding.Encoding, compression string, startFromEnd bool) (*reader, error) {
 	rr, err := newReaderAt(f, compression, 0)
 	if err != nil {
 		return nil, err
@@ -60,20 +60,22 @@ func newReader(logger *slog.Logger, f *os.File, offset int64, enc encoding.Encod
 	}
 
 	return &reader{
-		pos:     offset,
-		br:      bufio.NewReader(rr),
-		decoder: decoder,
-		nl:      nl,
-		lastNl:  nl[len(nl)-1],
-		cr:      cr,
-		pending: make([]byte, 0, defaultBufSize),
+		br:          bufio.NewReader(rr),
+		pos:         offset,
+		pending:     make([]byte, 0, defaultBufSize),
+		maxLineSize: maxLineSize,
+		decoder:     decoder,
+		nl:          nl,
+		lastNl:      nl[len(nl)-1],
+		cr:          cr,
 	}, nil
 }
 
 type reader struct {
-	pos     int64
-	br      *bufio.Reader
-	pending []byte
+	br          *bufio.Reader
+	pos         int64
+	pending     []byte
+	maxLineSize int
 
 	compression string
 	decoder     *encoding.Decoder
@@ -87,6 +89,10 @@ type reader struct {
 // It will return EOF if there is no more data to read.
 func (r *reader) next() (string, error) {
 	for {
+		if line, ok := r.consumeLine(); ok {
+			return r.decode(line)
+		}
+
 		// Read more data up until the last byte of nl.
 		chunk, err := r.br.ReadSlice(r.lastNl)
 		if len(chunk) > 0 {
@@ -135,21 +141,40 @@ func (r *reader) decode(line []byte) (string, error) {
 // consumeLine checks pending for the delimiter; if found, it splits
 // pending into line and remainder.
 func (r *reader) consumeLine() ([]byte, bool) {
-	// Check if pending contains a full line.
-	i := bytes.Index(r.pending, r.nl)
-	if i < 0 {
+	// IF we have no pending data we need more.
+	if len(r.pending) == 0 {
 		return nil, false
 	}
 
-	// Extract everything up until newline.
-	line := r.pending[:i]
+	// If we have buffered over maxLineSize we emit it as a line and advance position.
+	if r.maxLineSize > 0 && len(r.pending) >= r.maxLineSize {
+		// Here we need to copy the bytes because we reuse pending between calls.
+		partial := make([]byte, r.maxLineSize)
+		copy(partial, r.pending[:r.maxLineSize])
 
-	// Reset pending. We never buffer beyond newline so it is safe to reset.
-	r.pending = r.pending[:0]
+		// Copy remaning bytes to the beginning of the buffer.
+		n := copy(r.pending, r.pending[r.maxLineSize:])
+		r.pending = r.pending[:n]
 
-	// Advance the position on bytes we have consumed as a full line.
-	r.pos += int64(len(line) + len(r.nl))
-	return line, true
+		// Advance the position on the partial line we have consumed.
+		r.pos += int64(len(partial))
+		return partial, true
+	}
+
+	// If we have a full line buffered we emit it and advance position.
+	if i := bytes.Index(r.pending, r.nl); i >= 0 {
+		// Extract everything up until newline.
+		line := r.pending[:i]
+
+		// Reset pending. We never buffer beyond newline so it is safe to reset.
+		r.pending = r.pending[:0]
+
+		// Advance the position on bytes we have consumed.
+		r.pos += int64(len(line) + len(r.nl))
+		return line, true
+	}
+
+	return nil, false
 }
 
 // position returns the byte offset for completed lines,

--- a/internal/component/loki/source/file/legacy_file_test.go
+++ b/internal/component/loki/source/file/legacy_file_test.go
@@ -3,7 +3,6 @@
 package file
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -25,7 +24,6 @@ func TestLegacyConversion(t *testing.T) {
 
 	// create legacy position file
 	legacyPositionFilename := filepath.Join(tmpFileDir, "legacy.yaml")
-	fmt.Println(legacyPositionFilename)
 	legacy, err := os.Create(legacyPositionFilename)
 	require.NoError(t, err)
 

--- a/internal/component/loki/source/file/tailer.go
+++ b/internal/component/loki/source/file/tailer.go
@@ -29,23 +29,27 @@ type tailer struct {
 	receiver  loki.LogsReceiver
 	positions positions.Positions
 
-	key                positions.Entry
-	labels             model.LabelSet
-	legacyPositionUsed bool
+	opts   tailerOptions
+	key    positions.Entry
+	labels model.LabelSet
 
-	tailFromEnd          bool
-	onPositionsFileError OnPositionsFileError
-	watcherConfig        tail.WatcherConfig
-
-	running *atomic.Bool
-
+	report            sync.Once
+	running           *atomic.Bool
 	componentStopping func() bool
 
-	report sync.Once
+	file *tail.File
+}
 
-	file          *tail.File
-	encoding      string
-	decompression DecompressionConfig
+type tailerOptions struct {
+	path                 string
+	labels               model.LabelSet
+	encoding             string
+	tailFromEnd          bool
+	maxLineSize          int
+	fileWatch            FileWatch
+	onPositionsFileError OnPositionsFileError
+	legacyPositionUsed   bool
+	decompressionConfig  DecompressionConfig
 }
 
 func newTailer(
@@ -54,28 +58,19 @@ func newTailer(
 	receiver loki.LogsReceiver,
 	pos positions.Positions,
 	componentStopping func() bool,
-	opts sourceOptions,
+	opts tailerOptions,
 ) *tailer {
 
 	return &tailer{
-		metrics:              metrics,
-		logger:               logger.With("component", "tailer", "path", opts.path),
-		receiver:             receiver,
-		positions:            pos,
-		key:                  positions.Entry{Path: opts.path, Labels: opts.labels.String()},
-		labels:               opts.labels.Merge(model.LabelSet{labelFilename: model.LabelValue(opts.path)}),
-		running:              atomic.NewBool(false),
-		tailFromEnd:          opts.tailFromEnd,
-		legacyPositionUsed:   opts.legacyPositionUsed,
-		onPositionsFileError: opts.onPositionsFileError,
-		watcherConfig: tail.WatcherConfig{
-			MinPollFrequency: opts.fileWatch.MinPollFrequency,
-			MaxPollFrequency: opts.fileWatch.MaxPollFrequency,
-		},
+		metrics:           metrics,
+		logger:            logger.With("component", "tailer", "path", opts.path),
+		receiver:          receiver,
+		positions:         pos,
+		key:               positions.Entry{Path: opts.path, Labels: opts.labels.String()},
+		labels:            opts.labels.Merge(model.LabelSet{labelFilename: model.LabelValue(opts.path)}),
+		running:           atomic.NewBool(false),
+		opts:              opts,
 		componentStopping: componentStopping,
-		report:            sync.Once{},
-		encoding:          opts.encoding,
-		decompression:     opts.decompressionConfig,
 	}
 }
 
@@ -124,18 +119,18 @@ func (t *tailer) initRun() (int64, error) {
 		return 0, fmt.Errorf("failed to tail file: %w", err)
 	}
 
-	startFromEnd := t.tailFromEnd
+	startFromEnd := t.opts.tailFromEnd
 
 	pos, err := t.positions.Get(t.key.Path, t.key.Labels)
 	if err != nil {
-		switch t.onPositionsFileError {
+		switch t.opts.onPositionsFileError {
 		case OnPositionsFileErrorSkip:
 			return 0, fmt.Errorf("failed to get file position: %w", err)
 		case OnPositionsFileErrorRestartEnd:
 			startFromEnd = true
 			t.logger.Info("reset position to end of file after position error")
 		default:
-			t.logger.Debug("unrecognized `on_positions_file_error` option, defaulting to `restart_from_beginning`", "option", t.onPositionsFileError)
+			t.logger.Debug("unrecognized `on_positions_file_error` option, defaulting to `restart_from_beginning`", "option", t.opts.onPositionsFileError)
 			fallthrough
 		case OnPositionsFileErrorRestartBeginning:
 			pos = 0
@@ -145,7 +140,7 @@ func (t *tailer) initRun() (int64, error) {
 
 	// If we translated legacy positions we should try to get position offset without labels
 	// when no other position was matched.
-	if pos == 0 && t.legacyPositionUsed {
+	if pos == 0 && t.opts.legacyPositionUsed {
 		pos, err = t.positions.Get(t.key.Path, "{}")
 		if err != nil {
 			return 0, fmt.Errorf("failed to get file position with empty labels: %w", err)
@@ -162,12 +157,16 @@ func (t *tailer) initRun() (int64, error) {
 	}
 
 	tail, err := tail.NewFile(t.logger, &tail.Config{
-		Filename:      t.key.Path,
-		Offset:        pos,
-		StartFromEnd:  startFromEnd,
-		Encoding:      t.encoding,
-		Compression:   t.decompression.GetFormat(),
-		WatcherConfig: t.watcherConfig,
+		Filename:     t.key.Path,
+		Offset:       pos,
+		StartFromEnd: startFromEnd,
+		MaxLineSize:  t.opts.maxLineSize,
+		Encoding:     t.opts.encoding,
+		Compression:  t.opts.decompressionConfig.GetFormat(),
+		WatcherConfig: tail.WatcherConfig{
+			MinPollFrequency: t.opts.fileWatch.MinPollFrequency,
+			MaxPollFrequency: t.opts.fileWatch.MaxPollFrequency,
+		},
 	})
 
 	if err != nil {
@@ -188,9 +187,9 @@ func (t *tailer) initRun() (int64, error) {
 func (t *tailer) readLines(ctx context.Context, pos int64) {
 	t.logger.Info("start tailing file")
 
-	if t.decompression.Enabled && t.decompression.InitialDelay > 0 {
-		t.logger.Info("sleeping before reading file", "duration", t.decompression.InitialDelay.String())
-		time.Sleep(t.decompression.InitialDelay)
+	if t.opts.decompressionConfig.Enabled && t.opts.decompressionConfig.InitialDelay > 0 {
+		t.logger.Info("sleeping before reading file", "duration", t.opts.decompressionConfig.InitialDelay.String())
+		time.Sleep(t.opts.decompressionConfig.InitialDelay)
 	}
 
 	var (
@@ -280,7 +279,7 @@ func (t *tailer) shouldKeepPosition() bool {
 	// If component is not stopping that means that target is gone and we should no longer tail the file.
 	// If decompression is enabled we read file until we reach EOF and stop so tailer will exit, but we need
 	// to remember the position so that we don't re-ingest it on restart.
-	return t.componentStopping() || t.decompression.Enabled
+	return t.componentStopping() || t.opts.decompressionConfig.Enabled
 }
 
 // cleanupMetrics removes all metrics exported by this tailer

--- a/internal/component/loki/source/file/tailer.go
+++ b/internal/component/loki/source/file/tailer.go
@@ -45,10 +45,10 @@ type tailerOptions struct {
 	labels               model.LabelSet
 	encoding             string
 	tailFromEnd          bool
-	maxLineSize          int
 	fileWatch            FileWatch
 	onPositionsFileError OnPositionsFileError
 	legacyPositionUsed   bool
+	lineConfig           LineConfig
 	decompressionConfig  DecompressionConfig
 }
 
@@ -160,9 +160,9 @@ func (t *tailer) initRun() (int64, error) {
 		Filename:     t.key.Path,
 		Offset:       pos,
 		StartFromEnd: startFromEnd,
-		MaxLineSize:  t.opts.maxLineSize,
 		Encoding:     t.opts.encoding,
 		Compression:  t.opts.decompressionConfig.GetFormat(),
+		MaxLineSize:  int(t.opts.lineConfig.MaxSize),
 		WatcherConfig: tail.WatcherConfig{
 			MinPollFrequency: t.opts.fileWatch.MinPollFrequency,
 			MaxPollFrequency: t.opts.fileWatch.MaxPollFrequency,

--- a/internal/component/loki/source/file/tailer_test.go
+++ b/internal/component/loki/source/file/tailer_test.go
@@ -42,7 +42,7 @@ func TestTailer(t *testing.T) {
 		ch1,
 		positionsFile,
 		func() bool { return true },
-		sourceOptions{
+		tailerOptions{
 			path:   logFile.Name(),
 			labels: labels,
 			fileWatch: FileWatch{
@@ -138,7 +138,7 @@ func TestTailerPositionFileEntryDeleted(t *testing.T) {
 		ch1,
 		positionsFile,
 		func() bool { return false },
-		sourceOptions{
+		tailerOptions{
 			path:   logFile.Name(),
 			labels: labels,
 			fileWatch: FileWatch{
@@ -203,7 +203,7 @@ func TestTailerDeleteFileInstant(t *testing.T) {
 		ch1,
 		positionsFile,
 		func() bool { return true },
-		sourceOptions{
+		tailerOptions{
 			path:   logFile.Name(),
 			labels: labels,
 			fileWatch: FileWatch{
@@ -271,7 +271,7 @@ func TestTailerCancelWhileSendBlocked(t *testing.T) {
 		recv,
 		positionsFile,
 		func() bool { return true },
-		sourceOptions{
+		tailerOptions{
 			path:   path,
 			labels: labels,
 			fileWatch: FileWatch{
@@ -335,7 +335,7 @@ func TestTailerCorruptedPositions(t *testing.T) {
 		ch1,
 		positionsFile,
 		func() bool { return true },
-		sourceOptions{
+		tailerOptions{
 			path:   logFile.Name(),
 			labels: labels,
 			fileWatch: FileWatch{
@@ -435,7 +435,7 @@ func TestTailer_Compressions(t *testing.T) {
 		positionsFile,
 		// We return false here to verify that position is kept and we don't re-ingest the file.
 		func() bool { return false },
-		sourceOptions{
+		tailerOptions{
 			path:                 filename,
 			labels:               labels,
 			onPositionsFileError: OnPositionsFileErrorRestartBeginning,
@@ -478,7 +478,7 @@ func TestTailer_GigantiqueGunzipFile(t *testing.T) {
 		handler.Receiver(),
 		positions.NewNop(),
 		func() bool { return false },
-		sourceOptions{
+		tailerOptions{
 			path:                file,
 			decompressionConfig: DecompressionConfig{Enabled: true, Format: "gz"},
 		},
@@ -508,7 +508,7 @@ func TestTailer_CompressedOnelineFile(t *testing.T) {
 			handler.Receiver(),
 			positions.NewNop(),
 			func() bool { return false },
-			sourceOptions{
+			tailerOptions{
 				path:                file,
 				decompressionConfig: DecompressionConfig{Enabled: true, Format: "gz"},
 			},
@@ -537,7 +537,7 @@ func TestTailer_CompressedOnelineFile(t *testing.T) {
 			handler.Receiver(),
 			positions.NewNop(),
 			func() bool { return false },
-			sourceOptions{
+			tailerOptions{
 				path:                file,
 				decompressionConfig: DecompressionConfig{Enabled: true, Format: "bz2"},
 			},
@@ -565,7 +565,7 @@ func TestTailer_CompressedOnelineFile(t *testing.T) {
 			handler.Receiver(),
 			positions.NewNop(),
 			func() bool { return false },
-			sourceOptions{
+			tailerOptions{
 				path:                file,
 				decompressionConfig: DecompressionConfig{Enabled: true, Format: "gz"},
 			},

--- a/internal/converter/internal/promtailconvert/internal/build/scrape_builder.go
+++ b/internal/converter/internal/promtailconvert/internal/build/scrape_builder.go
@@ -69,15 +69,15 @@ func (s *ScrapeConfigBuilder) AppendLokiSourceFile(watchConfig *file.WatchConfig
 		return
 	}
 
-	args := lokisourcefile.Arguments{
-		ForwardTo:            s.getOrNewProcessStageReceivers(),
-		Encoding:             s.cfg.Encoding,
-		DecompressionConfig:  convertDecompressionConfig(s.cfg.DecompressionCfg),
-		FileWatch:            convertFileWatchConfig(watchConfig),
-		LegacyPositionsFile:  positionsCfg.PositionsFile,
-		OnPositionsFileError: lokisourcefile.OnPositionsFileErrorRestartBeginning,
-		FileMatch:            convertFileMatchConfig(s.globalCtx.TargetSyncPeriod),
-	}
+	args := lokisourcefile.Arguments{}
+	args.SetToDefault()
+
+	args.ForwardTo = s.getOrNewProcessStageReceivers()
+	args.Encoding = s.cfg.Encoding
+	args.FileWatch = convertFileWatchConfig(watchConfig)
+	args.FileMatch = convertFileMatchConfig(s.globalCtx.TargetSyncPeriod)
+	args.LegacyPositionsFile = positionsCfg.PositionsFile
+	args.DecompressionConfig = convertDecompressionConfig(s.cfg.DecompressionCfg)
 
 	targets := s.getAllRelabeledTargetsExpr()
 	overrideHook := func(val any) any {

--- a/internal/converter/internal/promtailconvert/testdata/static_pipeline_example.alloy
+++ b/internal/converter/internal/promtailconvert/testdata/static_pipeline_example.alloy
@@ -75,16 +75,16 @@ loki.source.file "example" {
 	forward_to = [loki.process.example.receiver]
 	encoding   = "UTF-16"
 
+	file_match {
+		enabled = true
+	}
+	legacy_positions_file = "/var/log/positions.yaml"
+
 	decompression {
 		enabled       = true
 		initial_delay = "30s"
 		format        = "z"
 	}
-
-	file_match {
-		enabled = true
-	}
-	legacy_positions_file = "/var/log/positions.yaml"
 }
 
 loki.write "default" {


### PR DESCRIPTION
### Brief description of Pull Request
Add config `max_line_size` to protect against reading to large lines. Currently it is possible to OOM alloy if you read a really big file without any newlines.

### Pull Request Details

### Issue(s) fixed by this Pull Request

Part of: #6014

### Notes to the Reviewer

This pr includes some small cleanups.

### PR Checklist

- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated
