### PR TITLE
docs: Document password_file reload behavior for basic_auth

### DIFF
--- a/docs/sources/reference/components/otelcol/otelcol.auth.basic.md
+++ b/docs/sources/reference/components/otelcol/otelcol.auth.basic.md
@@ -69,15 +69,20 @@ You can use the following block with `otelcol.auth.basic`:
 
 The `client_auth` block configures credentials that client extensions (such as exporters) use to authenticate to servers.
 
-| Name            | Type     | Description                                                                       | Default | Required |
-| --------------- | -------- | --------------------------------------------------------------------------------- | ------- | -------- |
-| `password`      | `secret` | Password to use for basic authentication requests.                                | `""`    | no       |
-| `password_file` | `string` | Path to a file containing the password. If set, takes precedence over `password`. | `""`    | no       |
-| `username`      | `string` | Username to use for basic authentication requests.                                | `""`    | no       |
-| `username_file` | `string` | Path to a file containing the username. If set, takes precedence over `username`. | `""`    | no       |
+| Name            | Type     | Description                                                                                                                    | Default | Required |
+| --------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ | ------- | -------- |
+| `password`      | `secret` | Password to use for basic authentication requests.                                                                             | `""`    | no       |
+| `password_file` | `string` | Path to a file containing the password. If set, takes precedence over `password`. The file is watched and reloaded on change.  | `""`    | no       |
+| `username`      | `string` | Username to use for basic authentication requests.                                                                             | `""`    | no       |
+| `username_file` | `string` | Path to a file containing the username. If set, takes precedence over `username`. The file is watched and reloaded on change.  | `""`    | no       |
 
 {{< admonition type="note" >}}
 When you specify both the `client_auth` block and the deprecated top-level `username` and `password` attributes, the `client_auth` block takes precedence and {{< param "PRODUCT_NAME" >}} ignores the top-level attributes for client authentication.
+{{< /admonition >}}
+
+{{< admonition type="note" >}}
+`client_auth` `password_file` and `username_file` are watched for changes by the upstream basicauth extension.
+This differs from the shared `basic_auth` block used by most non-OpenTelemetry components, which reads `password_file` on every outgoing request.
 {{< /admonition >}}
 
 ### `debug_metrics`

--- a/docs/sources/reference/components/otelcol/otelcol.auth.basic.md
+++ b/docs/sources/reference/components/otelcol/otelcol.auth.basic.md
@@ -69,20 +69,21 @@ You can use the following block with `otelcol.auth.basic`:
 
 The `client_auth` block configures credentials that client extensions (such as exporters) use to authenticate to servers.
 
-| Name            | Type     | Description                                                                                                                    | Default | Required |
-| --------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ | ------- | -------- |
-| `password`      | `secret` | Password to use for basic authentication requests.                                                                             | `""`    | no       |
-| `password_file` | `string` | Path to a file containing the password. If set, takes precedence over `password`. The file is watched and reloaded on change.  | `""`    | no       |
-| `username`      | `string` | Username to use for basic authentication requests.                                                                             | `""`    | no       |
-| `username_file` | `string` | Path to a file containing the username. If set, takes precedence over `username`. The file is watched and reloaded on change.  | `""`    | no       |
+| Name            | Type     | Description                                        | Default | Required |
+| --------------- | -------- | -------------------------------------------------- | ------- | -------- |
+| `password`      | `secret` | Password to use for basic authentication requests. | `""`    | no       |
+| `password_file` | `string` | Path to a file that contains the password.         | `""`    | no       |
+| `username`      | `string` | Username to use for basic authentication requests. | `""`    | no       |
+| `username_file` | `string` | Path to a file that contains the username.         | `""`    | no       |
+
+If you set both `password` and `password_file`, `password_file` takes precedence.
+
+If you set both `username` and `username_file`, `username_file` takes precedence.
+
+In `client_auth`, the OpenTelemetry Collector `basicauth` extension watches `password_file` and `username_file` and reloads them on change. In most non-OpenTelemetry components, `password_file` is read on every outgoing request.
 
 {{< admonition type="note" >}}
 When you specify both the `client_auth` block and the deprecated top-level `username` and `password` attributes, the `client_auth` block takes precedence and {{< param "PRODUCT_NAME" >}} ignores the top-level attributes for client authentication.
-{{< /admonition >}}
-
-{{< admonition type="note" >}}
-`client_auth` `password_file` and `username_file` are watched for changes by the upstream basicauth extension.
-This differs from the shared `basic_auth` block used by most non-OpenTelemetry components, which reads `password_file` on every outgoing request.
 {{< /admonition >}}
 
 ### `debug_metrics`

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.elasticsearch.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.elasticsearch.md
@@ -72,6 +72,10 @@ You can use the following block with `prometheus.exporter.elasticsearch`:
 
 {{< docs/shared lookup="reference/components/basic-auth-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
+{{< admonition type="note" >}}
+Unlike most components that use this block, `prometheus.exporter.elasticsearch` reads `password_file` once when the component starts or reloads its configuration, not on every outgoing request.
+{{< /admonition >}}
+
 ## Exported fields
 
 {{< docs/shared lookup="reference/components/exporter-component-exports.md" source="alloy" version="<ALLOY_VERSION>" >}}

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.elasticsearch.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.elasticsearch.md
@@ -73,7 +73,8 @@ You can use the following block with `prometheus.exporter.elasticsearch`:
 {{< docs/shared lookup="reference/components/basic-auth-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 {{< admonition type="note" >}}
-Unlike most components that use this block, `prometheus.exporter.elasticsearch` reads `password_file` once when the component starts or reloads its configuration, not on every outgoing request.
+`prometheus.exporter.elasticsearch` reads `password_file` once when it starts or reloads its configuration.
+It doesn't read the file on every outgoing request.
 {{< /admonition >}}
 
 ## Exported fields

--- a/docs/sources/shared/reference/components/basic-auth-block.md
+++ b/docs/sources/shared/reference/components/basic-auth-block.md
@@ -4,15 +4,28 @@ description: Shared content, basic auth block
 headless: true
 ---
 
-| Name            | Type     | Description                              | Default | Required |
-| --------------- | -------- | ---------------------------------------- | ------- | -------- |
-| `password_file` | `string` | File containing the basic auth password. |         | no       |
-| `password`      | `secret` | Basic auth password.                     |         | no       |
-| `username`      | `string` | Basic auth username.                     |         | no       |
+| Name            | Type     | Description                                                                                             | Default | Required |
+| --------------- | -------- | ------------------------------------------------------------------------------------------------------- | ------- | -------- |
+| `password_file` | `string` | File containing the basic auth password. Read on every outgoing request that uses basic authentication. |         | no       |
+| `password`      | `secret` | Basic auth password.                                                                                    |         | no       |
+| `username`      | `string` | Basic auth username.                                                                                    |         | no       |
 
 `password` and `password_file` are mutually exclusive, and only one can be provided inside a `basic_auth` block.
 
+This shared `basic_auth` block has the same arguments and the same `password_file` reload behavior in every component that embeds it, unless a component page documents an exception.
+
 {{< admonition type="warning" >}}
-Using `password_file` causes the file to be read on every outgoing request.
-Use the `local.file` component with the `password` attribute instead to avoid unnecessary reads.
+Using `password_file` causes the file to be read on every outgoing request. The file isn't limited to a one-time read at startup, so password rotation is picked up automatically, but high-frequency scrapes or writes re-read the file often.
+
+Prefer the `local.file` component with the `password` attribute when you want fewer filesystem reads. `local.file` watches the file for changes and exports the latest content:
+
+```alloy
+local.file "basic_auth_password" {
+  filename  = "/path/to/password"
+  is_secret = true
+}
+
+// Inside a basic_auth block:
+// password = local.file.basic_auth_password.content
+```
 {{< /admonition >}}

--- a/docs/sources/shared/reference/components/basic-auth-block.md
+++ b/docs/sources/shared/reference/components/basic-auth-block.md
@@ -4,28 +4,21 @@ description: Shared content, basic auth block
 headless: true
 ---
 
-| Name            | Type     | Description                                                                                             | Default | Required |
-| --------------- | -------- | ------------------------------------------------------------------------------------------------------- | ------- | -------- |
-| `password_file` | `string` | File containing the basic auth password. Read on every outgoing request that uses basic authentication. |         | no       |
-| `password`      | `secret` | Basic auth password.                                                                                    |         | no       |
-| `username`      | `string` | Basic auth username.                                                                                    |         | no       |
+| Name            | Type     | Description                                           | Default | Required |
+| --------------- | -------- | ----------------------------------------------------- | ------- | -------- |
+| `password_file` | `string` | Path to a file that contains the basic auth password. |         | no       |
+| `password`      | `secret` | Basic auth password.                                  |         | no       |
+| `username`      | `string` | Basic auth username.                                  |         | no       |
 
 `password` and `password_file` are mutually exclusive, and only one can be provided inside a `basic_auth` block.
 
-This shared `basic_auth` block has the same arguments and the same `password_file` reload behavior in every component that embeds it, unless a component page documents an exception.
+If you set `password_file`, {{< param "PRODUCT_NAME" >}} reads the file on every outgoing request that uses basic authentication.
+{{< param "PRODUCT_NAME" >}} reads the file on each request, so it picks up password rotation automatically.
 
-{{< admonition type="warning" >}}
-Using `password_file` causes the file to be read on every outgoing request. The file isn't limited to a one-time read at startup, so password rotation is picked up automatically, but high-frequency scrapes or writes re-read the file often.
+{{< admonition type="caution" >}}
+If you use `password_file`, {{< param "PRODUCT_NAME" >}} reads the file on every outgoing request.
+Use the `local.file` component with the `password` attribute instead to avoid unnecessary reads.
 
-Prefer the `local.file` component with the `password` attribute when you want fewer filesystem reads. `local.file` watches the file for changes and exports the latest content:
-
-```alloy
-local.file "basic_auth_password" {
-  filename  = "/path/to/password"
-  is_secret = true
-}
-
-// Inside a basic_auth block:
-// password = local.file.basic_auth_password.content
-```
+High scrape or write rates can trigger repeated file reads.
+The `local.file` component watches the file for changes and exports the latest content.
 {{< /admonition >}}

--- a/docs/sources/shared/reference/components/basic-auth-block.md
+++ b/docs/sources/shared/reference/components/basic-auth-block.md
@@ -10,15 +10,14 @@ headless: true
 | `password`      | `secret` | Basic auth password.                                  |         | no       |
 | `username`      | `string` | Basic auth username.                                  |         | no       |
 
+When you use `password_file`, the file is read on every outgoing request that uses basic authentication.
+
 `password` and `password_file` are mutually exclusive, and only one can be provided inside a `basic_auth` block.
 
-If you set `password_file`, {{< param "PRODUCT_NAME" >}} reads the file on every outgoing request that uses basic authentication.
-{{< param "PRODUCT_NAME" >}} reads the file on each request, so it picks up password rotation automatically.
+{{< admonition type="note" >}}
+High scrape or write rates create repeated file reads when you use `password_file`.
+You can use the [`local.file`][local.file] component to read the password file and provide the content to the `password` attribute.
+This avoids repeated file reads because `local.file` monitors the file and only reads when it changes.
 
-{{< admonition type="caution" >}}
-If you use `password_file`, {{< param "PRODUCT_NAME" >}} reads the file on every outgoing request.
-Use the `local.file` component with the `password` attribute instead to avoid unnecessary reads.
-
-High scrape or write rates can trigger repeated file reads.
-The `local.file` component watches the file for changes and exports the latest content.
+[local.file]: https://grafana.com/docs/alloy/<ALLOY_VERSION>/reference/components/local/local.file/
 {{< /admonition >}}

--- a/docs/sources/shared/reference/components/basic-auth-block.md
+++ b/docs/sources/shared/reference/components/basic-auth-block.md
@@ -17,7 +17,7 @@ When you use `password_file`, the file is read on every outgoing request that us
 {{< admonition type="note" >}}
 High scrape or write rates create repeated file reads when you use `password_file`.
 You can use the [`local.file`][local.file] component to read the password file and provide the content to the `password` attribute.
-This avoids repeated file reads because `local.file` monitors the file and only reads when it changes.
+This avoids repeated file reads because `local.file` monitors the file and reads when it changes.
 
 [local.file]: https://grafana.com/docs/alloy/<ALLOY_VERSION>/reference/components/local/local.file/
 {{< /admonition >}}


### PR DESCRIPTION
### Brief description of Pull Request

Document how `password_file` works in the shared `basic_auth` block: it is read on every outgoing request (not only at startup), recommend `local.file` as an alternative with an example, and note that this behavior is shared by components that embed the block. Call out exceptions for `prometheus.exporter.elasticsearch` (read once on start/reload) and `otelcol.auth.basic` (file watched and reloaded on change).

### Pull Request Details

Issue #2188 asked three things: when is `password_file` read, can `local.file` be used instead, and do all components behave the same.

I checked the Prometheus HTTP client path (`FileSecret.Fetch` → `os.ReadFile` on each request) that most Alloy components use for the shared block. That matches the existing one-line warning from #4255, but the docs still left gaps:

1. It never spelled out the startup-vs-request question explicitly.
2. `local.file` was mentioned without a concrete example.
3. Exceptions were not documented.

Verified differences:
- Shared `basic_auth` (prom HTTP client): read on every request
- `prometheus.exporter.elasticsearch`: reads the file once when the exporter is built (start/reload)
- `otelcol.auth.basic` `client_auth`: upstream basicauth watches the credential files and reloads on change

Docs-only change; no code updates.

### Issue(s) fixed by this Pull Request

Fixes #2188

### Notes to the Reviewer

Main edit is the shared `basic-auth-block.md`, so every component page that already includes it picks up the clearer wording and `local.file` example automatically.

The elasticsearch note is intentionally local to that component page so we do not water down the shared “every request” warning for the common path.

Happy to drop the otelcol note if maintainers want this PR scoped only to the shared block.

### PR Checklist

- [x] Documentation added
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))