### PR TITLE
ci: Path-filter helm-test workflow to skip non-helm PRs

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -1,5 +1,9 @@
 name: Test Helm chart
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - 'operations/helm/**'
+      - '.github/workflows/helm-test.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
### Brief description of Pull Request

Adds a workflow-level `paths` filter so the Test Helm chart workflow only runs on PRs that touch `operations/helm/**` or the workflow file itself.

### Pull Request Details

The `lint-test` job runs ~11 min on every PR. Inside it, `ct list-changed` already gates the expensive kind cluster + chart install steps on actual chart changes, but the setup overhead (Install Helm + Python 3.13 + chart-testing) still runs every time. For PRs that don't touch helm, that's ~11 min of compute wasted per push.

Same `paths:` pattern `docker-images.yml` already uses.

### Notes to the Reviewer

Opening as draft to verify CI behaves correctly — specifically, that this PR (which doesn't touch `operations/helm/**`) shows the Test Helm chart workflow as not triggered.