### PR TITLE
ci: Parallelize Test Linux into per-module matrix

### DIFF
--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -9,31 +9,13 @@ jobs:
   lint:
     uses: ./.github/workflows/lint.yml
 
-  discover_modules:
-    name: Discover test modules
-    runs-on: ubuntu-latest
-    outputs:
-      modules: ${{ steps.find.outputs.modules }}
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        persist-credentials: false
-    - name: Find go.mod modules
-      id: find
-      run: |
-        modules=$(find . -name go.mod -type f -not -path '*/testdata/*' -exec sh -c 'dirname "$1"' _ {} \; | jq -R -s -c 'split("\n") | map(select(length > 0))')
-        echo "modules=$modules" >> $GITHUB_OUTPUT
-        echo "Discovered: $modules"
-
   test_linux:
-    name: Test Linux (${{ matrix.module }})
-    needs: discover_modules
+    name: Test Linux (shard ${{ matrix.shard }}/8)
     runs-on: ubuntu-latest-8-cores
     strategy:
       fail-fast: false
       matrix:
-        module: ${{ fromJson(needs.discover_modules.outputs.modules) }}
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -46,4 +28,4 @@ jobs:
         go-version-file: go.mod
         cache: false
 
-    - run: make GO_TAGS="nodocker" MODULE=${{ matrix.module }} test
+    - run: make GO_TAGS="nodocker" SHARD=${{ matrix.shard }}/8 test

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -9,9 +9,31 @@ jobs:
   lint:
     uses: ./.github/workflows/lint.yml
 
+  discover_modules:
+    name: Discover test modules
+    runs-on: ubuntu-latest
+    outputs:
+      modules: ${{ steps.find.outputs.modules }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - name: Find go.mod modules
+      id: find
+      run: |
+        modules=$(find . -name go.mod -type f -not -path '*/testdata/*' -exec sh -c 'dirname "$1"' _ {} \; | jq -R -s -c 'split("\n") | map(select(length > 0))')
+        echo "modules=$modules" >> $GITHUB_OUTPUT
+        echo "Discovered: $modules"
+
   test_linux:
-    name: Test Linux
+    name: Test Linux (${{ matrix.module }})
+    needs: discover_modules
     runs-on: ubuntu-latest-8-cores
+    strategy:
+      fail-fast: false
+      matrix:
+        module: ${{ fromJson(needs.discover_modules.outputs.modules) }}
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -24,4 +46,4 @@ jobs:
         go-version-file: go.mod
         cache: false
 
-    - run: make GO_TAGS="nodocker" test
+    - run: make GO_TAGS="nodocker" MODULE=${{ matrix.module }} test

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -9,35 +9,8 @@ jobs:
   lint:
     uses: ./.github/workflows/lint.yml
 
-  prebuild_tests:
-    name: Prebuild test binaries
-    runs-on: ubuntu-latest-8-cores
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        persist-credentials: false
-
-    - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-      with:
-        go-version-file: go.mod
-        cache: false
-
-    - run: make GO_TAGS="nodocker" prebuild-tests
-
-    - name: Upload GOCACHE artifact
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-      with:
-        name: gocache
-        path: ~/.cache/go-build
-        retention-days: 1
-        if-no-files-found: error
-        include-hidden-files: true
-
   test_linux:
     name: Test Linux (shard ${{ matrix.shard }}/8)
-    needs: prebuild_tests
     runs-on: ubuntu-latest-8-cores
     strategy:
       fail-fast: false
@@ -54,11 +27,5 @@ jobs:
       with:
         go-version-file: go.mod
         cache: false
-
-    - name: Restore prebuilt GOCACHE
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: gocache
-        path: ~/.cache/go-build
 
     - run: make GO_TAGS="nodocker" SHARD=${{ matrix.shard }}/8 test

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -9,8 +9,35 @@ jobs:
   lint:
     uses: ./.github/workflows/lint.yml
 
+  prebuild_tests:
+    name: Prebuild test binaries
+    runs-on: ubuntu-latest-8-cores
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+
+    - name: Set up Go
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        go-version-file: go.mod
+        cache: false
+
+    - run: make GO_TAGS="nodocker" prebuild-tests
+
+    - name: Upload GOCACHE artifact
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: gocache
+        path: ~/.cache/go-build
+        retention-days: 1
+        if-no-files-found: error
+        include-hidden-files: true
+
   test_linux:
     name: Test Linux (shard ${{ matrix.shard }}/8)
+    needs: prebuild_tests
     runs-on: ubuntu-latest-8-cores
     strategy:
       fail-fast: false
@@ -27,5 +54,11 @@ jobs:
       with:
         go-version-file: go.mod
         cache: false
+
+    - name: Restore prebuilt GOCACHE
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: gocache
+        path: ~/.cache/go-build
 
     - run: make GO_TAGS="nodocker" SHARD=${{ matrix.shard }}/8 test

--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,18 @@ run-alloylint: alloylint
 test:
 ifdef MODULE
 	@cd $(MODULE) && $(GO_ENV) go test $(GO_FLAGS) -race ./...
+else ifdef SHARD
+	@idx=$$(echo $(SHARD) | cut -d/ -f1); \
+	total=$$(echo $(SHARD) | cut -d/ -f2); \
+	packages=$$(go list ./... | awk -v idx=$$idx -v total=$$total 'NR % total == idx'); \
+	echo "Shard $$idx/$$total: $$(echo $$packages | wc -w) root packages"; \
+	$(GO_ENV) go test $(GO_FLAGS) -race $$packages || exit 1; \
+	if [ "$$idx" = "0" ]; then \
+		for dir in $$(find . -mindepth 2 -name go.mod -type f -not -path '*/testdata/*' -exec sh -c 'dirname "$$1"' _ {} \;); do \
+			echo "Non-root module: $$dir"; \
+			(cd $$dir && $(GO_ENV) go test $(GO_FLAGS) -race ./...) || exit 1; \
+		done; \
+	fi
 else
 	@for dir in $$(find . -name go.mod -type f -exec sh -c 'dirname "$$1"' _ {} \;); do \
 		if echo "$$dir" | grep -qv testdata; then \

--- a/Makefile
+++ b/Makefile
@@ -183,11 +183,15 @@ run-alloylint: alloylint
 # more for packages that exclude tests via //go:build !race due to known race detection issues. The
 # final command runs tests for syntax module.
 test:
+ifdef MODULE
+	@cd $(MODULE) && $(GO_ENV) go test $(GO_FLAGS) -race ./...
+else
 	@for dir in $$(find . -name go.mod -type f -exec sh -c 'dirname "$$1"' _ {} \;); do \
 		if echo "$$dir" | grep -qv testdata; then \
 			(cd $$dir && $(GO_ENV) go test $(GO_FLAGS) -race ./...) || exit 1;\
 		fi;\
 	done
+endif
 
 test-packages:
 ifeq ($(USE_CONTAINER),1)

--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,16 @@ else
 	done
 endif
 
+# prebuild-tests compiles all test binaries (root + non-root modules) without
+# running tests. Used in CI to populate GOCACHE before the sharded test matrix.
+# Flags must match the `test` target so the build cache hits.
+prebuild-tests:
+	@$(GO_ENV) go test -count=0 $(GO_FLAGS) -race ./...
+	@for dir in $$(find . -mindepth 2 -name go.mod -type f -not -path '*/testdata/*' -exec sh -c 'dirname "$$1"' _ {} \;); do \
+		echo "Prebuilding tests in $$dir"; \
+		(cd $$dir && $(GO_ENV) go test -count=0 $(GO_FLAGS) -race ./...) || exit 1; \
+	done
+
 test-packages:
 ifeq ($(USE_CONTAINER),1)
 	$(RERUN_IN_CONTAINER)

--- a/Makefile
+++ b/Makefile
@@ -205,16 +205,6 @@ else
 	done
 endif
 
-# prebuild-tests compiles all test binaries (root + non-root modules) without
-# running tests. Used in CI to populate GOCACHE before the sharded test matrix.
-# Flags must match the `test` target so the build cache hits.
-prebuild-tests:
-	@$(GO_ENV) go test -count=0 $(GO_FLAGS) -race ./...
-	@for dir in $$(find . -mindepth 2 -name go.mod -type f -not -path '*/testdata/*' -exec sh -c 'dirname "$$1"' _ {} \;); do \
-		echo "Prebuilding tests in $$dir"; \
-		(cd $$dir && $(GO_ENV) go test -count=0 $(GO_FLAGS) -race ./...) || exit 1; \
-	done
-
 test-packages:
 ifeq ($(USE_CONTAINER),1)
 	$(RERUN_IN_CONTAINER)


### PR DESCRIPTION
Splits the Test Linux job into a matrix per Go module discovered at runtime. Naive split — root module still dominates wall-clock. Measuring as a stepping stone to package-level sharding within root.