### PR TITLE
feat(discovery.azure): Add "sdk_auth" and "workload_identity" auth options

### DIFF
--- a/docs/sources/reference/components/discovery/discovery.azure.md
+++ b/docs/sources/reference/components/discovery/discovery.azure.md
@@ -49,19 +49,23 @@ You can use the following blocks with `discovery.azure`:
 
 {{< docs/alloy-config >}}
 
-| Block                                  | Description                                      | Required |
-| -------------------------------------- | ------------------------------------------------ | -------- |
-| [`managed_identity`][managed_identity] | Managed Identity configuration for Azure API.    | no       |
-| [`oauth`][oauth]                       | OAuth 2.0 configuration for Azure API.           | no       |
-| [`tls_config`][tls_config]             | TLS configuration for requests to the Azure API. | no       |
+| Block                                    | Description                                        | Required |
+| ---------------------------------------- | -------------------------------------------------- | -------- |
+| [`managed_identity`][managed_identity]   | Managed Identity configuration for Azure API.      | no       |
+| [`oauth`][oauth]                         | OAuth 2.0 configuration for Azure API.             | no       |
+| [`sdk_auth`][sdk_auth]                   | Azure SDK configuration for Azure API.             | no       |
+| [`tls_config`][tls_config]               | TLS configuration for requests to the Azure API.   | no       |
+| [`workload_identity`][workload_identity] | Workload Identity configuration for Azure API.     | no       |
 
 [managed_identity]: #managed_identity
 [oauth]: #oauth
+[sdk_auth]: #sdk_auth
 [tls_config]: #tls_config
+[workload_identity]: #workload_identity
 
 {{< /docs/alloy-config >}}
 
-You must specify exactly one of the `oauth` or `managed_identity` blocks.
+You must specify exactly one of the `oauth`, `managed_identity`, `sdk_auth`, or `workload_identity` blocks.
 
 ### `managed_identity`
 
@@ -81,11 +85,34 @@ The `oauth` block configures OAuth 2.0 authentication for the Azure API.
 | `client_secret` | `string` | OAuth 2.0 client secret. |         | yes      |
 | `tenant_id`     | `string` | OAuth 2.0 tenant ID.     |         | yes      |
 
+### `sdk_auth`
+
+The `sdk_auth` block configures authentication using the [Azure SDK's `DefaultAzureCredential`][default-azure-credential] chain.
+The chain reads credentials from the environment and tries several sources in order, including environment variables, Microsoft Entra Workload Identity, and managed identities.
+Use `sdk_auth` when you want the SDK to pick the appropriate credential automatically, or [`workload_identity`](#workload_identity) when you want to use Workload Identity explicitly.
+
+| Name        | Type     | Description                                                | Default | Required |
+| ----------- | -------- | ---------------------------------------------------------- | ------- | -------- |
+| `tenant_id` | `string` | Tenant ID used to authenticate with the Azure CLI and Workload Identity credentials in the chain. |         | no       |
+
+[default-azure-credential]: https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication
+
 ### `tls_config`
 
 The `tls_config` block configures TLS settings for requests to the Azure API.
 
 {{< docs/shared lookup="reference/components/tls-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `workload_identity`
+
+The `workload_identity` block configures [Microsoft Entra Workload Identity][entra-workload-identity] authentication for the Azure API.
+This is the recommended authentication method when you run {{< param "PRODUCT_NAME" >}} in an Azure Kubernetes Service (AKS) cluster with Workload Identity enabled.
+
+The block takes no arguments.
+The credentials are read from the environment variables that the Azure Workload Identity webhook injects into the {{< param "PRODUCT_NAME" >}} Pod: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_FEDERATED_TOKEN_FILE`.
+Make sure the Pod is labeled with `azure.workload.identity/use: "true"` and uses a `ServiceAccount` annotated with the client ID of the federated managed identity or application.
+
+[entra-workload-identity]: https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview
 
 ## Exported fields
 

--- a/docs/sources/reference/components/discovery/discovery.azure.md
+++ b/docs/sources/reference/components/discovery/discovery.azure.md
@@ -87,7 +87,7 @@ The `oauth` block configures OAuth 2.0 authentication for the Azure API.
 
 ### `sdk_auth`
 
-The `sdk_auth` block configures authentication using the [Azure SDK's `DefaultAzureCredential`][default-azure-credential] chain.
+The `sdk_auth` block configures authentication with the [`DefaultAzureCredential`][default-azure-credential] chain from the Azure SDK.
 The chain reads credentials from the environment and tries several sources in order, including environment variables, Microsoft Entra Workload Identity, and managed identities.
 Use `sdk_auth` when you want the SDK to pick the appropriate credential automatically, or [`workload_identity`](#workload_identity) when you want to use Workload Identity explicitly.
 

--- a/internal/component/discovery/azure/azure.go
+++ b/internal/component/discovery/azure/azure.go
@@ -30,13 +30,15 @@ func init() {
 }
 
 type Arguments struct {
-	Environment     string           `alloy:"environment,attr,optional"`
-	Port            int              `alloy:"port,attr,optional"`
-	SubscriptionID  string           `alloy:"subscription_id,attr,optional"`
-	OAuth           *OAuth           `alloy:"oauth,block,optional"`
-	ManagedIdentity *ManagedIdentity `alloy:"managed_identity,block,optional"`
-	RefreshInterval time.Duration    `alloy:"refresh_interval,attr,optional"`
-	ResourceGroup   string           `alloy:"resource_group,attr,optional"`
+	Environment      string            `alloy:"environment,attr,optional"`
+	Port             int               `alloy:"port,attr,optional"`
+	SubscriptionID   string            `alloy:"subscription_id,attr,optional"`
+	OAuth            *OAuth            `alloy:"oauth,block,optional"`
+	ManagedIdentity  *ManagedIdentity  `alloy:"managed_identity,block,optional"`
+	SDK              *SDK              `alloy:"sdk_auth,block,optional"`
+	WorkloadIdentity *WorkloadIdentity `alloy:"workload_identity,block,optional"`
+	RefreshInterval  time.Duration     `alloy:"refresh_interval,attr,optional"`
+	ResourceGroup    string            `alloy:"resource_group,attr,optional"`
 
 	ProxyConfig     *config.ProxyConfig `alloy:",squash"`
 	FollowRedirects bool                `alloy:"follow_redirects,attr,optional"`
@@ -55,6 +57,22 @@ type ManagedIdentity struct {
 	ClientID string `alloy:"client_id,attr"`
 }
 
+// SDK configures authentication using the Azure SDK's DefaultAzureCredential
+// chain. The chain reads credentials from the environment and tries several
+// sources in order, including environment variables, Workload Identity, and
+// managed identities.
+// See https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication
+type SDK struct {
+	TenantID string `alloy:"tenant_id,attr,optional"`
+}
+
+// WorkloadIdentity configures Microsoft Entra Workload Identity authentication.
+// The credentials are read from the environment variables injected by the Azure
+// Workload Identity webhook (AZURE_CLIENT_ID, AZURE_TENANT_ID, and
+// AZURE_FEDERATED_TOKEN_FILE), so the block takes no arguments of its own.
+type WorkloadIdentity struct {
+}
+
 var DefaultArguments = Arguments{
 	Environment:     azure.PublicCloud.Name,
 	Port:            80,
@@ -70,8 +88,21 @@ func (a *Arguments) SetToDefault() {
 
 // Validate implements syntax.Validator.
 func (a *Arguments) Validate() error {
-	if a.OAuth == nil && a.ManagedIdentity == nil || a.OAuth != nil && a.ManagedIdentity != nil {
-		return fmt.Errorf("exactly one of oauth or managed_identity must be specified")
+	authMethods := 0
+	if a.OAuth != nil {
+		authMethods++
+	}
+	if a.ManagedIdentity != nil {
+		authMethods++
+	}
+	if a.SDK != nil {
+		authMethods++
+	}
+	if a.WorkloadIdentity != nil {
+		authMethods++
+	}
+	if authMethods != 1 {
+		return fmt.Errorf("exactly one of oauth, managed_identity, sdk_auth, or workload_identity must be specified")
 	}
 
 	if err := a.TLSConfig.Validate(); err != nil {
@@ -92,14 +123,20 @@ func (a Arguments) Convert() discovery.DiscovererConfig {
 		tenantID     string
 		clientSecret common.Secret
 	)
-	if a.OAuth != nil {
+	switch {
+	case a.OAuth != nil:
 		authMethod = "OAuth"
 		clientID = a.OAuth.ClientID
 		tenantID = a.OAuth.TenantID
 		clientSecret = common.Secret(a.OAuth.ClientSecret)
-	} else {
+	case a.ManagedIdentity != nil:
 		authMethod = "ManagedIdentity"
 		clientID = a.ManagedIdentity.ClientID
+	case a.SDK != nil:
+		authMethod = "SDK"
+		tenantID = a.SDK.TenantID
+	case a.WorkloadIdentity != nil:
+		authMethod = "WorkloadIdentity"
 	}
 
 	httpClientConfig := config.DefaultHTTPClientConfig

--- a/internal/component/discovery/azure/azure_test.go
+++ b/internal/component/discovery/azure/azure_test.go
@@ -15,183 +15,343 @@ import (
 	"github.com/grafana/alloy/syntax/alloytypes"
 )
 
-func TestAlloyUnmarshal(t *testing.T) {
-	alloyCfg := `
-		environment = "AzureTestCloud"
-		port = 8080
-		subscription_id = "subid"
-		refresh_interval = "10m"
-		resource_group = "test"
-		oauth {
-			client_id = "clientid"
-			tenant_id = "tenantid"
-			client_secret = "clientsecret"
-		}
-		enable_http2 = true
-		follow_redirects = false
-		proxy_url = "http://example:8080"
-		http_headers = {
-			"foo" = ["foobar"],
-		}`
+func TestUnmarshal(t *testing.T) {
+	proxyURL, _ := url.Parse("http://example:8080")
 
-	var args Arguments
-	err := syntax.Unmarshal([]byte(alloyCfg), &args)
-	require.NoError(t, err)
+	tests := []struct {
+		name      string
+		config    string
+		expectErr string
+		expected  Arguments
+	}{
+		{
+			name: "oauth full config",
+			config: `
+				environment = "AzureTestCloud"
+				port = 8080
+				subscription_id = "subid"
+				refresh_interval = "10m"
+				resource_group = "test"
+				oauth {
+					client_id = "clientid"
+					tenant_id = "tenantid"
+					client_secret = "clientsecret"
+				}
+				enable_http2 = true
+				follow_redirects = false
+				proxy_url = "http://example:8080"
+				http_headers = {
+					"foo" = ["foobar"],
+				}`,
+			expected: Arguments{
+				Environment:    "AzureTestCloud",
+				Port:           8080,
+				SubscriptionID: "subid",
+				OAuth: &OAuth{
+					ClientID:     "clientid",
+					TenantID:     "tenantid",
+					ClientSecret: "clientsecret",
+				},
+				RefreshInterval: 10 * time.Minute,
+				ResourceGroup:   "test",
+				ProxyConfig:     &config.ProxyConfig{ProxyURL: config.URL{URL: proxyURL}},
+				FollowRedirects: false,
+				EnableHTTP2:     true,
+				HTTPHeaders: &config.Headers{
+					Headers: map[string][]alloytypes.Secret{"foo": {"foobar"}},
+				},
+			},
+		},
+		{
+			name: "managed_identity",
+			config: `
+				environment = "AzureTestCloud"
+				port = 8080
+				subscription_id = "subid"
+				refresh_interval = "10m"
+				resource_group = "test"
+				managed_identity {
+					client_id = "clientid"
+				}`,
+			expected: Arguments{
+				Environment:     "AzureTestCloud",
+				Port:            8080,
+				SubscriptionID:  "subid",
+				ManagedIdentity: &ManagedIdentity{ClientID: "clientid"},
+				RefreshInterval: 10 * time.Minute,
+				ResourceGroup:   "test",
+				FollowRedirects: true,
+				EnableHTTP2:     true,
+			},
+		},
+		{
+			name: "sdk_auth with tenant_id",
+			config: `
+				environment = "AzureTestCloud"
+				port = 8080
+				subscription_id = "subid"
+				refresh_interval = "10m"
+				resource_group = "test"
+				sdk_auth {
+					tenant_id = "tenantid"
+				}`,
+			expected: Arguments{
+				Environment:     "AzureTestCloud",
+				Port:            8080,
+				SubscriptionID:  "subid",
+				SDK:             &SDK{TenantID: "tenantid"},
+				RefreshInterval: 10 * time.Minute,
+				ResourceGroup:   "test",
+				FollowRedirects: true,
+				EnableHTTP2:     true,
+			},
+		},
+		{
+			name: "sdk_auth without tenant_id",
+			config: `
+				environment = "AzureTestCloud"
+				port = 8080
+				subscription_id = "subid"
+				refresh_interval = "10m"
+				resource_group = "test"
+				sdk_auth {}`,
+			expected: Arguments{
+				Environment:     "AzureTestCloud",
+				Port:            8080,
+				SubscriptionID:  "subid",
+				SDK:             &SDK{},
+				RefreshInterval: 10 * time.Minute,
+				ResourceGroup:   "test",
+				FollowRedirects: true,
+				EnableHTTP2:     true,
+			},
+		},
+		{
+			name: "workload_identity",
+			config: `
+				environment = "AzureTestCloud"
+				port = 8080
+				subscription_id = "subid"
+				refresh_interval = "10m"
+				resource_group = "test"
+				workload_identity {}`,
+			expected: Arguments{
+				Environment:      "AzureTestCloud",
+				Port:             8080,
+				SubscriptionID:   "subid",
+				WorkloadIdentity: &WorkloadIdentity{},
+				RefreshInterval:  10 * time.Minute,
+				ResourceGroup:    "test",
+				FollowRedirects:  true,
+				EnableHTTP2:      true,
+			},
+		},
+		{
+			name: "oauth missing required fields",
+			config: `
+				environment = "AzureTestCloud"
+				port = 8080
+				subscription_id = "subid"
+				refresh_interval = "10m"
+				resource_group = "test"
+				oauth {
+					client_id = "clientid"
+				}`,
+			expectErr: "missing required attribute",
+		},
+		{
+			name: "no auth method",
+			config: `
+				environment = "AzureTestCloud"
+				port = 8080
+				subscription_id = "subid"
+				refresh_interval = "10m"
+				resource_group = "test"`,
+			expectErr: "exactly one of oauth, managed_identity, sdk_auth, or workload_identity must be specified",
+		},
+		{
+			name: "multiple auth methods",
+			config: `
+				environment = "AzureTestCloud"
+				port = 8080
+				subscription_id = "subid"
+				refresh_interval = "10m"
+				resource_group = "test"
+				oauth {
+					client_id = "clientid"
+					tenant_id = "tenantid"
+					client_secret = "clientsecret"
+				}
+				managed_identity {
+					client_id = "clientid"
+				}`,
+			expectErr: "exactly one of oauth, managed_identity, sdk_auth, or workload_identity must be specified",
+		},
+		{
+			name: "invalid tls config",
+			config: `
+				environment = "AzureTestCloud"
+				port = 8080
+				subscription_id = "subid"
+				refresh_interval = "10m"
+				resource_group = "test"
+				managed_identity {
+					client_id = "clientid"
+				}
+				tls_config {
+					cert_file = "certfile"
+					cert_pem = "certpem"
+				}`,
+			expectErr: "at most one of cert_pem and cert_file must be configured",
+		},
+	}
 
-	assert.Equal(t, "AzureTestCloud", args.Environment)
-	assert.Equal(t, 8080, args.Port)
-	assert.Equal(t, "subid", args.SubscriptionID)
-	assert.Equal(t, 10*time.Minute, args.RefreshInterval)
-	assert.Equal(t, "test", args.ResourceGroup)
-	assert.Equal(t, "clientid", args.OAuth.ClientID)
-	assert.Equal(t, "tenantid", args.OAuth.TenantID)
-	assert.Equal(t, "clientsecret", string(args.OAuth.ClientSecret))
-	assert.Equal(t, true, args.EnableHTTP2)
-	assert.Equal(t, false, args.FollowRedirects)
-	assert.Equal(t, "http://example:8080", args.ProxyConfig.ProxyURL.String())
-
-	header := args.HTTPHeaders.Headers["foo"][0]
-	assert.Equal(t, "foobar", string(header))
-}
-
-func TestAlloyUnmarshal_OAuthRequiredFields(t *testing.T) {
-	alloyCfg := `
-		environment = "AzureTestCloud"
-		port = 8080
-		subscription_id = "subid"
-		refresh_interval = "10m"
-		resource_group = "test"
-		oauth {
-			client_id = "clientid"
-		}`
-	var args Arguments
-	err := syntax.Unmarshal([]byte(alloyCfg), &args)
-	require.Error(t, err)
-}
-
-func TestValidate(t *testing.T) {
-	noAuth := `
-		environment = "AzureTestCloud"
-		port = 8080
-		subscription_id = "subid"
-		refresh_interval = "10m"
-		resource_group = "test"`
-
-	var args Arguments
-	err := syntax.Unmarshal([]byte(noAuth), &args)
-	require.ErrorContains(t, err, "exactly one of oauth or managed_identity must be specified")
-
-	bothAuth := `
-		environment = "AzureTestCloud"
-		port = 8080
-		subscription_id = "subid"
-		refresh_interval = "10m"
-		resource_group = "test"
-		oauth {
-			client_id = "clientid"
-			tenant_id = "tenantid"
-			client_secret = "clientsecret"
-		}
-		managed_identity {
-			client_id = "clientid"
-		}`
-	var args2 Arguments
-	err = syntax.Unmarshal([]byte(bothAuth), &args2)
-	require.ErrorContains(t, err, "exactly one of oauth or managed_identity must be specified")
-
-	invalidTLS := `
-		environment = "AzureTestCloud"
-		port = 8080
-		subscription_id = "subid"
-		refresh_interval = "10m"
-		resource_group = "test"
-		managed_identity {
-			client_id = "clientid"
-		}
-		tls_config {
-			cert_file = "certfile"
-			cert_pem = "certpem"
-		}`
-	var args3 Arguments
-	err = syntax.Unmarshal([]byte(invalidTLS), &args3)
-	require.ErrorContains(t, err, "at most one of cert_pem and cert_file must be configured")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var args Arguments
+			err := syntax.Unmarshal([]byte(tc.config), &args)
+			if tc.expectErr != "" {
+				require.ErrorContains(t, err, tc.expectErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, args)
+		})
+	}
 }
 
 func TestConvert(t *testing.T) {
-	proxyUrl, _ := url.Parse("http://example:8080")
-	alloyArgsOAuth := Arguments{
-		Environment:     "AzureTestCloud",
-		Port:            8080,
-		SubscriptionID:  "subid",
-		RefreshInterval: 10 * time.Minute,
-		ResourceGroup:   "test",
-		OAuth: &OAuth{
-			ClientID:     "clientid",
-			TenantID:     "tenantid",
-			ClientSecret: "clientsecret",
+	proxyURL, _ := url.Parse("http://example:8080")
+	proxyConfig := &config.ProxyConfig{ProxyURL: config.URL{URL: proxyURL}}
+
+	tests := []struct {
+		name string
+		args Arguments
+		// expected is compared against the converted SDConfig. HTTPClientConfig
+		// is derived from Prometheus defaults, so it's verified separately below
+		// via wantProxyURL/wantHeader rather than reconstructed here.
+		expected     promdiscovery.SDConfig
+		wantProxyURL string
+		wantHeader   string
+	}{
+		{
+			name: "oauth",
+			args: Arguments{
+				Environment:     "AzureTestCloud",
+				Port:            8080,
+				SubscriptionID:  "subid",
+				RefreshInterval: 10 * time.Minute,
+				ResourceGroup:   "test",
+				OAuth: &OAuth{
+					ClientID:     "clientid",
+					TenantID:     "tenantid",
+					ClientSecret: "clientsecret",
+				},
+				FollowRedirects: false,
+				EnableHTTP2:     false,
+				ProxyConfig:     proxyConfig,
+				HTTPHeaders: &config.Headers{
+					Headers: map[string][]alloytypes.Secret{"foo": {"foobar"}},
+				},
+			},
+			expected: promdiscovery.SDConfig{
+				Environment:          "AzureTestCloud",
+				Port:                 8080,
+				SubscriptionID:       "subid",
+				RefreshInterval:      model.Duration(10 * time.Minute),
+				ResourceGroup:        "test",
+				AuthenticationMethod: "OAuth",
+				ClientID:             "clientid",
+				TenantID:             "tenantid",
+				ClientSecret:         "clientsecret",
+			},
+			wantProxyURL: "http://example:8080",
+			wantHeader:   "foobar",
 		},
-		FollowRedirects: false,
-		EnableHTTP2:     false,
-		ProxyConfig: &config.ProxyConfig{
-			ProxyURL: config.URL{
-				URL: proxyUrl,
+		{
+			name: "managed_identity",
+			args: Arguments{
+				Environment:     "AzureTestCloud",
+				Port:            8080,
+				SubscriptionID:  "subid",
+				RefreshInterval: 10 * time.Minute,
+				ResourceGroup:   "test",
+				ManagedIdentity: &ManagedIdentity{ClientID: "clientid"},
+				FollowRedirects: true,
+				EnableHTTP2:     true,
+				ProxyConfig:     proxyConfig,
+			},
+			expected: promdiscovery.SDConfig{
+				Environment:          "AzureTestCloud",
+				Port:                 8080,
+				SubscriptionID:       "subid",
+				RefreshInterval:      model.Duration(10 * time.Minute),
+				ResourceGroup:        "test",
+				AuthenticationMethod: "ManagedIdentity",
+				ClientID:             "clientid",
+			},
+			wantProxyURL: "http://example:8080",
+		},
+		{
+			name: "sdk_auth",
+			args: Arguments{
+				Environment:     "AzureTestCloud",
+				Port:            8080,
+				SubscriptionID:  "subid",
+				RefreshInterval: 10 * time.Minute,
+				ResourceGroup:   "test",
+				SDK:             &SDK{TenantID: "tenantid"},
+			},
+			expected: promdiscovery.SDConfig{
+				Environment:          "AzureTestCloud",
+				Port:                 8080,
+				SubscriptionID:       "subid",
+				RefreshInterval:      model.Duration(10 * time.Minute),
+				ResourceGroup:        "test",
+				AuthenticationMethod: "SDK",
+				TenantID:             "tenantid",
 			},
 		},
-		HTTPHeaders: &config.Headers{
-			Headers: map[string][]alloytypes.Secret{
-				"foo": {"foobar"},
+		{
+			name: "workload_identity",
+			args: Arguments{
+				Environment:      "AzureTestCloud",
+				Port:             8080,
+				SubscriptionID:   "subid",
+				RefreshInterval:  10 * time.Minute,
+				ResourceGroup:    "test",
+				WorkloadIdentity: &WorkloadIdentity{},
+			},
+			expected: promdiscovery.SDConfig{
+				Environment:          "AzureTestCloud",
+				Port:                 8080,
+				SubscriptionID:       "subid",
+				RefreshInterval:      model.Duration(10 * time.Minute),
+				ResourceGroup:        "test",
+				AuthenticationMethod: "WorkloadIdentity",
 			},
 		},
 	}
 
-	args := alloyArgsOAuth.Convert()
-	promArgs, ok := args.(*promdiscovery.SDConfig)
-	require.True(t, ok)
-	assert.Equal(t, "AzureTestCloud", promArgs.Environment)
-	assert.Equal(t, 8080, promArgs.Port)
-	assert.Equal(t, "subid", promArgs.SubscriptionID)
-	assert.Equal(t, model.Duration(10*time.Minute), promArgs.RefreshInterval)
-	assert.Equal(t, "test", promArgs.ResourceGroup)
-	assert.Equal(t, "clientid", promArgs.ClientID)
-	assert.Equal(t, "tenantid", promArgs.TenantID)
-	assert.Equal(t, "clientsecret", string(promArgs.ClientSecret))
-	assert.Equal(t, false, promArgs.HTTPClientConfig.FollowRedirects)
-	assert.Equal(t, false, promArgs.HTTPClientConfig.EnableHTTP2)
-	assert.Equal(t, "http://example:8080", promArgs.HTTPClientConfig.ProxyURL.String())
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := tc.args.Convert().(*promdiscovery.SDConfig)
+			require.True(t, ok)
 
-	header := promArgs.HTTPClientConfig.HTTPHeaders.Headers["foo"].Secrets[0]
-	assert.Equal(t, "foobar", string(header))
+			// The HTTP client config is derived from Prometheus defaults; verify
+			// its relevant fields separately and exclude it from the struct diff.
+			httpCfg := got.HTTPClientConfig
+			got.HTTPClientConfig = tc.expected.HTTPClientConfig
+			require.Equal(t, &tc.expected, got)
 
-	alloyArgsManagedIdentity := Arguments{
-		Environment:     "AzureTestCloud",
-		Port:            8080,
-		SubscriptionID:  "subid",
-		RefreshInterval: 10 * time.Minute,
-		ResourceGroup:   "test",
-		ManagedIdentity: &ManagedIdentity{
-			ClientID: "clientid",
-		},
-		FollowRedirects: true,
-		EnableHTTP2:     true,
-		ProxyConfig: &config.ProxyConfig{
-			ProxyURL: config.URL{
-				URL: proxyUrl,
-			},
-		},
+			assert.Equal(t, tc.args.FollowRedirects, httpCfg.FollowRedirects)
+			assert.Equal(t, tc.args.EnableHTTP2, httpCfg.EnableHTTP2)
+			if tc.wantProxyURL != "" {
+				assert.Equal(t, tc.wantProxyURL, httpCfg.ProxyURL.String())
+			}
+			if tc.wantHeader != "" {
+				assert.Equal(t, tc.wantHeader, string(httpCfg.HTTPHeaders.Headers["foo"].Secrets[0]))
+			}
+		})
 	}
-
-	args = alloyArgsManagedIdentity.Convert()
-	promArgs, ok = args.(*promdiscovery.SDConfig)
-	require.True(t, ok)
-	assert.Equal(t, "AzureTestCloud", promArgs.Environment)
-	assert.Equal(t, 8080, promArgs.Port)
-	assert.Equal(t, "subid", promArgs.SubscriptionID)
-	assert.Equal(t, model.Duration(10*time.Minute), promArgs.RefreshInterval)
-	assert.Equal(t, "test", promArgs.ResourceGroup)
-	assert.Equal(t, "clientid", promArgs.ClientID)
-	assert.Equal(t, "", promArgs.TenantID)
-	assert.Equal(t, "", string(promArgs.ClientSecret))
-	assert.Equal(t, true, promArgs.HTTPClientConfig.FollowRedirects)
-	assert.Equal(t, true, promArgs.HTTPClientConfig.EnableHTTP2)
-	assert.Equal(t, "http://example:8080", promArgs.HTTPClientConfig.ProxyURL.String())
 }

--- a/internal/component/discovery/azure/azure_test.go
+++ b/internal/component/discovery/azure/azure_test.go
@@ -301,6 +301,8 @@ func TestConvert(t *testing.T) {
 				RefreshInterval: 10 * time.Minute,
 				ResourceGroup:   "test",
 				SDK:             &SDK{TenantID: "tenantid"},
+				FollowRedirects: true,
+				EnableHTTP2:     true,
 			},
 			expected: promdiscovery.SDConfig{
 				Environment:          "AzureTestCloud",
@@ -321,6 +323,8 @@ func TestConvert(t *testing.T) {
 				RefreshInterval:  10 * time.Minute,
 				ResourceGroup:    "test",
 				WorkloadIdentity: &WorkloadIdentity{},
+				FollowRedirects:  true,
+				EnableHTTP2:      true,
 			},
 			expected: promdiscovery.SDConfig{
 				Environment:          "AzureTestCloud",

--- a/internal/converter/internal/prometheusconvert/component/azure.go
+++ b/internal/converter/internal/prometheusconvert/component/azure.go
@@ -25,12 +25,10 @@ func toDiscoveryAzure(sdConfig *prom_azure.SDConfig) *azure.Arguments {
 		return nil
 	}
 
-	return &azure.Arguments{
+	args := &azure.Arguments{
 		Environment:     sdConfig.Environment,
 		Port:            sdConfig.Port,
 		SubscriptionID:  sdConfig.SubscriptionID,
-		OAuth:           toDiscoveryAzureOauth2(sdConfig.ClientID, sdConfig.TenantID, string(sdConfig.ClientSecret)),
-		ManagedIdentity: toManagedIdentity(sdConfig),
 		RefreshInterval: time.Duration(sdConfig.RefreshInterval),
 		ResourceGroup:   sdConfig.ResourceGroup,
 		ProxyConfig:     common.ToProxyConfig(sdConfig.HTTPClientConfig.ProxyConfig),
@@ -38,26 +36,32 @@ func toDiscoveryAzure(sdConfig *prom_azure.SDConfig) *azure.Arguments {
 		EnableHTTP2:     sdConfig.HTTPClientConfig.EnableHTTP2,
 		TLSConfig:       *common.ToTLSConfig(&sdConfig.HTTPClientConfig.TLSConfig),
 	}
+
+	// Only emit the block matching the configured authentication method.
+	// Emitting more than one auth block produces an invalid discovery.azure
+	// configuration. Prometheus defaults AuthenticationMethod to "OAuth".
+	switch sdConfig.AuthenticationMethod {
+	case "ManagedIdentity":
+		args.ManagedIdentity = &azure.ManagedIdentity{
+			ClientID: sdConfig.ClientID,
+		}
+	case "SDK":
+		args.SDK = &azure.SDK{
+			TenantID: sdConfig.TenantID,
+		}
+	case "WorkloadIdentity":
+		args.WorkloadIdentity = &azure.WorkloadIdentity{}
+	default: // "OAuth" or unset.
+		args.OAuth = &azure.OAuth{
+			ClientID:     sdConfig.ClientID,
+			TenantID:     sdConfig.TenantID,
+			ClientSecret: alloytypes.Secret(sdConfig.ClientSecret),
+		}
+	}
+
+	return args
 }
 
 func ValidateDiscoveryAzure(sdConfig *prom_azure.SDConfig) diag.Diagnostics {
 	return common.ValidateHttpClientConfig(&sdConfig.HTTPClientConfig)
-}
-
-func toManagedIdentity(sdConfig *prom_azure.SDConfig) *azure.ManagedIdentity {
-	if sdConfig == nil {
-		return nil
-	}
-
-	return &azure.ManagedIdentity{
-		ClientID: sdConfig.ClientID,
-	}
-}
-
-func toDiscoveryAzureOauth2(clientId string, tenantId string, clientSecret string) *azure.OAuth {
-	return &azure.OAuth{
-		ClientID:     clientId,
-		TenantID:     tenantId,
-		ClientSecret: alloytypes.Secret(clientSecret),
-	}
 }

--- a/internal/converter/internal/prometheusconvert/component/azure.go
+++ b/internal/converter/internal/prometheusconvert/component/azure.go
@@ -52,12 +52,14 @@ func toDiscoveryAzure(sdConfig *prom_azure.SDConfig) *azure.Arguments {
 		}
 	case "WorkloadIdentity":
 		args.WorkloadIdentity = &azure.WorkloadIdentity{}
-	default: // "OAuth" or unset.
+	case "", "OAuth":
 		args.OAuth = &azure.OAuth{
 			ClientID:     sdConfig.ClientID,
 			TenantID:     sdConfig.TenantID,
 			ClientSecret: alloytypes.Secret(sdConfig.ClientSecret),
 		}
+	default:
+		// Unknown method: leave auth unset; validation will surface a diagnostic.
 	}
 
 	return args

--- a/internal/converter/internal/prometheusconvert/component/azure.go
+++ b/internal/converter/internal/prometheusconvert/component/azure.go
@@ -1,6 +1,7 @@
 package component
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/grafana/alloy/internal/component/discovery"
@@ -63,5 +64,16 @@ func toDiscoveryAzure(sdConfig *prom_azure.SDConfig) *azure.Arguments {
 }
 
 func ValidateDiscoveryAzure(sdConfig *prom_azure.SDConfig) diag.Diagnostics {
-	return common.ValidateHttpClientConfig(&sdConfig.HTTPClientConfig)
+	d := common.ValidateHttpClientConfig(&sdConfig.HTTPClientConfig)
+
+	switch sdConfig.AuthenticationMethod {
+	case "ManagedIdentity", "SDK", "WorkloadIdentity", "", "OAuth":
+		return d
+	default:
+		d.Add(
+			diag.SeverityLevelCritical,
+			fmt.Sprintf("unknown authentication_type %q. Supported types are \"OAuth\", \"ManagedIdentity\", \"SDK\" or \"WorkloadIdentity\"", sdConfig.AuthenticationMethod),
+		)
+	}
+	return d
 }

--- a/internal/converter/internal/prometheusconvert/component/azure.go
+++ b/internal/converter/internal/prometheusconvert/component/azure.go
@@ -72,7 +72,7 @@ func ValidateDiscoveryAzure(sdConfig *prom_azure.SDConfig) diag.Diagnostics {
 	default:
 		d.Add(
 			diag.SeverityLevelCritical,
-			fmt.Sprintf("unknown authentication_type %q. Supported types are \"OAuth\", \"ManagedIdentity\", \"SDK\" or \"WorkloadIdentity\"", sdConfig.AuthenticationMethod),
+			fmt.Sprintf("unknown authentication_method %q. Supported methods are \"OAuth\", \"ManagedIdentity\", \"SDK\" or \"WorkloadIdentity\"", sdConfig.AuthenticationMethod),
 		)
 	}
 	return d

--- a/internal/converter/internal/prometheusconvert/testdata/azure.alloy
+++ b/internal/converter/internal/prometheusconvert/testdata/azure.alloy
@@ -6,10 +6,6 @@ discovery.azure "prometheus1" {
 		tenant_id     = "tenant"
 		client_secret = "secret"
 	}
-
-	managed_identity {
-		client_id = "client"
-	}
 }
 
 discovery.azure "prometheus2" {
@@ -20,12 +16,30 @@ discovery.azure "prometheus2" {
 		tenant_id     = "tenant"
 		client_secret = "secret"
 	}
+	proxy_url        = "proxy"
+	follow_redirects = false
+}
+
+discovery.azure "managed_identity" {
+	subscription_id = "subscription"
 
 	managed_identity {
 		client_id = "client"
 	}
-	proxy_url        = "proxy"
-	follow_redirects = false
+}
+
+discovery.azure "sdk" {
+	subscription_id = "subscription"
+
+	sdk_auth {
+		tenant_id = "tenant"
+	}
+}
+
+discovery.azure "workload_identity" {
+	subscription_id = "subscription"
+
+	workload_identity { }
 }
 
 prometheus.scrape "prometheus1" {
@@ -43,6 +57,24 @@ prometheus.scrape "prometheus2" {
 	targets    = discovery.azure.prometheus2.targets
 	forward_to = [prometheus.remote_write.default.receiver]
 	job_name   = "prometheus2"
+}
+
+prometheus.scrape "managed_identity" {
+	targets    = discovery.azure.managed_identity.targets
+	forward_to = [prometheus.remote_write.default.receiver]
+	job_name   = "managed_identity"
+}
+
+prometheus.scrape "sdk" {
+	targets    = discovery.azure.sdk.targets
+	forward_to = [prometheus.remote_write.default.receiver]
+	job_name   = "sdk"
+}
+
+prometheus.scrape "workload_identity" {
+	targets    = discovery.azure.workload_identity.targets
+	forward_to = [prometheus.remote_write.default.receiver]
+	job_name   = "workload_identity"
 }
 
 prometheus.remote_write "default" {

--- a/internal/converter/internal/prometheusconvert/testdata/azure.yaml
+++ b/internal/converter/internal/prometheusconvert/testdata/azure.yaml
@@ -15,6 +15,20 @@ scrape_configs:
         client_secret: "secret"
         proxy_url: "proxy"
         follow_redirects: false
+  - job_name: "managed_identity"
+    azure_sd_configs:
+      - subscription_id: "subscription"
+        authentication_method: "ManagedIdentity"
+        client_id: "client"
+  - job_name: "sdk"
+    azure_sd_configs:
+      - subscription_id: "subscription"
+        authentication_method: "SDK"
+        tenant_id: "tenant"
+  - job_name: "workload_identity"
+    azure_sd_configs:
+      - subscription_id: "subscription"
+        authentication_method: "WorkloadIdentity"
 
 remote_write:
   - name: "remote1"

--- a/internal/converter/internal/prometheusconvert/testdata/discovery.alloy
+++ b/internal/converter/internal/prometheusconvert/testdata/discovery.alloy
@@ -6,10 +6,6 @@ discovery.azure "prometheus1" {
 		tenant_id     = "tenant1"
 		client_secret = "secret1"
 	}
-
-	managed_identity {
-		client_id = "client1"
-	}
 }
 
 discovery.azure "prometheus1_2" {
@@ -19,10 +15,6 @@ discovery.azure "prometheus1_2" {
 		client_id     = "client2"
 		tenant_id     = "tenant2"
 		client_secret = "secret2"
-	}
-
-	managed_identity {
-		client_id = "client2"
 	}
 }
 

--- a/internal/converter/internal/prometheusconvert/testdata/discovery_relabel.alloy
+++ b/internal/converter/internal/prometheusconvert/testdata/discovery_relabel.alloy
@@ -6,10 +6,6 @@ discovery.azure "prometheus2" {
 		tenant_id     = "tenant"
 		client_secret = "secret"
 	}
-
-	managed_identity {
-		client_id = "client"
-	}
 }
 
 discovery.relabel "prometheus1" {

--- a/internal/converter/internal/promtailconvert/testdata/azure.alloy
+++ b/internal/converter/internal/promtailconvert/testdata/azure.alloy
@@ -6,10 +6,6 @@ discovery.azure "fun" {
 		tenant_id     = "tenant"
 		client_secret = "secret"
 	}
-
-	managed_identity {
-		client_id = "client"
-	}
 }
 
 loki.source.file "fun" {

--- a/internal/converter/internal/promtailconvert/testdata/azure_unknown_auth.diags
+++ b/internal/converter/internal/promtailconvert/testdata/azure_unknown_auth.diags
@@ -1,0 +1,1 @@
+(Critical) failed to parse Promtail config: unknown authentication_type "blablabla". Supported types are "OAuth", "ManagedIdentity", "SDK" or "WorkloadIdentity"

--- a/internal/converter/internal/promtailconvert/testdata/azure_unknown_auth.diags
+++ b/internal/converter/internal/promtailconvert/testdata/azure_unknown_auth.diags
@@ -1,1 +1,1 @@
-(Critical) failed to parse Promtail config: unknown authentication_type "blablabla". Supported types are "OAuth", "ManagedIdentity", "SDK" or "WorkloadIdentity"
+(Critical) failed to parse Promtail config: unknown authentication_method "blablabla". Supported methods are "OAuth", "ManagedIdentity", "SDK" or "WorkloadIdentity"

--- a/internal/converter/internal/promtailconvert/testdata/azure_unknown_auth.diags
+++ b/internal/converter/internal/promtailconvert/testdata/azure_unknown_auth.diags
@@ -1,1 +1,1 @@
-(Critical) failed to parse Promtail config: unknown authentication_type "blablabla". Supported methods are "OAuth", "ManagedIdentity", "SDK" or "WorkloadIdentity"
+(Critical) failed to parse Promtail config: unknown authentication_type "blablabla". Supported types are "OAuth", "ManagedIdentity", "SDK" or "WorkloadIdentity"

--- a/internal/converter/internal/promtailconvert/testdata/azure_unknown_auth.diags
+++ b/internal/converter/internal/promtailconvert/testdata/azure_unknown_auth.diags
@@ -1,1 +1,1 @@
-(Critical) failed to parse Promtail config: unknown authentication_method "blablabla". Supported methods are "OAuth", "ManagedIdentity", "SDK" or "WorkloadIdentity"
+(Critical) failed to parse Promtail config: unknown authentication_type "blablabla". Supported methods are "OAuth", "ManagedIdentity", "SDK" or "WorkloadIdentity"

--- a/internal/converter/internal/promtailconvert/testdata/azure_unknown_auth.yaml
+++ b/internal/converter/internal/promtailconvert/testdata/azure_unknown_auth.yaml
@@ -1,0 +1,10 @@
+scrape_configs:
+  - job_name: badauth
+    azure_sd_configs:
+      - subscription_id: "subscription"
+        authentication_method: "blablabla"
+        tenant_id: "tenant"
+        client_id: "client"
+        client_secret: "secret"
+tracing: {enabled: false}
+server: {register_instrumentation: false}

--- a/internal/converter/internal/staticconvert/testdata/prom_scrape.alloy
+++ b/internal/converter/internal/staticconvert/testdata/prom_scrape.alloy
@@ -6,10 +6,6 @@ discovery.azure "metrics_agent_promobee" {
 		tenant_id     = "tenant"
 		client_secret = "secret"
 	}
-
-	managed_identity {
-		client_id = "client"
-	}
 	proxy_url = "proxy"
 }
 
@@ -20,10 +16,6 @@ discovery.azure "metrics_agent_promobee_2" {
 		client_id     = "client"
 		tenant_id     = "tenant"
 		client_secret = "secret"
-	}
-
-	managed_identity {
-		client_id = "client"
 	}
 	proxy_url = "proxy"
 }

--- a/internal/converter/internal/staticconvert/testdata/traces.alloy
+++ b/internal/converter/internal/staticconvert/testdata/traces.alloy
@@ -58,10 +58,6 @@ discovery.azure "_0_default_prometheus1" {
 		tenant_id     = "tenant1"
 		client_secret = "secret1"
 	}
-
-	managed_identity {
-		client_id = "client1"
-	}
 }
 
 discovery.lightsail "_0_default_prometheus1" {


### PR DESCRIPTION
### Pull Request Details

These methods of authentication are present in Prometheus but haven't been ported to Alloy.

### Issue(s) fixed by this Pull Request

Fixes #313

### Notes to the Reviewer

This PR also fixes issues with the converters. They shouldn't set more than one auth method.

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
