### PR TITLE
chore: Add anonymous usage stats for OTel Engine

### DIFF
--- a/collector/generator/main_alloy.tpl
+++ b/collector/generator/main_alloy.tpl
@@ -44,8 +44,8 @@ func newAlloyCommand(params otelcol.CollectorSettings) *cobra.Command {
 		}
 		if !*disableReporting {
 			logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
-			// Use an empty seeDir since the OTel Engine cmd line has no storage path flag.
-			// The seed will be stored in the tmp dir.
+			// Use an empty seedDir since the OTel Engine cmd line has no storage path flag.
+			// The seed will fall back to the platform default location.
 			usagestats.StartReporter(cmd.Context(), logger, "", usagestats.GlobalTracker)
 		}
 		return nil

--- a/collector/generator/main_alloy.tpl
+++ b/collector/generator/main_alloy.tpl
@@ -1,21 +1,68 @@
 package main
 
 import (
+	"context"
+	"log/slog"
+	"os"
+
 	"github.com/grafana/alloy/flowcmd"
+	"github.com/grafana/alloy/internal/usagestats"
 	"github.com/grafana/alloy/internal/useragent"
 	"github.com/spf13/cobra"
+	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/otelcol"
 )
 
 func newAlloyCommand(params otelcol.CollectorSettings) *cobra.Command {
-    otelCmd := otelcol.NewCommand(params)
+	// Record the configured OTel Collector component types at config-load time so
+	// they can be included in the anonymous usage stats report.
+	params.ConfigProviderSettings.ResolverSettings.ConverterFactories = append(
+		params.ConfigProviderSettings.ResolverSettings.ConverterFactories,
+		confmap.NewConverterFactory(func(confmap.ConverterSettings) confmap.Converter {
+			return usageStatsConverter{}
+		}),
+	)
 
-    otelCmd.Use = useragent.EngineOTel
-    otelCmd.Short = "Use Alloy with OTel Engine"
-    otelCmd.Long = "[EXPERIMENTAL] Use Alloy with OpenTelemetry Collector Engine"
+	otelCmd := otelcol.NewCommand(params)
 
-    flowCmd := flowcmd.RootCommand()
-    flowCmd.AddCommand(otelCmd)
+	otelCmd.Use = useragent.EngineOTel
+	otelCmd.Short = "Use Alloy with OTel Engine"
+	otelCmd.Long = "[EXPERIMENTAL] Use Alloy with OpenTelemetry Collector Engine"
 
-    return flowCmd
+	// Match `alloy run`: report anonymous usage stats unless the user opts out.
+	disableReporting := otelCmd.Flags().Bool("disable-reporting", false, "Disable reporting of enabled components to Grafana.")
+
+	// Start the usage stats reporter alongside the collector. PreRunE runs after
+	// flags are parsed and only when the collector actually runs, not for
+	// subcommands such as validate/components/print-config or --help.
+	prevPreRunE := otelCmd.PreRunE
+	otelCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if prevPreRunE != nil {
+			if err := prevPreRunE(cmd, args); err != nil {
+				return err
+			}
+		}
+		if !*disableReporting {
+			logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+			// Use an empty seeDir since the OTel Engine cmd line has no storage path flag.
+			// The seed will be stored in the tmp dir.
+			usagestats.StartReporter(cmd.Context(), logger, "", usagestats.GlobalTracker)
+		}
+		return nil
+	}
+
+	flowCmd := flowcmd.RootCommand()
+	flowCmd.AddCommand(otelCmd)
+
+	return flowCmd
+}
+
+// usageStatsConverter records the configured OTel Collector component types into
+// the process-wide usage stats tracker. It runs on every config resolution.
+type usageStatsConverter struct{}
+
+func (usageStatsConverter) Convert(_ context.Context, conf *confmap.Conf) error {
+	components := usagestats.ExtractOtelComponents(conf.ToStringMap())
+	usagestats.GlobalTracker.SetOTelComponentsFunc(func() map[string][]string { return components })
+	return nil
 }

--- a/collector/main_alloy.go
+++ b/collector/main_alloy.go
@@ -46,8 +46,8 @@ func newAlloyCommand(params otelcol.CollectorSettings) *cobra.Command {
 		}
 		if !*disableReporting {
 			logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
-			// Use an empty seeDir since the OTel Engine cmd line has no storage path flag.
-			// The seed will be stored in the tmp dir.
+			// Use an empty seedDir since the OTel Engine cmd line has no storage path flag.
+			// The seed will fall back to the platform default location.
 			usagestats.StartReporter(cmd.Context(), logger, "", usagestats.GlobalTracker)
 		}
 		return nil

--- a/collector/main_alloy.go
+++ b/collector/main_alloy.go
@@ -3,21 +3,68 @@
 package main
 
 import (
+	"context"
+	"log/slog"
+	"os"
+
 	"github.com/grafana/alloy/flowcmd"
+	"github.com/grafana/alloy/internal/usagestats"
 	"github.com/grafana/alloy/internal/useragent"
 	"github.com/spf13/cobra"
+	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/otelcol"
 )
 
 func newAlloyCommand(params otelcol.CollectorSettings) *cobra.Command {
-    otelCmd := otelcol.NewCommand(params)
+	// Record the configured OTel Collector component types at config-load time so
+	// they can be included in the anonymous usage stats report.
+	params.ConfigProviderSettings.ResolverSettings.ConverterFactories = append(
+		params.ConfigProviderSettings.ResolverSettings.ConverterFactories,
+		confmap.NewConverterFactory(func(confmap.ConverterSettings) confmap.Converter {
+			return usageStatsConverter{}
+		}),
+	)
 
-    otelCmd.Use = useragent.EngineOTel
-    otelCmd.Short = "Use Alloy with OTel Engine"
-    otelCmd.Long = "[EXPERIMENTAL] Use Alloy with OpenTelemetry Collector Engine"
+	otelCmd := otelcol.NewCommand(params)
 
-    flowCmd := flowcmd.RootCommand()
-    flowCmd.AddCommand(otelCmd)
+	otelCmd.Use = useragent.EngineOTel
+	otelCmd.Short = "Use Alloy with OTel Engine"
+	otelCmd.Long = "[EXPERIMENTAL] Use Alloy with OpenTelemetry Collector Engine"
 
-    return flowCmd
+	// Match `alloy run`: report anonymous usage stats unless the user opts out.
+	disableReporting := otelCmd.Flags().Bool("disable-reporting", false, "Disable reporting of enabled components to Grafana.")
+
+	// Start the usage stats reporter alongside the collector. PreRunE runs after
+	// flags are parsed and only when the collector actually runs, not for
+	// subcommands such as validate/components/print-config or --help.
+	prevPreRunE := otelCmd.PreRunE
+	otelCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if prevPreRunE != nil {
+			if err := prevPreRunE(cmd, args); err != nil {
+				return err
+			}
+		}
+		if !*disableReporting {
+			logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+			// Use an empty seeDir since the OTel Engine cmd line has no storage path flag.
+			// The seed will be stored in the tmp dir.
+			usagestats.StartReporter(cmd.Context(), logger, "", usagestats.GlobalTracker)
+		}
+		return nil
+	}
+
+	flowCmd := flowcmd.RootCommand()
+	flowCmd.AddCommand(otelCmd)
+
+	return flowCmd
+}
+
+// usageStatsConverter records the configured OTel Collector component types into
+// the process-wide usage stats tracker. It runs on every config resolution.
+type usageStatsConverter struct{}
+
+func (usageStatsConverter) Convert(_ context.Context, conf *confmap.Conf) error {
+	components := usagestats.ExtractOtelComponents(conf.ToStringMap())
+	usagestats.GlobalTracker.SetOTelComponentsFunc(func() map[string][]string { return components })
+	return nil
 }

--- a/docs/sources/data-collection.md
+++ b/docs/sources/data-collection.md
@@ -31,7 +31,9 @@ This endpoint only accepts data and isn't available to view in a browser.
 - The version of {{< param "PRODUCT_NAME" >}}.
 - The operating system where {{< param "PRODUCT_NAME" >}} runs.
 - The system architecture where {{< param "PRODUCT_NAME" >}} runs.
-- A list of enabled [components][].
+- Which engine is running: the Default Engine (`alloy run`) or the OTel Engine (`alloy otel`).
+- When running the Default Engine, a list of enabled [components][].
+- When running the OTel Engine, the configured OpenTelemetry Collector component types, grouped by kind: `receivers`, `processors`, `exporters`, `connectors`, and `extensions`. For example, an `otlp` receiver is reported separately from an `otlp` exporter. If the `alloyengine` extension is used, the list of {{< param "PRODUCT_NAME" >}} components it runs is also reported.
 - The deployment method, such as `docker`, `helm`, `operator`, `deb`, `rpm`, `brew`, or `binary`.
 
 {{< admonition type="note" >}}
@@ -162,6 +164,19 @@ Replace the following:
 
 - _`<BINARY_PATH>`_: The path to the {{< param "PRODUCT_NAME" >}} binary.
 - _`<CONFIG_PATH>`_: The path to your {{< param "PRODUCT_NAME" >}} configuration file.
+
+### OTel Engine
+
+When you run the OTel Engine, add `--disable-reporting` to the `alloy otel` command:
+
+```shell
+<BINARY_PATH> otel --config <CONFIG_PATH> --disable-reporting
+```
+
+Replace the following:
+
+- _`<BINARY_PATH>`_: The path to the {{< param "PRODUCT_NAME" >}} binary.
+- _`<CONFIG_PATH>`_: The path to your OpenTelemetry Collector configuration file.
 
 [components]: ../get-started/components/
 [command line flag]: ../reference/cli/run/

--- a/docs/sources/data-collection.md
+++ b/docs/sources/data-collection.md
@@ -31,9 +31,11 @@ This endpoint only accepts data and isn't available to view in a browser.
 - The version of {{< param "PRODUCT_NAME" >}}.
 - The operating system where {{< param "PRODUCT_NAME" >}} runs.
 - The system architecture where {{< param "PRODUCT_NAME" >}} runs.
-- Which engine is running: the Default Engine (`alloy run`) or the OTel Engine (`alloy otel`).
-- When running the Default Engine, a list of enabled [components][].
-- When running the OTel Engine, the configured OpenTelemetry Collector component types, grouped by kind: `receivers`, `processors`, `exporters`, `connectors`, and `extensions`. For example, an `otlp` receiver is reported separately from an `otlp` exporter. If the `alloyengine` extension is used, the list of {{< param "PRODUCT_NAME" >}} components it runs is also reported.
+- Which engine is running: the {{< param "DEFAULT_ENGINE" >}} with `alloy run`, or the {{< param "OTEL_ENGINE" >}} with `alloy otel`.
+- When running the {{< param "DEFAULT_ENGINE" >}}, a list of enabled [components][].
+- When running the {{< param "OTEL_ENGINE" >}}, the configured OpenTelemetry Collector component types, grouped by kind: `receivers`, `processors`, `exporters`, `connectors`, and `extensions`.
+  For example, an `otlp` receiver is reported separately from an `otlp` exporter.
+  If the `alloyengine` extension is used, the list of {{< param "PRODUCT_NAME" >}} components it runs is also reported.
 - The deployment method, such as `docker`, `helm`, `operator`, `deb`, `rpm`, `brew`, or `binary`.
 
 {{< admonition type="note" >}}
@@ -167,7 +169,7 @@ Replace the following:
 
 ### OTel Engine
 
-When you run the OTel Engine, add `--disable-reporting` to the `alloy otel` command:
+When you run the {{< param "OTEL_ENGINE" >}}, add `--disable-reporting` to the `alloy otel` command:
 
 ```shell
 <BINARY_PATH> otel --config <CONFIG_PATH> --disable-reporting

--- a/docs/sources/reference/cli/otel.md
+++ b/docs/sources/reference/cli/otel.md
@@ -37,6 +37,10 @@ Replace the following:
   These flags are the same as upstream.
   Run `alloy otel --help` to show the complete list of supported flags.
 
+In addition to the upstream flags, the `otel` command accepts:
+
+- `--disable-reporting`: Disable [anonymous usage statistics reporting](../../../data-collection/) to Grafana.
+
 ## Configuration
 
 The `otel` command accepts standard OpenTelemetry Collector YAML configuration files.

--- a/internal/alloycli/cmd_run.go
+++ b/internal/alloycli/cmd_run.go
@@ -47,6 +47,7 @@ import (
 	uiservice "github.com/grafana/alloy/internal/service/ui"
 	"github.com/grafana/alloy/internal/static/config/instrumentation"
 	"github.com/grafana/alloy/internal/usagestats"
+	"github.com/grafana/alloy/internal/useragent"
 	"github.com/grafana/alloy/internal/util"
 	"github.com/grafana/alloy/internal/util/windowspriority"
 	"github.com/grafana/alloy/syntax/diag"
@@ -359,22 +360,20 @@ func (fr *alloyRun) runCommand(cmd *cobra.Command, configPath string) error {
 	return fr.run(cmd.Context(), cmd.Flags(), rp)
 }
 
-// getEnabledComponentsFunc returns a function that gets the current enabled components
-func getEnabledComponentsFunc(f *alloy_runtime.Runtime) func() map[string]any {
-	return func() map[string]any {
-		components := component.GetAllComponents(f, component.InfoOptions{})
-		if remoteCfgHost, err := remotecfgservice.GetHost(f); err == nil {
-			components = append(components, component.GetAllComponents(remoteCfgHost, component.InfoOptions{})...)
-		}
-		componentNames := map[string]struct{}{}
-		for _, c := range components {
-			if c.Type != component.TypeBuiltin {
-				continue
-			}
-			componentNames[c.ComponentName] = struct{}{}
-		}
-		return map[string]any{"enabled-components": maps.Keys(componentNames)}
+// getEnabledComponents returns the names of the currently enabled builtin components.
+func getEnabledComponents(f *alloy_runtime.Runtime) []string {
+	components := component.GetAllComponents(f, component.InfoOptions{})
+	if remoteCfgHost, err := remotecfgservice.GetHost(f); err == nil {
+		components = append(components, component.GetAllComponents(remoteCfgHost, component.InfoOptions{})...)
 	}
+	componentNames := map[string]struct{}{}
+	for _, c := range components {
+		if c.Type != component.TypeBuiltin {
+			continue
+		}
+		componentNames[c.ComponentName] = struct{}{}
+	}
+	return maps.Keys(componentNames)
 }
 
 type runParams struct {
@@ -596,18 +595,21 @@ func (fr *alloyRun) run(ctx context.Context, fset *pflag.FlagSet, params runPara
 		f.Run(ctx)
 	})
 
-	// Report usage of enabled components
-	if !fr.disableReporting {
-		reporter, err := usagestats.NewReporter(slogger)
-		if err != nil {
-			return fmt.Errorf("failed to create reporter: %w", err)
-		}
-		go func() {
-			err := reporter.Start(ctx, getEnabledComponentsFunc(f))
-			if err != nil && !errors.Is(err, context.Canceled) {
-				slogger.Error("failed to start reporter", "err", err)
-			}
-		}()
+	// Report usage of enabled components.
+	if useragent.GetEngineMode() == useragent.EngineOTel {
+		// Running embedded in the OTel Collector via the alloyengine extension (the
+		// only way run() executes under `alloy otel`): feed the Default Engine
+		// components to the process-wide tracker instead of starting a second
+		// reporter, so the single `alloy otel` report lists them under
+		// "alloyengine-components".
+		usagestats.GlobalTracker.SetAlloyEngineComponentsFunc(func() []string {
+			return getEnabledComponents(f)
+		})
+	} else if !fr.disableReporting {
+		usagestats.GlobalTracker.SetEnabledComponentsFunc(func() []string {
+			return getEnabledComponents(f)
+		})
+		usagestats.StartReporter(ctx, slogger, fr.storagePath, usagestats.GlobalTracker)
 	}
 
 	// Perform the initial load. This is done after starting the HTTP server so

--- a/internal/usagestats/components.go
+++ b/internal/usagestats/components.go
@@ -1,0 +1,133 @@
+package usagestats
+
+import (
+	"sort"
+	"strings"
+	"sync"
+)
+
+// Metric keys used in the "metrics" payload of a usage report.
+const (
+	// enabledComponentsMetric lists the enabled Alloy component names (Default Engine).
+	enabledComponentsMetric = "enabled-components"
+	// otelComponentsMetric holds the configured OTel Collector component types,
+	// grouped by kind (OTel Engine).
+	otelComponentsMetric = "otel-components"
+	// alloyEngineComponentsMetric lists the Alloy component names run by the
+	// alloyengine extension ("an alloy within an alloy").
+	alloyEngineComponentsMetric = "alloyengine-components"
+)
+
+var otelComponentSections = []string{
+	"receivers",
+	"processors",
+	"exporters",
+	"connectors",
+	"extensions",
+}
+
+// ExtractOtelComponents returns the OTel Collector component types grouped by kind.
+// For example: {"receivers":  {"otlp", "prometheus"}, "processors": {"batch"}}
+func ExtractOtelComponents(conf map[string]any) map[string][]string {
+	out := map[string][]string{}
+	for _, section := range otelComponentSections {
+		components, ok := conf[section].(map[string]any)
+		if !ok {
+			continue
+		}
+		types := map[string]struct{}{}
+		for id := range components {
+			t := componentType(id)
+			if t == "" {
+				continue
+			}
+			types[t] = struct{}{}
+		}
+		if len(types) == 0 {
+			continue
+		}
+		list := make([]string, 0, len(types))
+		for t := range types {
+			list = append(list, t)
+		}
+		sort.Strings(list)
+		out[section] = list
+	}
+	return out
+}
+
+// componentType returns the type portion of an OTel component ID. IDs use the
+// form "type[/name]"; the type is everything before the first "/".
+func componentType(id string) string {
+	if idx := strings.IndexByte(id, '/'); idx >= 0 {
+		id = id[:idx]
+	}
+	return strings.TrimSpace(id)
+}
+
+// Tracker holds the component information gathered during a run, and produces the
+// "metrics" payload for the usage report. Both engines feed the same tracker
+//
+// Each source registers a getter that is read lazily at report time, so the
+// reported lists always reflect the current state. In a given process only one
+// top-level engine runs, so Metrics only ever emits the keys relevant to that
+// engine.
+type Tracker struct {
+	mut                       sync.Mutex
+	enabledComponentsFunc     func() []string
+	otelComponentsFunc        func() map[string][]string
+	alloyEngineComponentsFunc func() []string
+}
+
+// GlobalTracker is the process-wide tracker read by the usage reporter. It is a
+// singleton because the component information is populated from several
+// independent places in the same process (the Default Engine runtime, the OTel
+// confmap converter, and the alloyengine extension).
+var GlobalTracker = &Tracker{}
+
+// SetEnabledComponentsFunc registers a getter for the Default Engine's enabled
+// component names.
+func (t *Tracker) SetEnabledComponentsFunc(fn func() []string) {
+	t.mut.Lock()
+	defer t.mut.Unlock()
+	t.enabledComponentsFunc = fn
+}
+
+// SetOTelComponentsFunc registers a getter for the configured OTel Collector
+// component types, grouped by kind. It is called by the confmap converter on
+// every config resolve.
+func (t *Tracker) SetOTelComponentsFunc(fn func() map[string][]string) {
+	t.mut.Lock()
+	defer t.mut.Unlock()
+	t.otelComponentsFunc = fn
+}
+
+// SetAlloyEngineComponentsFunc registers a getter for the Alloy component names
+// run by the alloyengine extension.
+func (t *Tracker) SetAlloyEngineComponentsFunc(fn func() []string) {
+	t.mut.Lock()
+	defer t.mut.Unlock()
+	t.alloyEngineComponentsFunc = fn
+}
+
+// Metrics returns the "metrics" payload for the usage report. Only the keys whose
+// sources have been registered are included.
+func (t *Tracker) Metrics() map[string]any {
+	t.mut.Lock()
+	enabledComponentsFunc := t.enabledComponentsFunc
+	otelComponentsFunc := t.otelComponentsFunc
+	alloyEngineComponentsFunc := t.alloyEngineComponentsFunc
+	t.mut.Unlock()
+
+	metrics := map[string]any{}
+	if enabledComponentsFunc != nil {
+		metrics[enabledComponentsMetric] = enabledComponentsFunc()
+	}
+	if otelComponentsFunc != nil {
+		metrics[otelComponentsMetric] = otelComponentsFunc()
+	}
+	if alloyEngineComponentsFunc != nil {
+		metrics[alloyEngineComponentsMetric] = alloyEngineComponentsFunc()
+	}
+	return metrics
+}

--- a/internal/usagestats/reporter.go
+++ b/internal/usagestats/reporter.go
@@ -2,6 +2,8 @@ package usagestats
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 	"math"
 	"time"
@@ -16,6 +18,12 @@ var (
 	reportCheckInterval = time.Minute
 	reportInterval      = 4 * time.Hour
 
+	// reportCheckIntervalOverride and reportIntervalOverride are empty in production.
+	// They exist only so an integration test build can shorten the reporting cadence via
+	// `-ldflags -X` (which can set string vars, not time.Duration);
+	reportCheckIntervalOverride = ""
+	reportIntervalOverride      = ""
+
 	reportBackoffConfig = backoff.Config{
 		MinBackoff: time.Second,
 		MaxBackoff: 30 * time.Second,
@@ -23,42 +31,57 @@ var (
 	}
 )
 
-// Reporter holds the Alloy seed information and sends report of usage
-type Reporter struct {
+// reporter holds the Alloy seed information and sends report of usage
+type reporter struct {
 	logger *slog.Logger
 
 	seed       *alloyseed.Seed
 	lastReport time.Time
 }
 
-// NewReporter creates a Reporter that will send periodically reports to grafana.com
-func NewReporter(logger *slog.Logger) (*Reporter, error) {
-	r := &Reporter{
-		logger: logger,
-	}
-	return r, nil
+// StartReporter launches a usage stats reporter in a background goroutine that
+// reports the given tracker's metrics until ctx is cancelled. It owns seed
+// initialization, reporter construction and the goroutine.
+// seedDir is where the anonymous instance seed is persisted (empty means the legacy default path).
+func StartReporter(ctx context.Context, logger *slog.Logger, seedDir string, tracker *Tracker) {
+	alloyseed.Init(seedDir, logger)
+	rep := &reporter{logger: logger}
+	go func() {
+		if err := rep.run(ctx, tracker.Metrics); err != nil && !errors.Is(err, context.Canceled) {
+			logger.Error("failed to run usage stats reporter", "err", err)
+		}
+	}()
 }
 
-// Start inits the reporter seed and start sending report for every interval
-func (rep *Reporter) Start(ctx context.Context, metricsFunc func() map[string]any) error {
+// run inits the reporter seed and start sending report for every interval
+func (rep *reporter) run(ctx context.Context, metricsFunc func() map[string]any) error {
 	rep.logger.Info("running usage stats reporter")
 	rep.seed = alloyseed.Get()
 
-	// check every minute if we should report.
-	ticker := time.NewTicker(reportCheckInterval)
+	checkInterval, err := resolveInterval("reportCheckIntervalOverride", reportCheckIntervalOverride, reportCheckInterval)
+	if err != nil {
+		return err
+	}
+	interval, err := resolveInterval("reportIntervalOverride", reportIntervalOverride, reportInterval)
+	if err != nil {
+		return err
+	}
+
+	// check every checkInterval if we should report.
+	ticker := time.NewTicker(checkInterval)
 	defer ticker.Stop()
 
-	// find  when to send the next report.
-	next := nextReport(reportInterval, rep.seed.CreatedAt, time.Now())
+	// find when to send the next report.
+	next := nextReport(interval, rep.seed.CreatedAt, time.Now())
 	if rep.lastReport.IsZero() {
 		// if we never reported assumed it was the last interval.
-		rep.lastReport = next.Add(-reportInterval)
+		rep.lastReport = next.Add(-interval)
 	}
 	for {
 		select {
 		case <-ticker.C:
 			now := time.Now()
-			if !next.Equal(now) && now.Sub(rep.lastReport) < reportInterval {
+			if !next.Equal(now) && now.Sub(rep.lastReport) < interval {
 				continue
 			}
 			rep.logger.Info("reporting Alloy stats", "date", time.Now())
@@ -72,7 +95,7 @@ func (rep *Reporter) Start(ctx context.Context, metricsFunc func() map[string]an
 			// wait a full interval rather than re-attempting on every tick, which
 			// would otherwise hammer the endpoint indefinitely.
 			rep.lastReport = next
-			next = next.Add(reportInterval)
+			next = next.Add(interval)
 		case <-ctx.Done():
 			return ctx.Err()
 		}
@@ -80,7 +103,7 @@ func (rep *Reporter) Start(ctx context.Context, metricsFunc func() map[string]an
 }
 
 // reportUsage reports the usage to grafana.com.
-func (rep *Reporter) reportUsage(ctx context.Context, interval time.Time, metrics map[string]any) error {
+func (rep *reporter) reportUsage(ctx context.Context, interval time.Time, metrics map[string]any) error {
 	backoff := backoff.New(ctx, reportBackoffConfig)
 	var errs multierror.MultiError
 	for backoff.Ongoing() {
@@ -102,4 +125,18 @@ func (rep *Reporter) reportUsage(ctx context.Context, interval time.Time, metric
 func nextReport(interval time.Duration, createdAt, now time.Time) time.Time {
 	duration := math.Ceil(float64(now.Sub(createdAt)) / float64(interval))
 	return createdAt.Add(time.Duration(duration) * interval)
+}
+
+func resolveInterval(name, override string, def time.Duration) (time.Duration, error) {
+	if override == "" {
+		return def, nil
+	}
+	d, err := time.ParseDuration(override)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s %q: %w", name, override, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("%s must be positive, got %q", name, override)
+	}
+	return d, nil
 }

--- a/internal/usagestats/reporter_test.go
+++ b/internal/usagestats/reporter_test.go
@@ -2,68 +2,167 @@ package usagestats
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/grafana/dskit/backoff"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
+	"gopkg.in/yaml.v3"
 
+	"github.com/grafana/alloy/internal/alloyseed"
 	"github.com/grafana/alloy/internal/util"
 )
 
-func Test_ReportLoop(t *testing.T) {
-	// stub
-	reportCheckInterval = 100 * time.Millisecond
-	reportInterval = time.Second
-
-	var (
-		mut          sync.Mutex
-		totalReports int
-		alloyIDs     []string
-	)
-
-	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		mut.Lock()
-		defer mut.Unlock()
-
-		totalReports++
-
-		var received Report
-		require.NoError(t, jsoniter.NewDecoder(r.Body).Decode(&received))
-		alloyIDs = append(alloyIDs, received.UsageStatsID)
-
-		rw.WriteHeader(http.StatusOK)
-	}))
-	usageStatsURL = server.URL
-
-	r, err := NewReporter(util.TestAlloyLogger(t).Slog())
-	require.NoError(t, err)
-
-	ctx, cancel := context.WithCancel(t.Context())
-
-	go func() {
-		<-time.After(6 * time.Second)
-		cancel()
-	}()
-	metricsFunc := func() map[string]any {
-		return map[string]any{}
+// TestReporter checks that the reporter POSTs the components tracked for each
+// engine to grafana.com. Components are supplied directly; turning an OTel
+// config into component types is covered separately by TestExtractOtelComponents.
+func TestReporter(t *testing.T) {
+	tests := map[string]struct {
+		setup func(tr *Tracker)
+		want  map[string]any
+	}{
+		"empty tracker reports no metrics": {
+			setup: func(*Tracker) {},
+			want:  map[string]any{},
+		},
+		"default engine reports enabled components": {
+			setup: func(tr *Tracker) {
+				tr.SetEnabledComponentsFunc(func() []string {
+					return []string{"prometheus.scrape", "loki.write"}
+				})
+			},
+			want: map[string]any{
+				"enabled-components": []string{"prometheus.scrape", "loki.write"},
+			},
+		},
+		"otel engine reports otel components": {
+			setup: func(tr *Tracker) {
+				tr.SetOTelComponentsFunc(func() map[string][]string {
+					return map[string][]string{"receivers": {"otlp"}, "processors": {"batch"}}
+				})
+			},
+			want: map[string]any{
+				"otel-components": map[string][]string{"receivers": {"otlp"}, "processors": {"batch"}},
+			},
+		},
+		"otel engine also reports embedded alloyengine components": {
+			setup: func(tr *Tracker) {
+				tr.SetOTelComponentsFunc(func() map[string][]string {
+					return map[string][]string{"receivers": {"otlp"}}
+				})
+				tr.SetAlloyEngineComponentsFunc(func() []string {
+					return []string{"prometheus.scrape", "loki.write"}
+				})
+			},
+			want: map[string]any{
+				"otel-components":        map[string][]string{"receivers": {"otlp"}},
+				"alloyengine-components": []string{"prometheus.scrape", "loki.write"},
+			},
+		},
 	}
-	require.Equal(t, context.Canceled, r.Start(ctx, metricsFunc))
 
-	mut.Lock()
-	defer mut.Unlock()
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			tr := &Tracker{}
+			tc.setup(tr)
 
-	require.GreaterOrEqual(t, totalReports, 5)
-	first := alloyIDs[0]
-	for _, uid := range alloyIDs {
-		require.Equal(t, first, uid)
+			// Capture the body the reporter POSTs.
+			gotBody := make(chan []byte, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				gotBody <- body
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			origURL := usageStatsURL
+			t.Cleanup(func() { usageStatsURL = origURL })
+			usageStatsURL = server.URL
+
+			rep := &reporter{
+				logger: util.TestAlloyLogger(t).Slog(),
+				seed:   &alloyseed.Seed{UID: "test-uid"},
+			}
+			require.NoError(t, rep.reportUsage(context.Background(), time.Now(), tr.Metrics()))
+
+			var got Report
+			require.NoError(t, json.Unmarshal(<-gotBody, &got))
+			require.Equal(t, "test-uid", got.UsageStatsID)
+
+			// Compare via JSON: the wire representation is what the backend reads,
+			// and it normalizes away Go's []string vs []any after a round-trip.
+			wantJSON, err := json.Marshal(tc.want)
+			require.NoError(t, err)
+			gotJSON, err := json.Marshal(got.Metrics)
+			require.NoError(t, err)
+			require.JSONEq(t, string(wantJSON), string(gotJSON))
+		})
 	}
-	require.Equal(t, first, r.seed.UID)
+}
+
+// TestExtractOtelComponents covers turning an OTel Collector config (as parsed
+// from YAML) into component types grouped by kind: ids collapse to their type
+// (otlp/2 -> otlp) and dedupe within a kind, non-component sections are ignored,
+// and malformed sections and empty ids are skipped.
+func TestExtractOtelComponents(t *testing.T) {
+	const groupedConfig = `
+receivers:
+  otlp:
+  otlp/2:
+  prometheus/scrape:
+processors:
+  batch:
+exporters:
+  debug:
+  otlp:
+service:
+  pipelines:
+    metrics:
+`
+	const malformedConfig = `
+receivers: not-a-map
+processors:
+exporters:
+  "":
+  "/foo":
+  otlp:
+`
+	tests := map[string]struct {
+		config string
+		want   map[string][]string
+	}{
+		"empty config": {
+			config: "",
+			want:   map[string][]string{},
+		},
+		"groups by kind and collapses ids to types": {
+			config: groupedConfig,
+			want: map[string][]string{
+				"receivers":  {"otlp", "prometheus"},
+				"processors": {"batch"},
+				"exporters":  {"debug", "otlp"},
+			},
+		},
+		"skips malformed sections and empty ids": {
+			config: malformedConfig,
+			want: map[string][]string{
+				"exporters": {"otlp"},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var conf map[string]any
+			require.NoError(t, yaml.Unmarshal([]byte(tc.config), &conf))
+			require.Equal(t, tc.want, ExtractOtelComponents(conf))
+		})
+	}
 }
 
 func Test_ReportLoop_BoundedRetriesOnFailure(t *testing.T) {
@@ -86,8 +185,7 @@ func Test_ReportLoop_BoundedRetriesOnFailure(t *testing.T) {
 	defer server.Close()
 	usageStatsURL = server.URL
 
-	r, err := NewReporter(util.TestAlloyLogger(t).Slog())
-	require.NoError(t, err)
+	r := &reporter{logger: util.TestAlloyLogger(t).Slog()}
 	// Make the first report eligible immediately; otherwise the loop waits a
 	// full (now hour-long) interval before its first attempt.
 	r.lastReport = time.Now().Add(-2 * reportInterval)
@@ -100,7 +198,7 @@ func Test_ReportLoop_BoundedRetriesOnFailure(t *testing.T) {
 		cycles.Add(1)
 		return map[string]any{}
 	}
-	require.Equal(t, context.DeadlineExceeded, r.Start(ctx, metricsFunc))
+	require.Equal(t, context.DeadlineExceeded, r.run(ctx, metricsFunc))
 
 	require.Equal(t, int64(1), cycles.Load())
 }

--- a/internal/usagestats/stats.go
+++ b/internal/usagestats/stats.go
@@ -30,6 +30,10 @@ type Report struct {
 	Os           string         `json:"os"`
 	Arch         string         `json:"arch"`
 	DeployMode   string         `json:"deployMode"`
+	// Engine identifies which Alloy engine is running:
+	// * "default" for `alloy run`
+	// * "otel" for `alloy otel`
+	Engine string `json:"engine"`
 }
 
 func sendReport(ctx context.Context, seed *alloyseed.Seed, interval time.Time, metrics map[string]any) error {
@@ -42,6 +46,7 @@ func sendReport(ctx context.Context, seed *alloyseed.Seed, interval time.Time, m
 		Interval:     interval,
 		Metrics:      metrics,
 		DeployMode:   useragent.GetDeployMode(),
+		Engine:       useragent.GetEngineMode(),
 	}
 	out, err := json.MarshalIndent(report, "", " ")
 	if err != nil {


### PR DESCRIPTION

### Pull Request Details

Similarly to how Default Engine has been sending usage stats, it would be good to have them for OTel Engine so that we know which components users find most valuable. I'm also making Alloy Extension telemetry separate from Default Engine so that we can also tell which Alloy Extension components people tend to use in OTel Engine.


### Notes to the Reviewer

This PR will need to be merged after #6620. Then I will also repoint the target branch of the PR to be the `main` branch.


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
