### PR TITLE
chore: Bump go version to 1.26.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
   build_linux:
     name: Build on Linux
     runs-on: github-hosted-ubuntu-x64-large
-    container: grafana/alloy-build-image:v0.1.33@sha256:dbdecbfbad6c9ed0b315a7a6da25ef066b795ffc57e887125333b1a352907155
+    container: grafana/alloy-build-image:v0.1.34@sha256:4371598809230ffd7611367ba0dcb92bbc8b74bda88471293e5d478b48a0d186
     strategy:
       matrix:
         os: [linux]
@@ -35,7 +35,7 @@ jobs:
   build_linux_boringcrypto:
     name: Build on Linux (boringcrypto)
     runs-on: github-hosted-ubuntu-x64-large
-    container: grafana/alloy-build-image:v0.1.33@sha256:dbdecbfbad6c9ed0b315a7a6da25ef066b795ffc57e887125333b1a352907155
+    container: grafana/alloy-build-image:v0.1.34@sha256:4371598809230ffd7611367ba0dcb92bbc8b74bda88471293e5d478b48a0d186
     strategy:
       matrix:
         os: [linux]
@@ -94,7 +94,7 @@ jobs:
   build_freebsd:
     name: Build on FreeBSD (AMD64)
     runs-on: github-hosted-ubuntu-x64-large
-    container: grafana/alloy-build-image:v0.1.33@sha256:dbdecbfbad6c9ed0b315a7a6da25ef066b795ffc57e887125333b1a352907155
+    container: grafana/alloy-build-image:v0.1.34@sha256:4371598809230ffd7611367ba0dcb92bbc8b74bda88471293e5d478b48a0d186
     steps:
     - name: Checkout code
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/publish-alloy-linux.yml
+++ b/.github/workflows/publish-alloy-linux.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   publish_linux_container:
     name: Publish Alloy Linux container
-    container: grafana/alloy-build-image:v0.1.33@sha256:dbdecbfbad6c9ed0b315a7a6da25ef066b795ffc57e887125333b1a352907155
+    container: grafana/alloy-build-image:v0.1.34@sha256:4371598809230ffd7611367ba0dcb92bbc8b74bda88471293e5d478b48a0d186
     runs-on:
       labels: github-hosted-ubuntu-x64-large
     permissions:

--- a/.github/workflows/release-publish-alloy-artifacts.yml
+++ b/.github/workflows/release-publish-alloy-artifacts.yml
@@ -77,7 +77,7 @@ jobs:
 
   build_alloy:
     name: Build Alloy
-    container: grafana/alloy-build-image:v0.1.33@sha256:dbdecbfbad6c9ed0b315a7a6da25ef066b795ffc57e887125333b1a352907155
+    container: grafana/alloy-build-image:v0.1.34@sha256:4371598809230ffd7611367ba0dcb92bbc8b74bda88471293e5d478b48a0d186
     runs-on:
       labels: github-hosted-ubuntu-x64-large
     needs:
@@ -153,7 +153,7 @@ jobs:
 
   build_alloy_windows_installer:
     name: Build Alloy Windows installer with signed executables
-    container: grafana/alloy-build-image:v0.1.33@sha256:dbdecbfbad6c9ed0b315a7a6da25ef066b795ffc57e887125333b1a352907155
+    container: grafana/alloy-build-image:v0.1.34@sha256:4371598809230ffd7611367ba0dcb92bbc8b74bda88471293e5d478b48a0d186
     runs-on:
       labels: github-hosted-ubuntu-x64-large
     needs:
@@ -225,7 +225,7 @@ jobs:
 
   upload_release_artifacts:
     name: Upload release artifacts
-    container: grafana/alloy-build-image:v0.1.33@sha256:dbdecbfbad6c9ed0b315a7a6da25ef066b795ffc57e887125333b1a352907155
+    container: grafana/alloy-build-image:v0.1.34@sha256:4371598809230ffd7611367ba0dcb92bbc8b74bda88471293e5d478b48a0d186
     runs-on:
       labels: github-hosted-ubuntu-x64-large
     needs:

--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -15,7 +15,7 @@ jobs:
     name: Test (Full)
     runs-on: ubuntu-latest-8-cores
     container:
-      image: grafana/alloy-build-image:v0.1.33@sha256:dbdecbfbad6c9ed0b315a7a6da25ef066b795ffc57e887125333b1a352907155
+      image: grafana/alloy-build-image:v0.1.34@sha256:4371598809230ffd7611367ba0dcb92bbc8b74bda88471293e5d478b48a0d186
       volumes:
         - /var/run/docker.sock
     steps:

--- a/.github/workflows/test_linux_system_packages.yml
+++ b/.github/workflows/test_linux_system_packages.yml
@@ -17,7 +17,7 @@ jobs:
     name: Test Linux system packages
     runs-on: ubuntu-latest-8-cores
     container:
-      image: grafana/alloy-build-image:v0.1.33@sha256:dbdecbfbad6c9ed0b315a7a6da25ef066b795ffc57e887125333b1a352907155
+      image: grafana/alloy-build-image:v0.1.34@sha256:4371598809230ffd7611367ba0dcb92bbc8b74bda88471293e5d478b48a0d186
       volumes:
         - /var/run/docker.sock
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
 # in environment variables.
 
-FROM --platform=$BUILDPLATFORM grafana/alloy-build-image:v0.1.33@sha256:dbdecbfbad6c9ed0b315a7a6da25ef066b795ffc57e887125333b1a352907155 AS ui-build
+FROM --platform=$BUILDPLATFORM grafana/alloy-build-image:v0.1.34@sha256:4371598809230ffd7611367ba0dcb92bbc8b74bda88471293e5d478b48a0d186 AS ui-build
 ARG BUILDPLATFORM
 COPY ./internal/web/ui /ui
 WORKDIR /ui
@@ -12,7 +12,7 @@ RUN --mount=type=cache,target=/root/.npm,sharing=locked \
     npm ci --no-audit --no-fund                         \
     && npm run build
 
-FROM --platform=$BUILDPLATFORM grafana/alloy-build-image:v0.1.33@sha256:dbdecbfbad6c9ed0b315a7a6da25ef066b795ffc57e887125333b1a352907155 AS build
+FROM --platform=$BUILDPLATFORM grafana/alloy-build-image:v0.1.34@sha256:4371598809230ffd7611367ba0dcb92bbc8b74bda88471293e5d478b48a0d186 AS build
 
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE_GO=golang:1.26.4-windowsservercore-ltsc2022@sha256:d50fe97a953eb04bfb276a274934411e6b0f7f3155b99edba90260ee6c650fa2
+ARG BASE_IMAGE_GO=golang:1.26.5-windowsservercore-ltsc2022@sha256:4e7754f6cc0f11bea333132cfcd406422ceaf5bd219336dd74dde71c90ef1fc7
 ARG BASE_IMAGE_WINDOWS=mcr.microsoft.com/windows/nanoserver:ltsc2022@sha256:3680dad0bb773da8efcd9d928eaf4e33817875ab71a43792640ab1bcc0b3c074
 
 FROM ${BASE_IMAGE_GO} AS builder

--- a/collector/go.mod
+++ b/collector/go.mod
@@ -2,7 +2,7 @@
 
 module github.com/grafana/alloy/otel_engine
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/grafana/alloy v1.17.0

--- a/example/docker-compose/images/grizzly/Dockerfile
+++ b/example/docker-compose/images/grizzly/Dockerfile
@@ -1,3 +1,3 @@
-FROM golang:1.26.4-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f
+FROM golang:1.26.5-alpine@sha256:99e12cfb19b753915f9b9fdc5a99f1869a24a69d3a0955832d5702e7fa68f1be
 
 RUN go install github.com/grafana/grizzly/cmd/grr@v0.7.1

--- a/example/docker-compose/images/jb/Dockerfile
+++ b/example/docker-compose/images/jb/Dockerfile
@@ -1,3 +1,3 @@
-FROM golang:1.26.4-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f
+FROM golang:1.26.5-alpine@sha256:99e12cfb19b753915f9b9fdc5a99f1869a24a69d3a0955832d5702e7fa68f1be
 
 RUN go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.5.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/alloy
 
-go 1.26.4
+go 1.26.5
 
 // This local replace is required for local development and testing of the syntax submodule.
 // It is intentionally local to this module; shared remote replaces are synced from collector/builder-config.yaml.

--- a/integration-tests/docker/configs/kafka/Dockerfile
+++ b/integration-tests/docker/configs/kafka/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4@sha256:68cb6d68bed024785b69195b89af7ac7a444f27791435f98647edff595aa0479 as build
+FROM golang:1.26.5@sha256:63f132d58c1f589f0dcda584933a9bb44bfda1150f1506377f5a902f34d86033 as build
 WORKDIR /app/
 COPY go.mod go.sum ./
 COPY syntax/go.mod syntax/go.sum ./syntax/

--- a/integration-tests/docker/configs/otel-gen/Dockerfile
+++ b/integration-tests/docker/configs/otel-gen/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4@sha256:68cb6d68bed024785b69195b89af7ac7a444f27791435f98647edff595aa0479 as build
+FROM golang:1.26.5@sha256:63f132d58c1f589f0dcda584933a9bb44bfda1150f1506377f5a902f34d86033 as build
 WORKDIR /app/
 COPY go.mod go.sum ./
 COPY syntax/go.mod syntax/go.sum ./syntax/

--- a/integration-tests/docker/configs/prom-gen/Dockerfile
+++ b/integration-tests/docker/configs/prom-gen/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4@sha256:68cb6d68bed024785b69195b89af7ac7a444f27791435f98647edff595aa0479 as build
+FROM golang:1.26.5@sha256:63f132d58c1f589f0dcda584933a9bb44bfda1150f1506377f5a902f34d86033 as build
 WORKDIR /app/
 COPY go.mod go.sum ./
 COPY syntax/go.mod syntax/go.sum ./syntax/

--- a/integration-tests/docker/tests/loki-cloudflare/logpullmock/Dockerfile
+++ b/integration-tests/docker/tests/loki-cloudflare/logpullmock/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine AS build
+FROM golang:1.26.5-alpine AS build
 WORKDIR /app
 COPY . .
 RUN go build -o /logpullmock .

--- a/integration-tests/docker/tests/loki-cloudflare/logpullmock/go.mod
+++ b/integration-tests/docker/tests/loki-cloudflare/logpullmock/go.mod
@@ -1,3 +1,3 @@
 module logpullmock
 
-go 1.26.4
+go 1.26.5

--- a/syntax/go.mod
+++ b/syntax/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/alloy/syntax
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/alloy/tools
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/google/go-github/v57 v57.0.0


### PR DESCRIPTION
### Brief description of Pull Request

Update go.mod, Dockerfiles, and CI workflows at the newly published `alloy-build-image:v0.1.34` and Go 1.26.5, fixing govulncheck's [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856) (crypto/tls) and [GO-2026-4970](https://pkg.go.dev/vuln/GO-2026-4970) (os) findings — the stage-2 follow-up to #6660.

### PR Checklist

- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))