### PR TITLE
feat(component): add component stability manifest

### DIFF
--- a/.github/workflows/check-generate-component-manifest.yml
+++ b/.github/workflows/check-generate-component-manifest.yml
@@ -1,0 +1,34 @@
+name: Check generate-component-manifest
+
+permissions:
+  contents: read
+on: pull_request
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run generate-component-manifest
+        run: |
+          make generate-component-manifest
+
+      - name: Check for generated file changes
+        run: |
+          if [ -n "$(git status --porcelain -- internal/component/manifest.yaml)" ]; then
+            echo "Error: generated component manifest is out of sync."
+            echo "  Run: make generate-component-manifest and commit the generated file"
+            git status -- internal/component/manifest.yaml
+            git diff -- internal/component/manifest.yaml
+            exit 1
+          fi

--- a/Makefile
+++ b/Makefile
@@ -312,14 +312,21 @@ alloy-image-windows:
 # Targets for generating assets
 #
 
-.PHONY: generate generate-helm-docs generate-helm-tests generate-ui generate-winmanifest generate-snmp generate-rendered-mixin generate-source-code generate-otel-collector-distro generate-graphql
-generate: generate-helm-docs generate-helm-tests generate-ui generate-docs generate-winmanifest generate-snmp generate-rendered-mixin generate-otel-collector-distro generate-graphql
+.PHONY: generate generate-helm-docs generate-helm-tests generate-ui generate-winmanifest generate-snmp generate-rendered-mixin generate-source-code generate-otel-collector-distro generate-graphql generate-component-manifest
+generate: generate-helm-docs generate-helm-tests generate-ui generate-docs generate-winmanifest generate-snmp generate-rendered-mixin generate-otel-collector-distro generate-graphql generate-component-manifest
 
 generate-graphql:
 ifeq ($(USE_CONTAINER),1)
 	$(RERUN_IN_CONTAINER)
 else
 	cd ./internal/service/graphql && GOOS= GOARCH= go generate ./...
+endif
+
+generate-component-manifest:
+ifeq ($(USE_CONTAINER),1)
+	$(RERUN_IN_CONTAINER)
+else
+	GOOS= GOARCH= go run ./internal/component/manifest_gen -output internal/component/manifest.yaml
 endif
 
 generate-helm-docs:

--- a/internal/component/manifest.yaml
+++ b/internal/component/manifest.yaml
@@ -1,0 +1,374 @@
+# This file is generated. DO NOT EDIT.
+# Regenerate with `make generate-component-manifest`.
+#
+# Lists every component registered in the Alloy default engine and its
+# stability. The Alloy version is the git tag this file is committed under.
+components:
+  - name: beyla.ebpf
+    stability: generally-available
+  - name: database_observability.mysql
+    stability: generally-available
+  - name: database_observability.postgres
+    stability: generally-available
+  - name: database_observability.sql_server
+    stability: experimental
+  - name: discovery.aws
+    stability: generally-available
+  - name: discovery.azure
+    stability: generally-available
+  - name: discovery.consul
+    stability: generally-available
+  - name: discovery.consulagent
+    stability: generally-available
+  - name: discovery.digitalocean
+    stability: generally-available
+  - name: discovery.dns
+    stability: generally-available
+  - name: discovery.docker
+    stability: generally-available
+  - name: discovery.dockerswarm
+    stability: generally-available
+  - name: discovery.ec2
+    stability: generally-available
+  - name: discovery.eureka
+    stability: generally-available
+  - name: discovery.file
+    stability: generally-available
+  - name: discovery.gce
+    stability: generally-available
+  - name: discovery.hetzner
+    stability: generally-available
+  - name: discovery.http
+    stability: generally-available
+  - name: discovery.ionos
+    stability: generally-available
+  - name: discovery.kubelet
+    stability: generally-available
+  - name: discovery.kubernetes
+    stability: generally-available
+  - name: discovery.kuma
+    stability: generally-available
+  - name: discovery.lightsail
+    stability: generally-available
+  - name: discovery.linode
+    stability: generally-available
+  - name: discovery.marathon
+    stability: generally-available
+  - name: discovery.nerve
+    stability: generally-available
+  - name: discovery.nomad
+    stability: generally-available
+  - name: discovery.openstack
+    stability: generally-available
+  - name: discovery.ovhcloud
+    stability: generally-available
+  - name: discovery.process
+    stability: generally-available
+  - name: discovery.puppetdb
+    stability: generally-available
+  - name: discovery.relabel
+    stability: generally-available
+  - name: discovery.scaleway
+    stability: generally-available
+  - name: discovery.serverset
+    stability: generally-available
+  - name: discovery.triton
+    stability: generally-available
+  - name: discovery.uyuni
+    stability: generally-available
+  - name: faro.receiver
+    stability: generally-available
+  - name: local.file
+    stability: generally-available
+  - name: local.file_match
+    stability: generally-available
+  - name: loki.echo
+    stability: generally-available
+  - name: loki.enrich
+    stability: experimental
+  - name: loki.process
+    stability: generally-available
+  - name: loki.relabel
+    stability: generally-available
+  - name: loki.rules.kubernetes
+    stability: generally-available
+  - name: loki.secretfilter
+    stability: experimental
+  - name: loki.source.api
+    stability: generally-available
+  - name: loki.source.awsfirehose
+    stability: generally-available
+  - name: loki.source.azure_event_hubs
+    stability: generally-available
+  - name: loki.source.cloudflare
+    stability: generally-available
+  - name: loki.source.docker
+    stability: generally-available
+  - name: loki.source.file
+    stability: generally-available
+  - name: loki.source.gcplog
+    stability: generally-available
+  - name: loki.source.gelf
+    stability: generally-available
+  - name: loki.source.heroku
+    stability: generally-available
+  - name: loki.source.journal
+    stability: generally-available
+  - name: loki.source.kafka
+    stability: generally-available
+  - name: loki.source.kubernetes
+    stability: generally-available
+  - name: loki.source.kubernetes_events
+    stability: generally-available
+  - name: loki.source.podlogs
+    stability: generally-available
+  - name: loki.source.syslog
+    stability: generally-available
+  - name: loki.source.windowsevent
+    stability: generally-available
+  - name: loki.write
+    stability: generally-available
+  - name: mimir.alerts.kubernetes
+    stability: experimental
+  - name: mimir.rules.kubernetes
+    stability: generally-available
+  - name: otelcol.auth.basic
+    stability: generally-available
+  - name: otelcol.auth.bearer
+    stability: generally-available
+  - name: otelcol.auth.google
+    stability: public-preview
+  - name: otelcol.auth.headers
+    stability: generally-available
+  - name: otelcol.auth.oauth2
+    stability: generally-available
+  - name: otelcol.auth.sigv4
+    stability: generally-available
+  - name: otelcol.connector.count
+    stability: experimental
+  - name: otelcol.connector.host_info
+    stability: generally-available
+  - name: otelcol.connector.servicegraph
+    stability: generally-available
+  - name: otelcol.connector.signaltometrics
+    stability: experimental
+  - name: otelcol.connector.spanlogs
+    stability: generally-available
+  - name: otelcol.connector.spanmetrics
+    stability: generally-available
+  - name: otelcol.exporter.awss3
+    stability: experimental
+  - name: otelcol.exporter.datadog
+    community: true
+  - name: otelcol.exporter.debug
+    stability: experimental
+  - name: otelcol.exporter.faro
+    stability: experimental
+  - name: otelcol.exporter.file
+    stability: public-preview
+  - name: otelcol.exporter.googlecloud
+    community: true
+  - name: otelcol.exporter.googlecloudpubsub
+    community: true
+  - name: otelcol.exporter.kafka
+    stability: generally-available
+  - name: otelcol.exporter.loadbalancing
+    stability: generally-available
+  - name: otelcol.exporter.loki
+    stability: generally-available
+  - name: otelcol.exporter.otlp
+    stability: generally-available
+  - name: otelcol.exporter.otlphttp
+    stability: generally-available
+  - name: otelcol.exporter.prometheus
+    stability: generally-available
+  - name: otelcol.exporter.splunkhec
+    community: true
+  - name: otelcol.exporter.syslog
+    stability: public-preview
+  - name: otelcol.extension.jaeger_remote_sampling
+    stability: generally-available
+  - name: otelcol.processor.attributes
+    stability: generally-available
+  - name: otelcol.processor.batch
+    stability: generally-available
+  - name: otelcol.processor.cumulativetodelta
+    stability: public-preview
+  - name: otelcol.processor.deltatocumulative
+    stability: experimental
+  - name: otelcol.processor.discovery
+    stability: generally-available
+  - name: otelcol.processor.filter
+    stability: generally-available
+  - name: otelcol.processor.groupbyattrs
+    stability: generally-available
+  - name: otelcol.processor.interval
+    stability: experimental
+  - name: otelcol.processor.k8sattributes
+    stability: generally-available
+  - name: otelcol.processor.memory_limiter
+    stability: generally-available
+  - name: otelcol.processor.metric_start_time
+    stability: generally-available
+  - name: otelcol.processor.probabilistic_sampler
+    stability: generally-available
+  - name: otelcol.processor.resourcedetection
+    stability: generally-available
+  - name: otelcol.processor.span
+    stability: generally-available
+  - name: otelcol.processor.tail_sampling
+    stability: generally-available
+  - name: otelcol.processor.transform
+    stability: generally-available
+  - name: otelcol.receiver.awscloudwatch
+    stability: experimental
+  - name: otelcol.receiver.awsecscontainermetrics
+    stability: experimental
+  - name: otelcol.receiver.awss3
+    stability: experimental
+  - name: otelcol.receiver.cloudflare
+    stability: experimental
+  - name: otelcol.receiver.datadog
+    stability: experimental
+  - name: otelcol.receiver.faro
+    stability: experimental
+  - name: otelcol.receiver.file_stats
+    stability: generally-available
+  - name: otelcol.receiver.filelog
+    stability: public-preview
+  - name: otelcol.receiver.fluentforward
+    stability: experimental
+  - name: otelcol.receiver.googlecloudpubsub
+    community: true
+  - name: otelcol.receiver.influxdb
+    stability: generally-available
+  - name: otelcol.receiver.jaeger
+    stability: generally-available
+  - name: otelcol.receiver.kafka
+    stability: generally-available
+  - name: otelcol.receiver.loki
+    stability: generally-available
+  - name: otelcol.receiver.nginx
+    stability: public-preview
+  - name: otelcol.receiver.otlp
+    stability: generally-available
+  - name: otelcol.receiver.prometheus
+    stability: generally-available
+  - name: otelcol.receiver.solace
+    stability: generally-available
+  - name: otelcol.receiver.splunkhec
+    stability: public-preview
+  - name: otelcol.receiver.syslog
+    stability: public-preview
+  - name: otelcol.receiver.tcplog
+    stability: experimental
+  - name: otelcol.receiver.vcenter
+    stability: experimental
+  - name: otelcol.receiver.zipkin
+    stability: generally-available
+  - name: otelcol.storage.file
+    stability: public-preview
+  - name: prometheus.echo
+    stability: generally-available
+  - name: prometheus.enrich
+    stability: experimental
+  - name: prometheus.exporter.apache
+    stability: generally-available
+  - name: prometheus.exporter.azure
+    stability: generally-available
+  - name: prometheus.exporter.blackbox
+    stability: generally-available
+  - name: prometheus.exporter.cadvisor
+    stability: generally-available
+  - name: prometheus.exporter.catchpoint
+    stability: experimental
+  - name: prometheus.exporter.cloudwatch
+    stability: generally-available
+  - name: prometheus.exporter.consul
+    stability: generally-available
+  - name: prometheus.exporter.databricks
+    stability: generally-available
+  - name: prometheus.exporter.dnsmasq
+    stability: generally-available
+  - name: prometheus.exporter.elasticsearch
+    stability: generally-available
+  - name: prometheus.exporter.gcp
+    stability: generally-available
+  - name: prometheus.exporter.github
+    stability: generally-available
+  - name: prometheus.exporter.kafka
+    stability: generally-available
+  - name: prometheus.exporter.memcached
+    stability: generally-available
+  - name: prometheus.exporter.mongodb
+    stability: generally-available
+  - name: prometheus.exporter.mssql
+    stability: generally-available
+  - name: prometheus.exporter.mysql
+    stability: generally-available
+  - name: prometheus.exporter.oracledb
+    stability: generally-available
+  - name: prometheus.exporter.postgres
+    stability: generally-available
+  - name: prometheus.exporter.process
+    stability: generally-available
+  - name: prometheus.exporter.redis
+    stability: generally-available
+  - name: prometheus.exporter.self
+    stability: generally-available
+  - name: prometheus.exporter.snmp
+    stability: generally-available
+  - name: prometheus.exporter.snowflake
+    stability: generally-available
+  - name: prometheus.exporter.squid
+    stability: generally-available
+  - name: prometheus.exporter.static
+    stability: experimental
+  - name: prometheus.exporter.statsd
+    stability: generally-available
+  - name: prometheus.exporter.unix
+    stability: generally-available
+  - name: prometheus.exporter.windows
+    stability: generally-available
+  - name: prometheus.operator.podmonitors
+    stability: generally-available
+  - name: prometheus.operator.probes
+    stability: generally-available
+  - name: prometheus.operator.scrapeconfigs
+    stability: experimental
+  - name: prometheus.operator.servicemonitors
+    stability: generally-available
+  - name: prometheus.receive_http
+    stability: generally-available
+  - name: prometheus.relabel
+    stability: generally-available
+  - name: prometheus.remote_write
+    stability: generally-available
+  - name: prometheus.scrape
+    stability: generally-available
+  - name: prometheus.write.queue
+    stability: experimental
+  - name: pyroscope.ebpf
+    stability: generally-available
+  - name: pyroscope.enrich
+    stability: experimental
+  - name: pyroscope.java
+    stability: generally-available
+  - name: pyroscope.receive_http
+    stability: generally-available
+  - name: pyroscope.relabel
+    stability: generally-available
+  - name: pyroscope.scrape
+    stability: generally-available
+  - name: pyroscope.write
+    stability: generally-available
+  - name: remote.http
+    stability: generally-available
+  - name: remote.kubernetes.configmap
+    stability: generally-available
+  - name: remote.kubernetes.secret
+    stability: generally-available
+  - name: remote.s3
+    stability: generally-available
+  - name: remote.vault
+    stability: generally-available

--- a/internal/component/manifest_gen/main.go
+++ b/internal/component/manifest_gen/main.go
@@ -1,0 +1,112 @@
+// Command manifest_gen generates internal/component/manifest.yaml: the list of
+// every component registered in the Alloy default engine and its stability
+// level. Regenerate with `make generate-component-manifest`.
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+
+	"github.com/grafana/alloy/internal/component"
+	"github.com/grafana/alloy/internal/featuregate"
+
+	_ "github.com/grafana/alloy/internal/component/all" // Import all component definitions.
+
+	"gopkg.in/yaml.v3"
+)
+
+const header = `# This file is generated. DO NOT EDIT.
+# Regenerate with ` + "`make generate-component-manifest`" + `.
+#
+# Lists every component registered in the Alloy default engine and its
+# stability. The Alloy version is the git tag this file is committed under.
+`
+
+type entry struct {
+	Name      string `yaml:"name"`
+	Stability string `yaml:"stability,omitempty"`
+	Community bool   `yaml:"community,omitempty"`
+}
+
+type manifest struct {
+	Components []entry `yaml:"components"`
+}
+
+func buildManifest(regs []component.Registration) (manifest, error) {
+	sorted := make([]component.Registration, len(regs))
+	copy(sorted, regs)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
+
+	m := manifest{Components: make([]entry, 0, len(sorted))}
+	for _, reg := range sorted {
+		e := entry{Name: reg.Name}
+		if reg.Community {
+			e.Community = true
+		} else {
+			if reg.Stability == featuregate.StabilityUndefined {
+				return manifest{}, fmt.Errorf("component %q has undefined stability", reg.Name)
+			}
+			stability, err := strconv.Unquote(reg.Stability.String())
+			if err != nil {
+				return manifest{}, fmt.Errorf("component %q: unquoting stability %q: %w", reg.Name, reg.Stability.String(), err)
+			}
+			e.Stability = stability
+		}
+		m.Components = append(m.Components, e)
+	}
+	return m, nil
+}
+
+func renderManifest(m manifest) ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteString(header)
+
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(m); err != nil {
+		return nil, fmt.Errorf("encoding manifest: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("closing encoder: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+func run(output string) error {
+	names := component.AllNames()
+	regs := make([]component.Registration, 0, len(names))
+	for _, name := range names {
+		reg, ok := component.Get(name)
+		if !ok {
+			continue
+		}
+		regs = append(regs, reg)
+	}
+
+	m, err := buildManifest(regs)
+	if err != nil {
+		return err
+	}
+	data, err := renderManifest(m)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(output, data, 0644); err != nil {
+		return fmt.Errorf("writing %s: %w", output, err)
+	}
+	return nil
+}
+
+func main() {
+	output := flag.String("output", "internal/component/manifest.yaml", "path to write the manifest")
+	flag.Parse()
+
+	if err := run(*output); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}

--- a/internal/component/manifest_gen/main_test.go
+++ b/internal/component/manifest_gen/main_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/grafana/alloy/internal/component"
+	"github.com/grafana/alloy/internal/featuregate"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildManifest_SortsAndMapsStability(t *testing.T) {
+	regs := []component.Registration{
+		{Name: "zzz.ga", Stability: featuregate.StabilityGenerallyAvailable},
+		{Name: "aaa.experimental", Stability: featuregate.StabilityExperimental},
+		{Name: "mmm.preview", Stability: featuregate.StabilityPublicPreview},
+		{Name: "ccc.community", Community: true},
+	}
+
+	m, err := buildManifest(regs)
+	require.NoError(t, err)
+	require.Equal(t, []entry{
+		{Name: "aaa.experimental", Stability: "experimental"},
+		{Name: "ccc.community", Community: true},
+		{Name: "mmm.preview", Stability: "public-preview"},
+		{Name: "zzz.ga", Stability: "generally-available"},
+	}, m.Components)
+}
+
+func TestBuildManifest_ErrorsOnUndefinedStability(t *testing.T) {
+	regs := []component.Registration{
+		{Name: "bad.component", Stability: featuregate.StabilityUndefined},
+	}
+
+	_, err := buildManifest(regs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bad.component")
+}
+
+func TestRenderManifest_HeaderAndYAML(t *testing.T) {
+	m := manifest{Components: []entry{
+		{Name: "aaa.experimental", Stability: "experimental"},
+		{Name: "ccc.community", Community: true},
+		{Name: "zzz.ga", Stability: "generally-available"},
+	}}
+
+	out, err := renderManifest(m)
+	require.NoError(t, err)
+
+	got := string(out)
+	require.True(t, strings.HasPrefix(got, "# This file is generated. DO NOT EDIT."), "missing header, got:\n%s", got)
+	require.Contains(t, got, "components:\n")
+	require.Contains(t, got, "  - name: aaa.experimental\n    stability: experimental\n")
+	require.Contains(t, got, "  - name: ccc.community\n    community: true\n")
+	require.Contains(t, got, "  - name: zzz.ga\n    stability: generally-available\n")
+}


### PR DESCRIPTION
## What

Adds a machine-readable **component stability manifest** — a generated, checked-in YAML file listing every component registered in the Alloy default engine and its stability level. External tools can read the file at a given git tag to learn which components are `experimental`, `public-preview`, or `generally-available` in that version of Alloy, with no running binary required.

No such machine-readable manifest existed before; stability was only expressed in code and hand-maintained per-component doc banners.

## Changes

- **`internal/component/manifest_gen/`** — a small generator that enumerates the component registry (via the blank-import of `internal/component/all`) and emits a name-sorted YAML manifest. Pure `buildManifest`/`renderManifest` functions with unit tests.
- **`internal/component/manifest.yaml`** — the generated manifest (184 components).
- **`Makefile`** — new `generate-component-manifest` target, wired into the aggregate `make generate`.
- **`.github/workflows/check-generate-component-manifest.yml`** — CI drift check that regenerates the manifest on PRs and fails if the committed file is out of sync (mirrors `check-generate-graphql.yml`).

## Manifest format

```yaml
# This file is generated. DO NOT EDIT.
# Regenerate with `make generate-component-manifest`.
components:
  - name: loki.enrich
    stability: experimental
  - name: otelcol.receiver.otlp
    stability: public-preview
  - name: discovery.azure
    stability: generally-available
  - name: otelcol.exporter.datadog
    community: true
```

- `name` — always present.
- `stability` — `experimental` / `public-preview` / `generally-available`; present for default-engine components.
- `community: true` — only for community components (which carry no stability by design).

The manifest intentionally embeds **no** Alloy version — the git tag the file is committed under is the version of record, which keeps the file stable and diff-free between releases.

## Testing

- `go test ./internal/component/manifest_gen/...` — unit tests for the transform + YAML rendering.
- CI drift check guarantees the committed file matches what the current code generates.
- Generator output is deterministic (registry names are sorted; no map iteration reaches output), so the drift check is not flaky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
