### PR TITLE
feat(prometheus.exporter.azure): Add Azure Monitor Batch API support

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.exporter.azure.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.azure.md
@@ -29,8 +29,8 @@ The exporter offers the following three options for gathering metrics.
    1. This approach doesn't work with all resource types, and Azure doesn't document which resource types do or don't work.
    1. A resource type that's not supported produces errors that look like `Resource type: microsoft.containerservice/managedclusters not enabled for Cross Resource metrics`.
    1. If you encounter one of these errors you must use the default Azure Resource Graph based option to gather metrics.
-1. Use the [Azure Monitor Batch API](https://learn.microsoft.com/en-us/rest/api/monitor/metrics-batch/batch) by setting `use_batch_api` to `true`.
-   1. This batches up to 50 resources per API call using the Azure Monitor data plane (`https://<region>.metrics.monitor.azure.com`).
+1. Set use_batch_api` to `true` to use the [Azure Monitor Batch API](https://learn.microsoft.com/en-us/rest/api/monitor/metrics-batch/batch).
+   1. This uses the Azure Monitor data plane (`https://<region>.metrics.monitor.azure.com`) to batch up to 50 resources per API call.
    1. The data plane has **separate rate limits** from the ARM management plane, which significantly reduces 429 (Too Many Requests) throttling when monitoring many resources.
    1. Resources are discovered using Azure Resource Graph (like option 1), then grouped by subscription and region for batch retrieval.
    1. Cannot be used together with `regions`. Use `resource_graph_query_filter` to target specific regions instead.
@@ -45,7 +45,7 @@ The account used by {{< param "PRODUCT_NAME" >}} needs:
 * When using an Azure Resource Graph query, [read access to the resources that will be queried by Resource Graph](https://learn.microsoft.com/en-us/azure/governance/resource-graph/overview#permissions-in-azure-resource-graph).
 <!-- vale Grafana.GoogleSpacing = NO -->
 * Permissions to call the [Microsoft.Insights Metrics API](https://learn.microsoft.com/en-us/rest/api/monitor/metrics/list) which should be the `Microsoft.Insights/Metrics/Read` permission.
-* When using `use_batch_api`, the identity also needs access to the Azure Monitor data plane (`https://<region>.metrics.monitor.azure.com`). This uses a different OAuth2 scope than the ARM management plane. In most environments this works with the same identity, but restrictive configurations may require additional permissions.
+* When you use `use_batch_api`, the identity also needs access to the Azure Monitor data plane (`https://<region>.metrics.monitor.azure.com`). This uses a different OAuth2 scope than the ARM management plane. In most environments this works with the same identity, but restrictive configurations may require additional permissions.
 <!-- vale Grafana.GoogleSpacing = YES -->
 
 ## Usage
@@ -201,8 +201,8 @@ Replace the following:
 
 ### Batch API example
 
-The following example uses the Batch API to collect metrics from Azure Key Vault resources across multiple subscriptions
-with reduced API call overhead. This is recommended when monitoring many resources to avoid ARM rate limiting.
+The following example uses the Batch API to collect metrics from Azure Key Vault resources across multiple subscriptions with reduced API call overhead.
+This is recommended when monitoring many resources to avoid ARM rate limiting.
 
 ```alloy
 prometheus.exporter.azure "keyvault" {

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.azure.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.azure.md
@@ -19,7 +19,7 @@ You can find the complete list of available metrics in the [Azure Monitor docume
 Metrics for this integration are exposed with the template `azure_{type}_{metric}_{aggregation}_{unit}` by default. As an example,
 the Egress metric for BlobService would be exported as `azure_microsoft_storage_storageaccounts_blobservices_egress_total_bytes`.
 
-The exporter offers the following two options for gathering metrics.
+The exporter offers the following three options for gathering metrics.
 
 1. (Default) Use an [Azure Resource Graph](https://azure.microsoft.com/en-us/get-started/azure-portal/resource-graph/#overview) query to identify resources for gathering metrics.
    1. This query makes one API call per resource identified.
@@ -29,6 +29,11 @@ The exporter offers the following two options for gathering metrics.
    1. This approach doesn't work with all resource types, and Azure doesn't document which resource types do or don't work.
    1. A resource type that's not supported produces errors that look like `Resource type: microsoft.containerservice/managedclusters not enabled for Cross Resource metrics`.
    1. If you encounter one of these errors you must use the default Azure Resource Graph based option to gather metrics.
+1. Use the [Azure Monitor Batch API](https://learn.microsoft.com/en-us/rest/api/monitor/metrics-batch/batch) by setting `use_batch_api` to `true`.
+   1. This batches up to 50 resources per API call using the Azure Monitor data plane (`https://<region>.metrics.monitor.azure.com`).
+   1. The data plane has **separate rate limits** from the ARM management plane, which significantly reduces 429 (Too Many Requests) throttling when monitoring many resources.
+   1. Resources are discovered using Azure Resource Graph (like option 1), then grouped by subscription and region for batch retrieval.
+   1. Cannot be used together with `regions`. Use `resource_graph_query_filter` to target specific regions instead.
 
 ## Authentication
 
@@ -40,6 +45,7 @@ The account used by {{< param "PRODUCT_NAME" >}} needs:
 * When using an Azure Resource Graph query, [read access to the resources that will be queried by Resource Graph](https://learn.microsoft.com/en-us/azure/governance/resource-graph/overview#permissions-in-azure-resource-graph).
 <!-- vale Grafana.GoogleSpacing = NO -->
 * Permissions to call the [Microsoft.Insights Metrics API](https://learn.microsoft.com/en-us/rest/api/monitor/metrics/list) which should be the `Microsoft.Insights/Metrics/Read` permission.
+* When using `use_batch_api`, the identity also needs access to the Azure Monitor data plane (`https://<region>.metrics.monitor.azure.com`). This uses a different OAuth2 scope than the ARM management plane. In most environments this works with the same identity, but restrictive configurations may require additional permissions.
 <!-- vale Grafana.GoogleSpacing = YES -->
 
 ## Usage
@@ -82,6 +88,7 @@ You can use the following arguments with `prometheus.exporter.azure`:
 | `resource_graph_query_filter` | `string`       | The [Kusto query][] filter to apply when searching for resources. Can't be used if `regions` is set.                                                     |                                                                               | no       |
 | `timespan`                    | `string`       | [ISO8601 Duration][] over which the metrics are being queried.                                                                                           | `"PT5M"` (5 minutes)                                                          | no       |
 | `interval`                    | `string`       | [ISO8601 Duration][] used when to generate individual datapoints in Azure Monitor. Must be smaller than `timespan`.                                      | `"PT1M"` (1 minute)                                                           | no       |
+| `use_batch_api`               | `bool`         | Use the Azure Monitor Batch API to fetch metrics for up to 50 resources per request. Can't be used with `regions`.                                       | `false`                                                                       | no       |
 | `validate_dimensions`         | `bool`         | Enable dimension validation in the azure SDK.                                                                                                            | `false`                                                                       | no       |
 
 The list of available `resource_type` values and their corresponding `metrics` can be found in [Azure Monitor essentials][].
@@ -191,6 +198,43 @@ Replace the following:
 * _`<PROMETHEUS_REMOTE_WRITE_URL>`_: The URL of the Prometheus remote_write-compatible server to send metrics to.
 * _`<USERNAME>`_: The username to use for authentication to the `remote_write` API.
 * _`<PASSWORD>`_: The password to use for authentication to the `remote_write` API.
+
+### Batch API example
+
+The following example uses the Batch API to collect metrics from Azure Key Vault resources across multiple subscriptions
+with reduced API call overhead. This is recommended when monitoring many resources to avoid ARM rate limiting.
+
+```alloy
+prometheus.exporter.azure "keyvault" {
+    subscriptions               = ["<SUB_ID_1>", "<SUB_ID_2>"]
+    resource_type               = "Microsoft.KeyVault/vaults"
+    resource_graph_query_filter = "where location == 'eastus'"
+    metrics                     = ["Availability", "SaturationShoebox", "ServiceApiHit", "ServiceApiLatency", "ServiceApiResult"]
+    use_batch_api               = true
+}
+
+prometheus.scrape "keyvault" {
+    targets    = prometheus.exporter.azure.keyvault.targets
+    forward_to = [prometheus.remote_write.demo.receiver]
+}
+```
+
+{{< admonition type="note" >}}
+Some Azure resource types require a larger `interval` than the default `PT1M`.
+For example, Azure Database for PostgreSQL Flexible Servers only supports time grains of `PT30M` or larger.
+If you receive errors about unsupported time grains, increase the `interval` and `timespan` accordingly:
+
+```alloy
+prometheus.exporter.azure "postgresql" {
+    subscriptions = ["<SUB_ID>"]
+    resource_type = "Microsoft.DBforPostgreSQL/flexibleServers"
+    metrics       = ["cpu_percent", "memory_percent", "active_connections"]
+    interval      = "PT1H"
+    timespan      = "PT1H"
+    use_batch_api = true
+}
+```
+{{< /admonition >}}
 
 <!-- START GENERATED COMPATIBLE COMPONENTS -->
 

--- a/internal/component/prometheus/exporter/azure/azure.go
+++ b/internal/component/prometheus/exporter/azure/azure.go
@@ -41,6 +41,7 @@ type Arguments struct {
 	AzureCloudEnvironment    string   `alloy:"azure_cloud_environment,attr,optional"`
 	ValidateDimensions       bool     `alloy:"validate_dimensions,attr,optional"`
 	Regions                  []string `alloy:"regions,attr,optional"`
+	UseBatchAPI              bool     `alloy:"use_batch_api,attr,optional"`
 }
 
 // SetToDefault implements syntax.Defaulter.
@@ -84,5 +85,6 @@ func (a *Arguments) Convert() *azure_exporter.Config {
 		AzureCloudEnvironment:    a.AzureCloudEnvironment,
 		ValidateDimensions:       a.ValidateDimensions,
 		Regions:                  a.Regions,
+		UseBatchAPI:              a.UseBatchAPI,
 	}
 }

--- a/internal/converter/internal/staticconvert/internal/build/azure_exporter.go
+++ b/internal/converter/internal/staticconvert/internal/build/azure_exporter.go
@@ -28,5 +28,6 @@ func toAzureExporter(config *azure_exporter.Config) *azure.Arguments {
 		AzureCloudEnvironment:    config.AzureCloudEnvironment,
 		ValidateDimensions:       config.ValidateDimensions,
 		Regions:                  config.Regions,
+		UseBatchAPI:              config.UseBatchAPI,
 	}
 }

--- a/internal/static/integrations/azure_exporter/azure_exporter.go
+++ b/internal/static/integrations/azure_exporter/azure_exporter.go
@@ -77,11 +77,21 @@ func (e Exporter) MetricsHandler() (http.Handler, error) {
 		prober.SetPrometheusRegistry(reg)
 		prober.SetAzureResourceTagManager(tagManager)
 
+		// When use_batch_api is enabled, use the Azure Monitor Batch API (metrics:getBatch) which
+		// queries up to 50 resources per request using the Azure Monitor data plane. This has
+		// separate rate limits from the ARM management plane, avoiding 429 throttling.
+		//
 		// When regions has values then the request is for all resources in the subscription.
 		//  "RunOnSubscriptionScope" uses a different API, https://github.com/Azure/azure-rest-api-specs/blob/main/specification/monitor/resource-manager/Microsoft.Insights/stable/2021-05-01/metrics_API.json#L40,
 		//  which can get metric data for all resources in a single API call reducing overhead/likelihood of being rate limited.
 		// Limiting to specific resources requires 1 API call per resource to get metrics which can easily lead to rate limiting
-		if len(settings.Regions) > 0 {
+		if mergedConfig.UseBatchAPI {
+			if err := e.collectBatchMetrics(ctx, reg, mergedConfig, settings, client); err != nil {
+				e.logger.Error(fmt.Errorf("batch metrics collection failed, %v", err))
+				http.Error(resp, "Failed to collect batch metrics", http.StatusInternalServerError)
+				return
+			}
+		} else if len(settings.Regions) > 0 {
 			prober.RunOnSubscriptionScope()
 		} else {
 			err = prober.ServiceDiscovery.FindResourceGraph(ctx, settings.Subscriptions, settings.ResourceType, settings.Filter)

--- a/internal/static/integrations/azure_exporter/batch.go
+++ b/internal/static/integrations/azure_exporter/batch.go
@@ -1,0 +1,663 @@
+package azure_exporter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	neturl "net/url"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/webdevops/azure-metrics-exporter/metrics"
+	"github.com/webdevops/go-common/azuresdk/armclient"
+	"github.com/webdevops/go-common/utils/to"
+)
+
+const (
+	batchAPIVersion       = "2024-02-01"
+	maxBatchSize          = 50  // Maximum resources per metrics:getBatch request.
+	maxMetricsPerRequest  = 20  // Azure Monitor limit on metric names per request.
+	resourceGraphTop      = int32(1000)
+)
+
+// batchMetricsEndpoint returns the base URL for the Azure Monitor Batch API for a given region and cloud.
+func batchMetricsEndpoint(region, cloudEnv string) string {
+	switch strings.ToLower(cloudEnv) {
+	case "azurechina", "azurechinacloud":
+		return fmt.Sprintf("https://%s.metrics.monitor.azure.cn", region)
+	case "usgov", "azuregovernment", "azuregovernmentcloud", "azureusgovernmentcloud":
+		return fmt.Sprintf("https://%s.metrics.monitor.azure.us", region)
+	default:
+		return fmt.Sprintf("https://%s.metrics.monitor.azure.com", region)
+	}
+}
+
+// batchMetricsScope returns the OAuth2 scope for the Azure Monitor metrics data plane.
+func batchMetricsScope(cloudEnv string) string {
+	switch strings.ToLower(cloudEnv) {
+	case "azurechina", "azurechinacloud":
+		return "https://metrics.monitor.azure.cn/.default"
+	case "usgov", "azuregovernment", "azuregovernmentcloud", "azureusgovernmentcloud":
+		return "https://metrics.monitor.azure.us/.default"
+	default:
+		return "https://metrics.monitor.azure.com/.default"
+	}
+}
+
+// discoveredResource holds a resource ID and its Azure region, as returned by Resource Graph.
+type discoveredResource struct {
+	ID       string
+	Location string
+	Tags     map[string]string
+}
+
+// batchRequest is the JSON body sent to the metrics:getBatch endpoint.
+type batchRequest struct {
+	ResourceIDs []string `json:"resourceids"`
+}
+
+// batchResponse is the top-level JSON response from the metrics:getBatch endpoint.
+type batchResponse struct {
+	Values []batchResourceResult `json:"values"`
+}
+
+// batchResourceResult holds the metrics response for a single resource within a batch.
+type batchResourceResult struct {
+	StartTime  string        `json:"starttime"`
+	EndTime    string        `json:"endtime"`
+	ResourceID string        `json:"resourceid"`
+	Value      []batchMetric `json:"value"`
+}
+
+// batchMetric represents a single metric definition in the batch response.
+type batchMetric struct {
+	ID         string            `json:"id"`
+	Name       batchLocalizable  `json:"name"`
+	Unit       string            `json:"unit"`
+	Timeseries []batchTimeseries `json:"timeseries"`
+}
+
+// batchLocalizable mirrors Azure's localizable string (name + localized value).
+type batchLocalizable struct {
+	Value          string `json:"value"`
+	LocalizedValue string `json:"localizedValue"`
+}
+
+// batchTimeseries holds metadata and data points for a timeseries.
+type batchTimeseries struct {
+	MetadataValues []batchMetadataValue `json:"metadatavalues"`
+	Data           []batchDataPoint     `json:"data"`
+}
+
+// batchMetadataValue holds a dimension name/value pair.
+type batchMetadataValue struct {
+	Name  batchLocalizable `json:"name"`
+	Value string           `json:"value"`
+}
+
+// batchDataPoint holds a single timestamped metric data point.
+type batchDataPoint struct {
+	TimeStamp time.Time `json:"timeStamp"`
+	Total     *float64  `json:"total"`
+	Minimum   *float64  `json:"minimum"`
+	Maximum   *float64  `json:"maximum"`
+	Average   *float64  `json:"average"`
+	Count     *float64  `json:"count"`
+}
+
+// discoverResourcesWithLocation runs a Resource Graph query that returns resource IDs with their locations.
+func discoverResourcesWithLocation(
+	ctx context.Context,
+	cred azcore.TokenCredential,
+	clientOpts *arm.ClientOptions,
+	subscriptions []string,
+	resourceType string,
+	filter string,
+) ([]discoveredResource, error) {
+	client, err := armresourcegraph.NewClient(cred, clientOpts)
+	if err != nil {
+		return nil, fmt.Errorf("creating resource graph client: %w", err)
+	}
+
+	if filter != "" {
+		filter = "| " + filter
+	}
+	query := strings.TrimSpace(fmt.Sprintf(
+		`Resources | where type =~ "%s" %s | project id, location, tags`,
+		strings.ReplaceAll(resourceType, "'", "\\'"),
+		filter,
+	))
+
+	queryFormat := armresourcegraph.ResultFormatObjectArray
+	queryTop := resourceGraphTop
+	queryRequest := armresourcegraph.QueryRequest{
+		Query: to.StringPtr(query),
+		Options: &armresourcegraph.QueryRequestOptions{
+			ResultFormat: &queryFormat,
+			Top:          &queryTop,
+		},
+		Subscriptions: to.SlicePtr(subscriptions),
+	}
+
+	result, err := client.Resources(ctx, queryRequest, nil)
+	if err != nil {
+		return nil, fmt.Errorf("resource graph query: %w", err)
+	}
+
+	var resources []discoveredResource
+	for {
+		resultList, ok := result.Data.([]interface{})
+		if !ok || len(resultList) == 0 {
+			break
+		}
+
+		for _, v := range resultList {
+			row, ok := v.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			id, _ := row["id"].(string)
+			location, _ := row["location"].(string)
+			if id == "" || location == "" {
+				continue
+			}
+
+			tags := parseResourceTags(row["tags"])
+			resources = append(resources, discoveredResource{
+				ID:       id,
+				Location: strings.ToLower(location),
+				Tags:     tags,
+			})
+		}
+
+		if result.SkipToken != nil {
+			queryRequest.Options.SkipToken = result.SkipToken
+			result, err = client.Resources(ctx, queryRequest, nil)
+			if err != nil {
+				return nil, fmt.Errorf("resource graph query (paginated): %w", err)
+			}
+		} else {
+			break
+		}
+	}
+
+	return resources, nil
+}
+
+// parseResourceTags converts the tags field from a Resource Graph result into a string map.
+func parseResourceTags(tags interface{}) map[string]string {
+	result := map[string]string{}
+	switch t := tags.(type) {
+	case map[string]interface{}:
+		for k, v := range t {
+			if s, ok := v.(string); ok {
+				result[k] = s
+			}
+		}
+	case map[string]string:
+		return t
+	}
+	return result
+}
+
+// resourceGroup is a set of resources sharing the same subscription and region.
+type resourceGroup struct {
+	SubscriptionID string
+	Region         string
+	Resources      []discoveredResource
+}
+
+// groupResources groups discovered resources by (subscription, region).
+func groupResources(resources []discoveredResource) []resourceGroup {
+	type key struct {
+		sub    string
+		region string
+	}
+	index := map[key]*resourceGroup{}
+	var order []key
+
+	for _, r := range resources {
+		info, err := azure.ParseResourceID(r.ID)
+		if err != nil {
+			continue
+		}
+		k := key{sub: info.SubscriptionID, region: r.Location}
+		if _, exists := index[k]; !exists {
+			index[k] = &resourceGroup{
+				SubscriptionID: info.SubscriptionID,
+				Region:         r.Location,
+			}
+			order = append(order, k)
+		}
+		index[k].Resources = append(index[k].Resources, r)
+	}
+
+	groups := make([]resourceGroup, 0, len(order))
+	for _, k := range order {
+		groups = append(groups, *index[k])
+	}
+	return groups
+}
+
+// collectBatchMetrics performs the full batch collection flow:
+// discover resources, group by (sub, region), call batch API, return Prometheus metrics.
+func (e Exporter) collectBatchMetrics(
+	ctx context.Context,
+	reg *prometheus.Registry,
+	cfg Config,
+	settings *metrics.RequestMetricSettings,
+	azureClient *armclient.ArmClient,
+) error {
+	resources, err := discoverResourcesWithLocation(
+		ctx,
+		azureClient.GetCred(),
+		azureClient.NewArmClientOptions(),
+		cfg.Subscriptions,
+		cfg.ResourceType,
+		cfg.ResourceGraphQueryFilter,
+	)
+	if err != nil {
+		return fmt.Errorf("batch resource discovery: %w", err)
+	}
+
+	if len(resources) == 0 {
+		e.logger.Info("no resources discovered, nothing to scrape")
+		return nil
+	}
+
+	groups := groupResources(resources)
+	scope := batchMetricsScope(cfg.AzureCloudEnvironment)
+
+	metricList := metrics.NewMetricList()
+
+	for _, group := range groups {
+		endpoint := batchMetricsEndpoint(group.Region, cfg.AzureCloudEnvironment)
+
+		// Batch in chunks of maxBatchSize
+		for i := 0; i < len(group.Resources); i += maxBatchSize {
+			end := i + maxBatchSize
+			if end > len(group.Resources) {
+				end = len(group.Resources)
+			}
+			chunk := group.Resources[i:end]
+
+			ids := make([]string, len(chunk))
+			// Build a lookup map for tags by resource ID
+			tagsByID := map[string]map[string]string{}
+			for j, r := range chunk {
+				ids[j] = r.ID
+				tagsByID[strings.ToLower(r.ID)] = r.Tags
+			}
+
+			// Metrics also need to be batched in chunks of maxMetricsPerRequest (Azure API limit).
+			for mi := 0; mi < len(settings.Metrics); mi += maxMetricsPerRequest {
+				mEnd := mi + maxMetricsPerRequest
+				if mEnd > len(settings.Metrics) {
+					mEnd = len(settings.Metrics)
+				}
+				metricNames := settings.Metrics[mi:mEnd]
+
+				resp, err := e.callBatchAPI(
+					ctx, azureClient.GetCred(), scope,
+					endpoint, group.SubscriptionID,
+					ids, metricNames, settings, cfg,
+				)
+				if err != nil {
+					e.logger.Warnf("batch API call failed for sub=%s region=%s: %v",
+						group.SubscriptionID, group.Region, err)
+					continue
+				}
+
+				e.processBatchResponse(resp, settings, azureClient, tagsByID, cfg, metricList)
+			}
+		}
+	}
+
+	publishMetricList(reg, metricList)
+	return nil
+}
+
+// callBatchAPI makes a single POST to the metrics:getBatch endpoint.
+func (e Exporter) callBatchAPI(
+	ctx context.Context,
+	cred azcore.TokenCredential,
+	scope string,
+	endpoint string,
+	subscriptionID string,
+	resourceIDs []string,
+	metricNames []string,
+	settings *metrics.RequestMetricSettings,
+	cfg Config,
+) (*batchResponse, error) {
+	token, err := cred.GetToken(ctx, policy.TokenRequestOptions{
+		Scopes: []string{scope},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("acquiring token: %w", err)
+	}
+
+	reqURL := fmt.Sprintf("%s/subscriptions/%s/metrics:getBatch",
+		endpoint, subscriptionID)
+
+	// Build query parameters using url.Values for proper encoding.
+	params := neturl.Values{}
+	params.Set("api-version", batchAPIVersion)
+	params.Set("metricnames", strings.Join(metricNames, ","))
+	if settings.Interval != nil && *settings.Interval != "" {
+		params.Set("interval", *settings.Interval)
+	}
+
+	// The batch API (2024-02-01) requires starttime/endtime as ISO 8601 datetimes,
+	// not a duration like "PT5M". Compute absolute times, widening the window to
+	// at least the interval so that at least one data point is returned.
+	now := time.Now().UTC()
+	window := computeTimeWindow(settings.Timespan, settings.Interval)
+	params.Set("starttime", now.Add(-window).Format(time.RFC3339))
+	params.Set("endtime", now.Format(time.RFC3339))
+
+	if len(settings.Aggregations) > 0 {
+		params.Set("aggregation", strings.Join(settings.Aggregations, ","))
+	}
+	if settings.MetricNamespace != "" {
+		params.Set("metricnamespace", settings.MetricNamespace)
+	} else {
+		params.Set("metricnamespace", cfg.ResourceType)
+	}
+	if settings.MetricFilter != "" {
+		params.Set("$filter", settings.MetricFilter)
+	}
+	if settings.MetricTop != nil {
+		params.Set("top", fmt.Sprintf("%d", *settings.MetricTop))
+	}
+	if settings.MetricOrderBy != "" {
+		params.Set("orderby", settings.MetricOrderBy)
+	}
+
+	reqURL += "?" + params.Encode()
+
+	body, err := json.Marshal(batchRequest{ResourceIDs: resourceIDs})
+	if err != nil {
+		return nil, fmt.Errorf("marshaling request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token.Token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("batch API request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("batch API returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var batchResp batchResponse
+	if err := json.Unmarshal(respBody, &batchResp); err != nil {
+		return nil, fmt.Errorf("unmarshaling response: %w", err)
+	}
+
+	return &batchResp, nil
+}
+
+// processBatchResponse converts a batch API response into MetricList entries,
+// producing the same Prometheus labels as the per-resource path.
+func (e Exporter) processBatchResponse(
+	resp *batchResponse,
+	settings *metrics.RequestMetricSettings,
+	azureClient *armclient.ArmClient,
+	tagsByID map[string]map[string]string,
+	cfg Config,
+	metricList *metrics.MetricList,
+) {
+	for _, resourceResult := range resp.Values {
+		resourceID := resourceResult.ResourceID
+		azureResource, parseErr := armclient.ParseResourceId(resourceID)
+		if parseErr != nil {
+			e.logger.Warnf("skipping resource with unparseable ID %q: %v", resourceID, parseErr)
+			continue
+		}
+
+		subscriptionName := ""
+		if azureClient != nil {
+			if sub, err := azureClient.GetCachedSubscription(context.Background(), azureResource.Subscription); err == nil && sub != nil {
+				subscriptionName = to.String(sub.DisplayName)
+			}
+		}
+
+		tags := tagsByID[strings.ToLower(resourceID)]
+
+		for _, metric := range resourceResult.Value {
+			metricUnit := metric.Unit
+
+			for _, ts := range metric.Timeseries {
+				dimensions := map[string]string{}
+				for _, md := range ts.MetadataValues {
+					dimensions[md.Name.Value] = md.Value
+				}
+
+				metricLabels := prometheus.Labels{
+					"resourceID":       strings.ToLower(resourceID),
+					"subscriptionID":   azureResource.Subscription,
+					"subscriptionName": subscriptionName,
+					"resourceGroup":    azureResource.ResourceGroup,
+					"resourceName":     azureResource.ResourceName,
+					"metric":           metric.Name.Value,
+					"unit":             metricUnit,
+					"interval":         to.String(settings.Interval),
+					"timespan":         settings.Timespan,
+					"aggregation":      "",
+				}
+
+				// Add resource tags as labels
+				for _, tagName := range cfg.IncludedResourceTags {
+					labelName := "tag_" + tagName
+					if val, ok := tags[tagName]; ok {
+						metricLabels[labelName] = val
+					} else {
+						metricLabels[labelName] = ""
+					}
+				}
+
+				// Handle dimensions (same logic as upstream)
+				if len(dimensions) == 1 {
+					for _, v := range dimensions {
+						metricLabels["dimension"] = v
+					}
+				} else if len(dimensions) >= 2 {
+					for dName, dValue := range dimensions {
+						labelName := "dimension" + strings.ToUpper(dName[:1]) + dName[1:]
+						metricLabels[labelName] = dValue
+					}
+				}
+
+				for _, dp := range ts.Data {
+					if dp.Total != nil {
+						metricLabels["aggregation"] = "total"
+						addMetric(metricList, settings, cfg, metricLabels, *dp.Total)
+					}
+					if dp.Minimum != nil {
+						metricLabels["aggregation"] = "minimum"
+						addMetric(metricList, settings, cfg, metricLabels, *dp.Minimum)
+					}
+					if dp.Maximum != nil {
+						metricLabels["aggregation"] = "maximum"
+						addMetric(metricList, settings, cfg, metricLabels, *dp.Maximum)
+					}
+					if dp.Average != nil {
+						metricLabels["aggregation"] = "average"
+						addMetric(metricList, settings, cfg, metricLabels, *dp.Average)
+					}
+					if dp.Count != nil {
+						metricLabels["aggregation"] = "count"
+						addMetric(metricList, settings, cfg, metricLabels, *dp.Count)
+					}
+				}
+			}
+		}
+	}
+}
+
+// addMetric builds a metric name from the template and adds it to the MetricList.
+func addMetric(
+	metricList *metrics.MetricList,
+	settings *metrics.RequestMetricSettings,
+	cfg Config,
+	labels prometheus.Labels,
+	value float64,
+) {
+	// Copy labels to avoid mutation
+	metricLabels := prometheus.Labels{}
+	for k, v := range labels {
+		metricLabels[k] = v
+	}
+
+	resourceType := settings.ResourceType
+	if settings.MetricNamespace != "" {
+		resourceType = settings.MetricNamespace
+	}
+
+	// Build metric name from template
+	name := settings.MetricTemplate
+	if name == "" {
+		name = settings.Name
+	}
+
+	replacer := strings.NewReplacer(
+		"-", "_", " ", "_", "/", "_", ".", "_",
+	)
+
+	name = replaceTemplatePlaceholders(name, metricLabels, resourceType)
+	name = replacer.Replace(name)
+	name = strings.ToLower(name)
+
+	// Build help from template
+	help := settings.HelpTemplate
+	help = replaceTemplatePlaceholders(help, metricLabels, resourceType)
+
+	metricList.Add(name, metrics.MetricRow{Labels: metricLabels, Value: value})
+	metricList.SetMetricHelp(name, help)
+}
+
+// replaceTemplatePlaceholders replaces {field} placeholders in a template string.
+func replaceTemplatePlaceholders(template string, labels prometheus.Labels, resourceType string) string {
+	result := template
+	// Simple replacement - find all {field} patterns
+	for {
+		start := strings.Index(result, "{")
+		if start == -1 {
+			break
+		}
+		end := strings.Index(result[start:], "}")
+		if end == -1 {
+			break
+		}
+		end += start
+
+		fieldName := result[start+1 : end]
+		var replacement string
+		switch fieldName {
+		case "type":
+			replacement = resourceType
+		default:
+			if val, exists := labels[fieldName]; exists {
+				replacement = val
+				// Remove label from map when used in metric name (matches upstream behavior)
+				delete(labels, fieldName)
+			}
+		}
+		result = result[:start] + replacement + result[end+1:]
+	}
+	return result
+}
+
+// computeTimeWindow returns the time window to use for a batch API request.
+// It ensures the window is at least as wide as the interval so that at least
+// one data point can be returned. For example, if interval is PT1H but timespan
+// is only PT5M, the window is widened to PT1H.
+func computeTimeWindow(timespan string, interval *string) time.Duration {
+	window := parseISO8601Duration(timespan)
+	if interval != nil && *interval != "" {
+		intervalDur := parseISO8601Duration(*interval)
+		if intervalDur > window {
+			window = intervalDur
+		}
+	}
+	return window
+}
+
+// parseISO8601Duration parses a simple ISO 8601 duration string (e.g., "PT5M", "PT1H", "P1D")
+// into a Go time.Duration. Supports days (D), hours (H), minutes (M), and seconds (S).
+// Does not support year (Y), month (M before T), or week (W) designators.
+func parseISO8601Duration(s string) time.Duration {
+	s = strings.TrimPrefix(s, "P")
+	var d time.Duration
+	inTime := false
+	numBuf := ""
+	for _, c := range s {
+		switch {
+		case c == 'T':
+			inTime = true
+		case c >= '0' && c <= '9' || c == '.':
+			numBuf += string(c)
+		default:
+			val := 0.0
+			if numBuf != "" {
+				fmt.Sscanf(numBuf, "%f", &val)
+				numBuf = ""
+			}
+			switch {
+			case c == 'D' && !inTime:
+				d += time.Duration(val * float64(24*time.Hour))
+			case c == 'H' && inTime:
+				d += time.Duration(val * float64(time.Hour))
+			case c == 'M' && inTime:
+				d += time.Duration(val * float64(time.Minute))
+			case c == 'S' && inTime:
+				d += time.Duration(val * float64(time.Second))
+			}
+		}
+	}
+	// Default to 5 minutes if parsing produces zero
+	if d == 0 {
+		d = 5 * time.Minute
+	}
+	return d
+}
+
+// publishMetricList registers all collected metrics with the Prometheus registry.
+func publishMetricList(reg *prometheus.Registry, metricList *metrics.MetricList) {
+	for _, metricName := range metricList.GetMetricNames() {
+		gauge := prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: metricName,
+				Help: metricList.GetMetricHelp(metricName),
+			},
+			metricList.GetMetricLabelNames(metricName),
+		)
+		reg.MustRegister(gauge)
+
+		for _, row := range metricList.GetMetricList(metricName) {
+			gauge.With(row.Labels).Set(row.Value)
+		}
+	}
+}

--- a/internal/static/integrations/azure_exporter/batch.go
+++ b/internal/static/integrations/azure_exporter/batch.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	neturl "net/url"
+	"net/url"
 	"strings"
 	"time"
 
@@ -23,10 +23,10 @@ import (
 )
 
 const (
-	batchAPIVersion       = "2024-02-01"
-	maxBatchSize          = 50  // Maximum resources per metrics:getBatch request.
-	maxMetricsPerRequest  = 20  // Azure Monitor limit on metric names per request.
-	resourceGraphTop      = int32(1000)
+	batchAPIVersion      = "2024-02-01"
+	maxBatchSize         = 50 // Maximum resources per metrics:getBatch request.
+	maxMetricsPerRequest = 20 // Azure Monitor limit on metric names per request.
+	resourceGraphTop     = int32(1000)
 )
 
 // batchMetricsEndpoint returns the base URL for the Azure Monitor Batch API for a given region and cloud.
@@ -153,6 +153,9 @@ func discoverResourcesWithLocation(
 		return nil, fmt.Errorf("resource graph query: %w", err)
 	}
 
+	// Resource Graph returns results as untyped JSON ([]interface{} of map[string]interface{}).
+	// We paginate through all results using SkipToken, extracting the fields we projected
+	// in the Kusto query: id, location, and tags.
 	var resources []discoveredResource
 	for {
 		resultList, ok := result.Data.([]interface{})
@@ -165,6 +168,8 @@ func discoverResourcesWithLocation(
 			if !ok {
 				continue
 			}
+
+			// Both id and location are required — skip malformed rows.
 			id, _ := row["id"].(string)
 			location, _ := row["location"].(string)
 			if id == "" || location == "" {
@@ -179,6 +184,7 @@ func discoverResourcesWithLocation(
 			})
 		}
 
+		// Resource Graph paginates via SkipToken. If present, fetch the next page.
 		if result.SkipToken != nil {
 			queryRequest.Options.SkipToken = result.SkipToken
 			result, err = client.Resources(ctx, queryRequest, nil)
@@ -349,7 +355,7 @@ func (e Exporter) callBatchAPI(
 		endpoint, subscriptionID)
 
 	// Build query parameters using url.Values for proper encoding.
-	params := neturl.Values{}
+	params := url.Values{}
 	params.Set("api-version", batchAPIVersion)
 	params.Set("metricnames", strings.Join(metricNames, ","))
 	if settings.Interval != nil && *settings.Interval != "" {
@@ -559,6 +565,8 @@ func addMetric(
 }
 
 // replaceTemplatePlaceholders replaces {field} placeholders in a template string.
+// Labels consumed by the template are deleted from the labels map (matching upstream behavior)
+// so they appear in the metric name rather than as separate Prometheus labels.
 func replaceTemplatePlaceholders(template string, labels prometheus.Labels, resourceType string) string {
 	result := template
 	// Simple replacement - find all {field} patterns
@@ -608,38 +616,51 @@ func computeTimeWindow(timespan string, interval *string) time.Duration {
 // parseISO8601Duration parses a simple ISO 8601 duration string (e.g., "PT5M", "PT1H", "P1D")
 // into a Go time.Duration. Supports days (D), hours (H), minutes (M), and seconds (S).
 // Does not support year (Y), month (M before T), or week (W) designators.
+//
+// Panics if the input produces a zero or negative duration, since Config.Validate() should
+// have already rejected invalid values before we get here.
 func parseISO8601Duration(s string) time.Duration {
+	original := s
+	// ISO 8601 durations have the form P[nD][T[nH][nM][nS]].
+	// The 'P' prefix marks the start; 'T' separates the date part (days) from the time part.
+	// We track whether we've seen 'T' to distinguish 'M' (months, unsupported) from 'M' (minutes).
 	s = strings.TrimPrefix(s, "P")
 	var d time.Duration
-	inTime := false
-	numBuf := ""
+	inTimePart := false // true after we see 'T'
+	numBuf := ""        // accumulates digit characters for the current number
+
 	for _, c := range s {
 		switch {
 		case c == 'T':
-			inTime = true
+			// Switch from date part to time part.
+			inTimePart = true
+
 		case c >= '0' && c <= '9' || c == '.':
+			// Accumulate digits (and decimal point) for the numeric value.
 			numBuf += string(c)
+
 		default:
+			// A unit designator (D, H, M, S) — parse the accumulated number and apply it.
 			val := 0.0
 			if numBuf != "" {
 				fmt.Sscanf(numBuf, "%f", &val)
 				numBuf = ""
 			}
 			switch {
-			case c == 'D' && !inTime:
+			case c == 'D' && !inTimePart:
 				d += time.Duration(val * float64(24*time.Hour))
-			case c == 'H' && inTime:
+			case c == 'H' && inTimePart:
 				d += time.Duration(val * float64(time.Hour))
-			case c == 'M' && inTime:
+			case c == 'M' && inTimePart:
 				d += time.Duration(val * float64(time.Minute))
-			case c == 'S' && inTime:
+			case c == 'S' && inTimePart:
 				d += time.Duration(val * float64(time.Second))
 			}
 		}
 	}
-	// Default to 5 minutes if parsing produces zero
-	if d == 0 {
-		d = 5 * time.Minute
+
+	if d <= 0 {
+		panic(fmt.Sprintf("parseISO8601Duration(%q): produced zero/negative duration; Config.Validate() should have caught this", original))
 	}
 	return d
 }

--- a/internal/static/integrations/azure_exporter/batch_test.go
+++ b/internal/static/integrations/azure_exporter/batch_test.go
@@ -1,0 +1,440 @@
+package azure_exporter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"github.com/webdevops/azure-metrics-exporter/metrics"
+)
+
+func TestGroupResources(t *testing.T) {
+	resources := []discoveredResource{
+		{ID: "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1", Location: "eastus", Tags: map[string]string{"env": "prod"}},
+		{ID: "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm2", Location: "eastus", Tags: map[string]string{"env": "prod"}},
+		{ID: "/subscriptions/sub1/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm3", Location: "westus", Tags: map[string]string{"env": "staging"}},
+		{ID: "/subscriptions/sub2/resourceGroups/rg3/providers/Microsoft.Compute/virtualMachines/vm4", Location: "eastus", Tags: map[string]string{"env": "prod"}},
+	}
+
+	groups := groupResources(resources)
+
+	require.Len(t, groups, 3, "expected 3 groups: (sub1, eastus), (sub1, westus), (sub2, eastus)")
+
+	// Verify group contents
+	found := map[string]int{}
+	for _, g := range groups {
+		key := g.SubscriptionID + ":" + g.Region
+		found[key] = len(g.Resources)
+	}
+	require.Equal(t, 2, found["sub1:eastus"])
+	require.Equal(t, 1, found["sub1:westus"])
+	require.Equal(t, 1, found["sub2:eastus"])
+}
+
+func TestGroupResources_Empty(t *testing.T) {
+	groups := groupResources(nil)
+	require.Empty(t, groups)
+}
+
+func TestGroupResources_InvalidResourceID(t *testing.T) {
+	resources := []discoveredResource{
+		{ID: "not-a-valid-resource-id", Location: "eastus"},
+		{ID: "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1", Location: "eastus"},
+	}
+
+	groups := groupResources(resources)
+	require.Len(t, groups, 1, "invalid resource IDs should be skipped")
+	require.Len(t, groups[0].Resources, 1)
+}
+
+func TestBatchMetricsEndpoint(t *testing.T) {
+	tests := []struct {
+		region   string
+		cloud    string
+		expected string
+	}{
+		{"eastus", "azurecloud", "https://eastus.metrics.monitor.azure.com"},
+		{"westeurope", "azurecloud", "https://westeurope.metrics.monitor.azure.com"},
+		{"chinaeast", "azurechinacloud", "https://chinaeast.metrics.monitor.azure.cn"},
+		{"usgovvirginia", "azuregovernment", "https://usgovvirginia.metrics.monitor.azure.us"},
+		{"eastus", "", "https://eastus.metrics.monitor.azure.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.region+"_"+tt.cloud, func(t *testing.T) {
+			endpoint := batchMetricsEndpoint(tt.region, tt.cloud)
+			require.Equal(t, tt.expected, endpoint)
+		})
+	}
+}
+
+func TestBatchMetricsScope(t *testing.T) {
+	require.Equal(t, "https://metrics.monitor.azure.com/.default", batchMetricsScope("azurecloud"))
+	require.Equal(t, "https://metrics.monitor.azure.cn/.default", batchMetricsScope("azurechinacloud"))
+	require.Equal(t, "https://metrics.monitor.azure.us/.default", batchMetricsScope("azuregovernment"))
+}
+
+func TestParseResourceTags(t *testing.T) {
+	t.Run("map[string]interface{}", func(t *testing.T) {
+		tags := map[string]interface{}{
+			"env":   "prod",
+			"owner": "sre",
+			"count": 42, // non-string values should be skipped
+		}
+		result := parseResourceTags(tags)
+		require.Equal(t, map[string]string{"env": "prod", "owner": "sre"}, result)
+	})
+
+	t.Run("map[string]string", func(t *testing.T) {
+		tags := map[string]string{"env": "prod"}
+		result := parseResourceTags(tags)
+		require.Equal(t, tags, result)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		result := parseResourceTags(nil)
+		require.Empty(t, result)
+	})
+}
+
+func TestReplaceTemplatePlaceholders(t *testing.T) {
+	labels := prometheus.Labels{
+		"metric":      "cpu_percent",
+		"aggregation": "average",
+		"unit":        "Percent",
+	}
+
+	result := replaceTemplatePlaceholders(
+		"azure_{type}_{metric}_{aggregation}_{unit}",
+		labels,
+		"Microsoft.Compute/virtualMachines",
+	)
+
+	require.Equal(t, "azure_Microsoft.Compute/virtualMachines_cpu_percent_average_Percent", result)
+	// Fields used in name should be removed from labels (matching upstream behavior)
+	require.NotContains(t, labels, "metric")
+	require.NotContains(t, labels, "aggregation")
+	require.NotContains(t, labels, "unit")
+}
+
+func TestProcessBatchResponse(t *testing.T) {
+	e := Exporter{
+		cfg:    Config{IncludedResourceTags: []string{"owner"}},
+		logger: nil, // not used in processBatchResponse
+	}
+
+	avgVal := 42.5
+	resp := &batchResponse{
+		Values: []batchResourceResult{
+			{
+				ResourceID: "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
+				Value: []batchMetric{
+					{
+						Name: batchLocalizable{Value: "Percentage CPU"},
+						Unit: "Percent",
+						Timeseries: []batchTimeseries{
+							{
+								Data: []batchDataPoint{
+									{Average: &avgVal},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	settings := &metrics.RequestMetricSettings{
+		ResourceType:   "Microsoft.Compute/virtualMachines",
+		Interval:       strPtr("PT1M"),
+		Timespan:       "PT5M",
+		MetricTemplate: "azure_{type}_{metric}_{aggregation}_{unit}",
+		HelpTemplate:   "Azure metric {metric} for {type} with aggregation {aggregation} as {unit}",
+	}
+
+	tagsByID := map[string]map[string]string{
+		"/subscriptions/sub1/resourcegroups/rg1/providers/microsoft.compute/virtualmachines/vm1": {
+			"owner": "sre-team",
+		},
+	}
+
+	// Create a mock arm client - we'll skip subscription name lookup by passing nil
+	// The processBatchResponse will handle the nil case gracefully
+	metricList := metrics.NewMetricList()
+	e.processBatchResponse(resp, settings, nil, tagsByID, e.cfg, metricList)
+
+	names := metricList.GetMetricNames()
+	require.NotEmpty(t, names, "should have produced at least one metric")
+
+	// Check that the metric name follows the template
+	found := false
+	for _, name := range names {
+		if name == "azure_microsoft_compute_virtualmachines_percentage_cpu_average_percent" {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "expected metric name matching template, got: %v", names)
+}
+
+func TestPublishMetricList(t *testing.T) {
+	metricList := metrics.NewMetricList()
+	metricList.Add("test_metric", metrics.MetricRow{
+		Labels: prometheus.Labels{"foo": "bar"},
+		Value:  1.0,
+	})
+	metricList.SetMetricHelp("test_metric", "A test metric")
+
+	reg := prometheus.NewRegistry()
+	publishMetricList(reg, metricList)
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	require.Len(t, families, 1)
+	require.Equal(t, "test_metric", *families[0].Name)
+}
+
+func TestParseISO8601Duration(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected time.Duration
+	}{
+		{"PT5M", 5 * time.Minute},
+		{"PT1M", 1 * time.Minute},
+		{"PT1H", 1 * time.Hour},
+		{"PT30M", 30 * time.Minute},
+		{"PT1H30M", 90 * time.Minute},
+		{"P1D", 24 * time.Hour},
+		{"P1DT12H", 36 * time.Hour},
+		{"PT90S", 90 * time.Second},
+		{"PT1H30M45S", time.Hour + 30*time.Minute + 45*time.Second},
+		{"P2D", 48 * time.Hour},
+		// Zero/invalid inputs fall back to 5 minutes
+		{"", 5 * time.Minute},
+		{"garbage", 5 * time.Minute},
+		{"PT0S", 5 * time.Minute}, // zero duration falls back
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := parseISO8601Duration(tt.input)
+			require.Equal(t, tt.expected, result, "parseISO8601Duration(%q)", tt.input)
+		})
+	}
+}
+
+func TestComputeTimeWindow(t *testing.T) {
+	tests := []struct {
+		name     string
+		timespan string
+		interval *string
+		expected time.Duration
+	}{
+		{
+			name:     "timespan wider than interval",
+			timespan: "PT5M",
+			interval: strPtr("PT1M"),
+			expected: 5 * time.Minute,
+		},
+		{
+			name:     "interval wider than timespan — window widens",
+			timespan: "PT5M",
+			interval: strPtr("PT1H"),
+			expected: 1 * time.Hour,
+		},
+		{
+			name:     "nil interval — use timespan as-is",
+			timespan: "PT5M",
+			interval: nil,
+			expected: 5 * time.Minute,
+		},
+		{
+			name:     "empty interval — use timespan as-is",
+			timespan: "PT5M",
+			interval: strPtr(""),
+			expected: 5 * time.Minute,
+		},
+		{
+			name:     "equal interval and timespan",
+			timespan: "PT1H",
+			interval: strPtr("PT1H"),
+			expected: 1 * time.Hour,
+		},
+		{
+			name:     "large interval with small timespan",
+			timespan: "PT5M",
+			interval: strPtr("P1D"),
+			expected: 24 * time.Hour,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := computeTimeWindow(tt.timespan, tt.interval)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestProcessBatchResponse_Dimensions(t *testing.T) {
+	e := Exporter{
+		cfg:    Config{},
+		logger: nil,
+	}
+
+	avgVal := 10.0
+	resp := &batchResponse{
+		Values: []batchResourceResult{
+			{
+				ResourceID: "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
+				Value: []batchMetric{
+					{
+						Name: batchLocalizable{Value: "Requests"},
+						Unit: "Count",
+						Timeseries: []batchTimeseries{
+							{
+								MetadataValues: []batchMetadataValue{
+									{Name: batchLocalizable{Value: "StatusCode"}, Value: "200"},
+								},
+								Data: []batchDataPoint{{Average: &avgVal}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	settings := &metrics.RequestMetricSettings{
+		ResourceType:   "Microsoft.Compute/virtualMachines",
+		Interval:       strPtr("PT1M"),
+		Timespan:       "PT5M",
+		MetricTemplate: "azure_{type}_{metric}_{aggregation}_{unit}",
+		HelpTemplate:   "test help",
+	}
+
+	metricList := metrics.NewMetricList()
+	e.processBatchResponse(resp, settings, nil, map[string]map[string]string{}, Config{}, metricList)
+
+	// With a single dimension, the label should be "dimension" (not "dimensionStatusCode")
+	names := metricList.GetMetricNames()
+	require.NotEmpty(t, names)
+	for _, name := range names {
+		for _, row := range metricList.GetMetricList(name) {
+			require.Equal(t, "200", row.Labels["dimension"], "single dimension should use 'dimension' label")
+		}
+	}
+}
+
+func TestProcessBatchResponse_MultiDimensions(t *testing.T) {
+	e := Exporter{
+		cfg:    Config{},
+		logger: nil,
+	}
+
+	avgVal := 5.0
+	resp := &batchResponse{
+		Values: []batchResourceResult{
+			{
+				ResourceID: "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
+				Value: []batchMetric{
+					{
+						Name: batchLocalizable{Value: "Requests"},
+						Unit: "Count",
+						Timeseries: []batchTimeseries{
+							{
+								MetadataValues: []batchMetadataValue{
+									{Name: batchLocalizable{Value: "statusCode"}, Value: "200"},
+									{Name: batchLocalizable{Value: "method"}, Value: "GET"},
+								},
+								Data: []batchDataPoint{{Average: &avgVal}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	settings := &metrics.RequestMetricSettings{
+		ResourceType:   "Microsoft.Compute/virtualMachines",
+		Interval:       strPtr("PT1M"),
+		Timespan:       "PT5M",
+		MetricTemplate: "azure_{type}_{metric}_{aggregation}_{unit}",
+		HelpTemplate:   "test help",
+	}
+
+	metricList := metrics.NewMetricList()
+	e.processBatchResponse(resp, settings, nil, map[string]map[string]string{}, Config{}, metricList)
+
+	names := metricList.GetMetricNames()
+	require.NotEmpty(t, names)
+	for _, name := range names {
+		for _, row := range metricList.GetMetricList(name) {
+			require.Equal(t, "200", row.Labels["dimensionStatusCode"], "multi-dimension: statusCode")
+			require.Equal(t, "GET", row.Labels["dimensionMethod"], "multi-dimension: method")
+		}
+	}
+}
+
+func TestProcessBatchResponse_AllAggregations(t *testing.T) {
+	e := Exporter{
+		cfg:    Config{},
+		logger: nil,
+	}
+
+	total, min, max, avg, count := 100.0, 1.0, 50.0, 25.0, 4.0
+	resp := &batchResponse{
+		Values: []batchResourceResult{
+			{
+				ResourceID: "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
+				Value: []batchMetric{
+					{
+						Name: batchLocalizable{Value: "cpu_percent"},
+						Unit: "Percent",
+						Timeseries: []batchTimeseries{
+							{
+								Data: []batchDataPoint{
+									{Total: &total, Minimum: &min, Maximum: &max, Average: &avg, Count: &count},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	settings := &metrics.RequestMetricSettings{
+		ResourceType:   "Microsoft.Compute/virtualMachines",
+		Interval:       strPtr("PT1M"),
+		Timespan:       "PT5M",
+		MetricTemplate: "azure_{type}_{metric}_{aggregation}_{unit}",
+		HelpTemplate:   "test help",
+	}
+
+	metricList := metrics.NewMetricList()
+	e.processBatchResponse(resp, settings, nil, map[string]map[string]string{}, Config{}, metricList)
+
+	// Should produce 5 metric names (one per aggregation type, since {aggregation}
+	// is part of the template and gets baked into the metric name).
+	names := metricList.GetMetricNames()
+	valueByName := map[string]float64{}
+	for _, name := range names {
+		for _, row := range metricList.GetMetricList(name) {
+			valueByName[name] = row.Value
+		}
+	}
+	require.Len(t, valueByName, 5, "should have 5 metric names for 5 aggregation types, got: %v", names)
+	require.Equal(t, 100.0, valueByName["azure_microsoft_compute_virtualmachines_cpu_percent_total_percent"])
+	require.Equal(t, 1.0, valueByName["azure_microsoft_compute_virtualmachines_cpu_percent_minimum_percent"])
+	require.Equal(t, 50.0, valueByName["azure_microsoft_compute_virtualmachines_cpu_percent_maximum_percent"])
+	require.Equal(t, 25.0, valueByName["azure_microsoft_compute_virtualmachines_cpu_percent_average_percent"])
+	require.Equal(t, 4.0, valueByName["azure_microsoft_compute_virtualmachines_cpu_percent_count_percent"])
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/internal/static/integrations/azure_exporter/batch_test.go
+++ b/internal/static/integrations/azure_exporter/batch_test.go
@@ -211,16 +211,25 @@ func TestParseISO8601Duration(t *testing.T) {
 		{"PT90S", 90 * time.Second},
 		{"PT1H30M45S", time.Hour + 30*time.Minute + 45*time.Second},
 		{"P2D", 48 * time.Hour},
-		// Zero/invalid inputs fall back to 5 minutes
-		{"", 5 * time.Minute},
-		{"garbage", 5 * time.Minute},
-		{"PT0S", 5 * time.Minute}, // zero duration falls back
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			result := parseISO8601Duration(tt.input)
 			require.Equal(t, tt.expected, result, "parseISO8601Duration(%q)", tt.input)
+		})
+	}
+}
+
+func TestParseISO8601Duration_PanicsOnInvalid(t *testing.T) {
+	// Invalid or zero-duration inputs should panic — Config.Validate() is responsible
+	// for catching these before they reach this function.
+	invalidInputs := []string{"", "garbage", "PT0S"}
+	for _, input := range invalidInputs {
+		t.Run(input, func(t *testing.T) {
+			require.Panics(t, func() {
+				parseISO8601Duration(input)
+			}, "parseISO8601Duration(%q) should panic", input)
 		})
 	}
 }

--- a/internal/static/integrations/azure_exporter/config.go
+++ b/internal/static/integrations/azure_exporter/config.go
@@ -82,6 +82,13 @@ type Config struct {
 	ValidateDimensions bool   `yaml:"validate_dimensions"`
 
 	AzureCloudEnvironment string `yaml:"azure_cloud_environment"`
+
+	// UseBatchAPI enables the Azure Monitor Batch API (metrics:getBatch) for fetching metrics.
+	// Instead of making one ARM API call per resource, this batches up to 50 resources per request
+	// using the Azure Monitor data plane (https://<region>.metrics.monitor.azure.com), which has
+	// separate rate limits from the ARM management plane. This significantly reduces the likelihood
+	// of hitting 429 throttling when monitoring many resources.
+	UseBatchAPI bool `yaml:"use_batch_api"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler for Config.
@@ -134,6 +141,10 @@ func (c *Config) Validate() error {
 
 	if len(c.Regions) > 0 && c.ResourceGraphQueryFilter != "" {
 		configErrors = append(configErrors, "regions and resource_graph_query_filter cannot be used together. If you want to target specific resources add a region filter to the resource_graph_query_filter. Otherwise, remove your resource_graph_query_filter to get metrics without further filtering.")
+	}
+
+	if c.UseBatchAPI && len(c.Regions) > 0 {
+		configErrors = append(configErrors, "use_batch_api and regions cannot be used together. The batch API discovers resource locations automatically via Resource Graph. Use resource_graph_query_filter to limit by location instead.")
 	}
 
 	validAggregations := []string{"minimum", "maximum", "average", "total", "count"}

--- a/internal/static/integrations/azure_exporter/config_test.go
+++ b/internal/static/integrations/azure_exporter/config_test.go
@@ -189,6 +189,14 @@ func TestConfig_Validate(t *testing.T) {
 			},
 		},
 		{
+			name: "use_batch_api with regions",
+			toInvalidConfig: func(config azure_exporter.Config) azure_exporter.Config {
+				config.UseBatchAPI = true
+				config.Regions = []string{"eastus"}
+				return config
+			},
+		},
+		{
 			name: "invalid interval",
 			toInvalidConfig: func(config azure_exporter.Config) azure_exporter.Config {
 				config.Interval = "Not a valid interval"
@@ -227,7 +235,7 @@ func TestMergeConfigWithQueryParams_MapsAllExpectedFieldsByYamlNameFromConfig(t 
 	for i := 0; i < thing.NumField(); i++ {
 		field := thing.Field(i)
 		// Not available to be mapped via query param
-		if field.Name == "AzureCloudEnvironment" {
+		if field.Name == "AzureCloudEnvironment" || field.Name == "UseBatchAPI" {
 			continue
 		}
 


### PR DESCRIPTION
### Brief description of Pull Request

Add support for the Azure Monitor Batch API (`metrics:getBatch`) to `prometheus.exporter.azure`, enabling up to 50 resources per API call using the Azure Monitor data plane. This data plane has separate rate limits from the ARM management plane, dramatically reducing 429 throttling for organizations monitoring many resources across multiple subscriptions.

### Pull Request Details

**Problem:** The existing per-resource collection path makes one ARM API call per discovered resource. At scale (e.g., 40 subscriptions × dozens of resource types), this quickly exhausts the [ARM rate limit](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/request-limits-and-throttling) (250-token bucket, 25 tokens/second refill per subscription), producing 429 errors and gaps in metrics.

**Solution:** A new `use_batch_api = true` config option routes metric collection through the [Azure Monitor Batch API](https://learn.microsoft.com/en-us/rest/api/monitor/metrics-batch/batch) (`POST https://{region}.metrics.monitor.azure.com/subscriptions/{sub}/metrics:getBatch`). This:

- Batches up to **50 resources** per request (vs. 1)
- Uses the Azure Monitor **data plane**, which has separate rate limits from ARM
- Auto-discovers resources via Resource Graph and groups them by (subscription, region)
- Chunks metric names in groups of 20 (Azure API limit per request)
- Produces the **same Prometheus labels** as the existing per-resource path
- Automatically widens the query time window when `interval > timespan`
- Supports all Azure cloud environments (public, China, US Government)

**What this does NOT change:** The existing per-resource and subscription-scope (`regions`) paths are completely untouched. `use_batch_api = false` (the default) preserves all existing behavior.

### Issue(s) fixed by this Pull Request

<!-- No existing issue — this addresses Azure Monitor ARM rate limiting at scale -->

### Notes to the Reviewer

**Architecture:** The batch API implementation lives entirely in a single new file (`batch.go`), with minimal wiring into the existing code:
- `config.go`: 1 new field + 1 validation rule
- `azure_exporter.go`: 1 new branch in `MetricsHandler()`, before the existing `regions` and per-resource branches
- `azure.go` (component layer): 1 new field in `Arguments` + `Convert()`

**Auth:** The batch API uses a data-plane OAuth2 scope (`https://metrics.monitor.azure.com/.default`) rather than the ARM management scope. The token is acquired per-request using the same credential the ARM client uses. In most environments this just works; restrictive environments may need to grant the identity access to the data plane.

**Time grains:** Some Azure resource types (e.g., PostgreSQL Flexible Servers) only support coarse time grains (≥ PT30M). This is an Azure-side constraint, not specific to the batch API. Users must set `interval` and `timespan` appropriately. The docs now include a note about this.

**`computeTimeWindow` auto-widening:** If the configured `interval` (time grain) is larger than the `timespan` (query window), the batch API would return no data. `computeTimeWindow()` automatically widens the window to at least match the interval. This is a safety net — `Config.Validate()` already rejects `timespan < interval`, but the batch API computes absolute start/end times and this guards against edge cases.

**`parseISO8601Duration`:** We implement a minimal parser rather than using the `iso8601duration` library already in the dependency tree. This is intentional — the library's `ToDuration()` doesn't handle all cases cleanly, and we only need D/H/M/S for Azure Monitor's supported intervals. Invalid inputs panic, since `Config.Validate()` runs the full library parser first.

**Query-param exclusion:** `UseBatchAPI` is intentionally excluded from `MergeConfigWithQueryParams` since enabling batch mode changes the data plane routing and auth scope.

### PR Checklist

- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)