### PR TITLE
docs: Add missing `validate` command to available commands list in CLI reference

### DIFF
--- a/docs/sources/reference/cli/_index.md
+++ b/docs/sources/reference/cli/_index.md
@@ -20,6 +20,7 @@ Available commands:
 * [`run`][run]: Start {{< param "PRODUCT_NAME" >}} with the Default Engine, given an Alloy syntax configuration file.
 * [`otel`][otel]: Start {{< param "PRODUCT_NAME" >}} with the experimental OTel Engine, given an OpenTelemetry Collector YAML configuration file.
 * [`tools`][tools]: Read the WAL and provide statistical information.
+* [`validate`][validate]: Validate an {{< param "PRODUCT_NAME" >}} configuration file or directory path.
 * `completion`: Generate shell completion for the `alloy` CLI.
 * `help`: Print help for supported commands.
 
@@ -29,3 +30,4 @@ Available commands:
 [convert]: ./convert/
 [otel]: ./otel/
 [tools]: ./tools/
+[validate]: ./validate/


### PR DESCRIPTION
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style with a capitalized
  description, e.g. `feat(scope): Add the thing` (not `add the thing`). For
  details on this, check out the Contributors Guide linked above.
-->

### Brief description of Pull Request

<!-- Human-readable description of the PR used as squash commit body. -->

This PR adds missing `validate` command to available commands list in CLI reference.

### Pull Request Details

<!-- Detailed description of the Pull Request, if needed. -->
I noticed `validate` command is available and found [the document page](https://grafana.com/docs/alloy/latest/reference/cli/validate/), but that is not listed in available commands.


### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->


### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
