### PR TITLE
chore: Bump mise go version with command

### DIFF
--- a/tools/goversion/command.go
+++ b/tools/goversion/command.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -76,14 +77,20 @@ func pr2Command() *cobra.Command {
 
 			version := args[0]
 
+			if err := updateMiseToml(root, version); err != nil {
+				return fmt.Errorf("error updating mise.toml: %w", err)
+			}
+
 			if err := updateGoModFiles(root, version); err != nil {
 				log.Fatalf("failed to update go.mod files: %s", err)
 				return fmt.Errorf("error updating go.mod files: %w", err)
 			}
+
 			if err := updateDockerFiles(root, version); err != nil {
 				log.Fatalf("failed to update Dockerfiles: %s", err)
 				return fmt.Errorf("error updating Dockerfiles: %w", err)
 			}
+
 			if err := bumpBuildImage(root); err != nil {
 				return fmt.Errorf("error updating build image: %w", err)
 			}
@@ -95,33 +102,6 @@ func pr2Command() *cobra.Command {
 	f.RootFlag.Register(cmd)
 
 	return cmd
-}
-
-func updateBuildImage(root string, version string) error {
-	paths := []string{
-		".github/workflows/create_build_image.yml",
-		".github/workflows/check-linux-build-image.yml",
-		"build-tools/build-image/windows/Dockerfile",
-	}
-
-	for _, path := range paths {
-		path = filepath.Join(root, path)
-		content, err := os.ReadFile(path)
-		if err != nil {
-			return fmt.Errorf("failed to read file: %w", err)
-		}
-
-		out, err := replaceDockerGoVersion(content, version)
-		if err != nil {
-			return fmt.Errorf("update %s: %w", path, err)
-		}
-
-		if err := os.WriteFile(path, out, 0644); err != nil {
-			return fmt.Errorf("failed to update file: %w", err)
-		}
-	}
-
-	return nil
 }
 
 func updateGoModFiles(root, version string) error {
@@ -169,6 +149,66 @@ func updateDockerFiles(root, version string) error {
 		}
 	}
 
+	return nil
+}
+
+func updateBuildImage(root string, version string) error {
+	paths := []string{
+		".github/workflows/create_build_image.yml",
+		".github/workflows/check-linux-build-image.yml",
+		"build-tools/build-image/windows/Dockerfile",
+	}
+
+	for _, path := range paths {
+		path = filepath.Join(root, path)
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read file: %w", err)
+		}
+
+		out, err := replaceDockerGoVersion(content, version)
+		if err != nil {
+			return fmt.Errorf("update %s: %w", path, err)
+		}
+
+		if err := os.WriteFile(path, out, 0644); err != nil {
+			return fmt.Errorf("failed to update file: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// miseGoVersionRE matches the go tool line in mise.toml, e.g. `go = "1.26.3"`.
+var miseGoVersionRE = regexp.MustCompile(`(?m)^go\s*=\s*"[^"]*"`)
+
+// updateMiseToml bumps the go version in mise.toml and refreshes the lockfile
+// so the pinned checksums and URLs match the new version.
+func updateMiseToml(root, version string) error {
+	path := filepath.Join(root, "mise.toml")
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+
+	if !miseGoVersionRE.Match(content) {
+		return fmt.Errorf("no go version found in %s", path)
+	}
+
+	newContent := miseGoVersionRE.ReplaceAllLiteral(content, []byte(`go = "`+version+`"`))
+	if err := os.WriteFile(path, newContent, 0644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+
+	cmd := exec.Command("mise", "lock", "go")
+	cmd.Dir = root
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("mise lock: %w", err)
+	}
 	return nil
 }
 

--- a/tools/goversion/command.go
+++ b/tools/goversion/command.go
@@ -104,6 +104,33 @@ func pr2Command() *cobra.Command {
 	return cmd
 }
 
+func updateBuildImage(root string, version string) error {
+	paths := []string{
+		".github/workflows/create_build_image.yml",
+		".github/workflows/check-linux-build-image.yml",
+		"build-tools/build-image/windows/Dockerfile",
+	}
+
+	for _, path := range paths {
+		path = filepath.Join(root, path)
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read file: %w", err)
+		}
+
+		out, err := replaceDockerGoVersion(content, version)
+		if err != nil {
+			return fmt.Errorf("update %s: %w", path, err)
+		}
+
+		if err := os.WriteFile(path, out, 0644); err != nil {
+			return fmt.Errorf("failed to update file: %w", err)
+		}
+	}
+
+	return nil
+}
+
 func updateGoModFiles(root, version string) error {
 	result, err := discover.GoModFiles(root)
 	if err != nil {
@@ -149,66 +176,6 @@ func updateDockerFiles(root, version string) error {
 		}
 	}
 
-	return nil
-}
-
-func updateBuildImage(root string, version string) error {
-	paths := []string{
-		".github/workflows/create_build_image.yml",
-		".github/workflows/check-linux-build-image.yml",
-		"build-tools/build-image/windows/Dockerfile",
-	}
-
-	for _, path := range paths {
-		path = filepath.Join(root, path)
-		content, err := os.ReadFile(path)
-		if err != nil {
-			return fmt.Errorf("failed to read file: %w", err)
-		}
-
-		out, err := replaceDockerGoVersion(content, version)
-		if err != nil {
-			return fmt.Errorf("update %s: %w", path, err)
-		}
-
-		if err := os.WriteFile(path, out, 0644); err != nil {
-			return fmt.Errorf("failed to update file: %w", err)
-		}
-	}
-
-	return nil
-}
-
-// miseGoVersionRE matches the go tool line in mise.toml, e.g. `go = "1.26.3"`.
-var miseGoVersionRE = regexp.MustCompile(`(?m)^go\s*=\s*"[^"]*"`)
-
-// updateMiseToml bumps the go version in mise.toml and refreshes the lockfile
-// so the pinned checksums and URLs match the new version.
-func updateMiseToml(root, version string) error {
-	path := filepath.Join(root, "mise.toml")
-
-	content, err := os.ReadFile(path)
-	if err != nil {
-		return fmt.Errorf("read %s: %w", path, err)
-	}
-
-	if !miseGoVersionRE.Match(content) {
-		return fmt.Errorf("no go version found in %s", path)
-	}
-
-	newContent := miseGoVersionRE.ReplaceAllLiteral(content, []byte(`go = "`+version+`"`))
-	if err := os.WriteFile(path, newContent, 0644); err != nil {
-		return fmt.Errorf("write %s: %w", path, err)
-	}
-
-	cmd := exec.Command("mise", "lock", "go")
-	cmd.Dir = root
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("mise lock: %w", err)
-	}
 	return nil
 }
 
@@ -335,4 +302,37 @@ func replaceDockerGoVersion(content []byte, version string) ([]byte, error) {
 	}
 	out.Write(content[last:])
 	return out.Bytes(), nil
+}
+
+// miseGoVersionRE matches the go tool line in mise.toml, e.g. `go = "1.26.3"`.
+var miseGoVersionRE = regexp.MustCompile(`(?m)^go\s*=\s*"[^"]*"`)
+
+// updateMiseToml bumps the go version in mise.toml and refreshes the lockfile
+// so the pinned checksums and URLs match the new version.
+func updateMiseToml(root, version string) error {
+	path := filepath.Join(root, "mise.toml")
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+
+	if !miseGoVersionRE.Match(content) {
+		return fmt.Errorf("no go version found in %s", path)
+	}
+
+	newContent := miseGoVersionRE.ReplaceAllLiteral(content, []byte(`go = "`+version+`"`))
+	if err := os.WriteFile(path, newContent, 0644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+
+	cmd := exec.Command("mise", "lock", "go")
+	cmd.Dir = root
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("mise lock: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
When updating go version in alloy repo we also need to bump the version stored in `mise.toml` and update `mise.lock`.