### PR TITLE
fix: Clashing cross compilation env variables when building/generating alloy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,8 +156,7 @@ endif
 
 GO_ENV := GOEXPERIMENT=$(GOEXPERIMENT) GOOS=$(GOOS) GOARCH=$(GOARCH) GOARM=$(GOARM) CGO_ENABLED=$(CGO_ENABLED)
 
-# Environment for host tools such as code generators: clears every cross-compile
-# setting, including the C toolchain, since these run on the build machine.
+# Clears cross-compile settings, to be set in any build-time generation steps that run "go run" under the hood
 GO_HOST_ENV := env -u GOOS -u GOARCH -u GOARM -u CC -u CXX CGO_ENABLED=0
 
 VERSION      ?= $(shell bash ./scripts/image-tag)

--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,10 @@ endif
 
 GO_ENV := GOEXPERIMENT=$(GOEXPERIMENT) GOOS=$(GOOS) GOARCH=$(GOARCH) GOARM=$(GOARM) CGO_ENABLED=$(CGO_ENABLED)
 
+# Environment for host tools such as code generators: clears every cross-compile
+# setting, including the C toolchain, since these run on the build machine.
+GO_HOST_ENV := env -u GOOS -u GOARCH -u GOARM CGO_ENABLED=0 CC= CXX=
+
 VERSION      ?= $(shell bash ./scripts/image-tag)
 GIT_REVISION := $(shell git rev-parse --short HEAD)
 GIT_BRANCH   := $(shell git rev-parse --abbrev-ref HEAD)
@@ -400,11 +404,12 @@ generate-otel-collector-distro:
 ifeq ($(USE_CONTAINER),1)
 	$(RERUN_IN_CONTAINER)
 else
-	# Here we clear the GOOS and GOARCH env variables so we're not accidentally cross compiling the builder tool within generate
-	GOOS= GOARCH= go run -C tools ./cmd sync-replaces --builder-config ../collector/builder-config.yaml --go-mod ../go.mod
+	# These are host tools, so GO_HOST_ENV clears the cross-compile settings to
+	# avoid accidentally building them for the target platform within generate
+	$(GO_HOST_ENV) go run -C tools ./cmd sync-replaces --builder-config ../collector/builder-config.yaml --go-mod ../go.mod
 	# This tidy propagates any root module changes to the collector module
-	cd ./collector && GOOS= GOARCH= go mod tidy
-	cd ./collector && GOOS= GOARCH= BUILDER_VERSION=$(BUILDER_VERSION) go generate
+	cd ./collector && $(GO_HOST_ENV) go mod tidy
+	cd ./collector && $(GO_HOST_ENV) BUILDER_VERSION=$(BUILDER_VERSION) go generate
 endif
 
 generate-ui:

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ endif
 GO_ENV := GOEXPERIMENT=$(GOEXPERIMENT) GOOS=$(GOOS) GOARCH=$(GOARCH) GOARM=$(GOARM) CGO_ENABLED=$(CGO_ENABLED)
 
 # Clears cross-compile settings, to be set in any build-time generation steps that run "go run" under the hood
-GO_HOST_ENV := env -u GOOS -u GOARCH -u GOARM -u CC -u CXX CGO_ENABLED=0
+GO_HOST_ENV := env -u GOOS -u GOARCH CGO_ENABLED=0
 
 VERSION      ?= $(shell bash ./scripts/image-tag)
 GIT_REVISION := $(shell git rev-parse --short HEAD)

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ GO_ENV := GOEXPERIMENT=$(GOEXPERIMENT) GOOS=$(GOOS) GOARCH=$(GOARCH) GOARM=$(GOA
 
 # Environment for host tools such as code generators: clears every cross-compile
 # setting, including the C toolchain, since these run on the build machine.
-GO_HOST_ENV := env -u GOOS -u GOARCH -u GOARM CGO_ENABLED=0 CC= CXX=
+GO_HOST_ENV := env -u GOOS -u GOARCH -u GOARM -u CC -u CXX CGO_ENABLED=0
 
 VERSION      ?= $(shell bash ./scripts/image-tag)
 GIT_REVISION := $(shell git rev-parse --short HEAD)


### PR DESCRIPTION
### Brief description of Pull Request
Addresses issue where cross compilation variables are unset and then clash with one another when building/x-compiling alloy manually

### Pull Request Details
Previously `GOOS` and `GOARCH` were cleared in the generation steps because, as part of the generation, `go run` was being ran - which meant that incompatible go binaries were ran on the host architecture during cross compilation. Clearing those env's meant that any generation step would always build and run the correct architecture (the same as the building host). 

The issue this PR fixes is a follow up: if we only clear these two variables and then cross-build alloy, which runs the generation steps as a pre-req (which clears `GOOS`/`GOARCH`), we can wind up in a situation where the go toolchain and the C toolchain are aimed at different architectures. `CGO_ENABLED` defaults to 1 in the MakeFile, but `CC` is left pointing at the cross-compiler for the target, while the cleared `GOOS`/`GOARCH` now select the host. We run into a scenario where the cgo runtime is compiled for the host, which then fails on the target assembler.

This PR introduces `GO_HOST_ENV` alongside the existing `GO_ENV` and uses it for the generation steps. Rather than keeping `GOOS`, `GOARCH` and `CC` in agreement, it sets `CGO_ENABLED`=0 - none of the generators need cgo, so no C compiler is consulted at all

### Issue(s) fixed by this Pull Request
https://github.com/grafana/alloy/issues/6765
