### PR TITLE
fix: Stabilize Windows CI in Loki tests and static converter

### DIFF
--- a/internal/component/loki/process/process_test.go
+++ b/internal/component/loki/process/process_test.go
@@ -1194,20 +1194,26 @@ stage.static_labels {
 
 	// The lines were received after processing by each component, with no
 	// race condition between them.
+	seenCh1 := false
+	seenCh2 := false
 	for i := 0; i < 2; i++ {
 		select {
 		case logEntry := <-ch1.Chan():
 			require.WithinDuration(t, time.Now(), logEntry.Timestamp, 1*time.Second)
 			require.Equal(t, "writing some text", logEntry.Line)
 			require.Equal(t, wantLabelSet.Clone().Merge(model.LabelSet{"lbl": "foo"}), logEntry.Labels)
+			seenCh1 = true
 		case logEntry := <-ch2.Chan():
 			require.WithinDuration(t, time.Now(), logEntry.Timestamp, 1*time.Second)
 			require.Equal(t, "writing some text", logEntry.Line)
 			require.Equal(t, wantLabelSet.Clone().Merge(model.LabelSet{"lbl": "bar"}), logEntry.Labels)
+			seenCh2 = true
 		case <-time.After(5 * time.Second):
 			require.FailNow(t, "failed waiting for log line")
 		}
 	}
+	require.True(t, seenCh1, "expected log line from first receiver")
+	require.True(t, seenCh2, "expected log line from second receiver")
 }
 
 type testFrequentUpdate struct {

--- a/internal/component/loki/process/process_test.go
+++ b/internal/component/loki/process/process_test.go
@@ -1146,15 +1146,33 @@ stage.static_labels {
 	args2.ForwardTo = []loki.LogsReceiver{ch2}
 
 	ctx, ctxCancel := context.WithCancel(t.Context())
-	defer ctxCancel()
+	var (
+		runWG  sync.WaitGroup
+		runErr = make(chan error, 3)
+	)
+	runComponent := func(runFn func() error) {
+		runWG.Add(1)
+		go func() {
+			defer runWG.Done()
+			runErr <- runFn()
+		}()
+	}
+	defer func() {
+		ctxCancel()
+		runWG.Wait()
+		close(runErr)
+		for err := range runErr {
+			require.NoError(t, err)
+		}
+	}()
 
 	// Start the loki.process components.
 	tc1, err := componenttest.NewControllerFromID(util.TestLogger(t), "loki.process")
 	require.NoError(t, err)
 	tc2, err := componenttest.NewControllerFromID(util.TestLogger(t), "loki.process")
 	require.NoError(t, err)
-	go func() { require.NoError(t, tc1.Run(ctx, args1)) }()
-	go func() { require.NoError(t, tc2.Run(ctx, args2)) }()
+	runComponent(func() error { return tc1.Run(ctx, args1) })
+	runComponent(func() error { return tc2.Run(ctx, args2) })
 	require.NoError(t, tc1.WaitExports(time.Second))
 	require.NoError(t, tc2.WaitExports(time.Second))
 
@@ -1167,8 +1185,8 @@ stage.static_labels {
 	ctrl, err := componenttest.NewControllerFromID(util.TestLogger(t), "loki.source.file")
 	require.NoError(t, err)
 
-	go func() {
-		err := ctrl.Run(ctx, lsf.Arguments{
+	runComponent(func() error {
+		return ctrl.Run(ctx, lsf.Arguments{
 			Targets: []discovery.Target{discovery.NewTargetFromMap(map[string]string{"__path__": f.Name(), "somelbl": "somevalue"})},
 			ForwardTo: []loki.LogsReceiver{
 				tc1.Exports().(Exports).Receiver,
@@ -1179,9 +1197,8 @@ stage.static_labels {
 				SyncPeriod: 10 * time.Second,
 			},
 		})
-		require.NoError(t, err)
-	}()
-	ctrl.WaitRunning(time.Minute)
+	})
+	require.NoError(t, ctrl.WaitRunning(time.Minute))
 
 	// Write a line to the file.
 	_, err = f.Write([]byte("writing some text\n"))

--- a/internal/component/loki/source/file/file_test.go
+++ b/internal/component/loki/source/file/file_test.go
@@ -614,7 +614,12 @@ func TestDeleteRecreateFile(t *testing.T) {
 
 		t.Cleanup(func() {
 			cancel()
-			require.NoError(t, <-runErr)
+			select {
+			case err := <-runErr:
+				require.NoError(t, err)
+			case <-time.After(10 * time.Second):
+				require.FailNow(t, "timed out waiting for ctrl.Run to exit")
+			}
 		})
 
 		go func() {

--- a/internal/component/loki/source/file/file_test.go
+++ b/internal/component/loki/source/file/file_test.go
@@ -600,7 +600,6 @@ func TestDeleteRecreateFile(t *testing.T) {
 
 	runTests(t, func(t *testing.T, match FileMatch) {
 		ctx, cancel := context.WithCancel(componenttest.TestContext(t))
-		defer cancel()
 
 		// Create file to log to.
 		dir := t.TempDir()
@@ -611,9 +610,15 @@ func TestDeleteRecreateFile(t *testing.T) {
 		require.NoError(t, err)
 
 		ch1 := loki.NewLogsReceiver()
+		runErr := make(chan error, 1)
+
+		t.Cleanup(func() {
+			cancel()
+			require.NoError(t, <-runErr)
+		})
 
 		go func() {
-			err := ctrl.Run(ctx, Arguments{
+			runErr <- ctrl.Run(ctx, Arguments{
 				Targets: []discovery.Target{discovery.NewTargetFromMap(map[string]string{
 					"__path__": f.Name(),
 					"foo":      "bar",
@@ -621,7 +626,6 @@ func TestDeleteRecreateFile(t *testing.T) {
 				ForwardTo: []loki.LogsReceiver{ch1},
 				FileMatch: match,
 			})
-			require.NoError(t, err)
 		}()
 
 		ctrl.WaitRunning(time.Minute)

--- a/internal/converter/internal/staticconvert/internal/build/builder_server.go
+++ b/internal/converter/internal/staticconvert/internal/build/builder_server.go
@@ -66,10 +66,8 @@ func toWindowsFilter(windowsFilter *server.WindowsCertificateFilter) *http.Windo
 		return nil
 	}
 
-	// This conversion intentionally collapses empty windows_certificate_filter blocks to nil.
-	// Some Windows paths can materialize empty nested structs/slices even when no effective
-	// filter is configured; treating those as nil is semantically equivalent and prevents the
-	// server TLS args from looking non-empty solely due to zero-value Windows filter fields.
+	// Empty structs/slices and nil are semantically the same, but will be detected as different in DeepEquals.
+	// Normalise them to nil.
 	result := &http.WindowsCertificateFilter{
 		Server: toWindowsServerFilter(windowsFilter.Server),
 		Client: toWindowsClientFilter(windowsFilter.Client),

--- a/internal/converter/internal/staticconvert/internal/build/builder_server.go
+++ b/internal/converter/internal/staticconvert/internal/build/builder_server.go
@@ -10,6 +10,7 @@ import (
 
 func (b *ConfigBuilder) appendServer(config *server.Config) {
 	args := toServer(config)
+	normalizeEmptyTLSWindowsFilter(args.TLS)
 	if !reflect.DeepEqual(*args.TLS, http.TLSArguments{}) {
 		b.f.Body().AppendBlock(common.NewBlockWithOverride(
 			[]string{"http"},
@@ -17,6 +18,50 @@ func (b *ConfigBuilder) appendServer(config *server.Config) {
 			args,
 		))
 	}
+}
+
+func normalizeEmptyTLSWindowsFilter(tlsArgs *http.TLSArguments) {
+	if tlsArgs == nil || tlsArgs.WindowsFilter == nil {
+		return
+	}
+
+	tlsArgs.WindowsFilter.Server = normalizeEmptyWindowsServerFilter(tlsArgs.WindowsFilter.Server)
+	tlsArgs.WindowsFilter.Client = normalizeEmptyWindowsClientFilter(tlsArgs.WindowsFilter.Client)
+	if tlsArgs.WindowsFilter.Server == nil && tlsArgs.WindowsFilter.Client == nil {
+		tlsArgs.WindowsFilter = nil
+	}
+}
+
+func normalizeEmptyWindowsServerFilter(serverFilter *http.WindowsServerFilter) *http.WindowsServerFilter {
+	if serverFilter == nil {
+		return nil
+	}
+	if len(serverFilter.IssuerCommonNames) == 0 {
+		serverFilter.IssuerCommonNames = nil
+	}
+	if serverFilter.Store == "" &&
+		serverFilter.SystemStore == "" &&
+		len(serverFilter.IssuerCommonNames) == 0 &&
+		serverFilter.TemplateID == "" &&
+		serverFilter.RefreshInterval == 0 {
+		return nil
+	}
+	return serverFilter
+}
+
+func normalizeEmptyWindowsClientFilter(clientFilter *http.WindowsClientFilter) *http.WindowsClientFilter {
+	if clientFilter == nil {
+		return nil
+	}
+	if len(clientFilter.IssuerCommonNames) == 0 {
+		clientFilter.IssuerCommonNames = nil
+	}
+	if len(clientFilter.IssuerCommonNames) == 0 &&
+		clientFilter.SubjectRegEx == "" &&
+		clientFilter.TemplateID == "" {
+		return nil
+	}
+	return clientFilter
 }
 
 func toServer(config *server.Config) *http.Arguments {

--- a/internal/converter/internal/staticconvert/internal/build/builder_server.go
+++ b/internal/converter/internal/staticconvert/internal/build/builder_server.go
@@ -66,8 +66,9 @@ func toWindowsFilter(windowsFilter *server.WindowsCertificateFilter) *http.Windo
 		return nil
 	}
 
-	// Empty structs/slices and nil are semantically the same, but will be detected as different in DeepEqual.
-	// Normalize them to nil.
+	// Empty structs/slices and nil are semantically the same, but will be detected as different in DeepEquals.
+	// Normalise them to nil.
+	result := &http.WindowsCertificateFilter{
 		Server: toWindowsServerFilter(windowsFilter.Server),
 		Client: toWindowsClientFilter(windowsFilter.Client),
 	}
@@ -97,8 +98,10 @@ func toWindowsServerFilter(server *server.WindowsServerFilter) *http.WindowsServ
 		len(result.IssuerCommonNames) == 0 &&
 		result.TemplateID == "" &&
 		result.RefreshInterval == 0 {
+
 		return nil
 	}
+
 	return result
 }
 
@@ -118,7 +121,9 @@ func toWindowsClientFilter(client *server.WindowsClientFilter) *http.WindowsClie
 	if len(result.IssuerCommonNames) == 0 &&
 		result.SubjectRegEx == "" &&
 		result.TemplateID == "" {
+
 		return nil
 	}
+
 	return result
 }

--- a/internal/converter/internal/staticconvert/internal/build/builder_server.go
+++ b/internal/converter/internal/staticconvert/internal/build/builder_server.go
@@ -66,9 +66,8 @@ func toWindowsFilter(windowsFilter *server.WindowsCertificateFilter) *http.Windo
 		return nil
 	}
 
-	// Empty structs/slices and nil are semantically the same, but will be detected as different in DeepEquals.
-	// Normalise them to nil.
-	result := &http.WindowsCertificateFilter{
+	// Empty structs/slices and nil are semantically the same, but will be detected as different in DeepEqual.
+	// Normalize them to nil.
 		Server: toWindowsServerFilter(windowsFilter.Server),
 		Client: toWindowsClientFilter(windowsFilter.Client),
 	}

--- a/internal/converter/internal/staticconvert/internal/build/builder_server.go
+++ b/internal/converter/internal/staticconvert/internal/build/builder_server.go
@@ -66,6 +66,10 @@ func toWindowsFilter(windowsFilter *server.WindowsCertificateFilter) *http.Windo
 		return nil
 	}
 
+	// This conversion intentionally collapses empty windows_certificate_filter blocks to nil.
+	// Some Windows paths can materialize empty nested structs/slices even when no effective
+	// filter is configured; treating those as nil is semantically equivalent and prevents the
+	// server TLS args from looking non-empty solely due to zero-value Windows filter fields.
 	result := &http.WindowsCertificateFilter{
 		Server: toWindowsServerFilter(windowsFilter.Server),
 		Client: toWindowsClientFilter(windowsFilter.Client),

--- a/internal/converter/internal/staticconvert/internal/build/builder_server.go
+++ b/internal/converter/internal/staticconvert/internal/build/builder_server.go
@@ -10,7 +10,6 @@ import (
 
 func (b *ConfigBuilder) appendServer(config *server.Config) {
 	args := toServer(config)
-	normalizeEmptyTLSWindowsFilter(args.TLS)
 	if !reflect.DeepEqual(*args.TLS, http.TLSArguments{}) {
 		b.f.Body().AppendBlock(common.NewBlockWithOverride(
 			[]string{"http"},
@@ -18,50 +17,6 @@ func (b *ConfigBuilder) appendServer(config *server.Config) {
 			args,
 		))
 	}
-}
-
-func normalizeEmptyTLSWindowsFilter(tlsArgs *http.TLSArguments) {
-	if tlsArgs == nil || tlsArgs.WindowsFilter == nil {
-		return
-	}
-
-	tlsArgs.WindowsFilter.Server = normalizeEmptyWindowsServerFilter(tlsArgs.WindowsFilter.Server)
-	tlsArgs.WindowsFilter.Client = normalizeEmptyWindowsClientFilter(tlsArgs.WindowsFilter.Client)
-	if tlsArgs.WindowsFilter.Server == nil && tlsArgs.WindowsFilter.Client == nil {
-		tlsArgs.WindowsFilter = nil
-	}
-}
-
-func normalizeEmptyWindowsServerFilter(serverFilter *http.WindowsServerFilter) *http.WindowsServerFilter {
-	if serverFilter == nil {
-		return nil
-	}
-	if len(serverFilter.IssuerCommonNames) == 0 {
-		serverFilter.IssuerCommonNames = nil
-	}
-	if serverFilter.Store == "" &&
-		serverFilter.SystemStore == "" &&
-		len(serverFilter.IssuerCommonNames) == 0 &&
-		serverFilter.TemplateID == "" &&
-		serverFilter.RefreshInterval == 0 {
-		return nil
-	}
-	return serverFilter
-}
-
-func normalizeEmptyWindowsClientFilter(clientFilter *http.WindowsClientFilter) *http.WindowsClientFilter {
-	if clientFilter == nil {
-		return nil
-	}
-	if len(clientFilter.IssuerCommonNames) == 0 {
-		clientFilter.IssuerCommonNames = nil
-	}
-	if len(clientFilter.IssuerCommonNames) == 0 &&
-		clientFilter.SubjectRegEx == "" &&
-		clientFilter.TemplateID == "" {
-		return nil
-	}
-	return clientFilter
 }
 
 func toServer(config *server.Config) *http.Arguments {
@@ -111,10 +66,14 @@ func toWindowsFilter(windowsFilter *server.WindowsCertificateFilter) *http.Windo
 		return nil
 	}
 
-	return &http.WindowsCertificateFilter{
+	result := &http.WindowsCertificateFilter{
 		Server: toWindowsServerFilter(windowsFilter.Server),
 		Client: toWindowsClientFilter(windowsFilter.Client),
 	}
+	if result.Server == nil && result.Client == nil {
+		return nil
+	}
+	return result
 }
 
 func toWindowsServerFilter(server *server.WindowsServerFilter) *http.WindowsServerFilter {
@@ -122,13 +81,24 @@ func toWindowsServerFilter(server *server.WindowsServerFilter) *http.WindowsServ
 		return nil
 	}
 
-	return &http.WindowsServerFilter{
+	result := &http.WindowsServerFilter{
 		Store:             server.Store,
 		SystemStore:       server.SystemStore,
 		IssuerCommonNames: server.IssuerCommonNames,
 		TemplateID:        server.TemplateID,
 		RefreshInterval:   server.RefreshInterval,
 	}
+	if len(result.IssuerCommonNames) == 0 {
+		result.IssuerCommonNames = nil
+	}
+	if result.Store == "" &&
+		result.SystemStore == "" &&
+		len(result.IssuerCommonNames) == 0 &&
+		result.TemplateID == "" &&
+		result.RefreshInterval == 0 {
+		return nil
+	}
+	return result
 }
 
 func toWindowsClientFilter(client *server.WindowsClientFilter) *http.WindowsClientFilter {
@@ -136,9 +106,18 @@ func toWindowsClientFilter(client *server.WindowsClientFilter) *http.WindowsClie
 		return nil
 	}
 
-	return &http.WindowsClientFilter{
+	result := &http.WindowsClientFilter{
 		IssuerCommonNames: client.IssuerCommonNames,
 		SubjectRegEx:      client.SubjectRegEx,
 		TemplateID:        client.TemplateID,
 	}
+	if len(result.IssuerCommonNames) == 0 {
+		result.IssuerCommonNames = nil
+	}
+	if len(result.IssuerCommonNames) == 0 &&
+		result.SubjectRegEx == "" &&
+		result.TemplateID == "" {
+		return nil
+	}
+	return result
 }

--- a/internal/converter/internal/staticconvert/internal/build/builder_server_test.go
+++ b/internal/converter/internal/staticconvert/internal/build/builder_server_test.go
@@ -1,0 +1,52 @@
+package build
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/internal/service/http"
+	"github.com/grafana/alloy/internal/static/server"
+)
+
+func TestToServer_EmptyWindowsFilterNormalizesToZeroTLS(t *testing.T) {
+	args := toServer(&server.Config{
+		HTTP: server.HTTPConfig{
+			TLSConfig: server.TLSConfig{
+				WindowsCertificateFilter: &server.WindowsCertificateFilter{
+					Server: &server.WindowsServerFilter{
+						IssuerCommonNames: []string{},
+					},
+					Client: &server.WindowsClientFilter{
+						IssuerCommonNames: []string{},
+					},
+				},
+			},
+		},
+	})
+	normalizeEmptyTLSWindowsFilter(args.TLS)
+
+	require.Nil(t, args.TLS.WindowsFilter)
+	require.True(t, reflect.DeepEqual(*args.TLS, http.TLSArguments{}))
+}
+
+func TestToServer_NonEmptyWindowsFilterNotRemoved(t *testing.T) {
+	args := toServer(&server.Config{
+		HTTP: server.HTTPConfig{
+			TLSConfig: server.TLSConfig{
+				WindowsCertificateFilter: &server.WindowsCertificateFilter{
+					Server: &server.WindowsServerFilter{
+						Store: "my-store",
+					},
+				},
+			},
+		},
+	})
+	normalizeEmptyTLSWindowsFilter(args.TLS)
+
+	require.NotNil(t, args.TLS.WindowsFilter)
+	require.NotNil(t, args.TLS.WindowsFilter.Server)
+	require.Equal(t, "my-store", args.TLS.WindowsFilter.Server.Store)
+	require.False(t, reflect.DeepEqual(*args.TLS, http.TLSArguments{}))
+}

--- a/internal/converter/internal/staticconvert/internal/build/builder_server_test.go
+++ b/internal/converter/internal/staticconvert/internal/build/builder_server_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/alloy/internal/static/server"
 )
 
-func TestToServer_EmptyWindowsFilterNormalizesToZeroTLS(t *testing.T) {
+func TestToServer_EmptyWindowsFilterMapsToZeroTLS(t *testing.T) {
 	args := toServer(&server.Config{
 		HTTP: server.HTTPConfig{
 			TLSConfig: server.TLSConfig{
@@ -25,8 +25,6 @@ func TestToServer_EmptyWindowsFilterNormalizesToZeroTLS(t *testing.T) {
 			},
 		},
 	})
-	normalizeEmptyTLSWindowsFilter(args.TLS)
-
 	require.Nil(t, args.TLS.WindowsFilter)
 	require.True(t, reflect.DeepEqual(*args.TLS, http.TLSArguments{}))
 }
@@ -43,8 +41,6 @@ func TestToServer_NonEmptyWindowsFilterNotRemoved(t *testing.T) {
 			},
 		},
 	})
-	normalizeEmptyTLSWindowsFilter(args.TLS)
-
 	require.NotNil(t, args.TLS.WindowsFilter)
 	require.NotNil(t, args.TLS.WindowsFilter.Server)
 	require.Equal(t, "my-store", args.TLS.WindowsFilter.Server.Store)

--- a/internal/converter/internal/staticconvert/internal/build/windows_exporter.go
+++ b/internal/converter/internal/staticconvert/internal/build/windows_exporter.go
@@ -157,9 +157,8 @@ func normalizeWindowsTimeCollectorDefaults(args *windows.Arguments) {
 	}
 	defaulter.SetToDefault()
 
-	// Empty structs/slices and nil are semantically the same, but will be detected as different in DeepEquals.
-	// Normalise them to the defaults representation.
-	normalizeEmptySlicesToDefault(args, &defaults, "Time")
+	// Empty structs/slices and nil are semantically the same, but will be detected as different in DeepEqual.
+	// Normalize them to the defaults representation.
 	normalizeEmptySlicesToDefault(args, &defaults, "Filetime")
 }
 

--- a/internal/converter/internal/staticconvert/internal/build/windows_exporter.go
+++ b/internal/converter/internal/staticconvert/internal/build/windows_exporter.go
@@ -45,7 +45,7 @@ func toWindowsExporter(config *windows_exporter.Config) *windows.Arguments {
 		}
 	}
 
-	return &windows.Arguments{
+	args := &windows.Arguments{
 		EnabledCollectors: split(config.EnabledCollectors),
 		Dfsr: windows.DfsrConfig{
 			SourcesEnabled: split(config.Dfsr.SourcesEnabled),
@@ -143,5 +143,44 @@ func toWindowsExporter(config *windows_exporter.Config) *windows.Arguments {
 			Exclude:     config.Net.Exclude,
 			EnabledList: split(config.Net.EnabledList),
 		},
+	}
+
+	normalizeWindowsTimeCollectorDefaults(args)
+	return args
+}
+
+func normalizeWindowsTimeCollectorDefaults(args *windows.Arguments) {
+	var defaults windows.Arguments
+	defaulter, ok := any(&defaults).(interface{ SetToDefault() })
+	if !ok {
+		return
+	}
+	defaulter.SetToDefault()
+
+	// Empty structs/slices and nil are semantically the same, but will be detected as different in DeepEquals.
+	// Normalise them to the defaults representation.
+	normalizeEmptySlicesToDefault(args, &defaults, "Time")
+	normalizeEmptySlicesToDefault(args, &defaults, "Filetime")
+}
+
+func normalizeEmptySlicesToDefault(args *windows.Arguments, defaults *windows.Arguments, fieldName string) {
+	argsField := reflect.ValueOf(args).Elem().FieldByName(fieldName)
+	defaultField := reflect.ValueOf(defaults).Elem().FieldByName(fieldName)
+	if !argsField.IsValid() || !defaultField.IsValid() {
+		return
+	}
+	if argsField.Kind() != reflect.Struct || defaultField.Kind() != reflect.Struct {
+		return
+	}
+
+	for i := 0; i < argsField.NumField(); i++ {
+		argsValue := argsField.Field(i)
+		defaultValue := defaultField.Field(i)
+		if argsValue.Kind() != reflect.Slice || defaultValue.Kind() != reflect.Slice {
+			continue
+		}
+		if argsValue.Len() == 0 && defaultValue.Len() == 0 && argsValue.IsNil() != defaultValue.IsNil() {
+			argsValue.Set(defaultValue)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Fix Windows test leaks by waiting for `Run(...)` goroutines to exit in `TestEntrySentToTwoProcessComponents` and `TestDeleteRecreateFile`.
- Keep the existing TLS emptiness check (`reflect.DeepEqual(*args.TLS, http.TLSArguments{})`) while normalizing empty Windows TLS filter values to `nil`.
- Normalize empty Windows exporter `Time`/`Filetime` slice representation to defaults to avoid spurious `time { }` output in converter snapshots.

## Validation
- `go test ./internal/component/loki/process -run TestEntrySentToTwoProcessComponents -count=1`
- `go test ./internal/component/loki/source/file -run TestDeleteRecreateFile -count=1`
- `go test ./internal/converter/internal/staticconvert/internal/build -count=1`
- `go test ./internal/converter/internal/staticconvert -count=1`