### PR TITLE
feat(prometheus.remote_write): Expose google_iam, round_robin_dns, and additional sigv4/azuread auth options

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.remote_write.md
+++ b/docs/sources/reference/components/prometheus/prometheus.remote_write.md
@@ -47,28 +47,31 @@ You can use the following blocks with `prometheus.remote_write`:
 
 {{< docs/alloy-config >}}
 
-| Block                                                           | Description                                                                | Required |
-|-----------------------------------------------------------------|----------------------------------------------------------------------------|----------|
-| [`endpoint`][endpoint]                                          | Location to send metrics to.                                               | no       |
-| `endpoint` > [`authorization`][authorization]                   | Configure generic authorization to the endpoint.                           | no       |
-| `endpoint` > [`azuread`][azuread]                               | Configure AzureAD for authenticating to the endpoint.                      | no       |
-| `endpoint` > `azuread` > [`managed_identity`][managed_identity] | Configure Azure user-assigned managed identity.                            | yes      |
-| `endpoint` > `azuread` > [`oauth`][oauth]                       | Configure Azure OAuth.                                                     | yes      |
-| `endpoint` > `azuread` > [`sdk`][sdk]                           | Configure Azure SDK authentication.                                        | yes      |
-| `endpoint` > [`basic_auth`][basic_auth]                         | Configure `basic_auth` for authenticating to the endpoint.                 | no       |
-| `endpoint` > [`metadata_config`][metadata_config]               | Configuration for how metric metadata is sent.                             | no       |
-| `endpoint` > [`oauth2`][oauth2]                                 | Configure OAuth 2.0 for authenticating to the endpoint.                    | no       |
-| `endpoint` > `oauth2` > [`tls_config`][tls_config]              | Configure TLS settings for connecting to the endpoint.                     | no       |
-| `endpoint` > [`queue_config`][queue_config]                     | Configuration for how metrics are batched before sending.                  | no       |
-| `endpoint` > [`sigv4`][sigv4]                                   | Configure AWS Signature Verification 4 for authenticating to the endpoint. | no       |
-| `endpoint` > [`tls_config`][tls_config]                         | Configure TLS settings for connecting to the endpoint.                     | no       |
-| `endpoint` > [`write_relabel_config`][write_relabel_config]     | Configuration for `write_relabel_config`.                                  | no       |
-| [`wal`][wal]                                                    | Configuration for the component's WAL.                                     | no       |
+| Block                                                             | Description                                                                | Required |
+|-------------------------------------------------------------------|----------------------------------------------------------------------------|----------|
+| [`endpoint`][endpoint]                                            | Location to send metrics to.                                               | no       |
+| `endpoint` > [`authorization`][authorization]                     | Configure generic authorization to the endpoint.                           | no       |
+| `endpoint` > [`azuread`][azuread]                                 | Configure AzureAD for authenticating to the endpoint.                      | no       |
+| `endpoint` > `azuread` > [`managed_identity`][managed_identity]   | Configure Azure user-assigned managed identity.                            | yes      |
+| `endpoint` > `azuread` > [`oauth`][oauth]                         | Configure Azure OAuth.                                                     | yes      |
+| `endpoint` > `azuread` > [`sdk`][sdk]                             | Configure Azure SDK authentication.                                        | yes      |
+| `endpoint` > `azuread` > [`workload_identity`][workload_identity] | Configure Microsoft Entra Workload ID.                                     | yes      |
+| `endpoint` > [`basic_auth`][basic_auth]                           | Configure `basic_auth` for authenticating to the endpoint.                 | no       |
+| `endpoint` > [`google_iam`][google_iam]                           | Configure Google IAM authentication for the endpoint.                      | no       |
+| `endpoint` > [`metadata_config`][metadata_config]                 | Configuration for how metric metadata is sent.                             | no       |
+| `endpoint` > [`oauth2`][oauth2]                                   | Configure OAuth 2.0 for authenticating to the endpoint.                    | no       |
+| `endpoint` > `oauth2` > [`tls_config`][tls_config]                | Configure TLS settings for connecting to the endpoint.                     | no       |
+| `endpoint` > [`queue_config`][queue_config]                       | Configuration for how metrics are batched before sending.                  | no       |
+| `endpoint` > [`sigv4`][sigv4]                                     | Configure AWS Signature Verification 4 for authenticating to the endpoint. | no       |
+| `endpoint` > [`tls_config`][tls_config]                           | Configure TLS settings for connecting to the endpoint.                     | no       |
+| `endpoint` > [`write_relabel_config`][write_relabel_config]       | Configuration for `write_relabel_config`.                                  | no       |
+| [`wal`][wal]                                                      | Configuration for the component's WAL.                                     | no       |
 
 [endpoint]: #endpoint
 [authorization]: #authorization
 [azuread]: #azuread
 [basic_auth]: #basic_auth
+[google_iam]: #google_iam
 [managed_identity]: #managed_identity
 [metadata_config]: #metadata_config
 [oauth]: #oauth
@@ -78,6 +81,7 @@ You can use the following blocks with `prometheus.remote_write`:
 [sigv4]: #sigv4
 [tls_config]: #tls_config
 [wal]: #wal
+[workload_identity]: #workload_identity
 [write_relabel_config]: #write_relabel_config
 
 {{< /docs/alloy-config >}}
@@ -105,6 +109,7 @@ The following arguments are supported:
 | `proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.                                                                                | `false`                     | no       |
 | `proxy_url`              | `string`            | HTTP proxy to send requests through.                                                                                                 |                             | no       |
 | `remote_timeout`         | `duration`          | Timeout for requests made to the URL.                                                                                                | `"30s"`                     | no       |
+| `round_robin_dns`        | `bool`              | Whether to round-robin requests across the resolved DNS addresses of the endpoint.                                                   | `false`                     | no       |
 | `send_exemplars`         | `bool`              | Whether exemplars should be sent.                                                                                                    | `true`                      | no       |
 | `send_native_histograms` | `bool`              | Whether native histograms should be sent.                                                                                            | `false`                     | no       |
 
@@ -115,6 +120,7 @@ The following arguments are supported:
 * [`basic_auth`][basic_auth] block
 * [`bearer_token_file`][endpoint] argument
 * [`bearer_token`][endpoint] argument
+* [`google_iam`][google_iam] block
 * [`oauth2`][oauth2] block
 * [`sigv4`][sigv4] block
 
@@ -138,6 +144,8 @@ If the endpoint doesn't support receiving native histogram samples, pushing metr
 
 {{< docs/shared lookup="reference/components/azuread-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
+You must configure exactly one of the [`managed_identity`][managed_identity], [`oauth`][oauth], [`sdk`][sdk], or [`workload_identity`][workload_identity] blocks.
+
 ### `managed_identity`
 
 {{< badge text="Required" >}}
@@ -155,6 +163,12 @@ If the endpoint doesn't support receiving native histogram samples, pushing metr
 {{< badge text="Required" >}}
 
 {{< docs/shared lookup="reference/components/azuread-sdk.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `workload_identity`
+
+{{< badge text="Required" >}}
+
+{{< docs/shared lookup="reference/components/azure-workload_identity-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 ### `basic_auth`
 
@@ -216,6 +230,14 @@ The default value is `0s`, which means that all samples are sent (feature is dis
 ### `sigv4`
 
 {{< docs/shared lookup="reference/components/sigv4-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `google_iam`
+
+The `google_iam` block configures Google IAM authentication for the endpoint.
+
+| Name               | Type     | Description                                                        | Default | Required |
+|--------------------|----------|--------------------------------------------------------------------|---------|----------|
+| `credentials_file` | `string` | Path to a Google Cloud credentials JSON file used to authenticate. |         | no       |
 
 ### `write_relabel_config`
 

--- a/docs/sources/shared/reference/components/azure-workload_identity-block.md
+++ b/docs/sources/shared/reference/components/azure-workload_identity-block.md
@@ -1,0 +1,24 @@
+---
+canonical: https://grafana.com/docs/alloy/latest/shared/reference/components/workload_identity-block/
+description: Shared content, workload_identity block
+headless: true
+---
+
+| Name              | Type     | Description                                                                     | Default                                                | Required |
+| ----------------- | -------- | ------------------------------------------------------------------------------- | ------------------------------------------------------ | -------- |
+| `client_id`       | `string` | Client ID of the Microsoft Entra application or user-assigned managed identity. |                                                        | yes      |
+| `tenant_id`       | `string` | Tenant ID of the Microsoft Entra application or user-assigned managed identity. |                                                        | yes      |
+| `token_file_path` | `string` | Path to the projected service account token file.                               | `"/var/run/secrets/azure/tokens/azure-identity-token"` | no       |
+
+`client_id` and `tenant_id` must be valid [UUID][]s in one of the supported formats:
+
+* `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
+* `urn:uuid:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
+* Microsoft encoding: `{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}`
+* Raw hex encoding: `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`
+
+Use `workload_identity` to authenticate from an AKS Pod configured with [Microsoft Entra Workload ID][workload-id] without requiring a client secret.
+{{< param "PRODUCT_NAME" >}} reads the projected service account token from `token_file_path` and federates it for a Microsoft Entra token.
+
+[UUID]: https://en.wikipedia.org/wiki/Universally_unique_identifier
+[workload-id]: https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview

--- a/docs/sources/shared/reference/components/azuread-block.md
+++ b/docs/sources/shared/reference/components/azuread-block.md
@@ -4,12 +4,16 @@ description: Shared content, azuread block
 headless: true
 ---
 
-| Name    | Type     | Description      | Default         | Required |
-| ------- | -------- | ---------------- | --------------- | -------- |
-| `cloud` | `string` | The Azure Cloud. | `"AzurePublic"` | no       |
+| Name    | Type     | Description                                                         | Default         | Required |
+| ------- | -------- | -------------------------------------------------------------------- | --------------- | -------- |
+| `cloud` | `string` | The Azure Cloud.                                                    | `"AzurePublic"` | no       |
+| `scope` | `string` | Custom OAuth 2.0 scope (audience) to request when acquiring tokens. | `""`            | no       |
 
 The supported values for `cloud` are:
 
 * `"AzurePublic"`
 * `"AzureChina"`
 * `"AzureGovernment"`
+
+When `scope` is left empty, {{< param "PRODUCT_NAME" >}} uses the per-cloud Azure Monitor ingestion audience, for example, `https://monitor.azure.com//.default` for `"AzurePublic"`.
+Set `scope` to request a token for a different audience, such as a custom Microsoft Entra app registration.

--- a/docs/sources/shared/reference/components/sigv4-block.md
+++ b/docs/sources/shared/reference/components/sigv4-block.md
@@ -4,13 +4,16 @@ description: Shared content, sigv4 block
 headless: true
 ---
 
-| Name         | Type     | Description                                         | Default | Required |
-| ------------ | -------- | --------------------------------------------------- | ------- | -------- |
-| `access_key` | `string` | AWS API access key.                                 |         | no       |
-| `profile`    | `string` | Named AWS profile used to authenticate.             |         | no       |
-| `region`     | `string` | AWS region.                                         |         | no       |
-| `role_arn`   | `string` | AWS Role ARN, an alternative to using AWS API keys. |         | no       |
-| `secret_key` | `secret` | AWS API secret key.                                 |         | no       |
+| Name                    | Type     | Description                                            | Default | Required |
+|-------------------------|----------|--------------------------------------------------------|---------|----------|
+| `access_key`            | `string` | AWS API access key.                                    |         | no       |
+| `external_id`           | `string` | AWS External ID used when assuming a role through STS. |         | no       |
+| `profile`               | `string` | Named AWS profile used to authenticate.                |         | no       |
+| `region`                | `string` | AWS region.                                            |         | no       |
+| `role_arn`              | `string` | AWS Role ARN, an alternative to using AWS API keys.    |         | no       |
+| `secret_key`            | `secret` | AWS API secret key.                                    |         | no       |
+| `service_name`          | `string` | AWS service name to sign requests for.                 | `"aps"` | no       |
+| `use_fips_sts_endpoint` | `bool`   | Whether to use a FIPS-compliant AWS STS endpoint.      | `false` | no       |
 
 If `region` is left blank, the region from the default credentials chain is used.
 

--- a/internal/component/prometheus/remotewrite/types.go
+++ b/internal/component/prometheus/remotewrite/types.go
@@ -19,6 +19,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/remote/azuread"
+	"github.com/prometheus/prometheus/storage/remote/googleiam"
 	promsigv4 "github.com/prometheus/sigv4"
 )
 
@@ -55,7 +56,7 @@ var (
 		MaxKeepaliveTime:  8 * time.Hour,
 	}
 
-	errTooManyAuth = errors.New("at most one of sigv4, azuread, basic_auth, oauth2, bearer_token & bearer_token_file must be configured")
+	errTooManyAuth = errors.New("at most one of sigv4, azuread, google_iam, basic_auth, oauth2, bearer_token & bearer_token_file must be configured")
 )
 
 // Arguments represents the input state of the prometheus.remote_write
@@ -87,6 +88,8 @@ type EndpointOptions struct {
 	WriteRelabelConfigs  []*alloy_relabel.Config `alloy:"write_relabel_config,block,optional"`
 	SigV4                *SigV4Config            `alloy:"sigv4,block,optional"`
 	AzureAD              *AzureADConfig          `alloy:"azuread,block,optional"`
+	GoogleIAM            *GoogleIAMConfig        `alloy:"google_iam,block,optional"`
+	RoundRobinDNS        bool                    `alloy:"round_robin_dns,attr,optional"`
 }
 
 // SetToDefault implements syntax.Defaulter.
@@ -118,16 +121,21 @@ func (r *EndpointOptions) Validate() error {
 		}
 	}
 
+	authMethods := 0
 	if r.SigV4 != nil {
-		if r.AzureAD != nil || isAuthSetInHttpClientConfig(r.HTTPClientConfig) {
-			return errTooManyAuth
-		}
+		authMethods++
 	}
-
 	if r.AzureAD != nil {
-		if r.SigV4 != nil || isAuthSetInHttpClientConfig(r.HTTPClientConfig) {
-			return errTooManyAuth
-		}
+		authMethods++
+	}
+	if r.GoogleIAM != nil {
+		authMethods++
+	}
+	if isAuthSetInHttpClientConfig(r.HTTPClientConfig) {
+		authMethods++
+	}
+	if authMethods > 1 {
+		return errTooManyAuth
 	}
 
 	if r.WriteRelabelConfigs != nil {
@@ -261,6 +269,8 @@ func convertConfigs(cfg Arguments) (*config.Config, error) {
 			MetadataConfig:       rw.MetadataOptions.toPrometheusType(),
 			SigV4Config:          rw.SigV4.toPrometheusType(),
 			AzureADConfig:        rw.AzureAD.toPrometheusType(),
+			GoogleIAMConfig:      rw.GoogleIAM.toPrometheusType(),
+			RoundRobinDNS:        rw.RoundRobinDNS,
 		})
 	}
 
@@ -328,9 +338,42 @@ func (c *SDKConfig) toPrometheusType() *azuread.SDKConfig {
 	}
 }
 
+// WorkloadIdentityConfig is used to store azure workload identity config values.
+type WorkloadIdentityConfig struct {
+	// ClientID is the clientId of the Microsoft Entra application or user-assigned managed identity.
+	ClientID string `alloy:"client_id,attr"`
+
+	// TenantID is the tenantId of the Microsoft Entra application or user-assigned managed identity.
+	TenantID string `alloy:"tenant_id,attr"`
+
+	// TokenFilePath is the path to the projected service-account token file. Defaults to the
+	// standard Azure Workload Identity path when unset.
+	TokenFilePath string `alloy:"token_file_path,attr,optional"`
+}
+
+func (c *WorkloadIdentityConfig) toPrometheusType() *azuread.WorkloadIdentityConfig {
+	if c == nil {
+		return nil
+	}
+
+	tokenFilePath := c.TokenFilePath
+	if tokenFilePath == "" {
+		tokenFilePath = azuread.DefaultWorkloadIdentityTokenPath
+	}
+
+	return &azuread.WorkloadIdentityConfig{
+		ClientID:      c.ClientID,
+		TenantID:      c.TenantID,
+		TokenFilePath: tokenFilePath,
+	}
+}
+
 type AzureADConfig struct {
 	// ManagedIdentity is the managed identity that is being used to authenticate.
 	ManagedIdentity *ManagedIdentityConfig `alloy:"managed_identity,block,optional"`
+
+	// WorkloadIdentity is the workload identity that is being used to authenticate.
+	WorkloadIdentity *WorkloadIdentityConfig `alloy:"workload_identity,block,optional"`
 
 	// OAuth is the oauth config that is being used to authenticate.
 	OAuth *OAuthConfig `alloy:"oauth,block,optional"`
@@ -340,6 +383,9 @@ type AzureADConfig struct {
 
 	// Cloud is the Azure cloud in which the service is running. Example: AzurePublic/AzureGovernment/AzureChina.
 	Cloud string `alloy:"cloud,attr,optional"`
+
+	// Scope is the custom OAuth 2.0 scope to request when acquiring tokens.
+	Scope string `alloy:"scope,attr,optional"`
 }
 
 func (a *AzureADConfig) Validate() error {
@@ -347,20 +393,17 @@ func (a *AzureADConfig) Validate() error {
 		return fmt.Errorf("must provide a cloud in the Azure AD config")
 	}
 
-	if a.ManagedIdentity == nil && a.OAuth == nil && a.SDK == nil {
-		return fmt.Errorf("must provide an Azure Managed Identity, Azure OAuth or Azure SDK in the Azure AD config")
+	authenticators := 0
+	for _, set := range []bool{a.ManagedIdentity != nil, a.WorkloadIdentity != nil, a.OAuth != nil, a.SDK != nil} {
+		if set {
+			authenticators++
+		}
 	}
-
-	if a.ManagedIdentity != nil && a.OAuth != nil {
-		return fmt.Errorf("cannot provide both Azure Managed Identity and Azure OAuth in the Azure AD config")
+	if authenticators == 0 {
+		return fmt.Errorf("must provide an Azure Managed Identity, Azure Workload Identity, Azure OAuth or Azure SDK in the Azure AD config")
 	}
-
-	if a.ManagedIdentity != nil && a.SDK != nil {
-		return fmt.Errorf("cannot provide both Azure Managed Identity and Azure SDK in the Azure AD config")
-	}
-
-	if a.OAuth != nil && a.SDK != nil {
-		return fmt.Errorf("cannot provide both Azure OAuth and Azure SDK in the Azure AD config")
+	if authenticators > 1 {
+		return fmt.Errorf("cannot provide multiple authentication methods in the Azure AD config")
 	}
 
 	if a.ManagedIdentity != nil {
@@ -371,6 +414,21 @@ func (a *AzureADConfig) Validate() error {
 		_, err := uuid.Parse(a.ManagedIdentity.ClientID)
 		if err != nil {
 			return fmt.Errorf("the provided Azure Managed Identity client_id is invalid")
+		}
+	}
+
+	if a.WorkloadIdentity != nil {
+		if a.WorkloadIdentity.ClientID == "" {
+			return fmt.Errorf("must provide an Azure Workload Identity client_id in the Azure AD config")
+		}
+		if a.WorkloadIdentity.TenantID == "" {
+			return fmt.Errorf("must provide an Azure Workload Identity tenant_id in the Azure AD config")
+		}
+		if _, err := uuid.Parse(a.WorkloadIdentity.ClientID); err != nil {
+			return fmt.Errorf("the provided Azure Workload Identity client_id is invalid")
+		}
+		if _, err := uuid.Parse(a.WorkloadIdentity.TenantID); err != nil {
+			return fmt.Errorf("the provided Azure Workload Identity tenant_id is invalid")
 		}
 	}
 
@@ -407,6 +465,12 @@ func (a *AzureADConfig) Validate() error {
 		}
 	}
 
+	if a.Scope != "" {
+		if matched, err := regexp.MatchString(`^[\w\s:/.\-]+$`, a.Scope); err != nil || !matched {
+			return fmt.Errorf("the provided scope contains invalid characters")
+		}
+	}
+
 	return nil
 }
 
@@ -423,24 +487,32 @@ func (a *AzureADConfig) toPrometheusType() *azuread.AzureADConfig {
 	}
 
 	return &azuread.AzureADConfig{
-		ManagedIdentity: a.ManagedIdentity.toPrometheusType(),
-		OAuth:           a.OAuth.toPrometheusType(),
-		SDK:             a.SDK.toPrometheusType(),
-		Cloud:           a.Cloud,
+		ManagedIdentity:  a.ManagedIdentity.toPrometheusType(),
+		WorkloadIdentity: a.WorkloadIdentity.toPrometheusType(),
+		OAuth:            a.OAuth.toPrometheusType(),
+		SDK:              a.SDK.toPrometheusType(),
+		Cloud:            a.Cloud,
+		Scope:            a.Scope,
 	}
 }
 
 type SigV4Config struct {
-	Region    string            `alloy:"region,attr,optional"`
-	AccessKey string            `alloy:"access_key,attr,optional"`
-	SecretKey alloytypes.Secret `alloy:"secret_key,attr,optional"`
-	Profile   string            `alloy:"profile,attr,optional"`
-	RoleARN   string            `alloy:"role_arn,attr,optional"`
+	Region             string            `alloy:"region,attr,optional"`
+	AccessKey          string            `alloy:"access_key,attr,optional"`
+	SecretKey          alloytypes.Secret `alloy:"secret_key,attr,optional"`
+	Profile            string            `alloy:"profile,attr,optional"`
+	RoleARN            string            `alloy:"role_arn,attr,optional"`
+	ExternalID         string            `alloy:"external_id,attr,optional"`
+	UseFIPSSTSEndpoint bool              `alloy:"use_fips_sts_endpoint,attr,optional"`
+	ServiceName        string            `alloy:"service_name,attr,optional"`
 }
 
 func (s *SigV4Config) Validate() error {
 	if (s.AccessKey == "") != (s.SecretKey == "") {
 		return fmt.Errorf("must provide an AWS SigV4 access key and secret key if credentials are specified in the SigV4 config")
+	}
+	if s.ExternalID != "" && s.RoleARN == "" {
+		return fmt.Errorf("external_id can only be used with role_arn")
 	}
 	return nil
 }
@@ -451,10 +523,27 @@ func (s *SigV4Config) toPrometheusType() *promsigv4.SigV4Config {
 	}
 
 	return &promsigv4.SigV4Config{
-		Region:    s.Region,
-		AccessKey: s.AccessKey,
-		SecretKey: common.Secret(s.SecretKey),
-		Profile:   s.Profile,
-		RoleARN:   s.RoleARN,
+		Region:             s.Region,
+		AccessKey:          s.AccessKey,
+		SecretKey:          common.Secret(s.SecretKey),
+		Profile:            s.Profile,
+		RoleARN:            s.RoleARN,
+		ExternalID:         s.ExternalID,
+		UseFIPSSTSEndpoint: s.UseFIPSSTSEndpoint,
+		ServiceName:        s.ServiceName,
+	}
+}
+
+type GoogleIAMConfig struct {
+	CredentialsFile string `alloy:"credentials_file,attr,optional"`
+}
+
+func (g *GoogleIAMConfig) toPrometheusType() *googleiam.Config {
+	if g == nil {
+		return nil
+	}
+
+	return &googleiam.Config{
+		CredentialsFile: g.CredentialsFile,
 	}
 }

--- a/internal/component/prometheus/remotewrite/types_test.go
+++ b/internal/component/prometheus/remotewrite/types_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/prometheus/prometheus/storage/remote/azuread"
+	"github.com/prometheus/prometheus/storage/remote/googleiam"
 	"github.com/prometheus/sigv4"
 	"github.com/stretchr/testify/require"
 
@@ -223,23 +224,119 @@ func TestAlloyConfig(t *testing.T) {
 				url  = "http://0.0.0.0:11111/api/v1/write"
 
 				sigv4 {
-					region     = "us-east-1"
-					access_key = "example_access_key"
-					secret_key = "example_secret_key"
-					profile    = "example_profile"
-					role_arn   = "example_role_arn"
+					region                = "us-east-1"
+					access_key            = "example_access_key"
+					secret_key            = "example_secret_key"
+					profile               = "example_profile"
+					role_arn              = "example_role_arn"
+					external_id           = "example_external_id"
+					use_fips_sts_endpoint = true
+					service_name          = "aps"
 				}
 			}`,
 			expectedCfg: expectedCfg(func(c *config.Config) {
 				c.RemoteWriteConfigs[0].SigV4Config = &sigv4.SigV4Config{
-					Region:    "us-east-1",
-					AccessKey: "example_access_key",
-					SecretKey: commonconfig.Secret("example_secret_key"),
-					Profile:   "example_profile",
-					RoleARN:   "example_role_arn",
+					Region:             "us-east-1",
+					AccessKey:          "example_access_key",
+					SecretKey:          commonconfig.Secret("example_secret_key"),
+					Profile:            "example_profile",
+					RoleARN:            "example_role_arn",
+					ExternalID:         "example_external_id",
+					UseFIPSSTSEndpoint: true,
+					ServiceName:        "aps",
 				}
 				c.RemoteWriteConfigs[0].ProtobufMessage = remote.WriteV1MessageType
 			}),
+		},
+		{
+			testName: "AzureAD_WorkloadIdentity",
+			cfg: `
+			endpoint {
+				url  = "http://0.0.0.0:11111/api/v1/write"
+
+				azuread {
+					workload_identity {
+						client_id = "f47ac10b-58cc-0372-8567-0e02b2c3d479"
+						tenant_id = "9f4ac10b-58cc-0372-8567-0e02b2c3d480"
+					}
+				}
+			}`,
+			expectedCfg: expectedCfg(func(c *config.Config) {
+				c.RemoteWriteConfigs[0].AzureADConfig = &azuread.AzureADConfig{
+					Cloud: "AzurePublic",
+					WorkloadIdentity: &azuread.WorkloadIdentityConfig{
+						ClientID:      "f47ac10b-58cc-0372-8567-0e02b2c3d479",
+						TenantID:      "9f4ac10b-58cc-0372-8567-0e02b2c3d480",
+						TokenFilePath: azuread.DefaultWorkloadIdentityTokenPath,
+					},
+				}
+				c.RemoteWriteConfigs[0].ProtobufMessage = remote.WriteV1MessageType
+			}),
+		},
+		{
+			testName: "AzureAD_Scope",
+			cfg: `
+			endpoint {
+				url  = "http://0.0.0.0:11111/api/v1/write"
+
+				azuread {
+					scope = "https://monitor.azure.com/.default"
+					managed_identity {
+						client_id = "f47ac10b-58cc-0372-8567-0e02b2c3d479"
+					}
+				}
+			}`,
+			expectedCfg: expectedCfg(func(c *config.Config) {
+				c.RemoteWriteConfigs[0].AzureADConfig = &azuread.AzureADConfig{
+					Cloud: "AzurePublic",
+					ManagedIdentity: &azuread.ManagedIdentityConfig{
+						ClientID: "f47ac10b-58cc-0372-8567-0e02b2c3d479",
+					},
+					Scope: "https://monitor.azure.com/.default",
+				}
+				c.RemoteWriteConfigs[0].ProtobufMessage = remote.WriteV1MessageType
+			}),
+		},
+		{
+			testName: "GoogleIAM",
+			cfg: `
+			endpoint {
+				url  = "http://0.0.0.0:11111/api/v1/write"
+
+				google_iam {
+					credentials_file = "/path/to/creds.json"
+				}
+			}`,
+			expectedCfg: expectedCfg(func(c *config.Config) {
+				c.RemoteWriteConfigs[0].GoogleIAMConfig = &googleiam.Config{
+					CredentialsFile: "/path/to/creds.json",
+				}
+				c.RemoteWriteConfigs[0].ProtobufMessage = remote.WriteV1MessageType
+			}),
+		},
+		{
+			testName: "RoundRobinDNS",
+			cfg: `
+			endpoint {
+				url             = "http://0.0.0.0:11111/api/v1/write"
+				round_robin_dns = true
+			}`,
+			expectedCfg: expectedCfg(func(c *config.Config) {
+				c.RemoteWriteConfigs[0].RoundRobinDNS = true
+				c.RemoteWriteConfigs[0].ProtobufMessage = remote.WriteV1MessageType
+			}),
+		},
+		{
+			testName: "SigV4ExternalIDWithoutRoleARN",
+			cfg: `
+			endpoint {
+				url  = "http://0.0.0.0:11111/api/v1/write"
+
+				sigv4 {
+					external_id = "example_external_id"
+				}
+			}`,
+			errorMsg: "external_id can only be used with role_arn",
 		},
 		{
 			testName: "TooManyAuth1",
@@ -250,7 +347,7 @@ func TestAlloyConfig(t *testing.T) {
 				sigv4 {}
 				bearer_token = "token"
 			}`,
-			errorMsg: "at most one of sigv4, azuread, basic_auth, oauth2, bearer_token & bearer_token_file must be configured",
+			errorMsg: "at most one of sigv4, azuread, google_iam, basic_auth, oauth2, bearer_token & bearer_token_file must be configured",
 		},
 		{
 			testName: "TooManyAuth2",
@@ -265,7 +362,7 @@ func TestAlloyConfig(t *testing.T) {
 					}
 				}
 			}`,
-			errorMsg: "at most one of sigv4, azuread, basic_auth, oauth2, bearer_token & bearer_token_file must be configured",
+			errorMsg: "at most one of sigv4, azuread, google_iam, basic_auth, oauth2, bearer_token & bearer_token_file must be configured",
 		},
 		{
 			testName: "BadAzureClientId",

--- a/internal/converter/internal/prometheusconvert/component/remote_write.go
+++ b/internal/converter/internal/prometheusconvert/component/remote_write.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/alloy/syntax/alloytypes"
 	prom_config "github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/storage/remote/azuread"
+	"github.com/prometheus/prometheus/storage/remote/googleiam"
 	"github.com/prometheus/sigv4"
 )
 
@@ -79,6 +80,8 @@ func getEndpointOptions(remoteWriteConfigs []*prom_config.RemoteWriteConfig) []*
 			WriteRelabelConfigs:  ToAlloyRelabelConfigs(remoteWriteConfig.WriteRelabelConfigs),
 			SigV4:                toSigV4(remoteWriteConfig.SigV4Config),
 			AzureAD:              toAzureAD(remoteWriteConfig.AzureADConfig),
+			GoogleIAM:            toGoogleIAM(remoteWriteConfig.GoogleIAMConfig),
+			RoundRobinDNS:        remoteWriteConfig.RoundRobinDNS,
 		}
 
 		endpoints = append(endpoints, endpoint)
@@ -116,11 +119,25 @@ func toSigV4(sigv4Config *sigv4.SigV4Config) *remotewrite.SigV4Config {
 	}
 
 	return &remotewrite.SigV4Config{
-		Region:    sigv4Config.Region,
-		AccessKey: sigv4Config.AccessKey,
-		SecretKey: alloytypes.Secret(sigv4Config.SecretKey),
-		Profile:   sigv4Config.Profile,
-		RoleARN:   sigv4Config.RoleARN,
+		Region:             sigv4Config.Region,
+		AccessKey:          sigv4Config.AccessKey,
+		SecretKey:          alloytypes.Secret(sigv4Config.SecretKey),
+		Profile:            sigv4Config.Profile,
+		RoleARN:            sigv4Config.RoleARN,
+		ExternalID:         sigv4Config.ExternalID,
+		UseFIPSSTSEndpoint: sigv4Config.UseFIPSSTSEndpoint,
+		ServiceName:        sigv4Config.ServiceName,
+	}
+}
+
+// toGoogleIAM converts a Prometheus Google IAM config to an Alloy Google IAM config.
+func toGoogleIAM(googleIAMConfig *googleiam.Config) *remotewrite.GoogleIAMConfig {
+	if googleIAMConfig == nil {
+		return nil
+	}
+
+	return &remotewrite.GoogleIAMConfig{
+		CredentialsFile: googleIAMConfig.CredentialsFile,
 	}
 }
 
@@ -134,9 +151,19 @@ func toAzureAD(azureADConfig *azuread.AzureADConfig) *remotewrite.AzureADConfig 
 		Cloud: azureADConfig.Cloud,
 	}
 
+	res.Scope = azureADConfig.Scope
+
 	if azureADConfig.ManagedIdentity != nil {
 		res.ManagedIdentity = &remotewrite.ManagedIdentityConfig{
 			ClientID: azureADConfig.ManagedIdentity.ClientID,
+		}
+	}
+
+	if azureADConfig.WorkloadIdentity != nil {
+		res.WorkloadIdentity = &remotewrite.WorkloadIdentityConfig{
+			ClientID:      azureADConfig.WorkloadIdentity.ClientID,
+			TenantID:      azureADConfig.WorkloadIdentity.TenantID,
+			TokenFilePath: azureADConfig.WorkloadIdentity.TokenFilePath,
 		}
 	}
 


### PR DESCRIPTION
### Brief description of Pull Request

Adds `google_iam` auth, `round_robin_dns`, and rounds out the existing sigv4/azuread auth blocks: sigv4 gets `external_id`, `use_fips_sts_endpoint`, and `service_name`; azuread gets `workload_identity` and `scope`.

### Pull Request Details

Auth validation now counts configured auth methods (sigv4/azuread/google_iam/HTTP client auth) instead of pairwise checks, so adding `google_iam` didn't need a new branch of exclusivity logic. Converter updated to map the new fields.

### PR Checklist

- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))