### PR TITLE
fix(loki): Clone structured metadata so we can perform fan-out correctly

### DIFF
--- a/internal/component/common/loki/entry.go
+++ b/internal/component/common/loki/entry.go
@@ -1,6 +1,7 @@
 package loki
 
 import (
+	"slices"
 	"time"
 
 	"github.com/grafana/loki/pkg/push"
@@ -47,8 +48,12 @@ type Entry struct {
 func (e *Entry) Clone() Entry {
 	return Entry{
 		Labels:  e.Labels.Clone(),
-		Entry:   e.Entry,
 		created: e.created,
+		Entry: push.Entry{
+			Timestamp:          e.Entry.Timestamp,
+			Line:               e.Entry.Line,
+			StructuredMetadata: slices.Clone(e.Entry.StructuredMetadata),
+		},
 	}
 }
 


### PR DESCRIPTION
### Pull Request Details
When performing fan-out of loki entries to multiple `loki.process` components that will mutate structured_metadata it will share the underlying slice even though we clone it, because it was only performing a shallow clone on embedded `push.Entry`.

We also have a slice for `Parsed` but this is not something we use in alloy. Ideally this would be solved at pipeline level and not in individual components like `loki.process` and `loki.relabel` as we currently do. I will change that in the bigger loki pipeline refactoring I am working on. But for now we can make a quick fix for it.


Its not trivial to make a test for it but I have added a test in https://github.com/grafana/alloy/pull/6049 that currently fails because we get a data race.

### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->

### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
