### PR TITLE
perf(loki.source.journal): Reduce allocations for labels

### DIFF
--- a/internal/component/loki/source/journal/journal_test.go
+++ b/internal/component/loki/source/journal/journal_test.go
@@ -62,7 +62,7 @@ func BenchmarkJournal(b *testing.B) {
 	b.ReportAllocs()
 
 	for b.Loop() {
-		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		ctrl.Run(ctx, Arguments{
 			ForwardTo: []loki.LogsReceiver{loki.NewLogsReceiver(loki.WithChannel(make(chan loki.Entry, 10000)))},
 			Labels:    map[string]string{"test": "yay"},

--- a/internal/component/loki/source/journal/journal_test.go
+++ b/internal/component/loki/source/journal/journal_test.go
@@ -4,6 +4,7 @@ package journal
 
 import (
 	"context"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/runtime/componenttest"
 	"github.com/grafana/alloy/internal/runtime/logging"
 )
 
@@ -49,5 +51,25 @@ func TestJournal(t *testing.T) {
 		if strings.Contains(msg.Line, ts) {
 			return
 		}
+	}
+}
+
+func BenchmarkJournal(b *testing.B) {
+	ctrl, err := componenttest.NewControllerFromID(slog.New(slog.DiscardHandler), "loki.source.journal")
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for b.Loop() {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		ctrl.Run(ctx, Arguments{
+			ForwardTo: []loki.LogsReceiver{loki.NewLogsReceiver(loki.WithChannel(make(chan loki.Entry, 10000)))},
+			Labels:    map[string]string{"test": "yay"},
+		}, func(opts component.Options) component.Options {
+			opts.DataPath = b.TempDir()
+			return opts
+		})
+		cancel()
 	}
 }

--- a/internal/component/loki/source/journal/tailer.go
+++ b/internal/component/loki/source/journal/tailer.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/coreos/go-systemd/v22/sdjournal"
 	"github.com/grafana/alloy/internal/loki/promtail/scrapeconfig"
+	"github.com/grafana/alloy/internal/loki/util"
 	"github.com/grafana/loki/pkg/push"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/prometheus/common/model"
@@ -106,7 +107,9 @@ type tailer struct {
 	positionPath  string
 	relabelConfig []*relabel.Config
 	config        *scrapeconfig.JournalTargetConfig
-	labels        model.LabelSet
+
+	builder *labels.Builder
+	labels  labels.Labels
 
 	r     journalReader
 	until chan time.Time
@@ -158,6 +161,8 @@ func newTailerWithReader(
 		entryFunc = defaultJournalEntryFunc
 	}
 
+	lbls := labels.FromMap(util.ModelLabelSetToMap(targetConfig.Labels))
+
 	until := make(chan time.Time)
 	t := &tailer{
 		metrics:       metrics,
@@ -166,7 +171,8 @@ func newTailerWithReader(
 		positions:     pos,
 		positionPath:  positionPath,
 		relabelConfig: relabelConfig,
-		labels:        targetConfig.Labels,
+		labels:        lbls,
+		builder:       labels.NewBuilder(lbls),
 		config:        targetConfig,
 
 		until: until,
@@ -217,13 +223,11 @@ func newTailerWithReader(
 				}
 
 				if err == syscall.EBADMSG || err == io.EOF || strings.HasPrefix(err.Error(), "failed to iterate journal:") {
-					t.logger.Error("unable to follow journal", "err", err.Error())
+					t.logger.Error("unable to follow journal", "err", err)
 					return
 				}
-
-				t.logger.Error("received unexpected error while following the journal", "err", err.Error())
+				t.logger.Error("received unexpected error while following the journal", "err", err)
 			}
-
 			// prevent tight loop
 			time.Sleep(100 * time.Millisecond)
 		}
@@ -288,6 +292,7 @@ func (t *tailer) generateJournalConfig(
 }
 
 func (t *tailer) formatter(entry *sdjournal.JournalEntry) (string, error) {
+	defer t.builder.Reset(t.labels)
 	ts := time.Unix(0, int64(entry.RealtimeTimestamp)*int64(time.Microsecond))
 
 	var msg string
@@ -311,31 +316,22 @@ func (t *tailer) formatter(entry *sdjournal.JournalEntry) (string, error) {
 		}
 	}
 
-	entryLabels := makeJournalFields(entry.Fields)
-
-	// Add constant labels
-	for k, v := range t.labels {
-		entryLabels[string(k)] = string(v)
+	addJournalFields(t.builder, entry.Fields)
+	if !relabel.ProcessBuilder(t.builder, t.relabelConfig...) {
+		t.logger.Debug("journal entry dropped by relabel rules", "unit", entry.Fields["_SYSTEMD_UNIT"])
+		t.metrics.journalErrors.WithLabelValues(emptyLabelsError).Inc()
+		return journalEmptyStr, nil
 	}
 
-	lb := labels.NewBuilder(labels.FromMap(entryLabels))
-	var processedLabels labels.Labels
-	if relabel.ProcessBuilder(lb, t.relabelConfig...) {
-		processedLabels = lb.Labels()
-	} else {
-		processedLabels = labels.EmptyLabels()
-	}
-
-	processedLabelsMap := processedLabels.Map()
-	lbls := make(model.LabelSet, len(processedLabelsMap))
-	for k, v := range processedLabelsMap {
-		if k[0:2] == "__" {
-			continue
+	lset := make(model.LabelSet)
+	t.builder.Range(func(l labels.Label) {
+		if strings.HasPrefix(l.Name, "__") {
+			return
 		}
+		lset[model.LabelName(l.Name)] = model.LabelValue(l.Value)
+	})
 
-		lbls[model.LabelName(k)] = model.LabelValue(v)
-	}
-	if len(lbls) == 0 {
+	if len(lset) == 0 {
 		// No labels, drop journal entry
 		t.logger.Debug("received journal entry with no labels", "unit", entry.Fields["_SYSTEMD_UNIT"])
 		t.metrics.journalErrors.WithLabelValues(emptyLabelsError).Inc()
@@ -345,10 +341,11 @@ func (t *tailer) formatter(entry *sdjournal.JournalEntry) (string, error) {
 	t.metrics.journalLines.Inc()
 	t.positions.PutString(t.positionPath, "", entry.Cursor)
 
-	t.recv.Chan() <- loki.NewEntry(lbls, push.Entry{
+	t.recv.Chan() <- loki.NewEntry(lset, push.Entry{
 		Line:      msg,
 		Timestamp: ts,
 	})
+
 	return journalEmptyStr, nil
 }
 
@@ -359,15 +356,19 @@ func (t *tailer) Stop() error {
 	return err
 }
 
-func makeJournalFields(fields map[string]string) map[string]string {
-	result := make(map[string]string, len(fields))
+const (
+	labelNamePrefix = "__journal_"
+	fieldPriority   = "PRIORITY"
+)
+
+func addJournalFields(br *labels.Builder, fields map[string]string) {
 	for k, v := range fields {
-		if k == "PRIORITY" {
-			result[fmt.Sprintf("__journal_%s_%s", strings.ToLower(k), "keyword")] = makeJournalPriority(v)
+		if k == fieldPriority {
+			br.Set(labelNamePrefix+"priority_keyword", makeJournalPriority(v))
 		}
-		result[fmt.Sprintf("__journal_%s", strings.ToLower(k))] = v
+		br.Set(labelNamePrefix+strings.ToLower(k), v)
 	}
-	return result
+	return
 }
 
 func makeJournalPriority(priority string) string {

--- a/internal/component/loki/source/journal/tailer_test.go
+++ b/internal/component/loki/source/journal/tailer_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -378,20 +379,22 @@ func TestTailer_Cursor_NotTooOld(t *testing.T) {
 	require.Equal(t, r.config.Cursor, "foobar")
 }
 
-func Test_MakeJournalFields(t *testing.T) {
+func Test_AddJournalFields(t *testing.T) {
+	br := labels.NewBuilder(labels.EmptyLabels())
 	entryFields := map[string]string{
 		"CODE_FILE":   "journaltarget_test.go",
 		"OTHER_FIELD": "foobar",
 		"PRIORITY":    "6",
 	}
-	receivedFields := makeJournalFields(entryFields)
-	expectedFields := map[string]string{
+	addJournalFields(br, entryFields)
+
+	expected := map[string]string{
 		"__journal_code_file":        "journaltarget_test.go",
 		"__journal_other_field":      "foobar",
 		"__journal_priority":         "6",
 		"__journal_priority_keyword": "info",
 	}
-	assert.Equal(t, expectedFields, receivedFields)
+	assert.Equal(t, expected, br.Labels().Map())
 }
 
 func TestTailer_Matches(t *testing.T) {


### PR DESCRIPTION
### Pull Request Details
When building labels for journal entries we do a lot of unnecessary allocations and this shows up in profiles.

What we did for each:
1. We created a map and add entry fields and static labels
2. We constructed `labels.Labels` from this map and passed it to a labels.Builder
3. After relabeling we converted the result back to labels.Labels so we could build a map from it
4. We loop over this map and build the final model.LabelSet

This is a lot of unnecessary allocations. In this pr I changed it so that we reuse the same labels.Builder pre-populated with the static labels. We then add all journal entry fields to this builder and run relabel rules. After we loop over entries in builder and construct the final model.LabelSet.

The only annoying thing is that there is no way to get the length for resulting labels from the builder without doing allocations, e.g. by converting it to labels.Labels. For now I left it empty but we could set the length to `len(entry.Fields)+t.labels.Len()+1`  but this would most of the time over allocate.


### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->


### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
