### PR TITLE
feat(database_observability.sql_server): Add `query_details` collector

### DIFF
--- a/docs/sources/reference/components/database_observability/database_observability.sql_server.md
+++ b/docs/sources/reference/components/database_observability/database_observability.sql_server.md
@@ -40,10 +40,11 @@ You can use the following arguments with `database_observability.sql_server`:
 
 The following collectors are configurable:
 
-| Name              | Description                                                  | Enabled by default |
-|-------------------|--------------------------------------------------------------|--------------------|
-| `schema_details`  | Collect schemas and tables from `information_schema`. | yes                |
+| Name              | Description                                                                   | Enabled by default |
+|-------------------|-------------------------------------------------------------------------------|--------------------|
+| `schema_details`  | Collect schemas and tables from `information_schema`.                         | yes                |
 | `query_metrics`   | Collect per-query executions, errors, and duration counters from Query Store. | yes                |
+| `query_details`   | Collect query text and parsed table names from Query Store.                   | yes                |
 
 ## Blocks
 
@@ -59,6 +60,7 @@ You can use the following blocks with `database_observability.sql_server`:
 | `cloud_provider` > [`gcp`][gcp]      | Provide GCP database host information.            | no       |
 | [`schema_details`][schema_details]   | Configure the schema and table details collector. | no       |
 | [`query_metrics`][query_metrics]     | Configure the Query Store metrics collector.      | no       |
+| [`query_details`][query_details]     | Configure the Query Store query text collector.   | no       |
 
 [cloud_provider]: #cloud_provider
 [aws]: #aws
@@ -66,6 +68,7 @@ You can use the following blocks with `database_observability.sql_server`:
 [gcp]: #gcp
 [schema_details]: #schema_details
 [query_metrics]: #query_metrics
+[query_details]: #query_details
 
 {{< /docs/alloy-config >}}
 
@@ -125,21 +128,21 @@ The collector scans every database that the login can access on the instance and
 | `statements_limit`    | `int`      | Maximum number of queries to track, ranked by recent duration.    | `50`   | no       |
 | `statements_lookback` | `duration` | Only queries executed within this window are eligible for tracking.| `"1h"`  | no       |
 
-The `query_metrics` collector reads [Query Store][query-store] for the database selected in the `data_source_name`, not every database on the instance.
+The `query_metrics` collector reads [Query Store][query_store] for the database selected in the `data_source_name`, not every database on the instance.
 Configure the `data_source_name` to select a user database that has Query Store enabled.
 When the connected database is a system database such as `master`, or Query Store is disabled or read-only, the collector skips collection and remains healthy.
 
 The login requires `VIEW DATABASE STATE` on the connected database. On SQL Server 2022 and later, `VIEW DATABASE PERFORMANCE STATE` is also sufficient.
 
-The collector exports the following counters, each labeled with `database` and `query_hash`:
-
-| Metric                                              | Description                                                      |
-|-----------------------------------------------------|------------------------------------------------------------------|
-| `database_observability_query_executions_total`     | Total number of query executions observed while the query is selected. |
-| `database_observability_query_errors_total`         | Total number of failed executions (aborted or exception) observed while the query is selected. |
-| `database_observability_query_duration_seconds_total`| Total query execution duration in seconds observed while the query is selected. |
-
 [query_store]: https://learn.microsoft.com/sql/relational-databases/performance/monitoring-performance-by-using-the-query-store
+
+### `query_details`
+
+| Name               | Type       | Description                                            | Default | Required |
+|--------------------|------------|--------------------------------------------------------|---------|----------|
+| `collect_interval` | `duration` | How frequently to collect query text from Query Store. | `"1m"`  | no       |
+
+The `query_details` collector reads [Query Store][query_store] query text for the database selected in the `data_source_name`, not every database on the instance.
 
 ## Example
 

--- a/internal/component/database_observability/sql_server/collector/query_details.go
+++ b/internal/component/database_observability/sql_server/collector/query_details.go
@@ -1,0 +1,282 @@
+package collector
+
+import (
+	"context"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/DataDog/go-sqllexer"
+	"go.uber.org/atomic"
+
+	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/component/database_observability"
+	"github.com/grafana/alloy/internal/runtime/logging"
+)
+
+const (
+	QueryDetailsCollector      = "query_details"
+	OP_QUERY_ASSOCIATION       = "query_association"
+	OP_QUERY_PARSED_TABLE_NAME = "query_parsed_table_name"
+)
+
+// selectQueryTextTemplate returns the query text for the tracked
+// query_hashes on the currently connected database.
+//
+// TODO(cristian): consider fetching only the first query_sql_text
+// and also using a cursor.
+const selectQueryTextTemplate = `
+	SELECT
+		q.query_hash,
+		qt.query_sql_text
+	FROM
+		sys.query_store_query q
+	JOIN
+		sys.query_store_query_text qt ON qt.query_text_id = q.query_text_id
+	WHERE
+		q.is_internal_query = 0
+		AND q.query_hash IN (%s)`
+
+// QueryTracker reports which (database, query_hash) pairs are currently tracked
+// by the query_metrics collector.
+type QueryTracker interface {
+	GetQueryHashes(database string) []string
+}
+
+type QueryDetailsArguments struct {
+	DB              *sql.DB
+	CollectInterval time.Duration
+	Tracker         QueryTracker
+	EntryHandler    loki.EntryHandler
+
+	Logger *slog.Logger
+}
+
+type QueryDetails struct {
+	dbConnection    *sql.DB
+	collectInterval time.Duration
+	entryHandler    loki.EntryHandler
+	tracker         QueryTracker
+	obfuscator      *sqllexer.Obfuscator
+	normalizer      *sqllexer.Normalizer
+
+	// lastEmittedAt records the wall-clock time at which OP_QUERY_ASSOCIATION
+	// was last emitted for a (database, query_hash), used to throttle logging
+	// to at most one emission per emitInterval per query.
+	lastEmittedAt map[queryMetricsKey]time.Time
+
+	// now allows overriding time.Now() in tests.
+	now func() time.Time
+
+	logger  *slog.Logger
+	running *atomic.Bool
+	ctx     context.Context
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+}
+
+func NewQueryDetails(args QueryDetailsArguments) (*QueryDetails, error) {
+	return &QueryDetails{
+		dbConnection:    args.DB,
+		collectInterval: args.CollectInterval,
+		entryHandler:    args.EntryHandler,
+		tracker:         args.Tracker,
+		obfuscator:      sqllexer.NewObfuscator(),
+		normalizer: sqllexer.NewNormalizer(
+			sqllexer.WithCollectTables(true),
+			sqllexer.WithKeepIdentifierQuotation(true),
+		),
+		lastEmittedAt: map[queryMetricsKey]time.Time{},
+		now:           time.Now,
+		logger:        args.Logger.With("collector", QueryDetailsCollector),
+		running:       &atomic.Bool{},
+	}, nil
+}
+
+func (c *QueryDetails) Name() string {
+	return QueryDetailsCollector
+}
+
+func (c *QueryDetails) Start(ctx context.Context) error {
+	c.logger.Debug("collector started")
+
+	c.running.Store(true)
+	ctx, cancel := context.WithCancel(ctx)
+	c.ctx = ctx
+	c.cancel = cancel
+
+	c.wg.Go(func() {
+		defer c.running.Store(false)
+
+		ticker := time.NewTicker(c.collectInterval)
+		defer ticker.Stop()
+
+		for {
+			if err := c.collectWithTimeout(c.ctx); err != nil {
+				c.logger.Error("collector error", "err", err)
+			}
+
+			select {
+			case <-c.ctx.Done():
+				return
+			case <-ticker.C:
+				// continue loop
+			}
+		}
+	})
+
+	return nil
+}
+
+func (c *QueryDetails) Stopped() bool {
+	return !c.running.Load()
+}
+
+func (c *QueryDetails) Stop() {
+	if c.cancel != nil {
+		c.cancel()
+	}
+	c.wg.Wait()
+}
+
+func (c *QueryDetails) collectWithTimeout(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	return c.collect(ctx)
+}
+
+func (c *QueryDetails) collect(ctx context.Context) error {
+	if c.tracker == nil {
+		c.logger.Error("no query tracker available, skipping collection")
+		return nil
+	}
+
+	database, ok := checkQueryStoreState(ctx, c.dbConnection, c.logger)
+	if !ok {
+		return nil
+	}
+
+	hashes := c.tracker.GetQueryHashes(database)
+	if len(hashes) == 0 {
+		// query_metrics is enabled but nothing is tracked yet: emit nothing.
+		c.pruneThrottle(nil)
+		return nil
+	}
+
+	query, args, err := buildQueryTextStatement(hashes)
+	if err != nil {
+		return err
+	}
+
+	rs, err := c.dbConnection.QueryContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("failed to fetch query text: %w", err)
+	}
+	defer rs.Close()
+
+	now := c.now()
+
+	// seen collects every (database, query_hash) returned this cycle, including
+	// throttled ones, so pruneThrottle only drops queries that truly left Query
+	// Store rather than those merely skipped by the throttle.
+	seen := map[queryMetricsKey]struct{}{}
+
+	for rs.Next() {
+		var hash []byte
+		var queryText string
+		if err := rs.Scan(&hash, &queryText); err != nil {
+			c.logger.Error("failed to scan query text row", "err", err)
+			continue
+		}
+
+		queryHash, err := formatQueryHash(hash)
+		if err != nil {
+			c.logger.Error("failed to format query hash", "err", err)
+			continue
+		}
+
+		key := queryMetricsKey{database: database, queryHash: queryHash}
+		if _, ok := seen[key]; ok {
+			// A query_hash can map to multiple query_text_id rows; emit once.
+			continue
+		}
+		seen[key] = struct{}{}
+
+		if last, ok := c.lastEmittedAt[key]; ok && now.Sub(last) < emitInterval {
+			continue
+		}
+
+		c.emit(database, queryHash, queryText)
+		c.lastEmittedAt[key] = now
+	}
+
+	if err := rs.Err(); err != nil {
+		return fmt.Errorf("failed to iterate over query text result set: %w", err)
+	}
+
+	c.pruneThrottle(seen)
+	return nil
+}
+
+// emit obfuscates and normalizes the query text, then emits the
+// query_association and query_parsed_table_name logs.
+func (c *QueryDetails) emit(database, queryHash, queryText string) {
+	normalized, metadata, err := sqllexer.ObfuscateAndNormalize(
+		queryText, c.obfuscator, c.normalizer, sqllexer.WithDBMS(sqllexer.DBMSSQLServer),
+	)
+	if err != nil {
+		c.logger.Warn("failed to normalize query text", "database", database, "query_hash", queryHash, "err", err)
+		normalized = c.obfuscator.Obfuscate(queryText, sqllexer.WithDBMS(sqllexer.DBMSSQLServer))
+		metadata = nil
+	}
+
+	c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
+		logging.LevelInfo,
+		OP_QUERY_ASSOCIATION,
+		fmt.Sprintf(`database="%s" query_hash="%s" querytext=%q`, database, queryHash, normalized),
+	)
+
+	if metadata == nil {
+		return
+	}
+
+	for _, table := range metadata.Tables {
+		c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
+			logging.LevelInfo,
+			OP_QUERY_PARSED_TABLE_NAME,
+			fmt.Sprintf(`database="%s" query_hash="%s" table="%s"`, database, queryHash, table),
+		)
+	}
+}
+
+// pruneThrottle drops throttle entries whose (database, query_hash) was not
+// observed this cycle so the map stays bounded as queries leave Query Store.
+func (c *QueryDetails) pruneThrottle(seen map[queryMetricsKey]struct{}) {
+	for key := range c.lastEmittedAt {
+		if _, ok := seen[key]; !ok {
+			delete(c.lastEmittedAt, key)
+		}
+	}
+}
+
+// buildQueryTextStatement returns the query text statement plus its named
+// parameters, binding each 16-char hex hash back to its binary(8) form.
+func buildQueryTextStatement(hashes []string) (string, []any, error) {
+	placeholders := make([]string, 0, len(hashes))
+	args := make([]any, 0, len(hashes))
+	for i, h := range hashes {
+		raw, err := hex.DecodeString(h)
+		if err != nil {
+			return "", nil, fmt.Errorf("failed to decode tracked query hash %q: %w", h, err)
+		}
+		name := fmt.Sprintf("h%d", i)
+		placeholders = append(placeholders, "@"+name)
+		args = append(args, sql.Named(name, raw))
+	}
+
+	return fmt.Sprintf(selectQueryTextTemplate, strings.Join(placeholders, ", ")), args, nil
+}

--- a/internal/component/database_observability/sql_server/collector/query_details_test.go
+++ b/internal/component/database_observability/sql_server/collector/query_details_test.go
@@ -1,0 +1,279 @@
+package collector
+
+import (
+	"context"
+	"database/sql/driver"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/util"
+)
+
+type fakeTracker struct {
+	hashes map[string][]string
+}
+
+func (f fakeTracker) GetQueryHashes(database string) []string {
+	return f.hashes[database]
+}
+
+func trackerFor(hashes ...string) QueryTracker {
+	return fakeTracker{hashes: map[string][]string{testDatabase: hashes}}
+}
+
+func mockQueryTextRows(rows ...[]driver.Value) *sqlmock.Rows {
+	r := sqlmock.NewRows([]string{"query_hash", "query_sql_text"})
+	for _, row := range rows {
+		r.AddRow(row...)
+	}
+	return r
+}
+
+// namedArgs converts the collector's []any of sql.Named parameters into the
+// []driver.Value that sqlmock's WithArgs expects.
+func namedArgs(args []any) []driver.Value {
+	out := make([]driver.Value, len(args))
+	for i, a := range args {
+		out[i] = a
+	}
+	return out
+}
+
+// expectQueryText sets up the two queries one collect cycle runs: the Query
+// Store state preflight and the query text fetch filtered to hashes.
+func expectQueryText(t *testing.T, mock sqlmock.Sqlmock, hashes []string, rows ...[]driver.Value) {
+	t.Helper()
+
+	query, args, err := buildQueryTextStatement(hashes)
+	require.NoError(t, err)
+
+	mockSelectQueryStoreState(mock, "READ_WRITE")
+	mock.ExpectQuery(query).
+		WithArgs(namedArgs(args)...).
+		RowsWillBeClosed().
+		WillReturnRows(mockQueryTextRows(rows...))
+}
+
+func TestQueryDetails_NoTrackerIsNoOp(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lokiClient := loki.NewCollectingHandler()
+	defer lokiClient.Stop()
+
+	c, err := NewQueryDetails(QueryDetailsArguments{
+		DB:              db,
+		CollectInterval: time.Minute,
+		EntryHandler:    lokiClient,
+		Tracker:         nil,
+		Logger:          util.TestAlloyLogger(t).Slog(),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, c.collect(context.Background()))
+	require.NoError(t, mock.ExpectationsWereMet())
+	require.Empty(t, lokiClient.Received())
+}
+
+func TestQueryDetails_EmptyTrackerEmitsNothing(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lokiClient := loki.NewCollectingHandler()
+	defer lokiClient.Stop()
+
+	c, err := NewQueryDetails(QueryDetailsArguments{
+		DB:              db,
+		CollectInterval: time.Minute,
+		EntryHandler:    lokiClient,
+		// Tracker is present but tracks nothing yet: no text query must run.
+		Tracker: fakeTracker{hashes: map[string][]string{}},
+		Logger:  util.TestAlloyLogger(t).Slog(),
+	})
+	require.NoError(t, err)
+
+	mockSelectQueryStoreState(mock, "READ_WRITE")
+
+	require.NoError(t, c.collect(context.Background()))
+	require.NoError(t, mock.ExpectationsWereMet())
+	require.Empty(t, lokiClient.Received())
+}
+
+func TestQueryDetails_SkipsWhenQueryStoreUnavailable(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lokiClient := loki.NewCollectingHandler()
+	defer lokiClient.Stop()
+
+	c, err := NewQueryDetails(QueryDetailsArguments{
+		DB:              db,
+		CollectInterval: time.Minute,
+		EntryHandler:    lokiClient,
+		Tracker:         trackerFor(testHash),
+		Logger:          util.TestAlloyLogger(t).Slog(),
+	})
+	require.NoError(t, err)
+
+	// Query Store is OFF: no text query must run and nothing is emitted.
+	mockSelectQueryStoreState(mock, "OFF")
+
+	require.NoError(t, c.collect(context.Background()))
+	require.NoError(t, mock.ExpectationsWereMet())
+	require.Empty(t, lokiClient.Received())
+}
+
+func TestQueryDetails_NormalizesQueryText(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lokiClient := loki.NewCollectingHandler()
+	defer lokiClient.Stop()
+
+	c, err := NewQueryDetails(QueryDetailsArguments{
+		DB:              db,
+		CollectInterval: time.Minute,
+		EntryHandler:    lokiClient,
+		Tracker:         trackerFor(testHash),
+		Logger:          util.TestAlloyLogger(t).Slog(),
+	})
+	require.NoError(t, err)
+
+	queryText := "SELECT *\n\tFROM [dbo].[orders] o /* pick up the big ones */\n\tJOIN customers c ON c.id = o.customer_id\n\tWHERE o.total > 100"
+
+	expectQueryText(t, mock, []string{testHash}, []driver.Value{queryHashBytes, queryText})
+
+	require.NoError(t, c.collect(context.Background()))
+	require.NoError(t, mock.ExpectationsWereMet())
+
+	require.Eventually(t, func() bool {
+		return len(lokiClient.Received()) == 3
+	}, 5*time.Second, 20*time.Millisecond)
+
+	entries := lokiClient.Received()
+	require.Equal(t, model.LabelSet{"op": OP_QUERY_ASSOCIATION}, entries[0].Labels)
+	require.Equal(t, `level="info" database="books_store" query_hash="0011223344556677" querytext="SELECT * FROM [dbo].[orders] o JOIN customers c ON c.id = o.customer_id WHERE o.total > ?"`, entries[0].Line)
+	require.NotContains(t, entries[0].Line, `\n`)
+	require.NotContains(t, entries[0].Line, `\t`)
+
+	require.Equal(t, model.LabelSet{"op": OP_QUERY_PARSED_TABLE_NAME}, entries[1].Labels)
+	require.Equal(t, `level="info" database="books_store" query_hash="0011223344556677" table="dbo.orders"`, entries[1].Line)
+	require.Equal(t, model.LabelSet{"op": OP_QUERY_PARSED_TABLE_NAME}, entries[2].Labels)
+	require.Equal(t, `level="info" database="books_store" query_hash="0011223344556677" table="customers"`, entries[2].Line)
+}
+
+func TestQueryDetails_DedupesRepeatedHashWithinCycle(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lokiClient := loki.NewCollectingHandler()
+	defer lokiClient.Stop()
+
+	c, err := NewQueryDetails(QueryDetailsArguments{
+		DB:              db,
+		CollectInterval: time.Minute,
+		EntryHandler:    lokiClient,
+		Tracker:         trackerFor(testHash),
+		Logger:          util.TestAlloyLogger(t).Slog(),
+	})
+	require.NoError(t, err)
+
+	// The same query_hash maps to two query_text_id rows; only the first is emitted.
+	expectQueryText(
+		t, mock, []string{testHash},
+		[]driver.Value{queryHashBytes, "SELECT * FROM foo WHERE id = 1"},
+		[]driver.Value{queryHashBytes, "SELECT * FROM foo WHERE id = 2"},
+	)
+
+	require.NoError(t, c.collect(context.Background()))
+	require.NoError(t, mock.ExpectationsWereMet())
+
+	require.Eventually(t, func() bool {
+		return len(lokiClient.Received()) == 2
+	}, 5*time.Second, 20*time.Millisecond)
+	require.Len(t, lokiClient.Received(), 2)
+}
+
+func TestQueryDetails_ThrottlesWithinEmitInterval(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lokiClient := loki.NewCollectingHandler()
+	defer lokiClient.Stop()
+
+	c, err := NewQueryDetails(QueryDetailsArguments{
+		DB:              db,
+		CollectInterval: time.Minute,
+		EntryHandler:    lokiClient,
+		Tracker:         trackerFor(testHash),
+		Logger:          util.TestAlloyLogger(t).Slog(),
+	})
+	require.NoError(t, err)
+
+	base := time.Now()
+	c.now = func() time.Time { return base }
+
+	poll := func() {
+		t.Helper()
+		expectQueryText(t, mock, []string{testHash},
+			[]driver.Value{queryHashBytes, "SELECT * FROM foo WHERE id = 1"})
+		require.NoError(t, c.collect(context.Background()))
+	}
+
+	// First cycle emits the association + parsed table (2 entries).
+	poll()
+	require.Eventually(t, func() bool { return len(lokiClient.Received()) == 2 }, 5*time.Second, 20*time.Millisecond)
+
+	// Second cycle within emitInterval: the query still runs but nothing new is emitted.
+	c.now = func() time.Time { return base.Add(emitInterval / 2) }
+	poll()
+	require.Never(t, func() bool { return len(lokiClient.Received()) != 2 }, 500*time.Millisecond, 50*time.Millisecond)
+
+	// Once emitInterval has elapsed, the query is emitted again (2 more entries).
+	c.now = func() time.Time { return base.Add(emitInterval + time.Minute) }
+	poll()
+	require.Eventually(t, func() bool { return len(lokiClient.Received()) == 4 }, 5*time.Second, 20*time.Millisecond)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBuildQueryTextStatement(t *testing.T) {
+	t.Parallel()
+
+	t.Run("hashes fill the IN clause with binary params", func(t *testing.T) {
+		query, args, err := buildQueryTextStatement([]string{testHash, "aabbccddeeff0011"})
+		require.NoError(t, err)
+		require.Equal(t, fmt.Sprintf(selectQueryTextTemplate, "@h0, @h1"), query)
+		require.Len(t, args, 2)
+	})
+
+	t.Run("invalid hex hash errors", func(t *testing.T) {
+		_, _, err := buildQueryTextStatement([]string{"not_hex_string"})
+		require.Error(t, err)
+	})
+}

--- a/internal/component/database_observability/sql_server/collector/query_metrics.go
+++ b/internal/component/database_observability/sql_server/collector/query_metrics.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 	"sync"
 	"time"
 
@@ -149,6 +147,14 @@ func (c *QueryMetrics) Name() string {
 	return QueryMetricsCollector
 }
 
+// Tracker exposes the collector's query-tracking state so other collectors
+// (e.g. query_details) can restrict their work to the query_hashes that are
+// currently tracked here. The returned value is safe for concurrent use and
+// remains valid across collector restarts.
+func (c *QueryMetrics) Tracker() QueryTracker {
+	return c.state
+}
+
 func (c *QueryMetrics) Start(ctx context.Context) error {
 	c.logger.Debug("collector started")
 
@@ -215,7 +221,7 @@ func (c *QueryMetrics) collectWithTimeout(ctx context.Context) error {
 }
 
 func (c *QueryMetrics) collect(ctx context.Context) error {
-	database, ok := c.checkQueryStoreState(ctx)
+	database, ok := checkQueryStoreState(ctx, c.dbConnection, c.logger)
 	if !ok {
 		// Query Store is unavailable on the connected database, skip this cycle.
 		// Existing counters and baselines are preserved if this is a transient error.
@@ -229,35 +235,6 @@ func (c *QueryMetrics) collect(ctx context.Context) error {
 
 	c.state.update(sources)
 	return nil
-}
-
-// checkQueryStoreState reports whether Query Store is available on the connected database
-// and returns that database's name.
-func (c *QueryMetrics) checkQueryStoreState(ctx context.Context) (string, bool) {
-	var database, actualState, captureMode sql.NullString
-	var readonlyReason sql.NullInt64
-
-	err := c.dbConnection.QueryRowContext(ctx, selectQueryStoreState).
-		Scan(&database, &actualState, &captureMode, &readonlyReason)
-
-	if errors.Is(err, sql.ErrNoRows) {
-		c.logger.Warn("Query Store options are unavailable: the login may lack VIEW DATABASE STATE, or the connected database has no Query Store")
-		return "", false
-	}
-	if err != nil {
-		c.logger.Warn("failed to inspect Query Store state; skipping collection", "err", err)
-		return "", false
-	}
-
-	if state := strings.ToUpper(strings.TrimSpace(actualState.String)); state != "READ_WRITE" {
-		c.logger.Warn("Query Store is not READ_WRITE; skipping collection",
-			"actual_state", actualState.String,
-			"capture_mode", captureMode.String,
-			"readonly_reason", readonlyReason.Int64)
-		return "", false
-	}
-
-	return database.String, true
 }
 
 func (c *QueryMetrics) fetchQueryStoreMetrics(ctx context.Context, database string) ([]queryMetricSource, error) {

--- a/internal/component/database_observability/sql_server/collector/query_metrics.go
+++ b/internal/component/database_observability/sql_server/collector/query_metrics.go
@@ -15,15 +15,6 @@ import (
 
 const QueryMetricsCollector = "query_metrics"
 
-// selectQueryStoreState reads the connected database's Query Store state
-const selectQueryStoreState = `
-SELECT
-	DB_NAME(),
-	actual_state_desc,
-	query_capture_mode_desc,
-	readonly_reason
-FROM sys.database_query_store_options`
-
 // selectQueryMetrics ranks the top-N queries by duration within the recent lookback
 // window, then sums their full retained Query Store history so the emitted
 // counters stay monotonic across interval rollover.
@@ -238,7 +229,8 @@ func (c *QueryMetrics) collect(ctx context.Context) error {
 }
 
 func (c *QueryMetrics) fetchQueryStoreMetrics(ctx context.Context, database string) ([]queryMetricSource, error) {
-	rows, err := c.dbConnection.QueryContext(ctx, selectQueryMetrics,
+	rows, err := c.dbConnection.QueryContext(
+		ctx, selectQueryMetrics,
 		sql.Named("limit", c.limit),
 		sql.Named("lookback_window", int(c.lookback/time.Second)),
 	)

--- a/internal/component/database_observability/sql_server/collector/query_metrics_state.go
+++ b/internal/component/database_observability/sql_server/collector/query_metrics_state.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -40,6 +41,7 @@ type queryMetricsState struct {
 	errors     *prometheus.CounterVec
 	duration   *prometheus.CounterVec
 
+	mu      sync.RWMutex
 	entries map[queryMetricsKey]queryMetricsEntry
 	ttl     time.Duration
 	now     func() time.Time
@@ -59,6 +61,9 @@ func newQueryMetricsState(executions, errors, duration *prometheus.CounterVec, t
 // update folds one poll's cumulative totals into the counters and prunes any
 // series that has aged out of the TTL window.
 func (s *queryMetricsState) update(sources []queryMetricSource) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	now := s.now()
 
 	for _, source := range sources {
@@ -111,9 +116,25 @@ func (s *queryMetricsState) update(sources []queryMetricSource) {
 	s.prune(now)
 }
 
+// GetQueryHashes returns a snapshot of the query_hashes currently tracked for
+// the given database, i.e. those observed within the TTL window.
+func (s *queryMetricsState) GetQueryHashes(database string) []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	hashes := make([]string, 0, len(s.entries))
+	for key := range s.entries {
+		if key.database == database {
+			hashes = append(hashes, key.queryHash)
+		}
+	}
+	return hashes
+}
+
 // prune deletes state and series for hashes not observed within the TTL window.
-// A hash that flaps around the top-N boundary keeps its baseline until then, so
-// activity accrued while it was absent is counted on re-entry.
+// A hash that flaps around the top-N boundary keeps its baseline until
+// then, so activity accrued while it was absent is counted on re-entry.
+// Callers must hold s.mu.
 func (s *queryMetricsState) prune(now time.Time) {
 	for key, entry := range s.entries {
 		if now.Sub(entry.lastSeen) <= s.ttl {
@@ -128,6 +149,8 @@ func (s *queryMetricsState) prune(now time.Time) {
 
 // reset drops all accumulated state and series. Used when the collector stops.
 func (s *queryMetricsState) reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.executions.Reset()
 	s.errors.Reset()
 	s.duration.Reset()

--- a/internal/component/database_observability/sql_server/collector/query_metrics_state_test.go
+++ b/internal/component/database_observability/sql_server/collector/query_metrics_state_test.go
@@ -137,6 +137,41 @@ func TestQueryMetricsState_FlappingHashKeepsBaselineWithinTTL(t *testing.T) {
 	require.InDelta(t, 8.0, counterValue(t, duration), 1e-9)
 }
 
+func TestQueryMetricsState_GetQueryHashes(t *testing.T) {
+	t.Parallel()
+
+	const (
+		otherHash = "aabbccddeeff0011"
+		otherDB   = "other_db"
+		otherKey  = "1122334455667788"
+	)
+
+	executions, errCounter, duration := newTestCounterVecs()
+	state := newQueryMetricsState(executions, errCounter, duration, 5*time.Minute)
+
+	now := time.Now()
+	state.now = func() time.Time { return now }
+
+	require.Empty(t, state.GetQueryHashes(testDatabase))
+
+	state.update([]queryMetricSource{
+		{database: testDatabase, queryHash: testHash, executions: 10},
+		{database: testDatabase, queryHash: otherHash, executions: 5},
+		{database: otherDB, queryHash: otherKey, executions: 3},
+	})
+
+	require.ElementsMatch(t, []string{testHash, otherHash}, state.GetQueryHashes(testDatabase))
+	require.ElementsMatch(t, []string{otherKey}, state.GetQueryHashes(otherDB))
+	require.Empty(t, state.GetQueryHashes("missing_db"))
+
+	// After the TTL elapses without re-observation, the hashes are pruned and no
+	// longer reported as tracked.
+	now = now.Add(6 * time.Minute)
+	state.update(nil)
+	require.Empty(t, state.GetQueryHashes(testDatabase))
+	require.Empty(t, state.GetQueryHashes(otherDB))
+}
+
 func TestQueryMetricsState_Reset(t *testing.T) {
 	t.Parallel()
 

--- a/internal/component/database_observability/sql_server/collector/query_store.go
+++ b/internal/component/database_observability/sql_server/collector/query_store.go
@@ -8,6 +8,15 @@ import (
 	"strings"
 )
 
+// selectQueryStoreState reads the connected database's Query Store state
+const selectQueryStoreState = `
+	SELECT
+		DB_NAME(),
+		actual_state_desc,
+		query_capture_mode_desc,
+		readonly_reason
+	FROM sys.database_query_store_options`
+
 // checkQueryStoreState reports whether Query Store is readable on the connected
 // database and returns that database's name. It mirrors the preflight used by
 // query_metrics so query_details skips cleanly when Query Store is unavailable.

--- a/internal/component/database_observability/sql_server/collector/query_store.go
+++ b/internal/component/database_observability/sql_server/collector/query_store.go
@@ -1,0 +1,39 @@
+package collector
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"log/slog"
+	"strings"
+)
+
+// checkQueryStoreState reports whether Query Store is readable on the connected
+// database and returns that database's name. It mirrors the preflight used by
+// query_metrics so query_details skips cleanly when Query Store is unavailable.
+func checkQueryStoreState(ctx context.Context, db *sql.DB, logger *slog.Logger) (string, bool) {
+	var database, actualState, captureMode sql.NullString
+	var readonlyReason sql.NullInt64
+
+	err := db.QueryRowContext(ctx, selectQueryStoreState).
+		Scan(&database, &actualState, &captureMode, &readonlyReason)
+
+	if errors.Is(err, sql.ErrNoRows) {
+		logger.Warn("Query Store options are unavailable: the login may lack VIEW DATABASE STATE, or the connected database has no Query Store")
+		return "", false
+	}
+	if err != nil {
+		logger.Warn("failed to inspect Query Store state; skipping collection", "err", err)
+		return "", false
+	}
+
+	if state := strings.ToUpper(strings.TrimSpace(actualState.String)); state != "READ_WRITE" {
+		logger.Warn("Query Store is not READ_WRITE; skipping collection",
+			"actual_state", actualState.String,
+			"capture_mode", captureMode.String,
+			"readonly_reason", readonlyReason.Int64)
+		return "", false
+	}
+
+	return database.String, true
+}

--- a/internal/component/database_observability/sql_server/component.go
+++ b/internal/component/database_observability/sql_server/component.go
@@ -72,6 +72,7 @@ type Arguments struct {
 	CloudProvider          *CloudProvider         `alloy:"cloud_provider,block,optional"`
 	SchemaDetailsArguments SchemaDetailsArguments `alloy:"schema_details,block,optional"`
 	QueryMetricsArguments  QueryMetricsArguments  `alloy:"query_metrics,block,optional"`
+	QueryDetailsArguments  QueryDetailsArguments  `alloy:"query_details,block,optional"`
 }
 
 type CloudProvider struct {
@@ -98,11 +99,14 @@ type SchemaDetailsArguments struct {
 	CollectInterval time.Duration `alloy:"collect_interval,attr,optional"`
 }
 
-// QueryMetricsArguments configures the Query Store metrics collector.
 type QueryMetricsArguments struct {
 	CollectInterval    time.Duration `alloy:"collect_interval,attr,optional"`
 	StatementsLimit    int           `alloy:"statements_limit,attr,optional"`
 	StatementsLookback time.Duration `alloy:"statements_lookback,attr,optional"`
+}
+
+type QueryDetailsArguments struct {
+	CollectInterval time.Duration `alloy:"collect_interval,attr,optional"`
 }
 
 func defaultArguments() Arguments {
@@ -118,6 +122,10 @@ func defaultArguments() Arguments {
 			CollectInterval:    1 * time.Minute,
 			StatementsLimit:    50,
 			StatementsLookback: 1 * time.Hour,
+		},
+
+		QueryDetailsArguments: QueryDetailsArguments{
+			CollectInterval: 1 * time.Minute,
 		},
 	}
 }
@@ -142,6 +150,12 @@ func (a *Arguments) Validate() error {
 		lookback := a.QueryMetricsArguments.StatementsLookback
 		if lookback < time.Second || lookback > math.MaxInt32*time.Second {
 			return fmt.Errorf("query_metrics.statements_lookback must be between 1s and %ds", math.MaxInt32)
+		}
+	}
+
+	if enableOrDisableCollectors(*a)[collector.QueryDetailsCollector] {
+		if a.QueryDetailsArguments.CollectInterval <= 0 {
+			return fmt.Errorf("query_details.collect_interval must be greater than zero")
 		}
 	}
 
@@ -411,6 +425,7 @@ func enableOrDisableCollectors(a Arguments) map[string]bool {
 	collectors := map[string]bool{
 		collector.SchemaDetailsCollector: true,
 		collector.QueryMetricsCollector:  true,
+		collector.QueryDetailsCollector:  true,
 	}
 
 	for _, disabled := range a.DisableCollectors {
@@ -459,6 +474,7 @@ func (c *Component) startCollectors(serverID string, engineVersion string, cloud
 		}
 	}
 
+	var queryMetricsCollector *collector.QueryMetrics
 	if collectors[collector.QueryMetricsCollector] {
 		qmCollector, err := collector.NewQueryMetrics(collector.QueryMetricsArguments{
 			DB:              c.dbConnection,
@@ -471,10 +487,36 @@ func (c *Component) startCollectors(serverID string, engineVersion string, cloud
 		if err != nil {
 			logStartError(collector.QueryMetricsCollector, "create", err)
 		} else {
+			queryMetricsCollector = qmCollector
 			if err := qmCollector.Start(context.Background()); err != nil {
 				logStartError(collector.QueryMetricsCollector, "start", err)
 			}
 			c.collectors = append(c.collectors, qmCollector)
+		}
+	}
+
+	if collectors[collector.QueryDetailsCollector] {
+		qdArgs := collector.QueryDetailsArguments{
+			DB:              c.dbConnection,
+			CollectInterval: c.args.QueryDetailsArguments.CollectInterval,
+			EntryHandler:    entryHandler,
+			Logger:          c.opts.Logger,
+		}
+
+		// NOTE: this might change in the future, but for now query_details has
+		// an hard dependency on query_metrics to determine which query_hashes to log.
+		if queryMetricsCollector != nil {
+			qdArgs.Tracker = queryMetricsCollector.Tracker()
+		}
+
+		qdCollector, err := collector.NewQueryDetails(qdArgs)
+		if err != nil {
+			logStartError(collector.QueryDetailsCollector, "create", err)
+		} else {
+			if err := qdCollector.Start(context.Background()); err != nil {
+				logStartError(collector.QueryDetailsCollector, "start", err)
+			}
+			c.collectors = append(c.collectors, qdCollector)
 		}
 	}
 


### PR DESCRIPTION
### Brief description of Pull Request
Introduce a basic `query_details` collector with functionality similar to mysql/postgres versions. However, here we use in-memory tracking data from `query_metrics` to filter the hashes of tracked queries to collect, and we implement a throttling mechanism to avoid emitting too many logs.

Known design limitations/tradeoffs:
- hard dependency on `query_metrics` collector
- no database switching is supported yet
- fetch query could be optimised further


### Pull Request Details

<!-- HUMAN ONLY: Motivations, trade-offs, and decisions. Write in your own words. -->


### Issue(s) fixed by this Pull Request

Relates to https://github.com/grafana/grafana-dbo11y-app/issues/3014


### Notes to the Reviewer

<!-- HUMAN ONLY: Context for reviewers/testers. Write in your own words. -->


### PR Checklist

<!-- HUMAN ONLY: Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
