### PR TITLE
fix(loki.process): Log logfmt decode failures at debug instead of error

### DIFF
--- a/internal/component/loki/process/stages/logfmt.go
+++ b/internal/component/loki/process/stages/logfmt.go
@@ -127,7 +127,7 @@ func (j *logfmtStage) Process(labels model.LabelSet, extracted map[string]any, t
 	}
 
 	if decoder.Err() != nil {
-		j.logger.Error("failed to decode logfmt", "err", decoder.Err())
+		j.logger.Debug("failed to decode logfmt", "err", decoder.Err())
 		return
 	}
 


### PR DESCRIPTION
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style with a capitalized
  description, e.g. `feat(scope): Add the thing` (not `add the thing`). For
  details on this, check out the Contributors Guide linked above.
-->

### Brief description of Pull Request

Lowers the log level of logfmt decode failures in the `loki.process` logfmt stage from `error` to `debug`. A single malformed log line is bad input, not an Alloy fault, so an unparseable entry shouldn't spam the logs at error level.

Somewhat related, the JSON parser is set to debug when those logs fail to parse (https://github.com/grafana/alloy/blob/main/internal/component/loki/process/stages/json.go#L140-L145)

### Pull Request Details

https://github.com/grafana/deployment_tools/pull/625507#discussion_r3472542269

> So when parsing json alloy only ever emits debug logs, even when we fail to parse a line. But logfmt is a problem since it will produce error logs for every failed parse, we should probably change that to debug as well so you don't have to do this workaround just to reduce noisy logs


### Issue(s) fixed by this Pull Request

N/A


### Notes to the Reviewer


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
