### PR TITLE
ci: Cross-compile darwin/amd64 from ARM runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,23 +62,8 @@ jobs:
         cache: false
     - run: GO_TAGS="embedalloyui promtail_journal_enabled" GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} GOARM= GOEXPERIMENT=boringcrypto make alloy
 
-  build_mac_intel:
-    name: Build on MacOS (Intel)
-    runs-on: macos-15-large
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        persist-credentials: false
-    - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-      with:
-        go-version-file: go.mod
-        cache: false
-    - run: GO_TAGS="embedalloyui" GOOS=darwin GOARCH=amd64 GOARM= make alloy
-
-  build_mac_arm:
-    name: Build on MacOS (ARM)
+  build_mac:
+    name: Build on MacOS
     runs-on: macos-15-xlarge
     steps:
     - name: Checkout code
@@ -90,7 +75,10 @@ jobs:
       with:
         go-version-file: go.mod
         cache: false
-    - run: CGO_LDFLAGS="-ld_classic $CGO_LDFLAGS" GO_TAGS="embedalloyui" GOOS=darwin GOARCH=arm64 GOARM= make alloy
+    - name: Build native arm64
+      run: CGO_LDFLAGS="-ld_classic $CGO_LDFLAGS" GO_TAGS="embedalloyui" GOOS=darwin GOARCH=arm64 GOARM= make alloy
+    - name: Cross-compile amd64
+      run: GO_TAGS="embedalloyui" GOOS=darwin GOARCH=amd64 GOARM= SKIP_UI_BUILD=1 make alloy
 
   build_windows:
     name: Build on Windows (AMD64)


### PR DESCRIPTION
### Brief description of Pull Request

Removes the dedicated `build_mac_intel` job (~17 min, long pole on PR critical path). Cross-compiles `darwin/amd64` from the existing macOS ARM runner instead. Native Intel hardware testing remains in the release pipeline.

### Pull Request Details

Measured on this PR:

| | Before | After |
|---|---|---|
| `build_mac_intel` | 17 min (parallel) | removed |
| `build_mac_arm` / `build_mac` | 7 min | 12m 40s |
| **PR critical path contribution** | **17 min** | **12m 40s** |

### Notes to the Reviewer

Apple shipped its last Intel Macs in 2023 (Mac Pro) and the lineup has been ARM-only since. The cost of a dedicated 17-minute runner per PR to verify native Intel hardware compatibility is increasingly hard to justify when nearly all users are on Apple Silicon. A successful cross-compile on every PR plus a native build on every release strikes a better balance.

The `Build on MacOS (Intel)` status check is removed and `Build on MacOS (ARM)` is renamed to `Build on MacOS`. I'll update the branch protection rule to match before merging.