### PR TITLE
feat(prometheus.operator): Expose bodySizeLimit and enableCompression

### DIFF
--- a/internal/component/prometheus/operator/configgen/config_gen_podmonitor.go
+++ b/internal/component/prometheus/operator/configgen/config_gen_podmonitor.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/alecthomas/units"
 	promopv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/namespacelabeler"
 	commonConfig "github.com/prometheus/common/config"
@@ -291,6 +292,11 @@ func (cg *ConfigGenerator) GeneratePodMonitorConfig(m *promopv1.PodMonitor, ep p
 	cfg.LabelLimit = uint(defaultIfNil(m.Spec.LabelLimit, 0))
 	cfg.LabelNameLengthLimit = uint(defaultIfNil(m.Spec.LabelNameLengthLimit, 0))
 	cfg.LabelValueLengthLimit = uint(defaultIfNil(m.Spec.LabelValueLengthLimit, 0))
+	if m.Spec.BodySizeLimit != nil {
+		if cfg.BodySizeLimit, err = units.ParseBase2Bytes(string(*m.Spec.BodySizeLimit)); err != nil {
+			return nil, fmt.Errorf("parsing bodySizeLimit from podMonitor: %w", err)
+		}
+	}
 
 	return cfg, cfg.Validate(cg.ScrapeOptions.GlobalConfig())
 }

--- a/internal/component/prometheus/operator/configgen/config_gen_podmonitor_test.go
+++ b/internal/component/prometheus/operator/configgen/config_gen_podmonitor_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alecthomas/units"
 	promopv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	commonConfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -404,6 +405,7 @@ func TestGeneratePodMonitorConfig(t *testing.T) {
 					LabelNameLengthLimit:  ptr.To(uint64(104)),
 					LabelValueLengthLimit: ptr.To(uint64(105)),
 					AttachMetadata:        &promopv1.AttachMetadata{Node: boolPtr(true)},
+					BodySizeLimit:         ptr.To(promopv1.ByteSize("15MiB")),
 				},
 			},
 			ep: promopv1.PodMetricsEndpoint{
@@ -534,6 +536,7 @@ func TestGeneratePodMonitorConfig(t *testing.T) {
 				LabelLimit:                     103,
 				LabelNameLengthLimit:           104,
 				LabelValueLengthLimit:          105,
+				BodySizeLimit:                  15 * units.MiB,
 				ExtraScrapeMetrics:             falsePtr,
 				ScrapeNativeHistograms:         falsePtr,
 				AlwaysScrapeClassicHistograms:  falsePtr,

--- a/internal/component/prometheus/operator/configgen/config_gen_scrapeconfig.go
+++ b/internal/component/prometheus/operator/configgen/config_gen_scrapeconfig.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alecthomas/units"
 	promopv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/namespacelabeler"
 	commonConfig "github.com/prometheus/common/config"
@@ -157,6 +158,14 @@ func (cg *ConfigGenerator) commonScrapeConfigConfig(m *promopv1alpha1.ScrapeConf
 		// the implementation expects lowercase "http" or "https" in the final scrape configuration. So, we
 		// have to lowercase the schema.
 		cfg.Scheme = strings.ToLower(string(*m.Spec.Scheme))
+	}
+	if m.Spec.EnableCompression != nil {
+		cfg.EnableCompression = *m.Spec.EnableCompression
+	}
+	if m.Spec.BodySizeLimit != nil {
+		if cfg.BodySizeLimit, err = units.ParseBase2Bytes(string(*m.Spec.BodySizeLimit)); err != nil {
+			return nil, fmt.Errorf("parsing bodySizeLimit from scrapeConfig: %w", err)
+		}
 	}
 	if m.Spec.TLSConfig != nil {
 		if cfg.HTTPClientConfig.TLSConfig, err = cg.generateSafeTLS(*m.Spec.TLSConfig, m.Namespace); err != nil {

--- a/internal/component/prometheus/operator/configgen/config_gen_scrapeconfig_test.go
+++ b/internal/component/prometheus/operator/configgen/config_gen_scrapeconfig_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alecthomas/units"
 	promopv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	promopv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	commonConfig "github.com/prometheus/common/config"
@@ -198,6 +199,65 @@ func TestGenerateStaticScrapeConfigConfig(t *testing.T) {
 				EnableCompression:              true,
 				MetricsPath:                    "/metrics",
 				Scheme:                         "https",
+				MetricNameValidationScheme:     model.LegacyValidation,
+				MetricNameEscapingScheme:       model.UnderscoreEscaping.String(),
+				HTTPClientConfig: commonConfig.HTTPClientConfig{
+					FollowRedirects: true,
+					EnableHTTP2:     true,
+				},
+				ServiceDiscoveryConfigs: discovery.Configs{
+					discovery.StaticConfig{
+						&targetgroup.Group{
+							Targets: []model.LabelSet{{model.AddressLabel: model.LabelValue("foo")}, {model.AddressLabel: model.LabelValue("bar")}},
+							Labels:  model.LabelSet{},
+							Source:  "scrapeConfig/operator/scrapeconfig/static/1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "body size limit and compression",
+			m: &promopv1alpha1.ScrapeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "operator",
+					Name:      "scrapeconfig",
+				},
+				Spec: promopv1alpha1.ScrapeConfigSpec{
+					EnableCompression: ptr.To(false),
+					BodySizeLimit:     ptr.To(promopv1.ByteSize("15MiB")),
+				},
+			},
+			ep: promopv1alpha1.StaticConfig{
+				Targets: []promopv1alpha1.Target{"foo", "bar"},
+			},
+			expectedRelabels: util.Untab(`
+				- target_label: __meta_foo
+				  replacement: bar
+				- source_labels: [job]
+				  target_label: __tmp_prometheus_job_name
+				- replacement: operator
+				  target_label: __meta_kubernetes_scrapeconfig_namespace
+				- replacement: scrapeconfig
+				  target_label: __meta_kubernetes_scrapeconfig_name
+				- source_labels: [__address__]
+				  target_label: instance
+			`),
+			expected: &config.ScrapeConfig{
+				JobName:                        "scrapeConfig/operator/scrapeconfig/static/1",
+				HonorTimestamps:                true,
+				ScrapeInterval:                 model.Duration(time.Hour),
+				ScrapeTimeout:                  model.Duration(42 * time.Second),
+				ScrapeProtocols:                config.DefaultScrapeProtocols,
+				ScrapeFallbackProtocol:         config.PrometheusText0_0_4,
+				ExtraScrapeMetrics:             falsePtr,
+				ScrapeNativeHistograms:         falsePtr,
+				AlwaysScrapeClassicHistograms:  falsePtr,
+				ConvertClassicHistogramsToNHCB: falsePtr,
+				EnableCompression:              false,
+				BodySizeLimit:                  15 * units.MiB,
+				MetricsPath:                    "/metrics",
+				Scheme:                         "http",
 				MetricNameValidationScheme:     model.LegacyValidation,
 				MetricNameEscapingScheme:       model.UnderscoreEscaping.String(),
 				HTTPClientConfig: commonConfig.HTTPClientConfig{

--- a/internal/component/prometheus/operator/configgen/config_gen_servicemonitor.go
+++ b/internal/component/prometheus/operator/configgen/config_gen_servicemonitor.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/alecthomas/units"
 	promopv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/namespacelabeler"
 	commonConfig "github.com/prometheus/common/config"
@@ -315,6 +316,11 @@ func (cg *ConfigGenerator) GenerateServiceMonitorConfig(m *promopv1.ServiceMonit
 	cfg.LabelLimit = uint(defaultIfNil(m.Spec.LabelLimit, 0))
 	cfg.LabelNameLengthLimit = uint(defaultIfNil(m.Spec.LabelNameLengthLimit, 0))
 	cfg.LabelValueLengthLimit = uint(defaultIfNil(m.Spec.LabelValueLengthLimit, 0))
+	if m.Spec.BodySizeLimit != nil {
+		if cfg.BodySizeLimit, err = units.ParseBase2Bytes(string(*m.Spec.BodySizeLimit)); err != nil {
+			return nil, fmt.Errorf("parsing bodySizeLimit from serviceMonitor: %w", err)
+		}
+	}
 
 	return cfg, cfg.Validate(cg.ScrapeOptions.GlobalConfig())
 }

--- a/internal/component/prometheus/operator/configgen/config_gen_servicemonitor_test.go
+++ b/internal/component/prometheus/operator/configgen/config_gen_servicemonitor_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alecthomas/units"
 	promopv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	commonConfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -390,6 +391,7 @@ func TestGenerateServiceMonitorConfig(t *testing.T) {
 					LabelNameLengthLimit:  ptr.To(uint64(104)),
 					LabelValueLengthLimit: ptr.To(uint64(105)),
 					AttachMetadata:        &promopv1.AttachMetadata{Node: boolPtr(true)},
+					BodySizeLimit:         ptr.To(promopv1.ByteSize("15MiB")),
 				},
 			},
 			ep: promopv1.Endpoint{
@@ -536,6 +538,7 @@ func TestGenerateServiceMonitorConfig(t *testing.T) {
 				LabelLimit:                     103,
 				LabelNameLengthLimit:           104,
 				LabelValueLengthLimit:          105,
+				BodySizeLimit:                  15 * units.MiB,
 				ExtraScrapeMetrics:             falsePtr,
 				ScrapeNativeHistograms:         falsePtr,
 				AlwaysScrapeClassicHistograms:  falsePtr,


### PR DESCRIPTION
### Brief description of Pull Request

Expose `bodySizeLimit` on `prometheus.operator.servicemonitors`/`.podmonitors`/`.scrapeconfigs` and `enableCompression` on `.scrapeconfigs`.

### PR Checklist

- [x] Tests updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))