### PR TITLE
fix(database_observability.postgres): Restore cgo SQL fingerprinting on Windows

### DIFF
--- a/internal/component/database_observability/postgres/fingerprint/fingerprint.go
+++ b/internal/component/database_observability/postgres/fingerprint/fingerprint.go
@@ -1,10 +1,8 @@
 // Package fingerprint computes stable, semantic SQL fingerprints via
 // libpg_query. The fingerprint is identical across comment/whitespace
-// differences and literal-vs-placeholder differences. libpg_query is cgo-only,
-// and its bundled C does not link with the TDM-GCC toolchain used for Windows
-// container builds, so the stub in fingerprint_nocgo.go covers both the !cgo
-// cross-compile and all Windows builds: it reports Supported() == false and
-// returns ErrEmpty from every Fingerprint call.
+// differences and literal-vs-placeholder differences. libpg_query is cgo-only;
+// the !cgo build is provided by fingerprint_nocgo.go, reports
+// Supported() == false, and returns ErrEmpty from every Fingerprint call.
 //
 // This file holds the declarations shared by both builds so the two
 // build-tagged implementations cannot drift apart.

--- a/internal/component/database_observability/postgres/fingerprint/fingerprint_cgo.go
+++ b/internal/component/database_observability/postgres/fingerprint/fingerprint_cgo.go
@@ -1,4 +1,4 @@
-//go:build cgo && !windows
+//go:build cgo
 
 package fingerprint
 

--- a/internal/component/database_observability/postgres/fingerprint/fingerprint_nocgo.go
+++ b/internal/component/database_observability/postgres/fingerprint/fingerprint_nocgo.go
@@ -1,4 +1,4 @@
-//go:build !cgo || windows
+//go:build !cgo
 
 package fingerprint
 

--- a/internal/component/database_observability/postgres/fingerprint/fingerprint_test.go
+++ b/internal/component/database_observability/postgres/fingerprint/fingerprint_test.go
@@ -1,4 +1,4 @@
-//go:build cgo && !windows
+//go:build cgo
 
 package fingerprint
 


### PR DESCRIPTION
### Brief description of Pull Request

Reverts the Windows fingerprint build-tag workaround from #6690. That workaround routed all Windows builds to the `nocgo` stub because the TDM-GCC toolchain used for Windows container builds could not link `pganalyze/pg_query_go/v6`'s stack-protector C (`__stack_chk_fail` / `__stack_chk_guard`). Now that #6692 replaced TDM-GCC with mingw-w64 (which ships `libssp` and links those symbols), the stub is no longer needed, so Windows regains the real cgo SQL fingerprinting.

- `fingerprint_cgo.go`: `//go:build cgo && !windows` → `//go:build cgo`
- `fingerprint_nocgo.go`: `//go:build !cgo || windows` → `//go:build !cgo`
- `fingerprint_test.go`: `//go:build cgo && !windows` → `//go:build cgo`
- `fingerprint.go`: restored the package doc comment

### Pull Request Details

<!-- HUMAN ONLY: Motivations, trade-offs, and decisions. Write in your own words. -->


### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->


### Notes to the Reviewer

<!-- HUMAN ONLY: Context for reviewers/testers. Write in your own words. -->


### PR Checklist

<!-- HUMAN ONLY: Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
