### PR TITLE
feat: Add helm option for the Beyla Kubernetes SDK injection controller

### DIFF
--- a/operations/helm/charts/alloy/README.md
+++ b/operations/helm/charts/alloy/README.md
@@ -181,6 +181,7 @@ useful if just using the default DaemonSet isn't sufficient.
 | rbac.rules[6] | object | `{"apiGroups":[""],"resources":["events"],"verbs":["get","list","watch"]}` | Rules required for the `loki.source.kubernetes_events` component. |
 | rbac.rules[7] | object | `{"apiGroups":[""],"resources":["configmaps","secrets"],"verbs":["get","list","watch"]}` | Rules required for the `remote.kubernetes.*` components. |
 | rbac.rules[8] | object | `{"apiGroups":["apps","extensions"],"resources":["replicasets"],"verbs":["get","list","watch"]}` | Rules required for the `otelcol.processor.k8sattributes` component. |
+| sdkInjectionController.enabled | bool | `false` | Whether to create RBAC resources for the Beyla Kubernetes SDK injection controller. When enabled, Alloy can get, create, and update ConfigMaps in its deployment namespace. |
 | service.annotations | object | `{}` |  |
 | service.clusterIP | string | `""` | Cluster IP, can be set to None, empty "" or an IP address |
 | service.enabled | bool | `true` | Creates a Service for the controller's pods. |

--- a/operations/helm/charts/alloy/ci/sdk-injection-controller-values.yaml
+++ b/operations/helm/charts/alloy/ci/sdk-injection-controller-values.yaml
@@ -1,0 +1,3 @@
+# Enable RBAC permissions required by the Beyla SDK injection controller.
+sdkInjectionController:
+  enabled: true

--- a/operations/helm/charts/alloy/templates/_helpers.tpl
+++ b/operations/helm/charts/alloy/templates/_helpers.tpl
@@ -84,6 +84,14 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Create the name of the SDK injection controller role to use
+*/}}
+{{- define "alloy.sdkInjectionControllerRoleName" -}}
+{{- $name := (include "alloy.fullname" .) | trunc 38 | trimSuffix "-" -}}
+{{- printf "%s-sdk-injection-controller" $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 Calculate name of image ID to use for "alloy.
 */}}
 {{- define "alloy.imageId" -}}

--- a/operations/helm/charts/alloy/templates/rbac.yaml
+++ b/operations/helm/charts/alloy/templates/rbac.yaml
@@ -67,4 +67,36 @@ subjects:
     name: {{ include "alloy.serviceAccountName" . }}
     namespace: {{ include "alloy.namespace" . }}
   {{- end }}
+  {{- if .Values.sdkInjectionController.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "alloy.sdkInjectionControllerRoleName" . }}
+  namespace: {{ include "alloy.namespace" . }}
+  labels:
+    {{- include "alloy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "alloy.sdkInjectionControllerRoleName" . }}
+  namespace: {{ include "alloy.namespace" . }}
+  labels:
+    {{- include "alloy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "alloy.sdkInjectionControllerRoleName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "alloy.serviceAccountName" . }}
+    namespace: {{ include "alloy.namespace" . }}
+  {{- end }}
 {{- end }}

--- a/operations/helm/charts/alloy/values.yaml
+++ b/operations/helm/charts/alloy/values.yaml
@@ -228,6 +228,11 @@ rbac:
     - nonResourceURLs: ["/metrics"]
       verbs: ["get"]
 
+sdkInjectionController:
+  # -- Whether to create RBAC resources for the Beyla Kubernetes SDK injection controller.
+  # When enabled, Alloy can get, create, and update ConfigMaps in its deployment namespace.
+  enabled: false
+
 serviceAccount:
   # -- Whether to create a service account for the Grafana Alloy deployment.
   create: true

--- a/operations/helm/tests/sdk-injection-controller/alloy/templates/configmap.yaml
+++ b/operations/helm/tests/sdk-injection-controller/alloy/templates/configmap.yaml
@@ -1,0 +1,44 @@
+---
+# Source: alloy/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alloy
+  namespace: default
+  labels:
+    helm.sh/chart: alloy
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/instance: alloy
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: config
+data:
+  config.alloy: |-
+    logging {
+    	level  = "info"
+    	format = "logfmt"
+    }
+    
+    discovery.kubernetes "pods" {
+    	role = "pod"
+    }
+    
+    discovery.kubernetes "nodes" {
+    	role = "node"
+    }
+    
+    discovery.kubernetes "services" {
+    	role = "service"
+    }
+    
+    discovery.kubernetes "endpoints" {
+    	role = "endpoints"
+    }
+    
+    discovery.kubernetes "endpointslices" {
+    	role = "endpointslice"
+    }
+    
+    discovery.kubernetes "ingresses" {
+    	role = "ingress"
+    }

--- a/operations/helm/tests/sdk-injection-controller/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/sdk-injection-controller/alloy/templates/controllers/daemonset.yaml
@@ -1,0 +1,81 @@
+---
+# Source: alloy/templates/controllers/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: alloy
+  namespace: default
+  labels:
+    helm.sh/chart: alloy
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/instance: alloy
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  minReadySeconds: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: alloy
+      app.kubernetes.io/instance: alloy
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: alloy
+      labels:
+        app.kubernetes.io/name: alloy
+        app.kubernetes.io/instance: alloy
+    spec:
+      serviceAccountName: alloy
+      containers:
+        - name: alloy
+          image: docker.io/grafana/alloy:v1.17.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - run
+            - /etc/alloy/config.alloy
+            - --storage.path=/tmp/alloy
+            - --server.http.listen-addr=0.0.0.0:12345
+            - --server.http.ui-path-prefix=/
+            - --stability.level=generally-available
+          env:
+            - name: ALLOY_DEPLOY_MODE
+              value: "helm"
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          ports:
+            - containerPort: 12345
+              name: http-metrics
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 12345
+              scheme: HTTP
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alloy
+        - name: config-reloader
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0@sha256:7d9e4eea5f1139e602508871f422b0116c60e87c662f3dcd234d5ab60cd0d8c1
+          imagePullPolicy: IfNotPresent
+          args:
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alloy
+          resources:
+            requests:
+              cpu: 10m
+              memory: 50Mi
+      dnsPolicy: ClusterFirst
+      volumes:
+        - name: config
+          configMap:
+            name: alloy

--- a/operations/helm/tests/sdk-injection-controller/alloy/templates/rbac.yaml
+++ b/operations/helm/tests/sdk-injection-controller/alloy/templates/rbac.yaml
@@ -1,0 +1,188 @@
+---
+# Source: alloy/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: alloy
+  labels:
+    helm.sh/chart: alloy
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/instance: alloy
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: rbac
+rules:
+  - apiGroups:
+    - ""
+    - discovery.k8s.io
+    - networking.k8s.io
+    resources:
+    - endpoints
+    - endpointslices
+    - ingresses
+    - pods
+    - services
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    - pods/log
+    - namespaces
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - monitoring.grafana.com
+    resources:
+    - podlogs
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - monitoring.coreos.com
+    resources:
+    - prometheusrules
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - monitoring.coreos.com
+    resources:
+    - alertmanagerconfigs
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - monitoring.coreos.com
+    resources:
+    - podmonitors
+    - servicemonitors
+    - probes
+    - scrapeconfigs
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    - secrets
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - apps
+    - extensions
+    resources:
+    - replicasets
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - nodes
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - nodes/pods
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - nodes/metrics
+    verbs:
+    - get
+    - list
+    - watch
+  - nonResourceURLs:
+    - /metrics
+    verbs:
+    - get
+---
+# Source: alloy/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: alloy
+  labels:
+    helm.sh/chart: alloy
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/instance: alloy
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: rbac
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: alloy
+subjects:
+  - kind: ServiceAccount
+    name: alloy
+    namespace: default
+---
+# Source: alloy/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: alloy-sdk-injection-controller
+  namespace: default
+  labels:
+    helm.sh/chart: alloy
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/instance: alloy
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: rbac
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create", "update"]
+---
+# Source: alloy/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: alloy-sdk-injection-controller
+  namespace: default
+  labels:
+    helm.sh/chart: alloy
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/instance: alloy
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: rbac
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: alloy-sdk-injection-controller
+subjects:
+  - kind: ServiceAccount
+    name: alloy
+    namespace: default

--- a/operations/helm/tests/sdk-injection-controller/alloy/templates/service.yaml
+++ b/operations/helm/tests/sdk-injection-controller/alloy/templates/service.yaml
@@ -1,0 +1,25 @@
+---
+# Source: alloy/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: alloy
+  namespace: default
+  labels:
+    helm.sh/chart: alloy
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/instance: alloy
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: networking
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/instance: alloy
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: http-metrics
+      port: 12345
+      targetPort: 12345
+      protocol: "TCP"

--- a/operations/helm/tests/sdk-injection-controller/alloy/templates/serviceaccount.yaml
+++ b/operations/helm/tests/sdk-injection-controller/alloy/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+---
+# Source: alloy/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  name: alloy
+  namespace: default
+  labels:
+    helm.sh/chart: alloy
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/instance: alloy
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: rbac


### PR DESCRIPTION
### Brief description of Pull Request

When Beyla and the Kubernetes SDK injection controller are deployed in a Kubernetes cluster, for the purpose of automatic injection of OpenTelemetry SDKs, they need to exchange information. This information is passed through specially designed configmap which the Beyla Alloy eBPF component needs to write. For this purpose, when this mode is enabled, Alloy needs RBAC permissions to write this configmap, only to its own namespace.

### Pull Request Details

I'm adding a Helm chart option to enable additional RBAC for alloy to get, create and update configmaps in its own namespace, when this deployment mode is enabled.


### Issue(s) fixed by this Pull Request


### Notes to the Reviewer


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Documentation added
- [X] Tests updated
