### PR TITLE
feat: Check imports of inline Alloy config in OTel mode

### DIFF
--- a/docs/sources/set-up/otel_engine.md
+++ b/docs/sources/set-up/otel_engine.md
@@ -272,7 +272,7 @@ In the meantime, use the CLI or Helm options for testing.
 1. **Server ports**: The {{< param "DEFAULT_ENGINE" >}} exposes its HTTP server on port `12345`.
    The {{< param "OTEL_ENGINE" >}} exposes its HTTP server on port `8888`.
    The {{< param "OTEL_ENGINE" >}} HTTP server doesn't expose a UI, support bundles, or reload endpoint functionality like the {{< param "DEFAULT_ENGINE" >}} does.
-1. **Inline configuration module path**: If `config.inline.module_path` isn't defined, the `module_path` Alloy config keyword resolves to the process current working directory.
+1. **Inline configuration module path**: If `config.inline.module_path` isn't defined, the `module_path` Alloy configuration keyword resolves to the process current working directory.
 1. **Fleet management**: [Grafana Fleet Management](https://grafana.com/blog/opentelemetry-and-grafana-labs-whats-new-and-whats-next-in-2026/#fleet-management) doesn't support the {{< param "OTEL_ENGINE" >}} yet.
    You must define and manage the input configuration manually.
 

--- a/docs/sources/set-up/otel_engine.md
+++ b/docs/sources/set-up/otel_engine.md
@@ -272,7 +272,7 @@ In the meantime, use the CLI or Helm options for testing.
 1. **Server ports**: The {{< param "DEFAULT_ENGINE" >}} exposes its HTTP server on port `12345`.
    The {{< param "OTEL_ENGINE" >}} exposes its HTTP server on port `8888`.
    The {{< param "OTEL_ENGINE" >}} HTTP server doesn't expose a UI, support bundles, or reload endpoint functionality like the {{< param "DEFAULT_ENGINE" >}} does.
-1. **Inline configuration module path**: If `config.inline.module_path` isn't defined, the `module_path` Alloy configuration keyword resolves to the process current working directory.
+1. **Inline configuration module path**: If `config.inline.module_path` isn't defined, the `module_path` {{< param "PRODUCT_NAME" >}} configuration keyword resolves to the process current working directory.
 1. **Fleet management**: [Grafana Fleet Management](https://grafana.com/blog/opentelemetry-and-grafana-labs-whats-new-and-whats-next-in-2026/#fleet-management) doesn't support the {{< param "OTEL_ENGINE" >}} yet.
    You must define and manage the input configuration manually.
 

--- a/docs/sources/set-up/otel_engine.md
+++ b/docs/sources/set-up/otel_engine.md
@@ -89,9 +89,10 @@ Since the {{< param "DEFAULT_ENGINE" >}} isn't running, the UI and metrics aren'
 
 You can also run the {{< param "OTEL_ENGINE" >}} with the {{< param "DEFAULT_ENGINE" >}}.
 Modify your YAML configuration to include the `alloyengine` extension.
-This extension accepts a path to the {{< param "DEFAULT_ENGINE" >}} configuration and starts a {{< param "DEFAULT_ENGINE" >}} pipeline alongside the {{< param "OTEL_ENGINE" >}} pipeline.
+This extension accepts a path to the {{< param "DEFAULT_ENGINE" >}} configuration or an inline {{< param "DEFAULT_ENGINE" >}} configuration.
+It starts a {{< param "DEFAULT_ENGINE" >}} pipeline alongside the {{< param "OTEL_ENGINE" >}} pipeline.
 
-The following example shows the configuration:
+The following example uses `config.path` to load the {{< param "DEFAULT_ENGINE" >}} configuration from a file or directory:
 
 ```yaml
 extensions:
@@ -139,6 +140,19 @@ Replace the following:
 - _`<USERNAME>`_: Your username. If you're using Grafana Cloud, this is your Grafana Cloud instance ID.
 - _`<PASSWORD>`_: Your password. If you're using Grafana Cloud, this is your Grafana Cloud API token.
 - _`<URL>`_: The URL to export data to. If you're using Grafana Cloud, this is your Grafana Cloud OTLP endpoint URL.
+
+To provide the {{< param "DEFAULT_ENGINE" >}} configuration inline, use `config.inline.content` instead of `config.path`:
+
+```yaml
+extensions:
+  alloyengine:
+    config:
+      inline:
+        content: |
+          logging {
+            level = "info"
+          }
+```
 
 This example adds the `alloyengine` block in the extension declarations and enables the extension in the `service` block.
 You can then run {{< param "PRODUCT_NAME" >}} with the exact same command as before:
@@ -258,6 +272,7 @@ In the meantime, use the CLI or Helm options for testing.
 1. **Server ports**: The {{< param "DEFAULT_ENGINE" >}} exposes its HTTP server on port `12345`.
    The {{< param "OTEL_ENGINE" >}} exposes its HTTP server on port `8888`.
    The {{< param "OTEL_ENGINE" >}} HTTP server doesn't expose a UI, support bundles, or reload endpoint functionality like the {{< param "DEFAULT_ENGINE" >}} does.
+1. **Inline configuration module path**: If `config.inline.module_path` isn't defined, the `module_path` Alloy config keyword resolves to the process current working directory.
 1. **Fleet management**: [Grafana Fleet Management](https://grafana.com/blog/opentelemetry-and-grafana-labs-whats-new-and-whats-next-in-2026/#fleet-management) doesn't support the {{< param "OTEL_ENGINE" >}} yet.
    You must define and manage the input configuration manually.
 

--- a/extension/alloyengine/README.md
+++ b/extension/alloyengine/README.md
@@ -17,7 +17,7 @@ The extension accepts the following configuration fields:
 
 ### Config Object
 
-The `config` object specifies the Alloy configuration source. Exactly one of `path` or `inline.content` must be set.
+The `config` object specifies the Alloy configuration source. Exactly one of `path` (or the deprecated `file`) or `inline.content` must be set.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|

--- a/extension/alloyengine/README.md
+++ b/extension/alloyengine/README.md
@@ -17,19 +17,19 @@ The extension accepts the following configuration fields:
 
 ### Config Object
 
-The `config` object specifies the Alloy configuration source. Either `path` or `inline` must be set, but not both.
+The `config` object specifies the Alloy configuration source. Exactly one of `path` or `inline.content` must be set.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `path` | string | No | - | Path to an Alloy config file or a directory containing `.alloy` files. |
-| `inline` | object | No | - | Inline Alloy configuration. See [Inline Object](#inline-object) for details. |
+| `path` | string | Required unless `inline.content` is set | - | Path to an Alloy config file or a directory containing `.alloy` files. Mutually exclusive with `inline.content`. |
+| `inline` | object | Required unless `path` is set | - | Inline Alloy configuration. See [Inline Object](#inline-object) for details. |
 
 ### Inline Object
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `content` | string | Yes | - | The inline Alloy configuration to run. |
-| `module_path` | string | No | current working directory | Value resolved for the `module_path` Alloy config keyword. Has no effect when `config.path` is set. |
+| `module_path` | string | No | current working directory | Value resolved for the `module_path` Alloy config keyword. |
 
 ### Example Configuration
 
@@ -115,6 +115,10 @@ The extension manages the lifecycle of the embedded default engine:
 Only one alloyengine instance can be active per process. The embedded Default Engine uses process-global state (Prometheus registry, controller ID, storage path and so forth), so running multiple instances will cause conflicts. If you configure multiple alloyengine extensions, only the first to start will succeed; subsequent instances will fail at startup with a clear error.
 
 Please note that if extensions fail to start, the collector will also fail to start. This means that the errors described above will ultimately mean you cannot start the collector without ensuring that you specify which of the alloyengine extensions you wish to run.
+
+If `config.inline.module_path` isn't defined, `config.inline` resolves the `module_path` Alloy config keyword to the current working directory of the OpenTelemetry Collector process.
+
+The `remotecfg` Alloy configuration block can't be used with the alloyengine extension. Use OpenTelemetry OpAMP for Collector configuration management instead.
 
 ## Stability
 

--- a/extension/alloyengine/config.go
+++ b/extension/alloyengine/config.go
@@ -27,6 +27,14 @@ type AlloyConfig struct {
 	Inline InlineAlloyConfig `mapstructure:"inline"`
 }
 
+func (cfg AlloyConfig) isModulePathUnset() bool {
+	if cfg.File != "" || cfg.Path != "" {
+		return false
+	}
+
+	return cfg.Inline.ModulePath == ""
+}
+
 type InlineAlloyConfig struct {
 	// ModulePath is value to be resolved for "module_path" alloy config keyword.
 	ModulePath string `mapstructure:"module_path"`

--- a/extension/alloyengine/config_test.go
+++ b/extension/alloyengine/config_test.go
@@ -1,0 +1,92 @@
+package alloyengine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  Config
+		wantErr string
+	}{
+		{
+			name:    "no config source",
+			wantErr: "either config.path or config.inline.content must be set",
+		},
+		{
+			name: "path and file",
+			config: Config{AlloyConfig: AlloyConfig{
+				Path: "config.alloy",
+				File: "legacy.alloy",
+			}},
+			wantErr: "config.path and config.file are mutually exclusive; config.file is deprecated, use config.path",
+		},
+		{
+			name: "path and inline",
+			config: Config{AlloyConfig: AlloyConfig{
+				Path:   "config.alloy",
+				Inline: InlineAlloyConfig{Content: "logging {}"},
+			}},
+			wantErr: "exactly one of config.path or config.inline.content must be set",
+		},
+		{
+			name: "file and inline",
+			config: Config{AlloyConfig: AlloyConfig{
+				File:   "legacy.alloy",
+				Inline: InlineAlloyConfig{Content: "logging {}"},
+			}},
+			wantErr: "exactly one of config.path or config.inline.content must be set",
+		},
+		{
+			name: "path file and inline",
+			config: Config{AlloyConfig: AlloyConfig{
+				Path:   "config.alloy",
+				File:   "legacy.alloy",
+				Inline: InlineAlloyConfig{Content: "logging {}"},
+			}},
+			wantErr: "exactly one of config.path or config.inline.content must be set",
+		},
+		{
+			name: "module path without inline content",
+			config: Config{AlloyConfig: AlloyConfig{
+				Inline: InlineAlloyConfig{ModulePath: "/modules"},
+			}},
+			wantErr: "either config.path or config.inline.content must be set",
+		},
+		{
+			name: "path",
+			config: Config{AlloyConfig: AlloyConfig{
+				Path: "config.alloy",
+			}},
+		},
+		{
+			name: "file",
+			config: Config{AlloyConfig: AlloyConfig{
+				File: "legacy.alloy",
+			}},
+		},
+		{
+			name: "inline",
+			config: Config{AlloyConfig: AlloyConfig{
+				Inline: InlineAlloyConfig{
+					ModulePath: "/modules",
+					Content:    "logging {}",
+				},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/extension/alloyengine/extension.go
+++ b/extension/alloyengine/extension.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/grafana/alloy/flowcmd"
+	"github.com/grafana/alloy/internal/nodeconf/importsource"
 	"github.com/grafana/alloy/internal/readyctx"
 	"github.com/grafana/alloy/internal/service/remotecfg"
 	"github.com/grafana/alloy/syntax/ast"
@@ -110,7 +111,7 @@ func (e *alloyEngineExtension) Start(_ context.Context, host component.Host) err
 		e.settings.Logger.Warn("config.file is deprecated, use config.path instead")
 	}
 
-	modulePath, files, err := buildAlloyConfig(e.config.AlloyConfig)
+	modulePath, files, err := buildAlloyConfig(e.settings.Logger, e.config.AlloyConfig)
 	if err != nil {
 		return err
 	}
@@ -241,7 +242,7 @@ func (e *alloyEngineExtension) NotReady() error {
 	}
 }
 
-func buildAlloyConfig(cfg AlloyConfig) (modulePath string, files map[string][]byte, err error) {
+func buildAlloyConfig(logger *zap.Logger, cfg AlloyConfig) (modulePath string, files map[string][]byte, err error) {
 	// File is deprecated; use it as fallback when Path is not set.
 	effectivePath := cfg.Path
 	if effectivePath == "" {
@@ -255,7 +256,8 @@ func buildAlloyConfig(cfg AlloyConfig) (modulePath string, files map[string][]by
 		}
 
 		modulePath = cfg.Inline.ModulePath
-		if modulePath == "" {
+		isModulePathUndefined := modulePath == ""
+		if isModulePathUndefined {
 			cwd, err := os.Getwd()
 			if err != nil {
 				return "", nil, fmt.Errorf("cannot get current working directory: %w", err)
@@ -264,7 +266,7 @@ func buildAlloyConfig(cfg AlloyConfig) (modulePath string, files map[string][]by
 		}
 
 		data := []byte(cfg.Inline.Content)
-		if err := validateAlloyConfig("config.alloy", data); err != nil {
+		if err := validateAlloyConfig(logger, "config.alloy", data, isModulePathUndefined); err != nil {
 			return "", nil, fmt.Errorf("invalid inline Alloy config: %w", err)
 		}
 
@@ -284,7 +286,7 @@ func buildAlloyConfig(cfg AlloyConfig) (modulePath string, files map[string][]by
 			return "", nil, fmt.Errorf("failed to read alloy config file %q: %w", effectivePath, err)
 		}
 
-		if err := validateAlloyConfig(effectivePath, data); err != nil {
+		if err := validateAlloyConfig(logger, effectivePath, data, false); err != nil {
 			return "", nil, fmt.Errorf("error in Alloy config file %q: %w", effectivePath, err)
 		}
 
@@ -314,7 +316,7 @@ func buildAlloyConfig(cfg AlloyConfig) (modulePath string, files map[string][]by
 			return "", nil, err
 		}
 
-		if err := validateAlloyConfig(fpath, data); err != nil {
+		if err := validateAlloyConfig(logger, fpath, data, false); err != nil {
 			return "", nil, fmt.Errorf("error in Alloy config file %q: %w", fpath, err)
 		}
 
@@ -325,13 +327,12 @@ func buildAlloyConfig(cfg AlloyConfig) (modulePath string, files map[string][]by
 }
 
 // validateAlloyConfig checks whether Alloy config contains statements unsupported in extension mode.
-func validateAlloyConfig(fname string, data []byte) error {
+func validateAlloyConfig(logger *zap.Logger, fname string, data []byte, warnIfModulePathUsed bool) error {
 	tree, err := parser.ParseFile(fname, data)
 	if err != nil {
 		return fmt.Errorf("failed to parse config file: %w", err)
 	}
 
-	// TODO: throw warning if 'import.file' uses 'module_path' in inline config.
 	for _, stmt := range tree.Body {
 		block, ok := stmt.(*ast.BlockStmt)
 		if !ok {
@@ -344,5 +345,30 @@ func validateAlloyConfig(fname string, data []byte) error {
 		}
 	}
 
+	if warnIfModulePathUsed && usesModulePath(tree) {
+		logger.Warn("inline Alloy config references `module_path` but config.inline.module_path is not set; it defaults to the current working directory",
+			zap.String("file", fname))
+	}
+
 	return nil
+}
+
+// usesModulePath reports whether the AST references the module_path keyword in any expression.
+func usesModulePath(tree *ast.File) bool {
+	var v modulePathVisitor
+	ast.Walk(&v, tree)
+	return v.found
+}
+
+// modulePathVisitor walks an AST looking for references to the module_path keyword.
+type modulePathVisitor struct {
+	found bool
+}
+
+func (v *modulePathVisitor) Visit(node ast.Node) ast.Visitor {
+	expr, ok := node.(*ast.IdentifierExpr)
+	if ok && expr.Ident.Name == importsource.ModulePath {
+		v.found = true
+	}
+	return v
 }

--- a/extension/alloyengine/extension.go
+++ b/extension/alloyengine/extension.go
@@ -116,13 +116,11 @@ func (e *alloyEngineExtension) Start(_ context.Context, host component.Host) err
 		return err
 	}
 
-	// A hook to check for `module_path` references in imported configs.
-	// Used only if inline config is used and module_path is undefined.
-	var onConfigImport importsource.ImportContentHook
+	// A hook to validate imported configs (rejecting unsupported blocks). It also warns about
+	// `module_path` references only when inline config is used and module_path is undefined.
 	cfg := e.config.AlloyConfig
-	if cfg.Inline.Content != "" && cfg.Inline.ModulePath == "" {
-		onConfigImport = newImportModulePathHook(e.settings.Logger, modulePath)
-	}
+	warnModulePathDefault := cfg.Inline.Content != "" && cfg.Inline.ModulePath == ""
+	onConfigImport := newImportContentHook(e.settings.Logger, warnModulePathDefault, modulePath)
 
 	runCommand := e.runCommandFactory(modulePath, files, onConfigImport)
 
@@ -341,16 +339,8 @@ func validateAlloyConfig(logger *zap.Logger, fname string, data []byte, warnIfMo
 		return fmt.Errorf("failed to parse config file: %w", err)
 	}
 
-	for _, stmt := range tree.Body {
-		block, ok := stmt.(*ast.BlockStmt)
-		if !ok {
-			continue
-		}
-
-		blockName := block.GetBlockName()
-		if blockName == remotecfg.ServiceName {
-			return fmt.Errorf("block %q is not supported in Alloy extension", blockName)
-		}
+	if err := checkUnsupportedBlocks(tree); err != nil {
+		return err
 	}
 
 	if warnIfModulePathUsed && usesModulePath(tree) {
@@ -361,21 +351,42 @@ func validateAlloyConfig(logger *zap.Logger, fname string, data []byte, warnIfMo
 	return nil
 }
 
-// newImportModulePathHook returns a hook that warns when an imported module references
-// module_path while it still resolves to the defaulted (cwd) value of an inline config.
-//
-// initialModulePath is a module_path used in a root Alloy config.
-func newImportModulePathHook(logger *zap.Logger, initialModulePath string) importsource.ImportContentHook {
-	return func(fileName string, content *ast.File, source importsource.ImportSource) {
-		// NOTE: only the `import.string` inherits the parent module_path.
-		if !source.InheritsModulePath() {
-			return
+// checkUnsupportedBlocks returns an error if the config uses a top-level block that is unsupported
+// in extension mode.
+func checkUnsupportedBlocks(tree *ast.File) error {
+	for _, stmt := range tree.Body {
+		block, ok := stmt.(*ast.BlockStmt)
+		if !ok {
+			continue
 		}
 
-		if source.ModulePath() == initialModulePath && usesModulePath(content) {
+		if name := block.GetBlockName(); name == remotecfg.ServiceName {
+			return fmt.Errorf("block %q is not supported in Alloy extension", name)
+		}
+	}
+	return nil
+}
+
+// newImportContentHook returns a hook that validates imported module content for extension mode.
+// It rejects unsupported blocks (e.g. remotecfg). When warnModulePathDefault is set, it also warns
+// if an imported module references module_path while it still resolves to the defaulted (cwd)
+// value of an inline config.
+//
+// initialModulePath is the module_path used in the root Alloy config.
+func newImportContentHook(logger *zap.Logger, warnModulePathDefault bool, initialModulePath string) importsource.ImportContentHook {
+	return func(fileName string, content *ast.File, source importsource.ImportSource) error {
+		// The caller (ImportConfigNode.onContentUpdate) logs the file name, so it isn't wrapped here.
+		if err := checkUnsupportedBlocks(content); err != nil {
+			return err
+		}
+
+		// NOTE: only the `import.string` inherits the parent module_path.
+		if warnModulePathDefault && source.InheritsModulePath() &&
+			source.ModulePath() == initialModulePath && usesModulePath(content) {
 			logger.Warn("imported module references `module_path` but config.inline.module_path is not set; it defaults to the current working directory",
 				zap.String("file", fileName))
 		}
+		return nil
 	}
 }
 

--- a/extension/alloyengine/extension.go
+++ b/extension/alloyengine/extension.go
@@ -81,7 +81,7 @@ type alloyEngineExtension struct {
 	config            *Config
 	settings          component.TelemetrySettings
 	runExited         chan struct{}
-	runCommandFactory func(modulePath string, configs map[string][]byte) *cobra.Command
+	runCommandFactory func(modulePath string, configs map[string][]byte, onConfigImport importsource.ImportContentHook) *cobra.Command
 
 	stateMutex sync.Mutex
 	state      state
@@ -116,7 +116,15 @@ func (e *alloyEngineExtension) Start(_ context.Context, host component.Host) err
 		return err
 	}
 
-	runCommand := e.runCommandFactory(modulePath, files)
+	// A hook to check for `module_path` references in imported configs.
+	// Used only if inline config is used and module_path is undefined.
+	var onConfigImport importsource.ImportContentHook
+	cfg := e.config.AlloyConfig
+	if cfg.Inline.Content != "" && cfg.Inline.ModulePath == "" {
+		onConfigImport = newImportModulePathHook(e.settings.Logger, modulePath)
+	}
+
+	runCommand := e.runCommandFactory(modulePath, files, onConfigImport)
 
 	// Prevent cobra from autoloading command-line args from os.Args
 	runCommand.SetArgs([]string{})
@@ -351,6 +359,24 @@ func validateAlloyConfig(logger *zap.Logger, fname string, data []byte, warnIfMo
 	}
 
 	return nil
+}
+
+// newImportModulePathHook returns a hook that warns when an imported module references
+// module_path while it still resolves to the defaulted (cwd) value of an inline config.
+//
+// initialModulePath is a module_path used in a root Alloy config.
+func newImportModulePathHook(logger *zap.Logger, initialModulePath string) importsource.ImportContentHook {
+	return func(fileName string, content *ast.File, source importsource.ImportSource) {
+		// NOTE: only the `import.string` inherits the parent module_path.
+		if !source.InheritsModulePath() {
+			return
+		}
+
+		if source.ModulePath() == initialModulePath && usesModulePath(content) {
+			logger.Warn("imported module references `module_path` but config.inline.module_path is not set; it defaults to the current working directory",
+				zap.String("file", fileName))
+		}
+	}
 }
 
 // usesModulePath reports whether the AST references the module_path keyword in any expression.

--- a/extension/alloyengine/extension.go
+++ b/extension/alloyengine/extension.go
@@ -116,11 +116,12 @@ func (e *alloyEngineExtension) Start(_ context.Context, host component.Host) err
 		return err
 	}
 
-	// A hook to validate imported configs (rejecting unsupported blocks). It also warns about
-	// `module_path` references only when inline config is used and module_path is undefined.
-	cfg := e.config.AlloyConfig
-	warnModulePathDefault := cfg.Inline.Content != "" && cfg.Inline.ModulePath == ""
-	onConfigImport := newImportContentHook(e.settings.Logger, warnModulePathDefault, modulePath)
+	// Optional hook to check imported configs whether they contain `module_path`.
+	// Has effect only for inline configs with `config.inline.module_path` is unset.
+	var onConfigImport importsource.ImportContentHook
+	if e.config.AlloyConfig.isModulePathUnset() {
+		onConfigImport = newImportContentHook(e.settings.Logger, modulePath)
+	}
 
 	runCommand := e.runCommandFactory(modulePath, files, onConfigImport)
 
@@ -333,7 +334,7 @@ func buildAlloyConfig(logger *zap.Logger, cfg AlloyConfig) (modulePath string, f
 }
 
 // validateAlloyConfig checks whether Alloy config contains statements unsupported in extension mode.
-func validateAlloyConfig(logger *zap.Logger, fname string, data []byte, warnIfModulePathUsed bool) error {
+func validateAlloyConfig(logger *zap.Logger, fname string, data []byte, warnModulePathDefault bool) error {
 	tree, err := parser.ParseFile(fname, data)
 	if err != nil {
 		return fmt.Errorf("failed to parse config file: %w", err)
@@ -343,7 +344,7 @@ func validateAlloyConfig(logger *zap.Logger, fname string, data []byte, warnIfMo
 		return err
 	}
 
-	if warnIfModulePathUsed && usesModulePath(tree) {
+	if warnModulePathDefault && usesModulePath(tree) {
 		logger.Warn("inline Alloy config references `module_path` but config.inline.module_path is not set; it defaults to the current working directory",
 			zap.String("file", fname))
 	}
@@ -351,8 +352,7 @@ func validateAlloyConfig(logger *zap.Logger, fname string, data []byte, warnIfMo
 	return nil
 }
 
-// checkUnsupportedBlocks returns an error if the config uses a top-level block that is unsupported
-// in extension mode.
+// checkUnsupportedBlocks checks whether Alloy config AST contains blocks that aren't allowed in the extension mode.
 func checkUnsupportedBlocks(tree *ast.File) error {
 	for _, stmt := range tree.Body {
 		block, ok := stmt.(*ast.BlockStmt)
@@ -367,27 +367,21 @@ func checkUnsupportedBlocks(tree *ast.File) error {
 	return nil
 }
 
-// newImportContentHook returns a hook that validates imported module content for extension mode.
-// It rejects unsupported blocks (e.g. remotecfg). When warnModulePathDefault is set, it also warns
-// if an imported module references module_path while it still resolves to the defaulted (cwd)
-// value of an inline config.
+// newImportContentHook returns a hook to check Alloy configs loaded via `import.*` blocks.
 //
-// initialModulePath is the module_path used in the root Alloy config.
-func newImportContentHook(logger *zap.Logger, warnModulePathDefault bool, initialModulePath string) importsource.ImportContentHook {
-	return func(fileName string, content *ast.File, source importsource.ImportSource) error {
-		// The caller (ImportConfigNode.onContentUpdate) logs the file name, so it isn't wrapped here.
-		if err := checkUnsupportedBlocks(content); err != nil {
-			return err
+// Hook throws warning if imported config uses `module_path` that was inherited from global Alloy config.
+func newImportContentHook(logger *zap.Logger, rootModulePath string) importsource.ImportContentHook {
+	return func(fileName string, content *ast.File, source importsource.ImportSource) {
+		if !source.InheritsModulePath() {
+			// only the `import.string` inherits the parent module_path.
+			return
 		}
 
-		// NOTE: only the `import.string` inherits the parent module_path.
-		usesDefaultedModulePath := warnModulePathDefault && source.InheritsModulePath() &&
-			source.ModulePath() == initialModulePath && usesModulePath(content)
-		if usesDefaultedModulePath {
+		shouldWarn := source.ModulePath() == rootModulePath && usesModulePath(content)
+		if shouldWarn {
 			logger.Warn("imported module references `module_path` but config.inline.module_path is not set; it defaults to the current working directory",
 				zap.String("file", fileName))
 		}
-		return nil
 	}
 }
 

--- a/extension/alloyengine/extension.go
+++ b/extension/alloyengine/extension.go
@@ -381,8 +381,9 @@ func newImportContentHook(logger *zap.Logger, warnModulePathDefault bool, initia
 		}
 
 		// NOTE: only the `import.string` inherits the parent module_path.
-		if warnModulePathDefault && source.InheritsModulePath() &&
-			source.ModulePath() == initialModulePath && usesModulePath(content) {
+		usesDefaultedModulePath := warnModulePathDefault && source.InheritsModulePath() &&
+			source.ModulePath() == initialModulePath && usesModulePath(content)
+		if usesDefaultedModulePath {
 			logger.Warn("imported module references `module_path` but config.inline.module_path is not set; it defaults to the current working directory",
 				zap.String("file", fileName))
 		}

--- a/extension/alloyengine/extension.go
+++ b/extension/alloyengine/extension.go
@@ -273,7 +273,7 @@ func buildAlloyConfig(logger *zap.Logger, cfg AlloyConfig) (modulePath string, f
 		}
 
 		data := []byte(cfg.Inline.Content)
-		if err := validateAlloyConfig(logger, "config.alloy", data, isModulePathUndefined); err != nil {
+		if err := validateAlloyConfig(logger, "config.alloy", data, !isModulePathUndefined); err != nil {
 			return "", nil, fmt.Errorf("invalid inline Alloy config: %w", err)
 		}
 
@@ -293,7 +293,7 @@ func buildAlloyConfig(logger *zap.Logger, cfg AlloyConfig) (modulePath string, f
 			return "", nil, fmt.Errorf("failed to read alloy config file %q: %w", effectivePath, err)
 		}
 
-		if err := validateAlloyConfig(logger, effectivePath, data, false); err != nil {
+		if err := validateAlloyConfig(logger, effectivePath, data, true); err != nil {
 			return "", nil, fmt.Errorf("error in Alloy config file %q: %w", effectivePath, err)
 		}
 
@@ -323,7 +323,7 @@ func buildAlloyConfig(logger *zap.Logger, cfg AlloyConfig) (modulePath string, f
 			return "", nil, err
 		}
 
-		if err := validateAlloyConfig(logger, fpath, data, false); err != nil {
+		if err := validateAlloyConfig(logger, fpath, data, true); err != nil {
 			return "", nil, fmt.Errorf("error in Alloy config file %q: %w", fpath, err)
 		}
 
@@ -334,7 +334,7 @@ func buildAlloyConfig(logger *zap.Logger, cfg AlloyConfig) (modulePath string, f
 }
 
 // validateAlloyConfig checks whether Alloy config contains statements unsupported in extension mode.
-func validateAlloyConfig(logger *zap.Logger, fname string, data []byte, warnModulePathDefault bool) error {
+func validateAlloyConfig(logger *zap.Logger, fname string, data []byte, isModulePathSet bool) error {
 	tree, err := parser.ParseFile(fname, data)
 	if err != nil {
 		return fmt.Errorf("failed to parse config file: %w", err)
@@ -344,7 +344,7 @@ func validateAlloyConfig(logger *zap.Logger, fname string, data []byte, warnModu
 		return err
 	}
 
-	if warnModulePathDefault && usesModulePath(tree) {
+	if !isModulePathSet && usesModulePath(tree) {
 		logger.Warn("inline Alloy config references `module_path` but config.inline.module_path is not set; it defaults to the current working directory",
 			zap.String("file", fname))
 	}

--- a/extension/alloyengine/extension_test.go
+++ b/extension/alloyengine/extension_test.go
@@ -336,11 +336,10 @@ func TestNewImportContentHook(t *testing.T) {
 	noMP := `declare "x" { export "v" { value = "static" } }`
 
 	tests := []struct {
-		name        string
-		content     string
-		source      fakeImportSource
-		wantWarns   int
-		errContains string
+		name      string
+		content   string
+		source    fakeImportSource
+		wantWarns int
 	}{
 		{
 			name:      "import.string inheriting defaulted cwd and using module_path warns",
@@ -366,25 +365,13 @@ func TestNewImportContentHook(t *testing.T) {
 			source:    fakeImportSource{modulePath: "/cwd", inherits: true},
 			wantWarns: 0,
 		},
-		{
-			name:        "remotecfg block is rejected",
-			content:     `remotecfg { }`,
-			source:      fakeImportSource{modulePath: "/cwd", inherits: true},
-			errContains: "remotecfg",
-		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			core, logs := observer.New(zapcore.WarnLevel)
-			hook := newImportContentHook(zap.New(core), true, "/cwd")
+			hook := newImportContentHook(zap.New(core), "/cwd")
 
-			err := hook("mod", mustParse(t, tc.content), tc.source)
-
-			if tc.errContains != "" {
-				require.ErrorContains(t, err, tc.errContains)
-			} else {
-				require.NoError(t, err)
-			}
+			hook("mod", mustParse(t, tc.content), tc.source)
 			require.Equal(t, tc.wantWarns, logs.Len())
 			if tc.wantWarns > 0 {
 				rec := logs.All()[0]

--- a/extension/alloyengine/extension_test.go
+++ b/extension/alloyengine/extension_test.go
@@ -12,9 +12,15 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
+	alloycomponent "github.com/grafana/alloy/internal/component"
+	"github.com/grafana/alloy/internal/nodeconf/importsource"
 	"github.com/grafana/alloy/internal/readyctx"
+	"github.com/grafana/alloy/syntax/ast"
 	"github.com/grafana/alloy/syntax/parser"
+	"github.com/grafana/alloy/syntax/vm"
 )
 
 func shutdownExtensionWithTestTimeout(e *alloyEngineExtension) error {
@@ -55,7 +61,7 @@ func defaultTestConfig() *Config {
 }
 
 // newTestExtension creates an extension with injectable runCommandFactory and a nop logger.
-func newTestExtension(t *testing.T, factory func(modulePath string, configs map[string][]byte) *cobra.Command, config *Config) *alloyEngineExtension {
+func newTestExtension(t *testing.T, factory func(modulePath string, configs map[string][]byte, onImportContent importsource.ImportContentHook) *cobra.Command, config *Config) *alloyEngineExtension {
 	t.Helper()
 	e := newAlloyEngineExtension(config, component.TelemetrySettings{Logger: zap.NewNop()})
 	e.runCommandFactory = factory
@@ -64,7 +70,7 @@ func newTestExtension(t *testing.T, factory func(modulePath string, configs map[
 }
 
 // blockingCommand returns a cobra command that blocks until the context is cancelled, then returns nil.
-func blockingCommand(_ string, _ map[string][]byte) *cobra.Command {
+func blockingCommand(_ string, _ map[string][]byte, _ importsource.ImportContentHook) *cobra.Command {
 	return &cobra.Command{
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if fn, ok := readyctx.OnReadyFromContext(cmd.Context()); ok && fn != nil {
@@ -77,7 +83,7 @@ func blockingCommand(_ string, _ map[string][]byte) *cobra.Command {
 }
 
 // blockingCommandWithoutReady blocks until context cancellation but never calls the ready callback.
-func blockingCommandWithoutReady(_ string, _ map[string][]byte) *cobra.Command {
+func blockingCommandWithoutReady(_ string, _ map[string][]byte, _ importsource.ImportContentHook) *cobra.Command {
 	return &cobra.Command{
 		RunE: func(cmd *cobra.Command, args []string) error {
 			<-cmd.Context().Done()
@@ -107,12 +113,12 @@ type retryTrackingState struct {
 	err         error
 }
 
-func newRetryTrackingCommand(failCount int, err error) (func(string, map[string][]byte) *cobra.Command, *retryTrackingState) {
+func newRetryTrackingCommand(failCount int, err error) (func(string, map[string][]byte, importsource.ImportContentHook) *cobra.Command, *retryTrackingState) {
 	state := &retryTrackingState{
 		failCount: failCount,
 		err:       err,
 	}
-	factory := func(_ string, _ map[string][]byte) *cobra.Command {
+	factory := func(_ string, _ map[string][]byte, _ importsource.ImportContentHook) *cobra.Command {
 		return &cobra.Command{
 			RunE: func(cmd *cobra.Command, args []string) error {
 				state.attempts++
@@ -144,10 +150,10 @@ func TestLifecycle_StartPassesInlineConfigToFactory(t *testing.T) {
 		gotModulePath string
 		gotConfigs    map[string][]byte
 	)
-	factory := func(modulePath string, configs map[string][]byte) *cobra.Command {
+	factory := func(modulePath string, configs map[string][]byte, v importsource.ImportContentHook) *cobra.Command {
 		gotModulePath = modulePath
 		gotConfigs = configs
-		return blockingCommand(modulePath, configs)
+		return blockingCommand(modulePath, configs, v)
 	}
 	e := newTestExtension(t, factory, &Config{
 		AlloyConfig: AlloyConfig{
@@ -222,7 +228,9 @@ func TestLifecycle_StayInStartingWhenReadyNotCalled(t *testing.T) {
 
 func TestLifecycle_ShutdownWithRunCommandError(t *testing.T) {
 	expected := errors.New("shutdown error")
-	e := newTestExtension(t, func(_ string, _ map[string][]byte) *cobra.Command { return shutdownErrorCommand(expected) }, defaultTestConfig())
+	e := newTestExtension(t, func(_ string, _ map[string][]byte, _ importsource.ImportContentHook) *cobra.Command {
+		return shutdownErrorCommand(expected)
+	}, defaultTestConfig())
 
 	require.NoError(t, e.Start(t.Context(), componenttest.NewNopHost()))
 	require.Eventually(t, func() bool { return e.getState() == stateRunning }, 1*time.Second, 25*time.Millisecond, "extension did not reach stateRunning")
@@ -310,6 +318,53 @@ func TestUsesModulePath(t *testing.T) {
 			require.Equal(t, tc.want, usesModulePath(tree))
 		})
 	}
+}
+
+// fakeImportSource is a minimal importsource.ImportSource for exercising the import hook.
+type fakeImportSource struct {
+	modulePath string
+	inherits   bool
+}
+
+func (f fakeImportSource) Evaluate(*vm.Scope) error             { return nil }
+func (f fakeImportSource) Run(context.Context) error            { return nil }
+func (f fakeImportSource) CurrentHealth() alloycomponent.Health { return alloycomponent.Health{} }
+func (f fakeImportSource) SetEval(*vm.Evaluator)                {}
+func (f fakeImportSource) ModulePath() string                   { return f.modulePath }
+func (f fakeImportSource) InheritsModulePath() bool             { return f.inherits }
+
+func mustParse(t *testing.T, src string) *ast.File {
+	t.Helper()
+	f, err := parser.ParseFile("test.alloy", []byte(src))
+	require.NoError(t, err)
+	return f
+}
+
+func TestNewImportModulePathHook(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	hook := newImportModulePathHook(zap.New(core), "/cwd")
+
+	usesMP := mustParse(t, `declare "x" { export "v" { value = module_path } }`)
+	noMP := mustParse(t, `declare "x" { export "v" { value = "static" } }`)
+
+	// import.string inheriting the defaulted cwd and using module_path -> one warning.
+	hook("mod", usesMP, fakeImportSource{modulePath: "/cwd", inherits: true})
+	require.Equal(t, 1, logs.Len())
+	rec := logs.All()[0]
+	require.Contains(t, rec.Message, "module_path")
+	require.Equal(t, "mod", rec.ContextMap()["file"])
+
+	// import.file (defines its own module_path) -> no additional warning.
+	hook("mod2", usesMP, fakeImportSource{modulePath: "/cwd", inherits: false})
+	require.Equal(t, 1, logs.Len())
+
+	// import.string whose inherited module_path is not the default -> no additional warning.
+	hook("mod3", usesMP, fakeImportSource{modulePath: "/other", inherits: true})
+	require.Equal(t, 1, logs.Len())
+
+	// import.string inheriting the default but not referencing module_path -> no additional warning.
+	hook("mod4", noMP, fakeImportSource{modulePath: "/cwd", inherits: true})
+	require.Equal(t, 1, logs.Len())
 }
 
 func TestLifecycle_RunSucceedsAfterRetries(t *testing.T) {

--- a/extension/alloyengine/extension_test.go
+++ b/extension/alloyengine/extension_test.go
@@ -134,15 +134,6 @@ func newRetryTrackingCommand(failCount int, err error) (func(string, map[string]
 	return factory, state
 }
 
-func TestConfig_MissingContent(t *testing.T) {
-	t.Helper()
-	cfg := &Config{
-		AlloyConfig: AlloyConfig{},
-		Flags:       map[string]string{},
-	}
-	require.EqualError(t, cfg.Validate(), "either config.path or config.inline.content must be set")
-}
-
 func TestLifecycle_StartPassesInlineConfigToFactory(t *testing.T) {
 	const content = "logging { level = \"debug\" }"
 

--- a/extension/alloyengine/extension_test.go
+++ b/extension/alloyengine/extension_test.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/grafana/alloy/internal/readyctx"
+	"github.com/grafana/alloy/syntax/parser"
 )
 
 func shutdownExtensionWithTestTimeout(e *alloyEngineExtension) error {
@@ -262,6 +263,51 @@ func TestBuildAlloyConfig_RemoteCfgValidation(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestUsesModulePath(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name:    "no module_path reference",
+			content: `logging { level = "debug" }`,
+			want:    false,
+		},
+		{
+			name: "module_path used in import.file filename",
+			content: `import.file "node_collector" {
+				filename = file.path_join(module_path, "modules/node_collector.alloy")
+			}`,
+			want: true,
+		},
+		{
+			name: "module_path used in component attribute",
+			content: `prometheus.exporter.blackbox "federation" {
+				config_file = file.path_join(module_path, "blackbox_federation.yaml")
+			}`,
+			want: true,
+		},
+		{
+			name:    "module_path as a bare attribute value",
+			content: `foo { bar = module_path }`,
+			want:    true,
+		},
+		{
+			name:    "attribute literally named module_path is not a reference",
+			content: `foo { module_path = "x" }`,
+			want:    false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tree, err := parser.ParseFile("test.alloy", []byte(tc.content))
+			require.NoError(t, err)
+			require.Equal(t, tc.want, usesModulePath(tree))
 		})
 	}
 }

--- a/extension/alloyengine/extension_test.go
+++ b/extension/alloyengine/extension_test.go
@@ -256,7 +256,7 @@ func TestBuildAlloyConfig_RemoteCfgValidation(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			_, _, err := buildAlloyConfig(tc.cfg)
+			_, _, err := buildAlloyConfig(zap.NewNop(), tc.cfg)
 			if tc.errContains != "" {
 				require.ErrorContains(t, err, tc.errContains)
 			} else {

--- a/extension/alloyengine/extension_test.go
+++ b/extension/alloyengine/extension_test.go
@@ -331,31 +331,74 @@ func mustParse(t *testing.T, src string) *ast.File {
 	return f
 }
 
-func TestNewImportModulePathHook(t *testing.T) {
-	core, logs := observer.New(zapcore.WarnLevel)
-	hook := newImportModulePathHook(zap.New(core), "/cwd")
+func TestNewImportContentHook(t *testing.T) {
+	usesMP := `declare "x" { export "v" { value = module_path } }`
+	noMP := `declare "x" { export "v" { value = "static" } }`
 
-	usesMP := mustParse(t, `declare "x" { export "v" { value = module_path } }`)
-	noMP := mustParse(t, `declare "x" { export "v" { value = "static" } }`)
+	tests := []struct {
+		name        string
+		content     string
+		source      fakeImportSource
+		wantWarns   int
+		errContains string
+	}{
+		{
+			name:      "import.string inheriting defaulted cwd and using module_path warns",
+			content:   usesMP,
+			source:    fakeImportSource{modulePath: "/cwd", inherits: true},
+			wantWarns: 1,
+		},
+		{
+			name:      "import.file defines its own module_path, no warning",
+			content:   usesMP,
+			source:    fakeImportSource{modulePath: "/cwd", inherits: false},
+			wantWarns: 0,
+		},
+		{
+			name:      "inherited module_path not the default, no warning",
+			content:   usesMP,
+			source:    fakeImportSource{modulePath: "/other", inherits: true},
+			wantWarns: 0,
+		},
+		{
+			name:      "inherits default but does not reference module_path, no warning",
+			content:   noMP,
+			source:    fakeImportSource{modulePath: "/cwd", inherits: true},
+			wantWarns: 0,
+		},
+		{
+			name:        "remotecfg block is rejected",
+			content:     `remotecfg { }`,
+			source:      fakeImportSource{modulePath: "/cwd", inherits: true},
+			errContains: "remotecfg",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			core, logs := observer.New(zapcore.WarnLevel)
+			hook := newImportContentHook(zap.New(core), true, "/cwd")
 
-	// import.string inheriting the defaulted cwd and using module_path -> one warning.
-	hook("mod", usesMP, fakeImportSource{modulePath: "/cwd", inherits: true})
-	require.Equal(t, 1, logs.Len())
-	rec := logs.All()[0]
-	require.Contains(t, rec.Message, "module_path")
-	require.Equal(t, "mod", rec.ContextMap()["file"])
+			err := hook("mod", mustParse(t, tc.content), tc.source)
 
-	// import.file (defines its own module_path) -> no additional warning.
-	hook("mod2", usesMP, fakeImportSource{modulePath: "/cwd", inherits: false})
-	require.Equal(t, 1, logs.Len())
+			if tc.errContains != "" {
+				require.ErrorContains(t, err, tc.errContains)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.wantWarns, logs.Len())
+			if tc.wantWarns > 0 {
+				rec := logs.All()[0]
+				require.Contains(t, rec.Message, "module_path")
+				require.Equal(t, "mod", rec.ContextMap()["file"])
+			}
+		})
+	}
+}
 
-	// import.string whose inherited module_path is not the default -> no additional warning.
-	hook("mod3", usesMP, fakeImportSource{modulePath: "/other", inherits: true})
-	require.Equal(t, 1, logs.Len())
-
-	// import.string inheriting the default but not referencing module_path -> no additional warning.
-	hook("mod4", noMP, fakeImportSource{modulePath: "/cwd", inherits: true})
-	require.Equal(t, 1, logs.Len())
+func TestCheckUnsupportedBlocks(t *testing.T) {
+	require.NoError(t, checkUnsupportedBlocks(mustParse(t, `logging { level = "debug" }`)))
+	require.NoError(t, checkUnsupportedBlocks(mustParse(t, `import.string "x" { content = "" }`)))
+	require.ErrorContains(t, checkUnsupportedBlocks(mustParse(t, `remotecfg { }`)), "remotecfg")
 }
 
 func TestLifecycle_RunSucceedsAfterRetries(t *testing.T) {

--- a/flowcmd/flowcmd.go
+++ b/flowcmd/flowcmd.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/alloy"
 	"github.com/grafana/alloy/internal/alloycli"
 	"github.com/grafana/alloy/internal/build"
+	"github.com/grafana/alloy/internal/nodeconf/importsource"
 
 	// Register Prometheus SD components
 	_ "github.com/prometheus/prometheus/discovery/install"
@@ -40,9 +41,12 @@ func RootCommand() *cobra.Command {
 }
 
 // RunAsExtensionCommand returns a standalone cobra command to run Alloy inside Otel collector.
-func RunAsExtensionCommand(modulePath string, configs map[string][]byte) *cobra.Command {
+//
+// configImportHook is a hook that called when `import.*` component loads additional config files.
+func RunAsExtensionCommand(modulePath string, configs map[string][]byte, configImportHook importsource.ImportContentHook) *cobra.Command {
 	return alloycli.NewRunAsExtensionCommand(alloycli.ExtensionModeParams{
-		Configs:    configs,
-		ModulePath: modulePath,
+		Configs:        configs,
+		ModulePath:     modulePath,
+		OnConfigImport: configImportHook,
 	})
 }

--- a/internal/alloycli/cmd_run.go
+++ b/internal/alloycli/cmd_run.go
@@ -33,6 +33,7 @@ import (
 	"github.com/grafana/alloy/internal/converter"
 	convert_diag "github.com/grafana/alloy/internal/converter/diag"
 	"github.com/grafana/alloy/internal/featuregate"
+	"github.com/grafana/alloy/internal/nodeconf/importsource"
 	"github.com/grafana/alloy/internal/readyctx"
 	alloy_runtime "github.com/grafana/alloy/internal/runtime"
 	"github.com/grafana/alloy/internal/runtime/logging"
@@ -124,6 +125,9 @@ type ExtensionModeParams struct {
 
 	// ModulePath is a value that will be used as "module_path" keyword value in Alloy config.
 	ModulePath string
+
+	// OnConfigImport is a hook that is called when config files are imported using `import.*` components.
+	OnConfigImport importsource.ImportContentHook
 }
 
 // NewRunAsExtensionCommand returns a standalone cobra command to run Alloy inside OTel collector as an extension.
@@ -140,6 +144,7 @@ func NewRunAsExtensionCommand(params ExtensionModeParams) *cobra.Command {
 		Args:         cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rp := runParams{
+				onConfigImport: params.OnConfigImport,
 				newReloadSignal: func() chan os.Signal {
 					// SIGHUP is reserved by otel collector. Thus, use nop.
 					return nil
@@ -384,6 +389,9 @@ type runParams struct {
 
 	// getConfig callback provides initial alloy config.
 	getConfig func(rt *alloy_runtime.Runtime, httpSvc *httpservice.Service) (map[string][]byte, error)
+
+	// onConfigImport is a hook that called when extra configs are loaded using `import.*` components.
+	onConfigImport importsource.ImportContentHook
 }
 
 func (fr *alloyRun) run(ctx context.Context, fset *pflag.FlagSet, params runParams) error {
@@ -417,7 +425,8 @@ func (fr *alloyRun) run(ctx context.Context, fset *pflag.FlagSet, params runPara
 		if err := featuregate.CheckAllowed(
 			featuregate.StabilityPublicPreview,
 			fr.minStability,
-			"Windows process priority"); err != nil {
+			"Windows process priority",
+		); err != nil {
 			return err
 		}
 
@@ -571,6 +580,7 @@ func (fr *alloyRun) run(ctx context.Context, fset *pflag.FlagSet, params runPara
 			uiService,
 		},
 		TaskShutdownDeadline: fr.taskShutdownDeadline,
+		OnImportContent:      params.onConfigImport,
 	})
 	if err != nil {
 		return err

--- a/internal/nodeconf/importsource/import.go
+++ b/internal/nodeconf/importsource/import.go
@@ -28,8 +28,7 @@ const (
 const ModulePath = "module_path"
 
 // ImportContentHook is a hook that is invoked with the parsed content of an imported config.
-// A non-nil error rejects that content.
-type ImportContentHook func(fileName string, content *ast.File, source ImportSource) error
+type ImportContentHook func(fileName string, content *ast.File, source ImportSource)
 
 // ImportSource retrieves a module from a source.
 type ImportSource interface {

--- a/internal/nodeconf/importsource/import.go
+++ b/internal/nodeconf/importsource/import.go
@@ -28,7 +28,8 @@ const (
 const ModulePath = "module_path"
 
 // ImportContentHook is a hook that is invoked with the parsed content of an imported config.
-type ImportContentHook func(fileName string, content *ast.File, source ImportSource)
+// A non-nil error rejects that content.
+type ImportContentHook func(fileName string, content *ast.File, source ImportSource) error
 
 // ImportSource retrieves a module from a source.
 type ImportSource interface {

--- a/internal/nodeconf/importsource/import.go
+++ b/internal/nodeconf/importsource/import.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/grafana/alloy/internal/component"
+	"github.com/grafana/alloy/syntax/ast"
 	"github.com/grafana/alloy/syntax/vm"
 )
 
@@ -26,6 +27,9 @@ const (
 
 const ModulePath = "module_path"
 
+// ImportContentHook is a hook that is invoked with the parsed content of an imported config.
+type ImportContentHook func(fileName string, content *ast.File, source ImportSource)
+
 // ImportSource retrieves a module from a source.
 type ImportSource interface {
 	// Evaluate updates the arguments provided via the Alloy block.
@@ -38,6 +42,9 @@ type ImportSource interface {
 	SetEval(eval *vm.Evaluator)
 	// ModulePath is the path where the module is stored locally.
 	ModulePath() string
+	// InheritsModulePath reports whether this source derives its module_path from the parent
+	// scope (true for import.string) rather than defining its own (import.file/git/http).
+	InheritsModulePath() bool
 }
 
 // NewImportSource creates a new ImportSource depending on the type.

--- a/internal/nodeconf/importsource/import_file.go
+++ b/internal/nodeconf/importsource/import_file.go
@@ -259,3 +259,8 @@ func (im *ImportFile) ModulePath() string {
 	}
 	return path
 }
+
+// InheritsModulePath reports that import.file defines its own module_path (the imported file's dir).
+func (im *ImportFile) InheritsModulePath() bool {
+	return false
+}

--- a/internal/nodeconf/importsource/import_git.go
+++ b/internal/nodeconf/importsource/import_git.go
@@ -306,3 +306,8 @@ func (im *ImportGit) SetEval(eval *vm.Evaluator) {
 func (im *ImportGit) ModulePath() string {
 	return im.repoPath
 }
+
+// InheritsModulePath reports that import.git defines its own module_path (the local clone dir).
+func (im *ImportGit) InheritsModulePath() bool {
+	return false
+}

--- a/internal/nodeconf/importsource/import_http.go
+++ b/internal/nodeconf/importsource/import_http.go
@@ -113,3 +113,8 @@ func (im *ImportHTTP) ModulePath() string {
 	dir, _ := path.Split(im.arguments.URL)
 	return dir
 }
+
+// InheritsModulePath reports that import.http defines its own module_path (the URL's dir).
+func (im *ImportHTTP) InheritsModulePath() bool {
+	return false
+}

--- a/internal/nodeconf/importsource/import_string.go
+++ b/internal/nodeconf/importsource/import_string.go
@@ -70,3 +70,8 @@ func (im *ImportString) SetEval(eval *vm.Evaluator) {
 func (im *ImportString) ModulePath() string {
 	return im.modulePath
 }
+
+// InheritsModulePath reports that import.string derives module_path from the parent scope.
+func (im *ImportString) InheritsModulePath() bool {
+	return true
+}

--- a/internal/nodeconf/importsource/import_test.go
+++ b/internal/nodeconf/importsource/import_test.go
@@ -1,0 +1,20 @@
+package importsource
+
+import "testing"
+
+func TestInheritsModulePath(t *testing.T) {
+	if !(&ImportString{}).InheritsModulePath() {
+		t.Fatal("import.string should inherit module_path from the parent scope")
+	}
+
+	notInheriting := map[string]ImportSource{
+		"import.file": &ImportFile{},
+		"import.git":  &ImportGit{},
+		"import.http": &ImportHTTP{},
+	}
+	for name, src := range notInheriting {
+		if src.InheritsModulePath() {
+			t.Fatalf("%s should define its own module_path, not inherit it", name)
+		}
+	}
+}

--- a/internal/runtime/alloy.go
+++ b/internal/runtime/alloy.go
@@ -117,6 +117,9 @@ type Options struct {
 
 	// TaskShutdownDeadline is the maximum duration to wait for a component to shut down before giving up and logging an error.
 	TaskShutdownDeadline time.Duration
+
+	// OnImportContent is a hook that is invoked with the parsed content of every imported module.
+	OnImportContent importsource.ImportContentHook
 }
 
 // Runtime is the Alloy system.
@@ -209,6 +212,7 @@ func newController(o controllerOptions) (*Runtime, error) {
 			DataPath:             o.DataPath,
 			MinStability:         o.MinStability,
 			EnableCommunityComps: o.EnableCommunityComps,
+			OnImportContent:      o.OnImportContent,
 			OnBlockNodeUpdate: func(cn controller.BlockNode) {
 				// Changed node should be queued for reevaluation.
 				f.updateQueue.Enqueue(&controller.QueuedNode{Node: cn, LastUpdatedTime: time.Now()})

--- a/internal/runtime/internal/controller/node_builtin_component.go
+++ b/internal/runtime/internal/controller/node_builtin_component.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/featuregate"
+	"github.com/grafana/alloy/internal/nodeconf/importsource"
 	"github.com/grafana/alloy/internal/runtime/equality"
 	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/grafana/alloy/internal/runtime/tracing"
@@ -83,6 +84,9 @@ type ComponentGlobals struct {
 	NewModuleController  func(opts ModuleControllerOpts) ModuleController // Func to generate a module controller.
 	GetServiceData       func(name string) (any, error)                   // Get data for a service.
 	EnableCommunityComps bool                                             // Enables the use of community components.
+
+	// OnImportContent is a hook that is invoked with the parsed content of every imported module.
+	OnImportContent importsource.ImportContentHook
 }
 
 // BuiltinComponentNode is a controller node which manages a builtin component.

--- a/internal/runtime/internal/controller/node_config_import.go
+++ b/internal/runtime/internal/controller/node_config_import.go
@@ -219,13 +219,8 @@ func (cn *ImportConfigNode) onContentUpdate(importedContent map[string]string) {
 			return
 		}
 
-		// call the config import hook. Used by OTel extension to sanitize imports.
 		if cn.globals.OnImportContent != nil {
-			if err := cn.globals.OnImportContent(f, parsedImportedContent, cn.source); err != nil {
-				cn.logger.Error("imported content rejected", "file", f, "err", err)
-				cn.setContentHealth(component.HealthTypeUnhealthy, fmt.Sprintf("imported content from %q rejected: %s", f, err))
-				return
-			}
+			cn.globals.OnImportContent(f, parsedImportedContent, cn.source)
 		}
 
 		// populate importedDeclares and importConfigNodesChildren

--- a/internal/runtime/internal/controller/node_config_import.go
+++ b/internal/runtime/internal/controller/node_config_import.go
@@ -221,7 +221,11 @@ func (cn *ImportConfigNode) onContentUpdate(importedContent map[string]string) {
 
 		// call the config import hook. Used by OTel extension to sanitize imports.
 		if cn.globals.OnImportContent != nil {
-			cn.globals.OnImportContent(f, parsedImportedContent, cn.source)
+			if err := cn.globals.OnImportContent(f, parsedImportedContent, cn.source); err != nil {
+				cn.logger.Error("imported content rejected", "file", f, "err", err)
+				cn.setContentHealth(component.HealthTypeUnhealthy, fmt.Sprintf("imported content from %q rejected: %s", f, err))
+				return
+			}
 		}
 
 		// populate importedDeclares and importConfigNodesChildren

--- a/internal/runtime/internal/controller/node_config_import.go
+++ b/internal/runtime/internal/controller/node_config_import.go
@@ -206,10 +206,8 @@ func (cn *ImportConfigNode) onContentUpdate(importedContent map[string]string) {
 		return
 	}
 
-	cn.importedContent = make(map[string]string)
-	for k, v := range importedContent {
-		cn.importedContent[k] = v
-	}
+	cn.importedContent = make(map[string]string, len(importedContent))
+	maps.Copy(cn.importedContent, importedContent)
 	cn.importedDeclares = make(map[string]ast.Body)
 	cn.importConfigNodesChildren = make(map[string]*ImportConfigNode)
 
@@ -219,6 +217,11 @@ func (cn *ImportConfigNode) onContentUpdate(importedContent map[string]string) {
 			cn.logger.Error("failed to parse file on update", "file", f, "err", err)
 			cn.setContentHealth(component.HealthTypeUnhealthy, fmt.Sprintf("imported content from %q cannot be parsed: %s", f, err))
 			return
+		}
+
+		// call the config import hook. Used by OTel extension to sanitize imports.
+		if cn.globals.OnImportContent != nil {
+			cn.globals.OnImportContent(f, parsedImportedContent, cn.source)
 		}
 
 		// populate importedDeclares and importConfigNodesChildren


### PR DESCRIPTION
### Brief description of Pull Request

Check configs imported by `import.*` components.

### Pull Request Details

This PR is a follow-up for #6442

The OTel extension mode imposes certain limitations:

- `module_path` keyword resolves to a current work dir, if `config.inline.module_path` is undefined.
  - As this behavior diverges from Alloy mode, a warning log is thrown.
- The `remotecfg` block cannot be used.

This PR extends config check for files that can be imported using `import.*` components.

#### Notes

- The `remotecfg` block can't be used inside imports and their `declare` blocks, therefore the import hook only validates the `module_path` usage.
- Only the `import.string` inherits global `module_path`, therefore warning isn't thrown for the rest of `import.*` components as they define their own path based on import URL.

### Issue(s) fixed by this Pull Request

Fixes #6420


### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [x] Tests updated
