### PR TITLE
fix(syntax): Avoid append aliasing when collecting squashed fields

### DIFF
--- a/syntax/internal/syntaxtags/syntaxtags.go
+++ b/syntax/internal/syntaxtags/syntaxtags.go
@@ -5,6 +5,7 @@ package syntaxtags
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 )
 
@@ -235,11 +236,12 @@ func Get(ty reflect.Type) []Field {
 				// Get the inner fields from the squashed struct and append each of them.
 				// The index of the squashed field is prepended to the index of the inner
 				// struct.
+				// Use slices.Concat to avoid append aliasing when field.Index has spare capacity.
 				innerFields := Get(deferenceType(field.Type))
 				for _, innerField := range innerFields {
 					fields = append(fields, Field{
 						Name:  innerField.Name,
-						Index: append(field.Index, innerField.Index...),
+						Index: slices.Concat(field.Index, innerField.Index),
 						Flags: innerField.Flags,
 					})
 				}


### PR DESCRIPTION
### Brief description of Pull Request

Fix slice aliasing in `syntaxtags.Get` when expanding squashed struct fields. Successive `append(field.Index, innerField.Index...)` calls could share a backing array and
   clobber previously-computed field indices, causing block names to silently resolve to the wrong struct field at runtime.


### Pull Request Details
In `syntax/internal/syntaxtags/syntaxtags.go`, the loop that expands a `,squash`-tagged field's inner fields used:

```go
Index: append(field.Index, innerField.Index...)
```
When field.Index has spare capacity (which reflect.VisibleFields may produce, depending on Go version and architecture), successive iterations extend the slice in place
and write into the same backing array. Previously-stored inner-field indices then get overwritten to point at later fields.

The visible symptom: block names resolve to the wrong struct field at runtime. In our case loki.write's tls_config block ended up pointing at HTTPClientConfig.EnableHTTP2 (a bool), which produced:

`panic: syntax/vm: can only evaluate blocks into structs, got bool`

The bug reproduces 100% on linux/arm/v7 (Go 1.25) for any loki.write config that includes a tls_config block. On linux/amd64 with current Go releases it appears dormant because reflect.VisibleFields happens to return []int{i} with cap == len == 1 — but the code was relying on lucky allocation.

The fix replaces the append with slices.Concat, which always returns a freshly allocated slice and is safe regardless of input capacities.

Minimal reproducer:
```
loki.write "x" {
  endpoint {
    url = "https://example.com/loki/api/v1/push"
    tls_config { }
  }
}
```
Before the fix: alloy validate (or alloy run) panics on affected platforms.
After the fix: alloy validate reports OK and the config loads correctly.

### Notes to the Reviewer

- The fix is a one-liner; the rest of the diff is comment/import.
- Although the bug only manifested on linux/arm/v7 in our environment, the underlying anti-pattern is architecture-independent. It would silently corrupt indices on any platform where reflect.VisibleFields happens to return slices with spare capacity, so the fix is unconditional.
- slices.Concat requires Go 1.22+; Alloy already targets newer Go.

### PR Checklist

- Tests updated — Could add a unit test that registers a struct with a squashed inner struct containing multiple fields, calls Get, and asserts that each returned Field.Index points to the correct underlying field. Happy to add this if reviewers prefer.


