### PR TITLE
fix(loki.process): Wrap NewPipeline error correctly in match stage

### DIFF
--- a/internal/component/loki/process/stages/match.go
+++ b/internal/component/loki/process/stages/match.go
@@ -73,7 +73,7 @@ func newMatcherStage(slogger *slog.Logger, config MatchConfig, registerer promet
 		var err error
 		pl, err = NewPipeline(slogger, config.Stages, registerer, minStability)
 		if err != nil {
-			return nil, fmt.Errorf("%v: %w", err, fmt.Errorf("match stage failed to create pipeline from config: %v", config))
+			return nil, fmt.Errorf("match stage failed to create pipeline from config %+v: %w", config, err)
 		}
 	}
 

--- a/internal/component/loki/process/stages/match_test.go
+++ b/internal/component/loki/process/stages/match_test.go
@@ -1,6 +1,7 @@
 package stages
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -226,4 +227,43 @@ func TestValidateMatcherConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestMatchStage_NewPipelineErrorIsWrapped verifies that when newMatcherStage's
+// NewPipeline call fails, the returned error wraps the original error from
+// NewPipeline so callers can use errors.Unwrap / errors.Is / errors.As to
+// inspect the underlying cause.
+//
+// Regression test for the reversed %w wrap that was previously at match.go:76,
+// where the %w slot held a fresh fmt.Errorf instead of the actual err from
+// NewPipeline. With the bug, errors.Unwrap returned the dummy fmt.Errorf
+// ("match stage failed to create pipeline...") and lost the original error
+// context. With the fix, errors.Unwrap returns NewPipeline's error.
+func TestMatchStage_NewPipelineErrorIsWrapped(t *testing.T) {
+	// Build a match config whose inner pipeline fails to construct: the
+	// regex stage gets an unclosed character class, which regexp.Compile
+	// rejects.
+	cfg := StageConfig{
+		MatchConfig: &MatchConfig{
+			Selector: `{app="loki"}`,
+			Action:   MatchActionKeep,
+			Stages: []StageConfig{
+				{RegexConfig: &RegexConfig{Expression: "[unclosed"}},
+			},
+		},
+	}
+
+	logger := util.TestAlloyLogger(t)
+	_, err := New(logger.Slog(), cfg, prometheus.NewRegistry(), featuregate.StabilityGenerallyAvailable)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "match stage failed to create pipeline")
+
+	// The returned error must unwrap to NewPipeline's error. Without the
+	// fix, errors.Unwrap returns a fresh fmt.Errorf("match stage failed to
+	// create pipeline from config: ...") which has no further unwrap chain
+	// and does not contain "invalid stage config".
+	unwrapped := errors.Unwrap(err)
+	require.NotNil(t, unwrapped, "match stage error should unwrap to NewPipeline's error")
+	require.ErrorContains(t, unwrapped, "invalid stage config",
+		"errors.Unwrap should reach NewPipeline's wrap, not a dummy fmt.Errorf")
 }

--- a/internal/component/loki/process/stages/match_test.go
+++ b/internal/component/loki/process/stages/match_test.go
@@ -229,20 +229,7 @@ func TestValidateMatcherConfig(t *testing.T) {
 	}
 }
 
-// TestMatchStage_NewPipelineErrorIsWrapped verifies that when newMatcherStage's
-// NewPipeline call fails, the returned error wraps the original error from
-// NewPipeline so callers can use errors.Unwrap / errors.Is / errors.As to
-// inspect the underlying cause.
-//
-// Regression test for the reversed %w wrap that was previously at match.go:76,
-// where the %w slot held a fresh fmt.Errorf instead of the actual err from
-// NewPipeline. With the bug, errors.Unwrap returned the dummy fmt.Errorf
-// ("match stage failed to create pipeline...") and lost the original error
-// context. With the fix, errors.Unwrap returns NewPipeline's error.
 func TestMatchStage_NewPipelineErrorIsWrapped(t *testing.T) {
-	// Build a match config whose inner pipeline fails to construct: the
-	// regex stage gets an unclosed character class, which regexp.Compile
-	// rejects.
 	cfg := StageConfig{
 		MatchConfig: &MatchConfig{
 			Selector: `{app="loki"}`,
@@ -255,15 +242,6 @@ func TestMatchStage_NewPipelineErrorIsWrapped(t *testing.T) {
 
 	logger := util.TestAlloyLogger(t)
 	_, err := New(logger.Slog(), cfg, prometheus.NewRegistry(), featuregate.StabilityGenerallyAvailable)
-	require.Error(t, err)
 	require.ErrorContains(t, err, "match stage failed to create pipeline")
-
-	// The returned error must unwrap to NewPipeline's error. Without the
-	// fix, errors.Unwrap returns a fresh fmt.Errorf("match stage failed to
-	// create pipeline from config: ...") which has no further unwrap chain
-	// and does not contain "invalid stage config".
-	unwrapped := errors.Unwrap(err)
-	require.NotNil(t, unwrapped, "match stage error should unwrap to NewPipeline's error")
-	require.ErrorContains(t, unwrapped, "invalid stage config",
-		"errors.Unwrap should reach NewPipeline's wrap, not a dummy fmt.Errorf")
+	require.ErrorContains(t, errors.Unwrap(err), "invalid stage config")
 }


### PR DESCRIPTION
## Pull Request Details

In `newMatcherStage`, the error wrap for a failed inner-pipeline
construction had its `fmt.Errorf` arguments reversed. The buggy line
at `match.go:76`:

```go
return nil, fmt.Errorf("%v: %w", err, fmt.Errorf("match stage failed to create pipeline from config: %v", config))
```

The `%w` verb wraps an error so `errors.Is` and `errors.As` can
unwrap it. Here the `%w` slot wraps the *inner* `fmt.Errorf` ("match
stage failed..."), not the actual `err` from `NewPipeline`. So
`errors.Unwrap`, `errors.Is`, and `errors.As` all silently fail to
reach the original error, which is reduced to a stringified message
in the `%v` slot.

The adjacent line 82 has the correct shape: `fmt.Errorf("%v: %w",
"error parsing pipeline", err)`, with a static string in `%v` and
the real `err` in `%w`.

The fix:

```go
return nil, fmt.Errorf("match stage failed to create pipeline from config %+v: %w", config, err)
```

### Issue(s) fixed by this Pull Request

No observable user-visible bug today (no callers in alloy use
`errors.Is`/`errors.As` on the returned error from match stage
construction), but the wrap is incorrect and would silently fail
sentinel-error matching if any caller starts using it. This is
correctness preservation for future callers.

### Notes to the Reviewer

`TestMatchStage_NewPipelineErrorIsWrapped` builds a match config with
a deliberately invalid inner regex, then asserts `errors.Unwrap`
reaches `NewPipeline`'s wrap (which contains `"invalid stage config"`).
Without the fix, `errors.Unwrap` returns the dummy fresh `fmt.Errorf`
and the assertion fails with a clear error. With the fix it passes.

Verified deterministically with `go test -race -count=3` and `make lint`.

### PR Checklist

- [ ] Documentation added (n/a)
- [x] Tests updated
- [ ] Config converters updated (n/a)
