### PR TITLE
docs: Update AI policy, AGENTS.md, and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,9 @@
 
   **HUMANS**
   - Read and understand docs/developer/genai.md
+  - Brief description / Issue(s) fixed: factual summary of the change (AI may
+    help). Details, Notes, and Checklist: your motivations, trade-offs, and
+    judgment — keep those human-owned.
 
   **AI AGENTS**
   - MANDATORY: Read, understand, and apply AGENTS.md
@@ -28,12 +31,12 @@
 
 ### Brief description of Pull Request
 
-<!-- Human-readable description of the PR used as squash commit body. -->
+<!-- Factual, human-readable summary of what changed (squash commit body). -->
 
 
 ### Pull Request Details
 
-<!-- HUMAN ONLY: Detailed description of the Pull Request, if needed. -->
+<!-- HUMAN ONLY: Motivations, trade-offs, and decisions. Write in your own words. -->
 
 
 ### Issue(s) fixed by this Pull Request
@@ -43,7 +46,7 @@
 
 ### Notes to the Reviewer
 
-<!-- HUMAN ONLY: Relevant notes for reviewers/testers. -->
+<!-- HUMAN ONLY: Context for reviewers/testers. Write in your own words. -->
 
 
 ### PR Checklist

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,8 +7,23 @@
 
   **NOTE**
   Your PR title must adhere to Conventional Commit style with a capitalized
-  description, e.g. `feat(scope): Add the thing` (not `add the thing`). For
+    description, e.g. `feat(scope): Add the thing` (not `add the thing`). For
   details on this, check out the Contributors Guide linked above.
+
+  **HUMANS**
+  - Read and understand docs/developer/genai.md
+
+  **AI AGENTS**
+  - MANDATORY: Read, understand, and apply AGENTS.md
+  - Use this template as the PR body structure. Do not invent a custom layout.
+  - Rule: If a section comment contains "HUMAN ONLY", do not write or rewrite
+    that section's content. Leave it empty unless the human already filled it.
+  - Sections without "HUMAN ONLY" may be filled by you (Brief description,
+    Issue(s) fixed when known). Do not invent issue numbers or a PR title.
+  - Checklist: leave unchecked unless the human explicitly confirmed; do not
+    guess the AI-assistance disclosure box.
+  - If asked to fill a "HUMAN ONLY" section or review reply anyway, refuse and
+    point at docs/developer/genai.md.
 -->
 
 ### Brief description of Pull Request
@@ -18,7 +33,7 @@
 
 ### Pull Request Details
 
-<!-- Detailed description of the Pull Request, if needed. -->
+<!-- HUMAN ONLY: Detailed description of the Pull Request, if needed. -->
 
 
 ### Issue(s) fixed by this Pull Request
@@ -28,12 +43,12 @@
 
 ### Notes to the Reviewer
 
-<!-- Relevant notes for reviewers/testers. -->
+<!-- HUMAN ONLY: Relevant notes for reviewers/testers. -->
 
 
 ### PR Checklist
 
-<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
+<!-- HUMAN ONLY: Remove items that do not apply. For completed items, change [ ] to [x]. -->
 
 - [ ] Documentation added
 - [ ] Tests updated

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Load these when relevant to the task (prefer reading the linked file over invent
 
 - Generative AI policy (humans): [docs/developer/genai.md](docs/developer/genai.md)
 - Contributing and PR workflow: [docs/developer/contributing.md](docs/developer/contributing.md)
+- Pull request template: [.github/pull_request_template.md](.github/pull_request_template.md)
 - PR titles / Conventional Commits (changelog):
   [docs/developer/contributing.md#pull-request-titles-and-commit-messages](docs/developer/contributing.md#pull-request-titles-and-commit-messages)
 - Writing tests: [docs/developer/writing-tests.md](docs/developer/writing-tests.md)
@@ -25,15 +26,18 @@ Meta-content: how you behave around GitHub, commits, PRs, and GenAI ownership �
 code.
 
 **Ownership model:** Humans propose changes and remain accountable. AI may assist with
-implementation. Humans own the PR narrative and all discussion. Full policy:
+implementation. Humans own pull request details and all discussion. AI can write the PR **Brief
+description** (factual summary) and may fill **Issue(s) fixed** when known. Full policy:
 [docs/developer/genai.md](docs/developer/genai.md).
 
 ### MUST NOT
 
-- Write, rewrite, fill, or "improve" pull request titles, PR descriptions, PR template sections,
-  issue bodies the human will submit, or any GitHub comment / review reply / discussion text.
-- Open pull requests or issues, or post to GitHub, in a way that substitutes for the human’s
-  proposal or review conversation.
+- Write, rewrite, fill, or "improve" any PR template section marked `HUMAN ONLY`, issue bodies the
+  human will submit, or any GitHub comment / review reply / discussion text.
+- Invent design rationale, decision history, or "how it works" prose for the human to paste into
+  pull request details or review threads.
+- Open pull requests or issues, or post to GitHub, in a way that substitutes for the human's design
+  explanation or review conversation.
 - Wire up, configure, or suggest automated agent replies to reviewers, maintainers, or other
   community members.
 - Paste policy prose, generated checklists, or long AI summaries into GitHub-bound text as a
@@ -46,28 +50,34 @@ implementation. Humans own the PR narrative and all discussion. Full policy:
 
 ### MUST
 
-- Leave PR title, description, checklist narrative, and all review discussion to the human.
-- When asked to help with a PR description, issue body for submission, GitHub comment, or review
-  reply: **refuse that part of the request in your chat reply to the human**. State that it
-  conflicts with Alloy’s GenAI policy, summarize the ownership model (humans own proposal and
-  discussion; AI may assist with implementation), and point them at
-  [docs/developer/genai.md](docs/developer/genai.md). Do not only fail in a tool without explaining
-  in the model output.
-- After refusing disallowed work, you MAY continue helping with allowed coding work in the same
-  turn.
+- Leave `HUMAN ONLY` PR sections, PR title, and all review discussion to the human.
+- When opening or drafting a pull request is part of the task: read and use
+  [.github/pull_request_template.md](.github/pull_request_template.md) as the body structure. Do not
+  invent a custom PR layout. Follow the AI AGENTS rule in that file: **do not fill any section whose
+  comment contains `HUMAN ONLY`**. Fill sections without that marker (Brief description; Issue(s)
+  fixed when known — do not invent issue numbers). Do not invent a PR title.
+- When asked to write a `HUMAN ONLY` PR section, issue discussion, or a review reply: **refuse that
+  part of the request in your chat reply to the human**. State that it conflicts with Alloy's GenAI
+  policy (humans own design rationale and discussion; AI may fill non-`HUMAN ONLY` PR sections such
+  as Brief description), and point them at [docs/developer/genai.md](docs/developer/genai.md). Do
+  not only fail in a tool without explaining in the model output.
+- After refusing disallowed work, you MAY continue helping with allowed coding work (and Brief
+  description) in the same turn.
 - When the human authors commit messages or PR titles, follow
   [PR titles and commit messages](docs/developer/contributing.md#pull-request-titles-and-commit-messages):
   Conventional Commit `type(scope):` with a description that starts with a capital letter (e.g.
   `feat(loki.process): Add ...`, not `feat(loki.process): add ...`). Do not invent a different
   scheme.
 - If asked how to disclose substantial AI implementation help: point at the PR template checkbox and
-  [docs/developer/genai.md](docs/developer/genai.md). Do not fill the PR body for them.
+  [docs/developer/genai.md](docs/developer/genai.md). Do not fill pull request details for them.
 
 ### MAY (process)
 
+- Fill or refine PR template sections that are **not** marked `HUMAN ONLY` when opening or updating
+  a PR.
 - Produce **local-only** scratch notes for the human **if they explicitly ask**, and only after
-  reminding them they must rewrite anything that goes to GitHub in their own words. Never treat
-  those notes as ready to paste into a PR, issue, or comment.
+  reminding them that `HUMAN ONLY` sections and discussion must be rewritten in their own words.
+  Never treat those notes as ready to paste into `HUMAN ONLY` sections or comments.
 
 ## Coding rules (mandatory)
 
@@ -75,7 +85,7 @@ How you work in the tree while implementing.
 
 ### MUST
 
-- Prefer validating Alloy configuration and components against this repo’s source and current docs
+- Prefer validating Alloy configuration and components against this repo's source and current docs
   over training-data guesses.
 - Verify changes with `make lint` and relevant tests before considering implementation work done.
   Prefer `GO_TAGS="nodocker" make test` or a focused `go test` for the packages you touched. See

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ description** (factual summary) and may fill **Issue(s) fixed** when known. Full
   part of the request in your chat reply to the human**. State that it conflicts with Alloy's GenAI
   policy (humans own design rationale and discussion; AI may fill non-`HUMAN ONLY` PR sections such
   as Brief description), and point them at [docs/developer/genai.md](docs/developer/genai.md). Do
-  not only fail in a tool without explaining in the model output.
+  not merely fail in a tool without also explaining in the model output.
 - After refusing disallowed work, you MAY continue helping with allowed coding work (and Brief
   description) in the same turn.
 - When the human authors commit messages or PR titles, follow
@@ -71,7 +71,7 @@ description** (factual summary) and may fill **Issue(s) fixed** when known. Full
 - If asked how to disclose substantial AI implementation help: point at the PR template checkbox and
   [docs/developer/genai.md](docs/developer/genai.md). Do not fill pull request details for them.
 
-### MAY (process)
+### MAY
 
 - Fill or refine PR template sections that are **not** marked `HUMAN ONLY` when opening or updating
   a PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,25 +7,104 @@ Multi-module Go repo: root, `syntax/`, `collector/`, `tools/`.
 
 ## Essential references
 
-- Generative AI contribution policy: [docs/developer/genai.md](docs/developer/genai.md)
-  - **If you are an AI agent, or a human using AI assistance for this contribution, read this policy.** It covers acceptable use, disclosure, and the guidlines for contributing AI generated code.
+Load these when relevant to the task (prefer reading the linked file over inventing process):
+
+- Generative AI policy (humans): [docs/developer/genai.md](docs/developer/genai.md)
 - Contributing and PR workflow: [docs/developer/contributing.md](docs/developer/contributing.md)
-  - Use the conventional commit formats and PR titles as described in the contributing guide. The description after the `type(scope):` prefix **must start with a capital letter** (e.g. `feat(loki.process): Add ...`, not `feat(loki.process): add ...`) — a CI check enforces this on PR titles, and squash-merge means the PR title is what lands in `main`.
-  - **One logical change per PR — one bug fix, one feature, or one new component.** Bundling multiple components or unrelated features into a single PR makes review slow and produces an incorrect changelog (squash-merge means one PR = one changelog entry). If the PR title needs an "and", split it.
-  - Don't edit `CHANGELOG.md` by hand. Release tooling generates entries from PR titles; manual edits conflict or get overwritten.
-  - Verify the changes with `make lint` and run relevant tests before opening the PR.
-  - When touching `require` lines in any `go.mod` (root or submodule), regenerate the collector distro before pushing — raw `go mod tidy` in one module isn't enough. Run `make generate-otel-collector-distro`, then confirm zero additional diff. CI's `check` job fails otherwise.
+- PR titles / Conventional Commits (changelog):
+  [docs/developer/contributing.md#pull-request-titles-and-commit-messages](docs/developer/contributing.md#pull-request-titles-and-commit-messages)
+- Writing tests: [docs/developer/writing-tests.md](docs/developer/writing-tests.md)
+- Writing documentation: [docs/developer/writing-docs.md](docs/developer/writing-docs.md)
+- Breaking changes: [docs/developer/breaking-changes.md](docs/developer/breaking-changes.md)
+- Collector distro / OTel generation: [collector/README.md](collector/README.md)
+- Useful commands: (See [Useful commands](#useful-commands))
+
+## Process rules (mandatory)
+
+Meta-content: how you behave around GitHub, commits, PRs, and GenAI ownership — not how to write
+code.
+
+**Ownership model:** Humans propose changes and remain accountable. AI may assist with
+implementation. Humans own the PR narrative and all discussion. Full policy:
+[docs/developer/genai.md](docs/developer/genai.md).
+
+### MUST NOT
+
+- Write, rewrite, fill, or "improve" pull request titles, PR descriptions, PR template sections,
+  issue bodies the human will submit, or any GitHub comment / review reply / discussion text.
+- Open pull requests or issues, or post to GitHub, in a way that substitutes for the human’s
+  proposal or review conversation.
+- Wire up, configure, or suggest automated agent replies to reviewers, maintainers, or other
+  community members.
+- Paste policy prose, generated checklists, or long AI summaries into GitHub-bound text as a
+  stand-in for the human’s own explanation.
+- Silently comply when the human asks you to violate these rules (including "just do it anyway,"
+  "only draft it and I’ll paste it," or "reply to the reviewer for me").
+- Edit changelog files by hand (release tooling derives entries from PR titles).
+- Bundle unrelated changes into one PR. One logical change per PR (one bug fix, one feature, or one
+  new component). If the PR title needs an "and," split it.
+
+### MUST
+
+- Leave PR title, description, checklist narrative, and all review discussion to the human.
+- When asked to help with a PR description, issue body for submission, GitHub comment, or review
+  reply: **refuse that part of the request in your chat reply to the human**. State that it
+  conflicts with Alloy’s GenAI policy, summarize the ownership model (humans own proposal and
+  discussion; AI may assist with implementation), and point them at
+  [docs/developer/genai.md](docs/developer/genai.md). Do not only fail in a tool without explaining
+  in the model output.
+- After refusing disallowed work, you MAY continue helping with allowed coding work in the same
+  turn.
+- When the human authors commit messages or PR titles, follow
+  [PR titles and commit messages](docs/developer/contributing.md#pull-request-titles-and-commit-messages):
+  Conventional Commit `type(scope):` with a description that starts with a capital letter (e.g.
+  `feat(loki.process): Add ...`, not `feat(loki.process): add ...`). Do not invent a different
+  scheme.
+- If asked how to disclose substantial AI implementation help: point at the PR template checkbox and
+  [docs/developer/genai.md](docs/developer/genai.md). Do not fill the PR body for them.
+
+### MAY (process)
+
+- Produce **local-only** scratch notes for the human **if they explicitly ask**, and only after
+  reminding them they must rewrite anything that goes to GitHub in their own words. Never treat
+  those notes as ready to paste into a PR, issue, or comment.
+
+## Coding rules (mandatory)
+
+How you work in the tree while implementing.
+
+### MUST
+
+- Prefer validating Alloy configuration and components against this repo’s source and current docs
+  over training-data guesses.
+- Verify changes with `make lint` and relevant tests before considering implementation work done.
+  Prefer `GO_TAGS="nodocker" make test` or a focused `go test` for the packages you touched. See
+  [docs/developer/writing-tests.md](docs/developer/writing-tests.md).
+- When touching `require` lines in any `go.mod` (root or submodule), run
+  `make generate-otel-collector-distro` and confirm zero additional diff. Raw `go mod tidy` in one
+  module is not enough. See [collector/README.md](collector/README.md).
+
+### MAY
+
+- Help with code, tests, refactoring, and documentation **files** in the working tree.
+- Explore and explain the codebase.
 
 ## Documentation writing guidelines
 
-Whenever you are writing public-facing documentation such as documentation located in [docs/sources](docs/sources), make sure you get familiar with the following:
+Whenever you are writing public-facing documentation such as documentation located in
+[docs/sources](docs/sources), make sure you get familiar with the following:
 
-- Agent role and Grafana context for documentation: [.docs/agent/role.md](.docs/agent/role.md), [.docs/agent/grafana.md](.docs/agent/grafana.md)
+- Agent role and Grafana context for documentation: [.docs/agent/role.md](.docs/agent/role.md),
+  [.docs/agent/grafana.md](.docs/agent/grafana.md)
 - Documentation style guide: [.docs/agent/style.md](.docs/agent/style.md)
+- Writing docs playbook: [docs/developer/writing-docs.md](docs/developer/writing-docs.md)
+- Component docs:
+  [docs/developer/writing-component-documentation.md](docs/developer/writing-component-documentation.md)
 
 ## Developer playbooks
 
-If you are developing code, depending on what you are building, make sure you get familiar with relevant playbooks from the list below:
+If you are developing code, depending on what you are building, make sure you familiarize yourself
+with relevant playbooks from the list below:
 
 - [Handling breaking changes](docs/developer/breaking-changes.md)
 - [Shepherding releases](docs/developer/shepherding-releases.md)
@@ -41,37 +120,37 @@ If you are developing code, depending on what you are building, make sure you ge
 
 ## Useful commands
 
-Show all Makefile targets and descriptions:
+### Show all Makefile targets and descriptions
 
 ```sh
 make help
 ```
 
-Lint (Go + custom alloylint):
+### Lint (Go + custom alloylint)
 
 ```sh
 make lint
 ```
 
-Test (PR-safe, skips Docker-dependent tests):
+### Test (PR-safe, skips Docker-dependent tests)
 
 ```sh
 GO_TAGS="nodocker" make test
 ```
 
-Test a single package:
+### Test a single package
 
 ```sh
 go test -race -tags="nodocker" ./internal/component/discovery/...
 ```
 
-Build (without UI):
+### Build (without UI)
 
 ```sh
 SKIP_UI_BUILD=1 make alloy
 ```
 
-Run:
+### Run
 
 ```sh
 ./build/alloy run example-config.alloy
@@ -81,9 +160,14 @@ Run:
 
 ### Gotchas
 
-- `~/go/bin` must be on PATH (`export PATH="$PATH:$(go env GOPATH)/bin"`). The VM update script handles this, but ad-hoc shells need it explicitly.
+- `~/go/bin` must be on PATH (`export PATH="$PATH:$(go env GOPATH)/bin"`). The VM update script
+  handles this, but ad-hoc shells need it explicitly.
 - `CGO_ENABLED=1` is the default. `libsystemd-dev` is required on Linux for the build to link.
-- Docker daemon is not started automatically. Before running tests without the `nodocker` tag: `sudo dockerd &` then `sudo chmod 666 /var/run/docker.sock`. Uses `fuse-overlayfs` storage driver (nested Firecracker VM).
+- Docker daemon is not started automatically. Before running tests without the `nodocker` tag:
+  `sudo dockerd &` then `sudo chmod 666 /var/run/docker.sock`. Uses `fuse-overlayfs` storage driver
+  (nested Firecracker VM).
 - First `make lint` on a cold cache takes ~10 min (module download + analysis). Cached runs ~30s.
-- `SKIP_UI_BUILD=1` saves ~90s when not touching UI code. The UI must be built at least once for the embedded web server at `:12345` to serve pages.
-- `.nvmrc` says Node 24.x; Node 22.x (pre-installed) works for builds. Only matters for exact CI parity on UI lint.
+- `SKIP_UI_BUILD=1` saves ~90s when not touching UI code. The UI must be built at least once for the
+  embedded web server at `:12345` to serve pages.
+- `.nvmrc` says Node 24.x; Node 22.x (pre-installed) works for builds. Only matters for exact CI
+  parity on UI lint.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/developer/genai.md
+++ b/docs/developer/genai.md
@@ -85,7 +85,9 @@ you draft; you own the argument in public discussion.
 
 Maintainers may close or request changes on contributions where pull request details or discussion
 look unowned or low-effort AI-generated, using the same [issue triage][issue-triage] process as
-other contributions. Repeated abuse may lead to stricter review or blocked contributions.
+other contributions. When they do, they will explain why and, where appropriate, offer guidance on
+how to improve the contribution. Repeated abuse may lead to stricter review or blocked
+contributions.
 
 [alloy-docs]: https://grafana.com/docs/alloy/latest/
 [issue-triage]: ./issue-triage.md

--- a/docs/developer/genai.md
+++ b/docs/developer/genai.md
@@ -14,28 +14,32 @@ review it, and defend it in discussion, regardless of which tools helped you wri
 
 ## Ownership model
 
-| You own (write yourself)              | AI may help with                               |
-| ------------------------------------- | ---------------------------------------------- |
-| Intent and design of the change       | Exploring the codebase                         |
-| Pull request title and description    | Writing or refactoring code and tests          |
-| Issue and proposal text you submit    | Editing documentation files in the repo        |
-| Review replies and ongoing discussion | Local notes you then rewrite in your own words |
-| Code review conclusions               |                                                |
+| You own (write yourself)                   | AI may help with                              |
+| ------------------------------------------ | --------------------------------------------- |
+| Intent and design of the change            | Exploring the codebase                        |
+| Pull request details (why, how, decisions) | Writing or refactoring code and tests         |
+| Issue and proposal text you submit         | Editing documentation files in the repo       |
+| Review replies and ongoing discussion      | Brief description of the PR (factual summary) |
+| Code review conclusions                    | Issue(s) fixed (`Fixes #N` when known)        |
+| Conventional Commit PR title               |                                               |
 
 AI-assisted **implementation** is welcome when you review and understand the result. AI-mediated
-**conversation** is not: reviewers need confidence that you understand what you opened.
+**conversation** is not. Reviewers need confidence that you understand the design choices and
+trade-offs of what you're proposing.
 
 ## Acceptable
 
 - Use AI to implement or refactor code and docs you then review and refine.
+- Use AI to draft the PR **Brief description** and **Issue(s) fixed** from the actual change.
 - Use AI to learn the codebase before contributing or reviewing.
-- Use AI privately to clarify your own thinking, then post **in your own words**.
+- Use AI privately to clarify your own thinking, then post discussion **in your own words**.
 
 ## Not acceptable
 
-- Submit a PR whose title, description, or discussion you did not write yourself.
-- Paste AI-generated text into issues, PRs, or review threads as a stand-in for your own analysis.
-- Wire an agent to open PRs/issues or reply to reviewers on your behalf.
+- Leave pull request details empty of your own reasoning on non-trivial PRs, or paste AI text there
+  as a stand-in for how/why you built the change.
+- Paste AI-generated text into review threads or issue discussion as a stand-in for your analysis.
+- Wire an agent to reply to reviewers on your behalf.
 - Use AI as a substitute for your judgment when **reviewing** others' code.
 - File automated, bot-driven issues or PRs from tools the Alloy team has not approved.
 - Submit PRs or issues that ignore the project templates.
@@ -48,7 +52,8 @@ When AI generates the **bulk of the implementation**, check **"This pull request
 generated with AI assistance"** in the PR template. Minor autocomplete or small edits do not need
 disclosure.
 
-Disclosure does not excuse AI-written descriptions or discussion. Those must still be yours.
+An AI-written Brief description and Issue(s) fixed line are fine. Disclosure does not excuse
+AI-written pull request details or discussion — those must still be yours.
 
 ## Licensing and provenance
 
@@ -69,9 +74,9 @@ you draft; you own the argument in public discussion.
 
 ## Enforcement
 
-Maintainers may close or request changes on contributions where the PR narrative or discussion looks
-unowned or low-effort AI-generated, using the same [issue triage][issue-triage] process as other
-contributions. Repeated abuse may lead to stricter review or blocked contributions.
+Maintainers may close or request changes on contributions where pull request details or discussion
+look unowned or low-effort AI-generated, using the same [issue triage][issue-triage] process as
+other contributions. Repeated abuse may lead to stricter review or blocked contributions.
 
 [alloy-docs]: https://grafana.com/docs/alloy/latest/
 [issue-triage]: ./issue-triage.md

--- a/docs/developer/genai.md
+++ b/docs/developer/genai.md
@@ -1,100 +1,77 @@
 # Generative AI Contribution Policy
 
-Generative AI (GenAI) tools such as large language model (LLM) assistants can help you write code,
-documentation, and proposals for Grafana Alloy. This policy explains what is an acceptable use of GenAI tools
-when contributing to the project.
+This page is intended to be read by **human contributors**.
+
+Generative AI tools can help you contribute to Grafana Alloy. It explains what we expect when you
+use AI assistance.
 
 ## Core principle
 
-**The human contributor is always in control and fully responsible for their contribution.**
+**Humans propose changes and remain accountable. AI may assist with implementation.**
 
-GenAI is a tool that assists you. It is not a substitute for your own understanding, judgment, or
-accountability. By submitting a contribution, you vouch for it as your own work, regardless
-of which tools helped you produce it. You are expected to understand, review, and provide rationale for
-everything you submit.
+By submitting a contribution, you vouch for it as your own work. You are expected to understand it,
+review it, and defend it in discussion, regardless of which tools helped you write the code.
 
-## Acceptable use
+## Ownership model
 
-You are welcome to use GenAI tools to:
+| You own (write yourself)              | AI may help with                               |
+| ------------------------------------- | ---------------------------------------------- |
+| Intent and design of the change       | Exploring the codebase                         |
+| Pull request title and description    | Writing or refactoring code and tests          |
+| Issue and proposal text you submit    | Editing documentation files in the repo        |
+| Review replies and ongoing discussion | Local notes you then rewrite in your own words |
+| Code review conclusions               |                                                |
 
-- Write or refactor code and documentation, as long as you actively review and refine the output.
-- Understand the Alloy codebase, a component, or a subsystem before contributing or reviewing.
-- Draft issues, proposals, or design documents that you then verify and shape into your own
-  reasoning.
-- Translate, summarize, or improve the clarity of text you have written.
+AI-assisted **implementation** is welcome when you review and understand the result. AI-mediated
+**conversation** is not: reviewers need confidence that you understand what you opened.
 
-In all cases, you remain the author. You read the output, you correct it, and you ensure your
-contribution meets the project's standards before submitting an issue, pull request, or comment.
+## Acceptable
+
+- Use AI to implement or refactor code and docs you then review and refine.
+- Use AI to learn the codebase before contributing or reviewing.
+- Use AI privately to clarify your own thinking, then post **in your own words**.
 
 ## Not acceptable
 
-Do not:
+- Submit a PR whose title, description, or discussion you did not write yourself.
+- Paste AI-generated text into issues, PRs, or review threads as a stand-in for your own analysis.
+- Wire an agent to open PRs/issues or reply to reviewers on your behalf.
+- Use AI as a substitute for your judgment when **reviewing** others' code.
+- File automated, bot-driven issues or PRs from tools the Alloy team has not approved.
+- Submit PRs or issues that ignore the project templates.
 
-- Submit unreviewed, bulk AI-generated content to pull requests, issues, or proposals. If you
-  did not read and understand it, do not submit it.
-- Use GenAI as a substitute for human judgment in code review. An AI tool may help you understand a
-  change, but the review and its conclusions must be yours.
-- File automated, bot-driven issues or pull requests from tools that have not been approved by the
-  Alloy team. This policy covers humans using AI assistance, not autonomous agents acting on their
-  own, including agentic IDE tools that file pull requests without human review.
-- Paste generated text into a discussion without adding your own analysis and context.
-- Wire up an AI agent to respond automatically to reviewers or other community members on your
-  behalf. If you want help from GenAI in a discussion, use it yourself and post in your own words,
-  rather than connecting it directly to maintainers.
-- Submit PRs or issues which do not follow our defined templates
-
-Maintainers may close low-effort AI-generated contributions, following the same
-[issue triage process][issue-triage] used for other contributions. When they do, they should explain
-why and, where appropriate, offer guidance on how to improve the contribution. Repeated low-effort
-submissions will trigger stricter review, and maintainers may block repeat offenders from contributing.
-
-## Approved automation
-
-Some automated tools are explicitly approved by the Alloy team and are an acceptable exception to the
-rule against bot-driven contributions. Examples include GitHub Copilot and the automated dependency
-review bot, and the Alloy team may approve more over time. Contributions from these tools are always
-clearly marked as bot-generated so that reviewers can tell them apart from human contributions.
+Approved bots (for example dependency bots) are fine when clearly marked as bot-generated.
 
 ## Disclosure
 
-When GenAI generates the **bulk** of a contribution, disclose it. For pull requests, check the
-**"This pull request was substantially generated with AI assistance"** box in the pull request
-template. Minor, incidental help such as autocomplete or small edits does not need to be disclosed.
+When AI generates the **bulk of the implementation**, check **"This pull request was substantially
+generated with AI assistance"** in the PR template. Minor autocomplete or small edits do not need
+disclosure.
 
-Disclosure is not a mark against your contribution. It helps reviewers know where to focus, and it
-keeps expectations clear for everyone.
+Disclosure does not excuse AI-written descriptions or discussion. Those must still be yours.
 
 ## Licensing and provenance
 
-Grafana Alloy is licensed under [Apache 2.0][license], and all contributions require a signed
-[Contributor License Agreement (CLA)][cla]. These obligations apply equally to AI-assisted
-contributions.
+Alloy is [Apache 2.0][license]. Contributions require a signed [CLA][cla]. The same obligations
+apply to AI-assisted work: you warrant you have the right to contribute it, it is
+license-compatible, and any new dependencies follow the [dependency guidance][contributing-deps].
 
-When you contribute AI-assisted code or content, you warrant that:
+If you are unsure whether generated code is original or license-compatible, do not submit it.
 
-- You have the right to contribute it under the project's license and CLA.
-- It does not reproduce code or text from sources whose licenses are incompatible with Apache 2.0
-  (for example, GPL-licensed or proprietary code that an LLM may have reproduced from its training
-  data).
-- Any third-party code or dependencies it introduces are license-compatible and follow the
-  [dependency guidance][contributing-deps] in the contributing guide.
+## Alloy tip
 
-Alloy vendors and wraps many upstream components. Provenance matters, so check where generated code came from.
-If you are unsure whether the generated code is original or license-compatible, do not submit it.
+LLMs often invent Alloy component names, arguments, and config syntax. Point tools at the [Alloy
+docs][alloy-docs] and the relevant source in this repo, and validate output against real component
+definitions and project checks before submitting.
 
-## Alloy-specific guidance
+For new components and larger changes, follow the [proposal process][proposal-process]. AI may help
+you draft; you own the argument in public discussion.
 
-LLMs frequently hallucinate Alloy configuration syntax, component names, and component arguments,
-and may produce configurations or components that do not match the current schemas. To reduce these
-errors, point the tool at authoritative sources rather than relying on its training data: provide the
-[Alloy documentation][alloy-docs] and the relevant component source code, ideally pinned to the
-specific Alloy version or git tag you are targeting, and ask the tool to validate its output against
-them. Always validate AI-generated code and configuration against the real component definitions and
-the project's checks before submitting.
+## Enforcement
 
-For new components and larger changes, follow the existing [proposal process][proposal-process].
-A proposal or design document must reflect your own reasoning. AI may help you draft it, but you own
-the argument in the public consensus discussion.
+Maintainers may close or request changes on contributions where the PR narrative or discussion looks
+unowned or low-effort AI-generated, using the same [issue triage][issue-triage] process as other
+contributions. Repeated abuse may lead to stricter review or blocked contributions.
 
 [alloy-docs]: https://grafana.com/docs/alloy/latest/
 [issue-triage]: ./issue-triage.md

--- a/docs/developer/genai.md
+++ b/docs/developer/genai.md
@@ -2,8 +2,8 @@
 
 This page is intended to be read by **human contributors**.
 
-Generative AI tools can help you contribute to Grafana Alloy. It explains what we expect when you
-use AI assistance.
+Generative AI tools can help you contribute to Grafana Alloy. This page explains what we expect when
+you use AI assistance.
 
 ## Core principle
 
@@ -37,7 +37,7 @@ trade-offs of what you're proposing.
 
 ## Acceptable
 
-- Use AI to implement or refactor code and docs you then review and refine.
+- Use AI to implement or refactor code and docs that you then review and refine.
 - Use AI to draft the PR **Brief description** and **Issue(s) fixed** from the actual change.
 - Use AI to learn the codebase before contributing or reviewing.
 - Use AI privately to clarify your own thinking, then post discussion **in your own words**.
@@ -60,14 +60,15 @@ When AI generates the **bulk of the implementation**, check **"This pull request
 generated with AI assistance"** in the PR template. Minor autocomplete or small edits do not need
 disclosure.
 
-An AI-written Brief description and Issue(s) fixed line are fine. Disclosure does not excuse
+An AI-written Brief description and Issue(s) fixed lines are fine. Disclosure does not excuse
 AI-written pull request details or discussion — those must still be yours.
 
 ## Licensing and provenance
 
 Alloy is [Apache 2.0][license]. Contributions require a signed [CLA][cla]. The same obligations
-apply to AI-assisted work: you warrant you have the right to contribute it, it is
-license-compatible, and any new dependencies follow the [dependency guidance][contributing-deps].
+apply to AI-assisted work: you warrant that you have the right to contribute it, that it is
+license-compatible, and that any new dependencies follow the [dependency
+guidance][contributing-deps].
 
 If you are unsure whether generated code is original or license-compatible, do not submit it.
 

--- a/docs/developer/genai.md
+++ b/docs/developer/genai.md
@@ -12,6 +12,14 @@ use AI assistance.
 By submitting a contribution, you vouch for it as your own work. You are expected to understand it,
 review it, and defend it in discussion, regardless of which tools helped you write the code.
 
+Contribution work has two sides.
+
+- **Factual and mechanical** work (what changed, implementing code or docs from clear intent, a
+  brief PR summary) is where AI is often well suited.
+- **Subjective and human** work (motivations, trade-offs, reviewer notes, and discussion) stays with
+  you. Use AI where it helps; keep human oversight and interaction where judgment and accountability
+  matter.
+
 ## Ownership model
 
 | You own (write yourself)                   | AI may help with                              |


### PR DESCRIPTION
### Brief description of Pull Request

Updates the GenAI contribution policy, AGENTS.md, and PR template so human ownership of design/rationale/discussion is explicit, AI agents have clear MUST/MUST NOT process rules, and PR template sections are marked HUMAN ONLY where AI must not fill them.

### Pull Request Details

This change draws a clearer line between two kinds of contribution work:

1. **Factual / mechanical** — what changed, which issues are fixed, code/docs/tests an agent can implement from clear intent. AI can help here (and can draft the brief description / issue links).

2. **Subjective / ownership** — why we made the tradeoff, how we want reviewers to think about it, notes for testers, checklist judgment, and ongoing discussion. Those stay human-written so reviewers can trust that a person understands and can defend the change.

`genai.md` is aimed at humans and spells out that ownership model. `AGENTS.md` and the PR template encode it for tools: sections marked `HUMAN ONLY` stay empty for agents; brief description (and known `Fixes #…`) may be filled.

**Screenshots of some basic agentic interaction in the context of this template and rules:**

<img width="588" height="689" alt="image" src="https://github.com/user-attachments/assets/bbede752-3c87-4ecf-9db7-c4582e0de72e" />

<img width="611" height="350" alt="image" src="https://github.com/user-attachments/assets/0622ae74-def6-4bd8-9ca2-510601916d03" />


### PR Checklist

- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))