### PR TITLE
fix(otelcol.exporter.loadbalancing): Change default Kubernetes resolver timeout to 1m

### DIFF
--- a/docs/sources/reference/components/otelcol/otelcol.exporter.loadbalancing.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.loadbalancing.md
@@ -210,7 +210,7 @@ The following arguments are supported:
 | `service`          | `string`       | Kubernetes service to resolve.                              |          | yes      |
 | `ports`            | `list(number)` | Ports to use with the IP addresses resolved from `service`. | `[4317]` | no       |
 | `return_hostnames` | `bool`         | Return hostnames instead of IPs.                            | `false`  | no       |
-| `timeout`          | `duration`     | Resolver timeout.                                           | `"1s"`   | no       |
+| `timeout`          | `duration`     | Resolver timeout.                                           | `"1m"`   | no       |
 
 If no namespace is specified inside `service`, an attempt will be made to infer the namespace for this {{< param "PRODUCT_NAME" >}}.
 If this fails, the `default` namespace will be used.

--- a/internal/component/otelcol/exporter/loadbalancing/loadbalancing.go
+++ b/internal/component/otelcol/exporter/loadbalancing/loadbalancing.go
@@ -277,7 +277,7 @@ var _ syntax.Defaulter = &KubernetesResolver{}
 func (r *KubernetesResolver) SetToDefault() {
 	*r = KubernetesResolver{
 		Ports:   []int32{4317},
-		Timeout: 1 * time.Second,
+		Timeout: 1 * time.Minute,
 	}
 }
 

--- a/internal/component/otelcol/exporter/loadbalancing/loadbalancing_test.go
+++ b/internal/component/otelcol/exporter/loadbalancing/loadbalancing_test.go
@@ -440,7 +440,7 @@ func TestConfigConversion(t *testing.T) {
 					K8sSvc: configoptional.Some(loadbalancingexporter.K8sSvcResolver{
 						Service:         "lb-svc.lb-ns",
 						Ports:           []int32{4317},
-						Timeout:         1 * time.Second,
+						Timeout:         1 * time.Minute,
 						ReturnHostnames: false,
 					}),
 				},


### PR DESCRIPTION
### Brief description of Pull Request

Update the default timeout of the loadbalancing exporter to 1m from 1s. This aligns with the upstream community default: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46204


### Pull Request Details

We had a customer report an issue from the k8s-monitoring helm chart where the loadbalancing component was causing a lot of pressure on their api server due to the number of daemonsets that have running it. Turns out that the default of 1 second is a lot of hits on the server. The upstream component had this same issue and the community update the default to 1m.


### Notes to the Reviewer

We plan to allow setting this value in the helm chart via https://github.com/grafana/k8s-monitoring-helm/pull/2845, but we wanted to update the default here as well.

### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [x] Tests updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
