### PR TITLE
ci: Publish Alloy Images to GAR 

### DIFF
--- a/.github/workflows/create_build_image.yml
+++ b/.github/workflows/create_build_image.yml
@@ -42,7 +42,6 @@ jobs:
       uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
       with:
         registry: us-docker.pkg.dev
-        environment: prod
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0

--- a/.github/workflows/create_build_image.yml
+++ b/.github/workflows/create_build_image.yml
@@ -38,8 +38,11 @@ jobs:
       id: get_image_version
       run: echo "image_tag=${FULL_TAG##*/}${{ matrix.build.suffix }}" >> $GITHUB_OUTPUT
 
-    - name: Login to DockerHub (from vault)
-      uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3
+    - name: Login to Google Artifact Registry
+      uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
+      with:
+        registry: us-docker.pkg.dev
+        environment: prod
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
@@ -53,6 +56,6 @@ jobs:
         platforms: linux/amd64,linux/arm64
         context: ./build-tools/build-image
         push: true
-        tags: grafana/alloy-build-image:${{ steps.get_image_version.outputs.image_tag }}
+        tags: us-docker.pkg.dev/grafanalabs-global/dockerhub-alloy-prod-mirror/alloy-build-image:${{ steps.get_image_version.outputs.image_tag }}
         build-args: |
           GO_RUNTIME=${{ matrix.build.runtime }}

--- a/.github/workflows/publish-alloy-devel.yml
+++ b/.github/workflows/publish-alloy-devel.yml
@@ -74,8 +74,7 @@ jobs:
     - name: Log in to Google Artifact Registry
       uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
       with:
-        registry: "us-docker.pkg.dev"
-        environment: "prod"
+        registry: us-docker.pkg.dev
 
     - name: Update to latest image
       run: |

--- a/.github/workflows/publish-alloy-linux.yml
+++ b/.github/workflows/publish-alloy-linux.yml
@@ -41,7 +41,6 @@ jobs:
       uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
       with:
         registry: us-docker.pkg.dev
-        environment: prod
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/publish-alloy-linux.yml
+++ b/.github/workflows/publish-alloy-linux.yml
@@ -37,8 +37,11 @@ jobs:
       # That's because it generates a new file.
       # We don't want this file to end up in the repo directory.
       # Then "scripts/image-tag" would get confused because "git status" no longer reports a clean repo.
-    - name: Login to DockerHub (from vault)
-      uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3
+    - name: Login to Google Artifact Registry
+      uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
+      with:
+        registry: us-docker.pkg.dev
+        environment: prod
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/publish-alloy-windows.yml
+++ b/.github/workflows/publish-alloy-windows.yml
@@ -54,7 +54,6 @@ jobs:
       uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
       with:
         registry: us-docker.pkg.dev
-        environment: prod
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/publish-alloy-windows.yml
+++ b/.github/workflows/publish-alloy-windows.yml
@@ -34,6 +34,9 @@ jobs:
       matrix:
         os: [windows-2022]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
     - name: Ensure Docker is running (Docker issue workaround)
       id: docker-workaround
@@ -47,8 +50,11 @@ jobs:
       # That's because it generates a new file.
       # We don't want this file to end up in the repo directory.
       # Then "scripts/image-tag" would get confused because "git status" no longer reports a clean repo.
-    - name: Login to DockerHub (from vault)
-      uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3
+    - name: Login to Google Artifact Registry
+      uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
+      with:
+        registry: us-docker.pkg.dev
+        environment: prod
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/scripts/docker-containers
+++ b/scripts/docker-containers
@@ -29,8 +29,9 @@ if [[ $PUSH_ALLOY_IMAGE == "true"  ]]; then
 	DOCKER_FLAGS="--push"
 fi
 
-export RELEASE_ALLOY_IMAGE=grafana/alloy
-export DEVEL_ALLOY_IMAGE=grafana/alloy-dev
+GAR_MIRROR=us-docker.pkg.dev/grafanalabs-global/dockerhub-alloy-prod-mirror
+export RELEASE_ALLOY_IMAGE=$GAR_MIRROR/alloy
+export DEVEL_ALLOY_IMAGE=$GAR_MIRROR/alloy-dev
 
 # We need to determine what version to assign to built binaries. 
 # If containers are being built from a GitHub Actions tag trigger, 

--- a/scripts/docker-containers-windows
+++ b/scripts/docker-containers-windows
@@ -41,7 +41,7 @@ export DEVEL_ALLOY_IMAGE=$GAR_MIRROR/alloy-dev
 
 # TODO: Unit test this script? Test cases:
 # * Input:  ALLOY_GO_VERSION=1.24 WINDOWS_VERSION=windows-2022 GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v1.8.0 ./scripts/docker-containers-windows alloy
-#   Output: docker build -t grafana/alloy:v1.8.0-windowsservercore-ltsc2022 -t grafana/alloy:windowsservercore-ltsc2022 --build-arg VERSION=v1.8.0 --build-arg RELEASE_BUILD=1 --build-arg BASE_IMAGE_GO=golang:1.24-windowsservercore-ltsc2022 --build-arg BASE_IMAGE_WINDOWS=mcr.microsoft.com/windows/nanoserver:ltsc2022 -f ./Dockerfile.windows .
+#   Output: docker build -t us-docker.pkg.dev/grafanalabs-global/dockerhub-alloy-prod-mirror/alloy:v1.8.0-windowsservercore-ltsc2022 -t us-docker.pkg.dev/grafanalabs-global/dockerhub-alloy-prod-mirror/alloy:windowsservercore-ltsc2022 --build-arg VERSION=v1.8.0 --build-arg RELEASE_BUILD=1 --build-arg BASE_IMAGE_GO=golang:1.24-windowsservercore-ltsc2022 --build-arg BASE_IMAGE_WINDOWS=mcr.microsoft.com/windows/nanoserver:ltsc2022 -f ./Dockerfile.windows .
 if [ -n "$GITHUB_TAG" ]; then
   VERSION=$GITHUB_TAG
 else

--- a/scripts/docker-containers-windows
+++ b/scripts/docker-containers-windows
@@ -35,8 +35,9 @@ else
   exit 1
 fi
 
-export RELEASE_ALLOY_IMAGE=grafana/alloy
-export DEVEL_ALLOY_IMAGE=grafana/alloy-dev
+GAR_MIRROR=us-docker.pkg.dev/grafanalabs-global/dockerhub-alloy-prod-mirror
+export RELEASE_ALLOY_IMAGE=$GAR_MIRROR/alloy
+export DEVEL_ALLOY_IMAGE=$GAR_MIRROR/alloy-dev
 
 # TODO: Unit test this script? Test cases:
 # * Input:  ALLOY_GO_VERSION=1.24 WINDOWS_VERSION=windows-2022 GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v1.8.0 ./scripts/docker-containers-windows alloy


### PR DESCRIPTION
### Brief description of Pull Request
We will now be publishing our Alloy images to GAR, which will then automatically be mirrored back to our Dockerhub repositories. This means that our CI workflows are no longer directly authenticating with Dockerhub. Part of following [these steps](https://github.com/grafana/deployment_tools/blob/master/docs/platform/gar-image-mirror.md)

Publishing `devel` images on PR merge to `main` hook into the `publish-alloy-*` workflows, so those will also be using GAR/mirroring after this PR is merged

### Issue(s) fixed by this Pull Request
Part of https://github.com/grafana/alloy-internal/issues/362