### PR TITLE
chore: Migrate test workflows mise setup

### DIFF
--- a/.github/actions/go-cache/action.yml
+++ b/.github/actions/go-cache/action.yml
@@ -6,16 +6,17 @@ runs:
   using: composite
   steps:
     - name: Resolve Go cache locations
+      id: go-cache-paths
       shell: bash
       run: |
-        echo "GO_MOD_CACHE=$(go env GOMODCACHE)" >> $GITHUB_ENV
-        echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> $GITHUB_ENV
+        echo "go-mod-cache=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+        echo "go-build-cache=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
     - name: Cache Go modules and build cache
       uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: |
-          ${{ env.GO_MOD_CACHE }}
-          ${{ env.GO_BUILD_CACHE }}
+          ${{ steps.go-cache-paths.outputs.go-mod-cache }}
+          ${{ steps.go-cache-paths.outputs.go-build-cache }}
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-

--- a/.github/actions/go-cache/action.yml
+++ b/.github/actions/go-cache/action.yml
@@ -1,0 +1,21 @@
+name: Cache Go modules and build
+description: |
+  Restore and save the Go module and build caches. Use after Go is installed
+  (e.g. via mise), since it resolves the cache locations with `go env`.
+runs:
+  using: composite
+  steps:
+    - name: Resolve Go cache locations
+      shell: bash
+      run: |
+        echo "GO_MOD_CACHE=$(go env GOMODCACHE)" >> $GITHUB_ENV
+        echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> $GITHUB_ENV
+    - name: Cache Go modules and build cache
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      with:
+        path: |
+          ${{ env.GO_MOD_CACHE }}
+          ${{ env.GO_BUILD_CACHE }}
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,8 @@ jobs:
     - name: Setup tools
       uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
       with:
+        version: v2026.5.18
+        sha256: cfac593469d028d7ae5fe36e37bd7c59118b5238e92d8a876209578464f24a84
         install_args: go task golangci-lint
 
     - name: Lint Go
@@ -42,6 +44,8 @@ jobs:
     - name: Setup tools
       uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
       with:
+        version: v2026.5.18
+        sha256: cfac593469d028d7ae5fe36e37bd7c59118b5238e92d8a876209578464f24a84
         install_args: go govulncheck task
 
     - name: Run govulncheck
@@ -60,6 +64,8 @@ jobs:
     - name: Setup tools
       uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
       with:
+        version: v2026.5.18
+        sha256: cfac593469d028d7ae5fe36e37bd7c59118b5238e92d8a876209578464f24a84
         install_args: shellcheck task go
 
     - name: Run shellcheck
@@ -81,6 +87,8 @@ jobs:
     - name: Setup tools
       uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
       with:
+        version: v2026.5.18
+        sha256: cfac593469d028d7ae5fe36e37bd7c59118b5238e92d8a876209578464f24a84
         install_args: node
 
     - name: Install dependencies

--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -23,15 +23,16 @@ jobs:
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         persist-credentials: false
+
     - name: Set ownership
       # https://github.com/actions/runner/issues/2033#issuecomment-1204205989
       run: |
           # this is to fix GIT not liking owner of the checkout dir
           chown -R $(id -u):$(id -g) $PWD
-    - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+
+    - name: Setup tools
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       with:
-        go-version-file: go.mod
-        # TODO: Enable caching later.
-        cache: false
+        install_args: go
+
     - run: K8S_USE_DOCKER_NETWORK=1 make test

--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -33,6 +33,8 @@ jobs:
     - name: Setup tools
       uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       with:
+        version: v2026.5.18
+        sha256: cfac593469d028d7ae5fe36e37bd7c59118b5238e92d8a876209578464f24a84
         install_args: go
 
     - run: K8S_USE_DOCKER_NETWORK=1 make test

--- a/.github/workflows/test_linux_system_packages.yml
+++ b/.github/workflows/test_linux_system_packages.yml
@@ -25,16 +25,17 @@ jobs:
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         persist-credentials: false
+
     - name: Set ownership
       # https://github.com/actions/runner/issues/2033#issuecomment-1204205989
       run: |
           # this is to fix GIT not liking owner of the checkout dir
           chown -R $(id -u):$(id -g) $PWD
-    - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+
+    - name: Setup tools
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       with:
-        go-version-file: go.mod
-        # TODO: Enable caching later
-        cache: false
+        install_args: go
+
     - run: DOCKER_OPTS="" make dist/alloy-linux-amd64
     - run: DOCKER_OPTS="" make test-packages

--- a/.github/workflows/test_linux_system_packages.yml
+++ b/.github/workflows/test_linux_system_packages.yml
@@ -35,6 +35,8 @@ jobs:
     - name: Setup tools
       uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       with:
+        version: v2026.5.18
+        sha256: cfac593469d028d7ae5fe36e37bd7c59118b5238e92d8a876209578464f24a84
         install_args: go
 
     - run: DOCKER_OPTS="" make dist/alloy-linux-amd64

--- a/.github/workflows/test_mac.yml
+++ b/.github/workflows/test_mac.yml
@@ -27,6 +27,8 @@ jobs:
     - name: Setup tools
       uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       with:
+        version: v2026.5.18
+        sha256: 998428f820e22301bab9273cba8b4e59d05a40f77a9a8411d75b2de85fbb0335
         install_args: go
 
     - name: Cache Go modules and build
@@ -51,6 +53,8 @@ jobs:
     - name: Setup tools
       uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       with:
+        version: v2026.5.18
+        sha256: 998428f820e22301bab9273cba8b4e59d05a40f77a9a8411d75b2de85fbb0335
         install_args: go
 
     - run: cd collector && go build .

--- a/.github/workflows/test_mac.yml
+++ b/.github/workflows/test_mac.yml
@@ -29,6 +29,9 @@ jobs:
       with:
         install_args: go
 
+    - name: Cache Go modules and build
+      uses: ./.github/actions/go-cache
+
     - name: Test
       run: CGO_LDFLAGS="-ld_classic $CGO_LDFLAGS" make GO_TAGS="nodocker" test
 

--- a/.github/workflows/test_mac.yml
+++ b/.github/workflows/test_mac.yml
@@ -23,11 +23,12 @@ jobs:
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         persist-credentials: false
-    - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+
+    - name: Setup tools
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       with:
-        go-version-file: go.mod
-        cache: true
+        install_args: go
+
     - name: Test
       run: CGO_LDFLAGS="-ld_classic $CGO_LDFLAGS" make GO_TAGS="nodocker" test
 
@@ -43,10 +44,11 @@ jobs:
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         persist-credentials: false
-    - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+
+    - name: Setup tools
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       with:
-        go-version-file: go.mod
-        cache: false
+        install_args: go
+
     - run: cd collector && go build .
     - run: go build ./internal/component/pyroscope/util/internal/cmd/playground

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -21,6 +21,8 @@ jobs:
     - name: Setup tools
       uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       with:
+        version: v2026.5.18
+        sha256: cfac593469d028d7ae5fe36e37bd7c59118b5238e92d8a876209578464f24a84
         install_args: go
 
     - run: make GO_TAGS="nodocker" test

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -18,10 +18,9 @@ jobs:
       with:
           persist-credentials: false
 
-    - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+    - name: Setup tools
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       with:
-        go-version-file: go.mod
-        cache: false
+        install_args: go
 
     - run: make GO_TAGS="nodocker" test

--- a/.github/workflows/test_pyroscope_pr.yml
+++ b/.github/workflows/test_pyroscope_pr.yml
@@ -20,10 +20,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - name: Setup tools
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          go-version-file: go.mod
-          cache: false
+          install_args: go
 
       - run: sudo make test-pyroscope

--- a/.github/workflows/test_pyroscope_pr.yml
+++ b/.github/workflows/test_pyroscope_pr.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Setup tools
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
+          version: v2026.5.18
+          sha256: cfac593469d028d7ae5fe36e37bd7c59118b5238e92d8a876209578464f24a84
           install_args: go
 
       - run: sudo make test-pyroscope

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -23,10 +23,11 @@ jobs:
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         persist-credentials: false
-    - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+
+    - name: Setup tools
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       with:
-        go-version-file: go.mod
-        cache: false
+        install_args: go
+
     - name: Test
       run: '& "C:/Program Files/git/bin/bash.exe" -c ''make GO_TAGS="nodocker nonetwork" test'''

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -27,6 +27,8 @@ jobs:
     - name: Setup tools
       uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       with:
+        version: v2026.5.18
+        sha256: 62aad5146848c6fb278eff90558940bd5685bb3ba7e34d64fd4e6ec9ed431f0d
         install_args: go
 
     - name: Test


### PR DESCRIPTION
Migrate test_* workflows to install go thorugh mise.

For the mac workflow we did have cache enabled. Mise will cache tools installed but not go modules or go build output so I created a resuable action for it.