### PR TITLE
refactor(loki.process): Move stage validations to syntax validation

### DIFF
--- a/internal/alloycli/cmd_fmt.go
+++ b/internal/alloycli/cmd_fmt.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"reflect"
 
 	"github.com/spf13/cobra"
 
@@ -117,7 +116,7 @@ func format(filename string, fi os.FileInfo, r io.Reader, write bool, test bool)
 
 	// If -t/--test flag is check, only check if file is formatted correctly
 	if test {
-		if !reflect.DeepEqual(bb, buf.Bytes()) {
+		if !bytes.Equal(bb, buf.Bytes()) {
 			return fmt.Errorf("file %s is not formatted correctly", filename)
 		}
 		return nil
@@ -126,6 +125,11 @@ func format(filename string, fi os.FileInfo, r io.Reader, write bool, test bool)
 	if !write {
 		_, err := io.Copy(os.Stdout, &buf)
 		return err
+	}
+
+	// Only write to the file if the content actually changed
+	if bytes.Equal(bb, buf.Bytes()) {
+		return nil
 	}
 
 	wf, err := os.OpenFile(filename, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, fi.Mode().Perm())

--- a/internal/alloycli/cmd_fmt_test.go
+++ b/internal/alloycli/cmd_fmt_test.go
@@ -1,0 +1,84 @@
+package alloycli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlloyFmt_NoWriteIfUnchanged(t *testing.T) {
+	// 1. Create a temporary file with already-formatted content.
+	content := []byte("logging {\n\tlevel  = \"debug\"\n\tformat = \"logfmt\"\n}\n")
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "config.alloy")
+	err := os.WriteFile(tmpFile, content, 0600)
+	require.NoError(t, err)
+
+	// 2. Set the file to read-only so that any attempt to open it with O_WRONLY/O_TRUNC will fail.
+	err = os.Chmod(tmpFile, 0400)
+	require.NoError(t, err)
+	defer func() {
+		// Restore write permissions so cleanup doesn't fail.
+		_ = os.Chmod(tmpFile, 0600)
+	}()
+
+	// 3. Run alloyFmt with write: true. Since the file is already formatted,
+	// it should NOT attempt to open/truncate the file, and should succeed.
+	f := &alloyFmt{
+		write: true,
+		test:  false,
+	}
+	err = f.Run(tmpFile)
+	require.NoError(t, err)
+}
+
+func TestAlloyFmt_WriteIfChanged(t *testing.T) {
+	// 1. Create a temporary file with unformatted content.
+	content := []byte("logging {\nlevel = \"debug\"\n}\n")
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "config.alloy")
+	err := os.WriteFile(tmpFile, content, 0600)
+	require.NoError(t, err)
+
+	// 2. Run alloyFmt with write: true. It should format and overwrite the file.
+	f := &alloyFmt{
+		write: true,
+		test:  false,
+	}
+	err = f.Run(tmpFile)
+	require.NoError(t, err)
+
+	// 3. Verify the file content was formatted.
+	newContent, err := os.ReadFile(tmpFile)
+	require.NoError(t, err)
+	expected := "logging {\n\tlevel = \"debug\"\n}\n"
+	require.Equal(t, expected, string(newContent))
+}
+
+func TestAlloyFmt_TestFlag(t *testing.T) {
+	// Test file with unformatted content
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "config.alloy")
+	content := []byte("logging {\nlevel = \"debug\"\n}\n")
+	err := os.WriteFile(tmpFile, content, 0600)
+	require.NoError(t, err)
+
+	// Run alloyFmt with test: true. It should return an error indicating changes would be made.
+	f := &alloyFmt{
+		write: false,
+		test:  true,
+	}
+	err = f.Run(tmpFile)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "is not formatted correctly")
+
+	// Now run it on formatted content. It should succeed without error.
+	formattedContent := []byte("logging {\n\tlevel = \"debug\"\n}\n")
+	err = os.WriteFile(tmpFile, formattedContent, 0600)
+	require.NoError(t, err)
+
+	err = f.Run(tmpFile)
+	require.NoError(t, err)
+}

--- a/internal/component/loki/process/process.go
+++ b/internal/component/loki/process/process.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/alloy/internal/component/loki/process/stages"
 	"github.com/grafana/alloy/internal/featuregate"
 	"github.com/grafana/alloy/internal/service/livedebugging"
+	"github.com/grafana/alloy/syntax"
 )
 
 func init() {
@@ -33,6 +34,16 @@ type Arguments struct {
 	Stages    []stages.StageConfig `alloy:"stage,enum,optional"`
 }
 
+// Validate implements syntax.Validator.
+func (a *Arguments) Validate() error {
+	for _, stage := range a.Stages {
+		if err := stage.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Exports exposes the receiver that can be used to send log entries to
 // loki.process.
 type Exports struct {
@@ -42,6 +53,7 @@ type Exports struct {
 var (
 	_ component.Component     = (*Component)(nil)
 	_ component.LiveDebugging = (*Component)(nil)
+	_ syntax.Validator        = (*Arguments)(nil)
 )
 
 // Component implements the loki.process component.

--- a/internal/component/loki/process/stages/drop.go
+++ b/internal/component/loki/process/stages/drop.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/alecthomas/units"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/grafana/alloy/syntax"
 )
 
 const (
@@ -36,6 +38,14 @@ type DropConfig struct {
 	Expression string           `alloy:"expression,attr,optional"`
 	OlderThan  time.Duration    `alloy:"older_than,attr,optional"`
 	LongerThan units.Base2Bytes `alloy:"longer_than,attr,optional"`
+}
+
+var _ syntax.Validator = (*DropConfig)(nil)
+
+// Validate implements syntax.Validator.
+func (cfg *DropConfig) Validate() error {
+	_, err := validateDropConfig(cfg)
+	return err
 }
 
 // validateDropConfig validates the DropConfig for the dropStage

--- a/internal/component/loki/process/stages/eventlogmessage.go
+++ b/internal/component/loki/process/stages/eventlogmessage.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/alloy/syntax"
 )
 
 const (
@@ -17,6 +19,11 @@ type EventLogMessageConfig struct {
 	DropInvalidLabels bool   `alloy:"drop_invalid_labels,attr,optional"`
 	OverwriteExisting bool   `alloy:"overwrite_existing,attr,optional"`
 }
+
+var (
+	_ syntax.Defaulter = (*EventLogMessageConfig)(nil)
+	_ syntax.Validator = (*EventLogMessageConfig)(nil)
+)
 
 func (e *EventLogMessageConfig) Validate() error {
 	// TODO: add support for different validation schemes.

--- a/internal/component/loki/process/stages/geoip.go
+++ b/internal/component/loki/process/stages/geoip.go
@@ -11,6 +11,8 @@ import (
 	"github.com/oschwald/geoip2-golang"
 	"github.com/oschwald/maxminddb-golang"
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/alloy/syntax"
 )
 
 var (
@@ -58,6 +60,14 @@ type GeoIPConfig struct {
 	Source        *string           `alloy:"source,attr"`
 	DBType        string            `alloy:"db_type,attr,optional"`
 	CustomLookups map[string]string `alloy:"custom_lookups,attr,optional"`
+}
+
+var _ syntax.Validator = (*GeoIPConfig)(nil)
+
+// Validate implements syntax.Validator.
+func (c *GeoIPConfig) Validate() error {
+	_, err := validateGeoIPConfig(*c)
+	return err
 }
 
 func validateGeoIPConfig(c GeoIPConfig) (map[string]jmespath.JMESPath, error) {

--- a/internal/component/loki/process/stages/json.go
+++ b/internal/component/loki/process/stages/json.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/jmespath-community/go-jmespath"
 	json "github.com/json-iterator/go"
+
+	"github.com/grafana/alloy/syntax"
 )
 
 // Config Errors
@@ -26,6 +28,14 @@ type JSONConfig struct {
 	Regex         string            `alloy:"regex,attr,optional"`
 	Source        *string           `alloy:"source,attr,optional"`
 	DropMalformed bool              `alloy:"drop_malformed,attr,optional"`
+}
+
+var _ syntax.Validator = (*JSONConfig)(nil)
+
+// Validate implements syntax.Validator.
+func (c *JSONConfig) Validate() error {
+	_, _, err := validateJSONConfig(c)
+	return err
 }
 
 // validateJSONConfig validates a json config and returns a map of necessary jmespath expressions.

--- a/internal/component/loki/process/stages/label_drop.go
+++ b/internal/component/loki/process/stages/label_drop.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/alloy/syntax"
 )
 
 // ErrEmptyLabelDropStageConfig error returned if the config is empty.
@@ -15,9 +17,19 @@ type LabelDropConfig struct {
 	Values []string `alloy:"values,attr"`
 }
 
+var _ syntax.Validator = (*LabelDropConfig)(nil)
+
+// Validate implements syntax.Validator.
+func (c *LabelDropConfig) Validate() error {
+	if len(c.Values) < 1 {
+		return ErrEmptyLabelDropStageConfig
+	}
+	return nil
+}
+
 func newLabelDropStage(config LabelDropConfig) (Stage, error) {
-	if len(config.Values) < 1 {
-		return nil, ErrEmptyLabelDropStageConfig
+	if err := config.Validate(); err != nil {
+		return nil, err
 	}
 
 	return toStage(&labelDropStage{

--- a/internal/component/loki/process/stages/label_keep.go
+++ b/internal/component/loki/process/stages/label_keep.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/alloy/syntax"
 )
 
 // ErrEmptyLabelAllowStageConfig error is returned if the config is empty.
@@ -15,9 +17,19 @@ type LabelAllowConfig struct {
 	Values []string `alloy:"values,attr"`
 }
 
+var _ syntax.Validator = (*LabelAllowConfig)(nil)
+
+// Validate implements syntax.Validator.
+func (c *LabelAllowConfig) Validate() error {
+	if len(c.Values) < 1 {
+		return ErrEmptyLabelAllowStageConfig
+	}
+	return nil
+}
+
 func newLabelAllowStage(config LabelAllowConfig) (Stage, error) {
-	if len(config.Values) < 1 {
-		return nil, ErrEmptyLabelAllowStageConfig
+	if err := config.Validate(); err != nil {
+		return nil, err
 	}
 
 	labelMap := make(map[string]struct{})

--- a/internal/component/loki/process/stages/labels.go
+++ b/internal/component/loki/process/stages/labels.go
@@ -9,6 +9,8 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/loki/pkg/push"
+
+	"github.com/grafana/alloy/syntax"
 )
 
 const (
@@ -24,6 +26,14 @@ const (
 type LabelsConfig struct {
 	Values     map[string]*string `alloy:"values,attr"`
 	SourceType SourceType         `alloy:"source_type,attr,optional"`
+}
+
+var _ syntax.Validator = (*LabelsConfig)(nil)
+
+// Validate implements syntax.Validator.
+func (args *LabelsConfig) Validate() error {
+	_, err := validateLabelsConfig(args)
+	return err
 }
 
 // validateLabelsConfig validates the Label stage configuration

--- a/internal/component/loki/process/stages/limit.go
+++ b/internal/component/loki/process/stages/limit.go
@@ -9,6 +9,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"golang.org/x/time/rate"
+
+	"github.com/grafana/alloy/syntax"
 )
 
 // Configuration errors.
@@ -28,6 +30,13 @@ type LimitConfig struct {
 	Drop              bool    `alloy:"drop,attr,optional"`
 	ByLabelName       string  `alloy:"by_label_name,attr,optional"`
 	MaxDistinctLabels int     `alloy:"max_distinct_labels,attr,optional"`
+}
+
+var _ syntax.Validator = (*LimitConfig)(nil)
+
+// Validate implements syntax.Validator.
+func (c *LimitConfig) Validate() error {
+	return validateLimitConfig(*c)
 }
 
 func newLimitStage(logger *slog.Logger, cfg LimitConfig, registerer prometheus.Registerer) (Stage, error) {

--- a/internal/component/loki/process/stages/logfmt.go
+++ b/internal/component/loki/process/stages/logfmt.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-logfmt/logfmt"
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/alloy/syntax"
 )
 
 // Config Errors
@@ -23,6 +25,14 @@ type LogfmtConfig struct {
 	Mapping map[string]string `alloy:"mapping,attr,optional"`
 	Source  string            `alloy:"source,attr,optional"`
 	Regex   string            `alloy:"regex,attr,optional"`
+}
+
+var _ syntax.Validator = (*LogfmtConfig)(nil)
+
+// Validate implements syntax.Validator.
+func (c *LogfmtConfig) Validate() error {
+	_, _, err := validateLogfmtConfig(c)
+	return err
 }
 
 // validateLogfmtConfig validates a logfmt stage config and returns an inverse mapping of configured mapping.

--- a/internal/component/loki/process/stages/luhn.go
+++ b/internal/component/loki/process/stages/luhn.go
@@ -7,6 +7,8 @@ import (
 	"unicode"
 
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/alloy/syntax"
 )
 
 // LuhnFilterConfig configures a processing stage that filters out Luhn-valid numbers.
@@ -15,6 +17,13 @@ type LuhnFilterConfig struct {
 	Source      *string `alloy:"source,attr,optional"`
 	MinLength   int     `alloy:"min_length,attr,optional"`
 	Delimiters  string  `alloy:"delimiters,attr,optional"`
+}
+
+var _ syntax.Validator = (*LuhnFilterConfig)(nil)
+
+// Validate implements syntax.Validator.
+func (c *LuhnFilterConfig) Validate() error {
+	return validateLuhnFilterConfig(c)
 }
 
 // validateLuhnFilterConfig validates the LuhnFilterConfig.

--- a/internal/component/loki/process/stages/match.go
+++ b/internal/component/loki/process/stages/match.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/grafana/alloy/internal/featuregate"
 	"github.com/grafana/alloy/internal/loki/logql"
+	"github.com/grafana/alloy/syntax"
 )
 
 // Configuration errors.
@@ -32,6 +33,21 @@ type MatchConfig struct {
 	Action       string        `alloy:"action,attr,optional"`
 	PipelineName string        `alloy:"pipeline_name,attr,optional"`
 	DropReason   string        `alloy:"drop_counter_reason,attr,optional"`
+}
+
+var _ syntax.Validator = (*MatchConfig)(nil)
+
+// Validate implements syntax.Validator.
+func (c *MatchConfig) Validate() error {
+	if _, err := validateMatcherConfig(c); err != nil {
+		return err
+	}
+	for _, stage := range c.Stages {
+		if err := stage.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // validateMatcherConfig validates the MatcherConfig for the matcherStage

--- a/internal/component/loki/process/stages/metric.go
+++ b/internal/component/loki/process/stages/metric.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/alloy/internal/component/loki/process/metric"
+	"github.com/grafana/alloy/syntax"
 )
 
 // Metric types.
@@ -26,9 +27,44 @@ type MetricConfig struct {
 	Histogram *metric.HistogramConfig `alloy:"histogram,block,optional"`
 }
 
+var _ syntax.Validator = (*MetricConfig)(nil)
+
+// Validate implements syntax.Validator.
+func (c *MetricConfig) Validate() error {
+	count := 0
+	if c.Counter != nil {
+		count++
+	}
+	if c.Gauge != nil {
+		count++
+	}
+	if c.Histogram != nil {
+		count++
+	}
+	if count == 0 {
+		return fmt.Errorf("metric block must configure one of counter, gauge, or histogram")
+	}
+	if count > 1 {
+		return fmt.Errorf("metric block must configure exactly one of counter, gauge, or histogram")
+	}
+	return nil
+}
+
 // MetricsConfig is a set of configured metrics.
 type MetricsConfig struct {
 	Metrics []MetricConfig `alloy:"metric,enum,optional"`
+}
+
+var _ syntax.Validator = (*MetricsConfig)(nil)
+
+// Validate implements syntax.Validator.
+func (c *MetricsConfig) Validate() error {
+	for _, m := range c.Metrics {
+		if err := m.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type cfgCollector struct {

--- a/internal/component/loki/process/stages/multiline.go
+++ b/internal/component/loki/process/stages/multiline.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/syntax"
 )
 
 // Configuration errors.
@@ -37,6 +38,11 @@ var DefaultMultilineConfig = MultilineConfig{
 	TrimNewlines: true,
 }
 
+var (
+	_ syntax.Defaulter = (*MultilineConfig)(nil)
+	_ syntax.Validator = (*MultilineConfig)(nil)
+)
+
 // SetToDefault implements syntax.Defaulter.
 func (args *MultilineConfig) SetToDefault() {
 	*args = DefaultMultilineConfig
@@ -47,7 +53,12 @@ func (args *MultilineConfig) Validate() error {
 	if args.MaxWaitTime <= 0 {
 		return fmt.Errorf("max_wait_time must be greater than 0")
 	}
-
+	if args.Expression == "" {
+		return ErrMultilineStageEmptyConfig
+	}
+	if _, err := regexp.Compile(args.Expression); err != nil {
+		return fmt.Errorf("%v: %w", ErrMultilineStageInvalidRegex, err)
+	}
 	return nil
 }
 

--- a/internal/component/loki/process/stages/output.go
+++ b/internal/component/loki/process/stages/output.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/alloy/syntax"
 )
 
 // Config Errors.
@@ -21,8 +23,21 @@ type OutputConfig struct {
 	Source string `alloy:"source,attr"`
 }
 
+var _ syntax.Validator = (*OutputConfig)(nil)
+
+// Validate implements syntax.Validator.
+func (c *OutputConfig) Validate() error {
+	if c.Source == "" {
+		return ErrOutputSourceRequired
+	}
+	return nil
+}
+
 // newOutputStage creates a new outputStage
 func newOutputStage(logger *slog.Logger, config OutputConfig) (Stage, error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
 	if config.Source == "" {
 		return nil, ErrOutputSourceRequired
 	}

--- a/internal/component/loki/process/stages/pack.go
+++ b/internal/component/loki/process/stages/pack.go
@@ -11,6 +11,8 @@ import (
 	json "github.com/json-iterator/go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/alloy/syntax"
 )
 
 const (
@@ -111,9 +113,22 @@ var DefaultPackConfig = PackConfig{
 	IngestTimestamp: true,
 }
 
+var (
+	_ syntax.Defaulter = (*PackConfig)(nil)
+	_ syntax.Validator = (*PackConfig)(nil)
+)
+
 // SetToDefault implements syntax.Defaulter.
 func (p *PackConfig) SetToDefault() {
 	*p = DefaultPackConfig
+}
+
+// Validate implements syntax.Validator.
+func (p *PackConfig) Validate() error {
+	if len(p.Labels) == 0 {
+		return errors.New("pack stage config must contain at least one label")
+	}
+	return nil
 }
 
 // newPackStage creates a DropStage from config

--- a/internal/component/loki/process/stages/pattern.go
+++ b/internal/component/loki/process/stages/pattern.go
@@ -10,6 +10,8 @@ import (
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/grafana/loki/v3/pkg/logql/log/pattern"
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/alloy/syntax"
 )
 
 // Config Errors.
@@ -25,6 +27,14 @@ type PatternConfig struct {
 	Pattern          string  `alloy:"pattern,attr"`
 	Source           *string `alloy:"source,attr,optional"`
 	LabelsFromGroups bool    `alloy:"labels_from_groups,attr,optional"`
+}
+
+var _ syntax.Validator = (*PatternConfig)(nil)
+
+// Validate implements syntax.Validator.
+func (c *PatternConfig) Validate() error {
+	_, err := validatePatternConfig(*c)
+	return err
 }
 
 // validatePatternConfig validates the config and return a regex

--- a/internal/component/loki/process/stages/pipeline.go
+++ b/internal/component/loki/process/stages/pipeline.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/featuregate"
+	"github.com/grafana/alloy/syntax"
 )
 
 // StageConfig defines a single stage in a processing pipeline.
@@ -46,6 +47,197 @@ type StageConfig struct {
 	TruncateConfig               *TruncateConfig               `alloy:"truncate,block,optional"`
 	TimestampConfig              *TimestampConfig              `alloy:"timestamp,block,optional"`
 	WindowsEventConfig           *WindowsEventConfig           `alloy:"windowsevent,block,optional"`
+}
+
+var _ syntax.Validator = (*StageConfig)(nil)
+
+// Validate implements syntax.Validator.
+func (s *StageConfig) Validate() error {
+	var nonNilConfigs []string
+	if s.CRIConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "cri")
+	}
+	if s.DecolorizeConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "decolorize")
+	}
+	if s.DockerConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "docker")
+	}
+	if s.DropConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "drop")
+	}
+	if s.EventLogMessageConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "eventlogmessage")
+	}
+	if s.GeoIPConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "geoip")
+	}
+	if s.JSONConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "json")
+	}
+	if s.LabelAllowConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "label_keep")
+	}
+	if s.LabelDropConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "label_drop")
+	}
+	if s.LabelsConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "labels")
+	}
+	if s.LimitConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "limit")
+	}
+	if s.LogfmtConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "logfmt")
+	}
+	if s.LuhnFilterConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "luhn")
+	}
+	if s.MatchConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "match")
+	}
+	if s.MetricsConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "metrics")
+	}
+	if s.MultilineConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "multiline")
+	}
+	if s.OutputConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "output")
+	}
+	if s.PackConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "pack")
+	}
+	if s.PatternConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "pattern")
+	}
+	if s.RegexConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "regex")
+	}
+	if s.ReplaceConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "replace")
+	}
+	if s.StaticLabelsConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "static_labels")
+	}
+	if s.StructuredMetadata != nil {
+		nonNilConfigs = append(nonNilConfigs, "structured_metadata")
+	}
+	if s.StructuredMetadataDropConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "structured_metadata_drop")
+	}
+	if s.SamplingConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "sampling")
+	}
+	if s.TemplateConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "template")
+	}
+	if s.TenantConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "tenant")
+	}
+	if s.TruncateConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "truncate")
+	}
+	if s.TimestampConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "timestamp")
+	}
+	if s.WindowsEventConfig != nil {
+		nonNilConfigs = append(nonNilConfigs, "windowsevent")
+	}
+
+	if len(nonNilConfigs) == 0 {
+		return fmt.Errorf("empty stage config")
+	}
+	if len(nonNilConfigs) > 1 {
+		return fmt.Errorf("stage config can only define one of %v", nonNilConfigs)
+	}
+
+	if s.CRIConfig != nil {
+		return s.CRIConfig.Validate()
+	}
+	if s.DropConfig != nil {
+		return s.DropConfig.Validate()
+	}
+	if s.EventLogMessageConfig != nil {
+		return s.EventLogMessageConfig.Validate()
+	}
+	if s.GeoIPConfig != nil {
+		return s.GeoIPConfig.Validate()
+	}
+	if s.JSONConfig != nil {
+		return s.JSONConfig.Validate()
+	}
+	if s.LabelAllowConfig != nil {
+		return s.LabelAllowConfig.Validate()
+	}
+	if s.LabelDropConfig != nil {
+		return s.LabelDropConfig.Validate()
+	}
+	if s.LabelsConfig != nil {
+		return s.LabelsConfig.Validate()
+	}
+	if s.LimitConfig != nil {
+		return s.LimitConfig.Validate()
+	}
+	if s.LogfmtConfig != nil {
+		return s.LogfmtConfig.Validate()
+	}
+	if s.LuhnFilterConfig != nil {
+		return s.LuhnFilterConfig.Validate()
+	}
+	if s.MatchConfig != nil {
+		return s.MatchConfig.Validate()
+	}
+	if s.MetricsConfig != nil {
+		return s.MetricsConfig.Validate()
+	}
+	if s.MultilineConfig != nil {
+		return s.MultilineConfig.Validate()
+	}
+	if s.OutputConfig != nil {
+		return s.OutputConfig.Validate()
+	}
+	if s.PackConfig != nil {
+		return s.PackConfig.Validate()
+	}
+	if s.PatternConfig != nil {
+		return s.PatternConfig.Validate()
+	}
+	if s.RegexConfig != nil {
+		return s.RegexConfig.Validate()
+	}
+	if s.ReplaceConfig != nil {
+		return s.ReplaceConfig.Validate()
+	}
+	if s.StaticLabelsConfig != nil {
+		return s.StaticLabelsConfig.Validate()
+	}
+	if s.StructuredMetadata != nil {
+		return s.StructuredMetadata.Validate()
+	}
+	if s.StructuredMetadataDropConfig != nil {
+		return s.StructuredMetadataDropConfig.Validate()
+	}
+	if s.SamplingConfig != nil {
+		return s.SamplingConfig.Validate()
+	}
+	if s.TemplateConfig != nil {
+		return s.TemplateConfig.Validate()
+	}
+	if s.TenantConfig != nil {
+		return s.TenantConfig.Validate()
+	}
+	if s.TruncateConfig != nil {
+		return s.TruncateConfig.Validate()
+	}
+	if s.TimestampConfig != nil {
+		return s.TimestampConfig.Validate()
+	}
+	if s.WindowsEventConfig != nil {
+		return s.WindowsEventConfig.Validate()
+	}
+
+	return nil
 }
 
 // Pipeline pass down a log entry to each stage for mutation and/or label extraction.

--- a/internal/component/loki/process/stages/regex.go
+++ b/internal/component/loki/process/stages/regex.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/alloy/syntax"
 )
 
 // Config Errors.
@@ -25,6 +27,14 @@ type RegexConfig struct {
 	Expression       string  `alloy:"expression,attr"`
 	Source           *string `alloy:"source,attr,optional"`
 	LabelsFromGroups bool    `alloy:"labels_from_groups,attr,optional"`
+}
+
+var _ syntax.Validator = (*RegexConfig)(nil)
+
+// Validate implements syntax.Validator.
+func (c *RegexConfig) Validate() error {
+	_, err := validateRegexConfig(*c)
+	return err
 }
 
 // validateRegexConfig validates the config and return a regex

--- a/internal/component/loki/process/stages/replace.go
+++ b/internal/component/loki/process/stages/replace.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/alloy/syntax"
 )
 
 func init() {
@@ -23,6 +25,20 @@ type ReplaceConfig struct {
 	Expression string `alloy:"expression,attr"`
 	Source     string `alloy:"source,attr,optional"`
 	Replace    string `alloy:"replace,attr,optional"`
+}
+
+var _ syntax.Validator = (*ReplaceConfig)(nil)
+
+// Validate implements syntax.Validator.
+func (c *ReplaceConfig) Validate() error {
+	if _, err := getExpressionRegex(*c); err != nil {
+		return err
+	}
+	_, err := template.New("pipeline_template").Funcs(functionMap).Parse(c.Replace)
+	if err != nil {
+		return fmt.Errorf("invalid replace template: %w", err)
+	}
+	return nil
 }
 
 func getExpressionRegex(c ReplaceConfig) (*regexp.Regexp, error) {

--- a/internal/component/loki/process/stages/sampling.go
+++ b/internal/component/loki/process/stages/sampling.go
@@ -7,6 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/alloy/internal/sampling"
+	"github.com/grafana/alloy/syntax"
 )
 
 const (
@@ -22,6 +23,11 @@ type SamplingConfig struct {
 	DropReason   string  `alloy:"drop_counter_reason,attr,optional"`
 	SamplingRate float64 `alloy:"rate,attr"`
 }
+
+var (
+	_ syntax.Defaulter = (*SamplingConfig)(nil)
+	_ syntax.Validator = (*SamplingConfig)(nil)
+)
 
 func (s *SamplingConfig) SetToDefault() {
 	s.DropReason = defaultSamplingpReason

--- a/internal/component/loki/process/stages/static_labels.go
+++ b/internal/component/loki/process/stages/static_labels.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/alloy/syntax"
 )
 
 // ErrEmptyStaticLabelStageConfig error returned if the config is empty.
@@ -16,8 +18,27 @@ type StaticLabelsConfig struct {
 	Values map[string]*string `alloy:"values,attr"`
 }
 
+var _ syntax.Validator = (*StaticLabelsConfig)(nil)
+
+// Validate implements syntax.Validator.
+func (c *StaticLabelsConfig) Validate() error {
+	if err := validateLabelStaticConfig(*c); err != nil {
+		return err
+	}
+	for _, v := range c.Values {
+		if v == nil || *v == "" {
+			continue
+		}
+		value := *v
+		if !model.LabelValue(value).IsValid() {
+			return fmt.Errorf("invalid label value: %s", value)
+		}
+	}
+	return nil
+}
+
 func newStaticLabelsStage(config StaticLabelsConfig) (Stage, error) {
-	err := validateLabelStaticConfig(config)
+	err := config.Validate()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/component/loki/process/stages/structured_metadata.go
+++ b/internal/component/loki/process/stages/structured_metadata.go
@@ -10,11 +10,28 @@ import (
 
 	"github.com/grafana/loki/pkg/push"
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/alloy/syntax"
 )
 
 type StructuredMetadataConfig struct {
 	Values map[string]*string `alloy:"values,attr,optional"`
 	Regex  string             `alloy:"regex,attr,optional"`
+}
+
+var _ syntax.Validator = (*StructuredMetadataConfig)(nil)
+
+// Validate implements syntax.Validator.
+func (c *StructuredMetadataConfig) Validate() error {
+	if len(c.Values) > 0 {
+		if _, err := validateStructuredMetadataConfig(c.Values); err != nil {
+			return err
+		}
+	}
+	if _, err := regexp.Compile(c.Regex); err != nil {
+		return err
+	}
+	return nil
 }
 
 // validateStructuredMetadataConfig validates the structured metadata stage config.

--- a/internal/component/loki/process/stages/structured_metadata_drop.go
+++ b/internal/component/loki/process/stages/structured_metadata_drop.go
@@ -6,6 +6,8 @@ import (
 	"slices"
 
 	"github.com/grafana/loki/pkg/push"
+
+	"github.com/grafana/alloy/syntax"
 )
 
 // ErrEmptyStructuredMetadataDropStageConfig error returned if the config is empty.
@@ -16,9 +18,19 @@ type StructuredMetadataDropConfig struct {
 	Values []string `alloy:"values,attr"`
 }
 
+var _ syntax.Validator = (*StructuredMetadataDropConfig)(nil)
+
+// Validate implements syntax.Validator.
+func (c *StructuredMetadataDropConfig) Validate() error {
+	if len(c.Values) < 1 {
+		return ErrEmptyStructuredMetadataDropStageConfig
+	}
+	return nil
+}
+
 func newStructuredMetadataDropStage(logger *slog.Logger, config StructuredMetadataDropConfig) (Stage, error) {
-	if len(config.Values) < 1 {
-		return nil, ErrEmptyStructuredMetadataDropStageConfig
+	if err := config.Validate(); err != nil {
+		return nil, err
 	}
 
 	return &structuredMetadataDropStage{

--- a/internal/component/loki/process/stages/tenant.go
+++ b/internal/component/loki/process/stages/tenant.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/alloy/syntax"
 )
 
 // Configuration errors.
@@ -28,6 +30,13 @@ type TenantConfig struct {
 	Label  string `alloy:"label,attr,optional"`
 	Source string `alloy:"source,attr,optional"`
 	Value  string `alloy:"value,attr,optional"`
+}
+
+var _ syntax.Validator = (*TenantConfig)(nil)
+
+// Validate implements syntax.Validator.
+func (c *TenantConfig) Validate() error {
+	return validateTenantConfig(*c)
 }
 
 // validateTenantConfig validates the tenant stage configuration

--- a/internal/component/loki/process/stages/timestamp.go
+++ b/internal/component/loki/process/stages/timestamp.go
@@ -11,6 +11,8 @@ import (
 
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/alloy/syntax"
 )
 
 // Config errors.
@@ -58,6 +60,14 @@ type TimestampConfig struct {
 	Location                   *string  `alloy:"location,attr,optional"`
 	ActionOnFailure            string   `alloy:"action_on_failure,attr,optional"`
 	ActionOnDuplicateTimestamp string   `alloy:"action_on_duplicate_timestamp,attr,optional"`
+}
+
+var _ syntax.Validator = (*TimestampConfig)(nil)
+
+// Validate implements syntax.Validator.
+func (c *TimestampConfig) Validate() error {
+	_, err := validateTimestampConfig(c)
+	return err
 }
 
 type parser func(string) (time.Time, error)

--- a/internal/component/loki/process/stages/truncate.go
+++ b/internal/component/loki/process/stages/truncate.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/alecthomas/units"
 	"github.com/grafana/alloy/internal/util"
+	"github.com/grafana/alloy/syntax"
 	"github.com/grafana/loki/pkg/push"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
@@ -32,12 +33,29 @@ type TruncateConfig struct {
 	Rules []*RuleConfig `alloy:"rule,block"`
 }
 
+var _ syntax.Validator = (*TruncateConfig)(nil)
+
+// Validate implements syntax.Validator.
+func (c *TruncateConfig) Validate() error {
+	for _, rule := range c.Rules {
+		if err := rule.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 type RuleConfig struct {
 	Limit      units.Base2Bytes `alloy:"limit,attr"`
 	Suffix     string           `alloy:"suffix,attr,optional"`
 	Sources    []string         `alloy:"sources,attr,optional"`
 	SourceType SourceType       `alloy:"source_type,attr,optional"`
 }
+
+var (
+	_ syntax.Defaulter = (*RuleConfig)(nil)
+	_ syntax.Validator = (*RuleConfig)(nil)
+)
 
 // SetToDefault implements syntax.Defaulter.
 func (r *RuleConfig) SetToDefault() {

--- a/internal/component/loki/process/stages/windowsevent.go
+++ b/internal/component/loki/process/stages/windowsevent.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/util/strutil"
+
+	"github.com/grafana/alloy/syntax"
 )
 
 const (
@@ -19,6 +21,11 @@ type WindowsEventConfig struct {
 	DropInvalidLabels bool   `alloy:"drop_invalid_labels,attr,optional"`
 	OverwriteExisting bool   `alloy:"overwrite_existing,attr,optional"`
 }
+
+var (
+	_ syntax.Defaulter = (*WindowsEventConfig)(nil)
+	_ syntax.Validator = (*WindowsEventConfig)(nil)
+)
 
 func (e *WindowsEventConfig) Validate() error {
 	// TODO: add support for different validation schemes.


### PR DESCRIPTION
### Description
This PR addresses issue #6471 by moving runtime validations for `loki.process` stages to early syntax-based validation using the `syntax.Validator` interface. 

With this change, syntax validation checks exactly one active stage block configuration and recurses down to call the `Validate()` method on each nested stage config. Errors like malformed regexes, invalid rates, or misconfigured rules are now flagged early during the parsing phase.

### Changes
- **loki.process**: Implemented `syntax.Validator` on `Arguments` and added interface assertions.
- **stages.StageConfig**: Implemented `syntax.Validator` to assert that exactly one stage configuration is specified, delegating validation to the active stage struct.
- **Stage Configurations**: Implemented `syntax.Validator` on all individual stage structs (e.g., `DropConfig`, `JSONConfig`, `RegexConfig`, `ReplaceConfig`, `MultilineConfig`, `SamplingConfig`, `WindowsEventConfig`, etc.).
- Cleaned up compile-time validations and added interface assertions for `syntax.Validator` and `syntax.Defaulter` across all stages.

### Verification
- **Build**: Successfully compiled production packages:
  ```bash
  go build -tags="nodocker" ./internal/component/loki/process
  go build -tags="nodocker" ./internal/component/loki/process/stages
