### PR TITLE
fix(alloycli): Use filepath.Base for CLI Use name to fix shell completions

### DIFF
--- a/internal/alloycli/alloycli.go
+++ b/internal/alloycli/alloycli.go
@@ -4,6 +4,7 @@ package alloycli
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/grafana/alloy/internal/build"
 	"github.com/spf13/cobra"
@@ -11,7 +12,7 @@ import (
 
 func Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:     fmt.Sprintf("%s [global options] <subcommand>", os.Args[0]),
+		Use:     fmt.Sprintf("%s [global options] <subcommand>", filepath.Base(os.Args[0])),
 		Short:   "Grafana Alloy",
 		Version: build.Print("alloy"),
 


### PR DESCRIPTION
### Brief description of Pull Request

Using os.Args[0] directly in the cobra command's Use field causes broken shell completion output when the binary is invoked with an absolute path (e.g. `/opt/homebrew/bin/alloy completion fish`). `filepath.Base` extracts just the command name, preserving the dynamic CLI name while generating correct completions.