### PR TITLE
fix(converter): default syslog protocol to tcp when converting from promtail

### DIFF
--- a/internal/converter/internal/promtailconvert/internal/build/syslog.go
+++ b/internal/converter/internal/promtailconvert/internal/build/syslog.go
@@ -22,9 +22,14 @@ func (s *ScrapeConfigBuilder) AppendSyslogConfig() {
 		return
 	}
 
+	listenProtocol := s.cfg.SyslogConfig.ListenProtocol
+	if listenProtocol == "" {
+		listenProtocol = syslog.DefaultListenerConfig.ListenProtocol
+	}
+
 	listenerConfig := syslog.ListenerConfig{
 		ListenAddress:        s.cfg.SyslogConfig.ListenAddress,
-		ListenProtocol:       s.cfg.SyslogConfig.ListenProtocol,
+		ListenProtocol:       listenProtocol,
 		IdleTimeout:          s.cfg.SyslogConfig.IdleTimeout,
 		LabelStructuredData:  s.cfg.SyslogConfig.LabelStructuredData,
 		Labels:               convertPromLabels(s.cfg.SyslogConfig.Labels),

--- a/internal/converter/internal/promtailconvert/testdata/syslog_default.alloy
+++ b/internal/converter/internal/promtailconvert/testdata/syslog_default.alloy
@@ -1,0 +1,25 @@
+discovery.relabel "syslog_default" {
+	targets = []
+
+}
+
+loki.source.syslog "syslog_default" {
+	listener {
+		address                = "localhost:4000"
+		protocol               = "tcp"
+		idle_timeout           = "1m0s"
+		max_message_length     = 0
+		syslog_format          = "rfc5424"
+		udp_queue_size         = 0
+		udp_host_cache_size    = 0
+	}
+	forward_to    = [loki.write.default.receiver]
+	relabel_rules = null
+}
+
+loki.write "default" {
+	endpoint {
+		url = "http://localhost/loki/api/v1/push"
+	}
+	external_labels = {}
+}

--- a/internal/converter/internal/promtailconvert/testdata/syslog_default.yaml
+++ b/internal/converter/internal/promtailconvert/testdata/syslog_default.yaml
@@ -1,0 +1,9 @@
+clients:
+  - url: http://localhost/loki/api/v1/push
+scrape_configs:
+  - job_name: syslog_default
+    syslog:
+      listen_address: localhost:4000
+      idle_timeout: 1m
+tracing: { enabled: false }
+server: { register_instrumentation: false }


### PR DESCRIPTION
alloy convert emits protocol="" for promtail syslog configs that omit listen_protocol, causing alloy run to fail at validation. Defaults to tcp to match promtail behavior and alloy native config.