### PR TITLE
docs: Fix docs links in prometheus remote write topic

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.remote_write.md
+++ b/docs/sources/reference/components/prometheus/prometheus.remote_write.md
@@ -110,13 +110,13 @@ The following arguments are supported:
 
  At most, one of the following can be provided:
 
-* [`authorization`][authorization] block
-* [`azuread`][azuread] block
-* [`basic_auth`][basic_auth] block
-* [`bearer_token_file`](#endpoint) argument
-* [`bearer_token`](#endpoint) argument
-* [`oauth2`][oauth2] block
-* [`sigv4`][sigv4] block
+* [`authorization`][#authorization] block
+* [`azuread`][#azuread] block
+* [`basic_auth`][#basic_auth] block
+* [`bearer_token_file`](#bearer_token_file) argument
+* [`bearer_token`](#bearer_token) argument
+* [`oauth2`][#oauth2] block
+* [`sigv4`][#sigv4] block
 
 When multiple `endpoint` blocks are provided, metrics are concurrently sent to all configured locations.
 Each endpoint has a _queue_ which is used to read metrics from the WAL and queue them for sending.

--- a/docs/sources/reference/components/prometheus/prometheus.remote_write.md
+++ b/docs/sources/reference/components/prometheus/prometheus.remote_write.md
@@ -550,6 +550,12 @@ Refer to the linked documentation for more details.
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->
 
+[authorization]: #authorization
+[azuread]: #azuread
+[basic_auth]: #basic_auth
+[oauth2]: #oauth2
+[sigv4]: #sigv4
+[endpoint]: #endpoint
 [snappy]: https://en.wikipedia.org/wiki/Snappy_(compression)
 [WAL block]: #wal
 [Stop]: ../../../../set-up/run/

--- a/docs/sources/reference/components/prometheus/prometheus.remote_write.md
+++ b/docs/sources/reference/components/prometheus/prometheus.remote_write.md
@@ -110,13 +110,13 @@ The following arguments are supported:
 
  At most, one of the following can be provided:
 
-* [`authorization`][#authorization] block
-* [`azuread`][#azuread] block
-* [`basic_auth`][#basic_auth] block
-* [`bearer_token_file`](#bearer_token_file) argument
-* [`bearer_token`](#bearer_token) argument
-* [`oauth2`][#oauth2] block
-* [`sigv4`][#sigv4] block
+* [`authorization`][authorization] block
+* [`azuread`][azuread] block
+* [`basic_auth`][basic_auth] block
+* [`bearer_token_file`][endpoint] argument
+* [`bearer_token`][endpoint] argument
+* [`oauth2`][oauth2] block
+* [`sigv4`][sigv4] block
 
 When multiple `endpoint` blocks are provided, metrics are concurrently sent to all configured locations.
 Each endpoint has a _queue_ which is used to read metrics from the WAL and queue them for sending.


### PR DESCRIPTION
Auth block/argument links are broken on the remote write topic, I assume this is from the refactor to how the blocks section is displayed.

<img width="405" height="258" alt="image" src="https://github.com/user-attachments/assets/0ccae211-75df-4475-9678-2b3e59783fa1" />
