### PR TITLE
docs: Clarify Probe prober path for blackbox-style scrapes

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.operator.probes.md
+++ b/docs/sources/reference/components/prometheus/prometheus.operator.probes.md
@@ -254,6 +254,85 @@ prometheus.operator.probes "probes" {
 }
 ```
 
+### Probe with {{< param "PRODUCT_NAME" >}} as the blackbox prober
+
+`prometheus.operator.probes` scrapes Probe targets by calling a prober (typically blackbox exporter).
+{{< param "PRODUCT_NAME" >}} can act as that prober when you also configure [`prometheus.exporter.blackbox`][blackbox].
+You don't need a separate blackbox-exporter Deployment unless you prefer one.
+
+The Probe resource must set `spec.prober`:
+
+* `url` — host:port of the prober. For the embedded exporter, use the {{< param "PRODUCT_NAME" >}} HTTP listen address (default port `12345`).
+* `path` — HTTP path of the blackbox probe endpoint on that prober.
+
+For `prometheus.exporter.blackbox`, {{< param "PRODUCT_NAME" >}} exposes the prober on the component HTTP API:
+
+```text
+/api/v0/component/prometheus.exporter.blackbox.<LABEL>/probe
+```
+
+The handler is the same for any trailing path segment under the component (including `/metrics`); `/probe` matches the conventional blackbox-exporter path and is recommended.
+
+The following end-to-end example assumes:
+
+* {{< param "PRODUCT_NAME" >}} is running in the `monitoring` namespace.
+* Its Service is `alloy.monitoring.svc.cluster.local:12345`.
+* The blackbox exporter component label is `blackbox_exporter`.
+* Probe resources live in the `testns` namespace.
+
+{{< param "PRODUCT_NAME" >}} configuration:
+
+```alloy
+prometheus.exporter.blackbox "blackbox_exporter" {
+  // Either config or config_file is required. This defines the blackbox modules
+  // referenced by Probe resources (for example module: http_2xx).
+  config = "{ modules: { http_2xx: { prober: http, timeout: 5s } } }"
+}
+
+prometheus.operator.probes "blackbox" {
+  namespaces = ["testns"]
+  forward_to = [prometheus.remote_write.staging.receiver]
+}
+
+prometheus.remote_write "staging" {
+  endpoint {
+    url = "http://mimir:9009/api/v1/push"
+  }
+}
+```
+
+Matching Kubernetes Probe resource:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: http-grafana
+  namespace: testns
+spec:
+  jobName: blackbox
+  interval: 30s
+  module: http_2xx
+  prober:
+    # Address of Alloy (not a separate blackbox-exporter pod).
+    url: alloy.monitoring.svc.cluster.local:12345
+    # Component HTTP API path for prometheus.exporter.blackbox.blackbox_exporter.
+    path: /api/v0/component/prometheus.exporter.blackbox.blackbox_exporter/probe
+  targets:
+    staticConfig:
+      static:
+        - https://grafana.com
+```
+
+Notes:
+
+* `spec.prober.url` is required. Pointing it at the Alloy UI root without the component path (for example only `localhost:12345` with path `/probe`) scrapes the wrong endpoint and fails with a non-Prometheus response.
+* The `module` field on the Probe must match a module name defined in the `prometheus.exporter.blackbox` `config` or `config_file`.
+* No extra container port is required beyond Alloy's existing HTTP listen port (default `12345`), which must be reachable from the Alloy process that runs `prometheus.operator.probes` (often the same process).
+* Alternatively, set `spec.prober.url` to a standalone [blackbox_exporter](https://github.com/prometheus/blackbox_exporter) Service and use `path: /probe`.
+
+[blackbox]: ../prometheus.exporter.blackbox/
+
 <!-- START GENERATED COMPATIBLE COMPONENTS -->
 
 ## Compatible components

--- a/docs/sources/reference/components/prometheus/prometheus.operator.probes.md
+++ b/docs/sources/reference/components/prometheus/prometheus.operator.probes.md
@@ -258,11 +258,12 @@ prometheus.operator.probes "probes" {
 
 `prometheus.operator.probes` scrapes Probe targets by calling a prober (typically blackbox exporter).
 {{< param "PRODUCT_NAME" >}} can act as that prober when you also configure [`prometheus.exporter.blackbox`][blackbox].
-You don't need a separate blackbox-exporter Deployment unless you prefer one.
+Configure {{< param "PRODUCT_NAME" >}} as your prober to eliminate the need for a separate blackbox-exporter deployment.
 
 Set `spec.prober.url` to the {{< param "PRODUCT_NAME" >}} HTTP listen address.
 Set `spec.prober.path` to the prober endpoint path.
-For blackbox-style probers, the `/probe` endpoint returns probe metrics, while `/metrics` exposes exporter operational metrics.
+For blackbox-style probers, the `/probe` endpoint returns probe metrics.
+The `/metrics` exposes exporter operational metrics.
 
 For `prometheus.exporter.blackbox`, use the component HTTP API path:
 

--- a/docs/sources/reference/components/prometheus/prometheus.operator.probes.md
+++ b/docs/sources/reference/components/prometheus/prometheus.operator.probes.md
@@ -272,8 +272,6 @@ For `prometheus.exporter.blackbox`, use the component HTTP API path:
 
 The `module` field on the Probe must match a module name defined in the `prometheus.exporter.blackbox` `config` or `config_file`.
 
-Runnable end-to-end examples that need Kubernetes and the Prometheus Operator belong in [alloy-scenarios](https://github.com/grafana/alloy-scenarios) rather than this reference page. See the [contribute guide](https://github.com/grafana/alloy-scenarios#contribute).
-
 [blackbox]: ../prometheus.exporter.blackbox/
 
 <!-- START GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/reference/components/prometheus/prometheus.operator.probes.md
+++ b/docs/sources/reference/components/prometheus/prometheus.operator.probes.md
@@ -260,16 +260,16 @@ prometheus.operator.probes "probes" {
 {{< param "PRODUCT_NAME" >}} can act as that prober when you also configure [`prometheus.exporter.blackbox`][blackbox].
 You don't need a separate blackbox-exporter Deployment unless you prefer one.
 
-Set `spec.prober` on the Probe resource:
+Set `spec.prober.url` to the {{< param "PRODUCT_NAME" >}} HTTP listen address.
+Set `spec.prober.path` to the prober endpoint path.
+For blackbox-style probers, the `/probe` endpoint returns probe metrics, while `/metrics` exposes exporter operational metrics.
 
-* `url` — host:port of the prober. For the embedded exporter, use the {{< param "PRODUCT_NAME" >}} HTTP listen address (default port `12345`).
-* `path` — HTTP path of the blackbox probe endpoint. For `prometheus.exporter.blackbox`, use:
+For `prometheus.exporter.blackbox`, use the component HTTP API path:
 
 ```text
 /api/v0/component/prometheus.exporter.blackbox.<LABEL>/probe
 ```
 
-Pointing `spec.prober.url` at the {{< param "PRODUCT_NAME" >}} UI root without the component path scrapes the wrong endpoint and fails with a non-Prometheus response.
 The `module` field on the Probe must match a module name defined in the `prometheus.exporter.blackbox` `config` or `config_file`.
 
 Runnable end-to-end examples that need Kubernetes and the Prometheus Operator belong in [alloy-scenarios](https://github.com/grafana/alloy-scenarios) rather than this reference page. See the [contribute guide](https://github.com/grafana/alloy-scenarios#contribute).

--- a/docs/sources/reference/components/prometheus/prometheus.operator.probes.md
+++ b/docs/sources/reference/components/prometheus/prometheus.operator.probes.md
@@ -260,76 +260,19 @@ prometheus.operator.probes "probes" {
 {{< param "PRODUCT_NAME" >}} can act as that prober when you also configure [`prometheus.exporter.blackbox`][blackbox].
 You don't need a separate blackbox-exporter Deployment unless you prefer one.
 
-The Probe resource must set `spec.prober`:
+Set `spec.prober` on the Probe resource:
 
 * `url` — host:port of the prober. For the embedded exporter, use the {{< param "PRODUCT_NAME" >}} HTTP listen address (default port `12345`).
-* `path` — HTTP path of the blackbox probe endpoint on that prober.
-
-For `prometheus.exporter.blackbox`, {{< param "PRODUCT_NAME" >}} exposes the prober on the component HTTP API:
+* `path` — HTTP path of the blackbox probe endpoint. For `prometheus.exporter.blackbox`, use:
 
 ```text
 /api/v0/component/prometheus.exporter.blackbox.<LABEL>/probe
 ```
 
-The handler is the same for any trailing path segment under the component (including `/metrics`); `/probe` matches the conventional blackbox-exporter path and is recommended.
+Pointing `spec.prober.url` at the {{< param "PRODUCT_NAME" >}} UI root without the component path scrapes the wrong endpoint and fails with a non-Prometheus response.
+The `module` field on the Probe must match a module name defined in the `prometheus.exporter.blackbox` `config` or `config_file`.
 
-The following end-to-end example assumes:
-
-* {{< param "PRODUCT_NAME" >}} is running in the `monitoring` namespace.
-* Its Service is `alloy.monitoring.svc.cluster.local:12345`.
-* The blackbox exporter component label is `blackbox_exporter`.
-* Probe resources live in the `testns` namespace.
-
-{{< param "PRODUCT_NAME" >}} configuration:
-
-```alloy
-prometheus.exporter.blackbox "blackbox_exporter" {
-  // Either config or config_file is required. This defines the blackbox modules
-  // referenced by Probe resources (for example module: http_2xx).
-  config = "{ modules: { http_2xx: { prober: http, timeout: 5s } } }"
-}
-
-prometheus.operator.probes "blackbox" {
-  namespaces = ["testns"]
-  forward_to = [prometheus.remote_write.staging.receiver]
-}
-
-prometheus.remote_write "staging" {
-  endpoint {
-    url = "http://mimir:9009/api/v1/push"
-  }
-}
-```
-
-Matching Kubernetes Probe resource:
-
-```yaml
-apiVersion: monitoring.coreos.com/v1
-kind: Probe
-metadata:
-  name: http-grafana
-  namespace: testns
-spec:
-  jobName: blackbox
-  interval: 30s
-  module: http_2xx
-  prober:
-    # Address of Alloy (not a separate blackbox-exporter pod).
-    url: alloy.monitoring.svc.cluster.local:12345
-    # Component HTTP API path for prometheus.exporter.blackbox.blackbox_exporter.
-    path: /api/v0/component/prometheus.exporter.blackbox.blackbox_exporter/probe
-  targets:
-    staticConfig:
-      static:
-        - https://grafana.com
-```
-
-Notes:
-
-* `spec.prober.url` is required. Pointing it at the Alloy UI root without the component path (for example only `localhost:12345` with path `/probe`) scrapes the wrong endpoint and fails with a non-Prometheus response.
-* The `module` field on the Probe must match a module name defined in the `prometheus.exporter.blackbox` `config` or `config_file`.
-* No extra container port is required beyond Alloy's existing HTTP listen port (default `12345`), which must be reachable from the Alloy process that runs `prometheus.operator.probes` (often the same process).
-* Alternatively, set `spec.prober.url` to a standalone [blackbox_exporter](https://github.com/prometheus/blackbox_exporter) Service and use `path: /probe`.
+Runnable end-to-end examples that need Kubernetes and the Prometheus Operator belong in [alloy-scenarios](https://github.com/grafana/alloy-scenarios) rather than this reference page. See the [contribute guide](https://github.com/grafana/alloy-scenarios#contribute).
 
 [blackbox]: ../prometheus.exporter.blackbox/
 


### PR DESCRIPTION
## What

Add an end-to-end, runnable example for `prometheus.operator.probes` that shows:

1. Enabling `prometheus.exporter.blackbox` as the embedded prober (no separate blackbox-exporter Deployment required)
2. A matching `Probe` CR with `spec.prober.url` and `spec.prober.path` pointed at Alloy's component HTTP API
3. Notes on common misconfiguration (using only the Alloy UI port without the component path)

## Why

The existing docs only showed discovering Probe resources, not what a working `Probe` should look like or how prober URL/path relate to Alloy. Users repeatedly hit this gap (see issue discussion).

Fixes #2333

## Source verification

- Alloy mounts exporter handlers under `/api/v0/component/<component ID>/…` (`internal/service/http/http.go`)
- `prometheus.exporter.blackbox` serves the blackbox prober via `MetricsHandler()` (`internal/static/integrations/blackbox_exporter`)
- Path `/api/v0/component/prometheus.exporter.blackbox.<LABEL>/probe` matches the community-verified setup and conventional blackbox `/probe` path