### PR TITLE
ci: Sign dev container images with cosign

### DIFF
--- a/.github/workflows/publish-alloy-devel.yml
+++ b/.github/workflows/publish-alloy-devel.yml
@@ -39,7 +39,37 @@ jobs:
     with:
       img-name: alloy-devel
       dev: true
-        
+
+  sign_linux_container:
+    needs: publish_linux_container
+    if: ${{ needs.publish_linux_container.outputs.image != '' }}
+    uses: ./.github/workflows/sign-and-attest.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      image: ${{ needs.publish_linux_container.outputs.image }}
+
+  sign_linux_boringcrypto_container:
+    needs: publish_linux_boringcrypto_container
+    if: ${{ needs.publish_linux_boringcrypto_container.outputs.image != '' }}
+    uses: ./.github/workflows/sign-and-attest.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      image: ${{ needs.publish_linux_boringcrypto_container.outputs.image }}
+
+  sign_windows_container:
+    needs: publish_windows_container
+    if: ${{ needs.publish_windows_container.outputs.image != '' }}
+    uses: ./.github/workflows/sign-and-attest.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      image: ${{ needs.publish_windows_container.outputs.image }}
+
   update_deployment_tools:
     name: Update deployment_tools
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-alloy-linux.yml
+++ b/.github/workflows/publish-alloy-linux.yml
@@ -18,6 +18,10 @@ on:
         required: false
         type: string
         default: ""
+    outputs:
+      image:
+        description: "Digest-pinned ref of the pushed image (e.g. <repo>@sha256:...). Empty when not pushed or when the build target isn't configured for signing."
+        value: ${{ jobs.publish_linux_container.outputs.image }}
 
 permissions:
   contents: read
@@ -32,6 +36,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    outputs:
+      image: ${{ steps.build.outputs.image }}
     steps:
       # This step needs to run before "Checkout code".
       # That's because it generates a new file.
@@ -58,7 +64,8 @@ jobs:
           # this is to fix GIT not liking owner of the checkout dir
           chown -R $(id -u):$(id -g) $PWD
 
-    - run: |
+    - id: build
+      run: |
         docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
         docker buildx create --name multiarch-alloy-${IMG_NAME}-${GITHUB_SHA} --driver docker-container --use
         ./scripts/docker-containers ${IMG_NAME}

--- a/.github/workflows/publish-alloy-windows.yml
+++ b/.github/workflows/publish-alloy-windows.yml
@@ -22,6 +22,10 @@ on:
         required: false
         type: string
         default: ""
+    outputs:
+      image:
+        description: "Digest-pinned ref of the pushed image (e.g. <repo>@sha256:...). Empty when not pushed or when the build target isn't configured for signing."
+        value: ${{ jobs.publish_windows_container.outputs.image }}
 
 permissions:
   contents: read
@@ -30,13 +34,12 @@ permissions:
 jobs:
   publish_windows_container:
     name: Publish Alloy Windows container
-    strategy:
-      matrix:
-        os: [windows-2022]
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-2022
     permissions:
       contents: read
       id-token: write
+    outputs:
+      image: ${{ steps.build.outputs.image }}
     steps:
     - name: Ensure Docker is running (Docker issue workaround)
       id: docker-workaround
@@ -83,9 +86,10 @@ jobs:
         "alloy_go_version=$go_short_version" >> $env:GITHUB_OUTPUT
 
     - name: Build and publish the container
+      id: build
       # TODO: Run "make alloy-image-windows" instead?
       run: |
-        & "C:/Program Files/git/bin/bash.exe" -c 'PUSH_ALLOY_IMAGE=${SHOULD_PUSH_ALLOY_IMAGE} WINDOWS_VERSION=${{matrix.os}} ALLOY_GO_VERSION=${GO_VERSION} ./scripts/docker-containers-windows ${IMG_NAME}'
+        & "C:/Program Files/git/bin/bash.exe" -c 'PUSH_ALLOY_IMAGE=${SHOULD_PUSH_ALLOY_IMAGE} WINDOWS_VERSION=windows-2022 ALLOY_GO_VERSION=${GO_VERSION} ./scripts/docker-containers-windows ${IMG_NAME}'
       env:
         SHOULD_PUSH_ALLOY_IMAGE: ${{ inputs.push }}
         IMG_NAME: ${{ inputs.img-name }}

--- a/.github/workflows/sign-and-attest.yml
+++ b/.github/workflows/sign-and-attest.yml
@@ -1,0 +1,70 @@
+name: Sign release image
+
+# Keyless-signs a pushed container image with cosign via GitHub Actions OIDC.
+# Input is a digest-pinned image ref.
+#
+# The signer is this workflow, so consumers verify against a cert identity of:
+#   https://github.com/grafana/alloy/.github/workflows/sign-and-attest.yml@<ref>
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: 'Digest-pinned image reference to sign, e.g. us-docker.pkg.dev/grafanalabs-global/dockerhub-alloy-prod-mirror/alloy@sha256:...'
+        required: true
+        type: string
+      registry:
+        description: 'Registry to authenticate against when writing the signature.'
+        required: false
+        type: string
+        default: us-docker.pkg.dev
+
+permissions:
+  contents: read
+  id-token: write # keyless cosign OIDC, and login-to-gar workload identity
+
+jobs:
+  sign:
+    name: Sign image with cosign
+    runs-on: ubuntu-latest
+    steps:
+    - name: Validate image is digest-pinned
+      env:
+        IMAGE: ${{ inputs.image }}
+      run: |
+        if [[ "${IMAGE}" != *"@sha256:"* ]]; then
+          echo "::error::image must be digest-pinned (contain @sha256:), got: ${IMAGE}"
+          exit 1
+        fi
+
+    - name: Log in to Google Artifact Registry
+      uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
+      with:
+        registry: ${{ inputs.registry }}
+
+    - name: Install cosign
+      uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      with:
+        cosign-release: v3.0.6
+
+    - name: Sign image
+      # Signs the image index only (no --recursive); that covers pulls by tag or
+      # index digest. Uploads to the public Rekor transparency log by default,
+      # which is what makes the short-lived cert verifiable after it expires.
+      env:
+        IMAGE: ${{ inputs.image }}
+      run: |
+        cosign sign --yes "${IMAGE}"
+
+    - name: Verify signature
+      # Catch a broken signature before the draft release is published, since
+      # immutable releases can't be re-signed after publish. This checks the GAR
+      # copy; the mirror to Docker Hub is async, so it isn't verified here.
+      env:
+        IMAGE: ${{ inputs.image }}
+        REPO: ${{ github.repository }}
+      run: |
+        cosign verify \
+          --certificate-identity-regexp "^https://github\.com/${REPO}/\.github/workflows/sign-and-attest\.yml@" \
+          --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+          "${IMAGE}"

--- a/scripts/docker-containers
+++ b/scripts/docker-containers
@@ -111,6 +111,8 @@ case "$TARGET_CONTAINER" in
       -t "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"  \
       -f Dockerfile                        \
       .
+    SIGN_IMAGE="$DEVEL_ALLOY_IMAGE"
+    SIGN_TAG="$TAG_VERSION"
     ;;
 
   alloy-devel-boringcrypto)
@@ -127,6 +129,8 @@ case "$TARGET_CONTAINER" in
       -t "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"               \
       -f Dockerfile                                     \
       .
+    SIGN_IMAGE="$DEVEL_ALLOY_IMAGE"
+    SIGN_TAG="$TAG_VERSION-boringcrypto"
     ;;
 
   alloy-devel-pr)
@@ -159,4 +163,12 @@ case "$TARGET_CONTAINER" in
     exit 1
     ;;
 esac
+
+# Surface the pushed digest so the signing workflow can sign it by digest (see
+# sign-and-attest.yml). SIGN_IMAGE/SIGN_TAG are set only for targets we sign.
+# buildx --push doesn't load the image locally, so query the registry for the digest.
+if [[ $PUSH_ALLOY_IMAGE == "true" && -n "${SIGN_IMAGE:-}" && -n "${SIGN_TAG:-}" && -n "${GITHUB_OUTPUT:-}" ]]; then
+  DIGEST=$(docker buildx imagetools inspect "$SIGN_IMAGE:$SIGN_TAG" --format '{{.Manifest.Digest}}')
+  echo "image=$SIGN_IMAGE@$DIGEST" >> "$GITHUB_OUTPUT"
+fi
 

--- a/scripts/docker-containers-windows
+++ b/scripts/docker-containers-windows
@@ -128,6 +128,14 @@ case "$TARGET_CONTAINER" in
     if [[ $PUSH_ALLOY_IMAGE == "true"  ]]; then
       docker push "$DEVEL_ALLOY_IMAGE:$VERSION_TAG"
       docker push "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"
+
+      # Surface the pushed digest so the signing workflow can sign it by digest
+      # (see sign-and-attest.yml). Only this repo is pushed, so the local
+      # image's RepoDigests has a single entry.
+      if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+        DIGEST_REF=$(docker inspect --format '{{index .RepoDigests 0}}' "$DEVEL_ALLOY_IMAGE:$VERSION_TAG")
+        echo "image=$DIGEST_REF" >> "$GITHUB_OUTPUT"
+      fi
     fi
     ;;
 


### PR DESCRIPTION
### Brief description of Pull Request

Sign the `alloy-dev` container images (Linux, Linux boringcrypto, Windows) on every push to `main` using keyless cosign via GitHub Actions OIDC. No Grafana product signs its images today, so this lights it up on dev first — proving the full path (digest capture on real runners, keyless OIDC, signature push to GAR, and the GAR→Docker Hub mirror carrying the `.sig`) on low-stakes images before release signing goes live.

### Pull Request Details

A reusable `sign-and-attest.yml` does the work: it signs the image index by digest (`cosign sign`, index-only, public Rekor), then verifies its own signature against the GAR digest before the job exits. The Linux/Windows build scripts surface the pushed digest as a job output, and the dev publish workflow wires a sign job per image. `alloy-dev` is on the `gar-image-mirror` allowlist, so the legacy-tag signature replicates to `docker.io/grafana/alloy-dev` for free. 
