### PR TITLE
fix: Don't emit error log when remotecfg is unused

### DIFF
--- a/internal/service/remotecfg/remotecfg.go
+++ b/internal/service/remotecfg/remotecfg.go
@@ -339,7 +339,7 @@ func (s *Service) unregisterCollector(ctx context.Context) error {
 			Id: s.args.ID,
 		},
 	})
-	if err != nil {
+	if err != nil && !errors.Is(err, errNoopClient) {
 		s.opts.Logger.Error("failed to unregister collector with remote server", "id", s.args.ID, "err", err)
 		return err
 	}

--- a/internal/service/remotecfg/remotecfg.go
+++ b/internal/service/remotecfg/remotecfg.go
@@ -145,7 +145,7 @@ func (s *Service) Run(ctx context.Context, host service.Host) error {
 
 	s.fetchLoadConfig(true) // Allow cache fallback on startup
 	err = s.registerCollector()
-	if err != nil && err != errNoopClient {
+	if err != nil && !errors.Is(err, errNoopClient) {
 		s.opts.Logger.Error("failed to register collector during service startup", "err", err)
 		return err
 	}


### PR DESCRIPTION
### Pull Request Details
Every time alloy is stopped _and_ remotecfg is not configured we get these lines:
```
ts=2026-06-12T13:17:36.940337521Z level=error msg="failed to unregister collector with remote server" service=remotecfg id=10b83d8f-be9e-454f-a493-0abf34936aa6 err="noop client"
ts=2026-06-12T13:17:36.940348332Z level=error msg="failed to unregister collector during service shutdown" service=remotecfg err="noop client"
``` 

### Issue(s) fixed by this Pull Request
<!-- Fixes #issue_id -->

### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
