### PR TITLE
fix: Default syslog listen protocol to tcp when unset in promtail conversion

### DIFF
--- a/internal/converter/internal/promtailconvert/internal/build/syslog.go
+++ b/internal/converter/internal/promtailconvert/internal/build/syslog.go
@@ -40,6 +40,11 @@ func (s *ScrapeConfigBuilder) AppendSyslogConfig() {
 		listenerConfig.SyslogFormat = syslog.DefaultListenerConfig.SyslogFormat
 	}
 
+	// If the listen protocol is not set, use the default (promtail defaults to tcp).
+	if listenerConfig.ListenProtocol == "" {
+		listenerConfig.ListenProtocol = syslog.DefaultListenerConfig.ListenProtocol
+	}
+
 	if fmtOpts := s.cfg.SyslogConfig.RawFormatOptions; fmtOpts != nil {
 		listenerConfig.RawFormatOptions = &syslog.RawFormatOptions{
 			UseNullTerminatorDelimiter: fmtOpts.UseNullTerminatorDelimiter,

--- a/internal/converter/internal/promtailconvert/testdata/syslog.alloy
+++ b/internal/converter/internal/promtailconvert/testdata/syslog.alloy
@@ -85,6 +85,20 @@ loki.source.syslog "test_raw" {
 	relabel_rules = null
 }
 
+loki.source.syslog "test_default_protocol" {
+	listener {
+		address             = "localhost:4000"
+		protocol            = "tcp"
+		idle_timeout        = "1m0s"
+		labels              = {}
+		max_message_length  = 0
+		udp_queue_size      = 0
+		udp_host_cache_size = 0
+	}
+	forward_to    = [loki.write.default.receiver]
+	relabel_rules = null
+}
+
 loki.write "default" {
 	endpoint {
 		url = "http://localhost/loki/api/v1/push"

--- a/internal/converter/internal/promtailconvert/testdata/syslog.yaml
+++ b/internal/converter/internal/promtailconvert/testdata/syslog.yaml
@@ -45,6 +45,10 @@ scrape_configs:
       syslog_format: raw
       raw_format_options:
         use_null_terminator_delimiter: true
+  - job_name: test_default_protocol
+    syslog:
+      listen_address: localhost:4000
+      idle_timeout: 1m
 
 tracing: { enabled: false }
 server: { register_instrumentation: false }


### PR DESCRIPTION
### Brief description of Pull Request

Fixes the promtail-to-Alloy config converter so that a `syslog` scrape config with no `listen_protocol` set defaults to `tcp`, matching Promtail's actual default behavior, instead of converting to an empty/invalid protocol.

### Pull Request Details

`ScrapeConfigBuilder.AppendSyslogConfig` already defaulted the `syslog_format` field when unset, but not `listen_protocol`. When a Promtail config omitted `listen_protocol`, the converter would carry through an empty string instead of applying Promtail's default of `tcp`, which is not a valid value for `loki.source.syslog`'s `listener.protocol` argument.

This PR adds the same fallback for `listen_protocol` that already exists for `syslog_format`, defaulting to `syslog.DefaultListenerConfig.ListenProtocol` (`tcp`) when unset.

### Issue(s) fixed by this Pull Request

Fixes #6603

### Notes to the Reviewer

Added a new `test_default_protocol` job to the `syslog.yaml`/`syslog.alloy` converter testdata that omits `listen_protocol`/`listen_address` protocol entirely, asserting the converted `loki.source.syslog` component defaults `protocol` to `tcp`.

### PR Checklist

- [ ] Documentation added
- [x] Tests updated
- [x] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
