### PR TITLE
chore: Bump build image to use go v1.26.4

### DIFF
--- a/.github/workflows/check-linux-build-image.yml
+++ b/.github/workflows/check-linux-build-image.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         build:
-          - runtime: golang:1.26.3-alpine3.23
-          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.26.3-bookworm
+          - runtime: golang:1.26.4-alpine3.23
+          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.26.4-bookworm
     runs-on: ubuntu-latest-8-cores
     steps:
       - name: Checkout

--- a/.github/workflows/create_build_image.yml
+++ b/.github/workflows/create_build_image.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         build:
-          - runtime: golang:1.26.3-alpine3.23
-          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.26.3-bookworm
+          - runtime: golang:1.26.4-alpine3.23
+          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.26.4-bookworm
             suffix: "-boringcrypto"
     runs-on: ubuntu-latest-8-cores
     steps:

--- a/build-tools/build-image/windows/Dockerfile
+++ b/build-tools/build-image/windows/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3-windowsservercore-ltsc2022@sha256:98c6379211d9edcf4b56241bae12b71cc41334d54b42d5743841c97f017123bd
+FROM golang:1.26.4-windowsservercore-ltsc2022@sha256:d50fe97a953eb04bfb276a274934411e6b0f7f3155b99edba90260ee6c650fa2
 
 SHELL ["powershell", "-command"]
 


### PR DESCRIPTION
## Summary

First of the two-step Go version bump (`make update-go-version-pr-1 VERSION=1.26.4`). This points the build-image builds at `go1.26.4` so a new build image can be published. A follow-up PR (`pr-2`) will switch `go.mod`, `mise.toml`/`mise.lock`, and the Dockerfiles over to the new image.

### Why

The `Govulncheck` lint job is failing on `main` (e.g. [run #26875696536](https://github.com/grafana/alloy/actions/runs/26875696536)). All three actionable findings are Go standard library vulnerabilities present in `go1.26.3` and fixed in `go1.26.4`:

| ID | Package | Issue |
|---|---|---|
| [GO-2026-5037](https://pkg.go.dev/vuln/GO-2026-5037) | `crypto/x509` | Inefficient candidate hostname parsing |
| [GO-2026-5038](https://pkg.go.dev/vuln/GO-2026-5038) | `mime` | Quadratic complexity in `WordDecoder.DecodeHeader` |
| [GO-2026-5039](https://pkg.go.dev/vuln/GO-2026-5039) | `net/textproto` | Arbitrary inputs included in errors without escaping |

Bumping the Go toolchain to `1.26.4` resolves all three.

