### PR TITLE
fix(remotewrite): Use blocking send with timeout in test server

### DIFF
--- a/internal/component/prometheus/remotewrite/remote_write_test.go
+++ b/internal/component/prometheus/remotewrite/remote_write_test.go
@@ -556,8 +556,8 @@ func newTestServer(t *testing.T, writeResult chan string, rwVersion RemoteWriteV
 
 			select {
 			case writeResult <- string(reqJson):
-			default:
-				require.Fail(t, "failed to send remote_write result over channel")
+			case <-time.After(time.Minute):
+				require.Fail(t, "timed out waiting to send remote_write result over channel")
 			}
 		}))
 	case RemoteWriteVersionV2:
@@ -573,8 +573,8 @@ func newTestServer(t *testing.T, writeResult chan string, rwVersion RemoteWriteV
 
 			select {
 			case writeResult <- string(reqJson):
-			default:
-				require.Fail(t, "failed to send remote_write result over channel")
+			case <-time.After(time.Minute):
+				require.Fail(t, "timed out waiting to send remote_write result over channel")
 			}
 
 			// If we don't set these headers, then the client will think that the write failed.


### PR DESCRIPTION
### Brief description of Pull Request

Fix a flaky `TestUpdate` test that was failing intermittently on Windows CI, https://github.com/grafana/alloy/actions/runs/25514067945.

### PR Checklist

- [x] Tests updated