### PR TITLE
chore: Migrate release to tools cli

### DIFF
--- a/.github/workflows/release-backport.yml
+++ b/.github/workflows/release-backport.yml
@@ -104,12 +104,10 @@ jobs:
           LABELS: ${{ steps.pr-info.outputs.labels }}
           PR_NUMBER: ${{ steps.pr-number.outputs.pr_number }}
         run: |
-          cd tools
-
           # Use while-read loop to safely handle labels with special characters
           echo "${LABELS}" | jq -r '.[]' | while IFS= read -r label; do
             echo "🍒 Processing backport for label: $label"
-            go run ./release/backport \
+            go run -C tools ./cmd release backport \
               --pr "${PR_NUMBER}" \
               --label "$label" || echo "⚠️ Backport for $label failed, moving to next..."
           done

--- a/.github/workflows/release-create-branch.yml
+++ b/.github/workflows/release-create-branch.yml
@@ -40,6 +40,4 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           APP_SLUG: ${{ env.ALLOYBOT_APP_NAME }}
           RELEASE_TAG: ${{ github.ref_name }}
-        run: |
-          cd tools
-          go run ./release/create-release-branch --tag "${RELEASE_TAG}"
+        run: go run -C tools ./cmd release create-release-branch --tag "${RELEASE_TAG}"

--- a/.github/workflows/release-create-rc.yml
+++ b/.github/workflows/release-create-rc.yml
@@ -54,6 +54,4 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
           APP_SLUG: ${{ env.ALLOYBOT_APP_NAME }}
-        run: |
-          cd tools
-          go run ./release/create-rc --branch "${GITHUB_REF_NAME}" ${{ inputs.dry_run == true && '--dry-run' || '' }}
+        run: go run -C tools ./cmd release create-rc --branch "${GITHUB_REF_NAME}" ${{ inputs.dry_run == true && '--dry-run' || '' }}

--- a/.github/workflows/release-enrich-release-notes.yml
+++ b/.github/workflows/release-enrich-release-notes.yml
@@ -33,9 +33,7 @@ jobs:
           cache-dependency-path: tools/go.sum
 
       - name: Enrich release notes 🙋
-        run: |
-          cd tools
-          go run ./release/enrich-release-notes --tag "${RELEASE_TAG_NAME}" --footer release/release-notes-footer.md
+        run: go run -C tools ./cmd release enrich-release-notes --tag "${RELEASE_TAG_NAME}" --footer release/release-notes-footer.md
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}

--- a/tools/README.md
+++ b/tools/README.md
@@ -49,6 +49,41 @@ Each workflow that uses `aireview` should pass a unique `--marker` (e.g.
 other AI-review bots on the same PR. See
 `.github/workflows/ai-dependency-review.yml` for a working example.
 
+### `release`
+
+Four subcommands that automate the release flow. Each is driven by a GitHub
+Actions workflow and supports `--dry-run` so you can verify what would happen
+without making changes.
+
+**`release create-release-branch --tag=<v1.X.0>`**
+
+Creates the `release/v1.X` branch from a finalized release tag and ensures the
+matching `backport/v1.X` label exists. Idempotent — re-running on an existing
+branch is a no-op. Driven by `release-create-branch.yml` (fires on `v*.*.0`
+tag pushes).
+
+**`release create-rc --branch=main|release/v1.X`**
+
+Tags the next RC and creates a draft prerelease from the open release-please
+PR for the given branch. Use `main` for a new minor RC, `release/v1.X` for a
+patch RC. Driven by `release-create-rc.yml` (manual `workflow_dispatch`).
+
+**`release backport --pr=<N> --label=backport/v1.X`**
+
+Cherry-picks the commit from a merged PR onto the `release/v1.X` branch, pushes
+the backport branch, and opens a backport PR. Skips cleanly when the target
+branch doesn't exist yet (release still in RC) or when the backport is already
+merged. On failure it comments on the source PR with manual instructions.
+Driven by `release-backport.yml` after the trigger workflow.
+
+**`release enrich-release-notes --tag=<v1.X.Y> [--footer=<path>]`**
+
+Adds contributor attribution (`@user1, @user2`) to each changelog entry in a
+published release's body, and optionally appends a footer template (with
+`${RELEASE_DOC_TAG}` substituted to `vX.Y`). Component release tags (those
+with a `/` like `syntax/v0.1.2`) skip the footer. Driven by
+`release-enrich-release-notes.yml` (fires on release publish).
+
 ### `update-go-version`
 
 Bumps the Go toolchain version across the repository. Split into two steps that

--- a/tools/cmd/main.go
+++ b/tools/cmd/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/alloy/tools/aireview"
 	"github.com/grafana/alloy/tools/goversion"
 	"github.com/grafana/alloy/tools/govulncheck"
+	"github.com/grafana/alloy/tools/release"
 )
 
 func main() {
@@ -21,6 +22,7 @@ func main() {
 		aireview.Command(),
 		goversion.Command(),
 		govulncheck.Command(),
+		release.Command(),
 	)
 
 	if err := cmd.Execute(); err != nil {

--- a/tools/release/backport/command.go
+++ b/tools/release/backport/command.go
@@ -1,18 +1,23 @@
-package main
+package backport
 
 import (
 	"context"
-	"flag"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 
 	"github.com/google/go-github/v57/github"
+	"github.com/spf13/cobra"
 
 	"github.com/grafana/alloy/tools/release/internal/git"
 	gh "github.com/grafana/alloy/tools/release/internal/github"
 )
+
+type flags struct {
+	prNumber int
+	label    string
+	dryRun   bool
+}
 
 // backportInfo holds all the data gathered during precondition checks that is
 // needed to perform the backport.
@@ -26,53 +31,46 @@ type backportInfo struct {
 	BackportBranch string
 }
 
-func main() {
-	var (
-		prNumber int
-		label    string
-		dryRun   bool
-	)
-	flag.IntVar(&prNumber, "pr", 0, "PR number to backport")
-	flag.StringVar(&label, "label", "", "Backport label (e.g., backport/v1.15)")
-	flag.BoolVar(&dryRun, "dry-run", false, "Dry run (do not create PR)")
-	flag.Parse()
+func Command() *cobra.Command {
+	var flags flags
 
-	if prNumber == 0 {
-		log.Fatal("PR number is required (use --pr flag)")
-	}
-	if label == "" {
-		log.Fatal("Label is required (use --label flag)")
+	cmd := &cobra.Command{
+		Use:   "backport",
+		Short: "Cherry-pick a merged PR to a release branch and open a backport PR",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(cmd.Context(), flags)
+		},
 	}
 
-	if err := run(prNumber, label, dryRun); err != nil {
-		log.Fatal(err)
-	}
+	cmd.Flags().IntVar(&flags.prNumber, "pr", 0, "PR number to backport")
+	cmd.Flags().StringVar(&flags.label, "label", "", "Backport label (e.g., backport/v1.15)")
+	cmd.Flags().BoolVar(&flags.dryRun, "dry-run", false, "Dry run (do not create PR)")
+	_ = cmd.MarkFlagRequired("pr")
+	_ = cmd.MarkFlagRequired("label")
+
+	return cmd
 }
 
-// run performs the backport operation. It is broken out into a separate function to allow deferred
-// working copy cleanup.
-func run(prNumber int, label string, dryRun bool) (retErr error) {
-	version := strings.TrimPrefix(label, "backport/")
-	if version == label {
-		return fmt.Errorf("invalid backport label format: %s (expected backport/vX.Y)", label)
+func run(ctx context.Context, flags flags) (retErr error) {
+	version := strings.TrimPrefix(flags.label, "backport/")
+	if version == flags.label {
+		return fmt.Errorf("invalid backport label format: %s (expected backport/vX.Y)", flags.label)
 	}
 	if !strings.HasPrefix(version, "v") {
 		return fmt.Errorf("invalid version format: %s (expected vX.Y)", version)
 	}
 
 	targetBranch := fmt.Sprintf("release/%s", version)
-	backportBranch := fmt.Sprintf("backport/pr-%d-to-%s", prNumber, version)
+	backportBranch := fmt.Sprintf("backport/pr-%d-to-%s", flags.prNumber, version)
 
-	fmt.Printf("🍒 Backporting PR #%d to %s\n", prNumber, targetBranch)
-
-	ctx := context.Background()
+	fmt.Printf("🍒 Backporting PR #%d to %s\n", flags.prNumber, targetBranch)
 
 	client, err := gh.NewClientFromEnv(ctx)
 	if err != nil {
 		return err
 	}
 
-	info, err := resolveBackportInfo(ctx, client, prNumber, targetBranch, backportBranch)
+	info, err := resolveBackportInfo(ctx, client, flags.prNumber, targetBranch, backportBranch)
 	if err != nil {
 		return err
 	}
@@ -80,7 +78,7 @@ func run(prNumber int, label string, dryRun bool) (retErr error) {
 		return nil
 	}
 
-	if dryRun {
+	if flags.dryRun {
 		fmt.Println("\n🏃 DRY RUN - No changes made")
 		fmt.Printf("Would create backport branch: %s\n", info.BackportBranch)
 		fmt.Printf("Would cherry-pick commit: %s\n", info.CommitSHA)

--- a/tools/release/command.go
+++ b/tools/release/command.go
@@ -1,0 +1,29 @@
+package release
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/grafana/alloy/tools/release/backport"
+	"github.com/grafana/alloy/tools/release/createrc"
+	"github.com/grafana/alloy/tools/release/createreleasebranch"
+	"github.com/grafana/alloy/tools/release/enrichreleasenotes"
+)
+
+func Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "release",
+		Short: "Release automation",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Usage()
+		},
+	}
+
+	cmd.AddCommand(
+		backport.Command(),
+		createrc.Command(),
+		createreleasebranch.Command(),
+		enrichreleasenotes.Command(),
+	)
+
+	return cmd
+}

--- a/tools/release/createrc/command.go
+++ b/tools/release/createrc/command.go
@@ -1,15 +1,14 @@
-package main
+package createrc
 
 import (
 	"context"
-	"flag"
 	"fmt"
-	"log"
 	"regexp"
 	"sort"
 	"strconv"
 
 	"github.com/google/go-github/v57/github"
+	"github.com/spf13/cobra"
 
 	gh "github.com/grafana/alloy/tools/release/internal/github"
 	"github.com/grafana/alloy/tools/release/internal/version"
@@ -17,9 +16,14 @@ import (
 
 const (
 	mainBranch          = "main"
-	backportLabelPrefix = "backport/v"
 	releaseBranchPrefix = "release/v"
+	backportLabelPrefix = "backport/v"
 )
+
+type flags struct {
+	branch string
+	dryRun bool
+}
 
 // rcInfo holds the resolved parameters for creating a release candidate.
 type rcInfo struct {
@@ -44,53 +48,62 @@ type prereleaseParams struct {
 	PRNumber  int    // Associated release-please PR number
 }
 
-func main() {
-	branch, dryRun := parseFlags()
+func Command() *cobra.Command {
+	var flags flags
 
-	ctx := context.Background()
-	client, err := gh.NewClientFromEnv(ctx)
-	if err != nil {
-		log.Fatal(err)
+	cmd := &cobra.Command{
+		Use:   "create-rc",
+		Short: "Create a release candidate tag and draft prerelease from the open release-please PR",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(cmd.Context(), flags)
+		},
 	}
 
-	info := resolveRCInfo(ctx, client, branch)
+	cmd.Flags().StringVar(&flags.branch, "branch", "", "Branch to create RC for (e.g., main or release/v1.15)")
+	cmd.Flags().BoolVar(&flags.dryRun, "dry-run", false, "Dry run (do not create tag or release)")
+	_ = cmd.MarkFlagRequired("branch")
 
-	if dryRun {
-		printDryRun(info)
-		return
-	}
-
-	createRCRelease(ctx, client, info)
-
-	if info.isFirstMinorRC() {
-		ensureBackportLabelForRC(ctx, client, info)
-	}
+	return cmd
 }
 
-func parseFlags() (string, bool) {
-	var (
-		dryRun bool
-		branch string
-	)
-	flag.BoolVar(&dryRun, "dry-run", false, "Dry run (do not create tag or release)")
-	flag.StringVar(&branch, "branch", "", "Branch to create RC for (e.g., main or release/v1.15)")
-	flag.Parse()
-
-	if branch == "" {
-		log.Fatal("Branch is required (use --branch flag, e.g., --branch main)")
-	}
-	if branch != mainBranch {
-		if _, err := version.ParseReleaseBranch(branch); err != nil {
-			log.Fatal(err)
+func run(ctx context.Context, flags flags) error {
+	if flags.branch != mainBranch {
+		if _, err := version.ParseReleaseBranch(flags.branch); err != nil {
+			return err
 		}
 	}
-	return branch, dryRun
+
+	client, err := gh.NewClientFromEnv(ctx)
+	if err != nil {
+		return err
+	}
+
+	info, err := resolveRCInfo(ctx, client, flags.branch)
+	if err != nil {
+		return err
+	}
+
+	if flags.dryRun {
+		printRCDryRun(info)
+		return nil
+	}
+
+	if err := createRCRelease(ctx, client, info); err != nil {
+		return err
+	}
+
+	if info.isFirstMinorRC() {
+		if err := ensureBackportLabelForRC(ctx, client, info); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
-func resolveRCInfo(ctx context.Context, client *gh.Client, branch string) rcInfo {
+func resolveRCInfo(ctx context.Context, client *gh.Client, branch string) (rcInfo, error) {
 	pr, err := findReleasePleasePR(ctx, client, branch)
 	if err != nil {
-		log.Fatalf("Failed to find release-please PR: %v", err)
+		return rcInfo{}, fmt.Errorf("finding release-please PR: %w", err)
 	}
 
 	fmt.Printf("Found release-please PR #%d: %s\n", pr.GetNumber(), pr.GetTitle())
@@ -99,22 +112,22 @@ func resolveRCInfo(ctx context.Context, client *gh.Client, branch string) rcInfo
 
 	ver, err := extractVersionFromTitle(pr.GetTitle())
 	if err != nil {
-		log.Fatalf("Failed to extract version from PR title: %v", err)
+		return rcInfo{}, fmt.Errorf("extracting version from PR title: %w", err)
 	}
 	fmt.Printf("Target version: %s\n", ver)
 
 	isPatch, err := version.IsPatch(ver)
 	if err != nil {
-		log.Fatalf("Failed to parse version: %v", err)
+		return rcInfo{}, fmt.Errorf("parsing version: %w", err)
 	}
 	if branch == mainBranch && isPatch {
 		mm, _ := version.MajorMinor(ver)
-		log.Fatalf("Cannot create a patch release RC from main. Use the release branch instead: --branch release/v%s", mm)
+		return rcInfo{}, fmt.Errorf("cannot create a patch release RC from main. Use the release branch instead: --branch release/v%s", mm)
 	}
 
 	rcNumber, err := findNextRCNumber(ctx, client, ver)
 	if err != nil {
-		log.Fatalf("Failed to determine next RC number: %v", err)
+		return rcInfo{}, fmt.Errorf("determining next RC number: %w", err)
 	}
 
 	rcTag := fmt.Sprintf("v%s-rc.%d", ver, rcNumber)
@@ -130,10 +143,10 @@ func resolveRCInfo(ctx context.Context, client *gh.Client, branch string) rcInfo
 		RCTag:     rcTag,
 		BranchSHA: branchSHA,
 		Branch:    branch,
-	}
+	}, nil
 }
 
-func printDryRun(info rcInfo) {
+func printRCDryRun(info rcInfo) {
 	fmt.Println("\n🏃 DRY RUN - No changes made")
 	fmt.Printf("Would create tag: %s\n", info.RCTag)
 	fmt.Printf("Base branch: %s\n", info.Branch)
@@ -145,7 +158,7 @@ func printDryRun(info rcInfo) {
 	}
 }
 
-func createRCRelease(ctx context.Context, client *gh.Client, info rcInfo) {
+func createRCRelease(ctx context.Context, client *gh.Client, info rcInfo) error {
 	// Draft releases don't create tags until published. Tag creation is what triggers artifacts to
 	// build and get attached to releases. So we create a tag here like how release-please does with
 	// force-tag-creation.
@@ -154,7 +167,7 @@ func createRCRelease(ctx context.Context, client *gh.Client, info rcInfo) {
 		SHA:     info.BranchSHA,
 		Message: fmt.Sprintf("Release candidate %s", info.RCTag),
 	}); err != nil {
-		log.Fatalf("Failed to create tag: %v", err)
+		return fmt.Errorf("creating tag: %w", err)
 	}
 	fmt.Printf("Created tag: %s -> %s\n", info.RCTag, info.BranchSHA[:12])
 
@@ -166,15 +179,16 @@ func createRCRelease(ctx context.Context, client *gh.Client, info rcInfo) {
 		PRNumber:  info.PR.GetNumber(),
 	})
 	if err != nil {
-		log.Fatalf("Failed to create draft prerelease: %v", err)
+		return fmt.Errorf("creating draft prerelease: %w", err)
 	}
 	fmt.Printf("✅ Created draft prerelease: %s\n", releaseURL)
+	return nil
 }
 
-func ensureBackportLabelForRC(ctx context.Context, client *gh.Client, info rcInfo) {
+func ensureBackportLabelForRC(ctx context.Context, client *gh.Client, info rcInfo) error {
 	majorMinor, err := version.MajorMinor(info.Version)
 	if err != nil {
-		log.Fatalf("Failed to parse major.minor from version %q: %v", info.Version, err)
+		return fmt.Errorf("parsing major.minor from version %q: %w", info.Version, err)
 	}
 	backportLabel := backportLabelPrefix + majorMinor
 	branchName := releaseBranchPrefix + majorMinor
@@ -185,13 +199,14 @@ func ensureBackportLabelForRC(ctx context.Context, client *gh.Client, info rcInf
 		Description: fmt.Sprintf("Backport to %s", branchName),
 	})
 	if err != nil {
-		log.Fatalf("Failed to ensure backport label: %v", err)
+		return fmt.Errorf("ensuring backport label: %w", err)
 	}
 	if created {
 		fmt.Printf("✅ Created backport label: %s\n", backportLabel)
 	} else {
 		fmt.Printf("Backport label %s already exists\n", backportLabel)
 	}
+	return nil
 }
 
 func findReleasePleasePR(ctx context.Context, client *gh.Client, baseBranch string) (*github.PullRequest, error) {

--- a/tools/release/createreleasebranch/command.go
+++ b/tools/release/createreleasebranch/command.go
@@ -1,10 +1,10 @@
-package main
+package createreleasebranch
 
 import (
 	"context"
-	"flag"
 	"fmt"
-	"log"
+
+	"github.com/spf13/cobra"
 
 	gh "github.com/grafana/alloy/tools/release/internal/github"
 	"github.com/grafana/alloy/tools/release/internal/version"
@@ -15,69 +15,76 @@ const (
 	backportLabelPrefix = "backport/v"
 )
 
-func main() {
-	var (
-		dryRun bool
-		tag    string
-	)
-	flag.BoolVar(&dryRun, "dry-run", false, "Dry run (do not create branch)")
-	flag.StringVar(&tag, "tag", "", "Release tag to branch from (e.g., v1.29.0)")
-	flag.Parse()
+type flags struct {
+	tag    string
+	dryRun bool
+}
 
-	if tag == "" {
-		log.Fatal("Release tag is required (use --tag flag, e.g., --tag v1.29.0)")
+func Command() *cobra.Command {
+	var flags flags
+
+	cmd := &cobra.Command{
+		Use:   "create-release-branch",
+		Short: "Create a release/vX.Y branch and matching backport label from a release tag",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(cmd.Context(), flags)
+		},
 	}
 
-	majorMinor, err := version.MajorMinor(tag)
+	cmd.Flags().StringVar(&flags.tag, "tag", "", "Release tag to branch from (e.g., v1.29.0)")
+	cmd.Flags().BoolVar(&flags.dryRun, "dry-run", false, "Dry run (do not create branch)")
+	_ = cmd.MarkFlagRequired("tag")
+
+	return cmd
+}
+
+func run(ctx context.Context, flags flags) error {
+	majorMinor, err := version.MajorMinor(flags.tag)
 	if err != nil {
-		log.Fatalf("Failed to parse version from tag %q: %v", tag, err)
+		return fmt.Errorf("parsing version from tag %q: %w", flags.tag, err)
 	}
-	fmt.Printf("Release tag: %s (major.minor: %s)\n", tag, majorMinor)
+	fmt.Printf("Release tag: %s (major.minor: %s)\n", flags.tag, majorMinor)
 
-	branchName := fmt.Sprintf("%s%s", releaseBranchPrefix, majorMinor)
+	branchName := releaseBranchPrefix + majorMinor
 	fmt.Printf("Release branch: %s\n", branchName)
 
-	backportLabel := fmt.Sprintf("%s%s", backportLabelPrefix, majorMinor)
+	backportLabel := backportLabelPrefix + majorMinor
 	fmt.Printf("Backport label: %s\n", backportLabel)
-
-	ctx := context.Background()
 
 	client, err := gh.NewClientFromEnv(ctx)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	exists, err := client.BranchExists(ctx, branchName)
 	if err != nil {
-		log.Fatalf("Failed to check if branch exists: %v", err)
+		return fmt.Errorf("checking if branch exists: %w", err)
 	}
 	if exists {
 		fmt.Printf("Branch %s already exists, skipping creation\n", branchName)
-		return
+		return nil
 	}
 
-	if dryRun {
+	if flags.dryRun {
 		fmt.Println("\n🏃 DRY RUN - No changes made")
 		fmt.Printf("Would create branch: %s\n", branchName)
 		fmt.Printf("Would create label: %s\n", backportLabel)
-		fmt.Printf("From tag: %s\n", tag)
-		return
+		fmt.Printf("From tag: %s\n", flags.tag)
+		return nil
 	}
 
-	// Get the SHA of the tag
-	tagSHA, err := client.GetRefSHA(ctx, tag)
+	tagSHA, err := client.GetRefSHA(ctx, flags.tag)
 	if err != nil {
-		log.Fatalf("Failed to get SHA for tag %s: %v", tag, err)
+		return fmt.Errorf("getting SHA for tag %s: %w", flags.tag, err)
 	}
 	fmt.Printf("Tag SHA: %s\n", tagSHA)
 
-	// Create the release branch
 	err = client.CreateBranch(ctx, gh.CreateBranchParams{
 		Branch: branchName,
 		SHA:    tagSHA,
 	})
 	if err != nil {
-		log.Fatalf("Failed to create branch: %v", err)
+		return fmt.Errorf("creating branch: %w", err)
 	}
 
 	fmt.Printf("✅ Created branch: %s\n", branchName)
@@ -89,11 +96,13 @@ func main() {
 		Description: fmt.Sprintf("Backport to %s", branchName),
 	})
 	if err != nil {
-		log.Fatalf("Failed to ensure label: %v", err)
+		return fmt.Errorf("ensuring label: %w", err)
 	}
 	if created {
 		fmt.Printf("✅ Created label: %s\n", backportLabel)
 	} else {
 		fmt.Printf("Label %s already exists\n", backportLabel)
 	}
+
+	return nil
 }

--- a/tools/release/enrichreleasenotes/command.go
+++ b/tools/release/enrichreleasenotes/command.go
@@ -1,18 +1,43 @@
-package main
+package enrichreleasenotes
 
 import (
 	"context"
-	"flag"
 	"fmt"
-	"log"
 	"os"
 	"regexp"
 	"strings"
 	"unicode"
 
+	"github.com/spf13/cobra"
+
 	gh "github.com/grafana/alloy/tools/release/internal/github"
 	"github.com/grafana/alloy/tools/release/internal/version"
 )
+
+type flags struct {
+	tag        string
+	footerFile string
+	dryRun     bool
+}
+
+func Command() *cobra.Command {
+	var flags flags
+
+	cmd := &cobra.Command{
+		Use:   "enrich-release-notes",
+		Short: "Add contributor attribution and an optional footer to a release's notes",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(cmd.Context(), flags)
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.tag, "tag", "", "Release tag to enrich (e.g., v1.15.0)")
+	cmd.Flags().StringVar(&flags.footerFile, "footer", "", "Path to footer template file (optional)")
+	cmd.Flags().BoolVar(&flags.dryRun, "dry-run", false, "Dry run (do not update release)")
+	_ = cmd.MarkFlagRequired("tag")
+
+	return cmd
+}
 
 // commitPattern matches a commit SHA in markdown link format: "([abc1234](https://github.com/.../commit/...))"
 // It captures the short SHA from the link text, regardless of surrounding context.
@@ -55,34 +80,18 @@ type commitAuthorsResponse struct {
 	} `json:"errors"`
 }
 
-func main() {
-	var (
-		tag        string
-		footerFile string
-		dryRun     bool
-	)
-	flag.StringVar(&tag, "tag", "", "Release tag to enrich (e.g., v1.15.0)")
-	flag.StringVar(&footerFile, "footer", "", "Path to footer template file (optional)")
-	flag.BoolVar(&dryRun, "dry-run", false, "Dry run (do not update release)")
-	flag.Parse()
-
-	if tag == "" {
-		log.Fatal("Release tag is required (use --tag flag)")
-	}
-
-	ctx := context.Background()
-
+func run(ctx context.Context, flags flags) error {
 	client, err := gh.NewClientFromEnv(ctx)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
-	fmt.Printf("📝 Enriching release notes for %s\n", tag)
+	fmt.Printf("📝 Enriching release notes for %s\n", flags.tag)
 
 	// Get the release by tag
-	release, err := client.GetReleaseByTag(ctx, tag)
+	release, err := client.GetReleaseByTag(ctx, flags.tag)
 	if err != nil {
-		log.Fatalf("Failed to get release: %v", err)
+		return fmt.Errorf("getting release: %w", err)
 	}
 
 	releaseBody := release.GetBody()
@@ -92,26 +101,26 @@ func main() {
 	newBody = addContributorInfo(ctx, client, newBody)
 
 	// Append the release notes footer if provided
-	if footerFile != "" {
-		newBody, err = appendFooter(newBody, tag, footerFile)
+	if flags.footerFile != "" {
+		newBody, err = appendFooter(newBody, flags.tag, flags.footerFile)
 		if err != nil {
-			log.Fatalf("Failed to append footer: %v", err)
+			return fmt.Errorf("appending footer: %w", err)
 		}
 	}
 
-	if dryRun {
+	if flags.dryRun {
 		fmt.Println("\n🏃 DRY RUN - No changes made")
 		fmt.Println("\n--- Updated release notes ---")
 		fmt.Println(newBody)
-		return
+		return nil
 	}
 
-	// Update the release
 	if err := client.UpdateReleaseBody(ctx, release.GetID(), newBody); err != nil {
-		log.Fatalf("Failed to update release: %v", err)
+		return fmt.Errorf("updating release: %w", err)
 	}
 
 	fmt.Println("✅ Release notes updated successfully")
+	return nil
 }
 
 // extractCommitSHA extracts a commit SHA from a changelog line.

--- a/tools/release/enrichreleasenotes/command_test.go
+++ b/tools/release/enrichreleasenotes/command_test.go
@@ -1,4 +1,4 @@
-package main
+package enrichreleasenotes
 
 import (
 	"os"


### PR DESCRIPTION
Migrate release go programs to tools cli.

I renamed directories and updated all of them to expose cobra commands. Nothing have changes functionality wise.