### PR TITLE
ci(sync-replaces): Respect an existing GOPROXY when running go mod tidy

### DIFF
--- a/tools/sync-replaces/tidy.go
+++ b/tools/sync-replaces/tidy.go
@@ -23,9 +23,14 @@ func runGoModTidy(moduleDir string) error {
 		// Forward go's output so diagnostics surface in the build log.
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
-		// Pipe falls through to direct on any proxy error; comma only falls
+		cmd.Env = os.Environ()
+		// Respect a GOPROXY the caller already configured (e.g. a corporate
+		// module proxy); only fall back to the public proxy otherwise. Pipe
+		// falls through to direct on any proxy error; comma only falls
 		// through on 404/410, which doesn't cover transient proxy failures.
-		cmd.Env = append(os.Environ(), "GOPROXY=https://proxy.golang.org|direct")
+		if os.Getenv("GOPROXY") == "" {
+			cmd.Env = append(cmd.Env, "GOPROXY=https://proxy.golang.org|direct")
+		}
 
 		log.Printf("Running go mod tidy in %s (attempt %d/%d)", moduleDir, attempt, tidyMaxAttempts)
 		if err := cmd.Run(); err == nil {

--- a/tools/sync-replaces/tidy.go
+++ b/tools/sync-replaces/tidy.go
@@ -24,11 +24,10 @@ func runGoModTidy(moduleDir string) error {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		cmd.Env = os.Environ()
-		// Respect a GOPROXY the caller already configured (e.g. a corporate
-		// module proxy); only fall back to the public proxy otherwise. Pipe
-		// falls through to direct on any proxy error; comma only falls
-		// through on 404/410, which doesn't cover transient proxy failures.
-		if os.Getenv("GOPROXY") == "" {
+		// Respect a GOPROXY the caller already configured.
+		if _, ok := os.LookupEnv("GOPROXY"); !ok {
+			// Pipe falls through to direct on any proxy error; comma only falls
+			// through on 404/410, which doesn't cover transient proxy failures.
 			cmd.Env = append(cmd.Env, "GOPROXY=https://proxy.golang.org|direct")
 		}
 


### PR DESCRIPTION
Currently `runGoModTidy` unconditionally forces `GOPROXY=https://proxy.golang.org|direct`,
overriding any GOPROXY the caller/environment already has configured (e.g. a corporate
Go module proxy). In environments without direct/reliable access to the public
proxy.golang.org (locked-down CI, offline builds, users behind a private proxy),
this causes `go mod tidy` to fail or fetch modules through a path that doesn't
match what GOSUMDB verification expects, producing spurious checksum mismatch
errors even though the module content itself is fine.

This change only falls back to the public proxy when GOPROXY isn't already set,
otherwise it honors the caller's configuration.