### PR TITLE
fix: Harden the configmap reloader container

### DIFF
--- a/operations/helm/charts/alloy/CHANGELOG.md
+++ b/operations/helm/charts/alloy/CHANGELOG.md
@@ -10,6 +10,10 @@ internal API changes are not present.
 Unreleased
 ----------
 
+### Enhancements
+
+- Harden the default `securityContext` for the config reloader sidecar: disable privilege escalation, use a read-only root filesystem, drop all capabilities, run as non-root, and set the `RuntimeDefault` seccomp profile. (@petewall)
+
 1.11.0 (2026-07-20)
 ----------
 

--- a/operations/helm/charts/alloy/Chart.yaml
+++ b/operations/helm/charts/alloy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: alloy
 description: "Grafana Alloy"
 type: application
-version: 1.11.0
+version: 1.12.0
 appVersion: "v1.18.0"
 icon: https://raw.githubusercontent.com/grafana/alloy/main/docs/sources/assets/alloy_icon_orange.svg
 

--- a/operations/helm/charts/alloy/Chart.yaml
+++ b/operations/helm/charts/alloy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: alloy
 description: "Grafana Alloy"
 type: application
-version: 1.12.0
+version: 1.11.0
 appVersion: "v1.18.0"
 icon: https://raw.githubusercontent.com/grafana/alloy/main/docs/sources/assets/alloy_icon_orange.svg
 

--- a/operations/helm/charts/alloy/README.md
+++ b/operations/helm/charts/alloy/README.md
@@ -1,6 +1,6 @@
 # Grafana Alloy Helm chart
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 1.12.0](https://img.shields.io/badge/Version-1.12.0-informational?style=flat-square) ![AppVersion: v1.18.0](https://img.shields.io/badge/AppVersion-v1.18.0-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 1.11.0](https://img.shields.io/badge/Version-1.11.0-informational?style=flat-square) ![AppVersion: v1.18.0](https://img.shields.io/badge/AppVersion-v1.18.0-informational?style=flat-square)
 
 Helm chart for deploying [Grafana Alloy][] to Kubernetes.
 

--- a/operations/helm/charts/alloy/README.md
+++ b/operations/helm/charts/alloy/README.md
@@ -1,6 +1,6 @@
 # Grafana Alloy Helm chart
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 1.11.0](https://img.shields.io/badge/Version-1.11.0-informational?style=flat-square) ![AppVersion: v1.18.0](https://img.shields.io/badge/AppVersion-v1.18.0-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 1.12.0](https://img.shields.io/badge/Version-1.12.0-informational?style=flat-square) ![AppVersion: v1.18.0](https://img.shields.io/badge/AppVersion-v1.18.0-informational?style=flat-square)
 
 Helm chart for deploying [Grafana Alloy][] to Kubernetes.
 
@@ -71,7 +71,7 @@ useful if just using the default DaemonSet isn't sufficient.
 | configReloader.image.repository | string | `"prometheus-operator/prometheus-config-reloader"` | Repository to get config reloader image from. |
 | configReloader.image.tag | string | `"v0.91.0@sha256:7d9e4eea5f1139e602508871f422b0116c60e87c662f3dcd234d5ab60cd0d8c1"` | Tag of image to use for config reloading. |
 | configReloader.resources | object | `{"requests":{"cpu":"10m","memory":"50Mi"}}` | Resource requests and limits to apply to the config reloader container. |
-| configReloader.securityContext | object | `{}` | Security context to apply to the Grafana configReloader container. |
+| configReloader.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context to apply to the Grafana configReloader container. |
 | controller.affinity | object | `{}` | Affinity configuration for pods. |
 | controller.autoscaling.enabled | bool | `false` | Creates a HorizontalPodAutoscaler for controller type deployment. Deprecated: Please use controller.autoscaling.horizontal instead |
 | controller.autoscaling.horizontal | object | `{"enabled":false,"externalHPA":false,"maxReplicas":5,"minReplicas":1,"scaleDown":{"policies":[],"selectPolicy":"Max","stabilizationWindowSeconds":300},"scaleUp":{"policies":[],"selectPolicy":"Max","stabilizationWindowSeconds":0},"targetCPUUtilizationPercentage":0,"targetMemoryUtilizationPercentage":80}` | Configures the Horizontal Pod Autoscaler for the controller. |

--- a/operations/helm/charts/alloy/values.yaml
+++ b/operations/helm/charts/alloy/values.yaml
@@ -264,7 +264,17 @@ configReloader:
       cpu: "10m"
       memory: "50Mi"
   # -- Security context to apply to the Grafana configReloader container.
-  securityContext: {}
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+    runAsNonRoot: true
+    runAsUser: 65534
+    runAsGroup: 65534
+    seccompProfile:
+      type: RuntimeDefault
 
 controller:
   # -- Type of controller to use for deploying Grafana Alloy in the cluster.

--- a/operations/helm/tests/additional-serviceaccount-label/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/additional-serviceaccount-label/alloy/templates/controllers/daemonset.yaml
@@ -74,6 +74,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/clustering/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/clustering/alloy/templates/controllers/statefulset.yaml
@@ -79,6 +79,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/configmap-key/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/configmap-key/alloy/templates/controllers/daemonset.yaml
@@ -74,6 +74,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/controller-deployment-pdb-max-unavailable/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/controller-deployment-pdb-max-unavailable/alloy/templates/controllers/deployment.yaml
@@ -75,6 +75,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/controller-deployment-pdb-min-available/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/controller-deployment-pdb-min-available/alloy/templates/controllers/deployment.yaml
@@ -75,6 +75,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/controller-extraLabels-label/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/controller-extraLabels-label/alloy/templates/controllers/daemonset.yaml
@@ -75,6 +75,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/controller-max-revison-history/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/controller-max-revison-history/alloy/templates/controllers/daemonset.yaml
@@ -75,6 +75,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/controller-statefulset-pdb-max-unavailable/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/controller-statefulset-pdb-max-unavailable/alloy/templates/controllers/statefulset.yaml
@@ -77,6 +77,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/controller-statefulset-pdb-min-available/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/controller-statefulset-pdb-min-available/alloy/templates/controllers/statefulset.yaml
@@ -77,6 +77,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/controller-volumes-extra/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/controller-volumes-extra/alloy/templates/controllers/daemonset.yaml
@@ -76,6 +76,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/create-daemonset-hostnetwork/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset-hostnetwork/alloy/templates/controllers/daemonset.yaml
@@ -74,6 +74,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       volumes:

--- a/operations/helm/tests/create-daemonset/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset/alloy/templates/controllers/daemonset.yaml
@@ -74,6 +74,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/create-deployment-autoscaling/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment-autoscaling/alloy/templates/controllers/deployment.yaml
@@ -77,6 +77,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/create-deployment-external-hpa/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment-external-hpa/alloy/templates/controllers/deployment.yaml
@@ -77,6 +77,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/create-deployment/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment/alloy/templates/controllers/deployment.yaml
@@ -75,6 +75,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/create-networkpolicy/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-networkpolicy/alloy/templates/controllers/daemonset.yaml
@@ -74,6 +74,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/create-statefulset-autoscaling/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset-autoscaling/alloy/templates/controllers/statefulset.yaml
@@ -79,6 +79,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/create-statefulset-external-hpa/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset-external-hpa/alloy/templates/controllers/statefulset.yaml
@@ -79,6 +79,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/create-statefulset-vertical-autoscaling/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset-vertical-autoscaling/alloy/templates/controllers/statefulset.yaml
@@ -77,6 +77,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/create-statefulset/alloy/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset/alloy/templates/controllers/statefulset.yaml
@@ -77,6 +77,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/custom-config/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/custom-config/alloy/templates/controllers/daemonset.yaml
@@ -74,6 +74,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/default-values/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/default-values/alloy/templates/controllers/daemonset.yaml
@@ -74,6 +74,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/disable-http-server-port/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/disable-http-server-port/alloy/templates/controllers/daemonset.yaml
@@ -64,6 +64,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/enable-servicemonitor-tls/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/enable-servicemonitor-tls/alloy/templates/controllers/daemonset.yaml
@@ -74,6 +74,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/enable-servicemonitor/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/enable-servicemonitor/alloy/templates/controllers/daemonset.yaml
@@ -74,6 +74,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/engine-flags/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/engine-flags/alloy/templates/controllers/daemonset.yaml
@@ -77,6 +77,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/envFrom/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/envFrom/alloy/templates/controllers/daemonset.yaml
@@ -77,6 +77,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/existing-config/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/existing-config/alloy/templates/controllers/daemonset.yaml
@@ -74,6 +74,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/extra-env/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-env/alloy/templates/controllers/daemonset.yaml
@@ -80,6 +80,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/extra-manifests/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-manifests/alloy/templates/controllers/daemonset.yaml
@@ -74,6 +74,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/extra-ports/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-ports/alloy/templates/controllers/daemonset.yaml
@@ -77,6 +77,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/faro-ingress/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/faro-ingress/alloy/templates/controllers/daemonset.yaml
@@ -77,6 +77,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/global-image-pullpolicy/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/global-image-pullpolicy/alloy/templates/controllers/daemonset.yaml
@@ -74,6 +74,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/global-image-pullsecrets/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/global-image-pullsecrets/alloy/templates/controllers/daemonset.yaml
@@ -79,6 +79,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/global-image-registry/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/global-image-registry/alloy/templates/controllers/daemonset.yaml
@@ -74,6 +74,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/host-alias/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/host-alias/alloy/templates/controllers/daemonset.yaml
@@ -74,6 +74,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/initcontainers/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/initcontainers/alloy/templates/controllers/daemonset.yaml
@@ -94,6 +94,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/lifecycle-hooks/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/lifecycle-hooks/alloy/templates/controllers/deployment.yaml
@@ -82,6 +82,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/livinessprobe/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/livinessprobe/alloy/templates/controllers/daemonset.yaml
@@ -84,6 +84,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/local-image-pullsecrets/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/local-image-pullsecrets/alloy/templates/controllers/daemonset.yaml
@@ -76,6 +76,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/local-image-registry/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/local-image-registry/alloy/templates/controllers/daemonset.yaml
@@ -74,6 +74,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/nodeselectors-and-tolerations/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/nodeselectors-and-tolerations/alloy/templates/controllers/daemonset.yaml
@@ -74,6 +74,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       nodeSelector:
         key1: value1

--- a/operations/helm/tests/nonroot/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/nonroot/alloy/templates/controllers/daemonset.yaml
@@ -79,6 +79,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/pod_annotations/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/pod_annotations/alloy/templates/controllers/daemonset.yaml
@@ -75,6 +75,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/rbac-empty-rules/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/rbac-empty-rules/alloy/templates/controllers/daemonset.yaml
@@ -74,6 +74,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/rbac-rules/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/rbac-rules/alloy/templates/controllers/daemonset.yaml
@@ -74,6 +74,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/readinessprobe/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/readinessprobe/alloy/templates/controllers/daemonset.yaml
@@ -74,6 +74,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/roles-and-rolebindings/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/roles-and-rolebindings/alloy/templates/controllers/daemonset.yaml
@@ -74,6 +74,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/service-external-traffic-policy/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/service-external-traffic-policy/alloy/templates/controllers/daemonset.yaml
@@ -74,6 +74,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config

--- a/operations/helm/tests/sidecars/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/sidecars/alloy/templates/controllers/daemonset.yaml
@@ -76,6 +76,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
         - env:
           - name: GEOIPUPDATE_ACCOUNT_ID
             value: geoipupdate_account_id

--- a/operations/helm/tests/termination-grace-period/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/termination-grace-period/alloy/templates/controllers/deployment.yaml
@@ -75,6 +75,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       terminationGracePeriodSeconds: 20
       volumes:

--- a/operations/helm/tests/topologyspreadconstraints/alloy/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/topologyspreadconstraints/alloy/templates/controllers/deployment.yaml
@@ -75,6 +75,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       topologySpreadConstraints:
         - labelSelector:

--- a/operations/helm/tests/with-digests/alloy/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/with-digests/alloy/templates/controllers/daemonset.yaml
@@ -74,6 +74,17 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       volumes:
         - name: config


### PR DESCRIPTION
### Brief description of Pull Request

Adds fairly standard security hardening to the configmap reloader container, which does not need any of these special privileges.

### Pull Request Details


### Issue(s) fixed by this Pull Request

Will fix or assist with:
* https://github.com/grafana/k8s-monitoring-helm/issues/2900
* https://github.com/grafana/k8s-monitoring-helm/issues/2899
* https://github.com/grafana/k8s-monitoring-helm/issues/2898

### Notes to the Reviewer


### PR Checklist

- [ ] Documentation added
- [X] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
