### PR TITLE
fix(loki.process): Return errors from metric registration instead of panicking

### DIFF
--- a/internal/component/loki/process/stages/drop.go
+++ b/internal/component/loki/process/stages/drop.go
@@ -84,11 +84,16 @@ func newDropStage(logger *slog.Logger, config DropConfig, registerer prometheus.
 		return nil, err
 	}
 
+	dropCount, err := getDropCountMetric(registerer)
+	if err != nil {
+		return nil, err
+	}
+
 	return &dropStage{
 		logger:    logger.With("stage", "drop"),
 		cfg:       &config,
 		regex:     regex,
-		dropCount: getDropCountMetric(registerer),
+		dropCount: dropCount,
 	}, nil
 }
 

--- a/internal/component/loki/process/stages/limit.go
+++ b/internal/component/loki/process/stages/limit.go
@@ -42,17 +42,25 @@ func newLimitStage(logger *slog.Logger, cfg LimitConfig, registerer prometheus.R
 		cfg.MaxDistinctLabels = MinReasonableMaxDistinctLabels
 	}
 
+	dropCount, err := getDropCountMetric(registerer)
+	if err != nil {
+		return nil, err
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	r := &limitStage{
 		logger:    logger,
 		cfg:       cfg,
-		dropCount: getDropCountMetric(registerer),
+		dropCount: dropCount,
 		ctx:       ctx,
 		cancel:    cancel,
 	}
 
 	if cfg.ByLabelName != "" {
-		r.dropCountByLabel = getDropCountByLabelMetric(registerer)
+		r.dropCountByLabel, err = getDropCountByLabelMetric(registerer)
+		if err != nil {
+			return nil, err
+		}
 		newRateLimiter := func() *rate.Limiter { return rate.NewLimiter(rate.Limit(cfg.Rate), cfg.Burst) }
 		gcCb := func() { r.dropCountByLabel.Reset() }
 		r.rateLimiterByLabel = NewGenMap[model.LabelValue, *rate.Limiter](cfg.MaxDistinctLabels, newRateLimiter, gcCb)
@@ -134,7 +142,7 @@ func (*limitStage) Cleanup() {
 	// no-op
 }
 
-func getDropCountByLabelMetric(registerer prometheus.Registerer) *prometheus.CounterVec {
+func getDropCountByLabelMetric(registerer prometheus.Registerer) (*prometheus.CounterVec, error) {
 	return registerCounterVec(registerer, "loki_process", "dropped_lines_by_label_total",
 		"A count of all log lines dropped as a result of a pipeline stage",
 		[]string{"label_name", "label_value"})
@@ -180,7 +188,7 @@ func (m *GenerationalMap[K, T]) GetOrCreate(key K) T {
 	return v
 }
 
-func registerCounterVec(registerer prometheus.Registerer, namespace, name, help string, labels []string) *prometheus.CounterVec {
+func registerCounterVec(registerer prometheus.Registerer, namespace, name, help string, labels []string) (*prometheus.CounterVec, error) {
 	vec := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
 		Name:      name,
@@ -191,9 +199,8 @@ func registerCounterVec(registerer prometheus.Registerer, namespace, name, help 
 		if existing, ok := err.(prometheus.AlreadyRegisteredError); ok {
 			vec = existing.ExistingCollector.(*prometheus.CounterVec)
 		} else {
-			// Same behavior as MustRegister if the error is not for AlreadyRegistered
-			panic(err)
+			return nil, err
 		}
 	}
-	return vec
+	return vec, nil
 }

--- a/internal/component/loki/process/stages/match.go
+++ b/internal/component/loki/process/stages/match.go
@@ -87,9 +87,14 @@ func newMatcherStage(slogger *slog.Logger, config MatchConfig, registerer promet
 		dropReason = config.DropReason
 	}
 
+	dropCount, err := getDropCountMetric(registerer)
+	if err != nil {
+		return nil, err
+	}
+
 	return &matcherStage{
 		dropReason: dropReason,
-		dropCount:  getDropCountMetric(registerer),
+		dropCount:  dropCount,
 		matchers:   selector.Matchers(),
 		pipeline:   pl,
 		action:     config.Action,
@@ -97,23 +102,20 @@ func newMatcherStage(slogger *slog.Logger, config MatchConfig, registerer promet
 	}, nil
 }
 
-func getDropCountMetric(registerer prometheus.Registerer) *prometheus.CounterVec {
+func getDropCountMetric(registerer prometheus.Registerer) (*prometheus.CounterVec, error) {
 	dropCount := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "loki_process_dropped_lines_total",
 		Help: "A count of all log lines dropped as a result of a pipeline stage",
 	}, []string{"reason"})
 	err := registerer.Register(dropCount)
 	if err != nil {
-		// TODO: This code should neither panic nor use AlreadyRegisteredError.
-		//       Register it without these, and return error if it fails.
 		if existing, ok := err.(prometheus.AlreadyRegisteredError); ok {
 			dropCount = existing.ExistingCollector.(*prometheus.CounterVec)
 		} else {
-			// Same behavior as MustRegister if the error is not for AlreadyRegistered
-			panic(err)
+			return nil, err
 		}
 	}
-	return dropCount
+	return dropCount, nil
 }
 
 // matcherStage applies Label matchers to determine if the include stages should be run

--- a/internal/component/loki/process/stages/pack.go
+++ b/internal/component/loki/process/stages/pack.go
@@ -116,13 +116,18 @@ func (p *PackConfig) SetToDefault() {
 	*p = DefaultPackConfig
 }
 
-// newPackStage creates a DropStage from config
-func newPackStage(logger *slog.Logger, config PackConfig, registerer prometheus.Registerer) Stage {
+// newPackStage creates a PackStage from config
+func newPackStage(logger *slog.Logger, config PackConfig, registerer prometheus.Registerer) (Stage, error) {
+	dropCount, err := getDropCountMetric(registerer)
+	if err != nil {
+		return nil, err
+	}
+
 	return &packStage{
 		logger:    logger.With("stage", "pack"),
 		cfg:       &config,
-		dropCount: getDropCountMetric(registerer),
-	}
+		dropCount: dropCount,
+	}, nil
 }
 
 // packStage applies Label matchers to determine if the include stages should be run

--- a/internal/component/loki/process/stages/pack_test.go
+++ b/internal/component/loki/process/stages/pack_test.go
@@ -336,7 +336,8 @@ func TestPackStage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			logger := util.TestAlloyLogger(t)
-			m := newPackStage(logger.Slog(), *tt.config, prometheus.DefaultRegisterer)
+			m, err := newPackStage(logger.Slog(), *tt.config, prometheus.DefaultRegisterer)
+			require.NoError(t, err)
 			// Normal pipeline operation will put all the labels into the extracted map
 			// replicate that here.
 			for labelName, labelValue := range tt.inputEntry.Labels {

--- a/internal/component/loki/process/stages/pipeline.go
+++ b/internal/component/loki/process/stages/pipeline.go
@@ -64,9 +64,14 @@ func NewPipeline(slogger *slog.Logger, stages []StageConfig, registerer promethe
 		}
 		st = append(st, newStage)
 	}
+	dropCount, err := getDropCountMetric(registerer)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Pipeline{
 		stages:    st,
-		dropCount: getDropCountMetric(registerer),
+		dropCount: dropCount,
 	}, nil
 }
 

--- a/internal/component/loki/process/stages/sampling.go
+++ b/internal/component/loki/process/stages/sampling.go
@@ -35,13 +35,18 @@ func (s *SamplingConfig) Validate() error {
 }
 
 // newSamplingStage creates a SamplingStage from config using the shared probabilistic sampler.
-func newSamplingStage(logger *slog.Logger, cfg SamplingConfig, registerer prometheus.Registerer) Stage {
+func newSamplingStage(logger *slog.Logger, cfg SamplingConfig, registerer prometheus.Registerer) (Stage, error) {
+	dropCount, err := getDropCountMetric(registerer)
+	if err != nil {
+		return nil, err
+	}
+
 	return &samplingStage{
 		logger:    logger.With("stage", "sampling"),
 		cfg:       cfg,
-		dropCount: getDropCountMetric(registerer),
+		dropCount: dropCount,
 		sampler:   sampling.NewSampler(cfg.SamplingRate),
-	}
+	}, nil
 }
 
 type samplingStage struct {

--- a/internal/component/loki/process/stages/stage.go
+++ b/internal/component/loki/process/stages/stage.go
@@ -156,7 +156,10 @@ func New(slogger *slog.Logger, cfg StageConfig, registerer prometheus.Registerer
 			return nil, err
 		}
 	case cfg.PackConfig != nil:
-		s = newPackStage(slogger, *cfg.PackConfig, registerer)
+		s, err = newPackStage(slogger, *cfg.PackConfig, registerer)
+		if err != nil {
+			return nil, err
+		}
 	case cfg.LabelAllowConfig != nil:
 		s, err = newLabelAllowStage(*cfg.LabelAllowConfig)
 		if err != nil {
@@ -183,7 +186,10 @@ func New(slogger *slog.Logger, cfg StageConfig, registerer prometheus.Registerer
 			return nil, err
 		}
 	case cfg.SamplingConfig != nil:
-		s = newSamplingStage(slogger, *cfg.SamplingConfig, registerer)
+		s, err = newSamplingStage(slogger, *cfg.SamplingConfig, registerer)
+		if err != nil {
+			return nil, err
+		}
 	case cfg.EventLogMessageConfig != nil:
 		s = newEventLogMessageStage(slogger, cfg.EventLogMessageConfig)
 	case cfg.WindowsEventConfig != nil:


### PR DESCRIPTION
### Brief description of Pull Request

Two functions in the `loki.process` pipeline stages package (`getDropCountMetric` and `registerCounterVec`) called `panic(err)` when Prometheus metric registration failed for non-duplicate reasons. This could crash the entire Alloy process on an otherwise recoverable error.

A TODO at `match.go:107` (added in #5399) already acknowledged this:

> This code should neither panic nor use AlreadyRegisteredError. Register it without these, and return error if it fails.

This PR implements that fix.

### Pull Request Details

Changes:
- Both helpers now return `error` instead of panicking; six callers and the stage factory propagate it
- `newSamplingStage` and `newPackStage` signatures changed from `Stage` to `(Stage, error)` for consistency with the other stage constructors

The `AlreadyRegisteredError` handling is preserved (returning the existing collector), as this is expected behavior when multiple stages share a metric. Only unexpected registration failures are now surfaced as errors instead of panics.

### Issue(s) fixed by this Pull Request

None. Resolves TODO at match.go:107 (#5399).

### Notes to the Reviewer

`pack_test.go` has the explicit `require.NoError` on the new return; other callers route through existing `NewPipeline` tests in `pipeline_test.go`, `drop_test.go`, etc.

Verified with `go test -race -count=1 ./internal/component/loki/process/stages/...` and `make lint`.

### PR Checklist

- [x] Tests updated
