### PR TITLE
fix: Stabilize ServiceMonitor e2e target injection sequencing

### DIFF
--- a/internal/component/prometheus/operator/servicemonitors/servicemonitors_test.go
+++ b/internal/component/prometheus/operator/servicemonitors/servicemonitors_test.go
@@ -181,12 +181,21 @@ func TestServiceMonitorEndToEnd(t *testing.T) {
 			// registered Kubernetes SD-backed scrape config is brittle.
 			jobName := "serviceMonitor/monitoring/test-service-monitor/0"
 			require.Eventually(t, func() bool {
+				for _, name := range testFactory.GetScrapeConfigJobNames() {
+					if name == jobName {
+						return true
+					}
+				}
+				return false
+			}, 10*time.Second, 100*time.Millisecond, "Expected generated ServiceMonitor job to appear")
+
+			require.Eventually(t, func() bool {
 				ready, err := testFactory.InjectStaticTargets(jobName, serverAddr)
 				if err != nil {
 					return false
 				}
 				return ready
-			}, 5*time.Second, 100*time.Millisecond, "Expected static target injection to succeed")
+			}, 10*time.Second, 100*time.Millisecond, "Expected static target injection to succeed")
 
 			// Wait for metrics to be scraped and forwarded, then verify
 			require.EventuallyWithT(t, func(ct *assert.CollectT) {

--- a/internal/component/prometheus/operator/servicemonitors/servicemonitors_test.go
+++ b/internal/component/prometheus/operator/servicemonitors/servicemonitors_test.go
@@ -176,17 +176,17 @@ func TestServiceMonitorEndToEnd(t *testing.T) {
 				return testFactory.TriggerServiceMonitorAdd(serviceMonitor)
 			}, 10*time.Second, 100*time.Millisecond, "Timeout waiting for manager to be ready")
 
-			// Verify scrape config was registered
-			require.Eventually(t, func() bool {
-				jobNames := testFactory.GetScrapeConfigJobNames()
-				return len(jobNames) == 1
-			}, 5*time.Second, 100*time.Millisecond, "Expected 1 scrape config to be registered")
-
-			// Inject static targets (since k8s service discovery won't work without a real cluster)
+			// Inject static targets once the generated job is available.
+			// In CI there is no in-cluster Kubernetes config, so waiting for a fully
+			// registered Kubernetes SD-backed scrape config is brittle.
 			jobName := "serviceMonitor/monitoring/test-service-monitor/0"
-			ready, err := testFactory.InjectStaticTargets(jobName, serverAddr)
-			require.True(t, ready, "Manager should be ready after TriggerServiceMonitorAdd succeeded")
-			require.NoError(t, err)
+			require.Eventually(t, func() bool {
+				ready, err := testFactory.InjectStaticTargets(jobName, serverAddr)
+				if err != nil {
+					return false
+				}
+				return ready
+			}, 5*time.Second, 100*time.Millisecond, "Expected static target injection to succeed")
 
 			// Wait for metrics to be scraped and forwarded, then verify
 			require.EventuallyWithT(t, func(ct *assert.CollectT) {

--- a/internal/component/prometheus/operator/servicemonitors/servicemonitors_test.go
+++ b/internal/component/prometheus/operator/servicemonitors/servicemonitors_test.go
@@ -189,13 +189,11 @@ func TestServiceMonitorEndToEnd(t *testing.T) {
 				return false
 			}, 10*time.Second, 100*time.Millisecond, "Expected generated ServiceMonitor job to appear")
 
-			require.Eventually(t, func() bool {
+			require.EventuallyWithT(t, func(ct *assert.CollectT) {
 				ready, err := testFactory.InjectStaticTargets(jobName, serverAddr)
-				if err != nil {
-					return false
-				}
-				return ready
-			}, 10*time.Second, 100*time.Millisecond, "Expected static target injection to succeed")
+				assert.NoError(ct, err, "Expected static target injection to apply cleanly")
+				assert.True(ct, ready, "Expected static target injection to succeed")
+			}, 10*time.Second, 100*time.Millisecond)
 
 			// Wait for metrics to be scraped and forwarded, then verify
 			require.EventuallyWithT(t, func(ct *assert.CollectT) {

--- a/internal/component/prometheus/operator/servicemonitors/servicemonitors_test.go
+++ b/internal/component/prometheus/operator/servicemonitors/servicemonitors_test.go
@@ -176,9 +176,9 @@ func TestServiceMonitorEndToEnd(t *testing.T) {
 				return testFactory.TriggerServiceMonitorAdd(serviceMonitor)
 			}, 10*time.Second, 100*time.Millisecond, "Timeout waiting for manager to be ready")
 
-			// Inject static targets once the generated job is available.
-			// In CI there is no in-cluster Kubernetes config, so waiting for a fully
-			// registered Kubernetes SD-backed scrape config is brittle.
+			// This test intentionally uses a fake Kubernetes client and then injects
+			// static targets for scraping. The ServiceMonitor add path is asynchronous,
+			// so we first wait for the expected generated job and then inject targets.
 			jobName := "serviceMonitor/monitoring/test-service-monitor/0"
 			require.Eventually(t, func() bool {
 				for _, name := range testFactory.GetScrapeConfigJobNames() {


### PR DESCRIPTION
## Summary
**Problem**: This test is flaky due to async sequencing in the test: asserting an intermediate scrape-config state and attempting injection before the generated job was consistently available

**Solution**: stabilize the flow by waiting for the expected generated job (`serviceMonitor/monitoring/test-service-monitor/0`) and then waiting for successful `InjectStaticTargets`, which is the actual prerequisite for the scrape/forward assertions
