### PR TITLE
fix(faro.receiver) Use Background context for log sending

### DIFF
--- a/internal/component/faro/receiver/exporters.go
+++ b/internal/component/faro/receiver/exporters.go
@@ -167,7 +167,8 @@ func (exp *logsExporter) sendKeyValsToLogsPipeline(ctx context.Context, kv *payl
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second) // TODO(rfratto): potentially make this configurable
+	// Use Background so that incoming request cancellation doesn't cancel sending already received logs.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second) // TODO(rfratto): potentially make this configurable
 	defer cancel()
 	return exp.fanout.Send(ctx, loki.NewEntry(exp.labelSet(kv), push.Entry{
 		Timestamp: time.Now(),


### PR DESCRIPTION
Change context to Background for log sending to avoid cancellation from incoming requests.

<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style. For details on this,
  check out the Contributors Guide linked above.
-->

### Brief description of Pull Request

Use Background context for log sending


### Pull Request Details

Use Background context for log sending


### Issue(s) fixed by this Pull Request

Fixes #6102 

