### PR TITLE
ci: Fix backport workflow when multiple commits have same title

### DIFF
--- a/tools/release/backport/command.go
+++ b/tools/release/backport/command.go
@@ -25,7 +25,6 @@ type backportInfo struct {
 	PRNumber       int
 	OriginalPR     *github.PullRequest
 	MergeCommitSHA string
-	CommitSHA      string
 	AppIdentity    gh.AppIdentity
 	TargetBranch   string
 	BackportBranch string
@@ -36,7 +35,7 @@ func Command() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "backport",
-		Short: "Cherry-pick a merged PR to a release branch and open a backport PR",
+		Short: "Cherry-pick a squash-merged PR to a release branch and open a backport PR",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return run(cmd.Context(), flags)
 		},
@@ -81,7 +80,7 @@ func run(ctx context.Context, flags flags) (retErr error) {
 	if flags.dryRun {
 		fmt.Println("\n🏃 DRY RUN - No changes made")
 		fmt.Printf("Would create backport branch: %s\n", info.BackportBranch)
-		fmt.Printf("Would cherry-pick commit: %s\n", info.CommitSHA)
+		fmt.Printf("Would cherry-pick commit: %s\n", info.MergeCommitSHA)
 		fmt.Printf("Would create PR: %s → %s\n", info.BackportBranch, info.TargetBranch)
 		return nil
 	}
@@ -113,7 +112,7 @@ func run(ctx context.Context, flags flags) (retErr error) {
 	}
 	defer resetWorkingCopy(originalBranch, info.BackportBranch)
 
-	if err := git.CherryPick(info.CommitSHA, true); err != nil {
+	if err := git.CherryPick(info.MergeCommitSHA, true); err != nil {
 		return err
 	}
 
@@ -168,31 +167,30 @@ func resolveBackportInfo(ctx context.Context, client *gh.Client, prNumber int, t
 		return nil, fmt.Errorf("getting app identity: %w", err)
 	}
 
-	commitSHA := originalPR.GetMergeCommitSHA()
-	if commitSHA == "" {
+	mergeCommitSHA := originalPR.GetMergeCommitSHA()
+	if mergeCommitSHA == "" {
 		return nil, fmt.Errorf("PR #%d does not have a merge commit SHA", prNumber)
 	}
 
 	cherryPickedCommit, err := client.FindCherryPickedCommit(ctx, gh.FindCherryPickedCommitParams{
 		Branch:      targetBranch,
-		OriginalSHA: commitSHA,
+		OriginalSHA: mergeCommitSHA,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("checking for existing backport: %w", err)
 	}
 	if cherryPickedCommit != nil {
-		fmt.Printf("ℹ️  Backport already merged (found cherry-pick of %s in %s)\n", commitSHA, targetBranch)
+		fmt.Printf("ℹ️  Backport already merged (found cherry-pick of %s in %s)\n", mergeCommitSHA, targetBranch)
 		return nil, nil
 	}
 
-	fmt.Printf("   Found commit: %s\n", commitSHA)
+	fmt.Printf("   Found commit: %s\n", mergeCommitSHA)
 	fmt.Printf("   Backport branch: %s\n", backportBranch)
 
 	return &backportInfo{
 		PRNumber:       prNumber,
 		OriginalPR:     originalPR,
-		MergeCommitSHA: originalPR.GetMergeCommitSHA(),
-		CommitSHA:      commitSHA,
+		MergeCommitSHA: mergeCommitSHA,
 		AppIdentity:    appIdentity,
 		TargetBranch:   targetBranch,
 		BackportBranch: backportBranch,

--- a/tools/release/backport/command.go
+++ b/tools/release/backport/command.go
@@ -168,27 +168,23 @@ func resolveBackportInfo(ctx context.Context, client *gh.Client, prNumber int, t
 		return nil, fmt.Errorf("getting app identity: %w", err)
 	}
 
-	// Check if backport was already merged by looking for the original PR
-	// title in the release branch history.
-	alreadyMerged, err := client.CommitExistsWithPattern(ctx, gh.FindCommitParams{
-		Branch:  targetBranch,
-		Pattern: originalPR.GetTitle(),
+	commitSHA := originalPR.GetMergeCommitSHA()
+	if commitSHA == "" {
+		return nil, fmt.Errorf("PR #%d does not have a merge commit SHA", prNumber)
+	}
+
+	cherryPickedCommit, err := client.FindCherryPickedCommit(ctx, gh.FindCherryPickedCommitParams{
+		Branch:      targetBranch,
+		OriginalSHA: commitSHA,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("checking for existing backport: %w", err)
 	}
-	if alreadyMerged {
-		fmt.Printf("ℹ️  Backport already merged (found commit with title %q in %s)\n", originalPR.GetTitle(), targetBranch)
+	if cherryPickedCommit != nil {
+		fmt.Printf("ℹ️  Backport already merged (found cherry-pick of %s in %s)\n", commitSHA, targetBranch)
 		return nil, nil
 	}
 
-	commitSHA, err := client.FindCommitWithPattern(ctx, gh.FindCommitParams{
-		Branch:  "main",
-		Pattern: fmt.Sprintf("(#%d)", prNumber),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("finding commit for PR #%d: %w", prNumber, err)
-	}
 	fmt.Printf("   Found commit: %s\n", commitSHA)
 	fmt.Printf("   Backport branch: %s\n", backportBranch)
 

--- a/tools/release/internal/github/client.go
+++ b/tools/release/internal/github/client.go
@@ -59,10 +59,10 @@ type CreatePRParams struct {
 	Draft bool
 }
 
-// FindCommitParams holds parameters for FindCommitWithPattern and CommitExistsWithPattern.
-type FindCommitParams struct {
-	Branch  string
-	Pattern string
+// FindCherryPickedCommitParams holds parameters for FindCherryPickedCommit.
+type FindCherryPickedCommitParams struct {
+	Branch      string
+	OriginalSHA string
 }
 
 // BackportLabelColor is the hex color for backport labels (without '#' prefix).
@@ -74,9 +74,6 @@ type CreateLabelParams struct {
 	Color       string // Hex color without '#' prefix (e.g., "ff0000")
 	Description string // Optional description
 }
-
-// ErrCommitNotFound is returned when a commit matching the search criteria is not found.
-var ErrCommitNotFound = errors.New("commit not found")
 
 // NewClientFromEnv creates a new Client from environment variables.
 // Reads GITHUB_TOKEN and GITHUB_REPOSITORY (format: owner/repo).
@@ -333,9 +330,10 @@ func (c *Client) CreatePR(ctx context.Context, p CreatePRParams) (*github.PullRe
 	return pr, nil
 }
 
-// FindCommitWithPattern searches the commit history of a branch for a commit whose title contains the pattern.
-// Returns the commit SHA if found, or an error if not found.
-func (c *Client) FindCommitWithPattern(ctx context.Context, p FindCommitParams) (string, error) {
+// FindCherryPickedCommit searches the commit history of a branch for a commit
+// message containing the original commit SHA. It returns nil when no matching
+// commit is found.
+func (c *Client) FindCherryPickedCommit(ctx context.Context, p FindCherryPickedCommitParams) (*github.RepositoryCommit, error) {
 	opts := &github.CommitsListOptions{
 		SHA: p.Branch,
 		ListOptions: github.ListOptions{
@@ -347,14 +345,13 @@ func (c *Client) FindCommitWithPattern(ctx context.Context, p FindCommitParams) 
 	for range 5 {
 		commits, resp, err := c.api.Repositories.ListCommits(ctx, c.owner, c.repo, opts)
 		if err != nil {
-			return "", fmt.Errorf("listing commits: %w", err)
+			return nil, fmt.Errorf("listing commits: %w", err)
 		}
 
 		for _, commit := range commits {
 			message := commit.GetCommit().GetMessage()
-			title := strings.Split(message, "\n")[0]
-			if strings.Contains(title, p.Pattern) {
-				return commit.GetSHA(), nil
+			if strings.Contains(message, p.OriginalSHA) {
+				return commit, nil
 			}
 		}
 
@@ -364,19 +361,7 @@ func (c *Client) FindCommitWithPattern(ctx context.Context, p FindCommitParams) 
 		opts.Page = resp.NextPage
 	}
 
-	return "", fmt.Errorf("%w with pattern %q in branch %s", ErrCommitNotFound, p.Pattern, p.Branch)
-}
-
-// CommitExistsWithPattern checks if any commit in the branch history contains the pattern in its title.
-func (c *Client) CommitExistsWithPattern(ctx context.Context, p FindCommitParams) (bool, error) {
-	_, err := c.FindCommitWithPattern(ctx, p)
-	if err != nil {
-		if errors.Is(err, ErrCommitNotFound) {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
+	return nil, nil
 }
 
 // IsBranchMergedInto checks if the source branch is fully merged into the target branch.

--- a/tools/release/internal/github/client.go
+++ b/tools/release/internal/github/client.go
@@ -350,7 +350,9 @@ func (c *Client) FindCherryPickedCommit(ctx context.Context, p FindCherryPickedC
 
 		for _, commit := range commits {
 			message := commit.GetCommit().GetMessage()
-			if strings.Contains(message, p.OriginalSHA) {
+			trailer := fmt.Sprintf("(cherry picked from commit %s)", p.OriginalSHA)
+
+			if strings.Contains(strings.ToLower(message), strings.ToLower(trailer)) {
 				return commit, nil
 			}
 		}


### PR DESCRIPTION
The backport workflow had a bug whereby if two commits being backported share the same git commit title, the second one will silently fail to create its PR, thinking that the commit was already backported.

Instead, now the exact line placed by `git cherry-pick -x` is searched for in the commit messages.