### PR TITLE
refactor(http): Make the /-/healthy endpoint suitable for liveness probes

### DIFF
--- a/docs/sources/reference/http/_index.md
+++ b/docs/sources/reference/http/_index.md
@@ -26,28 +26,17 @@ Otherwise, if the instance isn't ready, the `/-/ready` endpoint returns `HTTP 50
 
 ## `/-/healthy`
 
-When all {{< param "PRODUCT_NAME" >}} components are working correctly, all components are considered healthy.
-If all components are healthy, the `/-/healthy` endpoint returns `HTTP 200 OK` and the message `All Alloy components are healthy.`.
-Otherwise, if any of the components aren't working correctly, the `/-/healthy` endpoint returns `HTTP 500 Internal Server Error` and an error message.
-You can also monitor component health through the {{< param "PRODUCT_NAME" >}} [UI](../../troubleshoot/debug#alloy-ui).
+The `/-/healthy` endpoint returns `HTTP 200 OK` and the message `Alloy is healthy.` to indicate that the {{< param "PRODUCT_NAME" >}} instance is running.
 
 ```shell
 curl localhost:12345/-/healthy
-All Alloy components are healthy.
-```
-
-```shell
-curl localhost:12345/-/healthy
-unhealthy components: math.add
+Alloy is healthy.
 ```
 
 {{< admonition type="note" >}}
-The `/-/healthy` endpoint isn't suitable for a [Kubernetes liveness probe][k8s-liveness].
+The `/-/healthy` endpoint is suitable for a [Kubernetes liveness probe][k8s-liveness] to verify that the {{< param "PRODUCT_NAME" >}} process is alive and responsive.
 
-You don't necessarily need to restart an {{< param "PRODUCT_NAME" >}} instance that reports as unhealthy.
-For example, a component may be unhealthy due to an invalid configuration or an unavailable external resource.
-In this case, restarting {{< param "PRODUCT_NAME" >}} would not fix the problem.
-A restart may make it worse, because it would stop the flow of telemetry in healthy pipelines.
+Note that this endpoint only reflects the health of the {{< param "PRODUCT_NAME" >}} process itself, not individual internal components. Individual components can be monitored through the {{< param "PRODUCT_NAME" >}} [UI](../../troubleshoot/debug#alloy-ui) or via the `/metrics` endpoint (using `alloy_component_controller_running_components` with the `health_type` label).
 
 [k8s-liveness]: https://kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/
 {{< /admonition >}}

--- a/internal/service/http/http.go
+++ b/internal/service/http/http.go
@@ -213,27 +213,8 @@ func (s *Service) Run(ctx context.Context, host service.Host) error {
 	// The implementation for "/-/healthy" is inspired by
 	// the "/components" web API endpoint in /internal/web/api/api.go
 	r.HandleFunc("/-/healthy", func(w http.ResponseWriter, r *http.Request) {
-		components, err := host.ListComponents("", component.InfoOptions{
-			GetHealth: true,
-		})
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		unhealthyComponents := []string{}
-		for _, c := range components {
-			if c.Health.Health == component.HealthTypeUnhealthy {
-				unhealthyComponents = append(unhealthyComponents, c.ComponentName)
-			}
-		}
-		if len(unhealthyComponents) > 0 {
-			http.Error(w, "unhealthy components: "+strings.Join(unhealthyComponents, ", "), http.StatusInternalServerError)
-			return
-		}
-
 		w.WriteHeader(http.StatusOK)
-		_, _ = fmt.Fprintln(w, "All Alloy components are healthy.")
+		_, _ = fmt.Fprintln(w, "Alloy is healthy.")
 	})
 
 	r.Handle(

--- a/internal/service/http/http_test.go
+++ b/internal/service/http/http_test.go
@@ -64,7 +64,7 @@ func TestHTTP(t *testing.T) {
 
 		buf, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
-		require.Equal(t, "All Alloy components are healthy.\n", string(buf))
+		require.Equal(t, "Alloy is healthy.\n", string(buf))
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 	})
@@ -325,9 +325,9 @@ func TestUnhealthy(t *testing.T) {
 
 		buf, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
-		require.Equal(t, "unhealthy components: testCompName\n", string(buf))
+		require.Equal(t, "Alloy is healthy.\n", string(buf))
 
-		require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 }
 


### PR DESCRIPTION
### Purpose
Resolves #6340 by changing the `/-/healthy` HTTP endpoint behavior to always return `HTTP 200 OK` once Alloy is running.

### Background
Currently, the `/-/healthy` endpoint checks all internal components and returns `HTTP 500` if any component reports as unhealthy. This makes the endpoint unsuitable for Kubernetes liveness probes, as restarting Alloy does not fix common component-level failures (such as configuration errors or temporary unavailability of external backends). In fact, restarts can worsen issues by interrupting other healthy pipelines.

### Changes
- Updated `/-/healthy` in `internal/service/http/http.go` to return `HTTP 200 OK` with "Alloy is healthy." without performing component health checks.
- Updated `TestHTTP` and `TestUnhealthy` in `internal/service/http/http_test.go` to expect the new behavior and status code.
- Updated documentation in `docs/sources/reference/http/_index.md` to state that the endpoint is suitable for liveness probes to verify process status, and added notes on monitoring individual components via the UI or metrics.
