### PR TITLE
fix: respect logging levels in mongodb_exporter

### DIFF
--- a/internal/runtime/internal/controller/node_builtin_component.go
+++ b/internal/runtime/internal/controller/node_builtin_component.go
@@ -184,7 +184,7 @@ func getManagedOptions(globals ComponentGlobals, cn *BuiltinComponentNode) compo
 	parent, id := splitPath(cn.globalID)
 	return component.Options{
 		ID:     cn.globalID,
-		Logger: log.With(globals.Logger, "component_path", parent, "component_id", id),
+		Logger: logging.NewLevelAwareLogger(log.With(globals.Logger, "component_path", parent, "component_id", id), globals.Logger),
 		Registerer: prometheus.WrapRegistererWith(prometheus.Labels{
 			"component_path": parent,
 			"component_id":   id,

--- a/internal/runtime/logging/slgk_handler.go
+++ b/internal/runtime/logging/slgk_handler.go
@@ -26,18 +26,32 @@ func NewSlogGoKitHandler(logger log.Logger) *SlogGoKitHandler {
 }
 
 func (h SlogGoKitHandler) Enabled(ctx context.Context, level slog.Level) bool {
-	// Sometimes libraries will use this to check if certain logs should be emitted
-	// and then write logs using other methods such as fmt package.
-	// See https://github.com/percona/mongodb_exporter/blob/8290ba50eeb73d6380885d2546619afc878a6016/exporter/debug.go#L26-L42.
-	// We try to assert the concrete type so we can delegate the check.
-	// As a fallback we keep the old behavior.
-	l, ok := h.logger.(*Logger)
-	if !ok {
-		// return always true, we expect the underlying logger to handle the level
-		return true
+	// Some libraries check Enabled() to decide whether to emit output via
+	// non-slog paths (e.g. fmt.Fprintln to stderr). See:
+	// https://github.com/percona/mongodb_exporter/blob/8290ba50eeb73d6380885d2546619afc878a6016/exporter/debug.go#L26-L42
+	if ea, ok := h.logger.(EnabledAware); ok {
+		return ea.Enabled(ctx, level)
 	}
+	return true
+}
 
-	return l.Enabled(ctx, level)
+// levelAwareLogger wraps a go-kit logger and implements EnabledAware by
+// delegating to a separate EnabledAware instance. This preserves level
+// awareness through go-kit's log.With() wrapping.
+type levelAwareLogger struct {
+	log.Logger
+	ea EnabledAware
+}
+
+func (l *levelAwareLogger) Enabled(ctx context.Context, level slog.Level) bool {
+	return l.ea.Enabled(ctx, level)
+}
+
+// NewLevelAwareLogger returns a go-kit logger that also implements EnabledAware,
+// delegating level checks to ea. Use this when wrapping a logger with log.With()
+// to preserve the ability to check log levels via the EnabledAware interface.
+func NewLevelAwareLogger(logger log.Logger, ea EnabledAware) log.Logger {
+	return &levelAwareLogger{Logger: logger, ea: ea}
 }
 
 func (h SlogGoKitHandler) Handle(ctx context.Context, record slog.Record) error {

--- a/internal/runtime/logging/slgk_handler_test.go
+++ b/internal/runtime/logging/slgk_handler_test.go
@@ -2,6 +2,7 @@ package logging_test
 
 import (
 	"bytes"
+	"context"
 	"log/slog"
 	"strings"
 	"testing"
@@ -11,6 +12,33 @@ import (
 
 	"github.com/grafana/alloy/internal/runtime/logging"
 )
+
+// TestEnabledWithWrappedLogger verifies that SlogGoKitHandler.Enabled() correctly
+// reports the configured level when the go-kit logger is wrapped via log.With().
+// This is important for libraries like the Percona mongodb_exporter that call
+// Enabled() to decide whether to emit output via non-slog paths.
+func TestEnabledWithWrappedLogger(t *testing.T) {
+	buffer := bytes.NewBuffer(nil)
+	baseLogger, err := logging.New(buffer, logging.Options{Level: logging.LevelInfo, Format: logging.FormatLogfmt})
+	require.NoError(t, err)
+
+	// Wrap like the component runtime does: log.With strips EnabledAware,
+	// so use NewLevelAwareLogger to restore it.
+	wrapped := logging.NewLevelAwareLogger(log.With(baseLogger, "component", "test"), baseLogger)
+	handler := logging.NewSlogGoKitHandler(wrapped)
+
+	ctx := context.Background()
+	require.False(t, handler.Enabled(ctx, slog.LevelDebug), "debug should be disabled at info level")
+	require.True(t, handler.Enabled(ctx, slog.LevelInfo), "info should be enabled at info level")
+	require.True(t, handler.Enabled(ctx, slog.LevelError), "error should be enabled at info level")
+
+	err = baseLogger.Update(logging.Options{Level: logging.LevelError, Format: logging.FormatLogfmt})
+	require.NoError(t, err)
+
+	require.False(t, handler.Enabled(ctx, slog.LevelDebug), "debug should be disabled at error level")
+	require.False(t, handler.Enabled(ctx, slog.LevelInfo), "info should be disabled at error level")
+	require.True(t, handler.Enabled(ctx, slog.LevelError), "error should be enabled at error level")
+}
 
 func TestUpdateLevel(t *testing.T) {
 	buffer := bytes.NewBuffer(nil)

--- a/internal/web/ui/package-lock.json
+++ b/internal/web/ui/package-lock.json
@@ -83,7 +83,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1230,7 +1229,6 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
       "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.7.2"
       },
@@ -1686,7 +1684,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2701,7 +2698,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3112,7 +3110,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -3124,7 +3121,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -3217,7 +3213,6 @@
       "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.1",
         "@typescript-eslint/types": "8.57.1",
@@ -3649,7 +3644,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3696,6 +3690,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3818,7 +3813,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4417,7 +4411,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4575,7 +4568,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-css": {
       "version": "2.1.0",
@@ -4731,7 +4725,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5274,7 +5267,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.10"
       },
@@ -5342,8 +5334,7 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.0.3.tgz",
       "integrity": "sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -5716,6 +5707,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5753,7 +5745,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.6.tgz",
       "integrity": "sha512-Y07CUOE+HQXbVDCGl3LXggqJDbXDP2pArc2C1N1RRMN0ONiShoSsIInMd5Gsxupe7fKLpgimTV+HOJ9r7bA+pg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -5870,8 +5861,7 @@
       "version": "0.34.1",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.1.tgz",
       "integrity": "sha512-FKc80TyiMaruhJKKPz5SpJPIjL+dflGvz4CpuThaPMc94AyN7SeC9HQ8hrvaxX7EyHdJcUY5i4D0gNyJj1vSZQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -6181,7 +6171,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6256,6 +6245,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6271,6 +6261,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6283,7 +6274,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prismjs": {
       "version": "1.30.0",
@@ -6636,7 +6628,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6699,7 +6690,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7102,8 +7092,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
@@ -7325,7 +7314,6 @@
       "resolved": "https://registry.npmjs.org/slate/-/slate-0.47.9.tgz",
       "integrity": "sha512-EK4O6b7lGt+g5H9PGw9O5KCM4RrOvOgE9mPi3rzQ0zDRlgAb2ga4TdpS6XNQbrsJWsc8I1fjaSsUeCqCUhhi9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^3.1.0",
         "direction": "^0.1.5",
@@ -7779,8 +7767,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -7807,7 +7794,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7976,7 +7962,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",


### PR DESCRIPTION
**Describe the change:**
Fixed the Enabled() method to respect logging levels. mongodb_exporter and similar libraries check Enabled() before logging to stderr, but we were always returning true which bypassed the level filter.

**Detailed description:**
Created a levelAwareLogger wrapper that preserves EnabledAware through log.With() chains. Now Enabled() properly delegates to the level checker instead of defaulting to true.

**Which issue(s) this PR fixes:** Fixes #5258

**Notes for reviewers:**
Simple wrapper that delegates to EnabledAware. Tests added to cover the new behavior.

**Checklist:** Tests updated