### PR TITLE
fix(loki.source.docker): Stop tailer when container no longer exists

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/burningalchemist/sql_exporter v0.0.0-20260312184457-9bf25f71582f
 	github.com/c2h5oh/datasize v0.0.0-20231215233829-aa82cc1e6500
 	github.com/cespare/xxhash/v2 v2.3.0
+	github.com/containerd/errdefs v1.0.0
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/dimchansky/utfbom v1.1.1
 	github.com/docker/docker v28.5.2+incompatible // indirect
@@ -513,7 +514,6 @@ require (
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
 	github.com/containerd/continuity v0.4.5 // indirect
-	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v1.0.0-rc.1 // indirect

--- a/internal/component/loki/source/docker/tailer.go
+++ b/internal/component/loki/source/docker/tailer.go
@@ -18,6 +18,7 @@ import (
 	"time"
 	"unsafe"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/grafana/loki/pkg/push"
 	"github.com/moby/moby/api/pkg/stdcopy"
 	"github.com/moby/moby/client"
@@ -98,6 +99,11 @@ func (t *tailer) Run(ctx context.Context) {
 		case <-ticker.C:
 			res, err := t.client.ContainerInspect(ctx, t.containerID, client.ContainerInspectOptions{})
 			if err != nil {
+				if cerrdefs.IsNotFound(err) {
+					t.logger.Info("container no longer exists, stopping tailer", "id", t.containerID)
+					t.stop()
+					return
+				}
 				if !errors.Is(err, context.Canceled) {
 					t.logger.Error("error inspecting Docker container", "id", t.containerID, "error", err)
 				}

--- a/internal/component/loki/source/docker/tailer_test.go
+++ b/internal/component/loki/source/docker/tailer_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/moby/api/pkg/stdcopy"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
@@ -221,6 +222,38 @@ func TestTailerNeverStarted(t *testing.T) {
 	}, time.Second, 20*time.Millisecond, "Expected log lines were not found within the time limit after restart.")
 
 	require.NotPanics(t, func() { cancel() })
+}
+
+func TestTailerStopsWhenContainerNotFound(t *testing.T) {
+	inspectCount := atomic.NewInt32(0)
+	notFoundAfter := int32(2)
+
+	mock := clientMock{
+		logLine:    "2024-05-02T13:11:55.879889Z some log line",
+		running:    func() bool { return true },
+		finishedAt: func() string { return "0001-01-01T00:00:00Z" },
+		inspectErr: func() error {
+			if inspectCount.Add(1) > notFoundAfter {
+				return cerrdefs.ErrNotFound
+			}
+			return nil
+		},
+	}
+
+	tailer, _ := setupTailer(t, mock)
+
+	done := make(chan struct{})
+	go func() {
+		tailer.Run(t.Context())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Run exited — tailer stopped after getting "not found"
+	case <-time.After(5 * time.Second):
+		t.Fatal("tailer did not stop after container was removed")
+	}
 }
 
 var _ io.ReadCloser = (*stringReader)(nil)
@@ -478,9 +511,15 @@ type clientMock struct {
 	logLine    string
 	running    func() bool
 	finishedAt func() string
+	inspectErr func() error
 }
 
 func (mock clientMock) ContainerInspect(ctx context.Context, c string, opts client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
+	if mock.inspectErr != nil {
+		if err := mock.inspectErr(); err != nil {
+			return client.ContainerInspectResult{}, err
+		}
+	}
 	return client.ContainerInspectResult{
 		Container: container.InspectResponse{
 			ID: c,

--- a/internal/component/loki/source/docker/tailer_test.go
+++ b/internal/component/loki/source/docker/tailer_test.go
@@ -240,13 +240,22 @@ func TestTailerStopsWhenContainerNotFound(t *testing.T) {
 		},
 	}
 
-	tailer, _ := setupTailer(t, mock)
+	tailer, entryHandler := setupTailer(t, mock)
 
 	done := make(chan struct{})
 	go func() {
 		tailer.Run(t.Context())
 		close(done)
 	}()
+
+	// The container is still readable for the first few ticks, so its logs must
+	// be shipped before the tailer notices the container is gone and stops.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		logLines := entryHandler.Received()
+		if assert.NotEmpty(c, logLines) {
+			assert.Equal(c, "some log line", logLines[0].Line)
+		}
+	}, 5*time.Second, 20*time.Millisecond, "expected the container's log line to be shipped before the tailer stopped")
 
 	select {
 	case <-done:


### PR DESCRIPTION
## Summary

When a Docker container is removed, `ContainerInspect` returns a "not found" error. Previously, the tailer logged this as `level=error` and retried on every tick indefinitely, causing thousands of error log lines per 5-minute window in environments with frequent container churn.

This PR adds a check for `cerrdefs.IsNotFound(err)` in the tailer's `Run` loop. When the container no longer exists, the tailer stops gracefully instead of retrying forever.

### Root cause

In `tailer.go`, the `Run()` method calls `ContainerInspect` on each tick. When it returns an error, the code does `continue` — retrying on the next tick. For "not found" errors (container removed), the container will never come back with the same ID, so retrying is pointless and produces a steady stream of error logs.

### Impact

In a Docker Swarm environment with 17 tenants and `start-first` update order, each deploy replaces containers. Over 20 days of Alloy uptime, ~55 stale container references accumulated per node, each retried every 5 seconds — producing **6,660 error log lines per 5-minute window** across the cluster.

### Changes

- **`tailer.go`**: Check for `cerrdefs.IsNotFound(err)` before the generic error handler. If the container no longer exists, log at info level and stop the tailer.
- **`tailer_test.go`**: Add `TestTailerStopsWhenContainerNotFound` — verifies that `Run` exits when `ContainerInspect` returns `ErrNotFound`. Extended `clientMock` with an `inspectErr` callback.

Fixes #3054