### PR TITLE
feat(faro.receiver): Make logs export send timeout configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## Main (unreleased)
-
-### Features 🌟
-
-- `faro.receiver`: Add configurable `logs_send_timeout` in the `output` block to control how long the receiver waits when pushing log entries to the downstream pipeline. Defaults to `"2s"`. Previously this was hardcoded and could cause `context deadline exceeded` errors under backpressure. (@kpelelis)
-
 ## [1.18.0](https://github.com/grafana/alloy/compare/v1.17.0...v1.18.0) (2026-07-17)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Main (unreleased)
+
+### Features 🌟
+
+- `faro.receiver`: Add configurable `logs_send_timeout` in the `output` block to control how long the receiver waits when pushing log entries to the downstream pipeline. Defaults to `"2s"`. Previously this was hardcoded and could cause `context deadline exceeded` errors under backpressure. (@kpelelis)
+
 ## [1.18.0](https://github.com/grafana/alloy/compare/v1.17.0...v1.18.0) (2026-07-17)
 
 

--- a/internal/component/faro/receiver/arguments.go
+++ b/internal/component/faro/receiver/arguments.go
@@ -116,8 +116,17 @@ type LocationArguments struct {
 // OutputArguments configures where to send emitted logs and traces. Metrics
 // emitted by app_agent_receiver are exported as targets to be scraped.
 type OutputArguments struct {
-	Logs   []loki.LogsReceiver `alloy:"logs,attr,optional"`
-	Traces []otelcol.Consumer  `alloy:"traces,attr,optional"`
+	Logs              []loki.LogsReceiver `alloy:"logs,attr,optional"`
+	Traces            []otelcol.Consumer  `alloy:"traces,attr,optional"`
+	LogsSendTimeout   time.Duration       `alloy:"logs_send_timeout,attr,optional"`
+}
+
+var _ syntax.Defaulter = (*OutputArguments)(nil)
+
+func (o *OutputArguments) SetToDefault() {
+	*o = OutputArguments{
+		LogsSendTimeout: 2 * time.Second,
+	}
 }
 
 type LogFormat string

--- a/internal/component/faro/receiver/arguments.go
+++ b/internal/component/faro/receiver/arguments.go
@@ -116,17 +116,15 @@ type LocationArguments struct {
 // OutputArguments configures where to send emitted logs and traces. Metrics
 // emitted by app_agent_receiver are exported as targets to be scraped.
 type OutputArguments struct {
-	Logs              []loki.LogsReceiver `alloy:"logs,attr,optional"`
-	Traces            []otelcol.Consumer  `alloy:"traces,attr,optional"`
-	LogsSendTimeout   time.Duration       `alloy:"logs_send_timeout,attr,optional"`
+	Logs            []loki.LogsReceiver `alloy:"logs,attr,optional"`
+	Traces          []otelcol.Consumer  `alloy:"traces,attr,optional"`
+	LogsSendTimeout time.Duration       `alloy:"logs_send_timeout,attr,optional"`
 }
 
 var _ syntax.Defaulter = (*OutputArguments)(nil)
 
 func (o *OutputArguments) SetToDefault() {
-	*o = OutputArguments{
-		LogsSendTimeout: 2 * time.Second,
-	}
+	o.LogsSendTimeout = 2 * time.Second
 }
 
 type LogFormat string

--- a/internal/component/faro/receiver/exporters.go
+++ b/internal/component/faro/receiver/exporters.go
@@ -192,7 +192,11 @@ func (exp *logsExporter) sendKeyValsToLogsPipeline(ctx context.Context, kv *payl
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, exp.sendTimeout)
+	timeout := exp.sendTimeout
+	if timeout <= 0 {
+		timeout = 2 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	return exp.fanout.Send(ctx, loki.NewEntry(exp.labelSet(kv), push.Entry{
 		Timestamp: time.Now(),

--- a/internal/component/faro/receiver/exporters.go
+++ b/internal/component/faro/receiver/exporters.go
@@ -85,6 +85,8 @@ type logsExporter struct {
 	sourceMaps sourceMapsStore
 	format     LogFormat
 
+	sendTimeout time.Duration
+
 	fanout *loki.Fanout
 
 	labelsMut sync.RWMutex
@@ -93,12 +95,13 @@ type logsExporter struct {
 
 var _ exporter = (*logsExporter)(nil)
 
-func newLogsExporter(log *slog.Logger, sourceMaps sourceMapsStore, format LogFormat) *logsExporter {
+func newLogsExporter(log *slog.Logger, sourceMaps sourceMapsStore, format LogFormat, sendTimeout time.Duration) *logsExporter {
 	return &logsExporter{
-		log:        log,
-		sourceMaps: sourceMaps,
-		format:     format,
-		fanout:     loki.NewFanout([]loki.LogsReceiver{}),
+		log:         log,
+		sourceMaps:  sourceMaps,
+		format:      format,
+		sendTimeout: sendTimeout,
+		fanout:      loki.NewFanout([]loki.LogsReceiver{}),
 	}
 }
 
@@ -106,6 +109,11 @@ func newLogsExporter(log *slog.Logger, sourceMaps sourceMapsStore, format LogFor
 // emitted by the exporter.
 func (exp *logsExporter) SetReceivers(receivers []loki.LogsReceiver) {
 	exp.fanout.UpdateChildren(receivers)
+}
+
+// SetSendTimeout updates the per entry send timeout.
+func (exp *logsExporter) SetSendTimeout(d time.Duration) {
+	exp.sendTimeout = d
 }
 
 func (exp *logsExporter) Name() string { return "logs exporter" }
@@ -184,7 +192,7 @@ func (exp *logsExporter) sendKeyValsToLogsPipeline(ctx context.Context, kv *payl
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second) // TODO(rfratto): potentially make this configurable
+	ctx, cancel := context.WithTimeout(ctx, exp.sendTimeout)
 	defer cancel()
 	return exp.fanout.Send(ctx, loki.NewEntry(exp.labelSet(kv), push.Entry{
 		Timestamp: time.Now(),

--- a/internal/component/faro/receiver/exporters_test.go
+++ b/internal/component/faro/receiver/exporters_test.go
@@ -1,6 +1,7 @@
 package receiver
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -57,6 +58,24 @@ func Test_metricsExporter_Export(t *testing.T) {
 
 	err := promtestutil.CollectAndCompare(reg, strings.NewReader(expect), metricNames...)
 	require.NoError(t, err)
+}
+
+func Test_LogsExporter_SendTimeout(t *testing.T) {
+	blocked := loki.NewLogsReceiver()
+	exp := newLogsExporter(util.TestAlloyLogger(t).Slog(), &varSourceMapsStore{}, FormatLogfmt, 50*time.Millisecond)
+	exp.SetReceivers([]loki.LogsReceiver{blocked})
+
+	p := payload.Payload{
+		Logs: []payload.Log{{Message: "hello", LogLevel: payload.LogLevelInfo}},
+	}
+
+	start := time.Now()
+	err := exp.Export(t.Context(), p)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Less(t, elapsed, 500*time.Millisecond)
 }
 
 func Test_LogsExporter_Export(t *testing.T) {
@@ -318,7 +337,7 @@ func Test_LogsExporter_Export(t *testing.T) {
 			t.Parallel()
 			var (
 				lr  = newFakeLogsReceiver(t)
-				exp = newLogsExporter(util.TestAlloyLogger(t).Slog(), &varSourceMapsStore{}, tc.format)
+				exp = newLogsExporter(util.TestAlloyLogger(t).Slog(), &varSourceMapsStore{}, tc.format, 2*time.Second)
 			)
 			exp.SetReceivers([]loki.LogsReceiver{lr})
 			exp.SetLabels(map[string]string{

--- a/internal/component/faro/receiver/receiver.go
+++ b/internal/component/faro/receiver/receiver.go
@@ -54,7 +54,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		varStore = &varSourceMapsStore{}
 
 		metrics = newMetricsExporter(o.Registerer)
-		logs    = newLogsExporter(o.Logger.With("exporter", "logs"), varStore, args.LogFormat)
+		logs    = newLogsExporter(o.Logger.With("exporter", "logs"), varStore, args.LogFormat, args.Output.LogsSendTimeout)
 		traces  = newTracesExporter()
 	)
 
@@ -146,6 +146,7 @@ func (c *Component) Update(args component.Arguments) error {
 	// Start cleanup for new store
 	c.lazySourceMaps.Start()
 
+	c.logs.SetSendTimeout(newArgs.Output.LogsSendTimeout)
 	c.logs.SetReceivers(newArgs.Output.Logs)
 	c.traces.SetConsumers(newArgs.Output.Traces)
 

--- a/internal/converter/internal/staticconvert/internal/build/app_agent_receiver.go
+++ b/internal/converter/internal/staticconvert/internal/build/app_agent_receiver.go
@@ -2,6 +2,7 @@ package build
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/alecthomas/units"
 	"github.com/grafana/alloy/internal/component/common/loki"
@@ -67,8 +68,9 @@ func toAppAgentReceiverV2(config *app_agent_receiver_v2.Config) *receiver.Argume
 			Locations:           toLocationArguments(config.SourceMaps.FileSystem),
 		},
 		Output: receiver.OutputArguments{
-			Logs:   []loki.LogsReceiver{logsReceiver},
-			Traces: []otelcol.Consumer{},
+			Logs:            []loki.LogsReceiver{logsReceiver},
+			Traces:          []otelcol.Consumer{},
+			LogsSendTimeout: 2 * time.Second,
 		},
 	}
 }


### PR DESCRIPTION
## Summary

Closes #6772

The `faro.receiver` handler pushes each log entry into the downstream
`loki.write` channel with a hardcoded 2 second timeout
(`exporters.go:187`). Under backpressure (slow or rate limiting Loki
endpoint), the channel fills up and the timeout fires, producing
`context deadline exceeded` errors and dropping log entries.

This PR adds a `logs_send_timeout` attribute to the `output` block so
users can tune the timeout to match their environment:

```alloy
faro.receiver "default" {
  output {
    logs              = [loki.write.default.receiver]
    logs_send_timeout = "5s"
  }
}
```

The default remains `"2s"` for backwards compatibility.

### What was changed

- `arguments.go`: Added `LogsSendTimeout` field to `OutputArguments`
  with a 2s default via `SetToDefault()`.
- `exporters.go`: `logsExporter` now accepts and uses the configurable
  timeout instead of the hardcoded value. Added `SetSendTimeout()` for
  live config reloads.
- `receiver.go`: Threads the timeout through construction and updates.
- `exporters_test.go`: Added `Test_LogsExporter_SendTimeout` to verify
  the timeout is respected. Updated existing test calls.
- `CHANGELOG.md`: Added entry under unreleased.

## Reproduction

Reproduced locally with Alloy v1.17.1, Loki with very low rate limits,
and large faro payloads (500 entries per request). The 429 responses
cause `loki.write` to retry with backoff, slowing the channel drain.
Large payloads fill the channel faster than it drains, and the 2s
timeout fires for entries waiting to push in.

## Test plan

- [x] `go test ./internal/component/faro/receiver/...` passes
- [x] New test verifies the timeout triggers correctly
- [x] Existing tests unaffected (default 2s timeout preserved)