### PR TITLE
fix: Upgrade go-re2 to v1.12.0 to allow MemoryDenyWriteExecute=true with loki.secretfilter

### DIFF
--- a/collector/go.mod
+++ b/collector/go.mod
@@ -877,7 +877,7 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.480 // indirect
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.0.480 // indirect
-	github.com/tetratelabs/wazero v1.9.0 // indirect
+	github.com/tetratelabs/wazero v1.12.0 // indirect
 	github.com/tg123/go-htpasswd v1.2.4 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.2.0 // indirect
@@ -906,8 +906,8 @@ require (
 	github.com/vincent-petithory/dataurl v1.0.0 // indirect
 	github.com/vmware/govmomi v0.54.0 // indirect
 	github.com/vultr/govultr/v3 v3.31.2 // indirect
-	github.com/wasilibs/go-re2 v1.10.0 // indirect
-	github.com/wasilibs/wazero-helpers v0.0.0-20240620070341-3dff1577cd52 // indirect
+	github.com/wasilibs/go-re2 v1.12.0 // indirect
+	github.com/wasilibs/wazero-helpers v0.0.0-20250123031827-cd30c44769bb // indirect
 	github.com/webdevops/azure-metrics-exporter v0.0.0-20250720221040-5092ac086990 // indirect
 	github.com/webdevops/go-common v0.0.0-20250720220738-a468ce107f36 // indirect
 	github.com/wk8/go-ordered-map v0.2.0 // indirect

--- a/collector/go.sum
+++ b/collector/go.sum
@@ -2364,8 +2364,8 @@ github.com/testcontainers/testcontainers-go/modules/minio v0.34.0 h1:OpUqT7VV/d+
 github.com/testcontainers/testcontainers-go/modules/minio v0.34.0/go.mod h1:0iaOtVNCzu04KcXHgmdNE7aelKaMUwC9x1M0oe6h1sw=
 github.com/testcontainers/testcontainers-go/modules/mongodb v0.34.0 h1:o3bgcECyBFfMwqexCH/6vIJ8XzbCffCP/Euesu33rgY=
 github.com/testcontainers/testcontainers-go/modules/mongodb v0.34.0/go.mod h1:ljLR42dN7k40CX0dp30R8BRIB3OOdvr7rBANEpfmMs4=
-github.com/tetratelabs/wazero v1.9.0 h1:IcZ56OuxrtaEz8UYNRHBrUa9bYeX9oVY93KspZZBf/I=
-github.com/tetratelabs/wazero v1.9.0/go.mod h1:TSbcXCfFP0L2FGkRPxHphadXPjo1T6W+CseNNY7EkjM=
+github.com/tetratelabs/wazero v1.12.0 h1:DuWcpNu/FzgEXgGBDp8J1Spc+CWOvvtvVyjKlaZopYU=
+github.com/tetratelabs/wazero v1.12.0/go.mod h1:LvKtzl2RqO4gyF27BiXU+nKAjcV8f38U+kP/q2vgxh0=
 github.com/tg123/go-htpasswd v1.2.4 h1:HgH8KKCjdmo7jjXWN9k1nefPBd7Be3tFCTjc2jPraPU=
 github.com/tg123/go-htpasswd v1.2.4/go.mod h1:EKThQok9xHkun6NBMynNv6Jmu24A33XdZzzl4Q7H1+0=
 github.com/tidwall/gjson v1.10.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
@@ -2447,10 +2447,10 @@ github.com/vmware/govmomi v0.54.0 h1:akEKkM9XKMOhTskmdzTLG8JzH+sh61jbFrVPbAzv5IQ
 github.com/vmware/govmomi v0.54.0/go.mod h1:0F3hChqXDrSQQnjfSiCqRE5lPD4aZlbOtKG4uroq2a4=
 github.com/vultr/govultr/v3 v3.31.2 h1:2l3/KDvfemG+4azw4LLquJoh9mFOAVEdBXtPPzix3ac=
 github.com/vultr/govultr/v3 v3.31.2/go.mod h1:2zyUw9yADQaGwKnwDesmIOlBNLrm7edsCfWHFJpWKf8=
-github.com/wasilibs/go-re2 v1.10.0 h1:vQZEBYZOCA9jdBMmrO4+CvqyCj0x4OomXTJ4a5/urQ0=
-github.com/wasilibs/go-re2 v1.10.0/go.mod h1:k+5XqO2bCJS+QpGOnqugyfwC04nw0jaglmjrrkG8U6o=
-github.com/wasilibs/wazero-helpers v0.0.0-20240620070341-3dff1577cd52 h1:OvLBa8SqJnZ6P+mjlzc2K7PM22rRUPE1x32G9DTPrC4=
-github.com/wasilibs/wazero-helpers v0.0.0-20240620070341-3dff1577cd52/go.mod h1:jMeV4Vpbi8osrE/pKUxRZkVaA0EX7NZN0A9/oRzgpgY=
+github.com/wasilibs/go-re2 v1.12.0 h1:sq3A6ZOqT90HYY25MD5/cG8Xv6uT2AhmPgBfkCfhp10=
+github.com/wasilibs/go-re2 v1.12.0/go.mod h1:2W+7GrrdO4NHv7ITHz8Yy3a1IxzjZCk8JR5zgTprxZs=
+github.com/wasilibs/wazero-helpers v0.0.0-20250123031827-cd30c44769bb h1:gQ+ZV4wJke/EBKYciZ2MshEouEHFuinB85dY3f5s1q8=
+github.com/wasilibs/wazero-helpers v0.0.0-20250123031827-cd30c44769bb/go.mod h1:jMeV4Vpbi8osrE/pKUxRZkVaA0EX7NZN0A9/oRzgpgY=
 github.com/webdevops/azure-metrics-exporter v0.0.0-20250720221040-5092ac086990 h1:lZ2FF6ftDgcG9ntn81MTnjMeIRpQjQklUUscMfPqGLA=
 github.com/webdevops/azure-metrics-exporter v0.0.0-20250720221040-5092ac086990/go.mod h1:N7UMt8u3vundNaXHTtJgQRII4/LnLhx+1KoN3NTzAeY=
 github.com/webdevops/go-common v0.0.0-20250720220738-a468ce107f36 h1:N7tsRqWOSeYvtgioX4G9X5FpqiiwXadI7tzybv+IUAU=

--- a/go.mod
+++ b/go.mod
@@ -1084,12 +1084,12 @@ require (
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
-	github.com/tetratelabs/wazero v1.9.0 // indirect
+	github.com/tetratelabs/wazero v1.12.0 // indirect
 	github.com/ulikunitz/xz v0.5.15 // indirect
 	github.com/urfave/cli/v3 v3.9.0 // indirect
 	github.com/vultr/govultr/v3 v3.31.2 // indirect
-	github.com/wasilibs/go-re2 v1.10.0 // indirect
-	github.com/wasilibs/wazero-helpers v0.0.0-20240620070341-3dff1577cd52 // indirect
+	github.com/wasilibs/go-re2 v1.12.0 // indirect
+	github.com/wasilibs/wazero-helpers v0.0.0-20250123031827-cd30c44769bb // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.153.0 // indirect
 	go4.org v0.0.0-20230225012048-214862532bf5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2385,8 +2385,8 @@ github.com/testcontainers/testcontainers-go/modules/minio v0.34.0 h1:OpUqT7VV/d+
 github.com/testcontainers/testcontainers-go/modules/minio v0.34.0/go.mod h1:0iaOtVNCzu04KcXHgmdNE7aelKaMUwC9x1M0oe6h1sw=
 github.com/testcontainers/testcontainers-go/modules/mongodb v0.34.0 h1:o3bgcECyBFfMwqexCH/6vIJ8XzbCffCP/Euesu33rgY=
 github.com/testcontainers/testcontainers-go/modules/mongodb v0.34.0/go.mod h1:ljLR42dN7k40CX0dp30R8BRIB3OOdvr7rBANEpfmMs4=
-github.com/tetratelabs/wazero v1.9.0 h1:IcZ56OuxrtaEz8UYNRHBrUa9bYeX9oVY93KspZZBf/I=
-github.com/tetratelabs/wazero v1.9.0/go.mod h1:TSbcXCfFP0L2FGkRPxHphadXPjo1T6W+CseNNY7EkjM=
+github.com/tetratelabs/wazero v1.12.0 h1:DuWcpNu/FzgEXgGBDp8J1Spc+CWOvvtvVyjKlaZopYU=
+github.com/tetratelabs/wazero v1.12.0/go.mod h1:LvKtzl2RqO4gyF27BiXU+nKAjcV8f38U+kP/q2vgxh0=
 github.com/tg123/go-htpasswd v1.2.4 h1:HgH8KKCjdmo7jjXWN9k1nefPBd7Be3tFCTjc2jPraPU=
 github.com/tg123/go-htpasswd v1.2.4/go.mod h1:EKThQok9xHkun6NBMynNv6Jmu24A33XdZzzl4Q7H1+0=
 github.com/tidwall/gjson v1.10.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
@@ -2470,10 +2470,10 @@ github.com/vmware/govmomi v0.54.0 h1:akEKkM9XKMOhTskmdzTLG8JzH+sh61jbFrVPbAzv5IQ
 github.com/vmware/govmomi v0.54.0/go.mod h1:0F3hChqXDrSQQnjfSiCqRE5lPD4aZlbOtKG4uroq2a4=
 github.com/vultr/govultr/v3 v3.31.2 h1:2l3/KDvfemG+4azw4LLquJoh9mFOAVEdBXtPPzix3ac=
 github.com/vultr/govultr/v3 v3.31.2/go.mod h1:2zyUw9yADQaGwKnwDesmIOlBNLrm7edsCfWHFJpWKf8=
-github.com/wasilibs/go-re2 v1.10.0 h1:vQZEBYZOCA9jdBMmrO4+CvqyCj0x4OomXTJ4a5/urQ0=
-github.com/wasilibs/go-re2 v1.10.0/go.mod h1:k+5XqO2bCJS+QpGOnqugyfwC04nw0jaglmjrrkG8U6o=
-github.com/wasilibs/wazero-helpers v0.0.0-20240620070341-3dff1577cd52 h1:OvLBa8SqJnZ6P+mjlzc2K7PM22rRUPE1x32G9DTPrC4=
-github.com/wasilibs/wazero-helpers v0.0.0-20240620070341-3dff1577cd52/go.mod h1:jMeV4Vpbi8osrE/pKUxRZkVaA0EX7NZN0A9/oRzgpgY=
+github.com/wasilibs/go-re2 v1.12.0 h1:sq3A6ZOqT90HYY25MD5/cG8Xv6uT2AhmPgBfkCfhp10=
+github.com/wasilibs/go-re2 v1.12.0/go.mod h1:2W+7GrrdO4NHv7ITHz8Yy3a1IxzjZCk8JR5zgTprxZs=
+github.com/wasilibs/wazero-helpers v0.0.0-20250123031827-cd30c44769bb h1:gQ+ZV4wJke/EBKYciZ2MshEouEHFuinB85dY3f5s1q8=
+github.com/wasilibs/wazero-helpers v0.0.0-20250123031827-cd30c44769bb/go.mod h1:jMeV4Vpbi8osrE/pKUxRZkVaA0EX7NZN0A9/oRzgpgY=
 github.com/webdevops/azure-metrics-exporter v0.0.0-20250720221040-5092ac086990 h1:lZ2FF6ftDgcG9ntn81MTnjMeIRpQjQklUUscMfPqGLA=
 github.com/webdevops/azure-metrics-exporter v0.0.0-20250720221040-5092ac086990/go.mod h1:N7UMt8u3vundNaXHTtJgQRII4/LnLhx+1KoN3NTzAeY=
 github.com/webdevops/go-common v0.0.0-20250720220738-a468ce107f36 h1:N7tsRqWOSeYvtgioX4G9X5FpqiiwXadI7tzybv+IUAU=


### PR DESCRIPTION
### Brief description of Pull Request

Upgrade `github.com/wasilibs/go-re2` from v1.10.0 to v1.12.0 in the root and `collector/` modules. This transitively upgrades `github.com/tetratelabs/wazero` v1.9.0 -> v1.12.0 and `github.com/wasilibs/wazero-helpers` to the matching release. No Alloy source changes; only `go.mod` / `go.sum` in both modules.

Why: go-re2 v1.10.0 pins wazero v1.9.0, which maps WebAssembly executable memory as writable+executable in a single mmap. Under systemd hardening with `MemoryDenyWriteExecute=true` that mmap is denied, so Alloy binaries built with the `gore2regex` tag (the Makefile default) panic at startup with `panic: operation not permitted` in `wazevo.mmapExecutable` as soon as a `loki.secretfilter` component is configured (#6697, also reported earlier in #6289). wazero v1.10.1 maps the region writable first, then remaps it executable and non-writable (tetratelabs/wazero b94a430). go-re2 v1.11.0+ requires that fixed wazero; the issue reporter confirmed v1.12.0 clears the panic on Linux.

Verification:
- `go get github.com/wasilibs/go-re2@v1.12.0` + `go mod tidy` in root and `collector/`; only go-re2 / wazero / wazero-helpers lines changed
- `make generate-otel-collector-distro` after the bump: no extra diff
- `go test -tags gore2regex -race ./internal/component/loki/secretfilter/... -count=1`: pass
- `SKIP_UI_BUILD=1 make alloy` (with `gore2regex`): build ok
- Smoke on the built binary with the #6697 repro config (`loki.secretfilter "secret_filter" { forward_to = [] }`, `--stability.level experimental`): component loads, no panic. This was on macOS, so it does not exercise systemd `MemoryDenyWriteExecute=true` itself; that path relies on the wazero W^X fix plus the reporter’s Linux check of v1.12.0.

### Pull Request Details

#6697 is a startup panic under common systemd hardening, not a misconfiguration of Alloy. Default builds enable `gore2regex`, so anyone who turns on `loki.secretfilter` and runs with `MemoryDenyWriteExecute=true` can hit it.

I treated this as a dependency fix rather than an Alloy code change. Options I considered:

1. **Bump go-re2 (and thus wazero)** to a release that already does proper W^X mapping — preferred, stays on upstream releases.
2. Force a newer wazero via `replace` / manual pin without moving go-re2 — more fragile and easy to drift from what go-re2 tests against.
3. Document “turn off MDWE or don’t use secretfilter” — does not fix the real bug for default builds.

Went with (1) at v1.12.0 (latest stable the reporter already validated). Root and `collector/` both depend on go-re2, so both modules were updated together so the tree stays consistent. No config, docs, or converter surface changes.

Local limits: I cannot reproduce the systemd MDWE denial on macOS. What I did verify here is tidy/build, secretfilter tests with the `gore2regex` tag, and a smoke run that the component still loads. Confidence on the actual MDWE fix comes from the wazero change and the issue reporter’s Linux confirmation of go-re2 v1.12.0.

### Issue(s) fixed by this Pull Request

Fixes #6697

### Notes to the Reviewer

- Diff should be **only** root + `collector/` `go.mod` / `go.sum` (go-re2, wazero, wazero-helpers).
- `make generate-otel-collector-distro` was re-run after the bump and produced no additional changes.
- I did not add new tests; existing `loki/secretfilter` tests with `-tags gore2regex` cover the gitleaks → go-re2 → wazero path under the new versions.
- If you want a second confirmation on a Linux box with `MemoryDenyWriteExecute=true`, I can try to arrange that — happy to follow up.

### PR Checklist

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))