### PR TITLE
chore: Release Alloy Helm chart 1.10.0 (Alloy v1.17.0)

### DIFF
--- a/operations/helm/charts/alloy/CHANGELOG.md
+++ b/operations/helm/charts/alloy/CHANGELOG.md
@@ -9,9 +9,21 @@ internal API changes are not present.
 
 Unreleased
 ----------
+
+1.10.0 (2026-06-12)
+----------
+
 ### Enhancements
 
 - Allow configuring of the alloy service externalTrafficPolicy (@at-blacknight)
+
+- Update to Grafana Alloy v1.17.0 (@kgeckhart)
+
+1.9.0 (2026-06-08)
+----------
+
+### Enhancements
+
 - Add `controller.autoscaling.horizontal.externalHPA` to support externally-managed HPAs (e.g. KEDA `ScaledObject`s). When set to `true`, the chart omits `spec.replicas` from the workload and does not render its own HorizontalPodAutoscaler. Mutually exclusive with `horizontal.enabled`. (#6311)
 
 - Update to Grafana Alloy v1.16.3 (@kgeckhart)

--- a/operations/helm/charts/alloy/Chart.yaml
+++ b/operations/helm/charts/alloy/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: alloy
 description: "Grafana Alloy"
 type: application
-version: 1.9.0
-appVersion: "v1.16.3"
+version: 1.10.0
+appVersion: "v1.17.0"
 icon: https://raw.githubusercontent.com/grafana/alloy/main/docs/sources/assets/alloy_icon_orange.svg
 
 dependencies:

--- a/operations/helm/charts/alloy/README.md
+++ b/operations/helm/charts/alloy/README.md
@@ -1,6 +1,6 @@
 # Grafana Alloy Helm chart
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 1.9.0](https://img.shields.io/badge/Version-1.9.0-informational?style=flat-square) ![AppVersion: v1.16.3](https://img.shields.io/badge/AppVersion-v1.16.3-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![AppVersion: v1.17.0](https://img.shields.io/badge/AppVersion-v1.17.0-informational?style=flat-square)
 
 Helm chart for deploying [Grafana Alloy][] to Kubernetes.
 

--- a/operations/helm/tests/additional-serviceaccount-label/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/additional-serviceaccount-label/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/clustering/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/clustering/alloy/templates/controllers/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/configmap-key/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/configmap-key/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/controller-deployment-pdb-max-unavailable/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/controller-deployment-pdb-max-unavailable/alloy/templates/controllers/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/controller-deployment-pdb-min-available/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/controller-deployment-pdb-min-available/alloy/templates/controllers/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/controller-extraLabels-label/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/controller-extraLabels-label/alloy/templates/controllers/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/controller-max-revison-history/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/controller-max-revison-history/alloy/templates/controllers/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/controller-statefulset-pdb-max-unavailable/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/controller-statefulset-pdb-max-unavailable/alloy/templates/controllers/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/controller-statefulset-pdb-min-available/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/controller-statefulset-pdb-min-available/alloy/templates/controllers/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/controller-volumes-extra/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/controller-volumes-extra/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-daemonset-hostnetwork/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset-hostnetwork/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-daemonset/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-deployment-autoscaling/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment-autoscaling/alloy/templates/controllers/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-deployment-external-hpa/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment-external-hpa/alloy/templates/controllers/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-deployment/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment/alloy/templates/controllers/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-networkpolicy/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-networkpolicy/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-statefulset-autoscaling/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset-autoscaling/alloy/templates/controllers/statefulset.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-statefulset-external-hpa/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset-external-hpa/alloy/templates/controllers/statefulset.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-statefulset-vertical-autoscaling/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset-vertical-autoscaling/alloy/templates/controllers/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-statefulset/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset/alloy/templates/controllers/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/custom-config/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/custom-config/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/default-values/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/default-values/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/disable-http-server-port/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/disable-http-server-port/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/enable-servicemonitor-tls/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/enable-servicemonitor-tls/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/enable-servicemonitor/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/enable-servicemonitor/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/engine-flags/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/engine-flags/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/envFrom/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/envFrom/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/existing-config/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/existing-config/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/extra-env/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-env/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/extra-manifests/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-manifests/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/extra-ports/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-ports/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/faro-ingress/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/faro-ingress/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/global-image-pullpolicy/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/global-image-pullpolicy/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: Always
           args:
             - run

--- a/operations/helm/tests/global-image-pullsecrets/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/global-image-pullsecrets/alloy/templates/controllers/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         - name: global-cred
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/global-image-registry/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/global-image-registry/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: quay.io/grafana/alloy:v1.16.3
+          image: quay.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/host-alias/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/host-alias/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/initcontainers/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/initcontainers/alloy/templates/controllers/daemonset.yaml
@@ -46,7 +46,7 @@ spec:
             name: geoip
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/lifecycle-hooks/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/lifecycle-hooks/alloy/templates/controllers/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/livinessprobe/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/livinessprobe/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/local-image-pullsecrets/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/local-image-pullsecrets/alloy/templates/controllers/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         - name: local-cred
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/local-image-registry/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/local-image-registry/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: quay.io/grafana/alloy:v1.16.3
+          image: quay.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/nodeselectors-and-tolerations/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/nodeselectors-and-tolerations/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/nonroot/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/nonroot/alloy/templates/controllers/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/pod_annotations/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/pod_annotations/alloy/templates/controllers/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/rbac-empty-rules/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/rbac-empty-rules/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/rbac-rules/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/rbac-rules/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/readinessprobe/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/readinessprobe/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/roles-and-rolebindings/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/roles-and-rolebindings/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/service-external-traffic-policy/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/service-external-traffic-policy/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/sidecars/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/sidecars/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/termination-grace-period/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/termination-grace-period/alloy/templates/controllers/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/topologyspreadconstraints/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/topologyspreadconstraints/alloy/templates/controllers/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.3
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run


### PR DESCRIPTION
### Brief description of Pull Request

Release the Alloy Helm chart 1.10.0: bump `appVersion` to Alloy v1.17.0 and ship the new `service.externalTrafficPolicy` support from the externalTrafficPolicy PR (#4511).

### Pull Request Details

That externalTrafficPolicy PR merged from a stale branch and deleted the `1.9.0 (2026-06-08)` CHANGELOG header, which left 1.9.0's already-shipped entries (externalHPA, the v1.16.3 bump, the configmap key fix) sitting back under _Unreleased_. This restores that header and pulls only the externalTrafficPolicy entry up under the new `1.10.0` section. The rest is the standard release bump — Chart.yaml, helm-docs README badges, and regenerated golden test snapshots (`v1.16.3 → v1.17.0`).

### PR Checklist

- [x] Documentation added
- [x] Tests updated
