### PR TITLE
docs(pyroscope): Document scope labels added to profiles

### DIFF
--- a/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
@@ -203,11 +203,16 @@ You can use the `sample_rate` argument to define the number of stack traces coll
 The following labels are automatically injected into the collected profiles if you haven't defined them.
 These labels can help you pin down a profiling target.
 
-| Label              | Description                                                                                                                      |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| `__container_id__` | The container ID derived from target.                                                                                            |
-| `__name__`         | Pyroscope metric name. Defaults to `process_cpu`.                                                                                |
-| `service_name`     | Pyroscope service name. It's automatically selected from discovery meta labels if possible. Otherwise defaults to `unspecified`. |
+| Label                | Description                                                                                                                      |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `__container_id__`   | The container ID derived from target.                                                                                            |
+| `__name__`           | Pyroscope metric name. Defaults to `process_cpu`.                                                                                |
+| `service_name`       | Pyroscope service name. It's automatically selected from discovery meta labels if possible. Otherwise defaults to `unspecified`. |
+| `otel.scope.name`    | The instrumentation scope name, set to `com.grafana.alloy/pyroscope.ebpf`.                                                       |
+| `otel.scope.version` | The {{< param "PRODUCT_NAME" >}} version that produced the profile.                                                              |
+
+{{< param "PRODUCT_NAME" >}} only sets `otel.scope.name` and `otel.scope.version` if they aren't already present on the profile.
+`otel.scope.version` is only set when `otel.scope.name` matches the default value.
 
 ### Targets
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.java.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.java.md
@@ -111,6 +111,16 @@ If it's not specified, `pyroscope.scrape` will attempt to infer it from either o
 
 If `service_name` isn't specified and couldn't be inferred, then it's set to `unspecified`.
 
+The following labels are automatically injected into the collected profiles if you haven't defined them:
+
+| Label                | Description                                                                |
+| -------------------- | -------------------------------------------------------------------------- |
+| `otel.scope.name`    | The instrumentation scope name, set to `com.grafana.alloy/pyroscope.java`. |
+| `otel.scope.version` | The {{< param "PRODUCT_NAME" >}} version that produced the profile.        |
+
+{{< param "PRODUCT_NAME" >}} only sets `otel.scope.name` and `otel.scope.version` if they aren't already present on the profile.
+`otel.scope.version` is only set when `otel.scope.name` matches the default value.
+
 ## Blocks
 
 You can use the following block with `pyroscope.java`:

--- a/docs/sources/reference/components/pyroscope/pyroscope.scrape.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.scrape.md
@@ -120,11 +120,16 @@ If `service_name` isn't specified and couldn't be inferred, then it's set to `un
 
 The following labels are automatically injected to the scraped profiles so that they can be linked to a scrape target:
 
-| Label            | Description                                                      |
-| ---------------- | ---------------------------------------------------------------- |
-| `"job"`          | The `job_name` that the target belongs to.                       |
-| `"instance"`     | The `__address__` or `<host>:<port>` of the scrape target's URL. |
-| `"service_name"` | The inferred Pyroscope service name.                             |
+| Label                  | Description                                                                  |
+| ---------------------- | ----------------------------------------------------------------------------- |
+| `"job"`                | The `job_name` that the target belongs to.                                   |
+| `"instance"`           | The `__address__` or `<host>:<port>` of the scrape target's URL.             |
+| `"service_name"`       | The inferred Pyroscope service name.                                         |
+| `"otel.scope.name"`    | The instrumentation scope name, set to `com.grafana.alloy/pyroscope.scrape`. |
+| `"otel.scope.version"` | The {{< param "PRODUCT_NAME" >}} version that produced the profile.          |
+
+{{< param "PRODUCT_NAME" >}} only sets `otel.scope.name` and `otel.scope.version` if they aren't already present on the scraped profile.
+`otel.scope.version` is only set when `otel.scope.name` matches the default value.
 
 #### `scrape_interval`
 


### PR DESCRIPTION
## Summary

- Documents the `otel.scope.name` and `otel.scope.version` labels that `pyroscope.scrape`, `pyroscope.ebpf`, and `pyroscope.java` automatically inject into profiles, added in #6569.
- Follow-up to review feedback from @simonswine on #6569.

## Test plan

- Docs-only change; reviewed rendered tables for correct alignment and content in `pyroscope.scrape.md`, `pyroscope.ebpf.md`, and `pyroscope.java.md`.