### PR TITLE
fix(database_observability.postgres): Fix EXPLAIN param count when placeholders repeat

### DIFF
--- a/internal/component/database_observability/postgres/collector/explain_plans.go
+++ b/internal/component/database_observability/postgres/collector/explain_plans.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -565,6 +566,21 @@ func (c *ExplainPlans) fetchExplainPlans(ctx context.Context) error {
 	return nil
 }
 
+// postgresPreparedStatementParamCount returns N for EXECUTE, where N is the highest
+// placeholder index in the query. The same index may appear multiple times (e.g. two $1)
+// without increasing N.
+func postgresPreparedStatementParamCount(queryText string) int {
+	matches := paramCountRegex.FindAllString(queryText, -1)
+	maxParam := 0
+	for _, m := range matches {
+		n, err := strconv.Atoi(m[1:])
+		if err == nil && n > maxParam {
+			maxParam = n
+		}
+	}
+	return maxParam
+}
+
 func (c *ExplainPlans) fetchExplainPlanJSON(ctx context.Context, qi queryInfo) ([]byte, error) {
 	querySpecificDSN, err := replaceDatabaseNameInDSN(c.dbDSN, qi.datname)
 	if err != nil {
@@ -599,12 +615,10 @@ func (c *ExplainPlans) fetchExplainPlanJSON(ctx context.Context, qi queryInfo) (
 	}
 
 	explainQuery := fmt.Sprintf("%s%s", selectExplainPlanPrefix, preparedStatementName)
-	paramCount := len(paramCountRegex.FindAllString(qi.queryText, -1))
+	paramCount := postgresPreparedStatementParamCount(qi.queryText)
 	if paramCount > 0 {
 		nullParams := strings.Repeat("null,", paramCount)
-		if paramCount > 0 {
-			nullParams = nullParams[:len(nullParams)-1]
-		}
+		nullParams = nullParams[:len(nullParams)-1]
 
 		explainQuery = fmt.Sprintf("%s%s(%s)", selectExplainPlanPrefix, preparedStatementName, nullParams)
 	}

--- a/internal/component/database_observability/postgres/collector/explain_plans_test.go
+++ b/internal/component/database_observability/postgres/collector/explain_plans_test.go
@@ -2496,6 +2496,26 @@ func TestNewExplainPlanOutput_InvalidJSON(t *testing.T) {
 	assert.Nil(t, output)
 }
 
+func TestPostgresPreparedStatementParamCount(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		want  int
+	}{
+		{name: "empty", query: "", want: 0},
+		{name: "no placeholders", query: "SELECT 1", want: 0},
+		{name: "single placeholder", query: "SELECT * FROM t WHERE a = $1", want: 1},
+		{name: "repeated same index", query: "SELECT * FROM t WHERE a = $1 AND b = $1", want: 1},
+		{name: "issue example", query: `SELECT t2.payload FROM t1 INNER JOIN t2 ON t1.x = t2.x WHERE t1.a = $1 AND t2.a = $1 ORDER BY t1.x DESC LIMIT $2 OFFSET $3`, want: 3},
+		{name: "highest index wins", query: "SELECT * FROM t WHERE a = $10 AND b = $1", want: 10},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, postgresPreparedStatementParamCount(tt.query))
+		})
+	}
+}
+
 func TestExplainPlan_PopulateQueryCache(t *testing.T) {
 	lokiClient := loki.NewCollectingHandler()
 	defer lokiClient.Stop()
@@ -2986,6 +3006,74 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 			mock.ExpectExec("PREPARE explain_plan_123456 AS with cte as (select * from some_table where id = $1) select * from cte").WillReturnResult(sqlmock.NewResult(0, 1))
 			mock.ExpectExec("SET plan_cache_mode = force_generic_plan").WillReturnResult(sqlmock.NewResult(0, 1))
 			mock.ExpectQuery("EXPLAIN (FORMAT JSON) EXECUTE explain_plan_123456(null)").WillReturnRows(sqlmock.NewRows([]string{"json"}).AddRow(jsonData))
+			mock.ExpectExec("DEALLOCATE explain_plan_123456").WillReturnResult(sqlmock.NewResult(0, 1))
+
+			err = explainPlan.fetchExplainPlans(t.Context())
+			require.NoError(t, err)
+
+			assert.NoError(t, mock.ExpectationsWereMet())
+			assert.Equal(t, 1, dbConnFactory.InstantiationCount)
+
+			require.Eventually(
+				t,
+				func() bool {
+					return len(lokiClient.Received()) == 1
+				},
+				5*time.Second,
+				10*time.Millisecond,
+				"did not receive the explain plan output log message within the timeout",
+			)
+
+			require.NotContains(t, logBuffer.String(), "error")
+		})
+
+		t.Run("repeated placeholder uses max parameter index for EXECUTE", func(t *testing.T) {
+			db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+			require.NoError(t, err)
+			defer db.Close()
+
+			lokiClient.Clear()
+			logBuffer.Reset()
+			dbConnFactory := &mockDbConnectionFactory{
+				db:                 db,
+				Mock:               &mock,
+				InstantiationCount: 0,
+			}
+			dupParamQuery := "SELECT * FROM t1 INNER JOIN t2 ON t1.x = t2.x WHERE t1.a = $1 AND t2.a = $1 ORDER BY t1.x DESC LIMIT $2 OFFSET $3"
+			explainPlan = &ExplainPlans{
+				dbConnection:        db,
+				dbDSN:               "postgres://user:pass@host:1234/database",
+				dbConnectionFactory: dbConnFactory.NewDBConnection,
+				dbVersion:           post17ver,
+				queryCache: map[string]*queryInfo{
+					"testdb123456": {
+						datname:    "testdb",
+						queryId:    "123456",
+						queryText:  dupParamQuery,
+						calls:      int64(10),
+						callsReset: time.Now(),
+					},
+				},
+				queryDenylist:      map[string]*queryInfo{},
+				finishedQueryCache: map[string]*queryInfo{},
+				excludeDatabases:   []string{},
+				perScrapeRatio:     1.0,
+				logger:             log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+				currentBatchSize:   1,
+				entryHandler:       lokiClient,
+			}
+
+			archive, err := txtar.ParseFile("./testdata/explain_plan/complex_aggregation_with_case.txtar")
+			require.NoError(t, err)
+			require.Equal(t, 1, len(archive.Files))
+			jsonFile := archive.Files[0]
+			require.Equal(t, "complex_aggregation_with_case.json", jsonFile.Name)
+			jsonData := jsonFile.Data
+
+			mock.ExpectExec("SET SESSION search_path TO \"testdb\", public").WillReturnResult(sqlmock.NewResult(0, 1))
+			mock.ExpectExec("PREPARE explain_plan_123456 AS "+dupParamQuery).WillReturnResult(sqlmock.NewResult(0, 1))
+			mock.ExpectExec("SET plan_cache_mode = force_generic_plan").WillReturnResult(sqlmock.NewResult(0, 1))
+			mock.ExpectQuery("EXPLAIN (FORMAT JSON) EXECUTE explain_plan_123456(null,null,null)").WillReturnRows(sqlmock.NewRows([]string{"json"}).AddRow(jsonData))
 			mock.ExpectExec("DEALLOCATE explain_plan_123456").WillReturnResult(sqlmock.NewResult(0, 1))
 
 			err = explainPlan.fetchExplainPlans(t.Context())

--- a/internal/component/database_observability/postgres/collector/explain_plans_test.go
+++ b/internal/component/database_observability/postgres/collector/explain_plans_test.go
@@ -3071,7 +3071,7 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 			jsonData := jsonFile.Data
 
 			mock.ExpectExec("SET SESSION search_path TO \"testdb\", public").WillReturnResult(sqlmock.NewResult(0, 1))
-			mock.ExpectExec("PREPARE explain_plan_123456 AS "+dupParamQuery).WillReturnResult(sqlmock.NewResult(0, 1))
+			mock.ExpectExec("PREPARE explain_plan_123456 AS " + dupParamQuery).WillReturnResult(sqlmock.NewResult(0, 1))
 			mock.ExpectExec("SET plan_cache_mode = force_generic_plan").WillReturnResult(sqlmock.NewResult(0, 1))
 			mock.ExpectQuery("EXPLAIN (FORMAT JSON) EXECUTE explain_plan_123456(null,null,null)").WillReturnRows(sqlmock.NewRows([]string{"json"}).AddRow(jsonData))
 			mock.ExpectExec("DEALLOCATE explain_plan_123456").WillReturnResult(sqlmock.NewResult(0, 1))


### PR DESCRIPTION
### Brief description of Pull Request
The original implementation failed to account for queries which reuse the same parameter multiple times, in which case counting placeholders results in too many parameters being passed to the prepared statement.

### Issue(s) fixed by this Pull Request

grafana/grafana-dbo11y-app#2690

### PR Checklist
- [x] Tests updated
