### PR TITLE
feat(cli): Only write formatted files if content changed

### DIFF
--- a/internal/alloycli/cmd_fmt.go
+++ b/internal/alloycli/cmd_fmt.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"reflect"
 
 	"github.com/spf13/cobra"
 
@@ -117,7 +116,7 @@ func format(filename string, fi os.FileInfo, r io.Reader, write bool, test bool)
 
 	// If -t/--test flag is check, only check if file is formatted correctly
 	if test {
-		if !reflect.DeepEqual(bb, buf.Bytes()) {
+		if !bytes.Equal(bb, buf.Bytes()) {
 			return fmt.Errorf("file %s is not formatted correctly", filename)
 		}
 		return nil
@@ -126,6 +125,11 @@ func format(filename string, fi os.FileInfo, r io.Reader, write bool, test bool)
 	if !write {
 		_, err := io.Copy(os.Stdout, &buf)
 		return err
+	}
+
+	// Only write to the file if the content actually changed
+	if bytes.Equal(bb, buf.Bytes()) {
+		return nil
 	}
 
 	wf, err := os.OpenFile(filename, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, fi.Mode().Perm())

--- a/internal/alloycli/cmd_fmt_test.go
+++ b/internal/alloycli/cmd_fmt_test.go
@@ -1,0 +1,84 @@
+package alloycli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlloyFmt_NoWriteIfUnchanged(t *testing.T) {
+	// 1. Create a temporary file with already-formatted content.
+	content := []byte("logging {\n\tlevel  = \"debug\"\n\tformat = \"logfmt\"\n}\n")
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "config.alloy")
+	err := os.WriteFile(tmpFile, content, 0600)
+	require.NoError(t, err)
+
+	// 2. Set the file to read-only so that any attempt to open it with O_WRONLY/O_TRUNC will fail.
+	err = os.Chmod(tmpFile, 0400)
+	require.NoError(t, err)
+	defer func() {
+		// Restore write permissions so cleanup doesn't fail.
+		_ = os.Chmod(tmpFile, 0600)
+	}()
+
+	// 3. Run alloyFmt with write: true. Since the file is already formatted,
+	// it should NOT attempt to open/truncate the file, and should succeed.
+	f := &alloyFmt{
+		write: true,
+		test:  false,
+	}
+	err = f.Run(tmpFile)
+	require.NoError(t, err)
+}
+
+func TestAlloyFmt_WriteIfChanged(t *testing.T) {
+	// 1. Create a temporary file with unformatted content.
+	content := []byte("logging {\nlevel = \"debug\"\n}\n")
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "config.alloy")
+	err := os.WriteFile(tmpFile, content, 0600)
+	require.NoError(t, err)
+
+	// 2. Run alloyFmt with write: true. It should format and overwrite the file.
+	f := &alloyFmt{
+		write: true,
+		test:  false,
+	}
+	err = f.Run(tmpFile)
+	require.NoError(t, err)
+
+	// 3. Verify the file content was formatted.
+	newContent, err := os.ReadFile(tmpFile)
+	require.NoError(t, err)
+	expected := "logging {\n\tlevel = \"debug\"\n}\n"
+	require.Equal(t, expected, string(newContent))
+}
+
+func TestAlloyFmt_TestFlag(t *testing.T) {
+	// Test file with unformatted content
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "config.alloy")
+	content := []byte("logging {\nlevel = \"debug\"\n}\n")
+	err := os.WriteFile(tmpFile, content, 0600)
+	require.NoError(t, err)
+
+	// Run alloyFmt with test: true. It should return an error indicating changes would be made.
+	f := &alloyFmt{
+		write: false,
+		test:  true,
+	}
+	err = f.Run(tmpFile)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "is not formatted correctly")
+
+	// Now run it on formatted content. It should succeed without error.
+	formattedContent := []byte("logging {\n\tlevel = \"debug\"\n}\n")
+	err = os.WriteFile(tmpFile, formattedContent, 0600)
+	require.NoError(t, err)
+
+	err = f.Run(tmpFile)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Description

This PR addresses issue #6495. Currently, `alloy fmt` truncates and writes the formatted bytes back to disk even if no formatting changes were made. This causes files to appear modified in orchestration systems like `treefmt`.
We now compare the parsed and formatted byte slice to the original file content using `bytes.Equal`. If they are identical, the file is not opened/written to.

## Changes
- Modified `internal/alloycli/cmd_fmt.go` to check if `bytes.Equal(bb, buf.Bytes())` is true before initiating file writes.
- Cleaned up unused `"reflect"` package import.
- Created `internal/alloycli/cmd_fmt_test.go` to test that already-formatted files are not touched, unformatted files are correctly formatted, and the `--test` flag behaves as expected. #2936 
 
## Verification
Executed specific unit tests successfully on Windows:
```powershell
go test -tags="nodocker" internal/alloycli/cmd_fmt.go internal/alloycli/cmd_fmt_test.go