### PR TITLE
ci: Stop running fuzz tests on every PR

### DIFF
--- a/.github/workflows/fuzz-go-pr.yml
+++ b/.github/workflows/fuzz-go-pr.yml
@@ -1,6 +1,6 @@
 name: Run Go fuzz tests (PR)
 on:
-  pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
### Brief description of Pull Request

Change `fuzz-go-pr.yml` from auto-running on every PR to manual `workflow_dispatch:` only.

### Pull Request Details

The fuzz workflow adds ~8 minutes to every PR's CI but rarely surfaces new findings outside the nightly scheduled run on main. This shifts it to manual invocation while we discuss whether the PR-level run is worth keeping.

The scheduled workflow (`fuzz-go-scheduled.yml`) continues to run nightly on main, so fuzz coverage on the trunk is unchanged.