### PR TITLE
chore: Handle sha pinning for docker images

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE_GO=golang:1.26-windowsservercore-ltsc2022@sha256:b36e6e1036d0746855a215ecc693bdc45879a74a15edc797fc9af6cc3f505863
+ARG BASE_IMAGE_GO=golang:1.26.3-windowsservercore-ltsc2022@sha256:98c6379211d9edcf4b56241bae12b71cc41334d54b42d5743841c97f017123bd
 ARG BASE_IMAGE_WINDOWS=mcr.microsoft.com/windows/nanoserver:ltsc2022@sha256:3680dad0bb773da8efcd9d928eaf4e33817875ab71a43792640ab1bcc0b3c074
 
 FROM ${BASE_IMAGE_GO} AS builder

--- a/tools/goversion/command.go
+++ b/tools/goversion/command.go
@@ -1,11 +1,10 @@
 package goversion
 
 import (
-	"encoding/json"
+	"bytes"
 	"errors"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -112,7 +111,12 @@ func updateBuildImage(root string, version string) error {
 			return fmt.Errorf("failed to read file: %w", err)
 		}
 
-		if err := os.WriteFile(path, replaceDockerGoVersion(content, version), 0644); err != nil {
+		out, err := replaceDockerGoVersion(content, version)
+		if err != nil {
+			return fmt.Errorf("update %s: %w", path, err)
+		}
+
+		if err := os.WriteFile(path, out, 0644); err != nil {
 			return fmt.Errorf("failed to update file: %w", err)
 		}
 	}
@@ -144,7 +148,7 @@ func updateGoModFiles(root, version string) error {
 }
 
 func updateDockerFiles(root, version string) error {
-	result, err := discover.Files(root, discover.MatchPatternFn("Dockerfile*"), discover.WithSkipDirs("vendor", "build-tools"), discover.WithExclude("Dockerfile.windows"))
+	result, err := discover.Files(root, discover.MatchPatternFn("Dockerfile*"), discover.WithSkipDirs("vendor", "build-tools"))
 	if err != nil {
 		return err
 	}
@@ -154,7 +158,13 @@ func updateDockerFiles(root, version string) error {
 		if err != nil {
 			return fmt.Errorf("read %s: %w", path, err)
 		}
-		if err := os.WriteFile(path, replaceDockerGoVersion(content, version), 0644); err != nil {
+
+		out, err := replaceDockerGoVersion(content, version)
+		if err != nil {
+			return fmt.Errorf("update %s: %w", path, err)
+		}
+
+		if err := os.WriteFile(path, out, 0644); err != nil {
 			return fmt.Errorf("write %s: %w", path, err)
 		}
 	}
@@ -198,39 +208,6 @@ func bumpBuildImage(root string) error {
 	return nil
 }
 
-const dockerHubTagsURL = "https://hub.docker.com/v2/repositories/grafana/alloy-build-image/tags?page_size=2"
-
-type dockerTagsResponse struct {
-	Results []dockerTag `json:"results"`
-}
-
-type dockerTag struct {
-	Name   string `json:"name"`
-	Digest string `json:"digest"`
-}
-
-type buildImageRefs struct {
-	Default    string
-	Boring     string
-	DefaultTag string
-}
-
-func fetchBuildImageTags() (*dockerTagsResponse, error) {
-	resp, err := http.Get(dockerHubTagsURL)
-	if err != nil {
-		return nil, fmt.Errorf("fetch tags: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("fetch tags: %s", resp.Status)
-	}
-	var data dockerTagsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, fmt.Errorf("decode tags: %w", err)
-	}
-	return &data, nil
-}
-
 // buildImageRefsFromTags assumes 2 tags: one default, one boringcrypto.
 func buildImageRefsFromTags(data *dockerTagsResponse) (*buildImageRefs, error) {
 	if len(data.Results) != 2 {
@@ -268,9 +245,48 @@ func replaceBuildImageRefs(content []byte, refs *buildImageRefs) []byte {
 	return out
 }
 
-var dockerGoVersionRE = regexp.MustCompile(`golang:1\.\d+(\.\d+)?`)
+// dockerGoVersionRE matches a golang image reference: the version, an optional
+// variant suffix (e.g. -alpine, -windowsservercore-ltsc2022), and an optional
+// pinned digest. Submatch 1 is the suffix, submatch 2 is the @sha256 digest.
+var dockerGoVersionRE = regexp.MustCompile(`golang:1\.\d+(?:\.\d+)?(-[A-Za-z0-9._-]+)?(@sha256:[a-f0-9]+)?`)
 
-func replaceDockerGoVersion(content []byte, version string) []byte {
-	out := dockerGoVersionRE.ReplaceAllLiteral(content, []byte("golang:"+version))
-	return out
+// replaceDockerGoVersion rewrites golang image references to the given version.
+// When a reference is pinned by digest, the new tag's digest is resolved so the
+// pin stays consistent with the tag.
+func replaceDockerGoVersion(content []byte, version string) ([]byte, error) {
+	matches := dockerGoVersionRE.FindAllSubmatchIndex(content, -1)
+	if matches == nil {
+		return content, nil
+	}
+
+	var (
+		last int
+		out  bytes.Buffer
+	)
+
+	for _, m := range matches {
+		start, end := m[0], m[1]
+
+		suffix := ""
+		if m[2] >= 0 {
+			suffix = string(content[m[2]:m[3]])
+		}
+
+		hasDigest := m[4] >= 0
+		tag := version + suffix
+		replacement := "golang:" + tag
+		if hasDigest {
+			digest, err := resolveGolangDigest(tag)
+			if err != nil {
+				return nil, fmt.Errorf("resolve digest for golang:%s: %w", tag, err)
+			}
+			replacement += "@" + digest
+		}
+
+		out.Write(content[last:start])
+		out.WriteString(replacement)
+		last = end
+	}
+	out.Write(content[last:])
+	return out.Bytes(), nil
 }

--- a/tools/goversion/command.go
+++ b/tools/goversion/command.go
@@ -208,6 +208,12 @@ func bumpBuildImage(root string) error {
 	return nil
 }
 
+type buildImageRefs struct {
+	Default    string
+	Boring     string
+	DefaultTag string
+}
+
 // buildImageRefsFromTags assumes 2 tags: one default, one boringcrypto.
 func buildImageRefsFromTags(data *dockerTagsResponse) (*buildImageRefs, error) {
 	if len(data.Results) != 2 {

--- a/tools/goversion/docker.go
+++ b/tools/goversion/docker.go
@@ -51,12 +51,6 @@ type dockerTag struct {
 	Digest string `json:"digest"`
 }
 
-type buildImageRefs struct {
-	Default    string
-	Boring     string
-	DefaultTag string
-}
-
 func fetchBuildImageTags() (*dockerTagsResponse, error) {
 	resp, err := http.Get(alloyBuildImageTagsURL)
 	if err != nil {

--- a/tools/goversion/docker.go
+++ b/tools/goversion/docker.go
@@ -40,7 +40,7 @@ func resolveGolangDigest(tag string) (string, error) {
 	return data.Digest, nil
 }
 
-const dockerHubTagsURL = "https://hub.docker.com/v2/repositories/grafana/alloy-build-image/tags?page_size=2"
+const alloyBuildImageTagsURL = "https://hub.docker.com/v2/repositories/grafana/alloy-build-image/tags?page_size=2"
 
 type dockerTagsResponse struct {
 	Results []dockerTag `json:"results"`
@@ -58,7 +58,7 @@ type buildImageRefs struct {
 }
 
 func fetchBuildImageTags() (*dockerTagsResponse, error) {
-	resp, err := http.Get(dockerHubTagsURL)
+	resp, err := http.Get(alloyBuildImageTagsURL)
 	if err != nil {
 		return nil, fmt.Errorf("fetch tags: %w", err)
 	}

--- a/tools/goversion/docker.go
+++ b/tools/goversion/docker.go
@@ -1,0 +1,74 @@
+package goversion
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+const golangTagURL = "https://hub.docker.com/v2/repositories/library/golang/tags/"
+
+var golangDigestCache = map[string]string{}
+
+// resolveGolangDigest returns the multi-arch index digest (e.g. "sha256:...")
+// for a golang image tag such as "1.27.0-alpine", using the Docker Hub per-tag
+// API. Only Docker Hub library/golang images are supported, which covers every
+// digest-pinned golang reference in this repo. Results are cached for the run.
+func resolveGolangDigest(tag string) (string, error) {
+	if digest, ok := golangDigestCache[tag]; ok {
+		return digest, nil
+	}
+
+	resp, err := http.Get(golangTagURL + tag)
+	if err != nil {
+		return "", fmt.Errorf("fetch tag %s: %w", tag, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("fetch tag %s: %s", tag, resp.Status)
+	}
+
+	var data dockerTag
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return "", fmt.Errorf("decode tag %s: %w", tag, err)
+	}
+	if data.Digest == "" {
+		return "", fmt.Errorf("no digest for tag %s", tag)
+	}
+
+	golangDigestCache[tag] = data.Digest
+	return data.Digest, nil
+}
+
+const dockerHubTagsURL = "https://hub.docker.com/v2/repositories/grafana/alloy-build-image/tags?page_size=2"
+
+type dockerTagsResponse struct {
+	Results []dockerTag `json:"results"`
+}
+
+type dockerTag struct {
+	Name   string `json:"name"`
+	Digest string `json:"digest"`
+}
+
+type buildImageRefs struct {
+	Default    string
+	Boring     string
+	DefaultTag string
+}
+
+func fetchBuildImageTags() (*dockerTagsResponse, error) {
+	resp, err := http.Get(dockerHubTagsURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetch tags: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch tags: %s", resp.Status)
+	}
+	var data dockerTagsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, fmt.Errorf("decode tags: %w", err)
+	}
+	return &data, nil
+}


### PR DESCRIPTION
Our commands to update go version did not update the digest, it just replaces the go version in docker images and then you had to manually do it.

In this pr I have updated so that we do resolve the new digest, also now includes `Dockerfile.windows`. 