### PR TITLE
fix(oracledb_exporter): Support CGO_ENABLED=0 cross-compilation

### DIFF
--- a/.github/workflows/test_mac.yml
+++ b/.github/workflows/test_mac.yml
@@ -30,3 +30,23 @@ jobs:
         cache: true
     - name: Test
       run: CGO_LDFLAGS="-ld_classic $CGO_LDFLAGS" make GO_TAGS="nodocker" test
+
+  cross-compile-collector-linux-nocgo:
+    name: Cross-compile collector for linux/${{ matrix.goarch }} with CGO disabled
+    strategy:
+      matrix:
+        platform: [macos-15-xlarge]
+        goarch: [amd64, arm64]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - name: Set up Go
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        go-version-file: go.mod
+        cache: true
+    - name: Build
+      run: cd collector && CGO_ENABLED=0 GOOS=linux GOARCH=${{ matrix.goarch }} go build .

--- a/.github/workflows/test_mac.yml
+++ b/.github/workflows/test_mac.yml
@@ -31,8 +31,11 @@ jobs:
     - name: Test
       run: CGO_LDFLAGS="-ld_classic $CGO_LDFLAGS" make GO_TAGS="nodocker" test
 
-  cross-compile-collector-linux-nocgo:
-    name: Cross-compile collector for linux with CGO disabled
+  cross-compile-mac-to-linux-nocgo:
+    # Keeps mac-to-linux cross-compilation working for developers who build
+    # Alloy on macOS but test/run on linux. Catches regressions like CGO-only
+    # transitive deps slipping in unguarded.
+    name: Maintain developer-friendly mac-to-linux cross-compile
     runs-on: macos-15-xlarge
     steps:
     - name: Checkout code
@@ -44,7 +47,11 @@ jobs:
       with:
         go-version-file: go.mod
         cache: false
-    - name: Build linux/amd64
+    - name: Build collector linux/amd64
       run: cd collector && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build .
-    - name: Build linux/arm64
+    - name: Build collector linux/arm64
       run: cd collector && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build .
+    - name: Build pyroscope playground linux/amd64
+      run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./internal/component/pyroscope/util/internal/cmd/playground
+    - name: Build pyroscope playground linux/arm64
+      run: CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build ./internal/component/pyroscope/util/internal/cmd/playground

--- a/.github/workflows/test_mac.yml
+++ b/.github/workflows/test_mac.yml
@@ -37,6 +37,9 @@ jobs:
     # transitive deps slipping in unguarded.
     name: Maintain developer-friendly mac-to-linux cross-compile
     runs-on: macos-15-xlarge
+    env:
+      CGO_ENABLED: 0
+      GOOS: linux
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -47,11 +50,7 @@ jobs:
       with:
         go-version-file: go.mod
         cache: false
-    - name: Build collector linux/amd64
-      run: cd collector && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build .
-    - name: Build collector linux/arm64
-      run: cd collector && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build .
-    - name: Build pyroscope playground linux/amd64
-      run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./internal/component/pyroscope/util/internal/cmd/playground
-    - name: Build pyroscope playground linux/arm64
-      run: CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build ./internal/component/pyroscope/util/internal/cmd/playground
+    - run: cd collector && GOARCH=amd64 go build .
+    - run: cd collector && GOARCH=arm64 go build .
+    - run: GOARCH=amd64 go build ./internal/component/pyroscope/util/internal/cmd/playground
+    - run: GOARCH=arm64 go build ./internal/component/pyroscope/util/internal/cmd/playground

--- a/.github/workflows/test_mac.yml
+++ b/.github/workflows/test_mac.yml
@@ -32,9 +32,6 @@ jobs:
       run: CGO_LDFLAGS="-ld_classic $CGO_LDFLAGS" make GO_TAGS="nodocker" test
 
   cross-compile-mac-to-linux-nocgo:
-    # Keeps mac-to-linux cross-compilation working for developers who build
-    # Alloy on macOS but test/run on linux. Catches regressions like CGO-only
-    # transitive deps slipping in unguarded.
     name: Maintain developer-friendly mac-to-linux cross-compile
     runs-on: macos-15-xlarge
     env:

--- a/.github/workflows/test_mac.yml
+++ b/.github/workflows/test_mac.yml
@@ -32,12 +32,8 @@ jobs:
       run: CGO_LDFLAGS="-ld_classic $CGO_LDFLAGS" make GO_TAGS="nodocker" test
 
   cross-compile-collector-linux-nocgo:
-    name: Cross-compile collector for linux/${{ matrix.goarch }} with CGO disabled
-    strategy:
-      matrix:
-        platform: [macos-15-xlarge]
-        goarch: [amd64, arm64]
-    runs-on: ${{ matrix.platform }}
+    name: Cross-compile collector for linux with CGO disabled
+    runs-on: macos-15-xlarge
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -47,6 +43,8 @@ jobs:
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: go.mod
-        cache: true
-    - name: Build
-      run: cd collector && CGO_ENABLED=0 GOOS=linux GOARCH=${{ matrix.goarch }} go build .
+        cache: false
+    - name: Build linux/amd64
+      run: cd collector && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build .
+    - name: Build linux/arm64
+      run: cd collector && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build .

--- a/.github/workflows/test_mac.yml
+++ b/.github/workflows/test_mac.yml
@@ -37,6 +37,7 @@ jobs:
     env:
       CGO_ENABLED: 0
       GOOS: linux
+      GOARCH: amd64
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -47,7 +48,5 @@ jobs:
       with:
         go-version-file: go.mod
         cache: false
-    - run: cd collector && GOARCH=amd64 go build .
-    - run: cd collector && GOARCH=arm64 go build .
-    - run: GOARCH=amd64 go build ./internal/component/pyroscope/util/internal/cmd/playground
-    - run: GOARCH=arm64 go build ./internal/component/pyroscope/util/internal/cmd/playground
+    - run: cd collector &&  go build .
+    - run: go build ./internal/component/pyroscope/util/internal/cmd/playground

--- a/.github/workflows/test_mac.yml
+++ b/.github/workflows/test_mac.yml
@@ -32,7 +32,7 @@ jobs:
       run: CGO_LDFLAGS="-ld_classic $CGO_LDFLAGS" make GO_TAGS="nodocker" test
 
   cross-compile-mac-to-linux-nocgo:
-    name: Maintain developer-friendly mac-to-linux cross-compile
+    name: Verify mac-to-linux cross-compile # This is to maintain good developer experience on macOS
     runs-on: macos-15-xlarge
     env:
       CGO_ENABLED: 0

--- a/.github/workflows/test_mac.yml
+++ b/.github/workflows/test_mac.yml
@@ -48,5 +48,5 @@ jobs:
       with:
         go-version-file: go.mod
         cache: false
-    - run: cd collector &&  go build .
+    - run: cd collector && go build .
     - run: go build ./internal/component/pyroscope/util/internal/cmd/playground

--- a/.github/workflows/test_pyroscope_pr.yml
+++ b/.github/workflows/test_pyroscope_pr.yml
@@ -27,21 +27,3 @@ jobs:
           cache: false
 
       - run: sudo make test-pyroscope
-
-  cross-compile-pyroscope-playground-linux-nocgo:
-    name: Cross-compile pyroscope playground for linux with CGO disabled
-    runs-on: macos-15-xlarge
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-          cache: false
-      - name: Build linux/amd64
-        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./internal/component/pyroscope/util/internal/cmd/playground
-      - name: Build linux/arm64
-        run: CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build ./internal/component/pyroscope/util/internal/cmd/playground

--- a/.github/workflows/test_pyroscope_pr.yml
+++ b/.github/workflows/test_pyroscope_pr.yml
@@ -29,12 +29,8 @@ jobs:
       - run: sudo make test-pyroscope
 
   cross-compile-pyroscope-playground-linux-nocgo:
-    name: Cross-compile pyroscope playground for linux/${{ matrix.goarch }} with CGO disabled
-    strategy:
-      matrix:
-        platform: [macos-15-xlarge]
-        goarch: [amd64, arm64]
-    runs-on: ${{ matrix.platform }}
+    name: Cross-compile pyroscope playground for linux with CGO disabled
+    runs-on: macos-15-xlarge
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -44,6 +40,8 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
-          cache: true
-      - name: Build
-        run: CGO_ENABLED=0 GOOS=linux GOARCH=${{ matrix.goarch }} go build ./internal/component/pyroscope/util/internal/cmd/playground
+          cache: false
+      - name: Build linux/amd64
+        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./internal/component/pyroscope/util/internal/cmd/playground
+      - name: Build linux/arm64
+        run: CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build ./internal/component/pyroscope/util/internal/cmd/playground

--- a/.github/workflows/test_pyroscope_pr.yml
+++ b/.github/workflows/test_pyroscope_pr.yml
@@ -27,3 +27,23 @@ jobs:
           cache: false
 
       - run: sudo make test-pyroscope
+
+  cross-compile-pyroscope-playground-linux-nocgo:
+    name: Cross-compile pyroscope playground for linux/${{ matrix.goarch }} with CGO disabled
+    strategy:
+      matrix:
+        platform: [macos-15-xlarge]
+        goarch: [amd64, arm64]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Build
+        run: CGO_ENABLED=0 GOOS=linux GOARCH=${{ matrix.goarch }} go build ./internal/component/pyroscope/util/internal/cmd/playground

--- a/internal/static/integrations/oracledb_exporter/oracledb_exporter.go
+++ b/internal/static/integrations/oracledb_exporter/oracledb_exporter.go
@@ -1,23 +1,17 @@
 package oracledb_exporter
 
 import (
-	"errors"
 	"fmt"
-	"log/slog"
 	"net/url"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/grafana/alloy/internal/static/integrations"
-	oe "github.com/oracle/oracle-db-appdev-monitoring/collector"
 
 	integrations_v2 "github.com/grafana/alloy/internal/static/integrations/v2"
 	"github.com/grafana/alloy/internal/static/integrations/v2/metricsutils"
 	config_util "github.com/prometheus/common/config"
-	"k8s.io/utils/ptr"
 )
 
 const oracleScheme = "oracle://"
@@ -165,53 +159,4 @@ func (c *Config) normalizedTargets() ([]normalizedOracleDB, error) {
 		user: user,
 		pass: pass,
 	}}, nil
-}
-
-// New creates a new oracledb integration. The integration scrapes metrics
-// from an OracleDB exporter running with the https://github.com/oracle/oracle-db-appdev-monitoring
-func New(logger log.Logger, c *Config) (integrations.Integration, error) {
-	slogLogger := slog.New(logging.NewSlogGoKitHandler(logger))
-
-	targets, err := c.normalizedTargets()
-	if err != nil {
-		return nil, err
-	}
-	if len(targets) == 0 {
-		return nil, errors.New("no databases configured")
-	}
-
-	databases := make(map[string]oe.DatabaseConfig, len(targets))
-	for _, t := range targets {
-		databases[t.name] = oe.DatabaseConfig{
-			URL:      t.url,
-			Username: t.user,
-			Password: t.pass,
-			ConnectConfig: oe.ConnectConfig{
-				MaxIdleConns: ptr.To(c.MaxIdleConns),
-				MaxOpenConns: ptr.To(c.MaxOpenConns),
-				QueryTimeout: ptr.To(c.QueryTimeout),
-			},
-			Labels: t.labels,
-		}
-	}
-
-	// ScrapeInterval must be non-nil: the collector's Collect path dereferences it.
-	scrapeInterval := time.Duration(0)
-	oeExporter := oe.NewExporter(slogLogger, &oe.MetricsConfiguration{
-		Databases: databases,
-		Metrics: oe.MetricsFilesConfig{
-			Custom:         c.CustomMetrics,
-			Default:        c.DefaultMetrics,
-			ScrapeInterval: &scrapeInterval,
-		},
-	})
-
-	if oeExporter == nil {
-		return nil, errors.New("failed to create oracledb exporter")
-	}
-	// The upstream binary runs InitializeDatabases on startup to warm up the pool
-	// and flip StartupReady; without it, Collect only logs "Database connection in progress"
-	// and never scrapes Oracle metrics (see oracle-db-appdev-monitoring collector.Database).
-	go oeExporter.InitializeDatabases()
-	return integrations.NewCollectorIntegration(c.Name(), integrations.WithCollectors(oeExporter)), nil
 }

--- a/internal/static/integrations/oracledb_exporter/oracledb_exporter_cgo.go
+++ b/internal/static/integrations/oracledb_exporter/oracledb_exporter_cgo.go
@@ -1,0 +1,64 @@
+//go:build cgo
+
+package oracledb_exporter
+
+import (
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/alloy/internal/runtime/logging"
+	"github.com/grafana/alloy/internal/static/integrations"
+	oe "github.com/oracle/oracle-db-appdev-monitoring/collector"
+	"k8s.io/utils/ptr"
+)
+
+// New creates a new oracledb integration. The integration scrapes metrics
+// from an OracleDB exporter running with the https://github.com/oracle/oracle-db-appdev-monitoring
+func New(logger log.Logger, c *Config) (integrations.Integration, error) {
+	slogLogger := slog.New(logging.NewSlogGoKitHandler(logger))
+
+	targets, err := c.normalizedTargets()
+	if err != nil {
+		return nil, err
+	}
+	if len(targets) == 0 {
+		return nil, errors.New("no databases configured")
+	}
+
+	databases := make(map[string]oe.DatabaseConfig, len(targets))
+	for _, t := range targets {
+		databases[t.name] = oe.DatabaseConfig{
+			URL:      t.url,
+			Username: t.user,
+			Password: t.pass,
+			ConnectConfig: oe.ConnectConfig{
+				MaxIdleConns: ptr.To(c.MaxIdleConns),
+				MaxOpenConns: ptr.To(c.MaxOpenConns),
+				QueryTimeout: ptr.To(c.QueryTimeout),
+			},
+			Labels: t.labels,
+		}
+	}
+
+	// ScrapeInterval must be non-nil: the collector's Collect path dereferences it.
+	scrapeInterval := time.Duration(0)
+	oeExporter := oe.NewExporter(slogLogger, &oe.MetricsConfiguration{
+		Databases: databases,
+		Metrics: oe.MetricsFilesConfig{
+			Custom:         c.CustomMetrics,
+			Default:        c.DefaultMetrics,
+			ScrapeInterval: &scrapeInterval,
+		},
+	})
+
+	if oeExporter == nil {
+		return nil, errors.New("failed to create oracledb exporter")
+	}
+	// The upstream binary runs InitializeDatabases on startup to warm up the pool
+	// and flip StartupReady; without it, Collect only logs "Database connection in progress"
+	// and never scrapes Oracle metrics (see oracle-db-appdev-monitoring collector.Database).
+	go oeExporter.InitializeDatabases()
+	return integrations.NewCollectorIntegration(c.Name(), integrations.WithCollectors(oeExporter)), nil
+}

--- a/internal/static/integrations/oracledb_exporter/oracledb_exporter_stub.go
+++ b/internal/static/integrations/oracledb_exporter/oracledb_exporter_stub.go
@@ -1,0 +1,17 @@
+//go:build !cgo
+
+package oracledb_exporter
+
+import (
+	"errors"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/alloy/internal/static/integrations"
+)
+
+// New is a stub used when Alloy is built with CGO_ENABLED=0. The underlying
+// Oracle driver (godror) requires CGO, so the integration cannot run in
+// no-cgo builds; configs that reference it surface this error at construction.
+func New(_ log.Logger, _ *Config) (integrations.Integration, error) {
+	return nil, errors.New("oracledb integration requires CGO; this Alloy binary was built with CGO_ENABLED=0")
+}


### PR DESCRIPTION
The oracledb integration imported github.com/oracle/oracle-db-appdev-monitoring/collector, which transitively pulls in github.com/godror/godror. godror requires CGO, so `cd collector && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build .` failed with "undefined: VersionInfo" and similar errors from godror's orahlp.go.

The fix follows the existing loki.source.journal dual-file pattern: pure-Go config and helpers stay unconditional, the godror import and New() body move behind `//go:build cgo`, and a `//go:build !cgo` stub New() returns a clear error so configs surface a meaningful message in no-cgo builds.

To prevent regressions, two new CI jobs cross-compile the collector (in test_mac.yml) and the pyroscope playground (in test_pyroscope_pr.yml) for linux/amd64 and linux/arm64 with CGO_ENABLED=0 on macos-15-xlarge.