### PR TITLE
chore(renovate): Lower abandonment threshold

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,6 +17,9 @@
   // Updates must be published for at least 7 to be considered
   "minimumReleaseAge": "7 days",
 
+  // Surface abandonment signal in dependency dashboard after one year
+  "abandonmentThreshold": "365 days",
+
   "prConcurrentLimit": 5,
 
   // Move dependency files forward along with lock files


### PR DESCRIPTION
## Summary
- set Renovate `abandonmentThreshold` to `365 days`
- surface abandoned dependency signals in the dependency dashboard sooner

## Test plan
- [x] confirmed `.github/renovate.json5` includes `\"abandonmentThreshold\": \"365 days\"`