### PR TITLE
chore: Bump build image to use go v1.26.3

### DIFF
--- a/.github/workflows/check-linux-build-image.yml
+++ b/.github/workflows/check-linux-build-image.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         build:
-          - runtime: golang:1.26.2-alpine3.23
-          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.26.2-bookworm
+          - runtime: golang:1.26.3-alpine3.23
+          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.26.3-bookworm
     runs-on: ubuntu-latest-8-cores
     steps:
       - name: Checkout

--- a/.github/workflows/create_build_image.yml
+++ b/.github/workflows/create_build_image.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         build:
-          - runtime: golang:1.26.2-alpine3.23
-          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.26.2-bookworm
+          - runtime: golang:1.26.3-alpine3.23
+          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.26.3-bookworm
             suffix: "-boringcrypto"
     runs-on: ubuntu-latest-8-cores
     steps:

--- a/build-tools/build-image/windows/Dockerfile
+++ b/build-tools/build-image/windows/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2-windowsservercore-ltsc2022@sha256:b36e6e1036d0746855a215ecc693bdc45879a74a15edc797fc9af6cc3f505863
+FROM golang:1.26.3-windowsservercore-ltsc2022@sha256:98c6379211d9edcf4b56241bae12b71cc41334d54b42d5743841c97f017123bd
 
 SHELL ["powershell", "-command"]
 


### PR DESCRIPTION
PR 1 of 2 to upgrade Go to v1.26.3 (security fixes — see [Go 1.26.3 release announcement](https://groups.google.com/g/golang-announce/c/qcCIEXso47M)).

This PR updates the Go version used in the build image. Once the new build image is published, a follow-up PR will bump `go.mod` files, Dockerfiles, and the `grafana/alloy-build-image` references.

Generated by `make update-go-version-pr-1 VERSION=1.26.3` (Windows Dockerfile digest updated manually to match `golang:1.26.3-windowsservercore-ltsc2022` on Docker Hub).