### PR TITLE
fix(database_observability.postgres): Roll back op=query_association_v2, fold fingerprint into op=query_association

### DIFF
--- a/internal/component/database_observability/postgres/collector/query_details.go
+++ b/internal/component/database_observability/postgres/collector/query_details.go
@@ -165,8 +165,10 @@ func (c *QueryDetails) fetchAndAssociate(ctx context.Context) error {
 			// computed elsewhere from pg_stat_activity / server logs.
 			var fpErr error
 			fp, fpErr = fingerprint.Fingerprint(queryText)
-			if fpErr != nil || fp == "" {
+			if fpErr != nil {
 				c.logger.Warn("could not compute query fingerprint; emitting query_association without fingerprint", "queryid", queryID, "err", fpErr)
+			} else if fp == "" {
+				c.logger.Warn("empty query fingerprint; emitting query_association without fingerprint", "queryid", queryID)
 			}
 		}
 

--- a/internal/component/database_observability/postgres/collector/query_details.go
+++ b/internal/component/database_observability/postgres/collector/query_details.go
@@ -21,7 +21,6 @@ import (
 const (
 	QueryDetailsCollector      = "query_details"
 	OP_QUERY_ASSOCIATION       = "query_association"
-	OP_QUERY_ASSOCIATION_V2    = "query_association_v2"
 	OP_QUERY_PARSED_TABLE_NAME = "query_parsed_table_name"
 )
 
@@ -159,13 +158,16 @@ func (c *QueryDetails) fetchAndAssociate(ctx context.Context) error {
 		}
 
 		var fp string
-		var fpErr error
 		if c.enableErrorLogsProcessing {
 			// Fingerprint the raw text BEFORE comment stripping; pg_query
 			// canonicalizes literals at the AST level so the value is stable
 			// across comment-only differences and matches the fingerprint
 			// computed elsewhere from pg_stat_activity / server logs.
+			var fpErr error
 			fp, fpErr = fingerprint.Fingerprint(queryText)
+			if fpErr != nil || fp == "" {
+				c.logger.Warn("could not compute query fingerprint; emitting query_association without fingerprint", "queryid", queryID, "err", fpErr)
+			}
 		}
 
 		queryText, err = removeComments(c.normalizer, queryText)
@@ -174,24 +176,17 @@ func (c *QueryDetails) fetchAndAssociate(ctx context.Context) error {
 			continue
 		}
 
-		if !c.enableErrorLogsProcessing {
-			c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
-				logging.LevelInfo,
-				OP_QUERY_ASSOCIATION,
-				fmt.Sprintf(`queryid="%s" querytext=%q datname="%s"`, queryID, queryText, databaseName),
-			)
-		} else if fp != "" {
-			c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
-				logging.LevelInfo,
-				OP_QUERY_ASSOCIATION_V2,
-				fmt.Sprintf(`queryid="%s" query_fingerprint="%s" querytext=%q datname="%s"`, queryID, fp, queryText, databaseName),
-			)
+		var body string
+		if fp != "" {
+			body = fmt.Sprintf(`queryid="%s" query_fingerprint="%s" querytext=%q datname="%s"`, queryID, fp, queryText, databaseName)
 		} else {
-			// enable_error_logs_processing is on but fingerprinting failed
-			// (empty fp): warn with the queryid and skip the association rather
-			// than emit an empty query_fingerprint or a misleading v1 entry.
-			c.logger.Warn("skipping query_association_v2: could not compute query fingerprint", "queryid", queryID, "err", fpErr)
+			body = fmt.Sprintf(`queryid="%s" querytext=%q datname="%s"`, queryID, queryText, databaseName)
 		}
+		c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
+			logging.LevelInfo,
+			OP_QUERY_ASSOCIATION,
+			body,
+		)
 
 		tables, err := tokenizeTableNames(c.normalizer, queryText)
 		if err != nil {

--- a/internal/component/database_observability/postgres/collector/query_details_test.go
+++ b/internal/component/database_observability/postgres/collector/query_details_test.go
@@ -1044,12 +1044,12 @@ func TestQueryDetails_QueryAssociation_OnEmitsFingerprint(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		for _, e := range lokiClient.Received() {
-			if e.Labels["op"] == OP_QUERY_ASSOCIATION {
+			if e.Labels["op"] == OP_QUERY_ASSOCIATION && strings.Contains(e.Line, "query_fingerprint=") {
 				return true
 			}
 		}
 		return false
-	}, 3*time.Second, 50*time.Millisecond, "query_association op should be emitted")
+	}, 3*time.Second, 50*time.Millisecond, "fingerprinted query_association op should be emitted")
 
 	c.Stop()
 	lokiClient.Stop()
@@ -1057,12 +1057,12 @@ func TestQueryDetails_QueryAssociation_OnEmitsFingerprint(t *testing.T) {
 	entries := lokiClient.Received()
 	var assoc *loki.Entry
 	for i := range entries {
-		if entries[i].Labels["op"] == OP_QUERY_ASSOCIATION {
+		if entries[i].Labels["op"] == OP_QUERY_ASSOCIATION && strings.Contains(entries[i].Line, "query_fingerprint=") {
 			assoc = &entries[i]
 			break
 		}
 	}
-	require.NotNil(t, assoc, "expected at least one query_association entry")
+	require.NotNil(t, assoc, "expected at least one fingerprinted query_association entry")
 	require.Equal(t, model.LabelSet{"op": OP_QUERY_ASSOCIATION}, assoc.Labels)
 	expectedBody := fmt.Sprintf(`level="info" queryid="abc123" query_fingerprint="%s" querytext=%q datname="books_store"`, fp, q)
 	require.Equal(t, expectedBody, assoc.Line)
@@ -1166,12 +1166,12 @@ func TestQueryDetails_QueryAssociation_EmptyFingerprintFallsBack(t *testing.T) {
 	c.Stop()
 	lokiClient.Stop()
 
+	received := lokiClient.Received()
 	var emptyAssoc *loki.Entry
-	for i := range lokiClient.Received() {
-		e := lokiClient.Received()[i]
-		require.NotContains(t, e.Line, `query_fingerprint=""`, "must never emit an empty query_fingerprint")
-		if e.Labels["op"] == OP_QUERY_ASSOCIATION && strings.Contains(e.Line, `queryid="empty1"`) {
-			emptyAssoc = &e
+	for i := range received {
+		require.NotContains(t, received[i].Line, `query_fingerprint=""`, "must never emit an empty query_fingerprint")
+		if received[i].Labels["op"] == OP_QUERY_ASSOCIATION && strings.Contains(received[i].Line, `queryid="empty1"`) {
+			emptyAssoc = &received[i]
 		}
 	}
 	require.NotNil(t, emptyAssoc, "empty-fingerprint row should still emit a query_association entry")

--- a/internal/component/database_observability/postgres/collector/query_details_test.go
+++ b/internal/component/database_observability/postgres/collector/query_details_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1005,14 +1006,12 @@ func TestQueryDetails_ExcludeUsers(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-// TestQueryDetails_QueryAssociationV2_OnEmitsFingerprint pins three behaviors
-// when enable_error_logs_processing = true:
-//  1. the op label is "query_association_v2" (not the legacy "query_association")
-//  2. the body carries the query_fingerprint field between queryid and querytext
-//  3. the fingerprint matches what fingerprint.Fingerprint returns for the raw text
-func TestQueryDetails_QueryAssociationV2_OnEmitsFingerprint(t *testing.T) {
+// TestQueryDetails_QueryAssociation_OnEmitsFingerprint checks that with
+// enable_error_logs_processing = true the op stays "query_association" and the
+// body carries a query_fingerprint matching fingerprint.Fingerprint.
+func TestQueryDetails_QueryAssociation_OnEmitsFingerprint(t *testing.T) {
 	if !fingerprint.Supported() {
-		t.Skip("op=query_association_v2 fingerprints require SQL fingerprinting, which needs a cgo build")
+		t.Skip("query_association fingerprints require SQL fingerprinting, which needs a cgo build")
 	}
 	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"))
 
@@ -1045,12 +1044,12 @@ func TestQueryDetails_QueryAssociationV2_OnEmitsFingerprint(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		for _, e := range lokiClient.Received() {
-			if e.Labels["op"] == OP_QUERY_ASSOCIATION_V2 {
+			if e.Labels["op"] == OP_QUERY_ASSOCIATION {
 				return true
 			}
 		}
 		return false
-	}, 3*time.Second, 50*time.Millisecond, "v2 op should be emitted when flag is on")
+	}, 3*time.Second, 50*time.Millisecond, "query_association op should be emitted")
 
 	c.Stop()
 	lokiClient.Stop()
@@ -1058,26 +1057,21 @@ func TestQueryDetails_QueryAssociationV2_OnEmitsFingerprint(t *testing.T) {
 	entries := lokiClient.Received()
 	var assoc *loki.Entry
 	for i := range entries {
-		if entries[i].Labels["op"] == OP_QUERY_ASSOCIATION_V2 {
+		if entries[i].Labels["op"] == OP_QUERY_ASSOCIATION {
 			assoc = &entries[i]
 			break
 		}
 	}
-	require.NotNil(t, assoc, "expected at least one query_association_v2 entry")
-	require.Equal(t, model.LabelSet{"op": OP_QUERY_ASSOCIATION_V2}, assoc.Labels)
+	require.NotNil(t, assoc, "expected at least one query_association entry")
+	require.Equal(t, model.LabelSet{"op": OP_QUERY_ASSOCIATION}, assoc.Labels)
 	expectedBody := fmt.Sprintf(`level="info" queryid="abc123" query_fingerprint="%s" querytext=%q datname="books_store"`, fp, q)
 	require.Equal(t, expectedBody, assoc.Line)
-
-	for _, e := range entries {
-		require.NotEqual(t, OP_QUERY_ASSOCIATION, e.Labels["op"], "legacy op must not be emitted alongside v2")
-	}
 }
 
-// TestQueryDetails_QueryAssociationV2_OffPreservesLegacyOp confirms that with
-// enable_error_logs_processing = false (default) the collector emits the
-// pre-fingerprint shape unchanged: op="query_association", no
-// query_fingerprint field in the body.
-func TestQueryDetails_QueryAssociationV2_OffPreservesLegacyOp(t *testing.T) {
+// TestQueryDetails_QueryAssociation_OffOmitsFingerprint confirms that with
+// enable_error_logs_processing = false (default) the body carries no
+// query_fingerprint field.
+func TestQueryDetails_QueryAssociation_OffOmitsFingerprint(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"))
 
 	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
@@ -1116,19 +1110,17 @@ func TestQueryDetails_QueryAssociationV2_OffPreservesLegacyOp(t *testing.T) {
 	lokiClient.Stop()
 
 	for _, e := range lokiClient.Received() {
-		require.NotEqual(t, OP_QUERY_ASSOCIATION_V2, e.Labels["op"], "v2 op must not be emitted when flag is off")
 		require.NotContains(t, e.Line, "query_fingerprint=", "no body should carry query_fingerprint when flag is off")
 	}
 }
 
-// TestQueryDetails_QueryAssociationV2_EmptyFingerprintWarnsAndSkips pins that
-// with enable_error_logs_processing = true, a row whose text yields no
-// fingerprint (fingerprint.Fingerprint fails, e.g. empty text) is skipped with
-// a warning carrying the queryid — rather than emitting an empty
-// query_fingerprint or falling back to the legacy v1 op.
-func TestQueryDetails_QueryAssociationV2_EmptyFingerprintWarnsAndSkips(t *testing.T) {
+// TestQueryDetails_QueryAssociation_EmptyFingerprintFallsBack checks that with
+// enable_error_logs_processing = true, a row that yields no fingerprint still
+// emits a query_association entry without the query_fingerprint field, plus a
+// warning carrying the queryid — rather than dropping the association.
+func TestQueryDetails_QueryAssociation_EmptyFingerprintFallsBack(t *testing.T) {
 	if !fingerprint.Supported() {
-		t.Skip("op=query_association_v2 fingerprints require SQL fingerprinting, which needs a cgo build")
+		t.Skip("query_association fingerprints require SQL fingerprinting, which needs a cgo build")
 	}
 	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"))
 
@@ -1152,8 +1144,8 @@ func TestQueryDetails_QueryAssociationV2_EmptyFingerprintWarnsAndSkips(t *testin
 	})
 	require.NoError(t, err)
 
-	// "empty1" has empty text → no fingerprint. It is ordered first so that once
-	// the valid row's v2 entry appears, the empty row has already been processed.
+	// "empty1" (empty text → no fingerprint) is ordered first so that once the
+	// valid row's fingerprinted association appears, empty1 is already processed.
 	mock.ExpectQuery(fmt.Sprintf(selectQueriesFromActivity, exclusionClause, "", 100)).WithoutArgs().RowsWillBeClosed().
 		WillReturnRows(sqlmock.NewRows([]string{"queryid", "query", "datname"}).
 			AddRow("empty1", "", "books_store").
@@ -1164,24 +1156,27 @@ func TestQueryDetails_QueryAssociationV2_EmptyFingerprintWarnsAndSkips(t *testin
 
 	require.Eventually(t, func() bool {
 		for _, e := range lokiClient.Received() {
-			if e.Labels["op"] == OP_QUERY_ASSOCIATION_V2 {
+			if e.Labels["op"] == OP_QUERY_ASSOCIATION && strings.Contains(e.Line, "query_fingerprint=") {
 				return true
 			}
 		}
 		return false
-	}, 3*time.Second, 50*time.Millisecond, "valid row should emit the v2 op")
+	}, 3*time.Second, 50*time.Millisecond, "valid row should emit a fingerprinted query_association")
 
 	c.Stop()
 	lokiClient.Stop()
 
-	// The empty-fingerprint row must not produce any association entry (no v1
-	// fallback, no empty query_fingerprint).
-	for _, e := range lokiClient.Received() {
-		require.NotContains(t, e.Line, "empty1", "empty-fingerprint row must not emit an association entry")
+	var emptyAssoc *loki.Entry
+	for i := range lokiClient.Received() {
+		e := lokiClient.Received()[i]
 		require.NotContains(t, e.Line, `query_fingerprint=""`, "must never emit an empty query_fingerprint")
+		if e.Labels["op"] == OP_QUERY_ASSOCIATION && strings.Contains(e.Line, `queryid="empty1"`) {
+			emptyAssoc = &e
+		}
 	}
+	require.NotNil(t, emptyAssoc, "empty-fingerprint row should still emit a query_association entry")
+	require.NotContains(t, emptyAssoc.Line, "query_fingerprint=", "empty-fingerprint row must omit the query_fingerprint field")
 
-	// Instead it must warn, carrying the queryid.
 	logs := logBuf.String()
 	require.Contains(t, logs, "could not compute query fingerprint")
 	require.Contains(t, logs, "queryid=empty1")


### PR DESCRIPTION
## Summary

Rolls back the separate `op=query_association_v2` Loki op introduced in #6297. The Postgres `query_details` collector now always emits a single `op=query_association`, and the `enable_error_logs_processing` flag simply controls whether a `query_fingerprint` field is added to that same entry.

- Flag off → `queryid="..." querytext=... datname="..."`
- Flag on  → `queryid="..." query_fingerprint="..." querytext=... datname="..."`

## Behavior note

When fingerprinting fails while the flag is on, the collector now **warns and emits the association without a fingerprint** rather than dropping the entry (the previous v2 behavior). This keeps the association reliably present and consistent with the flag-off shape.

No CHANGELOG entry: the v2 op (#6297) was added two days ago and is unreleased.

## Testing

`go test ./internal/component/database_observability/postgres/collector/` passes, including the three renamed `query_association` tests (fingerprint-on, fingerprint-off, empty-fingerprint fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)