### PR TITLE
feat(database_observability.sql_server): Add `query_metrics` collector

### DIFF
--- a/docs/sources/reference/components/database_observability/database_observability.sql_server.md
+++ b/docs/sources/reference/components/database_observability/database_observability.sql_server.md
@@ -43,6 +43,7 @@ The following collectors are configurable:
 | Name              | Description                                                  | Enabled by default |
 |-------------------|--------------------------------------------------------------|--------------------|
 | `schema_details`  | Collect schemas and tables from `information_schema`. | yes                |
+| `query_metrics`   | Collect per-query executions, errors, and duration counters from Query Store. | yes                |
 
 ## Blocks
 
@@ -57,12 +58,14 @@ You can use the following blocks with `database_observability.sql_server`:
 | `cloud_provider` > [`azure`][azure]  | Provide Azure database host information.          | no       |
 | `cloud_provider` > [`gcp`][gcp]      | Provide GCP database host information.            | no       |
 | [`schema_details`][schema_details]   | Configure the schema and table details collector. | no       |
+| [`query_metrics`][query_metrics]     | Configure the Query Store metrics collector.      | no       |
 
 [cloud_provider]: #cloud_provider
 [aws]: #aws
 [azure]: #azure
 [gcp]: #gcp
 [schema_details]: #schema_details
+[query_metrics]: #query_metrics
 
 {{< /docs/alloy-config >}}
 
@@ -79,6 +82,7 @@ When you don't configure a `cloud_provider` block, {{< param "PRODUCT_NAME" >}} 
 [aws]: #aws
 [azure]: #azure
 [gcp]: #gcp
+
 ### `aws`
 
 The `aws` block supplies the [ARN](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html) identifier for the database being monitored.
@@ -112,6 +116,28 @@ The `gcp` block supplies the identifying information for the GCP Cloud SQL datab
 | `collect_interval` | `duration` | How frequently to collect information from database. | `"1m"`  | no       |
 
 The collector scans every database that the login can access on the instance and collects schema details from each. Only databases where the login has `CONNECT` access to catalog views are collected.
+
+### `query_metrics`
+
+| Name                  | Type       | Description                                                        | Default | Required |
+|-----------------------|------------|-------------------------------------------------------------------|---------|----------|
+| `collect_interval`    | `duration` | How frequently to collect metrics from Query Store.               | `"1m"`  | no       |
+| `statements_limit`    | `int`      | Maximum number of queries to track, ranked by recent duration.    | `50`   | no       |
+| `statements_lookback` | `duration` | Only queries executed within this window are eligible for tracking.| `"1h"`  | no       |
+
+The `query_metrics` collector reads [Query Store][query-store] for the database selected in the `data_source_name`, not every database on the instance.
+Configure the `data_source_name` to select a user database that has Query Store enabled.
+When the connected database is a system database such as `master`, or Query Store is disabled or read-only, the collector skips collection and remains healthy.
+
+The login requires `VIEW DATABASE STATE` on the connected database. On SQL Server 2022 and later, `VIEW DATABASE PERFORMANCE STATE` is also sufficient.
+
+The collector exports the following counters, each labeled with `database` and `query_hash`:
+
+| Metric                                              | Description                                                      |
+|-----------------------------------------------------|------------------------------------------------------------------|
+| `database_observability_query_executions_total`     | Total number of query executions observed while the query is selected. |
+| `database_observability_query_errors_total`         | Total number of failed executions (aborted or exception) observed while the query is selected. |
+| `database_observability_query_duration_seconds_total`| Total query execution duration in seconds observed while the query is selected. |
 
 ## Example
 

--- a/docs/sources/reference/components/database_observability/database_observability.sql_server.md
+++ b/docs/sources/reference/components/database_observability/database_observability.sql_server.md
@@ -139,6 +139,8 @@ The collector exports the following counters, each labeled with `database` and `
 | `database_observability_query_errors_total`         | Total number of failed executions (aborted or exception) observed while the query is selected. |
 | `database_observability_query_duration_seconds_total`| Total query execution duration in seconds observed while the query is selected. |
 
+[query_store]: https://learn.microsoft.com/sql/relational-databases/performance/monitoring-performance-by-using-the-query-store
+
 ## Example
 
 ```alloy

--- a/internal/component/database_observability/sql_server/collector/query_metrics.go
+++ b/internal/component/database_observability/sql_server/collector/query_metrics.go
@@ -1,0 +1,309 @@
+package collector
+
+import (
+	"context"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/atomic"
+)
+
+const QueryMetricsCollector = "query_metrics"
+
+// selectQueryStoreState reads the connected database's Query Store state
+const selectQueryStoreState = `
+SELECT
+	DB_NAME(),
+	actual_state_desc,
+	query_capture_mode_desc,
+	readonly_reason
+FROM sys.database_query_store_options`
+
+// selectQueryMetrics ranks the top-N queries by duration within the recent lookback
+// window, then sums their full retained Query Store history so the emitted
+// counters stay monotonic across interval rollover.
+//
+// Note: the final SELECT sums the full retained history per ranked hash
+// (no lookback filter on the aggregation), while the lookback window only
+// constrains the top-N ranking/eligibility in the eligible/ranked CTEs.
+// In internal state, on a Query Store bucket rollover (when interval ends),
+// the cumulative totals keep growing → deltas stay non-negative → the
+// Prometheus counters remain monotonic. The only time totals decrease
+// is when Query Store is cleared, or when retention/cleanup drops an old
+// interval: in that case the state re-baselines rather than emitting a spike.
+const selectQueryMetrics = `
+WITH eligible AS (
+	SELECT DISTINCT q.query_hash
+	FROM sys.query_store_query q
+	WHERE q.is_internal_query = 0
+		AND q.query_hash IS NOT NULL
+		AND q.last_execution_time >= DATEADD(SECOND, -CONVERT(int, @lookback_window), SYSUTCDATETIME())
+),
+ranked AS (
+	SELECT TOP (@limit) q.query_hash
+	FROM sys.query_store_query q
+	JOIN eligible e ON e.query_hash = q.query_hash
+	JOIN sys.query_store_plan p ON p.query_id = q.query_id
+	JOIN sys.query_store_runtime_stats rs ON rs.plan_id = p.plan_id
+	JOIN sys.query_store_runtime_stats_interval i
+		ON i.runtime_stats_interval_id = rs.runtime_stats_interval_id
+	WHERE q.is_internal_query = 0
+		AND i.end_time >= DATEADD(SECOND, -CONVERT(int, @lookback_window), SYSUTCDATETIME())
+	GROUP BY q.query_hash
+	ORDER BY SUM(CONVERT(float, rs.avg_duration) * CONVERT(float, rs.count_executions)) DESC,
+		q.query_hash ASC
+)
+SELECT
+	q.query_hash,
+	SUM(CONVERT(bigint, rs.count_executions)) AS executions,
+	SUM(CASE
+		WHEN rs.execution_type IN (3, 4)
+		THEN CONVERT(bigint, rs.count_executions)
+		ELSE 0 END) AS errors,
+	SUM(CONVERT(float, rs.avg_duration) * CONVERT(float, rs.count_executions)) AS total_duration_us
+FROM sys.query_store_query q
+JOIN ranked r ON r.query_hash = q.query_hash
+JOIN sys.query_store_plan p ON p.query_id = q.query_id
+JOIN sys.query_store_runtime_stats rs ON rs.plan_id = p.plan_id
+WHERE q.is_internal_query = 0
+GROUP BY q.query_hash
+ORDER BY q.query_hash ASC`
+
+type QueryMetricsArguments struct {
+	DB              *sql.DB
+	Registry        *prometheus.Registry
+	CollectInterval time.Duration
+	Limit           int
+	Lookback        time.Duration
+	Logger          *slog.Logger
+}
+
+type QueryMetrics struct {
+	dbConnection    *sql.DB
+	registry        *prometheus.Registry
+	collectInterval time.Duration
+	limit           int
+	lookback        time.Duration
+	logger          *slog.Logger
+
+	executionsMetric *prometheus.CounterVec
+	errorsMetric     *prometheus.CounterVec
+	durationMetric   *prometheus.CounterVec
+	metrics          []prometheus.Collector
+	registered       bool
+	state            *queryMetricsState
+
+	running *atomic.Bool
+	ctx     context.Context
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+}
+
+func NewQueryMetrics(args QueryMetricsArguments) (*QueryMetrics, error) {
+	labels := []string{"database", "query_hash"}
+	executionsMetric := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "database_observability",
+		Name:      "query_executions_total",
+		Help:      "The count of query executions by query_hash.",
+	}, labels)
+	errorsMetric := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "database_observability",
+		Name:      "query_errors_total",
+		Help:      "The count of failed query executions by query_hash.",
+	}, labels)
+	durationMetric := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "database_observability",
+		Name:      "query_duration_seconds_total",
+		Help:      "The total query execution duration in seconds by query_hash.",
+	}, labels)
+
+	ttl := args.Lookback
+	if floor := 5 * args.CollectInterval; floor > ttl {
+		ttl = floor
+	}
+
+	return &QueryMetrics{
+		dbConnection:     args.DB,
+		registry:         args.Registry,
+		collectInterval:  args.CollectInterval,
+		limit:            args.Limit,
+		lookback:         args.Lookback,
+		logger:           args.Logger.With("collector", QueryMetricsCollector),
+		executionsMetric: executionsMetric,
+		errorsMetric:     errorsMetric,
+		durationMetric:   durationMetric,
+		metrics:          []prometheus.Collector{executionsMetric, errorsMetric, durationMetric},
+		state:            newQueryMetricsState(executionsMetric, errorsMetric, durationMetric, ttl),
+		running:          atomic.NewBool(false),
+	}, nil
+}
+
+func (c *QueryMetrics) Name() string {
+	return QueryMetricsCollector
+}
+
+func (c *QueryMetrics) Start(ctx context.Context) error {
+	c.logger.Debug("collector started")
+
+	var registered []prometheus.Collector
+	for _, m := range c.metrics {
+		if err := c.registry.Register(m); err != nil {
+			for _, done := range registered {
+				c.registry.Unregister(done)
+			}
+			return fmt.Errorf("failed to register query metrics: %w", err)
+		}
+		registered = append(registered, m)
+	}
+	c.registered = true
+
+	c.running.Store(true)
+	c.ctx, c.cancel = context.WithCancel(ctx)
+
+	c.wg.Go(func() {
+		defer c.running.Store(false)
+
+		ticker := time.NewTicker(c.collectInterval)
+		defer ticker.Stop()
+
+		for {
+			if err := c.collectWithTimeout(c.ctx); err != nil {
+				c.logger.Error("collector error", "err", err)
+			}
+
+			select {
+			case <-c.ctx.Done():
+				return
+			case <-ticker.C:
+				// continue loop
+			}
+		}
+	})
+
+	return nil
+}
+
+func (c *QueryMetrics) Stopped() bool {
+	return !c.running.Load()
+}
+
+func (c *QueryMetrics) Stop() {
+	if c.cancel != nil {
+		c.cancel()
+	}
+	c.wg.Wait()
+	if c.registered {
+		for _, m := range c.metrics {
+			c.registry.Unregister(m)
+		}
+		c.registered = false
+	}
+	c.state.reset()
+}
+
+func (c *QueryMetrics) collectWithTimeout(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	return c.collect(ctx)
+}
+
+func (c *QueryMetrics) collect(ctx context.Context) error {
+	database, ok := c.checkQueryStoreState(ctx)
+	if !ok {
+		// Query Store is unavailable on the connected database, skip this cycle.
+		// Existing counters and baselines are preserved if this is a transient error.
+		return nil
+	}
+
+	sources, err := c.fetchQueryStoreMetrics(ctx, database)
+	if err != nil {
+		return err
+	}
+
+	c.state.update(sources)
+	return nil
+}
+
+// checkQueryStoreState reports whether Query Store is available on the connected database
+// and returns that database's name.
+func (c *QueryMetrics) checkQueryStoreState(ctx context.Context) (string, bool) {
+	var database, actualState, captureMode sql.NullString
+	var readonlyReason sql.NullInt64
+
+	err := c.dbConnection.QueryRowContext(ctx, selectQueryStoreState).
+		Scan(&database, &actualState, &captureMode, &readonlyReason)
+
+	if errors.Is(err, sql.ErrNoRows) {
+		c.logger.Warn("Query Store options are unavailable: the login may lack VIEW DATABASE STATE, or the connected database has no Query Store")
+		return "", false
+	}
+	if err != nil {
+		c.logger.Warn("failed to inspect Query Store state; skipping collection", "err", err)
+		return "", false
+	}
+
+	if state := strings.ToUpper(strings.TrimSpace(actualState.String)); state != "READ_WRITE" {
+		c.logger.Warn("Query Store is not READ_WRITE; skipping collection",
+			"actual_state", actualState.String,
+			"capture_mode", captureMode.String,
+			"readonly_reason", readonlyReason.Int64)
+		return "", false
+	}
+
+	return database.String, true
+}
+
+func (c *QueryMetrics) fetchQueryStoreMetrics(ctx context.Context, database string) ([]queryMetricSource, error) {
+	rows, err := c.dbConnection.QueryContext(ctx, selectQueryMetrics,
+		sql.Named("limit", c.limit),
+		sql.Named("lookback_window", int(c.lookback/time.Second)),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query Query Store metrics: %w", err)
+	}
+	defer rows.Close()
+
+	var sources []queryMetricSource
+	for rows.Next() {
+		var hash []byte
+		var executions, errorExecutions int64
+		var durationMicroseconds float64
+		if err := rows.Scan(&hash, &executions, &errorExecutions, &durationMicroseconds); err != nil {
+			return nil, fmt.Errorf("failed to scan Query Store metrics: %w", err)
+		}
+
+		queryHash, err := formatQueryHash(hash)
+		if err != nil {
+			return nil, err
+		}
+
+		sources = append(sources, queryMetricSource{
+			database:        database,
+			queryHash:       queryHash,
+			executions:      executions,
+			errors:          errorExecutions,
+			durationSeconds: durationMicroseconds / 1e6,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read Query Store metrics: %w", err)
+	}
+
+	return sources, nil
+}
+
+// formatQueryHash formats the Query Store binary(8) query_hash as a fixed
+// 16-character lowercase hex string.
+func formatQueryHash(hash []byte) (string, error) {
+	if len(hash) != 8 {
+		return "", fmt.Errorf("invalid Query Store query hash length %d, expected 8 bytes", len(hash))
+	}
+	return hex.EncodeToString(hash), nil
+}

--- a/internal/component/database_observability/sql_server/collector/query_metrics_state.go
+++ b/internal/component/database_observability/sql_server/collector/query_metrics_state.go
@@ -1,0 +1,135 @@
+package collector
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// queryMetricSource is one query_hash row returned by the Query Store query.
+// The executions/errors/duration values are the cumulative totals retained by
+// Query Store for the query, not per-poll deltas.
+type queryMetricSource struct {
+	database        string
+	queryHash       string
+	executions      int64
+	errors          int64
+	durationSeconds float64
+}
+
+type queryMetricsKey struct {
+	database  string
+	queryHash string
+}
+
+type queryMetricsEntry struct {
+	rawExecutions      int64
+	rawErrors          int64
+	rawDurationSeconds float64
+	lastSeen           time.Time
+}
+
+// queryMetricsState turns the cumulative totals reported by Query Store into
+// monotonic Prometheus counters. Each poll's absolute totals are folded into
+// non-negative deltas; when any total decreases (Query Store cleared, retention
+// or plan cleanup) the series is re-baselined instead of emitting a spurious
+// spike. Series that have not been observed within the TTL window are deleted so
+// registry cardinality stays bounded when a query leaves the top-N.
+type queryMetricsState struct {
+	executions *prometheus.CounterVec
+	errors     *prometheus.CounterVec
+	duration   *prometheus.CounterVec
+
+	entries map[queryMetricsKey]queryMetricsEntry
+	ttl     time.Duration
+	now     func() time.Time
+}
+
+func newQueryMetricsState(executions, errors, duration *prometheus.CounterVec, ttl time.Duration) *queryMetricsState {
+	return &queryMetricsState{
+		executions: executions,
+		errors:     errors,
+		duration:   duration,
+		entries:    make(map[queryMetricsKey]queryMetricsEntry),
+		ttl:        ttl,
+		now:        time.Now,
+	}
+}
+
+// update folds one poll's cumulative totals into the counters and prunes any
+// series that has aged out of the TTL window.
+func (s *queryMetricsState) update(sources []queryMetricSource) {
+	now := s.now()
+
+	for _, source := range sources {
+		key := queryMetricsKey{database: source.database, queryHash: source.queryHash}
+
+		previous, exists := s.entries[key]
+		if !exists {
+			// First sighting: create all three series at zero so downstream
+			// ratios resolve to 0 rather than no-data, and store the baseline
+			// without emitting the historical totals as a startup spike.
+			s.executions.WithLabelValues(source.database, source.queryHash).Add(0)
+			s.errors.WithLabelValues(source.database, source.queryHash).Add(0)
+			s.duration.WithLabelValues(source.database, source.queryHash).Add(0)
+			s.entries[key] = queryMetricsEntry{
+				rawExecutions:      source.executions,
+				rawErrors:          source.errors,
+				rawDurationSeconds: source.durationSeconds,
+				lastSeen:           now,
+			}
+			continue
+		}
+
+		executionsDelta := source.executions - previous.rawExecutions
+		errorsDelta := source.errors - previous.rawErrors
+		durationDelta := source.durationSeconds - previous.rawDurationSeconds
+
+		// A negative delta in any series means Query Store was cleared or pruned
+		// between polls; re-baseline and emit nothing this cycle. Normal interval
+		// rollover never triggers this because the query sums full history.
+		//
+		// NOTE: this is intentionally strict and can potentially "undercount",
+		// but we might relax this in the future. The three series are coupled here:
+		// a decrease in any one skips the increments for all three; e.g. in a case
+		// when an interval that had errors ends while new executions are all successful,
+		// gives errorsDelta < 0 but executionsDelta > 0, dropping all three counts for this cycle.
+		if executionsDelta >= 0 && errorsDelta >= 0 && durationDelta >= 0 {
+			s.executions.WithLabelValues(source.database, source.queryHash).Add(float64(executionsDelta))
+			s.errors.WithLabelValues(source.database, source.queryHash).Add(float64(errorsDelta))
+			s.duration.WithLabelValues(source.database, source.queryHash).Add(durationDelta)
+		}
+
+		s.entries[key] = queryMetricsEntry{
+			rawExecutions:      source.executions,
+			rawErrors:          source.errors,
+			rawDurationSeconds: source.durationSeconds,
+			lastSeen:           now,
+		}
+	}
+
+	s.prune(now)
+}
+
+// prune deletes state and series for hashes not observed within the TTL window.
+// A hash that flaps around the top-N boundary keeps its baseline until then, so
+// activity accrued while it was absent is counted on re-entry.
+func (s *queryMetricsState) prune(now time.Time) {
+	for key, entry := range s.entries {
+		if now.Sub(entry.lastSeen) <= s.ttl {
+			continue
+		}
+		s.executions.DeleteLabelValues(key.database, key.queryHash)
+		s.errors.DeleteLabelValues(key.database, key.queryHash)
+		s.duration.DeleteLabelValues(key.database, key.queryHash)
+		delete(s.entries, key)
+	}
+}
+
+// reset drops all accumulated state and series. Used when the collector stops.
+func (s *queryMetricsState) reset() {
+	s.executions.Reset()
+	s.errors.Reset()
+	s.duration.Reset()
+	clear(s.entries)
+}

--- a/internal/component/database_observability/sql_server/collector/query_metrics_state_test.go
+++ b/internal/component/database_observability/sql_server/collector/query_metrics_state_test.go
@@ -1,0 +1,153 @@
+package collector
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestCounterVecs() (executions, errors, duration *prometheus.CounterVec) {
+	labels := []string{"database", "query_hash"}
+	newVec := func(name string) *prometheus.CounterVec {
+		return prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "database_observability",
+			Name:      name,
+		}, labels)
+	}
+	return newVec("query_executions_total"), newVec("query_errors_total"), newVec("query_duration_seconds_total")
+}
+
+// counterValue reads the value of the single (testDatabase, testHash) series
+// tracked across these tests.
+func counterValue(t *testing.T, vec *prometheus.CounterVec) float64 {
+	t.Helper()
+	metric, err := vec.GetMetricWithLabelValues(testDatabase, testHash)
+	require.NoError(t, err)
+	var out dto.Metric
+	require.NoError(t, metric.Write(&out))
+	return out.Counter.GetValue()
+}
+
+func TestQueryMetricsState_BaselineAndDeltas(t *testing.T) {
+	t.Parallel()
+
+	executions, errCounter, duration := newTestCounterVecs()
+	state := newQueryMetricsState(executions, errCounter, duration, time.Hour)
+
+	// First sighting: series created at zero, historical totals not emitted.
+	state.update([]queryMetricSource{{
+		database: testDatabase, queryHash: testHash, executions: 10, errors: 2, durationSeconds: 5,
+	}})
+	require.Equal(t, 0.0, counterValue(t, executions))
+	require.Equal(t, 0.0, counterValue(t, errCounter))
+	require.Equal(t, 0.0, counterValue(t, duration))
+
+	// Second poll: only the increase is added.
+	state.update([]queryMetricSource{{
+		database: testDatabase, queryHash: testHash, executions: 14, errors: 3, durationSeconds: 8.5,
+	}})
+	require.Equal(t, 4.0, counterValue(t, executions))
+	require.Equal(t, 1.0, counterValue(t, errCounter))
+	require.InDelta(t, 3.5, counterValue(t, duration), 1e-9)
+
+	// Third poll: unchanged totals add nothing.
+	state.update([]queryMetricSource{{
+		database: testDatabase, queryHash: testHash, executions: 14, errors: 3, durationSeconds: 8.5,
+	}})
+	require.Equal(t, 4.0, counterValue(t, executions))
+	require.Equal(t, 1.0, counterValue(t, errCounter))
+	require.InDelta(t, 3.5, counterValue(t, duration), 1e-9)
+}
+
+func TestQueryMetricsState_NegativeDeltaRebaselines(t *testing.T) {
+	t.Parallel()
+
+	executions, errCounter, duration := newTestCounterVecs()
+	state := newQueryMetricsState(executions, errCounter, duration, time.Hour)
+
+	state.update([]queryMetricSource{{database: testDatabase, queryHash: testHash, executions: 100, errors: 10, durationSeconds: 50}})
+	state.update([]queryMetricSource{{database: testDatabase, queryHash: testHash, executions: 130, errors: 12, durationSeconds: 65}})
+	require.Equal(t, 30.0, counterValue(t, executions))
+	require.Equal(t, 2.0, counterValue(t, errCounter))
+	require.InDelta(t, 15.0, counterValue(t, duration), 1e-9)
+
+	// Query Store was cleared/pruned: totals drop. Nothing is added and the
+	// series re-baselines to the new, lower totals.
+	state.update([]queryMetricSource{{database: testDatabase, queryHash: testHash, executions: 5, errors: 1, durationSeconds: 2}})
+	require.Equal(t, 30.0, counterValue(t, executions))
+	require.Equal(t, 2.0, counterValue(t, errCounter))
+	require.InDelta(t, 15.0, counterValue(t, duration), 1e-9)
+
+	// Growth after the reset is measured from the new baseline.
+	state.update([]queryMetricSource{{database: testDatabase, queryHash: testHash, executions: 9, errors: 3, durationSeconds: 6}})
+	require.Equal(t, 34.0, counterValue(t, executions))
+	require.Equal(t, 4.0, counterValue(t, errCounter))
+	require.InDelta(t, 19.0, counterValue(t, duration), 1e-9)
+}
+
+func TestQueryMetricsState_PrunesAfterTTL(t *testing.T) {
+	t.Parallel()
+
+	executions, errCounter, duration := newTestCounterVecs()
+	state := newQueryMetricsState(executions, errCounter, duration, 5*time.Minute)
+
+	now := time.Now()
+	state.now = func() time.Time { return now }
+
+	state.update([]queryMetricSource{{database: testDatabase, queryHash: testHash, executions: 10, errors: 0, durationSeconds: 1}})
+	require.Equal(t, 1, testutil.CollectAndCount(executions))
+
+	// Not seen for longer than the TTL: series and state are dropped.
+	now = now.Add(6 * time.Minute)
+	state.update(nil)
+	require.Equal(t, 0, testutil.CollectAndCount(executions))
+	require.Equal(t, 0, testutil.CollectAndCount(errCounter))
+	require.Equal(t, 0, testutil.CollectAndCount(duration))
+	require.Empty(t, state.entries)
+}
+
+func TestQueryMetricsState_FlappingHashKeepsBaselineWithinTTL(t *testing.T) {
+	t.Parallel()
+
+	executions, errCounter, duration := newTestCounterVecs()
+	state := newQueryMetricsState(executions, errCounter, duration, 10*time.Minute)
+
+	now := time.Now()
+	state.now = func() time.Time { return now }
+
+	state.update([]queryMetricSource{{database: testDatabase, queryHash: testHash, executions: 10, errors: 0, durationSeconds: 1}})
+
+	// Drops out of the top-N for a couple of cycles, but stays within the TTL.
+	now = now.Add(1 * time.Minute)
+	state.update(nil)
+	now = now.Add(1 * time.Minute)
+	state.update(nil)
+	require.Equal(t, 1, testutil.CollectAndCount(executions), "series should be retained within the TTL window")
+
+	// Re-enters the top-N: activity accrued while absent is counted from the
+	// retained baseline, not lost to a re-baseline.
+	now = now.Add(1 * time.Minute)
+	state.update([]queryMetricSource{{database: testDatabase, queryHash: testHash, executions: 25, errors: 4, durationSeconds: 9}})
+	require.Equal(t, 15.0, counterValue(t, executions))
+	require.Equal(t, 4.0, counterValue(t, errCounter))
+	require.InDelta(t, 8.0, counterValue(t, duration), 1e-9)
+}
+
+func TestQueryMetricsState_Reset(t *testing.T) {
+	t.Parallel()
+
+	executions, errCounter, duration := newTestCounterVecs()
+	state := newQueryMetricsState(executions, errCounter, duration, time.Hour)
+
+	state.update([]queryMetricSource{{database: testDatabase, queryHash: testHash, executions: 10, errors: 1, durationSeconds: 5}})
+	state.reset()
+
+	require.Empty(t, state.entries)
+	require.Equal(t, 0, testutil.CollectAndCount(executions))
+	require.Equal(t, 0, testutil.CollectAndCount(errCounter))
+	require.Equal(t, 0, testutil.CollectAndCount(duration))
+}

--- a/internal/component/database_observability/sql_server/collector/query_metrics_test.go
+++ b/internal/component/database_observability/sql_server/collector/query_metrics_test.go
@@ -1,0 +1,249 @@
+package collector
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/grafana/alloy/internal/util"
+)
+
+var queryHashBytes = []byte{0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77}
+
+const (
+	testDatabase = "books_store"
+	testHash     = "0011223344556677"
+)
+
+func mockSelectQueryStoreState(mock sqlmock.Sqlmock, state string) {
+	mock.ExpectQuery(selectQueryStoreState).WillReturnRows(
+		sqlmock.NewRows([]string{"database_name", "actual_state_desc", "query_capture_mode_desc", "readonly_reason"}).
+			AddRow(testDatabase, state, "ALL", int64(0)),
+	)
+}
+
+func mockQueryMetricsRows(executions, errorExecutions int64, durationMicroseconds float64) *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"query_hash", "executions", "errors", "total_duration_us"}).
+		AddRow(queryHashBytes, executions, errorExecutions, durationMicroseconds)
+}
+
+func TestQueryMetrics_CollectDeltas(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	c, err := NewQueryMetrics(QueryMetricsArguments{
+		DB:              db,
+		Registry:        prometheus.NewRegistry(),
+		CollectInterval: time.Minute,
+		Limit:           50,
+		Lookback:        time.Hour,
+		Logger:          util.TestAlloyLogger(t).Slog(),
+	})
+	require.NoError(t, err)
+
+	// First poll: first sighting, series created at zero.
+	mockSelectQueryStoreState(mock, "READ_WRITE")
+	mock.ExpectQuery(selectQueryMetrics).
+		WithArgs(sql.Named("limit", 50), sql.Named("lookback_window", 3600)).
+		WillReturnRows(mockQueryMetricsRows(10, 2, 5_000_000))
+	require.NoError(t, c.collect(context.Background()))
+	require.Equal(t, 0.0, counterValue(t, c.executionsMetric))
+	require.Equal(t, 0.0, counterValue(t, c.errorsMetric))
+	require.Equal(t, 0.0, counterValue(t, c.durationMetric))
+
+	// Second poll: only the increase is emitted.
+	mockSelectQueryStoreState(mock, "READ_WRITE")
+	mock.ExpectQuery(selectQueryMetrics).
+		WithArgs(sql.Named("limit", 50), sql.Named("lookback_window", 3600)).
+		WillReturnRows(mockQueryMetricsRows(14, 3, 8_500_000))
+	require.NoError(t, c.collect(context.Background()))
+	require.Equal(t, 4.0, counterValue(t, c.executionsMetric))
+	require.Equal(t, 1.0, counterValue(t, c.errorsMetric))
+	require.InDelta(t, 3.5, counterValue(t, c.durationMetric), 1e-9)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestQueryMetrics_CollectAcrossIntervalRollover(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	c, err := NewQueryMetrics(QueryMetricsArguments{
+		DB:              db,
+		Registry:        prometheus.NewRegistry(),
+		CollectInterval: time.Minute,
+		Limit:           50,
+		Lookback:        time.Hour,
+		Logger:          util.TestAlloyLogger(t).Slog(),
+	})
+	require.NoError(t, err)
+
+	poll := func(executions, errorExecutions int64, durationMicroseconds float64) {
+		t.Helper()
+		mockSelectQueryStoreState(mock, "READ_WRITE")
+		mock.ExpectQuery(selectQueryMetrics).
+			WithArgs(sql.Named("limit", 50), sql.Named("lookback_window", 3600)).
+			WillReturnRows(mockQueryMetricsRows(executions, errorExecutions, durationMicroseconds))
+		require.NoError(t, c.collect(context.Background()))
+	}
+
+	// First sighting: series created at zero, historical totals not emitted.
+	poll(10, 2, 5_000_000)
+	require.Equal(t, 0.0, counterValue(t, c.executionsMetric))
+	require.Equal(t, 0.0, counterValue(t, c.errorsMetric))
+	require.Equal(t, 0.0, counterValue(t, c.durationMetric))
+
+	// Interval A closes and B opens; the full-history sum keeps growing, so only
+	// the increase is emitted.
+	poll(14, 3, 8_500_000)
+	require.Equal(t, 4.0, counterValue(t, c.executionsMetric))
+	require.Equal(t, 1.0, counterValue(t, c.errorsMetric))
+	require.InDelta(t, 3.5, counterValue(t, c.durationMetric), 1e-9)
+
+	// A new Query Store interval opens (rollover). Because the query sums full
+	// history, the total keeps growing, so deltas continue to accumulate.
+	poll(20, 4, 12_000_000)
+	require.Equal(t, 10.0, counterValue(t, c.executionsMetric))
+	require.Equal(t, 2.0, counterValue(t, c.errorsMetric))
+	require.InDelta(t, 7.0, counterValue(t, c.durationMetric), 1e-9)
+
+	// Retention drops the oldest interval: the full-history sum decreases. The
+	// counters must not regress, so nothing is emitted and the series
+	// re-baselines to the new, lower totals.
+	poll(6, 1, 3_000_000)
+	require.Equal(t, 10.0, counterValue(t, c.executionsMetric))
+	require.Equal(t, 2.0, counterValue(t, c.errorsMetric))
+	require.InDelta(t, 7.0, counterValue(t, c.durationMetric), 1e-9)
+
+	// Growth after the retention drop is measured from the new baseline.
+	poll(9, 2, 4_500_000)
+	require.Equal(t, 13.0, counterValue(t, c.executionsMetric))
+	require.Equal(t, 3.0, counterValue(t, c.errorsMetric))
+	require.InDelta(t, 8.5, counterValue(t, c.durationMetric), 1e-9)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestQueryMetrics_QueryStoreStateChecks(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	testCases := []struct {
+		name     string
+		state    string
+		noRows   bool
+		queryErr bool
+	}{
+		{name: "query store off", state: "OFF"},
+		{name: "query store read only", state: "READ_ONLY"},
+		{name: "no rows (missing permission)", noRows: true},
+		{name: "preflight error", queryErr: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+			require.NoError(t, err)
+			defer db.Close()
+
+			c, err := NewQueryMetrics(QueryMetricsArguments{
+				DB:              db,
+				Registry:        prometheus.NewRegistry(),
+				CollectInterval: time.Minute,
+				Limit:           50,
+				Lookback:        time.Hour,
+				Logger:          util.TestAlloyLogger(t).Slog(),
+			})
+			require.NoError(t, err)
+
+			switch {
+			case tc.queryErr:
+				mock.ExpectQuery(selectQueryStoreState).WillReturnError(errors.New("permission denied"))
+			case tc.noRows:
+				mock.ExpectQuery(selectQueryStoreState).WillReturnRows(
+					sqlmock.NewRows([]string{"database_name", "actual_state_desc", "query_capture_mode_desc", "readonly_reason"}),
+				)
+			default:
+				mockSelectQueryStoreState(mock, tc.state)
+			}
+
+			// Skipped collections must not surface as errors, so the collector stays healthy.
+			require.NoError(t, c.collect(context.Background()))
+			require.Equal(t, 0, testutil.CollectAndCount(c.executionsMetric))
+			require.Equal(t, 0, testutil.CollectAndCount(c.errorsMetric))
+			require.Equal(t, 0, testutil.CollectAndCount(c.durationMetric))
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestQueryMetrics_StartRegistersAndStopUnregisters(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	reg := prometheus.NewRegistry()
+	c, err := NewQueryMetrics(QueryMetricsArguments{
+		DB:              db,
+		Registry:        reg,
+		CollectInterval: time.Minute,
+		Limit:           50,
+		Lookback:        time.Hour,
+		Logger:          util.TestAlloyLogger(t).Slog(),
+	})
+	require.NoError(t, err)
+
+	mockSelectQueryStoreState(mock, "READ_WRITE")
+	mock.ExpectQuery(selectQueryMetrics).
+		WithArgs(sql.Named("limit", 50), sql.Named("lookback_window", 3600)).
+		WillReturnRows(mockQueryMetricsRows(10, 2, 5_000_000))
+
+	require.NoError(t, c.Start(context.Background()))
+
+	require.Eventually(t, func() bool {
+		n, err := testutil.GatherAndCount(reg, "database_observability_query_executions_total")
+		return err == nil && n == 1
+	}, 5*time.Second, 20*time.Millisecond)
+	require.False(t, c.Stopped())
+
+	c.Stop()
+	require.True(t, c.Stopped())
+
+	for _, metricName := range []string{
+		"database_observability_query_executions_total",
+		"database_observability_query_errors_total",
+		"database_observability_query_duration_seconds_total",
+	} {
+		n, err := testutil.GatherAndCount(reg, metricName)
+		require.NoError(t, err)
+		require.Equal(t, 0, n, "expected %s to be unregistered after Stop", metricName)
+	}
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFormatQueryHash(t *testing.T) {
+	t.Parallel()
+
+	hash, err := formatQueryHash(queryHashBytes)
+	require.NoError(t, err)
+	require.Equal(t, testHash, hash)
+
+	_, err = formatQueryHash([]byte{0x00, 0x11})
+	require.Error(t, err)
+}

--- a/internal/component/database_observability/sql_server/component.go
+++ b/internal/component/database_observability/sql_server/component.go
@@ -133,6 +133,9 @@ func (a *Arguments) Validate() error {
 	}
 
 	if enableOrDisableCollectors(*a)[collector.QueryMetricsCollector] {
+		if a.QueryMetricsArguments.CollectInterval <= 0 {
+			return fmt.Errorf("query_metrics.collect_interval must be greater than zero")
+		}
 		if a.QueryMetricsArguments.StatementsLimit <= 0 {
 			return fmt.Errorf("query_metrics.statements_limit must be greater than zero")
 		}

--- a/internal/component/database_observability/sql_server/component.go
+++ b/internal/component/database_observability/sql_server/component.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"fmt"
+	"math"
 	"net/http"
 	"path"
 	"strings"
@@ -70,6 +71,7 @@ type Arguments struct {
 
 	CloudProvider          *CloudProvider         `alloy:"cloud_provider,block,optional"`
 	SchemaDetailsArguments SchemaDetailsArguments `alloy:"schema_details,block,optional"`
+	QueryMetricsArguments  QueryMetricsArguments  `alloy:"query_metrics,block,optional"`
 }
 
 type CloudProvider struct {
@@ -96,6 +98,13 @@ type SchemaDetailsArguments struct {
 	CollectInterval time.Duration `alloy:"collect_interval,attr,optional"`
 }
 
+// QueryMetricsArguments configures the Query Store metrics collector.
+type QueryMetricsArguments struct {
+	CollectInterval    time.Duration `alloy:"collect_interval,attr,optional"`
+	StatementsLimit    int           `alloy:"statements_limit,attr,optional"`
+	StatementsLookback time.Duration `alloy:"statements_lookback,attr,optional"`
+}
+
 func defaultArguments() Arguments {
 	return Arguments{
 		ExcludeSchemas:   database_observability.DefaultExcludedSchemas(),
@@ -103,6 +112,12 @@ func defaultArguments() Arguments {
 
 		SchemaDetailsArguments: SchemaDetailsArguments{
 			CollectInterval: 1 * time.Minute,
+		},
+
+		QueryMetricsArguments: QueryMetricsArguments{
+			CollectInterval:    1 * time.Minute,
+			StatementsLimit:    50,
+			StatementsLookback: 1 * time.Hour,
 		},
 	}
 }
@@ -116,6 +131,17 @@ func (a *Arguments) Validate() error {
 	if err != nil {
 		return err
 	}
+
+	if enableOrDisableCollectors(*a)[collector.QueryMetricsCollector] {
+		if a.QueryMetricsArguments.StatementsLimit <= 0 {
+			return fmt.Errorf("query_metrics.statements_limit must be greater than zero")
+		}
+		lookback := a.QueryMetricsArguments.StatementsLookback
+		if lookback < time.Second || lookback > math.MaxInt32*time.Second {
+			return fmt.Errorf("query_metrics.statements_lookback must be between 1s and %ds", math.MaxInt32)
+		}
+	}
+
 	if a.CloudProvider != nil {
 		count := 0
 		if a.CloudProvider.AWS != nil {
@@ -381,6 +407,7 @@ func (c *Component) connectAndStartCollectors(ctx context.Context) error {
 func enableOrDisableCollectors(a Arguments) map[string]bool {
 	collectors := map[string]bool{
 		collector.SchemaDetailsCollector: true,
+		collector.QueryMetricsCollector:  true,
 	}
 
 	for _, disabled := range a.DisableCollectors {
@@ -426,6 +453,25 @@ func (c *Component) startCollectors(serverID string, engineVersion string, cloud
 				logStartError(collector.SchemaDetailsCollector, "start", err)
 			}
 			c.collectors = append(c.collectors, stCollector)
+		}
+	}
+
+	if collectors[collector.QueryMetricsCollector] {
+		qmCollector, err := collector.NewQueryMetrics(collector.QueryMetricsArguments{
+			DB:              c.dbConnection,
+			Registry:        c.registry,
+			CollectInterval: c.args.QueryMetricsArguments.CollectInterval,
+			Limit:           c.args.QueryMetricsArguments.StatementsLimit,
+			Lookback:        c.args.QueryMetricsArguments.StatementsLookback,
+			Logger:          c.opts.Logger,
+		})
+		if err != nil {
+			logStartError(collector.QueryMetricsCollector, "create", err)
+		} else {
+			if err := qmCollector.Start(context.Background()); err != nil {
+				logStartError(collector.QueryMetricsCollector, "start", err)
+			}
+			c.collectors = append(c.collectors, qmCollector)
 		}
 	}
 

--- a/internal/component/database_observability/sql_server/component_test.go
+++ b/internal/component/database_observability/sql_server/component_test.go
@@ -173,6 +173,12 @@ func TestValidateQueryMetrics(t *testing.T) {
 		require.NoError(t, args.Validate())
 	})
 
+	t.Run("non-positive collect_interval is rejected", func(t *testing.T) {
+		args := base()
+		args.QueryMetricsArguments.CollectInterval = 0
+		require.ErrorContains(t, args.Validate(), "query_metrics.collect_interval")
+	})
+
 	t.Run("non-positive statements_limit is rejected", func(t *testing.T) {
 		args := base()
 		args.QueryMetricsArguments.StatementsLimit = 0

--- a/internal/component/database_observability/sql_server/component_test.go
+++ b/internal/component/database_observability/sql_server/component_test.go
@@ -2,10 +2,12 @@ package sql_server
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/alloy/internal/component/database_observability/sql_server/collector"
 	"github.com/grafana/alloy/syntax"
 )
 
@@ -134,5 +136,60 @@ func Test_parseCloudProvider(t *testing.T) {
 		var args Arguments
 		err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
 		require.EqualError(t, err, "cloud_provider: at most one of aws, azure, or gcp must be specified")
+	})
+}
+
+func TestQueryMetricsDefaults(t *testing.T) {
+	var args Arguments
+	args.SetToDefault()
+
+	assert.Equal(t, 1*time.Minute, args.QueryMetricsArguments.CollectInterval)
+	assert.Equal(t, 50, args.QueryMetricsArguments.StatementsLimit)
+	assert.Equal(t, 1*time.Hour, args.QueryMetricsArguments.StatementsLookback)
+}
+
+func TestQueryMetricsEnabledByDefault(t *testing.T) {
+	var args Arguments
+	args.SetToDefault()
+
+	collectors := enableOrDisableCollectors(args)
+	assert.True(t, collectors[collector.QueryMetricsCollector])
+
+	args.DisableCollectors = []string{collector.QueryMetricsCollector}
+	collectors = enableOrDisableCollectors(args)
+	assert.False(t, collectors[collector.QueryMetricsCollector])
+}
+
+func TestValidateQueryMetrics(t *testing.T) {
+	base := func() Arguments {
+		var args Arguments
+		args.SetToDefault()
+		args.DataSourceName = "sqlserver://user:pass@localhost:1433?database=app"
+		return args
+	}
+
+	t.Run("defaults are valid", func(t *testing.T) {
+		args := base()
+		require.NoError(t, args.Validate())
+	})
+
+	t.Run("non-positive statements_limit is rejected", func(t *testing.T) {
+		args := base()
+		args.QueryMetricsArguments.StatementsLimit = 0
+		require.ErrorContains(t, args.Validate(), "query_metrics.statements_limit")
+	})
+
+	t.Run("non-positive statements_lookback is rejected", func(t *testing.T) {
+		args := base()
+		args.QueryMetricsArguments.StatementsLookback = 0
+		require.ErrorContains(t, args.Validate(), "query_metrics.statements_lookback")
+	})
+
+	t.Run("invalid values are ignored when the collector is disabled", func(t *testing.T) {
+		args := base()
+		args.DisableCollectors = []string{collector.QueryMetricsCollector}
+		args.QueryMetricsArguments.StatementsLimit = 0
+		args.QueryMetricsArguments.StatementsLookback = 0
+		require.NoError(t, args.Validate())
 	})
 }


### PR DESCRIPTION
### Brief description of Pull Request

Add a basic `query_metrics` collector implementation that reads per-query execution stats from Query Store and emits them as Prometheus counters (only RED metrics), keyed by `database` and `query_hash`.

### Pull Request Details

Notes on initial design decisions:
- Rank the top-N queries by duration within the recent lookback window, but sum each query's full retained Query Store history. This keeps the emitted counters monotonic across Query Store interval rollover: the windowed ranking changes as intervals roll over, but the summed totals only grow.

- Turn Query Store's cumulative totals into monotonic Prometheus counters by tracking a per-series baseline. A first sighting is created at zero so that historical totals don't surface as a startup spike, and a decrease in any total (e.g. Query Store cleared, retention or plan cleanup) re-baselines the series instead of emitting a spurious jump.

- Bound registry cardinality by pruning queries/series not seen within a TTL window, so queries that drop out of the top-N are removed. A query that flaps around the boundary will keep its baseline within the TTL, so activity accrued while it was absent is counted on re-entry rather than lost to a re-baseline.

- On instances with large Query Stores the collection query might be potentially slow as it intentionally sums the full retained history per ranked hash. This is deemed acceptable for now.

- Scope is limited to only the connected database. Also, when Query Store is not available or not `READ_WRITE`, we skip collection while preserving existing baselines, as a reasonable tradeoff.

None of these decisions are final, and the implementation is a work in progress. The internal state might be reworked to be exposed to other collectors in the future.


### Issue(s) fixed by this Pull Request

Relates to https://github.com/grafana/grafana-dbo11y-app/issues/3023


### Notes to the Reviewer

<!-- HUMAN ONLY: Context for reviewers/testers. Write in your own words. -->


### PR Checklist

<!-- HUMAN ONLY: Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
