### PR TITLE
fix(windows): Allow non-admin service account to start Alloy

### DIFF
--- a/internal/cmd/alloy-service/writer_windows.go
+++ b/internal/cmd/alloy-service/writer_windows.go
@@ -20,12 +20,26 @@ var (
 // newWriter creates a new writer which writes to the Windows Event
 // Logger.
 func newWriter() (*writer, error) {
+	// Fast path: if the event source is already registered, open it directly.
+	// eventlog.InstallAsEventCreate opens the parent EventLog\Application key
+	// with CREATE_SUB_KEY access, which requires admin. When Alloy runs under a
+	// dedicated non-admin service account, that call fails with "Access is
+	// denied" even though the source already exists, causing the process to
+	// exit before svc.Run can report back to the SCM (surfacing as service
+	// error 1053).
+	if el, err := eventlog.Open(serviceName); err == nil {
+		runtime.SetFinalizer(el, func(li *eventlog.Log) {
+			_ = li.Close()
+		})
+		return &writer{el: el}, nil
+	}
+
 	eventTypes := uint32(eventlog.Info | eventlog.Warning | eventlog.Error)
 
 	// Install the event source. This will fail with an error string saying "already
 	// exists" if it has been installed before.
-	err := eventlog.InstallAsEventCreate(serviceName, eventTypes)
-	if err != nil && !strings.Contains(err.Error(), "already exists") {
+	if err := eventlog.InstallAsEventCreate(serviceName, eventTypes); err != nil &&
+		!strings.Contains(err.Error(), "already exists") {
 		return nil, err
 	}
 

--- a/internal/cmd/alloy-service/writer_windows.go
+++ b/internal/cmd/alloy-service/writer_windows.go
@@ -17,15 +17,6 @@ var (
 )
 
 // newWriter creates a new writer which writes to the Windows Event Log.
-//
-// It uses the shared event log opener from internal/runtime/logging/eventlog,
-// which pre-checks whether the source is already registered before attempting
-// to install it. That lets a dedicated non-admin service account start the
-// service when the Alloy installer (or a prior admin run) has already
-// registered the "Alloy" event source, avoiding the CREATE_SUB_KEY access
-// requirement of eventlog.InstallAsEventCreate that would otherwise cause the
-// service to exit before svc.Run can report back to the SCM (surfacing as
-// service error 1053).
 func newWriter() (*writer, error) {
 	el, err := eventlog.GetEventLogOpener()(serviceName)
 	if err != nil {

--- a/internal/cmd/alloy-service/writer_windows.go
+++ b/internal/cmd/alloy-service/writer_windows.go
@@ -2,57 +2,35 @@ package main
 
 import (
 	"io"
-	"runtime"
 	"strings"
 
-	"golang.org/x/sys/windows/svc/eventlog"
+	"github.com/grafana/alloy/internal/runtime/logging/eventlog"
 )
 
 // writer sends writes to the Windows Event Log.
 type writer struct {
-	el *eventlog.Log
+	el eventlog.EventLog
 }
 
 var (
 	_ io.Writer = (*writer)(nil)
 )
 
-// newWriter creates a new writer which writes to the Windows Event
-// Logger.
+// newWriter creates a new writer which writes to the Windows Event Log.
+//
+// It uses the shared event log opener from internal/runtime/logging/eventlog,
+// which pre-checks whether the source is already registered before attempting
+// to install it. That lets a dedicated non-admin service account start the
+// service when the Alloy installer (or a prior admin run) has already
+// registered the "Alloy" event source, avoiding the CREATE_SUB_KEY access
+// requirement of eventlog.InstallAsEventCreate that would otherwise cause the
+// service to exit before svc.Run can report back to the SCM (surfacing as
+// service error 1053).
 func newWriter() (*writer, error) {
-	// Fast path: if the event source is already registered, open it directly.
-	// eventlog.InstallAsEventCreate opens the parent EventLog\Application key
-	// with CREATE_SUB_KEY access, which requires admin. When Alloy runs under a
-	// dedicated non-admin service account, that call fails with "Access is
-	// denied" even though the source already exists, causing the process to
-	// exit before svc.Run can report back to the SCM (surfacing as service
-	// error 1053).
-	if el, err := eventlog.Open(serviceName); err == nil {
-		runtime.SetFinalizer(el, func(li *eventlog.Log) {
-			_ = li.Close()
-		})
-		return &writer{el: el}, nil
-	}
-
-	eventTypes := uint32(eventlog.Info | eventlog.Warning | eventlog.Error)
-
-	// Install the event source. This will fail with an error string saying "already
-	// exists" if it has been installed before.
-	if err := eventlog.InstallAsEventCreate(serviceName, eventTypes); err != nil &&
-		!strings.Contains(err.Error(), "already exists") {
-		return nil, err
-	}
-
-	el, err := eventlog.Open(serviceName)
+	el, err := eventlog.GetEventLogOpener()(serviceName)
 	if err != nil {
 		return nil, err
 	}
-
-	// Ensure the logger gets closed when GC runs.
-	runtime.SetFinalizer(el, func(li *eventlog.Log) {
-		_ = li.Close()
-	})
-
 	return &writer{el: el}, nil
 }
 

--- a/packaging/windows/install_script.nsis
+++ b/packaging/windows/install_script.nsis
@@ -119,12 +119,13 @@ Section "install"
   Call CreateConfig
   Call CreateDataDirectory
   Call InitializeRegistry
+  Call RegisterEventSource
 
   ${If} $User != ""
     StrCpy $AuthFlag "obj= $\"$User$\""
     ${If} $Password != ""
       StrCpy $AuthFlag "$AuthFlag password= $\"$Password$\""
-    ${EndIf}  
+    ${EndIf}
   ${EndIf}
 
   # Create the service.
@@ -246,6 +247,20 @@ Function InitializeRegistry
   ${EndIf}
 
   Return
+FunctionEnd
+
+# RegisterEventSource pre-creates the Windows Event Log source for Alloy so
+# that a non-admin service account can open the source without needing write
+# access to HKLM\SYSTEM\CurrentControlSet\Services\EventLog\Application. Without
+# this, alloy-service.exe fails on first start under a dedicated service
+# account and the SCM reports error 1053 (timeout waiting to connect).
+Function RegisterEventSource
+  !define EVENTLOGKEY "HKLM\SYSTEM\CurrentControlSet\Services\EventLog\Application\Alloy"
+
+  nsExec::ExecToLog 'Reg.exe add "${EVENTLOGKEY}" /v EventMessageFile /t REG_EXPAND_SZ /d "%SystemRoot%\System32\EventCreate.exe" /f'
+  Pop $0
+  nsExec::ExecToLog 'Reg.exe add "${EVENTLOGKEY}" /v TypesSupported   /t REG_DWORD     /d 7 /f'
+  Pop $0
 FunctionEnd
 
 Function SetFolderPermissions

--- a/packaging/windows/install_script.nsis
+++ b/packaging/windows/install_script.nsis
@@ -17,6 +17,7 @@ Unicode true
 !define HELPURL     "https://grafana.com/docs/alloy/latest"
 !define UPDATEURL   "https://github.com/grafana/alloy/releases"
 !define ABOUTURL    "https://github.com/grafana/alloy"
+!define EVENTLOGKEY "HKLM\SYSTEM\CurrentControlSet\Services\EventLog\Application\Alloy"
 
 # Because we modify the registry and install a service that runs as
 # LocalSystem, we require admin permissions.
@@ -252,13 +253,22 @@ FunctionEnd
 # RegisterEventSource pre-creates the Windows Event Log source for Alloy so
 # that a non-admin service account can open the source without needing write
 # access to HKLM\SYSTEM\CurrentControlSet\Services\EventLog\Application.
+#
+# These values mirror what eventlog.InstallAsEventCreate writes at runtime
+# (golang.org/x/sys/windows/svc/eventlog). We only write the values when the
+# source key doesn't already exist. This matches eventlog.Install and preserves
+# customizations a user has made.
 Function RegisterEventSource
-  !define EVENTLOGKEY "HKLM\SYSTEM\CurrentControlSet\Services\EventLog\Application\Alloy"
-
-  nsExec::ExecToLog 'Reg.exe add "${EVENTLOGKEY}" /v EventMessageFile /t REG_EXPAND_SZ /d "%SystemRoot%\System32\EventCreate.exe" /f'
+  nsExec::ExecToLog 'Reg.exe query "${EVENTLOGKEY}"'
   Pop $0
-  nsExec::ExecToLog 'Reg.exe add "${EVENTLOGKEY}" /v TypesSupported   /t REG_DWORD     /d 7 /f'
-  Pop $0
+  ${If} $0 == 1
+    nsExec::ExecToLog 'Reg.exe add "${EVENTLOGKEY}" /v CustomSource     /t REG_DWORD     /d 1 /f'
+    Pop $0 # Ignore return result
+    nsExec::ExecToLog 'Reg.exe add "${EVENTLOGKEY}" /v EventMessageFile /t REG_EXPAND_SZ /d "%SystemRoot%\System32\EventCreate.exe" /f'
+    Pop $0 # Ignore return result
+    nsExec::ExecToLog 'Reg.exe add "${EVENTLOGKEY}" /v TypesSupported   /t REG_DWORD     /d 7 /f'
+    Pop $0 # Ignore return result
+  ${EndIf}
 FunctionEnd
 
 Function SetFolderPermissions
@@ -308,6 +318,8 @@ Section "uninstall"
   # service settings are stored in the 64-bit registry (so we use /reg:64),
   # while the uninstaller information is stored in the 32-bit registry.
   nsExec::ExecToLog 'Reg.exe delete "HKLM\SOFTWARE\GrafanaLabs\Alloy"  /reg:64 /f'
+  Pop $0
+  nsExec::ExecToLog 'Reg.exe delete "${EVENTLOGKEY}" /f'
   Pop $0
   DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}"
 SectionEnd

--- a/packaging/windows/install_script.nsis
+++ b/packaging/windows/install_script.nsis
@@ -251,9 +251,7 @@ FunctionEnd
 
 # RegisterEventSource pre-creates the Windows Event Log source for Alloy so
 # that a non-admin service account can open the source without needing write
-# access to HKLM\SYSTEM\CurrentControlSet\Services\EventLog\Application. Without
-# this, alloy-service.exe fails on first start under a dedicated service
-# account and the SCM reports error 1053 (timeout waiting to connect).
+# access to HKLM\SYSTEM\CurrentControlSet\Services\EventLog\Application.
 Function RegisterEventSource
   !define EVENTLOGKEY "HKLM\SYSTEM\CurrentControlSet\Services\EventLog\Application\Alloy"
 


### PR DESCRIPTION
### Brief description of Pull Request

Alloy fails to start with SCM error 1053 (`The service did not respond to the start or control request in a timely fashion.`) when installed with a dedicated non-admin service account via the silent installer's `/USERNAME=` / `/PASSWORD=` flags. Fix the runtime code path in `alloy-service.exe` and have the Windows installer pre-register the event source, so a fresh install under a dedicated service account works end to end.

### Pull Request Details

Two changes:

**1. `internal/cmd/alloy-service/writer_windows.go` — runtime fix**

`alloy-service.exe` called `eventlog.InstallAsEventCreate` unconditionally on every start. Internally that opens `HKLM\SYSTEM\CurrentControlSet\Services\EventLog\Application` with `CREATE_SUB_KEY` access, which non-admin accounts do not have — even when the `Alloy` source is already registered. The call returned `Access is denied`, `newWriter()` failed, `main()` exited before `svc.Run`, and the SCM surfaced the timeout as 1053.

Try `eventlog.Open` first (which does not need registry write access). If the source is already registered, the fast path returns immediately and the service starts. Only fall back to `InstallAsEventCreate` when the source isn't registered yet.

**2. `packaging/windows/install_script.nsis` — installer fix**

Pre-create `HKLM\SYSTEM\CurrentControlSet\Services\EventLog\Application\Alloy` with `EventMessageFile` and `TypesSupported` during install (the installer runs elevated). This closes the gap for a fresh install where the source doesn't exist yet on the first service start, and it also completes the existing TODO in `internal/runtime/logging/eventlog/eventlog_windows.go:64-65`:

```go
// TODO: Also do the registration in the Alloy Windows installer.
// That way users don't have to run Alloy with admin rights one time
// just for this to be installed.
```

The parent (`alloy-service.exe`) and the child (`alloy.exe`'s `logging {}` block via `openEventLogWindows`) both benefit: neither needs admin at runtime, and Event Viewer displays messages cleanly because the source has a message file registered.

### Issue(s) fixed by this Pull Request

Fixes #6626

### Notes to the Reviewer

- Validated end-to-end on Windows Server 2019 (EC2) with a dedicated service account (`svc_grafana_alloy`) that has only the **Log on as a service** right — no admin, no write access to the EventLog registry hive.
- Manually removed the `Alloy` event source subkey and any temporary ACL grants to reproduce a "fresh install" state, then confirmed that the fixed `alloy-service.exe` starts, the child `alloy.exe` initializes the `logging {}` block, and Alloy reaches `msg="{^_^} Alloy is running"` with the HTTP server listening — all without any admin-level runtime privileges.
- The change is Windows-only (build-tagged `_windows.go`) and does not affect other platforms.
- No new tests were added: the failure mode is a Windows-specific registry ACL interaction that requires a real non-admin service account to reproduce, which the existing test harness doesn't model. The change is a small ordering swap (`Open` before `Install`) that preserves the original behavior when `Open` fails.

### PR Checklist

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
