### PR TITLE
chore: Migrate jaegerremote off golang/protobuf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,6 @@ require (
 	github.com/go-sourcemap/sourcemap v2.1.4+incompatible
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/gogo/protobuf v1.3.2
-	github.com/golang/protobuf v1.5.4
 	github.com/golang/snappy v1.0.0
 	github.com/google/cadvisor v0.54.1
 	github.com/google/dnsmasq_exporter v0.2.1-0.20230620100026-44b14480804a
@@ -1059,6 +1058,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.30.2 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic v0.7.1 // indirect
 	github.com/google/go-github/v62 v62.0.0 // indirect
 	github.com/h2non/filetype v1.1.3 // indirect

--- a/internal/runtime/tracing/internal/jaegerremote/sampler_remote.go
+++ b/internal/runtime/tracing/internal/jaegerremote/sampler_remote.go
@@ -18,7 +18,6 @@
 package jaegerremote
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -27,10 +26,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/golang/protobuf/jsonpb"
 	jaeger_api_v2 "github.com/jaegertracing/jaeger-idl/proto-gen/api_v2"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/trace"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/protoadapt"
 )
 
 const (
@@ -314,7 +314,7 @@ type samplingStrategyParserImpl struct{}
 
 func (p *samplingStrategyParserImpl) Parse(response []byte) (any, error) {
 	strategy := new(jaeger_api_v2.SamplingStrategyResponse)
-	if err := jsonpb.Unmarshal(bytes.NewReader(response), strategy); err != nil {
+	if err := protojson.Unmarshal(response, protoadapt.MessageV2Of(strategy)); err != nil {
 		return nil, err
 	}
 	return strategy, nil


### PR DESCRIPTION
## Summary
- replace Jaeger remote sampler JSON parsing from `github.com/golang/protobuf/jsonpb` to `google.golang.org/protobuf/encoding/protojson` using `protoadapt` for v1-generated messages
- move `github.com/golang/protobuf` from a direct requirement to an indirect requirement in `go.mod`
- keep behavior intact while unblocking migration away from direct legacy protobuf usage in Alloy code

## Test plan
- [x] `go test ./internal/runtime/tracing/internal/jaegerremote/...`
- [x] `go test ./internal/component/common/net/...`
- [x] `go test ./internal/runtime/tracing/internal/jaegerremote/... ./internal/component/common/net/...`