### PR TITLE
fix(graphql): Update cli flags for consistency

### DIFF
--- a/docs/sources/reference/cli/gql.md
+++ b/docs/sources/reference/cli/gql.md
@@ -35,10 +35,10 @@ The `graphql` command is an alias for `gql`.
 ## Enable the GraphQL API
 
 The GraphQL API is disabled by default.
-To enable it, start {{< param "PRODUCT_NAME" >}} with the `--stability.level=experimental` and `--feature.graphql.enabled` flags:
+To enable it, start {{< param "PRODUCT_NAME" >}} with the `--stability.level=experimental` and `--server.http.enable-graphql` flags:
 
 ```shell
-alloy run --stability.level=experimental --feature.graphql.enabled <CONFIG_PATH>
+alloy run --stability.level=experimental --server.http.enable-graphql <CONFIG_PATH>
 ```
 
 Replace _`<CONFIG_PATH>`_ with the {{< param "PRODUCT_NAME" >}} configuration file or directory path.
@@ -94,7 +94,7 @@ The output resembles the following:
 }
 ```
 
-To query a GraphQL endpoint on a different address, use the `--endpoint` flag:
+To query a GraphQL endpoint on a different address (including other {{< param "PRODUCT_NAME" >}} deployments), use the `--endpoint` flag:
 
 ```shell
 alloy gql --endpoint=http://localhost:12345/graphql 'components { id health { message } }'

--- a/docs/sources/reference/cli/run.md
+++ b/docs/sources/reference/cli/run.md
@@ -67,8 +67,8 @@ The following flags are supported:
 * `--feature.community-components.enabled`: Enable community components (default `false`).
 * `--feature.component-shutdown-deadline`: Maximum duration to wait for a component to shut down before giving up and logging an error (default `"10m"`).
 * `--feature.prometheus.direct-fanout.enabled`: Enable experimental direct fanout for metric forwarding without a global label store.
-* `--feature.graphql.enabled`: Enable the [GraphQL API][] (default `false`).
-* `--feature.graphql-playground.enabled`: Enable the [GraphQL playground][] UI at `/graphql/playground` (default `false`). Requires `--feature.graphql.enabled`.
+* `--server.http.enable-graphql`: Enable the [GraphQL API][] (default `false`).
+* `--server.http.enable-graphql-playground`: Enable the [GraphQL playground][] UI at `/graphql/playground` (default `false`). Requires `--server.http.enable-graphql`.
 * `--windows.priority`: The priority to set for the {{< param "PRODUCT_NAME" >}} process when running on Windows. This is only available on Windows. Supported values: `above_normal`, `below_normal`, `normal`, `high`, `idle`, or `realtime` (default `"normal"`).
 
 {{< admonition type="note" >}}

--- a/docs/sources/reference/http/_index.md
+++ b/docs/sources/reference/http/_index.md
@@ -79,8 +79,8 @@ The `/debug/pprof` endpoint returns a pprof Go [profile](../../troubleshoot/prof
 
 {{< docs/shared lookup="stability/experimental_feature.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
-The `/graphql` endpoint exposes a [GraphQL API](./graphql/) for querying various aspects of {{< param "PRODUCT_NAME" >}}. It is disabled by default. To enable it, set the `--feature.graphql.enabled` flag to `true`.
+The `/graphql` endpoint exposes a [GraphQL API](./graphql/) for querying various aspects of {{< param "PRODUCT_NAME" >}}. It is disabled by default. To enable it, set the `--server.http.enable-graphql` flag to `true`.
 
-You can also enable an interactive GraphQL playground at `/graphql/playground` by setting the `--feature.graphql-playground.enabled` flag to `true`.
+You can also enable an interactive GraphQL playground at `/graphql/playground` by setting the `--server.http.enable-graphql-playground` flag to `true`.
 
 Refer to the [GraphQL API](./graphql/) documentation for the full schema and example queries.

--- a/docs/sources/reference/http/graphql.md
+++ b/docs/sources/reference/http/graphql.md
@@ -19,14 +19,14 @@ You can use the GraphQL API to retrieve build metadata, readiness status, and co
 Before you begin, ensure you have the following:
 
 - A running {{< param "PRODUCT_NAME" >}} instance.
-- The `--feature.graphql.enabled` flag set to `true` when starting {{< param "PRODUCT_NAME" >}}.
+- The `--server.http.enable-graphql` flag set to `true` when starting {{< param "PRODUCT_NAME" >}}.
 
 ## Enable the GraphQL API
 
-The GraphQL API is disabled by default. To enable it, start {{< param "PRODUCT_NAME" >}} with the `--feature.graphql.enabled` flag:
+The GraphQL API is disabled by default. To enable it, start {{< param "PRODUCT_NAME" >}} with the `--server.http.enable-graphql` flag:
 
 ```sh
-alloy run --feature.graphql.enabled config.alloy
+alloy run --server.http.enable-graphql config.alloy
 ```
 
 After you enable the API, the `/graphql` endpoint becomes available on the {{< param "PRODUCT_NAME" >}} HTTP server.
@@ -35,10 +35,10 @@ By default, this is `http://localhost:12345/graphql`.
 ## GraphQL playground
 
 {{< param "PRODUCT_NAME" >}} includes an optional interactive GraphQL playground that you can use to explore the schema and run queries.
-To enable the playground, use the `--feature.graphql-playground.enabled` flag:
+To enable the playground, use the `--server.http.enable-graphql-playground` flag:
 
 ```sh
-alloy run --feature.graphql.enabled --feature.graphql-playground.enabled config.alloy
+alloy run --server.http.enable-graphql --server.http.enable-graphql-playground config.alloy
 ```
 
 After you enable the playground, it's available at `/graphql/playground` on the {{< param "PRODUCT_NAME" >}} HTTP server.

--- a/docs/sources/reference/http/graphql.md
+++ b/docs/sources/reference/http/graphql.md
@@ -32,9 +32,9 @@ alloy run --server.http.enable-graphql config.alloy
 After you enable the API, the `/graphql` endpoint becomes available on the {{< param "PRODUCT_NAME" >}} HTTP server.
 By default, this is `http://localhost:12345/graphql`.
 
-## GraphQL playground
+## GraphQL Playground
 
-{{< param "PRODUCT_NAME" >}} includes an optional interactive GraphQL playground that you can use to explore the schema and run queries.
+{{< param "PRODUCT_NAME" >}} includes an optional interactive GraphQL Playground that you can use to explore the schema and run queries.
 To enable the playground, use the `--server.http.enable-graphql-playground` flag:
 
 ```sh

--- a/integration-tests/docker/tests/graphql/docker-compose.yaml
+++ b/integration-tests/docker/tests/graphql/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
         "--server.http.listen-addr",
         "0.0.0.0:12345",
         "--stability.level=experimental",
-        "--feature.graphql.enabled=true",
+        "--server.http.enable-graphql=true",
       ]
     volumes:
       - ./config.alloy:/etc/alloy/config.alloy:ro

--- a/internal/alloycli/cmd_gql.go
+++ b/internal/alloycli/cmd_gql.go
@@ -29,7 +29,7 @@ func gqlCommand() *cobra.Command {
 		Long: `The gql subcommand runs a GraphQL query against a running Alloy instance.
 The query is provided as a single argument to the command.
 
-It requires the --feature.graphql.enabled flag on the running Alloy instance to
+It requires the --server.http.enable-graphql flag on the running Alloy instance to
 be set, as well as --stability.level flag set to "experimental".
 
 This command is experimental and may be modified or removed in the future. Use

--- a/internal/alloycli/cmd_run.go
+++ b/internal/alloycli/cmd_run.go
@@ -113,48 +113,31 @@ depending on the nature of the reload error.
 	}
 
 	// Server flags
-	cmd.Flags().
-		StringVar(&r.httpListenAddr, "server.http.listen-addr", r.httpListenAddr, "Address to listen for HTTP traffic on")
+	cmd.Flags().StringVar(&r.httpListenAddr, "server.http.listen-addr", r.httpListenAddr, "Address to listen for HTTP traffic on")
 	cmd.Flags().StringVar(&r.inMemoryAddr, "server.http.memory-addr", r.inMemoryAddr, "Address to listen for in-memory HTTP traffic on. Change if it collides with a real address")
 	cmd.Flags().StringVar(&r.uiPrefix, "server.http.ui-path-prefix", r.uiPrefix, "Prefix to serve the HTTP UI at")
-	cmd.Flags().
-		BoolVar(&r.enablePprof, "server.http.enable-pprof", r.enablePprof, "Enable /debug/pprof profiling endpoints.")
-	cmd.Flags().
-		BoolVar(&r.disableSupportBundle, "server.http.disable-support-bundle", r.disableSupportBundle, "Disable /-/support support bundle retrieval.")
+	cmd.Flags().BoolVar(&r.enablePprof, "server.http.enable-pprof", r.enablePprof, "Enable /debug/pprof profiling endpoints.")
+	cmd.Flags().BoolVar(&r.disableSupportBundle, "server.http.disable-support-bundle", r.disableSupportBundle, "Disable /-/support support bundle retrieval.")
+	cmd.Flags().BoolVar(&r.enableGraphQL, "server.http.enable-graphql", r.enableGraphQL, "Enable the GraphQL API")
+	cmd.Flags().BoolVar(&r.enableGraphQLPlayground, "server.http.enable-graphql-playground", r.enableGraphQLPlayground, "Enable the GraphQL playground UI (/graphql/playground)")
 
 	// Cluster flags
-	cmd.Flags().
-		BoolVar(&r.clusterEnabled, "cluster.enabled", r.clusterEnabled, "Start in clustered mode")
-	cmd.Flags().
-		StringVar(&r.clusterNodeName, "cluster.node-name", r.clusterNodeName, "The name to use for this node")
-	cmd.Flags().
-		StringVar(&r.clusterAdvAddr, "cluster.advertise-address", r.clusterAdvAddr, "Address to advertise to the cluster")
-	cmd.Flags().
-		StringVar(&r.clusterJoinAddr, "cluster.join-addresses", r.clusterJoinAddr, "Comma-separated list of addresses to join the cluster at")
-	cmd.Flags().
-		StringVar(&r.clusterDiscoverPeers, "cluster.discover-peers", r.clusterDiscoverPeers, "List of key-value tuples for discovering peers")
-	cmd.Flags().
-		StringSliceVar(&r.clusterAdvInterfaces, "cluster.advertise-interfaces", r.clusterAdvInterfaces, "List of interfaces used to infer an address to advertise")
-	cmd.Flags().
-		DurationVar(&r.clusterRejoinInterval, "cluster.rejoin-interval", r.clusterRejoinInterval, "How often to rejoin the list of peers")
-	cmd.Flags().
-		IntVar(&r.clusterMaxJoinPeers, "cluster.max-join-peers", r.clusterMaxJoinPeers, "Number of peers to join from the discovered set")
-	cmd.Flags().
-		StringVar(&r.clusterName, "cluster.name", r.clusterName, "The name of the cluster to join")
-	cmd.Flags().
-		BoolVar(&r.clusterEnableTLS, "cluster.enable-tls", r.clusterEnableTLS, "Specifies whether TLS should be used for communication between peers")
-	cmd.Flags().
-		StringVar(&r.clusterTLSCAPath, "cluster.tls-ca-path", r.clusterTLSCAPath, "Path to the CA certificate file")
-	cmd.Flags().
-		StringVar(&r.clusterTLSCertPath, "cluster.tls-cert-path", r.clusterTLSCertPath, "Path to the certificate file")
-	cmd.Flags().
-		StringVar(&r.clusterTLSKeyPath, "cluster.tls-key-path", r.clusterTLSKeyPath, "Path to the key file")
-	cmd.Flags().
-		StringVar(&r.clusterTLSServerName, "cluster.tls-server-name", r.clusterTLSServerName, "Server name to use for TLS communication")
-	cmd.Flags().
-		IntVar(&r.clusterWaitForSize, "cluster.wait-for-size", r.clusterWaitForSize, "Wait for the cluster to reach the specified number of instances before allowing components that use clustering to begin processing. Zero means disabled")
-	cmd.Flags().
-		DurationVar(&r.clusterWaitTimeout, "cluster.wait-timeout", 0, "Maximum duration to wait for minimum cluster size before proceeding with available nodes. Zero means wait forever, no timeout")
+	cmd.Flags().BoolVar(&r.clusterEnabled, "cluster.enabled", r.clusterEnabled, "Start in clustered mode")
+	cmd.Flags().StringVar(&r.clusterNodeName, "cluster.node-name", r.clusterNodeName, "The name to use for this node")
+	cmd.Flags().StringVar(&r.clusterAdvAddr, "cluster.advertise-address", r.clusterAdvAddr, "Address to advertise to the cluster")
+	cmd.Flags().StringVar(&r.clusterJoinAddr, "cluster.join-addresses", r.clusterJoinAddr, "Comma-separated list of addresses to join the cluster at")
+	cmd.Flags().StringVar(&r.clusterDiscoverPeers, "cluster.discover-peers", r.clusterDiscoverPeers, "List of key-value tuples for discovering peers")
+	cmd.Flags().StringSliceVar(&r.clusterAdvInterfaces, "cluster.advertise-interfaces", r.clusterAdvInterfaces, "List of interfaces used to infer an address to advertise")
+	cmd.Flags().DurationVar(&r.clusterRejoinInterval, "cluster.rejoin-interval", r.clusterRejoinInterval, "How often to rejoin the list of peers")
+	cmd.Flags().IntVar(&r.clusterMaxJoinPeers, "cluster.max-join-peers", r.clusterMaxJoinPeers, "Number of peers to join from the discovered set")
+	cmd.Flags().StringVar(&r.clusterName, "cluster.name", r.clusterName, "The name of the cluster to join")
+	cmd.Flags().BoolVar(&r.clusterEnableTLS, "cluster.enable-tls", r.clusterEnableTLS, "Specifies whether TLS should be used for communication between peers")
+	cmd.Flags().StringVar(&r.clusterTLSCAPath, "cluster.tls-ca-path", r.clusterTLSCAPath, "Path to the CA certificate file")
+	cmd.Flags().StringVar(&r.clusterTLSCertPath, "cluster.tls-cert-path", r.clusterTLSCertPath, "Path to the certificate file")
+	cmd.Flags().StringVar(&r.clusterTLSKeyPath, "cluster.tls-key-path", r.clusterTLSKeyPath, "Path to the key file")
+	cmd.Flags().StringVar(&r.clusterTLSServerName, "cluster.tls-server-name", r.clusterTLSServerName, "Server name to use for TLS communication")
+	cmd.Flags().IntVar(&r.clusterWaitForSize, "cluster.wait-for-size", r.clusterWaitForSize, "Wait for the cluster to reach the specified number of instances before allowing components that use clustering to begin processing. Zero means disabled")
+	cmd.Flags().DurationVar(&r.clusterWaitTimeout, "cluster.wait-timeout", 0, "Maximum duration to wait for minimum cluster size before proceeding with available nodes. Zero means wait forever, no timeout")
 
 	// Config flags
 	cmd.Flags().StringVar(&r.configFormat, "config.format", r.configFormat, fmt.Sprintf("The format of the source file. Supported formats: %s.", supportedFormatsList()))
@@ -162,8 +145,7 @@ depending on the nature of the reload error.
 	cmd.Flags().StringVar(&r.configExtraArgs, "config.extra-args", r.configExtraArgs, "Extra arguments from the original format used by the converter. Multiple arguments can be passed by separating them with a space.")
 
 	// Misc flags
-	cmd.Flags().
-		BoolVar(&r.disableReporting, "disable-reporting", r.disableReporting, "Disable reporting of enabled components to Grafana.")
+	cmd.Flags().BoolVar(&r.disableReporting, "disable-reporting", r.disableReporting, "Disable reporting of enabled components to Grafana.")
 	cmd.Flags().StringVar(&r.storagePath, "storage.path", r.storagePath, "Base directory where components can store data")
 	cmd.Flags().Var(&r.minStability, "stability.level", fmt.Sprintf("Minimum stability level of features to enable. Supported values: %s", strings.Join(featuregate.AllowedValues(), ", ")))
 	if runtime.GOOS == "windows" {
@@ -173,8 +155,6 @@ depending on the nature of the reload error.
 	// Feature flags
 	cmd.Flags().BoolVar(&r.enableCommunityComps, "feature.community-components.enabled", r.enableCommunityComps, "Enable community components.")
 	cmd.Flags().DurationVar(&r.taskShutdownDeadline, "feature.component-shutdown-deadline", r.taskShutdownDeadline, "Maximum duration to wait for a component to shut down before giving up and logging an error")
-	cmd.Flags().BoolVar(&r.enableGraphQL, "feature.graphql.enabled", r.enableGraphQL, "Enable the GraphQL API")
-	cmd.Flags().BoolVar(&r.enableGraphQLPlayground, "feature.graphql-playground.enabled", r.enableGraphQLPlayground, "Enable the GraphQL playground UI (/graphql/playground)")
 	cmd.Flags().BoolVar(&r.enableDirectFanout, "feature.prometheus.direct-fanout.enabled", r.enableDirectFanout, "Enable experimental direct fanout for metric forwarding without a global label store")
 
 	addDeprecatedFlags(cmd)
@@ -230,11 +210,11 @@ func (fr *alloyRun) checkExperimentalFlags() error {
 	}
 
 	if fr.enableGraphQL {
-		return fmt.Errorf("'--feature.graphql.enabled' %s", errMsg)
+		return fmt.Errorf("'--server.http.enable-graphql' %s", errMsg)
 	}
 
 	if fr.enableGraphQLPlayground {
-		return fmt.Errorf("'--feature.graphql-playground.enabled' %s", errMsg)
+		return fmt.Errorf("'--server.http.enable-graphql-playground' %s", errMsg)
 	}
 
 	return nil

--- a/internal/service/graphql/README.md
+++ b/internal/service/graphql/README.md
@@ -16,5 +16,5 @@ make generate-graphql
 From here, you can start Alloy like normal and the GraphQL API will be reachable at
 http://localhost:12345/graphql
 
-To enable the GraphQL Playground, run Alloy with `--feature.graphql-playground.enabled` and connect
+To enable the GraphQL Playground, run Alloy with `--server.http.enable-graphql-playground` and connect
 to the UI at http://localhost:12345/graphql/playground


### PR DESCRIPTION
### Brief description of Pull Request

Change graphQL command line flags from `feature.*` to `server.http.*`

- [x] Documentation added
- [x] Tests updated
