### PR TITLE
feat: Add clustering for `loki.source.kubernetes_events`

### DIFF
--- a/docs/sources/reference/components/loki/loki.source.kubernetes_events.md
+++ b/docs/sources/reference/components/loki/loki.source.kubernetes_events.md
@@ -76,10 +76,12 @@ You can use the following blocks with `loki.source.kubernetes_events`:
 | `client` > [`oauth2`][oauth2]                    | Configure OAuth 2.0 for authenticating to the endpoint.    | no       |
 | `client` > `oauth2` > [`tls_config`][tls_config] | Configure TLS settings for connecting to the endpoint.     | no       |
 | `client` > [`tls_config`][tls_config]            | Configure TLS settings for connecting to the endpoint.     | no       |
+| [`clustering`][clustering]                       | Configure the component for when {{< param "PRODUCT_NAME" >}} is running in clustered mode. | no       |
 
 [authorization]: #authorization
 [basic_auth]: #basic_auth
 [client]: #client
+[clustering]: #clustering
 [oauth2]: #oauth2
 [tls_config]: #tls_config
 
@@ -131,6 +133,22 @@ The following arguments are supported:
 ### `tls_config`
 
 {{< docs/shared lookup="reference/components/tls-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `clustering`
+
+| Name      | Type   | Description                                               | Default | Required |
+| --------- | ------ | --------------------------------------------------------- | ------- | -------- |
+| `enabled` | `bool` | Distribute event collection with other cluster nodes.     |         | yes      |
+
+When {{< param "PRODUCT_NAME" >}} is [using clustering][], and `enabled` is set to true, then this `loki.source.kubernetes_events` component instance opts-in to participating in the cluster to distribute the load of event collection between all cluster nodes.
+
+If {{< param "PRODUCT_NAME" >}} is _not_ running in clustered mode, then the block is a no-op and `loki.source.kubernetes_events` collects events from every configured namespace.
+
+When clustering is enabled, each namespace is distributed across cluster nodes using consistent hashing.
+If the `namespaces` argument is empty (watching all namespaces), only a single node in the cluster will collect events, since all replicas share the same "all namespaces" target.
+If specific namespaces are listed, they are distributed across the available cluster nodes.
+
+[using clustering]: ../../../../get-started/clustering/
 
 ## Exported fields
 

--- a/docs/sources/reference/components/loki/loki.source.kubernetes_events.md
+++ b/docs/sources/reference/components/loki/loki.source.kubernetes_events.md
@@ -148,6 +148,13 @@ When clustering is enabled, each namespace is distributed across cluster nodes u
 If the `namespaces` argument is empty (watching all namespaces), only a single node in the cluster will collect events, since all replicas share the same "all namespaces" target.
 If specific namespaces are listed, they are distributed across the available cluster nodes.
 
+{{< admonition type="caution" >}}
+When a namespace moves from one cluster node to another (for example, during a rollout or pod restart), the new node may re-deliver events that were already sent by the previous node.
+This is because each node tracks its read position locally, and the new node starts from the beginning of the available events.
+The impact is bounded by the Kubernetes event TTL, which defaults to one hour.
+See [issue #3717](https://github.com/grafana/alloy/issues/3717) for more details.
+{{< /admonition >}}
+
 [using clustering]: ../../../../get-started/clustering/
 
 ## Exported fields

--- a/internal/component/loki/source/kubernetes_events/kubernetes_events.go
+++ b/internal/component/loki/source/kubernetes_events/kubernetes_events.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/ckit/shard"
 	"k8s.io/client-go/rest"
 
 	"github.com/grafana/alloy/internal/component"
@@ -21,6 +22,7 @@ import (
 	"github.com/grafana/alloy/internal/component/loki/source"
 	"github.com/grafana/alloy/internal/component/loki/source/internal/positions"
 	"github.com/grafana/alloy/internal/featuregate"
+	"github.com/grafana/alloy/internal/service/cluster"
 )
 
 // Generous timeout period for configuring informers
@@ -49,6 +51,8 @@ type Arguments struct {
 
 	// Client settings to connect to Kubernetes.
 	Client kubernetes.ClientArguments `alloy:"client,block,optional"`
+
+	Clustering cluster.ComponentBlock `alloy:"clustering,block,optional"`
 }
 
 // DefaultArguments holds default settings for loki.source.kubernetes_events.
@@ -83,6 +87,7 @@ type Component struct {
 	opts      component.Options
 	positions positions.Positions
 	handler   loki.LogsReceiver
+	cluster   cluster.Cluster
 
 	mut        sync.RWMutex
 	args       Arguments
@@ -95,6 +100,7 @@ type Component struct {
 var (
 	_ component.Component      = (*Component)(nil)
 	_ component.DebugComponent = (*Component)(nil)
+	_ cluster.Component        = (*Component)(nil)
 )
 
 // New creates a new loki.source.kubernetes_events component.
@@ -111,11 +117,17 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		return nil, err
 	}
 
+	data, err := o.GetServiceData(cluster.ServiceName)
+	if err != nil {
+		return nil, err
+	}
+
 	c := &Component{
 		log:       o.Logger,
 		opts:      o,
 		positions: positionsFile,
 		handler:   loki.NewLogsReceiver(),
+		cluster:   data.(cluster.Cluster),
 		scheduler: source.NewScheduler[string](),
 		fanout:    loki.NewFanout(args.ForwardTo),
 	}
@@ -149,12 +161,10 @@ func (c *Component) Update(args component.Arguments) error {
 
 	c.fanout.UpdateChildren(newArgs.ForwardTo)
 
-	restConfig := c.restConfig
-
 	// Create a new restConfig if we don't have one or if our arguments changed.
-	if restConfig == nil || !reflect.DeepEqual(c.args.Client, newArgs.Client) {
+	if c.restConfig == nil || !reflect.DeepEqual(c.args.Client, newArgs.Client) {
 		var err error
-		restConfig, err = newArgs.Client.BuildRESTConfig(c.log)
+		c.restConfig, err = newArgs.Client.BuildRESTConfig(c.log)
 		if err != nil {
 			return fmt.Errorf("building Kubernetes client config: %w", err)
 		}
@@ -163,31 +173,68 @@ func (c *Component) Update(args component.Arguments) error {
 		c.scheduler.Reset()
 	}
 
+	c.args = newArgs
+	c.reconcile()
+	return nil
+}
+
+// reconcile synchronizes the running event controllers with the desired set
+// of namespaces, filtered by clustering ownership.
+func (c *Component) reconcile() {
 	source.Reconcile(
 		c.opts.Logger,
 		c.scheduler,
-		getNamespaces(newArgs),
+		c.localNamespaces(),
 		func(namespace string) string { return namespace },
 		func(_ string, namespace string) (source.Source[string], error) {
 			return newEventController(eventControllerOptions{
 				Log:          c.log,
-				Config:       restConfig,
+				Config:       c.restConfig,
 				Namespace:    namespace,
-				JobName:      newArgs.JobName,
+				JobName:      c.args.JobName,
 				InstanceName: c.opts.ID,
 				Receiver:     c.handler,
 				Positions:    c.positions,
-				LogFormat:    newArgs.LogFormat,
+				LogFormat:    c.args.LogFormat,
 			}), nil
 		},
 	)
-
-	c.args = newArgs
-	return nil
 }
 
-// getNamespaces returns a iterator of namespaces to watch from the arguments. If the
-// list of namespaces is empty, returns a iterator to watch all namespaces.
+// NotifyClusterChange implements cluster.Component.
+func (c *Component) NotifyClusterChange() {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	if !c.args.Clustering.Enabled {
+		return
+	}
+	c.reconcile()
+}
+
+// localNamespaces returns an iterator of namespaces that this node should
+// watch, filtered by cluster ownership when clustering is enabled.
+func (c *Component) localNamespaces() iter.Seq[string] {
+	return func(yield func(string) bool) {
+		for ns := range getNamespaces(c.args) {
+			if c.args.Clustering.Enabled && c.cluster.Ready() {
+				// Use the namespace name as the hash key. For the "all namespaces"
+				// case (empty string), this results in a single key, so only one
+				// node in the cluster will watch all events.
+				peers, err := c.cluster.Lookup(shard.StringKey(ns), 1, shard.OpReadWrite)
+				if err == nil && len(peers) > 0 && !peers[0].Self {
+					continue // This namespace belongs to another node.
+				}
+			}
+			if !yield(ns) {
+				return
+			}
+		}
+	}
+}
+
+// getNamespaces returns an iterator of namespaces to watch from the arguments. If the
+// list of namespaces is empty, returns an iterator to watch all namespaces.
 func getNamespaces(args Arguments) iter.Seq[string] {
 	return func(yield func(string) bool) {
 		if len(args.Namespaces) == 0 {

--- a/internal/component/loki/source/kubernetes_events/kubernetes_events.go
+++ b/internal/component/loki/source/kubernetes_events/kubernetes_events.go
@@ -216,8 +216,15 @@ func (c *Component) NotifyClusterChange() {
 // watch, filtered by cluster ownership when clustering is enabled.
 func (c *Component) localNamespaces() iter.Seq[string] {
 	return func(yield func(string) bool) {
+		if c.args.Clustering.Enabled && !c.cluster.Ready() {
+			// When clustering is enabled but the cluster isn't ready yet,
+			// don't watch any namespaces. NotifyClusterChange will be called
+			// once the cluster is ready, triggering a reconcile.
+			return
+		}
+
 		for ns := range getNamespaces(c.args) {
-			if c.args.Clustering.Enabled && c.cluster.Ready() {
+			if c.args.Clustering.Enabled {
 				// Use the namespace name as the hash key. For the "all namespaces"
 				// case (empty string), this results in a single key, so only one
 				// node in the cluster will watch all events.


### PR DESCRIPTION
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style. For details on this,
  check out the Contributors Guide linked above.
-->

### Brief description of Pull Request

This change adds a `clustering` option for `loki.source.kubernetes_events` that will distribute the work according to the  list. If no namespaces are specificied, then only a single instance will run. This is great, because it means that it will be safe to run on Alloy instances with multiple replicas without resulting in duplication.

### Pull Request Details

<!-- Detailed descripion of the Pull Request, if needed. -->


### Issue(s) fixed by this Pull Request

Fixes #401

### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
