### PR TITLE
chore(runtime): Poll for component health in TestRuntime to avoid Windows-only race

### DIFF
--- a/internal/runtime/alloy_test.go
+++ b/internal/runtime/alloy_test.go
@@ -53,9 +53,14 @@ func TestRuntime(t *testing.T) {
 
 	var verifyHealth = func(comps []ScheduledComponent, l int, h component.HealthType) {
 		require.Len(t, comps, l)
-		for _, c := range comps {
-			assert.Equal(t, h, c.CurrentHealth().Health, "unexpected status for %s", c.NodeID())
-		}
+		// Component runHealth transitions to its terminal value inside the Run
+		// goroutine after the scheduler launches it, which happens asynchronously
+		// from LoadComplete. Poll so the assertion is not racey on slow runners.
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			for _, c := range comps {
+				assert.Equal(collect, h, c.CurrentHealth().Health, "unexpected status for %s", c.NodeID())
+			}
+		}, 2*time.Second, 50*time.Millisecond)
 	}
 
 	var verifyService = func(s serviceState, running bool) {


### PR DESCRIPTION
### Brief description of Pull Request

`TestRuntime` intermittently fails on the Windows CI runner with `unexpected status for foreach.fe` / `unexpected status for test.module.m` — `CurrentHealth().Health` reads `Unknown` instead of `Healthy`.

`reload()` only waits for `ctrl.LoadComplete()`, which flips true right after `sched.Synchronize` schedules the component goroutines but before those goroutines have called `setRunHealth(Healthy)`. For `CustomComponentNode` and `ForeachConfigNode`, `CurrentHealth() = LeastHealthy(runHealth, evalHealth)`, so until the Run goroutine wakes up the combined health is `Unknown`. On the slower Windows runner that window stays open long enough to lose the race.

Switch `verifyHealth` to `require.EventuallyWithT` (2s window, 50ms poll) so the assertion waits for the steady-state health. Length is still asserted immediately.

Recent example failure: https://github.com/grafana/alloy/actions/runs/25803682368/job/75800389765