### PR TITLE
chore: Drop redundant setup-go from build-image container jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,11 +30,6 @@ jobs:
       run: |
           # this is to fix GIT not liking owner of the checkout dir
           chown -R $(id -u):$(id -g) $PWD
-    - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-      with:
-        go-version-file: go.mod
-        cache: false
     - run: GO_TAGS="embedalloyui promtail_journal_enabled" GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} GOARM= make alloy
 
   build_linux_boringcrypto:
@@ -127,9 +122,4 @@ jobs:
       run: |
           # this is to fix GIT not liking owner of the checkout dir
           chown -R $(id -u):$(id -g) $PWD
-    - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-      with:
-        go-version-file: go.mod
-        cache: false
     - run: GO_TAGS="embedalloyui" GOOS=freebsd GOARCH=amd64 GOARM= make alloy

--- a/.github/workflows/publish-alloy-linux.yml
+++ b/.github/workflows/publish-alloy-linux.yml
@@ -58,12 +58,6 @@ jobs:
           # this is to fix GIT not liking owner of the checkout dir
           chown -R $(id -u):$(id -g) $PWD
 
-    - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-      with:
-        go-version-file: go.mod
-        cache: false
-
     - run: |
         docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
         docker buildx create --name multiarch-alloy-${IMG_NAME}-${GITHUB_SHA} --driver docker-container --use

--- a/.github/workflows/release-publish-alloy-artifacts.yml
+++ b/.github/workflows/release-publish-alloy-artifacts.yml
@@ -95,12 +95,6 @@ jobs:
           # This is to fix Git not liking owner of the checkout directory
           chown -R $(id -u):$(id -g) $PWD
 
-    - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-      with:
-        go-version-file: go.mod
-        cache: false
-
     - name: Build
       run: |
         RELEASE_BUILD=1 make -j4 dist
@@ -174,12 +168,6 @@ jobs:
       run: |
           # This is to fix Git not liking owner of the checkout directory
           chown -R $(id -u):$(id -g) $PWD
-
-    - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-      with:
-        go-version-file: go.mod
-        cache: false
 
     - name: Download signed Windows executables
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
### Brief description of Pull Request

Drops the redundant `actions/setup-go` step from the CI jobs that run inside the `alloy-build-image` container. The image already ships Go matching `go.mod` (1.26.3), so those jobs sourced Go twice — from the image and from `setup-go` — which can silently drift; the released container binary already builds from the image's Go (the root `Dockerfile` has no `setup-go`), so this makes every container job use that single source. The Mac/Windows jobs keep `setup-go` since they run on bare runners with no image. 

https://github.com/grafana/alloy/pull/6407 handles the boring crypto variant since there's more to be done there