### PR TITLE
chore(database_observability.mysql): Cleanup schema_details cache settings

### DIFF
--- a/internal/component/database_observability/mysql/collector/schema_details.go
+++ b/internal/component/database_observability/mysql/collector/schema_details.go
@@ -25,10 +25,10 @@ const (
 	OP_CREATE_STATEMENT    = "create_statement"
 )
 
-// EmitInterval is the minimum amount of time that must elapse between
+// emitInterval is the minimum amount of time that must elapse between
 // successive OP_CREATE_STATEMENT emissions for the same table, regardless of
 // the configured collect_interval.
-const EmitInterval = 30 * time.Minute
+const emitInterval = 30 * time.Minute
 
 const (
 	selectTablesTemplate = `
@@ -116,8 +116,8 @@ type SchemaDetails struct {
 	// to at most one per EmitInterval per table.
 	lastEmittedAt map[string]time.Time
 
-	// nowFn allows overriding time.Now() in tests
-	nowFn func() time.Time
+	// now allows overriding time.Now() in tests
+	now func() time.Time
 
 	logger  log.Logger
 	running *atomic.Bool
@@ -173,7 +173,7 @@ func NewSchemaDetails(args SchemaDetailsArguments) (*SchemaDetails, error) {
 		excludeSchemas:  args.ExcludeSchemas,
 		entryHandler:    args.EntryHandler,
 		lastEmittedAt:   map[string]time.Time{},
-		nowFn:           time.Now,
+		now:             time.Now,
 		logger:          log.With(args.Logger, "collector", SchemaDetailsCollector),
 		running:         &atomic.Bool{},
 	}
@@ -235,7 +235,7 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 	}
 	defer rs.Close()
 
-	now := c.nowFn()
+	now := c.now()
 	tables := []*tableInfo{}
 	seenTables := map[string]struct{}{}
 	for rs.Next() {
@@ -282,13 +282,13 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 	}
 
 	// Compute the due set: tables that have never emitted OP_CREATE_STATEMENT
-	// or whose last emission is older than EmitInterval.
+	// or whose last emission is older than emitInterval.
 	// Group by schema to preserve the iteration order from the tables-list query.
 	dueBySchema := map[string][]*tableInfo{}
 	dueSchemas := []string{}
 	for _, t := range tables {
 		k := fullyQualifiedName(t.schema, t.tableName)
-		if last, ok := c.lastEmittedAt[k]; ok && now.Sub(last) < EmitInterval {
+		if last, ok := c.lastEmittedAt[k]; ok && now.Sub(last) < emitInterval {
 			continue
 		}
 		if _, exists := dueBySchema[t.schema]; !exists {

--- a/internal/component/database_observability/mysql/collector/schema_details_test.go
+++ b/internal/component/database_observability/mysql/collector/schema_details_test.go
@@ -491,7 +491,7 @@ func TestSchemaDetails(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
-		collector.nowFn = func() time.Time { return fakeNow }
+		collector.now = func() time.Time { return fakeNow }
 
 		// First scrape: tables list, bulk metadata, then SHOW CREATE TABLE.
 		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
@@ -580,7 +580,7 @@ func TestSchemaDetails(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
-		collector.nowFn = func() time.Time { return fakeNow }
+		collector.now = func() time.Time { return fakeNow }
 
 		// Two scrapes' worth of expectations: tables list + bulk metadata +
 		// SHOW CREATE each time.
@@ -618,7 +618,7 @@ func TestSchemaDetails(t *testing.T) {
 		}
 
 		require.NoError(t, collector.extractSchema(t.Context()))
-		fakeNow = fakeNow.Add(EmitInterval + time.Minute) // past the throttle window
+		fakeNow = fakeNow.Add(emitInterval + time.Minute) // past the throttle window
 		require.NoError(t, collector.extractSchema(t.Context()))
 
 		require.Eventually(t, func() bool {
@@ -661,7 +661,7 @@ func TestSchemaDetails(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
-		collector.nowFn = func() time.Time { return fakeNow }
+		collector.now = func() time.Time { return fakeNow }
 
 		// First scrape: two tables in the same schema.
 		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().

--- a/internal/component/database_observability/mysql/component.go
+++ b/internal/component/database_observability/mysql/component.go
@@ -106,10 +106,10 @@ type QueryDetailsArguments struct {
 }
 
 type SchemaDetailsArguments struct {
-	CollectInterval time.Duration `alloy:"collect_interval,attr,optional"`
-	CacheEnabled    bool          `alloy:"cache_enabled,attr,optional"`
-	CacheSize       int           `alloy:"cache_size,attr,optional"`
-	CacheTTL        time.Duration `alloy:"cache_ttl,attr,optional"`
+	CollectInterval time.Duration  `alloy:"collect_interval,attr,optional"`
+	CacheEnabled    *bool          `alloy:"cache_enabled,attr,optional"`
+	CacheSize       *int           `alloy:"cache_size,attr,optional"`
+	CacheTTL        *time.Duration `alloy:"cache_ttl,attr,optional"`
 }
 
 type SetupConsumersArguments struct {
@@ -175,11 +175,6 @@ func defaultArguments() Arguments {
 
 		SchemaDetailsArguments: SchemaDetailsArguments{
 			CollectInterval: 1 * time.Minute,
-
-			// Deprecated settings, ignored.
-			CacheEnabled: true,
-			CacheSize:    256,
-			CacheTTL:     10 * time.Minute,
 		},
 
 		SetupConsumersArguments: SetupConsumersArguments{
@@ -589,12 +584,14 @@ func (c *Component) startCollectors(serverID string, engineVersion string, parse
 	}
 
 	if collectors[collector.SchemaDetailsCollector] {
-		if c.args.SchemaDetailsArguments.CollectInterval > collector.EmitInterval {
-			level.Warn(c.opts.Logger).Log(
-				"msg", "schema_details.collect_interval is greater than the log interval; log entries will be emitted at most once per collect_interval",
-				"collect_interval", c.args.SchemaDetailsArguments.CollectInterval,
-				"log_interval", collector.EmitInterval,
-			)
+		if c.args.SchemaDetailsArguments.CacheEnabled != nil {
+			level.Warn(c.opts.Logger).Log("msg", "schema_details.cache_enabled is set, but the cache is deprecated and will be removed in a future version")
+		}
+		if c.args.SchemaDetailsArguments.CacheSize != nil {
+			level.Warn(c.opts.Logger).Log("msg", "schema_details.cache_size is set, but the cache is deprecated and will be removed in a future version")
+		}
+		if c.args.SchemaDetailsArguments.CacheTTL != nil {
+			level.Warn(c.opts.Logger).Log("msg", "schema_details.cache_ttl is set, but the cache is deprecated and will be removed in a future version")
 		}
 
 		stCollector, err := collector.NewSchemaDetails(collector.SchemaDetailsArguments{


### PR DESCRIPTION
### Brief description of Pull Request
Changes:
- do not expose emitInterval
- rename nowFn
- remove non-actionable log message around collect_interval
- stop setting cache default values and emit deprecation warnings

Followup of https://github.com/grafana/alloy/pull/6239





<!-- Human-readable description of the PR used as squash commit body. -->


### Pull Request Details

<!-- Detailed descripion of the Pull Request, if needed. -->


### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->


### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
