### PR TITLE
feat(pyroscope.write): Add retry_on_http_429 endpoint option

### DIFF
--- a/docs/sources/reference/components/pyroscope/pyroscope.write.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.write.md
@@ -105,7 +105,7 @@ The following arguments are supported:
 When you provide multiple `endpoint` blocks, profiles are concurrently forwarded to all configured locations.
 
 The `retry_on_http_429` argument specifies whether `HTTP 429` status code responses should be treated as recoverable errors.
-Other `HTTP 4xx` status code responses are never considered recoverable errors.
+Other `HTTP 4xx` status code responses are never considered recoverable errors, with the exception of `HTTP 408 Request Timeout`, which is always retried.
 When `retry_on_http_429` is enabled, the retry mechanism is governed by the backoff configuration specified through `min_backoff_period`, `max_backoff_period` and `max_backoff_retries` attributes.
 
 ### `authorization`

--- a/docs/sources/reference/components/pyroscope/pyroscope.write.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.write.md
@@ -90,6 +90,7 @@ The following arguments are supported:
 | `proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.                                            | `false`   | no       |
 | `proxy_url`              | `string`            | HTTP proxy to send requests through.                                                             |           | no       |
 | `remote_timeout`         | `duration`          | Timeout for requests made to the URL.                                                            | `"10s"`   | no       |
+| `retry_on_http_429`      | `bool`              | Retry when an HTTP 429 status code is received.                                                  | `true`    | no       |
 
  At most, one of the following can be provided:
 
@@ -102,6 +103,10 @@ The following arguments are supported:
 {{< docs/shared lookup="reference/components/http-client-proxy-config-description.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 When you provide multiple `endpoint` blocks, profiles are concurrently forwarded to all configured locations.
+
+The `retry_on_http_429` argument specifies whether `HTTP 429` status code responses should be treated as recoverable errors.
+Other `HTTP 4xx` status code responses are never considered recoverable errors.
+When `retry_on_http_429` is enabled, the retry mechanism is governed by the backoff configuration specified through `min_backoff_period`, `max_backoff_period` and `max_backoff_retries` attributes.
 
 ### `authorization`
 

--- a/internal/component/pyroscope/write/write.go
+++ b/internal/component/pyroscope/write/write.go
@@ -427,9 +427,10 @@ func shouldRetry(err error, retryOnHTTP429 bool) bool {
 
 	switch connect.CodeOf(err) {
 	case connect.CodeDeadlineExceeded, connect.CodeUnknown,
-		connect.CodeResourceExhausted, connect.CodeInternal,
-		connect.CodeUnavailable, connect.CodeDataLoss, connect.CodeAborted:
+		connect.CodeInternal, connect.CodeUnavailable, connect.CodeDataLoss, connect.CodeAborted:
 		return true
+	case connect.CodeResourceExhausted:
+		return retryOnHTTP429
 	}
 	return false
 }

--- a/internal/component/pyroscope/write/write.go
+++ b/internal/component/pyroscope/write/write.go
@@ -78,6 +78,7 @@ type EndpointOptions struct {
 	MinBackoff             time.Duration            `alloy:"min_backoff_period,attr,optional"`  // start backoff at this level
 	MaxBackoff             time.Duration            `alloy:"max_backoff_period,attr,optional"`  // increase exponentially to this level
 	MaxBackoffRetries      int                      `alloy:"max_backoff_retries,attr,optional"` // give up after this many; zero means infinite retries
+	RetryOnHTTP429         bool                     `alloy:"retry_on_http_429,attr,optional"`
 }
 
 func GetDefaultEndpointOptions() EndpointOptions {
@@ -88,6 +89,7 @@ func GetDefaultEndpointOptions() EndpointOptions {
 		MaxBackoff:             5 * time.Minute,
 		MaxBackoffRetries:      10,
 		HTTPClientConfig:       config.CloneDefaultHTTPClientConfig(),
+		RetryOnHTTP429:         true,
 	}
 
 	return defaultEndpointOptions
@@ -381,7 +383,7 @@ func (f *fanOutClient) Push(
 					"retries", backoff.NumRetries(),
 					"err", err,
 				)
-				if !shouldRetry(err) {
+				if !shouldRetry(err, ec.options.RetryOnHTTP429) {
 					break
 				}
 				backoff.Wait()
@@ -406,7 +408,7 @@ func (f *fanOutClient) Push(
 	return connect.NewResponse(&pushv1.PushResponse{}), nil
 }
 
-func shouldRetry(err error) bool {
+func shouldRetry(err error, retryOnHTTP429 bool) bool {
 	if errors.Is(err, context.DeadlineExceeded) {
 		return true
 	}
@@ -414,7 +416,10 @@ func shouldRetry(err error) bool {
 	var writeErr *PyroscopeWriteError
 	if errors.As(err, &writeErr) {
 		status := writeErr.StatusCode
-		if status == http.StatusTooManyRequests || status == http.StatusRequestTimeout {
+		if status == http.StatusTooManyRequests {
+			return retryOnHTTP429
+		}
+		if status == http.StatusRequestTimeout {
 			return true
 		}
 		return status >= http.StatusInternalServerError
@@ -650,7 +655,7 @@ func (f *fanOutClient) AppendIngest(ctx context.Context, profile *pyroscope.Inco
 					"endpoint", ec.options.URL,
 					"retries", backoff.NumRetries(),
 					"err", err)
-				if !shouldRetry(err) {
+				if !shouldRetry(err, ec.options.RetryOnHTTP429) {
 					break
 				}
 				backoff.Wait()

--- a/internal/component/pyroscope/write/write_test.go
+++ b/internal/component/pyroscope/write/write_test.go
@@ -600,6 +600,106 @@ func Test_shouldRetry_On429(t *testing.T) {
 	badReqErr := fmt.Errorf("remote error: %w", &PyroscopeWriteError{StatusCode: http.StatusBadRequest})
 	require.False(t, shouldRetry(badReqErr, true))
 	require.False(t, shouldRetry(badReqErr, false))
+
+	// Connect CodeResourceExhausted mirrors HTTP 429 and is gated by the flag.
+	resourceExhaustedErr := connect.NewError(connect.CodeResourceExhausted, errors.New("rate limited"))
+	require.True(t, shouldRetry(resourceExhaustedErr, true))
+	require.False(t, shouldRetry(resourceExhaustedErr, false))
+}
+
+func Test_Write_Append_RetryOnResourceExhausted(t *testing.T) {
+	// Covers the push v1 / connect API path (fanOutClient.Append -> pushClient.Push),
+	// where a rate-limited backend responds with connect.CodeResourceExhausted rather
+	// than an HTTP 429 status code. shouldRetry treats the two the same way, gated by
+	// RetryOnHTTP429.
+	newServer := func(t *testing.T, requestCount *atomic.Int32) *httptest.Server {
+		t.Helper()
+		_, handler := pushv1connect.NewPusherServiceHandler(PushFunc(
+			func(_ context.Context, _ *connect.Request[pushv1.PushRequest]) (*connect.Response[pushv1.PushResponse], error) {
+				requestCount.Inc()
+				return nil, connect.NewError(connect.CodeResourceExhausted, errors.New("rate limited"))
+			},
+		))
+		return httptest.NewServer(handler)
+	}
+
+	newComponent := func(t *testing.T, endpoint *EndpointOptions) pyroscope.Appendable {
+		t.Helper()
+		var export Exports
+		var wg sync.WaitGroup
+		wg.Add(1)
+		c, err := New(
+			pyrotestlogger.TestLogger(t),
+			noop.Tracer{},
+			prometheus.NewRegistry(),
+			func(e Exports) {
+				defer wg.Done()
+				export = e
+			},
+			"Alloy/239",
+			"",
+			t.TempDir(),
+			Arguments{Endpoints: []*EndpointOptions{endpoint}},
+		)
+		require.NoError(t, err)
+		ctx, cancel := context.WithCancel(t.Context())
+		t.Cleanup(cancel)
+		go c.Run(ctx)
+		wg.Wait()
+		require.NotNil(t, export.Receiver)
+		return export.Receiver
+	}
+
+	appendProfile := func(t *testing.T, appendable pyroscope.Appendable) error {
+		t.Helper()
+		return appendable.Appender().Append(t.Context(), labels.FromMap(map[string]string{
+			"__name__": "test.profile",
+		}), []*pyroscope.RawSample{
+			{ID: "test-request-id", RawProfile: []byte("pprofraw")},
+		})
+	}
+
+	t.Run("disabled", func(t *testing.T) {
+		requestCount := atomic.NewInt32(0)
+		server := newServer(t, requestCount)
+		t.Cleanup(server.Close)
+
+		endpoint := &EndpointOptions{
+			URL:               server.URL,
+			RemoteTimeout:     GetDefaultEndpointOptions().RemoteTimeout,
+			MinBackoff:        1 * time.Millisecond,
+			MaxBackoff:        1 * time.Millisecond,
+			MaxBackoffRetries: 3,
+			RetryOnHTTP429:    false,
+		}
+
+		err := appendProfile(t, newComponent(t, endpoint))
+		require.Error(t, err)
+		require.ErrorContains(t, err, "resource_exhausted")
+		// With retries disabled for 429/ResourceExhausted, the request is attempted exactly once.
+		require.Equal(t, int32(1), requestCount.Load())
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		requestCount := atomic.NewInt32(0)
+		server := newServer(t, requestCount)
+		t.Cleanup(server.Close)
+
+		endpoint := &EndpointOptions{
+			URL:               server.URL,
+			RemoteTimeout:     GetDefaultEndpointOptions().RemoteTimeout,
+			MinBackoff:        1 * time.Millisecond,
+			MaxBackoff:        1 * time.Millisecond,
+			MaxBackoffRetries: 3,
+			RetryOnHTTP429:    true,
+		}
+
+		err := appendProfile(t, newComponent(t, endpoint))
+		require.Error(t, err)
+		require.ErrorContains(t, err, "resource_exhausted")
+		// With retries enabled, the request is retried up to MaxBackoffRetries times.
+		require.Equal(t, int32(endpoint.MaxBackoffRetries), requestCount.Load())
+	})
 }
 
 func (s *AppendIngestTestSuite) TestRetryOnHTTP429Disabled() {

--- a/internal/component/pyroscope/write/write_test.go
+++ b/internal/component/pyroscope/write/write_test.go
@@ -3,6 +3,7 @@ package write
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -575,6 +576,81 @@ func (s *AppendIngestTestSuite) TestInvalidLabels() {
 
 func Test_Write_AppendIngest(t *testing.T) {
 	suite.Run(t, new(AppendIngestTestSuite))
+}
+
+func Test_shouldRetry_On429(t *testing.T) {
+	err := fmt.Errorf("remote error: %w", &PyroscopeWriteError{StatusCode: http.StatusTooManyRequests})
+
+	// With retry_on_http_429 enabled, a 429 is retried.
+	require.True(t, shouldRetry(err, true))
+	// With retry_on_http_429 disabled, a 429 is not retried.
+	require.False(t, shouldRetry(err, false))
+
+	// A 408 Request Timeout is always retried regardless of the flag.
+	timeoutErr := fmt.Errorf("remote error: %w", &PyroscopeWriteError{StatusCode: http.StatusRequestTimeout})
+	require.True(t, shouldRetry(timeoutErr, true))
+	require.True(t, shouldRetry(timeoutErr, false))
+
+	// A 5xx is always retried regardless of the flag.
+	serverErr := fmt.Errorf("remote error: %w", &PyroscopeWriteError{StatusCode: http.StatusServiceUnavailable})
+	require.True(t, shouldRetry(serverErr, true))
+	require.True(t, shouldRetry(serverErr, false))
+
+	// A 400 is never retried.
+	badReqErr := fmt.Errorf("remote error: %w", &PyroscopeWriteError{StatusCode: http.StatusBadRequest})
+	require.False(t, shouldRetry(badReqErr, true))
+	require.False(t, shouldRetry(badReqErr, false))
+}
+
+func (s *AppendIngestTestSuite) TestRetryOnHTTP429Disabled() {
+	server := s.newServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte("too many requests"))
+	})
+
+	endpoint := s.newEndpoint(server, nil)
+	endpoint.RetryOnHTTP429 = false
+
+	s.newComponent(Arguments{
+		Endpoints: []*EndpointOptions{endpoint},
+	})
+
+	profile := s.newProfile(map[string]string{
+		"__name__": "test.profile",
+		"service":  "test-service",
+	})
+
+	err := s.export.Receiver.Appender().AppendIngest(s.ctx, profile)
+	s.Error(err)
+	s.Contains(err.Error(), "pyroscope write error: status=429")
+	// With retries disabled for 429, the request is attempted exactly once.
+	s.Equal(int32(1), s.requestCount.Load())
+}
+
+func (s *AppendIngestTestSuite) TestRetryOnHTTP429Enabled() {
+	server := s.newServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte("too many requests"))
+	})
+
+	endpoint := s.newEndpoint(server, nil)
+	endpoint.RetryOnHTTP429 = true
+
+	s.newComponent(Arguments{
+		Endpoints: []*EndpointOptions{endpoint},
+	})
+
+	profile := s.newProfile(map[string]string{
+		"__name__": "test.profile",
+		"service":  "test-service",
+	})
+
+	err := s.export.Receiver.Appender().AppendIngest(s.ctx, profile)
+	s.Error(err)
+	s.Contains(err.Error(), "pyroscope write error: status=429")
+	// With retries enabled for 429, the request is retried up to MaxBackoffRetries times.
+	s.Positive(endpoint.MaxBackoffRetries)
+	s.Equal(int32(endpoint.MaxBackoffRetries), s.requestCount.Load())
 }
 
 func Test_Write_FanOut_ValidateLabels(t *testing.T) {


### PR DESCRIPTION
Fixes #6667

Adds a retry_on_http_429 boolean argument to the pyroscope.write endpoint block, matching the option already offered by loki.write and prometheus.remote_write.

Previously shouldRetry hardcoded retrying on HTTP 429. This makes that behavior configurable while defaulting to true, so existing configs keep their current behavior. Users who want to drop rate-limited profiles instead of retrying can now set retry_on_http_429 to false. HTTP 408 and 5xx responses are still retried regardless of the flag.

- Added the retry_on_http_429 field (default true) to EndpointOptions.
- Threaded the flag into shouldRetry for both the push and ingest paths.
- Documented the new argument in the reference docs.
- Added unit tests covering the flag enabled and disabled plus the unchanged 408, 5xx and 400 behavior.