### PR TITLE
feat(helm): Add serviceMonitor.attachMetadata to the Alloy chart

### DIFF
--- a/operations/helm/charts/alloy/CHANGELOG.md
+++ b/operations/helm/charts/alloy/CHANGELOG.md
@@ -12,6 +12,8 @@ Unreleased
 
 ### Enhancements
 
+- Add `serviceMonitor.attachMetadata` to attach node metadata to targets discovered by the ServiceMonitor. (@aljohri)
+
 - Add `alloy.command` to override the entrypoint command for the Alloy container. This makes it possible to launch the Alloy binary from its image path when running as a HostProcess container on Windows nodes. (@petewall)
 
 1.10.1 (2026-06-29)

--- a/operations/helm/charts/alloy/README.md
+++ b/operations/helm/charts/alloy/README.md
@@ -194,6 +194,7 @@ useful if just using the default DaemonSet isn't sufficient.
 | serviceAccount.create | bool | `true` | Whether to create a service account for the Grafana Alloy deployment. |
 | serviceAccount.name | string | `nil` | The name of the existing service account to use when serviceAccount.create is false. |
 | serviceMonitor.additionalLabels | object | `{}` | Additional labels for the service monitor. |
+| serviceMonitor.attachMetadata | object | `{}` | Attaches node metadata to discovered targets. Requires Prometheus Operator v0.45+ and the `nodes` RBAC permission on the Prometheus service account. ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#attachmetadata |
 | serviceMonitor.enabled | bool | `false` |  |
 | serviceMonitor.interval | string | `""` | Scrape interval. If not set, the Prometheus default scrape interval is used. |
 | serviceMonitor.metricRelabelings | list | `[]` | MetricRelabelConfigs to apply to samples after scraping, but before ingestion. ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig |

--- a/operations/helm/charts/alloy/ci/enable-servicemonitor-tls-values.yaml
+++ b/operations/helm/charts/alloy/ci/enable-servicemonitor-tls-values.yaml
@@ -5,5 +5,7 @@ service:
   enabled: true
 serviceMonitor:
   enabled: true
+  attachMetadata:
+    node: true
   tlsConfig:
     insecureSkipVerify: true

--- a/operations/helm/charts/alloy/templates/servicemonitor.yaml
+++ b/operations/helm/charts/alloy/templates/servicemonitor.yaml
@@ -12,6 +12,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- with .Values.serviceMonitor.attachMetadata }}
+  attachMetadata:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   endpoints:
   - port: http-metrics
     scheme: {{ $values.listenScheme | lower }}

--- a/operations/helm/charts/alloy/values.yaml
+++ b/operations/helm/charts/alloy/values.yaml
@@ -518,6 +518,11 @@ serviceMonitor:
   additionalLabels: {}
   # -- Scrape interval. If not set, the Prometheus default scrape interval is used.
   interval: ""
+  # -- Attaches node metadata to discovered targets. Requires Prometheus Operator v0.45+ and the
+  # `nodes` RBAC permission on the Prometheus service account.
+  # ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#attachmetadata
+  attachMetadata: {}
+  # node: true
   # -- MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
   # ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
   metricRelabelings: []

--- a/operations/helm/tests/enable-servicemonitor-tls/alloy/templates/servicemonitor.yaml
+++ b/operations/helm/tests/enable-servicemonitor-tls/alloy/templates/servicemonitor.yaml
@@ -13,6 +13,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
 spec:
+  attachMetadata:
+    node: true
   endpoints:
   - port: http-metrics
     scheme: https


### PR DESCRIPTION
### Brief description of Pull Request

Adds a `serviceMonitor.attachMetadata` value to the Alloy chart. The `ServiceMonitor` template currently has no way to set `spec.attachMetadata`.

### Pull Request Details

[`attachMetadata`](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#attachmetadata) tells the operator to attach node metadata to discovered targets, making `__meta_kubernetes_node_label_*` / `__meta_kubernetes_node_name` available for relabeling — e.g. to label Alloy's own metrics with the node's instance type or topology zone. Today that requires patching the rendered manifest.

Rendered only when non-empty, so it's a no-op for existing users:

```yaml
serviceMonitor:
  enabled: true
  attachMetadata:
    node: true
```

Requires Prometheus Operator v0.45+ and the `nodes` RBAC permission on the Prometheus service account; that caveat is in the values comment. Covered by the `enable-servicemonitor-tls` test case; README regenerated with `helm-docs`.
