### PR TITLE
fix(loki.source.docker): Apply label changes to already-running tailers

### DIFF
--- a/internal/component/loki/source/docker/docker.go
+++ b/internal/component/loki/source/docker/docker.go
@@ -214,6 +214,18 @@ func (c *Component) Update(args component.Arguments) error {
 		return promTargets[i].fingerPrint < promTargets[j].fingerPrint
 	})
 
+	// Retain the winning target for each container ID so the labels of tailers
+	// which are already running can be refreshed below. Reconcile applies the
+	// same first-one-wins rule over the sorted slice.
+	targetsByID := make(map[string]promTarget, len(promTargets))
+	for _, target := range promTargets {
+		containerID := string(target.labels[dockerLabelContainerID])
+		if _, seen := targetsByID[containerID]; containerID == "" || seen {
+			continue
+		}
+		targetsByID[containerID] = target
+	}
+
 	source.Reconcile(
 		c.opts.Logger,
 		c.scheduler,
@@ -239,6 +251,18 @@ func (c *Component) Update(args component.Arguments) error {
 			)
 		},
 	)
+
+	// Reconcile only builds sources for container IDs that are not running yet,
+	// so a tailer which is already running would otherwise keep the labels it
+	// was created with forever. Push the newly computed labels and relabel
+	// rules to them instead of restarting them, which would reset their read
+	// offset and re-ship the container's log.
+	for s := range c.scheduler.Sources() {
+		t := s.(*tailer)
+		if target, ok := targetsByID[t.containerID]; ok {
+			t.updateLabels(target.labels.Merge(defaultLabels), c.rcs)
+		}
+	}
 
 	c.args = newArgs
 	return nil

--- a/internal/component/loki/source/docker/docker_test.go
+++ b/internal/component/loki/source/docker/docker_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alloy/internal/component"
@@ -93,4 +94,50 @@ func TestComponentDuplicateTargets(t *testing.T) {
 		ss := s.(*tailer)
 		require.Equal(t, "{__meta_docker_container_id=\"foo\", __meta_docker_port_private=\"8080\"}", ss.labelsStr)
 	}
+}
+
+func TestComponentUpdatesLabelsOfRunningTailer(t *testing.T) {
+	// Same container ID throughout: the component must apply label changes to
+	// the tailer it is already running instead of ignoring them until restart.
+	cfg := func(env, service string) Arguments {
+		var args Arguments
+		err := syntax.Unmarshal([]byte(`
+			host       = "tcp://127.0.0.1:9381"
+			targets    = [
+				{__meta_docker_container_id = "abc123", service = "`+service+`"},
+			]
+			labels     = {"env" = "`+env+`"}
+			forward_to = []
+		`), &args)
+		require.NoError(t, err)
+		return args
+	}
+
+	cmp, err := New(component.Options{
+		ID:         "loki.source.docker.test",
+		Logger:     logging.NewSlogNop(),
+		Registerer: prometheus.NewRegistry(),
+		DataPath:   t.TempDir(),
+	}, cfg("staging", "api"))
+	require.NoError(t, err)
+
+	streamLabelsOf := func() model.LabelSet {
+		for s := range cmp.scheduler.Sources() {
+			return s.(*tailer).curStreamLabels.Load().stdout
+		}
+		return nil
+	}
+
+	require.Equal(t, model.LabelValue("staging"), streamLabelsOf()["env"])
+	require.Equal(t, model.LabelValue("api"), streamLabelsOf()["service"])
+
+	// Change both the component's own `labels` argument and a target label
+	// arriving from discovery. Neither changes the container ID.
+	require.NoError(t, cmp.Update(cfg("production", "gateway")))
+
+	require.Equal(t, 1, cmp.scheduler.Len(), "the tailer must not be restarted")
+	require.Equal(t, model.LabelValue("production"), streamLabelsOf()["env"],
+		"a change to the `labels` argument must reach the running tailer")
+	require.Equal(t, model.LabelValue("gateway"), streamLabelsOf()["service"],
+		"a changed target label must reach the running tailer")
 }

--- a/internal/component/loki/source/docker/tailer.go
+++ b/internal/component/loki/source/docker/tailer.go
@@ -30,25 +30,45 @@ import (
 	"github.com/grafana/alloy/internal/component/loki/source/internal/positions"
 )
 
+// streamLabels holds the fully relabelled label sets for a container's stdout
+// and stderr streams. They are computed together whenever the tailer's labels
+// change and published as a single immutable value, so the hot path in process
+// can read them with one atomic load instead of taking a lock per log line.
+type streamLabels struct {
+	stdout model.LabelSet
+	stderr model.LabelSet
+}
+
 // tailer for Docker container logs.
 type tailer struct {
-	logger            *slog.Logger
-	recv              loki.LogsReceiver
-	positions         positions.Positions
-	containerID       string
-	labels            model.LabelSet
+	logger      *slog.Logger
+	recv        loki.LogsReceiver
+	positions   positions.Positions
+	containerID string
+	// labelsStr is the label set the tailer was created with. It is the
+	// positions-file key for this container and is deliberately never updated:
+	// the read offset describes how far we have read in the container's log,
+	// which does not depend on how the entries are labelled. Re-keying it when
+	// labels change would orphan the existing entry and re-ship the whole log.
 	labelsStr         string
-	relabelConfig     []*relabel.Config
 	metrics           *metrics
 	restartInterval   time.Duration
 	componentStopping func() bool
 
 	client client.APIClient
 
-	mu      sync.Mutex // protects cancel, running and err fields
+	mu      sync.Mutex // protects cancel, running, err, labels and relabelConfig
 	err     error
 	running bool
 	cancel  context.CancelFunc
+	// labels and relabelConfig may change while the tailer is running; both are
+	// guarded by mu and are only read when recomputing curStreamLabels.
+	labels        model.LabelSet
+	relabelConfig []*relabel.Config
+
+	// curStreamLabels is the published result of applying relabelConfig to
+	// labels. Written under mu, read lock-free by process.
+	curStreamLabels atomic.Pointer[streamLabels]
 
 	wg sync.WaitGroup
 
@@ -69,7 +89,7 @@ func newTailer(
 		return nil, err
 	}
 
-	return &tailer{
+	t := &tailer{
 		logger:            logger,
 		recv:              recv,
 		since:             atomic.NewInt64(pos),
@@ -83,7 +103,48 @@ func newTailer(
 		client:            client,
 		restartInterval:   restartInterval,
 		componentStopping: componentStopping,
-	}, nil
+	}
+	t.publishStreamLabels()
+	return t, nil
+}
+
+// updateLabels replaces the label set and relabel rules used to label entries
+// emitted by this tailer. It takes effect on the next entry read from the
+// container without restarting the log stream, so no entries are duplicated or
+// dropped and the positions file is left untouched.
+func (t *tailer) updateLabels(labels model.LabelSet, relabelConfig []*relabel.Config) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Recomputed unconditionally: Update builds a fresh []*relabel.Config on
+	// every call, so comparing rules to skip the work is not worthwhile.
+	t.labels = labels
+	t.relabelConfig = relabelConfig
+	t.publishStreamLabels()
+}
+
+// streamLabelsFor returns the label set to apply to entries read from the
+// given stream. It is safe on a tailer whose label sets have not been
+// published yet, in which case entries carry no labels.
+func (t *tailer) streamLabelsFor(stdout bool) model.LabelSet {
+	sl := t.curStreamLabels.Load()
+	if sl == nil {
+		return model.LabelSet{}
+	}
+	if stdout {
+		return sl.stdout
+	}
+	return sl.stderr
+}
+
+// publishStreamLabels recomputes the per-stream label sets from the current
+// labels and relabel rules. Callers must hold t.mu, except for newTailer where
+// the tailer is not yet shared.
+func (t *tailer) publishStreamLabels() {
+	t.curStreamLabels.Store(&streamLabels{
+		stdout: t.getStreamLabels("stdout"),
+		stderr: t.getStreamLabels("stderr"),
+	})
 }
 
 func (t *tailer) Run(ctx context.Context) {
@@ -194,10 +255,12 @@ func (t *tailer) DebugInfo() sourceInfo {
 	}
 
 	return sourceInfo{
-		ID:         t.containerID,
-		LastError:  errMsg,
-		Labels:     t.labelsStr,
-		IsRunning:  running,
+		ID:        t.containerID,
+		LastError: errMsg,
+		// Current labels, which may differ from labelsStr after updateLabels.
+		Labels:    t.labels.String(),
+		IsRunning: running,
+		// Keyed by labelsStr, the positions key fixed at creation time.
 		ReadOffset: t.positions.GetString(positions.CursorKey(t.containerID), t.labelsStr),
 	}
 }
@@ -243,12 +306,12 @@ func (t *tailer) processLoop(ctx context.Context, tty bool, reader io.ReadCloser
 	// Start processing
 	go func() {
 		defer t.wg.Done()
-		t.process(rstdout, t.getStreamLabels("stdout"))
+		t.process(rstdout, true)
 	}()
 
 	go func() {
 		defer t.wg.Done()
-		t.process(rstderr, t.getStreamLabels("stderr"))
+		t.process(rstderr, false)
 	}()
 
 	// Wait until done
@@ -273,7 +336,7 @@ func extractTsFromBytes(line []byte) (time.Time, []byte, error) {
 	return ts, line[spaceIdx+1:], nil
 }
 
-func (t *tailer) process(r io.Reader, logStreamLset model.LabelSet) {
+func (t *tailer) process(r io.Reader, stdout bool) {
 	const maxCapacity = dockerMaxChunkSize * 64
 
 	reader := bufio.NewReader(r)
@@ -322,7 +385,9 @@ func (t *tailer) process(r io.Reader, logStreamLset model.LabelSet) {
 			continue
 		}
 
-		t.recv.Chan() <- loki.NewEntry(logStreamLset, push.Entry{
+		// Read the label set per entry so that a label change applied by
+		// updateLabels takes effect without restarting the log stream.
+		t.recv.Chan() <- loki.NewEntry(t.streamLabelsFor(stdout), push.Entry{
 			Timestamp: ts,
 			Line:      string(content),
 		})

--- a/internal/component/loki/source/docker/tailer_test.go
+++ b/internal/component/loki/source/docker/tailer_test.go
@@ -517,3 +517,84 @@ func (sw *stdWriter) Write(p []byte) (int, error) {
 	}
 	return sw.Writer.Write(p)
 }
+
+func TestTailerUpdateLabelsAppliesToNewEntries(t *testing.T) {
+	logger := logging.NewSlogNop()
+	entryHandler := loki.NewCollectingHandler()
+	defer entryHandler.Stop()
+
+	ps, err := positions.New(logger, positions.Config{
+		SyncPeriod:    10 * time.Second,
+		PositionsFile: t.TempDir() + "/positions.yml",
+	})
+	require.NoError(t, err)
+	defer ps.Stop()
+
+	tailer, err := newTailer(
+		newMetrics(prometheus.NewRegistry()),
+		logger,
+		entryHandler.Receiver(),
+		ps,
+		"container-id",
+		model.LabelSet{"job": "docker", "env": "staging"},
+		[]*relabel.Config{},
+		nil,
+		restartInterval,
+		func() bool { return false },
+	)
+	require.NoError(t, err)
+
+	// process is fed directly so the label change can be applied while the
+	// stream stays open, which is the behaviour under test.
+	pr, pw := io.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		tailer.process(pr, true)
+	}()
+
+	_, err = pw.Write([]byte("2024-01-01T00:00:00.000000000Z before\n"))
+	require.NoError(t, err)
+
+	lineLabels := func(line string) (model.LabelSet, bool) {
+		for _, e := range entryHandler.Received() {
+			if e.Line == line {
+				return e.Labels, true
+			}
+		}
+		return nil, false
+	}
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		lset, ok := lineLabels("before")
+		if !assert.True(c, ok) {
+			return
+		}
+		assert.Equal(c, model.LabelValue("staging"), lset["env"])
+	}, 5*time.Second, 10*time.Millisecond)
+
+	tailer.updateLabels(model.LabelSet{"job": "docker", "env": "production"}, []*relabel.Config{})
+
+	_, err = pw.Write([]byte("2024-01-01T00:00:01.000000000Z after\n"))
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		lset, ok := lineLabels("after")
+		if !assert.True(c, ok) {
+			return
+		}
+		assert.Equal(c, model.LabelValue("production"), lset["env"])
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Entries already read keep the labels that applied when they were read.
+	lset, ok := lineLabels("before")
+	require.True(t, ok)
+	require.Equal(t, model.LabelValue("staging"), lset["env"])
+
+	require.NoError(t, pw.Close())
+	<-done
+
+	// The positions key must stay stable, otherwise the read offset for this
+	// container is orphaned and its log is re-shipped from the beginning.
+	require.Equal(t, `{env="staging", job="docker"}`, tailer.labelsStr)
+}


### PR DESCRIPTION
### Brief description of Pull Request

`loki.source.docker` silently ignored label changes for containers it was already tailing, so a
running tailer kept the label set it was constructed with until Alloy restarted. This affected the
component's own `labels` and `relabel_rules` arguments as well as target label changes arriving from
upstream `discovery.*` components.

The newly computed labels are now pushed to running tailers instead of being discarded. Labels are
updated in place rather than by restarting the tailer, so the container's log stream is not
interrupted and its read offset is preserved.

### Pull Request Details

`source.Reconcile` skips keys that are already scheduled:

```go
// Skip if a source with this key is already running.
if s.Contains(key) {
    continue
}
```

`loki.source.docker` keys its tailers on the container ID alone, so for a running container the
source factory is never re-invoked and the freshly computed `defaultLabels` / `c.rcs` in `Update()`
are discarded. `Update()` only calls `c.scheduler.Reset()` when the Docker client changes (a `host`
edit), so nothing else rebuilds the tailer.

Three things were therefore ignored for an already-running container:

- the component's own `labels` argument
- the component's own `relabel_rules` argument
- any target label change from an upstream `discovery.*` component that did not also change
  `__meta_docker_container_id`

#### Why not restart the tailer

Treating a label change as an identity change, so the tailer is stopped and rebuilt, looks like the
smaller fix but is the wrong one. `tailer.stop()` removes the container's positions entry when the
component is not shutting down, so the replacement would start from `since=0` and re-ship the whole
container log. That is also the behaviour #5026 set out to reduce, and the direction #5135 and #5717
are moving away from.

#### What this does instead

- `tailer` computes its two relabelled per-stream label sets together and publishes them in an
  `atomic.Pointer`. `process` reads them per entry, so the hot path costs one atomic load rather
  than a lock per log line.
- `updateLabels` swaps the label set and relabel rules under the existing mutex and republishes.
- `Update()` pushes the newly computed labels to every running tailer after `Reconcile`.

The log stream is never interrupted, no entries are duplicated or dropped, and the positions file is
untouched.

`labelsStr` deliberately stays fixed at the label set the tailer was created with, because it is the
positions key: the read offset describes how far we have read in the container's log and does not
depend on how entries are labelled. Re-keying it on a label change would orphan the existing entry.
`DebugInfo` now reports the current labels, while the read offset stays keyed by the original.

#### Scope

`loki.source.file` is unaffected — it folds labels into its key
(`positions.Entry{Path, Labels.String()}`) and so already restarts on a label change.

`loki.source.kubernetes_events` has the same class of problem (`job_name` and `log_format` are
frozen for already-running namespaces). I left it out to keep this PR to one component, and am happy
to follow up.

### Issue(s) fixed by this Pull Request

Fixes #6714

### Notes to the Reviewer

**This is a regression, first shipped in v1.13.0.** Before #5026 the tailer identity had two parts:
`internal/runner`'s `Task` required both `Hash()` (which bucket) and `Equals()` (has it changed?),
implemented for this component as the label fingerprint and a `LabelsStr()` comparison. A label
change produced a non-equal task, so the old worker was stopped and a new one started with fresh
labels. The replacement `source.Scheduler` has only `Key()`, so the change-detection half of the
identity was dropped. Neither #5026 nor #5095 carried a CHANGELOG entry, so the behaviour change
shipped unannounced.

**Design question for you:** I considered adding a general change-detection callback to
`source.Reconcile` so all three callers get this behaviour, which would be the broader fix. I chose
the localized change to leave the shared reconciler untouched. Happy to switch if you prefer the
general approach.

**Tests.** Two are added, and I confirmed both fail on `main` before the fix:

- `TestComponentUpdatesLabelsOfRunningTailer` — the component-level case from the issue: same
  container ID, changed `labels` argument and changed target label. Also asserts the tailer is not
  restarted.
- `TestTailerUpdateLabelsAppliesToNewEntries` — feeds `process` directly so labels can change while
  the stream stays open, then asserts entries read after the change carry the new labels, entries
  read before keep the old ones, and `labelsStr` is unchanged.

`TestComponentDuplicateTargets` still passes, so the existing first-one-wins de-duplication of
targets sharing a container ID is preserved.

Verified locally:

```
go test -race -tags="nodocker gore2regex" ./internal/component/loki/...   # all pass
golangci-lint run internal/component/loki/source/docker/...              # 0 issues
go vet -tags="nodocker gore2regex" ./internal/component/loki/source/docker/
alloylint github.com/grafana/alloy/internal/component/loki/source/docker/...
```

No CHANGELOG entry, since release tooling generates those from the PR title. No documentation change:
the reference page does not state that label changes require a restart, so nothing there is made
stale by this fix.

### PR Checklist

- [x] Tests updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
