### PR TITLE
docs: Correct factual errors and add OS-specific information

### DIFF
--- a/docs/sources/data-collection.md
+++ b/docs/sources/data-collection.md
@@ -12,59 +12,59 @@ weight: 900
 {{< param "PRODUCT_NAME" >}} maintainers use this anonymous information to learn how the open source community runs {{< param "PRODUCT_NAME" >}}.
 This data helps the {{< param "PRODUCT_NAME" >}} team prioritize features and improve documentation.
 
-The anonymous usage statistics reporting is **enabled by default**.
-You can opt out by passing the [CLI flag][command line flag] `--disable-reporting`.
+{{< param "PRODUCT_NAME" >}} reports anonymous usage statistics by default.
+To opt out, use the [CLI flag][command line flag] `--disable-reporting`.
 
 ## The statistics server
 
-When usage statistics reporting is enabled, a server that Grafana Labs runs collects the information.
-The statistics are sent via HTTP POST to `https://stats.grafana.org/alloy-usage-report`.
-This is an ingest-only endpoint and isn't browsable.
+{{< param "PRODUCT_NAME" >}} sends usage statistics to a server that Grafana Labs runs.
+It sends data to `https://stats.grafana.org/alloy-usage-report` with an HTTP POST request.
+This endpoint only accepts data and isn't available to view in a browser.
 
-## Which information is collected
+## What {{% param "PRODUCT_NAME" %}} collects
 
-When usage statistics reporting is enabled, {{< param "PRODUCT_NAME" >}} collects the following information:
+{{< param "PRODUCT_NAME" >}} collects the following information:
 
-* A randomly generated, anonymous, unique ID (UUID).
-* The timestamp when the UUID was first generated.
-* The scheduled interval time for the report (by default, every four hours).
-* The version of {{< param "PRODUCT_NAME" >}}.
-* The operating system where {{< param "PRODUCT_NAME" >}} is running.
-* The system architecture where {{< param "PRODUCT_NAME" >}} is running.
-* A list of enabled [components][].
-* The deployment method for {{< param "PRODUCT_NAME" >}}, such as `docker`, `helm`, `operator`, `deb`, `rpm`, `brew`, or `binary`.
+- A randomly generated anonymous UUID.
+- The timestamp when {{< param "PRODUCT_NAME" >}} first created the UUID.
+- The scheduled report interval, which defaults to four hours.
+- The version of {{< param "PRODUCT_NAME" >}}.
+- The operating system where {{< param "PRODUCT_NAME" >}} runs.
+- The system architecture where {{< param "PRODUCT_NAME" >}} runs.
+- A list of enabled [components][].
+- The deployment method, such as `docker`, `helm`, `operator`, `deb`, `rpm`, `brew`, or `binary`.
 
 {{< admonition type="note" >}}
-{{< param "PRODUCT_NAME" >}} maintainers commit to keeping the list of tracked information updated over time.
-Any changes are reported in the CHANGELOG.
+{{< param "PRODUCT_NAME" >}} maintainers update this list of tracked information over time and report any changes in the CHANGELOG.
 {{< /admonition >}}
 
-## Disable the anonymous usage statistics reporting
+## Disable anonymous usage statistics
 
-If possible, we ask you to keep the usage reporting feature enabled to help us understand how the open source community runs {{< param "PRODUCT_NAME" >}}.
-If you want to opt out of anonymous usage statistics reporting, pass the [CLI flag][command line flag] `--disable-reporting`.
+If possible, keep this feature enabled.
+It helps Grafana Labs understand how the open source community uses {{< param "PRODUCT_NAME" >}}.
+To opt out of anonymous usage statistics, use the [CLI flag][command line flag] `--disable-reporting`.
 
-### Example: Opt-out of data collection with Ansible
+### Example: Opt out of data collection with Ansible
 
 ```yaml
 - name: Install Alloy
-  hosts: all
-  become: true
-  tasks:
-    - name: Install Alloy
-      ansible.builtin.include_role:
-        name: grafana.grafana.alloy
-      vars:
-        alloy_env_file_vars:
-          CUSTOM_ARGS: "--disable-reporting"
+  hosts: all
+  become: true
+  tasks:
+    - name: Install Alloy
+      ansible.builtin.include_role:
+        name: grafana.grafana.alloy
+      vars:
+        alloy_env_file_vars:
+          CUSTOM_ARGS: "--disable-reporting"
 ```
 
-### Example: Opt-out of data collection on Linux
+### Example: Opt out of data collection on Linux
 
 1. Edit the environment file for the service:
 
-   * Debian-based systems: edit `/etc/default/alloy`
-   * RedHat or SUSE-based systems: edit `/etc/sysconfig/alloy`
+   - Debian-based systems: edit `/etc/default/alloy`
+   - RedHat or SUSE-based systems: edit `/etc/sysconfig/alloy`
 
 1. Add `--disable-reporting` to the `CUSTOM_ARGS` environment variable.
 1. Restart the Alloy service:

--- a/docs/sources/data-collection.md
+++ b/docs/sources/data-collection.md
@@ -42,9 +42,100 @@ This endpoint only accepts data and isn't available to view in a browser.
 
 If possible, keep this feature enabled.
 It helps Grafana Labs understand how the open source community uses {{< param "PRODUCT_NAME" >}}.
-To opt out of anonymous usage statistics, use the [CLI flag][command line flag] `--disable-reporting`.
+To opt out of anonymous usage statistics, use the [CLI flag][command line flag] `--disable-reporting` with the method that matches your install type.
 
-### Example: Opt out of data collection with Ansible
+### Linux
+
+1. Edit the environment file for the service:
+   - Debian-based systems: edit `/etc/default/alloy`
+   - RedHat or SUSE-based systems: edit `/etc/sysconfig/alloy`
+
+1. Add `--disable-reporting` to the `CUSTOM_ARGS` environment variable.
+
+1. Restart the {{< param "PRODUCT_NAME" >}} service:
+
+   ```shell
+   sudo systemctl restart alloy
+   ```
+
+### Windows
+
+{{< param "PRODUCT_NAME" >}} runs as a Windows service and reads its command-line arguments from the registry.
+
+1. Open the Registry Editor:
+   1. Right-click the **Start** menu and select **Run**.
+   1. Type `regedit` and click **OK**.
+
+1. Navigate to `HKEY_LOCAL_MACHINE\SOFTWARE\GrafanaLabs\Alloy`.
+
+1. Double-click the **Arguments** value.
+
+1. Add `--disable-reporting` on a separate line at the end of the arguments list.
+
+1. Click **OK**.
+
+1. Restart the {{< param "PRODUCT_NAME" >}} service:
+   1. Right-click the **Start** menu and select **Run**.
+   1. Type `services.msc` and click **OK**.
+   1. Right-click the **{{< param "PRODUCT_NAME" >}}** service and select **All Tasks > Restart**.
+
+### macOS
+
+{{< param "PRODUCT_NAME" >}} reads extra command-line flags from a dedicated file when you install it with Homebrew.
+
+1. Edit `$(brew --prefix)/etc/alloy/extra-args.txt`.
+
+1. Add `--disable-reporting` on a separate line.
+
+1. Restart the {{< param "PRODUCT_NAME" >}} service:
+
+   ```shell
+   brew services restart grafana/grafana/alloy
+   ```
+
+### Docker
+
+Add `--disable-reporting` to the `alloy run` arguments in your `docker run` command:
+
+```shell
+docker run \
+  -v <CONFIG_FILE_PATH>:/etc/alloy/config.alloy \
+  -p 12345:12345 \
+  grafana/alloy:latest \
+    run --server.http.listen-addr=0.0.0.0:12345 \
+    --storage.path=/var/lib/alloy/data \
+    --disable-reporting \
+    /etc/alloy/config.alloy
+```
+
+Replace the following:
+
+- _`<CONFIG_FILE_PATH>`_: The path to your configuration file on the host system.
+
+### Helm
+
+The Grafana Alloy Helm chart includes a dedicated value to disable usage statistics. Set `alloy.enableReporting` to `false` in your `values.yaml`:
+
+```yaml
+alloy:
+  enableReporting: false
+```
+
+Then apply the change:
+
+```shell
+helm upgrade --namespace <NAMESPACE> <RELEASE_NAME> grafana/alloy -f <VALUES_PATH>
+```
+
+Replace the following:
+
+- _`<NAMESPACE>`_: The namespace for your {{< param "PRODUCT_NAME" >}} installation.
+- _`<RELEASE_NAME>`_: The name of your {{< param "PRODUCT_NAME" >}} Helm release.
+- _`<VALUES_PATH>`_: The path to your `values.yaml` file.
+
+### Ansible
+
+Set `CUSTOM_ARGS` in your playbook using the Grafana Ansible collection:
 
 ```yaml
 - name: Install Alloy
@@ -59,19 +150,18 @@ To opt out of anonymous usage statistics, use the [CLI flag][command line flag] 
           CUSTOM_ARGS: "--disable-reporting"
 ```
 
-### Example: Opt out of data collection on Linux
+### Binary
 
-1. Edit the environment file for the service:
+Add `--disable-reporting` to the `alloy run` command:
 
-   - Debian-based systems: edit `/etc/default/alloy`
-   - RedHat or SUSE-based systems: edit `/etc/sysconfig/alloy`
+```shell
+<BINARY_PATH> run --disable-reporting <CONFIG_PATH>
+```
 
-1. Add `--disable-reporting` to the `CUSTOM_ARGS` environment variable.
-1. Restart the Alloy service:
+Replace the following:
 
-   ```shell
-   sudo systemctl restart alloy
-   ```
+- _`<BINARY_PATH>`_: The path to the {{< param "PRODUCT_NAME" >}} binary.
+- _`<CONFIG_PATH>`_: The path to your {{< param "PRODUCT_NAME" >}} configuration file.
 
 [components]: ../get-started/components/
 [command line flag]: ../reference/cli/run/

--- a/docs/sources/data-collection.md
+++ b/docs/sources/data-collection.md
@@ -13,12 +13,13 @@ weight: 900
 This data helps the {{< param "PRODUCT_NAME" >}} team prioritize features and improve documentation.
 
 The anonymous usage statistics reporting is **enabled by default**.
-You can opt out by setting the [CLI flag][command line flag] `--disable-reporting` to `true`.
+You can opt out by passing the [CLI flag][command line flag] `--disable-reporting`.
 
 ## The statistics server
 
 When usage statistics reporting is enabled, a server that Grafana Labs runs collects the information.
-The statistics are collected at `https://stats.grafana.org`.
+The statistics are sent via HTTP POST to `https://stats.grafana.org/alloy-usage-report`.
+This is an ingest-only endpoint and isn't browsable.
 
 ## Which information is collected
 
@@ -26,12 +27,12 @@ When usage statistics reporting is enabled, {{< param "PRODUCT_NAME" >}} collect
 
 * A randomly generated, anonymous, unique ID (UUID).
 * The timestamp when the UUID was first generated.
-* The timestamp when the report was created (by default, every four hours).
+* The scheduled interval time for the report (by default, every four hours).
 * The version of {{< param "PRODUCT_NAME" >}}.
 * The operating system where {{< param "PRODUCT_NAME" >}} is running.
 * The system architecture where {{< param "PRODUCT_NAME" >}} is running.
 * A list of enabled [components][].
-* The deployment method for {{< param "PRODUCT_NAME" >}}, such as Docker, Helm, or a Linux package.
+* The deployment method for {{< param "PRODUCT_NAME" >}}, such as `docker`, `helm`, `operator`, `deb`, `rpm`, `brew`, or `binary`.
 
 {{< admonition type="note" >}}
 {{< param "PRODUCT_NAME" >}} maintainers commit to keeping the list of tracked information updated over time.
@@ -41,7 +42,7 @@ Any changes are reported in the CHANGELOG.
 ## Disable the anonymous usage statistics reporting
 
 If possible, we ask you to keep the usage reporting feature enabled to help us understand how the open source community runs {{< param "PRODUCT_NAME" >}}.
-If you want to opt out of anonymous usage statistics reporting, set the [CLI flag][command line flag] `--disable-reporting` to `true`.
+If you want to opt out of anonymous usage statistics reporting, pass the [CLI flag][command line flag] `--disable-reporting`.
 
 ### Example: Opt-out of data collection with Ansible
 


### PR DESCRIPTION
Fix factual errors in the Data Collection topic - existing docs tell user to set the CLI flag as a boolean when it isn't a boolean value.

Added OS-specific info for configuring the CLI flag

Fixes: https://github.com/grafana/alloy/issues/5979

### Note to reviewer

Double check the OS-specific instructions. Some of this was generated content - validated against existing docs for accuracy, but it needs a careful look to make sure it's true/accurate.