### PR TITLE
fix(prometheus.operator): Expose CRD reconciliation errors and remove stale configs

### DIFF
--- a/internal/component/prometheus/operator/common/component.go
+++ b/internal/component/prometheus/operator/common/component.go
@@ -59,8 +59,17 @@ func New(o component.Options, args component.Arguments, kind string) (*Component
 
 func (c *Component) CurrentHealth() component.Health {
 	c.healthMut.RLock()
-	defer c.healthMut.RUnlock()
-	return c.health
+	componentHealth := c.health
+	c.healthMut.RUnlock()
+
+	c.mut.RLock()
+	manager := c.manager
+	c.mut.RUnlock()
+
+	if manager != nil {
+		componentHealth = component.LeastHealthy(componentHealth, manager.CurrentHealth())
+	}
+	return componentHealth
 }
 
 // Run implements component.Component.

--- a/internal/component/prometheus/operator/common/component_test.go
+++ b/internal/component/prometheus/operator/common/component_test.go
@@ -58,6 +58,13 @@ func (c *crdManagerHungRun) GetScrapeConfig(ns, name string) []*config.ScrapeCon
 	return nil
 }
 
+func (c *crdManagerHungRun) CurrentHealth() component.Health {
+	return component.Health{
+		Health:     component.HealthTypeHealthy,
+		UpdateTime: time.Now(),
+	}
+}
+
 func TestRunExit(t *testing.T) {
 	opts := component.Options{
 		Logger:     util.TestAlloyLogger(t),

--- a/internal/component/prometheus/operator/common/crdmanager.go
+++ b/internal/component/prometheus/operator/common/crdmanager.go
@@ -44,6 +44,7 @@ type crdManagerInterface interface {
 	ClusteringUpdated()
 	DebugInfo() any
 	GetScrapeConfig(ns, name string) []*config.ScrapeConfig
+	CurrentHealth() component.Health
 }
 
 type crdManagerFactory interface {
@@ -301,6 +302,37 @@ func (c *crdManager) DebugInfo() any {
 	return info
 }
 
+// CurrentHealth returns the health of the crdManager, which is Unhealthy if any managed CRD failed to reconcile.
+func (c *crdManager) CurrentHealth() component.Health {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	var errs []string
+	var maxTime time.Time
+	for _, res := range c.debugInfo {
+		if res.ReconcileError != "" {
+			errs = append(errs, fmt.Sprintf("%s/%s: %s", res.Namespace, res.Name, res.ReconcileError))
+			if res.LastReconcile.After(maxTime) {
+				maxTime = res.LastReconcile
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		sort.Strings(errs)
+		return component.Health{
+			Health:     component.HealthTypeUnhealthy,
+			Message:    fmt.Sprintf("error reconciling CRDs: %s", strings.Join(errs, "; ")),
+			UpdateTime: maxTime,
+		}
+	}
+
+	return component.Health{
+		Health:     component.HealthTypeHealthy,
+		UpdateTime: time.Now(),
+	}
+}
+
 func (c *crdManager) GetScrapeConfig(ns, name string) []*config.ScrapeConfig {
 	prefix := fmt.Sprintf("%s/%s/%s", c.kind, ns, name)
 	matches := []*config.ScrapeConfig{}
@@ -540,7 +572,13 @@ func (c *crdManager) addPodMonitor(pm *promopv1.PodMonitor) {
 		c.mut.Unlock()
 	}
 	if err != nil {
+		c.mut.Lock()
+		c.crdsToMapKeys[fmt.Sprintf("%s/%s", pm.Namespace, pm.Name)] = mapKeys
+		c.mut.Unlock()
 		c.addDebugInfo(pm.Namespace, pm.Name, err)
+		if applyErr := c.apply(); applyErr != nil {
+			c.logger.Error("error applying scrape configs after validation error", "name", pm.Name, "err", applyErr)
+		}
 		return
 	}
 	c.mut.Lock()
@@ -597,7 +635,13 @@ func (c *crdManager) addServiceMonitor(sm *promopv1.ServiceMonitor) {
 		c.mut.Unlock()
 	}
 	if err != nil {
+		c.mut.Lock()
+		c.crdsToMapKeys[fmt.Sprintf("%s/%s", sm.Namespace, sm.Name)] = mapKeys
+		c.mut.Unlock()
 		c.addDebugInfo(sm.Namespace, sm.Name, err)
+		if applyErr := c.apply(); applyErr != nil {
+			c.logger.Error("error applying scrape configs after validation error", "name", sm.Name, "err", applyErr)
+		}
 		return
 	}
 	c.mut.Lock()
@@ -642,7 +686,13 @@ func (c *crdManager) addProbe(p *promopv1.Probe) {
 	if err != nil {
 		// TODO(jcreixell): Generate Kubernetes event to inform of this error when running `kubectl get <probe>`.
 		c.logger.Error("error generating scrapeconfig from probe", "name", p.Name, "err", err)
+		c.mut.Lock()
+		c.crdsToMapKeys[fmt.Sprintf("%s/%s", p.Namespace, p.Name)] = nil
+		c.mut.Unlock()
 		c.addDebugInfo(p.Namespace, p.Name, err)
+		if applyErr := c.apply(); applyErr != nil {
+			c.logger.Error("error applying scrape configs after validation error", "name", p.Name, "err", applyErr)
+		}
 		return
 	}
 	c.mut.Lock()
@@ -694,6 +744,12 @@ func (c *crdManager) addScrapeConfig(pm *promopv1alpha1.ScrapeConfig) {
 	if len(errs) > 0 {
 		c.addDebugInfo(pm.Namespace, pm.Name, errors.Join(errs...))
 		if len(scrapeConfigs) == 0 {
+			c.mut.Lock()
+			c.crdsToMapKeys[objName] = nil
+			c.mut.Unlock()
+			if applyErr := c.apply(); applyErr != nil {
+				c.logger.Error("error applying scrape configs after validation error", "name", pm.Name, "err", applyErr)
+			}
 			return
 		}
 	}

--- a/internal/component/prometheus/operator/common/crdmanager_test.go
+++ b/internal/component/prometheus/operator/common/crdmanager_test.go
@@ -167,3 +167,87 @@ func (m *mockScrapeManager) TargetsActive() map[string][]*scrape.Target {
 func (m *mockScrapeManager) ApplyConfig(cfg *config.Config) error {
 	return nil
 }
+
+func TestInvalidConfigReconcileHealth(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	m := newCrdManager(
+		component.Options{
+			SLogger:        logger,
+			GetServiceData: func(name string) (any, error) { return nil, nil },
+		},
+		cluster.Mock(),
+		logger,
+		&operator.DefaultArguments,
+		KindServiceMonitor,
+		labelstore.New(logger, prometheus.DefaultRegisterer),
+	)
+
+	m.discoveryManager = newMockDiscoveryManager()
+	m.scrapeManager = newMockScrapeManager()
+
+	// 1. Add a valid ServiceMonitor. It should reconcile cleanly and health should be Healthy.
+	targetPort := intstr.FromInt(9090)
+	validSM := &promopv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "monitoring",
+			Name:      "svcmonitor",
+		},
+		Spec: promopv1.ServiceMonitorSpec{
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"group": "my-group",
+				},
+			},
+			Endpoints: []promopv1.Endpoint{
+				{
+					TargetPort:    &targetPort,
+					ScrapeTimeout: "5s",
+					Interval:      "10s",
+				},
+			},
+		},
+	}
+	m.onAddServiceMonitor(validSM)
+
+	require.Equal(t, component.HealthTypeHealthy, m.CurrentHealth().Health)
+	require.Contains(t, m.discoveryConfigs, "serviceMonitor/monitoring/svcmonitor/0")
+
+	// 2. Update the ServiceMonitor with an invalid configuration (e.g. dropEqual action without a target label).
+	// This should fail validation during GenerateServiceMonitorConfig.
+	invalidSM := &promopv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "monitoring",
+			Name:      "svcmonitor",
+		},
+		Spec: promopv1.ServiceMonitorSpec{
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"group": "my-group",
+				},
+			},
+			Endpoints: []promopv1.Endpoint{
+				{
+					TargetPort: &targetPort,
+					RelabelConfigs: []promopv1.RelabelConfig{
+						{
+							Action: "dropEqual", // case-insensitive Action in Prometheus
+							// Missing TargetLabel which is required for dropEqual
+						},
+					},
+					ScrapeTimeout: "5s",
+					Interval:      "10s",
+				},
+			},
+		},
+	}
+
+	m.onUpdateServiceMonitor(validSM, invalidSM)
+
+	// Health must now be Unhealthy because of the validation error.
+	health := m.CurrentHealth()
+	require.Equal(t, component.HealthTypeUnhealthy, health.Health)
+	require.Contains(t, health.Message, "dropequal action requires 'target_label' value")
+
+	// The configuration should have been deleted/applied (i.e. not present in the discoveryConfigs).
+	require.NotContains(t, m.discoveryConfigs, "serviceMonitor/monitoring/svcmonitor/0")
+}


### PR DESCRIPTION
### Purpose
This PR addresses issue #6544 where applying an invalid `ServiceMonitor` (or other CRDs like `PodMonitor`, `Probe`, `ScrapeConfig`) was silently ignored at runtime. The component's scrape and discovery managers would continue using the last valid configuration, and the component status remained `Healthy`.

### Changes
1. **Apply on Reconcile Failure**: Updated `addPodMonitor`, `addServiceMonitor`, `addProbe`, and `addScrapeConfig` in [internal/component/prometheus/operator/common/crdmanager.go](file:///c:/Users/Vishal/Code_File/Repo%20Folder/alloy/internal/component/prometheus/operator/common/crdmanager.go) to update state tracking (`crdsToMapKeys`) and invoke `c.apply()` when configuration generation or validation fails.
2. **Propagate Manager Health**: Implemented `CurrentHealth()` in `crdManager` to query all `debugInfo` entries and aggregate any reconciliation errors. The `Component` wrapper in [internal/component/prometheus/operator/common/component.go](file:///c:/Users/Vishal/Code_File/Repo%20Folder/alloy/internal/component/prometheus/operator/common/component.go) now calls `manager.CurrentHealth()` and merges it with the base component health using `component.LeastHealthy`.
3. **Unit Testing**: Added `TestInvalidConfigReconcileHealth` in [internal/component/prometheus/operator/common/crdmanager_test.go](file:///c:/Users/Vishal/Code_File/Repo%20Folder/alloy/internal/component/prometheus/operator/common/crdmanager_test.go) to assert that invalid configs trigger `Unhealthy` health status and remove target configs.

### Verification
Verified package compilation for Linux:
```bash
$env:GOOS="linux"; $env:CGO_ENABLED="0"; go test -c -o nul -tags="nodocker" ./internal/component/prometheus/operator/...
