### PR TITLE
docs: Add caution admonition to the TLS config block documentation

### DIFF
--- a/docs/sources/shared/reference/components/tls-config-block.md
+++ b/docs/sources/shared/reference/components/tls-config-block.md
@@ -31,3 +31,15 @@ If `min_version` is provided, it must be set to one of the following strings:
 * `"TLS11"` (TLS 1.1)
 * `"TLS12"` (TLS 1.2)
 * `"TLS13"` (TLS 1.3)
+
+{{< admonition type="caution" >}}
+If you set `insecure_skip_verify` to `true`, you disable verification of the server's certificate chain and hostname.
+Alloy accepts any certificate the server presents, including expired, self-signed, or invalid certificates.
+
+You can use `insecure_skip_verify` for local development, self-signed certificates, or endpoints that use a private CA outside the system trust store.
+If the hostname doesn't match the certificate, set `server_name` instead of `insecure_skip_verify`.
+In production, use `ca_file` or `ca_pem` to trust a private CA instead of `insecure_skip_verify`.
+
+Set `insecure_skip_verify` to `true` only in isolated development or testing environments where you don't transmit sensitive data.
+Remove the setting before you deploy to production.
+{{< /admonition >}}


### PR DESCRIPTION
If a user sets `insecure_skip_verify` to `true` they potentially expose their pipelines to MiM attack vectors because Alloy will accept any certificate the server presents. The potential risk is not made clear in the docs. The Caution admonition attempts to close this info gap and advises the reader not to use this arg in production - the text added also provides alternative argument suggestions that will ensure security is maintained.