### PR TITLE
chore(loki): Add new pipeline primitives

### DIFF
--- a/internal/component/common/loki/batch.go
+++ b/internal/component/common/loki/batch.go
@@ -8,28 +8,21 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-type EntryAction uint8
-
-const (
-	ActionKeep EntryAction = iota
-	ActionDrop
-)
-
 type Batch struct {
 	// created is a unix timestamp in micro seconds.
 	created  int64
-	streams  []Stream
 	entryLen int
+	streams  []Stream
 }
 
 // NewBatch creates an empty Batch.
 func NewBatch() Batch {
-	b := Batch{
-		created:  0,
-		streams:  []Stream{},
-		entryLen: 0,
-	}
-	return b
+	return Batch{}
+}
+
+// NewBatchWithCreatedUnixMicro creates an empty Batch with created.
+func NewBatchWithCreatedUnixMicro(created int64) Batch {
+	return Batch{created: created}
 }
 
 // Add adds a stream to the batch.
@@ -56,6 +49,13 @@ func (b *Batch) add(labels model.LabelSet, entries ...push.Entry) {
 	b.streams = append(b.streams, NewStream(labels, entries...))
 }
 
+type EntryAction uint8
+
+const (
+	ActionKeep EntryAction = iota
+	ActionDrop
+)
+
 // IterMut calls fn for each entry in the batch.
 // Kept entries are written back, dropped entries are removed,
 // and entries whose labels change are moved to a different stream.
@@ -71,8 +71,8 @@ func (b *Batch) IterMut(fn func(entry *Entry) EntryAction) {
 	)
 
 	// Process each entry and compact each stream in place.
-	// The callback mutates a temporary Entry view; kept entries are written back,
-	// dropped entries are skipped, and entries whose labels change are deferred
+	// The callback mutates a temporary Entry view. Kept entries are written back,
+	// dropped entries are skipped, and moved entries are deferred
 	// so we do not mutate the stream set while iterating it.
 	for i := range b.streams {
 		var (
@@ -133,6 +133,10 @@ func (b *Batch) EntryLen() int {
 	return b.entryLen
 }
 
+func (b *Batch) Created() int64 {
+	return b.created
+}
+
 // Clone returns a clone of the batch.
 func (b *Batch) Clone() Batch {
 	clone := Batch{
@@ -151,9 +155,9 @@ func (b *Batch) Clone() Batch {
 
 // ConsumeStreams calls fn for each stream in the batch and then resets the batch.
 // The callback receives ownership of the stream.
-func (b *Batch) ConsumeStreams(fn func(Stream)) {
+func (b *Batch) ConsumeStreams(fn func(stream Stream, created int64)) {
 	for _, s := range b.streams {
-		fn(s)
+		fn(s, b.created)
 	}
 	b.Reset()
 }
@@ -187,13 +191,15 @@ func (s Stream) Clone() Stream {
 	}
 	for _, entry := range s.Entries {
 		e := push.Entry{
-			Timestamp:          entry.Timestamp,
-			Line:               entry.Line,
-			StructuredMetadata: make(push.LabelsAdapter, 0, len(entry.StructuredMetadata)),
+			Timestamp: entry.Timestamp,
+			Line:      entry.Line,
 		}
 
-		for _, s := range entry.StructuredMetadata {
-			e.StructuredMetadata = append(e.StructuredMetadata, push.LabelAdapter{Name: s.Name, Value: s.Value})
+		if entry.StructuredMetadata != nil {
+			e.StructuredMetadata = make(push.LabelsAdapter, 0, len(entry.StructuredMetadata))
+			for _, s := range entry.StructuredMetadata {
+				e.StructuredMetadata = append(e.StructuredMetadata, push.LabelAdapter{Name: s.Name, Value: s.Value})
+			}
 		}
 
 		cloned.Entries = append(cloned.Entries, e)

--- a/internal/component/common/loki/batch.go
+++ b/internal/component/common/loki/batch.go
@@ -82,7 +82,7 @@ func (b *Batch) FilterMap(fn func(entry *Entry) FilterMapAction) {
 
 		for _, e := range stream.Entries {
 			// FIXME(kalleep): This clone protects stream.Labels from in-place mutation
-			// through Entry.Labels, which is a map. Most IterMut callbacks do not change
+			// through Entry.Labels, which is a map. Most FilterMap callbacks do not change
 			// labels, so once the new batched pipeline owns this path, consider replacing
 			// direct label access with copy-on-write label mutation methods.
 			entry := NewEntryWithCreatedUnixMicro(stream.Labels.Clone(), b.created, e)

--- a/internal/component/common/loki/batch.go
+++ b/internal/component/common/loki/batch.go
@@ -49,17 +49,10 @@ func (b *Batch) add(labels model.LabelSet, entries ...push.Entry) {
 	b.streams = append(b.streams, NewStream(labels, entries...))
 }
 
-type FilterMapAction uint8
-
-const (
-	FilterMapActionKeep FilterMapAction = iota
-	FilterMapActionDrop
-)
-
-// FilterMap calls fn for each entry in the batch.
-// Kept entries are written back, dropped entries are removed,
-// and entries whose labels change are moved to a different stream.
-func (b *Batch) FilterMap(fn func(entry *Entry) FilterMapAction) {
+// FilterMap calls fn for each entry in the batch. If fn returns true the
+// entry is kept, if fn returns false the entry is dropped. Kept entries are
+// written back, and entries whose labels change are moved to a different stream.
+func (b *Batch) FilterMap(fn func(entry *Entry) (keep bool)) {
 	type movedEntry struct {
 		labels model.LabelSet
 		entry  push.Entry
@@ -86,9 +79,7 @@ func (b *Batch) FilterMap(fn func(entry *Entry) FilterMapAction) {
 			// labels, so once the new batched pipeline owns this path, consider replacing
 			// direct label access with copy-on-write label mutation methods.
 			entry := NewEntryWithCreatedUnixMicro(stream.Labels.Clone(), b.created, e)
-			action := fn(&entry)
-
-			if action == FilterMapActionDrop {
+			if !fn(&entry) {
 				continue
 			}
 

--- a/internal/component/common/loki/batch.go
+++ b/internal/component/common/loki/batch.go
@@ -111,7 +111,7 @@ func (b *Batch) IterMut(fn func(entry *Entry) EntryAction) {
 	}
 	b.entryLen = newLen
 
-	// Remove any empty stream.
+	// Remove any empty streams.
 	streamDst := 0
 	for i := range b.streams {
 		if len(b.streams[i].Entries) == 0 {

--- a/internal/component/common/loki/batch.go
+++ b/internal/component/common/loki/batch.go
@@ -1,0 +1,199 @@
+package loki
+
+import (
+	"slices"
+	"time"
+
+	"github.com/grafana/loki/pkg/push"
+	"github.com/prometheus/common/model"
+)
+
+type EntryAction uint8
+
+const (
+	ActionKeep EntryAction = iota
+	ActionDrop
+)
+
+type Batch struct {
+	// created is a unix timestamp in micro seconds.
+	created  int64
+	streams  []Stream
+	entryLen int
+}
+
+// NewBatch creates an empty Batch.
+func NewBatch() Batch {
+	b := Batch{
+		created:  time.Now().UnixMicro(),
+		streams:  []Stream{},
+		entryLen: 0,
+	}
+	return b
+}
+
+// Add adds a stream to the batch.
+// Ownership of the stream data is transferred to the batch and it must not be
+// mutated or retained after calling Add.
+func (b *Batch) Add(stream Stream) {
+	b.add(stream.Labels, stream.Entries...)
+	b.entryLen += len(stream.Entries)
+}
+
+func (b *Batch) add(labels model.LabelSet, entries ...push.Entry) {
+	i := slices.IndexFunc(b.streams, func(s Stream) bool {
+		return s.Labels.Equal(labels)
+	})
+
+	if i >= 0 {
+		b.streams[i].Entries = append(b.streams[i].Entries, entries...)
+		return
+	}
+
+	b.streams = append(b.streams, NewStream(labels, entries...))
+}
+
+// IterMut calls fn for each entry in the batch.
+// Kept entries are written back, dropped entries are removed,
+// and entries whose labels change are moved to a different stream.
+func (b *Batch) IterMut(fn func(entry *Entry) EntryAction) {
+	type movedEntry struct {
+		labels model.LabelSet
+		entry  push.Entry
+	}
+
+	var (
+		newLen int
+		moves  []movedEntry
+	)
+
+	// Process each entry and compact each stream in place.
+	// The callback mutates a temporary Entry view; kept entries are written back,
+	// dropped entries are skipped, and entries whose labels change are deferred
+	// so we do not mutate the stream set while iterating it.
+	for i := range b.streams {
+		var (
+			dst    = 0
+			stream = &b.streams[i]
+		)
+
+		for _, e := range stream.Entries {
+			entry := NewEntryWithCreatedUnixMicro(stream.Labels.Clone(), b.created, e)
+			action := fn(&entry)
+
+			if action == ActionDrop {
+				continue
+			}
+
+			if !stream.Labels.Equal(entry.Labels) {
+				moves = append(moves, movedEntry{
+					labels: entry.Labels,
+					entry:  entry.Entry,
+				})
+				newLen++
+				continue
+			}
+
+			stream.Entries[dst] = entry.Entry
+			dst++
+			newLen++
+		}
+
+		stream.Entries = stream.Entries[:dst]
+	}
+
+	// Reinsert entries whose labels changed into their destination streams.
+	for _, moved := range moves {
+		b.add(moved.labels, moved.entry)
+	}
+	b.entryLen = newLen
+
+	// Remove any empty stream.
+	streamDst := 0
+	for i := range b.streams {
+		if len(b.streams[i].Entries) == 0 {
+			continue
+		}
+		b.streams[streamDst] = b.streams[i]
+		streamDst++
+	}
+	b.streams = b.streams[:streamDst]
+}
+
+// StreamLen returns the number of streams in the batch.
+func (b *Batch) StreamLen() int {
+	return len(b.streams)
+}
+
+// EntryLen returns the number of entries in the batch.
+func (b *Batch) EntryLen() int {
+	return b.entryLen
+}
+
+// Clone returns a clone of the batch.
+func (b *Batch) Clone() Batch {
+	clone := Batch{
+		created:  b.created,
+		streams:  make([]Stream, 0, len(b.streams)),
+		entryLen: b.entryLen,
+	}
+
+	for _, stream := range b.streams {
+		clonedStream := stream.Clone()
+		clone.streams = append(clone.streams, clonedStream)
+	}
+
+	return clone
+}
+
+// ConsumeStreams calls fn for each stream in the batch and then resets the batch.
+// The callback receives ownership of the stream.
+func (b *Batch) ConsumeStreams(fn func(Stream)) {
+	for _, s := range b.streams {
+		fn(s)
+	}
+	b.Reset()
+}
+
+// Reset clears the batch so it can be reused.
+func (b *Batch) Reset() {
+	b.created = time.Now().UnixMicro()
+	b.entryLen = 0
+	b.streams = b.streams[:0]
+}
+
+// NewStream creates a Stream that owns the provided labels and entries.
+func NewStream(labels model.LabelSet, entries ...push.Entry) Stream {
+	return Stream{
+		Labels:  labels,
+		Entries: entries,
+	}
+}
+
+// Stream is a group of entries sharing the same labels.
+type Stream struct {
+	Labels  model.LabelSet
+	Entries []push.Entry
+}
+
+// Clone returns a clone of the stream.
+func (s Stream) Clone() Stream {
+	cloned := Stream{
+		Labels:  s.Labels.Clone(),
+		Entries: make([]push.Entry, 0, len(s.Entries)),
+	}
+	for _, entry := range s.Entries {
+		e := push.Entry{
+			Timestamp:          entry.Timestamp,
+			Line:               entry.Line,
+			StructuredMetadata: make(push.LabelsAdapter, 0, len(entry.StructuredMetadata)),
+		}
+
+		for _, s := range entry.StructuredMetadata {
+			e.StructuredMetadata = append(e.StructuredMetadata, push.LabelAdapter{Name: s.Name, Value: s.Value})
+		}
+
+		cloned.Entries = append(cloned.Entries, e)
+	}
+	return cloned
+}

--- a/internal/component/common/loki/batch.go
+++ b/internal/component/common/loki/batch.go
@@ -191,15 +191,9 @@ func (s Stream) Clone() Stream {
 	}
 	for _, entry := range s.Entries {
 		e := push.Entry{
-			Timestamp: entry.Timestamp,
-			Line:      entry.Line,
-		}
-
-		if entry.StructuredMetadata != nil {
-			e.StructuredMetadata = make(push.LabelsAdapter, 0, len(entry.StructuredMetadata))
-			for _, s := range entry.StructuredMetadata {
-				e.StructuredMetadata = append(e.StructuredMetadata, push.LabelAdapter{Name: s.Name, Value: s.Value})
-			}
+			Timestamp:          entry.Timestamp,
+			Line:               entry.Line,
+			StructuredMetadata: slices.Clone(entry.StructuredMetadata),
 		}
 
 		cloned.Entries = append(cloned.Entries, e)

--- a/internal/component/common/loki/batch.go
+++ b/internal/component/common/loki/batch.go
@@ -52,14 +52,14 @@ func (b *Batch) add(labels model.LabelSet, entries ...push.Entry) {
 type EntryAction uint8
 
 const (
-	ActionKeep EntryAction = iota
-	ActionDrop
+	ApplyActionKeep EntryAction = iota
+	ApplyActionDrop
 )
 
-// IterMut calls fn for each entry in the batch.
+// Apply calls fn for each entry in the batch.
 // Kept entries are written back, dropped entries are removed,
 // and entries whose labels change are moved to a different stream.
-func (b *Batch) IterMut(fn func(entry *Entry) EntryAction) {
+func (b *Batch) Apply(fn func(entry *Entry) EntryAction) {
 	type movedEntry struct {
 		labels model.LabelSet
 		entry  push.Entry
@@ -88,7 +88,7 @@ func (b *Batch) IterMut(fn func(entry *Entry) EntryAction) {
 			entry := NewEntryWithCreatedUnixMicro(stream.Labels.Clone(), b.created, e)
 			action := fn(&entry)
 
-			if action == ActionDrop {
+			if action == ApplyActionDrop {
 				continue
 			}
 
@@ -98,6 +98,7 @@ func (b *Batch) IterMut(fn func(entry *Entry) EntryAction) {
 					entry:  entry.Entry,
 				})
 				newLen++
+
 				continue
 			}
 

--- a/internal/component/common/loki/batch.go
+++ b/internal/component/common/loki/batch.go
@@ -25,7 +25,7 @@ type Batch struct {
 // NewBatch creates an empty Batch.
 func NewBatch() Batch {
 	b := Batch{
-		created:  time.Now().UnixMicro(),
+		created:  0,
 		streams:  []Stream{},
 		entryLen: 0,
 	}
@@ -36,6 +36,9 @@ func NewBatch() Batch {
 // Ownership of the stream data is transferred to the batch and it must not be
 // mutated or retained after calling Add.
 func (b *Batch) Add(stream Stream) {
+	if b.created == 0 {
+		b.created = time.Now().UnixMicro()
+	}
 	b.add(stream.Labels, stream.Entries...)
 	b.entryLen += len(stream.Entries)
 }
@@ -157,7 +160,7 @@ func (b *Batch) ConsumeStreams(fn func(Stream)) {
 
 // Reset clears the batch so it can be reused.
 func (b *Batch) Reset() {
-	b.created = time.Now().UnixMicro()
+	b.created = 0
 	b.entryLen = 0
 	b.streams = b.streams[:0]
 }

--- a/internal/component/common/loki/batch.go
+++ b/internal/component/common/loki/batch.go
@@ -81,6 +81,10 @@ func (b *Batch) IterMut(fn func(entry *Entry) EntryAction) {
 		)
 
 		for _, e := range stream.Entries {
+			// FIXME(kalleep): This clone protects stream.Labels from in-place mutation
+			// through Entry.Labels, which is a map. Most IterMut callbacks do not change
+			// labels, so once the new batched pipeline owns this path, consider replacing
+			// direct label access with copy-on-write label mutation methods.
 			entry := NewEntryWithCreatedUnixMicro(stream.Labels.Clone(), b.created, e)
 			action := fn(&entry)
 

--- a/internal/component/common/loki/batch.go
+++ b/internal/component/common/loki/batch.go
@@ -49,17 +49,17 @@ func (b *Batch) add(labels model.LabelSet, entries ...push.Entry) {
 	b.streams = append(b.streams, NewStream(labels, entries...))
 }
 
-type EntryAction uint8
+type FilterMapAction uint8
 
 const (
-	ApplyActionKeep EntryAction = iota
-	ApplyActionDrop
+	FilterMapActionKeep FilterMapAction = iota
+	FilterMapActionDrop
 )
 
-// Apply calls fn for each entry in the batch.
+// FilterMap calls fn for each entry in the batch.
 // Kept entries are written back, dropped entries are removed,
 // and entries whose labels change are moved to a different stream.
-func (b *Batch) Apply(fn func(entry *Entry) EntryAction) {
+func (b *Batch) FilterMap(fn func(entry *Entry) FilterMapAction) {
 	type movedEntry struct {
 		labels model.LabelSet
 		entry  push.Entry
@@ -88,7 +88,7 @@ func (b *Batch) Apply(fn func(entry *Entry) EntryAction) {
 			entry := NewEntryWithCreatedUnixMicro(stream.Labels.Clone(), b.created, e)
 			action := fn(&entry)
 
-			if action == ApplyActionDrop {
+			if action == FilterMapActionDrop {
 				continue
 			}
 

--- a/internal/component/common/loki/batch_test.go
+++ b/internal/component/common/loki/batch_test.go
@@ -41,20 +41,20 @@ func TestBatch_FilterMap(t *testing.T) {
 	require.Equal(t, 3, b.EntryLen())
 	require.Equal(t, 1, b.StreamLen())
 
-	b.FilterMap(func(entry *Entry) FilterMapAction {
+	b.FilterMap(func(entry *Entry) bool {
 		switch entry.Line {
 		case "keep":
 			entry.Line = "kept"
-			return FilterMapActionKeep
+			return true
 		case "move":
 			entry.Line = "moved"
 			entry.Labels = bar
-			return FilterMapActionKeep
+			return true
 		case "drop":
-			return FilterMapActionDrop
+			return false
 		default:
 			t.Fatalf("unexpected entry %q", entry.Line)
-			return FilterMapActionDrop
+			return false
 		}
 	})
 
@@ -104,20 +104,20 @@ func TestBatch_Clone(t *testing.T) {
 
 	cloned := original.Clone()
 
-	original.FilterMap(func(entry *Entry) FilterMapAction {
+	original.FilterMap(func(entry *Entry) bool {
 		switch entry.Line {
 		case "keep":
 			entry.Line = "kept"
-			return FilterMapActionKeep
+			return true
 		case "move":
 			entry.Line = "moved"
 			entry.Labels = bar
-			return FilterMapActionKeep
+			return true
 		case "drop":
-			return FilterMapActionDrop
+			return false
 		default:
 			t.Fatalf("unexpected entry %q", entry.Line)
-			return FilterMapActionDrop
+			return false
 		}
 	})
 

--- a/internal/component/common/loki/batch_test.go
+++ b/internal/component/common/loki/batch_test.go
@@ -27,7 +27,7 @@ func TestBatch_Add(t *testing.T) {
 	require.Equal(t, []push.Entry{{Line: "3"}}, streams[1].Entries)
 }
 
-func TestBatch_Apply(t *testing.T) {
+func TestBatch_FilterMap(t *testing.T) {
 	foo := model.LabelSet{"job": "foo"}
 	bar := model.LabelSet{"job": "bar"}
 
@@ -41,20 +41,20 @@ func TestBatch_Apply(t *testing.T) {
 	require.Equal(t, 3, b.EntryLen())
 	require.Equal(t, 1, b.StreamLen())
 
-	b.Apply(func(entry *Entry) EntryAction {
+	b.FilterMap(func(entry *Entry) FilterMapAction {
 		switch entry.Line {
 		case "keep":
 			entry.Line = "kept"
-			return ApplyActionKeep
+			return FilterMapActionKeep
 		case "move":
 			entry.Line = "moved"
 			entry.Labels = bar
-			return ApplyActionKeep
+			return FilterMapActionKeep
 		case "drop":
-			return ApplyActionDrop
+			return FilterMapActionDrop
 		default:
 			t.Fatalf("unexpected entry %q", entry.Line)
-			return ApplyActionDrop
+			return FilterMapActionDrop
 		}
 	})
 
@@ -104,20 +104,20 @@ func TestBatch_Clone(t *testing.T) {
 
 	cloned := original.Clone()
 
-	original.Apply(func(entry *Entry) EntryAction {
+	original.FilterMap(func(entry *Entry) FilterMapAction {
 		switch entry.Line {
 		case "keep":
 			entry.Line = "kept"
-			return ApplyActionKeep
+			return FilterMapActionKeep
 		case "move":
 			entry.Line = "moved"
 			entry.Labels = bar
-			return ApplyActionKeep
+			return FilterMapActionKeep
 		case "drop":
-			return ApplyActionDrop
+			return FilterMapActionDrop
 		default:
 			t.Fatalf("unexpected entry %q", entry.Line)
-			return ApplyActionDrop
+			return FilterMapActionDrop
 		}
 	})
 

--- a/internal/component/common/loki/batch_test.go
+++ b/internal/component/common/loki/batch_test.go
@@ -1,0 +1,149 @@
+package loki
+
+import (
+	"testing"
+
+	"github.com/grafana/loki/pkg/push"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBatch_Add(t *testing.T) {
+	foo := model.LabelSet{"job": "foo"}
+	bar := model.LabelSet{"job": "bar"}
+
+	var b Batch
+	b.Add(NewStream(foo, push.Entry{Line: "1"}))
+	b.Add(NewStream(foo, push.Entry{Line: "2"}))
+	b.Add(NewStream(bar, push.Entry{Line: "3"}))
+
+	require.Equal(t, 3, b.EntryLen())
+	require.Equal(t, 2, b.StreamLen())
+
+	streams := collectStreams(&b)
+	require.Equal(t, foo, streams[0].Labels)
+	require.Equal(t, []push.Entry{{Line: "1"}, {Line: "2"}}, streams[0].Entries)
+	require.Equal(t, bar, streams[1].Labels)
+	require.Equal(t, []push.Entry{{Line: "3"}}, streams[1].Entries)
+}
+
+func TestBatch_IterMut(t *testing.T) {
+	foo := model.LabelSet{"job": "foo"}
+	bar := model.LabelSet{"job": "bar"}
+
+	var b Batch
+	b.Add(NewStream(foo,
+		push.Entry{Line: "keep"},
+		push.Entry{Line: "move"},
+		push.Entry{Line: "drop"},
+	))
+
+	require.Equal(t, 3, b.EntryLen())
+	require.Equal(t, 1, b.StreamLen())
+
+	b.IterMut(func(entry *Entry) EntryAction {
+		switch entry.Line {
+		case "keep":
+			entry.Line = "kept"
+			return ActionKeep
+		case "move":
+			entry.Line = "moved"
+			entry.Labels = bar
+			return ActionKeep
+		case "drop":
+			return ActionDrop
+		default:
+			t.Fatalf("unexpected entry %q", entry.Line)
+			return ActionDrop
+		}
+	})
+
+	require.Equal(t, 2, b.EntryLen())
+	require.Equal(t, 2, b.StreamLen())
+
+	streams := collectStreams(&b)
+	require.Equal(t, foo, streams[0].Labels)
+	require.Equal(t, []push.Entry{{Line: "kept"}}, streams[0].Entries)
+	require.Equal(t, bar, streams[1].Labels)
+	require.Equal(t, []push.Entry{{Line: "moved"}}, streams[1].Entries)
+}
+
+func TestBatch_ConsumeStreams(t *testing.T) {
+	foo := model.LabelSet{"job": "foo"}
+	bar := model.LabelSet{"job": "bar"}
+
+	var b Batch
+	b.Add(NewStream(foo, push.Entry{Line: "1"}))
+
+	first := collectStreams(&b)
+	require.Equal(t, 0, b.EntryLen())
+	require.Equal(t, 0, b.StreamLen())
+	require.Equal(t, foo, first[0].Labels)
+	require.Equal(t, []push.Entry{{Line: "1"}}, first[0].Entries)
+
+	b.Add(NewStream(bar, push.Entry{Line: "2"}))
+
+	second := collectStreams(&b)
+	require.Equal(t, 0, b.EntryLen())
+	require.Equal(t, 0, b.StreamLen())
+
+	require.Equal(t, bar, second[0].Labels)
+	require.Equal(t, []push.Entry{{Line: "2"}}, second[0].Entries)
+}
+
+func TestBatch_Clone(t *testing.T) {
+	foo := model.LabelSet{"job": "foo"}
+	bar := model.LabelSet{"job": "bar"}
+
+	var original Batch
+	original.Add(NewStream(foo,
+		push.Entry{Line: "keep"},
+		push.Entry{Line: "move"},
+		push.Entry{Line: "drop"},
+	))
+
+	cloned := original.Clone()
+
+	original.IterMut(func(entry *Entry) EntryAction {
+		switch entry.Line {
+		case "keep":
+			entry.Line = "kept"
+			return ActionKeep
+		case "move":
+			entry.Line = "moved"
+			entry.Labels = bar
+			return ActionKeep
+		case "drop":
+			return ActionDrop
+		default:
+			t.Fatalf("unexpected entry %q", entry.Line)
+			return ActionDrop
+		}
+	})
+
+	require.Equal(t, 2, original.EntryLen())
+	require.Equal(t, 2, original.StreamLen())
+
+	originalStreams := collectStreams(&original)
+	require.Equal(t, foo, originalStreams[0].Labels)
+	require.Equal(t, []push.Entry{{Line: "kept"}}, originalStreams[0].Entries)
+	require.Equal(t, bar, originalStreams[1].Labels)
+	require.Equal(t, []push.Entry{{Line: "moved"}}, originalStreams[1].Entries)
+
+	require.Equal(t, 3, cloned.EntryLen())
+	require.Equal(t, 1, cloned.StreamLen())
+
+	clonedStreams := collectStreams(&cloned)
+	require.Equal(t, foo, clonedStreams[0].Labels)
+	require.Equal(t, "keep", clonedStreams[0].Entries[0].Line)
+	require.Equal(t, "move", clonedStreams[0].Entries[1].Line)
+	require.Equal(t, "drop", clonedStreams[0].Entries[2].Line)
+}
+
+func collectStreams(b *Batch) []Stream {
+	var streams []Stream
+	b.ConsumeStreams(func(s Stream) {
+		streams = append(streams, s)
+	})
+	return streams
+}

--- a/internal/component/common/loki/batch_test.go
+++ b/internal/component/common/loki/batch_test.go
@@ -142,7 +142,7 @@ func TestBatch_Clone(t *testing.T) {
 
 func collectStreams(b *Batch) []Stream {
 	var streams []Stream
-	b.ConsumeStreams(func(s Stream) {
+	b.ConsumeStreams(func(s Stream, _ int64) {
 		streams = append(streams, s)
 	})
 	return streams

--- a/internal/component/common/loki/batch_test.go
+++ b/internal/component/common/loki/batch_test.go
@@ -27,7 +27,7 @@ func TestBatch_Add(t *testing.T) {
 	require.Equal(t, []push.Entry{{Line: "3"}}, streams[1].Entries)
 }
 
-func TestBatch_IterMut(t *testing.T) {
+func TestBatch_Apply(t *testing.T) {
 	foo := model.LabelSet{"job": "foo"}
 	bar := model.LabelSet{"job": "bar"}
 
@@ -41,20 +41,20 @@ func TestBatch_IterMut(t *testing.T) {
 	require.Equal(t, 3, b.EntryLen())
 	require.Equal(t, 1, b.StreamLen())
 
-	b.IterMut(func(entry *Entry) EntryAction {
+	b.Apply(func(entry *Entry) EntryAction {
 		switch entry.Line {
 		case "keep":
 			entry.Line = "kept"
-			return ActionKeep
+			return ApplyActionKeep
 		case "move":
 			entry.Line = "moved"
 			entry.Labels = bar
-			return ActionKeep
+			return ApplyActionKeep
 		case "drop":
-			return ActionDrop
+			return ApplyActionDrop
 		default:
 			t.Fatalf("unexpected entry %q", entry.Line)
-			return ActionDrop
+			return ApplyActionDrop
 		}
 	})
 
@@ -104,20 +104,20 @@ func TestBatch_Clone(t *testing.T) {
 
 	cloned := original.Clone()
 
-	original.IterMut(func(entry *Entry) EntryAction {
+	original.Apply(func(entry *Entry) EntryAction {
 		switch entry.Line {
 		case "keep":
 			entry.Line = "kept"
-			return ActionKeep
+			return ApplyActionKeep
 		case "move":
 			entry.Line = "moved"
 			entry.Labels = bar
-			return ActionKeep
+			return ApplyActionKeep
 		case "drop":
-			return ActionDrop
+			return ApplyActionDrop
 		default:
 			t.Fatalf("unexpected entry %q", entry.Line)
-			return ActionDrop
+			return ApplyActionDrop
 		}
 	})
 

--- a/internal/component/common/loki/consumer.go
+++ b/internal/component/common/loki/consumer.go
@@ -1,0 +1,23 @@
+package loki
+
+import (
+	"context"
+	"reflect"
+)
+
+type Consumer interface {
+	Consume(ctx context.Context, batch Batch) error
+	ConsumeEntry(ctx context.Context, entry Entry) error
+}
+
+func requireUpdate[T any](prev, next []T) bool {
+	if len(prev) != len(next) {
+		return true
+	}
+	for i := range prev {
+		if !reflect.DeepEqual(prev[i], next[i]) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/component/common/loki/consumer.go
+++ b/internal/component/common/loki/consumer.go
@@ -3,11 +3,57 @@ package loki
 import (
 	"context"
 	"reflect"
+	"sync"
 )
 
 type Consumer interface {
 	Consume(ctx context.Context, batch Batch) error
 	ConsumeEntry(ctx context.Context, entry Entry) error
+}
+
+var _ Consumer = (*CollectingConsumer)(nil)
+
+func NewCollectingConsumer() *CollectingConsumer {
+	return &CollectingConsumer{}
+}
+
+// CollectingConsumer is a Consumer that will collect all received entries
+// and batches so it can be inspected later.
+// Used in tests.
+type CollectingConsumer struct {
+	mut     sync.Mutex
+	batches []Batch
+	entries []Entry
+}
+
+func (c *CollectingConsumer) Consume(_ context.Context, batch Batch) error {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	c.batches = append(c.batches, batch)
+
+	return nil
+}
+
+func (c *CollectingConsumer) ConsumeEntry(_ context.Context, entry Entry) error {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	c.entries = append(c.entries, entry)
+	return nil
+}
+
+func (c *CollectingConsumer) Batches() []Batch {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	return c.batches
+}
+
+func (c *CollectingConsumer) Entries() []Entry {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+	return c.entries
 }
 
 func requireUpdate[T any](prev, next []T) bool {

--- a/internal/component/common/loki/consumer_fanout.go
+++ b/internal/component/common/loki/consumer_fanout.go
@@ -1,0 +1,99 @@
+package loki
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+var _ Consumer = (*FanoutConsumer)(nil)
+
+func NewFanoutConsumer(consumers []Consumer) *FanoutConsumer {
+	return &FanoutConsumer{
+		consumers: consumers,
+	}
+}
+
+type FanoutConsumer struct {
+	mut       sync.RWMutex
+	consumers []Consumer
+}
+
+func (f *FanoutConsumer) Consume(ctx context.Context, batch Batch) error {
+	// NOTE: It's important that we hold a read lock for the duration of Consume
+	// rather than making a copy of consumers and releasing the lock early.
+	//
+	// When config is updated, the loader evaluates all components and updates
+	// them while they continue running. The scheduler only stops removed components
+	// after all updates complete. During this window, Send may execute concurrently
+	// with receiver list updates. By holding the read lock for the entire Send
+	// operation, receiver list updates (which require a write lock) will block
+	// until all in-flight Send calls complete. This prevents sending entries to
+	// receivers that have been removed by the scheduler.
+
+	f.mut.RLock()
+	defer f.mut.RUnlock()
+
+	var errs []error
+
+	for i, consumer := range f.consumers {
+		if i == len(f.consumers)-1 {
+			if err := consumer.Consume(ctx, batch); err != nil {
+				errs = append(errs, err)
+			}
+			continue
+		}
+
+		if err := consumer.Consume(ctx, batch.Clone()); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func (f *FanoutConsumer) ConsumeEntry(ctx context.Context, entry Entry) error {
+	// NOTE: It's important that we hold a read lock for the duration of ConsumeEntry
+	// rather than making a copy of children and releasing the lock early.
+	//
+	// When config is updated, the loader evaluates all components and updates
+	// them while they continue running. The scheduler only stops removed components
+	// after all updates complete. During this window, Send may execute concurrently
+	// with receiver list updates. By holding the read lock for the entire Send
+	// operation, receiver list updates (which require a write lock) will block
+	// until all in-flight Send calls complete. This prevents sending entries to
+	// receivers that have been removed by the scheduler.
+
+	f.mut.RLock()
+	defer f.mut.RUnlock()
+
+	var errs []error
+
+	for i, consumer := range f.consumers {
+		if i == len(f.consumers)-1 {
+			if err := consumer.ConsumeEntry(ctx, entry); err != nil {
+				errs = append(errs, err)
+			}
+			continue
+		}
+
+		if err := consumer.ConsumeEntry(ctx, entry.Clone()); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func (f *FanoutConsumer) Update(consumers []Consumer) {
+	f.mut.RLock()
+	if requireUpdate(f.consumers, consumers) {
+		// Upgrade lock to write.
+		f.mut.RUnlock()
+		f.mut.Lock()
+		f.consumers = consumers
+		f.mut.Unlock()
+	} else {
+		f.mut.RUnlock()
+	}
+}

--- a/internal/component/common/loki/consumer_fanout.go
+++ b/internal/component/common/loki/consumer_fanout.go
@@ -54,7 +54,7 @@ func (f *FanoutConsumer) Consume(ctx context.Context, batch Batch) error {
 
 func (f *FanoutConsumer) ConsumeEntry(ctx context.Context, entry Entry) error {
 	// NOTE: It's important that we hold a read lock for the duration of ConsumeEntry
-	// rather than making a copy of children and releasing the lock early.
+	// rather than making a copy of consumers and releasing the lock early.
 	//
 	// When config is updated, the loader evaluates all components and updates
 	// them while they continue running. The scheduler only stops removed components

--- a/internal/component/common/loki/consumer_fanout_test.go
+++ b/internal/component/common/loki/consumer_fanout_test.go
@@ -63,10 +63,10 @@ func TestFanoutConsumer_Consume(t *testing.T) {
 	fanout := NewFanoutConsumer([]Consumer{
 		consumerFunc{
 			consume: func(_ context.Context, batch Batch) error {
-				batch.FilterMap(func(entry *Entry) FilterMapAction {
+				batch.FilterMap(func(entry *Entry) bool {
 					entry.Line = "mutated by first"
 					entry.Labels = bar
-					return FilterMapActionKeep
+					return true
 				})
 				firstBatch = batch
 				return firstErr

--- a/internal/component/common/loki/consumer_fanout_test.go
+++ b/internal/component/common/loki/consumer_fanout_test.go
@@ -63,10 +63,10 @@ func TestFanoutConsumer_Consume(t *testing.T) {
 	fanout := NewFanoutConsumer([]Consumer{
 		consumerFunc{
 			consume: func(_ context.Context, batch Batch) error {
-				batch.Apply(func(entry *Entry) EntryAction {
+				batch.FilterMap(func(entry *Entry) FilterMapAction {
 					entry.Line = "mutated by first"
 					entry.Labels = bar
-					return ApplyActionKeep
+					return FilterMapActionKeep
 				})
 				firstBatch = batch
 				return firstErr

--- a/internal/component/common/loki/consumer_fanout_test.go
+++ b/internal/component/common/loki/consumer_fanout_test.go
@@ -63,10 +63,10 @@ func TestFanoutConsumer_Consume(t *testing.T) {
 	fanout := NewFanoutConsumer([]Consumer{
 		consumerFunc{
 			consume: func(_ context.Context, batch Batch) error {
-				batch.IterMut(func(entry *Entry) EntryAction {
+				batch.Apply(func(entry *Entry) EntryAction {
 					entry.Line = "mutated by first"
 					entry.Labels = bar
-					return ActionKeep
+					return ApplyActionKeep
 				})
 				firstBatch = batch
 				return firstErr

--- a/internal/component/common/loki/consumer_fanout_test.go
+++ b/internal/component/common/loki/consumer_fanout_test.go
@@ -1,0 +1,116 @@
+package loki
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/grafana/loki/pkg/push"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFanoutConsumer_ConsumeEntry(t *testing.T) {
+	firstErr := errors.New("first consumer failed")
+	lastErr := errors.New("last consumer failed")
+
+	var (
+		firstEntry Entry
+		lastEntry  Entry
+	)
+
+	fanout := NewFanoutConsumer([]Consumer{
+		consumerFunc{
+			consumeEntry: func(_ context.Context, entry Entry) error {
+				entry.Line = "mutated by first"
+				firstEntry = entry
+				return firstErr
+			},
+		},
+		consumerFunc{
+			consumeEntry: func(_ context.Context, entry Entry) error {
+				lastEntry = entry
+				return lastErr
+			},
+		},
+	})
+
+	entry := Entry{
+		Labels: model.LabelSet{"job": "test"},
+		Entry:  push.Entry{Line: "original"},
+	}
+
+	err := fanout.ConsumeEntry(t.Context(), entry)
+	require.ErrorIs(t, err, firstErr)
+	require.ErrorIs(t, err, lastErr)
+
+	require.Equal(t, "mutated by first", firstEntry.Line)
+	require.Equal(t, "original", lastEntry.Line)
+}
+
+func TestFanoutConsumer_Consume(t *testing.T) {
+	firstErr := errors.New("first consumer failed")
+	lastErr := errors.New("last consumer failed")
+
+	foo := model.LabelSet{"job": "foo"}
+	bar := model.LabelSet{"job": "bar"}
+
+	var (
+		firstBatch Batch
+		lastBatch  Batch
+	)
+
+	fanout := NewFanoutConsumer([]Consumer{
+		consumerFunc{
+			consume: func(_ context.Context, batch Batch) error {
+				batch.IterMut(func(entry *Entry) EntryAction {
+					entry.Line = "mutated by first"
+					entry.Labels = bar
+					return ActionKeep
+				})
+				firstBatch = batch
+				return firstErr
+			},
+		},
+		consumerFunc{
+			consume: func(_ context.Context, batch Batch) error {
+				lastBatch = batch
+				return lastErr
+			},
+		},
+	})
+
+	var batch Batch
+	batch.Add(NewStream(foo, push.Entry{Line: "original"}))
+
+	err := fanout.Consume(t.Context(), batch)
+	require.ErrorIs(t, err, firstErr)
+	require.ErrorIs(t, err, lastErr)
+
+	firstStreams := collectStreams(&firstBatch)
+	require.Equal(t, bar, firstStreams[0].Labels)
+	require.Equal(t, "mutated by first", firstStreams[0].Entries[0].Line)
+
+	lastStreams := collectStreams(&lastBatch)
+	require.Equal(t, foo, lastStreams[0].Labels)
+	require.Equal(t, "original", lastStreams[0].Entries[0].Line)
+}
+
+type consumerFunc struct {
+	consume      func(context.Context, Batch) error
+	consumeEntry func(context.Context, Entry) error
+}
+
+func (c consumerFunc) Consume(ctx context.Context, batch Batch) error {
+	if c.consume == nil {
+		return nil
+	}
+	return c.consume(ctx, batch)
+}
+
+func (c consumerFunc) ConsumeEntry(ctx context.Context, entry Entry) error {
+	if c.consumeEntry == nil {
+		return nil
+	}
+	return c.consumeEntry(ctx, entry)
+}

--- a/internal/component/common/loki/consumer_sharding.go
+++ b/internal/component/common/loki/consumer_sharding.go
@@ -10,8 +10,13 @@ import (
 
 var _ Consumer = (*ShardingConsumer)(nil)
 
+var ErrConsumerStopped = errors.New("consumer stopped")
+
 // NewShardingConsumer creates a Consumer which shards streams across a fixed
 // number of shards before forwarding them to the downstream consumer.
+//
+// The returned consumer owns background worker goroutines for its lifetime and
+// must be stopped when no longer needed.
 func NewShardingConsumer(shards int, consumer Consumer) *ShardingConsumer {
 	if shards <= 0 {
 		shards = 1
@@ -20,6 +25,7 @@ func NewShardingConsumer(shards int, consumer Consumer) *ShardingConsumer {
 	s := &ShardingConsumer{
 		consumer: consumer,
 		shards:   make([]chan shardingRequest, shards),
+		done:     make(chan struct{}),
 	}
 
 	for i := range s.shards {
@@ -31,15 +37,23 @@ func NewShardingConsumer(shards int, consumer Consumer) *ShardingConsumer {
 }
 
 // ShardingConsumer shareds each stream to a shard based on the stream's labels.
+//
+// ShardingConsumer is intended to be scoped to the lifetime of a component.
+// Callers must stop all log-producing goroutines before calling Stop. After
+// Stop begins, Consume and ConsumeEntry reject late calls with
+// ErrConsumerStopped.
 type ShardingConsumer struct {
 	shards []chan shardingRequest
 
 	consumer Consumer
+
 	stopOnce sync.Once
 	wg       sync.WaitGroup
+	done     chan struct{}
 }
 
 // Consume shards each stream in the batch to a shard and waits for all to finish.
+// It returns ErrConsumerStopped if called after shutdown begins.
 func (s *ShardingConsumer) Consume(ctx context.Context, batch Batch) error {
 	streamLen := batch.StreamLen()
 	if streamLen == 0 {
@@ -50,19 +64,19 @@ func (s *ShardingConsumer) Consume(ctx context.Context, batch Batch) error {
 
 	// NOTE: when we only have one stream in a batch there is no need to split it.
 	if streamLen == 1 {
-		errChans = append(errChans, s.consume(ctx, batch, batch.streams[0].Labels))
+		errChans = append(errChans, s.consume(ctx, s.shardFor(batch.streams[0].Labels), batch))
 	} else {
 		batch.ConsumeStreams(func(stream Stream, created int64) {
 			streamBatch := NewBatchWithCreatedUnixMicro(created)
 			streamBatch.Add(stream)
-			errChans = append(errChans, s.consume(ctx, streamBatch, stream.Labels))
+			errChans = append(errChans, s.consume(ctx, s.shardFor(stream.Labels), streamBatch))
 		})
 	}
 
 	return s.joinErrors(ctx, errChans)
 }
 
-func (s *ShardingConsumer) consume(ctx context.Context, batch Batch, lables model.LabelSet) <-chan error {
+func (s *ShardingConsumer) consume(ctx context.Context, shard int, batch Batch) <-chan error {
 	errCh := make(chan error, 1)
 	req := shardingRequest{
 		errCh: errCh,
@@ -74,13 +88,16 @@ func (s *ShardingConsumer) consume(ctx context.Context, batch Batch, lables mode
 	select {
 	case <-ctx.Done():
 		errCh <- ctx.Err()
-	case s.shards[s.shardFor(lables)] <- req:
+	case <-s.done:
+		errCh <- ErrConsumerStopped
+	case s.shards[shard] <- req:
 	}
 
 	return errCh
 }
 
 // ConsumeEntry shards a single entry to the shard selected by the entry's labels.
+// It returns ErrConsumerStopped if called after shutdown begins.
 func (s *ShardingConsumer) ConsumeEntry(ctx context.Context, entry Entry) error {
 	errCh := make(chan error, 1)
 	req := shardingRequest{
@@ -93,18 +110,22 @@ func (s *ShardingConsumer) ConsumeEntry(ctx context.Context, entry Entry) error 
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
+	case <-s.done:
+		return ErrConsumerStopped
 	case s.shards[s.shardFor(entry.Labels)] <- req:
 	}
 
 	return s.joinErrors(ctx, []<-chan error{errCh})
 }
 
-// Stop stops the consumer and waits for shards to exit.
+// Stop stops the shard workers and waits for them to exit.
+//
+// Callers must ensure all producers have stopped before calling Stop. Any late
+// calls to Consume or ConsumeEntry after shutdown begins return
+// ErrConsumerStopped.
 func (s *ShardingConsumer) Stop() {
 	s.stopOnce.Do(func() {
-		for _, shard := range s.shards {
-			close(shard)
-		}
+		close(s.done)
 		s.wg.Wait()
 	})
 }
@@ -114,8 +135,13 @@ func (s *ShardingConsumer) shardFor(labels model.LabelSet) int {
 }
 
 func (s *ShardingConsumer) runShard(shard <-chan shardingRequest) {
-	for req := range shard {
-		req.errCh <- req.consume(s.consumer)
+	for {
+		select {
+		case <-s.done:
+			return
+		case req := <-shard:
+			req.errCh <- req.consume(s.consumer)
+		}
 	}
 }
 

--- a/internal/component/common/loki/consumer_sharding.go
+++ b/internal/component/common/loki/consumer_sharding.go
@@ -15,9 +15,7 @@ var ErrConsumerStopped = errors.New("consumer stopped")
 // NewShardingConsumer creates a Consumer which shards streams across a fixed
 // number of shards before forwarding them to the downstream consumer.
 func NewShardingConsumer(shards int, consumer Consumer) *ShardingConsumer {
-	if shards <= 0 {
-		shards = 1
-	}
+	shards = max(shards, 1)
 
 	s := &ShardingConsumer{
 		consumer: consumer,

--- a/internal/component/common/loki/consumer_sharding.go
+++ b/internal/component/common/loki/consumer_sharding.go
@@ -14,9 +14,6 @@ var ErrConsumerStopped = errors.New("consumer stopped")
 
 // NewShardingConsumer creates a Consumer which shards streams across a fixed
 // number of shards before forwarding them to the downstream consumer.
-//
-// The returned consumer owns background worker goroutines for its lifetime and
-// must be stopped when no longer needed.
 func NewShardingConsumer(shards int, consumer Consumer) *ShardingConsumer {
 	if shards <= 0 {
 		shards = 1
@@ -36,12 +33,11 @@ func NewShardingConsumer(shards int, consumer Consumer) *ShardingConsumer {
 	return s
 }
 
-// ShardingConsumer shareds each stream to a shard based on the stream's labels.
-//
-// ShardingConsumer is intended to be scoped to the lifetime of a component.
-// Callers must stop all log-producing goroutines before calling Stop. After
-// Stop begins, Consume and ConsumeEntry reject late calls with
-// ErrConsumerStopped.
+// ShardingConsumer serializes work per shard while allowing different shards to
+// make progress independently. It is intended to be scoped to the lifetime of a
+// component, and callers must stop all log-producing goroutines before calling
+// Stop. Once a batch or entry has been accepted by a shard, execution is handed
+// off to the downstream consumer.
 type ShardingConsumer struct {
 	shards []chan shardingRequest
 
@@ -118,11 +114,7 @@ func (s *ShardingConsumer) ConsumeEntry(ctx context.Context, entry Entry) error 
 	return s.joinErrors(ctx, []<-chan error{errCh})
 }
 
-// Stop stops the shard workers and waits for them to exit.
-//
-// Callers must ensure all producers have stopped before calling Stop. Any late
-// calls to Consume or ConsumeEntry after shutdown begins return
-// ErrConsumerStopped.
+// Stop stops the shards and waits for them to exit.
 func (s *ShardingConsumer) Stop() {
 	s.stopOnce.Do(func() {
 		close(s.done)
@@ -151,16 +143,11 @@ type shardingRequest struct {
 }
 
 func (s *ShardingConsumer) joinErrors(ctx context.Context, errChans []<-chan error) error {
-	var errs []error
+	errs := make([]error, 0, len(errChans))
 
 	for _, errCh := range errChans {
-		select {
-		case <-ctx.Done():
-			errs = append(errs, ctx.Err())
-		case err := <-errCh:
-			if err != nil {
-				errs = append(errs, err)
-			}
+		if err := <-errCh; err != nil {
+			errs = append(errs, err)
 		}
 	}
 

--- a/internal/component/common/loki/consumer_sharding.go
+++ b/internal/component/common/loki/consumer_sharding.go
@@ -69,7 +69,7 @@ func (s *ShardingConsumer) Consume(ctx context.Context, batch Batch) error {
 		})
 	}
 
-	return s.joinErrors(ctx, errChans)
+	return s.joinErrors(errChans)
 }
 
 func (s *ShardingConsumer) consume(ctx context.Context, shard int, batch Batch) <-chan error {
@@ -111,7 +111,7 @@ func (s *ShardingConsumer) ConsumeEntry(ctx context.Context, entry Entry) error 
 	case s.shards[s.shardFor(entry.Labels)] <- req:
 	}
 
-	return s.joinErrors(ctx, []<-chan error{errCh})
+	return s.joinErrors([]<-chan error{errCh})
 }
 
 // Stop stops the shards and waits for them to exit.
@@ -142,7 +142,7 @@ type shardingRequest struct {
 	errCh   chan<- error
 }
 
-func (s *ShardingConsumer) joinErrors(ctx context.Context, errChans []<-chan error) error {
+func (s *ShardingConsumer) joinErrors(errChans []<-chan error) error {
 	errs := make([]error, 0, len(errChans))
 
 	for _, errCh := range errChans {

--- a/internal/component/common/loki/consumer_sharding.go
+++ b/internal/component/common/loki/consumer_sharding.go
@@ -1,0 +1,142 @@
+package loki
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/prometheus/common/model"
+)
+
+var _ Consumer = (*ShardingConsumer)(nil)
+
+// NewShardingConsumer creates a Consumer which shards streams across a fixed
+// number of shards before forwarding them to the downstream consumer.
+func NewShardingConsumer(shards int, consumer Consumer) *ShardingConsumer {
+	if shards <= 0 {
+		shards = 1
+	}
+
+	s := &ShardingConsumer{
+		consumer: consumer,
+		shards:   make([]chan shardingRequest, shards),
+	}
+
+	for i := range s.shards {
+		s.shards[i] = make(chan shardingRequest)
+		s.wg.Go(func() { s.runShard(s.shards[i]) })
+	}
+
+	return s
+}
+
+// ShardingConsumer shareds each stream to a shard based on the stream's labels.
+type ShardingConsumer struct {
+	shards []chan shardingRequest
+
+	consumer Consumer
+	stopOnce sync.Once
+	wg       sync.WaitGroup
+}
+
+// Consume shards each stream in the batch to a shard and waits for all to finish.
+func (s *ShardingConsumer) Consume(ctx context.Context, batch Batch) error {
+	streamLen := batch.StreamLen()
+	if streamLen == 0 {
+		return nil
+	}
+
+	errChans := make([]<-chan error, 0, streamLen)
+
+	// NOTE: when we only have one stream in a batch there is no need to split it.
+	if streamLen == 1 {
+		errChans = append(errChans, s.consume(ctx, batch, batch.streams[0].Labels))
+	} else {
+		batch.ConsumeStreams(func(stream Stream, created int64) {
+			streamBatch := NewBatchWithCreatedUnixMicro(created)
+			streamBatch.Add(stream)
+			errChans = append(errChans, s.consume(ctx, streamBatch, stream.Labels))
+		})
+	}
+
+	return s.joinErrors(ctx, errChans)
+}
+
+func (s *ShardingConsumer) consume(ctx context.Context, batch Batch, lables model.LabelSet) <-chan error {
+	errCh := make(chan error, 1)
+	req := shardingRequest{
+		errCh: errCh,
+		consume: func(consumer Consumer) error {
+			return consumer.Consume(ctx, batch)
+		},
+	}
+
+	select {
+	case <-ctx.Done():
+		errCh <- ctx.Err()
+	case s.shards[s.shardFor(lables)] <- req:
+	}
+
+	return errCh
+}
+
+// ConsumeEntry shards a single entry to the shard selected by the entry's labels.
+func (s *ShardingConsumer) ConsumeEntry(ctx context.Context, entry Entry) error {
+	errCh := make(chan error, 1)
+	req := shardingRequest{
+		errCh: errCh,
+		consume: func(consumer Consumer) error {
+			return consumer.ConsumeEntry(ctx, entry)
+		},
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case s.shards[s.shardFor(entry.Labels)] <- req:
+	}
+
+	return s.joinErrors(ctx, []<-chan error{errCh})
+}
+
+// Stop stops the consumer and waits for shards to exit.
+func (s *ShardingConsumer) Stop() {
+	s.stopOnce.Do(func() {
+		for _, shard := range s.shards {
+			close(shard)
+		}
+		s.wg.Wait()
+	})
+}
+
+func (s *ShardingConsumer) shardFor(labels model.LabelSet) int {
+	return int(labels.FastFingerprint() % model.Fingerprint(len(s.shards)))
+}
+
+func (s *ShardingConsumer) runShard(shard <-chan shardingRequest) {
+	for req := range shard {
+		req.errCh <- req.consume(s.consumer)
+	}
+}
+
+type shardingRequest struct {
+	consume func(Consumer) error
+	errCh   chan<- error
+}
+
+func (s *ShardingConsumer) joinErrors(ctx context.Context, errChans []<-chan error) error {
+	var errs []error
+
+	for _, errCh := range errChans {
+		select {
+		case <-ctx.Done():
+			errs = append(errs, ctx.Err())
+		case err := <-errCh:
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+
+	return errors.Join(errs...)
+}

--- a/internal/component/common/loki/consumer_sharding_test.go
+++ b/internal/component/common/loki/consumer_sharding_test.go
@@ -76,9 +76,10 @@ func TestShardingConsumer_Consume(t *testing.T) {
 
 		batches := c.Batches()
 		require.Len(t, batches, 1)
-		require.Equal(t, 1, batch.StreamLen())
-		require.Equal(t, 2, batch.EntryLen())
-		batch.ConsumeStreams(func(stream Stream, _ int64) {
+		got := batches[0]
+		require.Equal(t, 1, got.StreamLen())
+		require.Equal(t, 2, got.EntryLen())
+		got.ConsumeStreams(func(stream Stream, _ int64) {
 			require.Equal(t, labels, stream.Labels)
 			require.Equal(t, "1", stream.Entries[0].Line)
 			require.Equal(t, "2", stream.Entries[1].Line)

--- a/internal/component/common/loki/consumer_sharding_test.go
+++ b/internal/component/common/loki/consumer_sharding_test.go
@@ -17,7 +17,7 @@ func TestShardingConsumer_Consume(t *testing.T) {
 	t.Run("splits batch into streams", func(t *testing.T) {
 		const created = int64(1234)
 
-		first := model.LabelSet{"job": "fist"}
+		first := model.LabelSet{"job": "first"}
 		second := model.LabelSet{"job": "second"}
 
 		c := NewCollectingConsumer()

--- a/internal/component/common/loki/consumer_sharding_test.go
+++ b/internal/component/common/loki/consumer_sharding_test.go
@@ -24,11 +24,11 @@ func TestShardingConsumer_Consume(t *testing.T) {
 		sharding := NewShardingConsumer(2, c)
 		defer sharding.Stop()
 
-		batch := NewBatchWithCreatedUnixMicro(created)
-		batch.Add(NewStream(first, push.Entry{Line: "1"}))
-		batch.Add(NewStream(second, push.Entry{Line: "2"}))
+		original := NewBatchWithCreatedUnixMicro(created)
+		original.Add(NewStream(first, push.Entry{Line: "1"}))
+		original.Add(NewStream(second, push.Entry{Line: "2"}))
 
-		err := sharding.Consume(t.Context(), batch)
+		err := sharding.Consume(t.Context(), original)
 		require.NoError(t, err)
 
 		batches := c.Batches()
@@ -36,15 +36,14 @@ func TestShardingConsumer_Consume(t *testing.T) {
 
 		got := make(map[string]Batch, len(batches))
 		for _, batch := range batches {
-			require.Equal(t, created, batch.created)
-			require.Len(t, batch.streams, 1)
 			got[batch.streams[0].Labels.String()] = batch
 		}
 
 		gotFirst := got[first.String()]
 		require.Equal(t, 1, gotFirst.StreamLen())
 		require.Equal(t, 1, gotFirst.EntryLen())
-		gotFirst.ConsumeStreams(func(stream Stream, _ int64) {
+		gotFirst.ConsumeStreams(func(stream Stream, created int64) {
+			require.Equal(t, original.Created(), created)
 			require.Equal(t, first, stream.Labels)
 			require.Equal(t, "1", stream.Entries[0].Line)
 		})
@@ -52,7 +51,8 @@ func TestShardingConsumer_Consume(t *testing.T) {
 		gotSecond := got[second.String()]
 		require.Equal(t, 1, gotSecond.StreamLen())
 		require.Equal(t, 1, gotSecond.EntryLen())
-		gotSecond.ConsumeStreams(func(stream Stream, _ int64) {
+		gotSecond.ConsumeStreams(func(stream Stream, created int64) {
+			require.Equal(t, original.Created(), created)
 			require.Equal(t, second, stream.Labels)
 			require.Equal(t, "2", stream.Entries[0].Line)
 		})
@@ -140,6 +140,67 @@ func TestShardingConsumer_Consume(t *testing.T) {
 
 		wg.Wait()
 	})
+
+	t.Run("returns context error while waiting for shard", func(t *testing.T) {
+		var (
+			wg        sync.WaitGroup
+			errs      = make(chan error, 2)
+			callCount = atomic.NewInt64(0)
+		)
+
+		consumer := NewShardingConsumer(1, consumerFunc{
+			consume: func(ctx context.Context, batch Batch) error {
+				callCount.Inc()
+				<-ctx.Done()
+				return ctx.Err()
+			},
+		})
+		defer consumer.Stop()
+
+		ctx1, cancel1 := context.WithCancel(context.Background())
+		first := NewBatch()
+		first.Add(NewStream(labelsForShard(consumer, 0), push.Entry{Line: "first"}))
+		wg.Go(func() {
+			errs <- consumer.Consume(ctx1, first)
+		})
+
+		require.Eventually(
+			t,
+			func() bool { return callCount.Load() == 1 },
+			1*time.Second,
+			50*time.Microsecond,
+		)
+
+		ctx2, cancel2 := context.WithCancel(context.Background())
+		second := NewBatch()
+		second.Add(NewStream(labelsForShard(consumer, 0), push.Entry{Line: "second"}))
+		wg.Go(func() {
+			errs <- consumer.Consume(ctx2, second)
+		})
+
+		// Cancel queued batch.
+		cancel2()
+		require.ErrorIs(t, <-errs, context.Canceled)
+
+		// Cancel in-flight batch.
+		cancel1()
+		require.ErrorIs(t, <-errs, context.Canceled)
+		require.Equal(t, int64(1), callCount.Load())
+
+		wg.Wait()
+	})
+
+	t.Run("returns error after stop", func(t *testing.T) {
+		consumer := NewShardingConsumer(1, consumerFunc{})
+		consumer.Stop()
+
+		batch := NewBatch()
+		batch.Add(NewStream(labelsForShard(consumer, 0), push.Entry{Line: "first"}))
+
+		err := consumer.Consume(t.Context(), batch)
+		require.ErrorIs(t, err, ErrConsumerStopped)
+	})
+
 }
 
 func TestShardingConsumer_ConsumeEntry(t *testing.T) {
@@ -209,6 +270,61 @@ func TestShardingConsumer_ConsumeEntry(t *testing.T) {
 		require.Equal(t, int64(3), callCount.Load())
 
 		wg.Wait()
+	})
+
+	t.Run("returns context error while waiting for shard", func(t *testing.T) {
+		var (
+			wg        sync.WaitGroup
+			errs      = make(chan error, 2)
+			callCount = atomic.NewInt64(0)
+		)
+
+		consumer := NewShardingConsumer(1, consumerFunc{
+			consumeEntry: func(ctx context.Context, entry Entry) error {
+				callCount.Inc()
+				<-ctx.Done()
+				return ctx.Err()
+			},
+		})
+		defer consumer.Stop()
+
+		ctx1, cancel1 := context.WithCancel(context.Background())
+		first := NewEntry(labelsForShard(consumer, 0), push.Entry{Line: "first"})
+		wg.Go(func() {
+			errs <- consumer.ConsumeEntry(ctx1, first)
+		})
+
+		require.Eventually(
+			t,
+			func() bool { return callCount.Load() == 1 },
+			1*time.Second,
+			50*time.Microsecond,
+		)
+
+		ctx2, cancel2 := context.WithCancel(context.Background())
+		second := NewEntry(labelsForShard(consumer, 0), push.Entry{Line: "second"})
+		wg.Go(func() {
+			errs <- consumer.ConsumeEntry(ctx2, second)
+		})
+
+		cancel2()
+		require.ErrorIs(t, <-errs, context.Canceled)
+
+		cancel1()
+		require.ErrorIs(t, <-errs, context.Canceled)
+		require.Equal(t, int64(1), callCount.Load())
+
+		wg.Wait()
+	})
+
+	t.Run("returns error after stop", func(t *testing.T) {
+		consumer := NewShardingConsumer(1, consumerFunc{})
+		consumer.Stop()
+
+		entry := NewEntry(labelsForShard(consumer, 0), push.Entry{Line: "first"})
+
+		err := consumer.ConsumeEntry(t.Context(), entry)
+		require.ErrorIs(t, err, ErrConsumerStopped)
 	})
 }
 

--- a/internal/component/common/loki/consumer_sharding_test.go
+++ b/internal/component/common/loki/consumer_sharding_test.go
@@ -1,8 +1,6 @@
 package loki
 
 import (
-	"context"
-	"sync"
 	"testing"
 
 	"github.com/grafana/loki/pkg/push"
@@ -17,8 +15,8 @@ func TestShardingConsumer_Consume(t *testing.T) {
 		foo := model.LabelSet{"job": "foo"}
 		bar := model.LabelSet{"job": "bar"}
 
-		rc := &recordingConsumer{}
-		sharding := NewShardingConsumer(2, rc)
+		c := NewCollectingConsumer()
+		sharding := NewShardingConsumer(2, c)
 		defer sharding.Stop()
 
 		batch := NewBatchWithCreatedUnixMicro(created)
@@ -28,7 +26,7 @@ func TestShardingConsumer_Consume(t *testing.T) {
 		err := sharding.Consume(t.Context(), batch)
 		require.NoError(t, err)
 
-		batches := rc.Batches()
+		batches := c.Batches()
 		require.Len(t, batches, 2)
 
 		got := make(map[string]Batch, len(batches))
@@ -49,8 +47,8 @@ func TestShardingConsumer_Consume(t *testing.T) {
 
 		foo := model.LabelSet{"job": "foo"}
 
-		rc := &recordingConsumer{}
-		consumer := NewShardingConsumer(2, rc)
+		c := NewCollectingConsumer()
+		consumer := NewShardingConsumer(2, c)
 		defer consumer.Stop()
 
 		batch := NewBatchWithCreatedUnixMicro(created)
@@ -62,7 +60,7 @@ func TestShardingConsumer_Consume(t *testing.T) {
 		err := consumer.Consume(t.Context(), batch)
 		require.NoError(t, err)
 
-		batches := rc.Batches()
+		batches := c.Batches()
 		require.Len(t, batches, 1)
 		require.Equal(t, created, batches[0].created)
 		require.Len(t, batches[0].streams, 1)
@@ -75,8 +73,8 @@ func TestShardingConsumer_Consume(t *testing.T) {
 
 func TestShardingConsumer_ConsumeEntry(t *testing.T) {
 	t.Run("forwards entry to consumer", func(t *testing.T) {
-		rc := &recordingConsumer{}
-		consumer := NewShardingConsumer(2, rc)
+		c := NewCollectingConsumer()
+		consumer := NewShardingConsumer(2, c)
 		defer consumer.Stop()
 
 		entry := Entry{
@@ -88,51 +86,10 @@ func TestShardingConsumer_ConsumeEntry(t *testing.T) {
 		err := consumer.ConsumeEntry(t.Context(), entry)
 		require.NoError(t, err)
 
-		entries := rc.Entries()
+		entries := c.Entries()
 		require.Len(t, entries, 1)
 		require.Equal(t, entry.Labels, entries[0].Labels)
 		require.Equal(t, entry.Created(), entries[0].Created())
 		require.Equal(t, entry.Line, entries[0].Line)
 	})
-}
-
-type recordingConsumer struct {
-	mut     sync.Mutex
-	batches []Batch
-	entries []Entry
-}
-
-type recordedBatch struct {
-	created int64
-	streams []Stream
-}
-
-func (c *recordingConsumer) Consume(_ context.Context, batch Batch) error {
-	c.mut.Lock()
-	defer c.mut.Unlock()
-
-	c.batches = append(c.batches, batch)
-
-	return nil
-}
-
-func (c *recordingConsumer) ConsumeEntry(_ context.Context, entry Entry) error {
-	c.mut.Lock()
-	defer c.mut.Unlock()
-
-	c.entries = append(c.entries, entry)
-	return nil
-}
-
-func (c *recordingConsumer) Batches() []Batch {
-	c.mut.Lock()
-	defer c.mut.Unlock()
-
-	return c.batches
-}
-
-func (c *recordingConsumer) Entries() []Entry {
-	c.mut.Lock()
-	defer c.mut.Unlock()
-	return c.entries
 }

--- a/internal/component/common/loki/consumer_sharding_test.go
+++ b/internal/component/common/loki/consumer_sharding_test.go
@@ -1,0 +1,138 @@
+package loki
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/grafana/loki/pkg/push"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShardingConsumer_Consume(t *testing.T) {
+	t.Run("splits batch and preserves created", func(t *testing.T) {
+		const created = int64(1234)
+
+		foo := model.LabelSet{"job": "foo"}
+		bar := model.LabelSet{"job": "bar"}
+
+		rc := &recordingConsumer{}
+		sharding := NewShardingConsumer(2, rc)
+		defer sharding.Stop()
+
+		batch := NewBatchWithCreatedUnixMicro(created)
+		batch.Add(NewStream(foo, push.Entry{Line: "1"}))
+		batch.Add(NewStream(bar, push.Entry{Line: "2"}))
+
+		err := sharding.Consume(t.Context(), batch)
+		require.NoError(t, err)
+
+		batches := rc.Batches()
+		require.Len(t, batches, 2)
+
+		got := make(map[string]Batch, len(batches))
+		for _, batch := range batches {
+			require.Equal(t, created, batch.created)
+			require.Len(t, batch.streams, 1)
+			got[batch.streams[0].Labels.String()] = batch
+		}
+
+		require.Equal(t, foo, got[foo.String()].streams[0].Labels)
+		require.Equal(t, "1", got[foo.String()].streams[0].Entries[0].Line)
+		require.Equal(t, bar, got[bar.String()].streams[0].Labels)
+		require.Equal(t, "2", got[bar.String()].streams[0].Entries[0].Line)
+	})
+
+	t.Run("single stream fast path", func(t *testing.T) {
+		const created = int64(5678)
+
+		foo := model.LabelSet{"job": "foo"}
+
+		rc := &recordingConsumer{}
+		consumer := NewShardingConsumer(2, rc)
+		defer consumer.Stop()
+
+		batch := NewBatchWithCreatedUnixMicro(created)
+		batch.Add(NewStream(foo,
+			push.Entry{Line: "1"},
+			push.Entry{Line: "2"},
+		))
+
+		err := consumer.Consume(t.Context(), batch)
+		require.NoError(t, err)
+
+		batches := rc.Batches()
+		require.Len(t, batches, 1)
+		require.Equal(t, created, batches[0].created)
+		require.Len(t, batches[0].streams, 1)
+		require.Equal(t, foo, batches[0].streams[0].Labels)
+		require.Len(t, batches[0].streams[0].Entries, 2)
+		require.Equal(t, "1", batches[0].streams[0].Entries[0].Line)
+		require.Equal(t, "2", batches[0].streams[0].Entries[1].Line)
+	})
+}
+
+func TestShardingConsumer_ConsumeEntry(t *testing.T) {
+	t.Run("forwards entry to consumer", func(t *testing.T) {
+		rc := &recordingConsumer{}
+		consumer := NewShardingConsumer(2, rc)
+		defer consumer.Stop()
+
+		entry := Entry{
+			Labels:  model.LabelSet{"job": "foo"},
+			created: 1234,
+			Entry:   push.Entry{Line: "hello"},
+		}
+
+		err := consumer.ConsumeEntry(t.Context(), entry)
+		require.NoError(t, err)
+
+		entries := rc.Entries()
+		require.Len(t, entries, 1)
+		require.Equal(t, entry.Labels, entries[0].Labels)
+		require.Equal(t, entry.Created(), entries[0].Created())
+		require.Equal(t, entry.Line, entries[0].Line)
+	})
+}
+
+type recordingConsumer struct {
+	mut     sync.Mutex
+	batches []Batch
+	entries []Entry
+}
+
+type recordedBatch struct {
+	created int64
+	streams []Stream
+}
+
+func (c *recordingConsumer) Consume(_ context.Context, batch Batch) error {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	c.batches = append(c.batches, batch)
+
+	return nil
+}
+
+func (c *recordingConsumer) ConsumeEntry(_ context.Context, entry Entry) error {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	c.entries = append(c.entries, entry)
+	return nil
+}
+
+func (c *recordingConsumer) Batches() []Batch {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	return c.batches
+}
+
+func (c *recordingConsumer) Entries() []Entry {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+	return c.entries
+}

--- a/internal/component/common/loki/consumer_sharding_test.go
+++ b/internal/component/common/loki/consumer_sharding_test.go
@@ -200,7 +200,6 @@ func TestShardingConsumer_Consume(t *testing.T) {
 		err := consumer.Consume(t.Context(), batch)
 		require.ErrorIs(t, err, ErrConsumerStopped)
 	})
-
 }
 
 func TestShardingConsumer_ConsumeEntry(t *testing.T) {

--- a/internal/component/common/loki/consumer_sharding_test.go
+++ b/internal/component/common/loki/consumer_sharding_test.go
@@ -330,7 +330,7 @@ func TestShardingConsumer_ConsumeEntry(t *testing.T) {
 
 func labelsForShard(consumer *ShardingConsumer, shard int) model.LabelSet {
 	for i := 0; ; i++ {
-		labels := model.LabelSet{"job": model.LabelValue(string(strconv.Itoa(i)))}
+		labels := model.LabelSet{"job": model.LabelValue(strconv.Itoa(i))}
 		if consumer.shardFor(labels) == shard {
 			return labels
 		}

--- a/internal/component/common/loki/consumer_sharding_test.go
+++ b/internal/component/common/loki/consumer_sharding_test.go
@@ -1,27 +1,32 @@
 package loki
 
 import (
+	"context"
+	"strconv"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/grafana/loki/pkg/push"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 )
 
 func TestShardingConsumer_Consume(t *testing.T) {
-	t.Run("splits batch and preserves created", func(t *testing.T) {
+	t.Run("splits batch into streams", func(t *testing.T) {
 		const created = int64(1234)
 
-		foo := model.LabelSet{"job": "foo"}
-		bar := model.LabelSet{"job": "bar"}
+		first := model.LabelSet{"job": "fist"}
+		second := model.LabelSet{"job": "second"}
 
 		c := NewCollectingConsumer()
 		sharding := NewShardingConsumer(2, c)
 		defer sharding.Stop()
 
 		batch := NewBatchWithCreatedUnixMicro(created)
-		batch.Add(NewStream(foo, push.Entry{Line: "1"}))
-		batch.Add(NewStream(bar, push.Entry{Line: "2"}))
+		batch.Add(NewStream(first, push.Entry{Line: "1"}))
+		batch.Add(NewStream(second, push.Entry{Line: "2"}))
 
 		err := sharding.Consume(t.Context(), batch)
 		require.NoError(t, err)
@@ -36,23 +41,32 @@ func TestShardingConsumer_Consume(t *testing.T) {
 			got[batch.streams[0].Labels.String()] = batch
 		}
 
-		require.Equal(t, foo, got[foo.String()].streams[0].Labels)
-		require.Equal(t, "1", got[foo.String()].streams[0].Entries[0].Line)
-		require.Equal(t, bar, got[bar.String()].streams[0].Labels)
-		require.Equal(t, "2", got[bar.String()].streams[0].Entries[0].Line)
+		gotFirst := got[first.String()]
+		require.Equal(t, 1, gotFirst.StreamLen())
+		require.Equal(t, 1, gotFirst.EntryLen())
+		gotFirst.ConsumeStreams(func(stream Stream, _ int64) {
+			require.Equal(t, first, stream.Labels)
+			require.Equal(t, "1", stream.Entries[0].Line)
+		})
+
+		gotSecond := got[second.String()]
+		require.Equal(t, 1, gotSecond.StreamLen())
+		require.Equal(t, 1, gotSecond.EntryLen())
+		gotSecond.ConsumeStreams(func(stream Stream, _ int64) {
+			require.Equal(t, second, stream.Labels)
+			require.Equal(t, "2", stream.Entries[0].Line)
+		})
 	})
 
 	t.Run("single stream fast path", func(t *testing.T) {
-		const created = int64(5678)
-
-		foo := model.LabelSet{"job": "foo"}
+		labels := model.LabelSet{"job": "first"}
 
 		c := NewCollectingConsumer()
 		consumer := NewShardingConsumer(2, c)
 		defer consumer.Stop()
 
-		batch := NewBatchWithCreatedUnixMicro(created)
-		batch.Add(NewStream(foo,
+		batch := NewBatch()
+		batch.Add(NewStream(labels,
 			push.Entry{Line: "1"},
 			push.Entry{Line: "2"},
 		))
@@ -62,12 +76,69 @@ func TestShardingConsumer_Consume(t *testing.T) {
 
 		batches := c.Batches()
 		require.Len(t, batches, 1)
-		require.Equal(t, created, batches[0].created)
-		require.Len(t, batches[0].streams, 1)
-		require.Equal(t, foo, batches[0].streams[0].Labels)
-		require.Len(t, batches[0].streams[0].Entries, 2)
-		require.Equal(t, "1", batches[0].streams[0].Entries[0].Line)
-		require.Equal(t, "2", batches[0].streams[0].Entries[1].Line)
+		require.Equal(t, 1, batch.StreamLen())
+		require.Equal(t, 2, batch.EntryLen())
+		batch.ConsumeStreams(func(stream Stream, _ int64) {
+			require.Equal(t, labels, stream.Labels)
+			require.Equal(t, "1", stream.Entries[0].Line)
+			require.Equal(t, "2", stream.Entries[1].Line)
+		})
+	})
+
+	t.Run("preserves backpressure per shard", func(t *testing.T) {
+		var (
+			wg             sync.WaitGroup
+			callCount      = atomic.NewInt64(0)
+			linesProcessed = make(chan string)
+			release        = make(chan struct{})
+		)
+
+		consumer := NewShardingConsumer(2, consumerFunc{
+			consume: func(_ context.Context, batch Batch) error {
+				callCount.Inc()
+				linesProcessed <- batch.streams[0].Entries[0].Line
+
+				<-release
+				return nil
+			},
+		})
+		defer consumer.Stop()
+
+		first := NewBatch()
+		first.Add(NewStream(labelsForShard(consumer, 0), push.Entry{Line: "first"}))
+		wg.Go(func() {
+			_ = consumer.Consume(t.Context(), first)
+		})
+
+		// Make sure first is being processed and thus taking up shard 0.
+		requireReceive(t, linesProcessed, "first", 1*time.Second)
+		require.Equal(t, int64(1), callCount.Load())
+
+		// Create a second batch with labels that will use shard 0.
+		second := NewBatch()
+		second.Add(NewStream(labelsForShard(consumer, 0), push.Entry{Line: "second"}))
+		wg.Go(func() {
+			_ = consumer.Consume(t.Context(), second)
+		})
+
+		// Create a third batch that will use shard 1 so it should
+		// be able to progress.
+		third := NewBatch()
+		third.Add(NewStream(labelsForShard(consumer, 1), push.Entry{Line: "third"}))
+		wg.Go(func() {
+			_ = consumer.Consume(t.Context(), third)
+		})
+
+		requireReceive(t, linesProcessed, "third", 1*time.Second)
+		require.Equal(t, int64(2), callCount.Load())
+
+		// Finish both in-flight calls so that the second batch can progress.
+		close(release)
+
+		requireReceive(t, linesProcessed, "second", 1*time.Second)
+		require.Equal(t, int64(3), callCount.Load())
+
+		wg.Wait()
 	})
 }
 
@@ -77,19 +148,86 @@ func TestShardingConsumer_ConsumeEntry(t *testing.T) {
 		consumer := NewShardingConsumer(2, c)
 		defer consumer.Stop()
 
-		entry := Entry{
-			Labels:  model.LabelSet{"job": "foo"},
-			created: 1234,
-			Entry:   push.Entry{Line: "hello"},
-		}
+		entry := NewEntry(model.LabelSet{"job": "foo"}, push.Entry{
+			Line: "hello",
+		})
 
 		err := consumer.ConsumeEntry(t.Context(), entry)
 		require.NoError(t, err)
 
 		entries := c.Entries()
 		require.Len(t, entries, 1)
-		require.Equal(t, entry.Labels, entries[0].Labels)
-		require.Equal(t, entry.Created(), entries[0].Created())
-		require.Equal(t, entry.Line, entries[0].Line)
+		got := entries[0]
+		require.Equal(t, entry.Line, got.Line)
+		require.Equal(t, entry.Labels, got.Labels)
+		require.Equal(t, entry.Created(), got.Created())
 	})
+
+	t.Run("preserves backpressure per shard", func(t *testing.T) {
+		var (
+			wg             sync.WaitGroup
+			callCount      = atomic.NewInt64(0)
+			linesProcessed = make(chan string)
+			release        = make(chan struct{})
+		)
+
+		consumer := NewShardingConsumer(2, consumerFunc{
+			consumeEntry: func(_ context.Context, entry Entry) error {
+				callCount.Inc()
+				linesProcessed <- entry.Line
+
+				<-release
+				return nil
+			},
+		})
+		defer consumer.Stop()
+
+		first := NewEntry(labelsForShard(consumer, 0), push.Entry{Line: "first"})
+		wg.Go(func() {
+			_ = consumer.ConsumeEntry(t.Context(), first)
+		})
+
+		requireReceive(t, linesProcessed, "first", 1*time.Second)
+		require.Equal(t, int64(1), callCount.Load())
+
+		second := NewEntry(labelsForShard(consumer, 0), push.Entry{Line: "second"})
+		wg.Go(func() {
+			_ = consumer.ConsumeEntry(t.Context(), second)
+		})
+
+		third := NewEntry(labelsForShard(consumer, 1), push.Entry{Line: "third"})
+		wg.Go(func() {
+			_ = consumer.ConsumeEntry(t.Context(), third)
+		})
+
+		requireReceive(t, linesProcessed, "third", 1*time.Second)
+		require.Equal(t, int64(2), callCount.Load())
+
+		close(release)
+
+		requireReceive(t, linesProcessed, "second", 1*time.Second)
+		require.Equal(t, int64(3), callCount.Load())
+
+		wg.Wait()
+	})
+}
+
+func labelsForShard(consumer *ShardingConsumer, shard int) model.LabelSet {
+	for i := 0; ; i++ {
+		labels := model.LabelSet{"job": model.LabelValue(string(strconv.Itoa(i)))}
+		if consumer.shardFor(labels) == shard {
+			return labels
+		}
+	}
+}
+
+func requireReceive[T any](t *testing.T, ch <-chan T, expected T, timeout time.Duration) {
+	t.Helper()
+
+	select {
+	case v := <-ch:
+		require.Equal(t, expected, v)
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for receive")
+	}
 }

--- a/internal/component/common/loki/fanout.go
+++ b/internal/component/common/loki/fanout.go
@@ -2,7 +2,6 @@ package loki
 
 import (
 	"context"
-	"reflect"
 	"sync"
 )
 
@@ -78,7 +77,7 @@ func (f *Fanout) SendBatch(ctx context.Context, batch []Entry) error {
 // UpdateChildren updates the list of receivers that will receive log entries.
 func (f *Fanout) UpdateChildren(children []LogsReceiver) {
 	f.mut.RLock()
-	if receiversChanged(f.children, children) {
+	if requireUpdate(f.children, children) {
 		// Upgrade lock to write.
 		f.mut.RUnlock()
 		f.mut.Lock()
@@ -87,16 +86,4 @@ func (f *Fanout) UpdateChildren(children []LogsReceiver) {
 	} else {
 		f.mut.RUnlock()
 	}
-}
-
-func receiversChanged(prev, next []LogsReceiver) bool {
-	if len(prev) != len(next) {
-		return true
-	}
-	for i := range prev {
-		if !reflect.DeepEqual(prev[i], next[i]) {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
### Pull Request Details

This PR introduces Loki pipeline primitives that should be used by the new pipeline architecture. For now, these primitives are unused by the existing pipeline.

#### `Consumer`

A new `Consumer` interface with both `Consume` and `ConsumeEntry` methods. `Consume` is the long-term batch-oriented interface, while `ConsumeEntry` exists as a temporary migration helper so components can move from channel-based handoff to synchronous function calls before they are converted to full batch processing. For more context on that migration step, see #4953.

#### `Batch`

It groups entries into streams by label set and stores created time once per batch instead of once per entry.

Two important operations on `Batch` are `Apply` and `ConsumeStreams`:
1. `Apply` makes it possible to walk entries in place, rewrite them, drop them, or move them between streams when labels change. One use case for this is `loki.process`, where a batch should be passed through the stage pipeline while still exposing the internal `loki.Entry` type that those stages already operate on.
2. `ConsumeStreams` hands batch contents off stream-by-stream. This is what `ShardingConsumer` uses to preserve per-stream ordering while still allowing different streams to make progress independently. It should also be useful when writing batches to the WAL, where entries for the same stream should be stored together in a record, and when adapting the `loki.write` client sharding and batch queueing mechanisms to operate on batch streams instead of individual entries.

#### `FanoutConsumer`

`FanoutConsumer` forwards batches or entries to multiple downstream consumers synchronously. It clones data for all but the final consumer so downstream consumers can safely mutate batches or entries without affecting each other.

#### `ShardingConsumer`

`ShardingConsumer` shards batches / entries by stream labels so that entries for the same stream stay ordered while different streams can make progress independently. It also gives sources and downstream components a synchronous backpressure boundary instead of relying on unbounded internal fanout.

### Issue(s) fixed by this Pull Request

Part of: https://github.com/grafana/alloy/issues/4953

### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->

### PR Checklist

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated