### PR TITLE
feat: Add ability to exempt lines matching a configured regex pattern from loki.process stage.luhn

### DIFF
--- a/docs/sources/reference/components/loki/loki.process.md
+++ b/docs/sources/reference/components/loki/loki.process.md
@@ -720,24 +720,28 @@ Many Payment Card Industry environments require these numbers to be redacted.
 
 The following arguments are supported:
 
-| Name          | Type     | Description                                                    | Default          | Required |
-| ------------- | -------- | -------------------------------------------------------------- | ---------------- | -------- |
-| `delimiters`  | `string` | A list containing delimiters to accept as part of the number.  | `""`             | no       |
-| `min_length`  | `int`    | Minimum length of digits to consider                           | `13`             | no       |
-| `replacement` | `string` | String to substitute the matched patterns with.                | `"**REDACTED**"` | no       |
-| `source`      | `string` | Source of the data to parse.                                   | `""`             | no       |
+| Name          | Type     | Description                                                                  | Default          | Required |
+| ------------- | -------- | ---------------------------------------------------------------------------- | ---------------- | -------- |
+| `delimiters`  | `string` | A list containing delimiters to accept as part of the number.                | `""`             | no       |
+| `min_length`  | `int`    | Minimum length of digits to consider                                         | `13`             | no       |
+| `replacement` | `string` | String to substitute the matched patterns with.                              | `"**REDACTED**"` | no       |
+| `skip_regex`  | `string` | A regular expression identifying substrings to exclude from Luhn evaluation. | `""`             | no       |
+| `source`      | `string` | Source of the data to parse.                                                 | `""`             | no       |
 
 The `source` field defines the source of data to search.
 When `source` is missing or empty, the stage parses the log line itself, but it can also be used to parse a previously extracted value.
 
-If you want the Luhn algorithm to identify numbers with delimiters, for example `4032-0325-1354-8443`, you can configure the `delimiters` field with the expected delimiters.
+If you want the Luhn algorithm to identify numbers with delimiters, for example `4242-4242-4242-4242`, you can configure the `delimiters` field with the expected delimiters.
+
+When `skip_regex` is set to a non-empty regular expression, any substring matching it is excluded from Luhn evaluation.
+This is useful when log lines contain values, such as UUIDs, whose digit groups happen to pass the Luhn check, which would otherwise cause them to be incorrectly redacted.
 
 #### Example
 
 The following example log line contains an approved credit card number.
 
 ```alloy
-time=2012-11-01T22:08:41+00:00 app=loki level=WARN duration=125 message="credit card approved 4032032513548443" extra="user=example_name"
+time=2012-11-01T22:08:41+00:00 app=loki level=WARN duration=125 message="credit card approved 4242424242424242" extra="user=example_name"
 
 stage.luhn {
     replacement = "**DELETED**"
@@ -755,7 +759,7 @@ time=2012-11-01T22:08:41+00:00 app=loki level=INFO duration=125 message="credit 
 The following example log line contains an approved credit card number, represented with dash characters between each group of four digits.
 
 ```alloy
-time=2012-11-01T22:08:41+00:00 app=loki level=WARN duration=125 message="credit card approved 4032-0325-1354-8443" extra="user=example_name"
+time=2012-11-01T22:08:41+00:00 app=loki level=WARN duration=125 message="credit card approved 4242-4242-4242-4242" extra="user=example_name"
 
 stage.luhn {
     replacement = "**DELETED**"
@@ -767,6 +771,27 @@ The stage parses the log line, redacts the credit card number, and produces the 
 
 ```text
 time=2012-11-01T22:08:41+00:00 app=loki level=INFO duration=125 message="credit card approved **DELETED**" extra="user=example_name"
+```
+
+#### Example with `skip_regex`
+
+The following example log line contains both a credit card number and a session UUID whose last segment (`424242424242`) is itself a 12-digit Luhn-valid number.
+Without `skip_regex`, the stage would incorrectly redact part of the UUID.
+
+```alloy
+time=2012-11-01T22:08:41+00:00 app=loki level=WARN duration=125 message="credit card approved 4242424242424242" session="a3f1b2e4-c5d6-7e8f-4242-424242424242"
+
+stage.luhn {
+    replacement = "**DELETED**"
+    min_length  = 12
+    skip_regex  = `[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`
+}
+```
+
+The stage redacts the credit card number but leaves the UUID intact:
+
+```text
+time=2012-11-01T22:08:41+00:00 app=loki level=INFO duration=125 message="credit card approved **DELETED**" session="a3f1b2e4-c5d6-7e8f-4242-424242424242"
 ```
 
 ### `stage.match`

--- a/docs/sources/reference/components/loki/loki.process.md
+++ b/docs/sources/reference/components/loki/loki.process.md
@@ -784,7 +784,7 @@ time=2012-11-01T22:08:41+00:00 app=loki level=WARN duration=125 message="credit 
 stage.luhn {
     replacement = "**DELETED**"
     min_length  = 12
-    skip_regex  = `[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`
+    skip_regex  = "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
 }
 ```
 

--- a/internal/component/loki/process/stages/luhn.go
+++ b/internal/component/loki/process/stages/luhn.go
@@ -48,16 +48,23 @@ func newLuhnFilterStage(config LuhnFilterConfig) (Stage, error) {
 	if err != nil {
 		return nil, err
 	}
-	return toStage(&luhnFilterStage{
-		config:    &config,
-		skipRegex: skipRegex,
-	}), nil
+	stage := &luhnFilterStage{config: &config}
+	if skipRegex != nil {
+		stage.skipRegex = skipRegex
+	}
+	return toStage(stage), nil
+}
+
+// skipRegexMatcher is the subset of *regexp.Regexp that findSkipRanges needs. It exists so
+// tests can substitute a call-counting stub to verify the regex is only run when needed.
+type skipRegexMatcher interface {
+	FindAllStringIndex(s string, n int) [][]int
 }
 
 // luhnFilterStage applies Luhn algorithm filtering to log entries.
 type luhnFilterStage struct {
 	config    *LuhnFilterConfig
-	skipRegex *regexp.Regexp
+	skipRegex skipRegexMatcher
 }
 
 // Process implements Stage.
@@ -81,6 +88,17 @@ func (r *luhnFilterStage) Process(labels model.LabelSet, extracted map[string]an
 
 	var skipRanges [][2]int
 	if r.skipRegex != nil {
+		// Running skip_regex is only worthwhile if there's a Luhn-valid number to potentially
+		// exempt from redaction. Skip it entirely for the common case of no match at all.
+		var hasMatch bool
+		if r.config.Delimiters != "" {
+			hasMatch = hasLuhnValidNumberWithDelimiters(*input, r.config.MinLength, r.config.Delimiters)
+		} else {
+			hasMatch = hasLuhnValidNumber(*input, r.config.MinLength)
+		}
+		if !hasMatch {
+			return
+		}
 		skipRanges = findSkipRanges(*input, r.skipRegex)
 	}
 
@@ -91,8 +109,69 @@ func (r *luhnFilterStage) Process(labels model.LabelSet, extracted map[string]an
 	}
 }
 
+// hasLuhnValidNumber reports whether input contains a run of at least minLength digits that is
+// Luhn-valid. It mirrors the digit-scanning logic in replaceLuhnValidNumbers without building any
+// output, so it can cheaply decide whether skip_regex is worth evaluating.
+func hasLuhnValidNumber(input string, minLength int) bool {
+	digitStart := -1
+
+	checkRun := func(end int) bool {
+		if digitStart == -1 {
+			return false
+		}
+		start := digitStart
+		digitStart = -1
+		if end-start < minLength {
+			return false
+		}
+		number, err := strconv.Atoi(input[start:end])
+		return err == nil && isLuhn(number)
+	}
+
+	for i, char := range input {
+		if unicode.IsDigit(char) {
+			if digitStart == -1 {
+				digitStart = i
+			}
+		} else if checkRun(i) {
+			return true
+		}
+	}
+	return checkRun(len(input))
+}
+
+// hasLuhnValidNumberWithDelimiters is the delimiter-aware counterpart to hasLuhnValidNumber,
+// mirroring replaceLuhnValidNumbersWithDelimiters's digit-scanning logic.
+func hasLuhnValidNumberWithDelimiters(input string, minLength int, delimiters string) bool {
+	var currentNumber strings.Builder
+
+	checkRun := func() bool {
+		valid := false
+		if currentNumber.Len() >= minLength {
+			number, err := strconv.Atoi(currentNumber.String())
+			valid = err == nil && isLuhn(number)
+		}
+		currentNumber.Reset()
+		return valid
+	}
+
+	for _, char := range input {
+		switch {
+		case unicode.IsDigit(char):
+			currentNumber.WriteRune(char)
+		case delimiters != "" && strings.ContainsRune(delimiters, char) && currentNumber.Len() > 0:
+			continue
+		default:
+			if checkRun() {
+				return true
+			}
+		}
+	}
+	return checkRun()
+}
+
 // findSkipRanges returns the byte ranges of all matches of skipRegex found in input.
-func findSkipRanges(input string, skipRegex *regexp.Regexp) [][2]int {
+func findSkipRanges(input string, skipRegex skipRegexMatcher) [][2]int {
 	matches := skipRegex.FindAllStringIndex(input, -1)
 	if len(matches) == 0 {
 		return nil

--- a/internal/component/loki/process/stages/luhn.go
+++ b/internal/component/loki/process/stages/luhn.go
@@ -181,6 +181,7 @@ func replaceLuhnValidNumbersSkipRegex(input, replacement string, minLength int, 
 // replaceLuhnValidNumbers scans the input for Luhn-valid numbers and replaces them.
 func replaceLuhnValidNumbers(input, replacement string, minLength int) string {
 	var sb strings.Builder
+	sb.Grow(len(input))
 	var currentNumber strings.Builder
 
 	flushNumber := func() {
@@ -223,6 +224,7 @@ func replaceLuhnValidNumbers(input, replacement string, minLength int) string {
 // These are separate functions to keep the base case as fast as possible, if no delimiters are needed.
 func replaceLuhnValidNumbersWithDelimiters(input, replacement string, minLength int, delimiters string) string {
 	var sb strings.Builder
+	sb.Grow(len(input))
 	var currentNumber strings.Builder
 	var currentString strings.Builder
 	var trailingDelimiter rune

--- a/internal/component/loki/process/stages/luhn.go
+++ b/internal/component/loki/process/stages/luhn.go
@@ -183,14 +183,19 @@ func findSkipRanges(input string, skipRegex skipRegexMatcher) [][2]int {
 	return ranges
 }
 
-// isInSkipRange reports whether the byte position pos falls within any of the given ranges.
-func isInSkipRange(pos int, ranges [][2]int) bool {
-	for _, r := range ranges {
-		if pos >= r[0] && pos < r[1] {
-			return true
+// newSkipRangeCursor returns a function that reports whether a byte position falls within any of
+// ranges. ranges must be sorted and non-overlapping (as returned by FindAllStringIndex), and
+// successive calls must pass strictly increasing positions (as in a range-over-string loop). Under
+// those conditions the cursor advances forward only, giving O(n+m) total cost across a scan instead
+// of the O(n*m) a fresh per-character linear scan over ranges would cost.
+func newSkipRangeCursor(ranges [][2]int) func(pos int) bool {
+	idx := 0
+	return func(pos int) bool {
+		for idx < len(ranges) && pos >= ranges[idx][1] {
+			idx++
 		}
+		return idx < len(ranges) && pos >= ranges[idx][0]
 	}
-	return false
 }
 
 // replaceLuhnValidNumbers scans the input for Luhn-valid numbers and replaces them.
@@ -219,9 +224,10 @@ func replaceLuhnValidNumbers(input, replacement string, minLength int, skipRange
 	}
 
 	// Iterate over the input, replacing Luhn-valid numbers.
+	inSkipRange := newSkipRangeCursor(skipRanges)
 	for pos, char := range input {
 		// Characters that fall inside a skip_regex match are passed through unchanged.
-		if len(skipRanges) > 0 && isInSkipRange(pos, skipRanges) {
+		if inSkipRange(pos) {
 			flushNumber()
 			sb.WriteRune(char)
 			continue
@@ -274,9 +280,10 @@ func replaceLuhnValidNumbersWithDelimiters(input, replacement string, minLength 
 	}
 
 	// Iterate over the input, replacing Luhn-valid numbers.
+	inSkipRange := newSkipRangeCursor(skipRanges)
 	for pos, char := range input {
 		// Characters that fall inside a skip_regex match are passed through unchanged.
-		if len(skipRanges) > 0 && isInSkipRange(pos, skipRanges) {
+		if inSkipRange(pos) {
 			flushNumber()
 			sb.WriteRune(char)
 			continue

--- a/internal/component/loki/process/stages/luhn.go
+++ b/internal/component/loki/process/stages/luhn.go
@@ -1,6 +1,8 @@
 package stages
 
 import (
+	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -15,10 +17,12 @@ type LuhnFilterConfig struct {
 	Source      *string `alloy:"source,attr,optional"`
 	MinLength   int     `alloy:"min_length,attr,optional"`
 	Delimiters  string  `alloy:"delimiters,attr,optional"`
+	SkipRegex   string  `alloy:"skip_regex,attr,optional"`
 }
 
-// validateLuhnFilterConfig validates the LuhnFilterConfig.
-func validateLuhnFilterConfig(c *LuhnFilterConfig) error {
+// validateLuhnFilterConfig validates the LuhnFilterConfig and returns the compiled
+// skip_regex expression, if one was configured.
+func validateLuhnFilterConfig(c *LuhnFilterConfig) (*regexp.Regexp, error) {
 	if c.Replacement == "" {
 		c.Replacement = "**REDACTED**"
 	}
@@ -26,24 +30,34 @@ func validateLuhnFilterConfig(c *LuhnFilterConfig) error {
 		c.MinLength = 13
 	}
 	if c.Source != nil && *c.Source == "" {
-		return ErrEmptyRegexStageSource
+		return nil, ErrEmptyRegexStageSource
 	}
-	return nil
+	if c.SkipRegex == "" {
+		return nil, nil
+	}
+	skipRegex, err := regexp.Compile(c.SkipRegex)
+	if err != nil {
+		return nil, fmt.Errorf("%v: %w", ErrCouldNotCompileRegex, err)
+	}
+	return skipRegex, nil
 }
 
 // newLuhnFilterStage creates a new LuhnFilterStage.
 func newLuhnFilterStage(config LuhnFilterConfig) (Stage, error) {
-	if err := validateLuhnFilterConfig(&config); err != nil {
+	skipRegex, err := validateLuhnFilterConfig(&config)
+	if err != nil {
 		return nil, err
 	}
 	return toStage(&luhnFilterStage{
-		config: &config,
+		config:    &config,
+		skipRegex: skipRegex,
 	}), nil
 }
 
 // luhnFilterStage applies Luhn algorithm filtering to log entries.
 type luhnFilterStage struct {
-	config *LuhnFilterConfig
+	config    *LuhnFilterConfig
+	skipRegex *regexp.Regexp
 }
 
 // Process implements Stage.
@@ -65,18 +79,43 @@ func (r *luhnFilterStage) Process(labels model.LabelSet, extracted map[string]an
 		return
 	}
 
-	// Replace Luhn-valid numbers in the input.
+	var skipRanges [][2]int
+	if r.skipRegex != nil {
+		skipRanges = findSkipRanges(*input, r.skipRegex)
+	}
+
 	if r.config.Delimiters != "" {
-		updatedEntry := replaceLuhnValidNumbersWithDelimiters(*input, r.config.Replacement, r.config.MinLength, r.config.Delimiters)
-		*entry = updatedEntry
+		*entry = replaceLuhnValidNumbersWithDelimiters(*input, r.config.Replacement, r.config.MinLength, r.config.Delimiters, skipRanges)
 	} else {
-		updatedEntry := replaceLuhnValidNumbers(*input, r.config.Replacement, r.config.MinLength)
-		*entry = updatedEntry
+		*entry = replaceLuhnValidNumbers(*input, r.config.Replacement, r.config.MinLength, skipRanges)
 	}
 }
 
+// findSkipRanges returns the byte ranges of all matches of skipRegex found in input.
+func findSkipRanges(input string, skipRegex *regexp.Regexp) [][2]int {
+	matches := skipRegex.FindAllStringIndex(input, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	ranges := make([][2]int, len(matches))
+	for i, m := range matches {
+		ranges[i] = [2]int{m[0], m[1]}
+	}
+	return ranges
+}
+
+// isInSkipRange reports whether the byte position pos falls within any of the given ranges.
+func isInSkipRange(pos int, ranges [][2]int) bool {
+	for _, r := range ranges {
+		if pos >= r[0] && pos < r[1] {
+			return true
+		}
+	}
+	return false
+}
+
 // replaceLuhnValidNumbers scans the input for Luhn-valid numbers and replaces them.
-func replaceLuhnValidNumbers(input, replacement string, minLength int) string {
+func replaceLuhnValidNumbers(input, replacement string, minLength int, skipRanges [][2]int) string {
 	var sb strings.Builder
 	var currentNumber strings.Builder
 
@@ -101,7 +140,13 @@ func replaceLuhnValidNumbers(input, replacement string, minLength int) string {
 	}
 
 	// Iterate over the input, replacing Luhn-valid numbers.
-	for _, char := range input {
+	for pos, char := range input {
+		// Characters that fall inside a skip_regex match are passed through unchanged.
+		if len(skipRanges) > 0 && isInSkipRange(pos, skipRanges) {
+			flushNumber()
+			sb.WriteRune(char)
+			continue
+		}
 		// If the character is a digit, add it to the current number.
 		if unicode.IsDigit(char) {
 			currentNumber.WriteRune(char)
@@ -118,7 +163,7 @@ func replaceLuhnValidNumbers(input, replacement string, minLength int) string {
 
 // replaceLuhnValidNumbersWithDelimiters scans the input for Luhn-valid numbers with delimiter support and replaces them.
 // These are separate functions to keep the base case as fast as possible, if no delimiters are needed.
-func replaceLuhnValidNumbersWithDelimiters(input, replacement string, minLength int, delimiters string) string {
+func replaceLuhnValidNumbersWithDelimiters(input, replacement string, minLength int, delimiters string, skipRanges [][2]int) string {
 	var sb strings.Builder
 	var currentNumber strings.Builder
 	var currentString strings.Builder
@@ -150,7 +195,13 @@ func replaceLuhnValidNumbersWithDelimiters(input, replacement string, minLength 
 	}
 
 	// Iterate over the input, replacing Luhn-valid numbers.
-	for _, char := range input {
+	for pos, char := range input {
+		// Characters that fall inside a skip_regex match are passed through unchanged.
+		if len(skipRanges) > 0 && isInSkipRange(pos, skipRanges) {
+			flushNumber()
+			sb.WriteRune(char)
+			continue
+		}
 		// If the character is a digit, add it to the current number.
 		if unicode.IsDigit(char) {
 			currentNumber.WriteRune(char)

--- a/internal/component/loki/process/stages/luhn.go
+++ b/internal/component/loki/process/stages/luhn.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/prometheus/common/model"
 )
@@ -20,9 +21,8 @@ type LuhnFilterConfig struct {
 	SkipRegex   string  `alloy:"skip_regex,attr,optional"`
 }
 
-// validateLuhnFilterConfig validates the LuhnFilterConfig and returns the compiled
-// skip_regex expression, if one was configured.
-func validateLuhnFilterConfig(c *LuhnFilterConfig) (*regexp.Regexp, error) {
+// validateLuhnFilterConfig validates the LuhnFilterConfig.
+func validateLuhnFilterConfig(c *LuhnFilterConfig) error {
 	if c.Replacement == "" {
 		c.Replacement = "**REDACTED**"
 	}
@@ -30,41 +30,36 @@ func validateLuhnFilterConfig(c *LuhnFilterConfig) (*regexp.Regexp, error) {
 		c.MinLength = 13
 	}
 	if c.Source != nil && *c.Source == "" {
-		return nil, ErrEmptyRegexStageSource
+		return ErrEmptyRegexStageSource
 	}
-	if c.SkipRegex == "" {
-		return nil, nil
-	}
-	skipRegex, err := regexp.Compile(c.SkipRegex)
-	if err != nil {
-		return nil, fmt.Errorf("%v: %w", ErrCouldNotCompileRegex, err)
-	}
-	return skipRegex, nil
+	return nil
 }
 
 // newLuhnFilterStage creates a new LuhnFilterStage.
 func newLuhnFilterStage(config LuhnFilterConfig) (Stage, error) {
-	skipRegex, err := validateLuhnFilterConfig(&config)
-	if err != nil {
+	if err := validateLuhnFilterConfig(&config); err != nil {
 		return nil, err
 	}
-	stage := &luhnFilterStage{config: &config}
-	if skipRegex != nil {
-		stage.skipRegex = skipRegex
-	}
-	return toStage(stage), nil
-}
 
-// skipRegexMatcher is the subset of *regexp.Regexp that findSkipRanges needs. It exists so
-// tests can substitute a call-counting stub to verify the regex is only run when needed.
-type skipRegexMatcher interface {
-	FindAllStringIndex(s string, n int) [][]int
+	var skipRegex *regexp.Regexp
+	if config.SkipRegex != "" {
+		var err error
+		skipRegex, err = regexp.Compile(config.SkipRegex)
+		if err != nil {
+			return nil, fmt.Errorf("%v: %w", ErrCouldNotCompileRegex, err)
+		}
+	}
+
+	return toStage(&luhnFilterStage{
+		config:    &config,
+		skipRegex: skipRegex,
+	}), nil
 }
 
 // luhnFilterStage applies Luhn algorithm filtering to log entries.
 type luhnFilterStage struct {
 	config    *LuhnFilterConfig
-	skipRegex skipRegexMatcher
+	skipRegex *regexp.Regexp
 }
 
 // Process implements Stage.
@@ -86,172 +81,148 @@ func (r *luhnFilterStage) Process(labels model.LabelSet, extracted map[string]an
 		return
 	}
 
-	var skipRanges [][]int
+	// Replace Luhn-valid numbers in the input.
 	if r.skipRegex != nil {
-		// Running skip_regex is only worthwhile if there's a Luhn-valid number to potentially
-		// exempt from redaction. Skip it entirely for the common case of no match at all.
-		var hasMatch bool
-		if r.config.Delimiters != "" {
-			hasMatch = hasLuhnValidNumberWithDelimiters(*input, r.config.MinLength, r.config.Delimiters)
-		} else {
-			hasMatch = hasLuhnValidNumber(*input, r.config.MinLength)
-		}
-		if !hasMatch {
-			return
-		}
-		skipRanges = findSkipRanges(*input, r.skipRegex)
-	}
-
-	if r.config.Delimiters != "" {
-		*entry = replaceLuhnValidNumbersWithDelimiters(*input, r.config.Replacement, r.config.MinLength, r.config.Delimiters, skipRanges)
+		updatedEntry := replaceLuhnValidNumbersSkipRegex(*input, r.config.Replacement, r.config.MinLength, r.config.Delimiters, r.skipRegex)
+		*entry = updatedEntry
+	} else if r.config.Delimiters != "" {
+		updatedEntry := replaceLuhnValidNumbersWithDelimiters(*input, r.config.Replacement, r.config.MinLength, r.config.Delimiters)
+		*entry = updatedEntry
 	} else {
-		*entry = replaceLuhnValidNumbers(*input, r.config.Replacement, r.config.MinLength, skipRanges)
+		updatedEntry := replaceLuhnValidNumbers(*input, r.config.Replacement, r.config.MinLength)
+		*entry = updatedEntry
 	}
 }
 
-// hasLuhnValidNumber reports whether input contains a run of at least minLength digits that is
-// Luhn-valid. It mirrors the digit-scanning logic in replaceLuhnValidNumbers without building any
-// output, so it can cheaply decide whether skip_regex is worth evaluating.
-func hasLuhnValidNumber(input string, minLength int) bool {
-	digitStart := -1
-
-	checkRun := func(end int) bool {
-		if digitStart == -1 {
-			return false
-		}
-		start := digitStart
-		digitStart = -1
-		if end-start < minLength {
-			return false
-		}
-		number, err := strconv.Atoi(input[start:end])
-		return err == nil && isLuhn(number)
-	}
-
-	for i, char := range input {
-		if unicode.IsDigit(char) {
-			if digitStart == -1 {
-				digitStart = i
-			}
-		} else if checkRun(i) {
-			return true
-		}
-	}
-	return checkRun(len(input))
-}
-
-// hasLuhnValidNumberWithDelimiters is the delimiter-aware counterpart to hasLuhnValidNumber,
-// mirroring replaceLuhnValidNumbersWithDelimiters's digit-scanning logic.
-func hasLuhnValidNumberWithDelimiters(input string, minLength int, delimiters string) bool {
+// replaceLuhnValidNumbersSkipRegex scans Luhn candidates in order and only evaluates skipRegex
+// after finding the first valid candidate. The regex match cursor then only moves forward.
+func replaceLuhnValidNumbersSkipRegex(input, replacement string, minLength int, delimiters string, skipRegex *regexp.Regexp) string {
+	var output strings.Builder
+	output.Grow(len(input))
 	var currentNumber strings.Builder
+	var trailingDelimiter rune
+	numberStart := -1
+	numberEnd := -1
+	numberTextEnd := -1
 
-	checkRun := func() bool {
-		valid := false
+	var skipMatches [][]int
+	skipMatchIndex := 0
+	skipMatchesLoaded := false
+
+	// Checks if the range is skipped by the skipRegex
+	isSkipped := func(start, end int) bool {
+		if !skipMatchesLoaded { // Lazy load the skipRegex matches
+			skipMatches = skipRegex.FindAllStringIndex(input, -1)
+			skipMatchesLoaded = true
+		}
+
+		for skipMatchIndex < len(skipMatches) && skipMatches[skipMatchIndex][1] <= start {
+			skipMatchIndex++
+		}
+		if skipMatchIndex == len(skipMatches) {
+			return false
+		}
+
+		match := skipMatches[skipMatchIndex]
+		return match[0] <= start && end <= match[1]
+	}
+
+	// Flushes the current number to the output, only replacing it if it's a Luhn-valid number and not skipped.
+	flushNumber := func() {
 		if currentNumber.Len() >= minLength {
 			number, err := strconv.Atoi(currentNumber.String())
-			valid = err == nil && isLuhn(number)
-		}
-		currentNumber.Reset()
-		return valid
-	}
-
-	for _, char := range input {
-		switch {
-		case unicode.IsDigit(char):
-			currentNumber.WriteRune(char)
-		case delimiters != "" && strings.ContainsRune(delimiters, char) && currentNumber.Len() > 0:
-			continue
-		default:
-			if checkRun() {
-				return true
+			if err == nil && isLuhn(number) {
+				if isSkipped(numberStart, numberEnd) {
+					output.WriteString(input[numberStart:numberTextEnd])
+				} else {
+					output.WriteString(replacement)
+					if trailingDelimiter != 0 {
+						output.WriteRune(trailingDelimiter)
+					}
+				}
+			} else {
+				output.WriteString(input[numberStart:numberTextEnd])
 			}
+		} else if currentNumber.Len() > 0 {
+			output.WriteString(input[numberStart:numberTextEnd])
 		}
-	}
-	return checkRun()
-}
 
-// findSkipRanges returns the byte ranges of all matches of skipRegex found in input, in the same
-// [start, end] pair-per-match form FindAllStringIndex already produces.
-func findSkipRanges(input string, skipRegex skipRegexMatcher) [][]int {
-	return skipRegex.FindAllStringIndex(input, -1)
-}
-
-// newSkipRangeCursor returns a function that reports whether a byte position falls within any of
-// ranges. ranges must be sorted and non-overlapping (as returned by FindAllStringIndex), and
-// successive calls must pass strictly increasing positions (as in a range-over-string loop). Under
-// those conditions the cursor advances forward only, giving O(n+m) total cost across a scan instead
-// of the O(n*m) a fresh per-character linear scan over ranges would cost.
-func newSkipRangeCursor(ranges [][]int) func(pos int) bool {
-	idx := 0
-	return func(pos int) bool {
-		for idx < len(ranges) && pos >= ranges[idx][1] {
-			idx++
-		}
-		return idx < len(ranges) && pos >= ranges[idx][0]
-	}
-}
-
-// replaceLuhnValidNumbers scans the input for Luhn-valid numbers and replaces them.
-func replaceLuhnValidNumbers(input, replacement string, minLength int, skipRanges [][]int) string {
-	var sb strings.Builder
-	sb.Grow(len(input))
-	// Track the current digit run by its start offset into input rather than copying digits into
-	// a separate buffer. This avoids an allocation per run, which matters when digit runs are short
-	// and frequent (e.g. lone digits interspersed with hex letters in a UUID).
-	digitStart := -1
-
-	flushNumber := func(end int) {
-		if digitStart == -1 {
-			return
-		}
-		start := digitStart
-		digitStart = -1
-		if end-start < minLength {
-			// If the number is less than minLength but not empty, write it as is.
-			sb.WriteString(input[start:end])
-			return
-		}
-		// If the number is at least minLength, check if it's a Luhn-valid number.
-		number, err := strconv.Atoi(input[start:end])
-		if err == nil && isLuhn(number) {
-			// If the number is Luhn-valid, replace it.
-			sb.WriteString(replacement)
-		} else {
-			// If the number is not Luhn-valid, write it as is.
-			sb.WriteString(input[start:end])
-		}
+		currentNumber.Reset()
+		trailingDelimiter = 0
+		numberStart = -1
+		numberEnd = -1
+		numberTextEnd = -1
 	}
 
 	// Iterate over the input, replacing Luhn-valid numbers.
-	inSkipRange := newSkipRangeCursor(skipRanges)
 	for pos, char := range input {
-		// Characters that fall inside a skip_regex match are passed through unchanged.
-		if inSkipRange(pos) {
-			flushNumber(pos)
-			sb.WriteRune(char)
-			continue
-		}
-		// If the character is a digit, extend the current run.
-		if unicode.IsDigit(char) {
-			if digitStart == -1 {
-				digitStart = pos
+		switch {
+		case unicode.IsDigit(char):
+			if numberStart == -1 {
+				numberStart = pos
 			}
+			currentNumber.WriteRune(char)
+			numberEnd = pos + utf8.RuneLen(char)
+			numberTextEnd = numberEnd
+			trailingDelimiter = 0
+		case delimiters != "" && strings.ContainsRune(delimiters, char) && currentNumber.Len() > 0:
+			numberTextEnd = pos + utf8.RuneLen(char)
+			trailingDelimiter = char
+		default:
+			flushNumber()
+			output.WriteRune(char)
+		}
+	}
+	flushNumber()
+
+	return output.String()
+}
+
+// replaceLuhnValidNumbers scans the input for Luhn-valid numbers and replaces them.
+func replaceLuhnValidNumbers(input, replacement string, minLength int) string {
+	var sb strings.Builder
+	var currentNumber strings.Builder
+
+	flushNumber := func() {
+		// If the number is at least minLength, check if it's a Luhn-valid number.
+		if currentNumber.Len() >= minLength {
+			numberStr := currentNumber.String()
+			number, err := strconv.Atoi(numberStr)
+			if err == nil && isLuhn(number) {
+				// If the number is Luhn-valid, replace it.
+				sb.WriteString(replacement)
+			} else {
+				// If the number is not Luhn-valid, write it as is.
+				sb.WriteString(numberStr)
+			}
+		} else if currentNumber.Len() > 0 {
+			// If the number is less than minLength but not empty, write it as is.
+			sb.WriteString(currentNumber.String())
+		}
+		// Reset the current number.
+		currentNumber.Reset()
+	}
+
+	// Iterate over the input, replacing Luhn-valid numbers.
+	for _, char := range input {
+		// If the character is a digit, add it to the current number.
+		if unicode.IsDigit(char) {
+			currentNumber.WriteRune(char)
 		} else {
-			// If the character is not a digit, flush the current run and write the character.
-			flushNumber(pos)
+			// If the character is not a digit, flush the current number and write the character.
+			flushNumber()
 			sb.WriteRune(char)
 		}
 	}
-	flushNumber(len(input)) // Ensure any trailing number is processed
+	flushNumber() // Ensure any trailing number is processed
 
 	return sb.String()
 }
 
 // replaceLuhnValidNumbersWithDelimiters scans the input for Luhn-valid numbers with delimiter support and replaces them.
 // These are separate functions to keep the base case as fast as possible, if no delimiters are needed.
-func replaceLuhnValidNumbersWithDelimiters(input, replacement string, minLength int, delimiters string, skipRanges [][]int) string {
+func replaceLuhnValidNumbersWithDelimiters(input, replacement string, minLength int, delimiters string) string {
 	var sb strings.Builder
-	sb.Grow(len(input))
 	var currentNumber strings.Builder
 	var currentString strings.Builder
 	var trailingDelimiter rune
@@ -282,14 +253,7 @@ func replaceLuhnValidNumbersWithDelimiters(input, replacement string, minLength 
 	}
 
 	// Iterate over the input, replacing Luhn-valid numbers.
-	inSkipRange := newSkipRangeCursor(skipRanges)
-	for pos, char := range input {
-		// Characters that fall inside a skip_regex match are passed through unchanged.
-		if inSkipRange(pos) {
-			flushNumber()
-			sb.WriteRune(char)
-			continue
-		}
+	for _, char := range input {
 		// If the character is a digit, add it to the current number.
 		if unicode.IsDigit(char) {
 			currentNumber.WriteRune(char)

--- a/internal/component/loki/process/stages/luhn.go
+++ b/internal/component/loki/process/stages/luhn.go
@@ -86,7 +86,7 @@ func (r *luhnFilterStage) Process(labels model.LabelSet, extracted map[string]an
 		return
 	}
 
-	var skipRanges [][2]int
+	var skipRanges [][]int
 	if r.skipRegex != nil {
 		// Running skip_regex is only worthwhile if there's a Luhn-valid number to potentially
 		// exempt from redaction. Skip it entirely for the common case of no match at all.
@@ -170,17 +170,10 @@ func hasLuhnValidNumberWithDelimiters(input string, minLength int, delimiters st
 	return checkRun()
 }
 
-// findSkipRanges returns the byte ranges of all matches of skipRegex found in input.
-func findSkipRanges(input string, skipRegex skipRegexMatcher) [][2]int {
-	matches := skipRegex.FindAllStringIndex(input, -1)
-	if len(matches) == 0 {
-		return nil
-	}
-	ranges := make([][2]int, len(matches))
-	for i, m := range matches {
-		ranges[i] = [2]int{m[0], m[1]}
-	}
-	return ranges
+// findSkipRanges returns the byte ranges of all matches of skipRegex found in input, in the same
+// [start, end] pair-per-match form FindAllStringIndex already produces.
+func findSkipRanges(input string, skipRegex skipRegexMatcher) [][]int {
+	return skipRegex.FindAllStringIndex(input, -1)
 }
 
 // newSkipRangeCursor returns a function that reports whether a byte position falls within any of
@@ -188,7 +181,7 @@ func findSkipRanges(input string, skipRegex skipRegexMatcher) [][2]int {
 // successive calls must pass strictly increasing positions (as in a range-over-string loop). Under
 // those conditions the cursor advances forward only, giving O(n+m) total cost across a scan instead
 // of the O(n*m) a fresh per-character linear scan over ranges would cost.
-func newSkipRangeCursor(ranges [][2]int) func(pos int) bool {
+func newSkipRangeCursor(ranges [][]int) func(pos int) bool {
 	idx := 0
 	return func(pos int) bool {
 		for idx < len(ranges) && pos >= ranges[idx][1] {
@@ -199,28 +192,34 @@ func newSkipRangeCursor(ranges [][2]int) func(pos int) bool {
 }
 
 // replaceLuhnValidNumbers scans the input for Luhn-valid numbers and replaces them.
-func replaceLuhnValidNumbers(input, replacement string, minLength int, skipRanges [][2]int) string {
+func replaceLuhnValidNumbers(input, replacement string, minLength int, skipRanges [][]int) string {
 	var sb strings.Builder
-	var currentNumber strings.Builder
+	sb.Grow(len(input))
+	// Track the current digit run by its start offset into input rather than copying digits into
+	// a separate buffer. This avoids an allocation per run, which matters when digit runs are short
+	// and frequent (e.g. lone digits interspersed with hex letters in a UUID).
+	digitStart := -1
 
-	flushNumber := func() {
-		// If the number is at least minLength, check if it's a Luhn-valid number.
-		if currentNumber.Len() >= minLength {
-			numberStr := currentNumber.String()
-			number, err := strconv.Atoi(numberStr)
-			if err == nil && isLuhn(number) {
-				// If the number is Luhn-valid, replace it.
-				sb.WriteString(replacement)
-			} else {
-				// If the number is not Luhn-valid, write it as is.
-				sb.WriteString(numberStr)
-			}
-		} else if currentNumber.Len() > 0 {
-			// If the number is less than minLength but not empty, write it as is.
-			sb.WriteString(currentNumber.String())
+	flushNumber := func(end int) {
+		if digitStart == -1 {
+			return
 		}
-		// Reset the current number.
-		currentNumber.Reset()
+		start := digitStart
+		digitStart = -1
+		if end-start < minLength {
+			// If the number is less than minLength but not empty, write it as is.
+			sb.WriteString(input[start:end])
+			return
+		}
+		// If the number is at least minLength, check if it's a Luhn-valid number.
+		number, err := strconv.Atoi(input[start:end])
+		if err == nil && isLuhn(number) {
+			// If the number is Luhn-valid, replace it.
+			sb.WriteString(replacement)
+		} else {
+			// If the number is not Luhn-valid, write it as is.
+			sb.WriteString(input[start:end])
+		}
 	}
 
 	// Iterate over the input, replacing Luhn-valid numbers.
@@ -228,28 +227,31 @@ func replaceLuhnValidNumbers(input, replacement string, minLength int, skipRange
 	for pos, char := range input {
 		// Characters that fall inside a skip_regex match are passed through unchanged.
 		if inSkipRange(pos) {
-			flushNumber()
+			flushNumber(pos)
 			sb.WriteRune(char)
 			continue
 		}
-		// If the character is a digit, add it to the current number.
+		// If the character is a digit, extend the current run.
 		if unicode.IsDigit(char) {
-			currentNumber.WriteRune(char)
+			if digitStart == -1 {
+				digitStart = pos
+			}
 		} else {
-			// If the character is not a digit, flush the current number and write the character.
-			flushNumber()
+			// If the character is not a digit, flush the current run and write the character.
+			flushNumber(pos)
 			sb.WriteRune(char)
 		}
 	}
-	flushNumber() // Ensure any trailing number is processed
+	flushNumber(len(input)) // Ensure any trailing number is processed
 
 	return sb.String()
 }
 
 // replaceLuhnValidNumbersWithDelimiters scans the input for Luhn-valid numbers with delimiter support and replaces them.
 // These are separate functions to keep the base case as fast as possible, if no delimiters are needed.
-func replaceLuhnValidNumbersWithDelimiters(input, replacement string, minLength int, delimiters string, skipRanges [][2]int) string {
+func replaceLuhnValidNumbersWithDelimiters(input, replacement string, minLength int, delimiters string, skipRanges [][]int) string {
 	var sb strings.Builder
+	sb.Grow(len(input))
 	var currentNumber strings.Builder
 	var currentString strings.Builder
 	var trailingDelimiter rune

--- a/internal/component/loki/process/stages/luhn_test.go
+++ b/internal/component/loki/process/stages/luhn_test.go
@@ -1,7 +1,6 @@
 package stages
 
 import (
-	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -60,9 +59,9 @@ func TestReplaceLuhnValidNumbers(t *testing.T) {
 	for _, c := range cases {
 		var got string
 		if c.delimiters == "" {
-			got = replaceLuhnValidNumbers(c.input, c.replacement, 13, nil)
+			got = replaceLuhnValidNumbers(c.input, c.replacement, 13)
 		} else {
-			got = replaceLuhnValidNumbersWithDelimiters(c.input, c.replacement, 13, c.delimiters, nil)
+			got = replaceLuhnValidNumbersWithDelimiters(c.input, c.replacement, 13, c.delimiters)
 		}
 		if got != c.want {
 			t.Errorf("replaceLuhnValidNumbers(%q, %q) == %q, want %q", c.input, c.replacement, got, c.want)
@@ -70,204 +69,9 @@ func TestReplaceLuhnValidNumbers(t *testing.T) {
 	}
 }
 
-func TestSkipRegex(t *testing.T) {
-	const (
-		uuidRegexStr = `[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`
-		luhnUUID     = "a3f1b2e4-c5d6-7e8f-4242-424242424242"
-		luhnCC       = "4242424242424242" // 16-digit Luhn-valid credit card number (Stripe test card)
-		replacement  = "**REDACTED**"
-	)
-	uuidRegex := regexp.MustCompile(uuidRegexStr)
-
-	t.Run("findSkipRanges finds a single match", func(t *testing.T) {
-		input := "session=" + luhnUUID + " end"
-		ranges := findSkipRanges(input, uuidRegex)
-		require.Len(t, ranges, 1)
-		require.Equal(t, []int{8, 8 + len(luhnUUID)}, ranges[0])
-	})
-
-	t.Run("findSkipRanges returns nil when no matches present", func(t *testing.T) {
-		require.Nil(t, findSkipRanges("no uuids here "+luhnCC, uuidRegex))
-	})
-
-	t.Run("findSkipRanges finds multiple matches", func(t *testing.T) {
-		input := luhnUUID + " " + luhnUUID
-		require.Len(t, findSkipRanges(input, uuidRegex), 2)
-	})
-
-	t.Run("UUID Luhn-valid segment preserved when skip_regex matches it", func(t *testing.T) {
-		// With minLength=12, the last UUID segment (424242424242) would be redacted normally.
-		input := "session=" + luhnUUID
-		got := replaceLuhnValidNumbers(input, replacement, 12, findSkipRanges(input, uuidRegex))
-		require.Equal(t, input, got)
-	})
-
-	t.Run("UUID Luhn-valid segment redacted when skip_regex not configured", func(t *testing.T) {
-		// Baseline: without skip ranges the segment gets replaced.
-		input := "session=" + luhnUUID
-		got := replaceLuhnValidNumbers(input, replacement, 12, nil)
-		require.Contains(t, got, replacement)
-		require.NotContains(t, got, "424242424242")
-	})
-
-	t.Run("credit card redacted but UUID preserved", func(t *testing.T) {
-		input := "card=" + luhnCC + " session=" + luhnUUID
-		got := replaceLuhnValidNumbers(input, replacement, 12, findSkipRanges(input, uuidRegex))
-		require.Contains(t, got, replacement)
-		require.Contains(t, got, luhnUUID)
-		require.NotContains(t, got, luhnCC)
-	})
-
-	t.Run("Luhn detection still works when skip_regex configured but no matches present", func(t *testing.T) {
-		input := "card=" + luhnCC
-		got := replaceLuhnValidNumbers(input, replacement, 16, findSkipRanges(input, uuidRegex))
-		require.Contains(t, got, replacement)
-		require.NotContains(t, got, luhnCC)
-	})
-
-	t.Run("delimiter support preserves UUID", func(t *testing.T) {
-		input := "card=4242-4242-4242-4242 session=" + luhnUUID
-		got := replaceLuhnValidNumbersWithDelimiters(input, replacement, 16, " -", findSkipRanges(input, uuidRegex))
-		require.Contains(t, got, replacement)
-		require.Contains(t, got, luhnUUID)
-		require.NotContains(t, got, "4242-4242-4242-4242")
-	})
-
-	t.Run("end-to-end Process with skip_regex set to the uuid pattern", func(t *testing.T) {
-		input := "card=" + luhnCC + " session=" + luhnUUID
-		entry := input
-		stage := &luhnFilterStage{
-			config: &LuhnFilterConfig{
-				Replacement: replacement,
-				MinLength:   12,
-				SkipRegex:   uuidRegexStr,
-			},
-			skipRegex: uuidRegex,
-		}
-		stage.Process(nil, nil, nil, &entry)
-		require.Contains(t, entry, replacement)
-		require.Contains(t, entry, luhnUUID)
-		require.NotContains(t, entry, luhnCC)
-	})
-
-	t.Run("end-to-end Process with skip_regex unset leaves behavior unchanged", func(t *testing.T) {
-		input := "card=" + luhnCC + " session=" + luhnUUID
-		entry := input
-		stage := &luhnFilterStage{
-			config: &LuhnFilterConfig{
-				Replacement: replacement,
-				MinLength:   12,
-			},
-		}
-		stage.Process(nil, nil, nil, &entry)
-		require.Contains(t, entry, replacement)
-		require.NotContains(t, entry, luhnCC)
-		require.NotContains(t, entry, luhnUUID)
-	})
-
-	t.Run("newLuhnFilterStage compiles skip_regex from config", func(t *testing.T) {
-		stage, err := newLuhnFilterStage(LuhnFilterConfig{
-			Replacement: replacement,
-			MinLength:   12,
-			SkipRegex:   uuidRegexStr,
-		})
-		require.NoError(t, err)
-
-		entry := "card=" + luhnCC + " session=" + luhnUUID
-		stage.(Processor).Process(nil, nil, nil, &entry)
-		require.Contains(t, entry, replacement)
-		require.Contains(t, entry, luhnUUID)
-		require.NotContains(t, entry, luhnCC)
-	})
-
-	t.Run("newLuhnFilterStage rejects invalid skip_regex", func(t *testing.T) {
-		_, err := newLuhnFilterStage(LuhnFilterConfig{
-			Replacement: replacement,
-			MinLength:   12,
-			SkipRegex:   "(",
-		})
-		require.Error(t, err)
-	})
-
-	t.Run("skip_regex is not evaluated when the entry has no Luhn-valid number", func(t *testing.T) {
-		matcher := &countingMatcher{}
-		// Hex-looking id with no digit run reaching minLength and no Luhn-valid number.
-		entry := "session=a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4 status=ok"
-		stage := &luhnFilterStage{
-			config: &LuhnFilterConfig{
-				Replacement: replacement,
-				MinLength:   12,
-			},
-			skipRegex: matcher,
-		}
-		stage.Process(nil, nil, nil, &entry)
-		require.Equal(t, 0, matcher.calls)
-	})
-
-	t.Run("skip_regex is evaluated when the entry has a Luhn-valid number", func(t *testing.T) {
-		matcher := &countingMatcher{}
-		entry := "card=" + luhnCC
-		stage := &luhnFilterStage{
-			config: &LuhnFilterConfig{
-				Replacement: replacement,
-				MinLength:   12,
-			},
-			skipRegex: matcher,
-		}
-		stage.Process(nil, nil, nil, &entry)
-		require.Equal(t, 1, matcher.calls)
-	})
-}
-
-// countingMatcher is a skipRegexMatcher stub that records how many times it was invoked, used to
-// verify that skip_regex is only evaluated when the entry actually has a Luhn-valid number.
-type countingMatcher struct {
-	calls int
-}
-
-func (m *countingMatcher) FindAllStringIndex(s string, n int) [][]int {
-	m.calls++
-	return nil
-}
-
-func TestHasLuhnValidNumber(t *testing.T) {
-	cases := []struct {
-		name      string
-		input     string
-		minLength int
-		want      bool
-	}{
-		{"no digits", "session=a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4", 12, false},
-		{"digit run shorter than minLength", "id=12345", 12, false},
-		{"digit run long enough but not Luhn-valid", "id=123456789012", 12, false},
-		{"digit run long enough and Luhn-valid", "card=4242424242424242", 12, true},
-		{"Luhn-valid run embedded in longer text", "card=4242424242424242 end", 12, true},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			require.Equal(t, c.want, hasLuhnValidNumber(c.input, c.minLength))
-		})
-	}
-}
-
-func TestHasLuhnValidNumberWithDelimiters(t *testing.T) {
-	cases := []struct {
-		name       string
-		input      string
-		minLength  int
-		delimiters string
-		want       bool
-	}{
-		{"no digits", "session=a1b2c3d4-e5f6", 12, " -", false},
-		{"delimited run shorter than minLength", "id=1234-5678", 12, " -", false},
-		{"delimited run long enough but not Luhn-valid", "id=1234-5678-9012", 12, " -", false},
-		{"delimited run long enough and Luhn-valid", "card=4242-4242-4242-4242", 12, " -", true},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			require.Equal(t, c.want, hasLuhnValidNumberWithDelimiters(c.input, c.minLength, c.delimiters))
-		})
-	}
+func TestLuhnFilterStageRejectsInvalidSkipRegex(t *testing.T) {
+	_, err := newLuhnFilterStage(LuhnFilterConfig{SkipRegex: "("})
+	require.ErrorContains(t, err, ErrCouldNotCompileRegex.Error())
 }
 
 func TestLuhnFilterStageSkipRegexEndToEnd(t *testing.T) {
@@ -606,27 +410,11 @@ func TestValidateConfig(t *testing.T) {
 				SkipRegex:   `[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`,
 			},
 		},
-		{
-			name: "invalid skip_regex error",
-			input: LuhnFilterConfig{
-				Replacement: "ABC",
-				Source:      &source,
-				MinLength:   10,
-				SkipRegex:   "(",
-			},
-			expected: LuhnFilterConfig{
-				Replacement: "ABC",
-				Source:      &source,
-				MinLength:   10,
-				SkipRegex:   "(",
-			},
-			errorContainsStr: "could not compile",
-		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			_, err := validateLuhnFilterConfig(&c.input)
+			err := validateLuhnFilterConfig(&c.input)
 			if c.errorContainsStr == "" {
 				require.NoError(t, err)
 			} else {

--- a/internal/component/loki/process/stages/luhn_test.go
+++ b/internal/component/loki/process/stages/luhn_test.go
@@ -188,6 +188,146 @@ func TestSkipRegex(t *testing.T) {
 		})
 		require.Error(t, err)
 	})
+
+	t.Run("skip_regex is not evaluated when the entry has no Luhn-valid number", func(t *testing.T) {
+		matcher := &countingMatcher{}
+		// Hex-looking id with no digit run reaching minLength and no Luhn-valid number.
+		entry := "session=a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4 status=ok"
+		stage := &luhnFilterStage{
+			config: &LuhnFilterConfig{
+				Replacement: replacement,
+				MinLength:   12,
+			},
+			skipRegex: matcher,
+		}
+		stage.Process(nil, nil, nil, &entry)
+		require.Equal(t, 0, matcher.calls)
+	})
+
+	t.Run("skip_regex is evaluated when the entry has a Luhn-valid number", func(t *testing.T) {
+		matcher := &countingMatcher{}
+		entry := "card=" + luhnCC
+		stage := &luhnFilterStage{
+			config: &LuhnFilterConfig{
+				Replacement: replacement,
+				MinLength:   12,
+			},
+			skipRegex: matcher,
+		}
+		stage.Process(nil, nil, nil, &entry)
+		require.Equal(t, 1, matcher.calls)
+	})
+}
+
+// countingMatcher is a skipRegexMatcher stub that records how many times it was invoked, used to
+// verify that skip_regex is only evaluated when the entry actually has a Luhn-valid number.
+type countingMatcher struct {
+	calls int
+}
+
+func (m *countingMatcher) FindAllStringIndex(s string, n int) [][]int {
+	m.calls++
+	return nil
+}
+
+func TestHasLuhnValidNumber(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		minLength int
+		want      bool
+	}{
+		{"no digits", "session=a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4", 12, false},
+		{"digit run shorter than minLength", "id=12345", 12, false},
+		{"digit run long enough but not Luhn-valid", "id=123456789012", 12, false},
+		{"digit run long enough and Luhn-valid", "card=4242424242424242", 12, true},
+		{"Luhn-valid run embedded in longer text", "card=4242424242424242 end", 12, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.want, hasLuhnValidNumber(c.input, c.minLength))
+		})
+	}
+}
+
+func TestHasLuhnValidNumberWithDelimiters(t *testing.T) {
+	cases := []struct {
+		name       string
+		input      string
+		minLength  int
+		delimiters string
+		want       bool
+	}{
+		{"no digits", "session=a1b2c3d4-e5f6", 12, " -", false},
+		{"delimited run shorter than minLength", "id=1234-5678", 12, " -", false},
+		{"delimited run long enough but not Luhn-valid", "id=1234-5678-9012", 12, " -", false},
+		{"delimited run long enough and Luhn-valid", "card=4242-4242-4242-4242", 12, " -", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.want, hasLuhnValidNumberWithDelimiters(c.input, c.minLength, c.delimiters))
+		})
+	}
+}
+
+// BenchmarkLuhnFilterStage compares Process performance with skip_regex enabled
+// vs disabled, across inputs that do and don't contain UUIDs and Luhn-valid numbers.
+func BenchmarkLuhnFilterStage(b *testing.B) {
+	const (
+		uuidRegexStr = `[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`
+		luhnUUID     = "a3f1b2e4-c5d6-7e8f-4242-424242424242" // last group is a 12-digit Luhn-valid run
+		luhnCC       = "4242424242424242"                     // 16-digit Luhn-valid credit card number
+	)
+
+	fixtures := []struct {
+		name  string
+		entry string
+	}{
+		{
+			name:  "no_uuid_no_luhn",
+			entry: `level=info ts=2024-01-15T10:23:45Z msg="processing request" request_id=req-8f14e45fceaa user_id=usr-2ab3c9d1e502 note="ref 12345 67890" status=success duration_ms=42`,
+		},
+		{
+			name:  "no_uuid_with_luhn",
+			entry: `level=info ts=2024-01-15T10:23:45Z msg="processing payment" request_id=req-8f14e45fceaa user_id=usr-2ab3c9d1e502 card=` + luhnCC + ` status=success duration_ms=42`,
+		},
+		{
+			name:  "with_uuid_no_luhn",
+			entry: `level=info ts=2024-01-15T10:23:45Z msg="processing request" request_id=` + luhnUUID + ` user_id=` + luhnUUID + ` note="ref 12345 67890" status=success duration_ms=42`,
+		},
+		{
+			name:  "with_uuid_with_luhn",
+			entry: `level=info ts=2024-01-15T10:23:45Z msg="processing payment" request_id=` + luhnUUID + ` user_id=` + luhnUUID + ` card=` + luhnCC + ` status=success duration_ms=42`,
+		},
+	}
+
+	skipRegexStates := []struct {
+		name      string
+		skipRegex string
+	}{
+		{"skip_regex=off", ""},
+		{"skip_regex=on", uuidRegexStr},
+	}
+
+	for _, fx := range fixtures {
+		for _, sr := range skipRegexStates {
+			b.Run(fx.name+"/"+sr.name, func(b *testing.B) {
+				stage, err := newLuhnFilterStage(LuhnFilterConfig{
+					Replacement: "**REDACTED**",
+					MinLength:   12,
+					SkipRegex:   sr.skipRegex,
+				})
+				require.NoError(b, err)
+				processor := stage.(Processor)
+
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					entry := fx.entry
+					processor.Process(nil, nil, nil, &entry)
+				}
+			})
+		}
+	}
 }
 
 func TestValidateConfig(t *testing.T) {

--- a/internal/component/loki/process/stages/luhn_test.go
+++ b/internal/component/loki/process/stages/luhn_test.go
@@ -1,6 +1,7 @@
 package stages
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -12,7 +13,7 @@ func TestIsLuhnValid(t *testing.T) {
 		input int
 		want  bool
 	}{
-		{4539_1488_0343_6467, true}, // Valid Luhn number
+		{4242_4242_4242_4242, true}, // Valid Luhn number
 		{1234_5678_1234_5670, true}, // Another valid Luhn number
 		{499_2739_8112_1717, false}, // Invalid Luhn number
 		{1234567812345678, false},   // Another invalid Luhn number
@@ -59,14 +60,134 @@ func TestReplaceLuhnValidNumbers(t *testing.T) {
 	for _, c := range cases {
 		var got string
 		if c.delimiters == "" {
-			got = replaceLuhnValidNumbers(c.input, c.replacement, 13)
+			got = replaceLuhnValidNumbers(c.input, c.replacement, 13, nil)
 		} else {
-			got = replaceLuhnValidNumbersWithDelimiters(c.input, c.replacement, 13, c.delimiters)
+			got = replaceLuhnValidNumbersWithDelimiters(c.input, c.replacement, 13, c.delimiters, nil)
 		}
 		if got != c.want {
 			t.Errorf("replaceLuhnValidNumbers(%q, %q) == %q, want %q", c.input, c.replacement, got, c.want)
 		}
 	}
+}
+
+func TestSkipRegex(t *testing.T) {
+	const (
+		uuidRegexStr = `[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`
+		luhnUUID     = "a3f1b2e4-c5d6-7e8f-4242-424242424242"
+		luhnCC       = "4242424242424242" // 16-digit Luhn-valid credit card number (Stripe test card)
+		replacement  = "**REDACTED**"
+	)
+	uuidRegex := regexp.MustCompile(uuidRegexStr)
+
+	t.Run("findSkipRanges finds a single match", func(t *testing.T) {
+		input := "session=" + luhnUUID + " end"
+		ranges := findSkipRanges(input, uuidRegex)
+		require.Len(t, ranges, 1)
+		require.Equal(t, [2]int{8, 8 + len(luhnUUID)}, ranges[0])
+	})
+
+	t.Run("findSkipRanges returns nil when no matches present", func(t *testing.T) {
+		require.Nil(t, findSkipRanges("no uuids here "+luhnCC, uuidRegex))
+	})
+
+	t.Run("findSkipRanges finds multiple matches", func(t *testing.T) {
+		input := luhnUUID + " " + luhnUUID
+		require.Len(t, findSkipRanges(input, uuidRegex), 2)
+	})
+
+	t.Run("UUID Luhn-valid segment preserved when skip_regex matches it", func(t *testing.T) {
+		// With minLength=12, the last UUID segment (424242424242) would be redacted normally.
+		input := "session=" + luhnUUID
+		got := replaceLuhnValidNumbers(input, replacement, 12, findSkipRanges(input, uuidRegex))
+		require.Equal(t, input, got)
+	})
+
+	t.Run("UUID Luhn-valid segment redacted when skip_regex not configured", func(t *testing.T) {
+		// Baseline: without skip ranges the segment gets replaced.
+		input := "session=" + luhnUUID
+		got := replaceLuhnValidNumbers(input, replacement, 12, nil)
+		require.Contains(t, got, replacement)
+		require.NotContains(t, got, "424242424242")
+	})
+
+	t.Run("credit card redacted but UUID preserved", func(t *testing.T) {
+		input := "card=" + luhnCC + " session=" + luhnUUID
+		got := replaceLuhnValidNumbers(input, replacement, 12, findSkipRanges(input, uuidRegex))
+		require.Contains(t, got, replacement)
+		require.Contains(t, got, luhnUUID)
+		require.NotContains(t, got, luhnCC)
+	})
+
+	t.Run("Luhn detection still works when skip_regex configured but no matches present", func(t *testing.T) {
+		input := "card=" + luhnCC
+		got := replaceLuhnValidNumbers(input, replacement, 16, findSkipRanges(input, uuidRegex))
+		require.Contains(t, got, replacement)
+		require.NotContains(t, got, luhnCC)
+	})
+
+	t.Run("delimiter support preserves UUID", func(t *testing.T) {
+		input := "card=4242-4242-4242-4242 session=" + luhnUUID
+		got := replaceLuhnValidNumbersWithDelimiters(input, replacement, 16, " -", findSkipRanges(input, uuidRegex))
+		require.Contains(t, got, replacement)
+		require.Contains(t, got, luhnUUID)
+		require.NotContains(t, got, "4242-4242-4242-4242")
+	})
+
+	t.Run("end-to-end Process with skip_regex set to the uuid pattern", func(t *testing.T) {
+		input := "card=" + luhnCC + " session=" + luhnUUID
+		entry := input
+		stage := &luhnFilterStage{
+			config: &LuhnFilterConfig{
+				Replacement: replacement,
+				MinLength:   12,
+				SkipRegex:   uuidRegexStr,
+			},
+			skipRegex: uuidRegex,
+		}
+		stage.Process(nil, nil, nil, &entry)
+		require.Contains(t, entry, replacement)
+		require.Contains(t, entry, luhnUUID)
+		require.NotContains(t, entry, luhnCC)
+	})
+
+	t.Run("end-to-end Process with skip_regex unset leaves behavior unchanged", func(t *testing.T) {
+		input := "card=" + luhnCC + " session=" + luhnUUID
+		entry := input
+		stage := &luhnFilterStage{
+			config: &LuhnFilterConfig{
+				Replacement: replacement,
+				MinLength:   12,
+			},
+		}
+		stage.Process(nil, nil, nil, &entry)
+		require.Contains(t, entry, replacement)
+		require.NotContains(t, entry, luhnCC)
+		require.NotContains(t, entry, luhnUUID)
+	})
+
+	t.Run("newLuhnFilterStage compiles skip_regex from config", func(t *testing.T) {
+		stage, err := newLuhnFilterStage(LuhnFilterConfig{
+			Replacement: replacement,
+			MinLength:   12,
+			SkipRegex:   uuidRegexStr,
+		})
+		require.NoError(t, err)
+
+		entry := "card=" + luhnCC + " session=" + luhnUUID
+		stage.(Processor).Process(nil, nil, nil, &entry)
+		require.Contains(t, entry, replacement)
+		require.Contains(t, entry, luhnUUID)
+		require.NotContains(t, entry, luhnCC)
+	})
+
+	t.Run("newLuhnFilterStage rejects invalid skip_regex", func(t *testing.T) {
+		_, err := newLuhnFilterStage(LuhnFilterConfig{
+			Replacement: replacement,
+			MinLength:   12,
+			SkipRegex:   "(",
+		})
+		require.Error(t, err)
+	})
 }
 
 func TestValidateConfig(t *testing.T) {
@@ -131,11 +252,42 @@ func TestValidateConfig(t *testing.T) {
 				MinLength:   13,
 			},
 		},
+		{
+			name: "valid skip_regex",
+			input: LuhnFilterConfig{
+				Replacement: "ABC",
+				Source:      &source,
+				MinLength:   10,
+				SkipRegex:   `[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`,
+			},
+			expected: LuhnFilterConfig{
+				Replacement: "ABC",
+				Source:      &source,
+				MinLength:   10,
+				SkipRegex:   `[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`,
+			},
+		},
+		{
+			name: "invalid skip_regex error",
+			input: LuhnFilterConfig{
+				Replacement: "ABC",
+				Source:      &source,
+				MinLength:   10,
+				SkipRegex:   "(",
+			},
+			expected: LuhnFilterConfig{
+				Replacement: "ABC",
+				Source:      &source,
+				MinLength:   10,
+				SkipRegex:   "(",
+			},
+			errorContainsStr: "could not compile",
+		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			err := validateLuhnFilterConfig(&c.input)
+			_, err := validateLuhnFilterConfig(&c.input)
 			if c.errorContainsStr == "" {
 				require.NoError(t, err)
 			} else {

--- a/internal/component/loki/process/stages/luhn_test.go
+++ b/internal/component/loki/process/stages/luhn_test.go
@@ -270,11 +270,210 @@ func TestHasLuhnValidNumberWithDelimiters(t *testing.T) {
 	}
 }
 
+func TestLuhnFilterStageSkipRegexEndToEnd(t *testing.T) {
+	const (
+		uuidRegex     = `[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`
+		nonLuhnUUID   = "a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4"
+		luhnUUID      = "a3f1b2e4-c5d6-7e8f-4242-424242424242"
+		luhnCard      = "4242424242424242"
+		anotherCard   = "6011111111111117"
+		delimitedCard = "4242-4242-4242-4242"
+		replacement   = "**REDACTED**"
+	)
+
+	tests := []struct {
+		name        string
+		entry       string
+		extracted   map[string]any
+		source      string
+		replacement string
+		minLength   int
+		delimiters  string
+		skipRegex   string
+		want        string
+	}{
+		{
+			name:  "no Luhn number",
+			entry: "payment accepted",
+			want:  "payment accepted",
+		},
+		{
+			name:  "matching UUID without a Luhn number",
+			entry: "session=" + nonLuhnUUID,
+			want:  "session=" + nonLuhnUUID,
+		},
+		{
+			name:  "standalone Luhn number is redacted",
+			entry: "card=" + luhnCard,
+			want:  "card=" + replacement,
+		},
+		{
+			name:      "Luhn number contained by a skip match is preserved",
+			entry:     "safe-card=" + luhnCard,
+			skipRegex: `safe-card=[0-9]+`,
+			want:      "safe-card=" + luhnCard,
+		},
+		{
+			name:      "Luhn number equal to a skip match is preserved",
+			entry:     "card=" + luhnCard,
+			skipRegex: luhnCard,
+			want:      "card=" + luhnCard,
+		},
+		{
+			name:  "Luhn-valid UUID segment is preserved",
+			entry: "session=" + luhnUUID,
+			want:  "session=" + luhnUUID,
+		},
+		{
+			name:  "card before UUID is redacted",
+			entry: "card=" + luhnCard + " session=" + luhnUUID,
+			want:  "card=" + replacement + " session=" + luhnUUID,
+		},
+		{
+			name:  "card after UUID is redacted",
+			entry: "session=" + luhnUUID + " card=" + luhnCard,
+			want:  "session=" + luhnUUID + " card=" + replacement,
+		},
+		{
+			name:  "cursor advances past an earlier non-Luhn UUID",
+			entry: "session=" + nonLuhnUUID + " card=" + luhnCard,
+			want:  "session=" + nonLuhnUUID + " card=" + replacement,
+		},
+		{
+			name:  "multiple skip matches and cards are handled in order",
+			entry: "session1=" + luhnUUID + " card1=" + luhnCard + " session2=" + luhnUUID + " card2=" + anotherCard,
+			want:  "session1=" + luhnUUID + " card1=" + replacement + " session2=" + luhnUUID + " card2=" + replacement,
+		},
+		{
+			name:      "one skip match can contain multiple Luhn numbers",
+			entry:     "safe=" + luhnCard + "/" + anotherCard,
+			skipRegex: `safe=[0-9/]+`,
+			want:      "safe=" + luhnCard + "/" + anotherCard,
+		},
+		{
+			name:      "partial overlap does not suppress redaction",
+			entry:     "card=" + luhnCard,
+			skipRegex: `42424242$`,
+			want:      "card=" + replacement,
+		},
+		{
+			name:      "zero-length skip matches do not suppress redaction",
+			entry:     "card=" + luhnCard,
+			skipRegex: `^|$`,
+			want:      "card=" + replacement,
+		},
+		{
+			name:  "invalid Luhn number is unchanged",
+			entry: "card=4242424242424243",
+			want:  "card=4242424242424243",
+		},
+		{
+			name:      "Luhn number below minimum length is unchanged",
+			entry:     "number=424242424242",
+			minLength: 13,
+			want:      "number=424242424242",
+		},
+		{
+			name:        "custom replacement is used",
+			entry:       "card=" + luhnCard,
+			replacement: "[SECRET]",
+			want:        "card=[SECRET]",
+		},
+		{
+			name:       "delimited card is redacted",
+			entry:      "card=" + delimitedCard,
+			delimiters: "-",
+			want:       "card=" + replacement,
+		},
+		{
+			name:       "delimited card contained by a skip match is preserved",
+			entry:      "safe-card=" + delimitedCard,
+			delimiters: "-",
+			skipRegex:  `safe-card=[0-9-]+`,
+			want:       "safe-card=" + delimitedCard,
+		},
+		{
+			name:      "source without a Luhn number replaces the entry",
+			entry:     "original log line",
+			extracted: map[string]any{"message": "payment accepted"},
+			source:    "message",
+			want:      "payment accepted",
+		},
+		{
+			name:      "source preserves UUID and redacts card",
+			entry:     "original log line",
+			extracted: map[string]any{"message": "session=" + luhnUUID + " card=" + luhnCard},
+			source:    "message",
+			want:      "session=" + luhnUUID + " card=" + replacement,
+		},
+		{
+			name:      "skip regex is evaluated against source rather than entry",
+			entry:     "session=" + luhnUUID,
+			extracted: map[string]any{"message": "card=" + luhnCard},
+			source:    "message",
+			want:      "card=" + replacement,
+		},
+		{
+			name:      "missing source leaves entry unchanged",
+			entry:     "original log line",
+			extracted: map[string]any{},
+			source:    "message",
+			want:      "original log line",
+		},
+		{
+			name:      "non-string source leaves entry unchanged",
+			entry:     "original log line",
+			extracted: map[string]any{"message": 42},
+			source:    "message",
+			want:      "original log line",
+		},
+		{
+			name:       "source supports delimiters",
+			entry:      "original log line",
+			extracted:  map[string]any{"message": "card=" + delimitedCard + " session=" + luhnUUID},
+			source:     "message",
+			delimiters: " -",
+			want:       "card=" + replacement + " session=" + luhnUUID,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			config := LuhnFilterConfig{
+				Replacement: replacement,
+				MinLength:   12,
+				Delimiters:  tc.delimiters,
+				SkipRegex:   uuidRegex,
+			}
+			if tc.replacement != "" {
+				config.Replacement = tc.replacement
+			}
+			if tc.minLength != 0 {
+				config.MinLength = tc.minLength
+			}
+			if tc.skipRegex != "" {
+				config.SkipRegex = tc.skipRegex
+			}
+			if tc.source != "" {
+				config.Source = &tc.source
+			}
+
+			stage, err := newLuhnFilterStage(config)
+			require.NoError(t, err)
+
+			entry := tc.entry
+			stage.(Processor).Process(nil, tc.extracted, nil, &entry)
+			require.Equal(t, tc.want, entry)
+		})
+	}
+}
+
 // BenchmarkLuhnFilterStage compares Process performance with skip_regex enabled
 // vs disabled, across inputs that do and don't contain UUIDs and Luhn-valid numbers.
 func BenchmarkLuhnFilterStage(b *testing.B) {
 	const (
 		uuidRegexStr = `[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`
+		nonLuhnUUID  = "a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4"
 		luhnUUID     = "a3f1b2e4-c5d6-7e8f-4242-424242424242" // last group is a 12-digit Luhn-valid run
 		luhnCC       = "4242424242424242"                     // 16-digit Luhn-valid credit card number
 	)
@@ -293,7 +492,7 @@ func BenchmarkLuhnFilterStage(b *testing.B) {
 		},
 		{
 			name:  "with_uuid_no_luhn",
-			entry: `level=info ts=2024-01-15T10:23:45Z msg="processing request" request_id=` + luhnUUID + ` user_id=` + luhnUUID + ` note="ref 12345 67890" status=success duration_ms=42`,
+			entry: `level=info ts=2024-01-15T10:23:45Z msg="processing request" request_id=` + nonLuhnUUID + ` user_id=` + nonLuhnUUID + ` note="ref 12345 67890" status=success duration_ms=42`,
 		},
 		{
 			name:  "with_uuid_with_luhn",

--- a/internal/component/loki/process/stages/luhn_test.go
+++ b/internal/component/loki/process/stages/luhn_test.go
@@ -83,7 +83,7 @@ func TestSkipRegex(t *testing.T) {
 		input := "session=" + luhnUUID + " end"
 		ranges := findSkipRanges(input, uuidRegex)
 		require.Len(t, ranges, 1)
-		require.Equal(t, [2]int{8, 8 + len(luhnUUID)}, ranges[0])
+		require.Equal(t, []int{8, 8 + len(luhnUUID)}, ranges[0])
 	})
 
 	t.Run("findSkipRanges returns nil when no matches present", func(t *testing.T) {


### PR DESCRIPTION
### Brief description of Pull Request

Add config option to ignore luhn matches in uuid substrings

### Issue(s) fixed by this Pull Request

In testing, approx 1 in 350 (~0.3%) of generated UUIDs contain a substring that satisfies the Luhn algorithm. This allows UUID segments of logs to be ignored in the loki luhn stage.


### PR Checklist

- [x] Documentation added
- [x] Tests updated
