### PR TITLE
feat(exporter): Add opensearch otlp exporter

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank.yaml
+++ b/.github/ISSUE_TEMPLATE/blank.yaml
@@ -101,6 +101,7 @@ body:
       - otelcol.exporter.kafka
       - otelcol.exporter.loadbalancing
       - otelcol.exporter.loki
+      - otelcol.exporter.opensearch
       - otelcol.exporter.otlp
       - otelcol.exporter.otlphttp
       - otelcol.exporter.prometheus

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -101,6 +101,7 @@ body:
       - otelcol.exporter.kafka
       - otelcol.exporter.loadbalancing
       - otelcol.exporter.loki
+      - otelcol.exporter.opensearch
       - otelcol.exporter.otlp
       - otelcol.exporter.otlphttp
       - otelcol.exporter.prometheus

--- a/.github/ISSUE_TEMPLATE/docs.yaml
+++ b/.github/ISSUE_TEMPLATE/docs.yaml
@@ -104,6 +104,7 @@ body:
       - otelcol.exporter.kafka
       - otelcol.exporter.loadbalancing
       - otelcol.exporter.loki
+      - otelcol.exporter.opensearch
       - otelcol.exporter.otlp
       - otelcol.exporter.otlphttp
       - otelcol.exporter.prometheus

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -101,6 +101,7 @@ body:
       - otelcol.exporter.kafka
       - otelcol.exporter.loadbalancing
       - otelcol.exporter.loki
+      - otelcol.exporter.opensearch
       - otelcol.exporter.otlp
       - otelcol.exporter.otlphttp
       - otelcol.exporter.prometheus

--- a/.github/ISSUE_TEMPLATE/proposal.yaml
+++ b/.github/ISSUE_TEMPLATE/proposal.yaml
@@ -101,6 +101,7 @@ body:
       - otelcol.exporter.kafka
       - otelcol.exporter.loadbalancing
       - otelcol.exporter.loki
+      - otelcol.exporter.opensearch
       - otelcol.exporter.otlp
       - otelcol.exporter.otlphttp
       - otelcol.exporter.prometheus

--- a/collector/go.mod
+++ b/collector/go.mod
@@ -417,8 +417,9 @@ require (
 	github.com/elastic/go-freelru v0.16.0 // indirect
 	github.com/elastic/go-grok v0.3.1 // indirect
 	github.com/elastic/go-perf v0.0.0-20260224073651-af0ee0c731b7 // indirect
-	github.com/elastic/go-sysinfo v1.8.1 // indirect
-	github.com/elastic/go-windows v1.0.1 // indirect
+	github.com/elastic/go-structform v0.0.12 // indirect
+	github.com/elastic/go-sysinfo v1.15.3 // indirect
+	github.com/elastic/go-windows v1.0.2 // indirect
 	github.com/elastic/lunes v0.2.0 // indirect
 	github.com/ema/qdisc v1.0.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
@@ -620,7 +621,6 @@ require (
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
 	github.com/jessevdk/go-flags v1.6.1 // indirect
 	github.com/jmespath-community/go-jmespath v1.1.1 // indirect
-	github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 // indirect
 	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/josharian/native v1.1.0 // indirect
 	github.com/joyent/triton-go v1.8.5 // indirect
@@ -715,6 +715,7 @@ require (
 	github.com/oliver006/redis_exporter v1.81.0 // indirect
 	github.com/open-telemetry/opamp-go v0.23.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.147.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter v0.147.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension v0.147.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.147.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension v0.147.0 // indirect
@@ -763,6 +764,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opencontainers/runtime-spec v1.2.1 // indirect
 	github.com/opencontainers/selinux v1.13.0 // indirect
+	github.com/opensearch-project/opensearch-go/v4 v4.6.0 // indirect
 	github.com/openshift/api v3.9.0+incompatible // indirect
 	github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235 // indirect
 	github.com/opentracing-contrib/go-grpc v0.1.2 // indirect
@@ -1076,7 +1078,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/gotestsum v1.13.0 // indirect
-	howett.net/plist v1.0.0 // indirect
+	howett.net/plist v1.0.1 // indirect
 	k8s.io/api v0.35.3 // indirect
 	k8s.io/apiextensions-apiserver v0.35.0 // indirect
 	k8s.io/apimachinery v0.35.3 // indirect

--- a/collector/go.sum
+++ b/collector/go.sum
@@ -813,11 +813,14 @@ github.com/elastic/go-grok v0.3.1 h1:WEhUxe2KrwycMnlvMimJXvzRa7DoByJB4PVUIE1ZD/U
 github.com/elastic/go-grok v0.3.1/go.mod h1:n38ls8ZgOboZRgKcjMY8eFeZFMmcL9n2lP0iHhIDk64=
 github.com/elastic/go-perf v0.0.0-20260224073651-af0ee0c731b7 h1:fGi5uudj7m5O1RgQl+bSZmwlqvuUMEi97X7TzWBOMGk=
 github.com/elastic/go-perf v0.0.0-20260224073651-af0ee0c731b7/go.mod h1:ucTo2u8JvFyIPQOaRlX7aVF0d3wwmF1dy/PVp5GUHZI=
-github.com/elastic/go-sysinfo v1.8.1 h1:4Yhj+HdV6WjbCRgGdZpPJ8lZQlXZLKDAeIkmQ/VRvi4=
+github.com/elastic/go-structform v0.0.12 h1:HXpzlAKyej8T7LobqKDThUw7BMhwV6Db24VwxNtgxCs=
+github.com/elastic/go-structform v0.0.12/go.mod h1:CZWf9aIRYY5SuKSmOhtXScE5uQiLZNqAFnwKR4OrIM4=
 github.com/elastic/go-sysinfo v1.8.1/go.mod h1:JfllUnzoQV/JRYymbH3dO1yggI3mV2oTKSXsDHM+uIM=
+github.com/elastic/go-sysinfo v1.15.3 h1:W+RnmhKFkqPTCRoFq2VCTmsT4p/fwpo+3gKNQsn1XU0=
+github.com/elastic/go-sysinfo v1.15.3/go.mod h1:K/cNrqYTDrSoMh2oDkYEMS2+a72GRxMvNP+GC+vRIlo=
 github.com/elastic/go-windows v1.0.0/go.mod h1:TsU0Nrp7/y3+VwE82FoZF8gC/XFg/Elz6CcloAxnPgU=
-github.com/elastic/go-windows v1.0.1 h1:AlYZOldA+UJ0/2nBuqWdo90GFCgG9xuyw9SYzGUtJm0=
-github.com/elastic/go-windows v1.0.1/go.mod h1:FoVvqWSun28vaDQPbj2Elfc0JahhPB7WQEGa3c814Ss=
+github.com/elastic/go-windows v1.0.2 h1:yoLLsAsV5cfg9FLhZ9EXZ2n2sQFKeDYrHenkcivY4vI=
+github.com/elastic/go-windows v1.0.2/go.mod h1:bGcDpBzXgYSqM0Gx3DM4+UxFj300SZLixie9u9ixLM8=
 github.com/elastic/lunes v0.2.0 h1:WI3bsdOTuaYXVe2DS1KbqA7u7FOHN4o8qJw80ZyZoQs=
 github.com/elastic/lunes v0.2.0/go.mod h1:u3W/BdONWTrh0JjNZ21C907dDc+cUZttZrGa625nf2k=
 github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o=
@@ -1459,7 +1462,6 @@ github.com/jessevdk/go-flags v1.6.1/go.mod h1:Mk8T1hIAWpOiJiHa9rJASDK2UGWji0EuPG
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/jmespath-community/go-jmespath v1.1.1 h1:bFikPhsi/FdmlZhVgSCd2jj1e7G/rw+zyQfyg5UF+L4=
 github.com/jmespath-community/go-jmespath v1.1.1/go.mod h1:4gOyFJsR/Gk+05RgTKYrifT7tBPWD8Lubtb5jRrfy9I=
-github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 h1:rp+c0RAYOWj8l6qbCUTSiRLG/iKnW3K3/QfPPuSsBt4=
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901/go.mod h1:Z86h9688Y0wesXCyonoVr47MasHilkuLMqGhRZ4Hpak=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
@@ -1780,6 +1782,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.147.0/go.mod h1:CXjSPfbi7uiP9HcOscN5ultxy9YZ4RrSAgarO9tMnAM=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter v0.147.0 h1:MnXuUm0GE6F7yEDWcaz0AUahpEWNoEOmme0BuU/M8iE=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter v0.147.0/go.mod h1:lYH6RurrGDHMWRSy1FQDL9cVxOPiyXqHb9+gSZed8Nc=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter v0.147.0 h1:/uW4Vl727CXVfyWkPAxhhzemOIOlO2pDADV3mg0QqRU=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter v0.147.0/go.mod h1:eV/TQM0V+PTN0/ORxiRIsCxJqaktyTzNpVRhSzAhEaI=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.147.0 h1:8k93l6lIa1W4QQOU0/OH9BEKciBIJWPmrXW9n/esXJs=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.147.0/go.mod h1:dRxp6Gk8ngODlTz+Cayv3dxyfPPiE55bdV7hwBG6XwY=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.147.0 h1:lF1zkn8hSBmZCK4UjmKuiob+w48QiJtfLaAxb/9PVOQ=
@@ -1998,6 +2002,8 @@ github.com/opencontainers/runtime-spec v1.2.1 h1:S4k4ryNgEpxW1dzyqffOmhI1BHYcjzU
 github.com/opencontainers/runtime-spec v1.2.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.13.0 h1:Zza88GWezyT7RLql12URvoxsbLfjFx988+LGaWfbL84=
 github.com/opencontainers/selinux v1.13.0/go.mod h1:XxWTed+A/s5NNq4GmYScVy+9jzXhGBVEOAyucdRUY8s=
+github.com/opensearch-project/opensearch-go/v4 v4.6.0 h1:Ac8aLtDSmLEyOmv0r1qhQLw3b4vcUhE42NE9k+Z4cRc=
+github.com/opensearch-project/opensearch-go/v4 v4.6.0/go.mod h1:3iZtb4SNt3IzaxavKq0dURh1AmtVgYW71E4XqmYnIiQ=
 github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDDLDLFresAeYs=
 github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235 h1:9JBeIXmnHlpXTQPi7LPmu1jdxznBhAE7bb1K+3D8gxY=
@@ -2363,6 +2369,8 @@ github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhV
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/tidwall/tinylru v1.1.0/go.mod h1:3+bX+TJ2baOLMWTnlyNWHh4QMnFyARg2TLTQ6OFbzw8=
 github.com/tidwall/tinylru v1.2.1 h1:VgBr72c2IEr+V+pCdkPZUwiQ0KJknnWIYbhxAVkYfQk=
 github.com/tidwall/tinylru v1.2.1/go.mod h1:9bQnEduwB6inr2Y7AkBP7JPgCkyrhTV/ZpX0oOOpBI4=
@@ -2435,6 +2443,8 @@ github.com/vmware/govmomi v0.53.0 h1:e1bZCotAq7wm4xy95ePN2uoWwz28pNp/ewZZhpBY7/4
 github.com/vmware/govmomi v0.53.0/go.mod h1:EWfuzPfxT5NV+aS2we02SLFdhvJkgeY7t7+TszgBSMY=
 github.com/vultr/govultr/v2 v2.17.2 h1:gej/rwr91Puc/tgh+j33p/BLR16UrIPnSr+AIwYWZQs=
 github.com/vultr/govultr/v2 v2.17.2/go.mod h1:ZFOKGWmgjytfyjeyAdhQlSWwTjh2ig+X49cAp50dzXI=
+github.com/wI2L/jsondiff v0.7.0 h1:1lH1G37GhBPqCfp/lrs91rf/2j3DktX6qYAKZkLuCQQ=
+github.com/wI2L/jsondiff v0.7.0/go.mod h1:KAEIojdQq66oJiHhDyQez2x+sRit0vIzC9KeK0yizxM=
 github.com/wasilibs/go-re2 v1.9.0 h1:kjAd8qbNvV4Ve2Uf+zrpTCrDHtqH4dlsRXktywo73JQ=
 github.com/wasilibs/go-re2 v1.9.0/go.mod h1:0sRtscWgpUdNA137bmr1IUgrRX0Su4dcn9AEe61y+yI=
 github.com/wasilibs/wazero-helpers v0.0.0-20240620070341-3dff1577cd52 h1:OvLBa8SqJnZ6P+mjlzc2K7PM22rRUPE1x32G9DTPrC4=
@@ -2990,7 +3000,6 @@ golang.org/x/sys v0.0.0-20190529164535-6a60838ec259/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -3309,8 +3318,8 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 howett.net/plist v0.0.0-20181124034731-591f970eefbb/go.mod h1:vMygbs4qMhSZSc4lCUl2OEE+rDiIIJAIdR4m7MiMcm0=
-howett.net/plist v1.0.0 h1:7CrbWYbPPO/PyNy38b2EB/+gYbjCe2DXBxgtOOZbSQM=
-howett.net/plist v1.0.0/go.mod h1:lqaXoTrLY4hg8tnEzNru53gicrbv7rrk+2xJA/7hw9g=
+howett.net/plist v1.0.1 h1:37GdZ8tP09Q35o9ych3ehygcsL+HqKSwzctveSlarvM=
+howett.net/plist v1.0.1/go.mod h1:lqaXoTrLY4hg8tnEzNru53gicrbv7rrk+2xJA/7hw9g=
 k8s.io/api v0.35.3 h1:pA2fiBc6+N9PDf7SAiluKGEBuScsTzd2uYBkA5RzNWQ=
 k8s.io/api v0.35.3/go.mod h1:9Y9tkBcFwKNq2sxwZTQh1Njh9qHl81D0As56tu42GA4=
 k8s.io/apiextensions-apiserver v0.35.0 h1:3xHk2rTOdWXXJM+RDQZJvdx0yEOgC0FgQ1PlJatA5T4=

--- a/docs/sources/reference/compatibility/_index.md
+++ b/docs/sources/reference/compatibility/_index.md
@@ -330,6 +330,7 @@ The following components, grouped by namespace, _export_ OpenTelemetry `otelcol.
 - [otelcol.exporter.kafka](../components/otelcol/otelcol.exporter.kafka)
 - [otelcol.exporter.loadbalancing](../components/otelcol/otelcol.exporter.loadbalancing)
 - [otelcol.exporter.loki](../components/otelcol/otelcol.exporter.loki)
+- [otelcol.exporter.opensearch](../components/otelcol/otelcol.exporter.opensearch)
 - [otelcol.exporter.otlp](../components/otelcol/otelcol.exporter.otlp)
 - [otelcol.exporter.otlphttp](../components/otelcol/otelcol.exporter.otlphttp)
 - [otelcol.exporter.prometheus](../components/otelcol/otelcol.exporter.prometheus)

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.opensearch.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.opensearch.md
@@ -1,0 +1,197 @@
+---
+canonical: https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.exporter.opensearch/
+description: Learn about otelcol.exporter.opensearch
+labels:
+  products:
+    - oss
+  tags:
+    - text: Community
+      tooltip: This component is developed, maintained, and supported by the Alloy user community.
+title: otelcol.exporter.opensearch
+---
+
+# `otelcol.exporter.opensearch`
+
+{{< docs/shared lookup="stability/community.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+`otelcol.exporter.opensearch` accepts logs and traces from other `otelcol` components and sends them to OpenSearch through the bulk API.
+
+{{< admonition type="note" >}}
+`otelcol.exporter.opensearch` is a wrapper over the upstream OpenTelemetry Collector [`opensearch`][] exporter.
+Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`opensearch`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/exporter/opensearchexporter
+{{< /admonition >}}
+
+You can specify multiple `otelcol.exporter.opensearch` components by giving them different labels.
+
+## Usage
+
+```alloy
+otelcol.exporter.opensearch "<LABEL>" {
+    client {
+        endpoint = "http://localhost:9200"
+    }
+}
+```
+
+## Arguments
+
+You can use the following arguments with `otelcol.exporter.opensearch`:
+
+| Name                       | Type       | Description                                                                                              | Default       | Required |
+| -------------------------- | ---------- | -------------------------------------------------------------------------------------------------------- | ------------- | -------- |
+| `bulk_action`              | `string`   | Bulk action for ingestion. Must be `"create"` or `"index"`.                                              | `"create"`    | no       |
+| `dataset`                  | `string`   | Observability dataset name used in the default index pattern `ss4o_{type}-{dataset}-{namespace}`.        | `"default"`   | no       |
+| `logs_index_fallback`      | `string`   | Fallback logs index when routing fails.                                                                  | `""`          | no       |
+| `logs_index_time_format`   | `string`   | Time-format suffix for `logs_index`. Uses tokens such as `yyyy`, `yy`, `MM`, `dd`, `HH`, `mm`, and `ss`. | `""`          | no       |
+| `logs_index`               | `string`   | Index, alias, or data stream name for logs. Overrides the default `ss4o_logs-{dataset}-{namespace}`.     | `""`          | no       |
+| `namespace`                | `string`   | Observability namespace used in the default index pattern.                                               | `"namespace"` | no       |
+| `timeout`                  | `duration` | Maximum time to wait before the exporter treats a bulk request as failed. `0s` uses the client default.  | `"0s"`        | no       |
+| `traces_index_fallback`    | `string`   | Fallback traces index when routing fails.                                                                | `""`          | no       |
+| `traces_index_time_format` | `string`   | Time-format suffix for `traces_index`.                                                                   | `""`          | no       |
+| `traces_index`             | `string`   | Index, alias, or data stream name for traces. Overrides the default `ss4o_traces-{dataset}-{namespace}`. | `""`          | no       |
+
+## Blocks
+
+You can use the following blocks with `otelcol.exporter.opensearch`:
+
+{{< docs/alloy-config >}}
+
+| Block                                              | Description                                                                              | Required |
+|----------------------------------------------------|------------------------------------------------------------------------------------------|----------|
+| [`client`][client]                                 | Configures the HTTP client used to send data to OpenSearch.                              | yes      |
+| `client` > [`tls`][tls]                            | Configures TLS for the HTTP client.                                                      | no       |
+| [`debug_metrics`][debug_metrics]                   | Configures the metrics that this component generates to monitor its state.               | no       |
+| [`mapping`][mapping]                               | Configures the document mapping mode and field transforms.                               | no       |
+| [`retry_on_failure`][retry_on_failure]             | Configures retry mechanism for failed requests.                                          | no       |
+| [`sending_queue`][sending_queue]                   | Configures batching of data before sending.                                              | no       |
+| `sending_queue` > [`batch`][batch]                 | Configures batching requests based on a timeout and a minimum number of items.           | no       |
+
+[client]: #client
+[tls]: #tls
+[debug_metrics]: #debug_metrics
+[mapping]: #mapping
+[retry_on_failure]: #retry_on_failure
+[sending_queue]: #sending_queue
+[batch]: #batch
+
+{{< /docs/alloy-config >}}
+
+### `client`
+
+{{< badge text="Required" >}}
+
+The `client` block configures the HTTP client used by the component.
+
+{{< docs/shared lookup="reference/components/otelcol-http-client-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+#### `tls`
+
+The `tls` block configures TLS for the HTTP client.
+
+{{< docs/shared lookup="reference/components/otelcol-tls-client-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `debug_metrics`
+
+{{< docs/shared lookup="reference/components/otelcol-debug-metrics-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `mapping`
+
+The `mapping` block configures the OpenSearch document mapping.
+
+| Name              | Type          | Description                                                                                                                                                                       | Default  | Required |
+|-------------------|---------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|----------|
+| `mode`            | `string`      | Field mapping standard. One of `"ss4o"` (Simple Schema for Observability), `"ecs"`, `"flatten_attributes"`, or `"bodymap"` (logs only — body is stored verbatim).                  | `"ss4o"` | no       |
+| `fields`          | `map(string)` | Additional field mappings applied on top of the selected mode.                                                                                                                    | `{}`     | no       |
+| `file`            | `string`      | Path to an external file with additional field mappings.                                                                                                                          | `""`     | no       |
+| `timestamp_field` | `string`      | Document field where the record timestamp is stored.                                                                                                                              | `""`     | no       |
+| `unix_timestamp`  | `bool`        | Store the timestamp as Unix epoch milliseconds instead of an ISO-8601 string.                                                                                                     | `false`  | no       |
+| `dedup`           | `bool`        | Remove duplicate fields before sending.                                                                                                                                           | `false`  | no       |
+| `dedot`           | `bool`        | Replace dots in field names with underscores.                                                                                                                                     | `false`  | no       |
+
+### `retry_on_failure`
+
+The `retry_on_failure` block configures how failed requests to OpenSearch are retried.
+
+{{< docs/shared lookup="reference/components/otelcol-retry-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `sending_queue`
+
+The `sending_queue` block configures an in-memory buffer of batches before data is sent to OpenSearch.
+
+{{< docs/shared lookup="reference/components/otelcol-queue-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+#### `batch`
+
+The `batch` block configures batching requests based on a timeout and a minimum number of items.
+
+{{< docs/shared lookup="reference/components/otelcol-queue-batch-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+## Exported fields
+
+The following fields are exported and can be referenced by other components:
+
+| Name    | Type               | Description                                                 |
+|---------|--------------------|-------------------------------------------------------------|
+| `input` | `otelcol.Consumer` | A value other components can use to send telemetry data to. |
+
+`input` accepts `otelcol.Consumer` data for logs and traces.
+
+## Component health
+
+`otelcol.exporter.opensearch` is only reported as unhealthy if given an invalid configuration.
+
+## Debug information
+
+`otelcol.exporter.opensearch` doesn't expose any component-specific debug information.
+
+## Example
+
+Forward OTLP logs and traces from an OTLP receiver to a local OpenSearch cluster:
+
+```alloy
+otelcol.receiver.otlp "default" {
+    http {}
+    grpc {}
+
+    output {
+        logs   = [otelcol.exporter.opensearch.default.input]
+        traces = [otelcol.exporter.opensearch.default.input]
+    }
+}
+
+otelcol.exporter.opensearch "default" {
+    dataset   = "kubernetes"
+    namespace = "production"
+
+    client {
+        endpoint = "https://opensearch.internal:9200"
+        tls {
+            insecure_skip_verify = true
+        }
+    }
+
+    mapping {
+        mode = "ss4o"
+    }
+}
+```
+
+With this configuration the exporter writes to data streams matching the SS4O naming convention: `ss4o_logs-kubernetes-production` and `ss4o_traces-kubernetes-production`.
+
+To target a static index instead, set `logs_index` and `traces_index` explicitly.
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.exporter.opensearch` has exports that can be consumed by the following components:
+
+- Components that consume [OpenTelemetry `otelcol.Consumer`](../../../compatibility/#opentelemetry-otelcolconsumer-consumers)
+
+{{< admonition type="note" >}}
+Connecting some components may not be sensible or components may require further configuration to make the connection work correctly.
+Refer to the linked documentation for more details.
+{{< /admonition >}}
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/go.mod
+++ b/go.mod
@@ -126,6 +126,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter v0.147.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.147.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter v0.147.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter v0.147.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.147.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter v0.147.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/syslogexporter v0.147.0
@@ -554,8 +555,8 @@ require (
 	github.com/efficientgo/core v1.0.0-rc.3 // indirect
 	github.com/elastic/go-grok v0.3.1 // indirect
 	github.com/elastic/go-perf v0.0.0-20260224073651-af0ee0c731b7 // indirect
-	github.com/elastic/go-sysinfo v1.8.1 // indirect
-	github.com/elastic/go-windows v1.0.1 // indirect
+	github.com/elastic/go-sysinfo v1.15.3 // indirect
+	github.com/elastic/go-windows v1.0.2 // indirect
 	github.com/elastic/lunes v0.2.0 // indirect
 	github.com/ema/qdisc v1.0.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
@@ -685,7 +686,6 @@ require (
 	github.com/jcmturner/gokrb5/v8 v8.4.4 // indirect
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
 	github.com/jessevdk/go-flags v1.6.1 // indirect
-	github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 // indirect
 	github.com/josharian/native v1.1.0 // indirect
 	github.com/joyent/triton-go v1.8.5 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
@@ -965,7 +965,7 @@ require (
 	gopkg.in/ini.v1 v1.67.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	howett.net/plist v1.0.0 // indirect
+	howett.net/plist v1.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.35.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260330154417-16be699c7b31 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
@@ -1047,6 +1047,7 @@ require (
 	github.com/containerd/containerd/api v1.9.0 // indirect
 	github.com/containerd/typeurl/v2 v2.2.3 // indirect
 	github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707 // indirect
+	github.com/elastic/go-structform v0.0.12 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/fatih/semgroup v1.2.0 // indirect
 	github.com/gitleaks/go-gitdiff v0.9.1 // indirect
@@ -1082,6 +1083,7 @@ require (
 	github.com/nwaples/rardecode/v2 v2.2.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/internal/credentialsfile v0.147.0 // indirect
 	github.com/opencontainers/cgroups v0.0.4 // indirect
+	github.com/opensearch-project/opensearch-go/v4 v4.6.0 // indirect
 	github.com/oschwald/maxminddb-golang/v2 v2.2.0 // indirect
 	github.com/paulmach/orb v0.12.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -861,11 +861,14 @@ github.com/elastic/go-grok v0.3.1 h1:WEhUxe2KrwycMnlvMimJXvzRa7DoByJB4PVUIE1ZD/U
 github.com/elastic/go-grok v0.3.1/go.mod h1:n38ls8ZgOboZRgKcjMY8eFeZFMmcL9n2lP0iHhIDk64=
 github.com/elastic/go-perf v0.0.0-20260224073651-af0ee0c731b7 h1:fGi5uudj7m5O1RgQl+bSZmwlqvuUMEi97X7TzWBOMGk=
 github.com/elastic/go-perf v0.0.0-20260224073651-af0ee0c731b7/go.mod h1:ucTo2u8JvFyIPQOaRlX7aVF0d3wwmF1dy/PVp5GUHZI=
-github.com/elastic/go-sysinfo v1.8.1 h1:4Yhj+HdV6WjbCRgGdZpPJ8lZQlXZLKDAeIkmQ/VRvi4=
+github.com/elastic/go-structform v0.0.12 h1:HXpzlAKyej8T7LobqKDThUw7BMhwV6Db24VwxNtgxCs=
+github.com/elastic/go-structform v0.0.12/go.mod h1:CZWf9aIRYY5SuKSmOhtXScE5uQiLZNqAFnwKR4OrIM4=
 github.com/elastic/go-sysinfo v1.8.1/go.mod h1:JfllUnzoQV/JRYymbH3dO1yggI3mV2oTKSXsDHM+uIM=
+github.com/elastic/go-sysinfo v1.15.3 h1:W+RnmhKFkqPTCRoFq2VCTmsT4p/fwpo+3gKNQsn1XU0=
+github.com/elastic/go-sysinfo v1.15.3/go.mod h1:K/cNrqYTDrSoMh2oDkYEMS2+a72GRxMvNP+GC+vRIlo=
 github.com/elastic/go-windows v1.0.0/go.mod h1:TsU0Nrp7/y3+VwE82FoZF8gC/XFg/Elz6CcloAxnPgU=
-github.com/elastic/go-windows v1.0.1 h1:AlYZOldA+UJ0/2nBuqWdo90GFCgG9xuyw9SYzGUtJm0=
-github.com/elastic/go-windows v1.0.1/go.mod h1:FoVvqWSun28vaDQPbj2Elfc0JahhPB7WQEGa3c814Ss=
+github.com/elastic/go-windows v1.0.2 h1:yoLLsAsV5cfg9FLhZ9EXZ2n2sQFKeDYrHenkcivY4vI=
+github.com/elastic/go-windows v1.0.2/go.mod h1:bGcDpBzXgYSqM0Gx3DM4+UxFj300SZLixie9u9ixLM8=
 github.com/elastic/lunes v0.2.0 h1:WI3bsdOTuaYXVe2DS1KbqA7u7FOHN4o8qJw80ZyZoQs=
 github.com/elastic/lunes v0.2.0/go.mod h1:u3W/BdONWTrh0JjNZ21C907dDc+cUZttZrGa625nf2k=
 github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o=
@@ -1528,7 +1531,6 @@ github.com/jmespath-community/go-jmespath v1.1.1 h1:bFikPhsi/FdmlZhVgSCd2jj1e7G/
 github.com/jmespath-community/go-jmespath v1.1.1/go.mod h1:4gOyFJsR/Gk+05RgTKYrifT7tBPWD8Lubtb5jRrfy9I=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
-github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 h1:rp+c0RAYOWj8l6qbCUTSiRLG/iKnW3K3/QfPPuSsBt4=
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901/go.mod h1:Z86h9688Y0wesXCyonoVr47MasHilkuLMqGhRZ4Hpak=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
@@ -1856,6 +1858,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.147.0/go.mod h1:CXjSPfbi7uiP9HcOscN5ultxy9YZ4RrSAgarO9tMnAM=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter v0.147.0 h1:MnXuUm0GE6F7yEDWcaz0AUahpEWNoEOmme0BuU/M8iE=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter v0.147.0/go.mod h1:lYH6RurrGDHMWRSy1FQDL9cVxOPiyXqHb9+gSZed8Nc=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter v0.147.0 h1:/uW4Vl727CXVfyWkPAxhhzemOIOlO2pDADV3mg0QqRU=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter v0.147.0/go.mod h1:eV/TQM0V+PTN0/ORxiRIsCxJqaktyTzNpVRhSzAhEaI=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.147.0 h1:8k93l6lIa1W4QQOU0/OH9BEKciBIJWPmrXW9n/esXJs=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.147.0/go.mod h1:dRxp6Gk8ngODlTz+Cayv3dxyfPPiE55bdV7hwBG6XwY=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter v0.147.0 h1:ahzbHptTD80rbSUEEW7hDttuUQ5wneevzRrnDAeAwgI=
@@ -2036,6 +2040,8 @@ github.com/opencontainers/runtime-spec v1.2.1 h1:S4k4ryNgEpxW1dzyqffOmhI1BHYcjzU
 github.com/opencontainers/runtime-spec v1.2.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.13.0 h1:Zza88GWezyT7RLql12URvoxsbLfjFx988+LGaWfbL84=
 github.com/opencontainers/selinux v1.13.0/go.mod h1:XxWTed+A/s5NNq4GmYScVy+9jzXhGBVEOAyucdRUY8s=
+github.com/opensearch-project/opensearch-go/v4 v4.6.0 h1:Ac8aLtDSmLEyOmv0r1qhQLw3b4vcUhE42NE9k+Z4cRc=
+github.com/opensearch-project/opensearch-go/v4 v4.6.0/go.mod h1:3iZtb4SNt3IzaxavKq0dURh1AmtVgYW71E4XqmYnIiQ=
 github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDDLDLFresAeYs=
 github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235 h1:9JBeIXmnHlpXTQPi7LPmu1jdxznBhAE7bb1K+3D8gxY=
@@ -2407,6 +2413,8 @@ github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhV
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/tidwall/tinylru v1.1.0/go.mod h1:3+bX+TJ2baOLMWTnlyNWHh4QMnFyARg2TLTQ6OFbzw8=
 github.com/tidwall/tinylru v1.2.1 h1:VgBr72c2IEr+V+pCdkPZUwiQ0KJknnWIYbhxAVkYfQk=
 github.com/tidwall/tinylru v1.2.1/go.mod h1:9bQnEduwB6inr2Y7AkBP7JPgCkyrhTV/ZpX0oOOpBI4=
@@ -2481,6 +2489,8 @@ github.com/vmware/govmomi v0.53.0 h1:e1bZCotAq7wm4xy95ePN2uoWwz28pNp/ewZZhpBY7/4
 github.com/vmware/govmomi v0.53.0/go.mod h1:EWfuzPfxT5NV+aS2we02SLFdhvJkgeY7t7+TszgBSMY=
 github.com/vultr/govultr/v2 v2.17.2 h1:gej/rwr91Puc/tgh+j33p/BLR16UrIPnSr+AIwYWZQs=
 github.com/vultr/govultr/v2 v2.17.2/go.mod h1:ZFOKGWmgjytfyjeyAdhQlSWwTjh2ig+X49cAp50dzXI=
+github.com/wI2L/jsondiff v0.7.0 h1:1lH1G37GhBPqCfp/lrs91rf/2j3DktX6qYAKZkLuCQQ=
+github.com/wI2L/jsondiff v0.7.0/go.mod h1:KAEIojdQq66oJiHhDyQez2x+sRit0vIzC9KeK0yizxM=
 github.com/wasilibs/go-re2 v1.9.0 h1:kjAd8qbNvV4Ve2Uf+zrpTCrDHtqH4dlsRXktywo73JQ=
 github.com/wasilibs/go-re2 v1.9.0/go.mod h1:0sRtscWgpUdNA137bmr1IUgrRX0Su4dcn9AEe61y+yI=
 github.com/wasilibs/wazero-helpers v0.0.0-20240620070341-3dff1577cd52 h1:OvLBa8SqJnZ6P+mjlzc2K7PM22rRUPE1x32G9DTPrC4=
@@ -3042,7 +3052,6 @@ golang.org/x/sys v0.0.0-20190529164535-6a60838ec259/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -3373,8 +3382,8 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 howett.net/plist v0.0.0-20181124034731-591f970eefbb/go.mod h1:vMygbs4qMhSZSc4lCUl2OEE+rDiIIJAIdR4m7MiMcm0=
-howett.net/plist v1.0.0 h1:7CrbWYbPPO/PyNy38b2EB/+gYbjCe2DXBxgtOOZbSQM=
-howett.net/plist v1.0.0/go.mod h1:lqaXoTrLY4hg8tnEzNru53gicrbv7rrk+2xJA/7hw9g=
+howett.net/plist v1.0.1 h1:37GdZ8tP09Q35o9ych3ehygcsL+HqKSwzctveSlarvM=
+howett.net/plist v1.0.1/go.mod h1:lqaXoTrLY4hg8tnEzNru53gicrbv7rrk+2xJA/7hw9g=
 k8s.io/api v0.35.3 h1:pA2fiBc6+N9PDf7SAiluKGEBuScsTzd2uYBkA5RzNWQ=
 k8s.io/api v0.35.3/go.mod h1:9Y9tkBcFwKNq2sxwZTQh1Njh9qHl81D0As56tu42GA4=
 k8s.io/apiextensions-apiserver v0.35.0 h1:3xHk2rTOdWXXJM+RDQZJvdx0yEOgC0FgQ1PlJatA5T4=

--- a/internal/component/all/all.go
+++ b/internal/component/all/all.go
@@ -84,6 +84,7 @@ import (
 	_ "github.com/grafana/alloy/internal/component/otelcol/exporter/kafka"                   // Import otelcol.exporter.kafka
 	_ "github.com/grafana/alloy/internal/component/otelcol/exporter/loadbalancing"           // Import otelcol.exporter.loadbalancing
 	_ "github.com/grafana/alloy/internal/component/otelcol/exporter/loki"                    // Import otelcol.exporter.loki
+	_ "github.com/grafana/alloy/internal/component/otelcol/exporter/opensearch"              // Import otelcol.exporter.opensearch
 	_ "github.com/grafana/alloy/internal/component/otelcol/exporter/otlp"                    // Import otelcol.exporter.otlp
 	_ "github.com/grafana/alloy/internal/component/otelcol/exporter/otlphttp"                // Import otelcol.exporter.otlphttp
 	_ "github.com/grafana/alloy/internal/component/otelcol/exporter/prometheus"              // Import otelcol.exporter.prometheus

--- a/internal/component/otelcol/exporter/opensearch/config/opensearch.go
+++ b/internal/component/otelcol/exporter/opensearch/config/opensearch.go
@@ -1,0 +1,173 @@
+// Package config contains configuration arguments for the
+// otelcol.exporter.opensearch component.
+package config
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/grafana/alloy/internal/component/otelcol"
+	otelcolCfg "github.com/grafana/alloy/internal/component/otelcol/config"
+	"github.com/grafana/alloy/syntax"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter"
+	otelcomponent "go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/pipeline"
+)
+
+const (
+	BulkActionCreate = "create"
+	BulkActionIndex  = "index"
+
+	MappingSS4O              = "ss4o"
+	MappingECS               = "ecs"
+	MappingFlattenAttributes = "flatten_attributes"
+	MappingBodyMap           = "bodymap"
+)
+
+// OpenSearchArguments configures the otelcol.exporter.opensearch component.
+type OpenSearchArguments struct {
+	Dataset   string `alloy:"dataset,attr,optional"`
+	Namespace string `alloy:"namespace,attr,optional"`
+
+	LogsIndex           string `alloy:"logs_index,attr,optional"`
+	LogsIndexFallback   string `alloy:"logs_index_fallback,attr,optional"`
+	LogsIndexTimeFormat string `alloy:"logs_index_time_format,attr,optional"`
+
+	TracesIndex           string `alloy:"traces_index,attr,optional"`
+	TracesIndexFallback   string `alloy:"traces_index_fallback,attr,optional"`
+	TracesIndexTimeFormat string `alloy:"traces_index_time_format,attr,optional"`
+
+	BulkAction string        `alloy:"bulk_action,attr,optional"`
+	Timeout    time.Duration `alloy:"timeout,attr,optional"`
+
+	Client  otelcol.HTTPClientArguments `alloy:"client,block"`
+	Mapping MappingArguments            `alloy:"mapping,block,optional"`
+
+	SendingQueue otelcol.QueueArguments `alloy:"sending_queue,block,optional"`
+	Retry        otelcol.RetryArguments `alloy:"retry_on_failure,block,optional"`
+
+	DebugMetrics otelcolCfg.DebugMetricsArguments `alloy:"debug_metrics,block,optional"`
+}
+
+// MappingArguments configures OpenSearch field-mapping behavior.
+type MappingArguments struct {
+	Mode           string            `alloy:"mode,attr,optional"`
+	Fields         map[string]string `alloy:"fields,attr,optional"`
+	File           string            `alloy:"file,attr,optional"`
+	TimestampField string            `alloy:"timestamp_field,attr,optional"`
+	UnixTimestamp  bool              `alloy:"unix_timestamp,attr,optional"`
+	Dedup          bool              `alloy:"dedup,attr,optional"`
+	Dedot          bool              `alloy:"dedot,attr,optional"`
+}
+
+var (
+	_ syntax.Defaulter = (*OpenSearchArguments)(nil)
+	_ syntax.Validator = (*OpenSearchArguments)(nil)
+)
+
+// SetToDefault implements syntax.Defaulter.
+func (args *OpenSearchArguments) SetToDefault() {
+	*args = OpenSearchArguments{
+		Dataset:    "default",
+		Namespace:  "namespace",
+		BulkAction: BulkActionCreate,
+	}
+	args.Mapping.SetToDefault()
+	args.SendingQueue.SetToDefault()
+	args.Retry.SetToDefault()
+	args.DebugMetrics.SetToDefault()
+}
+
+// SetToDefault implements syntax.Defaulter.
+func (args *MappingArguments) SetToDefault() {
+	*args = MappingArguments{
+		Mode: MappingSS4O,
+	}
+}
+
+// Validate implements syntax.Validator.
+func (args *OpenSearchArguments) Validate() error {
+	if args.Client.Endpoint == "" {
+		return errors.New("client endpoint must be specified")
+	}
+	if args.Dataset == "" {
+		return errors.New("dataset must be specified")
+	}
+	if args.Namespace == "" {
+		return errors.New("namespace must be specified")
+	}
+	if args.BulkAction != BulkActionCreate && args.BulkAction != BulkActionIndex {
+		return fmt.Errorf("bulk_action must be %q or %q", BulkActionCreate, BulkActionIndex)
+	}
+	switch args.Mapping.Mode {
+	case MappingSS4O, MappingECS, MappingFlattenAttributes, MappingBodyMap:
+	default:
+		return fmt.Errorf("mapping.mode must be one of %q, %q, %q, or %q",
+			MappingSS4O, MappingECS, MappingFlattenAttributes, MappingBodyMap)
+	}
+	return nil
+}
+
+// Convert implements exporter.Arguments.
+func (args OpenSearchArguments) Convert() (otelcomponent.Config, error) {
+	clientCfg, err := args.Client.Convert()
+	if err != nil {
+		return nil, err
+	}
+
+	q, err := args.SendingQueue.Convert()
+	if err != nil {
+		return nil, err
+	}
+
+	return &opensearchexporter.Config{
+		ClientConfig:  *clientCfg,
+		BackOffConfig: *args.Retry.Convert(),
+		TimeoutSettings: exporterhelper.TimeoutConfig{
+			Timeout: args.Timeout,
+		},
+		MappingsSettings: opensearchexporter.MappingsSettings{
+			Mode:           args.Mapping.Mode,
+			Fields:         args.Mapping.Fields,
+			File:           args.Mapping.File,
+			TimestampField: args.Mapping.TimestampField,
+			UnixTimestamp:  args.Mapping.UnixTimestamp,
+			Dedup:          args.Mapping.Dedup,
+			Dedot:          args.Mapping.Dedot,
+		},
+		QueueConfig:           q,
+		Dataset:               args.Dataset,
+		Namespace:             args.Namespace,
+		LogsIndex:             args.LogsIndex,
+		LogsIndexFallback:     args.LogsIndexFallback,
+		LogsIndexTimeFormat:   args.LogsIndexTimeFormat,
+		TracesIndex:           args.TracesIndex,
+		TracesIndexFallback:   args.TracesIndexFallback,
+		TracesIndexTimeFormat: args.TracesIndexTimeFormat,
+		BulkAction:            args.BulkAction,
+	}, nil
+}
+
+// Extensions implements exporter.Arguments.
+func (args OpenSearchArguments) Extensions() map[otelcomponent.ID]otelcomponent.Component {
+	m := make(map[otelcomponent.ID]otelcomponent.Component)
+	for k, v := range args.Client.Extensions() {
+		m[k] = v
+	}
+	for k, v := range args.SendingQueue.Extensions() {
+		m[k] = v
+	}
+	return m
+}
+
+// Exporters implements exporter.Arguments.
+func (args OpenSearchArguments) Exporters() map[pipeline.Signal]map[otelcomponent.ID]otelcomponent.Component {
+	return nil
+}
+
+// DebugMetricsConfig implements exporter.Arguments.
+func (args OpenSearchArguments) DebugMetricsConfig() otelcolCfg.DebugMetricsArguments {
+	return args.DebugMetrics
+}

--- a/internal/component/otelcol/exporter/opensearch/config/opensearch_test.go
+++ b/internal/component/otelcol/exporter/opensearch/config/opensearch_test.go
@@ -1,0 +1,172 @@
+package config_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/alloy/internal/component/otelcol/exporter/opensearch/config"
+	"github.com/grafana/alloy/syntax"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigConversion_Minimal(t *testing.T) {
+	alloyCfg := `
+		client {
+			endpoint = "http://localhost:9200"
+		}
+	`
+
+	var args config.OpenSearchArguments
+	require.NoError(t, syntax.Unmarshal([]byte(alloyCfg), &args))
+
+	otelCfg, err := args.Convert()
+	require.NoError(t, err)
+
+	cfg := otelCfg.(*opensearchexporter.Config)
+	require.Equal(t, "http://localhost:9200", cfg.ClientConfig.Endpoint)
+	require.Equal(t, "default", cfg.Dataset)
+	require.Equal(t, "namespace", cfg.Namespace)
+	require.Equal(t, "create", cfg.BulkAction)
+	require.Equal(t, "ss4o", cfg.MappingsSettings.Mode)
+}
+
+func TestConfigConversion_Full(t *testing.T) {
+	alloyCfg := `
+		dataset                  = "k8s"
+		namespace                = "prod"
+		logs_index               = "logs-cluster"
+		logs_index_fallback      = "logs-fallback"
+		logs_index_time_format   = "yyyy.MM.dd"
+		traces_index             = "traces-cluster"
+		traces_index_fallback    = "traces-fallback"
+		traces_index_time_format = "yyyy.MM.dd"
+		bulk_action              = "index"
+		timeout                  = "30s"
+
+		client {
+			endpoint = "https://opensearch:9200"
+			tls {
+				insecure_skip_verify = true
+			}
+		}
+
+		mapping {
+			mode            = "ecs"
+			timestamp_field = "@timestamp"
+			unix_timestamp  = true
+			dedup           = true
+			dedot           = false
+			fields = {
+				"k8s.namespace.name" = "kubernetes.namespace",
+			}
+		}
+
+		retry_on_failure {
+			enabled          = true
+			initial_interval = "1s"
+			max_interval     = "30s"
+		}
+
+		sending_queue {
+			enabled       = true
+			num_consumers = 5
+			queue_size    = 200
+		}
+	`
+
+	var args config.OpenSearchArguments
+	require.NoError(t, syntax.Unmarshal([]byte(alloyCfg), &args))
+
+	otelCfg, err := args.Convert()
+	require.NoError(t, err)
+
+	cfg := otelCfg.(*opensearchexporter.Config)
+	require.Equal(t, "https://opensearch:9200", cfg.ClientConfig.Endpoint)
+	require.True(t, cfg.ClientConfig.TLS.InsecureSkipVerify)
+	require.Equal(t, "k8s", cfg.Dataset)
+	require.Equal(t, "prod", cfg.Namespace)
+	require.Equal(t, "logs-cluster", cfg.LogsIndex)
+	require.Equal(t, "logs-fallback", cfg.LogsIndexFallback)
+	require.Equal(t, "yyyy.MM.dd", cfg.LogsIndexTimeFormat)
+	require.Equal(t, "traces-cluster", cfg.TracesIndex)
+	require.Equal(t, "traces-fallback", cfg.TracesIndexFallback)
+	require.Equal(t, "yyyy.MM.dd", cfg.TracesIndexTimeFormat)
+	require.Equal(t, "index", cfg.BulkAction)
+	require.Equal(t, 30*time.Second, cfg.TimeoutSettings.Timeout)
+	require.Equal(t, "ecs", cfg.MappingsSettings.Mode)
+	require.True(t, cfg.MappingsSettings.UnixTimestamp)
+	require.True(t, cfg.MappingsSettings.Dedup)
+	require.False(t, cfg.MappingsSettings.Dedot)
+	require.Equal(t, "@timestamp", cfg.MappingsSettings.TimestampField)
+	require.Equal(t, map[string]string{"k8s.namespace.name": "kubernetes.namespace"}, cfg.MappingsSettings.Fields)
+	require.True(t, cfg.BackOffConfig.Enabled)
+	require.Equal(t, time.Second, cfg.BackOffConfig.InitialInterval)
+	require.True(t, cfg.QueueConfig.HasValue())
+	require.Equal(t, 5, cfg.QueueConfig.Get().NumConsumers)
+	require.Equal(t, int64(200), cfg.QueueConfig.Get().QueueSize)
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		alloyCfg    string
+		expectError string
+	}{
+		{
+			name:     "valid minimal",
+			alloyCfg: `client { endpoint = "http://localhost:9200" }`,
+		},
+		{
+			name: "missing dataset",
+			alloyCfg: `
+				client { endpoint = "http://localhost:9200" }
+				dataset = ""
+			`,
+			expectError: "dataset must be specified",
+		},
+		{
+			name: "missing namespace",
+			alloyCfg: `
+				client { endpoint = "http://localhost:9200" }
+				namespace = ""
+			`,
+			expectError: "namespace must be specified",
+		},
+		{
+			name: "invalid bulk_action",
+			alloyCfg: `
+				client { endpoint = "http://localhost:9200" }
+				bulk_action = "update"
+			`,
+			expectError: "bulk_action must be",
+		},
+		{
+			name: "invalid mapping mode",
+			alloyCfg: `
+				client { endpoint = "http://localhost:9200" }
+				mapping { mode = "invalid" }
+			`,
+			expectError: "mapping.mode must be one of",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var args config.OpenSearchArguments
+			err := syntax.Unmarshal([]byte(tc.alloyCfg), &args)
+			if tc.expectError == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectError)
+			}
+		})
+	}
+}
+
+func TestDebugMetricsConfig(t *testing.T) {
+	var args config.OpenSearchArguments
+	require.NoError(t, syntax.Unmarshal([]byte(`client { endpoint = "http://localhost:9200" }`), &args))
+	require.True(t, args.DebugMetricsConfig().DisableHighCardinalityMetrics)
+}

--- a/internal/component/otelcol/exporter/opensearch/opensearch.go
+++ b/internal/component/otelcol/exporter/opensearch/opensearch.go
@@ -1,0 +1,26 @@
+// Package opensearch provides an otelcol.exporter.opensearch component.
+package opensearch
+
+import (
+	"github.com/grafana/alloy/internal/component"
+	"github.com/grafana/alloy/internal/component/otelcol"
+	"github.com/grafana/alloy/internal/component/otelcol/exporter"
+	"github.com/grafana/alloy/internal/component/otelcol/exporter/opensearch/config"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:      "otelcol.exporter.opensearch",
+		Community: true,
+		Args:      config.OpenSearchArguments{},
+		Exports:   otelcol.ConsumerExports{},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			fact := opensearchexporter.NewFactory()
+			return exporter.New(opts, fact, args.(config.OpenSearchArguments), exporter.TypeSignalConstFunc(exporter.TypeLogs|exporter.TypeTraces))
+		},
+	})
+}
+
+var _ exporter.Arguments = config.OpenSearchArguments{}

--- a/internal/converter/internal/otelcolconvert/converter_opensearchexporter.go
+++ b/internal/converter/internal/otelcolconvert/converter_opensearchexporter.go
@@ -1,0 +1,72 @@
+package otelcolconvert
+
+import (
+	"fmt"
+
+	"github.com/grafana/alloy/internal/component/otelcol/exporter/opensearch/config"
+	"github.com/grafana/alloy/internal/converter/diag"
+	"github.com/grafana/alloy/internal/converter/internal/common"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componentstatus"
+)
+
+func init() {
+	converters = append(converters, opensearchExporterConverter{})
+}
+
+type opensearchExporterConverter struct{}
+
+func (opensearchExporterConverter) Factory() component.Factory {
+	return opensearchexporter.NewFactory()
+}
+
+func (opensearchExporterConverter) InputComponentName() string {
+	return "otelcol.exporter.opensearch"
+}
+
+func (opensearchExporterConverter) ConvertAndAppend(state *State, id componentstatus.InstanceID, cfg component.Config) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	label := state.AlloyComponentLabel()
+	args := toOpenSearchExporter(cfg.(*opensearchexporter.Config))
+	block := common.NewBlockWithOverrideFn([]string{"otelcol", "exporter", "opensearch"}, label, args, common.GetAlloyTypesOverrideHook())
+
+	diags.Add(
+		diag.SeverityLevelInfo,
+		fmt.Sprintf("Converted %s into %s", StringifyInstanceID(id), StringifyBlock(block)),
+	)
+
+	state.Body().AppendBlock(block)
+	return diags
+}
+
+func toOpenSearchExporter(cfg *opensearchexporter.Config) *config.OpenSearchArguments {
+	return &config.OpenSearchArguments{
+		Dataset:               cfg.Dataset,
+		Namespace:             cfg.Namespace,
+		LogsIndex:             cfg.LogsIndex,
+		LogsIndexFallback:     cfg.LogsIndexFallback,
+		LogsIndexTimeFormat:   cfg.LogsIndexTimeFormat,
+		TracesIndex:           cfg.TracesIndex,
+		TracesIndexFallback:   cfg.TracesIndexFallback,
+		TracesIndexTimeFormat: cfg.TracesIndexTimeFormat,
+		BulkAction:            cfg.BulkAction,
+		Timeout:               cfg.TimeoutSettings.Timeout,
+
+		Client: toHTTPClientArguments(cfg.ClientConfig),
+		Mapping: config.MappingArguments{
+			Mode:           cfg.MappingsSettings.Mode,
+			Fields:         cfg.MappingsSettings.Fields,
+			File:           cfg.MappingsSettings.File,
+			TimestampField: cfg.MappingsSettings.TimestampField,
+			UnixTimestamp:  cfg.MappingsSettings.UnixTimestamp,
+			Dedup:          cfg.MappingsSettings.Dedup,
+			Dedot:          cfg.MappingsSettings.Dedot,
+		},
+
+		SendingQueue: toQueueArguments(cfg.QueueConfig),
+		Retry:        toRetryArguments(cfg.BackOffConfig),
+		DebugMetrics: common.DefaultValue[config.OpenSearchArguments]().DebugMetrics,
+	}
+}

--- a/internal/converter/internal/otelcolconvert/testdata/opensearch.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/opensearch.alloy
@@ -1,0 +1,36 @@
+otelcol.receiver.otlp "default" {
+	grpc {
+		endpoint = "localhost:4317"
+	}
+
+	output {
+		logs   = [otelcol.exporter.opensearch.default.input]
+		traces = [otelcol.exporter.opensearch.default.input]
+	}
+}
+
+otelcol.exporter.opensearch "default" {
+	dataset      = "kubernetes"
+	namespace    = "production"
+	logs_index   = "alloy-logs"
+	traces_index = "alloy-traces"
+	bulk_action  = "index"
+
+	client {
+		endpoint            = "http://opensearch:9200"
+		headers             = {}
+		max_idle_conns      = 100
+		idle_conn_timeout   = "1m30s"
+		force_attempt_http2 = true
+	}
+
+	mapping {
+		mode  = "ecs"
+		dedup = true
+		dedot = true
+	}
+
+	retry_on_failure {
+		initial_interval = "1s"
+	}
+}

--- a/internal/converter/internal/otelcolconvert/testdata/opensearch.yaml
+++ b/internal/converter/internal/otelcolconvert/testdata/opensearch.yaml
@@ -1,0 +1,32 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+
+exporters:
+  opensearch:
+    http:
+      endpoint: "http://opensearch:9200"
+    dataset: kubernetes
+    namespace: production
+    logs_index: alloy-logs
+    traces_index: alloy-traces
+    bulk_action: index
+    mapping:
+      mode: ecs
+      dedup: true
+      dedot: true
+    retry_on_failure:
+      enabled: true
+      initial_interval: 1s
+      max_interval: 30s
+
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      exporters: [opensearch]
+    traces:
+      receivers: [otlp]
+      exporters: [opensearch]


### PR DESCRIPTION
### Brief description of Pull Request

Add OpenSearch exporter.

### Pull Request Details

This allows users to run only Alloy instead of running Alloy together with something like Vector, giving them a single configuration to manage.

### Issue(s) fixed by this Pull Request

Fixes #6668

### Notes to the Reviewer
I tested the OpenSearch exporter with a simple local Docker setup.

I still need to test everything with our real config in dev/preview, but I haven’t found the time yet. I still wanted to share the MR early for review.

I hope I updated all the relevant markdown files. Overall, the written code is just some config and mapping stuff. The heavy lifting is done by github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter and of course Alloy.

### PR Checklist
- [x] Documentation added
- [x] Tests updated
