### PR TITLE
fix(faro): Abort on context cancelation

### DIFF
--- a/internal/component/faro/receiver/exporters.go
+++ b/internal/component/faro/receiver/exporters.go
@@ -112,7 +112,6 @@ func (exp *logsExporter) SetReceivers(receivers []loki.LogsReceiver) {
 func (exp *logsExporter) Name() string { return "logs exporter" }
 
 func (exp *logsExporter) Export(ctx context.Context, p payload.Payload) error {
-
 	var (
 		errs []error
 		meta = p.Meta.KeyVal()

--- a/internal/component/faro/receiver/exporters.go
+++ b/internal/component/faro/receiver/exporters.go
@@ -112,37 +112,56 @@ func (exp *logsExporter) SetReceivers(receivers []loki.LogsReceiver) {
 func (exp *logsExporter) Name() string { return "logs exporter" }
 
 func (exp *logsExporter) Export(ctx context.Context, p payload.Payload) error {
-	meta := p.Meta.KeyVal()
 
-	var errs []error
+	var (
+		errs []error
+		meta = p.Meta.KeyVal()
+	)
+
+	// send returns early on context cancellation.
+	// Other errors are accumulated in errs.
+	send := func(kv *payload.KeyVal) error {
+		payload.MergeKeyVal(kv, meta)
+
+		err := exp.sendKeyValsToLogsPipeline(ctx, kv)
+		if errors.Is(err, context.Canceled) {
+			return err
+		}
+
+		if err != nil {
+			errs = append(errs, err)
+		}
+
+		return nil
+	}
 
 	// log events
 	for _, logItem := range p.Logs {
-		kv := logItem.KeyVal()
-		payload.MergeKeyVal(kv, meta)
-		errs = append(errs, exp.sendKeyValsToLogsPipeline(ctx, kv))
+		if err := send(logItem.KeyVal()); err != nil {
+			return err
+		}
 	}
 
 	// exceptions
 	for _, exception := range p.Exceptions {
 		transformedException := transformException(exp.log, exp.sourceMaps, &exception, p.Meta.App.Release)
-		kv := transformedException.KeyVal()
-		payload.MergeKeyVal(kv, meta)
-		errs = append(errs, exp.sendKeyValsToLogsPipeline(ctx, kv))
+		if err := send(transformedException.KeyVal()); err != nil {
+			return err
+		}
 	}
 
 	// measurements
 	for _, measurement := range p.Measurements {
-		kv := measurement.KeyVal()
-		payload.MergeKeyVal(kv, meta)
-		errs = append(errs, exp.sendKeyValsToLogsPipeline(ctx, kv))
+		if err := send(measurement.KeyVal()); err != nil {
+			return err
+		}
 	}
 
 	// events
 	for _, event := range p.Events {
-		kv := event.KeyVal()
-		payload.MergeKeyVal(kv, meta)
-		errs = append(errs, exp.sendKeyValsToLogsPipeline(ctx, kv))
+		if err := send(event.KeyVal()); err != nil {
+			return err
+		}
 	}
 
 	return errors.Join(errs...)

--- a/internal/component/faro/receiver/handler.go
+++ b/internal/component/faro/receiver/handler.go
@@ -182,15 +182,12 @@ func (h *handler) processRequest(rw http.ResponseWriter, req *http.Request, p pa
 
 	var wg sync.WaitGroup
 	for _, exp := range h.exporters {
-		wg.Add(1)
-		go func(exp exporter) {
-			defer wg.Done()
-
+		wg.Go(func() {
 			if err := exp.Export(req.Context(), p); err != nil {
 				level.Error(h.log).Log("msg", "exporter failed with error", "exporter", exp.Name(), "err", err)
 				h.errorsTotal.WithLabelValues(exp.Name()).Inc()
 			}
-		}(exp)
+		})
 	}
 	wg.Wait()
 


### PR DESCRIPTION
### Pull Request Details

Currently the log exporter will accumulate all errors and join them. If a request is canceled we end up with a log that looks like this  `{"ts":"2026-04-21T07:54:58.325261114Z","level":"error","msg":"exporter failed with error","component_path":"/components.input_faro.input_faro","component_id":"faro.receiver.faro","subcomponent":"handler","exporter":"logs exporter","err":"context canceled\ncontext canceled\ncontext canceled\ncontext canceled\ncontext canceled\ncontext canceled\ncontext canceled\ncontext canceled\ncontext canceled"}` 

Instead we should abort first time we see this error.

### Issue(s) fixed by this Pull Request

Fixes: https://github.com/grafana/alloy/issues/6102

### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
