### PR TITLE
chore: Implement consumer for loki.echo

### DIFF
--- a/internal/component/common/loki/batch.go
+++ b/internal/component/common/loki/batch.go
@@ -151,9 +151,12 @@ func (b *Batch) Clone() Batch {
 
 // ConsumeStreams calls fn for each stream in the batch and then resets the batch.
 // The callback receives ownership of the stream.
-func (b *Batch) ConsumeStreams(fn func(stream Stream, created int64)) {
+// If callback returns false iteration will stop.
+func (b *Batch) ConsumeStreams(fn func(stream Stream, created int64) bool) {
 	for _, s := range b.streams {
-		fn(s, b.created)
+		if !fn(s, b.created) {
+			break
+		}
 	}
 	b.Reset()
 }

--- a/internal/component/common/loki/batch.go
+++ b/internal/component/common/loki/batch.go
@@ -151,14 +151,15 @@ func (b *Batch) Clone() Batch {
 
 // ConsumeStreams calls fn for each stream in the batch and then resets the batch.
 // The callback receives ownership of the stream.
-// If callback returns false iteration will stop.
-func (b *Batch) ConsumeStreams(fn func(stream Stream, created int64) bool) {
+// If callback returns errors interation will stop
+func (b *Batch) ConsumeStreams(fn func(stream Stream, created int64) error) error {
+	defer b.Reset()
 	for _, s := range b.streams {
-		if !fn(s, b.created) {
-			break
+		if err := fn(s, b.created); err != nil {
+			return err
 		}
 	}
-	b.Reset()
+	return nil
 }
 
 // Reset clears the batch so it can be reused.

--- a/internal/component/common/loki/batch_test.go
+++ b/internal/component/common/loki/batch_test.go
@@ -142,9 +142,9 @@ func TestBatch_Clone(t *testing.T) {
 
 func collectStreams(b *Batch) []Stream {
 	var streams []Stream
-	b.ConsumeStreams(func(s Stream, _ int64) bool {
+	_ = b.ConsumeStreams(func(s Stream, _ int64) error {
 		streams = append(streams, s)
-		return true
+		return nil
 	})
 	return streams
 }

--- a/internal/component/common/loki/batch_test.go
+++ b/internal/component/common/loki/batch_test.go
@@ -142,8 +142,9 @@ func TestBatch_Clone(t *testing.T) {
 
 func collectStreams(b *Batch) []Stream {
 	var streams []Stream
-	b.ConsumeStreams(func(s Stream, _ int64) {
+	b.ConsumeStreams(func(s Stream, _ int64) bool {
 		streams = append(streams, s)
+		return true
 	})
 	return streams
 }

--- a/internal/component/common/loki/consumer.go
+++ b/internal/component/common/loki/consumer.go
@@ -13,6 +13,7 @@ var ErrConsumerStopped = errors.New("consumer stopped")
 
 type Consumer interface {
 	Consume(ctx context.Context, batch Batch) error
+	// TODO: Remove this when we have moved over to batching.
 	ConsumeEntry(ctx context.Context, entry Entry) error
 }
 

--- a/internal/component/common/loki/consumer.go
+++ b/internal/component/common/loki/consumer.go
@@ -2,9 +2,14 @@ package loki
 
 import (
 	"context"
-	"reflect"
+	"errors"
+	"slices"
 	"sync"
 )
+
+// ErrConsumerStopped is returned by Consumer when an entry is
+// submitted after the consumer has been stopped.
+var ErrConsumerStopped = errors.New("consumer stopped")
 
 type Consumer interface {
 	Consume(ctx context.Context, batch Batch) error
@@ -47,23 +52,11 @@ func (c *CollectingConsumer) Batches() []Batch {
 	c.mut.Lock()
 	defer c.mut.Unlock()
 
-	return c.batches
+	return slices.Clone(c.batches)
 }
 
 func (c *CollectingConsumer) Entries() []Entry {
 	c.mut.Lock()
 	defer c.mut.Unlock()
-	return c.entries
-}
-
-func requireUpdate[T any](prev, next []T) bool {
-	if len(prev) != len(next) {
-		return true
-	}
-	for i := range prev {
-		if !reflect.DeepEqual(prev[i], next[i]) {
-			return true
-		}
-	}
-	return false
+	return slices.Clone(c.entries)
 }

--- a/internal/component/common/loki/consumer_fanout.go
+++ b/internal/component/common/loki/consumer_fanout.go
@@ -3,6 +3,7 @@ package loki
 import (
 	"context"
 	"errors"
+	"slices"
 	"sync"
 )
 
@@ -20,31 +21,36 @@ type FanoutConsumer struct {
 }
 
 func (f *FanoutConsumer) Consume(ctx context.Context, batch Batch) error {
-	// NOTE: It's important that we hold a read lock for the duration of Consume
-	// rather than making a copy of consumers and releasing the lock early.
+	// NOTE: We snapshot the consumer list under a brief read lock and release it
+	// before delivering, rather than holding the lock for the whole fan-out.
 	//
-	// When config is updated, the loader evaluates all components and updates
-	// them while they continue running. The scheduler only stops removed components
-	// after all updates complete. During this window, Send may execute concurrently
-	// with receiver list updates. By holding the read lock for the entire Send
-	// operation, receiver list updates (which require a write lock) will block
-	// until all in-flight Send calls complete. This prevents sending entries to
-	// receivers that have been removed by the scheduler.
+	// This is safe because delivery is a plain function call: a consumer that has
+	// stopped returns ErrConsumerStopped instead of blocking, so delivering against
+	// a stale snapshot can never deadlock — a consumer removed concurrently with
+	// delivery simply reports that it has stopped (see isReportableError). The
+	// snapshot stays valid because Update replaces the slice rather than mutating it
+	// in place. Releasing the lock early also keeps a slow consumer from blocking
+	// reconfiguration.
 
 	f.mut.RLock()
-	defer f.mut.RUnlock()
+	consumers := f.consumers
+	f.mut.RUnlock()
 
 	var errs []error
 
-	for i, consumer := range f.consumers {
-		if i == len(f.consumers)-1 {
-			if err := consumer.Consume(ctx, batch); err != nil {
+	for i, consumer := range consumers {
+		if consumer == nil {
+			continue
+		}
+
+		if i == len(consumers)-1 {
+			if err := consumer.Consume(ctx, batch); isReportableError(err) {
 				errs = append(errs, err)
 			}
 			continue
 		}
 
-		if err := consumer.Consume(ctx, batch.Clone()); err != nil {
+		if err := consumer.Consume(ctx, batch.Clone()); isReportableError(err) {
 			errs = append(errs, err)
 		}
 	}
@@ -53,31 +59,31 @@ func (f *FanoutConsumer) Consume(ctx context.Context, batch Batch) error {
 }
 
 func (f *FanoutConsumer) ConsumeEntry(ctx context.Context, entry Entry) error {
-	// NOTE: It's important that we hold a read lock for the duration of ConsumeEntry
-	// rather than making a copy of consumers and releasing the lock early.
+	// NOTE: We snapshot the consumer list under a brief read lock and release it
+	// before delivering, rather than holding the lock for the whole fan-out.
 	//
-	// When config is updated, the loader evaluates all components and updates
-	// them while they continue running. The scheduler only stops removed components
-	// after all updates complete. During this window, Send may execute concurrently
-	// with receiver list updates. By holding the read lock for the entire Send
-	// operation, receiver list updates (which require a write lock) will block
-	// until all in-flight Send calls complete. This prevents sending entries to
-	// receivers that have been removed by the scheduler.
+	// This is safe because delivery is a plain function call: a consumer that has
+	// stopped returns ErrConsumerStopped instead of blocking, so delivering against
+	// a stale snapshot can never deadlock — a consumer removed concurrently with
+	// delivery simply reports that it has stopped (see isReportableError). The
+	// snapshot stays valid because Update replaces the slice rather than mutating it
+	// in place. Releasing the lock early also keeps a slow consumer from blocking
+	// reconfiguration.
 
 	f.mut.RLock()
-	defer f.mut.RUnlock()
+	consumers := f.consumers
+	f.mut.RUnlock()
 
 	var errs []error
 
-	for i, consumer := range f.consumers {
-		if i == len(f.consumers)-1 {
-			if err := consumer.ConsumeEntry(ctx, entry); err != nil {
-				errs = append(errs, err)
-			}
+	for _, consumer := range consumers {
+		if consumer == nil {
 			continue
 		}
 
-		if err := consumer.ConsumeEntry(ctx, entry.Clone()); err != nil {
+		// ConsumeEntry does not clone entries. Components that mutate an entry must
+		// clone it first, as they already do. Batching will own cloning at the batch/pipeline boundary.
+		if err := consumer.ConsumeEntry(ctx, entry); isReportableError(err) {
 			errs = append(errs, err)
 		}
 	}
@@ -87,7 +93,7 @@ func (f *FanoutConsumer) ConsumeEntry(ctx context.Context, entry Entry) error {
 
 func (f *FanoutConsumer) Update(consumers []Consumer) {
 	f.mut.RLock()
-	if requireUpdate(f.consumers, consumers) {
+	if !slices.Equal(f.consumers, consumers) {
 		// Upgrade lock to write.
 		f.mut.RUnlock()
 		f.mut.Lock()
@@ -96,4 +102,13 @@ func (f *FanoutConsumer) Update(consumers []Consumer) {
 	} else {
 		f.mut.RUnlock()
 	}
+}
+
+func isReportableError(err error) bool {
+	// We can always ignore ErrConsumerStopped.
+	// If a downstream component have been stopped due to config update
+	// we should no longer forward entries there and when alloy it self
+	// stops we shut down components from sources to sinks so we should
+	// never hit this error.
+	return err != nil && !errors.Is(err, ErrConsumerStopped)
 }

--- a/internal/component/common/loki/consumer_fanout.go
+++ b/internal/component/common/loki/consumer_fanout.go
@@ -107,7 +107,7 @@ func (f *FanoutConsumer) Update(consumers []Consumer) {
 func isReportableError(err error) bool {
 	// We can always ignore ErrConsumerStopped.
 	// If a downstream component have been stopped due to config update
-	// we should no longer forward entries there and when alloy it self
+	// we should no longer forward entries there and when alloy itself
 	// stops we shut down components from sources to sinks so we should
 	// never hit this error.
 	return err != nil && !errors.Is(err, ErrConsumerStopped)

--- a/internal/component/common/loki/consumer_fanout.go
+++ b/internal/component/common/loki/consumer_fanout.go
@@ -58,6 +58,7 @@ func (f *FanoutConsumer) Consume(ctx context.Context, batch Batch) error {
 	return errors.Join(errs...)
 }
 
+// TODO: Remove this when we have moved over to batching.
 func (f *FanoutConsumer) ConsumeEntry(ctx context.Context, entry Entry) error {
 	// NOTE: We snapshot the consumer list under a brief read lock and release it
 	// before delivering, rather than holding the lock for the whole fan-out.

--- a/internal/component/common/loki/consumer_fanout_test.go
+++ b/internal/component/common/loki/consumer_fanout_test.go
@@ -99,8 +99,8 @@ func TestFanoutConsumer_Consume(t *testing.T) {
 func TestFanoutConsumer_NilConsumer(t *testing.T) {
 	fanout := NewFanoutConsumer([]Consumer{nil})
 	require.NotPanics(t, func() {
-		_ = fanout.Consume(context.Background(), NewBatch())
-		_ = fanout.ConsumeEntry(context.Background(), NewEntry(model.LabelSet{}, push.Entry{}))
+		require.NoError(t, fanout.Consume(context.Background(), NewBatch()))
+		require.NoError(t, fanout.ConsumeEntry(context.Background(), NewEntry(model.LabelSet{}, push.Entry{})))
 	})
 }
 

--- a/internal/component/common/loki/consumer_fanout_test.go
+++ b/internal/component/common/loki/consumer_fanout_test.go
@@ -96,6 +96,32 @@ func TestFanoutConsumer_Consume(t *testing.T) {
 	require.Equal(t, "original", lastStreams[0].Entries[0].Line)
 }
 
+func TestFanoutConsumer_NilConsumer(t *testing.T) {
+	fanout := NewFanoutConsumer([]Consumer{nil})
+	require.NotPanics(t, func() {
+		_ = fanout.Consume(context.Background(), NewBatch())
+		_ = fanout.ConsumeEntry(context.Background(), NewEntry(model.LabelSet{}, push.Entry{}))
+	})
+}
+
+func TestFanoutConsumer_ConsumerStopped(t *testing.T) {
+	fanout := NewFanoutConsumer([]Consumer{
+		consumerFunc{
+			consume: func(_ context.Context, batch Batch) error {
+				return ErrConsumerStopped
+			},
+		},
+		consumerFunc{
+			consume: func(_ context.Context, batch Batch) error {
+				return ErrConsumerStopped
+			},
+		},
+	})
+
+	require.NoError(t, fanout.Consume(context.Background(), NewBatch()))
+	require.NoError(t, fanout.ConsumeEntry(context.Background(), NewEntry(model.LabelSet{}, push.Entry{})))
+}
+
 type consumerFunc struct {
 	consume      func(context.Context, Batch) error
 	consumeEntry func(context.Context, Entry) error

--- a/internal/component/common/loki/consumer_interceptor.go
+++ b/internal/component/common/loki/consumer_interceptor.go
@@ -59,6 +59,7 @@ func (i *InterceptorConsumer) Consume(ctx context.Context, batch Batch) error {
 	return errors.New("loki interceptor: unimplemented consume")
 }
 
+// TODO: Remove this when we have moved over to batching.
 func (i *InterceptorConsumer) ConsumeEntry(ctx context.Context, entry Entry) error {
 	if i.onConsumeEntry != nil {
 		entry, keep, err := i.onConsumeEntry(ctx, entry)

--- a/internal/component/common/loki/consumer_interceptor.go
+++ b/internal/component/common/loki/consumer_interceptor.go
@@ -57,18 +57,15 @@ func (i *InterceptorConsumer) Consume(ctx context.Context, batch Batch) error {
 	}
 
 	// Fallback to ConsumeEntry.
-	var err error
-	batch.ConsumeStreams(func(stream Stream, created int64) bool {
+	return batch.ConsumeStreams(func(stream Stream, created int64) error {
 		for _, e := range stream.Entries {
-			err = i.ConsumeEntry(ctx, NewEntryWithCreatedUnixMicro(stream.Labels, created, e))
-			if err != nil {
-				return false
+			if err := i.ConsumeEntry(ctx, NewEntryWithCreatedUnixMicro(stream.Labels, created, e)); err != nil {
+				return err
 			}
 		}
-		return true
+		return nil
 	})
 
-	return err
 }
 
 // TODO: Remove this when we have moved over to batching.

--- a/internal/component/common/loki/consumer_interceptor.go
+++ b/internal/component/common/loki/consumer_interceptor.go
@@ -1,0 +1,76 @@
+package loki
+
+import (
+	"context"
+	"errors"
+)
+
+var _ Consumer = (*InterceptorConsumer)(nil)
+
+// InterceptorOption configures an InterceptorConsumer.
+type InterceptorOption func(*InterceptorConsumer)
+
+// WithConsumeHook hooks calls to Consume. Returning an empty batch drops it.
+func WithConsumeHook(f func(ctx context.Context, batch Batch) (Batch, error)) InterceptorOption {
+	return func(i *InterceptorConsumer) {
+		i.onConsume = f
+	}
+}
+
+// WithConsumeEntryHook hooks calls to ConsumeEntry. Returning false drops the entry.
+func WithConsumeEntryHook(f func(ctx context.Context, entry Entry) (Entry, bool, error)) InterceptorOption {
+	return func(i *InterceptorConsumer) {
+		i.onConsumeEntry = f
+	}
+}
+
+// InterceptorConsumer is a Consumer that runs hooks before forwarding to next.
+type InterceptorConsumer struct {
+	componentID string
+	next        Consumer
+
+	onConsume      func(ctx context.Context, batch Batch) (Batch, error)
+	onConsumeEntry func(ctx context.Context, entry Entry) (Entry, bool, error)
+}
+
+// NewInterceptorConsumer creates an InterceptorConsumer. The next consumer must be non-nil.
+func NewInterceptorConsumer(componentID string, next Consumer, opts ...InterceptorOption) *InterceptorConsumer {
+	i := &InterceptorConsumer{
+		componentID: componentID,
+		next:        next,
+	}
+
+	for _, o := range opts {
+		o(i)
+	}
+
+	return i
+}
+
+func (i *InterceptorConsumer) Consume(ctx context.Context, batch Batch) error {
+	if i.onConsume != nil {
+		batch, err := i.onConsume(ctx, batch)
+		if err != nil || batch.EntryLen() == 0 {
+			return err
+		}
+		return i.next.Consume(ctx, batch)
+	}
+
+	return errors.New("loki interceptor: unimplemented consume")
+}
+
+func (i *InterceptorConsumer) ConsumeEntry(ctx context.Context, entry Entry) error {
+	if i.onConsumeEntry != nil {
+		entry, keep, err := i.onConsumeEntry(ctx, entry)
+		if err != nil || !keep {
+			return err
+		}
+		return i.next.ConsumeEntry(ctx, entry)
+	}
+
+	return errors.New("loki interceptor: unimplemented consume entry")
+}
+
+func (i *InterceptorConsumer) String() string {
+	return i.componentID + ".receiver"
+}

--- a/internal/component/common/loki/consumer_interceptor.go
+++ b/internal/component/common/loki/consumer_interceptor.go
@@ -65,7 +65,6 @@ func (i *InterceptorConsumer) Consume(ctx context.Context, batch Batch) error {
 		}
 		return nil
 	})
-
 }
 
 // TODO: Remove this when we have moved over to batching.

--- a/internal/component/common/loki/consumer_interceptor.go
+++ b/internal/component/common/loki/consumer_interceptor.go
@@ -56,7 +56,19 @@ func (i *InterceptorConsumer) Consume(ctx context.Context, batch Batch) error {
 		return i.next.Consume(ctx, batch)
 	}
 
-	return errors.New("loki interceptor: unimplemented consume")
+	// Fallback to ConsumeEntry.
+	var err error
+	batch.ConsumeStreams(func(stream Stream, created int64) bool {
+		for _, e := range stream.Entries {
+			err = i.ConsumeEntry(ctx, NewEntryWithCreatedUnixMicro(stream.Labels, created, e))
+			if err != nil {
+				return false
+			}
+		}
+		return true
+	})
+
+	return err
 }
 
 // TODO: Remove this when we have moved over to batching.

--- a/internal/component/common/loki/consumer_interceptor_test.go
+++ b/internal/component/common/loki/consumer_interceptor_test.go
@@ -125,7 +125,6 @@ func TestInterceptorConsumer_Consume(t *testing.T) {
 		consumer := NewInterceptorConsumer("test", NewCollectingConsumer(), WithConsumeEntryHook(func(ctx context.Context, entry Entry) (Entry, bool, error) {
 			called = true
 			return entry, true, nil
-
 		}))
 
 		batch := NewBatch()

--- a/internal/component/common/loki/consumer_interceptor_test.go
+++ b/internal/component/common/loki/consumer_interceptor_test.go
@@ -81,9 +81,10 @@ func TestInterceptorConsumer_Consume(t *testing.T) {
 		batches := next.Batches()
 		require.Len(t, batches, 1)
 		require.Equal(t, 1, batches[0].EntryLen())
-		batches[0].ConsumeStreams(func(stream Stream, _ int64) {
+		batches[0].ConsumeStreams(func(stream Stream, _ int64) bool {
 			require.Equal(t, model.LabelValue("true"), stream.Labels["hook"])
 			require.Equal(t, "modified", stream.Entries[0].Line)
+			return true
 		})
 	})
 

--- a/internal/component/common/loki/consumer_interceptor_test.go
+++ b/internal/component/common/loki/consumer_interceptor_test.go
@@ -81,10 +81,10 @@ func TestInterceptorConsumer_Consume(t *testing.T) {
 		batches := next.Batches()
 		require.Len(t, batches, 1)
 		require.Equal(t, 1, batches[0].EntryLen())
-		batches[0].ConsumeStreams(func(stream Stream, _ int64) bool {
+		_ = batches[0].ConsumeStreams(func(stream Stream, _ int64) error {
 			require.Equal(t, model.LabelValue("true"), stream.Labels["hook"])
 			require.Equal(t, "modified", stream.Entries[0].Line)
-			return true
+			return nil
 		})
 	})
 
@@ -120,10 +120,17 @@ func TestInterceptorConsumer_Consume(t *testing.T) {
 		require.Empty(t, next.Batches())
 	})
 
-	t.Run("returns error without hook", func(t *testing.T) {
-		consumer := NewInterceptorConsumer("test", NewCollectingConsumer())
+	t.Run("fallback to consumeEntry", func(t *testing.T) {
+		var called bool
+		consumer := NewInterceptorConsumer("test", NewCollectingConsumer(), WithConsumeEntryHook(func(ctx context.Context, entry Entry) (Entry, bool, error) {
+			called = true
+			return entry, true, nil
 
-		err := consumer.Consume(t.Context(), NewBatch())
-		require.EqualError(t, err, "loki interceptor: unimplemented consume")
+		}))
+
+		batch := NewBatch()
+		batch.Add(NewStream(model.LabelSet{}, push.Entry{}))
+		require.NoError(t, consumer.Consume(t.Context(), batch))
+		require.True(t, called)
 	})
 }

--- a/internal/component/common/loki/consumer_interceptor_test.go
+++ b/internal/component/common/loki/consumer_interceptor_test.go
@@ -1,0 +1,128 @@
+package loki
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/grafana/loki/pkg/push"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInterceptorConsumer_ConsumeEntry(t *testing.T) {
+	t.Run("forwards modified entry", func(t *testing.T) {
+		next := NewCollectingConsumer()
+		consumer := NewInterceptorConsumer("test", next, WithConsumeEntryHook(func(_ context.Context, entry Entry) (Entry, bool, error) {
+			entry.Line = "modified"
+			entry.Labels["hook"] = "true"
+			return entry, true, nil
+		}))
+
+		entry := NewEntry(model.LabelSet{"job": "test"}, push.Entry{Line: "original"})
+		err := consumer.ConsumeEntry(t.Context(), entry)
+		require.NoError(t, err)
+
+		entries := next.Entries()
+		require.Len(t, entries, 1)
+		require.Equal(t, "modified", entries[0].Line)
+		require.Equal(t, model.LabelValue("true"), entries[0].Labels["hook"])
+	})
+
+	t.Run("drops entry", func(t *testing.T) {
+		next := NewCollectingConsumer()
+		consumer := NewInterceptorConsumer("test", next, WithConsumeEntryHook(func(_ context.Context, entry Entry) (Entry, bool, error) {
+			return entry, false, nil
+		}))
+
+		err := consumer.ConsumeEntry(t.Context(), NewEntry(model.LabelSet{"job": "test"}, push.Entry{Line: "dropped"}))
+		require.NoError(t, err)
+		require.Empty(t, next.Entries())
+	})
+
+	t.Run("returns hook error", func(t *testing.T) {
+		hookErr := errors.New("hook failed")
+		next := NewCollectingConsumer()
+		consumer := NewInterceptorConsumer("test", next, WithConsumeEntryHook(func(_ context.Context, entry Entry) (Entry, bool, error) {
+			return entry, true, hookErr
+		}))
+
+		err := consumer.ConsumeEntry(t.Context(), NewEntry(model.LabelSet{"job": "test"}, push.Entry{Line: "failed"}))
+		require.ErrorIs(t, err, hookErr)
+		require.Empty(t, next.Entries())
+	})
+
+	t.Run("returns error without hook", func(t *testing.T) {
+		consumer := NewInterceptorConsumer("test", NewCollectingConsumer())
+
+		err := consumer.ConsumeEntry(t.Context(), Entry{})
+		require.EqualError(t, err, "loki interceptor: unimplemented consume entry")
+	})
+}
+
+func TestInterceptorConsumer_Consume(t *testing.T) {
+	t.Run("forwards modified batch", func(t *testing.T) {
+		next := NewCollectingConsumer()
+		consumer := NewInterceptorConsumer("test", next, WithConsumeHook(func(_ context.Context, batch Batch) (Batch, error) {
+			batch.FilterMap(func(entry *Entry) bool {
+				entry.Line = "modified"
+				entry.Labels["hook"] = "true"
+				return true
+			})
+			return batch, nil
+		}))
+
+		batch := NewBatch()
+		batch.Add(NewStream(model.LabelSet{"job": "test"}, push.Entry{Line: "original"}))
+
+		err := consumer.Consume(t.Context(), batch)
+		require.NoError(t, err)
+
+		batches := next.Batches()
+		require.Len(t, batches, 1)
+		require.Equal(t, 1, batches[0].EntryLen())
+		batches[0].ConsumeStreams(func(stream Stream, _ int64) {
+			require.Equal(t, model.LabelValue("true"), stream.Labels["hook"])
+			require.Equal(t, "modified", stream.Entries[0].Line)
+		})
+	})
+
+	t.Run("drops empty batch", func(t *testing.T) {
+		next := NewCollectingConsumer()
+		consumer := NewInterceptorConsumer("test", next, WithConsumeHook(func(_ context.Context, batch Batch) (Batch, error) {
+			batch.FilterMap(func(_ *Entry) bool {
+				return false
+			})
+			return batch, nil
+		}))
+
+		batch := NewBatch()
+		batch.Add(NewStream(model.LabelSet{"job": "test"}, push.Entry{Line: "dropped"}))
+
+		err := consumer.Consume(t.Context(), batch)
+		require.NoError(t, err)
+		require.Empty(t, next.Batches())
+	})
+
+	t.Run("returns hook error", func(t *testing.T) {
+		hookErr := errors.New("hook failed")
+		next := NewCollectingConsumer()
+		consumer := NewInterceptorConsumer("test", next, WithConsumeHook(func(_ context.Context, batch Batch) (Batch, error) {
+			return batch, hookErr
+		}))
+
+		batch := NewBatch()
+		batch.Add(NewStream(model.LabelSet{"job": "test"}, push.Entry{Line: "failed"}))
+
+		err := consumer.Consume(t.Context(), batch)
+		require.ErrorIs(t, err, hookErr)
+		require.Empty(t, next.Batches())
+	})
+
+	t.Run("returns error without hook", func(t *testing.T) {
+		consumer := NewInterceptorConsumer("test", NewCollectingConsumer())
+
+		err := consumer.Consume(t.Context(), NewBatch())
+		require.EqualError(t, err, "loki interceptor: unimplemented consume")
+	})
+}

--- a/internal/component/common/loki/consumer_sharding.go
+++ b/internal/component/common/loki/consumer_sharding.go
@@ -90,6 +90,7 @@ func (s *ShardingConsumer) consume(ctx context.Context, shard int, batch Batch) 
 
 // ConsumeEntry shards a single entry to the shard selected by the entry's labels.
 // It returns ErrConsumerStopped if called after shutdown begins.
+// TODO: Remove this when we have moved over to batching.
 func (s *ShardingConsumer) ConsumeEntry(ctx context.Context, entry Entry) error {
 	errCh := make(chan error, 1)
 	req := shardingRequest{

--- a/internal/component/common/loki/consumer_sharding.go
+++ b/internal/component/common/loki/consumer_sharding.go
@@ -10,8 +10,6 @@ import (
 
 var _ Consumer = (*ShardingConsumer)(nil)
 
-var ErrConsumerStopped = errors.New("consumer stopped")
-
 // NewShardingConsumer creates a Consumer which shards streams across a fixed
 // number of shards before forwarding them to the downstream consumer.
 func NewShardingConsumer(shards int, consumer Consumer) *ShardingConsumer {

--- a/internal/component/common/loki/consumer_sharding.go
+++ b/internal/component/common/loki/consumer_sharding.go
@@ -58,11 +58,11 @@ func (s *ShardingConsumer) Consume(ctx context.Context, batch Batch) error {
 	if streamLen == 1 {
 		errChans = append(errChans, s.consume(ctx, s.shardFor(batch.streams[0].Labels), batch))
 	} else {
-		batch.ConsumeStreams(func(stream Stream, created int64) bool {
+		_ = batch.ConsumeStreams(func(stream Stream, created int64) error {
 			streamBatch := NewBatchWithCreatedUnixMicro(created)
 			streamBatch.Add(stream)
 			errChans = append(errChans, s.consume(ctx, s.shardFor(stream.Labels), streamBatch))
-			return true
+			return nil
 		})
 	}
 

--- a/internal/component/common/loki/consumer_sharding.go
+++ b/internal/component/common/loki/consumer_sharding.go
@@ -58,10 +58,11 @@ func (s *ShardingConsumer) Consume(ctx context.Context, batch Batch) error {
 	if streamLen == 1 {
 		errChans = append(errChans, s.consume(ctx, s.shardFor(batch.streams[0].Labels), batch))
 	} else {
-		batch.ConsumeStreams(func(stream Stream, created int64) {
+		batch.ConsumeStreams(func(stream Stream, created int64) bool {
 			streamBatch := NewBatchWithCreatedUnixMicro(created)
 			streamBatch.Add(stream)
 			errChans = append(errChans, s.consume(ctx, s.shardFor(stream.Labels), streamBatch))
+			return true
 		})
 	}
 

--- a/internal/component/common/loki/consumer_sharding_test.go
+++ b/internal/component/common/loki/consumer_sharding_test.go
@@ -42,19 +42,21 @@ func TestShardingConsumer_Consume(t *testing.T) {
 		gotFirst := got[first.String()]
 		require.Equal(t, 1, gotFirst.StreamLen())
 		require.Equal(t, 1, gotFirst.EntryLen())
-		gotFirst.ConsumeStreams(func(stream Stream, created int64) {
+		gotFirst.ConsumeStreams(func(stream Stream, created int64) bool {
 			require.Equal(t, original.Created(), created)
 			require.Equal(t, first, stream.Labels)
 			require.Equal(t, "1", stream.Entries[0].Line)
+			return true
 		})
 
 		gotSecond := got[second.String()]
 		require.Equal(t, 1, gotSecond.StreamLen())
 		require.Equal(t, 1, gotSecond.EntryLen())
-		gotSecond.ConsumeStreams(func(stream Stream, created int64) {
+		gotSecond.ConsumeStreams(func(stream Stream, created int64) bool {
 			require.Equal(t, original.Created(), created)
 			require.Equal(t, second, stream.Labels)
 			require.Equal(t, "2", stream.Entries[0].Line)
+			return true
 		})
 	})
 
@@ -79,10 +81,11 @@ func TestShardingConsumer_Consume(t *testing.T) {
 		got := batches[0]
 		require.Equal(t, 1, got.StreamLen())
 		require.Equal(t, 2, got.EntryLen())
-		got.ConsumeStreams(func(stream Stream, _ int64) {
+		got.ConsumeStreams(func(stream Stream, _ int64) bool {
 			require.Equal(t, labels, stream.Labels)
 			require.Equal(t, "1", stream.Entries[0].Line)
 			require.Equal(t, "2", stream.Entries[1].Line)
+			return true
 		})
 	})
 

--- a/internal/component/common/loki/consumer_sharding_test.go
+++ b/internal/component/common/loki/consumer_sharding_test.go
@@ -42,21 +42,21 @@ func TestShardingConsumer_Consume(t *testing.T) {
 		gotFirst := got[first.String()]
 		require.Equal(t, 1, gotFirst.StreamLen())
 		require.Equal(t, 1, gotFirst.EntryLen())
-		gotFirst.ConsumeStreams(func(stream Stream, created int64) bool {
+		_ = gotFirst.ConsumeStreams(func(stream Stream, created int64) error {
 			require.Equal(t, original.Created(), created)
 			require.Equal(t, first, stream.Labels)
 			require.Equal(t, "1", stream.Entries[0].Line)
-			return true
+			return nil
 		})
 
 		gotSecond := got[second.String()]
 		require.Equal(t, 1, gotSecond.StreamLen())
 		require.Equal(t, 1, gotSecond.EntryLen())
-		gotSecond.ConsumeStreams(func(stream Stream, created int64) bool {
+		_ = gotSecond.ConsumeStreams(func(stream Stream, created int64) error {
 			require.Equal(t, original.Created(), created)
 			require.Equal(t, second, stream.Labels)
 			require.Equal(t, "2", stream.Entries[0].Line)
-			return true
+			return nil
 		})
 	})
 

--- a/internal/component/common/loki/consumer_sharding_test.go
+++ b/internal/component/common/loki/consumer_sharding_test.go
@@ -81,11 +81,11 @@ func TestShardingConsumer_Consume(t *testing.T) {
 		got := batches[0]
 		require.Equal(t, 1, got.StreamLen())
 		require.Equal(t, 2, got.EntryLen())
-		got.ConsumeStreams(func(stream Stream, _ int64) bool {
+		_ = got.ConsumeStreams(func(stream Stream, _ int64) error {
 			require.Equal(t, labels, stream.Labels)
 			require.Equal(t, "1", stream.Entries[0].Line)
 			require.Equal(t, "2", stream.Entries[1].Line)
-			return true
+			return nil
 		})
 	})
 

--- a/internal/component/common/loki/fanout.go
+++ b/internal/component/common/loki/fanout.go
@@ -2,6 +2,7 @@ package loki
 
 import (
 	"context"
+	"slices"
 	"sync"
 )
 
@@ -77,7 +78,7 @@ func (f *Fanout) SendBatch(ctx context.Context, batch []Entry) error {
 // UpdateChildren updates the list of receivers that will receive log entries.
 func (f *Fanout) UpdateChildren(children []LogsReceiver) {
 	f.mut.RLock()
-	if requireUpdate(f.children, children) {
+	if !slices.Equal(f.children, children) {
 		// Upgrade lock to write.
 		f.mut.RUnlock()
 		f.mut.Lock()

--- a/internal/component/loki/echo/echo.go
+++ b/internal/component/loki/echo/echo.go
@@ -110,6 +110,7 @@ func (c *Component) Consume(ctx context.Context, batch loki.Batch) error {
 	return nil
 }
 
+// TODO: Remove this when we have moved over to batching.
 func (c *Component) ConsumeEntry(ctx context.Context, entry loki.Entry) error {
 	structured_metadata, err := entry.StructuredMetadata.MarshalJSON()
 	if err != nil {

--- a/internal/component/loki/echo/echo.go
+++ b/internal/component/loki/echo/echo.go
@@ -96,7 +96,7 @@ func (c *Component) Update(args component.Arguments) error {
 }
 
 func (c *Component) Consume(ctx context.Context, batch loki.Batch) error {
-	batch.ConsumeStreams(func(stream loki.Stream, created int64) {
+	batch.ConsumeStreams(func(stream loki.Stream, created int64) bool {
 		logger := c.opts.Logger.With("labels", stream.Labels.String())
 		for _, e := range stream.Entries {
 			sm, err := e.StructuredMetadata.MarshalJSON()
@@ -106,6 +106,7 @@ func (c *Component) Consume(ctx context.Context, batch loki.Batch) error {
 			}
 			logger.Info("received log entry", "entry", e.Line, "entry_timestamp", e.Timestamp, "structured_metadata", string(sm))
 		}
+		return true
 	})
 	return nil
 }

--- a/internal/component/loki/echo/echo.go
+++ b/internal/component/loki/echo/echo.go
@@ -40,6 +40,7 @@ func (args *Arguments) SetToDefault() {
 }
 
 var (
+	_ loki.Consumer       = (*Component)(nil)
 	_ component.Component = (*Component)(nil)
 )
 
@@ -78,12 +79,7 @@ func (c *Component) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			return nil
 		case entry := <-c.receiver.Chan():
-			structured_metadata, err := entry.StructuredMetadata.MarshalJSON()
-			if err != nil {
-				c.opts.Logger.Error("failed to marshal structured metadata", "receiver", c.opts.ID, "error", err)
-				structured_metadata = []byte("{}")
-			}
-			c.opts.Logger.Info("received log entry", "receiver", c.opts.ID, "entry", entry.Line, "entry_timestamp", entry.Timestamp, "labels", entry.Labels.String(), "structured_metadata", string(structured_metadata))
+			_ = c.ConsumeEntry(ctx, entry)
 		}
 	}
 }
@@ -97,4 +93,33 @@ func (c *Component) Update(args component.Arguments) error {
 	c.args = newArgs
 
 	return nil
+}
+
+func (c *Component) Consume(ctx context.Context, batch loki.Batch) error {
+	batch.ConsumeStreams(func(stream loki.Stream, created int64) {
+		logger := c.opts.Logger.With("labels", stream.Labels.String())
+		for _, e := range stream.Entries {
+			sm, err := e.StructuredMetadata.MarshalJSON()
+			if err != nil {
+				logger.Error("failed to marshal structured metadata", "error", err)
+				sm = []byte("{}")
+			}
+			logger.Info("received log entry", "entry", e.Line, "entry_timestamp", e.Timestamp, "structured_metadata", string(sm))
+		}
+	})
+	return nil
+}
+
+func (c *Component) ConsumeEntry(ctx context.Context, entry loki.Entry) error {
+	structured_metadata, err := entry.StructuredMetadata.MarshalJSON()
+	if err != nil {
+		c.opts.Logger.Error("failed to marshal structured metadata", "error", err)
+		structured_metadata = []byte("{}")
+	}
+	c.opts.Logger.Info("received log entry", "entry", entry.Line, "entry_timestamp", entry.Timestamp, "labels", entry.Labels.String(), "structured_metadata", string(structured_metadata))
+	return nil
+}
+
+func (c *Component) String() string {
+	return c.opts.ID + ".receiver"
 }

--- a/internal/component/loki/echo/echo.go
+++ b/internal/component/loki/echo/echo.go
@@ -96,7 +96,7 @@ func (c *Component) Update(args component.Arguments) error {
 }
 
 func (c *Component) Consume(ctx context.Context, batch loki.Batch) error {
-	batch.ConsumeStreams(func(stream loki.Stream, created int64) bool {
+	return batch.ConsumeStreams(func(stream loki.Stream, created int64) error {
 		logger := c.opts.Logger.With("labels", stream.Labels.String())
 		for _, e := range stream.Entries {
 			sm, err := e.StructuredMetadata.MarshalJSON()
@@ -106,9 +106,8 @@ func (c *Component) Consume(ctx context.Context, batch loki.Batch) error {
 			}
 			logger.Info("received log entry", "entry", e.Line, "entry_timestamp", e.Timestamp, "structured_metadata", string(sm))
 		}
-		return true
+		return nil
 	})
-	return nil
 }
 
 // TODO: Remove this when we have moved over to batching.


### PR DESCRIPTION
### Brief description of Pull Request


### Pull Request Details

Extracted from https://github.com/grafana/alloy/pull/6204. Updating `loki.echo` to implement consumer interface. We still expose `LogsReceiver` through the pipeline.

### Issue(s) fixed by this Pull Request

Part of: https://github.com/grafana/alloy/issues/4953

### Notes to the Reviewer

Bring over changes that have to be made to `FanoutConsumer` and implementing `InterceptorConsumer`

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
