### PR TITLE
fix(ci): Only stamp BuildDate for release builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,15 +151,20 @@ BEYLA_VERSION := $(shell echo $(BEYLA_MODULE) | cut -d' ' -f2)
 BEYLA_PKG     := $(shell echo $(BEYLA_MODULE) | cut -d' ' -f1)/pkg/buildinfo
 VPREFIX      := github.com/grafana/alloy/internal/build
 VPREFIXSYNTAX := github.com/grafana/alloy/syntax/internal/stdlib
+# Allow the Go build cache to be used except when doing a release build or when
+# an epoch is explicitly set. BuildDate otherwise changes on every invocation,
+# which busts the cache and forces a relink on every local build.
 ifdef SOURCE_DATE_EPOCH
-    DATE_STAMP = -d@$(SOURCE_DATE_EPOCH)
+    BUILD_DATE = $(shell date -u -d@$(SOURCE_DATE_EPOCH) +"%Y-%m-%dT%H:%M:%SZ")
+else ifeq ($(RELEASE_BUILD),1)
+    BUILD_DATE = $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 endif
 GO_LDFLAGS   := -X $(VPREFIX).Branch=$(GIT_BRANCH)                        \
                 -X $(VPREFIX).Version=$(VERSION)                          \
 		-X $(VPREFIXSYNTAX).Version=$(VERSION)                    \
                 -X $(VPREFIX).Revision=$(GIT_REVISION)                    \
                 -X $(VPREFIX).BuildUser=$(BUILDER_USER)@$(BUILDER_HOST) \
-                -X $(VPREFIX).BuildDate=$(shell date -u $(DATE_STAMP) +"%Y-%m-%dT%H:%M:%SZ") \
+                -X $(VPREFIX).BuildDate=$(BUILD_DATE) \
                 -X $(BEYLA_PKG).Version=$(BEYLA_VERSION)
 
 DEFAULT_FLAGS    := $(GO_FLAGS)


### PR DESCRIPTION
## What this does

The BuildDate linker flag is derived from the current time, so it changes on
every build. Because the value is different each time, the Go build cache is
invalidated and the binary is relinked on every local build even when nothing
else changed. This was raised in #4266.

This change computes BuildDate only when it is actually needed:

- Release builds (RELEASE_BUILD=1) stamp the current time, as before.
- Reproducible builds via SOURCE_DATE_EPOCH stamp the pinned time, as before.
- Local development builds leave it empty, so repeated builds stay cached and
  skip the relink.

The SOURCE_DATE_EPOCH path keeps the exact same date invocation as before, so
reproducible builds are unaffected.

## Why empty is fine for dev builds

BuildDate is a plain string passed through to the Prometheus version package.
An empty value simply renders as an empty build date in `alloy --version`; it
is not parsed and does not affect runtime behavior.

## Verification

Built the collector binary locally with the resulting dev-mode flags and
confirmed the build cache behavior:

- Rebuild with the empty (constant) BuildDate: 0 link invocations (cache hit).
- Rebuild changing only BuildDate: 1 link invocation (forced relink), which is
  the current behavior the issue describes.

Also confirmed the binary builds and runs with an empty BuildDate, and that
RELEASE_BUILD=1 still stamps the build time.

Fixes #4266
