### PR TITLE
ci: Add a healthcheck to additional_containers

### DIFF
--- a/integration-tests/docker/additional_containers.go
+++ b/integration-tests/docker/additional_containers.go
@@ -10,8 +10,25 @@ import (
 	"path/filepath"
 	"sync"
 
+	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
 )
+
+func dockerHealthcheck(h AdditionalContainerHealthcheck) (*dockercontainer.HealthConfig, error) {
+	if len(h.Test) == 0 {
+		return nil, fmt.Errorf("startup_healthcheck.test is required")
+	}
+	hc := &dockercontainer.HealthConfig{
+		Test: h.Test,
+	}
+
+	if h.Interval > 0 {
+		hc.Interval = h.Interval
+	}
+
+	return hc, nil
+}
 
 func startAdditionalContainers(ctx context.Context, absTestDir, networkName string, cfg TestConfig, skipImageBuild bool) ([]testcontainers.Container, error) {
 	requests := make([]testcontainers.ContainerRequest, 0, len(cfg.AdditionalContainers))
@@ -32,6 +49,16 @@ func startAdditionalContainers(ctx context.Context, absTestDir, networkName stri
 			Env:           containerCfg.Environment,
 			Cmd:           containerCfg.Command,
 			Networks:      []string{networkName},
+		}
+		if containerCfg.StartupHealthcheck != nil {
+			hc, err := dockerHealthcheck(*containerCfg.StartupHealthcheck)
+			if err != nil {
+				return nil, fmt.Errorf("additional_containers[%d] %q: %w", i, containerCfg.Name, err)
+			}
+			req.ConfigModifier = func(c *dockercontainer.Config) {
+				c.Healthcheck = hc
+			}
+			req.WaitingFor = wait.ForHealthCheck()
 		}
 
 		if containerCfg.Build.Context != "" || containerCfg.Build.Dockerfile != "" {

--- a/integration-tests/docker/config.go
+++ b/integration-tests/docker/config.go
@@ -1,5 +1,7 @@
 package main
 
+import "time"
+
 // TestConfig is used by tests to describe special setup requirements.
 type TestConfig struct {
 	Container            ContainerConfig             `yaml:"alloy_container"`
@@ -42,6 +44,14 @@ type AdditionalContainerConfig struct {
 	Command []string `yaml:"command"`
 	// Environment is passed to the container as KEY=value entries (Docker -e).
 	Environment map[string]string `yaml:"environment"`
+	// If a startup healthcheck is set, the test will wait until the container reports healthy.
+	StartupHealthcheck *AdditionalContainerHealthcheck `yaml:"startup_healthcheck,omitempty"`
+}
+
+// AdditionalContainerHealthcheck maps to Docker's healthcheck on the container config.
+type AdditionalContainerHealthcheck struct {
+	Test     []string      `yaml:"test"`
+	Interval time.Duration `yaml:"interval,omitempty"`
 }
 
 // AdditionalContainerBuildConfig is used to build an additional container image.

--- a/integration-tests/docker/tests/oracledb/test.yaml
+++ b/integration-tests/docker/tests/oracledb/test.yaml
@@ -6,3 +6,6 @@ additional_containers:
     image: gvenzl/oracle-free:23-slim
     environment:
       ORACLE_PASSWORD: testpassword
+    startup_healthcheck:
+      test: ["CMD", "/opt/oracle/healthcheck.sh"]
+      interval: 2s


### PR DESCRIPTION
This will make sure that the Oracle DB is up before the test proceeds.