### PR TITLE
fix: Ensure generate-otel-collector-distro runs "go mod tidy" after all generation steps

### DIFF
--- a/collector/generate.go
+++ b/collector/generate.go
@@ -1,5 +1,5 @@
 package main
 
 //go:generate go run go.opentelemetry.io/collector/cmd/builder@${BUILDER_VERSION} --config ./builder-config.yaml --skip-compilation
-//go:generate go mod tidy
 //go:generate go run ./generator/generator.go --path ./
+//go:generate go mod tidy

--- a/collector/go.mod
+++ b/collector/go.mod
@@ -98,7 +98,6 @@ require (
 	go.opentelemetry.io/collector/receiver v1.59.0
 	go.opentelemetry.io/collector/receiver/otlpreceiver v0.153.0
 	go.opentelemetry.io/collector/service v0.153.0
-	golang.org/x/sys v0.46.0
 )
 
 require (
@@ -1064,6 +1063,7 @@ require (
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
+	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260610154732-fb80ec83bdd9 // indirect
 	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.38.0 // indirect


### PR DESCRIPTION
I was running into some issues where running `make generate-otel-collector-distro` would end up in a state where the resulting `go.mod` files weren't tidy - which caused some issues in CI. When I ran `go mod tidy` and pushed to github though, the `check-generate-otel-collector-distro` action would fail because the code gen was essentially un-tidying the code. 

Turns out we're not running `go mod tidy` after all the generation steps, this PR moves the tidy command to happen _after_ we do the OCB generation and templating, instead of in between