### PR TITLE
docs(agents): Clarify cold-cache lint timeout gotcha

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,6 @@ Run:
 - `~/go/bin` must be on PATH (`export PATH="$PATH:$(go env GOPATH)/bin"`). The VM update script handles this, but ad-hoc shells need it explicitly.
 - `CGO_ENABLED=1` is the default. `libsystemd-dev` is required on Linux for the build to link.
 - Docker daemon is not started automatically. Before running tests without the `nodocker` tag: `sudo dockerd &` then `sudo chmod 666 /var/run/docker.sock`. Uses `fuse-overlayfs` storage driver (nested Firecracker VM).
-- First `make lint` on a cold cache takes ~10 min (module download + analysis). Cached runs ~30s.
+- First `make lint` on a cold cache takes ~10 min (module download + analysis) and can even fail: the lint wrapper runs `golangci-lint run --timeout=10m` per module, and the large `collector` module can exceed that timeout (exits status 4) on a cold build cache. Warm the cache first (e.g. `SKIP_UI_BUILD=1 make alloy` or run any test) and re-run; cached runs finish in ~30s with `0 issues`.
 - `SKIP_UI_BUILD=1` saves ~90s when not touching UI code. The UI must be built at least once for the embedded web server at `:12345` to serve pages.
 - `.nvmrc` says Node 24.x; Node 22.x (pre-installed) works for builds. Only matters for exact CI parity on UI lint.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

While setting up the development environment for Grafana Alloy in a fresh Cursor Cloud VM, I hit a non-obvious gotcha: the very first `make lint` on a cold build cache can **fail** (not just be slow). The lint wrapper runs `golangci-lint run --timeout=10m` per Go module, and the large `collector` module exceeds that 10-minute timeout on a cold cache, exiting with status 4.

This PR refines the existing `## Cursor Cloud specific instructions` note in `AGENTS.md` to document the failure mode and the remedy (warm the build cache first, then re-run lint — cached runs finish in ~30s with `0 issues`).

## Environment verification

Everything below was verified end-to-end in the VM:

- `mise install` provisions the toolchain pinned in `mise.toml` (Go 1.26.4, task, golangci-lint, node 24, shellcheck, helm, etc.).
- `libsystemd-dev` is required for the CGO build (already noted in AGENTS.md).
- ✅ Build: `make alloy` (incl. UI) produced `build/alloy` (`v1.17.0-devel`).
- ✅ Lint: `make lint` → `0 issues` (after warming cache).
- ✅ Test: `go test -race -tags="nodocker gore2regex" ./internal/component/discovery/` → `ok`.
- ✅ Run: `./build/alloy run` a self-contained pipeline (`prometheus.exporter.self` → `prometheus.scrape` → `prometheus.relabel`); UI healthy at `:12345`, metrics flowed through the relabel stage.

[alloy_ui_pipeline_demo.mp4](https://cursor.com/agents/bc-90f86680-9c3e-4a58-8c72-8b6e51d5d388/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Falloy_ui_pipeline_demo.mp4)

[Alloy components list, all healthy](https://cursor.com/agents/bc-90f86680-9c3e-4a58-8c72-8b6e51d5d388/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Falloy_components_healthy.webp)
[Alloy pipeline graph with connected nodes](https://cursor.com/agents/bc-90f86680-9c3e-4a58-8c72-8b6e51d5d388/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Falloy_pipeline_graph.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90f86680-9c3e-4a58-8c72-8b6e51d5d388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90f86680-9c3e-4a58-8c72-8b6e51d5d388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

