### PR TITLE
chore(ci): Upgrade GitHub Action pins off Node 20

### DIFF
--- a/.github/workflows/agent_bump_beyla.yml
+++ b/.github/workflows/agent_bump_beyla.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Get secrets
         id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
         with:
           export_env: false
           repo_secrets: |
@@ -67,7 +67,7 @@ jobs:
         run: mkdir -p .github/agent-output
 
       - name: Run Claude Code plan job
-        uses: anthropics/claude-code-action@cd77b50d2b0808657f8e6774085c8bf54484351c # v1.0.72
+        uses: anthropics/claude-code-action@476e359e6203e73dad705c8b322e333fabbd7416 # v1.0.119
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -161,7 +161,7 @@ jobs:
     steps:
       - name: Get secrets
         id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
         with:
           export_env: false
           repo_secrets: |
@@ -216,7 +216,7 @@ jobs:
           git config user.email "${APP_ID}+${APP_LOGIN}@users.noreply.github.com"
 
       - name: Run Claude Code implement job
-        uses: anthropics/claude-code-action@cd77b50d2b0808657f8e6774085c8bf54484351c # v1.0.72
+        uses: anthropics/claude-code-action@476e359e6203e73dad705c8b322e333fabbd7416 # v1.0.119
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/ai-dependency-review.yml
+++ b/.github/workflows/ai-dependency-review.yml
@@ -31,7 +31,7 @@ jobs:
           go-version-file: go.mod
 
       - id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
         with:
           repo_secrets: |
             OPENAI_API_KEY=openai:api-key

--- a/.github/workflows/bump-formula-pr.yml
+++ b/.github/workflows/bump-formula-pr.yml
@@ -22,7 +22,7 @@ jobs:
         persist-credentials: false
 
     - id: get-secrets
-      uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+      uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
       with:
         repo_secrets: |
           ALLOYBOT_APP_ID=alloybot:app_id

--- a/.github/workflows/check-windows-build-image.yml
+++ b/.github/workflows/check-windows-build-image.yml
@@ -18,10 +18,8 @@ jobs:
           persist-credentials: false
 
       - name: Create test Windows build image
-        uses: mr-smithers-excellent/docker-build-push@19d2beefef6bcdc202195fdcb9deb79a4fab5c1f # v6.8
-        with:
-          image: grafana/alloy-build-image
-          tags: latest
-          registry: docker.io
-          pushImage: false
-          dockerfile: ./tools/build-image/windows/Dockerfile
+        run: |
+          docker build \
+            --file ./tools/build-image/windows/Dockerfile \
+            --tag grafana/alloy-build-image:latest \
+            .

--- a/.github/workflows/create_build_image.yml
+++ b/.github/workflows/create_build_image.yml
@@ -39,7 +39,7 @@ jobs:
       run: echo "image_tag=${FULL_TAG##*/}${{ matrix.build.suffix }}" >> $GITHUB_OUTPUT
 
     - name: Login to DockerHub (from vault)
-      uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3
+      uses: grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7 # dockerhub-login/v1.0.4
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -74,7 +74,7 @@ jobs:
       id-token: write # Needed to generate app token
     steps:
       - id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
         with:
           repo_secrets: |
             ALLOYBOT_APP_ID=alloybot:app_id
@@ -171,7 +171,7 @@ jobs:
       # The tag name in grafana/helm-charts is <package>-<version>, while the
       # tag name for grafana/alloy is helm-chart/<version>.
       - name: Make github release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           name: ${{ steps.parse-chart.outputs.packagename }}
           repository: grafana/helm-charts

--- a/.github/workflows/publish-alloy-devel.yml
+++ b/.github/workflows/publish-alloy-devel.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
 
     - name: Get Vault secrets
-      uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+      uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
       with:
         common_secrets: |
           GITHUB_APP_ID=updater-app:app-id
@@ -69,7 +69,7 @@ jobs:
       # We don't want this file to end up in the repo directory.
       # Then "tools/image-tag" would get confused because "git status" no longer reports a clean repo.
     - name: Log in to Google Artifact Registry
-      uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
+      uses: grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136 # login-to-gar/v1.0.2
       with:
         registry: "us-docker.pkg.dev"
         environment: "prod"

--- a/.github/workflows/publish-alloy-linux.yml
+++ b/.github/workflows/publish-alloy-linux.yml
@@ -38,7 +38,7 @@ jobs:
       # We don't want this file to end up in the repo directory.
       # Then "tools/image-tag" would get confused because "git status" no longer reports a clean repo.
     - name: Login to DockerHub (from vault)
-      uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3
+      uses: grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7 # dockerhub-login/v1.0.4
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/publish-alloy-windows.yml
+++ b/.github/workflows/publish-alloy-windows.yml
@@ -48,7 +48,7 @@ jobs:
       # We don't want this file to end up in the repo directory.
       # Then "tools/image-tag" would get confused because "git status" no longer reports a clean repo.
     - name: Login to DockerHub (from vault)
-      uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3
+      uses: grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7 # dockerhub-login/v1.0.4
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release-announce.yml
+++ b/.github/workflows/release-announce.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Get secrets 🔐
         id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
         with:
           export_env: false
           repo_secrets: |
@@ -46,7 +46,7 @@ jobs:
 
       - name: Notify internal alloy channel 📢
         if: steps.release-type.outputs.is_rc == 'false'
-        uses: grafana/shared-workflows/actions/send-slack-message@0941e3408fa4789fec9062c44a2a9e1832146ba6 #v2.0.1
+        uses: grafana/shared-workflows/actions/send-slack-message@eb1fbd807f87aea8f40ff08dc9cd02872cad55b3 # send-slack-message/v2.0.5
         env:
           SLACK_MESSAGE: |
             :alloy: :alloy: :alloy:

--- a/.github/workflows/release-backport.yml
+++ b/.github/workflows/release-backport.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Get GitHub app secrets 🔐
         id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
         with:
           export_env: false
           repo_secrets: |

--- a/.github/workflows/release-create-branch.yml
+++ b/.github/workflows/release-create-branch.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Get GitHub app secrets 🔐
         id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
         with:
           export_env: false
           repo_secrets: |

--- a/.github/workflows/release-create-rc.yml
+++ b/.github/workflows/release-create-rc.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Get GitHub app secrets 🔐
         id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
         with:
           export_env: false
           repo_secrets: |

--- a/.github/workflows/release-enrich-release-notes.yml
+++ b/.github/workflows/release-enrich-release-notes.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Get GitHub app secrets 🔐
         id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
         with:
           export_env: false
           repo_secrets: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Get GitHub app secrets 🔐
         id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
         with:
           export_env: false
           repo_secrets: |

--- a/.github/workflows/release-publish-alloy-artifacts.yml
+++ b/.github/workflows/release-publish-alloy-artifacts.yml
@@ -134,7 +134,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-    - uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+    - uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
       id: get-signing-secrets
       with:
         export_env: false
@@ -144,7 +144,7 @@ jobs:
           tenant-id=azure-trusted-signing:tenant-id
 
     - name: Sign Windows binaries
-      uses: grafana/shared-workflows/actions/azure-trusted-signing@e86cdb1c0a8cf5df57d3078f285261f7c9577174 # azure-trusted-signing/v1.0.0
+      uses: grafana/shared-workflows/actions/azure-trusted-signing@fd75379254f1ff2d0a1f1c12b329a9008863ad82 # azure-trusted-signing/v1.0.2
       id: sign-artifacts
       with:
         application-description: 'Grafana Alloy'
@@ -212,7 +212,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-    - uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+    - uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
       id: get-signing-secrets
       with:
         export_env: false
@@ -222,7 +222,7 @@ jobs:
           tenant-id=azure-trusted-signing:tenant-id
 
     - name: Sign Windows installer
-      uses: grafana/shared-workflows/actions/azure-trusted-signing@e86cdb1c0a8cf5df57d3078f285261f7c9577174 # azure-trusted-signing/v1.0.0
+      uses: grafana/shared-workflows/actions/azure-trusted-signing@fd75379254f1ff2d0a1f1c12b329a9008863ad82 # azure-trusted-signing/v1.0.2
       id: sign-artifacts
       with:
         application-description: 'Grafana Alloy'
@@ -248,7 +248,7 @@ jobs:
     # submit-winget-manifest is triggered when the release is published
     - name: Get GitHub app secrets 🔐
       id: get-secrets
-      uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+      uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
       with:
         export_env: false
         repo_secrets: |

--- a/.github/workflows/release-submit-winget-manifest.yml
+++ b/.github/workflows/release-submit-winget-manifest.yml
@@ -27,7 +27,7 @@ jobs:
         Add-AppxPackage $appxBundleFile
 
     - name: Get WinGet token
-      uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+      uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
       id: get-token
       with:
         export_env: false

--- a/.github/workflows/release-tag-alloyengine.yml
+++ b/.github/workflows/release-tag-alloyengine.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Get GitHub app secrets 🔐
         id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
         with:
           export_env: false
           repo_secrets: |
@@ -29,7 +29,7 @@ jobs:
             ALLOYBOT_PRIVATE_KEY=alloybot:private_key
 
       - name: Generate token 🔐
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: app-token
         with:
           app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).ALLOYBOT_APP_ID }}

--- a/.github/workflows/trigger-argo-workflow-on-tag.yml
+++ b/.github/workflows/trigger-argo-workflow-on-tag.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Trigger ArgoCD Workflow
         if: steps.validate.outputs.is_alloy == 'true'
-        uses: grafana/shared-workflows/actions/trigger-argo-workflow@a37de51f3d713a30a9e4b21bcdfbd38170020593 # v1.3.0
+        uses: grafana/shared-workflows/actions/trigger-argo-workflow@8269e9362f30c5458c2cad54510ea74fd053920c # v1.3.0
         with:
           instance: "ops"
           namespace: "alloy-cd"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
         with:
           image-ref: 'grafana/alloy-dev:latest'
           format: 'template'


### PR DESCRIPTION
### Brief description of Pull Request

Refreshes GitHub Actions pins in `.github/workflows` to supported versions so CI moves away from deprecated Node.js 20-based actions.

### Pull Request Details

- Upgrades action pins for shared workflows and external actions to newer refs that run on supported runtimes.
- Replaces `mr-smithers-excellent/docker-build-push` in the Windows build-image check with an equivalent `docker build` step.
- Updates related comments to match the pinned versions.

### Issue(s) fixed by this Pull Request

- N/A

### Notes to the Reviewer

Still remaining:
* grafana/shared-workflows/actions/get-vault-secrets still pulls hashicorp/vault-action@v3.4.0 (Node 20 upstream).
* grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main

these need to be updated upstream first.

### PR Checklist

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated