### PR TITLE
chore: Migrate direct pkg/errors usage to stdlib errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -184,7 +184,7 @@ require (
 	github.com/percona/mongodb_exporter v0.47.2
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/pingcap/tidb/pkg/parser v0.0.0-20250501143621-a50a2323f4ba
-	github.com/pkg/errors v0.9.1
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/prometheus-community/elasticsearch_exporter v1.5.0
 	github.com/prometheus-community/postgres_exporter v0.19.0

--- a/internal/component/loki/source/journal/tailer.go
+++ b/internal/component/loki/source/journal/tailer.go
@@ -7,6 +7,7 @@ package journal
 // to other loki components.
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -18,7 +19,6 @@ import (
 	"github.com/grafana/alloy/internal/loki/promtail/scrapeconfig"
 	"github.com/grafana/loki/pkg/push"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
@@ -180,7 +180,7 @@ func newTailerWithReader(
 		maxAge, err = time.ParseDuration(targetConfig.MaxAge)
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, "parsing journal reader 'max_age' config value")
+		return nil, fmt.Errorf("parsing journal reader 'max_age' config value: %w", err)
 	}
 
 	cb := journalConfigBuilder{
@@ -205,7 +205,7 @@ func newTailerWithReader(
 	cfg := t.generateJournalConfig(cb)
 	t.r, err = readerFunc(cfg)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating journal reader")
+		return nil, fmt.Errorf("creating journal reader: %w", err)
 	}
 
 	go func() {

--- a/internal/loki/util/cfg/cfg.go
+++ b/internal/loki/util/cfg/cfg.go
@@ -1,10 +1,10 @@
 package cfg
 
 import (
+	"errors"
 	"reflect"
 
 	"github.com/grafana/dskit/flagext"
-	"github.com/pkg/errors" //nolint:depguard
 )
 
 // Source is a generic configuration source. This function may do whatever is

--- a/internal/loki/util/cfg/flag.go
+++ b/internal/loki/util/cfg/flag.go
@@ -1,10 +1,10 @@
 package cfg
 
 import (
+	"errors"
 	"flag"
 
 	"github.com/grafana/dskit/flagext"
-	"github.com/pkg/errors" //nolint:depguard
 )
 
 // Defaults registers flags to the flagSet using dst as the flagext.Registerer


### PR DESCRIPTION
## Summary
- replace the remaining direct `github.com/pkg/errors` imports in Loki journal/config code with stdlib `errors`
- convert `errors.Wrap(...)` calls to `fmt.Errorf(...: %w)` while preserving context
- run `go mod tidy`, which moves `github.com/pkg/errors` from direct to indirect because it is still transitively required by `github.com/grafana/dskit/flagext`

## Test plan
- [x] `go test ./internal/loki/util/cfg ./internal/component/loki/source/journal`
- [x] `go mod tidy`
- [x] `git grep -n "github.com/pkg/errors" -- '*.go'`