### PR TITLE
chore: Fix deploy preview workflow

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   deploy-pr-preview:
     if: "!github.event.pull_request.head.repo.fork"
-    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@e667b04447898008113abb9d79020ca38059ca41 # main
+    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main # zizmor: ignore[unpinned-uses]
     # ^ We can't pin a hash for this action because deploy-preview's checkout step relies on it
     # having been called against the main branch
     permissions:


### PR DESCRIPTION
This working stopped working after https://github.com/grafana/alloy/pull/6446 was merged.