### PR TITLE
fix: default converted syslog protocol

### DIFF
--- a/internal/converter/internal/promtailconvert/internal/build/syslog.go
+++ b/internal/converter/internal/promtailconvert/internal/build/syslog.go
@@ -39,6 +39,9 @@ func (s *ScrapeConfigBuilder) AppendSyslogConfig() {
 	if listenerConfig.SyslogFormat == "" {
 		listenerConfig.SyslogFormat = syslog.DefaultListenerConfig.SyslogFormat
 	}
+	if listenerConfig.ListenProtocol == "" {
+		listenerConfig.ListenProtocol = syslog.DefaultListenerConfig.ListenProtocol
+	}
 
 	if fmtOpts := s.cfg.SyslogConfig.RawFormatOptions; fmtOpts != nil {
 		listenerConfig.RawFormatOptions = &syslog.RawFormatOptions{

--- a/internal/converter/internal/promtailconvert/testdata/syslog.alloy
+++ b/internal/converter/internal/promtailconvert/testdata/syslog.alloy
@@ -66,6 +66,19 @@ loki.source.syslog "test_rfc5424" {
 	relabel_rules = null
 }
 
+loki.source.syslog "default_protocol" {
+	listener {
+		address             = "localhost:4000"
+		idle_timeout        = "0s"
+		labels              = {}
+		max_message_length  = 0
+		udp_queue_size      = 0
+		udp_host_cache_size = 0
+	}
+	forward_to    = [loki.write.default.receiver]
+	relabel_rules = null
+}
+
 loki.source.syslog "test_raw" {
 	listener {
 		address            = "localhost:4000"

--- a/internal/converter/internal/promtailconvert/testdata/syslog.yaml
+++ b/internal/converter/internal/promtailconvert/testdata/syslog.yaml
@@ -37,6 +37,9 @@ scrape_configs:
       label_structured_data: true
       use_incoming_timestamp: true
       syslog_format: rfc5424
+  - job_name: default_protocol
+    syslog:
+      listen_address: localhost:4000
   - job_name: test_raw
     syslog:
       listen_address: localhost:4000


### PR DESCRIPTION
## Summary
- default converted Promtail syslog listeners to Alloy's syslog listener protocol default when listen_protocol is omitted
- add a promtail converter fixture covering an omitted syslog listen_protocol

Fixes #6603

## Verification
- RED: added the omitted listen_protocol fixture and confirmed it generated protocol = "" before the converter fix
- GOMODCACHE=/Volumes/STOREJET/2/Dependencies/go/pkg/mod GOCACHE=/Volumes/STOREJET/2/Dependencies/go/cache go test ./internal/converter/internal/promtailconvert -run TestConvert/syslog.yaml -count=1
- GOMODCACHE=/Volumes/STOREJET/2/Dependencies/go/pkg/mod GOCACHE=/Volumes/STOREJET/2/Dependencies/go/cache go test ./internal/converter/internal/promtailconvert -count=1
- git diff --check