### PR TITLE
feat(database_observability.postgres): Add user, pid, and sqlstate fields to op=error_message

### DIFF
--- a/internal/component/database_observability/postgres/collector/logs.go
+++ b/internal/component/database_observability/postgres/collector/logs.go
@@ -78,11 +78,14 @@ func leadingLogLabel(s string) string {
 // error line's prefix; a STATEMENT line only attaches when its PID matches, so
 // interleaved log streams cannot pair one backend's error with another's SQL.
 type pendingError struct {
-	receivedAt time.Time
-	pid        string
-	severity   string
-	datname    string
-	timestamp  time.Time
+	receivedAt    time.Time
+	pid           string
+	severity      string
+	datname       string
+	user          string
+	sqlstate      string
+	sqlstateClass string
+	timestamp     time.Time
 
 	sql          strings.Builder
 	hasStatement bool
@@ -490,11 +493,14 @@ func (l *Logs) parseTextLog(entry loki.Entry) error {
 	// pending is displaced here (no STATEMENT captured → no op="error_message" entry);
 	// pg_errors_total still counted it above.
 	l.pending = &pendingError{
-		receivedAt: time.Now(),
-		pid:        pid,
-		severity:   label,
-		datname:    database,
-		timestamp:  parsedTimestamp,
+		receivedAt:    time.Now(),
+		pid:           pid,
+		severity:      label,
+		datname:       database,
+		user:          user,
+		sqlstate:      sqlstateCode,
+		sqlstateClass: sqlstateClass,
+		timestamp:     parsedTimestamp,
 	}
 
 	return nil
@@ -580,11 +586,14 @@ func (l *Logs) emitErrorEntry(p *pendingError) {
 	}
 
 	// Minimal logfmt body for one ERROR + STATEMENT pair: just the fields
-	// needed to compute per-query error rate. The SQL text and error-detail
-	// fields are intentionally omitted (deferred to a follow-up PR); consumers
-	// recover the SQL by joining on query_fingerprint. severity and fp never
-	// need quoting; %q fully escapes datname.
-	body := fmt.Sprintf("severity=%s datname=%q query_fingerprint=%s", p.severity, p.datname, fp)
+	// needed to compute per-query error rate plus who/what triggered it. The
+	// SQL text and remaining error-detail fields (client/session, error
+	// message, …) are intentionally omitted (deferred to a follow-up PR);
+	// consumers recover the SQL by joining on query_fingerprint. severity, pid,
+	// sqlstate, sqlstate_class, and fp never need quoting; %q escapes datname
+	// and user.
+	body := fmt.Sprintf("severity=%s datname=%q query_fingerprint=%s user=%q pid=%s sqlstate=%s sqlstate_class=%s",
+		p.severity, p.datname, fp, p.user, p.pid, p.sqlstate, p.sqlstateClass)
 
 	// Blocking send by design (backpressure over dropping entries), but guarded
 	// by the collector context so a stalled downstream can't wedge Stop().

--- a/internal/component/database_observability/postgres/collector/logs_test.go
+++ b/internal/component/database_observability/postgres/collector/logs_test.go
@@ -969,10 +969,14 @@ func TestLogsCollector_EmitsErrorEntry_OnErrorPlusStatement(t *testing.T) {
 	require.Equal(t, "ERROR", fields["severity"])
 	require.Equal(t, "books_store", fields["datname"])
 	require.Equal(t, expectedFP, fields["query_fingerprint"])
+	require.Equal(t, "user", fields["user"])
+	require.Equal(t, pid, fields["pid"])
+	require.Equal(t, "42P01", fields["sqlstate"])
+	require.Equal(t, "42", fields["sqlstate_class"])
 
-	// v1 emits only the bare-minimum field set; error-detail fields (sqlstate,
-	// pid, client/session, error_message, the SQL text, …) are deferred.
-	requireOnlyFields(t, fields, "severity", "datname", "query_fingerprint")
+	// v1 emits only the bare-minimum field set; error-detail fields (client/session,
+	// error_message, the SQL text, …) are deferred.
+	requireOnlyFields(t, fields, "severity", "datname", "query_fingerprint", "user", "pid", "sqlstate", "sqlstate_class")
 }
 
 func TestLogsCollector_TimedOutPendingDoesNotEmitErrorEntry(t *testing.T) {
@@ -1018,7 +1022,9 @@ func TestLogsCollector_DisplacedPendingEmitsExactlyOneEntry(t *testing.T) {
 	require.NoError(t, fpErr)
 	require.Equal(t, "ERROR", fields["severity"])
 	require.Equal(t, expectedFP, fields["query_fingerprint"], "the second error's STATEMENT is the one matched")
-	requireOnlyFields(t, fields, "severity", "datname", "query_fingerprint")
+	require.Equal(t, pid, fields["pid"])
+	require.Equal(t, "42P02", fields["sqlstate"], "the second error's SQLSTATE is the one matched")
+	requireOnlyFields(t, fields, "severity", "datname", "query_fingerprint", "user", "pid", "sqlstate", "sqlstate_class")
 }
 
 // TestLogsCollector_EmitsErrorEntry_PrefixedMultiLineStatement exercises the
@@ -1050,8 +1056,10 @@ func TestLogsCollector_EmitsErrorEntry_PrefixedMultiLineStatement(t *testing.T) 
 
 	require.Equal(t, "ERROR", fields["severity"])
 	require.Equal(t, expectedFP, fields["query_fingerprint"])
+	require.Equal(t, "app-user", fields["user"])
+	require.Equal(t, pid, fields["pid"])
 	// The multi-line STATEMENT is the behavior under test; fields stay minimal.
-	requireOnlyFields(t, fields, "severity", "datname", "query_fingerprint")
+	requireOnlyFields(t, fields, "severity", "datname", "query_fingerprint", "user", "pid", "sqlstate", "sqlstate_class")
 }
 
 // TestLogsCollector_StatementSurvivesTimeoutFlush_EmitsEntry pins that an


### PR DESCRIPTION
### Brief description of Pull Request

Threads the Postgres `user`, backend `pid`, and SQLSTATE `code`/`class` — already parsed from `log_line_prefix` for the `pg_errors_total` Prometheus counter — into the `op="error_message"` Loki log entry body, so consumers of that log stream get these fields without joining against the counter.

### Pull Request Details



### Issue(s) fixed by this Pull Request



### Notes to the Reviewer



### PR Checklist

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))