### PR TITLE
fix(database_observability.mysql): Exclude system schemas from MySQL health check

### DIFF
--- a/internal/component/database_observability/mysql/collector/health_check.go
+++ b/internal/component/database_observability/mysql/collector/health_check.go
@@ -26,6 +26,7 @@ const (
 type HealthCheckArguments struct {
 	DB              *sql.DB
 	CollectInterval time.Duration
+	ExcludeSchemas  []string
 	EntryHandler    loki.EntryHandler
 
 	Logger log.Logger
@@ -34,6 +35,7 @@ type HealthCheckArguments struct {
 type HealthCheck struct {
 	dbConnection    *sql.DB
 	collectInterval time.Duration
+	excludeSchemas  []string
 	entryHandler    loki.EntryHandler
 	logger          log.Logger
 
@@ -47,6 +49,7 @@ func NewHealthCheck(args HealthCheckArguments) (*HealthCheck, error) {
 	h := &HealthCheck{
 		dbConnection:    args.DB,
 		collectInterval: args.CollectInterval,
+		excludeSchemas:  args.ExcludeSchemas,
 		entryHandler:    args.EntryHandler,
 		logger:          log.With(args.Logger, "collector", HealthCheckCollector),
 		running:         &atomic.Bool{},
@@ -108,7 +111,7 @@ func (c *HealthCheck) fetchHealthChecks(ctx context.Context) {
 	checks := []func(context.Context, *sql.DB) healthCheckResult{
 		checkAlloyVersion,
 		checkRequiredGrants,
-		checkEventsStatementsDigestHasRows,
+		c.checkEventsStatementsDigestHasRows,
 	}
 
 	for _, checkFn := range checks {
@@ -221,10 +224,11 @@ func checkRequiredGrants(ctx context.Context, db *sql.DB) healthCheckResult {
 	return r
 }
 
-// checkEventsStatementsDigestHasRows ensures performance_schema.events_statements_summary_by_digest has rows.
-func checkEventsStatementsDigestHasRows(ctx context.Context, db *sql.DB) healthCheckResult {
+// checkEventsStatementsDigestHasRows ensures performance_schema.events_statements_summary_by_digest has rows,
+// excluding system schemas.
+func (c *HealthCheck) checkEventsStatementsDigestHasRows(ctx context.Context, db *sql.DB) healthCheckResult {
 	r := healthCheckResult{name: "PerformanceSchemaHasRows"}
-	const q = `SELECT COUNT(*) FROM performance_schema.events_statements_summary_by_digest`
+	q := fmt.Sprintf(`SELECT COUNT(*) FROM performance_schema.events_statements_summary_by_digest WHERE schema_name NOT IN %s`, buildExcludedSchemasClause(c.excludeSchemas))
 	var rowCount int64
 	if err := db.QueryRowContext(ctx, q).Scan(&rowCount); err != nil {
 		r.err = err

--- a/internal/component/database_observability/mysql/collector/health_check_test.go
+++ b/internal/component/database_observability/mysql/collector/health_check_test.go
@@ -33,6 +33,7 @@ func TestHealthCheck(t *testing.T) {
 		collector, err := NewHealthCheck(HealthCheckArguments{
 			DB:              db,
 			CollectInterval: 100 * time.Millisecond,
+			ExcludeSchemas:  nil,
 			EntryHandler:    lokiClient,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
 		})
@@ -122,7 +123,7 @@ func TestHealthCheck(t *testing.T) {
 				name:             "no rows in events statements digest",
 				failingCheckName: "PerformanceSchemaHasRows",
 				customSetup: func(mock sqlmock.Sqlmock) {
-					mock.ExpectQuery(`SELECT COUNT(*) FROM performance_schema.events_statements_summary_by_digest`).
+					mock.ExpectQuery(`SELECT COUNT(*) FROM performance_schema.events_statements_summary_by_digest WHERE schema_name NOT IN ('mysql', 'performance_schema', 'sys', 'information_schema')`).
 						WillReturnRows(
 							sqlmock.NewRows([]string{"COUNT(*)"}).
 								AddRow(0),
@@ -149,6 +150,7 @@ func TestHealthCheck(t *testing.T) {
 				collector, err := NewHealthCheck(HealthCheckArguments{
 					DB:              db,
 					CollectInterval: 100 * time.Millisecond,
+					ExcludeSchemas:  nil,
 					EntryHandler:    lokiClient,
 					Logger:          log.NewLogfmtLogger(os.Stderr),
 				})
@@ -214,7 +216,7 @@ func setupExpectQueryAssertions(checkName string, mock sqlmock.Sqlmock, customSe
 		{
 			name: "PerformanceSchemaHasRows",
 			setup: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(`SELECT COUNT(*) FROM performance_schema.events_statements_summary_by_digest`).
+				mock.ExpectQuery(`SELECT COUNT(*) FROM performance_schema.events_statements_summary_by_digest WHERE schema_name NOT IN ('mysql', 'performance_schema', 'sys', 'information_schema')`).
 					WillReturnRows(
 						sqlmock.NewRows([]string{"COUNT(*)"}).
 							AddRow(100),

--- a/internal/component/database_observability/mysql/collector/health_check_test.go
+++ b/internal/component/database_observability/mysql/collector/health_check_test.go
@@ -70,6 +70,66 @@ func TestHealthCheck(t *testing.T) {
 		}
 	})
 
+	t.Run("all checks pass with custom exclude schemas", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(
+			sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual),
+			sqlmock.MonitorPingsOption(true),
+		)
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki.NewCollectingHandler()
+
+		collector, err := NewHealthCheck(HealthCheckArguments{
+			DB:              db,
+			CollectInterval: 100 * time.Millisecond,
+			ExcludeSchemas:  []string{"custom_schema", "another_schema"},
+			EntryHandler:    lokiClient,
+			Logger:          log.NewLogfmtLogger(os.Stderr),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+
+		mock.ExpectQuery(`SHOW GRANTS`).
+			WillReturnRows(
+				sqlmock.NewRows([]string{"Grants"}).
+					AddRow("GRANT PROCESS, REPLICATION CLIENT, SELECT, SHOW VIEW ON *.* TO 'user'@'host'"),
+			)
+		mock.ExpectQuery(`SELECT COUNT(*) FROM performance_schema.events_statements_summary_by_digest WHERE schema_name NOT IN ('mysql', 'performance_schema', 'sys', 'information_schema', 'custom_schema', 'another_schema')`).
+			WillReturnRows(
+				sqlmock.NewRows([]string{"COUNT(*)"}).
+					AddRow(100),
+			)
+
+		err = collector.Start(t.Context())
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) >= 3
+		}, 5*time.Second, 10*time.Millisecond)
+
+		collector.Stop()
+
+		require.Eventually(t, func() bool {
+			return collector.Stopped()
+		}, 5*time.Second, 10*time.Millisecond)
+
+		lokiClient.Stop()
+
+		err = mock.ExpectationsWereMet()
+		require.NoError(t, err)
+
+		lokiEntries := lokiClient.Received()
+		require.GreaterOrEqual(t, len(lokiEntries), 3)
+
+		for _, entry := range lokiEntries[:3] {
+			require.Equal(t, model.LabelSet{"op": OP_HEALTH_STATUS}, entry.Labels)
+			require.Contains(t, entry.Line, `result="true"`)
+		}
+	})
+
 	t.Run("individual check failures", func(t *testing.T) {
 		testCases := []struct {
 			name             string

--- a/internal/component/database_observability/mysql/component.go
+++ b/internal/component/database_observability/mysql/component.go
@@ -737,6 +737,7 @@ func (c *Component) startCollectors(serverID string, engineVersion string, parse
 	hcCollector, err := collector.NewHealthCheck(collector.HealthCheckArguments{
 		DB:              c.dbConnection,
 		CollectInterval: c.args.HealthCheckArguments.CollectInterval,
+		ExcludeSchemas:  c.args.ExcludeSchemas,
 		EntryHandler:    entryHandler,
 		Logger:          c.opts.Logger,
 	})


### PR DESCRIPTION


<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style. For details on this,
  check out the Contributors Guide linked above.
-->

### Brief description of Pull Request
Include excluded schemas in the health check that confirms performance_schema has data. This refines the check to verify that application queries are present, and not just system queries that populate even on idle databases.

<!-- Human-readable description of the PR used as squash commit body. -->


### Pull Request Details

<!-- Detailed descripion of the Pull Request, if needed. -->


### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->


### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
