### PR TITLE
test(database_observability): Fix data race in SchemaDetails "no tables detected" tests

### DIFF
--- a/internal/component/database_observability/mysql/collector/schema_details_test.go
+++ b/internal/component/database_observability/mysql/collector/schema_details_test.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"encoding/base64"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,7 +14,9 @@ import (
 
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/component/database_observability"
+	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/grafana/alloy/internal/util"
+	"github.com/grafana/alloy/internal/util/syncbuffer"
 )
 
 func TestSchemaDetails(t *testing.T) {
@@ -969,11 +972,20 @@ func TestSchemaDetails(t *testing.T) {
 
 		lokiClient := loki.NewCollectingHandler()
 
+		// No loki-side sync point here, so sync on the collector's log via a
+		// thread-safe buffer and inspect the mock only after Stop().
+		logBuffer := syncbuffer.Buffer{}
+		logger, err := logging.New(&logBuffer, logging.Options{
+			Level:  logging.LevelDebug,
+			Format: logging.FormatLogfmt,
+		})
+		require.NoError(t, err)
+
 		collector, err := NewSchemaDetails(SchemaDetailsArguments{
 			DB:              db,
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			Logger:          util.TestAlloyLogger(t).Slog(),
+			Logger:          logger.Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -992,16 +1004,17 @@ func TestSchemaDetails(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
-			return mock.ExpectationsWereMet() == nil
+			return strings.Contains(logBuffer.String(), `msg="no tables detected from information_schema.tables"`)
 		}, 5*time.Second, 100*time.Millisecond)
 
 		collector.Stop()
-		lokiClient.Stop()
-
 		require.Eventually(t, func() bool {
 			return collector.Stopped()
 		}, 5*time.Second, 100*time.Millisecond)
 
+		require.NoError(t, mock.ExpectationsWereMet())
+
+		lokiClient.Stop()
 		require.Empty(t, lokiClient.Received())
 	})
 	t.Run("empty tables list clears throttle map", func(t *testing.T) {

--- a/internal/component/database_observability/sql_server/collector/schema_details_test.go
+++ b/internal/component/database_observability/sql_server/collector/schema_details_test.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"encoding/base64"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,7 +14,9 @@ import (
 
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/component/database_observability"
+	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/grafana/alloy/internal/util"
+	"github.com/grafana/alloy/internal/util/syncbuffer"
 )
 
 func TestSchemaDetails(t *testing.T) {
@@ -696,11 +699,20 @@ func TestSchemaDetails(t *testing.T) {
 
 		lokiClient := loki.NewCollectingHandler()
 
+		// No loki-side sync point here, so sync on the collector's log via a
+		// thread-safe buffer and inspect the mock only after Stop().
+		logBuffer := syncbuffer.Buffer{}
+		logger, err := logging.New(&logBuffer, logging.Options{
+			Level:  logging.LevelDebug,
+			Format: logging.FormatLogfmt,
+		})
+		require.NoError(t, err)
+
 		collector, err := NewSchemaDetails(SchemaDetailsArguments{
 			DB:              db,
 			CollectInterval: time.Millisecond,
 			EntryHandler:    lokiClient,
-			Logger:          util.TestAlloyLogger(t).Slog(),
+			Logger:          logger.Slog(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, collector)
@@ -721,16 +733,17 @@ func TestSchemaDetails(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
-			return mock.ExpectationsWereMet() == nil
+			return strings.Contains(logBuffer.String(), `msg="no tables detected from information_schema.tables"`)
 		}, 5*time.Second, 100*time.Millisecond)
 
 		collector.Stop()
-		lokiClient.Stop()
-
 		require.Eventually(t, func() bool {
 			return collector.Stopped()
 		}, 5*time.Second, 100*time.Millisecond)
 
+		require.NoError(t, mock.ExpectationsWereMet())
+
+		lokiClient.Stop()
 		require.Empty(t, lokiClient.Received())
 	})
 


### PR DESCRIPTION
## Problem

`TestSchemaDetails` / **"no tables detected"** (mssql, and latent in mysql) is flaky under `-race`:

```
WARNING: DATA RACE
Write (collector) schema_details.go  listDatabases -> rs.Next
Read  (test)      schema_details_test.go  mock.ExpectationsWereMet()
```

## Cause

`go-sqlmock` isn't concurrency-safe. With no `OP_*` loki entry to sync on when no tables are detected, these subtests polled `mock.ExpectationsWereMet()` from the test goroutine while the collector's ticker goroutine was still iterating rows on the same mock.

## Fix

Sync on the collector's `"no tables detected from information_schema.tables"` log line (via a thread-safe `syncbuffer.Buffer`) instead of the mock, and inspect the mock only after `Stop()`. Keeps the real `Start()`/ticker/`Stop()` path under test and matches the sibling postgres `no schemas found` subtest.

## Verification

`-race -count=100` on both `no_tables_detected` subtests, plus full `TestSchemaDetails` and both packages under `-race`: 0 races, no goroutine leaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
