### PR TITLE
fix: Bump moduledeps fixtures to go 1.26.4

### DIFF
--- a/tools/generate/moduledeps/testdata/basic-mod/go.mod
+++ b/tools/generate/moduledeps/testdata/basic-mod/go.mod
@@ -1,3 +1,3 @@
 module test.example.com
 
-go 1.26.2
+go 1.26.4

--- a/tools/generate/moduledeps/testdata/basic-mod/go.mod.expected
+++ b/tools/generate/moduledeps/testdata/basic-mod/go.mod.expected
@@ -1,6 +1,6 @@
 module test.example.com
 
-go 1.26.2
+go 1.26.4
 
 // BEGIN GENERATED REPLACES - DO NOT EDIT MANUALLY
 // Test replace for example.com/package

--- a/tools/generate/moduledeps/testdata/update-existing-mod/go.mod
+++ b/tools/generate/moduledeps/testdata/update-existing-mod/go.mod
@@ -1,6 +1,6 @@
 module test.example.com
 
-go 1.26.2
+go 1.26.4
 
 // BEGIN GENERATED REPLACES - DO NOT EDIT MANUALLY
 // Old comment

--- a/tools/generate/moduledeps/testdata/update-existing-mod/go.mod.expected
+++ b/tools/generate/moduledeps/testdata/update-existing-mod/go.mod.expected
@@ -1,6 +1,6 @@
 module test.example.com
 
-go 1.26.2
+go 1.26.4
 
 // BEGIN GENERATED REPLACES - DO NOT EDIT MANUALLY
 // Updated replace


### PR DESCRIPTION
## Summary
- Update moduledeps test fixture `go.mod` files from `go 1.26.2` to `go 1.26.4` to address CVE-2026-42504.
- Update corresponding `go.mod.expected` fixture snapshots so moduledeps E2E assertions stay aligned.
- Confirm no remaining `1.26.2` references in repository `go.mod` files.

## Test plan
- [x] Run `go test ./...` in `tools/`