### PR TITLE
fix(promethues.exporter.mongodb): Add currentop_slow_time argument

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.exporter.mongodb.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.mongodb.md
@@ -34,26 +34,27 @@ prometheus.exporter.mongodb "<LABEL>" {
 
 You can use the following arguments with `prometheus.exporter.mongodb`:
 
-| Name                           | Type     | Description                                                                                                                            | Default | Required |
-| ------------------------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------- | -------- |
-| `mongodb_uri`                  | `secret` | MongoDB node connection URI.                                                                                                           |         | yes      |
-| `collect_all`                  | `bool`   | Enables all collectors.                                                                                                                | `true`  | no       |
-| `compatible_mode`              | `bool`   | Enables metric names compatible with `mongodb_exporter` <v0.20.0.                                                                      | `true`  | no       |
-| `direct_connect`               | `bool`   | Whether or not a direct connect should be made. Direct connections aren't valid if multiple hosts are specified or an SRV URI is used. | `false` | no       |
-| `discovering_mode`             | `bool`   | Whether or not to enable autodiscover collections.                                                                                     | `false` | no       |
-| `enable_coll_stats`            | `bool`   | Enables collecting collection statistics.                                                                                              | `false` | no       |
-| `enable_currentop_metrics`     | `bool`   | Enables collecting current operation metrics.                                                                                          | `false` | no       |
-| `enable_db_stats_free_storage` | `bool`   | Enables collecting free storage statistics from `dbStats`.                                                                             | `false` | no       |
-| `enable_db_stats`              | `bool`   | Enables collecting database statistics.                                                                                                | `false` | no       |
-| `enable_diagnostic_data`       | `bool`   | Enables collecting diagnostic data.                                                                                                    | `false` | no       |
-| `enable_fcv`                   | `bool`   | Enables collecting Feature Compatibility Version (FCV) metrics.                                                                        | `false` | no       |
-| `enable_index_stats`           | `bool`   | Enables collecting index statistics.                                                                                                   | `false` | no       |
-| `enable_pbm_metrics`           | `bool`   | Enables collecting Percona Backup for MongoDB (PBM) metrics.                                                                           | `false` | no       |
-| `enable_profile`               | `bool`   | Enables collecting profile metrics.                                                                                                    | `false` | no       |
-| `enable_replicaset_config`     | `bool`   | Enables collecting replica set configuration.                                                                                          | `false` | no       |
-| `enable_replicaset_status`     | `bool`   | Enables collecting replica set status.                                                                                                 | `false` | no       |
-| `enable_shards`                | `bool`   | Enables collecting sharding information.                                                                                               | `false` | no       |
-| `enable_top_metrics`           | `bool`   | Enables collecting top metrics.                                                                                                        | `false` | no       |
+| Name                           | Type       | Description                                                                                                                            | Default | Required |
+| ------------------------------ | ---------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------- | -------- |
+| `mongodb_uri`                  | `secret`   | MongoDB node connection URI.                                                                                                           |         | yes      |
+| `collect_all`                  | `bool`     | Enables all collectors.                                                                                                                | `true`  | no       |
+| `compatible_mode`              | `bool`     | Enables metric names compatible with `mongodb_exporter` <v0.20.0.                                                                      | `true`  | no       |
+| `currentop_slow_time`          | `duration` | Minimum running time of an operation before it's reported by the currentop collector.                                                  | `"1m"`  | no       |
+| `direct_connect`               | `bool`     | Whether or not a direct connect should be made. Direct connections aren't valid if multiple hosts are specified or an SRV URI is used. | `false` | no       |
+| `discovering_mode`             | `bool`     | Whether or not to enable autodiscover collections.                                                                                     | `false` | no       |
+| `enable_coll_stats`            | `bool`     | Enables collecting collection statistics.                                                                                              | `false` | no       |
+| `enable_currentop_metrics`     | `bool`     | Enables collecting current operation metrics.                                                                                          | `false` | no       |
+| `enable_db_stats_free_storage` | `bool`     | Enables collecting free storage statistics from `dbStats`.                                                                             | `false` | no       |
+| `enable_db_stats`              | `bool`     | Enables collecting database statistics.                                                                                                | `false` | no       |
+| `enable_diagnostic_data`       | `bool`     | Enables collecting diagnostic data.                                                                                                    | `false` | no       |
+| `enable_fcv`                   | `bool`     | Enables collecting Feature Compatibility Version (FCV) metrics.                                                                        | `false` | no       |
+| `enable_index_stats`           | `bool`     | Enables collecting index statistics.                                                                                                   | `false` | no       |
+| `enable_pbm_metrics`           | `bool`     | Enables collecting Percona Backup for MongoDB (PBM) metrics.                                                                           | `false` | no       |
+| `enable_profile`               | `bool`     | Enables collecting profile metrics.                                                                                                    | `false` | no       |
+| `enable_replicaset_config`     | `bool`     | Enables collecting replica set configuration.                                                                                          | `false` | no       |
+| `enable_replicaset_status`     | `bool`     | Enables collecting replica set status.                                                                                                 | `false` | no       |
+| `enable_shards`                | `bool`     | Enables collecting sharding information.                                                                                               | `false` | no       |
+| `enable_top_metrics`           | `bool`     | Enables collecting top metrics.                                                                                                        | `false` | no       |
 
 MongoDB node connection URI must be in the [`Standard Connection String Format`](https://docs.mongodb.com/manual/reference/connection-string/#std-label-connections-standard-connection-string-format)
 

--- a/internal/component/prometheus/exporter/mongodb/mongodb.go
+++ b/internal/component/prometheus/exporter/mongodb/mongodb.go
@@ -1,6 +1,8 @@
 package mongodb
 
 import (
+	"time"
+
 	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/component/prometheus/exporter"
 	"github.com/grafana/alloy/internal/featuregate"
@@ -33,6 +35,7 @@ type Arguments struct {
 	CollectAll               bool              `alloy:"collect_all,attr,optional"`
 	DirectConnect            bool              `alloy:"direct_connect,attr,optional"`
 	DiscoveringMode          bool              `alloy:"discovering_mode,attr,optional"`
+	CurrentopSlowTime        time.Duration     `alloy:"currentop_slow_time,attr,optional"`
 	EnableDBStats            bool              `alloy:"enable_db_stats,attr,optional"`
 	EnableDBStatsFreeStorage bool              `alloy:"enable_db_stats_free_storage,attr,optional"`
 	EnableDiagnosticData     bool              `alloy:"enable_diagnostic_data,attr,optional"`
@@ -55,6 +58,7 @@ func (a *Arguments) Convert() *mongodb_exporter.Config {
 		CollectAll:               a.CollectAll,
 		DirectConnect:            a.DirectConnect,
 		DiscoveringMode:          a.DiscoveringMode,
+		CurrentopSlowTime:        a.CurrentopSlowTime,
 		EnableDBStats:            a.EnableDBStats,
 		EnableDBStatsFreeStorage: a.EnableDBStatsFreeStorage,
 		EnableDiagnosticData:     a.EnableDiagnosticData,
@@ -77,6 +81,8 @@ func (a *Arguments) SetToDefault() {
 	a.CompatibleMode = true
 	a.CollectAll = true
 	a.DiscoveringMode = false
+	// Same default as upstream collector https://github.com/percona/mongodb_exporter/blob/43a703c25d752b910e4457428a0cded0f9c5962d/main.go#L80
+	a.CurrentopSlowTime = 1 * time.Minute
 	a.EnableDBStats = false
 	a.EnableDBStatsFreeStorage = false
 	a.EnableDiagnosticData = false

--- a/internal/component/prometheus/exporter/mongodb/mongodb_test.go
+++ b/internal/component/prometheus/exporter/mongodb/mongodb_test.go
@@ -2,6 +2,7 @@ package mongodb
 
 import (
 	"testing"
+	"time"
 
 	"github.com/grafana/alloy/internal/static/integrations/mongodb_exporter"
 	"github.com/grafana/alloy/syntax"
@@ -20,11 +21,12 @@ func TestAlloyUnmarshal(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := Arguments{
-		URI:             "mongodb://127.0.0.1:27017",
-		DirectConnect:   true,
-		DiscoveringMode: true,
-		CompatibleMode:  true,
-		CollectAll:      true,
+		URI:               "mongodb://127.0.0.1:27017",
+		CurrentopSlowTime: 1 * time.Minute,
+		DirectConnect:     true,
+		DiscoveringMode:   true,
+		CompatibleMode:    true,
+		CollectAll:        true,
 	}
 
 	require.Equal(t, expected, args)
@@ -43,11 +45,12 @@ func TestConvert(t *testing.T) {
 	res := args.Convert()
 
 	expected := mongodb_exporter.Config{
-		URI:             "mongodb://127.0.0.1:27017",
-		DirectConnect:   true,
-		DiscoveringMode: true,
-		CompatibleMode:  true,
-		CollectAll:      true,
+		URI:               "mongodb://127.0.0.1:27017",
+		CurrentopSlowTime: 1 * time.Minute,
+		DirectConnect:     true,
+		DiscoveringMode:   true,
+		CompatibleMode:    true,
+		CollectAll:        true,
 	}
 	require.Equal(t, expected, *res)
 }

--- a/internal/converter/internal/staticconvert/internal/build/mongodb_exporter.go
+++ b/internal/converter/internal/staticconvert/internal/build/mongodb_exporter.go
@@ -1,6 +1,8 @@
 package build
 
 import (
+	"time"
+
 	"github.com/grafana/alloy/internal/component/discovery"
 	"github.com/grafana/alloy/internal/component/prometheus/exporter/mongodb"
 	"github.com/grafana/alloy/internal/static/integrations/mongodb_exporter"
@@ -19,6 +21,7 @@ func toMongodbExporter(config *mongodb_exporter.Config) *mongodb.Arguments {
 		CollectAll:               config.CollectAll,
 		DirectConnect:            config.DirectConnect,
 		DiscoveringMode:          config.DiscoveringMode,
+		CurrentopSlowTime:        1 * time.Minute,
 		EnableDBStats:            config.EnableDBStats,
 		EnableDBStatsFreeStorage: config.EnableDBStatsFreeStorage,
 		EnableDiagnosticData:     config.EnableDiagnosticData,

--- a/internal/static/integrations/mongodb_exporter/mongodb_exporter.go
+++ b/internal/static/integrations/mongodb_exporter/mongodb_exporter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"time"
 
 	"github.com/percona/mongodb_exporter/exporter"
 	config_util "github.com/prometheus/common/config"
@@ -19,6 +20,7 @@ var DefaultConfig = Config{
 	CollectAll:               true,
 	DirectConnect:            true,
 	DiscoveringMode:          true,
+	CurrentopSlowTime:        1 * time.Minute,
 	EnableDBStats:            false,
 	EnableDBStatsFreeStorage: false,
 	EnableDiagnosticData:     false,
@@ -48,6 +50,7 @@ type Config struct {
 	EnableReplicasetStatus   bool               `yaml:"enable_replicaset_status,omitempty"`
 	EnableReplicasetConfig   bool               `yaml:"enable_replicaset_config,omitempty"`
 	EnableCurrentopMetrics   bool               `yaml:"enable_currentop_metrics,omitempty"`
+	CurrentopSlowTime        time.Duration      `yaml:"currentop_slow_time,omitempty"`
 	EnableTopMetrics         bool               `yaml:"enable_top_metrics,omitempty"`
 	EnableIndexStats         bool               `yaml:"enable_index_stats,omitempty"`
 	EnableCollStats          bool               `yaml:"enable_coll_stats,omitempty"`
@@ -91,11 +94,11 @@ func init() {
 // New creates a new mongodb_exporter integration.
 func New(logger *slog.Logger, c *Config) (integrations.Integration, error) {
 	exp := exporter.New(&exporter.Opts{
-		URI:                    string(c.URI),
-		Logger:                 logger,
-		DisableDefaultRegistry: true,
-
+		URI:                      string(c.URI),
+		Logger:                   logger,
+		DisableDefaultRegistry:   true,
 		CompatibleMode:           c.CompatibleMode,
+		CurrentOpSlowTime:        c.CurrentopSlowTime.String(),
 		CollectAll:               c.CollectAll,
 		DirectConnect:            c.DirectConnect,
 		DiscoveringMode:          c.DiscoveringMode,


### PR DESCRIPTION
### Pull Request Details
As pointed out by the issue it's currently impossible to run currentop collector since we never set slow time. 

### Issue(s) fixed by this Pull Request

Fixes: #6516

### Notes to the Reviewer

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
