### PR TITLE
chore: Exclude Prometheus and OpenTelemetry Renovate updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -109,6 +109,17 @@
       "commitMessageTopic": "{{manager}} unstable dependency {{depName}}"
     },
     {
+      // These are updated in bulk via the key-deps process instead of Renovate.
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "github.com/prometheus/prometheus",
+        "github.com/prometheus/prometheus/**",
+        "github.com/open-telemetry/**",
+        "go.opentelemetry.io/**"
+      ],
+      "enabled": false
+    },
+    {
       "matchManagers": ["helm-values"],
       "groupName": "helm-values dependencies",
       "enabled": true

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -53,16 +53,15 @@
       "postUpdateOptions": ["gomodTidy"]
     },
     {
-      // Group and hold some otel-specific go dependencies
+      // These are updated in bulk via the key-deps process instead of Renovate.
       "matchManagers": ["gomod"],
       "matchPackageNames": [
-        // OpenTelemetry needs special handling due to a temporary fork
-        "github.com/open-telemetry/opentelemetry-collector-contrib/**",
-        "go.opentelemetry.io/collector/**",
-        "go.opentelemetry.io/otel/**",
+        "github.com/prometheus/prometheus",
+        "github.com/prometheus/prometheus/**",
+        "github.com/open-telemetry/**",
+        "go.opentelemetry.io/**",
       ],
-      "groupName": "go otel collector dependencies",
-      "dependencyDashboardApproval": true
+      "enabled": false
     },
     {
       // Hold unstable deps
@@ -107,17 +106,6 @@
       // having its own PR.
       "groupName": "{{manager}} unstable dependency {{depName}}",
       "commitMessageTopic": "{{manager}} unstable dependency {{depName}}"
-    },
-    {
-      // These are updated in bulk via the key-deps process instead of Renovate.
-      "matchManagers": ["gomod"],
-      "matchPackageNames": [
-        "github.com/prometheus/prometheus",
-        "github.com/prometheus/prometheus/**",
-        "github.com/open-telemetry/**",
-        "go.opentelemetry.io/**"
-      ],
-      "enabled": false
     },
     {
       "matchManagers": ["helm-values"],


### PR DESCRIPTION
## Summary
- disable Renovate `gomod` updates for `github.com/prometheus/prometheus` and OpenTelemetry module paths
- reduce Renovate PR noise for dependencies already handled in bulk via the key-deps update process
- keep the rule scoped to the targeted dependency families so other dependency automation remains unchanged
