### PR TITLE
docs: Add info about signed commits to developer contrib docs

### DIFF
--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -17,6 +17,13 @@ For trivial fixes or improvements, pull requests can be opened immediately witho
   - The [Uber Go Style Guide][uber-style-guide]
 - Sign our [CLA][], otherwise we're not able to accept contributions.
 
+### Signed commits
+
+All Grafana Labs repositories [require signed commits](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-signed-commits).
+To learn how to enable commit verification, refer to [about commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) and refer to this page to learn about [checking your commit signature verification status](https://docs.github.com/en/authentication/troubleshooting-commit-signature-verification/checking-your-commit-and-tag-signature-verification-status).
+
+**NOTE** Unsigned commits and pull requests will be rejected and closed. This includes pull requests that have been authored by Agents.
+
 ## Steps to Contribute
 
 Should you wish to work on an issue, please claim it first by commenting on the GitHub issue that


### PR DESCRIPTION
Add info about signed commits to developer contrib docs

This is aligned with the Grafana core contrib docs: https://github.com/grafana/grafana/pull/126963/