### PR TITLE
chore: Bump build image to use go v1.26.5

### DIFF
--- a/.github/workflows/check-linux-build-image.yml
+++ b/.github/workflows/check-linux-build-image.yml
@@ -40,4 +40,4 @@ jobs:
           push: false
           tags: grafana/alloy-build-image:latest
           build-args: |
-            GO_RUNTIME=golang:1.26.4-alpine3.23
+            GO_RUNTIME=golang:1.26.5-alpine3.23

--- a/.github/workflows/create_build_image.yml
+++ b/.github/workflows/create_build_image.yml
@@ -51,4 +51,4 @@ jobs:
         push: true
         tags: us-docker.pkg.dev/grafanalabs-global/dockerhub-alloy-prod-mirror/alloy-build-image:${{ steps.get_image_version.outputs.image_tag }}
         build-args: |
-          GO_RUNTIME=golang:1.26.4-alpine3.23
+          GO_RUNTIME=golang:1.26.5-alpine3.23

--- a/build-tools/build-image/windows/Dockerfile
+++ b/build-tools/build-image/windows/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-windowsservercore-ltsc2022@sha256:d50fe97a953eb04bfb276a274934411e6b0f7f3155b99edba90260ee6c650fa2
+FROM golang:1.26.5-windowsservercore-ltsc2022@sha256:4e7754f6cc0f11bea333132cfcd406422ceaf5bd219336dd74dde71c90ef1fc7
 
 SHELL ["powershell", "-command"]
 


### PR DESCRIPTION
### Brief description of Pull Request

I'm bumping the Linux and Windows build image's Go runtime to 1.26.5 to fix [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856) (crypto/tls) and [GO-2026-4970](https://pkg.go.dev/vuln/GO-2026-4970) (os), flagged by govulncheck on the [PR #6658 lint job](https://github.com/grafana/alloy/actions/runs/28966883772/job/85952218978?pr=6658). Step 2 as a follow up once the build image lands. 

### PR Checklist

- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))