### PR TITLE
fix(loki.process): Prevent data race for metircs

### DIFF
--- a/internal/component/loki/process/metric/counters.go
+++ b/internal/component/loki/process/metric/counters.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
+	"go.uber.org/atomic"
 )
 
 const (
@@ -73,12 +74,12 @@ type Counters struct {
 func NewCounters(name string, config *CounterConfig) (*Counters, error) {
 	return &Counters{
 		metricVec: newMetricVec(func(labels map[string]string) prometheus.Metric {
-			return &expiringCounter{prometheus.NewCounter(prometheus.CounterOpts{
-				Help:        config.Description,
-				Name:        name,
-				ConstLabels: labels,
-			}),
-				0,
+			return &expiringCounter{
+				Counter: prometheus.NewCounter(prometheus.CounterOpts{
+					Help:        config.Description,
+					Name:        name,
+					ConstLabels: labels,
+				}),
 			}
 		}, int64(config.MaxIdle.Seconds())),
 		Cfg: config,
@@ -92,24 +93,24 @@ func (c *Counters) With(labels model.LabelSet) prometheus.Counter {
 
 type expiringCounter struct {
 	prometheus.Counter
-	lastModSec int64
+	lastModSec atomic.Int64
 }
 
 // Inc increments the counter by 1. Use Add to increment it by arbitrary
 // non-negative values.
 func (e *expiringCounter) Inc() {
 	e.Counter.Inc()
-	e.lastModSec = time.Now().Unix()
+	e.lastModSec.Store(time.Now().Unix())
 }
 
 // Add adds the given value to the counter. It panics if the value is <
 // 0.
 func (e *expiringCounter) Add(val float64) {
 	e.Counter.Add(val)
-	e.lastModSec = time.Now().Unix()
+	e.lastModSec.Store(time.Now().Unix())
 }
 
 // HasExpired implements Expirable
 func (e *expiringCounter) HasExpired(currentTimeSec int64, maxAgeSec int64) bool {
-	return currentTimeSec-e.lastModSec >= maxAgeSec
+	return currentTimeSec-e.lastModSec.Load() >= maxAgeSec
 }

--- a/internal/component/loki/process/metric/gauges.go
+++ b/internal/component/loki/process/metric/gauges.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
+	"go.uber.org/atomic"
 )
 
 const (
@@ -72,12 +73,12 @@ type Gauges struct {
 func NewGauges(name string, config *GaugeConfig) (*Gauges, error) {
 	return &Gauges{
 		metricVec: newMetricVec(func(labels map[string]string) prometheus.Metric {
-			return &expiringGauge{prometheus.NewGauge(prometheus.GaugeOpts{
-				Help:        config.Description,
-				Name:        name,
-				ConstLabels: labels,
-			}),
-				0,
+			return &expiringGauge{
+				Gauge: prometheus.NewGauge(prometheus.GaugeOpts{
+					Help:        config.Description,
+					Name:        name,
+					ConstLabels: labels,
+				}),
 			}
 		}, int64(config.MaxIdle.Seconds())),
 		Cfg: config,
@@ -91,50 +92,50 @@ func (g *Gauges) With(labels model.LabelSet) prometheus.Gauge {
 
 type expiringGauge struct {
 	prometheus.Gauge
-	lastModSec int64
+	lastModSec atomic.Int64
 }
 
 // Set sets the Gauge to an arbitrary value.
 func (g *expiringGauge) Set(val float64) {
 	g.Gauge.Set(val)
-	g.lastModSec = time.Now().Unix()
+	g.lastModSec.Store(time.Now().Unix())
 }
 
 // Inc increments the Gauge by 1. Use Add to increment it by arbitrary
 // values.
 func (g *expiringGauge) Inc() {
 	g.Gauge.Inc()
-	g.lastModSec = time.Now().Unix()
+	g.lastModSec.Store(time.Now().Unix())
 }
 
 // Dec decrements the Gauge by 1. Use Sub to decrement it by arbitrary
 // values.
 func (g *expiringGauge) Dec() {
 	g.Gauge.Dec()
-	g.lastModSec = time.Now().Unix()
+	g.lastModSec.Store(time.Now().Unix())
 }
 
 // Add adds the given value to the Gauge. (The value can be negative,
 // resulting in a decrease of the Gauge.)
 func (g *expiringGauge) Add(val float64) {
 	g.Gauge.Add(val)
-	g.lastModSec = time.Now().Unix()
+	g.lastModSec.Store(time.Now().Unix())
 }
 
 // Sub subtracts the given value from the Gauge. (The value can be
 // negative, resulting in an increase of the Gauge.)
 func (g *expiringGauge) Sub(val float64) {
 	g.Gauge.Sub(val)
-	g.lastModSec = time.Now().Unix()
+	g.lastModSec.Store(time.Now().Unix())
 }
 
 // SetToCurrentTime sets the Gauge to the current Unix time in seconds.
 func (g *expiringGauge) SetToCurrentTime() {
 	g.Gauge.SetToCurrentTime()
-	g.lastModSec = time.Now().Unix()
+	g.lastModSec.Store(time.Now().Unix())
 }
 
 // HasExpired implements Expirable
 func (g *expiringGauge) HasExpired(currentTimeSec int64, maxAgeSec int64) bool {
-	return currentTimeSec-g.lastModSec >= maxAgeSec
+	return currentTimeSec-g.lastModSec.Load() >= maxAgeSec
 }

--- a/internal/component/loki/process/metric/histograms.go
+++ b/internal/component/loki/process/metric/histograms.go
@@ -57,13 +57,13 @@ type Histograms struct {
 func NewHistograms(name string, config *HistogramConfig) (*Histograms, error) {
 	return &Histograms{
 		metricVec: newMetricVec(func(labels map[string]string) prometheus.Metric {
-			return &expiringHistogram{prometheus.NewHistogram(prometheus.HistogramOpts{
-				Help:        config.Description,
-				Name:        name,
-				ConstLabels: labels,
-				Buckets:     config.Buckets,
-			}),
-				*atomic.NewInt64(0),
+			return &expiringHistogram{
+				Histogram: prometheus.NewHistogram(prometheus.HistogramOpts{
+					Help:        config.Description,
+					Name:        name,
+					ConstLabels: labels,
+					Buckets:     config.Buckets,
+				}),
 			}
 		}, int64(config.MaxIdle.Seconds())),
 		Cfg: config,

--- a/internal/component/loki/process/metric/histograms.go
+++ b/internal/component/loki/process/metric/histograms.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
+	"go.uber.org/atomic"
 )
 
 // DefaultHistogramConfig sets the defaults for a Histogram.
@@ -62,7 +63,7 @@ func NewHistograms(name string, config *HistogramConfig) (*Histograms, error) {
 				ConstLabels: labels,
 				Buckets:     config.Buckets,
 			}),
-				0,
+				*atomic.NewInt64(0),
 			}
 		}, int64(config.MaxIdle.Seconds())),
 		Cfg: config,
@@ -76,16 +77,16 @@ func (h *Histograms) With(labels model.LabelSet) prometheus.Histogram {
 
 type expiringHistogram struct {
 	prometheus.Histogram
-	lastModSec int64
+	lastModSec atomic.Int64
 }
 
 // Observe adds a single observation to the histogram.
 func (h *expiringHistogram) Observe(val float64) {
 	h.Histogram.Observe(val)
-	h.lastModSec = time.Now().Unix()
+	h.lastModSec.Store(time.Now().Unix())
 }
 
 // HasExpired implements Expirable
 func (h *expiringHistogram) HasExpired(currentTimeSec int64, maxAgeSec int64) bool {
-	return currentTimeSec-h.lastModSec >= maxAgeSec
+	return currentTimeSec-h.lastModSec.Load() >= maxAgeSec
 }


### PR DESCRIPTION
### Pull Request Details
Extracted from https://github.com/grafana/alloy/pull/6204. 
When metrics created by `stage.metric` are collected we use this field to see if we should remove them. But this can happen at the same time they are updating creating a race.

### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->


### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
