### PR TITLE
fix: Fix bug that caused 'logging' block's 'write_to' to be used after config update even if not set

### DIFF
--- a/internal/runtime/logging/logger.go
+++ b/internal/runtime/logging/logger.go
@@ -126,9 +126,7 @@ func (l *Logger) Update(o Options) error {
 	l.format.Set(o.Format)
 
 	l.writer.SetInnerWriter(l.inner)
-	if len(o.WriteTo) > 0 {
-		l.writer.SetLokiWriter(&lokiWriter{o.WriteTo})
-	}
+	l.writer.SetLokiWriter(o.WriteTo)
 	l.bufferMut.Unlock()
 
 	// Build deferred handlers outside bufferMut to avoid a deadlock: concurrent
@@ -279,10 +277,14 @@ func (w *writerVar) SetInnerWriter(writer io.Writer) {
 	w.innerWriter = writer
 }
 
-func (w *writerVar) SetLokiWriter(writer *lokiWriter) {
+func (w *writerVar) SetLokiWriter(receivers []loki.LogsReceiver) {
 	w.mut.Lock()
 	defer w.mut.Unlock()
-	w.lokiWriter = writer
+	if len(receivers) > 0 {
+		w.lokiWriter = &lokiWriter{receivers}
+	} else {
+		w.lokiWriter = nil
+	}
 }
 
 func (w *writerVar) Write(p []byte) (int, error) {

--- a/internal/runtime/logging/logger_test.go
+++ b/internal/runtime/logging/logger_test.go
@@ -205,6 +205,56 @@ func Test_lokiWriter_nil(t *testing.T) {
 	})
 }
 
+// TestWriteToDisabledViaUpdate verifies that logs go to both stderr and the
+// configured write_to receiver while write_to is set, and that calling Update
+// with an empty WriteTo stops sending logs to the receiver while still emitting
+// to stderr.
+func TestWriteToDisabledViaUpdate(t *testing.T) {
+	var buf safeBuffer
+	receiver := loki.NewLogsReceiver(loki.WithChannel(make(chan loki.Entry, 16)))
+
+	logger, err := logging.New(&buf, debugLevel())
+	require.NoError(t, err)
+
+	require.NoError(t, logger.Update(logging.Options{
+		Level:   logging.LevelDebug,
+		Format:  logging.FormatLogfmt,
+		WriteTo: []loki.LogsReceiver{receiver},
+	}))
+
+	require.NoError(t, logger.Log("msg", "with-write-to"))
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(buf.String(), "with-write-to")
+	}, time.Second, 10*time.Millisecond, "stderr did not receive log while write_to was enabled")
+
+	select {
+	case entry := <-receiver.Chan():
+		require.Contains(t, entry.Line, "with-write-to")
+	case <-time.After(time.Second):
+		t.Fatal("write_to receiver did not receive log while write_to was enabled")
+	}
+
+	require.NoError(t, logger.Update(logging.Options{
+		Level:  logging.LevelDebug,
+		Format: logging.FormatLogfmt,
+	}))
+
+	beforeLen := buf.String()
+	require.NoError(t, logger.Log("msg", "without-write-to"))
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(buf.String(), "without-write-to")
+	}, time.Second, 10*time.Millisecond, "stderr did not receive log after write_to was disabled")
+	require.Greater(t, len(buf.String()), len(beforeLen))
+
+	select {
+	case entry := <-receiver.Chan():
+		t.Fatalf("write_to receiver got log %q after write_to was disabled", entry.Line)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
 // TestUpdateConcurrentHandle verifies that Logger.Update completes successfully
 // when child handlers are being used concurrently, as happens when components
 // start logging during graph evaluation before the logging config block is processed.


### PR DESCRIPTION
If you use a config like this...

```hcl
logging{
  write_to = [loki.write.grafana_cloud.receiver]
}
```

...and then remove the `write` to, and reload the config...

```hcl
logging{}
```

... the `write_to` is still taking effect even though it's supposed to be disabled.