### PR TITLE
docs: document signed commit requirement

### DIFF
--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -274,6 +274,19 @@ Contributors are expected to work with upstream to make their changes acceptable
 If upstream is unresponsive, consider choosing a different dependency or making a hard fork (i.e.,
 creating a new Go module with the same source).
 
+## Submit a pull request
+
+Effective 2026-06-22, all Grafana Labs repositories [require signed commits][signed-commits].
+To learn more about Git commit verification, refer to [About commit signature verification][signing-commits]
+and [Checking your commit signature verification status][verifying-commits].
+
+> [!NOTE]
+> Pull requests containing any unsigned commits cannot be merged until all commits are signed.
+
+[signed-commits]: https://docs.github.com/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-signed-commits
+[signing-commits]: https://docs.github.com/authentication/managing-commit-signature-verification/about-commit-signature-verification
+[verifying-commits]: https://docs.github.com/authentication/troubleshooting-commit-signature-verification/checking-your-commit-and-tag-signature-verification-status
+
 [new-issue]: https://github.com/grafana/alloy/issues/new
 [code-review-comments]: https://code.google.com/p/go-wiki/wiki/CodeReviewComments
 [best-practices]: https://peter.bourgon.org/go-in-production/#formatting-and-style


### PR DESCRIPTION
Add the Grafana Labs signed-commit requirement to the contributor documentation.\n\nThis mirrors grafana/docker-otel-lgtm#1599.\n\nDocumentation-only change; no tests are required.