### PR TITLE
ci: Build the UI once before parallel dist to avoid an npm ci race

### DIFF
--- a/.github/workflows/release-publish-alloy-artifacts.yml
+++ b/.github/workflows/release-publish-alloy-artifacts.yml
@@ -96,9 +96,7 @@ jobs:
           chown -R $(id -u):$(id -g) $PWD
 
     - name: Build
-      # Build the UI once up front, then skip it during the parallel dist build.
-      # Each dist/alloy-* target's sub-make runs generate-ui (npm ci, which wipes
-      # node_modules), so -j4 makes them race in the shared internal/web/ui dir.
+      # Build the UI once up front, avoiding a race with the concurrent make that follows
       run: |
         make generate-ui
         RELEASE_BUILD=1 SKIP_CODE_GENERATION=1 SKIP_UI_BUILD=1 make -j4 dist

--- a/.github/workflows/release-publish-alloy-artifacts.yml
+++ b/.github/workflows/release-publish-alloy-artifacts.yml
@@ -96,7 +96,12 @@ jobs:
           chown -R $(id -u):$(id -g) $PWD
 
     - name: Build
-      run: RELEASE_BUILD=1 SKIP_CODE_GENERATION=1 make -j4 dist
+      # Build the UI once up front, then skip it during the parallel dist build.
+      # Each dist/alloy-* target's sub-make runs generate-ui (npm ci, which wipes
+      # node_modules), so -j4 makes them race in the shared internal/web/ui dir.
+      run: |
+        make generate-ui
+        RELEASE_BUILD=1 SKIP_CODE_GENERATION=1 SKIP_UI_BUILD=1 make -j4 dist
       env:
         VERSION: ${{ env.RELEASE_TAG }}
 


### PR DESCRIPTION
### Brief description of Pull Request

The release dist build runs `make -j4 dist`, and every `dist/alloy-*` target's sub-make runs `generate-ui`, which since the npm ci switch in #6368 wipes and reinstalls `internal/web/ui/node_modules`. Four of those run concurrently under `-j4` and collide on the `.bin` symlinks (`EEXIST`), so the build fails before producing any artifacts — it took down the first 1.17.0 RC build. Build the UI once up front, then pass `SKIP_UI_BUILD=1` to the parallel build so the per-arch binaries reuse the assets instead of each rebuilding them.

Failed build: https://github.com/grafana/alloy/actions/runs/27162525184/job/80181375741
