### PR TITLE
feat: Add gql subcommand

### DIFF
--- a/docs/sources/reference/cli/_index.md
+++ b/docs/sources/reference/cli/_index.md
@@ -16,14 +16,16 @@ Available commands:
 
 * [`convert`][convert]: Convert an {{< param "PRODUCT_NAME" >}} configuration file.
 * [`fmt`][fmt]: Format an {{< param "PRODUCT_NAME" >}} configuration file.
+* [`gql`][gql]: Run a GraphQL query against a running {{< param "PRODUCT_NAME" >}} instance.
 * [`run`][run]: Start {{< param "PRODUCT_NAME" >}} with the Default Engine, given an Alloy syntax configuration file.
-* [`otel`][otel]: Start {{< param "PRODUCT_NAME" >}} with the experimental OTel Engine, given an Open Telemetry Collector YAML configuration file.
+* [`otel`][otel]: Start {{< param "PRODUCT_NAME" >}} with the experimental OTel Engine, given an OpenTelemetry Collector YAML configuration file.
 * [`tools`][tools]: Read the WAL and provide statistical information.
 * `completion`: Generate shell completion for the `alloy` CLI.
 * `help`: Print help for supported commands.
 
 [run]: ./run/
 [fmt]: ./fmt/
+[gql]: ./gql/
 [convert]: ./convert/
 [otel]: ./otel/
 [tools]: ./tools/

--- a/docs/sources/reference/cli/gql.md
+++ b/docs/sources/reference/cli/gql.md
@@ -1,0 +1,101 @@
+---
+canonical: https://grafana.com/docs/alloy/latest/reference/cli/gql/
+description: Learn about the gql command
+labels:
+  stage: experimental
+  products:
+    - oss
+title: gql
+weight: 250
+---
+
+# `gql`
+
+{{< docs/shared lookup="stability/experimental_feature.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+The `gql` command runs a GraphQL query against the [{{< param "PRODUCT_NAME" >}} GraphQL API][GraphQL API].
+Use this command to query information from a running {{< param "PRODUCT_NAME" >}} instance, such as build metadata, readiness, and component health.
+
+The `gql` command doesn't enable the GraphQL API.
+The target {{< param "PRODUCT_NAME" >}} instance must run with the GraphQL API enabled.
+
+## Usage
+
+```shell
+alloy gql [<FLAG> ...] <QUERY>
+```
+
+Replace the following:
+
+* _`<FLAG>`_: One or more flags that define the GraphQL endpoint.
+* _`<QUERY>`_: Required. The GraphQL query to run.
+
+The `graphql` command is an alias for `gql`.
+
+## Enable the GraphQL API
+
+The GraphQL API is disabled by default.
+To enable it, start {{< param "PRODUCT_NAME" >}} with the `--stability.level=experimental` and `--feature.graphql.enabled` flags:
+
+```shell
+alloy run --stability.level=experimental --feature.graphql.enabled <PATH_NAME>
+```
+
+Replace _`<PATH_NAME>`_ with the {{< param "PRODUCT_NAME" >}} configuration file or directory path.
+
+## Query formats
+
+The `gql` command accepts complete GraphQL queries.
+For example, you can run an anonymous query:
+
+```shell
+alloy gql '{ alloy { version isReady } }'
+```
+
+The command also accepts query body shorthand.
+When the query doesn't start with `{`, `query`, `mutation`, or `subscription`, the command wraps it in `query { ... }`.
+
+For example, the following command:
+
+```shell
+alloy gql 'alloy { version isReady }'
+```
+
+Runs this GraphQL query:
+
+```graphql
+query { alloy { version isReady } }
+```
+
+## Flags
+
+The following flags are supported:
+
+* `--server.graphql.endpoint`: Address of the GraphQL endpoint (default `"http://127.0.0.1:12345/graphql"`).
+
+## Examples
+
+To query build and readiness information from the default GraphQL endpoint, use the following command:
+
+```shell
+alloy gql 'alloy { isReady version }'
+```
+
+The output resembles the following:
+
+```json
+{
+  "alloy": {
+    "isReady": true,
+    "version": "v1.14.0"
+  }
+}
+```
+
+To query a GraphQL endpoint on a different address, use the `--server.graphql.endpoint` flag:
+
+```shell
+alloy gql --server.graphql.endpoint=http://localhost:12345/graphql 'components { id health { message } }'
+```
+
+[GraphQL API]: ../../http/graphql/

--- a/docs/sources/reference/cli/gql.md
+++ b/docs/sources/reference/cli/gql.md
@@ -38,7 +38,7 @@ The GraphQL API is disabled by default.
 To enable it, start {{< param "PRODUCT_NAME" >}} with the `--stability.level=experimental` and `--feature.graphql.enabled` flags:
 
 ```shell
-alloy run --stability.level=experimental --feature.graphql.enabled <PATH_NAME>
+alloy run --stability.level=experimental --feature.graphql.enabled <CONFIG_PATH>
 ```
 
 Replace _`<PATH_NAME>`_ with the {{< param "PRODUCT_NAME" >}} configuration file or directory path.
@@ -71,7 +71,7 @@ query { alloy { version isReady } }
 
 The following flags are supported:
 
-* `--server.graphql.endpoint`: Address of the GraphQL endpoint (default `"http://127.0.0.1:12345/graphql"`).
+* `--endpoint`: Address of the GraphQL endpoint (default `"http://127.0.0.1:12345/graphql"`).
 
 ## Examples
 
@@ -85,17 +85,19 @@ The output resembles the following:
 
 ```json
 {
-  "alloy": {
-    "isReady": true,
-    "version": "v1.14.0"
+  "data": {
+    "alloy": {
+      "isReady": true,
+      "version": "v1.14.0"
+    }
   }
 }
 ```
 
-To query a GraphQL endpoint on a different address, use the `--server.graphql.endpoint` flag:
+To query a GraphQL endpoint on a different address, use the `--endpoint` flag:
 
 ```shell
-alloy gql --server.graphql.endpoint=http://localhost:12345/graphql 'components { id health { message } }'
+alloy gql --endpoint=http://localhost:12345/graphql 'components { id health { message } }'
 ```
 
 [GraphQL API]: ../../http/graphql/

--- a/docs/sources/reference/cli/gql.md
+++ b/docs/sources/reference/cli/gql.md
@@ -41,7 +41,7 @@ To enable it, start {{< param "PRODUCT_NAME" >}} with the `--stability.level=exp
 alloy run --stability.level=experimental --feature.graphql.enabled <CONFIG_PATH>
 ```
 
-Replace _`<PATH_NAME>`_ with the {{< param "PRODUCT_NAME" >}} configuration file or directory path.
+Replace _`<CONFIG_PATH>`_ with the {{< param "PRODUCT_NAME" >}} configuration file or directory path.
 
 ## Query formats
 

--- a/internal/alloycli/alloycli.go
+++ b/internal/alloycli/alloycli.go
@@ -25,6 +25,7 @@ func Command() *cobra.Command {
 	cmd.AddCommand(
 		convertCommand(),
 		fmtCommand(),
+		gqlCommand(),
 		RunCommand(),
 		toolsCommand(),
 		validateCommand(),

--- a/internal/alloycli/cmd_gql.go
+++ b/internal/alloycli/cmd_gql.go
@@ -1,0 +1,74 @@
+package alloycli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/grafana/alloy/internal/service/graphql/client"
+	"github.com/grafana/alloy/internal/service/graphql/utils"
+)
+
+type alloyGql struct {
+	httpAddr string
+}
+
+func gqlCommand() *cobra.Command {
+	g := &alloyGql{
+		httpAddr: "http://127.0.0.1:12345/graphql",
+	}
+
+	cmd := &cobra.Command{
+		Use:   "gql <query>",
+		Short: "[EXPERIMENTAL] Run a GraphQL query against a running Alloy instance",
+		Long: `The gql subcommand runs a GraphQL query against a running Alloy instance.
+The query is provided as a single argument to the command.
+
+It requires the --feature.graphql.enabled flag on the running Alloy instance to
+be set, as well as the stability.level flag set to "experimental".
+
+This command is experimental and may be modified or removed in the future. Use
+with caution in production.
+`,
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		Aliases:      []string{"graphql"},
+		RunE: func(_ *cobra.Command, args []string) error {
+			return g.Run(args[0])
+		},
+	}
+
+	cmd.Flags().StringVar(
+		&g.httpAddr,
+		"server.graphql.endpoint",
+		g.httpAddr,
+		"Address of the GraphQL endpoint",
+	)
+
+	return cmd
+}
+
+func (g *alloyGql) Run(query string) error {
+	c := client.NewGraphQLClient(g.httpAddr)
+
+	response, err := c.Execute(formatGraphQLQuery(query))
+	if err != nil {
+		return fmt.Errorf("execute GraphQL query: %w", err)
+	}
+
+	utils.PrintGraphQLResponse(response)
+	return nil
+}
+
+func formatGraphQLQuery(query string) string {
+	trimmedQuery := strings.TrimSpace(query)
+
+	for _, prefix := range []string{"{", "query", "mutation", "subscription"} {
+		if strings.HasPrefix(trimmedQuery, prefix) {
+			return query
+		}
+	}
+
+	return "query { " + query + " }"
+}

--- a/internal/alloycli/cmd_gql.go
+++ b/internal/alloycli/cmd_gql.go
@@ -42,7 +42,7 @@ with caution in production.
 
 	cmd.Flags().StringVar(
 		&g.httpAddr,
-		"server.graphql.endpoint",
+		"endpoint",
 		g.httpAddr,
 		"Address of the GraphQL endpoint",
 	)
@@ -70,7 +70,15 @@ func (g *alloyGql) Run(query string, out io.Writer) error {
 func formatGraphQLQuery(query string) string {
 	trimmedQuery := strings.TrimSpace(query)
 
-	for _, prefix := range []string{"{", "query", "mutation", "subscription"} {
+	for _, prefix := range []string{
+		"{",
+		"query ",
+		"mutation ",
+		"subscription ",
+		"query{",
+		"mutation{",
+		"subscription{",
+	} {
 		if strings.HasPrefix(trimmedQuery, prefix) {
 			return query
 		}

--- a/internal/alloycli/cmd_gql.go
+++ b/internal/alloycli/cmd_gql.go
@@ -3,6 +3,7 @@ package alloycli
 import (
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -12,12 +13,14 @@ import (
 )
 
 type alloyGql struct {
-	httpAddr string
+	endpoint string
 }
+
+var operationRegex = regexp.MustCompile(`^((query|mutation|subscription)(\s|\{)|(\{))`)
 
 func gqlCommand() *cobra.Command {
 	g := &alloyGql{
-		httpAddr: "http://127.0.0.1:12345/graphql",
+		endpoint: "http://127.0.0.1:12345/graphql",
 	}
 
 	cmd := &cobra.Command{
@@ -41,9 +44,9 @@ with caution in production.
 	}
 
 	cmd.Flags().StringVar(
-		&g.httpAddr,
+		&g.endpoint,
 		"endpoint",
-		g.httpAddr,
+		g.endpoint,
 		"Address of the GraphQL endpoint",
 	)
 
@@ -51,9 +54,14 @@ with caution in production.
 }
 
 func (g *alloyGql) Run(query string, out io.Writer) error {
-	c := client.NewGraphQLClient(g.httpAddr)
+	c := client.NewGraphQLClient(g.endpoint)
 
-	response, err := c.Execute(formatGraphQLQuery(query))
+	formattedQuery, err := formatGraphQLQuery(query)
+	if err != nil {
+		return fmt.Errorf("format GraphQL query: %w", err)
+	}
+
+	response, err := c.Execute(formattedQuery)
 	if err != nil {
 		return fmt.Errorf("execute GraphQL query: %w", err)
 	}
@@ -67,22 +75,18 @@ func (g *alloyGql) Run(query string, out io.Writer) error {
 	return nil
 }
 
-func formatGraphQLQuery(query string) string {
+func formatGraphQLQuery(query string) (string, error) {
 	trimmedQuery := strings.TrimSpace(query)
 
-	for _, prefix := range []string{
-		"{",
-		"query ",
-		"mutation ",
-		"subscription ",
-		"query{",
-		"mutation{",
-		"subscription{",
-	} {
-		if strings.HasPrefix(trimmedQuery, prefix) {
-			return query
-		}
+	firstParen := strings.Index(trimmedQuery, "(")
+	firstCurly := strings.Index(trimmedQuery, "{")
+	if firstParen >= 0 && (firstCurly == -1 || firstParen < firstCurly) {
+		return "", fmt.Errorf("query parameters are not supported")
 	}
 
-	return "query { " + query + " }"
+	if operationRegex.MatchString(trimmedQuery) {
+		return query, nil
+	}
+
+	return "query { " + query + " }", nil
 }

--- a/internal/alloycli/cmd_gql.go
+++ b/internal/alloycli/cmd_gql.go
@@ -2,6 +2,7 @@ package alloycli
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -26,7 +27,7 @@ func gqlCommand() *cobra.Command {
 The query is provided as a single argument to the command.
 
 It requires the --feature.graphql.enabled flag on the running Alloy instance to
-be set, as well as the stability.level flag set to "experimental".
+be set, as well as --stability.level flag set to "experimental".
 
 This command is experimental and may be modified or removed in the future. Use
 with caution in production.
@@ -34,8 +35,8 @@ with caution in production.
 		Args:         cobra.ExactArgs(1),
 		SilenceUsage: true,
 		Aliases:      []string{"graphql"},
-		RunE: func(_ *cobra.Command, args []string) error {
-			return g.Run(args[0])
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return g.Run(args[0], cmd.OutOrStdout())
 		},
 	}
 
@@ -49,7 +50,7 @@ with caution in production.
 	return cmd
 }
 
-func (g *alloyGql) Run(query string) error {
+func (g *alloyGql) Run(query string, out io.Writer) error {
 	c := client.NewGraphQLClient(g.httpAddr)
 
 	response, err := c.Execute(formatGraphQLQuery(query))
@@ -57,7 +58,9 @@ func (g *alloyGql) Run(query string) error {
 		return fmt.Errorf("execute GraphQL query: %w", err)
 	}
 
-	utils.PrintGraphQLResponse(response)
+	if err := utils.PrintGraphQLResponse(out, response); err != nil {
+		return fmt.Errorf("print GraphQL response: %w", err)
+	}
 	if len(response.Errors) > 0 {
 		return fmt.Errorf("GraphQL response contains errors")
 	}

--- a/internal/alloycli/cmd_gql.go
+++ b/internal/alloycli/cmd_gql.go
@@ -58,6 +58,9 @@ func (g *alloyGql) Run(query string) error {
 	}
 
 	utils.PrintGraphQLResponse(response)
+	if len(response.Errors) > 0 {
+		return fmt.Errorf("GraphQL response contains errors")
+	}
 	return nil
 }
 

--- a/internal/alloycli/cmd_gql_test.go
+++ b/internal/alloycli/cmd_gql_test.go
@@ -1,32 +1,14 @@
 package alloycli
 
 import (
+	"bytes"
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
-
-func TestCommandIncludesGQLCommand(t *testing.T) {
-	cmd := Command()
-
-	var foundGQL, foundREPL bool
-	for _, subcommand := range cmd.Commands() {
-		switch subcommand.Name() {
-		case "gql":
-			foundGQL = true
-		case "repl":
-			foundREPL = true
-		}
-	}
-
-	require.True(t, foundGQL)
-	require.False(t, foundREPL)
-}
 
 func TestAlloyGqlRunExecutesQuery(t *testing.T) {
 	var receivedQuery string
@@ -47,12 +29,11 @@ func TestAlloyGqlRunExecutesQuery(t *testing.T) {
 	defer server.Close()
 
 	g := &alloyGql{httpAddr: server.URL}
-	output := captureStdout(t, func() {
-		require.NoError(t, g.Run("alloy { isReady }"))
-	})
+	var output bytes.Buffer
+	require.NoError(t, g.Run("alloy { isReady }", &output))
 
 	require.Equal(t, "query { alloy { isReady } }", receivedQuery)
-	require.JSONEq(t, `{"alloy":{"isReady":true}}`, output)
+	require.JSONEq(t, `{"alloy":{"isReady":true}}`, output.String())
 }
 
 func TestAlloyGqlRunLeavesCompleteQueryUnchanged(t *testing.T) {
@@ -70,12 +51,11 @@ func TestAlloyGqlRunLeavesCompleteQueryUnchanged(t *testing.T) {
 	defer server.Close()
 
 	g := &alloyGql{httpAddr: server.URL}
-	output := captureStdout(t, func() {
-		require.NoError(t, g.Run("{ alloy { version } }"))
-	})
+	var output bytes.Buffer
+	require.NoError(t, g.Run("{ alloy { version } }", &output))
 
 	require.Equal(t, "{ alloy { version } }", receivedQuery)
-	require.JSONEq(t, `{"alloy":{"version":"dev"}}`, output)
+	require.JSONEq(t, `{"alloy":{"version":"dev"}}`, output.String())
 }
 
 func TestAlloyGqlRunReturnsErrorForGraphQLErrors(t *testing.T) {
@@ -87,31 +67,10 @@ func TestAlloyGqlRunReturnsErrorForGraphQLErrors(t *testing.T) {
 	defer server.Close()
 
 	g := &alloyGql{httpAddr: server.URL}
-	var runErr error
-	output := captureStdout(t, func() {
-		runErr = g.Run("{ alloy {")
-	})
+	var output bytes.Buffer
+	runErr := g.Run("{ alloy {", &output)
 
 	require.Error(t, runErr)
 	require.ErrorContains(t, runErr, "GraphQL response contains errors")
-	require.Contains(t, output, "bad query")
-}
-
-func captureStdout(t *testing.T, fn func()) string {
-	t.Helper()
-
-	originalStdout := os.Stdout
-	reader, writer, err := os.Pipe()
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		os.Stdout = originalStdout
-	})
-
-	os.Stdout = writer
-	fn()
-	require.NoError(t, writer.Close())
-
-	out, err := io.ReadAll(reader)
-	require.NoError(t, err)
-	return string(out)
+	require.Contains(t, output.String(), "bad query")
 }

--- a/internal/alloycli/cmd_gql_test.go
+++ b/internal/alloycli/cmd_gql_test.go
@@ -28,7 +28,7 @@ func TestAlloyGqlRunExecutesQuery(t *testing.T) {
 	}))
 	defer server.Close()
 
-	g := &alloyGql{httpAddr: server.URL}
+	g := &alloyGql{endpoint: server.URL}
 	var output bytes.Buffer
 	require.NoError(t, g.Run("alloy { isReady }", &output))
 
@@ -50,12 +50,129 @@ func TestAlloyGqlRunLeavesCompleteQueryUnchanged(t *testing.T) {
 	}))
 	defer server.Close()
 
-	g := &alloyGql{httpAddr: server.URL}
+	g := &alloyGql{endpoint: server.URL}
 	var output bytes.Buffer
 	require.NoError(t, g.Run("{ alloy { version } }", &output))
 
 	require.Equal(t, "{ alloy { version } }", receivedQuery)
 	require.JSONEq(t, `{"data":{"alloy":{"version":"dev"}}}`, output.String())
+}
+
+func TestFormatGraphQLQuery(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   string
+		want    string
+		wantErr string
+	}{
+		{
+			name:  "wraps field selection",
+			query: "alloy { isReady }",
+			want:  "query { alloy { isReady } }",
+		},
+		{
+			name: "leaves shorthand query unchanged",
+			query: `{
+	alloy {
+		isReady
+	}
+}`,
+			want: `{
+	alloy {
+		isReady
+	}
+}`,
+		},
+		{
+			name:  "leaves compact shorthand query unchanged",
+			query: "{alloy{version}}",
+			want:  "{alloy{version}}",
+		},
+		{
+			name:  "leaves compact operation unchanged",
+			query: "query{ alloy { isReady } }",
+			want:  "query{ alloy { isReady } }",
+		},
+		{
+			name: "leaves operation with newline before selection unchanged",
+			query: `query
+{
+	alloy {
+		isReady
+	}
+}`,
+			want: `query
+{
+	alloy {
+		isReady
+	}
+}`,
+		},
+		{
+			name: "leaves named operation with multiline selection unchanged",
+			query: `query GetAlloy
+{
+	alloy {
+		isReady
+	}
+}`,
+			want: `query GetAlloy
+{
+	alloy {
+		isReady
+	}
+}`,
+		},
+		{
+			name:  "leaves mutation with tab before selection unchanged",
+			query: "mutation\t{ reload { success } }",
+			want:  "mutation\t{ reload { success } }",
+		},
+		{
+			name: "leaves subscription with newline before selection unchanged",
+			query: `subscription
+{
+	events {
+		id
+	}
+}`,
+			want: `subscription
+{
+	events {
+		id
+	}
+}`,
+		},
+		{
+			name:    "rejects parameterized operation",
+			query:   `query($componentID: String!) { component(id: $componentID) { id } }`,
+			wantErr: "query parameters are not supported",
+		},
+		{
+			name:    "rejects named parameterized operation",
+			query:   `query GetComponent($componentID: String!) { component(id: $componentID) { id } }`,
+			wantErr: "query parameters are not supported",
+		},
+		{
+			name:    "rejects field selection with arguments before selection",
+			query:   `component(id: "local.file") { id }`,
+			wantErr: "query parameters are not supported",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := formatGraphQLQuery(tt.query)
+
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestAlloyGqlRunReturnsErrorForGraphQLErrors(t *testing.T) {
@@ -66,7 +183,7 @@ func TestAlloyGqlRunReturnsErrorForGraphQLErrors(t *testing.T) {
 	}))
 	defer server.Close()
 
-	g := &alloyGql{httpAddr: server.URL}
+	g := &alloyGql{endpoint: server.URL}
 	var output bytes.Buffer
 	runErr := g.Run("{ alloy {", &output)
 

--- a/internal/alloycli/cmd_gql_test.go
+++ b/internal/alloycli/cmd_gql_test.go
@@ -1,0 +1,98 @@
+package alloycli
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandIncludesGQLCommand(t *testing.T) {
+	cmd := Command()
+
+	var foundGQL, foundREPL bool
+	for _, subcommand := range cmd.Commands() {
+		switch subcommand.Name() {
+		case "gql":
+			foundGQL = true
+		case "repl":
+			foundREPL = true
+		}
+	}
+
+	require.True(t, foundGQL)
+	require.False(t, foundREPL)
+}
+
+func TestAlloyGqlRunExecutesQuery(t *testing.T) {
+	var receivedQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var req struct {
+			Query string `json:"query"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		receivedQuery = req.Query
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"data":{"alloy":{"isReady":true}}}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	g := &alloyGql{httpAddr: server.URL}
+	output := captureStdout(t, func() {
+		require.NoError(t, g.Run("alloy { isReady }"))
+	})
+
+	require.Equal(t, "query { alloy { isReady } }", receivedQuery)
+	require.JSONEq(t, `{"alloy":{"isReady":true}}`, output)
+}
+
+func TestAlloyGqlRunLeavesCompleteQueryUnchanged(t *testing.T) {
+	var receivedQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Query string `json:"query"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		receivedQuery = req.Query
+
+		_, err := w.Write([]byte(`{"data":{"alloy":{"version":"dev"}}}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	g := &alloyGql{httpAddr: server.URL}
+	output := captureStdout(t, func() {
+		require.NoError(t, g.Run("{ alloy { version } }"))
+	})
+
+	require.Equal(t, "{ alloy { version } }", receivedQuery)
+	require.JSONEq(t, `{"alloy":{"version":"dev"}}`, output)
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	originalStdout := os.Stdout
+	reader, writer, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		os.Stdout = originalStdout
+	})
+
+	os.Stdout = writer
+	fn()
+	require.NoError(t, writer.Close())
+
+	out, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	return string(out)
+}

--- a/internal/alloycli/cmd_gql_test.go
+++ b/internal/alloycli/cmd_gql_test.go
@@ -78,6 +78,25 @@ func TestAlloyGqlRunLeavesCompleteQueryUnchanged(t *testing.T) {
 	require.JSONEq(t, `{"alloy":{"version":"dev"}}`, output)
 }
 
+func TestAlloyGqlRunReturnsErrorForGraphQLErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"errors":[{"message":"bad query"}]}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	g := &alloyGql{httpAddr: server.URL}
+	var runErr error
+	output := captureStdout(t, func() {
+		runErr = g.Run("{ alloy {")
+	})
+
+	require.Error(t, runErr)
+	require.ErrorContains(t, runErr, "GraphQL response contains errors")
+	require.Contains(t, output, "bad query")
+}
+
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
 

--- a/internal/alloycli/cmd_gql_test.go
+++ b/internal/alloycli/cmd_gql_test.go
@@ -33,7 +33,7 @@ func TestAlloyGqlRunExecutesQuery(t *testing.T) {
 	require.NoError(t, g.Run("alloy { isReady }", &output))
 
 	require.Equal(t, "query { alloy { isReady } }", receivedQuery)
-	require.JSONEq(t, `{"alloy":{"isReady":true}}`, output.String())
+	require.JSONEq(t, `{"data":{"alloy":{"isReady":true}}}`, output.String())
 }
 
 func TestAlloyGqlRunLeavesCompleteQueryUnchanged(t *testing.T) {
@@ -55,7 +55,7 @@ func TestAlloyGqlRunLeavesCompleteQueryUnchanged(t *testing.T) {
 	require.NoError(t, g.Run("{ alloy { version } }", &output))
 
 	require.Equal(t, "{ alloy { version } }", receivedQuery)
-	require.JSONEq(t, `{"alloy":{"version":"dev"}}`, output.String())
+	require.JSONEq(t, `{"data":{"alloy":{"version":"dev"}}}`, output.String())
 }
 
 func TestAlloyGqlRunReturnsErrorForGraphQLErrors(t *testing.T) {
@@ -72,5 +72,5 @@ func TestAlloyGqlRunReturnsErrorForGraphQLErrors(t *testing.T) {
 
 	require.Error(t, runErr)
 	require.ErrorContains(t, runErr, "GraphQL response contains errors")
-	require.Contains(t, output.String(), "bad query")
+	require.JSONEq(t, `{"errors":[{"message":"bad query"}]}`, output.String())
 }

--- a/internal/service/graphql/client/graphql_client.go
+++ b/internal/service/graphql/client/graphql_client.go
@@ -48,11 +48,6 @@ func NewGraphQLClient(endpoint string) *GraphQLClient {
 	}
 }
 
-// SetHeader sets a custom header (useful for future auth support)
-func (c *GraphQLClient) SetHeader(key, value string) {
-	c.headers.Set(key, value)
-}
-
 // Execute sends a GraphQL query and returns the parsed response.
 func (c *GraphQLClient) Execute(query string) (*GraphQLResponse, error) {
 	reqBody := GraphQLRequest{Query: query}

--- a/internal/service/graphql/client/graphql_client.go
+++ b/internal/service/graphql/client/graphql_client.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -72,17 +74,19 @@ func (c *GraphQLClient) Execute(query string) (*GraphQLResponse, error) {
 
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to execute request: %s", resp.Status)
-	}
-
-	buf := new(bytes.Buffer)
-	_, err = buf.ReadFrom(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
-	return c.parseResponse(buf.Bytes())
+	if resp.StatusCode != http.StatusOK {
+		if body := strings.TrimSpace(string(data)); body != "" {
+			return nil, fmt.Errorf("failed to execute request: %s: %s", resp.Status, body)
+		}
+		return nil, fmt.Errorf("failed to execute request: %s", resp.Status)
+	}
+
+	return c.parseResponse(data)
 }
 
 // parseResponse converts raw GraphQL response bytes into a basic GraphQLResponse struct

--- a/internal/service/graphql/client/graphql_client.go
+++ b/internal/service/graphql/client/graphql_client.go
@@ -32,7 +32,6 @@ type GraphQLRequest struct {
 type GraphQLResponse struct {
 	Data   any   `json:"data,omitempty"`
 	Errors []any `json:"errors,omitempty"`
-	Raw    []byte
 }
 
 // NewGraphQLClient creates a new GraphQL client
@@ -54,7 +53,7 @@ func (c *GraphQLClient) SetHeader(key, value string) {
 	c.headers.Set(key, value)
 }
 
-// Execute sends a GraphQL query and returns the raw response bytes
+// Execute sends a GraphQL query and returns the parsed response.
 func (c *GraphQLClient) Execute(query string) (*GraphQLResponse, error) {
 	reqBody := GraphQLRequest{Query: query}
 	jsonBody, err := json.Marshal(reqBody)
@@ -100,6 +99,5 @@ func (c *GraphQLClient) parseResponse(data []byte) (*GraphQLResponse, error) {
 	if err := json.Unmarshal(data, &resp); err != nil {
 		return nil, fmt.Errorf("failed to parse GraphQL response: %w", err)
 	}
-	resp.Raw = data
 	return &resp, nil
 }

--- a/internal/service/graphql/client/graphql_client.go
+++ b/internal/service/graphql/client/graphql_client.go
@@ -14,6 +14,8 @@ import (
 // This package allows alloy to execute GraphQL queries against the Alloy GraphQL API.
 //
 
+const maxResponseBodySize = 5 * 1024 * 1024
+
 // GraphQLClient represents a simple GraphQL client
 type GraphQLClient struct {
 	endpoint   string
@@ -74,9 +76,12 @@ func (c *GraphQLClient) Execute(query string) (*GraphQLResponse, error) {
 
 	defer resp.Body.Close()
 
-	data, err := io.ReadAll(resp.Body)
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize+1))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+	if len(data) > maxResponseBodySize {
+		return nil, fmt.Errorf("response body exceeds %d bytes", maxResponseBodySize)
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/internal/service/graphql/client/graphql_client_test.go
+++ b/internal/service/graphql/client/graphql_client_test.go
@@ -38,12 +38,10 @@ func TestExecuteReturnsGraphQLErrorsInResponse(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Len(t, response.Errors, 1)
-	require.Contains(t, string(response.Raw), "bad query")
+	require.Equal(t, map[string]any{"message": "bad query"}, response.Errors[0])
 }
 
 func TestExecuteReturnsErrorForOversizedResponse(t *testing.T) {
-	const maxResponseBodySize = 5 * 1024 * 1024
-
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, err := w.Write([]byte(strings.Repeat("a", maxResponseBodySize+1)))
 		require.NoError(t, err)

--- a/internal/service/graphql/client/graphql_client_test.go
+++ b/internal/service/graphql/client/graphql_client_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -38,4 +39,20 @@ func TestExecuteReturnsGraphQLErrorsInResponse(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, response.Errors, 1)
 	require.Contains(t, string(response.Raw), "bad query")
+}
+
+func TestExecuteReturnsErrorForOversizedResponse(t *testing.T) {
+	const maxResponseBodySize = 5 * 1024 * 1024
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, err := w.Write([]byte(strings.Repeat("a", maxResponseBodySize+1)))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	c := NewGraphQLClient(server.URL)
+	_, err := c.Execute("{ alloy { isReady } }")
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "response body exceeds 5242880 bytes")
 }

--- a/internal/service/graphql/client/graphql_client_test.go
+++ b/internal/service/graphql/client/graphql_client_test.go
@@ -1,0 +1,41 @@
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecuteReturnsResponseBodyForNonOKStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, err := w.Write([]byte(`{"errors":[{"message":"bad query"}]}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	c := NewGraphQLClient(server.URL)
+	_, err := c.Execute("{ alloy {")
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "400 Bad Request")
+	require.ErrorContains(t, err, "bad query")
+}
+
+func TestExecuteReturnsGraphQLErrorsInResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"errors":[{"message":"bad query"}]}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	c := NewGraphQLClient(server.URL)
+	response, err := c.Execute("{ alloy {")
+
+	require.NoError(t, err)
+	require.Len(t, response.Errors, 1)
+	require.Contains(t, string(response.Raw), "bad query")
+}

--- a/internal/service/graphql/client/graphql_client_test.go
+++ b/internal/service/graphql/client/graphql_client_test.go
@@ -20,7 +20,6 @@ func TestExecuteReturnsResponseBodyForNonOKStatus(t *testing.T) {
 	c := NewGraphQLClient(server.URL)
 	_, err := c.Execute("{ alloy {")
 
-	require.Error(t, err)
 	require.ErrorContains(t, err, "400 Bad Request")
 	require.ErrorContains(t, err, "bad query")
 }
@@ -51,6 +50,5 @@ func TestExecuteReturnsErrorForOversizedResponse(t *testing.T) {
 	c := NewGraphQLClient(server.URL)
 	_, err := c.Execute("{ alloy { isReady } }")
 
-	require.Error(t, err)
 	require.ErrorContains(t, err, "response body exceeds 5242880 bytes")
 }

--- a/internal/service/graphql/utils/print_graphql_response.go
+++ b/internal/service/graphql/utils/print_graphql_response.go
@@ -3,25 +3,29 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 
 	"github.com/grafana/alloy/internal/service/graphql/client"
 )
 
 // PrintGraphQLResponse pretty prints a GraphQL response.
-func PrintGraphQLResponse(parsedResponse *client.GraphQLResponse) {
+func PrintGraphQLResponse(writer io.Writer, parsedResponse *client.GraphQLResponse) error {
 	prettyBytes, err := json.MarshalIndent(parsedResponse.Data, "", "  ")
 	if err != nil {
-		fmt.Printf("Failed to pretty print response data: %v\n", err)
-		return
+		return fmt.Errorf("marshal GraphQL response data: %w", err)
 	}
-	fmt.Println(string(prettyBytes))
+	if _, err := fmt.Fprintln(writer, string(prettyBytes)); err != nil {
+		return fmt.Errorf("write GraphQL response data: %w", err)
+	}
 
 	if len(parsedResponse.Errors) > 0 {
 		prettyBytes, err = json.MarshalIndent(parsedResponse.Errors, "", "  ")
 		if err != nil {
-			fmt.Printf("Failed to pretty print response errors: %v\n", err)
-			return
+			return fmt.Errorf("marshal GraphQL response errors: %w", err)
 		}
-		fmt.Println("Errors: ", string(prettyBytes))
+		if _, err := fmt.Fprintln(writer, "Errors: ", string(prettyBytes)); err != nil {
+			return fmt.Errorf("write GraphQL response errors: %w", err)
+		}
 	}
+	return nil
 }

--- a/internal/service/graphql/utils/print_graphql_response.go
+++ b/internal/service/graphql/utils/print_graphql_response.go
@@ -10,22 +10,12 @@ import (
 
 // PrintGraphQLResponse pretty prints a GraphQL response.
 func PrintGraphQLResponse(writer io.Writer, parsedResponse *client.GraphQLResponse) error {
-	prettyBytes, err := json.MarshalIndent(parsedResponse.Data, "", "  ")
+	prettyBytes, err := json.MarshalIndent(parsedResponse, "", "  ")
 	if err != nil {
-		return fmt.Errorf("marshal GraphQL response data: %w", err)
+		return fmt.Errorf("marshal GraphQL response: %w", err)
 	}
 	if _, err := fmt.Fprintln(writer, string(prettyBytes)); err != nil {
-		return fmt.Errorf("write GraphQL response data: %w", err)
-	}
-
-	if len(parsedResponse.Errors) > 0 {
-		prettyBytes, err = json.MarshalIndent(parsedResponse.Errors, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal GraphQL response errors: %w", err)
-		}
-		if _, err := fmt.Fprintln(writer, "Errors: ", string(prettyBytes)); err != nil {
-			return fmt.Errorf("write GraphQL response errors: %w", err)
-		}
+		return fmt.Errorf("write GraphQL response: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
### Brief description of Pull Request

Adds the `gql` subcommand to Alloy, allowing GraphQL queries to be invoked against a running Alloy instance.

### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->

Fixes #477  
Fixes #1891
Fixes #5001 

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [x] Tests updated
