### PR TITLE
feat(telemetry): Add graph connection metrics

### DIFF
--- a/docs/sources/troubleshoot/controller_metrics.md
+++ b/docs/sources/troubleshoot/controller_metrics.md
@@ -25,6 +25,7 @@ The controller exposes the following metrics:
 * `alloy_component_evaluation_seconds` (Histogram): The time it takes to evaluate components after one of their dependencies is updated.
 * `alloy_component_dependencies_wait_seconds` (Histogram): Time spent by components waiting to be evaluated after one of their dependencies is updated.
 * `alloy_component_evaluation_queue_size` (Gauge): The current number of component evaluations waiting to be performed.
+* `alloy_component_graph_connection` (Gauge): Indicates that two components are connected in the graph.
 
 [component controller]: ../../get-started/component_controller/
 [alloy run]: ../../reference/cli/run/

--- a/internal/runtime/internal/controller/loader.go
+++ b/internal/runtime/internal/controller/loader.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/grafana/dskit/backoff"
 	"github.com/hashicorp/go-multierror"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/storage"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -206,6 +207,7 @@ func (l *Loader) Apply(options ApplyOptions) diag.Diagnostics {
 	}()
 
 	l.cache.ClearModuleExports()
+	l.cm.graphEdgeConnection.Reset()
 
 	// Evaluate all the components.
 	_ = dag.WalkTopological(&newGraph, newGraph.Leaves(), func(n dag.Node) error {
@@ -222,8 +224,17 @@ func (l *Loader) Apply(options ApplyOptions) diag.Diagnostics {
 
 		switch n := n.(type) {
 		case ComponentNode:
+			idStr := n.ID().String()
 			components = append(components, n)
-			componentIDs[n.ID().String()] = n.ID()
+			componentIDs[idStr] = n.ID()
+			outgoing := n.GetDataFlowEdgesTo()
+
+			for _, e := range outgoing {
+				l.cm.graphEdgeConnection.With(prometheus.Labels{
+					"from": idStr,
+					"to":   e,
+				}).Set(1)
+			}
 
 			if err = l.evaluate(logger, n); err != nil {
 				var evalDiags diag.Diagnostics

--- a/internal/runtime/internal/controller/metrics.go
+++ b/internal/runtime/internal/controller/metrics.go
@@ -15,6 +15,7 @@ type controllerMetrics struct {
 	evaluationQueueSize         prometheus.Gauge
 	slowComponentThreshold      time.Duration
 	slowComponentEvaluationTime *prometheus.CounterVec
+	graphEdgeConnection         *prometheus.GaugeVec
 }
 
 // newControllerMetrics inits the metrics for the components controller
@@ -69,6 +70,12 @@ func newControllerMetrics(parent, id string) *controllerMetrics {
 		ConstLabels: map[string]string{"controller_path": parent, "controller_id": id},
 	}, []string{"component_id"})
 
+	cm.graphEdgeConnection = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name:        "alloy_component_graph_connection",
+		Help:        "Indicates that two components are connected in the graph",
+		ConstLabels: map[string]string{"controller_path": parent, "controller_id": id},
+	}, []string{"from", "to"})
+
 	return cm
 }
 
@@ -85,6 +92,7 @@ func (cm *controllerMetrics) Collect(ch chan<- prometheus.Metric) {
 	cm.dependenciesWaitTime.Collect(ch)
 	cm.evaluationQueueSize.Collect(ch)
 	cm.slowComponentEvaluationTime.Collect(ch)
+	cm.graphEdgeConnection.Collect(ch)
 }
 
 func (cm *controllerMetrics) Describe(ch chan<- *prometheus.Desc) {
@@ -93,6 +101,7 @@ func (cm *controllerMetrics) Describe(ch chan<- *prometheus.Desc) {
 	cm.dependenciesWaitTime.Describe(ch)
 	cm.evaluationQueueSize.Describe(ch)
 	cm.slowComponentEvaluationTime.Describe(ch)
+	cm.graphEdgeConnection.Describe(ch)
 }
 
 type controllerCollector struct {


### PR DESCRIPTION
### Brief description of Pull Request

This PR adds graph connection info metrics that signify a connection in the component graph.


### Pull Request Details

Connection metrics tell the story of how components are connected. An example might look like this:
```
alloy_component_graph_connection{controller_id="",controller_path="/",from="prometheus.scrape.integrations_alloy_health",to="prometheus.relabel.integrations_alloy_health"} 1
```
This shows a component `prometheus.scrape.integrations_alloy_health` which provides data to `prometheus.relabel.integrations_alloy_health`. This could be telemetry data, discovery data or an auth reference.

The metric can be used to gather data flow between components by combining this with metrics for forwarded samples like this:

```
(alloy_component_graph_connection{} * on(from) group_left  label_replace(
        sum(rate(prometheus_forwarded_samples_total{}[$__rate_interval])) by (component_id),
        "from","$1","component_id","(.*)"
        ))
```

### Issue(s) fixed by this Pull Request

This PR takes the idea from #5695 and makes it maintainable & scaleable by reducing the number of required series (just one instead of one per export target) and not requiring passing down component IDs to all fanouts.


### PR Checklist

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
