### PR TITLE
ci: Trim whitespace from contributor lines in release notes

### DIFF
--- a/tools/release/enrich-release-notes/main.go
+++ b/tools/release/enrich-release-notes/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"unicode"
 
 	gh "github.com/grafana/alloy/tools/release/internal/github"
 	"github.com/grafana/alloy/tools/release/internal/version"
@@ -129,13 +130,15 @@ func addContributorInfo(ctx context.Context, client *gh.Client, body string) str
 	lines := strings.Split(body, "\n")
 
 	for i, line := range lines {
-		if strings.TrimSpace(line) == "" {
+		trimmedLine := strings.TrimRightFunc(line, unicode.IsSpace)
+
+		if trimmedLine == "" {
 			continue
 		}
 
-		fmt.Printf("   Processing line %d: %s\n", i, line)
+		fmt.Printf("   Processing line %d: %s\n", i, trimmedLine)
 
-		sha := extractCommitSHA(line)
+		sha := extractCommitSHA(trimmedLine)
 		if sha == "" {
 			fmt.Printf("   No commit SHA found in line %d\n", i)
 			continue
@@ -152,7 +155,7 @@ func addContributorInfo(ctx context.Context, client *gh.Client, body string) str
 		}
 
 		fmt.Printf("   Commit %s: %v\n", sha, contributors)
-		lines[i] = line + " " + formatAttribution(contributors)
+		lines[i] = trimmedLine + " " + formatAttribution(contributors)
 	}
 
 	return strings.Join(lines, "\n")

--- a/tools/release/enrich-release-notes/main.go
+++ b/tools/release/enrich-release-notes/main.go
@@ -130,15 +130,13 @@ func addContributorInfo(ctx context.Context, client *gh.Client, body string) str
 	lines := strings.Split(body, "\n")
 
 	for i, line := range lines {
-		trimmedLine := strings.TrimRightFunc(line, unicode.IsSpace)
-
-		if trimmedLine == "" {
+		if strings.TrimSpace(line) == "" {
 			continue
 		}
 
-		fmt.Printf("   Processing line %d: %s\n", i, trimmedLine)
+		fmt.Printf("   Processing line %d: %s\n", i, line)
 
-		sha := extractCommitSHA(trimmedLine)
+		sha := extractCommitSHA(line)
 		if sha == "" {
 			fmt.Printf("   No commit SHA found in line %d\n", i)
 			continue
@@ -155,7 +153,7 @@ func addContributorInfo(ctx context.Context, client *gh.Client, body string) str
 		}
 
 		fmt.Printf("   Commit %s: %v\n", sha, contributors)
-		lines[i] = trimmedLine + " " + formatAttribution(contributors)
+		lines[i] = appendAttribution(line, contributors)
 	}
 
 	return strings.Join(lines, "\n")
@@ -210,6 +208,10 @@ func formatAttribution(usernames []string) string {
 		mentions = append(mentions, "@"+u)
 	}
 	return "(" + strings.Join(mentions, ", ") + ")"
+}
+
+func appendAttribution(line string, contributors []string) string {
+	return strings.TrimRightFunc(line, unicode.IsSpace) + " " + formatAttribution(contributors)
 }
 
 // appendFooter reads the release notes footer template and appends it with version substitution.

--- a/tools/release/enrich-release-notes/main_test.go
+++ b/tools/release/enrich-release-notes/main_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestExtractCommitSHA(t *testing.T) {
 	tests := []struct {
@@ -85,6 +88,21 @@ func TestFormatAttribution(t *testing.T) {
 				t.Errorf("formatAttribution(%v) = %q, want %q", tt.usernames, result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestOnlyOneLinePerEntry(t *testing.T) {
+	line := "* Fix release notes ([abc1234](https://github.com/grafana/alloy/commit/abc1234))\r"
+
+	result := appendAttribution(line, []string{"alice"})
+
+	if strings.ContainsAny(result, "\r\n") {
+		t.Fatalf("appendAttribution() returned a multi-line entry: %q", result)
+	}
+
+	expected := "* Fix release notes ([abc1234](https://github.com/grafana/alloy/commit/abc1234)) (@alice)"
+	if result != expected {
+		t.Errorf("appendAttribution() = %q, want %q", result, expected)
 	}
 }
 


### PR DESCRIPTION
Removes extra line breaks appearing for each entry in the release notes.

Before:

```
deps: Update module github.com/nwaples/rardecode/v2 to v2.2.0 [SECURITY] [backport] (910a37b)
(@jharvey10)
```

After:
```
deps: Update module github.com/nwaples/rardecode/v2 to v2.2.0 [SECURITY] [backport] (910a37b) (@jharvey10)
```