### PR TITLE
chore: Fix typo 'occured' -> 'occurred' in homebrew bump action

### DIFF
--- a/.github/actions/homebrew-bump-formula/main.rb
+++ b/.github/actions/homebrew-bump-formula/main.rb
@@ -174,7 +174,7 @@ module Homebrew
       end
     end
 
-    # Die if error occured
+    # Die if error occurred
     odie err if err
   end
 end


### PR DESCRIPTION
Fixes `occured` -> `occurred` typo in a comment inside `.github/actions/homebrew-bump-formula/main.rb`. Comment-only change.