### PR TITLE
ci: Harden PR workflows

### DIFF
--- a/.github/workflows/ai-dependency-review.yml
+++ b/.github/workflows/ai-dependency-review.yml
@@ -20,15 +20,10 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      # SECURITY: Check out the PR's base SHA (trusted code already merged to the
-      # target branch), not the PR head/merge ref. The tool below runs with
-      # OPENAI_API_KEY and a write-scoped GITHUB_TOKEN in its environment, so it
-      # must not execute any code or read any prompt from the PR. The PR's diff
-      # itself is fetched via the GitHub API inside the tool (see
-      # tools/ai-review/github.go: getPRDiff), so we never need PR files on disk.
-      - name: Checkout base ref (trusted code only)
+      - name: Checkout base ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          # Use the trusted base SHA so the tooling we run is not from the PR.
           ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
 

--- a/.github/workflows/ai-dependency-review.yml
+++ b/.github/workflows/ai-dependency-review.yml
@@ -20,9 +20,16 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      # SECURITY: Check out the PR's base SHA (trusted code already merged to the
+      # target branch), not the PR head/merge ref. The tool below runs with
+      # OPENAI_API_KEY and a write-scoped GITHUB_TOKEN in its environment, so it
+      # must not execute any code or read any prompt from the PR. The PR's diff
+      # itself is fetched via the GitHub API inside the tool (see
+      # tools/ai-review/github.go: getPRDiff), so we never need PR files on disk.
+      - name: Checkout base ref (trusted code only)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
 
       - name: Set up Go

--- a/.github/workflows/ai-dependency-review.yml
+++ b/.github/workflows/ai-dependency-review.yml
@@ -20,7 +20,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout base ref
+      - name: Checkout code (base ref)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Use the trusted base SHA so the tooling we run is not from the PR.

--- a/.github/workflows/ai-dependency-review.yml
+++ b/.github/workflows/ai-dependency-review.yml
@@ -20,11 +20,9 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code (base ref)
+      - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # Use the trusted base SHA so the tooling we run is not from the PR.
-          ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
 
       - name: Set up Go

--- a/.github/workflows/release-lint-pr-title.yml
+++ b/.github/workflows/release-lint-pr-title.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   pull-requests: read
-  id-token: write
 
 jobs:
   lint:


### PR DESCRIPTION
### Brief description of Pull Request

Two small hardening changes to PR-triggered workflows so a single missed manual approval cannot leak secrets or escalate token scope.

### Pull Request Details

**`ai-dependency-review.yml`** — checkout now pins to `${{ github.event.pull_request.base.sha }}` instead of relying on the default `pull_request` checkout ref (`refs/pull/<N>/merge`, which contains the PR author's code merged onto the base).

**`release-lint-pr-title.yml`** — removes the unused `id-token: write` permission. The only step in the workflow is `amannn/action-semantic-pull-request`, which does not use OIDC. 

### PR Checklist

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated