### PR TITLE
fix: Loki components not handling new labels of targets

### DIFF
--- a/internal/component/loki/source/docker/docker.go
+++ b/internal/component/loki/source/docker/docker.go
@@ -238,6 +238,11 @@ func (c *Component) Update(args component.Arguments) error {
 				func() bool { return c.exited.Load() },
 			)
 		},
+		func(existing source.Source[string], target promTarget) (source.Source[string], error) {
+			t := existing.(*tailer)
+			t.updateLabels(target.labels.Merge(defaultLabels), c.rcs)
+			return nil, nil
+		},
 	)
 
 	c.args = newArgs

--- a/internal/component/loki/source/docker/docker_test.go
+++ b/internal/component/loki/source/docker/docker_test.go
@@ -1,13 +1,23 @@
 package docker
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/moby/moby/api/types/container"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alloy/internal/component"
+	"github.com/grafana/alloy/internal/component/common/loki"
+	alloy_relabel "github.com/grafana/alloy/internal/component/common/relabel"
 	"github.com/grafana/alloy/internal/runtime/componenttest"
 	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/grafana/alloy/internal/util"
@@ -38,6 +48,8 @@ func TestComponent(t *testing.T) {
 }
 
 func TestComponentDuplicateTargets(t *testing.T) {
+	const expectedLabels = `{__meta_docker_container_id="foo", __meta_docker_port_private="8080"}`
+
 	// Use host that works on all platforms (including Windows).
 	var cfg = `
 		host       = "tcp://127.0.0.1:9376"
@@ -73,7 +85,8 @@ func TestComponentDuplicateTargets(t *testing.T) {
 	require.Equal(t, 1, cmp.scheduler.Len())
 	for s := range cmp.scheduler.Sources() {
 		ss := s.(*tailer)
-		require.Equal(t, "{__meta_docker_container_id=\"foo\", __meta_docker_port_private=\"8080\"}", ss.labelsStr)
+		require.Equal(t, expectedLabels, ss.positionsLabels)
+		require.Equal(t, expectedLabels, ss.labels.String())
 	}
 
 	var newCfg = `
@@ -91,6 +104,124 @@ func TestComponentDuplicateTargets(t *testing.T) {
 	require.Equal(t, 1, cmp.scheduler.Len())
 	for s := range cmp.scheduler.Sources() {
 		ss := s.(*tailer)
-		require.Equal(t, "{__meta_docker_container_id=\"foo\", __meta_docker_port_private=\"8080\"}", ss.labelsStr)
+		require.Equal(t, expectedLabels, ss.positionsLabels)
+		require.Equal(t, expectedLabels, ss.labels.String())
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	server := newStreamingDockerServer(t)
+	receiver := loki.NewLogsReceiver(loki.WithChannel(make(chan loki.Entry, 2)))
+	cfg := func(env, service, release string) Arguments {
+		var args Arguments
+		err := syntax.Unmarshal([]byte(fmt.Sprintf(`
+			host       = %q
+			targets    = [
+				{__meta_docker_container_id = "abc123", service = "`+service+`"},
+			]
+			labels     = {"env" = "`+env+`"}
+			forward_to = []
+		`, server.URL)), &args)
+		require.NoError(t, err)
+		args.ForwardTo = []loki.LogsReceiver{receiver}
+		rule := alloy_relabel.DefaultRelabelConfig
+		rule.TargetLabel = "release"
+		rule.Replacement = release
+		args.RelabelRules = alloy_relabel.Rules{&rule}
+		return args
+	}
+
+	cmp, err := New(component.Options{
+		ID:         "loki.source.docker.test",
+		Logger:     logging.NewSlogNop(),
+		Registerer: prometheus.NewRegistry(),
+		DataPath:   t.TempDir(),
+	}, cfg("staging", "api", "canary"))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	runDone := make(chan error, 1)
+	go func() { runDone <- cmp.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		require.NoError(t, <-runDone)
+	})
+
+	server.Send("2024-01-01T00:00:00.000000000Z before\n")
+	before := receiveDockerEntry(t, receiver)
+	require.Equal(t, "before", before.Line)
+	beforeLabels, err := json.Marshal(before.Labels)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"env":"staging","service":"api","release":"canary"}`, string(beforeLabels))
+
+	require.NoError(t, cmp.Update(cfg("production", "gateway", "stable")))
+
+	server.Send("2024-01-01T00:00:01.000000000Z after\n")
+	after := receiveDockerEntry(t, receiver)
+	require.Equal(t, "after", after.Line)
+	afterLabels, err := json.Marshal(after.Labels)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"env":"production","service":"gateway","release":"stable"}`, string(afterLabels))
+
+	retainedLabels, err := json.Marshal(before.Labels)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"env":"staging","service":"api","release":"canary"}`, string(retainedLabels))
+	require.Equal(t, int32(1), server.logRequests.Load(), "updating labels must not restart the Docker log stream")
+}
+
+type streamingDockerServer struct {
+	*httptest.Server
+	lines       chan string
+	logRequests atomic.Int32
+}
+
+func newStreamingDockerServer(t *testing.T) *streamingDockerServer {
+	t.Helper()
+	server := &streamingDockerServer{lines: make(chan string, 2)}
+	server.Server = httptest.NewServer(http.HandlerFunc(server.serveHTTP))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func (s *streamingDockerServer) Send(line string) {
+	s.lines <- line
+}
+
+func (s *streamingDockerServer) serveHTTP(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case strings.HasSuffix(r.URL.Path, "/json"):
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(container.InspectResponse{
+			ID:     "abc123",
+			State:  &container.State{Running: true},
+			Config: &container.Config{Tty: true},
+		})
+
+	case strings.HasSuffix(r.URL.Path, "/logs"):
+		s.logRequests.Add(1)
+		flusher, _ := w.(http.Flusher)
+		for {
+			select {
+			case line := <-s.lines:
+				_, _ = fmt.Fprint(w, line)
+				flusher.Flush()
+			case <-r.Context().Done():
+				return
+			}
+		}
+
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func receiveDockerEntry(t *testing.T, receiver loki.LogsReceiver) loki.Entry {
+	t.Helper()
+	select {
+	case entry := <-receiver.Chan():
+		return entry
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Docker log entry")
+		return loki.Entry{}
 	}
 }

--- a/internal/component/loki/source/docker/tailer.go
+++ b/internal/component/loki/source/docker/tailer.go
@@ -30,25 +30,60 @@ import (
 	"github.com/grafana/alloy/internal/component/loki/source/internal/positions"
 )
 
+type tailerLabels struct {
+	mut     sync.RWMutex
+	current string
+	stdout  model.LabelSet
+	stderr  model.LabelSet
+}
+
+func (l *tailerLabels) update(base model.LabelSet, rules []*relabel.Config) {
+	current := base.String()
+	stdout := getStreamLabels(base, rules, "stdout")
+	stderr := getStreamLabels(base, rules, "stderr")
+
+	l.mut.Lock()
+	defer l.mut.Unlock()
+	l.current = current
+	l.stdout = stdout
+	l.stderr = stderr
+}
+
+func (l *tailerLabels) forStream(stdout bool) model.LabelSet {
+	l.mut.RLock()
+	defer l.mut.RUnlock()
+	if stdout {
+		return l.stdout
+	}
+	return l.stderr
+}
+
+func (l *tailerLabels) String() string {
+	l.mut.RLock()
+	defer l.mut.RUnlock()
+	return l.current
+}
+
 // tailer for Docker container logs.
 type tailer struct {
-	logger            *slog.Logger
-	recv              loki.LogsReceiver
-	positions         positions.Positions
-	containerID       string
-	labels            model.LabelSet
-	labelsStr         string
-	relabelConfig     []*relabel.Config
+	logger      *slog.Logger
+	recv        loki.LogsReceiver
+	positions   positions.Positions
+	containerID string
+	// positionsLabels is stable even when emitted labels change.
+	positionsLabels   string
 	metrics           *metrics
 	restartInterval   time.Duration
 	componentStopping func() bool
 
 	client client.APIClient
 
-	mu      sync.Mutex // protects cancel, running and err fields
+	mu      sync.Mutex // protects cancel, running and err
 	err     error
 	running bool
 	cancel  context.CancelFunc
+
+	labels tailerLabels
 
 	wg sync.WaitGroup
 
@@ -63,27 +98,32 @@ func newTailer(
 	componentStopping func() bool,
 ) (*tailer, error) {
 
-	labelsStr := labels.String()
-	pos, err := position.Get(positions.CursorKey(containerID), labelsStr)
+	positionsLabels := labels.String()
+	pos, err := position.Get(positions.CursorKey(containerID), positionsLabels)
 	if err != nil {
 		return nil, err
 	}
 
-	return &tailer{
+	t := &tailer{
 		logger:            logger,
 		recv:              recv,
 		since:             atomic.NewInt64(pos),
 		last:              atomic.NewInt64(0),
 		positions:         position,
 		containerID:       containerID,
-		labels:            labels,
-		labelsStr:         labelsStr,
-		relabelConfig:     relabelConfig,
+		positionsLabels:   positionsLabels,
 		metrics:           metrics,
 		client:            client,
 		restartInterval:   restartInterval,
 		componentStopping: componentStopping,
-	}, nil
+	}
+	t.updateLabels(labels, relabelConfig)
+	return t, nil
+}
+
+// updateLabels changes labels for new entries without restarting the log stream.
+func (t *tailer) updateLabels(labels model.LabelSet, relabelConfig []*relabel.Config) {
+	t.labels.update(labels, relabelConfig)
 }
 
 func (t *tailer) Run(ctx context.Context) {
@@ -174,7 +214,7 @@ func (t *tailer) stop() {
 		// If the component is not stopping, then it means that the target for this component is gone and that
 		// we should clear the entry from the positions file.
 		if !t.componentStopping() {
-			t.positions.Remove(positions.CursorKey(t.containerID), t.labelsStr)
+			t.positions.Remove(positions.CursorKey(t.containerID), t.positionsLabels)
 		}
 	}
 }
@@ -196,9 +236,9 @@ func (t *tailer) DebugInfo() sourceInfo {
 	return sourceInfo{
 		ID:         t.containerID,
 		LastError:  errMsg,
-		Labels:     t.labelsStr,
+		Labels:     t.labels.String(),
 		IsRunning:  running,
-		ReadOffset: t.positions.GetString(positions.CursorKey(t.containerID), t.labelsStr),
+		ReadOffset: t.positions.GetString(positions.CursorKey(t.containerID), t.positionsLabels),
 	}
 }
 
@@ -243,12 +283,12 @@ func (t *tailer) processLoop(ctx context.Context, tty bool, reader io.ReadCloser
 	// Start processing
 	go func() {
 		defer t.wg.Done()
-		t.process(rstdout, t.getStreamLabels("stdout"))
+		t.process(rstdout, true)
 	}()
 
 	go func() {
 		defer t.wg.Done()
-		t.process(rstderr, t.getStreamLabels("stderr"))
+		t.process(rstderr, false)
 	}()
 
 	// Wait until done
@@ -273,7 +313,7 @@ func extractTsFromBytes(line []byte) (time.Time, []byte, error) {
 	return ts, line[spaceIdx+1:], nil
 }
 
-func (t *tailer) process(r io.Reader, logStreamLset model.LabelSet) {
+func (t *tailer) process(r io.Reader, stdout bool) {
 	const maxCapacity = dockerMaxChunkSize * 64
 
 	reader := bufio.NewReader(r)
@@ -322,7 +362,9 @@ func (t *tailer) process(r io.Reader, logStreamLset model.LabelSet) {
 			continue
 		}
 
-		t.recv.Chan() <- loki.NewEntry(logStreamLset, push.Entry{
+		// Read the label set per entry so that a label change applied by
+		// updateLabels takes effect without restarting the log stream.
+		t.recv.Chan() <- loki.NewEntry(t.labels.forStream(stdout), push.Entry{
 			Timestamp: ts,
 			Line:      string(content),
 		})
@@ -334,22 +376,22 @@ func (t *tailer) process(r io.Reader, logStreamLset model.LabelSet) {
 		// problematic if we have the same container with a different set of
 		// labels (e.g. duplicated and relabeled), but this shouldn't be the
 		// case anyway.
-		t.positions.Put(positions.CursorKey(t.containerID), t.labelsStr, ts.Unix())
+		t.positions.Put(positions.CursorKey(t.containerID), t.positionsLabels, ts.Unix())
 		t.since.Store(ts.Unix())
 		t.last.Store(time.Now().Unix())
 	}
 }
 
-func (t *tailer) getStreamLabels(logStream string) model.LabelSet {
+func getStreamLabels(base model.LabelSet, rules []*relabel.Config, logStream string) model.LabelSet {
 	// Add all labels from the config, relabel and filter them.
 	lb := labels.NewBuilder(labels.EmptyLabels())
-	for k, v := range t.labels {
+	for k, v := range base {
 		lb.Set(string(k), string(v))
 	}
 
 	lb.Set(dockerLabelLogStream, logStream)
 	processed := labels.EmptyLabels()
-	if relabel.ProcessBuilder(lb, t.relabelConfig...) {
+	if relabel.ProcessBuilder(lb, rules...) {
 		processed = lb.Labels()
 	}
 

--- a/internal/component/loki/source/docker/tailer_test.go
+++ b/internal/component/loki/source/docker/tailer_test.go
@@ -517,3 +517,84 @@ func (sw *stdWriter) Write(p []byte) (int, error) {
 	}
 	return sw.Writer.Write(p)
 }
+
+func TestTailerUpdateLabelsAppliesToNewEntries(t *testing.T) {
+	logger := logging.NewSlogNop()
+	entryHandler := loki.NewCollectingHandler()
+	defer entryHandler.Stop()
+
+	ps, err := positions.New(logger, positions.Config{
+		SyncPeriod:    10 * time.Second,
+		PositionsFile: t.TempDir() + "/positions.yml",
+	})
+	require.NoError(t, err)
+	defer ps.Stop()
+
+	tailer, err := newTailer(
+		newMetrics(prometheus.NewRegistry()),
+		logger,
+		entryHandler.Receiver(),
+		ps,
+		"container-id",
+		model.LabelSet{"job": "docker", "env": "staging"},
+		[]*relabel.Config{},
+		nil,
+		restartInterval,
+		func() bool { return false },
+	)
+	require.NoError(t, err)
+
+	// process is fed directly so the label change can be applied while the
+	// stream stays open, which is the behaviour under test.
+	pr, pw := io.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		tailer.process(pr, true)
+	}()
+
+	_, err = pw.Write([]byte("2024-01-01T00:00:00.000000000Z before\n"))
+	require.NoError(t, err)
+
+	lineLabels := func(line string) (model.LabelSet, bool) {
+		for _, e := range entryHandler.Received() {
+			if e.Line == line {
+				return e.Labels, true
+			}
+		}
+		return nil, false
+	}
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		lset, ok := lineLabels("before")
+		if !assert.True(c, ok) {
+			return
+		}
+		assert.Equal(c, model.LabelValue("staging"), lset["env"])
+	}, time.Second, 10*time.Millisecond)
+
+	tailer.updateLabels(model.LabelSet{"job": "docker", "env": "production"}, []*relabel.Config{})
+
+	_, err = pw.Write([]byte("2024-01-01T00:00:01.000000000Z after\n"))
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		lset, ok := lineLabels("after")
+		if !assert.True(c, ok) {
+			return
+		}
+		assert.Equal(c, model.LabelValue("production"), lset["env"])
+	}, time.Second, 10*time.Millisecond)
+
+	// Entries already read keep the labels that applied when they were read.
+	lset, ok := lineLabels("before")
+	require.True(t, ok)
+	require.Equal(t, model.LabelValue("staging"), lset["env"])
+
+	require.NoError(t, pw.Close())
+	<-done
+
+	// The positions key must stay stable, otherwise the read offset for this
+	// container is orphaned and its log is re-shipped from the beginning.
+	require.Equal(t, `{env="staging", job="docker"}`, tailer.positionsLabels)
+}

--- a/internal/component/loki/source/file/file.go
+++ b/internal/component/loki/source/file/file.go
@@ -328,39 +328,55 @@ func (c *Component) scheduleSources() {
 		func(_ positions.Entry, target resolvedTarget) (source.Source[positions.Entry], error) {
 			return c.createSource(target)
 		},
+		func(existing source.Source[positions.Entry], target resolvedTarget) (source.Source[positions.Entry], error) {
+			current := existing.(*fileSource).tailer
+			if current.readerOptions == c.sourceOptions(target).readerOptions() {
+				return nil, nil
+			}
+
+			replacement, err := c.createSource(target)
+			if err != nil {
+				return nil, err
+			}
+
+			// Replacing a source for the same path and labels must retain its
+			// offset so the replacement continues where the old reader stopped.
+			current.preservePosition.Store(true)
+			return replacement, nil
+		},
 	)
 }
 
 func (c *Component) createSource(target resolvedTarget) (source.Source[positions.Entry], error) {
 	fi, err := os.Stat(target.Path)
-			if err != nil {
-				c.metrics.totalBytes.DeleteLabelValues(target.Path)
-				return nil, fmt.Errorf("failed to tail file, stat failed: %w", err)
-			}
+	if err != nil {
+		c.metrics.totalBytes.DeleteLabelValues(target.Path)
+		return nil, fmt.Errorf("failed to tail file, stat failed: %w", err)
+	}
 
-			if fi.IsDir() {
-				c.metrics.totalBytes.DeleteLabelValues(target.Path)
-				return nil, errors.New("failed to tail file, is directory")
-			}
+	if fi.IsDir() {
+		c.metrics.totalBytes.DeleteLabelValues(target.Path)
+		return nil, errors.New("failed to tail file, is directory")
+	}
 
-			if c.args.FileMatch.Enabled && c.args.FileMatch.IgnoreOlderThan != 0 && fi.ModTime().Before(time.Now().Add(-c.args.FileMatch.IgnoreOlderThan)) {
-				return nil, source.ErrSkip
-			}
+	if c.args.FileMatch.Enabled && c.args.FileMatch.IgnoreOlderThan != 0 && fi.ModTime().Before(time.Now().Add(-c.args.FileMatch.IgnoreOlderThan)) {
+		return nil, source.ErrSkip
+	}
 
-			c.metrics.totalBytes.WithLabelValues(target.Path).Set(float64(fi.Size()))
+	c.metrics.totalBytes.WithLabelValues(target.Path).Set(float64(fi.Size()))
 	return c.newSource(c.sourceOptions(target))
 }
 
 func (c *Component) sourceOptions(target resolvedTarget) sourceOptions {
 	return sourceOptions{
-				path:                 target.Path,
-				labels:               target.Labels,
-				encoding:             c.args.Encoding,
-				decompressionConfig:  c.args.DecompressionConfig,
-				fileWatch:            c.args.FileWatch,
-				tailFromEnd:          c.args.TailFromEnd,
-				onPositionsFileError: c.args.OnPositionsFileError,
-				legacyPositionUsed:   c.args.LegacyPositionsFile != "",
+		path:                 target.Path,
+		labels:               target.Labels,
+		encoding:             c.args.Encoding,
+		decompressionConfig:  c.args.DecompressionConfig,
+		fileWatch:            c.args.FileWatch,
+		tailFromEnd:          c.args.TailFromEnd,
+		onPositionsFileError: c.args.OnPositionsFileError,
+		legacyPositionUsed:   c.args.LegacyPositionsFile != "",
 	}
 }
 

--- a/internal/component/loki/source/file/file.go
+++ b/internal/component/loki/source/file/file.go
@@ -326,7 +326,13 @@ func (c *Component) scheduleSources() {
 			return positions.Entry{Path: target.Path, Labels: target.Labels.String()}
 		},
 		func(_ positions.Entry, target resolvedTarget) (source.Source[positions.Entry], error) {
-			fi, err := os.Stat(target.Path)
+			return c.createSource(target)
+		},
+	)
+}
+
+func (c *Component) createSource(target resolvedTarget) (source.Source[positions.Entry], error) {
+	fi, err := os.Stat(target.Path)
 			if err != nil {
 				c.metrics.totalBytes.DeleteLabelValues(target.Path)
 				return nil, fmt.Errorf("failed to tail file, stat failed: %w", err)
@@ -342,8 +348,11 @@ func (c *Component) scheduleSources() {
 			}
 
 			c.metrics.totalBytes.WithLabelValues(target.Path).Set(float64(fi.Size()))
+	return c.newSource(c.sourceOptions(target))
+}
 
-			return c.newSource(sourceOptions{
+func (c *Component) sourceOptions(target resolvedTarget) sourceOptions {
+	return sourceOptions{
 				path:                 target.Path,
 				labels:               target.Labels,
 				encoding:             c.args.Encoding,
@@ -352,9 +361,7 @@ func (c *Component) scheduleSources() {
 				tailFromEnd:          c.args.TailFromEnd,
 				onPositionsFileError: c.args.OnPositionsFileError,
 				legacyPositionUsed:   c.args.LegacyPositionsFile != "",
-			})
-		},
-	)
+	}
 }
 
 type debugInfo struct {
@@ -395,7 +402,47 @@ type sourceOptions struct {
 	legacyPositionUsed   bool
 }
 
-// newSource will return a decompressor source if enabled, otherwise a tailer source.
+// readerOptions contains the comparable options that determine how a source
+// reads a file. Changes to these options require replacing the source.
+type readerOptions struct {
+	encoding             string
+	decompressionConfig  DecompressionConfig
+	fileWatch            FileWatch
+	tailFromEnd          bool
+	onPositionsFileError OnPositionsFileError
+	legacyPositionUsed   bool
+}
+
+func (o sourceOptions) readerOptions() readerOptions {
+	return readerOptions{
+		encoding:             o.encoding,
+		decompressionConfig:  o.decompressionConfig,
+		fileWatch:            o.fileWatch,
+		tailFromEnd:          o.tailFromEnd,
+		onPositionsFileError: o.onPositionsFileError,
+		legacyPositionUsed:   o.legacyPositionUsed,
+	}
+}
+
+// fileSource keeps the concrete source type stable while optionally adding
+// retry behavior around its tailer.
+type fileSource struct {
+	*tailer
+}
+
+func (s *fileSource) Run(ctx context.Context) {
+	// When decompression is enabled we don't retry starting the tailer.
+	if s.readerOptions.decompressionConfig.Enabled {
+		s.tailer.Run(ctx)
+		return
+	}
+
+	source.NewSourceWithRetry(s.tailer, backoff.Config{
+		MinBackoff: 1 * time.Second,
+		MaxBackoff: 10 * time.Second,
+	}).Run(ctx)
+}
+
 func (c *Component) newSource(opts sourceOptions) (source.Source[positions.Entry], error) {
 	tailer := newTailer(
 		c.metrics,
@@ -405,16 +452,7 @@ func (c *Component) newSource(opts sourceOptions) (source.Source[positions.Entry
 		c.IsStopping,
 		opts,
 	)
-
-	// When decompression is enabled we don't retry starting tailer.
-	if opts.decompressionConfig.Enabled {
-		return tailer, nil
-	}
-
-	return source.NewSourceWithRetry(tailer, backoff.Config{
-		MinBackoff: 1 * time.Second,
-		MaxBackoff: 10 * time.Second,
-	}), nil
+	return &fileSource{tailer: tailer}, nil
 }
 
 func (c *Component) IsStopping() bool {

--- a/internal/component/loki/source/file/file_test.go
+++ b/internal/component/loki/source/file/file_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+	"golang.org/x/text/encoding/unicode"
 
 	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/component/common/loki"
@@ -359,6 +360,76 @@ func TestUpdate_NoLeak(t *testing.T) {
 			require.NoError(t, err)
 		}
 	})
+}
+
+func TestUpdateAppliesEncoding(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		f, err := os.CreateTemp(t.TempDir(), "example")
+		require.NoError(t, err)
+		defer f.Close()
+		_, err = f.WriteString("before update\n")
+		require.NoError(t, err)
+
+		receiver := loki.NewLogsReceiver(loki.WithChannel(make(chan loki.Entry, 1)))
+		var args Arguments
+		require.NoError(t, syntax.Unmarshal([]byte(fmt.Sprintf(`
+			forward_to = []
+			targets = [{
+				__path__ = %q,
+				foo      = "bar",
+			}]
+			encoding = "UTF-8"
+			file_watch {
+				min_poll_frequency = "10ms"
+				max_poll_frequency = "10ms"
+			}
+		`, f.Name())), &args))
+		args.ForwardTo = []loki.LogsReceiver{receiver}
+
+		c, err := New(component.Options{
+			Logger:     logging.NewSlogNop(),
+			Registerer: prometheus.NewRegistry(),
+			DataPath:   t.TempDir(),
+		}, args)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		runDone := make(chan error, 1)
+		go func() { runDone <- c.Run(ctx) }()
+		defer func() {
+			cancel()
+			require.NoError(t, <-runDone)
+		}()
+
+		entry := receiveLogEntry(t, receiver)
+		require.Equal(t, "before update", entry.Line)
+		synctest.Wait()
+
+		args.Encoding = "UTF-16LE"
+		require.NoError(t, c.Update(args))
+		synctest.Wait()
+
+		encodedLine, err := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM).
+			NewEncoder().
+			Bytes([]byte("after update\n"))
+		require.NoError(t, err)
+		_, err = f.Write(encodedLine)
+		require.NoError(t, err)
+
+		entry = receiveLogEntry(t, receiver)
+		require.Equal(t, "after update", entry.Line)
+	})
+}
+
+func receiveLogEntry(t *testing.T, receiver loki.LogsReceiver) loki.Entry {
+	t.Helper()
+	select {
+	case entry := <-receiver.Chan():
+		return entry
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for log entry")
+		return loki.Entry{}
+	}
 }
 
 func TestTwoTargets(t *testing.T) {

--- a/internal/component/loki/source/file/tailer.go
+++ b/internal/component/loki/source/file/tailer.go
@@ -29,23 +29,18 @@ type tailer struct {
 	receiver  loki.LogsReceiver
 	positions positions.Positions
 
-	key                positions.Entry
-	labels             model.LabelSet
-	legacyPositionUsed bool
-
-	tailFromEnd          bool
-	onPositionsFileError OnPositionsFileError
-	watcherConfig        tail.WatcherConfig
+	key           positions.Entry
+	labels        model.LabelSet
+	readerOptions readerOptions
 
 	running *atomic.Bool
 
 	componentStopping func() bool
+	preservePosition  atomic.Bool
 
 	report sync.Once
 
-	file          *tail.File
-	encoding      string
-	decompression DecompressionConfig
+	file *tail.File
 }
 
 func newTailer(
@@ -58,24 +53,16 @@ func newTailer(
 ) *tailer {
 
 	return &tailer{
-		metrics:              metrics,
-		logger:               logger.With("component", "tailer", "path", opts.path),
-		receiver:             receiver,
-		positions:            pos,
-		key:                  positions.Entry{Path: opts.path, Labels: opts.labels.String()},
-		labels:               opts.labels.Merge(model.LabelSet{labelFilename: model.LabelValue(opts.path)}),
-		running:              atomic.NewBool(false),
-		tailFromEnd:          opts.tailFromEnd,
-		legacyPositionUsed:   opts.legacyPositionUsed,
-		onPositionsFileError: opts.onPositionsFileError,
-		watcherConfig: tail.WatcherConfig{
-			MinPollFrequency: opts.fileWatch.MinPollFrequency,
-			MaxPollFrequency: opts.fileWatch.MaxPollFrequency,
-		},
+		metrics:           metrics,
+		logger:            logger.With("component", "tailer", "path", opts.path),
+		receiver:          receiver,
+		positions:         pos,
+		key:               positions.Entry{Path: opts.path, Labels: opts.labels.String()},
+		labels:            opts.labels.Merge(model.LabelSet{labelFilename: model.LabelValue(opts.path)}),
+		readerOptions:     opts.readerOptions(),
+		running:           atomic.NewBool(false),
 		componentStopping: componentStopping,
 		report:            sync.Once{},
-		encoding:          opts.encoding,
-		decompression:     opts.decompressionConfig,
 	}
 }
 
@@ -109,18 +96,18 @@ func (t *tailer) initRun() (int64, error) {
 		return 0, fmt.Errorf("failed to tail file: %w", err)
 	}
 
-	startFromEnd := t.tailFromEnd
+	startFromEnd := t.readerOptions.tailFromEnd
 
 	pos, err := t.positions.Get(t.key.Path, t.key.Labels)
 	if err != nil {
-		switch t.onPositionsFileError {
+		switch t.readerOptions.onPositionsFileError {
 		case OnPositionsFileErrorSkip:
 			return 0, fmt.Errorf("failed to get file position: %w", err)
 		case OnPositionsFileErrorRestartEnd:
 			startFromEnd = true
 			t.logger.Info("reset position to end of file after position error")
 		default:
-			t.logger.Debug("unrecognized `on_positions_file_error` option, defaulting to `restart_from_beginning`", "option", t.onPositionsFileError)
+			t.logger.Debug("unrecognized `on_positions_file_error` option, defaulting to `restart_from_beginning`", "option", t.readerOptions.onPositionsFileError)
 			fallthrough
 		case OnPositionsFileErrorRestartBeginning:
 			pos = 0
@@ -130,7 +117,7 @@ func (t *tailer) initRun() (int64, error) {
 
 	// If we translated legacy positions we should try to get position offset without labels
 	// when no other position was matched.
-	if pos == 0 && t.legacyPositionUsed {
+	if pos == 0 && t.readerOptions.legacyPositionUsed {
 		pos, err = t.positions.Get(t.key.Path, "{}")
 		if err != nil {
 			return 0, fmt.Errorf("failed to get file position with empty labels: %w", err)
@@ -147,12 +134,15 @@ func (t *tailer) initRun() (int64, error) {
 	}
 
 	file, err := tail.NewFile(t.logger, &tail.Config{
-		Filename:      t.key.Path,
-		Offset:        pos,
-		StartFromEnd:  startFromEnd,
-		Encoding:      t.encoding,
-		Compression:   t.decompression.GetFormat(),
-		WatcherConfig: t.watcherConfig,
+		Filename:     t.key.Path,
+		Offset:       pos,
+		StartFromEnd: startFromEnd,
+		Encoding:     t.readerOptions.encoding,
+		Compression:  t.readerOptions.decompressionConfig.GetFormat(),
+		WatcherConfig: tail.WatcherConfig{
+			MinPollFrequency: t.readerOptions.fileWatch.MinPollFrequency,
+			MaxPollFrequency: t.readerOptions.fileWatch.MaxPollFrequency,
+		},
 	})
 
 	if err != nil {
@@ -171,9 +161,9 @@ func (t *tailer) tail(ctx context.Context, pos int64) {
 	t.metrics.filesActive.Add(1.)
 	t.logger.Info("start tailing file")
 
-	if t.decompression.Enabled && t.decompression.InitialDelay > 0 {
-		t.logger.Info("sleeping before reading file", "duration", t.decompression.InitialDelay.String())
-		time.Sleep(t.decompression.InitialDelay)
+	if t.readerOptions.decompressionConfig.Enabled && t.readerOptions.decompressionConfig.InitialDelay > 0 {
+		t.logger.Info("sleeping before reading file", "duration", t.readerOptions.decompressionConfig.InitialDelay.String())
+		time.Sleep(t.readerOptions.decompressionConfig.InitialDelay)
 	}
 
 	var (
@@ -221,7 +211,7 @@ func (t *tailer) tail(ctx context.Context, pos int64) {
 				return line, err
 			}
 
-			if t.decompression.Enabled {
+			if t.readerOptions.decompressionConfig.Enabled {
 				return t.file.Flush()
 			}
 
@@ -274,7 +264,7 @@ func (t *tailer) shouldKeepPosition() bool {
 	// If component is not stopping that means that target is gone and we should no longer tail the file.
 	// If decompression is enabled we read file until we reach EOF and stop so tailer will exit, but we need
 	// to remember the position so that we don't re-ingest it on restart.
-	return t.componentStopping() || t.decompression.Enabled
+	return t.componentStopping() || t.readerOptions.decompressionConfig.Enabled || t.preservePosition.Load()
 }
 
 // cleanupMetrics removes all metrics exported by this tailer

--- a/internal/component/loki/source/kubernetes_events/event_controller.go
+++ b/internal/component/loki/source/kubernetes_events/event_controller.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/grafana/loki/pkg/push"
@@ -44,6 +45,8 @@ type eventController struct {
 	opts    eventControllerOptions
 	handler loki.EntryHandler
 
+	formatMut sync.RWMutex
+
 	positionsKey  string
 	initTimestamp time.Time
 }
@@ -79,6 +82,16 @@ func (ctrl *eventController) Run(ctx context.Context) {
 
 func (ctrl *eventController) Key() string {
 	return ctrl.opts.Namespace
+}
+
+// update applies output settings that can change without restarting the informer.
+// Other controller options are immutable or handled through reconciliation.
+func (ctrl *eventController) update(jobName, logFormat string) {
+	ctrl.formatMut.Lock()
+	defer ctrl.formatMut.Unlock()
+
+	ctrl.opts.JobName = jobName
+	ctrl.opts.LogFormat = logFormat
 }
 
 func (ctrl *eventController) runError(ctx context.Context) error {
@@ -229,6 +242,11 @@ func (ctrl *eventController) handleEvent(ctx context.Context, event *corev1.Even
 }
 
 func (ctrl *eventController) parseEvent(event *corev1.Event) (model.LabelSet, string, error) {
+	ctrl.formatMut.RLock()
+	jobName := ctrl.opts.JobName
+	logFormat := ctrl.opts.LogFormat
+	ctrl.formatMut.RUnlock()
+
 	var (
 		msg      strings.Builder
 		lset     = make(model.LabelSet)
@@ -242,10 +260,10 @@ func (ctrl *eventController) parseEvent(event *corev1.Event) (model.LabelSet, st
 	}
 
 	lset[model.LabelName("namespace")] = model.LabelValue(obj.Namespace)
-	lset[model.LabelName("job")] = model.LabelValue(ctrl.opts.JobName)
+	lset[model.LabelName("job")] = model.LabelValue(jobName)
 	lset[model.LabelName("instance")] = model.LabelValue(ctrl.opts.InstanceName)
 
-	if ctrl.opts.LogFormat == logFormatJson {
+	if logFormat == logFormatJson {
 		appender = appendJsonMsg
 	}
 
@@ -289,7 +307,7 @@ func (ctrl *eventController) parseEvent(event *corev1.Event) (model.LabelSet, st
 
 	appender(&msg, fields, "msg", event.Message, "%q")
 
-	if ctrl.opts.LogFormat == logFormatJson {
+	if logFormat == logFormatJson {
 		bb, err := json.Marshal(fields)
 		if err != nil {
 			return nil, "", fmt.Errorf("failed to marshal Event to JSON: %w", err)

--- a/internal/component/loki/source/kubernetes_events/event_controller.go
+++ b/internal/component/loki/source/kubernetes_events/event_controller.go
@@ -27,6 +27,8 @@ const (
 	logFormatFmt  = "logfmt"
 )
 
+var newCache = cache.New
+
 type eventControllerOptions struct {
 	Log          *slog.Logger
 	Config       *rest.Config // Config to connect to Kubernetes.
@@ -93,7 +95,7 @@ func (ctrl *eventController) runError(ctx context.Context) error {
 		Scheme:            scheme,
 		DefaultNamespaces: defaultNamespaces,
 	}
-	informers, err := cache.New(ctrl.opts.Config, opts)
+	informers, err := newCache(ctrl.opts.Config, opts)
 	if err != nil {
 		return fmt.Errorf("creating informers cache: %w", err)
 	}

--- a/internal/component/loki/source/kubernetes_events/kubernetes_events.go
+++ b/internal/component/loki/source/kubernetes_events/kubernetes_events.go
@@ -195,6 +195,10 @@ func (c *Component) reconcile() {
 				LogFormat:    c.args.LogFormat,
 			}), nil
 		},
+		func(existing source.Source[string], _ string) (source.Source[string], error) {
+			existing.(*eventController).update(c.args.JobName, c.args.LogFormat)
+			return nil, nil
+		},
 	)
 }
 

--- a/internal/component/loki/source/kubernetes_events/kubernetes_events_test.go
+++ b/internal/component/loki/source/kubernetes_events/kubernetes_events_test.go
@@ -1,0 +1,155 @@
+package kubernetes_events
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	cachetools "k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/grafana/alloy/internal/component"
+	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/runtime/logging"
+	"github.com/grafana/alloy/internal/service/cluster"
+	"github.com/grafana/alloy/syntax"
+)
+
+func TestUpdate(t *testing.T) {
+	fixture := newTestFixture(t)
+	var args Arguments
+	require.NoError(t, syntax.Unmarshal([]byte(`
+		forward_to = []
+		job_name   = "events-before"
+		log_format = "logfmt"
+
+		client {
+			api_server = "http://127.0.0.1:1"
+		}
+	`), &args))
+	c := fixture.New(&args)
+
+	eventTime := time.Now()
+	fixture.SendEvent("alloy-reloaded-before", eventTime)
+	entry := fixture.ReceiveEntry()
+	require.Equal(t, model.LabelValue("events-before"), entry.Labels["job"])
+	require.Equal(t, `name=alloy msg="configuration reloaded" `, entry.Line)
+
+	args.JobName = "events-after"
+	args.LogFormat = logFormatJson
+	require.NoError(t, c.Update(args))
+
+	fixture.SendEvent("alloy-reloaded-after", eventTime.Add(time.Second))
+	entry = fixture.ReceiveEntry()
+	require.Equal(t, model.LabelValue("events-after"), entry.Labels["job"])
+	require.JSONEq(t, `{"msg":"configuration reloaded","name":"alloy"}`, entry.Line)
+}
+
+type testFixture struct {
+	t          *testing.T
+	ctx        context.Context
+	fakeClient *fake.Clientset
+	receiver   loki.LogsReceiver
+}
+
+func newTestFixture(t *testing.T) *testFixture {
+	t.Helper()
+
+	fakeClient := fake.NewClientset()
+	informerFactory := informers.NewSharedInformerFactory(fakeClient, 0)
+	fakeCache := &eventCache{informer: informerFactory.Core().V1().Events().Informer()}
+	originalNewCache := newCache
+	newCache = func(*rest.Config, cache.Options) (cache.Cache, error) {
+		return fakeCache, nil
+	}
+	t.Cleanup(func() { newCache = originalNewCache })
+
+	return &testFixture{
+		t:          t,
+		ctx:        context.Background(),
+		fakeClient: fakeClient,
+		receiver:   loki.NewLogsReceiver(loki.WithChannel(make(chan loki.Entry, 1))),
+	}
+}
+
+func (f *testFixture) New(args *Arguments) *Component {
+	f.t.Helper()
+	args.ForwardTo = []loki.LogsReceiver{f.receiver}
+
+	c, err := New(component.Options{
+		ID:       "loki.source.kubernetes_events.test",
+		Logger:   logging.NewSlogNop(),
+		DataPath: f.t.TempDir(),
+		GetServiceData: func(name string) (any, error) {
+			if name != cluster.ServiceName {
+				return nil, fmt.Errorf("unexpected service %q", name)
+			}
+			return cluster.Mock(), nil
+		},
+	}, *args)
+	require.NoError(f.t, err)
+
+	ctx, cancel := context.WithCancel(f.ctx)
+	runDone := make(chan error, 1)
+	go func() { runDone <- c.Run(ctx) }()
+	f.t.Cleanup(func() {
+		cancel()
+		require.NoError(f.t, <-runDone)
+	})
+	return c
+}
+
+func (f *testFixture) SendEvent(name string, eventTime time.Time) {
+	f.t.Helper()
+	_, err := f.fakeClient.CoreV1().Events("default").Create(f.ctx, &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		EventTime: metav1.MicroTime{Time: eventTime},
+		InvolvedObject: corev1.ObjectReference{
+			Name:      "alloy",
+			Namespace: "default",
+		},
+		Message: "configuration reloaded",
+	}, metav1.CreateOptions{})
+	require.NoError(f.t, err)
+}
+
+func (f *testFixture) ReceiveEntry() loki.Entry {
+	f.t.Helper()
+	select {
+	case entry := <-f.receiver.Chan():
+		return entry
+	case <-time.After(time.Second):
+		f.t.Fatal("timed out waiting for event")
+		return loki.Entry{}
+	}
+}
+
+type eventCache struct {
+	cache.Cache
+	informer cachetools.SharedIndexInformer
+}
+
+func (c *eventCache) GetInformer(context.Context, client.Object, ...cache.InformerGetOption) (cache.Informer, error) {
+	return c.informer, nil
+}
+
+func (c *eventCache) Start(ctx context.Context) error {
+	c.informer.Run(ctx.Done())
+	return nil
+}
+
+func (c *eventCache) WaitForCacheSync(ctx context.Context) bool {
+	return cachetools.WaitForCacheSync(ctx.Done(), c.informer.HasSynced)
+}

--- a/internal/component/loki/source/reconcile.go
+++ b/internal/component/loki/source/reconcile.go
@@ -19,15 +19,24 @@ type KeyFn[Key comparable, Input any] func(Input) Key
 // without logging an error.
 type SourceFactoryFn[Key comparable, Input any] func(Key, Input) (Source[Key], error)
 
+// SourceUpdateFn updates a source which is already scheduled for an input.
+//
+// If the source can be updated in place, SourceUpdateFn should update it and
+// return nil. If the source must be restarted, SourceUpdateFn should return a
+// replacement source. Returning ErrSkip stops the existing source without
+// scheduling a replacement.
+type SourceUpdateFn[Key comparable, Input any] func(Source[Key], Input) (Source[Key], error)
+
 // Reconcile synchronizes the scheduler's set of running sources with a desired state.
-// It iterates over inputs, creates sources for new items, and stops sources that are
-// no longer needed.
+// It iterates over inputs, creates sources for new items, updates or replaces existing
+// sources, and stops sources that are no longer needed.
 func Reconcile[Key comparable, Input any](
 	logger *slog.Logger,
 	s *Scheduler[Key],
 	it iter.Seq[Input],
 	keyFn KeyFn[Key, Input],
 	sourceFactoryFn SourceFactoryFn[Key, Input],
+	sourceUpdateFn SourceUpdateFn[Key, Input],
 ) {
 	// shouldRun tracks the set of keys that should be active after reconciliation.
 	shouldRun := make(map[Key]struct{})
@@ -43,8 +52,30 @@ func Reconcile[Key comparable, Input any](
 
 		shouldRun[key] = struct{}{}
 
-		// Skip if a source with this key is already running.
-		if s.Contains(key) {
+		// Update or replace a source with this key if one is already running.
+		if existing, ok := s.GetSource(key); ok {
+			if sourceUpdateFn == nil {
+				continue
+			}
+
+			replacement, err := sourceUpdateFn(existing, i)
+			if err != nil {
+				if errors.Is(err, ErrSkip) {
+					s.StopSource(existing)
+					delete(shouldRun, key)
+				} else {
+					logger.Error("failed to update source, keeping existing source", "error", err, "key", key)
+				}
+				continue
+			}
+
+			if replacement != nil {
+				if replacement.Key() != key {
+					logger.Error("failed to replace source, replacement has a different key", "key", key, "replacement_key", replacement.Key())
+					continue
+				}
+				s.ReplaceSource(existing, replacement)
+			}
 			continue
 		}
 

--- a/internal/component/loki/source/reconcile_test.go
+++ b/internal/component/loki/source/reconcile_test.go
@@ -3,6 +3,7 @@ package source
 import (
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/stretchr/testify/require"
@@ -23,6 +24,7 @@ func TestReconcile(t *testing.T) {
 			func(key int, target int) (Source[int], error) {
 				return newTestSource(key, false), nil
 			},
+			nil,
 		)
 		require.Equal(t, 3, s.Len())
 	})
@@ -38,11 +40,13 @@ func TestReconcile(t *testing.T) {
 			func(key int, target int) (Source[int], error) {
 				return newTestSource(key, false), nil
 			},
+			nil,
 		)
 		require.Equal(t, 2, s.Len())
 	})
 
-	t.Run("should prevent duplicated source from being scheduled", func(t *testing.T) {
+	t.Run("should process a duplicated key once", func(t *testing.T) {
+		var updated []int
 		Reconcile(
 			logging.NewSlogNop(),
 			s,
@@ -53,7 +57,12 @@ func TestReconcile(t *testing.T) {
 			func(key int, target int) (Source[int], error) {
 				return newTestSource(key, false), nil
 			},
+			func(existing Source[int], target int) (Source[int], error) {
+				updated = append(updated, target)
+				return nil, nil
+			},
 		)
+		require.Equal(t, []int{2, 3}, updated)
 		require.Equal(t, 2, s.Len())
 	})
 
@@ -71,7 +80,60 @@ func TestReconcile(t *testing.T) {
 				}
 				return newTestSource(key, false), nil
 			},
+			nil,
 		)
+		require.Equal(t, 2, s.Len())
+	})
+
+	t.Run("should update an existing source", func(t *testing.T) {
+		var updated []int
+		Reconcile(
+			logging.NewSlogNop(),
+			s,
+			slices.Values([]int{2, 3}),
+			func(v int) int {
+				return v
+			},
+			func(key int, target int) (Source[int], error) {
+				return newTestSource(key, false), nil
+			},
+			func(existing Source[int], target int) (Source[int], error) {
+				updated = append(updated, target)
+				return nil, nil
+			},
+		)
+		require.ElementsMatch(t, []int{2, 3}, updated)
+		require.Equal(t, 2, s.Len())
+	})
+
+	t.Run("should replace an existing source", func(t *testing.T) {
+		before, ok := s.GetSource(2)
+		require.True(t, ok)
+		require.Eventually(t, before.(*testSource).IsRunning, time.Second, 10*time.Millisecond)
+
+		Reconcile(
+			logging.NewSlogNop(),
+			s,
+			slices.Values([]int{2, 3}),
+			func(v int) int {
+				return v
+			},
+			func(key int, target int) (Source[int], error) {
+				return newTestSource(key, false), nil
+			},
+			func(existing Source[int], target int) (Source[int], error) {
+				if target == 2 {
+					return newTestSource(target, false), nil
+				}
+				return nil, nil
+			},
+		)
+
+		after, ok := s.GetSource(2)
+		require.True(t, ok)
+		require.NotSame(t, before, after)
+		require.False(t, before.(*testSource).IsRunning(),
+			"the old source must stop before its replacement is scheduled")
 		require.Equal(t, 2, s.Len())
 	})
 }

--- a/internal/component/loki/source/scheduler.go
+++ b/internal/component/loki/source/scheduler.go
@@ -38,15 +38,18 @@ func (s *Scheduler[Key]) ScheduleSource(source Source[Key]) {
 	}
 
 	ctx, cancel := context.WithCancel(s.ctx)
+	done := make(chan struct{})
 	st := scheduledSource[Key]{
 		ctx:    ctx,
 		cancel: cancel,
 		source: source,
+		done:   done,
 	}
 
 	s.sources[k] = st
 
 	s.running.Go(func() {
+		defer close(done)
 		st.source.Run(st.ctx)
 	})
 }
@@ -61,6 +64,21 @@ func (s *Scheduler[Key]) StopSource(source Source[Key]) {
 	}
 	delete(s.sources, k)
 	scheduledTask.cancel()
+}
+
+// ReplaceSource stops the currently scheduled source and waits for it to exit
+// before scheduling its replacement.
+func (s *Scheduler[Key]) ReplaceSource(current, replacement Source[Key]) {
+	k := current.Key()
+	scheduledTask, ok := s.sources[k]
+	if !ok {
+		return
+	}
+
+	delete(s.sources, k)
+	scheduledTask.cancel()
+	<-scheduledTask.done
+	s.ScheduleSource(replacement)
 }
 
 // Sources returns an iterator of all scheduled sources.
@@ -78,6 +96,15 @@ func (s *Scheduler[Key]) Sources() iter.Seq[Source[Key]] {
 func (s *Scheduler[Key]) Contains(k Key) bool {
 	_, ok := s.sources[k]
 	return ok
+}
+
+// GetSource returns the source scheduled with k.
+func (s *Scheduler[Key]) GetSource(k Key) (Source[Key], bool) {
+	scheduled, ok := s.sources[k]
+	if !ok {
+		return nil, false
+	}
+	return scheduled.source, true
 }
 
 // Len returns number of scheduled sources
@@ -153,4 +180,5 @@ type scheduledSource[Key comparable] struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 	source Source[Key]
+	done   chan struct{}
 }


### PR DESCRIPTION
### Pull Request Details

Extends Loki source reconciliation so existing sources can be updated or replaced when their configuration changes without changing their reconciliation key.
* Docker sources update labels and relabel rules without restarting the log stream.
* Kubernetes event sources update their job name and log format.
* File sources replace readers when reader options change while retaining their read positions.

Related to #6714 and #6716, but fixes the issue in a more general way.

### PR Checklist

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
