### PR TITLE
feat(database_observability.sql_server): Add `table_spec` to `schema_details` collector

### DIFF
--- a/internal/component/database_observability/sql_server/collector/schema_details.go
+++ b/internal/component/database_observability/sql_server/collector/schema_details.go
@@ -3,6 +3,8 @@ package collector
 import (
 	"context"
 	"database/sql"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -18,21 +20,89 @@ import (
 const (
 	SchemaDetailsCollector = "schema_details"
 	OP_TABLE_DETECTION     = "table_detection"
+	OP_CREATE_STATEMENT    = "create_statement"
 )
 
-// selectTablesTemplate lists every table and view visible in the connected
-// database, excluding the schemas in the IN-clause appended at format time.
-// We read from INFORMATION_SCHEMA.TABLES for portability across all supported
-// SQL Server versions and Azure SQL.
-const selectTablesTemplate = `
-SELECT
-	TABLE_CATALOG,
-	TABLE_SCHEMA,
-	TABLE_NAME,
-	TABLE_TYPE
-FROM INFORMATION_SCHEMA.TABLES
-WHERE TABLE_SCHEMA NOT IN %s
-ORDER BY TABLE_SCHEMA, TABLE_NAME`
+// emitInterval is the minimum amount of time that must elapse between
+// successive OP_CREATE_STATEMENT emissions for the same table, regardless of
+// the configured collect_interval.
+const emitInterval = 30 * time.Minute
+
+const (
+	selectTablesTemplate = `
+		SELECT
+			table_catalog,
+			table_schema,
+			table_name,
+			table_type
+		FROM information_schema.tables
+		WHERE table_schema NOT IN %s
+		ORDER BY table_schema, table_name`
+
+	// selectColumnsTemplate returns columns information for every table in
+	// the given IN-clause of table names, scoped to a single schema.
+	// Note that column_type is emitted as the bare SQL Server type family name
+	// (e.g. `varchar`, `int`, `decimal`) without precision/length.
+	selectColumnsTemplate = `
+		SELECT
+			OBJECT_NAME(c.object_id) AS table_name,
+			c.name AS column_name,
+			TYPE_NAME(c.user_type_id) AS column_type,
+			c.is_nullable,
+			c.is_identity,
+			dc.definition AS default_value,
+			CASE WHEN pk_ic.column_id IS NOT NULL THEN 1 ELSE 0 END AS is_primary_key
+		FROM sys.columns c
+		INNER JOIN sys.objects o ON c.object_id = o.object_id
+		INNER JOIN sys.schemas s ON o.schema_id = s.schema_id
+		LEFT JOIN sys.default_constraints dc ON c.default_object_id = dc.object_id
+		LEFT JOIN sys.indexes pk ON pk.object_id = c.object_id AND pk.is_primary_key = 1
+		LEFT JOIN sys.index_columns pk_ic ON pk_ic.object_id = c.object_id AND pk_ic.index_id = pk.index_id AND pk_ic.column_id = c.column_id
+		WHERE s.name = @p1 AND OBJECT_NAME(c.object_id) IN %s
+		ORDER BY OBJECT_NAME(c.object_id), c.column_id`
+
+	// selectIndexesTemplate returns index information for every table in
+	// the IN-clause. Note we filter out:
+	// - Heaps (i.type = 0) and unnamed rowstore rows
+	// - INCLUDE columns (ic.is_included_column = 1)
+	selectIndexesTemplate = `
+		SELECT
+			OBJECT_NAME(i.object_id) AS table_name,
+			i.name AS index_name,
+			ic.key_ordinal AS seq_in_index,
+			c.name AS column_name,
+			i.type_desc AS index_type,
+			i.is_unique,
+			c.is_nullable
+		FROM sys.indexes i
+		INNER JOIN sys.objects o ON i.object_id = o.object_id
+		INNER JOIN sys.schemas s ON o.schema_id = s.schema_id
+		INNER JOIN sys.index_columns ic ON i.object_id = ic.object_id AND i.index_id = ic.index_id AND ic.is_included_column = 0
+		INNER JOIN sys.columns c ON ic.object_id = c.object_id AND ic.column_id = c.column_id
+		WHERE s.name = @p1 AND OBJECT_NAME(i.object_id) IN %s
+			AND i.type > 0
+			AND i.name IS NOT NULL
+		ORDER BY OBJECT_NAME(i.object_id), i.name, ic.key_ordinal`
+
+	// selectForeignKeysTemplate returns foreign key information for every table in
+	// the IN-clause. Ordering by constraint_column_id preserves the correlation
+	// between parent and referenced columns in composite foreign keys.
+	selectForeignKeysTemplate = `
+		SELECT
+			OBJECT_NAME(fk.parent_object_id) AS table_name,
+			fk.name AS constraint_name,
+			pcol.name AS column_name,
+			OBJECT_NAME(fk.referenced_object_id) AS referenced_table_name,
+			rcol.name AS referenced_column_name
+		FROM sys.foreign_keys fk
+		INNER JOIN sys.objects o ON fk.parent_object_id = o.object_id
+		INNER JOIN sys.schemas s ON o.schema_id = s.schema_id
+		INNER JOIN sys.foreign_key_columns fkc ON fk.object_id = fkc.constraint_object_id
+		INNER JOIN sys.columns pcol ON fkc.parent_object_id = pcol.object_id AND fkc.parent_column_id = pcol.column_id
+		INNER JOIN sys.columns rcol ON fkc.referenced_object_id = rcol.object_id AND fkc.referenced_column_id = rcol.column_id
+		WHERE s.name = @p1 AND OBJECT_NAME(fk.parent_object_id) IN %s
+		ORDER BY OBJECT_NAME(fk.parent_object_id), fk.name, fkc.constraint_column_id`
+)
 
 type SchemaDetailsArguments struct {
 	DB              *sql.DB
@@ -49,11 +119,58 @@ type SchemaDetails struct {
 	excludeSchemas  []string
 	entryHandler    loki.EntryHandler
 
+	// lastEmittedAt records the wall-clock time at which OP_CREATE_STATEMENT
+	// was last emitted for a "schema.table" key. Used to throttle logging
+	// to at most one per emitInterval per table.
+	lastEmittedAt map[string]time.Time
+
+	// now allows overriding time.Now() in tests
+	now func() time.Time
+
 	logger  *slog.Logger
 	running *atomic.Bool
 	ctx     context.Context
 	cancel  context.CancelFunc
 	wg      sync.WaitGroup
+}
+
+type tableInfo struct {
+	database     string
+	schema       string
+	tableName    string
+	tableType    string
+	b64TableSpec string
+}
+
+type tableSpec struct {
+	Columns     []columnSpec `json:"columns"`
+	Indexes     []indexSpec  `json:"indexes,omitempty"`
+	ForeignKeys []foreignKey `json:"foreign_keys,omitempty"`
+}
+
+type columnSpec struct {
+	Name          string `json:"name"`
+	Type          string `json:"type"`
+	NotNull       bool   `json:"not_null,omitempty"`
+	AutoIncrement bool   `json:"auto_increment,omitempty"`
+	PrimaryKey    bool   `json:"primary_key,omitempty"`
+	DefaultValue  string `json:"default_value,omitempty"`
+}
+
+type indexSpec struct {
+	Name        string   `json:"name"`
+	Type        string   `json:"type"`
+	Columns     []string `json:"columns"`
+	Expressions []string `json:"expressions,omitempty"`
+	Unique      bool     `json:"unique"`
+	Nullable    bool     `json:"nullable"`
+}
+
+type foreignKey struct {
+	Name                 string `json:"name"`
+	ColumnName           string `json:"column_name"`
+	ReferencedTableName  string `json:"referenced_table_name"`
+	ReferencedColumnName string `json:"referenced_column_name"`
 }
 
 func NewSchemaDetails(args SchemaDetailsArguments) (*SchemaDetails, error) {
@@ -62,6 +179,8 @@ func NewSchemaDetails(args SchemaDetailsArguments) (*SchemaDetails, error) {
 		collectInterval: args.CollectInterval,
 		excludeSchemas:  args.ExcludeSchemas,
 		entryHandler:    args.EntryHandler,
+		lastEmittedAt:   map[string]time.Time{},
+		now:             time.Now,
 		logger:          args.Logger.With("collector", SchemaDetailsCollector),
 		running:         &atomic.Bool{},
 	}
@@ -123,29 +242,260 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 	}
 	defer rs.Close()
 
-	tableCount := 0
+	now := c.now()
+	tables := []*tableInfo{}
+	seenTables := map[string]struct{}{}
+
 	for rs.Next() {
 		var database, schema, tableName, tableType string
 		if err := rs.Scan(&database, &schema, &tableName, &tableType); err != nil {
 			c.logger.Error("failed to scan tables", "err", err)
 			break
 		}
+		tables = append(tables, &tableInfo{
+			database:  database,
+			schema:    schema,
+			tableName: tableName,
+			tableType: tableType,
+		})
+		seenTables[fullyQualifiedName(schema, tableName)] = struct{}{}
 
 		c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
 			logging.LevelInfo,
 			OP_TABLE_DETECTION,
 			fmt.Sprintf(`database="%s" schema="%s" table="%s"`, database, schema, tableName),
 		)
-		tableCount++
 	}
 
 	if err := rs.Err(); err != nil {
 		return fmt.Errorf("failed to iterate over tables result set: %w", err)
 	}
 
-	if tableCount == 0 {
+	// Cleanup: drop throttle entries for tables that no longer exist (e.g.
+	// tables dropped or renamed). Done before the empty-tables early return so
+	// the map is also pruned when every monitored table disappears.
+	for k := range c.lastEmittedAt {
+		if _, ok := seenTables[k]; !ok {
+			delete(c.lastEmittedAt, k)
+		}
+	}
+
+	if len(tables) == 0 {
 		c.logger.Info("no tables detected from information_schema.tables")
+		return nil
+	}
+
+	// Compute the due set: tables that have never emitted OP_CREATE_STATEMENT
+	// or whose last emission is older than emitInterval.
+	// Group by schema to preserve the iteration order from the tables-list query.
+	dueBySchema := map[string][]*tableInfo{}
+	dueSchemas := []string{}
+	for _, t := range tables {
+		k := fullyQualifiedName(t.schema, t.tableName)
+		if last, ok := c.lastEmittedAt[k]; ok && now.Sub(last) < emitInterval {
+			continue
+		}
+		if _, exists := dueBySchema[t.schema]; !exists {
+			dueSchemas = append(dueSchemas, t.schema)
+		}
+		dueBySchema[t.schema] = append(dueBySchema[t.schema], t)
+	}
+
+	if len(dueSchemas) == 0 {
+		return nil
+	}
+
+	for _, schema := range dueSchemas {
+		dueTables := dueBySchema[schema]
+		tableNames := make([]string, 0, len(dueTables))
+		for _, t := range dueTables {
+			tableNames = append(tableNames, t.tableName)
+		}
+
+		specs, err := c.fetchSchemaSpecs(ctx, schema, tableNames)
+		if err != nil {
+			c.logger.Error("failed to fetch schema specs", "schema", schema, "err", err)
+			continue
+		}
+
+		for _, table := range dueTables {
+			spec, ok := specs[table.tableName]
+			if !ok {
+				// This might happen if a table is dropped between the tables query and the metadata queries.
+				c.logger.Warn("no bulk metadata rows for table", "schema", table.schema, "table", table.tableName)
+				continue
+			}
+
+			b64Spec, err := encodeTableSpec(spec)
+			if err != nil {
+				c.logger.Error("failed to marshal table spec", "schema", table.schema, "table", table.tableName, "err", err)
+				continue
+			}
+			table.b64TableSpec = b64Spec
+
+			c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
+				logging.LevelInfo,
+				OP_CREATE_STATEMENT,
+				fmt.Sprintf(
+					`database="%s" schema="%s" table="%s" table_spec="%s"`,
+					table.database, table.schema, table.tableName, table.b64TableSpec,
+				),
+			)
+			c.lastEmittedAt[fullyQualifiedName(table.schema, table.tableName)] = now
+		}
 	}
 
 	return nil
+}
+
+// encodeTableSpec serializes a tableSpec to base64-encoded JSON.
+func encodeTableSpec(spec *tableSpec) (string, error) {
+	jsonSpec, err := json.Marshal(spec)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(jsonSpec), nil
+}
+
+// fetchSchemaSpecs runs three queries scoped to (schema, tableNames) to fetch
+// columns, indexes and foreign keys for the given tables in bulk and groups
+// the rows by table name. The returned map is keyed by table name; tables
+// with no rows in any of the three result sets are absent.
+func (c *SchemaDetails) fetchSchemaSpecs(ctx context.Context, schema string, tableNames []string) (map[string]*tableSpec, error) {
+	specs := map[string]*tableSpec{}
+	if len(tableNames) == 0 {
+		return specs, nil
+	}
+
+	specOf := func(name string) *tableSpec {
+		s, ok := specs[name]
+		if !ok {
+			s = &tableSpec{Columns: []columnSpec{}}
+			specs[name] = s
+		}
+		return s
+	}
+
+	colRS, err := c.dbConnection.QueryContext(ctx, fmt.Sprintf(selectColumnsTemplate, database_observability.BuildExclusionClause(tableNames)), schema)
+	if err != nil {
+		c.logger.Error("failed to query schema columns", "schema", schema, "err", err)
+		return nil, err
+	}
+	defer colRS.Close()
+
+	for colRS.Next() {
+		var tableName, columnName, columnType string
+		var isNullable, isIdentity, isPrimaryKey bool
+		var defaultValue sql.NullString
+		if err := colRS.Scan(&tableName, &columnName, &columnType, &isNullable, &isIdentity, &defaultValue, &isPrimaryKey); err != nil {
+			c.logger.Error("failed to scan schema columns", "schema", schema, "err", err)
+			return nil, err
+		}
+
+		defaultVal := ""
+		if defaultValue.Valid {
+			defaultVal = defaultValue.String
+		}
+
+		spec := specOf(tableName)
+		spec.Columns = append(spec.Columns, columnSpec{
+			Name:          columnName,
+			Type:          columnType,
+			NotNull:       !isNullable,
+			AutoIncrement: isIdentity,
+			PrimaryKey:    isPrimaryKey,
+			DefaultValue:  defaultVal,
+		})
+	}
+
+	if err := colRS.Err(); err != nil {
+		c.logger.Error("failed to iterate over schema columns result set", "schema", schema, "err", err)
+		return nil, err
+	}
+
+	idxRS, err := c.dbConnection.QueryContext(ctx, fmt.Sprintf(selectIndexesTemplate, database_observability.BuildExclusionClause(tableNames)), schema)
+	if err != nil {
+		c.logger.Error("failed to query schema indexes", "schema", schema, "err", err)
+		return nil, err
+	}
+	defer idxRS.Close()
+
+	// Track the table whose last appended index we may merge into. When the
+	// table changes we always treat the next index row as a new index, even if
+	// the index name happens to match.
+	var lastTable string
+	for idxRS.Next() {
+		var tableName, indexName, columnName, indexType string
+		var seqInIndex int
+		var isUnique, isNullable bool
+		if err := idxRS.Scan(&tableName, &indexName, &seqInIndex, &columnName, &indexType, &isUnique, &isNullable); err != nil {
+			c.logger.Error("failed to scan schema indexes", "schema", schema, "err", err)
+			return nil, err
+		}
+
+		spec := specOf(tableName)
+
+		// Append column to the last index if it's the same as the previous one
+		// within the same table (i.e. multi-column index).
+		if tableName == lastTable {
+			if nIndexes := len(spec.Indexes); nIndexes > 0 && spec.Indexes[nIndexes-1].Name == indexName {
+				lastIndex := &spec.Indexes[nIndexes-1]
+				if len(lastIndex.Columns) != seqInIndex-1 {
+					c.logger.Error("unexpected index ordinal position", "schema", schema, "table", tableName, "index", indexName, "seq", seqInIndex, "len_columns", len(lastIndex.Columns))
+					continue
+				}
+				lastIndex.Columns = append(lastIndex.Columns, columnName)
+				lastIndex.Nullable = lastIndex.Nullable || isNullable
+				continue
+			}
+		}
+
+		spec.Indexes = append(spec.Indexes, indexSpec{
+			Name:     indexName,
+			Type:     indexType,
+			Unique:   isUnique,
+			Nullable: isNullable,
+			Columns:  []string{columnName},
+		})
+		lastTable = tableName
+	}
+
+	if err := idxRS.Err(); err != nil {
+		c.logger.Error("failed to iterate over schema indexes result set", "schema", schema, "err", err)
+		return nil, err
+	}
+
+	fkRS, err := c.dbConnection.QueryContext(ctx, fmt.Sprintf(selectForeignKeysTemplate, database_observability.BuildExclusionClause(tableNames)), schema)
+	if err != nil {
+		c.logger.Error("failed to query schema foreign keys", "schema", schema, "err", err)
+		return nil, err
+	}
+	defer fkRS.Close()
+
+	for fkRS.Next() {
+		var tableName, constraintName, columnName, referencedTableName, referencedColumnName string
+		if err := fkRS.Scan(&tableName, &constraintName, &columnName, &referencedTableName, &referencedColumnName); err != nil {
+			c.logger.Error("failed to scan schema foreign keys", "schema", schema, "err", err)
+			return nil, err
+		}
+
+		spec := specOf(tableName)
+		spec.ForeignKeys = append(spec.ForeignKeys, foreignKey{
+			Name:                 constraintName,
+			ColumnName:           columnName,
+			ReferencedTableName:  referencedTableName,
+			ReferencedColumnName: referencedColumnName,
+		})
+	}
+
+	if err := fkRS.Err(); err != nil {
+		c.logger.Error("failed to iterate over schema foreign keys result set", "schema", schema, "err", err)
+		return nil, err
+	}
+
+	return specs, nil
+}
+
+func fullyQualifiedName(schema, table string) string {
+	return fmt.Sprintf("[%s].[%s]", schema, table)
 }

--- a/internal/component/database_observability/sql_server/collector/schema_details_test.go
+++ b/internal/component/database_observability/sql_server/collector/schema_details_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"encoding/base64"
 	"fmt"
 	"testing"
 	"time"
@@ -11,13 +12,14 @@ import (
 	"go.uber.org/goleak"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/component/database_observability"
 	"github.com/grafana/alloy/internal/util"
 )
 
 func TestSchemaDetails(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	t.Run("detect tables", func(t *testing.T) {
+	t.Run("detect table schema", func(t *testing.T) {
 		t.Parallel()
 
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
@@ -47,11 +49,51 @@ func TestSchemaDetails(t *testing.T) {
 					"dbo",
 					"some_table",
 					"BASE TABLE",
+				),
+			)
+
+		mock.ExpectQuery(fmt.Sprintf(selectColumnsTemplate, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("dbo").RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"table_name",
+					"column_name",
+					"column_type",
+					"is_nullable",
+					"is_identity",
+					"default_value",
+					"is_primary_key",
+				}).AddRow(
+					"some_table", "id", "int", false, true, nil, true,
 				).AddRow(
-					"some_db",
-					"dbo",
-					"some_view",
-					"VIEW",
+					"some_table", "category", "int", false, false, nil, false,
+				),
+			)
+
+		mock.ExpectQuery(fmt.Sprintf(selectIndexesTemplate, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("dbo").RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"table_name",
+					"index_name",
+					"seq_in_index",
+					"column_name",
+					"index_type",
+					"is_unique",
+					"is_nullable",
+				}).AddRow(
+					"some_table", "PK_some_table", 1, "id", "CLUSTERED", true, false,
+				),
+			)
+
+		mock.ExpectQuery(fmt.Sprintf(selectForeignKeysTemplate, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("dbo").RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"table_name",
+					"constraint_name",
+					"column_name",
+					"referenced_table_name",
+					"referenced_column_name",
+				}).AddRow(
+					"some_table", "fk_name", "category", "categories", "id",
 				),
 			)
 
@@ -71,11 +113,544 @@ func TestSchemaDetails(t *testing.T) {
 
 		require.NoError(t, mock.ExpectationsWereMet())
 
+		expectedTableSpec := base64.StdEncoding.EncodeToString([]byte(`{"columns":[{"name":"id","type":"int","not_null":true,"auto_increment":true,"primary_key":true},{"name":"category","type":"int","not_null":true}],"indexes":[{"name":"PK_some_table","type":"CLUSTERED","columns":["id"],"unique":true,"nullable":false}],"foreign_keys":[{"name":"fk_name","column_name":"category","referenced_table_name":"categories","referenced_column_name":"id"}]}`))
+
 		entries := lokiClient.Received()
 		require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, entries[0].Labels)
 		require.Equal(t, `level="info" database="some_db" schema="dbo" table="some_table"`, entries[0].Line)
+		require.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, entries[1].Labels)
+		require.Equal(t, fmt.Sprintf(`level="info" database="some_db" schema="dbo" table="some_table" table_spec="%s"`, expectedTableSpec), entries[1].Line)
+	})
+
+	t.Run("detect view schema", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki.NewCollectingHandler()
+
+		collector, err := NewSchemaDetails(SchemaDetailsArguments{
+			DB:              db,
+			CollectInterval: time.Millisecond,
+			EntryHandler:    lokiClient,
+			Logger:          util.TestAlloyLogger(t).Slog(),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+
+		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"TABLE_CATALOG",
+					"TABLE_SCHEMA",
+					"TABLE_NAME",
+					"TABLE_TYPE",
+				}).AddRow(
+					"some_db",
+					"dbo",
+					"some_view",
+					"VIEW",
+				),
+			)
+
+		mock.ExpectQuery(fmt.Sprintf(selectColumnsTemplate, database_observability.BuildExclusionClause([]string{"some_view"}))).WithArgs("dbo").RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"table_name",
+					"column_name",
+					"column_type",
+					"is_nullable",
+					"is_identity",
+					"default_value",
+					"is_primary_key",
+				}).AddRow(
+					"some_view", "id", "int", true, false, nil, false,
+				),
+			)
+
+		mock.ExpectQuery(fmt.Sprintf(selectIndexesTemplate, database_observability.BuildExclusionClause([]string{"some_view"}))).WithArgs("dbo").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "index_name", "seq_in_index", "column_name",
+				"index_type", "is_unique", "is_nullable",
+			}))
+
+		mock.ExpectQuery(fmt.Sprintf(selectForeignKeysTemplate, database_observability.BuildExclusionClause([]string{"some_view"}))).WithArgs("dbo").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "constraint_name", "column_name",
+				"referenced_table_name", "referenced_column_name",
+			}))
+
+		err = collector.Start(t.Context())
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 2
+		}, 5*time.Second, 100*time.Millisecond)
+
+		collector.Stop()
+		lokiClient.Stop()
+
+		require.Eventually(t, func() bool {
+			return collector.Stopped()
+		}, 5*time.Second, 100*time.Millisecond)
+
+		require.NoError(t, mock.ExpectationsWereMet())
+
+		expectedTableSpec := base64.StdEncoding.EncodeToString([]byte(`{"columns":[{"name":"id","type":"int"}]}`))
+
+		entries := lokiClient.Received()
+		require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, entries[0].Labels)
+		require.Equal(t, `level="info" database="some_db" schema="dbo" table="some_view"`, entries[0].Line)
+		require.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, entries[1].Labels)
+		require.Equal(t, fmt.Sprintf(`level="info" database="some_db" schema="dbo" table="some_view" table_spec="%s"`, expectedTableSpec), entries[1].Line)
+	})
+
+	t.Run("detect table with multi-column index", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki.NewCollectingHandler()
+
+		collector, err := NewSchemaDetails(SchemaDetailsArguments{
+			DB:              db,
+			CollectInterval: time.Millisecond,
+			EntryHandler:    lokiClient,
+			Logger:          util.TestAlloyLogger(t).Slog(),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+
+		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME", "TABLE_TYPE",
+				}).AddRow("some_db", "dbo", "some_table", "BASE TABLE"),
+			)
+
+		mock.ExpectQuery(fmt.Sprintf(selectColumnsTemplate, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("dbo").RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"table_name", "column_name", "column_type", "is_nullable",
+					"is_identity", "default_value", "is_primary_key",
+				}).
+					AddRow("some_table", "id", "int", false, false, nil, true).
+					AddRow("some_table", "name", "varchar", true, false, nil, false),
+			)
+
+		mock.ExpectQuery(fmt.Sprintf(selectIndexesTemplate, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("dbo").RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"table_name", "index_name", "seq_in_index", "column_name",
+					"index_type", "is_unique", "is_nullable",
+				}).
+					AddRow("some_table", "PK_some_table", 1, "id", "CLUSTERED", true, false).
+					AddRow("some_table", "idx_name", 1, "id", "NONCLUSTERED", false, false).
+					AddRow("some_table", "idx_name", 2, "name", "NONCLUSTERED", false, true),
+			)
+
+		mock.ExpectQuery(fmt.Sprintf(selectForeignKeysTemplate, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("dbo").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "constraint_name", "column_name",
+				"referenced_table_name", "referenced_column_name",
+			}))
+
+		err = collector.Start(t.Context())
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 2
+		}, 5*time.Second, 100*time.Millisecond)
+
+		collector.Stop()
+		lokiClient.Stop()
+
+		require.Eventually(t, func() bool {
+			return collector.Stopped()
+		}, 5*time.Second, 100*time.Millisecond)
+
+		require.NoError(t, mock.ExpectationsWereMet())
+
+		expectedTableSpec := base64.StdEncoding.EncodeToString([]byte(`{"columns":[{"name":"id","type":"int","not_null":true,"primary_key":true},{"name":"name","type":"varchar"}],"indexes":[{"name":"PK_some_table","type":"CLUSTERED","columns":["id"],"unique":true,"nullable":false},{"name":"idx_name","type":"NONCLUSTERED","columns":["id","name"],"unique":false,"nullable":true}]}`))
+
+		entries := lokiClient.Received()
+		require.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, entries[1].Labels)
+		require.Equal(t, fmt.Sprintf(`level="info" database="some_db" schema="dbo" table="some_table" table_spec="%s"`, expectedTableSpec), entries[1].Line)
+	})
+
+	t.Run("detect tables across multiple schemas in one bulk query", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki.NewCollectingHandler()
+
+		collector, err := NewSchemaDetails(SchemaDetailsArguments{
+			DB:              db,
+			CollectInterval: time.Millisecond,
+			EntryHandler:    lokiClient,
+			Logger:          util.TestAlloyLogger(t).Slog(),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+
+		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{
+					"TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME", "TABLE_TYPE",
+				}).
+					AddRow("some_db", "schema_a", "table_a", "BASE TABLE").
+					AddRow("some_db", "schema_b", "table_b", "BASE TABLE"),
+			)
+
+		// Per-schema follow-ups for both schemas.
+		for _, tc := range []struct{ schema, table string }{
+			{"schema_a", "table_a"},
+			{"schema_b", "table_b"},
+		} {
+			mock.ExpectQuery(fmt.Sprintf(selectColumnsTemplate, database_observability.BuildExclusionClause([]string{tc.table}))).WithArgs(tc.schema).RowsWillBeClosed().
+				WillReturnRows(
+					sqlmock.NewRows([]string{
+						"table_name", "column_name", "column_type", "is_nullable",
+						"is_identity", "default_value", "is_primary_key",
+					}).AddRow(tc.table, "id", "int", false, false, nil, true),
+				)
+
+			mock.ExpectQuery(fmt.Sprintf(selectIndexesTemplate, database_observability.BuildExclusionClause([]string{tc.table}))).WithArgs(tc.schema).RowsWillBeClosed().
+				WillReturnRows(sqlmock.NewRows([]string{
+					"table_name", "index_name", "seq_in_index", "column_name",
+					"index_type", "is_unique", "is_nullable",
+				}))
+
+			mock.ExpectQuery(fmt.Sprintf(selectForeignKeysTemplate, database_observability.BuildExclusionClause([]string{tc.table}))).WithArgs(tc.schema).RowsWillBeClosed().
+				WillReturnRows(sqlmock.NewRows([]string{
+					"table_name", "constraint_name", "column_name",
+					"referenced_table_name", "referenced_column_name",
+				}))
+		}
+
+		err = collector.Start(t.Context())
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 4
+		}, 5*time.Second, 100*time.Millisecond)
+
+		collector.Stop()
+		lokiClient.Stop()
+
+		require.Eventually(t, func() bool {
+			return collector.Stopped()
+		}, 5*time.Second, 100*time.Millisecond)
+
+		require.NoError(t, mock.ExpectationsWereMet())
+
+		entries := lokiClient.Received()
+		require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, entries[0].Labels)
+		require.Equal(t, `level="info" database="some_db" schema="schema_a" table="table_a"`, entries[0].Line)
 		require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, entries[1].Labels)
-		require.Equal(t, `level="info" database="some_db" schema="dbo" table="some_view"`, entries[1].Line)
+		require.Equal(t, `level="info" database="some_db" schema="schema_b" table="table_b"`, entries[1].Line)
+		require.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, entries[2].Labels)
+		require.Contains(t, entries[2].Line, `schema="schema_a" table="table_a"`)
+		require.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, entries[3].Labels)
+		require.Contains(t, entries[3].Line, `schema="schema_b" table="table_b"`)
+	})
+
+	t.Run("second scrape within emit_interval emits OP_TABLE_DETECTION but not OP_CREATE_STATEMENT", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki.NewCollectingHandler()
+		defer lokiClient.Stop()
+
+		fakeNow := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+		collector, err := NewSchemaDetails(SchemaDetailsArguments{
+			DB:           db,
+			EntryHandler: lokiClient,
+			Logger:       util.TestAlloyLogger(t).Slog(),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+		collector.now = func() time.Time { return fakeNow }
+
+		// First scrape: tables list + metadata queries.
+		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME", "TABLE_TYPE",
+			}).AddRow("some_db", "dbo", "some_table", "BASE TABLE"))
+
+		mock.ExpectQuery(fmt.Sprintf(selectColumnsTemplate, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("dbo").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "column_name", "column_type", "is_nullable",
+				"is_identity", "default_value", "is_primary_key",
+			}).AddRow("some_table", "id", "int", false, true, nil, true))
+
+		mock.ExpectQuery(fmt.Sprintf(selectIndexesTemplate, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("dbo").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "index_name", "seq_in_index", "column_name",
+				"index_type", "is_unique", "is_nullable",
+			}).AddRow("some_table", "PK_some_table", 1, "id", "CLUSTERED", true, false))
+
+		mock.ExpectQuery(fmt.Sprintf(selectForeignKeysTemplate, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("dbo").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "constraint_name", "column_name",
+				"referenced_table_name", "referenced_column_name",
+			}))
+
+		// Second scrape: only the tables list. The scrape is throttled (still
+		// within emitInterval) so it must not trigger any metadata queries.
+		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME", "TABLE_TYPE",
+			}).AddRow("some_db", "dbo", "some_table", "BASE TABLE"))
+
+		require.NoError(t, collector.extractSchema(t.Context()))
+		fakeNow = fakeNow.Add(time.Minute) // well within emitInterval
+		require.NoError(t, collector.extractSchema(t.Context()))
+
+		// First scrape emits OP_TABLE_DETECTION + OP_CREATE_STATEMENT; second
+		// scrape emits only OP_TABLE_DETECTION (still emitted on every scrape).
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 3
+		}, 5*time.Second, 10*time.Millisecond)
+
+		require.NoError(t, mock.ExpectationsWereMet())
+
+		entries := lokiClient.Received()
+		require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, entries[0].Labels)
+		require.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, entries[1].Labels)
+		require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, entries[2].Labels)
+	})
+
+	t.Run("second scrape after emit_interval re-emits OP_CREATE_STATEMENT", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki.NewCollectingHandler()
+		defer lokiClient.Stop()
+
+		fakeNow := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+		collector, err := NewSchemaDetails(SchemaDetailsArguments{
+			DB:              db,
+			CollectInterval: time.Hour,
+			EntryHandler:    lokiClient,
+			Logger:          util.TestAlloyLogger(t).Slog(),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+		collector.now = func() time.Time { return fakeNow }
+
+		// Two scrapes' worth of expectations.
+		for i := 0; i < 2; i++ {
+			mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+				WillReturnRows(sqlmock.NewRows([]string{
+					"TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME", "TABLE_TYPE",
+				}).AddRow("some_db", "dbo", "some_table", "BASE TABLE"))
+
+			mock.ExpectQuery(fmt.Sprintf(selectColumnsTemplate, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("dbo").RowsWillBeClosed().
+				WillReturnRows(sqlmock.NewRows([]string{
+					"table_name", "column_name", "column_type", "is_nullable",
+					"is_identity", "default_value", "is_primary_key",
+				}).AddRow("some_table", "id", "int", false, true, nil, true))
+
+			mock.ExpectQuery(fmt.Sprintf(selectIndexesTemplate, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("dbo").RowsWillBeClosed().
+				WillReturnRows(sqlmock.NewRows([]string{
+					"table_name", "index_name", "seq_in_index", "column_name",
+					"index_type", "is_unique", "is_nullable",
+				}).AddRow("some_table", "PK_some_table", 1, "id", "CLUSTERED", true, false))
+
+			mock.ExpectQuery(fmt.Sprintf(selectForeignKeysTemplate, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("dbo").RowsWillBeClosed().
+				WillReturnRows(sqlmock.NewRows([]string{
+					"table_name", "constraint_name", "column_name",
+					"referenced_table_name", "referenced_column_name",
+				}))
+		}
+
+		require.NoError(t, collector.extractSchema(t.Context()))
+		fakeNow = fakeNow.Add(emitInterval + time.Minute) // past the throttle window
+		require.NoError(t, collector.extractSchema(t.Context()))
+
+		require.Eventually(t, func() bool {
+			return len(lokiClient.Received()) == 4
+		}, 5*time.Second, 10*time.Millisecond)
+
+		require.NoError(t, mock.ExpectationsWereMet())
+
+		entries := lokiClient.Received()
+		require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, entries[0].Labels)
+		require.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, entries[1].Labels)
+		require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, entries[2].Labels)
+		require.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, entries[3].Labels)
+	})
+
+	t.Run("table dropped between scrapes is removed from throttle map", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki.NewCollectingHandler()
+		defer lokiClient.Stop()
+
+		fakeNow := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+		collector, err := NewSchemaDetails(SchemaDetailsArguments{
+			DB:              db,
+			CollectInterval: time.Hour,
+			EntryHandler:    lokiClient,
+			Logger:          util.TestAlloyLogger(t).Slog(),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+		collector.now = func() time.Time { return fakeNow }
+
+		// First scrape: two tables in the same schema.
+		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME", "TABLE_TYPE",
+			}).
+				AddRow("some_db", "dbo", "table_a", "BASE TABLE").
+				AddRow("some_db", "dbo", "table_b", "BASE TABLE"))
+
+		mock.ExpectQuery(fmt.Sprintf(selectColumnsTemplate, database_observability.BuildExclusionClause([]string{"table_a", "table_b"}))).WithArgs("dbo").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "column_name", "column_type", "is_nullable",
+				"is_identity", "default_value", "is_primary_key",
+			}).
+				AddRow("table_a", "id", "int", false, true, nil, true).
+				AddRow("table_b", "id", "int", false, true, nil, true))
+
+		mock.ExpectQuery(fmt.Sprintf(selectIndexesTemplate, database_observability.BuildExclusionClause([]string{"table_a", "table_b"}))).WithArgs("dbo").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "index_name", "seq_in_index", "column_name",
+				"index_type", "is_unique", "is_nullable",
+			}))
+
+		mock.ExpectQuery(fmt.Sprintf(selectForeignKeysTemplate, database_observability.BuildExclusionClause([]string{"table_a", "table_b"}))).WithArgs("dbo").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "constraint_name", "column_name",
+				"referenced_table_name", "referenced_column_name",
+			}))
+
+		require.NoError(t, collector.extractSchema(t.Context()))
+		require.Contains(t, collector.lastEmittedAt, fullyQualifiedName("dbo", "table_a"))
+		require.Contains(t, collector.lastEmittedAt, fullyQualifiedName("dbo", "table_b"))
+
+		// Second scrape: only table_a remains. table_b should be evicted from
+		// the throttle map. Since table_a is still within emitInterval, no
+		// metadata queries are expected.
+		fakeNow = fakeNow.Add(time.Minute)
+		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME", "TABLE_TYPE",
+			}).AddRow("some_db", "dbo", "table_a", "BASE TABLE"))
+
+		require.NoError(t, collector.extractSchema(t.Context()))
+
+		require.NoError(t, mock.ExpectationsWereMet())
+		require.Contains(t, collector.lastEmittedAt, fullyQualifiedName("dbo", "table_a"))
+		require.NotContains(t, collector.lastEmittedAt, fullyQualifiedName("dbo", "table_b"))
+	})
+
+	t.Run("bulk metadata returns no rows for a table", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki.NewCollectingHandler()
+
+		collector, err := NewSchemaDetails(SchemaDetailsArguments{
+			DB:              db,
+			CollectInterval: time.Millisecond,
+			EntryHandler:    lokiClient,
+			Logger:          util.TestAlloyLogger(t).Slog(),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+
+		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME", "TABLE_TYPE",
+			}).AddRow("some_db", "dbo", "some_table", "BASE TABLE"))
+
+		// All three per-schema queries return empty result sets, simulating a
+		// table that was dropped between the tables query and the metadata
+		// queries. The table is skipped: only OP_TABLE_DETECTION is emitted
+		// and no OP_CREATE_STATEMENT follows.
+		mock.ExpectQuery(fmt.Sprintf(selectColumnsTemplate, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("dbo").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "column_name", "column_type", "is_nullable",
+				"is_identity", "default_value", "is_primary_key",
+			}))
+		mock.ExpectQuery(fmt.Sprintf(selectIndexesTemplate, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("dbo").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "index_name", "seq_in_index", "column_name",
+				"index_type", "is_unique", "is_nullable",
+			}))
+		mock.ExpectQuery(fmt.Sprintf(selectForeignKeysTemplate, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("dbo").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "constraint_name", "column_name",
+				"referenced_table_name", "referenced_column_name",
+			}))
+
+		// No OP_CREATE_STATEMENT means no loki-side sync point; drive
+		// extractSchema synchronously to avoid racing the collector loop.
+		require.NoError(t, collector.extractSchema(t.Context()))
+		require.NoError(t, mock.ExpectationsWereMet())
+
+		lokiClient.Stop()
+
+		entries := lokiClient.Received()
+		require.Len(t, entries, 1)
+		require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, entries[0].Labels)
+		require.Equal(t, `level="info" database="some_db" schema="dbo" table="some_table"`, entries[0].Line)
+	})
+
+	t.Run("empty tables list clears throttle map", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki.NewCollectingHandler()
+		defer lokiClient.Stop()
+
+		collector, err := NewSchemaDetails(SchemaDetailsArguments{
+			DB:              db,
+			CollectInterval: time.Hour,
+			EntryHandler:    lokiClient,
+			Logger:          util.TestAlloyLogger(t).Slog(),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+
+		// Pre-populate the throttle map to simulate a table that was emitted
+		// in a previous scrape but no longer exists in INFORMATION_SCHEMA.TABLES.
+		collector.lastEmittedAt[fullyQualifiedName("dbo", "stale_table")] = time.Now()
+
+		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME", "TABLE_TYPE",
+			}))
+
+		require.NoError(t, collector.extractSchema(t.Context()))
+		require.NoError(t, mock.ExpectationsWereMet())
+		require.Empty(t, collector.lastEmittedAt)
 	})
 
 	t.Run("no tables detected", func(t *testing.T) {
@@ -212,11 +787,29 @@ func TestSchemaDetails(t *testing.T) {
 			),
 		)
 
+		mock.ExpectQuery(fmt.Sprintf(selectColumnsTemplate, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("dbo").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "column_name", "column_type", "is_nullable",
+				"is_identity", "default_value", "is_primary_key",
+			}).AddRow("some_table", "id", "int", false, true, nil, true))
+
+		mock.ExpectQuery(fmt.Sprintf(selectIndexesTemplate, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("dbo").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "index_name", "seq_in_index", "column_name",
+				"index_type", "is_unique", "is_nullable",
+			}).AddRow("some_table", "PK_some_table", 1, "id", "CLUSTERED", true, false))
+
+		mock.ExpectQuery(fmt.Sprintf(selectForeignKeysTemplate, database_observability.BuildExclusionClause([]string{"some_table"}))).WithArgs("dbo").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "constraint_name", "column_name",
+				"referenced_table_name", "referenced_column_name",
+			}))
+
 		err = collector.Start(t.Context())
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
-			return len(lokiClient.Received()) == 1
+			return len(lokiClient.Received()) == 2
 		}, 5*time.Second, 100*time.Millisecond)
 
 		collector.Stop()
@@ -226,9 +819,13 @@ func TestSchemaDetails(t *testing.T) {
 			return collector.Stopped()
 		}, 5*time.Second, 100*time.Millisecond)
 
+		expectedTableSpec := base64.StdEncoding.EncodeToString([]byte(`{"columns":[{"name":"id","type":"int","not_null":true,"auto_increment":true,"primary_key":true}],"indexes":[{"name":"PK_some_table","type":"CLUSTERED","columns":["id"],"unique":true,"nullable":false}]}`))
+
 		entries := lokiClient.Received()
 		require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, entries[0].Labels)
 		require.Equal(t, `level="info" database="some_db" schema="dbo" table="some_table"`, entries[0].Line)
+		require.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, entries[1].Labels)
+		require.Equal(t, fmt.Sprintf(`level="info" database="some_db" schema="dbo" table="some_table" table_spec="%s"`, expectedTableSpec), entries[1].Line)
 	})
 }
 


### PR DESCRIPTION
### Brief description of Pull Request
Extend the `schema_details` collector to emit `op="create_statement"` and to implement a throttling mechanism similar to collectors for other engines.

This is still missing the ability to cycle across databases, which I'll followup on.

Followup of https://github.com/grafana/alloy/pull/6624

### Pull Request Details

<!-- Detailed descripion of the Pull Request, if needed. -->


### Issue(s) fixed by this Pull Request
Relates to https://github.com/grafana/grafana-dbo11y-app/issues/3016


### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
