### PR TITLE
fix: Back off usage reporting on persistent failure instead of retrying every minute

### DIFF
--- a/internal/usagestats/reporter.go
+++ b/internal/usagestats/reporter.go
@@ -15,6 +15,12 @@ import (
 var (
 	reportCheckInterval = time.Minute
 	reportInterval      = 4 * time.Hour
+
+	reportBackoffConfig = backoff.Config{
+		MinBackoff: time.Second,
+		MaxBackoff: 30 * time.Second,
+		MaxRetries: 5,
+	}
 )
 
 // Reporter holds the Alloy seed information and sends report of usage
@@ -56,10 +62,15 @@ func (rep *Reporter) Start(ctx context.Context, metricsFunc func() map[string]an
 				continue
 			}
 			rep.logger.Info("reporting Alloy stats", "date", time.Now())
-			if err := rep.reportUsage(ctx, next, metricsFunc()); err != nil {
+			err := rep.reportUsage(ctx, next, metricsFunc())
+			if err != nil {
 				rep.logger.Warn("failed to report usage", "err", err)
-				continue
 			}
+			// Advance the schedule whether or not the report succeeded.
+			// reportUsage already retries with backoff; on persistent failure
+			// (e.g. the endpoint won't resolve) we treat the window as spent and
+			// wait a full interval rather than re-attempting on every tick, which
+			// would otherwise hammer the endpoint indefinitely.
 			rep.lastReport = next
 			next = next.Add(reportInterval)
 		case <-ctx.Done():
@@ -70,11 +81,7 @@ func (rep *Reporter) Start(ctx context.Context, metricsFunc func() map[string]an
 
 // reportUsage reports the usage to grafana.com.
 func (rep *Reporter) reportUsage(ctx context.Context, interval time.Time, metrics map[string]any) error {
-	backoff := backoff.New(ctx, backoff.Config{
-		MinBackoff: time.Second,
-		MaxBackoff: 30 * time.Second,
-		MaxRetries: 5,
-	})
+	backoff := backoff.New(ctx, reportBackoffConfig)
 	var errs multierror.MultiError
 	for backoff.Ongoing() {
 		if err := sendReport(ctx, rep.seed, interval, metrics); err != nil {

--- a/internal/usagestats/reporter_test.go
+++ b/internal/usagestats/reporter_test.go
@@ -8,8 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/dskit/backoff"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	"github.com/grafana/alloy/internal/util"
 )
@@ -62,6 +64,45 @@ func Test_ReportLoop(t *testing.T) {
 		require.Equal(t, first, uid)
 	}
 	require.Equal(t, first, r.seed.UID)
+}
+
+func Test_ReportLoop_BoundedRetriesOnFailure(t *testing.T) {
+	// A failed report advances the schedule by a full reportInterval, so a
+	// persistently unreachable endpoint is contacted at most once per interval
+	// rather than on every (much shorter) check tick. With the interval set far
+	// longer than the test, a correct reporter contacts the endpoint exactly
+	// once regardless of how slowly the test host runs.
+	reportCheckInterval = time.Millisecond
+	reportInterval = time.Hour
+	reportBackoffConfig = backoff.Config{
+		MinBackoff: time.Millisecond,
+		MaxBackoff: 2 * time.Millisecond,
+		MaxRetries: 2,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		rw.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	usageStatsURL = server.URL
+
+	r, err := NewReporter(util.TestAlloyLogger(t).Slog())
+	require.NoError(t, err)
+	// Make the first report eligible immediately; otherwise the loop waits a
+	// full (now hour-long) interval before its first attempt.
+	r.lastReport = time.Now().Add(-2 * reportInterval)
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	var cycles atomic.Int64
+	metricsFunc := func() map[string]any {
+		cycles.Add(1)
+		return map[string]any{}
+	}
+	require.Equal(t, context.DeadlineExceeded, r.Start(ctx, metricsFunc))
+
+	require.Equal(t, int64(1), cycles.Load())
 }
 
 func Test_NextReport(t *testing.T) {


### PR DESCRIPTION
### Brief description of Pull Request

When the usage-reporting endpoint persistently fails — e.g. `stats.grafana.org` is `NXDOMAIN`'d by a DNS blocklist or sinkholed in a closed network — the reporter re-attempted on every check tick (~1/minute) indefinitely, because `lastReport`/`next` only advanced on success. Across a fleet that turns one unreachable endpoint into a DNS query storm (the issue reports ~900k queries/day from 57 agents). `reportUsage` already retries with dskit backoff (5 attempts, up to 30s); this advances the schedule whether or not the report succeeded, so a spent window waits a full interval (4 hours) instead of looping every 1 minute.

### Issue(s) fixed by this Pull Request

Fixes #6474

### PR Checklist

- [x] Tests updated
