### PR TITLE
ci: Pin alloyengine to v1.16.0 and syntax to v0.2.0 on release/v1.16

### DIFF
--- a/collector/go.mod
+++ b/collector/go.mod
@@ -5,7 +5,7 @@ module github.com/grafana/alloy/otel_engine
 go 1.26.2
 
 require (
-	github.com/grafana/alloy v0.0.0-00010101000000-000000000000
+	github.com/grafana/alloy v1.16.0
 	github.com/grafana/alloy/extension/alloyengine v0.1.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector v0.147.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/grafanacloudconnector v0.147.0
@@ -518,7 +518,7 @@ require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/gosnmp/gosnmp v1.41.0 // indirect
 	github.com/grafana/alloy-remote-config v0.0.12 // indirect
-	github.com/grafana/alloy/syntax v0.1.0 // indirect
+	github.com/grafana/alloy/syntax v0.2.0 // indirect
 	github.com/grafana/beyla/v3 v3.9.5 // indirect
 	github.com/grafana/catchpoint-prometheus-exporter v0.0.0-20250218151502-6e97feaee761 // indirect
 	github.com/grafana/ckit v0.0.0-20251024151910-87043f5a3cf7 // indirect

--- a/extension/alloyengine/go.mod
+++ b/extension/alloyengine/go.mod
@@ -7,7 +7,7 @@ replace github.com/grafana/alloy => ../..
 replace github.com/grafana/alloy/syntax => ../../syntax
 
 require (
-	github.com/grafana/alloy v0.0.0-00010101000000-000000000000
+	github.com/grafana/alloy v1.16.0 // x-release-please-version
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.53.0
@@ -435,7 +435,7 @@ require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/gosnmp/gosnmp v1.41.0 // indirect
 	github.com/grafana/alloy-remote-config v0.0.12 // indirect
-	github.com/grafana/alloy/syntax v0.1.0 // indirect
+	github.com/grafana/alloy/syntax v0.2.0 // indirect
 	github.com/grafana/beyla/v3 v3.9.5 // indirect
 	github.com/grafana/catchpoint-prometheus-exporter v0.0.0-20250218151502-6e97feaee761 // indirect
 	github.com/grafana/ckit v0.0.0-20251024151910-87043f5a3cf7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/grafana/alloy-remote-config v0.0.12
-	github.com/grafana/alloy/syntax v0.1.0
+	github.com/grafana/alloy/syntax v0.2.0
 	github.com/grafana/beyla/v3 v3.9.5
 	github.com/grafana/catchpoint-prometheus-exporter v0.0.0-20250218151502-6e97feaee761
 	github.com/grafana/ckit v0.0.0-20251024151910-87043f5a3cf7


### PR DESCRIPTION
### Brief description of Pull Request

Backports the `require` version pins needed to produce an OCB-consumable `extension/alloyengine/v1.16.0` tag from `release/v1.16`.

### Pull Request Details

Two pins are stale on `release/v1.16` and break external consumption of `extension/alloyengine`:

- `extension/alloyengine/go.mod` and `collector/go.mod` use a sentinel `require github.com/grafana/alloy v0.0.0-...` → set to `v1.16.0`.
- Root `go.mod` requires `github.com/grafana/alloy/syntax v0.1.0`, which doesn't contain packages alloy uses (e.g. `syntax/typecheck`) → set to `v0.2.0`.

`syntax/v0.2.0` will be tagged from main once #6131 lands and release-please cuts it. This PR shouldn't merge until that tag exists.

### Issue(s) fixed by this Pull Request

Part of #5823

### Notes to the Reviewer

After merge, manually create the `extension/alloyengine/v1.16.0` annotated tag at the merge commit via `gh api`. The tag-alloyengine workflow's `workflow_dispatch` path can't be used — it dereferences the existing Alloy `v1.16.0` tag, which predates the alloyengine module's require updates.