### PR TITLE
fix(database_observability.postgres): Update postgres collect intervals to match mysql

### DIFF
--- a/docs/sources/reference/components/database_observability/database_observability.postgres.md
+++ b/docs/sources/reference/components/database_observability/database_observability.postgres.md
@@ -138,7 +138,7 @@ The `gcp` block supplies the identifying information for the GCP Cloud SQL datab
 
 | Name                      | Type       | Description                                                   | Default | Required |
 |---------------------------|------------|---------------------------------------------------------------|---------|----------|
-| `collect_interval`        | `duration` | How frequently to collect information from database.          | `"15s"` | no       |
+| `collect_interval`        | `duration` | How frequently to collect information from database.          | `"10s"` | no       |
 | `disable_query_redaction` | `bool`     | Collect unredacted SQL query text (might include parameters). | `false` | no       |
 | `exclude_current_user`    | `bool`     | Deprecated. Use the top-level `exclude_current_user` argument instead. This setting takes precedence over the top-level setting. | (unset) | no       |
 | `enable_pre_classified_wait_events`   | `boolean`  | When `true`, emits telemetry data with pre-classified wait event information. | `false` | no       |

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -131,7 +131,7 @@ func defaultArguments() Arguments {
 		ExcludeUsers:       database_observability.DefaultExcludedUsers(),
 		ExcludeCurrentUser: true,
 		QuerySampleArguments: QuerySampleArguments{
-			CollectInterval:       15 * time.Second,
+			CollectInterval:       10 * time.Second,
 			DisableQueryRedaction: false,
 		},
 		QueryDetailsArguments: QueryDetailsArguments{


### PR DESCRIPTION
### Brief description of Pull Request
Some discovery around billing and telemetry volume revealed that mysql and postgres have different default collection intervals. This PR unifies them to 10s which is the preferred default.
