### PR TITLE
chore: Use targeted module lookup for BEYLA_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ GO_ENV := GOEXPERIMENT=$(GOEXPERIMENT) GOOS=$(GOOS) GOARCH=$(GOARCH) GOARM=$(GOA
 VERSION      ?= $(shell bash ./tools/image-tag)
 GIT_REVISION := $(shell git rev-parse --short HEAD)
 GIT_BRANCH   := $(shell git rev-parse --abbrev-ref HEAD)
-BEYLA_MODULE  := $(shell go list -m all | grep "^github.com/grafana/beyla" | head -1)
+BEYLA_MODULE  := $(shell go list -m -f '{{.Path}} {{.Version}}' github.com/grafana/beyla/v3 2>/dev/null)
 BEYLA_VERSION := $(shell echo $(BEYLA_MODULE) | cut -d' ' -f2)
 BEYLA_PKG     := $(shell echo $(BEYLA_MODULE) | cut -d' ' -f1)/pkg/buildinfo
 VPREFIX      := github.com/grafana/alloy/internal/build


### PR DESCRIPTION
### Brief description of Pull Request

`go list -m all` is brittle: any unresolvable transitive (e.g. a relative-path `replace` in a submodule) silently drops `BEYLA_MODULE` to empty, leaving `-X .../buildinfo.Version=` ldflag empty and `beyla_internal_build_info` reporting `version="unset"`. Use a targeted `go list -m github.com/grafana/beyla/v3` instead. Exposed by #6240's transitive `datadog-agent` v0.79.
