### PR TITLE
ci: Update helm's action-gh-release to v3 to drop deprecated Node 20

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -160,7 +160,7 @@ jobs:
       # The tag name in grafana/helm-charts is <package>-<version>, while the
       # tag name for grafana/alloy is helm-chart/<version>.
       - name: Make github release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           name: ${{ steps.parse-chart.outputs.packagename }}
           repository: grafana/helm-charts


### PR DESCRIPTION
Closes #6398

## Summary

`softprops/action-gh-release` was pinned to `v2.5.0`, which runs on the **Node 20** Actions runtime. GitHub now emits deprecation warnings for Node 20 actions. This bumps it to **v3.0.0**, whose only change is moving the runtime to **Node 24** — no input or behavior changes.

- Updated `.github/workflows/helm-release.yml`: `softprops/action-gh-release` `v2.5.0` → `v3.0.0`, pinned by commit SHA (`b4309332981a82ec1c5618f44dd2e27cc8bfbfda`) per the repo's pinning convention.

### Audit notes

I checked the runtime (`runs.using`) of every action referenced in `.github/workflows/`. All `actions/*` (checkout v6, setup-go v6, setup-node v6, setup-python v6, upload-artifact v7, download-artifact v8, github-script v8, cache v5) and the other third-party actions (docker/*, golangci-lint-action, azure/setup-helm, helm/kind-action, amannn/action-semantic-pull-request, github/codeql-action) already run on Node 24 or are composite/docker actions. `action-gh-release` was the only remaining Node 20 JS action.

### Breaking changes / risk

Per the [v3.0.0 release notes](https://github.com/softprops/action-gh-release/releases/tag/v3.0.0), the release only moves the runtime/bundle target to Node 24. The inputs used in `helm-release.yml` (`name`, `repository`, `tag_name`, `token`, `body`, `files`) are unchanged. GitHub-hosted runners support the Node 24 runtime. Low risk, drop-in.

