### PR TITLE
docs: Add gRPC block documentation for loki.source.awsfirehose

### DIFF
--- a/docs/sources/reference/components/loki/loki.source.awsfirehose.md
+++ b/docs/sources/reference/components/loki/loki.source.awsfirehose.md
@@ -107,13 +107,20 @@ You can use the following blocks with `loki.source.awsfirehose`:
 
 | Name                  | Description                                        | Required |
 | --------------------- | -------------------------------------------------- | -------- |
+| [`grpc`][grpc]        | Configures the gRPC server that receives requests. | no       |
+| `grpc` > [`tls`][tls] | Configures TLS for the gRPC server.                | no       |
 | [`http`][http]        | Configures the HTTP server that receives requests. | no       |
 | `http` > [`tls`][tls] | Configures TLS for the HTTP server.                | no       |
 
 [http]: #http
+[grpc]: #grpc
 [tls]: #tls
 
 {{< /docs/alloy-config >}}
+
+### `grpc`
+
+{{< docs/shared lookup="reference/components/loki-server-grpc.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ### `http`
 


### PR DESCRIPTION
### Brief description of Pull Request

The `loki.source.awsfirehose` component uses the shared `ServerConfig` via `fnet.NewTargetServer`, which always binds both HTTP and gRPC listeners regardless of whether the blocks are configured. The docs only referenced the `http` block, leaving the gRPC port undocumented.

This is the same class of issue addressed for `loki.source.api` in #5919 (closed #2889), replicated for a sibling component. The `tls` block description already acknowledged "HTTP and gRPC servers", so the gap was plainly visible in the docs themselves.

### Pull Request Details

Changes:
- Added `grpc` and `grpc > tls` rows to the Blocks table
- Added `[grpc]: #grpc` reference
- Added `### grpc` section using the existing shared include (`loki-server-grpc.md`), matching the pattern in `loki.source.api`, `loki.source.heroku`, and `loki.source.gcplog`

The component intro is intentionally left unchanged. AWS Data Firehose only ever POSTs over HTTP, so claiming the component "receives over HTTP and gRPC" would be misleading. The gRPC listener is a side effect of the shared server config, not a functional ingestion path.

### Issue(s) fixed by this Pull Request

Related to #2889 (same root cause, sibling component).

### Notes to the Reviewer

Follow-up to #5919. Two other components (`pyroscope.receive_http` and `prometheus.receive_http`) have the same gap and will be addressed in separate PRs for focused review.

### PR Checklist

- [x] Documentation added
