### PR TITLE
feat(telemetry): Add loki_forwarded_entries_total metric

### DIFF
--- a/internal/component/common/loki/consume_test.go
+++ b/internal/component/common/loki/consume_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/grafana/loki/pkg/push"
 	"github.com/stretchr/testify/require"
 )
@@ -13,7 +15,7 @@ import (
 func TestConsume(t *testing.T) {
 	consumer := NewLogsReceiver()
 	producer := NewLogsReceiver()
-	fanout := NewFanout([]LogsReceiver{consumer})
+	fanout := NewFanout([]LogsReceiver{consumer}, prometheus.DefaultRegisterer)
 
 	t.Run("should fanout any consumed entries", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -46,7 +48,7 @@ func TestConsume(t *testing.T) {
 func TestConsumeAndProcess(t *testing.T) {
 	consumer := NewLogsReceiver()
 	producer := NewLogsReceiver()
-	fanout := NewFanout([]LogsReceiver{consumer})
+	fanout := NewFanout([]LogsReceiver{consumer}, prometheus.DefaultRegisterer)
 
 	t.Run("should process and fanout any consumed entries", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -111,7 +113,7 @@ func TestConsumeAndProcess(t *testing.T) {
 func TestConsumeBatch(t *testing.T) {
 	consumer := NewLogsReceiver()
 	producer := NewLogsBatchReceiver()
-	fanout := NewFanout([]LogsReceiver{consumer})
+	fanout := NewFanout([]LogsReceiver{consumer}, prometheus.DefaultRegisterer)
 
 	t.Run("should fanout any consumed entries", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())

--- a/internal/component/common/loki/drain_test.go
+++ b/internal/component/common/loki/drain_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/grafana/loki/pkg/push"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
@@ -32,7 +33,7 @@ func TestDrain(t *testing.T) {
 			}
 		})
 
-		Drain(recv, NewFanout([]LogsReceiver{collector.Receiver()}), time.Second, func() {
+		Drain(recv, NewFanout([]LogsReceiver{collector.Receiver()}, prometheus.DefaultRegisterer), time.Second, func() {
 			require.Eventually(t, func() bool {
 				return len(collector.Received()) == 1
 			}, time.Second, 10*time.Millisecond)
@@ -60,7 +61,7 @@ func TestDrain(t *testing.T) {
 			}
 		})
 
-		Drain(recv, NewFanout([]LogsReceiver{blockedRecv}), 20*time.Millisecond, func() {
+		Drain(recv, NewFanout([]LogsReceiver{blockedRecv}, prometheus.DefaultRegisterer), 20*time.Millisecond, func() {
 			time.Sleep(100 * time.Millisecond)
 		})
 
@@ -87,7 +88,7 @@ func TestDrain(t *testing.T) {
 
 			var wg sync.WaitGroup
 			wg.Go(func() {
-				Drain(recv, NewFanout([]LogsReceiver{consumer}), 100*time.Millisecond, func() {
+				Drain(recv, NewFanout([]LogsReceiver{consumer}, prometheus.DefaultRegisterer), 100*time.Millisecond, func() {
 					// Wait until the producer has finished sending all entries.
 					producerWG.Wait()
 				})

--- a/internal/component/common/loki/fanout.go
+++ b/internal/component/common/loki/fanout.go
@@ -3,21 +3,31 @@ package loki
 import (
 	"context"
 	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // NewFanout creates a new Fanout that will send log entries to the provided
 // list of LogsReceivers.
-func NewFanout(children []LogsReceiver) *Fanout {
+func NewFanout(children []LogsReceiver, reg prometheus.Registerer) *Fanout {
+	counter := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "loki_forwarded_entries_total",
+		Help: "Total number of entries sent to downstream components.",
+	})
+	_ = reg.Register(counter)
+
 	return &Fanout{
-		children: children,
+		children:     children,
+		entryCounter: counter,
 	}
 }
 
 // Fanout distributes log entries to multiple LogsReceivers.
 // It is thread-safe and allows the list of receivers to be updated dynamically
 type Fanout struct {
-	mut      sync.RWMutex
-	children []LogsReceiver
+	mut          sync.RWMutex
+	children     []LogsReceiver
+	entryCounter prometheus.Counter
 }
 
 // Send forwards a log entry to all registered receivers. It returns an error
@@ -33,6 +43,8 @@ func (f *Fanout) Send(ctx context.Context, entry Entry) error {
 	// operation, receiver list updates (which require a write lock) will block
 	// until all in-flight Send calls complete. This prevents sending entries to
 	// receivers that have been removed by the scheduler.
+
+	f.entryCounter.Inc()
 
 	f.mut.RLock()
 	defer f.mut.RUnlock()
@@ -59,6 +71,8 @@ func (f *Fanout) SendBatch(ctx context.Context, batch []Entry) error {
 	// operation, receiver list updates (which require a write lock) will block
 	// until all in-flight Send calls complete. This prevents sending entries to
 	// receivers that have been removed by the scheduler.
+
+	f.entryCounter.Add(float64(len(batch)))
 
 	f.mut.RLock()
 	defer f.mut.RUnlock()

--- a/internal/component/database_observability/mysql/component.go
+++ b/internal/component/database_observability/mysql/component.go
@@ -282,7 +282,7 @@ func new(opts component.Options, args Arguments, openFn func(driverName, dataSou
 	c := &Component{
 		opts:      opts,
 		args:      args,
-		fanout:    loki.NewFanout(args.ForwardTo),
+		fanout:    loki.NewFanout(args.ForwardTo, opts.Registerer),
 		handler:   loki.NewLogsReceiver(),
 		registry:  prometheus.NewRegistry(),
 		healthErr: atomic.NewString(""),

--- a/internal/component/database_observability/mysql/component_test.go
+++ b/internal/component/database_observability/mysql/component_test.go
@@ -548,7 +548,7 @@ func TestMySQL_Reconnection(t *testing.T) {
 		c := &Component{
 			opts:      opts,
 			args:      args,
-			fanout:    loki.NewFanout(args.ForwardTo),
+			fanout:    loki.NewFanout(args.ForwardTo, opts.Registerer),
 			handler:   loki.NewLogsReceiver(),
 			registry:  prometheus.NewRegistry(),
 			healthErr: atomic.NewString(""),

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -255,7 +255,7 @@ func new(opts component.Options, args Arguments, openFn func(driverName, dataSou
 	c := &Component{
 		opts:         opts,
 		args:         args,
-		fanout:       loki.NewFanout(args.ForwardTo),
+		fanout:       loki.NewFanout(args.ForwardTo, opts.Registerer),
 		handler:      loki.NewLogsReceiver(),
 		registry:     prometheus.NewRegistry(),
 		healthErr:    atomic.NewString(""),

--- a/internal/component/database_observability/postgres/component_test.go
+++ b/internal/component/database_observability/postgres/component_test.go
@@ -50,7 +50,7 @@ func newTestComponent(t *testing.T, openSQL func(string, string) (*sql.DB, error
 	c := &Component{
 		opts:         opts,
 		args:         args,
-		fanout:       loki.NewFanout(args.ForwardTo),
+		fanout:       loki.NewFanout(args.ForwardTo, opts.Registerer),
 		handler:      loki.NewLogsReceiver(),
 		registry:     prometheus.NewRegistry(),
 		healthErr:    atomic.NewString(""),

--- a/internal/component/faro/receiver/exporters.go
+++ b/internal/component/faro/receiver/exporters.go
@@ -94,12 +94,12 @@ type logsExporter struct {
 
 var _ exporter = (*logsExporter)(nil)
 
-func newLogsExporter(log log.Logger, sourceMaps sourceMapsStore, format LogFormat) *logsExporter {
+func newLogsExporter(log log.Logger, sourceMaps sourceMapsStore, format LogFormat, registerer prometheus.Registerer) *logsExporter {
 	return &logsExporter{
 		log:        log,
 		sourceMaps: sourceMaps,
 		format:     format,
-		fanout:     loki.NewFanout([]loki.LogsReceiver{}),
+		fanout:     loki.NewFanout([]loki.LogsReceiver{}, registerer),
 	}
 }
 

--- a/internal/component/faro/receiver/exporters_test.go
+++ b/internal/component/faro/receiver/exporters_test.go
@@ -318,7 +318,7 @@ func Test_LogsExporter_Export(t *testing.T) {
 			t.Parallel()
 			var (
 				lr  = newFakeLogsReceiver(t)
-				exp = newLogsExporter(util.TestLogger(t), &varSourceMapsStore{}, tc.format)
+				exp = newLogsExporter(util.TestLogger(t), &varSourceMapsStore{}, tc.format, prometheus.DefaultRegisterer)
 			)
 			exp.SetReceivers([]loki.LogsReceiver{lr})
 			exp.SetLabels(map[string]string{

--- a/internal/component/faro/receiver/receiver.go
+++ b/internal/component/faro/receiver/receiver.go
@@ -54,7 +54,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		varStore = &varSourceMapsStore{}
 
 		metrics = newMetricsExporter(o.Registerer)
-		logs    = newLogsExporter(log.With(o.Logger, "exporter", "logs"), varStore, args.LogFormat)
+		logs    = newLogsExporter(log.With(o.Logger, "exporter", "logs"), varStore, args.LogFormat, o.Registerer)
 		traces  = newTracesExporter(log.With(o.Logger, "exporter", "traces"))
 	)
 

--- a/internal/component/loki/enrich/enrich.go
+++ b/internal/component/loki/enrich/enrich.go
@@ -64,7 +64,7 @@ func New(opts component.Options, args Arguments) (*Component, error) {
 		args:         args,
 		targetsCache: make(map[string]model.LabelSet),
 		receiver:     loki.NewLogsReceiver(loki.WithComponentID(opts.ID)),
-		fanout:       loki.NewFanout(args.ForwardTo),
+		fanout:       loki.NewFanout(args.ForwardTo, opts.Registerer),
 	}
 
 	opts.OnStateChange(Exports{Receiver: c.receiver})

--- a/internal/component/loki/process/process.go
+++ b/internal/component/loki/process/process.go
@@ -71,7 +71,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		processOut:         loki.NewLogsReceiver(),
 		processIn:          loki.NewLogsReceiver(),
 		receiver:           loki.NewLogsReceiver(loki.WithComponentID(o.ID)),
-		fanout:             loki.NewFanout(args.ForwardTo),
+		fanout:             loki.NewFanout(args.ForwardTo, o.Registerer),
 		debugDataPublisher: debugDataPublisher.(livedebugging.DebugDataPublisher),
 	}
 

--- a/internal/component/loki/process/process_test.go
+++ b/internal/component/loki/process/process_test.go
@@ -956,7 +956,7 @@ func TestComponent_UpdateInvalidConfig(t *testing.T) {
 	require.NoError(t, ctrl.WaitExports(time.Minute))
 
 	recv := ctrl.Exports().(Exports).Receiver
-	fanout := loki.NewFanout([]loki.LogsReceiver{recv})
+	fanout := loki.NewFanout([]loki.LogsReceiver{recv}, prometheus.DefaultRegisterer)
 
 	wg.Go(func() {
 		for {
@@ -1489,12 +1489,12 @@ func TestLeakyUpdate(t *testing.T) {
 	metrics1 := fmt.Sprintf(metricsTemplate1, numLogsToSend)
 	metrics2 := fmt.Sprintf(metricsTemplate2, numLogsToSend)
 
-	tester.updateAndTest(numLogsToSend, cfg1, "", metrics1)
-	tester.updateAndTest(numLogsToSend, cfg2, "", metrics2)
+	tester.updateAndTest(numLogsToSend, cfg1, forwardedEntriesTotalMetric(0), metrics1+forwardedEntriesTotalMetric(numLogsToSend))
+	tester.updateAndTest(numLogsToSend, cfg2, forwardedEntriesTotalMetric(numLogsToSend), metrics2+forwardedEntriesTotalMetric(numLogsToSend*2))
 
 	for i := 0; i < 100; i++ {
-		tester.updateAndTest(numLogsToSend, cfg1, "", metrics1)
-		tester.updateAndTest(numLogsToSend, cfg2, "", metrics2)
+		tester.updateAndTest(numLogsToSend, cfg1, forwardedEntriesTotalMetric(2*(i+1)*numLogsToSend), metrics1+forwardedEntriesTotalMetric(2*(i+1)*numLogsToSend+1))
+		tester.updateAndTest(numLogsToSend, cfg2, forwardedEntriesTotalMetric(2*(i+1)*numLogsToSend+1), metrics2+forwardedEntriesTotalMetric(2*(i+2)*numLogsToSend))
 	}
 }
 
@@ -1541,8 +1541,8 @@ func TestMetricsStageRefresh(t *testing.T) {
 	// The component will be reconfigured so that it has a metric.
 	t.Run("config with a metric", func(t *testing.T) {
 		tester.updateAndTest(numLogsToSend, cfg,
-			"",
-			fmt.Sprintf(expectedMetrics, numLogsToSend, numLogsToSend))
+			forwardedEntriesTotalMetric(0),
+			fmt.Sprintf(expectedMetrics, numLogsToSend, numLogsToSend)+forwardedEntriesTotalMetric(numLogsToSend))
 	})
 
 	// The component will be "updated" with the same config.
@@ -1553,15 +1553,15 @@ func TestMetricsStageRefresh(t *testing.T) {
 	// Those users wouldn't expect their metrics to be reset every time the config is reloaded.
 	t.Run("config with the same metric", func(t *testing.T) {
 		tester.updateAndTest(numLogsToSend, cfg,
-			fmt.Sprintf(expectedMetrics, numLogsToSend, numLogsToSend),
-			fmt.Sprintf(expectedMetrics, 2*numLogsToSend, 2*numLogsToSend))
+			fmt.Sprintf(expectedMetrics, numLogsToSend, numLogsToSend)+forwardedEntriesTotalMetric(numLogsToSend),
+			fmt.Sprintf(expectedMetrics, 2*numLogsToSend, 2*numLogsToSend)+forwardedEntriesTotalMetric(2*numLogsToSend))
 	})
 
 	// Use a config which has no metrics stage.
 	// This should cause the metric to disappear.
 	cfgWithNoStages := forwardArgs
 	t.Run("config with no metrics stage", func(t *testing.T) {
-		tester.updateAndTest(numLogsToSend, cfgWithNoStages, "", "")
+		tester.updateAndTest(numLogsToSend, cfgWithNoStages, forwardedEntriesTotalMetric(numLogsToSend*2), forwardedEntriesTotalMetric(numLogsToSend*3))
 	})
 
 	// Use a config which has a metric with a different name,
@@ -1605,13 +1605,18 @@ func TestMetricsStageRefresh(t *testing.T) {
 	# HELP loki_process_custom_outer_counter_2
 	# TYPE loki_process_custom_outer_counter_2 counter
 	loki_process_custom_outer_counter_2{filename="/var/log/pods/agent/agent/1.log",foo="bar"} %d
-	`
+	` + forwardedEntriesTotalMetric(numLogsToSend*4)
 
 	t.Run("config with a new and old metric", func(t *testing.T) {
-		tester.updateAndTest(numLogsToSend, updatedCfg,
-			"",
-			fmt.Sprintf(expectedMetrics3, numLogsToSend, numLogsToSend, numLogsToSend))
+		tester.updateAndTest(numLogsToSend, updatedCfg, forwardedEntriesTotalMetric(9), fmt.Sprintf(expectedMetrics3, numLogsToSend, numLogsToSend, numLogsToSend))
 	})
+}
+func forwardedEntriesTotalMetric(n int) string {
+	return fmt.Sprintf(`
+	# HELP loki_forwarded_entries_total Total number of entries sent to downstream components.
+	# TYPE loki_forwarded_entries_total counter
+	loki_forwarded_entries_total %d
+`, n)
 }
 
 type tester struct {

--- a/internal/component/loki/relabel/relabel.go
+++ b/internal/component/loki/relabel/relabel.go
@@ -101,7 +101,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		maxCacheSize:       args.MaxCacheSize,
 		debugDataPublisher: debugDataPublisher.(livedebugging.DebugDataPublisher),
 		builder:            labels.NewScratchBuilder(0),
-		fanout:             loki.NewFanout(args.ForwardTo),
+		fanout:             loki.NewFanout(args.ForwardTo, o.Registerer),
 	}
 
 	// Create and immediately export the receiver which remains the same for

--- a/internal/component/loki/secretfilter/secretfilter.go
+++ b/internal/component/loki/secretfilter/secretfilter.go
@@ -249,7 +249,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		opts:               o,
 		log:                o.SLogger,
 		receiver:           loki.NewLogsReceiver(loki.WithComponentID(o.ID)),
-		fanout:             loki.NewFanout(args.ForwardTo),
+		fanout:             loki.NewFanout(args.ForwardTo, o.Registerer),
 		metrics:            newMetrics(o.Registerer),
 		debugDataPublisher: debugDataPublisher.(livedebugging.DebugDataPublisher),
 	}

--- a/internal/component/loki/secretfilter/secretfilter_test.go
+++ b/internal/component/loki/secretfilter/secretfilter_test.go
@@ -63,7 +63,7 @@ func TestDefaultRate_Unmarshalled(t *testing.T) {
 // Valid custom config file loading (and [extend] useDefault) is tested in the
 // extend package so it runs in a separate process and avoids gitleaks global state.
 func TestGitleaksConfig_InvalidPath(t *testing.T) {
-	opts := newTestOptions(t, nil)
+	opts := newTestOptions(t, prometheus.DefaultRegisterer)
 	args := Arguments{
 		ForwardTo:      []loki.LogsReceiver{loki.NewLogsReceiver()},
 		GitleaksConfig: filepath.Join(t.TempDir(), "nonexistent.gitleaks.toml"),
@@ -344,7 +344,7 @@ func FuzzProcessEntry(f *testing.F) {
 		f.Add(testLog.Log)
 	}
 
-	opts := newTestOptions(f, nil)
+	opts := newTestOptions(f, prometheus.DefaultRegisterer)
 	ch1 := loki.NewLogsReceiver()
 
 	// Create component with default config

--- a/internal/component/loki/source/api/api.go
+++ b/internal/component/loki/source/api/api.go
@@ -73,7 +73,7 @@ func New(opts component.Options, args Arguments) (*Component, error) {
 		handler:            loki.NewLogsBatchReceiver(),
 		uncheckedCollector: util.NewUncheckedCollector(nil),
 
-		fanout: loki.NewFanout(args.ForwardTo),
+		fanout: loki.NewFanout(args.ForwardTo, opts.Registerer),
 	}
 	opts.Registerer.MustRegister(c.uncheckedCollector)
 	err := c.Update(args)

--- a/internal/component/loki/source/aws_firehose/component.go
+++ b/internal/component/loki/source/aws_firehose/component.go
@@ -64,7 +64,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		metrics:       newMetrics(o.Registerer),
 		opts:          o,
 		handler:       loki.NewLogsBatchReceiver(),
-		fanout:        loki.NewFanout(args.ForwardTo),
+		fanout:        loki.NewFanout(args.ForwardTo, o.Registerer),
 		serverMetrics: util.NewUncheckedCollector(nil),
 	}
 

--- a/internal/component/loki/source/azure_event_hubs/azure_event_hubs.go
+++ b/internal/component/loki/source/azure_event_hubs/azure_event_hubs.go
@@ -78,7 +78,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 	c := &Component{
 		opts:    o,
 		handler: loki.NewLogsReceiver(),
-		fanout:  loki.NewFanout(args.ForwardTo),
+		fanout:  loki.NewFanout(args.ForwardTo, o.Registerer),
 	}
 
 	// Call to Update() to start readers and set receivers once at the start.

--- a/internal/component/loki/source/cloudflare/cloudflare.go
+++ b/internal/component/loki/source/cloudflare/cloudflare.go
@@ -113,7 +113,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		opts:    o,
 		metrics: newMetrics(o.Registerer),
 		handler: loki.NewLogsReceiver(),
-		fanout:  loki.NewFanout(args.ForwardTo),
+		fanout:  loki.NewFanout(args.ForwardTo, o.Registerer),
 		posFile: positionsFile,
 	}
 

--- a/internal/component/loki/source/docker/docker.go
+++ b/internal/component/loki/source/docker/docker.go
@@ -140,7 +140,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		exited:    atomic.NewBool(false),
 		handler:   loki.NewLogsReceiver(),
 		scheduler: source.NewScheduler[string](),
-		fanout:    loki.NewFanout(args.ForwardTo),
+		fanout:    loki.NewFanout(args.ForwardTo, o.Registerer),
 		posFile:   positionsFile,
 	}
 

--- a/internal/component/loki/source/file/file.go
+++ b/internal/component/loki/source/file/file.go
@@ -233,7 +233,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		opts:      o,
 		metrics:   newMetrics(o.Registerer),
 		handler:   loki.NewLogsReceiver(),
-		fanout:    loki.NewFanout(args.ForwardTo),
+		fanout:    loki.NewFanout(args.ForwardTo, o.Registerer),
 		posFile:   positionsFile,
 		scheduler: source.NewScheduler[positions.Entry](),
 		watcher:   time.NewTicker(args.FileMatch.SyncPeriod),

--- a/internal/component/loki/source/gcplog/gcplog.go
+++ b/internal/component/loki/source/gcplog/gcplog.go
@@ -71,7 +71,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		opts:          o,
 		metrics:       gt.NewMetrics(o.Registerer),
 		handler:       loki.NewLogsReceiver(),
-		fanout:        loki.NewFanout(args.ForwardTo),
+		fanout:        loki.NewFanout(args.ForwardTo, o.Registerer),
 		serverMetrics: util.NewUncheckedCollector(nil),
 	}
 

--- a/internal/component/loki/source/gelf/gelf.go
+++ b/internal/component/loki/source/gelf/gelf.go
@@ -50,7 +50,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		opts:    o,
 		metrics: metrics,
 		handler: loki.NewLogsReceiver(),
-		fanout:  loki.NewFanout(args.ForwardTo),
+		fanout:  loki.NewFanout(args.ForwardTo, o.Registerer),
 	}
 	// Call to Update() to start readers and set receivers once at the start.
 	if err := c.Update(args); err != nil {

--- a/internal/component/loki/source/heroku/heroku.go
+++ b/internal/component/loki/source/heroku/heroku.go
@@ -67,7 +67,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		metrics:       newMetrics(o.Registerer),
 		mut:           sync.RWMutex{},
 		args:          Arguments{},
-		fanout:        loki.NewFanout(args.ForwardTo),
+		fanout:        loki.NewFanout(args.ForwardTo, o.Registerer),
 		handler:       loki.NewLogsBatchReceiver(),
 		serverMetrics: util.NewUncheckedCollector(nil),
 	}

--- a/internal/component/loki/source/journal/journal.go
+++ b/internal/component/loki/source/journal/journal.go
@@ -77,7 +77,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		opts:           o,
 		recv:           loki.NewLogsReceiver(),
 		positions:      positionsFile,
-		fanout:         loki.NewFanout(args.ForwardTo),
+		fanout:         loki.NewFanout(args.ForwardTo, o.Registerer),
 		targetsUpdated: make(chan struct{}, 1),
 		args:           args,
 	}

--- a/internal/component/loki/source/kafka/kafka.go
+++ b/internal/component/loki/source/kafka/kafka.go
@@ -103,7 +103,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 	c := &Component{
 		opts:    o,
 		handler: loki.NewLogsReceiver(),
-		fanout:  loki.NewFanout(args.ForwardTo),
+		fanout:  loki.NewFanout(args.ForwardTo, o.Registerer),
 	}
 
 	// Call to Update() to start readers and set receivers once at the start.

--- a/internal/component/loki/source/kubernetes/kubernetes.go
+++ b/internal/component/loki/source/kubernetes/kubernetes.go
@@ -102,7 +102,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		cluster:   data.(cluster.Cluster),
 		opts:      o,
 		handler:   loki.NewLogsReceiver(),
-		fanout:    loki.NewFanout(args.ForwardTo),
+		fanout:    loki.NewFanout(args.ForwardTo, o.Registerer),
 		positions: positionsFile,
 	}
 	if err := c.Update(args); err != nil {

--- a/internal/component/loki/source/kubernetes_events/kubernetes_events.go
+++ b/internal/component/loki/source/kubernetes_events/kubernetes_events.go
@@ -127,7 +127,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		handler:   loki.NewLogsReceiver(),
 		cluster:   data.(cluster.Cluster),
 		scheduler: source.NewScheduler[string](),
-		fanout:    loki.NewFanout(args.ForwardTo),
+		fanout:    loki.NewFanout(args.ForwardTo, o.Registerer),
 	}
 	if err := c.Update(args); err != nil {
 		return nil, err

--- a/internal/component/loki/source/podlogs/podlogs.go
+++ b/internal/component/loki/source/podlogs/podlogs.go
@@ -137,7 +137,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 
 		positions: positionsFile,
 		handler:   loki.NewLogsReceiver(),
-		fanout:    loki.NewFanout(args.ForwardTo),
+		fanout:    loki.NewFanout(args.ForwardTo, o.Registerer),
 	}
 	if err := c.Update(args); err != nil {
 		return nil, err

--- a/internal/component/loki/source/syslog/syslog.go
+++ b/internal/component/loki/source/syslog/syslog.go
@@ -63,7 +63,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		opts:            o,
 		metrics:         st.NewMetrics(o.Registerer),
 		handler:         loki.NewLogsReceiver(),
-		fanout:          loki.NewFanout(args.ForwardTo),
+		fanout:          loki.NewFanout(args.ForwardTo, o.Registerer),
 		targetsUpdated:  make(chan struct{}, 1),
 		targets:         []*st.SyslogTarget{},
 		liveDbgListener: newLiveDebuggingListener(o),

--- a/internal/component/loki/source/windowsevent/component_windows.go
+++ b/internal/component/loki/source/windowsevent/component_windows.go
@@ -48,7 +48,7 @@ type Component struct {
 func New(o component.Options, args Arguments) (*Component, error) {
 	c := &Component{
 		opts:   o,
-		fanout: loki.NewFanout(args.ForwardTo),
+		fanout: loki.NewFanout(args.ForwardTo, o.Registerer),
 		handle: loki.NewLogsReceiver(),
 		args:   args,
 	}

--- a/internal/pipelinetest/harness/source.go
+++ b/internal/pipelinetest/harness/source.go
@@ -41,7 +41,7 @@ func NewSource(opts component.Options, args SourceArguments) (*Source, error) {
 	s := &Source{
 		opts: opts,
 
-		lokiFanout: loki.NewFanout(args.ForwardTo.Logs),
+		lokiFanout: loki.NewFanout(args.ForwardTo.Logs, opts.Registerer),
 	}
 
 	s.opts.OnStateChange(SourceExports{})


### PR DESCRIPTION
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style with a capitalized
  description, e.g. `feat(scope): Add the thing` (not `add the thing`). For
  details on this, check out the Contributors Guide linked above.
-->

### Brief description of Pull Request

This PR adds the `loki_forwarded_entries_total` metric with the same semantics as `prometheus_forwarded_samples_total`. It records the number of entries forwarded to the next components.


### Issue(s) fixed by this Pull Request

Partial continuation of #5695 but includes all current components


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
