### PR TITLE
fix: Skip noop error log at collector registration

### DIFF
--- a/internal/service/remotecfg/remotecfg.go
+++ b/internal/service/remotecfg/remotecfg.go
@@ -323,7 +323,7 @@ func (s *Service) registerCollector() error {
 		},
 	})
 
-	if err != nil {
+	if err != nil && !errors.Is(err, errNoopClient) {
 		s.opts.Logger.Error("failed to register collector with remote server", "id", s.args.ID, "name", s.args.Name, "err", err)
 		return err
 	}


### PR DESCRIPTION
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style with a capitalized
  description, e.g. `feat(scope): Add the thing` (not `add the thing`). For
  details on this, check out the Contributors Guide linked above.
-->

### Brief description of Pull Request

fix: Skip error log at collector registration when remotecfg is not used 

### Pull Request Details

Every time Alloy is started and remotecfg is not configured, the logs show:

```
ts=2026-06-18T10:51:37.401933675Z level=error msg="failed to register collector with remote server" service=remotecfg id=6f26cb90-4e78-43c5-b13e-31ef401e3bdb name="" err="noop client"
```


### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->


### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->

This PR is a startup follow-up to the shutdown work done previously:

- #6483


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
