### PR TITLE
ci: Cache the AccessControl NSIS plugin

### DIFF
--- a/.github/workflows/integration-test-windows-service.yml
+++ b/.github/workflows/integration-test-windows-service.yml
@@ -36,12 +36,25 @@ jobs:
         run: choco install nsis -y
         shell: pwsh
 
+      - name: Cache NSIS AccessControl plugin
+        id: cache-accesscontrol
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: ${{ runner.temp }}\AccessControl.zip
+          key: nsis-accesscontrol-zip-v1
+
+      - name: Download NSIS AccessControl plugin
+        if: steps.cache-accesscontrol.outputs.cache-hit != 'true'
+        run: |
+          $zipUrl = "https://nsis.sourceforge.io/mediawiki/images/4/4a/AccessControl.zip"
+          $zipPath = "$env:RUNNER_TEMP\AccessControl.zip"
+          Invoke-WebRequest -Uri $zipUrl -OutFile $zipPath -UseBasicParsing
+        shell: pwsh
+
       - name: Install NSIS AccessControl plugin
         run: |
           $nsisPath = "C:\Program Files (x86)\NSIS"
-          $zipUrl = "https://nsis.sourceforge.io/mediawiki/images/4/4a/AccessControl.zip"
-          $zipPath = "$env:TEMP\AccessControl.zip"
-          Invoke-WebRequest -Uri $zipUrl -OutFile $zipPath -UseBasicParsing
+          $zipPath = "$env:RUNNER_TEMP\AccessControl.zip"
           Expand-Archive -Path $zipPath -DestinationPath $env:TEMP\AccessControl -Force
           Copy-Item -Path "$env:TEMP\AccessControl\Plugins\*" -Destination "$nsisPath\Plugins\" -Recurse -Force
           New-Item -ItemType Directory -Path "$nsisPath\Plugins\x86-unicode" -Force

--- a/.github/workflows/integration-test-windows-service.yml
+++ b/.github/workflows/integration-test-windows-service.yml
@@ -51,6 +51,21 @@ jobs:
           Invoke-WebRequest -Uri $zipUrl -OutFile $zipPath -UseBasicParsing
         shell: pwsh
 
+      # Guard against supply chain attacks.
+      # Runs unconditionally so a poisoned cache entry is caught too, not just a fresh download.
+      # NOTE: This same hash is also pinned in build-tools/build-image/Dockerfile; update both.
+      - name: Verify NSIS AccessControl plugin checksum
+        run: |
+          $expected = "9aa60f9c5c023fda2808af216514d8913d2673bc522d944ee771da032a1bdc10"
+          $zipPath = "$env:RUNNER_TEMP\AccessControl.zip"
+          $actual = (Get-FileHash -Algorithm SHA256 -Path $zipPath).Hash.ToLower()
+          if ($actual -ne $expected) {
+            Write-Error "AccessControl.zip checksum mismatch: expected=$expected actual=$actual"
+            exit 1
+          }
+          Write-Host "AccessControl.zip checksum verified ($actual)"
+        shell: pwsh
+
       - name: Install NSIS AccessControl plugin
         run: |
           $nsisPath = "C:\Program Files (x86)\NSIS"

--- a/build-tools/build-image/Dockerfile
+++ b/build-tools/build-image/Dockerfile
@@ -27,7 +27,11 @@ RUN apk add --no-cache helm
 # https://nsis.sourceforge.io/Conda
 # TODO: Why do we use i386? Is it correct?
 FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 as nsis
+# Guard against supply chain attacks.
+# sha256sum -c fails the build on mismatch, before the archive is unpacked.
+# NOTE: This same hash is also pinned in .github/workflows/integration-test-windows-service.yml; update both.
 RUN wget -nv https://nsis.sourceforge.io/mediawiki/images/4/4a/AccessControl.zip \
+ && echo "9aa60f9c5c023fda2808af216514d8913d2673bc522d944ee771da032a1bdc10  AccessControl.zip" | sha256sum -c - \
  && unzip AccessControl.zip -d /usr/share/nsis/ \
  && mkdir -p /usr/share/nsis/Plugins/x86-unicode \
  && cp /usr/share/nsis/Plugins/i386-unicode/AccessControl.dll /usr/share/nsis/Plugins/x86-unicode/


### PR DESCRIPTION
AccessControl is used for changing file and folder permissions in NSIS. Alloy's NSIS script creates the Windows installer. AccessControl doesn't come pre-bundled with NSIS - it's a plugin which is downloaded separately. 

There are rare times when the [download fails](https://github.com/grafana/alloy/actions/runs/27411398458/job/81013283189). Caching the plugin binary will make the tests faster and reduce the chance of flaky failures.

In the future we can also consider #6502 to remove AccessControl entirely.

This PR relies on functionality which is not very clearly [documented](https://github.com/actions/cache/tree/cdf6c1fa76f9f475f3d7449005a359c84ca0f306/), but it seems to work. The first run of this branch showed a cache miss:

<img width="1512" height="860" alt="Screenshot 2026-06-16 at 14 21 44" src="https://github.com/user-attachments/assets/b3f256c5-7e67-43aa-b3d6-4ee6ff740d22" />

The second run had a cache hit:
<img width="1505" height="863" alt="Screenshot 2026-06-16 at 15 46 15" src="https://github.com/user-attachments/assets/64846dc7-e50a-43cb-a390-523a6cfc2a1c" />
