### PR TITLE
feat(prometheus.remote_write): Support Azure workload identity and custom OAuth scope in azuread

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.remote_write.md
+++ b/docs/sources/reference/components/prometheus/prometheus.remote_write.md
@@ -140,6 +140,8 @@ If the endpoint doesn't support receiving native histogram samples, pushing metr
 
 {{< docs/shared lookup="reference/components/azuread-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
+You must configure exactly one of the [`managed_identity`][managed_identity], [`oauth`][oauth], [`sdk`][sdk], or [`workload_identity`][workload_identity] blocks.
+
 ### `managed_identity`
 
 {{< badge text="Required" >}}

--- a/docs/sources/reference/components/prometheus/prometheus.remote_write.md
+++ b/docs/sources/reference/components/prometheus/prometheus.remote_write.md
@@ -55,6 +55,7 @@ You can use the following blocks with `prometheus.remote_write`:
 | `endpoint` > `azuread` > [`managed_identity`][managed_identity] | Configure Azure user-assigned managed identity.                            | yes      |
 | `endpoint` > `azuread` > [`oauth`][oauth]                       | Configure Azure OAuth.                                                     | yes      |
 | `endpoint` > `azuread` > [`sdk`][sdk]                           | Configure Azure SDK authentication.                                        | yes      |
+| `endpoint` > `azuread` > [`workload_identity`][workload_identity] | Configure Azure Workload Identity.                                       | yes      |
 | `endpoint` > [`basic_auth`][basic_auth]                         | Configure `basic_auth` for authenticating to the endpoint.                 | no       |
 | `endpoint` > [`metadata_config`][metadata_config]               | Configuration for how metric metadata is sent.                             | no       |
 | `endpoint` > [`oauth2`][oauth2]                                 | Configure OAuth 2.0 for authenticating to the endpoint.                    | no       |
@@ -75,6 +76,7 @@ You can use the following blocks with `prometheus.remote_write`:
 [oauth2]: #oauth2
 [queue_config]: #queue_config
 [sdk]: #sdk
+[workload_identity]: #workload_identity
 [sigv4]: #sigv4
 [tls_config]: #tls_config
 [wal]: #wal
@@ -155,6 +157,12 @@ If the endpoint doesn't support receiving native histogram samples, pushing metr
 {{< badge text="Required" >}}
 
 {{< docs/shared lookup="reference/components/azuread-sdk.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `workload_identity`
+
+{{< badge text="Required" >}}
+
+{{< docs/shared lookup="reference/components/azure-workload_identity-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ### `basic_auth`
 

--- a/docs/sources/reference/components/prometheus/prometheus.remote_write.md
+++ b/docs/sources/reference/components/prometheus/prometheus.remote_write.md
@@ -55,7 +55,7 @@ You can use the following blocks with `prometheus.remote_write`:
 | `endpoint` > `azuread` > [`managed_identity`][managed_identity] | Configure Azure user-assigned managed identity.                            | yes      |
 | `endpoint` > `azuread` > [`oauth`][oauth]                       | Configure Azure OAuth.                                                     | yes      |
 | `endpoint` > `azuread` > [`sdk`][sdk]                           | Configure Azure SDK authentication.                                        | yes      |
-| `endpoint` > `azuread` > [`workload_identity`][workload_identity] | Configure Azure AD Workload Identity.                                    | yes      |
+| `endpoint` > `azuread` > [`workload_identity`][workload_identity] | Configure Microsoft Entra Workload ID.                             | yes      |
 | `endpoint` > [`basic_auth`][basic_auth]                         | Configure `basic_auth` for authenticating to the endpoint.                 | no       |
 | `endpoint` > [`metadata_config`][metadata_config]               | Configuration for how metric metadata is sent.                             | no       |
 | `endpoint` > [`oauth2`][oauth2]                                 | Configure OAuth 2.0 for authenticating to the endpoint.                    | no       |

--- a/docs/sources/reference/components/prometheus/prometheus.remote_write.md
+++ b/docs/sources/reference/components/prometheus/prometheus.remote_write.md
@@ -55,7 +55,7 @@ You can use the following blocks with `prometheus.remote_write`:
 | `endpoint` > `azuread` > [`managed_identity`][managed_identity] | Configure Azure user-assigned managed identity.                            | yes      |
 | `endpoint` > `azuread` > [`oauth`][oauth]                       | Configure Azure OAuth.                                                     | yes      |
 | `endpoint` > `azuread` > [`sdk`][sdk]                           | Configure Azure SDK authentication.                                        | yes      |
-| `endpoint` > `azuread` > [`workload_identity`][workload_identity] | Configure Azure Workload Identity.                                       | yes      |
+| `endpoint` > `azuread` > [`workload_identity`][workload_identity] | Configure Azure AD Workload Identity.                                    | yes      |
 | `endpoint` > [`basic_auth`][basic_auth]                         | Configure `basic_auth` for authenticating to the endpoint.                 | no       |
 | `endpoint` > [`metadata_config`][metadata_config]               | Configuration for how metric metadata is sent.                             | no       |
 | `endpoint` > [`oauth2`][oauth2]                                 | Configure OAuth 2.0 for authenticating to the endpoint.                    | no       |

--- a/docs/sources/shared/reference/components/azure-workload_identity-block.md
+++ b/docs/sources/shared/reference/components/azure-workload_identity-block.md
@@ -1,0 +1,24 @@
+---
+canonical: https://grafana.com/docs/alloy/latest/shared/reference/components/workload_identity-block/
+description: Shared content, workload_identity block
+headless: true
+---
+
+| Name              | Type     | Description                                                                     | Default                                                | Required |
+| ----------------- | -------- | ------------------------------------------------------------------------------- | ------------------------------------------------------ | -------- |
+| `client_id`       | `string` | Client ID of the Microsoft Entra application or user-assigned managed identity. |                                                        | yes      |
+| `tenant_id`       | `string` | Tenant ID of the Microsoft Entra application or user-assigned managed identity. |                                                        | yes      |
+| `token_file_path` | `string` | Path to the projected service account token file.                               | `"/var/run/secrets/azure/tokens/azure-identity-token"` | no       |
+
+`client_id` and `tenant_id` must be valid [UUID][]s in one of the supported formats:
+
+* `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
+* `urn:uuid:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
+* Microsoft encoding: `{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}`
+* Raw hex encoding: `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`
+
+Use `workload_identity` for secretless authentication from an AKS pod configured with [Microsoft Entra Workload ID][workload-id].
+Alloy reads the projected service account token from `token_file_path` and federates it for a Microsoft Entra token.
+
+[UUID]: https://en.wikipedia.org/wiki/Universally_unique_identifier
+[workload-id]: https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview

--- a/docs/sources/shared/reference/components/azure-workload_identity-block.md
+++ b/docs/sources/shared/reference/components/azure-workload_identity-block.md
@@ -17,7 +17,7 @@ headless: true
 * Microsoft encoding: `{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}`
 * Raw hex encoding: `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`
 
-Use `workload_identity` for secretless authentication from an AKS Pod configured with [Microsoft Entra Workload ID][workload-id].
+Use `workload_identity` to authenticate from an AKS Pod configured with [Microsoft Entra Workload ID][workload-id] without requiring a client secret.
 Alloy reads the projected service account token from `token_file_path` and federates it for a Microsoft Entra token.
 
 [UUID]: https://en.wikipedia.org/wiki/Universally_unique_identifier

--- a/docs/sources/shared/reference/components/azure-workload_identity-block.md
+++ b/docs/sources/shared/reference/components/azure-workload_identity-block.md
@@ -17,7 +17,7 @@ headless: true
 * Microsoft encoding: `{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}`
 * Raw hex encoding: `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`
 
-Use `workload_identity` for secretless authentication from an AKS pod configured with [Microsoft Entra Workload ID][workload-id].
+Use `workload_identity` for secretless authentication from an AKS Pod configured with [Microsoft Entra Workload ID][workload-id].
 Alloy reads the projected service account token from `token_file_path` and federates it for a Microsoft Entra token.
 
 [UUID]: https://en.wikipedia.org/wiki/Universally_unique_identifier

--- a/docs/sources/shared/reference/components/azure-workload_identity-block.md
+++ b/docs/sources/shared/reference/components/azure-workload_identity-block.md
@@ -18,7 +18,7 @@ headless: true
 * Raw hex encoding: `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`
 
 Use `workload_identity` to authenticate from an AKS Pod configured with [Microsoft Entra Workload ID][workload-id] without requiring a client secret.
-Alloy reads the projected service account token from `token_file_path` and federates it for a Microsoft Entra token.
+{{< param "PRODUCT_NAME" >}} reads the projected service account token from `token_file_path` and federates it for a Microsoft Entra token.
 
 [UUID]: https://en.wikipedia.org/wiki/Universally_unique_identifier
 [workload-id]: https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview

--- a/docs/sources/shared/reference/components/azuread-block.md
+++ b/docs/sources/shared/reference/components/azuread-block.md
@@ -15,4 +15,5 @@ The supported values for `cloud` are:
 * `"AzureChina"`
 * `"AzureGovernment"`
 
-When `scope` is left empty, Alloy uses the per-cloud Azure Monitor ingestion audience, for example, `https://monitor.azure.com//.default` for `"AzurePublic"`. Set `scope` to request a token for a different audience, such as a custom Microsoft Entra app registration.
+When `scope` is left empty, {{< param "PRODUCT_NAME" >}} uses the per-cloud Azure Monitor ingestion audience, for example, `https://monitor.azure.com//.default` for `"AzurePublic"`.
+Set `scope` to request a token for a different audience, such as a custom Microsoft Entra app registration.

--- a/docs/sources/shared/reference/components/azuread-block.md
+++ b/docs/sources/shared/reference/components/azuread-block.md
@@ -4,12 +4,15 @@ description: Shared content, azuread block
 headless: true
 ---
 
-| Name    | Type     | Description      | Default         | Required |
-| ------- | -------- | ---------------- | --------------- | -------- |
-| `cloud` | `string` | The Azure Cloud. | `"AzurePublic"` | no       |
+| Name    | Type     | Description                                                         | Default         | Required |
+| ------- | -------- | ------------------------------------------------------------------- | --------------- | -------- |
+| `cloud` | `string` | The Azure Cloud.                                                    | `"AzurePublic"` | no       |
+| `scope` | `string` | Custom OAuth 2.0 scope (audience) to request when acquiring tokens. | `""`            | no       |
 
 The supported values for `cloud` are:
 
 * `"AzurePublic"`
 * `"AzureChina"`
 * `"AzureGovernment"`
+
+When `scope` is left empty, Alloy uses the per-cloud Azure Monitor ingestion audience, for example, `https://monitor.azure.com//.default` for `"AzurePublic"`. Set `scope` to request a token for a different audience, such as a custom Microsoft Entra app registration.

--- a/internal/component/prometheus/remotewrite/types.go
+++ b/internal/component/prometheus/remotewrite/types.go
@@ -329,9 +329,42 @@ func (c *SDKConfig) toPrometheusType() *azuread.SDKConfig {
 	}
 }
 
+// WorkloadIdentityConfig is used to store azure workload identity config values.
+type WorkloadIdentityConfig struct {
+	// ClientID is the clientId of the Microsoft Entra application or user-assigned managed identity.
+	ClientID string `alloy:"client_id,attr"`
+
+	// TenantID is the tenantId of the Microsoft Entra application or user-assigned managed identity.
+	TenantID string `alloy:"tenant_id,attr"`
+
+	// TokenFilePath is the path to the projected service account token file.
+	// Defaults to azuread.DefaultWorkloadIdentityTokenPath when unset.
+	TokenFilePath string `alloy:"token_file_path,attr,optional"`
+}
+
+func (c *WorkloadIdentityConfig) toPrometheusType() *azuread.WorkloadIdentityConfig {
+	if c == nil {
+		return nil
+	}
+
+	tokenFilePath := c.TokenFilePath
+	if tokenFilePath == "" {
+		tokenFilePath = azuread.DefaultWorkloadIdentityTokenPath
+	}
+
+	return &azuread.WorkloadIdentityConfig{
+		ClientID:      c.ClientID,
+		TenantID:      c.TenantID,
+		TokenFilePath: tokenFilePath,
+	}
+}
+
 type AzureADConfig struct {
 	// ManagedIdentity is the managed identity that is being used to authenticate.
 	ManagedIdentity *ManagedIdentityConfig `alloy:"managed_identity,block,optional"`
+
+	// WorkloadIdentity is the workload identity that is being used to authenticate.
+	WorkloadIdentity *WorkloadIdentityConfig `alloy:"workload_identity,block,optional"`
 
 	// OAuth is the oauth config that is being used to authenticate.
 	OAuth *OAuthConfig `alloy:"oauth,block,optional"`
@@ -341,6 +374,10 @@ type AzureADConfig struct {
 
 	// Cloud is the Azure cloud in which the service is running. Example: AzurePublic/AzureGovernment/AzureChina.
 	Cloud string `alloy:"cloud,attr,optional"`
+
+	// Scope is the custom OAuth 2.0 scope (audience) to request when acquiring tokens.
+	// When empty, the per-cloud Azure Monitor ingestion audience is used.
+	Scope string `alloy:"scope,attr,optional"`
 }
 
 func (a *AzureADConfig) Validate() error {
@@ -348,20 +385,25 @@ func (a *AzureADConfig) Validate() error {
 		return fmt.Errorf("must provide a cloud in the Azure AD config")
 	}
 
-	if a.ManagedIdentity == nil && a.OAuth == nil && a.SDK == nil {
-		return fmt.Errorf("must provide an Azure Managed Identity, Azure OAuth or Azure SDK in the Azure AD config")
+	authenticators := 0
+	if a.ManagedIdentity != nil {
+		authenticators++
+	}
+	if a.WorkloadIdentity != nil {
+		authenticators++
+	}
+	if a.OAuth != nil {
+		authenticators++
+	}
+	if a.SDK != nil {
+		authenticators++
 	}
 
-	if a.ManagedIdentity != nil && a.OAuth != nil {
-		return fmt.Errorf("cannot provide both Azure Managed Identity and Azure OAuth in the Azure AD config")
+	if authenticators == 0 {
+		return fmt.Errorf("must provide an Azure Managed Identity, Azure Workload Identity, Azure OAuth or Azure SDK in the Azure AD config")
 	}
-
-	if a.ManagedIdentity != nil && a.SDK != nil {
-		return fmt.Errorf("cannot provide both Azure Managed Identity and Azure SDK in the Azure AD config")
-	}
-
-	if a.OAuth != nil && a.SDK != nil {
-		return fmt.Errorf("cannot provide both Azure OAuth and Azure SDK in the Azure AD config")
+	if authenticators > 1 {
+		return fmt.Errorf("cannot provide multiple authentication methods in the Azure AD config")
 	}
 
 	if a.ManagedIdentity != nil {
@@ -369,9 +411,24 @@ func (a *AzureADConfig) Validate() error {
 			return fmt.Errorf("must provide an Azure Managed Identity client_id in the Azure AD config")
 		}
 
-		_, err := uuid.Parse(a.ManagedIdentity.ClientID)
-		if err != nil {
+		if _, err := uuid.Parse(a.ManagedIdentity.ClientID); err != nil {
 			return fmt.Errorf("the provided Azure Managed Identity client_id is invalid")
+		}
+	}
+
+	if a.WorkloadIdentity != nil {
+		if a.WorkloadIdentity.ClientID == "" {
+			return fmt.Errorf("must provide an Azure Workload Identity client_id in the Azure AD config")
+		}
+		if a.WorkloadIdentity.TenantID == "" {
+			return fmt.Errorf("must provide an Azure Workload Identity tenant_id in the Azure AD config")
+		}
+
+		if _, err := uuid.Parse(a.WorkloadIdentity.ClientID); err != nil {
+			return fmt.Errorf("the provided Azure Workload Identity client_id is invalid")
+		}
+		if _, err := uuid.Parse(a.WorkloadIdentity.TenantID); err != nil {
+			return fmt.Errorf("the provided Azure Workload Identity tenant_id is invalid")
 		}
 	}
 
@@ -386,25 +443,25 @@ func (a *AzureADConfig) Validate() error {
 			return fmt.Errorf("must provide an Azure OAuth tenant_id in the Azure AD config")
 		}
 
-		var err error
-		_, err = uuid.Parse(a.OAuth.ClientID)
-		if err != nil {
+		if _, err := uuid.Parse(a.OAuth.ClientID); err != nil {
 			return fmt.Errorf("the provided Azure OAuth client_id is invalid")
 		}
-		_, err = regexp.MatchString("^[0-9a-zA-Z-.]+$", a.OAuth.TenantID)
-		if err != nil {
+		if _, err := regexp.MatchString("^[0-9a-zA-Z-.]+$", a.OAuth.TenantID); err != nil {
 			return fmt.Errorf("the provided Azure OAuth tenant_id is invalid")
 		}
 	}
 
 	if a.SDK != nil {
-		var err error
-
 		if a.SDK.TenantID != "" {
-			_, err = regexp.MatchString("^[0-9a-zA-Z-.]+$", a.SDK.TenantID)
-			if err != nil {
-				return fmt.Errorf("the provided Azure OAuth tenant_id is invalid")
+			if _, err := regexp.MatchString("^[0-9a-zA-Z-.]+$", a.SDK.TenantID); err != nil {
+				return fmt.Errorf("the provided Azure SDK tenant_id is invalid")
 			}
+		}
+	}
+
+	if a.Scope != "" {
+		if matched, err := regexp.MatchString(`^[\w\s:/.\-]+$`, a.Scope); err != nil || !matched {
+			return fmt.Errorf("the provided Azure scope contains invalid characters")
 		}
 	}
 
@@ -424,10 +481,12 @@ func (a *AzureADConfig) toPrometheusType() *azuread.AzureADConfig {
 	}
 
 	return &azuread.AzureADConfig{
-		ManagedIdentity: a.ManagedIdentity.toPrometheusType(),
-		OAuth:           a.OAuth.toPrometheusType(),
-		SDK:             a.SDK.toPrometheusType(),
-		Cloud:           a.Cloud,
+		ManagedIdentity:  a.ManagedIdentity.toPrometheusType(),
+		WorkloadIdentity: a.WorkloadIdentity.toPrometheusType(),
+		OAuth:            a.OAuth.toPrometheusType(),
+		SDK:              a.SDK.toPrometheusType(),
+		Cloud:            a.Cloud,
+		Scope:            a.Scope,
 	}
 }
 

--- a/internal/component/prometheus/remotewrite/types_test.go
+++ b/internal/component/prometheus/remotewrite/types_test.go
@@ -204,6 +204,143 @@ func TestAlloyConfig(t *testing.T) {
 			}),
 		},
 		{
+			testName: "AzureAD_WorkloadIdentity_Defaults",
+			cfg: `
+			endpoint {
+				url  = "http://0.0.0.0:11111/api/v1/write"
+
+				azuread {
+					workload_identity {
+						client_id = "f47ac10b-58cc-0372-8567-0e02b2c3d479"
+						tenant_id = "00000000-0000-0000-0000-000000000001"
+					}
+				}
+			}`,
+			expectedCfg: expectedCfg(func(c *config.Config) {
+				c.RemoteWriteConfigs[0].AzureADConfig = &azuread.AzureADConfig{
+					Cloud: "AzurePublic",
+					WorkloadIdentity: &azuread.WorkloadIdentityConfig{
+						ClientID:      "f47ac10b-58cc-0372-8567-0e02b2c3d479",
+						TenantID:      "00000000-0000-0000-0000-000000000001",
+						TokenFilePath: "/var/run/secrets/azure/tokens/azure-identity-token",
+					},
+				}
+				c.RemoteWriteConfigs[0].ProtobufMessage = remote.WriteV1MessageType
+			}),
+		},
+		{
+			testName: "AzureAD_WorkloadIdentity_ExplicitTokenPath",
+			cfg: `
+			endpoint {
+				url  = "http://0.0.0.0:11111/api/v1/write"
+
+				azuread {
+					workload_identity {
+						client_id       = "f47ac10b-58cc-0372-8567-0e02b2c3d479"
+						tenant_id       = "00000000-0000-0000-0000-000000000001"
+						token_file_path = "/custom/token/path"
+					}
+				}
+			}`,
+			expectedCfg: expectedCfg(func(c *config.Config) {
+				c.RemoteWriteConfigs[0].AzureADConfig = &azuread.AzureADConfig{
+					Cloud: "AzurePublic",
+					WorkloadIdentity: &azuread.WorkloadIdentityConfig{
+						ClientID:      "f47ac10b-58cc-0372-8567-0e02b2c3d479",
+						TenantID:      "00000000-0000-0000-0000-000000000001",
+						TokenFilePath: "/custom/token/path",
+					},
+				}
+				c.RemoteWriteConfigs[0].ProtobufMessage = remote.WriteV1MessageType
+			}),
+		},
+		{
+			testName: "AzureAD_Scope",
+			cfg: `
+			endpoint {
+				url  = "http://0.0.0.0:11111/api/v1/write"
+
+				azuread {
+					managed_identity {
+						client_id = "f47ac10b-58cc-0372-8567-0e02b2c3d479"
+					}
+					scope = "api://alloy-gateway/.default"
+				}
+			}`,
+			expectedCfg: expectedCfg(func(c *config.Config) {
+				c.RemoteWriteConfigs[0].AzureADConfig = &azuread.AzureADConfig{
+					Cloud: "AzurePublic",
+					ManagedIdentity: &azuread.ManagedIdentityConfig{
+						ClientID: "f47ac10b-58cc-0372-8567-0e02b2c3d479",
+					},
+					Scope: "api://alloy-gateway/.default",
+				}
+				c.RemoteWriteConfigs[0].ProtobufMessage = remote.WriteV1MessageType
+			}),
+		},
+		{
+			testName: "AzureAD_WorkloadIdentity_MissingTenantID",
+			cfg: `
+			endpoint {
+				url  = "http://0.0.0.0:11111/api/v1/write"
+
+				azuread {
+					workload_identity {
+						client_id = "f47ac10b-58cc-0372-8567-0e02b2c3d479"
+					}
+				}
+			}`,
+			errorMsg: `missing required attribute "tenant_id"`,
+		},
+		{
+			testName: "AzureAD_WorkloadIdentity_BadClientID",
+			cfg: `
+			endpoint {
+				url  = "http://0.0.0.0:11111/api/v1/write"
+
+				azuread {
+					workload_identity {
+						client_id = "not-a-uuid"
+						tenant_id = "00000000-0000-0000-0000-000000000001"
+					}
+				}
+			}`,
+			errorMsg: "the provided Azure Workload Identity client_id is invalid",
+		},
+		{
+			testName: "AzureAD_MultipleAuthenticators",
+			cfg: `
+			endpoint {
+				url  = "http://0.0.0.0:11111/api/v1/write"
+
+				azuread {
+					managed_identity {
+						client_id = "f47ac10b-58cc-0372-8567-0e02b2c3d479"
+					}
+					workload_identity {
+						client_id = "f47ac10b-58cc-0372-8567-0e02b2c3d479"
+						tenant_id = "00000000-0000-0000-0000-000000000001"
+					}
+				}
+			}`,
+			errorMsg: "cannot provide multiple authentication methods in the Azure AD config",
+		},
+		{
+			testName: "AzureAD_BadScope",
+			cfg: `
+			endpoint {
+				url  = "http://0.0.0.0:11111/api/v1/write"
+
+				azuread {
+					managed_identity {
+						client_id = "f47ac10b-58cc-0372-8567-0e02b2c3d479"
+					}
+					scope = "invalid!scope"
+				}
+			}`,
+			errorMsg: "the provided Azure scope contains invalid characters",
+		},
+		{
 			testName: "SigV4_Defaults",
 			cfg: `
 			endpoint {

--- a/internal/converter/internal/prometheusconvert/component/remote_write.go
+++ b/internal/converter/internal/prometheusconvert/component/remote_write.go
@@ -132,11 +132,20 @@ func toAzureAD(azureADConfig *azuread.AzureADConfig) *remotewrite.AzureADConfig 
 
 	res := &remotewrite.AzureADConfig{
 		Cloud: azureADConfig.Cloud,
+		Scope: azureADConfig.Scope,
 	}
 
 	if azureADConfig.ManagedIdentity != nil {
 		res.ManagedIdentity = &remotewrite.ManagedIdentityConfig{
 			ClientID: azureADConfig.ManagedIdentity.ClientID,
+		}
+	}
+
+	if azureADConfig.WorkloadIdentity != nil {
+		res.WorkloadIdentity = &remotewrite.WorkloadIdentityConfig{
+			ClientID:      azureADConfig.WorkloadIdentity.ClientID,
+			TenantID:      azureADConfig.WorkloadIdentity.TenantID,
+			TokenFilePath: azureADConfig.WorkloadIdentity.TokenFilePath,
 		}
 	}
 

--- a/internal/converter/internal/prometheusconvert/testdata/scrape.alloy
+++ b/internal/converter/internal/prometheusconvert/testdata/scrape.alloy
@@ -129,4 +129,37 @@ prometheus.remote_write "default" {
 			cloud = "AzureGovernment"
 		}
 	}
+
+	endpoint {
+		name = "remote7_azuread_workload_identity"
+		url  = "http://localhost:9012/api/prom/push"
+
+		queue_config { }
+
+		metadata_config { }
+
+		azuread {
+			workload_identity {
+				client_id       = "00000000-0000-0000-0000-000000000000"
+				tenant_id       = "00000000-0000-0000-0000-000000000001"
+				token_file_path = "/var/run/secrets/azure/tokens/azure-identity-token"
+			}
+		}
+	}
+
+	endpoint {
+		name = "remote8_azuread_scope"
+		url  = "http://localhost:9012/api/prom/push"
+
+		queue_config { }
+
+		metadata_config { }
+
+		azuread {
+			managed_identity {
+				client_id = "00000000-0000-0000-0000-000000000000"
+			}
+			scope = "api://alloy-gateway/.default"
+		}
+	}
 }

--- a/internal/converter/internal/prometheusconvert/testdata/scrape.yaml
+++ b/internal/converter/internal/prometheusconvert/testdata/scrape.yaml
@@ -55,3 +55,15 @@ remote_write:
       cloud: AzureGovernment
       managed_identity:
         client_id: 00000000-0000-0000-0000-000000000000
+  - name: "remote7_azuread_workload_identity"
+    url: http://localhost:9012/api/prom/push
+    azuread:
+      workload_identity:
+        client_id: 00000000-0000-0000-0000-000000000000
+        tenant_id: 00000000-0000-0000-0000-000000000001
+  - name: "remote8_azuread_scope"
+    url: http://localhost:9012/api/prom/push
+    azuread:
+      managed_identity:
+        client_id: 00000000-0000-0000-0000-000000000000
+      scope: api://alloy-gateway/.default


### PR DESCRIPTION
### Brief description of Pull Request

Expose Azure Workload Identity and a custom OAuth 2.0 `scope` in the `prometheus.remote_write` `azuread` block, allowing Alloy to authenticate with secretless AKS federated tokens and to request Microsoft Entra tokens for a custom (non–Azure Monitor) audience.

### Pull Request Details

Alloy's pinned Prometheus dependency already implements both features in `azuread.AzureADConfig` (the `WorkloadIdentity` and `Scope` fields), but Alloy never surfaced them in its own `prometheus.remote_write` config schema or in the `alloy convert` path. This change adds that plumbing; no dependency bump is required.

The `azuread` block gains an optional `workload_identity` block with `client_id`, `tenant_id`, and an optional `token_file_path` that defaults to the standard Azure Workload Identity projected-token path (`/var/run/secrets/azure/tokens/azure-identity-token`). It also gains an optional `scope` attribute. When `scope` is empty, Alloy keeps using the per-cloud Azure Monitor ingestion audience; when it's set, Alloy requests a token for that audience instead.

Validation is reworked to mirror upstream's `azuread.AzureADConfig.Validate()`: authenticator exclusivity is now count-based (a single "cannot provide multiple authentication methods" message that includes Workload Identity), `client_id` and `tenant_id` are validated as UUIDs, and `scope` is checked against the same character set upstream uses. This also corrects a pre-existing copy-paste error where a failed SDK `tenant_id` validation reported an "Azure OAuth" message.

The `alloy convert` path (`toAzureAD`) maps both fields so existing Prometheus `azuread` configurations that use `workload_identity` or `scope` convert correctly, with `token_file_path` defaulted by the Prometheus loader.

Existing `azuread` configurations are unaffected: both the `workload_identity` block and the `scope` attribute are optional, and the default behavior is unchanged.

### Issue(s) fixed by this Pull Request

N/A

### Notes to the Reviewer

Scope is metrics-only by design. `loki.write` has no `azuread` block (it uses Prometheus's generic HTTP client config) and `otelcol` exporters have no Azure auth extension, so neither is touched here.

Validation run:

- `go test ./internal/component/prometheus/remotewrite/... ./internal/converter/internal/prometheusconvert/...`
- `gofmt -l` (clean) and `go vet` (clean) on both packages
- `build/alloylint ./internal/component/prometheus/remotewrite/... ./internal/converter/internal/prometheusconvert/...` (clean)
- `alloy validate` on a config that uses `workload_identity` and `scope` (succeeds)

`golangci-lint run --new-from-rev=HEAD` reports no new issues for this change. A full `golangci-lint run` over these packages surfaces only pre-existing repo-wide `goconst`/`govet` findings in unrelated files.
