### PR TITLE
feat(prometheus.exporter.mssql): Add a new `max_connection_lifetime` config attribute

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.exporter.mssql.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.mssql.md
@@ -26,14 +26,15 @@ prometheus.exporter.mssql "<LABEL>" {
 
 You can use the following arguments with `prometheus.exporter.mssql`:
 
-| Name                   | Type       | Description                                                         | Default | Required |
-| ---------------------- | ---------- | ------------------------------------------------------------------- | ------- | -------- |
-| `connection_string`    | `secret`   | The connection string used to connect to an Microsoft SQL Server.   |         | yes      |
-| `connection_name`      | `string`   | The name of the connection, used as a label in uptime metrics.      | `""`    | no       |
-| `max_idle_connections` | `int`      | Maximum number of idle connections to any one target.               | `3`     | no       |
-| `max_open_connections` | `int`      | Maximum number of open connections to any one target.               | `3`     | no       |
-| `timeout`              | `duration` | The query timeout in seconds.                                       | `"10s"` | no       |
-| `query_config`         | `string`   | MSSQL query to Prometheus metric configuration as an inline string. |         | no       |
+| Name                         | Type       | Description                                                                              | Default | Required |
+| ---------------------------- | ---------- | ---------------------------------------------------------------------------------------- | ------- | -------- |
+| `connection_string`          | `secret`   | The connection string used to connect to an Microsoft SQL Server.                        |         | yes      |
+| `connection_name`            | `string`   | The name of the connection, used as a label in uptime metrics.                           | `""`    | no       |
+| `max_idle_connections`       | `int`      | Maximum number of idle connections to any one target.                                    | `3`     | no       |
+| `max_open_connections`       | `int`      | Maximum number of open connections to any one target.                                    | `3`     | no       |
+| `max_connection_lifetime`    | `duration` | Maximum amount of time a connection may be reused. `0` keeps connections forever.        | `"0s"`  | no       |
+| `timeout`                    | `duration` | The query timeout in seconds.                                                            | `"10s"` | no       |
+| `query_config`               | `string`   | MSSQL query to Prometheus metric configuration as an inline string.                      |         | no       |
 
 The [`sql_exporter` examples](https://github.com/burningalchemist/sql_exporter/blob/master/examples/azure-sql-mi/sql_exporter.yml#L21) show the format of the `connection_string` argument:
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.mssql.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.mssql.md
@@ -28,7 +28,7 @@ You can use the following arguments with `prometheus.exporter.mssql`:
 
 | Name                         | Type       | Description                                                                              | Default | Required |
 | ---------------------------- | ---------- | ---------------------------------------------------------------------------------------- | ------- | -------- |
-| `connection_string`          | `secret`   | The connection string used to connect to an Microsoft SQL Server.                        |         | yes      |
+| `connection_string`          | `secret`   | The connection string used to connect to a Microsoft SQL Server.                        |         | yes      |
 | `connection_name`            | `string`   | The name of the connection, used as a label in uptime metrics.                           | `""`    | no       |
 | `max_idle_connections`       | `int`      | Maximum number of idle connections to any one target.                                    | `3`     | no       |
 | `max_open_connections`       | `int`      | Maximum number of open connections to any one target.                                    | `3`     | no       |

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.mssql.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.mssql.md
@@ -33,7 +33,7 @@ You can use the following arguments with `prometheus.exporter.mssql`:
 | `max_idle_connections`       | `int`      | Maximum number of idle connections to any one target.                                    | `3`     | no       |
 | `max_open_connections`       | `int`      | Maximum number of open connections to any one target.                                    | `3`     | no       |
 | `max_connection_lifetime`    | `duration` | Maximum amount of time a connection may be reused. `0` keeps connections forever.        | `"0s"`  | no       |
-| `timeout`                    | `duration` | The query timeout in seconds.                                                            | `"10s"` | no       |
+| `timeout`                    | `duration` | The query timeout duration for each scrape.                                               | `"10s"` | no       |
 | `query_config`               | `string`   | MSSQL query to Prometheus metric configuration as an inline string.                      |         | no       |
 
 The [`sql_exporter` examples](https://github.com/burningalchemist/sql_exporter/blob/master/examples/azure-sql-mi/sql_exporter.yml#L21) show the format of the `connection_string` argument:

--- a/integration-tests/k8s/deps/mssql.go
+++ b/integration-tests/k8s/deps/mssql.go
@@ -16,6 +16,8 @@ const (
 	mssqlSelector = "app=mssql"
 )
 
+var _ harness.Dependency = (*MSSQL)(nil)
+
 // MSSQL installs a Microsoft SQL Server instance as a scrape target for the
 // prometheus.exporter.mssql component. The image is linux/amd64 only and runs
 // under emulation on arm64 hosts.

--- a/internal/component/prometheus/exporter/mssql/mssql.go
+++ b/internal/component/prometheus/exporter/mssql/mssql.go
@@ -43,12 +43,13 @@ var DefaultArguments = Arguments{
 
 // Arguments controls the mssql exporter.
 type Arguments struct {
-	ConnectionString   alloytypes.Secret         `alloy:"connection_string,attr"`
-	ConnectionName     string                    `alloy:"connection_name,attr,optional"`
-	MaxIdleConnections int                       `alloy:"max_idle_connections,attr,optional"`
-	MaxOpenConnections int                       `alloy:"max_open_connections,attr,optional"`
-	Timeout            time.Duration             `alloy:"timeout,attr,optional"`
-	QueryConfig        alloytypes.OptionalSecret `alloy:"query_config,attr,optional"`
+	ConnectionString      alloytypes.Secret         `alloy:"connection_string,attr"`
+	ConnectionName        string                    `alloy:"connection_name,attr,optional"`
+	MaxIdleConnections    int                       `alloy:"max_idle_connections,attr,optional"`
+	MaxOpenConnections    int                       `alloy:"max_open_connections,attr,optional"`
+	MaxConnectionLifetime time.Duration             `alloy:"max_connection_lifetime,attr,optional"`
+	Timeout               time.Duration             `alloy:"timeout,attr,optional"`
+	QueryConfig           alloytypes.OptionalSecret `alloy:"query_config,attr,optional"`
 }
 
 // SetToDefault implements syntax.Defaulter.
@@ -70,6 +71,10 @@ func (a *Arguments) Validate() error {
 		return errors.New("timeout must be positive")
 	}
 
+	if a.MaxConnectionLifetime < 0 {
+		return errors.New("max_connection_lifetime must not be negative")
+	}
+
 	var collectorConfig config.CollectorConfig
 	err := yaml.UnmarshalStrict([]byte(a.QueryConfig.Value), &collectorConfig)
 	if err != nil {
@@ -81,10 +86,11 @@ func (a *Arguments) Validate() error {
 
 func (a *Arguments) Convert() *mssql.Config {
 	return &mssql.Config{
-		ConnectionString:   config_util.Secret(a.ConnectionString),
-		MaxIdleConnections: a.MaxIdleConnections,
-		MaxOpenConnections: a.MaxOpenConnections,
-		Timeout:            a.Timeout,
-		QueryConfig:        util.RawYAML(a.QueryConfig.Value),
+		ConnectionString:      config_util.Secret(a.ConnectionString),
+		MaxIdleConnections:    a.MaxIdleConnections,
+		MaxOpenConnections:    a.MaxOpenConnections,
+		MaxConnectionLifetime: a.MaxConnectionLifetime,
+		Timeout:               a.Timeout,
+		QueryConfig:           util.RawYAML(a.QueryConfig.Value),
 	}
 }

--- a/internal/component/prometheus/exporter/mssql/mssql.go
+++ b/internal/component/prometheus/exporter/mssql/mssql.go
@@ -87,6 +87,7 @@ func (a *Arguments) Validate() error {
 func (a *Arguments) Convert() *mssql.Config {
 	return &mssql.Config{
 		ConnectionString:      config_util.Secret(a.ConnectionString),
+		ConnectionName:        a.ConnectionName,
 		MaxIdleConnections:    a.MaxIdleConnections,
 		MaxOpenConnections:    a.MaxOpenConnections,
 		MaxConnectionLifetime: a.MaxConnectionLifetime,

--- a/internal/component/prometheus/exporter/mssql/mssql_test.go
+++ b/internal/component/prometheus/exporter/mssql/mssql_test.go
@@ -18,6 +18,7 @@ func TestAlloyUnmarshal(t *testing.T) {
 	connection_string = "sqlserver://user:pass@localhost:1433"
 	max_idle_connections = 3
 	max_open_connections = 3
+	max_connection_lifetime = "30m"
 	timeout = "10s"`
 
 	var args Arguments
@@ -25,11 +26,12 @@ func TestAlloyUnmarshal(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := Arguments{
-		ConnectionString:   alloytypes.Secret("sqlserver://user:pass@localhost:1433"),
-		MaxIdleConnections: 3,
-		MaxOpenConnections: 3,
-		Timeout:            10 * time.Second,
-		ConnectionName:     "",
+		ConnectionString:      alloytypes.Secret("sqlserver://user:pass@localhost:1433"),
+		MaxIdleConnections:    3,
+		MaxOpenConnections:    3,
+		MaxConnectionLifetime: 30 * time.Minute,
+		Timeout:               10 * time.Second,
+		ConnectionName:        "",
 	}
 
 	require.Equal(t, expected, args)
@@ -197,6 +199,17 @@ func TestArgumentsValidate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "invalid max connection lifetime",
+			args: Arguments{
+				ConnectionString:      alloytypes.Secret("test"),
+				MaxIdleConnections:    1,
+				MaxOpenConnections:    1,
+				Timeout:               10 * time.Second,
+				MaxConnectionLifetime: -1 * time.Second,
+			},
+			wantErr: true,
+		},
+		{
 			name: "valid",
 			args: Arguments{
 				ConnectionString:   alloytypes.Secret("test"),
@@ -233,10 +246,11 @@ metrics:
   query: "SELECT DATEDIFF(second, '19700101', GETUTCDATE()) AS unix_time"`
 
 	args := Arguments{
-		ConnectionString:   alloytypes.Secret("sqlserver://user:pass@localhost:1433"),
-		MaxIdleConnections: 1,
-		MaxOpenConnections: 1,
-		Timeout:            10 * time.Second,
+		ConnectionString:      alloytypes.Secret("sqlserver://user:pass@localhost:1433"),
+		MaxIdleConnections:    1,
+		MaxOpenConnections:    1,
+		MaxConnectionLifetime: 30 * time.Minute,
+		Timeout:               10 * time.Second,
 		QueryConfig: alloytypes.OptionalSecret{
 			Value: strQueryConfig,
 		},
@@ -244,11 +258,12 @@ metrics:
 	res := args.Convert()
 
 	expected := mssql.Config{
-		ConnectionString:   config_util.Secret("sqlserver://user:pass@localhost:1433"),
-		MaxIdleConnections: 1,
-		MaxOpenConnections: 1,
-		Timeout:            10 * time.Second,
-		QueryConfig:        []byte(strQueryConfig),
+		ConnectionString:      config_util.Secret("sqlserver://user:pass@localhost:1433"),
+		MaxIdleConnections:    1,
+		MaxOpenConnections:    1,
+		MaxConnectionLifetime: 30 * time.Minute,
+		Timeout:               10 * time.Second,
+		QueryConfig:           []byte(strQueryConfig),
 	}
 	require.Equal(t, expected, *res)
 }

--- a/internal/component/prometheus/exporter/mssql/mssql_test.go
+++ b/internal/component/prometheus/exporter/mssql/mssql_test.go
@@ -247,6 +247,7 @@ metrics:
 
 	args := Arguments{
 		ConnectionString:      alloytypes.Secret("sqlserver://user:pass@localhost:1433"),
+		ConnectionName:        "localhost",
 		MaxIdleConnections:    1,
 		MaxOpenConnections:    1,
 		MaxConnectionLifetime: 30 * time.Minute,
@@ -259,6 +260,7 @@ metrics:
 
 	expected := mssql.Config{
 		ConnectionString:      config_util.Secret("sqlserver://user:pass@localhost:1433"),
+		ConnectionName:        "localhost",
 		MaxIdleConnections:    1,
 		MaxOpenConnections:    1,
 		MaxConnectionLifetime: 30 * time.Minute,

--- a/internal/converter/internal/staticconvert/internal/build/mssql_exporter.go
+++ b/internal/converter/internal/staticconvert/internal/build/mssql_exporter.go
@@ -14,10 +14,11 @@ func (b *ConfigBuilder) appendMssqlExporter(config *mssql_exporter.Config, insta
 
 func toMssqlExporter(config *mssql_exporter.Config) *mssql.Arguments {
 	return &mssql.Arguments{
-		ConnectionString:   alloytypes.Secret(config.ConnectionString),
-		ConnectionName:     config.ConnectionName,
-		MaxIdleConnections: config.MaxIdleConnections,
-		MaxOpenConnections: config.MaxOpenConnections,
-		Timeout:            config.Timeout,
+		ConnectionString:      alloytypes.Secret(config.ConnectionString),
+		ConnectionName:        config.ConnectionName,
+		MaxIdleConnections:    config.MaxIdleConnections,
+		MaxOpenConnections:    config.MaxOpenConnections,
+		MaxConnectionLifetime: config.MaxConnectionLifetime,
+		Timeout:               config.Timeout,
 	}
 }

--- a/internal/static/integrations/mssql/collector_test.go
+++ b/internal/static/integrations/mssql/collector_test.go
@@ -149,10 +149,6 @@ func (mt mockTarget) Collect(_ context.Context, ch chan<- sql_exporter.Metric) {
 	}
 }
 
-func (mt mockTarget) Close() error {
-	return nil
-}
-
 func (mt mockTarget) JobGroup() string {
 	return ""
 }

--- a/internal/static/integrations/mssql/sql_exporter.go
+++ b/internal/static/integrations/mssql/sql_exporter.go
@@ -29,13 +29,16 @@ var DefaultConfig = Config{
 }
 
 // Config is the configuration for the mssql integration
+//
+// Don't expose upstream's ScrapeErrorDropInterval field - it's not relevant to Alloy.
 type Config struct {
-	ConnectionString   config_util.Secret `yaml:"connection_string,omitempty"`
-	ConnectionName     string             `yaml:"connection_name,omitempty"`
-	MaxIdleConnections int                `yaml:"max_idle_connections,omitempty"`
-	MaxOpenConnections int                `yaml:"max_open_connections,omitempty"`
-	Timeout            time.Duration      `yaml:"timeout,omitempty"`
-	QueryConfig        util.RawYAML       `yaml:"query_config,omitempty"`
+	ConnectionString      config_util.Secret `yaml:"connection_string,omitempty"`
+	ConnectionName        string             `yaml:"connection_name,omitempty"`
+	MaxIdleConnections    int                `yaml:"max_idle_connections,omitempty"`
+	MaxOpenConnections    int                `yaml:"max_open_connections,omitempty"`
+	MaxConnectionLifetime time.Duration      `yaml:"max_connection_lifetime,omitempty"`
+	Timeout               time.Duration      `yaml:"timeout,omitempty"`
+	QueryConfig           util.RawYAML       `yaml:"query_config,omitempty"`
 }
 
 func (c Config) validate() error {
@@ -53,15 +56,19 @@ func (c Config) validate() error {
 	}
 
 	if c.MaxOpenConnections < 1 {
-		return errors.New("max_connections must be at least 1")
+		return errors.New("max_open_connections must be at least 1")
 	}
 
 	if c.MaxIdleConnections < 1 {
-		return errors.New("max_idle_connection must be at least 1")
+		return errors.New("max_idle_connections must be at least 1")
 	}
 
 	if c.Timeout <= 0 {
 		return errors.New("timeout must be positive")
+	}
+
+	if c.MaxConnectionLifetime < 0 {
+		return errors.New("max_connection_lifetime must not be negative")
 	}
 
 	return nil
@@ -129,10 +136,11 @@ func (c *Config) NewIntegration(l *slog.Logger) (integrations.Integration, error
 		},
 		prometheus.Labels{},
 		&config.GlobalConfig{
-			ScrapeTimeout: model.Duration(c.Timeout),
-			TimeoutOffset: model.Duration(500 * time.Millisecond),
-			MaxConns:      c.MaxOpenConnections,
-			MaxIdleConns:  c.MaxIdleConnections,
+			ScrapeTimeout:   model.Duration(c.Timeout),
+			TimeoutOffset:   model.Duration(500 * time.Millisecond),
+			MaxConns:        c.MaxOpenConnections,
+			MaxIdleConns:    c.MaxIdleConnections,
+			MaxConnLifetime: c.MaxConnectionLifetime,
 		},
 		&enablePing,
 	)

--- a/internal/static/integrations/mssql/sql_exporter_test.go
+++ b/internal/static/integrations/mssql/sql_exporter_test.go
@@ -98,6 +98,17 @@ metrics:
 			err: "timeout must be positive",
 		},
 		{
+			name: "max connection lifetime is negative",
+			input: Config{
+				ConnectionString:      "sqlserver://user:pass@localhost:1433",
+				MaxIdleConnections:    3,
+				MaxOpenConnections:    3,
+				MaxConnectionLifetime: -1 * time.Second,
+				Timeout:               10 * time.Second,
+			},
+			err: "max_connection_lifetime must not be negative",
+		},
+		{
 			name: "good query config",
 			input: Config{
 				ConnectionString:   "sqlserver://user:pass@localhost:1433",

--- a/internal/static/integrations/mssql/sql_exporter_test.go
+++ b/internal/static/integrations/mssql/sql_exporter_test.go
@@ -75,7 +75,7 @@ metrics:
 				MaxOpenConnections: 0,
 				Timeout:            10 * time.Second,
 			},
-			err: "max_connections must be at least 1",
+			err: "max_open_connections must be at least 1",
 		},
 		{
 			name: "max idle connections is less than 1",
@@ -85,7 +85,7 @@ metrics:
 				MaxOpenConnections: 3,
 				Timeout:            10 * time.Second,
 			},
-			err: "max_idle_connection must be at least 1",
+			err: "max_idle_connections must be at least 1",
 		},
 		{
 			name: "timeout is not positive",


### PR DESCRIPTION
### Pull Request Details

I updated the exporter to a new version in #6292. This is a post-update sync that I've been meaning to do.

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
