### PR TITLE
ci: Backport macOS cross-compile and zizmor cache fix to v1.17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,23 +52,8 @@ jobs:
           chown -R $(id -u):$(id -g) $PWD
     - run: GO_TAGS="embedalloyui promtail_journal_enabled" GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} GOARM= GOEXPERIMENT=boringcrypto make alloy
 
-  build_mac_intel:
-    name: Build on MacOS (Intel)
-    runs-on: macos-15-large
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        persist-credentials: false
-    - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-      with:
-        go-version-file: go.mod
-        cache: false
-    - run: GO_TAGS="embedalloyui" GOOS=darwin GOARCH=amd64 GOARM= make alloy
-
-  build_mac_arm:
-    name: Build on MacOS (ARM)
+  build_mac:
+    name: Build on MacOS
     runs-on: macos-15-xlarge
     steps:
     - name: Checkout code
@@ -80,7 +65,10 @@ jobs:
       with:
         go-version-file: go.mod
         cache: false
-    - run: CGO_LDFLAGS="-ld_classic $CGO_LDFLAGS" GO_TAGS="embedalloyui" GOOS=darwin GOARCH=arm64 GOARM= make alloy
+    - name: Build native arm64
+      run: CGO_LDFLAGS="-ld_classic $CGO_LDFLAGS" GO_TAGS="embedalloyui" GOOS=darwin GOARCH=arm64 GOARM= make alloy
+    - name: Cross-compile amd64
+      run: GO_TAGS="embedalloyui" GOOS=darwin GOARCH=amd64 GOARM= SKIP_UI_BUILD=1 make alloy
 
   build_windows:
     name: Build on Windows (AMD64)

--- a/.github/workflows/release-enrich-release-notes.yml
+++ b/.github/workflows/release-enrich-release-notes.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           go-version-file: tools/go.mod
           cache-dependency-path: tools/go.sum
+          cache: false
 
       - name: Enrich release notes 🙋
         run: go run -C tools ./cmd release enrich-release-notes --tag "${RELEASE_TAG_NAME}" --footer release/release-notes-footer.md


### PR DESCRIPTION
Combined manual backport of #6196 and #6490. They mutually block on this branch — #6196 supplies the `Build on MacOS` required check and #6490 clears the high-severity zizmor cache-poisoning finding the code-scanning gate trips on — so neither merges alone. Together they unblock all v1.17 backports, including the usage-reporting backport (#6505) rebased on top.

Backported PRs:

- #6196
- #6490

BEGIN_COMMIT_OVERRIDE
ci: Cross-compile darwin/amd64 from ARM runner (#6196) [backport]
ci: Disable setup-go cache in enrich-release-notes (#6490) [backport]
END_COMMIT_OVERRIDE