### PR TITLE
ci: Verify kind binary checksum in k8s integration tests

### DIFF
--- a/.github/workflows/integration-tests-k8s.yml
+++ b/.github/workflows/integration-tests-k8s.yml
@@ -60,8 +60,12 @@ jobs:
       with:
         version: v3.14.4
     - name: Install kind
+      env:
+        KIND_VERSION: v0.24.0
+        KIND_SHA256: b89aada5a39d620da3fcd16435b7f28d858927dd53f92cbac77686b0588b600d
       run: |
-        curl -Lo ./kind "https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64"
+        curl -fLo ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
+        echo "${KIND_SHA256}  ./kind" | sha256sum -c -
         chmod +x ./kind
         sudo mv ./kind /usr/local/bin/kind
     - name: Download images artifact


### PR DESCRIPTION
### Brief description of Pull Request

Verify the `kind` binary against its official SHA256 checksum in the Kubernetes integration tests workflow so a tampered or unexpected download fails the job instead of being silently installed.

### Pull Request Details

In `.github/workflows/integration-tests-k8s.yml`, the `Install kind` step now:

- Promotes the version and checksum to env vars (`KIND_VERSION`, `KIND_SHA256`) so they're easy to bump together.
- Adds `-f` to `curl` so HTTP errors (e.g. a 404 on a future version typo) fail the step instead of writing an error page to `./kind`.
- Verifies the binary with `sha256sum -c -` against the official checksum before installing.

The SHA256 (`b89aada5a39d620da3fcd16435b7f28d858927dd53f92cbac77686b0588b600d`) comes from the official release file at https://github.com/kubernetes-sigs/kind/releases/download/v0.24.0/kind-linux-amd64.sha256sum, and matches the binary served at the `kind.sigs.k8s.io` URL the workflow already uses.

### Issue(s) fixed by this Pull Request

Follow-up hardening for the workflow introduced in #6125.

### Notes to the Reviewer

When bumping `KIND_VERSION` in the future, also update `KIND_SHA256` from the corresponding `kind-linux-amd64.sha256sum` asset on the kind release page.

### PR Checklist

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated