### PR TITLE
chore(database_observability.mysql): Fix race in schema_details_test

### DIFF
--- a/internal/component/database_observability/mysql/collector/schema_details_test.go
+++ b/internal/component/database_observability/mysql/collector/schema_details_test.go
@@ -1375,8 +1375,11 @@ func TestSchemaDetails(t *testing.T) {
 		err = collector.Start(t.Context())
 		require.NoError(t, err)
 
+		// Wait until every sqlmock expectation has been consumed to make sure
+		// the collector has a chance to run all bulk queries even if
+		// OP_CREATE_STATEMENT is not emitted.
 		require.Eventually(t, func() bool {
-			return len(lokiClient.Received()) == 1
+			return mock.ExpectationsWereMet() == nil
 		}, 5*time.Second, 100*time.Millisecond)
 
 		collector.Stop()


### PR DESCRIPTION
### Brief description of Pull Request
Wait until every sqlmock expectation has been consumed to make sure the collector has a chance to run all bulk queries even if OP_CREATE_STATEMENT is not emitted.

Followup of https://github.com/grafana/alloy/pull/6239




<!-- Human-readable description of the PR used as squash commit body. -->


### Pull Request Details

<!-- Detailed descripion of the Pull Request, if needed. -->


### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->


### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
