### PR TITLE
docs: Add gRPC block documentation for prometheus.receive_http

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.receive_http.md
+++ b/docs/sources/reference/components/prometheus/prometheus.receive_http.md
@@ -69,13 +69,20 @@ You can use the following blocks with `prometheus.receive_http`:
 
 | Name                  | Description                                        | Required |
 | --------------------- | -------------------------------------------------- | -------- |
+| [`grpc`][grpc]        | Configures the gRPC server that receives requests. | no       |
+| `grpc` > [`tls`][tls] | Configures TLS for the gRPC server.                | no       |
 | [`http`][http]        | Configures the HTTP server that receives requests. | no       |
 | `http` > [`tls`][tls] | Configures TLS for the HTTP server.                | no       |
 
+[grpc]: #grpc
 [http]: #http
 [tls]: #tls
 
 {{< /docs/alloy-config >}}
+
+### `grpc`
+
+{{< docs/shared lookup="reference/components/loki-server-grpc.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ### `http`
 
@@ -83,7 +90,7 @@ You can use the following blocks with `prometheus.receive_http`:
 
 ### `tls`
 
-The `tls` block configures TLS for the HTTP server.
+The `tls` block configures TLS for the HTTP and gRPC servers.
 
 {{< docs/shared lookup="reference/components/server-tls-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 


### PR DESCRIPTION
### Brief description of Pull Request

The `prometheus.receive_http` component uses the shared `ServerConfig` via `fnet.NewTargetServer`, which always binds both HTTP and gRPC listeners regardless of whether the blocks are configured. The docs only referenced the `http` block, leaving the gRPC port undocumented.

The component name implies HTTP-only, which makes the surprise gRPC port especially confusing for operators whose security teams flag unexpected network bindings. This is the same class of issue addressed for `loki.source.api` in #5919 (closed #2889).

Note: `prometheus.receive_http` only serves the Prometheus remote write protocol over HTTP — the gRPC listener opened by the shared server config has no application-level handlers bound to it. It is purely a side effect of the shared server configuration.

### Pull Request Details

Changes:
- Added `grpc` and `grpc > tls` rows to the Blocks table
- Added `[grpc]: #grpc` reference
- Added `### grpc` section using the existing shared include (`loki-server-grpc.md`)
- Updated `### tls` description from "HTTP server" to "HTTP and gRPC servers"

Pattern matches the merged `loki.source.api` (#5919) and pre-existing `loki.source.heroku` / `loki.source.gcplog` docs.

### Issue(s) fixed by this Pull Request

Related to #2889 (same root cause, sibling component).

### Notes to the Reviewer

Follow-up to #5919 and companion PRs for `loki.source.awsfirehose` (#6057) and `pyroscope.receive_http` (#6058). This completes the set of components that inherit the always-on gRPC listener from the shared `ServerConfig` but don't yet document it.

### PR Checklist

- [x] Documentation added
