### PR TITLE
fix(database_observability.mysql): Simplify denylist in-memory map for `explain_plans` collector

### DIFF
--- a/internal/component/database_observability/mysql/collector/explain_plans.go
+++ b/internal/component/database_observability/mysql/collector/explain_plans.go
@@ -366,11 +366,10 @@ func parseUnionResultNode(logger *slog.Logger, unionResultNode []byte) (database
 }
 
 type queryInfo struct {
-	schemaName   string
-	digest       string
-	queryText    string
-	failureCount int
-	uniqueKey    string
+	schemaName string
+	digest     string
+	queryText  string
+	uniqueKey  string
 }
 
 func newQueryInfo(schemaName, digest, queryText string) *queryInfo {
@@ -409,7 +408,7 @@ type ExplainPlans struct {
 	dbVersion        string
 	scrapeInterval   time.Duration
 	queryCache       map[string]*queryInfo
-	queryDenylist    map[string]*queryInfo
+	queryDenylist    map[string]struct{}
 	excludeSchemas   []string
 	perScrapeRatio   float64
 	currentBatchSize int
@@ -431,7 +430,7 @@ func NewExplainPlans(args ExplainPlansArguments) (*ExplainPlans, error) {
 		excludeSchemas: args.ExcludeSchemas,
 		lastSeen:       args.InitialLookback,
 		queryCache:     make(map[string]*queryInfo),
-		queryDenylist:  make(map[string]*queryInfo),
+		queryDenylist:  make(map[string]struct{}),
 		entryHandler:   args.EntryHandler,
 		logger:         args.Logger.With("collector", ExplainPlansCollector),
 		running:        atomic.NewBool(false),
@@ -586,8 +585,7 @@ func (c *ExplainPlans) fetchExplainPlans(ctx context.Context) error {
 		}
 
 		if c.processExplainPlan(ctx, qi) {
-			qi.failureCount++
-			c.queryDenylist[qi.uniqueKey] = qi
+			c.queryDenylist[qi.uniqueKey] = struct{}{}
 		}
 		delete(c.queryCache, qi.uniqueKey)
 		processedCount++

--- a/internal/component/database_observability/mysql/collector/explain_plans_test.go
+++ b/internal/component/database_observability/mysql/collector/explain_plans_test.go
@@ -1864,7 +1864,7 @@ func TestQueryFailureDenylist(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 0, len(c.queryCache))
 		require.Equal(t, 1, len(c.queryDenylist))
-		require.Equal(t, 1, c.queryDenylist[queryUnderTestHash].failureCount)
+		require.Contains(t, c.queryDenylist, queryUnderTestHash)
 	})
 
 	t.Run("denylisted queries are not added to query cache", func(t *testing.T) {


### PR DESCRIPTION
### Brief description of Pull Request
Reduce memory footprint for the `explain_plans` collector by not retaining the query text in memory for queries that have already been processed. Additionally, drop the unused `failureCount` field.

Followup of https://github.com/grafana/alloy/pull/6461




<!-- Human-readable description of the PR used as squash commit body. -->


### Pull Request Details

<!-- Detailed descripion of the Pull Request, if needed. -->


### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->


### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
