### PR TITLE
chore: Migrate database observability slog

### DIFF
--- a/internal/component/database_observability/mysql/collector/explain_plans.go
+++ b/internal/component/database_observability/mysql/collector/explain_plans.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"math"
 	"strconv"
 	"strings"
@@ -15,7 +16,6 @@ import (
 	"unicode/utf8"
 
 	"github.com/DataDog/go-sqllexer"
-	"github.com/go-kit/log"
 	"go.uber.org/atomic"
 
 	"github.com/buger/jsonparser"
@@ -24,7 +24,6 @@ import (
 	"github.com/grafana/alloy/internal/component/database_observability"
 	"github.com/grafana/alloy/internal/component/database_observability/mysql/collector/parser"
 	"github.com/grafana/alloy/internal/runtime/logging"
-	"github.com/grafana/alloy/internal/runtime/logging/level"
 )
 
 const (
@@ -46,7 +45,7 @@ const selectDigestsForExplainPlan = `
 
 const selectExplainPlanPrefix = `EXPLAIN FORMAT=JSON `
 
-func newExplainPlansOutput(logger log.Logger, explainJson []byte) (*database_observability.ExplainPlanNode, error) {
+func newExplainPlansOutput(logger *slog.Logger, explainJson []byte) (*database_observability.ExplainPlanNode, error) {
 	qblock, _, _, err := jsonparser.Get(explainJson, "query_block")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get query block: %w", err)
@@ -56,7 +55,7 @@ func newExplainPlansOutput(logger log.Logger, explainJson []byte) (*database_obs
 	return &planNode, err
 }
 
-func parseTopLevelPlanNode(logger log.Logger, topLevelPlanNode []byte) (database_observability.ExplainPlanNode, error) {
+func parseTopLevelPlanNode(logger *slog.Logger, topLevelPlanNode []byte) (database_observability.ExplainPlanNode, error) {
 	if table, _, _, err := jsonparser.Get(topLevelPlanNode, "table"); err == nil {
 		tableDetails, err := parseTableNode(logger, table)
 		if err != nil {
@@ -112,7 +111,7 @@ func parseTopLevelPlanNode(logger log.Logger, topLevelPlanNode []byte) (database
 	}, nil
 }
 
-func parseTableNode(logger log.Logger, tableNode []byte) (database_observability.ExplainPlanNode, error) {
+func parseTableNode(logger *slog.Logger, tableNode []byte) (database_observability.ExplainPlanNode, error) {
 	pnode := database_observability.ExplainPlanNode{
 		Operation: database_observability.ExplainPlanOutputOperationTableScan,
 		Details:   database_observability.ExplainPlanNodeDetails{},
@@ -194,7 +193,7 @@ func parseTableNode(logger log.Logger, tableNode []byte) (database_observability
 	return pnode, nil
 }
 
-func parseNestedLoopJoinNode(logger log.Logger, nestedLoopJoinNode []byte) (database_observability.ExplainPlanNode, error) {
+func parseNestedLoopJoinNode(logger *slog.Logger, nestedLoopJoinNode []byte) (database_observability.ExplainPlanNode, error) {
 	algo := database_observability.ExplainPlanJoinAlgorithmNestedLoop
 	pnode := database_observability.ExplainPlanNode{
 		Operation: database_observability.ExplainPlanOutputOperationNestedLoopJoin,
@@ -207,13 +206,13 @@ func parseNestedLoopJoinNode(logger log.Logger, nestedLoopJoinNode []byte) (data
 	_, err := jsonparser.ArrayEach(nestedLoopJoinNode, func(value []byte, dataType jsonparser.ValueType, offset int, inerr error) {
 		tableNode, _, _, err := jsonparser.Get(value, "table")
 		if err != nil {
-			level.Debug(logger).Log("msg", "no table node found in nested loop join", "error", err)
+			logger.Debug("no table node found in nested loop join", "error", err)
 			// In theory, this could be okay? Are there other things that could be in nested loop?
 			return
 		}
 		childDetails, err := parseTableNode(logger, tableNode)
 		if err != nil {
-			level.Error(logger).Log("msg", "failed to parse table node in nested loop join", "error", err)
+			logger.Error("failed to parse table node in nested loop join", "error", err)
 			return
 		}
 		if previousChild != nil {
@@ -259,7 +258,7 @@ func parseNestedLoopJoinNode(logger log.Logger, nestedLoopJoinNode []byte) (data
 	return pnode, nil
 }
 
-func parseGroupingOperationNode(logger log.Logger, groupingOperationNode []byte) (database_observability.ExplainPlanNode, error) {
+func parseGroupingOperationNode(logger *slog.Logger, groupingOperationNode []byte) (database_observability.ExplainPlanNode, error) {
 	pnode := database_observability.ExplainPlanNode{
 		Operation: database_observability.ExplainPlanOutputOperationGroupingOperation,
 	}
@@ -273,7 +272,7 @@ func parseGroupingOperationNode(logger log.Logger, groupingOperationNode []byte)
 	return pnode, nil
 }
 
-func parseOrderingOperationNode(logger log.Logger, orderingOperationNode []byte) (database_observability.ExplainPlanNode, error) {
+func parseOrderingOperationNode(logger *slog.Logger, orderingOperationNode []byte) (database_observability.ExplainPlanNode, error) {
 	pnode := database_observability.ExplainPlanNode{
 		Operation: database_observability.ExplainPlanOutputOperationOrderingOperation,
 	}
@@ -287,7 +286,7 @@ func parseOrderingOperationNode(logger log.Logger, orderingOperationNode []byte)
 	return pnode, nil
 }
 
-func parseDuplicatesRemovalNode(logger log.Logger, duplicatesRemovalNode []byte) (database_observability.ExplainPlanNode, error) {
+func parseDuplicatesRemovalNode(logger *slog.Logger, duplicatesRemovalNode []byte) (database_observability.ExplainPlanNode, error) {
 	pnode := database_observability.ExplainPlanNode{
 		Operation: database_observability.ExplainPlanOutputOperationDuplicatesRemoval,
 	}
@@ -301,7 +300,7 @@ func parseDuplicatesRemovalNode(logger log.Logger, duplicatesRemovalNode []byte)
 	return pnode, nil
 }
 
-func parseMaterializedSubqueryNode(logger log.Logger, materializedSubqueryNode []byte) (database_observability.ExplainPlanNode, error) {
+func parseMaterializedSubqueryNode(logger *slog.Logger, materializedSubqueryNode []byte) (database_observability.ExplainPlanNode, error) {
 	pnode := database_observability.ExplainPlanNode{
 		Operation: database_observability.ExplainPlanOutputOperationMaterializedSubquery,
 	}
@@ -320,7 +319,7 @@ func parseMaterializedSubqueryNode(logger log.Logger, materializedSubqueryNode [
 	return pnode, nil
 }
 
-func parseAttachedSubqueryNode(logger log.Logger, attachedSubqueryNode []byte) (database_observability.ExplainPlanNode, error) {
+func parseAttachedSubqueryNode(logger *slog.Logger, attachedSubqueryNode []byte) (database_observability.ExplainPlanNode, error) {
 	pnode := database_observability.ExplainPlanNode{
 		Operation: database_observability.ExplainPlanOutputOperationAttachedSubquery,
 	}
@@ -339,7 +338,7 @@ func parseAttachedSubqueryNode(logger log.Logger, attachedSubqueryNode []byte) (
 	return pnode, nil
 }
 
-func parseUnionResultNode(logger log.Logger, unionResultNode []byte) (database_observability.ExplainPlanNode, error) {
+func parseUnionResultNode(logger *slog.Logger, unionResultNode []byte) (database_observability.ExplainPlanNode, error) {
 	pnode := database_observability.ExplainPlanNode{
 		Operation: database_observability.ExplainPlanOutputOperationUnion,
 	}
@@ -402,7 +401,7 @@ type ExplainPlansArguments struct {
 	EntryHandler    loki.EntryHandler
 	DBVersion       string
 
-	Logger log.Logger
+	Logger *slog.Logger
 }
 
 type ExplainPlans struct {
@@ -416,7 +415,7 @@ type ExplainPlans struct {
 	currentBatchSize int
 	entryHandler     loki.EntryHandler
 	lastSeen         time.Time
-	logger           log.Logger
+	logger           *slog.Logger
 	running          *atomic.Bool
 	ctx              context.Context
 	cancel           context.CancelFunc
@@ -434,7 +433,7 @@ func NewExplainPlans(args ExplainPlansArguments) (*ExplainPlans, error) {
 		queryCache:     make(map[string]*queryInfo),
 		queryDenylist:  make(map[string]*queryInfo),
 		entryHandler:   args.EntryHandler,
-		logger:         log.With(args.Logger, "collector", ExplainPlansCollector),
+		logger:         args.Logger.With("collector", ExplainPlansCollector),
 		running:        atomic.NewBool(false),
 	}, nil
 }
@@ -480,7 +479,7 @@ func (c *ExplainPlans) Name() string {
 }
 
 func (c *ExplainPlans) Start(ctx context.Context) error {
-	level.Debug(c.logger).Log("msg", "collector started")
+	c.logger.Debug("collector started")
 
 	c.running.Store(true)
 	ctx, cancel := context.WithCancel(ctx)
@@ -495,7 +494,7 @@ func (c *ExplainPlans) Start(ctx context.Context) error {
 
 		for {
 			if err := c.fetchExplainPlans(c.ctx); err != nil {
-				level.Error(c.logger).Log("msg", "collector error", "err", err)
+				c.logger.Error("collector error", "err", err)
 			}
 
 			select {
@@ -525,7 +524,7 @@ func (c *ExplainPlans) populateQueryCache(ctx context.Context) error {
 	query := fmt.Sprintf(selectDigestsForExplainPlan, buildExcludedSchemasClause(c.excludeSchemas))
 	rs, err := c.dbConnection.QueryContext(ctx, query, c.lastSeen)
 	if err != nil {
-		level.Error(c.logger).Log("msg", "failed to fetch digests for explain plans", "err", err)
+		c.logger.Error("failed to fetch digests for explain plans", "err", err)
 		return err
 	}
 	defer rs.Close()
@@ -536,7 +535,7 @@ func (c *ExplainPlans) populateQueryCache(ctx context.Context) error {
 		var schemaName, digest, queryText string
 		var ls time.Time
 		if err = rs.Scan(&schemaName, &digest, &queryText, &ls); err != nil {
-			level.Error(c.logger).Log("msg", "failed to scan digest for explain plans", "err", err)
+			c.logger.Error("failed to scan digest for explain plans", "err", err)
 			return err
 		}
 
@@ -553,7 +552,7 @@ func (c *ExplainPlans) populateQueryCache(ctx context.Context) error {
 				nil,
 			)
 			if err != nil {
-				level.Error(c.logger).Log("msg", "failed to send denylisted query skip explain plan output", "err", err)
+				c.logger.Error("failed to send denylisted query skip explain plan output", "err", err)
 			}
 			continue
 		}
@@ -563,13 +562,13 @@ func (c *ExplainPlans) populateQueryCache(ctx context.Context) error {
 	}
 
 	if err := rs.Err(); err != nil {
-		level.Error(c.logger).Log("msg", "failed to iterate digest rows for explain plans", "err", err)
+		c.logger.Error("failed to iterate digest rows for explain plans", "err", err)
 		return err
 	}
 
 	// Calculate batch size based on current cache size
 	c.currentBatchSize = int(math.Ceil(float64(len(c.queryCache)) * c.perScrapeRatio))
-	level.Debug(c.logger).Log("msg", "populated query cache", "count", len(c.queryCache), "batch_size", c.currentBatchSize)
+	c.logger.Debug("populated query cache", "count", len(c.queryCache), "batch_size", c.currentBatchSize)
 	return nil
 }
 
@@ -601,7 +600,7 @@ func (c *ExplainPlans) fetchExplainPlans(ctx context.Context) error {
 // Returns true if the query encountered a non-recoverable failure and should be denylisted.
 func (c *ExplainPlans) processExplainPlan(ctx context.Context, qi *queryInfo) bool {
 	generatedAt := time.Now().Format(time.RFC3339)
-	logger := log.With(c.logger, "digest", qi.digest)
+	logger := c.logger.With("digest", qi.digest)
 
 	if strings.HasSuffix(qi.queryText, "...") {
 		err := c.sendExplainPlansOutput(
@@ -613,14 +612,14 @@ func (c *ExplainPlans) processExplainPlan(ctx context.Context, qi *queryInfo) bo
 			nil,
 		)
 		if err != nil {
-			level.Error(c.logger).Log("msg", "failed to send truncated query skip explain plan output", "err", err)
+			c.logger.Error("failed to send truncated query skip explain plan output", "err", err)
 		}
 		return false
 	}
 
 	containsReservedWord, err := database_observability.ContainsReservedKeywords(qi.queryText, database_observability.ExplainReservedWordDenyList, sqllexer.DBMSMySQL)
 	if err != nil {
-		level.Error(logger).Log("msg", "failed to check for reserved keywords", "err", err)
+		logger.Error("failed to check for reserved keywords", "err", err)
 		err := c.sendExplainPlansOutput(
 			qi.schemaName,
 			qi.digest,
@@ -630,7 +629,7 @@ func (c *ExplainPlans) processExplainPlan(ctx context.Context, qi *queryInfo) bo
 			nil,
 		)
 		if err != nil {
-			level.Error(c.logger).Log("msg", "failed to send reserved keyword check error explain plan output", "err", err)
+			c.logger.Error("failed to send reserved keyword check error explain plan output", "err", err)
 		}
 		return false
 	}
@@ -645,16 +644,16 @@ func (c *ExplainPlans) processExplainPlan(ctx context.Context, qi *queryInfo) bo
 			nil,
 		)
 		if err != nil {
-			level.Error(c.logger).Log("msg", "failed to send reserved keyword check error explain plan output", "err", err)
+			c.logger.Error("failed to send reserved keyword check error explain plan output", "err", err)
 		}
 		return false
 	}
 
-	logger = log.With(logger, "schema_name", qi.schemaName)
+	logger = logger.With("schema_name", qi.schemaName)
 
 	byteExplainPlanJSON, err := c.fetchExplainPlanJSON(ctx, *qi)
 	if err != nil {
-		level.Debug(logger).Log("msg", "failed to fetch explain plan json bytes", "err", err)
+		logger.Debug("failed to fetch explain plan json bytes", "err", err)
 		for _, code := range unrecoverableSQLCodes {
 			if strings.Contains(err.Error(), fmt.Sprintf("Error %s", code)) {
 				return true
@@ -664,18 +663,18 @@ func (c *ExplainPlans) processExplainPlan(ctx context.Context, qi *queryInfo) bo
 	}
 
 	if len(byteExplainPlanJSON) == 0 {
-		level.Error(logger).Log("msg", "explain plan json bytes is empty")
+		logger.Error("explain plan json bytes is empty")
 		return true
 	}
 
 	if !utf8.Valid(byteExplainPlanJSON) {
-		level.Error(logger).Log("msg", "explain plan json bytes is not valid UTF-8")
+		logger.Error("explain plan json bytes is not valid UTF-8")
 		return true
 	}
 
 	redactedByteExplainPlanJSON, _, err := redactAttachedConditions(byteExplainPlanJSON)
 	if err != nil {
-		level.Error(logger).Log("msg", "failed to redact explain plan json", "err", err)
+		logger.Error("failed to redact explain plan json", "err", err)
 		return true
 	}
 
@@ -683,28 +682,28 @@ func (c *ExplainPlans) processExplainPlan(ctx context.Context, qi *queryInfo) bo
 	if err != nil {
 		// An explain plan response typically will not have a message field if it is successful.
 		if msgDatType != jsonparser.NotExist {
-			level.Error(logger).Log("msg", "failed to parse explain plan json", "err", err)
+			logger.Error("failed to parse explain plan json", "err", err)
 		}
 	} else {
 		if strings.Contains(string(msgBlock), "no matching row in const table") {
-			level.Debug(logger).Log("msg", "explain plan query resulted in no rows, skipping", "message", string(msgBlock))
+			logger.Debug("explain plan query resulted in no rows, skipping", "message", string(msgBlock))
 			return false
 		}
 	}
 
-	level.Debug(logger).Log("msg", "db native explain plan",
+	logger.Debug("db native explain plan",
 		"db_native_explain_plan", base64.StdEncoding.EncodeToString(redactedByteExplainPlanJSON))
 
 	explainPlanOutput, genErr := newExplainPlansOutput(logger, byteExplainPlanJSON)
 	explainPlanOutputJSON, err := json.Marshal(explainPlanOutput)
 	if err != nil {
-		level.Error(logger).Log("msg", "failed to marshal explain plan output", "err", err)
+		logger.Error("failed to marshal explain plan output", "err", err)
 		return true
 	}
 
 	if genErr != nil {
-		level.Error(logger).Log(
-			"msg", "failed to create explain plan output",
+		logger.Error(
+			"failed to create explain plan output",
 			"incomplete_explain_plan", base64.StdEncoding.EncodeToString(explainPlanOutputJSON),
 			"err", genErr,
 		)
@@ -719,7 +718,7 @@ func (c *ExplainPlans) processExplainPlan(ctx context.Context, qi *queryInfo) bo
 		"",
 		explainPlanOutput,
 	); err != nil {
-		level.Error(c.logger).Log("msg", "failed to send explain plan output", "err", err)
+		c.logger.Error("failed to send explain plan output", "err", err)
 	}
 
 	return false

--- a/internal/component/database_observability/mysql/collector/explain_plans_test.go
+++ b/internal/component/database_observability/mysql/collector/explain_plans_test.go
@@ -2,17 +2,17 @@ package collector
 
 import (
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/tools/txtar"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/component/database_observability"
+	"github.com/grafana/alloy/internal/runtime/logging"
+	"github.com/grafana/alloy/internal/util"
 	"github.com/grafana/alloy/internal/util/syncbuffer"
 )
 
@@ -300,21 +300,21 @@ func TestExplainPlansRedactor(t *testing.T) {
 func TestExplainPlansOutput(t *testing.T) {
 	t.Run("invalid json", func(t *testing.T) {
 		notJsonData := []byte("not json data")
-		logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
+		logger := util.TestAlloyLogger(t).Slog()
 		_, err := newExplainPlansOutput(logger, notJsonData)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "failed to get query block: Key path not found")
 	})
 
 	t.Run("unknown operation", func(t *testing.T) {
-		logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
+		logger := util.TestAlloyLogger(t).Slog()
 		explainPlanOutput, err := newExplainPlansOutput(logger, []byte("{\"query_block\": {\"operation\": \"some unknown thing we've never seen before.\"}}"))
 		require.NoError(t, err)
 		require.Equal(t, database_observability.ExplainPlanOutputOperationUnknown, explainPlanOutput.Operation)
 	})
 
 	t.Run("zero rows", func(t *testing.T) {
-		logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
+		logger := util.TestAlloyLogger(t).Slog()
 		_, err := newExplainPlansOutput(logger, []byte("{\"query_block\": {\"message\": \"no matching row in const table\"}}"))
 		require.NoError(t, err)
 	})
@@ -1495,7 +1495,7 @@ func TestExplainPlansOutput(t *testing.T) {
 			jsonFile := archive.Files[0]
 			require.Equal(t, fmt.Sprintf("%s.json", test.fname), jsonFile.Name)
 			jsonData := jsonFile.Data
-			logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
+			logger := util.TestAlloyLogger(t).Slog()
 			output, err := newExplainPlansOutput(logger, jsonData)
 			require.NoError(t, err, "Failed generate explain plan output: %s", test.fname)
 			require.Equal(t, test.result.Plan, *output)
@@ -1515,7 +1515,7 @@ func TestExplainPlans(t *testing.T) {
 
 		c, err := NewExplainPlans(ExplainPlansArguments{
 			DB:              db,
-			Logger:          log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout)),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 			ScrapeInterval:  time.Second,
 			PerScrapeRatio:  1,
 			EntryHandler:    lokiClient,
@@ -1580,10 +1580,15 @@ func TestExplainPlans(t *testing.T) {
 		defer lokiClient.Stop()
 
 		logBuffer := syncbuffer.Buffer{}
+		logger, err := logging.New(&logBuffer, logging.Options{
+			Level:  logging.LevelDebug,
+			Format: logging.FormatLogfmt,
+		})
+		require.NoError(t, err)
 
 		c, err := NewExplainPlans(ExplainPlansArguments{
 			DB:              db,
-			Logger:          log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+			Logger:          logger.Slog(),
 			ScrapeInterval:  time.Second,
 			PerScrapeRatio:  1,
 			EntryHandler:    lokiClient,
@@ -1816,12 +1821,17 @@ func TestQueryFailureDenylist(t *testing.T) {
 	defer lokiClient.Stop()
 
 	logBuffer := syncbuffer.Buffer{}
+	logger, err := logging.New(&logBuffer, logging.Options{
+		Level:  logging.LevelDebug,
+		Format: logging.FormatLogfmt,
+	})
+	require.NoError(t, err)
 
 	queryUnderTestHash := "some_schemasome_digest1"
 
 	c, err := NewExplainPlans(ExplainPlansArguments{
 		DB:              db,
-		Logger:          log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+		Logger:          logger.Slog(),
 		ScrapeInterval:  time.Second,
 		PerScrapeRatio:  1,
 		EntryHandler:    lokiClient,
@@ -1907,7 +1917,7 @@ func TestBatchSizeLimitsProcessing(t *testing.T) {
 
 	c, err := NewExplainPlans(ExplainPlansArguments{
 		DB:             db,
-		Logger:         log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout)),
+		Logger:         util.TestAlloyLogger(t).Slog(),
 		ScrapeInterval: time.Second,
 		PerScrapeRatio: 1,
 		EntryHandler:   lokiClient,
@@ -1948,10 +1958,15 @@ func TestSchemaDenylist(t *testing.T) {
 	defer lokiClient.Stop()
 
 	logBuffer := syncbuffer.Buffer{}
+	logger, err := logging.New(&logBuffer, logging.Options{
+		Level:  logging.LevelDebug,
+		Format: logging.FormatLogfmt,
+	})
+	require.NoError(t, err)
 
 	c, err := NewExplainPlans(ExplainPlansArguments{
 		DB:              db,
-		Logger:          log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+		Logger:          logger.Slog(),
 		ScrapeInterval:  time.Second,
 		PerScrapeRatio:  1,
 		ExcludeSchemas:  []string{"some_schema"},

--- a/internal/component/database_observability/mysql/collector/health_check.go
+++ b/internal/component/database_observability/mysql/collector/health_check.go
@@ -4,18 +4,17 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/go-kit/log"
 	"go.uber.org/atomic"
 
 	"github.com/grafana/alloy/internal/build"
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/component/database_observability"
 	"github.com/grafana/alloy/internal/runtime/logging"
-	"github.com/grafana/alloy/internal/runtime/logging/level"
 )
 
 const (
@@ -38,7 +37,7 @@ type HealthCheckArguments struct {
 	ExcludeSchemas  []string
 	EntryHandler    loki.EntryHandler
 
-	Logger log.Logger
+	Logger *slog.Logger
 }
 
 type HealthCheck struct {
@@ -46,7 +45,7 @@ type HealthCheck struct {
 	collectInterval time.Duration
 	excludeSchemas  []string
 	entryHandler    loki.EntryHandler
-	logger          log.Logger
+	logger          *slog.Logger
 
 	running *atomic.Bool
 	ctx     context.Context
@@ -60,7 +59,7 @@ func NewHealthCheck(args HealthCheckArguments) (*HealthCheck, error) {
 		collectInterval: args.CollectInterval,
 		excludeSchemas:  args.ExcludeSchemas,
 		entryHandler:    args.EntryHandler,
-		logger:          log.With(args.Logger, "collector", HealthCheckCollector),
+		logger:          args.Logger.With("collector", HealthCheckCollector),
 		running:         &atomic.Bool{},
 	}
 	return h, nil
@@ -71,7 +70,7 @@ func (c *HealthCheck) Name() string {
 }
 
 func (c *HealthCheck) Start(ctx context.Context) error {
-	level.Debug(c.logger).Log("msg", "collector started")
+	c.logger.Debug("collector started")
 
 	c.running.Store(true)
 	ctx, cancel := context.WithCancel(ctx)
@@ -126,7 +125,7 @@ func (c *HealthCheck) fetchHealthChecks(ctx context.Context) {
 	for _, checkFn := range checks {
 		result := checkFn(ctx, c.dbConnection)
 		if result.err != nil {
-			level.Error(c.logger).Log("msg", "health check failed", "check", result.name, "err", result.err)
+			c.logger.Error("health check failed", "check", result.name, "err", result.err)
 			continue
 		}
 		msg := fmt.Sprintf(`check="%s" result="%v" value="%s"`, result.name, result.result, result.value)

--- a/internal/component/database_observability/mysql/collector/health_check_test.go
+++ b/internal/component/database_observability/mysql/collector/health_check_test.go
@@ -1,18 +1,17 @@
 package collector
 
 import (
-	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/util"
 )
 
 func TestHealthCheck(t *testing.T) {
@@ -35,7 +34,7 @@ func TestHealthCheck(t *testing.T) {
 			CollectInterval: 100 * time.Millisecond,
 			ExcludeSchemas:  nil,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -87,7 +86,7 @@ func TestHealthCheck(t *testing.T) {
 			CollectInterval: 100 * time.Millisecond,
 			ExcludeSchemas:  []string{"custom_schema", "another_schema"},
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -212,7 +211,7 @@ func TestHealthCheck(t *testing.T) {
 					CollectInterval: 100 * time.Millisecond,
 					ExcludeSchemas:  nil,
 					EntryHandler:    lokiClient,
-					Logger:          log.NewLogfmtLogger(os.Stderr),
+					Logger:          util.TestAlloyLogger(t).Slog(),
 				})
 				require.NoError(t, err)
 

--- a/internal/component/database_observability/mysql/collector/locks.go
+++ b/internal/component/database_observability/mysql/collector/locks.go
@@ -5,16 +5,15 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 
-	"github.com/go-kit/log"
 	"go.uber.org/atomic"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/component/database_observability"
 	"github.com/grafana/alloy/internal/runtime/logging"
-	"github.com/grafana/alloy/internal/runtime/logging/level"
 )
 
 const (
@@ -51,13 +50,13 @@ type LocksArguments struct {
 	LockWaitThreshold time.Duration
 	EntryHandler      loki.EntryHandler
 
-	Logger log.Logger
+	Logger *slog.Logger
 }
 
 type Locks struct {
 	mySQLClient     *sql.DB
 	collectInterval time.Duration
-	logger          log.Logger
+	logger          *slog.Logger
 	entryHandler    loki.EntryHandler
 
 	// The minimum amount of time elapsed waiting due to a lock
@@ -87,13 +86,13 @@ func NewLocks(args LocksArguments) (*Locks, error) {
 		collectInterval:   args.CollectInterval,
 		lockTimeThreshold: args.LockWaitThreshold,
 		entryHandler:      args.EntryHandler,
-		logger:            log.With(args.Logger, "collector", LocksCollector),
+		logger:            args.Logger.With("collector", LocksCollector),
 		running:           &atomic.Bool{},
 	}, nil
 }
 
 func (c *Locks) Start(ctx context.Context) error {
-	level.Debug(c.logger).Log("msg", "collector started")
+	c.logger.Debug("collector started")
 
 	c.running.Store(true)
 	ctx, cancel := context.WithCancel(ctx)
@@ -108,7 +107,7 @@ func (c *Locks) Start(ctx context.Context) error {
 
 		for {
 			if err := c.fetchLocks(c.ctx); err != nil {
-				level.Error(c.logger).Log("msg", "collector error", "err", err)
+				c.logger.Error("collector error", "err", err)
 			}
 
 			select {
@@ -148,7 +147,7 @@ func (c *Locks) fetchLocks(ctx context.Context) error {
 		err := rsdl.Scan(&waitingTimerWait, &waitingLockTime, &waitingDigest, &waitingDigestText,
 			&blockingTimerWait, &blockingLockTime, &blockingDigest, &blockingDigestText)
 		if err != nil {
-			level.Error(c.logger).Log("msg", "failed to scan data locks", "err", err)
+			c.logger.Error("failed to scan data locks", "err", err)
 			continue
 		}
 

--- a/internal/component/database_observability/mysql/collector/locks_test.go
+++ b/internal/component/database_observability/mysql/collector/locks_test.go
@@ -2,18 +2,17 @@ package collector
 
 import (
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/util"
 )
 
 func TestLocks(t *testing.T) {
@@ -29,7 +28,7 @@ func TestLocks(t *testing.T) {
 			DB:              db,
 			CollectInterval: 10 * time.Second,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -76,7 +75,7 @@ func TestLocks(t *testing.T) {
 			DB:              db,
 			CollectInterval: time.Second,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -134,7 +133,7 @@ func TestLocks(t *testing.T) {
 			DB:              db,
 			CollectInterval: time.Second,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -204,7 +203,7 @@ func TestLocks(t *testing.T) {
 			DB:              db,
 			CollectInterval: time.Second,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -262,7 +261,7 @@ func TestLocks(t *testing.T) {
 			DB:              db,
 			CollectInterval: 1 * time.Second,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -323,7 +322,7 @@ func TestLocks(t *testing.T) {
 			DB:              db,
 			CollectInterval: time.Second,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -390,7 +389,7 @@ func TestLocks(t *testing.T) {
 			DB:              db,
 			CollectInterval: 10 * time.Second,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)

--- a/internal/component/database_observability/mysql/collector/query_details.go
+++ b/internal/component/database_observability/mysql/collector/query_details.go
@@ -4,18 +4,17 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 
 	"github.com/DataDog/go-sqllexer"
-	"github.com/go-kit/log"
 	"go.uber.org/atomic"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/component/database_observability"
 	"github.com/grafana/alloy/internal/component/database_observability/mysql/collector/parser"
 	"github.com/grafana/alloy/internal/runtime/logging"
-	"github.com/grafana/alloy/internal/runtime/logging/level"
 )
 
 const (
@@ -43,7 +42,7 @@ type QueryDetailsArguments struct {
 	ExcludeSchemas  []string
 	EntryHandler    loki.EntryHandler
 
-	Logger log.Logger
+	Logger *slog.Logger
 }
 
 type QueryDetails struct {
@@ -55,7 +54,7 @@ type QueryDetails struct {
 	sqlParser       parser.Parser
 	normalizer      *sqllexer.Normalizer
 
-	logger  log.Logger
+	logger  *slog.Logger
 	running *atomic.Bool
 	ctx     context.Context
 	cancel  context.CancelFunc
@@ -71,7 +70,7 @@ func NewQueryDetails(args QueryDetailsArguments) (*QueryDetails, error) {
 		entryHandler:    args.EntryHandler,
 		sqlParser:       parser.NewTiDBSqlParser(),
 		normalizer:      sqllexer.NewNormalizer(sqllexer.WithCollectTables(true)),
-		logger:          log.With(args.Logger, "collector", QueryDetailsCollector),
+		logger:          args.Logger.With("collector", QueryDetailsCollector),
 		running:         &atomic.Bool{},
 	}
 
@@ -83,7 +82,7 @@ func (c *QueryDetails) Name() string {
 }
 
 func (c *QueryDetails) Start(ctx context.Context) error {
-	level.Debug(c.logger).Log("msg", "collector started")
+	c.logger.Debug("collector started")
 
 	c.running.Store(true)
 	ctx, cancel := context.WithCancel(ctx)
@@ -98,7 +97,7 @@ func (c *QueryDetails) Start(ctx context.Context) error {
 
 		for {
 			if err := c.tablesFromEventsStatements(c.ctx); err != nil {
-				level.Error(c.logger).Log("msg", "collector error", "err", err)
+				c.logger.Error("collector error", "err", err)
 			}
 
 			select {
@@ -136,7 +135,7 @@ func (c *QueryDetails) tablesFromEventsStatements(ctx context.Context) error {
 		var digest, digestText, schema string
 		var sampleText sql.NullString
 		if err := rs.Scan(&digest, &digestText, &schema, &sampleText); err != nil {
-			level.Error(c.logger).Log("msg", "failed to scan result set from summary table samples", "schema", schema, "err", err)
+			c.logger.Error("failed to scan result set from summary table samples", "schema", schema, "err", err)
 			continue
 		}
 
@@ -144,7 +143,7 @@ func (c *QueryDetails) tablesFromEventsStatements(ctx context.Context) error {
 		var parserErr, lexerErr error
 		if tables, parserErr = c.tryParseTableNames(sampleText.String, digestText); parserErr != nil {
 			if tables, lexerErr = c.tryTokenizeTableNames(sampleText.String, digestText); lexerErr != nil {
-				level.Warn(c.logger).Log("msg", "failed to extract tables from sql text", "schema", schema, "digest", digest, "parser_err", parserErr, "lexer_err", lexerErr)
+				c.logger.Warn("failed to extract tables from sql text", "schema", schema, "digest", digest, "parser_err", parserErr, "lexer_err", lexerErr)
 				continue
 			}
 		}

--- a/internal/component/database_observability/mysql/collector/query_details_test.go
+++ b/internal/component/database_observability/mysql/collector/query_details_test.go
@@ -3,17 +3,16 @@ package collector
 import (
 	"database/sql/driver"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/util"
 )
 
 func TestQueryTables(t *testing.T) {
@@ -390,7 +389,7 @@ func TestQueryTables(t *testing.T) {
 				CollectInterval: time.Second,
 				StatementsLimit: 250,
 				EntryHandler:    lokiClient,
-				Logger:          log.NewLogfmtLogger(os.Stderr),
+				Logger:          util.TestAlloyLogger(t).Slog(),
 			})
 			require.NoError(t, err)
 			require.NotNil(t, collector)
@@ -451,7 +450,7 @@ func TestQueryTablesSQLDriverErrors(t *testing.T) {
 			CollectInterval: time.Second,
 			StatementsLimit: 250,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -517,7 +516,7 @@ func TestQueryTablesSQLDriverErrors(t *testing.T) {
 			CollectInterval: time.Second,
 			StatementsLimit: 250,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -580,7 +579,7 @@ func TestQueryTablesSQLDriverErrors(t *testing.T) {
 			CollectInterval: time.Second,
 			StatementsLimit: 250,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -643,7 +642,7 @@ func TestQueryDetailsExcludeSchemas(t *testing.T) {
 		StatementsLimit: 250,
 		ExcludeSchemas:  []string{"excluded_schema"},
 		EntryHandler:    lokiClient,
-		Logger:          log.NewLogfmtLogger(os.Stderr),
+		Logger:          util.TestAlloyLogger(t).Slog(),
 	})
 	require.NoError(t, err)
 

--- a/internal/component/database_observability/mysql/collector/query_samples.go
+++ b/internal/component/database_observability/mysql/collector/query_samples.go
@@ -4,19 +4,18 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/blang/semver/v4"
-	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/atomic"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/component/database_observability"
 	"github.com/grafana/alloy/internal/runtime/logging"
-	"github.com/grafana/alloy/internal/runtime/logging/level"
 )
 
 const (
@@ -111,7 +110,7 @@ type QuerySamplesArguments struct {
 	WaitEventMinDuration          time.Duration
 	EnablePreClassifiedWaitEvents bool
 
-	Logger log.Logger
+	Logger *slog.Logger
 }
 
 type QuerySamples struct {
@@ -129,7 +128,7 @@ type QuerySamples struct {
 	waitEventCounter              *prometheus.CounterVec
 	enablePreClassifiedWaitEvents bool
 
-	logger  log.Logger
+	logger  *slog.Logger
 	running *atomic.Bool
 	ctx     context.Context
 	cancel  context.CancelFunc
@@ -152,7 +151,7 @@ func NewQuerySamples(args QuerySamplesArguments) (*QuerySamples, error) {
 		sampleMinDuration:             args.SampleMinDuration,
 		waitEventMinDuration:          args.WaitEventMinDuration,
 		enablePreClassifiedWaitEvents: args.EnablePreClassifiedWaitEvents,
-		logger:                        log.With(args.Logger, "collector", QuerySamplesCollector),
+		logger:                        args.Logger.With("collector", QuerySamplesCollector),
 		running:                       &atomic.Bool{},
 	}
 
@@ -175,9 +174,9 @@ func (c *QuerySamples) Name() string {
 
 func (c *QuerySamples) Start(ctx context.Context) error {
 	if c.disableQueryRedaction {
-		level.Warn(c.logger).Log("msg", "collector started with query redaction disabled. SQL text in query samples may include query parameters.")
+		c.logger.Warn("collector started with query redaction disabled. SQL text in query samples may include query parameters.")
 	} else {
-		level.Debug(c.logger).Log("msg", "collector started")
+		c.logger.Debug("collector started")
 	}
 
 	c.running.Store(true)
@@ -202,7 +201,7 @@ func (c *QuerySamples) Start(ctx context.Context) error {
 
 		for {
 			if err := c.fetchQuerySamples(c.ctx); err != nil {
-				level.Error(c.logger).Log("msg", "collector error", "err", err)
+				c.logger.Error("collector error", "err", err)
 			}
 
 			select {
@@ -237,7 +236,7 @@ func (c *QuerySamples) runSetupConsumersCheck() {
 
 	for {
 		if err := c.updateSetupConsumersSettings(c.ctx); err != nil {
-			level.Error(c.logger).Log("msg", "error with performance_schema.setup_consumers check", "err", err)
+			c.logger.Error("error with performance_schema.setup_consumers check", "err", err)
 		}
 
 		select {
@@ -399,12 +398,12 @@ func (c *QuerySamples) fetchQuerySamples(ctx context.Context) error {
 
 		err := rs.Scan(scanArgs...)
 		if err != nil {
-			level.Error(c.logger).Log("msg", "failed to scan history table samples", "err", err)
+			c.logger.Error("failed to scan history table samples", "err", err)
 			continue
 		}
 
 		if !row.TimerEndPicoseconds.Valid {
-			level.Debug(c.logger).Log("msg", "skipping query with invalid timer end timestamp", "schema", row.Schema.String, "digest", row.Digest.String, "timer_end", row.TimerEndPicoseconds.Float64)
+			c.logger.Debug("skipping query with invalid timer end timestamp", "schema", row.Schema.String, "digest", row.Digest.String, "timer_end", row.TimerEndPicoseconds.Float64)
 			continue
 		}
 
@@ -543,7 +542,7 @@ func (c *QuerySamples) updateSetupConsumersSettings(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to get rows affected from performance_schema.setup_consumers: %w", err)
 	}
-	level.Debug(c.logger).Log("msg", "updated performance_schema.setup_consumers", "rows_affected", rowsAffected)
+	c.logger.Debug("updated performance_schema.setup_consumers", "rows_affected", rowsAffected)
 
 	return nil
 }

--- a/internal/component/database_observability/mysql/collector/query_samples_test.go
+++ b/internal/component/database_observability/mysql/collector/query_samples_test.go
@@ -2837,7 +2837,7 @@ func TestQuerySamples_initializeTimer(t *testing.T) {
 			5,
 		))
 
-		c, err := NewQuerySamples(QuerySamplesArguments{DB: db})
+		c, err := NewQuerySamples(QuerySamplesArguments{DB: db, Logger: util.TestAlloyLogger(t).Slog()})
 		require.NoError(t, err)
 
 		require.NoError(t, c.initializeBookmark(t.Context()))
@@ -2856,7 +2856,7 @@ func TestQuerySamples_initializeTimer(t *testing.T) {
 			picosecondsToSeconds(math.MaxUint64) + 5,
 		))
 
-		c, err := NewQuerySamples(QuerySamplesArguments{DB: db})
+		c, err := NewQuerySamples(QuerySamplesArguments{DB: db, Logger: util.TestAlloyLogger(t).Slog()})
 		require.NoError(t, err)
 
 		require.NoError(t, c.initializeBookmark(t.Context()))
@@ -3524,7 +3524,7 @@ func TestQuerySamples_handles_timer_overflows(t *testing.T) {
 
 		mock.ExpectQuery(selectNowAndUptime).WithoutArgs().WillReturnError(fmt.Errorf("some error"))
 
-		c, err := NewQuerySamples(QuerySamplesArguments{DB: db})
+		c, err := NewQuerySamples(QuerySamplesArguments{DB: db, Logger: util.TestAlloyLogger(t).Slog()})
 		require.NoError(t, err)
 
 		err = c.fetchQuerySamples(t.Context())

--- a/internal/component/database_observability/mysql/collector/query_samples_test.go
+++ b/internal/component/database_observability/mysql/collector/query_samples_test.go
@@ -4,14 +4,12 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"math"
-	"os"
 	"regexp"
 	"testing"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/blang/semver/v4"
-	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/model"
@@ -21,6 +19,8 @@ import (
 
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/component/database_observability/mysql/collector/parser"
+	"github.com/grafana/alloy/internal/runtime/logging"
+	"github.com/grafana/alloy/internal/util"
 	"github.com/grafana/alloy/internal/util/syncbuffer"
 )
 
@@ -279,6 +279,12 @@ func TestQuerySamples(t *testing.T) {
 			defer db.Close()
 
 			logBuffer := syncbuffer.Buffer{}
+			logger, err := logging.New(&logBuffer, logging.Options{
+				Level:  logging.LevelDebug,
+				Format: logging.FormatLogfmt,
+			})
+			require.NoError(t, err)
+
 			lokiClient := loki.NewCollectingHandler()
 
 			collector, err := NewQuerySamples(QuerySamplesArguments{
@@ -286,7 +292,7 @@ func TestQuerySamples(t *testing.T) {
 				EngineVersion:   latestCompatibleVersion,
 				CollectInterval: time.Second,
 				EntryHandler:    lokiClient,
-				Logger:          log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+				Logger:          logger.Slog(),
 			})
 			require.NoError(t, err)
 			require.NotNil(t, collector)
@@ -395,7 +401,7 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 			EngineVersion:   latestCompatibleVersion,
 			CollectInterval: time.Second,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -508,7 +514,7 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 			EngineVersion:   latestCompatibleVersion,
 			CollectInterval: time.Second,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -621,7 +627,7 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 			EngineVersion:   latestCompatibleVersion,
 			CollectInterval: time.Second,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -833,7 +839,7 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 			EngineVersion:   latestCompatibleVersion,
 			CollectInterval: time.Second,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -979,7 +985,7 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 			EngineVersion:         latestCompatibleVersion,
 			CollectInterval:       time.Second,
 			EntryHandler:          lokiClient,
-			Logger:                log.NewLogfmtLogger(os.Stderr),
+			Logger:                util.TestAlloyLogger(t).Slog(),
 			DisableQueryRedaction: true,
 		})
 		require.NoError(t, err)
@@ -1107,7 +1113,7 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 			EngineVersion:        latestCompatibleVersion,
 			CollectInterval:      time.Second,
 			EntryHandler:         lokiClient,
-			Logger:               log.NewLogfmtLogger(os.Stderr),
+			Logger:               util.TestAlloyLogger(t).Slog(),
 			WaitEventMinDuration: 1 * time.Millisecond,
 		})
 		require.NoError(t, err)
@@ -1219,7 +1225,7 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 			EngineVersion:        latestCompatibleVersion,
 			CollectInterval:      time.Second,
 			EntryHandler:         lokiClient,
-			Logger:               log.NewLogfmtLogger(os.Stderr),
+			Logger:               util.TestAlloyLogger(t).Slog(),
 			WaitEventMinDuration: 1 * time.Millisecond,
 		})
 		require.NoError(t, err)
@@ -1334,7 +1340,7 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 			EngineVersion:   latestCompatibleVersion,
 			CollectInterval: time.Second,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -1444,7 +1450,7 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 			EngineVersion:                 latestCompatibleVersion,
 			CollectInterval:               time.Second,
 			EntryHandler:                  lokiClient,
-			Logger:                        log.NewLogfmtLogger(os.Stderr),
+			Logger:                        util.TestAlloyLogger(t).Slog(),
 			EnablePreClassifiedWaitEvents: true,
 		})
 		require.NoError(t, err)
@@ -1562,7 +1568,7 @@ func TestQuerySamples_WaitEvents(t *testing.T) {
 			EngineVersion:        latestCompatibleVersion,
 			CollectInterval:      time.Second,
 			EntryHandler:         lokiClient,
-			Logger:               log.NewLogfmtLogger(os.Stderr),
+			Logger:               util.TestAlloyLogger(t).Slog(),
 			WaitEventMinDuration: 1 * time.Millisecond,
 		})
 		require.NoError(t, err)
@@ -1675,7 +1681,7 @@ func TestQuerySamples_SampleMinDuration(t *testing.T) {
 			EngineVersion:     latestCompatibleVersion,
 			CollectInterval:   time.Second,
 			EntryHandler:      lokiClient,
-			Logger:            log.NewLogfmtLogger(os.Stderr),
+			Logger:            util.TestAlloyLogger(t).Slog(),
 			SampleMinDuration: 1 * time.Millisecond,
 		})
 		require.NoError(t, err)
@@ -1752,7 +1758,7 @@ func TestQuerySamples_SampleMinDuration(t *testing.T) {
 			EngineVersion:     latestCompatibleVersion,
 			CollectInterval:   time.Second,
 			EntryHandler:      lokiClient,
-			Logger:            log.NewLogfmtLogger(os.Stderr),
+			Logger:            util.TestAlloyLogger(t).Slog(),
 			SampleMinDuration: 1 * time.Millisecond,
 		})
 		require.NoError(t, err)
@@ -1867,7 +1873,7 @@ func TestQuerySamples_DisableQueryRedaction(t *testing.T) {
 			EngineVersion:         latestCompatibleVersion,
 			CollectInterval:       time.Second,
 			EntryHandler:          lokiClient,
-			Logger:                log.NewLogfmtLogger(os.Stderr),
+			Logger:                util.TestAlloyLogger(t).Slog(),
 			DisableQueryRedaction: true,
 		})
 		require.NoError(t, err)
@@ -1991,7 +1997,7 @@ func TestQuerySamples_DisableQueryRedaction(t *testing.T) {
 			EngineVersion:         latestCompatibleVersion,
 			CollectInterval:       time.Second,
 			EntryHandler:          lokiClient,
-			Logger:                log.NewLogfmtLogger(os.Stderr),
+			Logger:                util.TestAlloyLogger(t).Slog(),
 			DisableQueryRedaction: false,
 		})
 		require.NoError(t, err)
@@ -2324,7 +2330,7 @@ func TestQuerySamplesMySQLVersions(t *testing.T) {
 				EngineVersion:   semver.MustParse(tc.mysqlVersion),
 				CollectInterval: time.Second,
 				EntryHandler:    lokiClient,
-				Logger:          log.NewLogfmtLogger(os.Stderr),
+				Logger:          util.TestAlloyLogger(t).Slog(),
 			})
 			require.NoError(t, err)
 			require.NotNil(t, collector)
@@ -2393,7 +2399,7 @@ func TestQuerySamples_SQLDriverErrors(t *testing.T) {
 			EngineVersion:   latestCompatibleVersion,
 			CollectInterval: time.Second,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -2539,7 +2545,7 @@ func TestQuerySamples_SQLDriverErrors(t *testing.T) {
 			EngineVersion:   latestCompatibleVersion,
 			CollectInterval: time.Second,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -2692,7 +2698,7 @@ func TestQuerySamples_SQLDriverErrors(t *testing.T) {
 			EngineVersion:   latestCompatibleVersion,
 			CollectInterval: time.Second,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -2946,7 +2952,7 @@ func TestQuerySamples_logs_query_start_as_timestamp(t *testing.T) {
 			dbConnection:  db,
 			engineVersion: latestCompatibleVersion,
 			entryHandler:  lokiClient,
-			logger:        log.NewLogfmtLogger(os.Stderr),
+			logger:        util.TestAlloyLogger(t).Slog(),
 		}
 
 		require.NoError(t, c.fetchQuerySamples(t.Context()))
@@ -3051,7 +3057,7 @@ func TestQuerySamples_logs_query_start_as_timestamp(t *testing.T) {
 			dbConnection:                  db,
 			engineVersion:                 latestCompatibleVersion,
 			entryHandler:                  lokiClient,
-			logger:                        log.NewLogfmtLogger(os.Stderr),
+			logger:                        util.TestAlloyLogger(t).Slog(),
 			enablePreClassifiedWaitEvents: true,
 		}
 
@@ -3155,7 +3161,7 @@ func TestQuerySamples_handles_timer_overflows(t *testing.T) {
 			timerBookmark: 1e12,
 			lastUptime:    4,
 			entryHandler:  lokiClient,
-			logger:        log.NewLogfmtLogger(os.Stderr),
+			logger:        util.TestAlloyLogger(t).Slog(),
 		}
 
 		require.NoError(t, c.fetchQuerySamples(t.Context()))
@@ -3233,7 +3239,7 @@ func TestQuerySamples_handles_timer_overflows(t *testing.T) {
 			engineVersion: latestCompatibleVersion,
 			timerBookmark: 1e12,
 			lastUptime:    4,
-			logger:        log.NewLogfmtLogger(os.Stderr),
+			logger:        util.TestAlloyLogger(t).Slog(),
 		}
 
 		require.NoError(t, c.fetchQuerySamples(t.Context()))
@@ -3615,7 +3621,7 @@ func TestQuerySamples_handles_timer_overflows(t *testing.T) {
 			dbConnection:  db,
 			engineVersion: latestCompatibleVersion,
 			timerBookmark: 2e12,
-			logger:        log.NewLogfmtLogger(os.Stderr),
+			logger:        util.TestAlloyLogger(t).Slog(),
 		}
 
 		mockParser.On("CleanTruncatedText", "SELECT * FROM users").Return("SELECT * FROM users", nil)
@@ -3785,7 +3791,7 @@ func TestQuerySamples_AutoEnableSetupConsumers(t *testing.T) {
 			EngineVersion:               latestCompatibleVersion,
 			CollectInterval:             time.Second,
 			EntryHandler:                lokiClient,
-			Logger:                      log.NewLogfmtLogger(os.Stderr),
+			Logger:                      util.TestAlloyLogger(t).Slog(),
 			AutoEnableSetupConsumers:    true,
 			SetupConsumersCheckInterval: time.Second,
 		})
@@ -3912,7 +3918,7 @@ func TestQuerySamples_AutoEnableSetupConsumers(t *testing.T) {
 			EngineVersion:               latestCompatibleVersion,
 			CollectInterval:             time.Second,
 			EntryHandler:                lokiClient,
-			Logger:                      log.NewLogfmtLogger(os.Stderr),
+			Logger:                      util.TestAlloyLogger(t).Slog(),
 			AutoEnableSetupConsumers:    true,
 			SetupConsumersCheckInterval: time.Second,
 		})
@@ -3965,7 +3971,7 @@ func TestQuerySamplesExcludeSchemas(t *testing.T) {
 		CollectInterval: time.Millisecond,
 		ExcludeSchemas:  []string{"excluded_schema"},
 		EntryHandler:    lokiClient,
-		Logger:          log.NewLogfmtLogger(os.Stderr),
+		Logger:          util.TestAlloyLogger(t).Slog(),
 	})
 	require.NoError(t, err)
 
@@ -4008,7 +4014,7 @@ func TestQuerySamples_WaitEventCounter_MatchesLogLines(t *testing.T) {
 			CollectInterval:               time.Second,
 			EntryHandler:                  lokiClient,
 			Registry:                      registry,
-			Logger:                        log.NewLogfmtLogger(os.Stderr),
+			Logger:                        util.TestAlloyLogger(t).Slog(),
 			EnablePreClassifiedWaitEvents: true,
 		})
 		require.NoError(t, err)
@@ -4119,7 +4125,7 @@ func TestQuerySamples_WaitEvents_PreClassified(t *testing.T) {
 			EngineVersion:                 latestCompatibleVersion,
 			CollectInterval:               time.Second,
 			EntryHandler:                  lokiClient,
-			Logger:                        log.NewLogfmtLogger(os.Stderr),
+			Logger:                        util.TestAlloyLogger(t).Slog(),
 			EnablePreClassifiedWaitEvents: false,
 		})
 		require.NoError(t, err)
@@ -4186,7 +4192,7 @@ func TestQuerySamples_WaitEvents_PreClassified(t *testing.T) {
 			EngineVersion:                 latestCompatibleVersion,
 			CollectInterval:               time.Second,
 			EntryHandler:                  lokiClient,
-			Logger:                        log.NewLogfmtLogger(os.Stderr),
+			Logger:                        util.TestAlloyLogger(t).Slog(),
 			EnablePreClassifiedWaitEvents: true,
 		})
 		require.NoError(t, err)

--- a/internal/component/database_observability/mysql/collector/schema_details.go
+++ b/internal/component/database_observability/mysql/collector/schema_details.go
@@ -6,17 +6,16 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/go-kit/log"
 	"go.uber.org/atomic"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/component/database_observability"
 	"github.com/grafana/alloy/internal/runtime/logging"
-	"github.com/grafana/alloy/internal/runtime/logging/level"
 )
 
 const (
@@ -102,7 +101,7 @@ type SchemaDetailsArguments struct {
 	ExcludeSchemas  []string
 	EntryHandler    loki.EntryHandler
 
-	Logger log.Logger
+	Logger *slog.Logger
 }
 
 type SchemaDetails struct {
@@ -119,7 +118,7 @@ type SchemaDetails struct {
 	// now allows overriding time.Now() in tests
 	now func() time.Time
 
-	logger  log.Logger
+	logger  *slog.Logger
 	running *atomic.Bool
 	ctx     context.Context
 	cancel  context.CancelFunc
@@ -174,7 +173,7 @@ func NewSchemaDetails(args SchemaDetailsArguments) (*SchemaDetails, error) {
 		entryHandler:    args.EntryHandler,
 		lastEmittedAt:   map[string]time.Time{},
 		now:             time.Now,
-		logger:          log.With(args.Logger, "collector", SchemaDetailsCollector),
+		logger:          args.Logger.With("collector", SchemaDetailsCollector),
 		running:         &atomic.Bool{},
 	}
 
@@ -186,7 +185,7 @@ func (c *SchemaDetails) Name() string {
 }
 
 func (c *SchemaDetails) Start(ctx context.Context) error {
-	level.Debug(c.logger).Log("msg", "collector started")
+	c.logger.Debug("collector started")
 
 	c.running.Store(true)
 	ctx, cancel := context.WithCancel(ctx)
@@ -201,7 +200,7 @@ func (c *SchemaDetails) Start(ctx context.Context) error {
 
 		for {
 			if err := c.extractSchema(c.ctx); err != nil {
-				level.Error(c.logger).Log("msg", "collector error", "err", err)
+				c.logger.Error("collector error", "err", err)
 			}
 
 			select {
@@ -242,7 +241,7 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 		var schema, tableName, tableType string
 		var createTime, updateTime time.Time
 		if err := rs.Scan(&schema, &tableName, &tableType, &createTime, &updateTime); err != nil {
-			level.Error(c.logger).Log("msg", "failed to scan tables", "err", err)
+			c.logger.Error("failed to scan tables", "err", err)
 			break
 		}
 		tables = append(tables, &tableInfo{
@@ -277,7 +276,7 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 	}
 
 	if len(tables) == 0 {
-		level.Info(c.logger).Log("msg", "no tables detected from information_schema.tables")
+		c.logger.Info("no tables detected from information_schema.tables")
 		return nil
 	}
 
@@ -310,7 +309,7 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 
 		specs, err := c.fetchSchemaSpecs(ctx, schema, tableNames)
 		if err != nil {
-			level.Error(c.logger).Log("msg", "failed to fetch schema specs", "schema", schema, "err", err)
+			c.logger.Error("failed to fetch schema specs", "schema", schema, "err", err)
 			continue
 		}
 
@@ -318,20 +317,20 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 			fullyQualifiedTable := fullyQualifiedName(table.schema, table.tableName)
 
 			if err := c.fetchCreateStatement(ctx, fullyQualifiedTable, table); err != nil {
-				level.Error(c.logger).Log("msg", "failed to get table create statement", "schema", table.schema, "table", table.tableName, "err", err)
+				c.logger.Error("failed to get table create statement", "schema", table.schema, "table", table.tableName, "err", err)
 				continue
 			}
 
 			spec, ok := specs[table.tableName]
 			if !ok {
 				// This might happen if a table is dropped between the tables query and the metadata queries.
-				level.Warn(c.logger).Log("msg", "no bulk metadata rows for table", "schema", table.schema, "table", table.tableName)
+				c.logger.Warn("no bulk metadata rows for table", "schema", table.schema, "table", table.tableName)
 				continue
 			}
 
 			b64Spec, err := encodeTableSpec(spec)
 			if err != nil {
-				level.Error(c.logger).Log("msg", "failed to marshal table spec", "schema", table.schema, "table", table.tableName, "err", err)
+				c.logger.Error("failed to marshal table spec", "schema", table.schema, "table", table.tableName, "err", err)
 				continue
 			}
 			table.b64TableSpec = b64Spec
@@ -356,7 +355,7 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 func (c *SchemaDetails) fetchCreateStatement(ctx context.Context, fullyQualifiedTable string, table *tableInfo) error {
 	row := c.dbConnection.QueryRowContext(ctx, showCreateTable+" "+fullyQualifiedTable)
 	if err := row.Err(); err != nil {
-		level.Error(c.logger).Log("msg", "failed to show create table", "schema", table.schema, "table", table.tableName, "err", err)
+		c.logger.Error("failed to show create table", "schema", table.schema, "table", table.tableName, "err", err)
 		return err
 	}
 
@@ -364,16 +363,16 @@ func (c *SchemaDetails) fetchCreateStatement(ctx context.Context, fullyQualified
 	switch table.tableType {
 	case "BASE TABLE":
 		if err := row.Scan(&tableName, &createStmt); err != nil {
-			level.Error(c.logger).Log("msg", "failed to scan create table", "schema", table.schema, "table", table.tableName, "err", err)
+			c.logger.Error("failed to scan create table", "schema", table.schema, "table", table.tableName, "err", err)
 			return err
 		}
 	case "VIEW":
 		if err := row.Scan(&tableName, &createStmt, &characterSetClient, &collationConnection); err != nil {
-			level.Error(c.logger).Log("msg", "failed to scan create view", "schema", table.schema, "table", table.tableName, "err", err)
+			c.logger.Error("failed to scan create view", "schema", table.schema, "table", table.tableName, "err", err)
 			return err
 		}
 	default:
-		level.Error(c.logger).Log("msg", "unknown table type", "schema", table.schema, "table", table.tableName, "table_type", table.tableType)
+		c.logger.Error("unknown table type", "schema", table.schema, "table", table.tableName, "table_type", table.tableType)
 		return fmt.Errorf("unknown table type: %s", table.tableType)
 	}
 	table.b64CreateStmt = base64.StdEncoding.EncodeToString([]byte(createStmt))
@@ -410,7 +409,7 @@ func (c *SchemaDetails) fetchSchemaSpecs(ctx context.Context, schema string, tab
 
 	colRS, err := c.dbConnection.QueryContext(ctx, fmt.Sprintf(selectColumnNames, database_observability.BuildExclusionClause(tableNames)), schema)
 	if err != nil {
-		level.Error(c.logger).Log("msg", "failed to query schema columns", "schema", schema, "err", err)
+		c.logger.Error("failed to query schema columns", "schema", schema, "err", err)
 		return nil, err
 	}
 	defer colRS.Close()
@@ -419,7 +418,7 @@ func (c *SchemaDetails) fetchSchemaSpecs(ctx context.Context, schema string, tab
 		var tableName, columnName, isNullable, columnType, columnKey, extra string
 		var columnDefault sql.NullString
 		if err := colRS.Scan(&tableName, &columnName, &columnDefault, &isNullable, &columnType, &columnKey, &extra); err != nil {
-			level.Error(c.logger).Log("msg", "failed to scan schema columns", "schema", schema, "err", err)
+			c.logger.Error("failed to scan schema columns", "schema", schema, "err", err)
 			return nil, err
 		}
 
@@ -444,13 +443,13 @@ func (c *SchemaDetails) fetchSchemaSpecs(ctx context.Context, schema string, tab
 	}
 
 	if err := colRS.Err(); err != nil {
-		level.Error(c.logger).Log("msg", "failed to iterate over schema columns result set", "schema", schema, "err", err)
+		c.logger.Error("failed to iterate over schema columns result set", "schema", schema, "err", err)
 		return nil, err
 	}
 
 	idxRS, err := c.dbConnection.QueryContext(ctx, fmt.Sprintf(selectIndexNames, database_observability.BuildExclusionClause(tableNames)), schema)
 	if err != nil {
-		level.Error(c.logger).Log("msg", "failed to query schema indexes", "schema", schema, "err", err)
+		c.logger.Error("failed to query schema indexes", "schema", schema, "err", err)
 		return nil, err
 	}
 	defer idxRS.Close()
@@ -464,14 +463,14 @@ func (c *SchemaDetails) fetchSchemaSpecs(ctx context.Context, schema string, tab
 		var seqInIndex, nonUnique int
 		var columnName, expression, nullable sql.NullString
 		if err := idxRS.Scan(&tableName, &indexName, &seqInIndex, &columnName, &expression, &nullable, &nonUnique, &indexType); err != nil {
-			level.Error(c.logger).Log("msg", "failed to scan schema indexes", "schema", schema, "err", err)
+			c.logger.Error("failed to scan schema indexes", "schema", schema, "err", err)
 			return nil, err
 		}
 
 		// mysql docs describe column and expression as mutually exclusive,
 		// but at least one of them must be present.
 		if !columnName.Valid && !expression.Valid {
-			level.Error(c.logger).Log("msg", "index without a column or expression", "schema", schema, "table", tableName, "index", indexName)
+			c.logger.Error("index without a column or expression", "schema", schema, "table", tableName, "index", indexName)
 			continue
 		}
 
@@ -483,7 +482,7 @@ func (c *SchemaDetails) fetchSchemaSpecs(ctx context.Context, schema string, tab
 			if nIndexes := len(spec.Indexes); nIndexes > 0 && spec.Indexes[nIndexes-1].Name == indexName {
 				lastIndex := &spec.Indexes[nIndexes-1]
 				if len(lastIndex.Columns)+len(lastIndex.Expressions) != seqInIndex-1 {
-					level.Error(c.logger).Log("msg", "unexpected index ordinal position", "schema", schema, "table", tableName, "index", indexName, "seq", seqInIndex, "len_columns", len(lastIndex.Columns), "len_expressions", len(lastIndex.Expressions))
+					c.logger.Error("unexpected index ordinal position", "schema", schema, "table", tableName, "index", indexName, "seq", seqInIndex, "len_columns", len(lastIndex.Columns), "len_expressions", len(lastIndex.Expressions))
 					continue
 				}
 
@@ -513,13 +512,13 @@ func (c *SchemaDetails) fetchSchemaSpecs(ctx context.Context, schema string, tab
 	}
 
 	if err := idxRS.Err(); err != nil {
-		level.Error(c.logger).Log("msg", "failed to iterate over schema indexes result set", "schema", schema, "err", err)
+		c.logger.Error("failed to iterate over schema indexes result set", "schema", schema, "err", err)
 		return nil, err
 	}
 
 	fkRS, err := c.dbConnection.QueryContext(ctx, fmt.Sprintf(selectForeignKeys, database_observability.BuildExclusionClause(tableNames)), schema)
 	if err != nil {
-		level.Error(c.logger).Log("msg", "failed to query schema foreign keys", "schema", schema, "err", err)
+		c.logger.Error("failed to query schema foreign keys", "schema", schema, "err", err)
 		return nil, err
 	}
 	defer fkRS.Close()
@@ -527,7 +526,7 @@ func (c *SchemaDetails) fetchSchemaSpecs(ctx context.Context, schema string, tab
 	for fkRS.Next() {
 		var tableName, constraintName, columnName, referencedTableName, referencedColumnName string
 		if err := fkRS.Scan(&tableName, &constraintName, &columnName, &referencedTableName, &referencedColumnName); err != nil {
-			level.Error(c.logger).Log("msg", "failed to scan schema foreign keys", "schema", schema, "err", err)
+			c.logger.Error("failed to scan schema foreign keys", "schema", schema, "err", err)
 			return nil, err
 		}
 
@@ -541,7 +540,7 @@ func (c *SchemaDetails) fetchSchemaSpecs(ctx context.Context, schema string, tab
 	}
 
 	if err := fkRS.Err(); err != nil {
-		level.Error(c.logger).Log("msg", "failed to iterate over schema foreign keys result set", "schema", schema, "err", err)
+		c.logger.Error("failed to iterate over schema foreign keys result set", "schema", schema, "err", err)
 		return nil, err
 	}
 

--- a/internal/component/database_observability/mysql/collector/schema_details_test.go
+++ b/internal/component/database_observability/mysql/collector/schema_details_test.go
@@ -3,18 +3,17 @@ package collector
 import (
 	"encoding/base64"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/component/database_observability"
+	"github.com/grafana/alloy/internal/util"
 )
 
 func TestSchemaDetails(t *testing.T) {
@@ -33,7 +32,7 @@ func TestSchemaDetails(t *testing.T) {
 			DB:              db,
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -174,7 +173,7 @@ func TestSchemaDetails(t *testing.T) {
 			DB:              db,
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -318,7 +317,7 @@ func TestSchemaDetails(t *testing.T) {
 			DB:              db,
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -487,7 +486,7 @@ func TestSchemaDetails(t *testing.T) {
 			DB:              db,
 			CollectInterval: time.Hour, // unused; extractSchema is invoked manually
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -576,7 +575,7 @@ func TestSchemaDetails(t *testing.T) {
 			DB:              db,
 			CollectInterval: time.Hour,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -657,7 +656,7 @@ func TestSchemaDetails(t *testing.T) {
 			DB:              db,
 			CollectInterval: time.Hour,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -741,7 +740,7 @@ func TestSchemaDetails(t *testing.T) {
 			DB:              db,
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 
 		require.NoError(t, err)
@@ -872,7 +871,7 @@ func TestSchemaDetails(t *testing.T) {
 			DB:              db,
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -974,7 +973,7 @@ func TestSchemaDetails(t *testing.T) {
 			DB:              db,
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -1019,7 +1018,7 @@ func TestSchemaDetails(t *testing.T) {
 			DB:              db,
 			CollectInterval: time.Hour,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -1050,7 +1049,7 @@ func TestSchemaDetails(t *testing.T) {
 			DB:              db,
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -1111,7 +1110,7 @@ func TestSchemaDetails(t *testing.T) {
 			DB:              db,
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -1235,7 +1234,7 @@ func TestSchemaDetails(t *testing.T) {
 			DB:              db,
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -1329,7 +1328,7 @@ func TestSchemaDetails(t *testing.T) {
 			DB:              db,
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -1402,7 +1401,7 @@ func TestSchemaDetailsExcludeSchemas(t *testing.T) {
 		CollectInterval: time.Millisecond,
 		ExcludeSchemas:  []string{"excluded_schema"},
 		EntryHandler:    lokiClient,
-		Logger:          log.NewLogfmtLogger(os.Stderr),
+		Logger:          util.TestAlloyLogger(t).Slog(),
 	})
 	require.NoError(t, err)
 

--- a/internal/component/database_observability/mysql/collector/setup_actors.go
+++ b/internal/component/database_observability/mysql/collector/setup_actors.go
@@ -5,14 +5,12 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/go-kit/log"
 	"go.uber.org/atomic"
-
-	"github.com/grafana/alloy/internal/runtime/logging/level"
 )
 
 const (
@@ -35,7 +33,7 @@ const (
 
 type SetupActorsArguments struct {
 	DB                    *sql.DB
-	Logger                log.Logger
+	Logger                *slog.Logger
 	CollectInterval       time.Duration
 	AutoUpdateSetupActors bool
 }
@@ -45,7 +43,7 @@ type SetupActors struct {
 	collectInterval       time.Duration
 	autoUpdateSetupActors bool
 
-	logger  log.Logger
+	logger  *slog.Logger
 	running *atomic.Bool
 	ctx     context.Context
 	cancel  context.CancelFunc
@@ -56,7 +54,7 @@ func NewSetupActors(args SetupActorsArguments) (*SetupActors, error) {
 	return &SetupActors{
 		dbConnection:          args.DB,
 		running:               &atomic.Bool{},
-		logger:                log.With(args.Logger, "collector", SetupActorsCollector),
+		logger:                args.Logger.With("collector", SetupActorsCollector),
 		collectInterval:       args.CollectInterval,
 		autoUpdateSetupActors: args.AutoUpdateSetupActors,
 	}, nil
@@ -67,7 +65,7 @@ func (c *SetupActors) Name() string {
 }
 
 func (c *SetupActors) Start(ctx context.Context) error {
-	level.Debug(c.logger).Log("msg", "collector started")
+	c.logger.Debug("collector started")
 	c.running.Store(true)
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -76,7 +74,7 @@ func (c *SetupActors) Start(ctx context.Context) error {
 
 	var user string
 	if err := c.dbConnection.QueryRowContext(ctx, selectUserQuery).Scan(&user); err != nil {
-		level.Error(c.logger).Log("msg", "failed to get current user", "err", err)
+		c.logger.Error("failed to get current user", "err", err)
 		c.running.Store(false)
 		cancel()
 		return err
@@ -90,7 +88,7 @@ func (c *SetupActors) Start(ctx context.Context) error {
 
 		for {
 			if err := c.checkSetupActors(c.ctx, user); err != nil {
-				level.Error(c.logger).Log("msg", "collector error", "err", err)
+				c.logger.Error("collector error", "err", err)
 			}
 
 			select {
@@ -123,11 +121,11 @@ func (c *SetupActors) checkSetupActors(ctx context.Context, user string) error {
 		if c.autoUpdateSetupActors {
 			return c.insertSetupActors(ctx, user)
 		} else {
-			level.Info(c.logger).Log("msg", "setup_actors configuration missing, but auto-update is disabled")
+			c.logger.Info("setup_actors configuration missing, but auto-update is disabled")
 			return nil
 		}
 	} else if err != nil {
-		level.Error(c.logger).Log("msg", "failed to query setup_actors table", "err", err)
+		c.logger.Error("failed to query setup_actors table", "err", err)
 		return err
 	}
 
@@ -135,7 +133,7 @@ func (c *SetupActors) checkSetupActors(ctx context.Context, user string) error {
 		if c.autoUpdateSetupActors {
 			return c.updateSetupActors(ctx, user, enabled, history)
 		} else {
-			level.Info(c.logger).Log("msg", "setup_actors configuration is not correct, but auto-update is disabled")
+			c.logger.Info("setup_actors configuration is not correct, but auto-update is disabled")
 			return nil
 		}
 	}
@@ -146,31 +144,31 @@ func (c *SetupActors) checkSetupActors(ctx context.Context, user string) error {
 func (c *SetupActors) insertSetupActors(ctx context.Context, user string) error {
 	_, err := c.dbConnection.ExecContext(ctx, insertQuery, user)
 	if err != nil {
-		level.Error(c.logger).Log("msg", "failed to insert setup_actors row", "err", err, "user", user)
+		c.logger.Error("failed to insert setup_actors row", "err", err, "user", user)
 		return err
 	}
 
-	level.Debug(c.logger).Log("msg", "inserted new setup_actors row", "user", user)
+	c.logger.Debug("inserted new setup_actors row", "user", user)
 	return nil
 }
 
 func (c *SetupActors) updateSetupActors(ctx context.Context, user string, enabled string, history string) error {
 	r, err := c.dbConnection.ExecContext(ctx, updateQuery, user)
 	if err != nil {
-		level.Error(c.logger).Log("msg", "failed to update setup_actors row", "err", err, "user", user)
+		c.logger.Error("failed to update setup_actors row", "err", err, "user", user)
 		return err
 	}
 
 	rowsAffected, err := r.RowsAffected()
 	if err != nil {
-		level.Error(c.logger).Log("msg", "failed to get rows affected from setup_actors update", "err", err)
+		c.logger.Error("failed to get rows affected from setup_actors update", "err", err)
 		return err
 	}
 	if rowsAffected == 0 {
-		level.Error(c.logger).Log("msg", "no rows affected from setup_actors update", "user", user)
+		c.logger.Error("no rows affected from setup_actors update", "user", user)
 		return fmt.Errorf("no rows affected from setup_actors update")
 	}
 
-	level.Debug(c.logger).Log("msg", "updated setup_actors row", "rows_affected", rowsAffected, "previous_enabled", enabled, "previous_history", history, "user", user)
+	c.logger.Debug("updated setup_actors row", "rows_affected", rowsAffected, "previous_enabled", enabled, "previous_history", history, "user", user)
 	return nil
 }

--- a/internal/component/database_observability/mysql/collector/setup_actors_test.go
+++ b/internal/component/database_observability/mysql/collector/setup_actors_test.go
@@ -4,15 +4,15 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+
+	"github.com/grafana/alloy/internal/util"
 )
 
 func Test_SetupActors(t *testing.T) {
@@ -31,7 +31,7 @@ func Test_SetupActors(t *testing.T) {
 
 		c, err := NewSetupActors(SetupActorsArguments{
 			DB:                    db,
-			Logger:                log.NewLogfmtLogger(os.Stderr),
+			Logger:                util.TestAlloyLogger(t).Slog(),
 			CollectInterval:       time.Millisecond,
 			AutoUpdateSetupActors: true,
 		})
@@ -68,7 +68,7 @@ func Test_SetupActors(t *testing.T) {
 
 		c, err := NewSetupActors(SetupActorsArguments{
 			DB:                    db,
-			Logger:                log.NewLogfmtLogger(os.Stderr),
+			Logger:                util.TestAlloyLogger(t).Slog(),
 			CollectInterval:       time.Millisecond,
 			AutoUpdateSetupActors: true,
 		})
@@ -104,7 +104,7 @@ func Test_SetupActors(t *testing.T) {
 
 		c, err := NewSetupActors(SetupActorsArguments{
 			DB:                    db,
-			Logger:                log.NewLogfmtLogger(os.Stderr),
+			Logger:                util.TestAlloyLogger(t).Slog(),
 			CollectInterval:       time.Millisecond,
 			AutoUpdateSetupActors: false,
 		})
@@ -140,7 +140,7 @@ func Test_SetupActors(t *testing.T) {
 
 		c, err := NewSetupActors(SetupActorsArguments{
 			DB:                    db,
-			Logger:                log.NewLogfmtLogger(os.Stderr),
+			Logger:                util.TestAlloyLogger(t).Slog(),
 			CollectInterval:       time.Millisecond,
 			AutoUpdateSetupActors: true,
 		})
@@ -175,7 +175,7 @@ func Test_SetupActors(t *testing.T) {
 
 		c, err := NewSetupActors(SetupActorsArguments{
 			DB:                    db,
-			Logger:                log.NewLogfmtLogger(os.Stderr),
+			Logger:                util.TestAlloyLogger(t).Slog(),
 			CollectInterval:       time.Millisecond,
 			AutoUpdateSetupActors: false,
 		})
@@ -207,7 +207,7 @@ func Test_SetupActors(t *testing.T) {
 
 		c, err := NewSetupActors(SetupActorsArguments{
 			DB:                    db,
-			Logger:                log.NewLogfmtLogger(os.Stderr),
+			Logger:                util.TestAlloyLogger(t).Slog(),
 			CollectInterval:       time.Millisecond,
 			AutoUpdateSetupActors: true,
 		})
@@ -237,7 +237,7 @@ func Test_SetupActors(t *testing.T) {
 
 		c, err := NewSetupActors(SetupActorsArguments{
 			DB:                    db,
-			Logger:                log.NewLogfmtLogger(os.Stderr),
+			Logger:                util.TestAlloyLogger(t).Slog(),
 			CollectInterval:       time.Millisecond,
 			AutoUpdateSetupActors: true,
 		})
@@ -278,7 +278,7 @@ func Test_SetupActors(t *testing.T) {
 
 		c, err := NewSetupActors(SetupActorsArguments{
 			DB:                    db,
-			Logger:                log.NewLogfmtLogger(os.Stderr),
+			Logger:                util.TestAlloyLogger(t).Slog(),
 			CollectInterval:       time.Millisecond,
 			AutoUpdateSetupActors: true,
 		})
@@ -319,7 +319,7 @@ func Test_SetupActors(t *testing.T) {
 
 		c, err := NewSetupActors(SetupActorsArguments{
 			DB:                    db,
-			Logger:                log.NewLogfmtLogger(os.Stderr),
+			Logger:                util.TestAlloyLogger(t).Slog(),
 			CollectInterval:       time.Millisecond,
 			AutoUpdateSetupActors: true,
 		})
@@ -356,7 +356,7 @@ func Test_SetupActors(t *testing.T) {
 
 		c, err := NewSetupActors(SetupActorsArguments{
 			DB:                    db,
-			Logger:                log.NewLogfmtLogger(os.Stderr),
+			Logger:                util.TestAlloyLogger(t).Slog(),
 			CollectInterval:       time.Millisecond,
 			AutoUpdateSetupActors: true,
 		})
@@ -391,7 +391,7 @@ func Test_SetupActors(t *testing.T) {
 
 		c, err := NewSetupActors(SetupActorsArguments{
 			DB:                    db,
-			Logger:                log.NewLogfmtLogger(os.Stderr),
+			Logger:                util.TestAlloyLogger(t).Slog(),
 			CollectInterval:       time.Millisecond,
 			AutoUpdateSetupActors: true,
 		})
@@ -427,7 +427,7 @@ func Test_SetupActors(t *testing.T) {
 
 		c, err := NewSetupActors(SetupActorsArguments{
 			DB:                    db,
-			Logger:                log.NewLogfmtLogger(os.Stderr),
+			Logger:                util.TestAlloyLogger(t).Slog(),
 			CollectInterval:       time.Millisecond,
 			AutoUpdateSetupActors: true,
 		})
@@ -468,7 +468,7 @@ func Test_SetupActors(t *testing.T) {
 
 		c, err := NewSetupActors(SetupActorsArguments{
 			DB:                    db,
-			Logger:                log.NewLogfmtLogger(os.Stderr),
+			Logger:                util.TestAlloyLogger(t).Slog(),
 			CollectInterval:       time.Millisecond,
 			AutoUpdateSetupActors: true,
 		})
@@ -511,7 +511,7 @@ func Test_SetupActors(t *testing.T) {
 
 		c, err := NewSetupActors(SetupActorsArguments{
 			DB:                    db,
-			Logger:                log.NewLogfmtLogger(os.Stderr),
+			Logger:                util.TestAlloyLogger(t).Slog(),
 			CollectInterval:       time.Millisecond,
 			AutoUpdateSetupActors: true,
 		})
@@ -550,7 +550,7 @@ func Test_SetupActors(t *testing.T) {
 
 		c, err := NewSetupActors(SetupActorsArguments{
 			DB:                    db,
-			Logger:                log.NewLogfmtLogger(os.Stderr),
+			Logger:                util.TestAlloyLogger(t).Slog(),
 			CollectInterval:       time.Millisecond,
 			AutoUpdateSetupActors: true,
 		})
@@ -589,7 +589,7 @@ func Test_SetupActors(t *testing.T) {
 
 		c, err := NewSetupActors(SetupActorsArguments{
 			DB:                    db,
-			Logger:                log.NewLogfmtLogger(os.Stderr),
+			Logger:                util.TestAlloyLogger(t).Slog(),
 			CollectInterval:       time.Millisecond,
 			AutoUpdateSetupActors: true,
 		})

--- a/internal/component/database_observability/mysql/collector/setup_consumers.go
+++ b/internal/component/database_observability/mysql/collector/setup_consumers.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 
-	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/atomic"
-
-	"github.com/grafana/alloy/internal/runtime/logging/level"
 )
 
 const (
@@ -22,7 +20,7 @@ type SetupConsumersArguments struct {
 	DB       *sql.DB
 	Registry *prometheus.Registry
 
-	Logger          log.Logger
+	Logger          *slog.Logger
 	CollectInterval time.Duration
 }
 
@@ -32,7 +30,7 @@ type SetupConsumers struct {
 	collectInterval      time.Duration
 	setupConsumersMetric *prometheus.GaugeVec
 
-	logger  log.Logger
+	logger  *slog.Logger
 	running *atomic.Bool
 	ctx     context.Context
 	cancel  context.CancelFunc
@@ -53,7 +51,7 @@ func NewSetupConsumers(args SetupConsumersArguments) (*SetupConsumers, error) {
 		registry:             args.Registry,
 		setupConsumersMetric: setupConsumerMetric,
 		running:              &atomic.Bool{},
-		logger:               log.With(args.Logger, "collector", SetupConsumersCollector),
+		logger:               args.Logger.With("collector", SetupConsumersCollector),
 		collectInterval:      args.CollectInterval,
 	}, nil
 }
@@ -63,7 +61,7 @@ func (c *SetupConsumers) Name() string {
 }
 
 func (c *SetupConsumers) Start(ctx context.Context) error {
-	level.Debug(c.logger).Log("msg", "collector started")
+	c.logger.Debug("collector started")
 	c.running.Store(true)
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -78,7 +76,7 @@ func (c *SetupConsumers) Start(ctx context.Context) error {
 
 		for {
 			if err := c.getSetupConsumers(c.ctx); err != nil {
-				level.Error(c.logger).Log("msg", "collector error", "err", err)
+				c.logger.Error("collector error", "err", err)
 			}
 
 			select {
@@ -117,7 +115,7 @@ const (
 func (c *SetupConsumers) getSetupConsumers(ctx context.Context) error {
 	rs, err := c.dbConnection.QueryContext(ctx, selectSetupConsumers)
 	if err != nil {
-		level.Error(c.logger).Log("msg", "failed to query selectSetupConsumers", "err", err)
+		c.logger.Error("failed to query selectSetupConsumers", "err", err)
 		return err
 	}
 	defer rs.Close()

--- a/internal/component/database_observability/mysql/collector/setup_consumers_test.go
+++ b/internal/component/database_observability/mysql/collector/setup_consumers_test.go
@@ -2,17 +2,17 @@ package collector
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/internal/util"
 )
 
 func Test_getSetupConsumers(t *testing.T) {
@@ -30,7 +30,7 @@ func Test_getSetupConsumers(t *testing.T) {
 			Registry:        reg,
 			DB:              db,
 			CollectInterval: 1 * time.Second,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 
@@ -59,7 +59,7 @@ func Test_getSetupConsumers(t *testing.T) {
 			Registry:        reg,
 			DB:              db,
 			CollectInterval: 1 * time.Second,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 
@@ -84,7 +84,7 @@ func Test_getSetupConsumers(t *testing.T) {
 			DB:              db,
 			Registry:        prometheus.NewRegistry(),
 			CollectInterval: 1 * time.Second,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 

--- a/internal/component/database_observability/mysql/component.go
+++ b/internal/component/database_observability/mysql/component.go
@@ -28,7 +28,6 @@ import (
 	"github.com/grafana/alloy/internal/component/discovery"
 	exporter_mysql "github.com/grafana/alloy/internal/component/prometheus/exporter/mysql"
 	"github.com/grafana/alloy/internal/featuregate"
-	"github.com/grafana/alloy/internal/runtime/logging/level"
 	http_service "github.com/grafana/alloy/internal/service/http"
 	"github.com/grafana/alloy/internal/static/integrations/mysqld_exporter"
 	"github.com/grafana/alloy/syntax"
@@ -308,7 +307,7 @@ func new(opts component.Options, args Arguments, openFn func(driverName, dataSou
 
 func (c *Component) Run(ctx context.Context) error {
 	defer func() {
-		level.Info(c.opts.Logger).Log("msg", name+" component shutting down, stopping collectors")
+		c.opts.SLogger.Info(name + " component shutting down, stopping collectors")
 
 		loki.Drain(c.handler, c.fanout, loki.DefaultDrainTimeout, func() {
 			c.mut.Lock()
@@ -345,9 +344,9 @@ func (c *Component) Run(ctx context.Context) error {
 				c.mut.RUnlock()
 
 				if !hasCollectors {
-					level.Debug(c.opts.Logger).Log("msg", "attempting to reconnect to database")
+					c.opts.SLogger.Debug("attempting to reconnect to database")
 					if err := c.tryReconnect(ctx); err != nil {
-						level.Error(c.opts.Logger).Log("msg", "reconnection attempt failed", "err", err)
+						c.opts.SLogger.Error("reconnection attempt failed", "err", err)
 					}
 				}
 			}
@@ -380,7 +379,7 @@ func (c *Component) getBaseTarget() (discovery.Target, error) {
 var versionRegex = regexp.MustCompile(`^((\d+)(\.\d+)(\.\d+))`)
 
 func (c *Component) reportError(errorMsg string, err error) {
-	level.Error(c.opts.Logger).Log("msg", fmt.Sprintf("%s: %+v", errorMsg, err))
+	c.opts.SLogger.Error(fmt.Sprintf("%s: %+v", errorMsg, err))
 	c.healthErr.Store(fmt.Sprintf("%s: %+v", errorMsg, err))
 }
 
@@ -554,7 +553,7 @@ func (c *Component) startCollectors(serverID string, engineVersion string, parse
 
 	logStartError := func(collectorName, action string, err error) {
 		errorString := fmt.Sprintf("failed to %s %s collector: %+v", action, collectorName, err)
-		level.Error(c.opts.Logger).Log("msg", errorString)
+		c.opts.SLogger.Error(errorString)
 		startErrors = append(startErrors, errorString)
 	}
 	entryHandler := addLokiLabels(loki.NewEntryHandler(c.handler.Chan(), func() {}), c.instanceKey, serverID)
@@ -568,7 +567,7 @@ func (c *Component) startCollectors(serverID string, engineVersion string, parse
 			StatementsLimit: c.args.QueryDetailsArguments.StatementsLimit,
 			ExcludeSchemas:  c.args.ExcludeSchemas,
 			EntryHandler:    entryHandler,
-			Logger:          c.opts.Logger,
+			Logger:          c.opts.SLogger,
 		})
 		if err != nil {
 			logStartError(collector.QueryDetailsCollector, "create", err)
@@ -582,13 +581,13 @@ func (c *Component) startCollectors(serverID string, engineVersion string, parse
 
 	if collectors[collector.SchemaDetailsCollector] {
 		if c.args.SchemaDetailsArguments.CacheEnabled != nil {
-			level.Warn(c.opts.Logger).Log("msg", "schema_details.cache_enabled is set, but the cache is deprecated and will be removed in a future version")
+			c.opts.SLogger.Warn("schema_details.cache_enabled is set, but the cache is deprecated and will be removed in a future version")
 		}
 		if c.args.SchemaDetailsArguments.CacheSize != nil {
-			level.Warn(c.opts.Logger).Log("msg", "schema_details.cache_size is set, but the cache is deprecated and will be removed in a future version")
+			c.opts.SLogger.Warn("schema_details.cache_size is set, but the cache is deprecated and will be removed in a future version")
 		}
 		if c.args.SchemaDetailsArguments.CacheTTL != nil {
-			level.Warn(c.opts.Logger).Log("msg", "schema_details.cache_ttl is set, but the cache is deprecated and will be removed in a future version")
+			c.opts.SLogger.Warn("schema_details.cache_ttl is set, but the cache is deprecated and will be removed in a future version")
 		}
 
 		stCollector, err := collector.NewSchemaDetails(collector.SchemaDetailsArguments{
@@ -596,7 +595,7 @@ func (c *Component) startCollectors(serverID string, engineVersion string, parse
 			CollectInterval: c.args.SchemaDetailsArguments.CollectInterval,
 			ExcludeSchemas:  c.args.ExcludeSchemas,
 			EntryHandler:    entryHandler,
-			Logger:          c.opts.Logger,
+			Logger:          c.opts.SLogger,
 		})
 		if err != nil {
 			logStartError(collector.SchemaDetailsCollector, "create", err)
@@ -610,10 +609,10 @@ func (c *Component) startCollectors(serverID string, engineVersion string, parse
 
 	if collectors[collector.QuerySamplesCollector] {
 		if c.args.QuerySamplesArguments.AutoEnableSetupConsumers && !c.args.AllowUpdatePerfSchemaSettings {
-			level.Warn(c.opts.Logger).Log("msg", "auto_enable_setup_consumers is true but allow_update_performance_schema_settings is false, setup_consumers will not be enabled")
+			c.opts.SLogger.Warn("auto_enable_setup_consumers is true but allow_update_performance_schema_settings is false, setup_consumers will not be enabled")
 		}
 		if c.args.QuerySamplesArguments.SampleMinDuration > 0 && c.args.QuerySamplesArguments.WaitEventMinDuration > c.args.QuerySamplesArguments.SampleMinDuration {
-			level.Warn(c.opts.Logger).Log("msg", "wait_event_min_duration is greater than sample_min_duration, which may result in query samples with no associated wait events")
+			c.opts.SLogger.Warn("wait_event_min_duration is greater than sample_min_duration, which may result in query samples with no associated wait events")
 		}
 
 		qsCollector, err := collector.NewQuerySamples(collector.QuerySamplesArguments{
@@ -623,7 +622,7 @@ func (c *Component) startCollectors(serverID string, engineVersion string, parse
 			ExcludeSchemas:                c.args.ExcludeSchemas,
 			EntryHandler:                  entryHandler,
 			Registry:                      c.registry,
-			Logger:                        c.opts.Logger,
+			Logger:                        c.opts.SLogger,
 			DisableQueryRedaction:         c.args.QuerySamplesArguments.DisableQueryRedaction,
 			AutoEnableSetupConsumers:      c.args.AllowUpdatePerfSchemaSettings && c.args.QuerySamplesArguments.AutoEnableSetupConsumers,
 			SetupConsumersCheckInterval:   c.args.QuerySamplesArguments.SetupConsumersCheckInterval,
@@ -645,7 +644,7 @@ func (c *Component) startCollectors(serverID string, engineVersion string, parse
 		scCollector, err := collector.NewSetupConsumers(collector.SetupConsumersArguments{
 			DB:              c.dbConnection,
 			Registry:        c.registry,
-			Logger:          c.opts.Logger,
+			Logger:          c.opts.SLogger,
 			CollectInterval: c.args.SetupConsumersArguments.CollectInterval,
 		})
 		if err != nil {
@@ -660,12 +659,12 @@ func (c *Component) startCollectors(serverID string, engineVersion string, parse
 
 	if collectors[collector.SetupActorsCollector] {
 		if c.args.SetupActorsArguments.AutoUpdateSetupActors && !c.args.AllowUpdatePerfSchemaSettings {
-			level.Warn(c.opts.Logger).Log("msg", "auto_update_setup_actors is true but allow_update_performance_schema_settings is false, setup_actors will not be updated")
+			c.opts.SLogger.Warn("auto_update_setup_actors is true but allow_update_performance_schema_settings is false, setup_actors will not be updated")
 		}
 
 		saCollector, err := collector.NewSetupActors(collector.SetupActorsArguments{
 			DB:                    c.dbConnection,
-			Logger:                c.opts.Logger,
+			Logger:                c.opts.SLogger,
 			CollectInterval:       c.args.SetupActorsArguments.CollectInterval,
 			AutoUpdateSetupActors: c.args.AllowUpdatePerfSchemaSettings && c.args.SetupActorsArguments.AutoUpdateSetupActors,
 		})
@@ -684,7 +683,7 @@ func (c *Component) startCollectors(serverID string, engineVersion string, parse
 			DB:                c.dbConnection,
 			CollectInterval:   c.args.LocksArguments.CollectInterval,
 			LockWaitThreshold: c.args.LocksArguments.Threshold,
-			Logger:            c.opts.Logger,
+			Logger:            c.opts.SLogger,
 			EntryHandler:      entryHandler,
 		})
 		if err != nil {
@@ -704,7 +703,7 @@ func (c *Component) startCollectors(serverID string, engineVersion string, parse
 			PerScrapeRatio:  c.args.ExplainPlansArguments.PerCollectRatio,
 			ExcludeSchemas:  c.args.ExcludeSchemas,
 			InitialLookback: time.Now().Add(-c.args.ExplainPlansArguments.InitialLookback),
-			Logger:          c.opts.Logger,
+			Logger:          c.opts.SLogger,
 			DBVersion:       engineVersion,
 			EntryHandler:    entryHandler,
 		})
@@ -741,7 +740,7 @@ func (c *Component) startCollectors(serverID string, engineVersion string, parse
 		CollectInterval: c.args.HealthCheckArguments.CollectInterval,
 		ExcludeSchemas:  c.args.ExcludeSchemas,
 		EntryHandler:    entryHandler,
-		Logger:          c.opts.Logger,
+		Logger:          c.opts.SLogger,
 	})
 	if err != nil {
 		logStartError(collector.HealthCheckCollector, "create", err)

--- a/internal/component/database_observability/mysql/component_test.go
+++ b/internal/component/database_observability/mysql/component_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
-	kitlog "github.com/go-kit/log"
 	cmp "github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/component/database_observability"
@@ -416,7 +415,6 @@ func TestMySQL_Update_DBUnavailable_ReportsUnhealthy(t *testing.T) {
 	args := Arguments{DataSourceName: "user:pass@tcp(127.0.0.1:1)/db"}
 	opts := cmp.Options{
 		ID:      "test.mysql",
-		Logger:  kitlog.NewNopLogger(),
 		SLogger: logging.NewSlogNop(),
 		GetServiceData: func(name string) (any, error) {
 			return http_service.Data{MemoryListenAddr: "127.0.0.1:0", BaseHTTPPath: "/component"}, nil
@@ -451,7 +449,6 @@ func TestMySQL_StartCollectors_ReportsUnhealthy_StackedErrors(t *testing.T) {
 	var gotExports cmp.Exports
 	opts := cmp.Options{
 		ID:      "test.mysql",
-		Logger:  kitlog.NewNopLogger(),
 		SLogger: logging.NewSlogNop(),
 		GetServiceData: func(name string) (any, error) {
 			return http_service.Data{MemoryListenAddr: "127.0.0.1:0", BaseHTTPPath: "/component"}, nil
@@ -498,7 +495,6 @@ func TestMySQL_Reconnection(t *testing.T) {
 	t.Run("tryReconnect fails and maintains health error", func(t *testing.T) {
 		opts := cmp.Options{
 			ID:            "test",
-			Logger:        kitlog.NewNopLogger(),
 			SLogger:       logging.NewSlogNop(),
 			OnStateChange: func(e cmp.Exports) {},
 			GetServiceData: func(name string) (any, error) {
@@ -525,7 +521,6 @@ func TestMySQL_Reconnection(t *testing.T) {
 	t.Run("tryReconnect succeeds and clears health error", func(t *testing.T) {
 		opts := cmp.Options{
 			ID:            "test",
-			Logger:        kitlog.NewNopLogger(),
 			SLogger:       logging.NewSlogNop(),
 			OnStateChange: func(e cmp.Exports) {},
 			GetServiceData: func(name string) (any, error) {
@@ -592,7 +587,6 @@ func TestMySQL_Reconnection(t *testing.T) {
 	t.Run("Run exits on context cancellation", func(t *testing.T) {
 		opts := cmp.Options{
 			ID:            "test",
-			Logger:        kitlog.NewNopLogger(),
 			SLogger:       logging.NewSlogNop(),
 			OnStateChange: func(e cmp.Exports) {},
 			GetServiceData: func(name string) (any, error) {

--- a/internal/component/database_observability/postgres/collector/explain_plans.go
+++ b/internal/component/database_observability/postgres/collector/explain_plans.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"math"
 	"regexp"
 	"strconv"
@@ -16,13 +17,11 @@ import (
 
 	"github.com/DataDog/go-sqllexer"
 	"github.com/blang/semver/v4"
-	"github.com/go-kit/log"
 	"go.uber.org/atomic"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/component/database_observability"
 	"github.com/grafana/alloy/internal/runtime/logging"
-	"github.com/grafana/alloy/internal/runtime/logging/level"
 )
 
 const (
@@ -221,7 +220,7 @@ type ExplainPlansArguments struct {
 	EntryHandler     loki.EntryHandler
 	DBVersion        string
 
-	Logger log.Logger
+	Logger *slog.Logger
 }
 
 type ExplainPlans struct {
@@ -238,7 +237,7 @@ type ExplainPlans struct {
 	perScrapeRatio      float64
 	currentBatchSize    int
 	entryHandler        loki.EntryHandler
-	logger              log.Logger
+	logger              *slog.Logger
 	running             *atomic.Bool
 	ctx                 context.Context
 	cancel              context.CancelFunc
@@ -258,7 +257,7 @@ func NewExplainPlan(args ExplainPlansArguments) (*ExplainPlans, error) {
 		queryDenylist:       make(map[string]*queryInfo),
 		finishedQueryCache:  make(map[string]*queryInfo),
 		entryHandler:        args.EntryHandler,
-		logger:              log.With(args.Logger, "collector", ExplainPlanCollector),
+		logger:              args.Logger.With("collector", ExplainPlanCollector),
 		running:             atomic.NewBool(false),
 	}
 	// Pre-sanitize the version by removing any trailing characters before semver gets it
@@ -313,7 +312,7 @@ func (c *ExplainPlans) Name() string {
 }
 
 func (c *ExplainPlans) Start(ctx context.Context) error {
-	level.Debug(c.logger).Log("msg", "collector started")
+	c.logger.Debug("collector started")
 
 	c.running.Store(true)
 	ctx, cancel := context.WithCancel(ctx)
@@ -328,7 +327,7 @@ func (c *ExplainPlans) Start(ctx context.Context) error {
 
 		for {
 			if err := c.fetchExplainPlans(c.ctx); err != nil {
-				level.Error(c.logger).Log("msg", "collector error", "err", err)
+				c.logger.Error("collector error", "err", err)
 			}
 
 			select {
@@ -414,7 +413,7 @@ func (c *ExplainPlans) populateQueryCache(ctx context.Context) error {
 				nil,
 			)
 			if err != nil {
-				level.Error(c.logger).Log("msg", "failed to send denylisted query skip explain plan output", "err", err)
+				c.logger.Error("failed to send denylisted query skip explain plan output", "err", err)
 			}
 			continue
 		}
@@ -425,7 +424,7 @@ func (c *ExplainPlans) populateQueryCache(ctx context.Context) error {
 	}
 
 	c.currentBatchSize = int(math.Ceil(float64(len(c.queryCache)) * c.perScrapeRatio))
-	level.Debug(c.logger).Log("msg", "populated query cache", "count", len(c.queryCache), "batch_size", c.currentBatchSize)
+	c.logger.Debug("populated query cache", "count", len(c.queryCache), "batch_size", c.currentBatchSize)
 	return nil
 }
 
@@ -443,7 +442,7 @@ func (c *ExplainPlans) fetchExplainPlans(ctx context.Context) error {
 		if processedCount >= c.currentBatchSize {
 			break
 		}
-		logger := log.With(c.logger, "query_id", qi.queryId)
+		logger := c.logger.With("query_id", qi.queryId)
 
 		defer func(nonRecoverableFailureOccurred *bool) {
 			if *nonRecoverableFailureOccurred {
@@ -466,14 +465,14 @@ func (c *ExplainPlans) fetchExplainPlans(ctx context.Context) error {
 				nil,
 			)
 			if err != nil {
-				level.Error(c.logger).Log("msg", "failed to send truncated query skip explain plan output", "err", err)
+				c.logger.Error("failed to send truncated query skip explain plan output", "err", err)
 			}
 			continue
 		}
 
 		containsReservedWord, err := database_observability.ContainsReservedKeywords(qi.queryText, database_observability.ExplainReservedWordDenyList, sqllexer.DBMSPostgres)
 		if err != nil {
-			level.Error(logger).Log("msg", "failed to check for reserved keywords", "err", err)
+			logger.Error("failed to check for reserved keywords", "err", err)
 			err := c.sendExplainPlansOutput(
 				qi.datname,
 				qi.queryId,
@@ -483,7 +482,7 @@ func (c *ExplainPlans) fetchExplainPlans(ctx context.Context) error {
 				nil,
 			)
 			if err != nil {
-				level.Error(c.logger).Log("msg", "failed to send reserved keyword check error explain plan output", "err", err)
+				c.logger.Error("failed to send reserved keyword check error explain plan output", "err", err)
 			}
 			continue
 		}
@@ -498,16 +497,16 @@ func (c *ExplainPlans) fetchExplainPlans(ctx context.Context) error {
 				nil,
 			)
 			if err != nil {
-				level.Error(c.logger).Log("msg", "failed to send reserved keyword check error explain plan output", "err", err)
+				c.logger.Error("failed to send reserved keyword check error explain plan output", "err", err)
 			}
 			continue
 		}
 
-		logger = log.With(logger, "datname", qi.datname)
+		logger = logger.With("datname", qi.datname)
 
 		byteExplainPlanJSON, err := c.fetchExplainPlanJSON(ctx, *qi)
 		if err != nil {
-			level.Debug(logger).Log("msg", "failed to fetch explain plan json bytes", "err", err)
+			logger.Debug("failed to fetch explain plan json bytes", "err", err)
 			for _, code := range unrecoverablePostgresSQLErrors {
 				if strings.Contains(err.Error(), code) {
 					nonRecoverableFailureOccurred = true
@@ -518,32 +517,32 @@ func (c *ExplainPlans) fetchExplainPlans(ctx context.Context) error {
 		}
 
 		if len(byteExplainPlanJSON) == 0 {
-			level.Error(logger).Log("msg", "explain plan json bytes is empty")
+			logger.Error("explain plan json bytes is empty")
 			nonRecoverableFailureOccurred = true
 			continue
 		}
 
 		if !utf8.Valid(byteExplainPlanJSON) {
-			level.Error(logger).Log("msg", "explain plan json bytes is not valid UTF-8")
+			logger.Error("explain plan json bytes is not valid UTF-8")
 			nonRecoverableFailureOccurred = true
 			continue
 		}
 
 		redactedByteExplainPlanJSON := database_observability.RedactSql(string(byteExplainPlanJSON))
 
-		level.Debug(logger).Log("msg", "db native explain plan", "db_native_explain_plan", base64.StdEncoding.EncodeToString([]byte(redactedByteExplainPlanJSON)))
+		logger.Debug("db native explain plan", "db_native_explain_plan", base64.StdEncoding.EncodeToString([]byte(redactedByteExplainPlanJSON)))
 
 		explainPlanOutput, genErr := newExplainPlanOutput(byteExplainPlanJSON)
 		explainPlanOutputJSON, err := json.Marshal(explainPlanOutput)
 		if err != nil {
-			level.Error(logger).Log("msg", "failed to marshal explain plan output", "err", err)
+			logger.Error("failed to marshal explain plan output", "err", err)
 			nonRecoverableFailureOccurred = true
 			continue
 		}
 
 		if genErr != nil {
-			level.Error(logger).Log(
-				"msg", "failed to create explain plan output",
+			logger.Error(
+				"failed to create explain plan output",
 				"incomplete_explain_plan", base64.StdEncoding.EncodeToString(explainPlanOutputJSON),
 				"err", genErr,
 			)
@@ -559,7 +558,7 @@ func (c *ExplainPlans) fetchExplainPlans(ctx context.Context) error {
 			"",
 			explainPlanOutput,
 		); err != nil {
-			level.Error(c.logger).Log("msg", "failed to send explain plan output", "err", err)
+			c.logger.Error("failed to send explain plan output", "err", err)
 		}
 	}
 
@@ -599,14 +598,14 @@ func (c *ExplainPlans) fetchExplainPlanJSON(ctx context.Context, qi queryInfo) (
 
 	preparedStatementName := strings.ReplaceAll(fmt.Sprintf("explain_plan_%s", qi.queryId), "-", "_")
 	preparedStatementText := fmt.Sprintf("PREPARE %s AS %s", preparedStatementName, qi.queryText)
-	logger := log.With(c.logger, "query_id", qi.queryId, "datname", qi.datname, "preparedStatementName", preparedStatementName, "preparedStatementText", preparedStatementText)
+	logger := c.logger.With("query_id", qi.queryId, "datname", qi.datname, "preparedStatementName", preparedStatementName, "preparedStatementText", preparedStatementText)
 	if _, err := conn.ExecContext(ctx, preparedStatementText); err != nil {
 		return nil, fmt.Errorf("failed to prepare explain plan: %w", err)
 	}
 
 	defer func() {
 		if _, err := conn.ExecContext(ctx, fmt.Sprintf("DEALLOCATE %s", preparedStatementName)); err != nil {
-			level.Error(logger).Log("msg", "failed to deallocate explain plan", "err", err)
+			logger.Error("failed to deallocate explain plan", "err", err)
 		}
 	}()
 

--- a/internal/component/database_observability/postgres/collector/explain_plans_test.go
+++ b/internal/component/database_observability/postgres/collector/explain_plans_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/blang/semver/v4"
-	"github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
@@ -18,6 +17,7 @@ import (
 
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/component/database_observability"
+	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/grafana/alloy/internal/util/syncbuffer"
 )
 
@@ -2252,7 +2252,7 @@ func TestNewExplainPlan(t *testing.T) {
 	require.NoError(t, err)
 	defer db.Close()
 
-	logger := log.NewNopLogger()
+	logger := logging.NewSlogNop()
 	entryHandler := loki.NewCollectingHandler()
 	defer entryHandler.Stop()
 
@@ -2520,7 +2520,7 @@ func TestExplainPlan_PopulateQueryCache(t *testing.T) {
 	lokiClient := loki.NewCollectingHandler()
 	defer lokiClient.Stop()
 
-	logger := log.NewNopLogger()
+	logger := logging.NewSlogNop()
 
 	pre17ver, err := semver.ParseTolerant("14.1")
 	require.NoError(t, err)
@@ -2754,7 +2754,7 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 	require.NoError(t, err)
 	defer db.Close()
 
-	logger := log.NewNopLogger()
+	logger := logging.NewSlogNop()
 
 	post17ver, err := semver.ParseTolerant("17.0")
 	require.NoError(t, err)
@@ -2794,6 +2794,12 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 		defer lokiClient.Stop()
 
 		logBuffer := syncbuffer.Buffer{}
+		logger, err := logging.New(&logBuffer, logging.Options{
+			Level:  logging.LevelDebug,
+			Format: logging.FormatLogfmt,
+		})
+		require.NoError(t, err)
+		slogger := logger.Slog()
 
 		t.Run("skips truncated queries", func(t *testing.T) {
 			lokiClient.Clear()
@@ -2815,7 +2821,7 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 				finishedQueryCache: map[string]*queryInfo{},
 				excludeDatabases:   []string{},
 				perScrapeRatio:     1.0,
-				logger:             log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+				logger:             slogger,
 				entryHandler:       lokiClient,
 				currentBatchSize:   1,
 			}
@@ -2888,7 +2894,7 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 				finishedQueryCache: map[string]*queryInfo{},
 				excludeDatabases:   []string{},
 				perScrapeRatio:     1.0,
-				logger:             log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+				logger:             slogger,
 				entryHandler:       lokiClient,
 				currentBatchSize:   6,
 			}
@@ -2941,7 +2947,7 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 				finishedQueryCache: map[string]*queryInfo{},
 				excludeDatabases:   []string{},
 				perScrapeRatio:     1.0,
-				logger:             log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+				logger:             slogger,
 				currentBatchSize:   1,
 				entryHandler:       lokiClient,
 			}
@@ -3008,7 +3014,7 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 				finishedQueryCache: map[string]*queryInfo{},
 				excludeDatabases:   []string{},
 				perScrapeRatio:     1.0,
-				logger:             log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+				logger:             slogger,
 				currentBatchSize:   1,
 				entryHandler:       lokiClient,
 			}
@@ -3076,7 +3082,7 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 				finishedQueryCache: map[string]*queryInfo{},
 				excludeDatabases:   []string{},
 				perScrapeRatio:     1.0,
-				logger:             log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+				logger:             slogger,
 				currentBatchSize:   1,
 				entryHandler:       lokiClient,
 			}
@@ -3120,6 +3126,7 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 
 			lokiClient.Clear()
 			logBuffer.Reset()
+
 			dbConnFactory := &mockDbConnectionFactory{
 				db:                 db,
 				Mock:               &mock,
@@ -3143,7 +3150,7 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 				finishedQueryCache: map[string]*queryInfo{},
 				excludeDatabases:   []string{},
 				perScrapeRatio:     1.0,
-				logger:             log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+				logger:             slogger,
 				currentBatchSize:   1,
 				entryHandler:       lokiClient,
 			}
@@ -3194,6 +3201,12 @@ func TestExplainPlans_ExcludeDatabases_NoLogSent(t *testing.T) {
 
 	post17ver := semver.MustParse("17.0.0")
 	logBuffer := syncbuffer.Buffer{}
+	logger, err := logging.New(&logBuffer, logging.Options{
+		Level:  logging.LevelDebug,
+		Format: logging.FormatLogfmt,
+	})
+	require.NoError(t, err)
+
 	lokiClient := loki.NewCollectingHandler()
 	defer lokiClient.Stop()
 
@@ -3206,7 +3219,7 @@ func TestExplainPlans_ExcludeDatabases_NoLogSent(t *testing.T) {
 		finishedQueryCache: make(map[string]*queryInfo),
 		excludeDatabases:   []string{"excluded_db"},
 		perScrapeRatio:     1.0,
-		logger:             log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+		logger:             logger.Slog(),
 		entryHandler:       lokiClient,
 	}
 
@@ -3238,6 +3251,12 @@ func TestExplainPlans_ExcludeUsers(t *testing.T) {
 
 	post17ver := semver.MustParse("17.0.0")
 	logBuffer := syncbuffer.Buffer{}
+	logger, err := logging.New(&logBuffer, logging.Options{
+		Level:  logging.LevelDebug,
+		Format: logging.FormatLogfmt,
+	})
+	require.NoError(t, err)
+
 	lokiClient := loki.NewCollectingHandler()
 	defer lokiClient.Stop()
 
@@ -3249,7 +3268,7 @@ func TestExplainPlans_ExcludeUsers(t *testing.T) {
 		finishedQueryCache: make(map[string]*queryInfo),
 		excludeUsers:       []string{"excluded_user"},
 		perScrapeRatio:     1.0,
-		logger:             log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+		logger:             logger.Slog(),
 		entryHandler:       lokiClient,
 	}
 

--- a/internal/component/database_observability/postgres/collector/explain_plans_test.go
+++ b/internal/component/database_observability/postgres/collector/explain_plans_test.go
@@ -2293,6 +2293,7 @@ func TestNewExplainPlan(t *testing.T) {
 	t.Run("version with trailing characters from docker image", func(t *testing.T) {
 		args := ExplainPlansArguments{
 			DBVersion: "16.10 (Debian 16.10-1.pgdg13+1)",
+			Logger:    logger,
 		}
 
 		ep, err := NewExplainPlan(args)
@@ -2306,6 +2307,7 @@ func TestNewExplainPlan(t *testing.T) {
 	t.Run("version with trailing characters from percona helm", func(t *testing.T) {
 		args := ExplainPlansArguments{
 			DBVersion: "17.7 - Percona Server for PostgreSQL 17.7.1",
+			Logger:    logger,
 		}
 
 		ep, err := NewExplainPlan(args)

--- a/internal/component/database_observability/postgres/collector/health_check.go
+++ b/internal/component/database_observability/postgres/collector/health_check.go
@@ -4,18 +4,17 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"sync"
 	"time"
 
-	"github.com/go-kit/log"
 	"go.uber.org/atomic"
 
 	"github.com/grafana/alloy/internal/build"
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/component/database_observability"
 	"github.com/grafana/alloy/internal/runtime/logging"
-	"github.com/grafana/alloy/internal/runtime/logging/level"
 )
 
 const (
@@ -63,7 +62,7 @@ type HealthCheckArguments struct {
 	ExcludeUsers     []string
 	EntryHandler     loki.EntryHandler
 
-	Logger log.Logger
+	Logger *slog.Logger
 }
 
 type HealthCheck struct {
@@ -72,7 +71,7 @@ type HealthCheck struct {
 	excludeDatabases []string
 	excludeUsers     []string
 	entryHandler     loki.EntryHandler
-	logger           log.Logger
+	logger           *slog.Logger
 
 	running *atomic.Bool
 	ctx     context.Context
@@ -87,7 +86,7 @@ func NewHealthCheck(args HealthCheckArguments) (*HealthCheck, error) {
 		excludeDatabases: args.ExcludeDatabases,
 		excludeUsers:     args.ExcludeUsers,
 		entryHandler:     args.EntryHandler,
-		logger:           log.With(args.Logger, "collector", HealthCheckCollector),
+		logger:           args.Logger.With("collector", HealthCheckCollector),
 		running:          &atomic.Bool{},
 	}
 	return h, nil
@@ -98,7 +97,7 @@ func (c *HealthCheck) Name() string {
 }
 
 func (c *HealthCheck) Start(ctx context.Context) error {
-	level.Debug(c.logger).Log("msg", "collector started")
+	c.logger.Debug("collector started")
 
 	c.running.Store(true)
 	ctx, cancel := context.WithCancel(ctx)
@@ -156,7 +155,7 @@ func (c *HealthCheck) fetchHealthChecks(ctx context.Context) {
 	for _, checkFn := range checks {
 		result := checkFn(ctx, c.dbConnection)
 		if result.err != nil {
-			level.Error(c.logger).Log("msg", "health check failed", "check", result.name, "err", result.err)
+			c.logger.Error("health check failed", "check", result.name, "err", result.err)
 			continue
 		}
 		msg := fmt.Sprintf(`check="%s" result="%v" value="%s"`, result.name, result.result, result.value)

--- a/internal/component/database_observability/postgres/collector/health_check_test.go
+++ b/internal/component/database_observability/postgres/collector/health_check_test.go
@@ -1,18 +1,17 @@
 package collector
 
 import (
-	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/util"
 )
 
 func TestHealthCheck(t *testing.T) {
@@ -34,7 +33,7 @@ func TestHealthCheck(t *testing.T) {
 			DB:              db,
 			CollectInterval: 100 * time.Millisecond,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -179,7 +178,7 @@ func TestHealthCheck(t *testing.T) {
 					DB:              db,
 					CollectInterval: 100 * time.Millisecond,
 					EntryHandler:    lokiClient,
-					Logger:          log.NewLogfmtLogger(os.Stderr),
+					Logger:          util.TestAlloyLogger(t).Slog(),
 				})
 				require.NoError(t, err)
 
@@ -251,7 +250,7 @@ func TestHealthCheck(t *testing.T) {
 			ExcludeDatabases: []string{"my_db"},
 			ExcludeUsers:     []string{"my_user"},
 			EntryHandler:     lokiClient,
-			Logger:           log.NewLogfmtLogger(os.Stderr),
+			Logger:           util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 

--- a/internal/component/database_observability/postgres/collector/logs.go
+++ b/internal/component/database_observability/postgres/collector/logs.go
@@ -3,18 +3,17 @@ package collector
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"regexp"
 	"slices"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/atomic"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
-	"github.com/grafana/alloy/internal/runtime/logging/level"
 )
 
 const (
@@ -41,14 +40,14 @@ var supportedSeverities = map[string]struct{}{
 type LogsArguments struct {
 	Receiver         loki.LogsReceiver
 	EntryHandler     loki.EntryHandler
-	Logger           log.Logger
+	Logger           *slog.Logger
 	Registry         *prometheus.Registry
 	ExcludeDatabases []string
 	ExcludeUsers     []string
 }
 
 type Logs struct {
-	logger       log.Logger
+	logger       *slog.Logger
 	entryHandler loki.EntryHandler
 	registry     *prometheus.Registry
 
@@ -76,7 +75,7 @@ func NewLogs(args LogsArguments) (*Logs, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	l := &Logs{
-		logger:           log.With(args.Logger, "collector", LogsCollector),
+		logger:           args.Logger.With("collector", LogsCollector),
 		entryHandler:     args.EntryHandler,
 		registry:         args.Registry,
 		receiver:         args.Receiver,
@@ -127,7 +126,7 @@ func (l *Logs) Receiver() loki.LogsReceiver {
 }
 
 func (l *Logs) Start(ctx context.Context) error {
-	level.Debug(l.logger).Log("msg", "collector started")
+	l.logger.Debug("collector started")
 
 	l.wg.Go(l.run)
 
@@ -148,17 +147,17 @@ func (l *Logs) Stopped() bool {
 }
 
 func (l *Logs) run() {
-	level.Debug(l.logger).Log("msg", "collector running, waiting for log entries")
+	l.logger.Debug("collector running, waiting for log entries")
 
 	for {
 		select {
 		case <-l.ctx.Done():
-			level.Debug(l.logger).Log("msg", "collector stopping")
+			l.logger.Debug("collector stopping")
 			return
 		case entry := <-l.receiver.Chan():
 			if err := l.parseTextLog(entry); err != nil {
-				level.Warn(l.logger).Log(
-					"msg", "failed to process log line",
+				l.logger.Warn(
+					"failed to process log line",
 					"error", err,
 					"line_preview", truncateString(entry.Entry.Line, 100),
 				)
@@ -326,8 +325,8 @@ func (l *Logs) trackInvalidFormat() {
 	now := time.Now()
 	if now.Sub(l.lastFormatWarning) >= time.Minute {
 		if l.validLogsThisMinute == 0 && l.invalidLogsThisMinute > 0 {
-			level.Warn(l.logger).Log(
-				"msg", "all PostgreSQL error logs in the last minute had invalid format",
+			l.logger.Warn(
+				"all PostgreSQL error logs in the last minute had invalid format",
 				"invalid_count", l.invalidLogsThisMinute,
 				"expected_format", expectedLogLinePrefix,
 				"hint", "ensure log_line_prefix is set correctly on PostgreSQL server",

--- a/internal/component/database_observability/postgres/collector/logs_test.go
+++ b/internal/component/database_observability/postgres/collector/logs_test.go
@@ -7,13 +7,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/log"
 	"github.com/grafana/loki/pkg/push"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/runtime/logging"
 )
 
 func TestLogsCollector_ParseRDSFormat(t *testing.T) {
@@ -23,7 +23,7 @@ func TestLogsCollector_ParseRDSFormat(t *testing.T) {
 	collector, err := NewLogs(LogsArguments{
 		Receiver:     loki.NewLogsReceiver(),
 		EntryHandler: entryHandler,
-		Logger:       log.NewNopLogger(),
+		Logger:       logging.NewSlogNop(),
 		Registry:     registry,
 	})
 	require.NoError(t, err)
@@ -130,7 +130,7 @@ func TestLogsCollector_SkipsNonErrors(t *testing.T) {
 	collector, err := NewLogs(LogsArguments{
 		Receiver:     loki.NewLogsReceiver(),
 		EntryHandler: entryHandler,
-		Logger:       log.NewNopLogger(),
+		Logger:       logging.NewSlogNop(),
 		Registry:     registry,
 	})
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestLogsCollector_MetricSumming(t *testing.T) {
 	collector, err := NewLogs(LogsArguments{
 		Receiver:     loki.NewLogsReceiver(),
 		EntryHandler: entryHandler,
-		Logger:       log.NewNopLogger(),
+		Logger:       logging.NewSlogNop(),
 		Registry:     registry,
 	})
 	require.NoError(t, err)
@@ -283,7 +283,7 @@ func TestLogsCollector_InvalidFormat(t *testing.T) {
 	collector, err := NewLogs(LogsArguments{
 		Receiver:     loki.NewLogsReceiver(),
 		EntryHandler: entryHandler,
-		Logger:       log.NewNopLogger(),
+		Logger:       logging.NewSlogNop(),
 		Registry:     registry,
 	})
 	require.NoError(t, err)
@@ -321,7 +321,7 @@ func TestLogsCollector_EmptyUserAndDatabase(t *testing.T) {
 	collector, err := NewLogs(LogsArguments{
 		Receiver:     loki.NewLogsReceiver(),
 		EntryHandler: entryHandler,
-		Logger:       log.NewNopLogger(),
+		Logger:       logging.NewSlogNop(),
 		Registry:     registry,
 	})
 	require.NoError(t, err)
@@ -386,7 +386,7 @@ func TestLogsCollector_StartStop(t *testing.T) {
 	collector, err := NewLogs(LogsArguments{
 		Receiver:     loki.NewLogsReceiver(),
 		EntryHandler: entryHandler,
-		Logger:       log.NewNopLogger(),
+		Logger:       logging.NewSlogNop(),
 		Registry:     prometheus.NewRegistry(),
 	})
 	require.NoError(t, err)
@@ -450,7 +450,7 @@ func TestLogsCollector_SQLStateExtraction(t *testing.T) {
 	collector, err := NewLogs(LogsArguments{
 		Receiver:     loki.NewLogsReceiver(),
 		EntryHandler: entryHandler,
-		Logger:       log.NewNopLogger(),
+		Logger:       logging.NewSlogNop(),
 		Registry:     registry,
 	})
 	require.NoError(t, err)
@@ -563,7 +563,7 @@ func TestLogsCollector_SkipsHistoricalLogs(t *testing.T) {
 	collector, err := NewLogs(LogsArguments{
 		Receiver:     loki.NewLogsReceiver(),
 		EntryHandler: entryHandler,
-		Logger:       log.NewNopLogger(),
+		Logger:       logging.NewSlogNop(),
 		Registry:     registry,
 	})
 	require.NoError(t, err)
@@ -634,7 +634,7 @@ func TestLogsCollector_SkipsOnlyHistoricalLogs(t *testing.T) {
 	collector, err := NewLogs(LogsArguments{
 		Receiver:     loki.NewLogsReceiver(),
 		EntryHandler: entryHandler,
-		Logger:       log.NewNopLogger(),
+		Logger:       logging.NewSlogNop(),
 		Registry:     registry,
 	})
 	require.NoError(t, err)
@@ -680,7 +680,7 @@ func TestLogsCollector_ExcludeDatabases(t *testing.T) {
 	collector, err := NewLogs(LogsArguments{
 		Receiver:         loki.NewLogsReceiver(),
 		EntryHandler:     entryHandler,
-		Logger:           log.NewNopLogger(),
+		Logger:           logging.NewSlogNop(),
 		Registry:         registry,
 		ExcludeDatabases: []string{"excluded_db"},
 	})
@@ -727,7 +727,7 @@ func TestLogsCollector_ExcludeUsers(t *testing.T) {
 	collector, err := NewLogs(LogsArguments{
 		Receiver:     loki.NewLogsReceiver(),
 		EntryHandler: entryHandler,
-		Logger:       log.NewNopLogger(),
+		Logger:       logging.NewSlogNop(),
 		Registry:     registry,
 		ExcludeUsers: []string{"excluded_user"},
 	})

--- a/internal/component/database_observability/postgres/collector/query_details.go
+++ b/internal/component/database_observability/postgres/collector/query_details.go
@@ -4,18 +4,17 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/DataDog/go-sqllexer"
-	"github.com/go-kit/log"
 	"go.uber.org/atomic"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/component/database_observability"
 	"github.com/grafana/alloy/internal/runtime/logging"
-	"github.com/grafana/alloy/internal/runtime/logging/level"
 )
 
 const (
@@ -54,7 +53,7 @@ type QueryDetailsArguments struct {
 	EntryHandler     loki.EntryHandler
 	TableRegistry    *TableRegistry
 
-	Logger log.Logger
+	Logger *slog.Logger
 }
 
 type QueryDetails struct {
@@ -67,7 +66,7 @@ type QueryDetails struct {
 	tableRegistry    *TableRegistry
 	normalizer       *sqllexer.Normalizer
 
-	logger  log.Logger
+	logger  *slog.Logger
 	running *atomic.Bool
 	ctx     context.Context
 	cancel  context.CancelFunc
@@ -84,7 +83,7 @@ func NewQueryDetails(args QueryDetailsArguments) (*QueryDetails, error) {
 		entryHandler:     args.EntryHandler,
 		tableRegistry:    args.TableRegistry,
 		normalizer:       sqllexer.NewNormalizer(sqllexer.WithCollectTables(true), sqllexer.WithCollectComments(true), sqllexer.WithKeepIdentifierQuotation(true)),
-		logger:           log.With(args.Logger, "collector", QueryDetailsCollector),
+		logger:           args.Logger.With("collector", QueryDetailsCollector),
 		running:          &atomic.Bool{},
 	}, nil
 }
@@ -94,7 +93,7 @@ func (c *QueryDetails) Name() string {
 }
 
 func (c *QueryDetails) Start(ctx context.Context) error {
-	level.Debug(c.logger).Log("msg", "collector started")
+	c.logger.Debug("collector started")
 
 	c.running.Store(true)
 	ctx, cancel := context.WithCancel(ctx)
@@ -109,7 +108,7 @@ func (c *QueryDetails) Start(ctx context.Context) error {
 
 		for {
 			if err := c.fetchAndAssociate(c.ctx); err != nil {
-				level.Error(c.logger).Log("msg", "collector error", "err", err)
+				c.logger.Error("collector error", "err", err)
 			}
 
 			select {
@@ -150,13 +149,13 @@ func (c *QueryDetails) fetchAndAssociate(ctx context.Context) error {
 		var databaseName database
 		err := rs.Scan(&queryID, &queryText, &databaseName)
 		if err != nil {
-			level.Error(c.logger).Log("msg", "failed to scan result set for pg_stat_statements", "err", err)
+			c.logger.Error("failed to scan result set for pg_stat_statements", "err", err)
 			continue
 		}
 
 		queryText, err = removeComments(c.normalizer, queryText)
 		if err != nil {
-			level.Error(c.logger).Log("msg", "failed to remove comments", "err", err)
+			c.logger.Error("failed to remove comments", "err", err)
 			continue
 		}
 
@@ -168,7 +167,7 @@ func (c *QueryDetails) fetchAndAssociate(ctx context.Context) error {
 
 		tables, err := tokenizeTableNames(c.normalizer, queryText)
 		if err != nil {
-			level.Error(c.logger).Log("msg", "failed to tokenize table names", "err", err)
+			c.logger.Error("failed to tokenize table names", "err", err)
 			continue
 		}
 
@@ -188,7 +187,7 @@ func (c *QueryDetails) fetchAndAssociate(ctx context.Context) error {
 	}
 
 	if err := rs.Err(); err != nil {
-		level.Error(c.logger).Log("msg", "failed to iterate over result set", "err", err)
+		c.logger.Error("failed to iterate over result set", "err", err)
 		return err
 	}
 

--- a/internal/component/database_observability/postgres/collector/query_details_test.go
+++ b/internal/component/database_observability/postgres/collector/query_details_test.go
@@ -3,18 +3,17 @@ package collector
 import (
 	"database/sql/driver"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/DataDog/go-sqllexer"
-	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/util"
 )
 
 func TestQueryDetails(t *testing.T) {
@@ -503,7 +502,7 @@ func TestQueryDetails(t *testing.T) {
 				StatementsLimit: 100,
 				EntryHandler:    lokiClient,
 				TableRegistry:   tc.tableRegistry,
-				Logger:          log.NewLogfmtLogger(os.Stderr),
+				Logger:          util.TestAlloyLogger(t).Slog(),
 			})
 			require.NoError(t, err)
 			require.NotNil(t, collector)
@@ -565,7 +564,7 @@ func TestQueryDetails_SQLDriverErrors(t *testing.T) {
 			CollectInterval: time.Second,
 			StatementsLimit: 100,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -629,7 +628,7 @@ func TestQueryDetails_SQLDriverErrors(t *testing.T) {
 			CollectInterval: time.Second,
 			StatementsLimit: 100,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -689,7 +688,7 @@ func TestQueryDetails_SQLDriverErrors(t *testing.T) {
 			CollectInterval: time.Second,
 			StatementsLimit: 100,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -911,7 +910,7 @@ func TestQueryDetails_ExcludeDatabases(t *testing.T) {
 		StatementsLimit:  100,
 		ExcludeDatabases: []string{"excluded_database"},
 		EntryHandler:     lokiClient,
-		Logger:           log.NewLogfmtLogger(os.Stderr),
+		Logger:           util.TestAlloyLogger(t).Slog(),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, collector)
@@ -967,7 +966,7 @@ func TestQueryDetails_ExcludeUsers(t *testing.T) {
 		StatementsLimit: 100,
 		ExcludeUsers:    []string{"excluded_user"},
 		EntryHandler:    lokiClient,
-		Logger:          log.NewLogfmtLogger(os.Stderr),
+		Logger:          util.TestAlloyLogger(t).Slog(),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, collector)

--- a/internal/component/database_observability/postgres/collector/query_samples.go
+++ b/internal/component/database_observability/postgres/collector/query_samples.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
 	"slices"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/go-kit/log"
 	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/lib/pq"
 	"go.uber.org/atomic"
@@ -17,7 +17,6 @@ import (
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/component/database_observability"
 	"github.com/grafana/alloy/internal/runtime/logging"
-	"github.com/grafana/alloy/internal/runtime/logging/level"
 )
 
 const (
@@ -108,7 +107,7 @@ type QuerySamplesArguments struct {
 	ExcludeDatabases              []string
 	ExcludeUsers                  []string
 	EntryHandler                  loki.EntryHandler
-	Logger                        log.Logger
+	Logger                        *slog.Logger
 	DisableQueryRedaction         bool
 	ExcludeCurrentUser            bool
 	EnablePreClassifiedWaitEvents bool
@@ -124,7 +123,7 @@ type QuerySamples struct {
 	excludeCurrentUser            bool
 	enablePreClassifiedWaitEvents bool
 
-	logger  log.Logger
+	logger  *slog.Logger
 	running *atomic.Bool
 	ctx     context.Context
 	cancel  context.CancelFunc
@@ -239,7 +238,7 @@ func NewQuerySamples(args QuerySamplesArguments) (*QuerySamples, error) {
 		disableQueryRedaction:         args.DisableQueryRedaction,
 		excludeCurrentUser:            args.ExcludeCurrentUser,
 		enablePreClassifiedWaitEvents: args.EnablePreClassifiedWaitEvents,
-		logger:                        log.With(args.Logger, "collector", QuerySamplesCollector),
+		logger:                        args.Logger.With("collector", QuerySamplesCollector),
 		running:                       &atomic.Bool{},
 		samples:                       map[SampleKey]*SampleState{},
 		idleEmitted:                   expirable.NewLRU[SampleKey, struct{}](emittedCacheSize, nil, emittedCacheTTL),
@@ -252,9 +251,9 @@ func (c *QuerySamples) Name() string {
 
 func (c *QuerySamples) Start(ctx context.Context) error {
 	if c.disableQueryRedaction {
-		level.Warn(c.logger).Log("msg", "collector started with query redaction disabled. SQL text in query samples may include query parameters.")
+		c.logger.Warn("collector started with query redaction disabled. SQL text in query samples may include query parameters.")
 	} else {
-		level.Debug(c.logger).Log("msg", "collector started")
+		c.logger.Debug("collector started")
 	}
 
 	c.running.Store(true)
@@ -270,7 +269,7 @@ func (c *QuerySamples) Start(ctx context.Context) error {
 
 		for {
 			if err := c.fetchQuerySample(c.ctx); err != nil {
-				level.Error(c.logger).Log("msg", "collector error", "err", err)
+				c.logger.Error("collector error", "err", err)
 			}
 
 			select {
@@ -322,13 +321,13 @@ func (c *QuerySamples) fetchQuerySample(ctx context.Context) error {
 	for rows.Next() {
 		sample, scanErr := c.scanRow(rows)
 		if scanErr != nil {
-			level.Error(c.logger).Log("msg", "failed to scan pg_stat_activity", "err", scanErr)
+			c.logger.Error("failed to scan pg_stat_activity", "err", scanErr)
 			continue
 		}
 
 		key, procErr := c.processRow(sample)
 		if procErr != nil {
-			level.Debug(c.logger).Log("msg", "invalid pg_stat_activity set", "queryid", sample.QueryID.Int64, "err", procErr)
+			c.logger.Debug("invalid pg_stat_activity set", "queryid", sample.QueryID.Int64, "err", procErr)
 			continue
 		}
 
@@ -356,7 +355,7 @@ func (c *QuerySamples) fetchQuerySample(ctx context.Context) error {
 	}
 
 	if err := rows.Err(); err != nil {
-		level.Error(c.logger).Log("msg", "failed to iterate pg_stat_activity rows", "err", err)
+		c.logger.Error("failed to iterate pg_stat_activity rows", "err", err)
 		return err
 	}
 

--- a/internal/component/database_observability/postgres/collector/query_samples_test.go
+++ b/internal/component/database_observability/postgres/collector/query_samples_test.go
@@ -1540,7 +1540,7 @@ func TestQuerySamples_WaitEventBoundedByPriorScrape(t *testing.T) {
 		DB:                 db,
 		CollectInterval:    time.Millisecond,
 		EntryHandler:       lokiClient,
-		Logger:             log.NewNopLogger(),
+		Logger:             logging.NewSlogNop(),
 		ExcludeCurrentUser: true,
 	})
 	require.NoError(t, err)

--- a/internal/component/database_observability/postgres/collector/query_samples_test.go
+++ b/internal/component/database_observability/postgres/collector/query_samples_test.go
@@ -10,13 +10,13 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-kit/log"
 	"github.com/lib/pq"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/grafana/alloy/internal/util/syncbuffer"
 )
 
@@ -156,6 +156,12 @@ func TestQuerySamples_FetchQuerySamples(t *testing.T) {
 			defer db.Close()
 
 			logBuffer := syncbuffer.Buffer{}
+			logger, err := logging.New(&logBuffer, logging.Options{
+				Level:  logging.LevelDebug,
+				Format: logging.FormatLogfmt,
+			})
+			require.NoError(t, err)
+
 			lokiClient := loki.NewCollectingHandler()
 			defer lokiClient.Stop()
 
@@ -163,7 +169,7 @@ func TestQuerySamples_FetchQuerySamples(t *testing.T) {
 				DB:                    db,
 				CollectInterval:       time.Millisecond,
 				EntryHandler:          lokiClient,
-				Logger:                log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+				Logger:                logger.Slog(),
 				DisableQueryRedaction: tc.disableQueryRedaction,
 				ExcludeCurrentUser:    true,
 			})
@@ -275,6 +281,12 @@ func TestQuerySamples_FetchQuerySamples_ErrorCases(t *testing.T) {
 			defer db.Close()
 
 			logBuffer := syncbuffer.Buffer{}
+			logger, err := logging.New(&logBuffer, logging.Options{
+				Level:  logging.LevelDebug,
+				Format: logging.FormatLogfmt,
+			})
+			require.NoError(t, err)
+
 			lokiClient := loki.NewCollectingHandler()
 			defer lokiClient.Stop()
 
@@ -282,7 +294,7 @@ func TestQuerySamples_FetchQuerySamples_ErrorCases(t *testing.T) {
 				DB:                    db,
 				CollectInterval:       time.Millisecond,
 				EntryHandler:          lokiClient,
-				Logger:                log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+				Logger:                logger.Slog(),
 				DisableQueryRedaction: tc.disableQueryRedaction,
 				ExcludeCurrentUser:    true,
 			})
@@ -344,6 +356,12 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 		defer db.Close()
 
 		logBuffer := syncbuffer.Buffer{}
+		logger, err := logging.New(&logBuffer, logging.Options{
+			Level:  logging.LevelDebug,
+			Format: logging.FormatLogfmt,
+		})
+		require.NoError(t, err)
+
 		lokiClient := loki.NewCollectingHandler()
 		defer lokiClient.Stop()
 
@@ -351,7 +369,7 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 			DB:                    db,
 			CollectInterval:       time.Millisecond,
 			EntryHandler:          lokiClient,
-			Logger:                log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+			Logger:                logger.Slog(),
 			DisableQueryRedaction: true,
 			ExcludeCurrentUser:    true,
 		})
@@ -402,6 +420,12 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 		defer db.Close()
 
 		logBuffer := syncbuffer.Buffer{}
+		logger, err := logging.New(&logBuffer, logging.Options{
+			Level:  logging.LevelDebug,
+			Format: logging.FormatLogfmt,
+		})
+		require.NoError(t, err)
+
 		lokiClient := loki.NewCollectingHandler()
 		defer lokiClient.Stop()
 
@@ -409,7 +433,7 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 			DB:                    db,
 			CollectInterval:       time.Millisecond,
 			EntryHandler:          lokiClient,
-			Logger:                log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+			Logger:                logger.Slog(),
 			DisableQueryRedaction: true,
 			ExcludeCurrentUser:    true,
 		})
@@ -469,6 +493,12 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 		defer db.Close()
 
 		logBuffer := syncbuffer.Buffer{}
+		logger, err := logging.New(&logBuffer, logging.Options{
+			Level:  logging.LevelDebug,
+			Format: logging.FormatLogfmt,
+		})
+		require.NoError(t, err)
+
 		lokiClient := loki.NewCollectingHandler()
 		defer lokiClient.Stop()
 
@@ -476,7 +506,7 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 			DB:                    db,
 			CollectInterval:       time.Millisecond,
 			EntryHandler:          lokiClient,
-			Logger:                log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+			Logger:                logger.Slog(),
 			DisableQueryRedaction: true,
 			ExcludeCurrentUser:    true,
 		})
@@ -537,6 +567,12 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 		defer db.Close()
 
 		logBuffer := syncbuffer.Buffer{}
+		logger, err := logging.New(&logBuffer, logging.Options{
+			Level:  logging.LevelDebug,
+			Format: logging.FormatLogfmt,
+		})
+		require.NoError(t, err)
+
 		lokiClient := loki.NewCollectingHandler()
 		defer lokiClient.Stop()
 
@@ -544,7 +580,7 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 			DB:                    db,
 			CollectInterval:       time.Millisecond,
 			EntryHandler:          lokiClient,
-			Logger:                log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+			Logger:                logger.Slog(),
 			DisableQueryRedaction: true,
 			ExcludeCurrentUser:    true,
 		})
@@ -605,6 +641,12 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 		defer db.Close()
 
 		logBuffer := syncbuffer.Buffer{}
+		logger, err := logging.New(&logBuffer, logging.Options{
+			Level:  logging.LevelDebug,
+			Format: logging.FormatLogfmt,
+		})
+		require.NoError(t, err)
+
 		lokiClient := loki.NewCollectingHandler()
 		defer lokiClient.Stop()
 
@@ -612,7 +654,7 @@ func TestQuerySamples_FinalizationScenarios(t *testing.T) {
 			DB:                    db,
 			CollectInterval:       time.Millisecond,
 			EntryHandler:          lokiClient,
-			Logger:                log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+			Logger:                logger.Slog(),
 			DisableQueryRedaction: true,
 			ExcludeCurrentUser:    true,
 		})
@@ -702,6 +744,12 @@ func TestQuerySamples_IdleScenarios(t *testing.T) {
 		defer db.Close()
 
 		logBuffer := syncbuffer.Buffer{}
+		logger, err := logging.New(&logBuffer, logging.Options{
+			Level:  logging.LevelDebug,
+			Format: logging.FormatLogfmt,
+		})
+		require.NoError(t, err)
+
 		lokiClient := loki.NewCollectingHandler()
 		defer lokiClient.Stop()
 
@@ -709,7 +757,7 @@ func TestQuerySamples_IdleScenarios(t *testing.T) {
 			DB:                    db,
 			CollectInterval:       time.Millisecond,
 			EntryHandler:          lokiClient,
-			Logger:                log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+			Logger:                logger.Slog(),
 			DisableQueryRedaction: true,
 			ExcludeCurrentUser:    true,
 		})
@@ -768,6 +816,12 @@ func TestQuerySamples_IdleScenarios(t *testing.T) {
 		defer db.Close()
 
 		logBuffer := syncbuffer.Buffer{}
+		logger, err := logging.New(&logBuffer, logging.Options{
+			Level:  logging.LevelDebug,
+			Format: logging.FormatLogfmt,
+		})
+		require.NoError(t, err)
+
 		lokiClient := loki.NewCollectingHandler()
 		defer lokiClient.Stop()
 
@@ -775,7 +829,7 @@ func TestQuerySamples_IdleScenarios(t *testing.T) {
 			DB:                    db,
 			CollectInterval:       time.Millisecond,
 			EntryHandler:          lokiClient,
-			Logger:                log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+			Logger:                logger.Slog(),
 			DisableQueryRedaction: true,
 			ExcludeCurrentUser:    true,
 		})
@@ -841,6 +895,12 @@ func TestQuerySamples_IdleScenarios(t *testing.T) {
 		defer db.Close()
 
 		logBuffer := syncbuffer.Buffer{}
+		logger, err := logging.New(&logBuffer, logging.Options{
+			Level:  logging.LevelDebug,
+			Format: logging.FormatLogfmt,
+		})
+		require.NoError(t, err)
+
 		lokiClient := loki.NewCollectingHandler()
 		defer lokiClient.Stop()
 
@@ -848,7 +908,7 @@ func TestQuerySamples_IdleScenarios(t *testing.T) {
 			DB:                    db,
 			CollectInterval:       time.Millisecond,
 			EntryHandler:          lokiClient,
-			Logger:                log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+			Logger:                logger.Slog(),
 			DisableQueryRedaction: true,
 			ExcludeCurrentUser:    true,
 		})
@@ -914,6 +974,12 @@ func TestQuerySamples_IdleScenarios(t *testing.T) {
 		defer db.Close()
 
 		logBuffer := syncbuffer.Buffer{}
+		logger, err := logging.New(&logBuffer, logging.Options{
+			Level:  logging.LevelDebug,
+			Format: logging.FormatLogfmt,
+		})
+		require.NoError(t, err)
+
 		lokiClient := loki.NewCollectingHandler()
 		defer lokiClient.Stop()
 
@@ -921,7 +987,7 @@ func TestQuerySamples_IdleScenarios(t *testing.T) {
 			DB:                    db,
 			CollectInterval:       time.Millisecond,
 			EntryHandler:          lokiClient,
-			Logger:                log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+			Logger:                logger.Slog(),
 			DisableQueryRedaction: true,
 			ExcludeCurrentUser:    true,
 		})
@@ -1052,6 +1118,12 @@ func TestQuerySamples_ExcludeCurrentUser(t *testing.T) {
 			defer db.Close()
 
 			logBuffer := syncbuffer.Buffer{}
+			logger, err := logging.New(&logBuffer, logging.Options{
+				Level:  logging.LevelDebug,
+				Format: logging.FormatLogfmt,
+			})
+			require.NoError(t, err)
+
 			lokiClient := loki.NewCollectingHandler()
 			defer lokiClient.Stop()
 
@@ -1059,7 +1131,7 @@ func TestQuerySamples_ExcludeCurrentUser(t *testing.T) {
 				DB:                 db,
 				CollectInterval:    time.Millisecond,
 				EntryHandler:       lokiClient,
-				Logger:             log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+				Logger:             logger.Slog(),
 				ExcludeCurrentUser: tc.excludeCurrentUser,
 			})
 			require.NoError(t, err)
@@ -1123,6 +1195,12 @@ func TestQuerySamples_ExcludeDatabases(t *testing.T) {
 	defer db.Close()
 
 	logBuffer := syncbuffer.Buffer{}
+	logger, err := logging.New(&logBuffer, logging.Options{
+		Level:  logging.LevelDebug,
+		Format: logging.FormatLogfmt,
+	})
+	require.NoError(t, err)
+
 	lokiClient := loki.NewCollectingHandler()
 	defer lokiClient.Stop()
 
@@ -1132,7 +1210,7 @@ func TestQuerySamples_ExcludeDatabases(t *testing.T) {
 		CollectInterval:  time.Millisecond,
 		ExcludeDatabases: []string{"excluded_db"},
 		EntryHandler:     lokiClient,
-		Logger:           log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+		Logger:           logger.Slog(),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, sampleCollector)
@@ -1203,6 +1281,12 @@ func TestQuerySamples_ExcludeUsers(t *testing.T) {
 	defer db.Close()
 
 	logBuffer := syncbuffer.Buffer{}
+	logger, err := logging.New(&logBuffer, logging.Options{
+		Level:  logging.LevelDebug,
+		Format: logging.FormatLogfmt,
+	})
+	require.NoError(t, err)
+
 	lokiClient := loki.NewCollectingHandler()
 	defer lokiClient.Stop()
 
@@ -1211,7 +1295,7 @@ func TestQuerySamples_ExcludeUsers(t *testing.T) {
 		CollectInterval: time.Millisecond,
 		ExcludeUsers:    []string{"excluded_user"},
 		EntryHandler:    lokiClient,
-		Logger:          log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+		Logger:          logger.Slog(),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, sampleCollector)
@@ -1276,6 +1360,12 @@ func TestQuerySamples_WaitEvents_PreClassifiedFlag(t *testing.T) {
 		defer db.Close()
 
 		logBuffer := syncbuffer.Buffer{}
+		logger, err := logging.New(&logBuffer, logging.Options{
+			Level:  logging.LevelDebug,
+			Format: logging.FormatLogfmt,
+		})
+		require.NoError(t, err)
+
 		lokiClient := loki.NewCollectingHandler()
 		defer lokiClient.Stop()
 
@@ -1283,7 +1373,7 @@ func TestQuerySamples_WaitEvents_PreClassifiedFlag(t *testing.T) {
 			DB:                            db,
 			CollectInterval:               time.Millisecond,
 			EntryHandler:                  lokiClient,
-			Logger:                        log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+			Logger:                        logger.Slog(),
 			ExcludeCurrentUser:            true,
 			EnablePreClassifiedWaitEvents: false,
 		})
@@ -1333,6 +1423,12 @@ func TestQuerySamples_WaitEvents_PreClassifiedFlag(t *testing.T) {
 		defer db.Close()
 
 		logBuffer := syncbuffer.Buffer{}
+		logger, err := logging.New(&logBuffer, logging.Options{
+			Level:  logging.LevelDebug,
+			Format: logging.FormatLogfmt,
+		})
+		require.NoError(t, err)
+
 		lokiClient := loki.NewCollectingHandler()
 		defer lokiClient.Stop()
 
@@ -1340,7 +1436,7 @@ func TestQuerySamples_WaitEvents_PreClassifiedFlag(t *testing.T) {
 			DB:                            db,
 			CollectInterval:               time.Millisecond,
 			EntryHandler:                  lokiClient,
-			Logger:                        log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+			Logger:                        logger.Slog(),
 			ExcludeCurrentUser:            true,
 			EnablePreClassifiedWaitEvents: true,
 		})

--- a/internal/component/database_observability/postgres/collector/schema_details.go
+++ b/internal/component/database_observability/postgres/collector/schema_details.go
@@ -6,11 +6,11 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/go-kit/log"
 	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/lib/pq"
 	"go.uber.org/atomic"
@@ -18,7 +18,6 @@ import (
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/component/database_observability"
 	"github.com/grafana/alloy/internal/runtime/logging"
-	"github.com/grafana/alloy/internal/runtime/logging/level"
 )
 
 const (
@@ -317,7 +316,7 @@ type SchemaDetailsArguments struct {
 	CacheSize    int
 	CacheTTL     time.Duration
 
-	Logger log.Logger
+	Logger *slog.Logger
 
 	dbConnectionFactory databaseConnectionFactory
 }
@@ -337,7 +336,7 @@ type SchemaDetails struct {
 
 	tableRegistry *TableRegistry
 
-	logger  log.Logger
+	logger  *slog.Logger
 	running *atomic.Bool
 	ctx     context.Context
 	cancel  context.CancelFunc
@@ -358,7 +357,7 @@ func NewSchemaDetails(args SchemaDetailsArguments) (*SchemaDetails, error) {
 		excludeDatabases:    args.ExcludeDatabases,
 		entryHandler:        args.EntryHandler,
 		tableRegistry:       NewTableRegistry(),
-		logger:              log.With(args.Logger, "collector", SchemaDetailsCollector),
+		logger:              args.Logger.With("collector", SchemaDetailsCollector),
 		running:             &atomic.Bool{},
 	}
 
@@ -378,7 +377,7 @@ func (c *SchemaDetails) GetTableRegistry() *TableRegistry {
 }
 
 func (c *SchemaDetails) Start(ctx context.Context) error {
-	level.Debug(c.logger).Log("msg", "collector started")
+	c.logger.Debug("collector started")
 
 	c.running.Store(true)
 	ctx, cancel := context.WithCancel(ctx)
@@ -393,7 +392,7 @@ func (c *SchemaDetails) Start(ctx context.Context) error {
 
 		for {
 			if err := c.extractNames(c.ctx); err != nil {
-				level.Error(c.logger).Log("msg", "collector error", "err", err)
+				c.logger.Error("collector error", "err", err)
 			}
 
 			select {
@@ -423,7 +422,7 @@ func (c *SchemaDetails) getAllDatabases(ctx context.Context) ([]string, error) {
 	query := fmt.Sprintf(selectAllDatabases, buildExcludedDatabasesClause(c.excludeDatabases))
 	rows, err := c.initialConnection.QueryContext(ctx, query)
 	if err != nil {
-		level.Error(c.logger).Log("msg", "failed to discover databases", "err", err)
+		c.logger.Error("failed to discover databases", "err", err)
 		return nil, fmt.Errorf("failed to discover databases: %w", err)
 	}
 	defer rows.Close()
@@ -432,14 +431,14 @@ func (c *SchemaDetails) getAllDatabases(ctx context.Context) ([]string, error) {
 	for rows.Next() {
 		var datname string
 		if err := rows.Scan(&datname); err != nil {
-			level.Error(c.logger).Log("msg", "failed to scan database name", "err", err)
+			c.logger.Error("failed to scan database name", "err", err)
 			continue
 		}
 		databases = append(databases, datname)
 	}
 
 	if err := rows.Err(); err != nil {
-		level.Error(c.logger).Log("msg", "error iterating database rows", "err", err)
+		c.logger.Error("error iterating database rows", "err", err)
 		return nil, fmt.Errorf("error iterating database rows: %w", err)
 	}
 
@@ -457,7 +456,7 @@ func (c *SchemaDetails) extractSchemas(ctx context.Context, dbName string, dbCon
 	for schemaRs.Next() {
 		var schema string
 		if err := schemaRs.Scan(&schema); err != nil {
-			level.Error(c.logger).Log("msg", "failed to scan pg_namespace", "datname", dbName, "err", err)
+			c.logger.Error("failed to scan pg_namespace", "datname", dbName, "err", err)
 			break
 		}
 		schemas = append(schemas, schema)
@@ -468,7 +467,7 @@ func (c *SchemaDetails) extractSchemas(ctx context.Context, dbName string, dbCon
 	}
 
 	if len(schemas) == 0 {
-		level.Info(c.logger).Log("msg", "no schema detected from pg_namespace", "datname", dbName)
+		c.logger.Info("no schema detected from pg_namespace", "datname", dbName)
 		return nil
 	}
 
@@ -477,7 +476,7 @@ func (c *SchemaDetails) extractSchemas(ctx context.Context, dbName string, dbCon
 	for _, schemaName := range schemas {
 		rs, err := dbConnection.QueryContext(ctx, selectTableNames, schemaName)
 		if err != nil {
-			level.Error(c.logger).Log("msg", "failed to query tables", "datname", dbName, "schema", schemaName, "err", err)
+			c.logger.Error("failed to query tables", "datname", dbName, "schema", schemaName, "err", err)
 			break
 		}
 		defer rs.Close()
@@ -485,7 +484,7 @@ func (c *SchemaDetails) extractSchemas(ctx context.Context, dbName string, dbCon
 		for rs.Next() {
 			var tableName string
 			if err := rs.Scan(&tableName); err != nil {
-				level.Error(c.logger).Log("msg", "failed to scan tables", "datname", dbName, "schema", schemaName, "err", err)
+				c.logger.Error("failed to scan tables", "datname", dbName, "schema", schemaName, "err", err)
 				break
 			}
 			tables = append(tables, &tableInfo{
@@ -510,7 +509,7 @@ func (c *SchemaDetails) extractSchemas(ctx context.Context, dbName string, dbCon
 	c.tableRegistry.SetTablesForDatabase(database(dbName), tables)
 
 	if len(tables) == 0 {
-		level.Info(c.logger).Log("msg", "no tables detected from pg_tables", "datname", dbName)
+		c.logger.Info("no tables detected from pg_tables", "datname", dbName)
 		return nil
 	}
 
@@ -528,7 +527,7 @@ func (c *SchemaDetails) extractSchemas(ctx context.Context, dbName string, dbCon
 		if !cacheHit {
 			table, err = c.fetchTableDefinitions(ctx, table, dbConnection)
 			if err != nil {
-				level.Error(c.logger).Log("msg", "failed to get table definitions", "datname", dbName, "schema", table.schema, "table", table.tableName, "err", err)
+				c.logger.Error("failed to get table definitions", "datname", dbName, "schema", table.schema, "table", table.tableName, "err", err)
 				continue
 			}
 			if c.cache != nil {
@@ -552,25 +551,25 @@ func (c *SchemaDetails) extractSchemas(ctx context.Context, dbName string, dbCon
 func (c *SchemaDetails) extractNames(ctx context.Context) error {
 	databases, err := c.getAllDatabases(ctx)
 	if err != nil {
-		level.Error(c.logger).Log("msg", "failed to discover databases", "err", err)
+		c.logger.Error("failed to discover databases", "err", err)
 		return fmt.Errorf("failed to discover databases: %w", err)
 	}
 
 	for _, dbName := range databases {
 		databaseDSN, err := replaceDatabaseNameInDSN(c.dbDSN, dbName)
 		if err != nil {
-			level.Error(c.logger).Log("msg", "failed to create DSN for database", "datname", dbName, "err", err)
+			c.logger.Error("failed to create DSN for database", "datname", dbName, "err", err)
 			continue
 		}
 
 		conn, err := c.dbConnectionFactory(databaseDSN)
 		if err != nil {
-			level.Error(c.logger).Log("msg", "failed to create connection to database", "datname", dbName, "err", err)
+			c.logger.Error("failed to create connection to database", "datname", dbName, "err", err)
 			continue
 		}
 
 		if err := c.extractSchemas(ctx, dbName, conn); err != nil {
-			level.Error(c.logger).Log("msg", "failed to collect schema from database", "datname", dbName, "err", err)
+			c.logger.Error("failed to collect schema from database", "datname", dbName, "err", err)
 			if conn != c.initialConnection {
 				conn.Close()
 			}
@@ -579,7 +578,7 @@ func (c *SchemaDetails) extractNames(ctx context.Context) error {
 
 		if conn != c.initialConnection {
 			if err := conn.Close(); err != nil {
-				level.Warn(c.logger).Log("msg", "failed to close database connection", "datname", dbName, "err", err)
+				c.logger.Warn("failed to close database connection", "datname", dbName, "err", err)
 			}
 		}
 	}
@@ -590,13 +589,13 @@ func (c *SchemaDetails) extractNames(ctx context.Context) error {
 func (c *SchemaDetails) fetchTableDefinitions(ctx context.Context, table *tableInfo, dbConnection *sql.DB) (*tableInfo, error) {
 	spec, err := c.fetchColumnsDefinitions(ctx, table.database, table.schema, table.tableName, dbConnection)
 	if err != nil {
-		level.Error(c.logger).Log("msg", "failed to analyze table spec", "datname", table.database, "schema", table.schema, "table", table.tableName, "err", err)
+		c.logger.Error("failed to analyze table spec", "datname", table.database, "schema", table.schema, "table", table.tableName, "err", err)
 		return table, err
 	}
 
 	jsonSpec, err := json.Marshal(spec)
 	if err != nil {
-		level.Error(c.logger).Log("msg", "failed to marshal table spec", "datname", table.database, "schema", table.schema, "table", table.tableName, "err", err)
+		c.logger.Error("failed to marshal table spec", "datname", table.database, "schema", table.schema, "table", table.tableName, "err", err)
 		return table, err
 	}
 	table.b64TableSpec = base64.StdEncoding.EncodeToString(jsonSpec)
@@ -607,7 +606,7 @@ func (c *SchemaDetails) fetchTableDefinitions(ctx context.Context, table *tableI
 func (c *SchemaDetails) fetchColumnsDefinitions(ctx context.Context, databaseName database, schemaName schema, tableName table, dbConnection *sql.DB) (*tableSpec, error) {
 	colRS, err := dbConnection.QueryContext(ctx, selectColumnNames, schemaName, tableName)
 	if err != nil {
-		level.Error(c.logger).Log("msg", "failed to query table columns", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
+		c.logger.Error("failed to query table columns", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
 		return nil, err
 	}
 	defer colRS.Close()
@@ -619,7 +618,7 @@ func (c *SchemaDetails) fetchColumnsDefinitions(ctx context.Context, databaseNam
 		var columnDefault sql.NullString
 		var notNullable, isPrimaryKey bool
 		if err := colRS.Scan(&columnName, &columnType, &notNullable, &columnDefault, &identityGeneration, &isPrimaryKey); err != nil {
-			level.Error(c.logger).Log("msg", "failed to scan table columns", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
+			c.logger.Error("failed to scan table columns", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
 			return nil, err
 		}
 
@@ -644,13 +643,13 @@ func (c *SchemaDetails) fetchColumnsDefinitions(ctx context.Context, databaseNam
 	}
 
 	if err := colRS.Err(); err != nil {
-		level.Error(c.logger).Log("msg", "failed to iterate over table columns result set", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
+		c.logger.Error("failed to iterate over table columns result set", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
 		return nil, err
 	}
 
 	indexesRS, err := dbConnection.QueryContext(ctx, selectIndexes, schemaName, tableName)
 	if err != nil {
-		level.Error(c.logger).Log("msg", "failed to query indexes", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
+		c.logger.Error("failed to query indexes", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
 		return nil, err
 	}
 	defer indexesRS.Close()
@@ -661,7 +660,7 @@ func (c *SchemaDetails) fetchColumnsDefinitions(ctx context.Context, databaseNam
 		var columns, expressions pq.StringArray
 
 		if err := indexesRS.Scan(&indexName, &indexType, &unique, &columns, &expressions, &hasNullableColumn); err != nil {
-			level.Error(c.logger).Log("msg", "failed to scan indexes", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
+			c.logger.Error("failed to scan indexes", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
 			return nil, err
 		}
 
@@ -679,13 +678,13 @@ func (c *SchemaDetails) fetchColumnsDefinitions(ctx context.Context, databaseNam
 	}
 
 	if err := indexesRS.Err(); err != nil {
-		level.Error(c.logger).Log("msg", "error during iterating over indexes", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
+		c.logger.Error("error during iterating over indexes", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
 		return nil, err
 	}
 
 	fkRS, err := dbConnection.QueryContext(ctx, selectForeignKeys, schemaName, tableName)
 	if err != nil {
-		level.Error(c.logger).Log("msg", "failed to query foreign keys", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
+		c.logger.Error("failed to query foreign keys", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
 		return nil, err
 	}
 	defer fkRS.Close()
@@ -693,7 +692,7 @@ func (c *SchemaDetails) fetchColumnsDefinitions(ctx context.Context, databaseNam
 	for fkRS.Next() {
 		var constraintName, columnName, referencedTableName, referencedColumnName string
 		if err := fkRS.Scan(&constraintName, &columnName, &referencedTableName, &referencedColumnName); err != nil {
-			level.Error(c.logger).Log("msg", "failed to scan foreign keys", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
+			c.logger.Error("failed to scan foreign keys", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
 			return nil, err
 		}
 
@@ -706,7 +705,7 @@ func (c *SchemaDetails) fetchColumnsDefinitions(ctx context.Context, databaseNam
 	}
 
 	if err := fkRS.Err(); err != nil {
-		level.Error(c.logger).Log("msg", "failed to iterate over foreign keys result set", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
+		c.logger.Error("failed to iterate over foreign keys result set", "datname", databaseName, "schema", schemaName, "table", tableName, "err", err)
 		return nil, err
 	}
 

--- a/internal/component/database_observability/postgres/collector/schema_details_test.go
+++ b/internal/component/database_observability/postgres/collector/schema_details_test.go
@@ -5,13 +5,11 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-kit/log"
 	"github.com/lib/pq"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
@@ -19,6 +17,8 @@ import (
 	"go.uber.org/goleak"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/runtime/logging"
+	"github.com/grafana/alloy/internal/util"
 	"github.com/grafana/alloy/internal/util/syncbuffer"
 )
 
@@ -42,7 +42,7 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 			DSN:             "postgres://user:pass@localhost:5432/books_store",
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
 				return db, nil
 			},
@@ -149,7 +149,7 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 			DSN:             "postgres://user:pass@localhost:5432/books_store",
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
 				return db, nil
 			},
@@ -355,7 +355,7 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 			DSN:             "postgres://user:pass@localhost:5432/postgres",
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
 				switch dsn {
 				case "postgres://user:pass@localhost:5432/db1":
@@ -451,7 +451,7 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 			DSN:             "postgres://user:pass@localhost:5432/testdb",
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
 				return db, nil
 			},
@@ -559,12 +559,18 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 		defer lokiClient.Stop()
 
 		logBuffer := syncbuffer.Buffer{}
+		logger, err := logging.New(&logBuffer, logging.Options{
+			Level:  logging.LevelDebug,
+			Format: logging.FormatLogfmt,
+		})
+		require.NoError(t, err)
+
 		collector, err := NewSchemaDetails(SchemaDetailsArguments{
 			DB:              db,
 			DSN:             "postgres://user:pass@localhost:5432/testdb",
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(log.NewSyncWriter(&logBuffer)),
+			Logger:          logger.Slog(),
 			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
 				return db, nil
 			},
@@ -622,7 +628,7 @@ func Test_Postgres_SchemaDetails(t *testing.T) {
 			DSN:             "postgres://user:pass@localhost:5432/testdb",
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
 				return db, nil
 			},
@@ -733,7 +739,7 @@ func Test_Postgres_SchemaDetails_collector_detects_auto_increment_column(t *test
 			DSN:             "postgres://user:pass@localhost:5432/testdb",
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
 				return db, nil
 			},
@@ -839,7 +845,7 @@ func Test_Postgres_SchemaDetails_collector_detects_auto_increment_column(t *test
 			DSN:             "postgres://user:pass@localhost:5432/testdb",
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
 				return db, nil
 			},
@@ -946,7 +952,7 @@ func Test_Postgres_SchemaDetails_collector_detects_auto_increment_column(t *test
 			DSN:             "postgres://user:pass@localhost:5432/testdb",
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
 				return db, nil
 			},
@@ -1055,7 +1061,7 @@ func Test_Postgres_SchemaDetails_caching(t *testing.T) {
 			CacheSize:       256,
 			CacheTTL:        10 * time.Minute,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
 				return db, nil
 			},
@@ -1184,7 +1190,7 @@ func Test_Postgres_SchemaDetails_caching(t *testing.T) {
 			CollectInterval: time.Millisecond,
 			CacheEnabled:    false,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
 				return db, nil
 			},
@@ -1286,7 +1292,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 					RowError(0, fmt.Errorf("row iteration error")))
 
 		collector := &SchemaDetails{
-			logger:            log.NewNopLogger(),
+			logger:            logging.NewSlogNop(),
 			initialConnection: db,
 		}
 		_, err = collector.getAllDatabases(context.Background())
@@ -1309,7 +1315,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 					RowError(0, fmt.Errorf("schema iteration error")))
 
 		collector := &SchemaDetails{
-			logger: log.NewNopLogger(),
+			logger: logging.NewSlogNop(),
 		}
 
 		err = collector.extractSchemas(context.Background(), "testdb", db)
@@ -1327,7 +1333,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 		mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").
 			WillReturnError(fmt.Errorf("column query error"))
 
-		collector := &SchemaDetails{logger: log.NewNopLogger()}
+		collector := &SchemaDetails{logger: logging.NewSlogNop()}
 		_, err = collector.fetchTableDefinitions(context.Background(), &tableInfo{
 			database:  "testdb",
 			schema:    "public",
@@ -1346,7 +1352,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 		defer db.Close()
 
 		collector := &SchemaDetails{
-			logger: log.NewNopLogger(),
+			logger: logging.NewSlogNop(),
 		}
 
 		mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").
@@ -1366,7 +1372,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 		defer db.Close()
 
 		collector := &SchemaDetails{
-			logger: log.NewNopLogger(),
+			logger: logging.NewSlogNop(),
 		}
 
 		mock.ExpectQuery(selectColumnNames).WithArgs("public", "test_table").RowsWillBeClosed().
@@ -1391,7 +1397,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 					AddRow("id", "integer", true, nil, "", true).
 					RowError(0, fmt.Errorf("result set error")))
 
-		collector := &SchemaDetails{logger: log.NewNopLogger()}
+		collector := &SchemaDetails{logger: logging.NewSlogNop()}
 		_, err = collector.fetchColumnsDefinitions(context.Background(), "testdb", "public", "test_table", db)
 
 		require.Error(t, err)
@@ -1410,7 +1416,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 		mock.ExpectQuery(selectIndexes).WithArgs("public", "test_table").
 			WillReturnError(fmt.Errorf("index query error"))
 
-		collector := &SchemaDetails{logger: log.NewNopLogger()}
+		collector := &SchemaDetails{logger: logging.NewSlogNop()}
 		_, err = collector.fetchColumnsDefinitions(context.Background(), "testdb", "public", "test_table", db)
 
 		require.Error(t, err)
@@ -1430,7 +1436,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows([]string{"index_name", "index_type", "unique", "column_names", "expressions"}).
 				AddRow("idx_test", "btree", true, pq.StringArray{"id"}, pq.StringArray{}))
 
-		collector := &SchemaDetails{logger: log.NewNopLogger()}
+		collector := &SchemaDetails{logger: logging.NewSlogNop()}
 		_, err = collector.fetchColumnsDefinitions(context.Background(), "testdb", "public", "test_table", db)
 
 		require.Error(t, err)
@@ -1452,7 +1458,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 					AddRow("idx_test", "btree", true, pq.StringArray{"id"}, pq.StringArray{}, false).
 					RowError(0, fmt.Errorf("result set error")))
 
-		collector := &SchemaDetails{logger: log.NewNopLogger()}
+		collector := &SchemaDetails{logger: logging.NewSlogNop()}
 		_, err = collector.fetchColumnsDefinitions(context.Background(), "testdb", "public", "test_table", db)
 
 		require.Error(t, err)
@@ -1474,7 +1480,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 		mock.ExpectQuery(selectForeignKeys).WithArgs("public", "test_table").
 			WillReturnError(fmt.Errorf("foreign key query error"))
 
-		collector := &SchemaDetails{logger: log.NewNopLogger()}
+		collector := &SchemaDetails{logger: logging.NewSlogNop()}
 		_, err = collector.fetchColumnsDefinitions(context.Background(), "testdb", "public", "test_table", db)
 
 		require.Error(t, err)
@@ -1497,7 +1503,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows([]string{"constraint_name", "column_name", "referenced_table_name"}).
 				AddRow("fk_test", "author_id", "authors"))
 
-		collector := &SchemaDetails{logger: log.NewNopLogger()}
+		collector := &SchemaDetails{logger: logging.NewSlogNop()}
 		_, err = collector.fetchColumnsDefinitions(context.Background(), "testdb", "public", "test_table", db)
 
 		require.Error(t, err)
@@ -1521,7 +1527,7 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 					AddRow("fk_test", "author_id", "authors", "id").
 					RowError(0, fmt.Errorf("result set error")))
 
-		collector := &SchemaDetails{logger: log.NewNopLogger()}
+		collector := &SchemaDetails{logger: logging.NewSlogNop()}
 		_, err = collector.fetchColumnsDefinitions(context.Background(), "testdb", "public", "test_table", db)
 
 		require.Error(t, err)
@@ -1846,7 +1852,7 @@ func Test_SchemaDetails_populates_TableRegistry(t *testing.T) {
 			DSN:             "postgres://user:pass@localhost:5432/testdb",
 			CollectInterval: time.Hour,
 			EntryHandler:    lokiClient,
-			Logger:          log.NewLogfmtLogger(os.Stderr),
+			Logger:          util.TestAlloyLogger(t).Slog(),
 			dbConnectionFactory: func(dsn string) (*sql.DB, error) {
 				return db, nil
 			},
@@ -1969,7 +1975,7 @@ func Test_Postgres_SchemaDetails_ExcludeDatabases(t *testing.T) {
 		ExcludeDatabases: []string{"excluded_database"},
 		EntryHandler:     lokiClient,
 		CacheEnabled:     false,
-		Logger:           log.NewLogfmtLogger(os.Stderr),
+		Logger:           util.TestAlloyLogger(t).Slog(),
 		dbConnectionFactory: func(dsn string) (*sql.DB, error) {
 			return db, nil
 		},

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -28,7 +28,6 @@ import (
 	"github.com/grafana/alloy/internal/component/discovery"
 	exporter_postgres "github.com/grafana/alloy/internal/component/prometheus/exporter/postgres"
 	"github.com/grafana/alloy/internal/featuregate"
-	"github.com/grafana/alloy/internal/runtime/logging/level"
 	http_service "github.com/grafana/alloy/internal/service/http"
 	"github.com/grafana/alloy/syntax"
 	"github.com/grafana/alloy/syntax/alloytypes"
@@ -288,7 +287,7 @@ func new(opts component.Options, args Arguments, openFn func(driverName, dataSou
 
 func (c *Component) Run(ctx context.Context) error {
 	defer func() {
-		level.Info(c.opts.Logger).Log("msg", name+" component shutting down, stopping collectors")
+		c.opts.SLogger.Info(name + " component shutting down, stopping collectors")
 
 		loki.Drain(c.handler, c.fanout, loki.DefaultDrainTimeout, func() {
 			c.mut.Lock()
@@ -327,9 +326,9 @@ func (c *Component) Run(ctx context.Context) error {
 				c.mut.RUnlock()
 
 				if !hasCollectors {
-					level.Debug(c.opts.Logger).Log("msg", "attempting to reconnect to database")
+					c.opts.SLogger.Debug("attempting to reconnect to database")
 					if err := c.tryReconnect(ctx); err != nil {
-						level.Error(c.opts.Logger).Log("msg", "reconnection attempt failed", "err", err)
+						c.opts.SLogger.Error("reconnection attempt failed", "err", err)
 					}
 				}
 			}
@@ -358,7 +357,7 @@ func (c *Component) getBaseTarget() (discovery.Target, error) {
 }
 
 func (c *Component) reportError(errorMsg string, err error) {
-	level.Error(c.opts.Logger).Log("msg", fmt.Sprintf("%s: %+v", errorMsg, err))
+	c.opts.SLogger.Error(fmt.Sprintf("%s: %+v", errorMsg, err))
 	c.healthErr.Store(fmt.Sprintf("%s: %+v", errorMsg, err))
 }
 
@@ -572,7 +571,7 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 
 	logStartError := func(collectorName, action string, err error) {
 		errorString := fmt.Sprintf("failed to %s %s collector: %+v", action, collectorName, err)
-		level.Error(c.opts.Logger).Log("msg", errorString)
+		c.opts.SLogger.Error(errorString)
 		startErrors = append(startErrors, errorString)
 	}
 
@@ -591,7 +590,7 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 			CacheSize:        c.args.SchemaDetailsArguments.CacheSize,
 			CacheTTL:         c.args.SchemaDetailsArguments.CacheTTL,
 			EntryHandler:     entryHandler,
-			Logger:           c.opts.Logger,
+			Logger:           c.opts.SLogger,
 		})
 		if err != nil {
 			logStartError(collector.SchemaDetailsCollector, "create", err)
@@ -612,7 +611,7 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 			ExcludeUsers:     effectiveExcludeUsers,
 			EntryHandler:     entryHandler,
 			TableRegistry:    tableRegistry,
-			Logger:           c.opts.Logger,
+			Logger:           c.opts.SLogger,
 		})
 		if err != nil {
 			logStartError(collector.QueryDetailsCollector, "create", err)
@@ -630,7 +629,7 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 		qsExcludeUsers := effectiveExcludeUsers
 		qsExcludeCurrentUser := false
 		if localExcludeCurrentUser := c.args.QuerySampleArguments.ExcludeCurrentUser; localExcludeCurrentUser != nil {
-			level.Warn(c.opts.Logger).Log("msg", "query_samples.exclude_current_user is deprecated; use the top-level exclude_current_user setting instead")
+			c.opts.SLogger.Warn("query_samples.exclude_current_user is deprecated; use the top-level exclude_current_user setting instead")
 			qsExcludeUsers = c.args.ExcludeUsers
 			qsExcludeCurrentUser = *localExcludeCurrentUser
 		}
@@ -641,7 +640,7 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 			ExcludeDatabases:              c.args.ExcludeDatabases,
 			ExcludeUsers:                  qsExcludeUsers,
 			EntryHandler:                  entryHandler,
-			Logger:                        c.opts.Logger,
+			Logger:                        c.opts.SLogger,
 			DisableQueryRedaction:         c.args.QuerySampleArguments.DisableQueryRedaction,
 			ExcludeCurrentUser:            qsExcludeCurrentUser,
 			EnablePreClassifiedWaitEvents: c.args.QuerySampleArguments.EnablePreClassifiedWaitEvents,
@@ -680,7 +679,7 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 			PerScrapeRatio:   c.args.ExplainPlansArguments.PerCollectRatio,
 			ExcludeDatabases: c.args.ExcludeDatabases,
 			ExcludeUsers:     effectiveExcludeUsers,
-			Logger:           c.opts.Logger,
+			Logger:           c.opts.SLogger,
 			DBVersion:        engineVersion,
 			EntryHandler:     entryHandler,
 		})
@@ -700,7 +699,7 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 		ExcludeDatabases: c.args.ExcludeDatabases,
 		ExcludeUsers:     effectiveExcludeUsers,
 		EntryHandler:     entryHandler,
-		Logger:           c.opts.Logger,
+		Logger:           c.opts.SLogger,
 	})
 	if err != nil {
 		logStartError(collector.HealthCheckCollector, "create", err)
@@ -715,7 +714,7 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 	logsCollector, err := collector.NewLogs(collector.LogsArguments{
 		Receiver:         c.logsReceiver,
 		EntryHandler:     loki.NewEntryHandler(c.logsReceiver.Chan(), func() {}),
-		Logger:           c.opts.Logger,
+		Logger:           c.opts.SLogger,
 		Registry:         c.registry,
 		ExcludeDatabases: c.args.ExcludeDatabases,
 		ExcludeUsers:     effectiveExcludeUsers,

--- a/internal/component/database_observability/postgres/component_test.go
+++ b/internal/component/database_observability/postgres/component_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	kitlog "github.com/go-kit/log"
 	"github.com/grafana/loki/pkg/push"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
@@ -33,7 +32,6 @@ func newTestComponent(t *testing.T, openSQL func(string, string) (*sql.DB, error
 	t.Helper()
 	opts := cmp.Options{
 		ID:            "test",
-		Logger:        kitlog.NewNopLogger(),
 		SLogger:       logging.NewSlogNop(),
 		OnStateChange: func(e cmp.Exports) {},
 		GetServiceData: func(name string) (any, error) {
@@ -667,7 +665,6 @@ func TestPostgres_Update_DBUnavailable_ReportsUnhealthy(t *testing.T) {
 	args := Arguments{DataSourceName: "postgres://127.0.0.1:1/db?sslmode=disable"}
 	opts := cmp.Options{
 		ID:            "test.postgres",
-		Logger:        kitlog.NewNopLogger(),
 		SLogger:       logging.NewSlogNop(),
 		OnStateChange: func(e cmp.Exports) {},
 		GetServiceData: func(name string) (any, error) {
@@ -872,7 +869,6 @@ func Test_LogsReceiver_ExportedImmediately(t *testing.T) {
 	var exports Exports
 	opts := cmp.Options{
 		ID:         "test",
-		Logger:     kitlog.NewNopLogger(),
 		SLogger:    logging.NewSlogNop(),
 		Registerer: nil,
 		OnStateChange: func(e cmp.Exports) {
@@ -906,7 +902,6 @@ func Test_connectAndStartCollectors(t *testing.T) {
 	t.Run("returns error when database connection fails", func(t *testing.T) {
 		opts := cmp.Options{
 			ID:            "test-component",
-			Logger:        kitlog.NewNopLogger(),
 			SLogger:       logging.NewSlogNop(),
 			Registerer:    nil,
 			OnStateChange: func(e cmp.Exports) {},
@@ -940,7 +935,6 @@ func Test_connectAndStartCollectors(t *testing.T) {
 		// an existing connection before attempting a new one
 		opts := cmp.Options{
 			ID:            "test-component",
-			Logger:        kitlog.NewNopLogger(),
 			SLogger:       logging.NewSlogNop(),
 			Registerer:    nil,
 			OnStateChange: func(e cmp.Exports) {},
@@ -1032,7 +1026,6 @@ func TestPostgres_Reconnection(t *testing.T) {
 	t.Run("tryReconnect fails and maintains health error", func(t *testing.T) {
 		opts := cmp.Options{
 			ID:            "test",
-			Logger:        kitlog.NewNopLogger(),
 			SLogger:       logging.NewSlogNop(),
 			OnStateChange: func(e cmp.Exports) {},
 			GetServiceData: func(name string) (any, error) {


### PR DESCRIPTION
### Pull Request Details

Alloy is migrating from `go-kit/log` to `log/slog`. This pr migrates database_observability component.

### Issue(s) fixed by this Pull Request

Part of: https://github.com/grafana/alloy/issues/4813

### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
