### PR TITLE
feat(database_observability.sql_server): Support database switching on Azure SQL Database in `schema_details` collector

### DIFF
--- a/docs/sources/reference/components/database_observability/database_observability.sql_server.md
+++ b/docs/sources/reference/components/database_observability/database_observability.sql_server.md
@@ -66,6 +66,12 @@ You can use the following blocks with `database_observability.sql_server`:
 
 The collector scans every database that the login can access on the instance and collects schema details from each. Only databases where the login has `CONNECT` access to catalog views are collected.
 
+{{< admonition type="note" >}}
+On Azure SQL Database, set the `data_source_name` to connect to the `master` database, for example with `database=master`, to collect more than one database.
+The connecting login needs a user in each database you want to monitor, with `VIEW DEFINITION` granted so the component can read catalog metadata.
+If the connection targets a single user database, the component collects only that database.
+{{< /admonition >}}
+
 ## Example
 
 ```alloy

--- a/internal/component/database_observability/sql_server/collector/schema_details.go
+++ b/internal/component/database_observability/sql_server/collector/schema_details.go
@@ -23,6 +23,10 @@ const (
 	OP_CREATE_STATEMENT    = "create_statement"
 )
 
+// engineEditionAzureSQLDatabase has a value of 5 in Azure SQL Database,
+// where we use a different strategy for database switching.
+const engineEditionAzureSQLDatabase = 5
+
 // emitInterval is the minimum amount of time that must elapse between
 // successive OP_CREATE_STATEMENT emissions for the same table, regardless of
 // the configured collect_interval.
@@ -118,6 +122,8 @@ type SchemaDetailsArguments struct {
 	ExcludeSchemas   []string
 	ExcludeDatabases []string
 	EntryHandler     loki.EntryHandler
+	EngineEdition    int
+	NewDBForDatabase func(database string) (*sql.DB, error)
 
 	Logger *slog.Logger
 }
@@ -128,6 +134,8 @@ type SchemaDetails struct {
 	excludeSchemas   []string
 	excludeDatabases []string
 	entryHandler     loki.EntryHandler
+	engineEdition    int
+	newDBForDatabase func(database string) (*sql.DB, error)
 
 	// lastEmittedAt records the wall-clock time at which OP_CREATE_STATEMENT
 	// was last emitted for a table. The outer key is the database name and
@@ -191,6 +199,8 @@ func NewSchemaDetails(args SchemaDetailsArguments) (*SchemaDetails, error) {
 		excludeSchemas:   args.ExcludeSchemas,
 		excludeDatabases: args.ExcludeDatabases,
 		entryHandler:     args.EntryHandler,
+		engineEdition:    args.EngineEdition,
+		newDBForDatabase: args.NewDBForDatabase,
 		lastEmittedAt:    map[string]map[string]time.Time{},
 		now:              time.Now,
 		logger:           args.Logger.With("collector", SchemaDetailsCollector),
@@ -264,25 +274,8 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 
 	if len(databases) == 0 {
 		c.logger.Info("no databases detected")
-	} else {
-		// Pin one connection for the whole cycle as USE mutates session state
-		conn, err := c.dbConnection.Conn(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to acquire database connection: %w", err)
-		}
-		defer conn.Close()
-
-		for _, db := range databases {
-			discovered[db.name] = struct{}{}
-			if _, err := conn.ExecContext(ctx, fmt.Sprintf("USE %s", db.quoted)); err != nil {
-				c.logger.Error("failed to switch database context, skipping", "database", db.name, "err", err)
-				continue
-			}
-			if err := c.extractSchemaForDatabase(ctx, conn, db.name, now); err != nil {
-				c.logger.Error("failed to extract schema for database", "database", db.name, "err", err)
-				continue
-			}
-		}
+	} else if err := c.extractSchemaWithStrategy(ctx, databases, discovered, now); err != nil {
+		return err
 	}
 
 	// Drop throttle entries only for databases that discovery no longer
@@ -297,6 +290,78 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// extractSchemaWithStrategy dispatches to the extraction strategy appropriate
+// for the server's engine edition. Azure SQL Database binds each connection to
+// a single database and rejects cross-database USE, so it opens a fresh
+// connection per database; every other edition switches context with USE on a
+// single pinned connection.
+func (c *SchemaDetails) extractSchemaWithStrategy(ctx context.Context, databases []databaseName, discovered map[string]struct{}, now time.Time) error {
+	if c.engineEdition == engineEditionAzureSQLDatabase {
+		return c.extractSchemaPerDatabaseConn(ctx, databases, discovered, now)
+	}
+	return c.extractSchemaWithUSE(ctx, databases, discovered, now)
+}
+
+// extractSchemaWithUSE iterates the databases on a single pinned connection,
+// switching context with USE.
+func (c *SchemaDetails) extractSchemaWithUSE(ctx context.Context, databases []databaseName, discovered map[string]struct{}, now time.Time) error {
+	// Pin one connection for the whole cycle as USE mutates session state
+	conn, err := c.dbConnection.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to acquire database connection: %w", err)
+	}
+	defer conn.Close()
+
+	for _, db := range databases {
+		discovered[db.name] = struct{}{}
+		if _, err := conn.ExecContext(ctx, fmt.Sprintf("USE %s", db.quoted)); err != nil {
+			c.logger.Error("failed to switch database context, skipping", "database", db.name, "err", err)
+			continue
+		}
+		if err := c.extractSchemaForDatabase(ctx, conn, db.name, now); err != nil {
+			c.logger.Error("failed to extract schema for database", "database", db.name, "err", err)
+			continue
+		}
+	}
+	return nil
+}
+
+// extractSchemaPerDatabaseConn iterates the databases opening a fresh
+// connection scoped to each one, derived from the base DSN.
+func (c *SchemaDetails) extractSchemaPerDatabaseConn(ctx context.Context, databases []databaseName, discovered map[string]struct{}, now time.Time) error {
+	if c.newDBForDatabase == nil {
+		return fmt.Errorf("no per-database connection factory configured")
+	}
+
+	for _, db := range databases {
+		discovered[db.name] = struct{}{}
+		if err := c.extractSchemaForDatabaseConn(ctx, db.name, now); err != nil {
+			c.logger.Error("failed to extract schema for database", "database", db.name, "err", err)
+			continue
+		}
+	}
+	return nil
+}
+
+// extractSchemaForDatabaseConn opens a per-database connection pool, pins a
+// single connection from it, and extracts the schema. The pool and connection
+// are always closed before returning.
+func (c *SchemaDetails) extractSchemaForDatabaseConn(ctx context.Context, dbName string, now time.Time) error {
+	db, err := c.newDBForDatabase(dbName)
+	if err != nil {
+		return fmt.Errorf("failed to open connection for database: %w", err)
+	}
+	defer db.Close()
+
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to acquire connection for database: %w", err)
+	}
+	defer conn.Close()
+
+	return c.extractSchemaForDatabase(ctx, conn, dbName, now)
 }
 
 func (c *SchemaDetails) listDatabases(ctx context.Context) ([]databaseName, error) {

--- a/internal/component/database_observability/sql_server/collector/schema_details_test.go
+++ b/internal/component/database_observability/sql_server/collector/schema_details_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"database/sql"
 	"encoding/base64"
 	"fmt"
 	"strings"
@@ -1227,6 +1228,110 @@ func TestSchemaDetailsUndiscoveredDatabaseEvicted(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 
 	require.NotContains(t, c.lastEmittedAt, "gone_db")
+}
+
+// TestSchemaDetailsAzureSQLDatabase exercises the Azure SQL Database path:
+// discovery runs on the base connection, and each database is scanned through a
+// fresh per-database connection obtained from the injected factory. No USE
+// statement is ever issued (none is expected on any mock).
+func TestSchemaDetailsAzureSQLDatabase(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	baseDB, baseMock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer baseDB.Close()
+
+	lokiClient := loki.NewCollectingHandler()
+	defer lokiClient.Stop()
+
+	dbNames := []string{"db_a", "db_b"}
+
+	// One sqlmock per database, keyed by name and returned by the factory.
+	type perDBMock struct {
+		db   *sql.DB
+		mock sqlmock.Sqlmock
+	}
+	perDB := map[string]*perDBMock{}
+	for _, name := range dbNames {
+		d, m, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		perDB[name] = &perDBMock{db: d, mock: m}
+		defer d.Close()
+	}
+
+	fakeNow := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	c, err := NewSchemaDetails(SchemaDetailsArguments{
+		DB:              baseDB,
+		CollectInterval: time.Hour,
+		EntryHandler:    lokiClient,
+		Logger:          util.TestAlloyLogger(t).Slog(),
+		EngineEdition:   engineEditionAzureSQLDatabase,
+		NewDBForDatabase: func(database string) (*sql.DB, error) {
+			m, ok := perDB[database]
+			require.True(t, ok, "unexpected database %q", database)
+			return m.db, nil
+		},
+	})
+	require.NoError(t, err)
+	c.now = func() time.Time { return fakeNow }
+
+	// Discovery is the only query on the base connection; no USE follows.
+	expectListDatabases(baseMock, dbNames...)
+
+	for _, dbName := range dbNames {
+		m := perDB[dbName].mock
+		tableName := "t_" + dbName
+		m.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME", "TABLE_TYPE",
+			}).AddRow(dbName, "dbo", tableName, "BASE TABLE"))
+
+		m.ExpectQuery(fmt.Sprintf(selectColumnsTemplate, database_observability.BuildExclusionClause([]string{tableName}))).WithArgs("dbo").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "column_name", "column_type", "is_nullable",
+				"is_identity", "default_value", "is_primary_key",
+			}).AddRow(tableName, "id", "int", false, true, nil, true))
+
+		m.ExpectQuery(fmt.Sprintf(selectIndexesTemplate, database_observability.BuildExclusionClause([]string{tableName}))).WithArgs("dbo").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "index_name", "seq_in_index", "column_name",
+				"index_type", "is_unique", "is_nullable",
+			}))
+
+		m.ExpectQuery(fmt.Sprintf(selectForeignKeysTemplate, database_observability.BuildExclusionClause([]string{tableName}))).WithArgs("dbo").RowsWillBeClosed().
+			WillReturnRows(sqlmock.NewRows([]string{
+				"table_name", "constraint_name", "column_name",
+				"referenced_table_name", "referenced_column_name",
+			}))
+	}
+
+	require.NoError(t, c.extractSchema(t.Context()))
+	require.NoError(t, baseMock.ExpectationsWereMet())
+	for _, dbName := range dbNames {
+		require.NoError(t, perDB[dbName].mock.ExpectationsWereMet())
+	}
+
+	// Each database contributes an OP_TABLE_DETECTION + OP_CREATE_STATEMENT.
+	require.Eventually(t, func() bool {
+		return len(lokiClient.Received()) == 4
+	}, 5*time.Second, 10*time.Millisecond)
+
+	entries := lokiClient.Received()
+	require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, entries[0].Labels)
+	require.Contains(t, entries[0].Line, `database="db_a"`)
+	require.Contains(t, entries[0].Line, `table="t_db_a"`)
+	require.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, entries[1].Labels)
+	require.Contains(t, entries[1].Line, `database="db_a"`)
+	require.Equal(t, model.LabelSet{"op": OP_TABLE_DETECTION}, entries[2].Labels)
+	require.Contains(t, entries[2].Line, `database="db_b"`)
+	require.Contains(t, entries[2].Line, `table="t_db_b"`)
+	require.Equal(t, model.LabelSet{"op": OP_CREATE_STATEMENT}, entries[3].Labels)
+	require.Contains(t, entries[3].Line, `database="db_b"`)
+
+	require.Contains(t, c.lastEmittedAt, "db_a")
+	require.Contains(t, c.lastEmittedAt["db_a"], schemaTableKey("dbo", "t_db_a"))
+	require.Contains(t, c.lastEmittedAt, "db_b")
+	require.Contains(t, c.lastEmittedAt["db_b"], schemaTableKey("dbo", "t_db_b"))
 }
 
 func expectListDatabases(mock sqlmock.Sqlmock, databases ...string) {

--- a/internal/component/database_observability/sql_server/component.go
+++ b/internal/component/database_observability/sql_server/component.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	_ "github.com/microsoft/go-mssqldb"
+	mssql "github.com/microsoft/go-mssqldb"
 	"github.com/microsoft/go-mssqldb/msdsn"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -39,7 +39,8 @@ const selectServerInfo = `
 SELECT
     CONVERT(NVARCHAR(128), SERVERPROPERTY('ServerName')) AS server_name,
     CONVERT(NVARCHAR(128), SERVERPROPERTY('MachineName')) AS machine_name,
-    CONVERT(NVARCHAR(128), SERVERPROPERTY('ProductVersion')) AS product_version`
+    CONVERT(NVARCHAR(128), SERVERPROPERTY('ProductVersion')) AS product_version,
+    CONVERT(INT, SERVERPROPERTY('EngineEdition')) AS engine_edition`
 
 func init() {
 	component.Register(component.Registration{
@@ -296,8 +297,9 @@ func (c *Component) connectAndStartCollectors(ctx context.Context) error {
 	}
 
 	var serverName, machineName, engineVersion sql.NullString
-	if err := rs.Scan(&serverName, &machineName, &engineVersion); err != nil {
-		return fmt.Errorf("failed to scan engine version: %w", err)
+	var engineEdition sql.NullInt64
+	if err := rs.Scan(&serverName, &machineName, &engineVersion, &engineEdition); err != nil {
+		return fmt.Errorf("failed to scan server info: %w", err)
 	}
 
 	generatedServerID := fmt.Sprintf("%x", sha256.Sum256([]byte(fmt.Sprintf("%s:%s", serverName.String, machineName.String))))
@@ -320,7 +322,7 @@ func (c *Component) connectAndStartCollectors(ctx context.Context) error {
 	}
 	c.collectors = nil
 
-	if err := c.startCollectors(generatedServerID, engineVersion.String); err != nil {
+	if err := c.startCollectors(generatedServerID, engineVersion.String, int(engineEdition.Int64)); err != nil {
 		return fmt.Errorf("failed to start collectors: %w", err)
 	}
 
@@ -347,7 +349,7 @@ func enableOrDisableCollectors(a Arguments) map[string]bool {
 }
 
 // startCollectors attempts to start all of the enabled collectors. If one or more collectors fail to start, their errors are reported.
-func (c *Component) startCollectors(serverID string, engineVersion string) error {
+func (c *Component) startCollectors(serverID string, engineVersion string, engineEdition int) error {
 	var startErrors []string
 
 	logStartError := func(collectorName, action string, err error) {
@@ -360,6 +362,18 @@ func (c *Component) startCollectors(serverID string, engineVersion string) error
 	collectors := enableOrDisableCollectors(c.args)
 
 	if collectors[collector.SchemaDetailsCollector] {
+		// newDBForDatabase derives a fresh connection pool scoped to a specific
+		// database from the base DSN.
+		dsn := string(c.args.DataSourceName)
+		newDBForDatabase := func(database string) (*sql.DB, error) {
+			cfg, err := msdsn.Parse(dsn)
+			if err != nil {
+				return nil, err
+			}
+			cfg.Database = database
+			return sql.OpenDB(mssql.NewConnectorConfig(cfg)), nil
+		}
+
 		stCollector, err := collector.NewSchemaDetails(collector.SchemaDetailsArguments{
 			DB:               c.dbConnection,
 			CollectInterval:  c.args.SchemaDetailsArguments.CollectInterval,
@@ -367,6 +381,8 @@ func (c *Component) startCollectors(serverID string, engineVersion string) error
 			ExcludeDatabases: c.args.ExcludeDatabases,
 			EntryHandler:     entryHandler,
 			Logger:           c.opts.Logger,
+			EngineEdition:    engineEdition,
+			NewDBForDatabase: newDBForDatabase,
 		})
 		if err != nil {
 			logStartError(collector.SchemaDetailsCollector, "create", err)


### PR DESCRIPTION
### Brief description of Pull Request

Detect engine edition and implement a connection switching strategy for Azure SQL Database, where the USE commands returns an error by design.



### Pull Request Details

<!-- Detailed description of the Pull Request, if needed. -->


### Issue(s) fixed by this Pull Request

Relates to https://github.com/grafana/grafana-dbo11y-app/issues/3012


### Notes to the Reviewer

<!-- Relevant notes for reviewers/testers. -->


### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
