### PR TITLE
feat(syntax): Add array.get function to safely index arrays with fallbacks

### DIFF
--- a/syntax/internal/stdlib/stdlib.go
+++ b/syntax/internal/stdlib/stdlib.go
@@ -205,10 +205,50 @@ var groupBy = value.RawFunction(func(funcValue value.Value, args ...value.Value)
 	return value.Array(result...), nil
 })
 
+// get returns the element at the specified index of the array, or the fallback value if the index is out of bounds.
+var get = value.RawFunction(func(funcValue value.Value, args ...value.Value) (value.Value, error) {
+	if len(args) != 3 {
+		return value.Null, fmt.Errorf("array.get: expected 3 arguments, got %d", len(args))
+	}
+
+	if args[0].Type() != value.TypeArray {
+		return value.Null, value.ArgError{
+			Function: funcValue,
+			Argument: args[0],
+			Index:    0,
+			Inner: value.TypeError{
+				Value:    args[0],
+				Expected: value.TypeArray,
+			},
+		}
+	}
+
+	if args[1].Type() != value.TypeNumber {
+		return value.Null, value.ArgError{
+			Function: funcValue,
+			Argument: args[1],
+			Index:    1,
+			Inner: value.TypeError{
+				Value:    args[1],
+				Expected: value.TypeNumber,
+			},
+		}
+	}
+
+	idx := int(args[1].Int())
+	arr := args[0]
+	if idx < 0 || idx >= arr.Len() {
+		return args[2], nil
+	}
+
+	return arr.Index(idx), nil
+})
+
 var array = map[string]any{
 	"concat":       concat,
 	"combine_maps": combineMaps,
 	"group_by":     groupBy,
+	"get":          get,
 }
 
 var convert = map[string]any{

--- a/syntax/vm/vm_stdlib_test.go
+++ b/syntax/vm/vm_stdlib_test.go
@@ -154,6 +154,12 @@ func TestVM_Stdlib(t *testing.T) {
 				{"a": 1, "n": 2.1}, {"a": 1, "n": 2.2}, {"a": 1, "n": 2.3},
 			},
 		},
+		{"array.get within bounds", `array.get(["foo", "bar"], 0, "fallback")`, string("foo")},
+		{"array.get within bounds 2", `array.get(["foo", "bar"], 1, "fallback")`, string("bar")},
+		{"array.get out of bounds", `array.get(["foo", "bar"], 2, "fallback")`, string("fallback")},
+		{"array.get negative index", `array.get(["foo", "bar"], -1, "fallback")`, string("fallback")},
+		{"array.get empty array", `array.get([], 0, "fallback")`, string("fallback")},
+		{"array.get object fallback", `array.get([], 0, {"__address__" = "localhost:3100"}).__address__`, string("localhost:3100")},
 	}
 
 	for _, tc := range tt {
@@ -198,6 +204,16 @@ func TestVM_Stdlib_Errors(t *testing.T) {
 			"encoding.to_json",
 			`encoding.to_json(12)`,
 			`encoding.to_json jsonEncode only supports map`,
+		},
+		{
+			"array.get type error array",
+			`array.get("not array", 0, "fallback")`,
+			`"not array" should be array, got string`,
+		},
+		{
+			"array.get type error index",
+			`array.get(["foo"], "not number", "fallback")`,
+			`"not number" should be number, got string`,
 		},
 	}
 


### PR DESCRIPTION
### Purpose
Resolves #6372. Allows `loki.write` (and other write components) to dynamically resolve Loki's backend address via Consul service discovery without failing config load or starting up with index-out-of-bounds errors when no targets are found at startup.

### Description
Since Alloy evaluates expressions strictly at startup, direct indexing like `discovery.consul.loki_discovery.targets[0]` triggers an index out of bounds error before service discovery runs. Short-circuiting functions like `coalesce` cannot prevent this.

We introduce `array.get(arr, index, fallback)` to the `array` standard library namespace. This function safely accesses list elements by returning the provided fallback value if the index is out of range. 

Users can now write:
```alloy
loki.write "default" {
    endpoint {
        url = "http://" + array.get(discovery.consul.loki_discovery.targets, 0, {"__address__" = "localhost:3100"}).__address__ + "/loki/api/v1/push"
    }
}
