### PR TITLE
feat(prometheus): Add prometheus.expose component to expose metrics on /metrics

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.expose.md
+++ b/docs/sources/reference/components/prometheus/prometheus.expose.md
@@ -1,0 +1,106 @@
+---
+canonical: https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.expose/
+description: Learn about prometheus.expose
+labels:
+  stage: experimental
+  products:
+    - oss
+title: prometheus.expose
+---
+
+# `prometheus.expose`
+
+{{< docs/shared lookup="stability/experimental.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+The `prometheus.expose` component receives Prometheus metrics and re-exposes them on Alloy's own `/metrics` endpoint.
+This is useful when you want scraped or forwarded metrics to be visible as part of Alloy's self-monitoring metrics.
+
+## Usage
+
+```alloy
+prometheus.expose "<LABEL>" {
+}
+```
+
+## Arguments
+
+You can use the following arguments with `prometheus.expose`:
+
+| Name        | Type                | Description                                      | Default | Required |
+| ----------- | ------------------- | ------------------------------------------------ | ------- | -------- |
+| `namespace` | `string`            | Prefix added to all metric names as `namespace_`.| `""`    | no       |
+| `subsystem` | `string`            | Prefix added to all metric names as `subsystem_`.| `""`    | no       |
+| `labels`    | `map(string)`       | Extra labels added to every metric.              | `{}`    | no       |
+
+When both `namespace` and `subsystem` are set, the resulting metric name is `namespace_subsystem_<original_name>`.
+
+Global labels defined in `labels` are only added when the incoming metric does not already carry a label with the same name.
+
+## Blocks
+
+The `prometheus.expose` component doesn't support any blocks. You can configure this component with arguments.
+
+## Exported fields
+
+The following fields are exported and can be referenced by other components:
+
+| Name       | Type              | Description                                               |
+| ---------- | ----------------- | --------------------------------------------------------- |
+| `receiver` | `MetricsReceiver` | A value that other components can use to send metrics to. |
+
+## Component health
+
+`prometheus.expose` is only reported as unhealthy if given an invalid configuration.
+In those cases, exported fields retain their last healthy values.
+
+## Debug information
+
+`prometheus.expose` doesn't expose any component-specific debug information.
+
+## Debug metrics
+
+`prometheus.expose` doesn't expose any component-specific debug metrics.
+
+## Example
+
+Expose scraped application metrics on Alloy's own `/metrics` endpoint:
+
+```alloy
+prometheus.scrape "app" {
+  targets = [{"__address__" = "localhost:8080"}]
+  forward_to = [prometheus.expose.local.receiver]
+}
+
+prometheus.expose "local" {}
+```
+
+### With namespace and extra labels
+
+```alloy
+prometheus.scrape "app" {
+  targets = [{"__address__" = "localhost:8080"}]
+  forward_to = [prometheus.expose.local.receiver]
+}
+
+prometheus.expose "local" {
+  namespace = "myapp"
+  labels    = { env = "production" }
+}
+```
+
+In this example all metrics received will be renamed from `<name>` to `myapp_<name>` and will carry an additional `env="production"` label.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.expose` can accept metrics from the following components:
+
+- Components that export [Prometheus `MetricsReceiver`](../../../compatibility/#prometheus-metricsreceiver-exporters)
+
+{{< admonition type="note" >}}
+Connecting some components may not be sensible or components may require further configuration to make the connection work correctly.
+Refer to the linked documentation for more details.
+{{< /admonition >}}
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/internal/component/all/all.go
+++ b/internal/component/all/all.go
@@ -160,6 +160,7 @@ import (
 	_ "github.com/grafana/alloy/internal/component/prometheus/exporter/statsd"               // Import prometheus.exporter.statsd
 	_ "github.com/grafana/alloy/internal/component/prometheus/exporter/unix"                 // Import prometheus.exporter.unix
 	_ "github.com/grafana/alloy/internal/component/prometheus/exporter/windows"              // Import prometheus.exporter.windows
+	_ "github.com/grafana/alloy/internal/component/prometheus/expose"                        // Import prometheus.expose
 	_ "github.com/grafana/alloy/internal/component/prometheus/operator/podmonitors"          // Import prometheus.operator.podmonitors
 	_ "github.com/grafana/alloy/internal/component/prometheus/operator/probes"               // Import prometheus.operator.probes
 	_ "github.com/grafana/alloy/internal/component/prometheus/operator/scrapeconfigs"        // Import prometheus.operator.scrapeconfigs

--- a/internal/component/prometheus/expose/expose.go
+++ b/internal/component/prometheus/expose/expose.go
@@ -1,0 +1,192 @@
+package expose
+
+import (
+	"context"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/model/exemplar"
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
+	"github.com/prometheus/prometheus/storage"
+
+	"github.com/grafana/alloy/internal/component"
+	alloy_prometheus "github.com/grafana/alloy/internal/component/prometheus"
+	"github.com/grafana/alloy/internal/featuregate"
+)
+
+const (
+	name = "prometheus.expose"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:      name,
+		Stability: featuregate.StabilityExperimental,
+		Args:      Arguments{},
+		Exports:   Exports{},
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			return New(opts, args.(Arguments))
+		},
+	})
+}
+
+// Arguments holds the arguments for the prometheus.expose component
+type Arguments struct {
+	// Optional: namespace prefix for metrics
+	Namespace string `alloy:"namespace,attr,optional"`
+
+	// Optional: subsystem prefix for metrics
+	Subsystem string `alloy:"subsystem,attr,optional"`
+
+	// Optional: global labels to add to all metrics
+	Labels map[string]string `alloy:"labels,attr,optional"`
+}
+
+// Exports holds the exports of the prometheus.expose component
+type Exports struct {
+	// Receiver is a Prometheus Appendable that can be used as a forward_to target
+	Receiver storage.Appendable `alloy:"receiver,attr"`
+}
+
+// Component implements the prometheus.expose component
+type Component struct {
+	opts component.Options
+	mut  sync.RWMutex
+	args Arguments
+
+	// collector wraps metrics for exposition
+	collector *MetricsCollector
+
+	// registerer for registering the collector
+	registerer prometheus.Registerer
+}
+
+// New creates a new prometheus.expose component
+func New(opts component.Options, args Arguments) (*Component, error) {
+	c := &Component{
+		opts:       opts,
+		args:       args,
+		collector:  NewMetricsCollector(args.Namespace, args.Subsystem, args.Labels),
+		registerer: prometheus.DefaultRegisterer, // must use global registry to appear at /metrics
+	}
+
+	// Register the collector with the component's registerer
+	err := c.registerer.Register(c.collector)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create an interceptor that passes metrics through and stores them
+	receiver := alloy_prometheus.NewInterceptor(
+		noop{}, // Use a no-op appendable since we're just collecting
+		alloy_prometheus.WithAppendHook(func(ref storage.SeriesRef, l labels.Labels, t int64, v float64, next storage.Appender) (storage.SeriesRef, error) {
+			c.collector.AppendMetric(l, t, v)
+			return ref, nil
+		}),
+	)
+
+	opts.OnStateChange(Exports{Receiver: receiver})
+	return c, nil
+}
+
+// Update implements component.Component
+func (c *Component) Update(args component.Arguments) error {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	newArgs := args.(Arguments)
+
+	// If namespace, subsystem, or labels changed, recreate collector
+	if newArgs.Namespace != c.args.Namespace ||
+		newArgs.Subsystem != c.args.Subsystem ||
+		!mapsEqual(newArgs.Labels, c.args.Labels) {
+
+		// Unregister old collector
+		c.registerer.Unregister(c.collector)
+
+		// Create new collector
+		c.collector = NewMetricsCollector(newArgs.Namespace, newArgs.Subsystem, newArgs.Labels)
+
+		// Register new collector
+		err := c.registerer.Register(c.collector)
+		if err != nil {
+			// Try to restore old collector; ignore error since we're already handling one.
+			c.collector = NewMetricsCollector(c.args.Namespace, c.args.Subsystem, c.args.Labels)
+			_ = c.registerer.Register(c.collector)
+			return err
+		}
+	}
+
+	c.args = newArgs
+	return nil
+}
+
+// Run implements component.Component
+func (c *Component) Run(ctx context.Context) error {
+	<-ctx.Done()
+
+	// Unregister the collector when component stops
+	c.registerer.Unregister(c.collector)
+	return nil
+}
+
+// mapsEqual checks if two maps are equal
+func mapsEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// noop is a no-op Appendable
+type noop struct{}
+
+func (n noop) Appender(ctx context.Context) storage.Appender {
+	return noopAppender{}
+}
+
+type noopAppender struct{}
+
+func (a noopAppender) Append(ref storage.SeriesRef, l labels.Labels, t int64, v float64) (storage.SeriesRef, error) {
+	return ref, nil
+}
+
+func (a noopAppender) AppendExemplar(ref storage.SeriesRef, l labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
+	return ref, nil
+}
+
+func (a noopAppender) AppendHistogram(ref storage.SeriesRef, l labels.Labels, t int64, h *histogram.Histogram, fh *histogram.FloatHistogram) (storage.SeriesRef, error) {
+	return ref, nil
+}
+
+func (a noopAppender) AppendSTZeroSample(ref storage.SeriesRef, l labels.Labels, t, st int64) (storage.SeriesRef, error) {
+	return ref, nil
+}
+
+func (a noopAppender) AppendHistogramSTZeroSample(ref storage.SeriesRef, l labels.Labels, t, st int64, h *histogram.Histogram, fh *histogram.FloatHistogram) (storage.SeriesRef, error) {
+	return ref, nil
+}
+
+func (a noopAppender) UpdateMetadata(ref storage.SeriesRef, l labels.Labels, m metadata.Metadata) (storage.SeriesRef, error) {
+	return ref, nil
+}
+
+func (a noopAppender) SetOptions(_ *storage.AppendOptions) { /* no-op */ }
+
+func (a noopAppender) Commit() error {
+	return nil
+}
+
+func (a noopAppender) Rollback() error {
+	return nil
+}
+
+// _ ensures noop implements storage.Appendable
+var _ storage.Appendable = noop{}

--- a/internal/component/prometheus/expose/expose_test.go
+++ b/internal/component/prometheus/expose/expose_test.go
@@ -1,0 +1,148 @@
+package expose
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/internal/component"
+)
+
+func TestNew_ExportsReceiver(t *testing.T) {
+	var exported Exports
+	reg := prometheus.NewRegistry()
+
+	comp, err := New(component.Options{
+		ID:     "prometheus.expose.test",
+		Logger: log.NewNopLogger(),
+		OnStateChange: func(e component.Exports) {
+			exported = e.(Exports)
+		},
+		Registerer: reg,
+	}, Arguments{})
+	require.NoError(t, err)
+	require.NotNil(t, comp)
+	require.NotNil(t, exported.Receiver, "receiver export must be set")
+}
+
+func TestAppendMetric_AppearsInCollect(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	collector := NewMetricsCollector("", "", nil)
+	require.NoError(t, reg.Register(collector))
+
+	lbls := labels.FromStrings(model.MetricNameLabel, "my_metric", "job", "test")
+	collector.AppendMetric(lbls, time.Now().UnixMilli(), 42.0)
+
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	require.Len(t, mfs, 1)
+	require.Equal(t, "my_metric", mfs[0].GetName())
+	require.InDelta(t, 42.0, mfs[0].Metric[0].Gauge.GetValue(), 0.001)
+}
+
+func TestAppendMetric_GlobalLabels(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	collector := NewMetricsCollector("", "", map[string]string{"env": "prod"})
+	require.NoError(t, reg.Register(collector))
+
+	lbls := labels.FromStrings(model.MetricNameLabel, "my_metric", "job", "test")
+	collector.AppendMetric(lbls, time.Now().UnixMilli(), 1.0)
+
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	require.Len(t, mfs, 1)
+
+	metric := mfs[0].Metric[0]
+	labelMap := make(map[string]string)
+	for _, lp := range metric.Label {
+		labelMap[lp.GetName()] = lp.GetValue()
+	}
+	require.Equal(t, "prod", labelMap["env"])
+	require.Equal(t, "test", labelMap["job"])
+}
+
+func TestAppendMetric_NamespacedMetricName(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	collector := NewMetricsCollector("ns", "sub", nil)
+	require.NoError(t, reg.Register(collector))
+
+	lbls := labels.FromStrings(model.MetricNameLabel, "my_metric")
+	collector.AppendMetric(lbls, time.Now().UnixMilli(), 7.0)
+
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	require.Len(t, mfs, 1)
+	require.Equal(t, "ns_sub_my_metric", mfs[0].GetName())
+}
+
+func TestAppendMetric_UpdatesExistingSeries(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	collector := NewMetricsCollector("", "", nil)
+	require.NoError(t, reg.Register(collector))
+
+	lbls := labels.FromStrings(model.MetricNameLabel, "my_metric")
+	collector.AppendMetric(lbls, time.Now().UnixMilli(), 1.0)
+	collector.AppendMetric(lbls, time.Now().UnixMilli(), 99.0)
+
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	require.Len(t, mfs[0].Metric, 1, "same series must not be duplicated")
+	require.InDelta(t, 99.0, mfs[0].Metric[0].Gauge.GetValue(), 0.001)
+}
+
+func TestUpdate_RecreatesCollectorOnChange(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	var exported Exports
+
+	comp, err := New(component.Options{
+		ID:     "prometheus.expose.test",
+		Logger: log.NewNopLogger(),
+		OnStateChange: func(e component.Exports) {
+			exported = e.(Exports)
+		},
+		Registerer: reg,
+	}, Arguments{Namespace: "old"})
+	require.NoError(t, err)
+	require.NotNil(t, exported.Receiver)
+
+	// Override to isolated registry
+	comp.registerer = reg
+
+	err = comp.Update(Arguments{Namespace: "new"})
+	require.NoError(t, err)
+	require.Equal(t, "new", comp.args.Namespace)
+}
+
+func TestRun_UnregistersOnStop(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	collector := NewMetricsCollector("", "", nil)
+	require.NoError(t, reg.Register(collector))
+
+	comp := &Component{
+		collector:  collector,
+		registerer: reg,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- comp.Run(ctx)
+	}()
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after context cancel")
+	}
+
+	// After Run returns the collector should be unregistered; re-registering should succeed
+	require.NoError(t, reg.Register(collector))
+}

--- a/internal/component/prometheus/expose/metrics.go
+++ b/internal/component/prometheus/expose/metrics.go
@@ -1,0 +1,164 @@
+package expose
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"google.golang.org/protobuf/proto"
+)
+
+// MetricSample holds a single metric sample
+type MetricSample struct {
+	Labels    labels.Labels
+	Timestamp int64
+	Value     float64
+}
+
+// MetricsCollector implements prometheus.Collector and stores metrics in memory
+type MetricsCollector struct {
+	mut          sync.RWMutex
+	namespace    string
+	subsystem    string
+	globalLabels labels.Labels
+
+	// Store metrics by metric name for efficient collection
+	metrics map[string]*MetricSample
+}
+
+// NewMetricsCollector creates a new MetricsCollector
+func NewMetricsCollector(namespace, subsystem string, globalLabels map[string]string) *MetricsCollector {
+	builder := labels.NewBuilder(labels.EmptyLabels())
+	for k, v := range globalLabels {
+		builder.Set(k, v)
+	}
+	lbls := builder.Labels()
+
+	return &MetricsCollector{
+		namespace:    namespace,
+		subsystem:    subsystem,
+		globalLabels: lbls,
+		metrics:      make(map[string]*MetricSample),
+	}
+}
+
+// AppendMetric adds or updates a metric sample
+func (mc *MetricsCollector) AppendMetric(lbls labels.Labels, timestamp int64, value float64) {
+	mc.mut.Lock()
+	defer mc.mut.Unlock()
+
+	// Get metric name
+	metricName := lbls.Get(model.MetricNameLabel)
+	if metricName == "" {
+		return
+	}
+
+	// Combine with global labels
+	builder := labels.NewBuilder(lbls)
+	mc.globalLabels.Range(func(lbl labels.Label) {
+		if lbls.Get(lbl.Name) == "" {
+			builder.Set(lbl.Name, lbl.Value)
+		}
+	})
+
+	// Apply namespace and subsystem prefixes if specified
+	if mc.namespace != "" || mc.subsystem != "" {
+		builder.Set(model.MetricNameLabel, prometheus.BuildFQName(mc.namespace, mc.subsystem, metricName))
+	}
+
+	finalLabels := builder.Labels()
+	key := finalLabels.String()
+
+	mc.metrics[key] = &MetricSample{
+		Labels:    finalLabels,
+		Timestamp: timestamp,
+		Value:     value,
+	}
+}
+
+// Collect implements prometheus.Collector
+func (mc *MetricsCollector) Collect(ch chan<- prometheus.Metric) {
+	mc.mut.RLock()
+	defer mc.mut.RUnlock()
+
+	for _, sample := range mc.metrics {
+		metric := newMetricFromSample(sample)
+		if metric != nil {
+			ch <- metric
+		}
+	}
+}
+
+// Describe implements prometheus.Collector.
+// This is an unchecked collector — metric names are determined dynamically at
+// runtime from the incoming time series, so no descriptors are sent.
+func (mc *MetricsCollector) Describe(_ chan<- *prometheus.Desc) {
+	// Intentionally empty: unchecked collector with dynamic metric names.
+}
+
+// newMetricFromSample converts a MetricSample to a prometheus.Metric
+func newMetricFromSample(sample *MetricSample) prometheus.Metric {
+	metricName := sample.Labels.Get(model.MetricNameLabel)
+	labelNames := make([]string, 0)
+	labelValues := make([]string, 0)
+
+	sample.Labels.Range(func(lbl labels.Label) {
+		if lbl.Name != model.MetricNameLabel {
+			labelNames = append(labelNames, lbl.Name)
+			labelValues = append(labelValues, lbl.Value)
+		}
+	})
+
+	desc := prometheus.NewDesc(metricName, "Metric from prometheus.expose", labelNames, nil)
+
+	// Create a gauge metric value
+	value := &dto.Metric{
+		Gauge: &dto.Gauge{
+			Value: proto.Float64(sample.Value),
+		},
+		Label: labelPairsFromLabels(labelNames, labelValues),
+	}
+	if sample.Timestamp > 0 {
+		value.TimestampMs = proto.Int64(sample.Timestamp)
+	}
+
+	return newCustomMetric(desc, value)
+}
+
+// customMetric implements prometheus.Metric
+type customMetric struct {
+	desc   *prometheus.Desc
+	metric *dto.Metric
+}
+
+func newCustomMetric(desc *prometheus.Desc, metric *dto.Metric) prometheus.Metric {
+	return &customMetric{
+		desc:   desc,
+		metric: metric,
+	}
+}
+
+func (m *customMetric) Desc() *prometheus.Desc {
+	return m.desc
+}
+
+func (m *customMetric) Write(out *dto.Metric) error {
+	out.Label = m.metric.Label
+	out.Gauge = m.metric.Gauge
+	out.TimestampMs = m.metric.TimestampMs
+	return nil
+}
+
+// labelPairsFromLabels creates label pairs for the metric
+func labelPairsFromLabels(names, values []string) []*dto.LabelPair {
+	pairs := make([]*dto.LabelPair, len(names))
+	for i := range names {
+		pairs[i] = &dto.LabelPair{
+			Name:  proto.String(names[i]),
+			Value: proto.String(values[i]),
+		}
+	}
+	return pairs
+}


### PR DESCRIPTION


<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style with a capitalized
  description, e.g. `feat(scope): Add the thing` (not `add the thing`). For
  details on this, check out the Contributors Guide linked above.
-->

### Brief description of Pull Request

Add a new `prometheus.expose` component that receives Prometheus metrics via
`forward_to` and re-exposes them on Alloy's own `/metrics` endpoint. This
allows scraped or forwarded metrics to be surfaced as part of Alloy's
self-monitoring without requiring an external remote_write target.


### Pull Request Details

The component:
- Accepts metrics through a `receiver` export (compatible with any
  `forward_to` target)
- Stores the latest value per time series in memory
- Registers a dynamic Prometheus collector against `prometheus.DefaultRegisterer`
  so metrics appear at `http://<alloy-host>:12345/metrics`
- Supports optional `namespace`, `subsystem`, and global `labels` arguments
  for metric name prefixing and label injection

**Known limitation:** multiple `prometheus.expose` instances in the same
config will conflict if they receive metrics with identical names, since all
instances share `DefaultRegisterer`.


### Issue(s) fixed by this Pull Request

Fixes #576 


### Notes to the Reviewer

1. Stability is set to Experimental as this is a new component.
2.  The component uses an unchecked prometheus. Collector (empty Describe) because metric names are determined dynamically from incoming time series.
3. All metrics are treated as gauges — counter/histogram types are not distinguished at this stage.


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [x] Tests updated

