### PR TITLE
ci: Add missing wait for docker in windows workflow file

### DIFF
--- a/.github/workflows/check-windows-build-image.yml
+++ b/.github/workflows/check-windows-build-image.yml
@@ -12,6 +12,14 @@ jobs:
   check-windows-build-image:
     runs-on: windows-2022
     steps:
+      - name: Ensure Docker is running (Docker issue workaround)
+        id: docker-workaround
+        run: |
+          $dockerState = Get-Service -Name "docker"
+          if ($dockerState.Status -ne "Running") {
+            Start-Service -Name "docker"
+          }
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
Related: https://github.com/grafana/alloy/pull/5985#discussion_r3063724519