### PR TITLE
docs: Note PR title capitalization rule in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,8 +6,9 @@
   taking the time to review the guide.
 
   **NOTE**
-  Your PR title must adhere to Conventional Commit style. For details on this,
-  check out the Contributors Guide linked above.
+  Your PR title must adhere to Conventional Commit style with a capitalized
+  description, e.g. `feat(scope): Add the thing` (not `add the thing`). For
+  details on this, check out the Contributors Guide linked above.
 -->
 
 ### Brief description of Pull Request


### PR DESCRIPTION
### Brief description of Pull Request

Surface the title capitalization rule (already in `docs/developer/contributing.md` and enforced by `release-lint-pr-title.yml`) directly in the template so it's visible without clicking through.
