### PR TITLE
fix(loki.process): Potential deadlock on update with stage and receiver changes

### DIFF
--- a/internal/component/loki/process/process.go
+++ b/internal/component/loki/process/process.go
@@ -136,16 +136,17 @@ func (c *Component) Run(ctx context.Context) error {
 func (c *Component) Update(args component.Arguments) error {
 	newArgs := args.(Arguments)
 
-	// Update fanout first in case anything else fails.
-	c.fanout.UpdateChildren(newArgs.ForwardTo)
-
-	// Then update the pipeline itself.
 	c.mut.Lock()
 	defer c.mut.Unlock()
 
+	// We always want to update fanout but it's important to do so
+	// after we have drained the existing pipeline in case one of the
+	// new receivers is not running yet. This behaviour will go away with
+	// https://github.com/grafana/alloy/issues/4953.
+	defer c.fanout.UpdateChildren(newArgs.ForwardTo)
+
 	// We want to create a new pipeline if the config changed or if this is the
-	// first load. This will allow a component with no stages to function
-	// properly.
+	// first load. This will allow a component with no stages to function properly.
 	if stagesChanged(c.stages, newArgs.Stages) || c.stages == nil {
 		pipeline, err := stages.NewPipeline(c.opts.SLogger, newArgs.Stages, c.opts.Registerer, c.opts.MinStability)
 		if err != nil {


### PR DESCRIPTION
### Pull Request Details
When alloy runtime updates config it will:
1. Parse the new config
2. Create any new components
3. Update existing components
4. Start new components and stop components that was removed. 

The deadlock can happen if we get a config change where we create a new components and updates receivers for existing loki.process at the same time we need to restart the inner pipeline. The new component is created but not started i.e. not consuming from it's exported channel so when we try to drain the old pipeline through stop call and have updated receivers to include this new component it will never drain it because the new component have not started to consume.

With https://github.com/grafana/alloy/pull/6204 this problem disappears because we are not longer using channels nor requiring that `Run` is called before a new component can start to consume logs, but I decided to do this fix first so we can also backport it instead of just waiting to merge the other pr.  

### Issue(s) fixed by this Pull Request


### Notes to the Reviewer


### PR Checklist

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
