### PR TITLE
fix(discovery.dns): use Windows system resolver

### DIFF
--- a/internal/component/discovery/dns/common.go
+++ b/internal/component/discovery/dns/common.go
@@ -1,0 +1,62 @@
+package dns
+
+import (
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/prometheus/common/model"
+)
+
+const (
+	dnsNameLabel            = model.MetaLabelPrefix + "dns_name"
+	dnsSrvRecordPrefix      = model.MetaLabelPrefix + "dns_srv_record_"
+	dnsSrvRecordTargetLabel = dnsSrvRecordPrefix + "target"
+	dnsSrvRecordPortLabel   = dnsSrvRecordPrefix + "port"
+	dnsMxRecordPrefix       = model.MetaLabelPrefix + "dns_mx_record_"
+	dnsMxRecordTargetLabel  = dnsMxRecordPrefix + "target"
+	dnsNsRecordPrefix       = model.MetaLabelPrefix + "dns_ns_record_"
+	dnsNsRecordTargetLabel  = dnsNsRecordPrefix + "target"
+
+	dnsMetricsNamespace = "prometheus"
+)
+
+func hostPort(host string, port int) model.LabelValue {
+	return model.LabelValue(net.JoinHostPort(host, strconv.Itoa(port)))
+}
+
+func trimRootedName(name string) string {
+	return strings.TrimRight(name, ".")
+}
+
+func buildIPTarget(name string, ip net.IP, port int) model.LabelSet {
+	return model.LabelSet{
+		model.AddressLabel: hostPort(ip.String(), port),
+		dnsNameLabel:       model.LabelValue(name),
+	}
+}
+
+func buildSRVTarget(name string, record *net.SRV) model.LabelSet {
+	return model.LabelSet{
+		model.AddressLabel:      hostPort(trimRootedName(record.Target), int(record.Port)),
+		dnsNameLabel:            model.LabelValue(name),
+		dnsSrvRecordTargetLabel: model.LabelValue(record.Target),
+		dnsSrvRecordPortLabel:   model.LabelValue(strconv.Itoa(int(record.Port))),
+	}
+}
+
+func buildMXTarget(name string, record *net.MX, port int) model.LabelSet {
+	return model.LabelSet{
+		model.AddressLabel:     hostPort(trimRootedName(record.Host), port),
+		dnsNameLabel:           model.LabelValue(name),
+		dnsMxRecordTargetLabel: model.LabelValue(record.Host),
+	}
+}
+
+func buildNSTarget(name string, record *net.NS, port int) model.LabelSet {
+	return model.LabelSet{
+		model.AddressLabel:     hostPort(trimRootedName(record.Host), port),
+		dnsNameLabel:           model.LabelValue(name),
+		dnsNsRecordTargetLabel: model.LabelValue(record.Host),
+	}
+}

--- a/internal/component/discovery/dns/common_test.go
+++ b/internal/component/discovery/dns/common_test.go
@@ -1,0 +1,41 @@
+package dns
+
+import (
+	"net"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildSRVTarget(t *testing.T) {
+	labels := buildSRVTarget("_ldap._tcp.example.com", &net.SRV{Target: "dc1.example.com.", Port: 389})
+
+	require.Equal(t, model.LabelValue("dc1.example.com:389"), labels[model.AddressLabel])
+	require.Equal(t, model.LabelValue("_ldap._tcp.example.com"), labels[dnsNameLabel])
+	require.Equal(t, model.LabelValue("dc1.example.com."), labels[dnsSrvRecordTargetLabel])
+	require.Equal(t, model.LabelValue("389"), labels[dnsSrvRecordPortLabel])
+}
+
+func TestBuildMXTarget(t *testing.T) {
+	labels := buildMXTarget("example.com", &net.MX{Host: "mail.example.com."}, 25)
+
+	require.Equal(t, model.LabelValue("mail.example.com:25"), labels[model.AddressLabel])
+	require.Equal(t, model.LabelValue("example.com"), labels[dnsNameLabel])
+	require.Equal(t, model.LabelValue("mail.example.com."), labels[dnsMxRecordTargetLabel])
+}
+
+func TestBuildNSTarget(t *testing.T) {
+	labels := buildNSTarget("example.com", &net.NS{Host: "ns1.example.com."}, 53)
+
+	require.Equal(t, model.LabelValue("ns1.example.com:53"), labels[model.AddressLabel])
+	require.Equal(t, model.LabelValue("example.com"), labels[dnsNameLabel])
+	require.Equal(t, model.LabelValue("ns1.example.com."), labels[dnsNsRecordTargetLabel])
+}
+
+func TestBuildIPTarget(t *testing.T) {
+	labels := buildIPTarget("example.com", net.ParseIP("2001:db8::1"), 8080)
+
+	require.Equal(t, model.LabelValue("[2001:db8::1]:8080"), labels[model.AddressLabel])
+	require.Equal(t, model.LabelValue("example.com"), labels[dnsNameLabel])
+}

--- a/internal/component/discovery/dns/config_default.go
+++ b/internal/component/discovery/dns/config_default.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package dns
+
+import (
+	"github.com/prometheus/common/model"
+	promdns "github.com/prometheus/prometheus/discovery/dns"
+
+	"github.com/grafana/alloy/internal/component/discovery"
+)
+
+func newDiscovererConfig(args Arguments) discovery.DiscovererConfig {
+	return &promdns.SDConfig{
+		Names:           args.Names,
+		RefreshInterval: model.Duration(args.RefreshInterval),
+		Type:            args.Type,
+		Port:            args.Port,
+	}
+}

--- a/internal/component/discovery/dns/config_windows.go
+++ b/internal/component/discovery/dns/config_windows.go
@@ -1,0 +1,233 @@
+//go:build windows
+
+package dns
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/promslog"
+	promdiscovery "github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/refresh"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+
+	"github.com/grafana/alloy/internal/component/discovery"
+)
+
+type windowsSDConfig struct {
+	Names           []string
+	RefreshInterval time.Duration
+	Type            string
+	Port            int
+}
+
+func newDiscovererConfig(args Arguments) discovery.DiscovererConfig {
+	return &windowsSDConfig{
+		Names:           args.Names,
+		RefreshInterval: args.RefreshInterval,
+		Type:            strings.ToUpper(args.Type),
+		Port:            args.Port,
+	}
+}
+
+func (*windowsSDConfig) Name() string {
+	return "dns"
+}
+
+func (c *windowsSDConfig) NewDiscoverer(opts promdiscovery.DiscovererOptions) (promdiscovery.Discoverer, error) {
+	m, ok := opts.Metrics.(*windowsDNSMetrics)
+	if !ok {
+		return nil, errors.New("invalid discovery metrics type")
+	}
+
+	logger := opts.Logger
+	if logger == nil {
+		logger = promslog.NewNopLogger()
+	}
+
+	d := &windowsDiscovery{
+		names:    c.Names,
+		recordTy: c.Type,
+		port:     c.Port,
+		logger:   logger,
+		metrics:  m,
+		resolver: net.DefaultResolver,
+	}
+
+	d.Discovery = refresh.NewDiscovery(refresh.Options{
+		Logger:              logger,
+		Mech:                "dns",
+		SetName:             opts.SetName,
+		Interval:            c.RefreshInterval,
+		RefreshF:            d.refresh,
+		MetricsInstantiator: m.refreshMetrics,
+	})
+
+	return d, nil
+}
+
+func (*windowsSDConfig) NewDiscovererMetrics(reg prometheus.Registerer, rmi promdiscovery.RefreshMetricsInstantiator) promdiscovery.DiscovererMetrics {
+	return newWindowsDNSMetrics(reg, rmi)
+}
+
+type dnsResolver interface {
+	LookupSRV(ctx context.Context, service, proto, name string) (string, []*net.SRV, error)
+	LookupIP(ctx context.Context, network, host string) ([]net.IP, error)
+	LookupMX(ctx context.Context, name string) ([]*net.MX, error)
+	LookupNS(ctx context.Context, name string) ([]*net.NS, error)
+}
+
+type windowsDiscovery struct {
+	*refresh.Discovery
+
+	names    []string
+	recordTy string
+	port     int
+	logger   *slog.Logger
+	metrics  *windowsDNSMetrics
+	resolver dnsResolver
+}
+
+func (d *windowsDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
+	var (
+		wg  sync.WaitGroup
+		ch  = make(chan *targetgroup.Group)
+		tgs = make([]*targetgroup.Group, 0, len(d.names))
+	)
+
+	wg.Add(len(d.names))
+	for _, name := range d.names {
+		go func(name string) {
+			defer wg.Done()
+
+			tg, err := d.refreshOne(ctx, name)
+			if err != nil {
+				if !errors.Is(err, context.Canceled) {
+					d.logger.Error("Error refreshing DNS targets", "err", err)
+				}
+				return
+			}
+
+			select {
+			case <-ctx.Done():
+			case ch <- tg:
+			}
+		}(name)
+	}
+
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+
+	for tg := range ch {
+		tgs = append(tgs, tg)
+	}
+
+	return tgs, nil
+}
+
+func (d *windowsDiscovery) refreshOne(ctx context.Context, name string) (*targetgroup.Group, error) {
+	d.metrics.dnsSDLookupsCount.Inc()
+
+	tg := &targetgroup.Group{Source: name}
+
+	var err error
+	switch d.recordTy {
+	case "SRV":
+		_, addrs, lookupErr := d.resolver.LookupSRV(ctx, "", "", name)
+		err = lookupErr
+		for _, addr := range addrs {
+			tg.Targets = append(tg.Targets, buildSRVTarget(name, addr))
+		}
+	case "A":
+		ips, lookupErr := d.resolver.LookupIP(ctx, "ip4", name)
+		err = lookupErr
+		for _, ip := range ips {
+			tg.Targets = append(tg.Targets, buildIPTarget(name, ip, d.port))
+		}
+	case "AAAA":
+		ips, lookupErr := d.resolver.LookupIP(ctx, "ip6", name)
+		err = lookupErr
+		for _, ip := range ips {
+			tg.Targets = append(tg.Targets, buildIPTarget(name, ip, d.port))
+		}
+	case "MX":
+		mxRecords, lookupErr := d.resolver.LookupMX(ctx, name)
+		err = lookupErr
+		for _, record := range mxRecords {
+			tg.Targets = append(tg.Targets, buildMXTarget(name, record, d.port))
+		}
+	case "NS":
+		nsRecords, lookupErr := d.resolver.LookupNS(ctx, name)
+		err = lookupErr
+		for _, record := range nsRecords {
+			tg.Targets = append(tg.Targets, buildNSTarget(name, record, d.port))
+		}
+	default:
+		err = fmt.Errorf("unsupported DNS record type %q", d.recordTy)
+	}
+
+	if err == nil || isNotFound(err) {
+		return tg, nil
+	}
+
+	d.metrics.dnsSDLookupFailuresCount.Inc()
+	return nil, err
+}
+
+func isNotFound(err error) bool {
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return dnsErr.IsNotFound
+	}
+
+	return false
+}
+
+type windowsDNSMetrics struct {
+	refreshMetrics promdiscovery.RefreshMetricsInstantiator
+
+	dnsSDLookupsCount        prometheus.Counter
+	dnsSDLookupFailuresCount prometheus.Counter
+
+	metricRegisterer promdiscovery.MetricRegisterer
+}
+
+func newWindowsDNSMetrics(reg prometheus.Registerer, rmi promdiscovery.RefreshMetricsInstantiator) promdiscovery.DiscovererMetrics {
+	m := &windowsDNSMetrics{
+		refreshMetrics: rmi,
+		dnsSDLookupsCount: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: dnsMetricsNamespace,
+			Name:      "sd_dns_lookups_total",
+			Help:      "The number of DNS-SD lookups.",
+		}),
+		dnsSDLookupFailuresCount: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: dnsMetricsNamespace,
+			Name:      "sd_dns_lookup_failures_total",
+			Help:      "The number of DNS-SD lookup failures.",
+		}),
+	}
+
+	m.metricRegisterer = promdiscovery.NewMetricRegisterer(reg, []prometheus.Collector{
+		m.dnsSDLookupsCount,
+		m.dnsSDLookupFailuresCount,
+	})
+
+	return m
+}
+
+func (m *windowsDNSMetrics) Register() error {
+	return m.metricRegisterer.RegisterMetrics()
+}
+
+func (m *windowsDNSMetrics) Unregister() {
+	m.metricRegisterer.UnregisterMetrics()
+}

--- a/internal/component/discovery/dns/config_windows_test.go
+++ b/internal/component/discovery/dns/config_windows_test.go
@@ -1,0 +1,126 @@
+//go:build windows
+
+package dns
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeResolver struct {
+	lookupSRV func(ctx context.Context, service, proto, name string) (string, []*net.SRV, error)
+	lookupIP  func(ctx context.Context, network, host string) ([]net.IP, error)
+	lookupMX  func(ctx context.Context, name string) ([]*net.MX, error)
+	lookupNS  func(ctx context.Context, name string) ([]*net.NS, error)
+}
+
+func (f fakeResolver) LookupSRV(ctx context.Context, service, proto, name string) (string, []*net.SRV, error) {
+	return f.lookupSRV(ctx, service, proto, name)
+}
+
+func (f fakeResolver) LookupIP(ctx context.Context, network, host string) ([]net.IP, error) {
+	return f.lookupIP(ctx, network, host)
+}
+
+func (f fakeResolver) LookupMX(ctx context.Context, name string) ([]*net.MX, error) {
+	return f.lookupMX(ctx, name)
+}
+
+func (f fakeResolver) LookupNS(ctx context.Context, name string) ([]*net.NS, error) {
+	return f.lookupNS(ctx, name)
+}
+
+func TestWindowsDiscoveryRefreshOneSRV(t *testing.T) {
+	d := &windowsDiscovery{
+		recordTy: "SRV",
+		metrics:  newTestWindowsDNSMetrics(),
+		resolver: fakeResolver{
+			lookupSRV: func(_ context.Context, service, proto, name string) (string, []*net.SRV, error) {
+				require.Empty(t, service)
+				require.Empty(t, proto)
+				require.Equal(t, "_ldap._tcp.example.com", name)
+				return "", []*net.SRV{{Target: "dc1.example.com.", Port: 389}}, nil
+			},
+			lookupIP: func(context.Context, string, string) ([]net.IP, error) {
+				return nil, errors.New("unexpected LookupIP call")
+			},
+			lookupMX: func(context.Context, string) ([]*net.MX, error) { return nil, errors.New("unexpected LookupMX call") },
+			lookupNS: func(context.Context, string) ([]*net.NS, error) { return nil, errors.New("unexpected LookupNS call") },
+		},
+	}
+
+	tg, err := d.refreshOne(context.Background(), "_ldap._tcp.example.com")
+	require.NoError(t, err)
+	require.Equal(t, "_ldap._tcp.example.com", tg.Source)
+	require.Len(t, tg.Targets, 1)
+	require.Equal(t, model.LabelValue("dc1.example.com:389"), tg.Targets[0][model.AddressLabel])
+	require.Equal(t, model.LabelValue("dc1.example.com."), tg.Targets[0][dnsSrvRecordTargetLabel])
+}
+
+func TestWindowsDiscoveryRefreshOneNotFoundReturnsEmptyGroup(t *testing.T) {
+	d := &windowsDiscovery{
+		recordTy: "A",
+		port:     8080,
+		metrics:  newTestWindowsDNSMetrics(),
+		resolver: fakeResolver{
+			lookupSRV: func(context.Context, string, string, string) (string, []*net.SRV, error) {
+				return "", nil, errors.New("unexpected LookupSRV call")
+			},
+			lookupIP: func(_ context.Context, network, host string) ([]net.IP, error) {
+				require.Equal(t, "ip4", network)
+				require.Equal(t, "missing.example.com", host)
+				return nil, &net.DNSError{IsNotFound: true}
+			},
+			lookupMX: func(context.Context, string) ([]*net.MX, error) { return nil, errors.New("unexpected LookupMX call") },
+			lookupNS: func(context.Context, string) ([]*net.NS, error) { return nil, errors.New("unexpected LookupNS call") },
+		},
+	}
+
+	tg, err := d.refreshOne(context.Background(), "missing.example.com")
+	require.NoError(t, err)
+	require.Equal(t, "missing.example.com", tg.Source)
+	require.Empty(t, tg.Targets)
+	assertCounterValue(t, d.metrics.dnsSDLookupsCount, 1)
+	assertCounterValue(t, d.metrics.dnsSDLookupFailuresCount, 0)
+}
+
+func TestWindowsDiscoveryRefreshOneCountsFailures(t *testing.T) {
+	d := &windowsDiscovery{
+		recordTy: "AAAA",
+		port:     8080,
+		metrics:  newTestWindowsDNSMetrics(),
+		resolver: fakeResolver{
+			lookupSRV: func(context.Context, string, string, string) (string, []*net.SRV, error) {
+				return "", nil, errors.New("unexpected LookupSRV call")
+			},
+			lookupIP: func(context.Context, string, string) ([]net.IP, error) { return nil, errors.New("resolver failed") },
+			lookupMX: func(context.Context, string) ([]*net.MX, error) { return nil, errors.New("unexpected LookupMX call") },
+			lookupNS: func(context.Context, string) ([]*net.NS, error) { return nil, errors.New("unexpected LookupNS call") },
+		},
+	}
+
+	tg, err := d.refreshOne(context.Background(), "broken.example.com")
+	require.Nil(t, tg)
+	require.EqualError(t, err, "resolver failed")
+	assertCounterValue(t, d.metrics.dnsSDLookupsCount, 1)
+	assertCounterValue(t, d.metrics.dnsSDLookupFailuresCount, 1)
+}
+
+func newTestWindowsDNSMetrics() *windowsDNSMetrics {
+	return &windowsDNSMetrics{
+		dnsSDLookupsCount:        prometheus.NewCounter(prometheus.CounterOpts{Name: "test_dns_lookups_total"}),
+		dnsSDLookupFailuresCount: prometheus.NewCounter(prometheus.CounterOpts{Name: "test_dns_lookup_failures_total"}),
+	}
+}
+
+func assertCounterValue(t *testing.T, counter prometheus.Counter, want float64) {
+	t.Helper()
+	require.Equal(t, want, testutil.ToFloat64(counter))
+}

--- a/internal/component/discovery/dns/dns.go
+++ b/internal/component/discovery/dns/dns.go
@@ -6,9 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/discovery/dns"
-
 	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/component/discovery"
 	"github.com/grafana/alloy/internal/featuregate"
@@ -60,10 +57,5 @@ func (args *Arguments) Validate() error {
 }
 
 func (args Arguments) Convert() discovery.DiscovererConfig {
-	return &dns.SDConfig{
-		Names:           args.Names,
-		RefreshInterval: model.Duration(args.RefreshInterval),
-		Type:            args.Type,
-		Port:            args.Port,
-	}
+	return newDiscovererConfig(args)
 }


### PR DESCRIPTION
## Summary
- add a Windows-specific `discovery.dns` implementation that uses Go's system resolver instead of Prometheus DNS SD's `/etc/resolv.conf` path
- keep the existing Prometheus DNS SD behavior on non-Windows platforms
- add tests for Windows target formatting and resolver error handling

## Testing
- `go test common.go common_test.go` in `internal/component/discovery/dns`
- package-wide Go tests could not complete in this environment because the Windows host ran out of memory/paging file during compilation

Closes #6238.