### PR TITLE
DRAFT PoC: feat(database_observability/postgres): emit stable query_fingerprint across metrics and logs

### DIFF
--- a/docs/sources/reference/components/database_observability/database_observability.postgres.md
+++ b/docs/sources/reference/components/database_observability/database_observability.postgres.md
@@ -171,9 +171,42 @@ The `data_source_name` is inherited from the parent block.
 
 Refer to [`prometheus.exporter.postgres`](../../prometheus/prometheus.exporter.postgres/) docs for the full list of supported arguments and sub-blocks.
 
+## Emitted metrics
+
+`database_observability.postgres` registers the following Prometheus metrics on the component's own `/metrics` endpoint.
+
+| Name                                         | Type    | Description                                                                                                                                                                                                                                                                                          |
+|----------------------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `database_observability_query_hash_info`     | gauge   | Maps each `pg_stat_statements.queryid` to a stable, version-independent `query_fingerprint` computed by Alloy from the query's parsed AST. Value is always `1`. Labels: `queryid`, `query_fingerprint`, `server_id`, `datname`. Use as a join metric to attach `query_fingerprint` to existing series without increasing cardinality on the source. |
+| `database_observability_pg_errors_total`     | counter | Number of log lines with errors by severity and SQL state code. Labels: `severity`, `sqlstate`, `sqlstate_class`, `datname`, `user`.                                                                                                                                                                |
+
+You can use the join metric in PromQL to attach `query_fingerprint` to existing `pg_stat_statements` series:
+
+```promql
+pg_stat_statements_calls_total
+  * on (queryid, datname) group_left(query_fingerprint)
+    database_observability_query_hash_info
+```
+
+## Emitted Loki entries
+
+The component emits Loki log entries to the configured `forward_to` targets. Each entry carries an `op` label identifying the source of the line.
+
+| `op` label                | Source collector | Description                                                                                                                               | Structured metadata |
+|---------------------------|------------------|-------------------------------------------------------------------------------------------------------------------------------------------|---------------------|
+| `query_association`       | `query_details`  | One entry per slow query observed in `pg_stat_statements`, with the `queryid`, computed `query_fingerprint`, normalized text, and database. |                     |
+| `query_parsed_table_name` | `query_details`  | One entry per table referenced by a slow query, with validation against the schema registry.                                               |                     |
+| `query_sample`            | `query_samples`  | One entry per active sample observed in `pg_stat_activity`, emitted at session-end or idle transition.                                     | `query_fingerprint` |
+| `wait_event`              | `query_samples`  | One entry per consecutive wait event observed during an active session, with the raw `wait_event_type` and `wait_event` names.             | `query_fingerprint` |
+| `wait_event_v2`           | `query_samples`  | Same as `wait_event` with `wait_event_type` pre-classified as `IO Wait`, `Lock Wait`, `Network Wait`, or `Other Wait`.                    | `query_fingerprint` |
+| `pg_error`                | `logs`           | One entry per ERROR/FATAL/PANIC line in the PostgreSQL server log, with severity, SQL state, and the originating SQL when available.       | `query_fingerprint` |
+| `pg_slow_query`           | `logs`           | One entry per slow-query log line (`log_min_duration_statement`), with the duration in milliseconds and the SQL.                          | `query_fingerprint` |
+
+The `query_fingerprint` value is the same for `pg_stat_statements` metrics, `pg_stat_activity` samples, and PostgreSQL server log lines. Alloy computes it client-side using the same normalization across all sources, which enables joining metrics and logs by fingerprint on managed services (RDS, Aurora) where `pg_stat_statements.queryid` is not available in `log_line_prefix`.
+
 ## `logs` collector
 
-The `logs` collector processes PostgreSQL logs received through the `logs_receiver` entry point and exports Prometheus metrics for query and server errors.
+The `logs` collector processes PostgreSQL logs received through the `logs_receiver` entry point. It increments error metrics, captures the SQL behind ERROR/FATAL/PANIC entries from `STATEMENT:` continuation lines, parses slow-query log entries (`log_min_duration_statement`), and emits Loki entries for both with `query_fingerprint` attached as structured metadata so logs can be correlated with `pg_stat_statements` metrics — including on managed services (RDS, Aurora) where `pg_stat_statements.queryid` is not available in `log_line_prefix`.
 
 The `logs_receiver` entry point must be fed by `loki` log source components, for example:
 

--- a/docs/superpowers/plans/2026-04-15-wait-event-v2.md
+++ b/docs/superpowers/plans/2026-04-15-wait-event-v2.md
@@ -1,0 +1,733 @@
+# wait_event v2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the multi-version wait event experiment (v1–v6) with a clean two-state design: `wait_event` (v1 baseline) or `wait_event_v2` (pre-classified `wait_event_type` in log body), controlled by the renamed flag `enable_pre_classified_wait_events`; add a `database_observability_wait_event_seconds_total` Prometheus counter to MySQL only.
+
+**Architecture:** Work is done on branch `gaantunes/structured-metadata-poc`. Changes are split across Postgres (flag rename + op cleanup) and MySQL (same + Prometheus counter). TDD throughout — write the failing test first, then implement.
+
+**Tech Stack:** Go, `github.com/prometheus/client_golang/prometheus`, `github.com/grafana/alloy/internal/component/loki`, `sqlmock` for collector tests.
+
+**Spec:** `docs/superpowers/specs/2026-04-15-wait-event-v2-design.md`
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `internal/component/database_observability/postgres/component.go` | Rename flag |
+| `internal/component/database_observability/postgres/collector/query_samples.go` | Rename flag, remove v2/v3/v5/v6, rename v4→v2, mutual exclusion |
+| `internal/component/database_observability/postgres/collector/query_samples_test.go` | Update tests |
+| `internal/component/database_observability/mysql/component.go` | Rename flag, create + register counter, pass to QuerySamples |
+| `internal/component/database_observability/mysql/collector/query_details.go` | Rename flag field |
+| `internal/component/database_observability/mysql/collector/query_samples.go` | Rename flag, remove v2/v3/v5/v6, rename v4→v2, mutual exclusion, increment counter |
+| `internal/component/database_observability/mysql/collector/query_samples_test.go` | Update tests, add counter tests |
+| `docs/sources/reference/components/database_observability/database_observability.mysql.md` | Update flag name |
+| `docs/sources/reference/components/database_observability/database_observability.postgres.md` | Update flag name |
+
+---
+
+## Task 1: Rename flag in Postgres
+
+**Files:**
+- Modify: `internal/component/database_observability/postgres/component.go`
+- Modify: `internal/component/database_observability/postgres/collector/query_samples.go`
+- Modify: `internal/component/database_observability/postgres/component_test.go`
+
+- [ ] **Step 1: Rename in postgres/component.go Arguments struct**
+
+Find and replace all occurrences of `EnableStructuredMetadata` → `EnablePreClassifiedWaitEvents` and `enable_structured_metadata` → `enable_pre_classified_wait_events` in this file.
+
+The field in the Arguments struct changes from:
+```go
+EnableStructuredMetadata bool `alloy:"enable_structured_metadata,attr,optional"`
+```
+to:
+```go
+EnablePreClassifiedWaitEvents bool `alloy:"enable_pre_classified_wait_events,attr,optional"`
+```
+
+And in the default args and any place it's passed down (grep for `EnableStructuredMetadata` in this file and update all occurrences).
+
+- [ ] **Step 2: Rename in postgres/collector/query_samples.go**
+
+In `QuerySamplesArguments` struct:
+```go
+// before
+EnableStructuredMetadata bool
+// after
+EnablePreClassifiedWaitEvents bool
+```
+
+In `QuerySamples` struct:
+```go
+// before
+enableStructuredMetadata bool
+// after
+enablePreClassifiedWaitEvents bool
+```
+
+In `NewQuerySamples`:
+```go
+// before
+enableStructuredMetadata: args.EnableStructuredMetadata,
+// after
+enablePreClassifiedWaitEvents: args.EnablePreClassifiedWaitEvents,
+```
+
+In the emit logic, all references to `c.enableStructuredMetadata` → `c.enablePreClassifiedWaitEvents`.
+
+- [ ] **Step 3: Update postgres/component_test.go**
+
+Replace all `EnableStructuredMetadata` → `EnablePreClassifiedWaitEvents` in test setup.
+
+- [ ] **Step 4: Run tests to confirm rename compiles and passes**
+
+```bash
+cd /home/gaantunes/git/alloy
+git checkout gaantunes/structured-metadata-poc
+go test ./internal/component/database_observability/postgres/... -count=1 -timeout 60s
+```
+
+Expected: all tests pass (behaviour unchanged — this is a pure rename).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/component/database_observability/postgres/
+git commit -m "refactor(database_observability): rename enable_structured_metadata to enable_pre_classified_wait_events (postgres)"
+```
+
+---
+
+## Task 2: Postgres op cleanup + mutual exclusion
+
+**Files:**
+- Modify: `internal/component/database_observability/postgres/collector/query_samples.go`
+- Modify: `internal/component/database_observability/postgres/collector/query_samples_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Open `postgres/collector/query_samples_test.go`. Find `TestQuerySamples_WaitEvents`.
+
+Add two sub-tests after the existing ones (or replace the existing structural assertions — see Step 3 for what the new assertions look like):
+
+```go
+t.Run("flag OFF emits only wait_event (v1)", func(t *testing.T) {
+    // same DB mock setup as existing test
+    // EnablePreClassifiedWaitEvents: false (default)
+    // assert: entries contain OP_WAIT_EVENT only (no OP_WAIT_EVENT_V2)
+    // assert: wait_event_type field is NOT in the log line
+    collector, err := NewQuerySamples(QuerySamplesArguments{
+        DB:                           db,
+        EngineVersion:                latestCompatibleVersion,
+        CollectInterval:              time.Second,
+        EntryHandler:                 lokiClient,
+        Logger:                       log.NewLogfmtLogger(os.Stderr),
+        EnablePreClassifiedWaitEvents: false,
+    })
+    // ... run and collect entries
+    // There should be 2 entries: one OP_QUERY_SAMPLE, one OP_WAIT_EVENT
+    require.Len(t, lokiEntries, 2)
+    require.Equal(t, model.LabelSet{"op": OP_WAIT_EVENT}, lokiEntries[1].Labels)
+    require.NotContains(t, lokiEntries[1].Line, "wait_event_type=")
+})
+
+t.Run("flag ON emits only wait_event_v2", func(t *testing.T) {
+    // same DB mock setup
+    // EnablePreClassifiedWaitEvents: true
+    // assert: entries contain OP_WAIT_EVENT_V2 only (no OP_WAIT_EVENT)
+    // assert: wait_event_type="IO Wait" in the log line
+    collector, err := NewQuerySamples(QuerySamplesArguments{
+        DB:                           db,
+        EngineVersion:                latestCompatibleVersion,
+        CollectInterval:              time.Second,
+        EntryHandler:                 lokiClient,
+        Logger:                       log.NewLogfmtLogger(os.Stderr),
+        EnablePreClassifiedWaitEvents: true,
+    })
+    // ... run and collect entries
+    // There should be 2 entries: one OP_QUERY_SAMPLE, one OP_WAIT_EVENT_V2
+    require.Len(t, lokiEntries, 2)
+    require.Equal(t, model.LabelSet{"op": OP_WAIT_EVENT_V2}, lokiEntries[1].Labels)
+    require.Contains(t, lokiEntries[1].Line, `wait_event_type="IO Wait"`)
+    require.Empty(t, lokiEntries[1].StructuredMetadata)
+})
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+go test ./internal/component/database_observability/postgres/collector/... -run TestQuerySamples_WaitEvents -v -count=1
+```
+
+Expected: compile error (OP_WAIT_EVENT_V2 constant will be reused from old version, wrong semantics) or assertion failures showing 3–4 entries instead of 2.
+
+- [ ] **Step 3: Update constants in query_samples.go**
+
+Remove these constants:
+```go
+OP_WAIT_EVENT_V2 = "wait_event_v2"  // old SM version — DELETE
+OP_WAIT_EVENT_V3 = "wait_event_v3"  // DELETE
+OP_WAIT_EVENT_V5 = "wait_event_v5"  // DELETE
+OP_WAIT_EVENT_V6 = "wait_event_v6"  // DELETE
+```
+
+Rename:
+```go
+// before
+OP_WAIT_EVENT_V4 = "wait_event_v4"
+// after
+OP_WAIT_EVENT_V2 = "wait_event_v2"
+```
+
+- [ ] **Step 4: Remove helper functions for deleted ops**
+
+Delete from `query_samples.go`:
+- `buildWaitEventLabelsV2` (served old V2/V3/V5 SM ops)
+- `buildWaitEventV5Labels`
+- `buildWaitEventV6Labels`
+
+Rename:
+- `buildWaitEventV4Labels` → `buildWaitEventV2Labels`
+
+- [ ] **Step 5: Replace emit block with mutual exclusion**
+
+Find the wait event emit loop in `emitAndDeleteSample`. Replace the entire block (currently emits v1, then if-SM emits v2/v3/v5, then always emits v4 and v6) with:
+
+```go
+for _, we := range state.tracker.WaitEvents() {
+    if we.WaitEventType == "" || we.WaitEvent == "" {
+        continue
+    }
+    if c.enablePreClassifiedWaitEvents {
+        c.entryHandler.Chan() <- database_observability.BuildLokiEntryWithTimestamp(
+            logging.LevelInfo,
+            OP_WAIT_EVENT_V2,
+            c.buildWaitEventV2Labels(state, we),
+            we.LastTimestamp.UnixNano(),
+        )
+    } else {
+        c.entryHandler.Chan() <- database_observability.BuildLokiEntryWithTimestamp(
+            logging.LevelInfo,
+            OP_WAIT_EVENT,
+            c.buildWaitEventLabels(state, we),
+            we.LastTimestamp.UnixNano(),
+        )
+    }
+}
+```
+
+`buildWaitEventV2Labels` (renamed from `buildWaitEventV4Labels`) produces:
+```
+datname="%s" pid="%d" leader_pid="%s" user="%s" backend_type="%s" state="%s"
+xid="%d" xmin="%d" wait_time="%s" wait_event_type="%s" wait_event="%s"
+wait_event_name="%s" blocked_by_pids="%v" queryid="%d"
+```
+where `wait_event_type` is `classifyPostgresWaitEventType(we.WaitEventType)`.
+
+- [ ] **Step 6: Update existing test assertions**
+
+In `TestQuerySamples_WaitEvents`, all existing assertions that reference `OP_WAIT_EVENT_V4` → `OP_WAIT_EVENT_V2`. All assertions that reference `OP_WAIT_EVENT_V6` → remove (v6 is gone). Adjust `require.Len` counts accordingly (3 entries per wait event → 2 entries: one sample + one wait event op).
+
+Also update the structured-metadata enabled test (around line 1301) to use `EnablePreClassifiedWaitEvents` and assert `OP_WAIT_EVENT_V2` only.
+
+- [ ] **Step 7: Run tests**
+
+```bash
+go test ./internal/component/database_observability/postgres/collector/... -run TestQuerySamples_WaitEvents -v -count=1
+```
+
+Expected: all pass.
+
+- [ ] **Step 8: Run full Postgres suite**
+
+```bash
+go test ./internal/component/database_observability/postgres/... -count=1 -timeout 60s
+```
+
+Expected: all pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/component/database_observability/postgres/
+git commit -m "feat(database_observability): replace wait_event v1-v6 with clean v1/v2 mutual exclusion (postgres)"
+```
+
+---
+
+## Task 3: Rename flag in MySQL
+
+**Files:**
+- Modify: `internal/component/database_observability/mysql/component.go`
+- Modify: `internal/component/database_observability/mysql/collector/query_details.go`
+- Modify: `internal/component/database_observability/mysql/collector/query_samples.go`
+- Modify: `internal/component/database_observability/mysql/component_test.go`
+
+- [ ] **Step 1: Rename in mysql/component.go**
+
+In `Arguments` struct:
+```go
+// before
+EnableStructuredMetadata bool `alloy:"enable_structured_metadata,attr,optional"`
+// after
+EnablePreClassifiedWaitEvents bool `alloy:"enable_pre_classified_wait_events,attr,optional"`
+```
+
+In default args (search for `EnableStructuredMetadata: false`) and every place the flag is passed to collectors (two places: `NewQueryDetails` call and `NewQuerySamples` call):
+```go
+// before
+EnableStructuredMetadata: c.args.EnableStructuredMetadata,
+// after
+EnablePreClassifiedWaitEvents: c.args.EnablePreClassifiedWaitEvents,
+```
+
+- [ ] **Step 2: Rename in mysql/collector/query_details.go**
+
+In `QueryDetailsArguments`:
+```go
+EnablePreClassifiedWaitEvents bool
+```
+
+In `QueryDetails` struct:
+```go
+enablePreClassifiedWaitEvents bool
+```
+
+In `NewQueryDetails`:
+```go
+enablePreClassifiedWaitEvents: args.EnablePreClassifiedWaitEvents,
+```
+
+In the emit logic:
+```go
+if c.enablePreClassifiedWaitEvents {
+```
+
+- [ ] **Step 3: Rename in mysql/collector/query_samples.go**
+
+Same pattern as Postgres Task 1 Step 2:
+- `QuerySamplesArguments.EnableStructuredMetadata` → `EnablePreClassifiedWaitEvents`
+- `QuerySamples.enableStructuredMetadata` → `enablePreClassifiedWaitEvents`
+- Constructor assignment
+- All `c.enableStructuredMetadata` references in the emit loop
+
+- [ ] **Step 4: Update mysql/component_test.go**
+
+Replace all `EnableStructuredMetadata` → `EnablePreClassifiedWaitEvents`.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+go test ./internal/component/database_observability/mysql/... -count=1 -timeout 60s
+```
+
+Expected: all pass (pure rename, no behaviour change).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/component/database_observability/mysql/
+git commit -m "refactor(database_observability): rename enable_structured_metadata to enable_pre_classified_wait_events (mysql)"
+```
+
+---
+
+## Task 4: MySQL op cleanup + mutual exclusion
+
+**Files:**
+- Modify: `internal/component/database_observability/mysql/collector/query_samples.go`
+- Modify: `internal/component/database_observability/mysql/collector/query_samples_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+In `TestQuerySamples_WaitEvents`, add (or replace existing structural tests with) two sub-tests:
+
+```go
+t.Run("flag OFF emits only wait_event (v1)", func(t *testing.T) {
+    // use existing sqlmock setup (schema="some_schema", digest="some_digest",
+    // wait_event_name="wait/io/file/innodb/innodb_data_file", wait_time=100000000ps)
+    collector, err := NewQuerySamples(QuerySamplesArguments{
+        DB:                           db,
+        EngineVersion:                latestCompatibleVersion,
+        CollectInterval:              time.Second,
+        EntryHandler:                 lokiClient,
+        Logger:                       log.NewLogfmtLogger(os.Stderr),
+        EnablePreClassifiedWaitEvents: false,
+    })
+    require.NoError(t, err)
+    // ... start, wait for 2 entries, stop
+    require.Len(t, lokiEntries, 2) // OP_QUERY_SAMPLE + OP_WAIT_EVENT
+    require.Equal(t, model.LabelSet{"op": OP_WAIT_EVENT}, lokiEntries[1].Labels)
+    require.NotContains(t, lokiEntries[1].Line, "wait_event_type=")
+})
+
+t.Run("flag ON emits only wait_event_v2", func(t *testing.T) {
+    collector, err := NewQuerySamples(QuerySamplesArguments{
+        DB:                           db,
+        EngineVersion:                latestCompatibleVersion,
+        CollectInterval:              time.Second,
+        EntryHandler:                 lokiClient,
+        Logger:                       log.NewLogfmtLogger(os.Stderr),
+        EnablePreClassifiedWaitEvents: true,
+    })
+    require.NoError(t, err)
+    // ... start, wait for 2 entries, stop
+    require.Len(t, lokiEntries, 2) // OP_QUERY_SAMPLE + OP_WAIT_EVENT_V2
+    require.Equal(t, model.LabelSet{"op": OP_WAIT_EVENT_V2}, lokiEntries[1].Labels)
+    require.Contains(t, lokiEntries[1].Line, `wait_event_type="IO Wait"`)
+    require.Empty(t, lokiEntries[1].StructuredMetadata)
+    require.NotContains(t, lokiEntries[1].Line, "queryid=")  // no v6-style extra fields
+})
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+go test ./internal/component/database_observability/mysql/collector/... -run TestQuerySamples_WaitEvents -v -count=1
+```
+
+Expected: assertion failures (currently 4 entries, not 2).
+
+- [ ] **Step 3: Remove constants for deleted ops in query_samples.go**
+
+```go
+// DELETE these:
+OP_WAIT_EVENT_V2 = "wait_event_v2"  // old SM version
+OP_WAIT_EVENT_V3 = "wait_event_v3"
+OP_WAIT_EVENT_V5 = "wait_event_v5"
+OP_WAIT_EVENT_V6 = "wait_event_v6"
+
+// RENAME:
+// OP_WAIT_EVENT_V4 = "wait_event_v4"  →
+OP_WAIT_EVENT_V2 = "wait_event_v2"
+```
+
+- [ ] **Step 4: Remove SM helper functions**
+
+Delete from `query_samples.go`:
+- `classifyMySQLWaitEventType` — **keep** (used by new v2)
+- Any helper that only served old v2/v3/v5/v6 SM emission (search for functions only referenced in the deleted `if c.enablePreClassifiedWaitEvents` SM blocks)
+
+- [ ] **Step 5: Replace emit block with mutual exclusion**
+
+Find the wait event emit block (currently: always emits v1, if-flag emits old v2/v3/v5, always emits v4/v6). Replace with:
+
+```go
+if row.WaitEventID.Valid && row.WaitTime.Valid {
+    waitTime := picosecondsToMilliseconds(row.WaitTime.Float64)
+
+    if c.enablePreClassifiedWaitEvents {
+        waitV2LogMessage := fmt.Sprintf(
+            `schema="%s" user="%s" client_host="%s" thread_id="%s" digest="%s" event_id="%s" wait_event_id="%s" wait_end_event_id="%s" wait_event_name="%s" wait_event_type="%s" wait_object_name="%s" wait_object_type="%s" wait_time="%fms"`,
+            row.Schema.String,
+            row.User.String,
+            row.Host.String,
+            row.ThreadID.String,
+            row.Digest.String,
+            row.StatementEventID.String,
+            row.WaitEventID.String,
+            row.WaitEndEventID.String,
+            row.WaitEventName.String,
+            classifyMySQLWaitEventType(row.WaitEventName.String),
+            row.WaitObjectName.String,
+            row.WaitObjectType.String,
+            waitTime,
+        )
+        if c.disableQueryRedaction && row.SQLText.Valid {
+            waitV2LogMessage += fmt.Sprintf(` sql_text="%s"`, row.SQLText.String)
+        }
+        c.entryHandler.Chan() <- database_observability.BuildLokiEntryWithTimestamp(
+            logging.LevelInfo,
+            OP_WAIT_EVENT_V2,
+            waitV2LogMessage,
+            int64(millisecondsToNanoseconds(row.TimestampMilliseconds)),
+        )
+    } else {
+        waitLogMessage := fmt.Sprintf(
+            `schema="%s" user="%s" client_host="%s" thread_id="%s" digest="%s" event_id="%s" wait_event_id="%s" wait_end_event_id="%s" wait_event_name="%s" wait_object_name="%s" wait_object_type="%s" wait_time="%fms"`,
+            row.Schema.String,
+            row.User.String,
+            row.Host.String,
+            row.ThreadID.String,
+            row.Digest.String,
+            row.StatementEventID.String,
+            row.WaitEventID.String,
+            row.WaitEndEventID.String,
+            row.WaitEventName.String,
+            row.WaitObjectName.String,
+            row.WaitObjectType.String,
+            waitTime,
+        )
+        if c.disableQueryRedaction && row.SQLText.Valid {
+            waitLogMessage += fmt.Sprintf(` sql_text="%s"`, row.SQLText.String)
+        }
+        c.entryHandler.Chan() <- database_observability.BuildLokiEntryWithTimestamp(
+            logging.LevelInfo,
+            OP_WAIT_EVENT,
+            waitLogMessage,
+            int64(millisecondsToNanoseconds(row.TimestampMilliseconds)),
+        )
+    }
+}
+```
+
+- [ ] **Step 6: Update existing test assertions**
+
+All assertions referencing `OP_WAIT_EVENT_V4` → `OP_WAIT_EVENT_V2`. All assertions referencing `OP_WAIT_EVENT_V6` → remove. Adjust `require.Len` / `require.Eventually` counts from 4 down to 2 per wait event row.
+
+- [ ] **Step 7: Run tests**
+
+```bash
+go test ./internal/component/database_observability/mysql/collector/... -run TestQuerySamples_WaitEvents -v -count=1
+```
+
+Expected: all pass.
+
+- [ ] **Step 8: Run full MySQL suite**
+
+```bash
+go test ./internal/component/database_observability/mysql/... -count=1 -timeout 60s
+```
+
+Expected: all pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/component/database_observability/mysql/
+git commit -m "feat(database_observability): replace wait_event v1-v6 with clean v1/v2 mutual exclusion (mysql)"
+```
+
+---
+
+## Task 5: Prometheus counter in MySQL
+
+**Files:**
+- Modify: `internal/component/database_observability/mysql/component.go`
+- Modify: `internal/component/database_observability/mysql/collector/query_samples.go`
+- Modify: `internal/component/database_observability/mysql/collector/query_samples_test.go`
+
+- [ ] **Step 1: Write failing counter test**
+
+In `query_samples_test.go`, add a new test function:
+
+```go
+func TestQuerySamples_WaitEventCounter(t *testing.T) {
+    db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+    require.NoError(t, err)
+    defer db.Close()
+
+    lokiClient := loki.NewCollectingHandler()
+    reg := prometheus.NewRegistry()
+    counter := prometheus.NewCounterVec(prometheus.CounterOpts{
+        Name: "database_observability_wait_event_seconds_total",
+        Help: "Total wait time in seconds per query, aggregated by server, query digest, and database.",
+    }, []string{"server_id", "digest", "schema"})
+    require.NoError(t, reg.Register(counter))
+
+    collector, err := NewQuerySamples(QuerySamplesArguments{
+        DB:               db,
+        EngineVersion:    latestCompatibleVersion,
+        CollectInterval:  time.Second,
+        EntryHandler:     lokiClient,
+        Logger:           log.NewLogfmtLogger(os.Stderr),
+        WaitEventCounter: counter,
+        ServerID:         "test-server",
+    })
+    require.NoError(t, err)
+
+    // same mock rows as existing wait event test:
+    // wait_event_name="wait/io/file/innodb/innodb_data_file"
+    // timer_wait=100000000 (picoseconds) → 0.1ms → 0.0001s
+    // schema="some_schema", digest="some_digest"
+    mock.ExpectQuery(selectUptime)./* ... same as other tests ... */
+
+    err = collector.Start(t.Context())
+    require.NoError(t, err)
+
+    require.Eventually(t, func() bool {
+        return len(lokiClient.Received()) >= 2
+    }, 5*time.Second, 100*time.Millisecond)
+
+    collector.Stop()
+    lokiClient.Stop()
+
+    // Assert counter was incremented with correct labels and value
+    mfs, err := reg.Gather()
+    require.NoError(t, err)
+    require.Len(t, mfs, 1)
+    require.Equal(t, "database_observability_wait_event_seconds_total", *mfs[0].Name)
+    require.Len(t, mfs[0].Metric, 1)
+
+    m := mfs[0].Metric[0]
+    labels := map[string]string{}
+    for _, lp := range m.Label {
+        labels[*lp.Name] = *lp.Value
+    }
+    require.Equal(t, "test-server", labels["server_id"])
+    require.Equal(t, "some_digest", labels["digest"])
+    require.Equal(t, "some_schema", labels["schema"])
+    require.InDelta(t, 0.0001, m.Counter.GetValue(), 1e-9) // 100000000ps = 0.1ms = 0.0001s
+}
+```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+```bash
+go test ./internal/component/database_observability/mysql/collector/... -run TestQuerySamples_WaitEventCounter -v -count=1
+```
+
+Expected: compile error — `WaitEventCounter` and `ServerID` fields don't exist yet.
+
+- [ ] **Step 3: Add counter and ServerID to QuerySamplesArguments and QuerySamples**
+
+In `mysql/collector/query_samples.go`, add to `QuerySamplesArguments`:
+```go
+WaitEventCounter *prometheus.CounterVec
+ServerID         string
+```
+
+Add to `QuerySamples` struct:
+```go
+waitEventCounter *prometheus.CounterVec
+serverID         string
+```
+
+Add to `NewQuerySamples` constructor:
+```go
+waitEventCounter: args.WaitEventCounter,
+serverID:         args.ServerID,
+```
+
+Add import if not present: `"github.com/prometheus/client_golang/prometheus"`
+
+- [ ] **Step 4: Increment counter in the emit loop**
+
+At the end of the wait event block (after the if/else that emits v1 or v2), add unconditional counter increment:
+
+```go
+if c.waitEventCounter != nil {
+    waitTimeSeconds := waitTime / 1000.0 // waitTime is in ms (from picosecondsToMilliseconds)
+    c.waitEventCounter.WithLabelValues(c.serverID, row.Digest.String, row.Schema.String).Add(waitTimeSeconds)
+}
+```
+
+This goes inside the `if row.WaitEventID.Valid && row.WaitTime.Valid` block, after the if/else emission.
+
+- [ ] **Step 5: Run counter test**
+
+```bash
+go test ./internal/component/database_observability/mysql/collector/... -run TestQuerySamples_WaitEventCounter -v -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Wire counter in mysql/component.go**
+
+In `mysql/component.go`, in the `new()` function or `Update()` where `NewQuerySamples` is called, create and register the counter before constructing the collector:
+
+```go
+waitEventCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
+    Name: "database_observability_wait_event_seconds_total",
+    Help: "Total wait time in seconds per query, aggregated by server, query digest, and database.",
+}, []string{"server_id", "digest", "schema"})
+if err := c.registry.Register(waitEventCounter); err != nil {
+    return fmt.Errorf("failed to register wait event counter: %w", err)
+}
+```
+
+Then pass it into `NewQuerySamples`:
+```go
+qsCollector, err := collector.NewQuerySamples(collector.QuerySamplesArguments{
+    // ... existing fields ...
+    WaitEventCounter: waitEventCounter,
+    ServerID:         c.instanceKey,
+})
+```
+
+- [ ] **Step 7: Run full MySQL suite**
+
+```bash
+go test ./internal/component/database_observability/mysql/... -count=1 -timeout 60s
+```
+
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/component/database_observability/mysql/
+git commit -m "feat(database_observability): add database_observability_wait_event_seconds_total counter to mysql"
+```
+
+---
+
+## Task 6: Update docs
+
+**Files:**
+- Modify: `docs/sources/reference/components/database_observability/database_observability.mysql.md`
+- Modify: `docs/sources/reference/components/database_observability/database_observability.postgres.md`
+
+- [ ] **Step 1: Update mysql.md**
+
+Find the `enable_structured_metadata` attribute entry. Replace:
+```markdown
+`enable_structured_metadata` | `bool` | ...
+```
+with:
+```markdown
+`enable_pre_classified_wait_events` | `bool` | When `true`, emits `wait_event_v2` entries with `wait_event_type` pre-classified as `IO Wait`, `Lock Wait`, `Network Wait`, or `Other Wait` in the log body, instead of the baseline `wait_event` entries. Defaults to `false`. | `false`
+```
+
+Remove any reference to `enable_structured_metadata` in examples or description blocks.
+
+- [ ] **Step 2: Update postgres.md**
+
+Same change as Step 1 in the Postgres component doc.
+
+- [ ] **Step 3: Run doc build check (optional)**
+
+```bash
+# Only if make docs is available and fast:
+# make docs
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/sources/reference/components/database_observability/
+git commit -m "docs(database_observability): update flag name to enable_pre_classified_wait_events"
+```
+
+---
+
+## Final Verification
+
+- [ ] **Run full database_observability suite**
+
+```bash
+go test ./internal/component/database_observability/... -count=1 -timeout 120s
+```
+
+Expected: all pass, zero failures.
+
+- [ ] **Confirm no remaining references to old flag or old op names**
+
+```bash
+grep -r "enable_structured_metadata\|OP_WAIT_EVENT_V3\|OP_WAIT_EVENT_V5\|OP_WAIT_EVENT_V6\|wait_event_v3\|wait_event_v5\|wait_event_v6" \
+  internal/component/database_observability/ --include="*.go"
+```
+
+Expected: no output (zero matches).
+
+- [ ] **Confirm old SM emit helpers are gone**
+
+```bash
+grep -r "BuildLokiEntryWithStructuredMetadataAndTimestamp\|buildWaitEventLabelsV2\|buildWaitEventV5Labels\|buildWaitEventV6Labels" \
+  internal/component/database_observability/ --include="*.go"
+```
+
+Expected: no output in query_samples files (the function may still exist in loki_entry.go but should not be called from query_samples).

--- a/docs/superpowers/plans/2026-04-28-postgres-semantic-query-fingerprint.md
+++ b/docs/superpowers/plans/2026-04-28-postgres-semantic-query-fingerprint.md
@@ -1,0 +1,1340 @@
+# PostgreSQL Semantic Query Fingerprint Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a semantic query fingerprint to `database_observability.postgres` so the same logical SQL produces the same identifier across `pg_stat_statements`, `pg_stat_activity`, and PostgreSQL log lines — including on managed services (RDS, Aurora) where the native `queryid` is not available in logs.
+
+**Architecture:**
+1. A small `fingerprint` package wraps [pg_query_go](https://github.com/pganalyze/pg_query_go) with the pganalyze-style three-stage pipeline: parse-as-is → repair-and-retry → sentinel fallback.
+2. A `QueryHashRegistry` (queryid → fingerprint+datname, LRU+TTL) is populated by the `query_details` collector while it scrapes `pg_stat_statements`. A `QueryHashMetricsCollector` exposes the registry as a Prometheus join metric `database_observability_query_hash_info{queryid, query_fingerprint, server_id, datname} = 1`. Dashboards do `pg_stat_statements_X * on(queryid, datname) group_left(query_fingerprint) database_observability_query_hash_info` to attach the fingerprint to existing series with no cardinality bump on the source metrics.
+3. The `query_samples` collector consults the registry first (registry fingerprint comes from un-truncated text), falling back to fingerprinting the truncated `pg_stat_activity.query` text using the same pipeline with the truncation sentinel enabled.
+4. The `logs` collector is extended to (a) buffer ERROR + STATEMENT continuation pairs so the SQL behind an error is captured, and (b) parse slow-query `LOG: duration: N ms statement: ...` lines. Both emit Loki entries with `query_fingerprint` carried as Loki structured metadata so cardinality stays out of the index.
+
+**Recommendation followed:** Option 1 + Option B from `docs/design/XXXX-semantic-query-fingerprint.md` (compute via pg_query AST, augment alongside `queryid` rather than replace it).
+
+**Tech Stack:** Go, CGo (libpg_query via pg_query_go/v6), `prometheus/client_golang`, `grafana/loki/pkg/push`, `hashicorp/golang-lru/v2/expirable`.
+
+---
+
+## File Structure
+
+**New files:**
+- `internal/component/database_observability/postgres/fingerprint/fingerprint.go` — three-stage `Fingerprint` function, sentinel constants, `Source` enum.
+- `internal/component/database_observability/postgres/fingerprint/fingerprint_test.go` — table-driven unit tests.
+- `internal/component/database_observability/postgres/collector/query_hash_registry.go` — LRU+TTL `queryid → fingerprint, datname` map.
+- `internal/component/database_observability/postgres/collector/query_hash_registry_test.go`
+- `internal/component/database_observability/postgres/collector/query_hash_metrics.go` — `prometheus.Collector` exposing `query_hash_info` from the registry.
+- `internal/component/database_observability/postgres/collector/query_hash_metrics_test.go`
+
+**Modified files:**
+- `go.mod`, `go.sum`, `collector/go.mod`, `collector/go.sum`, `extension/alloyengine/go.mod`, `extension/alloyengine/go.sum` — add `github.com/pganalyze/pg_query_go/v6`.
+- `internal/component/database_observability/loki_entry.go` — add `BuildLokiEntryWithStructuredMetadata` variant.
+- `internal/component/database_observability/loki_entry_test.go` — cover the new variant.
+- `internal/component/database_observability/postgres/component.go` — construct registry + metrics collector, plumb into collectors, fetch `track_activity_query_size`.
+- `internal/component/database_observability/postgres/collector/query_details.go` — replace ad-hoc normalization with the fingerprint pipeline; populate the registry; emit `query_fingerprint=` on `OP_QUERY_ASSOCIATION` entries.
+- `internal/component/database_observability/postgres/collector/query_details_test.go` — fingerprint assertions.
+- `internal/component/database_observability/postgres/collector/query_samples.go` — registry lookup + fallback fingerprinting; emit `query_fingerprint=` on `OP_QUERY_SAMPLE`, `OP_WAIT_EVENT`, `OP_WAIT_EVENT_V2` entries.
+- `internal/component/database_observability/postgres/collector/query_samples_test.go` — assertions for fingerprint label.
+- `internal/component/database_observability/postgres/collector/logs.go` — multi-line ERROR/STATEMENT buffering, slow-query log parsing, Loki emission with `query_fingerprint` structured metadata, `pg_errors_total` gains a `query_fingerprint` label.
+- `internal/component/database_observability/postgres/collector/logs_test.go` — error+STATEMENT and slow-query test cases.
+- `docs/sources/reference/components/database_observability/database_observability.postgres.md` — document the new metric and structured-metadata field.
+
+**File responsibilities:**
+- `fingerprint/` is *only* about turning text into a stable identifier; it must not import anything from `database_observability` so it can be reused later (e.g. for MySQL via a different parser).
+- `query_hash_registry.go` is shared state; `query_details.go` writes, `query_samples.go` and `query_hash_metrics.go` read.
+- `query_hash_metrics.go` is the only place that talks to `prometheus.Collector` for the join metric — keep it small (mirrors the pattern of `connection_info.go`).
+- The logs collector is already on the larger side (~340 lines); the new buffering logic goes into a new private struct/method on the same file rather than creating a new file, since it's tightly coupled to `parseTextLog`.
+
+---
+
+## Phase 0 — Dependency and fingerprint package
+
+### Task 1: Add `pg_query_go/v6` dependency
+
+**Files:**
+- Modify: `go.mod`, `collector/go.mod`, `extension/alloyengine/go.mod`
+- Modify: `go.sum`, `collector/go.sum`, `extension/alloyengine/go.sum`
+
+- [ ] **Step 1: Add the require entry to the top-level `go.mod`**
+
+In `go.mod`, locate the existing `require ( ... )` block that already has named direct deps such as `buf.build/gen/...`, and add:
+
+```go
+require (
+    github.com/pganalyze/pg_query_go/v6 v6.1.0
+)
+```
+
+(Use a separate `require` block — matches the style already used for `buf.build/...` per PR #5354.)
+
+- [ ] **Step 2: Run `go mod tidy` from the repo root**
+
+Run: `cd /home/gaantunes/git/alloy && go mod tidy`
+Expected: `go.sum` is updated with `github.com/pganalyze/pg_query_go/v6 v6.1.0` lines and the protobuf transitive bump.
+
+- [ ] **Step 3: Tidy the sub-modules**
+
+Run:
+```bash
+cd /home/gaantunes/git/alloy/collector && go mod tidy
+cd /home/gaantunes/git/alloy/extension/alloyengine && go mod tidy
+```
+Expected: `pg_query_go/v6` appears as `// indirect` in those go.mod files.
+
+- [ ] **Step 4: Verify the binary still builds (CGo path)**
+
+Run: `cd /home/gaantunes/git/alloy && CGO_ENABLED=1 go build ./...`
+Expected: Build succeeds. If a CGo toolchain is missing, install `build-essential` (Linux) and re-run.
+
+- [ ] **Step 5: Smoke-check that `pg_query.Fingerprint` is usable**
+
+Add a temporary `cmd/_smoke/fingerprint_smoke/main.go`:
+```go
+package main
+
+import (
+    "fmt"
+
+    pg_query "github.com/pganalyze/pg_query_go/v6"
+)
+
+func main() {
+    fp, err := pg_query.Fingerprint("SELECT 1")
+    if err != nil {
+        panic(err)
+    }
+    fmt.Println(fp)
+}
+```
+
+Run: `cd /home/gaantunes/git/alloy && go run ./cmd/_smoke/fingerprint_smoke`
+Expected: A 16-character hex fingerprint is printed.
+
+- [ ] **Step 6: Delete the smoke binary and commit**
+
+Run:
+```bash
+rm -rf /home/gaantunes/git/alloy/cmd/_smoke
+git add go.mod go.sum collector/go.mod collector/go.sum extension/alloyengine/go.mod extension/alloyengine/go.sum
+git commit -m "feat(deps): add pg_query_go for postgres semantic query fingerprinting"
+```
+
+---
+
+### Task 2: Create the `fingerprint` package
+
+**Files:**
+- Create: `internal/component/database_observability/postgres/fingerprint/fingerprint.go`
+- Create: `internal/component/database_observability/postgres/fingerprint/fingerprint_test.go`
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `internal/component/database_observability/postgres/fingerprint/fingerprint_test.go`:
+
+```go
+package fingerprint
+
+import (
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+func TestFingerprint_StableAcrossCommentsAndWhitespace(t *testing.T) {
+    a, _, errA := Fingerprint("SELECT * FROM users WHERE id = $1 -- foo", SourcePgStatStatements, 0)
+    require.NoError(t, errA)
+    b, _, errB := Fingerprint("SELECT *\nFROM users\nWHERE id = $1 /* bar */", SourcePgStatStatements, 0)
+    require.NoError(t, errB)
+    assert.Equal(t, a, b)
+}
+
+func TestFingerprint_DifferentForDifferentQueries(t *testing.T) {
+    a, _, _ := Fingerprint("SELECT 1", SourcePgStatStatements, 0)
+    b, _, _ := Fingerprint("SELECT 2", SourcePgStatStatements, 0)
+    assert.NotEqual(t, a, b)
+}
+
+func TestFingerprint_RepairUnclosedQuotes(t *testing.T) {
+    fp, repaired, err := Fingerprint("SELECT * FROM t WHERE name = 'oh no", SourceLog, 0)
+    require.NoError(t, err)
+    assert.True(t, repaired, "should report that repair was used")
+    assert.NotEqual(t, "", fp)
+}
+
+func TestFingerprint_RepairUnclosedParens(t *testing.T) {
+    fp, repaired, err := Fingerprint("SELECT * FROM t WHERE id IN (1, 2, 3", SourceLog, 0)
+    require.NoError(t, err)
+    assert.True(t, repaired)
+    assert.NotEqual(t, "", fp)
+}
+
+func TestFingerprint_TruncatedSentinelOnPgStatActivity(t *testing.T) {
+    // Build a malformed query whose length equals trackActivityQuerySize-1.
+    const trackSize = 1024
+    bad := makeUnparsableOfLen(trackSize - 1)
+
+    fp, _, err := Fingerprint(bad, SourcePgStatActivity, trackSize)
+    require.NoError(t, err)
+    assert.Equal(t, FingerprintOf(SentinelTruncated), fp)
+}
+
+func TestFingerprint_UnparsableSentinel(t *testing.T) {
+    // Garbage that cannot be repaired and is not at the activity buffer limit.
+    fp, _, err := Fingerprint("$$$ not sql at all $$$", SourcePgStatStatements, 0)
+    require.NoError(t, err)
+    assert.Equal(t, FingerprintOf(SentinelUnparsable), fp)
+}
+
+func TestFingerprint_EmptyAndNullInputs(t *testing.T) {
+    _, _, err := Fingerprint("", SourcePgStatStatements, 0)
+    assert.Error(t, err, "empty input should error so callers can skip emitting")
+}
+
+// makeUnparsableOfLen returns an unparsable string of exactly n bytes (helps
+// exercise the trackActivityQuerySize-1 sentinel path).
+func makeUnparsableOfLen(n int) string {
+    s := "SELECT * FROM t WHERE x IN ("
+    for len(s) < n {
+        s += "1,"
+    }
+    return s[:n]
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/gaantunes/git/alloy && go test ./internal/component/database_observability/postgres/fingerprint/...`
+Expected: FAIL — package has no implementation yet.
+
+- [ ] **Step 3: Implement the fingerprint package**
+
+Create `internal/component/database_observability/postgres/fingerprint/fingerprint.go`:
+
+```go
+// Package fingerprint computes stable, semantic SQL fingerprints for PostgreSQL
+// query text using the libpg_query parser (via pg_query_go).
+//
+// The same fingerprint is produced by Alloy regardless of comments, whitespace,
+// or literal-vs-placeholder differences, allowing pg_stat_statements metrics,
+// pg_stat_activity samples, and server-log query text to be correlated by a
+// single client-side identifier — including on managed services (RDS, Aurora)
+// that do not expose pg_stat_statements.queryid in log_line_prefix.
+package fingerprint
+
+import (
+    "errors"
+    "strings"
+
+    pg_query "github.com/pganalyze/pg_query_go/v6"
+)
+
+// Source describes which PostgreSQL surface the query text was read from.
+// It only affects the sentinel chosen when both parse and repair fail.
+type Source int
+
+const (
+    SourcePgStatStatements Source = iota
+    SourcePgStatActivity
+    SourceLog
+)
+
+// Sentinel strings used when query text cannot be parsed even after repair.
+// These match the sentinels used by pganalyze's collector so existing
+// dashboards built around their values port over without changes.
+const (
+    SentinelTruncated  = "<truncated query>"
+    SentinelUnparsable = "<unparsable query>"
+)
+
+// ErrEmpty is returned when the input is empty or whitespace-only. Callers
+// should skip emitting fingerprints for these (don't even use a sentinel).
+var ErrEmpty = errors.New("fingerprint: empty query text")
+
+// Fingerprint runs the three-stage pipeline:
+//  1. Parse the input as-is.
+//  2. If parsing fails, balance unclosed quotes and parentheses and retry.
+//  3. If parsing still fails, return a sentinel fingerprint.
+//
+// trackActivityQuerySize is the value of the postgres setting
+// `track_activity_query_size` and is only consulted when source ==
+// SourcePgStatActivity. Pass 0 for other sources.
+//
+// The returned `repaired` flag reports whether stage 2 was needed; callers may
+// log this as a metric to detect upstream truncation issues.
+func Fingerprint(query string, source Source, trackActivityQuerySize int) (fp string, repaired bool, err error) {
+    if strings.TrimSpace(query) == "" {
+        return "", false, ErrEmpty
+    }
+
+    if fp, perr := pg_query.Fingerprint(query); perr == nil {
+        return fp, false, nil
+    }
+
+    fixed := repair(query)
+    if fp, perr := pg_query.Fingerprint(fixed); perr == nil {
+        return fp, true, nil
+    }
+
+    return sentinelFingerprint(query, source, trackActivityQuerySize), true, nil
+}
+
+// FingerprintOf hashes a known sentinel string deterministically. Exported so
+// tests and callers can compare against the values produced for sentinels.
+func FingerprintOf(text string) string {
+    fp, _ := pg_query.Fingerprint(text)
+    if fp != "" {
+        return fp
+    }
+    // pg_query.Fingerprint may not parse a non-SQL sentinel; fall back to a
+    // deterministic hash of the text. pg_query.HashXXH3_64 is what pganalyze
+    // uses for static texts (util/fingerprint.go).
+    return formatHash(pg_query.HashXXH3_64([]byte(text), 0xee))
+}
+
+func sentinelFingerprint(query string, source Source, trackActivityQuerySize int) string {
+    if source == SourcePgStatActivity && trackActivityQuerySize > 0 && len(query) == trackActivityQuerySize-1 {
+        return FingerprintOf(SentinelTruncated)
+    }
+    return FingerprintOf(SentinelUnparsable)
+}
+
+// repair closes unclosed single/double quotes and balances unclosed
+// parentheses, mirroring pganalyze's `fixTruncatedQuery`. The repaired text
+// is only used for fingerprint computation — it is not emitted anywhere.
+func repair(query string) string {
+    if strings.Count(query, "'")%2 == 1 {
+        query += "'"
+    }
+    if strings.Count(query, "\"")%2 == 1 {
+        query += "\""
+    }
+    open := strings.Count(query, "(") - strings.Count(query, ")")
+    for i := 0; i < open; i++ {
+        query += ")"
+    }
+    return query
+}
+
+func formatHash(h uint64) string {
+    const hexChars = "0123456789abcdef"
+    out := make([]byte, 16)
+    for i := 15; i >= 0; i-- {
+        out[i] = hexChars[h&0xF]
+        h >>= 4
+    }
+    return string(out)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /home/gaantunes/git/alloy && go test ./internal/component/database_observability/postgres/fingerprint/... -v`
+Expected: PASS for all 7 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/component/database_observability/postgres/fingerprint/
+git commit -m "feat(database_observability/postgres): add semantic query fingerprint package"
+```
+
+---
+
+## Phase 1 — Metrics side: query_hash_info join metric
+
+### Task 3: Implement `QueryHashRegistry`
+
+**Files:**
+- Create: `internal/component/database_observability/postgres/collector/query_hash_registry.go`
+- Create: `internal/component/database_observability/postgres/collector/query_hash_registry_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `query_hash_registry_test.go`:
+
+```go
+package collector
+
+import (
+    "testing"
+    "time"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+func TestQueryHashRegistry_SetAndGet(t *testing.T) {
+    r := NewQueryHashRegistry(100, time.Hour)
+    r.Set("123", "fp_a", "books")
+
+    info, ok := r.Get("123")
+    require.True(t, ok)
+    assert.Equal(t, "fp_a", info.Fingerprint)
+    assert.Equal(t, "books", info.DatabaseName)
+
+    _, ok = r.Get("missing")
+    assert.False(t, ok)
+}
+
+func TestQueryHashRegistry_Snapshot(t *testing.T) {
+    r := NewQueryHashRegistry(100, time.Hour)
+    r.Set("1", "fp_a", "db1")
+    r.Set("2", "fp_b", "db2")
+
+    snap := r.Snapshot()
+    assert.Len(t, snap, 2)
+    assert.Equal(t, "fp_a", snap["1"].Fingerprint)
+    assert.Equal(t, "fp_b", snap["2"].Fingerprint)
+}
+
+func TestQueryHashRegistry_TTLEviction(t *testing.T) {
+    r := NewQueryHashRegistry(100, 50*time.Millisecond)
+    r.Set("1", "fp_a", "db")
+    time.Sleep(80 * time.Millisecond)
+    _, ok := r.Get("1")
+    assert.False(t, ok, "entry should have expired")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/gaantunes/git/alloy && go test ./internal/component/database_observability/postgres/collector/ -run TestQueryHashRegistry`
+Expected: FAIL — `NewQueryHashRegistry` undefined.
+
+- [ ] **Step 3: Implement the registry**
+
+Create `query_hash_registry.go`:
+
+```go
+package collector
+
+import (
+    "sync"
+    "time"
+
+    "github.com/hashicorp/golang-lru/v2/expirable"
+)
+
+// QueryHashInfo holds the per-queryid data the metrics collector needs at
+// scrape time. The fields are intentionally narrow: anything more goes on the
+// emitted Loki entry, not on the join metric (cardinality control).
+type QueryHashInfo struct {
+    Fingerprint  string
+    DatabaseName string
+    LastSeen     time.Time
+}
+
+// QueryHashRegistry is a small LRU+TTL cache mapping the native PostgreSQL
+// queryid (string form) to the semantic fingerprint Alloy computed from that
+// query's text. The query_details collector populates it on each scrape; the
+// query_samples collector and the query_hash_info Prometheus collector read
+// from it.
+//
+// The size cap matches the pg_stat_statements.max default (5000 → 1000 hot
+// entries is plenty for typical fleets); TTL ensures stale queryids don't
+// keep being exported after the database evicts them.
+type QueryHashRegistry struct {
+    mu    sync.RWMutex
+    cache *expirable.LRU[string, QueryHashInfo]
+}
+
+func NewQueryHashRegistry(size int, ttl time.Duration) *QueryHashRegistry {
+    return &QueryHashRegistry{
+        cache: expirable.NewLRU[string, QueryHashInfo](size, nil, ttl),
+    }
+}
+
+func (r *QueryHashRegistry) Set(queryID, fingerprint, databaseName string) {
+    r.mu.Lock()
+    defer r.mu.Unlock()
+    r.cache.Add(queryID, QueryHashInfo{
+        Fingerprint:  fingerprint,
+        DatabaseName: databaseName,
+        LastSeen:     time.Now(),
+    })
+}
+
+func (r *QueryHashRegistry) Get(queryID string) (QueryHashInfo, bool) {
+    r.mu.RLock()
+    defer r.mu.RUnlock()
+    return r.cache.Get(queryID)
+}
+
+// Snapshot returns a shallow copy of all live entries. Used by the metrics
+// collector at scrape time; not on the hot path of any collector.
+func (r *QueryHashRegistry) Snapshot() map[string]QueryHashInfo {
+    r.mu.RLock()
+    defer r.mu.RUnlock()
+
+    out := make(map[string]QueryHashInfo, r.cache.Len())
+    for _, k := range r.cache.Keys() {
+        if v, ok := r.cache.Peek(k); ok {
+            out[k] = v
+        }
+    }
+    return out
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /home/gaantunes/git/alloy && go test ./internal/component/database_observability/postgres/collector/ -run TestQueryHashRegistry -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/component/database_observability/postgres/collector/query_hash_registry.go internal/component/database_observability/postgres/collector/query_hash_registry_test.go
+git commit -m "feat(database_observability/postgres): add QueryHashRegistry"
+```
+
+---
+
+### Task 4: Implement `QueryHashMetricsCollector`
+
+**Files:**
+- Create: `internal/component/database_observability/postgres/collector/query_hash_metrics.go`
+- Create: `internal/component/database_observability/postgres/collector/query_hash_metrics_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `query_hash_metrics_test.go`:
+
+```go
+package collector
+
+import (
+    "strings"
+    "testing"
+    "time"
+
+    "github.com/prometheus/client_golang/prometheus"
+    "github.com/prometheus/client_golang/prometheus/testutil"
+    "github.com/stretchr/testify/require"
+)
+
+func TestQueryHashMetricsCollector_ExposesRegistryAsJoinMetric(t *testing.T) {
+    reg := prometheus.NewRegistry()
+    qhr := NewQueryHashRegistry(100, time.Hour)
+    col := NewQueryHashMetricsCollector(qhr, "server-A")
+    require.NoError(t, reg.Register(col))
+
+    qhr.Set("12345", "fpAAAA", "books_store")
+    qhr.Set("67890", "fpBBBB", "library")
+
+    expected := `
+# HELP database_observability_query_hash_info Mapping of PostgreSQL queryid to semantic query fingerprint
+# TYPE database_observability_query_hash_info gauge
+database_observability_query_hash_info{datname="books_store",query_fingerprint="fpAAAA",queryid="12345",server_id="server-A"} 1
+database_observability_query_hash_info{datname="library",query_fingerprint="fpBBBB",queryid="67890",server_id="server-A"} 1
+`
+
+    require.NoError(t, testutil.GatherAndCompare(
+        reg,
+        strings.NewReader(expected),
+        "database_observability_query_hash_info",
+    ))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/gaantunes/git/alloy && go test ./internal/component/database_observability/postgres/collector/ -run TestQueryHashMetricsCollector`
+Expected: FAIL — `NewQueryHashMetricsCollector` undefined.
+
+- [ ] **Step 3: Implement the collector**
+
+Create `query_hash_metrics.go`:
+
+```go
+package collector
+
+import (
+    "github.com/prometheus/client_golang/prometheus"
+)
+
+// QueryHashMetricsCollector exposes the QueryHashRegistry as a Prometheus
+// "info" gauge metric. The metric is intended to be join-merged into existing
+// pg_stat_statements series via PromQL:
+//
+//   pg_stat_statements_calls_total
+//     * on(queryid, datname) group_left(query_fingerprint)
+//       database_observability_query_hash_info
+//
+// We deliberately keep the fingerprint *off* the existing pg_stat_statements
+// series labels so we don't bump cardinality on every scrape.
+type QueryHashMetricsCollector struct {
+    registry *QueryHashRegistry
+    serverID string
+    desc     *prometheus.Desc
+}
+
+func NewQueryHashMetricsCollector(registry *QueryHashRegistry, serverID string) *QueryHashMetricsCollector {
+    return &QueryHashMetricsCollector{
+        registry: registry,
+        serverID: serverID,
+        desc: prometheus.NewDesc(
+            prometheus.BuildFQName("database_observability", "", "query_hash_info"),
+            "Mapping of PostgreSQL queryid to semantic query fingerprint",
+            []string{"queryid", "query_fingerprint", "server_id", "datname"},
+            nil,
+        ),
+    }
+}
+
+func (c *QueryHashMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
+    ch <- c.desc
+}
+
+func (c *QueryHashMetricsCollector) Collect(ch chan<- prometheus.Metric) {
+    for queryID, info := range c.registry.Snapshot() {
+        ch <- prometheus.MustNewConstMetric(
+            c.desc,
+            prometheus.GaugeValue,
+            1,
+            queryID,
+            info.Fingerprint,
+            c.serverID,
+            info.DatabaseName,
+        )
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd /home/gaantunes/git/alloy && go test ./internal/component/database_observability/postgres/collector/ -run TestQueryHashMetricsCollector -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/component/database_observability/postgres/collector/query_hash_metrics.go internal/component/database_observability/postgres/collector/query_hash_metrics_test.go
+git commit -m "feat(database_observability/postgres): expose query_hash_info join metric"
+```
+
+---
+
+### Task 5: Wire fingerprinting into `query_details` collector
+
+**Files:**
+- Modify: `internal/component/database_observability/postgres/collector/query_details.go`
+- Modify: `internal/component/database_observability/postgres/collector/query_details_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `query_details_test.go` (read the existing file to find the right helper to reuse):
+
+```go
+func TestQueryDetails_PopulatesRegistryAndEmitsFingerprint(t *testing.T) {
+    db, mock, err := sqlmock.New()
+    require.NoError(t, err)
+    defer db.Close()
+
+    mock.ExpectQuery(`pg_stat_statements`).WillReturnRows(
+        sqlmock.NewRows([]string{"queryid", "query", "datname"}).
+            AddRow("9876", "SELECT * FROM books WHERE id = $1", "books_store"),
+    )
+
+    entries := loki_fake.NewClient(func() {})
+    registry := NewQueryHashRegistry(100, time.Hour)
+
+    qd, err := NewQueryDetails(QueryDetailsArguments{
+        DB:                db,
+        CollectInterval:   time.Hour,
+        StatementsLimit:   100,
+        EntryHandler:      entries,
+        QueryHashRegistry: registry,
+        Logger:            log.NewNopLogger(),
+    })
+    require.NoError(t, err)
+
+    require.NoError(t, qd.fetchAndAssociate(context.Background()))
+
+    info, ok := registry.Get("9876")
+    require.True(t, ok)
+    assert.NotEmpty(t, info.Fingerprint)
+    assert.Equal(t, "books_store", info.DatabaseName)
+
+    require.Eventually(t, func() bool { return len(entries.Received()) > 0 }, time.Second, 10*time.Millisecond)
+    line := entries.Received()[0].Line
+    assert.Contains(t, line, `queryid="9876"`)
+    assert.Contains(t, line, `query_fingerprint="`+info.Fingerprint+`"`)
+}
+```
+
+(Use whichever fake-loki helper the file already imports; the existing tests in this package tell you which.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/gaantunes/git/alloy && go test ./internal/component/database_observability/postgres/collector/ -run TestQueryDetails_PopulatesRegistry`
+Expected: FAIL — `QueryHashRegistry` field missing on `QueryDetailsArguments`, line missing fingerprint.
+
+- [ ] **Step 3: Modify `QueryDetailsArguments` and the struct to accept the registry**
+
+In `query_details.go`, add the field to both the args and the struct:
+
+```go
+type QueryDetailsArguments struct {
+    // ...existing fields...
+    QueryHashRegistry *QueryHashRegistry
+    // ...
+}
+
+type QueryDetails struct {
+    // ...existing fields...
+    queryHashRegistry *QueryHashRegistry
+    // ...
+}
+```
+
+Wire it through `NewQueryDetails` (alongside the other fields).
+
+- [ ] **Step 4: Update `fetchAndAssociate` to compute the fingerprint and emit it**
+
+Locate the loop body in `fetchAndAssociate` that builds the `OP_QUERY_ASSOCIATION` log line and replace the relevant block (around `queryText, err = removeComments(...)`) with:
+
+```go
+fp, _, fpErr := fingerprint.Fingerprint(queryText, fingerprint.SourcePgStatStatements, 0)
+if fpErr != nil {
+    level.Debug(c.logger).Log("msg", "skip fingerprint", "queryid", queryID, "err", fpErr)
+}
+
+if fp != "" && c.queryHashRegistry != nil {
+    c.queryHashRegistry.Set(queryID, fp, string(databaseName))
+}
+
+queryText, err = removeComments(c.normalizer, queryText)
+if err != nil {
+    level.Error(c.logger).Log("msg", "failed to remove comments", "err", err)
+    continue
+}
+
+c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
+    logging.LevelInfo,
+    OP_QUERY_ASSOCIATION,
+    fmt.Sprintf(`queryid="%s" query_fingerprint="%s" querytext=%q datname="%s"`,
+        queryID, fp, queryText, databaseName),
+)
+```
+
+Add the import `"github.com/grafana/alloy/internal/component/database_observability/postgres/fingerprint"`.
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd /home/gaantunes/git/alloy && go test ./internal/component/database_observability/postgres/collector/ -run TestQueryDetails -v`
+Expected: PASS for both the new test and the existing `TestQueryDetails_*` cases (you may need to update existing tests' expected log lines to include `query_fingerprint=`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/component/database_observability/postgres/collector/query_details.go internal/component/database_observability/postgres/collector/query_details_test.go
+git commit -m "feat(database_observability/postgres): populate query hash registry from pg_stat_statements"
+```
+
+---
+
+### Task 6: Wire metrics collector into `component.go`
+
+**Files:**
+- Modify: `internal/component/database_observability/postgres/component.go`
+
+- [ ] **Step 1: Add the registry to the component struct**
+
+In `component.go`, add the field to the `Component` struct (next to `dbConnection`):
+
+```go
+queryHashRegistry *collector.QueryHashRegistry
+```
+
+- [ ] **Step 2: Construct the registry and metrics collector during reconnection**
+
+In `connectAndStartCollectors` (just before the `if len(c.args.Targets) == 0 {` block), construct it once per reconnect:
+
+```go
+const queryHashRegistrySize = 5000          // matches pg_stat_statements.max default ceiling
+const queryHashRegistryTTL = 30 * time.Minute
+c.queryHashRegistry = collector.NewQueryHashRegistry(queryHashRegistrySize, queryHashRegistryTTL)
+
+queryHashMetrics := collector.NewQueryHashMetricsCollector(c.queryHashRegistry, generatedSystemID)
+if err := c.registry.Register(queryHashMetrics); err != nil {
+    return fmt.Errorf("failed to register query_hash_info metrics: %w", err)
+}
+c.exporterCollectors = append(c.exporterCollectors, queryHashMetrics)
+```
+
+(`exporterCollectors` is already cleaned up by `cleanupExporterCollectors`; the metrics collector implements `prometheus.Collector` so it fits the slice without changes.)
+
+- [ ] **Step 3: Pass the registry to `query_details`**
+
+In the `if collectors[collector.QueryDetailsCollector] {` block, add `QueryHashRegistry: c.queryHashRegistry,` to the `collector.QueryDetailsArguments{...}` literal.
+
+- [ ] **Step 4: Build and run the existing component tests**
+
+Run: `cd /home/gaantunes/git/alloy && go test ./internal/component/database_observability/postgres/...`
+Expected: All existing tests pass; if `component_test.go` instantiates `Component` directly, you may need to expose a constructor accepting a custom registry (skip if not required).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/component/database_observability/postgres/component.go
+git commit -m "feat(database_observability/postgres): register query_hash_info collector"
+```
+
+---
+
+## Phase 2 — query_samples integration
+
+### Task 7: Fetch `track_activity_query_size` once per reconnect
+
+**Files:**
+- Modify: `internal/component/database_observability/postgres/component.go`
+- Modify: `internal/component/database_observability/postgres/collector/query_samples.go`
+
+- [ ] **Step 1: Pull `track_activity_query_size` during reconnect**
+
+In `connectAndStartCollectors` (right after the `selectServerInfo` query), add:
+
+```go
+var trackActivityQuerySize int
+{
+    var raw sql.NullString
+    if err := dbConnection.QueryRowContext(ctx, "SELECT setting FROM pg_settings WHERE name = 'track_activity_query_size'").Scan(&raw); err != nil {
+        level.Warn(c.opts.Logger).Log("msg", "failed to read track_activity_query_size; truncation sentinel will not fire", "err", err)
+    } else if raw.Valid {
+        if v, err := strconv.Atoi(raw.String); err == nil {
+            trackActivityQuerySize = v
+        }
+    }
+}
+```
+
+(Add `"strconv"` to the imports.) Pass `trackActivityQuerySize` into `collector.QuerySamplesArguments`.
+
+- [ ] **Step 2: Add the field to `QuerySamplesArguments` and the struct**
+
+In `query_samples.go`:
+
+```go
+type QuerySamplesArguments struct {
+    // ...existing...
+    QueryHashRegistry        *QueryHashRegistry
+    TrackActivityQuerySize   int
+}
+
+type QuerySamples struct {
+    // ...existing...
+    queryHashRegistry      *QueryHashRegistry
+    trackActivityQuerySize int
+}
+```
+
+Wire through `NewQuerySamples`.
+
+- [ ] **Step 3: Pass the registry from `component.go`**
+
+In the `if collectors[collector.QuerySamplesCollector] {` block, add:
+```go
+QueryHashRegistry:      c.queryHashRegistry,
+TrackActivityQuerySize: trackActivityQuerySize,
+```
+
+- [ ] **Step 4: Run existing tests**
+
+Run: `cd /home/gaantunes/git/alloy && go test ./internal/component/database_observability/postgres/...`
+Expected: PASS — no behavior change yet, just new args.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/component/database_observability/postgres/component.go internal/component/database_observability/postgres/collector/query_samples.go
+git commit -m "feat(database_observability/postgres): plumb track_activity_query_size to query_samples"
+```
+
+---
+
+### Task 8: Emit `query_fingerprint` on query_sample / wait_event entries
+
+**Files:**
+- Modify: `internal/component/database_observability/postgres/collector/query_samples.go`
+- Modify: `internal/component/database_observability/postgres/collector/query_samples_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+In `query_samples_test.go`, add a new case (or extend an existing assertion) that drives a row through `fetchQuerySample` with `disableQueryRedaction=true` and a known query, then asserts the emitted log line contains `query_fingerprint="..."`. Use the existing test scaffolding for setting up `sqlmock`, the entry handler, and the registry. Compute the expected fingerprint via `fingerprint.Fingerprint`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd /home/gaantunes/git/alloy && go test ./internal/component/database_observability/postgres/collector/ -run TestQuerySamples`
+Expected: FAIL — emitted line does not contain `query_fingerprint=`.
+
+- [ ] **Step 3: Add a fingerprint helper on `QuerySamples`**
+
+In `query_samples.go`, add:
+
+```go
+// resolveQueryFingerprint returns the fingerprint to attach to a sample's
+// emitted Loki entry. Preference order:
+//  1. Registry hit on queryid (computed from un-truncated pg_stat_statements text).
+//  2. Direct fingerprint of the sample's (possibly truncated) query text — only
+//     when query redaction is disabled, since that's the only time we have text.
+// Empty string is returned when neither path is available; callers should
+// simply omit the label.
+func (c *QuerySamples) resolveQueryFingerprint(sample QuerySamplesInfo) string {
+    if c.queryHashRegistry != nil && sample.QueryID.Valid {
+        if info, ok := c.queryHashRegistry.Get(strconv.FormatInt(sample.QueryID.Int64, 10)); ok {
+            return info.Fingerprint
+        }
+    }
+    if c.disableQueryRedaction && sample.Query.Valid {
+        fp, _, err := fingerprint.Fingerprint(
+            sample.Query.String,
+            fingerprint.SourcePgStatActivity,
+            c.trackActivityQuerySize,
+        )
+        if err == nil {
+            return fp
+        }
+    }
+    return ""
+}
+```
+
+Add the imports `"strconv"` and `"github.com/grafana/alloy/internal/component/database_observability/postgres/fingerprint"`.
+
+- [ ] **Step 4: Append `query_fingerprint=` to the three label-builder methods**
+
+For `buildQuerySampleLabelsWithEnd`, `buildWaitEventLabels`, `buildWaitEventV2Labels`:
+- Pass the fingerprint into the function (or read it from a field on `SampleState` set when the active sample is upserted; either is fine — the field approach avoids re-resolving on every wait-event emission).
+- Append `query_fingerprint="<fp>"` to the format string only when non-empty.
+
+For example, in `upsertActiveSample`:
+
+```go
+state.LastRow = sample
+state.LastSeenAt = sample.Now
+if state.QueryFingerprint == "" {
+    state.QueryFingerprint = c.resolveQueryFingerprint(sample)
+}
+```
+
+(Add `QueryFingerprint string` to `SampleState`.)
+
+In each label builder, after the existing format string, do:
+
+```go
+if state.QueryFingerprint != "" {
+    labels = fmt.Sprintf(`%s query_fingerprint="%s"`, labels, state.QueryFingerprint)
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd /home/gaantunes/git/alloy && go test ./internal/component/database_observability/postgres/collector/ -run TestQuerySamples -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/component/database_observability/postgres/collector/query_samples.go internal/component/database_observability/postgres/collector/query_samples_test.go
+git commit -m "feat(database_observability/postgres): emit query_fingerprint on query_sample and wait_event entries"
+```
+
+---
+
+## Phase 3 — Logs integration
+
+### Task 9: Add structured-metadata variant to `BuildLokiEntry`
+
+**Files:**
+- Modify: `internal/component/database_observability/loki_entry.go`
+- Modify: `internal/component/database_observability/loki_entry_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `loki_entry_test.go`:
+
+```go
+func TestBuildLokiEntryWithStructuredMetadata(t *testing.T) {
+    e := BuildLokiEntryWithStructuredMetadata(
+        logging.LevelInfo,
+        "op_test",
+        `key="value"`,
+        push.LabelsAdapter{
+            push.LabelAdapter{Name: "query_fingerprint", Value: "abc123"},
+        },
+    )
+    require.Equal(t, model.LabelValue("op_test"), e.Labels["op"])
+    require.Equal(t, `level="info" key="value"`, e.Line)
+    require.Len(t, e.StructuredMetadata, 1)
+    require.Equal(t, "query_fingerprint", e.StructuredMetadata[0].Name)
+    require.Equal(t, "abc123", e.StructuredMetadata[0].Value)
+}
+```
+
+(Add the necessary imports.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/gaantunes/git/alloy && go test ./internal/component/database_observability/ -run TestBuildLokiEntryWithStructuredMetadata`
+Expected: FAIL — function undefined.
+
+- [ ] **Step 3: Add the variant**
+
+In `loki_entry.go`, add:
+
+```go
+import "github.com/grafana/loki/pkg/push"
+
+func BuildLokiEntryWithStructuredMetadata(level logging.Level, op, line string, metadata push.LabelsAdapter) loki.Entry {
+    e := BuildLokiEntry(level, op, line)
+    e.Entry.StructuredMetadata = metadata
+    return e
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd /home/gaantunes/git/alloy && go test ./internal/component/database_observability/ -run TestBuildLokiEntryWithStructuredMetadata -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/component/database_observability/loki_entry.go internal/component/database_observability/loki_entry_test.go
+git commit -m "feat(database_observability): add BuildLokiEntryWithStructuredMetadata variant"
+```
+
+---
+
+### Task 10: Buffer ERROR + STATEMENT pairs in the logs collector
+
+The current `parseTextLog` skips continuation lines (`STATEMENT:`, `QUERY:`, etc.) entirely. To attach a fingerprint to errors, we need to remember the prior ERROR row and stitch the SQL onto it when the matching `STATEMENT:` line arrives.
+
+**Files:**
+- Modify: `internal/component/database_observability/postgres/collector/logs.go`
+- Modify: `internal/component/database_observability/postgres/collector/logs_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+In `logs_test.go`, add:
+
+```go
+func TestLogs_AttachesQueryFingerprintToError(t *testing.T) {
+    var (
+        receiver  = loki.NewLogsReceiver()
+        emitter   = loki_fake.NewClient(func() {})
+        registry  = prometheus.NewRegistry()
+    )
+    l, err := NewLogs(LogsArguments{
+        Receiver:     receiver,
+        EntryHandler: emitter,
+        Logger:       log.NewNopLogger(),
+        Registry:     registry,
+    })
+    require.NoError(t, err)
+    require.NoError(t, l.Start(context.Background()))
+    t.Cleanup(l.Stop)
+
+    pid := "12345"
+    receiver.Chan() <- loki.NewEntry(model.LabelSet{}, push.Entry{
+        Timestamp: time.Now(),
+        Line:      `2026-04-28 12:00:00.000 UTC:127.0.0.1:user@books_store:[` + pid + `]:1:42P01::1:0:0:c1::ERROR:  relation "missing" does not exist`,
+    })
+    receiver.Chan() <- loki.NewEntry(model.LabelSet{}, push.Entry{
+        Timestamp: time.Now(),
+        Line:      `2026-04-28 12:00:00.000 UTC:127.0.0.1:user@books_store:[` + pid + `]:2:42P01::1:0:0:c1::STATEMENT:  SELECT * FROM missing WHERE id = $1`,
+    })
+
+    require.Eventually(t, func() bool { return len(emitter.Received()) >= 1 }, time.Second, 10*time.Millisecond)
+    e := emitter.Received()[0]
+    var fp string
+    for _, m := range e.StructuredMetadata {
+        if m.Name == "query_fingerprint" {
+            fp = m.Value
+        }
+    }
+    assert.NotEmpty(t, fp, "expected query_fingerprint structured metadata on the error entry")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/gaantunes/git/alloy && go test ./internal/component/database_observability/postgres/collector/ -run TestLogs_AttachesQueryFingerprintToError`
+Expected: FAIL — current logs collector does not emit Loki entries for errors.
+
+- [ ] **Step 3: Add a small in-memory buffer keyed by PID**
+
+In `logs.go`, add to the `Logs` struct:
+
+```go
+pendingErrors map[string]*pendingError
+pendingMu     sync.Mutex
+```
+
+```go
+type pendingError struct {
+    receivedAt time.Time
+    severity   string
+    sqlstate   string
+    database   string
+    user       string
+    timestamp  time.Time
+    // populated when the matching STATEMENT continuation arrives
+    statement  string
+}
+```
+
+Initialize the map in `NewLogs`. Drop pending entries older than 5 seconds in `run` (a ticker, not on the hot path of every line). The existing `parseTextLog` becomes the writer; add a new `processContinuation(line)` for `STATEMENT:` lines.
+
+- [ ] **Step 4: Refactor `parseTextLog`**
+
+When a matching ERROR/FATAL/PANIC line is detected, build the `pendingError` and store it under the line's PID instead of *only* incrementing `pg_errors_total`. Continuation lines starting with `STATEMENT:` look up the pending entry by PID, attach the SQL, and call a new `emitErrorEntry(*pendingError)` that:
+- computes `fp, _, _ := fingerprint.Fingerprint(stmt, fingerprint.SourceLog, 0)`
+- emits a Loki entry via `BuildLokiEntryWithStructuredMetadata` with `op="pg_error"`, line `severity="..." sqlstate="..." datname="..." user="..." statement_preview="..."`, and structured metadata `[{query_fingerprint, fp}]`
+- still increments `pg_errors_total` (now also gains a `query_fingerprint` label — see step 5).
+
+Important: the existing logic that early-returns on continuation lines (`if isContinuationLine(line) { return nil }`) needs to be replaced with a routing call so we don't drop `STATEMENT:` lines.
+
+- [ ] **Step 5: Add `query_fingerprint` to the `pg_errors_total` counter**
+
+In `initMetrics`, change the label list of `errorsBySQLState` from
+`{"severity", "sqlstate", "sqlstate_class", "datname", "user"}`
+to
+`{"severity", "sqlstate", "sqlstate_class", "datname", "user", "query_fingerprint"}`.
+
+In `emitErrorEntry`, increment with the fingerprint included. Pending entries that time out without a STATEMENT continuation (e.g. internal-server errors) are still counted, with `query_fingerprint=""`.
+
+- [ ] **Step 6: Run tests**
+
+Run: `cd /home/gaantunes/git/alloy && go test ./internal/component/database_observability/postgres/collector/ -run TestLogs -v`
+Expected: New test PASSES; existing tests may need their expected label sets updated.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/component/database_observability/postgres/collector/logs.go internal/component/database_observability/postgres/collector/logs_test.go
+git commit -m "feat(database_observability/postgres): emit query_fingerprint on error log entries"
+```
+
+---
+
+### Task 11: Parse slow-query `LOG: duration: ... ms statement: ...` lines
+
+**Files:**
+- Modify: `internal/component/database_observability/postgres/collector/logs.go`
+- Modify: `internal/component/database_observability/postgres/collector/logs_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `logs_test.go`:
+
+```go
+func TestLogs_EmitsSlowQueryWithFingerprint(t *testing.T) {
+    var (
+        receiver = loki.NewLogsReceiver()
+        emitter  = loki_fake.NewClient(func() {})
+        registry = prometheus.NewRegistry()
+    )
+    l, err := NewLogs(LogsArguments{
+        Receiver: receiver, EntryHandler: emitter,
+        Logger: log.NewNopLogger(), Registry: registry,
+    })
+    require.NoError(t, err)
+    require.NoError(t, l.Start(context.Background()))
+    t.Cleanup(l.Stop)
+
+    receiver.Chan() <- loki.NewEntry(model.LabelSet{}, push.Entry{
+        Timestamp: time.Now(),
+        Line:      `2026-04-28 12:00:00.000 UTC:127.0.0.1:user@books_store:[12345]:1:00000::1:0:0:c1::LOG:  duration: 1234.567 ms  statement: SELECT pg_sleep(1)`,
+    })
+
+    require.Eventually(t, func() bool {
+        for _, e := range emitter.Received() {
+            if e.Labels["op"] == "pg_slow_query" {
+                return true
+            }
+        }
+        return false
+    }, time.Second, 10*time.Millisecond)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/gaantunes/git/alloy && go test ./internal/component/database_observability/postgres/collector/ -run TestLogs_EmitsSlowQuery`
+Expected: FAIL.
+
+- [ ] **Step 3: Add slow-query parsing**
+
+In `logs.go`, add a regex anchored to the message-suffix portion of the log line:
+
+```go
+// LOG:  duration: <ms> ms  statement: <sql>
+var slowQueryRegex = regexp.MustCompile(`LOG:\s+duration:\s+([\d.]+)\s+ms\s+statement:\s+(.+)$`)
+```
+
+In `parseTextLog`, after the prefix match but before the ERROR keyword check, run the slow-query regex against the message portion. On match:
+- parse the duration (ms float),
+- compute the fingerprint via `fingerprint.Fingerprint(stmt, fingerprint.SourceLog, 0)`,
+- emit a Loki entry with `op="pg_slow_query"`, line `datname="..." user="..." duration_ms="..." statement_preview="..."`, structured metadata `[{query_fingerprint, fp}]`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd /home/gaantunes/git/alloy && go test ./internal/component/database_observability/postgres/collector/ -run TestLogs -v`
+Expected: PASS for all logs tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/component/database_observability/postgres/collector/logs.go internal/component/database_observability/postgres/collector/logs_test.go
+git commit -m "feat(database_observability/postgres): emit slow-query log entries with fingerprint"
+```
+
+---
+
+## Phase 4 — Documentation and integration
+
+### Task 12: Update component reference docs
+
+**Files:**
+- Modify: `docs/sources/reference/components/database_observability/database_observability.postgres.md`
+
+- [ ] **Step 1: Document the new metric**
+
+In the "Exported metrics" / "Metrics" section, add a row:
+
+```markdown
+| `database_observability_query_hash_info` | gauge | Maps each `pg_stat_statements.queryid` to a stable, version-independent `query_fingerprint` computed by Alloy from the query's parsed AST. Join against any `pg_stat_statements_*` series with `* on(queryid, datname) group_left(query_fingerprint)` to attach the fingerprint without bumping cardinality on the source series. |
+```
+
+List its labels: `queryid`, `query_fingerprint`, `server_id`, `datname`.
+
+- [ ] **Step 2: Document the new structured metadata fields**
+
+Add a "Loki structured metadata" subsection (or extend the existing Loki section) listing:
+- `query_fingerprint` on `op="query_sample"`, `op="wait_event"`, `op="wait_event_v2"`, `op="query_association"`, `op="pg_error"`, and `op="pg_slow_query"` entries.
+- A note that the same fingerprint value appears on the metric side (`query_hash_info`), enabling log↔metric correlation on managed services.
+
+- [ ] **Step 3: Document the new `pg_error` and `pg_slow_query` ops**
+
+If the doc lists Loki ops produced by the component, add the two new ones with sample lines.
+
+- [ ] **Step 4: Run docs lints if any**
+
+Run (if the repo's Makefile defines this): `make docs/lint`
+Expected: PASS, or skip if the target doesn't exist.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/sources/reference/components/database_observability/database_observability.postgres.md
+git commit -m "docs(database_observability/postgres): document query_fingerprint metric and structured metadata"
+```
+
+---
+
+### Task 13: Add a CHANGELOG entry
+
+**Files:**
+- Modify: `CHANGELOG.md` (root)
+
+- [ ] **Step 1: Add an "Unreleased" enhancement entry**
+
+```markdown
+### Enhancements
+
+- (_Public preview_) Add semantic query fingerprinting to `database_observability.postgres`: a new `database_observability_query_hash_info` join metric maps `pg_stat_statements.queryid` to a stable `query_fingerprint`, and the same fingerprint is attached as Loki structured metadata to `query_sample`, `wait_event`, `pg_error`, and `pg_slow_query` entries. This enables log↔metric correlation on managed PostgreSQL (RDS, Aurora) where `queryid` is not available in server logs. (@gaantunes)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): add semantic query fingerprint entry"
+```
+
+---
+
+### Task 14: End-to-end smoke test against a local PostgreSQL
+
+**Files:** none (manual verification step)
+
+- [ ] **Step 1: Bring up a postgres test container with `pg_stat_statements`**
+
+```bash
+docker run --rm -d --name alloy-fp-test \
+  -e POSTGRES_PASSWORD=test \
+  -p 5432:5432 \
+  postgres:18 \
+  -c shared_preload_libraries=pg_stat_statements \
+  -c log_min_duration_statement=0 \
+  -c log_line_prefix='%m:%r:%u@%d:[%p]:%l:%e:%s:%v:%x:%c:%q%a '
+```
+
+Run: `psql "postgres://postgres:test@localhost/postgres" -c "CREATE EXTENSION pg_stat_statements;"`
+Expected: `CREATE EXTENSION`.
+
+- [ ] **Step 2: Generate some traffic with comments**
+
+```bash
+psql "postgres://postgres:test@localhost/postgres" <<'SQL'
+SELECT 1 -- run 1;
+SELECT 1 /* run 2 */;
+SELECT 1;
+SQL
+```
+
+- [ ] **Step 3: Run alloy with a minimal config**
+
+```alloy
+database_observability.postgres "test" {
+  data_source_name = "postgres://postgres:test@localhost:5432/postgres?sslmode=disable"
+  forward_to       = [loki.write.local.receiver]
+}
+loki.write "local" { endpoint { url = "http://localhost:3100/loki/api/v1/push" } }
+```
+
+Run: `./build/alloy run config.alloy`
+Expected: starts up, no panic on the CGo path.
+
+- [ ] **Step 4: Curl the metrics endpoint**
+
+```bash
+curl -s http://127.0.0.1:12345/api/v0/component/database_observability.postgres.test/metrics | grep query_hash_info
+```
+
+Expected: One `database_observability_query_hash_info{...} 1` line per logical query — note the three `SELECT 1` variants must collapse to a single fingerprint value.
+
+- [ ] **Step 5: Tear down**
+
+```bash
+docker rm -f alloy-fp-test
+```
+
+No commit for this task — it's verification only.
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+- ✅ Problem 1 (non-uniqueness): Tasks 2, 5 — pg_query AST collapses comment/whitespace/literal differences.
+- ✅ Problem 2 (version instability): Task 4 — `query_fingerprint` is computed by Alloy and is independent of the PG-version-specific `queryid`.
+- ✅ Problem 3 (log↔metric correlation): Tasks 10, 11 — fingerprint emitted as structured metadata on log entries that carry SQL text; same value on the `query_hash_info` join metric.
+- ✅ Truncation/unparsable handling: Task 2 implements both sentinels; Task 7 plumbs `track_activity_query_size` so the truncation sentinel can fire.
+- ✅ Recommendation (Option 1 + Option B, additive): Tasks 4, 6 keep `queryid` intact and add a new join metric; existing dashboards keep working.
+
+**Placeholder scan:** No "TBD", "implement later", or "appropriate error handling" placeholders. All steps include either exact code or exact commands.
+
+**Type consistency:**
+- `QueryHashRegistry`, `QueryHashInfo`, `QueryHashMetricsCollector`, `QueryHashRegistry.Set/Get/Snapshot` are referenced consistently in tasks 3, 4, 5, 6, 8.
+- `fingerprint.Fingerprint(text, source, trackSize) (string, bool, error)` and `fingerprint.SourcePgStatStatements/PgStatActivity/Log` are used consistently in tasks 2, 5, 8, 10, 11.
+- `BuildLokiEntryWithStructuredMetadata(level, op, line, metadata)` is defined in task 9 and used in tasks 10, 11.
+- The metric name `database_observability_query_hash_info` and label names `queryid, query_fingerprint, server_id, datname` are stable across tasks 4, 6, 12.
+
+**Open follow-ups (out of scope of this plan):**
+- Migrating `grafana-dbo11y-app` PromQL/LogQL to consume `query_fingerprint`.
+- Eventual deprecation of native `queryid` (Option A) once the app migration completes.
+- Adding the same fingerprint pipeline to `database_observability.mysql` (would need a different parser; design doc only covers PostgreSQL).

--- a/docs/superpowers/specs/2026-04-15-wait-event-v2-design.md
+++ b/docs/superpowers/specs/2026-04-15-wait-event-v2-design.md
@@ -1,0 +1,183 @@
+# Design: wait_event v2 — Pre-Classified Wait Events + Prometheus Counter
+
+**Date:** 2026-04-15
+**Branch:** gaantunes/structured-metadata-poc (PR #5518)
+**Status:** Approved
+
+---
+
+## Background
+
+PR #5518 introduced an experiment with multiple parallel wait event op versions (v1–v6) to benchmark
+structured metadata and pre-classification strategies for `wait_event_type`. Benchmarking concluded:
+
+- **v4** (pre-classified `wait_event_type` in log body, no structured metadata) delivers −83 to −90%
+  p95 improvement on WaitEventsPanel duration by eliminating the Loki 500-series fallback retry loop.
+- All SM-based versions (v2, v3, v5) introduce 25× cardinality increases that negate their benefits
+  at wide unfiltered windows.
+- **v6** is superseded by v4 for this scope.
+- A Prometheus counter benchmarked externally shows −52 to −65% p50 on TotalWaitEventsTime at
+  windows ≥1h30 unfiltered, by bypassing Loki series limits entirely.
+
+This design formalises the outcome: adopt v4 as the production "v2", remove all other experiment
+versions, and implement the Prometheus counter for MySQL.
+
+---
+
+## Goals
+
+1. Rename the v4 op to `wait_event_v2` and make it the single alternative to v1.
+2. Enforce mutual exclusion: when v2 is enabled, v1 is not emitted.
+3. Clean up all intermediate experiment ops (old v2, v3, v5, v6) from both MySQL and Postgres.
+4. Rename the feature flag from `enable_structured_metadata` to `enable_pre_classified_wait_events`.
+5. Implement `database_observability_wait_event_seconds_total` Prometheus counter in MySQL only.
+
+---
+
+## Non-Goals
+
+- No changes to query_association, query_sample, or any other op type.
+- No structured metadata usage in the new v2.
+- No Prometheus counter for Postgres.
+- No changes to the Grafana app queries (handled separately as a follow-up).
+
+---
+
+## Design
+
+### 1. Flag Rename
+
+**Files:** `mysql/component.go`, `postgres/component.go`, and both `collector/query_samples.go`
+
+`enable_structured_metadata` → `enable_pre_classified_wait_events` everywhere:
+
+```go
+// Arguments struct (both components)
+EnablePreClassifiedWaitEvents bool `alloy:"enable_pre_classified_wait_events,attr,optional"`
+
+// QuerySamples args/struct
+EnablePreClassifiedWaitEvents bool
+enablePreClassifiedWaitEvents bool
+```
+
+The Alloy config attribute name changes accordingly. Users who had `enable_structured_metadata = true`
+will need to update their config to `enable_pre_classified_wait_events = true`.
+
+---
+
+### 2. Op Cleanup and Rename
+
+**Constants (both MySQL and Postgres `query_samples.go`):**
+
+Remove:
+- `OP_WAIT_EVENT_V2` (`"wait_event_v2"` — old SM version)
+- `OP_WAIT_EVENT_V3` (`"wait_event_v3"`)
+- `OP_WAIT_EVENT_V5` (`"wait_event_v5"`)
+- `OP_WAIT_EVENT_V6` (`"wait_event_v6"`)
+
+Rename:
+- `OP_WAIT_EVENT_V4` → `OP_WAIT_EVENT_V2` with string `"wait_event_v2"`
+
+**Log message format for new v2** (unchanged from v4 — includes `wait_event_type` pre-classified
+in the log body):
+
+MySQL:
+```
+schema="%s" user="%s" client_host="%s" thread_id="%s" digest="%s" event_id="%s"
+wait_event_id="%s" wait_end_event_id="%s" wait_event_name="%s" wait_event_type="%s"
+wait_object_name="%s" wait_object_type="%s" wait_time="%fms"
+```
+
+Postgres:
+```
+datname="%s" pid="%d" leader_pid="%s" user="%s" backend_type="%s" state="%s"
+xid="%d" xmin="%d" wait_time="%s" wait_event="%s" wait_event_name="%s"
+wait_event_type="%s" blocked_by_pids="%v" queryid="%d"
+```
+
+Also remove all helper functions that only served removed ops:
+- `classifyMySQLWaitEventType` — keep (used by new v2)
+- `classifyPostgresWaitEventType` — keep (used by new v2)
+- `buildWaitEventV3Labels`, `buildWaitEventV5Labels`, etc. — remove
+
+---
+
+### 3. Mutual Exclusion
+
+Emission logic in both MySQL and Postgres `fetchQuerySamples` / `emitAndDeleteSample`:
+
+```go
+if c.enablePreClassifiedWaitEvents {
+    // emit wait_event_v2 (pre-classified wait_event_type in log body)
+} else {
+    // emit wait_event (v1 baseline)
+}
+```
+
+v1 and v2 are never emitted in the same run. No other emission paths change.
+
+---
+
+### 4. Prometheus Counter (MySQL only)
+
+**Metric definition:**
+
+```go
+waitEventSecondsTotal = prometheus.NewCounterVec(
+    prometheus.CounterOpts{
+        Name: "database_observability_wait_event_seconds_total",
+        Help: "Total wait time in seconds per query, aggregated by server, query digest, and database.",
+    },
+    []string{"server_id", "queryid", "dbname"},
+)
+```
+
+**Labels:**
+- `server_id` — from the component's target label
+- `queryid` — MySQL `digest` value
+- `dbname` — MySQL `schema` value
+
+**Registration:** at MySQL component startup, registered into the existing `c.registry`
+(`prometheus.NewRegistry()` already present in `mysql/component.go`).
+
+**Passing to collector:** add `WaitEventCounter *prometheus.CounterVec` to `QuerySamplesArguments`
+in `mysql/component.go`. The component creates, registers, and passes the counter down. The
+`QuerySamples` struct holds a reference.
+
+**Increment:** in the wait event emit loop in `mysql/collector/query_samples.go`, unconditionally
+(regardless of v1/v2 flag), after processing each wait event row:
+
+```go
+if c.waitEventCounter != nil {
+    waitTimeSeconds := waitTime / 1000.0 // waitTime is in ms (from picosecondsToMilliseconds)
+    c.waitEventCounter.WithLabelValues(c.serverID, row.Digest.String, row.Schema.String).Add(waitTimeSeconds)
+}
+```
+
+The counter accumulates independently of which Loki op is being emitted. Postgres does not receive
+this counter.
+
+---
+
+## File Changelist
+
+| File | Change |
+|---|---|
+| `mysql/component.go` | Rename flag; create + register counter; pass to QuerySamples |
+| `mysql/collector/query_samples.go` | Rename flag + op; remove old v2/v3/v5/v6 blocks; mutual exclusion; increment counter |
+| `mysql/collector/query_samples_test.go` | Update tests for renamed flag/op; remove old version tests; add counter tests |
+| `postgres/component.go` | Rename flag only |
+| `postgres/collector/query_samples.go` | Rename flag + op; remove old v2/v3/v5/v6 blocks; mutual exclusion |
+| `postgres/collector/query_samples_test.go` | Update tests for renamed flag/op; remove old version tests |
+| `docs/sources/reference/components/database_observability/database_observability.mysql.md` | Update flag name and description |
+| `docs/sources/reference/components/database_observability/database_observability.postgres.md` | Update flag name and description |
+
+---
+
+## Test Plan
+
+- `TestQuerySamples_WaitEvents` (MySQL + Postgres): assert that with flag OFF only `wait_event` is
+  emitted; with flag ON only `wait_event_v2` is emitted; never both.
+- `TestWaitEventCounter` (MySQL): assert counter increments with correct `server_id`, `queryid`,
+  `dbname` labels and correct seconds value; assert it increments regardless of v1/v2 flag state.
+- Remove all test assertions for old v2/v3/v5/v6 ops.

--- a/docs/superpowers/specs/2026-04-15-wait-event-v2-design.md
+++ b/docs/superpowers/specs/2026-04-15-wait-event-v2-design.md
@@ -128,14 +128,14 @@ waitEventSecondsTotal = prometheus.NewCounterVec(
         Name: "database_observability_wait_event_seconds_total",
         Help: "Total wait time in seconds per query, aggregated by server, query digest, and database.",
     },
-    []string{"server_id", "queryid", "dbname"},
+    []string{"server_id", "digest", "schema"},
 )
 ```
 
 **Labels:**
 - `server_id` — from the component's target label
-- `queryid` — MySQL `digest` value
-- `dbname` — MySQL `schema` value
+- `digest` — MySQL `digest` value
+- `schema` — MySQL `schema` value
 
 **Registration:** at MySQL component startup, registered into the existing `c.registry`
 (`prometheus.NewRegistry()` already present in `mysql/component.go`).
@@ -150,7 +150,7 @@ in `mysql/component.go`. The component creates, registers, and passes the counte
 ```go
 if c.waitEventCounter != nil {
     waitTimeSeconds := waitTime / 1000.0 // waitTime is in ms (from picosecondsToMilliseconds)
-    c.waitEventCounter.WithLabelValues(c.serverID, row.Digest.String, row.Schema.String).Add(waitTimeSeconds)
+    c.waitEventCounter.WithLabelValues(c.serverID, row.Digest.String, row.Schema.String).Add(waitTimeSeconds) // labels: server_id, digest, schema
 }
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -182,6 +182,7 @@ require (
 	github.com/oschwald/geoip2-golang v1.13.0
 	github.com/oschwald/maxminddb-golang v1.13.1
 	github.com/percona/mongodb_exporter v0.47.2
+	github.com/pganalyze/pg_query_go/v6 v6.1.0
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/pingcap/tidb/pkg/parser v0.0.0-20250501143621-a50a2323f4ba
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -2099,6 +2099,8 @@ github.com/percona/percona-backup-mongodb v1.8.1-0.20250429102026-063dab6cc946 h
 github.com/percona/percona-backup-mongodb v1.8.1-0.20250429102026-063dab6cc946/go.mod h1:gB/bHx955pIDTTXo/4fPJZxo3YuK+840lfKqDDYo8AE=
 github.com/peterbourgon/ff/v3 v3.4.0 h1:QBvM/rizZM1cB0p0lGMdmR7HxZeI/ZrBWB4DqLkMUBc=
 github.com/peterbourgon/ff/v3 v3.4.0/go.mod h1:zjJVUhx+twciwfDl0zBcFzl4dW8axCRyXE/eKY9RztQ=
+github.com/pganalyze/pg_query_go/v6 v6.1.0 h1:jG5ZLhcVgL1FAw4C/0VNQaVmX1SUJx71wBGdtTtBvls=
+github.com/pganalyze/pg_query_go/v6 v6.1.0/go.mod h1:nvTHIuoud6e1SfrUaFwHqT0i4b5Nr+1rPWVds3B5+50=
 github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5 h1:Ii+DKncOVM8Cu1Hc+ETb5K+23HdAMvESYE3ZJ5b5cMI=
 github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/philhofer/fwd v1.2.0 h1:e6DnBTl7vGY+Gz322/ASL4Gyp1FspeMvx1RNDoToZuM=
@@ -3341,6 +3343,7 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=

--- a/internal/component/database_observability/loki_entry.go
+++ b/internal/component/database_observability/loki_entry.go
@@ -30,3 +30,9 @@ func BuildLokiEntryWithStructuredMetadata(level logging.Level, op, line string, 
 	e.Entry.StructuredMetadata = metadata
 	return e
 }
+
+func BuildLokiEntryWithTimestampAndStructuredMetadata(level logging.Level, op, line string, timestamp int64, metadata push.LabelsAdapter) loki.Entry {
+	e := BuildLokiEntryWithTimestamp(level, op, line, timestamp)
+	e.Entry.StructuredMetadata = metadata
+	return e
+}

--- a/internal/component/database_observability/loki_entry.go
+++ b/internal/component/database_observability/loki_entry.go
@@ -24,3 +24,9 @@ func BuildLokiEntryWithTimestamp(level logging.Level, op, line string, timestamp
 func BuildLokiEntry(level logging.Level, op, line string) loki.Entry {
 	return BuildLokiEntryWithTimestamp(level, op, line, time.Now().UnixNano())
 }
+
+func BuildLokiEntryWithStructuredMetadata(level logging.Level, op, line string, metadata push.LabelsAdapter) loki.Entry {
+	e := BuildLokiEntry(level, op, line)
+	e.Entry.StructuredMetadata = metadata
+	return e
+}

--- a/internal/component/database_observability/loki_entry_test.go
+++ b/internal/component/database_observability/loki_entry_test.go
@@ -4,9 +4,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alloy/internal/runtime/logging"
+	"github.com/grafana/loki/pkg/push"
 )
 
 func TestBuildLokiEntry(t *testing.T) {
@@ -22,4 +24,20 @@ func TestBuildLokiEntryWithTimestamp(t *testing.T) {
 
 	require.Equal(t, int64(5), entry.Entry.Timestamp.UnixNano())
 	require.Equal(t, time.Unix(0, 5), entry.Entry.Timestamp)
+}
+
+func TestBuildLokiEntryWithStructuredMetadata(t *testing.T) {
+	e := BuildLokiEntryWithStructuredMetadata(
+		logging.LevelInfo,
+		"op_test",
+		`key="value"`,
+		push.LabelsAdapter{
+			push.LabelAdapter{Name: "query_fingerprint", Value: "abc123"},
+		},
+	)
+	require.Equal(t, model.LabelValue("op_test"), e.Labels["op"])
+	require.Equal(t, `level="info" key="value"`, e.Line)
+	require.Len(t, e.StructuredMetadata, 1)
+	require.Equal(t, "query_fingerprint", e.StructuredMetadata[0].Name)
+	require.Equal(t, "abc123", e.StructuredMetadata[0].Value)
 }

--- a/internal/component/database_observability/loki_entry_test.go
+++ b/internal/component/database_observability/loki_entry_test.go
@@ -41,3 +41,20 @@ func TestBuildLokiEntryWithStructuredMetadata(t *testing.T) {
 	require.Equal(t, "query_fingerprint", e.StructuredMetadata[0].Name)
 	require.Equal(t, "abc123", e.StructuredMetadata[0].Value)
 }
+
+func TestBuildLokiEntryWithTimestampAndStructuredMetadata(t *testing.T) {
+	e := BuildLokiEntryWithTimestampAndStructuredMetadata(
+		logging.LevelInfo,
+		"op_test",
+		`key="value"`,
+		42,
+		push.LabelsAdapter{
+			push.LabelAdapter{Name: "query_fingerprint", Value: "abc123"},
+		},
+	)
+	require.Equal(t, model.LabelValue("op_test"), e.Labels["op"])
+	require.Equal(t, `level="info" key="value"`, e.Line)
+	require.Equal(t, int64(42), e.Entry.Timestamp.UnixNano())
+	require.Len(t, e.StructuredMetadata, 1)
+	require.Equal(t, "abc123", e.StructuredMetadata[0].Value)
+}

--- a/internal/component/database_observability/postgres/collector/logs.go
+++ b/internal/component/database_observability/postgres/collector/logs.go
@@ -10,17 +10,38 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/loki/pkg/push"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/atomic"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/component/database_observability"
+	"github.com/grafana/alloy/internal/component/database_observability/postgres/fingerprint"
+	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
 )
 
 const (
 	LogsCollector         = "logs"
+	OP_PG_ERROR           = "pg_error"
 	expectedLogLinePrefix = "%m:%r:%u@%d:[%p]:%l:%e:%s:%v:%x:%c:%q%a"
+
+	defaultPendingErrorTimeout = 5 * time.Second
 )
+
+// pendingError buffers an ERROR/FATAL/PANIC log line until either its
+// matching STATEMENT continuation arrives (allowing us to attach a SQL
+// fingerprint) or pendingErrorTimeout elapses (we emit with an empty
+// fingerprint). PostgreSQL emits the continuation immediately after the
+// corresponding error from the same backend.
+type pendingError struct {
+	receivedAt time.Time
+	severity   string
+	sqlstate   string
+	datname    string
+	user       string
+	timestamp  time.Time
+}
 
 // Postgres log format regex
 var logFormatRegex = regexp.MustCompile(
@@ -69,6 +90,10 @@ type Logs struct {
 	validLogsThisMinute   int
 	invalidLogsThisMinute int
 
+	pendingErrors       map[string]*pendingError
+	pendingMu           sync.Mutex
+	pendingErrorTimeout time.Duration
+
 	startTime time.Time
 }
 
@@ -76,16 +101,18 @@ func NewLogs(args LogsArguments) (*Logs, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	l := &Logs{
-		logger:           log.With(args.Logger, "collector", LogsCollector),
-		entryHandler:     args.EntryHandler,
-		registry:         args.Registry,
-		receiver:         args.Receiver,
-		excludeDatabases: args.ExcludeDatabases,
-		excludeUsers:     args.ExcludeUsers,
-		ctx:              ctx,
-		cancel:           cancel,
-		stopped:          atomic.NewBool(false),
-		startTime:        time.Now(),
+		logger:              log.With(args.Logger, "collector", LogsCollector),
+		entryHandler:        args.EntryHandler,
+		registry:            args.Registry,
+		receiver:            args.Receiver,
+		excludeDatabases:    args.ExcludeDatabases,
+		excludeUsers:        args.ExcludeUsers,
+		ctx:                 ctx,
+		cancel:              cancel,
+		stopped:             atomic.NewBool(false),
+		startTime:           time.Now(),
+		pendingErrors:       make(map[string]*pendingError),
+		pendingErrorTimeout: defaultPendingErrorTimeout,
 	}
 
 	l.initMetrics()
@@ -94,6 +121,10 @@ func NewLogs(args LogsArguments) (*Logs, error) {
 }
 
 func (l *Logs) initMetrics() {
+	// Note: query_fingerprint deliberately is NOT a label here — fingerprints can
+	// be highly cardinal and we surface them on the emitted Loki entry's
+	// structured metadata instead. Joining metrics+logs by fingerprint goes
+	// through the database_observability_query_hash_info join metric.
 	l.errorsBySQLState = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "database_observability",
@@ -139,6 +170,16 @@ func (l *Logs) Stop() {
 	l.stopped.Store(true)
 	l.wg.Wait()
 
+	// Drain any pending errors that never received a STATEMENT continuation.
+	// Force-flush by treating every remaining entry as expired.
+	l.pendingMu.Lock()
+	remaining := l.pendingErrors
+	l.pendingErrors = make(map[string]*pendingError)
+	l.pendingMu.Unlock()
+	for _, p := range remaining {
+		l.emitErrorEntry(p, "", "")
+	}
+
 	l.registry.Unregister(l.errorsBySQLState)
 	l.registry.Unregister(l.parseErrors)
 }
@@ -149,6 +190,15 @@ func (l *Logs) Stopped() bool {
 
 func (l *Logs) run() {
 	level.Debug(l.logger).Log("msg", "collector running, waiting for log entries")
+
+	// Ticker fires at least twice per pendingErrorTimeout window so a
+	// pending entry is emitted within at most one extra tick after expiry.
+	tickPeriod := l.pendingErrorTimeout / 2
+	if tickPeriod < 50*time.Millisecond {
+		tickPeriod = 50 * time.Millisecond
+	}
+	timeoutTicker := time.NewTicker(tickPeriod)
+	defer timeoutTicker.Stop()
 
 	for {
 		select {
@@ -163,6 +213,8 @@ func (l *Logs) run() {
 					"line_preview", truncateString(entry.Entry.Line, 100),
 				)
 			}
+		case <-timeoutTicker.C:
+			l.flushExpiredPending()
 		}
 	}
 }
@@ -171,6 +223,7 @@ func (l *Logs) parseTextLog(entry loki.Entry) error {
 	line := entry.Entry.Line
 
 	if isContinuationLine(line) {
+		l.processContinuation(line)
 		return nil
 	}
 
@@ -266,7 +319,105 @@ func (l *Logs) parseTextLog(entry loki.Entry) error {
 		user,
 	).Inc()
 
+	// Buffer the error so the matching STATEMENT continuation can attach SQL
+	// text (and thus a query_fingerprint) before we emit a Loki entry.
+	pidStart := strings.Index(afterAt, "[")
+	pidEnd := strings.Index(afterAt, "]")
+	pid := ""
+	if pidStart != -1 && pidEnd > pidStart {
+		pid = afterAt[pidStart+1 : pidEnd]
+	}
+
+	l.pendingMu.Lock()
+	l.pendingErrors[pid] = &pendingError{
+		receivedAt: time.Now(),
+		severity:   severity,
+		sqlstate:   sqlstateCode,
+		datname:    database,
+		user:       user,
+		timestamp:  entry.Entry.Timestamp,
+	}
+	l.pendingMu.Unlock()
+
 	return nil
+}
+
+// processContinuation handles a continuation line. Today only STATEMENT:
+// continuations are interesting — they carry the SQL text that produced the
+// preceding error. PostgreSQL emits the continuation immediately after the
+// corresponding error from the same backend; the continuation does NOT carry
+// log_line_prefix metadata, so we cannot match it by PID. Instead we attach
+// to the most recently buffered pending error, which works because logs from
+// a single connection are serialized by PostgreSQL.
+func (l *Logs) processContinuation(line string) {
+	trimmed := strings.TrimSpace(line)
+	if !strings.HasPrefix(trimmed, "STATEMENT:") {
+		return
+	}
+	stmt := strings.TrimSpace(strings.TrimPrefix(trimmed, "STATEMENT:"))
+
+	l.pendingMu.Lock()
+	var bestPID string
+	var bestEntry *pendingError
+	for pid, p := range l.pendingErrors {
+		if bestEntry == nil || p.receivedAt.After(bestEntry.receivedAt) {
+			bestPID = pid
+			bestEntry = p
+		}
+	}
+	if bestEntry != nil {
+		delete(l.pendingErrors, bestPID)
+	}
+	l.pendingMu.Unlock()
+
+	if bestEntry == nil {
+		return
+	}
+
+	fp, _, _ := fingerprint.Fingerprint(stmt, fingerprint.SourceLog, 0)
+	l.emitErrorEntry(bestEntry, stmt, fp)
+}
+
+// flushExpiredPending emits Loki entries for any pending errors older than
+// pendingErrorTimeout that never had their STATEMENT continuation arrive.
+// They emit with an empty fingerprint.
+func (l *Logs) flushExpiredPending() {
+	deadline := time.Now().Add(-l.pendingErrorTimeout)
+	l.pendingMu.Lock()
+	expired := make(map[string]*pendingError)
+	for pid, p := range l.pendingErrors {
+		if p.receivedAt.Before(deadline) {
+			expired[pid] = p
+			delete(l.pendingErrors, pid)
+		}
+	}
+	l.pendingMu.Unlock()
+
+	for _, p := range expired {
+		l.emitErrorEntry(p, "", "")
+	}
+}
+
+func (l *Logs) emitErrorEntry(p *pendingError, statement, fp string) {
+	sqlstateClass := ""
+	if len(p.sqlstate) >= 2 {
+		sqlstateClass = p.sqlstate[:2]
+	}
+	statementPreview := truncateString(statement, 200)
+
+	line := fmt.Sprintf(
+		`severity=%q sqlstate=%q sqlstate_class=%q datname=%q user=%q statement_preview=%q`,
+		p.severity, p.sqlstate, sqlstateClass, p.datname, p.user, statementPreview,
+	)
+
+	l.entryHandler.Chan() <- database_observability.BuildLokiEntryWithStructuredMetadata(
+		logging.LevelError,
+		OP_PG_ERROR,
+		line,
+		push.LabelsAdapter{
+			push.LabelAdapter{Name: "query_fingerprint", Value: fp},
+		},
+	)
 }
 
 // isContinuationLine checks if a line is part of a multi-line PostgreSQL error

--- a/internal/component/database_observability/postgres/collector/logs.go
+++ b/internal/component/database_observability/postgres/collector/logs.go
@@ -24,6 +24,7 @@ import (
 const (
 	LogsCollector         = "logs"
 	OP_PG_ERROR           = "pg_error"
+	OP_PG_SLOW_QUERY      = "pg_slow_query"
 	expectedLogLinePrefix = "%m:%r:%u@%d:[%p]:%l:%e:%s:%v:%x:%c:%q%a"
 
 	defaultPendingErrorTimeout = 5 * time.Second
@@ -42,6 +43,10 @@ type pendingError struct {
 	user       string
 	timestamp  time.Time
 }
+
+// slowQueryRegex matches the slow-query log line shape emitted by PostgreSQL at LOG severity:
+// LOG:  duration: <ms> ms  statement: <sql>
+var slowQueryRegex = regexp.MustCompile(`LOG:\s+duration:\s+([\d.]+)\s+ms\s+statement:\s+(.+)$`)
 
 // Postgres log format regex
 var logFormatRegex = regexp.MustCompile(
@@ -224,6 +229,31 @@ func (l *Logs) parseTextLog(entry loki.Entry) error {
 
 	if isContinuationLine(line) {
 		l.processContinuation(line)
+		return nil
+	}
+
+	// Slow-query handling: PostgreSQL emits these at LOG severity, so they're
+	// dropped by the ERROR/FATAL/PANIC severity filter below. Match the
+	// "LOG: duration: ... statement: ..." pattern first; if it matches, emit
+	// a pg_slow_query Loki entry and return.
+	if m := slowQueryRegex.FindStringSubmatch(line); m != nil {
+		if !logFormatRegex.MatchString(line) {
+			// Not in our expected prefix format; skip without complaining (the
+			// counter for invalid format is for ERROR-class lines).
+			return nil
+		}
+		// Historical-log filter (same as the ERROR path).
+		if !l.afterStartTime(line) {
+			return nil
+		}
+		datname, user := extractDatnameAndUser(line)
+		if slices.Contains(l.excludeDatabases, datname) || slices.Contains(l.excludeUsers, user) {
+			return nil
+		}
+		durationMs := m[1]
+		stmt := strings.TrimSpace(m[2])
+		fp, _, _ := fingerprint.Fingerprint(stmt, fingerprint.SourceLog, 0)
+		l.emitSlowQueryEntry(datname, user, durationMs, stmt, fp)
 		return nil
 	}
 
@@ -413,6 +443,69 @@ func (l *Logs) emitErrorEntry(p *pendingError, statement, fp string) {
 	l.entryHandler.Chan() <- database_observability.BuildLokiEntryWithStructuredMetadata(
 		logging.LevelError,
 		OP_PG_ERROR,
+		line,
+		push.LabelsAdapter{
+			push.LabelAdapter{Name: "query_fingerprint", Value: fp},
+		},
+	)
+}
+
+// extractDatnameAndUser parses the log_line_prefix portion to pull out the
+// "%u@%d:" segment. Returns ("", "") if the format doesn't match.
+func extractDatnameAndUser(line string) (datname, user string) {
+	atIdx := strings.Index(line, "@")
+	if atIdx == -1 {
+		return "", ""
+	}
+	afterAt := line[atIdx+1:]
+	pidMarkerIdx := strings.Index(afterAt, ":[")
+	if pidMarkerIdx == -1 {
+		return "", ""
+	}
+	datname = strings.TrimSpace(afterAt[:pidMarkerIdx])
+
+	beforeAt := line[:atIdx]
+	lastColonBeforeAt := strings.LastIndex(beforeAt, ":")
+	if lastColonBeforeAt == -1 {
+		return datname, ""
+	}
+	user = strings.TrimSpace(beforeAt[lastColonBeforeAt+1:])
+	return datname, user
+}
+
+// afterStartTime returns true if the line's parsed timestamp is after the
+// collector's start time, so historical logs are skipped.
+func (l *Logs) afterStartTime(line string) bool {
+	if len(line) <= 30 {
+		return true
+	}
+	colonIdx := strings.Index(line[20:], ":")
+	if colonIdx <= 0 {
+		return true
+	}
+	timestampStr := strings.TrimSpace(line[:20+colonIdx])
+	for _, layout := range []string{
+		"2006-01-02 15:04:05.000 MST",
+		"2006-01-02 15:04:05.000 -07",
+		"2006-01-02 15:04:05 MST",
+		"2006-01-02 15:04:05 -07",
+	} {
+		if logTimestamp, err := time.Parse(layout, timestampStr); err == nil {
+			return logTimestamp.After(l.startTime)
+		}
+	}
+	return true
+}
+
+func (l *Logs) emitSlowQueryEntry(datname, user, durationMs, statement, fp string) {
+	statementPreview := truncateString(statement, 200)
+	line := fmt.Sprintf(
+		`datname=%q user=%q duration_ms=%q statement_preview=%q`,
+		datname, user, durationMs, statementPreview,
+	)
+	l.entryHandler.Chan() <- database_observability.BuildLokiEntryWithStructuredMetadata(
+		logging.LevelInfo,
+		OP_PG_SLOW_QUERY,
 		line,
 		push.LabelsAdapter{
 			push.LabelAdapter{Name: "query_fingerprint", Value: fp},

--- a/internal/component/database_observability/postgres/collector/logs.go
+++ b/internal/component/database_observability/postgres/collector/logs.go
@@ -253,7 +253,7 @@ func (l *Logs) parseTextLog(entry loki.Entry) error {
 		durationMs := m[1]
 		stmt := strings.TrimSpace(m[2])
 		fp, _, _ := fingerprint.Fingerprint(stmt, fingerprint.SourceLog, 0)
-		l.emitSlowQueryEntry(datname, user, durationMs, stmt, fp)
+		l.emitSlowQueryEntry(entry.Entry.Timestamp, datname, user, durationMs, stmt, fp)
 		return nil
 	}
 
@@ -440,10 +440,16 @@ func (l *Logs) emitErrorEntry(p *pendingError, statement, fp string) {
 		p.severity, p.sqlstate, sqlstateClass, p.datname, p.user, statementPreview,
 	)
 
-	l.entryHandler.Chan() <- database_observability.BuildLokiEntryWithStructuredMetadata(
+	ts := p.timestamp.UnixNano()
+	if p.timestamp.IsZero() {
+		ts = time.Now().UnixNano()
+	}
+
+	l.entryHandler.Chan() <- database_observability.BuildLokiEntryWithTimestampAndStructuredMetadata(
 		logging.LevelError,
 		OP_PG_ERROR,
 		line,
+		ts,
 		push.LabelsAdapter{
 			push.LabelAdapter{Name: "query_fingerprint", Value: fp},
 		},
@@ -497,16 +503,21 @@ func (l *Logs) afterStartTime(line string) bool {
 	return true
 }
 
-func (l *Logs) emitSlowQueryEntry(datname, user, durationMs, statement, fp string) {
+func (l *Logs) emitSlowQueryEntry(timestamp time.Time, datname, user, durationMs, statement, fp string) {
 	statementPreview := truncateString(statement, 200)
 	line := fmt.Sprintf(
 		`datname=%q user=%q duration_ms=%q statement_preview=%q`,
 		datname, user, durationMs, statementPreview,
 	)
-	l.entryHandler.Chan() <- database_observability.BuildLokiEntryWithStructuredMetadata(
+	ts := timestamp.UnixNano()
+	if timestamp.IsZero() {
+		ts = time.Now().UnixNano()
+	}
+	l.entryHandler.Chan() <- database_observability.BuildLokiEntryWithTimestampAndStructuredMetadata(
 		logging.LevelInfo,
 		OP_PG_SLOW_QUERY,
 		line,
+		ts,
 		push.LabelsAdapter{
 			push.LabelAdapter{Name: "query_fingerprint", Value: fp},
 		},

--- a/internal/component/database_observability/postgres/collector/logs_test.go
+++ b/internal/component/database_observability/postgres/collector/logs_test.go
@@ -742,9 +742,10 @@ func TestLogsCollector_AttachesQueryFingerprintToError(t *testing.T) {
 	ts2 := ts.Add(-1 * time.Second).Format("2006-01-02 15:04:05 MST")
 	pid := "12345"
 
-	// ERROR line
+	// ERROR line — capture its timestamp so we can assert it is preserved on the emitted entry.
+	errorEntryTs := time.Now()
 	receiver.Chan() <- loki.Entry{Entry: push.Entry{
-		Timestamp: time.Now(),
+		Timestamp: errorEntryTs,
 		Line:      ts1 + ":127.0.0.1:5432:user@books_store:[" + pid + "]:1:42P01:" + ts2 + ":1/0:0:c1::psqlERROR:  relation \"missing\" does not exist",
 	}}
 	// STATEMENT continuation
@@ -778,6 +779,9 @@ func TestLogsCollector_AttachesQueryFingerprintToError(t *testing.T) {
 		}
 	}
 	require.NotEmpty(t, gotFP, "fingerprint should be set when STATEMENT is present")
+
+	// Timestamp must match the ERROR entry's timestamp, not the time the entry was emitted.
+	require.True(t, errEntry.Entry.Timestamp.Equal(errorEntryTs), "pg_error entry should preserve the source timestamp")
 
 	// And the line carries the structured fields
 	require.Contains(t, errEntry.Entry.Line, `severity="ERROR"`)
@@ -908,8 +912,10 @@ func TestLogsCollector_EmitsSlowQueryWithFingerprint(t *testing.T) {
 	ts2 := ts.Add(-1 * time.Second).Format("2006-01-02 15:04:05 MST")
 
 	const sqlText = "SELECT pg_sleep(1)"
+	// Capture the inbound timestamp so we can assert it is preserved on the emitted entry.
+	inboundTs := time.Now()
 	receiver.Chan() <- loki.Entry{Entry: push.Entry{
-		Timestamp: time.Now(),
+		Timestamp: inboundTs,
 		Line:      ts1 + ":127.0.0.1:5432:user@books_store:[12345]:1:00000:" + ts2 + ":1/0:0:c1::psqlLOG:  duration: 1234.567 ms  statement: " + sqlText,
 	}}
 
@@ -941,6 +947,9 @@ func TestLogsCollector_EmitsSlowQueryWithFingerprint(t *testing.T) {
 		}
 	}
 	require.Equal(t, expectedFP, gotFP)
+
+	// Timestamp must match the inbound entry's timestamp, not the time the entry was emitted.
+	require.True(t, slowEntry.Entry.Timestamp.Equal(inboundTs), "pg_slow_query entry should preserve the source timestamp")
 
 	require.Contains(t, slowEntry.Entry.Line, `datname="books_store"`)
 	require.Contains(t, slowEntry.Entry.Line, `user="user"`)

--- a/internal/component/database_observability/postgres/collector/logs_test.go
+++ b/internal/component/database_observability/postgres/collector/logs_test.go
@@ -720,6 +720,125 @@ func TestLogsCollector_ExcludeDatabases(t *testing.T) {
 	require.Equal(t, float64(1), totalCount, "only the non-excluded database log should be counted")
 }
 
+func TestLogsCollector_AttachesQueryFingerprintToError(t *testing.T) {
+	entryHandler := loki.NewCollectingHandler()
+	defer entryHandler.Stop()
+	registry := prometheus.NewRegistry()
+
+	receiver := loki.NewLogsReceiver()
+	c, err := NewLogs(LogsArguments{
+		Receiver:     receiver,
+		EntryHandler: entryHandler,
+		Logger:       log.NewNopLogger(),
+		Registry:     registry,
+	})
+	require.NoError(t, err)
+	require.NoError(t, c.Start(context.Background()))
+	t.Cleanup(c.Stop)
+
+	ts := c.startTime.Add(10 * time.Second).UTC()
+	ts1 := ts.Format("2006-01-02 15:04:05.000 MST")
+	ts2 := ts.Add(-1 * time.Second).Format("2006-01-02 15:04:05 MST")
+	pid := "12345"
+
+	// ERROR line
+	receiver.Chan() <- loki.Entry{Entry: push.Entry{
+		Timestamp: time.Now(),
+		Line:      ts1 + ":127.0.0.1:5432:user@books_store:[" + pid + "]:1:42P01:" + ts2 + ":1/0:0:c1::psqlERROR:  relation \"missing\" does not exist",
+	}}
+	// STATEMENT continuation
+	receiver.Chan() <- loki.Entry{Entry: push.Entry{
+		Timestamp: time.Now(),
+		Line:      "STATEMENT:  SELECT * FROM missing WHERE id = $1",
+	}}
+
+	require.Eventually(t, func() bool {
+		for _, e := range entryHandler.Received() {
+			if string(e.Labels["op"]) == "pg_error" {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 50*time.Millisecond, "expected a pg_error entry")
+
+	var errEntry loki.Entry
+	for _, e := range entryHandler.Received() {
+		if string(e.Labels["op"]) == "pg_error" {
+			errEntry = e
+			break
+		}
+	}
+
+	// Assert structured metadata carries the fingerprint
+	var gotFP string
+	for _, m := range errEntry.Entry.StructuredMetadata {
+		if m.Name == "query_fingerprint" {
+			gotFP = m.Value
+		}
+	}
+	require.NotEmpty(t, gotFP, "fingerprint should be set when STATEMENT is present")
+
+	// And the line carries the structured fields
+	require.Contains(t, errEntry.Entry.Line, `severity="ERROR"`)
+	require.Contains(t, errEntry.Entry.Line, `sqlstate="42P01"`)
+	require.Contains(t, errEntry.Entry.Line, `datname="books_store"`)
+	require.Contains(t, errEntry.Entry.Line, `user="user"`)
+	require.Contains(t, errEntry.Entry.Line, `statement_preview="SELECT * FROM missing WHERE id = $1"`)
+}
+
+func TestLogsCollector_EmitsErrorWithEmptyFingerprintAfterTimeout(t *testing.T) {
+	entryHandler := loki.NewCollectingHandler()
+	defer entryHandler.Stop()
+	registry := prometheus.NewRegistry()
+
+	receiver := loki.NewLogsReceiver()
+	c, err := NewLogs(LogsArguments{
+		Receiver:     receiver,
+		EntryHandler: entryHandler,
+		Logger:       log.NewNopLogger(),
+		Registry:     registry,
+	})
+	require.NoError(t, err)
+	c.pendingErrorTimeout = 100 * time.Millisecond // tighten for the test
+
+	require.NoError(t, c.Start(context.Background()))
+	t.Cleanup(c.Stop)
+
+	ts := c.startTime.Add(10 * time.Second).UTC()
+	ts1 := ts.Format("2006-01-02 15:04:05.000 MST")
+	ts2 := ts.Add(-1 * time.Second).Format("2006-01-02 15:04:05 MST")
+
+	// ERROR line with no following STATEMENT
+	receiver.Chan() <- loki.Entry{Entry: push.Entry{
+		Timestamp: time.Now(),
+		Line:      ts1 + ":127.0.0.1:5432:user@books_store:[99999]:1:53300:" + ts2 + ":1/0:0:c1::psqlFATAL:  too many connections",
+	}}
+
+	require.Eventually(t, func() bool {
+		for _, e := range entryHandler.Received() {
+			if string(e.Labels["op"]) == "pg_error" {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 50*time.Millisecond, "timeout-emitted entry should appear")
+
+	var errEntry loki.Entry
+	for _, e := range entryHandler.Received() {
+		if string(e.Labels["op"]) == "pg_error" {
+			errEntry = e
+			break
+		}
+	}
+	for _, m := range errEntry.Entry.StructuredMetadata {
+		if m.Name == "query_fingerprint" {
+			require.Equal(t, "", m.Value, "fingerprint should be empty when no STATEMENT arrived")
+		}
+	}
+	require.Contains(t, errEntry.Entry.Line, `severity="FATAL"`)
+	require.Contains(t, errEntry.Entry.Line, `statement_preview=""`)
+}
+
 func TestLogsCollector_ExcludeUsers(t *testing.T) {
 	entryHandler := loki.NewEntryHandler(make(chan loki.Entry, 10), func() {})
 	registry := prometheus.NewRegistry()

--- a/internal/component/database_observability/postgres/collector/logs_test.go
+++ b/internal/component/database_observability/postgres/collector/logs_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/component/database_observability/postgres/fingerprint"
 )
 
 func TestLogsCollector_ParseRDSFormat(t *testing.T) {
@@ -884,4 +885,65 @@ func TestLogsCollector_ExcludeUsers(t *testing.T) {
 		}
 	}
 	require.Equal(t, float64(1), totalCount, "only the non-excluded user log should be counted")
+}
+
+func TestLogsCollector_EmitsSlowQueryWithFingerprint(t *testing.T) {
+	entryHandler := loki.NewCollectingHandler()
+	defer entryHandler.Stop()
+	registry := prometheus.NewRegistry()
+
+	receiver := loki.NewLogsReceiver()
+	c, err := NewLogs(LogsArguments{
+		Receiver:     receiver,
+		EntryHandler: entryHandler,
+		Logger:       log.NewNopLogger(),
+		Registry:     registry,
+	})
+	require.NoError(t, err)
+	require.NoError(t, c.Start(context.Background()))
+	t.Cleanup(c.Stop)
+
+	ts := c.startTime.Add(10 * time.Second).UTC()
+	ts1 := ts.Format("2006-01-02 15:04:05.000 MST")
+	ts2 := ts.Add(-1 * time.Second).Format("2006-01-02 15:04:05 MST")
+
+	const sqlText = "SELECT pg_sleep(1)"
+	receiver.Chan() <- loki.Entry{Entry: push.Entry{
+		Timestamp: time.Now(),
+		Line:      ts1 + ":127.0.0.1:5432:user@books_store:[12345]:1:00000:" + ts2 + ":1/0:0:c1::psqlLOG:  duration: 1234.567 ms  statement: " + sqlText,
+	}}
+
+	require.Eventually(t, func() bool {
+		for _, e := range entryHandler.Received() {
+			if string(e.Labels["op"]) == "pg_slow_query" {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 50*time.Millisecond, "expected a pg_slow_query entry")
+
+	var slowEntry loki.Entry
+	for _, e := range entryHandler.Received() {
+		if string(e.Labels["op"]) == "pg_slow_query" {
+			slowEntry = e
+			break
+		}
+	}
+
+	expectedFP, _, fpErr := fingerprint.Fingerprint(sqlText, fingerprint.SourceLog, 0)
+	require.NoError(t, fpErr)
+	require.NotEmpty(t, expectedFP)
+
+	var gotFP string
+	for _, m := range slowEntry.Entry.StructuredMetadata {
+		if m.Name == "query_fingerprint" {
+			gotFP = m.Value
+		}
+	}
+	require.Equal(t, expectedFP, gotFP)
+
+	require.Contains(t, slowEntry.Entry.Line, `datname="books_store"`)
+	require.Contains(t, slowEntry.Entry.Line, `user="user"`)
+	require.Contains(t, slowEntry.Entry.Line, `duration_ms="1234.567"`)
+	require.Contains(t, slowEntry.Entry.Line, `statement_preview="SELECT pg_sleep(1)"`)
 }

--- a/internal/component/database_observability/postgres/collector/query_details.go
+++ b/internal/component/database_observability/postgres/collector/query_details.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/component/database_observability"
+	"github.com/grafana/alloy/internal/component/database_observability/postgres/fingerprint"
 	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
 )
@@ -46,26 +47,28 @@ var selectQueriesFromActivity = `
 `
 
 type QueryDetailsArguments struct {
-	DB               *sql.DB
-	CollectInterval  time.Duration
-	StatementsLimit  int
-	ExcludeDatabases []string
-	ExcludeUsers     []string
-	EntryHandler     loki.EntryHandler
-	TableRegistry    *TableRegistry
+	DB                *sql.DB
+	CollectInterval   time.Duration
+	StatementsLimit   int
+	ExcludeDatabases  []string
+	ExcludeUsers      []string
+	EntryHandler      loki.EntryHandler
+	TableRegistry     *TableRegistry
+	QueryHashRegistry *QueryHashRegistry
 
 	Logger log.Logger
 }
 
 type QueryDetails struct {
-	dbConnection     *sql.DB
-	collectInterval  time.Duration
-	statementsLimit  int
-	excludeDatabases []string
-	excludeUsers     []string
-	entryHandler     loki.EntryHandler
-	tableRegistry    *TableRegistry
-	normalizer       *sqllexer.Normalizer
+	dbConnection      *sql.DB
+	collectInterval   time.Duration
+	statementsLimit   int
+	excludeDatabases  []string
+	excludeUsers      []string
+	entryHandler      loki.EntryHandler
+	tableRegistry     *TableRegistry
+	queryHashRegistry *QueryHashRegistry
+	normalizer        *sqllexer.Normalizer
 
 	logger  log.Logger
 	running *atomic.Bool
@@ -76,16 +79,17 @@ type QueryDetails struct {
 
 func NewQueryDetails(args QueryDetailsArguments) (*QueryDetails, error) {
 	return &QueryDetails{
-		dbConnection:     args.DB,
-		collectInterval:  args.CollectInterval,
-		statementsLimit:  args.StatementsLimit,
-		excludeDatabases: args.ExcludeDatabases,
-		excludeUsers:     args.ExcludeUsers,
-		entryHandler:     args.EntryHandler,
-		tableRegistry:    args.TableRegistry,
-		normalizer:       sqllexer.NewNormalizer(sqllexer.WithCollectTables(true), sqllexer.WithCollectComments(true), sqllexer.WithKeepIdentifierQuotation(true)),
-		logger:           log.With(args.Logger, "collector", QueryDetailsCollector),
-		running:          &atomic.Bool{},
+		dbConnection:      args.DB,
+		collectInterval:   args.CollectInterval,
+		statementsLimit:   args.StatementsLimit,
+		excludeDatabases:  args.ExcludeDatabases,
+		excludeUsers:      args.ExcludeUsers,
+		entryHandler:      args.EntryHandler,
+		tableRegistry:     args.TableRegistry,
+		queryHashRegistry: args.QueryHashRegistry,
+		normalizer:        sqllexer.NewNormalizer(sqllexer.WithCollectTables(true), sqllexer.WithCollectComments(true), sqllexer.WithKeepIdentifierQuotation(true)),
+		logger:            log.With(args.Logger, "collector", QueryDetailsCollector),
+		running:           &atomic.Bool{},
 	}, nil
 }
 
@@ -154,6 +158,15 @@ func (c *QueryDetails) fetchAndAssociate(ctx context.Context) error {
 			continue
 		}
 
+		fp, _, fpErr := fingerprint.Fingerprint(queryText, fingerprint.SourcePgStatStatements, 0)
+		if fpErr != nil {
+			level.Debug(c.logger).Log("msg", "skip fingerprint", "queryid", queryID, "err", fpErr)
+		}
+
+		if fp != "" && c.queryHashRegistry != nil {
+			c.queryHashRegistry.Set(queryID, fp, string(databaseName))
+		}
+
 		queryText, err = removeComments(c.normalizer, queryText)
 		if err != nil {
 			level.Error(c.logger).Log("msg", "failed to remove comments", "err", err)
@@ -163,7 +176,7 @@ func (c *QueryDetails) fetchAndAssociate(ctx context.Context) error {
 		c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
 			logging.LevelInfo,
 			OP_QUERY_ASSOCIATION,
-			fmt.Sprintf(`queryid="%s" querytext=%q datname="%s"`, queryID, queryText, databaseName),
+			fmt.Sprintf(`queryid="%s" query_fingerprint="%s" querytext=%q datname="%s"`, queryID, fp, queryText, databaseName),
 		)
 
 		tables, err := tokenizeTableNames(c.normalizer, queryText)

--- a/internal/component/database_observability/postgres/collector/query_details_test.go
+++ b/internal/component/database_observability/postgres/collector/query_details_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,7 +16,39 @@ import (
 	"go.uber.org/goleak"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/component/database_observability/postgres/fingerprint"
 )
+
+// computeFingerprint is a small helper for tests so we don't hard-code
+// fingerprint hex values (which would break on pg_query_go version bumps).
+func computeFingerprint(t *testing.T, queryText string) string {
+	t.Helper()
+	fp, _, err := fingerprint.Fingerprint(queryText, fingerprint.SourcePgStatStatements, 0)
+	require.NoError(t, err)
+	return fp
+}
+
+// substituteFingerprints replaces every "<fp>" placeholder in logsLines with
+// the fingerprint computed from the corresponding row's query text. Rows are
+// consumed in order, one per association line. Non-association lines (e.g.
+// OP_QUERY_PARSED_TABLE_NAME) are passed through unchanged.
+func substituteFingerprints(t *testing.T, logsLines []string, logsLabels []model.LabelSet, rows [][]driver.Value) []string {
+	t.Helper()
+	out := make([]string, len(logsLines))
+	rowIdx := 0
+	for i, line := range logsLines {
+		if logsLabels[i]["op"] == OP_QUERY_ASSOCIATION {
+			require.Less(t, rowIdx, len(rows), "more association lines than rows")
+			queryText := rows[rowIdx][1].(string)
+			rowIdx++
+			fp := computeFingerprint(t, queryText)
+			out[i] = strings.Replace(line, "<fp>", fp, 1)
+		} else {
+			out[i] = line
+		}
+	}
+	return out
+}
 
 func TestQueryDetails(t *testing.T) {
 	// The goroutine which deletes expired entries runs indefinitely,
@@ -41,7 +74,7 @@ func TestQueryDetails(t *testing.T) {
 				{"op": OP_QUERY_PARSED_TABLE_NAME},
 			},
 			logsLines: []string{
-				`level="info" queryid="abc123" querytext="SELECT * FROM some_table WHERE id = $1" datname="some_database"`,
+				`level="info" queryid="abc123" query_fingerprint="<fp>" querytext="SELECT * FROM some_table WHERE id = $1" datname="some_database"`,
 				`level="info" queryid="abc123" datname="some_database" table="some_table" validated="true"`,
 			},
 			tableRegistry: &TableRegistry{
@@ -66,7 +99,7 @@ func TestQueryDetails(t *testing.T) {
 				{"op": OP_QUERY_PARSED_TABLE_NAME},
 			},
 			logsLines: []string{
-				`level="info" queryid="abc123" querytext="SELECT * FROM public.users WHERE id = $1" datname="some_database"`,
+				`level="info" queryid="abc123" query_fingerprint="<fp>" querytext="SELECT * FROM public.users WHERE id = $1" datname="some_database"`,
 				`level="info" queryid="abc123" datname="some_database" table="public.users" validated="true"`,
 			},
 			tableRegistry: &TableRegistry{
@@ -91,7 +124,7 @@ func TestQueryDetails(t *testing.T) {
 				{"op": OP_QUERY_PARSED_TABLE_NAME},
 			},
 			logsLines: []string{
-				`level="info" queryid="abc123" querytext="SELECT * FROM SOME_TABLE WHERE id = $1" datname="some_database"`,
+				`level="info" queryid="abc123" query_fingerprint="<fp>" querytext="SELECT * FROM SOME_TABLE WHERE id = $1" datname="some_database"`,
 				`level="info" queryid="abc123" datname="some_database" table="some_table" validated="true"`,
 			},
 			tableRegistry: &TableRegistry{
@@ -116,7 +149,7 @@ func TestQueryDetails(t *testing.T) {
 				{"op": OP_QUERY_PARSED_TABLE_NAME},
 			},
 			logsLines: []string{
-				`level="info" queryid="abc123" querytext="SELECT * FROM PUBLIC.USERS WHERE id = $1" datname="some_database"`,
+				`level="info" queryid="abc123" query_fingerprint="<fp>" querytext="SELECT * FROM PUBLIC.USERS WHERE id = $1" datname="some_database"`,
 				`level="info" queryid="abc123" datname="some_database" table="public.users" validated="true"`,
 			},
 			tableRegistry: &TableRegistry{
@@ -141,7 +174,7 @@ func TestQueryDetails(t *testing.T) {
 				{"op": OP_QUERY_PARSED_TABLE_NAME},
 			},
 			logsLines: []string{
-				`level="info" queryid="abc123" querytext="SELECT * FROM MyTable WHERE id = $1" datname="some_database"`,
+				`level="info" queryid="abc123" query_fingerprint="<fp>" querytext="SELECT * FROM MyTable WHERE id = $1" datname="some_database"`,
 				`level="info" queryid="abc123" datname="some_database" table="mytable" validated="true"`,
 			},
 			tableRegistry: &TableRegistry{
@@ -166,7 +199,7 @@ func TestQueryDetails(t *testing.T) {
 				{"op": OP_QUERY_PARSED_TABLE_NAME},
 			},
 			logsLines: []string{
-				`level="info" queryid="abc123" querytext="WITH some_with_table AS (SELECT * FROM some_table WHERE id = $1) SELECT * FROM some_with_table" datname="some_database"`,
+				`level="info" queryid="abc123" query_fingerprint="<fp>" querytext="WITH some_with_table AS (SELECT * FROM some_table WHERE id = $1) SELECT * FROM some_with_table" datname="some_database"`,
 				`level="info" queryid="abc123" datname="some_database" table="some_table" validated="false"`,
 			},
 		},
@@ -182,7 +215,7 @@ func TestQueryDetails(t *testing.T) {
 				{"op": OP_QUERY_PARSED_TABLE_NAME},
 			},
 			logsLines: []string{
-				`level="info" queryid="abc123" querytext="INSERT INTO some_table (id, name) VALUES (...)" datname="some_database"`,
+				`level="info" queryid="abc123" query_fingerprint="<fp>" querytext="INSERT INTO some_table (id, name) VALUES (...)" datname="some_database"`,
 				`level="info" queryid="abc123" datname="some_database" table="some_table" validated="false"`,
 			},
 		},
@@ -199,7 +232,7 @@ func TestQueryDetails(t *testing.T) {
 				{"op": OP_QUERY_PARSED_TABLE_NAME},
 			},
 			logsLines: []string{
-				`level="info" queryid="abc123" querytext="WITH some_with_table AS (SELECT id, name FROM some_other_table WHERE id = $1) INSERT INTO some_table (id, name) SELECT id, name FROM some_with_table" datname="some_database"`,
+				`level="info" queryid="abc123" query_fingerprint="<fp>" querytext="WITH some_with_table AS (SELECT id, name FROM some_other_table WHERE id = $1) INSERT INTO some_table (id, name) SELECT id, name FROM some_with_table" datname="some_database"`,
 				`level="info" queryid="abc123" datname="some_database" table="some_other_table" validated="false"`,
 				`level="info" queryid="abc123" datname="some_database" table="some_table" validated="false"`,
 			},
@@ -216,7 +249,7 @@ func TestQueryDetails(t *testing.T) {
 				{"op": OP_QUERY_PARSED_TABLE_NAME},
 			},
 			logsLines: []string{
-				`level="info" queryid="abc123" querytext="UPDATE some_table SET active = false, reason = ? WHERE id = $1 AND name = $2" datname="some_database"`,
+				`level="info" queryid="abc123" query_fingerprint="<fp>" querytext="UPDATE some_table SET active = false, reason = ? WHERE id = $1 AND name = $2" datname="some_database"`,
 				`level="info" queryid="abc123" datname="some_database" table="some_table" validated="false"`,
 			},
 		},
@@ -232,7 +265,7 @@ func TestQueryDetails(t *testing.T) {
 				{"op": OP_QUERY_PARSED_TABLE_NAME},
 			},
 			logsLines: []string{
-				`level="info" queryid="abc123" querytext="DELETE FROM some_table WHERE id = $1" datname="some_database"`,
+				`level="info" queryid="abc123" query_fingerprint="<fp>" querytext="DELETE FROM some_table WHERE id = $1" datname="some_database"`,
 				`level="info" queryid="abc123" datname="some_database" table="some_table" validated="false"`,
 			},
 		},
@@ -249,7 +282,7 @@ func TestQueryDetails(t *testing.T) {
 				{"op": OP_QUERY_PARSED_TABLE_NAME},
 			},
 			logsLines: []string{
-				`level="info" queryid="abc123" querytext="WITH some_with_table AS (SELECT id, name FROM some_other_table WHERE id = $1) DELETE FROM some_table WHERE id IN (SELECT id FROM some_with_table)" datname="some_database"`,
+				`level="info" queryid="abc123" query_fingerprint="<fp>" querytext="WITH some_with_table AS (SELECT id, name FROM some_other_table WHERE id = $1) DELETE FROM some_table WHERE id IN (SELECT id FROM some_with_table)" datname="some_database"`,
 				`level="info" queryid="abc123" datname="some_database" table="some_other_table" validated="false"`,
 				`level="info" queryid="abc123" datname="some_database" table="some_table" validated="false"`,
 			},
@@ -267,7 +300,7 @@ func TestQueryDetails(t *testing.T) {
 				{"op": OP_QUERY_PARSED_TABLE_NAME},
 			},
 			logsLines: []string{
-				`level="info" queryid="abc123" querytext="SELECT t.id, t.val1, o.val2 FROM some_table t INNER JOIN other_table AS o ON t.id = o.id WHERE o.val2 = $1 ORDER BY t.val1 DESC" datname="some_database"`,
+				`level="info" queryid="abc123" query_fingerprint="<fp>" querytext="SELECT t.id, t.val1, o.val2 FROM some_table t INNER JOIN other_table AS o ON t.id = o.id WHERE o.val2 = $1 ORDER BY t.val1 DESC" datname="some_database"`,
 				`level="info" queryid="abc123" datname="some_database" table="some_table" validated="false"`,
 				`level="info" queryid="abc123" datname="some_database" table="other_table" validated="false"`,
 			},
@@ -290,9 +323,9 @@ func TestQueryDetails(t *testing.T) {
 				{"op": OP_QUERY_PARSED_TABLE_NAME},
 			},
 			logsLines: []string{
-				`level="info" queryid="xyz456" querytext="INSERT INTO some_table..." datname="some_database"`,
+				`level="info" queryid="xyz456" query_fingerprint="<fp>" querytext="INSERT INTO some_table..." datname="some_database"`,
 				`level="info" queryid="xyz456" datname="some_database" table="some_table" validated="false"`,
-				`level="info" queryid="abc123" querytext="SELECT * FROM another_table WHERE id = $1" datname="some_database"`,
+				`level="info" queryid="abc123" query_fingerprint="<fp>" querytext="SELECT * FROM another_table WHERE id = $1" datname="some_database"`,
 				`level="info" queryid="abc123" datname="some_database" table="another_table" validated="false"`,
 			},
 		},
@@ -308,7 +341,7 @@ func TestQueryDetails(t *testing.T) {
 				{"op": OP_QUERY_PARSED_TABLE_NAME},
 			},
 			logsLines: []string{
-				`level="info" queryid="abc123" querytext="SELECT * FROM some_table WHERE id = $1 AND name =" datname="some_database"`,
+				`level="info" queryid="abc123" query_fingerprint="<fp>" querytext="SELECT * FROM some_table WHERE id = $1 AND name =" datname="some_database"`,
 				`level="info" queryid="abc123" datname="some_database" table="some_table" validated="false"`,
 			},
 		},
@@ -323,7 +356,7 @@ func TestQueryDetails(t *testing.T) {
 				{"op": OP_QUERY_ASSOCIATION},
 			},
 			logsLines: []string{
-				`level="info" queryid="abc123" querytext="START TRANSACTION" datname="some_database"`,
+				`level="info" queryid="abc123" query_fingerprint="<fp>" querytext="START TRANSACTION" datname="some_database"`,
 			},
 		},
 		{
@@ -343,8 +376,8 @@ func TestQueryDetails(t *testing.T) {
 				{"op": OP_QUERY_PARSED_TABLE_NAME},
 			},
 			logsLines: []string{
-				`level="info" queryid="xyz456" querytext="not valid sql" datname="some_database"`,
-				`level="info" queryid="abc123" querytext="SELECT * FROM some_table WHERE id = $1" datname="some_database"`,
+				`level="info" queryid="xyz456" query_fingerprint="<fp>" querytext="not valid sql" datname="some_database"`,
+				`level="info" queryid="abc123" query_fingerprint="<fp>" querytext="SELECT * FROM some_table WHERE id = $1" datname="some_database"`,
 				`level="info" queryid="abc123" datname="some_database" table="some_table" validated="false"`,
 			},
 		},
@@ -366,9 +399,9 @@ func TestQueryDetails(t *testing.T) {
 				{"op": OP_QUERY_PARSED_TABLE_NAME},
 			},
 			logsLines: []string{
-				`level="info" queryid="abc123" querytext="SELECT * FROM some_table WHERE id = $1" datname="some_database"`,
+				`level="info" queryid="abc123" query_fingerprint="<fp>" querytext="SELECT * FROM some_table WHERE id = $1" datname="some_database"`,
 				`level="info" queryid="abc123" datname="some_database" table="some_table" validated="false"`,
-				`level="info" queryid="abc123" querytext="SELECT * FROM some_table WHERE id = $1" datname="other_schema"`,
+				`level="info" queryid="abc123" query_fingerprint="<fp>" querytext="SELECT * FROM some_table WHERE id = $1" datname="other_schema"`,
 				`level="info" queryid="abc123" datname="other_schema" table="some_table" validated="false"`,
 			},
 		},
@@ -386,7 +419,7 @@ func TestQueryDetails(t *testing.T) {
 				{"op": OP_QUERY_PARSED_TABLE_NAME},
 			},
 			logsLines: []string{
-				`level="info" queryid="abc123" querytext="SELECT * FROM (SELECT id, name FROM employees_us_east UNION SELECT id, name FROM employees_us_west) AS employees_us UNION SELECT id, name FROM employees_emea" datname="some_database"`,
+				`level="info" queryid="abc123" query_fingerprint="<fp>" querytext="SELECT * FROM (SELECT id, name FROM employees_us_east UNION SELECT id, name FROM employees_us_west) AS employees_us UNION SELECT id, name FROM employees_emea" datname="some_database"`,
 				`level="info" queryid="abc123" datname="some_database" table="employees_us_east" validated="false"`,
 				`level="info" queryid="abc123" datname="some_database" table="employees_us_west" validated="false"`,
 				`level="info" queryid="abc123" datname="some_database" table="employees_emea" validated="false"`,
@@ -404,7 +437,7 @@ func TestQueryDetails(t *testing.T) {
 				{"op": OP_QUERY_PARSED_TABLE_NAME},
 			},
 			logsLines: []string{
-				`level="info" queryid="abc123" querytext="SHOW CREATE TABLE some_table" datname="some_database"`,
+				`level="info" queryid="abc123" query_fingerprint="<fp>" querytext="SHOW CREATE TABLE some_table" datname="some_database"`,
 				`level="info" queryid="abc123" datname="some_database" table="some_table" validated="false"`,
 			},
 		},
@@ -419,7 +452,7 @@ func TestQueryDetails(t *testing.T) {
 				{"op": OP_QUERY_ASSOCIATION},
 			},
 			logsLines: []string{
-				`level="info" queryid="abc123" querytext="SHOW VARIABLES LIKE $1" datname="some_database"`,
+				`level="info" queryid="abc123" query_fingerprint="<fp>" querytext="SHOW VARIABLES LIKE $1" datname="some_database"`,
 			},
 		},
 		{
@@ -434,7 +467,7 @@ func TestQueryDetails(t *testing.T) {
 				{"op": OP_QUERY_PARSED_TABLE_NAME},
 			},
 			logsLines: []string{
-				`level="info" queryid="abc123" querytext="SELECT * FROM some_table WHERE" datname="some_database"`,
+				`level="info" queryid="abc123" query_fingerprint="<fp>" querytext="SELECT * FROM some_table WHERE" datname="some_database"`,
 				`level="info" queryid="abc123" datname="some_database" table="some_table" validated="false"`,
 			},
 		},
@@ -474,14 +507,14 @@ func TestQueryDetails(t *testing.T) {
 				{"op": OP_QUERY_PARSED_TABLE_NAME},
 			},
 			logsLines: []string{
-				`level="info" queryid="3871016669222913500" querytext="SELECT \"pizza_to_ingredients\".\"pizza_id\", \"i\".\"id\", \"i\".\"name\", \"i\".\"calories_per_slice\", \"i\".\"vegetarian\", \"i\".\"type\" FROM \"ingredients\" AS \"i\" JOIN \"pizza_to_ingredients\" AS \"pizza_to_ingredients\" ON (\"pizza_to_ingredients\".\"pizza_id\") IN ($1) WHERE (\"i\".\"id\" = \"pizza_to_ingredients\".\"ingredient_id\")" datname="quickpizza"`,
+				`level="info" queryid="3871016669222913500" query_fingerprint="<fp>" querytext="SELECT \"pizza_to_ingredients\".\"pizza_id\", \"i\".\"id\", \"i\".\"name\", \"i\".\"calories_per_slice\", \"i\".\"vegetarian\", \"i\".\"type\" FROM \"ingredients\" AS \"i\" JOIN \"pizza_to_ingredients\" AS \"pizza_to_ingredients\" ON (\"pizza_to_ingredients\".\"pizza_id\") IN ($1) WHERE (\"i\".\"id\" = \"pizza_to_ingredients\".\"ingredient_id\")" datname="quickpizza"`,
 				`level="info" queryid="3871016669222913500" datname="quickpizza" table="ingredients" validated="false"`,
 				`level="info" queryid="3871016669222913500" datname="quickpizza" table="pizza_to_ingredients" validated="false"`,
-				`level="info" queryid="7865322458849960000" querytext="SELECT \"quote\".\"name\" FROM \"quotes\" AS \"quote\"" datname="quickpizza"`,
+				`level="info" queryid="7865322458849960000" query_fingerprint="<fp>" querytext="SELECT \"quote\".\"name\" FROM \"quotes\" AS \"quote\"" datname="quickpizza"`,
 				`level="info" queryid="7865322458849960000" datname="quickpizza" table="quotes" validated="false"`,
-				`level="info" queryid="5775615007769463000" querytext="SELECT \"classical_name\".\"name\" FROM \"classical_names\" AS \"classical_name\"" datname="quickpizza"`,
+				`level="info" queryid="5775615007769463000" query_fingerprint="<fp>" querytext="SELECT \"classical_name\".\"name\" FROM \"classical_names\" AS \"classical_name\"" datname="quickpizza"`,
 				`level="info" queryid="5775615007769463000" datname="quickpizza" table="classical_names" validated="false"`,
-				`level="info" queryid="7007034463187741000" querytext="SELECT \"dough\".\"id\", \"dough\".\"name\", \"dough\".\"calories_per_slice\" FROM \"doughs\" AS \"dough\"" datname="quickpizza"`,
+				`level="info" queryid="7007034463187741000" query_fingerprint="<fp>" querytext="SELECT \"dough\".\"id\", \"dough\".\"name\", \"dough\".\"calories_per_slice\" FROM \"doughs\" AS \"dough\"" datname="quickpizza"`,
 				`level="info" queryid="7007034463187741000" datname="quickpizza" table="doughs" validated="false"`,
 			},
 		},
@@ -490,6 +523,8 @@ func TestQueryDetails(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+
+			expectedLogsLines := substituteFingerprints(t, tc.logsLines, tc.logsLabels, tc.eventStatementsRows)
 
 			db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 			require.NoError(t, err)
@@ -523,7 +558,7 @@ func TestQueryDetails(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Eventually(t, func() bool {
-				return len(lokiClient.Received()) == len(tc.logsLines)
+				return len(lokiClient.Received()) == len(expectedLogsLines)
 			}, 5*time.Second, 100*time.Millisecond)
 
 			collector.Stop()
@@ -537,10 +572,10 @@ func TestQueryDetails(t *testing.T) {
 			require.NoError(t, err)
 
 			lokiEntries := lokiClient.Received()
-			require.Equal(t, len(tc.logsLines), len(lokiEntries))
+			require.Equal(t, len(expectedLogsLines), len(lokiEntries))
 			for i, entry := range lokiEntries {
 				require.Equal(t, tc.logsLabels[i], entry.Labels)
-				require.Equal(t, tc.logsLines[i], entry.Line)
+				require.Equal(t, expectedLogsLines[i], entry.Line)
 			}
 		})
 	}
@@ -608,9 +643,10 @@ func TestQueryDetails_SQLDriverErrors(t *testing.T) {
 		err = mock.ExpectationsWereMet()
 		require.NoError(t, err)
 
+		expectedFP := computeFingerprint(t, "SELECT * FROM some_table WHERE id = ?")
 		lokiEntries := lokiClient.Received()
 		require.Equal(t, model.LabelSet{"op": OP_QUERY_ASSOCIATION}, lokiEntries[0].Labels)
-		require.Equal(t, `level="info" queryid="abc123" querytext="SELECT * FROM some_table WHERE id = ?" datname="some_database"`, lokiEntries[0].Line)
+		require.Equal(t, fmt.Sprintf(`level="info" queryid="abc123" query_fingerprint="%s" querytext="SELECT * FROM some_table WHERE id = ?" datname="some_database"`, expectedFP), lokiEntries[0].Line)
 		require.Equal(t, model.LabelSet{"op": OP_QUERY_PARSED_TABLE_NAME}, lokiEntries[1].Labels)
 		require.Equal(t, `level="info" queryid="abc123" datname="some_database" table="some_table" validated="false"`, lokiEntries[1].Line)
 	})
@@ -668,9 +704,10 @@ func TestQueryDetails_SQLDriverErrors(t *testing.T) {
 		err = mock.ExpectationsWereMet()
 		require.NoError(t, err)
 
+		expectedFP := computeFingerprint(t, "SELECT * FROM some_table WHERE id = ?")
 		lokiEntries := lokiClient.Received()
 		require.Equal(t, model.LabelSet{"op": OP_QUERY_ASSOCIATION}, lokiEntries[0].Labels)
-		require.Equal(t, `level="info" queryid="abc123" querytext="SELECT * FROM some_table WHERE id = ?" datname="some_database"`, lokiEntries[0].Line)
+		require.Equal(t, fmt.Sprintf(`level="info" queryid="abc123" query_fingerprint="%s" querytext="SELECT * FROM some_table WHERE id = ?" datname="some_database"`, expectedFP), lokiEntries[0].Line)
 		require.Equal(t, model.LabelSet{"op": OP_QUERY_PARSED_TABLE_NAME}, lokiEntries[1].Labels)
 		require.Equal(t, `level="info" queryid="abc123" datname="some_database" table="some_table" validated="false"`, lokiEntries[1].Line)
 	})
@@ -726,9 +763,10 @@ func TestQueryDetails_SQLDriverErrors(t *testing.T) {
 		err = mock.ExpectationsWereMet()
 		require.NoError(t, err)
 
+		expectedFP := computeFingerprint(t, "SELECT * FROM some_table WHERE id = ?")
 		lokiEntries := lokiClient.Received()
 		require.Equal(t, model.LabelSet{"op": OP_QUERY_ASSOCIATION}, lokiEntries[0].Labels)
-		require.Equal(t, `level="info" queryid="abc123" querytext="SELECT * FROM some_table WHERE id = ?" datname="some_database"`, lokiEntries[0].Line)
+		require.Equal(t, fmt.Sprintf(`level="info" queryid="abc123" query_fingerprint="%s" querytext="SELECT * FROM some_table WHERE id = ?" datname="some_database"`, expectedFP), lokiEntries[0].Line)
 		require.Equal(t, model.LabelSet{"op": OP_QUERY_PARSED_TABLE_NAME}, lokiEntries[1].Labels)
 		require.Equal(t, `level="info" queryid="abc123" datname="some_database" table="some_table" validated="false"`, lokiEntries[1].Line)
 	})
@@ -949,6 +987,59 @@ func TestQueryDetails_ExcludeDatabases(t *testing.T) {
 	for _, entry := range lokiClient.Received() {
 		require.Contains(t, entry.Line, "another_database", "included database should appear in logs")
 	}
+}
+
+func TestQueryDetails_PopulatesRegistryAndEmitsFingerprint(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"))
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	const sqlText = "SELECT * FROM books WHERE id = $1"
+	expectedFP, _, fpErr := fingerprint.Fingerprint(sqlText, fingerprint.SourcePgStatStatements, 0)
+	require.NoError(t, fpErr)
+	require.NotEmpty(t, expectedFP)
+
+	mock.ExpectQuery(fmt.Sprintf(selectQueriesFromActivity, exclusionClause, "", 100)).WithoutArgs().RowsWillBeClosed().
+		WillReturnRows(
+			sqlmock.NewRows([]string{"queryid", "query", "datname"}).
+				AddRow("9876", sqlText, "books_store"),
+		)
+
+	lokiClient := loki.NewCollectingHandler()
+	registry := NewQueryHashRegistry(100, time.Hour)
+
+	c, err := NewQueryDetails(QueryDetailsArguments{
+		DB:                db,
+		CollectInterval:   time.Second,
+		StatementsLimit:   100,
+		EntryHandler:      lokiClient,
+		QueryHashRegistry: registry,
+		Logger:            log.NewLogfmtLogger(os.Stderr),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, c.Start(t.Context()))
+
+	require.Eventually(t, func() bool {
+		return len(lokiClient.Received()) >= 1
+	}, 5*time.Second, 100*time.Millisecond)
+
+	c.Stop()
+	lokiClient.Stop()
+	require.Eventually(t, func() bool { return c.Stopped() }, 5*time.Second, 100*time.Millisecond)
+
+	info, ok := registry.Get("9876")
+	require.True(t, ok, "registry should be populated for queryid 9876")
+	require.Equal(t, expectedFP, info.Fingerprint)
+	require.Equal(t, "books_store", info.DatabaseName)
+
+	got := lokiClient.Received()
+	require.NotEmpty(t, got)
+	require.Equal(t, model.LabelSet{"op": OP_QUERY_ASSOCIATION}, got[0].Labels)
+	require.Contains(t, got[0].Line, `queryid="9876"`)
+	require.Contains(t, got[0].Line, fmt.Sprintf(`query_fingerprint="%s"`, expectedFP))
 }
 
 func TestQueryDetails_ExcludeUsers(t *testing.T) {

--- a/internal/component/database_observability/postgres/collector/query_hash_metrics.go
+++ b/internal/component/database_observability/postgres/collector/query_hash_metrics.go
@@ -1,0 +1,52 @@
+package collector
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// QueryHashMetricsCollector exposes the QueryHashRegistry as a Prometheus
+// "info" gauge metric. The metric is intended to be join-merged into existing
+// pg_stat_statements series via PromQL:
+//
+//	pg_stat_statements_calls_total
+//	  * on(queryid, datname) group_left(query_fingerprint)
+//	    database_observability_query_hash_info
+//
+// We deliberately keep the fingerprint *off* the existing pg_stat_statements
+// series labels so we don't bump cardinality on every scrape.
+type QueryHashMetricsCollector struct {
+	registry *QueryHashRegistry
+	serverID string
+	desc     *prometheus.Desc
+}
+
+func NewQueryHashMetricsCollector(registry *QueryHashRegistry, serverID string) *QueryHashMetricsCollector {
+	return &QueryHashMetricsCollector{
+		registry: registry,
+		serverID: serverID,
+		desc: prometheus.NewDesc(
+			prometheus.BuildFQName("database_observability", "", "query_hash_info"),
+			"Mapping of PostgreSQL queryid to semantic query fingerprint",
+			[]string{"queryid", "query_fingerprint", "server_id", "datname"},
+			nil,
+		),
+	}
+}
+
+func (c *QueryHashMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.desc
+}
+
+func (c *QueryHashMetricsCollector) Collect(ch chan<- prometheus.Metric) {
+	for queryID, info := range c.registry.Snapshot() {
+		ch <- prometheus.MustNewConstMetric(
+			c.desc,
+			prometheus.GaugeValue,
+			1,
+			queryID,
+			info.Fingerprint,
+			c.serverID,
+			info.DatabaseName,
+		)
+	}
+}

--- a/internal/component/database_observability/postgres/collector/query_hash_metrics_test.go
+++ b/internal/component/database_observability/postgres/collector/query_hash_metrics_test.go
@@ -1,0 +1,34 @@
+package collector
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryHashMetricsCollector_ExposesRegistryAsJoinMetric(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	qhr := NewQueryHashRegistry(100, time.Hour)
+	col := NewQueryHashMetricsCollector(qhr, "server-A")
+	require.NoError(t, reg.Register(col))
+
+	qhr.Set("12345", "fpAAAA", "books_store")
+	qhr.Set("67890", "fpBBBB", "library")
+
+	expected := `
+# HELP database_observability_query_hash_info Mapping of PostgreSQL queryid to semantic query fingerprint
+# TYPE database_observability_query_hash_info gauge
+database_observability_query_hash_info{datname="books_store",query_fingerprint="fpAAAA",queryid="12345",server_id="server-A"} 1
+database_observability_query_hash_info{datname="library",query_fingerprint="fpBBBB",queryid="67890",server_id="server-A"} 1
+`
+
+	require.NoError(t, testutil.GatherAndCompare(
+		reg,
+		strings.NewReader(expected),
+		"database_observability_query_hash_info",
+	))
+}

--- a/internal/component/database_observability/postgres/collector/query_hash_registry.go
+++ b/internal/component/database_observability/postgres/collector/query_hash_registry.go
@@ -1,0 +1,67 @@
+package collector
+
+import (
+	"sync"
+	"time"
+
+	"github.com/hashicorp/golang-lru/v2/expirable"
+)
+
+// QueryHashInfo holds the per-queryid data the metrics collector needs at
+// scrape time. The fields are intentionally narrow: anything more goes on the
+// emitted Loki entry, not on the join metric (cardinality control).
+type QueryHashInfo struct {
+	Fingerprint  string
+	DatabaseName string
+	LastSeen     time.Time
+}
+
+// QueryHashRegistry is a small LRU+TTL cache mapping the native PostgreSQL
+// queryid (string form) to the semantic fingerprint Alloy computed from that
+// query's text. The query_details collector populates it on each scrape; the
+// query_samples collector and the query_hash_info Prometheus collector read
+// from it.
+//
+// The size cap matches the pg_stat_statements.max default ceiling; TTL ensures
+// stale queryids don't keep being exported after the database evicts them.
+type QueryHashRegistry struct {
+	mu    sync.RWMutex
+	cache *expirable.LRU[string, QueryHashInfo]
+}
+
+func NewQueryHashRegistry(size int, ttl time.Duration) *QueryHashRegistry {
+	return &QueryHashRegistry{
+		cache: expirable.NewLRU[string, QueryHashInfo](size, nil, ttl),
+	}
+}
+
+func (r *QueryHashRegistry) Set(queryID, fingerprint, databaseName string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cache.Add(queryID, QueryHashInfo{
+		Fingerprint:  fingerprint,
+		DatabaseName: databaseName,
+		LastSeen:     time.Now(),
+	})
+}
+
+func (r *QueryHashRegistry) Get(queryID string) (QueryHashInfo, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.cache.Get(queryID)
+}
+
+// Snapshot returns a shallow copy of all live entries. Used by the metrics
+// collector at scrape time; not on the hot path of any collector.
+func (r *QueryHashRegistry) Snapshot() map[string]QueryHashInfo {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	out := make(map[string]QueryHashInfo, r.cache.Len())
+	for _, k := range r.cache.Keys() {
+		if v, ok := r.cache.Peek(k); ok {
+			out[k] = v
+		}
+	}
+	return out
+}

--- a/internal/component/database_observability/postgres/collector/query_hash_registry_test.go
+++ b/internal/component/database_observability/postgres/collector/query_hash_registry_test.go
@@ -1,0 +1,41 @@
+package collector
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryHashRegistry_SetAndGet(t *testing.T) {
+	r := NewQueryHashRegistry(100, time.Hour)
+	r.Set("123", "fp_a", "books")
+
+	info, ok := r.Get("123")
+	require.True(t, ok)
+	assert.Equal(t, "fp_a", info.Fingerprint)
+	assert.Equal(t, "books", info.DatabaseName)
+
+	_, ok = r.Get("missing")
+	assert.False(t, ok)
+}
+
+func TestQueryHashRegistry_Snapshot(t *testing.T) {
+	r := NewQueryHashRegistry(100, time.Hour)
+	r.Set("1", "fp_a", "db1")
+	r.Set("2", "fp_b", "db2")
+
+	snap := r.Snapshot()
+	assert.Len(t, snap, 2)
+	assert.Equal(t, "fp_a", snap["1"].Fingerprint)
+	assert.Equal(t, "fp_b", snap["2"].Fingerprint)
+}
+
+func TestQueryHashRegistry_TTLEviction(t *testing.T) {
+	r := NewQueryHashRegistry(100, 50*time.Millisecond)
+	r.Set("1", "fp_a", "db")
+	time.Sleep(80 * time.Millisecond)
+	_, ok := r.Get("1")
+	assert.False(t, ok, "entry should have expired")
+}

--- a/internal/component/database_observability/postgres/collector/query_samples.go
+++ b/internal/component/database_observability/postgres/collector/query_samples.go
@@ -111,6 +111,8 @@ type QuerySamplesArguments struct {
 	DisableQueryRedaction         bool
 	ExcludeCurrentUser            bool
 	EnablePreClassifiedWaitEvents bool
+	QueryHashRegistry             *QueryHashRegistry
+	TrackActivityQuerySize        int
 }
 
 type QuerySamples struct {
@@ -122,6 +124,8 @@ type QuerySamples struct {
 	disableQueryRedaction         bool
 	excludeCurrentUser            bool
 	enablePreClassifiedWaitEvents bool
+	queryHashRegistry             *QueryHashRegistry
+	trackActivityQuerySize        int
 
 	logger  log.Logger
 	running *atomic.Bool
@@ -232,6 +236,8 @@ func NewQuerySamples(args QuerySamplesArguments) (*QuerySamples, error) {
 		disableQueryRedaction:         args.DisableQueryRedaction,
 		excludeCurrentUser:            args.ExcludeCurrentUser,
 		enablePreClassifiedWaitEvents: args.EnablePreClassifiedWaitEvents,
+		queryHashRegistry:             args.QueryHashRegistry,
+		trackActivityQuerySize:        args.TrackActivityQuerySize,
 		logger:                        log.With(args.Logger, "collector", QuerySamplesCollector),
 		running:                       &atomic.Bool{},
 		samples:                       map[SampleKey]*SampleState{},

--- a/internal/component/database_observability/postgres/collector/query_samples.go
+++ b/internal/component/database_observability/postgres/collector/query_samples.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"slices"
+	"strconv"
 	"sync"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/component/database_observability"
+	"github.com/grafana/alloy/internal/component/database_observability/postgres/fingerprint"
 	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/grafana/alloy/internal/runtime/logging/level"
 )
@@ -164,7 +166,8 @@ type SampleState struct {
 	tracker     WaitEventTracker
 	// EndAt is the time we determined the sample ended (idle transition
 	// or when it was only observed idle), used to compute durations/timestamps.
-	EndAt sql.NullTime
+	EndAt            sql.NullTime
+	QueryFingerprint string
 }
 
 func (s *SampleState) updateCpuTime(sample QuerySamplesInfo) {
@@ -182,6 +185,33 @@ func (s *SampleState) setEndedAt(sample QuerySamplesInfo) {
 	}
 	s.EndAt = sql.NullTime{Time: sample.Now, Valid: true}
 	s.LastSeenAt = sample.Now
+}
+
+// resolveQueryFingerprint returns the fingerprint to attach to a sample's
+// emitted Loki entry. Preference order:
+//  1. Registry hit on queryid (computed from un-truncated pg_stat_statements text).
+//  2. Direct fingerprint of the sample's (possibly truncated) query text — only
+//     when query redaction is disabled, since that's the only time we have text.
+//
+// Empty string is returned when neither path is available; callers should
+// simply omit the label.
+func (c *QuerySamples) resolveQueryFingerprint(sample QuerySamplesInfo) string {
+	if c.queryHashRegistry != nil && sample.QueryID.Valid {
+		if info, ok := c.queryHashRegistry.Get(strconv.FormatInt(sample.QueryID.Int64, 10)); ok {
+			return info.Fingerprint
+		}
+	}
+	if c.disableQueryRedaction && sample.Query.Valid {
+		fp, _, err := fingerprint.Fingerprint(
+			sample.Query.String,
+			fingerprint.SourcePgStatActivity,
+			c.trackActivityQuerySize,
+		)
+		if err == nil {
+			return fp
+		}
+	}
+	return ""
 }
 
 // WaitEventTracker coalesces consecutive identical wait events
@@ -342,6 +372,7 @@ func (c *QuerySamples) fetchQuerySample(ctx context.Context) error {
 				newIdleState := &SampleState{LastRow: sample, tracker: newWaitEventTracker()}
 				newIdleState.setEndedAt(sample)
 				newIdleState.LastRow.State = sample.State
+				newIdleState.QueryFingerprint = c.resolveQueryFingerprint(sample)
 				c.samples[key] = newIdleState
 				c.idleEmitted.Add(key, struct{}{}) // is actually emitted at the end of the loop
 			}
@@ -432,6 +463,9 @@ func (c *QuerySamples) upsertActiveSample(key SampleKey, sample QuerySamplesInfo
 	state.LastSeenAt = sample.Now
 	state.updateCpuTime(sample)
 	state.LastRow.State = sample.State
+	if state.QueryFingerprint == "" {
+		state.QueryFingerprint = c.resolveQueryFingerprint(sample)
+	}
 	state.tracker.upsertWaitEvent(sample, sample.Now)
 }
 
@@ -557,6 +591,9 @@ func (c *QuerySamples) buildQuerySampleLabelsWithEnd(state *SampleState, endAt s
 	if c.disableQueryRedaction && state.LastRow.Query.Valid {
 		labels = fmt.Sprintf(`%s query="%s"`, labels, state.LastRow.Query.String)
 	}
+	if state.QueryFingerprint != "" {
+		labels = fmt.Sprintf(`%s query_fingerprint="%s"`, labels, state.QueryFingerprint)
+	}
 	return labels
 }
 
@@ -566,7 +603,7 @@ func (c *QuerySamples) buildWaitEventLabels(state *SampleState, we WaitEventOccu
 	if state.LastRow.LeaderPID.Valid {
 		leaderPID = fmt.Sprintf(`%d`, state.LastRow.LeaderPID.Int64)
 	}
-	return fmt.Sprintf(
+	labels := fmt.Sprintf(
 		`datname="%s" pid="%d" leader_pid="%s" user="%s" backend_type="%s" state="%s" xid="%d" xmin="%d" wait_time="%s" wait_event_type="%s" wait_event="%s" wait_event_name="%s" blocked_by_pids="%v" queryid="%d"`,
 		state.LastRow.DatabaseName.String,
 		state.LastRow.PID,
@@ -583,6 +620,10 @@ func (c *QuerySamples) buildWaitEventLabels(state *SampleState, we WaitEventOccu
 		we.BlockedByPIDs,
 		state.LastRow.QueryID.Int64,
 	)
+	if state.QueryFingerprint != "" {
+		labels = fmt.Sprintf(`%s query_fingerprint="%s"`, labels, state.QueryFingerprint)
+	}
+	return labels
 }
 
 func calculateDuration(nullableTime sql.NullTime, currentTime time.Time) string {
@@ -631,7 +672,7 @@ func (c *QuerySamples) buildWaitEventV2Labels(state *SampleState, we WaitEventOc
 	if state.LastRow.LeaderPID.Valid {
 		leaderPID = fmt.Sprintf(`%d`, state.LastRow.LeaderPID.Int64)
 	}
-	return fmt.Sprintf(
+	labels := fmt.Sprintf(
 		`datname="%s" pid="%d" leader_pid="%s" user="%s" backend_type="%s" state="%s" xid="%d" xmin="%d" wait_time="%s" wait_event_type="%s" wait_event="%s" wait_event_name="%s" blocked_by_pids="%v" queryid="%d"`,
 		state.LastRow.DatabaseName.String,
 		state.LastRow.PID,
@@ -648,6 +689,10 @@ func (c *QuerySamples) buildWaitEventV2Labels(state *SampleState, we WaitEventOc
 		we.BlockedByPIDs,
 		state.LastRow.QueryID.Int64,
 	)
+	if state.QueryFingerprint != "" {
+		labels = fmt.Sprintf(`%s query_fingerprint="%s"`, labels, state.QueryFingerprint)
+	}
+	return labels
 }
 
 // classifyPostgresWaitEventType maps a raw PostgreSQL wait event type to a standardized category.

--- a/internal/component/database_observability/postgres/collector/query_samples_test.go
+++ b/internal/component/database_observability/postgres/collector/query_samples_test.go
@@ -17,10 +17,31 @@ import (
 	"go.uber.org/goleak"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/component/database_observability/postgres/fingerprint"
 	"github.com/grafana/alloy/internal/util/syncbuffer"
 )
 
 var errMockQuerySamplesFailed = errors.New("test-error")
+
+// substituteQuerySamplesFingerprint replaces placeholders of the form
+// "<fp:QUERY TEXT>" with the activity-source fingerprint of QUERY TEXT,
+// avoiding the need to hard-code fingerprint hex in test expectations.
+func substituteQuerySamplesFingerprint(t *testing.T, line string) string {
+	t.Helper()
+	for {
+		start := strings.Index(line, "<fp:")
+		if start < 0 {
+			return line
+		}
+		end := strings.Index(line[start:], ">")
+		require.GreaterOrEqual(t, end, 0, "unterminated <fp:...> placeholder in %q", line)
+		end += start
+		queryText := line[start+len("<fp:") : end]
+		fp, _, err := fingerprint.Fingerprint(queryText, fingerprint.SourcePgStatActivity, 0)
+		require.NoError(t, err)
+		line = line[:start] + fp + line[end+1:]
+	}
+}
 
 func TestQuerySamples_FetchQuerySamples(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"))
@@ -136,7 +157,7 @@ func TestQuerySamples_FetchQuerySamples(t *testing.T) {
 				{"op": OP_QUERY_SAMPLE},
 			},
 			expectedLines: []string{
-				`level="info" datname="testdb" pid="106" leader_pid="" user="testuser" app="testapp" client="127.0.0.1:5432" backend_type="client backend" state="active" xid="0" xmin="0" xact_time="2m0s" query_time="30s" queryid="128" cpu_time="10s" query="SELECT * FROM users WHERE id = 123 AND email = 'test@example.com'"`,
+				`level="info" datname="testdb" pid="106" leader_pid="" user="testuser" app="testapp" client="127.0.0.1:5432" backend_type="client backend" state="active" xid="0" xmin="0" xact_time="2m0s" query_time="30s" queryid="128" cpu_time="10s" query="SELECT * FROM users WHERE id = 123 AND email = 'test@example.com'" query_fingerprint="<fp:SELECT * FROM users WHERE id = 123 AND email = 'test@example.com'>"`,
 			},
 		},
 	}
@@ -177,7 +198,7 @@ func TestQuerySamples_FetchQuerySamples(t *testing.T) {
 				if !reflect.DeepEqual(entry.Labels, tc.expectedLabels[i]) {
 					t.Errorf("expected label %v, got %v", tc.expectedLabels[i], entry.Labels)
 				}
-				require.Equal(t, entry.Line, tc.expectedLines[i])
+				require.Equal(t, entry.Line, substituteQuerySamplesFingerprint(t, tc.expectedLines[i]))
 				// Verify that BuildLokiEntryWithTimestamp is setting the timestamp correctly
 				expectedTimestamp := time.Unix(0, now.UnixNano())
 				require.True(t, entry.Timestamp.Equal(expectedTimestamp))
@@ -193,6 +214,126 @@ func TestQuerySamples_FetchQuerySamples(t *testing.T) {
 			}, 5*time.Second, 100*time.Millisecond)
 		})
 	}
+}
+
+func TestQuerySamples_EmitsQueryFingerprint(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"))
+
+	now := time.Now()
+	stateChangeTime := now.Add(-10 * time.Second)
+	queryStartTime := now.Add(-30 * time.Second)
+	xactStartTime := now.Add(-2 * time.Minute)
+	backendStartTime := now.Add(-1 * time.Hour)
+
+	columns := []string{
+		"now", "datname", "pid", "leader_pid",
+		"usename", "application_name", "client_addr", "client_port",
+		"backend_type", "backend_start", "backend_xid", "backend_xmin",
+		"xact_start", "state", "state_change", "wait_event_type",
+		"wait_event", "blocked_by_pids", "query_start", "query_id",
+	}
+
+	t.Run("registry hit attaches fingerprint to sample and wait_event", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, "", exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows(columns).AddRow(
+				now, "books", 200, sql.NullInt64{},
+				"testuser", "testapp", "127.0.0.1", 5432,
+				"client backend", backendStartTime, sql.NullInt32{}, sql.NullInt32{},
+				xactStartTime, "waiting", stateChangeTime, sql.NullString{String: "Lock", Valid: true},
+				sql.NullString{String: "relation", Valid: true}, pq.Int64Array{201}, queryStartTime, sql.NullInt64{Int64: 9876, Valid: true},
+			))
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, "", exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows(columns))
+
+		registry := NewQueryHashRegistry(100, time.Hour)
+		registry.Set("9876", "FP_REGISTRY_HIT", "books")
+
+		lokiClient := loki.NewCollectingHandler()
+		defer lokiClient.Stop()
+
+		col, err := NewQuerySamples(QuerySamplesArguments{
+			DB:                 db,
+			CollectInterval:    time.Millisecond,
+			EntryHandler:       lokiClient,
+			Logger:             log.NewNopLogger(),
+			QueryHashRegistry:  registry,
+			ExcludeCurrentUser: true,
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, col.Start(t.Context()))
+
+		require.Eventually(t, func() bool { return len(lokiClient.Received()) >= 2 }, 5*time.Second, 100*time.Millisecond)
+
+		col.Stop()
+		require.Eventually(t, func() bool { return col.Stopped() }, 5*time.Second, 100*time.Millisecond)
+
+		entries := lokiClient.Received()
+		require.GreaterOrEqual(t, len(entries), 2)
+		for _, e := range entries {
+			require.Contains(t, e.Line, `query_fingerprint="FP_REGISTRY_HIT"`, "every emitted op should carry the fingerprint label")
+		}
+	})
+
+	t.Run("registry miss falls back to fingerprinting query text when redaction disabled", func(t *testing.T) {
+		t.Parallel()
+
+		const sqlText = "SELECT * FROM books WHERE id = 5"
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows(append(columns, "query")).AddRow(
+				now, "books", 300, sql.NullInt64{},
+				"testuser", "testapp", "127.0.0.1", 5432,
+				"client backend", backendStartTime, sql.NullInt32{}, sql.NullInt32{},
+				xactStartTime, "active", stateChangeTime, sql.NullString{},
+				sql.NullString{}, nil, queryStartTime, sql.NullInt64{Int64: 1234, Valid: true},
+				sqlText,
+			))
+		mock.ExpectQuery(fmt.Sprintf(selectPgStatActivity, queryTextClause, exclusionClause, excludeCurrentUserClause, "")).RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows(append(columns, "query")))
+
+		expectedFP, _, fpErr := fingerprint.Fingerprint(sqlText, fingerprint.SourcePgStatActivity, 0)
+		require.NoError(t, fpErr)
+		require.NotEmpty(t, expectedFP)
+
+		// Empty registry — verify the fallback path runs.
+		registry := NewQueryHashRegistry(100, time.Hour)
+
+		lokiClient := loki.NewCollectingHandler()
+		defer lokiClient.Stop()
+
+		col, err := NewQuerySamples(QuerySamplesArguments{
+			DB:                    db,
+			CollectInterval:       time.Millisecond,
+			EntryHandler:          lokiClient,
+			Logger:                log.NewNopLogger(),
+			DisableQueryRedaction: true,
+			QueryHashRegistry:     registry,
+			ExcludeCurrentUser:    true,
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, col.Start(t.Context()))
+
+		require.Eventually(t, func() bool { return len(lokiClient.Received()) >= 1 }, 5*time.Second, 100*time.Millisecond)
+
+		col.Stop()
+		require.Eventually(t, func() bool { return col.Stopped() }, 5*time.Second, 100*time.Millisecond)
+
+		entries := lokiClient.Received()
+		require.NotEmpty(t, entries)
+		require.Contains(t, entries[0].Line, fmt.Sprintf(`query_fingerprint="%s"`, expectedFP))
+	})
 }
 
 // TestQuerySamples_FetchQuerySamples_ErrorCases tests scenarios where errors occur
@@ -374,7 +515,7 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 		entries := lokiClient.Received()
 		require.Len(t, entries, 1)
 		require.Equal(t, model.LabelSet{"op": OP_QUERY_SAMPLE}, entries[0].Labels)
-		require.Equal(t, `level="info" datname="testdb" pid="1000" leader_pid="" user="testuser" app="testapp" client="127.0.0.1:5432" backend_type="client backend" state="active" xid="10" xmin="20" xact_time="2m0s" query_time="30s" queryid="999" cpu_time="10s" query="SELECT * FROM t"`, entries[0].Line)
+		require.Equal(t, substituteQuerySamplesFingerprint(t, `level="info" datname="testdb" pid="1000" leader_pid="" user="testuser" app="testapp" client="127.0.0.1:5432" backend_type="client backend" state="active" xid="10" xmin="20" xact_time="2m0s" query_time="30s" queryid="999" cpu_time="10s" query="SELECT * FROM t" query_fingerprint="<fp:SELECT * FROM t>"`), entries[0].Line)
 		expectedTimestamp := time.Unix(0, now.UnixNano())
 		require.True(t, entries[0].Timestamp.Equal(expectedTimestamp))
 
@@ -443,7 +584,7 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 		require.Len(t, entries, 2)
 		require.Equal(t, model.LabelSet{"op": OP_QUERY_SAMPLE}, entries[0].Labels)
 		require.Equal(t, model.LabelSet{"op": OP_WAIT_EVENT}, entries[1].Labels)
-		require.Equal(t, `level="info" datname="testdb" pid="300" leader_pid="" user="testuser" backend_type="client backend" state="waiting" xid="0" xmin="0" wait_time="12s" wait_event_type="Lock" wait_event="relation" wait_event_name="Lock:relation" blocked_by_pids="[103 104]" queryid="124"`, entries[1].Line)
+		require.Equal(t, substituteQuerySamplesFingerprint(t, `level="info" datname="testdb" pid="300" leader_pid="" user="testuser" backend_type="client backend" state="waiting" xid="0" xmin="0" wait_time="12s" wait_event_type="Lock" wait_event="relation" wait_event_name="Lock:relation" blocked_by_pids="[103 104]" queryid="124" query_fingerprint="<fp:UPDATE users SET status = 'active'>"`), entries[1].Line)
 
 		sampleCollector.Stop()
 		require.Eventually(t, func() bool {
@@ -509,9 +650,9 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 		entries := lokiClient.Received()
 		require.Len(t, entries, 2)
 		require.Equal(t, model.LabelSet{"op": OP_QUERY_SAMPLE}, entries[0].Labels)
-		require.Equal(t, `level="info" datname="testdb" pid="301" leader_pid="" user="testuser" app="testapp" client="127.0.0.1:5432" backend_type="client backend" state="active" xid="0" xmin="0" xact_time="2m0s" query_time="0s" queryid="555" cpu_time="0s" query="UPDATE users SET status = 'active'"`, entries[0].Line)
+		require.Equal(t, substituteQuerySamplesFingerprint(t, `level="info" datname="testdb" pid="301" leader_pid="" user="testuser" app="testapp" client="127.0.0.1:5432" backend_type="client backend" state="active" xid="0" xmin="0" xact_time="2m0s" query_time="0s" queryid="555" cpu_time="0s" query="UPDATE users SET status = 'active'" query_fingerprint="<fp:UPDATE users SET status = 'active'>"`), entries[0].Line)
 		require.Equal(t, model.LabelSet{"op": OP_WAIT_EVENT}, entries[1].Labels)
-		require.Equal(t, `level="info" datname="testdb" pid="301" leader_pid="" user="testuser" backend_type="client backend" state="active" xid="0" xmin="0" wait_time="10s" wait_event_type="Lock" wait_event="relation" wait_event_name="Lock:relation" blocked_by_pids="[103 104]" queryid="555"`, entries[1].Line)
+		require.Equal(t, substituteQuerySamplesFingerprint(t, `level="info" datname="testdb" pid="301" leader_pid="" user="testuser" backend_type="client backend" state="active" xid="0" xmin="0" wait_time="10s" wait_event_type="Lock" wait_event="relation" wait_event_name="Lock:relation" blocked_by_pids="[103 104]" queryid="555" query_fingerprint="<fp:UPDATE users SET status = 'active'>"`), entries[1].Line)
 
 		sampleCollector.Stop()
 		require.Eventually(t, func() bool {
@@ -577,9 +718,9 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 		entries := lokiClient.Received()
 		require.Len(t, entries, 2)
 		require.Equal(t, model.LabelSet{"op": OP_QUERY_SAMPLE}, entries[0].Labels)
-		require.Equal(t, `level="info" datname="testdb" pid="402" leader_pid="" user="testuser" app="testapp" client="127.0.0.1:5432" backend_type="client backend" state="waiting" xid="0" xmin="0" xact_time="2m0s" query_time="30s" queryid="9002" cpu_time="10s" query="SELECT * FROM t"`, entries[0].Line)
+		require.Equal(t, substituteQuerySamplesFingerprint(t, `level="info" datname="testdb" pid="402" leader_pid="" user="testuser" app="testapp" client="127.0.0.1:5432" backend_type="client backend" state="waiting" xid="0" xmin="0" xact_time="2m0s" query_time="30s" queryid="9002" cpu_time="10s" query="SELECT * FROM t" query_fingerprint="<fp:SELECT * FROM t>"`), entries[0].Line)
 		require.Equal(t, model.LabelSet{"op": OP_WAIT_EVENT}, entries[1].Labels)
-		require.Equal(t, `level="info" datname="testdb" pid="402" leader_pid="" user="testuser" backend_type="client backend" state="waiting" xid="0" xmin="0" wait_time="7s" wait_event_type="IO" wait_event="DataFileRead" wait_event_name="IO:DataFileRead" blocked_by_pids="[501]" queryid="9002"`, entries[1].Line)
+		require.Equal(t, substituteQuerySamplesFingerprint(t, `level="info" datname="testdb" pid="402" leader_pid="" user="testuser" backend_type="client backend" state="waiting" xid="0" xmin="0" wait_time="7s" wait_event_type="IO" wait_event="DataFileRead" wait_event_name="IO:DataFileRead" blocked_by_pids="[501]" queryid="9002" query_fingerprint="<fp:SELECT * FROM t>"`), entries[1].Line)
 
 		sampleCollector.Stop()
 		require.Eventually(t, func() bool {
@@ -645,11 +786,11 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 		entries := lokiClient.Received()
 		require.Len(t, entries, 3)
 		require.Equal(t, model.LabelSet{"op": OP_QUERY_SAMPLE}, entries[0].Labels)
-		require.Equal(t, `level="info" datname="testdb" pid="403" leader_pid="" user="testuser" app="testapp" client="127.0.0.1:5432" backend_type="client backend" state="waiting" xid="0" xmin="0" xact_time="2m0s" query_time="30s" queryid="9003" query="UPDATE t SET c=1"`, entries[0].Line)
+		require.Equal(t, substituteQuerySamplesFingerprint(t, `level="info" datname="testdb" pid="403" leader_pid="" user="testuser" app="testapp" client="127.0.0.1:5432" backend_type="client backend" state="waiting" xid="0" xmin="0" xact_time="2m0s" query_time="30s" queryid="9003" query="UPDATE t SET c=1" query_fingerprint="<fp:UPDATE t SET c=1>"`), entries[0].Line)
 		require.Equal(t, model.LabelSet{"op": OP_WAIT_EVENT}, entries[1].Labels)
-		require.Equal(t, `level="info" datname="testdb" pid="403" leader_pid="" user="testuser" backend_type="client backend" state="waiting" xid="0" xmin="0" wait_time="5s" wait_event_type="Lock" wait_event="relation" wait_event_name="Lock:relation" blocked_by_pids="[103]" queryid="9003"`, entries[1].Line)
+		require.Equal(t, substituteQuerySamplesFingerprint(t, `level="info" datname="testdb" pid="403" leader_pid="" user="testuser" backend_type="client backend" state="waiting" xid="0" xmin="0" wait_time="5s" wait_event_type="Lock" wait_event="relation" wait_event_name="Lock:relation" blocked_by_pids="[103]" queryid="9003" query_fingerprint="<fp:UPDATE t SET c=1>"`), entries[1].Line)
 		require.Equal(t, model.LabelSet{"op": OP_WAIT_EVENT}, entries[2].Labels)
-		require.Equal(t, `level="info" datname="testdb" pid="403" leader_pid="" user="testuser" backend_type="client backend" state="waiting" xid="0" xmin="0" wait_time="8s" wait_event_type="Lock" wait_event="relation" wait_event_name="Lock:relation" blocked_by_pids="[103 104]" queryid="9003"`, entries[2].Line)
+		require.Equal(t, substituteQuerySamplesFingerprint(t, `level="info" datname="testdb" pid="403" leader_pid="" user="testuser" backend_type="client backend" state="waiting" xid="0" xmin="0" wait_time="8s" wait_event_type="Lock" wait_event="relation" wait_event_name="Lock:relation" blocked_by_pids="[103 104]" queryid="9003" query_fingerprint="<fp:UPDATE t SET c=1>"`), entries[2].Line)
 
 		sampleCollector.Stop()
 		require.Eventually(t, func() bool {

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -240,6 +240,7 @@ type Component struct {
 	openSQL            func(driverName, dataSourceName string) (*sql.DB, error)
 	logsReceiver       loki.LogsReceiver
 	exporterCollectors []prometheus.Collector
+	queryHashRegistry  *collector.QueryHashRegistry
 }
 
 func New(opts component.Options, args Arguments) (*Component, error) {
@@ -433,6 +434,16 @@ func (c *Component) connectAndStartCollectors(ctx context.Context) error {
 		cp = cloudProvider
 	}
 
+	const queryHashRegistrySize = 5000 // matches pg_stat_statements.max default ceiling
+	const queryHashRegistryTTL = 30 * time.Minute
+	c.queryHashRegistry = collector.NewQueryHashRegistry(queryHashRegistrySize, queryHashRegistryTTL)
+
+	queryHashMetrics := collector.NewQueryHashMetricsCollector(c.queryHashRegistry, generatedSystemID)
+	if err := c.registry.Register(queryHashMetrics); err != nil {
+		return fmt.Errorf("failed to register query_hash_info metrics: %w", err)
+	}
+	c.exporterCollectors = append(c.exporterCollectors, queryHashMetrics)
+
 	if len(c.args.Targets) == 0 {
 		if c.args.PrometheusExporter == nil {
 			d := PrometheusExporterArguments(exporter_postgres.DefaultArguments)
@@ -589,14 +600,15 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 
 	if collectors[collector.QueryDetailsCollector] {
 		qCollector, err := collector.NewQueryDetails(collector.QueryDetailsArguments{
-			DB:               c.dbConnection,
-			CollectInterval:  c.args.QueryDetailsArguments.CollectInterval,
-			StatementsLimit:  c.args.QueryDetailsArguments.StatementsLimit,
-			ExcludeDatabases: c.args.ExcludeDatabases,
-			ExcludeUsers:     c.args.ExcludeUsers,
-			EntryHandler:     entryHandler,
-			TableRegistry:    tableRegistry,
-			Logger:           c.opts.Logger,
+			DB:                c.dbConnection,
+			CollectInterval:   c.args.QueryDetailsArguments.CollectInterval,
+			StatementsLimit:   c.args.QueryDetailsArguments.StatementsLimit,
+			ExcludeDatabases:  c.args.ExcludeDatabases,
+			ExcludeUsers:      c.args.ExcludeUsers,
+			EntryHandler:      entryHandler,
+			TableRegistry:     tableRegistry,
+			Logger:            c.opts.Logger,
+			QueryHashRegistry: c.queryHashRegistry,
 		})
 		if err != nil {
 			logStartError(collector.QueryDetailsCollector, "create", err)

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"path"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -417,6 +418,18 @@ func (c *Component) connectAndStartCollectors(ctx context.Context) error {
 		return fmt.Errorf("failed to scan engine version: %w", err)
 	}
 
+	var trackActivityQuerySize int
+	{
+		var raw sql.NullString
+		if err := dbConnection.QueryRowContext(ctx, "SELECT setting FROM pg_settings WHERE name = 'track_activity_query_size'").Scan(&raw); err != nil {
+			level.Warn(c.opts.Logger).Log("msg", "failed to read track_activity_query_size; truncation sentinel will not fire", "err", err)
+		} else if raw.Valid {
+			if v, err := strconv.Atoi(raw.String); err == nil {
+				trackActivityQuerySize = v
+			}
+		}
+	}
+
 	generatedSystemID := fmt.Sprintf("%x", sha256.Sum256([]byte(fmt.Sprintf("%s:%s:%s", systemID.String, systemIP.String, systemPort.String))))
 
 	var cp *database_observability.CloudProvider
@@ -515,7 +528,7 @@ func (c *Component) connectAndStartCollectors(ctx context.Context) error {
 	}
 	c.collectors = nil
 
-	if err := c.startCollectors(generatedSystemID, engineVersion.String, cp); err != nil {
+	if err := c.startCollectors(generatedSystemID, engineVersion.String, cp, trackActivityQuerySize); err != nil {
 		return fmt.Errorf("failed to start collectors: %w", err)
 	}
 
@@ -562,7 +575,7 @@ func enableOrDisableCollectors(a Arguments) map[string]bool {
 }
 
 // startCollectors attempts to start all of the enabled collectors. If one or more collectors fail to start, their errors are reported
-func (c *Component) startCollectors(systemID string, engineVersion string, cloudProviderInfo *database_observability.CloudProvider) error {
+func (c *Component) startCollectors(systemID string, engineVersion string, cloudProviderInfo *database_observability.CloudProvider, trackActivityQuerySize int) error {
 	var startErrors []string
 
 	logStartError := func(collectorName, action string, err error) {
@@ -630,6 +643,8 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 			DisableQueryRedaction:         c.args.QuerySampleArguments.DisableQueryRedaction,
 			ExcludeCurrentUser:            c.args.QuerySampleArguments.ExcludeCurrentUser,
 			EnablePreClassifiedWaitEvents: c.args.QuerySampleArguments.EnablePreClassifiedWaitEvents,
+			QueryHashRegistry:             c.queryHashRegistry,
+			TrackActivityQuerySize:        trackActivityQuerySize,
 		})
 		if err != nil {
 			logStartError(collector.QuerySamplesCollector, "create", err)

--- a/internal/component/database_observability/postgres/fingerprint/fingerprint.go
+++ b/internal/component/database_observability/postgres/fingerprint/fingerprint.go
@@ -1,0 +1,112 @@
+// Package fingerprint computes stable, semantic SQL fingerprints for PostgreSQL
+// query text using the libpg_query parser (via pg_query_go).
+//
+// The same fingerprint is produced by Alloy regardless of comments, whitespace,
+// or literal-vs-placeholder differences, allowing pg_stat_statements metrics,
+// pg_stat_activity samples, and server-log query text to be correlated by a
+// single client-side identifier — including on managed services (RDS, Aurora)
+// that do not expose pg_stat_statements.queryid in log_line_prefix.
+package fingerprint
+
+import (
+	"errors"
+	"strings"
+
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+)
+
+// Source describes which PostgreSQL surface the query text was read from.
+// It only affects the sentinel chosen when both parse and repair fail.
+type Source int
+
+const (
+	SourcePgStatStatements Source = iota
+	SourcePgStatActivity
+	SourceLog
+)
+
+// Sentinel strings used when query text cannot be parsed even after repair.
+// These match the sentinels used by pganalyze's collector so existing
+// dashboards built around their values port over without changes.
+const (
+	SentinelTruncated  = "<truncated query>"
+	SentinelUnparsable = "<unparsable query>"
+)
+
+// ErrEmpty is returned when the input is empty or whitespace-only. Callers
+// should skip emitting fingerprints for these (don't even use a sentinel).
+var ErrEmpty = errors.New("fingerprint: empty query text")
+
+// Fingerprint runs the three-stage pipeline:
+//  1. Parse the input as-is.
+//  2. If parsing fails, balance unclosed quotes and parentheses and retry.
+//  3. If parsing still fails, return a sentinel fingerprint.
+//
+// trackActivityQuerySize is the value of the postgres setting
+// `track_activity_query_size` and is only consulted when source ==
+// SourcePgStatActivity. Pass 0 for other sources.
+//
+// The returned `repaired` flag reports whether stage 2 was needed; callers may
+// log this as a metric to detect upstream truncation issues.
+func Fingerprint(query string, source Source, trackActivityQuerySize int) (fp string, repaired bool, err error) {
+	if strings.TrimSpace(query) == "" {
+		return "", false, ErrEmpty
+	}
+
+	if fp, perr := pg_query.Fingerprint(query); perr == nil {
+		return fp, false, nil
+	}
+
+	fixed := repair(query)
+	if fp, perr := pg_query.Fingerprint(fixed); perr == nil {
+		return fp, true, nil
+	}
+
+	return sentinelFingerprint(query, source, trackActivityQuerySize), true, nil
+}
+
+// FingerprintOf hashes a known sentinel string deterministically. Exported so
+// tests and callers can compare against the values produced for sentinels.
+func FingerprintOf(text string) string {
+	if fp, err := pg_query.Fingerprint(text); err == nil && fp != "" {
+		return fp
+	}
+	// pg_query.Fingerprint may not parse a non-SQL sentinel; fall back to a
+	// deterministic hash of the text. pg_query.HashXXH3_64 is what pganalyze
+	// uses for static texts (util/fingerprint.go).
+	return formatHash(pg_query.HashXXH3_64([]byte(text), 0xee))
+}
+
+func sentinelFingerprint(query string, source Source, trackActivityQuerySize int) string {
+	if source == SourcePgStatActivity && trackActivityQuerySize > 0 && len(query) == trackActivityQuerySize-1 {
+		return FingerprintOf(SentinelTruncated)
+	}
+	return FingerprintOf(SentinelUnparsable)
+}
+
+// repair closes unclosed single/double quotes and balances unclosed
+// parentheses, mirroring pganalyze's `fixTruncatedQuery`. The repaired text
+// is only used for fingerprint computation — it is not emitted anywhere.
+func repair(query string) string {
+	if strings.Count(query, "'")%2 == 1 {
+		query += "'"
+	}
+	if strings.Count(query, "\"")%2 == 1 {
+		query += "\""
+	}
+	open := strings.Count(query, "(") - strings.Count(query, ")")
+	for i := 0; i < open; i++ {
+		query += ")"
+	}
+	return query
+}
+
+func formatHash(h uint64) string {
+	const hexChars = "0123456789abcdef"
+	out := make([]byte, 16)
+	for i := 15; i >= 0; i-- {
+		out[i] = hexChars[h&0xF]
+		h >>= 4
+	}
+	return string(out)
+}

--- a/internal/component/database_observability/postgres/fingerprint/fingerprint.go
+++ b/internal/component/database_observability/postgres/fingerprint/fingerprint.go
@@ -37,6 +37,11 @@ const (
 // should skip emitting fingerprints for these (don't even use a sentinel).
 var ErrEmpty = errors.New("fingerprint: empty query text")
 
+var (
+	sentinelTruncatedFp  = FingerprintOf(SentinelTruncated)
+	sentinelUnparsableFp = FingerprintOf(SentinelUnparsable)
+)
+
 // Fingerprint runs the three-stage pipeline:
 //  1. Parse the input as-is.
 //  2. If parsing fails, balance unclosed quotes and parentheses and retry.
@@ -46,8 +51,13 @@ var ErrEmpty = errors.New("fingerprint: empty query text")
 // `track_activity_query_size` and is only consulted when source ==
 // SourcePgStatActivity. Pass 0 for other sources.
 //
-// The returned `repaired` flag reports whether stage 2 was needed; callers may
-// log this as a metric to detect upstream truncation issues.
+// The returned `repaired` flag is true when the input did NOT parse as-is
+// (i.e. either stage 2 succeeded, or both stage 2 and stage 3 ran). To
+// distinguish a successful repair from a sentinel fallback, compare the
+// returned fingerprint against FingerprintOf(SentinelTruncated) /
+// FingerprintOf(SentinelUnparsable). Callers may log `repaired` as a metric
+// to detect upstream truncation issues, and the sentinel fingerprints as
+// separate counters to detect parse failures Alloy could not recover from.
 func Fingerprint(query string, source Source, trackActivityQuerySize int) (fp string, repaired bool, err error) {
 	if strings.TrimSpace(query) == "" {
 		return "", false, ErrEmpty
@@ -79,14 +89,26 @@ func FingerprintOf(text string) string {
 
 func sentinelFingerprint(query string, source Source, trackActivityQuerySize int) string {
 	if source == SourcePgStatActivity && trackActivityQuerySize > 0 && len(query) == trackActivityQuerySize-1 {
-		return FingerprintOf(SentinelTruncated)
+		return sentinelTruncatedFp
 	}
-	return FingerprintOf(SentinelUnparsable)
+	return sentinelUnparsableFp
 }
 
 // repair closes unclosed single/double quotes and balances unclosed
 // parentheses, mirroring pganalyze's `fixTruncatedQuery`. The repaired text
 // is only used for fingerprint computation — it is not emitted anywhere.
+//
+// This is a heuristic and has known false positives:
+//   - Doubled-apostrophe escapes inside string literals (`'O''Brien'`) are
+//     counted as four separate `'` characters, so a truncation mid-name like
+//     `'O''Brien` looks balanced and gets passed to the parser unrepaired.
+//   - Dollar-quoted strings (`$body$ ... $body$`) are not understood at all.
+//   - Backslash-escaped quotes (with `standard_conforming_strings = off`) are
+//     similarly miscounted.
+//
+// Quote-balancing must run before paren-balancing — a string that ends in
+// `'(` should have the quote closed first, or paren-balancing would append
+// `)` outside the (still unclosed) string.
 func repair(query string) string {
 	if strings.Count(query, "'")%2 == 1 {
 		query += "'"

--- a/internal/component/database_observability/postgres/fingerprint/fingerprint_test.go
+++ b/internal/component/database_observability/postgres/fingerprint/fingerprint_test.go
@@ -24,17 +24,23 @@ func TestFingerprint_DifferentForDifferentQueries(t *testing.T) {
 }
 
 func TestFingerprint_RepairUnclosedQuotes(t *testing.T) {
+	want, _, errWant := Fingerprint("SELECT * FROM t WHERE name = 'oh no'", SourceLog, 0)
+	require.NoError(t, errWant)
+
 	fp, repaired, err := Fingerprint("SELECT * FROM t WHERE name = 'oh no", SourceLog, 0)
 	require.NoError(t, err)
 	assert.True(t, repaired, "should report that repair was used")
-	assert.NotEqual(t, "", fp)
+	assert.Equal(t, want, fp, "repaired fingerprint must match the closed-quote form")
 }
 
 func TestFingerprint_RepairUnclosedParens(t *testing.T) {
+	want, _, errWant := Fingerprint("SELECT * FROM t WHERE id IN (1, 2, 3)", SourceLog, 0)
+	require.NoError(t, errWant)
+
 	fp, repaired, err := Fingerprint("SELECT * FROM t WHERE id IN (1, 2, 3", SourceLog, 0)
 	require.NoError(t, err)
 	assert.True(t, repaired)
-	assert.NotEqual(t, "", fp)
+	assert.Equal(t, want, fp, "repaired fingerprint must match the closed-paren form")
 }
 
 func TestFingerprint_TruncatedSentinelOnPgStatActivity(t *testing.T) {
@@ -55,6 +61,27 @@ func TestFingerprint_UnparsableSentinel(t *testing.T) {
 func TestFingerprint_EmptyAndNullInputs(t *testing.T) {
 	_, _, err := Fingerprint("", SourcePgStatStatements, 0)
 	assert.Error(t, err, "empty input should error so callers can skip emitting")
+}
+
+func TestFingerprint_SentinelStability(t *testing.T) {
+	t.Run("truncated sentinel is stable", func(t *testing.T) {
+		const trackSize = 1024
+		bad := makeUnparsableOfLen(trackSize - 1)
+
+		first, _, err1 := Fingerprint(bad, SourcePgStatActivity, trackSize)
+		require.NoError(t, err1)
+		second, _, err2 := Fingerprint(bad, SourcePgStatActivity, trackSize)
+		require.NoError(t, err2)
+		assert.Equal(t, first, second)
+		assert.Equal(t, FingerprintOf(SentinelTruncated), first)
+	})
+
+	t.Run("unparsable sentinel is stable", func(t *testing.T) {
+		first, _, _ := Fingerprint("$$$ not sql at all $$$", SourcePgStatStatements, 0)
+		second, _, _ := Fingerprint("$$$ not sql at all $$$", SourcePgStatStatements, 0)
+		assert.Equal(t, first, second)
+		assert.Equal(t, FingerprintOf(SentinelUnparsable), first)
+	})
 }
 
 // makeUnparsableOfLen returns a string of exactly n bytes that is invalid SQL

--- a/internal/component/database_observability/postgres/fingerprint/fingerprint_test.go
+++ b/internal/component/database_observability/postgres/fingerprint/fingerprint_test.go
@@ -1,0 +1,71 @@
+package fingerprint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFingerprint_StableAcrossCommentsAndWhitespace(t *testing.T) {
+	a, _, errA := Fingerprint("SELECT * FROM users WHERE id = $1 -- foo", SourcePgStatStatements, 0)
+	require.NoError(t, errA)
+	b, _, errB := Fingerprint("SELECT *\nFROM users\nWHERE id = $1 /* bar */", SourcePgStatStatements, 0)
+	require.NoError(t, errB)
+	assert.Equal(t, a, b)
+}
+
+func TestFingerprint_DifferentForDifferentQueries(t *testing.T) {
+	// Use structurally different queries — SQL fingerprinting normalises
+	// constants, so "SELECT 1" vs "SELECT 2" hash to the same value.
+	a, _, _ := Fingerprint("SELECT * FROM users", SourcePgStatStatements, 0)
+	b, _, _ := Fingerprint("SELECT * FROM products", SourcePgStatStatements, 0)
+	assert.NotEqual(t, a, b)
+}
+
+func TestFingerprint_RepairUnclosedQuotes(t *testing.T) {
+	fp, repaired, err := Fingerprint("SELECT * FROM t WHERE name = 'oh no", SourceLog, 0)
+	require.NoError(t, err)
+	assert.True(t, repaired, "should report that repair was used")
+	assert.NotEqual(t, "", fp)
+}
+
+func TestFingerprint_RepairUnclosedParens(t *testing.T) {
+	fp, repaired, err := Fingerprint("SELECT * FROM t WHERE id IN (1, 2, 3", SourceLog, 0)
+	require.NoError(t, err)
+	assert.True(t, repaired)
+	assert.NotEqual(t, "", fp)
+}
+
+func TestFingerprint_TruncatedSentinelOnPgStatActivity(t *testing.T) {
+	const trackSize = 1024
+	bad := makeUnparsableOfLen(trackSize - 1)
+
+	fp, _, err := Fingerprint(bad, SourcePgStatActivity, trackSize)
+	require.NoError(t, err)
+	assert.Equal(t, FingerprintOf(SentinelTruncated), fp)
+}
+
+func TestFingerprint_UnparsableSentinel(t *testing.T) {
+	fp, _, err := Fingerprint("$$$ not sql at all $$$", SourcePgStatStatements, 0)
+	require.NoError(t, err)
+	assert.Equal(t, FingerprintOf(SentinelUnparsable), fp)
+}
+
+func TestFingerprint_EmptyAndNullInputs(t *testing.T) {
+	_, _, err := Fingerprint("", SourcePgStatStatements, 0)
+	assert.Error(t, err, "empty input should error so callers can skip emitting")
+}
+
+// makeUnparsableOfLen returns a string of exactly n bytes that is invalid SQL
+// and remains unparseable even after repair() closes quotes/parentheses. This
+// is needed because repair() can salvage a truncated IN-list (SELECT … IN
+// (1,1,…) is valid once the paren is closed) so that path never reaches the
+// sentinel branch.
+func makeUnparsableOfLen(n int) string {
+	s := "NOT VALID SQL !!! "
+	for len(s) < n {
+		s += "x "
+	}
+	return s[:n]
+}


### PR DESCRIPTION
## Summary

Adds a semantic query fingerprint to `database_observability.postgres`, computed client-side from the parsed AST via [pg_query_go](https://github.com/pganalyze/pg_query_go). The same fingerprint value is emitted for `pg_stat_statements`, `pg_stat_activity`, and PostgreSQL server-log lines — including on managed services (RDS, Aurora) where `pg_stat_statements.queryid` is not available in `log_line_prefix`.

Implements **Option 1 + Option B** from `docs/design/XXXX-semantic-query-fingerprint.md` (compute via pg_query AST, augment alongside the existing `queryid` rather than replace it). Detailed implementation plan: `docs/superpowers/plans/2026-04-28-postgres-semantic-query-fingerprint.md`.

### What ships

- New Prometheus join metric `database_observability_query_hash_info{queryid, query_fingerprint, server_id, datname} = 1` exposed by the component. Dashboards attach the fingerprint to existing `pg_stat_statements_*` series via PromQL `* on(queryid, datname) group_left(query_fingerprint)` — **no cardinality bump on the source metrics**.
- `query_fingerprint` emitted on Loki entries:
  - `query_association` — inline field on the line
  - `query_sample`, `wait_event`, `wait_event_v2` — appended at end of line, conditional on non-empty
  - **New ops:**
    - `pg_error` — emitted from buffered ERROR/FATAL/PANIC + STATEMENT continuation pairs in PostgreSQL server logs; fingerprint as Loki structured metadata
    - `pg_slow_query` — emitted from `LOG: duration: <ms> ms statement: ...` lines; fingerprint as Loki structured metadata
- Three-stage fingerprint pipeline: parse-as-is → repair (close unclosed quotes/parens) → sentinel fallback (`<truncated query>` for `pg_stat_activity` at `track_activity_query_size - 1`, `<unparsable query>` otherwise). Sentinels are pre-cached so the hot path never re-parses them.

### Architecture

- New freestanding package `internal/component/database_observability/postgres/fingerprint/` (no `database_observability` imports — reusable for MySQL later).
- `QueryHashRegistry` (LRU+TTL cache) populated by `query_details` while it scrapes `pg_stat_statements`. `QueryHashMetricsCollector` exposes the registry as the join metric. `query_samples` consults the registry first (registry FP comes from un-truncated text), falling back to fingerprinting the truncated `pg_stat_activity.query` text using the truncation sentinel when redaction is disabled.
- Logs collector buffers ERROR/STATEMENT pairs by PID with a 5s timeout (configurable); on STATEMENT arrival or timeout, emits the `pg_error` Loki entry.
- Source timestamps preserved end-to-end on the new `pg_error` and `pg_slow_query` entries via a new `BuildLokiEntryWithTimestampAndStructuredMetadata` helper.

### Backwards compatibility

Fully backward-compatible:
- `pg_stat_statements_*` series unchanged.
- `database_observability_pg_errors_total` labels unchanged (deliberately did **not** add `query_fingerprint` as a label here — fingerprints can be highly cardinal; they live on Loki structured metadata for the new `pg_error` op instead).
- Existing log-line consumers continue to work — `query_fingerprint` on `query_sample`/`wait_event`/`wait_event_v2` lines is appended at the end and only when non-empty.

### Known follow-ups (not blocking)

- The PID-matching heuristic in `processContinuation` ("match most recent unmatched pending error") could mis-attribute under high-concurrency multi-backend log streams. PostgreSQL's `STATEMENT:` continuation does not carry the `log_line_prefix`, so PID extraction from the line itself is impossible. A `pg_error_continuation_mismatches_total` observability counter and/or upstream tailer-side PID propagation are reasonable future improvements.
- The `repaired` flag from `Fingerprint()` is computed but unused by callers — wiring it (and sentinel hits) into Prometheus counters would surface upstream-truncation issues.
- `grafana-dbo11y-app` PromQL/LogQL needs to migrate to consume `query_fingerprint` for grouping and log↔metric correlation — out of scope here, tracked separately.
- Eventual deprecation of native `queryid` (Option A) once the app migration completes.

## Test plan

- [x] `go test -count=1 ./internal/component/database_observability/...` — all green
- [x] `go vet ./internal/component/database_observability/...` — clean
- [x] CGo build succeeds (`CGO_ENABLED=1 go build ./internal/component/...`)
- [x] All pre-existing `TestQueryDetails*`, `TestQuerySamples*`, `TestLogs*` tests still pass with the new fingerprint plumbing
- [x] New tests use red→green TDD; no fingerprint hex hard-coded — every expected value is computed via `fingerprint.Fingerprint(...)` at test time so `pg_query_go` version bumps don't silently invalidate assertions
- [x] Unit tests cover: (a) registry hit, (b) text-fallback when redaction disabled, (c) STATEMENT-arrives `pg_error` path, (d) timeout-no-STATEMENT path with empty fingerprint, (e) slow-query parsing, (f) source-timestamp preservation on the new ops
- [ ] Manual smoke test against `postgres:18` with `pg_stat_statements` and `log_min_duration_statement=0`: confirm three `SELECT 1` comment variants collapse to a single fingerprint on `/metrics` and that slow-query log lines get a non-empty `query_fingerprint` structured-metadata field (instructions in plan §Task 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)