### PR TITLE
feat(otelcol.exporter.prometheus): Config option to prevent stripping `service.*` attributes

### DIFF
--- a/docs/sources/reference/components/otelcol/otelcol.exporter.prometheus.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.prometheus.md
@@ -46,7 +46,7 @@ You can use the following arguments with `otelcol.exporter.prometheus`:
 | `include_scope_info`                   | `bool`                  | Whether to include `otel_scope_info` metrics.                                     | `false` | no       |
 | `include_scope_labels`                 | `bool`                  | Whether to include additional OTLP labels in all metrics.                         | `true`  | no       |
 | `include_target_info`                  | `bool`                  | Whether to include `target_info` metrics.                                         | `true`  | no       |
-| `keep_identifying_resource_attributes` | `bool`                  | Whether to keep `service.name`, `service.namespace`, and `service.instance.id` as labels on `target_info`. | `true`  | no       |
+| `keep_identifying_resource_attributes` | `bool`                  | Whether to keep `service.name`, `service.namespace`, and `service.instance.id` as labels on `target_info`. | `false` | no       |
 | `resource_to_telemetry_conversion`     | `bool`                  | Whether to convert OTel resource attributes to Prometheus labels.                 | `false` | no       |
 
 By default, OpenTelemetry resources are converted into `target_info` metrics.
@@ -82,9 +82,8 @@ When `include_scope_labels` is `true`  the `otel_scope_name` and `otel_scope_ver
 
 When `include_target_info` is true, OpenTelemetry Collector resources are converted into `target_info` metrics.
 
-By default (`keep_identifying_resource_attributes = true`), `service.name`, `service.namespace`, and `service.instance.id` are preserved as labels on `target_info` in addition to being mapped into `job` and `instance`.
-This keeps `target_info` compliant with the [OpenTelemetry service resource semantic conventions][otel-svc-semconv], which define these as standard resource attributes.
-Set the argument to `false` to strip them from `target_info` after the `job`/`instance` mapping.
+By default, `service.name`, `service.namespace`, and `service.instance.id` are stripped from `target_info` after being mapped into the `job` and `instance` labels.
+Set `keep_identifying_resource_attributes = true` to preserve them as labels on `target_info`, keeping it compliant with the [OpenTelemetry service resource semantic conventions][otel-svc-semconv].
 This option only affects `target_info`; regular metric series are unchanged.
 
 [otel-svc-semconv]: https://opentelemetry.io/docs/specs/semconv/resource/service/

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.prometheus.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.prometheus.md
@@ -36,17 +36,18 @@ otelcol.exporter.prometheus "<LABEL>" {
 
 You can use the following arguments with `otelcol.exporter.prometheus`:
 
-| Name                                 | Type                    | Description                                                                       | Default | Required |
-| ------------------------------------ | ----------------------- | --------------------------------------------------------------------------------- | ------- | -------- |
-| `forward_to`                         | `list(MetricsReceiver)` | Where to forward converted Prometheus metrics.                                    |         | yes      |
-| `add_metric_suffixes`                | `bool`                  | Whether to add type and unit suffixes to metric names.                            | `true`  | no       |
-| `convert_classic_histograms_to_nhcb` | `bool`                  | (Experimental) Convert OTel explicit-bucket histograms to NHCB.                   | `false` | no       |
-| `gc_frequency`                       | `duration`              | How often to clean up stale metrics from memory.                                  | `"5m"`  | no       |
-| `honor_metadata`                     | `bool`                  | (Experimental) Whether to send metric metadata to downstream components.          | `false` | no       |
-| `include_scope_info`                 | `bool`                  | Whether to include `otel_scope_info` metrics.                                     | `false` | no       |
-| `include_scope_labels`               | `bool`                  | Whether to include additional OTLP labels in all metrics.                         | `true`  | no       |
-| `include_target_info`                | `bool`                  | Whether to include `target_info` metrics.                                         | `true`  | no       |
-| `resource_to_telemetry_conversion`   | `bool`                  | Whether to convert OTel resource attributes to Prometheus labels.                 | `false` | no       |
+| Name                                   | Type                    | Description                                                                       | Default | Required |
+| -------------------------------------- | ----------------------- | --------------------------------------------------------------------------------- | ------- | -------- |
+| `forward_to`                           | `list(MetricsReceiver)` | Where to forward converted Prometheus metrics.                                    |         | yes      |
+| `add_metric_suffixes`                  | `bool`                  | Whether to add type and unit suffixes to metric names.                            | `true`  | no       |
+| `convert_classic_histograms_to_nhcb`   | `bool`                  | (Experimental) Convert OTel explicit-bucket histograms to NHCB.                   | `false` | no       |
+| `gc_frequency`                         | `duration`              | How often to clean up stale metrics from memory.                                  | `"5m"`  | no       |
+| `honor_metadata`                       | `bool`                  | (Experimental) Whether to send metric metadata to downstream components.          | `false` | no       |
+| `include_scope_info`                   | `bool`                  | Whether to include `otel_scope_info` metrics.                                     | `false` | no       |
+| `include_scope_labels`                 | `bool`                  | Whether to include additional OTLP labels in all metrics.                         | `true`  | no       |
+| `include_target_info`                  | `bool`                  | Whether to include `target_info` metrics.                                         | `true`  | no       |
+| `keep_identifying_resource_attributes` | `bool`                  | Whether to keep `service.name`, `service.namespace`, and `service.instance.id` as labels on `target_info`. | `true`  | no       |
+| `resource_to_telemetry_conversion`     | `bool`                  | Whether to convert OTel resource attributes to Prometheus labels.                 | `false` | no       |
 
 By default, OpenTelemetry resources are converted into `target_info` metrics.
 OpenTelemetry instrumentation scopes are converted into `otel_scope_info` metrics.
@@ -80,6 +81,13 @@ To enable and use an experimental feature, you must set the `stability.level` [f
 When `include_scope_labels` is `true`  the `otel_scope_name` and `otel_scope_version` labels are added to every converted metric sample.
 
 When `include_target_info` is true, OpenTelemetry Collector resources are converted into `target_info` metrics.
+
+By default (`keep_identifying_resource_attributes = true`), `service.name`, `service.namespace`, and `service.instance.id` are preserved as labels on `target_info` in addition to being mapped into `job` and `instance`.
+This keeps `target_info` compliant with the [OpenTelemetry service resource semantic conventions][otel-svc-semconv], which define these as standard resource attributes.
+Set the argument to `false` to strip them from `target_info` after the `job`/`instance` mapping.
+This option only affects `target_info`; regular metric series are unchanged.
+
+[otel-svc-semconv]: https://opentelemetry.io/docs/specs/semconv/resource/service/
 
 {{< admonition type="note" >}}
 OTLP metrics can have a lot of resource attributes.

--- a/internal/component/otelcol/exporter/prometheus/internal/convert/convert.go
+++ b/internal/component/otelcol/exporter/prometheus/internal/convert/convert.go
@@ -72,6 +72,14 @@ type Options struct {
 	// bounds) histograms are converted to Prometheus Native Histograms with
 	// Custom Buckets instead of being written as N+2 classic series.
 	ConvertClassicHistogramsToNHCB bool
+	// KeepIdentifyingResourceAttributes preserves service.name,
+	// service.namespace, and service.instance.id as labels on target_info
+	// in addition to mapping them to job and instance. Defaults to true to
+	// remain compliant with the OpenTelemetry service resource semantic
+	// conventions (https://opentelemetry.io/docs/specs/semconv/resource/service/),
+	// which define these as standard resource attributes. Only affects
+	// target_info; regular metric series are unchanged.
+	KeepIdentifyingResourceAttributes bool
 }
 
 var _ consumer.Metrics = (*Converter)(nil)
@@ -203,12 +211,16 @@ func (conv *Converter) getOrCreateResource(res pcommon.Resource) *memorySeries {
 	lb.Set(model.JobLabel, jobLabel)
 	lb.Set(model.InstanceLabel, instanceLabel)
 
+	keepIdentifying := conv.getOpts().KeepIdentifyingResourceAttributes
+
 	attrs.Range(func(k string, v pcommon.Value) bool {
-		// Skip attributes that we used for determining the job and instance
-		// labels.
-		if k == string(semconv.ServiceNameKey) ||
-			k == string(semconv.ServiceNamespaceKey) ||
-			k == string(semconv.ServiceInstanceIDKey) {
+		// Skip service.name/namespace/instance.id only when opted out.
+		// Default keeps them on target_info per the OTel service resource
+		// semantic conventions.
+		if !keepIdentifying &&
+			(k == string(semconv.ServiceNameKey) ||
+				k == string(semconv.ServiceNamespaceKey) ||
+				k == string(semconv.ServiceInstanceIDKey)) {
 
 			return true
 		}

--- a/internal/component/otelcol/exporter/prometheus/internal/convert/convert.go
+++ b/internal/component/otelcol/exporter/prometheus/internal/convert/convert.go
@@ -213,9 +213,9 @@ func (conv *Converter) getOrCreateResource(res pcommon.Resource) *memorySeries {
 	keepIdentifying := conv.getOpts().KeepIdentifyingResourceAttributes
 
 	attrs.Range(func(k string, v pcommon.Value) bool {
-		// Skip service.name/namespace/instance.id only when opted out.
-		// Default keeps them on target_info per the OTel service resource
-		// semantic conventions.
+		// Skip service.name/namespace/instance.id unless
+		// KeepIdentifyingResourceAttributes is set; they are already
+		// represented as the job/instance labels.
 		if !keepIdentifying &&
 			(k == string(semconv.ServiceNameKey) ||
 				k == string(semconv.ServiceNamespaceKey) ||

--- a/internal/component/otelcol/exporter/prometheus/internal/convert/convert.go
+++ b/internal/component/otelcol/exporter/prometheus/internal/convert/convert.go
@@ -74,11 +74,10 @@ type Options struct {
 	ConvertClassicHistogramsToNHCB bool
 	// KeepIdentifyingResourceAttributes preserves service.name,
 	// service.namespace, and service.instance.id as labels on target_info
-	// in addition to mapping them to job and instance. Defaults to true to
-	// remain compliant with the OpenTelemetry service resource semantic
-	// conventions (https://opentelemetry.io/docs/specs/semconv/resource/service/),
-	// which define these as standard resource attributes. Only affects
-	// target_info; regular metric series are unchanged.
+	// in addition to mapping them to job and instance, keeping target_info
+	// compliant with the OpenTelemetry service resource semantic conventions
+	// (https://opentelemetry.io/docs/specs/semconv/resource/service/).
+	// Only affects target_info; regular metric series are unchanged.
 	KeepIdentifyingResourceAttributes bool
 }
 

--- a/internal/component/otelcol/exporter/prometheus/internal/convert/convert_test.go
+++ b/internal/component/otelcol/exporter/prometheus/internal/convert/convert_test.go
@@ -34,6 +34,7 @@ func TestConverter(t *testing.T) {
 		addMetricSuffixes             bool
 		enableOpenMetrics             bool
 		resourceToTelemetryConversion bool
+		stripIdentifyingResourceAttrs bool
 	}{
 		{
 			name: "Gauge with metadata",
@@ -470,9 +471,92 @@ func TestConverter(t *testing.T) {
 			expect: `
 				# HELP target_info Target metadata
 				# TYPE target_info gauge
-				target_info{instance="instance",job="myservice",custom_attr="test"} 1.0
+				target_info{instance="instance",service_instance_id="instance",job="myservice",service_name="myservice",custom_attr="test"} 1.0
 				# TYPE test_metric_seconds gauge
 				test_metric_seconds{instance="instance",job="myservice"} 1234.56
+			`,
+			enableOpenMetrics: true,
+		},
+		{
+			name: "Target info metric, identifying attributes stripped",
+			input: `{
+				"resource_metrics": [{
+					"resource": {
+						"attributes": [{
+							"key": "service.name",
+							"value": { "stringValue": "myservice" }
+						}, {
+							"key": "service.namespace",
+							"value": { "stringValue": "myns" }
+						}, {
+							"key": "service.instance.id",
+							"value": { "stringValue": "instance" }
+						}, {
+							"key": "custom_attr",
+							"value": { "stringValue": "test" }
+						}]
+					},
+					"scope_metrics": [{
+						"metrics": [{
+							"name": "test_metric_seconds",
+							"gauge": {
+								"data_points": [{
+									"as_double": 1234.56
+								}]
+							}
+						}]
+					}]
+				}]
+			}`,
+			includeTargetInfo:             true,
+			stripIdentifyingResourceAttrs: true,
+			expect: `
+				# HELP target_info Target metadata
+				# TYPE target_info gauge
+				target_info{instance="instance",job="myns/myservice",custom_attr="test"} 1.0
+				# TYPE test_metric_seconds gauge
+				test_metric_seconds{instance="instance",job="myns/myservice"} 1234.56
+			`,
+			enableOpenMetrics: true,
+		},
+		{
+			name: "Target info metric with service.namespace",
+			input: `{
+				"resource_metrics": [{
+					"resource": {
+						"attributes": [{
+							"key": "service.name",
+							"value": { "stringValue": "myservice" }
+						}, {
+							"key": "service.namespace",
+							"value": { "stringValue": "myns" }
+						}, {
+							"key": "service.instance.id",
+							"value": { "stringValue": "instance" }
+						}, {
+							"key": "custom_attr",
+							"value": { "stringValue": "test" }
+						}]
+					},
+					"scope_metrics": [{
+						"metrics": [{
+							"name": "test_metric_seconds",
+							"gauge": {
+								"data_points": [{
+									"as_double": 1234.56
+								}]
+							}
+						}]
+					}]
+				}]
+			}`,
+			includeTargetInfo: true,
+			expect: `
+				# HELP target_info Target metadata
+				# TYPE target_info gauge
+				target_info{instance="instance",service_instance_id="instance",service_namespace="myns",job="myns/myservice",service_name="myservice",custom_attr="test"} 1.0
+				# TYPE test_metric_seconds gauge
+				test_metric_seconds{instance="instance",job="myns/myservice"} 1234.56
 			`,
 			enableOpenMetrics: true,
 		},
@@ -1197,12 +1281,13 @@ func TestConverter(t *testing.T) {
 
 			l := util.TestAlloyLogger(t)
 			conv := convert.New(l.Slog(), appenderAppendable{Inner: &app}, convert.Options{
-				IncludeTargetInfo:             tc.includeTargetInfo,
-				IncludeScopeInfo:              tc.includeScopeInfo,
-				IncludeScopeLabels:            tc.includeScopeLabels,
-				AddMetricSuffixes:             tc.addMetricSuffixes,
-				ResourceToTelemetryConversion: tc.resourceToTelemetryConversion,
-				HonorMetadata:                 true,
+				IncludeTargetInfo:                 tc.includeTargetInfo,
+				IncludeScopeInfo:                  tc.includeScopeInfo,
+				IncludeScopeLabels:                tc.includeScopeLabels,
+				AddMetricSuffixes:                 tc.addMetricSuffixes,
+				ResourceToTelemetryConversion:     tc.resourceToTelemetryConversion,
+				HonorMetadata:                     true,
+				KeepIdentifyingResourceAttributes: !tc.stripIdentifyingResourceAttrs,
 			})
 			require.NoError(t, conv.ConsumeMetrics(t.Context(), payload))
 

--- a/internal/component/otelcol/exporter/prometheus/internal/convert/convert_test.go
+++ b/internal/component/otelcol/exporter/prometheus/internal/convert/convert_test.go
@@ -34,7 +34,7 @@ func TestConverter(t *testing.T) {
 		addMetricSuffixes             bool
 		enableOpenMetrics             bool
 		resourceToTelemetryConversion bool
-		keepIdentifyingResourceAttrs bool
+		keepIdentifyingResourceAttrs  bool
 	}{
 		{
 			name: "Gauge with metadata",

--- a/internal/component/otelcol/exporter/prometheus/internal/convert/convert_test.go
+++ b/internal/component/otelcol/exporter/prometheus/internal/convert/convert_test.go
@@ -34,7 +34,7 @@ func TestConverter(t *testing.T) {
 		addMetricSuffixes             bool
 		enableOpenMetrics             bool
 		resourceToTelemetryConversion bool
-		stripIdentifyingResourceAttrs bool
+		keepIdentifyingResourceAttrs bool
 	}{
 		{
 			name: "Gauge with metadata",
@@ -471,14 +471,14 @@ func TestConverter(t *testing.T) {
 			expect: `
 				# HELP target_info Target metadata
 				# TYPE target_info gauge
-				target_info{instance="instance",service_instance_id="instance",job="myservice",service_name="myservice",custom_attr="test"} 1.0
+				target_info{instance="instance",job="myservice",custom_attr="test"} 1.0
 				# TYPE test_metric_seconds gauge
 				test_metric_seconds{instance="instance",job="myservice"} 1234.56
 			`,
 			enableOpenMetrics: true,
 		},
 		{
-			name: "Target info metric, identifying attributes stripped",
+			name: "Target info metric with keep_identifying_resource_attributes",
 			input: `{
 				"resource_metrics": [{
 					"resource": {
@@ -508,49 +508,8 @@ func TestConverter(t *testing.T) {
 					}]
 				}]
 			}`,
-			includeTargetInfo:             true,
-			stripIdentifyingResourceAttrs: true,
-			expect: `
-				# HELP target_info Target metadata
-				# TYPE target_info gauge
-				target_info{instance="instance",job="myns/myservice",custom_attr="test"} 1.0
-				# TYPE test_metric_seconds gauge
-				test_metric_seconds{instance="instance",job="myns/myservice"} 1234.56
-			`,
-			enableOpenMetrics: true,
-		},
-		{
-			name: "Target info metric with service.namespace",
-			input: `{
-				"resource_metrics": [{
-					"resource": {
-						"attributes": [{
-							"key": "service.name",
-							"value": { "stringValue": "myservice" }
-						}, {
-							"key": "service.namespace",
-							"value": { "stringValue": "myns" }
-						}, {
-							"key": "service.instance.id",
-							"value": { "stringValue": "instance" }
-						}, {
-							"key": "custom_attr",
-							"value": { "stringValue": "test" }
-						}]
-					},
-					"scope_metrics": [{
-						"metrics": [{
-							"name": "test_metric_seconds",
-							"gauge": {
-								"data_points": [{
-									"as_double": 1234.56
-								}]
-							}
-						}]
-					}]
-				}]
-			}`,
-			includeTargetInfo: true,
+			includeTargetInfo:            true,
+			keepIdentifyingResourceAttrs: true,
 			expect: `
 				# HELP target_info Target metadata
 				# TYPE target_info gauge
@@ -1287,7 +1246,7 @@ func TestConverter(t *testing.T) {
 				AddMetricSuffixes:                 tc.addMetricSuffixes,
 				ResourceToTelemetryConversion:     tc.resourceToTelemetryConversion,
 				HonorMetadata:                     true,
-				KeepIdentifyingResourceAttributes: !tc.stripIdentifyingResourceAttrs,
+				KeepIdentifyingResourceAttributes: tc.keepIdentifyingResourceAttrs,
 			})
 			require.NoError(t, conv.ConsumeMetrics(t.Context(), payload))
 

--- a/internal/component/otelcol/exporter/prometheus/prometheus.go
+++ b/internal/component/otelcol/exporter/prometheus/prometheus.go
@@ -54,7 +54,7 @@ var DefaultArguments = Arguments{
 	AddMetricSuffixes:                 true,
 	ResourceToTelemetryConversion:     false,
 	HonorMetadata:                     false,
-	KeepIdentifyingResourceAttributes: true,
+	KeepIdentifyingResourceAttributes: false,
 }
 
 // SetToDefault implements syntax.Defaulter.

--- a/internal/component/otelcol/exporter/prometheus/prometheus.go
+++ b/internal/component/otelcol/exporter/prometheus/prometheus.go
@@ -33,26 +33,28 @@ func init() {
 
 // Arguments configures the otelcol.exporter.prometheus component.
 type Arguments struct {
-	IncludeTargetInfo              bool                 `alloy:"include_target_info,attr,optional"`
-	IncludeScopeInfo               bool                 `alloy:"include_scope_info,attr,optional"`
-	IncludeScopeLabels             bool                 `alloy:"include_scope_labels,attr,optional"`
-	GCFrequency                    time.Duration        `alloy:"gc_frequency,attr,optional"`
-	ForwardTo                      []storage.Appendable `alloy:"forward_to,attr"`
-	AddMetricSuffixes              bool                 `alloy:"add_metric_suffixes,attr,optional"`
-	ResourceToTelemetryConversion  bool                 `alloy:"resource_to_telemetry_conversion,attr,optional"`
-	HonorMetadata                  bool                 `alloy:"honor_metadata,attr,optional"`
-	ConvertClassicHistogramsToNHCB bool                 `alloy:"convert_classic_histograms_to_nhcb,attr,optional"`
+	IncludeTargetInfo                bool                 `alloy:"include_target_info,attr,optional"`
+	IncludeScopeInfo                 bool                 `alloy:"include_scope_info,attr,optional"`
+	IncludeScopeLabels               bool                 `alloy:"include_scope_labels,attr,optional"`
+	GCFrequency                      time.Duration        `alloy:"gc_frequency,attr,optional"`
+	ForwardTo                        []storage.Appendable `alloy:"forward_to,attr"`
+	AddMetricSuffixes                bool                 `alloy:"add_metric_suffixes,attr,optional"`
+	ResourceToTelemetryConversion    bool                 `alloy:"resource_to_telemetry_conversion,attr,optional"`
+	HonorMetadata                    bool                 `alloy:"honor_metadata,attr,optional"`
+	ConvertClassicHistogramsToNHCB   bool                 `alloy:"convert_classic_histograms_to_nhcb,attr,optional"`
+	KeepIdentifyingResourceAttributes bool                `alloy:"keep_identifying_resource_attributes,attr,optional"`
 }
 
 // DefaultArguments holds defaults values.
 var DefaultArguments = Arguments{
-	IncludeTargetInfo:             true,
-	IncludeScopeInfo:              false,
-	IncludeScopeLabels:            true,
-	GCFrequency:                   5 * time.Minute,
-	AddMetricSuffixes:             true,
-	ResourceToTelemetryConversion: false,
-	HonorMetadata:                 false,
+	IncludeTargetInfo:                 true,
+	IncludeScopeInfo:                  false,
+	IncludeScopeLabels:                true,
+	GCFrequency:                       5 * time.Minute,
+	AddMetricSuffixes:                 true,
+	ResourceToTelemetryConversion:     false,
+	HonorMetadata:                     false,
+	KeepIdentifyingResourceAttributes: true,
 }
 
 // SetToDefault implements syntax.Defaulter.
@@ -172,11 +174,12 @@ func validateStabilityLevel(o component.Options, args Arguments) error {
 
 func convertArgumentsToConvertOptions(args Arguments) convert.Options {
 	return convert.Options{
-		IncludeTargetInfo:              args.IncludeTargetInfo,
-		IncludeScopeInfo:               args.IncludeScopeInfo,
-		AddMetricSuffixes:              args.AddMetricSuffixes,
-		ResourceToTelemetryConversion:  args.ResourceToTelemetryConversion,
-		HonorMetadata:                  args.HonorMetadata,
-		ConvertClassicHistogramsToNHCB: args.ConvertClassicHistogramsToNHCB,
+		IncludeTargetInfo:                 args.IncludeTargetInfo,
+		IncludeScopeInfo:                  args.IncludeScopeInfo,
+		AddMetricSuffixes:                 args.AddMetricSuffixes,
+		ResourceToTelemetryConversion:     args.ResourceToTelemetryConversion,
+		HonorMetadata:                     args.HonorMetadata,
+		ConvertClassicHistogramsToNHCB:    args.ConvertClassicHistogramsToNHCB,
+		KeepIdentifyingResourceAttributes: args.KeepIdentifyingResourceAttributes,
 	}
 }

--- a/internal/component/otelcol/exporter/prometheus/prometheus.go
+++ b/internal/component/otelcol/exporter/prometheus/prometheus.go
@@ -33,16 +33,16 @@ func init() {
 
 // Arguments configures the otelcol.exporter.prometheus component.
 type Arguments struct {
-	IncludeTargetInfo                bool                 `alloy:"include_target_info,attr,optional"`
-	IncludeScopeInfo                 bool                 `alloy:"include_scope_info,attr,optional"`
-	IncludeScopeLabels               bool                 `alloy:"include_scope_labels,attr,optional"`
-	GCFrequency                      time.Duration        `alloy:"gc_frequency,attr,optional"`
-	ForwardTo                        []storage.Appendable `alloy:"forward_to,attr"`
-	AddMetricSuffixes                bool                 `alloy:"add_metric_suffixes,attr,optional"`
-	ResourceToTelemetryConversion    bool                 `alloy:"resource_to_telemetry_conversion,attr,optional"`
-	HonorMetadata                    bool                 `alloy:"honor_metadata,attr,optional"`
-	ConvertClassicHistogramsToNHCB   bool                 `alloy:"convert_classic_histograms_to_nhcb,attr,optional"`
-	KeepIdentifyingResourceAttributes bool                `alloy:"keep_identifying_resource_attributes,attr,optional"`
+	IncludeTargetInfo                 bool                 `alloy:"include_target_info,attr,optional"`
+	IncludeScopeInfo                  bool                 `alloy:"include_scope_info,attr,optional"`
+	IncludeScopeLabels                bool                 `alloy:"include_scope_labels,attr,optional"`
+	GCFrequency                       time.Duration        `alloy:"gc_frequency,attr,optional"`
+	ForwardTo                         []storage.Appendable `alloy:"forward_to,attr"`
+	AddMetricSuffixes                 bool                 `alloy:"add_metric_suffixes,attr,optional"`
+	ResourceToTelemetryConversion     bool                 `alloy:"resource_to_telemetry_conversion,attr,optional"`
+	HonorMetadata                     bool                 `alloy:"honor_metadata,attr,optional"`
+	ConvertClassicHistogramsToNHCB    bool                 `alloy:"convert_classic_histograms_to_nhcb,attr,optional"`
+	KeepIdentifyingResourceAttributes bool                 `alloy:"keep_identifying_resource_attributes,attr,optional"`
 }
 
 // DefaultArguments holds defaults values.

--- a/internal/component/otelcol/exporter/prometheus/prometheus_test.go
+++ b/internal/component/otelcol/exporter/prometheus/prometheus_test.go
@@ -31,7 +31,7 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 				ForwardTo:                         []storage.Appendable{},
 				ResourceToTelemetryConversion:     false,
 				HonorMetadata:                     false,
-				KeepIdentifyingResourceAttributes: true,
+				KeepIdentifyingResourceAttributes: false,
 			},
 		},
 		{
@@ -44,7 +44,7 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 					add_metric_suffixes = false
 					resource_to_telemetry_conversion = true
 					honor_metadata = true
-					keep_identifying_resource_attributes = false
+					keep_identifying_resource_attributes = true
 					forward_to = []
 				`,
 			expected: prometheus.Arguments{
@@ -56,7 +56,7 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 				ForwardTo:                         []storage.Appendable{},
 				ResourceToTelemetryConversion:     true,
 				HonorMetadata:                     true,
-				KeepIdentifyingResourceAttributes: false,
+				KeepIdentifyingResourceAttributes: true,
 			},
 		},
 		{

--- a/internal/component/otelcol/exporter/prometheus/prometheus_test.go
+++ b/internal/component/otelcol/exporter/prometheus/prometheus_test.go
@@ -23,14 +23,15 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 					forward_to = []
 				`,
 			expected: prometheus.Arguments{
-				IncludeTargetInfo:             true,
-				IncludeScopeInfo:              false,
-				IncludeScopeLabels:            true,
-				GCFrequency:                   5 * time.Minute,
-				AddMetricSuffixes:             true,
-				ForwardTo:                     []storage.Appendable{},
-				ResourceToTelemetryConversion: false,
-				HonorMetadata:                 false,
+				IncludeTargetInfo:                 true,
+				IncludeScopeInfo:                  false,
+				IncludeScopeLabels:                true,
+				GCFrequency:                       5 * time.Minute,
+				AddMetricSuffixes:                 true,
+				ForwardTo:                         []storage.Appendable{},
+				ResourceToTelemetryConversion:     false,
+				HonorMetadata:                     false,
+				KeepIdentifyingResourceAttributes: true,
 			},
 		},
 		{
@@ -43,17 +44,19 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 					add_metric_suffixes = false
 					resource_to_telemetry_conversion = true
 					honor_metadata = true
+					keep_identifying_resource_attributes = false
 					forward_to = []
 				`,
 			expected: prometheus.Arguments{
-				IncludeTargetInfo:             false,
-				IncludeScopeInfo:              true,
-				IncludeScopeLabels:            false,
-				GCFrequency:                   1 * time.Second,
-				AddMetricSuffixes:             false,
-				ForwardTo:                     []storage.Appendable{},
-				ResourceToTelemetryConversion: true,
-				HonorMetadata:                 true,
+				IncludeTargetInfo:                 false,
+				IncludeScopeInfo:                  true,
+				IncludeScopeLabels:                false,
+				GCFrequency:                       1 * time.Second,
+				AddMetricSuffixes:                 false,
+				ForwardTo:                         []storage.Appendable{},
+				ResourceToTelemetryConversion:     true,
+				HonorMetadata:                     true,
+				KeepIdentifyingResourceAttributes: false,
 			},
 		},
 		{

--- a/internal/converter/internal/staticconvert/internal/build/converter_remotewriteexporter.go
+++ b/internal/converter/internal/staticconvert/internal/build/converter_remotewriteexporter.go
@@ -92,12 +92,13 @@ func toremotewriteexporterConfig(cfg *remotewriteexporter.Config, forwardTo []st
 	defaultArgs.SetToDefault()
 
 	return &prometheus.Arguments{
-		IncludeTargetInfo:             defaultArgs.IncludeTargetInfo,
-		IncludeScopeInfo:              defaultArgs.IncludeScopeInfo,
-		IncludeScopeLabels:            defaultArgs.IncludeScopeLabels,
-		GCFrequency:                   cfg.StaleTime,
-		ForwardTo:                     forwardTo,
-		AddMetricSuffixes:             defaultArgs.AddMetricSuffixes,
-		ResourceToTelemetryConversion: defaultArgs.ResourceToTelemetryConversion,
+		IncludeTargetInfo:                 defaultArgs.IncludeTargetInfo,
+		IncludeScopeInfo:                  defaultArgs.IncludeScopeInfo,
+		IncludeScopeLabels:                defaultArgs.IncludeScopeLabels,
+		GCFrequency:                       cfg.StaleTime,
+		ForwardTo:                         forwardTo,
+		AddMetricSuffixes:                 defaultArgs.AddMetricSuffixes,
+		ResourceToTelemetryConversion:     defaultArgs.ResourceToTelemetryConversion,
+		KeepIdentifyingResourceAttributes: defaultArgs.KeepIdentifyingResourceAttributes,
 	}
 }


### PR DESCRIPTION

<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style with a capitalized
  description, e.g. `feat(scope): Add the thing` (not `add the thing`). For
  details on this, check out the Contributors Guide linked above.
-->

### Brief description of Pull Request

<!-- Human-readable description of the PR used as squash commit body. -->

  - `service.*` attributes are required by OTEL's [service semantic conventions](https://opentelemetry.io/docs/specs/semconv/resource/service/)
  - In addition to mapping the `job` and `instance` labels, this component currently strips out the attributes, without possibility to opt-out.
  - This change adds a config option to strip them out conditionally.


### Pull Request Details

<!-- Detailed descripion of the Pull Request, if needed. -->

  - Given how critical these attributes are for APMs, ideally the default is set to `true` in a future release. 
  - The only risk is hitting label count limits in some prometheus setups. I believe this risk is not very high, as OTEL already produces high cardinality series and this only adds up to 3 labels, but it is worth considering.
  - Note: this only affects the `target_info` series, no individual metric series.

### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->


### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated
