### PR TITLE
ci: Add PR-scoped Buildx cache for Linux image builds

### DIFF
--- a/.github/workflows/check-linux-container.yml
+++ b/.github/workflows/check-linux-container.yml
@@ -25,6 +25,7 @@ jobs:
     with:
       img-name: alloy-devel
       push: false
+      cache-scope: alloy-pr-${{ github.event.pull_request.number || github.run_id }}-linux
 
   check-linux-boringcrypto-container:
     uses: ./.github/workflows/publish-alloy-linux.yml
@@ -34,3 +35,4 @@ jobs:
     with:
       img-name: alloy-devel-boringcrypto
       push: false
+      cache-scope: alloy-pr-${{ github.event.pull_request.number || github.run_id }}-linux-boringcrypto

--- a/.github/workflows/check-linux-container.yml
+++ b/.github/workflows/check-linux-container.yml
@@ -35,4 +35,4 @@ jobs:
     with:
       img-name: alloy-devel-boringcrypto
       push: false
-      cache-scope: alloy-pr-${{ github.event.pull_request.number || github.run_id }}-linux-boringcrypto
+      cache-scope: alloy-pr-${{ github.event.pull_request.number || github.run_id }}-linux

--- a/.github/workflows/publish-alloy-devel-pr.yml
+++ b/.github/workflows/publish-alloy-devel-pr.yml
@@ -17,6 +17,7 @@ jobs:
       img-name: alloy-devel-pr
       dev: true
       pr-number: ${{ github.event.pull_request.number }}
+      cache-scope: alloy-pr-${{ github.event.pull_request.number }}-devel-linux
 
   publish_linux_boringcrypto_container:
     if: ${{ github.repository == 'grafana/alloy' && contains(github.event.pull_request.labels.*.name, 'publish-dev:linux-bc')}}
@@ -28,6 +29,7 @@ jobs:
       img-name:  alloy-devel-boringcrypto-pr
       dev: true
       pr-number: ${{ github.event.pull_request.number }}
+      cache-scope: alloy-pr-${{ github.event.pull_request.number }}-devel-linux-boringcrypto
 
   publish_windows_container:
     if: ${{ github.repository == 'grafana/alloy' && contains(github.event.pull_request.labels.*.name, 'publish-dev:windows')}}

--- a/.github/workflows/publish-alloy-devel-pr.yml
+++ b/.github/workflows/publish-alloy-devel-pr.yml
@@ -17,7 +17,7 @@ jobs:
       img-name: alloy-devel-pr
       dev: true
       pr-number: ${{ github.event.pull_request.number }}
-      cache-scope: alloy-pr-${{ github.event.pull_request.number }}-devel-linux
+      cache-scope: alloy-pr-${{ github.event.pull_request.number }}-linux
 
   publish_linux_boringcrypto_container:
     if: ${{ github.repository == 'grafana/alloy' && contains(github.event.pull_request.labels.*.name, 'publish-dev:linux-bc')}}
@@ -29,7 +29,7 @@ jobs:
       img-name:  alloy-devel-boringcrypto-pr
       dev: true
       pr-number: ${{ github.event.pull_request.number }}
-      cache-scope: alloy-pr-${{ github.event.pull_request.number }}-devel-linux-boringcrypto
+      cache-scope: alloy-pr-${{ github.event.pull_request.number }}-linux
 
   publish_windows_container:
     if: ${{ github.repository == 'grafana/alloy' && contains(github.event.pull_request.labels.*.name, 'publish-dev:windows')}}

--- a/.github/workflows/publish-alloy-linux.yml
+++ b/.github/workflows/publish-alloy-linux.yml
@@ -6,6 +6,10 @@ on:
       img-name:
         required: true
         type: string
+      cache-scope:
+        required: false
+        type: string
+        default: ""
       push:
         required: false
         type: boolean
@@ -62,6 +66,10 @@ jobs:
         go-version-file: go.mod
         cache: false
 
+    - name: Expose GitHub runtime for Buildx cache
+      if: ${{ inputs.cache-scope != '' }}
+      uses: crazy-max/ghaction-github-runtime@3cb05d89e1f492524af3d41a1c98c83bc3025124 # v3
+
     - run: |
         docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
         docker buildx create --name multiarch-alloy-${IMG_NAME}-${GITHUB_SHA} --driver docker-container --use
@@ -71,3 +79,4 @@ jobs:
         PUSH_ALLOY_IMAGE: ${{ inputs.push }}
         IMG_NAME: ${{ inputs.img-name }}
         GITHUB_PR_NUMBER: ${{ inputs.pr-number }}
+        DOCKER_BUILD_CACHE_SCOPE: ${{ inputs.cache-scope }}

--- a/tools/ci/docker-containers
+++ b/tools/ci/docker-containers
@@ -17,6 +17,7 @@ export TARGET_CONTAINER=${1:-}
 PUSH_ALLOY_IMAGE=${PUSH_ALLOY_IMAGE:-}
 export GITHUB_REF_TYPE=${GITHUB_REF_TYPE:-}
 GITHUB_PR_NUMBER=${GITHUB_PR_NUMBER:-}
+DOCKER_BUILD_CACHE_SCOPE=${DOCKER_BUILD_CACHE_SCOPE:-}
 
 if [ "$GITHUB_REF_TYPE" = "tag" ]; then
   export GITHUB_TAG="$GITHUB_REF_NAME"
@@ -27,6 +28,11 @@ fi
 DOCKER_FLAGS=""
 if [[ $PUSH_ALLOY_IMAGE == "true"  ]]; then
 	DOCKER_FLAGS="--push"
+fi
+
+DOCKER_CACHE_FLAGS=""
+if [[ -n "$DOCKER_BUILD_CACHE_SCOPE" ]]; then
+	DOCKER_CACHE_FLAGS="--cache-from type=gha,scope=$DOCKER_BUILD_CACHE_SCOPE --cache-to type=gha,mode=max,scope=$DOCKER_BUILD_CACHE_SCOPE"
 fi
 
 export RELEASE_ALLOY_IMAGE=grafana/alloy
@@ -75,13 +81,14 @@ export BUILD_PLATFORMS_BORINGCRYPTO=linux/amd64,linux/arm64
 
 case "$TARGET_CONTAINER" in
   alloy)
-    docker buildx build $DOCKER_FLAGS        \
-      --platform $BUILD_PLATFORMS            \
-      --build-arg RELEASE_BUILD=1            \
-      --build-arg VERSION="$VERSION"         \
-      -t "$RELEASE_ALLOY_IMAGE:$TAG_VERSION" \
-      -t "$RELEASE_ALLOY_IMAGE:$BRANCH_TAG"  \
-      -f Dockerfile                          \
+    docker buildx build $DOCKER_FLAGS         \
+      $DOCKER_CACHE_FLAGS                     \
+      --platform $BUILD_PLATFORMS             \
+      --build-arg RELEASE_BUILD=1             \
+      --build-arg VERSION="$VERSION"          \
+      -t "$RELEASE_ALLOY_IMAGE:$TAG_VERSION"  \
+      -t "$RELEASE_ALLOY_IMAGE:$BRANCH_TAG"   \
+      -f Dockerfile                           \
       .
     ;;
 
@@ -90,25 +97,27 @@ case "$TARGET_CONTAINER" in
       BRANCH_TAG=$BORINGCRYPTO_LATEST
     fi
 
-    docker buildx build $DOCKER_FLAGS                     \
-      --platform $BUILD_PLATFORMS_BORINGCRYPTO            \
-      --build-arg RELEASE_BUILD=1                         \
-      --build-arg VERSION="$VERSION"                      \
-      --build-arg GOEXPERIMENT=boringcrypto               \
-      -t "$RELEASE_ALLOY_IMAGE:$TAG_VERSION-boringcrypto" \
-      -t "$RELEASE_ALLOY_IMAGE:$BRANCH_TAG"               \
-      -f Dockerfile                                       \
+    docker buildx build $DOCKER_FLAGS                      \
+      $DOCKER_CACHE_FLAGS                                  \
+      --platform $BUILD_PLATFORMS_BORINGCRYPTO             \
+      --build-arg RELEASE_BUILD=1                          \
+      --build-arg VERSION="$VERSION"                       \
+      --build-arg GOEXPERIMENT=boringcrypto                \
+      -t "$RELEASE_ALLOY_IMAGE:$TAG_VERSION-boringcrypto"  \
+      -t "$RELEASE_ALLOY_IMAGE:$BRANCH_TAG"                \
+      -f Dockerfile                                        \
       .
     ;;
 
   alloy-devel)
-    docker buildx build $DOCKER_FLAGS      \
-      --platform $BUILD_PLATFORMS          \
-      --build-arg RELEASE_BUILD=1          \
-      --build-arg VERSION="$VERSION"       \
-      -t "$DEVEL_ALLOY_IMAGE:$TAG_VERSION" \
-      -t "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"  \
-      -f Dockerfile                        \
+    docker buildx build $DOCKER_FLAGS       \
+      $DOCKER_CACHE_FLAGS                   \
+      --platform $BUILD_PLATFORMS           \
+      --build-arg RELEASE_BUILD=1           \
+      --build-arg VERSION="$VERSION"        \
+      -t "$DEVEL_ALLOY_IMAGE:$TAG_VERSION"  \
+      -t "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"   \
+      -f Dockerfile                         \
       .
     ;;
 
@@ -117,39 +126,42 @@ case "$TARGET_CONTAINER" in
       BRANCH_TAG=$BORINGCRYPTO_LATEST
     fi
 
-    docker buildx build $DOCKER_FLAGS                   \
-      --platform $BUILD_PLATFORMS_BORINGCRYPTO          \
-      --build-arg RELEASE_BUILD=1                       \
-      --build-arg VERSION="$VERSION"                    \
-      --build-arg GOEXPERIMENT=boringcrypto             \
-      -t "$DEVEL_ALLOY_IMAGE:$TAG_VERSION-boringcrypto" \
-      -t "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"               \
-      -f Dockerfile                                     \
+    docker buildx build $DOCKER_FLAGS                    \
+      $DOCKER_CACHE_FLAGS                                \
+      --platform $BUILD_PLATFORMS_BORINGCRYPTO           \
+      --build-arg RELEASE_BUILD=1                        \
+      --build-arg VERSION="$VERSION"                     \
+      --build-arg GOEXPERIMENT=boringcrypto              \
+      -t "$DEVEL_ALLOY_IMAGE:$TAG_VERSION-boringcrypto"  \
+      -t "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"                \
+      -f Dockerfile                                      \
       .
     ;;
 
   alloy-devel-pr)
 	TAG="pr-${GITHUB_PR_NUMBER}-${TAG_VERSION}"
 
-    docker buildx build $DOCKER_FLAGS      \
-      --platform $BUILD_PLATFORMS          \
-      --build-arg RELEASE_BUILD=1          \
-      --build-arg VERSION="$VERSION"       \
-      -t "$DEVEL_ALLOY_IMAGE:$TAG" \
-      -f Dockerfile                        \
+    docker buildx build $DOCKER_FLAGS \
+      $DOCKER_CACHE_FLAGS             \
+      --platform $BUILD_PLATFORMS     \
+      --build-arg RELEASE_BUILD=1     \
+      --build-arg VERSION="$VERSION"  \
+      -t "$DEVEL_ALLOY_IMAGE:$TAG"    \
+      -f Dockerfile                   \
       .
     ;;
 
   alloy-devel-boringcrypto-pr)
 	TAG="pr-${GITHUB_PR_NUMBER}-${TAG_VERSION}"
 
-    docker buildx build $DOCKER_FLAGS                   \
-      --platform $BUILD_PLATFORMS_BORINGCRYPTO          \
-      --build-arg RELEASE_BUILD=1                       \
-      --build-arg VERSION="$VERSION"                    \
-      --build-arg GOEXPERIMENT=boringcrypto             \
+    docker buildx build $DOCKER_FLAGS          \
+      $DOCKER_CACHE_FLAGS                      \
+      --platform $BUILD_PLATFORMS_BORINGCRYPTO \
+      --build-arg RELEASE_BUILD=1              \
+      --build-arg VERSION="$VERSION"           \
+      --build-arg GOEXPERIMENT=boringcrypto    \
       -t "$DEVEL_ALLOY_IMAGE:$TAG-boringcrypto" \
-      -f Dockerfile                                     \
+      -f Dockerfile                            \
       .
     ;;
 

--- a/tools/ci/docker-containers
+++ b/tools/ci/docker-containers
@@ -25,14 +25,17 @@ else
   export GITHUB_TAG=""
 fi
 
-DOCKER_FLAGS=""
+DOCKER_FLAGS=()
 if [[ $PUSH_ALLOY_IMAGE == "true"  ]]; then
-	DOCKER_FLAGS="--push"
+	DOCKER_FLAGS=("--push")
 fi
 
-DOCKER_CACHE_FLAGS=""
+DOCKER_CACHE_FLAGS=()
 if [[ -n "$DOCKER_BUILD_CACHE_SCOPE" ]]; then
-	DOCKER_CACHE_FLAGS="--cache-from type=gha,scope=$DOCKER_BUILD_CACHE_SCOPE --cache-to type=gha,mode=max,scope=$DOCKER_BUILD_CACHE_SCOPE"
+	DOCKER_CACHE_FLAGS=(
+		"--cache-from" "type=gha,scope=$DOCKER_BUILD_CACHE_SCOPE"
+		"--cache-to" "type=gha,mode=max,scope=$DOCKER_BUILD_CACHE_SCOPE"
+	)
 fi
 
 export RELEASE_ALLOY_IMAGE=grafana/alloy
@@ -81,8 +84,8 @@ export BUILD_PLATFORMS_BORINGCRYPTO=linux/amd64,linux/arm64
 
 case "$TARGET_CONTAINER" in
   alloy)
-    docker buildx build $DOCKER_FLAGS         \
-      $DOCKER_CACHE_FLAGS                     \
+    docker buildx build "${DOCKER_FLAGS[@]}"  \
+      "${DOCKER_CACHE_FLAGS[@]}"              \
       --platform $BUILD_PLATFORMS             \
       --build-arg RELEASE_BUILD=1             \
       --build-arg VERSION="$VERSION"          \
@@ -97,8 +100,8 @@ case "$TARGET_CONTAINER" in
       BRANCH_TAG=$BORINGCRYPTO_LATEST
     fi
 
-    docker buildx build $DOCKER_FLAGS                      \
-      $DOCKER_CACHE_FLAGS                                  \
+    docker buildx build "${DOCKER_FLAGS[@]}"               \
+      "${DOCKER_CACHE_FLAGS[@]}"                           \
       --platform $BUILD_PLATFORMS_BORINGCRYPTO             \
       --build-arg RELEASE_BUILD=1                          \
       --build-arg VERSION="$VERSION"                       \
@@ -110,8 +113,8 @@ case "$TARGET_CONTAINER" in
     ;;
 
   alloy-devel)
-    docker buildx build $DOCKER_FLAGS       \
-      $DOCKER_CACHE_FLAGS                   \
+    docker buildx build "${DOCKER_FLAGS[@]}"  \
+      "${DOCKER_CACHE_FLAGS[@]}"              \
       --platform $BUILD_PLATFORMS           \
       --build-arg RELEASE_BUILD=1           \
       --build-arg VERSION="$VERSION"        \
@@ -126,8 +129,8 @@ case "$TARGET_CONTAINER" in
       BRANCH_TAG=$BORINGCRYPTO_LATEST
     fi
 
-    docker buildx build $DOCKER_FLAGS                    \
-      $DOCKER_CACHE_FLAGS                                \
+    docker buildx build "${DOCKER_FLAGS[@]}"  \
+      "${DOCKER_CACHE_FLAGS[@]}"                         \
       --platform $BUILD_PLATFORMS_BORINGCRYPTO           \
       --build-arg RELEASE_BUILD=1                        \
       --build-arg VERSION="$VERSION"                     \
@@ -139,10 +142,10 @@ case "$TARGET_CONTAINER" in
     ;;
 
   alloy-devel-pr)
-	TAG="pr-${GITHUB_PR_NUMBER}-${TAG_VERSION}"
+    TAG="pr-${GITHUB_PR_NUMBER}-${TAG_VERSION}"
 
-    docker buildx build $DOCKER_FLAGS \
-      $DOCKER_CACHE_FLAGS             \
+    docker buildx build "${DOCKER_FLAGS[@]}"  \
+      "${DOCKER_CACHE_FLAGS[@]}"              \
       --platform $BUILD_PLATFORMS     \
       --build-arg RELEASE_BUILD=1     \
       --build-arg VERSION="$VERSION"  \
@@ -152,10 +155,10 @@ case "$TARGET_CONTAINER" in
     ;;
 
   alloy-devel-boringcrypto-pr)
-	TAG="pr-${GITHUB_PR_NUMBER}-${TAG_VERSION}"
+    TAG="pr-${GITHUB_PR_NUMBER}-${TAG_VERSION}"
 
-    docker buildx build $DOCKER_FLAGS          \
-      $DOCKER_CACHE_FLAGS                      \
+    docker buildx build "${DOCKER_FLAGS[@]}"   \
+      "${DOCKER_CACHE_FLAGS[@]}"               \
       --platform $BUILD_PLATFORMS_BORINGCRYPTO \
       --build-arg RELEASE_BUILD=1              \
       --build-arg VERSION="$VERSION"           \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Brief description of Pull Request
Add PR-scoped Buildx cache wiring for Linux Alloy image workflows so repeated PR runs can reuse Docker layers.

### Pull Request Details
- Add optional `cache-scope` input and runtime setup in shared Linux publish workflow.
- Add `type=gha` cache flags in `tools/ci/docker-containers` using shellcheck-safe argument arrays.
- Use a shared PR Linux cache scope in `check-linux-container` and `publish-alloy-devel-pr` Linux jobs.

### Issue(s) fixed by this Pull Request


### Notes to the Reviewer


### PR Checklist
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f83e953-20da-49ad-9969-90b217b47245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f83e953-20da-49ad-9969-90b217b47245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

