### PR TITLE
ci: Bump send-slack-message to v3.0.2 to fix release announce

### DIFF
--- a/.github/workflows/release-announce.yml
+++ b/.github/workflows/release-announce.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Notify internal alloy channel 📢
         if: steps.release-type.outputs.is_alloy_release == 'true'
-        uses: grafana/shared-workflows/actions/send-slack-message@0941e3408fa4789fec9062c44a2a9e1832146ba6 #v2.0.1
+        uses: grafana/shared-workflows/actions/send-slack-message@551bc8d50017d3e95d5da3f8a4826e733a208dc0 # send-slack-message/v3.0.2
         env:
           SLACK_MESSAGE: |
             :alloy: :alloy: :alloy:


### PR DESCRIPTION
### Brief description of Pull Request

Bumps `send-slack-message` from v2.0.1 to v3.0.2 in the release-announce workflow. 