### PR TITLE
fix(loki.process): Make limit stage shutdown cancelable

### DIFF
--- a/internal/component/loki/process/stages/limit.go
+++ b/internal/component/loki/process/stages/limit.go
@@ -42,10 +42,13 @@ func newLimitStage(logger *slog.Logger, cfg LimitConfig, registerer prometheus.R
 		cfg.MaxDistinctLabels = MinReasonableMaxDistinctLabels
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
 	r := &limitStage{
 		logger:    logger,
 		cfg:       cfg,
 		dropCount: getDropCountMetric(registerer),
+		ctx:       ctx,
+		cancel:    cancel,
 	}
 
 	if cfg.ByLabelName != "" {
@@ -79,6 +82,12 @@ type limitStage struct {
 	rateLimiterByLabel GenerationalMap[model.LabelValue, *rate.Limiter]
 	dropCount          *prometheus.CounterVec
 	dropCountByLabel   *prometheus.CounterVec
+	ctx                context.Context
+	cancel             context.CancelFunc
+}
+
+func (m *limitStage) Stop() {
+	m.cancel()
 }
 
 func (m *limitStage) Run(in chan Entry) chan Entry {
@@ -117,8 +126,7 @@ func (m *limitStage) shouldThrottle(labels model.LabelSet) bool {
 		m.dropCount.WithLabelValues(ratelimitDropReason).Inc()
 		return true
 	}
-	_ = m.rateLimiter.Wait(context.Background())
-	return false
+	return m.rateLimiter.Wait(m.ctx) != nil
 }
 
 // Cleanup implements Stage.

--- a/internal/component/loki/process/stages/limit_test.go
+++ b/internal/component/loki/process/stages/limit_test.go
@@ -4,11 +4,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/loki/pkg/push"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/featuregate"
 	"github.com/grafana/alloy/internal/runtime/logging"
 )
@@ -43,8 +45,15 @@ stage.limit {
 		rate  = 1
 		burst = 1
 		drop  = true
-		
+
 		by_label_name = "app"
+}`
+
+var testLimitWaitShutdownAlloy = `
+stage.limit {
+		rate  = 0.1
+		burst = 1
+		drop  = false
 }`
 
 var testNonAppLogLine = `
@@ -88,6 +97,37 @@ func TestLimitDropPipeline(t *testing.T) {
 	// Only the second line will go through.
 	assert.Len(t, out, 1)
 	assert.Equal(t, out[0].Line, testMatchLogLineApp1)
+}
+
+func assertPipelineStopsPromptly(t *testing.T, config string) {
+	pl, err := NewPipeline(logging.NewSlogNop(), loadConfig(config), prometheus.NewRegistry(), featuregate.StabilityGenerallyAvailable)
+	require.NoError(t, err)
+
+	in := make(chan loki.Entry)
+	out := make(chan loki.Entry, 1)
+	handler := pl.Start(in, out)
+
+	entry := loki.Entry{
+		Labels: model.LabelSet{"app": "loki"},
+		Entry:  push.Entry{Line: testMatchLogLineApp1, Timestamp: time.Now()},
+	}
+
+	in <- entry
+	<-out       // burst consumed; next Wait() will block
+	in <- entry // blocks the limit stage in rateLimiter.Wait
+
+	done := make(chan struct{})
+	go func() { defer close(done); handler.Stop() }()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("EntryHandler.Stop() did not return within 2s")
+	}
+}
+
+func TestLimitWaitPipelineShutdown(t *testing.T) {
+	assertPipelineStopsPromptly(t, testLimitWaitShutdownAlloy)
 }
 
 // TestLimitByLabelPipeline is used to verify we properly parse the yaml config and create a working pipeline

--- a/internal/component/loki/process/stages/match.go
+++ b/internal/component/loki/process/stages/match.go
@@ -193,3 +193,9 @@ func (m *matcherStage) Cleanup() {
 		m.pipeline.Cleanup()
 	}
 }
+
+func (m *matcherStage) Stop() {
+	if m.pipeline != nil { // nil for MatchActionDrop matchers, see Cleanup
+		m.pipeline.Stop()
+	}
+}

--- a/internal/component/loki/process/stages/match_test.go
+++ b/internal/component/loki/process/stages/match_test.go
@@ -245,3 +245,18 @@ func TestMatchStage_NewPipelineErrorIsWrapped(t *testing.T) {
 	require.ErrorContains(t, err, "match stage failed to create pipeline")
 	require.ErrorContains(t, errors.Unwrap(err), "invalid stage config")
 }
+
+var testMatchNestedLimitAlloy = `
+stage.match {
+		selector = "{app=\"loki\"}"
+		action = "keep"
+		stage.limit {
+				rate  = 0.1
+				burst = 1
+				drop  = false
+		}
+}`
+
+func TestMatchNestedLimitShutdown(t *testing.T) {
+	assertPipelineStopsPromptly(t, testMatchNestedLimitAlloy)
+}

--- a/internal/component/loki/process/stages/pipeline.go
+++ b/internal/component/loki/process/stages/pipeline.go
@@ -107,7 +107,10 @@ func (p *Pipeline) Start(in chan loki.Entry, out chan<- loki.Entry) loki.EntryHa
 	}))
 
 	return loki.NewEntryHandler(in, func() {
-		once.Do(func() { cancel() })
+		once.Do(func() {
+			cancel()
+			p.Stop()
+		})
 		wg.Wait()
 		p.Cleanup()
 	})
@@ -134,6 +137,20 @@ func (p *Pipeline) Run(in chan Entry) chan Entry {
 func (p *Pipeline) Cleanup() {
 	for _, s := range p.stages {
 		s.Cleanup()
+	}
+}
+
+// Stop implements Stopper.
+func (p *Pipeline) Stop() {
+	for _, s := range p.stages {
+		stopper, ok := s.(Stopper)
+		if !ok {
+			continue
+		}
+		func() {
+			defer func() { _ = recover() }()
+			stopper.Stop()
+		}()
 	}
 }
 

--- a/internal/component/loki/process/stages/stage.go
+++ b/internal/component/loki/process/stages/stage.go
@@ -28,6 +28,13 @@ type Stage interface {
 	Cleanup()
 }
 
+// Stopper is an optional interface for stages that need an out-of-band signal
+// to unblock goroutines during shutdown. Implementations must not block,
+// panic, or assume Run has stopped.
+type Stopper interface {
+	Stop()
+}
+
 // stageProcessor Allow to transform a Processor (old synchronous pipeline stage) into an async Stage
 type stageProcessor struct {
 	Processor


### PR DESCRIPTION
### Pull Request Details

When `loki.process` has `stage.limit { drop = false }`, the stage's
`shouldThrottle` calls `rateLimiter.Wait`, which blocks until the next
token. The Run goroutine only exits its range loop between iterations,
so a goroutine inside Wait doesn't observe `close(in)`. With a low
rate, `EntryHandler.Stop` hangs for the full token interval.

This adds an optional `Stopper` interface (`Stop()`) called by
`Pipeline.Stop` before `wg.Wait`. `limitStage` cancels its internal
context to unblock Wait. `Pipeline` itself implements `Stopper` so
nested inner pipelines (via `matcherStage`) forward recursively.

### Scope

The by-label code path (`stage.limit { by_label_name = "..." }`) is
not affected; `validateLimitConfig` requires `drop = true` with
`by_label_name`, so that path uses `rl.Allow()` and never reaches a
Wait call.

### Issue(s) fixed by this Pull Request

None. Goroutine leak triggered only on shutdown with non-trivial rate limits.

### Notes to the Reviewer

Repro: `stage.limit { rate = 1, burst = 1, drop = false }`, sustained
input, SIGTERM. Without the fix, alloy hangs.

Regression tests in `limit_test.go` and `match_test.go` share an
`assertPipelineStopsPromptly` helper using channel-based synchronization:
send one entry, receive it (signaling the first iteration completed),
send a second entry that blocks Wait, assert `EntryHandler.Stop`
returns within 2s. The `match_test.go` case exercises
`matcherStage.Stop` forwarding through its inner Pipeline.

Verified with `go test -race -count=1 ./internal/component/loki/process/...`
and `make lint`.

### PR Checklist

- [ ] Documentation added (n/a)
- [x] Tests updated
- [ ] Config converters updated (n/a)
