### PR TITLE
fix(logging): Fix startup deadlock when components log before logging config is evaluated

### DIFF
--- a/internal/runtime/logging/logger.go
+++ b/internal/runtime/logging/logger.go
@@ -116,12 +116,12 @@ func (nopSlogHandler) WithGroup(string) slog.Handler { return nopSlogHandler{} }
 // Update re-configures the options used for the logger.
 func (l *Logger) Update(o Options) error {
 	l.bufferMut.Lock()
-	defer l.bufferMut.Unlock()
 
 	switch o.Format {
 	case FormatLogfmt, FormatJSON:
 		l.hasLogFormat = true
 	default:
+		l.bufferMut.Unlock()
 		return fmt.Errorf("unrecognized log format %q", o.Format)
 	}
 
@@ -133,25 +133,35 @@ func (l *Logger) Update(o Options) error {
 		l.writer.SetLokiWriter(&lokiWriter{o.WriteTo})
 	}
 
-	// Build all our deferred handlers
+	l.bufferMut.Unlock()
+
+	// Build deferred handlers outside bufferMut to avoid a deadlock: concurrent
+	// Handle() calls hold a child handler's RLock while waiting for bufferMut
+	// (via addRecord), while Update holding bufferMut and waiting for the child's
+	// write lock in buildHandlers creates a cycle.
 	if l.deferredSlog != nil {
 		l.deferredSlog.buildHandlers(nil)
 	}
-	// Print out the buffered logs since we determined the log format already
-	for _, bufferedLogChunk := range l.buffer {
+
+	// Re-acquire to drain and clear the buffer now that handlers are built.
+	l.bufferMut.Lock()
+	buffer := l.buffer
+	l.buffer = nil
+	l.bufferMut.Unlock()
+
+	for _, bufferedLogChunk := range buffer {
 		if len(bufferedLogChunk.kvps) > 0 {
 			// the buffered logs are currently only sent to the standard output
 			// because the components with the receivers are not running yet
 			slogadapter.GoKit(l.handler).Log(bufferedLogChunk.kvps...)
 		} else {
-			// We now can check to see if if our buffered log is at the right level.
+			// We now can check to see if our buffered log is at the right level.
 			if bufferedLogChunk.handler.Enabled(context.Background(), bufferedLogChunk.record.Level) {
 				// These will always be valid due to the build handlers call above.
 				_ = bufferedLogChunk.handler.Handle(context.Background(), bufferedLogChunk.record)
 			}
 		}
 	}
-	l.buffer = nil
 
 	return nil
 }

--- a/internal/runtime/logging/logger.go
+++ b/internal/runtime/logging/logger.go
@@ -115,16 +115,13 @@ func (nopSlogHandler) WithGroup(string) slog.Handler { return nopSlogHandler{} }
 
 // Update re-configures the options used for the logger.
 func (l *Logger) Update(o Options) error {
-	l.bufferMut.Lock()
-
 	switch o.Format {
 	case FormatLogfmt, FormatJSON:
-		l.hasLogFormat = true
 	default:
-		l.bufferMut.Unlock()
 		return fmt.Errorf("unrecognized log format %q", o.Format)
 	}
 
+	l.bufferMut.Lock()
 	l.level.Set(slogLevel(o.Level).Level())
 	l.format.Set(o.Format)
 
@@ -132,7 +129,6 @@ func (l *Logger) Update(o Options) error {
 	if len(o.WriteTo) > 0 {
 		l.writer.SetLokiWriter(&lokiWriter{o.WriteTo})
 	}
-
 	l.bufferMut.Unlock()
 
 	// Build deferred handlers outside bufferMut to avoid a deadlock: concurrent
@@ -143,11 +139,14 @@ func (l *Logger) Update(o Options) error {
 		l.deferredSlog.buildHandlers(nil)
 	}
 
-	// Re-acquire to drain and clear the buffer now that handlers are built.
+	// Flip hasLogFormat and drain/replay while holding bufferMut so new Log()
+	// calls block on RLock until replay finishes — preserving the original
+	// guarantee that buffered logs are emitted before newly-arriving ones.
 	l.bufferMut.Lock()
+	defer l.bufferMut.Unlock()
+	l.hasLogFormat = true
 	buffer := l.buffer
 	l.buffer = nil
-	l.bufferMut.Unlock()
 
 	for _, bufferedLogChunk := range buffer {
 		if len(bufferedLogChunk.kvps) > 0 {
@@ -155,7 +154,7 @@ func (l *Logger) Update(o Options) error {
 			// because the components with the receivers are not running yet
 			slogadapter.GoKit(l.handler).Log(bufferedLogChunk.kvps...)
 		} else {
-			// We now can check to see if our buffered log is at the right level.
+			// We can now check whether our buffered log is at the right level.
 			if bufferedLogChunk.handler.Enabled(context.Background(), bufferedLogChunk.record.Level) {
 				// These will always be valid due to the build handlers call above.
 				_ = bufferedLogChunk.handler.Handle(context.Background(), bufferedLogChunk.record)

--- a/internal/runtime/logging/logger_test.go
+++ b/internal/runtime/logging/logger_test.go
@@ -186,22 +186,18 @@ func Test_lokiWriter_nil(t *testing.T) {
 	})
 }
 
-// TestUpdateDeadlock proves the deadlock between Logger.Update and concurrent
-// Handle calls on a child deferred handler. Update holds bufferMut.Lock and
-// then tries to acquire child.mut.Lock (via buildHandlers), while a concurrent
-// Handle call holds child.mut.RLock and blocks on bufferMut.Lock (via addRecord).
-func TestUpdateDeadlock(t *testing.T) {
+// TestUpdateConcurrentHandle verifies that Logger.Update completes successfully
+// when child handlers are being used concurrently, as happens when components
+// start logging during graph evaluation before the logging config block is processed.
+func TestUpdateConcurrentHandle(t *testing.T) {
 	l, err := logging.NewDeferred(io.Discard)
 	require.NoError(t, err)
 
-	// Create a child handler — this is what components do via slog.Logger.With().
 	child := l.Handler().WithAttrs([]slog.Attr{slog.String("component", "test")})
 
 	stop := make(chan struct{})
 	defer close(stop)
 
-	// Continuously call Handle on the child. Each call holds child.mut.RLock
-	// and then tries to acquire bufferMut.Lock via addRecord (because handle is nil).
 	go func() {
 		rec := slog.NewRecord(time.Now(), slog.LevelInfo, "concurrent log", 0)
 		for {
@@ -214,9 +210,6 @@ func TestUpdateDeadlock(t *testing.T) {
 		}
 	}()
 
-	// Update must complete within 5 seconds. With the bug it deadlocks: Update
-	// holds bufferMut.Lock and waits for child.mut.Lock (buildHandlers), while
-	// the goroutine above holds child.mut.RLock and waits for bufferMut.Lock.
 	done := make(chan error, 1)
 	go func() {
 		done <- l.Update(logging.Options{Level: logging.LevelInfo, Format: logging.FormatLogfmt})
@@ -226,7 +219,7 @@ func TestUpdateDeadlock(t *testing.T) {
 	case err := <-done:
 		require.NoError(t, err)
 	case <-time.After(5 * time.Second):
-		t.Fatal("deadlock: Logger.Update did not complete — concurrent Handle held child RLock while Update held bufferMut")
+		t.Fatal("Logger.Update did not complete while child handlers were being used concurrently")
 	}
 }
 

--- a/internal/runtime/logging/logger_test.go
+++ b/internal/runtime/logging/logger_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -206,6 +207,7 @@ func TestUpdateConcurrentHandle(t *testing.T) {
 				return
 			default:
 				_ = child.Handle(context.Background(), rec)
+				runtime.Gosched()
 			}
 		}
 	}()
@@ -238,7 +240,27 @@ func TestUpdateNoLostBufferedMessages(t *testing.T) {
 		require.NoError(t, child.Handle(context.Background(), rec))
 	}
 
+	// Hammer Handle from a separate goroutine so that calls are in-flight while
+	// Update releases bufferMut to run buildHandlers.
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		rec := slog.NewRecord(time.Now(), slog.LevelInfo, "concurrent", 0)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = child.Handle(context.Background(), rec)
+				runtime.Gosched()
+			}
+		}
+	}()
+
 	require.NoError(t, l.Update(logging.Options{Level: logging.LevelInfo, Format: logging.FormatLogfmt}))
+	close(stop)
+	<-done
 
 	for i := range 10 {
 		require.Contains(t, buf.String(), fmt.Sprintf("buffered-%d", i), "buffered message %d was lost", i)

--- a/internal/runtime/logging/logger_test.go
+++ b/internal/runtime/logging/logger_test.go
@@ -2,6 +2,7 @@ package logging_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
@@ -183,6 +184,88 @@ func Test_lokiWriter_nil(t *testing.T) {
 	require.NotPanics(t, func() {
 		_ = logger.Log("msg", "test message")
 	})
+}
+
+// TestUpdateDeadlock proves the deadlock between Logger.Update and concurrent
+// Handle calls on a child deferred handler. Update holds bufferMut.Lock and
+// then tries to acquire child.mut.Lock (via buildHandlers), while a concurrent
+// Handle call holds child.mut.RLock and blocks on bufferMut.Lock (via addRecord).
+func TestUpdateDeadlock(t *testing.T) {
+	l, err := logging.NewDeferred(io.Discard)
+	require.NoError(t, err)
+
+	// Create a child handler — this is what components do via slog.Logger.With().
+	child := l.Handler().WithAttrs([]slog.Attr{slog.String("component", "test")})
+
+	stop := make(chan struct{})
+	defer close(stop)
+
+	// Continuously call Handle on the child. Each call holds child.mut.RLock
+	// and then tries to acquire bufferMut.Lock via addRecord (because handle is nil).
+	go func() {
+		rec := slog.NewRecord(time.Now(), slog.LevelInfo, "concurrent log", 0)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = child.Handle(context.Background(), rec)
+			}
+		}
+	}()
+
+	// Update must complete within 5 seconds. With the bug it deadlocks: Update
+	// holds bufferMut.Lock and waits for child.mut.Lock (buildHandlers), while
+	// the goroutine above holds child.mut.RLock and waits for bufferMut.Lock.
+	done := make(chan error, 1)
+	go func() {
+		done <- l.Update(logging.Options{Level: logging.LevelInfo, Format: logging.FormatLogfmt})
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("deadlock: Logger.Update did not complete — concurrent Handle held child RLock while Update held bufferMut")
+	}
+}
+
+// TestUpdateNoLostBufferedMessages verifies that log records buffered before
+// Update is called are not lost even when concurrent Handle calls are in-flight
+// during the window between bufferMut being released and buildHandlers completing.
+func TestUpdateNoLostBufferedMessages(t *testing.T) {
+	var buf bytes.Buffer
+	l, err := logging.NewDeferred(&buf)
+	require.NoError(t, err)
+
+	// Buffer some messages before Update is called.
+	child := l.Handler().WithAttrs([]slog.Attr{slog.String("component", "test")})
+	for i := range 10 {
+		rec := slog.NewRecord(time.Now(), slog.LevelInfo, fmt.Sprintf("buffered-%d", i), 0)
+		require.NoError(t, child.Handle(context.Background(), rec))
+	}
+
+	require.NoError(t, l.Update(logging.Options{Level: logging.LevelInfo, Format: logging.FormatLogfmt}))
+
+	for i := range 10 {
+		require.Contains(t, buf.String(), fmt.Sprintf("buffered-%d", i), "buffered message %d was lost", i)
+	}
+}
+
+// TestHandlerAfterUpdateIsReal verifies that a child handler created via
+// WithAttrs or WithGroup after Update has been called writes directly to the
+// underlying handler rather than buffering.
+func TestHandlerAfterUpdateIsReal(t *testing.T) {
+	var buf bytes.Buffer
+	l, err := logging.New(&buf, infoLevel())
+	require.NoError(t, err)
+
+	// Handler created after Update should write immediately — no second Update needed.
+	child := l.Handler().WithAttrs([]slog.Attr{slog.String("component", "post-update")})
+	rec := slog.NewRecord(time.Now(), slog.LevelInfo, "direct-write", 0)
+	require.NoError(t, child.Handle(context.Background(), rec))
+
+	require.Contains(t, buf.String(), "direct-write")
 }
 
 func BenchmarkLogging_NoLevel_Prints(b *testing.B) {


### PR DESCRIPTION
### Brief description of Pull Request

Fix a deadlock that causes Alloy to hang at startup with no log output and the HTTP server never binding.

### Pull Request Details

When components start logging during graph evaluation before the `logging` config block is processed, a lock-order cycle between `Logger.Update` and concurrent `Handle` calls on child deferred handlers permanently deadlocks the process. The bug has been present since #707.

### Notes to the Reviewer

Proof-of-deadlock test hangs for 5s on the unfixed code.

### PR Checklist

- [x] Tests updated