### PR TITLE
fix(prometheus.operator.*): Pass ScrapeNativeHistograms to ScrapeOptions

### DIFF
--- a/internal/component/prometheus/operator/configgen/config_gen.go
+++ b/internal/component/prometheus/operator/configgen/config_gen.go
@@ -176,11 +176,14 @@ func (cg *ConfigGenerator) generateAuthorization(a promopv1.SafeAuthorization, n
 func (cg *ConfigGenerator) generateDefaultScrapeConfig() *config.ScrapeConfig {
 	opt := cg.ScrapeOptions
 
+	copyScrapeNativeHistograms := opt.ScrapeNativeHistograms // make a copy as Prometheus wants a pointer.
+
 	c := config.DefaultScrapeConfig
 	c.ScrapeInterval = config.DefaultGlobalConfig.ScrapeInterval
 	c.ScrapeTimeout = config.DefaultGlobalConfig.ScrapeTimeout
 	c.ScrapeProtocols = config.DefaultGlobalConfig.ScrapeProtocols
 	c.ScrapeFallbackProtocol = config.PrometheusText0_0_4 // Keep the same as Prometheus V2
+	c.ScrapeNativeHistograms = &copyScrapeNativeHistograms
 
 	if opt.DefaultScrapeInterval != 0 {
 		c.ScrapeInterval = model.Duration(opt.DefaultScrapeInterval)

--- a/internal/component/prometheus/operator/configgen/config_gen_test.go
+++ b/internal/component/prometheus/operator/configgen/config_gen_test.go
@@ -448,9 +448,10 @@ func TestGenerateDefaultScrapeConfig(t *testing.T) {
 		{
 			name: "defaults set",
 			scrapeOptions: operator.ScrapeOptions{
-				DefaultScrapeInterval: 30 * time.Second,
-				DefaultScrapeTimeout:  5 * time.Second,
-				DefaultSampleLimit:    100,
+				DefaultScrapeInterval:  30 * time.Second,
+				DefaultScrapeTimeout:   5 * time.Second,
+				DefaultSampleLimit:     100,
+				ScrapeNativeHistograms: true,
 			},
 			expectedInterval:         30 * time.Second,
 			expectedTimeout:          5 * time.Second,
@@ -468,6 +469,7 @@ func TestGenerateDefaultScrapeConfig(t *testing.T) {
 			assert.Equal(t, model.Duration(tt.expectedTimeout), got.ScrapeTimeout)
 			assert.Equal(t, tt.expectedFallbackProtocol, got.ScrapeFallbackProtocol)
 			assert.Equal(t, tt.scrapeOptions.DefaultSampleLimit, got.SampleLimit)
+			assert.Equal(t, &tt.scrapeOptions.ScrapeNativeHistograms, got.ScrapeNativeHistograms)
 		})
 	}
 }


### PR DESCRIPTION
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style with a capitalized
  description, e.g. `feat(scope): Add the thing` (not `add the thing`). For
  details on this, check out the Contributors Guide linked above.
-->

### Brief description of Pull Request

<!-- Human-readable description of the PR used as squash commit body. -->
Until now the `ScrapeNativeHistograms` option was only used to update `ScrapeProtocols`. This is not sufficient to scrape native histograms using `ServiceMonitors`. This adds the missing default value required to scrape targets with native histograms.

### Issue(s) fixed by this Pull Request

Fixes #5733 


### Notes to the Reviewer

- Not sure if this qualifies for a 1.16 backport, if not please remove the label again

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests updated
