### PR TITLE
feat(database_observability.postgres): Make health_check respect user/database exclusions settings

### DIFF
--- a/internal/component/database_observability/postgres/collector/health_check.go
+++ b/internal/component/database_observability/postgres/collector/health_check.go
@@ -24,18 +24,22 @@ const (
 )
 
 type HealthCheckArguments struct {
-	DB              *sql.DB
-	CollectInterval time.Duration
-	EntryHandler    loki.EntryHandler
+	DB               *sql.DB
+	CollectInterval  time.Duration
+	ExcludeDatabases []string
+	ExcludeUsers     []string
+	EntryHandler     loki.EntryHandler
 
 	Logger log.Logger
 }
 
 type HealthCheck struct {
-	dbConnection    *sql.DB
-	collectInterval time.Duration
-	entryHandler    loki.EntryHandler
-	logger          log.Logger
+	dbConnection     *sql.DB
+	collectInterval  time.Duration
+	excludeDatabases []string
+	excludeUsers     []string
+	entryHandler     loki.EntryHandler
+	logger           log.Logger
 
 	running *atomic.Bool
 	ctx     context.Context
@@ -45,11 +49,13 @@ type HealthCheck struct {
 
 func NewHealthCheck(args HealthCheckArguments) (*HealthCheck, error) {
 	h := &HealthCheck{
-		dbConnection:    args.DB,
-		collectInterval: args.CollectInterval,
-		entryHandler:    args.EntryHandler,
-		logger:          log.With(args.Logger, "collector", HealthCheckCollector),
-		running:         &atomic.Bool{},
+		dbConnection:     args.DB,
+		collectInterval:  args.CollectInterval,
+		excludeDatabases: args.ExcludeDatabases,
+		excludeUsers:     args.ExcludeUsers,
+		entryHandler:     args.EntryHandler,
+		logger:           log.With(args.Logger, "collector", HealthCheckCollector),
+		running:          &atomic.Bool{},
 	}
 	return h, nil
 }
@@ -109,7 +115,9 @@ func (c *HealthCheck) fetchHealthChecks(ctx context.Context) {
 		checkAlloyVersion,
 		checkPgStatStatementsEnabled,
 		checkTrackActivityQuerySize,
+		checkComputeQueryIdEnabled,
 		checkMonitoringUserPrivileges,
+		c.checkPgStatStatementsHasRows,
 	}
 
 	for _, checkFn := range checks {
@@ -201,5 +209,46 @@ func checkMonitoringUserPrivileges(ctx context.Context, db *sql.DB) healthCheckR
 		r.err = fmt.Errorf("iterate pg_stat_statements: %w", err)
 	}
 
+	return r
+}
+
+// checkComputeQueryIdEnabled verifies the compute_query_id is not disabled
+func checkComputeQueryIdEnabled(ctx context.Context, db *sql.DB) healthCheckResult {
+	r := healthCheckResult{name: "ComputeQueryIdEnabled"}
+	const q = `SELECT setting FROM pg_settings WHERE name = 'compute_query_id'`
+
+	var setting string
+	if err := db.QueryRowContext(ctx, q).Scan(&setting); err != nil {
+		r.err = fmt.Errorf("query compute_query_id: %w", err)
+		return r
+	}
+	r.value = setting
+	r.result = setting != "off"
+	return r
+}
+
+// checkPgStatStatementsHasRows ensures pg_stat_statements has at least one row
+// with a real queryid (non-null and non-zero) for a database/user we'd actually
+// ingest after applying the exclude_databases / exclude_users filters.
+func (c *HealthCheck) checkPgStatStatementsHasRows(ctx context.Context, db *sql.DB) healthCheckResult {
+	r := healthCheckResult{name: "PgStatStatementsHasRows"}
+	excludedDatabasesClause := buildExcludedDatabasesClause(c.excludeDatabases)
+	excludedUsersClause := buildExcludedUsersClause(c.excludeUsers, "pg_get_userbyid(pg_stat_statements.userid)")
+	q := fmt.Sprintf(`
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_stat_statements
+			JOIN pg_database ON pg_database.oid = pg_stat_statements.dbid
+			WHERE pg_database.datname NOT IN %s
+			  AND pg_stat_statements.queryid <> 0
+			  %s
+		)`, excludedDatabasesClause, excludedUsersClause)
+
+	var hasRows bool
+	if err := db.QueryRowContext(ctx, q).Scan(&hasRows); err != nil {
+		r.err = err
+		return r
+	}
+	r.result = hasRows
 	return r
 }

--- a/internal/component/database_observability/postgres/collector/health_check_test.go
+++ b/internal/component/database_observability/postgres/collector/health_check_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -46,7 +47,7 @@ func TestHealthCheck(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
-			return len(lokiClient.Received()) >= 4
+			return len(lokiClient.Received()) == 6
 		}, 5*time.Second, 10*time.Millisecond)
 
 		collector.Stop()
@@ -61,9 +62,9 @@ func TestHealthCheck(t *testing.T) {
 		require.NoError(t, err)
 
 		lokiEntries := lokiClient.Received()
-		require.GreaterOrEqual(t, len(lokiEntries), 4)
+		require.GreaterOrEqual(t, len(lokiEntries), 6)
 
-		for _, entry := range lokiEntries[:4] {
+		for _, entry := range lokiEntries[:6] {
 			require.Equal(t, model.LabelSet{"op": OP_HEALTH_STATUS}, entry.Labels)
 			require.Contains(t, entry.Line, `result="true"`)
 		}
@@ -92,6 +93,26 @@ func TestHealthCheck(t *testing.T) {
 					mock.ExpectQuery(`SELECT setting FROM pg_settings WHERE name = 'track_activity_query_size'`).
 						WillReturnRows(sqlmock.NewRows([]string{"track_activity_query_size"}).
 							AddRow("1024"))
+				},
+				expectedResult: `result="false"`,
+			},
+			{
+				name:             "compute_query_id is off",
+				failingCheckName: "ComputeQueryIdEnabled",
+				customSetup: func(mock sqlmock.Sqlmock) {
+					mock.ExpectQuery(`SELECT setting FROM pg_settings WHERE name = 'compute_query_id'`).
+						WillReturnRows(sqlmock.NewRows([]string{"setting"}).
+							AddRow("off"))
+				},
+				expectedResult: `result="false" value="off"`,
+			},
+			{
+				name:             "pg_stat_statements has no usable rows",
+				failingCheckName: "PgStatStatementsHasRows",
+				customSetup: func(mock sqlmock.Sqlmock) {
+					mock.ExpectQuery(pgStatStatementsHasRowsQuery(nil, nil)).
+						WillReturnRows(sqlmock.NewRows([]string{"exists"}).
+							AddRow(false))
 				},
 				expectedResult: `result="false"`,
 			},
@@ -124,7 +145,7 @@ func TestHealthCheck(t *testing.T) {
 				require.NoError(t, err)
 
 				require.Eventually(t, func() bool {
-					return len(lokiClient.Received()) >= 4
+					return len(lokiClient.Received()) == 6
 				}, 5*time.Second, 10*time.Millisecond)
 
 				collector.Stop()
@@ -153,6 +174,58 @@ func TestHealthCheck(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("PgStatStatementsHasRows renders excludes into SQL", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		mock.ExpectQuery(`SELECT * FROM pg_extension WHERE extname = 'pg_stat_statements'`).
+			WillReturnRows(sqlmock.NewRows([]string{"oid", "extname", "extowner", "extnamespace", "extrelocatable", "extversion"}).
+				AddRow(1, "pg_stat_statements", 10, 11, false, "1.9"))
+		mock.ExpectQuery(`SELECT setting FROM pg_settings WHERE name = 'track_activity_query_size'`).
+			WillReturnRows(sqlmock.NewRows([]string{"setting"}).AddRow("4096"))
+		mock.ExpectQuery(`SELECT setting FROM pg_settings WHERE name = 'compute_query_id'`).
+			WillReturnRows(sqlmock.NewRows([]string{"setting"}).AddRow("on"))
+		mock.ExpectQuery(`SELECT * FROM pg_stat_statements LIMIT 1`).
+			WillReturnRows(sqlmock.NewRows([]string{"userid", "dbid", "queryid"}).AddRow(1, 1, 123))
+		mock.ExpectQuery(pgStatStatementsHasRowsQuery([]string{"my_db"}, []string{"my_user"})).
+			WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+
+		lokiClient := loki.NewCollectingHandler()
+
+		collector, err := NewHealthCheck(HealthCheckArguments{
+			DB:               db,
+			CollectInterval:  100 * time.Millisecond,
+			ExcludeDatabases: []string{"my_db"},
+			ExcludeUsers:     []string{"my_user"},
+			EntryHandler:     lokiClient,
+			Logger:           log.NewLogfmtLogger(os.Stderr),
+		})
+		require.NoError(t, err)
+
+		err = collector.Start(t.Context())
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 6
+		}, 5*time.Second, 10*time.Millisecond)
+
+		collector.Stop()
+		require.Eventually(t, func() bool { return collector.Stopped() }, 5*time.Second, 10*time.Millisecond)
+		lokiClient.Stop()
+
+		require.NoError(t, mock.ExpectationsWereMet())
+
+		// Sanity check: the helper used to build the matcher above produces the
+		// same fragments we just asserted via the regex.
+		rendered := pgStatStatementsHasRowsQuery([]string{"my_db"}, []string{"my_user"})
+		require.Contains(t, rendered, "NOT IN ('azure_maintenance', 'my_db')")
+		require.Contains(t, rendered, "AND pg_get_userbyid(pg_stat_statements.userid) NOT IN ('my_user')")
+		require.Contains(t, rendered, "pg_stat_statements.queryid <> 0")
+	})
 }
 
 func setupExpectQueryAssertions(checkName string, mock sqlmock.Sqlmock, customSetup func(mock sqlmock.Sqlmock)) {
@@ -179,11 +252,27 @@ func setupExpectQueryAssertions(checkName string, mock sqlmock.Sqlmock, customSe
 			},
 		},
 		{
+			name: "ComputeQueryIdEnabled",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(`SELECT setting FROM pg_settings WHERE name = 'compute_query_id'`).
+					WillReturnRows(sqlmock.NewRows([]string{"setting"}).
+						AddRow("on"))
+			},
+		},
+		{
 			name: "MonitoringUserPrivileges",
 			setup: func(mock sqlmock.Sqlmock) {
 				mock.ExpectQuery(`SELECT * FROM pg_stat_statements LIMIT 1`).
 					WillReturnRows(sqlmock.NewRows([]string{"userid", "dbid", "queryid"}).
 						AddRow(1, 1, 123))
+			},
+		},
+		{
+			name: "PgStatStatementsHasRows",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(pgStatStatementsHasRowsQuery(nil, nil)).
+					WillReturnRows(sqlmock.NewRows([]string{"exists"}).
+						AddRow(true))
 			},
 		},
 	}
@@ -195,4 +284,19 @@ func setupExpectQueryAssertions(checkName string, mock sqlmock.Sqlmock, customSe
 		}
 		check.setup(mock)
 	}
+}
+
+func pgStatStatementsHasRowsQuery(excludeDatabases, excludeUsers []string) string {
+	return fmt.Sprintf(`
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_stat_statements
+			JOIN pg_database ON pg_database.oid = pg_stat_statements.dbid
+			WHERE pg_database.datname NOT IN %s
+			  AND pg_stat_statements.queryid <> 0
+			  %s
+		)`,
+		buildExcludedDatabasesClause(excludeDatabases),
+		buildExcludedUsersClause(excludeUsers, "pg_get_userbyid(pg_stat_statements.userid)"),
+	)
 }

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -668,10 +668,12 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 
 	// HealthCheck collector is always enabled
 	hcCollector, err := collector.NewHealthCheck(collector.HealthCheckArguments{
-		DB:              c.dbConnection,
-		CollectInterval: c.args.HealthCheckArguments.CollectInterval,
-		EntryHandler:    entryHandler,
-		Logger:          c.opts.Logger,
+		DB:               c.dbConnection,
+		CollectInterval:  c.args.HealthCheckArguments.CollectInterval,
+		ExcludeDatabases: c.args.ExcludeDatabases,
+		ExcludeUsers:     c.args.ExcludeUsers,
+		EntryHandler:     entryHandler,
+		Logger:           c.opts.Logger,
 	})
 	if err != nil {
 		logStartError(collector.HealthCheckCollector, "create", err)


### PR DESCRIPTION
### Brief description of Pull Request

In this changeset:
- add new check `PgStatStatementsHasRows` similar to mysql counterpart, using exclude_databases and exclude_users settings
- add `ComputeQueryIdEnabled` check to verify the `compute_query_id` is enabled

### Pull Request Details

<!-- Detailed descripion of the Pull Request, if needed. -->


### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->


### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
