### PR TITLE
prometheus.scrape: add labels_to_hash for stable cluster ownership

### DIFF
--- a/internal/component/prometheus/scrape/scrape.go
+++ b/internal/component/prometheus/scrape/scrape.go
@@ -431,7 +431,7 @@ func (c *Component) Run(ctx context.Context) error {
 
 func (c *Component) distributeTargets(targets []discovery.Target, jobName string, args Arguments) (map[string][]*targetgroup.Group, []*scrape.Target) {
 	var (
-		newDistTargets        = discovery.NewDistributedTargets(args.Clustering.Enabled, c.cluster, targets)
+		newDistTargets        = discovery.NewDistributedTargetsWithCustomLabels(args.Clustering.Enabled, c.cluster, targets, args.Clustering.LabelsToHash)
 		oldDistributedTargets *discovery.DistributedTargets
 	)
 

--- a/internal/component/prometheus/scrape/scrape_clustering_test.go
+++ b/internal/component/prometheus/scrape/scrape_clustering_test.go
@@ -383,3 +383,55 @@ func (f *fakeCluster) Peers() []peer.Peer {
 func (f *fakeCluster) Ready() bool {
 	return true
 }
+
+// TestLabelsToHash_VolatileLabelsIgnored verifies that setting LabelsToHash
+// makes two targets with identical stable labels but different volatile labels
+// (e.g. pre-signed URL params that change per node) hash to the same shard key
+// and be treated as the same logical target (issue #6484).
+//
+// Without LabelsToHash, the volatile __param_sig label enters the hash and
+// the two targets get different keys → one is owned locally, one remotely,
+// producing gaps or duplicates in a two-replica cluster.
+//
+// With LabelsToHash = ["__metrics_path__"], the volatile label is excluded and
+// both targets hash identically → consistent ownership on both replicas.
+func TestLabelsToHash_VolatileLabelsIgnored(t *testing.T) {
+	stablePath := "/__internal/db1/metrics"
+
+	// target A: what replica 1 sees after its discovery poll (sig=aaaa)
+	tgtA := discovery.Target{
+		"__address__":      "db.example.com:9104",
+		"__metrics_path__": stablePath,
+		"__param_sig":      "aaaa",
+		"__scheme__":       "https",
+	}
+	// target B: what replica 2 sees — identical except the rotating signature
+	tgtB := discovery.Target{
+		"__address__":      "db.example.com:9104",
+		"__metrics_path__": stablePath,
+		"__param_sig":      "bbbb",
+		"__scheme__":       "https",
+	}
+
+	t.Run("without LabelsToHash volatile labels cause different hash", func(t *testing.T) {
+		dt := discovery.NewDistributedTargets(true, nil, []discovery.Target{tgtA, tgtB})
+		// When clustering is enabled but cluster is nil, disabledCluster is used
+		// and all targets are assigned locally — but both must appear as separate
+		// targets because they hash differently.
+		require.Equal(t, 2, dt.TargetCount(),
+			"targets with different volatile labels must be treated as distinct (old behaviour)")
+	})
+
+	t.Run("with LabelsToHash volatile labels are ignored", func(t *testing.T) {
+		dt := discovery.NewDistributedTargetsWithCustomLabels(
+			true, nil,
+			[]discovery.Target{tgtA, tgtB},
+			[]string{"__metrics_path__"},
+		)
+		// With LabelsToHash restricting the hash to __metrics_path__ only, both
+		// targets produce the same key and are de-duplicated to one logical target.
+		require.Equal(t, 1, dt.TargetCount(),
+			"targets sharing stable labels must collapse to one with LabelsToHash set")
+	})
+}
+}

--- a/internal/service/cluster/cluster.go
+++ b/internal/service/cluster/cluster.go
@@ -127,6 +127,22 @@ type Component interface {
 // "clustering".
 type ComponentBlock struct {
 	Enabled bool `alloy:"enabled,attr"`
+
+	// LabelsToHash, when non-empty, restricts the set of target labels used to
+	// compute the ownership hash for clustered target distribution. Only the
+	// listed label names are hashed; all other labels are ignored for sharding
+	// purposes.
+	//
+	// Use this when targets carry volatile labels (e.g. pre-signed URL
+	// parameters such as __param_sig or __param_exp) that differ across nodes
+	// or over time, causing nodes to disagree on ownership and producing
+	// duplicate scrapes or gaps. Listing only the stable labels that uniquely
+	// identify a logical target (e.g. __metrics_path__) gives deterministic,
+	// consistent sharding.
+	//
+	// When unset, all non-meta labels (__address__, __metrics_path__,
+	// __param_*, __scheme__) are hashed, which is the historical default.
+	LabelsToHash []string `alloy:"labels_to_hash,attr,optional"`
 }
 
 var (


### PR DESCRIPTION
### Brief description of Pull Request

Add `labels_to_hash` to the `clustering` block so users can restrict
which target labels feed the ownership hash.

### Pull Request Details

When clustering is enabled, `prometheus.scrape` assigns each target to
a node by hashing all non-meta labels (`__address__`, `__metrics_path__`,
`__param_*`, etc.). There is no way to exclude labels from that hash.

This breaks ownership whenever a target carries a volatile label that
differs per node or per discovery poll. Issue #6484 has a concrete
example: PlanetScale's discovery endpoint returns a pre-signed scrape URL
with a fresh `?sig=...` on every poll. Each Alloy replica polls discovery
independently and gets a different `__param_sig`, so they compute
different ownership keys for the same database and disagree on who should
scrape it — resulting in duplicates on some targets and gaps on others.

The infrastructure to fix this already exists:
`NewDistributedTargetsWithCustomLabels` and `SpecificLabelsHash` are both
in the discovery package but not exposed to the component config.

This PR adds an optional `labels_to_hash` attribute to `ComponentBlock`.
When set, only those labels are used for the ownership hash. When empty
(the default), behaviour is unchanged — all non-meta labels are hashed
as before.
On the cluster.ComponentBlock placement: I went back and forth on this — flagged it as an open question in #6484 before implementing. I put LabelsToHash on the shared block because the underlying problem (volatile discovery labels breaking ownership hashing) isn't specific to prometheus.scrape — pyroscope.scrape and the loki.source.* clustered components could hit the same failure mode with their own volatile labels.

That said, this PR only wires the field into prometheus.scrape's distributeTargets. I didn't touch the other five consumers because I don't have a concrete volatile-label case for them, and I'd rather not guess at behavior nobody's asked for. Happy to either (a) scope the field down to prometheus.scrape for now and move it to the shared block if/when another component needs it, or (b) leave it shared as forward-looking API surface with a comment noting it's currently only consumed by scrape. Leaning toward (a) — smaller surface, easier to review — but open to your call.

Example config:

```alloy
prometheus.scrape "db_metrics" {
  clustering {
    enabled        = true
    labels_to_hash = ["__metrics_path__", "__address__"]
  }
}
```

Added a test `TestLabelsToHash_VolatileLabelsIgnored` that creates two
targets with identical `__metrics_path__` but different `__param_sig`,
and asserts they collapse to one ownership key when `labels_to_hash` is
set.

### Issue(s) fixed by this Pull Request

Fixes #6484

### Notes to the Reviewer

No new hashing logic is introduced — this just threads the existing
`SpecificLabelsHash` path through the component config. The attribute is
optional with no default change, so existing deployments are unaffected.

I am aware of the feedback about the PR template and AI disclosure —
updated accordingly. The change itself I have reviewed and understand
end to end.

### PR Checklist

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))