### PR TITLE
ci: Disable setup-go cache in enrich-release-notes

### DIFF
--- a/.github/workflows/release-enrich-release-notes.yml
+++ b/.github/workflows/release-enrich-release-notes.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           go-version-file: tools/go.mod
           cache-dependency-path: tools/go.sum
+          cache: false
 
       - name: Enrich release notes 🙋
         run: go run -C tools ./cmd release enrich-release-notes --tag "${RELEASE_TAG_NAME}" --footer release/release-notes-footer.md


### PR DESCRIPTION
### Brief description of Pull Request

zizmor fails it as a high-severity cache-poisoning risk because the workflow runs on `release: published` (an artifact-publishing trigger) with Go module caching left on.

### Pull Request Details

This matches the pattern already used by the other release/push-triggered workflows — `release-create-branch.yml` and `publish-alloy-windows.yml` both set `cache: false` on `setup-go`. The cache is a negligible speedup for a step that runs once per release.