### PR TITLE
chore: Add integration tests for User Agent

### DIFF
--- a/collector/generator/main_alloy.tpl
+++ b/collector/generator/main_alloy.tpl
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/grafana/alloy/flowcmd"
+	"github.com/grafana/alloy/internal/useragent"
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/collector/otelcol"
 )
@@ -9,7 +10,7 @@ import (
 func newAlloyCommand(params otelcol.CollectorSettings) *cobra.Command {
     otelCmd := otelcol.NewCommand(params)
 
-    otelCmd.Use = "otel"
+    otelCmd.Use = useragent.EngineOTel
     otelCmd.Short = "Use Alloy with OTel Engine"
     otelCmd.Long = "[EXPERIMENTAL] Use Alloy with OpenTelemetry Collector Engine"
 

--- a/collector/main_alloy.go
+++ b/collector/main_alloy.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"github.com/grafana/alloy/flowcmd"
+	"github.com/grafana/alloy/internal/useragent"
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/collector/otelcol"
 )
@@ -11,7 +12,7 @@ import (
 func newAlloyCommand(params otelcol.CollectorSettings) *cobra.Command {
     otelCmd := otelcol.NewCommand(params)
 
-    otelCmd.Use = "otel"
+    otelCmd.Use = useragent.EngineOTel
     otelCmd.Short = "Use Alloy with OTel Engine"
     otelCmd.Long = "[EXPERIMENTAL] Use Alloy with OpenTelemetry Collector Engine"
 

--- a/integration-tests/k8s/deps/alloy_otel.go
+++ b/integration-tests/k8s/deps/alloy_otel.go
@@ -1,0 +1,119 @@
+package deps
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/grafana/alloy/integration-tests/k8s/harness"
+	"github.com/grafana/alloy/integration-tests/k8s/util"
+)
+
+const (
+	// Must match manifests/alloy-otel.yaml.
+	alloyOtelSelector  = "app=alloy-otel"
+	alloyOtelConfigMap = "alloy-otel-config"
+	// alloyImagePlaceholder is replaced with the image under test at install time.
+	alloyImagePlaceholder = "__ALLOY_IMAGE__"
+)
+
+//go:embed manifests/alloy-otel.yaml
+var alloyOtelManifest string
+
+// Compile-time check that *AlloyOtel satisfies the harness.Dependency interface.
+var _ harness.Dependency = (*AlloyOtel)(nil)
+
+// AlloyOtel deploys Alloy running the OTel engine (`alloy otel`) via a raw
+// manifest, with the alloyengine extension running an inner Alloy config. The
+// Helm chart can't run `alloy otel` (its args hardcode `run`), hence the raw
+// Deployment. CollectorConfigPath is the collector YAML; AlloyConfigPath is the
+// inner .alloy config the alloyengine extension runs.
+type AlloyOtel struct {
+	opts      AlloyOtelOptions
+	installed bool
+}
+
+type AlloyOtelOptions struct {
+	Namespace           string
+	CollectorConfigPath string
+	AlloyConfigPath     string
+}
+
+func NewAlloyOtel(opts AlloyOtelOptions) *AlloyOtel {
+	return &AlloyOtel{opts: opts}
+}
+
+func (a *AlloyOtel) Name() string { return "alloy-otel" }
+
+func (a *AlloyOtel) Install(ctx *harness.TestContext) error {
+	if a.opts.Namespace == "" {
+		return fmt.Errorf("alloy-otel namespace is required")
+	}
+	image := os.Getenv(harness.AlloyImageEnv)
+	if image == "" {
+		return fmt.Errorf("%s must be set (the test runner sets this)", harness.AlloyImageEnv)
+	}
+
+	if err := util.Step("create alloy-otel configmap", func() error {
+		return a.createConfigMap()
+	}); err != nil {
+		return err
+	}
+	a.installed = true
+
+	manifest := strings.ReplaceAll(alloyOtelManifest, alloyImagePlaceholder, image)
+	if err := util.Step("apply alloy-otel manifest", func() error {
+		return harness.ApplyManifest(a.opts.Namespace, manifest)
+	}); err != nil {
+		return err
+	}
+
+	if err := util.Step("wait for alloy-otel pod ready", func() error {
+		return harness.WaitForReady(a.opts.Namespace, alloyOtelSelector)
+	}); err != nil {
+		return err
+	}
+
+	ctx.AddDiagnosticHook("alloy-otel logs", func(c context.Context) error {
+		return harness.RunDiagnosticCommands(c, [][]string{
+			{"kubectl", "--namespace", a.opts.Namespace, "logs", "-l", alloyOtelSelector, "--all-containers=true", "--tail", "200"},
+		})
+	})
+	return nil
+}
+
+func (a *AlloyOtel) Cleanup() {
+	if !a.installed || a.opts.Namespace == "" {
+		return
+	}
+	manifest := strings.ReplaceAll(alloyOtelManifest, alloyImagePlaceholder, os.Getenv(harness.AlloyImageEnv))
+	_ = harness.DeleteManifest(a.opts.Namespace, manifest)
+	_ = harness.RunCommand("kubectl", "delete", "configmap", alloyOtelConfigMap,
+		"--namespace", a.opts.Namespace,
+		"--ignore-not-found=true",
+	)
+}
+
+// createConfigMap creates the "alloy-otel-config" ConfigMap with keys
+// collector.yaml and config.alloy sourced from the given paths.
+func (a *AlloyOtel) createConfigMap() error {
+	collectorAbs, err := filepath.Abs(a.opts.CollectorConfigPath)
+	if err != nil {
+		return fmt.Errorf("resolve collector config path: %w", err)
+	}
+	alloyAbs, err := filepath.Abs(a.opts.AlloyConfigPath)
+	if err != nil {
+		return fmt.Errorf("resolve alloy config path: %w", err)
+	}
+	if err := harness.RunCommand("kubectl", "create", "configmap", alloyOtelConfigMap,
+		"--namespace", a.opts.Namespace,
+		"--from-file=collector.yaml="+collectorAbs,
+		"--from-file=config.alloy="+alloyAbs,
+	); err != nil {
+		return fmt.Errorf("create alloy-otel configmap: %w", err)
+	}
+	return nil
+}

--- a/integration-tests/k8s/deps/manifests/alloy-otel.yaml
+++ b/integration-tests/k8s/deps/manifests/alloy-otel.yaml
@@ -1,0 +1,46 @@
+---
+# Alloy running the OTel engine (`alloy otel`) with the alloyengine extension.
+# The extension runs an inner Alloy config (mounted as config.alloy) whose
+# prometheus.remote_write carries the "Alloy OTel Extension" User-Agent. The image
+# ENTRYPOINT is /bin/alloy, so args run `alloy otel --config=...`. __ALLOY_IMAGE__
+# is substituted by the AlloyOtel dependency at install time.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alloy-otel
+  labels:
+    app: alloy-otel
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alloy-otel
+  template:
+    metadata:
+      labels:
+        app: alloy-otel
+    spec:
+      containers:
+        - name: alloy
+          image: __ALLOY_IMAGE__
+          imagePullPolicy: Never
+          args:
+            - otel
+            - --config=/etc/alloy/collector.yaml
+          ports:
+            - name: health
+              containerPort: 13133
+          readinessProbe:
+            tcpSocket:
+              port: 13133
+            initialDelaySeconds: 2
+            periodSeconds: 3
+            timeoutSeconds: 3
+            failureThreshold: 30
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alloy
+      volumes:
+        - name: config
+          configMap:
+            name: alloy-otel-config

--- a/integration-tests/k8s/deps/manifests/nginx-proxy.yaml
+++ b/integration-tests/k8s/deps/manifests/nginx-proxy.yaml
@@ -1,0 +1,92 @@
+---
+# nginx reverse proxy in front of Mimir's push path. It logs the User-Agent of
+# every /api/v1/push request as a JSON line on stdout (readable via
+# `kubectl logs`) and transparently forwards the request to Mimir. This lets a
+# test assert which User-Agent Alloy sends while still exercising the real
+# remote_write path end to end.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-proxy-config
+  labels:
+    app: nginx-proxy
+data:
+  nginx.conf: |
+    worker_processes 1;
+    events { worker_connections 1024; }
+    http {
+      # escape=json makes each access log line valid JSON, so the test can
+      # parse it without regex.
+      log_format push_clients escape=json
+        '{"time":"$time_iso8601","user_agent":"$http_user_agent","status":$status}';
+
+      server {
+        listen 8080;
+
+        # The Prometheus remote_write path: log the User-Agent, then forward to
+        # Mimir. The literal upstream resolves at startup via the pod's kube-dns;
+        # Mimir is installed before this proxy, so the Service already exists.
+        location = /api/v1/push {
+          access_log /dev/stdout push_clients;
+          proxy_pass http://mimir:9009/api/v1/push;
+        }
+
+        # The OTLP metrics path: same logging, used by native otelcol exporters.
+        location = /otlp/v1/metrics {
+          access_log /dev/stdout push_clients;
+          proxy_pass http://mimir:9009/otlp/v1/metrics;
+        }
+
+        # Everything else proxied normally, without per-request logging.
+        location / {
+          access_log off;
+          proxy_pass http://mimir:9009;
+        }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-proxy
+  labels:
+    app: nginx-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx-proxy
+  template:
+    metadata:
+      labels:
+        app: nginx-proxy
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.27-alpine
+          imagePullPolicy: Never
+          ports:
+            - name: http
+              containerPort: 8080
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+      volumes:
+        - name: config
+          configMap:
+            name: nginx-proxy-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-proxy
+  labels:
+    app: nginx-proxy
+spec:
+  selector:
+    app: nginx-proxy
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/integration-tests/k8s/deps/nginx_proxy.go
+++ b/integration-tests/k8s/deps/nginx_proxy.go
@@ -1,0 +1,114 @@
+package deps
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/grafana/alloy/integration-tests/k8s/harness"
+	"github.com/grafana/alloy/integration-tests/k8s/util"
+)
+
+const (
+	// All must match manifests/nginx-proxy.yaml.
+	nginxSelector = "app=nginx-proxy"
+	nginxName     = "nginx-proxy"
+	nginxImage    = "nginx:1.27-alpine"
+)
+
+//go:embed manifests/nginx-proxy.yaml
+var nginxProxyManifest string
+
+// Compile-time check that *NginxProxy satisfies the harness.Dependency interface.
+var _ harness.Dependency = (*NginxProxy)(nil)
+
+// NginxProxy runs an nginx reverse proxy in front of Mimir's push path. It logs
+// the User-Agent of every /api/v1/push request as JSON on stdout and forwards
+// the request to http://mimir:9009. In-cluster URL: http://nginx-proxy:8080.
+// Install it after Mimir so the upstream Service exists when nginx starts.
+type NginxProxy struct {
+	opts      NginxProxyOptions
+	namespace string
+	installed bool
+}
+
+type NginxProxyOptions struct {
+	Namespace string
+}
+
+func NewNginxProxy(opts NginxProxyOptions) *NginxProxy {
+	return &NginxProxy{opts: opts, namespace: opts.Namespace}
+}
+
+func (n *NginxProxy) Name() string { return nginxName }
+
+func (n *NginxProxy) Install(ctx *harness.TestContext) error {
+	if n.namespace == "" {
+		return fmt.Errorf("nginx-proxy namespace is required")
+	}
+
+	if err := ensureKindImage(nginxImage); err != nil {
+		return fmt.Errorf("failed to load nginx image: %w", err)
+	}
+
+	if err := util.Step("apply nginx-proxy manifest", func() error {
+		return harness.ApplyManifest(n.namespace, nginxProxyManifest)
+	}); err != nil {
+		return err
+	}
+	n.installed = true
+
+	if err := util.Step("wait for nginx-proxy pod ready", func() error {
+		return harness.WaitForReady(n.namespace, nginxSelector)
+	}); err != nil {
+		return err
+	}
+
+	ctx.AddDiagnosticHook("nginx-proxy logs", func(c context.Context) error {
+		return harness.RunDiagnosticCommands(c, [][]string{
+			{"kubectl", "--namespace", n.namespace, "logs", "-l", nginxSelector, "--all-containers=true", "--tail", "200"},
+		})
+	})
+	return nil
+}
+
+func (n *NginxProxy) Cleanup() {
+	if !n.installed || n.namespace == "" {
+		return
+	}
+	_ = harness.DeleteManifest(n.namespace, nginxProxyManifest)
+}
+
+// pushLogLine matches the escape=json access log format in
+// manifests/nginx-proxy.yaml.
+type pushLogLine struct {
+	UserAgent string `json:"user_agent"`
+}
+
+// PushUserAgents reads the proxy's stdout and returns the User-Agent of every
+// logged /api/v1/push request, in order. Non-JSON lines (e.g. nginx error_log
+// output) are skipped.
+func (n *NginxProxy) PushUserAgents() ([]string, error) {
+	out, err := harness.RunCommandOutput("kubectl", "--namespace", n.namespace, "logs", "deploy/"+nginxName, "--tail=-1")
+	if err != nil {
+		return nil, err
+	}
+
+	var userAgents []string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var entry pushLogLine
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		if entry.UserAgent != "" {
+			userAgents = append(userAgents, entry.UserAgent)
+		}
+	}
+	return userAgents, nil
+}

--- a/integration-tests/k8s/deps/useragent.go
+++ b/integration-tests/k8s/deps/useragent.go
@@ -1,0 +1,36 @@
+package deps
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// AssertUserAgentPrefix polls the nginx proxy until it has logged a request whose
+// User-Agent starts with want.
+//
+// It checks for a match among all logged User-Agents (not just the latest), since a
+// single Alloy process emits several distinct User-Agents. For example, OTel-native
+// components in the OTel engine report a different product name than components in
+// the alloyengine extension.
+//
+// TODO: one day match the full User-Agent string (product name, version, and the
+// "(os; deploymode)" metadata) instead of just the prefix. That needs the test to
+// know the exact build version of the reused image, which it does not today.
+func AssertUserAgentPrefix(t *testing.T, n *NginxProxy, want string) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		userAgents, err := n.PushUserAgents()
+		require.NoError(c, err)
+		require.NotEmpty(c, userAgents, "nginx proxy logged no requests yet")
+		for _, ua := range userAgents {
+			if strings.HasPrefix(ua, want) {
+				return
+			}
+		}
+		require.Failf(c, "no matching User-Agent", "wanted a User-Agent with prefix %q; logged: %v", want, userAgents)
+	}, time.Minute, time.Second)
+}

--- a/integration-tests/k8s/harness/cmd.go
+++ b/integration-tests/k8s/harness/cmd.go
@@ -20,6 +20,21 @@ func RunCommand(name string, args ...string) error {
 	return cmd.Run()
 }
 
+// RunCommandOutput runs name with args and returns its stdout. stderr is folded
+// into the returned error so the caller gets clean stdout to parse (e.g.
+// `kubectl logs ...`). CommandEnv pins KUBECONFIG.
+func RunCommandOutput(name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Env = CommandEnv()
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return stdout.String(), fmt.Errorf("%s %v failed: %w: %s", name, args, err, stderr.String())
+	}
+	return stdout.String(), nil
+}
+
 // RunCommandQuiet is RunCommand with stdout/stderr discarded; use it when
 // only the exit code matters (e.g. `docker image inspect`).
 func RunCommandQuiet(name string, args ...string) error {

--- a/integration-tests/k8s/tests/metamonitor-alloy/config/alloy-values.yaml
+++ b/integration-tests/k8s/tests/metamonitor-alloy/config/alloy-values.yaml
@@ -1,0 +1,4 @@
+controller:
+  type: deployment
+alloy:
+  stabilityLevel: experimental

--- a/integration-tests/k8s/tests/metamonitor-alloy/config/config.alloy
+++ b/integration-tests/k8s/tests/metamonitor-alloy/config/config.alloy
@@ -1,0 +1,21 @@
+logging {
+  level = "debug"
+}
+
+prometheus.exporter.self "alloy" {}
+
+prometheus.scrape "alloy" {
+  targets         = prometheus.exporter.self.alloy.targets
+  forward_to      = [prometheus.remote_write.mimir.receiver]
+  scrape_interval = "1s"
+  scrape_timeout  = "500ms"
+}
+
+prometheus.remote_write "mimir" {
+  endpoint {
+    url = "http://nginx-proxy:8080/api/v1/push"
+  }
+  external_labels = {
+    alloy_test_name = "metamonitor-alloy",
+  }
+}

--- a/integration-tests/k8s/tests/metamonitor-alloy/k8s_test.go
+++ b/integration-tests/k8s/tests/metamonitor-alloy/k8s_test.go
@@ -1,0 +1,37 @@
+package metamonitoralloy
+
+import (
+	"testing"
+
+	"github.com/grafana/alloy/integration-tests/k8s/deps"
+	"github.com/grafana/alloy/integration-tests/k8s/harness"
+)
+
+// TestMetamonitorAlloy deploys Alloy with the default engine (`alloy run`, via the
+// Helm chart) and checks the product name in its outbound User-Agent.
+func TestMetamonitorAlloy(t *testing.T) {
+	ns := deps.NewNamespace(deps.NamespaceOptions{
+		Name:   "test-metamonitor-alloy",
+		Labels: map[string]string{"alloy-integration-test": "true"},
+	})
+	mimir := deps.NewMimir(deps.MimirOptions{Namespace: ns.Name()})
+	nginx := deps.NewNginxProxy(deps.NginxProxyOptions{Namespace: ns.Name()})
+	alloy := deps.NewAlloy(deps.AlloyOptions{
+		Namespace:  ns.Name(),
+		Release:    "alloy-test-metamonitor-alloy",
+		ConfigPath: "./config/config.alloy",
+		ValuesPath: "./config/alloy-values.yaml",
+	})
+
+	// nginx after mimir so the upstream Service exists when nginx starts; alloy
+	// last so it pushes once everything downstream is ready.
+	harness.Setup(t, harness.Options{
+		Dependencies: []harness.Dependency{ns, mimir, nginx, alloy},
+	})
+
+	t.Run("RemoteWriteUserAgent", func(t *testing.T) {
+		deps.AssertUserAgentPrefix(t, nginx, "Alloy/")
+	})
+}
+
+//TODO: Add more checks. We should get enough metrics so that Alloy Health dashboards can populate?

--- a/integration-tests/k8s/tests/metamonitor-otel/config/collector.yaml
+++ b/integration-tests/k8s/tests/metamonitor-otel/config/collector.yaml
@@ -1,0 +1,30 @@
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+  alloyengine:
+    config:
+      path: /etc/alloy/config.alloy
+    flags:
+      stability.level: experimental
+      storage.path: /tmp/alloy # writable WAL dir for the inner remote_write
+
+# A native collector pipeline (NOT via the alloyengine extension) so the test can
+# also capture a native otelcol exporter's User-Agent ("Alloy OTel Collector distribution.").
+receivers:
+  hostmetrics:
+    collection_interval: 5s
+    scrapers:
+      load: {}
+
+exporters:
+  otlphttp:
+    metrics_endpoint: http://nginx-proxy:8080/otlp/v1/metrics
+    tls:
+      insecure: true
+
+service:
+  extensions: [health_check, alloyengine]
+  pipelines:
+    metrics:
+      receivers: [hostmetrics]
+      exporters: [otlphttp]

--- a/integration-tests/k8s/tests/metamonitor-otel/config/config.alloy
+++ b/integration-tests/k8s/tests/metamonitor-otel/config/config.alloy
@@ -1,0 +1,23 @@
+// Runs inside the alloyengine extension.
+
+logging {
+  level = "debug"
+}
+
+prometheus.exporter.self "alloy" {}
+
+prometheus.scrape "alloy" {
+  targets         = prometheus.exporter.self.alloy.targets
+  forward_to      = [prometheus.remote_write.mimir.receiver]
+  scrape_interval = "1s"
+  scrape_timeout  = "500ms"
+}
+
+prometheus.remote_write "mimir" {
+  endpoint {
+    url = "http://nginx-proxy:8080/api/v1/push"
+  }
+  external_labels = {
+    alloy_test_name = "metamonitor-otel",
+  }
+}

--- a/integration-tests/k8s/tests/metamonitor-otel/k8s_test.go
+++ b/integration-tests/k8s/tests/metamonitor-otel/k8s_test.go
@@ -1,0 +1,39 @@
+package metamonitorotel
+
+import (
+	"testing"
+
+	"github.com/grafana/alloy/integration-tests/k8s/deps"
+	"github.com/grafana/alloy/integration-tests/k8s/harness"
+)
+
+// TestMetamonitorOtel runs Alloy with the OTel engine (`alloy otel`), which runs the
+// inner Alloy config via the alloyengine extension, and checks the product name
+// in its outbound User-Agent.
+func TestMetamonitorOtel(t *testing.T) {
+	ns := deps.NewNamespace(deps.NamespaceOptions{
+		Name:   "test-metamonitor-otel",
+		Labels: map[string]string{"alloy-integration-test": "true"},
+	})
+	mimir := deps.NewMimir(deps.MimirOptions{Namespace: ns.Name()})
+	nginx := deps.NewNginxProxy(deps.NginxProxyOptions{Namespace: ns.Name()})
+	alloyOtel := deps.NewAlloyOtel(deps.AlloyOtelOptions{
+		Namespace:           ns.Name(),
+		CollectorConfigPath: "./config/collector.yaml",
+		AlloyConfigPath:     "./config/config.alloy",
+	})
+
+	// nginx after mimir so the upstream Service exists when nginx starts; alloy
+	// last so it pushes once everything downstream is ready.
+	harness.Setup(t, harness.Options{
+		Dependencies: []harness.Dependency{ns, mimir, nginx, alloyOtel},
+	})
+
+	t.Run("ExtensionUserAgent", func(t *testing.T) {
+		deps.AssertUserAgentPrefix(t, nginx, "Alloy OTel Extension/")
+	})
+
+	t.Run("NativeOtelExporterUserAgent", func(t *testing.T) {
+		deps.AssertUserAgentPrefix(t, nginx, "Alloy OTel Collector distribution./")
+	})
+}

--- a/internal/component/otelcol/util/telemetry_settings.go
+++ b/internal/component/otelcol/util/telemetry_settings.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"github.com/grafana/alloy/internal/build"
+	"github.com/grafana/alloy/internal/useragent"
 	otelcomponent "go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/service/telemetry"
@@ -32,9 +33,17 @@ func GetTelemetrySettingsResource() (pcommon.Resource, error) {
 }
 
 func GetBuildInfo() otelcomponent.BuildInfo {
+	// otelcol exporters derive their User-Agent from BuildInfo.
+	// Under the OTel engine these components run via the alloyengine extension.
+	// Mentioning "extension" in User-Agent helps us distinguish whether the
+	// otelcol components run in OTel Engine or in Alloy Engine.
+	description := useragent.ProductName
+	if useragent.GetEngineMode() == useragent.EngineOTel {
+		description = useragent.ExtensionProductName
+	}
 	return otelcomponent.BuildInfo{
 		Command:     os.Args[0],
-		Description: "Grafana Alloy",
+		Description: description,
 		Version:     build.Version,
 	}
 }

--- a/internal/useragent/useragent.go
+++ b/internal/useragent/useragent.go
@@ -15,13 +15,20 @@ import (
 
 const (
 	ProductName = "Alloy"
+	// ExtensionProductName is the product name reported when Alloy runs as an OTel
+	// Collector extension (the OTel engine), distinguishing it from native Alloy.
+	ExtensionProductName = ProductName + " OTel Extension"
 
 	deployModeEnv = "ALLOY_DEPLOY_MODE"
+
+	EngineOTel    = "otel"
+	EngineDefault = "default"
 )
 
 // settable by tests
 var goos = runtime.GOOS
 var executable = os.Executable
+var args = os.Args
 
 func Get() string {
 	parenthesis := ""
@@ -33,7 +40,31 @@ func Get() string {
 	if len(metadata) > 0 {
 		parenthesis = fmt.Sprintf(" (%s)", strings.Join(metadata, "; "))
 	}
-	return fmt.Sprintf("%s/%s%s", ProductName, build.Version, parenthesis)
+	// The product name distinguishes the engine: native Alloy vs Alloy running as
+	// an OTel Collector extension.
+	product := ProductName
+	if GetEngineMode() == EngineOTel {
+		product = ExtensionProductName
+	}
+	return fmt.Sprintf("%s/%s%s", product, build.Version, parenthesis)
+}
+
+// GetEngineMode returns which engine Alloy is running with.
+func GetEngineMode() string {
+	// Find the first positional argument (the subcommand). Skip flags and any
+	// flag values that may precede it.
+	for _, a := range args[1:] {
+		if strings.HasPrefix(a, "-") {
+			continue
+		}
+		if a == EngineOTel {
+			return EngineOTel
+		}
+		// The first positional argument is the subcommand; if it isn't "otel"
+		// we are not running the OTel engine.
+		break
+	}
+	return EngineDefault
 }
 
 // GetDeployMode returns our best-effort guess at the way Grafana Alloy was deployed.

--- a/internal/useragent/useragent.go
+++ b/internal/useragent/useragent.go
@@ -16,7 +16,7 @@ import (
 const (
 	ProductName = "Alloy"
 	// ExtensionProductName is the product name reported when Alloy runs as an OTel
-	// Collector extension (the OTel engine), distinguishing it from native Alloy.
+	// Collector extension, distinguishing it from native Alloy.
 	ExtensionProductName = ProductName + " OTel Extension"
 
 	deployModeEnv = "ALLOY_DEPLOY_MODE"

--- a/internal/useragent/useragent_test.go
+++ b/internal/useragent/useragent_test.go
@@ -9,57 +9,98 @@ import (
 
 func TestUserAgent(t *testing.T) {
 	build.Version = "v1.2.3"
+	runArgs := []string{"alloy", "run", "config.alloy"}
 	tests := []struct {
 		Name       string
 		Expected   string
 		DeployMode string
 		GOOS       string
 		Exe        string
+		Args       []string
 	}{
 		{
 			Name:     "linux",
+			Args:     runArgs,
 			Expected: "Alloy/v1.2.3 (linux; binary)",
 			GOOS:     "linux",
 		},
 		{
 			Name:     "windows",
+			Args:     runArgs,
 			Expected: "Alloy/v1.2.3 (windows; binary)",
 			GOOS:     "windows",
 		},
 		{
 			Name:     "darwin",
+			Args:     runArgs,
 			Expected: "Alloy/v1.2.3 (darwin; binary)",
 			GOOS:     "darwin",
 		},
 		{
 			Name:       "deb",
+			Args:       runArgs,
 			DeployMode: "deb",
 			Expected:   "Alloy/v1.2.3 (linux; deb)",
 			GOOS:       "linux",
 		},
 		{
 			Name:       "rpm",
+			Args:       runArgs,
 			DeployMode: "rpm",
 			Expected:   "Alloy/v1.2.3 (linux; rpm)",
 			GOOS:       "linux",
 		},
 		{
 			Name:       "docker",
+			Args:       runArgs,
 			DeployMode: "docker",
 			Expected:   "Alloy/v1.2.3 (linux; docker)",
 			GOOS:       "linux",
 		},
 		{
 			Name:       "helm",
+			Args:       runArgs,
 			DeployMode: "helm",
 			Expected:   "Alloy/v1.2.3 (linux; helm)",
 			GOOS:       "linux",
 		},
 		{
 			Name:     "brew",
+			Args:     runArgs,
 			Expected: "Alloy/v1.2.3 (darwin; brew)",
 			GOOS:     "darwin",
 			Exe:      "/opt/homebrew/bin/alloy",
+		},
+		{
+			Name:       "otel engine",
+			Args:       []string{"alloy", "otel"},
+			DeployMode: "docker",
+			Expected:   "Alloy OTel Extension/v1.2.3 (linux; docker)",
+			GOOS:       "linux",
+		},
+		{
+			Name:     "otel engine with flags",
+			Args:     []string{"alloy", "otel", "--config", "config.yaml"},
+			Expected: "Alloy OTel Extension/v1.2.3 (linux; binary)",
+			GOOS:     "linux",
+		},
+		{
+			Name:     "no subcommand",
+			Args:     []string{"alloy"},
+			Expected: "Alloy/v1.2.3 (linux; binary)",
+			GOOS:     "linux",
+		},
+		{
+			Name:     "convert subcommand",
+			Args:     []string{"alloy", "convert", "config.river"},
+			Expected: "Alloy/v1.2.3 (linux; binary)",
+			GOOS:     "linux",
+		},
+		{
+			Name:     "run flag value that looks like otel",
+			Args:     []string{"alloy", "run", "--config.format", "otel"},
+			Expected: "Alloy/v1.2.3 (linux; binary)",
+			GOOS:     "linux",
 		},
 	}
 	for _, tst := range tests {
@@ -70,6 +111,7 @@ func TestUserAgent(t *testing.T) {
 				executable = func() (string, error) { return "/alloy", nil }
 			}
 			goos = tst.GOOS
+			args = tst.Args
 			t.Setenv(deployModeEnv, tst.DeployMode)
 			actual := Get()
 			require.Equal(t, tst.Expected, actual)


### PR DESCRIPTION
This PR will change the User-Agent header of the Alloy OTel Extension to start with "Alloy OTel Extension" as opposed to just "Alloy". That way it can be distinguished when we gather statistics about user agents.

It will also add tests to make sure that the User Agents are what they should be. For example:
* Default engine: `Alloy/v1.18.0 (linux; helm)`
* OTel Extension: `Alloy OTel Extension/v1.18.0 (linux; docker)`
* OTel Engine native components: `Alloy OTel Collector distribution./v1.18.0 (linux/amd64)`