### PR TITLE
feat: Add otel collector azureauthextension

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank.yaml
+++ b/.github/ISSUE_TEMPLATE/blank.yaml
@@ -80,6 +80,7 @@ body:
       - loki.write
       - mimir.alerts.kubernetes
       - mimir.rules.kubernetes
+      - otelcol.auth.azure
       - otelcol.auth.basic
       - otelcol.auth.bearer
       - otelcol.auth.google

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -80,6 +80,7 @@ body:
       - loki.write
       - mimir.alerts.kubernetes
       - mimir.rules.kubernetes
+      - otelcol.auth.azure
       - otelcol.auth.basic
       - otelcol.auth.bearer
       - otelcol.auth.google

--- a/.github/ISSUE_TEMPLATE/docs.yaml
+++ b/.github/ISSUE_TEMPLATE/docs.yaml
@@ -83,6 +83,7 @@ body:
       - loki.write
       - mimir.alerts.kubernetes
       - mimir.rules.kubernetes
+      - otelcol.auth.azure
       - otelcol.auth.basic
       - otelcol.auth.bearer
       - otelcol.auth.google

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -80,6 +80,7 @@ body:
       - loki.write
       - mimir.alerts.kubernetes
       - mimir.rules.kubernetes
+      - otelcol.auth.azure
       - otelcol.auth.basic
       - otelcol.auth.bearer
       - otelcol.auth.google

--- a/.github/ISSUE_TEMPLATE/proposal.yaml
+++ b/.github/ISSUE_TEMPLATE/proposal.yaml
@@ -80,6 +80,7 @@ body:
       - loki.write
       - mimir.alerts.kubernetes
       - mimir.rules.kubernetes
+      - otelcol.auth.azure
       - otelcol.auth.basic
       - otelcol.auth.bearer
       - otelcol.auth.google

--- a/collector/builder-config.yaml
+++ b/collector/builder-config.yaml
@@ -7,6 +7,7 @@ dist:
 
 extensions:
   - gomod: github.com/grafana/alloy/extension/alloyengine v0.1.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension v0.147.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.147.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.147.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.147.0

--- a/collector/components.go
+++ b/collector/components.go
@@ -33,6 +33,7 @@ import (
 	otlpexporter "go.opentelemetry.io/collector/exporter/otlpexporter"
 	otlphttpexporter "go.opentelemetry.io/collector/exporter/otlphttpexporter"
 	alloyengine "github.com/grafana/alloy/extension/alloyengine"
+	azureauthextension "github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension"
 	basicauthextension "github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension"
 	bearertokenauthextension "github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension"
 	headerssetterextension "github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension"
@@ -95,6 +96,7 @@ func components() (otelcol.Factories, error) {
 
 	factories.Extensions, err = otelcol.MakeFactoryMap[extension.Factory](
 		alloyengine.NewFactory(),
+		azureauthextension.NewFactory(),
 		basicauthextension.NewFactory(),
 		bearertokenauthextension.NewFactory(),
 		headerssetterextension.NewFactory(),
@@ -111,6 +113,7 @@ func components() (otelcol.Factories, error) {
 	}
 	factories.ExtensionModules = make(map[component.Type]string, len(factories.Extensions))
 	factories.ExtensionModules[alloyengine.NewFactory().Type()] = "github.com/grafana/alloy/extension/alloyengine v0.1.0"
+	factories.ExtensionModules[azureauthextension.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension v0.147.0"
 	factories.ExtensionModules[basicauthextension.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.147.0"
 	factories.ExtensionModules[bearertokenauthextension.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.147.0"
 	factories.ExtensionModules[headerssetterextension.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.147.0"

--- a/collector/go.mod
+++ b/collector/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter v0.147.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/syslogexporter v0.147.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter v0.147.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension v0.147.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.147.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.147.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.147.0

--- a/collector/go.sum
+++ b/collector/go.sum
@@ -1792,6 +1792,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporte
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter v0.147.0/go.mod h1:AUV1Ttz5M3BAbChQJSuzqC89NxwuUPah4Taal+8kNbs=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension v0.147.0 h1:Wobz+J9wkQkt9POiXpXSxJ5zE/DMO+xB9FYY5SNbXqo=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension v0.147.0/go.mod h1:nCCulTbtd/fLh7joMoKPDARlLPqGzKt+0DE2xiLKb4w=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension v0.147.0 h1:mENGkZK8N0bHNVITQpYB8P+cBNPHADBMe77uQEhNtf0=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension v0.147.0/go.mod h1:m0Zcc9qs6KsJa3j+MO7qt/ViVy/a5hfmR7ZPI6+LZw8=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.147.0 h1:5PjhFOIEALESZolVAfTC4Sg53RcIgGW/Ke5AYFQ9l5M=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.147.0/go.mod h1:47js3Z256jOh+XpOtCH+cQZtz9jW2wpcq6cWe5IVr6Q=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.147.0 h1:Qu+tMrwLH5KbyDhr8BqPjE++FtrMnMpZRMivl888OTE=

--- a/docs/sources/reference/components/otelcol/otelcol.auth.azure.md
+++ b/docs/sources/reference/components/otelcol/otelcol.auth.azure.md
@@ -1,0 +1,171 @@
+---
+canonical: https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.auth.azure/
+description: Learn about otelcol.auth.azure
+labels:
+  stage: public-preview
+  products:
+    - oss
+title: otelcol.auth.azure
+---
+
+# `otelcol.auth.azure`
+
+`otelcol.auth.azure` exposes a `handler` that other `otelcol` components can use to authenticate requests to Azure services using Microsoft Entra ID credentials.
+
+This component only supports client authentication.
+
+The authorization tokens can be used by HTTP and gRPC based OpenTelemetry exporters.
+
+{{< admonition type="note" >}}
+`otelcol.auth.azure` is a wrapper over the upstream OpenTelemetry Collector [`azureauth`][] extension.
+Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`azureauth`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/extension/azureauthextension
+{{< /admonition >}}
+
+You can specify multiple `otelcol.auth.azure` components by giving them different labels.
+
+## Usage
+
+```alloy
+otelcol.auth.azure "<LABEL>" {
+    use_default = true
+}
+```
+
+## Arguments
+
+You can use the following arguments with `otelcol.auth.azure`:
+
+| Name          | Type           | Description                                            | Default | Required |
+| ------------- | -------------- | ------------------------------------------------------ | ------- | -------- |
+| `scopes`      | `list(string)` | The scopes to request when fetching a token.           | `[]`    | no       |
+| `use_default` | `bool`         | Authenticate using the Azure default credential chain. | `false` | no       |
+
+You must configure exactly one authentication method.
+Either set `use_default` to `true`, or provide one of the [`managed_identity`][managed_identity], [`workload_identity`][workload_identity], or [`service_principal`][service_principal] blocks.
+
+When `use_default` is `true`, {{< param "PRODUCT_NAME" >}} uses the [`DefaultAzureCredential`][DefaultAzureCredential] chain, which looks for credentials from environment variables, workload identity, and managed identity, among other sources.
+
+[DefaultAzureCredential]: https://learn.microsoft.com/azure/developer/go/sdk/authentication/credential-chains#defaultazurecredential-overview
+
+## Blocks
+
+You can use the following blocks with `otelcol.auth.azure`:
+
+{{< docs/alloy-config >}}
+
+| Block                                  | Description                                                                | Required |
+| -------------------------------------- | -------------------------------------------------------------------------- | -------- |
+| [`debug_metrics`][debug_metrics]       | Configures the metrics that this component generates to monitor its state. | no       |
+| [`managed_identity`][managed_identity] | Authenticate using an Azure managed identity.                              | no       |
+| [`service_principal`][service_principal] | Authenticate using an Azure service principal.                           | no       |
+| [`workload_identity`][workload_identity] | Authenticate using an Azure workload identity.                           | no       |
+
+[debug_metrics]: #debug_metrics
+[managed_identity]: #managed_identity
+[service_principal]: #service_principal
+[workload_identity]: #workload_identity
+
+{{< /docs/alloy-config >}}
+
+### `debug_metrics`
+
+{{< docs/shared lookup="reference/components/otelcol-debug-metrics-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `managed_identity`
+
+The `managed_identity` block authenticates using an [Azure managed identity][managed-identities].
+
+| Name        | Type     | Description                                          | Default | Required |
+| ----------- | -------- | ---------------------------------------------------- | ------- | -------- |
+| `client_id` | `string` | The client ID of the user-assigned managed identity. | `""`    | no       |
+
+If `client_id` is empty, the system-assigned managed identity is used.
+
+[managed-identities]: https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview
+
+### `service_principal`
+
+The `service_principal` block authenticates using an [Azure service principal][service-principals].
+
+| Name                      | Type     | Description                                                    | Default | Required |
+| ------------------------- | -------- | ------------------------------------------------------------- | ------- | -------- |
+| `client_id`               | `string` | The client ID of the service principal.                       |         | yes      |
+| `tenant_id`               | `string` | The tenant ID of the service principal.                       |         | yes      |
+| `client_certificate_path` | `string` | The path to the certificate used to authenticate.             | `""`    | no       |
+| `client_secret`           | `string` | The client secret used to authenticate.                       | `""`    | no       |
+
+You must set exactly one of `client_secret` or `client_certificate_path`.
+
+[service-principals]: https://learn.microsoft.com/entra/identity-platform/app-objects-and-service-principals
+
+### `workload_identity`
+
+The `workload_identity` block authenticates using an [Azure workload identity][workload-identities].
+
+| Name                   | Type     | Description                                        | Default | Required |
+| ---------------------- | -------- | -------------------------------------------------- | ------- | -------- |
+| `client_id`            | `string` | The client ID of the application.                  |         | yes      |
+| `federated_token_file` | `string` | The path to a file that contains a federated token. |        | yes      |
+| `tenant_id`            | `string` | The tenant ID of the application.                  |         | yes      |
+
+[workload-identities]: https://learn.microsoft.com/entra/workload-id/workload-identities-overview
+
+## Exported fields
+
+The following fields are exported and can be referenced by other components:
+
+| Name      | Type                       | Description                                                     |
+| --------- | -------------------------- | --------------------------------------------------------------- |
+| `handler` | `capsule(otelcol.Handler)` | A value that other components can use to authenticate requests. |
+
+## Component health
+
+`otelcol.auth.azure` is only reported as unhealthy if given an invalid configuration.
+
+## Debug information
+
+`otelcol.auth.azure` doesn't expose any component-specific debug information.
+
+## Examples
+
+### Authenticate using a managed identity
+
+This example configures [`otelcol.exporter.otlp`][otelcol.exporter.otlp] to use `otelcol.auth.azure` with the system-assigned managed identity:
+
+```alloy
+otelcol.exporter.otlp "example" {
+  client {
+    endpoint = "my-otlp-grpc-server:4317"
+    auth     = otelcol.auth.azure.creds.handler
+  }
+}
+
+otelcol.auth.azure "creds" {
+    managed_identity {}
+}
+```
+
+### Authenticate using a service principal
+
+This example authenticates using a service principal with a client secret:
+
+```alloy
+otelcol.exporter.otlp "example" {
+  client {
+    endpoint = "my-otlp-grpc-server:4317"
+    auth     = otelcol.auth.azure.creds.handler
+  }
+}
+
+otelcol.auth.azure "creds" {
+    service_principal {
+        tenant_id     = sys.env("TENANT_ID") 
+        client_id     = sys.env("CLIENT_ID")
+        client_secret = sys.env("CLIENT_SECRET")
+    }
+}
+```
+
+[otelcol.exporter.otlp]: ../otelcol.exporter.otlp/

--- a/extension/alloyengine/go.mod
+++ b/extension/alloyengine/go.mod
@@ -642,6 +642,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter v0.147.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/syslogexporter v0.147.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension v0.147.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension v0.147.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.147.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.147.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.147.0 // indirect

--- a/extension/alloyengine/go.sum
+++ b/extension/alloyengine/go.sum
@@ -1817,6 +1817,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/exporter/syslogexporte
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/syslogexporter v0.147.0/go.mod h1:7kvuMrpnOMPWReVIeUUn5lPL8BMu0aa0/ToM5V0IFsA=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension v0.147.0 h1:Wobz+J9wkQkt9POiXpXSxJ5zE/DMO+xB9FYY5SNbXqo=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension v0.147.0/go.mod h1:nCCulTbtd/fLh7joMoKPDARlLPqGzKt+0DE2xiLKb4w=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension v0.147.0 h1:mENGkZK8N0bHNVITQpYB8P+cBNPHADBMe77uQEhNtf0=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension v0.147.0/go.mod h1:m0Zcc9qs6KsJa3j+MO7qt/ViVy/a5hfmR7ZPI6+LZw8=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.147.0 h1:5PjhFOIEALESZolVAfTC4Sg53RcIgGW/Ke5AYFQ9l5M=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.147.0/go.mod h1:47js3Z256jOh+XpOtCH+cQZtz9jW2wpcq6cWe5IVr6Q=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.147.0 h1:Qu+tMrwLH5KbyDhr8BqPjE++FtrMnMpZRMivl888OTE=

--- a/go.mod
+++ b/go.mod
@@ -991,6 +991,7 @@ require (
 	github.com/charmbracelet/huh v1.0.0
 	github.com/moby/moby/api v1.54.2
 	github.com/moby/moby/client v0.4.1
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension v0.147.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension v0.147.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/splunk v0.147.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver v0.147.0

--- a/go.sum
+++ b/go.sum
@@ -1864,6 +1864,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/exporter/syslogexporte
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/syslogexporter v0.147.0/go.mod h1:7kvuMrpnOMPWReVIeUUn5lPL8BMu0aa0/ToM5V0IFsA=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension v0.147.0 h1:Wobz+J9wkQkt9POiXpXSxJ5zE/DMO+xB9FYY5SNbXqo=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension v0.147.0/go.mod h1:nCCulTbtd/fLh7joMoKPDARlLPqGzKt+0DE2xiLKb4w=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension v0.147.0 h1:mENGkZK8N0bHNVITQpYB8P+cBNPHADBMe77uQEhNtf0=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension v0.147.0/go.mod h1:m0Zcc9qs6KsJa3j+MO7qt/ViVy/a5hfmR7ZPI6+LZw8=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.147.0 h1:5PjhFOIEALESZolVAfTC4Sg53RcIgGW/Ke5AYFQ9l5M=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.147.0/go.mod h1:47js3Z256jOh+XpOtCH+cQZtz9jW2wpcq6cWe5IVr6Q=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.147.0 h1:Qu+tMrwLH5KbyDhr8BqPjE++FtrMnMpZRMivl888OTE=

--- a/internal/component/all/all.go
+++ b/internal/component/all/all.go
@@ -63,6 +63,7 @@ import (
 	_ "github.com/grafana/alloy/internal/component/loki/write"                               // Import loki.write
 	_ "github.com/grafana/alloy/internal/component/mimir/alerts/kubernetes"                  // Import mimir.alerts.kubernetes
 	_ "github.com/grafana/alloy/internal/component/mimir/rules/kubernetes"                   // Import mimir.rules.kubernetes
+	_ "github.com/grafana/alloy/internal/component/otelcol/auth/azure"                       // Import otelcol.auth.azure
 	_ "github.com/grafana/alloy/internal/component/otelcol/auth/basic"                       // Import otelcol.auth.basic
 	_ "github.com/grafana/alloy/internal/component/otelcol/auth/bearer"                      // Import otelcol.auth.bearer
 	_ "github.com/grafana/alloy/internal/component/otelcol/auth/google"                      // Import otelcol.auth.google

--- a/internal/component/otelcol/auth/azure/azure.go
+++ b/internal/component/otelcol/auth/azure/azure.go
@@ -1,0 +1,153 @@
+package azure
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension"
+	otelcomponent "go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configoptional"
+	"go.opentelemetry.io/collector/pipeline"
+
+	"github.com/grafana/alloy/internal/component"
+	"github.com/grafana/alloy/internal/component/otelcol/auth"
+	otelcol "github.com/grafana/alloy/internal/component/otelcol/config"
+	"github.com/grafana/alloy/internal/featuregate"
+	"github.com/grafana/alloy/syntax"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:      "otelcol.auth.azure",
+		Stability: featuregate.StabilityPublicPreview,
+		Args:      Arguments{},
+		Exports:   auth.Exports{},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			fact := azureauthextension.NewFactory()
+			return auth.New(opts, fact, args.(Arguments))
+		},
+	})
+}
+
+var (
+	_ auth.Arguments   = Arguments{}
+	_ syntax.Validator = Arguments{}
+)
+
+type Arguments struct {
+	UseDefault       bool              `alloy:"use_default,attr,optional"`
+	Scopes           []string          `alloy:"scopes,attr,optional"`
+	ManagedIdentity  *ManagedIdentity  `alloy:"managed_identity,block,optional"`
+	WorkloadIdentity *WorkloadIdentity `alloy:"workload_identity,block,optional"`
+	ServicePrincipal *ServicePrincipal `alloy:"service_principal,block,optional"`
+
+	// DebugMetrics configures component internal metrics. Optional.
+	DebugMetrics otelcol.DebugMetricsArguments `alloy:"debug_metrics,block,optional"`
+}
+
+type ManagedIdentity struct {
+	ClientID string `alloy:"client_id,attr,optional"`
+}
+
+type WorkloadIdentity struct {
+	ClientID           string `alloy:"client_id,attr"`
+	TenantID           string `alloy:"tenant_id,attr"`
+	FederatedTokenFile string `alloy:"federated_token_file,attr"`
+}
+
+type ServicePrincipal struct {
+	TenantID              string `alloy:"tenant_id,attr"`
+	ClientID              string `alloy:"client_id,attr"`
+	ClientSecret          string `alloy:"client_secret,attr,optional"`
+	ClientCertificatePath string `alloy:"client_certificate_path,attr,optional"`
+}
+
+func (a Arguments) Validate() error {
+	client, err := a.ConvertClient()
+	if err != nil {
+		return err
+	}
+
+	c := client.(*azureauthextension.Config)
+
+	if err := c.Validate(); err != nil {
+		return err
+	}
+
+	if c.Managed.HasValue() {
+		if err := c.Managed.Get().Validate(); err != nil {
+			return err
+		}
+	}
+
+	if c.Workload.HasValue() {
+		if err := c.Workload.Get().Validate(); err != nil {
+			return err
+		}
+	}
+
+	if c.ServicePrincipal.HasValue() {
+		if err := c.ServicePrincipal.Get().Validate(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// AuthFeatures implements auth.Arguments.
+func (a Arguments) AuthFeatures() auth.AuthFeature {
+	return auth.ClientAuthSupported
+}
+
+// ConvertClient implements auth.Arguments.
+func (a Arguments) ConvertClient() (otelcomponent.Config, error) {
+	c := azureauthextension.Config{
+		UseDefault: a.UseDefault,
+		Scopes:     a.Scopes,
+	}
+
+	if a.ManagedIdentity != nil {
+		c.Managed = configoptional.Some(azureauthextension.ManagedIdentity{
+			ClientID: a.ManagedIdentity.ClientID,
+		})
+	}
+
+	if a.WorkloadIdentity != nil {
+		c.Workload = configoptional.Some(azureauthextension.WorkloadIdentity{
+			ClientID:           a.WorkloadIdentity.ClientID,
+			TenantID:           a.WorkloadIdentity.TenantID,
+			FederatedTokenFile: a.WorkloadIdentity.FederatedTokenFile,
+		})
+	}
+
+	if a.ServicePrincipal != nil {
+		c.ServicePrincipal = configoptional.Some(azureauthextension.ServicePrincipal{
+			TenantID:              a.ServicePrincipal.TenantID,
+			ClientID:              a.ServicePrincipal.ClientID,
+			ClientSecret:          a.ServicePrincipal.ClientSecret,
+			ClientCertificatePath: a.ServicePrincipal.ClientCertificatePath,
+		})
+	}
+
+	return &c, nil
+}
+
+// ConvertServer implements auth.Arguments.
+func (a Arguments) ConvertServer() (otelcomponent.Config, error) {
+	// FIXME(kalleep): Supports server authentication in newer versions.
+	return nil, nil
+}
+
+// DebugMetricsConfig implements auth.Arguments.
+func (a Arguments) DebugMetricsConfig() otelcol.DebugMetricsArguments {
+	return a.DebugMetrics
+}
+
+// Exporters implements auth.Arguments.
+func (a Arguments) Exporters() map[pipeline.Signal]map[otelcomponent.ID]otelcomponent.Component {
+	return nil
+}
+
+// Extensions implements auth.Arguments.
+func (a Arguments) Extensions() map[otelcomponent.ID]otelcomponent.Component {
+	return nil
+}

--- a/internal/component/otelcol/auth/azure/azure_test.go
+++ b/internal/component/otelcol/auth/azure/azure_test.go
@@ -1,0 +1,113 @@
+package azure_test
+
+import (
+	"testing"
+
+	"github.com/grafana/alloy/internal/component/otelcol/auth/azure"
+	"github.com/grafana/alloy/syntax"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnmarshalAlloy(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       string
+		expectErr bool
+	}{
+		{
+			name: "use default",
+			cfg:  `use_default = true`,
+		},
+		{
+			name: "use default with scopes",
+			cfg: `
+				use_default = true
+				scopes      = ["https://storage.azure.com/.default"]
+			`,
+		},
+		{
+			name: "system assigned managed identity",
+			cfg:  `managed_identity {}`,
+		},
+		{
+			name: "user assigned managed identity",
+			cfg: `
+				managed_identity {
+					client_id = "11111111-1111-1111-1111-111111111111"
+				}
+			`,
+		},
+		{
+			name: "workload identity",
+			cfg: `
+				workload_identity {
+					client_id            = "11111111-1111-1111-1111-111111111111"
+					tenant_id            = "22222222-2222-2222-2222-222222222222"
+					federated_token_file = "/var/run/secrets/azure/tokens/azure-identity-token"
+				}
+			`,
+		},
+		{
+			name: "empty workload identity",
+			cfg: `
+				workload_identity {}
+			`,
+			expectErr: true,
+		},
+		{
+			name: "workload identity missing federated_token_file",
+			cfg: `
+				workload_identity {
+					client_id = "11111111-1111-1111-1111-111111111111"
+					tenant_id = "22222222-2222-2222-2222-222222222222"
+				}
+			`,
+			expectErr: true,
+		},
+		{
+			name: "service principal with secret",
+			cfg: `
+				service_principal {
+					tenant_id     = "22222222-2222-2222-2222-222222222222"
+					client_id     = "11111111-1111-1111-1111-111111111111"
+					client_secret = "supersecret"
+				}
+			`,
+		},
+		{
+			name: "service principal with certificate",
+			cfg: `
+				service_principal {
+					tenant_id               = "22222222-2222-2222-2222-222222222222"
+					client_id               = "11111111-1111-1111-1111-111111111111"
+					client_certificate_path = "/etc/azure/cert.pem"
+				}
+			`,
+		},
+		{
+			name: "empty service principal",
+			cfg: `
+				workload_identity {}
+			`,
+			expectErr: true,
+		},
+		{
+			name:      "no authentication method",
+			cfg:       ``,
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var args azure.Arguments
+			err := syntax.Unmarshal([]byte(tc.cfg), &args)
+
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
### Pull Request Details
This pr adds [azureauthextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.147.0/extension/azureauthextension) to both engines.

Seems like later versions of this extension supports server authentication too but we need to wait until we update our otel verion for that.

### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->

### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
