### PR TITLE
fix(database_observability.sql_server): Fix schema_details flaky test

### DIFF
--- a/internal/component/database_observability/sql_server/collector/schema_details_test.go
+++ b/internal/component/database_observability/sql_server/collector/schema_details_test.go
@@ -695,6 +695,7 @@ func TestSchemaDetails(t *testing.T) {
 		defer db.Close()
 
 		lokiClient := loki.NewCollectingHandler()
+		defer lokiClient.Stop()
 
 		collector, err := NewSchemaDetails(SchemaDetailsArguments{
 			DB:              db,
@@ -717,20 +718,8 @@ func TestSchemaDetails(t *testing.T) {
 			}),
 		)
 
-		err = collector.Start(t.Context())
-		require.NoError(t, err)
-
-		require.Eventually(t, func() bool {
-			return mock.ExpectationsWereMet() == nil
-		}, 5*time.Second, 100*time.Millisecond)
-
-		collector.Stop()
-		lokiClient.Stop()
-
-		require.Eventually(t, func() bool {
-			return collector.Stopped()
-		}, 5*time.Second, 100*time.Millisecond)
-
+		require.NoError(t, collector.extractSchema(t.Context()))
+		require.NoError(t, mock.ExpectationsWereMet())
 		require.Empty(t, lokiClient.Received())
 	})
 


### PR DESCRIPTION



### Brief description of Pull Request

Calling mock.ExpectationsWereMet() inside Eventually() while the collector is running and closing rows causes a race.


### Pull Request Details

<!-- Detailed description of the Pull Request, if needed. -->


### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->


### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
