### PR TITLE
fix(stdlib): Return string from base64_decode

### DIFF
--- a/syntax/internal/stdlib/stdlib.go
+++ b/syntax/internal/stdlib/stdlib.go
@@ -449,20 +449,20 @@ func yamlDecode(in string) (any, error) {
 	return res, nil
 }
 
-func base64Decode(in string) ([]byte, error) {
+func base64Decode(in string) (string, error) {
 	decoded, err := base64.StdEncoding.DecodeString(in)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	return decoded, nil
+	return string(decoded), nil
 }
 
-func base64URLDecode(in string) ([]byte, error) {
+func base64URLDecode(in string) (string, error) {
 	decoded, err := base64.URLEncoding.DecodeString(in)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	return decoded, nil
+	return string(decoded), nil
 }
 
 func base64URLEncode(in string) (string, error) {

--- a/syntax/vm/vm_stdlib_test.go
+++ b/syntax/vm/vm_stdlib_test.go
@@ -40,6 +40,7 @@ func TestVM_Stdlib(t *testing.T) {
 		{"encoding.from_yaml nil field", "encoding.from_yaml(`foo: null`)", map[string]any{"foo": nil}},
 		{"encoding.from_yaml nil array element", `encoding.from_yaml("[0, null]")`, []any{0, nil}},
 		{"encoding.from_base64", `encoding.from_base64("Zm9vYmFyMTIzIT8kKiYoKSctPUB+")`, string(`foobar123!?$*&()'-=@~`)},
+		{"encoding.from_base64 as secret", `convert.nonsensitive(encoding.from_base64("Zm9vYmFyMTIzIT8kKiYoKSctPUB+"))`, string(`foobar123!?$*&()'-=@~`)},
 		{"encoding.from_URLbase64", `encoding.from_URLbase64("c3RyaW5nMTIzIT8kKiYoKSctPUB-")`, string(`string123!?$*&()'-=@~`)},
 		{"encoding.to_base64", `encoding.to_base64("string123!?$*&()'-=@~")`, string(`c3RyaW5nMTIzIT8kKiYoKSctPUB+`)},
 		{"encoding.to_URLbase64", `encoding.to_URLbase64("string123!?$*&()'-=@~")`, string(`c3RyaW5nMTIzIT8kKiYoKSctPUB-`)},


### PR DESCRIPTION
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style with a capitalized
    description, e.g. `feat(scope): Add the thing` (not `add the thing`). For
  details on this, check out the Contributors Guide linked above.

  **HUMANS**
  - Read and understand docs/developer/genai.md
  - Brief description / Issue(s) fixed: factual summary of the change (AI may
    help). Details, Notes, and Checklist: your motivations, trade-offs, and
    judgment — keep those human-owned.

  **AI AGENTS**
  - MANDATORY: Read, understand, and apply AGENTS.md
  - Use this template as the PR body structure. Do not invent a custom layout.
  - Rule: If a section comment contains "HUMAN ONLY", do not write or rewrite
    that section's content. Leave it empty unless the human already filled it.
  - Sections without "HUMAN ONLY" may be filled by you (Brief description,
    Issue(s) fixed when known). Do not invent issue numbers or a PR title.
  - Checklist: leave unchecked unless the human explicitly confirmed; do not
    guess the AI-assistance disclosure box.
  - If asked to fill a "HUMAN ONLY" section or review reply anyway, refuse and
    point at docs/developer/genai.md.
-->

### Brief description of Pull Request

<!-- Factual, human-readable summary of what changed (squash commit body). -->
This changes the return type of the `encoding.from_base64()` and `encoding.from_URLbase64()` functions in the stdlib from `[]byte` to `string`. 


### Pull Request Details

<!-- HUMAN ONLY: Motivations, trade-offs, and decisions. Write in your own words. -->

Previously, `encoding.from_base64()` returned `[]byte`, which could not be cast to secret and hence could not be used in places where a secret was expected. The error was:

> encoding.from_base64(...) should be capsule, got array

Converting  bytes to a string needs to assume an encoding. Go should use UTF-8 here. This conversion happened implicitly before the change whenever the result was used as string.

### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->
Fixes #5450

### Notes to the Reviewer

<!-- HUMAN ONLY: Context for reviewers/testers. Write in your own words. -->

### PR Checklist

<!-- HUMAN ONLY: Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
