### PR TITLE
fix(loki.source.docker): Updates in target labels are now taken into account

### DIFF
--- a/internal/component/loki/source/docker/docker.go
+++ b/internal/component/loki/source/docker/docker.go
@@ -238,6 +238,11 @@ func (c *Component) Update(args component.Arguments) error {
 				func() bool { return c.exited.Load() },
 			)
 		},
+		func(existing source.Source[string], target promTarget) (source.Source[string], error) {
+			t := existing.(*tailer)
+			t.updateLabels(target.labels.Merge(defaultLabels), c.rcs)
+			return nil, nil
+		},
 	)
 
 	c.args = newArgs

--- a/internal/component/loki/source/docker/docker_test.go
+++ b/internal/component/loki/source/docker/docker_test.go
@@ -1,13 +1,23 @@
 package docker
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/moby/moby/api/types/container"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alloy/internal/component"
+	"github.com/grafana/alloy/internal/component/common/loki"
+	alloy_relabel "github.com/grafana/alloy/internal/component/common/relabel"
 	"github.com/grafana/alloy/internal/runtime/componenttest"
 	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/grafana/alloy/internal/util"
@@ -38,6 +48,8 @@ func TestComponent(t *testing.T) {
 }
 
 func TestComponentDuplicateTargets(t *testing.T) {
+	const expectedLabels = `{__meta_docker_container_id="foo", __meta_docker_port_private="8080"}`
+
 	// Use host that works on all platforms (including Windows).
 	var cfg = `
 		host       = "tcp://127.0.0.1:9376"
@@ -73,7 +85,8 @@ func TestComponentDuplicateTargets(t *testing.T) {
 	require.Equal(t, 1, cmp.scheduler.Len())
 	for s := range cmp.scheduler.Sources() {
 		ss := s.(*tailer)
-		require.Equal(t, "{__meta_docker_container_id=\"foo\", __meta_docker_port_private=\"8080\"}", ss.labelsStr)
+		require.Equal(t, expectedLabels, ss.positionsLabels)
+		require.Equal(t, expectedLabels, ss.labels.String())
 	}
 
 	var newCfg = `
@@ -91,6 +104,124 @@ func TestComponentDuplicateTargets(t *testing.T) {
 	require.Equal(t, 1, cmp.scheduler.Len())
 	for s := range cmp.scheduler.Sources() {
 		ss := s.(*tailer)
-		require.Equal(t, "{__meta_docker_container_id=\"foo\", __meta_docker_port_private=\"8080\"}", ss.labelsStr)
+		require.Equal(t, expectedLabels, ss.positionsLabels)
+		require.Equal(t, expectedLabels, ss.labels.String())
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	server := newStreamingDockerServer(t)
+	receiver := loki.NewLogsReceiver(loki.WithChannel(make(chan loki.Entry, 2)))
+	cfg := func(env, service, release string) Arguments {
+		var args Arguments
+		err := syntax.Unmarshal([]byte(fmt.Sprintf(`
+			host       = %q
+			targets    = [
+				{__meta_docker_container_id = "abc123", service = "`+service+`"},
+			]
+			labels     = {"env" = "`+env+`"}
+			forward_to = []
+		`, server.URL)), &args)
+		require.NoError(t, err)
+		args.ForwardTo = []loki.LogsReceiver{receiver}
+		rule := alloy_relabel.DefaultRelabelConfig
+		rule.TargetLabel = "release"
+		rule.Replacement = release
+		args.RelabelRules = alloy_relabel.Rules{&rule}
+		return args
+	}
+
+	cmp, err := New(component.Options{
+		ID:         "loki.source.docker.test",
+		Logger:     logging.NewSlogNop(),
+		Registerer: prometheus.NewRegistry(),
+		DataPath:   t.TempDir(),
+	}, cfg("staging", "api", "canary"))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	runDone := make(chan error, 1)
+	go func() { runDone <- cmp.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		require.NoError(t, <-runDone)
+	})
+
+	server.Send("2024-01-01T00:00:00.000000000Z before\n")
+	before := receiveDockerEntry(t, receiver)
+	require.Equal(t, "before", before.Line)
+	beforeLabels, err := json.Marshal(before.Labels)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"env":"staging","service":"api","release":"canary"}`, string(beforeLabels))
+
+	require.NoError(t, cmp.Update(cfg("production", "gateway", "stable")))
+
+	server.Send("2024-01-01T00:00:01.000000000Z after\n")
+	after := receiveDockerEntry(t, receiver)
+	require.Equal(t, "after", after.Line)
+	afterLabels, err := json.Marshal(after.Labels)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"env":"production","service":"gateway","release":"stable"}`, string(afterLabels))
+
+	retainedLabels, err := json.Marshal(before.Labels)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"env":"staging","service":"api","release":"canary"}`, string(retainedLabels))
+	require.Equal(t, int32(1), server.logRequests.Load(), "updating labels must not restart the Docker log stream")
+}
+
+type streamingDockerServer struct {
+	*httptest.Server
+	lines       chan string
+	logRequests atomic.Int32
+}
+
+func newStreamingDockerServer(t *testing.T) *streamingDockerServer {
+	t.Helper()
+	server := &streamingDockerServer{lines: make(chan string, 2)}
+	server.Server = httptest.NewServer(http.HandlerFunc(server.serveHTTP))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func (s *streamingDockerServer) Send(line string) {
+	s.lines <- line
+}
+
+func (s *streamingDockerServer) serveHTTP(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case strings.HasSuffix(r.URL.Path, "/json"):
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(container.InspectResponse{
+			ID:     "abc123",
+			State:  &container.State{Running: true},
+			Config: &container.Config{Tty: true},
+		})
+
+	case strings.HasSuffix(r.URL.Path, "/logs"):
+		s.logRequests.Add(1)
+		flusher, _ := w.(http.Flusher)
+		for {
+			select {
+			case line := <-s.lines:
+				_, _ = fmt.Fprint(w, line)
+				flusher.Flush()
+			case <-r.Context().Done():
+				return
+			}
+		}
+
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func receiveDockerEntry(t *testing.T, receiver loki.LogsReceiver) loki.Entry {
+	t.Helper()
+	select {
+	case entry := <-receiver.Chan():
+		return entry
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Docker log entry")
+		return loki.Entry{}
 	}
 }

--- a/internal/component/loki/source/docker/tailer.go
+++ b/internal/component/loki/source/docker/tailer.go
@@ -30,25 +30,60 @@ import (
 	"github.com/grafana/alloy/internal/component/loki/source/internal/positions"
 )
 
+type tailerLabels struct {
+	mut     sync.RWMutex
+	current string
+	stdout  model.LabelSet
+	stderr  model.LabelSet
+}
+
+func (l *tailerLabels) update(base model.LabelSet, rules []*relabel.Config) {
+	current := base.String()
+	stdout := getStreamLabels(base, rules, "stdout")
+	stderr := getStreamLabels(base, rules, "stderr")
+
+	l.mut.Lock()
+	defer l.mut.Unlock()
+	l.current = current
+	l.stdout = stdout
+	l.stderr = stderr
+}
+
+func (l *tailerLabels) forStream(stdout bool) model.LabelSet {
+	l.mut.RLock()
+	defer l.mut.RUnlock()
+	if stdout {
+		return l.stdout
+	}
+	return l.stderr
+}
+
+func (l *tailerLabels) String() string {
+	l.mut.RLock()
+	defer l.mut.RUnlock()
+	return l.current
+}
+
 // tailer for Docker container logs.
 type tailer struct {
-	logger            *slog.Logger
-	recv              loki.LogsReceiver
-	positions         positions.Positions
-	containerID       string
-	labels            model.LabelSet
-	labelsStr         string
-	relabelConfig     []*relabel.Config
+	logger      *slog.Logger
+	recv        loki.LogsReceiver
+	positions   positions.Positions
+	containerID string
+	// positionsLabels is stable even when emitted labels change.
+	positionsLabels   string
 	metrics           *metrics
 	restartInterval   time.Duration
 	componentStopping func() bool
 
 	client client.APIClient
 
-	mu      sync.Mutex // protects cancel, running and err fields
+	mu      sync.Mutex // protects cancel, running and err
 	err     error
 	running bool
 	cancel  context.CancelFunc
+
+	labels tailerLabels
 
 	wg sync.WaitGroup
 
@@ -63,27 +98,32 @@ func newTailer(
 	componentStopping func() bool,
 ) (*tailer, error) {
 
-	labelsStr := labels.String()
-	pos, err := position.Get(positions.CursorKey(containerID), labelsStr)
+	positionsLabels := labels.String()
+	pos, err := position.Get(positions.CursorKey(containerID), positionsLabels)
 	if err != nil {
 		return nil, err
 	}
 
-	return &tailer{
+	t := &tailer{
 		logger:            logger,
 		recv:              recv,
 		since:             atomic.NewInt64(pos),
 		last:              atomic.NewInt64(0),
 		positions:         position,
 		containerID:       containerID,
-		labels:            labels,
-		labelsStr:         labelsStr,
-		relabelConfig:     relabelConfig,
+		positionsLabels:   positionsLabels,
 		metrics:           metrics,
 		client:            client,
 		restartInterval:   restartInterval,
 		componentStopping: componentStopping,
-	}, nil
+	}
+	t.updateLabels(labels, relabelConfig)
+	return t, nil
+}
+
+// updateLabels changes labels for new entries without restarting the log stream.
+func (t *tailer) updateLabels(labels model.LabelSet, relabelConfig []*relabel.Config) {
+	t.labels.update(labels, relabelConfig)
 }
 
 func (t *tailer) Run(ctx context.Context) {
@@ -174,7 +214,7 @@ func (t *tailer) stop() {
 		// If the component is not stopping, then it means that the target for this component is gone and that
 		// we should clear the entry from the positions file.
 		if !t.componentStopping() {
-			t.positions.Remove(positions.CursorKey(t.containerID), t.labelsStr)
+			t.positions.Remove(positions.CursorKey(t.containerID), t.positionsLabels)
 		}
 	}
 }
@@ -196,9 +236,9 @@ func (t *tailer) DebugInfo() sourceInfo {
 	return sourceInfo{
 		ID:         t.containerID,
 		LastError:  errMsg,
-		Labels:     t.labelsStr,
+		Labels:     t.labels.String(),
 		IsRunning:  running,
-		ReadOffset: t.positions.GetString(positions.CursorKey(t.containerID), t.labelsStr),
+		ReadOffset: t.positions.GetString(positions.CursorKey(t.containerID), t.positionsLabels),
 	}
 }
 
@@ -243,12 +283,12 @@ func (t *tailer) processLoop(ctx context.Context, tty bool, reader io.ReadCloser
 	// Start processing
 	go func() {
 		defer t.wg.Done()
-		t.process(rstdout, t.getStreamLabels("stdout"))
+		t.process(rstdout, true)
 	}()
 
 	go func() {
 		defer t.wg.Done()
-		t.process(rstderr, t.getStreamLabels("stderr"))
+		t.process(rstderr, false)
 	}()
 
 	// Wait until done
@@ -273,7 +313,7 @@ func extractTsFromBytes(line []byte) (time.Time, []byte, error) {
 	return ts, line[spaceIdx+1:], nil
 }
 
-func (t *tailer) process(r io.Reader, logStreamLset model.LabelSet) {
+func (t *tailer) process(r io.Reader, stdout bool) {
 	const maxCapacity = dockerMaxChunkSize * 64
 
 	reader := bufio.NewReader(r)
@@ -322,7 +362,9 @@ func (t *tailer) process(r io.Reader, logStreamLset model.LabelSet) {
 			continue
 		}
 
-		t.recv.Chan() <- loki.NewEntry(logStreamLset, push.Entry{
+		// Read the label set per entry so that a label change applied by
+		// updateLabels takes effect without restarting the log stream.
+		t.recv.Chan() <- loki.NewEntry(t.labels.forStream(stdout), push.Entry{
 			Timestamp: ts,
 			Line:      string(content),
 		})
@@ -334,22 +376,22 @@ func (t *tailer) process(r io.Reader, logStreamLset model.LabelSet) {
 		// problematic if we have the same container with a different set of
 		// labels (e.g. duplicated and relabeled), but this shouldn't be the
 		// case anyway.
-		t.positions.Put(positions.CursorKey(t.containerID), t.labelsStr, ts.Unix())
+		t.positions.Put(positions.CursorKey(t.containerID), t.positionsLabels, ts.Unix())
 		t.since.Store(ts.Unix())
 		t.last.Store(time.Now().Unix())
 	}
 }
 
-func (t *tailer) getStreamLabels(logStream string) model.LabelSet {
+func getStreamLabels(base model.LabelSet, rules []*relabel.Config, logStream string) model.LabelSet {
 	// Add all labels from the config, relabel and filter them.
 	lb := labels.NewBuilder(labels.EmptyLabels())
-	for k, v := range t.labels {
+	for k, v := range base {
 		lb.Set(string(k), string(v))
 	}
 
 	lb.Set(dockerLabelLogStream, logStream)
 	processed := labels.EmptyLabels()
-	if relabel.ProcessBuilder(lb, t.relabelConfig...) {
+	if relabel.ProcessBuilder(lb, rules...) {
 		processed = lb.Labels()
 	}
 

--- a/internal/component/loki/source/docker/tailer_test.go
+++ b/internal/component/loki/source/docker/tailer_test.go
@@ -517,3 +517,84 @@ func (sw *stdWriter) Write(p []byte) (int, error) {
 	}
 	return sw.Writer.Write(p)
 }
+
+func TestTailerUpdateLabelsAppliesToNewEntries(t *testing.T) {
+	logger := logging.NewSlogNop()
+	entryHandler := loki.NewCollectingHandler()
+	defer entryHandler.Stop()
+
+	ps, err := positions.New(logger, positions.Config{
+		SyncPeriod:    10 * time.Second,
+		PositionsFile: t.TempDir() + "/positions.yml",
+	})
+	require.NoError(t, err)
+	defer ps.Stop()
+
+	tailer, err := newTailer(
+		newMetrics(prometheus.NewRegistry()),
+		logger,
+		entryHandler.Receiver(),
+		ps,
+		"container-id",
+		model.LabelSet{"job": "docker", "env": "staging"},
+		[]*relabel.Config{},
+		nil,
+		restartInterval,
+		func() bool { return false },
+	)
+	require.NoError(t, err)
+
+	// process is fed directly so the label change can be applied while the
+	// stream stays open, which is the behaviour under test.
+	pr, pw := io.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		tailer.process(pr, true)
+	}()
+
+	_, err = pw.Write([]byte("2024-01-01T00:00:00.000000000Z before\n"))
+	require.NoError(t, err)
+
+	lineLabels := func(line string) (model.LabelSet, bool) {
+		for _, e := range entryHandler.Received() {
+			if e.Line == line {
+				return e.Labels, true
+			}
+		}
+		return nil, false
+	}
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		lset, ok := lineLabels("before")
+		if !assert.True(c, ok) {
+			return
+		}
+		assert.Equal(c, model.LabelValue("staging"), lset["env"])
+	}, time.Second, 10*time.Millisecond)
+
+	tailer.updateLabels(model.LabelSet{"job": "docker", "env": "production"}, []*relabel.Config{})
+
+	_, err = pw.Write([]byte("2024-01-01T00:00:01.000000000Z after\n"))
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		lset, ok := lineLabels("after")
+		if !assert.True(c, ok) {
+			return
+		}
+		assert.Equal(c, model.LabelValue("production"), lset["env"])
+	}, time.Second, 10*time.Millisecond)
+
+	// Entries already read keep the labels that applied when they were read.
+	lset, ok := lineLabels("before")
+	require.True(t, ok)
+	require.Equal(t, model.LabelValue("staging"), lset["env"])
+
+	require.NoError(t, pw.Close())
+	<-done
+
+	// The positions key must stay stable, otherwise the read offset for this
+	// container is orphaned and its log is re-shipped from the beginning.
+	require.Equal(t, `{env="staging", job="docker"}`, tailer.positionsLabels)
+}

--- a/internal/component/loki/source/file/file.go
+++ b/internal/component/loki/source/file/file.go
@@ -354,6 +354,7 @@ func (c *Component) scheduleSources() {
 				legacyPositionUsed:   c.args.LegacyPositionsFile != "",
 			})
 		},
+		nil,
 	)
 }
 

--- a/internal/component/loki/source/kubernetes_events/kubernetes_events.go
+++ b/internal/component/loki/source/kubernetes_events/kubernetes_events.go
@@ -195,6 +195,7 @@ func (c *Component) reconcile() {
 				LogFormat:    c.args.LogFormat,
 			}), nil
 		},
+		nil,
 	)
 }
 

--- a/internal/component/loki/source/reconcile.go
+++ b/internal/component/loki/source/reconcile.go
@@ -19,15 +19,24 @@ type KeyFn[Key comparable, Input any] func(Input) Key
 // without logging an error.
 type SourceFactoryFn[Key comparable, Input any] func(Key, Input) (Source[Key], error)
 
+// SourceUpdateFn updates a source which is already scheduled for an input.
+//
+// If the source can be updated in place, SourceUpdateFn should update it and
+// return nil. If the source must be restarted, SourceUpdateFn should return a
+// replacement source. Returning ErrSkip stops the existing source without
+// scheduling a replacement.
+type SourceUpdateFn[Key comparable, Input any] func(Source[Key], Input) (Source[Key], error)
+
 // Reconcile synchronizes the scheduler's set of running sources with a desired state.
-// It iterates over inputs, creates sources for new items, and stops sources that are
-// no longer needed.
+// It iterates over inputs, creates sources for new items, updates or replaces existing
+// sources, and stops sources that are no longer needed.
 func Reconcile[Key comparable, Input any](
 	logger *slog.Logger,
 	s *Scheduler[Key],
 	it iter.Seq[Input],
 	keyFn KeyFn[Key, Input],
 	sourceFactoryFn SourceFactoryFn[Key, Input],
+	sourceUpdateFn SourceUpdateFn[Key, Input],
 ) {
 	// shouldRun tracks the set of keys that should be active after reconciliation.
 	shouldRun := make(map[Key]struct{})
@@ -43,8 +52,30 @@ func Reconcile[Key comparable, Input any](
 
 		shouldRun[key] = struct{}{}
 
-		// Skip if a source with this key is already running.
-		if s.Contains(key) {
+		// Update or replace a source with this key if one is already running.
+		if existing, ok := s.GetSource(key); ok {
+			if sourceUpdateFn == nil {
+				continue
+			}
+
+			replacement, err := sourceUpdateFn(existing, i)
+			if err != nil {
+				if errors.Is(err, ErrSkip) {
+					s.StopSource(existing)
+					delete(shouldRun, key)
+				} else {
+					logger.Error("failed to update source, keeping existing source", "error", err, "key", key)
+				}
+				continue
+			}
+
+			if replacement != nil {
+				if replacement.Key() != key {
+					logger.Error("failed to replace source, replacement has a different key", "key", key, "replacement_key", replacement.Key())
+					continue
+				}
+				s.ReplaceSource(existing, replacement)
+			}
 			continue
 		}
 

--- a/internal/component/loki/source/reconcile_test.go
+++ b/internal/component/loki/source/reconcile_test.go
@@ -3,6 +3,7 @@ package source
 import (
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/stretchr/testify/require"
@@ -23,6 +24,7 @@ func TestReconcile(t *testing.T) {
 			func(key int, target int) (Source[int], error) {
 				return newTestSource(key, false), nil
 			},
+			nil,
 		)
 		require.Equal(t, 3, s.Len())
 	})
@@ -38,11 +40,13 @@ func TestReconcile(t *testing.T) {
 			func(key int, target int) (Source[int], error) {
 				return newTestSource(key, false), nil
 			},
+			nil,
 		)
 		require.Equal(t, 2, s.Len())
 	})
 
-	t.Run("should prevent duplicated source from being scheduled", func(t *testing.T) {
+	t.Run("should process a duplicated key once", func(t *testing.T) {
+		var updated []int
 		Reconcile(
 			logging.NewSlogNop(),
 			s,
@@ -53,7 +57,12 @@ func TestReconcile(t *testing.T) {
 			func(key int, target int) (Source[int], error) {
 				return newTestSource(key, false), nil
 			},
+			func(existing Source[int], target int) (Source[int], error) {
+				updated = append(updated, target)
+				return nil, nil
+			},
 		)
+		require.Equal(t, []int{2, 3}, updated)
 		require.Equal(t, 2, s.Len())
 	})
 
@@ -71,7 +80,60 @@ func TestReconcile(t *testing.T) {
 				}
 				return newTestSource(key, false), nil
 			},
+			nil,
 		)
+		require.Equal(t, 2, s.Len())
+	})
+
+	t.Run("should update an existing source", func(t *testing.T) {
+		var updated []int
+		Reconcile(
+			logging.NewSlogNop(),
+			s,
+			slices.Values([]int{2, 3}),
+			func(v int) int {
+				return v
+			},
+			func(key int, target int) (Source[int], error) {
+				return newTestSource(key, false), nil
+			},
+			func(existing Source[int], target int) (Source[int], error) {
+				updated = append(updated, target)
+				return nil, nil
+			},
+		)
+		require.ElementsMatch(t, []int{2, 3}, updated)
+		require.Equal(t, 2, s.Len())
+	})
+
+	t.Run("should replace an existing source", func(t *testing.T) {
+		before, ok := s.GetSource(2)
+		require.True(t, ok)
+		require.Eventually(t, before.(*testSource).IsRunning, time.Second, 10*time.Millisecond)
+
+		Reconcile(
+			logging.NewSlogNop(),
+			s,
+			slices.Values([]int{2, 3}),
+			func(v int) int {
+				return v
+			},
+			func(key int, target int) (Source[int], error) {
+				return newTestSource(key, false), nil
+			},
+			func(existing Source[int], target int) (Source[int], error) {
+				if target == 2 {
+					return newTestSource(target, false), nil
+				}
+				return nil, nil
+			},
+		)
+
+		after, ok := s.GetSource(2)
+		require.True(t, ok)
+		require.NotSame(t, before, after)
+		require.False(t, before.(*testSource).IsRunning(),
+			"the old source must stop before its replacement is scheduled")
 		require.Equal(t, 2, s.Len())
 	})
 }

--- a/internal/component/loki/source/scheduler.go
+++ b/internal/component/loki/source/scheduler.go
@@ -38,15 +38,18 @@ func (s *Scheduler[Key]) ScheduleSource(source Source[Key]) {
 	}
 
 	ctx, cancel := context.WithCancel(s.ctx)
+	done := make(chan struct{})
 	st := scheduledSource[Key]{
 		ctx:    ctx,
 		cancel: cancel,
 		source: source,
+		done:   done,
 	}
 
 	s.sources[k] = st
 
 	s.running.Go(func() {
+		defer close(done)
 		st.source.Run(st.ctx)
 	})
 }
@@ -61,6 +64,21 @@ func (s *Scheduler[Key]) StopSource(source Source[Key]) {
 	}
 	delete(s.sources, k)
 	scheduledTask.cancel()
+}
+
+// ReplaceSource stops the currently scheduled source and waits for it to exit
+// before scheduling its replacement.
+func (s *Scheduler[Key]) ReplaceSource(current, replacement Source[Key]) {
+	k := current.Key()
+	scheduledTask, ok := s.sources[k]
+	if !ok {
+		return
+	}
+
+	delete(s.sources, k)
+	scheduledTask.cancel()
+	<-scheduledTask.done
+	s.ScheduleSource(replacement)
 }
 
 // Sources returns an iterator of all scheduled sources.
@@ -78,6 +96,15 @@ func (s *Scheduler[Key]) Sources() iter.Seq[Source[Key]] {
 func (s *Scheduler[Key]) Contains(k Key) bool {
 	_, ok := s.sources[k]
 	return ok
+}
+
+// GetSource returns the source scheduled with k.
+func (s *Scheduler[Key]) GetSource(k Key) (Source[Key], bool) {
+	scheduled, ok := s.sources[k]
+	if !ok {
+		return nil, false
+	}
+	return scheduled.source, true
 }
 
 // Len returns number of scheduled sources
@@ -153,4 +180,5 @@ type scheduledSource[Key comparable] struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 	source Source[Key]
+	done   chan struct{}
 }


### PR DESCRIPTION
### Pull Request Details

Seems like #5026 broke label updates in `loki.source.docker`. Prior to #5026, a label update would be considered a new target even if the container ID is the same. This meant there was also a new positions entry, and I believe the container logs would be re-read. This was because `manager.syncTargets` would use `Runner.ApplyTasks` which seems to use the hash of the label set.

#5026 seems like a step in the right direction, because restarting the whole task when the container ID doesn't change doesn't seem efficient. It'd be good to keep this change, to fix the update mechanism (what this PR does), and in the future to also somehow fix the positions file so that when Alloy is restarted it doesn't re-read the same container logs again.

IIUC Alloy would previously re-read the logs when Update() was called. With this PR, this would be postponed to the next time Alloy restarts (that's when it will find out that the position in the file is different).

The PR consists of two commits. The first commit adds tests which fail. The second commit fixes the tests.

### Issue(s) fixed by this Pull Request

Fixes #6714

### Notes to the Reviewer

This is the Docker-specific part of #6759. The other changes in #6759 will be merged in separate pull requests.

### PR Checklist

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
