### PR TITLE
feat(database_observability.mysql): Refactor bulk table metadata collection

### DIFF
--- a/internal/component/database_observability/mysql/collector/schema_details.go
+++ b/internal/component/database_observability/mysql/collector/schema_details.go
@@ -46,6 +46,7 @@ const (
 
 	selectColumnNames = `
 	SELECT
+		TABLE_NAME,
 		COLUMN_NAME,
 		COLUMN_DEFAULT,
 		IS_NULLABLE,
@@ -55,11 +56,12 @@ const (
 	FROM
 		information_schema.columns
 	WHERE
-		TABLE_SCHEMA = ? AND TABLE_NAME = ?
-	ORDER BY ORDINAL_POSITION ASC`
+		TABLE_SCHEMA = ?
+	ORDER BY TABLE_NAME, ORDINAL_POSITION ASC`
 
 	selectIndexNames = `
 		SELECT
+			table_name,
 			index_name,
 			seq_in_index,
 			column_name,
@@ -70,12 +72,13 @@ const (
 		FROM
 			information_schema.statistics
 		WHERE
-			table_schema = ? and table_name = ?
+			table_schema = ?
 		ORDER BY table_name, index_name, seq_in_index`
 
 	// Ignore 'PRIMARY' constraints, as they're already covered by the query above
 	selectForeignKeys = `
 		SELECT
+			table_name,
 			constraint_name,
 			column_name,
 			referenced_table_name,
@@ -85,7 +88,7 @@ const (
 		WHERE
 			constraint_name <> 'PRIMARY'
 			AND referenced_table_schema is not null
-			AND table_schema = ? and table_name = ?
+			AND table_schema = ?
 		ORDER BY table_name, constraint_name, ordinal_position`
 )
 
@@ -266,47 +269,82 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 		return nil
 	}
 
-	for _, table := range tables {
-		fullyQualifiedTable := fmt.Sprintf("`%s`.`%s`", table.schema, table.tableName)
-		cacheKey := fmt.Sprintf("%s@%d", fullyQualifiedTable, table.updateTime.Unix())
+	// Group tables by schema, preserving the first-seen order so iteration is
+	// deterministic (the bulk tables query already orders by TABLE_SCHEMA).
+	tablesBySchema := map[string][]*tableInfo{}
+	seenSchemas := []string{}
+	for _, t := range tables {
+		if _, seen := tablesBySchema[t.schema]; !seen {
+			seenSchemas = append(seenSchemas, t.schema)
+		}
+		tablesBySchema[t.schema] = append(tablesBySchema[t.schema], t)
+	}
 
-		cacheHit := false
-		if c.cache != nil {
-			if cached, ok := c.cache.Get(cacheKey); ok {
-				table = cached
-				cacheHit = true
-			}
+	for _, schema := range seenSchemas {
+		specs, err := c.fetchSchemaSpecs(ctx, schema)
+		if err != nil {
+			level.Error(c.logger).Log("msg", "failed to fetch schema specs", "schema", schema, "err", err)
+			continue
 		}
 
-		if !cacheHit {
-			table, err = c.fetchTableDefinitions(ctx, fullyQualifiedTable, table)
-			if err != nil {
-				level.Error(c.logger).Log("msg", "failed to get table definitions", "schema", table.schema, "table", table.tableName, "err", err)
-				continue
-			}
+		for _, table := range tablesBySchema[schema] {
+			fullyQualifiedTable := fmt.Sprintf("`%s`.`%s`", table.schema, table.tableName)
+			cacheKey := fmt.Sprintf("%s@%d", fullyQualifiedTable, table.updateTime.Unix())
+
+			cacheHit := false
 			if c.cache != nil {
-				c.cache.Add(cacheKey, table)
+				if cached, ok := c.cache.Get(cacheKey); ok {
+					table = cached
+					cacheHit = true
+				}
 			}
-		}
 
-		c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
-			logging.LevelInfo,
-			OP_CREATE_STATEMENT,
-			fmt.Sprintf(
-				`schema="%s" table="%s" create_statement="%s" table_spec="%s"`,
-				table.schema, table.tableName, table.b64CreateStmt, table.b64TableSpec,
-			),
-		)
+			if !cacheHit {
+				if err := c.fetchCreateStatement(ctx, fullyQualifiedTable, table); err != nil {
+					level.Error(c.logger).Log("msg", "failed to get table create statement", "schema", table.schema, "table", table.tableName, "err", err)
+					continue
+				}
+
+				spec, ok := specs[table.tableName]
+				if !ok {
+					// This might happen if a table is dropped between the tables query and the metadata queries.
+					level.Warn(c.logger).Log("msg", "no bulk metadata rows for table", "schema", table.schema, "table", table.tableName)
+					continue
+				}
+
+				b64Spec, err := encodeTableSpec(spec)
+				if err != nil {
+					level.Error(c.logger).Log("msg", "failed to marshal table spec", "schema", table.schema, "table", table.tableName, "err", err)
+					continue
+				}
+				table.b64TableSpec = b64Spec
+
+				if c.cache != nil {
+					c.cache.Add(cacheKey, table)
+				}
+			}
+
+			c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
+				logging.LevelInfo,
+				OP_CREATE_STATEMENT,
+				fmt.Sprintf(
+					`schema="%s" table="%s" create_statement="%s" table_spec="%s"`,
+					table.schema, table.tableName, table.b64CreateStmt, table.b64TableSpec,
+				),
+			)
+		}
 	}
 
 	return nil
 }
 
-func (c *SchemaDetails) fetchTableDefinitions(ctx context.Context, fullyQualifiedTable string, table *tableInfo) (*tableInfo, error) {
+// fetchCreateStatement runs SHOW CREATE TABLE for a single table and stores the
+// base64-encoded DDL on the provided tableInfo.
+func (c *SchemaDetails) fetchCreateStatement(ctx context.Context, fullyQualifiedTable string, table *tableInfo) error {
 	row := c.dbConnection.QueryRowContext(ctx, showCreateTable+" "+fullyQualifiedTable)
 	if err := row.Err(); err != nil {
 		level.Error(c.logger).Log("msg", "failed to show create table", "schema", table.schema, "table", table.tableName, "err", err)
-		return table, err
+		return err
 	}
 
 	var tableName, createStmt, characterSetClient, collationConnection string
@@ -314,49 +352,57 @@ func (c *SchemaDetails) fetchTableDefinitions(ctx context.Context, fullyQualifie
 	case "BASE TABLE":
 		if err := row.Scan(&tableName, &createStmt); err != nil {
 			level.Error(c.logger).Log("msg", "failed to scan create table", "schema", table.schema, "table", table.tableName, "err", err)
-			return table, err
+			return err
 		}
 	case "VIEW":
 		if err := row.Scan(&tableName, &createStmt, &characterSetClient, &collationConnection); err != nil {
 			level.Error(c.logger).Log("msg", "failed to scan create view", "schema", table.schema, "table", table.tableName, "err", err)
-			return table, err
+			return err
 		}
 	default:
 		level.Error(c.logger).Log("msg", "unknown table type", "schema", table.schema, "table", table.tableName, "table_type", table.tableType)
-		return nil, fmt.Errorf("unknown table type: %s", table.tableType)
+		return fmt.Errorf("unknown table type: %s", table.tableType)
 	}
 	table.b64CreateStmt = base64.StdEncoding.EncodeToString([]byte(createStmt))
-
-	spec, err := c.fetchColumnsDefinitions(ctx, table.schema, table.tableName)
-	if err != nil {
-		level.Error(c.logger).Log("msg", "failed to analyze table spec", "schema", table.schema, "table", table.tableName, "err", err)
-		return table, err
-	}
-	jsonSpec, err := json.Marshal(spec)
-	if err != nil {
-		level.Error(c.logger).Log("msg", "failed to marshal table spec", "schema", table.schema, "table", table.tableName, "err", err)
-		return table, err
-	}
-	table.b64TableSpec = base64.StdEncoding.EncodeToString(jsonSpec)
-
-	return table, nil
+	return nil
 }
 
-func (c *SchemaDetails) fetchColumnsDefinitions(ctx context.Context, schemaName string, tableName string) (*tableSpec, error) {
-	colRS, err := c.dbConnection.QueryContext(ctx, selectColumnNames, schemaName, tableName)
+// encodeTableSpec serializes a tableSpec to base64-encoded JSON.
+func encodeTableSpec(spec *tableSpec) (string, error) {
+	jsonSpec, err := json.Marshal(spec)
 	if err != nil {
-		level.Error(c.logger).Log("msg", "failed to query table columns", "schema", schemaName, "table", tableName, "err", err)
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(jsonSpec), nil
+}
+
+// fetchSchemaSpecs runs three separate queries for a given schema in bulk in order
+// to fetch columns, indexes and foreign keys for all tables in the schema. Then groups the rows by table name.
+// The returned map is keyed by table name; tables with no columns/indexes/FKs are
+// absent.
+func (c *SchemaDetails) fetchSchemaSpecs(ctx context.Context, schema string) (map[string]*tableSpec, error) {
+	specs := map[string]*tableSpec{}
+	specOf := func(name string) *tableSpec {
+		s, ok := specs[name]
+		if !ok {
+			s = &tableSpec{Columns: []columnSpec{}}
+			specs[name] = s
+		}
+		return s
+	}
+
+	colRS, err := c.dbConnection.QueryContext(ctx, selectColumnNames, schema)
+	if err != nil {
+		level.Error(c.logger).Log("msg", "failed to query schema columns", "schema", schema, "err", err)
 		return nil, err
 	}
 	defer colRS.Close()
 
-	tblSpec := &tableSpec{Columns: []columnSpec{}}
-
 	for colRS.Next() {
-		var columnName, isNullable, columnType, columnKey, extra string
+		var tableName, columnName, isNullable, columnType, columnKey, extra string
 		var columnDefault sql.NullString
-		if err := colRS.Scan(&columnName, &columnDefault, &isNullable, &columnType, &columnKey, &extra); err != nil {
-			level.Error(c.logger).Log("msg", "failed to scan table columns", "schema", schemaName, "table", tableName, "err", err)
+		if err := colRS.Scan(&tableName, &columnName, &columnDefault, &isNullable, &columnType, &columnKey, &extra); err != nil {
+			level.Error(c.logger).Log("msg", "failed to scan schema columns", "schema", schema, "err", err)
 			return nil, err
 		}
 
@@ -369,95 +415,107 @@ func (c *SchemaDetails) fetchColumnsDefinitions(ctx context.Context, schemaName 
 			}
 		}
 
-		colSpec := columnSpec{
+		spec := specOf(tableName)
+		spec.Columns = append(spec.Columns, columnSpec{
 			Name:          columnName,
 			Type:          columnType,
 			NotNull:       isNullable == "NO", // "YES" if NULL values can be stored in the column, "NO" if not.
 			AutoIncrement: strings.Contains(extra, "AUTO_INCREMENT"),
 			PrimaryKey:    columnKey == "PRI", // "column_key" is "PRI" if this column a (or part of) PRIMARY KEY
 			DefaultValue:  defaultValue,
-		}
-		tblSpec.Columns = append(tblSpec.Columns, colSpec)
+		})
 	}
 
 	if err := colRS.Err(); err != nil {
-		level.Error(c.logger).Log("msg", "failed to iterate over table columns result set", "schema", schemaName, "table", tableName, "err", err)
+		level.Error(c.logger).Log("msg", "failed to iterate over schema columns result set", "schema", schema, "err", err)
 		return nil, err
 	}
 
-	idxRS, err := c.dbConnection.QueryContext(ctx, selectIndexNames, schemaName, tableName)
+	idxRS, err := c.dbConnection.QueryContext(ctx, selectIndexNames, schema)
 	if err != nil {
-		level.Error(c.logger).Log("msg", "failed to query table indexes", "schema", schemaName, "table", tableName, "err", err)
+		level.Error(c.logger).Log("msg", "failed to query schema indexes", "schema", schema, "err", err)
 		return nil, err
 	}
 	defer idxRS.Close()
 
+	// Track the table whose last appended index we may merge into. When the
+	// table changes we always treat the next index row as a new index, even if
+	// the index name happens to match.
+	var lastTable string
 	for idxRS.Next() {
-		var indexName, indexType string
+		var tableName, indexName, indexType string
 		var seqInIndex, nonUnique int
 		var columnName, expression, nullable sql.NullString
-		if err := idxRS.Scan(&indexName, &seqInIndex, &columnName, &expression, &nullable, &nonUnique, &indexType); err != nil {
-			level.Error(c.logger).Log("msg", "failed to scan table indexes", "schema", schemaName, "table", tableName, "err", err)
+		if err := idxRS.Scan(&tableName, &indexName, &seqInIndex, &columnName, &expression, &nullable, &nonUnique, &indexType); err != nil {
+			level.Error(c.logger).Log("msg", "failed to scan schema indexes", "schema", schema, "err", err)
 			return nil, err
 		}
 
 		// mysql docs describe column and expression as mutually exclusive,
 		// but at least one of them must be present.
 		if !columnName.Valid && !expression.Valid {
-			level.Error(c.logger).Log("msg", "index without a column or expression", "schema", schemaName, "table", tableName, "index", indexName)
+			level.Error(c.logger).Log("msg", "index without a column or expression", "schema", schema, "table", tableName, "index", indexName)
 			continue
 		}
 
-		// Append column to the last index if it's the same as the previous one (i.e. multi-column index)
-		if nIndexes := len(tblSpec.Indexes); nIndexes > 0 && tblSpec.Indexes[nIndexes-1].Name == indexName {
-			lastIndex := &tblSpec.Indexes[nIndexes-1]
-			if len(lastIndex.Columns)+len(lastIndex.Expressions) != seqInIndex-1 {
-				level.Error(c.logger).Log("msg", "unexpected index ordinal position", "schema", schemaName, "table", tableName, "index", indexName, "seq", seqInIndex, "len_columns", len(lastIndex.Columns), "len_expressions", len(lastIndex.Expressions))
+		spec := specOf(tableName)
+
+		// Append column to the last index if it's the same as the previous one
+		// within the same table (i.e. multi-column index).
+		if tableName == lastTable {
+			if nIndexes := len(spec.Indexes); nIndexes > 0 && spec.Indexes[nIndexes-1].Name == indexName {
+				lastIndex := &spec.Indexes[nIndexes-1]
+				if len(lastIndex.Columns)+len(lastIndex.Expressions) != seqInIndex-1 {
+					level.Error(c.logger).Log("msg", "unexpected index ordinal position", "schema", schema, "table", tableName, "index", indexName, "seq", seqInIndex, "len_columns", len(lastIndex.Columns), "len_expressions", len(lastIndex.Expressions))
+					continue
+				}
+
+				if columnName.Valid {
+					lastIndex.Columns = append(lastIndex.Columns, columnName.String)
+				} else if expression.Valid {
+					lastIndex.Expressions = append(lastIndex.Expressions, expression.String)
+				}
 				continue
 			}
-
-			if columnName.Valid {
-				lastIndex.Columns = append(lastIndex.Columns, columnName.String)
-			} else if expression.Valid {
-				lastIndex.Expressions = append(lastIndex.Expressions, expression.String)
-			}
-		} else {
-			idx := indexSpec{
-				Name:     indexName,
-				Type:     indexType,
-				Unique:   nonUnique == 0,                             // 0 if the index cannot contain duplicates, 1 if it can
-				Nullable: nullable.Valid && nullable.String == "YES", // "YES" if the column may contain NULL values
-			}
-
-			if columnName.Valid {
-				idx.Columns = append(idx.Columns, columnName.String)
-			} else if expression.Valid {
-				idx.Expressions = append(idx.Expressions, expression.String)
-			}
-			tblSpec.Indexes = append(tblSpec.Indexes, idx)
 		}
+
+		idx := indexSpec{
+			Name:     indexName,
+			Type:     indexType,
+			Unique:   nonUnique == 0,                             // 0 if the index cannot contain duplicates, 1 if it can
+			Nullable: nullable.Valid && nullable.String == "YES", // "YES" if the column may contain NULL values
+		}
+
+		if columnName.Valid {
+			idx.Columns = append(idx.Columns, columnName.String)
+		} else if expression.Valid {
+			idx.Expressions = append(idx.Expressions, expression.String)
+		}
+		spec.Indexes = append(spec.Indexes, idx)
+		lastTable = tableName
 	}
 
 	if err := idxRS.Err(); err != nil {
-		level.Error(c.logger).Log("msg", "failed to iterate over table indexes result set", "schema", schemaName, "table", tableName, "err", err)
+		level.Error(c.logger).Log("msg", "failed to iterate over schema indexes result set", "schema", schema, "err", err)
 		return nil, err
 	}
 
-	fkRS, err := c.dbConnection.QueryContext(ctx, selectForeignKeys, schemaName, tableName)
+	fkRS, err := c.dbConnection.QueryContext(ctx, selectForeignKeys, schema)
 	if err != nil {
-		level.Error(c.logger).Log("msg", "failed to query table foreign keys", "schema", schemaName, "table", tableName, "err", err)
+		level.Error(c.logger).Log("msg", "failed to query schema foreign keys", "schema", schema, "err", err)
 		return nil, err
 	}
 	defer fkRS.Close()
 
 	for fkRS.Next() {
-		var constraintName, columnName, referencedTableName, referencedColumnName string
-		if err := fkRS.Scan(&constraintName, &columnName, &referencedTableName, &referencedColumnName); err != nil {
-			level.Error(c.logger).Log("msg", "failed to scan foreign keys", "schema", schemaName, "table", tableName, "err", err)
+		var tableName, constraintName, columnName, referencedTableName, referencedColumnName string
+		if err := fkRS.Scan(&tableName, &constraintName, &columnName, &referencedTableName, &referencedColumnName); err != nil {
+			level.Error(c.logger).Log("msg", "failed to scan schema foreign keys", "schema", schema, "err", err)
 			return nil, err
 		}
 
-		tblSpec.ForeignKeys = append(tblSpec.ForeignKeys, foreignKey{
+		spec := specOf(tableName)
+		spec.ForeignKeys = append(spec.ForeignKeys, foreignKey{
 			Name:                 constraintName,
 			ColumnName:           columnName,
 			ReferencedTableName:  referencedTableName,
@@ -466,9 +524,9 @@ func (c *SchemaDetails) fetchColumnsDefinitions(ctx context.Context, schemaName 
 	}
 
 	if err := fkRS.Err(); err != nil {
-		level.Error(c.logger).Log("msg", "failed to iterate over foreign keys result set", "schema", schemaName, "table", tableName, "err", err)
+		level.Error(c.logger).Log("msg", "failed to iterate over schema foreign keys result set", "schema", schema, "err", err)
 		return nil, err
 	}
 
-	return tblSpec, nil
+	return specs, nil
 }

--- a/internal/component/database_observability/mysql/collector/schema_details_test.go
+++ b/internal/component/database_observability/mysql/collector/schema_details_test.go
@@ -27,6 +27,7 @@ func TestSchemaDetails(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
+		mock.MatchExpectationsInOrder(false)
 
 		lokiClient := loki.NewCollectingHandler()
 
@@ -68,9 +69,10 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
+					"TABLE_NAME",
 					"COLUMN_NAME",
 					"COLUMN_DEFAULT",
 					"IS_NULLABLE",
@@ -78,6 +80,7 @@ func TestSchemaDetails(t *testing.T) {
 					"COLUMN_KEY",
 					"EXTRA",
 				}).AddRow(
+					"some_table",
 					"id",
 					"null",
 					"NO",
@@ -85,6 +88,7 @@ func TestSchemaDetails(t *testing.T) {
 					"PRI",
 					"auto_increment",
 				).AddRow(
+					"some_table",
 					"category",
 					"null",
 					"NO",
@@ -94,9 +98,10 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
+					"table_name",
 					"index_name",
 					"seq_in_index",
 					"column_name",
@@ -105,6 +110,7 @@ func TestSchemaDetails(t *testing.T) {
 					"non_unique",
 					"index_type",
 				}).AddRow(
+					"some_table",
 					"PRIMARY",
 					1,
 					"id",
@@ -115,14 +121,16 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
+					"table_name",
 					"constraint_name",
 					"column_name",
 					"referenced_table_name",
 					"referenced_column_name",
 				}).AddRow(
+					"some_table",
 					"fk_name",
 					"category",
 					"categories",
@@ -162,6 +170,7 @@ func TestSchemaDetails(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
+		mock.MatchExpectationsInOrder(false)
 
 		lokiClient := loki.NewCollectingHandler()
 
@@ -203,9 +212,10 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
+					"TABLE_NAME",
 					"COLUMN_NAME",
 					"COLUMN_DEFAULT",
 					"IS_NULLABLE",
@@ -213,6 +223,7 @@ func TestSchemaDetails(t *testing.T) {
 					"COLUMN_KEY",
 					"EXTRA",
 				}).AddRow(
+					"some_table",
 					"id",
 					"null",
 					"NO",
@@ -220,6 +231,7 @@ func TestSchemaDetails(t *testing.T) {
 					"PRI",
 					"auto_increment",
 				).AddRow(
+					"some_table",
 					"category",
 					"null",
 					"NO",
@@ -229,9 +241,10 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
+					"table_name",
 					"index_name",
 					"seq_in_index",
 					"column_name",
@@ -240,6 +253,7 @@ func TestSchemaDetails(t *testing.T) {
 					"non_unique",
 					"index_type",
 				}).AddRow(
+					"some_table",
 					"idx_category",
 					1,
 					"category",
@@ -248,6 +262,7 @@ func TestSchemaDetails(t *testing.T) {
 					0,
 					"BTREE",
 				).AddRow(
+					"some_table",
 					"idx_category",
 					2,
 					nil,
@@ -258,9 +273,10 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
+					"table_name",
 					"constraint_name",
 					"column_name",
 					"referenced_table_name",
@@ -300,6 +316,7 @@ func TestSchemaDetails(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
+		mock.MatchExpectationsInOrder(false)
 
 		lokiClient := loki.NewCollectingHandler()
 
@@ -341,9 +358,10 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
+					"TABLE_NAME",
 					"COLUMN_NAME",
 					"COLUMN_DEFAULT",
 					"IS_NULLABLE",
@@ -351,6 +369,7 @@ func TestSchemaDetails(t *testing.T) {
 					"COLUMN_KEY",
 					"EXTRA",
 				}).AddRow(
+					"some_table",
 					"id",
 					"null",
 					"NO",
@@ -358,6 +377,7 @@ func TestSchemaDetails(t *testing.T) {
 					"PRI",
 					"auto_increment",
 				).AddRow(
+					"some_table",
 					"category",
 					"null",
 					"NO",
@@ -365,6 +385,7 @@ func TestSchemaDetails(t *testing.T) {
 					"",
 					"",
 				).AddRow(
+					"some_table",
 					"name",
 					"null",
 					"YES",
@@ -374,9 +395,10 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
+					"table_name",
 					"index_name",
 					"seq_in_index",
 					"column_name",
@@ -385,6 +407,7 @@ func TestSchemaDetails(t *testing.T) {
 					"non_unique",
 					"index_type",
 				}).AddRow(
+					"some_table",
 					"PRIMARY",
 					1,
 					"id",
@@ -393,6 +416,7 @@ func TestSchemaDetails(t *testing.T) {
 					0,
 					"BTREE",
 				).AddRow(
+					"some_table",
 					"idx_name",
 					1,
 					"name",
@@ -401,6 +425,7 @@ func TestSchemaDetails(t *testing.T) {
 					0,
 					"BTREE",
 				).AddRow(
+					"some_table",
 					"idx_name",
 					2,
 					nil,
@@ -411,14 +436,16 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
+					"table_name",
 					"constraint_name",
 					"column_name",
 					"referenced_table_name",
 					"referenced_column_name",
 				}).AddRow(
+					"some_table",
 					"fk_name",
 					"category",
 					"categories",
@@ -458,6 +485,7 @@ func TestSchemaDetails(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
+		mock.MatchExpectationsInOrder(false)
 
 		lokiClient := loki.NewCollectingHandler()
 
@@ -499,9 +527,10 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
+					"TABLE_NAME",
 					"COLUMN_NAME",
 					"COLUMN_DEFAULT",
 					"IS_NULLABLE",
@@ -509,6 +538,7 @@ func TestSchemaDetails(t *testing.T) {
 					"COLUMN_KEY",
 					"EXTRA",
 				}).AddRow(
+					"some_table",
 					"id",
 					"null",
 					"NO",
@@ -516,6 +546,7 @@ func TestSchemaDetails(t *testing.T) {
 					"PRI",
 					"auto_increment",
 				).AddRow(
+					"some_table",
 					"category",
 					"null",
 					"NO",
@@ -525,9 +556,10 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
+					"table_name",
 					"index_name",
 					"seq_in_index",
 					"column_name",
@@ -536,6 +568,7 @@ func TestSchemaDetails(t *testing.T) {
 					"non_unique",
 					"index_type",
 				}).AddRow(
+					"some_table",
 					"idx_category",
 					1,
 					"category",
@@ -544,6 +577,7 @@ func TestSchemaDetails(t *testing.T) {
 					0,
 					"BTREE",
 				).AddRow(
+					"some_table",
 					"idx_category",
 					2,
 					nil,
@@ -554,9 +588,10 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
+					"table_name",
 					"constraint_name",
 					"column_name",
 					"referenced_table_name",
@@ -596,6 +631,7 @@ func TestSchemaDetails(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
+		mock.MatchExpectationsInOrder(false)
 
 		lokiClient := loki.NewCollectingHandler()
 
@@ -637,9 +673,10 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
+					"TABLE_NAME",
 					"COLUMN_NAME",
 					"COLUMN_DEFAULT",
 					"IS_NULLABLE",
@@ -647,6 +684,7 @@ func TestSchemaDetails(t *testing.T) {
 					"COLUMN_KEY",
 					"EXTRA",
 				}).AddRow(
+					"some_table",
 					"id",
 					"null",
 					"NO",
@@ -654,6 +692,7 @@ func TestSchemaDetails(t *testing.T) {
 					"PRI",
 					"auto_increment",
 				).AddRow(
+					"some_table",
 					"category",
 					"null",
 					"NO",
@@ -661,6 +700,7 @@ func TestSchemaDetails(t *testing.T) {
 					"",
 					"",
 				).AddRow(
+					"some_table",
 					"name",
 					"null",
 					"YES",
@@ -670,9 +710,10 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
+					"table_name",
 					"index_name",
 					"seq_in_index",
 					"column_name",
@@ -681,6 +722,7 @@ func TestSchemaDetails(t *testing.T) {
 					"non_unique",
 					"index_type",
 				}).AddRow(
+					"some_table",
 					"PRIMARY",
 					1,
 					"id",
@@ -689,6 +731,7 @@ func TestSchemaDetails(t *testing.T) {
 					0,
 					"BTREE",
 				).AddRow(
+					"some_table",
 					"idx_name",
 					1,
 					"name",
@@ -697,6 +740,7 @@ func TestSchemaDetails(t *testing.T) {
 					0,
 					"BTREE",
 				).AddRow(
+					"some_table",
 					"idx_name",
 					2,
 					nil,
@@ -707,14 +751,16 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
+					"table_name",
 					"constraint_name",
 					"column_name",
 					"referenced_table_name",
 					"referenced_column_name",
 				}).AddRow(
+					"some_table",
 					"fk_name",
 					"category",
 					"categories",
@@ -754,6 +800,7 @@ func TestSchemaDetails(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
+		mock.MatchExpectationsInOrder(false)
 
 		lokiClient := loki.NewCollectingHandler()
 
@@ -798,9 +845,10 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
+					"TABLE_NAME",
 					"COLUMN_NAME",
 					"COLUMN_DEFAULT",
 					"IS_NULLABLE",
@@ -808,6 +856,7 @@ func TestSchemaDetails(t *testing.T) {
 					"COLUMN_KEY",
 					"EXTRA",
 				}).AddRow(
+					"some_table",
 					"id",
 					"null",
 					"NO",
@@ -815,6 +864,7 @@ func TestSchemaDetails(t *testing.T) {
 					"PRI",
 					"auto_increment",
 				).AddRow(
+					"some_table",
 					"category",
 					"null",
 					"NO",
@@ -824,9 +874,10 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
+					"table_name",
 					"index_name",
 					"seq_in_index",
 					"column_name",
@@ -835,6 +886,7 @@ func TestSchemaDetails(t *testing.T) {
 					"non_unique",
 					"index_type",
 				}).AddRow(
+					"some_table",
 					"PRIMARY",
 					1,
 					"id",
@@ -845,14 +897,16 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
+					"table_name",
 					"constraint_name",
 					"column_name",
 					"referenced_table_name",
 					"referenced_column_name",
 				}).AddRow(
+					"some_table",
 					"fk_name",
 					"category",
 					"categories",
@@ -893,6 +947,7 @@ func TestSchemaDetails(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
+		mock.MatchExpectationsInOrder(false)
 
 		lokiClient := loki.NewCollectingHandler()
 
@@ -936,9 +991,10 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
+					"TABLE_NAME",
 					"COLUMN_NAME",
 					"COLUMN_DEFAULT",
 					"IS_NULLABLE",
@@ -946,6 +1002,7 @@ func TestSchemaDetails(t *testing.T) {
 					"COLUMN_KEY",
 					"EXTRA",
 				}).AddRow(
+					"some_table",
 					"id",
 					"null",
 					"NO",
@@ -955,9 +1012,10 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
+					"table_name",
 					"index_name",
 					"seq_in_index",
 					"column_name",
@@ -966,6 +1024,7 @@ func TestSchemaDetails(t *testing.T) {
 					"non_unique",
 					"index_type",
 				}).AddRow(
+					"some_table",
 					"PRIMARY",
 					1,
 					"id",
@@ -976,9 +1035,10 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
+					"table_name",
 					"constraint_name",
 					"column_name",
 					"referenced_table_name",
@@ -986,8 +1046,9 @@ func TestSchemaDetails(t *testing.T) {
 				}),
 			)
 
-		// second loop, table info will be read from cache
-		// and no further queries will be executed
+		// second loop, table info will be read from cache so SHOW CREATE TABLE
+		// is skipped. The bulk metadata queries still fire per schema regardless
+		// of cache state (Step 2 "always-bulk" design).
 		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
@@ -1003,6 +1064,61 @@ func TestSchemaDetails(t *testing.T) {
 					time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
 					time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC),
 				),
+			)
+
+		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema").RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"TABLE_NAME",
+					"COLUMN_NAME",
+					"COLUMN_DEFAULT",
+					"IS_NULLABLE",
+					"COLUMN_TYPE",
+					"COLUMN_KEY",
+					"EXTRA",
+				}).AddRow(
+					"some_table",
+					"id",
+					"null",
+					"NO",
+					"int",
+					"PRI",
+					"auto_increment",
+				),
+			)
+
+		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema").RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"table_name",
+					"index_name",
+					"seq_in_index",
+					"column_name",
+					"expression",
+					"nullable",
+					"non_unique",
+					"index_type",
+				}).AddRow(
+					"some_table",
+					"PRIMARY",
+					1,
+					"id",
+					nil,
+					"",
+					0,
+					"BTREE",
+				),
+			)
+
+		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema").RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"table_name",
+					"constraint_name",
+					"column_name",
+					"referenced_table_name",
+					"referenced_column_name",
+				}),
 			)
 
 		err = collector.Start(t.Context())
@@ -1043,6 +1159,7 @@ func TestSchemaDetails(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
+		mock.MatchExpectationsInOrder(false)
 
 		lokiClient := loki.NewCollectingHandler()
 
@@ -1089,9 +1206,10 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
+					"TABLE_NAME",
 					"COLUMN_NAME",
 					"COLUMN_DEFAULT",
 					"IS_NULLABLE",
@@ -1099,6 +1217,7 @@ func TestSchemaDetails(t *testing.T) {
 					"COLUMN_KEY",
 					"EXTRA",
 				}).AddRow(
+					"some_table",
 					"id",
 					"null",
 					"NO",
@@ -1108,9 +1227,10 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
+					"table_name",
 					"index_name",
 					"seq_in_index",
 					"column_name",
@@ -1119,6 +1239,7 @@ func TestSchemaDetails(t *testing.T) {
 					"non_unique",
 					"index_type",
 				}).AddRow(
+					"some_table",
 					"PRIMARY",
 					1,
 					"id",
@@ -1129,9 +1250,10 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
+					"table_name",
 					"constraint_name",
 					"column_name",
 					"referenced_table_name",
@@ -1170,6 +1292,7 @@ func TestSchemaDetails(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
+		mock.MatchExpectationsInOrder(false)
 
 		lokiClient := loki.NewCollectingHandler()
 
@@ -1217,25 +1340,25 @@ func TestSchemaDetails(t *testing.T) {
 						AddRow(tc.schema+"."+tc.table, tc.ddl),
 				)
 
-			mock.ExpectQuery(selectColumnNames).WithArgs(tc.schema, tc.table).RowsWillBeClosed().
+			mock.ExpectQuery(selectColumnNames).WithArgs(tc.schema).RowsWillBeClosed().
 				WillReturnRows(
 					sqlmock.NewRows([]string{
-						"COLUMN_NAME", "COLUMN_DEFAULT", "IS_NULLABLE",
+						"TABLE_NAME", "COLUMN_NAME", "COLUMN_DEFAULT", "IS_NULLABLE",
 						"COLUMN_TYPE", "COLUMN_KEY", "EXTRA",
-					}).AddRow("id", "null", "NO", "int", "PRI", "auto_increment"),
+					}).AddRow(tc.table, "id", "null", "NO", "int", "PRI", "auto_increment"),
 				)
 
-			mock.ExpectQuery(selectIndexNames).WithArgs(tc.schema, tc.table).RowsWillBeClosed().
+			mock.ExpectQuery(selectIndexNames).WithArgs(tc.schema).RowsWillBeClosed().
 				WillReturnRows(
 					sqlmock.NewRows([]string{
-						"index_name", "seq_in_index", "column_name", "expression",
+						"table_name", "index_name", "seq_in_index", "column_name", "expression",
 						"nullable", "non_unique", "index_type",
-					}).AddRow("PRIMARY", 1, "id", nil, "", 0, "BTREE"),
+					}).AddRow(tc.table, "PRIMARY", 1, "id", nil, "", 0, "BTREE"),
 				)
 
-			mock.ExpectQuery(selectForeignKeys).WithArgs(tc.schema, tc.table).RowsWillBeClosed().
+			mock.ExpectQuery(selectForeignKeys).WithArgs(tc.schema).RowsWillBeClosed().
 				WillReturnRows(sqlmock.NewRows([]string{
-					"constraint_name", "column_name",
+					"table_name", "constraint_name", "column_name",
 					"referenced_table_name", "referenced_column_name",
 				}))
 		}
@@ -1273,6 +1396,7 @@ func TestSchemaDetails(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
+		mock.MatchExpectationsInOrder(false)
 
 		lokiClient := loki.NewCollectingHandler()
 
@@ -1318,6 +1442,7 @@ func TestSchemaDetails(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
+		mock.MatchExpectationsInOrder(false)
 
 		lokiClient := loki.NewCollectingHandler()
 
@@ -1380,6 +1505,7 @@ func TestSchemaDetails(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
+		mock.MatchExpectationsInOrder(false)
 
 		lokiClient := loki.NewCollectingHandler()
 
@@ -1420,9 +1546,10 @@ func TestSchemaDetails(t *testing.T) {
 			),
 		)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
+					"TABLE_NAME",
 					"COLUMN_NAME",
 					"COLUMN_DEFAULT",
 					"IS_NULLABLE",
@@ -1430,6 +1557,7 @@ func TestSchemaDetails(t *testing.T) {
 					"COLUMN_KEY",
 					"EXTRA",
 				}).AddRow(
+					"some_table",
 					"id",
 					"null",
 					"NO",
@@ -1439,9 +1567,10 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
+					"table_name",
 					"index_name",
 					"seq_in_index",
 					"column_name",
@@ -1450,6 +1579,7 @@ func TestSchemaDetails(t *testing.T) {
 					"non_unique",
 					"index_type",
 				}).AddRow(
+					"some_table",
 					"PRIMARY",
 					1,
 					"id",
@@ -1460,9 +1590,10 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema", "some_table").RowsWillBeClosed().
+		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
+					"table_name",
 					"constraint_name",
 					"column_name",
 					"referenced_table_name",
@@ -1493,6 +1624,182 @@ func TestSchemaDetails(t *testing.T) {
 		require.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, lokiEntries[1].Labels)
 		require.Equal(t, fmt.Sprintf(`level="info" schema="some_schema" table="some_table" create_statement="%s" table_spec="%s"`, expectedCreateStmt, expectedTableSpec), lokiEntries[1].Line)
 	})
+	t.Run("bulk metadata returns rows for multiple tables in one schema", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+		mock.MatchExpectationsInOrder(false)
+
+		lokiClient := loki.NewCollectingHandler()
+
+		collector, err := NewSchemaDetails(SchemaDetailsArguments{
+			DB:              db,
+			CollectInterval: time.Millisecond,
+			EntryHandler:    lokiClient,
+			CacheEnabled:    false,
+			Logger:          log.NewLogfmtLogger(os.Stderr),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+
+		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"table_schema", "table_name", "table_type",
+					"create_time", "update_time",
+				}).AddRow(
+					"some_schema", "table_a", "BASE TABLE",
+					time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+					time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC),
+				).AddRow(
+					"some_schema", "table_b", "BASE TABLE",
+					time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+					time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC),
+				),
+			)
+
+		// Single per-schema bulk fetches returning rows for both tables.
+		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"TABLE_NAME", "COLUMN_NAME", "COLUMN_DEFAULT", "IS_NULLABLE",
+				"COLUMN_TYPE", "COLUMN_KEY", "EXTRA",
+			}).
+				AddRow("table_a", "id", "null", "NO", "int", "PRI", "auto_increment").
+				AddRow("table_b", "id", "null", "NO", "int", "PRI", "auto_increment"))
+
+		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "index_name", "seq_in_index", "column_name", "expression",
+				"nullable", "non_unique", "index_type",
+			}).
+				AddRow("table_a", "PRIMARY", 1, "id", nil, "", 0, "BTREE").
+				AddRow("table_b", "PRIMARY", 1, "id", nil, "", 0, "BTREE"))
+
+		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "constraint_name", "column_name",
+				"referenced_table_name", "referenced_column_name",
+			}))
+
+		for _, table := range []string{"table_a", "table_b"} {
+			mock.ExpectQuery(fmt.Sprintf("SHOW CREATE TABLE `some_schema`.`%s`", table)).WithoutArgs().RowsWillBeClosed().
+				WillReturnRows(
+					sqlmock.NewRows([]string{"table_name", "create_statement"}).
+						AddRow("some_schema."+table, fmt.Sprintf("CREATE TABLE %s (id INT)", table)),
+				)
+		}
+
+		err = collector.Start(t.Context())
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 4
+		}, 5*time.Second, 100*time.Millisecond)
+
+		collector.Stop()
+		lokiClient.Stop()
+
+		require.Eventually(t, func() bool {
+			return collector.Stopped()
+		}, 5*time.Second, 100*time.Millisecond)
+
+		err = mock.ExpectationsWereMet()
+		require.NoError(t, err)
+
+		lokiEntries := lokiClient.Received()
+		// Two table-detection entries plus two create-statement entries; order
+		// within entry types follows the bulk-tables result order.
+		require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, lokiEntries[0].Labels)
+		require.Equal(t, `level="info" schema="some_schema" table="table_a"`, lokiEntries[0].Line)
+		require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, lokiEntries[1].Labels)
+		require.Equal(t, `level="info" schema="some_schema" table="table_b"`, lokiEntries[1].Line)
+		require.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, lokiEntries[2].Labels)
+		require.Contains(t, lokiEntries[2].Line, `schema="some_schema" table="table_a"`)
+		require.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, lokiEntries[3].Labels)
+		require.Contains(t, lokiEntries[3].Line, `schema="some_schema" table="table_b"`)
+	})
+	t.Run("bulk metadata returns no rows for a table", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+		mock.MatchExpectationsInOrder(false)
+
+		lokiClient := loki.NewCollectingHandler()
+
+		collector, err := NewSchemaDetails(SchemaDetailsArguments{
+			DB:              db,
+			CollectInterval: time.Millisecond,
+			EntryHandler:    lokiClient,
+			CacheEnabled:    false,
+			Logger:          log.NewLogfmtLogger(os.Stderr),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+
+		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"table_schema", "table_name", "table_type",
+					"create_time", "update_time",
+				}).AddRow(
+					"some_schema", "some_table", "BASE TABLE",
+					time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+					time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC),
+				),
+			)
+
+		// All three per-schema queries return empty result sets, simulating a
+		// table that was dropped between the tables query and the metadata
+		// queries. The table is skipped — only OP_TABLE_DETECTION is emitted
+		// and no OP_CREATE_STATEMENT follows.
+		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"TABLE_NAME", "COLUMN_NAME", "COLUMN_DEFAULT", "IS_NULLABLE",
+				"COLUMN_TYPE", "COLUMN_KEY", "EXTRA",
+			}))
+		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "index_name", "seq_in_index", "column_name", "expression",
+				"nullable", "non_unique", "index_type",
+			}))
+		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "constraint_name", "column_name",
+				"referenced_table_name", "referenced_column_name",
+			}))
+
+		mock.ExpectQuery("SHOW CREATE TABLE `some_schema`.`some_table`").WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{"table_name", "create_statement"}).
+					AddRow("some_schema.some_table", "CREATE TABLE some_table (id INT)"),
+			)
+
+		err = collector.Start(t.Context())
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 1
+		}, 5*time.Second, 100*time.Millisecond)
+
+		collector.Stop()
+		lokiClient.Stop()
+
+		require.Eventually(t, func() bool {
+			return collector.Stopped()
+		}, 5*time.Second, 100*time.Millisecond)
+
+		err = mock.ExpectationsWereMet()
+		require.NoError(t, err)
+
+		lokiEntries := lokiClient.Received()
+		require.Len(t, lokiEntries, 1)
+		require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, lokiEntries[0].Labels)
+		require.Equal(t, `level="info" schema="some_schema" table="some_table"`, lokiEntries[0].Line)
+	})
 }
 
 func TestSchemaDetailsExcludeSchemas(t *testing.T) {
@@ -1501,6 +1808,7 @@ func TestSchemaDetailsExcludeSchemas(t *testing.T) {
 	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 	require.NoError(t, err)
 	defer db.Close()
+	mock.MatchExpectationsInOrder(false)
 
 	lokiClient := loki.NewCollectingHandler()
 	defer lokiClient.Stop()


### PR DESCRIPTION
### Brief description of Pull Request
Refactor `schema_details` collector to fetch schema specs in bulk instead of per-table. This reduces the number of queries ran by the collector.

We now fetch a list of all tables and schemas first, then we fetch columns, indexes and foreign keys for all tables in a schema in bulk.

### Pull Request Details

<!-- Detailed descripion of the Pull Request, if needed. -->


### Issue(s) fixed by this Pull Request

Relates to https://github.com/grafana/grafana-dbo11y-app/issues/2694


### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
