### PR TITLE
test(logging): Fix data race in TestUpdateNoLostBufferedMessages

### DIFF
--- a/internal/runtime/logging/logger_test.go
+++ b/internal/runtime/logging/logger_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,6 +19,23 @@ import (
 	alloylevel "github.com/grafana/alloy/internal/runtime/logging/level"
 	"github.com/stretchr/testify/require"
 )
+
+type safeBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *safeBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *safeBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
 
 /* Most recent performance results on M2 Macbook Air:
 $ go test -count=1 -benchmem ./internal/alloy/logging -run ^$ -bench BenchmarkLogging_
@@ -229,7 +247,7 @@ func TestUpdateConcurrentHandle(t *testing.T) {
 // Update is called are not lost even when concurrent Handle calls are in-flight
 // during the window between bufferMut being released and buildHandlers completing.
 func TestUpdateNoLostBufferedMessages(t *testing.T) {
-	var buf bytes.Buffer
+	var buf safeBuffer
 	l, err := logging.NewDeferred(&buf)
 	require.NoError(t, err)
 


### PR DESCRIPTION
### Brief description of Pull Request

`TestUpdateNoLostBufferedMessages` (added in #6112) intermittently fails under \`-race\` because its concurrent goroutine and \`Update\`'s drain phase both write to the same \`bytes.Buffer\` through \`writerVar.Write\` (which uses \`RLock\` to permit concurrent writes — relying on the underlying \`io.Writer\` to be safe for concurrent calls).

### Pull Request Details

In production, \`inner\` is typically \`os.Stderr\`/\`os.Stdout\` whose \`Write\` doesn't mutate Go-visible state, so the race detector stays quiet. \`bytes.Buffer\` does mutate a Go slice on every write, so the same code path trips the detector.

Fix: wrap the test's buffer in a tiny mutex-protected shim used only by this test. Production stays unchanged; the contention coverage that the test was designed to provide stays intact.

Verified locally with \`go test -race -run TestUpdateNoLostBufferedMessages -count=20 -v ./internal/runtime/logging\` (20/20 clean) and \`go test -race ./internal/runtime/logging/...\` (no regressions).