### PR TITLE
feat(metrics): Add native histogram support for self-monitoring metrics

### DIFF
--- a/internal/component/common/loki/client/metrics.go
+++ b/internal/component/common/loki/client/metrics.go
@@ -76,8 +76,11 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 		NativeHistogramMinResetDuration: 1 * time.Hour,
 	}, []string{labelHost, labelTenant})
 	m.requestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name: "loki_write_request_duration_seconds",
-		Help: "Duration of send requests.",
+		Name:                            "loki_write_request_duration_seconds",
+		Help:                            "Duration of send requests.",
+		NativeHistogramBucketFactor:     1.1,
+		NativeHistogramMaxBucketNumber:  100,
+		NativeHistogramMinResetDuration: 1 * time.Hour,
 	}, []string{"status_code", labelHost, labelTenant})
 	m.batchRetries = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "loki_write_batch_retries_total",

--- a/internal/component/common/loki/client/metrics.go
+++ b/internal/component/common/loki/client/metrics.go
@@ -78,6 +78,7 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 	m.requestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:                            "loki_write_request_duration_seconds",
 		Help:                            "Duration of send requests.",
+		Buckets:                         prometheus.DefBuckets,
 		NativeHistogramBucketFactor:     1.1,
 		NativeHistogramMaxBucketNumber:  100,
 		NativeHistogramMinResetDuration: 1 * time.Hour,

--- a/internal/component/faro/receiver/server.go
+++ b/internal/component/faro/receiver/server.go
@@ -25,21 +25,30 @@ type serverMetrics struct {
 func newServerMetrics(reg prometheus.Registerer) *serverMetrics {
 	m := &serverMetrics{
 		requestDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "faro_receiver_request_duration_seconds",
-			Help:    "Time (in seconds) spent serving HTTP requests.",
-			Buckets: instrument.DefBuckets,
+			Name:                            "faro_receiver_request_duration_seconds",
+			Help:                            "Time (in seconds) spent serving HTTP requests.",
+			Buckets:                         instrument.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 1 * time.Hour,
 		}, []string{"method", "route", "status_code", "ws"}),
 
 		rxMessageSize: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "faro_receiver_request_message_bytes",
-			Help:    "Size (in bytes) of messages received in the request.",
-			Buckets: middleware.BodySizeBuckets,
+			Name:                            "faro_receiver_request_message_bytes",
+			Help:                            "Size (in bytes) of messages received in the request.",
+			Buckets:                         middleware.BodySizeBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 1 * time.Hour,
 		}, []string{"method", "route"}),
 
 		txMessageSize: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "faro_receiver_response_message_bytes",
-			Help:    "Size (in bytes) of messages sent in response.",
-			Buckets: middleware.BodySizeBuckets,
+			Name:                            "faro_receiver_response_message_bytes",
+			Help:                            "Size (in bytes) of messages sent in response.",
+			Buckets:                         middleware.BodySizeBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 1 * time.Hour,
 		}, []string{"method", "route"}),
 
 		inflightRequests: prometheus.NewGaugeVec(prometheus.GaugeOpts{

--- a/internal/component/loki/rules/kubernetes/rules.go
+++ b/internal/component/loki/rules/kubernetes/rules.go
@@ -111,10 +111,13 @@ func newMetrics() *metrics {
 			Help:      "Total number of retries across all events, partitioned by event type.",
 		}, []string{"type"}),
 		lokiClientTiming: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Subsystem: "loki_rules",
-			Name:      "loki_client_request_duration_seconds",
-			Help:      "Duration of requests to the Loki API.",
-			Buckets:   instrument.DefBuckets,
+			Subsystem:                       "loki_rules",
+			Name:                            "loki_client_request_duration_seconds",
+			Help:                            "Duration of requests to the Loki API.",
+			Buckets:                         instrument.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 1 * time.Hour,
 		}, instrument.HistogramCollectorBuckets),
 	}
 }

--- a/internal/component/loki/source/aws_firehose/metrics.go
+++ b/internal/component/loki/source/aws_firehose/metrics.go
@@ -1,6 +1,8 @@
 package aws_firehose
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/alloy/internal/util"
@@ -34,8 +36,12 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 			Help: "Number of records received from AWS Firehose",
 		}, []string{"type"})).(*prometheus.CounterVec),
 		batchSize: util.MustRegisterOrGet(reg, prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name: "loki_source_awsfirehose_batch_size",
-			Help: "AWS Firehose received batch size in number of records",
+			Name:                            "loki_source_awsfirehose_batch_size",
+			Help:                            "AWS Firehose received batch size in number of records",
+			Buckets:                         prometheus.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 1 * time.Hour,
 		})).(prometheus.Observer),
 		invalidStaticLabelsCount: util.MustRegisterOrGet(reg, prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "loki_source_awsfirehose_invalid_static_labels_errors",

--- a/internal/component/mimir/alerts/kubernetes/events.go
+++ b/internal/component/mimir/alerts/kubernetes/events.go
@@ -84,10 +84,13 @@ func newMetrics() *metrics {
 			Help:      "Total number of retries across all events, partitioned by event type.",
 		}, []string{"type"}),
 		mimirClientTiming: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Subsystem: "mimir_alerts",
-			Name:      "mimir_client_request_duration_seconds",
-			Help:      "Duration of requests to the Mimir API.",
-			Buckets:   instrument.DefBuckets,
+			Subsystem:                       "mimir_alerts",
+			Name:                            "mimir_client_request_duration_seconds",
+			Help:                            "Duration of requests to the Mimir API.",
+			Buckets:                         instrument.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 1 * time.Hour,
 		}, instrument.HistogramCollectorBuckets),
 	}
 }

--- a/internal/component/mimir/rules/kubernetes/rules.go
+++ b/internal/component/mimir/rules/kubernetes/rules.go
@@ -114,10 +114,13 @@ func newMetrics() *metrics {
 			Help:      "Total number of retries across all events, partitioned by event type.",
 		}, []string{"type"}),
 		mimirClientTiming: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Subsystem: "mimir_rules",
-			Name:      "mimir_client_request_duration_seconds",
-			Help:      "Duration of requests to the Mimir API.",
-			Buckets:   instrument.DefBuckets,
+			Subsystem:                       "mimir_rules",
+			Name:                            "mimir_client_request_duration_seconds",
+			Help:                            "Duration of requests to the Mimir API.",
+			Buckets:                         instrument.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 1 * time.Hour,
 		}, instrument.HistogramCollectorBuckets),
 	}
 }

--- a/internal/component/prometheus/fanout.go
+++ b/internal/component/prometheus/fanout.go
@@ -60,9 +60,12 @@ func normalizeChildren(children []storage.Appendable) []storage.Appendable {
 // NewFanout creates a fanout appendable.
 func NewFanout(children []storage.Appendable, componentID string, register prometheus.Registerer, ls labelstore.LabelStore) *Fanout {
 	wl := prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    "prometheus_fanout_latency",
-		Help:    "Write latency for sending to direct and indirect components",
-		Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60},
+		Name:                            "prometheus_fanout_latency",
+		Help:                            "Write latency for sending to direct and indirect components",
+		Buckets:                         []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60},
+		NativeHistogramBucketFactor:     1.1,
+		NativeHistogramMaxBucketNumber:  100,
+		NativeHistogramMinResetDuration: 1 * time.Hour,
 	})
 	_ = register.Register(wl)
 

--- a/internal/component/pyroscope/appender.go
+++ b/internal/component/pyroscope/appender.go
@@ -83,8 +83,12 @@ func (f *Fanout) Upload(j debuginfo.UploadJob) {
 // NewFanout creates a fanout appendable.
 func NewFanout(children []Appendable, componentID string, register prometheus.Registerer) *Fanout {
 	wl := prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name: "pyroscope_fanout_latency",
-		Help: "Write latency for sending to pyroscope profiles",
+		Name:                            "pyroscope_fanout_latency",
+		Help:                            "Write latency for sending to pyroscope profiles",
+		Buckets:                         prometheus.DefBuckets,
+		NativeHistogramBucketFactor:     1.1,
+		NativeHistogramMaxBucketNumber:  100,
+		NativeHistogramMinResetDuration: 1 * time.Hour,
 	})
 	_ = register.Register(wl)
 

--- a/internal/component/pyroscope/write/metrics.go
+++ b/internal/component/pyroscope/write/metrics.go
@@ -1,6 +1,8 @@
 package write
 
 import (
+	"time"
+
 	pyrometricsutil "github.com/grafana/alloy/internal/component/pyroscope/util/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -38,8 +40,12 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 			Help: "Total number of retries to Pyroscope.",
 		}, []string{"endpoint"}),
 		latency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name: "pyroscope_write_latency",
-			Help: "Write latency for sending profiles to pyroscope",
+			Name:                            "pyroscope_write_latency",
+			Help:                            "Write latency for sending profiles to pyroscope",
+			Buckets:                         prometheus.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 1 * time.Hour,
 		}, []string{"endpoint", "type"}),
 		debugInfoUploadBytes: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "pyroscope_ebpf_debug_info_upload_bytes_total",

--- a/internal/service/http/http.go
+++ b/internal/service/http/http.go
@@ -239,9 +239,7 @@ func (s *Service) Run(ctx context.Context, host service.Host) error {
 
 	r.Handle(
 		"/metrics",
-		promhttp.HandlerFor(s.gatherer, promhttp.HandlerOpts{
-			EnableOpenMetrics: true,
-		}),
+		promhttp.HandlerFor(s.gatherer, promhttp.HandlerOpts{}),
 	)
 	if s.opts.EnablePProf {
 		r.PathPrefix("/debug/pprof").Handler(http.DefaultServeMux)

--- a/internal/service/http/http.go
+++ b/internal/service/http/http.go
@@ -239,7 +239,9 @@ func (s *Service) Run(ctx context.Context, host service.Host) error {
 
 	r.Handle(
 		"/metrics",
-		promhttp.HandlerFor(s.gatherer, promhttp.HandlerOpts{}),
+		promhttp.HandlerFor(s.gatherer, promhttp.HandlerOpts{
+			EnableOpenMetrics: true,
+		}),
 	)
 	if s.opts.EnablePProf {
 		r.PathPrefix("/debug/pprof").Handler(http.DefaultServeMux)

--- a/internal/service/remotecfg/metrics.go
+++ b/internal/service/remotecfg/metrics.go
@@ -2,6 +2,7 @@ package remotecfg
 
 import (
 	"errors"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -69,8 +70,12 @@ func registerMetrics(reg prometheus.Registerer) *metrics {
 		),
 		getConfigTime: prometheus.NewHistogram(
 			prometheus.HistogramOpts{
-				Name: "remotecfg_request_duration_seconds",
-				Help: "Duration of remote configuration requests.",
+				Name:                            "remotecfg_request_duration_seconds",
+				Help:                            "Duration of remote configuration requests.",
+				Buckets:                         prometheus.DefBuckets,
+				NativeHistogramBucketFactor:     1.1,
+				NativeHistogramMaxBucketNumber:  100,
+				NativeHistogramMinResetDuration: 1 * time.Hour,
 			},
 		),
 	}

--- a/internal/service/remotecfg/metrics_test.go
+++ b/internal/service/remotecfg/metrics_test.go
@@ -324,3 +324,39 @@ func TestHistogramBuckets(t *testing.T) {
 	// Verify total count matches our observations
 	assert.Equal(t, uint64(len(observations)), histogram.GetSampleCount())
 }
+
+func TestNativeHistogramsEnabled(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := registerMetrics(reg)
+
+	// Observe some values to populate the histogram with data
+	for _, obs := range []float64{0.001, 0.01, 0.1, 0.5, 1.0} {
+		m.getConfigTime.Observe(obs)
+	}
+
+	// Gather metrics from the registry
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+
+	// Find the remotecfg_request_duration_seconds histogram
+	var h *dto.Histogram
+	for _, mf := range mfs {
+		if mf.GetName() == "remotecfg_request_duration_seconds" {
+			h = mf.GetMetric()[0].GetHistogram()
+			break
+		}
+	}
+	require.NotNil(t, h, "remotecfg_request_duration_seconds metric should be found")
+
+	// Verify classic buckets are still present.
+	// This confirms the histogram is in "both" mode — not native-only.
+	// Scrapers that don't support native histograms still get classic buckets.
+	assert.NotEmpty(t, h.GetBucket(),
+		"classic histogram buckets must be present for backward compatibility")
+
+	// Verify native histogram schema is set.
+	// Schema is populated by the client when NativeHistogramBucketFactor > 0.
+	// A nil schema means native histograms are NOT configured.
+	assert.NotNil(t, h.Schema,
+		"native histogram schema must be set — NativeHistogramBucketFactor should be configured")
+}

--- a/internal/static/integrations/snmp_exporter/snmp_exporter.go
+++ b/internal/static/integrations/snmp_exporter/snmp_exporter.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -145,9 +146,13 @@ func NewSNMPMetrics(reg prometheus.Registerer) collector.Metrics {
 	return collector.Metrics{
 		SNMPCollectionDuration: promauto.With(reg).NewHistogramVec(
 			prometheus.HistogramOpts{
-				Namespace: namespace,
-				Name:      "collection_duration_seconds",
-				Help:      "Duration of collections by the SNMP exporter",
+				Namespace:                       namespace,
+				Name:                            "collection_duration_seconds",
+				Help:                            "Duration of collections by the SNMP exporter",
+				Buckets:                         prometheus.DefBuckets,
+				NativeHistogramBucketFactor:     1.1,
+				NativeHistogramMaxBucketNumber:  100,
+				NativeHistogramMinResetDuration: 1 * time.Hour,
 			},
 			[]string{"module"},
 		),
@@ -160,10 +165,13 @@ func NewSNMPMetrics(reg prometheus.Registerer) collector.Metrics {
 		),
 		SNMPDuration: promauto.With(reg).NewHistogram(
 			prometheus.HistogramOpts{
-				Namespace: namespace,
-				Name:      "packet_duration_seconds",
-				Help:      "A histogram of latencies for SNMP packets.",
-				Buckets:   buckets,
+				Namespace:                       namespace,
+				Name:                            "packet_duration_seconds",
+				Help:                            "A histogram of latencies for SNMP packets.",
+				Buckets:                         buckets,
+				NativeHistogramBucketFactor:     1.1,
+				NativeHistogramMaxBucketNumber:  100,
+				NativeHistogramMinResetDuration: 1 * time.Hour,
 			},
 		),
 		SNMPPackets: promauto.With(reg).NewCounter(

--- a/operations/alloy-mixin/dashboards/loki.libsonnet
+++ b/operations/alloy-mixin/dashboards/loki.libsonnet
@@ -82,9 +82,17 @@ local filename = 'alloy-loki.json';
       panel.withQueries([
         panel.newQuery(
           expr=|||
-            sum by(${groupby}) (rate(loki_write_request_duration_seconds_bucket{%(instanceSelector)s, status_code=~"2..", host=~"$url"}[$__rate_interval]))
+            (
+              sum by(${groupby}) (rate(loki_write_request_duration_seconds{%(instanceSelector)s, status_code=~"2..", host=~"$url"}[$__rate_interval]))
+              or ignoring(le)
+              sum by(${groupby}) (rate(loki_write_request_duration_seconds_bucket{%(instanceSelector)s, status_code=~"2..", host=~"$url"}[$__rate_interval]))
+            )
             /
-            sum by(${groupby}) (rate(loki_write_request_duration_seconds_bucket{%(instanceSelector)s, host=~"$url"}[$__rate_interval])) * 100 
+            (
+              sum by(${groupby}) (rate(loki_write_request_duration_seconds{%(instanceSelector)s, host=~"$url"}[$__rate_interval]))
+              or ignoring(le)
+              sum by(${groupby}) (rate(loki_write_request_duration_seconds_bucket{%(instanceSelector)s, host=~"$url"}[$__rate_interval]))
+            ) * 100
           ||| % $._config,
         ),
       ])
@@ -103,8 +111,15 @@ local filename = 'alloy-loki.json';
           expr=|||
             histogram_quantile(
               0.99,
+              sum by (${groupby}) (
+                rate(loki_write_request_duration_seconds{%(instanceSelector)s, host=~"$url"}[$__rate_interval])
+              )
+            )
+            or ignoring(le)
+            histogram_quantile(
+              0.99,
               sum by (le, ${groupby}) (
-            	rate(loki_write_request_duration_seconds_bucket{%(instanceSelector)s, host=~"$url"}[$__rate_interval])
+                rate(loki_write_request_duration_seconds_bucket{%(instanceSelector)s, host=~"$url"}[$__rate_interval])
               )
             )
           ||| % $._config,
@@ -114,8 +129,15 @@ local filename = 'alloy-loki.json';
           expr=|||
             histogram_quantile(
               0.95,
+              sum by (${groupby}) (
+                rate(loki_write_request_duration_seconds{%(instanceSelector)s, host=~"$url"}[$__rate_interval])
+              )
+            )
+            or ignoring(le)
+            histogram_quantile(
+              0.95,
               sum by (le, ${groupby}) (
-            	rate(loki_write_request_duration_seconds_bucket{%(instanceSelector)s, host=~"$url"}[$__rate_interval])
+                rate(loki_write_request_duration_seconds_bucket{%(instanceSelector)s, host=~"$url"}[$__rate_interval])
               )
             )
           ||| % $._config,
@@ -125,8 +147,15 @@ local filename = 'alloy-loki.json';
           expr=|||
             histogram_quantile(
               0.50,
+              sum by (${groupby}) (
+                rate(loki_write_request_duration_seconds{%(instanceSelector)s, host=~"$url"}[$__rate_interval])
+              )
+            )
+            or ignoring(le)
+            histogram_quantile(
+              0.50,
               sum by (le, ${groupby}) (
-            	rate(loki_write_request_duration_seconds_bucket{%(instanceSelector)s, host=~"$url"}[$__rate_interval])
+                rate(loki_write_request_duration_seconds_bucket{%(instanceSelector)s, host=~"$url"}[$__rate_interval])
               )
             )
           ||| % $._config,

--- a/operations/alloy-mixin/rendered/dashboards/alloy-loki.json
+++ b/operations/alloy-mixin/rendered/dashboards/alloy-loki.json
@@ -181,7 +181,7 @@
          "targets": [
             {
                "datasource": "${datasource}",
-               "expr": "sum by(${groupby}) (rate(loki_write_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", status_code=~\"2..\", host=~\"$url\"}[$__rate_interval]))\n/\nsum by(${groupby}) (rate(loki_write_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", host=~\"$url\"}[$__rate_interval])) * 100 \n",
+               "expr": "(\n  sum by(${groupby}) (rate(loki_write_request_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", status_code=~\"2..\", host=~\"$url\"}[$__rate_interval]))\n  or ignoring(le)\n  sum by(${groupby}) (rate(loki_write_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", status_code=~\"2..\", host=~\"$url\"}[$__rate_interval]))\n)\n/\n(\n  sum by(${groupby}) (rate(loki_write_request_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", host=~\"$url\"}[$__rate_interval]))\n  or ignoring(le)\n  sum by(${groupby}) (rate(loki_write_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", host=~\"$url\"}[$__rate_interval]))\n) * 100\n",
                "instant": false,
                "legendFormat": "__auto",
                "range": true
@@ -207,21 +207,21 @@
          "targets": [
             {
                "datasource": "${datasource}",
-               "expr": "histogram_quantile(\n  0.99,\n  sum by (le, ${groupby}) (\n\trate(loki_write_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", host=~\"$url\"}[$__rate_interval])\n  )\n)\n",
+               "expr": "histogram_quantile(\n  0.99,\n  sum by (${groupby}) (\n    rate(loki_write_request_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", host=~\"$url\"}[$__rate_interval])\n  )\n)\nor ignoring(le)\nhistogram_quantile(\n  0.99,\n  sum by (le, ${groupby}) (\n    rate(loki_write_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", host=~\"$url\"}[$__rate_interval])\n  )\n)\n",
                "instant": false,
                "legendFormat": "{{${groupby}}} p99",
                "range": true
             },
             {
                "datasource": "${datasource}",
-               "expr": "histogram_quantile(\n  0.95,\n  sum by (le, ${groupby}) (\n\trate(loki_write_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", host=~\"$url\"}[$__rate_interval])\n  )\n)\n",
+               "expr": "histogram_quantile(\n  0.95,\n  sum by (${groupby}) (\n    rate(loki_write_request_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", host=~\"$url\"}[$__rate_interval])\n  )\n)\nor ignoring(le)\nhistogram_quantile(\n  0.95,\n  sum by (le, ${groupby}) (\n    rate(loki_write_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", host=~\"$url\"}[$__rate_interval])\n  )\n)\n",
                "instant": false,
                "legendFormat": "{{${groupby}}} p95",
                "range": true
             },
             {
                "datasource": "${datasource}",
-               "expr": "histogram_quantile(\n  0.50,\n  sum by (le, ${groupby}) (\n\trate(loki_write_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", host=~\"$url\"}[$__rate_interval])\n  )\n)\n",
+               "expr": "histogram_quantile(\n  0.50,\n  sum by (${groupby}) (\n    rate(loki_write_request_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", host=~\"$url\"}[$__rate_interval])\n  )\n)\nor ignoring(le)\nhistogram_quantile(\n  0.50,\n  sum by (le, ${groupby}) (\n    rate(loki_write_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", host=~\"$url\"}[$__rate_interval])\n  )\n)\n",
                "instant": false,
                "legendFormat": "{{${groupby}}} p50",
                "range": true


### PR DESCRIPTION
### Brief description of Pull Request
Initially, these components were using classic histograms, which create multiple time series — this becomes expensive when multiple Alloy instances are running at scale.

With native histograms, the full distribution is stored in a single time series instead of one series per bucket like classic histograms.

Native histograms were already enabled for some components, for example in `internal/runtime/internal/controller/metrics.go:`

```
cm.componentEvaluationTime = prometheus.NewHistogram(
		prometheus.HistogramOpts{
			Name:                            "alloy_component_evaluation_seconds",
			Help:                            "Time spent performing component evaluation",
			ConstLabels:                     map[string]string{"controller_path": parent, "controller_id": id},
			Buckets:                         evaluationTimesBuckets,
			NativeHistogramBucketFactor:     1.1,
			NativeHistogramMaxBucketNumber:  100,
			NativeHistogramMinResetDuration: 1 * time.Hour,
		},
	)
```


i followed the same pattern and enabled it in - these metrices : 

1. remotecfg_request_duration_seconds
2. prometheus_fanout_latency
3. loki_write_request_duration_seconds
4. loki_write_request_size_bytes 
5. loki_write_entry_propagation_latency_seconds
6. faro_receiver_request_duration_seconds
7. faro_receiver_request_message_bytes
8. faro_receiver_response_message_bytes
9. loki_rules_loki_client_request_duration_seconds
10. loki_source_awsfirehose_batch_size
11. mimir_alerts_mimir_client_request_duration_seconds
12. mimir_rules_mimir_client_request_duration_seconds
13. pyroscope_fanout_latency
14. pyroscope_write_latency
15. snmp_collection_duration_seconds
16. snmp_packet_duration_seconds

The same constant values were used as in `alloy_component_evaluation_seconds`:
```
NativeHistogramBucketFactor:     1.1,
NativeHistogramMaxBucketNumber:  100,
NativeHistogramMinResetDuration: 1 * time.Hour
```

As we enabled native histograms on `loki_write_request_duration_seconds`, we also updated the `loki.write` panel queries in `loki.libsonnet` — they were still using the classic histogram format (`_bucket` suffix). With this update, the Grafana dashboard queries native histograms first with a fallback to classic histograms using the `or ignoring(le)` pattern.

Note : wrong understanding -
~~Added EnableOpenMetrics: true to promhttp.HandlerOpts in the /metrics handler. Without this, native histogram data stored in the registry is never transmitted to scrapers~~

### Issue(s) fixed by this Pull Request

Fixes #6098

### PR Checklist

- [x] Tests updated