### PR TITLE
docs: Introduce GenAI Contributions Policy for Alloy Project

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -231,6 +231,12 @@ body:
       label: Logs
       description: Provide logs relevant to the issue. Remove sensitive information before sharing. This will be formatted into a code block; don't add backtick code fences.
       render: text
+  - type: checkboxes
+    attributes:
+      label: AI disclosure
+      description: See the [Generative AI Contribution Policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md).
+      options:
+        - label: This issue was substantially generated with AI assistance.
   - type: dropdown
     attributes:
       label: Tip

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -213,6 +213,12 @@ body:
       description: Why do you need this feature?
     validations:
       required: true
+  - type: checkboxes
+    attributes:
+      label: AI disclosure
+      description: See the [Generative AI Contribution Policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md).
+      options:
+        - label: This issue was substantially generated with AI assistance.
   - type: dropdown
     attributes:
       label: Tip

--- a/.github/ISSUE_TEMPLATE/proposal.yaml
+++ b/.github/ISSUE_TEMPLATE/proposal.yaml
@@ -213,6 +213,12 @@ body:
       description: How do you propose we implement the functionality?
     validations:
       required: true
+  - type: checkboxes
+    attributes:
+      label: AI disclosure
+      description: See the [Generative AI Contribution Policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md).
+      options:
+        - label: This issue was substantially generated with AI assistance.
   - type: dropdown
     attributes:
       label: Tip

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -38,3 +38,4 @@
 - [ ] Documentation added
 - [ ] Tests updated
 - [ ] Config converters updated
+- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,8 @@ Multi-module Go repo: root, `syntax/`, `collector/`, `extension/alloyengine/`, `
 
 ## Essential references
 
+- Generative AI contribution policy: [docs/developer/genai.md](docs/developer/genai.md)
+  - **If you are an AI agent, or a human using AI assistance for this contribution, read this policy.** It covers acceptable use, disclosure, and the guidlines for contributing AI generated code.
 - Contributing and PR workflow: [docs/developer/contributing.md](docs/developer/contributing.md)
   - Use the conventional commit formats and PR titles as described in the contributing guide. The description after the `type(scope):` prefix **must start with a capital letter** (e.g. `feat(loki.process): Add ...`, not `feat(loki.process): add ...`) — a CI check enforces this on PR titles, and squash-merge means the PR title is what lands in `main`.
   - **One logical change per PR — one bug fix, one feature, or one new component.** Bundling multiple components or unrelated features into a single PR makes review slow and produces an incorrect changelog (squash-merge means one PR = one changelog entry). If the PR title needs an "and", split it.

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -16,6 +16,7 @@ For trivial fixes or improvements, pull requests can be opened immediately witho
     Environments][best-practices]
   - The [Uber Go Style Guide][uber-style-guide]
 - Sign our [CLA][], otherwise we're not able to accept contributions.
+- If you use generative AI tools, review our [Generative AI Contribution Policy](./genai.md).
 
 ## Steps to Contribute
 

--- a/docs/developer/genai.md
+++ b/docs/developer/genai.md
@@ -10,7 +10,7 @@ when contributing to the project.
 
 GenAI is a tool that assists you. It is not a substitute for your own understanding, judgment, or
 accountability. By submitting a contribution, you are vouching for it as your own work, regardless
-of which tools helped you produce it. You are expected to understand, review, and stand behind
+of which tools helped you produce it. You are expected to understand, review, and provide rationale for
 everything you submit.
 
 ## Acceptable use

--- a/docs/developer/genai.md
+++ b/docs/developer/genai.md
@@ -23,8 +23,7 @@ You are welcome to use GenAI tools to:
   reasoning.
 - Translate, summarize, or improve the clarity of text you have written.
 
-In all cases, you remain the author: you read the output, you correct it, and you make sure it meets
-the project's standards before submitting.
+In all cases, you remain the author: you read the output, you correct it, and you ensure your contribution meets the project's standards before submitting an issue, pull request, or comment.
 
 ## Not acceptable
 

--- a/docs/developer/genai.md
+++ b/docs/developer/genai.md
@@ -81,13 +81,8 @@ For new components and larger changes, follow the existing [proposal process][pr
 A proposal or design document must reflect your own reasoning. AI may help you draft it, but you own
 the argument in the public consensus discussion.
 
-If you contribute a [community component][community-components], remember that doing so makes you its
-maintainer. AI can help you author it, but you accept ongoing, human responsibility for maintaining
-it.
-
 [issue-triage]: ./issue-triage.md
 [license]: ../../LICENSE
 [cla]: https://cla-assistant.io/grafana/alloy
 [contributing-deps]: ./contributing.md#dependency-management
 [proposal-process]: ../design/README.md
-[community-components]: ./adding-community-components.md

--- a/docs/developer/genai.md
+++ b/docs/developer/genai.md
@@ -44,7 +44,7 @@ Do not:
 Maintainers may close low-effort AI-generated contributions, following the same
 [issue triage process][issue-triage] used for other contributions. When they do, they should explain
 why and, where appropriate, offer guidance on how to improve the contribution. Repeated low-effort
-submissions will trigger additional review and offending users blocked from further contributing.
+submissions will trigger stricter review, and maintainers may block repeat offenders from contributing.
 
 ## Approved automation
 

--- a/docs/developer/genai.md
+++ b/docs/developer/genai.md
@@ -40,7 +40,7 @@ Do not:
 - Wire up an AI agent to respond automatically to reviewers or other community members on your
   behalf. If you want help from GenAI in a discussion, use it yourself and post in your own words,
   rather than connecting it directly to maintainers.
-
+- Submit PRs or issues which do not follow our defined templates
 Maintainers may close low-effort AI-generated contributions, following the same
 [issue triage process][issue-triage] used for other contributions. When they do, they should explain
 why and, where appropriate, offer guidance on how to improve the contribution. Repeated low-effort

--- a/docs/developer/genai.md
+++ b/docs/developer/genai.md
@@ -9,7 +9,7 @@ when contributing to the project.
 **The human contributor is always in control and fully responsible for their contribution.**
 
 GenAI is a tool that assists you. It is not a substitute for your own understanding, judgment, or
-accountability. By submitting a contribution, you are vouching for it as your own work, regardless
+accountability. By submitting a contribution, you vouch for it as your own work, regardless
 of which tools helped you produce it. You are expected to understand, review, and provide rationale for
 everything you submit.
 

--- a/docs/developer/genai.md
+++ b/docs/developer/genai.md
@@ -36,7 +36,7 @@ Do not:
   change, but the review and its conclusions must be yours.
 - File automated, bot-driven issues or pull requests from tools that have not been approved by the
   Alloy team. This policy covers humans using AI assistance, not autonomous agents acting on their
-  own.
+  own, including agentic IDE tools that file pull requests without human review.
 - Paste generated text into a discussion without adding your own analysis and context.
 - Wire up an AI agent to respond automatically to reviewers or other community members on your
   behalf. If you want help from GenAI in a discussion, use it yourself and post in your own words,

--- a/docs/developer/genai.md
+++ b/docs/developer/genai.md
@@ -1,0 +1,93 @@
+# Generative AI Contribution Policy
+
+Generative AI (GenAI) tools such as large language model (LLM) assistants can help you write code,
+documentation, and proposals for Grafana Alloy. This policy explains how to use them responsibly
+when contributing to the project.
+
+## Core principle
+
+**The human contributor is always in control and fully responsible for their contribution.**
+
+GenAI is a tool that assists you. It is not a substitute for your own understanding, judgment, or
+accountability. By submitting a contribution, you are vouching for it as your own work, regardless
+of which tools helped you produce it. You are expected to understand, review, and stand behind
+everything you submit.
+
+## Acceptable use
+
+You are welcome to use GenAI tools to:
+
+- Write or refactor code and documentation, as long as you actively review and refine the output.
+- Understand the Alloy codebase, a component, or a subsystem before contributing or reviewing.
+- Draft issues, proposals, or design documents that you then verify and shape into your own
+  reasoning.
+- Translate, summarize, or improve the clarity of text you have written.
+
+In all cases, you remain the author: you read the output, you correct it, and you make sure it meets
+the project's standards before submitting.
+
+## Not acceptable
+
+Do not:
+
+- Submit unreviewed, bulk AI-generated content to pull requests, issues or proposals. If you
+  did not read and understand it, do not submit it.
+- Use GenAI as a substitute for human judgment in code review. An AI tool may help you understand a
+  change, but the review and its conclusions must be yours.
+- File automated, bot-driven issues or pull requests. This policy covers humans using AI assistance,
+  not autonomous agents acting on their own.
+- Paste generated text into a discussion as if it were a considered human response without adding
+  your own analysis and context.
+
+Maintainers may close low-effort AI-generated contributions, following the same
+[issue triage process][issue-triage] used for other contributions. When they do, they should explain
+why and, where appropriate, offer guidance on how to improve the contribution. Repeated low-effort
+submissions may be escalated to the Alloy team and offending users blocked from further contributing.
+
+## Disclosure
+
+When GenAI generates the **bulk** of a contribution, disclose it. For pull requests, check the
+**"This pull request was substantially generated with AI assistance"** box in the pull request
+template. Minor, incidental help such as autocomplete or small edits does not need to be disclosed.
+
+Disclosure is not a mark against your contribution. It helps reviewers calibrate their attention and
+keeps the project's expectations transparent.
+
+## Licensing and provenance
+
+Grafana Alloy is licensed under [Apache 2.0][license], and all contributions require a signed
+[Contributor License Agreement (CLA)][cla]. These obligations apply equally to AI-assisted
+contributions.
+
+When you contribute AI-assisted code or content, you warrant that:
+
+- You have the right to contribute it under the project's license and CLA.
+- It does not reproduce code or text from sources whose licenses are incompatible with Apache 2.0
+  (for example, GPL-licensed or proprietary code that an LLM may have reproduced from its training
+  data).
+- Any third-party code or dependencies it introduces are license-compatible and follow the
+  [dependency guidance][contributing-deps] in the contributing guide.
+
+Because Alloy vendors and wraps many upstream components, provenance matters. If you are unsure
+whether generated code is original or where it came from, do not submit it.
+
+## Alloy-specific guidance
+
+LLMs frequently hallucinate Alloy configuration syntax, component names, and component arguments,
+and may produce configurations or components that do not match the current schemas. Always validate
+AI-generated code and configuration against the real component definitions and the project's checks.
+
+For new components and larger changes, follow the existing [proposal process][proposal-process].
+A proposal or design document must reflect your own reasoning. AI may help you draft it, but you own
+the argument in the public consensus discussion.
+
+If you contribute a [community component][community-components], remember that doing so makes you its
+maintainer. AI can help you author it, but you accept ongoing, human responsibility for maintaining
+it.
+
+[issue-triage]: ./issue-triage.md
+[license]: ../../LICENSE
+[cla]: https://cla-assistant.io/grafana/alloy
+[contributing-deps]: ./contributing.md#dependency-management
+[proposal-process]: ../design/README.md
+[community-components]: ./adding-community-components.md

--- a/docs/developer/genai.md
+++ b/docs/developer/genai.md
@@ -84,13 +84,18 @@ whether generated code is original or where it came from, do not submit it.
 ## Alloy-specific guidance
 
 LLMs frequently hallucinate Alloy configuration syntax, component names, and component arguments,
-and may produce configurations or components that do not match the current schemas. Always validate
-AI-generated code and configuration against the real component definitions and the project's checks.
+and may produce configurations or components that do not match the current schemas. To reduce these
+errors, point the tool at authoritative sources rather than relying on its training data: provide the
+[Alloy documentation][alloy-docs] and the relevant component source code, ideally pinned to the
+specific Alloy version or git tag you are targeting, and ask the tool to validate its output against
+them. Always validate AI-generated code and configuration against the real component definitions and
+the project's checks before submitting.
 
 For new components and larger changes, follow the existing [proposal process][proposal-process].
 A proposal or design document must reflect your own reasoning. AI may help you draft it, but you own
 the argument in the public consensus discussion.
 
+[alloy-docs]: https://grafana.com/docs/alloy/latest/
 [issue-triage]: ./issue-triage.md
 [license]: ../../LICENSE
 [cla]: https://cla-assistant.io/grafana/alloy

--- a/docs/developer/genai.md
+++ b/docs/developer/genai.md
@@ -41,7 +41,7 @@ Do not:
 Maintainers may close low-effort AI-generated contributions, following the same
 [issue triage process][issue-triage] used for other contributions. When they do, they should explain
 why and, where appropriate, offer guidance on how to improve the contribution. Repeated low-effort
-submissions may be escalated to the Alloy team and offending users blocked from further contributing.
+submissions will trigger additional review and offending users blocked from further contributing.
 
 ## Disclosure
 

--- a/docs/developer/genai.md
+++ b/docs/developer/genai.md
@@ -36,8 +36,7 @@ Do not:
 - File automated, bot-driven issues or pull requests from tools that have not been approved by the
   Alloy team. This policy covers humans using AI assistance, not autonomous agents acting on their
   own.
-- Paste generated text into a discussion as if it were a considered human response without adding
-  your own analysis and context.
+- Paste generated text into a discussion without adding your own analysis and context.
 - Wire up an AI agent to respond automatically to reviewers or other community members on your
   behalf. If you want help from GenAI in a discussion, use it yourself and post in your own words,
   rather than connecting it directly to maintainers.

--- a/docs/developer/genai.md
+++ b/docs/developer/genai.md
@@ -42,6 +42,7 @@ Do not:
   behalf. If you want help from GenAI in a discussion, use it yourself and post in your own words,
   rather than connecting it directly to maintainers.
 - Submit PRs or issues which do not follow our defined templates
+
 Maintainers may close low-effort AI-generated contributions, following the same
 [issue triage process][issue-triage] used for other contributions. When they do, they should explain
 why and, where appropriate, offer guidance on how to improve the contribution. Repeated low-effort

--- a/docs/developer/genai.md
+++ b/docs/developer/genai.md
@@ -29,7 +29,7 @@ In all cases, you remain the author: you read the output, you correct it, and yo
 
 Do not:
 
-- Submit unreviewed, bulk AI-generated content to pull requests, issues or proposals. If you
+- Submit unreviewed, bulk AI-generated content to pull requests, issues, or proposals. If you
   did not read and understand it, do not submit it.
 - Use GenAI as a substitute for human judgment in code review. An AI tool may help you understand a
   change, but the review and its conclusions must be yours.

--- a/docs/developer/genai.md
+++ b/docs/developer/genai.md
@@ -77,8 +77,8 @@ When you contribute AI-assisted code or content, you warrant that:
 - Any third-party code or dependencies it introduces are license-compatible and follow the
   [dependency guidance][contributing-deps] in the contributing guide.
 
-Because Alloy vendors and wraps many upstream components, provenance matters. If you are unsure
-whether generated code is original or where it came from, do not submit it.
+Alloy vendors and wraps many upstream components. Provenance matters, so check where generated code came from.
+If you are unsure whether the generated code is original or license-compatible, do not submit it.
 
 ## Alloy-specific guidance
 

--- a/docs/developer/genai.md
+++ b/docs/developer/genai.md
@@ -59,8 +59,8 @@ When GenAI generates the **bulk** of a contribution, disclose it. For pull reque
 **"This pull request was substantially generated with AI assistance"** box in the pull request
 template. Minor, incidental help such as autocomplete or small edits does not need to be disclosed.
 
-Disclosure is not a mark against your contribution. It helps reviewers calibrate their attention and
-keeps the project's expectations transparent.
+Disclosure is not a mark against your contribution. It helps reviewers know where to focus, and it
+keeps expectations clear for everyone.
 
 ## Licensing and provenance
 

--- a/docs/developer/genai.md
+++ b/docs/developer/genai.md
@@ -38,6 +38,9 @@ Do not:
   own.
 - Paste generated text into a discussion as if it were a considered human response without adding
   your own analysis and context.
+- Wire up an AI agent to respond automatically to reviewers or other community members on your
+  behalf. If you want help from GenAI in a discussion, use it yourself and post in your own words,
+  rather than connecting it directly to maintainers.
 
 Maintainers may close low-effort AI-generated contributions, following the same
 [issue triage process][issue-triage] used for other contributions. When they do, they should explain

--- a/docs/developer/genai.md
+++ b/docs/developer/genai.md
@@ -1,7 +1,7 @@
 # Generative AI Contribution Policy
 
 Generative AI (GenAI) tools such as large language model (LLM) assistants can help you write code,
-documentation, and proposals for Grafana Alloy. This policy explains how to use them responsibly
+documentation, and proposals for Grafana Alloy. This policy explains what is an acceptable use of GenAI tools
 when contributing to the project.
 
 ## Core principle

--- a/docs/developer/genai.md
+++ b/docs/developer/genai.md
@@ -33,8 +33,9 @@ Do not:
   did not read and understand it, do not submit it.
 - Use GenAI as a substitute for human judgment in code review. An AI tool may help you understand a
   change, but the review and its conclusions must be yours.
-- File automated, bot-driven issues or pull requests. This policy covers humans using AI assistance,
-  not autonomous agents acting on their own.
+- File automated, bot-driven issues or pull requests from tools that have not been approved by the
+  Alloy team. This policy covers humans using AI assistance, not autonomous agents acting on their
+  own.
 - Paste generated text into a discussion as if it were a considered human response without adding
   your own analysis and context.
 
@@ -42,6 +43,13 @@ Maintainers may close low-effort AI-generated contributions, following the same
 [issue triage process][issue-triage] used for other contributions. When they do, they should explain
 why and, where appropriate, offer guidance on how to improve the contribution. Repeated low-effort
 submissions will trigger additional review and offending users blocked from further contributing.
+
+## Approved automation
+
+Some automated tools are explicitly approved by the Alloy team and are an acceptable exception to the
+rule against bot-driven contributions. Examples include GitHub Copilot and the automated dependency
+review bot, and the Alloy team may approve more over time. Contributions from these tools are always
+clearly marked as bot-generated so that reviewers can tell them apart from human contributions.
 
 ## Disclosure
 

--- a/docs/developer/genai.md
+++ b/docs/developer/genai.md
@@ -23,7 +23,8 @@ You are welcome to use GenAI tools to:
   reasoning.
 - Translate, summarize, or improve the clarity of text you have written.
 
-In all cases, you remain the author: you read the output, you correct it, and you ensure your contribution meets the project's standards before submitting an issue, pull request, or comment.
+In all cases, you remain the author. You read the output, you correct it, and you ensure your
+contribution meets the project's standards before submitting an issue, pull request, or comment.
 
 ## Not acceptable
 


### PR DESCRIPTION
An initial draft of an AI contribution policy for Alloy

Part of https://github.com/grafana/alloy/issues/6402

This also includes updating the PR template to include a disclosure checkbox that contributors can use to indicate if their PR's were predominantly generated with AI. Open to other way forwards there in terms of disclosing, but thought this would be a simple enough first step

I also added a section specifically about licensing, feedback would be useful there just to make sure I understand those implications correctly