### PR TITLE
fix(loki.source.syslog): Treat RFC5424 structured-data as meaningful

### DIFF
--- a/docs/sources/reference/components/loki/loki.source.syslog.md
+++ b/docs/sources/reference/components/loki/loki.source.syslog.md
@@ -170,6 +170,7 @@ You can't use the `rfc3164_default_to_current_year`, `use_incoming_timestamp`, a
   `loki.source.syslog` drops messages with empty MSG content by default.
   Set `rfc5424_allow_empty_msg` to `true` to forward them.
   `loki.source.syslog` increments the `loki_source_syslog_empty_messages_total` counter in both cases for debugging.
+  Messages with empty MSG content but non-empty STRUCTURED-DATA are always forwarded regardless of `rfc5424_allow_empty_msg`, since their payload lives in the structured-data section. This is common in Junos `sd-syslog` flow records and similar network gear.
 - **`raw`**
   Disables log line parsing. This format allows receiving non-RFC5424 compliant logs, such as [CEF][cef].
   Raw logs can be forwarded to [`loki.process`](./loki.process.md) component for parsing.

--- a/internal/component/loki/source/syslog/internal/syslogtarget/syslogtarget.go
+++ b/internal/component/loki/source/syslog/internal/syslogtarget/syslogtarget.go
@@ -136,10 +136,13 @@ func (t *SyslogTarget) handleMessageError(err error) {
 
 func (t *SyslogTarget) handleMessageRFC5424(connLabels labels.Labels, msg *rfc5424.SyslogMessage) {
 	if msg.Message == nil {
-		t.metrics.syslogEmptyMessages.Inc()
+		hasStructuredData := msg.StructuredData != nil && len(*msg.StructuredData) > 0
+		if !hasStructuredData {
+			t.metrics.syslogEmptyMessages.Inc()
 
-		if !t.config.RFC5424AllowEmptyMsg {
-			return
+			if !t.config.RFC5424AllowEmptyMsg {
+				return
+			}
 		}
 	}
 

--- a/internal/component/loki/source/syslog/internal/syslogtarget/syslogtarget_test.go
+++ b/internal/component/loki/source/syslog/internal/syslogtarget/syslogtarget_test.go
@@ -608,8 +608,8 @@ func TestSyslogTarget_RFC5424MessageEmptyMSGWhenAllowed(t *testing.T) {
 }
 
 func TestSyslogTarget_RFC5424MessageEmptyMSGWhenNotAllowed(t *testing.T) {
-	// RFC5424 message with empty MSG part (no content after structured data)
-	msg := `<14>1 2026-02-19T14:57:17.097Z secfw-a RT_FLOW - RT_FLOW_SESSION_DENY [junos@2636.1.1.1.2.129 application="UNKNOWN"]`
+	// RFC5424 message with NILVALUE structured data and no MSG.
+	msg := `<14>1 2026-02-19T14:57:17.097Z secfw-a RT_FLOW - RT_FLOW_SESSION_DENY -`
 
 	handler := loki.NewCollectingHandler()
 	defer handler.Stop()
@@ -644,6 +644,63 @@ func TestSyslogTarget_RFC5424MessageEmptyMSGWhenNotAllowed(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return time.Since(start) >= 100*time.Millisecond && len(handler.Received()) == 0
 	}, 200*time.Millisecond, 10*time.Millisecond, "RFC5424 log with nil Message should be dropped when RFC5424AllowEmptyMsg is false")
+}
+
+// RFC5424 messages with no MSG body but populated STRUCTURED-DATA are common in
+// the wild (Junos sd-syslog flow records, OTel collectors, various network gear)
+// and should always be forwarded regardless of RFC5424AllowEmptyMsg, since the
+// payload lives in the structured-data section.
+func TestSyslogTarget_RFC5424EmptyMSGWithStructuredDataAlwaysAllowed(t *testing.T) {
+	msg := `<14>1 2026-02-19T14:57:17.097Z secfw-a RT_FLOW - RT_FLOW_SESSION_DENY [junos@99999 application="UNKNOWN" source_address="10.0.0.1"]`
+
+	handler := loki.NewCollectingHandler()
+	defer handler.Stop()
+
+	relabelCfg := unmarshalRelabelCfg(t, `
+- source_labels: ['__syslog_message_sd_junos_99999_application']
+  target_label: 'application'
+- source_labels: ['__syslog_message_sd_junos_99999_source_address']
+  target_label: 'source_address'
+`)
+
+	metrics := NewMetrics(nil)
+	tgt, err := NewSyslogTarget(TargetParams{
+		Metrics: metrics,
+		Logger:  logging.NewSlogNop(),
+		Handler: handler,
+		Relabel: relabelCfg,
+		Config: &scrapeconfig.SyslogTargetConfig{
+			ListenAddress:        "127.0.0.1:0",
+			ListenProtocol:       ProtocolUDP,
+			RFC5424AllowEmptyMsg: false,
+			LabelStructuredData:  true,
+			Labels: model.LabelSet{
+				"test": "syslog_target",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Eventually(t, tgt.Ready, time.Second, 10*time.Millisecond)
+	defer func() {
+		require.NoError(t, tgt.Stop())
+	}()
+
+	addr := tgt.ListenAddress().String()
+	c, err := net.Dial(ProtocolUDP, addr)
+	require.NoError(t, err)
+
+	err = writeMessagesToStream(c, []string{msg}, fmtNewline)
+	require.NoError(t, err)
+	require.NoError(t, c.Close())
+
+	require.Eventuallyf(t, func() bool {
+		return len(handler.Received()) == 1
+	}, time.Second, time.Millisecond, "Expected to receive 1 message, got %d.", len(handler.Received()))
+
+	entry := handler.Received()[0]
+	require.Equal(t, "", entry.Line, "MSG is empty so the line is empty")
+	require.Equal(t, model.LabelValue("UNKNOWN"), entry.Labels["application"])
+	require.Equal(t, model.LabelValue("10.0.0.1"), entry.Labels["source_address"])
 }
 
 const layout = "Jan 02 15:04:05"


### PR DESCRIPTION
### Brief description of Pull Request

`loki.source.syslog` now forwards RFC5424 messages that have an empty MSG field
when their STRUCTURED-DATA section is populated, instead of dropping them.
Previously such messages were discarded (and counted in
`loki_source_syslog_empty_messages_total`) unless `rfc5424_allow_empty_msg` was
set, even though their payload lived entirely in the structured-data section.

### Pull Request Details

RFC5424 explicitly allows MSG to be absent (`MSG = MSG-ANY / MSG-UTF8 / [empty]`),
and many real-world senders put their whole payload in STRUCTURED-DATA with no
MSG at all: Juniper Junos `sd-syslog` flow records
(`RT_FLOW_SESSION_CREATE/CLOSE/DENY`, …), OTel-style collectors, and assorted
network gear. For these, the structured-data section *is* the message, so
dropping them loses data even though parsing succeeded. The only prior workaround
was running senders in RFC3164 (`format syslog`) mode, which gets the bytes
through but forfeits first-class structured-data fields.

This change treats "empty MSG **with** non-empty STRUCTURED-DATA" as meaningful:
it is always forwarded and the empty-message counter is not incremented,
regardless of `rfc5424_allow_empty_msg`. The flag still governs the truly-empty
case (NILVALUE structured data `-` and no MSG), which is unchanged. The change is
scoped to the RFC5424 path (`handleMessageRFC5424`); RFC3164 has no structured
data and is intentionally left alone.

`StructuredData` on `leodido/go-syslog/v4` `rfc5424.SyslogMessage` is a
`*map[string]map[string]string`, so the guard is
`msg.StructuredData != nil && len(*msg.StructuredData) > 0`.

### Issue(s) fixed by this Pull Request

<!-- none filed -->

### Notes to the Reviewer

The existing negative test `TestSyslogTarget_RFC5424MessageEmptyMSGWhenNotAllowed`
previously used a message that *had* structured data, which would now (correctly)
be forwarded; it has been updated to a true NILVALUE-SD message
(`… RT_FLOW - … -`) so it still exercises the real drop path. A new test,
`TestSyslogTarget_RFC5424EmptyMSGWithStructuredDataAlwaysAllowed`, covers the new
behavior including structured-data label extraction.

### PR Checklist

- [x] Documentation added
- [x] Tests updated