### PR TITLE
fix: Add nop receiver to OTel Engine

### DIFF
--- a/collector/builder-config.yaml
+++ b/collector/builder-config.yaml
@@ -87,6 +87,7 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.153.0
+  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.153.0
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.153.0
 
 connectors:

--- a/collector/components.go
+++ b/collector/components.go
@@ -88,6 +88,7 @@ import (
 	tcplogreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver"
 	vcenterreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver"
 	zipkinreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver"
+	nopreceiver "go.opentelemetry.io/collector/receiver/nopreceiver"
 	otlpreceiver "go.opentelemetry.io/collector/receiver/otlpreceiver"
 )
 
@@ -157,6 +158,7 @@ func components() (otelcol.Factories, error) {
 		tcplogreceiver.NewFactory(),
 		vcenterreceiver.NewFactory(),
 		zipkinreceiver.NewFactory(),
+		nopreceiver.NewFactory(),
 		otlpreceiver.NewFactory(),
 	)
 	if err != nil {
@@ -189,6 +191,7 @@ func components() (otelcol.Factories, error) {
 	factories.ReceiverModules[tcplogreceiver.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver v0.153.0"
 	factories.ReceiverModules[vcenterreceiver.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver v0.153.0"
 	factories.ReceiverModules[zipkinreceiver.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.153.0"
+	factories.ReceiverModules[nopreceiver.NewFactory().Type()] = "go.opentelemetry.io/collector/receiver/nopreceiver v0.153.0"
 	factories.ReceiverModules[otlpreceiver.NewFactory().Type()] = "go.opentelemetry.io/collector/receiver/otlpreceiver v0.153.0"
 
 	factories.Exporters, err = otelcol.MakeFactoryMap[exporter.Factory](

--- a/collector/go.mod
+++ b/collector/go.mod
@@ -97,6 +97,7 @@ require (
 	go.opentelemetry.io/collector/processor/batchprocessor v0.153.0
 	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.153.0
 	go.opentelemetry.io/collector/receiver v1.59.0
+	go.opentelemetry.io/collector/receiver/nopreceiver v0.153.0
 	go.opentelemetry.io/collector/receiver/otlpreceiver v0.153.0
 	go.opentelemetry.io/collector/service v0.153.0
 )

--- a/collector/go.sum
+++ b/collector/go.sum
@@ -2683,6 +2683,8 @@ go.opentelemetry.io/collector/processor/xprocessor v0.153.0 h1:mXtOAwZAXcHgAgVRz
 go.opentelemetry.io/collector/processor/xprocessor v0.153.0/go.mod h1:yGFU58TvheCedrVkdqU8jW/vnCFqcyYElf+5lidn0nA=
 go.opentelemetry.io/collector/receiver v1.59.0 h1:2jf2guECLyWno3OqNaefjfo+Tt3MSm6uz1WsbIXv5Ao=
 go.opentelemetry.io/collector/receiver v1.59.0/go.mod h1:rklWFy0kaMMghuGlrTxqYP96V810HwDVwIgKpP6kn2o=
+go.opentelemetry.io/collector/receiver/nopreceiver v0.153.0 h1:/p/E5TE1Aq6eKY/Dry09KXYDJiF4MY2GMFYmSxTlYXA=
+go.opentelemetry.io/collector/receiver/nopreceiver v0.153.0/go.mod h1:1gNzN1lsQpl3fik8i6UzqdX5KmXpW55P6cL3BWoKzG8=
 go.opentelemetry.io/collector/receiver/otlpreceiver v0.153.0 h1:ayfzDrj/dkycnFxPfTxt4JGJBzBSKTbEAwXUkfIJfjk=
 go.opentelemetry.io/collector/receiver/otlpreceiver v0.153.0/go.mod h1:4d8DbrbDUUPs1tYytE1qnJoCzR6kSHolpj1nhCrw6eU=
 go.opentelemetry.io/collector/receiver/receiverhelper v0.153.0 h1:r7TaXD7T4PiwXXRVKocgpc87ygMQnFflOqUJaOtpfug=

--- a/docs/sources/introduction/otel_alloy.md
+++ b/docs/sources/introduction/otel_alloy.md
@@ -97,6 +97,7 @@ The following sections list all included components:
 - [tcplog](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/receiver/tcplogreceiver/README.md)
 - [vcenter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/receiver/vcenterreceiver/README.md)
 - [zipkin](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/receiver/zipkinreceiver/README.md)
+- [nop](https://github.com/open-telemetry/opentelemetry-collector/tree/{{< param "OTEL_VERSION" >}}/receiver/nopreceiver/README.md)
 - [otlp](https://github.com/open-telemetry/opentelemetry-collector/tree/{{< param "OTEL_VERSION" >}}/receiver/otlpreceiver/README.md)
 {{< /collapse >}}
 


### PR DESCRIPTION
This is required in order to be compatible with the opamp supervisor, as the supervisor pushes [nop](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/cmd/opampsupervisor/supervisor/templates/nooppipeline.yaml) config to the underlying collector in order to have it idle before the OpAmp backend returns configuration

I'll backport this so that we're not blocking any users from integrating alloy with the FM OpAmp server with the standalone supervisor