### PR TITLE
feat(otelcol.receiver.awscloudwatch): Add metrics support and upstream config parity

### DIFF
--- a/docs/sources/reference/components/otelcol/otelcol.receiver.awscloudwatch.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.awscloudwatch.md
@@ -12,7 +12,7 @@ title: otelcol.receiver.awscloudwatch
 
 {{< docs/shared lookup="stability/experimental.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
-`otelcol.receiver.awscloudwatch` receives logs from Amazon CloudWatch and forwards them to other `otelcol.*` components.
+`otelcol.receiver.awscloudwatch` receives logs and metrics from Amazon CloudWatch and forwards them to other `otelcol.*` components.
 
 {{< admonition type="note" >}}
 `otelcol.receiver.awscloudwatch` is a wrapper over the upstream OpenTelemetry Collector [`awscloudwatch`][] receiver.
@@ -30,7 +30,8 @@ otelcol.receiver.awscloudwatch "<LABEL>" {
   region = "us-west-2"
 
   output {
-    logs = [...]
+    logs    = [...]
+    metrics = [...]
   }
 }
 ```
@@ -41,7 +42,7 @@ You can use the following arguments with `otelcol.receiver.awscloudwatch`:
 
 | Name            | Type                       | Description                                                              | Default | Required |
 |-----------------|----------------------------|--------------------------------------------------------------------------|---------|----------|
-| `region`        | `string`                   | AWS region to collect logs from.                                         |         | yes      |
+| `region`        | `string`                   | AWS region to collect telemetry from.                                    |         | yes      |
 | `imds_endpoint` | `string`                   | Custom EC2 IMDS endpoint to use.                                         |         | no       |
 | `profile`       | `string`                   | AWS credentials profile to use.                                          |         | no       |
 | `storage`       | `capsule(otelcol.Handler)` | Handler from an `otelcol.storage` component to use for persisting state. |         | no       |
@@ -59,8 +60,10 @@ You can use the following blocks with `otelcol.receiver.awscloudwatch`:
 | [`output`][output]               | Configures where to send received telemetry data.                          | yes      |
 | [`debug_metrics`][debug_metrics] | Configures the metrics that this component generates to monitor its state. | no       |
 | [`logs`][logs]                   | Configures the log collection settings.                                    | no       |
+| [`metrics`][metrics]             | Configures the metric collection settings.                                 | no       |
 
 [logs]: #logs
+[metrics]: #metrics
 [debug_metrics]: #debug_metrics
 [output]: #output
 
@@ -111,10 +114,17 @@ The `autodiscover` block configures automatic discovery of log groups.
 
 The following arguments are supported:
 
-| Name     | Type     | Description                               | Default | Required |
-|----------|----------|-------------------------------------------|---------|----------|
-| `limit`  | `int`    | Maximum number of log groups to discover. | `50`    | no       |
-| `prefix` | `string` | Prefix to filter log groups by.           |         | no       |
+| Name                      | Type       | Description                                                        | Default | Required |
+|---------------------------|------------|--------------------------------------------------------------------|---------|----------|
+| `account_identifiers`     | `[]string` | AWS account identifiers to discover log groups from.               |         | no       |
+| `include_linked_accounts` | `bool`     | Whether to include log groups from linked source accounts.         |         | no       |
+| `limit`                   | `int`      | Maximum number of log groups to discover.                          | `50`    | no       |
+| `pattern`                 | `string`   | Pattern to filter log groups by.                                   |         | no       |
+| `prefix`                  | `string`   | Prefix to filter log groups by.                                    |         | no       |
+
+The `prefix` and `pattern` arguments are mutually exclusive.
+
+If you don't set `include_linked_accounts`, {{< param "PRODUCT_NAME" >}} omits the field from the request to CloudWatch and the AWS default applies.
 
 The `autodiscover` block supports the following blocks:
 
@@ -145,6 +155,84 @@ The following arguments are supported:
 | `names`      | `[]string` | List of exact stream names to collect. | no       |
 | `prefixes`   | `[]string` | List of prefixes to filter streams by. | no       |
 
+### `metrics`
+
+The `metrics` block configures how metrics are collected from CloudWatch with the `GetMetricData` API.
+
+If you don't set the `metrics` block, {{< param "PRODUCT_NAME" >}} doesn't collect metrics from CloudWatch.
+
+The following arguments are supported:
+
+| Name                  | Type       | Description                                                              | Default | Required |
+|-----------------------|------------|--------------------------------------------------------------------------|---------|----------|
+| `collection_interval` | `duration` | How frequently to scrape CloudWatch for metrics.                         | `"5m"`  | no       |
+| `delay`               | `duration` | How far to shift the query window back to allow for publication latency. | `"10m"` | no       |
+| `initial_delay`       | `duration` | How long to wait before the first scrape.                                | `"1s"`  | no       |
+| `period`              | `duration` | CloudWatch statistics aggregation window.                                | `"5m"`  | no       |
+| `timeout`             | `duration` | Deadline for a single scrape. Zero means no deadline.                    | `"0s"`  | no       |
+
+`collection_interval` must be greater than or equal to `period`.
+
+CloudWatch metrics are typically available three to ten minutes after they're recorded, which is why `delay` defaults to `"10m"`.
+
+The `metrics` block supports the following blocks:
+
+| Block                                     | Description                                          | Required |
+|-------------------------------------------|------------------------------------------------------|----------|
+| [`discovery`](#metrics--discovery)        | Configures automatic discovery of metrics.           | no       |
+| [`query`](#metrics--query)                | Configures a specific CloudWatch metric to collect.  | no       |
+
+The `query` and `discovery` blocks are mutually exclusive.
+
+#### `metrics` > `query`
+
+The `query` block configures a single CloudWatch metric to collect.
+You can specify multiple `query` blocks.
+
+The following arguments are supported:
+
+| Name          | Type                | Description                                        | Default | Required |
+|---------------|---------------------|----------------------------------------------------|---------|----------|
+| `metric_name` | `string`            | Name of the CloudWatch metric.                     |         | yes      |
+| `namespace`   | `string`            | CloudWatch namespace of the metric.                |         | yes      |
+| `dimensions`  | `map(string)`       | Dimensions used to narrow the metric.              |         | no       |
+| `stats`       | `[]string`          | CloudWatch statistics to collect.                  |         | no       |
+
+Valid `stats` values include `Sum`, `Average`, `Minimum`, `Maximum`, `SampleCount`, and percentiles such as `p95` and `p99`.
+
+If you don't set `stats`, {{< param "PRODUCT_NAME" >}} collects `Sum`, `SampleCount`, `Minimum`, and `Maximum`, and combines them into a single OpenTelemetry Summary metric.
+If you set `stats`, {{< param "PRODUCT_NAME" >}} emits each statistic as a separate Gauge data point with a `stat` attribute identifying the statistic.
+
+#### `metrics` > `discovery`
+
+The `discovery` block configures automatic discovery of metrics with the `ListMetrics` API.
+Discovered metrics are then collected with `GetMetricData`.
+
+The following arguments are supported:
+
+| Name    | Type       | Description                                                | Default | Required |
+|---------|------------|------------------------------------------------------------|---------|----------|
+| `limit` | `int`      | Maximum number of metrics to discover and collect.         | `100`   | no       |
+| `stats` | `[]string` | CloudWatch statistics to collect for all discovered metrics. |       | no       |
+
+The `discovery` block supports the following blocks:
+
+| Block                                          | Description                             | Required |
+|------------------------------------------------|-----------------------------------------|----------|
+| [`filters`](#metrics--discovery--filters)      | Narrows down which metrics to discover. | no       |
+
+#### `metrics` > `discovery` > `filters`
+
+The `filters` block narrows down which metrics are discovered.
+If you don't set the `filters` block, {{< param "PRODUCT_NAME" >}} discovers all metrics in all namespaces, up to `limit`.
+
+The following arguments are supported:
+
+| Name          | Type     | Description                          | Default | Required |
+|---------------|----------|--------------------------------------|---------|----------|
+| `metric_name` | `string` | Metric name to filter by.            |         | no       |
+| `namespace`   | `string` | CloudWatch namespace to filter by.   |         | no       |
+
 ## Exported fields
 
 `otelcol.receiver.awscloudwatch` doesn't export any fields.
@@ -157,7 +245,9 @@ The following arguments are supported:
 
 `otelcol.receiver.awscloudwatch` doesn't expose any component-specific debug information.
 
-## Example
+## Examples
+
+### Collect logs from named log groups
 
 The following example collects logs from specific EKS cluster log groups and forwards them through a batch processor:
 
@@ -189,6 +279,80 @@ otelcol.receiver.awscloudwatch "default" {
 otelcol.processor.batch "default" {
   output {
     logs = [otelcol.exporter.otlphttp.default.input]
+  }
+}
+
+otelcol.exporter.otlphttp "default" {
+  client {
+    endpoint = env("<OTLP_ENDPOINT>")
+  }
+}
+```
+
+### Collect specific metrics
+
+The following example collects two EC2 metrics, one narrowed to a single instance:
+
+```alloy
+otelcol.receiver.awscloudwatch "default" {
+  region = "us-west-2"
+
+  metrics {
+    collection_interval = "5m"
+    period = "5m"
+
+    query {
+      namespace = "AWS/EC2"
+      metric_name = "CPUUtilization"
+      dimensions = {
+        InstanceId = "i-1234567890abcdef0",
+      }
+      stats = ["Average", "p99"]
+    }
+
+    query {
+      namespace = "AWS/EC2"
+      metric_name = "NetworkIn"
+    }
+  }
+
+  output {
+    metrics = [otelcol.exporter.otlphttp.default.input]
+  }
+}
+
+otelcol.exporter.otlphttp "default" {
+  client {
+    endpoint = env("<OTLP_ENDPOINT>")
+  }
+}
+```
+
+### Discover metrics automatically
+
+The following example discovers up to 200 EC2 metrics and collects their average:
+
+```alloy
+otelcol.receiver.awscloudwatch "default" {
+  region = "us-west-2"
+
+  metrics {
+    collection_interval = "5m"
+    period = "5m"
+    delay = "10m"
+
+    discovery {
+      limit = 200
+      stats = ["Average"]
+
+      filters {
+        namespace = "AWS/EC2"
+      }
+    }
+  }
+
+  output {
+    metrics = [otelcol.exporter.otlphttp.default.input]
   }
 }
 

--- a/internal/component/otelcol/receiver/awscloudwatch/awscloudwatch.go
+++ b/internal/component/otelcol/receiver/awscloudwatch/awscloudwatch.go
@@ -80,11 +80,6 @@ func (args Arguments) Convert() (otelcomponent.Config, error) {
 		}
 	}
 
-	// If the autodiscover config is provided but the limit is not set, set the limit to the default.
-	if args.Logs.Groups.AutodiscoverConfig != nil && args.Logs.Groups.AutodiscoverConfig.Limit == nil {
-		otelConfig.Logs.Groups.AutodiscoverConfig.Limit = defaultLogGroupLimit
-	}
-
 	// Configure storage if args.Storage is set.
 	if args.Storage != nil {
 		if args.Storage.Extension == nil {

--- a/internal/component/otelcol/receiver/awscloudwatch/awscloudwatch.go
+++ b/internal/component/otelcol/receiver/awscloudwatch/awscloudwatch.go
@@ -36,6 +36,7 @@ type Arguments struct {
 	Profile      string                      `alloy:"profile,attr,optional"`
 	IMDSEndpoint string                      `alloy:"imds_endpoint,attr,optional"`
 	Logs         LogsConfig                  `alloy:"logs,block,optional"`
+	Metrics      *MetricsConfig              `alloy:"metrics,block,optional"`
 	Storage      *extension.ExtensionHandler `alloy:"storage,attr,optional"`
 
 	DebugMetrics otelcolCfg.DebugMetricsArguments `alloy:"debug_metrics,block,optional"`
@@ -69,6 +70,7 @@ func (args Arguments) Convert() (otelcomponent.Config, error) {
 		Profile:      args.Profile,
 		IMDSEndpoint: args.IMDSEndpoint,
 		Logs:         args.Logs.Convert(),
+		Metrics:      args.Metrics.Convert(),
 	}
 
 	// If no autodiscover or named configs are provided, set the autodiscover config with a default limit.

--- a/internal/component/otelcol/receiver/awscloudwatch/awscloudwatch_test.go
+++ b/internal/component/otelcol/receiver/awscloudwatch/awscloudwatch_test.go
@@ -8,7 +8,25 @@ import (
 	"github.com/grafana/alloy/syntax"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configoptional"
+	"go.opentelemetry.io/collector/scraper/scraperhelper"
 )
+
+// defaultLogsConfig is the logs config produced when no logs block is given.
+// Metrics test cases reuse it so they assert only on what they exercise.
+func defaultLogsConfig() awscloudwatchreceiver.LogsConfig {
+	return awscloudwatchreceiver.LogsConfig{
+		PollInterval:        time.Minute,
+		MaxEventsPerRequest: 1000,
+		Groups: awscloudwatchreceiver.GroupConfig{
+			AutodiscoverConfig: &awscloudwatchreceiver.AutodiscoverConfig{
+				Limit:   50,
+				Streams: awscloudwatchreceiver.StreamConfig{},
+			},
+			NamedConfigs: map[string]awscloudwatchreceiver.StreamConfig{},
+		},
+	}
+}
 
 func TestArguments_UnmarshalAlloy(t *testing.T) {
 	tests := []struct {
@@ -183,6 +201,181 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 				},
 			},
 		},
+		{
+			testName: "autodiscover with pattern and linked accounts",
+			cfg: `
+				region = "us-west-2"
+				logs {
+					groups {
+						autodiscover {
+							pattern = "/aws/lambda/.*"
+							account_identifiers = ["123456789012", "987654321098"]
+							include_linked_accounts = true
+						}
+					}
+				}
+				output {}
+			`,
+			expected: awscloudwatchreceiver.Config{
+				Region: "us-west-2",
+				Logs: awscloudwatchreceiver.LogsConfig{
+					PollInterval:        time.Minute,
+					MaxEventsPerRequest: 1000,
+					Groups: awscloudwatchreceiver.GroupConfig{
+						AutodiscoverConfig: &awscloudwatchreceiver.AutodiscoverConfig{
+							Pattern:               "/aws/lambda/.*",
+							Limit:                 50,
+							Streams:               awscloudwatchreceiver.StreamConfig{},
+							AccountIdentifiers:    []string{"123456789012", "987654321098"},
+							IncludeLinkedAccounts: boolPtr(true),
+						},
+						NamedConfigs: map[string]awscloudwatchreceiver.StreamConfig{},
+					},
+				},
+			},
+		},
+		{
+			testName: "metrics with explicit queries",
+			cfg: `
+				region = "us-west-2"
+				metrics {
+					collection_interval = "1m"
+					period = "1m"
+					query {
+						namespace = "AWS/EC2"
+						metric_name = "CPUUtilization"
+						dimensions = {
+							InstanceId = "i-1234567890abcdef0",
+						}
+						stats = ["Average", "p99"]
+					}
+					query {
+						namespace = "AWS/DynamoDB"
+						metric_name = "SuccessfulRequestLatency"
+					}
+				}
+				output {}
+			`,
+			expected: awscloudwatchreceiver.Config{
+				Region: "us-west-2",
+				Logs:   defaultLogsConfig(),
+				Metrics: awscloudwatchreceiver.MetricsConfig{
+					ControllerConfig: scraperhelper.ControllerConfig{
+						CollectionInterval: time.Minute,
+						InitialDelay:       time.Second,
+					},
+					Period: time.Minute,
+					Delay:  10 * time.Minute,
+					Queries: []awscloudwatchreceiver.MetricQuery{
+						{
+							Namespace:  "AWS/EC2",
+							MetricName: "CPUUtilization",
+							Dimensions: map[string]string{"InstanceId": "i-1234567890abcdef0"},
+							Stats:      []string{"Average", "p99"},
+						},
+						{
+							Namespace:  "AWS/DynamoDB",
+							MetricName: "SuccessfulRequestLatency",
+						},
+					},
+				},
+			},
+		},
+		{
+			testName: "metrics with defaults",
+			cfg: `
+				region = "us-west-2"
+				metrics {
+					query {
+						namespace = "AWS/EC2"
+						metric_name = "CPUUtilization"
+					}
+				}
+				output {}
+			`,
+			expected: awscloudwatchreceiver.Config{
+				Region: "us-west-2",
+				Logs:   defaultLogsConfig(),
+				Metrics: awscloudwatchreceiver.MetricsConfig{
+					ControllerConfig: scraperhelper.ControllerConfig{
+						// 5m, not the generic otelcol default of 1m.
+						CollectionInterval: 5 * time.Minute,
+						InitialDelay:       time.Second,
+					},
+					Period: 5 * time.Minute,
+					Delay:  10 * time.Minute,
+					Queries: []awscloudwatchreceiver.MetricQuery{
+						{Namespace: "AWS/EC2", MetricName: "CPUUtilization"},
+					},
+				},
+			},
+		},
+		{
+			testName: "metrics discovery with filters",
+			cfg: `
+				region = "us-west-2"
+				metrics {
+					collection_interval = "5m"
+					period = "5m"
+					delay = "15m"
+					discovery {
+						limit = 200
+						stats = ["Average"]
+						filters {
+							namespace = "AWS/EC2"
+							metric_name = "CPUUtilization"
+						}
+					}
+				}
+				output {}
+			`,
+			expected: awscloudwatchreceiver.Config{
+				Region: "us-west-2",
+				Logs:   defaultLogsConfig(),
+				Metrics: awscloudwatchreceiver.MetricsConfig{
+					ControllerConfig: scraperhelper.ControllerConfig{
+						CollectionInterval: 5 * time.Minute,
+						InitialDelay:       time.Second,
+					},
+					Period: 5 * time.Minute,
+					Delay:  15 * time.Minute,
+					Discovery: &awscloudwatchreceiver.MetricsDiscoveryConfig{
+						Filters: configoptional.Some(awscloudwatchreceiver.MetricsDiscoveryFilters{
+							Namespace:  "AWS/EC2",
+							MetricName: "CPUUtilization",
+						}),
+						Limit: 200,
+						Stats: []string{"Average"},
+					},
+				},
+			},
+		},
+		{
+			testName: "metrics discovery without filters uses default limit",
+			cfg: `
+				region = "us-west-2"
+				metrics {
+					discovery {}
+				}
+				output {}
+			`,
+			expected: awscloudwatchreceiver.Config{
+				Region: "us-west-2",
+				Logs:   defaultLogsConfig(),
+				Metrics: awscloudwatchreceiver.MetricsConfig{
+					ControllerConfig: scraperhelper.ControllerConfig{
+						CollectionInterval: 5 * time.Minute,
+						InitialDelay:       time.Second,
+					},
+					Period: 5 * time.Minute,
+					Delay:  10 * time.Minute,
+					Discovery: &awscloudwatchreceiver.MetricsDiscoveryConfig{
+						Filters: configoptional.None[awscloudwatchreceiver.MetricsDiscoveryFilters](),
+						Limit:   100,
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -199,6 +392,59 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 			require.Equal(t, tc.expected, *actual)
 		})
 	}
+}
+
+// TestArguments_NoMetricsBlock guards backwards compatibility: a configuration
+// without a metrics block must leave the upstream Metrics config at its zero
+// value, so existing logs-only users gain no CloudWatch GetMetricData calls.
+func TestArguments_NoMetricsBlock(t *testing.T) {
+	cfg := `
+		region = "us-west-2"
+		logs {
+			poll_interval = "1m"
+		}
+		output {}
+	`
+
+	var args awscloudwatch.Arguments
+	require.NoError(t, syntax.Unmarshal([]byte(cfg), &args))
+	require.Nil(t, args.Metrics)
+
+	actual, err := args.Convert()
+	require.NoError(t, err)
+
+	require.Equal(t,
+		awscloudwatchreceiver.MetricsConfig{},
+		actual.(*awscloudwatchreceiver.Config).Metrics,
+	)
+}
+
+// TestArguments_IncludeLinkedAccountsUnset guards the pointer semantics of
+// include_linked_accounts. Upstream only forwards the field to AWS when it is
+// non-nil, so omitting the attribute must not send an explicit false.
+func TestArguments_IncludeLinkedAccountsUnset(t *testing.T) {
+	cfg := `
+		region = "us-west-2"
+		logs {
+			groups {
+				autodiscover {
+					prefix = "app-"
+				}
+			}
+		}
+		output {}
+	`
+
+	var args awscloudwatch.Arguments
+	require.NoError(t, syntax.Unmarshal([]byte(cfg), &args))
+
+	actual, err := args.Convert()
+	require.NoError(t, err)
+
+	autodiscover := actual.(*awscloudwatchreceiver.Config).Logs.Groups.AutodiscoverConfig
+	require.NotNil(t, autodiscover)
+	require.Nil(t, autodiscover.IncludeLinkedAccounts)
+	require.Nil(t, autodiscover.AccountIdentifiers)
 }
 
 func TestArguments_Validate(t *testing.T) {
@@ -272,6 +518,109 @@ func TestArguments_Validate(t *testing.T) {
 			`,
 			expectedError: "invalid start_from time format",
 		},
+		{
+			testName: "both prefix and pattern",
+			cfg: `
+				region = "us-west-2"
+				logs {
+					groups {
+						autodiscover {
+							prefix = "app-"
+							pattern = "app-.*"
+						}
+					}
+				}
+				output {}
+			`,
+			expectedError: "cannot specify both prefix and pattern",
+		},
+		{
+			testName: "both queries and discovery",
+			cfg: `
+				region = "us-west-2"
+				metrics {
+					query {
+						namespace = "AWS/EC2"
+						metric_name = "CPUUtilization"
+					}
+					discovery {
+						limit = 100
+					}
+				}
+				output {}
+			`,
+			expectedError: "metrics and discovery are mutually exclusive",
+		},
+		{
+			testName: "collection_interval less than period",
+			cfg: `
+				region = "us-west-2"
+				metrics {
+					collection_interval = "1m"
+					period = "5m"
+					query {
+						namespace = "AWS/EC2"
+						metric_name = "CPUUtilization"
+					}
+				}
+				output {}
+			`,
+			expectedError: "metrics collection_interval must be greater than or equal to period",
+		},
+		{
+			testName: "empty stat name",
+			cfg: `
+				region = "us-west-2"
+				metrics {
+					query {
+						namespace = "AWS/EC2"
+						metric_name = "CPUUtilization"
+						stats = [""]
+					}
+				}
+				output {}
+			`,
+			expectedError: "stat name must not be empty",
+		},
+		{
+			testName: "discovery limit not positive",
+			cfg: `
+				region = "us-west-2"
+				metrics {
+					discovery {
+						limit = 0
+					}
+				}
+				output {}
+			`,
+			expectedError: "metrics discovery limit must be greater than 0",
+		},
+		{
+			testName: "query missing namespace",
+			cfg: `
+				region = "us-west-2"
+				metrics {
+					query {
+						metric_name = "CPUUtilization"
+					}
+				}
+				output {}
+			`,
+			expectedError: `missing required attribute "namespace"`,
+		},
+		{
+			testName: "query missing metric_name",
+			cfg: `
+				region = "us-west-2"
+				metrics {
+					query {
+						namespace = "AWS/EC2"
+					}
+				}
+				output {}
+			`,
+			expectedError: `missing required attribute "metric_name"`,
+		},
 	}
 
 	for _, tc := range tests {
@@ -285,4 +634,9 @@ func TestArguments_Validate(t *testing.T) {
 // Helper function to create string pointers
 func ptr(s string) *string {
 	return &s
+}
+
+// Helper function to create bool pointers
+func boolPtr(b bool) *bool {
+	return &b
 }

--- a/internal/component/otelcol/receiver/awscloudwatch/awscloudwatch_test.go
+++ b/internal/component/otelcol/receiver/awscloudwatch/awscloudwatch_test.go
@@ -419,6 +419,35 @@ func TestArguments_NoMetricsBlock(t *testing.T) {
 	)
 }
 
+// TestArguments_AutodiscoverNullLimit guards against a nil dereference in
+// AutodiscoverConfig.Convert. SetToDefault populates the limit when the block is
+// present, but an explicit `limit = null` leaves the pointer nil, which used to
+// panic while loading the configuration.
+func TestArguments_AutodiscoverNullLimit(t *testing.T) {
+	cfg := `
+		region = "us-west-2"
+		logs {
+			groups {
+				autodiscover {
+					prefix = "app-"
+					limit = null
+				}
+			}
+		}
+		output {}
+	`
+
+	var args awscloudwatch.Arguments
+	require.NoError(t, syntax.Unmarshal([]byte(cfg), &args))
+
+	actual, err := args.Convert()
+	require.NoError(t, err)
+
+	autodiscover := actual.(*awscloudwatchreceiver.Config).Logs.Groups.AutodiscoverConfig
+	require.NotNil(t, autodiscover)
+	require.Equal(t, 50, autodiscover.Limit)
+}
+
 // TestArguments_IncludeLinkedAccountsUnset guards the pointer semantics of
 // include_linked_accounts. Upstream only forwards the field to AWS when it is
 // non-nil, so omitting the attribute must not send an explicit false.

--- a/internal/component/otelcol/receiver/awscloudwatch/config_awscloudwatch.go
+++ b/internal/component/otelcol/receiver/awscloudwatch/config_awscloudwatch.go
@@ -3,10 +3,23 @@ package awscloudwatch
 import (
 	"time"
 
+	"github.com/grafana/alloy/internal/component/otelcol"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver"
+	"go.opentelemetry.io/collector/config/configoptional"
 )
 
-var defaultLogGroupLimit = 50
+var (
+	defaultLogGroupLimit = 50
+
+	// Defaults for the metrics block. These mirror upstream's createDefaultConfig
+	// rather than otelcol.DefaultScraperControllerArguments, whose generic
+	// collection_interval of 1m would poll CloudWatch five times as often as the
+	// equivalent OpenTelemetry Collector configuration.
+	defaultMetricsCollectionInterval = 5 * time.Minute
+	defaultMetricsPeriod             = 5 * time.Minute
+	defaultMetricsDelay              = 10 * time.Minute
+	defaultMetricsDiscoveryLimit     = 100
+)
 
 // LogsConfig is the configuration for the logs portion of this receiver
 type LogsConfig struct {
@@ -30,6 +43,116 @@ func (args *LogsConfig) SetToDefault() {
 		PollInterval:        time.Minute,
 		MaxEventsPerRequest: 1000,
 	}
+}
+
+// MetricsConfig is the configuration for the metrics (GetMetricData) portion of
+// this receiver. Either Queries or Discovery may be set, not both.
+type MetricsConfig struct {
+	Controller otelcol.ScraperControllerArguments `alloy:",squash"`
+
+	Period    time.Duration           `alloy:"period,attr,optional"`
+	Delay     time.Duration           `alloy:"delay,attr,optional"`
+	Queries   []MetricQuery           `alloy:"query,block,optional"`
+	Discovery *MetricsDiscoveryConfig `alloy:"discovery,block,optional"`
+}
+
+// Convert returns the zero value when args is nil so that a configuration
+// without a metrics block leaves the upstream Metrics config untouched.
+func (args *MetricsConfig) Convert() awscloudwatchreceiver.MetricsConfig {
+	if args == nil {
+		return awscloudwatchreceiver.MetricsConfig{}
+	}
+
+	cfg := awscloudwatchreceiver.MetricsConfig{
+		ControllerConfig: *args.Controller.Convert(),
+		Period:           args.Period,
+		Delay:            args.Delay,
+		Discovery:        args.Discovery.Convert(),
+	}
+
+	for _, q := range args.Queries {
+		cfg.Queries = append(cfg.Queries, q.Convert())
+	}
+
+	return cfg
+}
+
+func (args *MetricsConfig) SetToDefault() {
+	if args == nil {
+		return
+	}
+
+	*args = MetricsConfig{
+		Period: defaultMetricsPeriod,
+		Delay:  defaultMetricsDelay,
+	}
+	args.Controller.SetToDefault()
+	args.Controller.CollectionInterval = defaultMetricsCollectionInterval
+}
+
+// MetricQuery defines a single CloudWatch metric to scrape via GetMetricData.
+type MetricQuery struct {
+	Namespace  string            `alloy:"namespace,attr"`
+	MetricName string            `alloy:"metric_name,attr"`
+	Dimensions map[string]string `alloy:"dimensions,attr,optional"`
+	Stats      []string          `alloy:"stats,attr,optional"`
+}
+
+func (args MetricQuery) Convert() awscloudwatchreceiver.MetricQuery {
+	return awscloudwatchreceiver.MetricQuery{
+		Namespace:  args.Namespace,
+		MetricName: args.MetricName,
+		Dimensions: args.Dimensions,
+		Stats:      args.Stats,
+	}
+}
+
+// MetricsDiscoveryConfig configures automatic discovery of metrics via
+// ListMetrics. Mutually exclusive with MetricsConfig.Queries.
+type MetricsDiscoveryConfig struct {
+	Filters *MetricsDiscoveryFilters `alloy:"filters,block,optional"`
+	Limit   int                      `alloy:"limit,attr,optional"`
+	Stats   []string                 `alloy:"stats,attr,optional"`
+}
+
+func (args *MetricsDiscoveryConfig) Convert() *awscloudwatchreceiver.MetricsDiscoveryConfig {
+	if args == nil {
+		return nil
+	}
+
+	return &awscloudwatchreceiver.MetricsDiscoveryConfig{
+		Filters: args.Filters.Convert(),
+		Limit:   args.Limit,
+		Stats:   args.Stats,
+	}
+}
+
+func (args *MetricsDiscoveryConfig) SetToDefault() {
+	if args == nil {
+		return
+	}
+
+	*args = MetricsDiscoveryConfig{
+		Limit: defaultMetricsDiscoveryLimit,
+	}
+}
+
+// MetricsDiscoveryFilters optionally narrows which metrics are discovered. When
+// absent, all metrics in all namespaces are discovered.
+type MetricsDiscoveryFilters struct {
+	Namespace  string `alloy:"namespace,attr,optional"`
+	MetricName string `alloy:"metric_name,attr,optional"`
+}
+
+func (args *MetricsDiscoveryFilters) Convert() configoptional.Optional[awscloudwatchreceiver.MetricsDiscoveryFilters] {
+	if args == nil {
+		return configoptional.None[awscloudwatchreceiver.MetricsDiscoveryFilters]()
+	}
+
+	return configoptional.Some(awscloudwatchreceiver.MetricsDiscoveryFilters{
+		Namespace:  args.Namespace,
+		MetricName: args.MetricName,
+	})
 }
 
 // GroupConfig is the configuration for log group collection
@@ -67,8 +190,16 @@ func (args NamedConfigs) Convert() map[string]awscloudwatchreceiver.StreamConfig
 // AutodiscoverConfig is the configuration for the autodiscovery functionality of log groups
 type AutodiscoverConfig struct {
 	Prefix  string       `alloy:"prefix,attr,optional"`
+	Pattern string       `alloy:"pattern,attr,optional"`
 	Limit   *int         `alloy:"limit,attr,optional"`
 	Streams StreamConfig `alloy:"streams,block,optional"`
+
+	AccountIdentifiers []string `alloy:"account_identifiers,attr,optional"`
+	// IncludeLinkedAccounts must stay a pointer. Upstream only sets the field on
+	// the AWS DescribeLogGroups request when it is non-nil, otherwise leaving
+	// AWS's own default to apply. A plain bool would send an explicit false for
+	// every existing configuration that omits the attribute.
+	IncludeLinkedAccounts *bool `alloy:"include_linked_accounts,attr,optional"`
 }
 
 func (args *AutodiscoverConfig) Convert() *awscloudwatchreceiver.AutodiscoverConfig {
@@ -76,9 +207,12 @@ func (args *AutodiscoverConfig) Convert() *awscloudwatchreceiver.AutodiscoverCon
 		return nil
 	}
 	return &awscloudwatchreceiver.AutodiscoverConfig{
-		Prefix:  args.Prefix,
-		Limit:   *args.Limit,
-		Streams: args.Streams.Convert(),
+		Prefix:                args.Prefix,
+		Pattern:               args.Pattern,
+		Limit:                 *args.Limit,
+		Streams:               args.Streams.Convert(),
+		AccountIdentifiers:    args.AccountIdentifiers,
+		IncludeLinkedAccounts: args.IncludeLinkedAccounts,
 	}
 }
 

--- a/internal/component/otelcol/receiver/awscloudwatch/config_awscloudwatch.go
+++ b/internal/component/otelcol/receiver/awscloudwatch/config_awscloudwatch.go
@@ -206,10 +206,18 @@ func (args *AutodiscoverConfig) Convert() *awscloudwatchreceiver.AutodiscoverCon
 	if args == nil {
 		return nil
 	}
+
+	// SetToDefault populates Limit when the block is present, but an explicit
+	// `limit = null` leaves it nil, so fall back rather than dereferencing.
+	limit := defaultLogGroupLimit
+	if args.Limit != nil {
+		limit = *args.Limit
+	}
+
 	return &awscloudwatchreceiver.AutodiscoverConfig{
 		Prefix:                args.Prefix,
 		Pattern:               args.Pattern,
-		Limit:                 *args.Limit,
+		Limit:                 limit,
 		Streams:               args.Streams.Convert(),
 		AccountIdentifiers:    args.AccountIdentifiers,
 		IncludeLinkedAccounts: args.IncludeLinkedAccounts,

--- a/internal/converter/internal/otelcolconvert/converter_awscloudwatchreceiver.go
+++ b/internal/converter/internal/otelcolconvert/converter_awscloudwatchreceiver.go
@@ -43,6 +43,7 @@ func (awsCloudWatchReceiverConverter) ConvertAndAppend(state *State, id componen
 }
 
 func toAwsCloudWatchReceiver(state *State, id componentstatus.InstanceID, cfg *awscloudwatchreceiver.Config) *awscloudwatch.Arguments {
+	nextMetrics := state.Next(id, pipeline.SignalMetrics)
 	nextLogs := state.Next(id, pipeline.SignalLogs)
 
 	return &awscloudwatch.Arguments{
@@ -50,9 +51,11 @@ func toAwsCloudWatchReceiver(state *State, id componentstatus.InstanceID, cfg *a
 		Profile:      cfg.Profile,
 		IMDSEndpoint: cfg.IMDSEndpoint,
 		Logs:         toLogsConfig(cfg.Logs),
+		Metrics:      toMetricsConfig(cfg.Metrics),
 		DebugMetrics: common.DefaultValue[awscloudwatch.Arguments]().DebugMetrics,
 		Output: &otelcol.ConsumerArguments{
-			Logs: ToTokenizedConsumers(nextLogs),
+			Metrics: ToTokenizedConsumers(nextMetrics),
+			Logs:    ToTokenizedConsumers(nextLogs),
 		},
 	}
 }
@@ -62,7 +65,59 @@ func toLogsConfig(cfg awscloudwatchreceiver.LogsConfig) awscloudwatch.LogsConfig
 		PollInterval:        cfg.PollInterval,
 		MaxEventsPerRequest: cfg.MaxEventsPerRequest,
 		Groups:              toGroupConfig(cfg.Groups),
+		StartFrom:           cfg.StartFrom,
 	}
+}
+
+// toMetricsConfig returns nil when metrics collection is not configured, so that
+// the generated Alloy configuration omits the metrics block entirely.
+func toMetricsConfig(cfg awscloudwatchreceiver.MetricsConfig) *awscloudwatch.MetricsConfig {
+	if len(cfg.Queries) == 0 && cfg.Discovery == nil {
+		return nil
+	}
+
+	out := &awscloudwatch.MetricsConfig{
+		Controller: otelcol.ScraperControllerArguments{
+			CollectionInterval: cfg.CollectionInterval,
+			InitialDelay:       cfg.InitialDelay,
+			Timeout:            cfg.Timeout,
+		},
+		Period:    cfg.Period,
+		Delay:     cfg.Delay,
+		Discovery: toMetricsDiscoveryConfig(cfg.Discovery),
+	}
+
+	for _, q := range cfg.Queries {
+		out.Queries = append(out.Queries, awscloudwatch.MetricQuery{
+			Namespace:  q.Namespace,
+			MetricName: q.MetricName,
+			Dimensions: q.Dimensions,
+			Stats:      q.Stats,
+		})
+	}
+
+	return out
+}
+
+func toMetricsDiscoveryConfig(cfg *awscloudwatchreceiver.MetricsDiscoveryConfig) *awscloudwatch.MetricsDiscoveryConfig {
+	if cfg == nil {
+		return nil
+	}
+
+	out := &awscloudwatch.MetricsDiscoveryConfig{
+		Limit: cfg.Limit,
+		Stats: cfg.Stats,
+	}
+
+	if cfg.Filters.HasValue() {
+		filters := cfg.Filters.Get()
+		out.Filters = &awscloudwatch.MetricsDiscoveryFilters{
+			Namespace:  filters.Namespace,
+			MetricName: filters.MetricName,
+		}
+	}
+
+	return out
 }
 
 func toGroupConfig(cfg awscloudwatchreceiver.GroupConfig) awscloudwatch.GroupConfig {
@@ -81,9 +136,12 @@ func toAutodiscoverConfig(cfg *awscloudwatchreceiver.AutodiscoverConfig) *awsclo
 	*limit = cfg.Limit
 
 	return &awscloudwatch.AutodiscoverConfig{
-		Prefix:  cfg.Prefix,
-		Limit:   limit,
-		Streams: toStreamConfig(cfg.Streams),
+		Prefix:                cfg.Prefix,
+		Pattern:               cfg.Pattern,
+		Limit:                 limit,
+		Streams:               toStreamConfig(cfg.Streams),
+		AccountIdentifiers:    cfg.AccountIdentifiers,
+		IncludeLinkedAccounts: cfg.IncludeLinkedAccounts,
 	}
 }
 

--- a/internal/converter/internal/otelcolconvert/testdata/awscloudwatch.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/awscloudwatch.alloy
@@ -13,8 +13,25 @@ otelcol.receiver.awscloudwatch "default" {
 		}
 	}
 
+	metrics {
+		query {
+			namespace   = "AWS/EC2"
+			metric_name = "CPUUtilization"
+			dimensions  = {
+				InstanceId = "i-1234567890abcdef0",
+			}
+			stats = ["Average", "p99"]
+		}
+
+		query {
+			namespace   = "AWS/DynamoDB"
+			metric_name = "SuccessfulRequestLatency"
+		}
+	}
+
 	output {
-		logs = [otelcol.exporter.otlp.default.input]
+		metrics = [otelcol.exporter.otlp.default.input]
+		logs    = [otelcol.exporter.otlp.default.input]
 	}
 }
 

--- a/internal/converter/internal/otelcolconvert/testdata/awscloudwatch.yaml
+++ b/internal/converter/internal/otelcolconvert/testdata/awscloudwatch.yaml
@@ -8,6 +8,18 @@ receivers:
         named:
           /aws/eks/dev-0/cluster:
             names: [kube-apiserver-ea9c831555adca1815ae04b87661klasdj]
+    metrics:
+      collection_interval: 5m
+      period: 5m
+      delay: 10m
+      queries:
+        - namespace: AWS/EC2
+          metric_name: CPUUtilization
+          dimensions:
+            InstanceId: i-1234567890abcdef0
+          stats: [Average, p99]
+        - namespace: AWS/DynamoDB
+          metric_name: SuccessfulRequestLatency
 
 exporters:
   otlp:
@@ -16,6 +28,10 @@ exporters:
 service:
   pipelines:
     logs:
+      receivers: [awscloudwatch]
+      processors: []
+      exporters: [otlp]
+    metrics:
       receivers: [awscloudwatch]
       processors: []
       exporters: [otlp]

--- a/internal/converter/internal/otelcolconvert/testdata/awscloudwatch_discovery.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/awscloudwatch_discovery.alloy
@@ -1,0 +1,40 @@
+otelcol.receiver.awscloudwatch "default" {
+	region = "us-west-1"
+
+	logs {
+		groups {
+			autodiscover {
+				pattern                 = "/aws/lambda/.*"
+				limit                   = 100
+				account_identifiers     = ["123456789012", "987654321098"]
+				include_linked_accounts = true
+			}
+		}
+		start_from = "2025-06-25T00:00:00Z"
+	}
+
+	metrics {
+		collection_interval = "10m0s"
+		period              = "1m0s"
+		delay               = "15m0s"
+
+		discovery {
+			filters {
+				namespace = "AWS/EC2"
+			}
+			limit = 200
+			stats = ["Average"]
+		}
+	}
+
+	output {
+		metrics = [otelcol.exporter.otlp.default.input]
+		logs    = [otelcol.exporter.otlp.default.input]
+	}
+}
+
+otelcol.exporter.otlp "default" {
+	client {
+		endpoint = "database:4317"
+	}
+}

--- a/internal/converter/internal/otelcolconvert/testdata/awscloudwatch_discovery.yaml
+++ b/internal/converter/internal/otelcolconvert/testdata/awscloudwatch_discovery.yaml
@@ -1,0 +1,36 @@
+receivers:
+  awscloudwatch:
+    region: us-west-1
+    logs:
+      poll_interval: 1m
+      start_from: '2025-06-25T00:00:00Z'
+      groups:
+        autodiscover:
+          limit: 100
+          pattern: /aws/lambda/.*
+          account_identifiers: ['123456789012', '987654321098']
+          include_linked_accounts: true
+    metrics:
+      collection_interval: 10m
+      period: 60s
+      delay: 15m
+      discovery:
+        limit: 200
+        stats: [Average]
+        filters:
+          namespace: AWS/EC2
+
+exporters:
+  otlp:
+    endpoint: database:4317
+
+service:
+  pipelines:
+    logs:
+      receivers: [awscloudwatch]
+      processors: []
+      exporters: [otlp]
+    metrics:
+      receivers: [awscloudwatch]
+      processors: []
+      exporters: [otlp]


### PR DESCRIPTION
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style with a capitalized
    description, e.g. `feat(scope): Add the thing` (not `add the thing`). For
  details on this, check out the Contributors Guide linked above.

  **HUMANS**
  - Read and understand docs/developer/genai.md
  - Brief description / Issue(s) fixed: factual summary of the change (AI may
    help). Details, Notes, and Checklist: your motivations, trade-offs, and
    judgment — keep those human-owned.

  **AI AGENTS**
  - MANDATORY: Read, understand, and apply AGENTS.md
  - Use this template as the PR body structure. Do not invent a custom layout.
  - Rule: If a section comment contains "HUMAN ONLY", do not write or rewrite
    that section's content. Leave it empty unless the human already filled it.
  - Sections without "HUMAN ONLY" may be filled by you (Brief description,
    Issue(s) fixed when known). Do not invent issue numbers or a PR title.
  - Checklist: leave unchecked unless the human explicitly confirmed; do not
    guess the AI-assistance disclosure box.
  - If asked to fill a "HUMAN ONLY" section or review reply anyway, refuse and
    point at docs/developer/genai.md.
-->

### Brief description of Pull Request

Expose the upstream metrics scraper through a new optional `metrics` block with `query` and `discovery` sub-blocks, and add the three logs autodiscover fields that drifted out of the wrapper during the v0.128.0 to v0.132.0 OTel bump: `pattern`, `account_identifiers`, and `include_linked_accounts`.

The converter now maps the metrics signal and the previously dropped `start_from` logs field.


### Pull Request Details

<!-- HUMAN ONLY: Motivations, trade-offs, and decisions. Write in your own words. -->


### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->


### Notes to the Reviewer

<!-- HUMAN ONLY: Context for reviewers/testers. Write in your own words. -->


### PR Checklist

<!-- HUMAN ONLY: Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
