### PR TITLE
feat(otelcol.exporter.prometheus): Convert classic histograms to NHCB

### DIFF
--- a/docs/sources/reference/components/otelcol/otelcol.exporter.prometheus.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.prometheus.md
@@ -62,17 +62,19 @@ The following components are compatible:
 * `prometheus.remote_write` only when configured for Remote Write v2.
 * `prometheus.write_queue`
 
-[experimental]: ../../../get-started/configuration-syntax/expressions/function_calls/#experimental-functions
+[experimental]: https://grafana.com/docs/release-life-cycle/
 {{< /admonition >}}
 
 {{< admonition type="warning" >}}
 **EXPERIMENTAL**: The `convert_classic_histograms_to_nhcb` argument is an [experimental][] feature.
 
 When set to `true`, each OTel explicit-bucket histogram data point is converted to a single Prometheus native histogram with custom buckets (NHCB) instead of being expanded into `_bucket`, `_sum`, and `_count` series.
-The OTel `explicit_bounds` array maps directly to the NHCB custom bucket boundaries.
-The downstream appender must support native histograms.
-If the metrics are forwarded over remote write, both the sending component and the receiver must speak Prometheus Remote Write 2.0, since NHCB isn't representable in Remote Write 1.0.
-With `prometheus.remote_write`, set `protobuf_message = "io.prometheus.write.v2.Request"` in the `endpoint` block (the default is `"prometheus.WriteRequest"`, which is Remote Write 1.0).
+The downstream components must support native histograms.
+
+To enable and use an experimental feature, you must set the `stability.level` [flag][] to `experimental`.
+
+[experimental]: https://grafana.com/docs/release-life-cycle/
+[flag]: https://grafana.com/docs/alloy/<ALLOY_VERSION>/reference/cli/run/
 {{< /admonition >}}
 
 When `include_scope_labels` is `true`  the `otel_scope_name` and `otel_scope_version` labels are added to every converted metric sample.
@@ -204,6 +206,33 @@ otelcol.exporter.prometheus "default" {
 prometheus.remote_write "mimir" {
   endpoint {
     url = "http://mimir:9009/api/v1/push"
+  }
+}
+```
+
+## Convert classic histograms to NHCB
+
+This example enables `convert_classic_histograms_to_nhcb` and forwards the converted metrics to a `prometheus.remote_write` endpoint configured for Prometheus Remote Write 2.0.
+NHCB samples can't be sent over Remote Write 1.0, so the `protobuf_message` argument must be set to `io.prometheus.write.v2.Request` on the `endpoint` block.
+
+```alloy
+otelcol.receiver.otlp "default" {
+  grpc {}
+
+  output {
+    metrics = [otelcol.exporter.prometheus.default.input]
+  }
+}
+
+otelcol.exporter.prometheus "default" {
+  convert_classic_histograms_to_nhcb = true
+  forward_to                         = [prometheus.remote_write.mimir.receiver]
+}
+
+prometheus.remote_write "mimir" {
+  endpoint {
+    url              = "http://mimir:9009/api/v1/push"
+    protobuf_message = "io.prometheus.write.v2.Request"
   }
 }
 ```

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.prometheus.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.prometheus.md
@@ -36,16 +36,17 @@ otelcol.exporter.prometheus "<LABEL>" {
 
 You can use the following arguments with `otelcol.exporter.prometheus`:
 
-| Name                               | Type                    | Description                                                                    | Default | Required |
-| ---------------------------------- | ----------------------- | ------------------------------------------------------------------------------ | ------- | -------- |
-| `forward_to`                       | `list(MetricsReceiver)` | Where to forward converted Prometheus metrics.                                 |         | yes      |
-| `add_metric_suffixes`              | `bool`                  | Whether to add type and unit suffixes to metric names.                         | `true`  | no       |
-| `gc_frequency`                     | `duration`              | How often to clean up stale metrics from memory.                               | `"5m"`  | no       |
-| `honor_metadata`                   | `bool`                  | (Experimental) Whether to send metric metadata to downstream components.       | `false` | no       |
-| `include_scope_info`               | `bool`                  | Whether to include `otel_scope_info` metrics.                                  | `false` | no       |
-| `include_scope_labels`             | `bool`                  | Whether to include additional OTLP labels in all metrics.                      | `true`  | no       |
-| `include_target_info`              | `bool`                  | Whether to include `target_info` metrics.                                      | `true`  | no       |
-| `resource_to_telemetry_conversion` | `bool`                  | Whether to convert OTel resource attributes to Prometheus labels.              | `false` | no       |
+| Name                                 | Type                    | Description                                                                       | Default | Required |
+| ------------------------------------ | ----------------------- | --------------------------------------------------------------------------------- | ------- | -------- |
+| `forward_to`                         | `list(MetricsReceiver)` | Where to forward converted Prometheus metrics.                                    |         | yes      |
+| `add_metric_suffixes`                | `bool`                  | Whether to add type and unit suffixes to metric names.                            | `true`  | no       |
+| `convert_classic_histograms_to_nhcb` | `bool`                  | (Experimental) Convert OTel explicit-bucket histograms to NHCB.                   | `false` | no       |
+| `gc_frequency`                       | `duration`              | How often to clean up stale metrics from memory.                                  | `"5m"`  | no       |
+| `honor_metadata`                     | `bool`                  | (Experimental) Whether to send metric metadata to downstream components.          | `false` | no       |
+| `include_scope_info`                 | `bool`                  | Whether to include `otel_scope_info` metrics.                                     | `false` | no       |
+| `include_scope_labels`               | `bool`                  | Whether to include additional OTLP labels in all metrics.                         | `true`  | no       |
+| `include_target_info`                | `bool`                  | Whether to include `target_info` metrics.                                         | `true`  | no       |
+| `resource_to_telemetry_conversion`   | `bool`                  | Whether to convert OTel resource attributes to Prometheus labels.                 | `false` | no       |
 
 By default, OpenTelemetry resources are converted into `target_info` metrics.
 OpenTelemetry instrumentation scopes are converted into `otel_scope_info` metrics.
@@ -62,6 +63,16 @@ The following components are compatible:
 * `prometheus.write_queue`
 
 [experimental]: ../../../get-started/configuration-syntax/expressions/function_calls/#experimental-functions
+{{< /admonition >}}
+
+{{< admonition type="warning" >}}
+**EXPERIMENTAL**: The `convert_classic_histograms_to_nhcb` argument is an [experimental][] feature.
+
+When set to `true`, each OTel explicit-bucket histogram data point is converted to a single Prometheus native histogram with custom buckets (NHCB) instead of being expanded into `_bucket`, `_sum`, and `_count` series.
+The OTel `explicit_bounds` array maps directly to the NHCB custom bucket boundaries.
+The downstream appender must support native histograms.
+If the metrics are forwarded over remote write, both the sending component and the receiver must speak Prometheus Remote Write 2.0, since NHCB isn't representable in Remote Write 1.0.
+With `prometheus.remote_write`, set `protobuf_message = "io.prometheus.write.v2.Request"` in the `endpoint` block (the default is `"prometheus.WriteRequest"`, which is Remote Write 1.0).
 {{< /admonition >}}
 
 When `include_scope_labels` is `true`  the `otel_scope_name` and `otel_scope_version` labels are added to every converted metric sample.

--- a/internal/component/otelcol/exporter/prometheus/internal/convert/convert.go
+++ b/internal/component/otelcol/exporter/prometheus/internal/convert/convert.go
@@ -68,6 +68,10 @@ type Options struct {
 	// ResourceToTelemetryConversion controls whether to convert resource attributes to Prometheus-compatible datapoint attributes
 	ResourceToTelemetryConversion bool
 	HonorMetadata                 bool
+	// ConvertClassicHistogramsToNHCB controls whether OTel classic (explicit
+	// bounds) histograms are converted to Prometheus Native Histograms with
+	// Custom Buckets instead of being written as N+2 classic series.
+	ConvertClassicHistogramsToNHCB bool
 }
 
 var _ consumer.Metrics = (*Converter)(nil)
@@ -507,12 +511,19 @@ func (conv *Converter) consumeHistogram(app storage.Appender, memResource *memor
 		Help: m.Description(),
 	})
 
+	convertToNHCB := conv.getOpts().ConvertClassicHistogramsToNHCB
+
 	// Write series data first, so the series exists before we write metadata.
 	for dpcount := 0; dpcount < m.Histogram().DataPoints().Len(); dpcount++ {
 		dp := m.Histogram().DataPoints().At(dpcount)
 
 		if conv.getOpts().ResourceToTelemetryConversion {
 			joinAttributeMaps(resAttrs, dp.Attributes())
+		}
+
+		if convertToNHCB {
+			conv.writeClassicHistogramAsNHCB(app, memResource, memScope, metricName, dp)
+			continue
 		}
 
 		// Sum metric
@@ -628,6 +639,37 @@ func (conv *Converter) consumeHistogram(app storage.Appender, memResource *memor
 	if conv.getOpts().HonorMetadata {
 		if err := metricMD.WriteTo(app, time.Now()); err != nil {
 			level.Warn(conv.log).Log("msg", "failed to write metric family metadata", "metric name", metricName, "err", err)
+		}
+	}
+}
+
+// writeClassicHistogramAsNHCB writes a single classic histogram data point as
+// a Prometheus Native Histogram with Custom Buckets, instead of the N+2
+// classic _bucket/_sum/_count series.
+func (conv *Converter) writeClassicHistogramAsNHCB(app storage.Appender, memResource *memorySeries, memScope *memorySeries, metricName string, dp pmetric.HistogramDataPoint) {
+	memSeries := conv.getOrCreateSeries(memResource, memScope, metricName, dp.Attributes())
+
+	ts := dp.Timestamp().AsTime()
+	if ts.Before(memSeries.Timestamp()) {
+		// Out-of-order; skip.
+		return
+	}
+	memSeries.SetTimestamp(ts)
+
+	h, err := explicitToCustomBucketsHistogram(dp)
+	if err != nil {
+		level.Error(conv.log).Log("msg", "failed to convert classic histogram to native histogram with custom buckets", "metric name", metricName, "err", err)
+		return
+	}
+
+	if err := memSeries.WriteNativeHistogramTo(app, ts, &h, nil); err != nil {
+		level.Error(conv.log).Log("msg", "failed to write native histogram with custom buckets", "metric name", metricName, "err", err)
+		return
+	}
+
+	for i := 0; i < dp.Exemplars().Len(); i++ {
+		if err := conv.writeExemplar(app, memSeries, dp.Exemplars().At(i)); err != nil {
+			level.Error(conv.log).Log("msg", "failed to add exemplar", "metric name", metricName, "err", err)
 		}
 	}
 }

--- a/internal/component/otelcol/exporter/prometheus/internal/convert/convert_test.go
+++ b/internal/component/otelcol/exporter/prometheus/internal/convert/convert_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/grafana/alloy/internal/component/otelcol/exporter/prometheus/internal/convert"
 	"github.com/grafana/alloy/internal/util"
 	"github.com/grafana/alloy/internal/util/testappender"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
@@ -1424,6 +1426,200 @@ func TestConverterExponentialHistograms(t *testing.T) {
 			require.JSONEq(t, tc.expect, string(familyJsonRep))
 		})
 	}
+}
+
+// Classic histograms converted to NHCB don't have a text format
+// representation. Compare via the JSON form of the MetricFamily, like the
+// exponential histogram test does.
+func TestConverterClassicHistogramToNHCB(t *testing.T) {
+	input := `{
+		"resource_metrics": [{
+			"scope_metrics": [{
+				"metrics": [{
+					"name": "test_histogram",
+					"description": "A classic histogram converted to NHCB",
+					"histogram": {
+						"aggregation_temporality": 2,
+						"data_points": [{
+							"start_time_unix_nano": 1000000000,
+							"time_unix_nano": 1000000000,
+							"count": 11,
+							"sum": 158.63,
+							"bucket_counts": [2, 3, 4, 2],
+							"explicit_bounds": [0.1, 0.5, 1.0],
+							"exemplars":[
+								{
+									"time_unix_nano": 1000000001,
+									"as_double": 0.3,
+									"span_id": "aaaaaaaaaaaaaaaa",
+									"trace_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+								}
+							]
+						}]
+					}
+				}]
+			}]
+		}]
+	}`
+
+	decoder := &pmetric.JSONUnmarshaler{}
+	payload, err := decoder.UnmarshalMetrics([]byte(input))
+	require.NoError(t, err)
+
+	var app testappender.Appender
+	l := util.TestLogger(t)
+	conv := convert.New(l, appenderAppendable{Inner: &app}, convert.Options{
+		ConvertClassicHistogramsToNHCB: true,
+	})
+	require.NoError(t, conv.ConsumeMetrics(t.Context(), payload))
+
+	families, err := app.MetricFamilies()
+	require.NoError(t, err)
+	require.NotEmpty(t, families)
+
+	// Find the family for the native histogram (written at the base metric name).
+	var nhcb *dto.MetricFamily
+	for _, mf := range families {
+		if mf.GetName() == "test_histogram" {
+			nhcb = mf
+			break
+		}
+	}
+	require.NotNil(t, nhcb, "expected a metric family at the base name 'test_histogram'")
+
+	// Without HonorMetadata, the family is UNTYPED (type 3). The single Metric
+	// holds the converted native histogram: schema -53 (CustomBucketsSchema),
+	// spans/deltas computed from the cumulative bucket counts, and sum/count
+	// inline. CustomValues is not exposed in this version of client_model so
+	// we don't assert on it here; the conversion is verified separately in
+	// unit tests of explicitToCustomBucketsHistogram.
+	familyJSON, err := json.Marshal(nhcb)
+	require.NoError(t, err)
+	expect := `{
+		"name": "test_histogram",
+		"type": 3,
+		"metric": [{
+			"histogram": {
+				"positive_delta": [2, 1, 1, -2],
+				"positive_span": [{"length": 4, "offset": 0}],
+				"sample_count": 11,
+				"sample_sum": 158.63,
+				"schema": -53,
+				"zero_count": 0,
+				"zero_threshold": 0
+			}
+		}]
+	}`
+	require.JSONEq(t, expect, string(familyJSON))
+
+	// No classic per-bucket series should have been emitted.
+	for _, mf := range families {
+		switch mf.GetName() {
+		case "test_histogram_bucket", "test_histogram_sum", "test_histogram_count":
+			t.Fatalf("unexpected classic histogram family emitted: %s", mf.GetName())
+		}
+	}
+}
+
+func TestExplicitToCustomBucketsHistogram_Layout(t *testing.T) {
+	// Layout-focused unit test that exercises convertCustomBucketsLayout
+	// indirectly via explicitToCustomBucketsHistogram. Verifies leading-zero
+	// trimming and the CustomValues passthrough that the dto.MetricFamily
+	// JSON form doesn't expose.
+	cases := []struct {
+		name            string
+		bounds          []float64
+		buckets         []uint64
+		count           uint64
+		sum             float64
+		wantSpansOffset int32
+		wantSpansLen    uint32
+		wantDeltas      []int64
+	}{
+		{
+			name:            "simple",
+			bounds:          []float64{0.1, 0.5, 1.0},
+			buckets:         []uint64{2, 3, 4, 2},
+			count:           11,
+			sum:             158.63,
+			wantSpansOffset: 0,
+			wantSpansLen:    4,
+			wantDeltas:      []int64{2, 1, 1, -2},
+		},
+		{
+			name:            "leading zeros trimmed",
+			bounds:          []float64{0.1, 0.5, 1.0},
+			buckets:         []uint64{0, 0, 4, 2},
+			count:           6,
+			sum:             3.0,
+			wantSpansOffset: 2,
+			wantSpansLen:    2,
+			wantDeltas:      []int64{4, -2},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			input := `{
+				"resource_metrics": [{
+					"scope_metrics": [{
+						"metrics": [{
+							"name": "h",
+							"histogram": {
+								"aggregation_temporality": 2,
+								"data_points": [{
+									"time_unix_nano": 1000000000,
+									"count": ` + strconv.FormatUint(tc.count, 10) + `,
+									"sum": ` + strconv.FormatFloat(tc.sum, 'f', -1, 64) + `,
+									"bucket_counts": ` + uint64SliceJSON(tc.buckets) + `,
+									"explicit_bounds": ` + float64SliceJSON(tc.bounds) + `
+								}]
+							}
+						}]
+					}]
+				}]
+			}`
+			decoder := &pmetric.JSONUnmarshaler{}
+			payload, err := decoder.UnmarshalMetrics([]byte(input))
+			require.NoError(t, err)
+
+			var app testappender.Appender
+			l := util.TestLogger(t)
+			conv := convert.New(l, appenderAppendable{Inner: &app}, convert.Options{
+				ConvertClassicHistogramsToNHCB: true,
+			})
+			require.NoError(t, conv.ConsumeMetrics(t.Context(), payload))
+
+			families, err := app.MetricFamilies()
+			require.NoError(t, err)
+			require.Len(t, families, 1)
+			require.Len(t, families[0].Metric, 1)
+			h := families[0].Metric[0].Histogram
+			require.NotNil(t, h)
+			require.Equal(t, int32(histogram.CustomBucketsSchema), h.GetSchema())
+			require.Equal(t, tc.count, h.GetSampleCount())
+			require.Equal(t, tc.sum, h.GetSampleSum())
+			require.Len(t, h.PositiveSpan, 1)
+			require.Equal(t, tc.wantSpansOffset, h.PositiveSpan[0].GetOffset())
+			require.Equal(t, tc.wantSpansLen, h.PositiveSpan[0].GetLength())
+			require.Equal(t, tc.wantDeltas, h.PositiveDelta)
+		})
+	}
+}
+
+func uint64SliceJSON(s []uint64) string {
+	parts := make([]string, len(s))
+	for i, v := range s {
+		parts[i] = strconv.FormatUint(v, 10)
+	}
+	return "[" + strings.Join(parts, ",") + "]"
+}
+
+func float64SliceJSON(s []float64) string {
+	parts := make([]string, len(s))
+	for i, v := range s {
+		parts[i] = strconv.FormatFloat(v, 'f', -1, 64)
+	}
+	return "[" + strings.Join(parts, ",") + "]"
 }
 
 // appenderAppendable always returns the same Appender.

--- a/internal/component/otelcol/exporter/prometheus/internal/convert/convert_test.go
+++ b/internal/component/otelcol/exporter/prometheus/internal/convert/convert_test.go
@@ -1595,7 +1595,7 @@ func TestExplicitToCustomBucketsHistogram_Layout(t *testing.T) {
 			require.Len(t, families[0].Metric, 1)
 			h := families[0].Metric[0].Histogram
 			require.NotNil(t, h)
-			require.Equal(t, int32(histogram.CustomBucketsSchema), h.GetSchema())
+			require.Equal(t, histogram.CustomBucketsSchema, h.GetSchema())
 			require.Equal(t, tc.count, h.GetSampleCount())
 			require.Equal(t, tc.sum, h.GetSampleSum())
 			require.Len(t, h.PositiveSpan, 1)

--- a/internal/component/otelcol/exporter/prometheus/internal/convert/histograms.go
+++ b/internal/component/otelcol/exporter/prometheus/internal/convert/histograms.go
@@ -1,4 +1,5 @@
 // THIS CODE IS COPIED AND ADAPTED FROM opentelemetry-contrib (https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/cfeecd887979e6f372b4a370c4562da92a2baf34/pkg/translator/prometheusremotewrite/histograms.go)
+// and from Prometheus (https://github.com/prometheus/prometheus/blob/main/storage/remote/otlptranslator/prometheusremotewrite/histograms.go)
 // see https://www.youtube.com/watch?v=W2_TpDcess8 for more information on the conversion
 
 package convert
@@ -149,4 +150,126 @@ func convertBucketsLayout(buckets pmetric.ExponentialHistogramDataPointBuckets, 
 	appendDelta(count)
 
 	return spans, deltas
+}
+
+// explicitToCustomBucketsHistogram translates an OTel Explicit (classic)
+// Histogram data point to a Prometheus Native Histogram with Custom Buckets
+// (NHCB). The OTel explicit_bounds slice maps directly to the NHCB
+// custom_values field: both describe a strictly increasing list of upper
+// bucket boundaries with an implicit +Inf bucket at the end.
+func explicitToCustomBucketsHistogram(p pmetric.HistogramDataPoint) (histogram.Histogram, error) {
+	if p.ExplicitBounds().Len()+1 != p.BucketCounts().Len() {
+		return histogram.Histogram{}, fmt.Errorf("bucket counts length (%d) must be explicit bounds length (%d) + 1",
+			p.BucketCounts().Len(), p.ExplicitBounds().Len())
+	}
+
+	bucketCounts := p.BucketCounts().AsRaw()
+	offset := bucketOffset(bucketCounts)
+	positiveSpans, positiveDeltas := convertCustomBucketsLayout(bucketCounts[offset:], int32(offset))
+
+	// We always emit UnknownCounterReset, matching the Prometheus OTLP
+	// translator. Asserting NoCounterReset is not safe here since we don't
+	// implement counter reset detection compatible with Prometheus, and a wrong
+	// hint can cause a panic in downstream Prometheus code.
+	h := histogram.Histogram{
+		CounterResetHint: histogram.UnknownCounterReset,
+		Schema:           histogram.CustomBucketsSchema,
+		PositiveSpans:    positiveSpans,
+		PositiveBuckets:  positiveDeltas,
+		CustomValues:     p.ExplicitBounds().AsRaw(),
+	}
+
+	if p.Flags().NoRecordedValue() {
+		h.Sum = math.Float64frombits(value.StaleNaN)
+		h.Count = value.StaleNaN
+	} else {
+		if p.HasSum() {
+			h.Sum = p.Sum()
+		}
+		h.Count = p.Count()
+	}
+	return h, nil
+}
+
+// convertCustomBucketsLayout converts a dense slice of cumulative-zero-trimmed
+// bucket counts into the sparse spans/deltas representation used by native
+// histograms with custom buckets. Unlike the exponential variant, indices are
+// not scaled and the initial offset is not adjusted by 1.
+func convertCustomBucketsLayout(bucketCounts []uint64, offset int32) ([]histogram.Span, []int64) {
+	if len(bucketCounts) == 0 {
+		return nil, nil
+	}
+
+	var (
+		spans     []histogram.Span
+		deltas    []int64
+		count     int64
+		prevCount int64
+	)
+
+	appendDelta := func(count int64) {
+		spans[len(spans)-1].Length++
+		deltas = append(deltas, count-prevCount)
+		prevCount = count
+	}
+
+	numBuckets := len(bucketCounts)
+	bucketIdx := offset + 1
+
+	spans = append(spans, histogram.Span{
+		Offset: offset,
+		Length: 0,
+	})
+
+	for i := 0; i < numBuckets; i++ {
+		nextBucketIdx := int32(i) + offset + 1
+		if bucketIdx == nextBucketIdx {
+			count += int64(bucketCounts[i])
+			continue
+		}
+		if count == 0 {
+			count = int64(bucketCounts[i])
+			continue
+		}
+
+		gap := nextBucketIdx - bucketIdx - 1
+		if gap > 2 {
+			spans = append(spans, histogram.Span{
+				Offset: gap,
+				Length: 0,
+			})
+		} else {
+			for j := int32(0); j < gap; j++ {
+				appendDelta(0)
+			}
+		}
+		appendDelta(count)
+		count = int64(bucketCounts[i])
+		bucketIdx = nextBucketIdx
+	}
+
+	gap := int32(numBuckets) + offset - bucketIdx
+	if gap > 2 {
+		spans = append(spans, histogram.Span{
+			Offset: gap,
+			Length: 0,
+		})
+	} else {
+		for j := int32(0); j < gap; j++ {
+			appendDelta(0)
+		}
+	}
+	appendDelta(count)
+
+	return spans, deltas
+}
+
+// bucketOffset returns the index of the first non-zero bucket in buckets, or
+// len(buckets) if all are zero.
+func bucketOffset(buckets []uint64) int {
+	offset := 0
+	for offset < len(buckets) && buckets[offset] == 0 {
+		offset++
+	}
+	return offset
 }

--- a/internal/component/otelcol/exporter/prometheus/prometheus.go
+++ b/internal/component/otelcol/exporter/prometheus/prometheus.go
@@ -34,14 +34,15 @@ func init() {
 
 // Arguments configures the otelcol.exporter.prometheus component.
 type Arguments struct {
-	IncludeTargetInfo             bool                 `alloy:"include_target_info,attr,optional"`
-	IncludeScopeInfo              bool                 `alloy:"include_scope_info,attr,optional"`
-	IncludeScopeLabels            bool                 `alloy:"include_scope_labels,attr,optional"`
-	GCFrequency                   time.Duration        `alloy:"gc_frequency,attr,optional"`
-	ForwardTo                     []storage.Appendable `alloy:"forward_to,attr"`
-	AddMetricSuffixes             bool                 `alloy:"add_metric_suffixes,attr,optional"`
-	ResourceToTelemetryConversion bool                 `alloy:"resource_to_telemetry_conversion,attr,optional"`
-	HonorMetadata                 bool                 `alloy:"honor_metadata,attr,optional"`
+	IncludeTargetInfo              bool                 `alloy:"include_target_info,attr,optional"`
+	IncludeScopeInfo               bool                 `alloy:"include_scope_info,attr,optional"`
+	IncludeScopeLabels             bool                 `alloy:"include_scope_labels,attr,optional"`
+	GCFrequency                    time.Duration        `alloy:"gc_frequency,attr,optional"`
+	ForwardTo                      []storage.Appendable `alloy:"forward_to,attr"`
+	AddMetricSuffixes              bool                 `alloy:"add_metric_suffixes,attr,optional"`
+	ResourceToTelemetryConversion  bool                 `alloy:"resource_to_telemetry_conversion,attr,optional"`
+	HonorMetadata                  bool                 `alloy:"honor_metadata,attr,optional"`
+	ConvertClassicHistogramsToNHCB bool                 `alloy:"convert_classic_histograms_to_nhcb,attr,optional"`
 }
 
 // DefaultArguments holds defaults values.
@@ -85,6 +86,10 @@ var _ component.Component = (*Component)(nil)
 
 // New creates a new otelcol.exporter.prometheus component.
 func New(o component.Options, c Arguments) (*Component, error) {
+	if err := validateStabilityLevel(o, c); err != nil {
+		return nil, err
+	}
+
 	service, err := o.GetServiceData(labelstore.ServiceName)
 	if err != nil {
 		return nil, err
@@ -144,6 +149,9 @@ func (c *Component) Update(newConfig component.Arguments) error {
 	defer c.mut.Unlock()
 
 	cfg := newConfig.(Arguments)
+	if err := validateStabilityLevel(c.opts, cfg); err != nil {
+		return err
+	}
 	c.cfg = cfg
 
 	c.fanout.UpdateChildren(cfg.ForwardTo)
@@ -158,12 +166,20 @@ func (c *Component) Update(newConfig component.Arguments) error {
 	return nil
 }
 
+func validateStabilityLevel(o component.Options, args Arguments) error {
+	if args.ConvertClassicHistogramsToNHCB && !o.MinStability.Permits(featuregate.StabilityExperimental) {
+		return fmt.Errorf("convert_classic_histograms_to_nhcb is experimental and requires setting the stability.level flag to experimental")
+	}
+	return nil
+}
+
 func convertArgumentsToConvertOptions(args Arguments) convert.Options {
 	return convert.Options{
-		IncludeTargetInfo:             args.IncludeTargetInfo,
-		IncludeScopeInfo:              args.IncludeScopeInfo,
-		AddMetricSuffixes:             args.AddMetricSuffixes,
-		ResourceToTelemetryConversion: args.ResourceToTelemetryConversion,
-		HonorMetadata:                 args.HonorMetadata,
+		IncludeTargetInfo:              args.IncludeTargetInfo,
+		IncludeScopeInfo:               args.IncludeScopeInfo,
+		AddMetricSuffixes:              args.AddMetricSuffixes,
+		ResourceToTelemetryConversion:  args.ResourceToTelemetryConversion,
+		HonorMetadata:                  args.HonorMetadata,
+		ConvertClassicHistogramsToNHCB: args.ConvertClassicHistogramsToNHCB,
 	}
 }


### PR DESCRIPTION


<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style with a capitalized
  description, e.g. `feat(scope): Add the thing` (not `add the thing`). For
  details on this, check out the Contributors Guide linked above.
-->

### Brief description of Pull Request

Add an experimental `convert_classic_histograms_to_nhcb` argument that turns each OTel explicit-bucket histogram data point into a single Prometheus native histogram with custom buckets, instead of expanding into _bucket, _sum, and _count series. Gated behind the experimental stability level.
<!-- Human-readable description of the PR used as squash commit body. -->


### Pull Request Details

<!-- Detailed descripion of the Pull Request, if needed. -->


### Issue(s) fixed by this Pull Request

Fixes #6183
<!-- Fixes #issue_id -->


### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [x] Tests updated
