### PR TITLE
chore: Surface go mod tidy output when generating module dependencies

### DIFF
--- a/tools/generate/moduledeps/internal/tidy-modules.go
+++ b/tools/generate/moduledeps/internal/tidy-modules.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"fmt"
 	"log"
+	"os"
 	"os/exec"
 
 	"github.com/grafana/alloy/tools/generate/moduledeps/internal/helpers"
@@ -30,6 +31,10 @@ func runGoModTidy(dirs *helpers.FileHelper, module types.Module) error {
 
 	cmd := exec.Command("go", "mod", "tidy")
 	cmd.Dir = moduleDir
+	// Forward go's output so its diagnostics surface in the build log; without
+	// this a failure only ever shows up as a bare "exit status 1".
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 
 	log.Printf("Running go mod tidy in %s (module: %s)", moduleDir, module.Name)
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
### Brief description of Pull Request

`go mod tidy` failures during module-dependency generation only surfaced as a bare `exit status 1` — the wrapper ran the command without wiring up its output, so go's actual diagnostic went nowhere. This forwards stdout/stderr so the real cause (a missing sum, an unresolvable require, a proxy error) lands in the build log.

I ran in to this trying to troubleshoot a failed boringcrypto container publish — https://github.com/grafana/alloy/actions/runs/26961774170/job/79553717051 .