### PR TITLE
fix(database_observability.postgres): Count error logs when log_timezone is non-UTC

### DIFF
--- a/internal/component/database_observability/postgres/collector/logs.go
+++ b/internal/component/database_observability/postgres/collector/logs.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"log/slog"
 	"regexp"
@@ -19,7 +20,12 @@ import (
 const (
 	LogsCollector         = "logs"
 	expectedLogLinePrefix = "%m:%r:%u@%d:[%p]:%l:%e:%s:%v:%x:%c:%q%a"
+	selectLogTimezone     = `SELECT setting FROM pg_settings WHERE name = 'log_timezone';`
 )
+
+// log_timezone has context=sighup, so operators can change it without a
+// restart; re-read on a tick so we stay in sync.
+const logTimezoneRefreshInterval = time.Minute
 
 // Postgres log format regex
 var logFormatRegex = regexp.MustCompile(
@@ -44,9 +50,10 @@ type LogsArguments struct {
 	Registry         *prometheus.Registry
 	ExcludeDatabases []string
 	ExcludeUsers     []string
-	// LogTimezone returns PostgreSQL's configured log_timezone as a Location,
-	// or nil if it is unknown. Called on every log line, so must be cheap.
-	LogTimezone func() *time.Location
+	// DB, if non-nil, is polled for PostgreSQL's log_timezone setting so the
+	// historical-log filter can resolve non-UTC abbreviations. When nil, the
+	// collector skips the filter for ambiguous timezones (still counts the log).
+	DB *sql.DB
 }
 
 type Logs struct {
@@ -57,7 +64,10 @@ type Logs struct {
 	receiver         loki.LogsReceiver
 	excludeDatabases []string
 	excludeUsers     []string
-	getLogTimezone   func() *time.Location
+
+	db                     *sql.DB
+	logTimezone            atomic.Pointer[time.Location]
+	lastLogTimezoneWarning atomic.Pointer[string] // dedupes unparseable-log_timezone warns across refresh ticks
 
 	errorsBySQLState *prometheus.CounterVec
 	parseErrors      prometheus.Counter
@@ -78,11 +88,6 @@ type Logs struct {
 func NewLogs(args LogsArguments) (*Logs, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	getLogTimezone := args.LogTimezone
-	if getLogTimezone == nil {
-		getLogTimezone = func() *time.Location { return nil }
-	}
-
 	l := &Logs{
 		logger:           args.Logger.With("collector", LogsCollector),
 		entryHandler:     args.EntryHandler,
@@ -90,7 +95,7 @@ func NewLogs(args LogsArguments) (*Logs, error) {
 		receiver:         args.Receiver,
 		excludeDatabases: args.ExcludeDatabases,
 		excludeUsers:     args.ExcludeUsers,
-		getLogTimezone:   getLogTimezone,
+		db:               args.DB,
 		ctx:              ctx,
 		cancel:           cancel,
 		stopped:          atomic.NewBool(false),
@@ -138,9 +143,57 @@ func (l *Logs) Receiver() loki.LogsReceiver {
 func (l *Logs) Start(ctx context.Context) error {
 	l.logger.Debug("collector started")
 
+	if l.db != nil {
+		// Prime synchronously so the first log line can be filtered against
+		// the configured log_timezone, then poll for sighup-reload changes.
+		l.refreshLogTimezone(l.ctx)
+		l.wg.Go(l.logTimezoneRefreshLoop)
+	}
 	l.wg.Go(l.run)
 
 	return nil
+}
+
+func (l *Logs) logTimezoneRefreshLoop() {
+	ticker := time.NewTicker(logTimezoneRefreshInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-l.ctx.Done():
+			return
+		case <-ticker.C:
+			l.refreshLogTimezone(l.ctx)
+		}
+	}
+}
+
+// refreshLogTimezone queries log_timezone and caches the resulting Location.
+// Any failure clears the cache so resolveAbsolute falls back to its
+// ambiguous-zone path.
+func (l *Logs) refreshLogTimezone(ctx context.Context) {
+	queryCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	var name string
+	if err := l.db.QueryRowContext(queryCtx, selectLogTimezone).Scan(&name); err != nil {
+		level.Debug(l.logger).Log("msg", "failed to query log_timezone", "err", err)
+		l.logTimezone.Store(nil)
+		return
+	}
+
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		// PG accepts POSIX specs like 'EST5EDT,M3.2.0,M11.1.0' or '<+05>5' that
+		// Go's IANA-only tzdata can't load. Warn once per distinct value.
+		if prev := l.lastLogTimezoneWarning.Load(); prev == nil || *prev != name {
+			level.Warn(l.logger).Log("msg", "PostgreSQL log_timezone is not a Go-loadable IANA name; logs collector will skip its historical-log filter. Consider setting log_timezone to an IANA name (e.g. 'America/New_York') in postgresql.conf.", "log_timezone", name, "err", err)
+			l.lastLogTimezoneWarning.Store(&name)
+		}
+		l.logTimezone.Store(nil)
+		return
+	}
+	l.lastLogTimezoneWarning.Store(nil)
+	l.logTimezone.Store(loc)
 }
 
 func (l *Logs) Stop() {
@@ -291,7 +344,7 @@ func (l *Logs) resolveAbsolute(parsed time.Time) (time.Time, bool) {
 		return parsed, true
 	}
 
-	loc := l.getLogTimezone()
+	loc := l.logTimezone.Load()
 	if loc == nil {
 		return time.Time{}, false
 	}

--- a/internal/component/database_observability/postgres/collector/logs.go
+++ b/internal/component/database_observability/postgres/collector/logs.go
@@ -167,7 +167,7 @@ func (l *Logs) refreshLogTimezone(ctx context.Context) {
 
 	var tzName string
 	if err := l.db.QueryRowContext(queryCtx, selectLogTimezone).Scan(&tzName); err != nil {
-		level.Debug(l.logger).Log("msg", "failed to query log_timezone", "err", err)
+		l.logger.Debug("failed to query log_timezone", "err", err)
 		return
 	}
 
@@ -175,7 +175,7 @@ func (l *Logs) refreshLogTimezone(ctx context.Context) {
 	if err != nil {
 		// PG accepts POSIX specs (e.g. 'EST5EDT,M3.2.0,M11.1.0') that Go's tzdata can't load.
 		if prev := l.lastLogTimezone.Load(); prev == nil || *prev != tzName {
-			level.Warn(l.logger).Log("msg", "PostgreSQL log_timezone is not a Go-loadable IANA name; logs collector will skip its historical-log filter. Consider setting log_timezone to an IANA name (e.g. 'America/New_York') in postgresql.conf.", "log_timezone", tzName, "err", err)
+			l.logger.Warn("PostgreSQL log_timezone is not a Go-loadable IANA name; logs collector will skip its historical-log filter. Consider setting log_timezone to an IANA name (e.g. 'America/New_York') in postgresql.conf.", "log_timezone", tzName, "err", err)
 			l.lastLogTimezone.Store(&tzName)
 		}
 		l.logTimezone.Store(nil)

--- a/internal/component/database_observability/postgres/collector/logs.go
+++ b/internal/component/database_observability/postgres/collector/logs.go
@@ -44,6 +44,9 @@ type LogsArguments struct {
 	Registry         *prometheus.Registry
 	ExcludeDatabases []string
 	ExcludeUsers     []string
+	// LogTimezone returns PostgreSQL's configured log_timezone as a Location,
+	// or nil if it is unknown. Called on every log line, so must be cheap.
+	LogTimezone func() *time.Location
 }
 
 type Logs struct {
@@ -54,6 +57,7 @@ type Logs struct {
 	receiver         loki.LogsReceiver
 	excludeDatabases []string
 	excludeUsers     []string
+	getLogTimezone   func() *time.Location
 
 	errorsBySQLState *prometheus.CounterVec
 	parseErrors      prometheus.Counter
@@ -74,6 +78,11 @@ type Logs struct {
 func NewLogs(args LogsArguments) (*Logs, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
+	getLogTimezone := args.LogTimezone
+	if getLogTimezone == nil {
+		getLogTimezone = func() *time.Location { return nil }
+	}
+
 	l := &Logs{
 		logger:           args.Logger.With("collector", LogsCollector),
 		entryHandler:     args.EntryHandler,
@@ -81,6 +90,7 @@ func NewLogs(args LogsArguments) (*Logs, error) {
 		receiver:         args.Receiver,
 		excludeDatabases: args.ExcludeDatabases,
 		excludeUsers:     args.ExcludeUsers,
+		getLogTimezone:   getLogTimezone,
 		ctx:              ctx,
 		cancel:           cancel,
 		stopped:          atomic.NewBool(false),
@@ -199,10 +209,11 @@ func (l *Logs) parseTextLog(entry loki.Entry) error {
 			} {
 				logTimestamp, err := time.Parse(layout, timestampStr)
 				if err == nil {
-					if !logTimestamp.After(l.startTime) {
+					absolute, ok := l.resolveAbsolute(logTimestamp)
+					if ok && !absolute.After(l.startTime) {
 						return nil // Skip historical log
 					}
-					break // Found valid timestamp, continue processing
+					break
 				}
 			}
 		}
@@ -266,6 +277,33 @@ func (l *Logs) parseTextLog(entry loki.Entry) error {
 	).Inc()
 
 	return nil
+}
+
+// resolveAbsolute returns a trustworthy UTC instant for a timestamp produced
+// by time.Parse. Go's time.Parse fabricates a zero-offset Location for any
+// abbreviation it doesn't know (PST, PDT, EDT, AEDT, ...); we recover the
+// real instant by re-interpreting the wall-clock fields in the configured
+// log_timezone, but only trust the recovery when its abbreviation matches the
+// one in the log line (otherwise the cached log_timezone is stale).
+func (l *Logs) resolveAbsolute(parsed time.Time) (time.Time, bool) {
+	name, offset := parsed.Zone()
+	if offset != 0 || name == "UTC" || name == "GMT" {
+		return parsed, true
+	}
+
+	loc := l.getLogTimezone()
+	if loc == nil {
+		return time.Time{}, false
+	}
+
+	y, mo, d := parsed.Date()
+	h, mi, s := parsed.Clock()
+	reconstructed := time.Date(y, mo, d, h, mi, s, parsed.Nanosecond(), loc)
+	reconstructedName, _ := reconstructed.Zone()
+	if reconstructedName != name {
+		return time.Time{}, false
+	}
+	return reconstructed, true
 }
 
 // isContinuationLine checks if a line is part of a multi-line PostgreSQL error

--- a/internal/component/database_observability/postgres/collector/logs.go
+++ b/internal/component/database_observability/postgres/collector/logs.go
@@ -167,8 +167,6 @@ func (l *Logs) refreshLogTimezone(ctx context.Context) {
 
 	var tzName string
 	if err := l.db.QueryRowContext(queryCtx, selectLogTimezone).Scan(&tzName); err != nil {
-		// Keep any previously cached Location: a transient query failure
-		// doesn't mean PG's setting changed.
 		level.Debug(l.logger).Log("msg", "failed to query log_timezone", "err", err)
 		return
 	}

--- a/internal/component/database_observability/postgres/collector/logs.go
+++ b/internal/component/database_observability/postgres/collector/logs.go
@@ -23,7 +23,7 @@ const (
 	selectLogTimezone     = `SELECT setting FROM pg_settings WHERE name = 'log_timezone';`
 )
 
-// log_timezone is sighup-reloadable; poll for changes.
+// log_timezone is a sighup-reloadable Postgres setting so we periodically poll for changes
 const logTimezoneRefreshInterval = time.Hour
 
 // Postgres log format regex
@@ -49,8 +49,7 @@ type LogsArguments struct {
 	Registry         *prometheus.Registry
 	ExcludeDatabases []string
 	ExcludeUsers     []string
-	// DB, if non-nil, is polled for log_timezone to resolve non-UTC log abbreviations.
-	DB *sql.DB
+	DB               *sql.DB
 }
 
 type Logs struct {

--- a/internal/component/database_observability/postgres/collector/logs.go
+++ b/internal/component/database_observability/postgres/collector/logs.go
@@ -23,8 +23,7 @@ const (
 	selectLogTimezone     = `SELECT setting FROM pg_settings WHERE name = 'log_timezone';`
 )
 
-// log_timezone has context=sighup, so operators can change it without a
-// restart; re-read on a tick so we stay in sync.
+// log_timezone is sighup-reloadable; poll for changes.
 const logTimezoneRefreshInterval = time.Minute
 
 // Postgres log format regex
@@ -50,9 +49,7 @@ type LogsArguments struct {
 	Registry         *prometheus.Registry
 	ExcludeDatabases []string
 	ExcludeUsers     []string
-	// DB, if non-nil, is polled for PostgreSQL's log_timezone setting so the
-	// historical-log filter can resolve non-UTC abbreviations. When nil, the
-	// collector skips the filter for ambiguous timezones (still counts the log).
+	// DB, if non-nil, is polled for log_timezone to resolve non-UTC log abbreviations.
 	DB *sql.DB
 }
 
@@ -67,7 +64,7 @@ type Logs struct {
 
 	db                     *sql.DB
 	logTimezone            atomic.Pointer[time.Location]
-	lastLogTimezoneWarning atomic.Pointer[string] // dedupes unparseable-log_timezone warns across refresh ticks
+	lastLogTimezoneWarning atomic.Pointer[string]
 
 	errorsBySQLState *prometheus.CounterVec
 	parseErrors      prometheus.Counter
@@ -144,8 +141,6 @@ func (l *Logs) Start(ctx context.Context) error {
 	l.logger.Debug("collector started")
 
 	if l.db != nil {
-		// Prime synchronously so the first log line can be filtered against
-		// the configured log_timezone, then poll for sighup-reload changes.
 		l.refreshLogTimezone(l.ctx)
 		l.wg.Go(l.logTimezoneRefreshLoop)
 	}
@@ -167,9 +162,6 @@ func (l *Logs) logTimezoneRefreshLoop() {
 	}
 }
 
-// refreshLogTimezone queries log_timezone and caches the resulting Location.
-// Any failure clears the cache so resolveAbsolute falls back to its
-// ambiguous-zone path.
 func (l *Logs) refreshLogTimezone(ctx context.Context) {
 	queryCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
@@ -183,8 +175,7 @@ func (l *Logs) refreshLogTimezone(ctx context.Context) {
 
 	loc, err := time.LoadLocation(name)
 	if err != nil {
-		// PG accepts POSIX specs like 'EST5EDT,M3.2.0,M11.1.0' or '<+05>5' that
-		// Go's IANA-only tzdata can't load. Warn once per distinct value.
+		// PG accepts POSIX specs (e.g. 'EST5EDT,M3.2.0,M11.1.0') that Go's tzdata can't load.
 		if prev := l.lastLogTimezoneWarning.Load(); prev == nil || *prev != name {
 			level.Warn(l.logger).Log("msg", "PostgreSQL log_timezone is not a Go-loadable IANA name; logs collector will skip its historical-log filter. Consider setting log_timezone to an IANA name (e.g. 'America/New_York') in postgresql.conf.", "log_timezone", name, "err", err)
 			l.lastLogTimezoneWarning.Store(&name)
@@ -332,12 +323,10 @@ func (l *Logs) parseTextLog(entry loki.Entry) error {
 	return nil
 }
 
-// resolveAbsolute returns a trustworthy UTC instant for a timestamp produced
-// by time.Parse. Go's time.Parse fabricates a zero-offset Location for any
-// abbreviation it doesn't know (PST, PDT, EDT, AEDT, ...); we recover the
-// real instant by re-interpreting the wall-clock fields in the configured
-// log_timezone, but only trust the recovery when its abbreviation matches the
-// one in the log line (otherwise the cached log_timezone is stale).
+// resolveAbsolute returns a trustworthy UTC instant. time.Parse fabricates a
+// zero-offset Location for unknown abbreviations (PST, PDT, EDT, ...); we
+// recover the real instant via the configured log_timezone, trusting the
+// recovery only when its abbreviation matches the log line's.
 func (l *Logs) resolveAbsolute(parsed time.Time) (time.Time, bool) {
 	name, offset := parsed.Zone()
 	if offset != 0 || name == "UTC" || name == "GMT" {

--- a/internal/component/database_observability/postgres/collector/logs.go
+++ b/internal/component/database_observability/postgres/collector/logs.go
@@ -24,7 +24,7 @@ const (
 )
 
 // log_timezone is sighup-reloadable; poll for changes.
-const logTimezoneRefreshInterval = time.Minute
+const logTimezoneRefreshInterval = time.Hour
 
 // Postgres log format regex
 var logFormatRegex = regexp.MustCompile(
@@ -62,9 +62,9 @@ type Logs struct {
 	excludeDatabases []string
 	excludeUsers     []string
 
-	db                     *sql.DB
-	logTimezone            atomic.Pointer[time.Location]
-	lastLogTimezoneWarning atomic.Pointer[string]
+	db              *sql.DB
+	logTimezone     atomic.Pointer[time.Location]
+	lastLogTimezone atomic.Pointer[string]
 
 	errorsBySQLState *prometheus.CounterVec
 	parseErrors      prometheus.Counter
@@ -166,24 +166,25 @@ func (l *Logs) refreshLogTimezone(ctx context.Context) {
 	queryCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	var name string
-	if err := l.db.QueryRowContext(queryCtx, selectLogTimezone).Scan(&name); err != nil {
+	var tzName string
+	if err := l.db.QueryRowContext(queryCtx, selectLogTimezone).Scan(&tzName); err != nil {
+		// Keep any previously cached Location: a transient query failure
+		// doesn't mean PG's setting changed.
 		level.Debug(l.logger).Log("msg", "failed to query log_timezone", "err", err)
-		l.logTimezone.Store(nil)
 		return
 	}
 
-	loc, err := time.LoadLocation(name)
+	loc, err := time.LoadLocation(tzName)
 	if err != nil {
 		// PG accepts POSIX specs (e.g. 'EST5EDT,M3.2.0,M11.1.0') that Go's tzdata can't load.
-		if prev := l.lastLogTimezoneWarning.Load(); prev == nil || *prev != name {
-			level.Warn(l.logger).Log("msg", "PostgreSQL log_timezone is not a Go-loadable IANA name; logs collector will skip its historical-log filter. Consider setting log_timezone to an IANA name (e.g. 'America/New_York') in postgresql.conf.", "log_timezone", name, "err", err)
-			l.lastLogTimezoneWarning.Store(&name)
+		if prev := l.lastLogTimezone.Load(); prev == nil || *prev != tzName {
+			level.Warn(l.logger).Log("msg", "PostgreSQL log_timezone is not a Go-loadable IANA name; logs collector will skip its historical-log filter. Consider setting log_timezone to an IANA name (e.g. 'America/New_York') in postgresql.conf.", "log_timezone", tzName, "err", err)
+			l.lastLogTimezone.Store(&tzName)
 		}
 		l.logTimezone.Store(nil)
 		return
 	}
-	l.lastLogTimezoneWarning.Store(nil)
+	l.lastLogTimezone.Store(nil)
 	l.logTimezone.Store(loc)
 }
 

--- a/internal/component/database_observability/postgres/collector/logs_test.go
+++ b/internal/component/database_observability/postgres/collector/logs_test.go
@@ -97,28 +97,23 @@ func TestLogsCollector_ParseRDSFormat(t *testing.T) {
 				},
 			}
 
-			time.Sleep(100 * time.Millisecond)
-
-			mfs, _ := registry.Gather()
-			found := false
-			for _, mf := range mfs {
-				if mf.GetName() == "database_observability_pg_errors_total" {
-					for _, metric := range mf.GetMetric() {
-						labels := make(map[string]string)
-						for _, label := range metric.GetLabel() {
-							labels[label.GetName()] = label.GetValue()
-						}
-						if labels["user"] == tt.wantUser && labels["datname"] == tt.wantDB && labels["severity"] == tt.wantSev && labels["sqlstate"] == tt.wantSQLState {
-							require.Equal(t, tt.wantSev, labels["severity"])
-							require.Equal(t, tt.wantSQLState, labels["sqlstate"])
-							require.Equal(t, tt.wantSQLState[:2], labels["sqlstate_class"])
-							found = true
-							break
+			require.Eventuallyf(t, func() bool {
+				mfs, _ := registry.Gather()
+				for _, mf := range mfs {
+					if mf.GetName() == "database_observability_pg_errors_total" {
+						for _, metric := range mf.GetMetric() {
+							labels := make(map[string]string)
+							for _, label := range metric.GetLabel() {
+								labels[label.GetName()] = label.GetValue()
+							}
+							if labels["user"] == tt.wantUser && labels["datname"] == tt.wantDB && labels["severity"] == tt.wantSev && labels["sqlstate"] == tt.wantSQLState {
+								return labels["sqlstate_class"] == tt.wantSQLState[:2]
+							}
 						}
 					}
 				}
-			}
-			require.True(t, found, "metric not found for %s", tt.name)
+				return false
+			}, 2*time.Second, 5*time.Millisecond, "metric not found for %s", tt.name)
 		})
 	}
 }
@@ -135,14 +130,9 @@ func TestLogsCollector_SkipsNonErrors(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	startTime := collector.startTime
-	err = collector.Start(context.Background())
-	require.NoError(t, err)
-	defer collector.Stop()
-
 	// Build INFO and LOG lines with timestamps AFTER collector start, so they would pass the
 	// historical filter if they reached it. They are skipped for severity (not ERROR/FATAL/PANIC).
-	ts := startTime.Add(10 * time.Second).UTC()
+	ts := collector.startTime.Add(10 * time.Second).UTC()
 	ts1 := ts.Format("2006-01-02 15:04:05.000 MST")
 	ts2 := ts.Add(-1 * time.Second).Format("2006-01-02 15:04:05 MST")
 
@@ -155,15 +145,8 @@ func TestLogsCollector_SkipsNonErrors(t *testing.T) {
 	}
 
 	for _, logLine := range skipLogs {
-		collector.Receiver().Chan() <- loki.Entry{
-			Entry: push.Entry{
-				Line:      logLine,
-				Timestamp: time.Now(),
-			},
-		}
+		require.NoError(t, collector.parseTextLog(loki.Entry{Entry: push.Entry{Line: logLine}}))
 	}
-
-	time.Sleep(100 * time.Millisecond)
 
 	// Should have 0 metrics since all were skipped
 	mfs, _ := registry.Gather()
@@ -237,41 +220,41 @@ func TestLogsCollector_MetricSumming(t *testing.T) {
 		}
 	}
 
-	time.Sleep(200 * time.Millisecond)
-
-	// Verify metrics
-	mfs, _ := registry.Gather()
-	var errorMetrics *dto.MetricFamily
-	for _, mf := range mfs {
-		if mf.GetName() == "database_observability_pg_errors_total" {
-			errorMetrics = mf
-			break
-		}
-	}
-
-	require.NotNil(t, errorMetrics)
-	require.Equal(t, 2, len(errorMetrics.GetMetric()), "should have 2 unique label combinations")
-
-	// Check counts
 	type metricKey struct {
 		user string
 		db   string
 		sev  string
 	}
-	counts := make(map[metricKey]float64)
-	for _, metric := range errorMetrics.GetMetric() {
-		labels := make(map[string]string)
-		for _, label := range metric.GetLabel() {
-			labels[label.GetName()] = label.GetValue()
+
+	gatherCounts := func() map[metricKey]float64 {
+		mfs, _ := registry.Gather()
+		counts := make(map[metricKey]float64)
+		for _, mf := range mfs {
+			if mf.GetName() == "database_observability_pg_errors_total" {
+				for _, metric := range mf.GetMetric() {
+					labels := make(map[string]string)
+					for _, label := range metric.GetLabel() {
+						labels[label.GetName()] = label.GetValue()
+					}
+					counts[metricKey{
+						user: labels["user"],
+						db:   labels["datname"],
+						sev:  labels["severity"],
+					}] = metric.GetCounter().GetValue()
+				}
+			}
 		}
-		key := metricKey{
-			user: labels["user"],
-			db:   labels["datname"],
-			sev:  labels["severity"],
-		}
-		counts[key] = metric.GetCounter().GetValue()
+		return counts
 	}
 
+	require.Eventually(t, func() bool {
+		counts := gatherCounts()
+		return counts[metricKey{user: "user1", db: "db1", sev: "ERROR"}] == 3 &&
+			counts[metricKey{user: "user2", db: "db2", sev: "FATAL"}] == 1
+	}, 2*time.Second, 5*time.Millisecond, "expected counters did not reach target values")
+
+	counts := gatherCounts()
+	require.Len(t, counts, 2, "should have 2 unique label combinations")
 	require.Equal(t, float64(3), counts[metricKey{user: "user1", db: "db1", sev: "ERROR"}], "user1@db1:ERROR should have count of 3")
 	require.Equal(t, float64(1), counts[metricKey{user: "user2", db: "db2", sev: "FATAL"}], "user2@db2:FATAL should have count of 1")
 }
@@ -300,18 +283,15 @@ func TestLogsCollector_InvalidFormat(t *testing.T) {
 		},
 	}
 
-	time.Sleep(100 * time.Millisecond)
-
-	// Check parse errors counter was incremented
-	mfs, _ := registry.Gather()
-	found := false
-	for _, mf := range mfs {
-		if mf.GetName() == "database_observability_pg_error_log_parse_failures_total" {
-			found = true
-			require.Greater(t, mf.GetMetric()[0].GetCounter().GetValue(), 0.0)
+	require.Eventually(t, func() bool {
+		mfs, _ := registry.Gather()
+		for _, mf := range mfs {
+			if mf.GetName() == "database_observability_pg_error_log_parse_failures_total" {
+				return mf.GetMetric()[0].GetCounter().GetValue() > 0
+			}
 		}
-	}
-	require.True(t, found, "parse error metric should exist")
+		return false
+	}, 2*time.Second, 5*time.Millisecond, "parse error metric should be incremented")
 }
 
 func TestLogsCollector_EmptyUserAndDatabase(t *testing.T) {
@@ -344,9 +324,16 @@ func TestLogsCollector_EmptyUserAndDatabase(t *testing.T) {
 		},
 	}
 
-	time.Sleep(200 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		mfs, _ := registry.Gather()
+		for _, mf := range mfs {
+			if mf.GetName() == "database_observability_pg_errors_total" && len(mf.GetMetric()) == 1 {
+				return mf.GetMetric()[0].GetCounter().GetValue() == 1
+			}
+		}
+		return false
+	}, 2*time.Second, 5*time.Millisecond, "expected one FATAL metric with count 1")
 
-	// Verify metric was created with empty user and database labels
 	mfs, _ := registry.Gather()
 	var errorMetrics *dto.MetricFamily
 	for _, mf := range mfs {
@@ -531,27 +518,24 @@ func TestLogsCollector_SQLStateExtraction(t *testing.T) {
 				},
 			}
 
-			time.Sleep(100 * time.Millisecond)
-
-			mfs, _ := registry.Gather()
-			found := false
-			for _, mf := range mfs {
-				if mf.GetName() == "database_observability_pg_errors_total" {
-					for _, metric := range mf.GetMetric() {
-						labels := make(map[string]string)
-						for _, label := range metric.GetLabel() {
-							labels[label.GetName()] = label.GetValue()
-						}
-						if labels["sqlstate"] == tt.wantSQLState {
-							require.Equal(t, tt.wantSQLStateClass, labels["sqlstate_class"], "sqlstate_class should match")
-							require.Equal(t, tt.wantSeverity, labels["severity"], "severity should match")
-							found = true
-							break
+			require.Eventuallyf(t, func() bool {
+				mfs, _ := registry.Gather()
+				for _, mf := range mfs {
+					if mf.GetName() == "database_observability_pg_errors_total" {
+						for _, metric := range mf.GetMetric() {
+							labels := make(map[string]string)
+							for _, label := range metric.GetLabel() {
+								labels[label.GetName()] = label.GetValue()
+							}
+							if labels["sqlstate"] == tt.wantSQLState {
+								return labels["sqlstate_class"] == tt.wantSQLStateClass &&
+									labels["severity"] == tt.wantSeverity
+							}
 						}
 					}
 				}
-			}
-			require.True(t, found, "metric with sqlstate=%s not found for %s", tt.wantSQLState, tt.name)
+				return false
+			}, 2*time.Second, 5*time.Millisecond, "metric with sqlstate=%s not found for %s", tt.wantSQLState, tt.name)
 		})
 	}
 }
@@ -568,48 +552,22 @@ func TestLogsCollector_SkipsHistoricalLogs(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	startTime := collector.startTime
+	historicalTime := collector.startTime.Add(-1 * time.Hour)
+	recentTime := collector.startTime.Add(10 * time.Second)
 
-	err = collector.Start(context.Background())
-	require.NoError(t, err)
-	defer collector.Stop()
-
-	// Create timestamps relative to start time
-	historicalTime := startTime.Add(-1 * time.Hour)
-	recentTime := startTime.Add(10 * time.Second)
-
-	// Send historical log (1 hour before start) with timestamp in log line
 	historicalLine := fmt.Sprintf("%s:[local]:user@database:[1234]:1:28000:%s:1/1:0:000000.0::psqlERROR:  test historical error",
 		historicalTime.Format("2006-01-02 15:04:05.000 MST"),
 		historicalTime.Format("2006-01-02 15:04:05 MST"))
 	t.Logf("Historical line: %s", historicalLine)
 
-	historicalEntry := loki.Entry{
-		Entry: push.Entry{
-			Timestamp: time.Now(),
-			Line:      historicalLine,
-		},
-	}
-
-	// Send recent log (after start) with timestamp in log line
 	recentLine := fmt.Sprintf("%s:[local]:user@database:[1234]:1:28000:%s:1/1:0:000000.0::psqlERROR:  test recent error",
 		recentTime.Format("2006-01-02 15:04:05.000 MST"),
 		recentTime.Format("2006-01-02 15:04:05 MST"))
 	t.Logf("Recent line: %s", recentLine)
 
-	recentEntry := loki.Entry{
-		Entry: push.Entry{
-			Timestamp: time.Now(),
-			Line:      recentLine,
-		},
-	}
+	require.NoError(t, collector.parseTextLog(loki.Entry{Entry: push.Entry{Line: historicalLine}}))
+	require.NoError(t, collector.parseTextLog(loki.Entry{Entry: push.Entry{Line: recentLine}}))
 
-	// Process both
-	collector.Receiver().Chan() <- historicalEntry
-	collector.Receiver().Chan() <- recentEntry
-	time.Sleep(200 * time.Millisecond)
-
-	// Verify only recent log incremented counter
 	mfs, err := registry.Gather()
 	require.NoError(t, err)
 
@@ -639,26 +597,13 @@ func TestLogsCollector_SkipsOnlyHistoricalLogs(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	startTime := collector.startTime
-	err = collector.Start(context.Background())
-	require.NoError(t, err)
-	defer collector.Stop()
-
-	// Send ONLY historical logs (valid ERROR format, but timestamp before collector start)
-	historicalTime := startTime.Add(-1 * time.Hour)
+	historicalTime := collector.startTime.Add(-1 * time.Hour)
 	historicalLine := fmt.Sprintf("%s:[local]:user@database:[1234]:1:28000:%s:1/1:0:000000.0::psqlERROR:  test historical error",
 		historicalTime.Format("2006-01-02 15:04:05.000 MST"),
 		historicalTime.Format("2006-01-02 15:04:05 MST"))
 
-	collector.Receiver().Chan() <- loki.Entry{
-		Entry: push.Entry{
-			Line:      historicalLine,
-			Timestamp: time.Now(),
-		},
-	}
-	time.Sleep(200 * time.Millisecond)
+	require.NoError(t, collector.parseTextLog(loki.Entry{Entry: push.Entry{Line: historicalLine}}))
 
-	// Verify 0 metrics - historical logs must be skipped
 	mfs, err := registry.Gather()
 	require.NoError(t, err)
 
@@ -703,18 +648,18 @@ func TestLogsCollector_NonUTCLogTimezone(t *testing.T) {
 		},
 	}
 
-	time.Sleep(200 * time.Millisecond)
-
-	mfs, _ := registry.Gather()
-	var totalCount float64
-	for _, mf := range mfs {
-		if mf.GetName() == "database_observability_pg_errors_total" {
-			for _, metric := range mf.GetMetric() {
-				totalCount += metric.GetCounter().GetValue()
+	require.Eventually(t, func() bool {
+		mfs, _ := registry.Gather()
+		var totalCount float64
+		for _, mf := range mfs {
+			if mf.GetName() == "database_observability_pg_errors_total" {
+				for _, metric := range mf.GetMetric() {
+					totalCount += metric.GetCounter().GetValue()
+				}
 			}
 		}
-	}
-	require.Equal(t, float64(1), totalCount, "log with non-UTC abbreviation timezone must be counted")
+		return totalCount == 1
+	}, 2*time.Second, 5*time.Millisecond, "log with non-UTC abbreviation timezone must be counted")
 }
 
 func TestLogsCollector_LogTimezoneCountsRecentNonUTC(t *testing.T) {
@@ -746,18 +691,19 @@ func TestLogsCollector_LogTimezoneCountsRecentNonUTC(t *testing.T) {
 
 	logLine := ts1 + ":[local]:app-user@books_store:[9112]:4:57014:" + ts2 + ":25/112:0:693c34cb.2398::psqlERROR:  canceling statement"
 	collector.Receiver().Chan() <- loki.Entry{Entry: push.Entry{Line: logLine, Timestamp: time.Now()}}
-	time.Sleep(200 * time.Millisecond)
 
-	mfs, _ := registry.Gather()
-	var totalCount float64
-	for _, mf := range mfs {
-		if mf.GetName() == "database_observability_pg_errors_total" {
-			for _, metric := range mf.GetMetric() {
-				totalCount += metric.GetCounter().GetValue()
+	require.Eventually(t, func() bool {
+		mfs, _ := registry.Gather()
+		var totalCount float64
+		for _, mf := range mfs {
+			if mf.GetName() == "database_observability_pg_errors_total" {
+				for _, metric := range mf.GetMetric() {
+					totalCount += metric.GetCounter().GetValue()
+				}
 			}
 		}
-	}
-	require.Equal(t, float64(1), totalCount, "recent non-UTC log must be counted when log_timezone Location is supplied")
+		return totalCount == 1
+	}, 2*time.Second, 5*time.Millisecond, "recent non-UTC log must be counted when log_timezone Location is supplied")
 }
 
 func TestLogsCollector_LogTimezoneFiltersHistoricalNonUTC(t *testing.T) {
@@ -776,20 +722,14 @@ func TestLogsCollector_LogTimezoneFiltersHistoricalNonUTC(t *testing.T) {
 	require.NoError(t, err)
 	collector.logTimezone.Store(loc)
 
-	startTime := collector.startTime
-	err = collector.Start(context.Background())
-	require.NoError(t, err)
-	defer collector.Stop()
-
-	abs := startTime.Add(-1 * time.Hour)
+	abs := collector.startTime.Add(-1 * time.Hour)
 	inLoc := abs.In(loc)
 	abbrev, _ := inLoc.Zone()
 	ts1 := inLoc.Format("2006-01-02 15:04:05.000") + " " + abbrev
 	ts2 := inLoc.Add(-1*time.Second).Format("2006-01-02 15:04:05") + " " + abbrev
 
 	logLine := ts1 + ":[local]:app-user@books_store:[9112]:4:57014:" + ts2 + ":25/112:0:693c34cb.2398::psqlERROR:  canceling statement"
-	collector.Receiver().Chan() <- loki.Entry{Entry: push.Entry{Line: logLine, Timestamp: time.Now()}}
-	time.Sleep(200 * time.Millisecond)
+	require.NoError(t, collector.parseTextLog(loki.Entry{Entry: push.Entry{Line: logLine}}))
 
 	mfs, _ := registry.Gather()
 	var totalCount float64
@@ -831,18 +771,19 @@ func TestLogsCollector_LogTimezoneAbbrevMismatchFallsBack(t *testing.T) {
 
 	logLine := ts1 + ":[local]:app-user@books_store:[9112]:4:57014:" + ts2 + ":25/112:0:693c34cb.2398::psqlERROR:  canceling statement"
 	collector.Receiver().Chan() <- loki.Entry{Entry: push.Entry{Line: logLine, Timestamp: time.Now()}}
-	time.Sleep(200 * time.Millisecond)
 
-	mfs, _ := registry.Gather()
-	var totalCount float64
-	for _, mf := range mfs {
-		if mf.GetName() == "database_observability_pg_errors_total" {
-			for _, metric := range mf.GetMetric() {
-				totalCount += metric.GetCounter().GetValue()
+	require.Eventually(t, func() bool {
+		mfs, _ := registry.Gather()
+		var totalCount float64
+		for _, mf := range mfs {
+			if mf.GetName() == "database_observability_pg_errors_total" {
+				for _, metric := range mf.GetMetric() {
+					totalCount += metric.GetCounter().GetValue()
+				}
 			}
 		}
-	}
-	require.Equal(t, float64(1), totalCount, "stale/mismatched log_timezone must fall back to counting the log, not silently drop it")
+		return totalCount == 1
+	}, 2*time.Second, 5*time.Millisecond, "stale/mismatched log_timezone must fall back to counting the log, not silently drop it")
 }
 
 func TestLogsCollector_ExcludeDatabases(t *testing.T) {
@@ -858,22 +799,15 @@ func TestLogsCollector_ExcludeDatabases(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	startTime := collector.startTime
-	err = collector.Start(context.Background())
-	require.NoError(t, err)
-	defer collector.Stop()
-
-	ts := startTime.Add(10 * time.Second).UTC()
+	ts := collector.startTime.Add(10 * time.Second).UTC()
 	ts1 := ts.Format("2006-01-02 15:04:05.000 MST")
 	ts2 := ts.Add(-1 * time.Second).Format("2006-01-02 15:04:05 MST")
 
 	excludedLog := ts1 + ":10.0.1.5(12345):app-user@excluded_db:[9112]:4:57014:" + ts2 + ":25/112:0:693c34cb.2398::psqlERROR:  canceling statement"
 	allowedLog := ts1 + ":10.0.1.5(12345):app-user@allowed_db:[9113]:5:57014:" + ts2 + ":25/113:0:693c34cb.2399::psqlERROR:  canceling statement"
 
-	collector.Receiver().Chan() <- loki.Entry{Entry: push.Entry{Line: excludedLog, Timestamp: time.Now()}}
-	collector.Receiver().Chan() <- loki.Entry{Entry: push.Entry{Line: allowedLog, Timestamp: time.Now()}}
-
-	time.Sleep(200 * time.Millisecond)
+	require.NoError(t, collector.parseTextLog(loki.Entry{Entry: push.Entry{Line: excludedLog}}))
+	require.NoError(t, collector.parseTextLog(loki.Entry{Entry: push.Entry{Line: allowedLog}}))
 
 	mfs, _ := registry.Gather()
 	var totalCount float64
@@ -905,22 +839,15 @@ func TestLogsCollector_ExcludeUsers(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	startTime := collector.startTime
-	err = collector.Start(context.Background())
-	require.NoError(t, err)
-	defer collector.Stop()
-
-	ts := startTime.Add(10 * time.Second).UTC()
+	ts := collector.startTime.Add(10 * time.Second).UTC()
 	ts1 := ts.Format("2006-01-02 15:04:05.000 MST")
 	ts2 := ts.Add(-1 * time.Second).Format("2006-01-02 15:04:05 MST")
 
 	excludedLog := ts1 + ":10.0.1.5(12345):excluded_user@testdb:[9112]:4:57014:" + ts2 + ":25/112:0:693c34cb.2398::psqlERROR:  canceling statement"
 	allowedLog := ts1 + ":10.0.1.5(12345):allowed_user@testdb:[9113]:5:57014:" + ts2 + ":25/113:0:693c34cb.2399::psqlERROR:  canceling statement"
 
-	collector.Receiver().Chan() <- loki.Entry{Entry: push.Entry{Line: excludedLog, Timestamp: time.Now()}}
-	collector.Receiver().Chan() <- loki.Entry{Entry: push.Entry{Line: allowedLog, Timestamp: time.Now()}}
-
-	time.Sleep(200 * time.Millisecond)
+	require.NoError(t, collector.parseTextLog(loki.Entry{Entry: push.Entry{Line: excludedLog}}))
+	require.NoError(t, collector.parseTextLog(loki.Entry{Entry: push.Entry{Line: allowedLog}}))
 
 	mfs, _ := registry.Gather()
 	var totalCount float64

--- a/internal/component/database_observability/postgres/collector/logs_test.go
+++ b/internal/component/database_observability/postgres/collector/logs_test.go
@@ -673,6 +673,190 @@ func TestLogsCollector_SkipsOnlyHistoricalLogs(t *testing.T) {
 	require.Equal(t, float64(0), totalCount, "historical logs must not produce metrics")
 }
 
+// Without a log_timezone resolver, a non-UTC abbreviation (e.g. PST) must
+// still be counted: the historical filter is skipped rather than mis-applied.
+func TestLogsCollector_NonUTCLogTimezone(t *testing.T) {
+	entryHandler := loki.NewEntryHandler(make(chan loki.Entry, 10), func() {})
+	registry := prometheus.NewRegistry()
+
+	collector, err := NewLogs(LogsArguments{
+		Receiver:     loki.NewLogsReceiver(),
+		EntryHandler: entryHandler,
+		Logger:       log.NewNopLogger(),
+		Registry:     registry,
+	})
+	require.NoError(t, err)
+
+	startTime := collector.startTime
+	err = collector.Start(context.Background())
+	require.NoError(t, err)
+	defer collector.Stop()
+
+	// PST = UTC-8: PG's wall-clock for real instant startTime+10s is startTime+10s-8h.
+	pstWall := startTime.Add(10 * time.Second).Add(-8 * time.Hour)
+	ts1 := pstWall.Format("2006-01-02 15:04:05.000") + " PST"
+	ts2 := pstWall.Add(-1*time.Second).Format("2006-01-02 15:04:05") + " PST"
+
+	logLine := ts1 + ":[local]:app-user@books_store:[9112]:4:57014:" + ts2 + ":25/112:0:693c34cb.2398::psqlERROR:  canceling statement"
+
+	collector.Receiver().Chan() <- loki.Entry{
+		Entry: push.Entry{
+			Line:      logLine,
+			Timestamp: time.Now(),
+		},
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	mfs, _ := registry.Gather()
+	var totalCount float64
+	for _, mf := range mfs {
+		if mf.GetName() == "database_observability_pg_errors_total" {
+			for _, metric := range mf.GetMetric() {
+				totalCount += metric.GetCounter().GetValue()
+			}
+		}
+	}
+	require.Equal(t, float64(1), totalCount, "log with non-UTC abbreviation timezone must be counted")
+}
+
+// With the correct log_timezone Location supplied, a recent non-UTC log is
+// counted and the historical filter still applies (it just lets it through).
+func TestLogsCollector_LogTimezoneCountsRecentNonUTC(t *testing.T) {
+	loc, err := time.LoadLocation("America/Los_Angeles")
+	require.NoError(t, err)
+
+	entryHandler := loki.NewEntryHandler(make(chan loki.Entry, 10), func() {})
+	registry := prometheus.NewRegistry()
+
+	collector, err := NewLogs(LogsArguments{
+		Receiver:     loki.NewLogsReceiver(),
+		EntryHandler: entryHandler,
+		Logger:       log.NewNopLogger(),
+		Registry:     registry,
+		LogTimezone:  func() *time.Location { return loc },
+	})
+	require.NoError(t, err)
+
+	startTime := collector.startTime
+	err = collector.Start(context.Background())
+	require.NoError(t, err)
+	defer collector.Stop()
+
+	// Real UTC instant startTime+10s, expressed as wall-clock in loc (PST or PDT depending on date).
+	abs := startTime.Add(10 * time.Second)
+	inLoc := abs.In(loc)
+	abbrev, _ := inLoc.Zone()
+	ts1 := inLoc.Format("2006-01-02 15:04:05.000") + " " + abbrev
+	ts2 := inLoc.Add(-1*time.Second).Format("2006-01-02 15:04:05") + " " + abbrev
+
+	logLine := ts1 + ":[local]:app-user@books_store:[9112]:4:57014:" + ts2 + ":25/112:0:693c34cb.2398::psqlERROR:  canceling statement"
+	collector.Receiver().Chan() <- loki.Entry{Entry: push.Entry{Line: logLine, Timestamp: time.Now()}}
+	time.Sleep(200 * time.Millisecond)
+
+	mfs, _ := registry.Gather()
+	var totalCount float64
+	for _, mf := range mfs {
+		if mf.GetName() == "database_observability_pg_errors_total" {
+			for _, metric := range mf.GetMetric() {
+				totalCount += metric.GetCounter().GetValue()
+			}
+		}
+	}
+	require.Equal(t, float64(1), totalCount, "recent non-UTC log must be counted when log_timezone Location is supplied")
+}
+
+// With the correct log_timezone Location supplied, the historical filter
+// still drops a non-UTC log whose real UTC instant is before startTime.
+func TestLogsCollector_LogTimezoneFiltersHistoricalNonUTC(t *testing.T) {
+	loc, err := time.LoadLocation("America/Los_Angeles")
+	require.NoError(t, err)
+
+	entryHandler := loki.NewEntryHandler(make(chan loki.Entry, 10), func() {})
+	registry := prometheus.NewRegistry()
+
+	collector, err := NewLogs(LogsArguments{
+		Receiver:     loki.NewLogsReceiver(),
+		EntryHandler: entryHandler,
+		Logger:       log.NewNopLogger(),
+		Registry:     registry,
+		LogTimezone:  func() *time.Location { return loc },
+	})
+	require.NoError(t, err)
+
+	startTime := collector.startTime
+	err = collector.Start(context.Background())
+	require.NoError(t, err)
+	defer collector.Stop()
+
+	abs := startTime.Add(-1 * time.Hour) // real UTC 1h before startTime
+	inLoc := abs.In(loc)
+	abbrev, _ := inLoc.Zone()
+	ts1 := inLoc.Format("2006-01-02 15:04:05.000") + " " + abbrev
+	ts2 := inLoc.Add(-1*time.Second).Format("2006-01-02 15:04:05") + " " + abbrev
+
+	logLine := ts1 + ":[local]:app-user@books_store:[9112]:4:57014:" + ts2 + ":25/112:0:693c34cb.2398::psqlERROR:  canceling statement"
+	collector.Receiver().Chan() <- loki.Entry{Entry: push.Entry{Line: logLine, Timestamp: time.Now()}}
+	time.Sleep(200 * time.Millisecond)
+
+	mfs, _ := registry.Gather()
+	var totalCount float64
+	for _, mf := range mfs {
+		if mf.GetName() == "database_observability_pg_errors_total" {
+			for _, metric := range mf.GetMetric() {
+				totalCount += metric.GetCounter().GetValue()
+			}
+		}
+	}
+	require.Equal(t, float64(0), totalCount, "historical non-UTC log must be dropped when log_timezone Location is supplied")
+}
+
+// If the cached Location's abbreviation disagrees with the log line's, the
+// collector skips the filter rather than emitting a wrong absolute time.
+func TestLogsCollector_LogTimezoneAbbrevMismatchFallsBack(t *testing.T) {
+	// Europe/London emits GMT/BST — neither matches PST.
+	loc, err := time.LoadLocation("Europe/London")
+	require.NoError(t, err)
+
+	entryHandler := loki.NewEntryHandler(make(chan loki.Entry, 10), func() {})
+	registry := prometheus.NewRegistry()
+
+	collector, err := NewLogs(LogsArguments{
+		Receiver:     loki.NewLogsReceiver(),
+		EntryHandler: entryHandler,
+		Logger:       log.NewNopLogger(),
+		Registry:     registry,
+		LogTimezone:  func() *time.Location { return loc },
+	})
+	require.NoError(t, err)
+
+	startTime := collector.startTime
+	err = collector.Start(context.Background())
+	require.NoError(t, err)
+	defer collector.Stop()
+
+	// Wall-clock would look historical if naively reconstructed in Europe/London;
+	// the abbrev mismatch must prevent the drop.
+	pstWall := startTime.Add(-2 * time.Hour)
+	ts1 := pstWall.Format("2006-01-02 15:04:05.000") + " PST"
+	ts2 := pstWall.Add(-1*time.Second).Format("2006-01-02 15:04:05") + " PST"
+
+	logLine := ts1 + ":[local]:app-user@books_store:[9112]:4:57014:" + ts2 + ":25/112:0:693c34cb.2398::psqlERROR:  canceling statement"
+	collector.Receiver().Chan() <- loki.Entry{Entry: push.Entry{Line: logLine, Timestamp: time.Now()}}
+	time.Sleep(200 * time.Millisecond)
+
+	mfs, _ := registry.Gather()
+	var totalCount float64
+	for _, mf := range mfs {
+		if mf.GetName() == "database_observability_pg_errors_total" {
+			for _, metric := range mf.GetMetric() {
+				totalCount += metric.GetCounter().GetValue()
+			}
+		}
+	}
+	require.Equal(t, float64(1), totalCount, "stale/mismatched log_timezone must fall back to counting the log, not silently drop it")
+}
+
 func TestLogsCollector_ExcludeDatabases(t *testing.T) {
 	entryHandler := loki.NewEntryHandler(make(chan loki.Entry, 10), func() {})
 	registry := prometheus.NewRegistry()

--- a/internal/component/database_observability/postgres/collector/logs_test.go
+++ b/internal/component/database_observability/postgres/collector/logs_test.go
@@ -680,7 +680,7 @@ func TestLogsCollector_NonUTCLogTimezone(t *testing.T) {
 	collector, err := NewLogs(LogsArguments{
 		Receiver:     loki.NewLogsReceiver(),
 		EntryHandler: entryHandler,
-		Logger:       log.NewNopLogger(),
+		Logger:       logging.NewSlogNop(),
 		Registry:     registry,
 	})
 	require.NoError(t, err)
@@ -727,7 +727,7 @@ func TestLogsCollector_LogTimezoneCountsRecentNonUTC(t *testing.T) {
 	collector, err := NewLogs(LogsArguments{
 		Receiver:     loki.NewLogsReceiver(),
 		EntryHandler: entryHandler,
-		Logger:       log.NewNopLogger(),
+		Logger:       logging.NewSlogNop(),
 		Registry:     registry,
 	})
 	require.NoError(t, err)
@@ -770,7 +770,7 @@ func TestLogsCollector_LogTimezoneFiltersHistoricalNonUTC(t *testing.T) {
 	collector, err := NewLogs(LogsArguments{
 		Receiver:     loki.NewLogsReceiver(),
 		EntryHandler: entryHandler,
-		Logger:       log.NewNopLogger(),
+		Logger:       logging.NewSlogNop(),
 		Registry:     registry,
 	})
 	require.NoError(t, err)
@@ -814,7 +814,7 @@ func TestLogsCollector_LogTimezoneAbbrevMismatchFallsBack(t *testing.T) {
 	collector, err := NewLogs(LogsArguments{
 		Receiver:     loki.NewLogsReceiver(),
 		EntryHandler: entryHandler,
-		Logger:       log.NewNopLogger(),
+		Logger:       logging.NewSlogNop(),
 		Registry:     registry,
 	})
 	require.NoError(t, err)

--- a/internal/component/database_observability/postgres/collector/logs_test.go
+++ b/internal/component/database_observability/postgres/collector/logs_test.go
@@ -673,8 +673,6 @@ func TestLogsCollector_SkipsOnlyHistoricalLogs(t *testing.T) {
 	require.Equal(t, float64(0), totalCount, "historical logs must not produce metrics")
 }
 
-// Without a log_timezone resolver, a non-UTC abbreviation (e.g. PST) must
-// still be counted: the historical filter is skipped rather than mis-applied.
 func TestLogsCollector_NonUTCLogTimezone(t *testing.T) {
 	entryHandler := loki.NewEntryHandler(make(chan loki.Entry, 10), func() {})
 	registry := prometheus.NewRegistry()
@@ -692,8 +690,7 @@ func TestLogsCollector_NonUTCLogTimezone(t *testing.T) {
 	require.NoError(t, err)
 	defer collector.Stop()
 
-	// PST = UTC-8: PG's wall-clock for real instant startTime+10s is startTime+10s-8h.
-	pstWall := startTime.Add(10 * time.Second).Add(-8 * time.Hour)
+	pstWall := startTime.Add(10 * time.Second).Add(-8 * time.Hour) // PST wall-clock for real UTC startTime+10s
 	ts1 := pstWall.Format("2006-01-02 15:04:05.000") + " PST"
 	ts2 := pstWall.Add(-1*time.Second).Format("2006-01-02 15:04:05") + " PST"
 
@@ -720,8 +717,6 @@ func TestLogsCollector_NonUTCLogTimezone(t *testing.T) {
 	require.Equal(t, float64(1), totalCount, "log with non-UTC abbreviation timezone must be counted")
 }
 
-// With the correct log_timezone Location supplied, a recent non-UTC log is
-// counted and the historical filter still applies (it just lets it through).
 func TestLogsCollector_LogTimezoneCountsRecentNonUTC(t *testing.T) {
 	loc, err := time.LoadLocation("America/Los_Angeles")
 	require.NoError(t, err)
@@ -743,7 +738,6 @@ func TestLogsCollector_LogTimezoneCountsRecentNonUTC(t *testing.T) {
 	require.NoError(t, err)
 	defer collector.Stop()
 
-	// Real UTC instant startTime+10s, expressed as wall-clock in loc (PST or PDT depending on date).
 	abs := startTime.Add(10 * time.Second)
 	inLoc := abs.In(loc)
 	abbrev, _ := inLoc.Zone()
@@ -766,8 +760,6 @@ func TestLogsCollector_LogTimezoneCountsRecentNonUTC(t *testing.T) {
 	require.Equal(t, float64(1), totalCount, "recent non-UTC log must be counted when log_timezone Location is supplied")
 }
 
-// With the correct log_timezone Location supplied, the historical filter
-// still drops a non-UTC log whose real UTC instant is before startTime.
 func TestLogsCollector_LogTimezoneFiltersHistoricalNonUTC(t *testing.T) {
 	loc, err := time.LoadLocation("America/Los_Angeles")
 	require.NoError(t, err)
@@ -789,7 +781,7 @@ func TestLogsCollector_LogTimezoneFiltersHistoricalNonUTC(t *testing.T) {
 	require.NoError(t, err)
 	defer collector.Stop()
 
-	abs := startTime.Add(-1 * time.Hour) // real UTC 1h before startTime
+	abs := startTime.Add(-1 * time.Hour)
 	inLoc := abs.In(loc)
 	abbrev, _ := inLoc.Zone()
 	ts1 := inLoc.Format("2006-01-02 15:04:05.000") + " " + abbrev
@@ -811,10 +803,8 @@ func TestLogsCollector_LogTimezoneFiltersHistoricalNonUTC(t *testing.T) {
 	require.Equal(t, float64(0), totalCount, "historical non-UTC log must be dropped when log_timezone Location is supplied")
 }
 
-// If the cached Location's abbreviation disagrees with the log line's, the
-// collector skips the filter rather than emitting a wrong absolute time.
 func TestLogsCollector_LogTimezoneAbbrevMismatchFallsBack(t *testing.T) {
-	// Europe/London emits GMT/BST — neither matches PST.
+	// Europe/London emits GMT/BST — neither matches the PST in the log line.
 	loc, err := time.LoadLocation("Europe/London")
 	require.NoError(t, err)
 
@@ -835,8 +825,6 @@ func TestLogsCollector_LogTimezoneAbbrevMismatchFallsBack(t *testing.T) {
 	require.NoError(t, err)
 	defer collector.Stop()
 
-	// Wall-clock would look historical if naively reconstructed in Europe/London;
-	// the abbrev mismatch must prevent the drop.
 	pstWall := startTime.Add(-2 * time.Hour)
 	ts1 := pstWall.Format("2006-01-02 15:04:05.000") + " PST"
 	ts2 := pstWall.Add(-1*time.Second).Format("2006-01-02 15:04:05") + " PST"

--- a/internal/component/database_observability/postgres/collector/logs_test.go
+++ b/internal/component/database_observability/postgres/collector/logs_test.go
@@ -734,9 +734,9 @@ func TestLogsCollector_LogTimezoneCountsRecentNonUTC(t *testing.T) {
 		EntryHandler: entryHandler,
 		Logger:       log.NewNopLogger(),
 		Registry:     registry,
-		LogTimezone:  func() *time.Location { return loc },
 	})
 	require.NoError(t, err)
+	collector.logTimezone.Store(loc)
 
 	startTime := collector.startTime
 	err = collector.Start(context.Background())
@@ -780,9 +780,9 @@ func TestLogsCollector_LogTimezoneFiltersHistoricalNonUTC(t *testing.T) {
 		EntryHandler: entryHandler,
 		Logger:       log.NewNopLogger(),
 		Registry:     registry,
-		LogTimezone:  func() *time.Location { return loc },
 	})
 	require.NoError(t, err)
+	collector.logTimezone.Store(loc)
 
 	startTime := collector.startTime
 	err = collector.Start(context.Background())
@@ -826,9 +826,9 @@ func TestLogsCollector_LogTimezoneAbbrevMismatchFallsBack(t *testing.T) {
 		EntryHandler: entryHandler,
 		Logger:       log.NewNopLogger(),
 		Registry:     registry,
-		LogTimezone:  func() *time.Location { return loc },
 	})
 	require.NoError(t, err)
+	collector.logTimezone.Store(loc)
 
 	startTime := collector.startTime
 	err = collector.Start(context.Background())

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -44,12 +44,6 @@ SELECT
 FROM pg_settings
 WHERE name = 'server_version';`
 
-const selectLogTimezone = `SELECT setting FROM pg_settings WHERE name = 'log_timezone';`
-
-// log_timezone has context=sighup, so operators can change it without a
-// restart; re-read on a tick so the logs collector stays in sync.
-const logTimezoneRefreshInterval = time.Minute
-
 func init() {
 	component.Register(component.Registration{
 		Name:      name,
@@ -234,22 +228,20 @@ type Collector interface {
 }
 
 type Component struct {
-	opts                   component.Options
-	args                   Arguments
-	handler                loki.LogsReceiver
-	fanout                 *loki.Fanout
-	mut                    sync.RWMutex
-	registry               *prometheus.Registry
-	baseTarget             discovery.Target
-	collectors             []Collector
-	instanceKey            string
-	dbConnection           *sql.DB
-	healthErr              *atomic.String
-	openSQL                func(driverName, dataSourceName string) (*sql.DB, error)
-	logsReceiver           loki.LogsReceiver
-	exporterCollectors     []prometheus.Collector
-	logTimezone            atomic.Pointer[time.Location]
-	lastLogTimezoneWarning atomic.Pointer[string] // dedupes the unparseable-log_timezone warning across refresh ticks
+	opts               component.Options
+	args               Arguments
+	handler            loki.LogsReceiver
+	fanout             *loki.Fanout
+	mut                sync.RWMutex
+	registry           *prometheus.Registry
+	baseTarget         discovery.Target
+	collectors         []Collector
+	instanceKey        string
+	dbConnection       *sql.DB
+	healthErr          *atomic.String
+	openSQL            func(driverName, dataSourceName string) (*sql.DB, error)
+	logsReceiver       loki.LogsReceiver
+	exporterCollectors []prometheus.Collector
 }
 
 func New(opts component.Options, args Arguments) (*Component, error) {
@@ -343,20 +335,6 @@ func (c *Component) Run(ctx context.Context) error {
 		}
 	})
 
-	wg.Go(func() {
-		ticker := time.NewTicker(logTimezoneRefreshInterval)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				c.refreshLogTimezone(ctx)
-			}
-		}
-	})
-
 	wg.Wait()
 
 	return nil
@@ -381,49 +359,6 @@ func (c *Component) getBaseTarget() (discovery.Target, error) {
 func (c *Component) reportError(errorMsg string, err error) {
 	c.opts.SLogger.Error(fmt.Sprintf("%s: %+v", errorMsg, err))
 	c.healthErr.Store(fmt.Sprintf("%s: %+v", errorMsg, err))
-}
-
-// storeLogTimezoneFrom queries log_timezone on db and caches the resulting
-// Location. Any failure clears the cache and makes the logs collector fall
-// back to its ambiguous-zone path. Caller owns whatever locking is needed
-// to read db safely.
-func (c *Component) storeLogTimezoneFrom(ctx context.Context, db *sql.DB) {
-	if db == nil {
-		c.logTimezone.Store(nil)
-		return
-	}
-
-	queryCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
-	var name string
-	if err := db.QueryRowContext(queryCtx, selectLogTimezone).Scan(&name); err != nil {
-		level.Debug(c.opts.Logger).Log("msg", "failed to query log_timezone", "err", err)
-		c.logTimezone.Store(nil)
-		return
-	}
-
-	loc, err := time.LoadLocation(name)
-	if err != nil {
-		// PG accepts POSIX specs like 'EST5EDT,M3.2.0,M11.1.0' or '<+05>5' that
-		// Go's IANA-only tzdata can't load. Warn once per distinct value.
-		if prev := c.lastLogTimezoneWarning.Load(); prev == nil || *prev != name {
-			level.Warn(c.opts.Logger).Log("msg", "PostgreSQL log_timezone is not a Go-loadable IANA name; logs collector will skip its historical-log filter. Consider setting log_timezone to an IANA name (e.g. 'America/New_York') in postgresql.conf.", "log_timezone", name, "err", err)
-			c.lastLogTimezoneWarning.Store(&name)
-		}
-		c.logTimezone.Store(nil)
-		return
-	}
-	c.lastLogTimezoneWarning.Store(nil)
-	c.logTimezone.Store(loc)
-}
-
-// refreshLogTimezone is the locking variant. Must not be called while c.mut is held.
-func (c *Component) refreshLogTimezone(ctx context.Context) {
-	c.mut.RLock()
-	db := c.dbConnection
-	c.mut.RUnlock()
-	c.storeLogTimezoneFrom(ctx, db)
 }
 
 func (c *Component) tryReconnect(ctx context.Context) error {
@@ -583,10 +518,6 @@ func (c *Component) connectAndStartCollectors(ctx context.Context) error {
 		collector.Stop()
 	}
 	c.collectors = nil
-
-	// Prime log_timezone before the logs collector starts; the periodic
-	// refresh in Run() picks up later changes.
-	c.storeLogTimezoneFrom(ctx, dbConnection)
 
 	if err := c.startCollectors(generatedSystemID, engineVersion.String, cp, effectiveExcludeUsers); err != nil {
 		return fmt.Errorf("failed to start collectors: %w", err)
@@ -787,7 +718,7 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 		Registry:         c.registry,
 		ExcludeDatabases: c.args.ExcludeDatabases,
 		ExcludeUsers:     effectiveExcludeUsers,
-		LogTimezone:      c.logTimezone.Load,
+		DB:               c.dbConnection,
 	})
 	if err != nil {
 		logStartError(collector.LogsCollector, "create", err)

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	stdatomic "sync/atomic"
 	"time"
 
 	"github.com/lib/pq"
@@ -43,6 +44,12 @@ SELECT
 	setting as version
 FROM pg_settings
 WHERE name = 'server_version';`
+
+const selectLogTimezone = `SELECT setting FROM pg_settings WHERE name = 'log_timezone';`
+
+// log_timezone has context=sighup, so operators can change it without a
+// restart; re-read on a tick so the logs collector stays in sync.
+const logTimezoneRefreshInterval = time.Minute
 
 func init() {
 	component.Register(component.Registration{
@@ -228,20 +235,22 @@ type Collector interface {
 }
 
 type Component struct {
-	opts               component.Options
-	args               Arguments
-	handler            loki.LogsReceiver
-	fanout             *loki.Fanout
-	mut                sync.RWMutex
-	registry           *prometheus.Registry
-	baseTarget         discovery.Target
-	collectors         []Collector
-	instanceKey        string
-	dbConnection       *sql.DB
-	healthErr          *atomic.String
-	openSQL            func(driverName, dataSourceName string) (*sql.DB, error)
-	logsReceiver       loki.LogsReceiver
-	exporterCollectors []prometheus.Collector
+	opts                   component.Options
+	args                   Arguments
+	handler                loki.LogsReceiver
+	fanout                 *loki.Fanout
+	mut                    sync.RWMutex
+	registry               *prometheus.Registry
+	baseTarget             discovery.Target
+	collectors             []Collector
+	instanceKey            string
+	dbConnection           *sql.DB
+	healthErr              *atomic.String
+	openSQL                func(driverName, dataSourceName string) (*sql.DB, error)
+	logsReceiver           loki.LogsReceiver
+	exporterCollectors     []prometheus.Collector
+	logTimezone            stdatomic.Pointer[time.Location]
+	lastLogTimezoneWarning stdatomic.Pointer[string] // dedupes the unparseable-log_timezone warning across refresh ticks
 }
 
 func New(opts component.Options, args Arguments) (*Component, error) {
@@ -335,6 +344,20 @@ func (c *Component) Run(ctx context.Context) error {
 		}
 	})
 
+	wg.Go(func() {
+		ticker := time.NewTicker(logTimezoneRefreshInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				c.refreshLogTimezone(ctx)
+			}
+		}
+	})
+
 	wg.Wait()
 
 	return nil
@@ -359,6 +382,49 @@ func (c *Component) getBaseTarget() (discovery.Target, error) {
 func (c *Component) reportError(errorMsg string, err error) {
 	c.opts.SLogger.Error(fmt.Sprintf("%s: %+v", errorMsg, err))
 	c.healthErr.Store(fmt.Sprintf("%s: %+v", errorMsg, err))
+}
+
+// storeLogTimezoneFrom queries log_timezone on db and caches the resulting
+// Location. Any failure clears the cache and makes the logs collector fall
+// back to its ambiguous-zone path. Caller owns whatever locking is needed
+// to read db safely.
+func (c *Component) storeLogTimezoneFrom(ctx context.Context, db *sql.DB) {
+	if db == nil {
+		c.logTimezone.Store(nil)
+		return
+	}
+
+	queryCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	var name string
+	if err := db.QueryRowContext(queryCtx, selectLogTimezone).Scan(&name); err != nil {
+		level.Debug(c.opts.Logger).Log("msg", "failed to query log_timezone", "err", err)
+		c.logTimezone.Store(nil)
+		return
+	}
+
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		// PG accepts POSIX specs like 'EST5EDT,M3.2.0,M11.1.0' or '<+05>5' that
+		// Go's IANA-only tzdata can't load. Warn once per distinct value.
+		if prev := c.lastLogTimezoneWarning.Load(); prev == nil || *prev != name {
+			level.Warn(c.opts.Logger).Log("msg", "PostgreSQL log_timezone is not a Go-loadable IANA name; logs collector will skip its historical-log filter. Consider setting log_timezone to an IANA name (e.g. 'America/New_York') in postgresql.conf.", "log_timezone", name, "err", err)
+			c.lastLogTimezoneWarning.Store(&name)
+		}
+		c.logTimezone.Store(nil)
+		return
+	}
+	c.lastLogTimezoneWarning.Store(nil)
+	c.logTimezone.Store(loc)
+}
+
+// refreshLogTimezone is the locking variant. Must not be called while c.mut is held.
+func (c *Component) refreshLogTimezone(ctx context.Context) {
+	c.mut.RLock()
+	db := c.dbConnection
+	c.mut.RUnlock()
+	c.storeLogTimezoneFrom(ctx, db)
 }
 
 func (c *Component) tryReconnect(ctx context.Context) error {
@@ -518,6 +584,10 @@ func (c *Component) connectAndStartCollectors(ctx context.Context) error {
 		collector.Stop()
 	}
 	c.collectors = nil
+
+	// Prime log_timezone before the logs collector starts; the periodic
+	// refresh in Run() picks up later changes.
+	c.storeLogTimezoneFrom(ctx, dbConnection)
 
 	if err := c.startCollectors(generatedSystemID, engineVersion.String, cp, effectiveExcludeUsers); err != nil {
 		return fmt.Errorf("failed to start collectors: %w", err)
@@ -718,6 +788,7 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 		Registry:         c.registry,
 		ExcludeDatabases: c.args.ExcludeDatabases,
 		ExcludeUsers:     effectiveExcludeUsers,
+		LogTimezone:      c.logTimezone.Load,
 	})
 	if err != nil {
 		logStartError(collector.LogsCollector, "create", err)

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -10,7 +10,6 @@ import (
 	"slices"
 	"strings"
 	"sync"
-	stdatomic "sync/atomic"
 	"time"
 
 	"github.com/lib/pq"
@@ -249,8 +248,8 @@ type Component struct {
 	openSQL                func(driverName, dataSourceName string) (*sql.DB, error)
 	logsReceiver           loki.LogsReceiver
 	exporterCollectors     []prometheus.Collector
-	logTimezone            stdatomic.Pointer[time.Location]
-	lastLogTimezoneWarning stdatomic.Pointer[string] // dedupes the unparseable-log_timezone warning across refresh ticks
+	logTimezone            atomic.Pointer[time.Location]
+	lastLogTimezoneWarning atomic.Pointer[string] // dedupes the unparseable-log_timezone warning across refresh ticks
 }
 
 func New(opts component.Options, args Arguments) (*Component, error) {


### PR DESCRIPTION
## Summary

- Fixes `database_observability_pg_errors_total` returning no data when PostgreSQL is configured with a non-UTC `log_timezone` (e.g. `America/Los_Angeles`). Go's `time.Parse` fabricates a zero-offset `Location` for any timezone abbreviation it doesn't recognize (PST, PDT, EDT, AEDT, ...), so the collector's historical-log filter saw every live entry as hours in the past and silently dropped it.
- The collector now queries `log_timezone` from `pg_settings` (with a 1-hour refresh, since the GUC is `sighup`-reloadable) and uses the resolved `*time.Location` to reconstruct each log line's wall-clock into a real UTC instant. The historical filter is preserved for all IANA configurations.
- Layered safety net: if the cached Location's abbreviation disagrees with the log line's (stale cache between a `pg_reload_conf` and the next refresh), or `log_timezone` is a POSIX spec Go's tzdata can't load (`EST5EDT,M3.2.0,M11.1.0`, `<+05>5`, ...), the collector falls back to skipping the historical filter — live errors are still counted instead of being mis-classified as historical. A one-shot warn (deduped per distinct value) tells operators to switch to an IANA name.

Refs: grafana/grafana-dbo11y-app#2877

## Test plan

- [x] New unit tests in `logs_test.go` covering: bug repro (no resolver, PST log counted), reconstruction counts recent non-UTC log with filter preserved, reconstruction filters historical non-UTC log, abbrev mismatch falls back to counting.
- [x] `go test -race -tags=nodocker ./internal/component/database_observability/...` — full suite green.
- [x] `gofmt -d` clean, `go vet` clean.
- [x] Manual verification against the reproducer in grafana/grafana-dbo11y-app#2877 (PostgreSQL 15 + `log_timezone='America/Los_Angeles'`, confirm `database_observability_pg_errors_total` increments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)