### PR TITLE
feat(database_observability.postgres): Add `exclude_current_user` top-level setting

### DIFF
--- a/docs/sources/reference/components/database_observability/database_observability.postgres.md
+++ b/docs/sources/reference/components/database_observability/database_observability.postgres.md
@@ -36,6 +36,7 @@ You can use the following arguments with `database_observability.postgres`:
 | `enable_collectors`  | `list(string)`       | A list of collectors to enable on top of the default set.   |         | no       |
 | `exclude_databases`  | `list(string)`       | A list of databases to exclude from monitoring.             | `["alloydbadmin", "alloydbmetadata", "azure_maintenance", "azure_sys", "cloudsqladmin", "rdsadmin"]` | no       |
 | `exclude_users`      | `list(string)`       | A list of users to exclude from monitoring.                 | `["azuresu", "cloudsqladmin", "db-o11y", "rdsadmin"]` | no       |
+| `exclude_current_user` | `bool`             | Exclude from activity monitoring the user that Alloy uses to connect to the database. The resolved username is automatically added to `exclude_users`, if not already present. | `true` | no       |
 
 [Data Source Name]: https://pkg.go.dev/github.com/lib/pq#hdr-URL_connection_strings-NewConfig
 
@@ -139,7 +140,7 @@ The `gcp` block supplies the identifying information for the GCP Cloud SQL datab
 |---------------------------|------------|---------------------------------------------------------------|---------|----------|
 | `collect_interval`        | `duration` | How frequently to collect information from database.          | `"15s"` | no       |
 | `disable_query_redaction` | `bool`     | Collect unredacted SQL query text (might include parameters). | `false` | no       |
-| `exclude_current_user`    | `bool`     | Do not collect query samples for current database user.       | `true`  | no       |
+| `exclude_current_user`    | `bool`     | Deprecated. Use the top-level `exclude_current_user` argument instead. When set (`true` or `false`), this setting takes precedence over the top-level setting for the `query_samples` collector. When unset, the `query_samples` collector inherits the top-level setting. | (unset) | no       |
 | `enable_pre_classified_wait_events`   | `boolean`  | When `true`, emits telemetry data with pre-classified wait event information. | `false` | no       |
 
 ### `schema_details`

--- a/docs/sources/reference/components/database_observability/database_observability.postgres.md
+++ b/docs/sources/reference/components/database_observability/database_observability.postgres.md
@@ -140,7 +140,7 @@ The `gcp` block supplies the identifying information for the GCP Cloud SQL datab
 |---------------------------|------------|---------------------------------------------------------------|---------|----------|
 | `collect_interval`        | `duration` | How frequently to collect information from database.          | `"15s"` | no       |
 | `disable_query_redaction` | `bool`     | Collect unredacted SQL query text (might include parameters). | `false` | no       |
-| `exclude_current_user`    | `bool`     | Deprecated. Use the top-level `exclude_current_user` argument instead. When set (`true` or `false`), this setting takes precedence over the top-level setting for the `query_samples` collector. When unset, the `query_samples` collector inherits the top-level setting. | (unset) | no       |
+| `exclude_current_user`    | `bool`     | Deprecated. Use the top-level `exclude_current_user` argument instead. This setting takes precedence over the top-level setting. | (unset) | no       |
 | `enable_pre_classified_wait_events`   | `boolean`  | When `true`, emits telemetry data with pre-classified wait event information. | `false` | no       |
 
 ### `schema_details`

--- a/integration-tests/docker/tests/database-observability-postgres/config.alloy
+++ b/integration-tests/docker/tests/database-observability-postgres/config.alloy
@@ -2,11 +2,11 @@
 // It is not intended to represent a recommended production configuration.
 
 prometheus.exporter.postgres "postgres" {
-  data_source_names = ["postgresql://root:rootpassword@postgres:5432/testdb?sslmode=disable"]
+  data_source_names = ["postgresql://monitoring_user:monitoring_password@postgres:5432/testdb?sslmode=disable"]
 }
 
 database_observability.postgres "test" {
-  data_source_name = "postgresql://root:rootpassword@postgres:5432/testdb?sslmode=disable"
+  data_source_name = "postgresql://monitoring_user:monitoring_password@postgres:5432/testdb?sslmode=disable"
   forward_to       = [loki.write.default.receiver]
   targets          = prometheus.exporter.postgres.postgres.targets
 

--- a/integration-tests/docker/tests/database-observability-postgres/init_postgres.sh
+++ b/integration-tests/docker/tests/database-observability-postgres/init_postgres.sh
@@ -13,6 +13,14 @@ PGPASSWORD=rootpassword psql -h postgres -U root -d testdb <<EOF
 -- Enable pg_stat_statements extension
 CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
 
+-- Create dedicated monitoring user for Alloy
+CREATE ROLE monitoring_user LOGIN PASSWORD 'monitoring_password';
+GRANT pg_monitor TO monitoring_user;
+GRANT pg_read_all_stats TO monitoring_user;
+ALTER ROLE monitoring_user SET pg_stat_statements.track = 'none';
+GRANT USAGE ON SCHEMA public TO monitoring_user;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO monitoring_user;
+
 -- Create products table
 CREATE TABLE IF NOT EXISTS products (
     id SERIAL PRIMARY KEY,

--- a/integration-tests/docker/tests/database-observability-postgres/postgres_test.go
+++ b/integration-tests/docker/tests/database-observability-postgres/postgres_test.go
@@ -13,7 +13,7 @@ import (
 const testName = "database_observability_postgres"
 
 func TestDatabaseObservabilityPostgresMetrics(t *testing.T) {
-	var metrics = []string{
+	metrics := []string{
 		"database_observability_connection_info",
 	}
 	common.MimirMetricsTest(t, metrics, []string{}, testName)

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"path"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -65,13 +66,14 @@ var (
 )
 
 type Arguments struct {
-	DataSourceName    alloytypes.Secret   `alloy:"data_source_name,attr"`
-	ForwardTo         []loki.LogsReceiver `alloy:"forward_to,attr"`
-	Targets           []discovery.Target  `alloy:"targets,attr,optional"`
-	EnableCollectors  []string            `alloy:"enable_collectors,attr,optional"`
-	DisableCollectors []string            `alloy:"disable_collectors,attr,optional"`
-	ExcludeDatabases  []string            `alloy:"exclude_databases,attr,optional"`
-	ExcludeUsers      []string            `alloy:"exclude_users,attr,optional"`
+	DataSourceName     alloytypes.Secret   `alloy:"data_source_name,attr"`
+	ForwardTo          []loki.LogsReceiver `alloy:"forward_to,attr"`
+	Targets            []discovery.Target  `alloy:"targets,attr,optional"`
+	EnableCollectors   []string            `alloy:"enable_collectors,attr,optional"`
+	DisableCollectors  []string            `alloy:"disable_collectors,attr,optional"`
+	ExcludeDatabases   []string            `alloy:"exclude_databases,attr,optional"`
+	ExcludeUsers       []string            `alloy:"exclude_users,attr,optional"`
+	ExcludeCurrentUser bool                `alloy:"exclude_current_user,attr,optional"`
 
 	CloudProvider          *CloudProvider               `alloy:"cloud_provider,block,optional"`
 	QuerySampleArguments   QuerySampleArguments         `alloy:"query_samples,block,optional"`
@@ -103,10 +105,13 @@ type GCPCloudProviderInfo struct {
 }
 
 type QuerySampleArguments struct {
-	CollectInterval               time.Duration `alloy:"collect_interval,attr,optional"`
-	DisableQueryRedaction         bool          `alloy:"disable_query_redaction,attr,optional"`
-	ExcludeCurrentUser            bool          `alloy:"exclude_current_user,attr,optional"`
-	EnablePreClassifiedWaitEvents bool          `alloy:"enable_pre_classified_wait_events,attr,optional"`
+	CollectInterval       time.Duration `alloy:"collect_interval,attr,optional"`
+	DisableQueryRedaction bool          `alloy:"disable_query_redaction,attr,optional"`
+	// Note: `query_samples.exclude_current_user` is deprecated if favour of the top-level setting.
+	// When set (non-nil), it takes precedence over the top-level setting for the
+	// query_samples collector only and preserves the legacy behaviour.
+	ExcludeCurrentUser            *bool `alloy:"exclude_current_user,attr,optional"`
+	EnablePreClassifiedWaitEvents bool  `alloy:"enable_pre_classified_wait_events,attr,optional"`
 }
 
 type QueryDetailsArguments struct {
@@ -123,12 +128,12 @@ type SchemaDetailsArguments struct {
 
 func defaultArguments() Arguments {
 	return Arguments{
-		ExcludeDatabases: database_observability.DefaultExcludedDatabases(),
-		ExcludeUsers:     database_observability.DefaultExcludedUsers(),
+		ExcludeDatabases:   database_observability.DefaultExcludedDatabases(),
+		ExcludeUsers:       database_observability.DefaultExcludedUsers(),
+		ExcludeCurrentUser: true,
 		QuerySampleArguments: QuerySampleArguments{
 			CollectInterval:       15 * time.Second,
 			DisableQueryRedaction: false,
-			ExcludeCurrentUser:    true,
 		},
 		QueryDetailsArguments: QueryDetailsArguments{
 			CollectInterval: 1 * time.Minute,
@@ -418,6 +423,20 @@ func (c *Component) connectAndStartCollectors(ctx context.Context) error {
 
 	generatedSystemID := fmt.Sprintf("%x", sha256.Sum256([]byte(fmt.Sprintf("%s:%s:%s", systemID.String, systemIP.String, systemPort.String))))
 
+	// Get the current user and compute the effective exclude users list.
+	var currentUser sql.NullString
+	if c.args.ExcludeCurrentUser {
+		if err := dbConnection.QueryRowContext(ctx, "SELECT current_user").Scan(&currentUser); err != nil {
+			return fmt.Errorf("failed to query current_user: %w", err)
+		}
+	}
+	effectiveExcludeUsers := slices.Clone(c.args.ExcludeUsers)
+	if currentUser.Valid {
+		if !slices.Contains(effectiveExcludeUsers, currentUser.String) {
+			effectiveExcludeUsers = append(effectiveExcludeUsers, currentUser.String)
+		}
+	}
+
 	var cp *database_observability.CloudProvider
 	if c.args.CloudProvider != nil {
 		cloudProvider, err := populateCloudProviderFromConfig(c.args.CloudProvider)
@@ -504,7 +523,7 @@ func (c *Component) connectAndStartCollectors(ctx context.Context) error {
 	}
 	c.collectors = nil
 
-	if err := c.startCollectors(generatedSystemID, engineVersion.String, cp); err != nil {
+	if err := c.startCollectors(generatedSystemID, engineVersion.String, cp, effectiveExcludeUsers); err != nil {
 		return fmt.Errorf("failed to start collectors: %w", err)
 	}
 
@@ -550,8 +569,8 @@ func enableOrDisableCollectors(a Arguments) map[string]bool {
 	return collectors
 }
 
-// startCollectors attempts to start all of the enabled collectors. If one or more collectors fail to start, their errors are reported
-func (c *Component) startCollectors(systemID string, engineVersion string, cloudProviderInfo *database_observability.CloudProvider) error {
+// startCollectors attempts to start all of the enabled collectors. If one or more collectors fail to start, their errors are reported.
+func (c *Component) startCollectors(systemID string, engineVersion string, cloudProviderInfo *database_observability.CloudProvider, effectiveExcludeUsers []string) error {
 	var startErrors []string
 
 	logStartError := func(collectorName, action string, err error) {
@@ -593,7 +612,7 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 			CollectInterval:  c.args.QueryDetailsArguments.CollectInterval,
 			StatementsLimit:  c.args.QueryDetailsArguments.StatementsLimit,
 			ExcludeDatabases: c.args.ExcludeDatabases,
-			ExcludeUsers:     c.args.ExcludeUsers,
+			ExcludeUsers:     effectiveExcludeUsers,
 			EntryHandler:     entryHandler,
 			TableRegistry:    tableRegistry,
 			Logger:           c.opts.Logger,
@@ -608,15 +627,26 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 	}
 
 	if collectors[collector.QuerySamplesCollector] {
+		// For backward compatibility, give precedence to query_samples.exclude_current_user
+		// setting over the top-level exclude_current_user: when set, preserve today's behavior;
+		// when unset, inherit the top-level cascade.
+		qsExcludeUsers := effectiveExcludeUsers
+		qsExcludeCurrentUser := false
+		if localExcludeCurrentUser := c.args.QuerySampleArguments.ExcludeCurrentUser; localExcludeCurrentUser != nil {
+			level.Warn(c.opts.Logger).Log("msg", "query_samples.exclude_current_user is deprecated; use the top-level exclude_current_user setting instead")
+			qsExcludeUsers = c.args.ExcludeUsers
+			qsExcludeCurrentUser = *localExcludeCurrentUser
+		}
+
 		aCollector, err := collector.NewQuerySamples(collector.QuerySamplesArguments{
 			DB:                            c.dbConnection,
 			CollectInterval:               c.args.QuerySampleArguments.CollectInterval,
 			ExcludeDatabases:              c.args.ExcludeDatabases,
-			ExcludeUsers:                  c.args.ExcludeUsers,
+			ExcludeUsers:                  qsExcludeUsers,
 			EntryHandler:                  entryHandler,
 			Logger:                        c.opts.Logger,
 			DisableQueryRedaction:         c.args.QuerySampleArguments.DisableQueryRedaction,
-			ExcludeCurrentUser:            c.args.QuerySampleArguments.ExcludeCurrentUser,
+			ExcludeCurrentUser:            qsExcludeCurrentUser,
 			EnablePreClassifiedWaitEvents: c.args.QuerySampleArguments.EnablePreClassifiedWaitEvents,
 		})
 		if err != nil {
@@ -652,7 +682,7 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 			ScrapeInterval:   c.args.ExplainPlansArguments.CollectInterval,
 			PerScrapeRatio:   c.args.ExplainPlansArguments.PerCollectRatio,
 			ExcludeDatabases: c.args.ExcludeDatabases,
-			ExcludeUsers:     c.args.ExcludeUsers,
+			ExcludeUsers:     effectiveExcludeUsers,
 			Logger:           c.opts.Logger,
 			DBVersion:        engineVersion,
 			EntryHandler:     entryHandler,
@@ -671,7 +701,7 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 		DB:               c.dbConnection,
 		CollectInterval:  c.args.HealthCheckArguments.CollectInterval,
 		ExcludeDatabases: c.args.ExcludeDatabases,
-		ExcludeUsers:     c.args.ExcludeUsers,
+		ExcludeUsers:     effectiveExcludeUsers,
 		EntryHandler:     entryHandler,
 		Logger:           c.opts.Logger,
 	})
@@ -691,7 +721,7 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 		Logger:           c.opts.Logger,
 		Registry:         c.registry,
 		ExcludeDatabases: c.args.ExcludeDatabases,
-		ExcludeUsers:     c.args.ExcludeUsers,
+		ExcludeUsers:     effectiveExcludeUsers,
 	})
 	if err != nil {
 		logStartError(collector.LogsCollector, "create", err)

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -107,7 +107,7 @@ type GCPCloudProviderInfo struct {
 type QuerySampleArguments struct {
 	CollectInterval       time.Duration `alloy:"collect_interval,attr,optional"`
 	DisableQueryRedaction bool          `alloy:"disable_query_redaction,attr,optional"`
-	// Note: `query_samples.exclude_current_user` is deprecated if favour of the top-level setting.
+	// Note: `query_samples.exclude_current_user` is deprecated in favour of the top-level setting.
 	// When set (non-nil), it takes precedence over the top-level setting for the
 	// query_samples collector only and preserves the legacy behaviour.
 	ExcludeCurrentUser            *bool `alloy:"exclude_current_user,attr,optional"`

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -107,7 +107,7 @@ type GCPCloudProviderInfo struct {
 type QuerySampleArguments struct {
 	CollectInterval       time.Duration `alloy:"collect_interval,attr,optional"`
 	DisableQueryRedaction bool          `alloy:"disable_query_redaction,attr,optional"`
-	// Note: `query_samples.exclude_current_user` is deprecated in favour of the top-level setting.
+	// Deprecated: `query_samples.exclude_current_user` is deprecated in favour of the top-level setting.
 	// When set (non-nil), it takes precedence over the top-level setting for the
 	// query_samples collector only and preserves the legacy behaviour.
 	ExcludeCurrentUser            *bool `alloy:"exclude_current_user,attr,optional"`

--- a/internal/component/database_observability/postgres/component_test.go
+++ b/internal/component/database_observability/postgres/component_test.go
@@ -89,6 +89,9 @@ func Test_defaultExclusions(t *testing.T) {
 		"db-o11y",
 		"rdsadmin",
 	}, args.ExcludeUsers)
+
+	assert.True(t, args.ExcludeCurrentUser, "exclude_current_user should default to true")
+	assert.Nil(t, args.QuerySampleArguments.ExcludeCurrentUser, "query_samples.exclude_current_user should default to unset")
 }
 
 func Test_enableOrDisableCollectors(t *testing.T) {
@@ -339,6 +342,107 @@ func TestQueryRedactionConfig(t *testing.T) {
 		err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
 		require.NoError(t, err)
 		assert.False(t, args.QuerySampleArguments.DisableQueryRedaction, "query redaction should be enabled when explicitly set to false")
+	})
+}
+
+func TestQuerySamples_ExcludeCurrentUser_ConfigParsing(t *testing.T) {
+	t.Run("unset by default", func(t *testing.T) {
+		cfg := `
+		data_source_name = "postgres://db"
+		forward_to = []
+		targets = []
+		`
+		var args Arguments
+		require.NoError(t, syntax.Unmarshal([]byte(cfg), &args))
+		assert.Nil(t, args.QuerySampleArguments.ExcludeCurrentUser, "should default to nil (unset)")
+	})
+
+	t.Run("explicitly true", func(t *testing.T) {
+		cfg := `
+		data_source_name = "postgres://db"
+		forward_to = []
+		targets = []
+		query_samples {
+			exclude_current_user = true
+		}
+		`
+		var args Arguments
+		require.NoError(t, syntax.Unmarshal([]byte(cfg), &args))
+		require.NotNil(t, args.QuerySampleArguments.ExcludeCurrentUser)
+		assert.True(t, *args.QuerySampleArguments.ExcludeCurrentUser)
+	})
+
+	t.Run("explicitly false", func(t *testing.T) {
+		cfg := `
+		data_source_name = "postgres://db"
+		forward_to = []
+		targets = []
+		query_samples {
+			exclude_current_user = false
+		}
+		`
+		var args Arguments
+		require.NoError(t, syntax.Unmarshal([]byte(cfg), &args))
+		require.NotNil(t, args.QuerySampleArguments.ExcludeCurrentUser)
+		assert.False(t, *args.QuerySampleArguments.ExcludeCurrentUser)
+	})
+}
+
+func TestPostgres_ExcludeCurrentUser_Runtime(t *testing.T) {
+	t.Run("when true, queries current_user and merges it into effective exclude list", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true), sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		mock.ExpectPing()
+		mock.ExpectQuery(selectServerInfo).
+			WillReturnRows(sqlmock.NewRows([]string{"system_identifier", "inet_server_addr", "inet_server_port", "version"}).
+				AddRow("1234567890", "127.0.0.1", "5432", "14.0"))
+		mock.ExpectQuery(`SELECT current_user`).
+			WillReturnRows(sqlmock.NewRows([]string{"current_user"}).AddRow("alloy_monitor"))
+
+		c := newTestComponent(t, func(_, _ string) (*sql.DB, error) { return db, nil })
+		c.args.ExcludeCurrentUser = true
+		c.args.ExcludeUsers = []string{"rdsadmin"}
+
+		require.NoError(t, c.connectAndStartCollectors(context.Background()))
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("when false, current_user is not queried", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true), sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		mock.ExpectPing()
+		mock.ExpectQuery(selectServerInfo).
+			WillReturnRows(sqlmock.NewRows([]string{"system_identifier", "inet_server_addr", "inet_server_port", "version"}).
+				AddRow("1234567890", "127.0.0.1", "5432", "14.0"))
+
+		c := newTestComponent(t, func(_, _ string) (*sql.DB, error) { return db, nil })
+		c.args.ExcludeCurrentUser = false
+
+		require.NoError(t, c.connectAndStartCollectors(context.Background()))
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("returns wrapped error when current_user query fails", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true), sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		mock.ExpectPing()
+		mock.ExpectQuery(selectServerInfo).
+			WillReturnRows(sqlmock.NewRows([]string{"system_identifier", "inet_server_addr", "inet_server_port", "version"}).
+				AddRow("1234567890", "127.0.0.1", "5432", "14.0"))
+		mock.ExpectQuery(`SELECT current_user`).WillReturnError(assert.AnError)
+
+		c := newTestComponent(t, func(_, _ string) (*sql.DB, error) { return db, nil })
+		c.args.ExcludeCurrentUser = true
+
+		err = c.connectAndStartCollectors(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to query current_user")
 	})
 }
 
@@ -793,7 +897,7 @@ func TestPostgres_Reconnection(t *testing.T) {
 
 	t.Run("tryReconnect succeeds and clears health error", func(t *testing.T) {
 		// First mock: will fail
-		db1, mock1, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+		db1, mock1, err := sqlmock.New(sqlmock.MonitorPingsOption(true), sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db1.Close()
 
@@ -807,11 +911,11 @@ func TestPostgres_Reconnection(t *testing.T) {
 		assert.NotEmpty(t, c.healthErr.Load())
 
 		// Second mock: will succeed
-		db2, mock2, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+		db2, mock2, err := sqlmock.New(sqlmock.MonitorPingsOption(true), sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db2.Close()
 		mock2.ExpectPing()
-		mock2.ExpectQuery(`SELECT.*system_identifier.*inet_server_addr.*inet_server_port.*version`).
+		mock2.ExpectQuery(selectServerInfo).
 			WillReturnRows(sqlmock.NewRows([]string{"system_identifier", "inet_server_addr", "inet_server_port", "version"}).
 				AddRow("1234567890", "127.0.0.1", "5432", "14.0"))
 		c.openSQL = func(_ string, _ string) (*sql.DB, error) { return db2, nil }

--- a/internal/component/database_observability/postgres/component_test.go
+++ b/internal/component/database_observability/postgres/component_test.go
@@ -563,6 +563,41 @@ func TestQuerySamples_ExcludeCurrentUser_LocalPrecedence(t *testing.T) {
 		require.NoError(t, c.connectAndStartCollectors(context.Background()))
 		require.Eventually(t, func() bool { return mock.ExpectationsWereMet() == nil }, 5*time.Second, 50*time.Millisecond)
 	})
+
+	t.Run("top-level false with local override unset is a no-op baseline", func(t *testing.T) {
+		c, mock, db := setup(t)
+		defer db.Close()
+		c.args.ExcludeCurrentUser = false
+		c.args.ExcludeUsers = []string{"rdsadmin"}
+		c.args.QuerySampleArguments.ExcludeCurrentUser = nil
+
+		// Top-level is false, so SELECT current_user is NOT issued.
+		expectPrelude(mock, false)
+		// Neither knob is on: no current_user clause, raw c.args.ExcludeUsers.
+		mock.ExpectQuery(`(?s)` + fmt.Sprintf(regexNoCurrentUser, `'rdsadmin'`)).
+			WillReturnRows(emptyActivityRows())
+
+		require.NoError(t, c.connectAndStartCollectors(context.Background()))
+		require.Eventually(t, func() bool { return mock.ExpectationsWereMet() == nil }, 5*time.Second, 50*time.Millisecond)
+	})
+
+	t.Run("top-level false with local override false renders identically to baseline", func(t *testing.T) {
+		c, mock, db := setup(t)
+		defer db.Close()
+		c.args.ExcludeCurrentUser = false
+		c.args.ExcludeUsers = []string{"rdsadmin"}
+		c.args.QuerySampleArguments.ExcludeCurrentUser = ptrBool(false)
+
+		// Top-level is false, so SELECT current_user is NOT issued.
+		expectPrelude(mock, false)
+		// Same observable SQL as the local=nil baseline above; the deprecated
+		// branch is taken (warning logged) but the rendered query is unchanged.
+		mock.ExpectQuery(`(?s)` + fmt.Sprintf(regexNoCurrentUser, `'rdsadmin'`)).
+			WillReturnRows(emptyActivityRows())
+
+		require.NoError(t, c.connectAndStartCollectors(context.Background()))
+		require.Eventually(t, func() bool { return mock.ExpectationsWereMet() == nil }, 5*time.Second, 50*time.Millisecond)
+	})
 }
 
 func TestCollectionIntervals(t *testing.T) {

--- a/internal/component/database_observability/postgres/component_test.go
+++ b/internal/component/database_observability/postgres/component_test.go
@@ -3,6 +3,8 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"regexp"
 	"testing"
 	"time"
 
@@ -443,6 +445,123 @@ func TestPostgres_ExcludeCurrentUser_Runtime(t *testing.T) {
 		err = c.connectAndStartCollectors(context.Background())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to query current_user")
+	})
+}
+
+func TestQuerySamples_ExcludeCurrentUser_LocalPrecedence(t *testing.T) {
+	ptrBool := func(b bool) *bool { return &b }
+
+	serverInfoRows := func() *sqlmock.Rows {
+		return sqlmock.NewRows([]string{"system_identifier", "inet_server_addr", "inet_server_port", "version"}).
+			AddRow("1234567890", "127.0.0.1", "5432", "14.0")
+	}
+	currentUserRows := func() *sqlmock.Rows {
+		return sqlmock.NewRows([]string{"current_user"}).AddRow("alloy_monitor")
+	}
+	emptyActivityRows := func() *sqlmock.Rows {
+		return sqlmock.NewRows([]string{
+			"now", "datname", "pid", "leader_pid",
+			"usename", "application_name", "client_addr", "client_port",
+			"backend_type", "backend_start", "backend_xid", "backend_xmin",
+			"xact_start", "state", "state_change", "wait_event_type",
+			"wait_event", "blocked_by_pids", "query_start", "query_id",
+		})
+	}
+
+	setup := func(t *testing.T) (*Component, sqlmock.Sqlmock, *sql.DB) {
+		t.Helper()
+		db, mock, err := sqlmock.New(
+			sqlmock.MonitorPingsOption(true),
+			sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp),
+		)
+		require.NoError(t, err)
+		mock.MatchExpectationsInOrder(false)
+
+		c := newTestComponent(t, func(_, _ string) (*sql.DB, error) { return db, nil })
+		c.args.EnableCollectors = []string{"query_samples"}
+		c.args.DisableCollectors = []string{"query_details", "schema_details", "explain_plans"}
+		// Avoid scraping more than once during the test.
+		c.args.QuerySampleArguments.CollectInterval = time.Hour
+		return c, mock, db
+	}
+
+	expectPrelude := func(mock sqlmock.Sqlmock, mockSelectCurrentUser bool) {
+		mock.ExpectPing()
+		mock.ExpectQuery(regexp.QuoteMeta(selectServerInfo)).WillReturnRows(serverInfoRows())
+		if mockSelectCurrentUser {
+			mock.ExpectQuery(regexp.QuoteMeta("SELECT current_user")).WillReturnRows(currentUserRows())
+		}
+	}
+
+	// regexes for the query_samples collector to verify users clause
+	const (
+		regexNoCurrentUser   = `AND d\.datname NOT IN \('azure_maintenance'\)\s*AND s\.usename NOT IN \(%s\)\s*\z`
+		regexWithCurrentUser = `AND d\.datname NOT IN \('azure_maintenance'\)\s*AND s\.usesysid != \(select oid from pg_roles where rolname = current_user\)\s*AND s\.usename NOT IN \(%s\)\s*\z`
+	)
+
+	t.Run("local override unset inherits top-level cascade", func(t *testing.T) {
+		c, mock, db := setup(t)
+		defer db.Close()
+		c.args.ExcludeCurrentUser = true
+		c.args.ExcludeUsers = []string{"rdsadmin"}
+		c.args.QuerySampleArguments.ExcludeCurrentUser = nil
+
+		expectPrelude(mock, true)
+		// effectiveExcludeUsers = ['rdsadmin', 'alloy_monitor'], no current_user clause.
+		mock.ExpectQuery(`(?s)` + fmt.Sprintf(regexNoCurrentUser, `'rdsadmin', 'alloy_monitor'`)).
+			WillReturnRows(emptyActivityRows())
+
+		require.NoError(t, c.connectAndStartCollectors(context.Background()))
+		require.Eventually(t, func() bool { return mock.ExpectationsWereMet() == nil }, 5*time.Second, 50*time.Millisecond)
+	})
+
+	t.Run("local override true forces deprecated SQL-side path", func(t *testing.T) {
+		c, mock, db := setup(t)
+		defer db.Close()
+		c.args.ExcludeCurrentUser = true
+		c.args.ExcludeUsers = []string{"rdsadmin"}
+		c.args.QuerySampleArguments.ExcludeCurrentUser = ptrBool(true)
+
+		expectPrelude(mock, true)
+		// SQL contains the current_user clause, and uses raw c.args.ExcludeUsers
+		mock.ExpectQuery(`(?s)` + fmt.Sprintf(regexWithCurrentUser, `'rdsadmin'`)).
+			WillReturnRows(emptyActivityRows())
+
+		require.NoError(t, c.connectAndStartCollectors(context.Background()))
+		require.Eventually(t, func() bool { return mock.ExpectationsWereMet() == nil }, 5*time.Second, 50*time.Millisecond)
+	})
+
+	t.Run("local override false opts out and bypasses cascade", func(t *testing.T) {
+		c, mock, db := setup(t)
+		defer db.Close()
+		c.args.ExcludeCurrentUser = true
+		c.args.ExcludeUsers = []string{"rdsadmin"}
+		c.args.QuerySampleArguments.ExcludeCurrentUser = ptrBool(false)
+
+		expectPrelude(mock, true)
+		// No current_user clause, uses raw c.args.ExcludeUsers (no alloy_monitor appended).
+		mock.ExpectQuery(`(?s)` + fmt.Sprintf(regexNoCurrentUser, `'rdsadmin'`)).
+			WillReturnRows(emptyActivityRows())
+
+		require.NoError(t, c.connectAndStartCollectors(context.Background()))
+		require.Eventually(t, func() bool { return mock.ExpectationsWereMet() == nil }, 5*time.Second, 50*time.Millisecond)
+	})
+
+	t.Run("top-level false with local override true engages SQL clause without lookup", func(t *testing.T) {
+		c, mock, db := setup(t)
+		defer db.Close()
+		c.args.ExcludeCurrentUser = false
+		c.args.ExcludeUsers = []string{"rdsadmin"}
+		c.args.QuerySampleArguments.ExcludeCurrentUser = ptrBool(true)
+
+		// Top-level is false, so SELECT current_user is NOT issued.
+		expectPrelude(mock, false)
+		// SQL still contains the current_user clause via the local override.
+		mock.ExpectQuery(`(?s)` + fmt.Sprintf(regexWithCurrentUser, `'rdsadmin'`)).
+			WillReturnRows(emptyActivityRows())
+
+		require.NoError(t, c.connectAndStartCollectors(context.Background()))
+		require.Eventually(t, func() bool { return mock.ExpectationsWereMet() == nil }, 5*time.Second, 50*time.Millisecond)
 	})
 }
 


### PR DESCRIPTION
### Brief description of Pull Request

Add top-level `exclude_current_user` that is applied to all collectors and will eventually replace the local setting in `query_samples` (which is now deprecated, although continues to work as expected).

With `exclude_current_user = true` (the default), the current user is resolved before collectors are started and its name is appended to the list of excluded users (if it's not already present).

### Pull Request Details

<!-- Detailed descripion of the Pull Request, if needed. -->


### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->


### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
