### PR TITLE
[ci] Migrate from AccessControl to icacls

### DIFF
--- a/.github/workflows/integration-test-windows-service.yml
+++ b/.github/workflows/integration-test-windows-service.yml
@@ -36,18 +36,6 @@ jobs:
         run: choco install nsis -y
         shell: pwsh
 
-      - name: Install NSIS AccessControl plugin
-        run: |
-          $nsisPath = "C:\Program Files (x86)\NSIS"
-          $zipUrl = "https://nsis.sourceforge.io/mediawiki/images/4/4a/AccessControl.zip"
-          $zipPath = "$env:TEMP\AccessControl.zip"
-          Invoke-WebRequest -Uri $zipUrl -OutFile $zipPath -UseBasicParsing
-          Expand-Archive -Path $zipPath -DestinationPath $env:TEMP\AccessControl -Force
-          Copy-Item -Path "$env:TEMP\AccessControl\Plugins\*" -Destination "$nsisPath\Plugins\" -Recurse -Force
-          New-Item -ItemType Directory -Path "$nsisPath\Plugins\x86-unicode" -Force
-          Copy-Item -Path "$nsisPath\Plugins\i386-unicode\AccessControl.dll" -Destination "$nsisPath\Plugins\x86-unicode\"
-        shell: pwsh
-
       - name: Add NSIS to PATH
         run: Add-Content -Path $env:GITHUB_PATH -Value "C:\Program Files (x86)\NSIS"
         shell: pwsh

--- a/build-tools/build-image/Dockerfile
+++ b/build-tools/build-image/Dockerfile
@@ -22,16 +22,6 @@ RUN apk add --no-cache docker-cli docker-cli-buildx
 FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 as helm
 RUN apk add --no-cache helm
 
-# Dependency: nsis (for building Windows installers)
-# TODO: Use nsis with conda so that we don't have to pull those packages from the internet.
-# https://nsis.sourceforge.io/Conda
-# TODO: Why do we use i386? Is it correct?
-FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 as nsis
-RUN wget -nv https://nsis.sourceforge.io/mediawiki/images/4/4a/AccessControl.zip \
- && unzip AccessControl.zip -d /usr/share/nsis/ \
- && mkdir -p /usr/share/nsis/Plugins/x86-unicode \
- && cp /usr/share/nsis/Plugins/i386-unicode/AccessControl.dll /usr/share/nsis/Plugins/x86-unicode/
-
 # Dependency: Go and Go dependencies
 FROM ${GO_RUNTIME} as golang
 
@@ -73,7 +63,6 @@ RUN apt-get update                                \
 COPY --from=docker   /usr/bin/docker                     /usr/bin/docker
 COPY --from=docker   /usr/libexec/docker/cli-plugins     /usr/libexec/docker/cli-plugins
 COPY --from=helm     /usr/bin/helm                       /usr/bin/helm
-COPY --from=nsis     /usr/share/nsis/Plugins/x86-unicode /usr/share/nsis/Plugins/x86-unicode
 COPY --from=golang   /usr/local/go                       /usr/local/go
 COPY --from=golang   /go/bin                             /go/bin
 

--- a/integration-tests/windows-service/util/acl.go
+++ b/integration-tests/windows-service/util/acl.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package util
+
+import (
+	"os/exec"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// GetACL returns the output of `icacls <path>`, which lists the ACEs (access
+// control entries) and owner for the given file or directory.
+func GetACL(path string) (string, error) {
+	out, err := exec.Command("icacls", path).CombinedOutput()
+	return string(out), err
+}
+
+// AssertACLContains runs `icacls <path>` and asserts that each of the expected
+// substrings appears in its output. Each substring is typically a single ACE,
+// e.g. `NT AUTHORITY\SYSTEM:(OI)(CI)(F)`. We match on substrings rather than the
+// full output because icacls formatting can vary across Windows builds.
+func AssertACLContains(c *assert.CollectT, path string, want ...string) {
+	out, err := GetACL(path)
+	assert.NoError(c, err, "icacls %q should succeed", path)
+	if err != nil {
+		return
+	}
+	for _, w := range want {
+		assert.Contains(c, out, w, "ACL for %q missing entry %q; got:\n%s", path, w, out)
+	}
+}

--- a/integration-tests/windows-service/windows_service_test.go
+++ b/integration-tests/windows-service/windows_service_test.go
@@ -29,6 +29,8 @@ const (
 	waitTimeout  = 500 * time.Millisecond
 	waitAttempts = 10
 	installDir   = `C:\Program Files\GrafanaLabs\Alloy`
+	configFile   = installDir + `\config.alloy`
+	dataDir      = `C:\ProgramData\GrafanaLabs\Alloy\data`
 )
 
 // TestWindowsService runs the Alloy Windows installer, starts the Alloy service, and uninstalls.
@@ -98,6 +100,27 @@ func TestWindowsService(t *testing.T) {
 	// Check Windows Event Log for Alloy start message
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		util.AssertEventLogLine(c, "msg=\"{^_^} Alloy is running\"")
+	}, waitTimeout*waitAttempts, waitTimeout)
+
+	// Verify the installer set the expected ACLs on the install dir, config file,
+	// and data dir via icacls. These are presence checks on the key ACEs rather than
+	// a full golden-string match, since icacls formatting can vary across Windows builds.
+	// SYSTEM must have full control; Everyone must remain read-only (and crucially must
+	// NOT have full control on the secret-bearing config file).
+	// TODO: If the rights tokens below don't match the runner's icacls output, adjust them
+	//       against a baseline dump (see the PR verification steps), not by widening Everyone.
+	// TODO: Also exercise the "/USERNAME=" install path (needs a throwaway local user via
+	//       `net user`) so the $User ACL branch is covered.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		// Install directory (directory ACEs carry (OI)(CI) inheritance flags).
+		util.AssertACLContains(c, installDir, `NT AUTHORITY\SYSTEM:(OI)(CI)(F)`, `Everyone:(OI)(CI)`)
+		// Config file (a file, so no inheritance flags). Everyone must not be full.
+		util.AssertACLContains(c, configFile, `NT AUTHORITY\SYSTEM:(F)`, `Everyone:`)
+		acl, err := util.GetACL(configFile)
+		assert.NoError(c, err)
+		assert.NotContains(c, acl, `Everyone:(F)`, "Everyone must not have full control of the config file")
+		// Data directory.
+		util.AssertACLContains(c, dataDir, `NT AUTHORITY\SYSTEM:(OI)(CI)(F)`, `Everyone:(OI)(CI)`)
 	}, waitTimeout*waitAttempts, waitTimeout)
 }
 

--- a/packaging/windows/install_script.nsis
+++ b/packaging/windows/install_script.nsis
@@ -69,20 +69,19 @@ Section "install"
   ${GetOptions} $PassedInParameters "/PASSWORD=" $Password
   ${GetOptions} $PassedInParameters "/FORCEREGISTRY=" $ForceRegistry
 
-  # Calls to functions like nsExec::ExecToLog below push the exit code to the
-  # stack, and must be popped after calling.
+  # nsExec::ExecToLog pushes the command's exit code onto the stack; the ExecAndPop
+  # macro (see macros.nsis) runs the command and pops that code for the common case
+  # where we don't inspect it.
 
   # When /FORCEREGISTRY=yes, delete all Alloy registry keys at the start so the
   # rest of the installation can proceed as normal and write fresh values. This
   # also cleans up any old or unused keys from previous versions.
   ${If} $ForceRegistry == "yes"
-    nsExec::ExecToLog 'Reg.exe delete "HKLM\SOFTWARE\GrafanaLabs\Alloy" /reg:64 /f'
-    Pop $0
+    !insertmacro ExecAndPop 'Reg.exe delete "HKLM\SOFTWARE\GrafanaLabs\Alloy" /reg:64 /f'
   ${EndIf}
 
   # Preemptively stop the existing service if it's running.
-  nsExec::ExecToLog 'net stop "Alloy" /y'
-  Pop $0
+  !insertmacro ExecAndPop 'net stop "Alloy" /y'
 
   # Configure the out path and copy files to it.
   IfFileExists "$INSTDIR" Exists NotExists
@@ -128,16 +127,13 @@ Section "install"
   ${EndIf}
 
   # Create the service.
-  nsExec::ExecToLog 'sc create "Alloy" start= delayed-auto $AuthFlag binpath= "\"$INSTDIR\alloy-service-windows-amd64.exe\""'
-  Pop $0
+  !insertmacro ExecAndPop 'sc create "Alloy" start= delayed-auto $AuthFlag binpath= "\"$INSTDIR\alloy-service-windows-amd64.exe\""'
 
   # Start the service.
-  nsExec::ExecToLog 'sc start "Alloy"'
-  Pop $0
+  !insertmacro ExecAndPop 'sc start "Alloy"'
 
   # Auto-restart Alloy on failure with delays of 1 minute, 5 minutes, and 5 minutes. Reset failure counter after 1 day without failure.
-  nsExec::ExecToLog `sc failure "Alloy" reset= 86400 actions= restart/60000/restart/300000/restart/300000`
-  Pop $0
+  !insertmacro ExecAndPop 'sc failure "Alloy" reset= 86400 actions= restart/60000/restart/300000/restart/300000'
 SectionEnd
 
 Function CreateConfig
@@ -148,14 +144,14 @@ Function CreateConfig
     File "config.alloy"
 
     # Set permissions on the config file
-    AccessControl::DisableFileInheritance "$INSTDIR\config.alloy"
-    AccessControl::SetFileOwner "$INSTDIR\config.alloy" "Administrators"
-    AccessControl::ClearOnFile  "$INSTDIR\config.alloy" "Administrators" "FullAccess"
-    AccessControl::SetOnFile    "$INSTDIR\config.alloy" "SYSTEM" "FullAccess"
-    AccessControl::GrantOnFile  "$INSTDIR\config.alloy" "Everyone" "ListDirectory"
-    AccessControl::GrantOnFile  "$INSTDIR\config.alloy" "Everyone" "ReadAttributes"
+    !insertmacro ExecAndPop 'icacls "$INSTDIR\config.alloy" /inheritance:d'
+    !insertmacro ExecAndPop 'icacls "$INSTDIR\config.alloy" /setowner "Administrators"'
+    !insertmacro ExecAndPop 'icacls "$INSTDIR\config.alloy" /remove:g "Administrators"'
+    !insertmacro ExecAndPop 'icacls "$INSTDIR\config.alloy" /grant:r "SYSTEM:F"'
+    # Everyone: ListDirectory (read data) + ReadAttributes only.
+    !insertmacro ExecAndPop 'icacls "$INSTDIR\config.alloy" /grant "Everyone:(RD)(RA)"'
     ${If} $User != ""
-      AccessControl::SetOnFile    "$INSTDIR\config.alloy" "$User" "FullAccess"
+      !insertmacro ExecAndPop 'icacls "$INSTDIR\config.alloy" /grant:r "$User:F"'
     ${EndIf}
 
     Return
@@ -170,15 +166,16 @@ Function CreateDataDirectory
   CreateDataDirectory:
     CreateDirectory "$APPDATA\GrafanaLabs\${APPNAME}\data"
 
-    # Set permissions on the data directory
-    AccessControl::DisableFileInheritance "$APPDATA\GrafanaLabs\${APPNAME}\data"
-    AccessControl::SetFileOwner "$APPDATA\GrafanaLabs\${APPNAME}\data" "Administrators"
-    AccessControl::ClearOnFile  "$APPDATA\GrafanaLabs\${APPNAME}\data" "Administrators" "FullAccess"
-    AccessControl::SetOnFile    "$APPDATA\GrafanaLabs\${APPNAME}\data" "SYSTEM" "FullAccess"
-    AccessControl::GrantOnFile  "$APPDATA\GrafanaLabs\${APPNAME}\data" "Everyone" "ListDirectory"
-    AccessControl::GrantOnFile  "$APPDATA\GrafanaLabs\${APPNAME}\data" "Everyone" "ReadAttributes"
+    # Set permissions on the data directory using the built-in icacls.exe. This is a
+    # directory, so grants use (OI)(CI) to apply to subfolders and files.
+    !insertmacro ExecAndPop 'icacls "$APPDATA\GrafanaLabs\${APPNAME}\data" /inheritance:d'
+    !insertmacro ExecAndPop 'icacls "$APPDATA\GrafanaLabs\${APPNAME}\data" /setowner "Administrators"'
+    !insertmacro ExecAndPop 'icacls "$APPDATA\GrafanaLabs\${APPNAME}\data" /remove:g "Administrators"'
+    !insertmacro ExecAndPop 'icacls "$APPDATA\GrafanaLabs\${APPNAME}\data" /grant:r "SYSTEM:(OI)(CI)F"'
+    # Everyone: ListDirectory + ReadAttributes only.
+    !insertmacro ExecAndPop 'icacls "$APPDATA\GrafanaLabs\${APPNAME}\data" /grant "Everyone:(OI)(CI)(RD)(RA)"'
     ${If} $User != ""
-      AccessControl::SetOnFile    "$APPDATA\GrafanaLabs\${APPNAME}\data" "$User" "FullAccess"
+      !insertmacro ExecAndPop 'icacls "$APPDATA\GrafanaLabs\${APPNAME}\data" /grant:r "$User:(OI)(CI)F"'
     ${EndIf}
 
     Return
@@ -193,8 +190,7 @@ Function InitializeRegistry
   nsExec::ExecToLog 'Reg.exe query "${REGKEY}" /reg:64 /ve'
   Pop $0
   ${If} $0 == 1
-    nsExec::ExecToLog 'Reg.exe add "${REGKEY}" /reg:64 /ve /d  "$INSTDIR\alloy-windows-amd64.exe"'
-    Pop $0 # Ignore return result
+    !insertmacro ExecAndPop 'Reg.exe add "${REGKEY}" /reg:64 /ve /d  "$INSTDIR\alloy-windows-amd64.exe"'
   ${EndIf}
 
   ${If} $Config != ""
@@ -232,8 +228,7 @@ Function InitializeRegistry
   nsExec::ExecToLog 'Reg.exe query "${REGKEY}" /reg:64 /v Arguments'
   Pop $0
   ${If} $0 == 1
-    nsExec::ExecToLog 'Reg.exe add "${REGKEY}" /reg:64 /v Arguments /t REG_MULTI_SZ /d "run"\0"$ConfigFlag"\0"--storage.path=$APPDATA\GrafanaLabs\${APPNAME}\data"\0"$DisableReportingFlag$DisableProfilingFlag$RuntimePriorityFlag$StabilityFlag"'
-    Pop $0 # Ignore return result
+    !insertmacro ExecAndPop 'Reg.exe add "${REGKEY}" /reg:64 /v Arguments /t REG_MULTI_SZ /d "run"\0"$ConfigFlag"\0"--storage.path=$APPDATA\GrafanaLabs\${APPNAME}\data"\0"$DisableReportingFlag$DisableProfilingFlag$RuntimePriorityFlag$StabilityFlag"'
   ${EndIf}
 
   nsExec::ExecToLog 'Reg.exe query "${REGKEY}" /reg:64 /v Environment'
@@ -241,25 +236,36 @@ Function InitializeRegistry
   ${If} $0 == 1
     # Define the environment key, which holds environment variables to pass to the
     # service.
-    nsExec::ExecToLog 'Reg.exe add "${REGKEY}" /reg:64 /v Environment /t REG_MULTI_SZ /d "$Environment"'
-    Pop $0 # Ignore return result
+    !insertmacro ExecAndPop 'Reg.exe add "${REGKEY}" /reg:64 /v Environment /t REG_MULTI_SZ /d "$Environment"'
   ${EndIf}
 
   Return
 FunctionEnd
 
+# File/directory permissions are set with the built-in icacls.exe rather than the
+# third-party NSIS AccessControl plugin, so the installer can be built with stock NSIS
+# and we avoid downloading the plugin from SourceForge.
+#
+# /inheritance:d mirrors AccessControl::DisableFileInheritance: it disables inheritance
+# but *copies* the parent's inherited ACEs as explicit entries. /grant:r replaces a
+# trustee's existing ACEs (like SetOnFile); /grant without :r is additive (like
+# GrantOnFile). Directory grants use (OI)(CI) so they apply to subfolders and files.
+#
+# TODO: Consider /inheritance:r instead of /inheritance:d to produce fully deterministic
+#       ACLs independent of the parent folder's inherited entries (behavior change:
+#       currently-inherited access such as Users:RX would be dropped).
+# TODO: Consider referencing trustees by well-known SID (*S-1-5-32-544 Administrators,
+#       *S-1-5-18 SYSTEM, *S-1-1-0 Everyone) for locale-independent installs.
 Function SetFolderPermissions
     # Set permissions on the install directory
-    AccessControl::DisableFileInheritance $INSTDIR
-    AccessControl::SetFileOwner $INSTDIR "Administrators"
-    AccessControl::ClearOnFile  $INSTDIR "Administrators" "FullAccess"
-    AccessControl::SetOnFile    $INSTDIR "SYSTEM" "FullAccess"
-    AccessControl::GrantOnFile  $INSTDIR "Everyone" "ListDirectory"
-    AccessControl::GrantOnFile  $INSTDIR "Everyone" "GenericExecute"
-    AccessControl::GrantOnFile  $INSTDIR "Everyone" "GenericRead"
-    AccessControl::GrantOnFile  $INSTDIR "Everyone" "ReadAttributes"
+    !insertmacro ExecAndPop 'icacls "$INSTDIR" /inheritance:d'
+    !insertmacro ExecAndPop 'icacls "$INSTDIR" /setowner "Administrators"'
+    !insertmacro ExecAndPop 'icacls "$INSTDIR" /remove:g "Administrators"'
+    !insertmacro ExecAndPop 'icacls "$INSTDIR" /grant:r "SYSTEM:(OI)(CI)F"'
+    # Everyone: ListDirectory + GenericExecute + GenericRead + ReadAttributes.
+    !insertmacro ExecAndPop 'icacls "$INSTDIR" /grant "Everyone:(OI)(CI)(RD)(GE)(GR)(RA)"'
     ${If} $User != ""
-      AccessControl::SetOnFile    $INSTDIR "$User" "FullAccess"
+      !insertmacro ExecAndPop 'icacls "$INSTDIR" /grant:r "$User:(OI)(CI)F"'
     ${EndIf}
 FunctionEnd
 
@@ -282,10 +288,8 @@ Section "uninstall"
   DetailPrint "Starting uninstaller."
 
   # Stop and remove service.
-  nsExec::ExecToLog 'net stop "Alloy" /y'
-  Pop $0
-  nsExec::ExecToLog 'sc delete "Alloy"'
-  Pop $0
+  !insertmacro ExecAndPop 'net stop "Alloy" /y'
+  !insertmacro ExecAndPop 'sc delete "Alloy"'
 
   RMDir /r "$SMPROGRAMS\${APPNAME}"  # Start Menu folder.
   RMDir /r "$INSTDIR"                # Install directory.
@@ -294,7 +298,6 @@ Section "uninstall"
   # Remove service and uninstaller information from the registry. Note that the
   # service settings are stored in the 64-bit registry (so we use /reg:64),
   # while the uninstaller information is stored in the 32-bit registry.
-  nsExec::ExecToLog 'Reg.exe delete "HKLM\SOFTWARE\GrafanaLabs\Alloy"  /reg:64 /f'
-  Pop $0
+  !insertmacro ExecAndPop 'Reg.exe delete "HKLM\SOFTWARE\GrafanaLabs\Alloy"  /reg:64 /f'
   DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}"
 SectionEnd

--- a/packaging/windows/macros.nsis
+++ b/packaging/windows/macros.nsis
@@ -8,3 +8,17 @@ ${If} $0 != "admin" # Require admin rights on NT4+
 ${EndIf}
 !macroend
 
+# ExecAndPop runs a command with nsExec::ExecToLog and pops the exit code that
+# nsExec pushes onto the stack. Use it for fire-and-forget commands whose return
+# value we don't inspect. Commands whose exit code is checked (e.g. the Reg.exe
+# queries in InitializeRegistry) must call nsExec::ExecToLog and Pop directly so
+# they can read $0.
+#
+# The command is wrapped in backticks so it can freely contain double quotes; pass
+# the argument delimited by single quotes (none of our commands contain a single
+# quote).
+!macro ExecAndPop cmd
+  nsExec::ExecToLog `${cmd}`
+  Pop $0
+!macroend
+


### PR DESCRIPTION
### Pull Request Details

AccessControl is a plugin for NSIS which makes it easy to set file and folder permissions. It doesn't come with NSIS itself and it's awkward to install. 

This PR will need to be broken into multiple smaller PRs before it's merged:
1. Firstly we need to merge integration tests which check file and directory permissions after the installer is ran.
2. Migrate to `icacls` without changing behaviour. I'll need to test this on a Windows machine manually for good measure.

### Notes to the Reviewer

Once we migrate to `icacls`, we need to double check that the way permissions are setup makes sense. For example, should we support running as a less privileged account, not LocalSystem? E.g. an `NT SERVICE\alloy` account?

We could also consider a WiX migration? I'm not sure if it'll be worth it. WiX seems to be more powerful, integrates better with OS restore points, and comes pre-installed on GitHub Actions runners. However, it has a steeper learning curve.

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
