### PR TITLE
feat(prometheus.operator): Add missing native histogram scrape for parity with scrape

### DIFF
--- a/docs/sources/shared/reference/components/prom-operator-scrape.md
+++ b/docs/sources/shared/reference/components/prom-operator-scrape.md
@@ -10,9 +10,9 @@ headless: true
 | `default_sample_limit`               | `int`      | The default maximum samples per scrape. Used as the default if the target resource doesn't provide a sample limit.           |         | no       |
 | `default_scrape_interval`            | `duration` | The default interval between scraping targets. Used as the default if the target resource doesn't provide a scrape interval. | `1m`    | no       |
 | `default_scrape_timeout`             | `duration` | The default timeout for scrape requests. Used as the default if the target resource doesn't provide a scrape timeout.        | `10s`   | no       |
-| `convert_classic_histograms_to_nhcb` | `bool`     | Whether to convert classic histograms to native histograms with custom buckets (NHCB).                                      | `false` | no       |
+| `convert_classic_histograms_to_nhcb` | `bool`     | Whether to convert classic histograms to native histograms with custom buckets (NHCB).                                       | `false` | no       |
 | `enable_type_and_unit_labels`        | `bool`     | (Experimental) Whether the metric type and unit should be added as labels to scraped metrics.                                | `false` | no       |
-| `honor_metadata`                     | `bool`     | (Experimental) Indicates whether to send metric metadata to downstream components.                                          | `false` | no       |
+| `honor_metadata`                     | `bool`     | (Experimental) Indicates whether to send metric metadata to downstream components.                                           | `false` | no       |
 | `native_histogram_bucket_limit`      | `uint`     | Native histogram buckets will be merged to stay within this limit. Disabled when set to zero.                                | `0`     | no       |
 | `native_histogram_min_bucket_factor` | `float64`  | If the growth from one bucket to the next is smaller than this, buckets will be merged. Disabled when set to zero.           | `0`     | no       |
 | `scrape_classic_histograms`          | `bool`     | Whether to scrape a classic histogram that's also exposed as a native histogram.                                             | `false` | no       |

--- a/docs/sources/shared/reference/components/prom-operator-scrape.md
+++ b/docs/sources/shared/reference/components/prom-operator-scrape.md
@@ -4,15 +4,19 @@ description: Shared content, prom operator scrape
 headless: true
 ---
 
-| Name                             | Type       | Description                                                                                                                  | Default | Required |
-|----------------------------------|------------|------------------------------------------------------------------------------------------------------------------------------|---------|----------|
-| `start_timestamp_zero_ingestion` | `bool`     | (Experimental) Parse the start timestamp and inject a zero sample at it for cumulative metrics.                              | `false` | no       |
-| `default_sample_limit`           | `int`      | The default maximum samples per scrape. Used as the default if the target resource doesn't provide a sample limit.           |         | no       |
-| `default_scrape_interval`        | `duration` | The default interval between scraping targets. Used as the default if the target resource doesn't provide a scrape interval. | `1m`    | no       |
-| `default_scrape_timeout`         | `duration` | The default timeout for scrape requests. Used as the default if the target resource doesn't provide a scrape timeout.        | `10s`   | no       |
-| `enable_type_and_unit_labels`    | `bool`     | (Experimental) Whether the metric type and unit should be added as labels to scraped metrics.                                | `false` | no       |
-| `honor_metadata`                 | `bool`     | (Experimental) Indicates whether to send metric metadata to downstream components.                                           | `false` | no       |
-| `scrape_native_histograms`       | `bool`     | Whether to scrape native histograms from targets.                                                                            | `false` | no       |
+| Name                                 | Type       | Description                                                                                                                  | Default | Required |
+|--------------------------------------|------------|------------------------------------------------------------------------------------------------------------------------------|---------|----------|
+| `start_timestamp_zero_ingestion`     | `bool`     | (Experimental) Parse the start timestamp and inject a zero sample at it for cumulative metrics.                              | `false` | no       |
+| `default_sample_limit`               | `int`      | The default maximum samples per scrape. Used as the default if the target resource doesn't provide a sample limit.           |         | no       |
+| `default_scrape_interval`            | `duration` | The default interval between scraping targets. Used as the default if the target resource doesn't provide a scrape interval. | `1m`    | no       |
+| `default_scrape_timeout`             | `duration` | The default timeout for scrape requests. Used as the default if the target resource doesn't provide a scrape timeout.        | `10s`   | no       |
+| `convert_classic_histograms_to_nhcb` | `bool`     | Whether to convert classic histograms to native histograms with custom buckets (NHCB).                                      | `false` | no       |
+| `enable_type_and_unit_labels`        | `bool`     | (Experimental) Whether the metric type and unit should be added as labels to scraped metrics.                                | `false` | no       |
+| `honor_metadata`                     | `bool`     | (Experimental) Indicates whether to send metric metadata to downstream components.                                          | `false` | no       |
+| `native_histogram_bucket_limit`      | `uint`     | Native histogram buckets will be merged to stay within this limit. Disabled when set to zero.                                | `0`     | no       |
+| `native_histogram_min_bucket_factor` | `float64`  | If the growth from one bucket to the next is smaller than this, buckets will be merged. Disabled when set to zero.           | `0`     | no       |
+| `scrape_classic_histograms`          | `bool`     | Whether to scrape a classic histogram that's also exposed as a native histogram.                                             | `false` | no       |
+| `scrape_native_histograms`           | `bool`     | Whether to scrape native histograms from targets.                                                                            | `false` | no       |
 
 > **EXPERIMENTAL**: The `honor_metadata`, `enable_type_and_unit_labels`, and `start_timestamp_zero_ingestion` arguments are [experimental][] features.
 > 

--- a/internal/component/prometheus/operator/common/testing.go
+++ b/internal/component/prometheus/operator/common/testing.go
@@ -10,6 +10,7 @@ import (
 	promopv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	promopv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/prometheus/common/model"
+	promconfig "github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -275,6 +276,19 @@ func (f *TestCrdManagerFactory) GetScrapeConfigJobNames() []string {
 		names = append(names, name)
 	}
 	return names
+}
+
+// GetScrapeConfigForJob returns the scrape config for a specific job name, or nil if not found.
+func (f *TestCrdManagerFactory) GetScrapeConfigForJob(jobName string) *promconfig.ScrapeConfig {
+	f.mu.RLock()
+	m := f.manager
+	f.mu.RUnlock()
+	if m == nil {
+		return nil
+	}
+	m.mut.Lock()
+	defer m.mut.Unlock()
+	return m.scrapeConfigs[jobName]
 }
 
 // InjectStaticTargets injects static targets for a job, replacing k8s service discovery.

--- a/internal/component/prometheus/operator/configgen/config_gen.go
+++ b/internal/component/prometheus/operator/configgen/config_gen.go
@@ -176,7 +176,10 @@ func (cg *ConfigGenerator) generateAuthorization(a promopv1.SafeAuthorization, n
 func (cg *ConfigGenerator) generateDefaultScrapeConfig() *config.ScrapeConfig {
 	opt := cg.ScrapeOptions
 
-	copyScrapeNativeHistograms := opt.ScrapeNativeHistograms // make a copy as Prometheus wants a pointer.
+	// Copies required because Prometheus ScrapeConfig fields take pointers.
+	copyScrapeNativeHistograms := opt.ScrapeNativeHistograms
+	copyScrapeClassicHistograms := opt.ScrapeClassicHistograms
+	copyConvertClassicHistogramsToNHCB := opt.ConvertClassicHistogramsToNHCB
 
 	c := config.DefaultScrapeConfig
 	c.ScrapeInterval = config.DefaultGlobalConfig.ScrapeInterval
@@ -184,6 +187,10 @@ func (cg *ConfigGenerator) generateDefaultScrapeConfig() *config.ScrapeConfig {
 	c.ScrapeProtocols = config.DefaultGlobalConfig.ScrapeProtocols
 	c.ScrapeFallbackProtocol = config.PrometheusText0_0_4 // Keep the same as Prometheus V2
 	c.ScrapeNativeHistograms = &copyScrapeNativeHistograms
+	c.AlwaysScrapeClassicHistograms = &copyScrapeClassicHistograms
+	c.ConvertClassicHistogramsToNHCB = &copyConvertClassicHistogramsToNHCB
+	c.NativeHistogramBucketLimit = opt.NativeHistogramBucketLimit
+	c.NativeHistogramMinBucketFactor = opt.NativeHistogramMinBucketFactor
 
 	if opt.DefaultScrapeInterval != 0 {
 		c.ScrapeInterval = model.Duration(opt.DefaultScrapeInterval)

--- a/internal/component/prometheus/operator/configgen/config_gen_test.go
+++ b/internal/component/prometheus/operator/configgen/config_gen_test.go
@@ -459,6 +459,42 @@ func TestGenerateDefaultScrapeConfig(t *testing.T) {
 			expectedTimeout:          5 * time.Second,
 			expectedFallbackProtocol: promconfig.PrometheusText0_0_4,
 		},
+		{
+			name: "scrape classic histograms",
+			scrapeOptions: operator.ScrapeOptions{
+				ScrapeClassicHistograms: true,
+			},
+			expectedInterval:         1 * time.Minute,
+			expectedTimeout:          10 * time.Second,
+			expectedFallbackProtocol: promconfig.PrometheusText0_0_4,
+		},
+		{
+			name: "convert classic histograms to nhcb",
+			scrapeOptions: operator.ScrapeOptions{
+				ConvertClassicHistogramsToNHCB: true,
+			},
+			expectedInterval:         1 * time.Minute,
+			expectedTimeout:          10 * time.Second,
+			expectedFallbackProtocol: promconfig.PrometheusText0_0_4,
+		},
+		{
+			name: "native histogram bucket limit",
+			scrapeOptions: operator.ScrapeOptions{
+				NativeHistogramBucketLimit: 100,
+			},
+			expectedInterval:         1 * time.Minute,
+			expectedTimeout:          10 * time.Second,
+			expectedFallbackProtocol: promconfig.PrometheusText0_0_4,
+		},
+		{
+			name: "native histogram min bucket factor",
+			scrapeOptions: operator.ScrapeOptions{
+				NativeHistogramMinBucketFactor: 1.1,
+			},
+			expectedInterval:         1 * time.Minute,
+			expectedTimeout:          10 * time.Second,
+			expectedFallbackProtocol: promconfig.PrometheusText0_0_4,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -472,6 +508,10 @@ func TestGenerateDefaultScrapeConfig(t *testing.T) {
 			assert.Equal(t, tt.expectedFallbackProtocol, got.ScrapeFallbackProtocol)
 			assert.Equal(t, tt.scrapeOptions.DefaultSampleLimit, got.SampleLimit)
 			assert.Equal(t, &tt.scrapeOptions.ScrapeNativeHistograms, got.ScrapeNativeHistograms)
+			assert.Equal(t, &tt.scrapeOptions.ScrapeClassicHistograms, got.AlwaysScrapeClassicHistograms)
+			assert.Equal(t, &tt.scrapeOptions.ConvertClassicHistogramsToNHCB, got.ConvertClassicHistogramsToNHCB)
+			assert.Equal(t, tt.scrapeOptions.NativeHistogramBucketLimit, got.NativeHistogramBucketLimit)
+			assert.Equal(t, tt.scrapeOptions.NativeHistogramMinBucketFactor, got.NativeHistogramMinBucketFactor)
 		})
 	}
 }

--- a/internal/component/prometheus/operator/servicemonitors/servicemonitors_test.go
+++ b/internal/component/prometheus/operator/servicemonitors/servicemonitors_test.go
@@ -46,6 +46,7 @@ func TestServiceMonitorEndToEnd(t *testing.T) {
 		name           string
 		honorMetadata  bool
 		expectMetadata bool
+		scrapeOptions  operator.ScrapeOptions
 	}{
 		{
 			name:           "honor_metadata_enabled",
@@ -56,6 +57,18 @@ func TestServiceMonitorEndToEnd(t *testing.T) {
 			name:           "honor_metadata_disabled",
 			honorMetadata:  false,
 			expectMetadata: false,
+		},
+		{
+			name:           "native_histogram_options",
+			honorMetadata:  false,
+			expectMetadata: false,
+			scrapeOptions: operator.ScrapeOptions{
+				ScrapeNativeHistograms:         true,
+				ScrapeClassicHistograms:        true,
+				ConvertClassicHistogramsToNHCB: true,
+				NativeHistogramBucketLimit:     100,
+				NativeHistogramMinBucketFactor: 1.1,
+			},
 		},
 	}
 
@@ -114,6 +127,7 @@ func TestServiceMonitorEndToEnd(t *testing.T) {
 			args.SetToDefault()
 			args.ForwardTo = []storage.Appendable{mockAppendable}
 			args.Namespaces = []string{"monitoring"}
+			args.Scrape = tc.scrapeOptions
 			args.Scrape.HonorMetadata = tc.honorMetadata
 
 			// Create the component
@@ -188,6 +202,15 @@ func TestServiceMonitorEndToEnd(t *testing.T) {
 				}
 				return false
 			}, 10*time.Second, 100*time.Millisecond, "Expected generated ServiceMonitor job to appear")
+
+			// Verify native histogram options were applied to the generated scrape config
+			sc := testFactory.GetScrapeConfigForJob(jobName)
+			require.NotNil(t, sc)
+			assert.Equal(t, &tc.scrapeOptions.ScrapeNativeHistograms, sc.ScrapeNativeHistograms)
+			assert.Equal(t, &tc.scrapeOptions.ScrapeClassicHistograms, sc.AlwaysScrapeClassicHistograms)
+			assert.Equal(t, &tc.scrapeOptions.ConvertClassicHistogramsToNHCB, sc.ConvertClassicHistogramsToNHCB)
+			assert.Equal(t, tc.scrapeOptions.NativeHistogramBucketLimit, sc.NativeHistogramBucketLimit)
+			assert.Equal(t, tc.scrapeOptions.NativeHistogramMinBucketFactor, sc.NativeHistogramMinBucketFactor)
 
 			require.EventuallyWithT(t, func(ct *assert.CollectT) {
 				ready, err := testFactory.InjectStaticTargets(jobName, serverAddr)

--- a/internal/component/prometheus/operator/types.go
+++ b/internal/component/prometheus/operator/types.go
@@ -55,6 +55,21 @@ type ScrapeOptions struct {
 	// ScrapeNativeHistograms enables scraping of Prometheus native histograms.
 	ScrapeNativeHistograms bool `alloy:"scrape_native_histograms,attr,optional"`
 
+	// Whether to scrape a classic histogram that is also exposed as a native histogram.
+	ScrapeClassicHistograms bool `alloy:"scrape_classic_histograms,attr,optional"`
+
+	// Whether to convert classic histograms with buckets to native histograms
+	// with custom buckets (NHCB). False by default.
+	ConvertClassicHistogramsToNHCB bool `alloy:"convert_classic_histograms_to_nhcb,attr,optional"`
+
+	// If there are more than this many buckets in a native histogram,
+	// buckets will be merged to stay within the limit. Disabled when set to zero.
+	NativeHistogramBucketLimit uint `alloy:"native_histogram_bucket_limit,attr,optional"`
+
+	// If the growth factor of one bucket to the next is smaller than this,
+	// buckets will be merged to stay within the limit. Disabled when set zero.
+	NativeHistogramMinBucketFactor float64 `alloy:"native_histogram_min_bucket_factor,attr,optional"`
+
 	// HonorMetadata controls whether metric metadata should be passed to downstream components.
 	HonorMetadata bool `alloy:"honor_metadata,attr,optional"`
 

--- a/internal/component/prometheus/operator/types.go
+++ b/internal/component/prometheus/operator/types.go
@@ -42,6 +42,7 @@ type Arguments struct {
 }
 
 // ScrapeOptions holds values that configure scraping behavior.
+// Keep in sync with prometheus.scrape's Arguments.
 type ScrapeOptions struct {
 	// DefaultScrapeInterval is the default interval to scrape targets.
 	DefaultScrapeInterval time.Duration `alloy:"default_scrape_interval,attr,optional"`
@@ -67,7 +68,7 @@ type ScrapeOptions struct {
 	NativeHistogramBucketLimit uint `alloy:"native_histogram_bucket_limit,attr,optional"`
 
 	// If the growth factor of one bucket to the next is smaller than this,
-	// buckets will be merged to stay within the limit. Disabled when set zero.
+	// buckets will be merged to stay within the limit. Disabled when set to zero.
 	NativeHistogramMinBucketFactor float64 `alloy:"native_histogram_min_bucket_factor,attr,optional"`
 
 	// HonorMetadata controls whether metric metadata should be passed to downstream components.


### PR DESCRIPTION
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**z
  Your PR title must adhere to Conventional Commit style with a capitalized
  description, e.g. `feat(scope): Add the thing` (not `add the thing`). For
  details on this, check out the Contributors Guide linked above.
-->

### Brief description of Pull Request

`prometheus.operator.*` components were missing `scrape_classic_histograms`, `convert_classic_histograms_to_nhcb`, `native_histogram_bucket_limit`, and `native_histogram_min_bucket_factor` from their `scrape` block, even though `prometheus.scrape` supports all of them. 

This PR adds the missing options to `ScrapeOptions` and forwards them to the generated `ScrapeConfig`, bringing `prometheus.operator.*` to full parity with `prometheus.scrape` for native histogram configuration.

### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->

### Notes to the Reviewer

Follows the same pattern as #6356. Config converters don't apply (no CRD-to-Alloy converter exists).

### PR Checklist

- [x] Documentation added
- [x] Tests updated

