### PR TITLE
fix(prometheus.exporter.cloudwatch): Stop forcing legacy metric-name validation process-wide

### DIFF
--- a/collector/builder-config.yaml
+++ b/collector/builder-config.yaml
@@ -136,6 +136,8 @@ replaces:
   - github.com/prometheus/mysqld_exporter => github.com/grafana/mysqld_exporter v0.0.0-20260319134024-e0461af8db16
   # TODO: replace node_exporter with custom fork for multi usage. https://github.com/prometheus/node_exporter/pull/2812
   - github.com/prometheus/node_exporter => github.com/grafana/node_exporter v0.18.1-grafana-r01.0.20251024135609-318b01780c89
+  # TODO - tracks kgeckhart/yet-another-cloudwatch-exporter fix-name-validation-global; stops YACE mutating the process-global metric-name validation scheme. Remove once merged upstream.
+  - github.com/prometheus-community/yet-another-cloudwatch-exporter => github.com/kgeckhart/yet-another-cloudwatch-exporter v0.64.1-0.20260629154816-440211eac126
   # Use Grafana fork of smimesign
   - github.com/github/smimesign => github.com/grafana/smimesign v0.2.1-0.20220408144937-2a5adf3481d3
   # Replace OpenTelemetry OBI with Grafana fork

--- a/collector/go.mod
+++ b/collector/go.mod
@@ -1135,6 +1135,8 @@ replace github.com/prometheus/mysqld_exporter => github.com/grafana/mysqld_expor
 
 replace github.com/prometheus/node_exporter => github.com/grafana/node_exporter v0.18.1-grafana-r01.0.20251024135609-318b01780c89
 
+replace github.com/prometheus-community/yet-another-cloudwatch-exporter => github.com/kgeckhart/yet-another-cloudwatch-exporter v0.64.1-0.20260629154816-440211eac126
+
 replace github.com/github/smimesign => github.com/grafana/smimesign v0.2.1-0.20220408144937-2a5adf3481d3
 
 replace go.opentelemetry.io/obi => github.com/grafana/opentelemetry-ebpf-instrumentation v1.32.1

--- a/collector/go.sum
+++ b/collector/go.sum
@@ -1525,6 +1525,8 @@ github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRt
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/kgeckhart/prometheus-operator v0.90.2-0.20260511184813-5b1d6bf02253 h1:07JX4vP+dfMyNxuJxWMOthUKVfKE/JhwMEz7wP4k7AI=
 github.com/kgeckhart/prometheus-operator v0.90.2-0.20260511184813-5b1d6bf02253/go.mod h1:z+KVSl/9Oh8y0mvQwpIc5HnrNLUqPl6qEiq9pHwfQaU=
+github.com/kgeckhart/yet-another-cloudwatch-exporter v0.64.1-0.20260629154816-440211eac126 h1:2zGI/FxipO2lZzr2rc01KloYc+i6sZfT1qrvHAO7pjg=
+github.com/kgeckhart/yet-another-cloudwatch-exporter v0.64.1-0.20260629154816-440211eac126/go.mod h1:gsTwbxTbhpPpcurDJZP4JNzAUaxSUBnAsB4KOhMEbCE=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -2143,8 +2145,6 @@ github.com/prometheus-community/stackdriver_exporter v0.18.0 h1:nB7JwloiBziunauj
 github.com/prometheus-community/stackdriver_exporter v0.18.0/go.mod h1:f7T7XXRVc390sVc7rk2yNflf+RkClE4mlfsaSsW2K5Q=
 github.com/prometheus-community/windows_exporter v0.31.3 h1:v5HRhiSL/AgFtp96GjUATrtRMedNhjaMHogJBecgFSE=
 github.com/prometheus-community/windows_exporter v0.31.3/go.mod h1:tlw5aYgPu1kFassCBSBwnDBFHUlwznekAVJ0xiDuIko=
-github.com/prometheus-community/yet-another-cloudwatch-exporter v0.64.0 h1:1jz6+dRL2jjMTuIbyd8cJa522kMQbu75/wt9VXJIaWQ=
-github.com/prometheus-community/yet-another-cloudwatch-exporter v0.64.0/go.mod h1:gsTwbxTbhpPpcurDJZP4JNzAUaxSUBnAsB4KOhMEbCE=
 github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.91.0 h1:m2SZ2z5edgk0nXx7W6VHLfIsKZwgKbr+E5c2RNYyJB8=
 github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.91.0/go.mod h1:Gfzi4500QCMnptFIQc8YdDi8YZ4QA0vs22LROWZ3+YU=
 github.com/prometheus-operator/prometheus-operator/pkg/client v0.91.0 h1:WnKN4vTCEkqh4fVQ4q8XWJTXGUS3IPeEgLANVNWy4fk=

--- a/go.mod
+++ b/go.mod
@@ -1171,6 +1171,9 @@ replace github.com/prometheus/mysqld_exporter => github.com/grafana/mysqld_expor
 // TODO: replace node_exporter with custom fork for multi usage. https://github.com/prometheus/node_exporter/pull/2812 (auto-synced from collector/builder-config.yaml)
 replace github.com/prometheus/node_exporter => github.com/grafana/node_exporter v0.18.1-grafana-r01.0.20251024135609-318b01780c89
 
+// TODO - tracks kgeckhart/yet-another-cloudwatch-exporter fix-name-validation-global; stops YACE mutating the process-global metric-name validation scheme. Remove once merged upstream. (auto-synced from collector/builder-config.yaml)
+replace github.com/prometheus-community/yet-another-cloudwatch-exporter => github.com/kgeckhart/yet-another-cloudwatch-exporter v0.64.1-0.20260629154816-440211eac126
+
 // Use Grafana fork of smimesign (auto-synced from collector/builder-config.yaml)
 replace github.com/github/smimesign => github.com/grafana/smimesign v0.2.1-0.20220408144937-2a5adf3481d3
 

--- a/go.sum
+++ b/go.sum
@@ -1582,6 +1582,8 @@ github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRt
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/kgeckhart/prometheus-operator v0.90.2-0.20260511184813-5b1d6bf02253 h1:07JX4vP+dfMyNxuJxWMOthUKVfKE/JhwMEz7wP4k7AI=
 github.com/kgeckhart/prometheus-operator v0.90.2-0.20260511184813-5b1d6bf02253/go.mod h1:z+KVSl/9Oh8y0mvQwpIc5HnrNLUqPl6qEiq9pHwfQaU=
+github.com/kgeckhart/yet-another-cloudwatch-exporter v0.64.1-0.20260629154816-440211eac126 h1:2zGI/FxipO2lZzr2rc01KloYc+i6sZfT1qrvHAO7pjg=
+github.com/kgeckhart/yet-another-cloudwatch-exporter v0.64.1-0.20260629154816-440211eac126/go.mod h1:gsTwbxTbhpPpcurDJZP4JNzAUaxSUBnAsB4KOhMEbCE=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -2168,8 +2170,6 @@ github.com/prometheus-community/stackdriver_exporter v0.18.0 h1:nB7JwloiBziunauj
 github.com/prometheus-community/stackdriver_exporter v0.18.0/go.mod h1:f7T7XXRVc390sVc7rk2yNflf+RkClE4mlfsaSsW2K5Q=
 github.com/prometheus-community/windows_exporter v0.31.3 h1:v5HRhiSL/AgFtp96GjUATrtRMedNhjaMHogJBecgFSE=
 github.com/prometheus-community/windows_exporter v0.31.3/go.mod h1:tlw5aYgPu1kFassCBSBwnDBFHUlwznekAVJ0xiDuIko=
-github.com/prometheus-community/yet-another-cloudwatch-exporter v0.64.0 h1:1jz6+dRL2jjMTuIbyd8cJa522kMQbu75/wt9VXJIaWQ=
-github.com/prometheus-community/yet-another-cloudwatch-exporter v0.64.0/go.mod h1:gsTwbxTbhpPpcurDJZP4JNzAUaxSUBnAsB4KOhMEbCE=
 github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.91.0 h1:m2SZ2z5edgk0nXx7W6VHLfIsKZwgKbr+E5c2RNYyJB8=
 github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.91.0/go.mod h1:Gfzi4500QCMnptFIQc8YdDi8YZ4QA0vs22LROWZ3+YU=
 github.com/prometheus-operator/prometheus-operator/pkg/client v0.91.0 h1:WnKN4vTCEkqh4fVQ4q8XWJTXGUS3IPeEgLANVNWy4fk=


### PR DESCRIPTION
### Brief description of Pull Request

Points `prometheus.exporter.cloudwatch` at a fork of `yet-another-cloudwatch-exporter` that no longer mutates the process-global `model.NameValidationScheme` [v0.64.0...fix-name-validation-global](https://github.com/kgeckhart/yet-another-cloudwatch-exporter/compare/v0.64.0...kgeckhart/fix-name-validation-global). Mutating the global field causes validations for self metrics to fail when OTel components are used as their metrics include periods.

### Pull Request Details

This PR is a short term fix to support a quick patch. Upstreaming the fix does not look hard but upstream itself has gone through some large refactoring (and likely introduced new features) which would be more suitable for a minor release. 

I used a personal fork for now because it's short term and the grafana fork has been archived + moved to cold storage. It didn't seem worth it to undo that for this short term fix. 

### Issue(s) fixed by this Pull Request

Resolves #6590 and #6503 