### PR TITLE
docs: Update support bundle flag prefix

### DIFF
--- a/docs/sources/reference/cli/run.md
+++ b/docs/sources/reference/cli/run.md
@@ -41,9 +41,9 @@ The following flags are supported:
 * `--server.http.memory-addr`: Address to listen for [in-memory HTTP traffic][] on (default `"alloy.internal:12345"`).
 * `--server.http.listen-addr`: Address to listen for HTTP traffic on (default `"127.0.0.1:12345"`).
 * `--server.http.ui-path-prefix`: Base path where the UI is exposed (default `"/"`).
+* `--server.http.disable-support-bundle`: Disable [support bundle][] endpoint (default `false`).
 * `--storage.path`: Base directory where components can store data (default `"data-alloy/"`).
 * `--disable-reporting`: Disable [data collection][] (default `false`).
-* `--disable-support-bundle`: Disable [support bundle][] endpoint (default `false`).
 * `--cluster.enabled`: Start {{< param "PRODUCT_NAME" >}} in clustered mode (default `false`).
 * `--cluster.node-name`: The name to use for this node (defaults to the environment's hostname).
 * `--cluster.join-addresses`: Comma-separated list of addresses to join the cluster at (default `""`). Mutually exclusive with `--cluster.discover-peers`.

--- a/docs/sources/troubleshoot/support_bundle.md
+++ b/docs/sources/troubleshoot/support_bundle.md
@@ -19,7 +19,7 @@ to debug an [issue][alloy-repo].
 This feature isn't covered by the [backward-compatibility][backward-compatibility] guarantees.
 
 {{< admonition type="note" >}}
-This endpoint is enabled by default, but may be disabled using the `--disable-support-bundle` runtime flag.
+This endpoint is enabled by default, but may be disabled using the `--server.http.disable-support-bundle` runtime flag.
 {{< /admonition >}}
 
 The duration parameter is optional, must be less than or equal to the

--- a/internal/service/http/http.go
+++ b/internal/service/http/http.go
@@ -320,7 +320,7 @@ func (s *Service) generateSupportBundleHandler(host service.Host) func(rw http.R
 
 		if s.opts.BundleContext.DisableSupportBundle {
 			rw.WriteHeader(http.StatusForbidden)
-			_, _ = rw.Write([]byte("support bundle generation is disabled; it can be re-enabled by removing the --disable-support-bundle flag"))
+			_, _ = rw.Write([]byte("support bundle generation is disabled; it can be re-enabled by removing the --server.http.disable-support-bundle flag"))
 			return
 		}
 


### PR DESCRIPTION
Add the `server.http` prefix to the `disable-support-bundle` as this is what (at least) version 1.16.1 requires.

<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style with a capitalized
  description, e.g. `feat(scope): Add the thing` (not `add the thing`). For
  details on this, check out the Contributors Guide linked above.
-->

### Brief description of Pull Request

This PR adds the `server.http` prefix to the `disable-support-bundle` in the `run` reference documentation.


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
