### PR TITLE
chore(database_observability): Refactor lexer to use a ring buffer for exemption-prefix lookback

### DIFF
--- a/internal/component/database_observability/lexer.go
+++ b/internal/component/database_observability/lexer.go
@@ -17,56 +17,70 @@ func isCommandKeywordOrIdentifier(token sqllexer.Token) bool {
 	return token.Type == sqllexer.COMMAND || token.Type == sqllexer.KEYWORD || token.Type == sqllexer.IDENT
 }
 
+// bufSize bounds the number of recent command/keyword/identifier (CKI) tokens
+// stored for exemption-prefix matching. It is fixed so the ring lives on
+// the stack instead of the heap. The size is large enough to accommodate the
+// longest ExemptionPrefixes list.
+const bufSize = 32
+
 // ContainsReservedKeywords checks if the SQL query contains any reserved keywords
 // that indicate write operations, excluding those in string literals or comments
 func ContainsReservedKeywords(query string, reservedWords map[string]ExplainReservedWordMetadata, dbms sqllexer.DBMSType) (bool, error) {
-	// Use the lexer to tokenize the query
 	lexer := sqllexer.New(query, sqllexer.WithDBMS(dbms))
-	tokenBuffer := make([]sqllexer.Token, 0)
 
-	// Scan all tokens
+	// buf is a ringbuffer that stores the most recent tokens.
+	// bufHead points at the next write slot; once bufLen
+	// reaches bufSize the oldest entry is overwritten.
+	var buf [bufSize]string
+	bufHead := 0
+	bufLen := 0
+
 	for {
 		token := lexer.Scan()
-		if token.Type == sqllexer.ERROR {
+		switch token.Type {
+		case sqllexer.ERROR:
 			return false, fmt.Errorf("lexer failed to scan query, offending token value: %s", token.Value)
+		case sqllexer.EOF:
+			return false, nil
 		}
-		if token.Type == sqllexer.EOF {
-			break
-		}
-		tokenBuffer = append(tokenBuffer, *token)
-	}
 
-	for tIdx, token := range tokenBuffer {
-		if isCommandKeywordOrIdentifier(token) {
-			if resWord, ok := reservedWords[strings.ToUpper(token.Value)]; ok {
-				if resWord.ExemptionPrefixes != nil && len(*resWord.ExemptionPrefixes) > 0 {
-					lookbackCount := len(*resWord.ExemptionPrefixes)
-					skippedTokens := 0
-					matchedTokens := 0
-					currentExemptionPrefix := (*resWord.ExemptionPrefixes)[0]
-					for i := tIdx - 1; i >= 0; i-- {
-						if tokenBuffer[i].Type == sqllexer.SPACE {
-							skippedTokens++
-							continue
-						}
-						if isCommandKeywordOrIdentifier(tokenBuffer[i]) {
-							if strings.EqualFold(tokenBuffer[i].Value, currentExemptionPrefix) {
-								matchedTokens++
-								if matchedTokens < lookbackCount {
-									currentExemptionPrefix = (*resWord.ExemptionPrefixes)[matchedTokens]
-								}
-							}
-						}
-					}
-					if matchedTokens < lookbackCount {
-						return true, nil
-					}
-				} else {
-					return true, nil
+		if !isCommandKeywordOrIdentifier(*token) {
+			continue
+		}
+
+		if resWord, ok := reservedWords[strings.ToUpper(token.Value)]; ok {
+			if resWord.ExemptionPrefixes == nil || len(*resWord.ExemptionPrefixes) == 0 {
+				return true, nil
+			}
+
+			// check for prefixes match in the ring buffer
+			prefixes := *resWord.ExemptionPrefixes
+			lookbackCount := len(prefixes)
+			matchedTokens := 0
+			currentExemptionPrefix := prefixes[0]
+
+			for i := 0; i < bufLen; i++ {
+				// walk the ringbuffer newest-to-oldest, the most recently
+				// inserted entry is at bufHead-1 (mod bufSize)
+				idx := (bufHead - 1 - i + bufSize) % bufSize
+				if !strings.EqualFold(buf[idx], currentExemptionPrefix) {
+					continue
 				}
+				matchedTokens++
+				if matchedTokens >= lookbackCount {
+					break
+				}
+				currentExemptionPrefix = prefixes[matchedTokens]
+			}
+			if matchedTokens < lookbackCount {
+				return true, nil
 			}
 		}
-	}
 
-	return false, nil
+		buf[bufHead] = token.Value
+		bufHead = (bufHead + 1) % bufSize
+		if bufLen < bufSize {
+			bufLen++
+		}
+	}
 }

--- a/internal/component/database_observability/lexer_bench_test.go
+++ b/internal/component/database_observability/lexer_bench_test.go
@@ -1,0 +1,115 @@
+package database_observability
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DataDog/go-sqllexer"
+)
+
+// multiPrefixDenyList exercises the multi-token exemption lookback (LOCK IN
+// SHARE MODE) with a custom list. Used to benchmark the deeper prefix walk.
+var multiPrefixDenyList = map[string]ExplainReservedWordMetadata{
+	"MODE": {
+		ExemptionPrefixes: &[]string{"SHARE", "IN", "LOCK"},
+	},
+}
+
+var benchInputs = []struct {
+	name          string
+	reservedWords map[string]ExplainReservedWordMetadata
+	query         string
+}{
+	{
+		name:          "select",
+		reservedWords: ExplainReservedWordDenyList,
+		query:         "SELECT id FROM users WHERE id = 1",
+	},
+	{
+		name:          "select_with_joins",
+		reservedWords: ExplainReservedWordDenyList,
+		query:         "SELECT u.id, u.name, p.title, c.body FROM users u JOIN posts p ON u.id = p.user_id LEFT JOIN comments c ON c.post_id = p.id WHERE u.active = true AND p.created_at > '2024-01-01' ORDER BY p.created_at DESC LIMIT 100",
+	},
+	{
+		name:          "long_cte",
+		reservedWords: ExplainReservedWordDenyList,
+		query: strings.Repeat(`WITH active_users AS (
+					SELECT * FROM users WHERE last_login > '2024-01-01'
+				), recent_orders AS (
+					SELECT o.* FROM orders o
+					JOIN active_users u ON u.id = o.user_id
+					WHERE o.created_at > '2024-03-01'
+				)
+				SELECT au.name, COUNT(ro.id) as order_count
+				FROM active_users au
+				LEFT JOIN recent_orders ro ON ro.user_id = au.id
+				GROUP BY au.name
+				HAVING COUNT(ro.id) > 5
+				UNION ALL
+				`, 20) + "SELECT 1",
+	},
+	{
+		name:          "insert",
+		reservedWords: ExplainReservedWordDenyList,
+		query:         "INSERT INTO users (name, age) VALUES ('john', 30)",
+	},
+	{
+		name:          "for_update_exemption",
+		reservedWords: ExplainReservedWordDenyList,
+		query:         "SELECT name FROM users WHERE id = 1 FOR UPDATE",
+	},
+	{
+		name:          "for_update_exemption_deep_lookback",
+		reservedWords: ExplainReservedWordDenyList,
+		query:         "SELECT u.id, u.name, u.email, u.created_at, p.title, p.body, c.id, c.body, a.street, a.city FROM users u JOIN posts p ON u.id = p.user_id JOIN comments c ON c.post_id = p.id JOIN addresses a ON a.user_id = u.id WHERE u.active = true AND p.created_at > '2024-01-01' ORDER BY p.created_at DESC LIMIT 100 FOR UPDATE",
+	},
+	{
+		name:          "update_concatenated_no_exemption",
+		reservedWords: ExplainReservedWordDenyList,
+		query:         "SELECT u.id, u.name, u.email, p.title, c.body FROM users u JOIN posts p ON u.id = p.user_id JOIN comments c ON c.post_id = p.id WHERE u.active = true ORDER BY p.created_at DESC; UPDATE users SET name = 'john' WHERE id = 1",
+	},
+	{
+		name:          "repeated_for_update",
+		reservedWords: ExplainReservedWordDenyList,
+		query:         strings.Repeat("SELECT id FROM users WHERE id = 1 FOR UPDATE; ", 20) + "SELECT 1 FOR UPDATE",
+	},
+	{
+		name:          "multi_prefix_lock",
+		reservedWords: multiPrefixDenyList,
+		query:         "SELECT name FROM users WHERE id = 1 LOCK IN SHARE MODE",
+	},
+	{
+		name:          "multi_prefix_lock_deep_lookback",
+		reservedWords: multiPrefixDenyList,
+		query:         "SELECT u.id, u.name, u.email, u.created_at, p.title, p.body, c.id, c.body FROM users u JOIN posts p ON u.id = p.user_id JOIN comments c ON c.post_id = p.id WHERE u.active = true ORDER BY p.created_at DESC LIMIT 100 LOCK IN SHARE MODE",
+	},
+	{
+		name:          "multi_prefix_incomplete",
+		reservedWords: multiPrefixDenyList,
+		query:         "SELECT name FROM users WHERE id = 1 LOCK SHARE MODE",
+	},
+}
+
+var benchDBMS = []struct {
+	name string
+	dbms sqllexer.DBMSType
+}{
+	{name: "postgres", dbms: sqllexer.DBMSPostgres},
+	{name: "mysql", dbms: sqllexer.DBMSMySQL},
+}
+
+func BenchmarkContainsReservedKeywords(b *testing.B) {
+	for _, dbms := range benchDBMS {
+		for _, in := range benchInputs {
+			b.Run(dbms.name+"/"+in.name, func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					if _, err := ContainsReservedKeywords(in.query, in.reservedWords, dbms.dbms); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
### Brief description of Pull Request
Refactor the lexer used in `explain_plans` collectors to tokenize the sql text using an on-stack ring buffer instead of an unbounded heap array. This brings memory improvement on workloads with very large sql texts.

### Pull Request Details
bench diff

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/alloy/internal/component/database_observability
cpu: Apple M3 Pro
                                                                        │  before.txt  │              after.txt              │
                                                                        │    sec/op    │   sec/op     vs base                │
ContainsReservedKeywords/postgres/select-12                                732.2n ± 1%   445.9n ± 3%  -39.11% (p=0.000 n=10)
ContainsReservedKeywords/postgres/select_with_joins-12                     4.295µ ± 0%   2.613µ ± 1%  -39.18% (p=0.000 n=10)
ContainsReservedKeywords/postgres/long_cte-12                             122.76µ ± 1%   80.19µ ± 1%  -34.68% (p=0.000 n=10)
ContainsReservedKeywords/postgres/insert-12                               917.50n ± 0%   91.19n ± 1%  -90.06% (p=0.000 n=10)
ContainsReservedKeywords/postgres/for_update_exemption-12                 1090.0n ± 1%   546.4n ± 0%  -49.88% (p=0.000 n=10)
ContainsReservedKeywords/postgres/for_update_exemption_deep_lookback-12    5.783µ ± 1%   3.906µ ± 1%  -32.46% (p=0.000 n=10)
ContainsReservedKeywords/postgres/update_concatenated_no_exemption-12      4.531µ ± 2%   2.409µ ± 1%  -46.84% (p=0.000 n=10)
ContainsReservedKeywords/postgres/repeated_for_update-12                  24.805µ ± 2%   9.415µ ± 1%  -62.05% (p=0.000 n=10)
ContainsReservedKeywords/postgres/multi_prefix_lock-12                    1220.0n ± 3%   686.7n ± 0%  -43.71% (p=0.000 n=10)
ContainsReservedKeywords/postgres/multi_prefix_lock_deep_lookback-12       5.038µ ± 2%   3.081µ ± 5%  -38.85% (p=0.000 n=10)
ContainsReservedKeywords/postgres/multi_prefix_incomplete-12              1199.5n ± 1%   678.0n ± 2%  -43.48% (p=0.000 n=10)
ContainsReservedKeywords/mysql/select-12                                   762.9n ± 2%   454.8n ± 1%  -40.39% (p=0.000 n=10)
ContainsReservedKeywords/mysql/select_with_joins-12                        4.380µ ± 2%   2.702µ ± 2%  -38.33% (p=0.000 n=10)
ContainsReservedKeywords/mysql/long_cte-12                                121.76µ ± 1%   84.19µ ± 2%  -30.85% (p=0.000 n=10)
ContainsReservedKeywords/mysql/insert-12                                  922.70n ± 1%   95.97n ± 5%  -89.60% (p=0.000 n=10)
ContainsReservedKeywords/mysql/for_update_exemption-12                    1086.5n ± 1%   562.2n ± 1%  -48.25% (p=0.000 n=10)
ContainsReservedKeywords/mysql/for_update_exemption_deep_lookback-12       5.874µ ± 3%   3.987µ ± 0%  -32.12% (p=0.000 n=10)
ContainsReservedKeywords/mysql/update_concatenated_no_exemption-12         4.554µ ± 1%   2.491µ ± 3%  -45.31% (p=0.000 n=10)
ContainsReservedKeywords/mysql/repeated_for_update-12                     24.921µ ± 1%   9.630µ ± 0%  -61.36% (p=0.000 n=10)
ContainsReservedKeywords/mysql/multi_prefix_lock-12                       1247.0n ± 3%   700.2n ± 1%  -43.85% (p=0.000 n=10)
ContainsReservedKeywords/mysql/multi_prefix_lock_deep_lookback-12          5.099µ ± 4%   3.091µ ± 1%  -39.37% (p=0.000 n=10)
ContainsReservedKeywords/mysql/multi_prefix_incomplete-12                 1216.5n ± 1%   664.7n ± 1%  -45.36% (p=0.000 n=10)
geomean                                                                    3.735µ        1.808µ       -51.60%

                                                                        │   before.txt   │              after.txt               │
                                                                        │      B/op      │     B/op      vs base                │
ContainsReservedKeywords/postgres/select-12                                  2280.0 ± 0%     168.0 ± 0%  -92.63% (p=0.000 n=10)
ContainsReservedKeywords/postgres/select_with_joins-12                      19320.0 ± 0%     312.0 ± 0%  -98.39% (p=0.000 n=10)
ContainsReservedKeywords/postgres/long_cte-12                             563.861Ki ± 0%   5.297Ki ± 0%  -99.06% (p=0.000 n=10)
ContainsReservedKeywords/postgres/insert-12                                  4560.0 ± 0%     144.0 ± 0%  -96.84% (p=0.000 n=10)
ContainsReservedKeywords/postgres/for_update_exemption-12                    4584.0 ± 0%     168.0 ± 0%  -96.34% (p=0.000 n=10)
ContainsReservedKeywords/postgres/for_update_exemption_deep_lookback-12     19424.0 ± 0%     416.0 ± 0%  -97.86% (p=0.000 n=10)
ContainsReservedKeywords/postgres/update_concatenated_no_exemption-12       19312.0 ± 0%     304.0 ± 0%  -98.43% (p=0.000 n=10)
ContainsReservedKeywords/postgres/repeated_for_update-12                    81072.0 ± 0%     624.0 ± 0%  -99.23% (p=0.000 n=10)
ContainsReservedKeywords/postgres/multi_prefix_lock-12                       4584.0 ± 0%     168.0 ± 0%  -96.34% (p=0.000 n=10)
ContainsReservedKeywords/postgres/multi_prefix_lock_deep_lookback-12        19344.0 ± 0%     336.0 ± 0%  -98.26% (p=0.000 n=10)
ContainsReservedKeywords/postgres/multi_prefix_incomplete-12                 4584.0 ± 0%     168.0 ± 0%  -96.34% (p=0.000 n=10)
ContainsReservedKeywords/mysql/select-12                                     2280.0 ± 0%     168.0 ± 0%  -92.63% (p=0.000 n=10)
ContainsReservedKeywords/mysql/select_with_joins-12                         19320.0 ± 0%     312.0 ± 0%  -98.39% (p=0.000 n=10)
ContainsReservedKeywords/mysql/long_cte-12                                563.861Ki ± 0%   5.297Ki ± 0%  -99.06% (p=0.000 n=10)
ContainsReservedKeywords/mysql/insert-12                                     4560.0 ± 0%     144.0 ± 0%  -96.84% (p=0.000 n=10)
ContainsReservedKeywords/mysql/for_update_exemption-12                       4584.0 ± 0%     168.0 ± 0%  -96.34% (p=0.000 n=10)
ContainsReservedKeywords/mysql/for_update_exemption_deep_lookback-12        19424.0 ± 0%     416.0 ± 0%  -97.86% (p=0.000 n=10)
ContainsReservedKeywords/mysql/update_concatenated_no_exemption-12          19312.0 ± 0%     304.0 ± 0%  -98.43% (p=0.000 n=10)
ContainsReservedKeywords/mysql/repeated_for_update-12                       81072.0 ± 0%     624.0 ± 0%  -99.23% (p=0.000 n=10)
ContainsReservedKeywords/mysql/multi_prefix_lock-12                          4584.0 ± 0%     168.0 ± 0%  -96.34% (p=0.000 n=10)
ContainsReservedKeywords/mysql/multi_prefix_lock_deep_lookback-12           19344.0 ± 0%     336.0 ± 0%  -98.26% (p=0.000 n=10)
ContainsReservedKeywords/mysql/multi_prefix_incomplete-12                    4584.0 ± 0%     168.0 ± 0%  -96.34% (p=0.000 n=10)
geomean                                                                     14.29Ki          330.5       -97.74%

                                                                        │ before.txt  │             after.txt              │
                                                                        │  allocs/op  │ allocs/op   vs base                │
ContainsReservedKeywords/postgres/select-12                               11.000 ± 0%   6.000 ± 0%  -45.45% (p=0.000 n=10)
ContainsReservedKeywords/postgres/select_with_joins-12                     28.00 ± 0%   20.00 ± 0%  -28.57% (p=0.000 n=10)
ContainsReservedKeywords/postgres/long_cte-12                              477.0 ± 0%   463.0 ± 0%   -2.94% (p=0.000 n=10)
ContainsReservedKeywords/postgres/insert-12                                9.000 ± 0%   3.000 ± 0%  -66.67% (p=0.000 n=10)
ContainsReservedKeywords/postgres/for_update_exemption-12                 12.000 ± 0%   6.000 ± 0%  -50.00% (p=0.000 n=10)
ContainsReservedKeywords/postgres/for_update_exemption_deep_lookback-12    38.00 ± 0%   30.00 ± 0%  -21.05% (p=0.000 n=10)
ContainsReservedKeywords/postgres/update_concatenated_no_exemption-12      28.00 ± 0%   20.00 ± 0%  -28.57% (p=0.000 n=10)
ContainsReservedKeywords/postgres/repeated_for_update-12                   73.00 ± 0%   63.00 ± 0%  -13.70% (p=0.000 n=10)
ContainsReservedKeywords/postgres/multi_prefix_lock-12                    12.000 ± 0%   6.000 ± 0%  -50.00% (p=0.000 n=10)
ContainsReservedKeywords/postgres/multi_prefix_lock_deep_lookback-12       31.00 ± 0%   23.00 ± 0%  -25.81% (p=0.000 n=10)
ContainsReservedKeywords/postgres/multi_prefix_incomplete-12              12.000 ± 0%   6.000 ± 0%  -50.00% (p=0.000 n=10)
ContainsReservedKeywords/mysql/select-12                                  11.000 ± 0%   6.000 ± 0%  -45.45% (p=0.000 n=10)
ContainsReservedKeywords/mysql/select_with_joins-12                        28.00 ± 0%   20.00 ± 0%  -28.57% (p=0.000 n=10)
ContainsReservedKeywords/mysql/long_cte-12                                 477.0 ± 0%   463.0 ± 0%   -2.94% (p=0.000 n=10)
ContainsReservedKeywords/mysql/insert-12                                   9.000 ± 0%   3.000 ± 0%  -66.67% (p=0.000 n=10)
ContainsReservedKeywords/mysql/for_update_exemption-12                    12.000 ± 0%   6.000 ± 0%  -50.00% (p=0.000 n=10)
ContainsReservedKeywords/mysql/for_update_exemption_deep_lookback-12       38.00 ± 0%   30.00 ± 0%  -21.05% (p=0.000 n=10)
ContainsReservedKeywords/mysql/update_concatenated_no_exemption-12         28.00 ± 0%   20.00 ± 0%  -28.57% (p=0.000 n=10)
ContainsReservedKeywords/mysql/repeated_for_update-12                      73.00 ± 0%   63.00 ± 0%  -13.70% (p=0.000 n=10)
ContainsReservedKeywords/mysql/multi_prefix_lock-12                       12.000 ± 0%   6.000 ± 0%  -50.00% (p=0.000 n=10)
ContainsReservedKeywords/mysql/multi_prefix_lock_deep_lookback-12          31.00 ± 0%   23.00 ± 0%  -25.81% (p=0.000 n=10)
ContainsReservedKeywords/mysql/multi_prefix_incomplete-12                 12.000 ± 0%   6.000 ± 0%  -50.00% (p=0.000 n=10)
geomean                                                                    26.97        16.86       -37.49%
```

### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->


### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
