### PR TITLE
fix(database_observability/postgres): Route Windows builds to the nocgo fingerprint stub

### DIFF
--- a/internal/component/database_observability/postgres/fingerprint/fingerprint.go
+++ b/internal/component/database_observability/postgres/fingerprint/fingerprint.go
@@ -1,8 +1,10 @@
 // Package fingerprint computes stable, semantic SQL fingerprints via
 // libpg_query. The fingerprint is identical across comment/whitespace
-// differences and literal-vs-placeholder differences. libpg_query is cgo-only;
-// the !cgo build is provided by fingerprint_nocgo.go, reports
-// Supported() == false, and returns ErrEmpty from every Fingerprint call.
+// differences and literal-vs-placeholder differences. libpg_query is cgo-only,
+// and its bundled C does not link with the TDM-GCC toolchain used for Windows
+// container builds, so the stub in fingerprint_nocgo.go covers both the !cgo
+// cross-compile and all Windows builds: it reports Supported() == false and
+// returns ErrEmpty from every Fingerprint call.
 //
 // This file holds the declarations shared by both builds so the two
 // build-tagged implementations cannot drift apart.

--- a/internal/component/database_observability/postgres/fingerprint/fingerprint_cgo.go
+++ b/internal/component/database_observability/postgres/fingerprint/fingerprint_cgo.go
@@ -1,4 +1,4 @@
-//go:build cgo
+//go:build cgo && !windows
 
 package fingerprint
 

--- a/internal/component/database_observability/postgres/fingerprint/fingerprint_nocgo.go
+++ b/internal/component/database_observability/postgres/fingerprint/fingerprint_nocgo.go
@@ -1,4 +1,4 @@
-//go:build !cgo
+//go:build !cgo || windows
 
 package fingerprint
 

--- a/internal/component/database_observability/postgres/fingerprint/fingerprint_test.go
+++ b/internal/component/database_observability/postgres/fingerprint/fingerprint_test.go
@@ -1,4 +1,4 @@
-//go:build cgo
+//go:build cgo && !windows
 
 package fingerprint
 


### PR DESCRIPTION
## Problem

The Windows devel/release **container** build (`Publish alloy-devel containers`) is failing on `main` after #6180 merged:

```
pg_query_fingerprint_defs.c: undefined reference to `__stack_chk_fail'
...refptr.__stack_chk_guard: undefined reference to `__stack_chk_guard'
collect2.exe: error: ld returned 1 exit status
make: *** [Makefile:264: alloy] Error 1
```

#6180 added the `fingerprint` package, whose cgo path imports `pganalyze/pg_query_go/v6`. Its bundled C is compiled with the stack protector (emitting `__stack_chk_fail`/`__stack_chk_guard`). The **mingw-w64** on GitHub-hosted Windows runners links these symbols fine (so PR `Build on Windows` is green), but the **TDM-GCC 10.3.0** toolchain pinned in `Dockerfile.windows` — used only for the container publish — does not, so `make alloy` fails there.

The container publish was green on `c00551b59` (the commit right before #6180) and broke on the #6180 merge (`377f1d004`).

## Fix

Route all Windows builds to the **existing** nocgo stub via build tags, so `pg_query_go`'s C never enters the Windows binary regardless of `CGO_ENABLED`:

```go
// fingerprint_cgo.go
//go:build cgo && !windows
// fingerprint_nocgo.go
//go:build !cgo || windows
// fingerprint_test.go  (tests the real impl)
//go:build cgo && !windows
```

No shared build infra (`Dockerfile.windows`, `Makefile`, CI) is touched.

## Trade-off

Windows Alloy agents lose SQL fingerprinting for `database_observability.postgres`: `fingerprint.Supported()` returns `false`, which the collector already surfaces gracefully via component health. Linux and macOS keep the real cgo implementation. Windows→Postgres monitoring is an uncommon deployment; a follow-up could restore it by replacing TDM-GCC with mingw-w64 in the container image.

## Verification

- `GOOS=windows go list` selects `fingerprint_nocgo.go` with **no** `pg_query_go` import; `GOOS=linux CGO_ENABLED=1` keeps `fingerprint_cgo.go` + the real dep.
- Changed package builds for `GOOS=windows` in both CGO modes.
- `go test -tags=nodocker ./…/postgres/fingerprint/ ./…/postgres/collector/` green on Linux; `go vet` / `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)