### PR TITLE
feat(sigil): Add sigil.receiver and sigil.write components

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank.yaml
+++ b/.github/ISSUE_TEMPLATE/blank.yaml
@@ -199,6 +199,8 @@ body:
       - remote.kubernetes.secret
       - remote.s3
       - remote.vault
+      - sigil.receiver
+      - sigil.write
       # End components list
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -199,6 +199,8 @@ body:
       - remote.kubernetes.secret
       - remote.s3
       - remote.vault
+      - sigil.receiver
+      - sigil.write
       # End components list
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/docs.yaml
+++ b/.github/ISSUE_TEMPLATE/docs.yaml
@@ -202,6 +202,8 @@ body:
       - remote.kubernetes.secret
       - remote.s3
       - remote.vault
+      - sigil.receiver
+      - sigil.write
       # End components list
   - type: textarea
     id: feedback

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -199,6 +199,8 @@ body:
       - remote.kubernetes.secret
       - remote.s3
       - remote.vault
+      - sigil.receiver
+      - sigil.write
       # End components list
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/proposal.yaml
+++ b/.github/ISSUE_TEMPLATE/proposal.yaml
@@ -199,6 +199,8 @@ body:
       - remote.kubernetes.secret
       - remote.s3
       - remote.vault
+      - sigil.receiver
+      - sigil.write
       # End components list
   - type: textarea
     attributes:

--- a/docs/sources/reference/components/sigil/_index.md
+++ b/docs/sources/reference/components/sigil/_index.md
@@ -1,0 +1,12 @@
+---
+canonical: https://grafana.com/docs/alloy/latest/reference/components/sigil/
+description: Learn about the sigil components in Grafana Alloy
+title: sigil
+weight: 100
+---
+
+# `sigil`
+
+This section contains reference documentation for the `sigil` components.
+
+{{< section >}}

--- a/docs/sources/reference/components/sigil/sigil.receiver.md
+++ b/docs/sources/reference/components/sigil/sigil.receiver.md
@@ -1,0 +1,102 @@
+---
+canonical: https://grafana.com/docs/alloy/latest/reference/components/sigil/sigil.receiver/
+description: Learn about sigil.receiver
+labels:
+  stage: experimental
+  products:
+    - oss
+title: sigil.receiver
+---
+
+# `sigil.receiver`
+
+{{< docs/shared lookup="stability/experimental.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+`sigil.receiver` receives Sigil AI generation export requests over HTTP and forwards them to `sigil.write` components or other components capable of receiving generations.
+
+The component starts an HTTP server that accepts `POST /api/v1/generations:export` requests.
+Request and response bodies are forwarded as opaque bytes without deserialization.
+
+## Usage
+
+```alloy
+sigil.receiver "<LABEL>" {
+  forward_to = <RECEIVER_LIST>
+}
+```
+
+## Arguments
+
+You can use the following arguments with `sigil.receiver`:
+
+| Name            | Type                         | Description                                          | Default  | Required |
+| --------------- | ---------------------------- | ---------------------------------------------------- | -------- | -------- |
+| `forward_to`    | `list(GenerationsReceiver)`  | List of receivers to send generations to.            |          | yes      |
+| `max_request_body_size` | `string`               | Maximum allowed request body size (e.g. `"20MiB"`).  | `"20MiB"`| no       |
+
+## Blocks
+
+You can use the following blocks with `sigil.receiver`:
+
+{{< docs/alloy-config >}}
+
+| Block                  | Description                                        | Required |
+| ---------------------- | -------------------------------------------------- | -------- |
+| [`http`][http]         | Configures the HTTP server that receives requests. | no       |
+| `http` > [`tls`][tls] | Configures TLS for the HTTP server.                | no       |
+
+[http]: #http
+[tls]: #tls
+
+{{< /docs/alloy-config >}}
+
+### `http`
+
+{{< docs/shared lookup="reference/components/server-http.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `tls`
+
+The `tls` block configures TLS for the HTTP server.
+
+{{< docs/shared lookup="reference/components/server-tls-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+## Exported fields
+
+`sigil.receiver` doesn't export any fields.
+
+## Component health
+
+`sigil.receiver` is reported as unhealthy if it's given an invalid configuration.
+
+## Debug metrics
+
+| Metric                                          | Type      | Description                                          |
+| ----------------------------------------------- | --------- | ---------------------------------------------------- |
+| `sigil_receiver_requests_total`                 | Counter   | Total number of generation export requests received. |
+| `sigil_receiver_request_body_bytes_total`       | Counter   | Total bytes received in generation export requests.  |
+| `sigil_receiver_request_duration_seconds`       | Histogram | Duration of generation export request handling.      |
+
+## Example
+
+This example creates a `sigil.receiver` that listens on the default address and forwards generation records to a `sigil.write` component.
+
+```alloy
+sigil.receiver "default" {
+  forward_to = [sigil.write.default.receiver]
+}
+
+sigil.write "default" {
+  endpoint {
+    url = "https://sigil.grafana.net"
+
+    basic_auth {
+      username = env("SIGIL_USER")
+      password = env("SIGIL_API_KEY")
+    }
+
+    headers = {
+      "X-Scope-OrgID" = env("SIGIL_TENANT_ID"),
+    }
+  }
+}
+```

--- a/docs/sources/reference/components/sigil/sigil.write.md
+++ b/docs/sources/reference/components/sigil/sigil.write.md
@@ -1,0 +1,167 @@
+---
+canonical: https://grafana.com/docs/alloy/latest/reference/components/sigil/sigil.write/
+description: Learn about sigil.write
+labels:
+  stage: experimental
+  products:
+    - oss
+title: sigil.write
+---
+
+# `sigil.write`
+
+{{< docs/shared lookup="stability/experimental.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+`sigil.write` receives Sigil AI generation records from other components and forwards them to remote Sigil ingest endpoints.
+
+Request and response bodies are forwarded as opaque bytes without deserialization.
+When multiple `endpoint` blocks are provided, generation records are concurrently forwarded to all configured locations.
+
+You can specify multiple `sigil.write` components by giving them different labels.
+
+## Usage
+
+```alloy
+sigil.write "<LABEL>" {
+  endpoint {
+    url = "<SIGIL_URL>"
+  }
+}
+```
+
+## Arguments
+
+`sigil.write` has no top-level arguments.
+
+## Blocks
+
+You can use the following blocks with `sigil.write`:
+
+{{< docs/alloy-config >}}
+
+| Block                                              | Description                                                | Required |
+| -------------------------------------------------- | ---------------------------------------------------------- | -------- |
+| [`endpoint`][endpoint]                             | Location to send generations to.                           | no       |
+| `endpoint` > [`authorization`][authorization]      | Configure generic authorization to the endpoint.           | no       |
+| `endpoint` > [`basic_auth`][basic_auth]            | Configure `basic_auth` for authenticating to the endpoint. | no       |
+| `endpoint` > [`oauth2`][oauth2]                    | Configure OAuth 2.0 for authenticating to the endpoint.    | no       |
+| `endpoint` > `oauth2` > [`tls_config`][tls_config] | Configure TLS settings for connecting to the endpoint.     | no       |
+| `endpoint` > [`tls_config`][tls_config]            | Configure TLS settings for connecting to the endpoint.     | no       |
+
+[endpoint]: #endpoint
+[authorization]: #authorization
+[basic_auth]: #basic_auth
+[oauth2]: #oauth2
+[tls_config]: #tls_config
+
+{{< /docs/alloy-config >}}
+
+### `endpoint`
+
+The `endpoint` block describes a single location to send generation records to.
+Multiple `endpoint` blocks can be provided to fan out to multiple locations.
+
+The following arguments are supported:
+
+| Name                     | Type                | Description                                                                                      | Default   | Required |
+| ------------------------ | ------------------- | ------------------------------------------------------------------------------------------------ | --------- | -------- |
+| `url`                    | `string`            | Full URL of the Sigil ingest endpoint.                                                           |           | yes      |
+| `bearer_token_file`      | `string`            | File containing a bearer token to authenticate with.                                             |           | no       |
+| `bearer_token`           | `secret`            | Bearer token to authenticate with.                                                               |           | no       |
+| `enable_http2`           | `bool`              | Whether HTTP2 is supported for requests.                                                         | `true`    | no       |
+| `follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.                                     | `true`    | no       |
+| `headers`                | `map(string)`       | Extra headers to deliver with the request.                                                       |           | no       |
+| `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.          |           | no       |
+| `max_backoff_period`     | `duration`          | Maximum backoff time between retries.                                                            | `"5m"`    | no       |
+| `max_backoff_retries`    | `int`               | Maximum number of retries. 0 to retry infinitely.                                                | `10`      | no       |
+| `min_backoff_period`     | `duration`          | Initial backoff time between retries.                                                            | `"500ms"` | no       |
+| `name`                   | `string`            | Optional name to identify the endpoint in metrics.                                               |           | no       |
+| `no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. |           | no       |
+| `proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests.                                    |           | no       |
+| `proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.                                            | `false`   | no       |
+| `proxy_url`              | `string`            | HTTP proxy to send requests through.                                                             |           | no       |
+| `remote_timeout`         | `duration`          | Timeout for requests made to the URL.                                                            | `"10s"`   | no       |
+| `tenant_id`              | `string`            | Tenant ID to use for `X-Scope-OrgID` header. Overrides the value from the incoming request.      |           | no       |
+
+At most, one of the following can be provided:
+
+* [`authorization`][authorization] block
+* [`basic_auth`][basic_auth] block
+* [`bearer_token_file`][endpoint] argument
+* [`bearer_token`][endpoint] argument
+* [`oauth2`][oauth2] block
+
+{{< docs/shared lookup="reference/components/http-client-proxy-config-description.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+Requests are retried on HTTP 429, 408, and 5xx responses with exponential backoff. Requests that receive other 4xx responses are not retried.
+
+### `authorization`
+
+{{< docs/shared lookup="reference/components/authorization-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `basic_auth`
+
+{{< docs/shared lookup="reference/components/basic-auth-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `oauth2`
+
+{{< docs/shared lookup="reference/components/oauth2-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `tls_config`
+
+{{< docs/shared lookup="reference/components/tls-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+## Exported fields
+
+The following fields are exported and can be referenced by other components:
+
+| Name       | Type       | Description                                                     |
+| ---------- | ---------- | --------------------------------------------------------------- |
+| `receiver` | `receiver` | A value that other components can use to send generations to.   |
+
+## Component health
+
+`sigil.write` is only reported as unhealthy if given an invalid configuration.
+In those cases, exported fields are kept at their last healthy values.
+
+## Debug metrics
+
+| Metric                                | Type      | Description                                                    |
+| ------------------------------------- | --------- | -------------------------------------------------------------- |
+| `sigil_write_sent_bytes_total`        | Counter   | Total number of bytes sent to Sigil endpoints.                 |
+| `sigil_write_dropped_bytes_total`     | Counter   | Total number of bytes dropped by Sigil write.                  |
+| `sigil_write_requests_total`          | Counter   | Total number of requests sent to Sigil endpoints.              |
+| `sigil_write_retries_total`           | Counter   | Total number of retries to Sigil endpoints.                    |
+| `sigil_write_latency`                 | Histogram | Write latency for sending generations to Sigil endpoints.      |
+
+All metrics include an `endpoint` label identifying the specific endpoint URL.
+
+## Example
+
+This example forwards generation records to two Sigil endpoints with different tenant IDs.
+
+```alloy
+sigil.write "default" {
+  endpoint {
+    url = "https://sigil.grafana.net"
+
+    basic_auth {
+      username = env("SIGIL_USER")
+      password = env("SIGIL_API_KEY")
+    }
+
+    headers = {
+      "X-Scope-OrgID" = env("SIGIL_TENANT_ID"),
+    }
+  }
+
+  endpoint {
+    url = "https://sigil-staging.internal"
+    tenant_id = "staging"
+  }
+}
+
+sigil.receiver "default" {
+  forward_to = [sigil.write.default.receiver]
+}
+```

--- a/internal/component/all/all.go
+++ b/internal/component/all/all.go
@@ -181,4 +181,6 @@ import (
 	_ "github.com/grafana/alloy/internal/component/remote/kubernetes/secret"                 // Import remote.kubernetes.secret
 	_ "github.com/grafana/alloy/internal/component/remote/s3"                                // Import remote.s3
 	_ "github.com/grafana/alloy/internal/component/remote/vault"                             // Import remote.vault
+	_ "github.com/grafana/alloy/internal/component/sigil/receiver"                           // Import sigil.receiver
+	_ "github.com/grafana/alloy/internal/component/sigil/write"                              // Import sigil.write
 )

--- a/internal/component/sigil/receiver/arguments.go
+++ b/internal/component/sigil/receiver/arguments.go
@@ -1,0 +1,21 @@
+package receiver
+
+import (
+	"github.com/alecthomas/units"
+	fnet "github.com/grafana/alloy/internal/component/common/net"
+	"github.com/grafana/alloy/internal/component/sigil"
+)
+
+type Arguments struct {
+	Server             *fnet.ServerConfig          `alloy:",squash"`
+	ForwardTo          []sigil.GenerationsReceiver `alloy:"forward_to,attr"`
+	MaxRequestBodySize units.Base2Bytes            `alloy:"max_request_body_size,attr,optional"`
+}
+
+// SetToDefault implements syntax.Defaulter.
+func (a *Arguments) SetToDefault() {
+	*a = Arguments{
+		Server:             fnet.DefaultServerConfig(),
+		MaxRequestBodySize: 20 * units.MiB,
+	}
+}

--- a/internal/component/sigil/receiver/handler.go
+++ b/internal/component/sigil/receiver/handler.go
@@ -1,0 +1,128 @@
+package receiver
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/alloy/internal/component/sigil"
+	"github.com/grafana/alloy/internal/runtime/logging/level"
+)
+
+type handler struct {
+	logger  log.Logger
+	metrics *metrics
+
+	mu          sync.RWMutex
+	forwardTo   []sigil.GenerationsReceiver
+	maxBodySize int64
+}
+
+func newHandler(logger log.Logger, m *metrics, forwardTo []sigil.GenerationsReceiver, maxBodySize int64) *handler {
+	return &handler{
+		logger:      logger,
+		metrics:     m,
+		forwardTo:   forwardTo,
+		maxBodySize: maxBodySize,
+	}
+}
+
+func (h *handler) update(forwardTo []sigil.GenerationsReceiver, maxBodySize int64) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.forwardTo = forwardTo
+	h.maxBodySize = maxBodySize
+}
+
+func (h *handler) getConfig() ([]sigil.GenerationsReceiver, int64) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.forwardTo, h.maxBodySize
+}
+
+func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	forwardTo, maxBodySize := h.getConfig()
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			h.metrics.requests.WithLabelValues("413").Inc()
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		level.Warn(h.logger).Log("msg", "failed to read request body", "err", err)
+		h.metrics.requests.WithLabelValues("500").Inc()
+		http.Error(w, "failed to read body", http.StatusInternalServerError)
+		return
+	}
+
+	req := &sigil.GenerationsRequest{
+		Body:        body,
+		ContentType: r.Header.Get("Content-Type"),
+		OrgID:       r.Header.Get("X-Scope-OrgID"),
+	}
+
+	var (
+		wg   sync.WaitGroup
+		mu   sync.Mutex
+		errs error
+		resp *sigil.GenerationsResponse
+	)
+
+	for _, receiver := range forwardTo {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r, err := receiver.ExportGenerations(r.Context(), req)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				errs = errors.Join(errs, err)
+			} else if resp == nil {
+				resp = r
+			}
+		}()
+	}
+	wg.Wait()
+
+	h.metrics.latency.WithLabelValues().Observe(time.Since(start).Seconds())
+
+	if errs != nil {
+		level.Warn(h.logger).Log("msg", "failed to forward generations", "err", errs)
+	}
+
+	// If all receivers failed, return 502.
+	if resp == nil && errs != nil {
+		statusCode := http.StatusBadGateway
+		h.metrics.requests.WithLabelValues(strconv.Itoa(statusCode)).Inc()
+		h.metrics.requestBytes.WithLabelValues(strconv.Itoa(statusCode)).Add(float64(len(body)))
+		http.Error(w, "failed to forward", statusCode)
+		return
+	}
+
+	statusCode := http.StatusAccepted
+	if resp != nil {
+		statusCode = resp.StatusCode
+	}
+	h.metrics.requests.WithLabelValues(strconv.Itoa(statusCode)).Inc()
+	h.metrics.requestBytes.WithLabelValues(strconv.Itoa(statusCode)).Add(float64(len(body)))
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	if resp != nil && resp.Body != nil {
+		_, _ = w.Write(resp.Body)
+	}
+}

--- a/internal/component/sigil/receiver/metrics.go
+++ b/internal/component/sigil/receiver/metrics.go
@@ -1,0 +1,37 @@
+package receiver
+
+import (
+	"github.com/grafana/alloy/internal/util"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type metrics struct {
+	requests     *prometheus.CounterVec
+	requestBytes *prometheus.CounterVec
+	latency      *prometheus.HistogramVec
+}
+
+func newMetrics(reg prometheus.Registerer) *metrics {
+	m := &metrics{
+		requests: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "sigil_receiver_requests_total",
+			Help: "Total number of generation export requests received.",
+		}, []string{"status_code"}),
+		requestBytes: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "sigil_receiver_request_body_bytes_total",
+			Help: "Total bytes received in generation export requests.",
+		}, []string{"status_code"}),
+		latency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name: "sigil_receiver_request_duration_seconds",
+			Help: "Duration of generation export request handling.",
+		}, []string{}),
+	}
+
+	if reg != nil {
+		m.requests = util.MustRegisterOrGet(reg, m.requests).(*prometheus.CounterVec)
+		m.requestBytes = util.MustRegisterOrGet(reg, m.requestBytes).(*prometheus.CounterVec)
+		m.latency = util.MustRegisterOrGet(reg, m.latency).(*prometheus.HistogramVec)
+	}
+
+	return m
+}

--- a/internal/component/sigil/receiver/receiver.go
+++ b/internal/component/sigil/receiver/receiver.go
@@ -1,0 +1,112 @@
+package receiver
+
+import (
+	"context"
+	"reflect"
+	"sync"
+
+	"github.com/go-kit/log"
+	"github.com/gorilla/mux"
+	"github.com/grafana/alloy/internal/component"
+	fnet "github.com/grafana/alloy/internal/component/common/net"
+	"github.com/grafana/alloy/internal/featuregate"
+	"github.com/grafana/alloy/internal/runtime/logging/level"
+	"github.com/grafana/alloy/internal/util"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:      "sigil.receiver",
+		Stability: featuregate.StabilityExperimental,
+		Args:      Arguments{},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			return New(opts, args.(Arguments))
+		},
+	})
+}
+
+type Component struct {
+	logger             log.Logger
+	handler            *handler
+	uncheckedCollector *util.UncheckedCollector
+
+	mut          sync.Mutex
+	server       *fnet.TargetServer
+	serverConfig *fnet.HTTPConfig
+}
+
+func New(opts component.Options, args Arguments) (*Component, error) {
+	uncheckedCollector := util.NewUncheckedCollector(nil)
+	opts.Registerer.MustRegister(uncheckedCollector)
+
+	m := newMetrics(opts.Registerer)
+	h := newHandler(opts.Logger, m, args.ForwardTo, int64(args.MaxRequestBodySize))
+
+	c := &Component{
+		logger:             opts.Logger,
+		handler:            h,
+		uncheckedCollector: uncheckedCollector,
+	}
+
+	if err := c.update(args); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// Run implements component.Component.
+func (c *Component) Run(ctx context.Context) error {
+	defer func() {
+		c.mut.Lock()
+		defer c.mut.Unlock()
+		c.shutdownServer()
+	}()
+
+	<-ctx.Done()
+	level.Info(c.logger).Log("msg", "terminating sigil.receiver")
+	return nil
+}
+
+// Update implements component.Component.
+func (c *Component) Update(args component.Arguments) error {
+	return c.update(args.(Arguments))
+}
+
+func (c *Component) update(args Arguments) error {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	c.handler.update(args.ForwardTo, int64(args.MaxRequestBodySize))
+
+	serverNeedsRestarting := !reflect.DeepEqual(c.serverConfig, args.Server.HTTP)
+	if !serverNeedsRestarting {
+		return nil
+	}
+
+	c.shutdownServer()
+	c.serverConfig = nil
+
+	serverRegistry := prometheus.NewRegistry()
+	c.uncheckedCollector.SetCollector(serverRegistry)
+
+	srv, err := fnet.NewTargetServer(c.logger, "sigil_receiver", serverRegistry, args.Server)
+	if err != nil {
+		return err
+	}
+	c.server = srv
+	c.serverConfig = args.Server.HTTP
+
+	return c.server.MountAndRun(func(router *mux.Router) {
+		router.Handle("/api/v1/generations:export", c.handler).Methods("POST")
+	})
+}
+
+func (c *Component) shutdownServer() {
+	if c.server != nil {
+		c.server.StopAndShutdown()
+		c.server = nil
+	}
+}

--- a/internal/component/sigil/receiver/receiver_test.go
+++ b/internal/component/sigil/receiver/receiver_test.go
@@ -1,0 +1,215 @@
+package receiver
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.uber.org/atomic"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/alloy/internal/component/sigil"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+type mockReceiver struct {
+	calls    atomic.Int32
+	lastReq  *sigil.GenerationsRequest
+	response *sigil.GenerationsResponse
+	err      error
+}
+
+func (m *mockReceiver) ExportGenerations(_ context.Context, req *sigil.GenerationsRequest) (*sigil.GenerationsResponse, error) {
+	m.calls.Add(1)
+	m.lastReq = req
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.response != nil {
+		return m.response, nil
+	}
+	return &sigil.GenerationsResponse{
+		StatusCode: http.StatusAccepted,
+		Body:       []byte(`{"results":[]}`),
+	}, nil
+}
+
+func TestHandler(t *testing.T) {
+	tests := []struct {
+		name           string
+		method         string
+		body           string
+		contentType    string
+		orgID          string
+		auth           string
+		receivers      int
+		maxBodySize    int64
+		expectStatus   int
+		expectBody     string
+		expectForwards int
+	}{
+		{
+			name:           "forwards POST to receiver",
+			method:         http.MethodPost,
+			body:           `{"generations":[{"id":"gen-1"}]}`,
+			contentType:    "application/json",
+			orgID:          "tenant-1",
+			receivers:      1,
+			expectStatus:   http.StatusAccepted,
+			expectBody:     `{"results":[]}`,
+			expectForwards: 1,
+		},
+		{
+			name:         "rejects non-POST",
+			method:       http.MethodGet,
+			receivers:    0,
+			expectStatus: http.StatusMethodNotAllowed,
+		},
+		{
+			name:           "rejects body exceeding max size",
+			method:         http.MethodPost,
+			body:           "x]x]x]x]x]x]", // 13 bytes, limit set to 10
+			contentType:    "application/json",
+			receivers:      1,
+			maxBodySize:    10,
+			expectStatus:   http.StatusRequestEntityTooLarge,
+			expectForwards: 0,
+		},
+		{
+			name:           "does not forward Authorization to receivers",
+			method:         http.MethodPost,
+			body:           `{"generations":[]}`,
+			contentType:    "application/json",
+			auth:           "Bearer secret-token",
+			receivers:      1,
+			expectStatus:   http.StatusAccepted,
+			expectForwards: 1,
+		},
+		{
+			name:           "fans out to multiple receivers",
+			method:         http.MethodPost,
+			body:           `{"generations":[]}`,
+			contentType:    "application/json",
+			receivers:      2,
+			expectStatus:   http.StatusAccepted,
+			expectForwards: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mocks := make([]*mockReceiver, tc.receivers)
+			receivers := make([]sigil.GenerationsReceiver, tc.receivers)
+			for i := range tc.receivers {
+				mocks[i] = &mockReceiver{}
+				receivers[i] = mocks[i]
+			}
+
+			maxBody := int64(50 * 1024 * 1024)
+			if tc.maxBodySize > 0 {
+				maxBody = tc.maxBodySize
+			}
+			m := newMetrics(prometheus.NewRegistry())
+			h := newHandler(log.NewNopLogger(), m, receivers, maxBody)
+
+			var bodyReader *bytes.Reader
+			if tc.body != "" {
+				bodyReader = bytes.NewReader([]byte(tc.body))
+			} else {
+				bodyReader = bytes.NewReader(nil)
+			}
+
+			req := httptest.NewRequest(tc.method, "/api/v1/generations:export", bodyReader)
+			if tc.contentType != "" {
+				req.Header.Set("Content-Type", tc.contentType)
+			}
+			if tc.orgID != "" {
+				req.Header.Set("X-Scope-OrgID", tc.orgID)
+			}
+			if tc.auth != "" {
+				req.Header.Set("Authorization", tc.auth)
+			}
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+
+			require.Equal(t, tc.expectStatus, rr.Code)
+			if tc.expectBody != "" {
+				require.Equal(t, tc.expectBody, rr.Body.String())
+			}
+
+			totalForwards := 0
+			for _, mock := range mocks {
+				totalForwards += int(mock.calls.Load())
+			}
+			require.Equal(t, tc.expectForwards, totalForwards)
+
+			if tc.expectForwards > 0 && tc.receivers > 0 {
+				require.NotNil(t, mocks[0].lastReq)
+				require.Equal(t, []byte(tc.body), mocks[0].lastReq.Body)
+				if tc.contentType != "" {
+					require.Equal(t, tc.contentType, mocks[0].lastReq.ContentType)
+				}
+				if tc.orgID != "" {
+					require.Equal(t, tc.orgID, mocks[0].lastReq.OrgID)
+				}
+				require.Nil(t, mocks[0].lastReq.Headers)
+			}
+		})
+	}
+}
+
+func TestHandler_PartialSuccess(t *testing.T) {
+	tests := []struct {
+		name         string
+		failFirst    bool
+		failSecond   bool
+		expectStatus int
+	}{
+		{
+			name:         "one fails, one succeeds — returns success",
+			failFirst:    true,
+			failSecond:   false,
+			expectStatus: http.StatusAccepted,
+		},
+		{
+			name:         "both succeed",
+			failFirst:    false,
+			failSecond:   false,
+			expectStatus: http.StatusAccepted,
+		},
+		{
+			name:         "all fail — returns 502",
+			failFirst:    true,
+			failSecond:   true,
+			expectStatus: http.StatusBadGateway,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mock1 := &mockReceiver{}
+			mock2 := &mockReceiver{}
+			if tc.failFirst {
+				mock1.err = fmt.Errorf("downstream error")
+			}
+			if tc.failSecond {
+				mock2.err = fmt.Errorf("downstream error")
+			}
+
+			m := newMetrics(prometheus.NewRegistry())
+			h := newHandler(log.NewNopLogger(), m, []sigil.GenerationsReceiver{mock1, mock2}, 50*1024*1024)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/generations:export", bytes.NewReader([]byte(`{}`)))
+			req.Header.Set("Content-Type", "application/json")
+
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+
+			require.Equal(t, tc.expectStatus, rr.Code)
+		})
+	}
+}

--- a/internal/component/sigil/types.go
+++ b/internal/component/sigil/types.go
@@ -1,0 +1,25 @@
+package sigil
+
+import "context"
+
+// GenerationsReceiver is the interface connecting sigil.receiver to sigil.write.
+// It follows the same pattern as pyroscope.Appendable and loki.LogsReceiver.
+type GenerationsReceiver interface {
+	ExportGenerations(ctx context.Context, req *GenerationsRequest) (*GenerationsResponse, error)
+}
+
+// GenerationsRequest carries raw bytes and metadata through the pipeline.
+// The body is opaque — no deserialization is performed.
+// Fields must not be mutated after the request is passed to ExportGenerations.
+type GenerationsRequest struct {
+	Body        []byte
+	ContentType string
+	OrgID       string
+	Headers     map[string]string
+}
+
+// GenerationsResponse carries the upstream response back to the caller.
+type GenerationsResponse struct {
+	StatusCode int
+	Body       []byte
+}

--- a/internal/component/sigil/write/arguments.go
+++ b/internal/component/sigil/write/arguments.go
@@ -1,0 +1,73 @@
+package write
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/grafana/alloy/internal/component/common/config"
+)
+
+type Arguments struct {
+	Endpoints []*EndpointOptions `alloy:"endpoint,block,optional"`
+}
+
+// SetToDefault implements syntax.Defaulter.
+func (a *Arguments) SetToDefault() {
+	*a = Arguments{}
+}
+
+// Validate implements syntax.Validator.
+func (a *Arguments) Validate() error {
+	if len(a.Endpoints) == 0 {
+		return fmt.Errorf("at least one endpoint block must be specified")
+	}
+	return nil
+}
+
+type EndpointOptions struct {
+	Name              string                   `alloy:"name,attr,optional"`
+	URL               string                   `alloy:"url,attr"`
+	RemoteTimeout     time.Duration            `alloy:"remote_timeout,attr,optional"`
+	Headers           map[string]string        `alloy:"headers,attr,optional"`
+	HTTPClientConfig  *config.HTTPClientConfig `alloy:",squash"`
+	MinBackoff        time.Duration            `alloy:"min_backoff_period,attr,optional"`
+	MaxBackoff        time.Duration            `alloy:"max_backoff_period,attr,optional"`
+	MaxBackoffRetries int                      `alloy:"max_backoff_retries,attr,optional"`
+	TenantID          string                   `alloy:"tenant_id,attr,optional"`
+}
+
+func GetDefaultEndpointOptions() EndpointOptions {
+	return EndpointOptions{
+		RemoteTimeout:     10 * time.Second,
+		MinBackoff:        500 * time.Millisecond,
+		MaxBackoff:        5 * time.Minute,
+		MaxBackoffRetries: 10,
+		HTTPClientConfig:  config.CloneDefaultHTTPClientConfig(),
+	}
+}
+
+// SetToDefault implements syntax.Defaulter.
+func (e *EndpointOptions) SetToDefault() {
+	*e = GetDefaultEndpointOptions()
+}
+
+// Validate implements syntax.Validator.
+func (e *EndpointOptions) Validate() error {
+	if e.URL == "" {
+		return fmt.Errorf("url must not be empty")
+	}
+	if _, err := url.Parse(e.URL); err != nil {
+		return fmt.Errorf("invalid url: %w", err)
+	}
+	if e.MinBackoff > e.MaxBackoff {
+		return fmt.Errorf("min_backoff_period (%s) must not exceed max_backoff_period (%s)", e.MinBackoff, e.MaxBackoff)
+	}
+	if e.MaxBackoffRetries < 0 {
+		return fmt.Errorf("max_backoff_retries must be non-negative")
+	}
+	if e.HTTPClientConfig != nil {
+		return e.HTTPClientConfig.Validate()
+	}
+	return nil
+}

--- a/internal/component/sigil/write/client.go
+++ b/internal/component/sigil/write/client.go
@@ -1,0 +1,222 @@
+package write
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/alloy/internal/component/sigil"
+	"github.com/grafana/alloy/internal/runtime/logging/level"
+	"github.com/grafana/dskit/backoff"
+	promconfig "github.com/prometheus/common/config"
+)
+
+type endpointClient struct {
+	options    *EndpointOptions
+	httpClient *http.Client
+	logger     log.Logger
+	metrics    *metrics
+}
+
+func newEndpointClient(logger log.Logger, opts *EndpointOptions, m *metrics) (*endpointClient, error) {
+	httpClient, err := promconfig.NewClientFromConfig(*opts.HTTPClientConfig.Convert(), opts.Name)
+	if err != nil {
+		return nil, fmt.Errorf("creating HTTP client for %s: %w", opts.URL, err)
+	}
+
+	return &endpointClient{
+		options:    opts,
+		httpClient: httpClient,
+		logger:     logger,
+		metrics:    m,
+	}, nil
+}
+
+func (ec *endpointClient) send(ctx context.Context, req *sigil.GenerationsRequest) (*sigil.GenerationsResponse, error) {
+	bo := backoff.New(ctx, backoff.Config{
+		MinBackoff: ec.options.MinBackoff,
+		MaxBackoff: ec.options.MaxBackoff,
+		MaxRetries: ec.options.MaxBackoffRetries,
+	})
+
+	var lastErr error
+	for {
+		resp, err := ec.doRequest(ctx, req)
+		if err == nil {
+			ec.metrics.sentBytes.WithLabelValues(ec.options.URL).Add(float64(len(req.Body)))
+			ec.metrics.requests.WithLabelValues(ec.options.URL, strconv.Itoa(resp.StatusCode)).Inc()
+			return resp, nil
+		}
+
+		lastErr = err
+		level.Debug(ec.logger).Log(
+			"msg", "failed to send generations",
+			"endpoint", ec.options.URL,
+			"retries", bo.NumRetries(),
+			"err", err,
+		)
+
+		if !shouldRetry(err) {
+			break
+		}
+		bo.Wait()
+		if !bo.Ongoing() {
+			break
+		}
+		ec.metrics.retries.WithLabelValues(ec.options.URL).Inc()
+	}
+
+	ec.metrics.droppedBytes.WithLabelValues(ec.options.URL).Add(float64(len(req.Body)))
+	return nil, fmt.Errorf("failed to send to %s (%d retries): %w", ec.options.URL, bo.NumRetries(), lastErr)
+}
+
+func (ec *endpointClient) doRequest(ctx context.Context, req *sigil.GenerationsRequest) (*sigil.GenerationsResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, ec.options.RemoteTimeout)
+	defer cancel()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, ec.options.URL, bytes.NewReader(req.Body))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	// Apply endpoint-configured headers first so request content-type wins.
+	for k, v := range ec.options.Headers {
+		httpReq.Header.Set(k, v)
+	}
+
+	// Set content type from the incoming request, overwriting any endpoint header.
+	if req.ContentType != "" {
+		httpReq.Header.Set("Content-Type", req.ContentType)
+	}
+
+	// Set tenant ID: config overrides request metadata.
+	if ec.options.TenantID != "" {
+		httpReq.Header.Set("X-Scope-OrgID", ec.options.TenantID)
+	} else if req.OrgID != "" {
+		httpReq.Header.Set("X-Scope-OrgID", req.OrgID)
+	}
+
+	// Forward additional headers from the original request.
+	for k, v := range req.Headers {
+		if httpReq.Header.Get(k) == "" {
+			httpReq.Header.Set(k, v)
+		}
+	}
+
+	httpResp, err := ec.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("sending request: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode >= 400 {
+		errBody, _ := io.ReadAll(io.LimitReader(httpResp.Body, 2048))
+		return nil, &WriteError{
+			StatusCode: httpResp.StatusCode,
+			Message:    string(errBody),
+		}
+	}
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	return &sigil.GenerationsResponse{
+		StatusCode: httpResp.StatusCode,
+		Body:       respBody,
+	}, nil
+}
+
+// fanOutClient fans out generation requests to multiple endpoints.
+type fanOutClient struct {
+	endpoints []*endpointClient
+	metrics   *metrics
+	logger    log.Logger
+}
+
+func (f *fanOutClient) closeIdleConnections() {
+	for _, ec := range f.endpoints {
+		ec.httpClient.CloseIdleConnections()
+	}
+}
+
+func newFanOutClient(logger log.Logger, config Arguments, m *metrics) (*fanOutClient, error) {
+	endpoints := make([]*endpointClient, 0, len(config.Endpoints))
+	for _, ep := range config.Endpoints {
+		ec, err := newEndpointClient(logger, ep, m)
+		if err != nil {
+			return nil, err
+		}
+		endpoints = append(endpoints, ec)
+	}
+
+	return &fanOutClient{
+		endpoints: endpoints,
+		metrics:   m,
+		logger:    logger,
+	}, nil
+}
+
+func (f *fanOutClient) ExportGenerations(ctx context.Context, req *sigil.GenerationsRequest) (*sigil.GenerationsResponse, error) {
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		errs    error
+		resp    *sigil.GenerationsResponse
+		reqSize = int64(len(req.Body))
+	)
+
+	for _, ec := range f.endpoints {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			start := time.Now()
+			r, err := ec.send(ctx, req)
+			ec.metrics.latency.WithLabelValues(ec.options.URL).Observe(time.Since(start).Seconds())
+
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				level.Warn(ec.logger).Log("msg", "failed to send generations", "endpoint", ec.options.URL, "sz", reqSize, "err", err)
+				errs = errors.Join(errs, err)
+			} else if resp == nil {
+				resp = r
+			}
+		}()
+	}
+
+	wg.Wait()
+	if resp == nil && errs != nil {
+		return nil, errs
+	}
+	return resp, errs
+}
+
+func shouldRetry(err error) bool {
+	var writeErr *WriteError
+	if errors.As(err, &writeErr) {
+		s := writeErr.StatusCode
+		return s == http.StatusTooManyRequests ||
+			s == http.StatusRequestTimeout ||
+			s >= http.StatusInternalServerError
+	}
+	return true // network errors are retryable
+}
+
+// WriteError represents an HTTP error from the upstream Sigil endpoint.
+type WriteError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *WriteError) Error() string {
+	return fmt.Sprintf("sigil write error: status=%d msg=%s", e.StatusCode, e.Message)
+}

--- a/internal/component/sigil/write/metrics.go
+++ b/internal/component/sigil/write/metrics.go
@@ -1,0 +1,49 @@
+package write
+
+import (
+	"github.com/grafana/alloy/internal/util"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type metrics struct {
+	sentBytes    *prometheus.CounterVec
+	droppedBytes *prometheus.CounterVec
+	requests     *prometheus.CounterVec
+	retries      *prometheus.CounterVec
+	latency      *prometheus.HistogramVec
+}
+
+func newMetrics(reg prometheus.Registerer) *metrics {
+	m := &metrics{
+		sentBytes: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "sigil_write_sent_bytes_total",
+			Help: "Total number of bytes sent to Sigil.",
+		}, []string{"endpoint"}),
+		droppedBytes: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "sigil_write_dropped_bytes_total",
+			Help: "Total number of bytes dropped by Sigil write.",
+		}, []string{"endpoint"}),
+		requests: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "sigil_write_requests_total",
+			Help: "Total number of requests sent to Sigil.",
+		}, []string{"endpoint", "status_code"}),
+		retries: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "sigil_write_retries_total",
+			Help: "Total number of retries to Sigil.",
+		}, []string{"endpoint"}),
+		latency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name: "sigil_write_latency",
+			Help: "Write latency for sending generations to Sigil.",
+		}, []string{"endpoint"}),
+	}
+
+	if reg != nil {
+		m.sentBytes = util.MustRegisterOrGet(reg, m.sentBytes).(*prometheus.CounterVec)
+		m.droppedBytes = util.MustRegisterOrGet(reg, m.droppedBytes).(*prometheus.CounterVec)
+		m.requests = util.MustRegisterOrGet(reg, m.requests).(*prometheus.CounterVec)
+		m.retries = util.MustRegisterOrGet(reg, m.retries).(*prometheus.CounterVec)
+		m.latency = util.MustRegisterOrGet(reg, m.latency).(*prometheus.HistogramVec)
+	}
+
+	return m
+}

--- a/internal/component/sigil/write/write.go
+++ b/internal/component/sigil/write/write.go
@@ -1,0 +1,84 @@
+package write
+
+import (
+	"context"
+	"sync"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/alloy/internal/component"
+	"github.com/grafana/alloy/internal/component/sigil"
+	"github.com/grafana/alloy/internal/featuregate"
+	"github.com/grafana/alloy/internal/runtime/logging/level"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:      "sigil.write",
+		Stability: featuregate.StabilityExperimental,
+		Args:      Arguments{},
+		Exports:   Exports{},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			return New(opts, args.(Arguments))
+		},
+	})
+}
+
+// Exports are the set of fields exposed by the sigil.write component.
+type Exports struct {
+	Receiver sigil.GenerationsReceiver `alloy:"receiver,attr"`
+}
+
+// Component is the sigil.write component.
+type Component struct {
+	logger        log.Logger
+	onStateChange func(Exports)
+	metrics       *metrics
+
+	mu       sync.Mutex
+	receiver *fanOutClient
+}
+
+// New creates a new sigil.write component.
+func New(opts component.Options, args Arguments) (*Component, error) {
+	m := newMetrics(opts.Registerer)
+	receiver, err := newFanOutClient(opts.Logger, args, m)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &Component{
+		logger:        opts.Logger,
+		onStateChange: func(e Exports) { opts.OnStateChange(e) },
+		metrics:       m,
+		receiver:      receiver,
+	}
+
+	c.onStateChange(Exports{Receiver: receiver})
+	return c, nil
+}
+
+// Run implements component.Component.
+func (c *Component) Run(ctx context.Context) error {
+	<-ctx.Done()
+	level.Info(c.logger).Log("msg", "terminating sigil.write")
+	return nil
+}
+
+// Update implements component.Component.
+func (c *Component) Update(args component.Arguments) error {
+	newArgs := args.(Arguments)
+	receiver, err := newFanOutClient(c.logger, newArgs, c.metrics)
+	if err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.receiver != nil {
+		c.receiver.closeIdleConnections()
+	}
+	c.receiver = receiver
+	c.onStateChange(Exports{Receiver: receiver})
+	return nil
+}

--- a/internal/component/sigil/write/write_test.go
+++ b/internal/component/sigil/write/write_test.go
@@ -1,0 +1,309 @@
+package write
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/atomic"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/alloy/internal/component/sigil"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndpointClient(t *testing.T) {
+	tests := []struct {
+		name              string
+		tenantID          string
+		reqOrgID          string
+		contentType       string
+		serverStatus      int
+		serverBody        string
+		headers           map[string]string
+		expectOrgID       string
+		expectCustom      string
+		expectContentType string
+		expectStatus      int
+		expectErr         bool
+		expectErrMaxLen   int
+	}{
+		{
+			name:         "forwards headers and body",
+			contentType:  "application/json",
+			reqOrgID:     "tenant-1",
+			headers:      map[string]string{"X-Custom": "hello"},
+			serverStatus: http.StatusAccepted,
+			serverBody:   `{"results":[]}`,
+			expectOrgID:  "tenant-1",
+			expectCustom: "hello",
+			expectStatus: http.StatusAccepted,
+		},
+		{
+			name:         "tenant_id config overrides request org ID",
+			contentType:  "application/json",
+			tenantID:     "config-tenant",
+			reqOrgID:     "request-tenant",
+			serverStatus: http.StatusAccepted,
+			expectOrgID:  "config-tenant",
+			expectStatus: http.StatusAccepted,
+		},
+		{
+			name:         "no retry on 4xx",
+			contentType:  "application/json",
+			serverStatus: http.StatusBadRequest,
+			serverBody:   "bad request",
+			expectErr:    true,
+		},
+		{
+			name:              "request content-type overwrites endpoint header",
+			contentType:       "application/json",
+			headers:           map[string]string{"Content-Type": "text/plain"},
+			serverStatus:      http.StatusAccepted,
+			expectContentType: "application/json",
+			expectStatus:      http.StatusAccepted,
+		},
+		{
+			name:              "empty content-type preserves endpoint header",
+			contentType:       "",
+			headers:           map[string]string{"Content-Type": "text/plain"},
+			serverStatus:      http.StatusAccepted,
+			expectContentType: "text/plain",
+			expectStatus:      http.StatusAccepted,
+		},
+		{
+			name:            "large error body is truncated",
+			contentType:     "application/json",
+			serverStatus:    http.StatusInternalServerError,
+			serverBody:      strings.Repeat("x", 4096),
+			expectErr:       true,
+			expectErrMaxLen: 2300,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				gotOrgID       string
+				gotCustom      string
+				gotContentType string
+				gotBody        []byte
+			)
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotOrgID = r.Header.Get("X-Scope-OrgID")
+				gotCustom = r.Header.Get("X-Custom")
+				gotContentType = r.Header.Get("Content-Type")
+				gotBody, _ = io.ReadAll(r.Body)
+				w.WriteHeader(tc.serverStatus)
+				if tc.serverBody != "" {
+					_, _ = w.Write([]byte(tc.serverBody))
+				}
+			}))
+			defer srv.Close()
+
+			opts := GetDefaultEndpointOptions()
+			opts.URL = srv.URL
+			opts.TenantID = tc.tenantID
+			opts.Headers = tc.headers
+			opts.MinBackoff = 1 * time.Millisecond
+			opts.MaxBackoff = 10 * time.Millisecond
+			opts.MaxBackoffRetries = 1
+
+			ec, err := newEndpointClient(log.NewNopLogger(), &opts, newMetrics(prometheus.NewRegistry()))
+			require.NoError(t, err)
+
+			req := &sigil.GenerationsRequest{
+				Body:        []byte(`{"generations":[]}`),
+				ContentType: tc.contentType,
+				OrgID:       tc.reqOrgID,
+			}
+
+			resp, err := ec.send(context.Background(), req)
+			if tc.expectErr {
+				require.Error(t, err)
+				if tc.expectErrMaxLen > 0 {
+					require.LessOrEqual(t, len(err.Error()), tc.expectErrMaxLen,
+						"error message should be truncated")
+				}
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expectStatus, resp.StatusCode)
+			if tc.serverBody != "" {
+				require.Equal(t, tc.serverBody, string(resp.Body))
+			}
+			if tc.expectOrgID != "" {
+				require.Equal(t, tc.expectOrgID, gotOrgID)
+			}
+			if tc.expectCustom != "" {
+				require.Equal(t, tc.expectCustom, gotCustom)
+			}
+			if tc.expectContentType != "" {
+				require.Equal(t, tc.expectContentType, gotContentType)
+			}
+			require.Equal(t, `{"generations":[]}`, string(gotBody))
+		})
+	}
+}
+
+func TestEndpointClient_RetriesOn5xx(t *testing.T) {
+	var attempts atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if attempts.Add(1) <= 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"results":[]}`))
+	}))
+	defer srv.Close()
+
+	opts := GetDefaultEndpointOptions()
+	opts.URL = srv.URL
+	opts.MinBackoff = 1 * time.Millisecond
+	opts.MaxBackoff = 10 * time.Millisecond
+	opts.MaxBackoffRetries = 5
+
+	ec, err := newEndpointClient(log.NewNopLogger(), &opts, newMetrics(prometheus.NewRegistry()))
+	require.NoError(t, err)
+
+	resp, err := ec.send(context.Background(), &sigil.GenerationsRequest{
+		Body:        []byte(`{}`),
+		ContentType: "application/json",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusAccepted, resp.StatusCode)
+	require.Equal(t, int32(3), attempts.Load())
+}
+
+func TestFanOutClient_SendsToMultipleEndpoints(t *testing.T) {
+	var count1, count2 atomic.Int32
+
+	srv1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count1.Add(1)
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"results":[]}`))
+	}))
+	defer srv1.Close()
+
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count2.Add(1)
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"results":[]}`))
+	}))
+	defer srv2.Close()
+
+	ep1 := GetDefaultEndpointOptions()
+	ep1.URL = srv1.URL
+	ep2 := GetDefaultEndpointOptions()
+	ep2.URL = srv2.URL
+
+	fc, err := newFanOutClient(log.NewNopLogger(), Arguments{
+		Endpoints: []*EndpointOptions{&ep1, &ep2},
+	}, newMetrics(prometheus.NewRegistry()))
+	require.NoError(t, err)
+
+	resp, err := fc.ExportGenerations(context.Background(), &sigil.GenerationsRequest{
+		Body:        []byte(`{"generations":[]}`),
+		ContentType: "application/json",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusAccepted, resp.StatusCode)
+	require.Equal(t, int32(1), count1.Load())
+	require.Equal(t, int32(1), count2.Load())
+}
+
+func TestArguments_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    Arguments
+		wantErr bool
+	}{
+		{
+			name:    "no endpoints",
+			args:    Arguments{},
+			wantErr: true,
+		},
+		{
+			name: "with endpoint",
+			args: func() Arguments {
+				ep := GetDefaultEndpointOptions()
+				ep.URL = "http://localhost:4320"
+				return Arguments{Endpoints: []*EndpointOptions{&ep}}
+			}(),
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.args.Validate()
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestEndpointOptions_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		modify  func(*EndpointOptions)
+		wantErr bool
+	}{
+		{
+			name:    "valid defaults",
+			modify:  func(e *EndpointOptions) { e.URL = "http://localhost:4320" },
+			wantErr: false,
+		},
+		{
+			name:    "empty URL",
+			modify:  func(e *EndpointOptions) { e.URL = "" },
+			wantErr: true,
+		},
+		{
+			name:    "invalid URL",
+			modify:  func(e *EndpointOptions) { e.URL = "://bad" },
+			wantErr: true,
+		},
+		{
+			name: "min backoff exceeds max",
+			modify: func(e *EndpointOptions) {
+				e.URL = "http://localhost"
+				e.MinBackoff = 10 * time.Second
+				e.MaxBackoff = 1 * time.Second
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative retries",
+			modify: func(e *EndpointOptions) {
+				e.URL = "http://localhost"
+				e.MaxBackoffRetries = -1
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := GetDefaultEndpointOptions()
+			tc.modify(&opts)
+			err := opts.Validate()
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Brief description of Pull Request

Add `sigil.receiver` and `sigil.write` components for proxying Sigil AI generation ingest traffic through Alloy.

`sigil.receiver` listens on `POST /api/v1/generations:export` and forwards raw request bytes to downstream `GenerationsReceiver` targets.

`sigil.write` implements `GenerationsReceiver` by forwarding to remote Sigil ingest endpoints with configurable backoff/retry, tenant header rewriting, and fan-out to multiple backends.

Both components use the raw-proxy pattern (like `pyroscope.receive_http`). Request and response bodies are forwarded as opaque bytes without deserialization. Both are marked `StabilityExperimental`.

### Pull Request Details

Sigil SDKs currently send generation records directly to Sigil ingest, bypassing Alloy. This means operators who route all observability traffic through Alloy have a gap in their telemetry gateway for AI signals.

These components close that gap: SDKs point at Alloy's `sigil.receiver`, Alloy proxies the traffic through `sigil.write` to the upstream, applying auth header rewriting, retry/backoff, and multi-backend fan-out transparently.

### Notes to the Reviewer

- Modeled after `pyroscope.receive_http` (receiver) and `pyroscope.write` (writer).
- Docs: https://deploy-preview-alloy-6029-zb444pucvq-vp.a.run.app/docs/alloy/latest/reference/components/sigil/

### PR Checklist

- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated (N/A — new signal type, no prior config format)