### PR TITLE
docs: Fix a bunch of small typos across Alloy docs

### DIFF
--- a/docs/sources/collect/choose-component.md
+++ b/docs/sources/collect/choose-component.md
@@ -6,7 +6,7 @@ menuTitle: Choose a component
 weight: 100
 ---
 
-# Choose a  {{% param "FULL_PRODUCT_NAME" %}} component
+# Choose a {{% param "FULL_PRODUCT_NAME" %}} component
 
 [Components][components] are the building blocks of {{< param "FULL_PRODUCT_NAME" >}}, and there is a [large number of them][components-ref].
 The components you select and configure depend on the telemetry signals you want to collect.

--- a/docs/sources/collect/opentelemetry-data.md
+++ b/docs/sources/collect/opentelemetry-data.md
@@ -166,7 +166,7 @@ To configure an `otelcol.processor.batch` component, complete the following step
      output {
        metrics = [otelcol.exporter.otlp.<EXPORTER_LABEL>.input]
        logs    = [otelcol.exporter.otlp.<EXPORTER_LABEL>.input]
-       traces  = [otelcol.exporter.otlp.>EXPORTER_LABEL>.input]
+       traces  = [otelcol.exporter.otlp.<EXPORTER_LABEL>.input]
      }
    }
    ```

--- a/docs/sources/collect/opentelemetry-to-lgtm-stack.md
+++ b/docs/sources/collect/opentelemetry-to-lgtm-stack.md
@@ -37,11 +37,11 @@ This topic describes how to:
 * Have a set of OpenTelemetry applications ready to push telemetry data to {{< param "PRODUCT_NAME" >}}.
 * Identify where {{< param "PRODUCT_NAME" >}} writes received telemetry data.
 * Be familiar with the concept of [Components][] in {{< param "PRODUCT_NAME" >}}.
-* Complete the [Collect open telemetry data][] task.
+* Complete the [Collect OpenTelemetry data][] task.
 
 ## The pipeline
 
-You can start with the {{< param "PRODUCT_NAME" >}} configuration you created in the [Collect open telemetry data][] task.
+You can start with the {{< param "PRODUCT_NAME" >}} configuration you created in the [Collect OpenTelemetry data][] task.
 
 ```alloy
 otelcol.receiver.otlp "example" {
@@ -347,7 +347,7 @@ You can check the pipeline graphically by visiting <http://localhost:12345/graph
 [Grafana Cloud Portal]: https://grafana.com/docs/grafana-cloud/account-management/cloud-portal#your-grafana-cloud-stack
 [Prometheus Remote Write]: https://prometheus.io/docs/operating/integrations/#remote-endpoints-and-storage
 [Grafana Mimir]: https://grafana.com/oss/mimir/
-[Collect open telemetry data]: ../opentelemetry-data/
+[Collect OpenTelemetry data]: ../opentelemetry-data/
 [Components]: ../../get-started/components/
 [loki.write]: ../../reference/components/loki/loki.write/
 [otelcol.auth.basic]: ../../reference/components/otelcol/otelcol.auth.basic/

--- a/docs/sources/collect/prometheus-metrics.md
+++ b/docs/sources/collect/prometheus-metrics.md
@@ -318,7 +318,7 @@ To collect metrics from Kubernetes Services, complete the following steps.
        Replace the following:
 
        * _`<SCRAPE_LABEL>`_: The label for the component, such as `services`.
-         The label you use must be unique across all `prometeus.scrape` components in the same configuration file.
+         The label you use must be unique across all `prometheus.scrape` components in the same configuration file.
        * _`<DISCOVERY_LABEL>`_: The label for the `discovery.kubernetes` component.
        * _`<REMOTE_WRITE_LABEL>`_: The label for your `prometheus.remote_write` component.
 
@@ -402,7 +402,7 @@ prometheus.scrape "custom_targets" {
     },
     {
       __address__      = "custom-application:80",
-      __metrics_path__ = "/custom-metrics–path",
+      __metrics_path__ = "/custom-metrics-path",
     },
     {
       __address__ = "alloy:12345",

--- a/docs/sources/configure/macos.md
+++ b/docs/sources/configure/macos.md
@@ -17,7 +17,7 @@ To configure {{< param "PRODUCT_NAME" >}} on macOS, perform the following steps:
 1. Run the following command in a terminal to restart the {{< param "PRODUCT_NAME" >}} service:
 
    ```shell
-   brew services restart  grafana/grafana/alloy
+   brew services restart grafana/grafana/alloy
    ```
 
 ## Configure the {{% param "PRODUCT_NAME" %}} service
@@ -50,13 +50,13 @@ To customize the {{< param "PRODUCT_NAME" >}} service on macOS, perform the foll
 1. Reinstall the {{< param "PRODUCT_NAME" >}} Formula by running the following command in a terminal:
 
    ```shell
-   brew reinstall --formula  grafana/grafana/alloy
+   brew reinstall --formula grafana/grafana/alloy
    ```
 
 1. Restart the {{< param "PRODUCT_NAME" >}} service by running the command in a terminal:
 
    ```shell
-   brew services restart  grafana/grafana/alloy
+   brew services restart grafana/grafana/alloy
    ```
 
 ## Configure environment variables

--- a/docs/sources/monitor/monitor-logs-over-tcp.md
+++ b/docs/sources/monitor/monitor-logs-over-tcp.md
@@ -106,7 +106,7 @@ The logging configuration in this example requires three components:
 
 * `loki.source.api`
 * `loki.process`
-* `loki-write`
+* `loki.write`
 
 #### `loki.source.api`
 
@@ -164,7 +164,7 @@ loki.process "labels" {
 }
 ```
 
-#### `loki-write`
+#### `loki.write`
 
 The [`loki.write`][loki.write] component writes the logs to a Loki destination.
 In this example, the component requires the following argument:

--- a/docs/sources/reference/cli/run.md
+++ b/docs/sources/reference/cli/run.md
@@ -26,14 +26,14 @@ Replace the following:
 
 If the _`<PATH_NAME>`_ argument isn't provided, or if the configuration path can't be loaded or contains errors during the initial load, the `run` command immediately exits and shows an error message.
 
-If you provide a directory path for  the _`<PATH_NAME>`_, {{< param "PRODUCT_NAME" >}} finds `*.alloy` files, ignoring nested directories, and loads them as a single configuration source.
+If you provide a directory path for the _`<PATH_NAME>`_, {{< param "PRODUCT_NAME" >}} finds `*.alloy` files, ignoring nested directories, and loads them as a single configuration source.
 However, component names must be **unique** across all {{< param "PRODUCT_NAME" >}} configuration files, and configuration blocks must not be repeated.
 
 {{< param "PRODUCT_NAME" >}} continues to run if subsequent reloads of the configuration file fail, potentially marking components as unhealthy depending on the nature of the failure.
 When this happens, {{< param "PRODUCT_NAME" >}} continues functioning in the last valid state.
 
 `run` launches an HTTP server that exposes metrics about itself and its components.
-The HTTP server is also exposes a UI at `/` for debugging running components.
+The HTTP server exposes a UI at `/` for debugging running components.
 
 The following flags are supported:
 
@@ -140,7 +140,7 @@ If `--cluster.advertise-interfaces` isn't explicitly set, {{< param "PRODUCT_NAM
 {{< param "PRODUCT_NAME" >}} will fail to start if it can't determine the advertised address.
 Since Windows doesn't use the interface names `eth0` or `en0`, Windows users must explicitly pass at least one valid network interface for `--cluster.advertise-interfaces` or a value for `--cluster.advertise-address`.
 
-The comma-separated list of addresses provided in `--cluster.join-addresses` can either be IP addresses or DNS names to lookup (supports SRV and A/AAAA records).
+The comma-separated list of addresses provided in `--cluster.join-addresses` can either be IP addresses or DNS names to look up (supports SRV and A/AAAA records).
 In both cases, the port number can be specified with a `:<port>` suffix. If ports aren't provided, default of the port used for the HTTP listener is used.
 If you don't provide the port number explicitly, you must ensure that all instances use the same port for the HTTP listener.
 Optionally, you may specify a DNS query type as a prefix for each address. See [join addresses format](#join-address-format) for more information.

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.otlp.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.otlp.md
@@ -256,7 +256,7 @@ otelcol.exporter.otlphttp "default" {
 
 ## Enable authentication
 
-You can create a `otelcol.reciever.otlp` component that requires authentication for requests.
+You can create a `otelcol.receiver.otlp` component that requires authentication for requests.
 This is useful for limiting who can push data to the server.
 
 {{< admonition type="note" >}}

--- a/docs/sources/reference/config-blocks/argument.md
+++ b/docs/sources/reference/config-blocks/argument.md
@@ -72,5 +72,5 @@ declare "self_collect" {
 }
 ```
 
-[custom component]: ../../../get-started/custom_components/
+[custom component]: ../../../get-started/components/custom-components/
 [declare]: ../../config-blocks/declare/

--- a/docs/sources/reference/config-blocks/import.git.md
+++ b/docs/sources/reference/config-blocks/import.git.md
@@ -20,7 +20,7 @@ This enables, for example, your module to import other modules within the reposi
 
 ```alloy
 import.git "<NAMESPACE>" {
-  repository = "<GIT_REPOSTORY>"
+  repository = "<GIT_REPOSITORY>"
   path       = "<PATH_TO_MODULE>"
 }
 ```

--- a/docs/sources/reference/config-blocks/remotecfg.md
+++ b/docs/sources/reference/config-blocks/remotecfg.md
@@ -136,7 +136,7 @@ If {{< param "PRODUCT_NAME" >}} fails to load configuration using `remotecfg`, c
 - `401` or `403` errors: Verify that authentication settings are correct, such as `basic_auth`, `authorization`, OAuth2, or bearer token.
 - `404` errors: Confirm that the configured `url` points to a server implementing the alloy-remote-config API.
   Static HTTP servers can't serve configuration for `remotecfg`.
-- `415 Unsupported Media Type` errors: Ensure the server implements the [alloy-remote-config API][[API definition]] and returns the expected response format.
+- `415 Unsupported Media Type` errors: Ensure the server implements the [alloy-remote-config API][API definition] and returns the expected response format.
 - Connection timeouts: Check network connectivity, proxy settings, and firewall rules between the collector and the remote server.
 
 If you only want to load a static configuration file from an HTTP server, use [`import.http`][import.http] instead.

--- a/docs/sources/reference/config-blocks/tracing.md
+++ b/docs/sources/reference/config-blocks/tracing.md
@@ -36,7 +36,7 @@ The elements in the array can be any `otelcol` component that accept traces, inc
 When `write_to` is set to an empty array `[]`, all traces are dropped.
 
 {{< admonition type="note" >}}
-Any traces generated before the `tracing` block has been evaluated,such as at the early start of the process' lifetime, are dropped.
+Any traces generated before the `tracing` block has been evaluated, such as at the early start of the process' lifetime, are dropped.
 {{< /admonition >}}
 
 The `sampling_fraction` argument controls what percentage of generated traces should be sent to the consumers specified by `write_to`.

--- a/docs/sources/reference/stdlib/array.md
+++ b/docs/sources/reference/stdlib/array.md
@@ -40,7 +40,7 @@ Elements within the list can be any type.
 The `array.combine_maps` function allows you to join two arrays of maps if certain keys have matching values in both maps. It's particularly useful when combining labels of targets coming from different `prometheus.discovery.*` or `prometheus.exporter.*` components.
 It takes three arguments:
 
-* The first two arguments are a of type `list(map(string))`. The keys of the map are strings.
+* The first two arguments are of type `list(map(string))`. The keys of the map are strings.
   The value for each key could be of any Alloy type such as a `string`, `integer`, `map`, or a `capsule`.
 * The third input is an `array` containing strings. The strings are the keys whose value has to match for maps to be combined.
 * (optional) The fourth input is a `boolean` which defaults to `false`. 

--- a/docs/sources/reference/stdlib/constants.md
+++ b/docs/sources/reference/stdlib/constants.md
@@ -8,7 +8,7 @@ title: constants
 
 The `constants` object exposes a list of constant values about the system {{< param "PRODUCT_NAME" >}} is running on:
 
-* `constants.hostname`: The hostname of the machine {{< param "PRODUCT_NAME" >}} is running   on.
+* `constants.hostname`: The hostname of the machine {{< param "PRODUCT_NAME" >}} is running on.
 * `constants.os`: The operating system {{< param "PRODUCT_NAME" >}} is running on.
 * `constants.arch`: The architecture of the system {{< param "PRODUCT_NAME" >}} is running on.
 * `constants.version` : The version of the {{< param "PRODUCT_NAME" >}} instance if the binary was built with the version information, otherwise it's an empty string.

--- a/docs/sources/reference/stdlib/encoding.md
+++ b/docs/sources/reference/stdlib/encoding.md
@@ -9,82 +9,82 @@ menuTitle: encoding
 title: encoding
 ---
 
-# encoding
+# `encoding`
 
 The `encoding` namespace contains encoding and decoding functions.
 
-## encoding.from_base64
+## `encoding.from_base64`
 
 The `encoding.from_base64` function decodes a RFC4648-compliant Base64-encoded string into the original string.
 
 `encoding.from_base64` fails if the provided string argument contains invalid Base64 data.
 
-### Example
+### Example `encoding.from_base64`
 
-```text
-> encoding.from_base64("dGFuZ2VyaW5l")
+```alloy
+encoding.from_base64("dGFuZ2VyaW5l")
 tangerine
 ```
 
-## encoding.from_URLbase64
+## `encoding.from_URLbase64`
 
 The `encoding.from_URLbase64` function decodes a RFC4648-compliant Base64 URL safe encoded string into the original string.
 
 `encoding.from_URLbase64` fails if the provided string argument contains invalid Base64 data.
 
-### Example
+### Example `encoding.from_URLbase64`
 
-```
-> encoding.from_URLbase64("c3RyaW5nMTIzIT8kKiYoKSctPUB-")
+```alloy
+encoding.from_URLbase64("c3RyaW5nMTIzIT8kKiYoKSctPUB-")
 string123!?$*&()'-=@~
 ```
 
-## encoding.to_base64
+## `encoding.to_base64`
 
 The `encoding.to_base64` function encodes the original string into RFC4648-compliant Base64 encoded string.
 
-### Example
+### Example `encoding.to_base64`
 
-```
-> encoding.to_base64("string123!?$*&()'-=@~")
+```alloy
+encoding.to_base64("string123!?$*&()'-=@~")
 c3RyaW5nMTIzIT8kKiYoKSctPUB+
 ```
 
-## encoding.to_URLbase64
+## `encoding.to_URLbase64`
 
-The `encoding.to_base64` function encodes the original string into RFC4648-compliant URL safe Base64 encoded string.
+The `encoding.to_URLbase64` function encodes the original string into RFC4648-compliant URL safe Base64 encoded string.
 
-### Example
+### Example `encoding.to_URLbase64`
 
-```
-> encoding.to_URLbase64("string123!?$*&()'-=@~")
+```alloy
+encoding.to_URLbase64("string123!?$*&()'-=@~")
 c3RyaW5nMTIzIT8kKiYoKSctPUB-
 ```
 
-## encoding.url_encode
+## `encoding.url_encode`
 
 The `encoding.url_encode` function encodes the original string into a RFC3986 "percent encoding" compliant string.
 
-### Example
+### Example `encoding.url_encode`
 
-```
-> encoding.url_encode("string123!?$*&()'-=@~")
+```alloy
+encoding.url_encode("string123!?$*&()'-=@~")
 string123%21%3F%24%2A%26%28%29%27-%3D%40~
 ```
 
-## encoding.url_decode
+## `encoding.url_decode`
 
 The `encoding.url_decode` function decodes a RFC3986 "percent encoding" compliant string.
 `encoding.url_decode` fails if input string is not RFC3986 "percent encoding" compliant.
 
-### Example
+### Example `encoding.url_decode`
 
-```
-> encoding.url_decode("string123%21%3F%24%2A%26%28%29%27-%3D%40~")
+```alloy
+encoding.url_decode("string123%21%3F%24%2A%26%28%29%27-%3D%40~")
 string123!?$*&()'-=@~
 ```
 
-## encoding.to_json
+## `encoding.to_json`
 
 The `encoding.to_json` function encodes the map into a JSON string.
 `encoding.to_json` fails if the input argument provided can't be parsed as a JSON string.
@@ -92,14 +92,14 @@ The `encoding.to_json` function encodes the map into a JSON string.
 A common use case for `encoding.to_json` is to encode a configuration of component which is expected to be a JSON string.
 For example, `config` argument of [`prometheus.exporter.blackbox`][].
 
-### Examples
+### Example `encoding.to_json`
 
 ```alloy
-> encoding.to_json({"modules"={"http_2xx"={"prober"="http","timeout"="5s","http"={"headers"={"Authorization"=sys.env("TEST_VAR")}}}}})
+encoding.to_json({"modules"={"http_2xx"={"prober"="http","timeout"="5s","http"={"headers"={"Authorization"=sys.env("TEST_VAR")}}}}})
 "{\"modules\":{\"http_2xx\":{\"http\":{\"headers\":{\"Authorization\":\"Hello!\"}},\"prober\":\"http\",\"timeout\":\"5s\"}}}"
 ```
 
-## encoding.from_json
+## `encoding.from_json`
 
 The `encoding.from_json` function decodes a string representing JSON into an {{< param "PRODUCT_NAME" >}} value.
 `encoding.from_json` fails if the string argument provided can't be parsed as JSON.
@@ -112,28 +112,28 @@ Remember to escape double quotes when passing JSON string literals to `encoding.
 For example, the JSON value `{"key": "value"}` is properly represented by the string `"{\"key\": \"value\"}"`.
 {{< /admonition >}}
 
-### Examples
+### Example `encoding.from_json`
 
 ```alloy
-> encoding.from_json("15")
+encoding.from_json("15")
 15
 
-> encoding.from_json("[1, 2, 3]")
+encoding.from_json("[1, 2, 3]")
 [1, 2, 3]
 
-> encoding.from_json("null")
+encoding.from_json("null")
 null
 
-> encoding.from_json("{\"key\": \"value\"}")
+encoding.from_json("{\"key\": \"value\"}")
 {
   key = "value",
 }
 
-> encoding.from_json(local.file.some_file.content)
+encoding.from_json(local.file.some_file.content)
 "Hello, world!"
 ```
 
-## encoding.from_yaml
+## `encoding.from_yaml`
 
 The `encoding.from_yaml` function decodes a string representing YAML into an {{< param "PRODUCT_NAME" >}} value.
 `encoding.from_yaml` fails if the string argument provided can't be parsed as YAML.
@@ -146,20 +146,24 @@ A common use case of `encoding.from_yaml` is to decode the output of a [`local.f
 For example, the YAML value `key: "value"` is properly represented by the string `"key: \"value\""`.
 {{< /admonition >}}
 
-### Examples
+### Example `encoding.from_yaml`
 
 ```alloy
-> encoding.from_yaml("15")
+encoding.from_yaml("15")
 15
-> encoding.from_yaml("[1, 2, 3]")
+
+encoding.from_yaml("[1, 2, 3]")
 [1, 2, 3]
-> encoding.from_yaml("null")
+
+encoding.from_yaml("null")
 null
-> encoding.from_yaml("key: value")
+
+encoding.from_yaml("key: value")
 {
   key = "value",
 }
-> encoding.from_yaml(local.file.some_file.content)
+
+encoding.from_yaml(local.file.some_file.content)
 "Hello, world!"
 ```
 

--- a/docs/sources/reference/stdlib/string.md
+++ b/docs/sources/reference/stdlib/string.md
@@ -116,7 +116,7 @@ string.replace(string, substring, replacement)
 `string.split` produces a list by dividing a string at all occurrences of a separator.
 
 ```alloy
-split(list, separator)
+string.split(string, separator)
 ```
 
 ### Examples

--- a/docs/sources/set-up/deploy.md
+++ b/docs/sources/set-up/deploy.md
@@ -120,7 +120,7 @@ The Pod's controller, network configuration, enabled capabilities, and available
 - Long-lived applications
 - Scenarios where the {{< param "PRODUCT_NAME" >}} deployment size grows so large it can become a noisy neighbor
 
-[clustering]: ../../configure/clustering/
+[clustering]: ../../get-started/clustering/
 
 ## Process different types of telemetry in different {{% param "PRODUCT_NAME" %}} instances
 

--- a/docs/sources/set-up/migrate/from-otelcol.md
+++ b/docs/sources/set-up/migrate/from-otelcol.md
@@ -111,7 +111,7 @@ Your configuration file must be a valid OpenTelemetry Collector configuration fi
    You can bypass any non-critical issues and start {{< param "PRODUCT_NAME" >}} by including the `--config.bypass-conversion-errors` flag in addition to `--config.format=otelcol`.
 
    {{< admonition type="caution" >}}
-   If you bypass the errors, the behavior of the converted configuration may not match the original Prometheus configuration.
+   If you bypass the errors, the behavior of the converted configuration may not match the original OpenTelemetry Collector configuration.
    Don't use this flag in a production environment.
    {{< /admonition >}}
 

--- a/docs/sources/set-up/migrate/from-prometheus.md
+++ b/docs/sources/set-up/migrate/from-prometheus.md
@@ -136,7 +136,7 @@ remote_write:
       password: <PASSWORD>
 ```
 
-The convert command takes the YAML file as input and outputs a [{{< param "PRODUCT_NAME" >}} configuration][configuration]] file.
+The convert command takes the YAML file as input and outputs a [{{< param "PRODUCT_NAME" >}} configuration][configuration] file.
 
 ```shell
 alloy convert --source-format=prometheus --output=<OUTPUT_CONFIG_PATH> <INPUT_CONFIG_PATH>

--- a/docs/sources/set-up/otel_engine.md
+++ b/docs/sources/set-up/otel_engine.md
@@ -189,7 +189,7 @@ ports:
 alternateConfig:
   extensions:
     health_check:
-      endpoint: 0.0.0.0:13133 # This is necessary for the k8s liveliness check
+      endpoint: 0.0.0.0:13133 # This is necessary for the Kubernetes liveness check
     basicauth/my_auth:
       client_auth:
         username: <USERNAME>

--- a/docs/sources/troubleshoot/controller_metrics.md
+++ b/docs/sources/troubleshoot/controller_metrics.md
@@ -18,7 +18,7 @@ Metrics for the controller are exposed at the `/metrics` HTTP endpoint of the {{
 
 The controller exposes the following metrics:
 
-* `alloy_component_controller_evaluating` (Gauge): Set to `1` whenever the  component controller is evaluating components.
+* `alloy_component_controller_evaluating` (Gauge): Set to `1` whenever the component controller is evaluating components.
   This value may be misrepresented depending on how fast evaluations complete or how often evaluations occur.
 * `alloy_component_controller_running_components` (Gauge): The current number of running components by health.
    The health is represented in the `health_type` label.

--- a/docs/sources/tutorials/first-components-and-stdlib.md
+++ b/docs/sources/tutorials/first-components-and-stdlib.md
@@ -119,7 +119,7 @@ The `local.file` component's label is set to `"example"`, so the fully qualified
 The `prometheus.remote_write` component's label is set to `"local_prom"`, so the fully qualified name of the component is `prometheus.remote_write.local_prom`.
 {{< /admonition >}}
 
-This example pipeline still doesn't do anything, so its time to add some more components to it.
+This example pipeline still doesn't do anything, so it's time to add some more components to it.
 
 ## Send your first metrics
 

--- a/docs/sources/tutorials/processing-logs.md
+++ b/docs/sources/tutorials/processing-logs.md
@@ -351,7 +351,7 @@ Try executing the following which inserts the current timestamp:
 curl localhost:9999/loki/api/v1/raw -XPOST -H "Content-Type: application/json" -d '{"log": {"is_secret": "false", "level": "debug", "message": "This is a debug message!"}, "timestamp":  "'"$(date -u +"%Y-%m-%dT%H:%M:%SZ")"'"}'
 ```
 
-Now that you have sent some logs, its time to see how they look in Grafana.
+Now that you have sent some logs, it's time to see how they look in Grafana.
 Navigate to [http://localhost:3000/explore](http://localhost:3000/explore) and switch the data source to `Loki`.
 Try querying for `{source="demo-api"}` and see if you can find the logs you sent.
 


### PR DESCRIPTION
Fix a bunch of typos across the entire Alloy doc set. Mostly extra spaces and double characters.