### PR TITLE
chore: Add k8s integration test for loki.source.podlogs

### DIFF
--- a/integration-tests/k8s/deps/loki.go
+++ b/integration-tests/k8s/deps/loki.go
@@ -137,7 +137,6 @@ func (l *Loki) QueryLogs(t *testing.T, testName string, expected ...ExpectedLogR
 
 		for _, e := range expected {
 			entries := matchingEntries(e.Labels, e.StructuredMetadata, parsed.Data.Result)
-			require.NotEmptyf(c, entries, "no entries with labels %v and structured metadata %v", e.Labels, e.StructuredMetadata)
 			require.Lenf(c, entries, e.EntryCount, "unexpected entry count for labels %v and structured metadata %v", e.Labels, e.StructuredMetadata)
 		}
 	}, timeout, retryInterval)

--- a/integration-tests/k8s/harness/harness.go
+++ b/integration-tests/k8s/harness/harness.go
@@ -64,11 +64,7 @@ func Setup(t *testing.T, opts Options) *TestContext {
 	t.Cleanup(func() { ctx.cleanup(t) })
 
 	for _, dep := range opts.Dependencies {
-		err := util.Step("install dep "+dep.Name(), func() error { return dep.Install(ctx) })
-		if err != nil {
-			t.Fatalf("install dependency %q: %v", dep.Name(), err)
-		}
-		ctx.dependencies = append(ctx.dependencies, dep)
+		ctx.AddDependency(t, dep)
 	}
 
 	return ctx
@@ -100,6 +96,14 @@ func (ctx *TestContext) cleanup(t *testing.T) {
 			return nil
 		})
 	}
+}
+
+func (ctx *TestContext) AddDependency(t *testing.T, dep Dependency) {
+	err := util.Step("install dep "+dep.Name(), func() error { return dep.Install(ctx) })
+	if err != nil {
+		t.Fatalf("install dependency %q: %v", dep.Name(), err)
+	}
+	ctx.dependencies = append(ctx.dependencies, dep)
 }
 
 func (ctx *TestContext) AddDiagnosticHook(name string, fn func(context.Context) error) {

--- a/integration-tests/k8s/tests/loki-source-podlogs/config/alloy-values.yaml
+++ b/integration-tests/k8s/tests/loki-source-podlogs/config/alloy-values.yaml
@@ -1,0 +1,4 @@
+controller:
+  type: daemonset
+alloy:
+  initialDelaySeconds: 1

--- a/integration-tests/k8s/tests/loki-source-podlogs/config/config.alloy
+++ b/integration-tests/k8s/tests/loki-source-podlogs/config/config.alloy
@@ -1,0 +1,31 @@
+logging {
+  level = "debug"
+}
+
+livedebugging {
+  enabled = true
+}
+
+loki.source.podlogs "pods" {
+  forward_to = [loki.process.tag.receiver]
+}
+
+loki.process "tag" {
+  forward_to = [loki.write.loki.receiver]
+
+  stage.structured_metadata {
+    values = {
+      pod = "",
+    }
+  }
+}
+
+loki.write "loki" {
+  endpoint {
+    url = "http://loki:3100/loki/api/v1/push"
+  }
+
+  external_labels = {
+      alloy_test_name = "loki-source-podlogs",
+  }
+}

--- a/integration-tests/k8s/tests/loki-source-podlogs/config/podlogs-a.yaml
+++ b/integration-tests/k8s/tests/loki-source-podlogs/config/podlogs-a.yaml
@@ -8,7 +8,7 @@ spec:
       alloy-logs-test: "true"
   namespaceSelector:
     matchLabels:
-      kubernetes.io/metadata.name: log-producer-a
+      kubernetes.io/metadata.name: podlogs-producer-a
   relabelings:
     - sourceLabels: [__meta_kubernetes_namespace]
       targetLabel: namespace

--- a/integration-tests/k8s/tests/loki-source-podlogs/config/podlogs-a.yaml
+++ b/integration-tests/k8s/tests/loki-source-podlogs/config/podlogs-a.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.grafana.com/v1alpha2
+kind: PodLogs
+metadata:
+  name: pod-logs-a
+spec:
+  selector:
+    matchLabels:
+      alloy-logs-test: "true"
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: log-producer-a
+  relabelings:
+    - sourceLabels: [__meta_kubernetes_namespace]
+      targetLabel: namespace
+    - sourceLabels: [__meta_kubernetes_pod_name]
+      targetLabel: pod

--- a/integration-tests/k8s/tests/loki-source-podlogs/config/podlogs-bc.yaml
+++ b/integration-tests/k8s/tests/loki-source-podlogs/config/podlogs-bc.yaml
@@ -10,7 +10,7 @@ spec:
     matchExpressions:
       - key: kubernetes.io/metadata.name
         operator: In
-        values: [log-producer-b, log-producer-c]
+        values: [podlogs-producer-b, podlogs-producer-c]
   relabelings:
     - sourceLabels: [__meta_kubernetes_namespace]
       targetLabel: namespace

--- a/integration-tests/k8s/tests/loki-source-podlogs/config/podlogs-bc.yaml
+++ b/integration-tests/k8s/tests/loki-source-podlogs/config/podlogs-bc.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.grafana.com/v1alpha2
+kind: PodLogs
+metadata:
+  name: pod-logs-bc
+spec:
+  selector:
+    matchLabels:
+      alloy-logs-test: "true"
+  namespaceSelector:
+    matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: In
+        values: [log-producer-b, log-producer-c]
+  relabelings:
+    - sourceLabels: [__meta_kubernetes_namespace]
+      targetLabel: namespace
+    - sourceLabels: [__meta_kubernetes_pod_name]
+      targetLabel: pod

--- a/integration-tests/k8s/tests/loki-source-podlogs/config/test.log
+++ b/integration-tests/k8s/tests/loki-source-podlogs/config/test.log
@@ -1,0 +1,10 @@
+line 1
+line 2
+line 3
+line 4
+line 5
+line 6
+line 7
+line 8
+line 9
+line 10

--- a/integration-tests/k8s/tests/loki-source-podlogs/k8s_test.go
+++ b/integration-tests/k8s/tests/loki-source-podlogs/k8s_test.go
@@ -1,0 +1,116 @@
+package lokisourcepodlogs
+
+import (
+	"testing"
+
+	"github.com/grafana/alloy/integration-tests/k8s/deps"
+	"github.com/grafana/alloy/integration-tests/k8s/harness"
+)
+
+func TestLokiSourcePodlogs(t *testing.T) {
+	namespace := deps.NewNamespace(deps.NamespaceOptions{
+		Name:   "test-loki-source-podlogs",
+		Labels: map[string]string{"alloy-integration-test": "true"},
+	})
+
+	targetA := deps.NewNamespace(deps.NamespaceOptions{Name: "log-producer-a"})
+	targetB := deps.NewNamespace(deps.NamespaceOptions{Name: "log-producer-b"})
+	targetC := deps.NewNamespace(deps.NamespaceOptions{Name: "log-producer-c"})
+
+	loki := deps.NewLoki(deps.LokiOptions{Namespace: namespace.Name()})
+
+	genA := deps.NewLogGen(deps.LogGenOptions{
+		Namespace: targetA.Name(),
+		Replicas:  2,
+		FilePath:  "./config/test.log",
+	})
+
+	genB := deps.NewLogGen(deps.LogGenOptions{
+		Namespace: targetB.Name(),
+		Replicas:  2,
+		FilePath:  "./config/test.log",
+	})
+
+	genC := deps.NewLogGen(deps.LogGenOptions{
+		Namespace: targetC.Name(),
+		Replicas:  2,
+		FilePath:  "./config/test.log",
+	})
+
+	alloy := deps.NewAlloy(deps.AlloyOptions{
+		Namespace:  namespace.Name(),
+		Release:    "alloy-test-loki-source-podlogs",
+		ConfigPath: "./config/config.alloy",
+		ValuesPath: "./config/alloy-values.yaml",
+	})
+
+	podLogsA := deps.NewCustomWorkloads(deps.CustomWorkloadsOptions{
+		Namespace: namespace.Name(),
+		Path:      "./config/podlogs-a.yaml",
+	})
+
+	ctx := harness.Setup(t, harness.Options{
+		Dependencies: []harness.Dependency{namespace, targetA, targetB, targetC, genA, genB, genC, loki, alloy, podLogsA},
+	})
+
+	loki.QueryLogs(t, "loki-source-podlogs",
+		deps.ExpectedLogResult{
+			EntryCount:         10,
+			Labels:             map[string]string{"namespace": targetA.Name()},
+			StructuredMetadata: map[string]string{"pod": "log-gen-0"},
+		},
+		deps.ExpectedLogResult{
+			EntryCount:         10,
+			Labels:             map[string]string{"namespace": targetA.Name()},
+			StructuredMetadata: map[string]string{"pod": "log-gen-1"},
+		},
+		deps.ExpectedLogResult{
+			EntryCount: 0,
+			Labels:     map[string]string{"namespace": targetB.Name()},
+		},
+		deps.ExpectedLogResult{
+			EntryCount: 0,
+			Labels:     map[string]string{"namespace": targetC.Name()},
+		},
+	)
+
+	podLogsBC := deps.NewCustomWorkloads(deps.CustomWorkloadsOptions{
+		Namespace: namespace.Name(),
+		Path:      "./config/podlogs-bc.yaml",
+	})
+
+	ctx.AddDependency(t, podLogsBC)
+
+	loki.QueryLogs(t, "loki-source-podlogs",
+		deps.ExpectedLogResult{
+			EntryCount:         10,
+			Labels:             map[string]string{"namespace": targetA.Name()},
+			StructuredMetadata: map[string]string{"pod": "log-gen-0"},
+		},
+		deps.ExpectedLogResult{
+			EntryCount:         10,
+			Labels:             map[string]string{"namespace": targetA.Name()},
+			StructuredMetadata: map[string]string{"pod": "log-gen-1"},
+		},
+		deps.ExpectedLogResult{
+			EntryCount:         10,
+			Labels:             map[string]string{"namespace": targetB.Name()},
+			StructuredMetadata: map[string]string{"pod": "log-gen-0"},
+		},
+		deps.ExpectedLogResult{
+			EntryCount:         10,
+			Labels:             map[string]string{"namespace": targetB.Name()},
+			StructuredMetadata: map[string]string{"pod": "log-gen-1"},
+		},
+		deps.ExpectedLogResult{
+			EntryCount:         10,
+			Labels:             map[string]string{"namespace": targetC.Name()},
+			StructuredMetadata: map[string]string{"pod": "log-gen-0"},
+		},
+		deps.ExpectedLogResult{
+			EntryCount:         10,
+			Labels:             map[string]string{"namespace": targetC.Name()},
+			StructuredMetadata: map[string]string{"pod": "log-gen-1"},
+		},
+	)
+}

--- a/integration-tests/k8s/tests/loki-source-podlogs/k8s_test.go
+++ b/integration-tests/k8s/tests/loki-source-podlogs/k8s_test.go
@@ -13,9 +13,9 @@ func TestLokiSourcePodlogs(t *testing.T) {
 		Labels: map[string]string{"alloy-integration-test": "true"},
 	})
 
-	targetA := deps.NewNamespace(deps.NamespaceOptions{Name: "log-producer-a"})
-	targetB := deps.NewNamespace(deps.NamespaceOptions{Name: "log-producer-b"})
-	targetC := deps.NewNamespace(deps.NamespaceOptions{Name: "log-producer-c"})
+	targetA := deps.NewNamespace(deps.NamespaceOptions{Name: "podlogs-producer-a"})
+	targetB := deps.NewNamespace(deps.NamespaceOptions{Name: "podlogs-producer-b"})
+	targetC := deps.NewNamespace(deps.NamespaceOptions{Name: "podlogs-producer-c"})
 
 	loki := deps.NewLoki(deps.LokiOptions{Namespace: namespace.Name()})
 


### PR DESCRIPTION
### Pull Request Details
Add k8s integration test for `loki.source.podlogs`. This will create 3 namespaces and deploy 2 log generators in each namespace. We then create a podlogs resource that will start collecting logs from namespace `a` and assert that we only  collect those logs. After that we deploy another podlogs resource that will kick off collection of logs for the remaining two namespaces and assert that we got everything we expect.

### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->

### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
