### PR TITLE
feat: Bump Alloy Version to v1.18.0 in Helm Chart

### DIFF
--- a/operations/helm/charts/alloy/CHANGELOG.md
+++ b/operations/helm/charts/alloy/CHANGELOG.md
@@ -10,9 +10,14 @@ internal API changes are not present.
 Unreleased
 ----------
 
+1.11.0 (2026-07-20)
+----------
+
 ### Enhancements
 
 - Add `alloy.command` to override the entrypoint command for the Alloy container. This makes it possible to launch the Alloy binary from its image path when running as a HostProcess container on Windows nodes. (@petewall)
+
+- Update to Grafana Alloy v1.18.0 (@blewis12)
 
 1.10.1 (2026-06-29)
 ----------

--- a/operations/helm/charts/alloy/Chart.yaml
+++ b/operations/helm/charts/alloy/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: alloy
 description: "Grafana Alloy"
 type: application
-version: 1.10.1
-appVersion: "v1.17.1"
+version: 1.11.0
+appVersion: "v1.18.0"
 icon: https://raw.githubusercontent.com/grafana/alloy/main/docs/sources/assets/alloy_icon_orange.svg
 
 dependencies:

--- a/operations/helm/charts/alloy/README.md
+++ b/operations/helm/charts/alloy/README.md
@@ -1,6 +1,6 @@
 # Grafana Alloy Helm chart
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 1.10.1](https://img.shields.io/badge/Version-1.10.1-informational?style=flat-square) ![AppVersion: v1.17.1](https://img.shields.io/badge/AppVersion-v1.17.1-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 1.11.0](https://img.shields.io/badge/Version-1.11.0-informational?style=flat-square) ![AppVersion: v1.18.0](https://img.shields.io/badge/AppVersion-v1.18.0-informational?style=flat-square)
 
 Helm chart for deploying [Grafana Alloy][] to Kubernetes.
 

--- a/operations/helm/tests/additional-serviceaccount-label/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/additional-serviceaccount-label/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/clustering/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/clustering/alloy/templates/controllers/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/configmap-key/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/configmap-key/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/controller-deployment-pdb-max-unavailable/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/controller-deployment-pdb-max-unavailable/alloy/templates/controllers/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/controller-deployment-pdb-min-available/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/controller-deployment-pdb-min-available/alloy/templates/controllers/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/controller-extraLabels-label/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/controller-extraLabels-label/alloy/templates/controllers/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/controller-max-revison-history/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/controller-max-revison-history/alloy/templates/controllers/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/controller-statefulset-pdb-max-unavailable/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/controller-statefulset-pdb-max-unavailable/alloy/templates/controllers/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/controller-statefulset-pdb-min-available/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/controller-statefulset-pdb-min-available/alloy/templates/controllers/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/controller-volumes-extra/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/controller-volumes-extra/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-daemonset-hostnetwork/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset-hostnetwork/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-daemonset/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-deployment-autoscaling/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment-autoscaling/alloy/templates/controllers/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-deployment-external-hpa/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment-external-hpa/alloy/templates/controllers/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-deployment/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment/alloy/templates/controllers/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-networkpolicy/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-networkpolicy/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-statefulset-autoscaling/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset-autoscaling/alloy/templates/controllers/statefulset.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-statefulset-external-hpa/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset-external-hpa/alloy/templates/controllers/statefulset.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-statefulset-vertical-autoscaling/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset-vertical-autoscaling/alloy/templates/controllers/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-statefulset/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset/alloy/templates/controllers/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/custom-config/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/custom-config/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/default-values/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/default-values/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/disable-http-server-port/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/disable-http-server-port/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/enable-servicemonitor-tls/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/enable-servicemonitor-tls/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/enable-servicemonitor/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/enable-servicemonitor/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/engine-flags/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/engine-flags/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/envFrom/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/envFrom/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/existing-config/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/existing-config/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/extra-env/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-env/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/extra-manifests/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-manifests/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/extra-ports/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-ports/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/faro-ingress/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/faro-ingress/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/global-image-pullpolicy/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/global-image-pullpolicy/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: Always
           args:
             - run

--- a/operations/helm/tests/global-image-pullsecrets/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/global-image-pullsecrets/alloy/templates/controllers/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         - name: global-cred
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/global-image-registry/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/global-image-registry/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: quay.io/grafana/alloy:v1.17.1
+          image: quay.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/host-alias/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/host-alias/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/initcontainers/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/initcontainers/alloy/templates/controllers/daemonset.yaml
@@ -46,7 +46,7 @@ spec:
             name: geoip
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/lifecycle-hooks/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/lifecycle-hooks/alloy/templates/controllers/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/livinessprobe/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/livinessprobe/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/local-image-pullsecrets/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/local-image-pullsecrets/alloy/templates/controllers/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         - name: local-cred
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/local-image-registry/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/local-image-registry/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: quay.io/grafana/alloy:v1.17.1
+          image: quay.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/nodeselectors-and-tolerations/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/nodeselectors-and-tolerations/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/nonroot/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/nonroot/alloy/templates/controllers/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/pod_annotations/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/pod_annotations/alloy/templates/controllers/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/rbac-empty-rules/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/rbac-empty-rules/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/rbac-rules/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/rbac-rules/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/readinessprobe/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/readinessprobe/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/roles-and-rolebindings/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/roles-and-rolebindings/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/service-external-traffic-policy/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/service-external-traffic-policy/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/sidecars/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/sidecars/alloy/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/termination-grace-period/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/termination-grace-period/alloy/templates/controllers/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/topologyspreadconstraints/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/topologyspreadconstraints/alloy/templates/controllers/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.17.1
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run


### PR DESCRIPTION
### Pull Request Details
Bumps the pinned version of Alloy in the helm chart to `v1.18.0`, after this we can tag/release alloy helm chart v1.11.0

BEGIN_COMMIT_OVERRIDE
chore: Bump Alloy Version to v1.18.0 in Helm Chart (#6722)
END_COMMIT_OVERRIDE