### PR TITLE
chore: Migrate promethues components to slog

### DIFF
--- a/internal/component/prometheus/echo/echo.go
+++ b/internal/component/prometheus/echo/echo.go
@@ -94,21 +94,19 @@ func (c *Component) Appender(ctx context.Context) storage.Appender {
 	c.mut.RUnlock()
 
 	return &echoAppender{
-		logger:      c.opts.SLogger,
-		componentID: c.opts.ID,
-		format:      format,
-		samples:     make(map[string]sample),
-		exemplars:   make(map[string]seriesExemplar),
-		histograms:  make(map[string]seriesHistogram),
-		metadata:    make(map[string]metadata.Metadata),
+		logger:     c.opts.SLogger,
+		format:     format,
+		samples:    make(map[string]sample),
+		exemplars:  make(map[string]seriesExemplar),
+		histograms: make(map[string]seriesHistogram),
+		metadata:   make(map[string]metadata.Metadata),
 	}
 }
 
 type echoAppender struct {
-	logger      *slog.Logger
-	componentID string
-	format      string
-	mut         sync.Mutex
+	logger *slog.Logger
+	format string
+	mut    sync.Mutex
 
 	samples    map[string]sample
 	exemplars  map[string]seriesExemplar
@@ -252,7 +250,7 @@ func (a *echoAppender) Commit() error {
 		}
 	}
 
-	a.logger.Info("recieved metrics", "metrics", buf.String())
+	a.logger.Info("received metrics", "metrics", buf.String())
 	a.clearStorage()
 
 	return nil

--- a/internal/component/prometheus/echo/echo.go
+++ b/internal/component/prometheus/echo/echo.go
@@ -4,14 +4,13 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"sort"
 	"sync"
 	"time"
 
-	"github.com/go-kit/log"
 	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/featuregate"
-	"github.com/grafana/alloy/internal/runtime/logging/level"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/model"
@@ -95,7 +94,7 @@ func (c *Component) Appender(ctx context.Context) storage.Appender {
 	c.mut.RUnlock()
 
 	return &echoAppender{
-		logger:      c.opts.Logger,
+		logger:      c.opts.SLogger,
 		componentID: c.opts.ID,
 		format:      format,
 		samples:     make(map[string]sample),
@@ -106,7 +105,7 @@ func (c *Component) Appender(ctx context.Context) storage.Appender {
 }
 
 type echoAppender struct {
-	logger      log.Logger
+	logger      *slog.Logger
 	componentID string
 	format      string
 	mut         sync.Mutex
@@ -240,7 +239,7 @@ func (a *echoAppender) Commit() error {
 	case "text", "":
 		expFormat = expfmt.NewFormat(expfmt.TypeTextPlain)
 	default:
-		level.Warn(a.logger).Log("component", a.componentID, "msg", "unknown format, using text", "format", a.format)
+		a.logger.Warn("unknown format, using text", "format", a.format)
 		expFormat = expfmt.NewFormat(expfmt.TypeTextPlain)
 	}
 
@@ -248,13 +247,12 @@ func (a *echoAppender) Commit() error {
 
 	for _, family := range families {
 		if err := encoder.Encode(family); err != nil {
-			level.Error(a.logger).Log("component", a.componentID, "error", "failed to encode metric family", "family", family.GetName(), "err", err)
+			a.logger.Error("failed to encode metric family", "family", family.GetName(), "err", err)
 			continue
 		}
 	}
 
-	level.Info(a.logger).Log("component", a.componentID, "metrics", buf.String())
-
+	a.logger.Info("recieved metrics", "metrics", buf.String())
 	a.clearStorage()
 
 	return nil

--- a/internal/component/prometheus/echo/echo_test.go
+++ b/internal/component/prometheus/echo/echo_test.go
@@ -1,13 +1,14 @@
 package echo
 
 import (
+	"bytes"
 	"context"
 	"testing"
 	"time"
 
-	"github.com/go-kit/log"
 	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/runtime/componenttest"
+	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/stretchr/testify/require"
@@ -23,8 +24,8 @@ func TestComponent_Creation(t *testing.T) {
 	ctx := componenttest.TestContext(t)
 
 	comp, err := New(component.Options{
-		ID:     "test",
-		Logger: log.NewNopLogger(),
+		ID:      "test",
+		SLogger: logging.NewSlogNop(),
 	}, Arguments{})
 	require.NoError(t, err)
 	require.NotNil(t, comp)
@@ -44,8 +45,8 @@ func TestComponent_ExportsReceiver(t *testing.T) {
 	var exports component.Exports
 
 	comp, err := New(component.Options{
-		ID:     "test",
-		Logger: log.NewNopLogger(),
+		ID:      "test",
+		SLogger: logging.NewSlogNop(),
 		OnStateChange: func(e component.Exports) {
 			exports = e
 		},
@@ -62,8 +63,8 @@ func TestComponent_ExportsReceiver(t *testing.T) {
 
 func TestAppender_BasicMetrics(t *testing.T) {
 	comp, err := New(component.Options{
-		ID:     "test",
-		Logger: log.NewNopLogger(),
+		ID:      "test",
+		SLogger: logging.NewSlogNop(),
 	}, Arguments{})
 	require.NoError(t, err)
 
@@ -83,8 +84,8 @@ func TestAppender_BasicMetrics(t *testing.T) {
 
 func TestAppender_Rollback(t *testing.T) {
 	comp, err := New(component.Options{
-		ID:     "test",
-		Logger: log.NewNopLogger(),
+		ID:      "test",
+		SLogger: logging.NewSlogNop(),
 	}, Arguments{})
 	require.NoError(t, err)
 
@@ -103,8 +104,8 @@ func TestAppender_Rollback(t *testing.T) {
 
 func TestAppender_MultipleMetrics(t *testing.T) {
 	comp, err := New(component.Options{
-		ID:     "test",
-		Logger: log.NewNopLogger(),
+		ID:      "test",
+		SLogger: logging.NewSlogNop(),
 	}, Arguments{})
 	require.NoError(t, err)
 
@@ -133,8 +134,8 @@ func TestAppender_MultipleMetrics(t *testing.T) {
 
 func TestComponent_Update(t *testing.T) {
 	comp, err := New(component.Options{
-		ID:     "test",
-		Logger: log.NewNopLogger(),
+		ID:      "test",
+		SLogger: logging.NewSlogNop(),
 	}, Arguments{})
 	require.NoError(t, err)
 
@@ -143,20 +144,16 @@ func TestComponent_Update(t *testing.T) {
 }
 
 func TestAppender_WithExpfmtEncoding(t *testing.T) {
-	var loggedOutput string
-
-	logger := log.LoggerFunc(func(keyvals ...any) error {
-		for i := 0; i < len(keyvals); i += 2 {
-			if keyvals[i] == "metrics" && i+1 < len(keyvals) {
-				loggedOutput = keyvals[i+1].(string)
-			}
-		}
-		return nil
+	var buf bytes.Buffer
+	logger, err := logging.New(&buf, logging.Options{
+		Level:  logging.LevelInfo,
+		Format: logging.FormatLogfmt,
 	})
+	require.NoError(t, err)
 
 	comp, err := New(component.Options{
-		ID:     "test",
-		Logger: logger,
+		ID:      "test",
+		SLogger: logger.Slog(),
 	}, Arguments{})
 	require.NoError(t, err)
 
@@ -170,10 +167,11 @@ func TestAppender_WithExpfmtEncoding(t *testing.T) {
 	err = appender.Commit()
 	require.NoError(t, err)
 
+	loggedOutput := buf.String()
 	require.NotEmpty(t, loggedOutput)
 	require.Contains(t, loggedOutput, "test_metric")
-	require.Contains(t, loggedOutput, "job=\"test_job\"")
-	require.Contains(t, loggedOutput, "instance=\"localhost:8080\"")
+	require.Contains(t, loggedOutput, "job=\\\"test_job\\\"")
+	require.Contains(t, loggedOutput, "instance=\\\"localhost:8080\\\"")
 	require.Contains(t, loggedOutput, "42")
 
 	require.NotContains(t, loggedOutput, "Prometheus metrics received by")
@@ -181,22 +179,18 @@ func TestAppender_WithExpfmtEncoding(t *testing.T) {
 }
 
 func TestAppender_WithOpenMetricsFormat(t *testing.T) {
-	var loggedOutput string
-
-	logger := log.LoggerFunc(func(keyvals ...any) error {
-		for i := 0; i < len(keyvals); i += 2 {
-			if keyvals[i] == "metrics" && i+1 < len(keyvals) {
-				loggedOutput = keyvals[i+1].(string)
-			}
-		}
-		return nil
+	var buf bytes.Buffer
+	logger, err := logging.New(&buf, logging.Options{
+		Level:  logging.LevelInfo,
+		Format: logging.FormatLogfmt,
 	})
+	require.NoError(t, err)
 
 	args := Arguments{Format: "openmetrics"}
 
 	comp, err := New(component.Options{
-		ID:     "test",
-		Logger: logger,
+		ID:      "test",
+		SLogger: logger.Slog(),
 	}, args)
 	require.NoError(t, err)
 
@@ -210,9 +204,11 @@ func TestAppender_WithOpenMetricsFormat(t *testing.T) {
 	err = appender.Commit()
 	require.NoError(t, err)
 
+	loggedOutput := buf.String()
+
 	require.NotEmpty(t, loggedOutput)
 	require.Contains(t, loggedOutput, "test_metric")
-	require.Contains(t, loggedOutput, "job=\"test_job\"")
+	require.Contains(t, loggedOutput, "job=\\\"test_job\\\"")
 
 	t.Logf("OpenMetrics output: %s", loggedOutput)
 }

--- a/internal/component/prometheus/enrich/enrich_test.go
+++ b/internal/component/prometheus/enrich/enrich_test.go
@@ -181,8 +181,8 @@ func TestEnricher(t *testing.T) {
 			var entry storage.Appendable
 			tt.args.ForwardTo = []storage.Appendable{fanout}
 			_, err := New(component.Options{
-				ID:     "1",
-				Logger: util.TestAlloyLogger(t),
+				ID:      "1",
+				SLogger: util.TestAlloyLogger(t).Slog(),
 				OnStateChange: func(e component.Exports) {
 					newE := e.(Exports)
 					entry = newE.Receiver

--- a/internal/component/prometheus/pipeline_test.go
+++ b/internal/component/prometheus/pipeline_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/log"
 	promclient "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
@@ -48,7 +47,7 @@ func TestPipeline(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			destination := testappender.NewCollectingAppender()
 			cfg := refTrackingConfig{useLabelStore: tt.useLabelStore}
-			pipeline, ls, _ := newRemoteWritePipeline(t, util.TestLogger(t), 1, destination, cfg)
+			pipeline, ls, _ := newRemoteWritePipeline(t, util.TestAlloyLogger(t), 1, destination, cfg)
 			sampleTimestamp := time.Now().UnixMilli()
 
 			// Send metrics to our component. These will be written to the WAL and to the collecting appender
@@ -108,7 +107,7 @@ func TestRelabelPipeline(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			destination := testappender.NewCollectingAppender()
 			cfg := refTrackingConfig{useLabelStore: tt.useLabelStore}
-			pipeline, ls, _ := newRelabelPipeline(t, util.TestLogger(t), destination, cfg)
+			pipeline, ls, _ := newRelabelPipeline(t, util.TestAlloyLogger(t), destination, cfg)
 			sampleTimestamp := time.Now().UnixMilli()
 
 			// Send metrics to our component. These will be written to the WAL and to the collecting appender
@@ -187,17 +186,17 @@ func (ref refTrackingConfig) TestNameString() string {
 func BenchmarkPipelines(b *testing.B) {
 	pipelineTypes := []struct {
 		name            string
-		pipelineBuilder func(t testing.TB, logger log.Logger, rwComponents int, refTrackingConfig refTrackingConfig) (storage.Appendable, labelstore.LabelStore, clearCacheFunc)
+		pipelineBuilder func(t testing.TB, logger *logging.Logger, rwComponents int, refTrackingConfig refTrackingConfig) (storage.Appendable, labelstore.LabelStore, clearCacheFunc)
 	}{
 		{
 			name: "remote_write",
-			pipelineBuilder: func(t testing.TB, logger log.Logger, rwComponents int, refTrackingConfig refTrackingConfig) (storage.Appendable, labelstore.LabelStore, clearCacheFunc) {
+			pipelineBuilder: func(t testing.TB, logger *logging.Logger, rwComponents int, refTrackingConfig refTrackingConfig) (storage.Appendable, labelstore.LabelStore, clearCacheFunc) {
 				return newRemoteWritePipeline(t, logger, rwComponents, appenders.Noop{}, refTrackingConfig)
 			},
 		},
 		{
 			name: "relabel-remote_write",
-			pipelineBuilder: func(t testing.TB, logger log.Logger, _ int, refTrackingConfig refTrackingConfig) (storage.Appendable, labelstore.LabelStore, clearCacheFunc) {
+			pipelineBuilder: func(t testing.TB, logger *logging.Logger, _ int, refTrackingConfig refTrackingConfig) (storage.Appendable, labelstore.LabelStore, clearCacheFunc) {
 				return newRelabelPipeline(t, logger, appenders.Noop{}, refTrackingConfig)
 			},
 		},
@@ -249,7 +248,7 @@ func BenchmarkPipelines(b *testing.B) {
 					pipelineType.name, config.numberOfRWComponents, config.refTrackingConfig.TestNameString(), n)
 
 				b.Run(testName, func(b *testing.B) {
-					pipeline, _, clearCache := pipelineType.pipelineBuilder(b, log.NewNopLogger(), config.numberOfRWComponents, config.refTrackingConfig)
+					pipeline, _, clearCache := pipelineType.pipelineBuilder(b, util.TestAlloyLogger(b), config.numberOfRWComponents, config.refTrackingConfig)
 					metrics := setupMetrics(n)
 					b.ReportAllocs()
 					b.ResetTimer()
@@ -282,7 +281,7 @@ func BenchmarkPipelines(b *testing.B) {
 					pipelineType.name, config.numberOfRWComponents, config.refTrackingConfig.TestNameString(), c)
 
 				b.Run(testName, func(b *testing.B) {
-					pipeline, _, _ := pipelineType.pipelineBuilder(b, log.NewNopLogger(), config.numberOfRWComponents, config.refTrackingConfig)
+					pipeline, _, _ := pipelineType.pipelineBuilder(b, util.TestAlloyLogger(b), config.numberOfRWComponents, config.refTrackingConfig)
 					var metricsForAppenders [][]labels.Labels
 					numMetrics := 1000
 					for appenderIndex := range c {
@@ -366,14 +365,14 @@ func setupMetrics(numberOfMetrics int, extraLabels ...string) []labels.Labels {
 
 type clearCacheFunc = func()
 
-func newRemoteWritePipeline(t testing.TB, logger log.Logger, numberOfRemoteWriteComponents int, destination storage.Appender, config refTrackingConfig) (storage.Appendable, labelstore.LabelStore, clearCacheFunc) {
+func newRemoteWritePipeline(t testing.TB, logger *logging.Logger, numberOfRemoteWriteComponents int, destination storage.Appender, config refTrackingConfig) (storage.Appendable, labelstore.LabelStore, clearCacheFunc) {
 	ls := labelstore.New(logger, promclient.DefaultRegisterer, config.useLabelStore)
 
 	destAppendable := testappender.ConstantAppendable{Inner: destination}
 
 	rwAppendables := make([]storage.Appendable, 0, numberOfRemoteWriteComponents)
 	for range numberOfRemoteWriteComponents {
-		rwAppendable := newRemoteWriteComponent(t, logger, ls, destAppendable)
+		rwAppendable := newRemoteWriteComponent(t, logger.Slog(), ls, destAppendable)
 		rwAppendables = append(rwAppendables, rwAppendable)
 	}
 	pipelineAppendable := prometheus.NewFanout(rwAppendables, "", promclient.DefaultRegisterer, ls)
@@ -385,11 +384,11 @@ func newRemoteWritePipeline(t testing.TB, logger log.Logger, numberOfRemoteWrite
 	}
 }
 
-func newRelabelPipeline(t testing.TB, logger log.Logger, destination storage.Appender, config refTrackingConfig) (storage.Appendable, labelstore.LabelStore, clearCacheFunc) {
+func newRelabelPipeline(t testing.TB, logger *logging.Logger, destination storage.Appender, config refTrackingConfig) (storage.Appendable, labelstore.LabelStore, clearCacheFunc) {
 	ls := labelstore.New(logger, promclient.DefaultRegisterer, config.useLabelStore)
 
 	destAppendable := testappender.ConstantAppendable{Inner: destination}
-	rwAppendable := newRemoteWriteComponent(t, logger, ls, destAppendable)
+	rwAppendable := newRemoteWriteComponent(t, logger.Slog(), ls, destAppendable)
 	relabelAppendable := newRelabelComponent(t, logger, []storage.Appendable{rwAppendable}, ls)
 	pipelineAppendable := prometheus.NewFanout([]storage.Appendable{relabelAppendable}, "", promclient.DefaultRegisterer, ls)
 	scrapeInterceptor := scrape.NewInterceptor("prometheus.scrape.test", noopDebugDataPublisher{}, pipelineAppendable)
@@ -400,19 +399,13 @@ func newRelabelPipeline(t testing.TB, logger log.Logger, destination storage.App
 	}
 }
 
-func newRemoteWriteComponent(t testing.TB, logger log.Logger, ls labelstore.LabelStore, destination storage.Appendable) storage.Appendable {
+func newRemoteWriteComponent(t testing.TB, logger *slog.Logger, ls labelstore.LabelStore, destination storage.Appendable) storage.Appendable {
 	walDir := t.TempDir()
 
 	walStorage, err := wal.NewStorage(logger, promclient.NewRegistry(), walDir)
 	require.NoError(t, err)
 
-	fanoutLogger := slog.New(
-		logging.NewSlogGoKitHandler(
-			log.With(logger, "subcomponent", "fanout"),
-		),
-	)
-
-	store := storage.NewFanout(fanoutLogger, walStorage, testStorage{destination: destination})
+	store := storage.NewFanout(logger.With("subcomponent", "fanout"), walStorage, testStorage{destination: destination})
 
 	t.Cleanup(func() {
 		store.Close()
@@ -442,7 +435,7 @@ func (t testStorage) Close() error {
 	return nil
 }
 
-func newRelabelComponent(t testing.TB, logger log.Logger, forwardTo []storage.Appendable, ls labelstore.LabelStore) storage.Appendable {
+func newRelabelComponent(t testing.TB, logger *logging.Logger, forwardTo []storage.Appendable, ls labelstore.LabelStore) storage.Appendable {
 	cfg := `forward_to = []
 			rule {
 				action       = "replace"

--- a/internal/component/prometheus/receive_http/receive_http.go
+++ b/internal/component/prometheus/receive_http/receive_http.go
@@ -18,6 +18,7 @@ import (
 	alloyprom "github.com/grafana/alloy/internal/component/prometheus"
 	"github.com/grafana/alloy/internal/featuregate"
 	"github.com/grafana/alloy/internal/service/labelstore"
+	"github.com/grafana/alloy/internal/slogadapter"
 	"github.com/grafana/alloy/internal/util"
 )
 
@@ -178,7 +179,9 @@ func (c *Component) createNewServer(args Arguments) (*fnet.TargetServer, error) 
 	c.uncheckedCollector.SetCollector(serverRegistry)
 
 	s, err := fnet.NewTargetServer(
-		c.opts.Logger,
+		// FIXME(kalleep): Remove slogadapter.GoKit wrapper here once we have migrated all components that use fnet.NewTargetServer
+		// to slog. Part of https://github.com/grafana/alloy/issues/4813.
+		slogadapter.GoKit(c.opts.SLogger.Handler()),
 		"prometheus_receive_http",
 		serverRegistry,
 		args.Server,

--- a/internal/component/prometheus/receive_http/receive_http.go
+++ b/internal/component/prometheus/receive_http/receive_http.go
@@ -3,7 +3,6 @@ package receive_http
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"reflect"
 	"sync"
@@ -18,8 +17,6 @@ import (
 	fnet "github.com/grafana/alloy/internal/component/common/net"
 	alloyprom "github.com/grafana/alloy/internal/component/prometheus"
 	"github.com/grafana/alloy/internal/featuregate"
-	"github.com/grafana/alloy/internal/runtime/logging"
-	"github.com/grafana/alloy/internal/runtime/logging/level"
 	"github.com/grafana/alloy/internal/service/labelstore"
 	"github.com/grafana/alloy/internal/util"
 )
@@ -107,7 +104,7 @@ func New(opts component.Options, args Arguments) (*Component, error) {
 	c := &Component{
 		opts: opts,
 		handler: promremote.NewWriteHandler(
-			slog.New(logging.NewSlogGoKitHandler(opts.Logger)),
+			opts.SLogger,
 			opts.Registerer,
 			fanout,
 			supportedRemoteWriteProtoMsgs,
@@ -136,7 +133,7 @@ func (c *Component) Run(ctx context.Context) error {
 	}()
 
 	<-ctx.Done()
-	level.Info(c.opts.Logger).Log("msg", "terminating due to context done")
+	c.opts.SLogger.Info("terminating due to context done")
 	return nil
 }
 

--- a/internal/component/prometheus/receive_http/receive_http_test.go
+++ b/internal/component/prometheus/receive_http/receive_http_test.go
@@ -644,7 +644,7 @@ func requestV2(ctx context.Context, rawRemoteWriteURL string, req *writev2.Reque
 func testOptions(t *testing.T) component.Options {
 	return component.Options{
 		ID:         "prometheus.receive_http.test",
-		Logger:     util.TestAlloyLogger(t),
+		SLogger:    util.TestAlloyLogger(t).Slog(),
 		Registerer: prometheus.NewRegistry(),
 		GetServiceData: func(name string) (any, error) {
 			return labelstore.New(nil, prometheus.DefaultRegisterer), nil

--- a/internal/component/prometheus/relabel/relabel_test.go
+++ b/internal/component/prometheus/relabel/relabel_test.go
@@ -70,7 +70,7 @@ func TestNil(t *testing.T) {
 	}))
 	relabeller, err := New(component.Options{
 		ID:             "1",
-		Logger:         util.TestAlloyLogger(t),
+		SLogger:        util.TestAlloyLogger(t).Slog(),
 		OnStateChange:  func(e component.Exports) {},
 		Registerer:     prom.NewRegistry(),
 		GetServiceData: getServiceData,
@@ -152,7 +152,7 @@ func TestCacheSizeMetric(t *testing.T) {
 			}
 			relabeller, err := New(component.Options{
 				ID:             "1",
-				Logger:         util.TestAlloyLogger(t),
+				SLogger:        util.TestAlloyLogger(t).Slog(),
 				OnStateChange:  func(e component.Exports) {},
 				Registerer:     reg,
 				GetServiceData: getServiceData,
@@ -197,8 +197,8 @@ func BenchmarkCacheParallel(b *testing.B) {
 	}))
 	var entry storage.Appendable
 	_, err := New(component.Options{
-		ID:     "1",
-		Logger: util.TestAlloyLogger(b),
+		ID:      "1",
+		SLogger: util.TestAlloyLogger(b).Slog(),
 		OnStateChange: func(e component.Exports) {
 			newE := e.(Exports)
 			entry = newE.Receiver
@@ -237,8 +237,8 @@ func BenchmarkCache(b *testing.B) {
 	}))
 	var entry storage.Appendable
 	_, err := New(component.Options{
-		ID:     "1",
-		Logger: util.TestAlloyLogger(b),
+		ID:      "1",
+		SLogger: util.TestAlloyLogger(b).Slog(),
 		OnStateChange: func(e component.Exports) {
 			newE := e.(Exports)
 			entry = newE.Receiver
@@ -297,8 +297,8 @@ func BenchmarkCacheModes(b *testing.B) {
 			}
 			var entry storage.Appendable
 			_, err := New(component.Options{
-				ID:     "1",
-				Logger: util.TestAlloyLogger(b),
+				ID:      "1",
+				SLogger: util.TestAlloyLogger(b).Slog(),
 				OnStateChange: func(e component.Exports) {
 					entry = e.(Exports).Receiver
 				},
@@ -338,7 +338,7 @@ func generateRelabelWithArgs(t *testing.T, args Arguments) *Component {
 	}
 	relabeller, err := New(component.Options{
 		ID:             "1",
-		Logger:         util.TestAlloyLogger(t),
+		SLogger:        util.TestAlloyLogger(t).Slog(),
 		OnStateChange:  func(e component.Exports) {},
 		Registerer:     prom.NewRegistry(),
 		GetServiceData: getServiceData,

--- a/internal/component/prometheus/remotewrite/remote_write.go
+++ b/internal/component/prometheus/remotewrite/remote_write.go
@@ -21,7 +21,6 @@ import (
 	"github.com/grafana/alloy/internal/component/prometheus"
 	"github.com/grafana/alloy/internal/featuregate"
 	"github.com/grafana/alloy/internal/runtime/logging"
-	"github.com/grafana/alloy/internal/runtime/logging/level"
 	"github.com/grafana/alloy/internal/service/labelstore"
 	"github.com/grafana/alloy/internal/service/livedebugging"
 	"github.com/grafana/alloy/internal/static/metrics/wal"
@@ -50,7 +49,6 @@ func init() {
 
 // Component is the prometheus.remote_write component.
 type Component struct {
-	log  log.Logger
 	opts component.Options
 
 	walStore    *wal.Storage
@@ -77,8 +75,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 	oldDataPath := filepath.Join(o.DataPath, "wal", o.ID)
 	_ = os.RemoveAll(oldDataPath)
 
-	walLogger := log.With(o.Logger, "subcomponent", "wal")
-	walStorage, err := wal.NewStorage(walLogger, o.Registerer, o.DataPath)
+	walStorage, err := wal.NewStorage(o.SLogger.With("subcomponent", "wal"), o.Registerer, o.DataPath)
 	if err != nil {
 		return nil, err
 	}
@@ -108,17 +105,11 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		return nil, err
 	}
 
-	fanoutLogger := slog.New(
-		logging.NewSlogGoKitHandler(
-			log.With(o.Logger, "subcomponent", "fanout"),
-		),
-	)
 	res := &Component{
-		log:                o.Logger,
 		opts:               o,
 		walStore:           walStorage,
 		remoteStore:        remoteStore,
-		storage:            storage.NewFanout(fanoutLogger, walStorage, remoteStore),
+		storage:            storage.NewFanout(o.SLogger.With("subcomponent", "fanout"), walStorage, remoteStore),
 		debugDataPublisher: debugDataPublisher.(livedebugging.DebugDataPublisher),
 	}
 
@@ -144,11 +135,11 @@ func (c *Component) Run(ctx context.Context) error {
 	defer func() {
 		c.exited.Store(true)
 
-		level.Debug(c.log).Log("msg", "closing storage")
+		c.opts.SLogger.Debug("closing storage")
 		err := c.storage.Close()
-		level.Debug(c.log).Log("msg", "storage closed")
+		c.opts.SLogger.Debug("storage closed")
 		if err != nil {
-			level.Error(c.log).Log("msg", "error when closing storage", "err", err)
+			c.opts.SLogger.Error("error when closing storage", "err", err)
 		}
 	}()
 
@@ -192,17 +183,17 @@ func (c *Component) Run(ctx context.Context) error {
 			}
 
 			if ts == lastTs {
-				level.Debug(c.log).Log("msg", "not truncating the WAL, remote_write timestamp is unchanged", "ts", ts)
+				c.opts.SLogger.Debug("not truncating the WAL, remote_write timestamp is unchanged", "ts", ts)
 				continue
 			}
 			lastTs = ts
 
-			level.Debug(c.log).Log("msg", "truncating the WAL", "ts", ts)
+			c.opts.SLogger.Debug("truncating the WAL", "ts", ts)
 			err := c.walStore.Truncate(ts)
 			if err != nil {
 				// The only issue here is larger disk usage and a greater replay time,
 				// so we'll only log this as a warning.
-				level.Warn(c.log).Log("msg", "could not truncate WAL", "err", err)
+				c.opts.SLogger.Warn("could not truncate WAL", "err", err)
 			}
 		}
 	}

--- a/internal/component/prometheus/remotewrite/remote_write.go
+++ b/internal/component/prometheus/remotewrite/remote_write.go
@@ -3,14 +3,12 @@ package remotewrite
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"math"
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
 
-	"github.com/go-kit/log"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/remote"
@@ -20,7 +18,6 @@ import (
 	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/component/prometheus"
 	"github.com/grafana/alloy/internal/featuregate"
-	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/grafana/alloy/internal/service/labelstore"
 	"github.com/grafana/alloy/internal/service/livedebugging"
 	"github.com/grafana/alloy/internal/static/metrics/wal"
@@ -80,13 +77,8 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		return nil, err
 	}
 
-	remoteLogger := slog.New(
-		logging.NewSlogGoKitHandler(
-			log.With(o.Logger, "subcomponent", "rw"),
-		),
-	)
 	// TODO: Expose the option to enable type and unit labels: https://github.com/grafana/alloy/issues/4659
-	remoteStore := remote.NewStorage(remoteLogger, o.Registerer, startTime, o.DataPath, remoteFlushDeadline, nil, false)
+	remoteStore := remote.NewStorage(o.SLogger.With("subcomponent", "rw"), o.Registerer, startTime, o.DataPath, remoteFlushDeadline, nil, false)
 
 	walStorage.SetNotifier(remoteStore)
 

--- a/internal/component/prometheus/remotewrite/remote_write_test.go
+++ b/internal/component/prometheus/remotewrite/remote_write_test.go
@@ -206,7 +206,7 @@ func TestSend(t *testing.T) {
 			// Create our component and wait for it to start running, so we can write
 			// metrics to the WAL.
 			args := testArgs(t, cfg)
-			tc, err := componenttest.NewControllerFromID(util.TestLogger(t), "prometheus.remote_write")
+			tc, err := componenttest.NewControllerFromID(util.TestAlloyLogger(t), "prometheus.remote_write")
 			require.NoError(t, err)
 
 			promRegistry := prometheus.NewRegistry()
@@ -308,7 +308,7 @@ func TestMetadataResend_V2(t *testing.T) {
 	// Create our component and wait for it to start running, so we can write
 	// metrics to the WAL.
 	args := testArgs(t, cfg)
-	tc, err := componenttest.NewControllerFromID(util.TestLogger(t), "prometheus.remote_write")
+	tc, err := componenttest.NewControllerFromID(util.TestAlloyLogger(t), "prometheus.remote_write")
 	require.NoError(t, err)
 
 	promRegistry := prometheus.NewRegistry()
@@ -400,7 +400,7 @@ func TestUpdate(t *testing.T) {
 		}
 	}
 `, srv.URL))
-	tc, err := componenttest.NewControllerFromID(util.TestLogger(t), "prometheus.remote_write")
+	tc, err := componenttest.NewControllerFromID(util.TestAlloyLogger(t), "prometheus.remote_write")
 	require.NoError(t, err)
 	go func() {
 		err = tc.Run(componenttest.TestContext(t), args)

--- a/internal/component/prometheus/scrape/scrape.go
+++ b/internal/component/prometheus/scrape/scrape.go
@@ -3,7 +3,6 @@ package scrape
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"net/url"
 	"reflect"
 	"slices"
@@ -26,7 +25,6 @@ import (
 	"github.com/grafana/alloy/internal/component/discovery"
 	"github.com/grafana/alloy/internal/component/prometheus"
 	"github.com/grafana/alloy/internal/featuregate"
-	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/grafana/alloy/internal/service/cluster"
 	"github.com/grafana/alloy/internal/service/http"
 	"github.com/grafana/alloy/internal/service/labelstore"
@@ -492,7 +490,7 @@ func (c *Component) Update(args component.Arguments) error {
 
 	c.appendable.UpdateChildren(newArgs.ForwardTo)
 
-	promConfig, err := config.Load("", slog.New(logging.NewSlogGoKitHandler(c.opts.Logger)))
+	promConfig, err := config.Load("", c.opts.SLogger)
 	if err != nil {
 		return fmt.Errorf("error loading blank prometheus config: %w", err)
 	}

--- a/internal/component/prometheus/scrape/scrape.go
+++ b/internal/component/prometheus/scrape/scrape.go
@@ -27,7 +27,6 @@ import (
 	"github.com/grafana/alloy/internal/component/prometheus"
 	"github.com/grafana/alloy/internal/featuregate"
 	"github.com/grafana/alloy/internal/runtime/logging"
-	"github.com/grafana/alloy/internal/runtime/logging/level"
 	"github.com/grafana/alloy/internal/service/cluster"
 	"github.com/grafana/alloy/internal/service/http"
 	"github.com/grafana/alloy/internal/service/labelstore"
@@ -360,7 +359,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 
 	scraper, err := scrape.NewManager(
 		scrapeOptions,
-		slog.New(logging.NewSlogGoKitHandler(c.opts.Logger)),
+		c.opts.SLogger,
 		func(s string) (*promlogging.JSONFileLogger, error) { return promlogging.NewJSONFileLogger(s) },
 		interceptor,
 		unregisterer)
@@ -375,7 +374,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 	}
 
 	if args.EnableProtobufNegotiation {
-		level.Warn(o.Logger).Log("msg", "enable_protobuf_negotiation is deprecated and will be removed in a future major release, use scrape_protocols instead")
+		o.SLogger.Warn("enable_protobuf_negotiation is deprecated and will be removed in a future major release, use scrape_protocols instead")
 	}
 
 	return c, nil
@@ -391,9 +390,9 @@ func (c *Component) Run(ctx context.Context) error {
 
 	go func() {
 		err := c.scraper.Run(targetSetsChan)
-		level.Info(c.opts.Logger).Log("msg", "scrape manager stopped")
+		c.opts.SLogger.Info("scrape manager stopped")
 		if err != nil {
-			level.Error(c.opts.Logger).Log("msg", "scrape manager failed", "err", err)
+			c.opts.SLogger.Error("scrape manager failed", "err", err)
 		}
 	}()
 
@@ -424,7 +423,7 @@ func (c *Component) Run(ctx context.Context) error {
 
 			select {
 			case targetSetsChan <- newTargetGroups:
-				level.Debug(c.opts.Logger).Log("msg", "passed new targets to scrape manager")
+				c.opts.SLogger.Debug("passed new targets to scrape manager")
 			case <-ctx.Done():
 			}
 		}
@@ -480,11 +479,11 @@ func (c *Component) Update(args component.Arguments) error {
 	} else {
 		// TODO: When these change we could stop and re-create scrape manager.
 		if c.args.HonorMetadata != newArgs.HonorMetadata {
-			level.Warn(c.opts.Logger).Log("msg", "honor_metadata cannot be changed at runtime; the component will continue using the original setting until Alloy is restarted", "current", c.args.HonorMetadata, "requested", newArgs.HonorMetadata)
+			c.opts.SLogger.Warn("honor_metadata cannot be changed at runtime; the component will continue using the original setting until Alloy is restarted", "current", c.args.HonorMetadata, "requested", newArgs.HonorMetadata)
 			newArgs.HonorMetadata = c.args.HonorMetadata
 		}
 		if c.args.EnableTypeAndUnitLabels != newArgs.EnableTypeAndUnitLabels {
-			level.Warn(c.opts.Logger).Log("msg", "enable_type_and_unit_labels cannot be changed at runtime; the component will continue using the original setting until Alloy is restarted", "current", c.args.EnableTypeAndUnitLabels, "requested", newArgs.EnableTypeAndUnitLabels)
+			c.opts.SLogger.Warn("enable_type_and_unit_labels cannot be changed at runtime; the component will continue using the original setting until Alloy is restarted", "current", c.args.EnableTypeAndUnitLabels, "requested", newArgs.EnableTypeAndUnitLabels)
 			newArgs.EnableTypeAndUnitLabels = c.args.EnableTypeAndUnitLabels
 		}
 	}
@@ -503,7 +502,7 @@ func (c *Component) Update(args component.Arguments) error {
 	if err != nil {
 		return fmt.Errorf("error applying scrape configs: %w", err)
 	}
-	level.Debug(c.opts.Logger).Log("msg", "scrape config was updated")
+	c.opts.SLogger.Debug("scrape config was updated")
 
 	return nil
 }
@@ -650,7 +649,7 @@ func (c *Component) populatePromLabels(targets []discovery.Target, jobName strin
 				labels.NewBuilder(labels.EmptyLabels()),
 			)
 			for _, err := range errs {
-				level.Warn(c.opts.Logger).Log("msg", "error while populating labels of targets using prom config", "err", err)
+				c.opts.SLogger.Warn("error while populating labels of targets using prom config", "err", err)
 			}
 			allTargets = append(allTargets, promTargets...)
 		}

--- a/internal/component/prometheus/scrape/scrape_clustering_test.go
+++ b/internal/component/prometheus/scrape/scrape_clustering_test.go
@@ -202,7 +202,7 @@ func testArgs() Arguments {
 
 func testOptions(t *testing.T, alloyMetricsReg *client.Registry, fakeCluster *fakeCluster) component.Options {
 	opts := component.Options{
-		Logger:     util.TestAlloyLogger(t),
+		SLogger:    util.TestAlloyLogger(t).Slog(),
 		Registerer: alloyMetricsReg,
 		ID:         "prometheus.scrape.test",
 		GetServiceData: func(name string) (any, error) {

--- a/internal/component/prometheus/scrape/scrape_test.go
+++ b/internal/component/prometheus/scrape/scrape_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/log"
 	"github.com/grafana/ckit/memconn"
 	prometheus_client "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -25,6 +24,7 @@ import (
 	http_service "github.com/grafana/alloy/internal/service/http"
 	"github.com/grafana/alloy/internal/service/labelstore"
 	"github.com/grafana/alloy/internal/service/livedebugging"
+	"github.com/grafana/alloy/internal/slogadapter"
 	"github.com/grafana/alloy/internal/util"
 	"github.com/grafana/alloy/internal/util/testappender"
 	"github.com/grafana/alloy/syntax"
@@ -148,7 +148,7 @@ func TestCustomDialer(t *testing.T) {
 			}),
 		}
 
-		memLis = memconn.NewListener(util.TestLogger(t))
+		memLis = memconn.NewListener(slogadapter.GoKit(util.TestAlloyLogger(t).Handler()))
 	)
 
 	go srv.Serve(memLis)
@@ -1117,10 +1117,10 @@ func newComponentOpts(t *testing.T, dialFunc ...func(context.Context, string, st
 	if len(dialFunc) > 0 && dialFunc[0] != nil {
 		df = dialFunc[0]
 	}
-	baseLogger := util.TestAlloyLogger(t)
+	baseLogger := util.TestAlloyLogger(t).Slog()
 	return component.Options{
 		ID:         componentID,
-		Logger:     log.With(baseLogger, "component_path", "prometheus.scrape", "component_id", componentID),
+		SLogger:    baseLogger.With("component_path", "prometheus.scrape", "component_id", componentID),
 		Registerer: prometheus_client.NewRegistry(),
 		GetServiceData: func(name string) (any, error) {
 			switch name {

--- a/internal/component/prometheus/write/queue/component.go
+++ b/internal/component/prometheus/write/queue/component.go
@@ -6,13 +6,12 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	promqueue "github.com/grafana/walqueue/implementations/prometheus"
 	"github.com/prometheus/prometheus/storage"
 
 	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/featuregate"
+	"github.com/grafana/alloy/internal/slogadapter"
 )
 
 func init() {
@@ -28,12 +27,11 @@ func init() {
 }
 
 func NewComponent(opts component.Options, args Arguments) (*Queue, error) {
-	level.Warn(opts.Logger).Log("msg", "prometheus.write.queue is deprecated and will be removed in a future version. Migrate to prometheus.remote_write to prevent future errors.")
+	opts.SLogger.Warn("prometheus.write.queue is deprecated and will be removed in a future version. Migrate to prometheus.remote_write to prevent future errors.")
 
 	s := &Queue{
 		opts:      opts,
 		args:      args,
-		log:       opts.Logger,
 		endpoints: map[string]promqueue.Queue{},
 	}
 	s.opts.OnStateChange(Exports{Receiver: s})
@@ -50,7 +48,6 @@ type Queue struct {
 	mut       sync.RWMutex
 	args      Arguments
 	opts      component.Options
-	log       log.Logger
 	endpoints map[string]promqueue.Queue
 	ctx       context.Context
 }
@@ -114,7 +111,7 @@ func (s *Queue) Update(args component.Arguments) error {
 		}
 		nativeCfg := epCfg.ToNativeType()
 		// Create
-		end, err := promqueue.NewQueue(epCfg.Name, nativeCfg, filepath.Join(s.opts.DataPath, epCfg.Name, "wal"), uint32(s.args.Persistence.MaxSignalsToBatch), s.args.Persistence.BatchInterval, s.args.TTL, s.opts.Registerer, "alloy", s.opts.Logger)
+		end, err := promqueue.NewQueue(epCfg.Name, nativeCfg, filepath.Join(s.opts.DataPath, epCfg.Name, "wal"), uint32(s.args.Persistence.MaxSignalsToBatch), s.args.Persistence.BatchInterval, s.args.TTL, s.opts.Registerer, "alloy", slogadapter.GoKit(s.opts.SLogger.Handler()))
 		if err != nil {
 			return err
 		}
@@ -135,7 +132,7 @@ func (s *Queue) Update(args component.Arguments) error {
 func (s *Queue) createEndpoints() error {
 	for _, ep := range s.args.Endpoints {
 		nativeCfg := ep.ToNativeType()
-		end, err := promqueue.NewQueue(ep.Name, nativeCfg, filepath.Join(s.opts.DataPath, ep.Name, "wal"), uint32(s.args.Persistence.MaxSignalsToBatch), s.args.Persistence.BatchInterval, s.args.TTL, s.opts.Registerer, "alloy", s.opts.Logger)
+		end, err := promqueue.NewQueue(ep.Name, nativeCfg, filepath.Join(s.opts.DataPath, ep.Name, "wal"), uint32(s.args.Persistence.MaxSignalsToBatch), s.args.Persistence.BatchInterval, s.args.TTL, s.opts.Registerer, "alloy", slogadapter.GoKit(s.opts.SLogger.Handler()))
 		if err != nil {
 			return err
 		}

--- a/internal/static/metrics/wal/wal.go
+++ b/internal/static/metrics/wal/wal.go
@@ -14,8 +14,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
@@ -30,7 +28,6 @@ import (
 	"github.com/prometheus/prometheus/util/zeropool"
 	"go.uber.org/atomic"
 
-	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/grafana/alloy/internal/util"
 )
 
@@ -200,7 +197,7 @@ type Storage struct {
 
 	path   string
 	wal    *wlog.WL
-	logger log.Logger
+	logger *slog.Logger
 
 	appenderPool sync.Pool
 	bufPool      sync.Pool
@@ -229,11 +226,8 @@ type Storage struct {
 var stripeSeriesSize = 4096
 
 // NewStorage makes a new Storage.
-func NewStorage(logger log.Logger, registerer prometheus.Registerer, path string) (*Storage, error) {
-	// Convert go-kit logger to slog logger
-	slogLogger := slog.New(logging.NewSlogGoKitHandler(logger))
-
-	w, err := wlog.NewSize(slogLogger, registerer, SubDirectory(path), wlog.DefaultSegmentSize, compression.Snappy)
+func NewStorage(logger *slog.Logger, registerer prometheus.Registerer, path string) (*Storage, error) {
+	w, err := wlog.NewSize(logger, registerer, SubDirectory(path), wlog.DefaultSegmentSize, compression.Snappy)
 	if err != nil {
 		return nil, err
 	}
@@ -266,7 +260,7 @@ func NewStorage(logger log.Logger, registerer prometheus.Registerer, path string
 	}
 
 	if err := storage.replayWAL(); err != nil {
-		level.Warn(storage.logger).Log("msg", "encountered WAL read error, attempting repair", "err", err)
+		storage.logger.Warn("encountered WAL read error, attempting repair", "err", err)
 
 		var ce *wlog.CorruptionErr
 		if ok := errors.As(err, &ce); !ok {
@@ -274,9 +268,9 @@ func NewStorage(logger log.Logger, registerer prometheus.Registerer, path string
 		}
 		if err := w.Repair(ce); err != nil {
 			// if repair fails, truncate everything in WAL
-			level.Warn(storage.logger).Log("msg", "WAL repair failed, truncating!", "err", err)
+			storage.logger.Warn("WAL repair failed, truncating!", "err", err)
 			if e := w.Truncate(math.MaxInt); e != nil {
-				level.Error(storage.logger).Log("msg", "WAL truncate failure", "err", e)
+				storage.logger.Error("WAL truncate failure", "err", e)
 				return nil, fmt.Errorf("truncate corrupted WAL: %w", e)
 			}
 			if e := wlog.DeleteCheckpoints(w.Dir(), math.MaxInt); e != nil {
@@ -299,7 +293,7 @@ func (w *Storage) replayWAL() error {
 		return ErrWALClosed
 	}
 
-	level.Info(w.logger).Log("msg", "replaying WAL, this may take a while", "dir", w.wal.Dir())
+	w.logger.Info("msg", "replaying WAL, this may take a while", "dir", w.wal.Dir())
 	dir, startFrom, err := wlog.LastCheckpoint(w.wal.Dir())
 	if err != nil && !errors.Is(err, record.ErrNotFound) {
 		return fmt.Errorf("find last checkpoint: %w", err)
@@ -313,7 +307,7 @@ func (w *Storage) replayWAL() error {
 		}
 		defer func() {
 			if err := sr.Close(); err != nil {
-				level.Warn(w.logger).Log("msg", "error while closing the wal segments reader", "err", err)
+				w.logger.Warn("error while closing the wal segments reader", "err", err)
 			}
 		}()
 
@@ -323,7 +317,7 @@ func (w *Storage) replayWAL() error {
 			return fmt.Errorf("backfill checkpoint: %w", err)
 		}
 		startFrom++
-		level.Info(w.logger).Log("msg", "WAL checkpoint loaded")
+		w.logger.Info("WAL checkpoint loaded")
 	}
 
 	// Find the last segment.
@@ -342,12 +336,12 @@ func (w *Storage) replayWAL() error {
 		sr := wlog.NewSegmentBufReader(s)
 		err = w.loadWAL(wlog.NewReader(sr), duplicateRefToValidRef, i)
 		if err := sr.Close(); err != nil {
-			level.Warn(w.logger).Log("msg", "error while closing the wal segments reader", "err", err)
+			w.logger.Warn("error while closing the wal segments reader", "err", err)
 		}
 		if err != nil {
 			return err
 		}
-		level.Info(w.logger).Log("msg", "WAL segment loaded", "segment", i, "maxSegment", lastSegment)
+		w.logger.Info("WAL segment loaded", "segment", i, "maxSegment", lastSegment)
 	}
 
 	walReplayDuration := time.Since(start)
@@ -370,7 +364,7 @@ func (w *Storage) resetWALReplayResources() {
 func (w *Storage) loadWAL(r *wlog.Reader, duplicateRefToValidRef map[chunks.HeadSeriesRef]chunks.HeadSeriesRef, currentSegmentOrCheckpoint int) (err error) {
 	var (
 		syms    = labels.NewSymbolTable() // One table for the whole WAL.
-		dec     = record.NewDecoder(syms, slog.New(logging.NewSlogGoKitHandler(w.logger)))
+		dec     = record.NewDecoder(syms, w.logger)
 		lastRef = chunks.HeadSeriesRef(w.nextRef.Load())
 
 		decoded = make(chan any, 10)
@@ -560,7 +554,7 @@ func (w *Storage) loadWAL(r *wlog.Reader, duplicateRefToValidRef map[chunks.Head
 	}
 
 	if v := nonExistentSeriesRefs.Load(); v > 0 {
-		level.Warn(w.logger).Log("msg", "found sample referencing non-existing series", "skipped_series", v)
+		w.logger.Warn("found sample referencing non-existing series", "skipped_series", v)
 	}
 
 	w.nextRef.Store(uint64(lastRef))
@@ -612,7 +606,7 @@ func (w *Storage) Truncate(mint int64) error {
 
 	// Garbage collect series that haven't received an update since mint.
 	w.gc(mint)
-	level.Info(w.logger).Log("msg", "series GC completed", "duration", time.Since(start))
+	w.logger.Info("series GC completed", "duration", time.Since(start))
 
 	first, last, err := wlog.Segments(w.wal.Dir())
 	if err != nil {
@@ -647,13 +641,10 @@ func (w *Storage) Truncate(mint int64) error {
 		return ok && seg > last
 	}
 
-	// Convert go-kit logger to slog logger
-	slogLogger := slog.New(logging.NewSlogGoKitHandler(w.logger))
-
 	w.metrics.checkpointCreationTotal.Inc()
 
 	// TODO(x1unix): pass EnableSTStorage when Prometheus will be upgraded
-	if _, err = wlog.Checkpoint(slogLogger, w.wal, first, last, keep, mint); err != nil {
+	if _, err = wlog.Checkpoint(w.logger, w.wal, first, last, keep, mint); err != nil {
 		w.metrics.checkpointCreationFail.Inc()
 		var cerr *wlog.CorruptionErr
 		if errors.As(err, &cerr) {
@@ -665,7 +656,7 @@ func (w *Storage) Truncate(mint int64) error {
 		// If truncating fails, we'll just try again at the next checkpoint.
 		// Leftover segments will just be ignored in the future if there's a checkpoint
 		// that supersedes them.
-		level.Error(w.logger).Log("msg", "truncating segments failed", "err", err)
+		w.logger.Error("truncating segments failed", "err", err)
 	}
 
 	// The checkpoint is written and segments before it is truncated, so we no
@@ -683,13 +674,13 @@ func (w *Storage) Truncate(mint int64) error {
 		// Leftover old checkpoints do not cause problems down the line beyond
 		// occupying disk space.
 		// They will just be ignored since a higher checkpoint exists.
-		level.Error(w.logger).Log("msg", "delete old checkpoints", "err", err)
+		w.logger.Error("delete old checkpoints", "err", err)
 		w.metrics.checkpointDeleteFail.Inc()
 	}
 
 	w.metrics.walTruncateDuration.Observe(time.Since(start).Seconds())
 
-	level.Info(w.logger).Log("msg", "WAL checkpoint complete",
+	w.logger.Info("WAL checkpoint complete",
 		"first", first, "last", last, "duration", time.Since(start))
 	return nil
 }

--- a/internal/static/metrics/wal/wal.go
+++ b/internal/static/metrics/wal/wal.go
@@ -293,7 +293,7 @@ func (w *Storage) replayWAL() error {
 		return ErrWALClosed
 	}
 
-	w.logger.Info("msg", "replaying WAL, this may take a while", "dir", w.wal.Dir())
+	w.logger.Info("replaying WAL, this may take a while", "dir", w.wal.Dir())
 	dir, startFrom, err := wlog.LastCheckpoint(w.wal.Dir())
 	if err != nil && !errors.Is(err, record.ErrNotFound) {
 		return fmt.Errorf("find last checkpoint: %w", err)

--- a/internal/static/metrics/wal/wal_test.go
+++ b/internal/static/metrics/wal/wal_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/model/exemplar"
@@ -25,13 +24,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/grafana/alloy/internal/util"
 )
 
 func TestStorage_InvalidSeries(t *testing.T) {
 	walDir := t.TempDir()
 
-	s, err := NewStorage(log.NewNopLogger(), nil, walDir)
+	s, err := NewStorage(logging.NewSlogNop(), nil, walDir)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, s.Close())
@@ -74,7 +74,7 @@ func TestStorage(t *testing.T) {
 	onNotify := util.NewWaitTrigger()
 	notifier := &fakeNotifier{NotitfyFunc: onNotify.Trigger}
 
-	s, err := NewStorage(log.NewNopLogger(), nil, walDir)
+	s, err := NewStorage(logging.NewSlogNop(), nil, walDir)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, s.Close())
@@ -127,7 +127,7 @@ func TestStorage_RepeatedCommitWithMetadata(t *testing.T) {
 	notifier := &fakeNotifier{NotitfyFunc: onNotify.Trigger}
 
 	reg := prometheus.NewRegistry()
-	s, err := NewStorage(log.NewNopLogger(), reg, walDir)
+	s, err := NewStorage(logging.NewSlogNop(), reg, walDir)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, s.Close())
@@ -236,7 +236,7 @@ prometheus_remote_write_wal_samples_appended_total 40
 
 func TestStorage_Rollback(t *testing.T) {
 	walDir := t.TempDir()
-	s, err := NewStorage(log.NewNopLogger(), nil, walDir)
+	s, err := NewStorage(logging.NewSlogNop(), nil, walDir)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, s.Close())
@@ -266,7 +266,7 @@ func TestStorage_Rollback(t *testing.T) {
 func TestStorage_DuplicateExemplarsIgnored(t *testing.T) {
 	walDir := t.TempDir()
 
-	s, err := NewStorage(log.NewNopLogger(), nil, walDir)
+	s, err := NewStorage(logging.NewSlogNop(), nil, walDir)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, s.Close())
@@ -312,7 +312,7 @@ func TestStorage_DuplicateExemplarsIgnored(t *testing.T) {
 func TestStorage_ExistingWAL(t *testing.T) {
 	walDir := t.TempDir()
 
-	s, err := NewStorage(log.NewNopLogger(), nil, walDir)
+	s, err := NewStorage(logging.NewSlogNop(), nil, walDir)
 	require.NoError(t, err)
 
 	app := s.Appender(t.Context())
@@ -331,7 +331,7 @@ func TestStorage_ExistingWAL(t *testing.T) {
 	time.Sleep(time.Millisecond * 150)
 
 	// Create a new storage, write the other half of samples.
-	s, err = NewStorage(log.NewNopLogger(), nil, walDir)
+	s, err = NewStorage(logging.NewSlogNop(), nil, walDir)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, s.Close())
@@ -373,11 +373,11 @@ func TestStorage_ExistingWAL(t *testing.T) {
 }
 
 func TestStorage_ExistingWAL_RefID(t *testing.T) {
-	l := util.TestLogger(t)
+	l := util.TestAlloyLogger(t)
 
 	walDir := t.TempDir()
 
-	s, err := NewStorage(l, nil, walDir)
+	s, err := NewStorage(l.Slog(), nil, walDir)
 	require.NoError(t, err)
 
 	app := s.Appender(t.Context())
@@ -394,7 +394,7 @@ func TestStorage_ExistingWAL_RefID(t *testing.T) {
 	require.NoError(t, s.Close())
 
 	// Create a new storage and see what the ref ID is initialized to.
-	s, err = NewStorage(l, nil, walDir)
+	s, err = NewStorage(l.Slog(), nil, walDir)
 	require.NoError(t, err)
 	defer require.NoError(t, s.Close())
 
@@ -408,7 +408,7 @@ func TestStorage_Truncate(t *testing.T) {
 	// then read data back in. Expect to only get the latter half of data.
 	walDir := t.TempDir()
 
-	s, err := NewStorage(log.NewNopLogger(), nil, walDir)
+	s, err := NewStorage(logging.NewSlogNop(), nil, walDir)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, s.Close())
@@ -469,7 +469,7 @@ func TestStorage_HandlesDuplicateSeriesRefsByHash(t *testing.T) {
 	// Ensure the WAL can handle duplicate SeriesRefs by hash when being loaded.
 	walDir := t.TempDir()
 
-	s, err := NewStorage(log.NewLogfmtLogger(os.Stdout), nil, walDir)
+	s, err := NewStorage(logging.NewSlogNop(), nil, walDir)
 	require.NoError(t, err)
 
 	app := s.Appender(t.Context())
@@ -524,7 +524,7 @@ func TestStorage_HandlesDuplicateSeriesRefsByHash(t *testing.T) {
 	// Close the WAL before we have a chance to remove the first RefIDs
 	require.NoError(t, s.Close())
 
-	s, err = NewStorage(log.NewLogfmtLogger(os.Stdout), nil, walDir)
+	s, err = NewStorage(logging.NewSlogNop(), nil, walDir)
 	require.NoError(t, err)
 
 	// There should only be 4 active series after we reload the WAL
@@ -545,7 +545,7 @@ func TestStorage_HandlesDuplicateSeriesRefsByHash(t *testing.T) {
 func TestStorage_TruncateAfterClose(t *testing.T) {
 	walDir := t.TempDir()
 
-	s, err := NewStorage(log.NewNopLogger(), nil, walDir)
+	s, err := NewStorage(logging.NewSlogNop(), nil, walDir)
 	require.NoError(t, err)
 
 	require.NoError(t, s.Close())
@@ -562,7 +562,7 @@ func TestStorage_Corruption(t *testing.T) {
 	require.NoError(t, err)
 
 	// The storage should be initialized correctly anyway.
-	s, err := NewStorage(log.NewNopLogger(), nil, walDir)
+	s, err := NewStorage(logging.NewSlogNop(), nil, walDir)
 	require.NoError(t, err)
 	require.NotNil(t, s)
 
@@ -572,7 +572,7 @@ func TestStorage_Corruption(t *testing.T) {
 func TestGlobalReferenceID_Normal(t *testing.T) {
 	walDir := t.TempDir()
 
-	s, _ := NewStorage(log.NewNopLogger(), nil, walDir)
+	s, _ := NewStorage(logging.NewSlogNop(), nil, walDir)
 	defer s.Close()
 	app := s.Appender(t.Context())
 	l := labels.New(labels.Label{
@@ -599,7 +599,7 @@ func TestGlobalReferenceID_Normal(t *testing.T) {
 func TestDBAllowOOOSamples(t *testing.T) {
 	walDir := t.TempDir()
 
-	s, err := NewStorage(log.NewNopLogger(), nil, walDir)
+	s, err := NewStorage(logging.NewSlogNop(), nil, walDir)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, s.Close())
@@ -625,7 +625,7 @@ func TestDBAllowOOOSamples(t *testing.T) {
 func BenchmarkAppendExemplar(b *testing.B) {
 	walDir := b.TempDir()
 
-	s, _ := NewStorage(log.NewNopLogger(), nil, walDir)
+	s, _ := NewStorage(logging.NewSlogNop(), nil, walDir)
 	defer s.Close()
 	app := s.Appender(b.Context())
 	sRef, _ := app.Append(0, labels.FromStrings("a", "1"), 0, 0)
@@ -645,7 +645,7 @@ func BenchmarkAppendExemplar(b *testing.B) {
 func BenchmarkCreateSeries(b *testing.B) {
 	walDir := b.TempDir()
 
-	s, _ := NewStorage(log.NewNopLogger(), nil, walDir)
+	s, _ := NewStorage(logging.NewSlogNop(), nil, walDir)
 	defer s.Close()
 
 	app := s.Appender(b.Context()).(*appender)


### PR DESCRIPTION
Migrate promethues components to use `slog/log` instead of `go-kit/log`.

Part of: https://github.com/grafana/alloy/issues/4813