### PR TITLE
fix(database_observability.postgres): Do not retain query text in `explain_plans` collector

### DIFF
--- a/internal/component/database_observability/postgres/collector/explain_plans.go
+++ b/internal/component/database_observability/postgres/collector/explain_plans.go
@@ -190,13 +190,17 @@ func (p *PlanNode) totalCost() *float64 {
 }
 
 type queryInfo struct {
-	datname      string
-	queryId      string
-	queryText    string
-	failureCount int
-	uniqueKey    string
-	calls        int64
-	callsReset   time.Time
+	datname    string
+	queryId    string
+	queryText  string
+	uniqueKey  string
+	calls      int64
+	callsReset time.Time
+}
+
+type processedQueryInfo struct {
+	calls      int64
+	callsReset time.Time
 }
 
 func newQueryInfo(datname, queryId, queryText string, calls int64, callsReset time.Time) *queryInfo {
@@ -230,8 +234,8 @@ type ExplainPlans struct {
 	dbConnectionFactory databaseConnectionFactory
 	scrapeInterval      time.Duration
 	queryCache          map[string]*queryInfo
-	queryDenylist       map[string]*queryInfo
-	finishedQueryCache  map[string]*queryInfo
+	queryDenylist       map[string]struct{}
+	finishedQueryCache  map[string]processedQueryInfo
 	excludeDatabases    []string
 	excludeUsers        []string
 	perScrapeRatio      float64
@@ -254,8 +258,8 @@ func NewExplainPlan(args ExplainPlansArguments) (*ExplainPlans, error) {
 		excludeDatabases:    args.ExcludeDatabases,
 		excludeUsers:        args.ExcludeUsers,
 		queryCache:          make(map[string]*queryInfo),
-		queryDenylist:       make(map[string]*queryInfo),
-		finishedQueryCache:  make(map[string]*queryInfo),
+		queryDenylist:       make(map[string]struct{}),
+		finishedQueryCache:  make(map[string]processedQueryInfo),
 		entryHandler:        args.EntryHandler,
 		logger:              args.Logger.With("collector", ExplainPlanCollector),
 		running:             atomic.NewBool(false),
@@ -446,10 +450,12 @@ func (c *ExplainPlans) fetchExplainPlans(ctx context.Context) error {
 
 		defer func(nonRecoverableFailureOccurred *bool) {
 			if *nonRecoverableFailureOccurred {
-				qi.failureCount++
-				c.queryDenylist[qi.uniqueKey] = qi
+				c.queryDenylist[qi.uniqueKey] = struct{}{}
 			} else {
-				c.finishedQueryCache[qi.uniqueKey] = qi
+				c.finishedQueryCache[qi.uniqueKey] = processedQueryInfo{
+					calls:      qi.calls,
+					callsReset: qi.callsReset,
+				}
 			}
 			delete(c.queryCache, qi.uniqueKey)
 			processedCount++

--- a/internal/component/database_observability/postgres/collector/explain_plans_test.go
+++ b/internal/component/database_observability/postgres/collector/explain_plans_test.go
@@ -2349,7 +2349,6 @@ func TestNewQueryInfo(t *testing.T) {
 	assert.Equal(t, calls, qi.calls)
 	assert.Equal(t, callsReset, qi.callsReset)
 	assert.Equal(t, datname+queryId, qi.uniqueKey)
-	assert.Equal(t, 0, qi.failureCount)
 }
 
 func TestPlanNode_TotalCost(t *testing.T) {
@@ -2540,8 +2539,8 @@ func TestExplainPlan_PopulateQueryCache(t *testing.T) {
 				dbConnection:       db,
 				dbVersion:          pre17ver,
 				queryCache:         make(map[string]*queryInfo),
-				queryDenylist:      make(map[string]*queryInfo),
-				finishedQueryCache: make(map[string]*queryInfo),
+				queryDenylist:      make(map[string]struct{}),
+				finishedQueryCache: make(map[string]processedQueryInfo),
 				excludeDatabases:   []string{},
 				perScrapeRatio:     1.0,
 				logger:             logger,
@@ -2580,8 +2579,8 @@ func TestExplainPlan_PopulateQueryCache(t *testing.T) {
 				dbConnection:       db,
 				dbVersion:          post17ver,
 				queryCache:         make(map[string]*queryInfo),
-				queryDenylist:      make(map[string]*queryInfo),
-				finishedQueryCache: make(map[string]*queryInfo),
+				queryDenylist:      make(map[string]struct{}),
+				finishedQueryCache: make(map[string]processedQueryInfo),
 				excludeDatabases:   []string{"information_schema"},
 				perScrapeRatio:     0.5,
 				logger:             logger,
@@ -2621,8 +2620,8 @@ func TestExplainPlan_PopulateQueryCache(t *testing.T) {
 				logger:       logger,
 				entryHandler: lokiClient,
 				queryCache:   make(map[string]*queryInfo),
-				finishedQueryCache: map[string]*queryInfo{
-					"testdb123456": newQueryInfo("testdb", "123456", "SELECT * FROM users WHERE id = $1", int64(10), time.Now()),
+				finishedQueryCache: map[string]processedQueryInfo{
+					"testdb123456": {calls: int64(10), callsReset: time.Now()},
 				},
 			}
 
@@ -2647,8 +2646,8 @@ func TestExplainPlan_PopulateQueryCache(t *testing.T) {
 				logger:       logger,
 				entryHandler: lokiClient,
 				queryCache:   make(map[string]*queryInfo),
-				finishedQueryCache: map[string]*queryInfo{
-					"testdb123456": newQueryInfo("testdb", "123456", "SELECT * FROM users WHERE id = $1", int64(10), time.Now().Add(-time.Hour)),
+				finishedQueryCache: map[string]processedQueryInfo{
+					"testdb123456": {calls: int64(10), callsReset: time.Now().Add(-time.Hour)},
 				},
 			}
 
@@ -2674,8 +2673,8 @@ func TestExplainPlan_PopulateQueryCache(t *testing.T) {
 				logger:       logger,
 				entryHandler: lokiClient,
 				queryCache:   make(map[string]*queryInfo),
-				finishedQueryCache: map[string]*queryInfo{
-					"testdb123456": newQueryInfo("testdb", "123456", "SELECT * FROM users WHERE id = $1", int64(10), time.Now()),
+				finishedQueryCache: map[string]processedQueryInfo{
+					"testdb123456": {calls: int64(10), callsReset: time.Now()},
 				},
 			}
 
@@ -2767,8 +2766,8 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 		dbDSN:               "postgres://user:pass@host:1234/database",
 		dbVersion:           post17ver,
 		queryCache:          make(map[string]*queryInfo),
-		queryDenylist:       make(map[string]*queryInfo),
-		finishedQueryCache:  make(map[string]*queryInfo),
+		queryDenylist:       make(map[string]struct{}),
+		finishedQueryCache:  make(map[string]processedQueryInfo),
 		excludeDatabases:    []string{},
 		perScrapeRatio:      1.0,
 		logger:              logger,
@@ -2819,8 +2818,8 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 						callsReset: time.Now(),
 					},
 				},
-				queryDenylist:      map[string]*queryInfo{},
-				finishedQueryCache: map[string]*queryInfo{},
+				queryDenylist:      map[string]struct{}{},
+				finishedQueryCache: map[string]processedQueryInfo{},
 				excludeDatabases:   []string{},
 				perScrapeRatio:     1.0,
 				logger:             slogger,
@@ -2892,8 +2891,8 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 						callsReset: time.Now(),
 					},
 				},
-				queryDenylist:      map[string]*queryInfo{},
-				finishedQueryCache: map[string]*queryInfo{},
+				queryDenylist:      map[string]struct{}{},
+				finishedQueryCache: map[string]processedQueryInfo{},
 				excludeDatabases:   []string{},
 				perScrapeRatio:     1.0,
 				logger:             slogger,
@@ -2945,8 +2944,8 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 						callsReset: time.Now(),
 					},
 				},
-				queryDenylist:      map[string]*queryInfo{},
-				finishedQueryCache: map[string]*queryInfo{},
+				queryDenylist:      map[string]struct{}{},
+				finishedQueryCache: map[string]processedQueryInfo{},
 				excludeDatabases:   []string{},
 				perScrapeRatio:     1.0,
 				logger:             slogger,
@@ -3012,8 +3011,8 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 						callsReset: time.Now(),
 					},
 				},
-				queryDenylist:      map[string]*queryInfo{},
-				finishedQueryCache: map[string]*queryInfo{},
+				queryDenylist:      map[string]struct{}{},
+				finishedQueryCache: map[string]processedQueryInfo{},
 				excludeDatabases:   []string{},
 				perScrapeRatio:     1.0,
 				logger:             slogger,
@@ -3080,8 +3079,8 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 						callsReset: time.Now(),
 					},
 				},
-				queryDenylist:      map[string]*queryInfo{},
-				finishedQueryCache: map[string]*queryInfo{},
+				queryDenylist:      map[string]struct{}{},
+				finishedQueryCache: map[string]processedQueryInfo{},
 				excludeDatabases:   []string{},
 				perScrapeRatio:     1.0,
 				logger:             slogger,
@@ -3148,8 +3147,8 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 						callsReset: time.Now(),
 					},
 				},
-				queryDenylist:      map[string]*queryInfo{},
-				finishedQueryCache: map[string]*queryInfo{},
+				queryDenylist:      map[string]struct{}{},
+				finishedQueryCache: map[string]processedQueryInfo{},
 				excludeDatabases:   []string{},
 				perScrapeRatio:     1.0,
 				logger:             slogger,
@@ -3217,8 +3216,8 @@ func TestExplainPlans_ExcludeDatabases_NoLogSent(t *testing.T) {
 		dbConnection:       db,
 		dbVersion:          post17ver,
 		queryCache:         make(map[string]*queryInfo),
-		queryDenylist:      make(map[string]*queryInfo),
-		finishedQueryCache: make(map[string]*queryInfo),
+		queryDenylist:      make(map[string]struct{}),
+		finishedQueryCache: make(map[string]processedQueryInfo),
 		excludeDatabases:   []string{"excluded_db"},
 		perScrapeRatio:     1.0,
 		logger:             logger.Slog(),
@@ -3266,8 +3265,8 @@ func TestExplainPlans_ExcludeUsers(t *testing.T) {
 		dbConnection:       db,
 		dbVersion:          post17ver,
 		queryCache:         make(map[string]*queryInfo),
-		queryDenylist:      make(map[string]*queryInfo),
-		finishedQueryCache: make(map[string]*queryInfo),
+		queryDenylist:      make(map[string]struct{}),
+		finishedQueryCache: make(map[string]processedQueryInfo),
 		excludeUsers:       []string{"excluded_user"},
 		perScrapeRatio:     1.0,
 		logger:             logger.Slog(),


### PR DESCRIPTION
### Brief description of Pull Request

Reduce memory footprint for the `explain_plans` collector by not retaining the query text in memory for queries that have already been processed. Additionally, drop the unused `failureCount` field.


### Pull Request Details

<!-- Detailed descripion of the Pull Request, if needed. -->


### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->


### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
