### PR TITLE
feat(otelcol): Expose small v0.152/v0.153 upstream config field additions

### DIFF
--- a/docs/sources/reference/components/otelcol/otelcol.connector.spanmetrics.md
+++ b/docs/sources/reference/components/otelcol/otelcol.connector.spanmetrics.md
@@ -76,6 +76,7 @@ You can use the following arguments with `otelcol.connector.spanmetrics`:
 | `namespace`                       | `string`       | Metric namespace.                                                                                     | `"traces.span.metrics"` | no       |
 | `resource_metrics_cache_size`     | `number`       | The size of the cache holding metrics for a service.                                                  | `1000`                  | no       |
 | `resource_metrics_key_attributes` | `list(string)` | Limits the resource attributes used to create the metrics.                                            | `[]`                    | no       |
+| `series_expiration`               | `duration`     | Time period after which individual metric series are considered stale and are no longer exported.    | `"0s"`                  | no       |
 | `aggregation_cardinality_limit`   | `number`       | The maximum number of unique combinations of dimensions that will be tracked for metrics aggregation. | `0`                     | no       |
 | `include_instrumentation_scope`   | `list(string)` | A list of instrumentation scope names to include from the traces.                                     | `[]`                    | no       |
 | `include_collector_instance_id`   | `bool`         | Add a `collector.instance.id` dimension for [Single Writer Principle][single-writer-principle] compliance. | `false`                 | no       |
@@ -88,6 +89,8 @@ The supported values for `aggregation_temporality` are:
 If `namespace` is set, the generated metric name will be added a `namespace.` prefix.
 
 Setting `metrics_expiration` to `"0s"` means that the metrics will never expire.
+
+Setting `series_expiration` to `"0s"` means that series will never expire.
 
 `resource_metrics_cache_size` is mostly relevant for cumulative temporality. It helps avoid issues with increasing memory and with incorrect metric timestamp resets.
 

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.kafka.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.kafka.md
@@ -130,6 +130,7 @@ The `logs` block configures how to send logs to Kafka brokers.
 | Name                      | Type     | Description                                                                                                                                        | Default        | Required |
 | ------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | -------- |
 | `encoding`                | `string` | The encoding for logs. Refer to [Supported encodings](#supported-encodings).                                                                       | `"otlp_proto"` | no       |
+| `message_key_from_metadata_key` | `string` | The name of the metadata key whose value should be used as the message's key. Mutually exclusive with `partition_logs_by_resource_attributes` and `partition_logs_by_trace_id`. | `""`           | no       |
 | `topic`                   | `string` | The name of the Kafka topic to which logs will be exported.                                                                                        | `"otlp_logs"`  | no       |
 | `topic_from_metadata_key` | `string` | The name of the metadata key whose value should be used as the message's topic. Takes precedence over `topic_from_attribute` and `topic` settings. | `""`           | no       |
 
@@ -140,6 +141,7 @@ The `metrics` block configures how to send metrics to Kafka brokers.
 | Name                      | Type     | Description                                                                                                                                        | Default          | Required |
 | ------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
 | `encoding`                | `string` | The encoding for metrics. Refer to [Supported encodings](#supported-encodings).                                                                   | `"otlp_proto"`   | no       |
+| `message_key_from_metadata_key` | `string` | The name of the metadata key whose value should be used as the message's key. Mutually exclusive with `partition_metrics_by_resource_attributes`. | `""`             | no       |
 | `topic`                   | `string` | The name of the Kafka topic to which metrics will be exported.                                                                                     | `"otlp_metrics"` | no       |
 | `topic_from_metadata_key` | `string` | The name of the metadata key whose value should be used as the message's topic. Takes precedence over `topic_from_attribute` and `topic` settings. | `""`             | no       |
 
@@ -150,6 +152,7 @@ The `traces` block configures how to send traces to Kafka brokers.
 | Name                      | Type     | Description                                                                                                                                        | Default        | Required |
 | ------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | -------- |
 | `encoding`                | `string` | The encoding for traces. Refer to [Supported encodings](#supported-encodings).                                                                     | `"otlp_proto"` | no       |
+| `message_key_from_metadata_key` | `string` | The name of the metadata key whose value should be used as the message's key. Mutually exclusive with `partition_traces_by_id`. | `""`           | no       |
 | `topic`                   | `string` | The name of the Kafka topic to which traces will be exported.                                                                                      | `"otlp_spans"` | no       |
 | `topic_from_metadata_key` | `string` | The name of the metadata key whose value should be used as the message's topic. Takes precedence over `topic_from_attribute` and `topic` settings. | `""`           | no       |
 

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.loadbalancing.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.loadbalancing.md
@@ -164,6 +164,7 @@ The following arguments are supported:
 | `service_name`  | `string`   | The name of the service which was specified when registering the instance.         |             | yes      |
 | `health_status` | `string`   | Ports to use with the IP addresses resolved from `service`.                        | `"HEALTHY"` | no       |
 | `interval`      | `duration` | Resolver interval.                                                                 | `"30s"`     | no       |
+| `owner_account` | `string`   | The AWS account that owns the CloudMap namespace, for cross-account service discovery. | `""`    | no       |
 | `port`          | `number`   | Port to be used for exporting the traces to the addresses resolved from `service`. | `null`      | no       |
 | `timeout`       | `duration` | Resolver timeout.                                                                  | `"5s"`      | no       |
 

--- a/docs/sources/reference/components/otelcol/otelcol.processor.k8sattributes.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.k8sattributes.md
@@ -45,6 +45,7 @@ You can use the following arguments with `otelcol.processor.k8sattributes`:
 | `passthrough`               | `bool`     | Pass through signals as-is, only adding a `k8s.pod.ip` resource attribute.     | `false`            | no       |
 | `wait_for_metadata_timeout` | `duration` | How long to wait for Kubernetes metadata to arrive.                            | `"10s"`            | no       |
 | `wait_for_metadata`         | `bool`     | Whether to wait for Kubernetes metadata to arrive before processing telemetry. | `false`            | no       |
+| `watch_sync_period`         | `duration` | The resync period for the Kubernetes informers. `0` disables periodic resync.  | `"5m"`             | no       |
 
 The supported values for `auth_type` are:
 

--- a/docs/sources/reference/components/otelcol/otelcol.processor.tail_sampling.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.tail_sampling.md
@@ -312,6 +312,7 @@ The following arguments are supported:
 | Name               | Type     | Description                                                         | Default | Required |
 | ------------------ | -------- | ------------------------------------------------------------------- | ------- | -------- |
 | `spans_per_second` | `number` | Sets the maximum number of spans that can be processed each second. |         | yes      |
+| `burst_capacity`   | `number` | Sets the maximum burst size in spans. If omitted, it defaults to `2 * spans_per_second` in the upstream policy. | `0`     | no       |
 
 ### `bytes_limiting`
 

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.datadog.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.datadog.md
@@ -45,6 +45,8 @@ You can use the following arguments with `otelcol.receiver.datadog`:
 | `auth`                   | `capsule(otelcol.Handler)` | Handler from an `otelcol.auth` component to use for authenticating requests. |                                                            | no       |
 | `compression_algorithms` | `list(string)`             | A list of compression algorithms the server can accept.                      | `["", "gzip", "zstd", "zlib", "snappy", "deflate", "lz4"]` | no       |
 | `endpoint`               | `string`                   | `host:port` to listen for traffic on.                                        | `"localhost:8126"`                                         | no       |
+| `idle_series_cleanup_interval` | `duration`            | How frequently to check for stale series.                                    | `"5m"`                                                     | no       |
+| `idle_series_timeout`    | `duration`                 | Duration after which a series is considered stale and evicted. `0` disables eviction. | `"0s"`                                             | no       |
 | `idle_timeout`           | `duration`                 | Maximum idle time before closing a keep-alive connection.                    | `"1m"`                                                     | no       |
 | `include_metadata`       | `bool`                     | Propagate incoming connection metadata to downstream consumers.              | `false`                                                    | no       |
 | `keep_alives_enabled`    | `boolean`                  | Whether or not HTTP keep-alives are enabled                                  | `true`                                                     | no       |

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.filelog.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.filelog.md
@@ -48,6 +48,7 @@ You can use the following arguments with `otelcol.receiver.filelog`:
 | `encoding`                      | `string`                   | The encoding of the log file.                                                              | `"utf-8"` | no       |
 | `exclude_older_than`            | `duration`                 | Exclude files with a modification time older than the specified duration.                  | `"0s"`    | no       |
 | `exclude`                       | `list(string)`             | A list of glob patterns to exclude files that would be included by the `include` patterns. | `[]`      | no       |
+| `file_cache_advise`             | `bool`                     | Whether to advise the OS to expect sequential reads while tailing the file (Linux only).   | `false`   | no       |
 | `fingerprint_size`              | `units.Base2Bytes`         | The size of the fingerprint used to detect file changes.                                   | `1KiB`    | no       |
 | `force_flush_period`            | `duration`                 | The period after which logs are flushed even if the buffer isn't full.                     | `"500ms"` | no       |
 | `include_file_name_resolved`    | `bool`                     | Whether to include the resolved filename in the log entry.                                 | `false`   | no       |

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.vcenter.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.vcenter.md
@@ -63,6 +63,7 @@ You can use the following arguments with `otelcol.receiver.vcenter`:
 | `password`            | `string`   | Password to use for authentication.                                       |         | yes      |
 | `collection_interval` | `duration` | Defines how often to collect metrics.                                     | `"1m"`  | no       |
 | `initial_delay`       | `duration` | Defines how long this receiver waits before starting.                     | `"1s"`  | no       |
+| `max_query_metrics`   | `int`      | Caps the number of metrics requested per vSphere `QueryPerf` call.        | `256`   | no       |
 | `timeout`             | `duration` | Defines the timeout for the underlying HTTP client.                       | `"0s"`  | no       |
 
 `endpoint` has the format `<protocol>://<hostname>`. For example, `https://vcsa.hostname.localnet`.

--- a/internal/component/otelcol/connector/spanmetrics/spanmetrics.go
+++ b/internal/component/otelcol/connector/spanmetrics/spanmetrics.go
@@ -74,6 +74,10 @@ type Arguments struct {
 	// Default value (0) means that the metrics will never expire.
 	MetricsExpiration time.Duration `alloy:"metrics_expiration,attr,optional"`
 
+	// SeriesExpiration is the time period after which individual metric series are considered stale and are no longer exported.
+	// Default value (0) means that series will never expire.
+	SeriesExpiration time.Duration `alloy:"series_expiration,attr,optional"`
+
 	// TimestampCacheSize controls the size of the cache used to keep track of delta metrics' TimestampUnixNano the last time it was flushed
 	TimestampCacheSize int `alloy:"metric_timestamp_cache_size,attr,optional"`
 
@@ -117,6 +121,7 @@ var DefaultArguments = Arguments{
 	AggregationTemporality:   AggregationTemporalityCumulative,
 	MetricsFlushInterval:     60 * time.Second,
 	MetricsExpiration:        0,
+	SeriesExpiration:         0,
 	ResourceMetricsCacheSize: 1000,
 	TimestampCacheSize:       1000,
 	Namespace:                "traces.span.metrics",
@@ -226,6 +231,7 @@ func (args Arguments) Convert() (otelcomponent.Config, error) {
 		Histogram:                    *histogram,
 		MetricsFlushInterval:         args.MetricsFlushInterval,
 		MetricsExpiration:            args.MetricsExpiration,
+		SeriesExpiration:             args.SeriesExpiration,
 		Namespace:                    args.Namespace,
 		Exemplars:                    *args.Exemplars.Convert(),
 		Events:                       args.Events.Convert(),

--- a/internal/component/otelcol/connector/spanmetrics/spanmetrics_test.go
+++ b/internal/component/otelcol/connector/spanmetrics/spanmetrics_test.go
@@ -149,6 +149,7 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 			}
 			metrics_flush_interval = "33s"
 			metrics_expiration = "44s"
+			series_expiration = "55s"
 			namespace = "test.namespace"
 			exemplars {
 				enabled = true
@@ -191,6 +192,7 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 				},
 				MetricsFlushInterval: 33 * time.Second,
 				MetricsExpiration:    44 * time.Second,
+				SeriesExpiration:     55 * time.Second,
 				Namespace:            "test.namespace",
 				Exemplars: spanmetricsconnector.ExemplarsConfig{
 					Enabled:         true,

--- a/internal/component/otelcol/exporter/kafka/kafka.go
+++ b/internal/component/otelcol/exporter/kafka/kafka.go
@@ -95,9 +95,10 @@ type Arguments struct {
 }
 
 type KafkaExporterSignalConfig struct {
-	Topic                string `alloy:"topic,attr,optional"`
-	TopicFromMetadataKey string `alloy:"topic_from_metadata_key,attr,optional"`
-	Encoding             string `alloy:"encoding,attr,optional"`
+	Topic                     string `alloy:"topic,attr,optional"`
+	TopicFromMetadataKey      string `alloy:"topic_from_metadata_key,attr,optional"`
+	Encoding                  string `alloy:"encoding,attr,optional"`
+	MessageKeyFromMetadataKey string `alloy:"message_key_from_metadata_key,attr,optional"`
 }
 
 // RecordPartitionerConfig selects the strategy used to assign Kafka records to partitions.
@@ -148,6 +149,7 @@ func (c *KafkaExporterSignalConfig) convert(topic, encoding deprecatedArg) kafka
 			result.Encoding = c.Encoding
 		}
 		result.TopicFromMetadataKey = c.TopicFromMetadataKey
+		result.MessageKeyFromMetadataKey = c.MessageKeyFromMetadataKey
 	} else { // Try to use deprecated attributes only if the new block is not set.
 		if len(topic.value) > 0 {
 			result.Topic = topic.value

--- a/internal/component/otelcol/exporter/kafka/kafka_test.go
+++ b/internal/component/otelcol/exporter/kafka/kafka_test.go
@@ -202,6 +202,20 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 			}(),
 		},
 		{
+			testName: "Message key from metadata key",
+			cfg: `
+				protocol_version = "2.0.0"
+				logs {
+					message_key_from_metadata_key = "my.metadata.key"
+				}
+			`,
+			expected: func() kafkaexporter.Config {
+				cfg := defaultExpected()
+				cfg.Logs.MessageKeyFromMetadataKey = "my.metadata.key"
+				return cfg
+			}(),
+		},
+		{
 			testName: "Explicit",
 			cfg: `
 				protocol_version = "2.0.0"

--- a/internal/component/otelcol/exporter/loadbalancing/loadbalancing.go
+++ b/internal/component/otelcol/exporter/loadbalancing/loadbalancing.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/pipeline"
+	"k8s.io/utils/ptr"
 
 	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/component/otelcol"
@@ -310,6 +311,8 @@ type AWSCloudMapResolver struct {
 	Interval      time.Duration `alloy:"interval,attr,optional"`
 	Timeout       time.Duration `alloy:"timeout,attr,optional"`
 	Port          *uint16       `alloy:"port,attr,optional"`
+	// OwnerAccount is the AWS account that owns the Cloud Map namespace, for cross-account service discovery.
+	OwnerAccount string `alloy:"owner_account,attr,optional"`
 }
 
 var _ syntax.Defaulter = &AWSCloudMapResolver{}
@@ -351,6 +354,11 @@ func (r *AWSCloudMapResolver) Convert() configoptional.Optional[loadbalancingexp
 		port = &portNum
 	}
 
+	var ownerAccount *string
+	if r.OwnerAccount != "" {
+		ownerAccount = ptr.To(r.OwnerAccount)
+	}
+
 	return configoptional.Some(loadbalancingexporter.AWSCloudMapResolver{
 		NamespaceName: r.NamespaceName,
 		ServiceName:   r.ServiceName,
@@ -358,6 +366,7 @@ func (r *AWSCloudMapResolver) Convert() configoptional.Optional[loadbalancingexp
 		Interval:      r.Interval,
 		Timeout:       r.Timeout,
 		Port:          port,
+		OwnerAccount:  ownerAccount,
 	})
 }
 

--- a/internal/component/otelcol/exporter/loadbalancing/loadbalancing_test.go
+++ b/internal/component/otelcol/exporter/loadbalancing/loadbalancing_test.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 	"google.golang.org/grpc"
+	"k8s.io/utils/ptr"
 
 	"github.com/grafana/alloy/internal/component/otelcol"
 	otelcolCfg "github.com/grafana/alloy/internal/component/otelcol/config"
@@ -521,6 +522,7 @@ func TestConfigConversion(t *testing.T) {
 						interval = "123s"
 						timeout = "113s"
 						port = 4321
+						owner_account = "123456789012"
 					}
 				}
 				protocol {
@@ -540,6 +542,7 @@ func TestConfigConversion(t *testing.T) {
 						Interval:      123 * time.Second,
 						Timeout:       113 * time.Second,
 						Port:          getPtrToUint(4321),
+						OwnerAccount:  ptr.To("123456789012"),
 					}),
 				},
 				RoutingKey: "traceID",

--- a/internal/component/otelcol/processor/k8sattributes/k8sattributes.go
+++ b/internal/component/otelcol/processor/k8sattributes/k8sattributes.go
@@ -48,6 +48,9 @@ type Arguments struct {
 	// The maximum time the processor will wait for the k8s metadata to be synced.
 	WaitForMetadataTimeout time.Duration `alloy:"wait_for_metadata_timeout,attr,optional"`
 
+	// WatchSyncPeriod determines the resync period for the k8s informers. 0 disables periodic resync.
+	WatchSyncPeriod time.Duration `alloy:"watch_sync_period,attr,optional"`
+
 	// Output configures where to send processed data. Required.
 	Output *otelcol.ConsumerArguments `alloy:"output,block"`
 
@@ -66,6 +69,7 @@ func (args *Arguments) SetToDefault() {
 		},
 	}
 	args.WaitForMetadataTimeout = 10 * time.Second
+	args.WatchSyncPeriod = 5 * time.Minute
 	args.ExtractConfig.SetToDefault()
 	args.DebugMetrics.SetToDefault()
 }
@@ -120,6 +124,7 @@ func (args Arguments) Convert() (otelcomponent.Config, error) {
 	// Set the timeout after the decoding step.
 	// That way we don't have to convert a duration to a string.
 	result.WaitForMetadataTimeout = args.WaitForMetadataTimeout
+	result.WatchSyncPeriod = args.WatchSyncPeriod
 
 	return &result, nil
 }

--- a/internal/component/otelcol/processor/k8sattributes/k8sattributes_test.go
+++ b/internal/component/otelcol/processor/k8sattributes/k8sattributes_test.go
@@ -431,3 +431,39 @@ func Test_WaitForMetadata(t *testing.T) {
 		require.Equal(t, 14*time.Second, otelObj.WaitForMetadataTimeout)
 	})
 }
+
+func Test_WatchSyncPeriod(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		cfg := `
+		output {
+			// no-op: will be overridden by test code.
+		}
+	`
+		var args k8sattributes.Arguments
+		require.NoError(t, syntax.Unmarshal([]byte(cfg), &args))
+
+		convertedArgs, err := args.Convert()
+		require.NoError(t, err)
+		otelObj := (convertedArgs).(*k8sattributesprocessor.Config)
+
+		require.Equal(t, 5*time.Minute, otelObj.WatchSyncPeriod)
+	})
+
+	t.Run("non_default", func(t *testing.T) {
+		cfg := `
+		watch_sync_period = "30s"
+
+		output {
+			// no-op: will be overridden by test code.
+		}
+	`
+		var args k8sattributes.Arguments
+		require.NoError(t, syntax.Unmarshal([]byte(cfg), &args))
+
+		convertedArgs, err := args.Convert()
+		require.NoError(t, err)
+		otelObj := (convertedArgs).(*k8sattributesprocessor.Config)
+
+		require.Equal(t, 30*time.Second, otelObj.WatchSyncPeriod)
+	})
+}

--- a/internal/component/otelcol/processor/tail_sampling/tail_sampling_test.go
+++ b/internal/component/otelcol/processor/tail_sampling/tail_sampling_test.go
@@ -171,6 +171,7 @@ func TestBigConfig(t *testing.T) {
       type = "rate_limiting"
       rate_limiting {
         spans_per_second = 35
+        burst_capacity = 70
       }
     }
     policy {

--- a/internal/component/otelcol/processor/tail_sampling/types.go
+++ b/internal/component/otelcol/processor/tail_sampling/types.go
@@ -176,11 +176,14 @@ func (stringAttributeConfig StringAttributeConfig) Convert() tsp.StringAttribute
 type RateLimitingConfig struct {
 	// SpansPerSecond sets the limit on the maximum nuber of spans that can be processed each second.
 	SpansPerSecond int64 `alloy:"spans_per_second,attr"`
+	// BurstCapacity sets the maximum burst capacity in spans. If not specified, defaults to 2x SpansPerSecond.
+	BurstCapacity int64 `alloy:"burst_capacity,attr,optional"`
 }
 
 func (rateLimitingConfig RateLimitingConfig) Convert() tsp.RateLimitingCfg {
 	return tsp.RateLimitingCfg{
 		SpansPerSecond: rateLimitingConfig.SpansPerSecond,
+		BurstCapacity:  rateLimitingConfig.BurstCapacity,
 	}
 }
 

--- a/internal/component/otelcol/receiver/datadog/datadog.go
+++ b/internal/component/otelcol/receiver/datadog/datadog.go
@@ -37,6 +37,11 @@ type Arguments struct {
 
 	TraceIDCacheSize int `alloy:"trace_id_cache_size,attr,optional"`
 
+	// IdleSeriesTimeout is the duration after which a series is considered stale and evicted. 0 disables eviction.
+	IdleSeriesTimeout time.Duration `alloy:"idle_series_timeout,attr,optional"`
+	// IdleSeriesCleanupInterval defines how frequently the receiver checks for stale series.
+	IdleSeriesCleanupInterval time.Duration `alloy:"idle_series_cleanup_interval,attr,optional"`
+
 	Intake *IntakeArguments `alloy:"intake,block,optional"`
 
 	// DebugMetrics configures component internal metrics. Optional.
@@ -105,6 +110,7 @@ func (args *Arguments) SetToDefault() {
 			ReadHeaderTimeout:     otelcol.DefaultHTTPServerReadHeaderTimeout,
 			WriteTimeout:          otelcol.DefaultHTTPServerWriteTimeout,
 		},
+		IdleSeriesCleanupInterval: 5 * time.Minute,
 	}
 	args.DebugMetrics.SetToDefault()
 }
@@ -117,8 +123,10 @@ func (args Arguments) Convert() (otelcomponent.Config, error) {
 	}
 
 	cfg := &datadogreceiver.Config{
-		ServerConfig:     *convertedHttpServer,
-		TraceIDCacheSize: args.TraceIDCacheSize,
+		ServerConfig:              *convertedHttpServer,
+		TraceIDCacheSize:          args.TraceIDCacheSize,
+		IdleSeriesTimeout:         args.IdleSeriesTimeout,
+		IdleSeriesCleanupInterval: args.IdleSeriesCleanupInterval,
 	}
 
 	if args.Intake != nil {

--- a/internal/component/otelcol/receiver/datadog/datadog_test.go
+++ b/internal/component/otelcol/receiver/datadog/datadog_test.go
@@ -89,6 +89,22 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 		require.Equal(t, 500, otelArgs.TraceIDCacheSize)
 	})
 
+	t.Run("idle_series", func(t *testing.T) {
+		in := `
+		idle_series_timeout = "10m"
+		idle_series_cleanup_interval = "1m"
+
+		output { /* no-op */ }
+		`
+		var args datadog.Arguments
+		require.NoError(t, syntax.Unmarshal([]byte(in), &args))
+		ext, err := args.Convert()
+		require.NoError(t, err)
+		otelArgs := ext.(*datadogreceiver.Config)
+		require.Equal(t, 10*time.Minute, otelArgs.IdleSeriesTimeout)
+		require.Equal(t, time.Minute, otelArgs.IdleSeriesCleanupInterval)
+	})
+
 	t.Run("intake_proxy", func(t *testing.T) {
 		in := `
 		intake {

--- a/internal/component/otelcol/receiver/filelog/filelog.go
+++ b/internal/component/otelcol/receiver/filelog/filelog.go
@@ -55,6 +55,7 @@ type Arguments struct {
 	IncludeFileRecordNumber bool                     `alloy:"include_file_record_number,attr,optional"`
 	Compression             string                   `alloy:"compression,attr,optional"`
 	AcquireFSLock           bool                     `alloy:"acquire_fs_lock,attr,optional"`
+	FileCacheAdvise         bool                     `alloy:"file_cache_advise,attr,optional"`
 	MultilineConfig         *otelcol.MultilineConfig `alloy:"multiline,block,optional"`
 	TrimConfig              *otelcol.TrimConfig      `alloy:",squash"`
 	Header                  *HeaderConfig            `alloy:"header,block,optional"`
@@ -172,6 +173,7 @@ func (args Arguments) Convert() (otelcomponent.Config, error) {
 	cfg.InputConfig.IncludeFileRecordNumber = args.IncludeFileRecordNumber
 	cfg.InputConfig.Compression = args.Compression
 	cfg.InputConfig.AcquireFSLock = args.AcquireFSLock
+	cfg.InputConfig.FileCacheAdvise = args.FileCacheAdvise
 
 	if len(args.Attributes) > 0 {
 		cfg.InputConfig.Attributes = make(map[string]helper.ExprStringConfig, len(args.Attributes))

--- a/internal/component/otelcol/receiver/filelog/filelog_test.go
+++ b/internal/component/otelcol/receiver/filelog/filelog_test.go
@@ -124,6 +124,7 @@ func TestUnmarshal(t *testing.T) {
 	include_file_record_number = true
 	compression                = "gzip"
 	acquire_fs_lock            = true
+	file_cache_advise          = true
 
 	header {
 		pattern = "^HEADER .*$"

--- a/internal/component/otelcol/receiver/vcenter/vcenter.go
+++ b/internal/component/otelcol/receiver/vcenter/vcenter.go
@@ -378,6 +378,9 @@ type Arguments struct {
 	ScraperControllerArguments otelcol.ScraperControllerArguments `alloy:",squash"`
 	TLS                        otelcol.TLSClientArguments         `alloy:"tls,block,optional"`
 
+	// MaxQueryMetrics caps the number of metrics requested per vSphere QueryPerf call.
+	MaxQueryMetrics int `alloy:"max_query_metrics,attr,optional"`
+
 	// DebugMetrics configures component internal metrics. Optional.
 	DebugMetrics otelcolCfg.DebugMetricsArguments `alloy:"debug_metrics,block,optional"`
 
@@ -391,6 +394,7 @@ var _ receiver.Arguments = Arguments{}
 func (args *Arguments) SetToDefault() {
 	*args = Arguments{
 		ScraperControllerArguments: otelcol.DefaultScraperControllerArguments,
+		MaxQueryMetrics:            256,
 	}
 	args.MetricsBuilderConfig.SetToDefault()
 	args.DebugMetrics.SetToDefault()
@@ -412,6 +416,7 @@ func (args Arguments) Convert() (otelcomponent.Config, error) {
 	result.Password = configopaque.String(args.Password)
 	result.ClientConfig = *args.TLS.Convert()
 	result.ControllerConfig = *args.ScraperControllerArguments.Convert()
+	result.MaxQueryMetrics = args.MaxQueryMetrics
 
 	return &result, nil
 }

--- a/internal/component/otelcol/receiver/vcenter/vcenter_test.go
+++ b/internal/component/otelcol/receiver/vcenter/vcenter_test.go
@@ -17,6 +17,7 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 		username = "user"
 		password = "pass"
 		collection_interval = "2m"
+		max_query_metrics = 128
 
 		resource_attributes {
 			vcenter.datacenter.name {
@@ -244,6 +245,7 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 	require.Equal(t, 2*time.Minute, otelArgs.ControllerConfig.CollectionInterval)
 	require.Equal(t, time.Second, otelArgs.ControllerConfig.InitialDelay)
 	require.Equal(t, 0*time.Second, otelArgs.ControllerConfig.Timeout)
+	require.Equal(t, 128, otelArgs.MaxQueryMetrics)
 
 	// Verify ResourceAttributesConfig fields
 	require.True(t, otelArgs.ResourceAttributes.VcenterClusterName.Enabled)

--- a/internal/converter/internal/otelcolconvert/testdata/datadog.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/datadog.alloy
@@ -1,8 +1,9 @@
 otelcol.receiver.datadog "default" {
-	idle_timeout        = "0s"
-	read_timeout        = "0s"
-	write_timeout       = "0s"
-	read_header_timeout = "0s"
+	idle_timeout                 = "0s"
+	read_timeout                 = "0s"
+	write_timeout                = "0s"
+	read_header_timeout          = "0s"
+	idle_series_cleanup_interval = "0s"
 
 	output {
 		metrics = [otelcol.exporter.otlp.default.input, otelcol.exporter.datadog.default.input]

--- a/internal/converter/internal/otelcolconvert/testdata/k8sattributes.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/k8sattributes.alloy
@@ -23,6 +23,7 @@ otelcol.processor.k8sattributes "default" {
 	extract {
 		metadata = ["container.image.name", "container.image.tag", "k8s.deployment.name", "k8s.namespace.name", "k8s.node.name", "k8s.pod.name", "k8s.pod.start_time", "k8s.pod.uid"]
 	}
+	watch_sync_period = "0s"
 
 	output {
 		metrics = [otelcol.exporter.otlp.default.input]

--- a/internal/converter/internal/otelcolconvert/testdata/vcenterreceiver.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/vcenterreceiver.alloy
@@ -14,6 +14,7 @@ otelcol.receiver.vcenter "default" {
 			enabled = false
 		}
 	}
+	max_query_metrics = 0
 
 	output {
 		traces = [otelcol.exporter.otlp.default.input]


### PR DESCRIPTION
### Brief description of Pull Request

I bundled 8 small config-field exposures from the v0.152/v0.153 delta sweep into one PR since each is a single independent field: `idle_series_timeout`/`idle_series_cleanup_interval` on `otelcol.receiver.datadog`, `max_query_metrics` on `otelcol.receiver.vcenter`, `file_cache_advise` on `otelcol.receiver.filelog`, `message_key_from_metadata_key` on `otelcol.exporter.kafka`, `owner_account` on the `aws_cloud_map` resolver of `otelcol.exporter.loadbalancing`, `watch_sync_period` on `otelcol.processor.k8sattributes`, `rate_limiting.burst_capacity` on `otelcol.processor.tail_sampling`, and `series_expiration` on `otelcol.connector.spanmetrics`.

### PR Checklist

- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))