### PR TITLE
feat(database_observability.sql_server): Scan all databases in `schema_details` collector

### DIFF
--- a/docs/sources/reference/components/database_observability/database_observability.sql_server.md
+++ b/docs/sources/reference/components/database_observability/database_observability.sql_server.md
@@ -12,7 +12,7 @@ labels:
 
 {{< docs/shared lookup="stability/experimental.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
-`database_observability.sql_server` connects to a Microsoft SQL Server database and collects observability data.
+`database_observability.sql_server` connects to a Microsoft SQL Server instance and collects observability data across every accessible user database on that instance.
 The component forwards this data as log entries to Loki receivers and exports targets for Prometheus scraping.
 
 ## Usage
@@ -36,6 +36,7 @@ You can use the following arguments with `database_observability.sql_server`:
 | `disable_collectors`| `list(string)`       | A list of collectors to disable from the default set.                    |         | no       |
 | `enable_collectors` | `list(string)`       | A list of collectors to enable on top of the default set.                |         | no       |
 | `exclude_schemas`   | `list(string)`       | A list of schemas to exclude from monitoring, on top of the always-excluded system schemas `sys` and `information_schema`. | `["alloydbadmin", "alloydbmetadata", "azure_maintenance", "azure_sys", "cloudsqladmin", "rdsadmin"]` | no       |
+| `exclude_databases` | `list(string)`       | A list of databases to exclude from monitoring, on top of the always-excluded system databases `master`, `model`, `msdb`, and `tempdb`. | `["alloydbadmin", "alloydbmetadata", "azure_maintenance", "azure_sys", "cloudsqladmin", "rdsadmin"]` | no       |
 
 The following collectors are configurable:
 
@@ -62,6 +63,8 @@ You can use the following blocks with `database_observability.sql_server`:
 | Name               | Type       | Description                                          | Default | Required |
 |--------------------|------------|------------------------------------------------------|---------|----------|
 | `collect_interval` | `duration` | How frequently to collect information from database. | `"1m"`  | no       |
+
+The collector scans every database that the login can access on the instance and collects schema details from each. Only databases where the login has `CONNECT` access to catalog views are collected.
 
 ## Example
 

--- a/internal/component/database_observability/sql_server/collector/exclude_databases.go
+++ b/internal/component/database_observability/sql_server/collector/exclude_databases.go
@@ -1,0 +1,20 @@
+package collector
+
+import "github.com/grafana/alloy/internal/component/database_observability"
+
+// excludedDatabases lists SQL Server system databases that must never be
+// iterated: their catalogs do not correspond to user-managed schemas.
+var excludedDatabases = []string{"master", "model", "msdb", "tempdb"}
+
+var databasesExclusionClause = database_observability.BuildExclusionClause(excludedDatabases)
+
+func buildExcludedDatabasesClause(databases []string) string {
+	if len(databases) == 0 {
+		return databasesExclusionClause
+	}
+
+	all := make([]string, 0, len(excludedDatabases)+len(databases))
+	all = append(all, excludedDatabases...)
+	all = append(all, databases...)
+	return database_observability.BuildExclusionClause(all)
+}

--- a/internal/component/database_observability/sql_server/collector/schema_details.go
+++ b/internal/component/database_observability/sql_server/collector/schema_details.go
@@ -29,6 +29,14 @@ const (
 const emitInterval = 30 * time.Minute
 
 const (
+	selectDatabasesTemplate = `
+		SELECT name, QUOTENAME(name)
+		FROM sys.databases
+		WHERE state_desc = 'ONLINE'
+			AND HAS_DBACCESS(name) = 1
+			AND name NOT IN %s
+		ORDER BY name`
+
 	selectTablesTemplate = `
 		SELECT
 			table_catalog,
@@ -105,24 +113,27 @@ const (
 )
 
 type SchemaDetailsArguments struct {
-	DB              *sql.DB
-	CollectInterval time.Duration
-	ExcludeSchemas  []string
-	EntryHandler    loki.EntryHandler
+	DB               *sql.DB
+	CollectInterval  time.Duration
+	ExcludeSchemas   []string
+	ExcludeDatabases []string
+	EntryHandler     loki.EntryHandler
 
 	Logger *slog.Logger
 }
 
 type SchemaDetails struct {
-	dbConnection    *sql.DB
-	collectInterval time.Duration
-	excludeSchemas  []string
-	entryHandler    loki.EntryHandler
+	dbConnection     *sql.DB
+	collectInterval  time.Duration
+	excludeSchemas   []string
+	excludeDatabases []string
+	entryHandler     loki.EntryHandler
 
 	// lastEmittedAt records the wall-clock time at which OP_CREATE_STATEMENT
-	// was last emitted for a "schema.table" key. Used to throttle logging
-	// to at most one per emitInterval per table.
-	lastEmittedAt map[string]time.Time
+	// was last emitted for a table. The outer key is the database name and
+	// the inner key is "schema.table". Used to throttle logging to at most
+	// one per emitInterval per table.
+	lastEmittedAt map[string]map[string]time.Time
 
 	// now allows overriding time.Now() in tests
 	now func() time.Time
@@ -175,14 +186,15 @@ type foreignKey struct {
 
 func NewSchemaDetails(args SchemaDetailsArguments) (*SchemaDetails, error) {
 	c := &SchemaDetails{
-		dbConnection:    args.DB,
-		collectInterval: args.CollectInterval,
-		excludeSchemas:  args.ExcludeSchemas,
-		entryHandler:    args.EntryHandler,
-		lastEmittedAt:   map[string]time.Time{},
-		now:             time.Now,
-		logger:          args.Logger.With("collector", SchemaDetailsCollector),
-		running:         &atomic.Bool{},
+		dbConnection:     args.DB,
+		collectInterval:  args.CollectInterval,
+		excludeSchemas:   args.ExcludeSchemas,
+		excludeDatabases: args.ExcludeDatabases,
+		entryHandler:     args.EntryHandler,
+		lastEmittedAt:    map[string]map[string]time.Time{},
+		now:              time.Now,
+		logger:           args.Logger.With("collector", SchemaDetailsCollector),
+		running:          &atomic.Bool{},
 	}
 
 	return c, nil
@@ -234,22 +246,107 @@ func (c *SchemaDetails) Stop() {
 	c.wg.Wait()
 }
 
+// databaseName holds the raw name plus its server-quoted identifier form,
+// which is safe to splice directly into a USE statement
+type databaseName struct {
+	name   string
+	quoted string
+}
+
 func (c *SchemaDetails) extractSchema(ctx context.Context) error {
-	query := fmt.Sprintf(selectTablesTemplate, buildExcludedSchemasClause(c.excludeSchemas))
+	databases, err := c.listDatabases(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list databases: %w", err)
+	}
+
+	now := c.now()
+	discovered := make(map[string]struct{}, len(databases))
+
+	if len(databases) == 0 {
+		c.logger.Info("no databases detected")
+	} else {
+		// Pin one connection for the whole cycle as USE mutates session state
+		conn, err := c.dbConnection.Conn(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to acquire database connection: %w", err)
+		}
+		defer conn.Close()
+
+		for _, db := range databases {
+			discovered[db.name] = struct{}{}
+			if _, err := conn.ExecContext(ctx, fmt.Sprintf("USE %s", db.quoted)); err != nil {
+				c.logger.Error("failed to switch database context, skipping", "database", db.name, "err", err)
+				continue
+			}
+			if err := c.extractSchemaForDatabase(ctx, conn, db.name, now); err != nil {
+				c.logger.Error("failed to extract schema for database", "database", db.name, "err", err)
+				continue
+			}
+		}
+	}
+
+	// Drop throttle entries only for databases that discovery no longer
+	// returns (dropped, access revoked, newly excluded). Per-table cleanup
+	// within a still-present database is handled by extractSchemaForDatabase
+	// and is gated on a clean scan so a transient failure does not evict
+	// state that would defeat emitInterval on the next successful cycle.
+	for db := range c.lastEmittedAt {
+		if _, ok := discovered[db]; !ok {
+			delete(c.lastEmittedAt, db)
+		}
+	}
+
+	return nil
+}
+
+func (c *SchemaDetails) listDatabases(ctx context.Context) ([]databaseName, error) {
+	query := fmt.Sprintf(selectDatabasesTemplate, buildExcludedDatabasesClause(c.excludeDatabases))
 	rs, err := c.dbConnection.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rs.Close()
+
+	var databases []databaseName
+	for rs.Next() {
+		var name, quoted string
+		if err := rs.Scan(&name, &quoted); err != nil {
+			return nil, fmt.Errorf("failed to scan database row: %w", err)
+		}
+		databases = append(databases, databaseName{name: name, quoted: quoted})
+	}
+	if err := rs.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate over databases result set: %w", err)
+	}
+	return databases, nil
+}
+
+// extractSchemaForDatabase runs the tables discovery + per-schema bulk
+// metadata queries scoped to the caller's current database context.
+// This function is responsible for pruning stale throttle entries for
+// dbName, but only when the tables scan completed cleanly: a mid-iteration
+// scan failure yields a partial view and pruning is skipped so we never
+// evict entries for tables we simply did not observe this cycle.
+func (c *SchemaDetails) extractSchemaForDatabase(ctx context.Context, conn *sql.Conn, dbName string, now time.Time) error {
+	query := fmt.Sprintf(selectTablesTemplate, buildExcludedSchemasClause(c.excludeSchemas))
+	rs, err := conn.QueryContext(ctx, query)
 	if err != nil {
 		return fmt.Errorf("failed to query tables: %w", err)
 	}
 	defer rs.Close()
 
-	now := c.now()
 	tables := []*tableInfo{}
-	seenTables := map[string]struct{}{}
+	// scanComplete tracks whether we iterated the tables result set without
+	// bailing out early. If false we have a partial view and must skip the
+	// per-database throttle prune to avoid evicting entries for tables we
+	// did not get to scan this round.
+	scanComplete := true
 
 	for rs.Next() {
 		var database, schema, tableName, tableType string
 		if err := rs.Scan(&database, &schema, &tableName, &tableType); err != nil {
-			c.logger.Error("failed to scan tables", "err", err)
+			c.logger.Error("failed to scan tables", "database", dbName, "err", err)
+			scanComplete = false
 			break
 		}
 		tables = append(tables, &tableInfo{
@@ -258,7 +355,6 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 			tableName: tableName,
 			tableType: tableType,
 		})
-		seenTables[fullyQualifiedName(schema, tableName)] = struct{}{}
 
 		c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
 			logging.LevelInfo,
@@ -271,17 +367,11 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 		return fmt.Errorf("failed to iterate over tables result set: %w", err)
 	}
 
-	// Cleanup: drop throttle entries for tables that no longer exist (e.g.
-	// tables dropped or renamed). Done before the empty-tables early return so
-	// the map is also pruned when every monitored table disappears.
-	for k := range c.lastEmittedAt {
-		if _, ok := seenTables[k]; !ok {
-			delete(c.lastEmittedAt, k)
-		}
-	}
-
 	if len(tables) == 0 {
-		c.logger.Info("no tables detected from information_schema.tables")
+		c.logger.Info("no tables detected from information_schema.tables", "database", dbName)
+		if scanComplete {
+			c.pruneDatabaseThrottle(dbName, nil)
+		}
 		return nil
 	}
 
@@ -291,9 +381,10 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 	dueBySchema := map[string][]*tableInfo{}
 	dueSchemas := []string{}
 	for _, t := range tables {
-		k := fullyQualifiedName(t.schema, t.tableName)
-		if last, ok := c.lastEmittedAt[k]; ok && now.Sub(last) < emitInterval {
-			continue
+		if inner := c.lastEmittedAt[dbName]; inner != nil {
+			if last, ok := inner[schemaTableKey(t.schema, t.tableName)]; ok && now.Sub(last) < emitInterval {
+				continue
+			}
 		}
 		if _, exists := dueBySchema[t.schema]; !exists {
 			dueSchemas = append(dueSchemas, t.schema)
@@ -302,6 +393,9 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 	}
 
 	if len(dueSchemas) == 0 {
+		if scanComplete {
+			c.pruneDatabaseThrottle(dbName, tables)
+		}
 		return nil
 	}
 
@@ -312,9 +406,9 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 			tableNames = append(tableNames, t.tableName)
 		}
 
-		specs, err := c.fetchSchemaSpecs(ctx, schema, tableNames)
+		specs, err := c.fetchSchemaSpecs(ctx, conn, schema, tableNames)
 		if err != nil {
-			c.logger.Error("failed to fetch schema specs", "schema", schema, "err", err)
+			c.logger.Error("failed to fetch schema specs", "database", dbName, "schema", schema, "err", err)
 			continue
 		}
 
@@ -322,13 +416,13 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 			spec, ok := specs[table.tableName]
 			if !ok {
 				// This might happen if a table is dropped between the tables query and the metadata queries.
-				c.logger.Warn("no bulk metadata rows for table", "schema", table.schema, "table", table.tableName)
+				c.logger.Warn("no bulk metadata rows for table", "database", table.database, "schema", table.schema, "table", table.tableName)
 				continue
 			}
 
 			b64Spec, err := encodeTableSpec(spec)
 			if err != nil {
-				c.logger.Error("failed to marshal table spec", "schema", table.schema, "table", table.tableName, "err", err)
+				c.logger.Error("failed to marshal table spec", "database", table.database, "schema", table.schema, "table", table.tableName, "err", err)
 				continue
 			}
 			table.b64TableSpec = b64Spec
@@ -341,11 +435,41 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 					table.database, table.schema, table.tableName, table.b64TableSpec,
 				),
 			)
-			c.lastEmittedAt[fullyQualifiedName(table.schema, table.tableName)] = now
+			if c.lastEmittedAt[dbName] == nil {
+				c.lastEmittedAt[dbName] = map[string]time.Time{}
+			}
+			c.lastEmittedAt[dbName][schemaTableKey(table.schema, table.tableName)] = now
 		}
 	}
 
+	if scanComplete {
+		c.pruneDatabaseThrottle(dbName, tables)
+	}
+
 	return nil
+}
+
+// pruneDatabaseThrottle removes entries in c.lastEmittedAt[dbName] whose
+// schema.table key is not present in the given tables. If the resulting
+// inner map is empty, the outer entry is also deleted. Must only be called
+// after a complete scan of the database's tables.
+func (c *SchemaDetails) pruneDatabaseThrottle(dbName string, tables []*tableInfo) {
+	if _, ok := c.lastEmittedAt[dbName]; !ok {
+		return
+	}
+
+	currentKeys := make(map[string]struct{}, len(tables))
+	for _, t := range tables {
+		currentKeys[schemaTableKey(t.schema, t.tableName)] = struct{}{}
+	}
+	for k := range c.lastEmittedAt[dbName] {
+		if _, ok := currentKeys[k]; !ok {
+			delete(c.lastEmittedAt[dbName], k)
+		}
+	}
+	if len(c.lastEmittedAt[dbName]) == 0 {
+		delete(c.lastEmittedAt, dbName)
+	}
 }
 
 // encodeTableSpec serializes a tableSpec to base64-encoded JSON.
@@ -360,8 +484,9 @@ func encodeTableSpec(spec *tableSpec) (string, error) {
 // fetchSchemaSpecs runs three queries scoped to (schema, tableNames) to fetch
 // columns, indexes and foreign keys for the given tables in bulk and groups
 // the rows by table name. The returned map is keyed by table name; tables
-// with no rows in any of the three result sets are absent.
-func (c *SchemaDetails) fetchSchemaSpecs(ctx context.Context, schema string, tableNames []string) (map[string]*tableSpec, error) {
+// with no rows in any of the three result sets are absent. conn must be the
+// pinned connection whose current database contains the target schema.
+func (c *SchemaDetails) fetchSchemaSpecs(ctx context.Context, conn *sql.Conn, schema string, tableNames []string) (map[string]*tableSpec, error) {
 	specs := map[string]*tableSpec{}
 	if len(tableNames) == 0 {
 		return specs, nil
@@ -376,7 +501,7 @@ func (c *SchemaDetails) fetchSchemaSpecs(ctx context.Context, schema string, tab
 		return s
 	}
 
-	colRS, err := c.dbConnection.QueryContext(ctx, fmt.Sprintf(selectColumnsTemplate, database_observability.BuildExclusionClause(tableNames)), schema)
+	colRS, err := conn.QueryContext(ctx, fmt.Sprintf(selectColumnsTemplate, database_observability.BuildExclusionClause(tableNames)), schema)
 	if err != nil {
 		c.logger.Error("failed to query schema columns", "schema", schema, "err", err)
 		return nil, err
@@ -413,7 +538,7 @@ func (c *SchemaDetails) fetchSchemaSpecs(ctx context.Context, schema string, tab
 		return nil, err
 	}
 
-	idxRS, err := c.dbConnection.QueryContext(ctx, fmt.Sprintf(selectIndexesTemplate, database_observability.BuildExclusionClause(tableNames)), schema)
+	idxRS, err := conn.QueryContext(ctx, fmt.Sprintf(selectIndexesTemplate, database_observability.BuildExclusionClause(tableNames)), schema)
 	if err != nil {
 		c.logger.Error("failed to query schema indexes", "schema", schema, "err", err)
 		return nil, err
@@ -465,7 +590,7 @@ func (c *SchemaDetails) fetchSchemaSpecs(ctx context.Context, schema string, tab
 		return nil, err
 	}
 
-	fkRS, err := c.dbConnection.QueryContext(ctx, fmt.Sprintf(selectForeignKeysTemplate, database_observability.BuildExclusionClause(tableNames)), schema)
+	fkRS, err := conn.QueryContext(ctx, fmt.Sprintf(selectForeignKeysTemplate, database_observability.BuildExclusionClause(tableNames)), schema)
 	if err != nil {
 		c.logger.Error("failed to query schema foreign keys", "schema", schema, "err", err)
 		return nil, err
@@ -496,6 +621,6 @@ func (c *SchemaDetails) fetchSchemaSpecs(ctx context.Context, schema string, tab
 	return specs, nil
 }
 
-func fullyQualifiedName(schema, table string) string {
+func schemaTableKey(schema, table string) string {
 	return fmt.Sprintf("[%s].[%s]", schema, table)
 }

--- a/internal/component/database_observability/sql_server/collector/schema_details_test.go
+++ b/internal/component/database_observability/sql_server/collector/schema_details_test.go
@@ -37,6 +37,9 @@ func TestSchemaDetails(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, collector)
 
+		expectListDatabases(mock, "some_db")
+		expectUseDatabase(mock, "some_db")
+
 		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
@@ -140,6 +143,9 @@ func TestSchemaDetails(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, collector)
 
+		expectListDatabases(mock, "some_db")
+		expectUseDatabase(mock, "some_db")
+
 		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
@@ -225,6 +231,9 @@ func TestSchemaDetails(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, collector)
 
+		expectListDatabases(mock, "some_db")
+		expectUseDatabase(mock, "some_db")
+
 		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(
 				sqlmock.NewRows([]string{
@@ -299,6 +308,9 @@ func TestSchemaDetails(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
+
+		expectListDatabases(mock, "some_db")
+		expectUseDatabase(mock, "some_db")
 
 		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(
@@ -383,6 +395,9 @@ func TestSchemaDetails(t *testing.T) {
 		collector.now = func() time.Time { return fakeNow }
 
 		// First scrape: tables list + metadata queries.
+		expectListDatabases(mock, "some_db")
+		expectUseDatabase(mock, "some_db")
+
 		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{
 				"TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME", "TABLE_TYPE",
@@ -408,6 +423,9 @@ func TestSchemaDetails(t *testing.T) {
 
 		// Second scrape: only the tables list. The scrape is throttled (still
 		// within emitInterval) so it must not trigger any metadata queries.
+		expectListDatabases(mock, "some_db")
+		expectUseDatabase(mock, "some_db")
+
 		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{
 				"TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME", "TABLE_TYPE",
@@ -454,6 +472,9 @@ func TestSchemaDetails(t *testing.T) {
 
 		// Two scrapes' worth of expectations.
 		for i := 0; i < 2; i++ {
+			expectListDatabases(mock, "some_db")
+			expectUseDatabase(mock, "some_db")
+
 			mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
 				WillReturnRows(sqlmock.NewRows([]string{
 					"TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME", "TABLE_TYPE",
@@ -517,6 +538,9 @@ func TestSchemaDetails(t *testing.T) {
 		collector.now = func() time.Time { return fakeNow }
 
 		// First scrape: two tables in the same schema.
+		expectListDatabases(mock, "some_db")
+		expectUseDatabase(mock, "some_db")
+
 		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{
 				"TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME", "TABLE_TYPE",
@@ -545,13 +569,16 @@ func TestSchemaDetails(t *testing.T) {
 			}))
 
 		require.NoError(t, collector.extractSchema(t.Context()))
-		require.Contains(t, collector.lastEmittedAt, fullyQualifiedName("dbo", "table_a"))
-		require.Contains(t, collector.lastEmittedAt, fullyQualifiedName("dbo", "table_b"))
+		require.Contains(t, collector.lastEmittedAt, "some_db")
+		require.Contains(t, collector.lastEmittedAt["some_db"], schemaTableKey("dbo", "table_a"))
+		require.Contains(t, collector.lastEmittedAt["some_db"], schemaTableKey("dbo", "table_b"))
 
 		// Second scrape: only table_a remains. table_b should be evicted from
 		// the throttle map. Since table_a is still within emitInterval, no
 		// metadata queries are expected.
 		fakeNow = fakeNow.Add(time.Minute)
+		expectListDatabases(mock, "some_db")
+		expectUseDatabase(mock, "some_db")
 		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{
 				"TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME", "TABLE_TYPE",
@@ -560,8 +587,9 @@ func TestSchemaDetails(t *testing.T) {
 		require.NoError(t, collector.extractSchema(t.Context()))
 
 		require.NoError(t, mock.ExpectationsWereMet())
-		require.Contains(t, collector.lastEmittedAt, fullyQualifiedName("dbo", "table_a"))
-		require.NotContains(t, collector.lastEmittedAt, fullyQualifiedName("dbo", "table_b"))
+		require.Contains(t, collector.lastEmittedAt, "some_db")
+		require.Contains(t, collector.lastEmittedAt["some_db"], schemaTableKey("dbo", "table_a"))
+		require.NotContains(t, collector.lastEmittedAt["some_db"], schemaTableKey("dbo", "table_b"))
 	})
 
 	t.Run("bulk metadata returns no rows for a table", func(t *testing.T) {
@@ -581,6 +609,9 @@ func TestSchemaDetails(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
+
+		expectListDatabases(mock, "some_db")
+		expectUseDatabase(mock, "some_db")
 
 		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{
@@ -641,7 +672,10 @@ func TestSchemaDetails(t *testing.T) {
 
 		// Pre-populate the throttle map to simulate a table that was emitted
 		// in a previous scrape but no longer exists in INFORMATION_SCHEMA.TABLES.
-		collector.lastEmittedAt[fullyQualifiedName("dbo", "stale_table")] = time.Now()
+		collector.lastEmittedAt["some_db"] = map[string]time.Time{schemaTableKey("dbo", "stale_table"): time.Now()}
+
+		expectListDatabases(mock, "some_db")
+		expectUseDatabase(mock, "some_db")
 
 		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{
@@ -670,6 +704,9 @@ func TestSchemaDetails(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
+
+		expectListDatabases(mock, "some_db")
+		expectUseDatabase(mock, "some_db")
 
 		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().WillReturnRows(
 			sqlmock.NewRows([]string{
@@ -714,6 +751,9 @@ func TestSchemaDetails(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
+
+		expectListDatabases(mock, "some_db")
+		expectUseDatabase(mock, "some_db")
 
 		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().WillReturnRows(
 			sqlmock.NewRows([]string{
@@ -771,8 +811,14 @@ func TestSchemaDetails(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, collector)
 
+		// First scrape: discovery + USE + tables query fails. The collector
+		// logs the failure and continues; the second scrape succeeds.
+		expectListDatabases(mock, "some_db")
+		expectUseDatabase(mock, "some_db")
 		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().WillReturnError(fmt.Errorf("connection error"))
 
+		expectListDatabases(mock, "some_db")
+		expectUseDatabase(mock, "some_db")
 		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().WillReturnRows(
 			sqlmock.NewRows([]string{
 				"TABLE_CATALOG",
@@ -848,6 +894,9 @@ func TestSchemaDetailsExcludeSchemas(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	expectListDatabases(mock, "some_db")
+	expectUseDatabase(mock, "some_db")
+
 	mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, buildExcludedSchemasClause([]string{"excluded_schema"}))).
 		WithoutArgs().RowsWillBeClosed().WillReturnRows(sqlmock.NewRows([]string{
 		"TABLE_CATALOG",
@@ -858,4 +907,324 @@ func TestSchemaDetailsExcludeSchemas(t *testing.T) {
 
 	require.NoError(t, c.extractSchema(t.Context()))
 	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSchemaDetailsExcludeDatabases(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lokiClient := loki.NewCollectingHandler()
+	defer lokiClient.Stop()
+
+	c, err := NewSchemaDetails(SchemaDetailsArguments{
+		DB:               db,
+		CollectInterval:  time.Millisecond,
+		ExcludeDatabases: []string{"excluded_db"},
+		EntryHandler:     lokiClient,
+		Logger:           util.TestAlloyLogger(t).Slog(),
+	})
+	require.NoError(t, err)
+
+	// The user-supplied exclude_db is merged with the hardcoded system DBs.
+	// Discovery returns no databases; extractSchema returns cleanly and no
+	// USE / tables queries follow.
+	mock.ExpectQuery(fmt.Sprintf(selectDatabasesTemplate, buildExcludedDatabasesClause([]string{"excluded_db"}))).
+		WithoutArgs().RowsWillBeClosed().WillReturnRows(sqlmock.NewRows([]string{"name", "quoted_name"}))
+
+	require.NoError(t, c.extractSchema(t.Context()))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestSchemaDetailsMultiDatabase exercises the full multi-database iteration
+// path: one discovery, N USE statements, and per-database bulk metadata.
+func TestSchemaDetailsMultiDatabase(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lokiClient := loki.NewCollectingHandler()
+	defer lokiClient.Stop()
+
+	fakeNow := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	c, err := NewSchemaDetails(SchemaDetailsArguments{
+		DB:              db,
+		CollectInterval: time.Hour,
+		EntryHandler:    lokiClient,
+		Logger:          util.TestAlloyLogger(t).Slog(),
+	})
+	require.NoError(t, err)
+	c.now = func() time.Time { return fakeNow }
+
+	// Discovery returns two databases; loop USEs each in turn and runs the
+	// tables + per-schema bulk queries against the pinned session. USE is
+	// interleaved with each database's queries because the collector switches
+	// context and immediately queries before moving to the next database.
+	expectListDatabases(mock, "db_a", "db_b")
+
+	for _, dbName := range []string{"db_a", "db_b"} {
+		expectUseDatabase(mock, dbName)
+		tableName := "t_" + dbName
+		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME", "TABLE_TYPE",
+			}).AddRow(dbName, "dbo", tableName, "BASE TABLE"))
+
+		mock.ExpectQuery(fmt.Sprintf(selectColumnsTemplate, database_observability.BuildExclusionClause([]string{tableName}))).WithArgs("dbo").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "column_name", "column_type", "is_nullable",
+				"is_identity", "default_value", "is_primary_key",
+			}).AddRow(tableName, "id", "int", false, true, nil, true))
+
+		mock.ExpectQuery(fmt.Sprintf(selectIndexesTemplate, database_observability.BuildExclusionClause([]string{tableName}))).WithArgs("dbo").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "index_name", "seq_in_index", "column_name",
+				"index_type", "is_unique", "is_nullable",
+			}))
+
+		mock.ExpectQuery(fmt.Sprintf(selectForeignKeysTemplate, database_observability.BuildExclusionClause([]string{tableName}))).WithArgs("dbo").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "constraint_name", "column_name",
+				"referenced_table_name", "referenced_column_name",
+			}))
+	}
+
+	require.NoError(t, c.extractSchema(t.Context()))
+	require.NoError(t, mock.ExpectationsWereMet())
+
+	// Each database contributes an OP_TABLE_DETECTION + OP_CREATE_STATEMENT.
+	require.Eventually(t, func() bool {
+		return len(lokiClient.Received()) == 4
+	}, 5*time.Second, 10*time.Millisecond)
+
+	entries := lokiClient.Received()
+	require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, entries[0].Labels)
+	require.Contains(t, entries[0].Line, `database="db_a"`)
+	require.Contains(t, entries[0].Line, `table="t_db_a"`)
+	require.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, entries[1].Labels)
+	require.Contains(t, entries[1].Line, `database="db_a"`)
+	require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, entries[2].Labels)
+	require.Contains(t, entries[2].Line, `database="db_b"`)
+	require.Contains(t, entries[2].Line, `table="t_db_b"`)
+	require.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, entries[3].Labels)
+	require.Contains(t, entries[3].Line, `database="db_b"`)
+
+	// Throttle keys are qualified with the database, so same-named tables in
+	// different databases would coexist.
+	require.Contains(t, c.lastEmittedAt, "db_a")
+	require.Contains(t, c.lastEmittedAt["db_a"], schemaTableKey("dbo", "t_db_a"))
+	require.Contains(t, c.lastEmittedAt, "db_b")
+	require.Contains(t, c.lastEmittedAt["db_b"], schemaTableKey("dbo", "t_db_b"))
+}
+
+// TestSchemaDetailsMultiDatabase_UseFailureContinues verifies that a USE
+// failure for one database does not abort the whole cycle.
+func TestSchemaDetailsMultiDatabase_UseFailureContinues(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lokiClient := loki.NewCollectingHandler()
+	defer lokiClient.Stop()
+
+	c, err := NewSchemaDetails(SchemaDetailsArguments{
+		DB:              db,
+		CollectInterval: time.Hour,
+		EntryHandler:    lokiClient,
+		Logger:          util.TestAlloyLogger(t).Slog(),
+	})
+	require.NoError(t, err)
+
+	mock.ExpectQuery(fmt.Sprintf(selectDatabasesTemplate, databasesExclusionClause)).
+		WithoutArgs().RowsWillBeClosed().
+		WillReturnRows(sqlmock.NewRows([]string{"name", "quoted_name"}).
+			AddRow("bad_db", "[bad_db]").
+			AddRow("good_db", "[good_db]"))
+
+	// First USE fails; the second one succeeds and the loop continues.
+	mock.ExpectExec("USE [bad_db]").WillReturnError(fmt.Errorf("cannot open database"))
+	mock.ExpectExec("USE [good_db]").WillReturnResult(sqlmock.NewResult(0, 0))
+
+	mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+		WillReturnRows(sqlmock.NewRows([]string{
+			"TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME", "TABLE_TYPE",
+		}).AddRow("good_db", "dbo", "ok_table", "BASE TABLE"))
+
+	mock.ExpectQuery(fmt.Sprintf(selectColumnsTemplate, database_observability.BuildExclusionClause([]string{"ok_table"}))).WithArgs("dbo").RowsWillBeClosed().
+		WillReturnRows(sqlmock.NewRows([]string{
+			"table_name", "column_name", "column_type", "is_nullable",
+			"is_identity", "default_value", "is_primary_key",
+		}).AddRow("ok_table", "id", "int", false, true, nil, true))
+
+	mock.ExpectQuery(fmt.Sprintf(selectIndexesTemplate, database_observability.BuildExclusionClause([]string{"ok_table"}))).WithArgs("dbo").RowsWillBeClosed().
+		WillReturnRows(sqlmock.NewRows([]string{
+			"table_name", "index_name", "seq_in_index", "column_name",
+			"index_type", "is_unique", "is_nullable",
+		}))
+
+	mock.ExpectQuery(fmt.Sprintf(selectForeignKeysTemplate, database_observability.BuildExclusionClause([]string{"ok_table"}))).WithArgs("dbo").RowsWillBeClosed().
+		WillReturnRows(sqlmock.NewRows([]string{
+			"table_name", "constraint_name", "column_name",
+			"referenced_table_name", "referenced_column_name",
+		}))
+
+	require.NoError(t, c.extractSchema(t.Context()))
+	require.NoError(t, mock.ExpectationsWereMet())
+
+	require.Eventually(t, func() bool {
+		return len(lokiClient.Received()) == 2
+	}, 5*time.Second, 10*time.Millisecond)
+
+	entries := lokiClient.Received()
+	require.Contains(t, entries[0].Line, `database="good_db"`)
+	require.Contains(t, entries[1].Line, `database="good_db"`)
+}
+
+// TestSchemaDetailsUseFailurePreservesThrottle verifies that a USE failure
+// for one database does not evict its throttle entries. Without this
+// guarantee a flapping database would re-emit OP_CREATE_STATEMENT on every
+// recovery, defeating emitInterval.
+func TestSchemaDetailsUseFailurePreservesThrottle(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lokiClient := loki.NewCollectingHandler()
+	defer lokiClient.Stop()
+
+	c, err := NewSchemaDetails(SchemaDetailsArguments{
+		DB:              db,
+		CollectInterval: time.Hour,
+		EntryHandler:    lokiClient,
+		Logger:          util.TestAlloyLogger(t).Slog(),
+	})
+	require.NoError(t, err)
+
+	// Seed db_b with a recent throttle entry as if a previous cycle had
+	// already emitted for it. The USE failure this cycle must not evict it.
+	seededAt := time.Now()
+	c.lastEmittedAt["db_b"] = map[string]time.Time{
+		schemaTableKey("dbo", "existing_table"): seededAt,
+	}
+
+	expectListDatabases(mock, "db_a", "db_b")
+
+	// db_a: USE succeeds; tables query returns no rows (nothing to do).
+	expectUseDatabase(mock, "db_a")
+	mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+		WillReturnRows(sqlmock.NewRows([]string{
+			"TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME", "TABLE_TYPE",
+		}))
+
+	// db_b: USE fails. No tables query should follow.
+	mock.ExpectExec("USE [db_b]").WillReturnError(fmt.Errorf("cannot open database"))
+
+	require.NoError(t, c.extractSchema(t.Context()))
+	require.NoError(t, mock.ExpectationsWereMet())
+
+	require.Contains(t, c.lastEmittedAt, "db_b")
+	require.Equal(t, seededAt, c.lastEmittedAt["db_b"][schemaTableKey("dbo", "existing_table")])
+}
+
+// TestSchemaDetailsMidScanBreakPreservesThrottle verifies that a scan error
+// on a tables-result row (partial view) does not prune the database's
+// throttle map.
+func TestSchemaDetailsMidScanBreakPreservesThrottle(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lokiClient := loki.NewCollectingHandler()
+	defer lokiClient.Stop()
+
+	c, err := NewSchemaDetails(SchemaDetailsArguments{
+		DB:              db,
+		CollectInterval: time.Hour,
+		EntryHandler:    lokiClient,
+		Logger:          util.TestAlloyLogger(t).Slog(),
+	})
+	require.NoError(t, err)
+
+	seededAt := time.Now()
+	c.lastEmittedAt["some_db"] = map[string]time.Time{
+		schemaTableKey("dbo", "existing_table"): seededAt,
+	}
+
+	expectListDatabases(mock, "some_db")
+	expectUseDatabase(mock, "some_db")
+
+	// A NULL TABLE_NAME triggers a scan error when scanning into a plain
+	// string, which the collector treats as an incomplete scan and skips
+	// pruning for this cycle.
+	mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+		WillReturnRows(sqlmock.NewRows([]string{
+			"TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME", "TABLE_TYPE",
+		}).AddRow("some_db", "dbo", nil, "BASE TABLE"))
+
+	require.NoError(t, c.extractSchema(t.Context()))
+	require.NoError(t, mock.ExpectationsWereMet())
+
+	require.Contains(t, c.lastEmittedAt, "some_db")
+	require.Equal(t, seededAt, c.lastEmittedAt["some_db"][schemaTableKey("dbo", "existing_table")])
+}
+
+// TestSchemaDetailsUndiscoveredDatabaseEvicted verifies that a database no
+// longer returned by discovery has its throttle entries dropped, so we do
+// not leak state for dropped or newly-excluded databases.
+func TestSchemaDetailsUndiscoveredDatabaseEvicted(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lokiClient := loki.NewCollectingHandler()
+	defer lokiClient.Stop()
+
+	c, err := NewSchemaDetails(SchemaDetailsArguments{
+		DB:              db,
+		CollectInterval: time.Hour,
+		EntryHandler:    lokiClient,
+		Logger:          util.TestAlloyLogger(t).Slog(),
+	})
+	require.NoError(t, err)
+
+	c.lastEmittedAt["gone_db"] = map[string]time.Time{
+		schemaTableKey("dbo", "old_table"): time.Now(),
+	}
+
+	expectListDatabases(mock, "some_db")
+	expectUseDatabase(mock, "some_db")
+	mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+		WillReturnRows(sqlmock.NewRows([]string{
+			"TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME", "TABLE_TYPE",
+		}))
+
+	require.NoError(t, c.extractSchema(t.Context()))
+	require.NoError(t, mock.ExpectationsWereMet())
+
+	require.NotContains(t, c.lastEmittedAt, "gone_db")
+}
+
+func expectListDatabases(mock sqlmock.Sqlmock, databases ...string) {
+	rows := sqlmock.NewRows([]string{"name", "quoted_name"})
+	for _, db := range databases {
+		rows.AddRow(db, "["+db+"]")
+	}
+	mock.ExpectQuery(fmt.Sprintf(selectDatabasesTemplate, databasesExclusionClause)).
+		WithoutArgs().RowsWillBeClosed().WillReturnRows(rows)
+}
+
+func expectUseDatabase(mock sqlmock.Sqlmock, dbName string) {
+	mock.ExpectExec(fmt.Sprintf("USE [%s]", dbName)).WillReturnResult(sqlmock.NewResult(0, 0))
 }

--- a/internal/component/database_observability/sql_server/component.go
+++ b/internal/component/database_observability/sql_server/component.go
@@ -66,6 +66,7 @@ type Arguments struct {
 	EnableCollectors  []string            `alloy:"enable_collectors,attr,optional"`
 	DisableCollectors []string            `alloy:"disable_collectors,attr,optional"`
 	ExcludeSchemas    []string            `alloy:"exclude_schemas,attr,optional"`
+	ExcludeDatabases  []string            `alloy:"exclude_databases,attr,optional"`
 
 	SchemaDetailsArguments SchemaDetailsArguments `alloy:"schema_details,block,optional"`
 }
@@ -76,7 +77,8 @@ type SchemaDetailsArguments struct {
 
 func defaultArguments() Arguments {
 	return Arguments{
-		ExcludeSchemas: database_observability.DefaultExcludedSchemas(),
+		ExcludeSchemas:   database_observability.DefaultExcludedSchemas(),
+		ExcludeDatabases: database_observability.DefaultExcludedDatabases(),
 
 		SchemaDetailsArguments: SchemaDetailsArguments{
 			CollectInterval: 1 * time.Minute,
@@ -359,11 +361,12 @@ func (c *Component) startCollectors(serverID string, engineVersion string) error
 
 	if collectors[collector.SchemaDetailsCollector] {
 		stCollector, err := collector.NewSchemaDetails(collector.SchemaDetailsArguments{
-			DB:              c.dbConnection,
-			CollectInterval: c.args.SchemaDetailsArguments.CollectInterval,
-			ExcludeSchemas:  c.args.ExcludeSchemas,
-			EntryHandler:    entryHandler,
-			Logger:          c.opts.Logger,
+			DB:               c.dbConnection,
+			CollectInterval:  c.args.SchemaDetailsArguments.CollectInterval,
+			ExcludeSchemas:   c.args.ExcludeSchemas,
+			ExcludeDatabases: c.args.ExcludeDatabases,
+			EntryHandler:     entryHandler,
+			Logger:           c.opts.Logger,
 		})
 		if err != nil {
 			logStartError(collector.SchemaDetailsCollector, "create", err)


### PR DESCRIPTION
### Brief description of Pull Request


Scan all databases that the user can connect to on the instance, switching between them using the `USE` statement.

Followup of https://github.com/grafana/alloy/pull/6641


### Pull Request Details

<!-- Detailed descripion of the Pull Request, if needed. -->


### Issue(s) fixed by this Pull Request

Relates to https://github.com/grafana/grafana-dbo11y-app/issues/3016


### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
