### PR TITLE
ci: Fix tests on windows

### DIFF
--- a/internal/converter/internal/staticconvert/internal/build/builder_logging.go
+++ b/internal/converter/internal/staticconvert/internal/build/builder_logging.go
@@ -20,9 +20,9 @@ func (b *ConfigBuilder) appendLogging(config *server.Config) {
 }
 
 func toLogging(config *server.Config) *logging.Options {
-	return &logging.Options{
-		Level:       logging.Level(config.LogLevel.String()),
-		Format:      logging.Format(config.LogFormat),
-		Destination: logging.LogDestinationStderr,
-	}
+	opts := &logging.Options{}
+	opts.SetToDefault()
+	opts.Level = logging.Level(config.LogLevel.String())
+	opts.Format = logging.Format(config.LogFormat)
+	return opts
 }

--- a/internal/runtime/logging/logger_test.go
+++ b/internal/runtime/logging/logger_test.go
@@ -47,7 +47,6 @@ func TestLevels(t *testing.T) {
 	}
 
 	var testCases = []testCase{
-
 		{
 			name:            "debug - prints",
 			configuredLevel: logging.LevelDebug,
@@ -105,9 +104,12 @@ func TestLevels(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			buffer := bytes.NewBuffer(nil)
+
 			opts := logging.Options{}
 			opts.SetToDefault()
+			opts.Destination = logging.LogDestinationStderr
 			opts.Level = tt.configuredLevel
+
 			logger, err := logging.New(buffer, opts)
 			require.NoError(t, err)
 			logger.Slog().Log(context.Background(), tt.level, tt.message)
@@ -313,6 +315,7 @@ func BenchmarkLogging_Slog_Prints(b *testing.B) {
 func debugLevel() logging.Options {
 	opts := logging.Options{}
 	opts.SetToDefault()
+	opts.Destination = logging.LogDestinationStderr
 	opts.Level = logging.LevelDebug
 	return opts
 }


### PR DESCRIPTION
### Pull Request Details
After https://github.com/grafana/alloy/pull/5626 we have some issues with our tests.

When running our tests alloy things it's run through a windows service and then the default value for destination is set to windows event logs. So by just pinning the destination to stderr we fix tests that verifies log output.

We also have the same issue for converters where we hardcoded stderr as destination. To fix this we can instead call SetToDefault.


### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->


### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
