### PR TITLE
feat: Integration tests for loki.source.gcplog

### DIFF
--- a/integration-tests/docker/tests/loki-gcplog/config.alloy
+++ b/integration-tests/docker/tests/loki-gcplog/config.alloy
@@ -1,5 +1,5 @@
-// Push receiver: HTTP server bound to :1518; the host-run Go test posts
-// Pub/Sub envelopes to this port directly.
+// Push receiver: HTTP server bound to :1518
+// The host-run Go test posts Pub/Sub envelopes to this port directly.
 loki.source.gcplog "push" {
 	push {
 		http {
@@ -15,6 +15,8 @@ loki.source.gcplog "push" {
 // Pull receiver: subscribes to the pre-created subscription on the Pub/Sub
 // emulator. The PUBSUB_EMULATOR_HOST env var (set on the alloy container)
 // redirects the Google Pub/Sub client to the emulator.
+//
+// The PUBSUB_EMULATOR_HOST env var is read by "cloud.google.com/go/pubsub/v2" under the hood.
 loki.source.gcplog "pull" {
 	pull {
 		project_id   = "test-project"

--- a/integration-tests/docker/tests/loki-gcplog/config.alloy
+++ b/integration-tests/docker/tests/loki-gcplog/config.alloy
@@ -1,0 +1,122 @@
+// Push receiver: HTTP server bound to :1518; the host-run Go test posts
+// Pub/Sub envelopes to this port directly.
+loki.source.gcplog "push" {
+	push {
+		http {
+			listen_address = "0.0.0.0"
+			listen_port    = 1518
+		}
+	}
+
+	forward_to    = [loki.process.push.receiver]
+	relabel_rules = loki.relabel.gcplog.rules
+}
+
+// Pull receiver: subscribes to the pre-created subscription on the Pub/Sub
+// emulator. The PUBSUB_EMULATOR_HOST env var (set on the alloy container)
+// redirects the Google Pub/Sub client to the emulator.
+loki.source.gcplog "pull" {
+	pull {
+		project_id   = "test-project"
+		subscription = "gcplog-subscription"
+	}
+
+	forward_to    = [loki.process.pull.receiver]
+	relabel_rules = loki.relabel.gcplog.rules
+}
+
+// Shared relabel rules: extract __gcp_* internals into user-facing labels
+// (indexed) and a few values that downstream stages move to structured metadata.
+loki.relabel "gcplog" {
+	forward_to = []
+
+	rule {
+		source_labels = ["__gcp_resource_type"]
+		target_label  = "service_name"
+	}
+
+	rule {
+		source_labels = ["__gcp_resource_labels_cluster_name"]
+		target_label  = "cluster"
+	}
+
+	rule {
+		source_labels = ["__gcp_resource_labels_bucket_name"]
+		target_label  = "bucket"
+	}
+
+	rule {
+		source_labels = ["__gcp_severity"]
+		target_label  = "severity"
+	}
+
+	rule {
+		source_labels = ["__gcp_logname"]
+		target_label  = "log_name"
+	}
+
+	rule {
+		source_labels = ["__gcp_subscription_name"]
+		target_label  = "subscription"
+	}
+
+	rule {
+		source_labels = ["__tenant_id__"]
+		target_label  = "tenant_id"
+	}
+}
+
+loki.process "push" {
+	stage.static_labels {
+		values = {
+			test_name = "lokigcplog",
+			mode      = "push",
+		}
+	}
+
+	stage.structured_metadata {
+		values = {
+			severity     = "",
+			log_name     = "",
+			subscription = "",
+			tenant_id    = "",
+		}
+	}
+
+	forward_to = [loki.relabel.test.receiver]
+}
+
+loki.process "pull" {
+	stage.static_labels {
+		values = {
+			test_name = "lokigcplog",
+			mode      = "pull",
+		}
+	}
+
+	stage.structured_metadata {
+		values = {
+			severity = "",
+			log_name = "",
+		}
+	}
+
+	forward_to = [loki.relabel.test.receiver]
+}
+
+// Drop labels that should not be indexed (they are already promoted to
+// structured metadata by the stage above).
+loki.relabel "test" {
+	forward_to = [loki.write.test.receiver]
+
+	rule {
+		action = "labeldrop"
+		regex  = "severity|log_name|subscription|tenant_id"
+	}
+}
+
+loki.write "test" {
+	endpoint {
+		url = "http://loki:3100/loki/api/v1/push"
+	}
+}

--- a/integration-tests/docker/tests/loki-gcplog/config.alloy
+++ b/integration-tests/docker/tests/loki-gcplog/config.alloy
@@ -106,8 +106,7 @@ loki.process "pull" {
 	forward_to = [loki.relabel.test.receiver]
 }
 
-// Drop labels that should not be indexed (they are already promoted to
-// structured metadata by the stage above).
+// Drop labels that should not be indexed.
 loki.relabel "test" {
 	forward_to = [loki.write.test.receiver]
 

--- a/integration-tests/docker/tests/loki-gcplog/docker-compose.yaml
+++ b/integration-tests/docker/tests/loki-gcplog/docker-compose.yaml
@@ -1,0 +1,47 @@
+services:
+  pubsub-emulator:
+    image: messagebird/gcloud-pubsub-emulator:latest
+    container_name: pubsub-emulator
+    environment:
+      # Pre-create the topic+subscription pair on boot so Alloy can start subscribing
+      # immediately and the test publisher has a topic to publish to.
+      PUBSUB_PROJECT1: "test-project,gcplog-topic:gcplog-subscription"
+    ports:
+      - "8681:8681"
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z localhost 8681 || exit 1"]
+      interval: 1s
+      timeout: 3s
+      retries: 30
+      start_period: 10s
+
+  alloy:
+    image: alloy-integration-tests
+    depends_on:
+      pubsub-emulator:
+        condition: service_healthy
+    command:
+      - run
+      - /etc/alloy/config.alloy
+      - --server.http.listen-addr
+      - 0.0.0.0:12345
+      - --stability.level
+      - generally-available
+    environment:
+      PUBSUB_EMULATOR_HOST: pubsub-emulator:8681
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy:ro
+    ports:
+      - "1518:1518"
+    healthcheck:
+      test: ["CMD", "bash", "-c", "echo > /dev/tcp/localhost/12345"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+    networks:
+      - default
+      - alloy-integration-tests_integration-tests
+
+networks:
+  alloy-integration-tests_integration-tests:
+    external: true

--- a/integration-tests/docker/tests/loki-gcplog/docker-compose.yaml
+++ b/integration-tests/docker/tests/loki-gcplog/docker-compose.yaml
@@ -1,7 +1,6 @@
 services:
   pubsub-emulator:
     image: messagebird/gcloud-pubsub-emulator@sha256:7ac0917f6278e3c1d27ecc3d390edfe913b66887ea23af9d3aa459e766ed736c
-    container_name: pubsub-emulator
     environment:
       # Pre-create the topic+subscription pair on boot so Alloy can start subscribing
       # immediately and the test publisher has a topic to publish to.

--- a/integration-tests/docker/tests/loki-gcplog/docker-compose.yaml
+++ b/integration-tests/docker/tests/loki-gcplog/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   pubsub-emulator:
-    image: messagebird/gcloud-pubsub-emulator:latest
+    image: messagebird/gcloud-pubsub-emulator@sha256:7ac0917f6278e3c1d27ecc3d390edfe913b66887ea23af9d3aa459e766ed736c
     container_name: pubsub-emulator
     environment:
       # Pre-create the topic+subscription pair on boot so Alloy can start subscribing

--- a/integration-tests/docker/tests/loki-gcplog/loki_gcplog_test.go
+++ b/integration-tests/docker/tests/loki-gcplog/loki_gcplog_test.go
@@ -1,0 +1,315 @@
+//go:build alloyintegrationtests
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/pubsub/v2"
+	"github.com/grafana/dskit/backoff"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/integration-tests/docker/common"
+)
+
+const (
+	pushURL = "http://127.0.0.1:1518/gcp/api/v1/push"
+
+	emulatorHost     = "localhost:8681"
+	emulatorProject  = "test-project"
+	emulatorTopic    = "gcplog-topic"
+	emulatorEnvVar   = "PUBSUB_EMULATOR_HOST"
+	pushSubscription = "projects/test-project/subscriptions/test-push-sub"
+
+	entriesPerType = 10
+	tenantEntries  = 5
+	tenantOrgID    = "42"
+)
+
+// gcpResource represents a resource entry (parsed from `resource` in a GCP LogEntry).
+type gcpResource struct {
+	Type   string            `json:"type"`
+	Labels map[string]string `json:"labels"`
+}
+
+// gcpLogEntry is a minimal subset of the GCP Cloud Logging LogEntry shape used by
+// the gcplog parser (formatter.go::LogEntry). Only the fields the test exercises
+// are populated.
+type gcpLogEntry struct {
+	LogName     string      `json:"logName"`
+	Resource    gcpResource `json:"resource"`
+	Timestamp   string      `json:"timestamp"`
+	Severity    string      `json:"severity"`
+	TextPayload string      `json:"textPayload,omitempty"`
+}
+
+// resourceShape bundles a resource type with the resource.labels values used to
+// generate fixtures. The component prefixes each label with __gcp_resource_labels_
+// (after sanitization) so the relabel chain in config.alloy can promote them.
+type resourceShape struct {
+	resourceType  string
+	resourceLabel map[string]string
+}
+
+var resourceShapes = []resourceShape{
+	{
+		resourceType: "k8s_cluster",
+		resourceLabel: map[string]string{
+			"cluster_name": "dev-us-central-42",
+			"location":     "us-central1",
+			"project_id":   emulatorProject,
+		},
+	},
+	{
+		resourceType: "gcs_bucket",
+		resourceLabel: map[string]string{
+			"bucket_name": "loki-bucket",
+			"project_id":  emulatorProject,
+		},
+	},
+	{
+		resourceType: "cloud_function",
+		resourceLabel: map[string]string{
+			"function_name": "loki-fn",
+			"region":        "us-central1",
+		},
+	},
+}
+
+func TestLokiGcplog(t *testing.T) {
+	ctx := t.Context()
+
+	// ---- Push: per-resource-type batches ----
+	for _, rs := range resourceShapes {
+		require.NoError(t, postEnvelopes(ctx, "", buildEntries(rs, entriesPerType, "")))
+	}
+
+	// ---- Push: tenant header batch (X-Scope-OrgID -> tenant_id) ----
+	tenantShape := resourceShape{
+		resourceType: "k8s_cluster",
+		resourceLabel: map[string]string{
+			// distinct cluster name so the assertion can target this slice
+			// without ambiguity against the regular k8s_cluster batch above.
+			"cluster_name": "tenant-cluster",
+			"location":     "us-central1",
+			"project_id":   emulatorProject,
+		},
+	}
+	require.NoError(t, postEnvelopes(ctx, tenantOrgID, buildEntries(tenantShape, tenantEntries, "tenant ")))
+
+	// ---- Pull: publish identical per-resource-type batches via the emulator ----
+	require.NoError(t, publishViaEmulator(ctx, t, resourceShapes, entriesPerType))
+
+	// ---- Assert ----
+	totalPush := entriesPerType*len(resourceShapes) + tenantEntries
+	totalPull := entriesPerType * len(resourceShapes)
+
+	common.AssertLogsPresent(
+		t,
+		totalPush+totalPull,
+		// Push streams.
+		common.ExpectedLogResult{
+			Labels: map[string]string{
+				"mode":         "push",
+				"service_name": "k8s_cluster",
+				"cluster":      "dev-us-central-42",
+			},
+			StructuredMetadata: map[string]string{"severity": "INFO"},
+			EntryCount:         entriesPerType,
+		},
+		common.ExpectedLogResult{
+			Labels: map[string]string{
+				"mode":         "push",
+				"service_name": "gcs_bucket",
+				"bucket":       "loki-bucket",
+			},
+			EntryCount: entriesPerType,
+		},
+		common.ExpectedLogResult{
+			Labels: map[string]string{
+				"mode":         "push",
+				"service_name": "cloud_function",
+			},
+			EntryCount: entriesPerType,
+		},
+		// Push tenant slice.
+		common.ExpectedLogResult{
+			Labels: map[string]string{
+				"mode":         "push",
+				"service_name": "k8s_cluster",
+				"cluster":      "tenant-cluster",
+			},
+			StructuredMetadata: map[string]string{"tenant_id": tenantOrgID},
+			EntryCount:         tenantEntries,
+		},
+		// Pull streams.
+		common.ExpectedLogResult{
+			Labels: map[string]string{
+				"mode":         "pull",
+				"service_name": "k8s_cluster",
+				"cluster":      "dev-us-central-42",
+			},
+			EntryCount: entriesPerType,
+		},
+		common.ExpectedLogResult{
+			Labels: map[string]string{
+				"mode":         "pull",
+				"service_name": "gcs_bucket",
+				"bucket":       "loki-bucket",
+			},
+			EntryCount: entriesPerType,
+		},
+		common.ExpectedLogResult{
+			Labels: map[string]string{
+				"mode":         "pull",
+				"service_name": "cloud_function",
+			},
+			EntryCount: entriesPerType,
+		},
+	)
+
+	common.AssertLabelsNotIndexed(t, "severity", "log_name", "subscription", "tenant_id")
+}
+
+// buildEntries produces n LogEntry values with the given resource shape. The
+// optional linePrefix is mixed into textPayload to make per-batch lines unique.
+func buildEntries(rs resourceShape, n int, linePrefix string) []gcpLogEntry {
+	now := time.Now().UTC()
+	entries := make([]gcpLogEntry, 0, n)
+	for i := range n {
+		entries = append(entries, gcpLogEntry{
+			LogName:     fmt.Sprintf("projects/%s/logs/integration-test", emulatorProject),
+			Resource:    gcpResource{Type: rs.resourceType, Labels: rs.resourceLabel},
+			Timestamp:   now.Add(time.Duration(i) * time.Second).Format(time.RFC3339Nano),
+			Severity:    "INFO",
+			TextPayload: fmt.Sprintf("%s%s message %d", linePrefix, rs.resourceType, i),
+		})
+	}
+	return entries
+}
+
+// postEnvelopes wraps each LogEntry in a Pub/Sub push envelope and POSTs it to
+// the gcplog push receiver. If tenantID is non-empty it is sent in the
+// X-Scope-OrgID header so the receiver promotes it to __tenant_id__.
+func postEnvelopes(ctx context.Context, tenantID string, entries []gcpLogEntry) error {
+	for i, entry := range entries {
+		body, err := buildPushEnvelopeBody(entry, i)
+		if err != nil {
+			return err
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, pushURL, bytes.NewReader(body))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if tenantID != "" {
+			req.Header.Set("X-Scope-OrgID", tenantID)
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("push request: %w", err)
+		}
+		resp.Body.Close()
+
+		if resp.StatusCode != http.StatusNoContent {
+			return fmt.Errorf("unexpected push status %d (entry %d, type %s)", resp.StatusCode, i, entry.Resource.Type)
+		}
+	}
+	return nil
+}
+
+// buildPushEnvelopeBody marshals a LogEntry into a Pub/Sub push envelope. The
+// envelope shape mirrors the GCP Pub/Sub push spec and matches the unit-test
+// fixture in push_target_test.go::testPayload.
+func buildPushEnvelopeBody(entry gcpLogEntry, idx int) ([]byte, error) {
+	entryJSON, err := json.Marshal(entry)
+	if err != nil {
+		return nil, fmt.Errorf("marshal entry: %w", err)
+	}
+
+	envelope := struct {
+		Message struct {
+			Attributes map[string]string `json:"attributes,omitempty"`
+			Data       string            `json:"data"`
+			MessageID  string            `json:"messageId"`
+		} `json:"message"`
+		Subscription string `json:"subscription"`
+	}{
+		Subscription: pushSubscription,
+	}
+	envelope.Message.Data = base64.StdEncoding.EncodeToString(entryJSON)
+	envelope.Message.MessageID = strconv.Itoa(idx)
+
+	return json.Marshal(envelope)
+}
+
+// publishViaEmulator publishes per-resource-type batches to the emulator topic.
+// Alloy's pull subscriber consumes them through the pre-created subscription.
+func publishViaEmulator(ctx context.Context, t *testing.T, shapes []resourceShape, perShape int) error {
+	t.Helper()
+
+	if err := os.Setenv(emulatorEnvVar, emulatorHost); err != nil {
+		return fmt.Errorf("set %s: %w", emulatorEnvVar, err)
+	}
+
+	client, err := newEmulatorClient(ctx)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	publisher := client.Publisher(emulatorTopic)
+	defer publisher.Stop()
+
+	results := make([]*pubsub.PublishResult, 0, perShape*len(shapes))
+	for _, rs := range shapes {
+		for _, entry := range buildEntries(rs, perShape, "") {
+			data, err := json.Marshal(entry)
+			if err != nil {
+				return fmt.Errorf("marshal pull entry: %w", err)
+			}
+			results = append(results, publisher.Publish(ctx, &pubsub.Message{Data: data}))
+		}
+	}
+
+	for _, r := range results {
+		if _, err := r.Get(ctx); err != nil {
+			return fmt.Errorf("publish: %w", err)
+		}
+	}
+	return nil
+}
+
+// newEmulatorClient retries until the Pub/Sub emulator accepts a client. The
+// emulator's TCP listener may answer before topic provisioning completes, so a
+// brief retry window absorbs the gap.
+func newEmulatorClient(ctx context.Context) (*pubsub.Client, error) {
+	bk := backoff.New(ctx, backoff.Config{
+		MinBackoff: 100 * time.Millisecond,
+		MaxBackoff: 2 * time.Second,
+		MaxRetries: 20,
+	})
+
+	var lastErr error
+	for bk.Ongoing() {
+		client, err := pubsub.NewClient(ctx, emulatorProject)
+		if err == nil {
+			return client, nil
+		}
+		lastErr = err
+		bk.Wait()
+	}
+
+	return nil, fmt.Errorf("connect to pubsub emulator: %w", lastErr)
+}

--- a/integration-tests/docker/tests/loki-gcplog/loki_gcplog_test.go
+++ b/integration-tests/docker/tests/loki-gcplog/loki_gcplog_test.go
@@ -88,12 +88,12 @@ var resourceShapes = []resourceShape{
 func TestLokiGcplog(t *testing.T) {
 	ctx := t.Context()
 
-	// ---- Push: per-resource-type batches ----
+	// Push: per-resource-type batches
 	for _, rs := range resourceShapes {
 		require.NoError(t, postEnvelopes(ctx, "", buildEntries(rs, entriesPerType, "")))
 	}
 
-	// ---- Push: tenant header batch (X-Scope-OrgID -> tenant_id) ----
+	// Push: tenant header batch (X-Scope-OrgID -> tenant_id)
 	tenantShape := resourceShape{
 		resourceType: "k8s_cluster",
 		resourceLabel: map[string]string{
@@ -106,10 +106,10 @@ func TestLokiGcplog(t *testing.T) {
 	}
 	require.NoError(t, postEnvelopes(ctx, tenantOrgID, buildEntries(tenantShape, tenantEntries, "tenant ")))
 
-	// ---- Pull: publish identical per-resource-type batches via the emulator ----
+	// Pull: publish identical per-resource-type batches via the emulator
 	require.NoError(t, publishViaEmulator(ctx, t, resourceShapes, entriesPerType))
 
-	// ---- Assert ----
+	// Assert
 	totalPush := entriesPerType*len(resourceShapes) + tenantEntries
 	totalPull := entriesPerType * len(resourceShapes)
 

--- a/integration-tests/docker/tests/loki-gcplog/loki_gcplog_test.go
+++ b/integration-tests/docker/tests/loki-gcplog/loki_gcplog_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -259,10 +258,7 @@ func buildPushEnvelopeBody(entry gcpLogEntry, idx int) ([]byte, error) {
 func publishViaEmulator(ctx context.Context, t *testing.T, shapes []resourceShape, perShape int) error {
 	t.Helper()
 
-	if err := os.Setenv(emulatorEnvVar, emulatorHost); err != nil {
-		return fmt.Errorf("set %s: %w", emulatorEnvVar, err)
-	}
-
+	t.Setenv(emulatorEnvVar, emulatorHost)
 	client, err := newEmulatorClient(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
### Brief description of Pull Request

Add integration tests for `loki.source.gcplog`

### Pull Request Details

Covered both HTTP push and Pub/Sub pull scenarios through relabeling into Loki.

The [gcloud pubsub emulator](https://github.com/marcelcorso/gcloud-pubsub-emulator) is used to cover the Pub/Sub pull scenario.


### Issue(s) fixed by this Pull Request

Related to https://github.com/grafana/alloy/issues/4953

### Notes to the Reviewer

Pub/Sub server address override is done using `PUBSUB_EMULATOR_HOST` env var, which is used by `cloud.google.com/go/pubsub/v2` package under the hood.

Also, I've chose `messagebird/gcloud-pubsub-emulator` over `gcr.io/google.com/cloudsdktool/cloud-sdk:emulators` because it's ~150 MB vs ~1 GB and provisions topics/subscriptions from a single env var on boot — no separate init container or `gcloud beta emulators pubsub` orchestration.

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests updated