### PR TITLE
fix(loki.process): No longer mutate rules in stage.truncate causing every config update to reload pipeline when this stage is used [backport]

### DIFF
--- a/internal/component/loki/process/stages/stage.go
+++ b/internal/component/loki/process/stages/stage.go
@@ -187,10 +187,7 @@ func New(logger log.Logger, cfg StageConfig, registerer prometheus.Registerer, m
 			return nil, err
 		}
 	case cfg.TruncateConfig != nil:
-		s, err = newTruncateStage(logger, *cfg.TruncateConfig, registerer)
-		if err != nil {
-			return nil, err
-		}
+		s = newTruncateStage(logger, *cfg.TruncateConfig, registerer)
 	default:
 		panic(fmt.Sprintf("unreachable; should have decoded into one of the StageConfig fields: %+v", cfg))
 	}

--- a/internal/component/loki/process/stages/truncate.go
+++ b/internal/component/loki/process/stages/truncate.go
@@ -22,10 +22,10 @@ var (
 	truncateExtractedField          = "extracted"
 )
 
-const (
-	errLimitMustBeGreaterThanZero = "limit must be greater than zero"
-	errSourcesForLine             = "sources cannot be set when source_type is 'line'"
-	errAtLeastOneRule             = "at least one truncate rule must be defined"
+var (
+	errTruncateLimit          = errors.New("limit must be greater than zero")
+	errTruncateSourcesForLine = errors.New("sources cannot be set when source_type is 'line'")
+	errTruncateSuffixLength   = errors.New("suffix length cannot be greater than or equal to limit")
 )
 
 // TruncateConfig contains the configuration for a truncateStage
@@ -38,61 +38,46 @@ type RuleConfig struct {
 	Suffix     string           `alloy:"suffix,attr,optional"`
 	Sources    []string         `alloy:"sources,attr,optional"`
 	SourceType SourceType       `alloy:"source_type,attr,optional"`
-
-	effectiveLimit units.Base2Bytes
 }
 
-// validateTruncateConfig validates the TruncateConfig for the truncateStage
-func validateTruncateConfig(cfg *TruncateConfig) error {
-	if len(cfg.Rules) == 0 {
-		return errors.New(errAtLeastOneRule)
+// SetToDefault implements syntax.Defaulter.
+func (r *RuleConfig) SetToDefault() {
+	*r = RuleConfig{SourceType: SourceTypeLine}
+}
+
+// Validate implements syntax.Validator.
+func (r *RuleConfig) Validate() error {
+	if r.Limit <= 0 {
+		return errTruncateLimit
 	}
-
-	for _, r := range cfg.Rules {
-		r.effectiveLimit = r.Limit
-
-		if r.Limit <= 0 {
-			return errors.New(errLimitMustBeGreaterThanZero)
-		}
-
-		if r.SourceType == "" {
-			r.SourceType = SourceTypeLine
-		}
-
-		if r.SourceType == SourceTypeLine && len(r.Sources) > 0 {
-			return errors.New(errSourcesForLine)
-		}
-
-		if len(r.Suffix) > 0 {
-			if len(r.Suffix) >= int(r.Limit) {
-				return errors.New("suffix length cannot be greater than or equal to limit")
-			}
-
-			r.effectiveLimit -= units.Base2Bytes(len(r.Suffix))
-		}
+	if r.SourceType == SourceTypeLine && len(r.Sources) > 0 {
+		return errTruncateSourcesForLine
 	}
-
+	if len(r.Suffix) > 0 && int(r.Limit) <= len(r.Suffix) {
+		return errTruncateSuffixLength
+	}
 	return nil
 }
 
-// newTruncateStage creates a TruncateStage from config
-func newTruncateStage(logger log.Logger, config TruncateConfig, registerer prometheus.Registerer) (Stage, error) {
-	err := validateTruncateConfig(&config)
-	if err != nil {
-		return nil, err
-	}
+// effectiveLimit returns the truncation threshold after accounting for the
+// suffix length. Computed on demand so RuleConfig stays a pure parse target.
+func (r *RuleConfig) effectiveLimit() units.Base2Bytes {
+	return r.Limit - units.Base2Bytes(len(r.Suffix))
+}
 
+// newTruncateStage creates a TruncateStage from config
+func newTruncateStage(logger log.Logger, cfg TruncateConfig, registerer prometheus.Registerer) Stage {
 	return &truncateStage{
 		logger:         log.With(logger, "component", "stage", "type", "truncate"),
-		cfg:            &config,
+		cfg:            cfg,
 		truncatedCount: getTruncateCountMetric(registerer),
-	}, nil
+	}
 }
 
 // truncateStage applies Label matchers to determine if the include stages should be run
 type truncateStage struct {
 	logger         log.Logger
-	cfg            *TruncateConfig
+	cfg            TruncateConfig
 	truncatedCount *prometheus.CounterVec
 }
 
@@ -105,12 +90,13 @@ func (m *truncateStage) Run(in chan Entry) chan Entry {
 			for _, r := range m.cfg.Rules {
 				switch r.SourceType {
 				case SourceTypeLine:
-					if len(e.Line) > int(r.effectiveLimit) {
-						e.Line = e.Line[:r.effectiveLimit] + r.Suffix
+					limit := r.effectiveLimit()
+					if len(e.Line) > int(limit) {
+						e.Line = e.Line[:limit] + r.Suffix
 						markTruncated(m.truncatedCount, truncated, truncateLineField)
 
 						if Debug {
-							level.Debug(m.logger).Log("msg", "line has been truncated", "limit", r.effectiveLimit, "truncated_line", e.Line)
+							level.Debug(m.logger).Log("msg", "line has been truncated", "limit", limit, "truncated_line", e.Line)
 						}
 					}
 				case SourceTypeLabel:
@@ -172,34 +158,37 @@ func (m *truncateStage) Run(in chan Entry) chan Entry {
 }
 
 func (m *truncateStage) tryTruncateLabel(rule *RuleConfig, l model.LabelSet, name model.LabelName, val model.LabelValue, truncated map[string]struct{}) {
-	if len(val) > int(rule.effectiveLimit) {
-		l[name] = val[:rule.effectiveLimit] + model.LabelValue(rule.Suffix)
+	limit := rule.effectiveLimit()
+	if len(val) > int(limit) {
+		l[name] = val[:limit] + model.LabelValue(rule.Suffix)
 		markTruncated(m.truncatedCount, truncated, truncateLabelField)
 
 		if Debug {
-			level.Debug(m.logger).Log("msg", "label has been truncated", "limit", rule.effectiveLimit, "name", name, "truncated_value", l[name])
+			level.Debug(m.logger).Log("msg", "label has been truncated", "limit", limit, "name", name, "truncated_value", l[name])
 		}
 	}
 }
 
 func (m *truncateStage) tryTruncateExtracted(rule *RuleConfig, extracted map[string]any, name string, val any, truncated map[string]struct{}) {
-	if strVal, ok := val.(string); ok && len(strVal) > int(rule.effectiveLimit) {
-		extracted[name] = strVal[:rule.effectiveLimit] + rule.Suffix
+	limit := rule.effectiveLimit()
+	if strVal, ok := val.(string); ok && len(strVal) > int(limit) {
+		extracted[name] = strVal[:limit] + rule.Suffix
 		markTruncated(m.truncatedCount, truncated, truncateExtractedField)
 
 		if Debug {
-			level.Debug(m.logger).Log("msg", "extracted has been truncated", "limit", rule.effectiveLimit, "name", name, "truncated_value", extracted[name])
+			level.Debug(m.logger).Log("msg", "extracted has been truncated", "limit", limit, "name", name, "truncated_value", extracted[name])
 		}
 	}
 }
 
 func (m *truncateStage) tryTruncateStructuredMetadata(rule *RuleConfig, metadata push.LabelAdapter, truncated map[string]struct{}) push.LabelAdapter {
-	if len(metadata.Value) > int(rule.effectiveLimit) {
-		metadata.Value = metadata.Value[:rule.effectiveLimit] + rule.Suffix
+	limit := rule.effectiveLimit()
+	if len(metadata.Value) > int(limit) {
+		metadata.Value = metadata.Value[:limit] + rule.Suffix
 		markTruncated(m.truncatedCount, truncated, truncateStructuredMetadataField)
 
 		if Debug {
-			level.Debug(m.logger).Log("msg", "structured_metadata has been truncated", "limit", rule.effectiveLimit, "name", metadata.Name, "truncated_value", metadata.Value)
+			level.Debug(m.logger).Log("msg", "structured_metadata has been truncated", "limit", limit, "name", metadata.Name, "truncated_value", metadata.Value)
 		}
 	}
 	return metadata

--- a/internal/component/loki/process/stages/truncate_test.go
+++ b/internal/component/loki/process/stages/truncate_test.go
@@ -1,7 +1,6 @@
 package stages
 
 import (
-	"errors"
 	"testing"
 	"time"
 
@@ -38,8 +37,9 @@ func Test_TruncateStage_Process(t *testing.T) {
 			name: "passthrough when under limits",
 			config: []*RuleConfig{
 				{
-					Limit:  1000,
-					Suffix: "...",
+					Limit:      1000,
+					Suffix:     "...",
+					SourceType: SourceTypeLine,
 				},
 			},
 			labels:              map[string]string{},
@@ -51,7 +51,8 @@ func Test_TruncateStage_Process(t *testing.T) {
 			name: "Longer line should truncate",
 			config: []*RuleConfig{
 				{
-					Limit: 10,
+					Limit:      10,
+					SourceType: SourceTypeLine,
 				},
 			},
 			labels:              map[string]string{},
@@ -64,8 +65,9 @@ func Test_TruncateStage_Process(t *testing.T) {
 			name: "Longer line should truncate with suffix",
 			config: []*RuleConfig{
 				{
-					Limit:  10,
-					Suffix: "...",
+					Limit:      10,
+					Suffix:     "...",
+					SourceType: SourceTypeLine,
 				},
 			},
 			labels:              map[string]string{},
@@ -151,7 +153,8 @@ func Test_TruncateStage_Process(t *testing.T) {
 			name: "Multiple rules applied together",
 			config: []*RuleConfig{
 				{
-					Limit: 10,
+					Limit:      10,
+					SourceType: SourceTypeLine,
 				},
 				{
 					Limit:      15,
@@ -189,14 +192,10 @@ func Test_TruncateStage_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &TruncateConfig{Rules: tt.config}
-			err := validateTruncateConfig(cfg)
-			if err != nil {
-				t.Error(err)
-			}
+
 			logger := util.TestAlloyLogger(t)
 			registry := prometheus.NewRegistry()
-			m, err := newTruncateStage(logger, *cfg, registry)
-			require.NoError(t, err)
+			m := newTruncateStage(logger, *cfg, registry)
 			entry := newEntry(map[string]any{}, toLabelSet(tt.labels), tt.entry, tt.t)
 			if tt.extracted != nil {
 				entry.Extracted = tt.extracted
@@ -251,109 +250,6 @@ func Test_TruncateStage_Process(t *testing.T) {
 	}
 }
 
-func Test_ValidateTruncateConfig(t *testing.T) {
-	tests := []struct {
-		name    string
-		config  *TruncateConfig
-		wantErr error
-	}{
-		{
-			name: "Error no rules",
-			config: &TruncateConfig{
-				Rules: []*RuleConfig{},
-			},
-			wantErr: errors.New(errAtLeastOneRule),
-		},
-		{
-			name: "Error limit must be positive",
-			config: &TruncateConfig{
-				Rules: []*RuleConfig{{
-					Limit: 0,
-				}},
-			},
-			wantErr: errors.New(errLimitMustBeGreaterThanZero),
-		},
-		{
-			name: "Error sources cannot be set for line",
-			config: &TruncateConfig{
-				Rules: []*RuleConfig{{
-					Limit:   10,
-					Sources: []string{"app"},
-				}},
-			},
-			wantErr: errors.New(errSourcesForLine),
-		},
-		{
-			name: "No error for intrinsic line limit",
-			config: &TruncateConfig{
-				Rules: []*RuleConfig{{
-					Limit:  10,
-					Suffix: "...",
-				}},
-			},
-			wantErr: nil,
-		},
-		{
-			name: "No error for label limit",
-			config: &TruncateConfig{
-				Rules: []*RuleConfig{{
-					Limit:      10,
-					SourceType: SourceTypeLabel,
-					Suffix:     "...",
-				}},
-			},
-			wantErr: nil,
-		},
-		{
-			name: "No error for structured_metadata limit",
-			config: &TruncateConfig{
-				Rules: []*RuleConfig{{
-					Limit:      10,
-					SourceType: SourceTypeStructuredMetadata,
-					Suffix:     "...",
-				}},
-			},
-			wantErr: nil,
-		},
-		{
-			name: "No error for specific label limit",
-			config: &TruncateConfig{
-				Rules: []*RuleConfig{
-					{
-						Limit:      10,
-						SourceType: SourceTypeLabel,
-						Sources:    []string{"app"},
-						Suffix:     "...",
-					},
-				},
-			},
-			wantErr: nil,
-		},
-		{
-			name: "Suffix too long",
-			config: &TruncateConfig{
-				Rules: []*RuleConfig{
-					{
-						Limit:  10,
-						Suffix: "12345678901",
-					},
-				},
-			},
-			wantErr: errors.New(`suffix length cannot be greater than or equal to limit`),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateTruncateConfig(tt.config)
-			if tt.wantErr != nil {
-				require.EqualError(t, err, tt.wantErr.Error())
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
-
 func TestTruncateStage_UnmarshalAlloy(t *testing.T) {
 	type testCase struct {
 		name    string
@@ -388,8 +284,8 @@ func TestTruncateStage_UnmarshalAlloy(t *testing.T) {
 			name: "all attributes",
 			config: `
 				rule {
-					limit = "1B"
-					source_type = "line"
+					limit = "1MiB"
+					source_type = "extracted"
 					sources = ["app", "app2"]
 					suffix = "..."
 				}
@@ -400,30 +296,102 @@ func TestTruncateStage_UnmarshalAlloy(t *testing.T) {
 			name: "multiple rules",
 			config: `
 				rule {
-					limit = "1B"
+					limit = "1MiB"
 					source_type = "line"
+					suffix = "..."
+				}
+
+				rule {
+					limit = "1MiB"
+					source_type = "label"
 					sources = ["app", "app2"]
 					suffix = "..."
 				}
 
 				rule {
-					limit = "1B"
-					source_type = "label"
-					sources = ["app", "app2"]
-					suffix = "..."
-				}
-				
-				rule {
-					limit = "1B"
+					limit = "1MiB"
 					source_type = "extracted"
 					sources = ["app", "app2"]
 					suffix = "..."
 				}
 
 				rule {
-					limit = "1B"
+					limit = "1MiB"
 					source_type = "structured_metadata"
 					sources = ["app", "app2"]
+					suffix = "..."
+				}
+			`,
+			wantErr: false,
+		},
+		{
+			name: "limit must be greater than zero",
+			config: `
+				rule {
+					limit = "0B"
+				}
+			`,
+			wantErr: true,
+		},
+		{
+			name: "sources cannot be set when source_type is line",
+			config: `
+				rule {
+					limit = "10B"
+					sources = ["app"]
+				}
+			`,
+			wantErr: true,
+		},
+		{
+			name: "suffix length greater than or equal to limit",
+			config: `
+				rule {
+					limit = "10B"
+					suffix = "12345678901"
+				}
+			`,
+			wantErr: true,
+		},
+		{
+			name: "intrinsic line limit",
+			config: `
+				rule {
+					limit = "10B"
+					suffix = "..."
+				}
+			`,
+			wantErr: false,
+		},
+		{
+			name: "label limit",
+			config: `
+				rule {
+					limit = "10B"
+					source_type = "label"
+					suffix = "..."
+				}
+			`,
+			wantErr: false,
+		},
+		{
+			name: "structured_metadata limit",
+			config: `
+				rule {
+					limit = "10B"
+					source_type = "structured_metadata"
+					suffix = "..."
+				}
+			`,
+			wantErr: false,
+		},
+		{
+			name: "specific label limit",
+			config: `
+				rule {
+					limit = "10B"
+					source_type = "label"
+					sources = ["app"]
 					suffix = "..."
 				}
 			`,

--- a/internal/converter/internal/promtailconvert/testdata/limits_config.alloy
+++ b/internal/converter/internal/promtailconvert/testdata/limits_config.alloy
@@ -19,8 +19,7 @@ loki.process "example" {
 
 	stage.truncate {
 		rule {
-			limit       = "256KiB"
-			source_type = "line"
+			limit = "256KiB"
 		}
 	}
 }


### PR DESCRIPTION
Backport of #6271 to release/v1.16.

The cherry-pick conflicted because #6271 sits on top of the `slog` logger migration that's on `main` but not on this release branch. I kept the fix (rules are no longer mutated — `SetToDefault`/`Validate` plus an on-demand `effectiveLimit()`) and adapted the logging back to v1.16's `log.Logger`/`level.Debug` style. Build, vet, and the loki/process + promtailconvert tests all pass.