### PR TITLE
feat(pyroscope.java): Add tlab profiling config option for TLAB-based allocation events

### DIFF
--- a/docs/sources/reference/components/pyroscope/pyroscope.java.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.java.md
@@ -153,6 +153,7 @@ The following arguments are supported:
 | `per_thread`                      | `bool`          | Sets per thread mode on async profiler. It's passed as an `-t` argument to async-profiler.                                         | `false`    | no       |
 | `quiet`                           | `bool`          | If set, suppresses the `Profiling started/stopped` log message.                                                                    | `false`    | no       |
 | `sample_rate`                     | `int`           | CPU profiling sample rate. It's converted from Hz to interval and passed as an `-i` argument to async-profiler.                    | `100`      | no       |
+| `tlab`                            | `bool`          | Enables TLAB-based allocation events. Passed as `--tlab` to async-profiler. Requires `alloc` to be set.                            | `false`    | no       |
 
 Refer to [profiler-options](https://github.com/async-profiler/async-profiler?tab=readme-ov-file#profiler-options) for more information about async-profiler configuration.
 
@@ -176,7 +177,7 @@ For more details, refer to [Options applicable to any output format except JFR](
 
 When `custom_arguments` is set, Alloy skips these options from this block:
 
-`cpu`, `event`, `per_thread`, `sample_rate`, `alloc`, `lock`, `log_level`.
+`cpu`, `event`, `per_thread`, `sample_rate`, `alloc`, `lock`, `log_level`, `tlab`.
 
 For example, this enables multi-event profiling (`cpu`, `alloc`, and `lock`) with custom thresholds:
 

--- a/internal/component/pyroscope/java/args.go
+++ b/internal/component/pyroscope/java/args.go
@@ -1,6 +1,7 @@
 package java
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/grafana/alloy/internal/component/discovery"
@@ -29,6 +30,7 @@ type ProfilingConfig struct {
 	LogLevel        string        `alloy:"log_level,attr,optional"`
 	Quiet           bool          `alloy:"quiet,attr,optional"`
 	CustomArguments []string      `alloy:"custom_arguments,attr,optional"`
+	Tlab            bool          `alloy:"tlab,attr,optional"`
 }
 
 func (rc *Arguments) UnmarshalAlloy(f func(any) error) error {
@@ -38,6 +40,9 @@ func (rc *Arguments) UnmarshalAlloy(f func(any) error) error {
 }
 
 func (arg *Arguments) Validate() error {
+	if len(arg.ProfilingConfig.CustomArguments) == 0 && arg.ProfilingConfig.Tlab && arg.ProfilingConfig.Alloc == "" {
+		return fmt.Errorf("profiling_config.tlab requires profiling_config.alloc to be set")
+	}
 	return nil
 }
 
@@ -55,6 +60,7 @@ func DefaultArguments() Arguments {
 			LogLevel:        "INFO",
 			Quiet:           false,
 			CustomArguments: []string{},
+			Tlab:            false,
 		},
 	}
 }

--- a/internal/component/pyroscope/java/args_test.go
+++ b/internal/component/pyroscope/java/args_test.go
@@ -1,0 +1,30 @@
+package java
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestArguments_Validate(t *testing.T) {
+	t.Run("tlab without alloc is invalid", func(t *testing.T) {
+		args := DefaultArguments()
+		args.ProfilingConfig.Tlab = true
+		args.ProfilingConfig.Alloc = ""
+		require.Error(t, args.Validate())
+	})
+
+	t.Run("tlab with alloc is valid", func(t *testing.T) {
+		args := DefaultArguments()
+		args.ProfilingConfig.Tlab = true
+		args.ProfilingConfig.Alloc = "512k"
+		require.NoError(t, args.Validate())
+	})
+
+	t.Run("tlab false without alloc is valid", func(t *testing.T) {
+		args := DefaultArguments()
+		args.ProfilingConfig.Tlab = false
+		args.ProfilingConfig.Alloc = ""
+		require.NoError(t, args.Validate())
+	})
+}

--- a/internal/component/pyroscope/java/loop.go
+++ b/internal/component/pyroscope/java/loop.go
@@ -242,6 +242,9 @@ func (p *profilingLoop) start() error {
 		}
 		if cfg.Alloc != "" {
 			argv = append(argv, "--alloc", cfg.Alloc)
+			if cfg.Tlab {
+				argv = append(argv, "--tlab")
+			}
 		}
 		if cfg.Lock != "" {
 			argv = append(argv, "--lock", cfg.Lock)

--- a/internal/component/pyroscope/java/loop_test.go
+++ b/internal/component/pyroscope/java/loop_test.go
@@ -101,6 +101,20 @@ func newTestProfilingLoop(_ *testing.T, profiler *mockProfiler, appendable pyros
 	return newProfilingLoop(os.Getpid(), target, logger, profiler, output, cfg)
 }
 
+func newTestTLABLoop(_ *testing.T, profiler *mockProfiler, appendable pyroscope.Appendable) *profilingLoop {
+	reg := prometheus.NewRegistry()
+	output := pyroscope.NewFanout([]pyroscope.Appendable{appendable}, "test-appendable", reg)
+	logger := slog.New(slog.DiscardHandler)
+	cfg := ProfilingConfig{
+		Interval:   10 * time.Millisecond,
+		SampleRate: 1000,
+		Tlab:       true,
+		Alloc:      "512k",
+	}
+	target := discovery.NewTargetFromMap(map[string]string{"foo": "bar"})
+	return newProfilingLoop(os.Getpid(), target, logger, profiler, output, cfg)
+}
+
 func newTestCustomArgumentsLoop(_ *testing.T, profiler *mockProfiler, appendable pyroscope.Appendable) *profilingLoop {
 	reg := prometheus.NewRegistry()
 	output := pyroscope.NewFanout([]pyroscope.Appendable{appendable}, "test-appendable", reg)
@@ -206,6 +220,57 @@ func TestProfilingLoop_CustomArguments(t *testing.T) {
 
 	require.NoError(t, p.Close())
 
+	_, err := os.Stat(p.jfrFile)
+	require.True(t, os.IsNotExist(err))
+
+	profiler.AssertExpectations(t)
+	appendable.AssertExpectations(t)
+}
+
+func TestProfilingLoop_TLAB(t *testing.T) {
+	profiler := &mockProfiler{}
+	appendable := &mockAppendable{}
+	pid := os.Getpid()
+	jfrPath := fmt.Sprintf("/tmp/asprof-%d-%d.jfr", pid, pid)
+
+	pCh := make(chan *profilingLoop)
+
+	profiler.On("CopyLib", pid).Return(nil).Once()
+
+	// expect the profiler to be executed with the correct arguments to start it
+	profiler.On("Execute", []string{
+		"-f",
+		jfrPath,
+		"-o", "jfr",
+		"--alloc", "512k",
+		"--tlab",
+		"start",
+		"--timeout", "0",
+		strconv.Itoa(pid),
+	}).Run(func(args mock.Arguments) {
+		// wait for the profiling loop to be created
+		p := <-pCh
+
+		// create the jfr file
+		f, err := os.Create(p.jfrFile)
+		require.NoError(t, err)
+		defer f.Close()
+	}).Return("", "", nil).Once()
+
+	// expect the profiler to be executed with the correct arguments to stop it
+	profiler.On("Execute", []string{
+		"stop",
+		"-o", "jfr",
+		strconv.Itoa(pid),
+	}).Return("", "", nil).Once()
+
+	p := newTestTLABLoop(t, profiler, appendable)
+	pCh <- p
+
+	// wait for the profiling loop to finish
+	require.NoError(t, p.Close())
+
+	// expect the profiler to clean up the jfr file
 	_, err := os.Stat(p.jfrFile)
 	require.True(t, os.IsNotExist(err))
 


### PR DESCRIPTION
### Brief description of Pull Request

Adds a `tlab` boolean to `profiling_config` that passes `--tlab` to async-profiler alongside `--alloc`, switching allocation profiling from the statistically sampled `jdk.ObjectAllocationSample` events (produced by the JVMTI ObjectSampler, default since v4.0) to the fully-instrumented `jdk.ObjectAllocationOutsideTLAB` and `jdk.ObjectAllocationInNewTLAB` events (produced by the TLAB-hook AllocTracer engine). The TLAB engine captures every allocation without sampling gaps, at the cost of higher overhead — prefer it when sampling bias would skew results, not as a general production default.

**Requires async-profiler v4.4+**. The `--tlab` engine-selection flag was introduced in v4.4 (issue #[1671](https://github.com/async-profiler/async-profiler/pull/1671)). On earlier versions the flag is unrecognised; no config-layer version check guards against this.

Without this, users who want TLAB-based allocation events had to abandon structured config and fall back to `custom_arguments`. 

Setting `tlab = true` without alloc is rejected at config parse time, since `--tlab` only affects engine selection inside the `EM_ALLOC` event path; without `--alloc` it has no effect.

### Pull Request Details

<!-- HUMAN ONLY: Motivations, trade-offs, and decisions. Write in your own words. -->

### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->

### Notes to the Reviewer

<!-- HUMAN ONLY: Context for reviewers/testers. Write in your own words. -->

### PR Checklist

<!-- HUMAN ONLY: Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))