### PR TITLE
ci: Use "npm ci" instead of "npm install"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -84,7 +84,7 @@ jobs:
         install_args: node
 
     - name: Install dependencies
-      run: npm install
+      run: npm ci
 
     - name: Lint
       run: npm run lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -84,7 +84,7 @@ jobs:
         install_args: node
 
     - name: Install dependencies
-      run: npm ci
+      run: npm ci --no-audit --no-fund
 
     - name: Lint
       run: npm run lint

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install dependencies 📦
         working-directory: build-tools/release-please-runner
-        run: npm install
+        run: npm ci
 
       - name: Run release-please 🚀
         working-directory: build-tools/release-please-runner

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install dependencies 📦
         working-directory: build-tools/release-please-runner
-        run: npm ci
+        run: npm ci --no-audit --no-fund
 
       - name: Run release-please 🚀
         working-directory: build-tools/release-please-runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG BUILDPLATFORM
 COPY ./internal/web/ui /ui
 WORKDIR /ui
 RUN --mount=type=cache,target=/root/.npm,sharing=locked \
-    npm ci                                              \
+    npm ci --no-audit --no-fund                         \
     && npm run build
 
 FROM --platform=$BUILDPLATFORM grafana/alloy-build-image:v0.1.33@sha256:dbdecbfbad6c9ed0b315a7a6da25ef066b795ffc57e887125333b1a352907155 AS build

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ FROM --platform=$BUILDPLATFORM grafana/alloy-build-image:v0.1.33@sha256:dbdecbfb
 ARG BUILDPLATFORM
 COPY ./internal/web/ui /ui
 WORKDIR /ui
-RUN --mount=type=cache,target=/ui/node_modules,sharing=locked \
-    npm install                                               \
+RUN --mount=type=cache,target=/root/.npm,sharing=locked \
+    npm ci                                              \
     && npm run build
 
 FROM --platform=$BUILDPLATFORM grafana/alloy-build-image:v0.1.33@sha256:dbdecbfbad6c9ed0b315a7a6da25ef066b795ffc57e887125333b1a352907155 AS build

--- a/Makefile
+++ b/Makefile
@@ -365,7 +365,7 @@ ifeq ($(USE_CONTAINER),1)
 else ifeq ($(SKIP_UI_BUILD),1)
 	@echo "Skipping UI build (SKIP_UI_BUILD=1)"
 else
-	cd ./internal/web/ui && npm install && npm run build
+	cd ./internal/web/ui && npm ci && npm run build
 endif
 
 generate-docs:

--- a/Makefile
+++ b/Makefile
@@ -365,7 +365,7 @@ ifeq ($(USE_CONTAINER),1)
 else ifeq ($(SKIP_UI_BUILD),1)
 	@echo "Skipping UI build (SKIP_UI_BUILD=1)"
 else
-	cd ./internal/web/ui && npm ci && npm run build
+	cd ./internal/web/ui && npm ci --no-audit --no-fund && npm run build
 endif
 
 generate-docs:

--- a/internal/web/ui/assets_builtin.go
+++ b/internal/web/ui/assets_builtin.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 )
 
-//go:generate npm ci
+//go:generate npm ci --no-audit --no-fund
 //go:generate npm run build
 
 //go:embed dist

--- a/internal/web/ui/assets_builtin.go
+++ b/internal/web/ui/assets_builtin.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 )
 
-//go:generate npm install
+//go:generate npm ci
 //go:generate npm run build
 
 //go:embed dist


### PR DESCRIPTION
It's considered a [best practice](https://github.com/lirantal/npm-security-best-practices#6-use-npm-ci) to use `npm ci` since it checks the lock file and returns an error if there are inconsistencies in the checksum and the actual files on disc.