### PR TITLE
fix: Prevent loki.write WAL watcher panic when a record spans a page boundary

### DIFF
--- a/internal/component/common/loki/wal/watcher.go
+++ b/internal/component/common/loki/wal/watcher.go
@@ -185,15 +185,6 @@ func (w *Watcher) run() error {
 	return nil
 }
 
-// newLiveReader builds a wlog.LiveReader for the given segment. It always
-// passes a non-nil *wlog.LiveReaderMetrics (with a nil registerer, since
-// there is nowhere to register it): wlog.LiveReader.readRecord dereferences
-// the metrics unconditionally when a record spans a page boundary, so
-// passing literal nil there panics instead of just skipping the metric.
-func newLiveReader(logger *slog.Logger, r io.Reader) *wlog.LiveReader {
-	return wlog.NewLiveReader(logger, wlog.NewLiveReaderMetrics(nil), r)
-}
-
 // watch will start reading from the segment identified by segmentNum.
 // If an EOF is reached and tail is true, it will keep reading for more WAL records with a wlog.LiveReader. Periodically,
 // it will check if there's a new segment, and if positive read the remaining from the current one and return.
@@ -208,7 +199,8 @@ func (w *Watcher) watch(segmentNum int, tail bool) error {
 	}
 	defer segment.Close()
 
-	reader := newLiveReader(w.logger, segment)
+	// Metrics must be non-nil (built with a nil registerer), the LiveReader panics otherwise.
+	reader := wlog.NewLiveReader(w.logger, wlog.NewLiveReaderMetrics(nil), segment)
 
 	readTimer := newBackoffTimer(w.minReadFreq, w.maxReadFreq)
 

--- a/internal/component/common/loki/wal/watcher.go
+++ b/internal/component/common/loki/wal/watcher.go
@@ -185,6 +185,15 @@ func (w *Watcher) run() error {
 	return nil
 }
 
+// newLiveReader builds a wlog.LiveReader for the given segment. It always
+// passes a non-nil *wlog.LiveReaderMetrics (with a nil registerer, since
+// there is nowhere to register it): wlog.LiveReader.readRecord dereferences
+// the metrics unconditionally when a record spans a page boundary, so
+// passing literal nil there panics instead of just skipping the metric.
+func newLiveReader(logger *slog.Logger, r io.Reader) *wlog.LiveReader {
+	return wlog.NewLiveReader(logger, wlog.NewLiveReaderMetrics(nil), r)
+}
+
 // watch will start reading from the segment identified by segmentNum.
 // If an EOF is reached and tail is true, it will keep reading for more WAL records with a wlog.LiveReader. Periodically,
 // it will check if there's a new segment, and if positive read the remaining from the current one and return.
@@ -199,7 +208,7 @@ func (w *Watcher) watch(segmentNum int, tail bool) error {
 	}
 	defer segment.Close()
 
-	reader := wlog.NewLiveReader(w.logger, nil, segment)
+	reader := newLiveReader(w.logger, segment)
 
 	readTimer := newBackoffTimer(w.minReadFreq, w.maxReadFreq)
 

--- a/internal/component/common/loki/wal/watcher_test.go
+++ b/internal/component/common/loki/wal/watcher_test.go
@@ -1,7 +1,10 @@
 package wal
 
 import (
+	"bytes"
+	"encoding/binary"
 	"fmt"
+	"hash/crc32"
 	"log/slog"
 	"testing"
 	"time"
@@ -777,5 +780,37 @@ func TestWatcher_StopAndDrainWAL(t *testing.T) {
 		require.InDelta(t, time.Second*10, time.Since(now), float64(time.Millisecond*2000), "expected the drain procedure to take around 15s")
 		require.Less(t, int(writeTo.entriesReceived.Load()), 20, "expected watcher to have not consumed WAL fully")
 		require.InDelta(t, 15, int(writeTo.entriesReceived.Load()), 1.0, "expected Watcher to consume at most +/- 1 entry from the WAL")
+	})
+}
+
+// TestLiveReaderRecordSpanningPage is a regression test for a crash in the
+// watcher's segment reading: wlog.LiveReader.readRecord dereferences its
+// metrics unconditionally when a record spans a page boundary, so building
+// the reader with nil metrics panics on that input instead of tolerating it.
+//
+// The page bytes encode a small valid record first, so the reader is
+// mid-page when it hits a second record header whose declared length runs
+// past the WAL page size, which is the condition seen in the wild.
+func TestLiveReaderRecordSpanningPage(t *testing.T) {
+	const recFull = byte(1)
+
+	payload := make([]byte, 10)
+	crc := crc32.Checksum(payload, crc32.MakeTable(crc32.Castagnoli))
+
+	var page bytes.Buffer
+	page.WriteByte(recFull)
+	binary.Write(&page, binary.BigEndian, uint16(len(payload)))
+	binary.Write(&page, binary.BigEndian, crc)
+	page.Write(payload)
+	page.WriteByte(recFull)
+	binary.Write(&page, binary.BigEndian, uint16(32750))
+	binary.Write(&page, binary.BigEndian, uint32(0))
+
+	logger := autil.TestAlloyLogger(t).Slog()
+	reader := newLiveReader(logger, bytes.NewReader(page.Bytes()))
+
+	require.NotPanics(t, func() {
+		for reader.Next() {
+		}
 	})
 }

--- a/internal/component/common/loki/wal/watcher_test.go
+++ b/internal/component/common/loki/wal/watcher_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/tsdb/record"
+	"github.com/prometheus/prometheus/tsdb/wlog"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
@@ -783,14 +784,7 @@ func TestWatcher_StopAndDrainWAL(t *testing.T) {
 	})
 }
 
-// TestLiveReaderRecordSpanningPage is a regression test for a crash in the
-// watcher's segment reading: wlog.LiveReader.readRecord dereferences its
-// metrics unconditionally when a record spans a page boundary, so building
-// the reader with nil metrics panics on that input instead of tolerating it.
-//
-// The page bytes encode a small valid record first, so the reader is
-// mid-page when it hits a second record header whose declared length runs
-// past the WAL page size, which is the condition seen in the wild.
+// Regression test: reading a record that spans a page boundary must not panic.
 func TestLiveReaderRecordSpanningPage(t *testing.T) {
 	const recFull = byte(1)
 
@@ -807,7 +801,7 @@ func TestLiveReaderRecordSpanningPage(t *testing.T) {
 	binary.Write(&page, binary.BigEndian, uint32(0))
 
 	logger := autil.TestAlloyLogger(t).Slog()
-	reader := newLiveReader(logger, bytes.NewReader(page.Bytes()))
+	reader := wlog.NewLiveReader(logger, wlog.NewLiveReaderMetrics(nil), bytes.NewReader(page.Bytes()))
 
 	require.NotPanics(t, func() {
 		for reader.Next() {


### PR DESCRIPTION
When the experimental WAL is enabled for loki.write, the watcher builds its LiveReader with nil metrics, so the moment a record spans a page boundary the reader panics on the nil counter instead of just logging the corruption. This is what #6757 hit, 19 restarts in 35 hours from the same stack frame.

The fix passes a LiveReaderMetrics built with a nil registerer, meaning that the branch increments an unregistered counter instead of crashing. Also added a regression test that feeds the reader a crafted page where a record header runs past the page size. It panics without the fix and passes with it.

Closes #6757