### PR TITLE
docs: Fix labels_snake_case argument in prometheus.exporter.cloudwatch

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.exporter.cloudwatch.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.cloudwatch.md
@@ -121,7 +121,7 @@ You can use the following arguments with `prometheus.exporter.cloudwatch`:
 | `fips_disabled`           | `bool`              | Disable use of FIPS endpoints. Set 'true' when running outside of USA regions. | `true`  | no       |
 | `debug`                   | `bool`              | (Deprecated, no-op) Has no effect. Use the global log level instead.           | `false` | no       |
 | `discovery_exported_tags` | `map(list(string))` | List of tags (value) per service (key) to export in all metrics.               | `{}`    | no       |
-| `labels_to_snake_case`    | `bool`              | Output labels on metrics in snake case instead of camel case.                  | `false` | no       |
+| `labels_snake_case`       | `bool`              | Output labels on metrics in snake case instead of camel case.                  | `false` | no       |
 
 If you define the `["name", "type"]` under `"AWS/EC2"` in the `discovery_exported_tags` argument, it exports the name and type tags and its values as labels in all metrics.
 This affects all discovery jobs.


### PR DESCRIPTION


<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style with a capitalized
  description, e.g. `feat(scope): Add the thing` (not `add the thing`). For
  details on this, check out the Contributors Guide linked above.
-->

### Brief description of Pull Request

Fixes documentation for prometheus.exporter.cloudwatch labels_snake_case argument.


### Pull Request Details

The argument is listed in the documentation as `labels_to_snake_case` but the accepted argument is `labels_snake_case`.

The argument is defined as `labelsSnakeCase` in the alloy source code: https://github.com/grafana/alloy/blob/main/internal/static/integrations/cloudwatch_exporter/cloudwatch_exporter.go#L49

