### PR TITLE
feat(database_observability.mysql): Refactor schema_details logging strategy

### DIFF
--- a/docs/sources/reference/components/database_observability/database_observability.mysql.md
+++ b/docs/sources/reference/components/database_observability/database_observability.mysql.md
@@ -136,12 +136,14 @@ The `gcp` block supplies the identifying information for the GCP Cloud SQL datab
 
 ### `schema_details`
 
-| Name               | Type       | Description                                                           | Default | Required |
-|--------------------|------------|-----------------------------------------------------------------------|---------|----------|
-| `collect_interval` | `duration` | How frequently to collect information from database.                  | `"1m"`  | no       |
-| `cache_enabled`    | `boolean`  | Whether to enable caching of table definitions.                       | `true`  | no       |
-| `cache_size`       | `integer`  | Cache size.                                                           | `256`   | no       |
-| `cache_ttl`        | `duration` | Cache TTL.                                                            | `"10m"` | no       |
+| Name               | Type       | Description                                                 | Default | Required |
+|--------------------|------------|-------------------------------------------------------------|---------|----------|
+| `collect_interval` | `duration` | How frequently to collect information from database.        | `"1m"`  | no       |
+| `cache_enabled`    | `boolean`  | Deprecated. Whether to enable caching of table definitions. | `true`  | no       |
+| `cache_size`       | `integer`  | Deprecated. Cache size.                                     | `256`   | no       |
+| `cache_ttl`        | `duration` | Deprecated. Cache TTL.                                      | `"10m"` | no       |
+
+The `cache_enabled`, `cache_size`, and `cache_ttl` settings are deprecated: they are accepted for backward compatibility, but ignored.
 
 ### `explain_plans`
 

--- a/integration-tests/docker/common/logs_assert.go
+++ b/integration-tests/docker/common/logs_assert.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,10 +15,21 @@ import (
 
 const lokiURL = "http://localhost:3100/loki/api/v1/"
 
-// LogQuery returns a formatted Loki query with the given test_name label
-func LogQuery(testName string, limit int) string {
+// LabelMatcher is an extra Loki stream selector matcher (e.g. op="create_statement")
+// that callers can pass to LogQuery to narrow the query beyond test_name.
+type LabelMatcher struct {
+	Name, Value string
+}
+
+// LogQuery returns a formatted Loki query selecting on the given test_name
+// label and any additional label matchers.
+func LogQuery(testName string, limit int, extraLabelMatchers ...LabelMatcher) string {
 	// https://grafana.com/docs/loki/latest/reference/loki-http-api/#query-logs-within-a-range-of-time
-	queryFilter := fmt.Sprintf("{test_name=\"%s\"}", testName)
+	parts := []string{fmt.Sprintf(`test_name=%q`, testName)}
+	for _, m := range extraLabelMatchers {
+		parts = append(parts, fmt.Sprintf(`%s=%q`, m.Name, m.Value))
+	}
+	queryFilter := "{" + strings.Join(parts, ", ") + "}"
 	query := fmt.Sprintf("%squery_range?query=%s&limit=%d", lokiURL, url.QueryEscape(queryFilter), limit)
 
 	// Loki queries require a nanosecond unix timestamp for the start time.

--- a/integration-tests/docker/tests/database-observability-mysql/mysql_test.go
+++ b/integration-tests/docker/tests/database-observability-mysql/mysql_test.go
@@ -15,7 +15,7 @@ import (
 const testName = "database_observability_mysql"
 
 func TestDatabaseObservabilityMySQLMetrics(t *testing.T) {
-	var metrics = []string{
+	metrics := []string{
 		"database_observability_connection_info",
 	}
 	common.MimirMetricsTest(t, metrics, []string{}, testName)
@@ -32,21 +32,16 @@ func TestDatabaseObservabilityMySQLLogs(t *testing.T) {
 		"create_statement",
 	}
 
-	var logResponse lokihttp.LogResponse
-
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		_, err := common.FetchDataFromURL(common.LogQuery(testName, 100), &logResponse)
-		assert.NoError(c, err)
-
-		ops := make(map[string]bool)
-		for _, result := range logResponse.Data.Result {
-			if op, ok := result.Stream["op"]; ok {
-				ops[op] = true
-			}
-		}
-
 		for _, op := range expectedOps {
-			assert.True(c, ops[op], "expected %s logs", op)
+			var resp common.LogResponse
+			_, err := common.FetchDataFromURL(
+				// fetch one log with exact match for op label
+				common.LogQuery(testName, 1, common.LabelMatcher{Name: "op", Value: op}),
+				&resp,
+			)
+			assert.NoError(c, err)
+			assert.NotEmpty(c, resp.Data.Result, "expected at least one log with op=%s", op)
 		}
 	}, common.TestTimeoutEnv(t), common.DefaultRetryInterval)
 }

--- a/integration-tests/docker/tests/database-observability-mysql/mysql_test.go
+++ b/integration-tests/docker/tests/database-observability-mysql/mysql_test.go
@@ -34,7 +34,7 @@ func TestDatabaseObservabilityMySQLLogs(t *testing.T) {
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		for _, op := range expectedOps {
-			var resp common.LogResponse
+			var resp lokihttp.LogResponse
 			_, err := common.FetchDataFromURL(
 				// fetch one log with exact match for op label
 				common.LogQuery(testName, 1, common.LabelMatcher{Name: "op", Value: op}),

--- a/internal/component/database_observability/mysql/collector/schema_details.go
+++ b/internal/component/database_observability/mysql/collector/schema_details.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/hashicorp/golang-lru/v2/expirable"
 	"go.uber.org/atomic"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
@@ -25,6 +24,11 @@ const (
 	OP_TABLE_DETECTION     = "table_detection"
 	OP_CREATE_STATEMENT    = "create_statement"
 )
+
+// EmitInterval is the minimum amount of time that must elapse between
+// successive OP_CREATE_STATEMENT emissions for the same table, regardless of
+// the configured collect_interval.
+const EmitInterval = 30 * time.Minute
 
 const (
 	selectTablesTemplate = `
@@ -56,7 +60,7 @@ const (
 	FROM
 		information_schema.columns
 	WHERE
-		TABLE_SCHEMA = ?
+		TABLE_SCHEMA = ? AND TABLE_NAME IN %s
 	ORDER BY TABLE_NAME, ORDINAL_POSITION ASC`
 
 	selectIndexNames = `
@@ -72,7 +76,7 @@ const (
 		FROM
 			information_schema.statistics
 		WHERE
-			table_schema = ?
+			table_schema = ? AND table_name IN %s
 		ORDER BY table_name, index_name, seq_in_index`
 
 	// Ignore 'PRIMARY' constraints, as they're already covered by the query above
@@ -88,7 +92,7 @@ const (
 		WHERE
 			constraint_name <> 'PRIMARY'
 			AND referenced_table_schema is not null
-			AND table_schema = ?
+			AND table_schema = ? AND table_name IN %s
 		ORDER BY table_name, constraint_name, ordinal_position`
 )
 
@@ -97,10 +101,6 @@ type SchemaDetailsArguments struct {
 	CollectInterval time.Duration
 	ExcludeSchemas  []string
 	EntryHandler    loki.EntryHandler
-
-	CacheEnabled bool
-	CacheSize    int
-	CacheTTL     time.Duration
 
 	Logger log.Logger
 }
@@ -111,11 +111,13 @@ type SchemaDetails struct {
 	excludeSchemas  []string
 	entryHandler    loki.EntryHandler
 
-	// Cache of table definitions. Entries are removed after a configurable TTL.
-	// Key is a string of the form "schema.table@timestamp", where timestamp is
-	// the last update time of the table (this allows capturing schema changes
-	// at each scan, regardless of caching).
-	cache *expirable.LRU[string, *tableInfo]
+	// lastEmittedAt records the wall-clock time at which OP_CREATE_STATEMENT
+	// was last emitted for a "schema.table" key. Used to throttle logging
+	// to at most one per EmitInterval per table.
+	lastEmittedAt map[string]time.Time
+
+	// nowFn allows overriding time.Now() in tests
+	nowFn func() time.Time
 
 	logger  log.Logger
 	running *atomic.Bool
@@ -170,12 +172,10 @@ func NewSchemaDetails(args SchemaDetailsArguments) (*SchemaDetails, error) {
 		collectInterval: args.CollectInterval,
 		excludeSchemas:  args.ExcludeSchemas,
 		entryHandler:    args.EntryHandler,
+		lastEmittedAt:   map[string]time.Time{},
+		nowFn:           time.Now,
 		logger:          log.With(args.Logger, "collector", SchemaDetailsCollector),
 		running:         &atomic.Bool{},
-	}
-
-	if args.CacheEnabled {
-		c.cache = expirable.NewLRU[string, *tableInfo](args.CacheSize, nil, args.CacheTTL)
 	}
 
 	return c, nil
@@ -235,7 +235,9 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 	}
 	defer rs.Close()
 
+	now := c.nowFn()
 	tables := []*tableInfo{}
+	seenTables := map[string]struct{}{}
 	for rs.Next() {
 		var schema, tableName, tableType string
 		var createTime, updateTime time.Time
@@ -252,6 +254,7 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 			b64CreateStmt: "",
 			b64TableSpec:  "",
 		})
+		seenTables[fullyQualifiedName(schema, tableName)] = struct{}{}
 
 		c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
 			logging.LevelInfo,
@@ -264,65 +267,74 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 		return fmt.Errorf("failed to iterate over tables result set: %w", err)
 	}
 
+	// Cleanup: drop throttle entries for tables that no longer exist (e.g.
+	// tables dropped or renamed). Done before the empty-tables early return so
+	// the map is also pruned when every monitored table disappears.
+	for k := range c.lastEmittedAt {
+		if _, ok := seenTables[k]; !ok {
+			delete(c.lastEmittedAt, k)
+		}
+	}
+
 	if len(tables) == 0 {
 		level.Info(c.logger).Log("msg", "no tables detected from information_schema.tables")
 		return nil
 	}
 
-	// Group tables by schema, preserving the first-seen order so iteration is
-	// deterministic (the bulk tables query already orders by TABLE_SCHEMA).
-	tablesBySchema := map[string][]*tableInfo{}
-	seenSchemas := []string{}
+	// Compute the due set: tables that have never emitted OP_CREATE_STATEMENT
+	// or whose last emission is older than EmitInterval.
+	// Group by schema to preserve the iteration order from the tables-list query.
+	dueBySchema := map[string][]*tableInfo{}
+	dueSchemas := []string{}
 	for _, t := range tables {
-		if _, seen := tablesBySchema[t.schema]; !seen {
-			seenSchemas = append(seenSchemas, t.schema)
+		k := fullyQualifiedName(t.schema, t.tableName)
+		if last, ok := c.lastEmittedAt[k]; ok && now.Sub(last) < EmitInterval {
+			continue
 		}
-		tablesBySchema[t.schema] = append(tablesBySchema[t.schema], t)
+		if _, exists := dueBySchema[t.schema]; !exists {
+			dueSchemas = append(dueSchemas, t.schema)
+		}
+		dueBySchema[t.schema] = append(dueBySchema[t.schema], t)
 	}
 
-	for _, schema := range seenSchemas {
-		specs, err := c.fetchSchemaSpecs(ctx, schema)
+	if len(dueSchemas) == 0 {
+		return nil
+	}
+
+	for _, schema := range dueSchemas {
+		dueTables := dueBySchema[schema]
+		tableNames := make([]string, 0, len(dueTables))
+		for _, t := range dueTables {
+			tableNames = append(tableNames, t.tableName)
+		}
+
+		specs, err := c.fetchSchemaSpecs(ctx, schema, tableNames)
 		if err != nil {
 			level.Error(c.logger).Log("msg", "failed to fetch schema specs", "schema", schema, "err", err)
 			continue
 		}
 
-		for _, table := range tablesBySchema[schema] {
-			fullyQualifiedTable := fmt.Sprintf("`%s`.`%s`", table.schema, table.tableName)
-			cacheKey := fmt.Sprintf("%s@%d", fullyQualifiedTable, table.updateTime.Unix())
+		for _, table := range dueTables {
+			fullyQualifiedTable := fullyQualifiedName(table.schema, table.tableName)
 
-			cacheHit := false
-			if c.cache != nil {
-				if cached, ok := c.cache.Get(cacheKey); ok {
-					table = cached
-					cacheHit = true
-				}
+			if err := c.fetchCreateStatement(ctx, fullyQualifiedTable, table); err != nil {
+				level.Error(c.logger).Log("msg", "failed to get table create statement", "schema", table.schema, "table", table.tableName, "err", err)
+				continue
 			}
 
-			if !cacheHit {
-				if err := c.fetchCreateStatement(ctx, fullyQualifiedTable, table); err != nil {
-					level.Error(c.logger).Log("msg", "failed to get table create statement", "schema", table.schema, "table", table.tableName, "err", err)
-					continue
-				}
-
-				spec, ok := specs[table.tableName]
-				if !ok {
-					// This might happen if a table is dropped between the tables query and the metadata queries.
-					level.Warn(c.logger).Log("msg", "no bulk metadata rows for table", "schema", table.schema, "table", table.tableName)
-					continue
-				}
-
-				b64Spec, err := encodeTableSpec(spec)
-				if err != nil {
-					level.Error(c.logger).Log("msg", "failed to marshal table spec", "schema", table.schema, "table", table.tableName, "err", err)
-					continue
-				}
-				table.b64TableSpec = b64Spec
-
-				if c.cache != nil {
-					c.cache.Add(cacheKey, table)
-				}
+			spec, ok := specs[table.tableName]
+			if !ok {
+				// This might happen if a table is dropped between the tables query and the metadata queries.
+				level.Warn(c.logger).Log("msg", "no bulk metadata rows for table", "schema", table.schema, "table", table.tableName)
+				continue
 			}
+
+			b64Spec, err := encodeTableSpec(spec)
+			if err != nil {
+				level.Error(c.logger).Log("msg", "failed to marshal table spec", "schema", table.schema, "table", table.tableName, "err", err)
+				continue
+			}
+			table.b64TableSpec = b64Spec
 
 			c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
 				logging.LevelInfo,
@@ -332,6 +344,7 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 					table.schema, table.tableName, table.b64CreateStmt, table.b64TableSpec,
 				),
 			)
+			c.lastEmittedAt[fullyQualifiedName(table.schema, table.tableName)] = now
 		}
 	}
 
@@ -376,12 +389,16 @@ func encodeTableSpec(spec *tableSpec) (string, error) {
 	return base64.StdEncoding.EncodeToString(jsonSpec), nil
 }
 
-// fetchSchemaSpecs runs three separate queries for a given schema in bulk in order
-// to fetch columns, indexes and foreign keys for all tables in the schema. Then groups the rows by table name.
-// The returned map is keyed by table name; tables with no columns/indexes/FKs are
-// absent.
-func (c *SchemaDetails) fetchSchemaSpecs(ctx context.Context, schema string) (map[string]*tableSpec, error) {
+// fetchSchemaSpecs runs three queries scoped to (schema, tableNames) to fetch
+// columns, indexes and foreign keys for the given tables in bulk and groups
+// the rows by table name. The returned map is keyed by table name; tables
+// with no rows in any of the three result sets are absent.
+func (c *SchemaDetails) fetchSchemaSpecs(ctx context.Context, schema string, tableNames []string) (map[string]*tableSpec, error) {
 	specs := map[string]*tableSpec{}
+	if len(tableNames) == 0 {
+		return specs, nil
+	}
+
 	specOf := func(name string) *tableSpec {
 		s, ok := specs[name]
 		if !ok {
@@ -391,7 +408,7 @@ func (c *SchemaDetails) fetchSchemaSpecs(ctx context.Context, schema string) (ma
 		return s
 	}
 
-	colRS, err := c.dbConnection.QueryContext(ctx, selectColumnNames, schema)
+	colRS, err := c.dbConnection.QueryContext(ctx, fmt.Sprintf(selectColumnNames, database_observability.BuildExclusionClause(tableNames)), schema)
 	if err != nil {
 		level.Error(c.logger).Log("msg", "failed to query schema columns", "schema", schema, "err", err)
 		return nil, err
@@ -431,7 +448,7 @@ func (c *SchemaDetails) fetchSchemaSpecs(ctx context.Context, schema string) (ma
 		return nil, err
 	}
 
-	idxRS, err := c.dbConnection.QueryContext(ctx, selectIndexNames, schema)
+	idxRS, err := c.dbConnection.QueryContext(ctx, fmt.Sprintf(selectIndexNames, database_observability.BuildExclusionClause(tableNames)), schema)
 	if err != nil {
 		level.Error(c.logger).Log("msg", "failed to query schema indexes", "schema", schema, "err", err)
 		return nil, err
@@ -500,7 +517,7 @@ func (c *SchemaDetails) fetchSchemaSpecs(ctx context.Context, schema string) (ma
 		return nil, err
 	}
 
-	fkRS, err := c.dbConnection.QueryContext(ctx, selectForeignKeys, schema)
+	fkRS, err := c.dbConnection.QueryContext(ctx, fmt.Sprintf(selectForeignKeys, database_observability.BuildExclusionClause(tableNames)), schema)
 	if err != nil {
 		level.Error(c.logger).Log("msg", "failed to query schema foreign keys", "schema", schema, "err", err)
 		return nil, err
@@ -529,4 +546,8 @@ func (c *SchemaDetails) fetchSchemaSpecs(ctx context.Context, schema string) (ma
 	}
 
 	return specs, nil
+}
+
+func fullyQualifiedName(schema, table string) string {
+	return fmt.Sprintf("`%s`.`%s`", schema, table)
 }

--- a/internal/component/database_observability/mysql/collector/schema_details_test.go
+++ b/internal/component/database_observability/mysql/collector/schema_details_test.go
@@ -14,12 +14,11 @@ import (
 	"go.uber.org/goleak"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/component/database_observability"
 )
 
 func TestSchemaDetails(t *testing.T) {
-	// The goroutine which deletes expired entries runs indefinitely,
-	// see https://github.com/hashicorp/golang-lru/blob/v2.0.7/expirable/expirable_lru.go#L79-L80
-	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"))
+	defer goleak.VerifyNone(t)
 
 	t.Run("detect table schema", func(t *testing.T) {
 		t.Parallel()
@@ -27,7 +26,6 @@ func TestSchemaDetails(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
-		mock.MatchExpectationsInOrder(false)
 
 		lokiClient := loki.NewCollectingHandler()
 
@@ -35,7 +33,6 @@ func TestSchemaDetails(t *testing.T) {
 			DB:              db,
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			CacheEnabled:    false,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
 		})
 		require.NoError(t, err)
@@ -58,18 +55,7 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery("SHOW CREATE TABLE `some_schema`.`some_table`").WithoutArgs().RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"table_name",
-					"create_statement",
-				}).AddRow(
-					"some_schema.some_table",
-					"CREATE TABLE some_table (id INT, category INT)",
-				),
-			)
-
-		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema").RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectColumnNames, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"TABLE_NAME",
@@ -98,7 +84,7 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema").RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectIndexNames, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"table_name",
@@ -121,7 +107,7 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema").RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectForeignKeys, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"table_name",
@@ -135,6 +121,17 @@ func TestSchemaDetails(t *testing.T) {
 					"category",
 					"categories",
 					"id",
+				),
+			)
+
+		mock.ExpectQuery("SHOW CREATE TABLE `some_schema`.`some_table`").WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"table_name",
+					"create_statement",
+				}).AddRow(
+					"some_schema.some_table",
+					"CREATE TABLE some_table (id INT, category INT)",
 				),
 			)
 
@@ -170,7 +167,6 @@ func TestSchemaDetails(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
-		mock.MatchExpectationsInOrder(false)
 
 		lokiClient := loki.NewCollectingHandler()
 
@@ -178,7 +174,6 @@ func TestSchemaDetails(t *testing.T) {
 			DB:              db,
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			CacheEnabled:    false,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
 		})
 		require.NoError(t, err)
@@ -201,18 +196,7 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery("SHOW CREATE TABLE `some_schema`.`some_table`").WithoutArgs().RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"table_name",
-					"create_statement",
-				}).AddRow(
-					"some_schema.some_table",
-					"CREATE TABLE some_table (id INT, category INT)",
-				),
-			)
-
-		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema").RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectColumnNames, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"TABLE_NAME",
@@ -241,7 +225,7 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema").RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectIndexNames, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"table_name",
@@ -273,7 +257,7 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema").RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectForeignKeys, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"table_name",
@@ -282,6 +266,17 @@ func TestSchemaDetails(t *testing.T) {
 					"referenced_table_name",
 					"referenced_column_name",
 				}),
+			)
+
+		mock.ExpectQuery("SHOW CREATE TABLE `some_schema`.`some_table`").WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"table_name",
+					"create_statement",
+				}).AddRow(
+					"some_schema.some_table",
+					"CREATE TABLE some_table (id INT, category INT)",
+				),
 			)
 
 		err = collector.Start(t.Context())
@@ -316,7 +311,6 @@ func TestSchemaDetails(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
-		mock.MatchExpectationsInOrder(false)
 
 		lokiClient := loki.NewCollectingHandler()
 
@@ -324,7 +318,6 @@ func TestSchemaDetails(t *testing.T) {
 			DB:              db,
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			CacheEnabled:    false,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
 		})
 		require.NoError(t, err)
@@ -347,18 +340,7 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery("SHOW CREATE TABLE `some_schema`.`some_table`").WithoutArgs().RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"table_name",
-					"create_statement",
-				}).AddRow(
-					"some_schema.some_table",
-					"CREATE TABLE some_table (id INT, category INT, name VARCHAR(255))",
-				),
-			)
-
-		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema").RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectColumnNames, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"TABLE_NAME",
@@ -395,7 +377,7 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema").RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectIndexNames, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"table_name",
@@ -436,7 +418,7 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema").RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectForeignKeys, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"table_name",
@@ -450,215 +432,6 @@ func TestSchemaDetails(t *testing.T) {
 					"category",
 					"categories",
 					"id",
-				),
-			)
-
-		err = collector.Start(t.Context())
-		require.NoError(t, err)
-
-		require.Eventually(t, func() bool {
-			return len(lokiClient.Received()) == 2
-		}, 5*time.Second, 100*time.Millisecond)
-
-		collector.Stop()
-		lokiClient.Stop()
-
-		require.Eventually(t, func() bool {
-			return collector.Stopped()
-		}, 5*time.Second, 100*time.Millisecond)
-
-		err = mock.ExpectationsWereMet()
-		require.NoError(t, err)
-
-		expectedCreateStmt := base64.StdEncoding.EncodeToString([]byte("CREATE TABLE some_table (id INT, category INT, name VARCHAR(255))"))
-		expectedTableSpec := base64.StdEncoding.EncodeToString([]byte(`{"columns":[{"name":"id","type":"int","not_null":true,"auto_increment":true,"primary_key":true,"default_value":"null"},{"name":"category","type":"int","not_null":true,"default_value":"null"},{"name":"name","type":"varchar(255)","default_value":"null"}],"indexes":[{"name":"PRIMARY","type":"BTREE","columns":["id"],"unique":true,"nullable":false},{"name":"idx_name","type":"BTREE","columns":["name"],"expressions":["name = 'test'"],"unique":true,"nullable":false}],"foreign_keys":[{"name":"fk_name","column_name":"category","referenced_table_name":"categories","referenced_column_name":"id"}]}`))
-
-		lokiEntries := lokiClient.Received()
-		require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, lokiEntries[0].Labels)
-		require.Equal(t, `level="info" schema="some_schema" table="some_table"`, lokiEntries[0].Line)
-		require.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, lokiEntries[1].Labels)
-		require.Equal(t, fmt.Sprintf(`level="info" schema="some_schema" table="some_table" create_statement="%s" table_spec="%s"`, expectedCreateStmt, expectedTableSpec), lokiEntries[1].Line)
-	})
-	t.Run("detect table schema, index with expression", func(t *testing.T) {
-		t.Parallel()
-
-		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
-		require.NoError(t, err)
-		defer db.Close()
-		mock.MatchExpectationsInOrder(false)
-
-		lokiClient := loki.NewCollectingHandler()
-
-		collector, err := NewSchemaDetails(SchemaDetailsArguments{
-			DB:              db,
-			CollectInterval: time.Millisecond,
-			EntryHandler:    lokiClient,
-			CacheEnabled:    false,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
-		})
-		require.NoError(t, err)
-		require.NotNil(t, collector)
-
-		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"table_schema",
-					"table_name",
-					"table_type",
-					"create_time",
-					"update_time",
-				}).AddRow(
-					"some_schema",
-					"some_table",
-					"BASE TABLE",
-					time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
-					time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC),
-				),
-			)
-
-		mock.ExpectQuery("SHOW CREATE TABLE `some_schema`.`some_table`").WithoutArgs().RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"table_name",
-					"create_statement",
-				}).AddRow(
-					"some_schema.some_table",
-					"CREATE TABLE some_table (id INT, category INT)",
-				),
-			)
-
-		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema").RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"TABLE_NAME",
-					"COLUMN_NAME",
-					"COLUMN_DEFAULT",
-					"IS_NULLABLE",
-					"COLUMN_TYPE",
-					"COLUMN_KEY",
-					"EXTRA",
-				}).AddRow(
-					"some_table",
-					"id",
-					"null",
-					"NO",
-					"int",
-					"PRI",
-					"auto_increment",
-				).AddRow(
-					"some_table",
-					"category",
-					"null",
-					"NO",
-					"int",
-					"",
-					"",
-				),
-			)
-
-		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema").RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"table_name",
-					"index_name",
-					"seq_in_index",
-					"column_name",
-					"expression",
-					"nullable",
-					"non_unique",
-					"index_type",
-				}).AddRow(
-					"some_table",
-					"idx_category",
-					1,
-					"category",
-					nil,
-					"",
-					0,
-					"BTREE",
-				).AddRow(
-					"some_table",
-					"idx_category",
-					2,
-					nil,
-					"category = 0",
-					"",
-					0,
-					"BTREE",
-				),
-			)
-
-		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema").RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"table_name",
-					"constraint_name",
-					"column_name",
-					"referenced_table_name",
-					"referenced_column_name",
-				}),
-			)
-
-		err = collector.Start(t.Context())
-		require.NoError(t, err)
-
-		require.Eventually(t, func() bool {
-			return len(lokiClient.Received()) == 2
-		}, 5*time.Second, 100*time.Millisecond)
-
-		collector.Stop()
-		lokiClient.Stop()
-
-		require.Eventually(t, func() bool {
-			return collector.Stopped()
-		}, 5*time.Second, 100*time.Millisecond)
-
-		err = mock.ExpectationsWereMet()
-		require.NoError(t, err)
-
-		expectedCreateStmt := base64.StdEncoding.EncodeToString([]byte("CREATE TABLE some_table (id INT, category INT)"))
-		expectedTableSpec := base64.StdEncoding.EncodeToString([]byte(`{"columns":[{"name":"id","type":"int","not_null":true,"auto_increment":true,"primary_key":true,"default_value":"null"},{"name":"category","type":"int","not_null":true,"default_value":"null"}],"indexes":[{"name":"idx_category","type":"BTREE","columns":["category"],"expressions":["category = 0"],"unique":true,"nullable":false}]}`))
-
-		lokiEntries := lokiClient.Received()
-		require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, lokiEntries[0].Labels)
-		require.Equal(t, `level="info" schema="some_schema" table="some_table"`, lokiEntries[0].Line)
-		require.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, lokiEntries[1].Labels)
-		require.Equal(t, fmt.Sprintf(`level="info" schema="some_schema" table="some_table" create_statement="%s" table_spec="%s"`, expectedCreateStmt, expectedTableSpec), lokiEntries[1].Line)
-	})
-	t.Run("detect table schema, index with multiple columns", func(t *testing.T) {
-		t.Parallel()
-
-		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
-		require.NoError(t, err)
-		defer db.Close()
-		mock.MatchExpectationsInOrder(false)
-
-		lokiClient := loki.NewCollectingHandler()
-
-		collector, err := NewSchemaDetails(SchemaDetailsArguments{
-			DB:              db,
-			CollectInterval: time.Millisecond,
-			EntryHandler:    lokiClient,
-			CacheEnabled:    false,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
-		})
-		require.NoError(t, err)
-		require.NotNil(t, collector)
-
-		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"table_schema",
-					"table_name",
-					"table_type",
-					"create_time",
-					"update_time",
-				}).AddRow(
-					"some_schema",
-					"some_table",
-					"BASE TABLE",
-					time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
-					time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC),
 				),
 			)
 
@@ -673,101 +446,6 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema").RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"TABLE_NAME",
-					"COLUMN_NAME",
-					"COLUMN_DEFAULT",
-					"IS_NULLABLE",
-					"COLUMN_TYPE",
-					"COLUMN_KEY",
-					"EXTRA",
-				}).AddRow(
-					"some_table",
-					"id",
-					"null",
-					"NO",
-					"int",
-					"PRI",
-					"auto_increment",
-				).AddRow(
-					"some_table",
-					"category",
-					"null",
-					"NO",
-					"int",
-					"",
-					"",
-				).AddRow(
-					"some_table",
-					"name",
-					"null",
-					"YES",
-					"varchar(255)",
-					"",
-					"",
-				),
-			)
-
-		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema").RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"table_name",
-					"index_name",
-					"seq_in_index",
-					"column_name",
-					"expression",
-					"nullable",
-					"non_unique",
-					"index_type",
-				}).AddRow(
-					"some_table",
-					"PRIMARY",
-					1,
-					"id",
-					nil,
-					"",
-					0,
-					"BTREE",
-				).AddRow(
-					"some_table",
-					"idx_name",
-					1,
-					"name",
-					nil,
-					"",
-					0,
-					"BTREE",
-				).AddRow(
-					"some_table",
-					"idx_name",
-					2,
-					nil,
-					"name = 'test'",
-					"",
-					0,
-					"BTREE",
-				),
-			)
-
-		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema").RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"table_name",
-					"constraint_name",
-					"column_name",
-					"referenced_table_name",
-					"referenced_column_name",
-				}).AddRow(
-					"some_table",
-					"fk_name",
-					"category",
-					"categories",
-					"id",
-				),
-			)
-
 		err = collector.Start(t.Context())
 		require.NoError(t, err)
 
@@ -794,364 +472,261 @@ func TestSchemaDetails(t *testing.T) {
 		require.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, lokiEntries[1].Labels)
 		require.Equal(t, fmt.Sprintf(`level="info" schema="some_schema" table="some_table" create_statement="%s" table_spec="%s"`, expectedCreateStmt, expectedTableSpec), lokiEntries[1].Line)
 	})
-	t.Run("detect table schema, cache enabled (write)", func(t *testing.T) {
+	t.Run("second scrape within emit_interval emits OP_TABLE_DETECTION but not OP_CREATE_STATEMENT", func(t *testing.T) {
 		t.Parallel()
 
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
-		mock.MatchExpectationsInOrder(false)
 
 		lokiClient := loki.NewCollectingHandler()
+		defer lokiClient.Stop()
 
-		// Enable caching. This will exercise the code path
-		// that writes to cache (but we don't explicitly assert it in this test)
+		fakeNow := time.Date(2024, 5, 1, 12, 0, 0, 0, time.UTC)
 		collector, err := NewSchemaDetails(SchemaDetailsArguments{
 			DB:              db,
-			CollectInterval: time.Millisecond,
+			CollectInterval: time.Hour, // unused; extractSchema is invoked manually
 			EntryHandler:    lokiClient,
-			CacheEnabled:    true,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
 		})
-
 		require.NoError(t, err)
 		require.NotNil(t, collector)
+		collector.nowFn = func() time.Time { return fakeNow }
 
+		// First scrape: tables list, bulk metadata, then SHOW CREATE TABLE.
 		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"table_schema",
-					"table_name",
-					"table_type",
-					"create_time",
-					"update_time",
-				}).AddRow(
-					"some_schema",
-					"some_table",
-					"BASE TABLE",
-					time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
-					time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC),
-				),
-			)
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_schema", "table_name", "table_type", "create_time", "update_time",
+			}).AddRow(
+				"some_schema", "some_table", "BASE TABLE",
+				time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC),
+			))
+
+		mock.ExpectQuery(fmt.Sprintf(selectColumnNames, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("some_schema").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"TABLE_NAME", "COLUMN_NAME", "COLUMN_DEFAULT", "IS_NULLABLE",
+				"COLUMN_TYPE", "COLUMN_KEY", "EXTRA",
+			}).AddRow("some_table", "id", "null", "NO", "int", "PRI", "auto_increment"))
+
+		mock.ExpectQuery(fmt.Sprintf(selectIndexNames, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("some_schema").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "index_name", "seq_in_index", "column_name", "expression",
+				"nullable", "non_unique", "index_type",
+			}).AddRow("some_table", "PRIMARY", 1, "id", nil, "", 0, "BTREE"))
+
+		mock.ExpectQuery(fmt.Sprintf(selectForeignKeys, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("some_schema").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "constraint_name", "column_name",
+				"referenced_table_name", "referenced_column_name",
+			}))
 
 		mock.ExpectQuery("SHOW CREATE TABLE `some_schema`.`some_table`").WithoutArgs().RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"table_name",
-					"create_statement",
-				}).AddRow(
-					"some_schema.some_table",
-					"CREATE TABLE some_table (id INT, category INT)",
-				),
-			)
+			WillReturnRows(sqlmock.NewRows([]string{"table_name", "create_statement"}).
+				AddRow("some_schema.some_table", "CREATE TABLE some_table (id INT)"))
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema").RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"TABLE_NAME",
-					"COLUMN_NAME",
-					"COLUMN_DEFAULT",
-					"IS_NULLABLE",
-					"COLUMN_TYPE",
-					"COLUMN_KEY",
-					"EXTRA",
-				}).AddRow(
-					"some_table",
-					"id",
-					"null",
-					"NO",
-					"int",
-					"PRI",
-					"auto_increment",
-				).AddRow(
-					"some_table",
-					"category",
-					"null",
-					"NO",
-					"int",
-					"",
-					"",
-				),
-			)
-
-		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema").RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"table_name",
-					"index_name",
-					"seq_in_index",
-					"column_name",
-					"expression",
-					"nullable",
-					"non_unique",
-					"index_type",
-				}).AddRow(
-					"some_table",
-					"PRIMARY",
-					1,
-					"id",
-					nil,
-					"",
-					0,
-					"BTREE",
-				),
-			)
-
-		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema").RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"table_name",
-					"constraint_name",
-					"column_name",
-					"referenced_table_name",
-					"referenced_column_name",
-				}).AddRow(
-					"some_table",
-					"fk_name",
-					"category",
-					"categories",
-					"id",
-				),
-			)
-		err = collector.Start(t.Context())
-		require.NoError(t, err)
-
-		require.Eventually(t, func() bool {
-			return len(lokiClient.Received()) == 2
-		}, 5*time.Second, 100*time.Millisecond)
-
-		collector.Stop()
-		lokiClient.Stop()
-
-		require.Eventually(t, func() bool {
-			return collector.Stopped()
-		}, 5*time.Second, 100*time.Millisecond)
-
-		err = mock.ExpectationsWereMet()
-		require.NoError(t, err)
-
-		require.Equal(t, 1, collector.cache.Len())
-
-		expectedCreateStmt := base64.StdEncoding.EncodeToString([]byte("CREATE TABLE some_table (id INT, category INT)"))
-		expectedTableSpec := base64.StdEncoding.EncodeToString([]byte(`{"columns":[{"name":"id","type":"int","not_null":true,"auto_increment":true,"primary_key":true,"default_value":"null"},{"name":"category","type":"int","not_null":true,"default_value":"null"}],"indexes":[{"name":"PRIMARY","type":"BTREE","columns":["id"],"unique":true,"nullable":false}],"foreign_keys":[{"name":"fk_name","column_name":"category","referenced_table_name":"categories","referenced_column_name":"id"}]}`))
-
-		lokiEntries := lokiClient.Received()
-		require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, lokiEntries[0].Labels)
-		require.Equal(t, `level="info" schema="some_schema" table="some_table"`, lokiEntries[0].Line)
-		require.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, lokiEntries[1].Labels)
-		require.Equal(t, fmt.Sprintf(`level="info" schema="some_schema" table="some_table" create_statement="%s" table_spec="%s"`, expectedCreateStmt, expectedTableSpec), lokiEntries[1].Line)
-	})
-	t.Run("detect table schema, cache enabled (write and read)", func(t *testing.T) {
-		t.Parallel()
-
-		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
-		require.NoError(t, err)
-		defer db.Close()
-		mock.MatchExpectationsInOrder(false)
-
-		lokiClient := loki.NewCollectingHandler()
-
-		// first loop, table info will be written to cache
-		collector, err := NewSchemaDetails(SchemaDetailsArguments{
-			DB:              db,
-			CollectInterval: time.Millisecond,
-			EntryHandler:    lokiClient,
-			CacheEnabled:    true,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
-		})
-
-		require.NoError(t, err)
-		require.NotNil(t, collector)
-
+		// Second scrape: only the tables list. The scrape is throttled (still
+		// within EmitInterval) so it must not trigger any create-statement
+		// related queries.
 		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"table_schema",
-					"table_name",
-					"table_type",
-					"create_time",
-					"update_time",
-				}).AddRow(
-					"some_schema",
-					"some_table",
-					"BASE TABLE",
-					time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
-					time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC),
-				),
-			)
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_schema", "table_name", "table_type", "create_time", "update_time",
+			}).AddRow(
+				"some_schema", "some_table", "BASE TABLE",
+				time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC),
+			))
 
-		mock.ExpectQuery("SHOW CREATE TABLE `some_schema`.`some_table`").WithoutArgs().RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"table_name",
-					"create_statement",
-				}).AddRow(
-					"some_schema.some_table",
-					"CREATE TABLE some_table (id INT)",
-				),
-			)
+		require.NoError(t, collector.extractSchema(t.Context()))
+		fakeNow = fakeNow.Add(time.Minute) // well within EmitInterval
+		require.NoError(t, collector.extractSchema(t.Context()))
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema").RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"TABLE_NAME",
-					"COLUMN_NAME",
-					"COLUMN_DEFAULT",
-					"IS_NULLABLE",
-					"COLUMN_TYPE",
-					"COLUMN_KEY",
-					"EXTRA",
-				}).AddRow(
-					"some_table",
-					"id",
-					"null",
-					"NO",
-					"int",
-					"PRI",
-					"auto_increment",
-				),
-			)
-
-		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema").RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"table_name",
-					"index_name",
-					"seq_in_index",
-					"column_name",
-					"expression",
-					"nullable",
-					"non_unique",
-					"index_type",
-				}).AddRow(
-					"some_table",
-					"PRIMARY",
-					1,
-					"id",
-					nil,
-					"",
-					0,
-					"BTREE",
-				),
-			)
-
-		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema").RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"table_name",
-					"constraint_name",
-					"column_name",
-					"referenced_table_name",
-					"referenced_column_name",
-				}),
-			)
-
-		// second loop, table info will be read from cache so SHOW CREATE TABLE
-		// is skipped. The bulk metadata queries still fire per schema regardless
-		// of cache state (Step 2 "always-bulk" design).
-		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"table_schema",
-					"table_name",
-					"table_type",
-					"create_time",
-					"update_time",
-				}).AddRow(
-					"some_schema",
-					"some_table",
-					"BASE TABLE",
-					time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
-					time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC),
-				),
-			)
-
-		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema").RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"TABLE_NAME",
-					"COLUMN_NAME",
-					"COLUMN_DEFAULT",
-					"IS_NULLABLE",
-					"COLUMN_TYPE",
-					"COLUMN_KEY",
-					"EXTRA",
-				}).AddRow(
-					"some_table",
-					"id",
-					"null",
-					"NO",
-					"int",
-					"PRI",
-					"auto_increment",
-				),
-			)
-
-		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema").RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"table_name",
-					"index_name",
-					"seq_in_index",
-					"column_name",
-					"expression",
-					"nullable",
-					"non_unique",
-					"index_type",
-				}).AddRow(
-					"some_table",
-					"PRIMARY",
-					1,
-					"id",
-					nil,
-					"",
-					0,
-					"BTREE",
-				),
-			)
-
-		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema").RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"table_name",
-					"constraint_name",
-					"column_name",
-					"referenced_table_name",
-					"referenced_column_name",
-				}),
-			)
-
-		err = collector.Start(t.Context())
-		require.NoError(t, err)
-
+		// First scrape emits OP_TABLE_DETECTION + OP_CREATE_STATEMENT; second
+		// scrape emits only OP_TABLE_DETECTION (still emitted on every scrape).
 		require.Eventually(t, func() bool {
-			return len(lokiClient.Received()) == 4
-		}, 5*time.Second, 100*time.Millisecond)
+			return len(lokiClient.Received()) == 3
+		}, 5*time.Second, 10*time.Millisecond)
 
-		collector.Stop()
-		lokiClient.Stop()
-
-		require.Eventually(t, func() bool {
-			return collector.Stopped()
-		}, 5*time.Second, 100*time.Millisecond)
-
-		require.Equal(t, 1, collector.cache.Len())
-
-		err = mock.ExpectationsWereMet()
-		require.NoError(t, err)
+		require.NoError(t, mock.ExpectationsWereMet())
 
 		expectedCreateStmt := base64.StdEncoding.EncodeToString([]byte("CREATE TABLE some_table (id INT)"))
 		expectedTableSpec := base64.StdEncoding.EncodeToString([]byte(`{"columns":[{"name":"id","type":"int","not_null":true,"auto_increment":true,"primary_key":true,"default_value":"null"}],"indexes":[{"name":"PRIMARY","type":"BTREE","columns":["id"],"unique":true,"nullable":false}]}`))
+		expectedCreateLine := fmt.Sprintf(`level="info" schema="some_schema" table="some_table" create_statement="%s" table_spec="%s"`, expectedCreateStmt, expectedTableSpec)
 
-		lokiEntries := lokiClient.Received()
-		require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, lokiEntries[0].Labels)
-		require.Equal(t, `level="info" schema="some_schema" table="some_table"`, lokiEntries[0].Line)
-		require.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, lokiEntries[1].Labels)
-		require.Equal(t, fmt.Sprintf(`level="info" schema="some_schema" table="some_table" create_statement="%s" table_spec="%s"`, expectedCreateStmt, expectedTableSpec), lokiEntries[1].Line)
-		require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, lokiEntries[2].Labels)
-		require.Equal(t, `level="info" schema="some_schema" table="some_table"`, lokiEntries[2].Line)
-		require.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, lokiEntries[3].Labels)
-		require.Equal(t, fmt.Sprintf(`level="info" schema="some_schema" table="some_table" create_statement="%s" table_spec="%s"`, expectedCreateStmt, expectedTableSpec), lokiEntries[3].Line)
+		entries := lokiClient.Received()
+		require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, entries[0].Labels)
+		require.Equal(t, `level="info" schema="some_schema" table="some_table"`, entries[0].Line)
+		require.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, entries[1].Labels)
+		require.Equal(t, expectedCreateLine, entries[1].Line)
+		require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, entries[2].Labels)
+		require.Equal(t, `level="info" schema="some_schema" table="some_table"`, entries[2].Line)
+	})
+	t.Run("second scrape after emit_interval re-emits OP_CREATE_STATEMENT", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki.NewCollectingHandler()
+		defer lokiClient.Stop()
+
+		fakeNow := time.Date(2024, 5, 1, 12, 0, 0, 0, time.UTC)
+		collector, err := NewSchemaDetails(SchemaDetailsArguments{
+			DB:              db,
+			CollectInterval: time.Hour,
+			EntryHandler:    lokiClient,
+			Logger:          log.NewLogfmtLogger(os.Stderr),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+		collector.nowFn = func() time.Time { return fakeNow }
+
+		// Two scrapes' worth of expectations: tables list + bulk metadata +
+		// SHOW CREATE each time.
+		for i := 0; i < 2; i++ {
+			mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+				WillReturnRows(sqlmock.NewRows([]string{
+					"table_schema", "table_name", "table_type", "create_time", "update_time",
+				}).AddRow(
+					"some_schema", "some_table", "BASE TABLE",
+					time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+					time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC),
+				))
+
+			mock.ExpectQuery(fmt.Sprintf(selectColumnNames, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("some_schema").RowsWillBeClosed().
+				WillReturnRows(sqlmock.NewRows([]string{
+					"TABLE_NAME", "COLUMN_NAME", "COLUMN_DEFAULT", "IS_NULLABLE",
+					"COLUMN_TYPE", "COLUMN_KEY", "EXTRA",
+				}).AddRow("some_table", "id", "null", "NO", "int", "PRI", "auto_increment"))
+
+			mock.ExpectQuery(fmt.Sprintf(selectIndexNames, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("some_schema").RowsWillBeClosed().
+				WillReturnRows(sqlmock.NewRows([]string{
+					"table_name", "index_name", "seq_in_index", "column_name", "expression",
+					"nullable", "non_unique", "index_type",
+				}).AddRow("some_table", "PRIMARY", 1, "id", nil, "", 0, "BTREE"))
+
+			mock.ExpectQuery(fmt.Sprintf(selectForeignKeys, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("some_schema").RowsWillBeClosed().
+				WillReturnRows(sqlmock.NewRows([]string{
+					"table_name", "constraint_name", "column_name",
+					"referenced_table_name", "referenced_column_name",
+				}))
+
+			mock.ExpectQuery("SHOW CREATE TABLE `some_schema`.`some_table`").WithoutArgs().RowsWillBeClosed().
+				WillReturnRows(sqlmock.NewRows([]string{"table_name", "create_statement"}).
+					AddRow("some_schema.some_table", "CREATE TABLE some_table (id INT)"))
+		}
+
+		require.NoError(t, collector.extractSchema(t.Context()))
+		fakeNow = fakeNow.Add(EmitInterval + time.Minute) // past the throttle window
+		require.NoError(t, collector.extractSchema(t.Context()))
+
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 4
+		}, 5*time.Second, 10*time.Millisecond)
+
+		require.NoError(t, mock.ExpectationsWereMet())
+
+		expectedCreateStmt := base64.StdEncoding.EncodeToString([]byte("CREATE TABLE some_table (id INT)"))
+		expectedTableSpec := base64.StdEncoding.EncodeToString([]byte(`{"columns":[{"name":"id","type":"int","not_null":true,"auto_increment":true,"primary_key":true,"default_value":"null"}],"indexes":[{"name":"PRIMARY","type":"BTREE","columns":["id"],"unique":true,"nullable":false}]}`))
+		expectedTableDetectionLine := `level="info" schema="some_schema" table="some_table"`
+		expectedCreateLine := fmt.Sprintf(`level="info" schema="some_schema" table="some_table" create_statement="%s" table_spec="%s"`, expectedCreateStmt, expectedTableSpec)
+
+		entries := lokiClient.Received()
+		require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, entries[0].Labels)
+		require.Equal(t, expectedTableDetectionLine, entries[0].Line)
+		require.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, entries[1].Labels)
+		require.Equal(t, expectedCreateLine, entries[1].Line)
+		require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, entries[2].Labels)
+		require.Equal(t, expectedTableDetectionLine, entries[2].Line)
+		require.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, entries[3].Labels)
+		require.Equal(t, expectedCreateLine, entries[3].Line)
+	})
+	t.Run("table dropped between scrapes is removed from throttle map", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki.NewCollectingHandler()
+		defer lokiClient.Stop()
+
+		fakeNow := time.Date(2024, 5, 1, 12, 0, 0, 0, time.UTC)
+		collector, err := NewSchemaDetails(SchemaDetailsArguments{
+			DB:              db,
+			CollectInterval: time.Hour,
+			EntryHandler:    lokiClient,
+			Logger:          log.NewLogfmtLogger(os.Stderr),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+		collector.nowFn = func() time.Time { return fakeNow }
+
+		// First scrape: two tables in the same schema.
+		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_schema", "table_name", "table_type", "create_time", "update_time",
+			}).AddRow(
+				"some_schema", "table_a", "BASE TABLE",
+				time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC),
+			).AddRow(
+				"some_schema", "table_b", "BASE TABLE",
+				time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC),
+			))
+
+		mock.ExpectQuery(fmt.Sprintf(selectColumnNames, database_observability.BuildExclusionClause([]string{"table_a", "table_b"}))).WithArgs("some_schema").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"TABLE_NAME", "COLUMN_NAME", "COLUMN_DEFAULT", "IS_NULLABLE",
+				"COLUMN_TYPE", "COLUMN_KEY", "EXTRA",
+			}).
+				AddRow("table_a", "id", "null", "NO", "int", "PRI", "auto_increment").
+				AddRow("table_b", "id", "null", "NO", "int", "PRI", "auto_increment"))
+
+		mock.ExpectQuery(fmt.Sprintf(selectIndexNames, database_observability.BuildExclusionClause([]string{"table_a", "table_b"}))).WithArgs("some_schema").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "index_name", "seq_in_index", "column_name", "expression",
+				"nullable", "non_unique", "index_type",
+			}).
+				AddRow("table_a", "PRIMARY", 1, "id", nil, "", 0, "BTREE").
+				AddRow("table_b", "PRIMARY", 1, "id", nil, "", 0, "BTREE"))
+
+		mock.ExpectQuery(fmt.Sprintf(selectForeignKeys, database_observability.BuildExclusionClause([]string{"table_a", "table_b"}))).WithArgs("some_schema").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "constraint_name", "column_name",
+				"referenced_table_name", "referenced_column_name",
+			}))
+
+		for _, table := range []string{"table_a", "table_b"} {
+			mock.ExpectQuery(fmt.Sprintf("SHOW CREATE TABLE `some_schema`.`%s`", table)).WithoutArgs().RowsWillBeClosed().
+				WillReturnRows(sqlmock.NewRows([]string{"table_name", "create_statement"}).
+					AddRow("some_schema."+table, fmt.Sprintf("CREATE TABLE %s (id INT)", table)))
+		}
+
+		require.NoError(t, collector.extractSchema(t.Context()))
+		require.Contains(t, collector.lastEmittedAt, fullyQualifiedName("some_schema", "table_a"))
+		require.Contains(t, collector.lastEmittedAt, fullyQualifiedName("some_schema", "table_b"))
+
+		// Second scrape: only table_a remains. table_b should be evicted from
+		// the throttle map by housekeeping. Since table_a was already emitted
+		// less than EmitInterval ago, no further fetch queries are expected.
+		fakeNow = fakeNow.Add(time.Minute)
+		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_schema", "table_name", "table_type", "create_time", "update_time",
+			}).AddRow(
+				"some_schema", "table_a", "BASE TABLE",
+				time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC),
+			))
+
+		require.NoError(t, collector.extractSchema(t.Context()))
+
+		require.NoError(t, mock.ExpectationsWereMet())
+		require.Contains(t, collector.lastEmittedAt, fullyQualifiedName("some_schema", "table_a"))
+		require.NotContains(t, collector.lastEmittedAt, fullyQualifiedName("some_schema", "table_b"))
 	})
 	t.Run("detect view schema", func(t *testing.T) {
 		t.Parallel()
@@ -1159,7 +734,6 @@ func TestSchemaDetails(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
-		mock.MatchExpectationsInOrder(false)
 
 		lokiClient := loki.NewCollectingHandler()
 
@@ -1167,7 +741,6 @@ func TestSchemaDetails(t *testing.T) {
 			DB:              db,
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			CacheEnabled:    false,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
 		})
 
@@ -1191,22 +764,7 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery("SHOW CREATE TABLE `some_schema`.`some_table`").WithoutArgs().RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"table_name",
-					"create_statement",
-					"character_set_client",
-					"collation_connection",
-				}).AddRow(
-					"some_schema.some_table",
-					"CREATE VIEW some_view (id INT)",
-					"some_charset",
-					"some_charset_connection",
-				),
-			)
-
-		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema").RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectColumnNames, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"TABLE_NAME",
@@ -1227,7 +785,7 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema").RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectIndexNames, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"table_name",
@@ -1250,7 +808,7 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema").RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectForeignKeys, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"table_name",
@@ -1259,6 +817,21 @@ func TestSchemaDetails(t *testing.T) {
 					"referenced_table_name",
 					"referenced_column_name",
 				}),
+			)
+
+		mock.ExpectQuery("SHOW CREATE TABLE `some_schema`.`some_table`").WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"table_name",
+					"create_statement",
+					"character_set_client",
+					"collation_connection",
+				}).AddRow(
+					"some_schema.some_table",
+					"CREATE VIEW some_view (id INT)",
+					"some_charset",
+					"some_charset_connection",
+				),
 			)
 		err = collector.Start(t.Context())
 		require.NoError(t, err)
@@ -1292,7 +865,6 @@ func TestSchemaDetails(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
-		mock.MatchExpectationsInOrder(false)
 
 		lokiClient := loki.NewCollectingHandler()
 
@@ -1300,7 +872,6 @@ func TestSchemaDetails(t *testing.T) {
 			DB:              db,
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			CacheEnabled:    false,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
 		})
 		require.NoError(t, err)
@@ -1334,13 +905,7 @@ func TestSchemaDetails(t *testing.T) {
 			{"schema_a", "table_a", "CREATE TABLE table_a (id INT)"},
 			{"schema_b", "table_b", "CREATE TABLE table_b (id INT)"},
 		} {
-			mock.ExpectQuery(fmt.Sprintf("SHOW CREATE TABLE `%s`.`%s`", tc.schema, tc.table)).WithoutArgs().RowsWillBeClosed().
-				WillReturnRows(
-					sqlmock.NewRows([]string{"table_name", "create_statement"}).
-						AddRow(tc.schema+"."+tc.table, tc.ddl),
-				)
-
-			mock.ExpectQuery(selectColumnNames).WithArgs(tc.schema).RowsWillBeClosed().
+			mock.ExpectQuery(fmt.Sprintf(selectColumnNames, database_observability.BuildExclusionClause([]string{tc.table}))).WithArgs(tc.schema).RowsWillBeClosed().
 				WillReturnRows(
 					sqlmock.NewRows([]string{
 						"TABLE_NAME", "COLUMN_NAME", "COLUMN_DEFAULT", "IS_NULLABLE",
@@ -1348,7 +913,7 @@ func TestSchemaDetails(t *testing.T) {
 					}).AddRow(tc.table, "id", "null", "NO", "int", "PRI", "auto_increment"),
 				)
 
-			mock.ExpectQuery(selectIndexNames).WithArgs(tc.schema).RowsWillBeClosed().
+			mock.ExpectQuery(fmt.Sprintf(selectIndexNames, database_observability.BuildExclusionClause([]string{tc.table}))).WithArgs(tc.schema).RowsWillBeClosed().
 				WillReturnRows(
 					sqlmock.NewRows([]string{
 						"table_name", "index_name", "seq_in_index", "column_name", "expression",
@@ -1356,11 +921,17 @@ func TestSchemaDetails(t *testing.T) {
 					}).AddRow(tc.table, "PRIMARY", 1, "id", nil, "", 0, "BTREE"),
 				)
 
-			mock.ExpectQuery(selectForeignKeys).WithArgs(tc.schema).RowsWillBeClosed().
+			mock.ExpectQuery(fmt.Sprintf(selectForeignKeys, database_observability.BuildExclusionClause([]string{tc.table}))).WithArgs(tc.schema).RowsWillBeClosed().
 				WillReturnRows(sqlmock.NewRows([]string{
 					"table_name", "constraint_name", "column_name",
 					"referenced_table_name", "referenced_column_name",
 				}))
+
+			mock.ExpectQuery("SHOW CREATE TABLE " + fullyQualifiedName(tc.schema, tc.table)).WithoutArgs().RowsWillBeClosed().
+				WillReturnRows(
+					sqlmock.NewRows([]string{"table_name", "create_statement"}).
+						AddRow(tc.schema+"."+tc.table, tc.ddl),
+				)
 		}
 
 		err = collector.Start(t.Context())
@@ -1396,7 +967,6 @@ func TestSchemaDetails(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
-		mock.MatchExpectationsInOrder(false)
 
 		lokiClient := loki.NewCollectingHandler()
 
@@ -1404,7 +974,6 @@ func TestSchemaDetails(t *testing.T) {
 			DB:              db,
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			CacheEnabled:    false,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
 		})
 		require.NoError(t, err)
@@ -1436,13 +1005,44 @@ func TestSchemaDetails(t *testing.T) {
 
 		require.Empty(t, lokiClient.Received())
 	})
+	t.Run("empty tables list clears throttle map", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki.NewCollectingHandler()
+		defer lokiClient.Stop()
+
+		collector, err := NewSchemaDetails(SchemaDetailsArguments{
+			DB:              db,
+			CollectInterval: time.Hour,
+			EntryHandler:    lokiClient,
+			Logger:          log.NewLogfmtLogger(os.Stderr),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+
+		// Pre-populate the throttle map to simulate a table that was emitted
+		// in a previous scrape but no longer exists in information_schema.
+		collector.lastEmittedAt[fullyQualifiedName("some_schema", "stale_table")] = time.Now()
+
+		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_schema", "table_name", "table_type", "create_time", "update_time",
+			}))
+
+		require.NoError(t, collector.extractSchema(t.Context()))
+		require.NoError(t, mock.ExpectationsWereMet())
+		require.Empty(t, collector.lastEmittedAt)
+	})
 	t.Run("tables result set iteration error", func(t *testing.T) {
 		t.Parallel()
 
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
-		mock.MatchExpectationsInOrder(false)
 
 		lokiClient := loki.NewCollectingHandler()
 
@@ -1450,7 +1050,6 @@ func TestSchemaDetails(t *testing.T) {
 			DB:              db,
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			CacheEnabled:    false,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
 		})
 		require.NoError(t, err)
@@ -1505,7 +1104,6 @@ func TestSchemaDetails(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
-		mock.MatchExpectationsInOrder(false)
 
 		lokiClient := loki.NewCollectingHandler()
 
@@ -1513,7 +1111,6 @@ func TestSchemaDetails(t *testing.T) {
 			DB:              db,
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			CacheEnabled:    false,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
 		})
 		require.NoError(t, err)
@@ -1536,17 +1133,8 @@ func TestSchemaDetails(t *testing.T) {
 				time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC),
 			),
 		)
-		mock.ExpectQuery("SHOW CREATE TABLE `some_schema`.`some_table`").WithoutArgs().WillReturnRows(
-			sqlmock.NewRows([]string{
-				"table_name",
-				"create_statement",
-			}).AddRow(
-				"some_schema.some_table",
-				"CREATE TABLE some_table (id INT)",
-			),
-		)
 
-		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema").RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectColumnNames, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"TABLE_NAME",
@@ -1567,7 +1155,7 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema").RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectIndexNames, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"table_name",
@@ -1590,7 +1178,7 @@ func TestSchemaDetails(t *testing.T) {
 				),
 			)
 
-		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema").RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectForeignKeys, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
 					"table_name",
@@ -1600,6 +1188,16 @@ func TestSchemaDetails(t *testing.T) {
 					"referenced_column_name",
 				}),
 			)
+
+		mock.ExpectQuery("SHOW CREATE TABLE `some_schema`.`some_table`").WithoutArgs().WillReturnRows(
+			sqlmock.NewRows([]string{
+				"table_name",
+				"create_statement",
+			}).AddRow(
+				"some_schema.some_table",
+				"CREATE TABLE some_table (id INT)",
+			),
+		)
 
 		err = collector.Start(t.Context())
 		require.NoError(t, err)
@@ -1630,7 +1228,6 @@ func TestSchemaDetails(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
-		mock.MatchExpectationsInOrder(false)
 
 		lokiClient := loki.NewCollectingHandler()
 
@@ -1638,7 +1235,6 @@ func TestSchemaDetails(t *testing.T) {
 			DB:              db,
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			CacheEnabled:    false,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
 		})
 		require.NoError(t, err)
@@ -1661,7 +1257,7 @@ func TestSchemaDetails(t *testing.T) {
 			)
 
 		// Single per-schema bulk fetches returning rows for both tables.
-		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema").RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectColumnNames, database_observability.BuildExclusionClause([]string{"table_a", "table_b"}))).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{
 				"TABLE_NAME", "COLUMN_NAME", "COLUMN_DEFAULT", "IS_NULLABLE",
 				"COLUMN_TYPE", "COLUMN_KEY", "EXTRA",
@@ -1669,7 +1265,7 @@ func TestSchemaDetails(t *testing.T) {
 				AddRow("table_a", "id", "null", "NO", "int", "PRI", "auto_increment").
 				AddRow("table_b", "id", "null", "NO", "int", "PRI", "auto_increment"))
 
-		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema").RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectIndexNames, database_observability.BuildExclusionClause([]string{"table_a", "table_b"}))).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{
 				"table_name", "index_name", "seq_in_index", "column_name", "expression",
 				"nullable", "non_unique", "index_type",
@@ -1677,7 +1273,7 @@ func TestSchemaDetails(t *testing.T) {
 				AddRow("table_a", "PRIMARY", 1, "id", nil, "", 0, "BTREE").
 				AddRow("table_b", "PRIMARY", 1, "id", nil, "", 0, "BTREE"))
 
-		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema").RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectForeignKeys, database_observability.BuildExclusionClause([]string{"table_a", "table_b"}))).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{
 				"table_name", "constraint_name", "column_name",
 				"referenced_table_name", "referenced_column_name",
@@ -1726,7 +1322,6 @@ func TestSchemaDetails(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
-		mock.MatchExpectationsInOrder(false)
 
 		lokiClient := loki.NewCollectingHandler()
 
@@ -1734,7 +1329,6 @@ func TestSchemaDetails(t *testing.T) {
 			DB:              db,
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			CacheEnabled:    false,
 			Logger:          log.NewLogfmtLogger(os.Stderr),
 		})
 		require.NoError(t, err)
@@ -1756,17 +1350,17 @@ func TestSchemaDetails(t *testing.T) {
 		// table that was dropped between the tables query and the metadata
 		// queries. The table is skipped — only OP_TABLE_DETECTION is emitted
 		// and no OP_CREATE_STATEMENT follows.
-		mock.ExpectQuery(selectColumnNames).WithArgs("some_schema").RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectColumnNames, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{
 				"TABLE_NAME", "COLUMN_NAME", "COLUMN_DEFAULT", "IS_NULLABLE",
 				"COLUMN_TYPE", "COLUMN_KEY", "EXTRA",
 			}))
-		mock.ExpectQuery(selectIndexNames).WithArgs("some_schema").RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectIndexNames, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{
 				"table_name", "index_name", "seq_in_index", "column_name", "expression",
 				"nullable", "non_unique", "index_type",
 			}))
-		mock.ExpectQuery(selectForeignKeys).WithArgs("some_schema").RowsWillBeClosed().
+		mock.ExpectQuery(fmt.Sprintf(selectForeignKeys, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("some_schema").RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{
 				"table_name", "constraint_name", "column_name",
 				"referenced_table_name", "referenced_column_name",
@@ -1803,12 +1397,11 @@ func TestSchemaDetails(t *testing.T) {
 }
 
 func TestSchemaDetailsExcludeSchemas(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"))
+	defer goleak.VerifyNone(t)
 
 	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 	require.NoError(t, err)
 	defer db.Close()
-	mock.MatchExpectationsInOrder(false)
 
 	lokiClient := loki.NewCollectingHandler()
 	defer lokiClient.Stop()
@@ -1818,7 +1411,6 @@ func TestSchemaDetailsExcludeSchemas(t *testing.T) {
 		CollectInterval: time.Millisecond,
 		ExcludeSchemas:  []string{"excluded_schema"},
 		EntryHandler:    lokiClient,
-		CacheEnabled:    false,
 		Logger:          log.NewLogfmtLogger(os.Stderr),
 	})
 	require.NoError(t, err)

--- a/internal/component/database_observability/mysql/component.go
+++ b/internal/component/database_observability/mysql/component.go
@@ -175,9 +175,11 @@ func defaultArguments() Arguments {
 
 		SchemaDetailsArguments: SchemaDetailsArguments{
 			CollectInterval: 1 * time.Minute,
-			CacheEnabled:    true,
-			CacheSize:       256,
-			CacheTTL:        10 * time.Minute,
+
+			// Deprecated settings, ignored.
+			CacheEnabled: true,
+			CacheSize:    256,
+			CacheTTL:     10 * time.Minute,
 		},
 
 		SetupConsumersArguments: SetupConsumersArguments{
@@ -587,13 +589,18 @@ func (c *Component) startCollectors(serverID string, engineVersion string, parse
 	}
 
 	if collectors[collector.SchemaDetailsCollector] {
+		if c.args.SchemaDetailsArguments.CollectInterval > collector.EmitInterval {
+			level.Warn(c.opts.Logger).Log(
+				"msg", "schema_details.collect_interval is greater than the log interval; log entries will be emitted at most once per collect_interval",
+				"collect_interval", c.args.SchemaDetailsArguments.CollectInterval,
+				"log_interval", collector.EmitInterval,
+			)
+		}
+
 		stCollector, err := collector.NewSchemaDetails(collector.SchemaDetailsArguments{
 			DB:              c.dbConnection,
 			CollectInterval: c.args.SchemaDetailsArguments.CollectInterval,
 			ExcludeSchemas:  c.args.ExcludeSchemas,
-			CacheEnabled:    c.args.SchemaDetailsArguments.CacheEnabled,
-			CacheSize:       c.args.SchemaDetailsArguments.CacheSize,
-			CacheTTL:        c.args.SchemaDetailsArguments.CacheTTL,
 			EntryHandler:    entryHandler,
 			Logger:          c.opts.Logger,
 		})


### PR DESCRIPTION
### Brief description of Pull Request
Refactor the collector to log at most one OP_CREATE_STATEMENT per table every 30m, while still checking for new tables at every collect interval tick.

Remove the internal cache (settings are ignored/deprecated) and replace it with an in-memory map to throttle logging of OP_CREATE_STATEMENT to at most once per 30 minutes per table.

The metadata queries (columns, indexes, foreign keys) are also narrowed with TABLE_NAME IN (...) to fetch only "due" tables.

Note that we partially give up on schema DDL changes detection, which was anyway not working exactly as expected: the old internal cache was keyed by UPDATE_TIME timestamp, which however is not guaranteed to be updated on every schema changes (mysql caches metadata [24h](https://dev.mysql.com/doc/refman/8.0/en/information-schema-tables-table.html) by default).

<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style with a capitalized
  description, e.g. `feat(scope): Add the thing` (not `add the thing`). For
  details on this, check out the Contributors Guide linked above.
-->



<!-- Human-readable description of the PR used as squash commit body. -->


### Pull Request Details

<!-- Detailed descripion of the Pull Request, if needed. -->


### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->


### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
