### PR TITLE
docs: Add gRPC block documentation for pyroscope.receive_http

### DIFF
--- a/docs/sources/reference/components/pyroscope/pyroscope.receive_http.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.receive_http.md
@@ -50,12 +50,19 @@ You can use the following blocks with `pyroscope.receive_http`:
 
 | Name                  | Description                                        | Required |
 | --------------------- | -------------------------------------------------- | -------- |
+| [`grpc`][grpc]        | Configures the gRPC server that receives requests. | no       |
+| `grpc` > [`tls`][tls] | Configures TLS for the gRPC server.                | no       |
 | [`http`][http]        | Configures the HTTP server that receives requests. | no       |
 | `http` > [`tls`][tls] | Configures TLS for the HTTP server.                | no       |
 
+[grpc]: #grpc
 [http]: #http
 
 {{< /docs/alloy-config >}}
+
+### `grpc`
+
+{{< docs/shared lookup="reference/components/loki-server-grpc.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ### `http`
 
@@ -65,7 +72,7 @@ You can use the following blocks with `pyroscope.receive_http`:
 
 ### `tls`
 
-The `tls` block configures TLS for the HTTP server.
+The `tls` block configures TLS for the HTTP and gRPC servers.
 
 {{< docs/shared lookup="reference/components/server-tls-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 


### PR DESCRIPTION
### Brief description of Pull Request

The `pyroscope.receive_http` component uses the shared `ServerConfig` via `fnet.NewTargetServer`, which always binds both HTTP and gRPC listeners regardless of whether the blocks are configured. The docs only referenced the `http` block, leaving the gRPC port undocumented.

The component name implies HTTP-only, which makes the surprise gRPC port especially confusing for operators whose security teams flag unexpected network bindings. This is the same class of issue addressed for `loki.source.api` in #5919 (closed #2889).

Note: the Connect handlers in this component (`pushv1connect.PusherService`, `debuginfov1alpha1connect.DebuginfoService`) are mounted on the HTTP router, not the native gRPC server. The gRPC listener opened by the shared server config therefore has no application-level handlers bound to it — it is purely a side effect of the shared server configuration.

### Pull Request Details

Changes:
- Added `grpc` and `grpc > tls` rows to the Blocks table
- Added `[grpc]: #grpc` reference
- Added `### grpc` section using the existing shared include (`loki-server-grpc.md`)
- Updated `### tls` description from "HTTP server" to "HTTP and gRPC servers"

Pattern matches the merged `loki.source.api` (#5919), as well as pre-existing `loki.source.heroku` and `loki.source.gcplog` docs.

### Issue(s) fixed by this Pull Request

Related to #2889 (same root cause, sibling component).

### Notes to the Reviewer

Follow-up to #5919 and a companion PR for `loki.source.awsfirehose` (#6057). A third PR for `prometheus.receive_http` will follow.

### PR Checklist

- [x] Documentation added
