### PR TITLE
chore: Update go version for build image to v1.26.2

### DIFF
--- a/.github/workflows/check-linux-build-image.yml
+++ b/.github/workflows/check-linux-build-image.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         build:
-          - runtime: golang:1.25.9-alpine3.23
-          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.25.9-bookworm
+          - runtime: golang:1.26.2-alpine3.23
+          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.26.2-bookworm
     runs-on: ubuntu-latest-8-cores
     steps:
       - name: Checkout

--- a/.github/workflows/create_build_image.yml
+++ b/.github/workflows/create_build_image.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         build:
-          - runtime: golang:1.25.9-alpine3.23
-          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.25.9-bookworm
+          - runtime: golang:1.26.2-alpine3.23
+          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.26.2-bookworm
             suffix: "-boringcrypto"
     runs-on: ubuntu-latest-8-cores
     steps:

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE_GO=library/golang:1.26-windowsservercore-ltsc2022@sha256:8231fbb9b76c4acf94daf580a35ef5a64480e545aded8062fb29deaf456c145f
+ARG BASE_IMAGE_GO=golang:1.26-windowsservercore-ltsc2022@sha256:b36e6e1036d0746855a215ecc693bdc45879a74a15edc797fc9af6cc3f505863
 ARG BASE_IMAGE_WINDOWS=mcr.microsoft.com/windows/nanoserver:ltsc2022@sha256:60612a30303eb5a15ce7f53fa2eecf70bca41d72657de0482fbde601ae5f3403
 
 FROM ${BASE_IMAGE_GO} AS builder

--- a/tools/build-image/windows/Dockerfile
+++ b/tools/build-image/windows/Dockerfile
@@ -1,4 +1,4 @@
-FROM library/golang:1.25.9-windowsservercore-ltsc2022@sha256:8231fbb9b76c4acf94daf580a35ef5a64480e545aded8062fb29deaf456c145f
+FROM golang:1.26.2-windowsservercore-ltsc2022@sha256:b36e6e1036d0746855a215ecc693bdc45879a74a15edc797fc9af6cc3f505863
 
 SHELL ["powershell", "-command"]
 

--- a/tools/ci/docker-containers-windows
+++ b/tools/ci/docker-containers-windows
@@ -26,7 +26,7 @@ fi
 
 WINDOWS_VERSION=${WINDOWS_VERSION:-}
 if [ "$WINDOWS_VERSION" = "windows-2022" ]; then
-  export BASE_IMAGE_GO="library/golang:${ALLOY_GO_VERSION}-windowsservercore-ltsc2022"
+  export BASE_IMAGE_GO="golang:${ALLOY_GO_VERSION}-windowsservercore-ltsc2022"
   export BASE_IMAGE_WINDOWS="mcr.microsoft.com/windows/nanoserver:ltsc2022"
   IMAGE_NAME_SUFFIX="windowsservercore-ltsc2022"
 else
@@ -40,7 +40,7 @@ export DEVEL_ALLOY_IMAGE=grafana/alloy-dev
 
 # TODO: Unit test this script? Test cases:
 # * Input:  ALLOY_GO_VERSION=1.24 WINDOWS_VERSION=windows-2022 GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v1.8.0 ./tools/ci/docker-containers-windows alloy
-#   Output: docker build -t grafana/alloy:v1.8.0-windowsservercore-ltsc2022 -t grafana/alloy:windowsservercore-ltsc2022 --build-arg VERSION=v1.8.0 --build-arg RELEASE_BUILD=1 --build-arg BASE_IMAGE_GO=library/golang:1.24-windowsservercore-ltsc2022 --build-arg BASE_IMAGE_WINDOWS=mcr.microsoft.com/windows/nanoserver:ltsc2022 -f ./Dockerfile.windows .
+#   Output: docker build -t grafana/alloy:v1.8.0-windowsservercore-ltsc2022 -t grafana/alloy:windowsservercore-ltsc2022 --build-arg VERSION=v1.8.0 --build-arg RELEASE_BUILD=1 --build-arg BASE_IMAGE_GO=golang:1.24-windowsservercore-ltsc2022 --build-arg BASE_IMAGE_WINDOWS=mcr.microsoft.com/windows/nanoserver:ltsc2022 -f ./Dockerfile.windows .
 if [ -n "$GITHUB_TAG" ]; then
   VERSION=$GITHUB_TAG
 else


### PR DESCRIPTION
Update our build images to use go v1.26.2, required for https://github.com/grafana/alloy/pull/6008#issuecomment-4247768682