### PR TITLE
fix(loki.process): Eliminate per-stream goroutines in multiline stage

### DIFF
--- a/internal/component/loki/process/stages/multiline.go
+++ b/internal/component/loki/process/stages/multiline.go
@@ -7,15 +7,15 @@ import (
 	"regexp"
 	"slices"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
 
+	"github.com/grafana/loki/pkg/push"
+
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
-	"github.com/grafana/loki/pkg/push"
 )
 
 // Configuration errors.
@@ -68,22 +68,18 @@ func validateMultilineConfig(cfg MultilineConfig) (*regexp.Regexp, error) {
 
 // multilineStage matches lines to determine whether the following lines belong to a block and should be collapsed
 type multilineStage struct {
-	logger log.Logger
-	cfg    MultilineConfig
-	regex  *regexp.Regexp
+	logger  log.Logger
+	cfg     MultilineConfig
+	regex   *regexp.Regexp
+	streams map[model.Fingerprint]*multilineState
 }
 
 // multilineState captures the internal state of a running multiline stage.
 type multilineState struct {
-	buffer         *bytes.Buffer // The lines of the current multiline block.
-	startLineEntry Entry         // The entry of the start line of a multiline block.
-	currentLines   uint64        // The number of lines of the current multiline block.
-}
-
-func (s *multilineState) Reset() {
-	// We don't reset startLineEntry here to keep old behaviour.
-	s.buffer.Reset()
-	s.currentLines = 0
+	buffer         *bytes.Buffer
+	startLineEntry Entry  // The entry of the start line of a multiline block.
+	currentLines   uint64 // The number of lines of the current multiline block.
+	lastSeen       time.Time
 }
 
 // newMultilineStage creates a MulitlineStage from config
@@ -94,9 +90,10 @@ func newMultilineStage(logger log.Logger, config MultilineConfig) (Stage, error)
 	}
 
 	return &multilineStage{
-		logger: log.With(logger, "component", "stage", "type", "multiline"),
-		cfg:    config,
-		regex:  regex,
+		logger:  log.With(logger, "component", "stage", "type", "multiline"),
+		cfg:     config,
+		regex:   regex,
+		streams: make(map[model.Fingerprint]*multilineState),
 	}, nil
 }
 
@@ -105,97 +102,171 @@ func (m *multilineStage) Run(in chan Entry) chan Entry {
 	go func() {
 		defer close(out)
 
-		streams := make(map[model.Fingerprint]chan Entry)
-		wg := new(sync.WaitGroup)
+		// timer fires at the earliest per-stream deadline (lastSeen + MaxWaitTime).
+		// Start it stopped; it is armed on the first entry that starts a block.
+		timer := time.NewTimer(0)
+		if !timer.Stop() {
+			<-timer.C
+		}
 
-		for e := range in {
-			key := e.Labels.FastFingerprint()
-			s, ok := streams[key]
-			if !ok {
-				// Pass through entries until we hit first start line.
-				if !m.regex.MatchString(e.Line) {
-					level.Debug(m.logger).Log("msg", "pass through entry", "stream", key)
-					out <- e
-					continue
+		// nearestDeadline tracks the earliest active stream deadline so that
+		// we can easily update the timer if the incoming entry has a newer deadline.
+		var nearestDeadline time.Time
+
+		armTimer := func(deadline time.Time) {
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
 				}
-
-				level.Debug(m.logger).Log("msg", "creating new stream", "stream", key)
-				s = make(chan Entry)
-				streams[key] = s
-
-				wg.Add(1)
-				go m.runMultiline(s, out, wg)
 			}
-			level.Debug(m.logger).Log("msg", "pass entry", "stream", key, "line", e.Line)
-			s <- e
+			if d := time.Until(deadline); d > 0 {
+				timer.Reset(d)
+			} else {
+				timer.Reset(0)
+			}
+			nearestDeadline = deadline
 		}
 
-		// Close all streams and wait for them to finish being processed.
-		for _, s := range streams {
-			close(s)
+		// rescanDeadline rescans all streams to find the new nearest deadline
+		// after a flush removes a stream from contention. We include streams with
+		// currentLines==0 (flushed at max_lines) so they are cleaned up by the
+		// timer even when idle.
+		rescanDeadline := func() {
+			nearestDeadline = time.Time{}
+			for _, state := range m.streams {
+				if dl := state.lastSeen.Add(m.cfg.MaxWaitTime); nearestDeadline.IsZero() || dl.Before(nearestDeadline) {
+					nearestDeadline = dl
+				}
+			}
+			if nearestDeadline.IsZero() {
+				return // no streams; leave timer stopped
+			}
+			armTimer(nearestDeadline)
 		}
-		wg.Wait()
+
+		for {
+			select {
+			case e, ok := <-in:
+				if !ok {
+					// Flush all per-stream buffers when the input closes.
+					for _, state := range m.streams {
+						if state.currentLines > 0 {
+							out <- m.flushState(state)
+						}
+					}
+					m.streams = nil
+					return
+				}
+				for _, r := range m.processEntry(e) {
+					out <- r
+				}
+				// Arm the timer for any stream that now has the earliest deadline,
+				// including streams where currentLines==0 (just hit max_lines) so
+				// the timer fires to remove them if they subsequently go idle.
+				if key := e.Labels.FastFingerprint(); m.streams[key] != nil {
+					if dl := m.streams[key].lastSeen.Add(m.cfg.MaxWaitTime); nearestDeadline.IsZero() || dl.Before(nearestDeadline) {
+						armTimer(dl)
+					}
+				}
+			case <-timer.C:
+				nearestDeadline = time.Time{}
+				// Remove every stream whose deadline has been reached. Flush its
+				// buffer if it has accumulated lines; streams with currentLines==0
+				// (flushed at max_lines and then gone idle) are deleted.
+				now := time.Now()
+				for key, state := range m.streams {
+					if !state.lastSeen.Add(m.cfg.MaxWaitTime).After(now) {
+						if state.currentLines > 0 {
+							if Debug {
+								level.Debug(m.logger).Log("msg", fmt.Sprintf("flush multiline block due to %v timeout", m.cfg.MaxWaitTime), "block", state.buffer.String())
+							}
+							out <- m.flushState(state)
+						}
+						delete(m.streams, key)
+					}
+				}
+				rescanDeadline()
+			}
+		}
 	}()
 	return out
 }
 
-func (m *multilineStage) runMultiline(in chan Entry, out chan Entry, wg *sync.WaitGroup) {
-	defer wg.Done()
-
-	state := &multilineState{
-		buffer:       new(bytes.Buffer),
-		currentLines: 0,
+// processEntry processes a single entry synchronously, returning any entries
+// ready to emit. Before the first start line is seen for a stream, non-start
+// lines are passed through unchanged. Once a stream is started, all lines are
+// accumulated
+func (m *multilineStage) processEntry(e Entry) []Entry {
+	key := e.Labels.FastFingerprint()
+	if m.streams == nil {
+		m.streams = make(map[model.Fingerprint]*multilineState)
 	}
+	state, hasState := m.streams[key]
 
-	for {
-		select {
-		case <-time.After(m.cfg.MaxWaitTime):
+	var out []Entry
+
+	// flush stale block before processing new entry.
+	if hasState && state.currentLines > 0 && time.Since(state.lastSeen) >= m.cfg.MaxWaitTime {
+		if Debug {
 			level.Debug(m.logger).Log("msg", fmt.Sprintf("flush multiline block due to %v timeout", m.cfg.MaxWaitTime), "block", state.buffer.String())
-			m.flush(out, state)
-		case e, ok := <-in:
-			level.Debug(m.logger).Log("msg", "processing line", "line", e.Line, "stream", e.Labels.FastFingerprint())
-
-			if !ok {
-				level.Debug(m.logger).Log("msg", "flush multiline block because inbound closed", "block", state.buffer.String(), "stream", e.Labels.FastFingerprint())
-				m.flush(out, state)
-				return
-			}
-
-			isFirstLine := m.regex.MatchString(e.Line)
-			if isFirstLine {
-				level.Debug(m.logger).Log("msg", "flush multiline block because new start line", "block", state.buffer.String(), "stream", e.Labels.FastFingerprint())
-				m.flush(out, state)
-
-				// The start line entry is used to set timestamp and labels in the flush method.
-				// The timestamps for following lines are ignored for now.
-				state.startLineEntry = e
-			}
-
-			// Append block line
-			if state.buffer.Len() > 0 {
-				state.buffer.WriteRune('\n')
-			}
-
-			line := e.Line
-			if m.cfg.TrimNewlines {
-				line = strings.TrimRight(line, "\r\n")
-			}
-			state.buffer.WriteString(line)
-			state.currentLines++
-
-			if state.currentLines == m.cfg.MaxLines {
-				m.flush(out, state)
-			}
 		}
+		out = append(out, m.flushState(state))
 	}
+
+	isFirstLine := m.regex.MatchString(e.Line)
+	if !hasState {
+		// Pass through entries until the first start line for this stream.
+		if !isFirstLine {
+			if Debug {
+				level.Debug(m.logger).Log("msg", "pass through entry", "stream", key)
+			}
+			return append(out, e)
+		}
+		state = &multilineState{buffer: new(bytes.Buffer)}
+		m.streams[key] = state
+	}
+
+	// Stream is active: flush current block if a new start line arrived.
+	if isFirstLine && state.currentLines > 0 {
+		if Debug {
+			level.Debug(m.logger).Log("msg", "flush multiline block because new start line", "block", state.buffer.String(), "stream", key)
+		}
+		out = append(out, m.flushState(state))
+	}
+	// startLineEntry is only updated on start lines; it is intentionally
+	// preserved across max_lines flushes to match the original behaviour.
+	if isFirstLine {
+		state.startLineEntry = e
+	}
+
+	if Debug {
+		level.Debug(m.logger).Log("msg", "processing line", "line", e.Line, "stream", key)
+	}
+
+	// Append line to buffer.
+	if state.buffer.Len() > 0 {
+		state.buffer.WriteRune('\n')
+	}
+	line := e.Line
+	if m.cfg.TrimNewlines {
+		line = strings.TrimRight(line, "\r\n")
+	}
+	state.buffer.WriteString(line)
+	state.currentLines++
+	state.lastSeen = time.Now()
+
+	if state.currentLines == m.cfg.MaxLines {
+		out = append(out, m.flushState(state))
+	}
+
+	return out
 }
 
-func (m *multilineStage) flush(out chan Entry, s *multilineState) {
-	if s.buffer.Len() == 0 {
-		level.Debug(m.logger).Log("msg", "nothing to flush", "buffer_len", s.buffer.Len())
-		return
-	}
-
+// flushState collapses the accumulated block into a single entry and resets
+// the line counter and buffer. startLineEntry is intentionally not reset so
+// that subsequent lines (before the next start line) inherit its metadata.
+func (m *multilineStage) flushState(s *multilineState) Entry {
 	// copy extracted data.
 	extracted := make(map[string]any, len(s.startLineEntry.Extracted))
 	for k, v := range s.startLineEntry.Extracted {
@@ -210,9 +281,10 @@ func (m *multilineStage) flush(out chan Entry, s *multilineState) {
 		}),
 	}
 
-	s.Reset()
+	s.buffer.Reset()
+	s.currentLines = 0
 
-	out <- collapsed
+	return collapsed
 }
 
 // Cleanup implements Stage.

--- a/internal/component/loki/process/stages/multiline.go
+++ b/internal/component/loki/process/stages/multiline.go
@@ -156,15 +156,21 @@ func (m *multilineStage) Run(in chan Entry) chan Entry {
 						}
 					}
 					m.streams = nil
+					timer.Stop()
 					return
 				}
+				// Capture the stream key before emitting entries downstream.
+				// A downstream stage goroutine may mutate e.Labels concurrently
+				// once the entry is sent on out, which would race with a
+				// post-emit FastFingerprint() call.
+				key := e.Labels.FastFingerprint()
 				for _, r := range m.processEntry(e) {
 					out <- r
 				}
 				// Arm the timer for any stream that now has the earliest deadline,
 				// including streams where currentLines==0 (just hit max_lines) so
 				// the timer fires to remove them if they subsequently go idle.
-				if key := e.Labels.FastFingerprint(); m.streams[key] != nil {
+				if m.streams[key] != nil {
 					if dl := m.streams[key].lastSeen.Add(m.cfg.MaxWaitTime); nearestDeadline.IsZero() || dl.Before(nearestDeadline) {
 						armTimer(dl)
 					}

--- a/internal/component/loki/process/stages/multiline.go
+++ b/internal/component/loki/process/stages/multiline.go
@@ -120,12 +120,14 @@ func (m *multilineStage) Run(in chan Entry) chan Entry {
 				default:
 				}
 			}
-			if d := time.Until(deadline); d > 0 {
-				timer.Reset(d)
-			} else {
-				timer.Reset(0)
-			}
+			timer.Reset(max(0, time.Until(deadline)))
 			nearestDeadline = deadline
+		}
+
+		// isEarlierDeadline reports whether candidate should replace current as
+		// the nearest deadline (i.e. it is earlier, or there is no current deadline).
+		isEarlierDeadline := func(candidate, current time.Time) bool {
+			return current.IsZero() || candidate.Before(current)
 		}
 
 		// rescanDeadline rescans all streams to find the new nearest deadline
@@ -135,7 +137,7 @@ func (m *multilineStage) Run(in chan Entry) chan Entry {
 		rescanDeadline := func() {
 			nearestDeadline = time.Time{}
 			for _, state := range m.streams {
-				if dl := state.lastSeen.Add(m.cfg.MaxWaitTime); nearestDeadline.IsZero() || dl.Before(nearestDeadline) {
+				if dl := state.lastSeen.Add(m.cfg.MaxWaitTime); isEarlierDeadline(dl, nearestDeadline) {
 					nearestDeadline = dl
 				}
 			}
@@ -164,14 +166,14 @@ func (m *multilineStage) Run(in chan Entry) chan Entry {
 				// once the entry is sent on out, which would race with a
 				// post-emit FastFingerprint() call.
 				key := e.Labels.FastFingerprint()
-				for _, r := range m.processEntry(e) {
+				for _, r := range m.processEntry(key, e) {
 					out <- r
 				}
 				// Arm the timer for any stream that now has the earliest deadline,
 				// including streams where currentLines==0 (just hit max_lines) so
 				// the timer fires to remove them if they subsequently go idle.
 				if m.streams[key] != nil {
-					if dl := m.streams[key].lastSeen.Add(m.cfg.MaxWaitTime); nearestDeadline.IsZero() || dl.Before(nearestDeadline) {
+					if dl := m.streams[key].lastSeen.Add(m.cfg.MaxWaitTime); isEarlierDeadline(dl, nearestDeadline) {
 						armTimer(dl)
 					}
 				}
@@ -203,8 +205,7 @@ func (m *multilineStage) Run(in chan Entry) chan Entry {
 // ready to emit. Before the first start line is seen for a stream, non-start
 // lines are passed through unchanged. Once a stream is started, all lines are
 // accumulated
-func (m *multilineStage) processEntry(e Entry) []Entry {
-	key := e.Labels.FastFingerprint()
+func (m *multilineStage) processEntry(key model.Fingerprint, e Entry) []Entry {
 	if m.streams == nil {
 		m.streams = make(map[model.Fingerprint]*multilineState)
 	}

--- a/internal/component/loki/process/stages/multiline_test.go
+++ b/internal/component/loki/process/stages/multiline_test.go
@@ -463,62 +463,6 @@ func TestMultilineStageStreamsMapCleanedUpOnClose(t *testing.T) {
 	require.Equal(t, 0, len(stage.streams), "streams map should be empty after channel close")
 }
 
-// TestMultilineStageStreamsMapCleanedUpAfterMaxLinesFlush verifies that streams
-// flushed at the max_lines boundary (currentLines resets to 0) are removed from
-// the map by the timer once they go idle, not just at channel close.
-func TestMultilineStageStreamsMapCleanedUpAfterMaxLinesFlush(t *testing.T) {
-	mcfg := MultilineConfig{
-		Expression:   "^START",
-		MaxLines:     1, // every start line immediately flushes → currentLines=0
-		MaxWaitTime:  50 * time.Millisecond,
-		TrimNewlines: true,
-	}
-	regex, err := validateMultilineConfig(mcfg)
-	require.NoError(t, err)
-	stage := &multilineStage{
-		cfg:     mcfg,
-		regex:   regex,
-		logger:  log.NewNopLogger(),
-		streams: make(map[model.Fingerprint]*multilineState),
-	}
-
-	in := make(chan Entry, 3)
-	in <- simpleEntry("START a", "stream-a")
-	in <- simpleEntry("START b", "stream-b")
-	in <- simpleEntry("START c", "stream-c")
-
-	out := stage.Run(in)
-
-	mu := new(sync.Mutex)
-	var res []Entry
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		for e := range out {
-			mu.Lock()
-			res = append(res, e)
-			mu.Unlock()
-		}
-	}()
-
-	// All 3 are flushed immediately by MaxLines=1; wait for them to arrive.
-	require.Eventually(t, func() bool {
-		mu.Lock()
-		defer mu.Unlock()
-		return len(res) == 3
-	}, 2*time.Second, 10*time.Millisecond)
-
-	// Sleep past MaxWaitTime so the timer fires and removes the currentLines=0
-	// entries. There is no emitted output to observe from this timer fire, so
-	// a brief sleep is necessary before closing.
-	time.Sleep(100 * time.Millisecond)
-
-	close(in)
-	<-done
-
-	require.Equal(t, 0, len(stage.streams), "streams map should be empty after timer cleans up max_lines-flushed entries")
-}
-
 // TestMultilineStageStreamsMapCleanedUpAfterTimeout verifies that streams are
 // removed from the map when the timer-based flush fires, so the map does not
 // accumulate dead entries for streams that go idle.
@@ -552,7 +496,9 @@ func TestMultilineStageStreamsMapCleanedUpAfterTimeout(t *testing.T) {
 		}
 	}()
 
-	// Wait until the timer has flushed all 3 streams.
+	// Wait until the timer has flushed all 3 streams. Verifying len(res)==3
+	// before closing in proves the timer (not the close path) did the flush,
+	// which also deleted the streams from the map in the same goroutine.
 	require.Eventually(t, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
@@ -565,6 +511,42 @@ func TestMultilineStageStreamsMapCleanedUpAfterTimeout(t *testing.T) {
 	<-done
 
 	require.Equal(t, 0, len(stage.streams), "streams map should be empty after timer-based flush")
+}
+
+// TestMultilineStagePassThroughNoLabelRace is a race-detector regression test.
+// Pass-through entries (non-start lines before any start line) are emitted
+// unchanged, meaning the downstream stage goroutine shares the same Labels map.
+// A bug where FastFingerprint() was called after out<-r would race with
+// downstream label mutations; this test exercises that path.
+func TestMultilineStagePassThroughNoLabelRace(t *testing.T) {
+	mcfg := MultilineConfig{Expression: "^START", MaxWaitTime: 3 * time.Second, TrimNewlines: true}
+	regex, err := validateMultilineConfig(mcfg)
+	require.NoError(t, err)
+
+	stage := &multilineStage{cfg: mcfg, regex: regex, logger: log.NewNopLogger()}
+
+	in := make(chan Entry)
+	out := stage.Run(in)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for e := range out {
+			// Simulate a downstream stage (e.g. static_labels) mutating the
+			// Labels map of a received entry. This races with any post-emit
+			// read of e.Labels in the multiline goroutine.
+			e.Labels["injected"] = "value"
+		}
+	}()
+
+	go func() {
+		for i := 0; i < 50; i++ {
+			in <- simpleEntry("not a start line", "label")
+		}
+		close(in)
+	}()
+
+	<-done
 }
 
 var mlBenchTime = time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)

--- a/internal/component/loki/process/stages/multiline_test.go
+++ b/internal/component/loki/process/stages/multiline_test.go
@@ -8,10 +8,12 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/loki/pkg/push"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/featuregate"
 )
 
 func TestMultilineStageProcess(t *testing.T) {
@@ -196,21 +198,58 @@ func TestMultilineStageStartLineFlushedBeforeNew(t *testing.T) {
 	require.Equal(t, "continuation line 2", out[1].Line)
 }
 
-func simpleEntry(line, label string) Entry {
-	// We're adding a small wait time here, because on Windows, timers have a
-	// smaller resolution than on Linux. This can mess with the ordering of log
-	// lines, making the test Flaky on Windows runners.
-	time.Sleep(1 * time.Millisecond)
-	return Entry{
-		Extracted: map[string]any{},
-		Entry: loki.Entry{
-			Labels: model.LabelSet{"value": model.LabelValue(label)},
-			Entry: push.Entry{
-				Timestamp: time.Now(),
-				Line:      line,
-			},
-		},
+// TestMultilineStageMultipleMaxLinesFlushes verifies that startLineEntry is
+// preserved across max_lines flushes, so all sub-blocks inherit the original
+// start line's timestamp.
+func TestMultilineStageMultipleMaxLinesFlushes(t *testing.T) {
+	mcfg := MultilineConfig{
+		Expression:   "^START",
+		MaxLines:     2,
+		MaxWaitTime:  3 * time.Second,
+		TrimNewlines: true,
 	}
+	regex, err := validateMultilineConfig(mcfg)
+	require.NoError(t, err)
+
+	stage := &multilineStage{
+		cfg:    mcfg,
+		regex:  regex,
+		logger: log.NewNopLogger(),
+	}
+
+	startTs := time.Now()
+	lset := model.LabelSet{"value": "label"}
+
+	out := processEntries(stage,
+		Entry{
+			Extracted: map[string]any{},
+			Entry:     loki.NewEntry(lset.Clone(), push.Entry{Timestamp: startTs, Line: "START line 1"}),
+		},
+		Entry{
+			Extracted: map[string]any{},
+			Entry:     loki.NewEntry(lset.Clone(), push.Entry{Timestamp: startTs.Add(1 * time.Second), Line: "continuation 1"}),
+		},
+		Entry{
+			Extracted: map[string]any{},
+			Entry:     loki.NewEntry(lset.Clone(), push.Entry{Timestamp: startTs.Add(2 * time.Second), Line: "continuation 2"}),
+		},
+		Entry{
+			Extracted: map[string]any{},
+			Entry:     loki.NewEntry(lset.Clone(), push.Entry{Timestamp: startTs.Add(3 * time.Second), Line: "continuation 3"}),
+		},
+		Entry{
+			Extracted: map[string]any{},
+			Entry:     loki.NewEntry(lset.Clone(), push.Entry{Timestamp: startTs.Add(4 * time.Second), Line: "continuation 4"}),
+		},
+	)
+
+	require.Len(t, out, 3)
+	require.Equal(t, "START line 1\ncontinuation 1", out[0].Line)
+	require.Equal(t, startTs, out[0].Timestamp)
+	require.Equal(t, "continuation 2\ncontinuation 3", out[1].Line)
+	require.Equal(t, startTs, out[1].Timestamp)
+	require.Equal(t, "continuation 4", out[2].Line)
+	require.Equal(t, startTs, out[2].Timestamp)
 }
 
 func TestMultilineStageKeepingStructuredMetadata(t *testing.T) {
@@ -278,4 +317,344 @@ func TestMultilineStageKeepingStructuredMetadata(t *testing.T) {
 	require.Equal(t, model.LabelValue("one"), out[1].Labels["value"])
 	require.Equal(t, "sm-key2", out[1].StructuredMetadata[0].Name)
 	require.Equal(t, "sm-value2", out[1].StructuredMetadata[0].Value)
+}
+
+// TestMultilineStageMaxWaitTimeMultiStream verifies that the timeout flush only
+// affects streams that have been idle for at least max_wait_time, leaving
+// recently-active streams alone.
+func TestMultilineStageMaxWaitTimeMultiStream(t *testing.T) {
+	mcfg := MultilineConfig{Expression: "^START", MaxWaitTime: 100 * time.Millisecond, TrimNewlines: true}
+	regex, err := validateMultilineConfig(mcfg)
+	require.NoError(t, err)
+
+	stage := &multilineStage{
+		cfg:    mcfg,
+		regex:  regex,
+		logger: log.NewNopLogger(),
+	}
+
+	in := make(chan Entry, 4)
+	out := stage.Run(in)
+
+	mu := new(sync.Mutex)
+	var res []Entry
+	go func() {
+		for e := range out {
+			mu.Lock()
+			res = append(res, e)
+			mu.Unlock()
+		}
+	}()
+
+	go func() {
+		// Stream "idle" accumulates a block and then goes quiet — should be
+		// flushed by the timeout.
+		in <- simpleEntry("START idle", "idle")
+
+		// Stream "active" starts a block around the same time.
+		in <- simpleEntry("START active", "active")
+
+		// After the timeout window, "active" gets a new line — keeping it alive.
+		time.Sleep(80 * time.Millisecond)
+		in <- simpleEntry("continuation active", "active")
+
+		// Wait long enough for the idle stream to time out while active does not.
+		time.Sleep(150 * time.Millisecond)
+
+		close(in)
+	}()
+
+	// Wait for both streams to eventually flush (timeout + close).
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(res) == 2
+	}, 2*time.Second, 20*time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	lines := map[string]bool{}
+	for _, e := range res {
+		lines[e.Line] = true
+	}
+	require.True(t, lines["START idle"], "idle stream should have been flushed by timeout")
+	require.True(t, lines["START active\ncontinuation active"], "active stream should have been flushed on close")
+}
+
+// TestMultilineStagePostTimeoutContinuation verifies the three-phase sequence:
+// (1) start line accumulated, (2) timeout flushes the block, (3) a non-start
+// line arrives and is accumulated as a new block using the preserved
+// startLineEntry, (4) a new start line flushes that block.
+func TestMultilineStagePostTimeoutContinuation(t *testing.T) {
+	mcfg := MultilineConfig{Expression: "^START", MaxWaitTime: 100 * time.Millisecond, TrimNewlines: true}
+	regex, err := validateMultilineConfig(mcfg)
+	require.NoError(t, err)
+
+	stage := &multilineStage{
+		cfg:    mcfg,
+		regex:  regex,
+		logger: log.NewNopLogger(),
+	}
+
+	in := make(chan Entry, 4)
+	out := stage.Run(in)
+
+	mu := new(sync.Mutex)
+	var res []Entry
+	go func() {
+		for e := range out {
+			mu.Lock()
+			res = append(res, e)
+			mu.Unlock()
+		}
+	}()
+
+	go func() {
+		in <- simpleEntry("START first", "label")
+
+		// Let the timeout flush the first block.
+		time.Sleep(150 * time.Millisecond)
+
+		// Non-start line after timeout — accumulated as a new block.
+		in <- simpleEntry("continuation after timeout", "label")
+
+		// New start line should flush the accumulated non-start block, then
+		// begin its own block.
+		in <- simpleEntry("START second", "label")
+
+		close(in)
+	}()
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(res) == 3
+	}, 2*time.Second, 20*time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	require.Equal(t, "START first", res[0].Line)
+	require.Equal(t, "continuation after timeout", res[1].Line)
+	require.Equal(t, "START second", res[2].Line)
+}
+
+// TestMultilineStageStreamsMapCleanedUpOnClose verifies that the streams map
+// is empty after the input channel closes, so that closed-over state from one
+// pipeline run cannot leak into a future run.
+func TestMultilineStageStreamsMapCleanedUpOnClose(t *testing.T) {
+	mcfg := MultilineConfig{Expression: "^START", MaxWaitTime: 3 * time.Second, TrimNewlines: true}
+	regex, err := validateMultilineConfig(mcfg)
+	require.NoError(t, err)
+	stage := &multilineStage{
+		cfg:     mcfg,
+		regex:   regex,
+		logger:  log.NewNopLogger(),
+		streams: make(map[model.Fingerprint]*multilineState),
+	}
+
+	processEntries(stage,
+		simpleEntry("START a", "stream-a"),
+		simpleEntry("START b", "stream-b"),
+		simpleEntry("START c", "stream-c"),
+	)
+
+	require.Equal(t, 0, len(stage.streams), "streams map should be empty after channel close")
+}
+
+// TestMultilineStageStreamsMapCleanedUpAfterMaxLinesFlush verifies that streams
+// flushed at the max_lines boundary (currentLines resets to 0) are removed from
+// the map by the timer once they go idle, not just at channel close.
+func TestMultilineStageStreamsMapCleanedUpAfterMaxLinesFlush(t *testing.T) {
+	mcfg := MultilineConfig{
+		Expression:   "^START",
+		MaxLines:     1, // every start line immediately flushes → currentLines=0
+		MaxWaitTime:  50 * time.Millisecond,
+		TrimNewlines: true,
+	}
+	regex, err := validateMultilineConfig(mcfg)
+	require.NoError(t, err)
+	stage := &multilineStage{
+		cfg:     mcfg,
+		regex:   regex,
+		logger:  log.NewNopLogger(),
+		streams: make(map[model.Fingerprint]*multilineState),
+	}
+
+	in := make(chan Entry, 3)
+	in <- simpleEntry("START a", "stream-a")
+	in <- simpleEntry("START b", "stream-b")
+	in <- simpleEntry("START c", "stream-c")
+
+	out := stage.Run(in)
+
+	mu := new(sync.Mutex)
+	var res []Entry
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for e := range out {
+			mu.Lock()
+			res = append(res, e)
+			mu.Unlock()
+		}
+	}()
+
+	// All 3 are flushed immediately by MaxLines=1; wait for them to arrive.
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(res) == 3
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// Sleep past MaxWaitTime so the timer fires and removes the currentLines=0
+	// entries. There is no emitted output to observe from this timer fire, so
+	// a brief sleep is necessary before closing.
+	time.Sleep(100 * time.Millisecond)
+
+	close(in)
+	<-done
+
+	require.Equal(t, 0, len(stage.streams), "streams map should be empty after timer cleans up max_lines-flushed entries")
+}
+
+// TestMultilineStageStreamsMapCleanedUpAfterTimeout verifies that streams are
+// removed from the map when the timer-based flush fires, so the map does not
+// accumulate dead entries for streams that go idle.
+func TestMultilineStageStreamsMapCleanedUpAfterTimeout(t *testing.T) {
+	mcfg := MultilineConfig{Expression: "^START", MaxWaitTime: 50 * time.Millisecond, TrimNewlines: true}
+	regex, err := validateMultilineConfig(mcfg)
+	require.NoError(t, err)
+	stage := &multilineStage{
+		cfg:     mcfg,
+		regex:   regex,
+		logger:  log.NewNopLogger(),
+		streams: make(map[model.Fingerprint]*multilineState),
+	}
+
+	in := make(chan Entry, 3)
+	in <- simpleEntry("START a", "stream-a")
+	in <- simpleEntry("START b", "stream-b")
+	in <- simpleEntry("START c", "stream-c")
+
+	out := stage.Run(in)
+
+	mu := new(sync.Mutex)
+	var res []Entry
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for e := range out {
+			mu.Lock()
+			res = append(res, e)
+			mu.Unlock()
+		}
+	}()
+
+	// Wait until the timer has flushed all 3 streams.
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(res) == 3
+	}, 2*time.Second, 20*time.Millisecond)
+
+	// Close input and wait for the Run goroutine to exit; m.streams is then
+	// safe to inspect without a data race.
+	close(in)
+	<-done
+
+	require.Equal(t, 0, len(stage.streams), "streams map should be empty after timer-based flush")
+}
+
+var mlBenchTime = time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// BenchmarkMultilineStage benchmarks the multiline stage with a realistic
+// stack-trace pattern: 1 firstline ("Date:") followed by 9 continuation lines,
+// cycling continuously. Each input line amortises one-tenth of the flush cost.
+func BenchmarkMultilineStage(b *testing.B) {
+	origDebug := Debug
+	b.Cleanup(func() { Debug = origDebug })
+
+	for _, debugEnabled := range []bool{false, true} {
+		name := "debug=false"
+		if debugEnabled {
+			name = "debug=true"
+		}
+		b.Run(name, func(b *testing.B) {
+			Debug = debugEnabled
+
+			stages := []StageConfig{
+				{
+					MultilineConfig: &MultilineConfig{
+						Expression:   "^Date:",
+						MaxWaitTime:  3 * time.Second,
+						MaxLines:     128,
+						TrimNewlines: true,
+					},
+				},
+			}
+
+			pl, err := NewPipeline(
+				log.NewNopLogger(),
+				stages,
+				prometheus.NewRegistry(),
+				featuregate.StabilityGenerallyAvailable,
+			)
+			if err != nil {
+				b.Fatalf("NewPipeline: %v", err)
+			}
+
+			in := make(chan Entry)
+			out := pl.Run(in)
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				for range out {
+				}
+			}()
+
+			const linesPerBlock = 10
+			block := make([]Entry, linesPerBlock)
+			block[0] = newEntry(nil, model.LabelSet{"job": "bench"},
+				"Date: Mon, 01 Jan 2024 00:00:00 +0000 error occurred", mlBenchTime)
+			for i := 1; i < linesPerBlock; i++ {
+				block[i] = newEntry(nil, model.LabelSet{"job": "bench"},
+					"\tat com.example.Foo.bar(Foo.java:42)", mlBenchTime)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			i := 0
+			for b.Loop() {
+				e := block[i%linesPerBlock]
+				e.Entry.Labels = e.Entry.Labels.Clone()
+				e.Extracted = make(map[string]any)
+				in <- e
+				i++
+			}
+
+			close(in)
+			<-done
+		})
+	}
+}
+
+func simpleEntry(line, label string) Entry {
+	// We're adding a small wait time here, because on Windows, timers have a
+	// smaller resolution than on Linux. This can mess with the ordering of log
+	// lines, making the test Flaky on Windows runners.
+	time.Sleep(1 * time.Millisecond)
+	return Entry{
+		Extracted: map[string]any{},
+		Entry: loki.Entry{
+			Labels: model.LabelSet{"value": model.LabelValue(label)},
+			Entry: push.Entry{
+				Timestamp: time.Now(),
+				Line:      line,
+			},
+		},
+	}
 }


### PR DESCRIPTION
### Brief description of Pull Request

Replace per-stream goroutines in the `loki.process` multiline stage with a single goroutine and a shared `time.Timer`, reducing allocations by up to 76% and latency by up to 39% under benchmark.

### Pull Request Details

The multiline stage previously spawned one goroutine per active log stream to handle `max_wait_time` timeouts via `time.After`. In environments with many label combinations this creates O(N) goroutines and allocations that grow with cardinality.

The new implementation uses a single goroutine with a shared timer set to the earliest per-stream deadline. When it fires, all expired streams are flushed and the timer is rescheduled to the next deadline. Streams are removed from the map after a timeout flush, preventing unbounded map growth for idle streams.

All debug log calls are now wrapped in `if Debug { ... }` guards, consistent with the `drop`, `regex`, and `labels` stages, to avoid `fmt.Sprintf` and `buffer.String()` more overhead when debug logging is disabled.

**Benchmarks**

```
                          │   main   │            this PR            │
                          │  sec/op  │   sec/op     vs base          │
MultilineStage/debug=false  2.131µ ±1%   1.310µ ±1%  -38.55% (p=0.000 n=10)
MultilineStage/debug=true   2.131µ ±1%   1.610µ ±1%  -24.45% (p=0.000 n=10)

                          │   main   │            this PR            │
                          │  B/op    │   B/op       vs base          │
MultilineStage/debug=false  2112.0 ±0%    808.0 ±0%  -61.74% (p=0.000 n=10)
MultilineStage/debug=true  2.062Ki ±0%  1.310Ki ±0%  -36.51% (p=0.000 n=10)

                          │   main   │            this PR            │
                          │ allocs/op │  allocs/op  vs base          │
MultilineStage/debug=false  21.000 ±0%    5.000 ±0%  -76.19% (p=0.000 n=10)
MultilineStage/debug=true    21.00 ±0%   12.00 ±0%  -42.86% (p=0.000 n=10)
```

### Notes to the Reviewer

Two intentional behavioural changes:

1. **Stale-block flush on entry receipt**: Previously a timed-out block was only flushed when the `time.After` goroutine fired. The new code also flushes inline in `processEntry` when a new entry arrives for a stream that has been idle past `max_wait_time`. The outcome is the same — the block is flushed before the new entry is processed — but the trigger differs.

2. **Cross-stream output ordering is now deterministic**: The old goroutine-per-stream model had multiple goroutines writing concurrently to `out`, so ordering across streams was non-deterministic. The new model serializes all output through a single goroutine, so entries are emitted in arrival order.

### PR Checklist

- [x] Tests updated