### PR TITLE
docs: Document Immutable Releases constraint in release shepherding guide

### DIFF
--- a/docs/developer/shepherding-releases.md
+++ b/docs/developer/shepherding-releases.md
@@ -57,6 +57,12 @@ out the section below on modifying a PR's changelog entry after it's been merged
    gh release edit <VERSION>-rc.0 --draft=false --repo grafana/alloy
    ```
 
+> **NOTE:** Publishing is irreversible. This repo enforces
+> [Immutable Releases](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/immutable-releases):
+> once published, a release's Git tag and attached assets are permanently locked, so you can't add,
+> change, or remove assets afterward. Confirm every expected artifact is attached to the draft before
+> you publish.
+
 ### 3. Validate the RC on internal deployments
 
 1. Deploy the RC to internal clusters following the
@@ -76,6 +82,12 @@ cut a new RC and repeat step 3.
 > bypass the guard.
 
 ### 5. When ready, cut the release
+
+> **NOTE:** Publishing is irreversible. This repo enforces
+> [Immutable Releases](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/immutable-releases):
+> once published, a release's Git tag and attached assets are permanently locked. Merging the
+> release-please PR only creates a *draft* and attaches artifacts — confirm every artifact is present,
+> then publish as the final step. **This applies to patch releases too, even though they skip the RC.**
 
 1. Merge the release-please PR into `main`.
 2. This will trigger workflows to create a draft release on GitHub, build the release artifacts, and


### PR DESCRIPTION
### Brief description of Pull Request

Updates the the release shepherding guide ahead of enabling GitHub Immutable Releases to highlight that it's critically important to wait for _all_ artifacts before moving the release out of draft state. This is the only real important piece before we can enable the setting. 

I'll change the repo setting after this merges.

### PR Checklist

- [x] Documentation added
