### PR TITLE
feat: Ability to disable Alloy's own logging to stderr

### DIFF
--- a/docs/sources/reference/config-blocks/logging.md
+++ b/docs/sources/reference/config-blocks/logging.md
@@ -50,7 +50,7 @@ The following strings are recognized as valid log line formats:
 
 ### `write_to`
 
-The `write_to` argument allows {{< param "PRODUCT_NAME" >}} to tee its log entries to one or more `loki.*` component log receivers in addition to the default [location][].
+The `write_to` argument allows {{< param "PRODUCT_NAME" >}} to tee its log entries to one or more `loki.*` component log receivers in addition to the default [destinations][].
 This, for example can be the export of a `loki.write` component to send log entries directly to Loki, or a `loki.relabel` component to add a certain label first.
 
 ### `destination`
@@ -59,6 +59,7 @@ The following strings are recognized as valid log destinations:
 
 * `"stderr"`: Write logs to `stderr`.
 * `"windows_event_log"`:  Windows only. Write logs to the Windows Event Log under the "Alloy" source.
+* `"none"`: Don't write the primary log output. Logs are still forwarded to any receivers configured in [`write_to`](#write_to).
 
 The default value of `destination` is set to `"windows_event_log"` when {{< param "PRODUCT_NAME" >}} runs as a Windows service.
 Otherwise, `destination` defaults to `"stderr"`.
@@ -104,4 +105,4 @@ logging {
 ```
 
 [logfmt]: https://brandur.org/logfmt
-[location]: #log-location
+[destination]: #destination

--- a/internal/runtime/logging/deferred_handler_test.go
+++ b/internal/runtime/logging/deferred_handler_test.go
@@ -20,9 +20,10 @@ func TestDefferredSlogTester(t *testing.T) {
 		// This does something a bit ugly where it DEPENDS on the var in slogtest.Run, if the behavior of slogtest.Run
 		// changes this may break the tests.
 		updateErr := l.Update(Options{
-			Level:   "debug",
-			Format:  "json",
-			WriteTo: nil,
+			Level:       "debug",
+			Format:      "json",
+			Destination: LogDestinationStderr,
+			WriteTo:     nil,
 		})
 		require.NoError(t, updateErr)
 		line := buf.Bytes()
@@ -59,9 +60,10 @@ func TestSlogHandle(t *testing.T) {
 	sl, alloy, l := newLoggers(t, bb, bbSl)
 	logInfo(t.Context(), sl, alloy, "simple_test")
 	err := l.Update(Options{
-		Level:   "debug",
-		Format:  "json",
-		WriteTo: nil,
+		Level:       "debug",
+		Format:      "json",
+		Destination: LogDestinationStderr,
+		WriteTo:     nil,
 	})
 	require.NoError(t, err)
 	require.True(t, equal(bb, bbSl))
@@ -73,9 +75,10 @@ func TestSlogHandleWithDifferingLevelDeny(t *testing.T) {
 	sl, alloy, l := newLoggers(t, bb, bbSl)
 	logInfo(t.Context(), sl, alloy, "test_denied")
 	err := l.Update(Options{
-		Level:   "warn",
-		Format:  "json",
-		WriteTo: nil,
+		Level:       "warn",
+		Format:      "json",
+		Destination: LogDestinationStderr,
+		WriteTo:     nil,
 	})
 	require.NoError(t, err)
 	require.True(t, bb.Len() == 0)
@@ -87,9 +90,10 @@ func TestSlogHandleWithDifferingLevelAllow(t *testing.T) {
 	sl, alloy, l := newLoggers(t, bb, bbSl)
 	logError(t.Context(), sl, alloy, "test3")
 	err := l.Update(Options{
-		Level:   "warn",
-		Format:  "json",
-		WriteTo: nil,
+		Level:       "warn",
+		Format:      "json",
+		Destination: LogDestinationStderr,
+		WriteTo:     nil,
 	})
 	require.NoError(t, err)
 	require.True(t, bb.Len() > 0)
@@ -110,9 +114,10 @@ func TestDeferredHandler(t *testing.T) {
 				sl, alloy = withAttrs(sl, alloy, "attr1", "value1")
 				logInfo(t.Context(), sl, alloy, "test_attr")
 				err := l.Update(Options{
-					Level:   "debug",
-					Format:  "json",
-					WriteTo: nil,
+					Level:       "debug",
+					Format:      "json",
+					Destination: LogDestinationStderr,
+					WriteTo:     nil,
 				})
 				require.NoError(t, err)
 			},
@@ -125,9 +130,10 @@ func TestDeferredHandler(t *testing.T) {
 				sl, alloy = withAttrs(sl, alloy, "nestedattr1", "nestedvalue1")
 				logInfo(t.Context(), sl, alloy, "test_nested")
 				err := l.Update(Options{
-					Level:   "debug",
-					Format:  "json",
-					WriteTo: nil,
+					Level:       "debug",
+					Format:      "json",
+					Destination: LogDestinationStderr,
+					WriteTo:     nil,
 				})
 				require.NoError(t, err)
 			},
@@ -140,9 +146,10 @@ func TestDeferredHandler(t *testing.T) {
 				sl, alloy = withAttrs(sl, alloy, "nestedattr1", "nestedvalue1")
 				logInfo(t.Context(), sl, alloy, "test_group")
 				err := l.Update(Options{
-					Level:   "debug",
-					Format:  "json",
-					WriteTo: nil,
+					Level:       "debug",
+					Format:      "json",
+					Destination: LogDestinationStderr,
+					WriteTo:     nil,
 				})
 				require.NoError(t, err)
 			},
@@ -156,9 +163,10 @@ func TestDeferredHandler(t *testing.T) {
 				sl, alloy = withAttrs(sl, alloy, "nestedattr1", "nestedvalue1")
 				logInfo(t.Context(), sl, alloy, "test_nested_group")
 				err := l.Update(Options{
-					Level:   "debug",
-					Format:  "json",
-					WriteTo: nil,
+					Level:       "debug",
+					Format:      "json",
+					Destination: LogDestinationStderr,
+					WriteTo:     nil,
 				})
 				require.NoError(t, err)
 			},

--- a/internal/runtime/logging/handler_test.go
+++ b/internal/runtime/logging/handler_test.go
@@ -50,8 +50,9 @@ func TestGroups(t *testing.T) {
 func TestSlogTester(t *testing.T) {
 	var buf bytes.Buffer
 	l, err := New(&buf, Options{
-		Level:  "debug",
-		Format: "json",
+		Level:       "debug",
+		Format:      "json",
+		Destination: LogDestinationStderr,
 	})
 	require.NoError(t, err)
 	results := func() []map[string]any {
@@ -84,8 +85,9 @@ func getTestHandler(t *testing.T, w io.Writer) slog.Handler {
 	t.Helper()
 
 	l, err := New(w, Options{
-		Level:  LevelDebug,
-		Format: FormatLogfmt,
+		Level:       LevelDebug,
+		Format:      FormatLogfmt,
+		Destination: LogDestinationStderr,
 	})
 	require.NoError(t, err)
 

--- a/internal/runtime/logging/logger.go
+++ b/internal/runtime/logging/logger.go
@@ -76,11 +76,16 @@ func NewDeferred(w io.Writer) (*Logger, error) {
 		leveler slog.LevelVar
 		format  formatVar
 	)
-	// innerWriter is stable for the life of the Logger; destinations that
-	// want to suppress it (windows_event_log) lazily open an event log via
-	// the writer's own opener instead of swapping the writer.
 	writer := &writerVar{
-		innerWriter:    w,
+		// Default to stderr: unlike the event log it always works, and logs are buffered
+		// until Update is called anyway, so this destination isn't reached before then.
+		activeDestination: LogDestinationStderr,
+
+		// Stable for the life of the Logger
+		innerWriter: w,
+
+		// Used to suppress innerWriter by lazily opening an event log writer
+		// that's separate from innerWriter.
 		eventLogOpener: eventlog.GetEventLogOpener(),
 	}
 	bh := newHandler(writer, &leveler, &format, replace, nil)
@@ -109,10 +114,8 @@ func (l *Logger) Slog() *slog.Logger { return slog.New(l.deferredSlog) }
 
 // Update re-configures the options used for the logger.
 func (l *Logger) Update(o Options) error {
-	switch o.Format {
-	case FormatLogfmt, FormatJSON:
-	default:
-		return fmt.Errorf("unrecognized log format %q", o.Format)
+	if err := o.Validate(); err != nil {
+		return err
 	}
 
 	l.bufferMut.Lock()
@@ -225,6 +228,8 @@ func (f *formatVar) Set(format Format) {
 type writerVar struct {
 	mut sync.RWMutex
 
+	activeDestination LogDestination
+
 	// Inner writer is stderr on the production path.
 	// Tests may set it to something else.
 	innerWriter io.Writer
@@ -270,7 +275,18 @@ func (w *writerVar) SetDestination(d LogDestination) error {
 	w.mut.Lock()
 	defer w.mut.Unlock()
 
-	if d == LogDestinationWindowsEventLog {
+	w.activeDestination = d
+
+	err := w.configureEventLog(d == LogDestinationWindowsEventLog)
+	if err != nil && w.activeDestination == LogDestinationWindowsEventLog {
+		// Fallback to stderr in case the event log configuration fails
+		w.activeDestination = LogDestinationStderr
+	}
+	return err
+}
+
+func (w *writerVar) configureEventLog(useEventLog bool) error {
+	if useEventLog {
 		if w.eventLog != nil {
 			return nil // already open; reuse the handle
 		}
@@ -293,16 +309,11 @@ func (w *writerVar) SetDestination(d LogDestination) error {
 // Dispatch is the canonical write entry point. It fans p out to every
 // active sink: innerWriter (unless suppressed), lokiWriter, tmpWriter,
 // and, when attached, the event log.
-//
-// SetDestination holds the write lock across the swap it makes, so any
-// Dispatch RLock observes one of two states:
-// 1. eventLog=nil — stderr mode.
-// 2. eventLog!=nil — event_log mode.
 func (w *writerVar) Dispatch(p []byte, eventLogLevel *slog.Level) error {
 	w.mut.RLock()
 	defer w.mut.RUnlock()
 
-	if w.eventLog == nil && w.innerWriter != nil {
+	if w.activeDestination == LogDestinationStderr {
 		if _, err := w.innerWriter.Write(p); err != nil {
 			return err
 		}
@@ -317,35 +328,36 @@ func (w *writerVar) Dispatch(p []byte, eventLogLevel *slog.Level) error {
 			return err
 		}
 	}
-	if w.eventLog == nil {
-		return nil
-	}
 
-	// The trailing newline added by slog's TextHandler/JSONHandler is trimmed
-	// before handing the message to the event log API, which renders cleaner
-	// in Event Viewer.
-	msg := p
-	if n := len(msg); n > 0 && msg[n-1] == '\n' {
-		msg = msg[:n-1]
-	}
-
-	// Loss-prevention property: in event_log mode, a fast-path Write call
-	// (eventLogLevel=nil) can still occur if a destination switch happened
-	// between handler.Handle's FastPathFlags read and the slog handler's
-	// Write. Rather than dropping the record or misrouting it to stderr,
-	// Dispatch defaults to Info and delivers it to the event log — the
-	// operator's configured destination. The level may be slightly off
-	// (the original record's level is embedded in the formatted text), but
-	// the message reaches Event Viewer.
-	if eventLogLevel != nil {
-		switch *eventLogLevel {
-		case slog.LevelWarn:
-			return w.eventLog.Warning(1, string(msg))
-		case slog.LevelError:
-			return w.eventLog.Error(1, string(msg))
+	if w.activeDestination == LogDestinationWindowsEventLog {
+		// The trailing newline added by slog's TextHandler/JSONHandler is trimmed
+		// before handing the message to the event log API, which renders cleaner
+		// in Event Viewer.
+		msg := p
+		if n := len(msg); n > 0 && msg[n-1] == '\n' {
+			msg = msg[:n-1]
 		}
+
+		// Loss-prevention property: in event_log mode, a fast-path Write call
+		// (eventLogLevel=nil) can still occur if a destination switch happened
+		// between handler.Handle's FastPathFlags read and the slog handler's
+		// Write. Rather than dropping the record or misrouting it to stderr,
+		// Dispatch defaults to Info and delivers it to the event log — the
+		// operator's configured destination. The level may be slightly off
+		// (the original record's level is embedded in the formatted text), but
+		// the message reaches Event Viewer.
+		if eventLogLevel != nil {
+			switch *eventLogLevel {
+			case slog.LevelWarn:
+				return w.eventLog.Warning(1, string(msg))
+			case slog.LevelError:
+				return w.eventLog.Error(1, string(msg))
+			}
+		}
+		return w.eventLog.Info(1, string(msg))
 	}
-	return w.eventLog.Info(1, string(msg))
+
+	return nil
 }
 
 // Write is the io.Writer adapter used by the fast-path slog handler.

--- a/internal/runtime/logging/logger_event_log_test.go
+++ b/internal/runtime/logging/logger_event_log_test.go
@@ -187,8 +187,9 @@ func TestDispatch_FastPathRaceRoutesToEventLogAsInfo(t *testing.T) {
 	mock := &testutil.MockEventLog{}
 	var inner bytes.Buffer
 	w := &writerVar{
-		innerWriter: &inner,
-		eventLog:    mock,
+		activeDestination: LogDestinationWindowsEventLog,
+		innerWriter:       &inner,
+		eventLog:          mock,
 	}
 
 	require.NoError(t, w.Dispatch([]byte("fast-path race bytes\n"), nil))

--- a/internal/runtime/logging/logger_test.go
+++ b/internal/runtime/logging/logger_test.go
@@ -122,6 +122,125 @@ func TestLevels(t *testing.T) {
 	}
 }
 
+// TestUpdateRoutesLogs walks the logger through every combination of
+// destination (stderr/none) and write_to (zero/one/many receivers), and for
+// each step verifies that exactly the expected sinks observe the log.
+func TestUpdateRoutesLogs(t *testing.T) {
+	const (
+		// arrivalTimeout bounds how long we wait for a sink we *expect* to
+		// receive a log.
+		arrivalTimeout = time.Second
+		// arrivalPollInterval is how often we re-check the expected sink
+		// while waiting.
+		arrivalPollInterval = 10 * time.Millisecond
+		// absenceWait is how long we let any (incorrect) write land before
+		// asserting that a sink we do *not* expect remained empty.
+		absenceWait = 100 * time.Millisecond
+	)
+
+	var buf safeBuffer
+	receivers := []loki.LogsReceiver{
+		loki.NewLogsReceiver(loki.WithChannel(make(chan loki.Entry, 16))),
+		loki.NewLogsReceiver(loki.WithChannel(make(chan loki.Entry, 16))),
+	}
+
+	logger, err := logging.NewDeferred(&buf)
+	require.NoError(t, err)
+
+	steps := []struct {
+		name          string
+		destination   logging.LogDestination
+		writeTo       []int // indices into receivers
+		wantStderr    bool
+		wantReceivers []int // indices into receivers
+	}{
+		{
+			name:        "destination=none, no write_to: everything dropped",
+			destination: logging.LogDestinationNone,
+		},
+		{
+			name:          "destination=none with write_to: only receiver gets the log",
+			destination:   logging.LogDestinationNone,
+			writeTo:       []int{0},
+			wantReceivers: []int{0},
+		},
+		{
+			name:          "destination=stderr with write_to: stderr and receiver get the log",
+			destination:   logging.LogDestinationStderr,
+			writeTo:       []int{0},
+			wantStderr:    true,
+			wantReceivers: []int{0},
+		},
+		{
+			name:          "destination=stderr with multiple receivers: stderr and all receivers get the log",
+			destination:   logging.LogDestinationStderr,
+			writeTo:       []int{0, 1},
+			wantStderr:    true,
+			wantReceivers: []int{0, 1},
+		},
+		{
+			name:        "destination=stderr, write_to cleared: only stderr gets the log",
+			destination: logging.LogDestinationStderr,
+			wantStderr:  true,
+		},
+		{
+			name:        "destination=none, write_to cleared: everything dropped",
+			destination: logging.LogDestinationNone,
+		},
+	}
+
+	for i, step := range steps {
+		t.Run(step.name, func(t *testing.T) {
+			var writeTo []loki.LogsReceiver
+			for _, idx := range step.writeTo {
+				writeTo = append(writeTo, receivers[idx])
+			}
+			require.NoError(t, logger.Update(logging.Options{
+				Level:       logging.LevelDebug,
+				Format:      logging.FormatLogfmt,
+				Destination: step.destination,
+				WriteTo:     writeTo,
+			}))
+
+			msg := fmt.Sprintf("step-%d", i)
+			beforeBuf := buf.String()
+			require.NoError(t, logger.Log("msg", msg))
+
+			if step.wantStderr {
+				require.Eventually(t, func() bool {
+					return strings.Contains(buf.String(), msg)
+				}, arrivalTimeout, arrivalPollInterval, "stderr did not receive %q", msg)
+			} else {
+				time.Sleep(absenceWait)
+				require.NotContains(t, strings.TrimPrefix(buf.String(), beforeBuf), msg,
+					"stderr unexpectedly received %q", msg)
+			}
+
+			wantSet := make(map[int]bool, len(step.wantReceivers))
+			for _, idx := range step.wantReceivers {
+				wantSet[idx] = true
+			}
+			for idx, r := range receivers {
+				if wantSet[idx] {
+					select {
+					case entry := <-r.Chan():
+						require.Contains(t, entry.Line, msg,
+							"receiver %d got wrong log", idx)
+					case <-time.After(arrivalTimeout):
+						t.Fatalf("receiver %d did not receive %q", idx, msg)
+					}
+				} else {
+					select {
+					case entry := <-r.Chan():
+						t.Fatalf("receiver %d unexpectedly got %q", idx, entry.Line)
+					case <-time.After(absenceWait):
+					}
+				}
+			}
+		})
+	}
+}
+
 // Test_lokiWriter_nil ensures that writing to a lokiWriter doesn't panic when
 // given a nil receiver.
 func Test_lokiWriter_nil(t *testing.T) {
@@ -129,8 +248,9 @@ func Test_lokiWriter_nil(t *testing.T) {
 	require.NoError(t, err)
 
 	err = logger.Update(logging.Options{
-		Level:  logging.LevelDebug,
-		Format: logging.FormatLogfmt,
+		Level:       logging.LevelDebug,
+		Format:      logging.FormatLogfmt,
+		Destination: logging.LogDestinationStderr,
 
 		WriteTo: []loki.LogsReceiver{nil},
 	})
@@ -153,9 +273,10 @@ func TestWriteToDisabledViaUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, logger.Update(logging.Options{
-		Level:   logging.LevelDebug,
-		Format:  logging.FormatLogfmt,
-		WriteTo: []loki.LogsReceiver{receiver},
+		Level:       logging.LevelDebug,
+		Format:      logging.FormatLogfmt,
+		Destination: logging.LogDestinationStderr,
+		WriteTo:     []loki.LogsReceiver{receiver},
 	}))
 
 	slogger := logger.Slog()
@@ -173,8 +294,9 @@ func TestWriteToDisabledViaUpdate(t *testing.T) {
 	}
 
 	require.NoError(t, logger.Update(logging.Options{
-		Level:  logging.LevelDebug,
-		Format: logging.FormatLogfmt,
+		Level:       logging.LevelDebug,
+		Format:      logging.FormatLogfmt,
+		Destination: logging.LogDestinationStderr,
 	}))
 
 	beforeLen := buf.String()
@@ -219,7 +341,11 @@ func TestUpdateConcurrentHandle(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- l.Update(logging.Options{Level: logging.LevelInfo, Format: logging.FormatLogfmt})
+		done <- l.Update(logging.Options{
+			Level:       logging.LevelInfo,
+			Format:      logging.FormatLogfmt,
+			Destination: logging.LogDestinationStderr,
+		})
 	}()
 
 	select {
@@ -263,7 +389,11 @@ func TestUpdateNoLostBufferedMessages(t *testing.T) {
 		}
 	}()
 
-	require.NoError(t, l.Update(logging.Options{Level: logging.LevelInfo, Format: logging.FormatLogfmt}))
+	require.NoError(t, l.Update(logging.Options{
+		Level:       logging.LevelInfo,
+		Format:      logging.FormatLogfmt,
+		Destination: logging.LogDestinationStderr,
+	}))
 	close(stop)
 	<-done
 

--- a/internal/runtime/logging/options.go
+++ b/internal/runtime/logging/options.go
@@ -22,10 +22,10 @@ type Options struct {
 // LogDestination is where to send the primary log output.
 type LogDestination string
 
-// TODO: Add a "none" destination to disable primary output.
 const (
 	LogDestinationStderr          LogDestination = "stderr"
 	LogDestinationWindowsEventLog LogDestination = "windows_event_log"
+	LogDestinationNone            LogDestination = "none"
 )
 
 var _ encoding.TextUnmarshaler = (*LogDestination)(nil)
@@ -33,7 +33,7 @@ var _ encoding.TextUnmarshaler = (*LogDestination)(nil)
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (d *LogDestination) UnmarshalText(text []byte) error {
 	switch LogDestination(text) {
-	case LogDestinationStderr, LogDestinationWindowsEventLog:
+	case LogDestinationStderr, LogDestinationWindowsEventLog, LogDestinationNone:
 		*d = LogDestination(text)
 		return nil
 	default:
@@ -62,7 +62,27 @@ func defaultOptions() Options {
 // DefaultOptions holds defaults for creating a Logger.
 var DefaultOptions = defaultOptions()
 
-var _ syntax.Defaulter = (*Options)(nil)
+var (
+	_ syntax.Defaulter = (*Options)(nil)
+	_ syntax.Validator = (*Options)(nil)
+)
+
+// Validate implements syntax.Validator.
+func (o *Options) Validate() error {
+	switch o.Format {
+	case FormatLogfmt, FormatJSON:
+	default:
+		return fmt.Errorf("unrecognized log format %q", o.Format)
+	}
+
+	switch o.Destination {
+	case LogDestinationStderr, LogDestinationWindowsEventLog, LogDestinationNone:
+	default:
+		return fmt.Errorf("unrecognized log destination %q", o.Destination)
+	}
+
+	return nil
+}
 
 // SetToDefault implements syntax.Defaulter. It re-evaluates the defaults at
 // call time (rather than reusing DefaultOptions) so that tests which stub

--- a/internal/runtime/logging/slgk_handler_test.go
+++ b/internal/runtime/logging/slgk_handler_test.go
@@ -1,0 +1,62 @@
+package logging_test
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/internal/runtime/logging"
+)
+
+func TestUpdateLevel(t *testing.T) {
+	buffer := bytes.NewBuffer(nil)
+	baseLogger, err := logging.New(
+		buffer,
+		logging.Options{
+			Level:       logging.LevelInfo,
+			Format:      logging.FormatLogfmt,
+			Destination: logging.LogDestinationStderr,
+		})
+	require.NoError(t, err)
+
+	gkLogger := log.With(baseLogger, "test", "test")
+	gkLogger.Log("msg", "hello")
+	require.Contains(t, buffer.String(), "ts=")
+	noTimestamp := strings.Join(strings.Split(buffer.String(), " ")[1:], " ")
+	require.Equal(t, "level=info msg=hello test=test\n", noTimestamp)
+
+	sLogger := slog.New(logging.NewSlogGoKitHandler(gkLogger))
+	buffer.Reset()
+	sLogger.Info("hello")
+	require.Contains(t, buffer.String(), "ts=")
+	noTimestamp = strings.Join(strings.Split(buffer.String(), " ")[1:], " ")
+	require.Equal(t, "level=info msg=hello test=test\n", noTimestamp)
+
+	buffer.Reset()
+	sLogger.Debug("hello")
+	require.Equal(t, "", buffer.String())
+
+	err = baseLogger.Update(
+		logging.Options{
+			Level:       logging.LevelDebug,
+			Format:      logging.FormatLogfmt,
+			Destination: logging.LogDestinationStderr,
+		})
+	require.NoError(t, err)
+
+	buffer.Reset()
+	sLogger.Info("hello")
+	require.Contains(t, buffer.String(), "ts=")
+	noTimestamp = strings.Join(strings.Split(buffer.String(), " ")[1:], " ")
+	require.Equal(t, "level=info msg=hello test=test\n", noTimestamp)
+
+	buffer.Reset()
+	sLogger.Debug("hello")
+	require.Contains(t, buffer.String(), "ts=")
+	noTimestamp = strings.Join(strings.Split(buffer.String(), " ")[1:], " ")
+	require.Equal(t, "level=debug msg=hello test=test\n", noTimestamp)
+}

--- a/internal/util/test_logger.go
+++ b/internal/util/test_logger.go
@@ -34,8 +34,9 @@ func TestAlloyLogger(t require.TestingT) *logging.Logger {
 	}
 
 	l, err := logging.New(os.Stderr, logging.Options{
-		Level:  logging.LevelDebug,
-		Format: logging.FormatLogfmt,
+		Level:       logging.LevelDebug,
+		Format:      logging.FormatLogfmt,
+		Destination: logging.LogDestinationStderr,
 	})
 	require.NoError(t, err)
 	return l


### PR DESCRIPTION
### Pull Request Details

This is mostly useful if you are using `write_to` to get Alloy's logs. In that case logging to stderr can lead to a double collection of the Alloy logs - once via write_to and once via stderr.

### Issue(s) fixed by this Pull Request

Fixes #2525

### Notes to the Reviewer

When #6264 is merged I will rebase this branch against `main` and will open the PR for review.

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated
