### PR TITLE
feat(database_observability.postgres): Improve monitoring user privileges check

### DIFF
--- a/internal/component/database_observability/postgres/collector/health_check.go
+++ b/internal/component/database_observability/postgres/collector/health_check.go
@@ -23,6 +23,18 @@ const (
 	OP_HEALTH_STATUS     = "health_status"
 )
 
+// monitoringUserPrivilegesQuery probes whether the connected user can usefully
+// read data from pg_stat_statements.
+const monitoringUserPrivilegesQuery = `
+	SELECT
+		pg_has_role(current_user, 'pg_monitor',        'MEMBER') AS has_pg_monitor_role,
+		pg_has_role(current_user, 'pg_read_all_stats', 'MEMBER') AS has_pg_read_all_stats_role,
+		has_table_privilege(current_user, 'pg_stat_statements', 'SELECT') AS can_select_pg_stat_statements,
+		EXISTS (
+			SELECT 1 FROM pg_stat_statements
+			WHERE query = '<insufficient privilege>'
+		) AS sees_insufficient_privilege`
+
 type HealthCheckArguments struct {
 	DB               *sql.DB
 	CollectInterval  time.Duration
@@ -192,23 +204,45 @@ func checkTrackActivityQuerySize(ctx context.Context, db *sql.DB) healthCheckRes
 
 func checkMonitoringUserPrivileges(ctx context.Context, db *sql.DB) healthCheckResult {
 	r := healthCheckResult{name: "MonitoringUserPrivileges"}
-	const q = `SELECT * FROM pg_stat_statements LIMIT 1`
 
-	rows, err := db.QueryContext(ctx, q)
-	if err != nil {
-		r.err = fmt.Errorf("query pg_stat_statements: %w", err)
+	var hasMonitorRole, hasReadStatsRole, canSelectView, seesInsufficientPrivilege bool
+	if err := db.QueryRowContext(ctx, monitoringUserPrivilegesQuery).Scan(
+		&hasMonitorRole, &hasReadStatsRole, &canSelectView, &seesInsufficientPrivilege,
+	); err != nil {
+		r.err = fmt.Errorf("query monitoring user privileges: %w", err)
 		return r
 	}
-	defer rows.Close()
 
-	if rows.Next() {
-		r.result = true
-	}
-
-	if err := rows.Err(); err != nil {
-		r.err = fmt.Errorf("iterate pg_stat_statements: %w", err)
-	}
-
+	// The 'result' doesn't take role membership into account, but we report the
+	// role checks in 'value' for diagnostics:
+	// checks in 'value' for diagnostics:
+	//
+	// - canSelectView (i.e. can read the view) and !seesInsufficientPrivilege (i.e.
+	//   no '<insufficient privilege>' rows visible) gate result, because
+	//   together they prove the user can actually read real data
+	//   regardless of how that access was granted.
+	//
+	// - hasMonitorRole / hasReadStatsRole are reported in value for diagnostics only.
+	//   pg_has_role(_, _, 'MEMBER') resolves transitive membership, so
+	//   granting pg_monitor implies has_pg_read_all_stats_role=true (pg_monitor is
+	//   its parent role); the reverse does not hold. Role membership is also
+	//   not the only path: a direct GRANT SELECT on pg_stat_statements lets a
+	//   user read the view without either role - they show can_select_view=true but
+	//   will see '<insufficient privilege>' for queries from other users,
+	//   which sees_insufficient_privilege catches. Treating the role columns as gating
+	//   would produce false negatives on perfectly valid setups.
+	//
+	// Example: a user with only `GRANT SELECT ON pg_stat_statements TO ...`
+	// reports can_select_view=true, has_pg_monitor_role=false, has_pg_read_all_stats_role=false,
+	// sees_insufficient_privilege=true once any other user has executed a
+	// statement; result is correctly false because the collector won't get
+	// useful data, even though the role checks alone wouldn't have told us
+	// whether SELECT was reachable.
+	r.result = canSelectView && !seesInsufficientPrivilege
+	r.value = fmt.Sprintf(
+		"can_select_view=%v,has_pg_monitor_role=%v,has_pg_read_all_stats_role=%v,sees_insufficient_privilege=%v",
+		canSelectView, hasMonitorRole, hasReadStatsRole, seesInsufficientPrivilege,
+	)
 	return r
 }
 

--- a/internal/component/database_observability/postgres/collector/health_check_test.go
+++ b/internal/component/database_observability/postgres/collector/health_check_test.go
@@ -116,6 +116,51 @@ func TestHealthCheck(t *testing.T) {
 				},
 				expectedResult: `result="false"`,
 			},
+			{
+				name:             "monitoring user lacks SELECT on pg_stat_statements",
+				failingCheckName: "MonitoringUserPrivileges",
+				customSetup: func(mock sqlmock.Sqlmock) {
+					mock.ExpectQuery(monitoringUserPrivilegesQuery).
+						WillReturnRows(sqlmock.NewRows([]string{
+							"has_pg_monitor_role",
+							"has_pg_read_all_stats_role",
+							"can_select_pg_stat_statements",
+							"sees_insufficient_privilege",
+						}).AddRow(false, false, false, false))
+				},
+				expectedResult: `result="false" value="can_select_view=false,has_pg_monitor_role=false,has_pg_read_all_stats_role=false,sees_insufficient_privilege=false"`,
+			},
+			{
+				name:             "monitoring user sees insufficient privilege rows",
+				failingCheckName: "MonitoringUserPrivileges",
+				customSetup: func(mock sqlmock.Sqlmock) {
+					mock.ExpectQuery(monitoringUserPrivilegesQuery).
+						WillReturnRows(sqlmock.NewRows([]string{
+							"has_pg_monitor_role",
+							"has_pg_read_all_stats_role",
+							"can_select_pg_stat_statements",
+							"sees_insufficient_privilege",
+						}).AddRow(false, false, true, true))
+				},
+				expectedResult: `result="false" value="can_select_view=true,has_pg_monitor_role=false,has_pg_read_all_stats_role=false,sees_insufficient_privilege=true"`,
+			},
+			{
+				// Informational: lacking pg_read_all_stats role membership alone
+				// must NOT fail the check when SELECT works and no masking is
+				// observed (e.g. direct GRANT SELECT on pg_stat_statements).
+				name:             "monitoring user lacks role membership but no masking observed",
+				failingCheckName: "MonitoringUserPrivileges",
+				customSetup: func(mock sqlmock.Sqlmock) {
+					mock.ExpectQuery(monitoringUserPrivilegesQuery).
+						WillReturnRows(sqlmock.NewRows([]string{
+							"has_pg_monitor_role",
+							"has_pg_read_all_stats_role",
+							"can_select_pg_stat_statements",
+							"sees_insufficient_privilege",
+						}).AddRow(false, false, true, false))
+				},
+				expectedResult: `result="true" value="can_select_view=true,has_pg_monitor_role=false,has_pg_read_all_stats_role=false,sees_insufficient_privilege=false"`,
+			},
 		}
 
 		for _, tc := range testCases {
@@ -189,8 +234,13 @@ func TestHealthCheck(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows([]string{"setting"}).AddRow("4096"))
 		mock.ExpectQuery(`SELECT setting FROM pg_settings WHERE name = 'compute_query_id'`).
 			WillReturnRows(sqlmock.NewRows([]string{"setting"}).AddRow("on"))
-		mock.ExpectQuery(`SELECT * FROM pg_stat_statements LIMIT 1`).
-			WillReturnRows(sqlmock.NewRows([]string{"userid", "dbid", "queryid"}).AddRow(1, 1, 123))
+		mock.ExpectQuery(monitoringUserPrivilegesQuery).
+			WillReturnRows(sqlmock.NewRows([]string{
+				"has_pg_monitor_role",
+				"has_pg_read_all_stats_role",
+				"can_select_pg_stat_statements",
+				"sees_insufficient_privilege",
+			}).AddRow(true, true, true, false))
 		mock.ExpectQuery(pgStatStatementsHasRowsQuery([]string{"my_db"}, []string{"my_user"})).
 			WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
 
@@ -262,9 +312,13 @@ func setupExpectQueryAssertions(checkName string, mock sqlmock.Sqlmock, customSe
 		{
 			name: "MonitoringUserPrivileges",
 			setup: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(`SELECT * FROM pg_stat_statements LIMIT 1`).
-					WillReturnRows(sqlmock.NewRows([]string{"userid", "dbid", "queryid"}).
-						AddRow(1, 1, 123))
+				mock.ExpectQuery(monitoringUserPrivilegesQuery).
+					WillReturnRows(sqlmock.NewRows([]string{
+						"has_pg_monitor_role",
+						"has_pg_read_all_stats_role",
+						"can_select_pg_stat_statements",
+						"sees_insufficient_privilege",
+					}).AddRow(true, true, true, false))
 			},
 		},
 		{


### PR DESCRIPTION
### Brief description of Pull Request
Extend the user privileges check to add the following:
- user is member of `pg_monitor` and `pg_read_all_stats` roles
- user has `SELECT` privilege on pg_stat_statements
- user does not see `<insufficient privilege>` rows in pg_stat_statements


### Pull Request Details

<!-- Detailed descripion of the Pull Request, if needed. -->


### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->


### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
