### PR TITLE
test: Fix flaky tests

### DIFF
--- a/internal/component/common/loki/client/internal/marker/tracker_test.go
+++ b/internal/component/common/loki/client/internal/marker/tracker_test.go
@@ -38,7 +38,7 @@ func TestTracker(t *testing.T) {
 
 		require.Eventually(t, func() bool {
 			return st.LastMarkedSegment() == 11
-		}, 2*time.Second, time.Millisecond*100, "expected last marked segment to catch up")
+		}, 3*time.Second, time.Millisecond*100, "expected last marked segment to catch up")
 		require.Equal(t, 11, f.LastMarkedSegment())
 	})
 

--- a/internal/component/common/loki/client/internal/marker/tracker_test.go
+++ b/internal/component/common/loki/client/internal/marker/tracker_test.go
@@ -38,7 +38,7 @@ func TestTracker(t *testing.T) {
 
 		require.Eventually(t, func() bool {
 			return st.LastMarkedSegment() == 11
-		}, time.Second, time.Millisecond*100, "expected last marked segment to catch up")
+		}, 2*time.Second, time.Millisecond*100, "expected last marked segment to catch up")
 		require.Equal(t, 11, f.LastMarkedSegment())
 	})
 

--- a/internal/component/database_observability/postgres/collector/schema_details_test.go
+++ b/internal/component/database_observability/postgres/collector/schema_details_test.go
@@ -1489,10 +1489,12 @@ func Test_Postgres_SchemaDetails_ErrorCases(t *testing.T) {
 		require.False(t, ok, "tableRegistry must not be partially overwritten with the in-progress sweep")
 
 		// schema_a.table_a is still detected and emitted before schema_b fails.
-		entries := lokiClient.Received()
-		require.Len(t, entries, 1)
-		require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, entries[0].Labels)
-		require.Equal(t, `level="info" datname="testdb" schema="schema_a" table="table_a"`, entries[0].Line)
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			entries := lokiClient.Received()
+			require.Len(c, entries, 1)
+			require.Equal(c, model.LabelSet{"op": OP_TABLE_DETECTION}, entries[0].Labels)
+			require.Equal(c, `level="info" datname="testdb" schema="schema_a" table="table_a"`, entries[0].Line)
+		}, 2*time.Second, 100*time.Millisecond)
 	})
 
 	t.Run("fetchTableDefinitions returns error when selectColumnNames query fails", func(t *testing.T) {


### PR DESCRIPTION
* Tracker test fail something on windows, updated time to match the other test we have there.
* The schema test is really flaky and since there are channels involved we need to use Eventually function to perform the check.