### PR TITLE
fix(otelcol): Limit component shutdown timeout during hot-reload

### DIFF
--- a/internal/component/otelcol/internal/scheduler/scheduler.go
+++ b/internal/component/otelcol/internal/scheduler/scheduler.go
@@ -15,6 +15,16 @@ import (
 	"github.com/grafana/alloy/internal/component"
 )
 
+// DefaultShutdownTimeout is the default maximum time to wait for a component
+// to shut down during a hot-reload (Schedule call). This prevents a component
+// whose Shutdown() blocks (e.g. a gRPC server draining long-lived connections)
+// from hanging /-/reload indefinitely.
+//
+// Note: this timeout only applies to the hot-reload path (Schedule). The final
+// shutdown triggered by Run() cancellation always uses context.Background() so
+// Alloy can drain gracefully on process exit.
+const DefaultShutdownTimeout = 30 * time.Second
+
 // Scheduler implements manages a set of OpenTelemetry Collector components.
 // Scheduler is intended to be used from Alloy components which need to
 // schedule OpenTelemetry Collector components; it does not implement the full
@@ -42,15 +52,23 @@ type Scheduler struct {
 	onPause func()
 	// onResume is called when scheduler is done making changes to running components.
 	onResume func()
+
+	// shutdownTimeout is the maximum duration to wait for components to shut
+	// down during a hot-reload (Schedule). 0 means wait forever (no timeout).
+	shutdownTimeout time.Duration
 }
 
 // New creates a new unstarted Scheduler. Call Run to start it, and call
 // Schedule to schedule components to run.
+//
+// The scheduler uses DefaultShutdownTimeout when stopping components during a
+// hot-reload.
 func New(l *slog.Logger) *Scheduler {
 	return &Scheduler{
-		log:      l,
-		onPause:  func() {},
-		onResume: func() {},
+		log:             l,
+		onPause:         func() {},
+		onResume:        func() {},
+		shutdownTimeout: DefaultShutdownTimeout,
 	}
 }
 
@@ -62,10 +80,23 @@ func New(l *slog.Logger) *Scheduler {
 // The scheduler is assumed to start paused; Schedule() won't call onPause() if Run() was never ran.
 func NewWithPauseCallbacks(l *slog.Logger, onPause func(), onResume func()) *Scheduler {
 	return &Scheduler{
-		log:      l,
-		onPause:  onPause,
-		onResume: onResume,
+		log:             l,
+		onPause:         onPause,
+		onResume:        onResume,
+		shutdownTimeout: DefaultShutdownTimeout,
 	}
+}
+
+// SetShutdownTimeout overrides the maximum time that Schedule() will wait for
+// old components to shut down during a hot-reload. A value of 0 disables the
+// timeout (components are allowed to block indefinitely).
+//
+// SetShutdownTimeout is intended for testing. Production callers should rely on
+// the default set by New or NewWithPauseCallbacks.
+func (cs *Scheduler) SetShutdownTimeout(d time.Duration) {
+	cs.schedMut.Lock()
+	defer cs.schedMut.Unlock()
+	cs.shutdownTimeout = d
 }
 
 // Schedule a new set of OpenTelemetry Components to run.
@@ -103,8 +134,19 @@ func (cs *Scheduler) Schedule(ctx context.Context, updateConsumers func(), h ote
 	// This prevents them from accepting new data while we're shutting them down.
 	cs.onPause()
 
-	// 2. Stop the old components
-	stopComponents(ctx, cs.log, cs.schedComponents...)
+	// 2. Stop the old components.
+	// Use a bounded context so that a component whose Shutdown() blocks (e.g. a
+	// gRPC server draining long-lived connections) cannot hang a hot-reload
+	// indefinitely. The caller's ctx is kept for reference but we always derive
+	// the stop context from context.Background() so cancellation of ctx (e.g.
+	// the component being torn down) does not race with shutdown here.
+	stopCtx := ctx
+	var stopCancel context.CancelFunc
+	if cs.shutdownTimeout > 0 {
+		stopCtx, stopCancel = context.WithTimeout(context.Background(), cs.shutdownTimeout)
+		defer stopCancel()
+	}
+	stopComponents(stopCtx, cs.log, cs.schedComponents...)
 
 	// 3. Change the consumers
 	// This can only be done after stopping the previous components and before starting the new ones.

--- a/internal/component/otelcol/internal/scheduler/scheduler_test.go
+++ b/internal/component/otelcol/internal/scheduler/scheduler_test.go
@@ -148,6 +148,74 @@ func TestScheduler(t *testing.T) {
 		cancel()
 		require.NoError(t, stopped.Wait(5*time.Second), "component did not shutdown")
 	})
+
+	// TestShutdownTimeout_HotReload verifies that when a component's Shutdown()
+	// blocks longer than shutdownTimeout, Schedule() still returns within a
+	// bounded time and the new component is successfully started. This is a
+	// regression test for https://github.com/grafana/alloy/issues/6622 where a
+	// blocking Shutdown (e.g. a gRPC server draining long-lived connections)
+	// caused /-/reload to hang indefinitely.
+	t.Run("Schedule returns promptly when old component Shutdown blocks (shutdownTimeout)", func(t *testing.T) {
+		const shutdownTimeout = 200 * time.Millisecond
+
+		var (
+			l  = util.TestAlloyLogger(t)
+			cs = scheduler.NewWithPauseCallbacks(l.Slog(), func() {}, func() {})
+			h  = scheduler.NewHost()
+		)
+		// Override the default shutdown timeout to something short for this test.
+		cs.SetShutdownTimeout(shutdownTimeout)
+
+		// Run our scheduler in the background.
+		go func() {
+			err := cs.Run(componenttest.TestContext(t))
+			require.NoError(t, err)
+		}()
+
+		// First, schedule a component that blocks on Shutdown (simulating a gRPC
+		// server with active long-lived connections configured with keepalive params).
+		blockingStarted := util.NewWaitTrigger()
+		shutdownCalled := util.NewWaitTrigger()
+		blockingComponent := &fakeComponent{
+			StartFunc: func(_ context.Context, _ otelcomponent.Host) error {
+				blockingStarted.Trigger()
+				return nil
+			},
+			ShutdownFunc: func(ctx context.Context) error {
+				// Signal that Shutdown was called, then block until the context
+				// provided by the scheduler (with shutdownTimeout) expires.
+				shutdownCalled.Trigger()
+				<-ctx.Done()
+				return ctx.Err()
+			},
+		}
+		cs.Schedule(t.Context(), func() {}, h, blockingComponent)
+
+		// Give the scheduler's Run() goroutine time to start the blocking component.
+		require.NoError(t, blockingStarted.Wait(5*time.Second))
+		// Wait just a bit to ensure Run() has fully started the component.
+		time.Sleep(50 * time.Millisecond)
+
+		// Hot-reload: schedule a new component. This calls Shutdown on the
+		// blocking component. With the timeout, Schedule must not block past
+		// shutdownTimeout.
+		newComponent, newStarted, _ := newTriggerComponent()
+
+		start := time.Now()
+		cs.Schedule(t.Context(), func() {}, h, newComponent)
+		elapsed := time.Since(start)
+
+		// Schedule should return within roughly shutdownTimeout + overhead,
+		// NOT after an indefinite wait.
+		assert.Less(t, elapsed, shutdownTimeout+2*time.Second,
+			"Schedule() took too long; Shutdown() may be blocking the hot-reload path")
+
+		// The new component must be started even though the old one's Shutdown blocked.
+		require.NoError(t, newStarted.Wait(5*time.Second), "new component did not start after hot-reload")
+
+		// Shutdown of the old component should have been called.
+		require.NoError(t, shutdownCalled.Wait(5*time.Second), "old component Shutdown was not called")
+	})
 }
 
 func newTriggerComponent() (component otelcomponent.Component, started, stopped *util.WaitTrigger) {


### PR DESCRIPTION
### Context
fix(otelcol): Limit component shutdown timeout during hot-reload

We resolved the issue where hot-reloading (via the `/-/reload` HTTP endpoint) could deadlock when an OpenTelemetry component (such as `otelcol.receiver.otlp` or `otelcol.receiver.jaeger`) takes too long to shut down (e.g., due to active gRPC connections draining or keepalive parameter timeouts).

### Automated Tests
Run the scheduler tests:
```bash
go test -tags="nodocker" ./internal/component/otelcol/internal/scheduler/...
```

