### PR TITLE
fix(validation): Typecheck attribute object

### DIFF
--- a/syntax/typecheck/typecheck.go
+++ b/syntax/typecheck/typecheck.go
@@ -314,6 +314,7 @@ func typecheckObjectExpr(expr *ast.ObjectExpr, rv reflect.Value) diag.Diagnostic
 		return nil
 	}
 
+	rv = reflectutil.DeferencePointer(rv)
 	switch rv.Kind() {
 	case reflect.Map:
 		return typecheckMapExpr(expr, rv)
@@ -325,7 +326,7 @@ func typecheckObjectExpr(expr *ast.ObjectExpr, rv reflect.Value) diag.Diagnostic
 			Severity: diag.SeverityLevelError,
 			StartPos: ast.StartPos(expr).Position(),
 			EndPos:   ast.EndPos(expr).Position(),
-			Message:  fmt.Sprintf("expected %s, got %s", expectedType, rv.Kind()),
+			Message:  fmt.Sprintf("expected %s, got object", expectedType),
 		}}
 	}
 }

--- a/syntax/typecheck/typecheck.go
+++ b/syntax/typecheck/typecheck.go
@@ -219,23 +219,31 @@ func checkStructAttr(s *structState, a *ast.AttributeStmt, rv reflect.Value) dia
 
 	s.seenAttrs[a.Name.Name] = struct{}{}
 
-	var diags diag.Diagnostics
+	diags := typecheckExpr(a.Value, reflectutil.GetOrAlloc(rv, tf))
+	if diags != nil {
+		return diags
+	}
 
-	switch expr := a.Value.(type) {
-	case *ast.ArrayExpr:
-		diags.Merge(typecheckArrayExpr(expr, reflectutil.GetOrAlloc(rv, tf)))
-	case *ast.ObjectExpr:
-		diags.Merge(typecheckObjectExpr(expr, reflectutil.GetOrAlloc(rv, tf)))
+	return nil
+}
+
+func typecheckExpr(expr ast.Expr, rv reflect.Value) diag.Diagnostics {
+	var diags diag.Diagnostics
+	switch expr := expr.(type) {
 	case *ast.LiteralExpr:
-		if d := typecheckLiteralExpr(expr, reflectutil.GetOrAlloc(rv, tf)); d != nil {
+		if d := typecheckLiteralExpr(expr, rv); d != nil {
 			diags.Add(*d)
 		}
+	case *ast.ArrayExpr:
+		diags.Merge(typecheckArrayExpr(expr, rv))
+	case *ast.ObjectExpr:
+		diags.Merge(typecheckObjectExpr(expr, rv))
 	case *ast.UnaryExpr:
-		if d := typecheckUnaryExpr(expr, reflectutil.GetOrAlloc(rv, tf)); d != nil {
+		if d := typecheckUnaryExpr(expr, rv); d != nil {
 			diags.Add(*d)
 		}
 	case *ast.BinaryExpr:
-		if d := typecheckBinaryExpr(expr, reflectutil.GetOrAlloc(rv, tf)); d != nil {
+		if d := typecheckBinaryExpr(expr, rv); d != nil {
 			diags.Add(*d)
 		}
 	default:
@@ -245,7 +253,6 @@ func checkStructAttr(s *structState, a *ast.AttributeStmt, rv reflect.Value) dia
 	if diags != nil {
 		return diags
 	}
-
 	return nil
 }
 
@@ -275,26 +282,7 @@ func typecheckArrayExpr(expr *ast.ArrayExpr, rv reflect.Value) diag.Diagnostics 
 
 	var diags diag.Diagnostics
 	for _, e := range expr.Elements {
-		switch expr := e.(type) {
-		case *ast.LiteralExpr:
-			if d := typecheckLiteralExpr(expr, expected); d != nil {
-				diags.Add(*d)
-			}
-		case *ast.ArrayExpr:
-			diags.Merge(typecheckArrayExpr(expr, expected))
-		case *ast.ObjectExpr:
-			diags.Merge(typecheckObjectExpr(expr, expected))
-		case *ast.UnaryExpr:
-			if d := typecheckUnaryExpr(expr, expected); d != nil {
-				diags.Add(*d)
-			}
-		case *ast.BinaryExpr:
-			if d := typecheckBinaryExpr(expr, expected); d != nil {
-				diags.Add(*d)
-			}
-		default:
-			// ignore rest for now.
-		}
+		diags.Merge(typecheckExpr(e, expected))
 	}
 
 	if diags != nil {
@@ -326,17 +314,66 @@ func typecheckObjectExpr(expr *ast.ObjectExpr, rv reflect.Value) diag.Diagnostic
 		return nil
 	}
 
-	// Check if the expected type is actually a map before trying to get its element type
-	if rv.Kind() != reflect.Map {
+	switch rv.Kind() {
+	case reflect.Map:
+		return typecheckMapExpr(expr, rv)
+	case reflect.Struct:
+		return typecheckStructExpr(expr, rv)
+	default:
 		expectedType := value.AlloyType(rv.Type())
 		return diag.Diagnostics{{
 			Severity: diag.SeverityLevelError,
 			StartPos: ast.StartPos(expr).Position(),
 			EndPos:   ast.EndPos(expr).Position(),
-			Message:  fmt.Sprintf("expected %s, got object", expectedType),
+			Message:  fmt.Sprintf("expected %s, got %s", expectedType, rv.Kind()),
 		}}
 	}
+}
 
+func typecheckStructExpr(expr *ast.ObjectExpr, rv reflect.Value) diag.Diagnostics {
+	tags := tagcache.Get(rv.Type())
+
+	var diags diag.Diagnostics
+	seen := make(map[string]struct{}, len(expr.Fields))
+
+	for _, f := range expr.Fields {
+		name := f.Name.Name
+		tag, ok := tags.TagLookup[name]
+		if !ok {
+			diags.Add(diag.Diagnostic{
+				Severity: diag.SeverityLevelError,
+				StartPos: ast.StartPos(f.Name).Position(),
+				EndPos:   ast.EndPos(f.Value).Position(),
+				Message:  fmt.Sprintf("unrecognized attribute name %q", name),
+			})
+			continue
+		}
+
+		seen[name] = struct{}{}
+		diags.Merge(typecheckExpr(f.Value, reflectutil.DeferencePointer(reflectutil.GetOrAlloc(rv, tag))))
+	}
+
+	// Report any required attributes that were not provided.
+	for _, t := range tags.Tags {
+		if t.IsOptional() || !t.IsAttr() {
+			continue
+		}
+
+		name := strings.Join(t.Name, ".")
+		if _, ok := seen[name]; !ok {
+			diags.Add(diag.Diagnostic{
+				Severity: diag.SeverityLevelError,
+				StartPos: ast.StartPos(expr).Position(),
+				EndPos:   ast.EndPos(expr).Position(),
+				Message:  fmt.Sprintf("missing required attribute %q", name),
+			})
+		}
+	}
+
+	return diags
+}
+
+func typecheckMapExpr(expr *ast.ObjectExpr, rv reflect.Value) diag.Diagnostics {
 	// Extract value from map.
 	expectedValue := reflectutil.DeferencePointer(reflect.New(rv.Type().Elem()))
 	// If values of map can be any type we don't have to check further.
@@ -346,26 +383,7 @@ func typecheckObjectExpr(expr *ast.ObjectExpr, rv reflect.Value) diag.Diagnostic
 
 	var diags diag.Diagnostics
 	for _, f := range expr.Fields {
-		switch expr := f.Value.(type) {
-		case *ast.LiteralExpr:
-			if d := typecheckLiteralExpr(expr, expectedValue); d != nil {
-				diags.Add(*d)
-			}
-		case *ast.ArrayExpr:
-			diags.Merge(typecheckArrayExpr(expr, expectedValue))
-		case *ast.ObjectExpr:
-			diags.Merge(typecheckObjectExpr(expr, expectedValue))
-		case *ast.UnaryExpr:
-			if d := typecheckUnaryExpr(expr, expectedValue); d != nil {
-				diags.Add(*d)
-			}
-		case *ast.BinaryExpr:
-			if d := typecheckBinaryExpr(expr, expectedValue); d != nil {
-				diags.Add(*d)
-			}
-		default:
-			// ignore rest for now.
-		}
+		diags.Merge(typecheckExpr(f.Value, expectedValue))
 	}
 
 	if diags != nil {

--- a/syntax/typecheck/typecheck_test.go
+++ b/syntax/typecheck/typecheck_test.go
@@ -386,14 +386,16 @@ func TestObjectAttr(t *testing.T) {
 	}
 
 	type Args struct {
-		Structs []Struct `alloy:"structs,attr"`
-		Struct  Struct   `alloy:"struct,attr"`
+		Structs   []Struct `alloy:"structs,attr"`
+		Struct    Struct   `alloy:"struct,attr"`
+		StructPtr *Struct  `alloy:"struct_ptr,attr,optional"`
 	}
 
 	src := []byte(`
 		test "name" {
 			struct =  {str = "test"}
 			structs = [{str= "test"}]	
+			struct_ptr =  {str = "test"}
 		}
 	`)
 

--- a/syntax/typecheck/typecheck_test.go
+++ b/syntax/typecheck/typecheck_test.go
@@ -380,6 +380,29 @@ func TestBlockMap(t *testing.T) {
 	require.Len(t, diag, 0)
 }
 
+func TestObjectAttr(t *testing.T) {
+	type Struct struct {
+		Str string `alloy:"str,attr"`
+	}
+
+	type Args struct {
+		Structs []Struct `alloy:"structs,attr"`
+		Struct  Struct   `alloy:"struct,attr"`
+	}
+
+	src := []byte(`
+		test "name" {
+			struct =  {str = "test"}
+			structs = [{str= "test"}]	
+		}
+	`)
+
+	file, err := parser.ParseFile("", src)
+	require.NoError(t, err)
+	diag := Block(file.Body[0].(*ast.BlockStmt), &Args{})
+	require.Len(t, diag, 0, diag)
+}
+
 type ValidatedString string
 
 func (s *ValidatedString) UnmarshalText(text []byte) error {


### PR DESCRIPTION
### Pull Request Details
Before it was assumed that all objects was either a capsule or a map, so it missed the case there a struct is marked as a attribute e.g:
```
struct = {
  str = "1"
  int = 1
}
```

We need to do a similar check as we do for blocks here, checking all sub expressions and check that required attributes are set for the struct.

To check this we need to perform similar checks as we do for block

### Issue(s) fixed by this Pull Request

Fixes: #6801

### Notes to the Reviewer

<!-- HUMAN ONLY: Context for reviewers/testers. Write in your own words. -->


### PR Checklist

<!-- HUMAN ONLY: Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
