### PR TITLE
WIP: perf: discovery.Target as stringslice and partial relabeling

### DIFF
--- a/docs/sources/reference/components/discovery/discovery.relabel.md
+++ b/docs/sources/reference/components/discovery/discovery.relabel.md
@@ -91,7 +91,15 @@ In those cases, exported fields retain their last healthy values.
 
 ## Debug metrics
 
-`discovery.relabel` doesn't expose any component-specific debug metrics.
+`discovery.relabel` caches the result of applying its rules to each target, so that targets which don't change between discovery updates don't need to be processed again.
+The cache holds one entry per target it currently receives, and entries are dropped as soon as a target is no longer discovered.
+The cache is emptied when you change the `rule` blocks.
+
+`discovery.relabel` exposes the following metrics:
+
+* `alloy_discovery_relabel_cache_hits_total` (counter): The total number of targets whose relabeling result was reused from the cache.
+* `alloy_discovery_relabel_cache_misses_total` (counter): The total number of targets that had to be relabeled.
+* `alloy_discovery_relabel_cache_size` (gauge): The number of targets currently held in the cache.
 
 ## Example
 

--- a/internal/component/common/relabel/relabel.go
+++ b/internal/component/common/relabel/relabel.go
@@ -129,6 +129,12 @@ func (re Regexp) String() string {
 	return str[5 : len(str)-2]
 }
 
+// Equals compares the source expressions instead of the compiled regexp internals.
+func (re Regexp) Equals(other any) bool {
+	otherRegexp, ok := other.(*Regexp)
+	return ok && otherRegexp != nil && re.String() == otherRegexp.String()
+}
+
 // Config describes a relabelling step to be applied on a target.
 type Config struct {
 	SourceLabels []string `alloy:"source_labels,attr,optional"`

--- a/internal/component/discovery/discovery.go
+++ b/internal/component/discovery/discovery.go
@@ -237,8 +237,12 @@ func toAlloyTargets(cache map[string]*targetgroup.Group) []Target {
 
 	for _, source := range sources {
 		group := cache[source]
+		// Pack the group's shared labels once and let every target in the group
+		// reference them, so they are stored once per group rather than once per
+		// target.
+		groupLabels := newGroupLabels(group.Labels)
 		for _, target := range group.Targets {
-			allTargets = append(allTargets, NewTargetFromSpecificAndBaseLabelSet(target, group.Labels))
+			allTargets = append(allTargets, newTargetFromGroup(groupLabels, target))
 		}
 	}
 	return allTargets

--- a/internal/component/discovery/discovery.go
+++ b/internal/component/discovery/discovery.go
@@ -3,6 +3,7 @@ package discovery
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -228,7 +229,14 @@ func toAlloyTargets(cache map[string]*targetgroup.Group) []Target {
 	}
 	allTargets := make([]Target, 0, targetsCount)
 
-	for _, group := range cache {
+	sources := make([]string, 0, len(cache))
+	for source := range cache {
+		sources = append(sources, source)
+	}
+	sort.Strings(sources)
+
+	for _, source := range sources {
+		group := cache[source]
 		for _, target := range group.Targets {
 			allTargets = append(allTargets, NewTargetFromSpecificAndBaseLabelSet(target, group.Labels))
 		}

--- a/internal/component/discovery/discovery.go
+++ b/internal/component/discovery/discovery.go
@@ -178,9 +178,12 @@ func (c *Component) runDiscovery(ctx context.Context, d DiscovererWithMetrics) {
 		runExited <- struct{}{}
 	}()
 
+	// Reuses the conversion of any target group that has not changed between sends.
+	packer := newGroupPacker()
+
 	// function to convert and send targets in format scraper expects
 	send := func() {
-		allTargets := toAlloyTargets(cache)
+		allTargets := packer.toAlloyTargets(cache)
 		componentID := livedebugging.ComponentID(c.opts.ID)
 		c.debugDataPublisher.PublishIfActive(livedebugging.NewData(
 			componentID,
@@ -222,7 +225,39 @@ func (c *Component) runDiscovery(ctx context.Context, d DiscovererWithMetrics) {
 	}
 }
 
-func toAlloyTargets(cache map[string]*targetgroup.Group) []Target {
+// groupPacker converts Prometheus service discovery target groups into Targets,
+// reusing the result for any source whose target group has not changed.
+//
+// This matters because runDiscovery only replaces the cache entries for sources
+// present in an update, so a component watching many sources keeps the same
+// *targetgroup.Group for all the sources that did not change, yet every send
+// re-converts all of them. Converting a target means sorting and encoding its
+// labels, so for a component with many stable sources that was almost entirely
+// wasted work.
+//
+// Reuse is keyed on the *targetgroup.Group pointer. Discoverers construct a new
+// group whenever its contents change and never mutate a group after sending it,
+// so pointer identity is sufficient to know a previous conversion is still valid.
+type groupPacker struct {
+	packed map[string]packedGroup
+}
+
+type packedGroup struct {
+	// src is the target group this conversion was built from, used to detect
+	// whether the conversion is still valid.
+	src     *targetgroup.Group
+	targets []Target
+}
+
+func newGroupPacker() *groupPacker {
+	return &groupPacker{packed: map[string]packedGroup{}}
+}
+
+// toAlloyTargets converts every group in cache, reusing previous conversions
+// where possible. The returned slice is freshly allocated and owned by the
+// caller; the Target values in it are immutable and may be shared with the
+// result of an earlier call.
+func (p *groupPacker) toAlloyTargets(cache map[string]*targetgroup.Group) []Target {
 	targetsCount := 0
 	for _, group := range cache {
 		targetsCount += len(group.Targets)
@@ -237,15 +272,44 @@ func toAlloyTargets(cache map[string]*targetgroup.Group) []Target {
 
 	for _, source := range sources {
 		group := cache[source]
-		// Pack the group's shared labels once and let every target in the group
-		// reference them, so they are stored once per group rather than once per
-		// target.
-		groupLabels := newGroupLabels(group.Labels)
-		for _, target := range group.Targets {
-			allTargets = append(allTargets, newTargetFromGroup(groupLabels, target))
+		entry, ok := p.packed[source]
+		if !ok || entry.src != group {
+			entry = packedGroup{src: group, targets: packGroup(group)}
+			p.packed[source] = entry
+		}
+		allTargets = append(allTargets, entry.targets...)
+	}
+
+	// Drop conversions for sources that have gone away, so that a component
+	// churning through sources does not grow this map without bound.
+	if len(p.packed) > len(cache) {
+		for source := range p.packed {
+			if _, ok := cache[source]; !ok {
+				delete(p.packed, source)
+			}
 		}
 	}
+
 	return allTargets
+}
+
+// packGroup converts a single target group into Targets.
+func packGroup(group *targetgroup.Group) []Target {
+	// Pack the group's shared labels once and let every target in the group
+	// reference them, so they are stored once per group rather than once per
+	// target.
+	groupLabels := newGroupLabels(group.Labels)
+	targets := make([]Target, 0, len(group.Targets))
+	for _, target := range group.Targets {
+		targets = append(targets, newTargetFromGroup(groupLabels, target))
+	}
+	return targets
+}
+
+// toAlloyTargets converts cache without reusing any previous conversion. Prefer
+// groupPacker in long-running code.
+func toAlloyTargets(cache map[string]*targetgroup.Group) []Target {
+	return newGroupPacker().toAlloyTargets(cache)
 }
 
 func (c *Component) LiveDebugging() {}

--- a/internal/component/discovery/discovery_test.go
+++ b/internal/component/discovery/discovery_test.go
@@ -215,6 +215,30 @@ func assertExportsEqual(t *assert.CollectT, expected []component.Exports, actual
 	}
 }
 
+func TestToAlloyTargetsOrdersGroupsBySource(t *testing.T) {
+	cache := map[string]*targetgroup.Group{
+		"zeta": {
+			Source:  "zeta",
+			Labels:  model.LabelSet{"group": "zeta"},
+			Targets: []model.LabelSet{{"target": "one"}},
+		},
+		"alpha": {
+			Source:  "alpha",
+			Labels:  model.LabelSet{"group": "alpha"},
+			Targets: []model.LabelSet{{"target": "two"}},
+		},
+	}
+
+	expected := []Target{
+		NewTargetFromMap(map[string]string{"group": "alpha", "target": "two"}),
+		NewTargetFromMap(map[string]string{"group": "zeta", "target": "one"}),
+	}
+
+	for range 100 {
+		require.True(t, equality.DeepEqual(expected, toAlloyTargets(cache)))
+	}
+}
+
 /*
 on darwin/arm64/Apple M2:
 Benchmark_ToAlloyTargets-8   	     150	   7549967 ns/op	12768249 B/op	   40433 allocs/op

--- a/internal/component/discovery/internal/labelpack/fuzz_test.go
+++ b/internal/component/discovery/internal/labelpack/fuzz_test.go
@@ -1,0 +1,164 @@
+package labelpack
+
+import (
+	"maps"
+	"slices"
+	"strings"
+	"testing"
+
+	modellabels "github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+)
+
+// decodeFuzzLabels turns fuzzer bytes into a label map. The input is split on a
+// separator byte into alternating names and values, which lets the fuzzer reach
+// duplicate names, empty names and empty values easily.
+func decodeFuzzLabels(data []byte) map[string]string {
+	parts := strings.Split(string(data), "\x00")
+	out := map[string]string{}
+	for i := 0; i+1 < len(parts); i += 2 {
+		out[parts[i]] = parts[i+1]
+	}
+	return out
+}
+
+// referenceNormalize applies the documented construction rules to a label map:
+// drop empty names and empty values.
+func referenceNormalize(m map[string]string) map[string]string {
+	out := make(map[string]string, len(m))
+	for name, value := range m {
+		if name == "" || value == "" {
+			continue
+		}
+		out[name] = value
+	}
+	return out
+}
+
+// FuzzRoundTrip checks that packing a label set and reading it back yields
+// exactly the normalized input, and that Get agrees with Range for every stored
+// name.
+func FuzzRoundTrip(f *testing.F) {
+	f.Add([]byte("a\x001\x00b\x002"))
+	f.Add([]byte("\x001"))
+	f.Add([]byte("a\x00"))
+	f.Add([]byte("a\x001\x00a\x002"))
+	f.Add([]byte(strings.Repeat("x", 300) + "\x00v"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		input := decodeFuzzLabels(data)
+		want := referenceNormalize(input)
+
+		packed, n := FromMap(input)
+
+		require.Equal(t, len(want), n, "reported count")
+		require.Equal(t, len(want), packed.Len(), "Len()")
+		require.Equal(t, len(want) == 0, packed.IsEmpty(), "IsEmpty()")
+
+		got := map[string]string{}
+		prev := ""
+		first := true
+		packed.Range(func(name, value string) bool {
+			if !first {
+				require.Less(t, prev, name, "names must be sorted ascending")
+			}
+			prev, first = name, false
+			got[name] = value
+			return true
+		})
+		require.Equal(t, want, got, "round trip")
+
+		// Every stored label must be findable, with the right value.
+		for name, value := range want {
+			gotValue, ok := packed.Get(name)
+			require.True(t, ok, "Get(%q) must find the label", name)
+			require.Equal(t, value, gotValue, "Get(%q)", name)
+		}
+
+		// Names that were normalized away must not be findable.
+		for name := range input {
+			if _, kept := want[name]; kept {
+				continue
+			}
+			_, ok := packed.Get(name)
+			require.False(t, ok, "Get(%q) must not find a dropped label", name)
+		}
+	})
+}
+
+// FuzzEncodingMatchesPrometheus checks that our packed bytes are identical to
+// the Prometheus stringlabels encoding of the same label set. This is the main
+// safety net for the hand-rolled encoder: if it ever diverges, StableHash-based
+// clustering compatibility would silently break.
+func FuzzEncodingMatchesPrometheus(f *testing.F) {
+	if modellabels.ImplementationName != "stringlabels" {
+		f.Skipf("prometheus labels implementation is %q, not stringlabels", modellabels.ImplementationName)
+	}
+
+	f.Add([]byte("a\x001\x00b\x002"))
+	f.Add([]byte("zed\x00z\x00abc\x00a"))
+	f.Add([]byte(strings.Repeat("x", 254) + "\x00v"))
+	f.Add([]byte(strings.Repeat("x", 255) + "\x00v"))
+	f.Add([]byte(strings.Repeat("x", 256) + "\x00v"))
+	f.Add([]byte("n\x00" + strings.Repeat("v", 300)))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		want := referenceNormalize(decodeFuzzLabels(data))
+
+		ours, _ := FromMap(want)
+
+		promPairs := make([]modellabels.Label, 0, len(want))
+		for _, name := range slices.Sorted(maps.Keys(want)) {
+			promPairs = append(promPairs, modellabels.Label{Name: name, Value: want[name]})
+		}
+		theirs := modellabels.New(promPairs...)
+
+		require.Equal(t, string(theirs.Bytes(nil)), string(ours), "encoding must match prometheus stringlabels")
+
+		// Get must agree with Prometheus for every name, including absent ones.
+		for name := range want {
+			gotValue, ok := ours.Get(name)
+			require.True(t, ok)
+			require.Equal(t, theirs.Get(name), gotValue, "Get(%q)", name)
+		}
+	})
+}
+
+// FuzzMerge checks the two-way merge against a naive map-based reference, where
+// own shadows group.
+func FuzzMerge(f *testing.F) {
+	f.Add([]byte("a\x001\x00b\x002"), []byte("a\x00override"))
+	f.Add([]byte("b\x00gb\x00d\x00gd"), []byte("a\x00oa\x00c\x00oc\x00e\x00oe"))
+	f.Add([]byte(""), []byte("a\x001"))
+	f.Add([]byte("a\x001"), []byte(""))
+
+	f.Fuzz(func(t *testing.T, groupData, ownData []byte) {
+		groupMap := referenceNormalize(decodeFuzzLabels(groupData))
+		ownMap := referenceNormalize(decodeFuzzLabels(ownData))
+
+		// Reference: union with own winning.
+		want := make(map[string]string, len(groupMap)+len(ownMap))
+		maps.Copy(want, groupMap)
+		maps.Copy(want, ownMap)
+
+		group, _ := FromMap(groupMap)
+		own, _ := FromMap(ownMap)
+
+		got := map[string]string{}
+		prev := ""
+		first := true
+		finished := RangeMerged(group, own, func(name, value string) bool {
+			if !first {
+				require.Less(t, prev, name, "merged names must be sorted ascending")
+			}
+			prev, first = name, false
+			_, dup := got[name]
+			require.False(t, dup, "label %q yielded twice", name)
+			got[name] = value
+			return true
+		})
+		require.True(t, finished)
+		require.Equal(t, want, got, "RangeMerged")
+		require.Equal(t, len(want), MergedLen(group, own), "MergedLen")
+	})
+}

--- a/internal/component/discovery/internal/labelpack/labelpack.go
+++ b/internal/component/discovery/internal/labelpack/labelpack.go
@@ -1,0 +1,286 @@
+// Package labelpack provides a compact, immutable representation of a set of
+// label name/value pairs packed into a single Go string.
+//
+// The encoding is byte-identical to the "stringlabels" implementation in
+// github.com/prometheus/prometheus/model/labels: each name and each value is
+// preceded by its length, encoded as a single byte for lengths 0-254, or as the
+// byte 255 followed by 3 bytes little-endian for longer strings. The maximum
+// encodable length is 1<<24 (16MiB); attempting to encode anything longer
+// panics, matching Prometheus' behaviour.
+//
+// A valid packed buffer always satisfies these invariants:
+//
+//  1. Label names are sorted in ascending byte order.
+//  2. Label names are unique.
+//  3. No label has an empty value. An empty value is indistinguishable from an
+//     absent label, so such labels are dropped at construction time.
+//  4. No label has an empty name. An empty name is not a valid label name, and
+//     Get cannot report one as present, so such labels are dropped at
+//     construction time.
+//
+// Callers must only construct Labels through the functions in this package, as
+// the accessors rely on the invariants above and will panic or misbehave on
+// malformed data.
+package labelpack
+
+import (
+	"slices"
+	"strings"
+	"unsafe"
+
+	commonlabels "github.com/prometheus/common/model"
+)
+
+// maxLabelLen is the longest name or value that can be encoded. It matches the
+// limit of the Prometheus stringlabels encoding, where lengths of 255 or more
+// are stored in 3 bytes little-endian.
+const maxLabelLen = 1 << 24
+
+// smallSetSize is the number of pairs we can sort on the stack without
+// allocating. Real targets are almost always below this.
+const smallSetSize = 32
+
+// Labels is an immutable, name-sorted set of label pairs packed into a single
+// string. The zero value is a valid, empty set.
+type Labels string
+
+// Pair is a single label name/value pair, used when building Labels.
+type Pair struct {
+	Name  string
+	Value string
+}
+
+// Empty is the empty set of labels.
+const Empty Labels = ""
+
+// FromPairs builds Labels from pairs. It sorts p in place, drops pairs with an
+// empty name or an empty value, and de-duplicates by name keeping the last
+// occurrence of each name. It returns the packed labels and the number of labels
+// retained.
+func FromPairs(p []Pair) (Labels, int) {
+	if len(p) == 0 {
+		return Empty, 0
+	}
+
+	// Stable sort so that "keep the last occurrence" is well defined for
+	// duplicate names.
+	slices.SortStableFunc(p, func(a, b Pair) int { return strings.Compare(a.Name, b.Name) })
+
+	// Compact in place: for runs of equal names keep only the last entry, then
+	// drop anything with an empty name or an empty value.
+	out := p[:0]
+	for i := 0; i < len(p); {
+		j := i + 1
+		for j < len(p) && p[j].Name == p[i].Name {
+			j++
+		}
+		// p[j-1] is the last pair with this name.
+		if last := p[j-1]; last.Name != "" && last.Value != "" {
+			out = append(out, last)
+		}
+		i = j
+	}
+	p = out
+
+	if len(p) == 0 {
+		return Empty, 0
+	}
+
+	size := 0
+	for i := range p {
+		size += pairSize(p[i].Name) + pairSize(p[i].Value)
+	}
+
+	buf := make([]byte, 0, size)
+	for i := range p {
+		buf = appendString(buf, p[i].Name)
+		buf = appendString(buf, p[i].Value)
+	}
+	return Labels(yoloString(buf)), len(p)
+}
+
+// yoloString converts buf to a string without copying it. This is the same trick
+// prometheus/model/labels uses, and it is safe here because buf was allocated in
+// this package and is never written to again after the conversion. Using a
+// regular []byte to string conversion would double the allocations of every
+// label set built.
+func yoloString(buf []byte) string {
+	return unsafe.String(unsafe.SliceData(buf), len(buf))
+}
+
+// FromLabelSet builds Labels from a commonlabels.LabelSet. Labels with an empty
+// value are dropped. It returns the packed labels and the number of labels
+// retained.
+func FromLabelSet(ls commonlabels.LabelSet) (Labels, int) {
+	if len(ls) == 0 {
+		return Empty, 0
+	}
+
+	var stack [smallSetSize]Pair
+	var pairs []Pair
+	if len(ls) <= len(stack) {
+		pairs = stack[:0]
+	} else {
+		pairs = make([]Pair, 0, len(ls))
+	}
+	for name, value := range ls {
+		if name == "" || value == "" {
+			continue
+		}
+		pairs = append(pairs, Pair{Name: string(name), Value: string(value)})
+	}
+	return FromPairs(pairs)
+}
+
+// FromMap builds Labels from a map of strings. Labels with an empty value are
+// dropped. It returns the packed labels and the number of labels retained.
+func FromMap(m map[string]string) (Labels, int) {
+	if len(m) == 0 {
+		return Empty, 0
+	}
+
+	var stack [smallSetSize]Pair
+	var pairs []Pair
+	if len(m) <= len(stack) {
+		pairs = stack[:0]
+	} else {
+		pairs = make([]Pair, 0, len(m))
+	}
+	for name, value := range m {
+		if name == "" || value == "" {
+			continue
+		}
+		pairs = append(pairs, Pair{Name: name, Value: value})
+	}
+	return FromPairs(pairs)
+}
+
+// IsEmpty reports whether l holds no labels.
+func (l Labels) IsEmpty() bool { return len(l) == 0 }
+
+// Get returns the value of the label with the given name, and whether it was
+// present. Because names are stored in sorted order, the scan stops early once
+// it passes the position where name would be.
+func (l Labels) Get(name string) (string, bool) {
+	if name == "" {
+		// An empty name can never be stored, and indexing name[0] below would
+		// panic.
+		return "", false
+	}
+	data := string(l)
+	for i := 0; i < len(data); {
+		var size int
+		size, i = decodeSize(data, i)
+		// Compare the first byte before slicing, to skip non-matching names as
+		// cheaply as possible.
+		switch {
+		case data[i] == name[0]:
+			lName := data[i : i+size]
+			i += size
+			if lName == name {
+				value, _ := decodeString(data, i)
+				return value, true
+			}
+			if lName > name {
+				// Names are sorted, so name cannot appear later.
+				return "", false
+			}
+		case data[i] > name[0]:
+			// Names are sorted, so name cannot appear later.
+			return "", false
+		default:
+			i += size
+		}
+		// Skip over the value.
+		size, i = decodeSize(data, i)
+		i += size
+	}
+	return "", false
+}
+
+// Has reports whether a label with the given name is present.
+func (l Labels) Has(name string) bool {
+	_, ok := l.Get(name)
+	return ok
+}
+
+// Len returns the number of labels. It requires a full scan of the buffer, so
+// callers on a hot path should cache the count returned at construction time.
+func (l Labels) Len() int {
+	count := 0
+	data := string(l)
+	for i := 0; i < len(data); {
+		var size int
+		size, i = decodeSize(data, i)
+		i += size
+		size, i = decodeSize(data, i)
+		i += size
+		count++
+	}
+	return count
+}
+
+// Range calls f for each label in ascending name order. If f returns false the
+// iteration stops and Range returns false; otherwise Range returns true once
+// every label has been visited.
+func (l Labels) Range(f func(name, value string) bool) bool {
+	data := string(l)
+	for i := 0; i < len(data); {
+		var name, value string
+		name, i = decodeString(data, i)
+		value, i = decodeString(data, i)
+		if !f(name, value) {
+			return false
+		}
+	}
+	return true
+}
+
+// pairSize returns the number of bytes needed to encode s with its length
+// prefix. It panics if s is too long to encode.
+func pairSize(s string) int {
+	switch n := len(s); {
+	case n < 255:
+		return 1 + n
+	case n <= maxLabelLen:
+		return 4 + n
+	default:
+		panic("labelpack: label too long to encode")
+	}
+}
+
+// appendString appends s to buf, prefixed by its length.
+func appendString(buf []byte, s string) []byte {
+	if n := len(s); n < 255 {
+		buf = append(buf, uint8(n))
+	} else if n <= maxLabelLen {
+		buf = append(buf, 255, byte(n), byte(n>>8), byte(n>>16))
+	} else {
+		panic("labelpack: label too long to encode")
+	}
+	return append(buf, s...)
+}
+
+// decodeSize reads a length prefix at index and returns it along with the index
+// of the first byte after the prefix.
+func decodeSize(data string, index int) (int, int) {
+	b := data[index]
+	index++
+	if b == 255 {
+		// Larger numbers are encoded as 3 bytes little-endian. Indexing past the
+		// end panics, which is the intended behaviour: all Labels are built
+		// inside this package, so malformed data indicates a bug or memory
+		// corruption.
+		return int(data[index]) + (int(data[index+1]) << 8) + (int(data[index+2]) << 16), index + 3
+	}
+	return int(b), index
+}
+
+// decodeString reads a length-prefixed string at index and returns it along
+// with the index of the first byte after it. The returned string shares memory
+// with data, which is safe because Labels is immutable.
+func decodeString(data string, index int) (string, int) {
+	var size int
+	size, index = decodeSize(data, index)
+	return data[index : index+size], index + size
+}

--- a/internal/component/discovery/internal/labelpack/labelpack_test.go
+++ b/internal/component/discovery/internal/labelpack/labelpack_test.go
@@ -1,0 +1,291 @@
+package labelpack
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+	"testing"
+
+	commonlabels "github.com/prometheus/common/model"
+	modellabels "github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// collect returns all labels of l as a map, and asserts that Range yielded them
+// in ascending name order.
+func collect(t *testing.T, l Labels) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	prev := ""
+	first := true
+	l.Range(func(name, value string) bool {
+		if !first {
+			assert.Less(t, prev, name, "labels must be yielded in ascending name order")
+		}
+		prev, first = name, false
+		_, dup := out[name]
+		assert.False(t, dup, "label %q yielded twice", name)
+		out[name] = value
+		return true
+	})
+	return out
+}
+
+func TestFromMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]string
+		expected map[string]string
+	}{
+		{
+			name:     "nil",
+			input:    nil,
+			expected: map[string]string{},
+		},
+		{
+			name:     "empty",
+			input:    map[string]string{},
+			expected: map[string]string{},
+		},
+		{
+			name:     "single",
+			input:    map[string]string{"a": "1"},
+			expected: map[string]string{"a": "1"},
+		},
+		{
+			name:     "many, unsorted input",
+			input:    map[string]string{"zed": "z", "abc": "a", "mno": "m", "b": "bb"},
+			expected: map[string]string{"abc": "a", "b": "bb", "mno": "m", "zed": "z"},
+		},
+		{
+			name:     "empty values dropped",
+			input:    map[string]string{"a": "1", "b": "", "c": "3"},
+			expected: map[string]string{"a": "1", "c": "3"},
+		},
+		{
+			name:     "all values empty",
+			input:    map[string]string{"a": "", "b": ""},
+			expected: map[string]string{},
+		},
+		{
+			// An empty name is not a valid label name, and Get can never report
+			// one as present, so it is dropped rather than stored unreachably.
+			name:     "empty name dropped",
+			input:    map[string]string{"": "1", "a": "2"},
+			expected: map[string]string{"a": "2"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			l, n := FromMap(tc.input)
+			require.Equal(t, len(tc.expected), n, "reported count")
+			require.Equal(t, len(tc.expected), l.Len(), "Len()")
+			require.Equal(t, tc.expected, collect(t, l))
+			require.Equal(t, len(tc.expected) == 0, l.IsEmpty())
+
+			for name, want := range tc.expected {
+				got, ok := l.Get(name)
+				require.True(t, ok, "Get(%q) should find the label", name)
+				require.Equal(t, want, got, "Get(%q)", name)
+				require.True(t, l.Has(name))
+			}
+		})
+	}
+}
+
+func TestFromLabelSetMatchesFromMap(t *testing.T) {
+	m := map[string]string{"zed": "z", "abc": "a", "mno": "", "b": "bb"}
+	ls := commonlabels.LabelSet{}
+	for k, v := range m {
+		ls[commonlabels.LabelName(k)] = commonlabels.LabelValue(v)
+	}
+
+	fromMap, nMap := FromMap(m)
+	fromLabelSet, nLabelSet := FromLabelSet(ls)
+
+	require.Equal(t, nMap, nLabelSet)
+	require.Equal(t, fromMap, fromLabelSet, "both constructors must produce identical bytes")
+}
+
+func TestFromPairsDeduplicatesKeepingLast(t *testing.T) {
+	l, n := FromPairs([]Pair{
+		{Name: "a", Value: "first"},
+		{Name: "b", Value: "b"},
+		{Name: "a", Value: "second"},
+		{Name: "a", Value: "third"},
+	})
+	require.Equal(t, 2, n)
+	require.Equal(t, map[string]string{"a": "third", "b": "b"}, collect(t, l))
+}
+
+func TestFromPairsDeduplicateThenDropEmpty(t *testing.T) {
+	// The last occurrence wins, and if that last occurrence is empty the label is
+	// dropped entirely rather than falling back to an earlier value.
+	l, n := FromPairs([]Pair{
+		{Name: "a", Value: "first"},
+		{Name: "a", Value: ""},
+	})
+	require.Equal(t, 0, n)
+	require.True(t, l.IsEmpty())
+	_, ok := l.Get("a")
+	require.False(t, ok)
+}
+
+func TestGetMissing(t *testing.T) {
+	l, _ := FromMap(map[string]string{"bbb": "1", "ddd": "2", "fff": "3"})
+
+	// Includes names that sort before, between and after the stored ones, plus
+	// names sharing a first byte with a stored name, to cover every early-exit
+	// branch in Get.
+	for _, name := range []string{"", "a", "aaa", "b", "bb", "bbbb", "bbz", "ccc", "d", "ddz", "eee", "fffz", "g", "zzz"} {
+		t.Run(fmt.Sprintf("name=%q", name), func(t *testing.T) {
+			value, ok := l.Get(name)
+			require.False(t, ok, "Get(%q) should not find a label", name)
+			require.Empty(t, value)
+			require.False(t, l.Has(name))
+		})
+	}
+}
+
+func TestGetEmptyLabels(t *testing.T) {
+	value, ok := Empty.Get("anything")
+	require.False(t, ok)
+	require.Empty(t, value)
+	require.Equal(t, 0, Empty.Len())
+	require.True(t, Empty.IsEmpty())
+	require.True(t, Empty.Range(func(string, string) bool { return true }))
+}
+
+// TestVarintBoundary covers the length encoding switchover: lengths 0-254 use a
+// single byte, 255 and above use a 255 marker plus 3 bytes little-endian.
+func TestVarintBoundary(t *testing.T) {
+	for _, size := range []int{0, 1, 2, 253, 254, 255, 256, 257, 1000, 70000} {
+		t.Run(fmt.Sprintf("size=%d", size), func(t *testing.T) {
+			long := strings.Repeat("x", size)
+
+			// A long value, with a short name.
+			if size > 0 {
+				l, n := FromPairs([]Pair{{Name: "name", Value: long}})
+				require.Equal(t, 1, n)
+				got, ok := l.Get("name")
+				require.True(t, ok)
+				require.Equal(t, long, got)
+				require.Equal(t, 1, l.Len())
+			}
+
+			// A long name, with a short value. Prefixed so the name is never
+			// empty, which would collide with the "no labels" case.
+			l, n := FromPairs([]Pair{{Name: "n" + long, Value: "value"}})
+			require.Equal(t, 1, n)
+			got, ok := l.Get("n" + long)
+			require.True(t, ok)
+			require.Equal(t, "value", got)
+			require.Equal(t, 1, l.Len())
+		})
+	}
+}
+
+func TestEncodingMatchesPrometheus(t *testing.T) {
+	// Our encoding must be byte-identical to the Prometheus stringlabels
+	// encoding. Labels.Bytes exposes the raw buffer, so we can compare directly.
+	// This test is meaningful only when Prometheus is built with the stringlabels
+	// implementation, which is the default.
+	if modellabels.ImplementationName != "stringlabels" {
+		t.Skipf("prometheus labels implementation is %q, not stringlabels", modellabels.ImplementationName)
+	}
+
+	tests := []map[string]string{
+		{},
+		{"a": "1"},
+		{"zed": "z", "abc": "a", "mno": "m", "b": "bb"},
+		{"name": strings.Repeat("x", 254)},
+		{"name": strings.Repeat("x", 255)},
+		{"name": strings.Repeat("x", 256)},
+		{strings.Repeat("n", 300): "value"},
+	}
+
+	for i, m := range tests {
+		t.Run(fmt.Sprintf("case=%d", i), func(t *testing.T) {
+			ours, _ := FromMap(m)
+
+			promPairs := make([]modellabels.Label, 0, len(m))
+			for _, name := range slices.Sorted(maps.Keys(m)) {
+				promPairs = append(promPairs, modellabels.Label{Name: name, Value: m[name]})
+			}
+			theirs := modellabels.New(promPairs...)
+
+			require.Equal(t, string(theirs.Bytes(nil)), string(ours))
+		})
+	}
+}
+
+func TestTooLongPanics(t *testing.T) {
+	// Build a string longer than the 16MiB encoding limit. Constructed lazily so
+	// the allocation only happens in this test.
+	tooLong := strings.Repeat("x", maxLabelLen+1)
+
+	require.PanicsWithValue(t, "labelpack: label too long to encode", func() {
+		FromPairs([]Pair{{Name: "name", Value: tooLong}})
+	})
+	require.PanicsWithValue(t, "labelpack: label too long to encode", func() {
+		FromPairs([]Pair{{Name: tooLong, Value: "value"}})
+	})
+}
+
+func TestRangeEarlyExit(t *testing.T) {
+	l, _ := FromMap(map[string]string{"a": "1", "b": "2", "c": "3"})
+
+	var seen []string
+	finished := l.Range(func(name, value string) bool {
+		seen = append(seen, name)
+		return name != "b"
+	})
+	require.False(t, finished, "Range must report that iteration was interrupted")
+	require.Equal(t, []string{"a", "b"}, seen)
+
+	finished = l.Range(func(name, value string) bool { return true })
+	require.True(t, finished)
+}
+
+func TestIter(t *testing.T) {
+	l, _ := FromMap(map[string]string{"b": "2", "a": "1"})
+	it := l.Iter()
+
+	name, value, ok := it.Next()
+	require.True(t, ok)
+	require.Equal(t, "a", name)
+	require.Equal(t, "1", value)
+
+	name, value, ok = it.Next()
+	require.True(t, ok)
+	require.Equal(t, "b", name)
+	require.Equal(t, "2", value)
+
+	_, _, ok = it.Next()
+	require.False(t, ok)
+
+	// Exhausted iterators keep reporting false.
+	_, _, ok = it.Next()
+	require.False(t, ok)
+}
+
+// smallSetSize is the stack-slice threshold in FromMap and FromLabelSet. Cross
+// it to make sure both the stack and heap paths behave identically.
+func TestLargeLabelSetCrossesStackThreshold(t *testing.T) {
+	for _, count := range []int{smallSetSize - 1, smallSetSize, smallSetSize + 1, smallSetSize * 4} {
+		t.Run(fmt.Sprintf("count=%d", count), func(t *testing.T) {
+			m := map[string]string{}
+			for i := 0; i < count; i++ {
+				m[fmt.Sprintf("label_%04d", i)] = fmt.Sprintf("value_%d", i)
+			}
+
+			l, n := FromMap(m)
+			require.Equal(t, count, n)
+			require.Equal(t, count, l.Len())
+			require.Equal(t, m, collect(t, l))
+		})
+	}
+}

--- a/internal/component/discovery/internal/labelpack/merge.go
+++ b/internal/component/discovery/internal/labelpack/merge.go
@@ -1,0 +1,175 @@
+package labelpack
+
+// Iter is a forward cursor over a packed Labels buffer. The zero value iterates
+// an empty set. Iter must be used by pointer.
+type Iter struct {
+	data string
+	i    int
+}
+
+// Iter returns a cursor over l, yielding labels in ascending name order.
+func (l Labels) Iter() Iter {
+	return Iter{data: string(l)}
+}
+
+// Next returns the next label and true, or zero values and false once the
+// iterator is exhausted.
+func (it *Iter) Next() (name, value string, ok bool) {
+	if it.i >= len(it.data) {
+		return "", "", false
+	}
+	name, it.i = decodeString(it.data, it.i)
+	value, it.i = decodeString(it.data, it.i)
+	return name, value, true
+}
+
+// MergeIter iterates the union of two packed label sets in ascending name
+// order. A label present in own shadows the label of the same name in group.
+// MergeIter must be used by pointer.
+type MergeIter struct {
+	group Iter
+	own   Iter
+
+	groupName  string
+	groupValue string
+	groupOK    bool
+
+	ownName  string
+	ownValue string
+	ownOK    bool
+}
+
+// Merge returns an iterator over the union of group and own, in ascending name
+// order, where own shadows group for labels present in both.
+func Merge(group, own Labels) MergeIter {
+	m := MergeIter{group: group.Iter(), own: own.Iter()}
+	m.groupName, m.groupValue, m.groupOK = m.group.Next()
+	m.ownName, m.ownValue, m.ownOK = m.own.Next()
+	return m
+}
+
+// Next returns the next label of the merged set and true, or zero values and
+// false once the iterator is exhausted.
+func (m *MergeIter) Next() (name, value string, ok bool) {
+	switch {
+	case m.groupOK && m.ownOK:
+		switch {
+		case m.groupName < m.ownName:
+			name, value = m.groupName, m.groupValue
+			m.groupName, m.groupValue, m.groupOK = m.group.Next()
+		case m.ownName < m.groupName:
+			name, value = m.ownName, m.ownValue
+			m.ownName, m.ownValue, m.ownOK = m.own.Next()
+		default:
+			// Same name in both: own wins, and the group entry is consumed too.
+			name, value = m.ownName, m.ownValue
+			m.groupName, m.groupValue, m.groupOK = m.group.Next()
+			m.ownName, m.ownValue, m.ownOK = m.own.Next()
+		}
+		return name, value, true
+	case m.groupOK:
+		name, value = m.groupName, m.groupValue
+		m.groupName, m.groupValue, m.groupOK = m.group.Next()
+		return name, value, true
+	case m.ownOK:
+		name, value = m.ownName, m.ownValue
+		m.ownName, m.ownValue, m.ownOK = m.own.Next()
+		return name, value, true
+	default:
+		return "", "", false
+	}
+}
+
+// RangeMerged calls f for each label of the union of group and own, in ascending
+// name order, where own shadows group. If f returns false the iteration stops
+// and RangeMerged returns false; otherwise it returns true once every label has
+// been visited.
+func RangeMerged(group, own Labels, f func(name, value string) bool) bool {
+	// Fast paths avoid the merge bookkeeping when one side is empty, which is
+	// common: targets with no group labels, or group labels with no overrides.
+	switch {
+	case group.IsEmpty():
+		return own.Range(f)
+	case own.IsEmpty():
+		return group.Range(f)
+	}
+
+	it := Merge(group, own)
+	for {
+		name, value, ok := it.Next()
+		if !ok {
+			return true
+		}
+		if !f(name, value) {
+			return false
+		}
+	}
+}
+
+// EqualMerged reports whether the union of aGroup and aOwn holds exactly the same
+// labels as the union of bGroup and bOwn. It walks both merged views in lockstep,
+// so it is linear in the total number of labels and allocates nothing.
+func EqualMerged(aGroup, aOwn, bGroup, bOwn Labels) bool {
+	// Identical buffers on both sides mean identical merged views, without
+	// needing to decode anything.
+	if aGroup == bGroup && aOwn == bOwn {
+		return true
+	}
+
+	a := Merge(aGroup, aOwn)
+	b := Merge(bGroup, bOwn)
+	for {
+		aName, aValue, aOK := a.Next()
+		bName, bValue, bOK := b.Next()
+		if !aOK || !bOK {
+			// Equal only if both ran out at the same point.
+			return aOK == bOK
+		}
+		if aName != bName || aValue != bValue {
+			return false
+		}
+	}
+}
+
+// Overlaps reports whether a and b share at least one label name. It scans both
+// buffers once and allocates nothing.
+func Overlaps(a, b Labels) bool {
+	if a.IsEmpty() || b.IsEmpty() {
+		return false
+	}
+
+	aIter, bIter := a.Iter(), b.Iter()
+	aName, _, aOK := aIter.Next()
+	bName, _, bOK := bIter.Next()
+	for aOK && bOK {
+		switch {
+		case aName < bName:
+			aName, _, aOK = aIter.Next()
+		case bName < aName:
+			bName, _, bOK = bIter.Next()
+		default:
+			return true
+		}
+	}
+	return false
+}
+
+// MergedLen returns the number of labels in the union of group and own, counting
+// a name present in both only once. It requires a full scan of both buffers.
+func MergedLen(group, own Labels) int {
+	switch {
+	case group.IsEmpty():
+		return own.Len()
+	case own.IsEmpty():
+		return group.Len()
+	}
+
+	count := 0
+	it := Merge(group, own)
+	for {
+		if _, _, ok := it.Next(); !ok {
+			return count
+		}
+		count++
+	}
+}

--- a/internal/component/discovery/internal/labelpack/merge_test.go
+++ b/internal/component/discovery/internal/labelpack/merge_test.go
@@ -1,0 +1,164 @@
+package labelpack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// mergeToMap drains a MergeIter into a map, asserting ascending name order and
+// that no name is yielded twice.
+func mergeToMap(t *testing.T, group, own Labels) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	it := Merge(group, own)
+	prev := ""
+	first := true
+	for {
+		name, value, ok := it.Next()
+		if !ok {
+			return out
+		}
+		if !first {
+			require.Less(t, prev, name, "merged labels must be yielded in ascending name order")
+		}
+		prev, first = name, false
+		_, dup := out[name]
+		require.False(t, dup, "label %q yielded twice", name)
+		out[name] = value
+	}
+}
+
+func TestMerge(t *testing.T) {
+	tests := []struct {
+		name     string
+		group    map[string]string
+		own      map[string]string
+		expected map[string]string
+	}{
+		{
+			name:     "both empty",
+			expected: map[string]string{},
+		},
+		{
+			name:     "only group",
+			group:    map[string]string{"a": "1", "b": "2"},
+			expected: map[string]string{"a": "1", "b": "2"},
+		},
+		{
+			name:     "only own",
+			own:      map[string]string{"a": "1", "b": "2"},
+			expected: map[string]string{"a": "1", "b": "2"},
+		},
+		{
+			name:     "disjoint, interleaved",
+			group:    map[string]string{"b": "gb", "d": "gd"},
+			own:      map[string]string{"a": "oa", "c": "oc", "e": "oe"},
+			expected: map[string]string{"a": "oa", "b": "gb", "c": "oc", "d": "gd", "e": "oe"},
+		},
+		{
+			name:     "own shadows group",
+			group:    map[string]string{"a": "group", "b": "gb"},
+			own:      map[string]string{"a": "own"},
+			expected: map[string]string{"a": "own", "b": "gb"},
+		},
+		{
+			name:     "own shadows every group label",
+			group:    map[string]string{"a": "ga", "b": "gb"},
+			own:      map[string]string{"a": "oa", "b": "ob"},
+			expected: map[string]string{"a": "oa", "b": "ob"},
+		},
+		{
+			name:     "group entirely before own",
+			group:    map[string]string{"a": "ga", "b": "gb"},
+			own:      map[string]string{"y": "oy", "z": "oz"},
+			expected: map[string]string{"a": "ga", "b": "gb", "y": "oy", "z": "oz"},
+		},
+		{
+			name:     "own entirely before group",
+			group:    map[string]string{"y": "gy", "z": "gz"},
+			own:      map[string]string{"a": "oa", "b": "ob"},
+			expected: map[string]string{"a": "oa", "b": "ob", "y": "gy", "z": "gz"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			group, _ := FromMap(tc.group)
+			own, _ := FromMap(tc.own)
+
+			require.Equal(t, tc.expected, mergeToMap(t, group, own), "Merge")
+			require.Equal(t, len(tc.expected), MergedLen(group, own), "MergedLen")
+
+			// RangeMerged has fast paths for an empty side; it must agree with the
+			// general merge either way.
+			viaRange := map[string]string{}
+			finished := RangeMerged(group, own, func(name, value string) bool {
+				viaRange[name] = value
+				return true
+			})
+			require.True(t, finished)
+			require.Equal(t, tc.expected, viaRange, "RangeMerged")
+		})
+	}
+}
+
+func TestRangeMergedEarlyExit(t *testing.T) {
+	group, _ := FromMap(map[string]string{"b": "gb", "d": "gd"})
+	own, _ := FromMap(map[string]string{"a": "oa", "c": "oc"})
+
+	var seen []string
+	finished := RangeMerged(group, own, func(name, value string) bool {
+		seen = append(seen, name)
+		return name != "b"
+	})
+	require.False(t, finished, "RangeMerged must report that iteration was interrupted")
+	require.Equal(t, []string{"a", "b"}, seen)
+}
+
+func TestRangeMergedEarlyExitSingleSided(t *testing.T) {
+	// Exercise the empty-side fast paths, which delegate to Labels.Range.
+	labels, _ := FromMap(map[string]string{"a": "1", "b": "2", "c": "3"})
+
+	for _, tc := range []struct {
+		name       string
+		group, own Labels
+	}{
+		{name: "empty group", group: Empty, own: labels},
+		{name: "empty own", group: labels, own: Empty},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var seen []string
+			finished := RangeMerged(tc.group, tc.own, func(name, value string) bool {
+				seen = append(seen, name)
+				return name != "a"
+			})
+			require.False(t, finished)
+			require.Equal(t, []string{"a"}, seen)
+		})
+	}
+}
+
+func TestMergedLenLargeSets(t *testing.T) {
+	// Overlapping ranges so that shadowed labels are counted once.
+	groupMap := map[string]string{}
+	ownMap := map[string]string{}
+	for i := 0; i < 100; i++ {
+		groupMap[fmt.Sprintf("label_%04d", i)] = "group"
+	}
+	for i := 50; i < 200; i++ {
+		ownMap[fmt.Sprintf("label_%04d", i)] = "own"
+	}
+
+	group, _ := FromMap(groupMap)
+	own, _ := FromMap(ownMap)
+
+	require.Equal(t, 200, MergedLen(group, own))
+
+	merged := mergeToMap(t, group, own)
+	require.Len(t, merged, 200)
+	require.Equal(t, "group", merged["label_0000"])
+	require.Equal(t, "own", merged["label_0050"], "own must shadow group")
+	require.Equal(t, "own", merged["label_0199"])
+}

--- a/internal/component/discovery/relabel/cache.go
+++ b/internal/component/discovery/relabel/cache.go
@@ -1,0 +1,193 @@
+package relabel
+
+import (
+	"slices"
+	"strings"
+
+	alloy_relabel "github.com/grafana/alloy/internal/component/common/relabel"
+	"github.com/grafana/alloy/internal/component/discovery"
+)
+
+// rebuildMinSize is the smallest cache the collapse check considers. Below this
+// the memory a Go map keeps in its buckets after deletions is not worth the cost
+// of copying every live entry into a fresh map.
+const rebuildMinSize = 10_000
+
+// ruleSnapshot is a comparable copy of the parts of a relabel rule that affect
+// its outcome, used to decide whether cached results are still valid.
+//
+// The rules cannot be compared directly: alloy_relabel.Config holds a compiled
+// *regexp.Regexp, so it is not comparable with ==, and the Config values are
+// reachable from the component's arguments rather than owned by the component.
+// Snapshotting the source form makes the comparison exact and independent of the
+// caller.
+type ruleSnapshot struct {
+	// sourceLabels is joined with a byte that cannot appear in a label name, so
+	// that the snapshot stays comparable while still distinguishing
+	// ["a", "b"] from ["a\xffb"].
+	sourceLabels string
+	separator    string
+	regex        string
+	modulus      uint64
+	targetLabel  string
+	replacement  string
+	action       alloy_relabel.Action
+}
+
+const sourceLabelSep = "\xff"
+
+func snapshotRules(cfgs []*alloy_relabel.Config) []ruleSnapshot {
+	if len(cfgs) == 0 {
+		return nil
+	}
+	out := make([]ruleSnapshot, 0, len(cfgs))
+	for _, cfg := range cfgs {
+		if cfg == nil {
+			out = append(out, ruleSnapshot{})
+			continue
+		}
+		out = append(out, ruleSnapshot{
+			sourceLabels: strings.Join(cfg.SourceLabels, sourceLabelSep),
+			separator:    cfg.Separator,
+			regex:        cfg.Regex.String(),
+			modulus:      cfg.Modulus,
+			targetLabel:  cfg.TargetLabel,
+			replacement:  cfg.Replacement,
+			action:       cfg.Action,
+		})
+	}
+	return out
+}
+
+// cacheEntry is the memoised outcome of relabeling one target. Targets dropped by
+// the rules are cached too, with keep false, because deciding to drop a target is
+// often the most expensive part of a rule set.
+type cacheEntry struct {
+	output discovery.Target
+	keep   bool
+
+	// generation is the last update in which this entry was used. Entries not used
+	// in the current update refer to targets that have gone away.
+	generation uint64
+}
+
+// targetCache memoises relabeling results for the lifetime of a target.
+//
+// discovery.relabel is handed a complete snapshot of its input on every update,
+// so the cache is bounded by the current number of discovered targets rather than
+// by a configured size: anything absent from an update is dropped at the end of
+// it. That keeps the cache exactly as large as it is useful and means there is no
+// size to tune.
+//
+// Not safe for concurrent use; the component holds its write lock throughout an
+// update.
+type targetCache struct {
+	entries map[discovery.TargetCacheKey]*cacheEntry
+
+	generation uint64
+	// seen counts the entries used in the current generation, so that the common
+	// case of nothing having gone away can skip the eviction scan.
+	seen int
+	// peak is the high-water mark of live entries since the last rebuild, measured
+	// after eviction. It deliberately excludes the transient growth while an update
+	// is in flight: when every target changes, the map holds the previous and the
+	// current generation at once, and treating that as a peak would make every
+	// update look like a collapse and rebuild the map needlessly.
+	peak int
+}
+
+func newTargetCache() *targetCache {
+	return &targetCache{entries: map[discovery.TargetCacheKey]*cacheEntry{}}
+}
+
+// begin starts a new update.
+func (c *targetCache) begin() {
+	c.generation++
+	c.seen = 0
+}
+
+// lookup returns the cached result for a target, if any.
+func (c *targetCache) lookup(key discovery.TargetCacheKey) (*cacheEntry, bool) {
+	entry, ok := c.entries[key]
+	if !ok {
+		return nil, false
+	}
+	// Mark the entry as still in use. Entries are stored by pointer so this does
+	// not need a second map operation, which matters because hashing the key means
+	// hashing the target's packed labels.
+	if entry.generation != c.generation {
+		entry.generation = c.generation
+		c.seen++
+	}
+	return entry, true
+}
+
+// insert records the result of relabeling a target.
+func (c *targetCache) insert(key discovery.TargetCacheKey, output discovery.Target, keep bool) *cacheEntry {
+	entry := &cacheEntry{output: output, keep: keep, generation: c.generation}
+	c.entries[key] = entry
+	c.seen++
+	return entry
+}
+
+// end finishes an update, dropping the entries for targets that were not part of
+// it.
+func (c *targetCache) end() {
+	// Entries touched this generation are the live ones; the rest belong to targets
+	// that have gone away.
+	live := c.seen
+	stale := len(c.entries) - live
+
+	// Deleting in place is cheaper than copying the survivors into a fresh map,
+	// even when most of the map is stale: measured on a 20k target set where every
+	// target changes each update, rebuilding every time cost ~13% more memory for
+	// no gain in time.
+	if stale > 0 {
+		for key, entry := range c.entries {
+			if entry.generation != c.generation {
+				delete(c.entries, key)
+			}
+		}
+	}
+
+	// A Go map never gives back bucket memory on delete, so once the live set has
+	// collapsed far enough, copy what is left into a right-sized map. This is for
+	// the case where targets drain away over several updates; a single update that
+	// replaces everything keeps a steady live size and does not trigger it.
+	if shouldRebuild(c.peak, live) {
+		rebuilt := make(map[discovery.TargetCacheKey]*cacheEntry, live)
+		for key, entry := range c.entries {
+			rebuilt[key] = entry
+		}
+		c.entries = rebuilt
+		c.peak = live
+		return
+	}
+
+	if live > c.peak {
+		c.peak = live
+	}
+}
+
+// shouldRebuild reports whether the backing map should be replaced with one sized
+// to the live entries, to give back memory after the live set has shrunk.
+func shouldRebuild(peak, live int) bool {
+	return peak >= rebuildMinSize && live*2 <= peak
+}
+
+func (c *targetCache) len() int { return len(c.entries) }
+
+// clear drops every entry, for when the relabeling rules change and no cached
+// result is valid any more.
+func (c *targetCache) clear() {
+	// Release the buckets rather than clear() them: the rules changing says
+	// nothing about how many targets there will be, and holding the old footprint
+	// is not justified.
+	c.entries = map[discovery.TargetCacheKey]*cacheEntry{}
+	c.seen = 0
+	c.peak = 0
+}
+
+func rulesChanged(prev, next []ruleSnapshot) bool {
+	return !slices.Equal(prev, next)
+}

--- a/internal/component/discovery/relabel/cache_bench_test.go
+++ b/internal/component/discovery/relabel/cache_bench_test.go
@@ -1,0 +1,309 @@
+package relabel
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	commonlabels "github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/internal/component"
+	alloy_relabel "github.com/grafana/alloy/internal/component/common/relabel"
+	"github.com/grafana/alloy/internal/component/discovery"
+)
+
+func benchRegexp(tb testing.TB, s string) alloy_relabel.Regexp {
+	tb.Helper()
+	var re alloy_relabel.Regexp
+	require.NoError(tb, re.UnmarshalText([]byte(s)))
+	return re
+}
+
+func benchRule(c alloy_relabel.Config) *alloy_relabel.Config {
+	out := alloy_relabel.DefaultRelabelConfig
+	if len(c.SourceLabels) > 0 {
+		out.SourceLabels = c.SourceLabels
+	}
+	if c.Separator != "" {
+		out.Separator = c.Separator
+	}
+	if c.Regex.Regexp != nil {
+		out.Regex = c.Regex
+	}
+	if c.Modulus != 0 {
+		out.Modulus = c.Modulus
+	}
+	if c.TargetLabel != "" {
+		out.TargetLabel = c.TargetLabel
+	}
+	if c.Replacement != "" {
+		out.Replacement = c.Replacement
+	}
+	if c.Action != "" {
+		out.Action = c.Action
+	}
+	return &out
+}
+
+// benchRules is a realistic Kubernetes pod rule set: it inspects labels, maps
+// some, computes a hashmod and drops a temporary label.
+func benchRules(tb testing.TB) []*alloy_relabel.Config {
+	tb.Helper()
+	return []*alloy_relabel.Config{
+		benchRule(alloy_relabel.Config{
+			SourceLabels: []string{"__meta_kubernetes_pod_phase"},
+			Regex:        benchRegexp(tb, "Running"),
+			Action:       alloy_relabel.Keep,
+		}),
+		benchRule(alloy_relabel.Config{
+			SourceLabels: []string{"__address__", "__meta_kubernetes_pod_annotation_prometheus_io_port"},
+			Regex:        benchRegexp(tb, `(.+?)(\:\d+)?;(\d+)`),
+			TargetLabel:  "__address__",
+			Replacement:  "$1:$3",
+		}),
+		benchRule(alloy_relabel.Config{
+			Regex:       benchRegexp(tb, "__meta_kubernetes_pod_label_(.+)"),
+			Action:      alloy_relabel.LabelMap,
+			Replacement: "$1",
+		}),
+		benchRule(alloy_relabel.Config{
+			SourceLabels: []string{"__meta_kubernetes_namespace", "__meta_kubernetes_pod_name"},
+			Separator:    "/",
+			TargetLabel:  "instance",
+		}),
+		benchRule(alloy_relabel.Config{
+			SourceLabels: []string{"__meta_kubernetes_namespace"},
+			TargetLabel:  "namespace",
+		}),
+		benchRule(alloy_relabel.Config{
+			TargetLabel: "cluster",
+			Replacement: "dev-us-central-0",
+		}),
+		benchRule(alloy_relabel.Config{
+			SourceLabels: []string{"__address__"},
+			TargetLabel:  "__tmp_hash",
+			Modulus:      3,
+			Action:       alloy_relabel.HashMod,
+		}),
+		benchRule(alloy_relabel.Config{
+			Regex:  benchRegexp(tb, "__tmp_hash"),
+			Action: alloy_relabel.LabelDrop,
+		}),
+	}
+}
+
+// benchTargets builds targets the way service discovery does: grouped by source,
+// with each group's shared labels packed once and referenced by every target of
+// that group.
+func benchTargets(sources, perSource int, generation int) []discovery.Target {
+	out := make([]discovery.Target, 0, sources*perSource)
+	for s := 0; s < sources; s++ {
+		group := commonlabels.LabelSet{
+			"__meta_kubernetes_namespace":                         "prod",
+			"__meta_kubernetes_service_name":                      commonlabels.LabelValue(fmt.Sprintf("svc-%d", s)),
+			"__meta_kubernetes_pod_phase":                         "Running",
+			"__meta_kubernetes_pod_annotation_prometheus_io_port": "8080",
+			"__meta_kubernetes_pod_label_app":                     commonlabels.LabelValue(fmt.Sprintf("app-%d", s)),
+			"__meta_kubernetes_pod_label_team":                    "platform",
+			"__meta_kubernetes_pod_label_tier":                    "backend",
+			"job":                                                 commonlabels.LabelValue(fmt.Sprintf("job-%d", s)),
+		}
+		// Pack the group once, then derive each target from it by setting only its
+		// own labels. A builder that does not touch group labels keeps the group
+		// pointer, so every target of this source shares one copy, which is what
+		// toAlloyTargets produces.
+		base := discovery.NewTargetFromSpecificAndBaseLabelSet(nil, group)
+		for i := 0; i < perSource; i++ {
+			tb := discovery.NewTargetBuilderFrom(base)
+			tb.Set("__address__", fmt.Sprintf("10.%d.%d.%d:8080", s%256, i%256, generation%256))
+			tb.Set("__meta_kubernetes_pod_name", fmt.Sprintf("pod-%d-%d-%d", s, i, generation))
+			tb.Set("__meta_kubernetes_pod_ip", fmt.Sprintf("10.%d.%d.%d", s%256, i%256, generation%256))
+			tb.Set("__meta_kubernetes_pod_uid", fmt.Sprintf("uid-%d-%d-%d", s, i, generation))
+			out = append(out, tb.Target())
+		}
+	}
+	return out
+}
+
+func benchComponent(tb testing.TB) *Component {
+	tb.Helper()
+	return &Component{
+		opts: component.Options{
+			ID:            "discovery.relabel.bench",
+			OnStateChange: func(component.Exports) {},
+		},
+		cache:              newTargetCache(),
+		metrics:            newMetrics(prometheus.NewRegistry()),
+		debugDataPublisher: &fakePublisher{},
+	}
+}
+
+// Benchmark_Cache measures the per-update cost of discovery.relabel for a
+// realistic 20k target set, in the shapes an update actually takes.
+//
+// linux/amd64, Ryzen AI MAX+ 395, 50 sources x 400 targets = 20k targets:
+//
+//	                           time/op   alloc/op  allocs/op
+//	cold                       78.1ms    43.3MB    941k       every target relabeled
+//	unchanged snapshot          1.52ms    1.61MB    20.0k     every target a cache hit
+//	one of 50 sources changed   3.16ms    2.38MB    38.4k
+//	rules changed              82.1ms    45.3MB    1.02M      cache purged, as intended
+//
+// The 20k allocations left on the fully cached path are the live debugging
+// closure built per target in Update, not the cache: with that call removed the
+// same benchmark reports 0.99ms and 5 allocations. DebugDataPublisher has no way
+// to ask whether anything is listening, so the closure is allocated even when it
+// is never called. Fixing that needs a change to the livedebugging service and
+// would speed this path up by a further ~40%.
+func Benchmark_Cache(b *testing.B) {
+	const sources, perSource = 50, 400
+	rules := benchRules(b)
+	targets := benchTargets(sources, perSource, 0)
+
+	b.Run("cold", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			c := benchComponent(b)
+			if err := c.Update(Arguments{Targets: targets, RelabelConfigs: rules}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("unchanged snapshot", func(b *testing.B) {
+		c := benchComponent(b)
+		args := Arguments{Targets: targets, RelabelConfigs: rules}
+		require.NoError(b, c.Update(args)) // warm
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := c.Update(args); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("one source changed", func(b *testing.B) {
+		c := benchComponent(b)
+		require.NoError(b, c.Update(Arguments{Targets: targets, RelabelConfigs: rules}))
+
+		// Pre-build the per-generation replacements so the benchmark measures the
+		// component rather than target construction.
+		gens := make([][]discovery.Target, 8)
+		for g := range gens {
+			next := make([]discovery.Target, len(targets))
+			copy(next, targets)
+			replacement := benchTargets(1, perSource, g+1)
+			copy(next[:perSource], replacement)
+			gens[g] = next
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := c.Update(Arguments{Targets: gens[i%len(gens)], RelabelConfigs: rules}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("rules changed", func(b *testing.B) {
+		c := benchComponent(b)
+		alt := append([]*alloy_relabel.Config(nil), rules...)
+		alt = append(alt, benchRule(alloy_relabel.Config{TargetLabel: "extra", Replacement: "a"}))
+		alt2 := append([]*alloy_relabel.Config(nil), rules...)
+		alt2 = append(alt2, benchRule(alloy_relabel.Config{TargetLabel: "extra", Replacement: "b"}))
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			cfg := alt
+			if i%2 == 1 {
+				cfg = alt2
+			}
+			if err := c.Update(Arguments{Targets: targets, RelabelConfigs: cfg}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// Benchmark_Cache_DropHeavy covers the case the cache helps most: rules that drop
+// most targets, where the expensive work produces no output at all and would
+// otherwise be repeated on every update.
+func Benchmark_Cache_DropHeavy(b *testing.B) {
+	rules := []*alloy_relabel.Config{
+		benchRule(alloy_relabel.Config{
+			SourceLabels: []string{"__meta_kubernetes_pod_label_app"},
+			Regex:        benchRegexp(b, "app-0"),
+			Action:       alloy_relabel.Keep,
+		}),
+	}
+	targets := benchTargets(50, 400, 0)
+
+	b.Run("cold", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			c := benchComponent(b)
+			if err := c.Update(Arguments{Targets: targets, RelabelConfigs: rules}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("unchanged snapshot", func(b *testing.B) {
+		c := benchComponent(b)
+		args := Arguments{Targets: targets, RelabelConfigs: rules}
+		require.NoError(b, c.Update(args))
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := c.Update(args); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// Benchmark_Cache_NoRules measures the pass-through path, which bypasses the
+// cache entirely.
+func Benchmark_Cache_NoRules(b *testing.B) {
+	targets := benchTargets(50, 400, 0)
+	c := benchComponent(b)
+	args := Arguments{Targets: targets}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := c.Update(args); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// Benchmark_CacheKey isolates the cost of the map key itself, which is what makes
+// the cache worthwhile: hashing the packed labels must be far cheaper than
+// relabeling.
+func Benchmark_CacheKey(b *testing.B) {
+	targets := benchTargets(1, 1, 0)
+	target := targets[0]
+
+	b.Run("CacheKey", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = target.CacheKey()
+		}
+	})
+
+	b.Run("map lookup", func(b *testing.B) {
+		m := map[discovery.TargetCacheKey]*cacheEntry{}
+		m[target.CacheKey()] = &cacheEntry{}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, ok := m[target.CacheKey()]; !ok {
+				b.Fatal("expected a hit")
+			}
+		}
+	})
+}

--- a/internal/component/discovery/relabel/cache_bench_test.go
+++ b/internal/component/discovery/relabel/cache_bench_test.go
@@ -145,10 +145,10 @@ func benchComponent(tb testing.TB) *Component {
 // linux/amd64, Ryzen AI MAX+ 395, 50 sources x 400 targets = 20k targets:
 //
 //	                           time/op   alloc/op  allocs/op
-//	cold                       78.1ms    43.3MB    941k       every target relabeled
-//	unchanged snapshot          1.52ms    1.61MB    20.0k     every target a cache hit
-//	one of 50 sources changed   3.16ms    2.38MB    38.4k
-//	rules changed              82.1ms    45.3MB    1.02M      cache purged, as intended
+//	cold                       78.5ms    43.8MB    941k       every target relabeled
+//	unchanged snapshot          1.33ms    1.61MB    20.0k     every target a cache hit
+//	one of 50 sources changed   3.10ms    2.38MB    38.4k
+//	rules changed              82.1ms    45.9MB    1.02M      cache purged, as intended
 //
 // The 20k allocations left on the fully cached path are the live debugging
 // closure built per target in Update, not the cache: with that call removed the

--- a/internal/component/discovery/relabel/cache_test.go
+++ b/internal/component/discovery/relabel/cache_test.go
@@ -502,3 +502,74 @@ func TestCacheDoesNotRebuildOnFullChurn(t *testing.T) {
 	// Only the current generation is retained.
 	require.Equal(t, rebuildMinSize, c.cache.len())
 }
+
+// TestCacheHitsWhenGroupIsRebuilt is the regression test for the cache keying on
+// group contents rather than on the group pointer.
+//
+// Most service discovery mechanisms are built on refresh: they rebuild every
+// target group on every refresh interval, so a group whose contents did not change
+// still arrives as a fresh allocation. toAlloyTargets then packs a new
+// *groupLabels for it, and a cache keyed on that pointer missed for every target
+// of every refresh-based mechanism, which is nearly all of them. Verified against
+// a running discovery.file: changing one address in one of three groups produced
+// 0 hits and 12 misses.
+func TestCacheHitsWhenGroupIsRebuilt(t *testing.T) {
+	group := commonlabels.LabelSet{"job": "alpha", "env": "prod"}
+
+	// Two independently packed groups with identical contents, as consecutive
+	// refreshes of the same service discovery mechanism produce.
+	build := func(addr string) discovery.Target {
+		return discovery.NewTargetFromSpecificAndBaseLabelSet(
+			commonlabels.LabelSet{"__address__": commonlabels.LabelValue(addr), "app": "backend"},
+			commonlabels.LabelSet{"job": group["job"], "env": group["env"]},
+		)
+	}
+
+	first := build("10.0.0.1:80")
+	rebuilt := build("10.0.0.1:80")
+
+	require.True(t, first.EqualsTarget(&rebuilt), "the two targets have identical labels")
+	require.Equal(t, first.CacheKey(), rebuilt.CacheKey(),
+		"a rebuilt group with identical contents must produce the same cache key")
+
+	reg := prometheus.NewRegistry()
+	c := testComponent(t, reg, &fakePublisher{})
+	args := mustArgs(t, keepBackendRules)
+
+	args.Targets = []discovery.Target{first}
+	require.NoError(t, c.Update(args))
+	require.Equal(t, float64(1), counterValue(t, reg, "alloy_discovery_relabel_cache_misses_total"))
+	require.Equal(t, float64(0), counterValue(t, reg, "alloy_discovery_relabel_cache_hits_total"))
+
+	// The same target arriving from a rebuilt group must be served from the cache.
+	args.Targets = []discovery.Target{rebuilt}
+	require.NoError(t, c.Update(args))
+	require.Equal(t, float64(1), counterValue(t, reg, "alloy_discovery_relabel_cache_misses_total"),
+		"a rebuilt group must not cause a miss")
+	require.Equal(t, float64(1), counterValue(t, reg, "alloy_discovery_relabel_cache_hits_total"))
+	require.Equal(t, 1, c.cache.len(), "the rebuilt target must reuse the existing entry, not add one")
+
+	// A partially changed group: only the target that actually changed may miss.
+	changed := build("10.0.0.99:80")
+	args.Targets = []discovery.Target{rebuilt, changed}
+	require.NoError(t, c.Update(args))
+	require.Equal(t, float64(2), counterValue(t, reg, "alloy_discovery_relabel_cache_hits_total"),
+		"the unchanged target must still hit")
+	require.Equal(t, float64(2), counterValue(t, reg, "alloy_discovery_relabel_cache_misses_total"),
+		"only the changed target may miss")
+}
+
+// TestCacheKeyIgnoresGroupIdentityNotContents checks the key distinguishes group
+// contents, so that a target cannot be served a result computed for different
+// group labels.
+func TestCacheKeyIgnoresGroupIdentityNotContents(t *testing.T) {
+	own := commonlabels.LabelSet{"__address__": "10.0.0.1:80"}
+
+	a := discovery.NewTargetFromSpecificAndBaseLabelSet(own, commonlabels.LabelSet{"job": "alpha"})
+	sameContents := discovery.NewTargetFromSpecificAndBaseLabelSet(own, commonlabels.LabelSet{"job": "alpha"})
+	differentContents := discovery.NewTargetFromSpecificAndBaseLabelSet(own, commonlabels.LabelSet{"job": "beta"})
+
+	require.Equal(t, a.CacheKey(), sameContents.CacheKey())
+	require.NotEqual(t, a.CacheKey(), differentContents.CacheKey(),
+		"different group labels must not share a cache entry")
+}

--- a/internal/component/discovery/relabel/cache_test.go
+++ b/internal/component/discovery/relabel/cache_test.go
@@ -1,0 +1,504 @@
+package relabel
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	commonlabels "github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/internal/component"
+	alloy_relabel "github.com/grafana/alloy/internal/component/common/relabel"
+	"github.com/grafana/alloy/internal/component/discovery"
+	"github.com/grafana/alloy/internal/service/livedebugging"
+	"github.com/grafana/alloy/syntax"
+)
+
+// fakePublisher records the live debugging messages that were published, and can
+// pretend to be inactive so that the message functions are never evaluated.
+type fakePublisher struct {
+	active   bool
+	messages []string
+	count    int
+}
+
+func (p *fakePublisher) PublishIfActive(data livedebugging.Data) {
+	p.count++
+	if p.active {
+		p.messages = append(p.messages, data.DataFunc())
+	}
+}
+
+// testComponent builds a Component directly so that tests can inspect the cache.
+func testComponent(t *testing.T, reg prometheus.Registerer, pub *fakePublisher) *Component {
+	t.Helper()
+	return &Component{
+		opts: component.Options{
+			ID:            "discovery.relabel.test",
+			OnStateChange: func(component.Exports) {},
+		},
+		cache:              newTargetCache(),
+		metrics:            newMetrics(reg),
+		debugDataPublisher: pub,
+	}
+}
+
+func mustArgs(t *testing.T, cfg string) Arguments {
+	t.Helper()
+	var args Arguments
+	require.NoError(t, syntax.Unmarshal([]byte(cfg), &args))
+	return args
+}
+
+// counterValue reads a counter out of a registry by metric name.
+func counterValue(t *testing.T, reg *prometheus.Registry, name string) float64 {
+	t.Helper()
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	for _, f := range families {
+		if f.GetName() != name {
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			switch {
+			case m.GetCounter() != nil:
+				return m.GetCounter().GetValue()
+			case m.GetGauge() != nil:
+				return m.GetGauge().GetValue()
+			}
+		}
+	}
+	return 0
+}
+
+const keepBackendRules = `
+targets = []
+
+rule {
+	source_labels = ["app"]
+	action        = "keep"
+	regex         = "backend"
+}
+
+rule {
+	source_labels = ["instance"]
+	target_label  = "name"
+}
+`
+
+func targetsFromMaps(ms ...map[string]string) []discovery.Target {
+	out := make([]discovery.Target, 0, len(ms))
+	for _, m := range ms {
+		out = append(out, discovery.NewTargetFromMap(m))
+	}
+	return out
+}
+
+func TestCacheReusesUnchangedTargets(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	pub := &fakePublisher{}
+	c := testComponent(t, reg, pub)
+
+	args := mustArgs(t, keepBackendRules)
+	args.Targets = targetsFromMaps(
+		map[string]string{"app": "backend", "instance": "one"},
+		map[string]string{"app": "frontend", "instance": "two"},
+		map[string]string{"app": "backend", "instance": "three"},
+	)
+
+	require.NoError(t, c.Update(args))
+	require.Equal(t, float64(0), counterValue(t, reg, "alloy_discovery_relabel_cache_hits_total"))
+	require.Equal(t, float64(3), counterValue(t, reg, "alloy_discovery_relabel_cache_misses_total"))
+	// Dropped targets are cached too, so all three are held.
+	require.Equal(t, float64(3), counterValue(t, reg, "alloy_discovery_relabel_cache_size"))
+	require.Equal(t, 3, c.cache.len())
+
+	// Feeding the very same targets again must be served entirely from the cache.
+	require.NoError(t, c.Update(args))
+	require.Equal(t, float64(3), counterValue(t, reg, "alloy_discovery_relabel_cache_hits_total"))
+	require.Equal(t, float64(3), counterValue(t, reg, "alloy_discovery_relabel_cache_misses_total"))
+	require.Equal(t, 3, c.cache.len())
+}
+
+func TestCacheHitsForDuplicateTargetsInOneUpdate(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	c := testComponent(t, reg, &fakePublisher{})
+
+	same := map[string]string{"app": "backend", "instance": "one"}
+	args := mustArgs(t, keepBackendRules)
+	args.Targets = targetsFromMaps(same, same, same)
+
+	require.NoError(t, c.Update(args))
+	require.Equal(t, float64(1), counterValue(t, reg, "alloy_discovery_relabel_cache_misses_total"))
+	require.Equal(t, float64(2), counterValue(t, reg, "alloy_discovery_relabel_cache_hits_total"))
+	require.Equal(t, 1, c.cache.len(), "identical targets share a cache entry")
+
+	// All three are still emitted.
+	var got []discovery.Target
+	c.opts.OnStateChange = func(e component.Exports) { got = e.(Exports).Output }
+	require.NoError(t, c.Update(args))
+	require.Len(t, got, 3)
+}
+
+func TestCacheMissesWhenLabelsChange(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	c := testComponent(t, reg, &fakePublisher{})
+
+	args := mustArgs(t, keepBackendRules)
+	args.Targets = targetsFromMaps(map[string]string{"app": "backend", "instance": "one"})
+	require.NoError(t, c.Update(args))
+	require.Equal(t, float64(1), counterValue(t, reg, "alloy_discovery_relabel_cache_misses_total"))
+
+	// A changed label value must not be served from the cache.
+	args.Targets = targetsFromMaps(map[string]string{"app": "backend", "instance": "CHANGED"})
+	var got []discovery.Target
+	c.opts.OnStateChange = func(e component.Exports) { got = e.(Exports).Output }
+	require.NoError(t, c.Update(args))
+	require.Equal(t, float64(2), counterValue(t, reg, "alloy_discovery_relabel_cache_misses_total"))
+	require.Equal(t, float64(0), counterValue(t, reg, "alloy_discovery_relabel_cache_hits_total"))
+
+	require.Len(t, got, 1)
+	name, ok := got[0].Get("name")
+	require.True(t, ok)
+	require.Equal(t, "CHANGED", name, "relabeling must have been redone")
+}
+
+func TestCacheCachesDropDecision(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	c := testComponent(t, reg, &fakePublisher{})
+
+	args := mustArgs(t, keepBackendRules)
+	args.Targets = targetsFromMaps(map[string]string{"app": "frontend", "instance": "one"})
+
+	var got []discovery.Target
+	c.opts.OnStateChange = func(e component.Exports) { got = e.(Exports).Output }
+
+	require.NoError(t, c.Update(args))
+	require.Empty(t, got, "target should be dropped")
+	require.Equal(t, 1, c.cache.len(), "the drop decision must be cached")
+
+	require.NoError(t, c.Update(args))
+	require.Empty(t, got, "target must still be dropped when served from the cache")
+	require.Equal(t, float64(1), counterValue(t, reg, "alloy_discovery_relabel_cache_hits_total"))
+}
+
+func TestCachePreservesInputOrder(t *testing.T) {
+	c := testComponent(t, prometheus.NewRegistry(), &fakePublisher{})
+
+	args := mustArgs(t, `
+targets = []
+
+rule {
+	source_labels = ["instance"]
+	target_label  = "name"
+}
+`)
+	args.Targets = targetsFromMaps(
+		map[string]string{"instance": "c"},
+		map[string]string{"instance": "a"},
+		map[string]string{"instance": "b"},
+	)
+
+	var got []discovery.Target
+	c.opts.OnStateChange = func(e component.Exports) { got = e.(Exports).Output }
+
+	// Run twice: the second pass is served from the cache and must still preserve
+	// the order of the input rather than the order entries were cached in.
+	for i := 0; i < 2; i++ {
+		require.NoError(t, c.Update(args))
+		require.Len(t, got, 3)
+		var names []string
+		for _, target := range got {
+			name, ok := target.Get("name")
+			require.True(t, ok)
+			names = append(names, name)
+		}
+		require.Equal(t, []string{"c", "a", "b"}, names, "pass %d", i)
+	}
+}
+
+func TestCacheEvictsRemovedTargets(t *testing.T) {
+	c := testComponent(t, prometheus.NewRegistry(), &fakePublisher{})
+
+	args := mustArgs(t, keepBackendRules)
+	args.Targets = targetsFromMaps(
+		map[string]string{"app": "backend", "instance": "one"},
+		map[string]string{"app": "backend", "instance": "two"},
+		map[string]string{"app": "backend", "instance": "three"},
+	)
+	require.NoError(t, c.Update(args))
+	require.Equal(t, 3, c.cache.len())
+
+	// Two targets go away.
+	args.Targets = targetsFromMaps(map[string]string{"app": "backend", "instance": "two"})
+	require.NoError(t, c.Update(args))
+	require.Equal(t, 1, c.cache.len(), "entries for targets that went away must be dropped")
+
+	// Everything goes away.
+	args.Targets = nil
+	require.NoError(t, c.Update(args))
+	require.Equal(t, 0, c.cache.len())
+}
+
+func TestCacheClearedWhenRulesChange(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	c := testComponent(t, reg, &fakePublisher{})
+
+	targets := targetsFromMaps(map[string]string{"app": "backend", "instance": "one"})
+
+	args := mustArgs(t, keepBackendRules)
+	args.Targets = targets
+	require.NoError(t, c.Update(args))
+	require.Equal(t, 1, c.cache.len())
+
+	var got []discovery.Target
+	c.opts.OnStateChange = func(e component.Exports) { got = e.(Exports).Output }
+
+	// Same targets, different rules: the cached result must not be reused.
+	changed := mustArgs(t, `
+targets = []
+
+rule {
+	source_labels = ["app"]
+	action        = "keep"
+	regex         = "backend"
+}
+
+rule {
+	source_labels = ["instance"]
+	target_label  = "renamed"
+}
+`)
+	changed.Targets = targets
+	require.NoError(t, c.Update(changed))
+
+	require.Equal(t, float64(0), counterValue(t, reg, "alloy_discovery_relabel_cache_hits_total"))
+	require.Len(t, got, 1)
+	_, ok := got[0].Get("name")
+	require.False(t, ok, "result from the old rules must not leak through the cache")
+	renamed, ok := got[0].Get("renamed")
+	require.True(t, ok)
+	require.Equal(t, "one", renamed)
+}
+
+// TestRuleSnapshotDetectsEveryField guards against a rule field being added
+// without being included in the snapshot, which would let a config change go
+// unnoticed and serve stale relabeling results.
+func TestRuleSnapshotDetectsEveryField(t *testing.T) {
+	base := alloy_relabel.DefaultRelabelConfig
+	base.SourceLabels = []string{"a"}
+	base.TargetLabel = "t"
+
+	mutations := map[string]func(c *alloy_relabel.Config){
+		"source_labels": func(c *alloy_relabel.Config) { c.SourceLabels = []string{"b"} },
+		"separator":     func(c *alloy_relabel.Config) { c.Separator = "|" },
+		"regex":         func(c *alloy_relabel.Config) { require.NoError(t, c.Regex.UnmarshalText([]byte("something"))) },
+		"modulus":       func(c *alloy_relabel.Config) { c.Modulus = 7 },
+		"target_label":  func(c *alloy_relabel.Config) { c.TargetLabel = "other" },
+		"replacement":   func(c *alloy_relabel.Config) { c.Replacement = "other" },
+		"action":        func(c *alloy_relabel.Config) { c.Action = alloy_relabel.Drop },
+	}
+
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			before := base
+			after := base
+			mutate(&after)
+			require.True(t,
+				rulesChanged(snapshotRules([]*alloy_relabel.Config{&before}), snapshotRules([]*alloy_relabel.Config{&after})),
+				"changing %s must invalidate the cache", name)
+		})
+	}
+
+	t.Run("identical", func(t *testing.T) {
+		a, b := base, base
+		require.False(t, rulesChanged(
+			snapshotRules([]*alloy_relabel.Config{&a}),
+			snapshotRules([]*alloy_relabel.Config{&b})))
+	})
+
+	t.Run("rule count", func(t *testing.T) {
+		a := base
+		require.True(t, rulesChanged(
+			snapshotRules([]*alloy_relabel.Config{&a}),
+			snapshotRules([]*alloy_relabel.Config{&a, &a})))
+	})
+
+	t.Run("source label boundaries", func(t *testing.T) {
+		// ["a", "b"] must not snapshot the same as ["ab"].
+		x, y := base, base
+		x.SourceLabels = []string{"a", "b"}
+		y.SourceLabels = []string{"ab"}
+		require.True(t, rulesChanged(
+			snapshotRules([]*alloy_relabel.Config{&x}),
+			snapshotRules([]*alloy_relabel.Config{&y})))
+	})
+}
+
+func TestNoRulesBypassesCache(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	c := testComponent(t, reg, &fakePublisher{})
+
+	targets := targetsFromMaps(
+		map[string]string{"app": "backend", "instance": "one"},
+		map[string]string{"app": "frontend", "instance": "two"},
+	)
+
+	var got []discovery.Target
+	c.opts.OnStateChange = func(e component.Exports) { got = e.(Exports).Output }
+
+	args := Arguments{Targets: targets}
+	require.NoError(t, c.Update(args))
+
+	require.Len(t, got, 2, "with no rules every target passes through")
+	require.Equal(t, 0, c.cache.len(), "nothing should be cached when there are no rules")
+	require.Equal(t, float64(0), counterValue(t, reg, "alloy_discovery_relabel_cache_size"))
+	for i := range targets {
+		require.True(t, targets[i].EqualsTarget(&got[i]))
+	}
+
+	// The exported slice must not alias the caller's argument slice.
+	require.NotSame(t, &args.Targets[0], &got[0])
+}
+
+func TestRemovingRulesReleasesCache(t *testing.T) {
+	c := testComponent(t, prometheus.NewRegistry(), &fakePublisher{})
+
+	targets := targetsFromMaps(map[string]string{"app": "backend", "instance": "one"})
+
+	args := mustArgs(t, keepBackendRules)
+	args.Targets = targets
+	require.NoError(t, c.Update(args))
+	require.Equal(t, 1, c.cache.len())
+
+	require.NoError(t, c.Update(Arguments{Targets: targets}))
+	require.Equal(t, 0, c.cache.len(), "dropping the rules must release the cache")
+	require.Nil(t, c.rules)
+}
+
+func TestLiveDebuggingReportsCachedResults(t *testing.T) {
+	pub := &fakePublisher{active: true}
+	c := testComponent(t, prometheus.NewRegistry(), pub)
+
+	args := mustArgs(t, keepBackendRules)
+	args.Targets = targetsFromMaps(
+		map[string]string{"app": "backend", "instance": "one"},
+		map[string]string{"app": "frontend", "instance": "two"},
+	)
+
+	require.NoError(t, c.Update(args))
+	first := append([]string(nil), pub.messages...)
+	require.Len(t, first, 2)
+	require.Contains(t, first[0], `"name"="one"`, "kept target should show its relabeled form")
+	require.Contains(t, first[1], "=> {}", "dropped target should show an empty result")
+
+	// The second pass is served from the cache and must publish the same thing.
+	pub.messages = nil
+	require.NoError(t, c.Update(args))
+	require.Equal(t, first, pub.messages, "cached results must produce the same debug output")
+}
+
+func TestCacheRebuildsAfterCardinalityCollapse(t *testing.T) {
+	require.False(t, shouldRebuild(rebuildMinSize-1, 0), "small caches are not worth rebuilding")
+	require.False(t, shouldRebuild(rebuildMinSize, rebuildMinSize), "no collapse, no rebuild")
+	require.False(t, shouldRebuild(rebuildMinSize, rebuildMinSize/2+1), "less than half is not a collapse")
+	require.True(t, shouldRebuild(rebuildMinSize, rebuildMinSize/2), "half or less is a collapse")
+	require.True(t, shouldRebuild(rebuildMinSize, 0))
+
+	c := testComponent(t, prometheus.NewRegistry(), &fakePublisher{})
+	args := mustArgs(t, keepBackendRules)
+
+	// Grow past the rebuild threshold.
+	big := make([]map[string]string, 0, rebuildMinSize+10)
+	for i := 0; i < rebuildMinSize+10; i++ {
+		big = append(big, map[string]string{"app": "backend", "instance": fmt.Sprintf("i%d", i)})
+	}
+	args.Targets = targetsFromMaps(big...)
+	require.NoError(t, c.Update(args))
+	require.Equal(t, rebuildMinSize+10, c.cache.len())
+
+	// Maps are not comparable, so identify the backing map by its address.
+	mapIdentity := func(m map[discovery.TargetCacheKey]*cacheEntry) uintptr {
+		return reflect.ValueOf(m).Pointer()
+	}
+	before := mapIdentity(c.cache.entries)
+
+	// Collapse to a single target.
+	args.Targets = targetsFromMaps(big[0])
+	require.NoError(t, c.Update(args))
+	require.Equal(t, 1, c.cache.len())
+	require.NotEqual(t, before, mapIdentity(c.cache.entries), "the backing map should have been rebuilt")
+	require.Equal(t, 1, c.cache.peak, "peak resets to the live size after a rebuild")
+
+	// The surviving entry must still be usable.
+	require.NoError(t, c.Update(args))
+	require.Equal(t, 1, c.cache.len())
+}
+
+// TestCacheKeyDistinguishesGroupSplit documents that the cache key is based on
+// the packed representation, so two targets with the same labels but a different
+// group/own split are different keys. That is a safe miss, never a wrong hit.
+func TestCacheKeyDistinguishesGroupSplit(t *testing.T) {
+	labels := map[string]string{"job": "j", "instance": "i"}
+
+	flat := discovery.NewTargetFromMap(labels)
+	split := discovery.NewTargetFromSpecificAndBaseLabelSet(
+		commonlabels.LabelSet{"instance": "i"},
+		commonlabels.LabelSet{"job": "j"},
+	)
+
+	require.True(t, flat.EqualsTarget(&split), "the targets have the same labels")
+	require.NotEqual(t, flat.CacheKey(), split.CacheKey(), "different splits are different keys")
+
+	// Same split, same labels: keys must match.
+	again := discovery.NewTargetFromMap(labels)
+	require.Equal(t, flat.CacheKey(), again.CacheKey())
+}
+
+// TestCacheDoesNotRebuildOnFullChurn guards the peak accounting. While an update
+// is in flight the map holds both the previous and the current generation, so a
+// component whose targets all change every update momentarily has twice as many
+// entries as are live. Treating that as the high-water mark made every single
+// update look like a collapse and rebuild the map, which cost ~13% more memory
+// for no benefit.
+func TestCacheDoesNotRebuildOnFullChurn(t *testing.T) {
+	c := testComponent(t, prometheus.NewRegistry(), &fakePublisher{})
+	args := mustArgs(t, keepBackendRules)
+
+	build := func(generation int) []discovery.Target {
+		ms := make([]map[string]string, 0, rebuildMinSize)
+		for i := 0; i < rebuildMinSize; i++ {
+			ms = append(ms, map[string]string{
+				"app":      "backend",
+				"instance": fmt.Sprintf("i%d-gen%d", i, generation),
+			})
+		}
+		return targetsFromMaps(ms...)
+	}
+
+	mapIdentity := func(m map[discovery.TargetCacheKey]*cacheEntry) uintptr {
+		return reflect.ValueOf(m).Pointer()
+	}
+
+	args.Targets = build(0)
+	require.NoError(t, c.Update(args))
+	require.Equal(t, rebuildMinSize, c.cache.len())
+	require.Equal(t, rebuildMinSize, c.cache.peak)
+
+	// Replace every target, repeatedly. The live size never changes, so the map
+	// must not be rebuilt.
+	identity := mapIdentity(c.cache.entries)
+	for generation := 1; generation <= 3; generation++ {
+		args.Targets = build(generation)
+		require.NoError(t, c.Update(args))
+		require.Equal(t, rebuildMinSize, c.cache.len(), "generation %d", generation)
+		require.Equal(t, rebuildMinSize, c.cache.peak, "generation %d: peak must track live size", generation)
+		require.Equal(t, identity, mapIdentity(c.cache.entries),
+			"generation %d: full churn must not rebuild the map", generation)
+	}
+
+	// Only the current generation is retained.
+	require.Equal(t, rebuildMinSize, c.cache.len())
+}

--- a/internal/component/discovery/relabel/metrics.go
+++ b/internal/component/discovery/relabel/metrics.go
@@ -1,0 +1,38 @@
+package relabel
+
+import (
+	prometheus_client "github.com/prometheus/client_golang/prometheus"
+
+	"github.com/grafana/alloy/internal/util"
+)
+
+type metrics struct {
+	cacheHits   prometheus_client.Counter
+	cacheMisses prometheus_client.Counter
+	cacheSize   prometheus_client.Gauge
+}
+
+func newMetrics(reg prometheus_client.Registerer) *metrics {
+	m := metrics{
+		cacheHits: prometheus_client.NewCounter(prometheus_client.CounterOpts{
+			Name: "alloy_discovery_relabel_cache_hits_total",
+			Help: "Total number of targets whose relabeling result was reused from the cache",
+		}),
+		cacheMisses: prometheus_client.NewCounter(prometheus_client.CounterOpts{
+			Name: "alloy_discovery_relabel_cache_misses_total",
+			Help: "Total number of targets that had to be relabeled",
+		}),
+		cacheSize: prometheus_client.NewGauge(prometheus_client.GaugeOpts{
+			Name: "alloy_discovery_relabel_cache_size",
+			Help: "Number of targets currently held in the relabeling cache",
+		}),
+	}
+
+	if reg != nil {
+		m.cacheHits = util.MustRegisterOrGet(reg, m.cacheHits).(prometheus_client.Counter)
+		m.cacheMisses = util.MustRegisterOrGet(reg, m.cacheMisses).(prometheus_client.Counter)
+		m.cacheSize = util.MustRegisterOrGet(reg, m.cacheSize).(prometheus_client.Gauge)
+	}
+
+	return &m
+}

--- a/internal/component/discovery/relabel/relabel.go
+++ b/internal/component/discovery/relabel/relabel.go
@@ -46,6 +46,14 @@ type Component struct {
 
 	mut sync.RWMutex
 
+	// cache memoises the relabeling result per target, keyed on the target's
+	// packed labels. Guarded by mut.
+	cache *targetCache
+	// rules is a snapshot of the rules the cached results were produced with.
+	rules []ruleSnapshot
+
+	metrics *metrics
+
 	debugDataPublisher livedebugging.DebugDataPublisher
 }
 
@@ -60,6 +68,8 @@ func New(o component.Options, args Arguments) (*Component, error) {
 	}
 	c := &Component{
 		opts:               o,
+		cache:              newTargetCache(),
+		metrics:            newMetrics(o.Registerer),
 		debugDataPublisher: debugDataPublisher.(livedebugging.DebugDataPublisher),
 	}
 
@@ -83,27 +93,86 @@ func (c *Component) Update(args component.Arguments) error {
 	defer c.mut.Unlock()
 
 	newArgs := args.(Arguments)
+	componentID := livedebugging.ComponentID(c.opts.ID)
+
+	// With no rules every target passes through unchanged, so there is nothing
+	// worth caching. Drop anything cached previously so that a config that removes
+	// its rules does not keep the memory.
+	if len(newArgs.RelabelConfigs) == 0 {
+		if c.cache.len() > 0 {
+			c.cache.clear()
+		}
+		c.rules = nil
+		c.metrics.cacheSize.Set(0)
+
+		targets := make([]discovery.Target, len(newArgs.Targets))
+		copy(targets, newArgs.Targets)
+		for _, t := range targets {
+			c.debugDataPublisher.PublishIfActive(livedebugging.NewData(
+				componentID,
+				livedebugging.Target,
+				1,
+				func() string { return fmt.Sprintf("%s => %s", t, t) },
+			))
+		}
+		c.opts.OnStateChange(Exports{Output: targets, Rules: newArgs.RelabelConfigs})
+		return nil
+	}
+
+	// Cached results are only valid for the rules that produced them.
+	rules := snapshotRules(newArgs.RelabelConfigs)
+	if rulesChanged(c.rules, rules) {
+		c.cache.clear()
+		c.rules = rules
+	}
 
 	targets := make([]discovery.Target, 0, len(newArgs.Targets))
 
+	c.cache.begin()
+	var hits, misses int
 	for _, t := range newArgs.Targets {
-		var (
-			relabelled discovery.Target
-			builder    = discovery.NewTargetBuilderFrom(t)
-			keep       = alloy_relabel.ProcessBuilder(builder, newArgs.RelabelConfigs...)
-		)
-		if keep {
-			relabelled = builder.Target()
-			targets = append(targets, relabelled)
+		key := t.CacheKey()
+		entry, cached := c.cache.lookup(key)
+		if cached {
+			hits++
+		} else {
+			misses++
+			var (
+				relabelled discovery.Target
+				builder    = discovery.NewTargetBuilderFrom(t)
+				keep       = alloy_relabel.ProcessBuilder(builder, newArgs.RelabelConfigs...)
+			)
+			if keep {
+				relabelled = builder.Target()
+			}
+			entry = c.cache.insert(key, relabelled, keep)
 		}
-		componentID := livedebugging.ComponentID(c.opts.ID)
+
+		if entry.keep {
+			targets = append(targets, entry.output)
+		}
+
+		// Capture the entry rather than the loop variable so that the message is
+		// built from this target's result if live debugging is active.
+		e := entry
 		c.debugDataPublisher.PublishIfActive(livedebugging.NewData(
 			componentID,
 			livedebugging.Target,
 			1,
-			func() string { return fmt.Sprintf("%s => %s", t, relabelled) },
+			func() string {
+				var relabelled discovery.Target
+				if e.keep {
+					relabelled = e.output
+				}
+				return fmt.Sprintf("%s => %s", t, relabelled)
+			},
 		))
 	}
+	c.cache.end()
+
+	c.metrics.cacheHits.Add(float64(hits))
+	c.metrics.cacheMisses.Add(float64(misses))
+	c.metrics.cacheSize.Set(float64(c.cache.len()))
 
 	c.opts.OnStateChange(Exports{
 		Output: targets,

--- a/internal/component/discovery/target.go
+++ b/internal/component/discovery/target.go
@@ -13,21 +13,147 @@ import (
 	modellabels "github.com/prometheus/prometheus/model/labels"
 	"golang.org/x/exp/maps"
 
+	"github.com/grafana/alloy/internal/component/discovery/internal/labelpack"
 	"github.com/grafana/alloy/internal/runtime/equality"
 	"github.com/grafana/alloy/syntax"
 )
 
+// groupLabels holds the labels that a Target shares with all the other targets
+// that came from the same service discovery target group. It is referenced by
+// pointer from every such Target, so the packed labels are stored once per group
+// rather than once per target.
+//
+// A nil *groupLabels means "no group labels" and all its methods are safe to
+// call on a nil receiver.
+type groupLabels struct {
+	packed labelpack.Labels
+	n      int
+
+	// hash is the hash of packed on its own, computed eagerly because a group is
+	// shared by many targets and each of them needs it in
+	// ComponentTargetsToPromTargetGroupsForSingleJob.
+	hash uint64
+
+	// ls is the LabelSet view of packed, materialised on first use. It is only
+	// needed when converting back into Prometheus target groups, so most groups
+	// never build it.
+	lsOnce sync.Once
+	ls     commonlabels.LabelSet
+}
+
+// newGroupLabels packs ls into a groupLabels. It returns nil if ls holds no
+// labels that survive normalisation, so that targets without group labels do not
+// pay for an allocation.
+func newGroupLabels(ls commonlabels.LabelSet) *groupLabels {
+	if len(ls) == 0 {
+		return nil
+	}
+	packed, n := labelpack.FromLabelSet(ls)
+	return newGroupLabelsFromPacked(packed, n)
+}
+
+func newGroupLabelsFromPacked(packed labelpack.Labels, n int) *groupLabels {
+	if n == 0 {
+		return nil
+	}
+	return &groupLabels{
+		packed: packed,
+		n:      n,
+		hash:   hashLabels(packed, labelpack.Empty, nil),
+	}
+}
+
+func (g *groupLabels) labels() labelpack.Labels {
+	if g == nil {
+		return labelpack.Empty
+	}
+	return g.packed
+}
+
+func (g *groupLabels) len() int {
+	if g == nil {
+		return 0
+	}
+	return g.n
+}
+
+// labelSet returns the group labels as a LabelSet. The result is cached, and
+// must not be mutated by callers.
+func (g *groupLabels) labelSet() commonlabels.LabelSet {
+	if g == nil {
+		return commonlabels.LabelSet{}
+	}
+	g.lsOnce.Do(func() {
+		g.ls = make(commonlabels.LabelSet, g.n)
+		g.packed.Range(func(name, value string) bool {
+			g.ls[commonlabels.LabelName(name)] = commonlabels.LabelValue(value)
+			return true
+		})
+	})
+	return g.ls
+}
+
+// withoutEmptyIn returns g with every label removed whose name is mapped to an
+// empty value in own. Setting a label to an empty value means deleting it, so
+// such a group label must not shine through. g is returned unchanged when there
+// is nothing to remove, which is the overwhelmingly common case and keeps the
+// group shared between targets.
+func (g *groupLabels) withoutEmptyIn(own commonlabels.LabelSet) *groupLabels {
+	if g == nil || len(own) == 0 {
+		return g
+	}
+
+	// Cheap scan first: only build a derived group if a deletion actually
+	// applies.
+	tombstoned := false
+	for name, value := range own {
+		if value == "" && g.packed.Has(string(name)) {
+			tombstoned = true
+			break
+		}
+	}
+	if !tombstoned {
+		return g
+	}
+
+	pairs := make([]labelpack.Pair, 0, g.n)
+	g.packed.Range(func(name, value string) bool {
+		if ownValue, ok := own[commonlabels.LabelName(name)]; ok && ownValue == "" {
+			return true
+		}
+		pairs = append(pairs, labelpack.Pair{Name: name, Value: value})
+		return true
+	})
+	return newGroupLabelsFromPacked(labelpack.FromPairs(pairs))
+}
+
+// Target is an immutable set of labels describing something to collect from.
+//
+// Labels are stored in two packed, name-sorted string buffers: group holds the
+// labels shared with every other target from the same service discovery target
+// group, and own holds the labels specific to this target. A label present in
+// own shadows the label of the same name in group.
+//
+// Labels with an empty name or an empty value are dropped at construction. An
+// empty value is indistinguishable from an absent label in this representation,
+// which matches how Prometheus and TargetBuilder already behave.
 type Target struct {
-	group commonlabels.LabelSet
-	own   commonlabels.LabelSet
-	size  int
+	// Keep Target non-comparable. Comparing two Targets with == would compile
+	// once the label storage is a pointer and a string, but it would be wrong:
+	// two Targets holding identical labels can have different group pointers.
+	// Callers must use EqualsTarget instead. This field must stay first, so that
+	// it does not add trailing padding to the struct.
+	_ [0]func()
+
+	group *groupLabels
+	own   labelpack.Labels
+	size  int32
 }
 
 var (
 	seps = []byte{'\xff'}
 	// used in tests to simulate hash conflicts
 	labelSetEqualsFn = func(l1, l2 commonlabels.LabelSet) bool { return &l1 == &l2 || l1.Equal(l2) }
-	stringSlicesPool = sync.Pool{New: func() any { return make([]string, 0, 20) }}
 
 	_ syntax.Capsule                = Target{}
 	_ syntax.ConvertibleIntoCapsule = Target{}
@@ -35,72 +161,60 @@ var (
 	_ equality.CustomEquality       = Target{}
 )
 
-func borrowLabelsSlice() []string {
-	return stringSlicesPool.Get().([]string)
-}
-
-func releaseLabelsSlice(labels []string) {
-	// We can ignore linter warning here, because slice headers are small and the underlying array will be reused.
-	stringSlicesPool.Put(labels[:0]) //nolint:staticcheck // SA6002
-}
-
-var EmptyTarget = Target{
-	group: commonlabels.LabelSet{},
-	own:   commonlabels.LabelSet{},
-	size:  0,
-}
+// EmptyTarget is a Target with no labels. It is equal to the zero value.
+var EmptyTarget = Target{}
 
 func NewTargetFromLabelSet(ls commonlabels.LabelSet) Target {
 	return NewTargetFromSpecificAndBaseLabelSet(ls, nil)
 }
 
 func NewTargetFromSpecificAndBaseLabelSet(own, group commonlabels.LabelSet) Target {
-	if group == nil {
-		group = commonlabels.LabelSet{}
-	}
-	if own == nil {
-		own = commonlabels.LabelSet{}
-	}
-	ret := Target{
+	return newTargetFromGroup(newGroupLabels(group), own)
+}
+
+// newTargetFromGroup builds a Target from an already packed group. Callers that
+// create many targets sharing the same group labels should pack the group once
+// and reuse it here, so that the group labels are stored once rather than once
+// per target.
+func newTargetFromGroup(group *groupLabels, own commonlabels.LabelSet) Target {
+	ownPacked, _ := labelpack.FromLabelSet(own)
+	// An empty value in own deletes the label, including one inherited from the
+	// group, so the group may need narrowing for this target.
+	group = group.withoutEmptyIn(own)
+	return newTarget(group, ownPacked)
+}
+
+func newTarget(group *groupLabels, own labelpack.Labels) Target {
+	return Target{
 		group: group,
 		own:   own,
+		size:  int32(labelpack.MergedLen(group.labels(), own)),
 	}
-	size := 0
-	ret.ForEachLabel(func(key string, value string) bool {
-		size++
-		return true
-	})
-	ret.size = size
-	return ret
 }
 
 // NewTargetFromModelLabels creates a target from model Labels.
-// NOTE: this is not optimised and should be avoided on a hot path.
 func NewTargetFromModelLabels(labels modellabels.Labels) Target {
-	l := make(commonlabels.LabelSet, labels.Len())
+	pairs := make([]labelpack.Pair, 0, labels.Len())
 	labels.Range(func(label modellabels.Label) {
-		l[commonlabels.LabelName(label.Name)] = commonlabels.LabelValue(label.Value)
+		pairs = append(pairs, labelpack.Pair{Name: label.Name, Value: label.Value})
 	})
-	return NewTargetFromLabelSet(l)
+	packed, n := labelpack.FromPairs(pairs)
+	return Target{own: packed, size: int32(n)}
 }
 
 func NewTargetFromMap(m map[string]string) Target {
-	l := make(commonlabels.LabelSet, len(m))
-	for k, v := range m {
-		l[commonlabels.LabelName(k)] = commonlabels.LabelValue(v)
-	}
-	return NewTargetFromLabelSet(l)
+	packed, n := labelpack.FromMap(m)
+	return Target{own: packed, size: int32(n)}
 }
 
-// PromLabels converts this target into prometheus/prometheus/model/labels.Labels. It is not efficient and should be
-// avoided on a hot path.
+// PromLabels converts this target into prometheus/prometheus/model/labels.Labels.
 func (t Target) PromLabels() modellabels.Labels {
 	builder := modellabels.NewScratchBuilder(t.Len())
+	// Labels are already in ascending name order, so there is no need to sort.
 	t.ForEachLabel(func(key string, value string) bool {
 		builder.Add(key, value)
 		return true
 	})
-	builder.Sort()
 	return builder.Labels()
 }
 
@@ -121,25 +235,7 @@ func (t Target) NonReservedLabelSet() commonlabels.LabelSet {
 // returns true if all the labels were iterated over or false if any call to f has interrupted the iteration.
 // ForEachLabel does not guarantee iteration order or sort labels in any way.
 func (t Target) ForEachLabel(f func(key string, value string) bool) bool {
-	for k, v := range t.own {
-		if !f(string(k), string(v)) {
-			// f has returned false, interrupt the iteration and return false.
-			return false
-		}
-	}
-	// Now go over the group ones only if they were not part of own labels
-	for k, v := range t.group {
-		if _, ok := t.own[k]; ok {
-			continue
-		}
-		if !f(string(k), string(v)) {
-			// f has returned false, interrupt the iteration and return false.
-			return false
-		}
-	}
-
-	// We finished the iteration, return true.
-	return true
+	return labelpack.RangeMerged(t.group.labels(), t.own, f)
 }
 
 // AsMap returns target's labels as a map of strings.
@@ -154,29 +250,36 @@ func (t Target) AsMap() map[string]string {
 }
 
 func (t Target) Get(key string) (string, bool) {
-	lv, ok := t.own[commonlabels.LabelName(key)]
-	if ok {
-		return string(lv), ok
+	if value, ok := t.own.Get(key); ok {
+		return value, true
 	}
-	lv, ok = t.group[commonlabels.LabelName(key)]
-	return string(lv), ok
+	return t.group.labels().Get(key)
 }
 
 // LabelSet converts this target in to a LabelSet
 // Deprecated: this is not optimised and should be avoided if possible.
 func (t Target) LabelSet() commonlabels.LabelSet {
 	merged := make(commonlabels.LabelSet, t.Len())
-	for k, v := range t.group {
-		merged[k] = v
-	}
-	for k, v := range t.own {
-		merged[k] = v
-	}
+	t.ForEachLabel(func(key string, value string) bool {
+		merged[commonlabels.LabelName(key)] = commonlabels.LabelValue(value)
+		return true
+	})
 	return merged
 }
 
+// ownLabelSet returns only the labels specific to this target, excluding the
+// ones inherited from its group.
+func (t Target) ownLabelSet() commonlabels.LabelSet {
+	own := make(commonlabels.LabelSet, t.Len()-t.group.len())
+	t.own.Range(func(name, value string) bool {
+		own[commonlabels.LabelName(name)] = commonlabels.LabelValue(value)
+		return true
+	})
+	return own
+}
+
 func (t Target) Len() int {
-	return t.size
+	return int(t.size)
 }
 
 // AlloyCapsule marks FastTarget as a capsule so Alloy syntax can marshal to or from it.
@@ -212,7 +315,7 @@ func (t Target) ConvertInto(dst any) error {
 func (t *Target) ConvertFrom(src any) error {
 	switch src := src.(type) {
 	case map[string]syntax.Value:
-		labelSet := make(commonlabels.LabelSet, len(src))
+		pairs := make([]labelpack.Pair, 0, len(src))
 		for k, v := range src {
 			var strValue string
 			switch {
@@ -223,23 +326,28 @@ func (t *Target) ConvertFrom(src any) error {
 			default:
 				return fmt.Errorf("target::ConvertFrom: cannot convert value that can't be interfaced to (e.g. unexported struct field)")
 			}
-			labelSet[commonlabels.LabelName(k)] = commonlabels.LabelValue(strValue)
+			pairs = append(pairs, labelpack.Pair{Name: k, Value: strValue})
 		}
-		*t = NewTargetFromLabelSet(labelSet)
+		packed, n := labelpack.FromPairs(pairs)
+		*t = Target{own: packed, size: int32(n)}
 		return nil
 	default: // handle all other types of maps via reflection as Go generics don't support generics in switch/case.
 		rv := reflect.ValueOf(src)
 		switch rv.Kind() {
 		case reflect.Map:
-			labelSet := make(commonlabels.LabelSet, rv.Len())
+			pairs := make([]labelpack.Pair, 0, rv.Len())
 			for _, key := range rv.MapKeys() {
 				value := rv.MapIndex(key)
 				if !value.CanInterface() || !key.CanInterface() {
 					return fmt.Errorf("target::ConvertFrom: conversion from '%T' is not supported", src)
 				}
-				labelSet[commonlabels.LabelName(fmt.Sprintf("%v", key.Interface()))] = commonlabels.LabelValue(fmt.Sprintf("%v", value.Interface()))
+				pairs = append(pairs, labelpack.Pair{
+					Name:  fmt.Sprintf("%v", key.Interface()),
+					Value: fmt.Sprintf("%v", value.Interface()),
+				})
 			}
-			*t = NewTargetFromLabelSet(labelSet)
+			packed, n := labelpack.FromPairs(pairs)
+			*t = Target{own: packed, size: int32(n)}
 			return nil
 		default:
 			return fmt.Errorf("target::ConvertFrom: conversion from '%T' is not supported", src)
@@ -248,13 +356,20 @@ func (t *Target) ConvertFrom(src any) error {
 }
 
 func (t Target) String() string {
-	s := make([]string, 0, t.Len())
+	// Labels are already in ascending name order, so there is no need to sort.
+	sb := strings.Builder{}
+	sb.WriteString("{")
+	first := true
 	t.ForEachLabel(func(key string, value string) bool {
-		s = append(s, fmt.Sprintf("%q=%q", key, value))
+		if !first {
+			sb.WriteString(", ")
+		}
+		first = false
+		fmt.Fprintf(&sb, "%q=%q", key, value)
 		return true
 	})
-	slices.Sort(s)
-	return fmt.Sprintf("{%s}", strings.Join(s, ", "))
+	sb.WriteString("}")
+	return sb.String()
 }
 
 // Equals implements equality.CustomEquality. Works only with pointers.
@@ -266,17 +381,19 @@ func (t Target) Equals(other any) bool {
 }
 
 func (t Target) EqualsTarget(other *Target) bool {
-	if t.Len() != other.Len() {
+	// Fast path: targets that share a group pointer and have identical own labels
+	// are equal without decoding anything. This is the common case when checking
+	// whether a component's exports changed, since a relabel step that changes
+	// nothing reuses both the group pointer and the own buffer.
+	if t.group == other.group && t.own == other.own {
+		return true
+	}
+	if t.size != other.size {
 		return false
 	}
-	finished := t.ForEachLabel(func(key string, value string) bool {
-		otherValue, ok := other.Get(key)
-		if !ok || otherValue != value {
-			return false
-		}
-		return true
-	})
-	return finished
+	// Otherwise walk both merged views in lockstep. Both are sorted by name, so
+	// this is linear rather than a lookup per label.
+	return labelpack.EqualMerged(t.group.labels(), t.own, other.group.labels(), other.own)
 }
 
 func (t Target) NonMetaLabelsHash() uint64 {
@@ -292,64 +409,110 @@ func (t Target) SpecificLabelsHash(labelNames []string) uint64 {
 }
 
 func (t Target) HashLabelsWithPredicate(pred func(key string) bool) uint64 {
-	// For hash to be deterministic, we need labels order to be deterministic too. Figure this out first.
-	labelsInOrder := borrowLabelsSlice()
-	defer func() { releaseLabelsSlice(labelsInOrder) }()
-	t.ForEachLabel(func(key string, value string) bool {
-		if pred(key) {
-			labelsInOrder = append(labelsInOrder, key)
-		}
-		return true
-	})
-	slices.Sort(labelsInOrder)
-	return t.hashLabelsInOrder(labelsInOrder)
+	return hashLabels(t.group.labels(), t.own, pred)
 }
 
+// groupLabelsHash hashes only the labels this target inherits from its group,
+// but resolves their values through the target, so that a label overridden in
+// own changes the hash. Targets with the same group labels hash can be sent to
+// Prometheus as a single target group with shared labels.
 func (t Target) groupLabelsHash() uint64 {
-	// For hash to be deterministic, we need labels order to be deterministic too. Figure this out first.
-	labelsInOrder := borrowLabelsSlice()
-	defer func() { releaseLabelsSlice(labelsInOrder) }()
-
-	for name := range t.group {
-		labelsInOrder = append(labelsInOrder, string(name))
+	group := t.group.labels()
+	if group.IsEmpty() {
+		return hashLabels(labelpack.Empty, labelpack.Empty, nil)
 	}
-	slices.Sort(labelsInOrder)
-	return t.hashLabelsInOrder(labelsInOrder)
+	// When own cannot override any group label, the hash is just the group's own
+	// hash, which was computed once when the group was packed.
+	if !labelpack.Overlaps(group, t.own) {
+		return t.group.hash
+	}
+	// Hash the group's names, taking values from own where it overrides them.
+	return hashShadowedLabels(group, t.own)
 }
 
 // NOTE 1: This function is copied from Prometheus codebase (labels.StableHash()) and adapted to work correctly with Alloy types.
 // NOTE 2: It is important to keep the hashing function consistent between Alloy versions in order to have smooth clustering
 // rollouts without duplicated or missing scraping of targets. There are tests to verify this behaviour. Do not change it.
-func (t Target) hashLabelsInOrder(order []string) uint64 {
+//
+// hashLabels hashes the merged group and own labels, in ascending name order,
+// keeping only the labels for which pred returns true. A nil pred keeps all of
+// them.
+func hashLabels(group, own labelpack.Labels, pred func(key string) bool) uint64 {
 	// This optimisation is adapted from prometheus/model/labels.
 	// Use xxhash.Sum64(b) for fast path as it's faster.
 	b := make([]byte, 0, 1024)
-	mustGet := func(label string) string {
-		val, _ := t.Get(label)
-		// if val is not found it would mean there is a bug and Target is no longer immutable. But we can still provide
-		// a consistent hashing behaviour by returning empty string we got from Get.
-		return val
-	}
+	var h *xxhash.Digest
 
-	for i, key := range order {
-		value := mustGet(key)
-		if len(b)+len(key)+len(value)+2 >= cap(b) {
-			// If labels entry is 1KB+ do not allocate whole entry.
-			h := xxhash.New()
-			_, _ = h.Write(b)
-			for _, key := range order[i:] {
-				_, _ = h.WriteString(key)
-				_, _ = h.Write(seps)
-				_, _ = h.WriteString(mustGet(key))
-				_, _ = h.Write(seps)
-			}
-			return h.Sum64()
+	labelpack.RangeMerged(group, own, func(key, value string) bool {
+		if pred != nil && !pred(key) {
+			return true
 		}
-
+		if h == nil && len(b)+len(key)+len(value)+2 >= cap(b) {
+			// If labels entry is 1KB+, switch to the streaming API and copy in
+			// everything hashed so far.
+			h = xxhash.New()
+			_, _ = h.Write(b)
+		}
+		if h != nil {
+			_, _ = h.WriteString(key)
+			_, _ = h.Write(seps)
+			_, _ = h.WriteString(value)
+			_, _ = h.Write(seps)
+			return true
+		}
 		b = append(b, key...)
 		b = append(b, seps[0])
 		b = append(b, value...)
 		b = append(b, seps[0])
+		return true
+	})
+
+	if h != nil {
+		return h.Sum64()
+	}
+	return xxhash.Sum64(b)
+}
+
+// hashShadowedLabels hashes the names of group, in ascending order, taking each
+// value from own where own holds the same name. It must produce the same bytes
+// as hashLabels for the equivalent label set.
+func hashShadowedLabels(group, own labelpack.Labels) uint64 {
+	b := make([]byte, 0, 1024)
+	var h *xxhash.Digest
+
+	ownIter := own.Iter()
+	ownName, ownValue, ownOK := ownIter.Next()
+
+	group.Range(func(key, value string) bool {
+		// Advance own until it reaches or passes key. Both sides are sorted by
+		// name, so this is a single pass over each.
+		for ownOK && ownName < key {
+			ownName, ownValue, ownOK = ownIter.Next()
+		}
+		if ownOK && ownName == key {
+			value = ownValue
+		}
+
+		if h == nil && len(b)+len(key)+len(value)+2 >= cap(b) {
+			h = xxhash.New()
+			_, _ = h.Write(b)
+		}
+		if h != nil {
+			_, _ = h.WriteString(key)
+			_, _ = h.Write(seps)
+			_, _ = h.WriteString(value)
+			_, _ = h.Write(seps)
+			return true
+		}
+		b = append(b, key...)
+		b = append(b, seps[0])
+		b = append(b, value...)
+		b = append(b, seps[0])
+		return true
+	})
+
+	if h != nil {
+		return h.Sum64()
 	}
 	return xxhash.Sum64(b)
 }
@@ -377,16 +540,16 @@ func ComponentTargetsToPromTargetGroupsForSingleJob(jobName string, tgs []Target
 		// targetIndices = indices of all the targets that have the same group labels hash
 		targetIndices := targetIndWithCommonGroupLabels[hash]
 		// since we grouped them by their group labels hash, their group labels should all be the same (except for hash collision handled below)
-		sharedLabels := tgs[targetIndices[0]].group
+		sharedLabels := tgs[targetIndices[0]].group.labelSet()
 		individualLabels := make([]commonlabels.LabelSet, 0, len(targetIndices))
 		for _, ind := range targetIndices {
 			target := tgs[ind]
 			// detect hash collisions - we'll append them separately - it's still correct, just may be less efficient
-			if !labelSetEqualsFn(sharedLabels, target.group) {
+			if !labelSetEqualsFn(sharedLabels, target.group.labelSet()) {
 				hashConflicts = append(hashConflicts, target.LabelSet())
 				continue
 			}
-			individualLabels = append(individualLabels, target.own)
+			individualLabels = append(individualLabels, target.ownLabelSet())
 		}
 
 		if len(individualLabels) != 0 {

--- a/internal/component/discovery/target.go
+++ b/internal/component/discovery/target.go
@@ -406,20 +406,21 @@ func (t Target) EqualsTarget(other *Target) bool {
 // and own buffers have different keys, so a cache keyed on this may miss where a
 // label comparison would have matched. A miss only costs recomputation.
 type TargetCacheKey struct {
-	group *groupLabels
+	group labelpack.Labels
 	own   labelpack.Labels
 }
 
 // CacheKey returns a comparable key identifying this target's labels, for use as
 // a map key when memoising work per target.
 //
-// This is cheap: the group is compared by pointer and the own labels by their
-// already-packed string, so no labels are decoded and nothing is allocated.
-// Targets discovered together share a group pointer, and a target that came
-// through service discovery or relabeling unchanged keeps the same own buffer, so
-// unchanged targets produce equal keys.
+// The key holds the two packed label buffers, so no labels are decoded and
+// nothing is allocated. It deliberately compares the group by its contents rather
+// than by pointer: service discovery mechanisms built on refresh, which is most of
+// them, rebuild every target group on every refresh, so an unchanged group arrives
+// as a new allocation with identical contents. Keying on the pointer made every
+// target of such a mechanism miss.
 func (t Target) CacheKey() TargetCacheKey {
-	return TargetCacheKey{group: t.group, own: t.own}
+	return TargetCacheKey{group: t.group.labels(), own: t.own}
 }
 
 func (t Target) NonMetaLabelsHash() uint64 {

--- a/internal/component/discovery/target.go
+++ b/internal/component/discovery/target.go
@@ -396,6 +396,32 @@ func (t Target) EqualsTarget(other *Target) bool {
 	return labelpack.EqualMerged(t.group.labels(), t.own, other.group.labels(), other.own)
 }
 
+// TargetCacheKey identifies the labels of a Target and can be used as a map key.
+// It is only meaningful as an opaque key: use Target.EqualsTarget to compare
+// targets for equality.
+//
+// Two Targets with equal keys always have the same labels, which is what makes
+// the key safe to memoise a per-target computation on. The converse does not
+// hold: two Targets with the same labels split differently between their group
+// and own buffers have different keys, so a cache keyed on this may miss where a
+// label comparison would have matched. A miss only costs recomputation.
+type TargetCacheKey struct {
+	group *groupLabels
+	own   labelpack.Labels
+}
+
+// CacheKey returns a comparable key identifying this target's labels, for use as
+// a map key when memoising work per target.
+//
+// This is cheap: the group is compared by pointer and the own labels by their
+// already-packed string, so no labels are decoded and nothing is allocated.
+// Targets discovered together share a group pointer, and a target that came
+// through service discovery or relabeling unchanged keeps the same own buffer, so
+// unchanged targets produce equal keys.
+func (t Target) CacheKey() TargetCacheKey {
+	return TargetCacheKey{group: t.group, own: t.own}
+}
+
 func (t Target) NonMetaLabelsHash() uint64 {
 	return t.HashLabelsWithPredicate(func(key string) bool {
 		return !strings.HasPrefix(key, commonlabels.MetaLabelPrefix)

--- a/internal/component/discovery/target_builder.go
+++ b/internal/component/discovery/target_builder.go
@@ -1,9 +1,12 @@
 package discovery
 
 import (
+	"slices"
+
 	commonlabels "github.com/prometheus/common/model"
 
 	"github.com/grafana/alloy/internal/component/common/relabel"
+	"github.com/grafana/alloy/internal/component/discovery/internal/labelpack"
 )
 
 type TargetBuilder interface {
@@ -12,114 +15,114 @@ type TargetBuilder interface {
 	MergeWith(Target) TargetBuilder
 }
 
+// targetBuilder accumulates changes to a Target without touching its packed
+// label buffers, then applies them all at once in Target(). It follows the same
+// model as prometheus/model/labels.Builder: pending additions and deletions are
+// kept in small slices, and the base labels are only re-encoded if something
+// actually changed.
+//
+// The zero value is not usable; use one of the constructors.
 type targetBuilder struct {
-	group commonlabels.LabelSet
-	own   commonlabels.LabelSet
+	group *groupLabels
+	own   labelpack.Labels
 
-	toAdd map[string]string
-	toDel map[string]struct{}
+	// add and del stay nil until something is actually changed, so relabel rules
+	// that only inspect labels allocate nothing beyond the builder itself.
+	add []labelpack.Pair
+	del []string
 }
 
 // NewTargetBuilder creates an empty labels builder.
 func NewTargetBuilder() TargetBuilder {
-	return targetBuilder{
-		group: nil,
-		own:   make(commonlabels.LabelSet),
-		toAdd: make(map[string]string),
-		toDel: make(map[string]struct{}),
-	}
+	return newTargetBuilder(nil, labelpack.Empty)
 }
 
 func NewTargetBuilderFrom(t Target) TargetBuilder {
-	return NewTargetBuilderFromLabelSets(t.group, t.own)
+	return newTargetBuilder(t.group, t.own)
 }
 
 func NewTargetBuilderFromLabelSets(group, own commonlabels.LabelSet) TargetBuilder {
-	toAdd := make(map[string]string)
-	toDel := make(map[string]struct{})
+	t := NewTargetFromSpecificAndBaseLabelSet(own, group)
+	return newTargetBuilder(t.group, t.own)
+}
 
-	// if we are given labels that are set to empty value, it should be treated as deleting them
-	for name, value := range group {
-		if len(value) == 0 { // if group has empty value
-			// and own doesn't override it OR overrides it with an empty value
-			if ownValue, ok := own[name]; !ok || len(ownValue) == 0 {
-				toDel[string(name)] = struct{}{} // mark label as deleted
-			}
-		}
-	}
-	for name, value := range own {
-		if len(value) == 0 {
-			toDel[string(name)] = struct{}{}
-		}
-	}
-
-	return targetBuilder{
+func newTargetBuilder(group *groupLabels, own labelpack.Labels) TargetBuilder {
+	return &targetBuilder{
 		group: group,
 		own:   own,
-		toAdd: toAdd,
-		toDel: toDel,
 	}
 }
 
-func (t targetBuilder) Get(label string) string {
-	if v, ok := t.toAdd[label]; ok {
-		return v
+func (t *targetBuilder) Get(label string) string {
+	// Del removes entries from add but Set does not remove from del, so add has
+	// to be checked first.
+	for _, p := range t.add {
+		if p.Name == label {
+			return p.Value
+		}
 	}
-	if _, ok := t.toDel[label]; ok {
+	if slices.Contains(t.del, label) {
 		return ""
 	}
-	lv, ok := t.own[commonlabels.LabelName(label)]
-	if ok {
-		return string(lv)
+	if value, ok := t.own.Get(label); ok {
+		return value
 	}
-	lv = t.group[commonlabels.LabelName(label)]
-	return string(lv)
+	value, _ := t.group.labels().Get(label)
+	return value
 }
 
-func (t targetBuilder) Range(f func(label string, value string)) {
-	for k, v := range t.toAdd {
-		f(k, v)
-	}
-	for k, v := range t.own {
-		if _, deleted := t.toDel[string(k)]; deleted {
-			continue // skip if it's deleted
+func (t *targetBuilder) Range(f func(label string, value string)) {
+	// Take a copy of add and del so that they are unaffected by calls to Set or
+	// Del from within f. Relabel rules such as labelmap, labeldrop and labelkeep
+	// mutate the builder while ranging over it. Stack-based arrays avoid a heap
+	// allocation in the common case.
+	var addStack [64]labelpack.Pair
+	var delStack [64]string
+	origAdd := append(addStack[:0], t.add...)
+	origDel := append(delStack[:0], t.del...)
+
+	labelpack.RangeMerged(t.group.labels(), t.own, func(label string, value string) bool {
+		if slices.Contains(origDel, label) {
+			return true // skip if it's deleted
 		}
-		if _, added := t.toAdd[string(k)]; added {
-			continue // skip if it was in toAdd
+		if containsName(origAdd, label) {
+			return true // skip if it was in add
 		}
-		f(string(k), string(v))
-	}
-	for k, v := range t.group {
-		if _, deleted := t.toDel[string(k)]; deleted {
-			continue // skip if it's deleted
-		}
-		if _, added := t.toAdd[string(k)]; added {
-			continue // skip if it was in toAdd
-		}
-		if _, inOwn := t.own[k]; inOwn {
-			continue // skip if it was in own
-		}
-		f(string(k), string(v))
+		f(label, value)
+		return true
+	})
+	for _, p := range origAdd {
+		f(p.Name, p.Value)
 	}
 }
 
-func (t targetBuilder) Set(label string, val string) {
+func (t *targetBuilder) Set(label string, val string) {
 	if val == "" { // Setting to empty is treated as deleting.
 		t.Del(label)
 		return
 	}
-	t.toAdd[label] = val
+	for i, p := range t.add {
+		if p.Name == label {
+			t.add[i].Value = val
+			return
+		}
+	}
+	t.add = append(t.add, labelpack.Pair{Name: label, Value: val})
 }
 
-func (t targetBuilder) Del(labels ...string) {
+func (t *targetBuilder) Del(labels ...string) {
 	for _, label := range labels {
-		t.toDel[label] = struct{}{}
 		// If we were adding one, may need to clean it up too.
-		delete(t.toAdd, label)
+		if i := indexOfName(t.add, label); i >= 0 {
+			t.add = slices.Delete(t.add, i, i+1)
+		}
+		if !slices.Contains(t.del, label) {
+			t.del = append(t.del, label)
+		}
 	}
 }
 
-func (t targetBuilder) MergeWith(target Target) TargetBuilder {
+func (t *targetBuilder) MergeWith(target Target) TargetBuilder {
 	// Not on a hot path, so doesn't really need to be optimised.
 	target.ForEachLabel(func(key string, value string) bool {
 		t.Set(key, value)
@@ -128,26 +131,28 @@ func (t targetBuilder) MergeWith(target Target) TargetBuilder {
 	return t
 }
 
-func (t targetBuilder) Target() Target {
-	if len(t.toAdd) == 0 && len(t.toDel) == 0 {
-		return NewTargetFromSpecificAndBaseLabelSet(t.own, t.group)
+func (t *targetBuilder) Target() Target {
+	if len(t.add) == 0 && len(t.del) == 0 {
+		// Nothing changed, so both packed buffers can be reused as they are.
+		return newTarget(t.group, t.own)
 	}
-	// Figure out if we need to modify own set
-	modifyOwn := false
-	if len(t.toAdd) > 0 { // if there is anything to add
-		modifyOwn = true
-	} else {
-		for label := range t.toDel { // if there is anything to delete
-			if _, ok := t.own[commonlabels.LabelName(label)]; ok {
+
+	// Figure out whether the own labels need re-encoding.
+	modifyOwn := len(t.add) > 0 // if there is anything to add
+	if !modifyOwn {
+		for _, label := range t.del { // if there is anything to delete
+			if t.own.Has(label) {
 				modifyOwn = true
 				break
 			}
 		}
 	}
 
+	// Figure out whether the group labels need re-encoding. Deleting a label the
+	// group provides has to narrow the group, otherwise it would shine through.
 	modifyGroup := false
-	for label := range t.toDel { // if there is anything to delete from group
-		if _, ok := t.group[commonlabels.LabelName(label)]; ok {
+	for _, label := range t.del {
+		if t.group.labels().Has(label) {
 			modifyGroup = true
 			break
 		}
@@ -159,29 +164,52 @@ func (t targetBuilder) Target() Target {
 	)
 
 	if modifyOwn {
-		newOwn = make(commonlabels.LabelSet, len(t.own)+len(t.toAdd))
-		for k, v := range t.own {
-			if _, ok := t.toDel[string(k)]; ok {
-				continue
+		pairs := make([]labelpack.Pair, 0, t.own.Len()+len(t.add))
+		t.own.Range(func(name, value string) bool {
+			if slices.Contains(t.del, name) {
+				return true
 			}
-			newOwn[k] = v
-		}
-		for k, v := range t.toAdd {
-			newOwn[commonlabels.LabelName(k)] = commonlabels.LabelValue(v)
-		}
+			if containsName(t.add, name) {
+				// The value from add wins and is appended below; skip it here so
+				// FromPairs does not have to de-duplicate.
+				return true
+			}
+			pairs = append(pairs, labelpack.Pair{Name: name, Value: value})
+			return true
+		})
+		pairs = append(pairs, t.add...)
+		newOwn, _ = labelpack.FromPairs(pairs)
 	}
+
 	if modifyGroup {
 		// TODO(thampiotr): When relabeling a lot of targets that require changes to t.group, we might produce a lot of
 		//  				t.groups that will be essentially the same. If this becomes a hot spot, it could be
 		//  				remediated with an extra step to consolidate them using perhaps a hash as an ID.
-		newGroup = make(commonlabels.LabelSet, len(t.group))
-		for k, v := range t.group {
-			if _, ok := t.toDel[string(k)]; ok {
-				continue
+		//  				The packed representation makes this straightforward: the packed string is a natural
+		//  				interning key.
+		pairs := make([]labelpack.Pair, 0, t.group.len())
+		t.group.labels().Range(func(name, value string) bool {
+			if slices.Contains(t.del, name) {
+				return true
 			}
-			newGroup[k] = v
-		}
+			pairs = append(pairs, labelpack.Pair{Name: name, Value: value})
+			return true
+		})
+		newGroup = newGroupLabelsFromPacked(labelpack.FromPairs(pairs))
 	}
 
-	return NewTargetFromSpecificAndBaseLabelSet(newOwn, newGroup)
+	return newTarget(newGroup, newOwn)
+}
+
+func containsName(pairs []labelpack.Pair, name string) bool {
+	return indexOfName(pairs, name) >= 0
+}
+
+func indexOfName(pairs []labelpack.Pair, name string) int {
+	for i, p := range pairs {
+		if p.Name == name {
+			return i
+		}
+	}
+	return -1
 }

--- a/internal/component/discovery/target_fuzz_test.go
+++ b/internal/component/discovery/target_fuzz_test.go
@@ -1,0 +1,258 @@
+package discovery
+
+import (
+	"strings"
+	"testing"
+
+	commonlabels "github.com/prometheus/common/model"
+	modellabels "github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+)
+
+// decodeFuzzLabels turns fuzzer bytes into a label map. Splitting on a separator
+// byte into alternating names and values lets the fuzzer reach duplicate names,
+// empty names and empty values easily.
+func decodeFuzzLabels(data []byte) map[string]string {
+	parts := strings.Split(string(data), "\x00")
+	out := map[string]string{}
+	for i := 0; i+1 < len(parts); i += 2 {
+		out[parts[i]] = parts[i+1]
+	}
+	return out
+}
+
+// referenceLabels is a naive map-based model of what a Target built from a group
+// and an own label set must contain. Group labels are inherited, own labels
+// override them, and a label with an empty name or an empty value is absent - so
+// an empty value in own deletes an inherited group label.
+func referenceLabels(group, own map[string]string) map[string]string {
+	ref := map[string]string{}
+	for name, value := range group {
+		if name == "" || value == "" {
+			continue
+		}
+		ref[name] = value
+	}
+	for name, value := range own {
+		if name == "" {
+			continue
+		}
+		if value == "" {
+			delete(ref, name)
+			continue
+		}
+		ref[name] = value
+	}
+	return ref
+}
+
+func labelSet(m map[string]string) commonlabels.LabelSet {
+	if m == nil {
+		return nil
+	}
+	ls := make(commonlabels.LabelSet, len(m))
+	for name, value := range m {
+		ls[commonlabels.LabelName(name)] = commonlabels.LabelValue(value)
+	}
+	return ls
+}
+
+// assertTargetMatches checks every Target accessor against the reference label
+// map.
+func assertTargetMatches(t *testing.T, target Target, want map[string]string) {
+	t.Helper()
+
+	require.Equal(t, len(want), target.Len(), "Len()")
+
+	got := map[string]string{}
+	prev := ""
+	first := true
+	finished := target.ForEachLabel(func(key, value string) bool {
+		if !first {
+			require.Less(t, prev, key, "labels must be iterated in ascending name order")
+		}
+		prev, first = key, false
+		_, dup := got[key]
+		require.False(t, dup, "label %q iterated twice", key)
+		got[key] = value
+		return true
+	})
+	require.True(t, finished, "ForEachLabel should report a complete iteration")
+	require.Equal(t, want, got, "ForEachLabel")
+
+	require.Equal(t, want, target.AsMap(), "AsMap")
+	require.Equal(t, labelSet(want), target.LabelSet(), "LabelSet")
+
+	for name, value := range want {
+		gotValue, ok := target.Get(name)
+		require.True(t, ok, "Get(%q) must find the label", name)
+		require.Equal(t, value, gotValue, "Get(%q)", name)
+	}
+
+	// PromLabels must be a faithful, sorted conversion, and the Alloy hash must
+	// agree with the Prometheus one. The latter is the clustering compatibility
+	// contract.
+	promLabels := target.PromLabels()
+	require.Equal(t, want, promLabels.Map(), "PromLabels")
+	require.NoError(t, promLabels.Validate(func(modellabels.Label) error { return nil }))
+	require.Equal(t,
+		modellabels.StableHash(promLabels),
+		target.HashLabelsWithPredicate(func(string) bool { return true }),
+		"alloy and prometheus hashes must match")
+
+	// A target built purely from the merged map must compare equal and hash
+	// identically, regardless of how the labels were split between group and own.
+	flat := NewTargetFromMap(want)
+	require.True(t, target.EqualsTarget(&flat), "target must equal its flattened form")
+	require.True(t, flat.EqualsTarget(&target), "equality must be symmetric")
+	require.Equal(t, flat.NonMetaLabelsHash(), target.NonMetaLabelsHash(),
+		"hash must not depend on the group/own split")
+	require.Equal(t, flat.String(), target.String(), "String must not depend on the group/own split")
+}
+
+// FuzzTargetFromGroupAndOwn checks Target against a naive map reference for
+// arbitrary group/own splits, including empty values that delete inherited
+// labels.
+func FuzzTargetFromGroupAndOwn(f *testing.F) {
+	f.Add([]byte("a\x001\x00b\x002"), []byte("a\x00override"))
+	f.Add([]byte("a\x001"), []byte("a\x00"))
+	f.Add([]byte("a\x001\x00b\x002"), []byte(""))
+	f.Add([]byte(""), []byte("a\x001"))
+	f.Add([]byte("\x00v"), []byte("\x00v"))
+	f.Add([]byte("a\x00"), []byte("a\x00"))
+	f.Add([]byte(strings.Repeat("x", 300)+"\x00v"), []byte("a\x001"))
+
+	f.Fuzz(func(t *testing.T, groupData, ownData []byte) {
+		groupMap := decodeFuzzLabels(groupData)
+		ownMap := decodeFuzzLabels(ownData)
+		want := referenceLabels(groupMap, ownMap)
+
+		target := NewTargetFromSpecificAndBaseLabelSet(labelSet(ownMap), labelSet(groupMap))
+		assertTargetMatches(t, target, want)
+
+		// A builder that changes nothing must round trip to an equal target.
+		roundTripped := NewTargetBuilderFrom(target).Target()
+		assertTargetMatches(t, roundTripped, want)
+		require.True(t, target.EqualsTarget(&roundTripped))
+	})
+}
+
+// FuzzTargetBuilder applies a sequence of Set and Del operations to a builder and
+// checks the result against both a naive map reference and the Prometheus
+// labels.Builder, which TargetBuilder is required to behave like.
+func FuzzTargetBuilder(f *testing.F) {
+	f.Add([]byte("a\x001\x00b\x002"), []byte("c\x003"), []byte("a\x00b"))
+	f.Add([]byte("a\x001"), []byte("a\x00"), []byte(""))
+	f.Add([]byte("a\x001"), []byte(""), []byte("a"))
+	f.Add([]byte("g\x001"), []byte("g\x002"), []byte("g"))
+
+	f.Fuzz(func(t *testing.T, groupData, setData, delData []byte) {
+		groupMap := decodeFuzzLabels(groupData)
+		setMap := decodeFuzzLabels(setData)
+		delNames := strings.Split(string(delData), "\x00")
+
+		// Prometheus rejects empty label names, and TargetBuilder drops them, so
+		// exclude them from the operations being compared.
+		for name := range setMap {
+			if name == "" {
+				delete(setMap, name)
+			}
+		}
+
+		apply := func(tb TargetBuilder) {
+			for name, value := range setMap {
+				tb.Set(name, value)
+			}
+			for _, name := range delNames {
+				if name == "" {
+					continue
+				}
+				tb.Del(name)
+			}
+		}
+
+		// Reference: start from the normalised group labels, then apply the same
+		// operations, where setting an empty value deletes.
+		want := referenceLabels(groupMap, nil)
+		for name, value := range setMap {
+			if value == "" {
+				delete(want, name)
+				continue
+			}
+			want[name] = value
+		}
+		for _, name := range delNames {
+			delete(want, name)
+		}
+
+		// The group/own split must not affect the outcome, so exercise all of
+		// them.
+		t.Run("all own", func(t *testing.T) {
+			tb := NewTargetBuilderFromLabelSets(nil, labelSet(groupMap))
+			apply(tb)
+			assertTargetMatches(t, tb.Target(), want)
+		})
+
+		t.Run("all group", func(t *testing.T) {
+			tb := NewTargetBuilderFromLabelSets(labelSet(groupMap), nil)
+			apply(tb)
+			assertTargetMatches(t, tb.Target(), want)
+		})
+
+		t.Run("prometheus builder", func(t *testing.T) {
+			// Cross-check against the Prometheus builder over the same inputs.
+			tb := newPromBuilderAdapter(modellabels.FromMap(referenceLabels(groupMap, nil)))
+			apply(tb)
+			assertTargetMatches(t, tb.Target(), want)
+		})
+	})
+}
+
+// FuzzTargetBuilderRangeMutation covers the relabel rules that mutate a builder
+// while ranging over it, such as labelmap, labeldrop and labelkeep. Labels set
+// during a Range must not be visited by that same Range.
+func FuzzTargetBuilderRangeMutation(f *testing.F) {
+	f.Add([]byte("a\x001\x00b\x002"), []byte("c\x003"))
+	f.Add([]byte("prefix_a\x001"), []byte(""))
+	f.Add([]byte(""), []byte(""))
+	f.Add([]byte("a\x001"), []byte("a\x00"))
+
+	f.Fuzz(func(t *testing.T, groupData, ownData []byte) {
+		groupMap := decodeFuzzLabels(groupData)
+		ownMap := decodeFuzzLabels(ownData)
+
+		build := func() TargetBuilder {
+			return NewTargetBuilderFromLabelSets(labelSet(groupMap), labelSet(ownMap))
+		}
+
+		// labelmap: copy every label to a prefixed name while ranging.
+		alloy := build()
+		var visited []string
+		alloy.Range(func(label, value string) {
+			visited = append(visited, label)
+			alloy.Set("mapped_"+label, value)
+		})
+
+		base := referenceLabels(groupMap, ownMap)
+		wantVisited := make([]string, 0, len(base))
+		for name := range base {
+			wantVisited = append(wantVisited, name)
+		}
+		require.ElementsMatch(t, wantVisited, visited,
+			"Range must visit exactly the base labels, and must not visit labels Set during the Range")
+
+		want := map[string]string{}
+		for name, value := range base {
+			want[name] = value
+			want["mapped_"+name] = value
+		}
+		assertTargetMatches(t, alloy.Target(), want)
+
+		// labeldrop: delete every label while ranging.
+		dropped := build()
+		dropped.Range(func(label, value string) {
+			dropped.Del(label)
+		})
+		assertTargetMatches(t, dropped.Target(), map[string]string{})
+	})
+}

--- a/internal/component/discovery/target_layout_test.go
+++ b/internal/component/discovery/target_layout_test.go
@@ -1,0 +1,132 @@
+package discovery
+
+import (
+	"reflect"
+	"testing"
+	"unsafe"
+
+	commonlabels "github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTargetIsNotComparable guards the [0]func() field in Target.
+//
+// Now that labels are stored as a pointer and a string rather than as maps,
+// Target would otherwise be comparable, and == would compile while being wrong:
+// two targets holding identical labels can reference different groupLabels, and
+// two targets with the same labels split differently between group and own have
+// different field values. Callers must use EqualsTarget.
+//
+// This also keeps Target out of map keys, which the compiler previously
+// prevented.
+func TestTargetIsNotComparable(t *testing.T) {
+	require.False(t, reflect.TypeOf(Target{}).Comparable(),
+		"Target must not be comparable; keep the [0]func() field so that == and map keys stay compile errors")
+}
+
+// TestTargetSize documents the size of a Target, since holding hundreds of
+// thousands of them is a normal workload. It is a pointer, a string header and an
+// int32, so 8+16+4 rounded up to the alignment of a pointer.
+//
+// The [0]func() field must stay first: a zero-size field at the end of a struct
+// gets trailing padding added, which would make Target larger for no reason.
+func TestTargetSize(t *testing.T) {
+	require.Equal(t, uintptr(32), unsafe.Sizeof(Target{}),
+		"unexpected Target size; ensure the zero-size field stays first so it adds no padding")
+}
+
+// TestZeroValueTargetIsUsable checks that the zero value behaves as an empty
+// target. Code outside this package constructs Target{} and passes it to
+// NewTargetBuilderFrom, so a nil group and an empty packed buffer must be valid
+// everywhere.
+func TestZeroValueTargetIsUsable(t *testing.T) {
+	var zero Target
+
+	require.Equal(t, 0, zero.Len())
+	require.Equal(t, "{}", zero.String())
+	require.Empty(t, zero.AsMap())
+	require.Empty(t, zero.LabelSet())
+	require.Empty(t, zero.NonReservedLabelSet())
+	require.Equal(t, 0, zero.PromLabels().Len())
+
+	value, ok := zero.Get("anything")
+	require.False(t, ok)
+	require.Empty(t, value)
+
+	require.True(t, zero.ForEachLabel(func(string, string) bool {
+		t.Fatal("the zero value must have no labels")
+		return true
+	}))
+
+	// EmptyTarget is documented as equivalent to the zero value.
+	require.True(t, zero.EqualsTarget(&EmptyTarget))
+	require.True(t, EmptyTarget.EqualsTarget(&zero))
+
+	// Hashing an empty target must not panic and must be stable.
+	require.Equal(t, EmptyTarget.NonMetaLabelsHash(), zero.NonMetaLabelsHash())
+
+	// A builder over the zero value must work, and must be able to add labels.
+	built := NewTargetBuilderFrom(zero)
+	built.Set("foo", "bar")
+	result := built.Target()
+	require.Equal(t, 1, result.Len())
+	value, ok = result.Get("foo")
+	require.True(t, ok)
+	require.Equal(t, "bar", value)
+}
+
+// TestGroupLabelsSharedAcrossTargets checks that targets discovered together
+// share one copy of their group labels. This is the property that keeps memory
+// flat when a single service discovery group yields many targets, and losing it
+// would be an invisible regression.
+func TestGroupLabelsSharedAcrossTargets(t *testing.T) {
+	cache := targetGroupCacheForTest(t)
+	targets := toAlloyTargets(cache)
+	require.Greater(t, len(targets), 1)
+
+	first := targets[0].group
+	require.NotNil(t, first, "targets should have group labels")
+	for i, target := range targets {
+		require.Same(t, first, target.group,
+			"target %d must share the group labels pointer with the other targets of its group", i)
+	}
+
+	// Relabeling that does not touch group labels must preserve the sharing.
+	for i := range targets {
+		tb := NewTargetBuilderFrom(targets[i])
+		tb.Set("added", "value")
+		relabelled := tb.Target()
+		require.Same(t, first, relabelled.group,
+			"changing own labels must not copy the group labels")
+	}
+
+	// Deleting a group label has to narrow the group for that target only.
+	tb := NewTargetBuilderFrom(targets[0])
+	tb.Del("shared")
+	narrowed := tb.Target()
+	require.NotSame(t, first, narrowed.group)
+	_, ok := narrowed.Get("shared")
+	require.False(t, ok, "deleted group label must not shine through")
+	// The other targets keep the original group untouched.
+	value, ok := targets[1].Get("shared")
+	require.True(t, ok)
+	require.Equal(t, "shared_value", value)
+}
+
+// targetGroupCacheForTest builds a service discovery cache with one group whose
+// targets share group labels.
+func targetGroupCacheForTest(t *testing.T) map[string]*targetgroup.Group {
+	t.Helper()
+	return map[string]*targetgroup.Group{
+		"source_a": {
+			Source: "source_a",
+			Labels: commonlabels.LabelSet{"shared": "shared_value", "job": "test"},
+			Targets: []commonlabels.LabelSet{
+				{"__address__": "10.0.0.1:80"},
+				{"__address__": "10.0.0.2:80"},
+				{"__address__": "10.0.0.3:80"},
+			},
+		},
+	}
+}

--- a/internal/component/discovery/target_layout_test.go
+++ b/internal/component/discovery/target_layout_test.go
@@ -130,3 +130,95 @@ func targetGroupCacheForTest(t *testing.T) map[string]*targetgroup.Group {
 		},
 	}
 }
+
+// TestGroupPackerReusesUnchangedGroups covers the memoisation in groupPacker.
+// Converting a target means sorting and encoding its labels, so reusing the
+// result for sources that did not change is what keeps repeated sends cheap.
+func TestGroupPackerReusesUnchangedGroups(t *testing.T) {
+	groupA := &targetgroup.Group{
+		Source:  "a",
+		Labels:  commonlabels.LabelSet{"job": "a"},
+		Targets: []commonlabels.LabelSet{{"__address__": "10.0.0.1:80"}, {"__address__": "10.0.0.2:80"}},
+	}
+	groupB := &targetgroup.Group{
+		Source:  "b",
+		Labels:  commonlabels.LabelSet{"job": "b"},
+		Targets: []commonlabels.LabelSet{{"__address__": "10.0.1.1:80"}},
+	}
+	cache := map[string]*targetgroup.Group{"a": groupA, "b": groupB}
+
+	packer := newGroupPacker()
+	first := packer.toAlloyTargets(cache)
+	require.Len(t, first, 3)
+
+	// A second send with an unchanged cache must reuse the packed label buffers,
+	// not re-encode them.
+	second := packer.toAlloyTargets(cache)
+	require.Len(t, second, 3)
+	for i := range first {
+		require.Same(t, first[i].group, second[i].group, "target %d group must be reused", i)
+		require.Equal(t, first[i].own, second[i].own, "target %d own labels must be reused", i)
+		require.True(t, first[i].EqualsTarget(&second[i]))
+	}
+
+	// The outer slice must still be freshly allocated, since it is handed to
+	// downstream components.
+	require.NotSame(t, unsafe.SliceData(first), unsafe.SliceData(second))
+
+	// Replacing one source must re-convert only that source.
+	groupBv2 := &targetgroup.Group{
+		Source:  "b",
+		Labels:  commonlabels.LabelSet{"job": "b"},
+		Targets: []commonlabels.LabelSet{{"__address__": "10.0.1.9:80"}},
+	}
+	cache["b"] = groupBv2
+	third := packer.toAlloyTargets(cache)
+	require.Len(t, third, 3)
+	require.Same(t, first[0].group, third[0].group, "unchanged source must still be reused")
+	require.Same(t, first[1].group, third[1].group, "unchanged source must still be reused")
+	value, ok := third[2].Get("__address__")
+	require.True(t, ok)
+	require.Equal(t, "10.0.1.9:80", value, "changed source must be re-converted")
+
+	// A group mutated in place cannot be detected, which is why the reuse is keyed
+	// on the pointer; discoverers allocate a new group whenever contents change.
+	// Removing a source must drop its cached conversion.
+	delete(cache, "a")
+	fourth := packer.toAlloyTargets(cache)
+	require.Len(t, fourth, 1)
+	require.Len(t, packer.packed, 1, "stale conversions must be pruned")
+	require.Contains(t, packer.packed, "b")
+}
+
+// TestGroupPackerMatchesUncachedConversion checks the memoising and
+// non-memoising paths agree, including after sources are added and removed.
+func TestGroupPackerMatchesUncachedConversion(t *testing.T) {
+	mk := func(source, job string, addrs ...string) *targetgroup.Group {
+		g := &targetgroup.Group{Source: source, Labels: commonlabels.LabelSet{"job": commonlabels.LabelValue(job)}}
+		for _, a := range addrs {
+			g.Targets = append(g.Targets, commonlabels.LabelSet{"__address__": commonlabels.LabelValue(a)})
+		}
+		return g
+	}
+
+	packer := newGroupPacker()
+	cache := map[string]*targetgroup.Group{}
+	steps := []func(){
+		func() { cache["a"] = mk("a", "a", "1:80", "2:80") },
+		func() { cache["b"] = mk("b", "b", "3:80") },
+		func() { cache["a"] = mk("a", "a", "1:80", "2:80", "4:80") }, // changed
+		func() { delete(cache, "b") },
+		func() { cache["c"] = mk("c", "c", "5:80") },
+		func() { delete(cache, "a"); delete(cache, "c") },
+	}
+	for i, step := range steps {
+		step()
+		got := packer.toAlloyTargets(cache)
+		want := toAlloyTargets(cache)
+		require.Len(t, got, len(want), "step %d", i)
+		for j := range want {
+			require.True(t, want[j].EqualsTarget(&got[j]), "step %d target %d", i, j)
+			require.Equal(t, want[j].String(), got[j].String(), "step %d target %d", i, j)
+		}
+	}
+}

--- a/internal/component/discovery/target_memory_bench_test.go
+++ b/internal/component/discovery/target_memory_bench_test.go
@@ -1,0 +1,107 @@
+package discovery
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+	"time"
+
+	commonlabels "github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+)
+
+// Benchmark_Targets_ResidentMemory measures the memory a live set of targets
+// occupies once service discovery has handed them over, which is what matters
+// for a collector holding tens of thousands of targets between updates.
+//
+// Per-operation allocs/op cannot show this. The map-based layout allocated almost
+// nothing when building a target because it stored references to the LabelSets
+// the Prometheus service discovery library had already built, but it kept every
+// one of those maps resident for the lifetime of the target and made the GC scan
+// them. The packed layout copies the labels once, which lets the source maps be
+// collected.
+//
+// The measurement therefore drops the service discovery cache before sampling the
+// heap: whatever the targets still reference stays resident.
+//
+// Run with -benchtime 1x, since the reported metrics are absolute rather than
+// per-iteration.
+func Benchmark_Targets_ResidentMemory(b *testing.B) {
+	const (
+		targetsCount = 100_000
+		groupsCount  = 20 // as if 20 Kubernetes services were discovered
+	)
+
+	buildCache := func() map[string]*targetgroup.Group {
+		cache := make(map[string]*targetgroup.Group, groupsCount)
+		for g := 0; g < groupsCount; g++ {
+			// Shared meta labels, as Kubernetes SD produces per target group.
+			shared := commonlabels.LabelSet{}
+			for i := 0; i < 20; i++ {
+				shared[commonlabels.LabelName(fmt.Sprintf("__meta_kubernetes_service_label_%d", i))] =
+					commonlabels.LabelValue(fmt.Sprintf("shared_value_%d_%d", g, i))
+			}
+			shared["job"] = commonlabels.LabelValue(fmt.Sprintf("kubernetes-pods-%d", g))
+
+			targets := make([]commonlabels.LabelSet, 0, targetsCount/groupsCount)
+			for i := 0; i < targetsCount/groupsCount; i++ {
+				targets = append(targets, commonlabels.LabelSet{
+					"__address__":                     commonlabels.LabelValue(fmt.Sprintf("10.132.%d.%d:8080", g, i%256)),
+					"__meta_kubernetes_pod_name":      commonlabels.LabelValue(fmt.Sprintf("pod-%d-%d", g, i)),
+					"__meta_kubernetes_pod_ip":        commonlabels.LabelValue(fmt.Sprintf("10.132.%d.%d", g, i%256)),
+					"__meta_kubernetes_pod_node_name": commonlabels.LabelValue(fmt.Sprintf("node-%d", i%64)),
+					"__meta_kubernetes_pod_uid":       commonlabels.LabelValue(fmt.Sprintf("4c586419-7f6c-448d-aeec-%012d", i)),
+				})
+			}
+
+			source := fmt.Sprintf("group_%d", g)
+			cache[source] = &targetgroup.Group{Source: source, Labels: shared, Targets: targets}
+		}
+		return cache
+	}
+
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	// Build the targets through the real service discovery path, then drop the
+	// cache. Anything the targets still reference cannot be collected.
+	cache := buildCache()
+	targets := toAlloyTargets(cache)
+	cache = nil
+	_ = cache
+
+	runtime.GC()
+	runtime.GC() // second cycle so that anything freed by finalisation is accounted for
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+
+	if len(targets) != targetsCount {
+		b.Fatalf("expected %d targets, got %d", targetsCount, len(targets))
+	}
+
+	residentBytes := int64(after.HeapAlloc) - int64(before.HeapAlloc)
+	residentObjects := int64(after.HeapObjects) - int64(before.HeapObjects)
+	b.ReportMetric(float64(residentBytes)/targetsCount, "resident-B/target")
+	b.ReportMetric(float64(residentObjects)/targetsCount, "resident-obj/target")
+
+	// Measure how long a GC cycle takes with this target set live, which is driven
+	// by the number of pointers the GC has to chase per target.
+	const gcRuns = 10
+	start := time.Now()
+	for i := 0; i < gcRuns; i++ {
+		runtime.GC()
+	}
+	b.ReportMetric(float64(time.Since(start).Nanoseconds())/gcRuns, "gc-ns/cycle")
+
+	// Touch every target so none of the above can be optimised away, and so the
+	// set is still live for the GC measurements.
+	total := 0
+	for i := range targets {
+		total += targets[i].Len()
+	}
+	if want := targetsCount * 26; total != want {
+		b.Fatalf("unexpected total label count: got %d, want %d", total, want)
+	}
+	runtime.KeepAlive(targets)
+}

--- a/internal/component/discovery/target_memory_bench_test.go
+++ b/internal/component/discovery/target_memory_bench_test.go
@@ -105,3 +105,85 @@ func Benchmark_Targets_ResidentMemory(b *testing.B) {
 	}
 	runtime.KeepAlive(targets)
 }
+
+// Benchmark_ToAlloyTargets_Memoised models what a long-running component
+// actually does: many discovered sources, of which only one changes between
+// sends. runDiscovery keeps the *targetgroup.Group for every unchanged source, so
+// without memoisation each send re-sorts and re-encodes the labels of every
+// target of every source.
+//
+// Compare against Benchmark_ToAlloyTargets, which measures the cold conversion.
+//
+// 50 sources x 400 targets = 20k targets, on linux/amd64 Ryzen AI MAX+ 395:
+//
+//	                                    time/op    B/op    allocs/op
+//	map-based layout (before packing)    2.30ms    484kB        2
+//	packed, no memoisation               4.28ms   4224kB    20159
+//	packed, memoised, 1 source changes   0.39ms    900kB     3825
+//	packed, memoised, nothing changes    0.045ms   648kB        2
+//
+// The memoised numbers are the ones that matter for a long-running collector.
+// Note the worst case is unchanged by memoisation: a discoverer with a single
+// source that changes on every cycle still pays the full conversion, which is
+// what Benchmark_ToAlloyTargets measures.
+func Benchmark_ToAlloyTargets_Memoised(b *testing.B) {
+	const (
+		sources          = 50
+		targetsPerSource = 400 // 20k targets in total
+	)
+
+	mkGroup := func(s, gen int) *targetgroup.Group {
+		shared := commonlabels.LabelSet{
+			"job":                               commonlabels.LabelValue(fmt.Sprintf("job_%d", s)),
+			"__meta_kubernetes_namespace":       "prod",
+			"__meta_kubernetes_service_name":    commonlabels.LabelValue(fmt.Sprintf("svc_%d", s)),
+			"__meta_kubernetes_service_label_a": "aaaaaaaaaa",
+			"__meta_kubernetes_service_label_b": "bbbbbbbbbb",
+		}
+		targets := make([]commonlabels.LabelSet, 0, targetsPerSource)
+		for i := 0; i < targetsPerSource; i++ {
+			targets = append(targets, commonlabels.LabelSet{
+				"__address__":                commonlabels.LabelValue(fmt.Sprintf("10.%d.%d.%d:8080", s%256, i%256, gen%256)),
+				"__meta_kubernetes_pod_name": commonlabels.LabelValue(fmt.Sprintf("pod-%d-%d-%d", s, i, gen)),
+				"__meta_kubernetes_pod_ip":   commonlabels.LabelValue(fmt.Sprintf("10.%d.%d.%d", s%256, i%256, gen%256)),
+				"__meta_kubernetes_pod_uid":  commonlabels.LabelValue(fmt.Sprintf("uid-%d-%d-%d", s, i, gen)),
+			})
+		}
+		return &targetgroup.Group{Source: fmt.Sprintf("source_%d", s), Labels: shared, Targets: targets}
+	}
+
+	cache := make(map[string]*targetgroup.Group, sources)
+	for s := 0; s < sources; s++ {
+		cache[fmt.Sprintf("source_%d", s)] = mkGroup(s, 0)
+	}
+
+	b.Run("one source changes per send", func(b *testing.B) {
+		packer := newGroupPacker()
+		packer.toAlloyTargets(cache) // warm
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			s := i % sources
+			cache[fmt.Sprintf("source_%d", s)] = mkGroup(s, i+1)
+			_ = packer.toAlloyTargets(cache)
+		}
+	})
+
+	b.Run("nothing changes", func(b *testing.B) {
+		packer := newGroupPacker()
+		packer.toAlloyTargets(cache) // warm
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = packer.toAlloyTargets(cache)
+		}
+	})
+
+	b.Run("no memoisation", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = toAlloyTargets(cache)
+		}
+	})
+}

--- a/internal/component/discovery/target_relabel_bench_test.go
+++ b/internal/component/discovery/target_relabel_bench_test.go
@@ -1,0 +1,309 @@
+// This file is in the external test package so that it can import
+// common/relabel alongside discovery and exercise the real relabel rule engine
+// against discovery.TargetBuilder. The in-package benchmarks cannot do this,
+// which is why Benchmark_Targets_TypicalPipeline only approximates the relabel
+// step.
+package discovery_test
+
+import (
+	"fmt"
+	"testing"
+
+	commonlabels "github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	alloy_relabel "github.com/grafana/alloy/internal/component/common/relabel"
+	"github.com/grafana/alloy/internal/component/discovery"
+)
+
+func mustRegexp(tb testing.TB, s string) alloy_relabel.Regexp {
+	tb.Helper()
+	// The Regexp constructor is unexported, but Regexp implements
+	// encoding.TextUnmarshaler, which is how relabel rules are decoded.
+	var re alloy_relabel.Regexp
+	require.NoError(tb, re.UnmarshalText([]byte(s)))
+	return re
+}
+
+// kubernetesRules mirrors the "kubernetes" case of
+// common/relabel.BenchmarkRelabel: a realistic pod-scraping rule set covering
+// replace, labelmap, hashmod, keep, drop and labeldrop.
+func kubernetesRules(tb testing.TB) []*alloy_relabel.Config {
+	tb.Helper()
+
+	rule := func(c alloy_relabel.Config) *alloy_relabel.Config {
+		out := alloy_relabel.DefaultRelabelConfig
+		if len(c.SourceLabels) > 0 {
+			out.SourceLabels = c.SourceLabels
+		}
+		if c.Separator != "" {
+			out.Separator = c.Separator
+		}
+		if c.Regex.Regexp != nil {
+			out.Regex = c.Regex
+		}
+		if c.Modulus != 0 {
+			out.Modulus = c.Modulus
+		}
+		if c.TargetLabel != "" {
+			out.TargetLabel = c.TargetLabel
+		}
+		if c.Replacement != "" {
+			out.Replacement = c.Replacement
+		}
+		if c.Action != "" {
+			out.Action = c.Action
+		}
+		return &out
+	}
+
+	return []*alloy_relabel.Config{
+		rule(alloy_relabel.Config{
+			SourceLabels: []string{"__meta_kubernetes_pod_annotation_prometheus_io_scrape"},
+			Regex:        mustRegexp(tb, "true"),
+			Action:       alloy_relabel.Keep,
+		}),
+		rule(alloy_relabel.Config{
+			SourceLabels: []string{"__address__", "__meta_kubernetes_pod_annotation_prometheus_io_port"},
+			Regex:        mustRegexp(tb, `(.+?)(\:\d+)?;(\d+)`),
+			TargetLabel:  "__address__",
+			Replacement:  "$1:$3",
+			Action:       alloy_relabel.Replace,
+		}),
+		rule(alloy_relabel.Config{
+			Regex:       mustRegexp(tb, "__meta_kubernetes_pod_label_prometheus_io_label_(.+)"),
+			Action:      alloy_relabel.LabelMap,
+			Replacement: "$1",
+		}),
+		rule(alloy_relabel.Config{
+			SourceLabels: []string{"__meta_kubernetes_namespace", "__meta_kubernetes_pod_label_name"},
+			Separator:    "/",
+			TargetLabel:  "job",
+			Replacement:  "$1",
+			Action:       alloy_relabel.Replace,
+		}),
+		rule(alloy_relabel.Config{
+			SourceLabels: []string{"__meta_kubernetes_namespace"},
+			TargetLabel:  "namespace",
+			Action:       alloy_relabel.Replace,
+		}),
+		rule(alloy_relabel.Config{
+			SourceLabels: []string{"__meta_kubernetes_pod_name"},
+			TargetLabel:  "pod",
+			Action:       alloy_relabel.Replace,
+		}),
+		rule(alloy_relabel.Config{
+			SourceLabels: []string{"__meta_kubernetes_pod_container_name"},
+			TargetLabel:  "container",
+			Action:       alloy_relabel.Replace,
+		}),
+		rule(alloy_relabel.Config{
+			SourceLabels: []string{
+				"__meta_kubernetes_pod_name",
+				"__meta_kubernetes_pod_container_name",
+				"__meta_kubernetes_pod_container_port_name",
+			},
+			Separator:   ":",
+			TargetLabel: "instance",
+			Action:      alloy_relabel.Replace,
+		}),
+		rule(alloy_relabel.Config{
+			TargetLabel: "cluster",
+			Replacement: "dev-us-central-0",
+		}),
+		rule(alloy_relabel.Config{
+			SourceLabels: []string{"__meta_kubernetes_namespace"},
+			Regex:        mustRegexp(tb, "hosted-grafana"),
+			Action:       alloy_relabel.Drop,
+		}),
+		rule(alloy_relabel.Config{
+			SourceLabels: []string{"__address__"},
+			TargetLabel:  "__tmp_hash",
+			Modulus:      3,
+			Action:       alloy_relabel.HashMod,
+		}),
+		rule(alloy_relabel.Config{
+			Regex:  mustRegexp(tb, "__tmp_hash"),
+			Action: alloy_relabel.LabelDrop,
+		}),
+	}
+}
+
+// kubernetesTarget returns the group labels shared by every pod of a service and
+// the labels specific to one pod, mirroring how Kubernetes SD populates a
+// targetgroup.Group.
+func kubernetesTarget(ind int) (group, own commonlabels.LabelSet) {
+	group = commonlabels.LabelSet{
+		"__meta_kubernetes_namespace":                                  "loki-boltdb-shipper",
+		"__meta_kubernetes_pod_annotation_prometheus_io_scrape":        "true",
+		"__meta_kubernetes_pod_annotation_prometheus_io_port":          "80",
+		"__meta_kubernetes_pod_annotationpresent_prometheus_io_scrape": "true",
+		"__meta_kubernetes_pod_container_init":                         "false",
+		"__meta_kubernetes_pod_container_name":                         "promtail",
+		"__meta_kubernetes_pod_container_port_name":                    "http-metrics",
+		"__meta_kubernetes_pod_container_port_number":                  "80",
+		"__meta_kubernetes_pod_container_port_protocol":                "TCP",
+		"__meta_kubernetes_pod_controller_kind":                        "DaemonSet",
+		"__meta_kubernetes_pod_controller_name":                        "promtail-loki-boltdb-shipper",
+		"__meta_kubernetes_pod_label_name":                             "promtail-loki-boltdb-shipper",
+		"__meta_kubernetes_pod_label_prometheus_io_label_team":         "logs",
+		"__meta_kubernetes_pod_labelpresent_name":                      "true",
+		"__meta_kubernetes_pod_phase":                                  "Running",
+		"__meta_kubernetes_pod_ready":                                  "true",
+		"__metrics_path__":                                             "/metrics",
+		"__scheme__":                                                   "http",
+		"__scrape_interval__":                                          "15s",
+		"__scrape_timeout__":                                           "10s",
+		"job":                                                          "kubernetes-pods",
+	}
+	own = commonlabels.LabelSet{
+		"__address__":                     commonlabels.LabelValue(fmt.Sprintf("10.132.183.%d:80", ind%256)),
+		"__meta_kubernetes_pod_host_ip":   commonlabels.LabelValue(fmt.Sprintf("10.128.0.%d", ind%256)),
+		"__meta_kubernetes_pod_ip":        commonlabels.LabelValue(fmt.Sprintf("10.132.183.%d", ind%256)),
+		"__meta_kubernetes_pod_name":      commonlabels.LabelValue(fmt.Sprintf("promtail-loki-boltdb-shipper-%d", ind)),
+		"__meta_kubernetes_pod_node_name": commonlabels.LabelValue(fmt.Sprintf("gke-dev-us-central-0-main-n2s8-2-%d", ind)),
+		"__meta_kubernetes_pod_uid":       commonlabels.LabelValue(fmt.Sprintf("4c586419-7f6c-448d-aeec-ca4fa5b0%04d", ind)),
+	}
+	return group, own
+}
+
+// Benchmark_Relabel_TargetBuilder measures the real relabeling path that
+// discovery.relabel and the database_observability components take: build a
+// TargetBuilder from a Target, run the Alloy relabel rule engine over it, and
+// materialise the result. This is the main workload the packed label layout is
+// meant to improve, and it was previously unmeasured.
+func Benchmark_Relabel_TargetBuilder(b *testing.B) {
+	rules := kubernetesRules(b)
+	const targetsCount = 2_000
+
+	// Group labels are shared across the whole set, as they would be for targets
+	// coming from a single Kubernetes SD target group.
+	sharedGroup, _ := kubernetesTarget(0)
+	targets := make([]discovery.Target, 0, targetsCount)
+	for i := 0; i < targetsCount; i++ {
+		_, own := kubernetesTarget(i)
+		targets = append(targets, discovery.NewTargetFromSpecificAndBaseLabelSet(own, sharedGroup))
+	}
+
+	// Sanity check that the rules actually keep targets and do real work, so the
+	// benchmark cannot silently degrade into a no-op.
+	{
+		tb := discovery.NewTargetBuilderFrom(targets[0])
+		require.True(b, alloy_relabel.ProcessBuilder(tb, rules...))
+		result := tb.Target()
+		_, hasTmp := result.Get("__tmp_hash")
+		require.False(b, hasTmp, "labeldrop should have removed __tmp_hash")
+		cluster, ok := result.Get("cluster")
+		require.True(b, ok)
+		require.Equal(b, "dev-us-central-0", cluster)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		out := make([]discovery.Target, 0, len(targets))
+		for _, t := range targets {
+			tb := discovery.NewTargetBuilderFrom(t)
+			if alloy_relabel.ProcessBuilder(tb, rules...) {
+				out = append(out, tb.Target())
+			}
+		}
+		if len(out) == 0 {
+			b.Fatal("expected at least some targets to be kept")
+		}
+	}
+}
+
+// Benchmark_Relabel_NoChanges measures the copy-on-write fast path: rules that
+// inspect labels but change nothing must not re-encode either label buffer.
+func Benchmark_Relabel_NoChanges(b *testing.B) {
+	rules := []*alloy_relabel.Config{
+		func() *alloy_relabel.Config {
+			c := alloy_relabel.DefaultRelabelConfig
+			c.SourceLabels = []string{"__meta_kubernetes_pod_annotation_prometheus_io_scrape"}
+			c.Regex = mustRegexp(b, "true")
+			c.Action = alloy_relabel.Keep
+			return &c
+		}(),
+	}
+
+	sharedGroup, own := kubernetesTarget(0)
+	target := discovery.NewTargetFromSpecificAndBaseLabelSet(own, sharedGroup)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		tb := discovery.NewTargetBuilderFrom(target)
+		if !alloy_relabel.ProcessBuilder(tb, rules...) {
+			b.Fatal("target should be kept")
+		}
+		_ = tb.Target()
+	}
+}
+
+// Benchmark_Target_EqualsTarget measures the comparison the runtime performs on
+// every component export to decide whether downstream components need to be
+// re-evaluated.
+func Benchmark_Target_EqualsTarget(b *testing.B) {
+	sharedGroup, own := kubernetesTarget(0)
+	left := discovery.NewTargetFromSpecificAndBaseLabelSet(own, sharedGroup)
+
+	b.Run("unchanged", func(b *testing.B) {
+		// Same group pointer and same own buffer, as produced by a relabel step
+		// that changed nothing. This is the overwhelmingly common case.
+		right := discovery.NewTargetBuilderFrom(left).Target()
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if !left.EqualsTarget(&right) {
+				b.Fatal("targets should be equal")
+			}
+		}
+	})
+
+	b.Run("equal but rebuilt", func(b *testing.B) {
+		// Same labels, independently constructed, so the fast path does not apply.
+		right := discovery.NewTargetFromSpecificAndBaseLabelSet(own, sharedGroup)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if !left.EqualsTarget(&right) {
+				b.Fatal("targets should be equal")
+			}
+		}
+	})
+
+	b.Run("different", func(b *testing.B) {
+		_, otherOwn := kubernetesTarget(1)
+		right := discovery.NewTargetFromSpecificAndBaseLabelSet(otherOwn, sharedGroup)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if left.EqualsTarget(&right) {
+				b.Fatal("targets should differ")
+			}
+		}
+	})
+}
+
+// Benchmark_Target_Get measures a single label lookup, which the packed layout
+// makes an O(n) scan instead of a map lookup. Targets in this benchmark carry a
+// realistic number of labels.
+func Benchmark_Target_Get(b *testing.B) {
+	sharedGroup, own := kubernetesTarget(0)
+	target := discovery.NewTargetFromSpecificAndBaseLabelSet(own, sharedGroup)
+
+	// Cover a label at the start of the buffer, one in the middle, one in the
+	// group rather than own, and one that is absent.
+	for _, name := range []string{"__address__", "__meta_kubernetes_pod_name", "job", "does_not_exist"} {
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _ = target.Get(name)
+			}
+		})
+	}
+}

--- a/internal/runtime/equality/equality.go
+++ b/internal/runtime/equality/equality.go
@@ -16,9 +16,8 @@ type CustomEquality interface {
 // DeepEqual is a wrapper around reflect.DeepEqual, which first checks if arguments implement CustomEquality. If they
 // do, their Equals method is used for comparison instead of reflect.DeepEqual.
 // For simplicity, DeepEqual requires x and y to be of the same type before calling CustomEquality.Equals.
-// NOTE: structs, slices, maps and arrays that contain a mix of values implementing CustomEquality and not implementing it
-// are not supported. Unexported fields are not supported either. In those cases, implement CustomEquality on higher
-// level of your object hierarchy.
+// Structs, slices, maps, and arrays may contain a mix of values implementing CustomEquality and basic values. Unexported
+// fields are not supported; in those cases, implement CustomEquality on a higher-level exported type.
 func DeepEqual(x, y any) bool {
 	if x == nil || y == nil {
 		return x == y
@@ -118,6 +117,13 @@ func deepCustomEqual(v1, v2 reflect.Value) result {
 			}
 		}
 		return comparedAndEqual
+	case reflect.Bool, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64, reflect.Complex64, reflect.Complex128, reflect.String:
+		if !v1.CanInterface() {
+			return couldNotCompare
+		}
+		return successfulCompare(v1.Equal(v2))
 	default:
 		return couldNotCompare
 	}

--- a/internal/runtime/equality/equality_test.go
+++ b/internal/runtime/equality/equality_test.go
@@ -3,6 +3,8 @@ package equality
 import (
 	"testing"
 
+	alloy_relabel "github.com/grafana/alloy/internal/component/common/relabel"
+	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -139,22 +141,22 @@ func TestDeepEqual(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "mixed fields structs are not supported",
+			name: "mixed exported fields structs are equal",
 			args: args{
-				x: mixedFieldsStruct{
-					i:  123,
-					e1: equalsTester{"1234"},
-					e2: equalsTester{"ab"},
-					s:  justAStruct{567, 3.14},
+				x: mixedExportedFieldsStruct{
+					I:  123,
+					E1: equalsTester{"1234"},
+					E2: equalsTester{"ab"},
+					S:  basicStruct{567, 3.14},
 				},
-				y: mixedFieldsStruct{
-					i:  123,
-					e1: equalsTester{"abcd"},
-					e2: equalsTester{"12"},
-					s:  justAStruct{567, 3.14},
+				y: mixedExportedFieldsStruct{
+					I:  123,
+					E1: equalsTester{"abcd"},
+					E2: equalsTester{"12"},
+					S:  basicStruct{567, 3.14},
 				},
 			},
-			want: false,
+			want: true,
 		},
 		{
 			name: "all custom unexported fields struct not supported",
@@ -247,16 +249,38 @@ func TestDeepEqual(t *testing.T) {
 	}
 }
 
+func TestDeepEqualRelabelConfig(t *testing.T) {
+	config := func() alloy_relabel.Config {
+		return alloy_relabel.Config{
+			SourceLabels: []string{"__meta_kubernetes_namespace"},
+			Regex:        alloy_relabel.Regexp{Regexp: regexp.MustCompile("^(?s:default)$")},
+			TargetLabel:  "namespace",
+			Replacement:  "$1",
+			Action:       alloy_relabel.Replace,
+		}
+	}
+
+	assert.True(t, DeepEqual(config(), config()))
+	changed := config()
+	changed.TargetLabel = "different_namespace"
+	assert.False(t, DeepEqual(config(), changed))
+}
+
 type justAStruct struct {
 	i int
 	f float64
 }
 
-type mixedFieldsStruct struct {
-	i  int
-	e1 equalsTester
-	e2 equalsTester
-	s  justAStruct
+type basicStruct struct {
+	I int
+	F float64
+}
+
+type mixedExportedFieldsStruct struct {
+	I  int
+	E1 equalsTester
+	E2 equalsTester
+	S  basicStruct
 }
 
 type allCustomFieldsStructUnexported struct {

--- a/stringlabels.md
+++ b/stringlabels.md
@@ -1,0 +1,349 @@
+# Pack `discovery.Target` labels into sorted string buffers
+
+Working plan for changing the memory layout of `internal/component/discovery.Target` from two
+map-based `commonlabels.LabelSet` fields to a Prometheus-style packed single-string representation
+(see `prometheus/model/labels/labels_stringlabels.go`).
+
+## Motivation
+
+`Target` today stores labels as two maps:
+
+```go
+type Target struct {
+    group commonlabels.LabelSet
+    own   commonlabels.LabelSet
+    size  int
+}
+```
+
+Maps are expensive for the access patterns Alloy actually has:
+
+- **Clustering hash** (`HashLabelsWithPredicate`, `target.go:294`) needs labels in deterministic
+  order, so it materialises a pooled `[]string` of names, sorts it, then does one `Get` (two map
+  lookups) per label. This runs per target on every reshard.
+- **Export change detection** (`equality.go:60` → `Target.EqualsTarget`, `target.go:268`) is O(n)
+  map lookups per target on every component export.
+- **Steady-state memory**: a map with n labels costs ~2n pointers for the GC to scan, per target.
+  Alloy routinely holds 10k-100k+ targets live.
+
+A packed, name-sorted string makes hashing a single forward scan (no sort, no pool, no `Get`),
+makes equality a pointer plus string compare, and reduces each target to ~2 pointers.
+
+## Decisions
+
+| Decision | Choice |
+|---|---|
+| Encoding | Hand-rolled, in a new subpackage `internal/component/discovery/internal/labelpack` |
+| group/own split | **Survives**: shared `*groupLabels` + per-target packed `own` |
+| Empty-valued labels | Normalized away at construction |
+| Oversized labels (>= 16 MB) | Panic, matching Prometheus (`labels_stringlabels.go:551`) |
+| Rollout | One PR, layout swap only. No exported signature changes, no call-site changes outside `internal/component/discovery` |
+
+### Why hand-roll instead of wrapping `modellabels.Labels`
+
+`prometheus/prometheus v0.312.0`'s `labels_stringlabels.go` is `//go:build !slicelabels &&
+!dedupelabels`, so `labels.Labels` *is* already the packed implementation in this build. Wrapping it
+would be attractive if `Target` were flat. But because the group/own split survives:
+
+- Two `labels.Labels` cannot be cheaply merged into one view; `data` is unexported, so there is no
+  raw-buffer escape hatch.
+- `PromLabels()` needs a rebuild from the merged view either way.
+
+So wrapping buys little here, and hand-rolling gives a `Get` that returns `(string, bool)` and a
+2-way merge iterator over group+own.
+
+### Why keep the group/own split
+
+`toAlloyTargets` (`discovery.go:225-245`) stores the Prometheus `targetgroup.Group.Labels` map *by
+reference* into every target in the group. Kubernetes SD typically has 5-40 shared
+`__meta_kubernetes_*` labels across thousands of pods. Flattening would materialise those bytes per
+target, and would make `ComponentTargetsToPromTargetGroupsForSingleJob` unable to reconstruct
+`targetgroup.Group.Labels` — changing the `Source` strings, which Prometheus' scrape manager keys
+target sets by, causing scrape-loop churn on upgrade.
+
+## Encoding
+
+Byte-identical to `prometheus/model/labels` stringlabels: each name and each value is preceded by
+its length, encoded as a single byte for length 0..254, or `0xFF` followed by 3 bytes little-endian
+for longer. Maximum length `1<<24` (16 MB); panic above that.
+
+Invariants for a packed buffer:
+
+1. Names sorted ascending (byte-wise).
+2. Names unique.
+3. No empty values.
+
+## Types
+
+```go
+// internal/component/discovery/internal/labelpack
+type Labels string
+
+func FromLabelSet(ls commonlabels.LabelSet) (Labels, int)
+func FromPairs(p []Pair) (Labels, int)   // sorts in place, de-dupes, drops empty values
+
+func (l Labels) Get(name string) (string, bool)             // forward scan, early-exit on sort order
+func (l Labels) Range(f func(name, value string) bool) bool
+func (l Labels) Iter() Iter                                  // cursor, for merges
+func Merge(group, own Labels) MergeIter                      // sorted 2-way merge, own shadows group
+```
+
+```go
+// internal/component/discovery
+type groupLabels struct {
+    packed labelpack.Labels
+    n      int
+    hash   uint64                // cached pure-group StableHash (no-shadowing fast path)
+    lsOnce sync.Once
+    ls     commonlabels.LabelSet // lazily materialised for targetgroup.Group
+}
+
+type Target struct {
+    _     [0]func()   // keeps Target non-comparable; MUST be first (trailing zero-size fields get padded)
+    group *groupLabels
+    own   labelpack.Labels
+    size  int32
+}
+```
+
+`labelpack` lives under `discovery/internal/` so it is importable from the whole
+`internal/component/discovery/...` tree but nowhere else, and so its fuzz targets and micro
+benchmarks stay isolated from the component tests.
+
+## Files to change
+
+| File | Change |
+|---|---|
+| `internal/component/discovery/internal/labelpack/*.go` | **New.** Encoder, decoder, `Get`, `Range`, `Iter`, `Merge`, plus tests and fuzz. |
+| `internal/component/discovery/target.go:20-355` | Rewrite internals. All exported signatures unchanged. Delete `stringSlicesPool`, `borrowLabelsSlice`, `releaseLabelsSlice` (`:30,38-45`). |
+| `internal/component/discovery/target.go:357-408` | `ComponentTargetsToPromTargetGroups*`, see below. |
+| `internal/component/discovery/target_builder.go` | Rewrite `targetBuilder` on the `labels.Builder` model (`add []Pair`, `del []string`). |
+| `internal/component/discovery/discovery.go:225-245` | `toAlloyTargets`: build `*groupLabels` once per SD group, not per target. |
+| `internal/component/discovery/distributed_targets.go` | No change; benefits automatically from a faster `NonMetaLabelsHash`. |
+
+Nothing outside `internal/component/discovery` changes. Verified: no code outside the package
+touches `group`/`own`, no `map[discovery.Target]`, no `==` on targets, no reflective JSON/YAML
+serialization of `Target`. `NewTargetBuilderFromLabelSets` (exported, `target_builder.go:37`) keeps
+its `(group, own commonlabels.LabelSet)` signature.
+
+## Per-method design
+
+- **`ForEachLabel`** (`:123`) → `labelpack.Merge(group.packed, own)`. Sorted order, own shadows
+  group, zero allocation. Iteration order changes from map-random to sorted; safe, since the doc
+  comment at `:119-122` already disclaims order and every order-sensitive consumer re-sorts.
+- **`Get`** (`:156`) → scan `own` (early-exit on sort order), then `group.packed`. O(n) instead of
+  O(1), but contiguous and branch-predictable.
+- **`HashLabelsWithPredicate`** (`:294`) → biggest win. Single merge scan appending straight into the
+  hash buffer. Drops the pooled `[]string`, the `slices.Sort` and the per-label `Get`.
+- **`hashLabelsInOrder`** (`:323-355`) → byte emission and the 1 KB `xxhash.Digest` switchover stay
+  character-for-character identical. This is the pinned clustering contract (`:320-322`).
+- **`groupLabelsHash`** (`:308-318`) → preserve exactly: it hashes group *names* but resolves values
+  through `t.Get`, so an `own` override silently changes it. Merge-scan group names with a parallel
+  `own` cursor; use the cached `groupLabels.hash` when no shadowing is detected.
+- **`EqualsTarget`** (`:268`) → fast path `t.group == o.group && t.own == o.own`.
+- **`PromLabels`** (`:97`) → `ScratchBuilder.Add` in merge order, skip the `Sort()` call.
+- **`Len`** (`:178`) → still O(1) from `size`.
+
+## `ComponentTargetsToPromTargetGroupsForSingleJob` (`target.go:363-408`)
+
+The structure survives intact because the split survives.
+
+- `Labels:` ← `groupLabels.ls`, materialised once per group under `sync.Once` (parity with today,
+  where it is the original map).
+- `Targets:` ← **new per-target `LabelSet` decode.** Unavoidable regression with a packed layout.
+  Runs once per target per SD update (>= 5 s apart, `discovery.go:166`), and Prometheus'
+  `TargetsFromGroup` does more per-target work immediately after.
+- `Source` strings (`"%s_part_%v"`, `"%s_rest"`) unchanged, because the group hash is unchanged.
+- `labelSetEqualsFn` (`:29`, swapped by `target_test.go:961-964` to fake hash collisions) becomes
+  `groupEqualsFn func(a, b *groupLabels) bool`, with pointer identity as the fast path.
+
+## Semantics that must be right
+
+1. **Empty values dropped.** `Get`'s `bool` becomes true presence. Audit the external bool users:
+   `pyroscope/java/target.go:15,18,19,24,27,30`, `discovery/process/container.go:45,49,53`,
+   `promtailconvert/.../service_discovery.go:30`, `promsdprocessor/consumer/consumer.go:234`. All
+   probe `__meta_*` presence, so low risk. `NewTargetFromMap({"a":""})` goes from `Len()==1` to
+   `Len()==0`, matching what `targetBuilder` already does (`target_builder_test.go:28-39`).
+2. **Empty `own` value shadowing a group label.** `own={a:""}, group={a:"x"}` must still resolve to
+   absent, not `"x"`. The tombstone logic currently in `target_builder.go:42-49` moves into
+   `NewTargetFromSpecificAndBaseLabelSet`; such a target needs its own `*groupLabels` rather than the
+   shared one. Rare, but must be detected at construction, not skipped.
+3. **Group interning in `toAlloyTargets`.** `discovery.go:241` passes the same `group.Labels` map for
+   every target in the group. Add an unexported constructor taking an already-built `*groupLabels`.
+   Getting this wrong turns an O(groups) cost into O(targets).
+4. **Builder copy-on-write must survive.** No add/del → return the `group` pointer and `own` string
+   verbatim, zero allocation (parity with `target_builder.go:132-134`). Only `own` affected →
+   re-encode `own`, share the `group` pointer. A `Del` hitting a group label → a new `*groupLabels`
+   per target (the existing TODO at `:174-176`; out of scope, but the packed string is now a natural
+   intern key).
+5. **`Range` must not revisit labels `Set` during iteration.** Required by
+   `LabelMap`/`LabelDrop`/`LabelKeep` (`relabel.go:296-314`), which mutate while ranging. Snapshot
+   `add`/`del` into stack arrays, exactly as `labels_common.go:218-231`.
+6. **`Target` must stay non-comparable.** `struct{*groupLabels; string; int32}` compiles under `==`,
+   but `==` would be semantically wrong (equal content, different group pointers). Today the map
+   fields make it a compile error. The `_ [0]func()` field preserves that guard for free.
+
+## Behaviour changes
+
+All of these follow from normalising empty names and values at construction, and none are covered by
+an existing test.
+
+1. **A label with an empty value is now absent rather than present-and-empty.** `Get` reports it as
+   missing and `Len` does not count it. `TargetBuilder` already behaved this way
+   (`target_builder_test.go:28-39`), and Prometheus cannot represent such a label at all, so this only
+   affects targets built directly from a map or `LabelSet` that never passed through a builder.
+2. **A label with an empty name is dropped.** An empty name is not a valid label name, and `Get("")`
+   cannot report it as present without panicking on `name[0]`, so storing it would make it
+   unreachable.
+3. **Hashes change for targets that carry empty-valued labels.** The old `hashLabelsInOrder` emitted
+   `name\xff\xff` for them; they are now absent and contribute nothing. This affects
+   `NonMetaLabelsHash`, so during a rolling upgrade the old and new versions would disagree on
+   ownership of such targets, causing temporarily duplicated or missed scrapes for those targets
+   only. Non-meta labels are rarely empty in practice (`__address__` never is, and anything that went
+   through a relabel step already had empty values dropped), but this is the one place where the
+   clustering compatibility contract at `target.go:320-322` is knowingly relaxed. Hashes for targets
+   without empty-valued labels are byte-identical, as the pinned tests verify.
+4. **`groupLabelsHash` changes for groups containing empty-valued labels**, for the same reason,
+   which changes the `targetgroup.Group.Source` string and so restarts the affected scrape loops
+   once on upgrade.
+
+## Tests
+
+Preserve unmodified (these are the compatibility contracts):
+
+- `target_test.go:591` `TestHashing` — pinned `0xa28155048ff30d6f`, `0xbbbe498586b668f3`
+- `target_test.go:797` `TestHashLargeLabelSets` — including `:839` vs `labels.StableHash`
+- `target_test.go:852` `TestComponentTargetsToPromTargetGroups` — pinned
+  `job_part_9994420383135092995`, `job_part_13313558424202542889`, `job_rest`
+- `target_builder_test.go:254-305` — the `builderAdapter` cross-check, incl. `StableHash`
+  equivalence at `:270`
+- `discovery_test.go:218` `TestToAlloyTargetsOrdersGroupsBySource`
+- `distributed_targets_test.go:114,212`
+
+Added:
+
+- `labelpack/labelpack_test.go`, `merge_test.go`: 0/1/many labels; name and value lengths exactly
+  254/255/256 (the varint boundary); empty buffer; duplicate and empty-value handling; a panic test
+  for the 16 MB limit; `TestEncodingMatchesPrometheus` comparing raw bytes against
+  `modellabels.New(...).Bytes(nil)`.
+- `labelpack/fuzz_test.go`: `FuzzRoundTrip`, `FuzzEncodingMatchesPrometheus` and `FuzzMerge`. The
+  second is the primary safety net for the hand-rolled encoder, since a divergence would silently
+  break `StableHash`-based clustering compatibility. ~29M executions, no divergence.
+- `target_fuzz_test.go`: `FuzzTargetFromGroupAndOwn`, `FuzzTargetBuilder` and
+  `FuzzTargetBuilderRangeMutation`, checking `Target` and `TargetBuilder` against a naive map
+  reference and against Prometheus' `labels.Builder` for arbitrary group/own splits. The last one
+  covers the mutate-while-ranging contract that `labelmap`/`labeldrop`/`labelkeep` depend on.
+- `target_layout_test.go`: guards that `Target` stays non-comparable (`reflect.Type.Comparable`), that
+  it stays 32 bytes with the zero-size field first, that the zero value is usable, and that targets
+  from one SD group share a single `*groupLabels` pointer before and after relabeling.
+- `target_relabel_bench_test.go` (`package discovery_test`, so it can import `common/relabel`
+  alongside `discovery`): `Benchmark_Relabel_TargetBuilder` running the real Alloy relabel engine
+  over `TargetBuilder` with a realistic Kubernetes rule set. This path was previously unmeasured,
+  which is what the comment at `target_test.go:1037` refers to. Plus
+  `Benchmark_Relabel_NoChanges`, `Benchmark_Target_EqualsTarget` and `Benchmark_Target_Get`.
+- `target_memory_bench_test.go`: `Benchmark_Targets_ResidentMemory`, described above.
+
+## Measured results
+
+Measured on linux/amd64, AMD Ryzen AI MAX+ 395, `-count 6`, compared with `benchstat`.
+
+### Resident memory (`Benchmark_Targets_ResidentMemory`, 100k targets in 20 groups)
+
+This is the headline result and the main justification for the change. It builds targets through
+`toAlloyTargets`, drops the service discovery cache, and then samples the heap, so whatever the
+targets still reference stays resident. The map layout retained every source `LabelSet` by reference;
+the packed layout copies the labels once and lets those maps be collected.
+
+| metric | old (maps) | new (packed) | delta |
+|---|---|---|---|
+| resident bytes / target | 476 | 251 | **-47%** |
+| resident heap objects / target | 6.82 | 1.00 | **-85%** |
+| GC ns / cycle with the set live | ~2.5M | ~0.95M | **-62%** |
+
+Note that per-operation `allocs/op` cannot show this, which is why this benchmark exists.
+
+### Throughput
+
+| benchmark | time/op | allocs/op |
+|---|---|---|
+| `BenchmarkDistributedTargets` (clustering) | **-55.7%** | **-99.2%** (101k -> 1k) |
+| `Benchmark_Relabel_NoChanges` | **-61.1%** | **-66.7%** (3 -> 1) |
+| `Benchmark_Relabel_TargetBuilder` | **-18.7%** | **-5.2%** |
+| `Benchmark_Targets_TypicalPipeline` (net effect) | **-18.5%** | +39.9% |
+| `Benchmark_Target_EqualsTarget/unchanged` | **-99.7%** (619ns -> 2ns) | 0 |
+| `Benchmark_Target_EqualsTarget/equal_but_rebuilt` | **-97.7%** (617ns -> 14ns) | 0 |
+| `Benchmark_Target_EqualsTarget/different` | +23.8% (33ns -> 41ns) | 0 |
+| `Benchmark_ToAlloyTargets` | +145.8% | 1 -> 20003 |
+| `Benchmark_Target_Get/__address__` (first in `own`) | -7.5% | 0 |
+| `Benchmark_Target_Get/job` (in `group`) | +381.8% (9ns -> 44ns) | 0 |
+
+### Regressions, and why they are acceptable
+
+1. **`Benchmark_ToAlloyTargets`: 1 alloc/op -> 20003 alloc/op, +146% time.** The old code stored
+   references to the `LabelSet` maps that the Prometheus SD library had already allocated, so
+   building a target cost nothing beyond the slice. The new code encodes each target's own labels
+   into one buffer, which is one allocation per target and roughly half the bytes of the map it
+   replaces. The old benchmark measures only incremental allocation and so flatters the old layout;
+   `Benchmark_Targets_ResidentMemory` measures what is actually retained. `toAlloyTargets` runs at
+   most every `MaxUpdateFrequency` (5s, `discovery.go:166`).
+2. **`Get` on a group label: 9ns -> 44ns.** Inherent to a packed layout: the scan walks `own` and
+   then `group` instead of doing two map lookups. Absolute cost is tens of nanoseconds, and `Get` is
+   called a handful of times per target per update rather than per sample. Names sort ascending, so
+   the scan exits early when it passes the requested name.
+3. **`EqualsTarget/different`: 33ns -> 41ns.** The merge walk first compares the packed buffers,
+   which for equal group labels is a memcmp before the difference in `own` is found. The cases that
+   dominate in practice, unchanged and equal-but-rebuilt, are 44x and 300x faster respectively.
+4. **`Benchmark_Targets_TypicalPipeline` allocs +40% while time is -18.5%.** Same cause as (1): the
+   encoding cost moved into Alloy from the SD library. Time and resident memory both improve.
+
+### Rejected optimisation
+
+`toAlloyTargets` could pack every target of a group into a single buffer and give each target a
+substring of it, reducing allocations from one per target to one per group. Rejected for this PR:
+a substring keeps the entire parent buffer alive, so a relabel step that drops most of a group would
+retain the dropped targets' bytes indefinitely. Worth revisiting with an explicit re-pack threshold.
+
+## Verification
+
+```sh
+# Unit and race tests
+go test -race -tags "nodocker gore2regex" ./internal/...
+
+# Encoder fuzzing (the safety net for the hand-rolled encoding)
+go test -run '^$' -fuzz FuzzEncodingMatchesPrometheus -fuzztime 5m ./internal/component/discovery/internal/labelpack
+go test -run '^$' -fuzz FuzzTargetFromGroupAndOwn    -fuzztime 5m ./internal/component/discovery
+go test -run '^$' -fuzz FuzzTargetBuilder            -fuzztime 5m ./internal/component/discovery
+
+# Throughput comparison
+go test -run XXX -bench . -benchmem -count 6 -skip ResidentMemory ./internal/component/discovery/ > new.txt
+benchstat old.txt new.txt
+
+# Resident memory comparison (absolute metrics, so a single iteration)
+go test -run XXX -bench Benchmark_Targets_ResidentMemory -benchtime 1x -count 3 ./internal/component/discovery/
+
+# Lint
+golangci-lint run --build-tags "nodocker gore2regex" ./internal/component/discovery/...
+go run ./internal/cmd/alloylint ./internal/component/discovery/...
+```
+
+Status: all of the above pass. The only failing test in the tree is
+`TestPyroscopeJavaIntegration`, which requires root and fails identically on the base commit. The
+only lint findings are four pre-existing `goconst` warnings in `discovery/consulagent`,
+`discovery/dockerswarm` and `discovery/openstack`, none of which this change touches.
+
+No `go.mod` change, so `make generate-otel-collector-distro` is not required. No `docs/sources`
+change; this is internal only. Per `AGENTS.md` the changelog is derived from the PR title, which is
+yours to write.
+
+## Out of scope (follow-up PRs)
+
+- Batch-pack a whole SD group into one buffer in `toAlloyTargets`, with an explicit re-pack threshold
+  to bound the substring retention described above. This would address the one remaining allocation
+  regression.
+- Intern duplicate `*groupLabels` produced by relabeling (`target_builder.go:174-176`); the packed
+  string is now a natural key.
+- Drop `AsMap()` from its two hot callers: `pyroscope/java/loop.go:214` (per profile) and
+  `pyroscope/ebpf/ebpf_linux.go:441`.
+- Cache `NonReservedLabelSet()` for `loki/source/file/resolver.go:46,77`.
+- Add a builder pool or result cache to `discovery.relabel`, which today re-relabels every target
+  from scratch on every `Update` with no cache (`relabel/relabel.go:88-105`).

--- a/stringlabels.md
+++ b/stringlabels.md
@@ -296,6 +296,48 @@ Note that per-operation `allocs/op` cannot show this, which is why this benchmar
 4. **`Benchmark_Targets_TypicalPipeline` allocs +40% while time is -18.5%.** Same cause as (1): the
    encoding cost moved into Alloy from the SD library. Time and resident memory both improve.
 
+### Why not make Prometheus service discovery emit packed labels
+
+The obvious way to remove the conversion entirely would be for service discovery to hand over packed
+labels in the first place. That is not practical:
+
+- `targetgroup.Group` is `Targets []model.LabelSet` plus `Labels model.LabelSet`
+  (`discovery/targetgroup/targetgroup.go:24-33`), and `Discoverer.Run(ctx, chan<- []*targetgroup.Group)`
+  (`discovery/discovery.go:35-40`) is the contract every discoverer implements.
+- There is no `labels.Labels` anywhere in the upstream service discovery API.
+- Alloy wraps 35 upstream discoverers, spanning 41 packages and ~22.8k lines. Changing the label type
+  means forking all of it and giving up upstream fixes, for a conversion that runs at most every 5s.
+
+Instead the conversion is memoised, which removes the repeated cost without touching Prometheus. See
+below.
+
+### Memoising the conversion
+
+`runDiscovery` only replaces the cache entry for sources present in an update
+(`discovery.go:210-219`), so every unchanged source keeps the same `*targetgroup.Group` pointer, yet
+`toAlloyTargets` re-sorted and re-encoded all of them on every send. `groupPacker` keys a cached
+conversion on that pointer; discoverers build a new group whenever contents change and never mutate a
+group after sending it, so pointer identity is sufficient.
+
+50 sources x 400 targets = 20k targets:
+
+| variant | time/op | B/op | allocs/op |
+|---|---|---|---|
+| map-based layout (before this change) | 2.30ms | 484kB | 2 |
+| packed, no memoisation | 4.28ms | 4224kB | 20159 |
+| packed, memoised, one source changes per send | **0.39ms** | 900kB | 3825 |
+| packed, memoised, nothing changes | **0.045ms** | 648kB | 2 |
+
+So the realistic long-running case is ~5.9x faster than the original map-based code rather than 1.9x
+slower, and the steady state is ~51x faster. Memoisation also makes the group pointer and own buffer
+identical across sends for unchanged targets, so `EqualsTarget` hits its 2ns fast path and the
+export-comparison short circuit added in `45f3994b5` becomes effective.
+
+**Worst case is unchanged:** a discoverer with a single source that changes on every cycle gets no
+reuse and still pays the full conversion, i.e. the `Benchmark_ToAlloyTargets` regression above. Fixing
+that would need content-based rather than identity-based invalidation, which costs about as much as
+just re-encoding.
+
 ### Rejected optimisation
 
 `toAlloyTargets` could pack every target of a group into a single buffer and give each target a


### PR DESCRIPTION
Store `discovery.Target` labels as two packed, name-sorted strings — one shared by every target of a service discovery group, one per target — using an encoding byte-identical to `prometheus/model/labels` stringlabels, instead of two `model.LabelSet` maps. Reuse that representation to skip repeated work: service discovery target groups whose `*targetgroup.Group` has not changed keep their previous conversion, and `discovery.relabel` memoises its per-target result keyed on the packed labels. Holding 100k targets costs 251 resident bytes and 1 heap object each instead of 476 bytes and 6.8 objects, clustering is 56% faster with 99% fewer allocations, and a `discovery.relabel` update where one of 50 sources changed drops from 78ms to 3.1ms.

### Pull Request Details

<!-- HUMAN ONLY: Motivations, trade-offs, and decisions. Write in your own words. -->


### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->


### Notes to the Reviewer

<img width="1709" height="960" alt="image" src="https://github.com/user-attachments/assets/a28dfb0e-7a9c-460e-90de-3e43988e7831" />


https://flamegraph.com/share/7abce4fc-8b26-11f1-a7b0-62d7592ece77/87cfb656-8b26-11f1-8ebb-e2d1d61de28d

<!-- HUMAN ONLY: Context for reviewers/testers. Write in your own words. -->


### PR Checklist

<!-- HUMAN ONLY: Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
