### PR TITLE
feat(otelcol.connector.spanmetrics): Expose include_collector_instance_id

### DIFF
--- a/docs/sources/reference/components/otelcol/otelcol.connector.spanmetrics.md
+++ b/docs/sources/reference/components/otelcol/otelcol.connector.spanmetrics.md
@@ -78,6 +78,7 @@ You can use the following arguments with `otelcol.connector.spanmetrics`:
 | `resource_metrics_key_attributes` | `list(string)` | Limits the resource attributes used to create the metrics.                                            | `[]`                    | no       |
 | `aggregation_cardinality_limit`   | `number`       | The maximum number of unique combinations of dimensions that will be tracked for metrics aggregation. | `0`                     | no       |
 | `include_instrumentation_scope`   | `list(string)` | A list of instrumentation scope names to include from the traces.                                     | `[]`                    | no       |
+| `include_collector_instance_id`   | `bool`         | Add a `collector.instance.id` dimension for [Single Writer Principle][single-writer-principle] compliance. | `false`                 | no       |
 
 The supported values for `aggregation_temporality` are:
 
@@ -102,6 +103,13 @@ For example, `["service.name", "telemetry.sdk.language", "telemetry.sdk.name"]`.
 
 When the `aggregation_cardinality_limit` limit is reached, additional unique combinations will be dropped but registered under a new entry with `otel.metric.overflow="true"`. 
 A value of `0` means no limit is applied.
+
+`include_collector_instance_id` is `false` by default.
+When enabled, the connector adds a `collector.instance.id` dimension whose value is a random UUID generated per connector instance.
+That UUID changes each time the component restarts or its arguments change, so with a single {{< param "PRODUCT_NAME" >}} instance it only fragments the metric series and breaks `rate()` continuity.
+Set it to `true` when you run multiple {{< param "PRODUCT_NAME" >}} instances that send spanmetrics to the same backend, where a unique ID per instance keeps their series distinct and satisfies the [Single Writer Principle][single-writer-principle].
+
+[single-writer-principle]: https://opentelemetry.io/docs/specs/otel/metrics/data-model/#single-writer
 
 ## Blocks
 
@@ -180,9 +188,8 @@ The default dimensions are:
 {{< param "PRODUCT_NAME" >}} adds the default dimensions unless you list them in `exclude_dimensions`.
 If you don't specify additional dimensions, {{< param "PRODUCT_NAME" >}} adds only the default ones.
 
-{{< param "PRODUCT_NAME" >}} always excludes the `collector.instance.id` dimension to keep the metric series stable across restarts.
-`otelcol.connector.spanmetrics` adds this dimension by default, populated from a resource attribute of the same name.
-Because {{< param "PRODUCT_NAME" >}} never sets that attribute, the connector would otherwise fall back to a random value that changes on every restart, fragmenting the metric series and breaking `rate()` continuity.
+`otelcol.connector.spanmetrics` also adds a `collector.instance.id` dimension by default, set to a random UUID generated once per connector instance.
+{{< param "PRODUCT_NAME" >}} excludes it unless you set `include_collector_instance_id`; see [Arguments](#arguments) for why.
 
 The following attributes are supported:
 

--- a/internal/component/otelcol/connector/spanmetrics/spanmetrics.go
+++ b/internal/component/otelcol/connector/spanmetrics/spanmetrics.go
@@ -93,6 +93,12 @@ type Arguments struct {
 	DebugMetrics otelcolCfg.DebugMetricsArguments `alloy:"debug_metrics,block,optional"`
 
 	IncludeInstrumentationScope []string `alloy:"include_instrumentation_scope,attr,optional"`
+
+	// IncludeCollectorInstanceID adds the connector's collector.instance.id dimension, which
+	// upstream uses to satisfy the Single Writer Principle in multi-instance deployments.
+	// Its value is a random UUID per connector instance that changes on every rebuild, so a
+	// single Alloy suppresses it by default to keep the series stable.
+	IncludeCollectorInstanceID bool `alloy:"include_collector_instance_id,attr,optional"`
 }
 
 var (
@@ -171,12 +177,11 @@ func FromOTelAggregationTemporality(temporality string) string {
 	}
 }
 
-// Convert implements connector.Arguments.
-// collectorInstanceIDDimension is the dimension the spanmetrics connector fills with
-// a random UUID when collector.instance.id is absent from the resource. Alloy never
-// sets it, so we exclude it unconditionally.
+// collectorInstanceIDDimension is the dimension the spanmetrics connector fills with a
+// random UUID to satisfy the Single Writer Principle across multi-instance deployments.
 const collectorInstanceIDDimension = "collector.instance.id"
 
+// Convert implements connector.Arguments.
 func (args Arguments) Convert() (otelcomponent.Config, error) {
 	dimensions := make([]spanmetricsconnector.Dimension, 0, len(args.Dimensions))
 	for _, d := range args.Dimensions {
@@ -199,11 +204,10 @@ func (args Arguments) Convert() (otelcomponent.Config, error) {
 	}
 
 	excludeDimensions := append([]string(nil), args.ExcludeDimensions...)
-	// The connector adds a collector.instance.id dimension by default (beta gate
-	// connector.spanmetrics.includeCollectorInstanceID), but Alloy never populates
-	// that resource attribute, so the connector mints a fresh random UUID per build —
-	// a churning, meaningless label that breaks rate() continuity. Always suppress it.
-	if !slices.Contains(excludeDimensions, collectorInstanceIDDimension) {
+	// Suppress collector.instance.id unless the user opts in. The connector sets it to a
+	// random UUID per instance that changes on every rebuild, so for a single Alloy it just
+	// fragments the series. It's only useful across multiple instances (Single Writer).
+	if !args.IncludeCollectorInstanceID && !slices.Contains(excludeDimensions, collectorInstanceIDDimension) {
 		excludeDimensions = append(excludeDimensions, collectorInstanceIDDimension)
 	}
 

--- a/internal/component/otelcol/connector/spanmetrics/spanmetrics_test.go
+++ b/internal/component/otelcol/connector/spanmetrics/spanmetrics_test.go
@@ -242,6 +242,62 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 			},
 		},
 		{
+			testName: "includeCollectorInstanceID",
+			cfg: `
+			include_collector_instance_id = true
+
+			histogram {
+				explicit {}
+			}
+
+			output {}
+			`,
+			expected: spanmetricsconnector.Config{
+				Dimensions:               []spanmetricsconnector.Dimension{},
+				CallsDimensions:          []spanmetricsconnector.Dimension{},
+				ExcludeDimensions:        []string(nil),
+				TimestampCacheSize:       &defaultTimestampCacheSize,
+				AggregationTemporality:   "AGGREGATION_TEMPORALITY_CUMULATIVE",
+				ResourceMetricsCacheSize: 1000,
+				Histogram: spanmetricsconnector.HistogramConfig{
+					Dimensions:  []spanmetricsconnector.Dimension{},
+					Disable:     false,
+					Unit:        0,
+					Exponential: configoptional.None[spanmetricsconnector.ExponentialHistogramConfig](),
+					Explicit: configoptional.Some(spanmetricsconnector.ExplicitHistogramConfig{
+						Buckets: []time.Duration{
+							2 * time.Millisecond,
+							4 * time.Millisecond,
+							6 * time.Millisecond,
+							8 * time.Millisecond,
+							10 * time.Millisecond,
+							50 * time.Millisecond,
+							100 * time.Millisecond,
+							200 * time.Millisecond,
+							400 * time.Millisecond,
+							800 * time.Millisecond,
+							1 * time.Second,
+							1400 * time.Millisecond,
+							2 * time.Second,
+							5 * time.Second,
+							10 * time.Second,
+							15 * time.Second,
+						},
+					}),
+				},
+				MetricsFlushInterval: 60 * time.Second,
+				Namespace:            "traces.span.metrics",
+				Exemplars: spanmetricsconnector.ExemplarsConfig{
+					Enabled:         false,
+					MaxPerDataPoint: 5,
+				},
+				Events: spanmetricsconnector.EventsConfig{
+					Enabled:    false,
+					Dimensions: []spanmetricsconnector.Dimension{},
+				},
+			},
+		},
+		{
 			testName: "invalidAggregationTemporality",
 			cfg: `
 			aggregation_temporality = "badVal"


### PR DESCRIPTION
### Brief description of Pull Request

Expose the `include_collector_instance_id` argument on `otelcol.connector.spanmetrics`

### Pull Request Details

This is a change in course from #6597 where I had a misread it's intended purpose. Upstream uses it for [Single Writer Principle](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/README.md#known-limitation-the-single-writer-principle). It is still a deviation from upstream which enables it by default. I'm not sure I want to add it + make it a default in a single release but am open to having it as another breaking change. 

### PR Checklist

- [x] Documentation added
- [x] Tests updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))