### PR TITLE
feat(prometheus.relabel): Add opt-in TTL cache mode

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.relabel.md
+++ b/docs/sources/reference/components/prometheus/prometheus.relabel.md
@@ -57,14 +57,21 @@ You can use the following arguments with `prometheus.relabel`:
 `prometheus.relabel` ships with two cache modes. By default, the component uses a bounded LRU cache (`max_cache_size = 100000`, `cache_ttl = 0`):
 
 * **LRU (default)**: `max_cache_size > 0`, `cache_ttl = 0`. Hash-keyed LRU with a fixed entry cap. When the cache is smaller than the cardinality of metrics flowing through the component, the LRU can degenerate into thrashing—the entry it just evicted is the next one requested.
-* **TTL**: `max_cache_size = 0`, `cache_ttl > 0` (minimum `1m`). Entries expire a fixed duration after their last insertion; the cache sizes itself to the working set of series flowing through the component. Recommended when cardinality is variable or substantially larger than `max_cache_size` would allow.
+* **TTL**: `max_cache_size = 0`, `cache_ttl > 0` (minimum `1m`). Entries expire after `cache_ttl` of inactivity—each cache hit slides the entry's expiry forward, so series that stay active stay cached. The cache sizes itself to the working set of series flowing through the component.
 
-`max_cache_size` and `cache_ttl` are mutually exclusive: exactly one must be non-zero. To switch to TTL mode, set `max_cache_size = 0` and `cache_ttl` to a non-zero duration (`10m` is a reasonable starting point).
+If you don't know the cardinality of metrics flowing through this component, prefer TTL mode—it sizes itself to the working set without you having to estimate `max_cache_size`. To switch to TTL mode, set `max_cache_size = 0` and `cache_ttl` to a non-zero duration (`10m` is a reasonable starting point):
 
-### TTL mode caveats
+```alloy
+prometheus.relabel "example" {
+  forward_to     = [/* ... */]
+  max_cache_size = 0
+  cache_ttl      = "10m"
+}
+```
 
-* Series that send a Prometheus stale marker are evicted immediately, the same as in LRU mode. The TTL is a backstop for series that disappear *without* a stale marker (for example, a target lost without a final scrape)—those linger up to `cache_ttl` before the periodic scan evicts them. Workloads that churn through unique series faster than stale markers can clear them (for example, an exporter emitting random label values) hurt either mode: TTL holds entries until they expire, and LRU thrashes—every call re-runs the relabel rules *and* pays the cache lock/map overhead. Fix the source of the churn rather than relying on the cache to absorb it.
-* The cache is keyed by the input labels' hash, so two label sets that hash to the same value share a cache entry. Under LRU mode, eviction by size pressure naturally bounds how long a wrong cached value can persist; under TTL mode that window is bounded by `cache_ttl` instead, which is typically longer.
+`max_cache_size` and `cache_ttl` are mutually exclusive: exactly one must be non-zero.
+
+In TTL mode, series that send a Prometheus stale marker are evicted immediately, just as in LRU mode. Series that disappear *without* a stale marker (for example, a target lost without a final scrape) linger up to `cache_ttl` before the periodic scan evicts them.
 
 ## Blocks
 

--- a/docs/sources/reference/components/prometheus/prometheus.relabel.md
+++ b/docs/sources/reference/components/prometheus/prometheus.relabel.md
@@ -57,7 +57,7 @@ You can use the following arguments with `prometheus.relabel`:
 `prometheus.relabel` ships with two cache modes. By default, the component uses a bounded LRU cache (`max_cache_size = 100000`, `cache_ttl = 0`):
 
 * **LRU (default)**: `max_cache_size > 0`, `cache_ttl = 0`. Hash-keyed LRU with a fixed entry cap. When the cache is smaller than the cardinality of metrics flowing through the component, the LRU can degenerate into thrashing—the entry it just evicted is the next one requested.
-* **TTL**: `max_cache_size = 0`, `cache_ttl > 0` (minimum `5s`). Entries expire a fixed duration after their last insertion; the cache sizes itself to the working set of series flowing through the component. Recommended when cardinality is variable or substantially larger than `max_cache_size` would allow.
+* **TTL**: `max_cache_size = 0`, `cache_ttl > 0` (minimum `1m`). Entries expire a fixed duration after their last insertion; the cache sizes itself to the working set of series flowing through the component. Recommended when cardinality is variable or substantially larger than `max_cache_size` would allow.
 
 `max_cache_size` and `cache_ttl` are mutually exclusive: exactly one must be non-zero. To switch to TTL mode, set `max_cache_size = 0` and `cache_ttl` to a non-zero duration (`10m` is a reasonable starting point).
 
@@ -109,8 +109,7 @@ In those cases, exported fields are kept at their last healthy values.
 * `prometheus_relabel_cache_hits` (counter): Total number of cache hits.
 * `prometheus_relabel_cache_misses` (counter): Total number of cache misses.
 * `prometheus_relabel_cache_size` (gauge): Total size of relabel cache.
-* `prometheus_relabel_cache_ttl_evictions_total` (counter): Cache entries removed by the periodic TTL scan. Always `0` when `cache_ttl` is unset.
-* `prometheus_relabel_cache_ttl_rebuilds_total` (counter): Number of times the TTL cache's internal map has been rebuilt to release bucket memory after a shrink. Always `0` when `cache_ttl` is unset.
+* `prometheus_relabel_cache_ttl_evictions` (counter): Cache entries removed by the periodic TTL scan. Always `0` when `cache_ttl` is unset.
 * `prometheus_relabel_metrics_processed` (counter): Total number of metrics processed.
 * `prometheus_relabel_metrics_written` (counter): Total number of metrics written.
 

--- a/docs/sources/reference/components/prometheus/prometheus.relabel.md
+++ b/docs/sources/reference/components/prometheus/prometheus.relabel.md
@@ -48,10 +48,23 @@ prometheus.relabel "<LABEL>" {
 
 You can use the following arguments with `prometheus.relabel`:
 
-| Name             | Type                    | Description                                                             | Default  | Required |
-| ---------------- | ----------------------- | ----------------------------------------------------------------------- | -------- | -------- |
-| `forward_to`     | `list(MetricsReceiver)` | Where the metrics should be forwarded to, after relabeling takes place. |          | yes      |
-| `max_cache_size` | `int`                   | The maximum number of elements to hold in the relabeling cache.         | `100000` | no       |
+| Name             | Type                    | Description                                                                                                                 | Default  | Required |
+| ---------------- | ----------------------- | --------------------------------------------------------------------------------------------------------------------------- | -------- | -------- |
+| `forward_to`     | `list(MetricsReceiver)` | Where the metrics should be forwarded to, after relabeling takes place.                                                     |          | yes      |
+| `max_cache_size` | `int`                   | The maximum number of elements to hold in the relabeling LRU cache.                                                         | `100000` | no       |
+| `cache_ttl`      | `duration`              | When set, switches the cache to TTL mode: entries expire after this duration. Mutually exclusive with `max_cache_size > 0`. | `0`      | no       |
+
+`prometheus.relabel` ships with two cache modes. By default, the component uses a bounded LRU cache (`max_cache_size = 100000`, `cache_ttl = 0`):
+
+* **LRU (default)**: `max_cache_size > 0`, `cache_ttl = 0`. Hash-keyed LRU with a fixed entry cap. When the cache is smaller than the cardinality of metrics flowing through the component, the LRU can degenerate into thrashing—the entry it just evicted is the next one requested.
+* **TTL**: `max_cache_size = 0`, `cache_ttl > 0` (minimum `5s`). Entries expire a fixed duration after their last insertion; the cache sizes itself to the working set of series flowing through the component. Recommended when cardinality is variable or substantially larger than `max_cache_size` would allow.
+
+`max_cache_size` and `cache_ttl` are mutually exclusive: exactly one must be non-zero. To switch to TTL mode, set `max_cache_size = 0` and `cache_ttl` to a non-zero duration (`10m` is a reasonable starting point).
+
+### TTL mode caveats
+
+* Series that send a Prometheus stale marker are evicted immediately, the same as in LRU mode. The TTL is a backstop for series that disappear *without* a stale marker (for example, a target lost without a final scrape)—those linger up to `cache_ttl` before the periodic scan evicts them. Workloads that churn through unique series faster than stale markers can clear them (for example, an exporter emitting random label values) hurt either mode: TTL holds entries until they expire, and LRU thrashes—every call re-runs the relabel rules *and* pays the cache lock/map overhead. Fix the source of the churn rather than relying on the cache to absorb it.
+* The cache is keyed by the input labels' hash, so two label sets that hash to the same value share a cache entry. Under LRU mode, eviction by size pressure naturally bounds how long a wrong cached value can persist; under TTL mode that window is bounded by `cache_ttl` instead, which is typically longer.
 
 ## Blocks
 
@@ -96,6 +109,8 @@ In those cases, exported fields are kept at their last healthy values.
 * `prometheus_relabel_cache_hits` (counter): Total number of cache hits.
 * `prometheus_relabel_cache_misses` (counter): Total number of cache misses.
 * `prometheus_relabel_cache_size` (gauge): Total size of relabel cache.
+* `prometheus_relabel_cache_ttl_evictions_total` (counter): Cache entries removed by the periodic TTL scan. Always `0` when `cache_ttl` is unset.
+* `prometheus_relabel_cache_ttl_rebuilds_total` (counter): Number of times the TTL cache's internal map has been rebuilt to release bucket memory after a shrink. Always `0` when `cache_ttl` is unset.
 * `prometheus_relabel_metrics_processed` (counter): Total number of metrics processed.
 * `prometheus_relabel_metrics_written` (counter): Total number of metrics written.
 

--- a/internal/component/prometheus/relabel/cache.go
+++ b/internal/component/prometheus/relabel/cache.go
@@ -2,6 +2,7 @@ package relabel
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 
 	lru "github.com/hashicorp/golang-lru/v2"
@@ -9,16 +10,9 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 )
 
-// relabelCache abstracts the per-component cache of relabeled labels keyed
-// by the input labels' hash. Implementations cover two modes selectable
-// via Arguments: bounded LRU (default) and time-bounded ("size dictated
-// by working set"). All methods are safe for concurrent use.
-//
-// Implementations own any background work (e.g. periodic eviction).
-// `newRelabelCache` returns a ready-to-use cache; callers must invoke
-// Close when the cache is no longer needed. Tests that want to drive
-// eviction manually can use the per-impl bare constructors (e.g.
-// `newTTLRelabelCache`) which don't spawn the background goroutine.
+// relabelCache is the per-component cache of relabeled labels keyed by
+// the input labels' hash. Implementations are safe for concurrent use
+// and may own background goroutines; callers must Close when done.
 type relabelCache interface {
 	// Get returns the cached relabel result for the given hash. The
 	// boolean is false if no entry is cached (or, in TTL mode, if the
@@ -35,11 +29,8 @@ type relabelCache interface {
 	Close()
 }
 
-// newRelabelCache constructs a cache impl based on Arguments and
-// readies it for use (TTL caches have their background scan goroutine
-// running on return). Validation has already ensured exactly one of
-// CacheSize and CacheTTL is non-zero, so the lru.New error here is
-// effectively unreachable in production but propagated for safety.
+// newRelabelCache constructs a cache from args. TTL caches return with
+// their scan goroutine already running; the caller owns Close.
 func newRelabelCache(args Arguments, evictions prometheus_client.Counter) (relabelCache, error) {
 	if args.CacheTTL > 0 {
 		c := newTTLRelabelCache(args.CacheTTL, evictions)
@@ -72,23 +63,24 @@ func (c *lruRelabelCache) Remove(hash uint64) {
 func (c *lruRelabelCache) Len() int { return c.c.Len() }
 func (c *lruRelabelCache) Close()   {}
 
+// ttlEntry's lbls is immutable after insertion (same input hash always
+// yields the same relabel output within a cache lifetime); expires is
+// atomic so Get can slide the TTL window without taking the write lock.
 type ttlEntry struct {
 	lbls    labels.Labels
-	expires time.Time
+	expires atomic.Int64 // Unix seconds
 }
 
-// ttlRelabelCache is a TTL-bounded cache without a hard size limit. The
-// active set sizes itself to the working set of series flowing through
-// the component. Entries expire after a fixed TTL relative to the most
-// recent insertion.
+// ttlRelabelCache is a TTL-bounded cache with no hard size limit. Each
+// Get slides the entry's expiry forward, so active series stay cached
+// while inactive entries are reaped after cache_ttl.
 //
-// Note: Go maps don't return bucket memory on delete, so the underlying
-// map's footprint stays at the peak working set for the cache's
-// lifetime. Operators who need to reclaim that memory should restart
-// the component (config reload also recreates the cache from scratch).
+// Go maps don't release bucket memory on delete, so the underlying map
+// holds at the peak working set for the cache's lifetime; restart or
+// config reload to reclaim it.
 type ttlRelabelCache struct {
 	mu      sync.RWMutex
-	entries map[uint64]ttlEntry
+	entries map[uint64]*ttlEntry
 
 	ttl          time.Duration
 	scanInterval time.Duration
@@ -101,17 +93,14 @@ type ttlRelabelCache struct {
 	scanWG    sync.WaitGroup
 }
 
-// scanIntervalFor scales the background scan cadence to the configured
-// TTL: scanning at TTL/4 caps the post-expiry lag at ~25% of the TTL,
-// which keeps the cache sized to roughly the working set without
-// scanning so often that the bookkeeping dominates real work.
+// scanIntervalFor caps post-expiry lag at ~25% of the TTL.
 func scanIntervalFor(ttl time.Duration) time.Duration {
 	return ttl / 4
 }
 
 func newTTLRelabelCache(ttl time.Duration, evictions prometheus_client.Counter) *ttlRelabelCache {
 	return &ttlRelabelCache{
-		entries:      make(map[uint64]ttlEntry),
+		entries:      make(map[uint64]*ttlEntry),
 		ttl:          ttl,
 		scanInterval: scanIntervalFor(ttl),
 		evictions:    evictions,
@@ -126,17 +115,23 @@ func (c *ttlRelabelCache) Get(hash uint64) (labels.Labels, bool) {
 	if !ok {
 		return labels.EmptyLabels(), false
 	}
-	// Lazy expiration: an entry past its expiry counts as a miss even if
-	// the periodic scan hasn't pruned it yet.
-	if time.Now().After(entry.expires) {
-		return labels.EmptyLabels(), false
-	}
+	// Slide the TTL window forward without upgrading to the write lock.
+	entry.expires.Store(time.Now().Add(c.ttl).Unix())
 	return entry.lbls, true
 }
 
 func (c *ttlRelabelCache) Add(hash uint64, lbls labels.Labels) {
+	expires := time.Now().Add(c.ttl).Unix()
 	c.mu.Lock()
-	c.entries[hash] = ttlEntry{lbls: lbls, expires: time.Now().Add(c.ttl)}
+	if existing, ok := c.entries[hash]; ok {
+		// Concurrent miss: keep lbls immutable and just refresh expiry.
+		existing.expires.Store(expires)
+		c.mu.Unlock()
+		return
+	}
+	e := &ttlEntry{lbls: lbls}
+	e.expires.Store(expires)
+	c.entries[hash] = e
 	c.mu.Unlock()
 }
 
@@ -172,11 +167,8 @@ func (c *ttlRelabelCache) start() {
 	})
 }
 
-// Close terminates the background scan goroutine (if any) and blocks
-// until it exits. Idempotent. Safe to call even if start was never
-// called. The blocking-wait matters for testing/synctest's deadlock
-// detector, which fires if any goroutine in the bubble is still
-// running when the test's main goroutine returns.
+// Close terminates the background scan goroutine and blocks until it
+// exits. Idempotent.
 func (c *ttlRelabelCache) Close() {
 	c.closeOnce.Do(func() { close(c.closeCh) })
 	c.scanWG.Wait()
@@ -184,12 +176,13 @@ func (c *ttlRelabelCache) Close() {
 
 // scan prunes expired entries.
 func (c *ttlRelabelCache) scan(now time.Time) {
+	nowSec := now.Unix()
 	// Phase 1: collect expired keys under RLock. If there's no work,
 	// skip the write lock entirely.
 	c.mu.RLock()
 	var expired []uint64
 	for h, e := range c.entries {
-		if now.After(e.expires) {
+		if nowSec > e.expires.Load() {
 			expired = append(expired, h)
 		}
 	}
@@ -202,10 +195,10 @@ func (c *ttlRelabelCache) scan(now time.Time) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// Phase 2: prune. Re-check expiry per key in case a concurrent
-	// Add refreshed the entry between the phases.
+	// Phase 2: prune. Re-check expiry per key in case a concurrent Get
+	// slid the entry forward (or Add refreshed it) between the phases.
 	for _, h := range expired {
-		if e, ok := c.entries[h]; ok && now.After(e.expires) {
+		if e, ok := c.entries[h]; ok && nowSec > e.expires.Load() {
 			delete(c.entries, h)
 			c.evictions.Inc()
 		}

--- a/internal/component/prometheus/relabel/cache.go
+++ b/internal/component/prometheus/relabel/cache.go
@@ -1,7 +1,6 @@
 package relabel
 
 import (
-	"maps"
 	"sync"
 	"time"
 
@@ -11,10 +10,9 @@ import (
 )
 
 // relabelCache abstracts the per-component cache of relabeled labels keyed
-// by the input labels' hash. Implementations cover three modes selectable
-// via Arguments: bounded LRU (default), no caching at all, and
-// time-bounded ("size dictated by working set"). All methods are safe for
-// concurrent use.
+// by the input labels' hash. Implementations cover two modes selectable
+// via Arguments: bounded LRU (default) and time-bounded ("size dictated
+// by working set"). All methods are safe for concurrent use.
 //
 // Implementations own any background work (e.g. periodic eviction).
 // `newRelabelCache` returns a ready-to-use cache; callers must invoke
@@ -40,15 +38,19 @@ type relabelCache interface {
 // newRelabelCache constructs a cache impl based on Arguments and
 // readies it for use (TTL caches have their background scan goroutine
 // running on return). Validation has already ensured exactly one of
-// CacheSize and CacheTTL is non-zero.
-func newRelabelCache(args Arguments, counters ttlCounters) relabelCache {
+// CacheSize and CacheTTL is non-zero, so the lru.New error here is
+// effectively unreachable in production but propagated for safety.
+func newRelabelCache(args Arguments, evictions prometheus_client.Counter) (relabelCache, error) {
 	if args.CacheTTL > 0 {
-		c := newTTLRelabelCache(args.CacheTTL, counters)
+		c := newTTLRelabelCache(args.CacheTTL, evictions)
 		c.start()
-		return c
+		return c, nil
 	}
-	c, _ := lru.New[uint64, labels.Labels](args.CacheSize)
-	return &lruRelabelCache{c: c}
+	c, err := lru.New[uint64, labels.Labels](args.CacheSize)
+	if err != nil {
+		return nil, err
+	}
+	return &lruRelabelCache{c: c}, nil
 }
 
 type lruRelabelCache struct {
@@ -70,11 +72,6 @@ func (c *lruRelabelCache) Remove(hash uint64) {
 func (c *lruRelabelCache) Len() int { return c.c.Len() }
 func (c *lruRelabelCache) Close()   {}
 
-type ttlCounters struct {
-	evictions prometheus_client.Counter
-	rebuilds  prometheus_client.Counter
-}
-
 type ttlEntry struct {
 	lbls    labels.Labels
 	expires time.Time
@@ -84,16 +81,19 @@ type ttlEntry struct {
 // active set sizes itself to the working set of series flowing through
 // the component. Entries expire after a fixed TTL relative to the most
 // recent insertion.
+//
+// Note: Go maps don't return bucket memory on delete, so the underlying
+// map's footprint stays at the peak working set for the cache's
+// lifetime. Operators who need to reclaim that memory should restart
+// the component (config reload also recreates the cache from scratch).
 type ttlRelabelCache struct {
 	mu      sync.RWMutex
 	entries map[uint64]ttlEntry
 
-	ttl time.Duration
+	ttl          time.Duration
+	scanInterval time.Duration
 
-	peak        int // highest len(entries) observed since lastRebuild
-	lastRebuild time.Time
-
-	counters ttlCounters
+	evictions prometheus_client.Counter
 
 	startOnce sync.Once
 	closeOnce sync.Once
@@ -101,12 +101,21 @@ type ttlRelabelCache struct {
 	scanWG    sync.WaitGroup
 }
 
-func newTTLRelabelCache(ttl time.Duration, counters ttlCounters) *ttlRelabelCache {
+// scanIntervalFor scales the background scan cadence to the configured
+// TTL: scanning at TTL/4 caps the post-expiry lag at ~25% of the TTL,
+// which keeps the cache sized to roughly the working set without
+// scanning so often that the bookkeeping dominates real work.
+func scanIntervalFor(ttl time.Duration) time.Duration {
+	return ttl / 4
+}
+
+func newTTLRelabelCache(ttl time.Duration, evictions prometheus_client.Counter) *ttlRelabelCache {
 	return &ttlRelabelCache{
-		entries:  make(map[uint64]ttlEntry),
-		ttl:      ttl,
-		counters: counters,
-		closeCh:  make(chan struct{}),
+		entries:      make(map[uint64]ttlEntry),
+		ttl:          ttl,
+		scanInterval: scanIntervalFor(ttl),
+		evictions:    evictions,
+		closeCh:      make(chan struct{}),
 	}
 }
 
@@ -128,9 +137,6 @@ func (c *ttlRelabelCache) Get(hash uint64) (labels.Labels, bool) {
 func (c *ttlRelabelCache) Add(hash uint64, lbls labels.Labels) {
 	c.mu.Lock()
 	c.entries[hash] = ttlEntry{lbls: lbls, expires: time.Now().Add(c.ttl)}
-	if l := len(c.entries); l > c.peak {
-		c.peak = l
-	}
 	c.mu.Unlock()
 }
 
@@ -146,16 +152,13 @@ func (c *ttlRelabelCache) Len() int {
 	return len(c.entries)
 }
 
-// scanInterval is how often the background scan runs.
-const scanInterval = 1 * time.Minute
-
 // start spawns the background scan goroutine. Idempotent.
 func (c *ttlRelabelCache) start() {
 	c.startOnce.Do(func() {
 		c.scanWG.Add(1)
 		go func() {
 			defer c.scanWG.Done()
-			t := time.NewTicker(scanInterval)
+			t := time.NewTicker(c.scanInterval)
 			defer t.Stop()
 			for {
 				select {
@@ -179,12 +182,10 @@ func (c *ttlRelabelCache) Close() {
 	c.scanWG.Wait()
 }
 
-// scan prunes expired entries and, when the underlying map has shrunk
-// far below its high-water mark, reallocates it to release bucket
-// memory (Go maps never shrink on delete).
+// scan prunes expired entries.
 func (c *ttlRelabelCache) scan(now time.Time) {
-	// Phase 1: collect expired keys and peek at the rebuild predicate
-	// under RLock. If neither has work, skip the write lock entirely.
+	// Phase 1: collect expired keys under RLock. If there's no work,
+	// skip the write lock entirely.
 	c.mu.RLock()
 	var expired []uint64
 	for h, e := range c.entries {
@@ -192,59 +193,21 @@ func (c *ttlRelabelCache) scan(now time.Time) {
 			expired = append(expired, h)
 		}
 	}
-	rebuildEligible := c.shouldRebuildLocked(now)
 	c.mu.RUnlock()
 
-	if len(expired) == 0 && !rebuildEligible {
+	if len(expired) == 0 {
 		return
 	}
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// Phase 2a: prune. Re-check expiry per key in case a concurrent
+	// Phase 2: prune. Re-check expiry per key in case a concurrent
 	// Add refreshed the entry between the phases.
 	for _, h := range expired {
 		if e, ok := c.entries[h]; ok && now.After(e.expires) {
 			delete(c.entries, h)
-			c.counters.evictions.Inc()
+			c.evictions.Inc()
 		}
 	}
-
-	// Phase 2b: re-evaluate the rebuild predicate now that we've
-	// pruned, then rebuild if still eligible.
-	if !c.shouldRebuildLocked(now) {
-		return
-	}
-	c.entries = maps.Clone(c.entries)
-	c.peak = len(c.entries)
-	c.lastRebuild = now
-	c.counters.rebuilds.Inc()
-}
-
-// Exposed as vars so tests can override. The floor is set so a 50%
-// shrink reclaims ~2MB of bucket memory — small enough to skip noise,
-// large enough that rebuilds are worth the write-lock window.
-var (
-	rebuildFloor   = 32_768
-	rebuildSpacing = 30 * time.Minute
-)
-
-// shouldRebuildLocked decides whether the underlying map should be
-// reallocated. Returns true when (a) the high-water mark crossed
-// rebuildFloor (skips trivial caches), (b) live entries have fallen to
-// half the peak or less, and (c) at least rebuildSpacing has passed
-// since the last rebuild (avoids churn on oscillating workloads). Must
-// be called with at least the read lock held.
-func (c *ttlRelabelCache) shouldRebuildLocked(now time.Time) bool {
-	if c.peak < rebuildFloor {
-		return false
-	}
-	if len(c.entries)*2 > c.peak {
-		return false
-	}
-	if !c.lastRebuild.IsZero() && now.Sub(c.lastRebuild) < rebuildSpacing {
-		return false
-	}
-	return true
 }

--- a/internal/component/prometheus/relabel/cache.go
+++ b/internal/component/prometheus/relabel/cache.go
@@ -12,21 +12,20 @@ import (
 
 // relabelCache is the per-component cache of relabeled labels keyed by
 // the input labels' hash. Implementations are safe for concurrent use
-// and may own background goroutines; callers must Close when done.
+// and may own background goroutines; callers must close when done.
 type relabelCache interface {
-	// Get returns the cached relabel result for the given hash. The
-	// boolean is false if no entry is cached (or, in TTL mode, if the
-	// entry has expired).
-	Get(hash uint64) (labels.Labels, bool)
-	// Add inserts or refreshes the cached relabel result for the given
+	// get returns the cached relabel result for the given hash. The
+	// boolean is false if no entry is cached.
+	get(hash uint64) (labels.Labels, bool)
+	// add inserts or refreshes the cached relabel result for the given
 	// hash.
-	Add(hash uint64, lbls labels.Labels)
-	// Remove drops the cached entry for the given hash, if present.
-	Remove(hash uint64)
-	// Len returns the number of entries currently in the cache.
-	Len() int
-	// Close releases any background resources held by the cache.
-	Close()
+	add(hash uint64, lbls labels.Labels)
+	// remove drops the cached entry for the given hash, if present.
+	remove(hash uint64)
+	// len returns the number of entries currently in the cache.
+	len() int
+	// close releases any background resources held by the cache.
+	close()
 }
 
 // newRelabelCache constructs a cache from args. TTL caches return with
@@ -48,20 +47,20 @@ type lruRelabelCache struct {
 	c *lru.Cache[uint64, labels.Labels]
 }
 
-func (c *lruRelabelCache) Get(hash uint64) (labels.Labels, bool) {
+func (c *lruRelabelCache) get(hash uint64) (labels.Labels, bool) {
 	return c.c.Get(hash)
 }
 
-func (c *lruRelabelCache) Add(hash uint64, lbls labels.Labels) {
+func (c *lruRelabelCache) add(hash uint64, lbls labels.Labels) {
 	c.c.Add(hash, lbls)
 }
 
-func (c *lruRelabelCache) Remove(hash uint64) {
+func (c *lruRelabelCache) remove(hash uint64) {
 	c.c.Remove(hash)
 }
 
-func (c *lruRelabelCache) Len() int { return c.c.Len() }
-func (c *lruRelabelCache) Close()   {}
+func (c *lruRelabelCache) len() int { return c.c.Len() }
+func (c *lruRelabelCache) close()   {}
 
 // ttlEntry's lbls is immutable after insertion (same input hash always
 // yields the same relabel output within a cache lifetime); expires is
@@ -108,7 +107,7 @@ func newTTLRelabelCache(ttl time.Duration, evictions prometheus_client.Counter) 
 	}
 }
 
-func (c *ttlRelabelCache) Get(hash uint64) (labels.Labels, bool) {
+func (c *ttlRelabelCache) get(hash uint64) (labels.Labels, bool) {
 	c.mu.RLock()
 	entry, ok := c.entries[hash]
 	c.mu.RUnlock()
@@ -120,7 +119,7 @@ func (c *ttlRelabelCache) Get(hash uint64) (labels.Labels, bool) {
 	return entry.lbls, true
 }
 
-func (c *ttlRelabelCache) Add(hash uint64, lbls labels.Labels) {
+func (c *ttlRelabelCache) add(hash uint64, lbls labels.Labels) {
 	expires := time.Now().Add(c.ttl).Unix()
 	c.mu.Lock()
 	if existing, ok := c.entries[hash]; ok {
@@ -135,13 +134,13 @@ func (c *ttlRelabelCache) Add(hash uint64, lbls labels.Labels) {
 	c.mu.Unlock()
 }
 
-func (c *ttlRelabelCache) Remove(hash uint64) {
+func (c *ttlRelabelCache) remove(hash uint64) {
 	c.mu.Lock()
 	delete(c.entries, hash)
 	c.mu.Unlock()
 }
 
-func (c *ttlRelabelCache) Len() int {
+func (c *ttlRelabelCache) len() int {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return len(c.entries)
@@ -167,9 +166,9 @@ func (c *ttlRelabelCache) start() {
 	})
 }
 
-// Close terminates the background scan goroutine and blocks until it
+// close terminates the background scan goroutine and blocks until it
 // exits. Idempotent.
-func (c *ttlRelabelCache) Close() {
+func (c *ttlRelabelCache) close() {
 	c.closeOnce.Do(func() { close(c.closeCh) })
 	c.scanWG.Wait()
 }

--- a/internal/component/prometheus/relabel/cache.go
+++ b/internal/component/prometheus/relabel/cache.go
@@ -2,12 +2,12 @@ package relabel
 
 import (
 	"sync"
-	"sync/atomic"
 	"time"
 
 	lru "github.com/hashicorp/golang-lru/v2"
 	prometheus_client "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
+	"go.uber.org/atomic"
 )
 
 // relabelCache is the per-component cache of relabeled labels keyed by

--- a/internal/component/prometheus/relabel/cache.go
+++ b/internal/component/prometheus/relabel/cache.go
@@ -1,0 +1,250 @@
+package relabel
+
+import (
+	"maps"
+	"sync"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	prometheus_client "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+// relabelCache abstracts the per-component cache of relabeled labels keyed
+// by the input labels' hash. Implementations cover three modes selectable
+// via Arguments: bounded LRU (default), no caching at all, and
+// time-bounded ("size dictated by working set"). All methods are safe for
+// concurrent use.
+//
+// Implementations own any background work (e.g. periodic eviction).
+// `newRelabelCache` returns a ready-to-use cache; callers must invoke
+// Close when the cache is no longer needed. Tests that want to drive
+// eviction manually can use the per-impl bare constructors (e.g.
+// `newTTLRelabelCache`) which don't spawn the background goroutine.
+type relabelCache interface {
+	// Get returns the cached relabel result for the given hash. The
+	// boolean is false if no entry is cached (or, in TTL mode, if the
+	// entry has expired).
+	Get(hash uint64) (labels.Labels, bool)
+	// Add inserts or refreshes the cached relabel result for the given
+	// hash.
+	Add(hash uint64, lbls labels.Labels)
+	// Remove drops the cached entry for the given hash, if present.
+	Remove(hash uint64)
+	// Len returns the number of entries currently in the cache.
+	Len() int
+	// Close releases any background resources held by the cache.
+	Close()
+}
+
+// newRelabelCache constructs a cache impl based on Arguments and
+// readies it for use (TTL caches have their background scan goroutine
+// running on return). Validation has already ensured exactly one of
+// CacheSize and CacheTTL is non-zero.
+func newRelabelCache(args Arguments, counters ttlCounters) relabelCache {
+	if args.CacheTTL > 0 {
+		c := newTTLRelabelCache(args.CacheTTL, counters)
+		c.start()
+		return c
+	}
+	c, _ := lru.New[uint64, labels.Labels](args.CacheSize)
+	return &lruRelabelCache{c: c}
+}
+
+type lruRelabelCache struct {
+	c *lru.Cache[uint64, labels.Labels]
+}
+
+func (c *lruRelabelCache) Get(hash uint64) (labels.Labels, bool) {
+	return c.c.Get(hash)
+}
+
+func (c *lruRelabelCache) Add(hash uint64, lbls labels.Labels) {
+	c.c.Add(hash, lbls)
+}
+
+func (c *lruRelabelCache) Remove(hash uint64) {
+	c.c.Remove(hash)
+}
+
+func (c *lruRelabelCache) Len() int { return c.c.Len() }
+func (c *lruRelabelCache) Close()   {}
+
+type ttlCounters struct {
+	evictions prometheus_client.Counter
+	rebuilds  prometheus_client.Counter
+}
+
+type ttlEntry struct {
+	lbls    labels.Labels
+	expires time.Time
+}
+
+// ttlRelabelCache is a TTL-bounded cache without a hard size limit. The
+// active set sizes itself to the working set of series flowing through
+// the component. Entries expire after a fixed TTL relative to the most
+// recent insertion.
+type ttlRelabelCache struct {
+	mu      sync.RWMutex
+	entries map[uint64]ttlEntry
+
+	ttl time.Duration
+
+	peak        int // highest len(entries) observed since lastRebuild
+	lastRebuild time.Time
+
+	counters ttlCounters
+
+	startOnce sync.Once
+	closeOnce sync.Once
+	closeCh   chan struct{}
+	scanWG    sync.WaitGroup
+}
+
+func newTTLRelabelCache(ttl time.Duration, counters ttlCounters) *ttlRelabelCache {
+	return &ttlRelabelCache{
+		entries:  make(map[uint64]ttlEntry),
+		ttl:      ttl,
+		counters: counters,
+		closeCh:  make(chan struct{}),
+	}
+}
+
+func (c *ttlRelabelCache) Get(hash uint64) (labels.Labels, bool) {
+	c.mu.RLock()
+	entry, ok := c.entries[hash]
+	c.mu.RUnlock()
+	if !ok {
+		return labels.EmptyLabels(), false
+	}
+	// Lazy expiration: an entry past its expiry counts as a miss even if
+	// the periodic scan hasn't pruned it yet.
+	if time.Now().After(entry.expires) {
+		return labels.EmptyLabels(), false
+	}
+	return entry.lbls, true
+}
+
+func (c *ttlRelabelCache) Add(hash uint64, lbls labels.Labels) {
+	c.mu.Lock()
+	c.entries[hash] = ttlEntry{lbls: lbls, expires: time.Now().Add(c.ttl)}
+	if l := len(c.entries); l > c.peak {
+		c.peak = l
+	}
+	c.mu.Unlock()
+}
+
+func (c *ttlRelabelCache) Remove(hash uint64) {
+	c.mu.Lock()
+	delete(c.entries, hash)
+	c.mu.Unlock()
+}
+
+func (c *ttlRelabelCache) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.entries)
+}
+
+// scanInterval is how often the background scan runs.
+const scanInterval = 1 * time.Minute
+
+// start spawns the background scan goroutine. Idempotent.
+func (c *ttlRelabelCache) start() {
+	c.startOnce.Do(func() {
+		c.scanWG.Add(1)
+		go func() {
+			defer c.scanWG.Done()
+			t := time.NewTicker(scanInterval)
+			defer t.Stop()
+			for {
+				select {
+				case <-c.closeCh:
+					return
+				case now := <-t.C:
+					c.scan(now)
+				}
+			}
+		}()
+	})
+}
+
+// Close terminates the background scan goroutine (if any) and blocks
+// until it exits. Idempotent. Safe to call even if start was never
+// called. The blocking-wait matters for testing/synctest's deadlock
+// detector, which fires if any goroutine in the bubble is still
+// running when the test's main goroutine returns.
+func (c *ttlRelabelCache) Close() {
+	c.closeOnce.Do(func() { close(c.closeCh) })
+	c.scanWG.Wait()
+}
+
+// scan prunes expired entries and, when the underlying map has shrunk
+// far below its high-water mark, reallocates it to release bucket
+// memory (Go maps never shrink on delete).
+func (c *ttlRelabelCache) scan(now time.Time) {
+	// Phase 1: collect expired keys and peek at the rebuild predicate
+	// under RLock. If neither has work, skip the write lock entirely.
+	c.mu.RLock()
+	var expired []uint64
+	for h, e := range c.entries {
+		if now.After(e.expires) {
+			expired = append(expired, h)
+		}
+	}
+	rebuildEligible := c.shouldRebuildLocked(now)
+	c.mu.RUnlock()
+
+	if len(expired) == 0 && !rebuildEligible {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Phase 2a: prune. Re-check expiry per key in case a concurrent
+	// Add refreshed the entry between the phases.
+	for _, h := range expired {
+		if e, ok := c.entries[h]; ok && now.After(e.expires) {
+			delete(c.entries, h)
+			c.counters.evictions.Inc()
+		}
+	}
+
+	// Phase 2b: re-evaluate the rebuild predicate now that we've
+	// pruned, then rebuild if still eligible.
+	if !c.shouldRebuildLocked(now) {
+		return
+	}
+	c.entries = maps.Clone(c.entries)
+	c.peak = len(c.entries)
+	c.lastRebuild = now
+	c.counters.rebuilds.Inc()
+}
+
+// Exposed as vars so tests can override. The floor is set so a 50%
+// shrink reclaims ~2MB of bucket memory — small enough to skip noise,
+// large enough that rebuilds are worth the write-lock window.
+var (
+	rebuildFloor   = 32_768
+	rebuildSpacing = 30 * time.Minute
+)
+
+// shouldRebuildLocked decides whether the underlying map should be
+// reallocated. Returns true when (a) the high-water mark crossed
+// rebuildFloor (skips trivial caches), (b) live entries have fallen to
+// half the peak or less, and (c) at least rebuildSpacing has passed
+// since the last rebuild (avoids churn on oscillating workloads). Must
+// be called with at least the read lock held.
+func (c *ttlRelabelCache) shouldRebuildLocked(now time.Time) bool {
+	if c.peak < rebuildFloor {
+		return false
+	}
+	if len(c.entries)*2 > c.peak {
+		return false
+	}
+	if !c.lastRebuild.IsZero() && now.Sub(c.lastRebuild) < rebuildSpacing {
+		return false
+	}
+	return true
+}

--- a/internal/component/prometheus/relabel/cache.go
+++ b/internal/component/prometheus/relabel/cache.go
@@ -74,12 +74,16 @@ type ttlEntry struct {
 // Get slides the entry's expiry forward, so active series stay cached
 // while inactive entries are reaped after cache_ttl.
 //
-// Go maps don't release bucket memory on delete, so the underlying map
-// holds at the peak working set for the cache's lifetime; restart or
-// config reload to reclaim it.
+// Go maps don't release bucket memory on delete, so a transient
+// cardinality spike would otherwise pin the map at its peak footprint
+// indefinitely. The scanner rebuilds the map when live entries drop far
+// enough below the high-water mark for the reclaim to be worth the copy.
 type ttlRelabelCache struct {
 	mu      sync.RWMutex
 	entries map[uint64]*ttlEntry
+	// peak is the high-water mark of map size since the last rebuild;
+	// scan compares len(entries) against it to decide when to shrink.
+	peak int
 
 	ttl          time.Duration
 	scanInterval time.Duration
@@ -90,6 +94,21 @@ type ttlRelabelCache struct {
 	closeOnce sync.Once
 	closeCh   chan struct{}
 	scanWG    sync.WaitGroup
+}
+
+// shouldShrink applies a two-tier policy. Reclaim scales roughly linearly
+// with peak (empirically ~18MB at 1M / 50% drop, ~150MB at 10M / 33%
+// drop), so larger peaks justify shrinking at smaller drops. Below 1M
+// the absolute savings (≤2MB at 10x drop) aren't worth the rebuild.
+func shouldShrink(peak, live int) bool {
+	switch {
+	case peak >= 10_000_000:
+		return live*3 <= peak*2 // 33%+ drop, reclaims ~150MB+
+	case peak >= 1_000_000:
+		return live*2 <= peak // 50%+ drop, reclaims ~18MB+
+	default:
+		return false
+	}
 }
 
 // scanIntervalFor caps post-expiry lag at ~25% of the TTL.
@@ -131,6 +150,9 @@ func (c *ttlRelabelCache) add(hash uint64, lbls labels.Labels) {
 	e := &ttlEntry{lbls: lbls}
 	e.expires.Store(expires)
 	c.entries[hash] = e
+	if n := len(c.entries); n > c.peak {
+		c.peak = n
+	}
 	c.mu.Unlock()
 }
 
@@ -173,11 +195,13 @@ func (c *ttlRelabelCache) close() {
 	c.scanWG.Wait()
 }
 
-// scan prunes expired entries.
+// scan prunes expired entries and rebuilds the map when it has drained
+// far enough below its peak to make the reclaim worthwhile.
 func (c *ttlRelabelCache) scan(now time.Time) {
 	nowSec := now.Unix()
-	// Phase 1: collect expired keys under RLock. If there's no work,
-	// skip the write lock entirely.
+	// Phase 1: collect expired keys under RLock. Also peek at the
+	// shrink condition so a drain-only cycle (entries removed via stale
+	// markers, nothing expired) still triggers the write lock.
 	c.mu.RLock()
 	var expired []uint64
 	for h, e := range c.entries {
@@ -185,9 +209,10 @@ func (c *ttlRelabelCache) scan(now time.Time) {
 			expired = append(expired, h)
 		}
 	}
+	maybeShrink := shouldShrink(c.peak, len(c.entries)-len(expired))
 	c.mu.RUnlock()
 
-	if len(expired) == 0 {
+	if len(expired) == 0 && !maybeShrink {
 		return
 	}
 
@@ -201,5 +226,24 @@ func (c *ttlRelabelCache) scan(now time.Time) {
 			delete(c.entries, h)
 			c.evictions.Inc()
 		}
+	}
+
+	// Phase 3: shrink if the live set has drained far enough below peak
+	// that the bucket reclaim outweighs the rebuild cost. Resetting peak
+	// to the new size provides natural hysteresis — we can't rebuild
+	// again until the map grows back up and drains.
+	//
+	// The old and new maps coexist until this function returns and the
+	// old one becomes unreachable, so peak footprint briefly grows by
+	// the new map's bucket size (roughly len/peak of the existing
+	// allocation). Acceptable: we'd rather hold the spike for one scan
+	// interval than carry the bloated map indefinitely.
+	if shouldShrink(c.peak, len(c.entries)) {
+		rebuilt := make(map[uint64]*ttlEntry, len(c.entries))
+		for h, e := range c.entries {
+			rebuilt[h] = e
+		}
+		c.entries = rebuilt
+		c.peak = len(c.entries)
 	}
 }

--- a/internal/component/prometheus/relabel/cache_test.go
+++ b/internal/component/prometheus/relabel/cache_test.go
@@ -12,11 +12,8 @@ import (
 	prometheus_client "github.com/prometheus/client_golang/prometheus"
 )
 
-func newTestTTLCounters() ttlCounters {
-	return ttlCounters{
-		evictions: prometheus_client.NewCounter(prometheus_client.CounterOpts{Name: "test_evictions"}),
-		rebuilds:  prometheus_client.NewCounter(prometheus_client.CounterOpts{Name: "test_rebuilds"}),
-	}
+func newTestEvictionsCounter() prometheus_client.Counter {
+	return prometheus_client.NewCounter(prometheus_client.CounterOpts{Name: "test_evictions"})
 }
 
 func counterVal(t *testing.T, c prometheus_client.Counter) float64 {
@@ -27,7 +24,8 @@ func counterVal(t *testing.T, c prometheus_client.Counter) float64 {
 }
 
 func TestLRURelabelCache_FillsToCap(t *testing.T) {
-	c := newRelabelCache(Arguments{CacheSize: 100_000}, newTestTTLCounters())
+	c, err := newRelabelCache(Arguments{CacheSize: 100_000}, newTestEvictionsCounter())
+	require.NoError(t, err)
 	defer c.Close()
 	for i := uint64(0); i < 600_000; i++ {
 		c.Add(i, labels.FromStrings("k", "v"))
@@ -36,7 +34,8 @@ func TestLRURelabelCache_FillsToCap(t *testing.T) {
 }
 
 func TestLRURelabelCache_BasicOps(t *testing.T) {
-	c := newRelabelCache(Arguments{CacheSize: 100}, newTestTTLCounters())
+	c, err := newRelabelCache(Arguments{CacheSize: 100}, newTestEvictionsCounter())
+	require.NoError(t, err)
 	defer c.Close()
 	require.IsType(t, &lruRelabelCache{}, c)
 
@@ -57,7 +56,9 @@ func TestLRURelabelCache_BasicOps(t *testing.T) {
 
 func TestTTLRelabelCache_LazyExpiry(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		c := newRelabelCache(Arguments{CacheTTL: 30 * time.Second}, newTestTTLCounters()).(*ttlRelabelCache)
+		raw, err := newRelabelCache(Arguments{CacheTTL: 30 * time.Second}, newTestEvictionsCounter())
+		require.NoError(t, err)
+		c := raw.(*ttlRelabelCache)
 		defer c.Close()
 
 		lbls := labels.FromStrings("a", "b")
@@ -80,8 +81,8 @@ func TestTTLRelabelCache_LazyExpiry(t *testing.T) {
 
 func TestTTLRelabelCache_ScanEvicts(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		counters := newTestTTLCounters()
-		c := newTTLRelabelCache(time.Minute, counters)
+		evictions := newTestEvictionsCounter()
+		c := newTTLRelabelCache(time.Minute, evictions)
 		defer c.Close()
 
 		c.Add(1, labels.FromStrings("a", "b"))
@@ -92,14 +93,14 @@ func TestTTLRelabelCache_ScanEvicts(t *testing.T) {
 		c.scan(time.Now())
 
 		require.Equal(t, 0, c.Len())
-		require.Equal(t, float64(2), counterVal(t, counters.evictions))
+		require.Equal(t, float64(2), counterVal(t, evictions))
 	})
 }
 
 func TestTTLRelabelCache_ScanLeavesFreshEntries(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		counters := newTestTTLCounters()
-		c := newTTLRelabelCache(time.Minute, counters)
+		evictions := newTestEvictionsCounter()
+		c := newTTLRelabelCache(time.Minute, evictions)
 		defer c.Close()
 
 		c.Add(1, labels.FromStrings("old", ""))
@@ -110,13 +111,13 @@ func TestTTLRelabelCache_ScanLeavesFreshEntries(t *testing.T) {
 		require.Equal(t, 1, c.Len())
 		_, ok := c.Get(2)
 		require.True(t, ok)
-		require.Equal(t, float64(1), counterVal(t, counters.evictions))
+		require.Equal(t, float64(1), counterVal(t, evictions))
 	})
 }
 
 func TestTTLRelabelCache_StaleRemove(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		c := newTTLRelabelCache(time.Hour, newTestTTLCounters())
+		c := newTTLRelabelCache(time.Hour, newTestEvictionsCounter())
 		defer c.Close()
 
 		c.Add(1, labels.FromStrings("a", "b"))
@@ -125,94 +126,5 @@ func TestTTLRelabelCache_StaleRemove(t *testing.T) {
 		_, ok := c.Get(1)
 		require.False(t, ok, "Remove must drop the entry immediately, even with a long TTL")
 		require.Equal(t, 0, c.Len())
-	})
-}
-
-func TestTTLRelabelCache_RebuildAfterShrink(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		// Tighten the rebuild knobs so the test can assert on them
-		// without inserting tens of thousands of entries.
-		t.Cleanup(func() {
-			rebuildFloor = 4096
-			rebuildSpacing = 30 * time.Minute
-		})
-		rebuildFloor = 16
-		rebuildSpacing = time.Minute
-
-		counters := newTestTTLCounters()
-		c := newTTLRelabelCache(time.Minute, counters)
-
-		// Spike the cache well above the rebuild floor.
-		for i := uint64(0); i < 100; i++ {
-			c.Add(i, labels.FromStrings("k", "v"))
-		}
-		require.Equal(t, 100, c.Len())
-
-		// Let the cache age out and scan; the scan should both prune
-		// the entries and rebuild the underlying map because the live
-		// count fell below half the watermark.
-		time.Sleep(2 * time.Minute)
-		c.scan(time.Now())
-
-		require.Equal(t, 0, c.Len())
-		require.Equal(t, float64(1), counterVal(t, counters.rebuilds))
-	})
-}
-
-func TestTTLRelabelCache_RebuildRateLimit(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		t.Cleanup(func() {
-			rebuildFloor = 4096
-			rebuildSpacing = 30 * time.Minute
-		})
-		rebuildFloor = 16
-		rebuildSpacing = 30 * time.Minute
-
-		counters := newTestTTLCounters()
-		c := newTTLRelabelCache(time.Minute, counters)
-
-		for i := uint64(0); i < 100; i++ {
-			c.Add(i, labels.FromStrings("k", "v"))
-		}
-
-		// First scan after expiry — rebuilds.
-		time.Sleep(2 * time.Minute)
-		c.scan(time.Now())
-		require.Equal(t, float64(1), counterVal(t, counters.rebuilds))
-
-		// Spike again, age out again, but call Scan before
-		// rebuildSpacing has elapsed: the cache should NOT rebuild.
-		for i := uint64(100); i < 200; i++ {
-			c.Add(i, labels.FromStrings("k", "v"))
-		}
-		time.Sleep(2 * time.Minute)
-		c.scan(time.Now())
-		require.Equal(t, float64(1), counterVal(t, counters.rebuilds), "rebuild rate-limited")
-
-		// After spacing elapses, the next eligible scan rebuilds again.
-		for i := uint64(200); i < 300; i++ {
-			c.Add(i, labels.FromStrings("k", "v"))
-		}
-		time.Sleep(31 * time.Minute)
-		c.scan(time.Now())
-		require.Equal(t, float64(2), counterVal(t, counters.rebuilds))
-	})
-}
-
-func TestTTLRelabelCache_RebuildSkippedBelowFloor(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		counters := newTestTTLCounters()
-		c := newTTLRelabelCache(time.Minute, counters)
-		defer c.Close()
-
-		// Default floor is 4096 — far above the 100 entries we'll add.
-		for i := uint64(0); i < 100; i++ {
-			c.Add(i, labels.FromStrings("k", "v"))
-		}
-		time.Sleep(2 * time.Minute)
-		c.scan(time.Now())
-
-		require.Equal(t, 0, c.Len())
-		require.Equal(t, float64(0), counterVal(t, counters.rebuilds), "below-floor caches skip rebuild")
 	})
 }

--- a/internal/component/prometheus/relabel/cache_test.go
+++ b/internal/component/prometheus/relabel/cache_test.go
@@ -54,27 +54,25 @@ func TestLRURelabelCache_BasicOps(t *testing.T) {
 	require.False(t, ok)
 }
 
-func TestTTLRelabelCache_LazyExpiry(t *testing.T) {
+// TestTTLRelabelCache_GetReturnsCachedValuePastExpiry confirms that
+// scan is the sole arbiter of eviction: a Get on an entry whose
+// nominal expiry has passed but which scan hasn't pruned still returns
+// a hit (and slides the entry forward). The cached value is always
+// correct since relabel rules can't change without rebuilding the
+// cache, so there's no reason to force a re-relabel on the caller.
+func TestTTLRelabelCache_GetReturnsCachedValuePastExpiry(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		raw, err := newRelabelCache(Arguments{CacheTTL: 30 * time.Second}, newTestEvictionsCounter())
-		require.NoError(t, err)
-		c := raw.(*ttlRelabelCache)
+		c := newTTLRelabelCache(time.Minute, newTestEvictionsCounter())
 		defer c.Close()
 
 		lbls := labels.FromStrings("a", "b")
 		c.Add(1, lbls)
 
-		// Within TTL: hit.
+		// Past the TTL with no scan in between.
+		time.Sleep(2 * time.Minute)
 		got, ok := c.Get(1)
-		require.True(t, ok)
+		require.True(t, ok, "Get returns cached value until scan prunes it")
 		require.Equal(t, lbls, got)
-
-		// Advance past TTL: lazy expiry rejects the entry on Get even
-		// though Scan hasn't run yet.
-		time.Sleep(31 * time.Second)
-		_, ok = c.Get(1)
-		require.False(t, ok)
-		// Entry is still in the map until Scan prunes it.
 		require.Equal(t, 1, c.Len())
 	})
 }
@@ -126,5 +124,55 @@ func TestTTLRelabelCache_StaleRemove(t *testing.T) {
 		_, ok := c.Get(1)
 		require.False(t, ok, "Remove must drop the entry immediately, even with a long TTL")
 		require.Equal(t, 0, c.Len())
+	})
+}
+
+// TestTTLRelabelCache_GetSlidesExpiry asserts that a successful Get
+// pushes the entry's expiry forward by a full TTL, so series that
+// stay active stay cached without ever paying for re-relabeling.
+func TestTTLRelabelCache_GetSlidesExpiry(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		c := newTTLRelabelCache(time.Minute, newTestEvictionsCounter())
+		defer c.Close()
+
+		c.Add(1, labels.FromStrings("a", "b"))
+
+		// Halfway through the TTL: still a hit, and the Get slides
+		// expiry from t=60s out to t=90s.
+		time.Sleep(30 * time.Second)
+		_, ok := c.Get(1)
+		require.True(t, ok)
+
+		// Now at t=80s — past the original t=60s expiry. Without
+		// sliding, this would be a miss. With sliding, the entry's
+		// expiry is t=90s, so it's still valid.
+		time.Sleep(50 * time.Second)
+		_, ok = c.Get(1)
+		require.True(t, ok, "Get must slide the TTL window forward")
+	})
+}
+
+// TestTTLRelabelCache_ScanLeavesActiveEntries confirms the scanner
+// does not evict an entry whose Get keeps refreshing it, even when
+// scans fire after each TTL window's nominal expiry.
+func TestTTLRelabelCache_ScanLeavesActiveEntries(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		evictions := newTestEvictionsCounter()
+		c := newTTLRelabelCache(time.Minute, evictions)
+		defer c.Close()
+
+		c.Add(1, labels.FromStrings("a", "b"))
+
+		// Three full TTL cycles: each cycle, Get keeps the entry hot,
+		// then scan runs after the original-expiry would have hit.
+		for cycle := 0; cycle < 3; cycle++ {
+			time.Sleep(45 * time.Second)
+			_, ok := c.Get(1)
+			require.True(t, ok)
+			c.scan(time.Now())
+		}
+
+		require.Equal(t, 1, c.Len())
+		require.Equal(t, float64(0), counterVal(t, evictions))
 	})
 }

--- a/internal/component/prometheus/relabel/cache_test.go
+++ b/internal/component/prometheus/relabel/cache_test.go
@@ -26,31 +26,31 @@ func counterVal(t *testing.T, c prometheus_client.Counter) float64 {
 func TestLRURelabelCache_FillsToCap(t *testing.T) {
 	c, err := newRelabelCache(Arguments{CacheSize: 100_000}, newTestEvictionsCounter())
 	require.NoError(t, err)
-	defer c.Close()
+	defer c.close()
 	for i := uint64(0); i < 600_000; i++ {
-		c.Add(i, labels.FromStrings("k", "v"))
+		c.add(i, labels.FromStrings("k", "v"))
 	}
-	require.Equal(t, 100_000, c.Len())
+	require.Equal(t, 100_000, c.len())
 }
 
 func TestLRURelabelCache_BasicOps(t *testing.T) {
 	c, err := newRelabelCache(Arguments{CacheSize: 100}, newTestEvictionsCounter())
 	require.NoError(t, err)
-	defer c.Close()
+	defer c.close()
 	require.IsType(t, &lruRelabelCache{}, c)
 
 	lbls := labels.FromStrings("a", "b")
-	_, ok := c.Get(1)
+	_, ok := c.get(1)
 	require.False(t, ok)
 
-	c.Add(1, lbls)
-	got, ok := c.Get(1)
+	c.add(1, lbls)
+	got, ok := c.get(1)
 	require.True(t, ok)
 	require.Equal(t, lbls, got)
-	require.Equal(t, 1, c.Len())
+	require.Equal(t, 1, c.len())
 
-	c.Remove(1)
-	_, ok = c.Get(1)
+	c.remove(1)
+	_, ok = c.get(1)
 	require.False(t, ok)
 }
 
@@ -63,17 +63,17 @@ func TestLRURelabelCache_BasicOps(t *testing.T) {
 func TestTTLRelabelCache_GetReturnsCachedValuePastExpiry(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		c := newTTLRelabelCache(time.Minute, newTestEvictionsCounter())
-		defer c.Close()
+		defer c.close()
 
 		lbls := labels.FromStrings("a", "b")
-		c.Add(1, lbls)
+		c.add(1, lbls)
 
 		// Past the TTL with no scan in between.
 		time.Sleep(2 * time.Minute)
-		got, ok := c.Get(1)
+		got, ok := c.get(1)
 		require.True(t, ok, "Get returns cached value until scan prunes it")
 		require.Equal(t, lbls, got)
-		require.Equal(t, 1, c.Len())
+		require.Equal(t, 1, c.len())
 	})
 }
 
@@ -81,16 +81,16 @@ func TestTTLRelabelCache_ScanEvicts(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		evictions := newTestEvictionsCounter()
 		c := newTTLRelabelCache(time.Minute, evictions)
-		defer c.Close()
+		defer c.close()
 
-		c.Add(1, labels.FromStrings("a", "b"))
-		c.Add(2, labels.FromStrings("c", "d"))
-		require.Equal(t, 2, c.Len())
+		c.add(1, labels.FromStrings("a", "b"))
+		c.add(2, labels.FromStrings("c", "d"))
+		require.Equal(t, 2, c.len())
 
 		time.Sleep(2 * time.Minute)
 		c.scan(time.Now())
 
-		require.Equal(t, 0, c.Len())
+		require.Equal(t, 0, c.len())
 		require.Equal(t, float64(2), counterVal(t, evictions))
 	})
 }
@@ -99,15 +99,15 @@ func TestTTLRelabelCache_ScanLeavesFreshEntries(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		evictions := newTestEvictionsCounter()
 		c := newTTLRelabelCache(time.Minute, evictions)
-		defer c.Close()
+		defer c.close()
 
-		c.Add(1, labels.FromStrings("old", ""))
+		c.add(1, labels.FromStrings("old", ""))
 		time.Sleep(90 * time.Second)
-		c.Add(2, labels.FromStrings("fresh", ""))
+		c.add(2, labels.FromStrings("fresh", ""))
 		c.scan(time.Now())
 
-		require.Equal(t, 1, c.Len())
-		_, ok := c.Get(2)
+		require.Equal(t, 1, c.len())
+		_, ok := c.get(2)
 		require.True(t, ok)
 		require.Equal(t, float64(1), counterVal(t, evictions))
 	})
@@ -116,14 +116,14 @@ func TestTTLRelabelCache_ScanLeavesFreshEntries(t *testing.T) {
 func TestTTLRelabelCache_StaleRemove(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		c := newTTLRelabelCache(time.Hour, newTestEvictionsCounter())
-		defer c.Close()
+		defer c.close()
 
-		c.Add(1, labels.FromStrings("a", "b"))
-		c.Remove(1)
+		c.add(1, labels.FromStrings("a", "b"))
+		c.remove(1)
 
-		_, ok := c.Get(1)
+		_, ok := c.get(1)
 		require.False(t, ok, "Remove must drop the entry immediately, even with a long TTL")
-		require.Equal(t, 0, c.Len())
+		require.Equal(t, 0, c.len())
 	})
 }
 
@@ -133,21 +133,21 @@ func TestTTLRelabelCache_StaleRemove(t *testing.T) {
 func TestTTLRelabelCache_GetSlidesExpiry(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		c := newTTLRelabelCache(time.Minute, newTestEvictionsCounter())
-		defer c.Close()
+		defer c.close()
 
-		c.Add(1, labels.FromStrings("a", "b"))
+		c.add(1, labels.FromStrings("a", "b"))
 
 		// Halfway through the TTL: still a hit, and the Get slides
 		// expiry from t=60s out to t=90s.
 		time.Sleep(30 * time.Second)
-		_, ok := c.Get(1)
+		_, ok := c.get(1)
 		require.True(t, ok)
 
 		// Now at t=80s — past the original t=60s expiry. Without
 		// sliding, this would be a miss. With sliding, the entry's
 		// expiry is t=90s, so it's still valid.
 		time.Sleep(50 * time.Second)
-		_, ok = c.Get(1)
+		_, ok = c.get(1)
 		require.True(t, ok, "Get must slide the TTL window forward")
 	})
 }
@@ -159,20 +159,20 @@ func TestTTLRelabelCache_ScanLeavesActiveEntries(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		evictions := newTestEvictionsCounter()
 		c := newTTLRelabelCache(time.Minute, evictions)
-		defer c.Close()
+		defer c.close()
 
-		c.Add(1, labels.FromStrings("a", "b"))
+		c.add(1, labels.FromStrings("a", "b"))
 
 		// Three full TTL cycles: each cycle, Get keeps the entry hot,
 		// then scan runs after the original-expiry would have hit.
 		for cycle := 0; cycle < 3; cycle++ {
 			time.Sleep(45 * time.Second)
-			_, ok := c.Get(1)
+			_, ok := c.get(1)
 			require.True(t, ok)
 			c.scan(time.Now())
 		}
 
-		require.Equal(t, 1, c.Len())
+		require.Equal(t, 1, c.len())
 		require.Equal(t, float64(0), counterVal(t, evictions))
 	})
 }

--- a/internal/component/prometheus/relabel/cache_test.go
+++ b/internal/component/prometheus/relabel/cache_test.go
@@ -1,0 +1,218 @@
+package relabel
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+
+	prometheus_client "github.com/prometheus/client_golang/prometheus"
+)
+
+func newTestTTLCounters() ttlCounters {
+	return ttlCounters{
+		evictions: prometheus_client.NewCounter(prometheus_client.CounterOpts{Name: "test_evictions"}),
+		rebuilds:  prometheus_client.NewCounter(prometheus_client.CounterOpts{Name: "test_rebuilds"}),
+	}
+}
+
+func counterVal(t *testing.T, c prometheus_client.Counter) float64 {
+	t.Helper()
+	var m dto.Metric
+	require.NoError(t, c.Write(&m))
+	return *m.Counter.Value
+}
+
+func TestLRURelabelCache_FillsToCap(t *testing.T) {
+	c := newRelabelCache(Arguments{CacheSize: 100_000}, newTestTTLCounters())
+	defer c.Close()
+	for i := uint64(0); i < 600_000; i++ {
+		c.Add(i, labels.FromStrings("k", "v"))
+	}
+	require.Equal(t, 100_000, c.Len())
+}
+
+func TestLRURelabelCache_BasicOps(t *testing.T) {
+	c := newRelabelCache(Arguments{CacheSize: 100}, newTestTTLCounters())
+	defer c.Close()
+	require.IsType(t, &lruRelabelCache{}, c)
+
+	lbls := labels.FromStrings("a", "b")
+	_, ok := c.Get(1)
+	require.False(t, ok)
+
+	c.Add(1, lbls)
+	got, ok := c.Get(1)
+	require.True(t, ok)
+	require.Equal(t, lbls, got)
+	require.Equal(t, 1, c.Len())
+
+	c.Remove(1)
+	_, ok = c.Get(1)
+	require.False(t, ok)
+}
+
+func TestTTLRelabelCache_LazyExpiry(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		c := newRelabelCache(Arguments{CacheTTL: 30 * time.Second}, newTestTTLCounters()).(*ttlRelabelCache)
+		defer c.Close()
+
+		lbls := labels.FromStrings("a", "b")
+		c.Add(1, lbls)
+
+		// Within TTL: hit.
+		got, ok := c.Get(1)
+		require.True(t, ok)
+		require.Equal(t, lbls, got)
+
+		// Advance past TTL: lazy expiry rejects the entry on Get even
+		// though Scan hasn't run yet.
+		time.Sleep(31 * time.Second)
+		_, ok = c.Get(1)
+		require.False(t, ok)
+		// Entry is still in the map until Scan prunes it.
+		require.Equal(t, 1, c.Len())
+	})
+}
+
+func TestTTLRelabelCache_ScanEvicts(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		counters := newTestTTLCounters()
+		c := newTTLRelabelCache(time.Minute, counters)
+		defer c.Close()
+
+		c.Add(1, labels.FromStrings("a", "b"))
+		c.Add(2, labels.FromStrings("c", "d"))
+		require.Equal(t, 2, c.Len())
+
+		time.Sleep(2 * time.Minute)
+		c.scan(time.Now())
+
+		require.Equal(t, 0, c.Len())
+		require.Equal(t, float64(2), counterVal(t, counters.evictions))
+	})
+}
+
+func TestTTLRelabelCache_ScanLeavesFreshEntries(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		counters := newTestTTLCounters()
+		c := newTTLRelabelCache(time.Minute, counters)
+		defer c.Close()
+
+		c.Add(1, labels.FromStrings("old", ""))
+		time.Sleep(90 * time.Second)
+		c.Add(2, labels.FromStrings("fresh", ""))
+		c.scan(time.Now())
+
+		require.Equal(t, 1, c.Len())
+		_, ok := c.Get(2)
+		require.True(t, ok)
+		require.Equal(t, float64(1), counterVal(t, counters.evictions))
+	})
+}
+
+func TestTTLRelabelCache_StaleRemove(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		c := newTTLRelabelCache(time.Hour, newTestTTLCounters())
+		defer c.Close()
+
+		c.Add(1, labels.FromStrings("a", "b"))
+		c.Remove(1)
+
+		_, ok := c.Get(1)
+		require.False(t, ok, "Remove must drop the entry immediately, even with a long TTL")
+		require.Equal(t, 0, c.Len())
+	})
+}
+
+func TestTTLRelabelCache_RebuildAfterShrink(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// Tighten the rebuild knobs so the test can assert on them
+		// without inserting tens of thousands of entries.
+		t.Cleanup(func() {
+			rebuildFloor = 4096
+			rebuildSpacing = 30 * time.Minute
+		})
+		rebuildFloor = 16
+		rebuildSpacing = time.Minute
+
+		counters := newTestTTLCounters()
+		c := newTTLRelabelCache(time.Minute, counters)
+
+		// Spike the cache well above the rebuild floor.
+		for i := uint64(0); i < 100; i++ {
+			c.Add(i, labels.FromStrings("k", "v"))
+		}
+		require.Equal(t, 100, c.Len())
+
+		// Let the cache age out and scan; the scan should both prune
+		// the entries and rebuild the underlying map because the live
+		// count fell below half the watermark.
+		time.Sleep(2 * time.Minute)
+		c.scan(time.Now())
+
+		require.Equal(t, 0, c.Len())
+		require.Equal(t, float64(1), counterVal(t, counters.rebuilds))
+	})
+}
+
+func TestTTLRelabelCache_RebuildRateLimit(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		t.Cleanup(func() {
+			rebuildFloor = 4096
+			rebuildSpacing = 30 * time.Minute
+		})
+		rebuildFloor = 16
+		rebuildSpacing = 30 * time.Minute
+
+		counters := newTestTTLCounters()
+		c := newTTLRelabelCache(time.Minute, counters)
+
+		for i := uint64(0); i < 100; i++ {
+			c.Add(i, labels.FromStrings("k", "v"))
+		}
+
+		// First scan after expiry — rebuilds.
+		time.Sleep(2 * time.Minute)
+		c.scan(time.Now())
+		require.Equal(t, float64(1), counterVal(t, counters.rebuilds))
+
+		// Spike again, age out again, but call Scan before
+		// rebuildSpacing has elapsed: the cache should NOT rebuild.
+		for i := uint64(100); i < 200; i++ {
+			c.Add(i, labels.FromStrings("k", "v"))
+		}
+		time.Sleep(2 * time.Minute)
+		c.scan(time.Now())
+		require.Equal(t, float64(1), counterVal(t, counters.rebuilds), "rebuild rate-limited")
+
+		// After spacing elapses, the next eligible scan rebuilds again.
+		for i := uint64(200); i < 300; i++ {
+			c.Add(i, labels.FromStrings("k", "v"))
+		}
+		time.Sleep(31 * time.Minute)
+		c.scan(time.Now())
+		require.Equal(t, float64(2), counterVal(t, counters.rebuilds))
+	})
+}
+
+func TestTTLRelabelCache_RebuildSkippedBelowFloor(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		counters := newTestTTLCounters()
+		c := newTTLRelabelCache(time.Minute, counters)
+		defer c.Close()
+
+		// Default floor is 4096 — far above the 100 entries we'll add.
+		for i := uint64(0); i < 100; i++ {
+			c.Add(i, labels.FromStrings("k", "v"))
+		}
+		time.Sleep(2 * time.Minute)
+		c.scan(time.Now())
+
+		require.Equal(t, 0, c.Len())
+		require.Equal(t, float64(0), counterVal(t, counters.rebuilds), "below-floor caches skip rebuild")
+	})
+}

--- a/internal/component/prometheus/relabel/cache_test.go
+++ b/internal/component/prometheus/relabel/cache_test.go
@@ -152,6 +152,124 @@ func TestTTLRelabelCache_GetSlidesExpiry(t *testing.T) {
 	})
 }
 
+func TestShouldShrink(t *testing.T) {
+	cases := []struct {
+		name string
+		peak int
+		live int
+		want bool
+	}{
+		// Below 1M peak: never shrink — absolute savings too small.
+		{"under tier: huge drop on small peak", 100_000, 1_000, false},
+		{"under tier: at boundary", 999_999, 0, false},
+
+		// 1M-10M tier: 2x drop required.
+		{"1M tier: 50% drop triggers", 1_000_000, 500_000, true},
+		{"1M tier: just under 50% drop", 1_000_000, 500_001, false},
+		{"1M tier: 40% drop does not trigger", 1_000_000, 600_000, false},
+
+		// >=10M tier: 1.5x drop (33%) triggers.
+		{"10M tier: 33% drop triggers", 10_000_000, 6_666_666, true},
+		{"10M tier: 30% drop does not trigger", 10_000_000, 7_000_000, false},
+		{"10M tier: 50% drop triggers", 10_000_000, 5_000_000, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, shouldShrink(tc.peak, tc.live))
+		})
+	}
+}
+
+// TestTTLRelabelCache_ScanRebuildsAfterDrain verifies that the scanner
+// rebuilds the underlying map after a large transient working set
+// drains. We can't observe map bucket memory directly, but we can
+// observe peak resetting to len(entries), which is the policy's
+// internal trigger.
+func TestTTLRelabelCache_ScanRebuildsAfterDrain(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		c := newTTLRelabelCache(time.Minute, newTestEvictionsCounter())
+		defer c.close()
+
+		// Fill past the 1M-tier boundary, then let everything expire
+		// except a small live set. Peak should reset to the post-shrink
+		// size.
+		const peak = 1_000_000
+		for i := uint64(0); i < peak; i++ {
+			c.add(i, labels.FromStrings("k", "v"))
+		}
+		require.Equal(t, peak, c.peak)
+
+		// Keep a few entries fresh; let the rest expire.
+		const keep = 100
+		time.Sleep(30 * time.Second)
+		for i := uint64(0); i < keep; i++ {
+			_, ok := c.get(i)
+			require.True(t, ok)
+		}
+		time.Sleep(45 * time.Second) // total 75s — past TTL for the rest
+
+		c.scan(time.Now())
+
+		require.Equal(t, keep, c.len())
+		require.Equal(t, keep, c.peak, "peak resets to live size after rebuild")
+	})
+}
+
+// TestTTLRelabelCache_ScanRebuildsAfterRemoveDrain verifies the
+// shrink path fires for drains caused by Remove (stale markers) and
+// not just by TTL expiry. The phase-1 RLock peeks at the shrink
+// condition specifically for this case, since with no expirations to
+// prune scan would otherwise early-return before reaching the rebuild.
+func TestTTLRelabelCache_ScanRebuildsAfterRemoveDrain(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		c := newTTLRelabelCache(time.Hour, newTestEvictionsCounter())
+		defer c.close()
+
+		const peak = 1_000_000
+		for i := uint64(0); i < peak; i++ {
+			c.add(i, labels.FromStrings("k", "v"))
+		}
+		require.Equal(t, peak, c.peak)
+
+		// Drain via Remove — no expirations. With a 1h TTL nothing
+		// would expire on its own; only the shrink-condition peek
+		// drives the rebuild here.
+		const keep = 100
+		for i := uint64(keep); i < peak; i++ {
+			c.remove(i)
+		}
+		require.Equal(t, keep, c.len())
+		require.Equal(t, peak, c.peak, "peak preserved until scan rebuilds")
+
+		c.scan(time.Now())
+
+		require.Equal(t, keep, c.len())
+		require.Equal(t, keep, c.peak, "peak resets after rebuild even without expirations")
+	})
+}
+
+// TestTTLRelabelCache_ScanSkipsShrinkBelowTier confirms small caches
+// don't pay the rebuild cost — peak stays at its original high-water
+// mark even after a deep drain.
+func TestTTLRelabelCache_ScanSkipsShrinkBelowTier(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		c := newTTLRelabelCache(time.Minute, newTestEvictionsCounter())
+		defer c.close()
+
+		const peak = 10_000 // below the 1M tier
+		for i := uint64(0); i < peak; i++ {
+			c.add(i, labels.FromStrings("k", "v"))
+		}
+		require.Equal(t, peak, c.peak)
+
+		time.Sleep(2 * time.Minute) // expire all
+		c.scan(time.Now())
+
+		require.Equal(t, 0, c.len())
+		require.Equal(t, peak, c.peak, "peak preserved — below shrink tier")
+	})
+}
+
 // TestTTLRelabelCache_ScanLeavesActiveEntries confirms the scanner
 // does not evict an entry whose Get keeps refreshing it, even when
 // scans fire after each TTL window's nominal expiry.

--- a/internal/component/prometheus/relabel/relabel.go
+++ b/internal/component/prometheus/relabel/relabel.go
@@ -65,10 +65,7 @@ func (arg *Arguments) SetToDefault() {
 	}
 }
 
-// minCacheTTL rejects values short enough that the cache can't
-// realistically size itself to the working set: with the scan interval
-// scaled to a fraction of the TTL, very short TTLs make scan frequency
-// approach the cost of just doing the relabel work uncached.
+// minCacheTTL keeps the scan cadence (TTL/4) from dominating real work.
 const minCacheTTL = 1 * time.Minute
 
 // Validate implements syntax.Validator.

--- a/internal/component/prometheus/relabel/relabel.go
+++ b/internal/component/prometheus/relabel/relabel.go
@@ -65,9 +65,11 @@ func (arg *Arguments) SetToDefault() {
 	}
 }
 
-// minCacheTTL rejects values short enough to be effectively useless
-// (almost certainly a typo, e.g. "5" interpreted as nanoseconds).
-const minCacheTTL = 5 * time.Second
+// minCacheTTL rejects values short enough that the cache can't
+// realistically size itself to the working set: with the scan interval
+// scaled to a fraction of the TTL, very short TTLs make scan frequency
+// approach the cost of just doing the relabel work uncached.
+const minCacheTTL = 1 * time.Minute
 
 // Validate implements syntax.Validator.
 func (arg *Arguments) Validate() error {
@@ -97,18 +99,18 @@ type Exports struct {
 
 // Component implements the prometheus.relabel component.
 type Component struct {
-	mut              sync.RWMutex
-	opts             component.Options
-	mrc              []*relabel.Config
-	receiver         *prometheus.Interceptor
-	metricsProcessed prometheus_client.Counter
-	metricsOutgoing  prometheus_client.Counter
-	cacheHits        prometheus_client.Counter
-	cacheMisses      prometheus_client.Counter
-	cacheDeletes     prometheus_client.Counter
-	cacheTTLCounters ttlCounters
-	fanout           *prometheus.Fanout
-	exited           atomic.Bool
+	mut               sync.RWMutex
+	opts              component.Options
+	mrc               []*relabel.Config
+	receiver          *prometheus.Interceptor
+	metricsProcessed  prometheus_client.Counter
+	metricsOutgoing   prometheus_client.Counter
+	cacheHits         prometheus_client.Counter
+	cacheMisses       prometheus_client.Counter
+	cacheDeletes      prometheus_client.Counter
+	cacheTTLEvictions prometheus_client.Counter
+	fanout            *prometheus.Fanout
+	exited            atomic.Bool
 
 	debugDataPublisher livedebugging.DebugDataPublisher
 
@@ -156,17 +158,14 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		Name: "alloy_prometheus_relabel_cache_deletes",
 		Help: "Total number of cache deletes",
 	})
-	c.cacheTTLCounters = ttlCounters{
-		evictions: prometheus_client.NewCounter(prometheus_client.CounterOpts{
-			Name: "alloy_prometheus_relabel_cache_ttl_evictions_total",
-			Help: "Number of relabel cache entries removed by the periodic TTL scan. Always 0 when cache_ttl is unset.",
-		}),
-		rebuilds: prometheus_client.NewCounter(prometheus_client.CounterOpts{
-			Name: "alloy_prometheus_relabel_cache_ttl_rebuilds_total",
-			Help: "Number of times the TTL cache's underlying map has been rebuilt to release bucket memory after a shrink. Always 0 when cache_ttl is unset.",
-		}),
+	c.cacheTTLEvictions = prometheus_client.NewCounter(prometheus_client.CounterOpts{
+		Name: "alloy_prometheus_relabel_cache_ttl_evictions",
+		Help: "Number of relabel cache entries removed by the periodic TTL scan. Always 0 when cache_ttl is unset.",
+	})
+	c.cache, err = newRelabelCache(args, c.cacheTTLEvictions)
+	if err != nil {
+		return nil, err
 	}
-	c.cache = newRelabelCache(args, c.cacheTTLCounters)
 
 	cacheSizeGauge := prometheus_client.NewGaugeFunc(prometheus_client.GaugeOpts{
 		Name: "alloy_prometheus_relabel_cache_size",
@@ -180,11 +179,12 @@ func New(o component.Options, args Arguments) (*Component, error) {
 
 	collectors := []prometheus_client.Collector{
 		c.metricsProcessed, c.metricsOutgoing, c.cacheMisses, c.cacheHits, c.cacheDeletes,
-		c.cacheTTLCounters.evictions, c.cacheTTLCounters.rebuilds, cacheSizeGauge,
+		c.cacheTTLEvictions, cacheSizeGauge,
 	}
 	for _, metric := range collectors {
 		err = o.Registerer.Register(metric)
 		if err != nil {
+			c.cache.Close()
 			return nil, err
 		}
 	}
@@ -254,6 +254,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 
 	// Call to Update() to set the relabelling rules once at the start.
 	if err = c.Update(args); err != nil {
+		c.cache.Close()
 		return nil, err
 	}
 
@@ -280,10 +281,14 @@ func (c *Component) Update(args component.Arguments) error {
 	defer c.mut.Unlock()
 
 	newArgs := args.(Arguments)
+	cache, err := newRelabelCache(newArgs, c.cacheTTLEvictions)
+	if err != nil {
+		return err
+	}
 	if c.cache != nil {
 		c.cache.Close()
 	}
-	c.cache = newRelabelCache(newArgs, c.cacheTTLCounters)
+	c.cache = cache
 	c.mrc = alloy_relabel.ComponentToPromRelabelConfigs(newArgs.MetricRelabelConfigs)
 	c.fanout.UpdateChildren(newArgs.ForwardTo)
 

--- a/internal/component/prometheus/relabel/relabel.go
+++ b/internal/component/prometheus/relabel/relabel.go
@@ -171,7 +171,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		c.mut.RLock()
 		cache := c.cache
 		c.mut.RUnlock()
-		return float64(cache.Len())
+		return float64(cache.len())
 	})
 
 	collectors := []prometheus_client.Collector{
@@ -181,7 +181,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 	for _, metric := range collectors {
 		err = o.Registerer.Register(metric)
 		if err != nil {
-			c.cache.Close()
+			c.cache.close()
 			return nil, err
 		}
 	}
@@ -251,7 +251,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 
 	// Call to Update() to set the relabelling rules once at the start.
 	if err = c.Update(args); err != nil {
-		c.cache.Close()
+		c.cache.close()
 		return nil, err
 	}
 
@@ -264,7 +264,7 @@ func (c *Component) Run(ctx context.Context) error {
 	defer c.fanout.Clear()
 	defer func() {
 		c.mut.RLock()
-		c.cache.Close()
+		c.cache.close()
 		c.mut.RUnlock()
 	}()
 
@@ -283,7 +283,7 @@ func (c *Component) Update(args component.Arguments) error {
 		return err
 	}
 	if c.cache != nil {
-		c.cache.Close()
+		c.cache.close()
 	}
 	c.cache = cache
 	c.mrc = alloy_relabel.ComponentToPromRelabelConfigs(newArgs.MetricRelabelConfigs)
@@ -343,23 +343,23 @@ func (c *Component) relabel(val float64, lbls labels.Labels) labels.Labels {
 
 func (c *Component) getFromCache(lbls labels.Labels) (labels.Labels, bool) {
 	hash := lbls.Hash()
-	return c.cache.Get(hash)
+	return c.cache.get(hash)
 }
 
 func (c *Component) deleteFromCache(lbls labels.Labels) {
 	c.cacheDeletes.Inc()
 
 	hash := lbls.Hash()
-	c.cache.Remove(hash)
+	c.cache.remove(hash)
 }
 
 func (c *Component) addToCache(lbls labels.Labels, relabeled labels.Labels, keep bool) {
 	hash := lbls.Hash()
 	if !keep {
-		c.cache.Add(hash, labels.EmptyLabels())
+		c.cache.add(hash, labels.EmptyLabels())
 		return
 	}
-	c.cache.Add(hash, relabeled)
+	c.cache.add(hash, relabeled)
 }
 
 func (c *Component) LiveDebugging() {}

--- a/internal/component/prometheus/relabel/relabel.go
+++ b/internal/component/prometheus/relabel/relabel.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
-	lru "github.com/hashicorp/golang-lru/v2"
 	prometheus_client "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
@@ -48,8 +48,14 @@ type Arguments struct {
 	// The relabelling rules to apply to each metric before it's forwarded.
 	MetricRelabelConfigs []*alloy_relabel.Config `alloy:"rule,block,optional"`
 
-	// Cache size to use for LRU cache.
+	// CacheSize is the bounded LRU cache size. Mutually exclusive with
+	// CacheTTL: when CacheTTL is set, CacheSize must be 0.
 	CacheSize int `alloy:"max_cache_size,attr,optional"`
+
+	// CacheTTL opts in to a time-bounded cache that sizes itself to the
+	// working set of series flowing through the component. When set,
+	// CacheSize must be 0.
+	CacheTTL time.Duration `alloy:"cache_ttl,attr,optional"`
 }
 
 // SetToDefault implements syntax.Defaulter.
@@ -59,10 +65,26 @@ func (arg *Arguments) SetToDefault() {
 	}
 }
 
+// minCacheTTL rejects values short enough to be effectively useless
+// (almost certainly a typo, e.g. "5" interpreted as nanoseconds).
+const minCacheTTL = 5 * time.Second
+
 // Validate implements syntax.Validator.
 func (arg *Arguments) Validate() error {
-	if arg.CacheSize <= 0 {
-		return fmt.Errorf("max_cache_size must be greater than 0 and is %d", arg.CacheSize)
+	if arg.CacheSize < 0 {
+		return fmt.Errorf("max_cache_size must be >= 0; got %d", arg.CacheSize)
+	}
+	if arg.CacheTTL < 0 {
+		return fmt.Errorf("cache_ttl must be >= 0; got %s", arg.CacheTTL)
+	}
+	if arg.CacheSize > 0 && arg.CacheTTL > 0 {
+		return fmt.Errorf("max_cache_size and cache_ttl are mutually exclusive: set max_cache_size = 0 to use cache_ttl, or unset cache_ttl to keep the bounded LRU cache")
+	}
+	if arg.CacheSize == 0 && arg.CacheTTL == 0 {
+		return fmt.Errorf("one of max_cache_size or cache_ttl must be set")
+	}
+	if arg.CacheTTL > 0 && arg.CacheTTL < minCacheTTL {
+		return fmt.Errorf("cache_ttl must be at least %s when set; got %s", minCacheTTL, arg.CacheTTL)
 	}
 	return nil
 }
@@ -83,14 +105,14 @@ type Component struct {
 	metricsOutgoing  prometheus_client.Counter
 	cacheHits        prometheus_client.Counter
 	cacheMisses      prometheus_client.Counter
-	cacheSize        prometheus_client.Gauge
 	cacheDeletes     prometheus_client.Counter
+	cacheTTLCounters ttlCounters
 	fanout           *prometheus.Fanout
 	exited           atomic.Bool
 
 	debugDataPublisher livedebugging.DebugDataPublisher
 
-	cache *lru.Cache[uint64, labels.Labels]
+	cache relabelCache
 }
 
 var (
@@ -100,11 +122,6 @@ var (
 
 // New creates a new prometheus.relabel component.
 func New(o component.Options, args Arguments) (*Component, error) {
-	cache, err := lru.New[uint64, labels.Labels](args.CacheSize)
-	if err != nil {
-		return nil, err
-	}
-
 	debugDataPublisher, err := o.GetServiceData(livedebugging.ServiceName)
 	if err != nil {
 		return nil, err
@@ -117,7 +134,6 @@ func New(o component.Options, args Arguments) (*Component, error) {
 	ls := data.(labelstore.LabelStore)
 	c := &Component{
 		opts:               o,
-		cache:              cache,
 		debugDataPublisher: debugDataPublisher.(livedebugging.DebugDataPublisher),
 	}
 	c.metricsProcessed = prometheus_client.NewCounter(prometheus_client.CounterOpts{
@@ -136,16 +152,37 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		Name: "alloy_prometheus_relabel_cache_hits",
 		Help: "Total number of cache hits",
 	})
-	c.cacheSize = prometheus_client.NewGauge(prometheus_client.GaugeOpts{
-		Name: "alloy_prometheus_relabel_cache_size",
-		Help: "Total size of relabel cache",
-	})
 	c.cacheDeletes = prometheus_client.NewCounter(prometheus_client.CounterOpts{
 		Name: "alloy_prometheus_relabel_cache_deletes",
 		Help: "Total number of cache deletes",
 	})
+	c.cacheTTLCounters = ttlCounters{
+		evictions: prometheus_client.NewCounter(prometheus_client.CounterOpts{
+			Name: "alloy_prometheus_relabel_cache_ttl_evictions_total",
+			Help: "Number of relabel cache entries removed by the periodic TTL scan. Always 0 when cache_ttl is unset.",
+		}),
+		rebuilds: prometheus_client.NewCounter(prometheus_client.CounterOpts{
+			Name: "alloy_prometheus_relabel_cache_ttl_rebuilds_total",
+			Help: "Number of times the TTL cache's underlying map has been rebuilt to release bucket memory after a shrink. Always 0 when cache_ttl is unset.",
+		}),
+	}
+	c.cache = newRelabelCache(args, c.cacheTTLCounters)
 
-	for _, metric := range []prometheus_client.Collector{c.metricsProcessed, c.metricsOutgoing, c.cacheMisses, c.cacheHits, c.cacheSize, c.cacheDeletes} {
+	cacheSizeGauge := prometheus_client.NewGaugeFunc(prometheus_client.GaugeOpts{
+		Name: "alloy_prometheus_relabel_cache_size",
+		Help: "Total size of relabel cache.",
+	}, func() float64 {
+		c.mut.RLock()
+		cache := c.cache
+		c.mut.RUnlock()
+		return float64(cache.Len())
+	})
+
+	collectors := []prometheus_client.Collector{
+		c.metricsProcessed, c.metricsOutgoing, c.cacheMisses, c.cacheHits, c.cacheDeletes,
+		c.cacheTTLCounters.evictions, c.cacheTTLCounters.rebuilds, cacheSizeGauge,
+	}
+	for _, metric := range collectors {
 		err = o.Registerer.Register(metric)
 		if err != nil {
 			return nil, err
@@ -227,6 +264,11 @@ func New(o component.Options, args Arguments) (*Component, error) {
 func (c *Component) Run(ctx context.Context) error {
 	defer c.exited.Store(true)
 	defer c.fanout.Clear()
+	defer func() {
+		c.mut.RLock()
+		c.cache.Close()
+		c.mut.RUnlock()
+	}()
 
 	<-ctx.Done()
 	return nil
@@ -238,7 +280,10 @@ func (c *Component) Update(args component.Arguments) error {
 	defer c.mut.Unlock()
 
 	newArgs := args.(Arguments)
-	c.clearCache(newArgs.CacheSize)
+	if c.cache != nil {
+		c.cache.Close()
+	}
+	c.cache = newRelabelCache(newArgs, c.cacheTTLCounters)
 	c.mrc = alloy_relabel.ComponentToPromRelabelConfigs(newArgs.MetricRelabelConfigs)
 	c.fanout.UpdateChildren(newArgs.ForwardTo)
 
@@ -276,9 +321,6 @@ func (c *Component) relabel(val float64, lbls labels.Labels) labels.Labels {
 	if value.IsStaleNaN(val) {
 		c.deleteFromCache(lbls)
 	}
-	// Set the cache size to the cache.len
-	// TODO(@mattdurham): Instead of setting this each time could collect on demand for better performance.
-	c.cacheSize.Set(float64(c.cache.Len()))
 
 	count := uint64(1)
 	if relabelled.Len() == 0 {
@@ -307,11 +349,6 @@ func (c *Component) deleteFromCache(lbls labels.Labels) {
 
 	hash := lbls.Hash()
 	c.cache.Remove(hash)
-}
-
-func (c *Component) clearCache(cacheSize int) {
-	cache, _ := lru.New[uint64, labels.Labels](cacheSize)
-	c.cache = cache
 }
 
 func (c *Component) addToCache(lbls labels.Labels, relabeled labels.Labels, keep bool) {

--- a/internal/component/prometheus/relabel/relabel_test.go
+++ b/internal/component/prometheus/relabel/relabel_test.go
@@ -28,12 +28,12 @@ func TestUpdateReset(t *testing.T) {
 	relabeller := generateRelabel(t)
 	lbls := labels.FromStrings("__address__", "localhost")
 	relabeller.relabel(0, lbls)
-	require.True(t, relabeller.cache.Len() == 1)
+	require.True(t, relabeller.cache.len() == 1)
 	require.NoError(t, relabeller.Update(Arguments{
 		CacheSize:            100000,
 		MetricRelabelConfigs: []*alloy_relabel.Config{},
 	}))
-	require.True(t, relabeller.cache.Len() == 0)
+	require.True(t, relabeller.cache.len() == 0)
 }
 
 func TestValidator(t *testing.T) {
@@ -160,7 +160,7 @@ func TestCacheSizeMetric(t *testing.T) {
 			require.NoError(t, err)
 			t.Cleanup(func() {
 				relabeller.mut.RLock()
-				relabeller.cache.Close()
+				relabeller.cache.close()
 				relabeller.mut.RUnlock()
 			})
 
@@ -347,7 +347,7 @@ func generateRelabelWithArgs(t *testing.T, args Arguments) *Component {
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		relabeller.mut.RLock()
-		relabeller.cache.Close()
+		relabeller.cache.close()
 		relabeller.mut.RUnlock()
 	})
 	return relabeller

--- a/internal/component/prometheus/relabel/relabel_test.go
+++ b/internal/component/prometheus/relabel/relabel_test.go
@@ -30,10 +30,10 @@ func TestUpdateReset(t *testing.T) {
 	lbls := labels.FromStrings("__address__", "localhost")
 	relabeller.relabel(0, lbls)
 	require.True(t, relabeller.cache.Len() == 1)
-	_ = relabeller.Update(Arguments{
+	require.NoError(t, relabeller.Update(Arguments{
 		CacheSize:            100000,
 		MetricRelabelConfigs: []*alloy_relabel.Config{},
-	})
+	}))
 	require.True(t, relabeller.cache.Len() == 0)
 }
 
@@ -44,12 +44,12 @@ func TestValidator(t *testing.T) {
 		wantErr string
 	}{
 		{name: "default LRU", args: Arguments{CacheSize: 1}},
-		{name: "TTL only", args: Arguments{CacheSize: 0, CacheTTL: time.Minute}},
+		{name: "TTL only", args: Arguments{CacheSize: 0, CacheTTL: 5 * time.Minute}},
 		{name: "negative size", args: Arguments{CacheSize: -1}, wantErr: "max_cache_size must be >= 0"},
 		{name: "negative ttl", args: Arguments{CacheSize: 1, CacheTTL: -time.Second}, wantErr: "cache_ttl must be >= 0"},
 		{name: "both set", args: Arguments{CacheSize: 100, CacheTTL: time.Minute}, wantErr: "mutually exclusive"},
 		{name: "neither set", args: Arguments{}, wantErr: "one of max_cache_size or cache_ttl must be set"},
-		{name: "ttl too short", args: Arguments{CacheSize: 0, CacheTTL: time.Second}, wantErr: "at least"},
+		{name: "ttl too short", args: Arguments{CacheSize: 0, CacheTTL: 30 * time.Second}, wantErr: "at least"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -177,6 +177,11 @@ func TestCacheSizeMetric(t *testing.T) {
 				GetServiceData: getServiceData,
 			}, args)
 			require.NoError(t, err)
+			t.Cleanup(func() {
+				relabeller.mut.RLock()
+				relabeller.cache.Close()
+				relabeller.mut.RUnlock()
+			})
 
 			relabeller.relabel(0, labels.FromStrings("__address__", "localhost"))
 
@@ -359,6 +364,11 @@ func generateRelabelWithArgs(t *testing.T, args Arguments) *Component {
 	}, args)
 	require.NotNil(t, relabeller)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		relabeller.mut.RLock()
+		relabeller.cache.Close()
+		relabeller.mut.RUnlock()
+	})
 	return relabeller
 }
 

--- a/internal/component/prometheus/relabel/relabel_test.go
+++ b/internal/component/prometheus/relabel/relabel_test.go
@@ -38,13 +38,30 @@ func TestUpdateReset(t *testing.T) {
 }
 
 func TestValidator(t *testing.T) {
-	args := Arguments{CacheSize: 0}
-	err := args.Validate()
-	require.Error(t, err)
-
-	args.CacheSize = 1
-	err = args.Validate()
-	require.NoError(t, err)
+	cases := []struct {
+		name    string
+		args    Arguments
+		wantErr string
+	}{
+		{name: "default LRU", args: Arguments{CacheSize: 1}},
+		{name: "TTL only", args: Arguments{CacheSize: 0, CacheTTL: time.Minute}},
+		{name: "negative size", args: Arguments{CacheSize: -1}, wantErr: "max_cache_size must be >= 0"},
+		{name: "negative ttl", args: Arguments{CacheSize: 1, CacheTTL: -time.Second}, wantErr: "cache_ttl must be >= 0"},
+		{name: "both set", args: Arguments{CacheSize: 100, CacheTTL: time.Minute}, wantErr: "mutually exclusive"},
+		{name: "neither set", args: Arguments{}, wantErr: "one of max_cache_size or cache_ttl must be set"},
+		{name: "ttl too short", args: Arguments{CacheSize: 0, CacheTTL: time.Second}, wantErr: "at least"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.args.Validate()
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
 }
 
 func TestNil(t *testing.T) {
@@ -76,17 +93,41 @@ func TestNil(t *testing.T) {
 	relabeller.relabel(0, lbls)
 }
 
-func TestLRU(t *testing.T) {
-	relabeller := generateRelabel(t)
+// TestTTLFixesThrashing asserts that the workload that thrashes a
+// size-bounded LRU (#5225) hits 100% in TTL mode: with no size cap, the
+// cache fills on the first pass and serves every lookup on the second.
+func TestTTLFixesThrashing(t *testing.T) {
+	const cardinality = 5_000
+	relabeller := generateRelabelWithArgs(t, Arguments{CacheSize: 0, CacheTTL: 10 * time.Minute})
 
-	for i := 0; i < 600_000; i++ {
-		lbls := labels.FromStrings("__address__", "localhost", "inc", strconv.Itoa(i))
-		relabeller.relabel(0, lbls)
+	for pass := 0; pass < 2; pass++ {
+		for i := 0; i < cardinality; i++ {
+			lbls := labels.FromStrings("__address__", "localhost", "inc", strconv.Itoa(i))
+			relabeller.relabel(0, lbls)
+		}
 	}
-	require.Equal(t, 100_000, relabeller.cache.Len())
+
+	require.Equal(t, float64(cardinality), counterValue(t, relabeller.cacheHits), "second pass should be all hits")
+	require.Equal(t, cardinality, relabeller.cache.Len())
 }
 
-func TestLRUNaN(t *testing.T) {
+// TestUpdateSwitchesCacheMode confirms that toggling cache_ttl on or
+// off via Update() swaps the cache implementation.
+func TestUpdateSwitchesCacheMode(t *testing.T) {
+	relabeller := generateRelabelWithArgs(t, Arguments{CacheSize: 1_000})
+	require.IsType(t, &lruRelabelCache{}, relabeller.cache)
+
+	require.NoError(t, relabeller.Update(Arguments{CacheSize: 0, CacheTTL: time.Minute}))
+	require.IsType(t, &ttlRelabelCache{}, relabeller.cache)
+
+	require.NoError(t, relabeller.Update(Arguments{CacheSize: 1_000}))
+	require.IsType(t, &lruRelabelCache{}, relabeller.cache)
+}
+
+// TestStaleNaNRemovesFromCache asserts that the relabel hook drops a
+// cached entry when it sees a stale-NaN sample, regardless of cache
+// mode (the cache itself is exercised via the component's interface).
+func TestStaleNaNRemovesFromCache(t *testing.T) {
 	relabeller := generateRelabel(t)
 	lbls := labels.FromStrings("__address__", "localhost")
 	relabeled := relabeller.relabel(0, lbls)
@@ -100,6 +141,57 @@ func TestLRUNaN(t *testing.T) {
 
 	_, found = relabeller.getFromCache(lbls)
 	require.False(t, found)
+}
+
+// TestCacheSizeMetric verifies the cache_size gauge reports the live
+// cache length when scraped, in each mode.
+func TestCacheSizeMetric(t *testing.T) {
+	cases := []struct {
+		name string
+		args Arguments
+		want float64
+	}{
+		{name: "lru", args: Arguments{CacheSize: 100}, want: 1},
+		{name: "ttl", args: Arguments{CacheSize: 0, CacheTTL: time.Hour}, want: 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := prom.NewRegistry()
+			fanout := prometheus.NewInterceptor(nil)
+			args := tc.args
+			args.ForwardTo = []storage.Appendable{fanout}
+			args.MetricRelabelConfigs = []*alloy_relabel.Config{
+				{
+					SourceLabels: []string{"__address__"},
+					Regex:        alloy_relabel.Regexp(relabel.MustNewRegexp("(.+)")),
+					TargetLabel:  "new_label",
+					Replacement:  "new_value",
+					Action:       "replace",
+				},
+			}
+			relabeller, err := New(component.Options{
+				ID:             "1",
+				Logger:         util.TestAlloyLogger(t),
+				OnStateChange:  func(e component.Exports) {},
+				Registerer:     reg,
+				GetServiceData: getServiceData,
+			}, args)
+			require.NoError(t, err)
+
+			relabeller.relabel(0, labels.FromStrings("__address__", "localhost"))
+
+			mfs, err := reg.Gather()
+			require.NoError(t, err)
+			var got float64
+			for _, mf := range mfs {
+				if mf.GetName() == "alloy_prometheus_relabel_cache_size" {
+					got = mf.Metric[0].Gauge.GetValue()
+					break
+				}
+			}
+			require.Equal(t, tc.want, got)
+		})
+	}
 }
 
 func TestMetrics(t *testing.T) {
@@ -190,30 +282,91 @@ func BenchmarkCache(b *testing.B) {
 	app.Commit()
 }
 
+// BenchmarkCacheModes exercises the relabel hot path under each cache
+// mode at steady state (single label set; every call hits the cache
+// after the first). Use to compare per-call overhead between modes.
+func BenchmarkCacheModes(b *testing.B) {
+	cases := []struct {
+		name string
+		args Arguments
+	}{
+		{name: "lru", args: Arguments{CacheSize: 100_000}},
+		{name: "ttl", args: Arguments{CacheSize: 0, CacheTTL: 10 * time.Minute}},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			fanout := prometheus.NewInterceptor(nil, prometheus.WithAppendHook(func(ref storage.SeriesRef, _ labels.Labels, _ int64, _ float64, _ storage.Appender) (storage.SeriesRef, error) {
+				return ref, nil
+			}))
+			args := tc.args
+			args.ForwardTo = []storage.Appendable{fanout}
+			args.MetricRelabelConfigs = []*alloy_relabel.Config{
+				{
+					SourceLabels: []string{"__address__"},
+					Regex:        alloy_relabel.Regexp(relabel.MustNewRegexp("(.+)")),
+					TargetLabel:  "new_label",
+					Replacement:  "new_value",
+					Action:       "replace",
+				},
+			}
+			var entry storage.Appendable
+			_, err := New(component.Options{
+				ID:     "1",
+				Logger: util.TestAlloyLogger(b),
+				OnStateChange: func(e component.Exports) {
+					entry = e.(Exports).Receiver
+				},
+				Registerer:     prom.NewRegistry(),
+				GetServiceData: getServiceData,
+			}, args)
+			require.NoError(b, err)
+
+			lbls := labels.FromStrings("__address__", "localhost")
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				app := entry.Appender(b.Context())
+				for pb.Next() {
+					app.Append(0, lbls, time.Now().UnixMilli(), 0)
+				}
+				app.Commit()
+			})
+		})
+	}
+}
+
 func generateRelabel(t *testing.T) *Component {
+	return generateRelabelWithArgs(t, Arguments{CacheSize: 100_000})
+}
+
+func generateRelabelWithArgs(t *testing.T, args Arguments) *Component {
 	fanout := prometheus.NewInterceptor(nil)
+	args.ForwardTo = []storage.Appendable{fanout}
+	args.MetricRelabelConfigs = []*alloy_relabel.Config{
+		{
+			SourceLabels: []string{"__address__"},
+			Regex:        alloy_relabel.Regexp(relabel.MustNewRegexp("(.+)")),
+			TargetLabel:  "new_label",
+			Replacement:  "new_value",
+			Action:       "replace",
+		},
+	}
 	relabeller, err := New(component.Options{
 		ID:             "1",
 		Logger:         util.TestAlloyLogger(t),
 		OnStateChange:  func(e component.Exports) {},
 		Registerer:     prom.NewRegistry(),
 		GetServiceData: getServiceData,
-	}, Arguments{
-		ForwardTo: []storage.Appendable{fanout},
-		MetricRelabelConfigs: []*alloy_relabel.Config{
-			{
-				SourceLabels: []string{"__address__"},
-				Regex:        alloy_relabel.Regexp(relabel.MustNewRegexp("(.+)")),
-				TargetLabel:  "new_label",
-				Replacement:  "new_value",
-				Action:       "replace",
-			},
-		},
-		CacheSize: 100_000,
-	})
+	}, args)
 	require.NotNil(t, relabeller)
 	require.NoError(t, err)
 	return relabeller
+}
+
+func counterValue(t *testing.T, c prom.Counter) float64 {
+	t.Helper()
+	var m dto.Metric
+	require.NoError(t, c.Write(&m))
+	return *m.Counter.Value
 }
 
 func TestRuleGetter(t *testing.T) {

--- a/internal/component/prometheus/relabel/relabel_test.go
+++ b/internal/component/prometheus/relabel/relabel_test.go
@@ -3,7 +3,6 @@ package relabel
 import (
 	"fmt"
 	"math"
-	"strconv"
 	"testing"
 	"time"
 
@@ -91,24 +90,6 @@ func TestNil(t *testing.T) {
 
 	lbls := labels.FromStrings("__address__", "localhost")
 	relabeller.relabel(0, lbls)
-}
-
-// TestTTLFixesThrashing asserts that the workload that thrashes a
-// size-bounded LRU (#5225) hits 100% in TTL mode: with no size cap, the
-// cache fills on the first pass and serves every lookup on the second.
-func TestTTLFixesThrashing(t *testing.T) {
-	const cardinality = 5_000
-	relabeller := generateRelabelWithArgs(t, Arguments{CacheSize: 0, CacheTTL: 10 * time.Minute})
-
-	for pass := 0; pass < 2; pass++ {
-		for i := 0; i < cardinality; i++ {
-			lbls := labels.FromStrings("__address__", "localhost", "inc", strconv.Itoa(i))
-			relabeller.relabel(0, lbls)
-		}
-	}
-
-	require.Equal(t, float64(cardinality), counterValue(t, relabeller.cacheHits), "second pass should be all hits")
-	require.Equal(t, cardinality, relabeller.cache.Len())
 }
 
 // TestUpdateSwitchesCacheMode confirms that toggling cache_ttl on or
@@ -370,13 +351,6 @@ func generateRelabelWithArgs(t *testing.T, args Arguments) *Component {
 		relabeller.mut.RUnlock()
 	})
 	return relabeller
-}
-
-func counterValue(t *testing.T, c prom.Counter) float64 {
-	t.Helper()
-	var m dto.Metric
-	require.NoError(t, c.Write(&m))
-	return *m.Counter.Value
 }
 
 func TestRuleGetter(t *testing.T) {


### PR DESCRIPTION
### Brief description of Pull Request

Adds a TTL cache mode to `prometheus.relabel` so the cache can size itself to the working set of series, instead of an operator-guessed `max_cache_size`.

### Pull Request Details

The component currently uses a fixed-size LRU cache. When scraped cardinality exceeds `max_cache_size`, the LRU degenerates to ~0% hit rate — series arrive in a stable cyclic order, so the entry the LRU just evicted is often the next one requested.

| `max_cache_size` | `cache_ttl` | Mode |
|---|---|---|
| `> 0` | `0` | LRU (today's default, unchanged) |
| `0` | `> 0` | TTL — entries expire after `cache_ttl` of inactivity, no size cap |

`max_cache_size` and `cache_ttl` are mutually exclusive (validation error). `cache_ttl` minimum is `1m`. TTL semantics are sliding: each cache hit pushes the entry's expiry forward, so active series stay cached. Default behavior is unchanged; flipping the default to TTL mode is deferred to a follow-up once the opt-in has production exposure.

Steady-state hot-path benchmark (`BenchmarkCacheModes`, M3 Pro, single label set):

| Mode | ns/op | B/op | allocs/op |
|---|---|---|---|
| lru | 192 | 284 | 1 |
| ttl | 203 | 269 | 1 |

### Issue(s) fixed by this Pull Request

Fixes #5225

### PR Checklist

- [x] Documentation added
- [x] Tests updated
