### PR TITLE
chore: Update port used in graphql test

### DIFF
--- a/integration-tests/docker/tests/graphql/docker-compose.yaml
+++ b/integration-tests/docker/tests/graphql/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
     volumes:
       - ./config.alloy:/etc/alloy/config.alloy:ro
     ports:
-      - "12365:12345"
+      - "12382:12345"
     healthcheck:
       test: ["CMD", "bash", "-c", "echo > /dev/tcp/localhost/12345"]
       interval: 2s

--- a/integration-tests/docker/tests/graphql/docker-compose.yaml
+++ b/integration-tests/docker/tests/graphql/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
     volumes:
       - ./config.alloy:/etc/alloy/config.alloy:ro
     ports:
-      - "12382:12345"
+      - "12344:12345"
     healthcheck:
       test: ["CMD", "bash", "-c", "echo > /dev/tcp/localhost/12345"]
       interval: 2s

--- a/integration-tests/docker/tests/graphql/graphql_test.go
+++ b/integration-tests/docker/tests/graphql/graphql_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const graphqlEndpoint = "http://localhost:12365/graphql"
+const graphqlEndpoint = "http://localhost:12382/graphql"
 
 func TestGraphQLAlloyInfo(t *testing.T) {
 	body := postGraphQL(t, `{"query": "{ alloy { version isReady } }"}`)

--- a/integration-tests/docker/tests/graphql/graphql_test.go
+++ b/integration-tests/docker/tests/graphql/graphql_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const graphqlEndpoint = "http://localhost:12382/graphql"
+const graphqlEndpoint = "http://localhost:12344/graphql"
 
 func TestGraphQLAlloyInfo(t *testing.T) {
 	body := postGraphQL(t, `{"query": "{ alloy { version isReady } }"}`)


### PR DESCRIPTION
So we have apparently two kind of docker integration tests, one using testcontainers and one using custom docker-compose file in test.

We run all tests in parallel and for testcontainers we expose the alloy http port starting from 12345 and adding the test index.

Graphql test is using a custom docker-compose file and manually maps host 123465 to 123456. This will collide with `loki-syslog` port, and failing this test. As a simple fix I just updated the graphql test to use a port before the starting range but we should have a better solution for this.