### PR TITLE
perf(loki.write): Reduce allocations when building label string 

### DIFF
--- a/internal/component/common/loki/client/batch.go
+++ b/internal/component/common/loki/client/batch.go
@@ -177,6 +177,8 @@ func labelsMapToString(ls model.LabelSet) string {
 		if cap(lstrs) <= maxPooledLabelNamesCapacity {
 			// append may have updated the slice header so write it back before
 			// returning the slice to the pool.
+			// This is not necessary with the current cap check, but we keep it so
+			// the pooled slice state stays correct if that ever changes.
 			*pooled = lstrs[:0]
 			labelNamesPool.Put(pooled)
 		}

--- a/internal/component/common/loki/client/batch.go
+++ b/internal/component/common/loki/client/batch.go
@@ -153,6 +153,7 @@ func (b *batch) reportAsSentData(h SentDataMarkerHandler, obs prometheus.Observe
 	}
 }
 
+// 15 matches Loki's default maximum for indexed labels.
 const maxPooledLabelNamesCapacity = 15
 
 var labelNamesPool = sync.Pool{

--- a/internal/component/common/loki/client/batch.go
+++ b/internal/component/common/loki/client/batch.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unsafe"
 
 	"github.com/grafana/loki/pkg/push"
 	"github.com/prometheus/client_golang/prometheus"
@@ -154,22 +155,20 @@ func (b *batch) reportAsSentData(h SentDataMarkerHandler, obs prometheus.Observe
 
 const maxPooledLabelNamesCapacity = 15
 
-var (
-	labelNamesPool = sync.Pool{
-		New: func() any {
-			s := make([]model.LabelName, 0, maxPooledLabelNamesCapacity)
-			return &s
-		},
-	}
-)
+var labelNamesPool = sync.Pool{
+	New: func() any {
+		s := make([]model.LabelName, 0, maxPooledLabelNamesCapacity)
+		return &s
+	},
+}
 
 // labelsMapToString encodes an entry's label set as a string, ignoring internal labels
 func labelsMapToString(ls model.LabelSet) string {
-	var b strings.Builder
-	totalSize := 2
-
-	pooled := labelNamesPool.Get().(*[]model.LabelName)
-	lstrs := *pooled
+	var (
+		totalSize = 2
+		pooled    = labelNamesPool.Get().(*[]model.LabelName)
+		lstrs     = *pooled
+	)
 
 	defer func() {
 		// Only return slices that stayed within the pooled capacity, this avoids
@@ -195,18 +194,23 @@ func labelsMapToString(ls model.LabelSet) string {
 
 	slices.Sort(lstrs)
 
-	b.Grow(totalSize)
-	b.WriteByte('{')
+	// Build into a local byte slice so strconv.AppendQuote can write directly
+	// into the final buffer. With strings.Builder we would need strconv.Quote,
+	// which creates an intermediate quoted string for each label value.
+	buf := make([]byte, 0, totalSize)
+	buf = append(buf, '{')
 	for i, l := range lstrs {
 		if i > 0 {
-			b.WriteString(", ")
+			buf = append(buf, ',', ' ')
 		}
 
-		b.WriteString(string(l))
-		b.WriteString(`=`)
-		b.WriteString(strconv.Quote(string(ls[l])))
+		buf = append(buf, string(l)...)
+		buf = append(buf, '=')
+		buf = strconv.AppendQuote(buf, string(ls[l]))
 	}
-	b.WriteByte('}')
+	buf = append(buf, '}')
 
-	return b.String()
+	// Safe: buf is local to this call and is never mutated again after converting
+	// it to a string so the returned strings backing bytes remain immutable.
+	return unsafe.String(unsafe.SliceData(buf), len(buf))
 }

--- a/internal/component/common/loki/client/batch.go
+++ b/internal/component/common/loki/client/batch.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/grafana/loki/pkg/push"
@@ -151,11 +152,35 @@ func (b *batch) reportAsSentData(h SentDataMarkerHandler, obs prometheus.Observe
 	}
 }
 
+const maxPooledLabelNamesCapacity = 15
+
+var (
+	labelNamesPool = sync.Pool{
+		New: func() any {
+			s := make([]model.LabelName, 0, maxPooledLabelNamesCapacity)
+			return &s
+		},
+	}
+)
+
 // labelsMapToString encodes an entry's label set as a string, ignoring internal labels
 func labelsMapToString(ls model.LabelSet) string {
 	var b strings.Builder
 	totalSize := 2
-	lstrs := make([]model.LabelName, 0, len(ls))
+
+	pooled := labelNamesPool.Get().(*[]model.LabelName)
+	lstrs := *pooled
+
+	defer func() {
+		// Only return slices that stayed within the pooled capacity, this avoids
+		// retaining large one-off backing arrays.
+		if cap(lstrs) <= maxPooledLabelNamesCapacity {
+			// append may have updated the slice header so write it back before
+			// returning the slice to the pool.
+			*pooled = lstrs[:0]
+			labelNamesPool.Put(pooled)
+		}
+	}()
 
 	for l, v := range ls {
 		// skip internal labels
@@ -168,9 +193,10 @@ func labelsMapToString(ls model.LabelSet) string {
 		totalSize += len(l) + 2 + len(v) + 3
 	}
 
+	slices.Sort(lstrs)
+
 	b.Grow(totalSize)
 	b.WriteByte('{')
-	slices.Sort(lstrs)
 	for i, l := range lstrs {
 		if i > 0 {
 			b.WriteString(", ")

--- a/internal/component/common/loki/client/batch.go
+++ b/internal/component/common/loki/client/batch.go
@@ -213,7 +213,8 @@ func labelsMapToString(ls model.LabelSet) string {
 	}
 	buf = append(buf, '}')
 
-	// Safe: buf is local to this call and is never mutated again after converting
+	// #nosec G103 nosemgrep: use-of-unsafe-block
+	// Safety: buf is local to this call and is never mutated again after converting
 	// it to a string so the returned strings backing bytes remain immutable.
 	return unsafe.String(unsafe.SliceData(buf), len(buf))
 }


### PR DESCRIPTION
### Pull Request Details
This pr includes two performance improvements for `labelsMapToString`, which is in the hotpat because we call it for every entry we want to send in `loki.write`.

1. Use a sync.Pool for LabelName slice, this is used to sort the LabelSet. By default loki restrict each stream to 15 indexed labels allowed so this should be a good default. For now I do not put the slice back if we for some reason allocate more, if this is ever a problem we can revisit that part but in our internal cluster this is not a problem from my testing.
2. Use a byte slice instead of string.Builder. This done to get rid of `strconv.Quote`, which will do a temporary string allocation before writing it it the builder. `strconv.AppendQuote` will instead write it directly to our pre-allocated slice.

### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->

### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
