### PR TITLE
fix(otelcol.exporter.prometheus): Pass missing `include_scope_labels` to converter

### DIFF
--- a/internal/component/otelcol/exporter/prometheus/prometheus.go
+++ b/internal/component/otelcol/exporter/prometheus/prometheus.go
@@ -180,6 +180,7 @@ func convertArgumentsToConvertOptions(args Arguments) convert.Options {
 	return convert.Options{
 		IncludeTargetInfo:                 args.IncludeTargetInfo,
 		IncludeScopeInfo:                  args.IncludeScopeInfo,
+		IncludeScopeLabels:                args.IncludeScopeLabels,
 		AddMetricSuffixes:                 args.AddMetricSuffixes,
 		ResourceToTelemetryConversion:     args.ResourceToTelemetryConversion,
 		HonorMetadata:                     args.HonorMetadata,


### PR DESCRIPTION
### Brief description of Pull Request

<!-- Factual, human-readable summary of what changed (squash commit body). -->
This PR fixes the following issue:

For the `otelcol.exporter.prometheus` component, the `include_scope_labels` argument is ineffective, and any OTel scope information aren't converted to Prometheus labels.

### Pull Request Details

<!-- HUMAN ONLY: Motivations, trade-offs, and decisions. Write in your own words. -->
As the corrections are minor, there is nothing to mention in detail.

### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->
N/A (It's a simple fix)

### Notes to the Reviewer

<!-- HUMAN ONLY: Context for reviewers/testers. Write in your own words. -->
N/A (It's a simple fix)

### PR Checklist

<!-- HUMAN ONLY: Remove items that do not apply. For completed items, change [ ] to [x]. -->

N/A (It's a simple fix and no LLM assisted)