### PR TITLE
ci: Add GAR <-> Dockerhub Mirror Wait Action In Workflows with Race Condition

### DIFF
--- a/.github/workflows/publish-alloy-devel.yml
+++ b/.github/workflows/publish-alloy-devel.yml
@@ -65,9 +65,10 @@ jobs:
     - name: Get the image tag
       id: get-tag
       run: |
-        echo "$(bash ./scripts/image-tag-docker)" > .tag-only
-        echo "grafana/alloy-dev:$(bash ./scripts/image-tag-docker)" > .image-tag
-        echo "tag=$(bash ./scripts/image-tag-docker)" >> "$GITHUB_OUTPUT"
+        TAG="$(bash ./scripts/image-tag-docker)"
+        echo "${TAG}" > .tag-only
+        echo "grafana/alloy-dev:${TAG}" > .image-tag
+        echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
       # This step needs to run after "Get the image tag".
       # That's because the login to GAR generates a new file.

--- a/.github/workflows/publish-alloy-devel.yml
+++ b/.github/workflows/publish-alloy-devel.yml
@@ -63,9 +63,11 @@ jobs:
         persist-credentials: false
 
     - name: Get the image tag
+      id: get-tag
       run: |
         echo "$(bash ./scripts/image-tag-docker)" > .tag-only
         echo "grafana/alloy-dev:$(bash ./scripts/image-tag-docker)" > .image-tag
+        echo "tag=$(bash ./scripts/image-tag-docker)" >> "$GITHUB_OUTPUT"
 
       # This step needs to run after "Get the image tag".
       # That's because the login to GAR generates a new file.
@@ -75,6 +77,12 @@ jobs:
       uses: grafana/shared-workflows/actions/login-to-gar@1f541877ceb22c7be7667d8a8df04984aeac9f9d # login-to-gar/v1.0.3
       with:
         registry: us-docker.pkg.dev
+
+    - name: Wait for image to mirror to DockerHub
+      uses: grafana/shared-workflows/actions/wait-for-docker-publish@cd185787ec303639a71383384e1b0d424b7422fb # wait-for-docker-publish/v0.2.0
+      with:
+        image: grafana/alloy-dev:${{ steps.get-tag.outputs.tag }}
+        timeout: 10m
 
     - name: Update to latest image
       run: |

--- a/.github/workflows/trigger-argo-workflow-on-tag.yml
+++ b/.github/workflows/trigger-argo-workflow-on-tag.yml
@@ -61,6 +61,13 @@ jobs:
           fi
           echo "Tag ${TAG_NAME} exists in repository"
 
+      - name: Wait for release image to mirror to DockerHub
+        if: steps.validate.outputs.is_alloy == 'true'
+        uses: grafana/shared-workflows/actions/wait-for-docker-publish@cd185787ec303639a71383384e1b0d424b7422fb # wait-for-docker-publish/v0.2.0
+        with:
+          image: grafana/alloy:${{ steps.tag.outputs.tag }}
+          timeout: 10m
+
       - name: Trigger ArgoCD Workflow
         if: steps.validate.outputs.is_alloy == 'true'
         uses: grafana/shared-workflows/actions/trigger-argo-workflow@a37de51f3d713a30a9e4b21bcdfbd38170020593 # v1.3.0


### PR DESCRIPTION
This PR incorporates the [GAR mirror wait action](https://github.com/grafana/shared-workflows/pull/1956) into workflows where there could be a race condition if mirror fails or is slow:

1. `publish-alloy-devel.yml` => this workflow will first publish devel images to GAR, then immediately proceeds to open a PR against `deployment_tools`. We can insert a wait action between the former and latter steps
2. `trigger-argo-workflow-on-tag.yml` => this workflow will trigger an argo deployment workflow that deploys devel images to our internal environment for testing, we can use this wait action as a check to ensure that mirroring is complete before we start opening any PR's against `deployment_tools` as part of the argo workflow