### PR TITLE
feat(database_observability.postgres): Throttle schema details create_statement logs

### DIFF
--- a/docs/sources/reference/components/database_observability/database_observability.postgres.md
+++ b/docs/sources/reference/components/database_observability/database_observability.postgres.md
@@ -145,12 +145,14 @@ The `gcp` block supplies the identifying information for the GCP Cloud SQL datab
 
 ### `schema_details`
 
-| Name               | Type       | Description                                                           | Default | Required |
-|--------------------|------------|-----------------------------------------------------------------------|---------|----------|
-| `collect_interval` | `duration` | How frequently to collect information from database.                  | `"1m"`  | no       |
-| `cache_enabled`    | `boolean`  | Whether to enable caching of table definitions.                       | `true`  | no       |
-| `cache_size`       | `integer`  | Cache size.                                                           | `256`   | no       |
-| `cache_ttl`        | `duration` | Cache TTL.                                                            | `"10m"` | no       |
+| Name               | Type       | Description                                                 | Default | Required |
+|--------------------|------------|-------------------------------------------------------------|---------|----------|
+| `collect_interval` | `duration` | How frequently to collect information from database.        | `"1m"`  | no       |
+| `cache_enabled`    | `boolean`  | Deprecated. Whether to enable caching of table definitions. | `true`  | no       |
+| `cache_size`       | `integer`  | Deprecated. Cache size.                                     | `256`   | no       |
+| `cache_ttl`        | `duration` | Deprecated. Cache TTL.                                      | `"10m"` | no       |
+
+The `cache_enabled`, `cache_size`, and `cache_ttl` settings are deprecated: they are accepted for backward compatibility, but ignored.
 
 ### `explain_plans`
 

--- a/integration-tests/docker/tests/database-observability-postgres/postgres_test.go
+++ b/integration-tests/docker/tests/database-observability-postgres/postgres_test.go
@@ -5,10 +5,11 @@ package main
 import (
 	"testing"
 
-	"github.com/grafana/alloy/integration-tests/docker/common"
-	"github.com/grafana/alloy/integration-tests/internal/lokihttp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/integration-tests/docker/common"
+	"github.com/grafana/alloy/integration-tests/internal/lokihttp"
 )
 
 const testName = "database_observability_postgres"
@@ -31,21 +32,16 @@ func TestDatabaseObservabilityPostgresLogs(t *testing.T) {
 		"create_statement",
 	}
 
-	var logResponse lokihttp.LogResponse
-
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		_, err := common.FetchDataFromURL(common.LogQuery(testName, 100), &logResponse)
-		assert.NoError(c, err)
-
-		ops := make(map[string]bool)
-		for _, result := range logResponse.Data.Result {
-			if op, ok := result.Stream["op"]; ok {
-				ops[op] = true
-			}
-		}
-
 		for _, op := range expectedOps {
-			assert.True(c, ops[op], "expected %s logs", op)
+			var resp lokihttp.LogResponse
+			_, err := common.FetchDataFromURL(
+				// fetch one log with exact match for op label
+				common.LogQuery(testName, 1, common.LabelMatcher{Name: "op", Value: op}),
+				&resp,
+			)
+			assert.NoError(c, err)
+			assert.NotEmpty(c, resp.Data.Result, "expected at least one log with op=%s", op)
 		}
 	}, common.TestTimeoutEnv(t), common.DefaultRetryInterval)
 }

--- a/internal/component/database_observability/mysql/collector/schema_details_test.go
+++ b/internal/component/database_observability/mysql/collector/schema_details_test.go
@@ -525,7 +525,7 @@ func TestSchemaDetails(t *testing.T) {
 				AddRow("some_schema.some_table", "CREATE TABLE some_table (id INT)"))
 
 		// Second scrape: only the tables list. The scrape is throttled (still
-		// within EmitInterval) so it must not trigger any create-statement
+		// within emitInterval) so it must not trigger any create-statement
 		// related queries.
 		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{
@@ -537,7 +537,7 @@ func TestSchemaDetails(t *testing.T) {
 			))
 
 		require.NoError(t, collector.extractSchema(t.Context()))
-		fakeNow = fakeNow.Add(time.Minute) // well within EmitInterval
+		fakeNow = fakeNow.Add(time.Minute) // well within emitInterval
 		require.NoError(t, collector.extractSchema(t.Context()))
 
 		// First scrape emits OP_TABLE_DETECTION + OP_CREATE_STATEMENT; second
@@ -710,7 +710,7 @@ func TestSchemaDetails(t *testing.T) {
 
 		// Second scrape: only table_a remains. table_b should be evicted from
 		// the throttle map by housekeeping. Since table_a was already emitted
-		// less than EmitInterval ago, no further fetch queries are expected.
+		// less than emitInterval ago, no further fetch queries are expected.
 		fakeNow = fakeNow.Add(time.Minute)
 		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{

--- a/internal/component/database_observability/postgres/collector/schema_details.go
+++ b/internal/component/database_observability/postgres/collector/schema_details.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/lib/pq"
 	"go.uber.org/atomic"
 
@@ -25,6 +24,11 @@ const (
 	OP_TABLE_DETECTION     = "table_detection"
 	OP_CREATE_STATEMENT    = "create_statement"
 )
+
+// emitInterval is the minimum amount of time that must elapse between
+// successive OP_CREATE_STATEMENT emissions for the same table, regardless of
+// the configured collect_interval.
+const emitInterval = 30 * time.Minute
 
 const (
 	// selectAllDatabases makes use of the initial DB connection to discover other databases on the same Postgres instance
@@ -312,10 +316,6 @@ type SchemaDetailsArguments struct {
 	ExcludeDatabases []string
 	EntryHandler     loki.EntryHandler
 
-	CacheEnabled bool
-	CacheSize    int
-	CacheTTL     time.Duration
-
 	Logger *slog.Logger
 
 	dbConnectionFactory databaseConnectionFactory
@@ -329,10 +329,13 @@ type SchemaDetails struct {
 	excludeDatabases    []string
 	entryHandler        loki.EntryHandler
 
-	// Cache of table definitions. Entries are removed after a configurable TTL.
-	// Key is a string of the form "database.schema.table".
-	// (unlike MySQL) no create/update timestamp available for detecting immediately when a table schema is changed; relying on TTL only
-	cache *expirable.LRU[string, *tableInfo]
+	// lastEmittedAt records the wall-clock time at which OP_CREATE_STATEMENT
+	// was last emitted for a "database.schema.table" key. Used to throttle
+	// logging to at most one per EmitInterval per table.
+	lastEmittedAt map[string]time.Time
+
+	// now allows overriding time.Now() in tests
+	now func() time.Time
 
 	tableRegistry *TableRegistry
 
@@ -356,13 +359,11 @@ func NewSchemaDetails(args SchemaDetailsArguments) (*SchemaDetails, error) {
 		collectInterval:     args.CollectInterval,
 		excludeDatabases:    args.ExcludeDatabases,
 		entryHandler:        args.EntryHandler,
+		lastEmittedAt:       map[string]time.Time{},
+		now:                 time.Now,
 		tableRegistry:       NewTableRegistry(),
 		logger:              args.Logger.With("collector", SchemaDetailsCollector),
 		running:             &atomic.Bool{},
-	}
-
-	if args.CacheEnabled {
-		c.cache = expirable.NewLRU[string, *tableInfo](args.CacheSize, nil, args.CacheTTL)
 	}
 
 	return c, nil
@@ -445,7 +446,7 @@ func (c *SchemaDetails) getAllDatabases(ctx context.Context) ([]string, error) {
 	return databases, nil
 }
 
-func (c *SchemaDetails) extractSchemas(ctx context.Context, dbName string, dbConnection *sql.DB) error {
+func (c *SchemaDetails) extractSchemas(ctx context.Context, dbName string, dbConnection *sql.DB, now time.Time, seenTables map[string]struct{}) error {
 	schemaRs, err := dbConnection.QueryContext(ctx, selectSchemaNames)
 	if err != nil {
 		return fmt.Errorf("failed to query pg_namespace for database %s: %w", dbName, err)
@@ -491,8 +492,9 @@ func (c *SchemaDetails) extractSchemas(ctx context.Context, dbName string, dbCon
 				database:   database(dbName),
 				schema:     schema(schemaName),
 				tableName:  table(tableName),
-				updateTime: time.Now(),
+				updateTime: now,
 			})
+			seenTables[fullyQualifiedName(database(dbName), schema(schemaName), table(tableName))] = struct{}{}
 
 			c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
 				logging.LevelInfo,
@@ -514,25 +516,15 @@ func (c *SchemaDetails) extractSchemas(ctx context.Context, dbName string, dbCon
 	}
 
 	for _, table := range tables {
-		cacheKey := fmt.Sprintf("%s.%s.%s", table.database, table.schema, table.tableName)
-
-		cacheHit := false
-		if c.cache != nil {
-			if cached, ok := c.cache.Get(cacheKey); ok {
-				table = cached
-				cacheHit = true
-			}
+		key := fullyQualifiedName(table.database, table.schema, table.tableName)
+		if last, ok := c.lastEmittedAt[key]; ok && now.Sub(last) < emitInterval {
+			continue
 		}
 
-		if !cacheHit {
-			table, err = c.fetchTableDefinitions(ctx, table, dbConnection)
-			if err != nil {
-				c.logger.Error("failed to get table definitions", "datname", dbName, "schema", table.schema, "table", table.tableName, "err", err)
-				continue
-			}
-			if c.cache != nil {
-				c.cache.Add(cacheKey, table)
-			}
+		table, err = c.fetchTableDefinitions(ctx, table, dbConnection)
+		if err != nil {
+			c.logger.Error("failed to get table definitions", "datname", dbName, "schema", table.schema, "table", table.tableName, "err", err)
+			continue
 		}
 
 		c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
@@ -543,6 +535,7 @@ func (c *SchemaDetails) extractSchemas(ctx context.Context, dbName string, dbCon
 				dbName, table.schema, table.tableName, table.b64TableSpec,
 			),
 		)
+		c.lastEmittedAt[key] = now
 	}
 
 	return nil
@@ -554,6 +547,9 @@ func (c *SchemaDetails) extractNames(ctx context.Context) error {
 		c.logger.Error("failed to discover databases", "err", err)
 		return fmt.Errorf("failed to discover databases: %w", err)
 	}
+
+	now := c.now()
+	seenTables := map[string]struct{}{}
 
 	for _, dbName := range databases {
 		databaseDSN, err := replaceDatabaseNameInDSN(c.dbDSN, dbName)
@@ -568,7 +564,7 @@ func (c *SchemaDetails) extractNames(ctx context.Context) error {
 			continue
 		}
 
-		if err := c.extractSchemas(ctx, dbName, conn); err != nil {
+		if err := c.extractSchemas(ctx, dbName, conn, now, seenTables); err != nil {
 			c.logger.Error("failed to collect schema from database", "datname", dbName, "err", err)
 			if conn != c.initialConnection {
 				conn.Close()
@@ -580,6 +576,14 @@ func (c *SchemaDetails) extractNames(ctx context.Context) error {
 			if err := conn.Close(); err != nil {
 				c.logger.Warn("failed to close database connection", "datname", dbName, "err", err)
 			}
+		}
+	}
+
+	// Cleanup: drop throttle entries for tables (or whole databases) that no
+	// longer exist in any scanned database.
+	for k := range c.lastEmittedAt {
+		if _, ok := seenTables[k]; !ok {
+			delete(c.lastEmittedAt, k)
 		}
 	}
 
@@ -710,4 +714,8 @@ func (c *SchemaDetails) fetchColumnsDefinitions(ctx context.Context, databaseNam
 	}
 
 	return tblSpec, nil
+}
+
+func fullyQualifiedName(db database, sch schema, tbl table) string {
+	return fmt.Sprintf("%s.%s.%s", db, sch, tbl)
 }

--- a/internal/component/database_observability/postgres/collector/schema_details.go
+++ b/internal/component/database_observability/postgres/collector/schema_details.go
@@ -764,10 +764,6 @@ func (c *SchemaDetails) fetchColumnsDefinitions(ctx context.Context, databaseNam
 	return tblSpec, nil
 }
 
-func fullyQualifiedName(db database, sch schema, tbl table) string {
-	return fmt.Sprintf("%s.%s.%s", db, sch, tbl)
-}
-
 func schemaTableKey(sch schema, tbl table) string {
 	return fmt.Sprintf("%s.%s", sch, tbl)
 }

--- a/internal/component/database_observability/postgres/collector/schema_details.go
+++ b/internal/component/database_observability/postgres/collector/schema_details.go
@@ -178,7 +178,6 @@ type tableInfo struct {
 	database     database
 	schema       schema
 	tableName    table
-	updateTime   time.Time
 	b64TableSpec string
 }
 
@@ -330,9 +329,10 @@ type SchemaDetails struct {
 	entryHandler        loki.EntryHandler
 
 	// lastEmittedAt records the wall-clock time at which OP_CREATE_STATEMENT
-	// was last emitted for a "database.schema.table" key. Used to throttle
-	// logging to at most one per EmitInterval per table.
-	lastEmittedAt map[string]time.Time
+	// was last emitted for a table. The outer key is the database name and
+	// the inner key is "schema.table". Used to throttle logging to at most
+	// one per emitInterval per table.
+	lastEmittedAt map[database]map[string]time.Time
 
 	// now allows overriding time.Now() in tests
 	now func() time.Time
@@ -359,7 +359,7 @@ func NewSchemaDetails(args SchemaDetailsArguments) (*SchemaDetails, error) {
 		collectInterval:     args.CollectInterval,
 		excludeDatabases:    args.ExcludeDatabases,
 		entryHandler:        args.EntryHandler,
-		lastEmittedAt:       map[string]time.Time{},
+		lastEmittedAt:       map[database]map[string]time.Time{},
 		now:                 time.Now,
 		tableRegistry:       NewTableRegistry(),
 		logger:              args.Logger.With("collector", SchemaDetailsCollector),
@@ -446,7 +446,10 @@ func (c *SchemaDetails) getAllDatabases(ctx context.Context) ([]string, error) {
 	return databases, nil
 }
 
-func (c *SchemaDetails) extractSchemas(ctx context.Context, dbName string, dbConnection *sql.DB, now time.Time, seenTables map[string]struct{}) error {
+func (c *SchemaDetails) extractSchemas(ctx context.Context, dbName string, dbConnection *sql.DB) error {
+	now := c.now()
+	db := database(dbName)
+
 	schemaRs, err := dbConnection.QueryContext(ctx, selectSchemaNames)
 	if err != nil {
 		return fmt.Errorf("failed to query pg_namespace for database %s: %w", dbName, err)
@@ -469,15 +472,22 @@ func (c *SchemaDetails) extractSchemas(ctx context.Context, dbName string, dbCon
 
 	if len(schemas) == 0 {
 		c.logger.Info("no schema detected from pg_namespace", "datname", dbName)
+		c.pruneDatabaseThrottle(db, nil)
 		return nil
 	}
 
 	tables := []*tableInfo{}
+	// scanComplete tracks whether we managed to iterate every schema's
+	// tables without bailing out early. If false, we have a partial view of
+	// the database and must skip cleanup to avoid evicting throttle entries
+	// for tables we simply didn't get to scan this round.
+	scanComplete := true
 
 	for _, schemaName := range schemas {
 		rs, err := dbConnection.QueryContext(ctx, selectTableNames, schemaName)
 		if err != nil {
 			c.logger.Error("failed to query tables", "datname", dbName, "schema", schemaName, "err", err)
+			scanComplete = false
 			break
 		}
 		defer rs.Close()
@@ -486,15 +496,14 @@ func (c *SchemaDetails) extractSchemas(ctx context.Context, dbName string, dbCon
 			var tableName string
 			if err := rs.Scan(&tableName); err != nil {
 				c.logger.Error("failed to scan tables", "datname", dbName, "schema", schemaName, "err", err)
+				scanComplete = false
 				break
 			}
 			tables = append(tables, &tableInfo{
-				database:   database(dbName),
-				schema:     schema(schemaName),
-				tableName:  table(tableName),
-				updateTime: now,
+				database:  db,
+				schema:    schema(schemaName),
+				tableName: table(tableName),
 			})
-			seenTables[fullyQualifiedName(database(dbName), schema(schemaName), table(tableName))] = struct{}{}
 
 			c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
 				logging.LevelInfo,
@@ -508,17 +517,24 @@ func (c *SchemaDetails) extractSchemas(ctx context.Context, dbName string, dbCon
 		}
 	}
 
-	c.tableRegistry.SetTablesForDatabase(database(dbName), tables)
+	if scanComplete {
+		c.tableRegistry.SetTablesForDatabase(db, tables)
+	}
 
 	if len(tables) == 0 {
 		c.logger.Info("no tables detected from pg_tables", "datname", dbName)
+		if scanComplete {
+			c.pruneDatabaseThrottle(db, nil)
+		}
 		return nil
 	}
 
 	for _, table := range tables {
-		key := fullyQualifiedName(table.database, table.schema, table.tableName)
-		if last, ok := c.lastEmittedAt[key]; ok && now.Sub(last) < emitInterval {
-			continue
+		key := schemaTableKey(table.schema, table.tableName)
+		if inner := c.lastEmittedAt[db]; inner != nil {
+			if last, ok := inner[key]; ok && now.Sub(last) < emitInterval {
+				continue
+			}
 		}
 
 		table, err = c.fetchTableDefinitions(ctx, table, dbConnection)
@@ -535,10 +551,40 @@ func (c *SchemaDetails) extractSchemas(ctx context.Context, dbName string, dbCon
 				dbName, table.schema, table.tableName, table.b64TableSpec,
 			),
 		)
-		c.lastEmittedAt[key] = now
+		if c.lastEmittedAt[db] == nil {
+			c.lastEmittedAt[db] = map[string]time.Time{}
+		}
+		c.lastEmittedAt[db][key] = now
+	}
+
+	if scanComplete {
+		c.pruneDatabaseThrottle(db, tables)
 	}
 
 	return nil
+}
+
+// pruneDatabaseThrottle removes entries in c.lastEmittedAt[db] whose
+// schema.table key is not present in the given tables. If the resulting
+// inner map is empty, the outer entry is also deleted. Must only be called
+// after a complete scan of the database's tables.
+func (c *SchemaDetails) pruneDatabaseThrottle(db database, tables []*tableInfo) {
+	if _, ok := c.lastEmittedAt[db]; !ok {
+		return
+	}
+
+	currentKeys := make(map[string]struct{}, len(tables))
+	for _, t := range tables {
+		currentKeys[schemaTableKey(t.schema, t.tableName)] = struct{}{}
+	}
+	for k := range c.lastEmittedAt[db] {
+		if _, ok := currentKeys[k]; !ok {
+			delete(c.lastEmittedAt[db], k)
+		}
+	}
+	if len(c.lastEmittedAt[db]) == 0 {
+		delete(c.lastEmittedAt, db)
+	}
 }
 
 func (c *SchemaDetails) extractNames(ctx context.Context) error {
@@ -547,9 +593,6 @@ func (c *SchemaDetails) extractNames(ctx context.Context) error {
 		c.logger.Error("failed to discover databases", "err", err)
 		return fmt.Errorf("failed to discover databases: %w", err)
 	}
-
-	now := c.now()
-	seenTables := map[string]struct{}{}
 
 	for _, dbName := range databases {
 		databaseDSN, err := replaceDatabaseNameInDSN(c.dbDSN, dbName)
@@ -564,7 +607,7 @@ func (c *SchemaDetails) extractNames(ctx context.Context) error {
 			continue
 		}
 
-		if err := c.extractSchemas(ctx, dbName, conn, now, seenTables); err != nil {
+		if err := c.extractSchemas(ctx, dbName, conn); err != nil {
 			c.logger.Error("failed to collect schema from database", "datname", dbName, "err", err)
 			if conn != c.initialConnection {
 				conn.Close()
@@ -579,11 +622,16 @@ func (c *SchemaDetails) extractNames(ctx context.Context) error {
 		}
 	}
 
-	// Cleanup: drop throttle entries for tables (or whole databases) that no
-	// longer exist in any scanned database.
-	for k := range c.lastEmittedAt {
-		if _, ok := seenTables[k]; !ok {
-			delete(c.lastEmittedAt, k)
+	// Drop throttle entries for databases that getAllDatabases no longer
+	// returns (dropped, CONNECT revoked, added to exclude list). Per-table
+	// cleanup within a still-present database is handled by extractSchemas.
+	seenDatabases := make(map[database]struct{}, len(databases))
+	for _, dbName := range databases {
+		seenDatabases[database(dbName)] = struct{}{}
+	}
+	for db := range c.lastEmittedAt {
+		if _, ok := seenDatabases[db]; !ok {
+			delete(c.lastEmittedAt, db)
 		}
 	}
 
@@ -718,4 +766,8 @@ func (c *SchemaDetails) fetchColumnsDefinitions(ctx context.Context, databaseNam
 
 func fullyQualifiedName(db database, sch schema, tbl table) string {
 	return fmt.Sprintf("%s.%s.%s", db, sch, tbl)
+}
+
+func schemaTableKey(sch schema, tbl table) string {
+	return fmt.Sprintf("%s.%s", sch, tbl)
 }

--- a/internal/component/database_observability/postgres/collector/schema_details.go
+++ b/internal/component/database_observability/postgres/collector/schema_details.go
@@ -484,36 +484,43 @@ func (c *SchemaDetails) extractSchemas(ctx context.Context, dbName string, dbCon
 	scanComplete := true
 
 	for _, schemaName := range schemas {
-		rs, err := dbConnection.QueryContext(ctx, selectTableNames, schemaName)
-		if err != nil {
-			c.logger.Error("failed to query tables", "datname", dbName, "schema", schemaName, "err", err)
+		complete := func() bool {
+			rs, err := dbConnection.QueryContext(ctx, selectTableNames, schemaName)
+			if err != nil {
+				c.logger.Error("failed to query tables", "datname", dbName, "schema", schemaName, "err", err)
+				return false
+			}
+			defer rs.Close()
+
+			for rs.Next() {
+				var tableName string
+				if err := rs.Scan(&tableName); err != nil {
+					c.logger.Error("failed to scan tables", "datname", dbName, "schema", schemaName, "err", err)
+					return false
+				}
+				tables = append(tables, &tableInfo{
+					database:  db,
+					schema:    schema(schemaName),
+					tableName: table(tableName),
+				})
+
+				c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
+					logging.LevelInfo,
+					OP_TABLE_DETECTION,
+					fmt.Sprintf(`datname="%s" schema="%s" table="%s"`, dbName, schemaName, tableName),
+				)
+			}
+
+			if err := rs.Err(); err != nil {
+				c.logger.Error("failed to iterate over tables result set", "datname", dbName, "schema", schemaName, "err", err)
+				return false
+			}
+			return true
+		}()
+
+		if !complete {
 			scanComplete = false
 			break
-		}
-		defer rs.Close()
-
-		for rs.Next() {
-			var tableName string
-			if err := rs.Scan(&tableName); err != nil {
-				c.logger.Error("failed to scan tables", "datname", dbName, "schema", schemaName, "err", err)
-				scanComplete = false
-				break
-			}
-			tables = append(tables, &tableInfo{
-				database:  db,
-				schema:    schema(schemaName),
-				tableName: table(tableName),
-			})
-
-			c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
-				logging.LevelInfo,
-				OP_TABLE_DETECTION,
-				fmt.Sprintf(`datname="%s" schema="%s" table="%s"`, dbName, schemaName, tableName),
-			)
-		}
-
-		if err := rs.Err(); err != nil {
-			return fmt.Errorf("failed to iterate over tables result set for database %q schema %q: %w", dbName, schemaName, err)
 		}
 	}
 

--- a/internal/component/database_observability/postgres/collector/schema_details_test.go
+++ b/internal/component/database_observability/postgres/collector/schema_details_test.go
@@ -5,11 +5,13 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/go-kit/kit/log"
 	"github.com/lib/pq"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
@@ -23,8 +25,8 @@ import (
 )
 
 func Test_Postgres_SchemaDetails(t *testing.T) {
-	// The goroutine which deletes expired entries runs indefinitely,
-	// see https://github.com/hashicorp/golang-lru/blob/v2.0.7/expirable/expirable_lru.go#L79-L80
+	// query_samples_test.go (in the same package) still uses the LRU goroutine,
+	// so we need to ignore it here when tests run in parallel.
 	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"))
 
 	t.Run("collector selects and logs schema details", func(t *testing.T) {
@@ -1044,8 +1046,10 @@ func Test_Postgres_SchemaDetails_collector_detects_auto_increment_column(t *test
 	})
 }
 
-func Test_Postgres_SchemaDetails_caching(t *testing.T) {
-	t.Run("uses cache on second run when caching is enabled", func(t *testing.T) {
+func Test_Postgres_SchemaDetails_throttling(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"))
+
+	t.Run("second scrape within emit_interval emits OP_TABLE_DETECTION but not OP_CREATE_STATEMENT", func(t *testing.T) {
 		t.Parallel()
 
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
@@ -1053,13 +1057,13 @@ func Test_Postgres_SchemaDetails_caching(t *testing.T) {
 		defer db.Close()
 
 		lokiClient := loki.NewCollectingHandler()
+		defer lokiClient.Stop()
+
+		fakeNow := time.Date(2024, 5, 1, 12, 0, 0, 0, time.UTC)
 		collector, err := NewSchemaDetails(SchemaDetailsArguments{
 			DB:              db,
-			DSN:             "postgres://user:pass@localhost:5432/cache_test_db",
-			CollectInterval: time.Millisecond,
-			CacheEnabled:    true,
-			CacheSize:       256,
-			CacheTTL:        10 * time.Minute,
+			DSN:             "postgres://user:pass@localhost:5432/throttle_test_db",
+			CollectInterval: time.Hour, // unused; extractNames is invoked manually
 			EntryHandler:    lokiClient,
 			Logger:          util.TestAlloyLogger(t).Slog(),
 			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
@@ -1068,114 +1072,60 @@ func Test_Postgres_SchemaDetails_caching(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
+		collector.now = func() time.Time { return fakeNow }
 
-		// first run mock declarations
-		// selectDatabaseName, selectSchemaNames, selectTableNames always called
+		// First scrape: tables list + per-table metadata queries.
 		mock.ExpectQuery(fmt.Sprintf(selectAllDatabases, exclusionClause)).WithoutArgs().RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"datname",
-				}).AddRow(
-					"cache_test_db",
-				),
-			)
+			WillReturnRows(sqlmock.NewRows([]string{"datname"}).AddRow("throttle_test_db"))
 		mock.ExpectQuery(selectSchemaNames).WithoutArgs().RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"schema_name",
-				}).AddRow("public"),
-			)
+			WillReturnRows(sqlmock.NewRows([]string{"schema_name"}).AddRow("public"))
 		mock.ExpectQuery(selectTableNames).WithArgs("public").RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"table_name",
-				}).AddRow("test_table"),
-			)
-
-		// selectColumnNames, selectIndexes, selectForeignKeys called only first run
+			WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("test_table"))
 		mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"column_name",
-					"column_type",
-					"not_nullable",
-					"column_default",
-					"identity_generation",
-					"is_primary_key",
-				}).AddRow("id", "integer", true, nil, "", true),
-			)
+			WillReturnRows(sqlmock.NewRows([]string{
+				"column_name", "column_type", "not_nullable", "column_default",
+				"identity_generation", "is_primary_key",
+			}).AddRow("id", "integer", true, nil, "", true))
 		mock.ExpectQuery(selectIndexes).WithArgs("public", "test_table").RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"index_name",
-					"index_type",
-					"unique",
-					"column_names",
-					"expressions",
-					"has_nullable_column",
-				}),
-			)
+			WillReturnRows(sqlmock.NewRows([]string{
+				"index_name", "index_type", "unique", "column_names",
+				"expressions", "has_nullable_column",
+			}))
 		mock.ExpectQuery(selectForeignKeys).WithArgs("public", "test_table").RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"constraint_name",
-					"column_name",
-					"referenced_table_name",
-					"referenced_column_name",
-				}),
-			)
+			WillReturnRows(sqlmock.NewRows([]string{
+				"constraint_name", "column_name", "referenced_table_name", "referenced_column_name",
+			}))
 
-		// first run invocation
-		require.NoError(t, collector.extractNames(context.Background()))
-		require.Eventually(t, func() bool { return len(lokiClient.Received()) == 2 }, 2*time.Second, 100*time.Millisecond)
-		firstRunEntries := lokiClient.Received()
-		require.Len(t, firstRunEntries, 2)
-
-		lokiClient.Clear()
-
-		// second run mock declarations
-		// selectDatabaseName, selectSchemaNames, selectTableNames always called
+		// Second scrape: only tables-list queries. Within EmitInterval so
+		// no metadata queries are expected.
 		mock.ExpectQuery(fmt.Sprintf(selectAllDatabases, exclusionClause)).WithoutArgs().RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"datname",
-				}).AddRow(
-					"cache_test_db",
-				),
-			)
+			WillReturnRows(sqlmock.NewRows([]string{"datname"}).AddRow("throttle_test_db"))
 		mock.ExpectQuery(selectSchemaNames).WithoutArgs().RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"schema_name",
-				}).AddRow("public"),
-			)
+			WillReturnRows(sqlmock.NewRows([]string{"schema_name"}).AddRow("public"))
 		mock.ExpectQuery(selectTableNames).WithArgs("public").RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{
-					"table_name",
-				}).AddRow("test_table"),
-			)
-		// Here, note that selectColumnNames, selectIndexes, selectForeignKeys mocks are not declared: they should not be called due to caching
+			WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("test_table"))
 
-		// second run invocation
 		require.NoError(t, collector.extractNames(context.Background()))
-		require.Eventually(t, func() bool { return len(lokiClient.Received()) == 2 }, 2*time.Second, 100*time.Millisecond)
-		secondRunEntries := lokiClient.Received()
-		require.Len(t, secondRunEntries, 2)
+		fakeNow = fakeNow.Add(time.Minute) // well within EmitInterval
+		require.NoError(t, collector.extractNames(context.Background()))
 
-		// assert that first and second run results are identical
-		for i := range firstRunEntries {
-			assert.Equal(t, firstRunEntries[i].Labels, secondRunEntries[i].Labels)
-			assert.Equal(t, firstRunEntries[i].Line, secondRunEntries[i].Line)
-		}
+		// First scrape emits OP_TABLE_DETECTION + OP_CREATE_STATEMENT; second
+		// scrape emits only OP_TABLE_DETECTION (still emitted on every scrape).
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 3
+		}, 5*time.Second, 10*time.Millisecond)
 
-		// ensure that selectColumnNames, selectIndexes, selectForeignKeys are not called
 		require.NoError(t, mock.ExpectationsWereMet())
 
-		lokiClient.Stop()
+		entries := lokiClient.Received()
+		require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, entries[0].Labels)
+		require.Equal(t, `level="info" datname="throttle_test_db" schema="public" table="test_table"`, entries[0].Line)
+		require.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, entries[1].Labels)
+		require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, entries[2].Labels)
+		require.Equal(t, `level="info" datname="throttle_test_db" schema="public" table="test_table"`, entries[2].Line)
 	})
 
-	t.Run("bypasses cache when caching is disabled", func(t *testing.T) {
+	t.Run("second scrape after emit_interval re-emits OP_CREATE_STATEMENT", func(t *testing.T) {
 		t.Parallel()
 
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
@@ -1183,12 +1133,13 @@ func Test_Postgres_SchemaDetails_caching(t *testing.T) {
 		defer db.Close()
 
 		lokiClient := loki.NewCollectingHandler()
+		defer lokiClient.Stop()
 
+		fakeNow := time.Date(2024, 5, 1, 12, 0, 0, 0, time.UTC)
 		collector, err := NewSchemaDetails(SchemaDetailsArguments{
 			DB:              db,
-			DSN:             "postgres://user:pass@localhost:5432/no_cache_test_db",
-			CollectInterval: time.Millisecond,
-			CacheEnabled:    false,
+			DSN:             "postgres://user:pass@localhost:5432/throttle_test_db",
+			CollectInterval: time.Hour,
 			EntryHandler:    lokiClient,
 			Logger:          util.TestAlloyLogger(t).Slog(),
 			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
@@ -1197,84 +1148,191 @@ func Test_Postgres_SchemaDetails_caching(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
+		collector.now = func() time.Time { return fakeNow }
 
-		// declare mocks for two runs
+		// Two scrapes' worth of expectations: tables list + per-table metadata.
 		for i := 0; i < 2; i++ {
 			mock.ExpectQuery(fmt.Sprintf(selectAllDatabases, exclusionClause)).WithoutArgs().RowsWillBeClosed().
-				WillReturnRows(
-					sqlmock.NewRows([]string{
-						"datname",
-					}).AddRow(
-						"no_cache_test_db",
-					),
-				)
-
+				WillReturnRows(sqlmock.NewRows([]string{"datname"}).AddRow("throttle_test_db"))
 			mock.ExpectQuery(selectSchemaNames).WithoutArgs().RowsWillBeClosed().
-				WillReturnRows(
-					sqlmock.NewRows([]string{
-						"schema_name",
-					}).AddRow("public"),
-				)
-
+				WillReturnRows(sqlmock.NewRows([]string{"schema_name"}).AddRow("public"))
 			mock.ExpectQuery(selectTableNames).WithArgs("public").RowsWillBeClosed().
-				WillReturnRows(
-					sqlmock.NewRows([]string{
-						"table_name",
-					}).AddRow("test_table"),
-				)
-
+				WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("test_table"))
 			mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").RowsWillBeClosed().
-				WillReturnRows(
-					sqlmock.NewRows([]string{
-						"column_name",
-						"column_type",
-						"not_nullable",
-						"column_default",
-						"identity_generation",
-						"is_primary_key",
-					}).AddRow("id", "integer", true, nil, "", true),
-				)
-
+				WillReturnRows(sqlmock.NewRows([]string{
+					"column_name", "column_type", "not_nullable", "column_default",
+					"identity_generation", "is_primary_key",
+				}).AddRow("id", "integer", true, nil, "", true))
 			mock.ExpectQuery(selectIndexes).WithArgs("public", "test_table").RowsWillBeClosed().
-				WillReturnRows(
-					sqlmock.NewRows([]string{
-						"index_name",
-						"index_type",
-						"unique",
-						"column_names",
-						"expressions",
-						"has_nullable_column",
-					}),
-				)
-
+				WillReturnRows(sqlmock.NewRows([]string{
+					"index_name", "index_type", "unique", "column_names",
+					"expressions", "has_nullable_column",
+				}))
 			mock.ExpectQuery(selectForeignKeys).WithArgs("public", "test_table").RowsWillBeClosed().
-				WillReturnRows(
-					sqlmock.NewRows([]string{
-						"constraint_name",
-						"column_name",
-						"referenced_table_name",
-						"referenced_column_name",
-					}),
-				)
+				WillReturnRows(sqlmock.NewRows([]string{
+					"constraint_name", "column_name", "referenced_table_name", "referenced_column_name",
+				}))
 		}
 
-		// first run
 		require.NoError(t, collector.extractNames(context.Background()))
-		require.Eventually(t, func() bool {
-			return len(lokiClient.Received()) == 2
-		}, 2*time.Second, 100*time.Millisecond)
-		lokiClient.Clear()
-
-		// second run
+		fakeNow = fakeNow.Add(emitInterval + time.Minute) // past the throttle window
 		require.NoError(t, collector.extractNames(context.Background()))
-		require.Eventually(t, func() bool {
-			return len(lokiClient.Received()) == 2
-		}, 2*time.Second, 100*time.Millisecond)
 
-		// ensure that selectColumnNames, selectIndexes, selectForeignKeys are called twice
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 4
+		}, 5*time.Second, 10*time.Millisecond)
+
 		require.NoError(t, mock.ExpectationsWereMet())
 
-		lokiClient.Stop()
+		entries := lokiClient.Received()
+		require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, entries[0].Labels)
+		require.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, entries[1].Labels)
+		require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, entries[2].Labels)
+		require.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, entries[3].Labels)
+	})
+
+	t.Run("table dropped between scrapes is removed from throttle map", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki.NewCollectingHandler()
+		defer lokiClient.Stop()
+
+		fakeNow := time.Date(2024, 5, 1, 12, 0, 0, 0, time.UTC)
+		collector, err := NewSchemaDetails(SchemaDetailsArguments{
+			DB:              db,
+			DSN:             "postgres://user:pass@localhost:5432/throttle_test_db",
+			CollectInterval: time.Hour,
+			EntryHandler:    lokiClient,
+			Logger:          log.NewLogfmtLogger(os.Stderr),
+			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
+				return db, nil
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+		collector.now = func() time.Time { return fakeNow }
+
+		// First scrape: two tables.
+		mock.ExpectQuery(fmt.Sprintf(selectAllDatabases, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{"datname"}).AddRow("throttle_test_db"))
+		mock.ExpectQuery(selectSchemaNames).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{"schema_name"}).AddRow("public"))
+		mock.ExpectQuery(selectTableNames).WithArgs("public").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("table_a").AddRow("table_b"))
+		for _, tableName := range []string{"table_a", "table_b"} {
+			mock.ExpectQuery(selectColumnNames).WithArgs("public", tableName).RowsWillBeClosed().
+				WillReturnRows(sqlmock.NewRows([]string{
+					"column_name", "column_type", "not_nullable", "column_default",
+					"identity_generation", "is_primary_key",
+				}).AddRow("id", "integer", true, nil, "", true))
+			mock.ExpectQuery(selectIndexes).WithArgs("public", tableName).RowsWillBeClosed().
+				WillReturnRows(sqlmock.NewRows([]string{
+					"index_name", "index_type", "unique", "column_names",
+					"expressions", "has_nullable_column",
+				}))
+			mock.ExpectQuery(selectForeignKeys).WithArgs("public", tableName).RowsWillBeClosed().
+				WillReturnRows(sqlmock.NewRows([]string{
+					"constraint_name", "column_name", "referenced_table_name", "referenced_column_name",
+				}))
+		}
+
+		require.NoError(t, collector.extractNames(context.Background()))
+		require.Contains(t, collector.lastEmittedAt, fullyQualifiedName("throttle_test_db", "public", "table_a"))
+		require.Contains(t, collector.lastEmittedAt, fullyQualifiedName("throttle_test_db", "public", "table_b"))
+
+		// Second scrape: only table_a remains. table_b should be evicted from
+		// the throttle map by housekeeping. Since table_a was already emitted
+		// less than EmitInterval ago, no further metadata queries are expected.
+		fakeNow = fakeNow.Add(time.Minute)
+		mock.ExpectQuery(fmt.Sprintf(selectAllDatabases, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{"datname"}).AddRow("throttle_test_db"))
+		mock.ExpectQuery(selectSchemaNames).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{"schema_name"}).AddRow("public"))
+		mock.ExpectQuery(selectTableNames).WithArgs("public").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("table_a"))
+
+		require.NoError(t, collector.extractNames(context.Background()))
+
+		require.NoError(t, mock.ExpectationsWereMet())
+		require.Contains(t, collector.lastEmittedAt, fullyQualifiedName("throttle_test_db", "public", "table_a"))
+		require.NotContains(t, collector.lastEmittedAt, fullyQualifiedName("throttle_test_db", "public", "table_b"))
+	})
+
+	t.Run("same schema.table in different databases is throttled independently", func(t *testing.T) {
+		t.Parallel()
+
+		dbA, mockA, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer dbA.Close()
+
+		dbB, mockB, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer dbB.Close()
+
+		lokiClient := loki.NewCollectingHandler()
+		defer lokiClient.Stop()
+
+		fakeNow := time.Date(2024, 5, 1, 12, 0, 0, 0, time.UTC)
+		collector, err := NewSchemaDetails(SchemaDetailsArguments{
+			DB:              dbA, // initial connection
+			DSN:             "postgres://user:pass@localhost:5432/db_a",
+			CollectInterval: time.Hour,
+			EntryHandler:    lokiClient,
+			Logger:          log.NewLogfmtLogger(os.Stderr),
+			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
+				if strings.Contains(dsn, "db_a") {
+					return dbA, nil
+				}
+				return dbB, nil
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+		collector.now = func() time.Time { return fakeNow }
+
+		// First scrape: getAllDatabases (on dbA) returns two databases.
+		mockA.ExpectQuery(fmt.Sprintf(selectAllDatabases, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{"datname"}).AddRow("db_a").AddRow("db_b"))
+
+		// Per-database expectations: each db has a single "public.test_table".
+		for _, m := range []sqlmock.Sqlmock{mockA, mockB} {
+			m.ExpectQuery(selectSchemaNames).WithoutArgs().RowsWillBeClosed().
+				WillReturnRows(sqlmock.NewRows([]string{"schema_name"}).AddRow("public"))
+			m.ExpectQuery(selectTableNames).WithArgs("public").RowsWillBeClosed().
+				WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("test_table"))
+			m.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").RowsWillBeClosed().
+				WillReturnRows(sqlmock.NewRows([]string{
+					"column_name", "column_type", "not_nullable", "column_default",
+					"identity_generation", "is_primary_key",
+				}).AddRow("id", "integer", true, nil, "", true))
+			m.ExpectQuery(selectIndexes).WithArgs("public", "test_table").RowsWillBeClosed().
+				WillReturnRows(sqlmock.NewRows([]string{
+					"index_name", "index_type", "unique", "column_names",
+					"expressions", "has_nullable_column",
+				}))
+			m.ExpectQuery(selectForeignKeys).WithArgs("public", "test_table").RowsWillBeClosed().
+				WillReturnRows(sqlmock.NewRows([]string{
+					"constraint_name", "column_name", "referenced_table_name", "referenced_column_name",
+				}))
+		}
+
+		require.NoError(t, collector.extractNames(context.Background()))
+
+		// Each database produces an OP_TABLE_DETECTION + OP_CREATE_STATEMENT.
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 4
+		}, 5*time.Second, 10*time.Millisecond)
+
+		require.NoError(t, mockA.ExpectationsWereMet())
+		require.NoError(t, mockB.ExpectationsWereMet())
+
+		require.Contains(t, collector.lastEmittedAt, fullyQualifiedName("db_a", "public", "test_table"))
+		require.Contains(t, collector.lastEmittedAt, fullyQualifiedName("db_b", "public", "test_table"))
+		require.Len(t, collector.lastEmittedAt, 2)
 	})
 }
 
@@ -1318,7 +1376,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 			logger: logging.NewSlogNop(),
 		}
 
-		err = collector.extractSchemas(context.Background(), "testdb", db)
+		err = collector.extractSchemas(context.Background(), "testdb", db, time.Now(), map[string]struct{}{})
 
 		require.Error(t, err)
 		require.NoError(t, mock.ExpectationsWereMet())
@@ -1835,8 +1893,6 @@ func Test_parseSchemaQualifiedIfAny(t *testing.T) {
 }
 
 func Test_SchemaDetails_populates_TableRegistry(t *testing.T) {
-	// The goroutine which deletes expired entries runs indefinitely,
-	// see https://github.com/hashicorp/golang-lru/blob/v2.0.7/expirable/expirable_lru.go#L79-L80
 	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"))
 
 	t.Run("extractSchemas populates TableRegistry", func(t *testing.T) {
@@ -1974,7 +2030,6 @@ func Test_Postgres_SchemaDetails_ExcludeDatabases(t *testing.T) {
 		CollectInterval:  time.Millisecond,
 		ExcludeDatabases: []string{"excluded_database"},
 		EntryHandler:     lokiClient,
-		CacheEnabled:     false,
 		Logger:           util.TestAlloyLogger(t).Slog(),
 		dbConnectionFactory: func(dsn string) (*sql.DB, error) {
 			return db, nil

--- a/internal/component/database_observability/postgres/collector/schema_details_test.go
+++ b/internal/component/database_observability/postgres/collector/schema_details_test.go
@@ -1241,12 +1241,12 @@ func Test_Postgres_SchemaDetails_throttling(t *testing.T) {
 		}
 
 		require.NoError(t, collector.extractNames(context.Background()))
-		require.Contains(t, collector.lastEmittedAt, fullyQualifiedName("throttle_test_db", "public", "table_a"))
-		require.Contains(t, collector.lastEmittedAt, fullyQualifiedName("throttle_test_db", "public", "table_b"))
+		require.Contains(t, collector.lastEmittedAt[database("throttle_test_db")], schemaTableKey("public", "table_a"))
+		require.Contains(t, collector.lastEmittedAt[database("throttle_test_db")], schemaTableKey("public", "table_b"))
 
 		// Second scrape: only table_a remains. table_b should be evicted from
 		// the throttle map by housekeeping. Since table_a was already emitted
-		// less than EmitInterval ago, no further metadata queries are expected.
+		// less than emitInterval ago, no further metadata queries are expected.
 		fakeNow = fakeNow.Add(time.Minute)
 		mock.ExpectQuery(fmt.Sprintf(selectAllDatabases, exclusionClause)).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{"datname"}).AddRow("throttle_test_db"))
@@ -1258,8 +1258,8 @@ func Test_Postgres_SchemaDetails_throttling(t *testing.T) {
 		require.NoError(t, collector.extractNames(context.Background()))
 
 		require.NoError(t, mock.ExpectationsWereMet())
-		require.Contains(t, collector.lastEmittedAt, fullyQualifiedName("throttle_test_db", "public", "table_a"))
-		require.NotContains(t, collector.lastEmittedAt, fullyQualifiedName("throttle_test_db", "public", "table_b"))
+		require.Contains(t, collector.lastEmittedAt[database("throttle_test_db")], schemaTableKey("public", "table_a"))
+		require.NotContains(t, collector.lastEmittedAt[database("throttle_test_db")], schemaTableKey("public", "table_b"))
 	})
 
 	t.Run("same schema.table in different databases is throttled independently", func(t *testing.T) {
@@ -1330,9 +1330,90 @@ func Test_Postgres_SchemaDetails_throttling(t *testing.T) {
 		require.NoError(t, mockA.ExpectationsWereMet())
 		require.NoError(t, mockB.ExpectationsWereMet())
 
-		require.Contains(t, collector.lastEmittedAt, fullyQualifiedName("db_a", "public", "test_table"))
-		require.Contains(t, collector.lastEmittedAt, fullyQualifiedName("db_b", "public", "test_table"))
+		require.Contains(t, collector.lastEmittedAt[database("db_a")], schemaTableKey("public", "test_table"))
+		require.Contains(t, collector.lastEmittedAt[database("db_b")], schemaTableKey("public", "test_table"))
 		require.Len(t, collector.lastEmittedAt, 2)
+	})
+
+	t.Run("transient extractSchemas error does not purge throttle entries", func(t *testing.T) {
+		t.Parallel()
+
+		// Single mock used for both databases. The factory returns this
+		// connection (which is also the initial connection), so extractNames
+		// never calls conn.Close() on it.
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki.NewCollectingHandler()
+		defer lokiClient.Stop()
+
+		fakeNow := time.Date(2024, 5, 1, 12, 0, 0, 0, time.UTC)
+		collector, err := NewSchemaDetails(SchemaDetailsArguments{
+			DB:              db,
+			DSN:             "postgres://user:pass@localhost:5432/db_a",
+			CollectInterval: time.Hour,
+			EntryHandler:    lokiClient,
+			Logger:          log.NewLogfmtLogger(os.Stderr),
+			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
+				return db, nil
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+		collector.now = func() time.Time { return fakeNow }
+
+		// First scrape: both databases succeed. Each populates a throttle entry.
+		mock.ExpectQuery(fmt.Sprintf(selectAllDatabases, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{"datname"}).AddRow("db_a").AddRow("db_b"))
+		for i := 0; i < 2; i++ {
+			mock.ExpectQuery(selectSchemaNames).WithoutArgs().RowsWillBeClosed().
+				WillReturnRows(sqlmock.NewRows([]string{"schema_name"}).AddRow("public"))
+			mock.ExpectQuery(selectTableNames).WithArgs("public").RowsWillBeClosed().
+				WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("test_table"))
+			mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").RowsWillBeClosed().
+				WillReturnRows(sqlmock.NewRows([]string{
+					"column_name", "column_type", "not_nullable", "column_default",
+					"identity_generation", "is_primary_key",
+				}).AddRow("id", "integer", true, nil, "", true))
+			mock.ExpectQuery(selectIndexes).WithArgs("public", "test_table").RowsWillBeClosed().
+				WillReturnRows(sqlmock.NewRows([]string{
+					"index_name", "index_type", "unique", "column_names",
+					"expressions", "has_nullable_column",
+				}))
+			mock.ExpectQuery(selectForeignKeys).WithArgs("public", "test_table").RowsWillBeClosed().
+				WillReturnRows(sqlmock.NewRows([]string{
+					"constraint_name", "column_name", "referenced_table_name", "referenced_column_name",
+				}))
+		}
+
+		require.NoError(t, collector.extractNames(context.Background()))
+		require.Contains(t, collector.lastEmittedAt[database("db_a")], schemaTableKey("public", "test_table"))
+		require.Contains(t, collector.lastEmittedAt[database("db_b")], schemaTableKey("public", "test_table"))
+
+		// Second scrape (within emitInterval): db_a scrapes successfully but
+		// is throttled (no metadata queries). db_b's selectSchemaNames fails
+		// transiently. The throttle entry for db_b must survive — otherwise
+		// the throttle guarantee is broken.
+		fakeNow = fakeNow.Add(time.Minute)
+		mock.ExpectQuery(fmt.Sprintf(selectAllDatabases, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{"datname"}).AddRow("db_a").AddRow("db_b"))
+		// db_a: schemas + tables (throttled, so no metadata queries)
+		mock.ExpectQuery(selectSchemaNames).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{"schema_name"}).AddRow("public"))
+		mock.ExpectQuery(selectTableNames).WithArgs("public").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("test_table"))
+		// db_b: schemas query fails
+		mock.ExpectQuery(selectSchemaNames).WithoutArgs().
+			WillReturnError(fmt.Errorf("transient db_b error"))
+
+		require.NoError(t, collector.extractNames(context.Background()))
+
+		require.NoError(t, mock.ExpectationsWereMet())
+
+		require.Contains(t, collector.lastEmittedAt[database("db_a")], schemaTableKey("public", "test_table"))
+		require.Contains(t, collector.lastEmittedAt[database("db_b")], schemaTableKey("public", "test_table"),
+			"transient error for db_b must not purge its throttle entries")
 	})
 }
 
@@ -1374,9 +1455,10 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 
 		collector := &SchemaDetails{
 			logger: logging.NewSlogNop(),
+			now:    time.Now,
 		}
 
-		err = collector.extractSchemas(context.Background(), "testdb", db, time.Now(), map[string]struct{}{})
+		err = collector.extractSchemas(context.Background(), "testdb", db)
 
 		require.Error(t, err)
 		require.NoError(t, mock.ExpectationsWereMet())

--- a/internal/component/database_observability/postgres/collector/schema_details_test.go
+++ b/internal/component/database_observability/postgres/collector/schema_details_test.go
@@ -1059,11 +1059,10 @@ func Test_Postgres_SchemaDetails_throttling(t *testing.T) {
 
 		fakeNow := time.Date(2024, 5, 1, 12, 0, 0, 0, time.UTC)
 		collector, err := NewSchemaDetails(SchemaDetailsArguments{
-			DB:              db,
-			DSN:             "postgres://user:pass@localhost:5432/throttle_test_db",
-			CollectInterval: time.Hour, // unused; extractNames is invoked manually
-			EntryHandler:    lokiClient,
-			Logger:          util.TestAlloyLogger(t).Slog(),
+			DB:           db,
+			DSN:          "postgres://user:pass@localhost:5432/throttle_test_db",
+			EntryHandler: lokiClient,
+			Logger:       util.TestAlloyLogger(t).Slog(),
 			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
 				return db, nil
 			},
@@ -1438,28 +1437,62 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
-	t.Run("extractSchemas returns error when there is an error iterating over pg_namespace result set", func(t *testing.T) {
+	t.Run("extractSchemas preserves registry and throttle when a schema's table query fails", func(t *testing.T) {
 		t.Parallel()
 
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
 
-		mock.ExpectQuery(selectSchemaNames).
-			WillReturnRows(
-				sqlmock.NewRows([]string{"nspname"}).
-					AddRow("public").
-					RowError(0, fmt.Errorf("schema iteration error")))
+		lokiClient := loki.NewCollectingHandler()
+		defer lokiClient.Stop()
 
+		fakeNow := time.Date(2024, 5, 1, 12, 0, 0, 0, time.UTC)
 		collector := &SchemaDetails{
-			logger: logging.NewSlogNop(),
-			now:    time.Now,
+			logger:        logging.NewSlogNop(),
+			now:           func() time.Time { return fakeNow },
+			lastEmittedAt: map[database]map[string]time.Time{},
+			tableRegistry: NewTableRegistry(),
+			entryHandler:  lokiClient,
 		}
+		// Pre-seed state from a previous successful scrape so the metadata
+		// fetch is throttled (no per-table queries needed) and we can verify
+		// the registry/throttle survive a partial read of the current sweep.
+		collector.lastEmittedAt[database("testdb")] = map[string]time.Time{
+			schemaTableKey("schema_a", "table_a"): fakeNow,
+		}
+		collector.tableRegistry.SetTablesForDatabase("testdb", []*tableInfo{
+			{database: "testdb", schema: "schema_a", tableName: "previous_table"},
+		})
+
+		mock.ExpectQuery(selectSchemaNames).
+			WillReturnRows(sqlmock.NewRows([]string{"schema_name"}).
+				AddRow("schema_a").
+				AddRow("schema_b").
+				AddRow("schema_c"))
+		mock.ExpectQuery(selectTableNames).WithArgs("schema_a").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("table_a"))
+		mock.ExpectQuery(selectTableNames).WithArgs("schema_b").
+			WillReturnError(fmt.Errorf("transient tables query failure"))
 
 		err = collector.extractSchemas(context.Background(), "testdb", db)
-
-		require.Error(t, err)
+		require.NoError(t, err, "per-schema query failure should not propagate")
 		require.NoError(t, mock.ExpectationsWereMet())
+
+		require.Contains(t, collector.lastEmittedAt[database("testdb")], schemaTableKey("schema_a", "table_a"),
+			"throttle entries must survive a partial schemas sweep")
+
+		resolved, ok := collector.tableRegistry.IsValid("testdb", "previous_table")
+		require.True(t, ok, "tableRegistry must not be overwritten by a partial schemas sweep")
+		require.Equal(t, "previous_table", resolved)
+		_, ok = collector.tableRegistry.IsValid("testdb", "table_a")
+		require.False(t, ok, "tableRegistry must not be partially overwritten with the in-progress sweep")
+
+		// schema_a.table_a is still detected and emitted before schema_b fails.
+		entries := lokiClient.Received()
+		require.Len(t, entries, 1)
+		require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, entries[0].Labels)
+		require.Equal(t, `level="info" datname="testdb" schema="schema_a" table="table_a"`, entries[0].Line)
 	})
 
 	t.Run("fetchTableDefinitions returns error when selectColumnNames query fails", func(t *testing.T) {

--- a/internal/component/database_observability/postgres/collector/schema_details_test.go
+++ b/internal/component/database_observability/postgres/collector/schema_details_test.go
@@ -5,13 +5,11 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-kit/kit/log"
 	"github.com/lib/pq"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
@@ -1207,7 +1205,7 @@ func Test_Postgres_SchemaDetails_throttling(t *testing.T) {
 			DSN:             "postgres://user:pass@localhost:5432/throttle_test_db",
 			CollectInterval: time.Hour,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
 				return db, nil
 			},
@@ -1282,7 +1280,7 @@ func Test_Postgres_SchemaDetails_throttling(t *testing.T) {
 			DSN:             "postgres://user:pass@localhost:5432/db_a",
 			CollectInterval: time.Hour,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
 				if strings.Contains(dsn, "db_a") {
 					return dbA, nil
@@ -1354,7 +1352,7 @@ func Test_Postgres_SchemaDetails_throttling(t *testing.T) {
 			DSN:             "postgres://user:pass@localhost:5432/db_a",
 			CollectInterval: time.Hour,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
 				return db, nil
 			},

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -581,13 +581,13 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 
 	if collectors[collector.SchemaDetailsCollector] {
 		if c.args.SchemaDetailsArguments.CacheEnabled != nil {
-			level.Warn(c.opts.Logger).Log("msg", "schema_details.cache_enabled is set, but the cache is deprecated and will be removed in a future version")
+			c.opts.SLogger.Warn("schema_details.cache_enabled is set, but the cache is deprecated and will be removed in a future version")
 		}
 		if c.args.SchemaDetailsArguments.CacheSize != nil {
-			level.Warn(c.opts.Logger).Log("msg", "schema_details.cache_size is set, but the cache is deprecated and will be removed in a future version")
+			c.opts.SLogger.Warn("schema_details.cache_size is set, but the cache is deprecated and will be removed in a future version")
 		}
 		if c.args.SchemaDetailsArguments.CacheTTL != nil {
-			level.Warn(c.opts.Logger).Log("msg", "schema_details.cache_ttl is set, but the cache is deprecated and will be removed in a future version")
+			c.opts.SLogger.Warn("schema_details.cache_ttl is set, but the cache is deprecated and will be removed in a future version")
 		}
 
 		stCollector, err := collector.NewSchemaDetails(collector.SchemaDetailsArguments{

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -118,9 +118,11 @@ type QueryDetailsArguments struct {
 
 type SchemaDetailsArguments struct {
 	CollectInterval time.Duration `alloy:"collect_interval,attr,optional"`
-	CacheEnabled    bool          `alloy:"cache_enabled,attr,optional"`
-	CacheSize       int           `alloy:"cache_size,attr,optional"`
-	CacheTTL        time.Duration `alloy:"cache_ttl,attr,optional"`
+
+	// Deprecated settings
+	CacheEnabled *bool          `alloy:"cache_enabled,attr,optional"`
+	CacheSize    *int           `alloy:"cache_size,attr,optional"`
+	CacheTTL     *time.Duration `alloy:"cache_ttl,attr,optional"`
 }
 
 func defaultArguments() Arguments {
@@ -138,9 +140,6 @@ func defaultArguments() Arguments {
 		},
 		SchemaDetailsArguments: SchemaDetailsArguments{
 			CollectInterval: 1 * time.Minute,
-			CacheEnabled:    true,
-			CacheSize:       256,
-			CacheTTL:        10 * time.Minute,
 		},
 		ExplainPlansArguments: ExplainPlansArguments{
 			CollectInterval: 1 * time.Minute,
@@ -581,14 +580,21 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 	collectors := enableOrDisableCollectors(c.args)
 
 	if collectors[collector.SchemaDetailsCollector] {
+		if c.args.SchemaDetailsArguments.CacheEnabled != nil {
+			level.Warn(c.opts.Logger).Log("msg", "schema_details.cache_enabled is set, but the cache is deprecated and will be removed in a future version")
+		}
+		if c.args.SchemaDetailsArguments.CacheSize != nil {
+			level.Warn(c.opts.Logger).Log("msg", "schema_details.cache_size is set, but the cache is deprecated and will be removed in a future version")
+		}
+		if c.args.SchemaDetailsArguments.CacheTTL != nil {
+			level.Warn(c.opts.Logger).Log("msg", "schema_details.cache_ttl is set, but the cache is deprecated and will be removed in a future version")
+		}
+
 		stCollector, err := collector.NewSchemaDetails(collector.SchemaDetailsArguments{
 			DB:               c.dbConnection,
 			DSN:              string(c.args.DataSourceName),
 			CollectInterval:  c.args.SchemaDetailsArguments.CollectInterval,
 			ExcludeDatabases: c.args.ExcludeDatabases,
-			CacheEnabled:     c.args.SchemaDetailsArguments.CacheEnabled,
-			CacheSize:        c.args.SchemaDetailsArguments.CacheSize,
-			CacheTTL:         c.args.SchemaDetailsArguments.CacheTTL,
 			EntryHandler:     entryHandler,
 			Logger:           c.opts.SLogger,
 		})

--- a/internal/component/database_observability/postgres/component_test.go
+++ b/internal/component/database_observability/postgres/component_test.go
@@ -696,47 +696,6 @@ func TestPostgres_schema_details_collect_interval_is_parsed_from_config(t *testi
 	assert.Equal(t, 11*time.Second, args.SchemaDetailsArguments.CollectInterval)
 }
 
-func TestPostgres_schema_details_cache_configuration_is_parsed_from_config(t *testing.T) {
-	t.Run("default cache configuration", func(t *testing.T) {
-		exampleDBO11yAlloyConfig := `
-		data_source_name = "postgres://db"
-		forward_to = []
-		targets = []
-		`
-
-		var args Arguments
-		err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
-		require.NoError(t, err)
-
-		assert.Equal(t, defaultArguments().SchemaDetailsArguments.CacheEnabled, args.SchemaDetailsArguments.CacheEnabled)
-		assert.Equal(t, defaultArguments().SchemaDetailsArguments.CacheSize, args.SchemaDetailsArguments.CacheSize)
-		assert.Equal(t, defaultArguments().SchemaDetailsArguments.CacheTTL, args.SchemaDetailsArguments.CacheTTL)
-	})
-
-	t.Run("custom cache configuration", func(t *testing.T) {
-		exampleDBO11yAlloyConfig := `
-		data_source_name = "postgres://db"
-		forward_to = []
-		targets = []
-		schema_details {
-			collect_interval = "30s"
-			cache_enabled = false
-			cache_size = 512
-			cache_ttl = "5m"
-		}
-		`
-
-		var args Arguments
-		err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
-		require.NoError(t, err)
-
-		assert.Equal(t, 30*time.Second, args.SchemaDetailsArguments.CollectInterval)
-		assert.False(t, args.SchemaDetailsArguments.CacheEnabled)
-		assert.Equal(t, 512, args.SchemaDetailsArguments.CacheSize)
-		assert.Equal(t, 5*time.Minute, args.SchemaDetailsArguments.CacheTTL)
-	})
-}
-
 func Test_parseCloudProvider(t *testing.T) {
 	t.Run("parse aws cloud provider block", func(t *testing.T) {
 		exampleDBO11yAlloyConfig := `


### PR DESCRIPTION
### Brief description of Pull Request
Refactor the collector to log at most one OP_CREATE_STATEMENT per table every 30m, while still checking for new objects at every collect interval tick.

Remove the internal cache (settings are ignored/deprecated) and replace it with an in-memory map to throttle logging of OP_CREATE_STATEMENT to at most once per 30 minutes per database/schema/table.


### Pull Request Details

<!-- Detailed descripion of the Pull Request, if needed. -->


### Issue(s) fixed by this Pull Request

Followup of https://github.com/grafana/alloy/pull/6239

Relates to https://github.com/grafana/grafana-dbo11y-app/issues/2694


### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
