### PR TITLE
feat: Add alloy.command to override the Alloy Helm container entrypoint

### DIFF
--- a/operations/helm/charts/alloy/CHANGELOG.md
+++ b/operations/helm/charts/alloy/CHANGELOG.md
@@ -10,6 +10,10 @@ internal API changes are not present.
 Unreleased
 ----------
 
+### Enhancements
+
+- Add `alloy.command` to override the entrypoint command for the Alloy container. This makes it possible to launch the Alloy binary from its image path when running as a HostProcess container on Windows nodes. (@petewall)
+
 1.10.0 (2026-06-12)
 ----------
 

--- a/operations/helm/charts/alloy/README.md
+++ b/operations/helm/charts/alloy/README.md
@@ -36,6 +36,7 @@ useful if just using the default DaemonSet isn't sufficient.
 | alloy.clustering.enabled | bool | `false` | Deploy Alloy in a cluster to allow for load distribution. |
 | alloy.clustering.name | string | `""` | Name for the Alloy cluster. Used for differentiating between clusters. |
 | alloy.clustering.portName | string | `"http"` | Name for the port used for clustering, useful if running inside an Istio Mesh |
+| alloy.command | list | `[]` | Override the entrypoint command for the Alloy container. When set, this replaces the image's default entrypoint (the chart-provided `args` are still passed). Useful on Windows where the binary lives at a different path, for example `["C:\\Program Files\\GrafanaLabs\\Alloy\\alloy.exe"]`. Leave empty to use the image's default entrypoint. |
 | alloy.configMap.content | string | `""` | Content to assign to the new ConfigMap.  This is passed into `tpl` allowing for templating from values. |
 | alloy.configMap.create | bool | `true` | Create a new ConfigMap for the config file. |
 | alloy.configMap.key | string | `nil` | Key in ConfigMap to get config from. |

--- a/operations/helm/charts/alloy/templates/containers/_agent.yaml
+++ b/operations/helm/charts/alloy/templates/containers/_agent.yaml
@@ -3,6 +3,10 @@
 - name: alloy
   image: {{ .Values.global.image.registry | default .Values.image.registry }}/{{ .Values.image.repository }}{{ include "alloy.imageId" . }}
   imagePullPolicy: {{ .Values.global.image.pullPolicy | default .Values.image.pullPolicy }}
+  {{- with $values.command }}
+  command:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   args:
     - run
     - /etc/alloy/{{ include "alloy.config-map.key" . }}

--- a/operations/helm/charts/alloy/values.yaml
+++ b/operations/helm/charts/alloy/values.yaml
@@ -93,6 +93,13 @@ alloy:
   # -- Maps all the keys on a ConfigMap or Secret as environment variables. https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envfromsource-v1-core
   envFrom: []
 
+  # -- Override the entrypoint command for the Alloy container. When set, this
+  # replaces the image's default entrypoint (the chart-provided `args` are still
+  # passed). Useful on Windows where the binary lives at a different path, for
+  # example `["C:\\Program Files\\GrafanaLabs\\Alloy\\alloy.exe"]`. Leave empty
+  # to use the image's default entrypoint.
+  command: []
+
   # -- Extra args to pass to `alloy run`: https://grafana.com/docs/alloy/latest/reference/cli/run/
   extraArgs: []
 


### PR DESCRIPTION
## What

Adds an optional `alloy.command` value to the Alloy Helm chart. When set, it renders a `command:` on the Alloy container, overriding the image's default entrypoint. The chart-provided `args` (`run`, the config path, `--storage.path`, etc.) are still passed through.

```yaml
alloy:
  command:
    - "%CONTAINER_SANDBOX_MOUNT_POINT%\\Program Files\\GrafanaLabs\\Alloy\\alloy.exe"
```

Defaults to `[]`, so when unset nothing is rendered and **there is no change for existing deployments**.

## Why

This is required to run Alloy as a **HostProcess** container on Windows nodes.

The Windows image's entrypoint is an absolute path:

```
ENTRYPOINT ["C:/Program Files/GrafanaLabs/Alloy/alloy.exe"]
```

In HostProcess mode, absolute paths resolve against the **host** filesystem, which does not contain `alloy.exe` — the binary lives inside the container image, exposed under `%CONTAINER_SANDBOX_MOUNT_POINT%`. As a result the container fails to start, and the chart previously offered no way to override the entrypoint (it only rendered `args:`, which append *after* the broken entrypoint).

Overriding the command lets users launch the binary from the sandbox mount point. This is the root cause of grafana/helm-charts#4037, and a prerequisite for reading pod logs from the filesystem on Windows (which requires HostProcess, since the entries under `C:\var\log\pods` are symlinks a normal hostPath mount can't traverse).

Related: #425

## Testing

- Verified end-to-end on an EKS cluster with a Windows node group: with `alloy.command` set to the sandbox-relative `alloy.exe`, the HostProcess pod reaches `1/1 Running`, loads its config, and reads pod logs from `C:\var\log\pods\…`.
- `helm lint` passes; README regenerated via `helm-docs`.
- Golden template tests are unaffected (no CI values set `alloy.command`; default renders nothing).

## Changes

- Add `command:` block to `templates/containers/_agent.yaml` (rendered only when `alloy.command` is set).
- Add `alloy.command` to `values.yaml` (default `[]`) with docs.
- Regenerate `README.md`.