### PR TITLE
feat(otelcol.receiver.loki): Add selective label mapping via labels block

### DIFF
--- a/docs/sources/reference/components/otelcol/otelcol.receiver.loki.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.loki.md
@@ -42,11 +42,38 @@ You can use the following blocks with `otelcol.receiver.loki`:
 
 | Block              | Description                                        | Required |
 |--------------------|----------------------------------------------------|----------|
+| [`labels`][labels] | Configures selective label forwarding.             | no       |
 | [`output`][output] | Configures where to send converted telemetry data. | yes      |
 
+[labels]: #labels
 [output]: #output
 
 {{< /docs/alloy-config >}}
+
+### `labels`
+
+The `labels` block configures which Loki labels are forwarded as OpenTelemetry log record attributes and allows renaming them during conversion.
+When the `labels` block isn't provided, all Loki labels are forwarded as attributes, preserving backward compatibility.
+
+You can use the following arguments with `labels`:
+
+| Name      | Type              | Description                                                        | Default | Required |
+|-----------|-------------------|--------------------------------------------------------------------|---------|----------|
+| `include` | `list(string)`    | Allowlist of label names to forward. All others are dropped.       |         | no       |
+| `exclude` | `list(string)`    | Blocklist of label names to drop. All others are forwarded.        |         | no       |
+| `rename`  | `map(string)`     | Map of original label names to new attribute names.                |         | no       |
+
+The `include` and `exclude` attributes are mutually exclusive.
+Setting both results in a validation error.
+
+The `rename` attribute is applied after `include` or `exclude` filtering.
+It maps the original Loki label name to the desired OpenTelemetry attribute name.
+Renamed keys are also reflected in the `loki.attribute.labels` hint attribute.
+
+{{< admonition type="note" >}}
+The `filename` label receives special handling: when present, the `log.file.path` and `log.file.name` attributes are always added to the log record regardless of filtering.
+However, the `filename` label itself is subject to the `include` and `exclude` filters.
+{{< /admonition >}}
 
 ### `output`
 
@@ -70,7 +97,9 @@ The following fields are exported and can be referenced by other components:
 
 `otelcol.receiver.loki` doesn't expose any component-specific debug information.
 
-## Example
+## Examples
+
+### Basic usage
 
 This example uses the `otelcol.receiver.loki` component as a bridge between the Loki and OpenTelemetry ecosystems.
 The component exposes a receiver which the `loki.source.file` component uses to send Loki log entries to.
@@ -86,6 +115,60 @@ loki.source.file "default" {
 }
 
 otelcol.receiver.loki "default" {
+  output {
+    logs = [otelcol.exporter.otlphttp.default.input]
+  }
+}
+
+otelcol.exporter.otlphttp "default" {
+  client {
+    endpoint = sys.env("<OTLP_ENDPOINT>")
+  }
+}
+```
+
+### Selective label forwarding with renaming
+
+This example only forwards the `job` label and renames it to `service.name`, dropping all other labels:
+
+```alloy
+loki.source.file "default" {
+  targets = [
+    {__path__ = "/var/log/*.log"},
+  ]
+  forward_to = [otelcol.receiver.loki.default.receiver]
+}
+
+otelcol.receiver.loki "default" {
+  labels {
+    include = ["job"]
+    rename = {
+      job = "service.name",
+    }
+  }
+
+  output {
+    logs = [otelcol.exporter.otlphttp.default.input]
+  }
+}
+
+otelcol.exporter.otlphttp "default" {
+  client {
+    endpoint = sys.env("<OTLP_ENDPOINT>")
+  }
+}
+```
+
+### Excluding specific labels
+
+This example drops high-cardinality labels like `instance` and `stream`, forwarding all others:
+
+```alloy
+otelcol.receiver.loki "default" {
+  labels {
+    exclude = ["instance", "stream"]
+  }
+
   output {
     logs = [otelcol.exporter.otlphttp.default.input]
   }

--- a/internal/component/otelcol/receiver/loki/loki.go
+++ b/internal/component/otelcol/receiver/loki/loki.go
@@ -3,11 +3,14 @@ package loki
 
 import (
 	"context"
+	"fmt"
 	"path"
+	"sort"
 	"strings"
 	"sync"
 
 	loki_translator "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki"
+	"github.com/prometheus/common/model"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/plog"
 
@@ -36,10 +39,39 @@ func init() {
 
 var hintAttributes = "loki.attribute.labels"
 
+// LabelsConfig controls which Loki labels are forwarded as OTel log record
+// attributes and allows renaming them during conversion.
+type LabelsConfig struct {
+	// Include is an allowlist of label names. When set, only these labels are
+	// forwarded as attributes; all others are dropped. Mutually exclusive with
+	// Exclude.
+	Include []string `alloy:"include,attr,optional"`
+
+	// Exclude is a blocklist of label names. When set, these labels are dropped
+	// and all others are forwarded. Mutually exclusive with Include.
+	Exclude []string `alloy:"exclude,attr,optional"`
+
+	// Rename maps original label names to new attribute names. Applied after
+	// include/exclude filtering.
+	Rename map[string]string `alloy:"rename,attr,optional"`
+}
+
 // Arguments configures the otelcol.receiver.loki component.
 type Arguments struct {
+	// Labels optionally controls which Loki labels are forwarded and how they
+	// are named in the resulting OTel log record attributes.
+	Labels *LabelsConfig `alloy:"labels,block,optional"`
+
 	// Output configures where to send received data. Required.
 	Output *otelcol.ConsumerArguments `alloy:"output,block"`
+}
+
+// Validate implements syntax.Validator.
+func (a Arguments) Validate() error {
+	if a.Labels != nil && len(a.Labels.Include) > 0 && len(a.Labels.Exclude) > 0 {
+		return fmt.Errorf("the \"include\" and \"exclude\" attributes inside the \"labels\" block are mutually exclusive")
+	}
+	return nil
 }
 
 // Exports holds the receiver that is used to send log entries to the
@@ -98,8 +130,11 @@ func (c *Component) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			return nil
 		case entry := <-c.receiver.Chan():
+			c.mut.RLock()
+			labelsCfg := c.args.Labels
+			c.mut.RUnlock()
 
-			logs := convertLokiEntryToPlog(entry)
+			logs := convertLokiEntryToPlog(entry, labelsCfg)
 
 			// TODO(@tpaschalis) Is there any more handling to be done here?
 			err := c.logsSink.ConsumeLogs(ctx, logs)
@@ -129,8 +164,60 @@ func (c *Component) Update(newConfig component.Arguments) error {
 	return nil
 }
 
-// Create a new Otlp Logs entry from a Promtail entry
-func convertLokiEntryToPlog(lokiEntry loki.Entry) plog.Logs {
+// filterLabels applies the LabelsConfig to a label set, returning a new
+// filtered label set. When cfg is nil, the original set is returned as-is.
+func filterLabels(labels model.LabelSet, cfg *LabelsConfig) model.LabelSet {
+	if cfg == nil {
+		return labels
+	}
+
+	filtered := make(model.LabelSet, len(labels))
+
+	if len(cfg.Include) > 0 {
+		includeSet := make(map[string]struct{}, len(cfg.Include))
+		for _, l := range cfg.Include {
+			includeSet[l] = struct{}{}
+		}
+		for k, v := range labels {
+			if _, ok := includeSet[string(k)]; ok {
+				filtered[k] = v
+			}
+		}
+	} else if len(cfg.Exclude) > 0 {
+		excludeSet := make(map[string]struct{}, len(cfg.Exclude))
+		for _, l := range cfg.Exclude {
+			excludeSet[l] = struct{}{}
+		}
+		for k, v := range labels {
+			if _, ok := excludeSet[string(k)]; !ok {
+				filtered[k] = v
+			}
+		}
+	} else {
+		// No include/exclude: copy all labels.
+		for k, v := range labels {
+			filtered[k] = v
+		}
+	}
+
+	return filtered
+}
+
+// renameLabel returns the renamed key for a label if a rename mapping exists,
+// otherwise returns the original key.
+func renameLabel(key string, cfg *LabelsConfig) string {
+	if cfg != nil && len(cfg.Rename) > 0 {
+		if newName, ok := cfg.Rename[key]; ok {
+			return newName
+		}
+	}
+	return key
+}
+
+// convertLokiEntryToPlog creates a new OTel Logs entry from a Loki entry.
+// The optional LabelsConfig controls which labels are forwarded and how they
+// are named.
+func convertLokiEntryToPlog(lokiEntry loki.Entry, labelsCfg *LabelsConfig) plog.Logs {
 	logs := plog.NewLogs()
 
 	lr := logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
@@ -151,11 +238,16 @@ func convertLokiEntryToPlog(lokiEntry loki.Entry) plog.Logs {
 		// because the Collector doesn't do it and we would be more in line with it.
 	}
 
+	// Apply label filtering.
+	filteredLabels := filterLabels(lokiEntry.Labels, labelsCfg)
+
+	// Build the hint attribute key list, applying renames.
 	var lbls []string
-	for key := range lokiEntry.Labels {
-		keyStr := string(key)
+	for key := range filteredLabels {
+		keyStr := renameLabel(string(key), labelsCfg)
 		lbls = append(lbls, keyStr)
 	}
+	sort.Strings(lbls)
 
 	if len(lbls) > 0 {
 		// This hint is defined in the pkg/translator/loki package and the
@@ -166,7 +258,19 @@ func convertLokiEntryToPlog(lokiEntry loki.Entry) plog.Logs {
 		lr.Attributes().PutStr(hintAttributes, strings.Join(lbls, ","))
 	}
 
-	loki_translator.ConvertEntryToLogRecord(&lokiEntry.Entry, &lr, lokiEntry.Labels, true)
+	// Let the upstream translator set timestamps and body from the entry,
+	// and add the filtered labels as log record attributes.
+	loki_translator.ConvertEntryToLogRecord(&lokiEntry.Entry, &lr, filteredLabels, true)
+
+	// Apply renames: overwrite original label keys with new names.
+	if labelsCfg != nil && len(labelsCfg.Rename) > 0 {
+		for origName, newName := range labelsCfg.Rename {
+			if val, ok := lr.Attributes().Get(origName); ok {
+				lr.Attributes().PutStr(newName, val.AsString())
+				lr.Attributes().Remove(origName)
+			}
+		}
+	}
 
 	return logs
 }

--- a/internal/component/otelcol/receiver/loki/loki_test.go
+++ b/internal/component/otelcol/receiver/loki/loki_test.go
@@ -2,6 +2,8 @@ package loki
 
 import (
 	"context"
+	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -67,7 +69,7 @@ func Test(t *testing.T) {
 		"filename":              "/var/log/app/errors.log",
 		"log.file.name":         "errors.log",
 		"log.file.path":         "/var/log/app/errors.log",
-		"loki.attribute.labels": "filename,env",
+		"loki.attribute.labels": "env,filename",
 	}
 
 	// Wait for our client to get the log.
@@ -82,9 +84,268 @@ func Test(t *testing.T) {
 		require.Equal(t, wantAttributes["filename"], otelLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().AsRaw()["filename"])
 		require.Equal(t, wantAttributes["log.file.name"], otelLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().AsRaw()["log.file.name"])
 		require.Equal(t, wantAttributes["log.file.path"], otelLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().AsRaw()["log.file.path"])
-		require.Contains(t, otelLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().AsRaw()["loki.attribute.labels"], "env")
-		require.Contains(t, otelLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().AsRaw()["loki.attribute.labels"], "filename")
+		// The hint attribute is now sorted, so check for the sorted value.
+		hintVal := otelLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().AsRaw()["loki.attribute.labels"].(string)
+		require.Contains(t, hintVal, "env")
+		require.Contains(t, hintVal, "filename")
 	}
+}
+
+func TestConvertLokiEntryToPlog_IncludeLabels(t *testing.T) {
+	entry := lokiapi.Entry{
+		Labels: map[model.LabelName]model.LabelValue{
+			"job":      "myapp",
+			"instance": "host123:8080",
+			"level":    "error",
+			"stream":   "stdout",
+		},
+		Entry: push.Entry{
+			Timestamp: time.Now(),
+			Line:      "test log line",
+		},
+	}
+
+	cfg := &LabelsConfig{
+		Include: []string{"job", "instance"},
+	}
+
+	logs := convertLokiEntryToPlog(entry, cfg)
+	require.Equal(t, 1, logs.LogRecordCount())
+
+	lr := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	attrs := lr.Attributes().AsRaw()
+
+	// Only "job" and "instance" should be present as label-derived attributes.
+	require.Equal(t, "myapp", attrs["job"])
+	require.Equal(t, "host123:8080", attrs["instance"])
+
+	// "level" and "stream" should NOT be present.
+	_, hasLevel := attrs["level"]
+	require.False(t, hasLevel, "level should be excluded")
+	_, hasStream := attrs["stream"]
+	require.False(t, hasStream, "stream should be excluded")
+
+	// The hint attribute should only contain the included labels.
+	hintVal := attrs["loki.attribute.labels"].(string)
+	parts := strings.Split(hintVal, ",")
+	sort.Strings(parts)
+	require.Equal(t, []string{"instance", "job"}, parts)
+}
+
+func TestConvertLokiEntryToPlog_ExcludeLabels(t *testing.T) {
+	entry := lokiapi.Entry{
+		Labels: map[model.LabelName]model.LabelValue{
+			"job":      "myapp",
+			"instance": "host123:8080",
+			"level":    "error",
+			"stream":   "stdout",
+		},
+		Entry: push.Entry{
+			Timestamp: time.Now(),
+			Line:      "test log line",
+		},
+	}
+
+	cfg := &LabelsConfig{
+		Exclude: []string{"level", "stream"},
+	}
+
+	logs := convertLokiEntryToPlog(entry, cfg)
+	require.Equal(t, 1, logs.LogRecordCount())
+
+	lr := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	attrs := lr.Attributes().AsRaw()
+
+	// "job" and "instance" should be present.
+	require.Equal(t, "myapp", attrs["job"])
+	require.Equal(t, "host123:8080", attrs["instance"])
+
+	// "level" and "stream" should NOT be present.
+	_, hasLevel := attrs["level"]
+	require.False(t, hasLevel, "level should be excluded")
+	_, hasStream := attrs["stream"]
+	require.False(t, hasStream, "stream should be excluded")
+
+	// The hint attribute should only contain the non-excluded labels.
+	hintVal := attrs["loki.attribute.labels"].(string)
+	parts := strings.Split(hintVal, ",")
+	sort.Strings(parts)
+	require.Equal(t, []string{"instance", "job"}, parts)
+}
+
+func TestConvertLokiEntryToPlog_RenameLabels(t *testing.T) {
+	entry := lokiapi.Entry{
+		Labels: map[model.LabelName]model.LabelValue{
+			"job": "myapp",
+			"env": "production",
+		},
+		Entry: push.Entry{
+			Timestamp: time.Now(),
+			Line:      "test log line",
+		},
+	}
+
+	cfg := &LabelsConfig{
+		Rename: map[string]string{
+			"job": "service.name",
+		},
+	}
+
+	logs := convertLokiEntryToPlog(entry, cfg)
+	require.Equal(t, 1, logs.LogRecordCount())
+
+	lr := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	attrs := lr.Attributes().AsRaw()
+
+	// "job" should be renamed to "service.name".
+	require.Equal(t, "myapp", attrs["service.name"])
+	_, hasJob := attrs["job"]
+	require.False(t, hasJob, "original 'job' key should be removed after rename")
+
+	// "env" should remain unchanged.
+	require.Equal(t, "production", attrs["env"])
+
+	// The hint attribute should use the renamed key.
+	hintVal := attrs["loki.attribute.labels"].(string)
+	parts := strings.Split(hintVal, ",")
+	sort.Strings(parts)
+	require.Equal(t, []string{"env", "service.name"}, parts)
+}
+
+func TestConvertLokiEntryToPlog_IncludeAndRename(t *testing.T) {
+	entry := lokiapi.Entry{
+		Labels: map[model.LabelName]model.LabelValue{
+			"job":      "myapp",
+			"instance": "host123:8080",
+			"level":    "error",
+		},
+		Entry: push.Entry{
+			Timestamp: time.Now(),
+			Line:      "test log line",
+		},
+	}
+
+	cfg := &LabelsConfig{
+		Include: []string{"job"},
+		Rename: map[string]string{
+			"job": "service.name",
+		},
+	}
+
+	logs := convertLokiEntryToPlog(entry, cfg)
+	require.Equal(t, 1, logs.LogRecordCount())
+
+	lr := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	attrs := lr.Attributes().AsRaw()
+
+	// Only "job" was included, and it's renamed to "service.name".
+	require.Equal(t, "myapp", attrs["service.name"])
+	_, hasJob := attrs["job"]
+	require.False(t, hasJob, "original 'job' key should be removed")
+	_, hasInstance := attrs["instance"]
+	require.False(t, hasInstance, "instance should be excluded by include filter")
+	_, hasLevel := attrs["level"]
+	require.False(t, hasLevel, "level should be excluded by include filter")
+
+	// Hint should only contain the renamed label.
+	hintVal := attrs["loki.attribute.labels"].(string)
+	require.Equal(t, "service.name", hintVal)
+}
+
+func TestConvertLokiEntryToPlog_NilConfig(t *testing.T) {
+	// This verifies backward compatibility: nil config forwards all labels.
+	entry := lokiapi.Entry{
+		Labels: map[model.LabelName]model.LabelValue{
+			"job":   "myapp",
+			"level": "info",
+		},
+		Entry: push.Entry{
+			Timestamp: time.Now(),
+			Line:      "test log line",
+		},
+	}
+
+	logs := convertLokiEntryToPlog(entry, nil)
+	require.Equal(t, 1, logs.LogRecordCount())
+
+	lr := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	attrs := lr.Attributes().AsRaw()
+
+	require.Equal(t, "myapp", attrs["job"])
+	require.Equal(t, "info", attrs["level"])
+
+	hintVal := attrs["loki.attribute.labels"].(string)
+	parts := strings.Split(hintVal, ",")
+	sort.Strings(parts)
+	require.Equal(t, []string{"job", "level"}, parts)
+}
+
+func TestConvertLokiEntryToPlog_FilenameAlwaysProcessed(t *testing.T) {
+	// Even when filename is excluded, log.file.path and log.file.name are still set.
+	entry := lokiapi.Entry{
+		Labels: map[model.LabelName]model.LabelValue{
+			"filename": "/var/log/app.log",
+			"job":      "myapp",
+		},
+		Entry: push.Entry{
+			Timestamp: time.Now(),
+			Line:      "test log line",
+		},
+	}
+
+	cfg := &LabelsConfig{
+		Exclude: []string{"filename"},
+	}
+
+	logs := convertLokiEntryToPlog(entry, cfg)
+	lr := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	attrs := lr.Attributes().AsRaw()
+
+	// log.file.path and log.file.name are always added when filename label exists.
+	require.Equal(t, "/var/log/app.log", attrs["log.file.path"])
+	require.Equal(t, "app.log", attrs["log.file.name"])
+
+	// But the "filename" label itself should be excluded from the forwarded attributes.
+	_, hasFilename := attrs["filename"]
+	require.False(t, hasFilename, "filename label should be excluded")
+
+	// "job" should be present.
+	require.Equal(t, "myapp", attrs["job"])
+}
+
+func TestValidate_IncludeAndExcludeMutuallyExclusive(t *testing.T) {
+	args := Arguments{
+		Labels: &LabelsConfig{
+			Include: []string{"job"},
+			Exclude: []string{"level"},
+		},
+	}
+	err := args.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestValidate_IncludeOnly(t *testing.T) {
+	args := Arguments{
+		Labels: &LabelsConfig{
+			Include: []string{"job"},
+		},
+	}
+	require.NoError(t, args.Validate())
+}
+
+func TestValidate_ExcludeOnly(t *testing.T) {
+	args := Arguments{
+		Labels: &LabelsConfig{
+			Exclude: []string{"level"},
+		},
+	}
+	require.NoError(t, args.Validate())
+}
+
+func TestValidate_NoLabelsBlock(t *testing.T) {
+	args := Arguments{}
+	require.NoError(t, args.Validate())
 }
 
 // makeLogsOutput returns a ConsumerArguments which will forward logs to


### PR DESCRIPTION
## What

Adds an optional `labels` configuration block to `otelcol.receiver.loki` that
allows users to selectively control which Loki labels become OTel log record
attributes during ingestion.

Closes #6556

## Why

Currently all Loki labels are unconditionally forwarded as log record
attributes. This is problematic when labels like `instance`, `stream`, or
`level` should remain as log-level attributes, be dropped entirely, or be
renamed to match OTel semantic conventions (e.g. `job` → `service.name`).

The only workaround today is adding a downstream `otelcol.processor.attributes`
step, which is wasteful for high-volume Loki ingestion since the data is
already structured at that point.

## How

The new `labels` block supports three optional attributes:

| Attribute | Type | Description |
|-----------|------|-------------|
| `include` | `list(string)` | Allowlist — only these labels are forwarded |
| `exclude` | `list(string)` | Blocklist — these labels are dropped |
| `rename`  | `map(string)` | Rename labels during conversion |

- `include` and `exclude` are mutually exclusive (validation error if both set)
- `rename` is applied after filtering
- When `labels` block is omitted, all labels are forwarded (backward compatible)
- The `filename` → `log.file.path`/`log.file.name` special handling is
  independent of label filtering

### Example

```alloy
otelcol.receiver.loki "default" {
  labels {
    include = ["job"]
    rename = {
      job = "service.name",
    }
  }

  output {
    logs = [otelcol.exporter.otlphttp.default.input]
  }
}
