### PR TITLE
ci: Let require.Eventually increase its timeout via the --test-timeout cmd arg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ endif
 
 .PHONY: integration-test-docker
 integration-test-docker:
-	cd integration-tests/docker && $(GO_ENV) go run . --test-timeout=15m
+	cd integration-tests/docker && $(GO_ENV) go run .
 
 .PHONY: integration-test-k8s
 integration-test-k8s: alloy-image

--- a/integration-tests/docker/common/common.go
+++ b/integration-tests/docker/common/common.go
@@ -18,12 +18,12 @@ type Unmarshaler interface {
 const (
 	DefaultRetryInterval = 100 * time.Millisecond
 
-	// Timeout to use if no -timeout is provided to go test.
-	defaultTimeout = 10 * time.Minute
+	// Default timeout for polling/assertions if no -timeout is provided to go test.
+	defaultTimeout = 120 * time.Second
 
 	// Timeout padding to subtract from the time left until the go test -timeout deadline.
 	// This makes sure that polling/assertions fail before the process watchdog kills the test.
-	timeoutPadding = 30 * time.Second
+	timeoutPadding = 15 * time.Second
 )
 
 func FetchDataFromURL(url string, target Unmarshaler) (string, error) {
@@ -131,6 +131,10 @@ func isStatefulFromEnv() (bool, error) {
 	}
 
 	return isStateful, nil
+}
+
+func DefaultProcessTimeout() time.Duration {
+	return defaultTimeout + timeoutPadding
 }
 
 // TestTimeout returns how long polling helpers should keep retrying. When the

--- a/integration-tests/docker/common/common.go
+++ b/integration-tests/docker/common/common.go
@@ -19,7 +19,7 @@ const (
 	DefaultRetryInterval = 100 * time.Millisecond
 
 	// Default timeout for polling/assertions if no -timeout is provided to go test.
-	defaultTimeout = 120 * time.Second
+	defaultTimeout = 180 * time.Second
 
 	// Timeout padding to subtract from the time left until the go test -timeout deadline.
 	// This makes sure that polling/assertions fail before the process watchdog kills the test.

--- a/integration-tests/docker/common/common.go
+++ b/integration-tests/docker/common/common.go
@@ -17,7 +17,13 @@ type Unmarshaler interface {
 
 const (
 	DefaultRetryInterval = 100 * time.Millisecond
-	DefaultTimeout       = 90 * time.Second
+
+	// Timeout to use if no -timeout is provided to go test.
+	defaultTimeout = 10 * time.Minute
+
+	// Timeout padding to subtract from the time left until the go test -timeout deadline.
+	// This makes sure that polling/assertions fail before the process watchdog kills the test.
+	timeoutPadding = 30 * time.Second
 )
 
 func FetchDataFromURL(url string, target Unmarshaler) (string, error) {
@@ -127,17 +133,18 @@ func isStatefulFromEnv() (bool, error) {
 	return isStateful, nil
 }
 
-func TestTimeoutEnv(t *testing.T) time.Duration {
-	if toStr := os.Getenv(TestTimeout); toStr != "" {
-		if to, err := time.ParseDuration(toStr); err == nil {
-			return to
-		} else {
-			t.Logf("failed to parse %s value %s as a duration: %s, defaulting to %s", TestTimeout, toStr, err, DefaultTimeout)
+// TestTimeout returns how long polling helpers should keep retrying. When the
+// test is run with go test -timeout (as the integration harness does), this is
+// assertionPollingTimeout, but never longer than the time left until that
+// deadline. Otherwise it defaults to DefaultTimeout.
+func TestTimeout(t *testing.T) time.Duration {
+	if t != nil {
+		if deadline, ok := t.Deadline(); ok {
+			remaining := time.Until(deadline)
+			return remaining - timeoutPadding
 		}
-	} else {
-		t.Logf("%s not set, defaulting to %s", TestTimeout, DefaultTimeout)
 	}
-	return DefaultTimeout
+	return defaultTimeout
 }
 
 func SanitizeTestName(t *testing.T) string {

--- a/integration-tests/docker/common/env.go
+++ b/integration-tests/docker/common/env.go
@@ -6,5 +6,4 @@ var (
 
 	// Environment variables which adjust the test behavior are prefixed with TEST_
 	TestStatefulEnv = "TEST_STATEFUL"
-	TestTimeout     = "TEST_TIMEOUT"
 )

--- a/integration-tests/docker/common/logs_assert.go
+++ b/integration-tests/docker/common/logs_assert.go
@@ -50,7 +50,7 @@ func AssertLogsPresent(t *testing.T, totalCount int, expected ...ExpectedLogResu
 		}
 
 		require.Equal(c, totalCount, totalRecv)
-	}, TestTimeoutEnv(t), DefaultRetryInterval)
+	}, TestTimeout(t), DefaultRetryInterval)
 
 	for _, e := range expected {
 		entries := matchingEntries(e.Labels, logResponse.Data.Result)
@@ -102,7 +102,7 @@ func AssertLabelsNotIndexed(t *testing.T, labels ...string) {
 // It will return an error if no logs are found after test timeout.
 func WaitForInitalLogs(testName string) error {
 	var (
-		after = time.After(DefaultTimeout)
+		after = time.After(TestTimeout(nil))
 		tick  = time.NewTicker(DefaultRetryInterval)
 	)
 

--- a/integration-tests/docker/common/metadata_asserts.go
+++ b/integration-tests/docker/common/metadata_asserts.go
@@ -56,7 +56,7 @@ func MimirMetadataTest(t *testing.T, expectedMetadata map[string]Metadata) {
 		metricMetadata, err = GetMetadata()
 		assert.NoError(c, err)
 		assert.Subset(c, maps.Keys(metricMetadata.Data), expectedMetricsWithMetadata, "did not find metadata for the expected metrics")
-	}, TestTimeoutEnv(t), DefaultRetryInterval)
+	}, TestTimeout(t), DefaultRetryInterval)
 
 	for metricName, expectedMeta := range expectedMetadata {
 		actualMetas := metricMetadata.Data[metricName]

--- a/integration-tests/docker/common/metrics_assert.go
+++ b/integration-tests/docker/common/metrics_assert.go
@@ -102,7 +102,7 @@ func AssertMetricsAvailable(t *testing.T, metrics []string, histogramMetrics []s
 		missingMetrics = findMissingMetrics(expectedMetrics, actualMetrics)
 
 		assert.Emptyf(c, missingMetrics, "Did not find %v in received metrics %v", missingMetrics, maps.Keys(actualMetrics))
-	}, TestTimeoutEnv(t), DefaultRetryInterval)
+	}, TestTimeout(t), DefaultRetryInterval)
 }
 
 // findMissingMetrics returns the expectedMetrics which are not contained in actualMetrics.
@@ -140,7 +140,7 @@ func AssertHistogramData(t *testing.T, query string, expectedMetric string, test
 			assert.NotEmpty(c, histogram.Data.Buckets)
 			assert.Nil(c, metricResponse.Data.Result[0].Value)
 		}
-	}, TestTimeoutEnv(t), DefaultRetryInterval, "Histogram data did not satisfy the conditions within the time limit")
+	}, TestTimeout(t), DefaultRetryInterval, "Histogram data did not satisfy the conditions within the time limit")
 }
 
 // AssertMetricData performs a Prometheus query and expect the result to eventually contain the expected metric.
@@ -155,5 +155,5 @@ func AssertMetricData(t *testing.T, query, expectedMetric string, testName strin
 			assert.NotEmpty(c, metricResponse.Data.Result[0].Value.Value)
 			assert.Nil(c, metricResponse.Data.Result[0].Histogram)
 		}
-	}, TestTimeoutEnv(t), DefaultRetryInterval, "Data did not satisfy the conditions within the time limit")
+	}, TestTimeout(t), DefaultRetryInterval, "Data did not satisfy the conditions within the time limit")
 }

--- a/integration-tests/docker/common/traces_assert.go
+++ b/integration-tests/docker/common/traces_assert.go
@@ -82,7 +82,7 @@ func AssertTracesAvailable(t *testing.T, tags map[string]string, probe func(c *a
 				t.Logf("Note: Trace has zero duration (TraceID: %s). This can occur with very fast eBPF-instrumented operations.", trace.TraceID)
 			}
 		}
-	}, DefaultTimeout, DefaultRetryInterval, "No traces found matching the search criteria within the time limit")
+	}, TestTimeout(t), DefaultRetryInterval, "No traces found matching the search criteria within the time limit")
 }
 
 func (t *TempoTraceSearchResponse) Unmarshal(data []byte) error {

--- a/integration-tests/docker/main.go
+++ b/integration-tests/docker/main.go
@@ -11,8 +11,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-
-	"github.com/grafana/alloy/integration-tests/docker/common"
 )
 
 var (
@@ -40,7 +38,7 @@ func main() {
 		"This is useful for a fast iteration loop locally but should not be used in CI." +
 		"You must run 'docker compose down' manually if you want to switch from stateful to stateless mode."
 	rootCmd.PersistentFlags().BoolVar(&stateful, "stateful", false, statefulUsageString)
-	rootCmd.PersistentFlags().DurationVar(&testTimeout, "test-timeout", common.DefaultTimeout, "Timeout for each individual test")
+	rootCmd.PersistentFlags().DurationVar(&testTimeout, "test-timeout", 10*time.Minute, "Timeout for each individual test")
 	rootCmd.PersistentFlags().BoolVar(&alwaysPrintLogs, "always-print-logs", false, "Always print the test and alloy logs, even if the test passed")
 
 	if err := rootCmd.Execute(); err != nil {

--- a/integration-tests/docker/main.go
+++ b/integration-tests/docker/main.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/alloy/integration-tests/docker/common"
 	"github.com/spf13/cobra"
 )
 
@@ -38,7 +39,7 @@ func main() {
 		"This is useful for a fast iteration loop locally but should not be used in CI." +
 		"You must run 'docker compose down' manually if you want to switch from stateful to stateless mode."
 	rootCmd.PersistentFlags().BoolVar(&stateful, "stateful", false, statefulUsageString)
-	rootCmd.PersistentFlags().DurationVar(&testTimeout, "test-timeout", 10*time.Minute, "Timeout for each individual test")
+	rootCmd.PersistentFlags().DurationVar(&testTimeout, "test-timeout", common.DefaultProcessTimeout(), "Timeout for each individual test")
 	rootCmd.PersistentFlags().BoolVar(&alwaysPrintLogs, "always-print-logs", false, "Always print the test and alloy logs, even if the test passed")
 
 	if err := rootCmd.Execute(); err != nil {

--- a/integration-tests/docker/tests/beyla-java/beyla_java_test.go
+++ b/integration-tests/docker/tests/beyla-java/beyla_java_test.go
@@ -25,7 +25,7 @@ func waitForJavaApp(t *testing.T, client *http.Client) {
 		}
 		defer resp.Body.Close()
 		return resp.StatusCode >= 200 && resp.StatusCode < 400
-	}, common.DefaultTimeout, common.DefaultRetryInterval)
+	}, common.TestTimeout(t), common.DefaultRetryInterval)
 }
 
 func triggerJavaRequest(client *http.Client) func(c *assert.CollectT) {

--- a/integration-tests/docker/tests/beyla/beyla_test.go
+++ b/integration-tests/docker/tests/beyla/beyla_test.go
@@ -39,5 +39,5 @@ func TestBeylaVersion(t *testing.T) {
 		if assert.NotEmpty(c, metricResponse.Data.Result) {
 			assert.NotEqual(c, "unset", metricResponse.Data.Result[0].Metric.Version)
 		}
-	}, common.TestTimeoutEnv(t), common.DefaultRetryInterval)
+	}, common.TestTimeout(t), common.DefaultRetryInterval)
 }

--- a/integration-tests/docker/tests/database-observability-mysql/mysql_test.go
+++ b/integration-tests/docker/tests/database-observability-mysql/mysql_test.go
@@ -47,5 +47,5 @@ func TestDatabaseObservabilityMySQLLogs(t *testing.T) {
 		for _, op := range expectedOps {
 			assert.True(c, ops[op], "expected %s logs", op)
 		}
-	}, common.TestTimeoutEnv(t), common.DefaultRetryInterval)
+	}, common.TestTimeout(t), common.DefaultRetryInterval)
 }

--- a/integration-tests/docker/tests/database-observability-postgres/postgres_test.go
+++ b/integration-tests/docker/tests/database-observability-postgres/postgres_test.go
@@ -46,5 +46,5 @@ func TestDatabaseObservabilityPostgresLogs(t *testing.T) {
 		for _, op := range expectedOps {
 			assert.True(c, ops[op], "expected %s logs", op)
 		}
-	}, common.TestTimeoutEnv(t), common.DefaultRetryInterval)
+	}, common.TestTimeout(t), common.DefaultRetryInterval)
 }

--- a/integration-tests/docker/utils.go
+++ b/integration-tests/docker/utils.go
@@ -256,7 +256,7 @@ func createContainerRequest(dirName, testDir string, port int, networkName strin
 
 // Configure the test command with appropriate environment variables if needed
 func setupTestCommand(testDir string, testTimeout time.Duration) *exec.Cmd {
-	testCmd := exec.Command("go", "test", "-tags", "alloyintegrationtests")
+	testCmd := exec.Command("go", "test", "-tags", "alloyintegrationtests", "-timeout", testTimeout.String())
 	testCmd.Dir = testDir
 
 	testCmd.Env = append(testCmd.Environ(), fmt.Sprintf("%s=%s", common.TestTimeout, testTimeout.String()))
@@ -499,7 +499,7 @@ func runComposeTest(ctx context.Context, testDir string, stateful bool, testTime
 	defer cancel()
 
 	// Setup and run test command with context for timeout enforcement
-	testCmd := exec.CommandContext(testCtx, "go", "test", "-tags", "alloyintegrationtests")
+	testCmd := exec.CommandContext(testCtx, "go", "test", "-tags", "alloyintegrationtests", "-timeout", testTimeout.String())
 	testCmd.Dir = testDir
 	testCmd.Env = append(os.Environ(), fmt.Sprintf("%s=%s", common.TestTimeout, testTimeout.String()))
 	if stateful {

--- a/integration-tests/docker/utils.go
+++ b/integration-tests/docker/utils.go
@@ -259,7 +259,6 @@ func setupTestCommand(testDir string, testTimeout time.Duration) *exec.Cmd {
 	testCmd := exec.Command("go", "test", "-tags", "alloyintegrationtests", "-timeout", testTimeout.String())
 	testCmd.Dir = testDir
 
-	testCmd.Env = append(testCmd.Environ(), fmt.Sprintf("%s=%s", common.TestTimeout, testTimeout.String()))
 	return testCmd
 }
 


### PR DESCRIPTION
Currently, there is a `TEST_TIMEOUT` env var which governs how long `require.Eventually` should wait for. There's also a `--test-timeout` cmd arg which sets `TEST_TIMEOUT`, but only if the integration test framework is ran for a specific test. 

Neither `--test-timeout` nor `TEST_TIMEOUT` increase the timeout of the child `go test` sub process. So if you set `--test-timeout` or `TEST_TIMEOUT` to a high value, then the test will just panic in the end due to a timeout. This is not helpful because you won't see the output from `require.Eventually` - it won't say why it failed. This can happen, if for example `TEST_TIMEOUT` is 15 min. Then Go by default will run the test for a maximum of 10 min, and the test will time out and panic in 10 min before reaching the full 15 min.

This is all confusing and inconsistent. IMO it'd be more intuitive if the command line argument sets the global timeout limit for the `go test` process, and then `require.Eventually`'s timeout expands and contracts according to that.