### PR TITLE
feat(logging): Add option to disable Alloy log timestamps

### DIFF
--- a/docs/sources/reference/config-blocks/logging.md
+++ b/docs/sources/reference/config-blocks/logging.md
@@ -25,12 +25,13 @@ logging {
 
 You can use the following arguments with `logging`:
 
-| Name          | Type                 | Description                                  | Default       | Required |
-| ------------- | -------------------- | -------------------------------------------- | ------------- | -------- |
-| `destination` | `string`             | Primary log destination.                     | __See below__ | no       |
-| `format`      | `string`             | Format to use for writing log lines.         | `"logfmt"`    | no       |
-| `level`       | `string`             | Level at which log lines should be written.  | `"info"`      | no       |
-| `write_to`    | `list(LogsReceiver)` | List of receivers to send log entries to.    | `[]`          | no       |
+| Name                | Type                 | Description                                 | Default       | Required |
+| ------------------- | -------------------- | ------------------------------------------- | ------------- | -------- |
+| `destination`       | `string`             | Primary log destination.                    | **See below** | no       |
+| `disable_timestamp` | `bool`               | Whether to omit timestamps from log lines.  | `false`       | no       |
+| `format`            | `string`             | Format to use for writing log lines.        | `"logfmt"`    | no       |
+| `level`             | `string`             | Level at which log lines should be written. | `"info"`      | no       |
+| `write_to`          | `list(LogsReceiver)` | List of receivers to send log entries to.   | `[]`          | no       |
 
 ### `level`
 
@@ -58,12 +59,18 @@ This, for example can be the export of a `loki.write` component to send log entr
 The following strings are recognized as valid log destinations:
 
 * `"stderr"`: Write logs to `stderr`.
-* `"windows_event_log"`:  Windows only. Write logs to the Windows Event Log under the "Alloy" source.
+* `"windows_event_log"`: Windows only. Write logs to the Windows Event Log under the "Alloy" source.
 
 The default value of `destination` is set to `"windows_event_log"` when {{< param "PRODUCT_NAME" >}} runs as a Windows service.
 Otherwise, `destination` defaults to `"stderr"`.
 
 {{< param "PRODUCT_NAME" >}} fails to start if `destination` is set to `"windows_event_log"` and {{< param "PRODUCT_NAME" >}} is not running on Windows.
+
+### `disable_timestamp`
+
+The `disable_timestamp` argument controls whether {{< param "PRODUCT_NAME" >}} includes timestamps in its log lines.
+
+When `disable_timestamp` is `true`, {{< param "PRODUCT_NAME" >}} omits the timestamp field from log lines written to the configured destination.
 
 ## Retrieve logs
 
@@ -100,6 +107,7 @@ You can retrieve the logs in different ways depending on your platform and insta
 logging {
   level  = "info"
   format = "logfmt"
+  disable_timestamp = false
 }
 ```
 

--- a/internal/runtime/logging/handler.go
+++ b/internal/runtime/logging/handler.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -169,6 +170,15 @@ var unsafeKeyCharReplacer = strings.NewReplacer(
 	"\f", "_",
 	"\r", "_",
 )
+
+func replaceWithOptions(disableTimestamp *atomic.Bool) func([]string, slog.Attr) slog.Attr {
+	return func(groups []string, a slog.Attr) slog.Attr {
+		if len(groups) == 0 && a.Key == slog.TimeKey && disableTimestamp.Load() {
+			return slog.Attr{}
+		}
+		return replace(groups, a)
+	}
+}
 
 func replace(groups []string, a slog.Attr) slog.Attr {
 	if len(groups) > 0 {

--- a/internal/runtime/logging/handler.go
+++ b/internal/runtime/logging/handler.go
@@ -7,8 +7,9 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
+
+	"go.uber.org/atomic"
 )
 
 // We need an implementation of slog.Handler that always matches the current

--- a/internal/runtime/logging/logger.go
+++ b/internal/runtime/logging/logger.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/prometheus/common/model"
@@ -36,6 +37,8 @@ type Logger struct {
 	// the optional Windows Event Log.
 	handler      *handler
 	deferredSlog *deferredSlogHandler // Buffers slog output until config is loaded, then delegates to handler.
+
+	disableTimestamp atomic.Bool // controls whether timestamps are omitted from serialized logs.
 }
 
 var _ EnabledAware = (*Logger)(nil)
@@ -76,6 +79,7 @@ func NewDeferred(w io.Writer) (*Logger, error) {
 		leveler slog.LevelVar
 		format  formatVar
 	)
+
 	// innerWriter is stable for the life of the Logger; destinations that
 	// want to suppress it (windows_event_log) lazily open an event log via
 	// the writer's own opener instead of swapping the writer.
@@ -83,17 +87,17 @@ func NewDeferred(w io.Writer) (*Logger, error) {
 		innerWriter:    w,
 		eventLogOpener: eventlog.GetEventLogOpener(),
 	}
-	bh := newHandler(writer, &leveler, &format, replace, nil)
 
 	l := &Logger{
 		buffer:       []*bufferedItem{},
 		hasLogFormat: false,
-
-		level:   &leveler,
-		format:  &format,
-		writer:  writer,
-		handler: bh,
+		level:        &leveler,
+		format:       &format,
+		writer:       writer,
 	}
+
+	replacer := replaceWithOptions(&l.disableTimestamp)
+	l.handler = newHandler(writer, &leveler, &format, replacer, nil)
 	l.deferredSlog = newDeferredHandler(l)
 
 	return l, nil
@@ -118,6 +122,7 @@ func (l *Logger) Update(o Options) error {
 	l.bufferMut.Lock()
 	l.level.Set(slogLevel(o.Level).Level())
 	l.format.Set(o.Format)
+	l.disableTimestamp.Store(o.DisableTimestamp)
 	if err := l.writer.SetDestination(o.Destination); err != nil {
 		l.bufferMut.Unlock()
 		return err

--- a/internal/runtime/logging/logger.go
+++ b/internal/runtime/logging/logger.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"log/slog"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/prometheus/common/model"
@@ -14,6 +13,7 @@ import (
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/runtime/logging/eventlog"
 	"github.com/grafana/loki/pkg/push"
+	"go.uber.org/atomic"
 )
 
 type EnabledAware interface {

--- a/internal/runtime/logging/logger_test.go
+++ b/internal/runtime/logging/logger_test.go
@@ -3,6 +3,7 @@ package logging_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -122,6 +123,98 @@ func TestLevels(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDisableTimestamp(t *testing.T) {
+	tests := []struct {
+		name   string
+		format logging.Format
+		check  func(*testing.T, string)
+	}{
+		{
+			name:   "logfmt",
+			format: logging.FormatLogfmt,
+			check: func(t *testing.T, output string) {
+				require.NotContains(t, output, "ts=")
+				require.Contains(t, output, "level=info msg=test")
+			},
+		},
+		{
+			name:   "json",
+			format: logging.FormatJSON,
+			check: func(t *testing.T, output string) {
+				var record map[string]any
+				require.NoError(t, json.Unmarshal([]byte(output), &record))
+				require.NotContains(t, record, "ts")
+				require.Equal(t, "test", record["msg"])
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			opts := infoLevel()
+			opts.Format = tc.format
+			opts.DisableTimestamp = true
+
+			logger, err := logging.New(&buf, opts)
+			require.NoError(t, err)
+			logger.Slog().Info("test")
+
+			tc.check(t, buf.String())
+		})
+	}
+}
+
+func TestDisableTimestampPreservesNestedTimeAttribute(t *testing.T) {
+	var buf bytes.Buffer
+	opts := infoLevel()
+	opts.DisableTimestamp = true
+
+	logger, err := logging.New(&buf, opts)
+	require.NoError(t, err)
+	logger.Slog().WithGroup("details").Info("test", slog.String("time", "user-value"))
+
+	require.NotContains(t, buf.String(), "ts=")
+	require.Contains(t, buf.String(), "details.time=user-value")
+}
+
+func TestDisableTimestampUpdate(t *testing.T) {
+	var buf bytes.Buffer
+	opts := infoLevel()
+
+	logger, err := logging.New(&buf, opts)
+	require.NoError(t, err)
+	logger.Slog().Info("enabled-before-update")
+	require.Contains(t, buf.String(), "ts=")
+
+	buf.Reset()
+	opts.DisableTimestamp = true
+	require.NoError(t, logger.Update(opts))
+	logger.Slog().Info("disabled-after-update")
+	require.NotContains(t, buf.String(), "ts=")
+
+	buf.Reset()
+	opts.DisableTimestamp = false
+	require.NoError(t, logger.Update(opts))
+	logger.Slog().Info("enabled-after-second-update")
+	require.Contains(t, buf.String(), "ts=")
+}
+
+func TestDisableTimestampBufferedRecord(t *testing.T) {
+	var buf bytes.Buffer
+	logger, err := logging.NewDeferred(&buf)
+	require.NoError(t, err)
+
+	logger.Slog().Info("buffered")
+	require.Empty(t, buf.String())
+
+	opts := infoLevel()
+	opts.DisableTimestamp = true
+	require.NoError(t, logger.Update(opts))
+	require.Contains(t, buf.String(), "msg=buffered")
+	require.NotContains(t, buf.String(), "ts=")
 }
 
 // Test_lokiWriter_nil ensures that writing to a lokiWriter doesn't panic when

--- a/internal/runtime/logging/options.go
+++ b/internal/runtime/logging/options.go
@@ -12,9 +12,10 @@ import (
 
 // Options is a set of options used to construct and configure a Logger.
 type Options struct {
-	Level       Level          `alloy:"level,attr,optional"`
-	Format      Format         `alloy:"format,attr,optional"`
-	Destination LogDestination `alloy:"destination,attr,optional"`
+	Level            Level          `alloy:"level,attr,optional"`
+	Format           Format         `alloy:"format,attr,optional"`
+	Destination      LogDestination `alloy:"destination,attr,optional"`
+	DisableTimestamp bool           `alloy:"disable_timestamp,attr,optional"`
 
 	WriteTo []loki.LogsReceiver `alloy:"write_to,attr,optional"`
 }

--- a/internal/runtime/logging/options_test.go
+++ b/internal/runtime/logging/options_test.go
@@ -88,3 +88,37 @@ func TestOptions_EndToEnd(t *testing.T) {
 		})
 	}
 }
+
+func TestOptionsDisableTimestamp(t *testing.T) {
+	tests := []struct {
+		name   string
+		config string
+		want   bool
+	}{
+		{
+			name:   "omitted",
+			config: `level = "info"`,
+			want:   false,
+		},
+		{
+			name:   "enabled",
+			config: `disable_timestamp = true`,
+			want:   true,
+		},
+		{
+			name:   "explicitly disabled",
+			config: `disable_timestamp = false`,
+			want:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stubIsWindowsService(t, false)
+
+			var o Options
+			require.NoError(t, syntax.Unmarshal([]byte(tc.config), &o))
+			require.Equal(t, tc.want, o.DisableTimestamp)
+		})
+	}
+}


### PR DESCRIPTION
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style with a capitalized
  description, e.g. `feat(scope): Add the thing` (not `add the thing`). For
  details on this, check out the Contributors Guide linked above.
-->

### Brief description of Pull Request
Adds a `disable_timestamp` option to the global `logging` block. When enabled, Alloy omits the timestamp field from its own serialized log output while preserving all other log attributes.

<!-- Human-readable description of the PR used as squash commit body. -->


### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->
Fixes #6571

### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
