### PR TITLE
feat(prometheus.exporter.windows): Add time collector to the Windows exporter

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
@@ -463,9 +463,8 @@ The `.prom` files must end with an empty line feed for the component to recogniz
 ### `time`
 
 The time collector exposes the Windows Time Service and other time related metrics.
-If the Windows Time Service is stopped after collection has started, collector metric values will reset to 0.
+If the Windows Time Service is stopped after collection has started, collector metric values reset to 0.
 
-Please note the Time Service perflib counters are only available on [Windows Server 2016 or newer](https://docs.microsoft.com/en-us/windows-server/networking/windows-time-service/windows-server-2016-improvements).
 | Name           | Type           | Description                  | Default                                       | Required |
 | -------------- | -------------- | ---------------------------- | --------------------------------------------- | -------- |
 | `enabled_list` | `list(string)` | A list of collectors to use. | `["system_time","clock_source","ntp"]`        | no       |
@@ -476,7 +475,9 @@ The collectors specified by `enabled_list` can include the following:
 - `ntp`
 - `system_time`
 
-The `ntp` collector may not be available on all systems.
+The `ntp` sub-collector reads the Windows Time Service performance counters, which are only available on [Windows Server 2016 or newer][win2016-time-svc-improv]. It produces no metrics on older systems.
+
+[win2016-time-svc-improv]: https://docs.microsoft.com/en-us/windows-server/networking/windows-time-service/windows-server-2016-improvements
 
 ### `update`
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.windows.md
@@ -83,6 +83,7 @@ Each block only takes effect if you include its corresponding collector in `enab
 | [`tcp`][tcp]                               | Configures the `tcp` collector.                                           | no       |
 | [`textfile`][textfile]                     | Configures the `textfile` collector.                                      | no       |
 | [`text_file`][text_file]                   | (Deprecated: use `textfile` instead) Configures the `textfile` collector. | no       |
+| [`time`][time]                             | Configures the `time` collector.                                          | no       |
 | [`update`][update]                         | Configures the `update` collector.                                        | no       |
 
 [dfsr]: #dfsr
@@ -108,6 +109,7 @@ Each block only takes effect if you include its corresponding collector in `enab
 [textfile]: #textfile
 [text_file]: #text_file-deprecated-use-textfile-instead
 [tcp]: #tcp
+[time]: #time
 [update]: #update
 
 {{< /docs/alloy-config >}}
@@ -457,6 +459,24 @@ The component only reads files with the `.prom` extension inside the specified d
 {{< admonition type="note" >}}
 The `.prom` files must end with an empty line feed for the component to recognize and read them.
 {{< /admonition >}}
+
+### `time`
+
+The time collector exposes the Windows Time Service and other time related metrics.
+If the Windows Time Service is stopped after collection has started, collector metric values will reset to 0.
+
+Please note the Time Service perflib counters are only available on [Windows Server 2016 or newer](https://docs.microsoft.com/en-us/windows-server/networking/windows-time-service/windows-server-2016-improvements).
+| Name           | Type           | Description                  | Default                                       | Required |
+| -------------- | -------------- | ---------------------------- | --------------------------------------------- | -------- |
+| `enabled_list` | `list(string)` | A list of collectors to use. | `["system_time","clock_source","ntp"]`        | no       |
+
+The collectors specified by `enabled_list` can include the following:
+
+- `clock_source`
+- `ntp`
+- `system_time`
+
+The `ntp` collector may not be available on all systems.
 
 ### `update`
 

--- a/internal/component/prometheus/exporter/windows/config.go
+++ b/internal/component/prometheus/exporter/windows/config.go
@@ -55,6 +55,7 @@ type Arguments struct {
 	NetFramework       NetFrameworkConfig       `alloy:"netframework,block,optional"`
 	DNS                DNSConfig                `alloy:"dns,block,optional"`
 	Net                NetConfig                `alloy:"net,block,optional"`
+	Time               TimeConfig               `alloy:"time,block,optional"`
 }
 
 // Convert converts the component's Arguments to the integration's Config.
@@ -90,6 +91,7 @@ func (a *Arguments) Convert(logger *slog.Logger) *windows_integration.Config {
 		Update:             a.Update.Convert(),
 		DNS:                a.DNS.Convert(),
 		Net:                a.Net.Convert(),
+		Time:               a.Time.Convert(),
 	}
 }
 
@@ -491,6 +493,18 @@ type DNSConfig struct {
 // Convert converts the component's DNSConfig to the integration's DNSConfig.
 func (t DNSConfig) Convert() windows_integration.DNSConfig {
 	return windows_integration.DNSConfig{
+		EnabledList: strings.Join(t.EnabledList, ","),
+	}
+}
+
+// TimeConfig handles settings for the windows_exporter time collector
+type TimeConfig struct {
+	EnabledList []string `alloy:"enabled_list,attr,optional"`
+}
+
+// Convert converts the component's TimeConfig to the integration's TimeConfig.
+func (t TimeConfig) Convert() windows_integration.TimeConfig {
+	return windows_integration.TimeConfig{
 		EnabledList: strings.Join(t.EnabledList, ","),
 	}
 }

--- a/internal/component/prometheus/exporter/windows/config_default_windows_test.go
+++ b/internal/component/prometheus/exporter/windows/config_default_windows_test.go
@@ -53,6 +53,7 @@ func TestAlloyUnmarshalWithDefaultConfig(t *testing.T) {
 	require.Equal(t, defaultArgs.Net.Include, args.Net.Include)
 	require.Equal(t, defaultArgs.Net.Exclude, args.Net.Exclude)
 	require.Equal(t, defaultArgs.Net.EnabledList, args.Net.EnabledList)
+	require.Equal(t, defaultArgs.Time.EnabledList, args.Time.EnabledList)
 }
 
 // This is a copy of the getDefaultPath() function in:
@@ -90,6 +91,7 @@ func TestDefaultConfig(t *testing.T) {
 		DNS:      DNSConfig{EnabledList: []string{"metrics", "wmi_stats"}},
 		Update:   UpdateConfig{Online: false, ScrapeInterval: 6 * time.Hour},
 		Net:      NetConfig{Include: "^.+$", Exclude: "^$", EnabledList: []string{"metrics", "nic_info"}},
+		Time:     TimeConfig{EnabledList: []string{"system_time", "clock_source", "ntp"}},
 	}
 
 	var args Arguments

--- a/internal/component/prometheus/exporter/windows/config_windows.go
+++ b/internal/component/prometheus/exporter/windows/config_windows.go
@@ -107,5 +107,8 @@ func (a *Arguments) SetToDefault() {
 			Exclude:     col.ConfigDefaults.Net.NicExclude.String(),
 			Include:     col.ConfigDefaults.Net.NicInclude.String(),
 		},
+		Time: TimeConfig{
+			EnabledList: slices.Clone(col.ConfigDefaults.Time.CollectorsEnabled),
+		},
 	}
 }

--- a/internal/component/prometheus/exporter/windows/windows_test.go
+++ b/internal/component/prometheus/exporter/windows/windows_test.go
@@ -82,6 +82,10 @@ var (
 			file_patterns = ["example"]
 		}
 
+		time {
+			enabled_list = ["example"]
+		}
+
 		performancecounter {
 			objects =   "---" +
 						"	- name: \"Processor\"" +
@@ -128,6 +132,7 @@ func TestAlloyUnmarshal(t *testing.T) {
 
 	require.Equal(t, []string{"example"}, args.TCP.EnabledList)
 	require.Equal(t, []string{"example"}, args.Filetime.FilePatterns)
+	require.Equal(t, []string{"example"}, args.Time.EnabledList)
 	// This isn't a real example, and the recommendation would be to use a file rather than a raw string
 	require.Equal(t, "---\t- name: \"Processor\"\t\tcounters:\t\t\t- name: \"% Processor Time\"\t\t\t  instance: \"_Total\"\t\t\t  type: \"counter\"\t\t\t  labels:\t\t\t\t  state: idle", args.PerformanceCounter.Objects)
 }
@@ -165,4 +170,5 @@ func TestConvert(t *testing.T) {
 	require.Equal(t, "^(?:.+)$", conf.LogicalDisk.Include)
 	require.Equal(t, "example", conf.TCP.EnabledList)
 	require.Equal(t, []string{"example"}, conf.Filetime.FilePatterns)
+	require.Equal(t, "example", conf.Time.EnabledList)
 }

--- a/internal/static/integrations/windows_exporter/config.go
+++ b/internal/static/integrations/windows_exporter/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	PerformanceCounter PerformanceCounterConfig `yaml:"performancecounter,omitempty"`
 	DNS                DNSConfig                `yaml:"dns,omitempty"`
 	Net                NetConfig                `yaml:"net,omitempty"`
+	Time               TimeConfig               `yaml:"time,omitempty"`
 }
 
 // Name returns the name used, "windows_explorer"
@@ -202,4 +203,9 @@ type NetConfig struct {
 	EnabledList string `yaml:"enabled_list,omitempty"`
 	Exclude     string `yaml:"exclude,omitempty"`
 	Include     string `yaml:"include,omitempty"`
+}
+
+// TimeConfig handles settings for the windows_exporter time collector
+type TimeConfig struct {
+	EnabledList string `yaml:"enabled_list,omitempty"`
 }

--- a/internal/static/integrations/windows_exporter/config_windows.go
+++ b/internal/static/integrations/windows_exporter/config_windows.go
@@ -139,6 +139,8 @@ func (c *Config) ToWindowsExporterConfig() (collector.Config, error) {
 	cfg.Net.NicInclude, err = regexp.Compile(c.Net.Include)
 	errs = append(errs, err)
 
+	cfg.Time.CollectorsEnabled = strings.Split(c.Time.EnabledList, ",")
+
 	return cfg, errors.Join(errs...)
 }
 
@@ -251,6 +253,9 @@ var DefaultConfig = Config{
 		EnabledList: strings.Join(collector.ConfigDefaults.Net.CollectorsEnabled, ","),
 		Exclude:     collector.ConfigDefaults.Net.NicExclude.String(),
 		Include:     collector.ConfigDefaults.Net.NicInclude.String(),
+	},
+	Time: TimeConfig{
+		EnabledList: strings.Join(collector.ConfigDefaults.Time.CollectorsEnabled, ","),
 	},
 }
 


### PR DESCRIPTION
### Pull Request Details

This is just a BAU change to add more options to the Windows exporter. Upstream has the [same options](https://github.com/prometheus-community/windows_exporter/blob/v0.31.3/internal/collector/time/time.go#L42-L44) and the [same defaults](https://github.com/prometheus-community/windows_exporter/blob/v0.31.3/internal/collector/time/time.go#L52-L58).

We do not need to add this collector to the list of collectors enabled by default.

### PR Checklist

- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
