### PR TITLE
fix(integration-tests): Forward GO_TAGS to k8s integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,13 +205,13 @@ integration-test-docker:
 
 .PHONY: integration-test-k8s
 integration-test-k8s:
-	$(GO_ENV) go run ./integration-tests/k8s/runner $(RUN_ARGS)
+	$(GO_ENV) go run ./integration-tests/k8s/runner --test-tags='$(GO_TAGS)' $(RUN_ARGS)
 
 # Interactive mode for local development: pick reuse-cluster, skip-image-builds,
 # and shard/packages from a TUI menu before tests run.
 .PHONY: integration-test-k8s-local-dev
 integration-test-k8s-local-dev:
-	$(GO_ENV) go run ./integration-tests/k8s/runner --interactive $(RUN_ARGS)
+	$(GO_ENV) go run ./integration-tests/k8s/runner --interactive --test-tags='$(GO_TAGS)' $(RUN_ARGS)
 
 # Windows service integration test. Runs only on Windows with Administrator privileges.
 # Builds the Windows installer, runs it, verifies the Alloy service, then uninstalls.

--- a/integration-tests/k8s/runner/main.go
+++ b/integration-tests/k8s/runner/main.go
@@ -231,6 +231,27 @@ func loadImages(cfg config) error {
 	return nil
 }
 
+// goTestBuildTags returns the -tags value for `go test`, mirroring the
+// Makefile's GO_TAGS handling: gore2regex is always included unless already
+// present, so loki.secretfilter uses go-re2 instead of silently falling back
+// to stdlib regexp.
+func goTestBuildTags() string {
+	raw := strings.TrimSpace(os.Getenv("GO_TAGS"))
+	var tags []string
+	for _, t := range strings.Fields(strings.ReplaceAll(raw, ",", " ")) {
+		if t != "" {
+			tags = append(tags, t)
+		}
+	}
+	for _, t := range tags {
+		if t == "gore2regex" {
+			return strings.Join(tags, ",")
+		}
+	}
+	tags = append([]string{"gore2regex"}, tags...)
+	return strings.Join(tags, ",")
+}
+
 // runGoTests runs `go test` for the configured patterns. We intentionally
 // leave package-level parallelism on (no `-p 1`): each test package owns a
 // distinct namespace, so concurrent packages don't conflict on the shared
@@ -241,7 +262,7 @@ func runGoTests(cfg config) error {
 	if len(patterns) == 0 {
 		patterns = []string{defaultTestPackages}
 	}
-	args := []string{"test", "-v", "-count=1", "-timeout", "30m"}
+	args := []string{"test", "-v", "-count=1", "-timeout", "30m", "-tags=" + goTestBuildTags()}
 	args = append(args, patterns...)
 	if cfg.shard != "" {
 		args = append(args, "-args", "-shard="+cfg.shard)

--- a/integration-tests/k8s/runner/main.go
+++ b/integration-tests/k8s/runner/main.go
@@ -33,6 +33,7 @@ type config struct {
 	shard           string
 	packages        []string
 	interactive     bool
+	testTags        string
 }
 
 func main() {
@@ -113,6 +114,7 @@ func parseFlags() (config, error) {
 	fs.StringVar(&pkgFlag, "package", "", "Restrict tests to one package path or pattern (default: "+defaultTestPackages+")")
 	fs.StringVar(&cfg.alloyImage, "alloy-image", "grafana/alloy:latest", "Alloy image (repo:tag) used by tests; must exist locally or in the kind cluster")
 	fs.BoolVar(&cfg.interactive, "interactive", false, "Pick run options (reuse-cluster, skip-image-builds, shard/packages) via an interactive menu before running")
+	fs.StringVar(&cfg.testTags, "test-tags", "", "Build tags (space- or comma-separated) forwarded to `go test -tags=...`. Empty means no -tags flag is passed. Makefile targets pass $(GO_TAGS) here so the Makefile remains the single source of truth for tags like gore2regex")
 	fs.Usage = func() {
 		fmt.Println("Usage: go run ./integration-tests/k8s/runner [flags]")
 		fmt.Println()
@@ -231,24 +233,16 @@ func loadImages(cfg config) error {
 	return nil
 }
 
-// goTestBuildTags returns the -tags value for `go test`, mirroring the
-// Makefile's GO_TAGS handling: gore2regex is always included unless already
-// present, so loki.secretfilter uses go-re2 instead of silently falling back
-// to stdlib regexp.
-func goTestBuildTags() string {
-	raw := strings.TrimSpace(os.Getenv("GO_TAGS"))
+// normalizeTestTags converts a user-supplied space- or comma-separated tag
+// list into the comma-separated form `go test -tags=` expects. Empty input
+// yields the empty string so callers can omit the flag entirely.
+func normalizeTestTags(raw string) string {
 	var tags []string
 	for _, t := range strings.Fields(strings.ReplaceAll(raw, ",", " ")) {
 		if t != "" {
 			tags = append(tags, t)
 		}
 	}
-	for _, t := range tags {
-		if t == "gore2regex" {
-			return strings.Join(tags, ",")
-		}
-	}
-	tags = append([]string{"gore2regex"}, tags...)
 	return strings.Join(tags, ",")
 }
 
@@ -262,7 +256,10 @@ func runGoTests(cfg config) error {
 	if len(patterns) == 0 {
 		patterns = []string{defaultTestPackages}
 	}
-	args := []string{"test", "-v", "-count=1", "-timeout", "30m", "-tags=" + goTestBuildTags()}
+	args := []string{"test", "-v", "-count=1", "-timeout", "30m"}
+	if tags := normalizeTestTags(cfg.testTags); tags != "" {
+		args = append(args, "-tags="+tags)
+	}
 	args = append(args, patterns...)
 	if cfg.shard != "" {
 		args = append(args, "-args", "-shard="+cfg.shard)

--- a/integration-tests/k8s/runner/main.go
+++ b/integration-tests/k8s/runner/main.go
@@ -114,7 +114,7 @@ func parseFlags() (config, error) {
 	fs.StringVar(&pkgFlag, "package", "", "Restrict tests to one package path or pattern (default: "+defaultTestPackages+")")
 	fs.StringVar(&cfg.alloyImage, "alloy-image", "grafana/alloy:latest", "Alloy image (repo:tag) used by tests; must exist locally or in the kind cluster")
 	fs.BoolVar(&cfg.interactive, "interactive", false, "Pick run options (reuse-cluster, skip-image-builds, shard/packages) via an interactive menu before running")
-	fs.StringVar(&cfg.testTags, "test-tags", "", "Build tags (space- or comma-separated) forwarded to `go test -tags=...`. Empty means no -tags flag is passed. Makefile targets pass $(GO_TAGS) here so the Makefile remains the single source of truth for tags like gore2regex")
+	fs.StringVar(&cfg.testTags, "test-tags", "", "Build tags (space- or comma-separated) forwarded to `go test -tags=...`. Empty means no -tags flag is passed")
 	fs.Usage = func() {
 		fmt.Println("Usage: go run ./integration-tests/k8s/runner [flags]")
 		fmt.Println()

--- a/integration-tests/k8s/runner/main_test.go
+++ b/integration-tests/k8s/runner/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import "testing"
+
+func TestNormalizeTestTags(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"whitespace only", "   \t  ", ""},
+		{"single tag", "gore2regex", "gore2regex"},
+		{"space separated", "gore2regex nodocker", "gore2regex,nodocker"},
+		{"comma separated", "gore2regex,nodocker", "gore2regex,nodocker"},
+		{"mixed separators", "gore2regex, nodocker  extra", "gore2regex,nodocker,extra"},
+		{"trailing comma", "gore2regex,", "gore2regex"},
+		{"duplicate separators", "gore2regex,,  ,nodocker", "gore2regex,nodocker"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizeTestTags(tc.in)
+			if got != tc.want {
+				t.Fatalf("normalizeTestTags(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Brief description of Pull Request

Follow-up to https://github.com/grafana/alloy/pull/6125: the k8s integration runner invokes `go test` directly and was not passing any build tags, so `loki.secretfilter` silently fell back to stdlib regex instead of using `gore2regex`/go-re2.

This adds an explicit `--test-tags` flag to the runner. The Makefile targets forward `$(GO_TAGS)` to that flag, so the Makefile remains the single source of truth for default tags (including the `gore2regex` prepend rule). The runner itself does no env reads and applies no defaults.

### PR Checklist

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2a51650-d5f7-49e3-9314-84a7be1e7617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2a51650-d5f7-49e3-9314-84a7be1e7617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

