### PR TITLE
perf(loki.source.file): Remove one goroutine per tailed file

### DIFF
--- a/internal/component/loki/source/file/internal/tail/file.go
+++ b/internal/component/loki/source/file/internal/tail/file.go
@@ -2,12 +2,10 @@ package tail
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"os"
-	"sync"
 	"time"
 
 	"github.com/grafana/dskit/backoff"
@@ -15,10 +13,10 @@ import (
 	"github.com/grafana/alloy/internal/component/loki/source/file/internal/tail/fileext"
 )
 
-// NewFile creates a new File tailer for the specified file path.
+// NewFile creates a new File for the specified file path.
 // It opens the file and seeks to the provided offset if one is specified.
 // The returned File can be used to read lines from the file as they are appended.
-// The caller is responsible for calling Stop() when done to close the file and clean up resources.
+// The caller is responsible for calling Close() when done to clean up resources.
 func NewFile(logger *slog.Logger, cfg *Config) (*File, error) {
 	f, err := fileext.OpenFile(cfg.Filename)
 	if err != nil {
@@ -48,28 +46,26 @@ func NewFile(logger *slog.Logger, cfg *Config) (*File, error) {
 	}
 
 	cfg.WatcherConfig.MinPollFrequency = min(cfg.WatcherConfig.MinPollFrequency, cfg.WatcherConfig.MaxPollFrequency)
-	ctx, cancel := context.WithCancel(context.Background())
-
 	return &File{
 		cfg:       cfg,
 		logger:    logger,
 		file:      f,
 		reader:    reader,
-		ctx:       ctx,
-		cancel:    cancel,
 		signature: sig,
-		waitAtEOF: cfg.Compression == "",
 	}, nil
 }
 
 // File represents a file being tailed. It provides methods to read lines
 // from the file as they are appended, handling file events such as truncation,
-// deletion, and modification. File is safe for concurrent use.
+// deletion, and modification.
+//
+// File is not safe for concurrent use: Next, Flush, Wait, and Close must all be
+// called from a single goroutine. Cancellation is driven through the context
+// passed to Wait rather than by closing the file from another goroutine.
 type File struct {
 	cfg    *Config
 	logger *slog.Logger
 
-	mu        sync.Mutex
 	file      *os.File
 	reader    *reader
 	signature *signature
@@ -77,29 +73,14 @@ type File struct {
 	// bufferedLines stores lines that were read from an old file handle before
 	// it was closed during file rotation.
 	bufferedLines []Line
-
-	ctx    context.Context
-	cancel context.CancelFunc
-
-	// waitAtEOF controls whether we should wait for file events
-	// when we get EOF
-	waitAtEOF bool
 }
 
-// Next reads and returns the next line from the file.
-// It blocks until a line is available, file is closed or unrecoverable error occurs.
-// If file was closed context.Canceled is returned.
+// Next returns the next available line from the file.
+// When no complete line is available it returns io.EOF. On io.EOF the caller
+// should call Wait to block until more data is available and then call Next
+// again, or call Flush to read any remaining partial line. Any other error
+// indicates an unrecoverable read or decode failure.
 func (f *File) Next() (*Line, error) {
-	select {
-	case <-f.ctx.Done():
-		return nil, f.ctx.Err()
-	default:
-	}
-
-	f.mu.Lock()
-	defer f.mu.Unlock()
-
-read:
 	// If we have buffered lines from a previous file rotation, return them first.
 	// These are lines that were read from the old file handle before it was closed,
 	// ensuring we don't lose any data during file rotation.
@@ -111,31 +92,23 @@ read:
 
 	text, err := f.reader.next()
 	if err != nil {
-		if errors.Is(err, io.EOF) && f.waitAtEOF {
-			if err := f.wait(); err != nil {
-				return nil, err
-			}
-			goto read
-		}
-
-		// If we should wait at EOF we go an unexpected error
-		// here and can just return.
-		if f.waitAtEOF {
-			return nil, err
-		}
-
-		if !errors.Is(err, io.EOF) {
-			return nil, err
-		}
-
-		// If we should return at EOF we want to flush all remaining
-		// data from reader.
-		text, err = f.reader.flush()
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 
+	return f.makeLine(text)
+}
+
+// Flush returns any remaining data at the end of the file not
+// terminated by a newline. It returns io.EOF if there is nothing left.
+func (f *File) Flush() (*Line, error) {
+	text, err := f.reader.flush()
+	if err != nil {
+		return nil, err
+	}
+	return f.makeLine(text)
+}
+
+func (f *File) makeLine(text string) (*Line, error) {
 	offset := f.reader.position()
 
 	// Recompute signature if we've crossed a threshold and haven't reached it yet.
@@ -157,11 +130,7 @@ read:
 }
 
 // Size returns the current size of the file in bytes.
-// It is safe to call concurrently with other File methods.
 func (f *File) Size() (int64, error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-
 	fi, err := f.file.Stat()
 	if err != nil {
 		return 0, err
@@ -169,25 +138,21 @@ func (f *File) Size() (int64, error) {
 	return fi.Size(), nil
 }
 
-// Stop closes the file and cancels any ongoing wait operations.
-// After Stop is called, Next() will return errors for any subsequent calls.
-// It is safe to call Stop multiple times.
-func (f *File) Stop() error {
-	f.cancel()
-	f.mu.Lock()
-	defer f.mu.Unlock()
+// Close closes the underlying file and releases its resources.
+func (f *File) Close() error {
 	return f.file.Close()
 }
 
-// wait blocks until a file event is detected (modification, truncation, or deletion).
-// Returns an error if the context is canceled or an unrecoverable error occurs.
-func (f *File) wait() error {
+// Wait blocks until a file event is detected (modification, truncation, or deletion).
+// It returns once the caller should resume calling Next, or an error if ctx is canceled
+// or the wait fails.
+func (f *File) Wait(ctx context.Context) error {
 	offset, err := f.offset()
 	if err != nil {
 		return err
 	}
 
-	event, err := blockUntilEvent(f.ctx, f.file, offset, f.cfg)
+	event, err := blockUntilEvent(ctx, f.file, offset, f.cfg)
 	switch event {
 	case eventModified:
 		f.logger.Debug("file modified")
@@ -195,7 +160,7 @@ func (f *File) wait() error {
 	case eventTruncated:
 		f.logger.Debug("file truncated")
 		// We need to reopen the file when it was truncated.
-		return f.reopen(true)
+		return f.reopen(ctx, true)
 	case eventDeleted:
 		f.logger.Debug("file deleted")
 		// If a file is deleted we want to make sure we drain what's remaining in the open file.
@@ -208,7 +173,7 @@ func (f *File) wait() error {
 		}
 		// In polling mode we could miss events when a file is deleted, so before we give up
 		// we try to reopen the file.
-		return f.reopen(false)
+		return f.reopen(ctx, false)
 	default:
 		return err
 	}
@@ -268,7 +233,7 @@ func (f *File) drain() {
 // which could cause the poller to hang on an open file handle to a file no longer being
 // written to. It saves the current file handle info to ensure we only start tailing a
 // different file instance.
-func (f *File) reopen(truncated bool) error {
+func (f *File) reopen(ctx context.Context, truncated bool) error {
 	cf, err := f.file.Stat()
 	if !truncated && err != nil {
 		// We don't action on this error but are logging it, not expecting to see it happen and not sure if we
@@ -278,7 +243,7 @@ func (f *File) reopen(truncated bool) error {
 
 	f.file.Close()
 
-	backoff := backoff.New(f.ctx, backoff.Config{
+	backoff := backoff.New(ctx, backoff.Config{
 		MinBackoff: f.cfg.WatcherConfig.MinPollFrequency,
 		MaxBackoff: f.cfg.WatcherConfig.MaxPollFrequency,
 		MaxRetries: 20,
@@ -289,7 +254,7 @@ func (f *File) reopen(truncated bool) error {
 		if err != nil {
 			if os.IsNotExist(err) {
 				f.logger.Debug("waiting for file to appear", "filename", f.cfg.Filename)
-				if err := blockUntilExists(f.ctx, f.cfg); err != nil {
+				if err := blockUntilExists(ctx, f.cfg); err != nil {
 					return fmt.Errorf("failed to detect creation of %s: %w", f.cfg.Filename, err)
 				}
 				continue

--- a/internal/component/loki/source/file/internal/tail/file.go
+++ b/internal/component/loki/source/file/internal/tail/file.go
@@ -75,12 +75,12 @@ type File struct {
 	bufferedLines []Line
 }
 
-// Read returns the next available line from the file.
+// Next returns the next available line from the file.
 // When no complete line is available it returns io.EOF. On io.EOF the caller
-// should call Wait to block until more data is available and then call Read
+// should call Wait to block until more data is available and then call Next
 // again, or call Flush to read any remaining partial line. Any other error
 // indicates an unrecoverable read or decode failure.
-func (f *File) Read() (*Line, error) {
+func (f *File) Next() (*Line, error) {
 	// If we have buffered lines from a previous file rotation, return them first.
 	// These are lines that were read from the old file handle before it was closed,
 	// ensuring we don't lose any data during file rotation.

--- a/internal/component/loki/source/file/internal/tail/file.go
+++ b/internal/component/loki/source/file/internal/tail/file.go
@@ -75,12 +75,12 @@ type File struct {
 	bufferedLines []Line
 }
 
-// Next returns the next available line from the file.
+// Read returns the next available line from the file.
 // When no complete line is available it returns io.EOF. On io.EOF the caller
-// should call Wait to block until more data is available and then call Next
+// should call Wait to block until more data is available and then call Read
 // again, or call Flush to read any remaining partial line. Any other error
 // indicates an unrecoverable read or decode failure.
-func (f *File) Next() (*Line, error) {
+func (f *File) Read() (*Line, error) {
 	// If we have buffered lines from a previous file rotation, return them first.
 	// These are lines that were read from the old file handle before it was closed,
 	// ensuring we don't lose any data during file rotation.

--- a/internal/component/loki/source/file/internal/tail/file_test.go
+++ b/internal/component/loki/source/file/internal/tail/file_test.go
@@ -543,7 +543,7 @@ func startFromEndTest(t *testing.T, name string, encoder, appendEncoder *encodin
 	verify := func(t *testing.T, f *File, line *Line) {
 		t.Helper()
 		for {
-			got, err := f.Next()
+			got, err := f.Read()
 			if errors.Is(err, io.EOF) {
 				require.NoError(t, f.Wait(t.Context()))
 				continue
@@ -665,7 +665,7 @@ func createCompressedFile(t *testing.T, name, compression string, reader io.Read
 
 func verifyResult(t *testing.T, f *File, expectedLine *Line, expectedErr error) {
 	t.Helper()
-	line, err := f.Next()
+	line, err := f.Read()
 	require.ErrorIs(t, err, expectedErr)
 	if expectedLine == nil {
 		require.Nil(t, line)
@@ -694,7 +694,7 @@ func BenchmarkFile(b *testing.B) {
 		require.NoError(b, err)
 		for {
 			var err error
-			benchLine, err = file.Next()
+			benchLine, err = file.Read()
 			if errors.Is(err, io.EOF) {
 				break
 			}

--- a/internal/component/loki/source/file/internal/tail/file_test.go
+++ b/internal/component/loki/source/file/internal/tail/file_test.go
@@ -543,7 +543,7 @@ func startFromEndTest(t *testing.T, name string, encoder, appendEncoder *encodin
 	verify := func(t *testing.T, f *File, line *Line) {
 		t.Helper()
 		for {
-			got, err := f.Read()
+			got, err := f.Next()
 			if errors.Is(err, io.EOF) {
 				require.NoError(t, f.Wait(t.Context()))
 				continue
@@ -665,7 +665,7 @@ func createCompressedFile(t *testing.T, name, compression string, reader io.Read
 
 func verifyResult(t *testing.T, f *File, expectedLine *Line, expectedErr error) {
 	t.Helper()
-	line, err := f.Read()
+	line, err := f.Next()
 	require.ErrorIs(t, err, expectedErr)
 	if expectedLine == nil {
 		require.Nil(t, line)
@@ -694,7 +694,7 @@ func BenchmarkFile(b *testing.B) {
 		require.NoError(b, err)
 		for {
 			var err error
-			benchLine, err = file.Read()
+			benchLine, err = file.Next()
 			if errors.Is(err, io.EOF) {
 				break
 			}

--- a/internal/component/loki/source/file/internal/tail/file_test.go
+++ b/internal/component/loki/source/file/internal/tail/file_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"io/fs"
 	"os"
 	"strings"
 	"testing"
@@ -44,12 +45,13 @@ func TestFile(t *testing.T) {
 			Filename: name,
 		})
 		require.NoError(t, err)
-		defer file.Stop()
+		defer file.Close()
 
 		verifyResult(t, file, &Line{Text: "test", Offset: 5}, nil)
 		verifyResult(t, file, &Line{Text: testString, Offset: 4104}, nil)
 		verifyResult(t, file, &Line{Text: "hello", Offset: 4110}, nil)
 		verifyResult(t, file, &Line{Text: "world", Offset: 4116}, nil)
+		verifyResult(t, file, nil, io.EOF)
 	})
 
 	t.Run("read", func(t *testing.T) {
@@ -68,11 +70,12 @@ func TestFile(t *testing.T) {
 				Offset:   0,
 			})
 			require.NoError(t, err)
-			defer file.Stop()
+			defer file.Close()
 
 			verifyResult(t, file, &Line{Text: "hello", Offset: first}, nil)
 			verifyResult(t, file, &Line{Text: "world", Offset: middle}, nil)
 			verifyResult(t, file, &Line{Text: "test", Offset: end}, nil)
+			verifyResult(t, file, nil, io.EOF)
 		})
 
 		t.Run("skip first", func(t *testing.T) {
@@ -81,10 +84,11 @@ func TestFile(t *testing.T) {
 				Offset:   first,
 			})
 			require.NoError(t, err)
-			defer file.Stop()
+			defer file.Close()
 
 			verifyResult(t, file, &Line{Text: "world", Offset: middle}, nil)
 			verifyResult(t, file, &Line{Text: "test", Offset: end}, nil)
+			verifyResult(t, file, nil, io.EOF)
 		})
 
 		t.Run("last", func(t *testing.T) {
@@ -93,9 +97,10 @@ func TestFile(t *testing.T) {
 				Offset:   middle,
 			})
 			require.NoError(t, err)
-			defer file.Stop()
+			defer file.Close()
 
 			verifyResult(t, file, &Line{Text: "test", Offset: end}, nil)
+			verifyResult(t, file, nil, io.EOF)
 		})
 	})
 
@@ -108,14 +113,17 @@ func TestFile(t *testing.T) {
 			Filename: name,
 		})
 		require.NoError(t, err)
-		defer file.Stop()
+		defer file.Close()
 
 		verifyResult(t, file, &Line{Text: "hello", Offset: 6}, nil)
+		verifyResult(t, file, nil, io.EOF)
 		go func() {
 			time.Sleep(50 * time.Millisecond)
 			appendToFile(t, name, "rld\n")
 		}()
+		require.NoError(t, file.Wait(t.Context()))
 		verifyResult(t, file, &Line{Text: "world", Offset: 12}, nil)
+		verifyResult(t, file, nil, io.EOF)
 	})
 
 	t.Run("truncate", func(t *testing.T) {
@@ -130,7 +138,7 @@ func TestFile(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		defer file.Stop()
+		defer file.Close()
 
 		verifyResult(t, file, &Line{Text: "a really long string goes here", Offset: 31}, nil)
 		verifyResult(t, file, &Line{Text: "hello", Offset: 37}, nil)
@@ -141,7 +149,7 @@ func TestFile(t *testing.T) {
 			<-time.After(100 * time.Millisecond)
 			truncateFile(t, name, "h311o\nw0r1d\nendofworld\n")
 		}()
-
+		require.NoError(t, file.Wait(t.Context()))
 		verifyResult(t, file, &Line{Text: "h311o", Offset: 6}, nil)
 		verifyResult(t, file, &Line{Text: "w0r1d", Offset: 12}, nil)
 		verifyResult(t, file, &Line{Text: "endofworld", Offset: 23}, nil)
@@ -156,16 +164,17 @@ func TestFile(t *testing.T) {
 			Filename: name,
 		})
 		require.NoError(t, err)
+		defer file.Close()
 
 		verifyResult(t, file, &Line{Text: "hello", Offset: 6}, nil)
+		ctx, cancel := context.WithCancel(t.Context())
 
 		go func() {
 			time.Sleep(100 * time.Millisecond)
-			require.NoError(t, file.Stop())
+			cancel()
 		}()
 
-		_, err = file.Next()
-		require.ErrorIs(t, err, context.Canceled)
+		require.ErrorIs(t, file.Wait(ctx), context.Canceled)
 	})
 
 	t.Run("stopped while waiting for file to be created", func(t *testing.T) {
@@ -180,16 +189,18 @@ func TestFile(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
+		defer file.Close()
 
 		verifyResult(t, file, &Line{Text: "hello", Offset: 6}, nil)
 		removeFile(t, name)
+		verifyResult(t, file, nil, io.EOF)
+		ctx, cancel := context.WithCancel(t.Context())
 
 		go func() {
 			time.Sleep(100 * time.Millisecond)
-			file.Stop()
+			cancel()
 		}()
-		_, err = file.Next()
-		require.ErrorIs(t, err, context.Canceled)
+		require.ErrorIs(t, file.Wait(ctx), context.Canceled)
 	})
 
 	t.Run("calls to next after stop", func(t *testing.T) {
@@ -201,9 +212,9 @@ func TestFile(t *testing.T) {
 			Filename: name,
 		})
 		require.NoError(t, err)
-		file.Stop()
+		file.Close()
 
-		verifyResult(t, file, nil, context.Canceled)
+		verifyResult(t, file, nil, fs.ErrClosed)
 	})
 
 	t.Run("file rotation drains remaining lines from old file", func(t *testing.T) {
@@ -218,7 +229,7 @@ func TestFile(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		defer file.Stop()
+		defer file.Close()
 
 		// Read first two lines
 		verifyResult(t, file, &Line{Text: "line1", Offset: 6}, nil)
@@ -232,7 +243,12 @@ func TestFile(t *testing.T) {
 		// Verify we get the remaining old lines first, then new lines
 		verifyResult(t, file, &Line{Text: "line3", Offset: 18}, nil)
 		verifyResult(t, file, &Line{Text: "line4", Offset: 24}, nil)
+		verifyResult(t, file, nil, io.EOF)
+		require.NoError(t, file.Wait(t.Context()))
 		verifyResult(t, file, &Line{Text: "partial", Offset: 31}, nil)
+
+		verifyResult(t, file, nil, io.EOF)
+		require.NoError(t, file.Wait(t.Context()))
 		verifyResult(t, file, &Line{Text: "newline1", Offset: 9}, nil)
 		verifyResult(t, file, &Line{Text: "newline2", Offset: 18}, nil)
 	})
@@ -248,7 +264,7 @@ func TestFile(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		defer file.Stop()
+		defer file.Close()
 
 		appended := make(chan struct{})
 		deleteNow := make(chan struct{})
@@ -279,7 +295,7 @@ func TestFile(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		defer file.Stop()
+		defer file.Close()
 
 		// Read first two lines
 		verifyResult(t, file, &Line{Text: "line1", Offset: 6}, nil)
@@ -287,6 +303,8 @@ func TestFile(t *testing.T) {
 		atomicWrite(t, name, "line1\nline2\nline3\nline4\nnewline1\n")
 		verifyResult(t, file, &Line{Text: "line3", Offset: 18}, nil)
 		verifyResult(t, file, &Line{Text: "line4", Offset: 24}, nil)
+		verifyResult(t, file, nil, io.EOF)
+		require.NoError(t, file.Wait(t.Context()))
 		verifyResult(t, file, &Line{Text: "newline1", Offset: 33}, nil)
 	})
 
@@ -302,7 +320,7 @@ func TestFile(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		defer file.Stop()
+		defer file.Close()
 
 		// Read first two lines
 		verifyResult(t, file, &Line{Text: "line1", Offset: 6}, nil)
@@ -311,6 +329,8 @@ func TestFile(t *testing.T) {
 		// Because we buffer lines when file is deleted we still get line3 and line4.
 		verifyResult(t, file, &Line{Text: "line3", Offset: 18}, nil)
 		verifyResult(t, file, &Line{Text: "line4", Offset: 24}, nil)
+		verifyResult(t, file, nil, io.EOF)
+		require.NoError(t, file.Wait(t.Context()))
 		verifyResult(t, file, &Line{Text: "newline1", Offset: 9}, nil)
 	})
 
@@ -320,7 +340,7 @@ func TestFile(t *testing.T) {
 			Encoding: "UTF-16LE",
 		})
 		require.NoError(t, err)
-		defer file.Stop()
+		defer file.Close()
 
 		verifyResult(t, file, &Line{Text: "2025-03-11 11:11:02.58 Server      Microsoft SQL Server 2019 (RTM) - 15.0.2000.5 (X64) ", Offset: 180}, nil)
 		verifyResult(t, file, &Line{Text: "	Sep 24 2019 13:48:23 ", Offset: 228}, nil)
@@ -347,7 +367,7 @@ func TestFile(t *testing.T) {
 		require.NoError(t, err)
 
 		verifyResult(t, file, &Line{Text: "Hello, 世界", Offset: 24}, nil)
-		file.Stop()
+		file.Close()
 
 		enc = unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM).NewEncoder()
 		encoded, err = enc.String("newline\r\n")
@@ -362,7 +382,7 @@ func TestFile(t *testing.T) {
 			Offset:   24,
 		})
 		require.NoError(t, err)
-		defer file.Stop()
+		defer file.Close()
 
 		verifyResult(t, file, &Line{Text: "newline", Offset: 42}, nil)
 	})
@@ -382,7 +402,7 @@ func TestFile(t *testing.T) {
 		require.NoError(t, err)
 
 		verifyResult(t, file, &Line{Text: "Hello, 世界", Offset: 24}, nil)
-		file.Stop()
+		file.Close()
 
 		enc = unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM).NewEncoder()
 		encoded, err = enc.String("newline\r\n")
@@ -397,7 +417,7 @@ func TestFile(t *testing.T) {
 			Offset:   24,
 		})
 		require.NoError(t, err)
-		defer file.Stop()
+		defer file.Close()
 
 		verifyResult(t, file, &Line{Text: "newline", Offset: 42}, nil)
 	})
@@ -413,7 +433,7 @@ func TestFile(t *testing.T) {
 			Encoding: "UTF-16",
 		})
 		require.NoError(t, err)
-		defer file.Stop()
+		defer file.Close()
 
 		verifyResult(t, file, &Line{Text: "Hello, 世界", Offset: 18}, nil)
 	})
@@ -499,7 +519,7 @@ func compressionTest(t *testing.T, name, compression string, enc *encoding.Encod
 		verifyResult(t, file, &Line{Text: "line2", Offset: offsets[1]}, nil)
 		verifyResult(t, file, &Line{Text: "line3", Offset: offsets[2]}, nil)
 		verifyResult(t, file, nil, io.EOF)
-		require.NoError(t, file.Stop())
+		require.NoError(t, file.Close())
 
 		file, err = NewFile(logging.NewSlogNop(), &Config{
 			Filename: fileName,
@@ -511,7 +531,7 @@ func compressionTest(t *testing.T, name, compression string, enc *encoding.Encod
 			Offset:      offsets[0],
 		})
 		require.NoError(t, err)
-		defer file.Stop()
+		defer file.Close()
 
 		verifyResult(t, file, &Line{Text: "line2", Offset: offsets[1]}, nil)
 		verifyResult(t, file, &Line{Text: "line3", Offset: offsets[2]}, nil)
@@ -520,6 +540,21 @@ func compressionTest(t *testing.T, name, compression string, enc *encoding.Encod
 }
 
 func startFromEndTest(t *testing.T, name string, encoder, appendEncoder *encoding.Encoder, useCR bool, offset int64, expected []Line) {
+	verify := func(t *testing.T, f *File, line *Line) {
+		t.Helper()
+		for {
+			got, err := f.Next()
+			if errors.Is(err, io.EOF) {
+				require.NoError(t, f.Wait(t.Context()))
+				continue
+			}
+
+			require.Equal(t, line.Text, got.Text)
+			require.Equal(t, line.Offset, got.Offset)
+			return
+		}
+	}
+
 	t.Run(name, func(t *testing.T) {
 		var (
 			content string
@@ -551,7 +586,7 @@ func startFromEndTest(t *testing.T, name string, encoder, appendEncoder *encodin
 			StartFromEnd: true,
 		})
 		require.NoError(t, err)
-		defer file.Stop()
+		defer file.Close()
 
 		go func() {
 			time.Sleep(100 * time.Millisecond)
@@ -559,7 +594,7 @@ func startFromEndTest(t *testing.T, name string, encoder, appendEncoder *encodin
 		}()
 
 		for _, line := range expected {
-			verifyResult(t, file, &line, nil)
+			verify(t, file, &line)
 		}
 	})
 }
@@ -631,7 +666,6 @@ func createCompressedFile(t *testing.T, name, compression string, reader io.Read
 func verifyResult(t *testing.T, f *File, expectedLine *Line, expectedErr error) {
 	t.Helper()
 	line, err := f.Next()
-
 	require.ErrorIs(t, err, expectedErr)
 	if expectedLine == nil {
 		require.Nil(t, line)
@@ -658,9 +692,6 @@ func BenchmarkFile(b *testing.B) {
 			WatcherConfig: WatcherConfig{},
 		})
 		require.NoError(b, err)
-		// Disable waiting at EOF so Next returns io.EOF after the file is fully consumed.
-		file.waitAtEOF = false
-
 		for {
 			var err error
 			benchLine, err = file.Next()
@@ -670,6 +701,6 @@ func BenchmarkFile(b *testing.B) {
 			require.NoError(b, err)
 		}
 
-		file.Stop()
+		file.Close()
 	}
 }

--- a/internal/component/loki/source/file/tailer.go
+++ b/internal/component/loki/source/file/tailer.go
@@ -100,22 +100,7 @@ func (t *tailer) Run(ctx context.Context) {
 
 	// We call report so that retries won't log.
 	t.report.Do(func() {})
-
-	t.metrics.filesActive.Add(1.)
-
-	ctx, cancel := context.WithCancel(ctx)
-	var wg sync.WaitGroup
-
-	wg.Go(func() {
-		t.readLines(ctx, pos)
-		cancel()
-	})
-
-	t.running.Store(true)
-	defer t.running.Store(false)
-
-	<-ctx.Done()
-	t.stop(&wg)
+	t.tail(ctx, pos)
 }
 
 func (t *tailer) initRun() (int64, error) {
@@ -161,7 +146,7 @@ func (t *tailer) initRun() (int64, error) {
 		t.positions.Remove(t.key.Path, t.key.Labels)
 	}
 
-	tail, err := tail.NewFile(t.logger, &tail.Config{
+	file, err := tail.NewFile(t.logger, &tail.Config{
 		Filename:      t.key.Path,
 		Offset:        pos,
 		StartFromEnd:  startFromEnd,
@@ -174,18 +159,16 @@ func (t *tailer) initRun() (int64, error) {
 		return pos, fmt.Errorf("failed to tail the file: %w", err)
 	}
 
-	t.file = tail
+	t.file = file
 
 	return pos, nil
 }
 
-// readLines reads lines from the tailed file by calling Next() in a loop.
-// It processes each line by sending it to the receiver's channel and updates
-// position tracking periodically. It exits either when Next() returns an error
-// (for example, when the tail.File is stopped, we have an unrecoverable error, or EOF
-// is reached for a fully consumed compressed file) or when the context is canceled,
-// including while a send to the receiver's channel is blocked.
-func (t *tailer) readLines(ctx context.Context, pos int64) {
+// tail reads lines from the file and forwards them to the receiver, periodically
+// recording the read offset. It blocks until ctx is canceled or the file is fully read.
+func (t *tailer) tail(ctx context.Context, pos int64) {
+	t.running.Store(true)
+	t.metrics.filesActive.Add(1.)
 	t.logger.Info("start tailing file")
 
 	if t.decompression.Enabled && t.decompression.InitialDelay > 0 {
@@ -201,17 +184,56 @@ func (t *tailer) readLines(ctx context.Context, pos int64) {
 	)
 
 	defer func() {
+		t.running.Store(false)
 		size, _ := t.file.Size()
 		t.updateStats(lastOffset, size)
+
+		if err := t.file.Close(); err != nil {
+			if util.IsEphemeralOrFileClosed(err) {
+				// Don't log as error if the file is already closed, or we got an ephemeral error - it's a common case
+				// when files are rotating while being read and the tailer would have stopped correctly anyway.
+				t.logger.Debug("failed to stop tailer", "error", err)
+			} else if !errors.Is(err, os.ErrNotExist) {
+				// Log as error for other reasons, as a resource leak may have happened.
+				t.logger.Error("failed to stop tailer", "error", err)
+			}
+		}
+
+		t.logger.Info("stopped tailing file")
+
+		// We need to cleanup created metrics.
+		t.cleanupMetrics()
+		if !t.shouldKeepPosition() {
+			t.positions.Remove(t.key.Path, t.key.Labels)
+		}
 	}()
 
+	nextLine := func() (*tail.Line, error) {
+		for {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			default:
+			}
+
+			line, err := t.file.Next()
+			if !errors.Is(err, io.EOF) {
+				return line, err
+			}
+
+			if t.decompression.Enabled {
+				return t.file.Flush()
+			}
+
+			if err := t.file.Wait(ctx); err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	for {
-		line, err := t.file.Next()
+		line, err := nextLine()
 		if err != nil {
-			// We get context.Canceled if tail.File was stopped so we don't have to log it.
-			// If we get context.Canceled it means that tail.File was stopped. If we get EOF
-			// that means that we consumed the file fully and don't wait for more events, this
-			// happens when compression is configured.
 			if !errors.Is(err, context.Canceled) && !errors.Is(err, io.EOF) {
 				t.logger.Error("failed to tail file", "err", err)
 			}
@@ -219,7 +241,6 @@ func (t *tailer) readLines(ctx context.Context, pos int64) {
 		}
 
 		t.metrics.readLines.WithLabelValues(t.key.Path).Inc()
-
 		select {
 		case <-ctx.Done():
 			return
@@ -238,37 +259,10 @@ func (t *tailer) readLines(ctx context.Context, pos int64) {
 }
 
 func (t *tailer) updateStats(offset int64, size int64) {
-	// Update metrics and positions file all together to avoid race conditions when `t.tail` is stopped.
+	// Update metrics and the positions file together so the reported offset stays consistent.
 	t.metrics.totalBytes.WithLabelValues(t.key.Path).Set(float64(size))
 	t.metrics.readBytes.WithLabelValues(t.key.Path).Set(float64(offset))
 	t.positions.Put(t.key.Path, t.key.Labels, offset)
-}
-
-func (t *tailer) stop(wg *sync.WaitGroup) {
-	if err := t.file.Stop(); err != nil {
-		if util.IsEphemeralOrFileClosed(err) {
-			// Don't log as error if the file is already closed, or we got an ephemeral error - it's a common case
-			// when files are rotating while being read and the tailer would have stopped correctly anyway.
-			t.logger.Debug("failed to stop tailer", "error", err)
-		} else if !errors.Is(err, os.ErrNotExist) {
-			// Log as error for other reasons, as a resource leak may have happened.
-			t.logger.Error("failed to stop tailer", "error", err)
-		}
-	}
-
-	t.logger.Debug("waiting for readLines to exit")
-
-	// Wait for readLines() to exit.
-	wg.Wait()
-
-	t.logger.Info("stopped tailing file")
-
-	// We need to cleanup created metrics.
-	t.cleanupMetrics()
-
-	if !t.shouldKeepPosition() {
-		t.positions.Remove(t.key.Path, t.key.Labels)
-	}
 }
 
 func (t *tailer) Key() positions.Entry {

--- a/internal/component/loki/source/file/tailer.go
+++ b/internal/component/loki/source/file/tailer.go
@@ -216,7 +216,7 @@ func (t *tailer) tail(ctx context.Context, pos int64) {
 			default:
 			}
 
-			line, err := t.file.Next()
+			line, err := t.file.Read()
 			if !errors.Is(err, io.EOF) {
 				return line, err
 			}

--- a/internal/component/loki/source/file/tailer.go
+++ b/internal/component/loki/source/file/tailer.go
@@ -216,7 +216,7 @@ func (t *tailer) tail(ctx context.Context, pos int64) {
 			default:
 			}
 
-			line, err := t.file.Read()
+			line, err := t.file.Next()
 			if !errors.Is(err, io.EOF) {
 				return line, err
 			}


### PR DESCRIPTION
### Pull Request Details
For each tailer we had 2 goroutines. One consuming lines and another one waiting for context to be canceled and when that happened it would stop the other one.

Instead we can expose Wait and flush to the caller. The caller is instead responsible to drive this read / wait loop. With this we no longer need to spawn a extra go routine and we don't need a mutex in tail.File.

This will also be better when we move to batching since the caller will be able to read lines until we reach EOF and flush a batch and only call wait after if we still get EOF. 

### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->

### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
