### PR TITLE
fix: Remove duplicate Time field in windows exporter

### DIFF
--- a/internal/converter/internal/staticconvert/internal/build/windows_exporter.go
+++ b/internal/converter/internal/staticconvert/internal/build/windows_exporter.go
@@ -146,8 +146,5 @@ func toWindowsExporter(config *windows_exporter.Config) *windows.Arguments {
 			Exclude:     config.Net.Exclude,
 			EnabledList: split(config.Net.EnabledList),
 		},
-		Time: windows.TimeConfig{
-			EnabledList: split(config.Time.EnabledList),
-		},
 	}
 }


### PR DESCRIPTION
### Brief description of Pull Request

Remove duplicated time block in the windows exporter converter

### Notes to the Reviewer

This broke with #6555 which looks like it was merged after #6596 landed with the same change. I think github could resolve it so it didn't come through as a merge conflict.
