### PR TITLE
chore(release): Stop the syntax module from interfering with Alloy release tooling

### DIFF
--- a/.github/workflows/bump-formula-pr.yml
+++ b/.github/workflows/bump-formula-pr.yml
@@ -56,7 +56,10 @@ jobs:
         type: "stable"
 
     - name: Update Homebrew formula
-      if: 'steps.latest_release.outputs.release_id == github.event.release.id'
+      # Only the Alloy binary (vX.Y.Z tags) has a Homebrew formula. The release_id
+      # check alone doesn't exclude component releases (e.g. syntax/v0.2.0):
+      # GitHub's "latest stable" is the component release at publish time.
+      if: steps.latest_release.outputs.release_id == github.event.release.id && startsWith(github.event.release.tag_name, 'v')
       # TODO: Use the upstream once they have this change:
       # https://github.com/dawidd6/action-homebrew-bump-formula/pull/90
       # uses: dawidd6/action-homebrew-bump-formula@v4

--- a/.github/workflows/release-announce.yml
+++ b/.github/workflows/release-announce.yml
@@ -35,17 +35,19 @@ jobs:
           repo_secrets: |
             SLACK_CHANNEL_ID_ALLOY=slack:channel_id_alloy
 
-      - name: Determine release type 🏷️
+      - name: Check for a final Alloy release 🏷️
         id: release-type
         run: |
-          if [[ "$RELEASE_TAG" == *"-rc"* ]]; then
-            echo "is_rc=true" >> "$GITHUB_OUTPUT"
+          # Announce only final Alloy releases (vX.Y.Z) — not RCs (vX.Y.Z-rc.N) or
+          # component releases (e.g. syntax/v0.2.0).
+          if [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "is_alloy_release=true" >> "$GITHUB_OUTPUT"
           else
-            echo "is_rc=false" >> "$GITHUB_OUTPUT"
+            echo "is_alloy_release=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Notify internal alloy channel 📢
-        if: steps.release-type.outputs.is_rc == 'false'
+        if: steps.release-type.outputs.is_alloy_release == 'true'
         uses: grafana/shared-workflows/actions/send-slack-message@0941e3408fa4789fec9062c44a2a9e1832146ba6 #v2.0.1
         env:
           SLACK_MESSAGE: |

--- a/.github/workflows/release-winget-on-publish.yml
+++ b/.github/workflows/release-winget-on-publish.yml
@@ -9,6 +9,9 @@ permissions: {}
 jobs:
   submit_winget_manifest:
     name: Submit WinGet Manifest
+    # Only the Alloy binary (vX.Y.Z tags) has a WinGet package; skip component
+    # releases like syntax/v0.2.0.
+    if: ${{ startsWith(github.event.release.tag_name, 'v') }}
     uses: ./.github/workflows/release-submit-winget-manifest.yml
     permissions:
       contents: read

--- a/tools/release/createrc/command.go
+++ b/tools/release/createrc/command.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/google/go-github/v57/github"
 	"github.com/spf13/cobra"
@@ -18,6 +19,11 @@ const (
 	mainBranch          = "main"
 	releaseBranchPrefix = "release/v"
 	backportLabelPrefix = "backport/v"
+
+	// release-please names PR head branches "release-please--branches--<branch>",
+	// appending "--components--<name>" for component modules.
+	releasePleaseBranchPrefix = "release-please--branches--"
+	releasePleaseComponentSep = "--components--"
 )
 
 type flags struct {
@@ -53,7 +59,9 @@ func Command() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "create-rc",
-		Short: "Create a release candidate tag and draft prerelease from the open release-please PR",
+		Short: "Create a release candidate tag and draft prerelease for the main Alloy module",
+		Long: "Creates the RC from the main Alloy module's release-please PR. Component modules such as " +
+			"syntax are released directly by release-please and are ignored.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return run(cmd.Context(), flags)
 		},
@@ -224,28 +232,36 @@ func findReleasePleasePR(ctx context.Context, client *gh.Client, baseBranch stri
 	}
 
 	fmt.Printf("Found %d open PRs targeting %s\n", len(prs), baseBranch)
-
-	// Look for PR with "autorelease: pending" label (handle both with/without space after colon)
 	for _, pr := range prs {
 		fmt.Printf("  PR #%d: %q has %d labels\n", pr.GetNumber(), pr.GetTitle(), len(pr.Labels))
 		for _, label := range pr.Labels {
+			fmt.Printf("    - label: %q\n", label.GetName())
+		}
+	}
+
+	return selectMainModuleReleasePR(prs, baseBranch)
+}
+
+// selectMainModuleReleasePR picks the main Alloy module's release-please PR, not
+// a component module's (e.g. syntax). It keys off release-please's own head
+// branch naming rather than the PR title (which our config can freely rewrite):
+// the main module's head branch has no "--components--" segment. prs are already
+// filtered to baseBranch by the caller.
+func selectMainModuleReleasePR(prs []*github.PullRequest, baseBranch string) (*github.PullRequest, error) {
+	for _, pr := range prs {
+		head := pr.GetHead().GetRef()
+		if !strings.HasPrefix(head, releasePleaseBranchPrefix) || strings.Contains(head, releasePleaseComponentSep) {
+			continue
+		}
+		for _, label := range pr.Labels {
 			labelName := label.GetName()
-			fmt.Printf("    - label: %q\n", labelName)
 			if labelName == "autorelease: pending" || labelName == "autorelease:pending" {
 				return pr, nil
 			}
 		}
 	}
 
-	// Fallback: look for PR with release-please title pattern
-	titlePattern := regexp.MustCompile(fmt.Sprintf(`^chore\(%s\): Release`, regexp.QuoteMeta(baseBranch)))
-	for _, pr := range prs {
-		if titlePattern.MatchString(pr.GetTitle()) {
-			return pr, nil
-		}
-	}
-
-	return nil, fmt.Errorf("no release-please PR found for branch %s (looked for 'autorelease: pending' or 'autorelease:pending' label or release-please title pattern)", baseBranch)
+	return nil, fmt.Errorf("no main-module release-please PR found for branch %s (looked for a %q head branch with an 'autorelease: pending' label)", baseBranch, releasePleaseBranchPrefix+baseBranch)
 }
 
 func extractVersionFromTitle(title string) (string, error) {

--- a/tools/release/createrc/command_test.go
+++ b/tools/release/createrc/command_test.go
@@ -1,0 +1,100 @@
+package createrc
+
+import (
+	"testing"
+
+	"github.com/google/go-github/v57/github"
+)
+
+func pr(number int, headRef string, labels ...string) *github.PullRequest {
+	p := &github.PullRequest{
+		Number: github.Int(number),
+		Head:   &github.PullRequestBranch{Ref: github.String(headRef)},
+	}
+	for _, l := range labels {
+		p.Labels = append(p.Labels, &github.Label{Name: github.String(l)})
+	}
+	return p
+}
+
+func TestSelectMainModuleReleasePR(t *testing.T) {
+	tests := []struct {
+		name       string
+		prs        []*github.PullRequest
+		baseBranch string
+		wantNumber int
+		wantErr    bool
+	}{
+		{
+			// The component PR carries "autorelease: pending" and sorts first, but
+			// only the main module's PR (no --components-- segment) should win.
+			name:       "skips syntax component PR ordered before main release PR",
+			baseBranch: "main",
+			prs: []*github.PullRequest{
+				pr(6266, "release-please--branches--main--components--syntax", "autorelease: pending"),
+				pr(6111, "release-please--branches--main", "autorelease: pending"),
+			},
+			wantNumber: 6111,
+		},
+		{
+			name:       "selects release PR on a release branch",
+			baseBranch: "release/v1.16",
+			prs: []*github.PullRequest{
+				pr(7000, "release-please--branches--release/v1.16", "autorelease: pending"),
+			},
+			wantNumber: 7000,
+		},
+		{
+			name:       "tolerates label without space after colon",
+			baseBranch: "main",
+			prs: []*github.PullRequest{
+				pr(6111, "release-please--branches--main", "autorelease:pending"),
+			},
+			wantNumber: 6111,
+		},
+		{
+			// An already-tagged release-please PR drops the pending label.
+			name:       "ignores main release PR missing the pending label",
+			baseBranch: "main",
+			prs: []*github.PullRequest{
+				pr(6111, "release-please--branches--main", "autorelease: tagged"),
+			},
+			wantErr: true,
+		},
+		{
+			name:       "errors when only a component PR is open",
+			baseBranch: "main",
+			prs: []*github.PullRequest{
+				pr(6266, "release-please--branches--main--components--syntax", "autorelease: pending"),
+			},
+			wantErr: true,
+		},
+		{
+			// A non-release-please branch that happens to carry the label is ignored.
+			name:       "ignores a non-release-please branch with the pending label",
+			baseBranch: "main",
+			prs: []*github.PullRequest{
+				pr(9000, "kgeckhart/some-feature", "autorelease: pending"),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := selectMainModuleReleasePR(tt.prs, tt.baseBranch)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got PR #%d", got.GetNumber())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.GetNumber() != tt.wantNumber {
+				t.Errorf("selected PR #%d, want #%d", got.GetNumber(), tt.wantNumber)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Brief description of Pull Request

release-please releases the syntax submodule as its own component — its own PR and `syntax/vX.Y.Z` release — but parts of the Alloy release tooling assumed every release PR and published release was the Alloy binary. So `create-rc` picked the syntax PR and aborted, and the announce, WinGet, and Homebrew workflows would each fire for a syntax release. This makes them component-aware: `create-rc` selects by release-please's head branch, and the three workflows act only on Alloy `v*` tags.

### PR Checklist

- [x] Tests updated
