### PR TITLE
fix(helm): Honor alloy.configMap.key in templates/configmap.yaml

### DIFF
--- a/operations/helm/charts/alloy/CHANGELOG.md
+++ b/operations/helm/charts/alloy/CHANGELOG.md
@@ -10,6 +10,10 @@ internal API changes are not present.
 Unreleased
 ----------
 
+### Bug fixes
+
+- Fix `templates/configmap.yaml` ignoring `alloy.configMap.key`. The pod template honors the value via the `alloy.config-map.key` helper, but the ConfigMap template hardcoded the data key as `config.alloy`, producing a key/expected-path mismatch that crash-looped Alloy when the value was set. (#TBD)
+
 1.8.2 (2026-05-25)
 ----------
 

--- a/operations/helm/charts/alloy/CHANGELOG.md
+++ b/operations/helm/charts/alloy/CHANGELOG.md
@@ -12,7 +12,7 @@ Unreleased
 
 ### Bug fixes
 
-- Fix `templates/configmap.yaml` ignoring `alloy.configMap.key`. The pod template honors the value via the `alloy.config-map.key` helper, but the ConfigMap template hardcoded the data key as `config.alloy`, producing a key/expected-path mismatch that crash-looped Alloy when the value was set. (#TBD)
+- Fix `templates/configmap.yaml` ignoring `alloy.configMap.key`. The pod template honors the value via the `alloy.config-map.key` helper, but the ConfigMap template hardcoded the data key as `config.alloy`, producing a key/expected-path mismatch that crash-looped Alloy when the value was set. (#6312)
 
 1.8.2 (2026-05-25)
 ----------

--- a/operations/helm/charts/alloy/templates/configmap.yaml
+++ b/operations/helm/charts/alloy/templates/configmap.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/component: config
 data:
   {{- if $values.configMap.content }}
-  config.alloy: |- {{- (tpl  $values.configMap.content .) | nindent 4 }}
+  {{ include "alloy.config-map.key" . }}: |- {{- (tpl  $values.configMap.content .) | nindent 4 }}
   {{- else }}
-  config.alloy: |- {{- .Files.Get "config/example.alloy" | trim | nindent 4 }}
+  {{ include "alloy.config-map.key" . }}: |- {{- .Files.Get "config/example.alloy" | trim | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/operations/helm/tests/configmap-key/alloy/templates/configmap.yaml
+++ b/operations/helm/tests/configmap-key/alloy/templates/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: config
 data:
-  config.alloy: |-
+  collector.yaml: |-
     logging {
       level = "debug"
     }


### PR DESCRIPTION
### Brief description of Pull Request

Split off from #6311 per [@kalleep's request](https://github.com/grafana/alloy/pull/6311#issuecomment-4543676031). Fixes `templates/configmap.yaml` ignoring `alloy.configMap.key`.

### Pull Request Details

The chart hardcoded the ConfigMap data key as `config.alloy`, but the pod template derives the mount subPath / `--config.file` from `alloy.configMap.key` (via the `alloy.config-map.key` helper). Setting `configMap.key: collector.yaml` produced a ConfigMap with key `config.alloy` and a pod expecting `collector.yaml`:

```
reading config path '/etc/alloy/collector.yaml': no such file or directory
```

Wires the existing helper into the ConfigMap template. Default (no key set) renders `config.alloy:` unchanged. Also unblocks `ct install` on the pre-existing `configmap-key-values.yaml` test case.

### How I tested this

`helm install configmap-key-verify . -f ci/configmap-key-values.yaml --wait` reaches `STATUS=deployed`; Alloy pod starts cleanly. With default values, ConfigMap key is still `config.alloy`. Golden under `operations/helm/tests/configmap-key/` regenerated (one-line change).

### Issue(s) fixed by this Pull Request

N/A — surfaced during work on #6311.

### Notes to the Reviewer

CHANGELOG entry uses `(#TBD)` placeholder; I'll fix up with the PR number once it's assigned.

### PR Checklist

- [x] Documentation added (`CHANGELOG.md` entry under `Unreleased` > `Bug fixes`)
- [x] Tests updated (golden regenerated)
- [ ] Config converters updated (N/A)
